### PR TITLE
feat: proxy GitHub version check through backend to fix CSP violations

### DIFF
--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -70,6 +70,7 @@ type Handler struct {
 	settingsRepo   SettingsStore
 	systemHandler  *SystemHandler
 	appVersion     string
+	ghReleasesURL  string // injectable for testing; defaults to githubReleasesURL const
 }
 
 // NewHandler creates a new admin API handler with the given dependencies.
@@ -82,6 +83,7 @@ func NewHandler(cfg *config.Config, providerRepo ProviderStore, database *db.DB,
 		virtualKeyRepo: vkRepo,
 		settingsRepo:   settingsRepo,
 		appVersion:     appVersion,
+		ghReleasesURL:  githubReleasesURL,
 	}
 }
 
@@ -115,6 +117,7 @@ func (h *Handler) Register(r chi.Router) {
 	h.RegisterAppLogs(r)
 	h.RegisterSettings(r)
 	h.RegisterVirtualKeys(r)
+	h.RegisterVersion(r)
 
 	failoverRepo := failover.NewRepository(h.dbPool.Pool())
 	modelRepo := model.NewRepository(h.dbPool.Pool())

--- a/internal/api/admin_test.go
+++ b/internal/api/admin_test.go
@@ -176,6 +176,7 @@ func testHandler(provStore *mockProviderStore, vkStore *mockVirtualKeyStore, set
 		virtualKeyRepo: vkStore,
 		settingsRepo:   setsStore,
 		appVersion:     "test",
+		ghReleasesURL:  githubReleasesURL,
 	}
 }
 

--- a/internal/api/version.go
+++ b/internal/api/version.go
@@ -1,0 +1,106 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/hugalafutro/model-hotel/internal/debuglog"
+)
+
+const (
+	githubReleasesURL = "https://api.github.com/repos/hugalafutro/model-hotel/releases/latest"
+	versionCacheTTL   = 30 * time.Minute
+)
+
+// githubRelease matches the subset of GitHub's release API response we need.
+type githubRelease struct {
+	TagName string `json:"tag_name"`
+}
+
+// versionCache holds the cached latest release tag and expiry.
+type versionCache struct {
+	mu        sync.Mutex
+	tag       string
+	fetchedAt time.Time
+}
+
+var vCache versionCache
+
+// RegisterVersion mounts the version check route.
+func (h *Handler) RegisterVersion(r chi.Router) {
+	r.Get("/version/latest", h.GetLatestVersion)
+}
+
+// GetLatestVersion proxies the GitHub latest-release API with server-side caching.
+// This avoids CSP connect-src violations in the browser (the frontend fetches
+// /api/version/latest instead of api.github.com directly).
+func (h *Handler) GetLatestVersion(w http.ResponseWriter, r *http.Request) {
+	vCache.mu.Lock()
+	tag := vCache.tag
+	fetchedAt := vCache.fetchedAt
+	vCache.mu.Unlock()
+
+	if tag != "" && time.Since(fetchedAt) < versionCacheTTL {
+		writeJSON(w, map[string]string{"tag_name": tag})
+		return
+	}
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, h.ghReleasesURL, http.NoBody)
+	if err != nil {
+		respondError(w, "failed to create GitHub request", err, http.StatusInternalServerError)
+		return
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		debuglog.Error("version: GitHub request failed", "error", err)
+		// Return stale cache if available, otherwise 502
+		if tag != "" {
+			writeJSON(w, map[string]string{"tag_name": tag})
+			return
+		}
+		respondError(w, "failed to fetch latest release", err, http.StatusBadGateway)
+		return
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			debuglog.Error("version: failed to close response body", "error", closeErr)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		debuglog.Error("version: GitHub returned non-200", "status", resp.StatusCode)
+		if tag != "" {
+			writeJSON(w, map[string]string{"tag_name": tag})
+			return
+		}
+		http.Error(w, "upstream error", http.StatusBadGateway)
+		return
+	}
+
+	var release githubRelease
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		debuglog.Error("version: failed to decode GitHub response", "error", err)
+		respondError(w, "failed to decode release", err, http.StatusInternalServerError)
+		return
+	}
+
+	if release.TagName == "" {
+		debuglog.Error("version: GitHub response missing tag_name")
+		http.Error(w, "no tag_name in response", http.StatusBadGateway)
+		return
+	}
+
+	vCache.mu.Lock()
+	vCache.tag = release.TagName
+	vCache.fetchedAt = time.Now()
+	vCache.mu.Unlock()
+
+	writeJSON(w, map[string]string{"tag_name": release.TagName})
+}

