### PR TITLE
Improve frontend test coverage (81.7% → 83.3%)

### DIFF
--- a/web/src/components/__tests__/ProviderQuotaPanel.test.tsx
+++ b/web/src/components/__tests__/ProviderQuotaPanel.test.tsx
@@ -1,32 +1,315 @@
-import { HttpResponse, http } from "msw";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { QuotaDataResult } from "../../hooks/useQuotaData";
 import { server } from "../../test/mocks/server";
 import { renderWithProviders } from "../../test/utils";
 import { ProviderQuotaPanel } from "../ProviderQuotaPanel";
+
+// Mock useQuotaData
+vi.mock("../../hooks/useQuotaData", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("../../hooks/useQuotaData")>();
+	return {
+		...actual,
+		useQuotaData: vi.fn(),
+	};
+});
+
+// Get the mocked function after vi.mock is set up
+const { useQuotaData } = await import("../../hooks/useQuotaData");
+const mockUseQuotaData = vi.mocked(useQuotaData);
+
+function createMockQuotaData(
+	overrides?: Partial<QuotaDataResult>,
+): QuotaDataResult {
+	return {
+		hasAnyProvider: true,
+		nanogptUsage: undefined,
+		zaiCodingUsage: undefined,
+		openrouterBalance: undefined,
+		isNanoRefetching: false,
+		isZaiCodingRefetching: false,
+		isDsRefetching: false,
+		isOrRefetching: false,
+		isOllamaCloudRefetching: false,
+		invalidateAll: vi.fn(),
+		refetchNano: vi.fn(),
+		refetchZaiCoding: vi.fn(),
+		refetchDeepseek: vi.fn(),
+		refetchOpenRouter: vi.fn(),
+		refetchOllamaCloud: vi.fn(),
+		nanogptDataUpdatedAt: 0,
+		zaiCodingDataUpdatedAt: 0,
+		openrouterDataUpdatedAt: 0,
+		deepseekDataUpdatedAt: 0,
+		ollamaCloudDataUpdatedAt: 0,
+		showNanoBadge: false,
+		showZaiCodingBadge: false,
+		showDsBadge: false,
+		showOrBadge: false,
+		showOllamaCloudBadge: false,
+		nanogptProviderId: undefined,
+		zaiCodingProviderId: undefined,
+		deepseekProviderId: undefined,
+		openrouterProviderId: undefined,
+		ollamaCloudProviderId: undefined,
+		deepseekBalance: undefined,
+		ollamaCloudAccount: undefined,
+		zaiCodingFiveHour: undefined,
+		zaiCodingWeekly: undefined,
+		nanoWeeklyUsed: undefined,
+		nanoWeeklyLimit: undefined,
+		...overrides,
+	};
+}
+
+function setupPanel(overrides?: Partial<QuotaDataResult>) {
+	mockUseQuotaData.mockReturnValue(createMockQuotaData(overrides));
+	return renderWithProviders(<ProviderQuotaPanel />);
+}
 
 describe("ProviderQuotaPanel", () => {
 	beforeEach(() => {
 		server.resetHandlers();
 		vi.clearAllMocks();
+		localStorage.clear();
+		mockUseQuotaData.mockReturnValue(createMockQuotaData());
 	});
 
-	it("renders null when no providers", () => {
-		server.use(
-			http.get("/api/providers", () => {
-				return HttpResponse.json([]);
-			}),
-		);
-		const { container } = renderWithProviders(<ProviderQuotaPanel />);
-		expect(container.querySelector(".sidebar-quota-panel")).toBeNull();
-	});
-
-	it("renders null when quota is disabled", () => {
-		const getItemSpy = vi.spyOn(Storage.prototype, "getItem");
-		getItemSpy.mockImplementation((key) => {
-			if (key === "sidebarQuotaRefreshMin") return "0";
-			return null;
+	describe("rendering", () => {
+		it("renders null when hasAnyProvider is false", () => {
+			mockUseQuotaData.mockReturnValue(
+				createMockQuotaData({ hasAnyProvider: false }),
+			);
+			const { container } = renderWithProviders(<ProviderQuotaPanel />);
+			expect(container.querySelector(".sidebar-quota-panel")).toBeNull();
 		});
-		const { container } = renderWithProviders(<ProviderQuotaPanel />);
-		expect(container.querySelector(".sidebar-quota-panel")).toBeNull();
-		getItemSpy.mockRestore();
+
+		it("renders null when quota is disabled", () => {
+			localStorage.setItem("sidebarQuotaDisabled", "true");
+			mockUseQuotaData.mockReturnValue(
+				createMockQuotaData({ hasAnyProvider: true }),
+			);
+			const { container } = renderWithProviders(<ProviderQuotaPanel />);
+			expect(container.querySelector(".sidebar-quota-panel")).toBeNull();
+		});
+
+		it("renders panel when providers exist", () => {
+			const { container } = setupPanel();
+			expect(
+				container.querySelector(".sidebar-quota-panel"),
+			).toBeInTheDocument();
+		});
+	});
+
+	describe("collapsed state", () => {
+		it("toggleCollapsed changes collapsed state and saves to localStorage", async () => {
+			const user = userEvent.setup();
+			const { getByTitle } = setupPanel();
+
+			// Initially expanded - check for collapse button
+			expect(getByTitle("Collapse")).toBeInTheDocument();
+
+			// Click to collapse
+			await user.click(getByTitle("Collapse"));
+
+			expect(localStorage.getItem("sidebarQuotaCollapsed")).toBe("true");
+		});
+
+		it("toggleCollapsed shows toast when collapsing", async () => {
+			const user = userEvent.setup();
+			setupPanel();
+
+			const collapseButton = screen.getByTitle("Collapse");
+			await user.click(collapseButton);
+
+			expect(
+				screen.getByText("Quota panel collapsed - auto-refresh paused"),
+			).toBeInTheDocument();
+		});
+
+		it("toggleCollapsed shows toast when expanding", async () => {
+			const user = userEvent.setup();
+			localStorage.setItem("sidebarQuotaCollapsed", "true");
+			setupPanel();
+
+			const expandButton = screen.getByTitle("Expand quotas");
+			await user.click(expandButton);
+
+			expect(
+				screen.getByText("Quota panel expanded - auto-refresh resumed"),
+			).toBeInTheDocument();
+		});
+
+		it("collapsed UI hides label and refresh button", () => {
+			localStorage.setItem("sidebarQuotaCollapsed", "true");
+			const { container, queryByTitle } = setupPanel();
+
+			// Label should have invisible class
+			const label = container.querySelector(".sidebar-quota-label");
+			expect(label).toHaveClass("invisible");
+
+			// Refresh button should be hidden when collapsed
+			expect(queryByTitle("Refresh all quotas")).toBeNull();
+
+			// Should show expand button
+			expect(queryByTitle("Expand quotas")).toBeInTheDocument();
+		});
+
+		it("expanded UI shows label and refresh button", () => {
+			const { container, queryByTitle } = setupPanel();
+
+			// Label should be visible (no invisible class)
+			const label = container.querySelector(".sidebar-quota-label");
+			expect(label).not.toHaveClass("invisible");
+
+			// Refresh button should be shown
+			expect(queryByTitle("Refresh all quotas")).toBeInTheDocument();
+
+			// Should show collapse button
+			expect(queryByTitle("Collapse")).toBeInTheDocument();
+		});
+	});
+
+	describe("refresh behavior", () => {
+		it("handleRefresh calls invalidateAll and shows toast", async () => {
+			const mockInvalidateAll = vi.fn();
+			const user = userEvent.setup();
+			setupPanel({ invalidateAll: mockInvalidateAll });
+
+			const refreshButton = screen.getByTitle("Refresh all quotas");
+			await user.click(refreshButton);
+
+			expect(mockInvalidateAll).toHaveBeenCalledTimes(1);
+			expect(screen.getByText("Refreshing quotas...")).toBeInTheDocument();
+		});
+
+		it("handleRefresh enforces cooldown on rapid clicks", async () => {
+			const mockInvalidateAll = vi.fn();
+			const user = userEvent.setup();
+			setupPanel({ invalidateAll: mockInvalidateAll });
+
+			const refreshButton = screen.getByTitle("Refresh all quotas");
+
+			// First click succeeds
+			await user.click(refreshButton);
+			expect(mockInvalidateAll).toHaveBeenCalledTimes(1);
+
+			// Immediate second click blocked by cooldown
+			await user.click(refreshButton);
+			expect(mockInvalidateAll).toHaveBeenCalledTimes(1);
+			expect(
+				screen.getByText("Please wait before refreshing again"),
+			).toBeInTheDocument();
+		});
+
+		it("refresh button is disabled when anyRefreshing is true", () => {
+			setupPanel({ isNanoRefetching: true });
+
+			const refreshButton = screen.getByTitle(
+				"Refresh all quotas",
+			) as HTMLButtonElement;
+			expect(refreshButton).toBeDisabled();
+		});
+
+		it("refresh icon spins when auto-refreshing", () => {
+			const { container } = setupPanel({ isNanoRefetching: true });
+
+			const refreshIcon = container.querySelector(".sidebar-quota-btn svg");
+			expect(refreshIcon).toHaveClass("animate-spin");
+		});
+
+		it("refresh icon does not spin when not refreshing", () => {
+			const { container } = setupPanel({ isNanoRefetching: false });
+
+			const refreshIcon = container.querySelector(".sidebar-quota-btn svg");
+			expect(refreshIcon).not.toHaveClass("animate-spin");
+		});
+	});
+
+	describe("event listeners", () => {
+		it("sidebarQuotaToggle event hides panel when disabled", async () => {
+			const { container } = setupPanel();
+
+			// Panel should be visible initially
+			expect(
+				container.querySelector(".sidebar-quota-panel"),
+			).toBeInTheDocument();
+
+			// Set disabled in localStorage before dispatching event
+			localStorage.setItem("sidebarQuotaDisabled", "true");
+
+			// Dispatch toggle event
+			window.dispatchEvent(new CustomEvent("sidebarQuotaToggle"));
+
+			// Panel should be hidden when disabled
+			await vi.waitFor(() => {
+				expect(container.querySelector(".sidebar-quota-panel")).toBeNull();
+			});
+		});
+
+		it("sidebarQuotaRefreshChange event updates refresh interval", () => {
+			const { container } = setupPanel();
+
+			localStorage.setItem("sidebarQuotaRefreshMin", "10");
+			window.dispatchEvent(new CustomEvent("sidebarQuotaRefreshChange"));
+
+			// Component should still render with updated interval
+			expect(
+				container.querySelector(".sidebar-quota-panel"),
+			).toBeInTheDocument();
+		});
+
+		it("storage event (cross-tab) updates disabled state", async () => {
+			const { container } = setupPanel();
+
+			// Panel should be visible initially
+			expect(
+				container.querySelector(".sidebar-quota-panel"),
+			).toBeInTheDocument();
+
+			// Set disabled in localStorage (simulates cross-tab change)
+			localStorage.setItem("sidebarQuotaDisabled", "true");
+
+			// Simulate cross-tab storage change
+			window.dispatchEvent(
+				new StorageEvent("storage", {
+					key: "sidebarQuotaDisabled",
+					newValue: "true",
+				}),
+			);
+
+			// Panel should be hidden when disabled via cross-tab
+			await vi.waitFor(() => {
+				expect(container.querySelector(".sidebar-quota-panel")).toBeNull();
+			});
+		});
+	});
+
+	describe("refreshMs calculation", () => {
+		it("renders panel when refreshIntervalMin is 0 (auto-refresh disabled)", () => {
+			localStorage.setItem("sidebarQuotaRefreshMin", "0");
+			const { container } = setupPanel();
+			expect(
+				container.querySelector(".sidebar-quota-panel"),
+			).toBeInTheDocument();
+		});
+
+		it("renders panel with valid refresh interval", () => {
+			localStorage.setItem("sidebarQuotaRefreshMin", "10");
+			const { container } = setupPanel();
+			expect(
+				container.querySelector(".sidebar-quota-panel"),
+			).toBeInTheDocument();
+		});
+
+		it("renders panel with invalid refresh interval (defaults to 5min)", () => {
+			localStorage.setItem("sidebarQuotaRefreshMin", "invalid");
+			const { container } = setupPanel();
+			expect(
+				container.querySelector(".sidebar-quota-panel"),
+			).toBeInTheDocument();
+		});
 	});
 });

--- a/web/src/components/__tests__/ProviderQuotaPanel.test.tsx
+++ b/web/src/components/__tests__/ProviderQuotaPanel.test.tsx
@@ -2,7 +2,6 @@ import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { QuotaDataResult } from "../../hooks/useQuotaData";
-import { server } from "../../test/mocks/server";
 import { renderWithProviders } from "../../test/utils";
 import { ProviderQuotaPanel } from "../ProviderQuotaPanel";
 
@@ -71,7 +70,6 @@ function setupPanel(overrides?: Partial<QuotaDataResult>) {
 
 describe("ProviderQuotaPanel", () => {
 	beforeEach(() => {
-		server.resetHandlers();
 		vi.clearAllMocks();
 		localStorage.clear();
 		mockUseQuotaData.mockReturnValue(createMockQuotaData());
@@ -249,16 +247,21 @@ describe("ProviderQuotaPanel", () => {
 			});
 		});
 
-		it("sidebarQuotaRefreshChange event updates refresh interval", () => {
-			const { container } = setupPanel();
+		it("sidebarQuotaRefreshChange event updates refresh interval", async () => {
+			setupPanel();
 
 			localStorage.setItem("sidebarQuotaRefreshMin", "10");
 			window.dispatchEvent(new CustomEvent("sidebarQuotaRefreshChange"));
 
-			// Component should still render with updated interval
-			expect(
-				container.querySelector(".sidebar-quota-panel"),
-			).toBeInTheDocument();
+			// The handler calls setRefreshIntervalMin which triggers a
+			// re-render with the updated refetchInterval passed to
+			// useQuotaData. 10min = 600000ms.
+			await vi.waitFor(() => {
+				expect(mockUseQuotaData).toHaveBeenCalledWith(
+					expect.anything(),
+					expect.objectContaining({ refetchInterval: 600_000 }),
+				);
+			});
 		});
 
 		it("storage event (cross-tab) updates disabled state", async () => {
@@ -272,13 +275,11 @@ describe("ProviderQuotaPanel", () => {
 			// Set disabled in localStorage (simulates cross-tab change)
 			localStorage.setItem("sidebarQuotaDisabled", "true");
 
-			// Simulate cross-tab storage change
-			window.dispatchEvent(
-				new StorageEvent("storage", {
-					key: "sidebarQuotaDisabled",
-					newValue: "true",
-				}),
-			);
+			// Simulate cross-tab storage change.
+			// The production handler re-reads localStorage directly and
+			// does not inspect event.key or event.newValue, so those
+			// fields are omitted to avoid implying key-based filtering.
+			window.dispatchEvent(new StorageEvent("storage"));
 
 			// Panel should be hidden when disabled via cross-tab
 			await vi.waitFor(() => {

--- a/web/src/context/ToastContext.tsx
+++ b/web/src/context/ToastContext.tsx
@@ -32,7 +32,8 @@ interface ToastContextType {
 	setTimeout: (timeout: number) => void;
 }
 
-const ToastContext = createContext<ToastContextType>({
+// eslint-disable-next-line react-refresh/only-export-components
+export const ToastContext = createContext<ToastContextType>({
 	toast: () => {},
 	position: "bottom-center",
 	setPosition: () => {},

--- a/web/src/pages/FailoverGroups/__tests__/FailoverGroupCard.test.tsx
+++ b/web/src/pages/FailoverGroups/__tests__/FailoverGroupCard.test.tsx
@@ -419,6 +419,131 @@ describe("FailoverGroupCard", () => {
 			// This is a simplified test - full DnD testing would require more setup
 			expect(onReorder).toBeDefined();
 		});
+
+		it("copies model reference to clipboard on Enter key", async () => {
+			const group = {
+				...mockFailoverGroup,
+				display_model: "test-model",
+			};
+
+			const { user } = renderWithProviders(
+				<FailoverGroupCard {...defaultProps} group={group} />,
+			);
+
+			// The model name div has role="button" and tabIndex={0}
+			// Use getAllByRole since there are multiple buttons (ON/OFF toggle, delete)
+			const modelButton = screen
+				.getAllByRole("button")
+				.find((btn) => btn.textContent?.includes("hotel/test-model"));
+			expect(modelButton).toBeDefined();
+			if (!modelButton) throw new Error("Model button not found");
+
+			modelButton.focus();
+			await user.keyboard("{Enter}");
+
+			// Toast should appear confirming copy
+			await waitFor(() => {
+				expect(screen.getByText("Copied hotel/test-model")).toBeInTheDocument();
+			});
+		});
+
+		it("copies model reference to clipboard on Space key", async () => {
+			const group = {
+				...mockFailoverGroup,
+				display_model: "test-model",
+			};
+
+			const { user } = renderWithProviders(
+				<FailoverGroupCard {...defaultProps} group={group} />,
+			);
+
+			const modelButton = screen
+				.getAllByRole("button")
+				.find((btn) => btn.textContent?.includes("hotel/test-model"));
+			expect(modelButton).toBeDefined();
+			if (!modelButton) throw new Error("Model button not found");
+
+			modelButton.focus();
+			await user.keyboard(" ");
+
+			// Toast should appear confirming copy
+			await waitFor(() => {
+				expect(screen.getByText("Copied hotel/test-model")).toBeInTheDocument();
+			});
+		});
+
+		it("resets local entries when server data changes after mutation", async () => {
+			const entries = [
+				{
+					model_uuid: "entry-1",
+					model_id: "model-1",
+					provider_id: "p1",
+					provider_name: "P1",
+					display_name: "M1",
+					enabled: true,
+					context_length: 8192,
+					owned_by: "p1",
+				},
+				{
+					model_uuid: "entry-2",
+					model_id: "model-2",
+					provider_id: "p2",
+					provider_name: "P2",
+					display_name: "M2",
+					enabled: true,
+					context_length: 4096,
+					owned_by: "p2",
+				},
+			];
+			const { rerender } = renderWithProviders(
+				<FailoverGroupCard
+					{...defaultProps}
+					group={{ ...mockFailoverGroup, entries }}
+				/>,
+			);
+
+			expect(screen.getByText("P1")).toBeInTheDocument();
+			expect(screen.getByText("P2")).toBeInTheDocument();
+
+			// Re-render with reversed entries (simulating server data change after mutation)
+			const reversedEntries = [...entries].reverse();
+			rerender(
+				<FailoverGroupCard
+					{...defaultProps}
+					group={{ ...mockFailoverGroup, entries: reversedEntries }}
+				/>,
+			);
+
+			// Both should still render (order may differ but both visible)
+			expect(screen.getByText("P1")).toBeInTheDocument();
+			expect(screen.getByText("P2")).toBeInTheDocument();
+		});
+
+		it("does not call onReorder without drag interaction", () => {
+			const onReorder = vi.fn();
+			const entries = [
+				{
+					model_uuid: "entry-1",
+					model_id: "model-1",
+					provider_id: "p1",
+					provider_name: "P1",
+					display_name: "M1",
+					enabled: true,
+					context_length: 8192,
+					owned_by: "p1",
+				},
+			];
+
+			renderWithProviders(
+				<FailoverGroupCard
+					{...defaultProps}
+					group={{ ...mockFailoverGroup, entries }}
+					onReorder={onReorder}
+				/>,
+			);
+
+			expect(onReorder).not.toHaveBeenCalled();
+		});
 	});
 
 	describe("Entry Rendering", () => {

--- a/web/src/pages/Providers/__tests__/AddProviderModal.test.tsx
+++ b/web/src/pages/Providers/__tests__/AddProviderModal.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from "@testing-library/react";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 import { HttpResponse, http } from "msw";
 import { server } from "../../../test/mocks/server";
 import { renderWithProviders } from "../../../test/utils";
@@ -708,6 +708,699 @@ describe("AddProviderModal", () => {
 				expect(onToast).toHaveBeenCalledWith(
 					expect.stringContaining("Discovered 5 models"),
 					"success",
+				);
+			});
+		});
+
+		it("shows singular 'model' when discovery returns 1", async () => {
+			server.use(
+				http.post("/api/providers", async ({ request }) => {
+					const body = await request.json();
+					return HttpResponse.json(
+						{
+							id: "provider-new",
+							name: (body as { name?: string }).name ?? "New Provider",
+							base_url:
+								(body as { base_url?: string }).base_url ??
+								"https://api.example.com/v1",
+							masked_key: "sk_test_••••••••",
+							enabled: true,
+							last_discovered_at: null,
+							last_used_at: null,
+							created_at: new Date().toISOString(),
+							updated_at: new Date().toISOString(),
+							model_count: 0,
+							total_tokens: 0,
+						},
+						{ status: 201 },
+					);
+				}),
+				http.post("/api/providers/:id/discover", () => {
+					return HttpResponse.json({ discovered: 1 });
+				}),
+			);
+			const { user } = renderWithProviders(
+				<AddProviderModal
+					{...defaultProps}
+					settings={{ discovery_on_provider_create: "true" }}
+				/>,
+			);
+			const nameInput = screen.getByLabelText("Name");
+			const baseUrlInput = screen.getByLabelText("Base URL");
+			const apiKeyInput = screen.getByLabelText("API Key");
+			await user.type(nameInput, "Test Provider");
+			await user.type(baseUrlInput, "https://api.test.com/v1");
+			await user.type(apiKeyInput, "sk-test-key");
+			const submitButton = screen.getByRole("button", {
+				name: "Add Provider",
+			});
+			await user.click(submitButton);
+			await waitFor(() => {
+				expect(onToast).toHaveBeenCalledWith(
+					expect.stringContaining("Discovered 1 model from"),
+					"success",
+				);
+			});
+		});
+
+		it("skips auto-discovery when disabled in settings", async () => {
+			server.use(
+				http.post("/api/providers", async ({ request }) => {
+					const body = await request.json();
+					return HttpResponse.json(
+						{
+							id: "provider-new",
+							name: (body as { name?: string }).name ?? "New Provider",
+							base_url:
+								(body as { base_url?: string }).base_url ??
+								"https://api.example.com/v1",
+							masked_key: "sk_test_••••••••",
+							enabled: true,
+							last_discovered_at: null,
+							last_used_at: null,
+							created_at: new Date().toISOString(),
+							updated_at: new Date().toISOString(),
+							model_count: 0,
+							total_tokens: 0,
+						},
+						{ status: 201 },
+					);
+				}),
+			);
+			const { user } = renderWithProviders(
+				<AddProviderModal
+					{...defaultProps}
+					settings={{ discovery_on_provider_create: "false" }}
+				/>,
+			);
+			const nameInput = screen.getByLabelText("Name");
+			const baseUrlInput = screen.getByLabelText("Base URL");
+			const apiKeyInput = screen.getByLabelText("API Key");
+			await user.type(nameInput, "Test Provider");
+			await user.type(baseUrlInput, "https://api.test.com/v1");
+			await user.type(apiKeyInput, "sk-test-key");
+			const submitButton = screen.getByRole("button", {
+				name: "Add Provider",
+			});
+			await user.click(submitButton);
+			await waitFor(() => {
+				expect(onToast).toHaveBeenCalledWith(
+					expect.stringContaining("added"),
+					"success",
+				);
+			});
+			// No discovery toast should appear
+			expect(onToast).not.toHaveBeenCalledWith(
+				expect.stringContaining("Discovered"),
+				"success",
+			);
+		});
+
+		it("shows warning toast when auto-discovery fails", async () => {
+			server.use(
+				http.post("/api/providers", async ({ request }) => {
+					const body = await request.json();
+					return HttpResponse.json(
+						{
+							id: "provider-new",
+							name: (body as { name?: string }).name ?? "New Provider",
+							base_url:
+								(body as { base_url?: string }).base_url ??
+								"https://api.example.com/v1",
+							masked_key: "sk_test_••••••••",
+							enabled: true,
+							last_discovered_at: null,
+							last_used_at: null,
+							created_at: new Date().toISOString(),
+							updated_at: new Date().toISOString(),
+							model_count: 0,
+							total_tokens: 0,
+						},
+						{ status: 201 },
+					);
+				}),
+				http.post("/api/providers/:id/discover", () => {
+					return HttpResponse.json({ error: "failed" }, { status: 500 });
+				}),
+			);
+			const { user } = renderWithProviders(
+				<AddProviderModal
+					{...defaultProps}
+					settings={{ discovery_on_provider_create: "true" }}
+				/>,
+			);
+			const nameInput = screen.getByLabelText("Name");
+			const baseUrlInput = screen.getByLabelText("Base URL");
+			const apiKeyInput = screen.getByLabelText("API Key");
+			await user.type(nameInput, "Test Provider");
+			await user.type(baseUrlInput, "https://api.test.com/v1");
+			await user.type(apiKeyInput, "sk-test-key");
+			const submitButton = screen.getByRole("button", {
+				name: "Add Provider",
+			});
+			await user.click(submitButton);
+			await waitFor(() => {
+				expect(onToast).toHaveBeenCalledWith(
+					expect.stringContaining("Auto-discovery failed"),
+					"warning",
+				);
+			});
+		});
+	});
+
+	describe("generateProviderName", () => {
+		it("returns base display name when no providers exist", () => {
+			renderWithProviders(<AddProviderModal {...defaultProps} />);
+			const typeSelect = screen.getByLabelText("Type");
+			const nameInput = screen.getByLabelText("Name");
+			// Select OpenAI type - should set name to "OpenAI"
+			fireEvent.change(typeSelect, { target: { value: "openai" } });
+			expect(nameInput).toHaveValue("OpenAI");
+		});
+
+		it("appends ' 2' when provider with same name already exists", () => {
+			const existingProviders = [
+				{
+					name: "OpenAI",
+					base_url: "https://api.openai.com/v1",
+					id: "p1",
+					masked_key: "sk_••••",
+					enabled: true,
+					last_discovered_at: null,
+					last_used_at: null,
+					created_at: new Date().toISOString(),
+					updated_at: new Date().toISOString(),
+					model_count: 0,
+					total_tokens: 0,
+				},
+			];
+			renderWithProviders(
+				<AddProviderModal {...defaultProps} providers={existingProviders} />,
+			);
+			const typeSelect = screen.getByLabelText("Type");
+			const nameInput = screen.getByLabelText("Name");
+			fireEvent.change(typeSelect, { target: { value: "openai" } });
+			expect(nameInput).toHaveValue("OpenAI 2");
+		});
+
+		it("appends ' 3' when 'OpenAI 2' also exists", () => {
+			const existingProviders = [
+				{
+					name: "OpenAI",
+					base_url: "https://api.openai.com/v1",
+					id: "p1",
+					masked_key: "sk_••••",
+					enabled: true,
+					last_discovered_at: null,
+					last_used_at: null,
+					created_at: new Date().toISOString(),
+					updated_at: new Date().toISOString(),
+					model_count: 0,
+					total_tokens: 0,
+				},
+				{
+					name: "OpenAI 2",
+					base_url: "https://api.openai.com/v1",
+					id: "p2",
+					masked_key: "sk_••••",
+					enabled: true,
+					last_discovered_at: null,
+					last_used_at: null,
+					created_at: new Date().toISOString(),
+					updated_at: new Date().toISOString(),
+					model_count: 0,
+					total_tokens: 0,
+				},
+			];
+			renderWithProviders(
+				<AddProviderModal {...defaultProps} providers={existingProviders} />,
+			);
+			const typeSelect = screen.getByLabelText("Type");
+			const nameInput = screen.getByLabelText("Name");
+			fireEvent.change(typeSelect, { target: { value: "openai" } });
+			expect(nameInput).toHaveValue("OpenAI 3");
+		});
+	});
+
+	describe("handleProviderTypeChange with custom", () => {
+		it("keeps existing name and base_url when switching back to custom", async () => {
+			const { user } = renderWithProviders(
+				<AddProviderModal {...defaultProps} />,
+			);
+			const typeSelect = screen.getByLabelText("Type");
+			const nameInput = screen.getByLabelText("Name");
+			const baseUrlInput = screen.getByLabelText("Base URL");
+
+			// First select a preset type
+			await user.selectOptions(typeSelect, "openai");
+			expect(nameInput).toHaveValue("OpenAI");
+			expect(baseUrlInput).toHaveValue("https://api.openai.com/v1");
+
+			// Edit the name and base URL
+			await user.clear(nameInput);
+			await user.type(nameInput, "My Custom OpenAI");
+			// Base URL is readonly for preset types, so we need to switch to custom first
+			// Actually, let's just test that switching to custom preserves the name
+			await user.selectOptions(typeSelect, "custom");
+
+			// Name should be preserved (not overwritten)
+			expect(nameInput).toHaveValue("My Custom OpenAI");
+			// Base URL should also be preserved
+			expect(baseUrlInput).toHaveValue("https://api.openai.com/v1");
+		});
+	});
+
+	describe("local provider types (ollama, lmstudio, koboldcpp)", () => {
+		it("has editable base URL for ollama type", async () => {
+			const { user } = renderWithProviders(
+				<AddProviderModal {...defaultProps} />,
+			);
+			const typeSelect = screen.getByLabelText("Type");
+			await user.selectOptions(typeSelect, "ollama");
+			const baseUrlInput = screen.getByLabelText("Base URL");
+			// Should have default value
+			expect(baseUrlInput).toHaveValue("http://localhost:11434");
+			// Should NOT be readonly
+			expect(baseUrlInput).not.toHaveAttribute("readonly");
+			// Should show helper text
+			expect(
+				screen.getByText(/Default URL pre-filled; edit if your server/),
+			).toBeInTheDocument();
+		});
+
+		it("has editable base URL for lmstudio type", async () => {
+			const { user } = renderWithProviders(
+				<AddProviderModal {...defaultProps} />,
+			);
+			const typeSelect = screen.getByLabelText("Type");
+			await user.selectOptions(typeSelect, "lmstudio");
+			const baseUrlInput = screen.getByLabelText("Base URL");
+			expect(baseUrlInput).toHaveValue("http://localhost:1234/v1");
+			expect(baseUrlInput).not.toHaveAttribute("readonly");
+		});
+
+		it("has editable base URL for koboldcpp type", async () => {
+			const { user } = renderWithProviders(
+				<AddProviderModal {...defaultProps} />,
+			);
+			const typeSelect = screen.getByLabelText("Type");
+			await user.selectOptions(typeSelect, "koboldcpp");
+			const baseUrlInput = screen.getByLabelText("Base URL");
+			expect(baseUrlInput).toHaveValue("http://localhost:5001/v1");
+			expect(baseUrlInput).not.toHaveAttribute("readonly");
+		});
+	});
+
+	describe("provider types with free models", () => {
+		it("shows 'Optional - free models available' placeholder for opencode-zen", async () => {
+			const { user } = renderWithProviders(
+				<AddProviderModal {...defaultProps} />,
+			);
+			const typeSelect = screen.getByLabelText("Type");
+			await user.selectOptions(typeSelect, "opencode-zen");
+			const apiKeyInput = screen.getByLabelText("API Key");
+			expect(apiKeyInput).toHaveAttribute(
+				"placeholder",
+				"Optional - free models available",
+			);
+		});
+
+		it("API key is not required for opencode-zen", async () => {
+			const { user } = renderWithProviders(
+				<AddProviderModal {...defaultProps} />,
+			);
+			const typeSelect = screen.getByLabelText("Type");
+			await user.selectOptions(typeSelect, "opencode-zen");
+			const apiKeyInput = screen.getByLabelText("API Key");
+			expect(apiKeyInput).not.toHaveAttribute("required");
+		});
+	});
+
+	describe("providerTypeAllowsEmptyKey types", () => {
+		it("API key is not required for ollama", async () => {
+			const { user } = renderWithProviders(
+				<AddProviderModal {...defaultProps} />,
+			);
+			const typeSelect = screen.getByLabelText("Type");
+			await user.selectOptions(typeSelect, "ollama");
+			const apiKeyInput = screen.getByLabelText("API Key");
+			expect(apiKeyInput).not.toHaveAttribute("required");
+		});
+
+		it("API key is not required for koboldcpp", async () => {
+			const { user } = renderWithProviders(
+				<AddProviderModal {...defaultProps} />,
+			);
+			const typeSelect = screen.getByLabelText("Type");
+			await user.selectOptions(typeSelect, "koboldcpp");
+			const apiKeyInput = screen.getByLabelText("API Key");
+			expect(apiKeyInput).not.toHaveAttribute("required");
+		});
+
+		it("API key is not required for lmstudio", async () => {
+			const { user } = renderWithProviders(
+				<AddProviderModal {...defaultProps} />,
+			);
+			const typeSelect = screen.getByLabelText("Type");
+			await user.selectOptions(typeSelect, "lmstudio");
+			const apiKeyInput = screen.getByLabelText("API Key");
+			expect(apiKeyInput).not.toHaveAttribute("required");
+		});
+
+		it("API key is not required for custom", () => {
+			renderWithProviders(<AddProviderModal {...defaultProps} />);
+			const apiKeyInput = screen.getByLabelText("API Key");
+			// Custom type is default, should not require API key
+			expect(apiKeyInput).not.toHaveAttribute("required");
+		});
+	});
+
+	describe("quota/balance detection", () => {
+		it("shows NanoGPT quota detected toast", async () => {
+			const nanogptUsage = {
+				subscription: { plan: "Pro", status: "active" },
+				usage: { tokens_used: 1000, tokens_limit: 10000 },
+			};
+			server.use(
+				http.post("/api/providers", async ({ request }) => {
+					const body = await request.json();
+					return HttpResponse.json(
+						{
+							id: "provider-new",
+							name: (body as { name?: string }).name ?? "NanoGPT",
+							base_url:
+								(body as { base_url?: string }).base_url ??
+								"https://nano-gpt.com/api/subscription/v1",
+							masked_key: "sk_test_••••••••",
+							enabled: true,
+							last_discovered_at: null,
+							last_used_at: null,
+							created_at: new Date().toISOString(),
+							updated_at: new Date().toISOString(),
+							model_count: 0,
+							total_tokens: 0,
+						},
+						{ status: 201 },
+					);
+				}),
+				http.post("/api/providers/:id/discover", () => {
+					return HttpResponse.json({ discovered: 5 });
+				}),
+				http.get("/api/providers/:id/usage", () => {
+					return HttpResponse.json(nanogptUsage);
+				}),
+			);
+			const { user } = renderWithProviders(
+				<AddProviderModal
+					{...defaultProps}
+					settings={{ discovery_on_provider_create: "true" }}
+				/>,
+			);
+			const nameInput = screen.getByLabelText("Name");
+			const baseUrlInput = screen.getByLabelText("Base URL");
+			const apiKeyInput = screen.getByLabelText("API Key");
+			await user.type(nameInput, "NanoGPT");
+			await user.type(baseUrlInput, "https://nano-gpt.com/api/subscription/v1");
+			await user.type(apiKeyInput, "sk-test-key");
+			const submitButton = screen.getByRole("button", {
+				name: "Add Provider",
+			});
+			await user.click(submitButton);
+			await waitFor(() => {
+				expect(onToast).toHaveBeenCalledWith("NanoGPT quota detected", "info");
+			});
+		});
+
+		it("shows Z.ai Coding quota detected toast", async () => {
+			server.use(
+				http.post("/api/providers", async ({ request }) => {
+					const body = await request.json();
+					return HttpResponse.json(
+						{
+							id: "provider-new",
+							name: (body as { name?: string }).name ?? "Z.ai Coding",
+							base_url:
+								(body as { base_url?: string }).base_url ??
+								"https://api.z.ai/api/coding/paas/v4",
+							masked_key: "sk_test_••••••••",
+							enabled: true,
+							last_discovered_at: null,
+							last_used_at: null,
+							created_at: new Date().toISOString(),
+							updated_at: new Date().toISOString(),
+							model_count: 0,
+							total_tokens: 0,
+						},
+						{ status: 201 },
+					);
+				}),
+				http.post("/api/providers/:id/discover", () => {
+					return HttpResponse.json({ discovered: 5 });
+				}),
+				http.get("/api/providers/:id/usage", () => {
+					return HttpResponse.json({ quota: { used: 100, limit: 1000 } });
+				}),
+			);
+			const { user } = renderWithProviders(
+				<AddProviderModal
+					{...defaultProps}
+					settings={{ discovery_on_provider_create: "true" }}
+				/>,
+			);
+			const nameInput = screen.getByLabelText("Name");
+			const baseUrlInput = screen.getByLabelText("Base URL");
+			const apiKeyInput = screen.getByLabelText("API Key");
+			await user.type(nameInput, "Z.ai Coding");
+			await user.type(baseUrlInput, "https://api.z.ai/api/coding/paas/v4");
+			await user.type(apiKeyInput, "sk-test-key");
+			const submitButton = screen.getByRole("button", {
+				name: "Add Provider",
+			});
+			await user.click(submitButton);
+			await waitFor(() => {
+				expect(onToast).toHaveBeenCalledWith(
+					"Z.ai Coding quota detected",
+					"info",
+				);
+			});
+		});
+
+		it("shows DeepSeek balance with USD currency", async () => {
+			server.use(
+				http.post("/api/providers", async ({ request }) => {
+					const body = await request.json();
+					return HttpResponse.json(
+						{
+							id: "provider-new",
+							name: (body as { name?: string }).name ?? "DeepSeek",
+							base_url:
+								(body as { base_url?: string }).base_url ??
+								"https://api.deepseek.com/v1",
+							masked_key: "sk_test_••••••••",
+							enabled: true,
+							last_discovered_at: null,
+							last_used_at: null,
+							created_at: new Date().toISOString(),
+							updated_at: new Date().toISOString(),
+							model_count: 0,
+							total_tokens: 0,
+						},
+						{ status: 201 },
+					);
+				}),
+				http.post("/api/providers/:id/discover", () => {
+					return HttpResponse.json({ discovered: 5 });
+				}),
+				http.get("/api/providers/:id/balance", () => {
+					return HttpResponse.json({
+						balance_infos: [{ currency: "USD", total_balance: "10.50" }],
+					});
+				}),
+			);
+			const { user } = renderWithProviders(
+				<AddProviderModal
+					{...defaultProps}
+					settings={{ discovery_on_provider_create: "true" }}
+				/>,
+			);
+			const nameInput = screen.getByLabelText("Name");
+			const baseUrlInput = screen.getByLabelText("Base URL");
+			const apiKeyInput = screen.getByLabelText("API Key");
+			await user.type(nameInput, "DeepSeek");
+			await user.type(baseUrlInput, "https://api.deepseek.com/v1");
+			await user.type(apiKeyInput, "sk-test-key");
+			const submitButton = screen.getByRole("button", {
+				name: "Add Provider",
+			});
+			await user.click(submitButton);
+			await waitFor(() => {
+				expect(onToast).toHaveBeenCalledWith(
+					"DeepSeek balance detected: $10.50",
+					"info",
+				);
+			});
+		});
+
+		it("shows DeepSeek balance without USD currency", async () => {
+			server.use(
+				http.post("/api/providers", async ({ request }) => {
+					const body = await request.json();
+					return HttpResponse.json(
+						{
+							id: "provider-new",
+							name: (body as { name?: string }).name ?? "DeepSeek",
+							base_url:
+								(body as { base_url?: string }).base_url ??
+								"https://api.deepseek.com/v1",
+							masked_key: "sk_test_••••••••",
+							enabled: true,
+							last_discovered_at: null,
+							last_used_at: null,
+							created_at: new Date().toISOString(),
+							updated_at: new Date().toISOString(),
+							model_count: 0,
+							total_tokens: 0,
+						},
+						{ status: 201 },
+					);
+				}),
+				http.post("/api/providers/:id/discover", () => {
+					return HttpResponse.json({ discovered: 5 });
+				}),
+				http.get("/api/providers/:id/balance", () => {
+					return HttpResponse.json({
+						balance_infos: [{ currency: "EUR", total_balance: "5.00" }],
+					});
+				}),
+			);
+			const { user } = renderWithProviders(
+				<AddProviderModal
+					{...defaultProps}
+					settings={{ discovery_on_provider_create: "true" }}
+				/>,
+			);
+			const nameInput = screen.getByLabelText("Name");
+			const baseUrlInput = screen.getByLabelText("Base URL");
+			const apiKeyInput = screen.getByLabelText("API Key");
+			await user.type(nameInput, "DeepSeek");
+			await user.type(baseUrlInput, "https://api.deepseek.com/v1");
+			await user.type(apiKeyInput, "sk-test-key");
+			const submitButton = screen.getByRole("button", {
+				name: "Add Provider",
+			});
+			await user.click(submitButton);
+			await waitFor(() => {
+				expect(onToast).toHaveBeenCalledWith(
+					"DeepSeek balance detected",
+					"info",
+				);
+			});
+		});
+
+		it("shows OpenRouter balance detected toast", async () => {
+			server.use(
+				http.post("/api/providers", async ({ request }) => {
+					const body = await request.json();
+					return HttpResponse.json(
+						{
+							id: "provider-new",
+							name: (body as { name?: string }).name ?? "OpenRouter",
+							base_url:
+								(body as { base_url?: string }).base_url ??
+								"https://openrouter.ai/api/v1",
+							masked_key: "sk_test_••••••••",
+							enabled: true,
+							last_discovered_at: null,
+							last_used_at: null,
+							created_at: new Date().toISOString(),
+							updated_at: new Date().toISOString(),
+							model_count: 0,
+							total_tokens: 0,
+						},
+						{ status: 201 },
+					);
+				}),
+				http.post("/api/providers/:id/discover", () => {
+					return HttpResponse.json({ discovered: 5 });
+				}),
+				http.get("/api/providers/:id/usage", () => {
+					return HttpResponse.json({ credits_remaining: 5.5 });
+				}),
+			);
+			const { user } = renderWithProviders(
+				<AddProviderModal
+					{...defaultProps}
+					settings={{ discovery_on_provider_create: "true" }}
+				/>,
+			);
+			const nameInput = screen.getByLabelText("Name");
+			const baseUrlInput = screen.getByLabelText("Base URL");
+			const apiKeyInput = screen.getByLabelText("API Key");
+			await user.type(nameInput, "OpenRouter");
+			await user.type(baseUrlInput, "https://openrouter.ai/api/v1");
+			await user.type(apiKeyInput, "sk-test-key");
+			const submitButton = screen.getByRole("button", {
+				name: "Add Provider",
+			});
+			await user.click(submitButton);
+			await waitFor(() => {
+				expect(onToast).toHaveBeenCalledWith(
+					expect.stringContaining("$5.50"),
+					"info",
+				);
+			});
+		});
+
+		it("shows Ollama Cloud free plan detected toast", async () => {
+			server.use(
+				http.post("/api/providers", async ({ request }) => {
+					const body = await request.json();
+					return HttpResponse.json(
+						{
+							id: "provider-new",
+							name: (body as { name?: string }).name ?? "Ollama Cloud",
+							base_url:
+								(body as { base_url?: string }).base_url ??
+								"https://ollama.com/v1",
+							masked_key: "sk_test_••••••••",
+							enabled: true,
+							last_discovered_at: null,
+							last_used_at: null,
+							created_at: new Date().toISOString(),
+							updated_at: new Date().toISOString(),
+							model_count: 0,
+							total_tokens: 0,
+						},
+						{ status: 201 },
+					);
+				}),
+				http.post("/api/providers/:id/discover", () => {
+					return HttpResponse.json({ discovered: 5 });
+				}),
+				http.get("/api/providers/:id/account", () => {
+					return HttpResponse.json({ plan: "free" });
+				}),
+			);
+			const { user } = renderWithProviders(
+				<AddProviderModal
+					{...defaultProps}
+					settings={{ discovery_on_provider_create: "true" }}
+				/>,
+			);
+			const nameInput = screen.getByLabelText("Name");
+			const baseUrlInput = screen.getByLabelText("Base URL");
+			const apiKeyInput = screen.getByLabelText("API Key");
+			await user.type(nameInput, "Ollama Cloud");
+			await user.type(baseUrlInput, "https://ollama.com/v1");
+			await user.type(apiKeyInput, "sk-test-key");
+			const submitButton = screen.getByRole("button", {
+				name: "Add Provider",
+			});
+			await user.click(submitButton);
+			await waitFor(() => {
+				expect(onToast).toHaveBeenCalledWith(
+					"Ollama Cloud free plan detected",
+					"info",
 				);
 			});
 		});

--- a/web/src/pages/Settings/ColorPickerModal.tsx
+++ b/web/src/pages/Settings/ColorPickerModal.tsx
@@ -37,6 +37,7 @@ export function ColorPickerModal({
 						maxLength={6}
 					/>
 					<div
+						data-testid="color-preview"
 						className="w-8 h-8 rounded-full border-2 border-gray-600 shrink-0"
 						style={{ backgroundColor: color }}
 					/>

--- a/web/src/pages/Settings/__tests__/CircuitBreakerSettings.test.tsx
+++ b/web/src/pages/Settings/__tests__/CircuitBreakerSettings.test.tsx
@@ -1,0 +1,517 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { HttpResponse, http } from "msw";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mockSettings } from "../../../test/helpers";
+import { server } from "../../../test/mocks/server";
+import { renderWithProviders } from "../../../test/utils";
+import { CircuitBreakerSettings } from "../CircuitBreakerSettings";
+
+describe("CircuitBreakerSettings", () => {
+	const onToggle = vi.fn();
+
+	beforeEach(() => {
+		onToggle.mockClear();
+		localStorage.setItem("adminToken", "test-token");
+	});
+
+	it("renders section title with Shield icon", () => {
+		renderWithProviders(
+			<CircuitBreakerSettings collapsed={false} onToggle={onToggle} />,
+		);
+		expect(screen.getByText("Circuit Breaker & Failover")).toBeInTheDocument();
+		const icon = document.querySelector(".lucide-shield");
+		expect(icon).toBeInTheDocument();
+	});
+
+	it("renders description text", () => {
+		renderWithProviders(
+			<CircuitBreakerSettings collapsed={false} onToggle={onToggle} />,
+		);
+		expect(
+			screen.getByText(
+				"Configure how the proxy handles provider failures and rate-limited requests.",
+			),
+		).toBeInTheDocument();
+	});
+
+	it("renders Enable Circuit Breaker toggle with label and description", () => {
+		renderWithProviders(
+			<CircuitBreakerSettings collapsed={false} onToggle={onToggle} />,
+		);
+		expect(screen.getByText("Enable Circuit Breaker")).toBeInTheDocument();
+		expect(
+			screen.getByText(
+				"Temporarily stop routing to providers that are failing",
+			),
+		).toBeInTheDocument();
+	});
+
+	it("renders Failover on Rate Limit toggle with label and description", () => {
+		renderWithProviders(
+			<CircuitBreakerSettings collapsed={false} onToggle={onToggle} />,
+		);
+		expect(screen.getByText("Failover on Rate Limit")).toBeInTheDocument();
+		expect(
+			screen.getByText("Route to failover group when a provider returns 429"),
+		).toBeInTheDocument();
+	});
+
+	it("circuit breaker toggle is ON by default when settings undefined", async () => {
+		server.use(...mockSettings({ body: {} }));
+		renderWithProviders(
+			<CircuitBreakerSettings collapsed={false} onToggle={onToggle} />,
+		);
+		await waitFor(() => {
+			const section = screen
+				.getByText("Enable Circuit Breaker")
+				.closest(".flex.items-center.justify-between");
+			const toggle = section?.querySelector("button[role='switch']");
+			expect(toggle).toHaveAttribute("aria-checked", "true");
+		});
+	});
+
+	it("failover on rate limit toggle is OFF by default when settings undefined", async () => {
+		server.use(...mockSettings({ body: {} }));
+		renderWithProviders(
+			<CircuitBreakerSettings collapsed={false} onToggle={onToggle} />,
+		);
+		await waitFor(() => {
+			const section = screen
+				.getByText("Failover on Rate Limit")
+				.closest(".flex.items-center.justify-between");
+			const toggle = section?.querySelector("button[role='switch']");
+			expect(toggle).toHaveAttribute("aria-checked", "false");
+		});
+	});
+
+	it("shows threshold and cooldown when circuit breaker is enabled", async () => {
+		server.use(
+			...mockSettings({
+				body: {
+					circuit_breaker_enabled: "true",
+					circuit_breaker_threshold: "5",
+					circuit_breaker_cooldown: "1m0s",
+				},
+			}),
+		);
+		renderWithProviders(
+			<CircuitBreakerSettings collapsed={false} onToggle={onToggle} />,
+		);
+		await waitFor(() => {
+			expect(screen.getByLabelText("Failure Threshold")).toBeInTheDocument();
+			expect(screen.getByLabelText("Cooldown Period")).toBeInTheDocument();
+		});
+	});
+
+	it("hides threshold and cooldown when circuit breaker is disabled", async () => {
+		server.use(
+			...mockSettings({
+				body: { circuit_breaker_enabled: "false" },
+			}),
+		);
+		renderWithProviders(
+			<CircuitBreakerSettings collapsed={false} onToggle={onToggle} />,
+		);
+		await waitFor(() => {
+			expect(
+				screen.queryByLabelText("Failure Threshold"),
+			).not.toBeInTheDocument();
+			expect(
+				screen.queryByLabelText("Cooldown Period"),
+			).not.toBeInTheDocument();
+		});
+	});
+
+	it("displays threshold default value 5", async () => {
+		server.use(
+			...mockSettings({
+				body: {
+					circuit_breaker_enabled: "true",
+					circuit_breaker_threshold: "5",
+				},
+			}),
+		);
+		renderWithProviders(
+			<CircuitBreakerSettings collapsed={false} onToggle={onToggle} />,
+		);
+		await waitFor(() => {
+			const input = screen.getByLabelText(
+				"Failure Threshold",
+			) as HTMLInputElement;
+			expect(input.value).toBe("5");
+		});
+	});
+
+	it("displays threshold value from settings", async () => {
+		server.use(
+			...mockSettings({
+				body: {
+					circuit_breaker_enabled: "true",
+					circuit_breaker_threshold: "10",
+				},
+			}),
+		);
+		renderWithProviders(
+			<CircuitBreakerSettings collapsed={false} onToggle={onToggle} />,
+		);
+		await waitFor(() => {
+			const input = screen.getByLabelText(
+				"Failure Threshold",
+			) as HTMLInputElement;
+			expect(input.value).toBe("10");
+		});
+	});
+
+	it("displays cooldown default value 1m0s", async () => {
+		server.use(
+			...mockSettings({
+				body: {
+					circuit_breaker_enabled: "true",
+					circuit_breaker_cooldown: "1m0s",
+				},
+			}),
+		);
+		renderWithProviders(
+			<CircuitBreakerSettings collapsed={false} onToggle={onToggle} />,
+		);
+		await waitFor(() => {
+			const select = screen.getByLabelText(
+				"Cooldown Period",
+			) as HTMLSelectElement;
+			expect(select.value).toBe("1m0s");
+		});
+	});
+
+	it("displays cooldown value from settings", async () => {
+		server.use(
+			...mockSettings({
+				body: {
+					circuit_breaker_enabled: "true",
+					circuit_breaker_cooldown: "5m0s",
+				},
+			}),
+		);
+		renderWithProviders(
+			<CircuitBreakerSettings collapsed={false} onToggle={onToggle} />,
+		);
+		await waitFor(() => {
+			const select = screen.getByLabelText(
+				"Cooldown Period",
+			) as HTMLSelectElement;
+			expect(select.value).toBe("5m0s");
+		});
+	});
+
+	it("failover on rate limit toggle is ON when setting is true", async () => {
+		server.use(
+			...mockSettings({
+				body: { failover_on_rate_limit: "true" },
+			}),
+		);
+		renderWithProviders(
+			<CircuitBreakerSettings collapsed={false} onToggle={onToggle} />,
+		);
+		await waitFor(() => {
+			const section = screen
+				.getByText("Failover on Rate Limit")
+				.closest(".flex.items-center.justify-between");
+			const toggle = section?.querySelector("button[role='switch']");
+			expect(toggle).toHaveAttribute("aria-checked", "true");
+		});
+	});
+
+	it("calls mutation when circuit breaker toggle is clicked", async () => {
+		const user = userEvent.setup();
+		let mutationCalled = false;
+
+		server.use(
+			...mockSettings({ body: { circuit_breaker_enabled: "true" } }),
+			http.put("/api/settings", async ({ request }) => {
+				if (!request.headers.get("Authorization")?.startsWith("Bearer ")) {
+					return HttpResponse.json({ error: "Unauthorized" }, { status: 401 });
+				}
+				const body = await request.json();
+				if (
+					typeof body === "object" &&
+					body !== null &&
+					"circuit_breaker_enabled" in body
+				) {
+					mutationCalled = true;
+				}
+				return HttpResponse.json({ ok: true });
+			}),
+		);
+
+		renderWithProviders(
+			<CircuitBreakerSettings collapsed={false} onToggle={onToggle} />,
+		);
+
+		await waitFor(() => {
+			const container = screen
+				.getByText("Enable Circuit Breaker")
+				.closest(".flex.items-center.justify-between");
+			expect(
+				container?.querySelector("button[role='switch']"),
+			).toBeInTheDocument();
+		});
+
+		const container = screen
+			.getByText("Enable Circuit Breaker")
+			.closest(".flex.items-center.justify-between");
+		const toggle = container?.querySelector("button[role='switch']");
+		if (!toggle) throw new Error("Circuit breaker toggle not found");
+		await user.click(toggle);
+
+		await waitFor(() => {
+			expect(mutationCalled).toBe(true);
+		});
+	});
+
+	it("calls mutation when failover on rate limit toggle is clicked", async () => {
+		const user = userEvent.setup();
+		let mutationCalled = false;
+
+		server.use(
+			http.put("/api/settings", async ({ request }) => {
+				if (!request.headers.get("Authorization")?.startsWith("Bearer ")) {
+					return HttpResponse.json({ error: "Unauthorized" }, { status: 401 });
+				}
+				const body = await request.json();
+				if (
+					typeof body === "object" &&
+					body !== null &&
+					"failover_on_rate_limit" in body
+				) {
+					mutationCalled = true;
+				}
+				return HttpResponse.json({ ok: true });
+			}),
+		);
+
+		renderWithProviders(
+			<CircuitBreakerSettings collapsed={false} onToggle={onToggle} />,
+		);
+
+		await waitFor(() => {
+			const container = screen
+				.getByText("Failover on Rate Limit")
+				.closest(".flex.items-center.justify-between");
+			expect(
+				container?.querySelector("button[role='switch']"),
+			).toBeInTheDocument();
+		});
+
+		const container = screen
+			.getByText("Failover on Rate Limit")
+			.closest(".flex.items-center.justify-between");
+		const toggle = container?.querySelector("button[role='switch']");
+		if (!toggle) throw new Error("Failover toggle not found");
+		await user.click(toggle);
+
+		await waitFor(() => {
+			expect(mutationCalled).toBe(true);
+		});
+	});
+
+	it("calls mutation when threshold input changes", async () => {
+		const user = userEvent.setup();
+		let mutationCalled = false;
+
+		server.use(
+			...mockSettings({
+				body: {
+					circuit_breaker_enabled: "true",
+					circuit_breaker_threshold: "5",
+				},
+			}),
+			http.put("/api/settings", async ({ request }) => {
+				if (!request.headers.get("Authorization")?.startsWith("Bearer ")) {
+					return HttpResponse.json({ error: "Unauthorized" }, { status: 401 });
+				}
+				const body = await request.json();
+				if (
+					typeof body === "object" &&
+					body !== null &&
+					"circuit_breaker_threshold" in body
+				) {
+					mutationCalled = true;
+				}
+				return HttpResponse.json({ ok: true });
+			}),
+		);
+
+		renderWithProviders(
+			<CircuitBreakerSettings collapsed={false} onToggle={onToggle} />,
+		);
+
+		await waitFor(() => {
+			const input = screen.getByLabelText("Failure Threshold");
+			expect(input).toBeInTheDocument();
+		});
+
+		const input = screen.getByLabelText(
+			"Failure Threshold",
+		) as HTMLInputElement;
+		await user.clear(input);
+		await user.type(input, "15");
+
+		await waitFor(() => {
+			expect(mutationCalled).toBe(true);
+		});
+	});
+
+	it("calls mutation when cooldown select changes", async () => {
+		const user = userEvent.setup();
+		let mutationCalled = false;
+
+		server.use(
+			...mockSettings({
+				body: {
+					circuit_breaker_enabled: "true",
+					circuit_breaker_cooldown: "1m0s",
+				},
+			}),
+			http.put("/api/settings", async ({ request }) => {
+				if (!request.headers.get("Authorization")?.startsWith("Bearer ")) {
+					return HttpResponse.json({ error: "Unauthorized" }, { status: 401 });
+				}
+				const body = await request.json();
+				if (
+					typeof body === "object" &&
+					body !== null &&
+					"circuit_breaker_cooldown" in body
+				) {
+					mutationCalled = true;
+				}
+				return HttpResponse.json({ ok: true });
+			}),
+		);
+
+		renderWithProviders(
+			<CircuitBreakerSettings collapsed={false} onToggle={onToggle} />,
+		);
+
+		await waitFor(() => {
+			const select = screen.getByLabelText("Cooldown Period");
+			expect(select).toBeInTheDocument();
+		});
+
+		const select = screen.getByLabelText(
+			"Cooldown Period",
+		) as HTMLSelectElement;
+		await user.selectOptions(select, "5m0s");
+
+		await waitFor(() => {
+			expect(mutationCalled).toBe(true);
+		});
+	});
+
+	it("shows success toast on mutation success", async () => {
+		const user = userEvent.setup();
+
+		server.use(
+			...mockSettings({
+				body: {
+					circuit_breaker_enabled: "true",
+					circuit_breaker_cooldown: "1m0s",
+				},
+			}),
+			http.put("/api/settings", async ({ request }) => {
+				if (!request.headers.get("Authorization")?.startsWith("Bearer ")) {
+					return HttpResponse.json({ error: "Unauthorized" }, { status: 401 });
+				}
+				return HttpResponse.json({ ok: true });
+			}),
+		);
+
+		renderWithProviders(
+			<CircuitBreakerSettings collapsed={false} onToggle={onToggle} />,
+		);
+
+		await waitFor(() => {
+			const select = screen.getByLabelText("Cooldown Period");
+			expect(select).toBeInTheDocument();
+		});
+
+		const select = screen.getByLabelText(
+			"Cooldown Period",
+		) as HTMLSelectElement;
+		await user.selectOptions(select, "2m0s");
+
+		await waitFor(() => {
+			expect(screen.getByText("Settings saved")).toBeInTheDocument();
+		});
+	});
+
+	it("shows error toast on mutation failure", async () => {
+		const user = userEvent.setup();
+
+		server.use(
+			...mockSettings({
+				body: {
+					circuit_breaker_enabled: "true",
+					circuit_breaker_cooldown: "1m0s",
+				},
+			}),
+			http.put("/api/settings", () => HttpResponse.error()),
+		);
+
+		renderWithProviders(
+			<CircuitBreakerSettings collapsed={false} onToggle={onToggle} />,
+		);
+
+		await waitFor(() => {
+			const select = screen.getByLabelText("Cooldown Period");
+			expect(select).toBeInTheDocument();
+		});
+
+		const select = screen.getByLabelText(
+			"Cooldown Period",
+		) as HTMLSelectElement;
+		await user.selectOptions(select, "2m0s");
+
+		await waitFor(() => {
+			expect(screen.getByText(/Failed to save:/i)).toBeInTheDocument();
+		});
+	});
+
+	it("calls onToggle when collapsible toggle is clicked", async () => {
+		const user = userEvent.setup();
+
+		renderWithProviders(
+			<CircuitBreakerSettings collapsed={false} onToggle={onToggle} />,
+		);
+
+		const toggleButton = screen.getByRole("button", {
+			name: /collapse|expand/i,
+		});
+		await user.click(toggleButton);
+
+		expect(onToggle).toHaveBeenCalledTimes(1);
+	});
+
+	it("renders all cooldown period options", async () => {
+		server.use(
+			...mockSettings({
+				body: { circuit_breaker_enabled: "true" },
+			}),
+		);
+
+		renderWithProviders(
+			<CircuitBreakerSettings collapsed={false} onToggle={onToggle} />,
+		);
+
+		await waitFor(() => {
+			const select = screen.getByLabelText(
+				"Cooldown Period",
+			) as HTMLSelectElement;
+			expect(select.options).toHaveLength(5);
+			expect(select.options[0].value).toBe("30s");
+			expect(select.options[1].value).toBe("1m0s");
+			expect(select.options[2].value).toBe("2m0s");
+			expect(select.options[3].value).toBe("5m0s");
+			expect(select.options[4].value).toBe("10m0s");
+		});
+	});
+});

--- a/web/src/pages/Settings/__tests__/ColorPickerModal.test.tsx
+++ b/web/src/pages/Settings/__tests__/ColorPickerModal.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from "@testing-library/react";
+import { fireEvent, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { renderWithProviders } from "../../../test/utils";
 import { ColorPickerModal } from "../ColorPickerModal";
@@ -79,5 +79,157 @@ describe("ColorPickerModal", () => {
 		await user.click(applyButton);
 
 		expect(onApply).toHaveBeenCalledTimes(1);
+	});
+
+	it("calls onChange when typing in hex input", () => {
+		const onClose = vi.fn();
+		const onChange = vi.fn();
+		const onApply = vi.fn();
+
+		renderWithProviders(
+			<ColorPickerModal
+				color="#3b82f6"
+				onChange={onChange}
+				onClose={onClose}
+				onApply={onApply}
+			/>,
+		);
+
+		const input = screen.getByRole("textbox") as HTMLInputElement;
+		fireEvent.change(input, { target: { value: "ff0000" } });
+
+		expect(onChange).toHaveBeenCalledWith("#ff0000");
+	});
+
+	it("strips non-hex characters from hex input", async () => {
+		const user = userEvent.setup();
+		const onClose = vi.fn();
+		const onChange = vi.fn();
+		const onApply = vi.fn();
+
+		renderWithProviders(
+			<ColorPickerModal
+				color="#3b82f6"
+				onChange={onChange}
+				onClose={onClose}
+				onApply={onApply}
+			/>,
+		);
+
+		const input = screen.getByRole("textbox") as HTMLInputElement;
+		await user.clear(input);
+		await user.type(input, "gg");
+
+		expect(onChange).toHaveBeenCalledWith("#");
+	});
+
+	it("does not call onChange when stripped value exceeds 6 characters", () => {
+		const onClose = vi.fn();
+		const onChange = vi.fn();
+		const onApply = vi.fn();
+
+		renderWithProviders(
+			<ColorPickerModal
+				color="#3b82f6"
+				onChange={onChange}
+				onClose={onClose}
+				onApply={onApply}
+			/>,
+		);
+
+		const input = screen.getByRole("textbox") as HTMLInputElement;
+
+		// The component's onChange handler strips non-hex and guards on length:
+		// if (val.length <= 6) { onChange(`#${val}`) }
+		// So an 8-char hex value (>6 after stripping) should NOT trigger onChange
+		fireEvent.change(input, { target: { value: "abcdef12" } });
+
+		expect(input.maxLength).toBe(6);
+		expect(onChange).not.toHaveBeenCalled();
+	});
+
+	it("renders color preview swatch with correct background color", () => {
+		const onClose = vi.fn();
+		const onChange = vi.fn();
+		const onApply = vi.fn();
+		const testColor = "#ff5500";
+
+		renderWithProviders(
+			<ColorPickerModal
+				color={testColor}
+				onChange={onChange}
+				onClose={onClose}
+				onApply={onApply}
+			/>,
+		);
+
+		const swatch = screen.getByTestId("color-preview") as HTMLElement;
+		expect(swatch).toHaveStyle(`background-color: ${testColor}`);
+	});
+
+	it("renders # prefix label", () => {
+		const onClose = vi.fn();
+		const onChange = vi.fn();
+		const onApply = vi.fn();
+
+		renderWithProviders(
+			<ColorPickerModal
+				color="#3b82f6"
+				onChange={onChange}
+				onClose={onClose}
+				onApply={onApply}
+			/>,
+		);
+
+		expect(screen.getByText("#")).toBeInTheDocument();
+	});
+
+	it("updates hex input value when color prop changes", () => {
+		const onClose = vi.fn();
+		const onChange = vi.fn();
+		const onApply = vi.fn();
+		const { rerender } = renderWithProviders(
+			<ColorPickerModal
+				color="#3b82f6"
+				onChange={onChange}
+				onClose={onClose}
+				onApply={onApply}
+			/>,
+		);
+
+		const input = screen.getByRole("textbox") as HTMLInputElement;
+		expect(input.value).toBe("3b82f6");
+
+		rerender(
+			<ColorPickerModal
+				color="#ff0000"
+				onChange={onChange}
+				onClose={onClose}
+				onApply={onApply}
+			/>,
+		);
+
+		expect(input.value).toBe("ff0000");
+	});
+
+	it("calls onClose when modal overlay is clicked", async () => {
+		const user = userEvent.setup();
+		const onClose = vi.fn();
+		const onChange = vi.fn();
+		const onApply = vi.fn();
+
+		renderWithProviders(
+			<ColorPickerModal
+				color="#3b82f6"
+				onChange={onChange}
+				onClose={onClose}
+				onApply={onApply}
+			/>,
+		);
+
+		// The Modal renders a backdrop button with aria-label="Close dialog"
+		const backdrop = screen.getByRole("button", { name: "Close dialog" });
+		await user.click(backdrop);
+		expect(onClose).toHaveBeenCalledTimes(1);
 	});
 });

--- a/web/src/pages/Settings/__tests__/DataStorageSettings.test.tsx
+++ b/web/src/pages/Settings/__tests__/DataStorageSettings.test.tsx
@@ -19,6 +19,15 @@ vi.mock("../constants", () => ({
 	clearProviderCache: vi.fn(),
 }));
 
+function getToggleByLabel(label: string) {
+	const heading = screen.getByText(label);
+	const row = heading.closest(".flex.items-center.justify-between");
+	if (!row) throw new Error(`Could not find toggle row for "${label}"`);
+	const toggle = row.querySelector("button[role='switch']");
+	if (!toggle) throw new Error(`Could not find switch in row for "${label}"`);
+	return toggle as HTMLElement;
+}
+
 describe("DataStorageSettings", () => {
 	const onToggle = vi.fn();
 
@@ -115,9 +124,7 @@ describe("Session Persistence toggles", () => {
 			<DataStorageSettings collapsed={false} onToggle={onToggle} />,
 		);
 
-		// Find the Persist Chat toggle (it's the first toggle in the section)
-		const toggles = screen.getAllByRole("switch");
-		const persistChatToggle = toggles[0];
+		const persistChatToggle = getToggleByLabel("Persist Chat");
 
 		await user.click(persistChatToggle);
 
@@ -138,8 +145,7 @@ describe("Session Persistence toggles", () => {
 			<DataStorageSettings collapsed={false} onToggle={onToggle} />,
 		);
 
-		const toggles = screen.getAllByRole("switch");
-		const persistArenaToggle = toggles[1];
+		const persistArenaToggle = getToggleByLabel("Persist Arena");
 
 		await user.click(persistArenaToggle);
 
@@ -160,8 +166,9 @@ describe("Session Persistence toggles", () => {
 			<DataStorageSettings collapsed={false} onToggle={onToggle} />,
 		);
 
-		const toggles = screen.getAllByRole("switch");
-		const persistConversationToggle = toggles[2];
+		const persistConversationToggle = getToggleByLabel(
+			"Persist AI Conversation",
+		);
 
 		await user.click(persistConversationToggle);
 
@@ -172,7 +179,7 @@ describe("Session Persistence toggles", () => {
 		confirmSpy.mockRestore();
 	});
 
-	it("does not apply toggle change when confirm is cancelled", async () => {
+	it("does not apply toggle change when Persist Chat confirm is cancelled", async () => {
 		localStorage.setItem("persistChat", "true");
 
 		const user = userEvent.setup();
@@ -182,13 +189,57 @@ describe("Session Persistence toggles", () => {
 			<DataStorageSettings collapsed={false} onToggle={onToggle} />,
 		);
 
-		const toggles = screen.getAllByRole("switch");
-		const persistChatToggle = toggles[0];
+		const persistChatToggle = getToggleByLabel("Persist Chat");
+		expect(persistChatToggle).toHaveAttribute("aria-checked", "true");
 
 		await user.click(persistChatToggle);
 
 		expect(confirmSpy).toHaveBeenCalled();
-		// Toggle state should not have changed since confirm was cancelled
+		expect(persistChatToggle).toHaveAttribute("aria-checked", "true");
+
+		confirmSpy.mockRestore();
+	});
+
+	it("does not apply toggle change when Persist Arena confirm is cancelled", async () => {
+		localStorage.setItem("persistArena", "true");
+
+		const user = userEvent.setup();
+		const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+
+		renderWithProviders(
+			<DataStorageSettings collapsed={false} onToggle={onToggle} />,
+		);
+
+		const persistArenaToggle = getToggleByLabel("Persist Arena");
+		expect(persistArenaToggle).toHaveAttribute("aria-checked", "true");
+
+		await user.click(persistArenaToggle);
+
+		expect(confirmSpy).toHaveBeenCalled();
+		expect(persistArenaToggle).toHaveAttribute("aria-checked", "true");
+
+		confirmSpy.mockRestore();
+	});
+
+	it("does not apply toggle change when Persist Conversation confirm is cancelled", async () => {
+		localStorage.setItem("persistConversation", "true");
+
+		const user = userEvent.setup();
+		const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+
+		renderWithProviders(
+			<DataStorageSettings collapsed={false} onToggle={onToggle} />,
+		);
+
+		const persistConversationToggle = getToggleByLabel(
+			"Persist AI Conversation",
+		);
+		expect(persistConversationToggle).toHaveAttribute("aria-checked", "true");
+
+		await user.click(persistConversationToggle);
+
+		expect(confirmSpy).toHaveBeenCalled();
+		expect(persistConversationToggle).toHaveAttribute("aria-checked", "true");
 
 		confirmSpy.mockRestore();
 	});
@@ -260,6 +311,71 @@ describe("Arena History section", () => {
 		expect(select).toBeDisabled();
 	});
 
+	it("enables history limit select when arena history is enabled", () => {
+		localStorage.setItem("arenaHistoryEnabled", "true");
+
+		renderWithProviders(
+			<DataStorageSettings collapsed={false} onToggle={onToggle} />,
+		);
+
+		const select = screen.getByRole("combobox", {
+			name: "Maximum Saved Matches",
+		}) as HTMLSelectElement;
+		expect(select).not.toBeDisabled();
+	});
+
+	it("calls setArenaHistoryLimit and shows toast when history limit changes", async () => {
+		const user = userEvent.setup();
+		localStorage.setItem("arenaHistoryEnabled", "true");
+
+		renderWithProviders(
+			<DataStorageSettings collapsed={false} onToggle={onToggle} />,
+		);
+
+		const select = screen.getByRole("combobox", {
+			name: "Maximum Saved Matches",
+		}) as HTMLSelectElement;
+
+		await user.selectOptions(select, "50");
+
+		expect(localStorage.getItem("arenaHistoryLimit")).toBe("50");
+		expect(
+			screen.getByText("History limit set to 50 matches"),
+		).toBeInTheDocument();
+	});
+
+	it("shows Arena history enabled toast when toggling on", async () => {
+		const user = userEvent.setup();
+		localStorage.removeItem("arenaHistoryEnabled");
+
+		renderWithProviders(
+			<DataStorageSettings collapsed={false} onToggle={onToggle} />,
+		);
+
+		const arenaHistoryToggle = getToggleByLabel("Save Match History");
+
+		await user.click(arenaHistoryToggle);
+
+		expect(screen.getByText("Arena history enabled")).toBeInTheDocument();
+	});
+
+	it("shows Arena history disabled toast when toggling off", async () => {
+		const user = userEvent.setup();
+		localStorage.setItem("arenaHistoryEnabled", "true");
+
+		renderWithProviders(
+			<DataStorageSettings collapsed={false} onToggle={onToggle} />,
+		);
+
+		const arenaHistoryToggle = getToggleByLabel("Save Match History");
+
+		await user.click(arenaHistoryToggle);
+
+		expect(
+			screen.getByText("Arena history disabled - existing entries preserved"),
+		).toBeInTheDocument();
+	});
+
 	it("renders description about oldest matches", () => {
 		renderWithProviders(
 			<DataStorageSettings collapsed={false} onToggle={onToggle} />,
@@ -281,6 +397,16 @@ describe("Arena History section", () => {
 
 		expect(screen.getByText("Clear History")).toBeInTheDocument();
 		expect(screen.getByText("5 entries stored")).toBeInTheDocument();
+	});
+
+	it("shows singular 'entry' text when arena history count is 1", () => {
+		vi.mocked(getArenaHistoryCount).mockReturnValue(1);
+
+		renderWithProviders(
+			<DataStorageSettings collapsed={false} onToggle={onToggle} />,
+		);
+
+		expect(screen.getByText("1 entry stored")).toBeInTheDocument();
 	});
 
 	it("disables Clear History button when count is 0", () => {
@@ -395,6 +521,18 @@ describe("Cache & Resets section", () => {
 		).toBeInTheDocument();
 	});
 
+	it("shows singular 'cached entry' text when provider cache count is 1", () => {
+		vi.mocked(getProviderCacheCount).mockReturnValue(1);
+
+		renderWithProviders(
+			<DataStorageSettings collapsed={false} onToggle={onToggle} />,
+		);
+
+		expect(
+			screen.getByText("1 cached entry (NanoGPT, Z.ai Coding Plan, DeepSeek)"),
+		).toBeInTheDocument();
+	});
+
 	it("renders Clear Cache button", () => {
 		vi.mocked(getProviderCacheCount).mockReturnValue(1);
 
@@ -448,6 +586,24 @@ describe("Cache & Resets section", () => {
 		await user.click(clearButton);
 
 		expect(clearProviderCache).toHaveBeenCalled();
+	});
+
+	it("does not call clearProviderCache when confirm is cancelled", async () => {
+		const user = userEvent.setup();
+		vi.mocked(getProviderCacheCount).mockReturnValue(2);
+		const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+
+		renderWithProviders(
+			<DataStorageSettings collapsed={false} onToggle={onToggle} />,
+		);
+
+		const clearButton = screen.getByRole("button", { name: "Clear Cache" });
+		await user.click(clearButton);
+
+		expect(confirmSpy).toHaveBeenCalled();
+		expect(clearProviderCache).not.toHaveBeenCalled();
+
+		confirmSpy.mockRestore();
 	});
 
 	it("renders Dismissed Error Banners section", () => {

--- a/web/src/pages/Settings/__tests__/DatabaseBackupSettings.test.tsx
+++ b/web/src/pages/Settings/__tests__/DatabaseBackupSettings.test.tsx
@@ -436,4 +436,111 @@ describe("DatabaseBackupSettings", () => {
 			expect(confirmButton).toBeDisabled();
 		});
 	});
+
+	it("shows 0 B for zero-size backup", async () => {
+		server.use(
+			http.get("/api/backups", () =>
+				HttpResponse.json([
+					{
+						filename: "empty.dump",
+						size_bytes: 0,
+						created_at: "2026-01-01T00:00:00Z",
+					},
+				]),
+			),
+		);
+		renderWithProviders(
+			<DatabaseBackupSettings collapsed={false} onToggle={onToggle} />,
+		);
+		await waitFor(() => {
+			expect(screen.getByText(/0 B -/)).toBeInTheDocument();
+		});
+	});
+
+	it("shows raw string for invalid date", async () => {
+		server.use(
+			http.get("/api/backups", () =>
+				HttpResponse.json([
+					{
+						filename: "bad-date.dump",
+						size_bytes: 1024,
+						created_at: "not-a-date",
+					},
+				]),
+			),
+		);
+		renderWithProviders(
+			<DatabaseBackupSettings collapsed={false} onToggle={onToggle} />,
+		);
+		await waitFor(() => {
+			expect(screen.getByText(/Invalid Date/)).toBeInTheDocument();
+		});
+	});
+
+	it("shows error toast when download fails", async () => {
+		server.use(
+			http.get("/api/backups/:filename", () =>
+				HttpResponse.json({ error: "not found" }, { status: 404 }),
+			),
+		);
+		const user = userEvent.setup();
+		renderWithProviders(
+			<DatabaseBackupSettings collapsed={false} onToggle={onToggle} />,
+		);
+		const downloadButtons = await screen.findAllByRole("button", {
+			name: /download/i,
+		});
+		await user.click(downloadButtons[0]);
+		await waitFor(() => {
+			expect(screen.getByText(/download failed:/i)).toBeInTheDocument();
+		});
+	});
+
+	it("shows restore modal when file is selected", async () => {
+		const user = userEvent.setup();
+		renderWithProviders(
+			<DatabaseBackupSettings collapsed={false} onToggle={onToggle} />,
+		);
+		const fileInput = screen.getByLabelText("Select backup file to restore");
+		const file = new File(["test"], "backup.dump", {
+			type: "application/octet-stream",
+		});
+		await user.upload(fileInput, file);
+		await waitFor(() => {
+			expect(screen.getByText("Restore Database Backup")).toBeInTheDocument();
+		});
+	});
+
+	it("shows Upload & Restore button text when not restoring", async () => {
+		renderWithProviders(
+			<DatabaseBackupSettings collapsed={false} onToggle={onToggle} />,
+		);
+		await waitFor(() => {
+			expect(
+				screen.getByRole("button", { name: /upload & restore/i }),
+			).toBeInTheDocument();
+		});
+	});
+
+	it("can close restore modal", async () => {
+		const user = userEvent.setup();
+		renderWithProviders(
+			<DatabaseBackupSettings collapsed={false} onToggle={onToggle} />,
+		);
+		const fileInput = screen.getByLabelText("Select backup file to restore");
+		const file = new File(["test"], "backup.dump", {
+			type: "application/octet-stream",
+		});
+		await user.upload(fileInput, file);
+		await waitFor(() => {
+			expect(screen.getByText("Restore Database Backup")).toBeInTheDocument();
+		});
+		const cancelButton = screen.getByRole("button", { name: /cancel/i });
+		await user.click(cancelButton);
+		await waitFor(() => {
+			expect(
+				screen.queryByText("Restore Database Backup"),
+			).not.toBeInTheDocument();
+		});
+	});
 });

--- a/web/src/pages/Settings/__tests__/ToastSettings.test.tsx
+++ b/web/src/pages/Settings/__tests__/ToastSettings.test.tsx
@@ -1,76 +1,18 @@
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import type { ReactElement } from "react";
-import { MemoryRouter } from "react-router-dom";
+import type { ReactElement, ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { EventProvider } from "../../../context/EventContext";
-import { QuotaModalProvider } from "../../../context/QuotaModalContext";
-import { SidebarModeProvider } from "../../../context/SidebarModeContext";
-import { StorageProvider } from "../../../context/StorageContext";
-import { ThemeProvider } from "../../../context/ThemeContext";
 import type { ToastPosition } from "../../../context/ToastContext";
 import { ToastContext } from "../../../context/ToastContext";
 import { renderWithProviders } from "../../../test/utils";
 import { ToastSettings } from "../ToastSettings";
-
-function createTestQueryClient() {
-	return new QueryClient({
-		defaultOptions: {
-			queries: { retry: false },
-			mutations: { retry: false },
-		},
-	});
-}
 
 interface MockToastOptions {
 	position?: ToastPosition;
 	timeout?: number;
 }
 
-function renderWithMockToast(ui: ReactElement, options?: MockToastOptions) {
-	const mockToast = vi.fn();
-	const mockSetPosition = vi.fn();
-	const mockSetTimeout = vi.fn();
-	const queryClient = createTestQueryClient();
-
-	function Wrapper({ children }: { children: React.ReactNode }) {
-		return (
-			<MemoryRouter>
-				<ThemeProvider>
-					<StorageProvider>
-						<SidebarModeProvider>
-							<EventProvider>
-								<QuotaModalProvider>
-									<QueryClientProvider client={queryClient}>
-										<MockToastContext
-											toast={mockToast}
-											setPosition={mockSetPosition}
-											setTimeout={mockSetTimeout}
-											position={options?.position ?? "bottom-center"}
-											timeout={options?.timeout ?? 4000}
-										>
-											{children}
-										</MockToastContext>
-									</QueryClientProvider>
-								</QuotaModalProvider>
-							</EventProvider>
-						</SidebarModeProvider>
-					</StorageProvider>
-				</ThemeProvider>
-			</MemoryRouter>
-		);
-	}
-
-	return {
-		...render(ui, { wrapper: Wrapper }),
-		mockToast,
-		mockSetPosition,
-		mockSetTimeout,
-	};
-}
-
-function MockToastContext({
+function MockToastWrapper({
 	children,
 	toast,
 	setPosition,
@@ -78,7 +20,7 @@ function MockToastContext({
 	position,
 	timeout,
 }: {
-	children: React.ReactNode;
+	children: ReactNode;
 	toast: (
 		message: string,
 		type?: "success" | "error" | "info" | "warning",
@@ -114,6 +56,33 @@ function MockToastContext({
 			</div>
 		</ToastContext.Provider>
 	);
+}
+
+function renderWithMockToast(ui: ReactElement, options?: MockToastOptions) {
+	const mockToast = vi.fn();
+	const mockSetPosition = vi.fn();
+	const mockSetTimeout = vi.fn();
+	const position = options?.position ?? "bottom-center";
+	const timeout = options?.timeout ?? 4000;
+
+	const toastWrapper = ({ children }: { children: ReactNode }) => (
+		<MockToastWrapper
+			toast={mockToast}
+			setPosition={mockSetPosition}
+			setTimeout={mockSetTimeout}
+			position={position}
+			timeout={timeout}
+		>
+			{children}
+		</MockToastWrapper>
+	);
+
+	return {
+		...renderWithProviders(ui, { toastWrapper }),
+		mockToast,
+		mockSetPosition,
+		mockSetTimeout,
+	};
 }
 
 describe("ToastSettings", () => {

--- a/web/src/pages/Settings/__tests__/ToastSettings.test.tsx
+++ b/web/src/pages/Settings/__tests__/ToastSettings.test.tsx
@@ -1,8 +1,120 @@
-import { screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import type { ReactElement } from "react";
+import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { EventProvider } from "../../../context/EventContext";
+import { QuotaModalProvider } from "../../../context/QuotaModalContext";
+import { SidebarModeProvider } from "../../../context/SidebarModeContext";
+import { StorageProvider } from "../../../context/StorageContext";
+import { ThemeProvider } from "../../../context/ThemeContext";
+import type { ToastPosition } from "../../../context/ToastContext";
+import { ToastContext } from "../../../context/ToastContext";
 import { renderWithProviders } from "../../../test/utils";
 import { ToastSettings } from "../ToastSettings";
+
+function createTestQueryClient() {
+	return new QueryClient({
+		defaultOptions: {
+			queries: { retry: false },
+			mutations: { retry: false },
+		},
+	});
+}
+
+interface MockToastOptions {
+	position?: ToastPosition;
+	timeout?: number;
+}
+
+function renderWithMockToast(ui: ReactElement, options?: MockToastOptions) {
+	const mockToast = vi.fn();
+	const mockSetPosition = vi.fn();
+	const mockSetTimeout = vi.fn();
+	const queryClient = createTestQueryClient();
+
+	function Wrapper({ children }: { children: React.ReactNode }) {
+		return (
+			<MemoryRouter>
+				<ThemeProvider>
+					<StorageProvider>
+						<SidebarModeProvider>
+							<EventProvider>
+								<QuotaModalProvider>
+									<QueryClientProvider client={queryClient}>
+										<MockToastContext
+											toast={mockToast}
+											setPosition={mockSetPosition}
+											setTimeout={mockSetTimeout}
+											position={options?.position ?? "bottom-center"}
+											timeout={options?.timeout ?? 4000}
+										>
+											{children}
+										</MockToastContext>
+									</QueryClientProvider>
+								</QuotaModalProvider>
+							</EventProvider>
+						</SidebarModeProvider>
+					</StorageProvider>
+				</ThemeProvider>
+			</MemoryRouter>
+		);
+	}
+
+	return {
+		...render(ui, { wrapper: Wrapper }),
+		mockToast,
+		mockSetPosition,
+		mockSetTimeout,
+	};
+}
+
+function MockToastContext({
+	children,
+	toast,
+	setPosition,
+	setTimeout,
+	position,
+	timeout,
+}: {
+	children: React.ReactNode;
+	toast: (
+		message: string,
+		type?: "success" | "error" | "info" | "warning",
+	) => void;
+	setPosition: (position: ToastPosition) => void;
+	setTimeout: (timeout: number) => void;
+	position: ToastPosition;
+	timeout: number;
+}) {
+	return (
+		<ToastContext.Provider
+			value={{
+				toast,
+				setPosition,
+				setTimeout,
+				position,
+				timeout,
+			}}
+		>
+			{children}
+			<div
+				className={`fixed z-50 flex flex-col gap-2 ${
+					position.includes("top") ? "top-4" : "bottom-4"
+				} ${
+					position.includes("left")
+						? "left-4 items-start"
+						: position.includes("right")
+							? "right-4 items-end"
+							: "left-1/2 -translate-x-1/2 items-center"
+				}`}
+			>
+				{[]}
+			</div>
+		</ToastContext.Provider>
+	);
+}
 
 describe("ToastSettings", () => {
 	const onToggle = vi.fn();
@@ -189,5 +301,88 @@ describe("ToastSettings", () => {
 		// Active position has opacity-100, inactive has opacity-30
 		const positionButtons = screen.getAllByTitle(/top|bottom/i);
 		expect(positionButtons.length).toBe(6);
+	});
+
+	it("displays default position label as 'bottom center' on mount", () => {
+		renderWithMockToast(
+			<ToastSettings collapsed={false} onToggle={onToggle} />,
+			{ position: "bottom-center" },
+		);
+		// Position label shows position with hyphens replaced by spaces
+		expect(screen.getByText("bottom center")).toBeInTheDocument();
+	});
+
+	it("updates position label to 'bottom left' when bottom-left button clicked", async () => {
+		const user = userEvent.setup();
+		renderWithProviders(
+			<ToastSettings collapsed={false} onToggle={onToggle} />,
+		);
+		const bottomLeftButton = screen.getByTitle("Bottom Left");
+		await user.click(bottomLeftButton);
+		await waitFor(() => {
+			expect(screen.getByText("bottom left")).toBeInTheDocument();
+		});
+	});
+
+	it("updates position label to 'bottom right' when bottom-right button clicked", async () => {
+		const user = userEvent.setup();
+		renderWithProviders(
+			<ToastSettings collapsed={false} onToggle={onToggle} />,
+		);
+		const bottomRightButton = screen.getByTitle("Bottom Right");
+		await user.click(bottomRightButton);
+		await waitFor(() => {
+			expect(screen.getByText("bottom right")).toBeInTheDocument();
+		});
+	});
+
+	it("updates position label to 'top center' when top-center button clicked", async () => {
+		const user = userEvent.setup();
+		renderWithProviders(
+			<ToastSettings collapsed={false} onToggle={onToggle} />,
+		);
+		const topCenterButton = screen.getByTitle("Top Center");
+		await user.click(topCenterButton);
+		await waitFor(() => {
+			expect(screen.getByText("top center")).toBeInTheDocument();
+		});
+	});
+
+	it("calls toast with correct message and type when position button clicked", async () => {
+		const user = userEvent.setup();
+		const { mockToast, mockSetPosition } = renderWithMockToast(
+			<ToastSettings collapsed={false} onToggle={onToggle} />,
+		);
+		const topLeftButton = screen.getByTitle("Top Left");
+		await user.click(topLeftButton);
+		expect(mockToast).toHaveBeenCalledWith(
+			"Test notification - you'll see toasts here",
+			"info",
+		);
+		expect(mockSetPosition).toHaveBeenCalledWith("top-left");
+	});
+
+	it("calls setPosition when clicking already-active position button", async () => {
+		const user = userEvent.setup();
+		const { mockSetPosition } = renderWithMockToast(
+			<ToastSettings collapsed={false} onToggle={onToggle} />,
+			{ position: "top-left" },
+		);
+		const topLeftButton = screen.getByTitle("Top Left");
+		// Button is already active (top-left is current position)
+		expect(topLeftButton).toHaveClass("opacity-100");
+		await user.click(topLeftButton);
+		// setPosition should still be called (no guard against re-clicking)
+		expect(mockSetPosition).toHaveBeenCalledWith("top-left");
+	});
+
+	it("calls setTimeout when slider value changes via fireEvent.change", () => {
+		const { mockSetTimeout } = renderWithMockToast(
+			<ToastSettings collapsed={false} onToggle={onToggle} />,
+		);
+		const slider = screen.getByRole("slider") as HTMLInputElement;
+		// Simulate changing the slider value directly
+		fireEvent.change(slider, { target: { value: "5000" } });
+		expect(mockSetTimeout).toHaveBeenCalledWith(5000);
 	});
 });

--- a/web/src/test/utils.tsx
+++ b/web/src/test/utils.tsx
@@ -28,16 +28,23 @@ function createTestQueryClient() {
 interface AllProvidersProps {
 	children: ReactNode;
 	initialEntries?: MemoryRouterProps["initialEntries"];
+	/** Optional wrapper to replace the default ToastProvider (e.g. for mocking). */
+	toastWrapper?: ({ children }: { children: ReactNode }) => ReactElement;
 }
 
-export function AllProviders({ children, initialEntries }: AllProvidersProps) {
+export function AllProviders({
+	children,
+	initialEntries,
+	toastWrapper,
+}: AllProvidersProps) {
 	const queryClient = createTestQueryClient();
+	const ToastSlot = toastWrapper ?? ToastProvider;
 	return (
 		<MemoryRouter initialEntries={initialEntries}>
 			<ThemeProvider>
 				<StorageProvider>
 					<SidebarModeProvider>
-						<ToastProvider>
+						<ToastSlot>
 							<EventProvider>
 								<QuotaModalProvider>
 									<QueryClientProvider client={queryClient}>
@@ -45,7 +52,7 @@ export function AllProviders({ children, initialEntries }: AllProvidersProps) {
 									</QueryClientProvider>
 								</QuotaModalProvider>
 							</EventProvider>
-						</ToastProvider>
+						</ToastSlot>
 					</SidebarModeProvider>
 				</StorageProvider>
 			</ThemeProvider>
@@ -57,14 +64,18 @@ export function renderWithProviders(
 	ui: ReactElement,
 	options?: Omit<RenderOptions, "wrapper"> & {
 		initialEntries?: MemoryRouterProps["initialEntries"];
+		toastWrapper?: AllProvidersProps["toastWrapper"];
 	},
 ) {
 	const user = userEvent.setup();
-	const { initialEntries, ...renderOptions } = options || {};
+	const { initialEntries, toastWrapper, ...renderOptions } = options || {};
 	return {
 		...render(ui, {
 			wrapper: (props) => (
-				<AllProviders initialEntries={initialEntries}>
+				<AllProviders
+					initialEntries={initialEntries}
+					toastWrapper={toastWrapper}
+				>
 					{props.children}
 				</AllProviders>
 			),


### PR DESCRIPTION
## Summary

Improve frontend test coverage from 81.7% to 83.3% (93 new tests, +2262 lines).

### New test files
- **CircuitBreakerSettings.test.tsx** — 21 tests (toggle interactions, mutation feedback, cooldown options, collapsible section)

### Expanded test files
| File | Before | After | Added |
|------|--------|-------|-------|
| DatabaseBackupSettings.test.tsx | 22 | 29 | +7 (formatBytes, download error, restore modal) |
| FailoverGroupCard.test.tsx | 27 | 31 | +4 (keyboard copy, state reset, drag guard) |
| ToastSettings.test.tsx | 17 | 24 | +7 (position labels, toast calls, slider) |
| ColorPickerModal.test.tsx | 4 | 11 | +7 (hex input, preview swatch, backdrop close) |
| DataStorageSettings.test.tsx | 33 | 41 | +8 (confirm-cancel, toggles, limits) |
| ProviderQuotaPanel.test.tsx | 2 | 21 | +19 (rendering, collapse, refresh, events) |
| AddProviderModal.test.tsx | 41 | 69 | +28 (name gen, provider types, discovery, quotas) |

### Production changes (minimal)
- `ToastContext.tsx`: export context + eslint-disable for test mocking
- `ColorPickerModal.tsx`: added `data-testid="color-preview"` on swatch

### Test quality fixes from review
- Weak assertions in confirm-cancel tests now verify toggle state before/after click
- Silent-pass `if (element)` guards replaced with proper selectors or throw-on-missing
- Fragile toggle indexing replaced with `getToggleByLabel()` helper
- Inaccurate comment about maxLength behavior corrected