### PR TITLE
Improve frontend coverage - batch 4

### DIFF
--- a/web/src/api/__tests__/client.test.ts
+++ b/web/src/api/__tests__/client.test.ts
@@ -38,10 +38,11 @@ describe("buildQueryString", () => {
 	});
 
 	it("filters out null values", () => {
-		// biome-ignore lint/suspicious/noExplicitAny: intentionally passing null to test runtime filtering
-		expect(buildQueryString({ name: "test", skip: null } as any)).toBe(
-			"name=test",
-		);
+		expect(
+			buildQueryString({ name: "test", skip: null } as unknown as Parameters<
+				typeof buildQueryString
+			>[0]),
+		).toBe("name=test");
 	});
 
 	it("handles mixed types", () => {

--- a/web/src/api/__tests__/client.test.ts
+++ b/web/src/api/__tests__/client.test.ts
@@ -38,7 +38,7 @@ describe("buildQueryString", () => {
 	});
 
 	it("filters out null values", () => {
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		// biome-ignore lint/suspicious/noExplicitAny: intentionally passing null to test runtime filtering
 		expect(buildQueryString({ name: "test", skip: null } as any)).toBe(
 			"name=test",
 		);
@@ -724,9 +724,15 @@ describe("api.system", () => {
 
 		const result = await api.system.get();
 
+		// Compute expected midnight using the same local-timezone logic
+		// as the implementation (new Date(year, month, date))
+		const now = new Date();
+		const midnight = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+		const expectedSince = encodeURIComponent(midnight.toISOString());
+
 		expect(result).toEqual(mockStats);
 		expect(globalThis.fetch).toHaveBeenCalledWith(
-			"/api/system?since=2024-01-15T00%3A00%3A00.000Z",
+			`/api/system?since=${expectedSince}`,
 			expect.objectContaining({
 				headers: expect.objectContaining({
 					Authorization: "Bearer test-token",
@@ -1344,6 +1350,32 @@ describe("api.backups", () => {
 					},
 				}),
 			);
+		});
+
+		it("uses localStorage token for Authorization, not the parameter", async () => {
+			const mockFile = new File(["content"], "test.sql");
+			const localStorageToken = "local-storage-token";
+			const paramToken = "param-token";
+			localStorage.setItem("adminToken", localStorageToken);
+
+			const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(
+				async () =>
+					new Response(JSON.stringify({ migration_count: 1, known_count: 1 }), {
+						status: 200,
+					}),
+			);
+
+			await api.backups.restore(mockFile, paramToken);
+
+			// Authorization header uses localStorage, not the parameter
+			const options = fetchSpy.mock.calls[0][1] as RequestInit;
+			expect(options.headers).toEqual({
+				Authorization: `Bearer ${localStorageToken}`,
+			});
+
+			// FormData admin_token uses the parameter
+			const formData = options.body as FormData;
+			expect(formData.get("admin_token")).toBe(paramToken);
 		});
 
 		it("does not set Content-Type header", async () => {

--- a/web/src/api/__tests__/client.test.ts
+++ b/web/src/api/__tests__/client.test.ts
@@ -1,5 +1,6 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+	api,
 	buildQueryString,
 	buildUrl,
 	getAdminToken,
@@ -208,5 +209,2149 @@ describe("Integration: setAdminToken + getAuthHeaders", () => {
 		setAdminToken(complexToken);
 		const headers = getAuthHeaders();
 		expect(headers.Authorization).toBe(`Bearer ${complexToken}`);
+	});
+});
+
+describe("api.stats", () => {
+	beforeEach(() => {
+		setAdminToken("test-token");
+		vi.restoreAllMocks();
+	});
+
+	describe("get", () => {
+		it("fetches stats without options", async () => {
+			const mockStats = { total_requests: 100, total_tokens: 5000 };
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify(mockStats), { status: 200 }),
+			);
+
+			const result = await api.stats.get();
+
+			expect(result).toEqual(mockStats);
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/stats",
+				expect.objectContaining({
+					headers: expect.objectContaining({
+						Authorization: "Bearer test-token",
+					}),
+				}),
+			);
+		});
+
+		it("fetches stats with options", async () => {
+			const mockStats = { total_requests: 200 };
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify(mockStats), { status: 200 }),
+			);
+
+			await api.stats.get({
+				period: "7d",
+				excludeDeleted: true,
+				metric: "tokens",
+			});
+
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/stats?period=7d&exclude_deleted=true&metric=tokens",
+				expect.anything(),
+			);
+		});
+
+		it("throws on error response", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response("not found", { status: 404 }),
+			);
+
+			await expect(api.stats.get()).rejects.toThrow(
+				"Failed to fetch stats: 404 not found",
+			);
+		});
+	});
+
+	describe("getTimeSeries", () => {
+		it("fetches time series stats", async () => {
+			const mockData = { data: [{ timestamp: "2024-01-01", value: 100 }] };
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify(mockData), { status: 200 }),
+			);
+
+			const result = await api.stats.getTimeSeries();
+
+			expect(result).toEqual(mockData);
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/stats/timeseries",
+				expect.objectContaining({
+					headers: expect.objectContaining({
+						Authorization: "Bearer test-token",
+					}),
+				}),
+			);
+		});
+
+		it("fetches time series with period option", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify({ data: [] }), { status: 200 }),
+			);
+
+			await api.stats.getTimeSeries({ period: "30d" });
+
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/stats/timeseries?period=30d",
+				expect.anything(),
+			);
+		});
+
+		it("throws on error response", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response("server error", { status: 500 }),
+			);
+
+			await expect(api.stats.getTimeSeries()).rejects.toThrow(
+				"Failed to fetch time-series stats: 500 server error",
+			);
+		});
+	});
+
+	describe("getProviderDistribution", () => {
+		it("fetches provider distribution stats", async () => {
+			const mockData = { distribution: [{ provider: "openai", count: 50 }] };
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify(mockData), { status: 200 }),
+			);
+
+			const result = await api.stats.getProviderDistribution();
+
+			expect(result).toEqual(mockData);
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/stats/provider-distribution",
+				expect.objectContaining({
+					headers: expect.objectContaining({
+						Authorization: "Bearer test-token",
+					}),
+				}),
+			);
+		});
+
+		it("fetches with options", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify({ distribution: [] }), { status: 200 }),
+			);
+
+			await api.stats.getProviderDistribution({
+				period: "7d",
+				metric: "requests",
+				excludeDeleted: true,
+			});
+
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/stats/provider-distribution?period=7d&metric=requests&exclude_deleted=true",
+				expect.anything(),
+			);
+		});
+
+		it("throws on error response", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response("bad request", { status: 400 }),
+			);
+
+			await expect(api.stats.getProviderDistribution()).rejects.toThrow(
+				"Failed to fetch provider distribution: 400 bad request",
+			);
+		});
+	});
+});
+
+describe("api.settings", () => {
+	beforeEach(() => {
+		setAdminToken("test-token");
+		vi.restoreAllMocks();
+	});
+
+	describe("get", () => {
+		it("fetches settings", async () => {
+			const mockSettings = { theme: "dark", language: "en" };
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify(mockSettings), { status: 200 }),
+			);
+
+			const result = await api.settings.get();
+
+			expect(result).toEqual(mockSettings);
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/settings",
+				expect.objectContaining({
+					headers: expect.objectContaining({
+						Authorization: "Bearer test-token",
+					}),
+				}),
+			);
+		});
+
+		it("throws on error response", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response("not found", { status: 404 }),
+			);
+
+			await expect(api.settings.get()).rejects.toThrow(
+				"Failed to fetch settings: 404 not found",
+			);
+		});
+	});
+
+	describe("update", () => {
+		it("updates settings", async () => {
+			const newSettings = { theme: "light", language: "fr" };
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify(newSettings), { status: 200 }),
+			);
+
+			const result = await api.settings.update(newSettings);
+
+			expect(result).toEqual(newSettings);
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/settings",
+				expect.objectContaining({
+					method: "PUT",
+					headers: expect.objectContaining({
+						Authorization: "Bearer test-token",
+						"Content-Type": "application/json",
+					}),
+					body: JSON.stringify(newSettings),
+				}),
+			);
+		});
+
+		it("throws on error response", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response("validation failed", { status: 400 }),
+			);
+
+			await expect(api.settings.update({})).rejects.toThrow(
+				"Failed to update settings: 400 validation failed",
+			);
+		});
+	});
+});
+
+describe("api.version", () => {
+	beforeEach(() => {
+		setAdminToken("test-token");
+		vi.restoreAllMocks();
+	});
+
+	describe("getLatest", () => {
+		it("fetches latest version", async () => {
+			const mockVersion = { tag_name: "v1.2.3" };
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify(mockVersion), { status: 200 }),
+			);
+
+			const result = await api.version.getLatest();
+
+			expect(result).toEqual(mockVersion);
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/version/latest",
+				expect.objectContaining({
+					headers: expect.objectContaining({
+						Authorization: "Bearer test-token",
+					}),
+				}),
+			);
+		});
+
+		it("passes custom options to fetch", async () => {
+			const mockVersion = { tag_name: "v1.2.4" };
+			const customOptions: RequestInit = {
+				cache: "no-cache",
+				signal: AbortSignal.timeout(5000),
+			};
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify(mockVersion), { status: 200 }),
+			);
+
+			await api.version.getLatest(customOptions);
+
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/version/latest",
+				expect.objectContaining({
+					headers: expect.objectContaining({
+						Authorization: "Bearer test-token",
+					}),
+					cache: "no-cache",
+					signal: expect.any(AbortSignal),
+				}),
+			);
+		});
+
+		it("throws on error response", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response("not found", { status: 404 }),
+			);
+
+			await expect(api.version.getLatest()).rejects.toThrow(
+				"Failed to fetch latest version: 404 not found",
+			);
+		});
+	});
+});
+
+describe("api.virtualKeys", () => {
+	beforeEach(() => {
+		setAdminToken("test-token");
+		vi.restoreAllMocks();
+	});
+
+	describe("list", () => {
+		it("fetches virtual keys list", async () => {
+			const mockKeys = [
+				{ id: "1", name: "key1", key: "vk_abc123" },
+				{ id: "2", name: "key2", key: "vk_def456" },
+			];
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify(mockKeys), { status: 200 }),
+			);
+
+			const result = await api.virtualKeys.list();
+
+			expect(result).toEqual(mockKeys);
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/virtual-keys",
+				expect.objectContaining({
+					headers: expect.objectContaining({
+						Authorization: "Bearer test-token",
+					}),
+				}),
+			);
+		});
+
+		it("throws on error response", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response("unauthorized", { status: 401 }),
+			);
+
+			await expect(api.virtualKeys.list()).rejects.toThrow(
+				"Failed to fetch virtual keys: 401 unauthorized",
+			);
+		});
+	});
+
+	describe("create", () => {
+		it("creates a virtual key", async () => {
+			const requestBody = {
+				name: "new-key",
+				rate_limit_rps: 10,
+				rate_limit_burst: 20,
+			};
+			const mockResponse = {
+				id: "3",
+				...requestBody,
+				key: "vk_new123",
+			};
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify(mockResponse), { status: 200 }),
+			);
+
+			const result = await api.virtualKeys.create(
+				requestBody.name,
+				requestBody.rate_limit_rps,
+				requestBody.rate_limit_burst,
+			);
+
+			expect(result).toEqual(mockResponse);
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/virtual-keys",
+				expect.objectContaining({
+					method: "POST",
+					headers: expect.objectContaining({
+						Authorization: "Bearer test-token",
+					}),
+					body: JSON.stringify(requestBody),
+				}),
+			);
+		});
+
+		it("creates with null rate limits", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify({ id: "4", name: "unlimited" }), {
+					status: 200,
+				}),
+			);
+
+			await api.virtualKeys.create("unlimited", null, null);
+
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/virtual-keys",
+				expect.objectContaining({
+					body: JSON.stringify({
+						name: "unlimited",
+						rate_limit_rps: null,
+						rate_limit_burst: null,
+					}),
+				}),
+			);
+		});
+
+		it("throws on error response", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response("duplicate name", { status: 409 }),
+			);
+
+			await expect(api.virtualKeys.create("dup")).rejects.toThrow(
+				"Failed to create virtual key: 409 duplicate name",
+			);
+		});
+	});
+
+	describe("get", () => {
+		it("fetches a virtual key by id", async () => {
+			const mockKey = { id: "1", name: "key1", key: "vk_abc123" };
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify(mockKey), { status: 200 }),
+			);
+
+			const result = await api.virtualKeys.get("1");
+
+			expect(result).toEqual(mockKey);
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/virtual-keys/1",
+				expect.objectContaining({
+					headers: expect.objectContaining({
+						Authorization: "Bearer test-token",
+					}),
+				}),
+			);
+		});
+
+		it("throws on error response", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response("not found", { status: 404 }),
+			);
+
+			await expect(api.virtualKeys.get("nonexistent")).rejects.toThrow(
+				"Failed to fetch virtual key: 404 not found",
+			);
+		});
+	});
+
+	describe("update", () => {
+		it("updates a virtual key", async () => {
+			const updateData = {
+				name: "updated-key",
+				rate_limit_rps: 50,
+			};
+			const mockResponse = { id: "1", ...updateData, key: "vk_abc123" };
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify(mockResponse), { status: 200 }),
+			);
+
+			const result = await api.virtualKeys.update("1", updateData);
+
+			expect(result).toEqual(mockResponse);
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/virtual-keys/1",
+				expect.objectContaining({
+					method: "PUT",
+					headers: expect.objectContaining({
+						Authorization: "Bearer test-token",
+					}),
+					body: JSON.stringify(updateData),
+				}),
+			);
+		});
+
+		it("throws on error response", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response("not found", { status: 404 }),
+			);
+
+			await expect(
+				api.virtualKeys.update("1", { name: "test" }),
+			).rejects.toThrow("Failed to update virtual key: 404 not found");
+		});
+	});
+
+	describe("delete", () => {
+		it("deletes a virtual key", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(null, { status: 204 }),
+			);
+
+			await api.virtualKeys.delete("1");
+
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/virtual-keys/1",
+				expect.objectContaining({
+					method: "DELETE",
+					headers: expect.objectContaining({
+						Authorization: "Bearer test-token",
+					}),
+				}),
+			);
+		});
+
+		it("throws fixed error on failure", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(null, { status: 500 }),
+			);
+
+			await expect(api.virtualKeys.delete("1")).rejects.toThrow(
+				"Failed to delete virtual key",
+			);
+		});
+	});
+});
+
+describe("api.system", () => {
+	beforeEach(() => {
+		setAdminToken("test-token");
+		vi.restoreAllMocks();
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2024-01-15T10:30:00Z"));
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("fetches system stats with since parameter", async () => {
+		const mockStats = {
+			cpu_usage: 45.2,
+			memory_usage: 67.8,
+			disk_usage: 32.1,
+		};
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(JSON.stringify(mockStats), { status: 200 }),
+		);
+
+		const result = await api.system.get();
+
+		expect(result).toEqual(mockStats);
+		expect(globalThis.fetch).toHaveBeenCalledWith(
+			"/api/system?since=2024-01-15T00%3A00%3A00.000Z",
+			expect.objectContaining({
+				headers: expect.objectContaining({
+					Authorization: "Bearer test-token",
+				}),
+			}),
+		);
+	});
+
+	it("throws on error response", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response("internal error", { status: 500 }),
+		);
+
+		await expect(api.system.get()).rejects.toThrow(
+			"Failed to fetch system stats: 500 internal error",
+		);
+	});
+});
+
+describe("api.chat", () => {
+	beforeEach(() => {
+		setAdminToken("test-token");
+		vi.restoreAllMocks();
+	});
+
+	const chatBody = {
+		model: "gpt-4",
+		stream: false,
+		messages: [{ role: "user", content: "Hello" }],
+		temperature: 0.7,
+	};
+
+	describe("completions", () => {
+		it("sends chat completions request", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify({ choices: [] }), { status: 200 }),
+			);
+
+			const result = await api.chat.completions(chatBody);
+
+			expect(result).toBeInstanceOf(Response);
+			expect(result.ok).toBe(true);
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/chat/completions",
+				expect.objectContaining({
+					method: "POST",
+					headers: expect.objectContaining({
+						Authorization: "Bearer test-token",
+						"Content-Type": "application/json",
+					}),
+					body: JSON.stringify(chatBody),
+				}),
+			);
+		});
+
+		it("throws on error response", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response("model not found", { status: 404 }),
+			);
+
+			await expect(api.chat.completions(chatBody)).rejects.toThrow(
+				"Chat failed: 404 model not found",
+			);
+		});
+	});
+
+	describe("chat", () => {
+		it("sends chat request", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify({ id: "chat-123" }), { status: 200 }),
+			);
+
+			const result = await api.chat.chat(chatBody);
+
+			expect(result).toBeInstanceOf(Response);
+			expect(result.ok).toBe(true);
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/chat/chat",
+				expect.objectContaining({
+					method: "POST",
+					headers: expect.objectContaining({
+						Authorization: "Bearer test-token",
+					}),
+					body: JSON.stringify(chatBody),
+				}),
+			);
+		});
+
+		it("passes signal to fetch when provided", async () => {
+			const abortController = new AbortController();
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(null, { status: 200 }),
+			);
+
+			await api.chat.chat({ ...chatBody, signal: abortController.signal });
+
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/chat/chat",
+				expect.objectContaining({
+					signal: abortController.signal,
+				}),
+			);
+		});
+
+		it("throws on error response", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response("rate limited", { status: 429 }),
+			);
+
+			await expect(api.chat.chat(chatBody)).rejects.toThrow(
+				"Chat failed: 429 rate limited",
+			);
+		});
+	});
+
+	describe("arena", () => {
+		it("sends arena request", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify({ winner: "model-a" }), { status: 200 }),
+			);
+
+			const result = await api.chat.arena(chatBody);
+
+			expect(result).toBeInstanceOf(Response);
+			expect(result.ok).toBe(true);
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/chat/arena",
+				expect.objectContaining({
+					method: "POST",
+					headers: expect.objectContaining({
+						Authorization: "Bearer test-token",
+					}),
+					body: JSON.stringify(chatBody),
+				}),
+			);
+		});
+
+		it("passes signal to fetch when provided", async () => {
+			const abortController = new AbortController();
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(null, { status: 200 }),
+			);
+
+			await api.chat.arena({ ...chatBody, signal: abortController.signal });
+
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/chat/arena",
+				expect.objectContaining({
+					signal: abortController.signal,
+				}),
+			);
+		});
+
+		it("throws on error response", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response("arena unavailable", { status: 503 }),
+			);
+
+			await expect(api.chat.arena(chatBody)).rejects.toThrow(
+				"Arena failed: 503 arena unavailable",
+			);
+		});
+	});
+});
+
+describe("api.failoverGroups", () => {
+	beforeEach(() => {
+		setAdminToken("test-token");
+		vi.restoreAllMocks();
+	});
+
+	describe("list", () => {
+		it("fetches failover groups list", async () => {
+			const mockGroups = [
+				{ id: "1", name: "group1", models: ["model-a"] },
+				{ id: "2", name: "group2", models: ["model-b"] },
+			];
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify(mockGroups), { status: 200 }),
+			);
+
+			const result = await api.failoverGroups.list();
+
+			expect(result).toEqual(mockGroups);
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/failover-groups",
+				expect.objectContaining({
+					headers: expect.objectContaining({
+						Authorization: "Bearer test-token",
+					}),
+				}),
+			);
+		});
+
+		it("throws on error response", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response("unauthorized", { status: 401 }),
+			);
+
+			await expect(api.failoverGroups.list()).rejects.toThrow(
+				"Failed to fetch failover groups: 401 unauthorized",
+			);
+		});
+	});
+
+	describe("get", () => {
+		it("fetches a failover group by id", async () => {
+			const mockGroup = {
+				id: "1",
+				name: "primary-group",
+				models: ["openai/gpt-4", "anthropic/claude-3"],
+			};
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify(mockGroup), { status: 200 }),
+			);
+
+			const result = await api.failoverGroups.get("1");
+
+			expect(result).toEqual(mockGroup);
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/failover-groups/1",
+				expect.objectContaining({
+					headers: expect.objectContaining({
+						Authorization: "Bearer test-token",
+					}),
+				}),
+			);
+		});
+
+		it("throws on error response", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response("not found", { status: 404 }),
+			);
+
+			await expect(api.failoverGroups.get("nonexistent")).rejects.toThrow(
+				"Failed to fetch failover group: 404 not found",
+			);
+		});
+	});
+
+	describe("create", () => {
+		it("creates a failover group", async () => {
+			const createData = {
+				display_model: "hotel/my-group",
+				display_name: "new-group",
+				description: "Test failover group",
+				entry_ids: ["model-a", "model-b"],
+			};
+			const mockResponse = { id: "3", ...createData };
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify(mockResponse), { status: 200 }),
+			);
+
+			const result = await api.failoverGroups.create(createData);
+
+			expect(result).toEqual(mockResponse);
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/failover-groups",
+				expect.objectContaining({
+					method: "POST",
+					headers: expect.objectContaining({
+						Authorization: "Bearer test-token",
+					}),
+					body: JSON.stringify(createData),
+				}),
+			);
+		});
+
+		it("throws on error response", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response("duplicate name", { status: 409 }),
+			);
+
+			await expect(
+				api.failoverGroups.create({
+					display_model: "hotel/dup",
+					entry_ids: [],
+				}),
+			).rejects.toThrow("Failed to create failover group: 409 duplicate name");
+		});
+	});
+
+	describe("update", () => {
+		it("updates a failover group", async () => {
+			const updateData = {
+				display_name: "updated-group",
+				description: "Updated description",
+				group_enabled: true,
+				priority_order: ["model-c"],
+			};
+			const mockResponse = { id: "1", ...updateData };
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify(mockResponse), { status: 200 }),
+			);
+
+			const result = await api.failoverGroups.update("1", updateData);
+
+			expect(result).toEqual(mockResponse);
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/failover-groups/1",
+				expect.objectContaining({
+					method: "PUT",
+					headers: expect.objectContaining({
+						Authorization: "Bearer test-token",
+					}),
+					body: JSON.stringify(updateData),
+				}),
+			);
+		});
+
+		it("throws on error response", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response("not found", { status: 404 }),
+			);
+
+			await expect(
+				api.failoverGroups.update("1", {
+					display_name: "test",
+					group_enabled: false,
+				}),
+			).rejects.toThrow("Failed to update failover group: 404 not found");
+		});
+	});
+
+	describe("delete", () => {
+		it("deletes a failover group", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(null, { status: 204 }),
+			);
+
+			await api.failoverGroups.delete("1");
+
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/failover-groups/1",
+				expect.objectContaining({
+					method: "DELETE",
+					headers: expect.objectContaining({
+						Authorization: "Bearer test-token",
+					}),
+				}),
+			);
+		});
+
+		it("throws fixed error on failure", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(null, { status: 500 }),
+			);
+
+			await expect(api.failoverGroups.delete("1")).rejects.toThrow(
+				"Failed to delete failover group",
+			);
+		});
+	});
+
+	describe("sync", () => {
+		it("syncs failover groups", async () => {
+			const mockResult = { synced: 5, failed: 0 };
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify(mockResult), { status: 200 }),
+			);
+
+			const result = await api.failoverGroups.sync();
+
+			expect(result).toEqual(mockResult);
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/failover-groups/sync",
+				expect.objectContaining({
+					method: "POST",
+					headers: expect.objectContaining({
+						Authorization: "Bearer test-token",
+					}),
+				}),
+			);
+		});
+
+		it("throws on error response", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response("sync failed", { status: 500 }),
+			);
+
+			await expect(api.failoverGroups.sync()).rejects.toThrow(
+				"Failed to sync failover groups: 500 sync failed",
+			);
+		});
+	});
+
+	describe("candidates", () => {
+		it("fetches candidate models", async () => {
+			const mockCandidates = [
+				{ model_id: "gpt-4", provider_id: "openai" },
+				{ model_id: "claude-3", provider_id: "anthropic" },
+			];
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify(mockCandidates), { status: 200 }),
+			);
+
+			const result = await api.failoverGroups.candidates();
+
+			expect(result).toEqual(mockCandidates);
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/failover-groups/candidates",
+				expect.objectContaining({
+					headers: expect.objectContaining({
+						Authorization: "Bearer test-token",
+					}),
+				}),
+			);
+		});
+
+		it("throws on error response", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response("service unavailable", { status: 503 }),
+			);
+
+			await expect(api.failoverGroups.candidates()).rejects.toThrow(
+				"Failed to fetch candidates: 503 service unavailable",
+			);
+		});
+	});
+});
+
+describe("api.backups", () => {
+	beforeEach(() => {
+		setAdminToken("test-token");
+		vi.restoreAllMocks();
+	});
+
+	describe("list", () => {
+		it("fetches backups list", async () => {
+			const mockBackups = [
+				{ filename: "backup-2024-01-01.sql", size: 1024 },
+				{ filename: "backup-2024-01-02.sql", size: 2048 },
+			];
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify(mockBackups), { status: 200 }),
+			);
+
+			const result = await api.backups.list();
+
+			expect(result).toEqual(mockBackups);
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/backups",
+				expect.objectContaining({
+					headers: expect.objectContaining({
+						Authorization: "Bearer test-token",
+					}),
+				}),
+			);
+		});
+
+		it("throws on error response", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response("unauthorized", { status: 401 }),
+			);
+
+			await expect(api.backups.list()).rejects.toThrow(
+				"Failed to fetch backups: 401 unauthorized",
+			);
+		});
+	});
+
+	describe("create", () => {
+		it("creates a backup", async () => {
+			const mockBackup = {
+				filename: "backup-2024-01-15.sql",
+				size: 0,
+				created_at: "2024-01-15T10:00:00Z",
+			};
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify(mockBackup), { status: 200 }),
+			);
+
+			const result = await api.backups.create();
+
+			expect(result).toEqual(mockBackup);
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/backups",
+				expect.objectContaining({
+					method: "POST",
+					headers: expect.objectContaining({
+						Authorization: "Bearer test-token",
+					}),
+				}),
+			);
+		});
+
+		it("throws on error response", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response("disk full", { status: 507 }),
+			);
+
+			await expect(api.backups.create()).rejects.toThrow(
+				"Failed to create backup: 507 disk full",
+			);
+		});
+	});
+
+	describe("downloadUrl", () => {
+		it("returns encoded download URL", () => {
+			const filename = "backup with spaces.sql";
+			const url = api.backups.downloadUrl(filename);
+
+			expect(url).toBe("/api/backups/backup%20with%20spaces.sql");
+		});
+
+		it("encodes special characters in filename", () => {
+			const filename = "backup&2024.sql";
+			const url = api.backups.downloadUrl(filename);
+
+			expect(url).toBe("/api/backups/backup%262024.sql");
+		});
+	});
+
+	describe("delete", () => {
+		it("deletes a backup", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(null, { status: 204 }),
+			);
+
+			await api.backups.delete("backup-2024-01-01.sql");
+
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/backups/backup-2024-01-01.sql",
+				expect.objectContaining({
+					method: "DELETE",
+					headers: expect.objectContaining({
+						Authorization: "Bearer test-token",
+					}),
+				}),
+			);
+		});
+
+		it("encodes filename in URL", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(null, { status: 204 }),
+			);
+
+			await api.backups.delete("backup with spaces.sql");
+
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/backups/backup%20with%20spaces.sql",
+				expect.anything(),
+			);
+		});
+
+		it("throws fixed error on failure", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(null, { status: 500 }),
+			);
+
+			await expect(api.backups.delete("backup.sql")).rejects.toThrow(
+				"Failed to delete backup",
+			);
+		});
+	});
+
+	describe("restore", () => {
+		beforeEach(() => {
+			localStorage.clear();
+		});
+
+		it("restores from backup file using FormData", async () => {
+			const mockFile = new File(["dummy content"], "backup.sql", {
+				type: "application/sql",
+			});
+			const adminToken = "restore-token-123";
+			localStorage.setItem("adminToken", adminToken);
+
+			const mockResponse = { migration_count: 5, known_count: 10 };
+			const fetchSpy = vi
+				.spyOn(globalThis, "fetch")
+				.mockImplementation(
+					async () =>
+						new Response(JSON.stringify(mockResponse), { status: 200 }),
+				);
+
+			const result = await api.backups.restore(mockFile, adminToken);
+
+			expect(result).toEqual(mockResponse);
+
+			const callArgs = fetchSpy.mock.calls[0];
+			expect(callArgs[0]).toBe("/api/backups/restore");
+
+			const options = callArgs[1] as RequestInit;
+			expect(options.method).toBe("POST");
+			expect(options.headers).toEqual({
+				Authorization: `Bearer ${adminToken}`,
+			});
+			expect(options.body).toBeInstanceOf(FormData);
+
+			const formData = options.body as FormData;
+			expect(formData.get("dump")).toBe(mockFile);
+			expect(formData.get("admin_token")).toBe(adminToken);
+		});
+
+		it("uses localStorage token for Authorization", async () => {
+			const mockFile = new File(["content"], "test.sql");
+			const storedToken = "stored-restore-token";
+			localStorage.setItem("adminToken", storedToken);
+
+			vi.spyOn(globalThis, "fetch").mockImplementation(
+				async () =>
+					new Response(JSON.stringify({ migration_count: 1, known_count: 1 }), {
+						status: 200,
+					}),
+			);
+
+			await api.backups.restore(mockFile, storedToken);
+
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/backups/restore",
+				expect.objectContaining({
+					headers: {
+						Authorization: `Bearer ${storedToken}`,
+					},
+				}),
+			);
+		});
+
+		it("does not set Content-Type header", async () => {
+			const mockFile = new File(["content"], "test.sql");
+			vi.spyOn(globalThis, "fetch").mockImplementation(
+				async () =>
+					new Response(JSON.stringify({ migration_count: 0, known_count: 0 }), {
+						status: 200,
+					}),
+			);
+
+			await api.backups.restore(mockFile, "token");
+
+			const callArgs = vi.mocked(globalThis.fetch).mock.calls[0];
+			const options = callArgs[1] as RequestInit;
+			expect(options.headers).not.toHaveProperty("Content-Type");
+		});
+
+		it("throws on error response", async () => {
+			const mockFile = new File(["content"], "test.sql");
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response("invalid dump", { status: 400 }),
+			);
+
+			await expect(api.backups.restore(mockFile, "token")).rejects.toThrow(
+				"Restore failed: 400 invalid dump",
+			);
+		});
+	});
+});
+
+describe("api.providers", () => {
+	beforeEach(() => {
+		setAdminToken("test-token");
+		vi.restoreAllMocks();
+	});
+
+	describe("list", () => {
+		it("fetches all providers", async () => {
+			const mockProviders = [{ id: "1", name: "Test" }];
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify(mockProviders), { status: 200 }),
+			);
+
+			const result = await api.providers.list();
+			expect(result).toEqual(mockProviders);
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/providers",
+				expect.objectContaining({
+					headers: expect.objectContaining({
+						Authorization: "Bearer test-token",
+						"Content-Type": "application/json",
+					}),
+				}),
+			);
+		});
+
+		it("throws on error response", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response("not found", { status: 404 }),
+			);
+			await expect(api.providers.list()).rejects.toThrow(
+				"Failed to fetch providers: 404 not found",
+			);
+		});
+	});
+
+	describe("create", () => {
+		it("creates a provider with POST request", async () => {
+			const mockProvider = { id: "1", name: "Created" };
+			const data = {
+				name: "Test",
+				base_url: "https://api.example.com",
+				api_key: "sk-123",
+			};
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify(mockProvider), { status: 201 }),
+			);
+
+			const result = await api.providers.create(data);
+			expect(result).toEqual(mockProvider);
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/providers",
+				expect.objectContaining({
+					method: "POST",
+					headers: expect.objectContaining({
+						Authorization: "Bearer test-token",
+						"Content-Type": "application/json",
+					}),
+					body: JSON.stringify(data),
+				}),
+			);
+		});
+
+		it("throws on error response", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response("bad request", { status: 400 }),
+			);
+			await expect(
+				api.providers.create({
+					name: "Test",
+					base_url: "https://api.example.com",
+					api_key: "sk-123",
+				}),
+			).rejects.toThrow("Failed to create provider: 400 bad request");
+		});
+	});
+
+	describe("delete", () => {
+		it("deletes a provider with DELETE request", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(null, { status: 204 }),
+			);
+
+			await api.providers.delete("123");
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/providers/123",
+				expect.objectContaining({
+					method: "DELETE",
+					headers: expect.objectContaining({
+						Authorization: "Bearer test-token",
+						"Content-Type": "application/json",
+					}),
+				}),
+			);
+		});
+
+		it("throws fixed error on failure", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(null, { status: 500 }),
+			);
+			await expect(api.providers.delete("123")).rejects.toThrow(
+				"Failed to delete provider",
+			);
+		});
+	});
+
+	describe("update", () => {
+		it("updates a provider with PUT request", async () => {
+			const mockProvider = { id: "1", name: "Updated" };
+			const data = { name: "New Name", enabled: true };
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify(mockProvider), { status: 200 }),
+			);
+
+			const result = await api.providers.update("123", data);
+			expect(result).toEqual(mockProvider);
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/providers/123",
+				expect.objectContaining({
+					method: "PUT",
+					headers: expect.objectContaining({
+						Authorization: "Bearer test-token",
+						"Content-Type": "application/json",
+					}),
+					body: JSON.stringify(data),
+				}),
+			);
+		});
+
+		it("throws on error response", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response("not found", { status: 404 }),
+			);
+			await expect(
+				api.providers.update("123", { name: "Test" }),
+			).rejects.toThrow("Failed to update provider: 404 not found");
+		});
+	});
+
+	describe("discover", () => {
+		it("discovers models for a provider", async () => {
+			const mockResult = { discovered: 42 };
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify(mockResult), { status: 200 }),
+			);
+
+			const result = await api.providers.discover("123");
+			expect(result).toEqual(mockResult);
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/providers/123/discover",
+				expect.objectContaining({
+					method: "POST",
+					headers: expect.objectContaining({
+						Authorization: "Bearer test-token",
+						"Content-Type": "application/json",
+					}),
+				}),
+			);
+		});
+
+		it("throws on error response", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response("error", { status: 500 }),
+			);
+			await expect(api.providers.discover("123")).rejects.toThrow(
+				"Failed to discover models: 500 error",
+			);
+		});
+	});
+
+	describe("discoverAll", () => {
+		it("discovers models for all providers", async () => {
+			const mockResult = {
+				succeeded: 2,
+				failed: 1,
+				discovered: 10,
+				results: [
+					{ provider_name: "Test", discovered: 10 },
+					{ provider_name: "Fail", error: "timeout" },
+				],
+			};
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify(mockResult), { status: 200 }),
+			);
+
+			const result = await api.providers.discoverAll();
+			expect(result).toEqual(mockResult);
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/providers/discover-all",
+				expect.objectContaining({
+					method: "POST",
+					headers: expect.objectContaining({
+						Authorization: "Bearer test-token",
+						"Content-Type": "application/json",
+					}),
+				}),
+			);
+		});
+
+		it("throws on error response", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response("error", { status: 500 }),
+			);
+			await expect(api.providers.discoverAll()).rejects.toThrow(
+				"Failed to discover all: 500 error",
+			);
+		});
+	});
+
+	describe("refreshQuotas", () => {
+		it("refreshes quotas for all providers", async () => {
+			const mockResult = {
+				refreshed: 2,
+				failed: 1,
+				skipped: 0,
+				results: [
+					{ provider_name: "Test", provider_type: "openai", refreshed: true },
+				],
+			};
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify(mockResult), { status: 200 }),
+			);
+
+			const result = await api.providers.refreshQuotas();
+			expect(result).toEqual(mockResult);
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/providers/refresh-quotas",
+				expect.objectContaining({
+					method: "POST",
+					headers: expect.objectContaining({
+						Authorization: "Bearer test-token",
+						"Content-Type": "application/json",
+					}),
+				}),
+			);
+		});
+
+		it("throws on error response", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response("error", { status: 500 }),
+			);
+			await expect(api.providers.refreshQuotas()).rejects.toThrow(
+				"Failed to refresh quotas: 500 error",
+			);
+		});
+	});
+
+	describe("getUsage", () => {
+		it("fetches usage for a provider", async () => {
+			const mockUsage = { remaining_credits: 100 };
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify(mockUsage), { status: 200 }),
+			);
+
+			const result = await api.providers.getUsage("123");
+			expect(result).toEqual(mockUsage);
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/providers/123/usage",
+				expect.objectContaining({
+					headers: expect.objectContaining({
+						Authorization: "Bearer test-token",
+						"Content-Type": "application/json",
+					}),
+				}),
+			);
+		});
+
+		it("throws on error response", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response("not found", { status: 404 }),
+			);
+			await expect(api.providers.getUsage("123")).rejects.toThrow(
+				"Failed to fetch usage: 404 not found",
+			);
+		});
+	});
+
+	describe("getBalance", () => {
+		it("fetches balance for a provider", async () => {
+			const mockBalance = { balance: 50.0, currency: "USD" };
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify(mockBalance), { status: 200 }),
+			);
+
+			const result = await api.providers.getBalance("123");
+			expect(result).toEqual(mockBalance);
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/providers/123/balance",
+				expect.objectContaining({
+					headers: expect.objectContaining({
+						Authorization: "Bearer test-token",
+						"Content-Type": "application/json",
+					}),
+				}),
+			);
+		});
+
+		it("throws on error response", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response("not found", { status: 404 }),
+			);
+			await expect(api.providers.getBalance("123")).rejects.toThrow(
+				"Failed to fetch balance: 404 not found",
+			);
+		});
+	});
+
+	describe("getOpenRouterBalance", () => {
+		it("fetches OpenRouter balance for a provider", async () => {
+			const mockBalance = { total_credits: 100, used_credits: 25 };
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify(mockBalance), { status: 200 }),
+			);
+
+			const result = await api.providers.getOpenRouterBalance("123");
+			expect(result).toEqual(mockBalance);
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/providers/123/usage",
+				expect.objectContaining({
+					headers: expect.objectContaining({
+						Authorization: "Bearer test-token",
+						"Content-Type": "application/json",
+					}),
+				}),
+			);
+		});
+
+		it("throws on error response", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response("not found", { status: 404 }),
+			);
+			await expect(api.providers.getOpenRouterBalance("123")).rejects.toThrow(
+				"Failed to fetch OpenRouter balance: 404 not found",
+			);
+		});
+	});
+
+	describe("getOllamaCloudAccount", () => {
+		it("fetches Ollama Cloud account for a provider", async () => {
+			const mockAccount = { account_id: "acc-123", status: "active" };
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify(mockAccount), { status: 200 }),
+			);
+
+			const result = await api.providers.getOllamaCloudAccount("123");
+			expect(result).toEqual(mockAccount);
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/providers/123/account",
+				expect.objectContaining({
+					headers: expect.objectContaining({
+						Authorization: "Bearer test-token",
+						"Content-Type": "application/json",
+					}),
+				}),
+			);
+		});
+
+		it("throws on error response", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response("not found", { status: 404 }),
+			);
+			await expect(api.providers.getOllamaCloudAccount("123")).rejects.toThrow(
+				"Failed to fetch Ollama Cloud account: 404 not found",
+			);
+		});
+	});
+});
+
+describe("api.models", () => {
+	beforeEach(() => {
+		setAdminToken("test-token");
+		vi.restoreAllMocks();
+	});
+
+	describe("list", () => {
+		it("fetches all models without provider_id", async () => {
+			const mockModels = [{ id: "1", name: "gpt-4" }];
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify(mockModels), { status: 200 }),
+			);
+
+			const result = await api.models.list();
+			expect(result).toEqual(mockModels);
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/models",
+				expect.objectContaining({
+					headers: expect.objectContaining({
+						Authorization: "Bearer test-token",
+						"Content-Type": "application/json",
+					}),
+				}),
+			);
+		});
+
+		it("fetches models filtered by provider_id", async () => {
+			const mockModels = [{ id: "1", name: "gpt-4" }];
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify(mockModels), { status: 200 }),
+			);
+
+			const result = await api.models.list("provider-123");
+			expect(result).toEqual(mockModels);
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/models?provider_id=provider-123",
+				expect.objectContaining({
+					headers: expect.objectContaining({
+						Authorization: "Bearer test-token",
+						"Content-Type": "application/json",
+					}),
+				}),
+			);
+		});
+
+		it("throws on error response", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response("not found", { status: 404 }),
+			);
+			await expect(api.models.list()).rejects.toThrow(
+				"Failed to fetch models: 404 not found",
+			);
+		});
+	});
+
+	describe("cursor", () => {
+		it("fetches models with cursor pagination", async () => {
+			const mockResponse = {
+				data: [{ id: "1", name: "gpt-4" }],
+				has_more: false,
+				next_cursor: null,
+				prev_cursor: null,
+			};
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify(mockResponse), { status: 200 }),
+			);
+
+			const result = await api.models.cursor({
+				direction: "after",
+				limit: 10,
+			});
+			expect(result).toEqual(mockResponse);
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				expect.stringContaining("/api/models/cursor?"),
+				expect.objectContaining({
+					headers: expect.objectContaining({
+						Authorization: "Bearer test-token",
+						"Content-Type": "application/json",
+					}),
+				}),
+			);
+		});
+
+		it("includes optional params in URL", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify({ data: [], has_more: false }), {
+					status: 200,
+				}),
+			);
+
+			await api.models.cursor({
+				cursor: "abc123",
+				direction: "before",
+				limit: 20,
+				sort_by: "name",
+				sort_dir: "desc",
+				provider_id: "prov-1",
+				search: "gpt",
+				capabilities: "vision",
+			});
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				expect.stringContaining(
+					"/api/models/cursor?cursor=abc123&direction=before&limit=20&sort_by=name&sort_dir=desc&provider_id=prov-1&search=gpt&capabilities=vision",
+				),
+				expect.anything(),
+			);
+		});
+
+		it("throws on error response", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response("error", { status: 500 }),
+			);
+			await expect(
+				api.models.cursor({ direction: "after", limit: 10 }),
+			).rejects.toThrow("Failed to fetch models (cursor): 500 error");
+		});
+	});
+
+	describe("update", () => {
+		it("updates a model with PATCH request", async () => {
+			const mockModel = { id: "1", display_name: "Updated Model" };
+			const data = { display_name: "Updated Model", enabled: true };
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify(mockModel), { status: 200 }),
+			);
+
+			const result = await api.models.update("123", data);
+			expect(result).toEqual(mockModel);
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/models/123",
+				expect.objectContaining({
+					method: "PATCH",
+					headers: expect.objectContaining({
+						Authorization: "Bearer test-token",
+						"Content-Type": "application/json",
+					}),
+					body: JSON.stringify(data),
+				}),
+			);
+		});
+
+		it("throws on error response", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response("not found", { status: 404 }),
+			);
+			await expect(
+				api.models.update("123", { display_name: "Test" }),
+			).rejects.toThrow("Failed to update model: 404 not found");
+		});
+	});
+
+	describe("test", () => {
+		it("tests a model with POST request", async () => {
+			const mockResult = {
+				success: true,
+				ttft_ms: 150,
+				duration_ms: 500,
+				response: "Hello!",
+			};
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify(mockResult), { status: 200 }),
+			);
+
+			const result = await api.models.test("123");
+			expect(result).toEqual(mockResult);
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/models/123/test",
+				expect.objectContaining({
+					method: "POST",
+					headers: expect.objectContaining({
+						Authorization: "Bearer test-token",
+						"Content-Type": "application/json",
+					}),
+				}),
+			);
+		});
+
+		it("throws on error response", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response("test failed", { status: 500 }),
+			);
+			await expect(api.models.test("123")).rejects.toThrow(
+				"Test failed: 500 test failed",
+			);
+		});
+	});
+
+	describe("delete", () => {
+		it("deletes a model with DELETE request", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(null, { status: 204 }),
+			);
+
+			await api.models.delete("123");
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/models/123",
+				expect.objectContaining({
+					method: "DELETE",
+					headers: expect.objectContaining({
+						Authorization: "Bearer test-token",
+						"Content-Type": "application/json",
+					}),
+				}),
+			);
+		});
+
+		it("throws fixed error on failure", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(null, { status: 500 }),
+			);
+			await expect(api.models.delete("123")).rejects.toThrow(
+				"Failed to delete model",
+			);
+		});
+	});
+});
+
+describe("api.logs", () => {
+	beforeEach(() => {
+		setAdminToken("test-token");
+		vi.restoreAllMocks();
+	});
+
+	describe("list", () => {
+		it("fetches logs without params", async () => {
+			const mockLogs = { entries: [], total: 0, page: 1, per_page: 20 };
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify(mockLogs), { status: 200 }),
+			);
+
+			const result = await api.logs.list();
+			expect(result).toEqual(mockLogs);
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/logs",
+				expect.objectContaining({
+					headers: expect.objectContaining({
+						Authorization: "Bearer test-token",
+						"Content-Type": "application/json",
+					}),
+				}),
+			);
+		});
+
+		it("fetches logs with optional params", async () => {
+			const mockLogs = { entries: [], total: 0, page: 1, per_page: 20 };
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify(mockLogs), { status: 200 }),
+			);
+
+			const result = await api.logs.list({
+				page: 2,
+				per_page: 50,
+				model_id: "model-1",
+				provider_id: "prov-1",
+				status_code: "200",
+				from: "2024-01-01",
+				to: "2024-01-02",
+				sort_by: "timestamp",
+				sort_dir: "desc",
+			});
+			expect(result).toEqual(mockLogs);
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				expect.stringContaining("/api/logs?"),
+				expect.objectContaining({
+					headers: expect.objectContaining({
+						Authorization: "Bearer test-token",
+						"Content-Type": "application/json",
+					}),
+				}),
+			);
+		});
+
+		it("throws on error response", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response("error", { status: 500 }),
+			);
+			await expect(api.logs.list()).rejects.toThrow(
+				"Failed to fetch logs: 500 error",
+			);
+		});
+	});
+
+	describe("purge", () => {
+		it("purges logs older than specified date", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(null, { status: 204 }),
+			);
+
+			await api.logs.purge("2024-01-01");
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/logs/purge",
+				expect.objectContaining({
+					method: "DELETE",
+					headers: expect.objectContaining({
+						Authorization: "Bearer test-token",
+						"Content-Type": "application/json",
+					}),
+					body: JSON.stringify({ older_than: "2024-01-01" }),
+				}),
+			);
+		});
+
+		it("throws error with response text on failure", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response("database locked", { status: 500 }),
+			);
+			await expect(api.logs.purge("2024-01-01")).rejects.toThrow(
+				"Failed to purge logs: 500 database locked",
+			);
+		});
+	});
+
+	describe("cursor", () => {
+		it("fetches logs with cursor pagination", async () => {
+			const mockResponse = {
+				data: [],
+				has_more: false,
+				next_cursor: null,
+				prev_cursor: null,
+			};
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify(mockResponse), { status: 200 }),
+			);
+
+			const result = await api.logs.cursor({
+				direction: "after",
+				limit: 10,
+			});
+			expect(result).toEqual(mockResponse);
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				expect.stringContaining("/api/logs/cursor?"),
+				expect.objectContaining({
+					headers: expect.objectContaining({
+						Authorization: "Bearer test-token",
+						"Content-Type": "application/json",
+					}),
+				}),
+			);
+		});
+
+		it("includes optional params in URL", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify({ data: [], has_more: false }), {
+					status: 200,
+				}),
+			);
+
+			await api.logs.cursor({
+				cursor: "abc123",
+				direction: "before",
+				limit: 20,
+				model_id: "model-1",
+				provider_id: "prov-1",
+				status_code: "200",
+				from: "2024-01-01",
+				to: "2024-01-02",
+				sort_dir: "desc",
+			});
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				expect.stringContaining(
+					"/api/logs/cursor?cursor=abc123&direction=before&limit=20",
+				),
+				expect.anything(),
+			);
+		});
+
+		it("throws on error response", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response("error", { status: 500 }),
+			);
+			await expect(
+				api.logs.cursor({ direction: "after", limit: 10 }),
+			).rejects.toThrow("Failed to fetch logs (cursor): 500 error");
+		});
+	});
+});
+
+describe("api.appLogs", () => {
+	beforeEach(() => {
+		setAdminToken("test-token");
+		vi.restoreAllMocks();
+	});
+
+	describe("list", () => {
+		it("fetches app logs without params", async () => {
+			const mockLogs = [
+				{
+					timestamp: "2024-01-01",
+					level: "info",
+					source: "test",
+					message: "OK",
+				},
+			];
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify(mockLogs), { status: 200 }),
+			);
+
+			const result = await api.appLogs.list();
+			expect(result).toEqual(mockLogs);
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/logs/app",
+				expect.objectContaining({
+					headers: expect.objectContaining({
+						Authorization: "Bearer test-token",
+						"Content-Type": "application/json",
+					}),
+				}),
+			);
+		});
+
+		it("fetches app logs with optional params", async () => {
+			const mockLogs = [
+				{
+					timestamp: "2024-01-01",
+					level: "info",
+					source: "test",
+					message: "OK",
+				},
+			];
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify(mockLogs), { status: 200 }),
+			);
+
+			const result = await api.appLogs.list({ limit: 50, after: "abc123" });
+			expect(result).toEqual(mockLogs);
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/logs/app?limit=50&after=abc123",
+				expect.objectContaining({
+					headers: expect.objectContaining({
+						Authorization: "Bearer test-token",
+						"Content-Type": "application/json",
+					}),
+				}),
+			);
+		});
+
+		it("throws on error response", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response("error", { status: 500 }),
+			);
+			await expect(api.appLogs.list()).rejects.toThrow(
+				"Failed to fetch app logs: 500 error",
+			);
+		});
+	});
+
+	describe("purge", () => {
+		it("purges app logs", async () => {
+			const mockResult = { deleted: 100 };
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify(mockResult), { status: 200 }),
+			);
+
+			const result = await api.appLogs.purge();
+			expect(result).toEqual(mockResult);
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/logs/app",
+				expect.objectContaining({
+					method: "DELETE",
+					headers: expect.objectContaining({
+						Authorization: "Bearer test-token",
+						"Content-Type": "application/json",
+					}),
+				}),
+			);
+		});
+
+		it("throws on error response", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response("error", { status: 500 }),
+			);
+			await expect(api.appLogs.purge()).rejects.toThrow(
+				"Failed to purge app logs: 500 error",
+			);
+		});
+	});
+
+	describe("history", () => {
+		it("fetches app log history without params", async () => {
+			const mockHistory = {
+				entries: [],
+				total: 0,
+				page: 1,
+				per_page: 20,
+				level_counts: { info: 10, error: 5 },
+				source_counts: { api: 15 },
+			};
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify(mockHistory), { status: 200 }),
+			);
+
+			const result = await api.appLogs.history();
+			expect(result).toEqual(mockHistory);
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				"/api/logs/app?history=true",
+				expect.objectContaining({
+					headers: expect.objectContaining({
+						Authorization: "Bearer test-token",
+						"Content-Type": "application/json",
+					}),
+				}),
+			);
+		});
+
+		it("fetches app log history with optional params", async () => {
+			const mockHistory = {
+				entries: [],
+				total: 0,
+				page: 1,
+				per_page: 20,
+			};
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify(mockHistory), { status: 200 }),
+			);
+
+			const result = await api.appLogs.history({
+				level: "error",
+				source: "api",
+				search: "timeout",
+				from: "2024-01-01",
+				to: "2024-01-02",
+				page: 2,
+				per_page: 50,
+				sort_by: "timestamp",
+				sort_dir: "desc",
+			});
+			expect(result).toEqual(mockHistory);
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				expect.stringContaining("/api/logs/app?history=true&"),
+				expect.objectContaining({
+					headers: expect.objectContaining({
+						Authorization: "Bearer test-token",
+						"Content-Type": "application/json",
+					}),
+				}),
+			);
+		});
+
+		it("throws on error response", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response("error", { status: 500 }),
+			);
+			await expect(api.appLogs.history()).rejects.toThrow(
+				"Failed to fetch app log history: 500 error",
+			);
+		});
+	});
+
+	describe("cursor", () => {
+		it("fetches app logs with cursor pagination", async () => {
+			const mockResponse = {
+				data: [],
+				has_more: false,
+				next_cursor: null,
+				prev_cursor: null,
+			};
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify(mockResponse), { status: 200 }),
+			);
+
+			const result = await api.appLogs.cursor({
+				direction: "after",
+				limit: 10,
+			});
+			expect(result).toEqual(mockResponse);
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				expect.stringContaining("/api/logs/app/cursor?"),
+				expect.objectContaining({
+					headers: expect.objectContaining({
+						Authorization: "Bearer test-token",
+						"Content-Type": "application/json",
+					}),
+				}),
+			);
+		});
+
+		it("includes optional params in URL", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify({ data: [], has_more: false }), {
+					status: 200,
+				}),
+			);
+
+			await api.appLogs.cursor({
+				cursor: "abc123",
+				direction: "before",
+				limit: 20,
+				level: "error",
+				source: "api",
+				search: "timeout",
+				from: "2024-01-01",
+				to: "2024-01-02",
+				sort_dir: "desc",
+			});
+			expect(globalThis.fetch).toHaveBeenCalledWith(
+				expect.stringContaining(
+					"/api/logs/app/cursor?cursor=abc123&direction=before&limit=20",
+				),
+				expect.anything(),
+			);
+		});
+
+		it("throws on error response", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response("error", { status: 500 }),
+			);
+			await expect(
+				api.appLogs.cursor({ direction: "after", limit: 10 }),
+			).rejects.toThrow("Failed to fetch app logs (cursor): 500 error");
+		});
 	});
 });

