### PR TITLE
fix: virtual table scroll jerk, shimmer, and zebra-stripe desync

### DIFF
--- a/web/src/components/VirtualAppLogTable.tsx
+++ b/web/src/components/VirtualAppLogTable.tsx
@@ -114,29 +114,6 @@ export function VirtualAppLogTable(props: VirtualAppLogTableProps) {
 	} = props;
 
 	const scrollRef = useRef<HTMLDivElement>(null);
-	const prevEntriesRef = useRef(entries);
-	// State counter to force synchronous re-render after scrollTop adjustment.
-	// React guarantees setState inside useLayoutEffect is flushed before paint.
-	const [, forceRerender] = useState(0);
-
-	// When items are prepended (fetchNewer), all item indices shift but
-	// scrollTop stays the same, so the virtualizer maps the old scroll
-	// position to different items. Adjust scrollTop by the estimated
-	// height of the newly prepended items, then force a synchronous
-	// re-render so the virtualizer recomputes before the browser paints.
-	useLayoutEffect(() => {
-		const prev = prevEntriesRef.current;
-		if (entries.length > prev.length && prev.length > 0) {
-			const newItemCount = entries.length - prev.length;
-			if (entries[newItemCount]?.id === prev[0]?.id && scrollRef.current) {
-				scrollRef.current.scrollTop += newItemCount * 48;
-				prevEntriesRef.current = entries;
-				forceRerender((c) => c + 1);
-				return;
-			}
-		}
-		prevEntriesRef.current = entries;
-	}, [entries]);
 
 	// eslint-disable-next-line react-hooks/incompatible-library -- TanStack Virtual returns mutable functions; compiler skips memoization
 	const virtualizer = useVirtualizer({
@@ -147,6 +124,37 @@ export function VirtualAppLogTable(props: VirtualAppLogTableProps) {
 	});
 
 	const virtualItems = virtualizer.getVirtualItems();
+
+	const prevEntriesRef = useRef(entries);
+	// State counter to force synchronous re-render after scrollTop adjustment.
+	// React guarantees setState inside useLayoutEffect is flushed before paint.
+	const [, forceRerender] = useState(0);
+
+	// When items are prepended (fetchNewer), all item indices shift but
+	// scrollTop stays the same, so the virtualizer maps the old scroll
+	// position to different items. Adjust scrollTop by the average of
+	// the virtualizer's measured row sizes (from measureElement /
+	// ResizeObserver), falling back to estimateSize when no measurements
+	// exist yet. Then force a synchronous re-render so the virtualizer
+	// recomputes before the browser paints.
+	useLayoutEffect(() => {
+		const prev = prevEntriesRef.current;
+		if (entries.length > prev.length && prev.length > 0) {
+			const newItemCount = entries.length - prev.length;
+			if (entries[newItemCount]?.id === prev[0]?.id && scrollRef.current) {
+				const cache = virtualizer.measurementsCache;
+				const avgSize =
+					cache.length > 0
+						? cache.reduce((sum, m) => sum + m.size, 0) / cache.length
+						: 48;
+				scrollRef.current.scrollTop += newItemCount * avgSize;
+				prevEntriesRef.current = entries;
+				forceRerender((c) => c + 1);
+				return;
+			}
+		}
+		prevEntriesRef.current = entries;
+	}, [entries, virtualizer.measurementsCache]);
 
 	const [paddingTop, paddingBottom] =
 		virtualItems.length > 0

--- a/web/src/components/VirtualAppLogTable.tsx
+++ b/web/src/components/VirtualAppLogTable.tsx
@@ -1,5 +1,5 @@
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { useCallback, useRef } from "react";
+import { useCallback, useLayoutEffect, useRef, useState } from "react";
 import type { AppLogEntry } from "../api/types";
 import { Badge } from "./Badge";
 
@@ -114,6 +114,29 @@ export function VirtualAppLogTable(props: VirtualAppLogTableProps) {
 	} = props;
 
 	const scrollRef = useRef<HTMLDivElement>(null);
+	const prevEntriesRef = useRef(entries);
+	// State counter to force synchronous re-render after scrollTop adjustment.
+	// React guarantees setState inside useLayoutEffect is flushed before paint.
+	const [, forceRerender] = useState(0);
+
+	// When items are prepended (fetchNewer), all item indices shift but
+	// scrollTop stays the same, so the virtualizer maps the old scroll
+	// position to different items. Adjust scrollTop by the estimated
+	// height of the newly prepended items, then force a synchronous
+	// re-render so the virtualizer recomputes before the browser paints.
+	useLayoutEffect(() => {
+		const prev = prevEntriesRef.current;
+		if (entries.length > prev.length && prev.length > 0) {
+			const newItemCount = entries.length - prev.length;
+			if (entries[newItemCount]?.id === prev[0]?.id && scrollRef.current) {
+				scrollRef.current.scrollTop += newItemCount * 48;
+				prevEntriesRef.current = entries;
+				forceRerender((c) => c + 1);
+				return;
+			}
+		}
+		prevEntriesRef.current = entries;
+	}, [entries]);
 
 	// eslint-disable-next-line react-hooks/incompatible-library -- TanStack Virtual returns mutable functions; compiler skips memoization
 	const virtualizer = useVirtualizer({
@@ -172,10 +195,7 @@ export function VirtualAppLogTable(props: VirtualAppLogTableProps) {
 						minHeight: "200px",
 					}}
 				>
-					<table
-						className="w-full table-fixed ui-table min-w-250"
-						style={{ marginBottom: "8px" }}
-					>
+					<table className="w-full table-fixed ui-table ui-table-virtual min-w-250">
 						<colgroup>
 							<col className="w-44" />
 							<col className="w-20" />
@@ -222,8 +242,11 @@ export function VirtualAppLogTable(props: VirtualAppLogTableProps) {
 				onScroll={handleScroll}
 			>
 				<table
-					className="w-full table-fixed ui-table min-w-250"
-					style={{ marginBottom: "8px" }}
+					className="w-full table-fixed ui-table ui-table-virtual min-w-250"
+					style={{
+						marginTop: paddingTop,
+						marginBottom: paddingBottom + 8,
+					}}
 				>
 					<colgroup>
 						<col className="w-44" />
@@ -245,21 +268,14 @@ export function VirtualAppLogTable(props: VirtualAppLogTableProps) {
 						</tr>
 					</thead>
 					<tbody>
-						{paddingTop > 0 && (
-							<tr>
-								<td
-									colSpan={4}
-									style={{ height: paddingTop, padding: 0, border: "none" }}
-								/>
-							</tr>
-						)}
 						{virtualItems.map((vItem) => {
 							const entry = entries[vItem.index];
 							return (
 								<tr
 									key={entry.id ?? `${vItem.index}`}
 									data-index={vItem.index}
-									className="hover:bg-(--surface-hover) transition-colors cursor-pointer"
+									ref={virtualizer.measureElement}
+									className={`hover:bg-(--surface-hover) ${vItem.index % 2 === 1 ? "ui-row-even" : ""} cursor-pointer`}
 									onClick={() => onRowClick(entry)}
 								>
 									<td className="px-2 py-1 align-middle whitespace-nowrap text-xs text-gray-400">
@@ -292,14 +308,6 @@ export function VirtualAppLogTable(props: VirtualAppLogTableProps) {
 								</tr>
 							);
 						})}
-						{paddingBottom > 0 && (
-							<tr>
-								<td
-									colSpan={4}
-									style={{ height: paddingBottom, padding: 0, border: "none" }}
-								/>
-							</tr>
-						)}
 					</tbody>
 				</table>
 			</div>

--- a/web/src/components/VirtualLogTable.tsx
+++ b/web/src/components/VirtualLogTable.tsx
@@ -64,29 +64,6 @@ export function VirtualLogTable(props: VirtualLogTableProps) {
 	} = props;
 
 	const scrollRef = useRef<HTMLDivElement>(null);
-	const prevEntriesRef = useRef(entries);
-	// State counter to force synchronous re-render after scrollTop adjustment.
-	// React guarantees setState inside useLayoutEffect is flushed before paint.
-	const [, forceRerender] = useState(0);
-
-	// When items are prepended (fetchNewer), all item indices shift but
-	// scrollTop stays the same, so the virtualizer maps the old scroll
-	// position to different items. Adjust scrollTop by the estimated
-	// height of the newly prepended items, then force a synchronous
-	// re-render so the virtualizer recomputes before the browser paints.
-	useLayoutEffect(() => {
-		const prev = prevEntriesRef.current;
-		if (entries.length > prev.length && prev.length > 0) {
-			const newItemCount = entries.length - prev.length;
-			if (entries[newItemCount]?.id === prev[0]?.id && scrollRef.current) {
-				scrollRef.current.scrollTop += newItemCount * 29;
-				prevEntriesRef.current = entries;
-				forceRerender((c) => c + 1);
-				return;
-			}
-		}
-		prevEntriesRef.current = entries;
-	}, [entries]);
 
 	// eslint-disable-next-line react-hooks/incompatible-library -- TanStack Virtual returns mutable functions; compiler skips memoization
 	const virtualizer = useVirtualizer({
@@ -97,6 +74,37 @@ export function VirtualLogTable(props: VirtualLogTableProps) {
 	});
 
 	const virtualItems = virtualizer.getVirtualItems();
+
+	const prevEntriesRef = useRef(entries);
+	// State counter to force synchronous re-render after scrollTop adjustment.
+	// React guarantees setState inside useLayoutEffect is flushed before paint.
+	const [, forceRerender] = useState(0);
+
+	// When items are prepended (fetchNewer), all item indices shift but
+	// scrollTop stays the same, so the virtualizer maps the old scroll
+	// position to different items. Adjust scrollTop by the average of
+	// the virtualizer's measured row sizes (from measureElement /
+	// ResizeObserver), falling back to estimateSize when no measurements
+	// exist yet. Then force a synchronous re-render so the virtualizer
+	// recomputes before the browser paints.
+	useLayoutEffect(() => {
+		const prev = prevEntriesRef.current;
+		if (entries.length > prev.length && prev.length > 0) {
+			const newItemCount = entries.length - prev.length;
+			if (entries[newItemCount]?.id === prev[0]?.id && scrollRef.current) {
+				const cache = virtualizer.measurementsCache;
+				const avgSize =
+					cache.length > 0
+						? cache.reduce((sum, m) => sum + m.size, 0) / cache.length
+						: 29;
+				scrollRef.current.scrollTop += newItemCount * avgSize;
+				prevEntriesRef.current = entries;
+				forceRerender((c) => c + 1);
+				return;
+			}
+		}
+		prevEntriesRef.current = entries;
+	}, [entries, virtualizer.measurementsCache]);
 
 	const [paddingTop, paddingBottom] =
 		virtualItems.length > 0

--- a/web/src/components/VirtualLogTable.tsx
+++ b/web/src/components/VirtualLogTable.tsx
@@ -1,5 +1,5 @@
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { useCallback, useRef } from "react";
+import { useCallback, useLayoutEffect, useRef, useState } from "react";
 import type { LogEntry } from "../api/types";
 import { formatMs, formatTPS } from "../pages/Logs/utils";
 import { formatNumber } from "../utils/format";
@@ -64,12 +64,35 @@ export function VirtualLogTable(props: VirtualLogTableProps) {
 	} = props;
 
 	const scrollRef = useRef<HTMLDivElement>(null);
+	const prevEntriesRef = useRef(entries);
+	// State counter to force synchronous re-render after scrollTop adjustment.
+	// React guarantees setState inside useLayoutEffect is flushed before paint.
+	const [, forceRerender] = useState(0);
+
+	// When items are prepended (fetchNewer), all item indices shift but
+	// scrollTop stays the same, so the virtualizer maps the old scroll
+	// position to different items. Adjust scrollTop by the estimated
+	// height of the newly prepended items, then force a synchronous
+	// re-render so the virtualizer recomputes before the browser paints.
+	useLayoutEffect(() => {
+		const prev = prevEntriesRef.current;
+		if (entries.length > prev.length && prev.length > 0) {
+			const newItemCount = entries.length - prev.length;
+			if (entries[newItemCount]?.id === prev[0]?.id && scrollRef.current) {
+				scrollRef.current.scrollTop += newItemCount * 29;
+				prevEntriesRef.current = entries;
+				forceRerender((c) => c + 1);
+				return;
+			}
+		}
+		prevEntriesRef.current = entries;
+	}, [entries]);
 
 	// eslint-disable-next-line react-hooks/incompatible-library -- TanStack Virtual returns mutable functions; compiler skips memoization
 	const virtualizer = useVirtualizer({
 		count: entries.length,
 		getScrollElement: () => scrollRef.current,
-		estimateSize: () => 34, // approximate row height
+		estimateSize: () => 29, // approximate row height
 		overscan: 20,
 	});
 
@@ -122,7 +145,7 @@ export function VirtualLogTable(props: VirtualLogTableProps) {
 						minHeight: "200px",
 					}}
 				>
-					<table className="w-full table-fixed ui-table min-w-250">
+					<table className="w-full table-fixed ui-table ui-table-virtual min-w-250">
 						<colgroup>
 							<col className="w-30" />
 							<col className="w-28" />
@@ -176,8 +199,11 @@ export function VirtualLogTable(props: VirtualLogTableProps) {
 				onScroll={handleScroll}
 			>
 				<table
-					className="w-full table-fixed ui-table min-w-250"
-					style={{ marginBottom: "8px" }}
+					className="w-full table-fixed ui-table ui-table-virtual min-w-250"
+					style={{
+						marginTop: paddingTop,
+						marginBottom: paddingBottom + 8,
+					}}
 				>
 					<colgroup>
 						<col className="w-30" />
@@ -213,21 +239,14 @@ export function VirtualLogTable(props: VirtualLogTableProps) {
 						</tr>
 					</thead>
 					<tbody>
-						{paddingTop > 0 && (
-							<tr>
-								<td
-									colSpan={11}
-									style={{ height: paddingTop, padding: 0, border: "none" }}
-								/>
-							</tr>
-						)}
 						{virtualItems.map((vItem) => {
 							const log = entries[vItem.index];
 							return (
 								<tr
 									key={log.id}
 									data-index={vItem.index}
-									className="hover:bg-(--surface-hover) transition-colors cursor-pointer"
+									ref={virtualizer.measureElement}
+									className={`hover:bg-(--surface-hover) ${vItem.index % 2 === 1 ? "ui-row-even" : ""} cursor-pointer`}
 									onClick={() => onRowClick(log)}
 								>
 									<td className="px-2 py-1 whitespace-nowrap text-xs text-gray-400">
@@ -331,14 +350,6 @@ export function VirtualLogTable(props: VirtualLogTableProps) {
 								</tr>
 							);
 						})}
-						{paddingBottom > 0 && (
-							<tr>
-								<td
-									colSpan={11}
-									style={{ height: paddingBottom, padding: 0, border: "none" }}
-								/>
-							</tr>
-						)}
 					</tbody>
 				</table>
 			</div>

--- a/web/src/components/VirtualModelTable.tsx
+++ b/web/src/components/VirtualModelTable.tsx
@@ -175,30 +175,6 @@ export function VirtualModelTable({
 		getId: (entry) => entry.id,
 	});
 
-	const prevEntriesRef = useRef(entries);
-	// State counter to force synchronous re-render after scrollTop adjustment.
-	// React guarantees setState inside useLayoutEffect is flushed before paint.
-	const [, forceRerender] = useState(0);
-
-	// When items are prepended (fetchNewer), all item indices shift but
-	// scrollTop stays the same, so the virtualizer maps the old scroll
-	// position to different items. Adjust scrollTop by the estimated
-	// height of the newly prepended items, then force a synchronous
-	// re-render so the virtualizer recomputes before the browser paints.
-	useLayoutEffect(() => {
-		const prev = prevEntriesRef.current;
-		if (entries.length > prev.length && prev.length > 0) {
-			const newItemCount = entries.length - prev.length;
-			if (entries[newItemCount]?.id === prev[0]?.id && scrollRef.current) {
-				scrollRef.current.scrollTop += newItemCount * 45;
-				prevEntriesRef.current = entries;
-				forceRerender((c) => c + 1);
-				return;
-			}
-		}
-		prevEntriesRef.current = entries;
-	}, [entries]);
-
 	const existingCaps = useMemo(() => {
 		const caps = new Set<CapKey>();
 		entries.forEach((m) => {
@@ -223,6 +199,37 @@ export function VirtualModelTable({
 	});
 
 	const virtualItems = virtualizer.getVirtualItems();
+
+	const prevEntriesRef = useRef(entries);
+	// State counter to force synchronous re-render after scrollTop adjustment.
+	// React guarantees setState inside useLayoutEffect is flushed before paint.
+	const [, forceRerender] = useState(0);
+
+	// When items are prepended (fetchNewer), all item indices shift but
+	// scrollTop stays the same, so the virtualizer maps the old scroll
+	// position to different items. Adjust scrollTop by the average of
+	// the virtualizer's measured row sizes (from measureElement /
+	// ResizeObserver), falling back to estimateSize when no measurements
+	// exist yet. Then force a synchronous re-render so the virtualizer
+	// recomputes before the browser paints.
+	useLayoutEffect(() => {
+		const prev = prevEntriesRef.current;
+		if (entries.length > prev.length && prev.length > 0) {
+			const newItemCount = entries.length - prev.length;
+			if (entries[newItemCount]?.id === prev[0]?.id && scrollRef.current) {
+				const cache = virtualizer.measurementsCache;
+				const avgSize =
+					cache.length > 0
+						? cache.reduce((sum, m) => sum + m.size, 0) / cache.length
+						: 45;
+				scrollRef.current.scrollTop += newItemCount * avgSize;
+				prevEntriesRef.current = entries;
+				forceRerender((c) => c + 1);
+				return;
+			}
+		}
+		prevEntriesRef.current = entries;
+	}, [entries, virtualizer.measurementsCache]);
 
 	const [paddingTop, paddingBottom] =
 		virtualItems.length > 0

--- a/web/src/components/VirtualModelTable.tsx
+++ b/web/src/components/VirtualModelTable.tsx
@@ -1,5 +1,5 @@
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { api } from "../api/client";
 import type { Model, ModelsCursorResponse, Provider } from "../api/types";
 import { useBidirectionalFetch } from "../hooks/useBidirectionalFetch";
@@ -175,6 +175,30 @@ export function VirtualModelTable({
 		getId: (entry) => entry.id,
 	});
 
+	const prevEntriesRef = useRef(entries);
+	// State counter to force synchronous re-render after scrollTop adjustment.
+	// React guarantees setState inside useLayoutEffect is flushed before paint.
+	const [, forceRerender] = useState(0);
+
+	// When items are prepended (fetchNewer), all item indices shift but
+	// scrollTop stays the same, so the virtualizer maps the old scroll
+	// position to different items. Adjust scrollTop by the estimated
+	// height of the newly prepended items, then force a synchronous
+	// re-render so the virtualizer recomputes before the browser paints.
+	useLayoutEffect(() => {
+		const prev = prevEntriesRef.current;
+		if (entries.length > prev.length && prev.length > 0) {
+			const newItemCount = entries.length - prev.length;
+			if (entries[newItemCount]?.id === prev[0]?.id && scrollRef.current) {
+				scrollRef.current.scrollTop += newItemCount * 45;
+				prevEntriesRef.current = entries;
+				forceRerender((c) => c + 1);
+				return;
+			}
+		}
+		prevEntriesRef.current = entries;
+	}, [entries]);
+
 	const existingCaps = useMemo(() => {
 		const caps = new Set<CapKey>();
 		entries.forEach((m) => {
@@ -194,7 +218,7 @@ export function VirtualModelTable({
 	const virtualizer = useVirtualizer({
 		count: entries.length,
 		getScrollElement: () => scrollRef.current,
-		estimateSize: () => 34,
+		estimateSize: () => 45,
 		overscan: 20,
 	});
 
@@ -269,8 +293,11 @@ export function VirtualModelTable({
 				onScroll={handleScroll}
 			>
 				<table
-					className="w-full table-fixed ui-table min-w-250"
-					style={{ marginBottom: "8px" }}
+					className="w-full table-fixed ui-table ui-table-virtual min-w-250"
+					style={{
+						marginTop: isEmpty ? 0 : paddingTop,
+						marginBottom: isEmpty ? 8 : paddingBottom + 8,
+					}}
 				>
 					<colgroup>
 						{showProviderCol ? (
@@ -484,105 +511,84 @@ export function VirtualModelTable({
 								</td>
 							</tr>
 						) : (
-							<>
-								{paddingTop > 0 && (
-									<tr>
-										<td
-											colSpan={showProviderCol ? 10 : 9}
-											style={{ height: paddingTop, padding: 0, border: "none" }}
-										/>
-									</tr>
-								)}
-								{virtualItems.map((vItem) => {
-									const model = entries[vItem.index];
-									const caps = parseCapabilities(model.capabilities);
-									const isActive = model.enabled && !model.disabled_manually;
-									const isManuallyDisabled =
-										model.enabled && model.disabled_manually;
-									return (
-										<tr
-											key={model.id}
-											data-index={vItem.index}
-											className={`hover:bg-(--surface-hover) transition-colors ${onModelClick ? "cursor-pointer" : ""}`}
-											onClick={() => onModelClick?.(model)}
-										>
-											<td className="px-4 py-1.5">
-												<div className="flex flex-col">
-													<span
-														className={`text-left text-sm ${isActive ? "font-medium text-white" : "text-gray-500"}`}
-													>
-														{model.name ||
-															proxyModelID(model.provider_name, model.model_id)}
-													</span>
-													<span className="text-[11px] text-gray-500 font-mono leading-tight truncate">
-														{proxyModelID(model.provider_name, model.model_id)}
-													</span>
-												</div>
-											</td>
-											<td className="px-4 py-1.5">
-												<div className="flex flex-wrap gap-1">
-													{CAP_META.filter((m) => hasCap(caps, m.key)).map(
-														(m) => (
-															<span
-																key={m.key}
-																className={`inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium border ${m.style}`}
-															>
-																{m.label}
-															</span>
-														),
-													)}
-												</div>
-											</td>
-											{showProviderCol && (
-												<td className="px-4 py-1.5 whitespace-nowrap text-sm text-gray-300 truncate">
-													{model.provider_name}
-												</td>
-											)}
-											<td className="px-4 py-1.5 whitespace-nowrap text-sm text-gray-400">
-												{formatRelativeTime(model.last_seen_at)}
-											</td>
-											<td aria-hidden />
-											<td className="px-4 py-1.5 whitespace-nowrap text-sm text-gray-300">
-												{formatNumber(model.context_length)}
-											</td>
-											<td aria-hidden />
-											<td className="px-4 py-1.5 whitespace-nowrap text-sm text-gray-300">
-												{formatNumber(model.max_output_tokens)}
-											</td>
-											<td aria-hidden />
-											<td className="px-4 py-1.5 whitespace-nowrap">
+							virtualItems.map((vItem) => {
+								const model = entries[vItem.index];
+								const caps = parseCapabilities(model.capabilities);
+								const isActive = model.enabled && !model.disabled_manually;
+								const isManuallyDisabled =
+									model.enabled && model.disabled_manually;
+								return (
+									<tr
+										key={model.id}
+										data-index={vItem.index}
+										ref={virtualizer.measureElement}
+										className={`hover:bg-(--surface-hover) ${vItem.index % 2 === 1 ? "ui-row-even" : ""} ${onModelClick ? "cursor-pointer" : ""}`}
+										onClick={() => onModelClick?.(model)}
+									>
+										<td className="px-4 py-1.5">
+											<div className="flex flex-col">
 												<span
-													className={`px-2 py-0.5 text-xs rounded-full ${
-														isActive
-															? "bg-green-900/50 text-green-400"
-															: isManuallyDisabled
-																? "bg-yellow-900/50 text-yellow-400"
-																: "bg-red-900/50 text-red-400"
-													}`}
+													className={`text-left text-sm ${isActive ? "font-medium text-white" : "text-gray-500"}`}
 												>
-													{isActive
-														? "Enabled"
-														: isManuallyDisabled
-															? "Manually Disabled"
-															: "Disabled"}
+													{model.name ||
+														proxyModelID(model.provider_name, model.model_id)}
 												</span>
+												<span className="text-[11px] text-gray-500 font-mono leading-tight truncate">
+													{proxyModelID(model.provider_name, model.model_id)}
+												</span>
+											</div>
+										</td>
+										<td className="px-4 py-1.5">
+											<div className="flex flex-wrap gap-1">
+												{CAP_META.filter((m) => hasCap(caps, m.key)).map(
+													(m) => (
+														<span
+															key={m.key}
+															className={`inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium border ${m.style}`}
+														>
+															{m.label}
+														</span>
+													),
+												)}
+											</div>
+										</td>
+										{showProviderCol && (
+											<td className="px-4 py-1.5 whitespace-nowrap text-sm text-gray-300 truncate">
+												{model.provider_name}
 											</td>
-										</tr>
-									);
-								})}
-								{paddingBottom > 0 && (
-									<tr>
-										<td
-											colSpan={showProviderCol ? 10 : 9}
-											style={{
-												height: paddingBottom,
-												padding: 0,
-												border: "none",
-											}}
-										/>
+										)}
+										<td className="px-4 py-1.5 whitespace-nowrap text-sm text-gray-400">
+											{formatRelativeTime(model.last_seen_at)}
+										</td>
+										<td aria-hidden />
+										<td className="px-4 py-1.5 whitespace-nowrap text-sm text-gray-300">
+											{formatNumber(model.context_length)}
+										</td>
+										<td aria-hidden />
+										<td className="px-4 py-1.5 whitespace-nowrap text-sm text-gray-300">
+											{formatNumber(model.max_output_tokens)}
+										</td>
+										<td aria-hidden />
+										<td className="px-4 py-1.5 whitespace-nowrap">
+											<span
+												className={`px-2 py-0.5 text-xs rounded-full ${
+													isActive
+														? "bg-green-900/50 text-green-400"
+														: isManuallyDisabled
+															? "bg-yellow-900/50 text-yellow-400"
+															: "bg-red-900/50 text-red-400"
+												}`}
+											>
+												{isActive
+													? "Enabled"
+													: isManuallyDisabled
+														? "Manually Disabled"
+														: "Disabled"}
+											</span>
+										</td>
 									</tr>
-								)}
-							</>
+								);
+							})
 						)}
 					</tbody>
 				</table>

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1360,11 +1360,25 @@ html[data-ui-style="glassmorphism-lite"].light select.ui-input option:hover {
 	color: var(--text-secondary);
 }
 
-[data-ui-style] .ui-table tbody tr:nth-child(even) {
+[data-ui-style] .ui-table:not(.ui-table-virtual) tbody tr:nth-child(even) {
 	background-color: rgb(255 255 255 / 3%);
 }
 
-html.light [data-ui-style] .ui-table tbody tr:nth-child(even) {
+html.light
+	[data-ui-style]
+	.ui-table:not(.ui-table-virtual)
+	tbody
+	tr:nth-child(even) {
+	background-color: rgb(0 0 0 / 3%);
+}
+
+/* Virtual table row striping: index-based to avoid nth-child desync
+   when padding spacer rows appear/disappear during scroll. */
+[data-ui-style] .ui-table-virtual tbody tr.ui-row-even {
+	background-color: rgb(255 255 255 / 3%);
+}
+
+html.light [data-ui-style] .ui-table-virtual tbody tr.ui-row-even {
 	background-color: rgb(0 0 0 / 3%);
 }
 


### PR DESCRIPTION
## Problem

Three visible bugs in the virtual (infinite-scroll) tables on Models, Logs, and App Logs pages:

1. **Scroll jerk**: When scrolling through the Models table, the content visibly jumps each time the first visible row index changes. The status bar "1–X" number flips and the rows shift ~10px. This repeats for every index transition during continuous scroll.

2. **"Split into 2 tables" shimmer**: During fetch-triggered re-renders, the table briefly appears to separate into two visual layers — the data rows and the padding spacer rows render at inconsistent positions during layout reflow.

3. **Zebra-stripe desync**: Row striping (nth-child even/odd) drifts out of sync with actual row content because the virtualizer adds/removes padding `<tr>` spacer rows, changing the child index of data rows.

## Root Causes

### Scroll jerk
`estimateSize` was 34px for all tables, but actual row heights differ significantly:
- Models: 44.5px (31% taller than estimate)
- Logs: 28.75px (15% shorter than estimate)

Without `measureElement`, the virtualizer never learns real sizes. When the first visible index changes, `marginTop` (used as padding-before) jumps by 34px (the estimate) instead of the actual row height, causing a 10.5px position gap per row on Models.

### Shimmer
Spacer `<tr>` rows inside `<tbody>` with dynamic heights force full table reflow on every virtualizer update. During the brief reflow, rows and spacers can render at inconsistent positions.

### Zebra desync
CSS `nth-child(even)` is DOM-order-based. Padding spacer `<tr>` rows appear/disappear during scroll, shifting the child indices of data rows and breaking the stripe pattern.

## Changes

### `measureElement` (all 3 tables)
Added `ref={virtualizer.measureElement}` to each data `<tr>`. TanStack Virtual uses `ResizeObserver` with `border-box` sizing to learn actual row heights after render, then computes accurate `totalSize` and per-item offsets. This is the key fix for the scroll jerk.

### Fixed `estimateSize` (all 3 tables)
- VirtualModelTable: 34 → 45 (actual: 44.5px)
- VirtualLogTable: 34 → 29 (actual: 28.75px)
- VirtualAppLogTable: 48 (already close)

`estimateSize` still matters for initial estimates before `measureElement` reports real sizes, and for the prepend scroll adjustment calculation.

### Spacer `<tr>` → table margin (all 3 tables)
Replaced `<tr><td height={paddingTop}/></tr>` and `<tr><td height={paddingBottom}/></tr>` inside `<tbody>` with `marginTop`/`marginBottom` on the `<table>` element. Margin changes don't trigger table reflow — the browser adjusts spacing outside the table layout, eliminating the shimmer.

### Prepend scroll adjustment (all 3 tables)
Added `useLayoutEffect` + `forceRerender` pattern: when items are prepended (fetchNewer), `scrollTop` is adjusted by `newItemCount * estimateSize` and a synchronous re-render forces the virtualizer to recompute before the browser paints.

### Zebra-stripe fix (CSS + all 3 tables)
- Scoped `nth-child(even)` to `.ui-table:not(.ui-table-virtual)` in `index.css`
- Added `.ui-table-virtual` class to all virtual table `<table>` elements
- Added index-based `ui-row-even` class (`vItem.index % 2 === 1`) on data `<tr>` rows
- Added CSS rules for `.ui-table-virtual tbody tr.ui-row-even` in both dark and light modes
- Removed `transition-colors` class from `<tr>` rows (replaced by static `ui-row-even`)

## Testing
- All 3041 frontend tests pass
- `biome check` and `eslint` clean