### PR TITLE
Add coverage for App.tsx lazy imports and Models.tsx mutation branches

### DIFF
--- a/web/src/__tests__/App.test.tsx
+++ b/web/src/__tests__/App.test.tsx
@@ -470,4 +470,52 @@ describe("Route navigation", () => {
 			expect(screen.getByText("Arena")).toBeInTheDocument();
 		});
 	});
+
+	it("navigates to Dashboard page", async () => {
+		localStorage.setItem("adminToken", "test-token");
+		renderWithProviders(<App />);
+
+		const dashboardLink = screen.getByRole("link", { name: "Dashboard" });
+		await userEvent.click(dashboardLink);
+
+		await waitFor(() => {
+			expect(screen.getByText("Dashboard")).toBeInTheDocument();
+		});
+	});
+
+	it("navigates to Providers page", async () => {
+		localStorage.setItem("adminToken", "test-token");
+		renderWithProviders(<App />);
+
+		const providersLink = screen.getByRole("link", { name: "Providers" });
+		await userEvent.click(providersLink);
+
+		await waitFor(() => {
+			expect(screen.getByText("Providers")).toBeInTheDocument();
+		});
+	});
+
+	it("navigates to Models page", async () => {
+		localStorage.setItem("adminToken", "test-token");
+		renderWithProviders(<App />);
+
+		const modelsLink = screen.getByRole("link", { name: "Models" });
+		await userEvent.click(modelsLink);
+
+		await waitFor(() => {
+			expect(screen.getByText("Models")).toBeInTheDocument();
+		});
+	});
+
+	it("navigates to Failover Groups page", async () => {
+		localStorage.setItem("adminToken", "test-token");
+		renderWithProviders(<App />);
+
+		const failoverLink = screen.getByRole("link", { name: "Failover" });
+		await userEvent.click(failoverLink);
+
+		await waitFor(() => {
+			expect(screen.getByText("Failover Groups")).toBeInTheDocument();
+		});
+	});
 });

--- a/web/src/__tests__/App.test.tsx
+++ b/web/src/__tests__/App.test.tsx
@@ -5,6 +5,7 @@ import { lazy, Suspense } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import App from "../App";
 import { setAdminToken } from "../api/client";
+import { mockAllDefaults } from "../test/helpers";
 import { server } from "../test/mocks/server";
 import { renderWithProviders } from "../test/utils";
 
@@ -396,5 +397,77 @@ describe("PageSuspense pattern (Suspense with spinner fallback)", () => {
 		);
 
 		expect(screen.getByText("Lazy Loaded")).toBeInTheDocument();
+	});
+});
+
+describe("Route navigation", () => {
+	beforeEach(() => {
+		localStorage.clear();
+		vi.clearAllMocks();
+		server.resetHandlers();
+		server.use(...mockAllDefaults());
+	});
+
+	it("navigates to Logs page", async () => {
+		localStorage.setItem("adminToken", "test-token");
+		renderWithProviders(<App />);
+
+		// Default sub-mode is "request", so link shows "Requests / Logs"
+		const logsLink = screen.getByRole("link", { name: /Requests/ });
+		await userEvent.click(logsLink);
+
+		await waitFor(() => {
+			expect(screen.getByText("Requests")).toBeInTheDocument();
+		});
+	});
+
+	it("navigates to Settings page", async () => {
+		localStorage.setItem("adminToken", "test-token");
+		renderWithProviders(<App />);
+
+		const settingsLink = screen.getByRole("link", { name: "Settings" });
+		await userEvent.click(settingsLink);
+
+		await waitFor(() => {
+			expect(screen.getByText("Settings")).toBeInTheDocument();
+		});
+	});
+
+	it("navigates to Virtual Keys page", async () => {
+		localStorage.setItem("adminToken", "test-token");
+		renderWithProviders(<App />);
+
+		const virtualKeysLink = screen.getByRole("link", { name: "Virtual Keys" });
+		await userEvent.click(virtualKeysLink);
+
+		await waitFor(() => {
+			expect(screen.getByText("Virtual Keys")).toBeInTheDocument();
+		});
+	});
+
+	it("navigates to Chat page", async () => {
+		localStorage.setItem("adminToken", "test-token");
+		renderWithProviders(<App />);
+
+		// Default sub-mode is "chat", so link shows "Chat / Conversation"
+		const chatLink = screen.getByRole("link", { name: /Chat/ });
+		await userEvent.click(chatLink);
+
+		await waitFor(() => {
+			expect(screen.getByText("Chat")).toBeInTheDocument();
+		});
+	});
+
+	it("navigates to Arena page", async () => {
+		localStorage.setItem("adminToken", "test-token");
+		renderWithProviders(<App />);
+
+		// Default sub-mode is "competition", so link shows "Arena / Compare"
+		const arenaLink = screen.getByRole("link", { name: /Arena/ });
+		await userEvent.click(arenaLink);
+
+		await waitFor(() => {
+			expect(screen.getByText("Arena")).toBeInTheDocument();
+		});
 	});
 });

--- a/web/src/__tests__/App.test.tsx
+++ b/web/src/__tests__/App.test.tsx
@@ -412,12 +412,13 @@ describe("Route navigation", () => {
 		localStorage.setItem("adminToken", "test-token");
 		renderWithProviders(<App />);
 
-		// Default sub-mode is "request", so link shows "Requests / Logs"
 		const logsLink = screen.getByRole("link", { name: /Requests/ });
 		await userEvent.click(logsLink);
 
 		await waitFor(() => {
-			expect(screen.getByText("Requests")).toBeInTheDocument();
+			expect(
+				screen.getByText("Monitor API requests across all providers and keys"),
+			).toBeInTheDocument();
 		});
 	});
 
@@ -429,7 +430,9 @@ describe("Route navigation", () => {
 		await userEvent.click(settingsLink);
 
 		await waitFor(() => {
-			expect(screen.getByText("Settings")).toBeInTheDocument();
+			expect(
+				screen.getByText("Configure your Model Hotel instance"),
+			).toBeInTheDocument();
 		});
 	});
 
@@ -441,7 +444,9 @@ describe("Route navigation", () => {
 		await userEvent.click(virtualKeysLink);
 
 		await waitFor(() => {
-			expect(screen.getByText("Virtual Keys")).toBeInTheDocument();
+			expect(
+				screen.getByText(/Issue keys for clients to access the proxy at/),
+			).toBeInTheDocument();
 		});
 	});
 
@@ -449,12 +454,13 @@ describe("Route navigation", () => {
 		localStorage.setItem("adminToken", "test-token");
 		renderWithProviders(<App />);
 
-		// Default sub-mode is "chat", so link shows "Chat / Conversation"
 		const chatLink = screen.getByRole("link", { name: /Chat/ });
 		await userEvent.click(chatLink);
 
 		await waitFor(() => {
-			expect(screen.getByText("Chat")).toBeInTheDocument();
+			expect(
+				screen.getByText("Test enabled models in temporary chat"),
+			).toBeInTheDocument();
 		});
 	});
 
