### PR TITLE
fix: pre-commit sync check compares against origin/master

### DIFF
--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -6,15 +6,9 @@ set -euo pipefail
 
 # ── Sync check: refuse commits if branch is behind master ──
 current_branch=$(git rev-parse --abbrev-ref HEAD)
-if [ "$current_branch" != "master" ]; then
-	tracking_branch=$(git rev-parse --abbrev-ref --symbolic-full-name @{upstream} 2>/dev/null || echo "")
-	if [ -n "$tracking_branch" ]; then
-		behind=$(git rev-list --count HEAD.."$tracking_branch" 2>/dev/null || echo "0")
-	else
-		# No upstream set — check against origin/master
-		git fetch origin master --quiet 2>/dev/null || true
-		behind=$(git rev-list --count HEAD..origin/master 2>/dev/null || echo "0")
-	fi
+if [ "$current_branch" != "master" ] && [ "$current_branch" != "HEAD" ]; then
+	git fetch origin master --quiet 2>/dev/null || true
+	behind=$(git rev-list --count HEAD..origin/master 2>/dev/null || echo "0")
 	if [ "$behind" -gt 0 ]; then
 		echo "" >&2
 		echo "⛔ STOP. BRANCH BEHIND MASTER. STOP EVERYTHING." >&2


### PR DESCRIPTION
Fixes three issues in the sync check added in #44:

1. **Tracking-branch path compared wrong ref** — compared against feature branch remote (e.g. `origin/feature/foo`), not `origin/master`. Branch current with its own remote but behind master would pass silently.
2. **No fetch on tracking-branch path** — stale remote-tracking ref meant `behind` could be 0 even when genuinely behind.
3. **Detached HEAD triggered network fetch** — `git rev-parse --abbrev-ref HEAD` returns literal `HEAD` in detached state, which isn't `master`, so the sync check ran and fetched.

Fix: drop tracking-branch path entirely. Always fetch `origin/master` and compare. Skip detached HEAD.