### PR TITLE
fix: CopyablePill should not stretch full width when lines > 1

### DIFF
--- a/web/src/components/CopyablePill.tsx
+++ b/web/src/components/CopyablePill.tsx
@@ -43,13 +43,11 @@ export const CopyablePill = memo(function CopyablePill({
 	};
 
 	return (
-		<div
-			className={`flex ${lines > 1 ? "items-start w-full" : "items-center"} gap-2 min-w-0 ${className}`}
-		>
+		<div className={`flex items-center gap-2 min-w-0 ${className}`}>
 			<button
 				type="button"
 				onClick={handleCopy}
-				className={`flex ${lines > 1 ? "items-start w-full" : "items-center"} gap-1.5 min-w-0 ${lines > 1 ? "" : "overflow-hidden"} select-none text-left pl-0 pr-1 py-0.5 rounded hover:bg-gray-700 transition-colors cursor-pointer`}
+				className={`flex ${lines > 1 ? "items-start" : "items-center"} gap-1.5 min-w-0 ${lines > 1 ? "" : "overflow-hidden"} select-none text-left pl-0 pr-1 py-0.5 rounded hover:bg-gray-700 transition-colors cursor-pointer`}
 				title={effectiveTitle}
 				aria-label={ariaLabel}
 			>

--- a/web/src/components/__tests__/CopyablePill.test.tsx
+++ b/web/src/components/__tests__/CopyablePill.test.tsx
@@ -85,11 +85,12 @@ describe("CopyablePill", () => {
 		// line-clamp style applied
 		expect(span.style.display).toBe("-webkit-box");
 		expect(span.style.WebkitLineClamp).toBe("2");
-		// button and outer div use items-start and w-full
+		// button uses items-start (icon aligns with first text line)
 		const button = span.closest("button")!;
 		expect(button.className).toContain("items-start");
-		expect(button.className).toContain("w-full");
 		expect(button.className).toContain("text-left");
+		// pill does not stretch full width (sizes to content)
+		expect(button.className).not.toContain("w-full");
 		// default truncate class NOT applied
 		expect(span.className).not.toContain("truncate");
 	});


### PR DESCRIPTION
The model CopyablePill in request details was stretching across the entire cell width because `w-full` was applied when `lines > 1`. This made the pill look wrong and the copy icon misaligned.

**Fix:** Removed `w-full` from both outer div and button when `lines > 1`. The pill now sizes to its content (inline). The `text-left` on the button already prevents browser-default `text-align:center`, so `w-full` was no longer needed.

- Button still uses `items-start` when `lines > 1` (copy icon aligns with first text line)
- Outer div always uses `items-center` (consistent vertical alignment)
- Text remains left-aligned via `text-left` on button