### PR TITLE
test: add coverage tests for LogDetailModal, ArenaHistoryModal, ModelTable

### DIFF
--- a/web/src/components/__tests__/ArenaHistoryModal.test.tsx
+++ b/web/src/components/__tests__/ArenaHistoryModal.test.tsx
@@ -1038,6 +1038,7 @@ describe("ArenaHistoryModal", () => {
 		// Second click: collapse
 		await user.click(entryButton);
 		// After collapsing, the grid container switches to grid-rows-[0fr]
+		// (not.toBeVisible() doesn't work in jsdom — CSS grid layout isn't applied)
 		const winnerText = screen.getByText("Winner: model-a");
 		const gridContainer = winnerText.closest("[class*='grid-rows']");
 		expect(gridContainer).toHaveClass("grid-rows-[0fr]");

--- a/web/src/components/__tests__/ArenaHistoryModal.test.tsx
+++ b/web/src/components/__tests__/ArenaHistoryModal.test.tsx
@@ -741,6 +741,401 @@ describe("ArenaHistoryModal", () => {
 		});
 	});
 
+	it("shows Final round label for multi-round competition", async () => {
+		const user = userEvent.setup();
+		const multiRoundEntry = {
+			...mockCompetitionEntry,
+			rounds: [
+				{
+					matchups: [
+						{
+							slotA: { modelId: "provider/model-a", personaId: null },
+							slotB: { modelId: "provider/model-b", personaId: null },
+							responseA: mockCompetitionEntry.rounds[0].matchups[0].responseA,
+							responseB: mockCompetitionEntry.rounds[0].matchups[0].responseB,
+							vote: "A" as const,
+						},
+					],
+				},
+				{
+					matchups: [
+						{
+							slotA: { modelId: "provider/model-c", personaId: null },
+							slotB: { modelId: "provider/model-d", personaId: null },
+							responseA: {
+								modelId: "provider/model-c",
+								content: "Final A",
+								thinkingContent: "",
+								error: null,
+								metrics: {
+									tokensPerSecond: 50,
+									durationMs: 2000,
+									promptTokens: 100,
+									completionTokens: 200,
+								},
+							},
+							responseB: {
+								modelId: "provider/model-d",
+								content: "Final B",
+								thinkingContent: "",
+								error: null,
+								metrics: {
+									tokensPerSecond: 45,
+									durationMs: 2200,
+									promptTokens: 100,
+									completionTokens: 180,
+								},
+							},
+							vote: "B" as const,
+						},
+					],
+				},
+			],
+		};
+		mockLocalStorage.store.set(
+			"arenaMatchHistory",
+			JSON.stringify([multiRoundEntry]),
+		);
+		renderWithProviders(
+			<ArenaHistoryModal onClose={onClose} onRestore={onRestore} />,
+		);
+		await waitFor(() => {
+			expect(screen.getByText(/model-a vs model-b/)).toBeInTheDocument();
+		});
+		await user.click(
+			screen.getByRole("button", { name: /model-a vs model-b/ }),
+		);
+		await waitFor(() => {
+			// Round 0 with 2 total rounds: totalRounds-2=0, so index 0 = Semifinals
+			expect(screen.getByText("Semifinals")).toBeInTheDocument();
+			// Last round (index 1) gets "Final" label
+			expect(screen.getByText("Final")).toBeInTheDocument();
+		});
+	});
+
+	it("shows Semifinals and Quarterfinals labels for 4-round competition", async () => {
+		const user = userEvent.setup();
+		const makeRound = (suffix: string, voteSlot: "A" | "B") => ({
+			matchups: [
+				{
+					slotA: { modelId: `provider/model-a-${suffix}`, personaId: null },
+					slotB: { modelId: `provider/model-b-${suffix}`, personaId: null },
+					responseA: {
+						modelId: `provider/model-a-${suffix}`,
+						content: `Response A ${suffix}`,
+						thinkingContent: "",
+						error: null,
+						metrics: {
+							tokensPerSecond: 50,
+							durationMs: 2000,
+							promptTokens: 100,
+							completionTokens: 200,
+						},
+					},
+					responseB: {
+						modelId: `provider/model-b-${suffix}`,
+						content: `Response B ${suffix}`,
+						thinkingContent: "",
+						error: null,
+						metrics: {
+							tokensPerSecond: 45,
+							durationMs: 2200,
+							promptTokens: 100,
+							completionTokens: 180,
+						},
+					},
+					vote: voteSlot,
+				},
+			],
+		});
+		const fourRoundEntry = {
+			...mockCompetitionEntry,
+			rounds: [
+				makeRound("r1", "A" as const),
+				makeRound("r2", "B" as const),
+				makeRound("r3", "A" as const),
+				makeRound("r4", "B" as const),
+			],
+		};
+		mockLocalStorage.store.set(
+			"arenaMatchHistory",
+			JSON.stringify([fourRoundEntry]),
+		);
+		renderWithProviders(
+			<ArenaHistoryModal onClose={onClose} onRestore={onRestore} />,
+		);
+		await waitFor(() => {
+			expect(screen.getByText(/model-a-r1 vs model-b-r1/)).toBeInTheDocument();
+		});
+		await user.click(
+			screen.getByRole("button", { name: /model-a-r1 vs model-b-r1/ }),
+		);
+		await waitFor(() => {
+			// Round 1 (index 0) → "Round 1", Round 2 → "Quarterfinals",
+			// Round 3 → "Semifinals", Round 4 (index 3) → "Final"
+			expect(screen.getByText("Round 1")).toBeInTheDocument();
+			expect(screen.getByText("Quarterfinals")).toBeInTheDocument();
+			expect(screen.getByText("Semifinals")).toBeInTheDocument();
+			expect(screen.getByText("Final")).toBeInTheDocument();
+		});
+	});
+
+	it("shows vote B winner with trophy for B-side matchup", async () => {
+		const user = userEvent.setup();
+		const bWinnerEntry = {
+			...mockCompetitionEntry,
+			rounds: [
+				{
+					matchups: [
+						{
+							slotA: { modelId: "provider/model-a", personaId: null },
+							slotB: { modelId: "provider/model-b", personaId: null },
+							responseA: mockCompetitionEntry.rounds[0].matchups[0].responseA,
+							responseB: mockCompetitionEntry.rounds[0].matchups[0].responseB,
+							vote: "B" as const,
+						},
+					],
+				},
+			],
+			winner: "provider/model-b",
+		};
+		mockLocalStorage.store.set(
+			"arenaMatchHistory",
+			JSON.stringify([bWinnerEntry]),
+		);
+		renderWithProviders(
+			<ArenaHistoryModal onClose={onClose} onRestore={onRestore} />,
+		);
+		await waitFor(() => {
+			expect(screen.getByText(/model-a vs model-b/)).toBeInTheDocument();
+		});
+		await user.click(
+			screen.getByRole("button", { name: /model-a vs model-b/ }),
+		);
+		await waitFor(() => {
+			// Winner badge shows model-b
+			expect(screen.getByText("Winner: model-b")).toBeInTheDocument();
+			// Vote indicator shows → B
+			expect(screen.getByText("→ B")).toBeInTheDocument();
+		});
+	});
+
+	it("shows dash for matchup with no vote", async () => {
+		const user = userEvent.setup();
+		const noVoteEntry = {
+			...mockCompetitionEntry,
+			rounds: [
+				{
+					matchups: [
+						{
+							slotA: { modelId: "provider/model-a", personaId: null },
+							slotB: { modelId: "provider/model-b", personaId: null },
+							responseA: mockCompetitionEntry.rounds[0].matchups[0].responseA,
+							responseB: mockCompetitionEntry.rounds[0].matchups[0].responseB,
+							vote: null as unknown as "A",
+						},
+					],
+				},
+			],
+			winner: null as unknown as string,
+		};
+		mockLocalStorage.store.set(
+			"arenaMatchHistory",
+			JSON.stringify([noVoteEntry]),
+		);
+		renderWithProviders(
+			<ArenaHistoryModal onClose={onClose} onRestore={onRestore} />,
+		);
+		await waitFor(() => {
+			expect(screen.getByText(/model-a vs model-b/)).toBeInTheDocument();
+		});
+		await user.click(
+			screen.getByRole("button", { name: /model-a vs model-b/ }),
+		);
+		await waitFor(() => {
+			// No vote → dash indicator, no winner badge
+			const dashElements = screen.getAllByText("-");
+			expect(dashElements.length).toBeGreaterThanOrEqual(1);
+			expect(screen.queryByText(/Winner:/)).not.toBeInTheDocument();
+		});
+	});
+
+	it("shows error message for failed compare response", async () => {
+		const user = userEvent.setup();
+		const errorEntry = {
+			...mockCompareEntry,
+			compareModels: ["provider/model-err"],
+			compareResponses: [
+				{
+					modelId: "provider/model-err",
+					content: "",
+					thinkingContent: "",
+					error: "Rate limit exceeded",
+					metrics: {
+						tokensPerSecond: 0,
+						durationMs: 0,
+						promptTokens: 100,
+						completionTokens: 0,
+					},
+				},
+			],
+		};
+		mockLocalStorage.store.set(
+			"arenaMatchHistory",
+			JSON.stringify([errorEntry]),
+		);
+		renderWithProviders(
+			<ArenaHistoryModal onClose={onClose} onRestore={onRestore} />,
+		);
+		// Wait for the entry to appear, then click to expand
+		await waitFor(() => {
+			expect(
+				screen.getByRole("button", { name: /model-err/ }),
+			).toBeInTheDocument();
+		});
+		await user.click(screen.getByRole("button", { name: /model-err/ }));
+		await waitFor(() => {
+			// Error shown with "Error:" prefix in expanded detail
+			expect(
+				screen.getByText(/Error: Rate limit exceeded/),
+			).toBeInTheDocument();
+		});
+	});
+
+	it("shows 1 entry singular for single entry count", async () => {
+		mockLocalStorage.store.set(
+			"arenaMatchHistory",
+			JSON.stringify([mockCompetitionEntry]),
+		);
+		renderWithProviders(
+			<ArenaHistoryModal onClose={onClose} onRestore={onRestore} />,
+		);
+		await waitFor(() => {
+			expect(screen.getByText("1 entry")).toBeInTheDocument();
+		});
+	});
+
+	it("collapses expanded entry when clicking same entry again", async () => {
+		const user = userEvent.setup();
+		mockLocalStorage.store.set(
+			"arenaMatchHistory",
+			JSON.stringify([mockCompetitionEntry]),
+		);
+		renderWithProviders(
+			<ArenaHistoryModal onClose={onClose} onRestore={onRestore} />,
+		);
+		await waitFor(() => {
+			expect(screen.getByText(/model-a vs model-b/)).toBeInTheDocument();
+		});
+		const entryButton = screen.getByRole("button", {
+			name: /model-a vs model-b/,
+		});
+		// First click: expand
+		await user.click(entryButton);
+		await waitFor(() => {
+			expect(screen.getByText("Winner: model-a")).toBeInTheDocument();
+		});
+		// Second click: collapse
+		await user.click(entryButton);
+		// After collapsing, the grid container switches to grid-rows-[0fr]
+		const winnerText = screen.getByText("Winner: model-a");
+		const gridContainer = winnerText.closest("[class*='grid-rows']");
+		expect(gridContainer).toHaveClass("grid-rows-[0fr]");
+	});
+
+	it("hides Restore Setup when onRestore is not provided", async () => {
+		const user = userEvent.setup();
+		mockLocalStorage.store.set(
+			"arenaMatchHistory",
+			JSON.stringify([mockCompetitionEntry]),
+		);
+		renderWithProviders(<ArenaHistoryModal onClose={onClose} />);
+		await waitFor(() => {
+			expect(screen.getByText(/model-a vs model-b/)).toBeInTheDocument();
+		});
+		await user.click(
+			screen.getByRole("button", { name: /model-a vs model-b/ }),
+		);
+		await waitFor(() => {
+			expect(
+				screen.queryByRole("button", { name: /restore setup/i }),
+			).not.toBeInTheDocument();
+		});
+	});
+
+	it("resets confirmClear on blur", async () => {
+		const user = userEvent.setup();
+		mockLocalStorage.store.set(
+			"arenaMatchHistory",
+			JSON.stringify([mockCompetitionEntry]),
+		);
+		renderWithProviders(
+			<ArenaHistoryModal onClose={onClose} onRestore={onRestore} />,
+		);
+		await waitFor(() => {
+			expect(
+				screen.getByRole("button", { name: /clear all history/i }),
+			).toBeInTheDocument();
+		});
+		const clearButton = screen.getByRole("button", {
+			name: /clear all history/i,
+		});
+		// First click: enter confirm state
+		await user.click(clearButton);
+		await waitFor(() => {
+			expect(
+				screen.getByRole("button", { name: /click again to confirm/i }),
+			).toBeInTheDocument();
+		});
+		// Blur the button — should reset confirmClear
+		await user.tab();
+		await waitFor(() => {
+			expect(
+				screen.getByRole("button", { name: /clear all history/i }),
+			).toBeInTheDocument();
+		});
+	});
+
+	it("shows Bracket fallback for competition with no rounds", async () => {
+		mockLocalStorage.store.set(
+			"arenaMatchHistory",
+			JSON.stringify([
+				{
+					...mockCompetitionEntry,
+					rounds: [],
+				},
+			]),
+		);
+		renderWithProviders(
+			<ArenaHistoryModal onClose={onClose} onRestore={onRestore} />,
+		);
+		await waitFor(() => {
+			expect(screen.getByText("Bracket")).toBeInTheDocument();
+		});
+	});
+
+	it("shows Compare fallback for compare with no models", async () => {
+		const noModelsEntry = {
+			...mockCompareEntry,
+			compareModels: null as unknown as string[],
+			compareResponses: [],
+		};
+		mockLocalStorage.store.set(
+			"arenaMatchHistory",
+			JSON.stringify([noModelsEntry]),
+		);
+		renderWithProviders(
+			<ArenaHistoryModal onClose={onClose} onRestore={onRestore} />,
+		);
+		await waitFor(() => {
+			// "Compare" appears as both a filter button and the entry label
+			// There should be at least one instance from the entry (not the filter)
+			const compareTexts = screen.getAllByText("Compare");
+			// The filter button + the entry label = 2+ occurrences
+			expect(compareTexts.length).toBeGreaterThanOrEqual(2);
+		});
+	});
+
 	it("shows custom prompt label when promptPresetId is null", async () => {
 		const user = userEvent.setup();
 		const customEntry = {

--- a/web/src/components/__tests__/LogDetailModal.test.tsx
+++ b/web/src/components/__tests__/LogDetailModal.test.tsx
@@ -645,6 +645,170 @@ describe("LogDetailModal", () => {
 		});
 	});
 
+	describe("StatusBadge fallback", () => {
+		it("displays plain code for 1xx status", () => {
+			const infoLog = { ...mockRequestLog, status_code: 100 };
+			renderWithProviders(
+				<LogDetailModal log={infoLog} type="request" onClose={onClose} />,
+			);
+
+			// 1xx falls through all specific cases to the fallback
+			const codeElement = screen.getByText("100");
+			expect(codeElement).toBeInTheDocument();
+			expect(codeElement.closest("span")).toHaveClass("text-xs");
+		});
+
+		it("displays plain code for 3xx status", () => {
+			const redirectLog = { ...mockRequestLog, status_code: 301 };
+			renderWithProviders(
+				<LogDetailModal log={redirectLog} type="request" onClose={onClose} />,
+			);
+
+			const codeElement = screen.getByText("301");
+			expect(codeElement).toBeInTheDocument();
+		});
+	});
+
+	describe("Failed badge without error message", () => {
+		it("displays Failed without colon when error_message is empty", () => {
+			const failedLog = {
+				...mockRequestLog,
+				state: "failed",
+				status_code: 0,
+				error_message: "",
+			};
+			renderWithProviders(
+				<LogDetailModal log={failedLog} type="request" onClose={onClose} />,
+			);
+
+			expect(screen.getByText("Failed")).toBeInTheDocument();
+			// Should NOT contain a colon suffix
+			const badge = screen.getByText("Failed").closest("span");
+			expect(badge?.textContent).toBe("Failed");
+		});
+	});
+
+	describe("Tokens per second null fallback", () => {
+		it("displays dash when tokens_per_second is null", () => {
+			const nullTpsLog = {
+				...mockRequestLog,
+				tokens_per_second: null as unknown as number,
+			};
+			renderWithProviders(
+				<LogDetailModal log={nullTpsLog} type="request" onClose={onClose} />,
+			);
+
+			// The Tokens/s timing card contains both the label and the value
+			const tpsLabel = screen.getByText("Tokens/s");
+			const tpsCard = tpsLabel.closest("[class*=rounded-lg]");
+			expect(tpsCard).toBeInTheDocument();
+			expect(tpsCard?.textContent).toContain("-");
+		});
+	});
+
+	describe("Virtual key fallback", () => {
+		it("displays virtual_key_id when name is empty", () => {
+			const noNameLog = {
+				...mockRequestLog,
+				virtual_key_name: "",
+				virtual_key_id: "vk-fallback-123",
+			};
+			renderWithProviders(
+				<LogDetailModal log={noNameLog} type="request" onClose={onClose} />,
+			);
+
+			expect(screen.getByText("vk-fallback-123")).toBeInTheDocument();
+		});
+
+		it("displays dash when both name and id are empty", () => {
+			const noKeyLog = {
+				...mockRequestLog,
+				virtual_key_name: "",
+				virtual_key_id: "",
+			};
+			renderWithProviders(
+				<LogDetailModal log={noKeyLog} type="request" onClose={onClose} />,
+			);
+
+			// DetailItem renders the value in a div after the label
+			const vkLabel = screen.getByText("Virtual Key");
+			const vkItem = vkLabel.closest("[class*=rounded-lg]");
+			expect(vkItem).toBeInTheDocument();
+			expect(vkItem?.textContent).toContain("-");
+		});
+	});
+
+	describe("Reasoning tokens", () => {
+		it("displays Reasoning section when tokens_completion_reasoning > 0", () => {
+			const reasoningLog = {
+				...mockRequestLog,
+				tokens_completion_reasoning: 500,
+			};
+			renderWithProviders(
+				<LogDetailModal log={reasoningLog} type="request" onClose={onClose} />,
+			);
+
+			expect(screen.getByText("Reasoning")).toBeInTheDocument();
+			const reasoningValue = screen.getByText("500");
+			expect(reasoningValue).toHaveClass("text-purple-400");
+		});
+	});
+
+	describe("Overhead with Dial reused and zero components", () => {
+		it("shows reused for Dial when dial_ms is 0", () => {
+			const dialReusedLog = {
+				...mockRequestLog,
+				proxy_overhead_ms: 50,
+				parse_ms: 5,
+				failover_lookup_ms: 0,
+				model_lookup_ms: 0,
+				provider_lookup_ms: 0,
+				key_decrypt_ms: 0,
+				dial_ms: 0,
+				settings_read_ms: 0,
+			};
+			renderWithProviders(
+				<LogDetailModal log={dialReusedLog} type="request" onClose={onClose} />,
+			);
+
+			expect(screen.getByText("Dial (DNS+TCP)")).toBeInTheDocument();
+			expect(screen.getByText("reused")).toBeInTheDocument();
+			// Only Request Parsing and Dial rows should appear
+			expect(screen.getByText("Request Parsing")).toBeInTheDocument();
+			expect(
+				screen.queryByText("Failover Group Lookup"),
+			).not.toBeInTheDocument();
+			expect(screen.queryByText("Model Lookup")).not.toBeInTheDocument();
+		});
+
+		it("computes total overhead with zero-valued components", () => {
+			const partialOverheadLog = {
+				...mockRequestLog,
+				proxy_overhead_ms: 50,
+				parse_ms: 5,
+				failover_lookup_ms: 0,
+				model_lookup_ms: 0,
+				provider_lookup_ms: 0,
+				key_decrypt_ms: 0,
+				dial_ms: 0,
+				settings_read_ms: 0,
+			};
+			renderWithProviders(
+				<LogDetailModal
+					log={partialOverheadLog}
+					type="request"
+					onClose={onClose}
+				/>,
+			);
+
+			// Total = 5 (parse) + 0 (others) = 5 → shown as accent-colored value
+			const totalLabel = screen.getByText("Total Overhead");
+			const totalRow = totalLabel.closest("div");
+			expect(totalRow).toBeInTheDocument();
+			expect(totalRow?.textContent).toContain("5.000ms");
+		});
+	});
+
 	describe("Token formatting", () => {
 		it("formats large token counts with locale separators", () => {
 			const largeTokenLog: LogEntry = {

--- a/web/src/components/__tests__/ModelTable.test.tsx
+++ b/web/src/components/__tests__/ModelTable.test.tsx
@@ -777,290 +777,295 @@ describe("ModelTable", () => {
 			expect(screen.queryByText("Provider 2")).not.toBeInTheDocument();
 		});
 	});
-});
 
-describe("Manually Disabled Status", () => {
-	it("renders Manually Disabled status badge", () => {
-		const manuallyDisabledModel = {
-			...mockModel,
-			enabled: true,
-			disabled_manually: true,
-		};
-
-		renderWithProviders(
-			<ModelTable
-				models={[manuallyDisabledModel]}
-				providers={[mockProvider]}
-			/>,
-		);
-
-		// Verify "Manually Disabled" text appears
-		expect(screen.getByText("Manually Disabled")).toBeInTheDocument();
-
-		// Verify the badge has yellow/warning styling
-		const badge = screen.getByText("Manually Disabled").closest("span");
-		expect(badge?.className).toMatch(/yellow|amber/);
-	});
-});
-
-describe("Capability Filter Clear All", () => {
-	it("clears all capability filters when clicking clear all button", async () => {
-		const models = [
-			{
+	describe("Manually Disabled Status", () => {
+		it("renders Manually Disabled status badge", () => {
+			const manuallyDisabledModel = {
 				...mockModel,
-				id: "model-001",
-				name: "Vision Model",
-				capabilities: '{"streaming":true,"vision":true,"audio_input":true}',
-			},
-			{
-				...mockModel,
-				id: "model-002",
-				name: "Audio Model",
-				capabilities: '{"streaming":true,"vision":false,"audio_input":true}',
-			},
-		];
+				enabled: true,
+				disabled_manually: true,
+			};
 
-		const { user } = renderWithProviders(
-			<ModelTable models={models} providers={[mockProvider]} />,
-		);
+			renderWithProviders(
+				<ModelTable
+					models={[manuallyDisabledModel]}
+					providers={[mockProvider]}
+				/>,
+			);
 
-		// Click Vision filter button
-		const visionFilter = screen.getByRole("button", { name: "Vision" });
-		await user.click(visionFilter);
+			// Verify "Manually Disabled" text appears
+			expect(screen.getByText("Manually Disabled")).toBeInTheDocument();
 
-		// Click Audio filter button
-		const audioFilter = screen.getByRole("button", { name: "Audio" });
-		await user.click(audioFilter);
-
-		// Verify both filters are active: only model-001 matches both Vision AND Audio (AND-logic)
-		await waitFor(() => {
-			const rows = screen.getByRole("table").querySelectorAll("tbody tr");
-			expect(rows.length).toBe(1);
-		});
-
-		// Click the ✕ clear button
-		const clearButton = screen.getByText("✕");
-		await user.click(clearButton);
-
-		// Verify both filters are cleared (all models visible again)
-		await waitFor(() => {
-			const rows = screen.getByRole("table").querySelectorAll("tbody tr");
-			expect(rows.length).toBe(2);
-		});
-
-		// Verify ✕ button disappears
-		expect(screen.queryByText("✕")).not.toBeInTheDocument();
-	});
-});
-
-describe("Empty State with Null Models", () => {
-	it("renders empty state when models is null", () => {
-		renderWithProviders(
-			<ModelTable models={null as unknown as []} providers={[mockProvider]} />,
-		);
-
-		expect(
-			screen.getByText(
-				"No models discovered yet. Add a provider and discover models.",
-			),
-		).toBeInTheDocument();
-	});
-});
-
-describe("Sort by Provider Name", () => {
-	it("sorts by provider name", async () => {
-		const models = [
-			{
-				...mockModel,
-				id: "model-001",
-				name: "Model Z",
-				provider_name: "Zeta Provider",
-			},
-			{
-				...mockModel,
-				id: "model-002",
-				name: "Model A",
-				provider_name: "Alpha Provider",
-			},
-		];
-
-		const { user } = renderWithProviders(
-			<ModelTable models={models} providers={[mockProvider]} />,
-		);
-
-		// Click Provider header - use aria-label to find the sort button specifically
-		const providerHeader = screen.getByRole("button", {
-			name: "Sort by Provider",
-		});
-		await user.click(providerHeader);
-
-		await waitFor(() => {
-			const rows = screen.getByRole("table").querySelectorAll("tbody tr");
-			expect(rows.length).toBe(2);
-			// Alpha Provider should appear first
-			expect(rows[0].textContent).toContain("Alpha Provider");
-			expect(rows[1].textContent).toContain("Zeta Provider");
+			// Verify the badge has yellow/warning styling
+			const badge = screen.getByText("Manually Disabled").closest("span");
+			expect(badge?.className).toMatch(/yellow|amber/);
 		});
 	});
-});
 
-describe("Capabilities Column Rendering", () => {
-	it("renders capabilities column with badges", async () => {
-		const models = [
-			{
-				...mockModel,
-				id: "model-001",
-				name: "Few Caps Model",
-				capabilities: '{"streaming":true,"vision":false,"audio_input":false}',
-			},
-			{
-				...mockModel,
-				id: "model-002",
-				name: "Many Caps Model",
-				capabilities: '{"streaming":true,"vision":true,"tools":true}',
-			},
-		];
+	describe("Capability Filter Clear All", () => {
+		it("clears all capability filters when clicking clear all button", async () => {
+			const models = [
+				{
+					...mockModel,
+					id: "model-001",
+					name: "Vision Model",
+					capabilities: '{"streaming":true,"vision":true,"audio_input":true}',
+				},
+				{
+					...mockModel,
+					id: "model-002",
+					name: "Audio Model",
+					capabilities: '{"streaming":true,"vision":false,"audio_input":true}',
+				},
+			];
 
-		renderWithProviders(
-			<ModelTable models={models} providers={[mockProvider]} />,
-		);
+			const { user } = renderWithProviders(
+				<ModelTable models={models} providers={[mockProvider]} />,
+			);
 
-		// Capabilities column header is not sortable (plain <th>, no SortableHeader)
-		await waitFor(() => {
-			const rows = screen.getByRole("table").querySelectorAll("tbody tr");
-			expect(rows.length).toBe(2);
-			// Both models should be visible with their capability badges
-			expect(rows[0].textContent).toContain("Few Caps Model");
-			expect(rows[1].textContent).toContain("Many Caps Model");
-			expect(rows[1].textContent).toContain("Vision");
-		});
-	});
-});
+			// Click Vision filter button
+			const visionFilter = screen.getByRole("button", { name: "Vision" });
+			await user.click(visionFilter);
 
-describe("Fallback to proxyModelID", () => {
-	it("falls back to proxyModelID when model name is missing", () => {
-		const modelWithoutName = {
-			...mockModel,
-			name: undefined,
-		};
+			// Click Audio filter button
+			const audioFilter = screen.getByRole("button", { name: "Audio" });
+			await user.click(audioFilter);
 
-		renderWithProviders(
-			<ModelTable models={[modelWithoutName]} providers={[mockProvider]} />,
-		);
-
-		// Verify it displays the proxyModelID format in the model name cell (first occurrence)
-		const table = screen.getByRole("table");
-		const modelCell = table.querySelector("tbody td");
-		expect(modelCell?.textContent).toContain("Test-Provider/test-model-v1");
-	});
-});
-
-describe("Row Click Without Callback", () => {
-	it("does not throw when clicking row without onModelClick callback", async () => {
-		const { user } = renderWithProviders(
-			<ModelTable models={[mockModel]} providers={[mockProvider]} />,
-		);
-
-		// Click on model row - should not throw
-		const modelRow = screen.getByText("Test Model");
-		await expect(user.click(modelRow)).resolves.not.toThrow();
-	});
-});
-
-describe("Search by Display Name", () => {
-	it("searches by display_name field", async () => {
-		const modelWithDisplayName = {
-			...mockModel,
-			name: "Plain Name",
-			display_name: "Fancy Display Name",
-		};
-
-		const { user } = renderWithProviders(
-			<ModelTable models={[modelWithDisplayName]} providers={[mockProvider]} />,
-		);
-
-		// Type "Fancy" in search
-		const searchInput = screen.getByPlaceholderText("Search models…");
-		await user.type(searchInput, "Fancy");
-
-		await waitFor(() => {
-			// Model should still be visible
-			expect(screen.getByText("Plain Name")).toBeInTheDocument();
-		});
-	});
-});
-
-describe("Search by Model ID", () => {
-	it("searches by model_id field", async () => {
-		const modelWithUniqueID = {
-			...mockModel,
-			name: "Generic",
-			model_id: "unique-model-id-xyz",
-		};
-
-		const { user } = renderWithProviders(
-			<ModelTable models={[modelWithUniqueID]} providers={[mockProvider]} />,
-		);
-
-		// Type "unique-model-id" in search
-		const searchInput = screen.getByPlaceholderText("Search models…");
-		await user.type(searchInput, "unique-model-id");
-
-		await waitFor(() => {
-			// Model should be visible
-			expect(screen.getByText("Generic")).toBeInTheDocument();
-		});
-	});
-});
-
-describe("Pagination Reset on Provider Filter Change", () => {
-	it("resets to page 1 when provider filter changes", async () => {
-		// Create 25+ models for pagination
-		const models = Array.from({ length: 25 }, (_, i) => ({
-			...mockModel,
-			id: `model-${i}`,
-			model_id: `model-${i}`,
-			name: `Model ${i}`,
-			provider_id: i < 15 ? "provider-1" : "provider-2",
-			provider_name: i < 15 ? "Provider 1" : "Provider 2",
-		}));
-
-		const providers = [
-			{ ...mockProvider, id: "provider-1", name: "Provider 1" },
-			{ ...mockProvider, id: "provider-2", name: "Provider 2" },
-		];
-
-		const { user } = renderWithProviders(
-			<ModelTable models={models} providers={providers} />,
-		);
-
-		// Navigate to page 2
-		const page2Button = screen.getByRole("button", { name: "2" });
-		await user.click(page2Button);
-
-		// Verify we're on page 2 (pagination shows "21 to 25 of 25 models")
-		await waitFor(() => {
-			expect(screen.getByText(/21 to 25 of 25/)).toBeInTheDocument();
-		});
-
-		// Open provider filter dropdown
-		const providerFilter = screen.getByText("Filter Providers");
-		await user.click(providerFilter);
-
-		// Click Provider 1 option
-		const allButtons = screen.getAllByRole("button");
-		const provider1Button = allButtons.find(
-			(btn) => btn.textContent === "Provider 1",
-		);
-		if (provider1Button) await user.click(provider1Button);
-
-		// Verify we're back on page 1 (pagination shows "1 to 15 of 15 models")
-		// The text is split across elements, so we check for the key parts
-		await waitFor(() => {
-			const paginationText = screen.getByText((content) => {
-				return content.includes("1") && content.includes("of 15");
+			// Verify both filters are active: only model-001 matches both Vision AND Audio (AND-logic)
+			await waitFor(() => {
+				const rows = screen.getByRole("table").querySelectorAll("tbody tr");
+				expect(rows.length).toBe(1);
 			});
-			expect(paginationText).toBeInTheDocument();
+
+			// Click the ✕ clear button
+			const clearButton = screen.getByText("✕");
+			await user.click(clearButton);
+
+			// Verify both filters are cleared (all models visible again)
+			await waitFor(() => {
+				const rows = screen.getByRole("table").querySelectorAll("tbody tr");
+				expect(rows.length).toBe(2);
+			});
+
+			// Verify ✕ button disappears
+			expect(screen.queryByText("✕")).not.toBeInTheDocument();
+		});
+	});
+
+	describe("Empty State with Null Models", () => {
+		it("renders empty state when models is null", () => {
+			renderWithProviders(
+				<ModelTable
+					models={null as unknown as []}
+					providers={[mockProvider]}
+				/>,
+			);
+
+			expect(
+				screen.getByText(
+					"No models discovered yet. Add a provider and discover models.",
+				),
+			).toBeInTheDocument();
+		});
+	});
+
+	describe("Sort by Provider Name", () => {
+		it("sorts by provider name", async () => {
+			const models = [
+				{
+					...mockModel,
+					id: "model-001",
+					name: "Model Z",
+					provider_name: "Zeta Provider",
+				},
+				{
+					...mockModel,
+					id: "model-002",
+					name: "Model A",
+					provider_name: "Alpha Provider",
+				},
+			];
+
+			const { user } = renderWithProviders(
+				<ModelTable models={models} providers={[mockProvider]} />,
+			);
+
+			// Click Provider header - use aria-label to find the sort button specifically
+			const providerHeader = screen.getByRole("button", {
+				name: "Sort by Provider",
+			});
+			await user.click(providerHeader);
+
+			await waitFor(() => {
+				const rows = screen.getByRole("table").querySelectorAll("tbody tr");
+				expect(rows.length).toBe(2);
+				// Alpha Provider should appear first
+				expect(rows[0].textContent).toContain("Alpha Provider");
+				expect(rows[1].textContent).toContain("Zeta Provider");
+			});
+		});
+	});
+
+	describe("Capabilities Column Rendering", () => {
+		it("renders capabilities column with badges", async () => {
+			const models = [
+				{
+					...mockModel,
+					id: "model-001",
+					name: "Few Caps Model",
+					capabilities: '{"streaming":true,"vision":false,"audio_input":false}',
+				},
+				{
+					...mockModel,
+					id: "model-002",
+					name: "Many Caps Model",
+					capabilities: '{"streaming":true,"vision":true,"tools":true}',
+				},
+			];
+
+			renderWithProviders(
+				<ModelTable models={models} providers={[mockProvider]} />,
+			);
+
+			// Capabilities column header is not sortable (plain <th>, no SortableHeader)
+			await waitFor(() => {
+				const rows = screen.getByRole("table").querySelectorAll("tbody tr");
+				expect(rows.length).toBe(2);
+				// Both models should be visible with their capability badges
+				expect(rows[0].textContent).toContain("Few Caps Model");
+				expect(rows[1].textContent).toContain("Many Caps Model");
+				expect(rows[1].textContent).toContain("Vision");
+			});
+		});
+	});
+
+	describe("Fallback to proxyModelID", () => {
+		it("falls back to proxyModelID when model name is missing", () => {
+			const modelWithoutName = {
+				...mockModel,
+				name: undefined,
+			};
+
+			renderWithProviders(
+				<ModelTable models={[modelWithoutName]} providers={[mockProvider]} />,
+			);
+
+			// Verify it displays the proxyModelID format in the model name cell (first occurrence)
+			const table = screen.getByRole("table");
+			const modelCell = table.querySelector("tbody td");
+			expect(modelCell?.textContent).toContain("Test-Provider/test-model-v1");
+		});
+	});
+
+	describe("Row Click Without Callback", () => {
+		it("does not throw when clicking row without onModelClick callback", async () => {
+			const { user } = renderWithProviders(
+				<ModelTable models={[mockModel]} providers={[mockProvider]} />,
+			);
+
+			// Click on model row - should not throw
+			const modelRow = screen.getByText("Test Model");
+			await expect(user.click(modelRow)).resolves.not.toThrow();
+		});
+	});
+
+	describe("Search by Display Name", () => {
+		it("searches by display_name field", async () => {
+			const modelWithDisplayName = {
+				...mockModel,
+				name: "Plain Name",
+				display_name: "Fancy Display Name",
+			};
+
+			const { user } = renderWithProviders(
+				<ModelTable
+					models={[modelWithDisplayName]}
+					providers={[mockProvider]}
+				/>,
+			);
+
+			// Type "Fancy" in search
+			const searchInput = screen.getByPlaceholderText("Search models…");
+			await user.type(searchInput, "Fancy");
+
+			await waitFor(() => {
+				// Model should still be visible
+				expect(screen.getByText("Plain Name")).toBeInTheDocument();
+			});
+		});
+	});
+
+	describe("Search by Model ID", () => {
+		it("searches by model_id field", async () => {
+			const modelWithUniqueID = {
+				...mockModel,
+				name: "Generic",
+				model_id: "unique-model-id-xyz",
+			};
+
+			const { user } = renderWithProviders(
+				<ModelTable models={[modelWithUniqueID]} providers={[mockProvider]} />,
+			);
+
+			// Type "unique-model-id" in search
+			const searchInput = screen.getByPlaceholderText("Search models…");
+			await user.type(searchInput, "unique-model-id");
+
+			await waitFor(() => {
+				// Model should be visible
+				expect(screen.getByText("Generic")).toBeInTheDocument();
+			});
+		});
+	});
+
+	describe("Pagination Reset on Provider Filter Change", () => {
+		it("resets to page 1 when provider filter changes", async () => {
+			// Create 25+ models for pagination
+			const models = Array.from({ length: 25 }, (_, i) => ({
+				...mockModel,
+				id: `model-${i}`,
+				model_id: `model-${i}`,
+				name: `Model ${i}`,
+				provider_id: i < 15 ? "provider-1" : "provider-2",
+				provider_name: i < 15 ? "Provider 1" : "Provider 2",
+			}));
+
+			const providers = [
+				{ ...mockProvider, id: "provider-1", name: "Provider 1" },
+				{ ...mockProvider, id: "provider-2", name: "Provider 2" },
+			];
+
+			const { user } = renderWithProviders(
+				<ModelTable models={models} providers={providers} />,
+			);
+
+			// Navigate to page 2
+			const page2Button = screen.getByRole("button", { name: "2" });
+			await user.click(page2Button);
+
+			// Verify we're on page 2 (pagination shows "21 to 25 of 25 models")
+			await waitFor(() => {
+				expect(screen.getByText(/21 to 25 of 25/)).toBeInTheDocument();
+			});
+
+			// Open provider filter dropdown
+			const providerFilter = screen.getByText("Filter Providers");
+			await user.click(providerFilter);
+
+			// Click Provider 1 option
+			const provider1Button = screen.getByRole("button", {
+				name: "Provider 1",
+			});
+			await user.click(provider1Button);
+
+			// Verify we're back on page 1 (pagination shows "1 to 15 of 15 models")
+			// The text is split across elements, so we check for the key parts
+			await waitFor(() => {
+				const paginationText = screen.getByText((content) => {
+					return content.includes("1") && content.includes("of 15");
+				});
+				expect(paginationText).toBeInTheDocument();
+			});
 		});
 	});
 });

--- a/web/src/components/__tests__/ModelTable.test.tsx
+++ b/web/src/components/__tests__/ModelTable.test.tsx
@@ -1059,10 +1059,10 @@ describe("ModelTable", () => {
 			await user.click(provider1Button);
 
 			// Verify we're back on page 1 (pagination shows "1 to 15 of 15 models")
-			// The text is split across elements, so we check for the key parts
+			// Anchor "1" to start to avoid matching "21 of 15" (broken state)
 			await waitFor(() => {
 				const paginationText = screen.getByText((content) => {
-					return content.includes("1") && content.includes("of 15");
+					return /^1\b/.test(content) && content.includes("of 15");
 				});
 				expect(paginationText).toBeInTheDocument();
 			});

--- a/web/src/components/__tests__/ModelTable.test.tsx
+++ b/web/src/components/__tests__/ModelTable.test.tsx
@@ -875,13 +875,13 @@ describe("ModelTable", () => {
 				{
 					...mockModel,
 					id: "model-001",
-					name: "Model Z",
+					name: "Model A",
 					provider_name: "Zeta Provider",
 				},
 				{
 					...mockModel,
 					id: "model-002",
-					name: "Model A",
+					name: "Model Z",
 					provider_name: "Alpha Provider",
 				},
 			];

--- a/web/src/components/__tests__/ModelTable.test.tsx
+++ b/web/src/components/__tests__/ModelTable.test.tsx
@@ -950,10 +950,11 @@ describe("ModelTable", () => {
 				<ModelTable models={[modelWithoutName]} providers={[mockProvider]} />,
 			);
 
-			// Verify it displays the proxyModelID format in the model name cell (first occurrence)
+			// Verify it displays the proxyModelID format in the name span specifically
+			// (not the CopyablePill below it, which also shows proxyModelID)
 			const table = screen.getByRole("table");
-			const modelCell = table.querySelector("tbody td");
-			expect(modelCell?.textContent).toContain("Test-Provider/test-model-v1");
+			const nameSpan = table.querySelector("tbody td div > span.font-medium");
+			expect(nameSpan?.textContent).toBe("Test-Provider/test-model-v1");
 		});
 	});
 

--- a/web/src/components/__tests__/ModelTable.test.tsx
+++ b/web/src/components/__tests__/ModelTable.test.tsx
@@ -778,3 +778,289 @@ describe("ModelTable", () => {
 		});
 	});
 });
+
+describe("Manually Disabled Status", () => {
+	it("renders Manually Disabled status badge", () => {
+		const manuallyDisabledModel = {
+			...mockModel,
+			enabled: true,
+			disabled_manually: true,
+		};
+
+		renderWithProviders(
+			<ModelTable
+				models={[manuallyDisabledModel]}
+				providers={[mockProvider]}
+			/>,
+		);
+
+		// Verify "Manually Disabled" text appears
+		expect(screen.getByText("Manually Disabled")).toBeInTheDocument();
+
+		// Verify the badge has yellow/warning styling
+		const badge = screen.getByText("Manually Disabled").closest("span");
+		expect(badge?.className).toMatch(/yellow|amber/);
+	});
+});
+
+describe("Capability Filter Clear All", () => {
+	it("clears all capability filters when clicking clear all button", async () => {
+		const models = [
+			{
+				...mockModel,
+				id: "model-001",
+				name: "Vision Model",
+				capabilities: '{"streaming":true,"vision":true,"audio_input":true}',
+			},
+			{
+				...mockModel,
+				id: "model-002",
+				name: "Audio Model",
+				capabilities: '{"streaming":true,"vision":false,"audio_input":true}',
+			},
+		];
+
+		const { user } = renderWithProviders(
+			<ModelTable models={models} providers={[mockProvider]} />,
+		);
+
+		// Click Vision filter button
+		const visionFilter = screen.getByRole("button", { name: "Vision" });
+		await user.click(visionFilter);
+
+		// Click Audio filter button
+		const audioFilter = screen.getByRole("button", { name: "Audio" });
+		await user.click(audioFilter);
+
+		// Verify both filters are active: only model-001 matches both Vision AND Audio (AND-logic)
+		await waitFor(() => {
+			const rows = screen.getByRole("table").querySelectorAll("tbody tr");
+			expect(rows.length).toBe(1);
+		});
+
+		// Click the ✕ clear button
+		const clearButton = screen.getByText("✕");
+		await user.click(clearButton);
+
+		// Verify both filters are cleared (all models visible again)
+		await waitFor(() => {
+			const rows = screen.getByRole("table").querySelectorAll("tbody tr");
+			expect(rows.length).toBe(2);
+		});
+
+		// Verify ✕ button disappears
+		expect(screen.queryByText("✕")).not.toBeInTheDocument();
+	});
+});
+
+describe("Empty State with Null Models", () => {
+	it("renders empty state when models is null", () => {
+		renderWithProviders(
+			<ModelTable models={null as unknown as []} providers={[mockProvider]} />,
+		);
+
+		expect(
+			screen.getByText(
+				"No models discovered yet. Add a provider and discover models.",
+			),
+		).toBeInTheDocument();
+	});
+});
+
+describe("Sort by Provider Name", () => {
+	it("sorts by provider name", async () => {
+		const models = [
+			{
+				...mockModel,
+				id: "model-001",
+				name: "Model Z",
+				provider_name: "Zeta Provider",
+			},
+			{
+				...mockModel,
+				id: "model-002",
+				name: "Model A",
+				provider_name: "Alpha Provider",
+			},
+		];
+
+		const { user } = renderWithProviders(
+			<ModelTable models={models} providers={[mockProvider]} />,
+		);
+
+		// Click Provider header - use aria-label to find the sort button specifically
+		const providerHeader = screen.getByRole("button", {
+			name: "Sort by Provider",
+		});
+		await user.click(providerHeader);
+
+		await waitFor(() => {
+			const rows = screen.getByRole("table").querySelectorAll("tbody tr");
+			expect(rows.length).toBe(2);
+			// Alpha Provider should appear first
+			expect(rows[0].textContent).toContain("Alpha Provider");
+			expect(rows[1].textContent).toContain("Zeta Provider");
+		});
+	});
+});
+
+describe("Capabilities Column Rendering", () => {
+	it("renders capabilities column with badges", async () => {
+		const models = [
+			{
+				...mockModel,
+				id: "model-001",
+				name: "Few Caps Model",
+				capabilities: '{"streaming":true,"vision":false,"audio_input":false}',
+			},
+			{
+				...mockModel,
+				id: "model-002",
+				name: "Many Caps Model",
+				capabilities: '{"streaming":true,"vision":true,"tools":true}',
+			},
+		];
+
+		renderWithProviders(
+			<ModelTable models={models} providers={[mockProvider]} />,
+		);
+
+		// Capabilities column header is not sortable (plain <th>, no SortableHeader)
+		await waitFor(() => {
+			const rows = screen.getByRole("table").querySelectorAll("tbody tr");
+			expect(rows.length).toBe(2);
+			// Both models should be visible with their capability badges
+			expect(rows[0].textContent).toContain("Few Caps Model");
+			expect(rows[1].textContent).toContain("Many Caps Model");
+			expect(rows[1].textContent).toContain("Vision");
+		});
+	});
+});
+
+describe("Fallback to proxyModelID", () => {
+	it("falls back to proxyModelID when model name is missing", () => {
+		const modelWithoutName = {
+			...mockModel,
+			name: undefined,
+		};
+
+		renderWithProviders(
+			<ModelTable models={[modelWithoutName]} providers={[mockProvider]} />,
+		);
+
+		// Verify it displays the proxyModelID format in the model name cell (first occurrence)
+		const table = screen.getByRole("table");
+		const modelCell = table.querySelector("tbody td");
+		expect(modelCell?.textContent).toContain("Test-Provider/test-model-v1");
+	});
+});
+
+describe("Row Click Without Callback", () => {
+	it("does not throw when clicking row without onModelClick callback", async () => {
+		const { user } = renderWithProviders(
+			<ModelTable models={[mockModel]} providers={[mockProvider]} />,
+		);
+
+		// Click on model row - should not throw
+		const modelRow = screen.getByText("Test Model");
+		await expect(user.click(modelRow)).resolves.not.toThrow();
+	});
+});
+
+describe("Search by Display Name", () => {
+	it("searches by display_name field", async () => {
+		const modelWithDisplayName = {
+			...mockModel,
+			name: "Plain Name",
+			display_name: "Fancy Display Name",
+		};
+
+		const { user } = renderWithProviders(
+			<ModelTable models={[modelWithDisplayName]} providers={[mockProvider]} />,
+		);
+
+		// Type "Fancy" in search
+		const searchInput = screen.getByPlaceholderText("Search models…");
+		await user.type(searchInput, "Fancy");
+
+		await waitFor(() => {
+			// Model should still be visible
+			expect(screen.getByText("Plain Name")).toBeInTheDocument();
+		});
+	});
+});
+
+describe("Search by Model ID", () => {
+	it("searches by model_id field", async () => {
+		const modelWithUniqueID = {
+			...mockModel,
+			name: "Generic",
+			model_id: "unique-model-id-xyz",
+		};
+
+		const { user } = renderWithProviders(
+			<ModelTable models={[modelWithUniqueID]} providers={[mockProvider]} />,
+		);
+
+		// Type "unique-model-id" in search
+		const searchInput = screen.getByPlaceholderText("Search models…");
+		await user.type(searchInput, "unique-model-id");
+
+		await waitFor(() => {
+			// Model should be visible
+			expect(screen.getByText("Generic")).toBeInTheDocument();
+		});
+	});
+});
+
+describe("Pagination Reset on Provider Filter Change", () => {
+	it("resets to page 1 when provider filter changes", async () => {
+		// Create 25+ models for pagination
+		const models = Array.from({ length: 25 }, (_, i) => ({
+			...mockModel,
+			id: `model-${i}`,
+			model_id: `model-${i}`,
+			name: `Model ${i}`,
+			provider_id: i < 15 ? "provider-1" : "provider-2",
+			provider_name: i < 15 ? "Provider 1" : "Provider 2",
+		}));
+
+		const providers = [
+			{ ...mockProvider, id: "provider-1", name: "Provider 1" },
+			{ ...mockProvider, id: "provider-2", name: "Provider 2" },
+		];
+
+		const { user } = renderWithProviders(
+			<ModelTable models={models} providers={providers} />,
+		);
+
+		// Navigate to page 2
+		const page2Button = screen.getByRole("button", { name: "2" });
+		await user.click(page2Button);
+
+		// Verify we're on page 2 (pagination shows "21 to 25 of 25 models")
+		await waitFor(() => {
+			expect(screen.getByText(/21 to 25 of 25/)).toBeInTheDocument();
+		});
+
+		// Open provider filter dropdown
+		const providerFilter = screen.getByText("Filter Providers");
+		await user.click(providerFilter);
+
+		// Click Provider 1 option
+		const allButtons = screen.getAllByRole("button");
+		const provider1Button = allButtons.find(
+			(btn) => btn.textContent === "Provider 1",
+		);
+		if (provider1Button) await user.click(provider1Button);
+
+		// Verify we're back on page 1 (pagination shows "1 to 15 of 15 models")
+		// The text is split across elements, so we check for the key parts
+		await waitFor(() => {
+			const paginationText = screen.getByText((content) => {
+				return content.includes("1") && content.includes("of 15");
+			});
+			expect(paginationText).toBeInTheDocument();
+		});
+	});
+});


### PR DESCRIPTION
## Coverage tests for 3 components

### LogDetailModal (9 tests, commit `fb21772`)
- StatusBadge fallback for 1xx/3xx codes
- Failed badge without error_message
- tokens_per_second null → "-"
- Virtual key name/id fallback (2 tests)
- Reasoning tokens section
- Dial "reused" display (dial_ms=0)
- Overhead total with zero-valued `|| 0` components

### ArenaHistoryModal (12 tests, commit `4125de0`)
- Round labels: Final, Semifinals, Quarterfinals, generic Round N
- Vote-B winner display
- No vote matchup
- Compare error response
- Entry count singular ("1 entry")
- Collapse toggle (asserts `grid-rows-[0fr]` class)
- Missing onRestore → no Restore button
- confirmClear blur reset
- Bracket/Compare fallback labels

### ModelTable (10 tests, commit `a2a1b4f`)
- Manually Disabled status badge
- Clear all capability filters (✕ button)
- Null models → empty state
- Sort by provider name
- Capabilities column rendering with badges
- Model name fallback to proxyModelID
- Row click without callback (no throw)
- Search by display_name
- Search by model_id
- Provider filter resets to page 1

All 145 tests pass across the 3 files.