### PR TITLE
Remove DB port exposure from docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,8 +281,6 @@ ADMIN_TOKEN=
                 - POSTGRES_DB=${POSTGRES_DB:-modelhotel}
             volumes:
                 - ./.data/pgdata:/var/lib/postgresql/data
-            ports:
-                - "5432:5432"
             healthcheck:
                 test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-modelhotel}"]
                 interval: 5s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,8 +49,6 @@ services:
             - POSTGRES_DB=${POSTGRES_DB:-modelhotel}
         volumes:
             - ./.data/pgdata:/var/lib/postgresql/data
-        ports:
-            - "5432:5432"
         healthcheck:
             test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-modelhotel}"]
             interval: 5s


### PR DESCRIPTION
## Summary
Removes the `ports: - "5432:5432"` block from the `db` service in `docker-compose.yml`.

## Rationale
The `app` service connects to PostgreSQL via the internal Docker network hostname `db` (set by `POSTGRES_HOST=db`). Publishing port 5432 to the host is unnecessary for the application to function and exposes the database to the host network, which is a security concern in production.

The test compose file (`docker-compose.test.yml`) retains its port mapping (5433:5432) since it's dev-only and intentionally exposes the test DB for local tooling.

## Testing
Verified working in production without the port exposure.