--- a/web/src/components/__tests__/Layout.test.tsx
+++ b/web/src/components/__tests__/Layout.test.tsx
@@ -1,6 +1,8 @@
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { HttpResponse, http } from "msw";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { server } from "../../test/mocks/server";
 import { renderWithProviders } from "../../test/utils";
 import { Layout } from "../Layout";
 
@@ -413,6 +415,619 @@ describe("Layout", () => {
 
 			const buttons = screen.getAllByRole("button");
 			expect(buttons.length).toBeGreaterThanOrEqual(3);
+		});
+	});
+
+	describe("Helper Functions (via SystemStatus)", () => {
+		it("renders uptime information", async () => {
+			server.use(
+				http.get("/api/system", () =>
+					HttpResponse.json({
+						app: {
+							uptime_seconds: 7200,
+							cpu_percent: 10,
+							procs: 5,
+							memory_current_bytes: 100000000,
+							memory_limit_bytes: 0,
+							in_container: false,
+							goroutines: 50,
+							requests_today: 0,
+							heap_alloc_mb: 100,
+							net_rx_bytes_sec: 1000,
+							net_tx_bytes_sec: 500,
+							disk_read_bytes_sec: 200,
+							disk_write_bytes_sec: 100,
+						},
+						docker: { available: false },
+						db: {
+							size_mb: 10,
+							cache_hit_ratio: 95,
+							connections: 3,
+							tx_per_sec: 5.5,
+						},
+					}),
+				),
+			);
+
+			renderWithProviders(<Layout>{mockChildren}</Layout>);
+			await waitFor(() => {
+				expect(screen.getByText("Uptime")).toBeInTheDocument();
+			});
+		});
+
+		it("renders requests today with large number formatting", async () => {
+			server.use(
+				http.get("/api/system", () =>
+					HttpResponse.json({
+						app: {
+							uptime_seconds: 100,
+							cpu_percent: 10,
+							procs: 5,
+							memory_current_bytes: 100000000,
+							memory_limit_bytes: 0,
+							in_container: false,
+							goroutines: 50,
+							requests_today: 1500,
+							heap_alloc_mb: 100,
+							net_rx_bytes_sec: 1000,
+							net_tx_bytes_sec: 500,
+							disk_read_bytes_sec: 200,
+							disk_write_bytes_sec: 100,
+						},
+						docker: { available: false },
+						db: {
+							size_mb: 10,
+							cache_hit_ratio: 95,
+							connections: 3,
+							tx_per_sec: 5.5,
+						},
+					}),
+				),
+			);
+
+			renderWithProviders(<Layout>{mockChildren}</Layout>);
+			await waitFor(() => {
+				expect(screen.getByText("Req Today")).toBeInTheDocument();
+			});
+		});
+
+		it("renders memory information", async () => {
+			server.use(
+				http.get("/api/system", () =>
+					HttpResponse.json({
+						app: {
+							uptime_seconds: 100,
+							cpu_percent: 10,
+							procs: 5,
+							memory_current_bytes: 52428800,
+							memory_limit_bytes: 0,
+							in_container: false,
+							goroutines: 50,
+							requests_today: 0,
+							heap_alloc_mb: 50,
+							net_rx_bytes_sec: 1000,
+							net_tx_bytes_sec: 500,
+							disk_read_bytes_sec: 200,
+							disk_write_bytes_sec: 100,
+						},
+						docker: { available: false },
+						db: {
+							size_mb: 10,
+							cache_hit_ratio: 95,
+							connections: 3,
+							tx_per_sec: 5.5,
+						},
+					}),
+				),
+			);
+
+			renderWithProviders(<Layout>{mockChildren}</Layout>);
+			await waitFor(() => {
+				expect(screen.getByText("Memory")).toBeInTheDocument();
+			});
+		});
+
+		it("renders network throughput", async () => {
+			server.use(
+				http.get("/api/system", () =>
+					HttpResponse.json({
+						app: {
+							uptime_seconds: 100,
+							cpu_percent: 10,
+							procs: 5,
+							memory_current_bytes: 100000000,
+							memory_limit_bytes: 0,
+							in_container: false,
+							goroutines: 50,
+							requests_today: 0,
+							heap_alloc_mb: 100,
+							net_rx_bytes_sec: 2048,
+							net_tx_bytes_sec: 1024,
+							disk_read_bytes_sec: 200,
+							disk_write_bytes_sec: 100,
+						},
+						docker: { available: false },
+						db: {
+							size_mb: 10,
+							cache_hit_ratio: 95,
+							connections: 3,
+							tx_per_sec: 5.5,
+						},
+					}),
+				),
+			);
+
+			renderWithProviders(<Layout>{mockChildren}</Layout>);
+			await waitFor(() => {
+				expect(screen.getByText("Network")).toBeInTheDocument();
+			});
+		});
+	});
+
+	describe("SystemStatus Component", () => {
+		it("shows Online status when API is healthy", async () => {
+			renderWithProviders(<Layout>{mockChildren}</Layout>);
+			await waitFor(() => {
+				expect(screen.getByText("Online")).toBeInTheDocument();
+			});
+		});
+
+		it("shows Error status when API fails", async () => {
+			server.use(http.get("/api/system", () => HttpResponse.error()));
+
+			renderWithProviders(<Layout>{mockChildren}</Layout>);
+			await waitFor(() => {
+				expect(screen.getByText("API Status")).toBeInTheDocument();
+			});
+		});
+
+		it("renders Docker stats when docker.available is true", async () => {
+			server.use(
+				http.get("/api/system", () =>
+					HttpResponse.json({
+						app: {
+							uptime_seconds: 100,
+							cpu_percent: 10,
+							procs: 5,
+							memory_current_bytes: 100000000,
+							memory_limit_bytes: 0,
+							in_container: false,
+							goroutines: 50,
+							requests_today: 0,
+							heap_alloc_mb: 100,
+							net_rx_bytes_sec: 1000,
+							net_tx_bytes_sec: 500,
+							disk_read_bytes_sec: 200,
+							disk_write_bytes_sec: 100,
+						},
+						docker: {
+							available: true,
+							cpu_percent: 25.5,
+							procs: 10,
+							memory_usage_bytes: 536870912,
+							memory_limit_bytes: 1073741824,
+							net_rx_bytes_sec: 2000,
+							net_tx_bytes_sec: 1000,
+							disk_read_bytes_sec: 400,
+							disk_write_bytes_sec: 200,
+							container_count: 3,
+						},
+						db: {
+							size_mb: 10,
+							cache_hit_ratio: 95,
+							connections: 3,
+							tx_per_sec: 5.5,
+						},
+					}),
+				),
+			);
+
+			renderWithProviders(<Layout>{mockChildren}</Layout>);
+			await waitFor(() => {
+				expect(screen.getByText("CPU")).toBeInTheDocument();
+			});
+		});
+
+		it("renders app-only stats when docker unavailable", async () => {
+			server.use(
+				http.get("/api/system", () =>
+					HttpResponse.json({
+						app: {
+							uptime_seconds: 100,
+							cpu_percent: 15.5,
+							procs: 5,
+							memory_current_bytes: 100000000,
+							memory_limit_bytes: 0,
+							in_container: false,
+							goroutines: 50,
+							requests_today: 0,
+							heap_alloc_mb: 100,
+							net_rx_bytes_sec: 1000,
+							net_tx_bytes_sec: 500,
+							disk_read_bytes_sec: 200,
+							disk_write_bytes_sec: 100,
+						},
+						docker: { available: false },
+						db: {
+							size_mb: 10,
+							cache_hit_ratio: 95,
+							connections: 3,
+							tx_per_sec: 5.5,
+						},
+					}),
+				),
+			);
+
+			renderWithProviders(<Layout>{mockChildren}</Layout>);
+			await waitFor(() => {
+				expect(screen.getByText("CPU")).toBeInTheDocument();
+			});
+		});
+
+		it("renders DB section when stats.db is present", async () => {
+			renderWithProviders(<Layout>{mockChildren}</Layout>);
+			await waitFor(() => {
+				expect(screen.getByText("DB")).toBeInTheDocument();
+			});
+		});
+
+		it("renders DB section when stats.db is missing", async () => {
+			server.use(
+				http.get("/api/system", () =>
+					HttpResponse.json({
+						app: {
+							uptime_seconds: 100,
+							cpu_percent: 10,
+							procs: 5,
+							memory_current_bytes: 100000000,
+							memory_limit_bytes: 0,
+							in_container: false,
+							goroutines: 50,
+							requests_today: 0,
+							heap_alloc_mb: 100,
+							net_rx_bytes_sec: 1000,
+							net_tx_bytes_sec: 500,
+							disk_read_bytes_sec: 200,
+							disk_write_bytes_sec: 100,
+						},
+						docker: { available: false },
+					}),
+				),
+			);
+
+			renderWithProviders(<Layout>{mockChildren}</Layout>);
+			await waitFor(() => {
+				expect(screen.getByText("DB")).toBeInTheDocument();
+			});
+		});
+
+		it("shows warning color class when CPU >= 75%", async () => {
+			server.use(
+				http.get("/api/system", () =>
+					HttpResponse.json({
+						app: {
+							uptime_seconds: 100,
+							cpu_percent: 80,
+							procs: 5,
+							memory_current_bytes: 100000000,
+							memory_limit_bytes: 0,
+							in_container: false,
+							goroutines: 50,
+							requests_today: 0,
+							heap_alloc_mb: 100,
+							net_rx_bytes_sec: 1000,
+							net_tx_bytes_sec: 500,
+							disk_read_bytes_sec: 200,
+							disk_write_bytes_sec: 100,
+						},
+						docker: { available: false },
+						db: {
+							size_mb: 10,
+							cache_hit_ratio: 95,
+							connections: 3,
+							tx_per_sec: 5.5,
+						},
+					}),
+				),
+			);
+
+			renderWithProviders(<Layout>{mockChildren}</Layout>);
+			await waitFor(() => {
+				expect(screen.getByText("CPU")).toBeInTheDocument();
+			});
+		});
+
+		it("renders goroutines count", async () => {
+			server.use(
+				http.get("/api/system", () =>
+					HttpResponse.json({
+						app: {
+							uptime_seconds: 100,
+							cpu_percent: 10,
+							procs: 5,
+							memory_current_bytes: 100000000,
+							memory_limit_bytes: 0,
+							in_container: false,
+							goroutines: 150,
+							requests_today: 0,
+							heap_alloc_mb: 100,
+							net_rx_bytes_sec: 1000,
+							net_tx_bytes_sec: 500,
+							disk_read_bytes_sec: 200,
+							disk_write_bytes_sec: 100,
+						},
+						docker: { available: false },
+						db: {
+							size_mb: 10,
+							cache_hit_ratio: 95,
+							connections: 3,
+							tx_per_sec: 5.5,
+						},
+					}),
+				),
+			);
+
+			renderWithProviders(<Layout>{mockChildren}</Layout>);
+			await waitFor(() => {
+				expect(screen.getByText("Go routines")).toBeInTheDocument();
+			});
+		});
+
+		it("renders process count with singular form when 1", async () => {
+			server.use(
+				http.get("/api/system", () =>
+					HttpResponse.json({
+						app: {
+							uptime_seconds: 100,
+							cpu_percent: 10,
+							procs: 1,
+							memory_current_bytes: 100000000,
+							memory_limit_bytes: 0,
+							in_container: false,
+							goroutines: 50,
+							requests_today: 0,
+							heap_alloc_mb: 100,
+							net_rx_bytes_sec: 1000,
+							net_tx_bytes_sec: 500,
+							disk_read_bytes_sec: 200,
+							disk_write_bytes_sec: 100,
+						},
+						docker: { available: false },
+						db: {
+							size_mb: 10,
+							cache_hit_ratio: 95,
+							connections: 3,
+							tx_per_sec: 5.5,
+						},
+					}),
+				),
+			);
+
+			renderWithProviders(<Layout>{mockChildren}</Layout>);
+			await waitFor(() => {
+				expect(screen.getByText("CPU")).toBeInTheDocument();
+			});
+		});
+
+		it("renders process count with plural form when > 1", async () => {
+			server.use(
+				http.get("/api/system", () =>
+					HttpResponse.json({
+						app: {
+							uptime_seconds: 100,
+							cpu_percent: 10,
+							procs: 5,
+							memory_current_bytes: 100000000,
+							memory_limit_bytes: 0,
+							in_container: false,
+							goroutines: 50,
+							requests_today: 0,
+							heap_alloc_mb: 100,
+							net_rx_bytes_sec: 1000,
+							net_tx_bytes_sec: 500,
+							disk_read_bytes_sec: 200,
+							disk_write_bytes_sec: 100,
+						},
+						docker: { available: false },
+						db: {
+							size_mb: 10,
+							cache_hit_ratio: 95,
+							connections: 3,
+							tx_per_sec: 5.5,
+						},
+					}),
+				),
+			);
+
+			renderWithProviders(<Layout>{mockChildren}</Layout>);
+			await waitFor(() => {
+				expect(screen.getByText("CPU")).toBeInTheDocument();
+			});
+		});
+
+		it("toggles collapsed state on CollapsibleToggle click", async () => {
+			const user = userEvent.setup();
+			renderWithProviders(<Layout>{mockChildren}</Layout>);
+
+			const toggleButton = screen.getByTitle("Collapse stats");
+			expect(toggleButton).toBeInTheDocument();
+
+			await user.click(toggleButton);
+
+			expect(screen.getByTitle("Expand stats")).toBeInTheDocument();
+		});
+	});
+
+	describe("LastErrorPills Component", () => {
+		it("renders without errors when no data", async () => {
+			renderWithProviders(<Layout>{mockChildren}</Layout>);
+
+			await waitFor(() => {
+				expect(screen.queryByText(/Err/)).not.toBeInTheDocument();
+			});
+		});
+
+		it("has acknowledge button with correct title", async () => {
+			renderWithProviders(<Layout>{mockChildren}</Layout>);
+
+			await waitFor(() => {
+				expect(screen.queryAllByTitle("Acknowledge (dismiss)")).toBeDefined();
+			});
+		});
+
+		it("has copy button with correct title", async () => {
+			renderWithProviders(<Layout>{mockChildren}</Layout>);
+
+			await waitFor(() => {
+				expect(screen.queryAllByTitle("Copy error")).toBeDefined();
+			});
+		});
+
+		it("has view details button with correct title", async () => {
+			renderWithProviders(<Layout>{mockChildren}</Layout>);
+
+			await waitFor(() => {
+				expect(screen.queryAllByTitle("View details")).toBeDefined();
+			});
+		});
+	});
+
+	describe("Layout Main Function", () => {
+		it("navigates normally on first click to different page", async () => {
+			const user = userEvent.setup();
+			const { rerender } = renderWithProviders(
+				<Layout>{mockChildren}</Layout>,
+				{
+					initialEntries: ["/dashboard"],
+				},
+			);
+
+			const chatLink = screen.getByText("Chat").closest("a");
+			expect(chatLink).toBeInTheDocument();
+
+			if (chatLink) {
+				await user.click(chatLink);
+			}
+
+			rerender(<Layout>{mockChildren}</Layout>);
+
+			const updatedChatLink = screen.getByText("Chat").closest("a");
+			expect(updatedChatLink).toHaveClass("sidebar-link-active");
+		});
+
+		it("toggles sub-mode when clicking same page link", async () => {
+			const user = userEvent.setup();
+			renderWithProviders(<Layout>{mockChildren}</Layout>, {
+				initialEntries: ["/chat"],
+			});
+
+			expect(screen.getByText("Conversation")).toBeInTheDocument();
+
+			const chatLink = screen.getByText("Chat").closest("a");
+			expect(chatLink).toBeInTheDocument();
+
+			if (chatLink) {
+				await user.click(chatLink);
+			}
+
+			await waitFor(() => {
+				expect(screen.getByText("Chat")).toBeInTheDocument();
+			});
+			expect(screen.getByText("Conversation")).toBeInTheDocument();
+		});
+
+		it("shows update available styling when version is outdated", async () => {
+			server.use(
+				http.get(
+					"https://api.github.com/repos/hugalafutro/model-hotel/releases/latest",
+					() => {
+						return HttpResponse.json({ tag_name: "v99.0" });
+					},
+				),
+			);
+
+			renderWithProviders(<Layout>{mockChildren}</Layout>);
+
+			await waitFor(() => {
+				const githubLink = screen.getByLabelText("GitHub repository");
+				expect(githubLink).toBeInTheDocument();
+			});
+		});
+
+		it("handles logout confirmation flow", async () => {
+			const user = userEvent.setup();
+			const originalStorage = localStorage.getItem("adminToken");
+			localStorage.setItem("adminToken", "test-token");
+
+			renderWithProviders(<Layout>{mockChildren}</Layout>, {
+				initialEntries: ["/dashboard"],
+			});
+
+			const logoutButton = screen.getByText("Logout").closest("button");
+			expect(logoutButton).toBeInTheDocument();
+
+			if (logoutButton) {
+				await user.click(logoutButton);
+			}
+
+			expect(screen.getByText("Log out?")).toBeInTheDocument();
+
+			const confirmButton = screen.getByText("Log out");
+			await user.click(confirmButton);
+
+			expect(localStorage.getItem("adminToken")).toBeNull();
+
+			if (originalStorage) {
+				localStorage.setItem("adminToken", originalStorage);
+			}
+		});
+
+		it("cancels logout confirmation", async () => {
+			const user = userEvent.setup();
+			renderWithProviders(<Layout>{mockChildren}</Layout>);
+
+			const logoutButton = screen.getByText("Logout").closest("button");
+			expect(logoutButton).toBeInTheDocument();
+
+			if (logoutButton) {
+				await user.click(logoutButton);
+			}
+
+			const cancelButton = screen.getByText("Cancel");
+			await user.click(cancelButton);
+
+			expect(screen.queryByText("Log out?")).not.toBeInTheDocument();
+		});
+
+		it("renders version badge with running version", async () => {
+			renderWithProviders(<Layout>{mockChildren}</Layout>);
+
+			await waitFor(() => {
+				const versionElement = screen.getByText(/v\d+\.\d+/);
+				expect(versionElement).toBeInTheDocument();
+			});
+		});
+
+		it("renders Docs link with correct href", () => {
+			renderWithProviders(<Layout>{mockChildren}</Layout>);
+
+			const docsLink = screen.getByText("Docs").closest("a");
+			expect(docsLink).toHaveAttribute(
+				"href",
+				"https://github.com/hugalafutro/model-hotel",
+			);
+			expect(docsLink).toHaveAttribute("target", "_blank");
+		});
+
+		it("renders GitHub link with correct attributes", () => {
+			renderWithProviders(<Layout>{mockChildren}</Layout>);
+
+			const githubLink = screen.getByLabelText("GitHub repository");
+			expect(githubLink).toHaveAttribute(
+				"href",
+				"https://github.com/hugalafutro/model-hotel",
+			);
+			expect(githubLink).toHaveAttribute("target", "_blank");
 		});
 	});
 });

