### PR TITLE
feat: separate custom failover groups above auto groups with ★ in alphabet strip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,7 +65,6 @@ Thumbs.db
 /.codenomad/
 /.opencode/
 /.skills/
-/.gitmodules
 # Wiki (published separately as GitHub wiki)
 /model-hotel.wiki/
 .rules

--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,8 @@ Thumbs.db
 /.claude/
 /.codenomad/
 /.opencode/
+/.skills/
+/.gitmodules
 # Wiki (published separately as GitHub wiki)
 /model-hotel.wiki/
 .rules

--- a/web/src/components/VirtualAppLogTable.tsx
+++ b/web/src/components/VirtualAppLogTable.tsx
@@ -97,6 +97,8 @@ const HEADER_BASE =
 const EDGE_THRESHOLD_PX = 500; // pixels from edge to trigger fetch
 
 export function VirtualAppLogTable(props: VirtualAppLogTableProps) {
+	"use no memo";
+
 	const {
 		entries,
 		total,
@@ -113,6 +115,7 @@ export function VirtualAppLogTable(props: VirtualAppLogTableProps) {
 
 	const scrollRef = useRef<HTMLDivElement>(null);
 
+	// eslint-disable-next-line react-hooks/incompatible-library -- TanStack Virtual returns mutable functions; compiler skips memoization
 	const virtualizer = useVirtualizer({
 		count: entries.length,
 		getScrollElement: () => scrollRef.current,

--- a/web/src/components/VirtualLogTable.tsx
+++ b/web/src/components/VirtualLogTable.tsx
@@ -47,6 +47,8 @@ const HEADER_BASE =
 const EDGE_THRESHOLD_PX = 500; // pixels from edge to trigger fetch
 
 export function VirtualLogTable(props: VirtualLogTableProps) {
+	"use no memo";
+
 	const {
 		entries,
 		total,
@@ -63,6 +65,7 @@ export function VirtualLogTable(props: VirtualLogTableProps) {
 
 	const scrollRef = useRef<HTMLDivElement>(null);
 
+	// eslint-disable-next-line react-hooks/incompatible-library -- TanStack Virtual returns mutable functions; compiler skips memoization
 	const virtualizer = useVirtualizer({
 		count: entries.length,
 		getScrollElement: () => scrollRef.current,

--- a/web/src/components/VirtualModelTable.tsx
+++ b/web/src/components/VirtualModelTable.tsx
@@ -34,6 +34,7 @@ export function VirtualModelTable({
 	initialProviderFilter,
 	onModelClick,
 }: VirtualModelTableProps) {
+	"use no memo";
 	const [searchQuery, setSearchQuery] = useState("");
 	const [selectedProviders, setSelectedProviders] = useState<Set<string>>(
 		initialProviderFilter ?? new Set(),
@@ -189,6 +190,7 @@ export function VirtualModelTable({
 		return caps;
 	}, [entries]);
 
+	// eslint-disable-next-line react-hooks/incompatible-library -- TanStack Virtual returns mutable functions; compiler skips memoization
 	const virtualizer = useVirtualizer({
 		count: entries.length,
 		getScrollElement: () => scrollRef.current,

--- a/web/src/pages/FailoverGroups.tsx
+++ b/web/src/pages/FailoverGroups.tsx
@@ -83,11 +83,16 @@ export function FailoverGroups() {
 	const totalDisabled = (allGroups?.length ?? 0) - totalEnabled;
 	const allSameState = totalEnabled === 0 || totalDisabled === 0;
 
-	// Sort groups alphabetically by display_model and group by first letter
-	const sortedGroups = [...(groups ?? [])].sort((a, b) =>
-		a.display_model.localeCompare(b.display_model),
-	);
-	const letterGroups = sortedGroups.reduce<Record<string, typeof sortedGroups>>(
+	// Separate custom groups (manually created) from auto groups
+	const customGroups = [...(groups ?? [])]
+		.filter((g) => !g.auto_created)
+		.sort((a, b) => a.display_model.localeCompare(b.display_model));
+	const autoGroups = [...(groups ?? [])]
+		.filter((g) => g.auto_created)
+		.sort((a, b) => a.display_model.localeCompare(b.display_model));
+
+	// Auto groups grouped by first letter
+	const letterGroups = autoGroups.reduce<Record<string, typeof autoGroups>>(
 		(acc, group) => {
 			const letter = group.display_model.charAt(0).toUpperCase();
 			if (!acc[letter]) acc[letter] = [];
@@ -539,6 +544,64 @@ export function FailoverGroups() {
 			) : (
 				<div className="relative flex gap-4">
 					<div className="flex-1 space-y-6">
+						{/* Custom groups section (manually created) */}
+						{customGroups.length > 0 && (
+							<section id="failover-section-custom">
+								<button
+									type="button"
+									onClick={() => toggleLetterCollapse("custom")}
+									className="flex items-center gap-3 mb-3 w-full text-left group cursor-pointer"
+								>
+									<ChevronRight
+										size={16}
+										className={`text-gray-500 transition-transform group-hover:text-(--accent) group-hover:drop-shadow-[0_0_8px_var(--accent)] ${collapsedLetters.has("custom") ? "" : "rotate-90"}`}
+									/>
+									<span className="text-lg font-bold text-(--accent) group-hover:[text-shadow:0_0_8px_var(--accent)]">
+										Custom
+									</span>
+									<div className="flex-1 h-px bg-gray-700/50" />
+									<span className="text-xs text-gray-500">
+										{customGroups.length} group
+										{customGroups.length > 1 ? "s" : ""}
+									</span>
+								</button>
+								<div
+									className="grid transition-[grid-template-rows] duration-200 ease-in-out"
+									style={{
+										gridTemplateRows: collapsedLetters.has("custom")
+											? "0fr"
+											: "1fr",
+									}}
+								>
+									<div className="overflow-hidden">
+										<div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-4">
+											{customGroups.map((group) => (
+												<FailoverGroupCard
+													key={group.id}
+													group={group}
+													selected={selectedGroupIds.has(group.id)}
+													onToggleSelect={(checked) =>
+														toggleGroupSelect(group.id, checked)
+													}
+													onToggleGroup={(enabled) =>
+														handleToggleGroup(group, enabled)
+													}
+													onToggleEntry={(uuid, enabled) =>
+														handleToggleEntry(group, uuid, enabled)
+													}
+													onReorder={(newOrder) =>
+														handleReorder(group, newOrder)
+													}
+													onDelete={() => handleDelete(group)}
+												/>
+											))}
+										</div>
+									</div>
+								</div>
+							</section>
+						)}
+
+						{/* Auto groups grouped by first letter */}
 						{sortedLetters.map((letter) => (
 							<section key={letter} id={`failover-section-${letter}`}>
 								<button
@@ -597,8 +660,22 @@ export function FailoverGroups() {
 					</div>
 
 					{/* Alphabet sidebar */}
-					{sortedLetters.length > 3 && (
+					{(sortedLetters.length > 3 || customGroups.length > 0) && (
 						<nav className="hidden xl:flex flex-col items-center gap-1 pt-2 sticky top-4 self-start">
+							{customGroups.length > 0 && (
+								<button
+									type="button"
+									onClick={() =>
+										document
+											.getElementById("failover-section-custom")
+											?.scrollIntoView({ behavior: "smooth", block: "start" })
+									}
+									className="text-xs font-medium text-(--accent) hover:[text-shadow:0_0_8px_var(--accent)] transition-all cursor-pointer px-1.5 py-0.5 rounded"
+									aria-label="Jump to custom groups"
+								>
+									★
+								</button>
+							)}
 							{sortedLetters.map((letter) => (
 								<button
 									key={letter}

--- a/web/src/pages/FailoverGroups.tsx
+++ b/web/src/pages/FailoverGroups.tsx
@@ -661,7 +661,10 @@ export function FailoverGroups() {
 
 					{/* Alphabet sidebar */}
 					{(sortedLetters.length > 3 || customGroups.length > 0) && (
-						<nav className="hidden xl:flex flex-col items-center gap-1 pt-2 sticky top-4 self-start">
+						<nav
+							aria-label="Alphabet sidebar"
+							className="hidden xl:flex flex-col items-center gap-1 pt-2 sticky top-4 self-start"
+						>
 							{customGroups.length > 0 && (
 								<button
 									type="button"

--- a/web/src/pages/__tests__/FailoverGroups.test.tsx
+++ b/web/src/pages/__tests__/FailoverGroups.test.tsx
@@ -2836,9 +2836,23 @@ describe("FailoverGroups", () => {
 
 		it("Does not show alphabet sidebar with 3 or fewer letter groups", async () => {
 			const groups = [
-				{ ...mockFailoverGroup, display_model: "alpha-model" },
-				{ ...mockFailoverGroup, id: "fg-002", display_model: "beta-model" },
-				{ ...mockFailoverGroup, id: "fg-003", display_model: "gamma-model" },
+				{
+					...mockFailoverGroup,
+					display_model: "alpha-model",
+					auto_created: true,
+				},
+				{
+					...mockFailoverGroup,
+					id: "fg-002",
+					display_model: "beta-model",
+					auto_created: true,
+				},
+				{
+					...mockFailoverGroup,
+					id: "fg-003",
+					display_model: "gamma-model",
+					auto_created: true,
+				},
 			];
 
 			server.use(
@@ -2854,6 +2868,11 @@ describe("FailoverGroups", () => {
 					screen.queryByRole("button", { name: "A" }),
 				).not.toBeInTheDocument();
 			});
+
+			// Sidebar should not render at all (no custom groups + ≤3 letter sections)
+			expect(
+				screen.queryByRole("navigation", { name: /alphabet/i }),
+			).not.toBeInTheDocument();
 		});
 	});
 

--- a/web/src/pages/__tests__/FailoverGroups.test.tsx
+++ b/web/src/pages/__tests__/FailoverGroups.test.tsx
@@ -610,13 +610,23 @@ describe("FailoverGroups", () => {
 
 		it("groups are grouped by first letter with collapse toggle", async () => {
 			const groups = [
-				{ ...mockFailoverGroup, display_model: "alpha-one" },
+				{
+					...mockFailoverGroup,
+					display_model: "alpha-one",
+					auto_created: true,
+				},
 				{
 					...mockFailoverGroup,
 					display_model: "alpha-two",
 					id: "fg-002",
+					auto_created: true,
 				},
-				{ ...mockFailoverGroup, display_model: "beta-one", id: "fg-003" },
+				{
+					...mockFailoverGroup,
+					display_model: "beta-one",
+					id: "fg-003",
+					auto_created: true,
+				},
 			];
 
 			server.use(
@@ -655,8 +665,13 @@ describe("FailoverGroups", () => {
 
 		it("toggling letter collapse expands/collapses groups", async () => {
 			const groups = [
-				{ ...mockFailoverGroup, display_model: "test-one" },
-				{ ...mockFailoverGroup, display_model: "test-two", id: "fg-002" },
+				{ ...mockFailoverGroup, display_model: "test-one", auto_created: true },
+				{
+					...mockFailoverGroup,
+					display_model: "test-two",
+					id: "fg-002",
+					auto_created: true,
+				},
 			];
 
 			server.use(
@@ -692,6 +707,152 @@ describe("FailoverGroups", () => {
 				await waitFor(() => {
 					expect(screen.getByText("hotel/test-one")).toBeInTheDocument();
 					expect(screen.getByText("hotel/test-two")).toBeInTheDocument();
+				});
+			}
+		});
+
+		it("custom groups appear in a Custom section above letter sections", async () => {
+			const groups = [
+				{
+					...mockFailoverGroup,
+					display_model: "custom-model",
+					auto_created: false,
+				},
+				{
+					...mockFailoverGroup,
+					display_model: "alpha-model",
+					id: "fg-002",
+					auto_created: true,
+				},
+				{
+					...mockFailoverGroup,
+					display_model: "beta-model",
+					id: "fg-003",
+					auto_created: true,
+				},
+			];
+
+			server.use(
+				http.get("/api/failover-groups", () => {
+					return HttpResponse.json({
+						groups,
+						last_synced_at: null,
+					});
+				}),
+			);
+
+			renderWithProviders(<FailoverGroups />);
+
+			await waitFor(() => {
+				// Custom section header should appear
+				expect(screen.getByText("Custom")).toBeInTheDocument();
+				// Custom group should be in Custom section
+				expect(screen.getByText("hotel/custom-model")).toBeInTheDocument();
+				// Auto groups should be in their letter sections
+				expect(screen.getByText("hotel/alpha-model")).toBeInTheDocument();
+				expect(screen.getByText("hotel/beta-model")).toBeInTheDocument();
+				// Letter section headers should exist (use query to avoid multiple match error)
+				expect(screen.queryAllByText("A").length).toBeGreaterThan(0);
+				expect(screen.queryAllByText("B").length).toBeGreaterThan(0);
+			});
+		});
+
+		it("★ symbol appears in alphabet strip when custom groups exist", async () => {
+			const groups = [
+				{
+					...mockFailoverGroup,
+					display_model: "custom-model",
+					auto_created: false,
+				},
+				{
+					...mockFailoverGroup,
+					display_model: "alpha-model",
+					id: "fg-002",
+					auto_created: true,
+				},
+			];
+
+			server.use(
+				http.get("/api/failover-groups", () => {
+					return HttpResponse.json({
+						groups,
+						last_synced_at: null,
+					});
+				}),
+			);
+
+			renderWithProviders(<FailoverGroups />);
+
+			await waitFor(() => {
+				// ★ button should appear in alphabet strip
+				// The ★ button has aria-label "Jump to custom groups"
+				expect(
+					screen.getByRole("button", { name: /Jump to custom groups/i }),
+				).toBeInTheDocument();
+				// Verify it contains the ★ symbol
+				expect(screen.getByText("★")).toBeInTheDocument();
+			});
+		});
+
+		it("Custom section is collapsible", async () => {
+			const groups = [
+				{
+					...mockFailoverGroup,
+					display_model: "custom-model",
+					auto_created: false,
+				},
+				{
+					...mockFailoverGroup,
+					display_model: "another-custom",
+					id: "fg-002",
+					auto_created: false,
+				},
+			];
+
+			server.use(
+				http.get("/api/failover-groups", () => {
+					return HttpResponse.json({
+						groups,
+						last_synced_at: null,
+					});
+				}),
+			);
+
+			const { user } = renderWithProviders(<FailoverGroups />);
+
+			await waitFor(() => {
+				expect(screen.getByText("Custom")).toBeInTheDocument();
+				expect(screen.getByText("hotel/custom-model")).toBeInTheDocument();
+			});
+
+			// Find the Custom section collapse toggle button
+			// The button contains the "Custom" text and a ChevronRight icon
+			const customText = screen.getByText("Custom");
+			const customToggle = customText.closest("button");
+			expect(customToggle).toBeTruthy();
+
+			if (customToggle) {
+				// Collapse
+				await user.click(customToggle);
+
+				// Wait for the collapse animation to complete
+				await new Promise((resolve) => setTimeout(resolve, 300));
+
+				// After collapse, the custom groups should not be visible
+				// The content is hidden via gridTemplateRows: 0fr
+				const customSection = customText.closest("section");
+				expect(customSection).toBeTruthy();
+				const contentDiv = customSection?.querySelector(
+					'[style*="grid-template-rows: 0fr"]',
+				);
+				expect(contentDiv).toBeTruthy();
+
+				// Expand again
+				await user.click(customToggle);
+
+				await waitFor(() => {
+					expect(screen.getByText("hotel/custom-model")).toBeInTheDocument();
+					expect(screen.getByText("hotel/another-custom")).toBeInTheDocument();
 				});
 			}
 		});
@@ -2632,10 +2793,29 @@ describe("FailoverGroups", () => {
 	describe("Alphabet Sidebar", () => {
 		it("Shows alphabet sidebar when more than 3 letter groups", async () => {
 			const groups = [
-				{ ...mockFailoverGroup, display_model: "alpha-model" },
-				{ ...mockFailoverGroup, id: "fg-002", display_model: "beta-model" },
-				{ ...mockFailoverGroup, id: "fg-003", display_model: "gamma-model" },
-				{ ...mockFailoverGroup, id: "fg-004", display_model: "delta-model" },
+				{
+					...mockFailoverGroup,
+					display_model: "alpha-model",
+					auto_created: true,
+				},
+				{
+					...mockFailoverGroup,
+					id: "fg-002",
+					display_model: "beta-model",
+					auto_created: true,
+				},
+				{
+					...mockFailoverGroup,
+					id: "fg-003",
+					display_model: "gamma-model",
+					auto_created: true,
+				},
+				{
+					...mockFailoverGroup,
+					id: "fg-004",
+					display_model: "delta-model",
+					auto_created: true,
+				},
 			];
 
 			server.use(


### PR DESCRIPTION
## Changes

### Custom failover groups separated on top
- Custom (manually created, `auto_created=false`) groups now appear in a dedicated collapsible **"Custom"** section at the top of the page
- Auto-discovered groups remain grouped by first letter below
- Collapsible section uses same animation/style as letter sections

### ★ in alphabet strip
- A **★** symbol appears at the top of the alphabet sidebar when custom groups exist
- Clicking ★ scrolls to the Custom section
- Alphabet strip now appears when custom groups exist even if there are fewer than 3 letter sections

### React Compiler warnings silenced
- Added `"use no memo"` directive and `eslint-disable-next-line` to `VirtualAppLogTable`, `VirtualLogTable`, and `VirtualModelTable` for TanStack Virtual's `useVirtualizer` hook

### Housekeeping
- Added `.skills/` and `.gitmodules` to `.gitignore`