@@ -462,12 +468,13 @@ describe("Route navigation", () => {
 		localStorage.setItem("adminToken", "test-token");
 		renderWithProviders(<App />);
 
-		// Default sub-mode is "competition", so link shows "Arena / Compare"
 		const arenaLink = screen.getByRole("link", { name: /Arena/ });
 		await userEvent.click(arenaLink);
 
 		await waitFor(() => {
-			expect(screen.getByText("Arena")).toBeInTheDocument();
+			expect(
+				screen.getByText("Bracket tournament - models compete head-to-head"),
+			).toBeInTheDocument();
 		});
 	});
 
@@ -476,21 +483,19 @@ describe("Route navigation", () => {
 		renderWithProviders(<App />);
 
 		// Navigate away first (to Settings), since Dashboard is the default route
-		// and "Dashboard" heading is already present from initial render
 		const settingsLink = screen.getByRole("link", { name: "Settings" });
 		await userEvent.click(settingsLink);
 		await waitFor(() => {
-			expect(screen.getByText("Settings")).toBeInTheDocument();
+			expect(
+				screen.getByText("Configure your Model Hotel instance"),
+			).toBeInTheDocument();
 		});
 
 		// Now click Dashboard to verify navigation back works
 		const dashboardLink = screen.getByRole("link", { name: "Dashboard" });
 		await userEvent.click(dashboardLink);
 
-		// Verify navigation by checking URL and a unique Dashboard element
-		// (the header description is unique to Dashboard)
 		await waitFor(() => {
-			// MemoryRouter doesn't update window.location; verify by unique page content
 			expect(
 				screen.getByText("Overview of your Model Hotel usage"),
 			).toBeInTheDocument();
@@ -505,7 +510,9 @@ describe("Route navigation", () => {
 		await userEvent.click(providersLink);
 
 		await waitFor(() => {
-			expect(screen.getByText("Providers")).toBeInTheDocument();
+			expect(
+				screen.getByText("Manage your provider configurations"),
+			).toBeInTheDocument();
 		});
 	});
 
@@ -517,7 +524,9 @@ describe("Route navigation", () => {
 		await userEvent.click(modelsLink);
 
 		await waitFor(() => {
-			expect(screen.getByText("Models")).toBeInTheDocument();
+			expect(
+				screen.getByText("Discovered models from your providers"),
+			).toBeInTheDocument();
 		});
 	});
 
@@ -529,7 +538,11 @@ describe("Route navigation", () => {
 		await userEvent.click(failoverLink);
 
 		await waitFor(() => {
-			expect(screen.getByText("Failover Groups")).toBeInTheDocument();
+			expect(
+				screen.getByText(
+					/Route requests through multiple providers in priority order via/,
+				),
+			).toBeInTheDocument();
 		});
 	});
 });

--- a/web/src/__tests__/App.test.tsx
+++ b/web/src/__tests__/App.test.tsx
@@ -490,7 +490,7 @@ describe("Route navigation", () => {
 		// Verify navigation by checking URL and a unique Dashboard element
 		// (the header description is unique to Dashboard)
 		await waitFor(() => {
-			expect(window.location.pathname).toBe("/");
+			// MemoryRouter doesn't update window.location; verify by unique page content
 			expect(
 				screen.getByText("Overview of your Model Hotel usage"),
 			).toBeInTheDocument();

--- a/web/src/__tests__/App.test.tsx
+++ b/web/src/__tests__/App.test.tsx
@@ -475,11 +475,25 @@ describe("Route navigation", () => {
 		localStorage.setItem("adminToken", "test-token");
 		renderWithProviders(<App />);
 
+		// Navigate away first (to Settings), since Dashboard is the default route
+		// and "Dashboard" heading is already present from initial render
+		const settingsLink = screen.getByRole("link", { name: "Settings" });
+		await userEvent.click(settingsLink);
+		await waitFor(() => {
+			expect(screen.getByText("Settings")).toBeInTheDocument();
+		});
+
+		// Now click Dashboard to verify navigation back works
 		const dashboardLink = screen.getByRole("link", { name: "Dashboard" });
 		await userEvent.click(dashboardLink);
 
+		// Verify navigation by checking URL and a unique Dashboard element
+		// (the header description is unique to Dashboard)
 		await waitFor(() => {
-			expect(screen.getByText("Dashboard")).toBeInTheDocument();
+			expect(window.location.pathname).toBe("/");
+			expect(
+				screen.getByText("Overview of your Model Hotel usage"),
+			).toBeInTheDocument();
 		});
 	});
 

--- a/web/src/pages/Models/__tests__/Models.test.tsx
+++ b/web/src/pages/Models/__tests__/Models.test.tsx
@@ -2,7 +2,8 @@ import { screen, waitFor, within } from "@testing-library/react";
 import { HttpResponse, http } from "msw";
 import { beforeEach, describe, expect, it } from "vitest";
 import type { Model } from "../../../api/types";
-import { mockModel, mockProvider } from "../../../test/mocks/data";
+import { mockAllDefaults } from "../../../test/helpers";
+import { mockModel } from "../../../test/mocks/data";
 import { server } from "../../../test/mocks/server";
 import { renderWithProviders } from "../../../test/utils";
 import { Models } from "../../Models";
@@ -17,14 +18,7 @@ describe("Models", () => {
 		it("starts in scroll mode by default and shows VirtualModelTable", async () => {
 			localStorage.removeItem("modelsViewMode");
 
-			server.use(
-				http.get("/api/models", () => {
-					return HttpResponse.json([mockModel]);
-				}),
-				http.get("/api/providers", () => {
-					return HttpResponse.json([mockProvider]);
-				}),
-			);
+			server.use(...mockAllDefaults());
 
 			renderWithProviders(<Models />);
 
@@ -45,14 +39,7 @@ describe("Models", () => {
 		it("switches from scroll to paginate mode when clicking toggle", async () => {
 			localStorage.removeItem("modelsViewMode");
 
-			server.use(
-				http.get("/api/models", () => {
-					return HttpResponse.json([mockModel]);
-				}),
-				http.get("/api/providers", () => {
-					return HttpResponse.json([mockProvider]);
-				}),
-			);
+			server.use(...mockAllDefaults());
 
 			const { user } = renderWithProviders(<Models />);
 
@@ -77,14 +64,7 @@ describe("Models", () => {
 		});
 
 		it("switches from paginate to scroll mode when clicking toggle", async () => {
-			server.use(
-				http.get("/api/models", () => {
-					return HttpResponse.json([mockModel]);
-				}),
-				http.get("/api/providers", () => {
-					return HttpResponse.json([mockProvider]);
-				}),
-			);
+			server.use(...mockAllDefaults());
 
 			const { user } = renderWithProviders(<Models />);
 
@@ -109,14 +89,7 @@ describe("Models", () => {
 		it("does not show loading spinner in scroll mode even when models query is disabled", async () => {
 			localStorage.removeItem("modelsViewMode");
 
-			server.use(
-				http.get("/api/models", () => {
-					return HttpResponse.json([mockModel]);
-				}),
-				http.get("/api/providers", () => {
-					return HttpResponse.json([mockProvider]);
-				}),
-			);
+			server.use(...mockAllDefaults());
 
 			renderWithProviders(<Models />);
 
@@ -149,14 +122,7 @@ describe("Models", () => {
 
 	describe("Rendering", () => {
 		it("renders page header with correct title and icon", async () => {
-			server.use(
-				http.get("/api/models", () => {
-					return HttpResponse.json([mockModel]);
-				}),
-				http.get("/api/providers", () => {
-					return HttpResponse.json([mockProvider]);
-				}),
-			);
+			server.use(...mockAllDefaults());
 
 			renderWithProviders(<Models />);
 
@@ -175,14 +141,7 @@ describe("Models", () => {
 				{ ...mockModel, id: "model-003", enabled: false },
 			];
 
-			server.use(
-				http.get("/api/models", () => {
-					return HttpResponse.json(models);
-				}),
-				http.get("/api/providers", () => {
-					return HttpResponse.json([mockProvider]);
-				}),
-			);
+			server.use(...mockAllDefaults({ models }));
 
 			renderWithProviders(<Models />);
 
@@ -196,14 +155,7 @@ describe("Models", () => {
 		});
 
 		it("renders model table with models", async () => {
-			server.use(
-				http.get("/api/models", () => {
-					return HttpResponse.json([mockModel]);
-				}),
-				http.get("/api/providers", () => {
-					return HttpResponse.json([mockProvider]);
-				}),
-			);
+			server.use(...mockAllDefaults());
 
 			renderWithProviders(<Models />);
 
@@ -222,14 +174,7 @@ describe("Models", () => {
 		});
 
 		it("renders empty state when no models", async () => {
-			server.use(
-				http.get("/api/models", () => {
-					return HttpResponse.json([]);
-				}),
-				http.get("/api/providers", () => {
-					return HttpResponse.json([mockProvider]);
-				}),
-			);
+			server.use(...mockAllDefaults({ models: [] }));
 
 			renderWithProviders(<Models />);
 
@@ -249,14 +194,7 @@ describe("Models", () => {
 				model_id: `test-model-${i}`,
 			}));
 
-			server.use(
-				http.get("/api/models", () => {
-					return HttpResponse.json(models);
-				}),
-				http.get("/api/providers", () => {
-					return HttpResponse.json([mockProvider]);
-				}),
-			);
+			server.use(...mockAllDefaults({ models }));
 
 			renderWithProviders(<Models />);
 
@@ -271,14 +209,7 @@ describe("Models", () => {
 				{ ...mockModel, id: "model-002", enabled: true },
 			];
 
-			server.use(
-				http.get("/api/models", () => {
-					return HttpResponse.json(models);
-				}),
-				http.get("/api/providers", () => {
-					return HttpResponse.json([mockProvider]);
-				}),
-			);
+			server.use(...mockAllDefaults({ models }));
 
 			renderWithProviders(<Models />);
 
@@ -296,14 +227,7 @@ describe("Models", () => {
 				{ ...mockModel, id: "model-002", enabled: false },
 			];
 
-			server.use(
-				http.get("/api/models", () => {
-					return HttpResponse.json(models);
-				}),
-				http.get("/api/providers", () => {
-					return HttpResponse.json([mockProvider]);
-				}),
-			);
+			server.use(...mockAllDefaults({ models }));
 
 			renderWithProviders(<Models />);
 
@@ -318,14 +242,7 @@ describe("Models", () => {
 
 	describe("Model Interactions", () => {
 		it("opens model detail modal when clicking on a model", async () => {
-			server.use(
-				http.get("/api/models", () => {
-					return HttpResponse.json([mockModel]);
-				}),
-				http.get("/api/providers", () => {
-					return HttpResponse.json([mockProvider]);
-				}),
-			);
+			server.use(...mockAllDefaults());
 
 			const { user } = renderWithProviders(<Models />);
 
@@ -346,12 +263,7 @@ describe("Models", () => {
 
 		it("handles updateMutation success via ModelDetailModal", async () => {
 			server.use(
-				http.get("/api/models", () => {
-					return HttpResponse.json([mockModel]);
-				}),
-				http.get("/api/providers", () => {
-					return HttpResponse.json([mockProvider]);
-				}),
+				...mockAllDefaults(),
 				http.patch("/api/models/:id", async ({ request, params }) => {
 					const body = (await request.json()) as Partial<Model>;
 					return HttpResponse.json({
@@ -400,12 +312,7 @@ describe("Models", () => {
 
 		it("handles updateMutation error via ModelDetailModal", async () => {
 			server.use(
-				http.get("/api/models", () => {
-					return HttpResponse.json([mockModel]);
-				}),
-				http.get("/api/providers", () => {
-					return HttpResponse.json([mockProvider]);
-				}),
+				...mockAllDefaults(),
 				http.patch("/api/models/:id", () => {
 					return HttpResponse.json(
 						{ error: "Database connection failed" },
@@ -452,12 +359,7 @@ describe("Models", () => {
 
 		it("handles deleteMutation success via ModelDetailModal", async () => {
 			server.use(
-				http.get("/api/models", () => {
-					return HttpResponse.json([mockModel]);
-				}),
-				http.get("/api/providers", () => {
-					return HttpResponse.json([mockProvider]);
-				}),
+				...mockAllDefaults(),
 				http.delete("/api/models/:id", () => {
 					return new HttpResponse(null, { status: 204 });
 				}),
@@ -493,16 +395,18 @@ describe("Models", () => {
 					screen.getByText("Model deleted successfully"),
 				).toBeInTheDocument();
 			});
+
+			// Modal should close after deletion
+			await waitFor(() => {
+				expect(
+					screen.queryByRole("heading", { name: "Test Model v1" }),
+				).not.toBeInTheDocument();
+			});
 		});
 
 		it("handles deleteMutation error via ModelDetailModal", async () => {
 			server.use(
-				http.get("/api/models", () => {
-					return HttpResponse.json([mockModel]);
-				}),
-				http.get("/api/providers", () => {
-					return HttpResponse.json([mockProvider]);
-				}),
+				...mockAllDefaults(),
 				http.delete("/api/models/:id", () => {
 					return HttpResponse.json(
 						{ error: "Database constraint violation" },
@@ -543,12 +447,7 @@ describe("Models", () => {
 
 		it("calls handleDiscover and invalidates queries", async () => {
 			server.use(
-				http.get("/api/models", () => {
-					return HttpResponse.json([mockModel]);
-				}),
-				http.get("/api/providers", () => {
-					return HttpResponse.json([mockProvider]);
-				}),
+				...mockAllDefaults(),
 				http.post("/api/providers/:id/discover", () => {
 					return HttpResponse.json({ discovered: 5 });
 				}),
@@ -587,12 +486,7 @@ describe("Models", () => {
 
 		it("calls handleTest and shows success toast", async () => {
 			server.use(
-				http.get("/api/models", () => {
-					return HttpResponse.json([mockModel]);
-				}),
-				http.get("/api/providers", () => {
-					return HttpResponse.json([mockProvider]);
-				}),
+				...mockAllDefaults(),
 				http.post("/api/models/:id/test", () => {
 					return HttpResponse.json({
 						success: true,
@@ -634,12 +528,7 @@ describe("Models", () => {
 
 		it("calls handleTest and shows error toast on failure", async () => {
 			server.use(
-				http.get("/api/models", () => {
-					return HttpResponse.json([mockModel]);
-				}),
-				http.get("/api/providers", () => {
-					return HttpResponse.json([mockProvider]);
-				}),
+				...mockAllDefaults(),
 				http.post("/api/models/:id/test", () => {
 					return HttpResponse.json({
 						success: false,
@@ -678,12 +567,7 @@ describe("Models", () => {
 
 		it("calls handleTest and shows error toast on exception", async () => {
 			server.use(
-				http.get("/api/models", () => {
-					return HttpResponse.json([mockModel]);
-				}),
-				http.get("/api/providers", () => {
-					return HttpResponse.json([mockProvider]);
-				}),
+				...mockAllDefaults(),
 				http.post("/api/models/:id/test", () => {
 					return HttpResponse.json(
 						{ error: "Connection refused" },
@@ -719,12 +603,7 @@ describe("Models", () => {
 
 		it("toggles model enabled/disabled state", async () => {
 			server.use(
-				http.get("/api/models", () => {
-					return HttpResponse.json([mockModel]);
-				}),
-				http.get("/api/providers", () => {
-					return HttpResponse.json([mockProvider]);
-				}),
+				...mockAllDefaults(),
 				http.patch("/api/models/:id", async ({ params }) => {
 					return HttpResponse.json({
 						...mockModel,
@@ -764,12 +643,7 @@ describe("Models", () => {
 
 		it("handles toggleMutation onError", async () => {
 			server.use(
-				http.get("/api/models", () => {
-					return HttpResponse.json([mockModel]);
-				}),
-				http.get("/api/providers", () => {
-					return HttpResponse.json([mockProvider]);
-				}),
+				...mockAllDefaults(),
 				http.patch("/api/models/:id", () => {
 					return HttpResponse.json(
 						{ error: "Database connection failed" },
@@ -808,12 +682,7 @@ describe("Models", () => {
 
 		it("updates detailModel state on toggle success", async () => {
 			server.use(
-				http.get("/api/models", () => {
-					return HttpResponse.json([mockModel]);
-				}),
-				http.get("/api/providers", () => {
-					return HttpResponse.json([mockProvider]);
-				}),
+				...mockAllDefaults(),
 				http.patch("/api/models/:id", async ({ params }) => {
 					return HttpResponse.json({
 						...mockModel,
@@ -852,6 +721,59 @@ describe("Models", () => {
 				).toBeInTheDocument();
 			});
 		});
+
+		it("toggles model from disabled to enabled and shows 'Model enabled' toast", async () => {
+			const disabledModel = {
+				...mockModel,
+				id: "model-disabled",
+				enabled: false,
+			};
+
+			server.use(
+				...mockAllDefaults({ models: [disabledModel] }),
+				http.patch("/api/models/:id", async ({ params }) => {
+					return HttpResponse.json({
+						...disabledModel,
+						id: params.id as string,
+						enabled: true,
+					});
+				}),
+			);
+
+			const { user } = renderWithProviders(<Models />);
+
+			await waitFor(() => {
+				expect(screen.getByText("Test Model")).toBeInTheDocument();
+			});
+
+			// Open detail modal
+			await user.click(screen.getByText("Test Model"));
+
+			await waitFor(() => {
+				expect(
+					screen.getByRole("heading", { name: "Test Model v1" }),
+				).toBeInTheDocument();
+			});
+
+			// Find and click the toggle button (should show "Disabled" initially)
+			const modal = screen.getByRole("dialog");
+			const toggleButton = within(modal).getByRole("button", {
+				name: "Disabled",
+			});
+			await user.click(toggleButton);
+
+			// Should show "Model enabled" toast
+			await waitFor(() => {
+				expect(screen.getByText("Model enabled")).toBeInTheDocument();
+			});
+
+			// After toggle, button should now show "Enabled"
+			await waitFor(() => {
+				expect(
+					within(modal).getByRole("button", { name: "Enabled" }),
+				).toBeInTheDocument();
+			});
+		});
 	});
 
 	describe("countLabel", () => {
@@ -859,14 +781,7 @@ describe("Models", () => {
 			// Ensure paginate mode is set
 			localStorage.setItem("modelsViewMode", "paginate");
 
-			server.use(
-				http.get("/api/models", () => {
-					return HttpResponse.json([]);
-				}),
-				http.get("/api/providers", () => {
-					return HttpResponse.json([mockProvider]);
-				}),
-			);
+			server.use(...mockAllDefaults({ models: [] }));
 
 			renderWithProviders(<Models />);
 
@@ -885,32 +800,27 @@ describe("Models", () => {
 	describe("API Error Handling", () => {
 		it("handles models API error gracefully", async () => {
 			server.use(
-				http.get("/api/models", () => {
-					return HttpResponse.json(
-						{ error: "Failed to fetch" },
-						{ status: 500 },
-					);
-				}),
-				http.get("/api/providers", () => {
-					return HttpResponse.json([mockProvider]);
+				...mockAllDefaults({
+					models: { status: 500, body: { error: "Failed to fetch" } },
 				}),
 			);
 
 			renderWithProviders(<Models />);
 
-			// Should handle error gracefully - may show empty state or error
+			// On query error, models is undefined, so models ?? [] = []
+			// Component renders empty state
 			await waitFor(() => {
 				expect(
-					screen.queryByText(/No models|Failed:|Error/),
+					screen.getByText(
+						"No models discovered yet. Add a provider and discover models.",
+					),
 				).toBeInTheDocument();
 			});
 		});
 
 		it("handles providers API error gracefully", async () => {
 			server.use(
-				http.get("/api/models", () => {
-					return HttpResponse.json([mockModel]);
-				}),
+				...mockAllDefaults(),
 				http.get("/api/providers", () => {
 					return HttpResponse.json(
 						{ error: "Failed to fetch" },

--- a/web/src/pages/Models/__tests__/Models.test.tsx
+++ b/web/src/pages/Models/__tests__/Models.test.tsx
@@ -396,7 +396,10 @@ describe("Models", () => {
 				).toBeInTheDocument();
 			});
 
-			// Modal should close after deletion
+			// Modal closes synchronously on click (onClose called in onClick handler),
+			// independent of the async mutation outcome. This assertion verifies the
+			// UI interaction pattern (click confirm → modal dismisses), not that closure
+			// is a post-success side effect.
 			await waitFor(() => {
 				expect(
 					screen.queryByRole("heading", { name: "Test Model v1" }),
@@ -442,6 +445,15 @@ describe("Models", () => {
 			// Should show error toast - partial match
 			await waitFor(() => {
 				expect(screen.getByText(/Failed to delete model:/)).toBeInTheDocument();
+			});
+
+			// Modal also closes on error path (onClose called synchronously in onClick),
+			// same as success path. This verifies the UI interaction pattern, not that
+			// closure depends on mutation outcome.
+			await waitFor(() => {
+				expect(
+					screen.queryByRole("heading", { name: "Test Model v1" }),
+				).not.toBeInTheDocument();
 			});
 		});
 

--- a/web/src/pages/Models/__tests__/Models.test.tsx
+++ b/web/src/pages/Models/__tests__/Models.test.tsx
@@ -1,0 +1,932 @@
+import { screen, waitFor, within } from "@testing-library/react";
+import { HttpResponse, http } from "msw";
+import { beforeEach, describe, expect, it } from "vitest";
+import type { Model } from "../../../api/types";
+import { mockModel, mockProvider } from "../../../test/mocks/data";
+import { server } from "../../../test/mocks/server";
+import { renderWithProviders } from "../../../test/utils";
+import { Models } from "../../Models";
+
+describe("Models", () => {
+	beforeEach(() => {
+		server.resetHandlers();
+		localStorage.setItem("modelsViewMode", "paginate");
+	});
+
+	describe("View Mode Toggle", () => {
+		it("starts in scroll mode by default and shows VirtualModelTable", async () => {
+			localStorage.removeItem("modelsViewMode");
+
+			server.use(
+				http.get("/api/models", () => {
+					return HttpResponse.json([mockModel]);
+				}),
+				http.get("/api/providers", () => {
+					return HttpResponse.json([mockProvider]);
+				}),
+			);
+
+			renderWithProviders(<Models />);
+
+			// Title should be "Models" (not count label)
+			await waitFor(() => {
+				expect(screen.getByText("Models")).toBeInTheDocument();
+			});
+
+			// Toggle button should show "⬡ Pages" in scroll mode
+			expect(
+				screen.getByRole("button", { name: "Switch to pagination mode" }),
+			).toHaveTextContent("⬡ Pages");
+
+			// Badge should not be shown in scroll mode
+			expect(screen.queryByText(/\d+ enabled/)).not.toBeInTheDocument();
+		});
+
+		it("switches from scroll to paginate mode when clicking toggle", async () => {
+			localStorage.removeItem("modelsViewMode");
+
+			server.use(
+				http.get("/api/models", () => {
+					return HttpResponse.json([mockModel]);
+				}),
+				http.get("/api/providers", () => {
+					return HttpResponse.json([mockProvider]);
+				}),
+			);
+
+			const { user } = renderWithProviders(<Models />);
+
+			await waitFor(() => {
+				expect(screen.getByText("Models")).toBeInTheDocument();
+			});
+
+			// Click toggle to switch to paginate mode
+			await user.click(
+				screen.getByRole("button", { name: "Switch to pagination mode" }),
+			);
+
+			// Should now show count label
+			await waitFor(() => {
+				expect(screen.getByText("1 Model")).toBeInTheDocument();
+			});
+
+			// Toggle button should now show "⇊ Scroll"
+			expect(
+				screen.getByRole("button", { name: "Switch to scroll mode" }),
+			).toHaveTextContent("⇊ Scroll");
+		});
+
+		it("switches from paginate to scroll mode when clicking toggle", async () => {
+			server.use(
+				http.get("/api/models", () => {
+					return HttpResponse.json([mockModel]);
+				}),
+				http.get("/api/providers", () => {
+					return HttpResponse.json([mockProvider]);
+				}),
+			);
+
+			const { user } = renderWithProviders(<Models />);
+
+			await waitFor(() => {
+				expect(screen.getByText("1 Model")).toBeInTheDocument();
+			});
+
+			// Click toggle to switch to scroll mode
+			await user.click(
+				screen.getByRole("button", { name: "Switch to scroll mode" }),
+			);
+
+			// Should now show "Models" without count
+			await waitFor(() => {
+				expect(screen.getByText("Models")).toBeInTheDocument();
+			});
+
+			// Badge should not be shown in scroll mode
+			expect(screen.queryByText(/\d+ enabled/)).not.toBeInTheDocument();
+		});
+
+		it("does not show loading spinner in scroll mode even when models query is disabled", async () => {
+			localStorage.removeItem("modelsViewMode");
+
+			server.use(
+				http.get("/api/models", () => {
+					return HttpResponse.json([mockModel]);
+				}),
+				http.get("/api/providers", () => {
+					return HttpResponse.json([mockProvider]);
+				}),
+			);
+
+			renderWithProviders(<Models />);
+
+			// Should not show spinner - query is disabled in scroll mode
+			expect(screen.queryByTestId("spinner")).not.toBeInTheDocument();
+
+			// Should show title immediately
+			await waitFor(() => {
+				expect(screen.getByText("Models")).toBeInTheDocument();
+			});
+		});
+	});
+
+	describe("Loading State", () => {
+		it("renders loading spinner initially", () => {
+			server.use(
+				http.get("/api/models", () => {
+					return new Promise((resolve) => {
+						setTimeout(() => {
+							resolve(HttpResponse.json([mockModel]));
+						}, 100);
+					});
+				}),
+			);
+
+			renderWithProviders(<Models />);
+			expect(screen.getByTestId("spinner")).toBeInTheDocument();
+		});
+	});
+
+	describe("Rendering", () => {
+		it("renders page header with correct title and icon", async () => {
+			server.use(
+				http.get("/api/models", () => {
+					return HttpResponse.json([mockModel]);
+				}),
+				http.get("/api/providers", () => {
+					return HttpResponse.json([mockProvider]);
+				}),
+			);
+
+			renderWithProviders(<Models />);
+
+			await waitFor(() => {
+				expect(screen.getByText("1 Model")).toBeInTheDocument();
+			});
+			expect(
+				screen.getByText("Discovered models from your providers"),
+			).toBeInTheDocument();
+		});
+
+		it("renders model count badge with enabled/disabled breakdown", async () => {
+			const models = [
+				{ ...mockModel, id: "model-001", enabled: true },
+				{ ...mockModel, id: "model-002", enabled: true },
+				{ ...mockModel, id: "model-003", enabled: false },
+			];
+
+			server.use(
+				http.get("/api/models", () => {
+					return HttpResponse.json(models);
+				}),
+				http.get("/api/providers", () => {
+					return HttpResponse.json([mockProvider]);
+				}),
+			);
+
+			renderWithProviders(<Models />);
+
+			await waitFor(() => {
+				expect(screen.getByText("3 Models")).toBeInTheDocument();
+			});
+
+			// Badge should show breakdown
+			expect(screen.getByText("2 enabled")).toBeInTheDocument();
+			expect(screen.getByText("1 disabled")).toBeInTheDocument();
+		});
+
+		it("renders model table with models", async () => {
+			server.use(
+				http.get("/api/models", () => {
+					return HttpResponse.json([mockModel]);
+				}),
+				http.get("/api/providers", () => {
+					return HttpResponse.json([mockProvider]);
+				}),
+			);
+
+			renderWithProviders(<Models />);
+
+			await waitFor(() => {
+				expect(screen.getByText("Test Model")).toBeInTheDocument();
+			});
+
+			// Table should have headers
+			expect(screen.getByText("Model")).toBeInTheDocument();
+			expect(screen.getByText("Capabilities")).toBeInTheDocument();
+			expect(screen.getByText("Provider")).toBeInTheDocument();
+			expect(screen.getByText("Discovered")).toBeInTheDocument();
+			expect(screen.getByText("Ctx")).toBeInTheDocument();
+			expect(screen.getByText("Max Out")).toBeInTheDocument();
+			expect(screen.getByText("Status")).toBeInTheDocument();
+		});
+
+		it("renders empty state when no models", async () => {
+			server.use(
+				http.get("/api/models", () => {
+					return HttpResponse.json([]);
+				}),
+				http.get("/api/providers", () => {
+					return HttpResponse.json([mockProvider]);
+				}),
+			);
+
+			renderWithProviders(<Models />);
+
+			await waitFor(() => {
+				expect(
+					screen.getByText(
+						"No models discovered yet. Add a provider and discover models.",
+					),
+				).toBeInTheDocument();
+			});
+		});
+
+		it("renders model count in header correctly", async () => {
+			const models = Array.from({ length: 5 }, (_, i) => ({
+				...mockModel,
+				id: `model-${i}`,
+				model_id: `test-model-${i}`,
+			}));
+
+			server.use(
+				http.get("/api/models", () => {
+					return HttpResponse.json(models);
+				}),
+				http.get("/api/providers", () => {
+					return HttpResponse.json([mockProvider]);
+				}),
+			);
+
+			renderWithProviders(<Models />);
+
+			await waitFor(() => {
+				expect(screen.getByText("5 Models")).toBeInTheDocument();
+			});
+		});
+
+		it("shows all models enabled badge when all are enabled", async () => {
+			const models = [
+				{ ...mockModel, id: "model-001", enabled: true },
+				{ ...mockModel, id: "model-002", enabled: true },
+			];
+
+			server.use(
+				http.get("/api/models", () => {
+					return HttpResponse.json(models);
+				}),
+				http.get("/api/providers", () => {
+					return HttpResponse.json([mockProvider]);
+				}),
+			);
+
+			renderWithProviders(<Models />);
+
+			await waitFor(() => {
+				expect(screen.getByText("2 Models")).toBeInTheDocument();
+			});
+
+			// No breakdown badge when all same state
+			expect(screen.queryByText(/\d+ enabled/)).not.toBeInTheDocument();
+		});
+
+		it("shows all models disabled badge when all are disabled", async () => {
+			const models = [
+				{ ...mockModel, id: "model-001", enabled: false },
+				{ ...mockModel, id: "model-002", enabled: false },
+			];
+
+			server.use(
+				http.get("/api/models", () => {
+					return HttpResponse.json(models);
+				}),
+				http.get("/api/providers", () => {
+					return HttpResponse.json([mockProvider]);
+				}),
+			);
+
+			renderWithProviders(<Models />);
+
+			await waitFor(() => {
+				expect(screen.getByText("2 Models")).toBeInTheDocument();
+			});
+
+			// No breakdown badge when all same state
+			expect(screen.queryByText("disabled")).not.toBeInTheDocument();
+		});
+	});
+
+	describe("Model Interactions", () => {
+		it("opens model detail modal when clicking on a model", async () => {
+			server.use(
+				http.get("/api/models", () => {
+					return HttpResponse.json([mockModel]);
+				}),
+				http.get("/api/providers", () => {
+					return HttpResponse.json([mockProvider]);
+				}),
+			);
+
+			const { user } = renderWithProviders(<Models />);
+
+			await waitFor(() => {
+				expect(screen.getByText("Test Model")).toBeInTheDocument();
+			});
+
+			// Click on the model row
+			await user.click(screen.getByText("Test Model"));
+
+			// Modal should open
+			await waitFor(() => {
+				expect(
+					screen.getByRole("heading", { name: "Test Model v1" }),
+				).toBeInTheDocument();
+			});
+		});
+
+		it("handles updateMutation success via ModelDetailModal", async () => {
+			server.use(
+				http.get("/api/models", () => {
+					return HttpResponse.json([mockModel]);
+				}),
+				http.get("/api/providers", () => {
+					return HttpResponse.json([mockProvider]);
+				}),
+				http.patch("/api/models/:id", async ({ request, params }) => {
+					const body = (await request.json()) as Partial<Model>;
+					return HttpResponse.json({
+						...mockModel,
+						id: params.id as string,
+						...body,
+					});
+				}),
+			);
+
+			const { user } = renderWithProviders(<Models />);
+
+			await waitFor(() => {
+				expect(screen.getByText("Test Model")).toBeInTheDocument();
+			});
+
+			// Open detail modal
+			await user.click(screen.getByText("Test Model"));
+
+			await waitFor(() => {
+				expect(
+					screen.getByRole("heading", { name: "Test Model v1" }),
+				).toBeInTheDocument();
+			});
+
+			// Click edit button
+			const modal = screen.getByRole("dialog");
+			await user.click(within(modal).getByRole("button", { name: "Edit" }));
+
+			// Change display name - find the display name input (first textbox)
+			const inputs = within(modal).getAllByRole("textbox");
+			const displayNameField = inputs[0];
+			await user.clear(displayNameField);
+			await user.type(displayNameField, "Updated Model Name");
+
+			// Click save
+			await user.click(
+				within(modal).getByRole("button", { name: "Save Changes" }),
+			);
+
+			// Should show success toast
+			await waitFor(() => {
+				expect(screen.getByText("Model updated")).toBeInTheDocument();
+			});
+		});
+
+		it("handles updateMutation error via ModelDetailModal", async () => {
+			server.use(
+				http.get("/api/models", () => {
+					return HttpResponse.json([mockModel]);
+				}),
+				http.get("/api/providers", () => {
+					return HttpResponse.json([mockProvider]);
+				}),
+				http.patch("/api/models/:id", () => {
+					return HttpResponse.json(
+						{ error: "Database connection failed" },
+						{ status: 500 },
+					);
+				}),
+			);
+
+			const { user } = renderWithProviders(<Models />);
+
+			await waitFor(() => {
+				expect(screen.getByText("Test Model")).toBeInTheDocument();
+			});
+
+			// Open detail modal
+			await user.click(screen.getByText("Test Model"));
+
+			await waitFor(() => {
+				expect(
+					screen.getByRole("heading", { name: "Test Model v1" }),
+				).toBeInTheDocument();
+			});
+
+			// Click edit button
+			const modal = screen.getByRole("dialog");
+			await user.click(within(modal).getByRole("button", { name: "Edit" }));
+
+			// Change display name - find the display name input (first textbox)
+			const inputs = within(modal).getAllByRole("textbox");
+			const displayNameField = inputs[0];
+			await user.clear(displayNameField);
+			await user.type(displayNameField, "Updated Model Name");
+
+			// Click save
+			await user.click(
+				within(modal).getByRole("button", { name: "Save Changes" }),
+			);
+
+			// Should show error toast - check for partial match
+			await waitFor(() => {
+				expect(screen.getByText(/Failed to update model:/)).toBeInTheDocument();
+			});
+		});
+
+		it("handles deleteMutation success via ModelDetailModal", async () => {
+			server.use(
+				http.get("/api/models", () => {
+					return HttpResponse.json([mockModel]);
+				}),
+				http.get("/api/providers", () => {
+					return HttpResponse.json([mockProvider]);
+				}),
+				http.delete("/api/models/:id", () => {
+					return new HttpResponse(null, { status: 204 });
+				}),
+			);
+
+			const { user } = renderWithProviders(<Models />);
+
+			await waitFor(() => {
+				expect(screen.getByText("Test Model")).toBeInTheDocument();
+			});
+
+			// Open detail modal
+			await user.click(screen.getByText("Test Model"));
+
+			await waitFor(() => {
+				expect(
+					screen.getByRole("heading", { name: "Test Model v1" }),
+				).toBeInTheDocument();
+			});
+
+			// Click delete button
+			const modal = screen.getByRole("dialog");
+			await user.click(within(modal).getByRole("button", { name: "Delete" }));
+
+			// Click confirm delete
+			await user.click(
+				within(modal).getByRole("button", { name: "Confirm delete" }),
+			);
+
+			// Should show success toast
+			await waitFor(() => {
+				expect(
+					screen.getByText("Model deleted successfully"),
+				).toBeInTheDocument();
+			});
+		});
+
+		it("handles deleteMutation error via ModelDetailModal", async () => {
+			server.use(
+				http.get("/api/models", () => {
+					return HttpResponse.json([mockModel]);
+				}),
+				http.get("/api/providers", () => {
+					return HttpResponse.json([mockProvider]);
+				}),
+				http.delete("/api/models/:id", () => {
+					return HttpResponse.json(
+						{ error: "Database constraint violation" },
+						{ status: 500 },
+					);
+				}),
+			);
+
+			const { user } = renderWithProviders(<Models />);
+
+			await waitFor(() => {
+				expect(screen.getByText("Test Model")).toBeInTheDocument();
+			});
+
+			// Open detail modal
+			await user.click(screen.getByText("Test Model"));
+
+			await waitFor(() => {
+				expect(
+					screen.getByRole("heading", { name: "Test Model v1" }),
+				).toBeInTheDocument();
+			});
+
+			// Click delete button
+			const modal = screen.getByRole("dialog");
+			await user.click(within(modal).getByRole("button", { name: "Delete" }));
+
+			// Click confirm delete
+			await user.click(
+				within(modal).getByRole("button", { name: "Confirm delete" }),
+			);
+
+			// Should show error toast - partial match
+			await waitFor(() => {
+				expect(screen.getByText(/Failed to delete model:/)).toBeInTheDocument();
+			});
+		});
+
+		it("calls handleDiscover and invalidates queries", async () => {
+			server.use(
+				http.get("/api/models", () => {
+					return HttpResponse.json([mockModel]);
+				}),
+				http.get("/api/providers", () => {
+					return HttpResponse.json([mockProvider]);
+				}),
+				http.post("/api/providers/:id/discover", () => {
+					return HttpResponse.json({ discovered: 5 });
+				}),
+			);
+
+			const { user } = renderWithProviders(<Models />);
+
+			await waitFor(() => {
+				expect(screen.getByText("Test Model")).toBeInTheDocument();
+			});
+
+			// Open detail modal
+			await user.click(screen.getByText("Test Model"));
+
+			await waitFor(() => {
+				expect(
+					screen.getByRole("heading", { name: "Test Model v1" }),
+				).toBeInTheDocument();
+			});
+
+			// Click "Update info" button (discover)
+			const modal = screen.getByRole("dialog");
+			const updateButton = within(modal).getByRole("button", {
+				name: "Update info",
+			});
+			await user.click(updateButton);
+
+			// After discovery completes, should show cooldown
+			await waitFor(
+				() => {
+					expect(updateButton).toHaveTextContent(/Update \(\d+s\)/);
+				},
+				{ timeout: 5000 },
+			);
+		});
+
+		it("calls handleTest and shows success toast", async () => {
+			server.use(
+				http.get("/api/models", () => {
+					return HttpResponse.json([mockModel]);
+				}),
+				http.get("/api/providers", () => {
+					return HttpResponse.json([mockProvider]);
+				}),
+				http.post("/api/models/:id/test", () => {
+					return HttpResponse.json({
+						success: true,
+						ttft_ms: 150,
+						duration_ms: 800,
+						response: "This is a test response from the model",
+					});
+				}),
+			);
+
+			const { user } = renderWithProviders(<Models />);
+
+			await waitFor(() => {
+				expect(screen.getByText("Test Model")).toBeInTheDocument();
+			});
+
+			// Open detail modal
+			await user.click(screen.getByText("Test Model"));
+
+			await waitFor(() => {
+				expect(
+					screen.getByRole("heading", { name: "Test Model v1" }),
+				).toBeInTheDocument();
+			});
+
+			// Click Test button
+			const modal = screen.getByRole("dialog");
+			const testButton = within(modal).getByRole("button", { name: "Test" });
+			await user.click(testButton);
+
+			// Should show success toast
+			await waitFor(
+				() => {
+					expect(screen.getByText(/^Success \|/)).toBeInTheDocument();
+				},
+				{ timeout: 5000 },
+			);
+		});
+
+		it("calls handleTest and shows error toast on failure", async () => {
+			server.use(
+				http.get("/api/models", () => {
+					return HttpResponse.json([mockModel]);
+				}),
+				http.get("/api/providers", () => {
+					return HttpResponse.json([mockProvider]);
+				}),
+				http.post("/api/models/:id/test", () => {
+					return HttpResponse.json({
+						success: false,
+						ttft_ms: 0,
+						duration_ms: 0,
+						response: "",
+						error: "Model timeout",
+					});
+				}),
+			);
+
+			const { user } = renderWithProviders(<Models />);
+
+			await waitFor(() => {
+				expect(screen.getByText("Test Model")).toBeInTheDocument();
+			});
+
+			// Open detail modal
+			await user.click(screen.getByText("Test Model"));
+
+			await waitFor(() => {
+				expect(
+					screen.getByRole("heading", { name: "Test Model v1" }),
+				).toBeInTheDocument();
+			});
+
+			// Click Test button
+			const modal = screen.getByRole("dialog");
+			await user.click(within(modal).getByRole("button", { name: "Test" }));
+
+			// Should show error toast
+			await waitFor(() => {
+				expect(screen.getByText(/Test failed:/)).toBeInTheDocument();
+			});
+		});
+
+		it("calls handleTest and shows error toast on exception", async () => {
+			server.use(
+				http.get("/api/models", () => {
+					return HttpResponse.json([mockModel]);
+				}),
+				http.get("/api/providers", () => {
+					return HttpResponse.json([mockProvider]);
+				}),
+				http.post("/api/models/:id/test", () => {
+					return HttpResponse.json(
+						{ error: "Connection refused" },
+						{ status: 500 },
+					);
+				}),
+			);
+
+			const { user } = renderWithProviders(<Models />);
+
+			await waitFor(() => {
+				expect(screen.getByText("Test Model")).toBeInTheDocument();
+			});
+
+			// Open detail modal
+			await user.click(screen.getByText("Test Model"));
+
+			await waitFor(() => {
+				expect(
+					screen.getByRole("heading", { name: "Test Model v1" }),
+				).toBeInTheDocument();
+			});
+
+			// Click Test button
+			const modal = screen.getByRole("dialog");
+			await user.click(within(modal).getByRole("button", { name: "Test" }));
+
+			// Should show error toast
+			await waitFor(() => {
+				expect(screen.getByText(/Test failed:/)).toBeInTheDocument();
+			});
+		});
+
+		it("toggles model enabled/disabled state", async () => {
+			server.use(
+				http.get("/api/models", () => {
+					return HttpResponse.json([mockModel]);
+				}),
+				http.get("/api/providers", () => {
+					return HttpResponse.json([mockProvider]);
+				}),
+				http.patch("/api/models/:id", async ({ params }) => {
+					return HttpResponse.json({
+						...mockModel,
+						id: params.id as string,
+						enabled: false,
+					});
+				}),
+			);
+
+			const { user } = renderWithProviders(<Models />);
+
+			await waitFor(() => {
+				expect(screen.getByText("Test Model")).toBeInTheDocument();
+			});
+
+			// Open detail modal
+			await user.click(screen.getByText("Test Model"));
+
+			await waitFor(() => {
+				expect(
+					screen.getByRole("heading", { name: "Test Model v1" }),
+				).toBeInTheDocument();
+			});
+
+			// Find and click the toggle button in the modal
+			const modal = screen.getByRole("dialog");
+			const toggleButton = within(modal).getByRole("button", {
+				name: /Enabled|Disabled/i,
+			});
+			await user.click(toggleButton);
+
+			// Should show toast
+			await waitFor(() => {
+				expect(screen.getByText("Model disabled")).toBeInTheDocument();
+			});
+		});
+
+		it("handles toggleMutation onError", async () => {
+			server.use(
+				http.get("/api/models", () => {
+					return HttpResponse.json([mockModel]);
+				}),
+				http.get("/api/providers", () => {
+					return HttpResponse.json([mockProvider]);
+				}),
+				http.patch("/api/models/:id", () => {
+					return HttpResponse.json(
+						{ error: "Database connection failed" },
+						{ status: 500 },
+					);
+				}),
+			);
+
+			const { user } = renderWithProviders(<Models />);
+
+			await waitFor(() => {
+				expect(screen.getByText("Test Model")).toBeInTheDocument();
+			});
+
+			// Open detail modal
+			await user.click(screen.getByText("Test Model"));
+
+			await waitFor(() => {
+				expect(
+					screen.getByRole("heading", { name: "Test Model v1" }),
+				).toBeInTheDocument();
+			});
+
+			// Find and click the toggle button in the modal
+			const modal = screen.getByRole("dialog");
+			const toggleButton = within(modal).getByRole("button", {
+				name: /Enabled|Disabled/i,
+			});
+			await user.click(toggleButton);
+
+			// Should show error toast - partial match
+			await waitFor(() => {
+				expect(screen.getByText(/Failed to update model:/)).toBeInTheDocument();
+			});
+		});
+
+		it("updates detailModel state on toggle success", async () => {
+			server.use(
+				http.get("/api/models", () => {
+					return HttpResponse.json([mockModel]);
+				}),
+				http.get("/api/providers", () => {
+					return HttpResponse.json([mockProvider]);
+				}),
+				http.patch("/api/models/:id", async ({ params }) => {
+					return HttpResponse.json({
+						...mockModel,
+						id: params.id as string,
+						enabled: false,
+					});
+				}),
+			);
+
+			const { user } = renderWithProviders(<Models />);
+
+			await waitFor(() => {
+				expect(screen.getByText("Test Model")).toBeInTheDocument();
+			});
+
+			// Open detail modal
+			await user.click(screen.getByText("Test Model"));
+
+			await waitFor(() => {
+				expect(
+					screen.getByRole("heading", { name: "Test Model v1" }),
+				).toBeInTheDocument();
+			});
+
+			// Find and click the toggle button in the modal
+			const modal = screen.getByRole("dialog");
+			const toggleButton = within(modal).getByRole("button", {
+				name: "Enabled",
+			});
+			await user.click(toggleButton);
+
+			// After toggle, button should now show "Disabled"
+			await waitFor(() => {
+				expect(
+					within(modal).getByRole("button", { name: "Disabled" }),
+				).toBeInTheDocument();
+			});
+		});
+	});
+
+	describe("countLabel", () => {
+		it("shows 'Models' (without count) when 0 models in paginate mode", async () => {
+			// Ensure paginate mode is set
+			localStorage.setItem("modelsViewMode", "paginate");
+
+			server.use(
+				http.get("/api/models", () => {
+					return HttpResponse.json([]);
+				}),
+				http.get("/api/providers", () => {
+					return HttpResponse.json([mockProvider]);
+				}),
+			);
+
+			renderWithProviders(<Models />);
+
+			// countLabel returns just "Models" for 0 count (not "0 Models")
+			await waitFor(() => {
+				expect(screen.getByText("Models")).toBeInTheDocument();
+			});
+
+			// Verify paginate mode is active (toggle button should show "⇊ Scroll")
+			expect(
+				screen.getByRole("button", { name: "Switch to scroll mode" }),
+			).toBeInTheDocument();
+		});
+	});
+
+	describe("API Error Handling", () => {
+		it("handles models API error gracefully", async () => {
+			server.use(
+				http.get("/api/models", () => {
+					return HttpResponse.json(
+						{ error: "Failed to fetch" },
+						{ status: 500 },
+					);
+				}),
+				http.get("/api/providers", () => {
+					return HttpResponse.json([mockProvider]);
+				}),
+			);
+
+			renderWithProviders(<Models />);
+
+			// Should handle error gracefully - may show empty state or error
+			await waitFor(() => {
+				expect(
+					screen.queryByText(/No models|Failed:|Error/),
+				).toBeInTheDocument();
+			});
+		});
+
+		it("handles providers API error gracefully", async () => {
+			server.use(
+				http.get("/api/models", () => {
+					return HttpResponse.json([mockModel]);
+				}),
+				http.get("/api/providers", () => {
+					return HttpResponse.json(
+						{ error: "Failed to fetch" },
+						{ status: 500 },
+					);
+				}),
+			);
+
+			renderWithProviders(<Models />);
+
+			await waitFor(() => {
+				expect(screen.getByText("Test Model")).toBeInTheDocument();
+			});
+
+			// Should still render models without provider data
+			expect(screen.getByText("Test Model")).toBeInTheDocument();
+		});
+	});
+});

--- a/web/src/pages/Models/__tests__/Models.test.tsx
+++ b/web/src/pages/Models/__tests__/Models.test.tsx
@@ -832,12 +832,8 @@ describe("Models", () => {
 
 		it("handles providers API error gracefully", async () => {
 			server.use(
-				...mockAllDefaults(),
-				http.get("/api/providers", () => {
-					return HttpResponse.json(
-						{ error: "Failed to fetch" },
-						{ status: 500 },
-					);
+				...mockAllDefaults({
+					providers: { status: 500, body: { error: "Failed to fetch" } },
 				}),
 			);
 


### PR DESCRIPTION
## Coverage Improvements

### App.tsx
- Added 9 route navigation tests covering all lazy import callbacks (Dashboard, Providers, Models, FailoverGroups, Logs, Settings, VirtualKeys, Chat, Arena)
- **71% → 85% stmts**, **35% → 65% func**, **82% → 92% lines**

### Models.tsx
- 28 tests covering handleToggleModel (enable/disable), handleUpdateModel, deleteMutation, handleDiscover, handleTest, view mode toggle, model badge, API error handling
- Used `mockAllDefaults()` for clean handler setup
- **90% branches** (V8 coverage for inline mutation callbacks; enable-toggle path now covered)

### Oracle review addressed (fbce725)
1. Sharpened API error test — exact empty-state text instead of vague regex
2. Added enable-toggle test (disabled→enabled, "Model enabled" toast)
3. Added 4 missing lazy route tests (Dashboard, Providers, Models, FailoverGroups)
4. Delete success test now verifies modal closes
5. Replaced duplicated handler blocks with `mockAllDefaults()`