### PR TITLE
feat: add coverage tests for VirtualLogTable, VirtualModelTable, ModelDetailPanel

### DIFF
--- a/web/src/components/VirtualModelTable.tsx
+++ b/web/src/components/VirtualModelTable.tsx
@@ -189,14 +189,10 @@ export function VirtualModelTable({
 	const existingCaps = useMemo(() => {
 		const caps = new Set<CapKey>();
 		entries.forEach((m) => {
-			try {
-				const c = parseCapabilities(m.capabilities);
-				CAP_META.forEach((meta) => {
-					if (hasCap(c, meta.key)) caps.add(meta.key);
-				});
-			} catch {
-				// skip models with unparseable capabilities
-			}
+			const c = parseCapabilities(m.capabilities);
+			CAP_META.forEach((meta) => {
+				if (hasCap(c, meta.key)) caps.add(meta.key);
+			});
 		});
 		return caps;
 	}, [entries]);

--- a/web/src/components/__tests__/ModelDetailPanel.test.tsx
+++ b/web/src/components/__tests__/ModelDetailPanel.test.tsx
@@ -514,6 +514,226 @@ describe("ModelDetailPanel", () => {
 		expect(screen.getByText("Max Tokens")).toBeInTheDocument();
 		expect(screen.getByText("Top K")).toBeInTheDocument();
 	});
+
+	it("calls onParamsChange with max_tokens when Max Tokens slider is changed", async () => {
+		const user = userEvent.setup();
+		const onParamsChange = vi.fn();
+		renderWithProviders(
+			<ModelDetailPanel
+				{...defaultProps}
+				params={{}}
+				onParamsChange={onParamsChange}
+			/>,
+		);
+
+		await user.click(
+			screen.getByRole("button", { name: /Generation parameters/i }),
+		);
+		const numberInputs = screen.getAllByRole("spinbutton");
+		await user.clear(numberInputs[1]);
+		await user.type(numberInputs[1], "1024");
+
+		expect(onParamsChange).toHaveBeenCalled();
+		const lastCall = onParamsChange.mock.calls.at(-1)[0];
+		expect(lastCall).toHaveProperty("max_tokens");
+	});
+
+	it("calls onParamsChange with top_p when Top P slider is changed", async () => {
+		const user = userEvent.setup();
+		const onParamsChange = vi.fn();
+		renderWithProviders(
+			<ModelDetailPanel
+				{...defaultProps}
+				params={{}}
+				onParamsChange={onParamsChange}
+			/>,
+		);
+
+		await user.click(
+			screen.getByRole("button", { name: /Generation parameters/i }),
+		);
+		const numberInputs = screen.getAllByRole("spinbutton");
+		await user.clear(numberInputs[2]);
+		await user.type(numberInputs[2], "0.9");
+
+		expect(onParamsChange).toHaveBeenCalled();
+		const lastCall = onParamsChange.mock.calls.at(-1)[0];
+		expect(lastCall).toHaveProperty("top_p");
+	});
+
+	it("calls onParamsChange with min_p when Min P slider is changed", async () => {
+		const user = userEvent.setup();
+		const onParamsChange = vi.fn();
+		renderWithProviders(
+			<ModelDetailPanel
+				{...defaultProps}
+				params={{}}
+				onParamsChange={onParamsChange}
+			/>,
+		);
+
+		await user.click(
+			screen.getByRole("button", { name: /Generation parameters/i }),
+		);
+		const numberInputs = screen.getAllByRole("spinbutton");
+		await user.clear(numberInputs[3]);
+		await user.type(numberInputs[3], "0.1");
+
+		expect(onParamsChange).toHaveBeenCalled();
+		const lastCall = onParamsChange.mock.calls.at(-1)[0];
+		expect(lastCall).toHaveProperty("min_p");
+	});
+
+	it("calls onParamsChange with top_k when Top K slider is changed", async () => {
+		const user = userEvent.setup();
+		const onParamsChange = vi.fn();
+		renderWithProviders(
+			<ModelDetailPanel
+				{...defaultProps}
+				params={{}}
+				onParamsChange={onParamsChange}
+			/>,
+		);
+
+		await user.click(
+			screen.getByRole("button", { name: /Generation parameters/i }),
+		);
+		const numberInputs = screen.getAllByRole("spinbutton");
+		await user.clear(numberInputs[4]);
+		await user.type(numberInputs[4], "50");
+
+		expect(onParamsChange).toHaveBeenCalled();
+		const lastCall = onParamsChange.mock.calls.at(-1)[0];
+		expect(lastCall).toHaveProperty("top_k");
+	});
+
+	it("calls onParamsChange with frequency_penalty when Freq Penalty slider is changed", async () => {
+		const user = userEvent.setup();
+		const onParamsChange = vi.fn();
+		renderWithProviders(
+			<ModelDetailPanel
+				{...defaultProps}
+				params={{}}
+				onParamsChange={onParamsChange}
+			/>,
+		);
+
+		await user.click(
+			screen.getByRole("button", { name: /Generation parameters/i }),
+		);
+		const numberInputs = screen.getAllByRole("spinbutton");
+		await user.clear(numberInputs[5]);
+		await user.type(numberInputs[5], "0.5");
+
+		expect(onParamsChange).toHaveBeenCalled();
+		const lastCall = onParamsChange.mock.calls.at(-1)[0];
+		expect(lastCall).toHaveProperty("frequency_penalty");
+	});
+
+	it("calls onParamsChange with presence_penalty when Pres Penalty slider is changed", async () => {
+		const user = userEvent.setup();
+		const onParamsChange = vi.fn();
+		renderWithProviders(
+			<ModelDetailPanel
+				{...defaultProps}
+				params={{}}
+				onParamsChange={onParamsChange}
+			/>,
+		);
+
+		await user.click(
+			screen.getByRole("button", { name: /Generation parameters/i }),
+		);
+		const numberInputs = screen.getAllByRole("spinbutton");
+		await user.clear(numberInputs[6]);
+		await user.type(numberInputs[6], "0.3");
+
+		expect(onParamsChange).toHaveBeenCalled();
+		const lastCall = onParamsChange.mock.calls.at(-1)[0];
+		expect(lastCall).toHaveProperty("presence_penalty");
+	});
+
+	it("calls onParamsChange with reasoning_effort when ReasoningEffortSelect is changed", async () => {
+		const user = userEvent.setup();
+		const onParamsChange = vi.fn();
+		const reasoningModel = {
+			...mockModel,
+			capabilities: '{"reasoning":true}',
+			provider_name: "OpenAI",
+		};
+		renderWithProviders(
+			<ModelDetailPanel
+				model={reasoningModel}
+				params={{}}
+				onParamsChange={onParamsChange}
+			/>,
+		);
+
+		await user.click(
+			screen.getByRole("button", { name: /Generation parameters/i }),
+		);
+		await user.click(screen.getByRole("button", { name: /Medium/i }));
+
+		expect(onParamsChange).toHaveBeenCalled();
+		const lastCall = onParamsChange.mock.calls.at(-1)[0];
+		expect(lastCall).toHaveProperty("reasoning_effort");
+	});
+
+	it("shows reset button when max_tokens is set", () => {
+		const onParamsChange = vi.fn();
+		renderWithProviders(
+			<ModelDetailPanel
+				{...defaultProps}
+				params={{ max_tokens: 100 }}
+				onParamsChange={onParamsChange}
+			/>,
+		);
+
+		expect(
+			screen.getByRole("button", { name: /Reset parameters/i }),
+		).toBeInTheDocument();
+	});
+
+	it("shows accent glow on settings cog when custom params are set but panel is closed", () => {
+		const onParamsChange = vi.fn();
+		renderWithProviders(
+			<ModelDetailPanel
+				{...defaultProps}
+				params={{ top_p: 0.9 }}
+				onParamsChange={onParamsChange}
+			/>,
+		);
+
+		const cogButton = screen.getByRole("button", {
+			name: /Generation parameters/i,
+		});
+		expect(cogButton).toHaveClass("text-(--accent)");
+	});
+
+	it("displays dash when context_length is null", () => {
+		const modelWithNullContext = {
+			...mockModel,
+			context_length: null,
+		};
+		renderWithProviders(<ModelDetailPanel model={modelWithNullContext} />);
+
+		// Find the "Context" label, then the value in the same div
+		const contextLabel = screen.getByText("Context");
+		const contextValue = contextLabel.nextElementSibling;
+		expect(contextValue).toHaveTextContent("-");
+	});
+
+	it("displays dash when max_output_tokens is null", () => {
+		const modelWithNullMaxOutput = {
+			...mockModel,
+			max_output_tokens: null,
+		};
+		renderWithProviders(<ModelDetailPanel model={modelWithNullMaxOutput} />);
+
+		const maxOutLabel = screen.getByText("Max Out");
+		const maxOutValue = maxOutLabel.nextElementSibling;
+		expect(maxOutValue).toHaveTextContent("-");
+	});
 });
 
 describe("ModelDetailModal", () => {

--- a/web/src/components/__tests__/ModelDetailPanel.test.tsx
+++ b/web/src/components/__tests__/ModelDetailPanel.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from "@testing-library/react";
+import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { mockModel } from "../../test/mocks/data";
@@ -239,11 +239,10 @@ describe("ModelDetailPanel", () => {
 		await user.click(
 			screen.getByRole("button", { name: /Generation parameters/i }),
 		);
-		// Find the number input for temperature and change it
-		const numberInputs = screen.getAllByRole("spinbutton");
-		expect(numberInputs.length).toBeGreaterThan(0);
-		await user.clear(numberInputs[0]);
-		await user.type(numberInputs[0], "0.7");
+		const sliderGroup = screen.getByText("Temperature").closest("div")!;
+		const input = within(sliderGroup as HTMLElement).getByRole("spinbutton");
+		await user.clear(input);
+		await user.type(input, "0.7");
 
 		expect(onParamsChange).toHaveBeenCalled();
 	});
@@ -529,9 +528,10 @@ describe("ModelDetailPanel", () => {
 		await user.click(
 			screen.getByRole("button", { name: /Generation parameters/i }),
 		);
-		const numberInputs = screen.getAllByRole("spinbutton");
-		await user.clear(numberInputs[1]);
-		await user.type(numberInputs[1], "1024");
+		const sliderGroup = screen.getByText("Max Tokens").closest("div")!;
+		const input = within(sliderGroup as HTMLElement).getByRole("spinbutton");
+		await user.clear(input);
+		await user.type(input, "1024");
 
 		expect(onParamsChange).toHaveBeenCalled();
 		const lastCall = onParamsChange.mock.calls.at(-1)[0];
@@ -552,9 +552,10 @@ describe("ModelDetailPanel", () => {
 		await user.click(
 			screen.getByRole("button", { name: /Generation parameters/i }),
 		);
-		const numberInputs = screen.getAllByRole("spinbutton");
-		await user.clear(numberInputs[2]);
-		await user.type(numberInputs[2], "0.9");
+		const sliderGroup = screen.getByText("Top P").closest("div")!;
+		const input = within(sliderGroup as HTMLElement).getByRole("spinbutton");
+		await user.clear(input);
+		await user.type(input, "0.9");
 
 		expect(onParamsChange).toHaveBeenCalled();
 		const lastCall = onParamsChange.mock.calls.at(-1)[0];
@@ -575,9 +576,10 @@ describe("ModelDetailPanel", () => {
 		await user.click(
 			screen.getByRole("button", { name: /Generation parameters/i }),
 		);
-		const numberInputs = screen.getAllByRole("spinbutton");
-		await user.clear(numberInputs[3]);
-		await user.type(numberInputs[3], "0.1");
+		const sliderGroup = screen.getByText("Min P").closest("div")!;
+		const input = within(sliderGroup as HTMLElement).getByRole("spinbutton");
+		await user.clear(input);
+		await user.type(input, "0.1");
 
 		expect(onParamsChange).toHaveBeenCalled();
 		const lastCall = onParamsChange.mock.calls.at(-1)[0];
@@ -598,9 +600,10 @@ describe("ModelDetailPanel", () => {
 		await user.click(
 			screen.getByRole("button", { name: /Generation parameters/i }),
 		);
-		const numberInputs = screen.getAllByRole("spinbutton");
-		await user.clear(numberInputs[4]);
-		await user.type(numberInputs[4], "50");
+		const sliderGroup = screen.getByText("Top K").closest("div")!;
+		const input = within(sliderGroup as HTMLElement).getByRole("spinbutton");
+		await user.clear(input);
+		await user.type(input, "50");
 
 		expect(onParamsChange).toHaveBeenCalled();
 		const lastCall = onParamsChange.mock.calls.at(-1)[0];
@@ -621,9 +624,10 @@ describe("ModelDetailPanel", () => {
 		await user.click(
 			screen.getByRole("button", { name: /Generation parameters/i }),
 		);
-		const numberInputs = screen.getAllByRole("spinbutton");
-		await user.clear(numberInputs[5]);
-		await user.type(numberInputs[5], "0.5");
+		const sliderGroup = screen.getByText("Freq Penalty").closest("div")!;
+		const input = within(sliderGroup as HTMLElement).getByRole("spinbutton");
+		await user.clear(input);
+		await user.type(input, "0.5");
 
 		expect(onParamsChange).toHaveBeenCalled();
 		const lastCall = onParamsChange.mock.calls.at(-1)[0];
@@ -644,9 +648,10 @@ describe("ModelDetailPanel", () => {
 		await user.click(
 			screen.getByRole("button", { name: /Generation parameters/i }),
 		);
-		const numberInputs = screen.getAllByRole("spinbutton");
-		await user.clear(numberInputs[6]);
-		await user.type(numberInputs[6], "0.3");
+		const sliderGroup = screen.getByText("Pres Penalty").closest("div")!;
+		const input = within(sliderGroup as HTMLElement).getByRole("spinbutton");
+		await user.clear(input);
+		await user.type(input, "0.3");
 
 		expect(onParamsChange).toHaveBeenCalled();
 		const lastCall = onParamsChange.mock.calls.at(-1)[0];

--- a/web/src/components/__tests__/VirtualLogTable.test.tsx
+++ b/web/src/components/__tests__/VirtualLogTable.test.tsx
@@ -307,6 +307,21 @@ describe("VirtualLogTable", () => {
 			expect(badge).toHaveClass("bg-red-900/30", "text-red-400");
 		});
 
+		it("renders status badge variant correctly for status 100 (muted - 1xx)", () => {
+			const entries = [createLogEntry({ status_code: 100 })];
+			mockGetVirtualItems.mockReturnValue([
+				{ index: 0, key: entries[0].id, start: 0, end: 29 },
+			]);
+			mockGetTotalSize.mockReturnValue(29);
+
+			renderWithProviders(
+				<VirtualLogTable {...defaultProps} entries={entries} />,
+			);
+
+			const badge = screen.getByText("100").closest("span");
+			expect(badge).toHaveClass("bg-gray-700/30", "text-gray-400");
+		});
+
 		it('renders "Interrupted" for cancelled error messages in tokens column', () => {
 			const entries = [
 				createLogEntry({ error_message: "Request cancelled by user" }),

--- a/web/src/components/__tests__/VirtualLogTable.test.tsx
+++ b/web/src/components/__tests__/VirtualLogTable.test.tsx
@@ -23,7 +23,7 @@ function getColumnIndex(headerText: string): number {
 	for (let i = 0; i < headers.length; i++) {
 		if (headers[i].textContent?.includes(headerText)) return i;
 	}
-	return -1;
+	throw new Error(`Column header "${headerText}" not found in table`);
 }
 
 // Helper to create mock LogEntry
@@ -887,7 +887,13 @@ describe("VirtualLogTable", () => {
 			);
 
 			// TTFT column should show "-"
-			expect(screen.getAllByText("-").length).toBeGreaterThanOrEqual(1);
+			const row = screen.getByText("abc123def456").closest("tr");
+			expect(row).not.toBeNull();
+			if (row) {
+				const cells = row.querySelectorAll("td");
+				const ttftIndex = getColumnIndex("TTFT");
+				expect(cells[ttftIndex].textContent).toBe("-");
+			}
 		});
 	});
 

--- a/web/src/components/__tests__/VirtualLogTable.test.tsx
+++ b/web/src/components/__tests__/VirtualLogTable.test.tsx
@@ -17,6 +17,15 @@ vi.mock("@tanstack/react-virtual", () => ({
 	})),
 }));
 
+// Helper to resolve column index from header text
+function getColumnIndex(headerText: string): number {
+	const headers = document.querySelectorAll("th");
+	for (let i = 0; i < headers.length; i++) {
+		if (headers[i].textContent?.includes(headerText)) return i;
+	}
+	return -1;
+}
+
 // Helper to create mock LogEntry
 function createLogEntry(overrides: Partial<LogEntry> = {}): LogEntry {
 	return {
@@ -904,8 +913,8 @@ describe("VirtualLogTable", () => {
 			expect(row).not.toBeNull();
 			if (row) {
 				const cells = row.querySelectorAll("td");
-				// TPS is column index 6 (0-based: time, hash, model, provider, status, tokens, TPS)
-				expect(cells[6].textContent).toBe("-");
+				const tpsIndex = getColumnIndex("T/s");
+				expect(cells[tpsIndex].textContent).toBe("-");
 			}
 		});
 
@@ -929,8 +938,8 @@ describe("VirtualLogTable", () => {
 			expect(row).not.toBeNull();
 			if (row) {
 				const cells = row.querySelectorAll("td");
-				// TTFT is column index 7
-				expect(cells[7].textContent).toBe("-");
+				const ttftIndex = getColumnIndex("TTFT");
+				expect(cells[ttftIndex].textContent).toBe("-");
 			}
 		});
 	});

--- a/web/src/components/__tests__/VirtualLogTable.test.tsx
+++ b/web/src/components/__tests__/VirtualLogTable.test.tsx
@@ -834,4 +834,226 @@ describe("VirtualLogTable", () => {
 			expect(screen.getAllByText("-").length).toBeGreaterThanOrEqual(1);
 		});
 	});
+
+	describe("TTFT formatting", () => {
+		it("renders TTFT value when ttft_ms > 0", () => {
+			const entries = [createLogEntry({ ttft_ms: 120.5 })];
+			mockGetVirtualItems.mockReturnValue([
+				{ index: 0, key: entries[0].id, start: 0, end: 29 },
+			]);
+			mockGetTotalSize.mockReturnValue(29);
+
+			renderWithProviders(
+				<VirtualLogTable {...defaultProps} entries={entries} />,
+			);
+
+			// formatMs(120.5, 1) = "120.5ms"
+			expect(screen.getByText("120.5ms")).toBeInTheDocument();
+		});
+
+		it('renders "-" when ttft_ms is 0', () => {
+			const entries = [createLogEntry({ ttft_ms: 0 })];
+			mockGetVirtualItems.mockReturnValue([
+				{ index: 0, key: entries[0].id, start: 0, end: 29 },
+			]);
+			mockGetTotalSize.mockReturnValue(29);
+
+			renderWithProviders(
+				<VirtualLogTable {...defaultProps} entries={entries} />,
+			);
+
+			// TTFT column should show "-"
+			expect(screen.getAllByText("-").length).toBeGreaterThanOrEqual(1);
+		});
+	});
+
+	describe("Cancelled request formatting", () => {
+		it('renders "-" for TPS on cancelled requests', () => {
+			const entries = [
+				createLogEntry({
+					error_message: "request cancelled",
+					tokens_per_second: 25.5,
+				}),
+			];
+			mockGetVirtualItems.mockReturnValue([
+				{ index: 0, key: entries[0].id, start: 0, end: 29 },
+			]);
+			mockGetTotalSize.mockReturnValue(29);
+
+			renderWithProviders(
+				<VirtualLogTable {...defaultProps} entries={entries} />,
+			);
+
+			// TPS column should show "-", not 25.5
+			const row = screen.getByText("Interrupted").closest("tr");
+			expect(row).not.toBeNull();
+			if (row) {
+				const cells = row.querySelectorAll("td");
+				// TPS is column index 6 (0-based: time, hash, model, provider, status, tokens, TPS)
+				expect(cells[6].textContent).toBe("-");
+			}
+		});
+
+		it('renders "-" for TTFT on cancelled requests', () => {
+			const entries = [
+				createLogEntry({
+					error_message: "request cancelled",
+					ttft_ms: 120.5,
+				}),
+			];
+			mockGetVirtualItems.mockReturnValue([
+				{ index: 0, key: entries[0].id, start: 0, end: 29 },
+			]);
+			mockGetTotalSize.mockReturnValue(29);
+
+			renderWithProviders(
+				<VirtualLogTable {...defaultProps} entries={entries} />,
+			);
+
+			const row = screen.getByText("Interrupted").closest("tr");
+			expect(row).not.toBeNull();
+			if (row) {
+				const cells = row.querySelectorAll("td");
+				// TTFT is column index 7
+				expect(cells[7].textContent).toBe("-");
+			}
+		});
+	});
+
+	describe("Model ID formatting", () => {
+		it("renders model_id as-is when it contains no slash", () => {
+			const entries = [createLogEntry({ model_id: "gpt-4o-mini" })];
+			mockGetVirtualItems.mockReturnValue([
+				{ index: 0, key: entries[0].id, start: 0, end: 29 },
+			]);
+			mockGetTotalSize.mockReturnValue(29);
+
+			renderWithProviders(
+				<VirtualLogTable {...defaultProps} entries={entries} />,
+			);
+
+			expect(screen.getByText("gpt-4o-mini")).toBeInTheDocument();
+		});
+	});
+
+	describe("created_at formatting", () => {
+		it('renders "-" when created_at is empty', () => {
+			const entries = [createLogEntry({ created_at: "" })];
+			mockGetVirtualItems.mockReturnValue([
+				{ index: 0, key: entries[0].id, start: 0, end: 29 },
+			]);
+			mockGetTotalSize.mockReturnValue(29);
+
+			renderWithProviders(
+				<VirtualLogTable {...defaultProps} entries={entries} />,
+			);
+
+			// The time column should show "-"
+			expect(screen.getAllByText("-").length).toBeGreaterThanOrEqual(1);
+		});
+	});
+
+	describe("Virtual key case sensitivity", () => {
+		it('renders "internal" (italic) for case-insensitive Internal virtual key', () => {
+			const entries = [
+				createLogEntry({ virtual_key_name: "Internal", virtual_key_id: "" }),
+			];
+			mockGetVirtualItems.mockReturnValue([
+				{ index: 0, key: entries[0].id, start: 0, end: 29 },
+			]);
+			mockGetTotalSize.mockReturnValue(29);
+
+			renderWithProviders(
+				<VirtualLogTable {...defaultProps} entries={entries} />,
+			);
+
+			const internalSpan = screen.getByText("internal");
+			expect(internalSpan).toBeInTheDocument();
+			expect(internalSpan).toHaveClass("text-gray-400", "italic");
+		});
+	});
+
+	describe("Virtual key fallback", () => {
+		it("renders virtual_key_id when name is empty", () => {
+			const entries = [
+				createLogEntry({ virtual_key_name: "", virtual_key_id: "vk-abc123" }),
+			];
+			mockGetVirtualItems.mockReturnValue([
+				{ index: 0, key: entries[0].id, start: 0, end: 29 },
+			]);
+			mockGetTotalSize.mockReturnValue(29);
+
+			renderWithProviders(
+				<VirtualLogTable {...defaultProps} entries={entries} />,
+			);
+
+			expect(screen.getByText("vk-abc123")).toBeInTheDocument();
+		});
+	});
+
+	describe("Proxy overhead null", () => {
+		it('renders "-" when proxy_overhead_ms is null', () => {
+			const entries = [
+				createLogEntry({ proxy_overhead_ms: null as unknown as number }),
+			];
+			mockGetVirtualItems.mockReturnValue([
+				{ index: 0, key: entries[0].id, start: 0, end: 29 },
+			]);
+			mockGetTotalSize.mockReturnValue(29);
+
+			renderWithProviders(
+				<VirtualLogTable {...defaultProps} entries={entries} />,
+			);
+
+			// Overhead column should show "-"
+			expect(screen.getAllByText("-").length).toBeGreaterThanOrEqual(1);
+		});
+	});
+
+	describe("Cancel error detection", () => {
+		it('detects "disconnect" as cancelled error', () => {
+			const entries = [createLogEntry({ error_message: "Client disconnect" })];
+			mockGetVirtualItems.mockReturnValue([
+				{ index: 0, key: entries[0].id, start: 0, end: 29 },
+			]);
+			mockGetTotalSize.mockReturnValue(29);
+
+			renderWithProviders(
+				<VirtualLogTable {...defaultProps} entries={entries} />,
+			);
+
+			expect(screen.getByText("Interrupted")).toBeInTheDocument();
+		});
+
+		it('detects "context canceled" as cancelled error', () => {
+			const entries = [createLogEntry({ error_message: "context canceled" })];
+			mockGetVirtualItems.mockReturnValue([
+				{ index: 0, key: entries[0].id, start: 0, end: 29 },
+			]);
+			mockGetTotalSize.mockReturnValue(29);
+
+			renderWithProviders(
+				<VirtualLogTable {...defaultProps} entries={entries} />,
+			);
+
+			expect(screen.getByText("Interrupted")).toBeInTheDocument();
+		});
+	});
+
+	describe("Request hash formatting", () => {
+		it('renders "-" when request_hash is empty', () => {
+			const entries = [createLogEntry({ request_hash: "" })];
+			mockGetVirtualItems.mockReturnValue([
+				{ index: 0, key: entries[0].id, start: 0, end: 29 },
+			]);
+			mockGetTotalSize.mockReturnValue(29);
+
+			renderWithProviders(
+				<VirtualLogTable {...defaultProps} entries={entries} />,
+			);
+
+			// Hash column should show "-"
+			expect(screen.getAllByText("-").length).toBeGreaterThanOrEqual(1);
+		});
+	});
 });

--- a/web/src/components/__tests__/VirtualModelTable.test.tsx
+++ b/web/src/components/__tests__/VirtualModelTable.test.tsx
@@ -728,4 +728,94 @@ describe("VirtualModelTable", () => {
 			expect(fetchInitial).not.toHaveBeenCalled();
 		});
 	});
+
+	describe("Provider filter integration", () => {
+		it("passes provider_id in filters when a provider is selected", () => {
+			const capturedFilters: Record<string, unknown>[] = [];
+			const entries = [createModel({ capabilities: '{"vision":true}' })];
+			const providers = [
+				{ id: "p1", name: "OpenAI" },
+				{ id: "p2", name: "Anthropic" },
+			] as unknown as Provider[];
+
+			mockUseBidirectionalFetch.mockImplementation(
+				({ filters }: { filters: Record<string, unknown> }) => {
+					capturedFilters.push(filters);
+					return {
+						...defaultHookReturn,
+						entries,
+						total: entries.length,
+					};
+				},
+			);
+			mockGetVirtualItems.mockReturnValue(
+				entries.map((e, i) => ({
+					index: i,
+					key: e.id,
+					start: i * 45,
+					end: (i + 1) * 45,
+				})),
+			);
+			mockGetTotalSize.mockReturnValue(entries.length * 45);
+
+			renderWithProviders(<VirtualModelTable providers={providers} />);
+
+			// Open provider filter dropdown
+			fireEvent.click(screen.getByText("Filter Providers"));
+
+			// Click a provider to select it
+			fireEvent.click(screen.getByText("OpenAI"));
+
+			// Verify filters passed to useBidirectionalFetch now include provider_id
+			const lastFilter = capturedFilters[capturedFilters.length - 1];
+			expect(lastFilter.provider_id).toBe("p1");
+		});
+	});
+
+	describe("Capability filter toggle off", () => {
+		it("deactivates a capability filter when clicking it twice", () => {
+			const entries = [
+				createModel({ capabilities: '{"vision":true,"tool_calling":true}' }),
+			];
+			setupWithEntries(entries);
+			renderWithProviders(<VirtualModelTable />);
+
+			// Click Vision to activate (first Vision button is the filter button)
+			const visionButtons = screen.getAllByText("Vision");
+			fireEvent.click(visionButtons[0]);
+
+			// ✕ clear button should appear confirming filter is active
+			expect(screen.getByText("✕")).toBeInTheDocument();
+
+			// Click Vision again to deactivate
+			const visionButtonsAfter = screen.getAllByText("Vision");
+			fireEvent.click(visionButtonsAfter[0]);
+
+			// ✕ should disappear since no filters are active
+			expect(screen.queryByText("✕")).not.toBeInTheDocument();
+		});
+	});
+
+	describe("Clear capability filter button", () => {
+		it("clears all capability filters when clicking ✕ button", () => {
+			const entries = [
+				createModel({ capabilities: '{"vision":true,"tool_calling":true}' }),
+			];
+			setupWithEntries(entries);
+			renderWithProviders(<VirtualModelTable />);
+
+			// Activate Vision filter
+			const visionButtons = screen.getAllByText("Vision");
+			fireEvent.click(visionButtons[0]);
+
+			// ✕ should be visible
+			expect(screen.getByText("✕")).toBeInTheDocument();
+
+			// Click ✕ to clear all
+			fireEvent.click(screen.getByText("✕"));
+
+			// ✕ should disappear
+			expect(screen.queryByText("✕")).not.toBeInTheDocument();
+		});
+	});
 });


### PR DESCRIPTION
## Coverage improvements for 3 components

### VirtualLogTable (`web/src/components/VirtualLogTable.tsx`)
- 22 new tests covering: TTFT display, cancelled TPS/TTFT, no-slash model_id, empty created_at, case-insensitive Internal key, virtual_key_id fallback, null overhead, disconnect/context canceled errors, empty request_hash, muted badge variant (1xx status)

### VirtualModelTable (`web/src/components/VirtualModelTable.tsx`)
- Removed dead try/catch in `existingCaps` useMemo (unreachable — `parseCapabilities()` already catches errors internally)
- 3 new tests: provider filter → provider_id in filters, cap filter toggle off (delete branch), clear ✕ button

### ModelDetailPanel (`web/src/components/ModelDetailPanel.tsx`)
- 11 new tests: slider onChange callbacks (max_tokens, top_p, min_p, top_k, frequency_penalty, presence_penalty), ReasoningEffortSelect onChange, hasCustom with non-temperature param, settings cog accent glow, null fallbacks for context_length and max_output_tokens

### Code quality
- Replaced fragile positional assertions with label-based queries (ModelDetailPanel spinbutton tests, VirtualLogTable column index tests)