### PR TITLE
fix: layout cache hit/miss on their own row in token usage

### DIFF
--- a/web/src/components/LogDetailModal.tsx
+++ b/web/src/components/LogDetailModal.tsx
@@ -314,24 +314,26 @@ export function LogDetailModal({ log, type, onClose }: LogDetailModalProps) {
 								</div>
 							)}
 							{hasCache && (
-								<>
-									<div>
-										<div className="text-[11px] uppercase text-(--text-tertiary)">
-											Cache Hit
+								<div className="col-span-2 sm:col-span-4">
+									<div className="grid grid-cols-2 gap-3">
+										<div>
+											<div className="text-[11px] uppercase text-(--text-tertiary)">
+												Cache Hit
+											</div>
+											<div className="text-sm font-mono text-green-400">
+												{requestLog.tokens_prompt_cache_hit.toLocaleString()}
+											</div>
 										</div>
-										<div className="text-sm font-mono text-green-400">
-											{requestLog.tokens_prompt_cache_hit.toLocaleString()}
+										<div>
+											<div className="text-[11px] uppercase text-(--text-tertiary)">
+												Cache Miss
+											</div>
+											<div className="text-sm font-mono text-orange-400">
+												{requestLog.tokens_prompt_cache_miss.toLocaleString()}
+											</div>
 										</div>
 									</div>
-									<div>
-										<div className="text-[11px] uppercase text-(--text-tertiary)">
-											Cache Miss
-										</div>
-										<div className="text-sm font-mono text-orange-400">
-											{requestLog.tokens_prompt_cache_miss.toLocaleString()}
-										</div>
-									</div>
-								</>
+								</div>
 							)}
 						</div>
 					</div>


### PR DESCRIPTION
Cache Hit and Cache Miss were split across the 4-column grid when reasoning tokens were present (Cache Hit at end of row 1, Cache Miss at start of row 2). Now they always appear together on their own row by spanning the full width with an inner 2-column grid for the pair.

**Before:** Prompt | Completion | Reasoning | Cache Hit
             Cache Miss | (empty) | (empty) | (empty)

**After:**  Prompt | Completion | Reasoning | (empty)
             Cache Hit     |     Cache Miss