### PR TITLE
fix: pass branch name to tokensave branch add in reference-transaction hook

### DIFF
--- a/scripts/reference-transaction
+++ b/scripts/reference-transaction
@@ -10,7 +10,7 @@ if [ "$state" = "committed" ]; then
 		if [ "$old_rev" = "$zero" ]; then
 			branch="${ref_name#refs/heads/}"
 			if [ "$ref_name" != "$branch" ]; then
-				tokensave branch add || true
+				tokensave branch add "$branch" || true
 			fi
 		fi
 	done


### PR DESCRIPTION
The `reference-transaction` hook extracts the branch name from `$ref_name` but then runs `tokensave branch add` without passing it, relying on the default (current branch). This works by accident for `checkout -b` but fails for other ref transaction patterns and is fragile.

Fix: pass `"$branch"` explicitly to `tokensave branch add`.