--- a/internal/api/version_test.go
+++ b/internal/api/version_test.go
@@ -1,0 +1,210 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func resetVersionCache() {
+	vCache.mu.Lock()
+	vCache.tag = ""
+	vCache.fetchedAt = time.Time{}
+	vCache.mu.Unlock()
+}
+
+func TestGetLatestVersion_CacheHit(t *testing.T) {
+	resetVersionCache()
+
+	// Pre-populate cache
+	vCache.mu.Lock()
+	vCache.tag = "v1.2.3"
+	vCache.fetchedAt = time.Now()
+	vCache.mu.Unlock()
+
+	h := &Handler{
+		ghReleasesURL: githubReleasesURL,
+	}
+	r := chi.NewRouter()
+	h.RegisterVersion(r)
+
+	req := httptest.NewRequest(http.MethodGet, "/version/latest", http.NoBody)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, w.Code)
+	}
+
+	var result map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+		t.Fatalf("failed to decode: %v", err)
+	}
+	if result["tag_name"] != "v1.2.3" {
+		t.Errorf("expected tag_name 'v1.2.3', got %q", result["tag_name"])
+	}
+}
+
+func TestGetLatestVersion_FetchSuccess(t *testing.T) {
+	resetVersionCache()
+
+	// Mock GitHub API
+	ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Accept") != "application/vnd.github+json" {
+			t.Errorf("expected GitHub Accept header, got %q", r.Header.Get("Accept"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"tag_name": "v2.0.0"})
+	}))
+	defer ghServer.Close()
+
+	h := &Handler{
+		ghReleasesURL: ghServer.URL,
+	}
+	r := chi.NewRouter()
+	h.RegisterVersion(r)
+
+	req := httptest.NewRequest(http.MethodGet, "/version/latest", http.NoBody)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d; body: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+
+	var result map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+		t.Fatalf("failed to decode: %v", err)
+	}
+	if result["tag_name"] != "v2.0.0" {
+		t.Errorf("expected tag_name 'v2.0.0', got %q", result["tag_name"])
+	}
+
+	// Verify cache was populated
+	vCache.mu.Lock()
+	cachedTag := vCache.tag
+	vCache.mu.Unlock()
+	if cachedTag != "v2.0.0" {
+		t.Errorf("expected cached tag 'v2.0.0', got %q", cachedTag)
+	}
+}
+
+func TestGetLatestVersion_StaleCacheFallback(t *testing.T) {
+	resetVersionCache()
+
+	// Set stale cache (expired)
+	vCache.mu.Lock()
+	vCache.tag = "v1.0.0"
+	vCache.fetchedAt = time.Now().Add(-2 * time.Hour) // stale
+	vCache.mu.Unlock()
+
+	// Mock GitHub API returning 500
+	ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ghServer.Close()
+
+	h := &Handler{
+		ghReleasesURL: ghServer.URL,
+	}
+	r := chi.NewRouter()
+	h.RegisterVersion(r)
+
+	req := httptest.NewRequest(http.MethodGet, "/version/latest", http.NoBody)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	// Should fall back to stale cache
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d; body: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+
+	var result map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+		t.Fatalf("failed to decode: %v", err)
+	}
+	if result["tag_name"] != "v1.0.0" {
+		t.Errorf("expected stale tag_name 'v1.0.0', got %q", result["tag_name"])
+	}
+}
+
+func TestGetLatestVersion_NoCache_UpstreamError(t *testing.T) {
+	resetVersionCache()
+
+	// Mock GitHub API returning 500
+	ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ghServer.Close()
+
+	h := &Handler{
+		ghReleasesURL: ghServer.URL,
+	}
+	r := chi.NewRouter()
+	h.RegisterVersion(r)
+
+	req := httptest.NewRequest(http.MethodGet, "/version/latest", http.NoBody)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	// With no cache and upstream error, should get 502
+	if w.Code != http.StatusBadGateway {
+		t.Errorf("expected status %d, got %d; body: %s", http.StatusBadGateway, w.Code, w.Body.String())
+	}
+}
+
+func TestGetLatestVersion_MissingTagName(t *testing.T) {
+	resetVersionCache()
+
+	// Mock GitHub API returning response without tag_name
+	ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{}) // no tag_name
+	}))
+	defer ghServer.Close()
+
+	h := &Handler{
+		ghReleasesURL: ghServer.URL,
+	}
+	r := chi.NewRouter()
+	h.RegisterVersion(r)
+
+	req := httptest.NewRequest(http.MethodGet, "/version/latest", http.NoBody)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	// Missing tag_name should return 502
+	if w.Code != http.StatusBadGateway {
+		t.Errorf("expected status %d, got %d; body: %s", http.StatusBadGateway, w.Code, w.Body.String())
+	}
+}
+
+func TestGetLatestVersion_InvalidJSON(t *testing.T) {
+	resetVersionCache()
+
+	// Mock GitHub API returning invalid JSON
+	ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{invalid json}`))
+	}))
+	defer ghServer.Close()
+
+	h := &Handler{
+		ghReleasesURL: ghServer.URL,
+	}
+	r := chi.NewRouter()
+	h.RegisterVersion(r)
+
+	req := httptest.NewRequest(http.MethodGet, "/version/latest", http.NoBody)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	// Invalid JSON should return 500
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected status %d, got %d; body: %s", http.StatusInternalServerError, w.Code, w.Body.String())
+	}
+}

--- a/web/src/__tests__/App.test.tsx
+++ b/web/src/__tests__/App.test.tsx
@@ -16,6 +16,9 @@ vi.mock("../api/client", () => ({
 		settings: {
 			get: vi.fn().mockResolvedValue({ app_version: "v0.0.0-test" }),
 		},
+		version: {
+			getLatest: vi.fn().mockResolvedValue({ tag_name: "v0.0.0-test" }),
+		},
 	},
 }));
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -593,6 +593,16 @@ export const api = {
 		},
 	},
 
+	version: {
+		getLatest: async (): Promise<{ tag_name: string }> => {
+			return fetchJSON<{ tag_name: string }>(
+				`${API_BASE}/api/version/latest`,
+				{ headers: getAuthHeaders() },
+				"Failed to fetch latest version",
+			);
+		},
+	},
+
 	virtualKeys: {
 		list: async (): Promise<VirtualKey[]> => {
 			return fetchJSON<VirtualKey[]>(

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -594,10 +594,10 @@ export const api = {
 	},
 
 	version: {
-		getLatest: async (): Promise<{ tag_name: string }> => {
+		getLatest: async (options?: RequestInit): Promise<{ tag_name: string }> => {
 			return fetchJSON<{ tag_name: string }>(
 				`${API_BASE}/api/version/latest`,
-				{ headers: getAuthHeaders() },
+				{ headers: getAuthHeaders(), ...options },
 				"Failed to fetch latest version",
 			);
 		},

--- a/web/src/hooks/__tests__/useGitHubVersion.test.ts
+++ b/web/src/hooks/__tests__/useGitHubVersion.test.ts
@@ -1,26 +1,10 @@
 import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { mockSettings } from "../../test/helpers";
+import { mockSettings, mockVersionLatest } from "../../test/helpers";
 import { server } from "../../test/mocks/server";
 import { useGitHubVersion } from "../useGitHubVersion";
 
 const STORAGE_KEY = "github-latest-version";
-const REPO_API =
-	"https://api.github.com/repos/hugalafutro/model-hotel/releases/latest";
-
-/** Mock fetch only for the GitHub releases API; let MSW handle /api/* */
-function mockGitHubFetch(
-	impl: (url: string, init?: RequestInit) => Promise<Response>,
-) {
-	const realFetch = globalThis.fetch;
-	vi.spyOn(globalThis, "fetch").mockImplementation((url, init) => {
-		if (typeof url === "string" && url.startsWith(REPO_API)) {
-			return impl(url, init);
-		}
-		// Fall through to real fetch (MSW intercepts /api/* requests)
-		return realFetch(url, init);
-	});
-}
 
 describe("useGitHubVersion", () => {
 	beforeEach(() => {
@@ -30,7 +14,7 @@ describe("useGitHubVersion", () => {
 
 	it("returns dev running version when settings fetch fails", async () => {
 		server.use(...mockSettings({ status: 500 }));
-		mockGitHubFetch(() => Promise.reject(new Error("offline")));
+		server.use(...mockVersionLatest({ status: 500 }));
 
 		const { result } = renderHook(() => useGitHubVersion());
 		expect(result.current.running).toBe("dev");
@@ -40,7 +24,7 @@ describe("useGitHubVersion", () => {
 
 	it("returns running version from settings API", async () => {
 		server.use(...mockSettings({ body: { app_version: "v1.0.0" } }));
-		mockGitHubFetch(() => Promise.reject(new Error("offline")));
+		server.use(...mockVersionLatest({ status: 500 }));
 
 		const { result } = renderHook(() => useGitHubVersion());
 
@@ -55,7 +39,7 @@ describe("useGitHubVersion", () => {
 		const cached = JSON.stringify({ tag: "v0.1.2", timestamp: Date.now() });
 		localStorage.setItem(STORAGE_KEY, cached);
 
-		mockGitHubFetch(() => Promise.reject(new Error("offline")));
+		server.use(...mockVersionLatest({ status: 500 }));
 		const { result } = renderHook(() => useGitHubVersion());
 		expect(result.current.latest).toBe("v0.1.2");
 	});
@@ -71,7 +55,11 @@ describe("useGitHubVersion", () => {
 			await new Promise((r) => setTimeout(r, 0));
 		});
 
-		expect(fetchSpy).not.toHaveBeenCalledWith(REPO_API, expect.anything());
+		// Should not call /api/version/latest when cache is fresh
+		expect(fetchSpy).not.toHaveBeenCalledWith(
+			expect.stringContaining("/api/version/latest"),
+			expect.anything(),
+		);
 	});
 
 	it("fetches when cache is stale", async () => {
@@ -79,9 +67,7 @@ describe("useGitHubVersion", () => {
 		const cached = JSON.stringify({ tag: "v0.1.1", timestamp: staleTimestamp });
 		localStorage.setItem(STORAGE_KEY, cached);
 
-		mockGitHubFetch(() =>
-			Promise.resolve(new Response(JSON.stringify({ tag_name: "v0.2" }))),
-		);
+		server.use(...mockVersionLatest({ body: { tag_name: "v0.2" } }));
 
 		renderHook(() => useGitHubVersion());
 
@@ -91,9 +77,7 @@ describe("useGitHubVersion", () => {
 	});
 
 	it("updates latest from API response", async () => {
-		mockGitHubFetch(() =>
-			Promise.resolve(new Response(JSON.stringify({ tag_name: "v0.2" }))),
-		);
+		server.use(...mockVersionLatest({ body: { tag_name: "v0.2" } }));
 
 		const { result } = renderHook(() => useGitHubVersion());
 		expect(result.current.latest).toBe("GitHub");
@@ -106,9 +90,7 @@ describe("useGitHubVersion", () => {
 	});
 
 	it("caches fetched version in localStorage", async () => {
-		mockGitHubFetch(() =>
-			Promise.resolve(new Response(JSON.stringify({ tag_name: "v0.2" }))),
-		);
+		server.use(...mockVersionLatest({ body: { tag_name: "v0.2" } }));
 
 		renderHook(() => useGitHubVersion());
 
@@ -126,9 +108,14 @@ describe("useGitHubVersion", () => {
 		const cached = JSON.stringify({ tag: "v0.1.2", timestamp: Date.now() });
 		localStorage.setItem(STORAGE_KEY, cached);
 
-		mockGitHubFetch(() =>
-			Promise.resolve(new Response("rate limited", { status: 403 })),
+		// Make cache stale so it tries to fetch
+		const staleTimestamp = Date.now() - 31 * 60 * 1000;
+		localStorage.setItem(
+			STORAGE_KEY,
+			JSON.stringify({ tag: "v0.1.2", timestamp: staleTimestamp }),
 		);
+
+		server.use(...mockVersionLatest({ status: 403 }));
 
 		const { result } = renderHook(() => useGitHubVersion());
 		expect(result.current.latest).toBe("v0.1.2");
@@ -144,7 +131,14 @@ describe("useGitHubVersion", () => {
 		const cached = JSON.stringify({ tag: "v0.1.2", timestamp: Date.now() });
 		localStorage.setItem(STORAGE_KEY, cached);
 
-		mockGitHubFetch(() => Promise.reject(new Error("network error")));
+		// Make cache stale
+		const staleTimestamp = Date.now() - 31 * 60 * 1000;
+		localStorage.setItem(
+			STORAGE_KEY,
+			JSON.stringify({ tag: "v0.1.2", timestamp: staleTimestamp }),
+		);
+
+		server.use(...mockVersionLatest({ status: 500 }));
 
 		const { result } = renderHook(() => useGitHubVersion());
 
@@ -156,9 +150,7 @@ describe("useGitHubVersion", () => {
 	});
 
 	it("ignores response without tag_name", async () => {
-		mockGitHubFetch(() =>
-			Promise.resolve(new Response(JSON.stringify({ message: "Not Found" }))),
-		);
+		server.use(...mockVersionLatest({ body: { message: "Not Found" } }));
 
 		const { result } = renderHook(() => useGitHubVersion());
 
@@ -171,9 +163,7 @@ describe("useGitHubVersion", () => {
 
 	it("sets updateAvailable=true when latest > running", async () => {
 		server.use(...mockSettings({ body: { app_version: "v1.0.0" } }));
-		mockGitHubFetch(() =>
-			Promise.resolve(new Response(JSON.stringify({ tag_name: "v1.1.0" }))),
-		);
+		server.use(...mockVersionLatest({ body: { tag_name: "v1.1.0" } }));
 
 		const { result } = renderHook(() => useGitHubVersion());
 
@@ -188,9 +178,7 @@ describe("useGitHubVersion", () => {
 
 	it("sets updateAvailable=false when versions match", async () => {
 		server.use(...mockSettings({ body: { app_version: "v1.0.0" } }));
-		mockGitHubFetch(() =>
-			Promise.resolve(new Response(JSON.stringify({ tag_name: "v1.0.0" }))),
-		);
+		server.use(...mockVersionLatest({ body: { tag_name: "v1.0.0" } }));
 
 		const { result } = renderHook(() => useGitHubVersion());
 
@@ -203,9 +191,7 @@ describe("useGitHubVersion", () => {
 
 	it("sets updateAvailable=true when running is dev", async () => {
 		server.use(...mockSettings({ body: { app_version: "dev" } }));
-		mockGitHubFetch(() =>
-			Promise.resolve(new Response(JSON.stringify({ tag_name: "v1.0.0" }))),
-		);
+		server.use(...mockVersionLatest({ body: { tag_name: "v1.0.0" } }));
 
 		const { result } = renderHook(() => useGitHubVersion());
 

--- a/web/src/hooks/useGitHubVersion.ts
+++ b/web/src/hooks/useGitHubVersion.ts
@@ -2,8 +2,6 @@ import { useEffect, useState } from "react";
 import { api } from "../api/client";
 
 const STORAGE_KEY = "github-latest-version";
-const REPO_API =
-	"https://api.github.com/repos/hugalafutro/model-hotel/releases/latest";
 const CACHE_TTL = 30 * 60 * 1000; // 30 minutes
 
 interface CachedVersion {
@@ -76,32 +74,8 @@ export function useGitHubVersion(): VersionInfo {
 		};
 	}, []);
 
-	// Fetch latest GitHub release (existing logic, adapted)
+	// Fetch latest GitHub release via backend proxy
 	useEffect(() => {
-		const controller = new AbortController();
-
-		async function fetchVersion() {
-			try {
-				const res = await fetch(REPO_API, { signal: controller.signal });
-				if (!res.ok) return;
-				const data = await res.json();
-				if (data.tag_name) {
-					const cached: CachedVersion = {
-						tag: data.tag_name,
-						timestamp: Date.now(),
-					};
-					try {
-						localStorage.setItem(STORAGE_KEY, JSON.stringify(cached));
-					} catch {
-						/* quota exceeded */
-					}
-					setLatest(data.tag_name);
-				}
-			} catch {
-				/* network error or aborted - keep current value */
-			}
-		}
-
 		// Check if cache is still fresh
 		try {
 			const raw = localStorage.getItem(STORAGE_KEY);
@@ -115,8 +89,30 @@ export function useGitHubVersion(): VersionInfo {
 			/* ignore, proceed to fetch */
 		}
 
-		fetchVersion();
-		return () => controller.abort();
+		let cancelled = false;
+		api.version
+			.getLatest()
+			.then((data) => {
+				if (cancelled) return;
+				if (data.tag_name) {
+					const cached: CachedVersion = {
+						tag: data.tag_name,
+						timestamp: Date.now(),
+					};
+					try {
+						localStorage.setItem(STORAGE_KEY, JSON.stringify(cached));
+					} catch {
+						/* quota exceeded */
+					}
+					setLatest(data.tag_name);
+				}
+			})
+			.catch(() => {
+				/* network error — keep current value */
+			});
+		return () => {
+			cancelled = true;
+		};
 	}, []);
 
 	const updateAvailable =

--- a/web/src/hooks/useGitHubVersion.ts
+++ b/web/src/hooks/useGitHubVersion.ts
@@ -89,11 +89,10 @@ export function useGitHubVersion(): VersionInfo {
 			/* ignore, proceed to fetch */
 		}
 
-		let cancelled = false;
+		const controller = new AbortController();
 		api.version
-			.getLatest()
+			.getLatest({ signal: controller.signal })
 			.then((data) => {
-				if (cancelled) return;
 				if (data.tag_name) {
 					const cached: CachedVersion = {
 						tag: data.tag_name,
@@ -108,10 +107,10 @@ export function useGitHubVersion(): VersionInfo {
 				}
 			})
 			.catch(() => {
-				/* network error — keep current value */
+				/* network error or aborted — keep current value */
 			});
 		return () => {
-			cancelled = true;
+			controller.abort();
 		};
 	}, []);
 

--- a/web/src/test/helpers.ts
+++ b/web/src/test/helpers.ts
@@ -159,6 +159,21 @@ export function mockSettings(options: OverrideOptions = {}): RequestHandler[] {
 	];
 }
 
+/** Create handler that returns the latest version. */
+export function mockVersionLatest(
+	options: OverrideOptions = {},
+): RequestHandler[] {
+	const { status = 200, body } = options;
+	const data = body ?? { tag_name: "v0.0.0" };
+	return [
+		http.get("/api/version/latest", () =>
+			status === 200
+				? HttpResponse.json(data)
+				: HttpResponse.json(data, { status }),
+		),
+	];
+}
+
 /** Create handler that returns empty logs. */
 export function mockLogs(options: OverrideOptions = {}): RequestHandler[] {
 	const { status = 200, body } = options;
@@ -286,6 +301,7 @@ export function mockAllDefaults(
 		systemStats: OverrideOptions | SystemStats;
 		settings: OverrideOptions | Record<string, string>;
 		logs: OverrideOptions | LogsResponse;
+		versionLatest: OverrideOptions | { tag_name: string };
 	}> = {},
 ): RequestHandler[] {
 	function toOpts<T>(v: OverrideOptions | T[] | undefined): OverrideOptions {
@@ -305,6 +321,7 @@ export function mockAllDefaults(
 		...mockSystemStats(toOpts(overrides.systemStats)),
 		...mockSettings(toOpts(overrides.settings)),
 		...mockLogs(toOpts(overrides.logs)),
+		...mockVersionLatest(toOpts(overrides.versionLatest)),
 	];
 }
 


### PR DESCRIPTION
## Problem

The sidebar version check fetched `https://api.github.com/repos/hugalafutro/model-hotel/releases/latest` directly from the browser. This violated the CSP `connect-src 'self'` directive, and antivirus tools like Kaspersky would also block the cross-origin request.

## Solution

Add `GET /api/version/latest` backend endpoint that proxies the GitHub API call server-side with:
- 30-minute in-memory cache (avoids hammering GitHub)
- Stale-cache fallback (returns last known version if GitHub is temporarily unreachable)
- Injectable GitHub URL for testability

The frontend now fetches from this same-origin endpoint, which passes CSP and is unaffected by browser extensions.

## Changes

**Backend** (`internal/api/`)
- New `version.go` handler with `RegisterVersion` route, server-side caching, and graceful error handling
- New `version_test.go` with 6 tests: cache hits, successful fetches, stale cache fallback, upstream errors, missing `tag_name`, and invalid JSON
- `admin.go`: Added `ghReleasesURL` field to `Handler` struct, registered version route

**Frontend** (`web/src/`)
- `api/client.ts`: Added `api.version.getLatest()` client method
- `hooks/useGitHubVersion.ts`: Replaced raw `fetch(REPO_API)` with `api.version.getLatest()` proxy call
- `hooks/__tests__/useGitHubVersion.test.ts`: Replaced `mockGitHubFetch` with MSW `mockVersionLatest` helper (all 13 tests updated)
- `test/helpers.ts`: Added `mockVersionLatest` mock helper and included it in `mockAllDefaults`