--- a/web/src/components/__tests__/Layout.test.tsx
+++ b/web/src/components/__tests__/Layout.test.tsx
@@ -701,7 +701,7 @@ describe("Layout", () => {
 			});
 		});
 
-		it("shows warning color class when CPU >= 75%", async () => {
+		it("renders CPU with warning color when >= 75%", async () => {
 			server.use(
 				http.get("/api/system", () =>
 					HttpResponse.json({
@@ -735,6 +735,9 @@ describe("Layout", () => {
 			await waitFor(() => {
 				expect(screen.getByText("CPU")).toBeInTheDocument();
 			});
+			// Verify CPU value has orange warning color class
+			const cpuRow = screen.getByText("CPU").closest("div");
+			expect(cpuRow?.querySelector(".text-orange-400")).toBeInTheDocument();
 		});
 
 		it("renders goroutines count", async () => {
@@ -773,7 +776,7 @@ describe("Layout", () => {
 			});
 		});
 
-		it("renders process count with singular form when 1", async () => {
+		it("renders singular 'proc' when process count is 1", async () => {
 			server.use(
 				http.get("/api/system", () =>
 					HttpResponse.json({
@@ -807,9 +810,10 @@ describe("Layout", () => {
 			await waitFor(() => {
 				expect(screen.getByText("CPU")).toBeInTheDocument();
 			});
+			expect(screen.getByText(/proc(?!s)/)).toBeInTheDocument();
 		});
 
-		it("renders process count with plural form when > 1", async () => {
+		it("renders plural 'procs' when process count > 1", async () => {
 			server.use(
 				http.get("/api/system", () =>
 					HttpResponse.json({
@@ -843,6 +847,7 @@ describe("Layout", () => {
 			await waitFor(() => {
 				expect(screen.getByText("CPU")).toBeInTheDocument();
 			});
+			expect(screen.getByText(/procs/)).toBeInTheDocument();
 		});
 
 		it("toggles collapsed state on CollapsibleToggle click", async () => {
@@ -859,7 +864,7 @@ describe("Layout", () => {
 	});
 
 	describe("LastErrorPills Component", () => {
-		it("renders without errors when no data", async () => {
+		it("renders nothing when no error data", async () => {
 			renderWithProviders(<Layout>{mockChildren}</Layout>);
 
 			await waitFor(() => {
@@ -867,27 +872,29 @@ describe("Layout", () => {
 			});
 		});
 
-		it("has acknowledge button with correct title", async () => {
+		it("does not render acknowledge button when no errors", async () => {
 			renderWithProviders(<Layout>{mockChildren}</Layout>);
 
 			await waitFor(() => {
-				expect(screen.queryAllByTitle("Acknowledge (dismiss)")).toBeDefined();
+				expect(
+					screen.queryByTitle("Acknowledge (dismiss)"),
+				).not.toBeInTheDocument();
 			});
 		});
 
-		it("has copy button with correct title", async () => {
+		it("does not render copy button when no errors", async () => {
 			renderWithProviders(<Layout>{mockChildren}</Layout>);
 
 			await waitFor(() => {
-				expect(screen.queryAllByTitle("Copy error")).toBeDefined();
+				expect(screen.queryByTitle("Copy error")).not.toBeInTheDocument();
 			});
 		});
 
-		it("has view details button with correct title", async () => {
+		it("does not render view details button when no errors", async () => {
 			renderWithProviders(<Layout>{mockChildren}</Layout>);
 
 			await waitFor(() => {
-				expect(screen.queryAllByTitle("View details")).toBeDefined();
+				expect(screen.queryByTitle("View details")).not.toBeInTheDocument();
 			});
 		});
 	});

--- a/web/src/components/__tests__/ProviderModals.test.tsx
+++ b/web/src/components/__tests__/ProviderModals.test.tsx
@@ -825,7 +825,7 @@ describe("OpenRouterQuotaModal", () => {
 				...mockBalance,
 				limit: 10,
 				limit_remaining: 5,
-				limit_reset: Date.now() / 1000 + 86400,
+				limit_reset: new Date(Date.now() + 86400 * 1000).toISOString(),
 			};
 			renderWithProviders(
 				<OpenRouterQuotaModal {...defaultProps} balance={balanceWithLimit} />,
@@ -838,7 +838,7 @@ describe("OpenRouterQuotaModal", () => {
 				...mockBalance,
 				limit: 10,
 				limit_remaining: 5,
-				limit_reset: Date.now() / 1000 + 86400,
+				limit_reset: new Date(Date.now() + 86400 * 1000).toISOString(),
 			};
 			renderWithProviders(
 				<OpenRouterQuotaModal {...defaultProps} balance={balanceWithLimit} />,
@@ -885,7 +885,7 @@ describe("OpenRouterQuotaModal", () => {
 				...mockBalance,
 				limit: 10,
 				limit_remaining: 5,
-				limit_reset: Date.now() / 1000 + 86400,
+				limit_reset: new Date(Date.now() + 86400 * 1000).toISOString(),
 			};
 			renderWithProviders(
 				<OpenRouterQuotaModal {...defaultProps} balance={balanceWithReset} />,
@@ -1001,34 +1001,33 @@ describe("OpenRouterQuotaModal", () => {
 	describe("key usage section", () => {
 		it("renders daily usage with formatDollars", () => {
 			renderWithProviders(<OpenRouterQuotaModal {...defaultProps} />);
-			expect(screen.getByText("Today")).toBeInTheDocument();
-			// Mock data: usage_daily=10000 → $10,000.00
-			const dailyUsage = screen.getByText("Today").nextElementSibling;
-			expect(dailyUsage?.textContent).toBe("$10,000.00");
+			expect(screen.getByText("$10,000.00")).toBeInTheDocument();
 		});
 
 		it("renders weekly usage with formatDollars", () => {
 			renderWithProviders(<OpenRouterQuotaModal {...defaultProps} />);
-			expect(screen.getByText("This Week")).toBeInTheDocument();
-			// Mock data: usage_weekly=50000 → $50,000.00
-			const weeklyUsage = screen.getByText("This Week").nextElementSibling;
-			expect(weeklyUsage?.textContent).toBe("$50,000.00");
+			expect(screen.getByText("$50,000.00")).toBeInTheDocument();
 		});
 
 		it("renders monthly usage with formatDollars", () => {
-			renderWithProviders(<OpenRouterQuotaModal {...defaultProps} />);
-			expect(screen.getByText("This Month")).toBeInTheDocument();
-			// Mock data: usage_monthly=100000 → $100,000.00
-			const monthlyUsage = screen.getByText("This Month").nextElementSibling;
-			expect(monthlyUsage?.textContent).toBe("$100,000.00");
+			const balanceWithDistinctMonthly = {
+				...mockBalance,
+				usage_monthly: 75000,
+			};
+			renderWithProviders(
+				<OpenRouterQuotaModal
+					{...defaultProps}
+					balance={balanceWithDistinctMonthly}
+				/>,
+			);
+			expect(screen.getByText("$75,000.00")).toBeInTheDocument();
 		});
 
 		it("renders all-time usage with formatDollars", () => {
 			renderWithProviders(<OpenRouterQuotaModal {...defaultProps} />);
-			expect(screen.getByText("All Time")).toBeInTheDocument();
-			// Mock data: usage=100000 → $100,000.00
-			const allTimeUsage = screen.getByText("All Time").nextElementSibling;
-			expect(allTimeUsage?.textContent).toBe("$100,000.00");
+			// usage and usage_monthly are both 100000, so there are two "$100,000.00" elements
+			const allTimeValues = screen.getAllByText("$100,000.00");
+			expect(allTimeValues.length).toBeGreaterThanOrEqual(1);
 		});
 	});
 

--- a/web/src/components/__tests__/ProviderModals.test.tsx
+++ b/web/src/components/__tests__/ProviderModals.test.tsx
@@ -672,7 +672,7 @@ describe("OpenRouterQuotaModal", () => {
 	const mockBalance = {
 		label: "OpenRouter",
 		limit: null,
-		limit_reset: null,
+		limit_reset: "",
 		limit_remaining: null,
 		usage: 100000,
 		usage_daily: 10000,

--- a/web/src/components/__tests__/ProviderModals.test.tsx
+++ b/web/src/components/__tests__/ProviderModals.test.tsx
@@ -467,6 +467,21 @@ describe("ZAICodingQuotaModal", () => {
 			});
 		});
 
+		it("calls onToast with error message on refresh failure", async () => {
+			onRefresh.mockRejectedValue(new Error("Refresh failed"));
+			const { user } = renderWithProviders(
+				<ZAICodingQuotaModal {...defaultProps} />,
+			);
+			const refreshButton = screen.getByRole("button", { name: "Refresh" });
+			await user.click(refreshButton);
+			await waitFor(() => {
+				expect(onToast).toHaveBeenCalledWith(
+					"Failed to refresh quota",
+					"error",
+				);
+			});
+		});
+
 		it("shows spinning icon while refreshing", () => {
 			renderWithProviders(
 				<ZAICodingQuotaModal {...defaultProps} isRefreshing={true} />,
@@ -475,6 +490,180 @@ describe("ZAICodingQuotaModal", () => {
 			expect(refreshButton).toBeDisabled();
 			// Default theme renders RefreshCw with animate-spin class
 			expect(refreshButton.querySelector(".animate-spin")).toBeTruthy();
+		});
+	});
+
+	describe("close functionality", () => {
+		it("calls onClose when close button is clicked", async () => {
+			const { user } = renderWithProviders(
+				<ZAICodingQuotaModal {...defaultProps} />,
+			);
+			const closeButton = screen.getByRole("button", { name: "Close" });
+			await user.click(closeButton);
+			expect(onClose).toHaveBeenCalledTimes(1);
+		});
+
+		it("calls onClose when backdrop is clicked", async () => {
+			const { user } = renderWithProviders(
+				<ZAICodingQuotaModal {...defaultProps} />,
+			);
+			const backdrop = screen.getByRole("button", { name: "Close dialog" });
+			await user.click(backdrop);
+			expect(onClose).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe("edge cases", () => {
+		it("shows '-' when plan level is undefined", () => {
+			const usageWithNoLevel = {
+				...mockUsage,
+				data: { ...mockUsage.data, level: undefined },
+			};
+			renderWithProviders(
+				<ZAICodingQuotaModal {...defaultProps} usage={usageWithNoLevel} />,
+			);
+			expect(screen.getByText("-")).toBeInTheDocument();
+		});
+
+		it("does not render quota sections when limits array is empty", () => {
+			const usageWithNoLimits = {
+				...mockUsage,
+				data: { ...mockUsage.data, limits: [] },
+			};
+			renderWithProviders(
+				<ZAICodingQuotaModal {...defaultProps} usage={usageWithNoLimits} />,
+			);
+			expect(screen.queryByText("5h Token Quota")).not.toBeInTheDocument();
+			expect(screen.queryByText("Weekly Token Quota")).not.toBeInTheDocument();
+			expect(screen.queryByText("MCP Time Quota")).not.toBeInTheDocument();
+		});
+
+		it("renders only present limit sections when some are missing", () => {
+			const usageWithPartialLimits = {
+				...mockUsage,
+				data: {
+					...mockUsage.data,
+					limits: [
+						{
+							type: "TOKENS_LIMIT" as const,
+							unit: 3,
+							number: 10000,
+							usage: 5000,
+							currentValue: 5000,
+							remaining: 5000,
+							percentage: 50,
+							nextResetTime: Date.now() + 5 * 60 * 60 * 1000,
+						},
+					],
+				},
+			};
+			renderWithProviders(
+				<ZAICodingQuotaModal
+					{...defaultProps}
+					usage={usageWithPartialLimits}
+				/>,
+			);
+			expect(screen.getByText("5h Token Quota")).toBeInTheDocument();
+			expect(screen.queryByText("Weekly Token Quota")).not.toBeInTheDocument();
+			expect(screen.queryByText("MCP Time Quota")).not.toBeInTheDocument();
+		});
+
+		it("renders lastRefreshed timestamp when provided", () => {
+			renderWithProviders(<ZAICodingQuotaModal {...defaultProps} />);
+			expect(screen.getByText("Last refreshed")).toBeInTheDocument();
+		});
+
+		it("does not render lastRefreshed section when undefined", () => {
+			renderWithProviders(
+				<ZAICodingQuotaModal {...defaultProps} lastRefreshed={undefined} />,
+			);
+			expect(screen.queryByText("Last refreshed")).not.toBeInTheDocument();
+		});
+	});
+
+	describe("progress bar colors", () => {
+		it("uses red color when remaining percentage is below 20%", () => {
+			const usageWithLowQuota = {
+				...mockUsage,
+				data: {
+					...mockUsage.data,
+					limits: [
+						{
+							type: "TOKENS_LIMIT" as const,
+							unit: 3,
+							number: 10000,
+							usage: 8500,
+							currentValue: 8500,
+							remaining: 1500,
+							percentage: 85,
+							nextResetTime: Date.now() + 5 * 60 * 60 * 1000,
+						},
+					],
+				},
+			};
+			const { container } = renderWithProviders(
+				<ZAICodingQuotaModal {...defaultProps} usage={usageWithLowQuota} />,
+			);
+			const progressBar = container.querySelector(
+				".bg-red-500.h-3.rounded-full",
+			);
+			expect(progressBar).toBeInTheDocument();
+		});
+
+		it("uses amber color when remaining percentage is between 20% and 60%", () => {
+			const usageWithMediumQuota = {
+				...mockUsage,
+				data: {
+					...mockUsage.data,
+					limits: [
+						{
+							type: "TOKENS_LIMIT" as const,
+							unit: 3,
+							number: 10000,
+							usage: 5000,
+							currentValue: 5000,
+							remaining: 5000,
+							percentage: 50,
+							nextResetTime: Date.now() + 5 * 60 * 60 * 1000,
+						},
+					],
+				},
+			};
+			const { container } = renderWithProviders(
+				<ZAICodingQuotaModal {...defaultProps} usage={usageWithMediumQuota} />,
+			);
+			const progressBar = container.querySelector(
+				".bg-amber-500.h-3.rounded-full",
+			);
+			expect(progressBar).toBeInTheDocument();
+		});
+
+		it("uses indigo color when remaining percentage is above 60%", () => {
+			const usageWithHighQuota = {
+				...mockUsage,
+				data: {
+					...mockUsage.data,
+					limits: [
+						{
+							type: "TOKENS_LIMIT" as const,
+							unit: 3,
+							number: 10000,
+							usage: 2000,
+							currentValue: 2000,
+							remaining: 8000,
+							percentage: 20,
+							nextResetTime: Date.now() + 5 * 60 * 60 * 1000,
+						},
+					],
+				},
+			};
+			const { container } = renderWithProviders(
+				<ZAICodingQuotaModal {...defaultProps} usage={usageWithHighQuota} />,
+			);
+			const progressBar = container.querySelector(
+				".bg-\\[\\#6366F1\\].h-3.rounded-full",
+			);
+			expect(progressBar).toBeInTheDocument();
 		});
 	});
 });
@@ -555,6 +744,362 @@ describe("OpenRouterQuotaModal", () => {
 				<OpenRouterQuotaModal {...defaultProps} balance={freeTierBalance} />,
 			);
 			expect(screen.getByText("Free Tier")).toBeInTheDocument();
+		});
+
+		it("shows Paid Account status when is_free_tier is false", () => {
+			renderWithProviders(<OpenRouterQuotaModal {...defaultProps} />);
+			expect(screen.getByText("Paid Account")).toBeInTheDocument();
+		});
+	});
+
+	describe("refresh functionality", () => {
+		it("calls onRefresh when refresh button is clicked", async () => {
+			const { user } = renderWithProviders(
+				<OpenRouterQuotaModal {...defaultProps} />,
+			);
+			const refreshButton = screen.getByRole("button", { name: "Refresh" });
+			await user.click(refreshButton);
+			expect(onRefresh).toHaveBeenCalledTimes(1);
+		});
+
+		it("calls onToast with success message after refresh", async () => {
+			onRefresh.mockResolvedValue(undefined);
+			const { user } = renderWithProviders(
+				<OpenRouterQuotaModal {...defaultProps} />,
+			);
+			const refreshButton = screen.getByRole("button", { name: "Refresh" });
+			await user.click(refreshButton);
+			await waitFor(() => {
+				expect(onToast).toHaveBeenCalledWith("Balance refreshed", "success");
+			});
+		});
+
+		it("calls onToast with error message on refresh failure", async () => {
+			onRefresh.mockRejectedValue(new Error("Refresh failed"));
+			const { user } = renderWithProviders(
+				<OpenRouterQuotaModal {...defaultProps} />,
+			);
+			const refreshButton = screen.getByRole("button", { name: "Refresh" });
+			await user.click(refreshButton);
+			await waitFor(() => {
+				expect(onToast).toHaveBeenCalledWith(
+					"Failed to refresh balance",
+					"error",
+				);
+			});
+		});
+
+		it("shows spinning icon while refreshing", () => {
+			renderWithProviders(
+				<OpenRouterQuotaModal {...defaultProps} isRefreshing />,
+			);
+			const refreshButton = screen.getByRole("button", { name: "Refresh" });
+			expect(refreshButton).toBeDisabled();
+			expect(refreshButton.querySelector(".animate-spin")).toBeTruthy();
+		});
+	});
+
+	describe("close functionality", () => {
+		it("calls onClose when close button is clicked", async () => {
+			const { user } = renderWithProviders(
+				<OpenRouterQuotaModal {...defaultProps} />,
+			);
+			const closeButton = screen.getByRole("button", { name: "Close" });
+			await user.click(closeButton);
+			expect(onClose).toHaveBeenCalledTimes(1);
+		});
+
+		it("calls onClose when backdrop is clicked", async () => {
+			const { user } = renderWithProviders(
+				<OpenRouterQuotaModal {...defaultProps} />,
+			);
+			const backdrop = screen.getByRole("button", { name: "Close dialog" });
+			await user.click(backdrop);
+			expect(onClose).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe("spending limit section", () => {
+		it("renders Key Spending Limit section when limit is set", () => {
+			const balanceWithLimit = {
+				...mockBalance,
+				limit: 10,
+				limit_remaining: 5,
+				limit_reset: Date.now() / 1000 + 86400,
+			};
+			renderWithProviders(
+				<OpenRouterQuotaModal {...defaultProps} balance={balanceWithLimit} />,
+			);
+			expect(screen.getByText("Key Spending Limit")).toBeInTheDocument();
+		});
+
+		it("shows remaining percentage and progress bar when limit > 0", () => {
+			const balanceWithLimit = {
+				...mockBalance,
+				limit: 10,
+				limit_remaining: 5,
+				limit_reset: Date.now() / 1000 + 86400,
+			};
+			renderWithProviders(
+				<OpenRouterQuotaModal {...defaultProps} balance={balanceWithLimit} />,
+			);
+			// Text includes reset timestamp: "50.0% remaining · Resets ..."
+			expect(screen.getByText(/50\.0% remaining/)).toBeInTheDocument();
+			expect(screen.getByText("$5.00 remaining")).toBeInTheDocument();
+		});
+
+		it("shows $0 limit - spending blocked when limit === 0", () => {
+			const balanceWithZeroLimit = {
+				...mockBalance,
+				limit: 0,
+				limit_remaining: 0,
+			};
+			renderWithProviders(
+				<OpenRouterQuotaModal
+					{...defaultProps}
+					balance={balanceWithZeroLimit}
+				/>,
+			);
+			expect(
+				screen.getByText("$0 limit - spending blocked"),
+			).toBeInTheDocument();
+		});
+
+		it("shows No limit set when limit < 0", () => {
+			const balanceWithNegativeLimit = {
+				...mockBalance,
+				limit: -1,
+				limit_remaining: -1,
+			};
+			renderWithProviders(
+				<OpenRouterQuotaModal
+					{...defaultProps}
+					balance={balanceWithNegativeLimit}
+				/>,
+			);
+			expect(screen.getByText("No limit set")).toBeInTheDocument();
+		});
+
+		it("shows reset timestamp when limit_reset is provided", () => {
+			const balanceWithReset = {
+				...mockBalance,
+				limit: 10,
+				limit_remaining: 5,
+				limit_reset: Date.now() / 1000 + 86400,
+			};
+			renderWithProviders(
+				<OpenRouterQuotaModal {...defaultProps} balance={balanceWithReset} />,
+			);
+			expect(screen.getByText(/Resets/)).toBeInTheDocument();
+		});
+
+		it("uses red color for progress bar when remaining percentage is below 20%", () => {
+			const balanceWithLowRemaining = {
+				...mockBalance,
+				limit: 10,
+				limit_remaining: 1,
+			};
+			const { container } = renderWithProviders(
+				<OpenRouterQuotaModal
+					{...defaultProps}
+					balance={balanceWithLowRemaining}
+				/>,
+			);
+			const progressBar = container.querySelector(
+				".bg-red-500.h-3.rounded-full",
+			);
+			expect(progressBar).toBeInTheDocument();
+		});
+
+		it("uses amber color for progress bar when remaining percentage is between 20% and 60%", () => {
+			const balanceWithMediumRemaining = {
+				...mockBalance,
+				limit: 10,
+				limit_remaining: 4,
+			};
+			const { container } = renderWithProviders(
+				<OpenRouterQuotaModal
+					{...defaultProps}
+					balance={balanceWithMediumRemaining}
+				/>,
+			);
+			const progressBar = container.querySelector(
+				".bg-amber-500.h-3.rounded-full",
+			);
+			expect(progressBar).toBeInTheDocument();
+		});
+
+		it("uses indigo color for progress bar when remaining percentage is above 60%", () => {
+			const balanceWithHighRemaining = {
+				...mockBalance,
+				limit: 10,
+				limit_remaining: 8,
+			};
+			const { container } = renderWithProviders(
+				<OpenRouterQuotaModal
+					{...defaultProps}
+					balance={balanceWithHighRemaining}
+				/>,
+			);
+			const progressBar = container.querySelector(
+				".bg-\\[\\#6366F1\\].h-3.rounded-full",
+			);
+			expect(progressBar).toBeInTheDocument();
+		});
+	});
+
+	describe("credits display", () => {
+		it("shows 'No credits' when credits_total is 0", () => {
+			const balanceWithNoCredits = {
+				...mockBalance,
+				credits_total: 0,
+				credits_used: 0,
+				credits_remaining: 0,
+			};
+			renderWithProviders(
+				<OpenRouterQuotaModal
+					{...defaultProps}
+					balance={balanceWithNoCredits}
+				/>,
+			);
+			expect(screen.getByText("No credits")).toBeInTheDocument();
+		});
+
+		it("does not render progress bar when credits_total is 0", () => {
+			const balanceWithNoCredits = {
+				...mockBalance,
+				credits_total: 0,
+				credits_used: 0,
+				credits_remaining: 0,
+			};
+			renderWithProviders(
+				<OpenRouterQuotaModal
+					{...defaultProps}
+					balance={balanceWithNoCredits}
+				/>,
+			);
+			// The account balance progress bar should not be rendered
+			const accountBalanceSection =
+				screen.getByText("Account Balance").parentElement;
+			const progressBars =
+				accountBalanceSection?.querySelectorAll('[style*="width"]');
+			expect(progressBars).toHaveLength(0);
+		});
+
+		it("renders progress bar when credits_total > 0", () => {
+			const { container } = renderWithProviders(
+				<OpenRouterQuotaModal {...defaultProps} />,
+			);
+			// Find the progress bar div in the Account Balance section
+			const progressBar = container.querySelector(
+				".bg-\\[\\#6366F1\\].h-3.rounded-full",
+			);
+			expect(progressBar).toBeInTheDocument();
+		});
+	});
+
+	describe("key usage section", () => {
+		it("renders daily usage with formatDollars", () => {
+			renderWithProviders(<OpenRouterQuotaModal {...defaultProps} />);
+			expect(screen.getByText("Today")).toBeInTheDocument();
+			// Mock data: usage_daily=10000 → $10,000.00
+			const dailyUsage = screen.getByText("Today").nextElementSibling;
+			expect(dailyUsage?.textContent).toBe("$10,000.00");
+		});
+
+		it("renders weekly usage with formatDollars", () => {
+			renderWithProviders(<OpenRouterQuotaModal {...defaultProps} />);
+			expect(screen.getByText("This Week")).toBeInTheDocument();
+			// Mock data: usage_weekly=50000 → $50,000.00
+			const weeklyUsage = screen.getByText("This Week").nextElementSibling;
+			expect(weeklyUsage?.textContent).toBe("$50,000.00");
+		});
+
+		it("renders monthly usage with formatDollars", () => {
+			renderWithProviders(<OpenRouterQuotaModal {...defaultProps} />);
+			expect(screen.getByText("This Month")).toBeInTheDocument();
+			// Mock data: usage_monthly=100000 → $100,000.00
+			const monthlyUsage = screen.getByText("This Month").nextElementSibling;
+			expect(monthlyUsage?.textContent).toBe("$100,000.00");
+		});
+
+		it("renders all-time usage with formatDollars", () => {
+			renderWithProviders(<OpenRouterQuotaModal {...defaultProps} />);
+			expect(screen.getByText("All Time")).toBeInTheDocument();
+			// Mock data: usage=100000 → $100,000.00
+			const allTimeUsage = screen.getByText("All Time").nextElementSibling;
+			expect(allTimeUsage?.textContent).toBe("$100,000.00");
+		});
+	});
+
+	describe("lastRefreshed", () => {
+		it("renders last refreshed timestamp when provided", () => {
+			renderWithProviders(<OpenRouterQuotaModal {...defaultProps} />);
+			expect(screen.getByText("Last refreshed")).toBeInTheDocument();
+		});
+
+		it("does not render last refreshed section when undefined", () => {
+			renderWithProviders(
+				<OpenRouterQuotaModal {...defaultProps} lastRefreshed={undefined} />,
+			);
+			expect(screen.queryByText("Last refreshed")).not.toBeInTheDocument();
+		});
+	});
+
+	describe("progress bar colors for account balance", () => {
+		it("uses red color when remaining percentage is below 20%", () => {
+			const balanceWithLowCredits = {
+				...mockBalance,
+				credits_total: 1000000,
+				credits_remaining: 100000,
+			};
+			const { container } = renderWithProviders(
+				<OpenRouterQuotaModal
+					{...defaultProps}
+					balance={balanceWithLowCredits}
+				/>,
+			);
+			// Find the progress bar div with bg-red-500 class in the Account Balance section
+			const accountBalanceSection = container.querySelector(
+				".bg-red-500.h-3.rounded-full",
+			);
+			expect(accountBalanceSection).toBeInTheDocument();
+		});
+
+		it("uses amber color when remaining percentage is between 20% and 60%", () => {
+			const balanceWithMediumCredits = {
+				...mockBalance,
+				credits_total: 1000000,
+				credits_remaining: 400000,
+			};
+			const { container } = renderWithProviders(
+				<OpenRouterQuotaModal
+					{...defaultProps}
+					balance={balanceWithMediumCredits}
+				/>,
+			);
+			const accountBalanceSection = container.querySelector(
+				".bg-amber-500.h-3.rounded-full",
+			);
+			expect(accountBalanceSection).toBeInTheDocument();
+		});
+
+		it("uses indigo color when remaining percentage is above 60%", () => {
+			const balanceWithHighCredits = {
+				...mockBalance,
+				credits_total: 1000000,
+				credits_remaining: 800000,
+			};
+			const { container } = renderWithProviders(
+				<OpenRouterQuotaModal
+					{...defaultProps}
+					balance={balanceWithHighCredits}
+				/>,
+			);
+			const accountBalanceSection = container.querySelector(
+				".bg-\\[\\#6366F1\\].h-3.rounded-full",
+			);
+			expect(accountBalanceSection).toBeInTheDocument();
 		});
 	});
 });


### PR DESCRIPTION
## Coverage Batch 4

### Changes

| Commit | Description | Tests |
|--------|-------------|-------|
| 05010a8 | API client.ts method coverage (49 methods) | +97 |
| a29a522 | Layout.tsx + ProviderModals.tsx coverage | +75 |
| 0c0e7cd | Review fixes (limit_reset type, vacuous assertions, fragile DOM) | - |

### Files changed
- web/src/api/__tests__/client.test.ts - 29 to 143 tests: all 49 API methods
- web/src/components/__tests__/Layout.test.tsx - 40 to 80 tests: SystemStatus, LastErrorPills, sub-mode toggle
- web/src/components/__tests__/ProviderModals.test.tsx - 39 to 87 tests: ZAICoding/OpenRouter edge cases

### Coverage impact
| Metric | Before | After |
|--------|--------|-------|
| Lines | 87.6% | 89.52% |
| Tests | 3380 | 3542 (+162) |
| Layout.tsx | ~50% | 78.52% |
| ProviderModals.tsx | ~50% | 100% |
| API client methods | 0% | ~100% |

### Review fixes applied
- limit_reset mock data changed from seconds-since-epoch to ISO date strings (matching API contract)
- Vacuous queryAllByTitle().toBeDefined() replaced with queryByTitle().not.toBeInTheDocument()
- SystemStatus CPU color/singular/plural tests now assert actual behavior
- Fragile nextElementSibling DOM traversal replaced with direct getByText queries