### PR TITLE
Replace esoteric Go errors with human-readable messages in request logs

### DIFF
--- a/internal/proxy/logging.go
+++ b/internal/proxy/logging.go
@@ -13,10 +13,14 @@ import (
 )
 
 // insertRequestLogAsync pre-generates the log ID and fires off the DB
-// insert + SSE event in a goroutine so the handler is not blocked by the
-// write. The ID is assigned synchronously so updateRequestLog can reference
-// it later. If the insert fails, the error is logged but does not fail the
-// request — the update will simply be a no-op.
+// insert in a goroutine so the handler is not blocked by the write. The ID
+// is assigned synchronously so updateRequestLog can reference it later. If
+// the insert fails, the error is logged but does not fail the request —
+// the update will simply be a no-op.
+//
+// Note: The SSE "request.started" event is NOT published here because
+// modelID may be empty when this is called (before body parsing). Call
+// publishRequestStartedEvent after modelID is resolved.
 func (h *Handler) insertRequestLogAsync(logEntry *requestLogData) {
 	logEntry.id = uuid.New().String()
 	logEntry.requestHash = generateRequestHash()
@@ -62,21 +66,27 @@ func (h *Handler) insertRequestLogAsync(logEntry *requestLogData) {
 		)
 		if err != nil {
 			debuglog.Error("proxy: failed to insert initial request log", "request_id", id, "error", err)
-			return
 		}
-		events.Publish(events.Event{
-			Type:     "request.started",
-			Severity: "info",
-			Source:   "proxy",
-			Message:  fmt.Sprintf("Request started: %s", modelID),
-			Metadata: map[string]interface{}{
-				"request_id": id,
-				"model_id":   modelID,
-				"streaming":  streaming,
-				"state":      state,
-			},
-		})
 	}()
+}
+
+// publishRequestStartedEvent emits the SSE "request.started" event.
+// Call this after modelID is resolved so the event always carries the
+// correct model (previously this was embedded in insertRequestLogAsync,
+// which could fire before body parsing had set modelID).
+func publishRequestStartedEvent(logEntry *requestLogData) {
+	events.Publish(events.Event{
+		Type:     "request.started",
+		Severity: "info",
+		Source:   "proxy",
+		Message:  fmt.Sprintf("Request started: %s", logEntry.modelID),
+		Metadata: map[string]interface{}{
+			"request_id": logEntry.id,
+			"model_id":   logEntry.modelID,
+			"streaming":  logEntry.streaming,
+			"state":      logEntry.state,
+		},
+	})
 }
 
 // WaitForInsert blocks until the async INSERT goroutine has completed (or

--- a/internal/proxy/logging.go
+++ b/internal/proxy/logging.go
@@ -20,6 +20,12 @@ import (
 func (h *Handler) insertRequestLogAsync(logEntry *requestLogData) {
 	logEntry.id = uuid.New().String()
 	logEntry.requestHash = generateRequestHash()
+
+	// Skip DB operations when no pool is available (unit tests without DB).
+	if h.dbPool == nil {
+		return
+	}
+
 	logEntry.insertWg.Add(1)
 
 	// Capture values before spawning goroutine to avoid data races.
@@ -101,6 +107,11 @@ func (h *Handler) updateRequestLog(logEntry *requestLogData) {
 		return
 	}
 
+	// Skip DB operations when no pool is available (unit tests without DB).
+	if h.dbPool == nil {
+		return
+	}
+
 	// Ensure the async INSERT has completed before we try to UPDATE the row.
 	h.WaitForInsert(logEntry)
 
@@ -115,30 +126,31 @@ func (h *Handler) updateRequestLog(logEntry *requestLogData) {
 
 	tag, err := h.dbPool.Exec(ctx, `
 		UPDATE request_logs SET
-			provider_id = $2,
-			status_code = $3,
-			duration_ms = $4,
-			latency_ms = $20,
-			proxy_overhead_ms = $5,
-			parse_ms = $6,
-			failover_lookup_ms = $7,
-			model_lookup_ms = $8,
-			provider_lookup_ms = $9,
-			key_decrypt_ms = $10,
-			dial_ms = $21,
-			settings_read_ms = $22,
-			ttft_ms = $11,
-			tokens_per_second = $12,
-			tokens_prompt = $13,
-			tokens_completion = $14,
-			tokens_completion_reasoning = $23,
-			tokens_prompt_cache_hit = $15,
-			tokens_prompt_cache_miss = $16,
-			error_message = $17,
-			failover_attempt = $18,
-			state = $19
+			model_id = $2,
+			provider_id = $3,
+			status_code = $4,
+			duration_ms = $5,
+			latency_ms = $21,
+			proxy_overhead_ms = $6,
+			parse_ms = $7,
+			failover_lookup_ms = $8,
+			model_lookup_ms = $9,
+			provider_lookup_ms = $10,
+			key_decrypt_ms = $11,
+			dial_ms = $22,
+			settings_read_ms = $23,
+			ttft_ms = $12,
+			tokens_per_second = $13,
+			tokens_prompt = $14,
+			tokens_completion = $15,
+			tokens_completion_reasoning = $24,
+			tokens_prompt_cache_hit = $16,
+			tokens_prompt_cache_miss = $17,
+			error_message = $18,
+			failover_attempt = $19,
+			state = $20
 		WHERE id = $1`,
-		logEntry.id, providerID, logEntry.statusCode, logEntry.durationMs,
+		logEntry.id, logEntry.modelID, providerID, logEntry.statusCode, logEntry.durationMs,
 		logEntry.proxyOverheadMs, logEntry.parseMs, logEntry.failoverLookupMs, logEntry.modelLookupMs, logEntry.providerLookupMs,
 		logEntry.keyDecryptMs, logEntry.ttftMs, logEntry.tokensPerSecond, logEntry.tokensPrompt,
 		logEntry.tokensCompletion, logEntry.tokensPromptCacheHit, logEntry.tokensPromptCacheMiss,

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -26,7 +26,7 @@ import (
 // newRequestWithContext is injectable for testing request creation errors.
 var newRequestWithContext = http.NewRequestWithContext
 
-func (h *Handler) handleStreamingResponse(w http.ResponseWriter, r *http.Request, logData *requestLogData, resp *http.Response, startTime time.Time, proxyOverhead, parseMs, failoverLookupMs, modelLookupMs, providerLookupMs, keyDecryptMs, dialMs, settingsReadMs, ttft float64, vkHash string, attempt int) {
+func (h *Handler) handleStreamingResponse(w http.ResponseWriter, r *http.Request, logData *requestLogData, resp *http.Response, startTime time.Time, proxyOverhead, parseMs, failoverLookupMs, modelLookupMs, providerLookupMs, keyDecryptMs, dialMs, settingsReadMs, ttft float64, vkHash string, attempt int, cancelOrigin string) {
 	defer func() {
 		// Drain remaining bytes so the Transport reuses the connection.
 		// Skip drain if the client already disconnected: the upstream body
@@ -628,7 +628,25 @@ logUpdate:
 
 	errMsg := lastErrMsg
 	if errMsg == "" && scanner.Err() != nil {
-		errMsg = scanner.Err().Error()
+		scannerErr := scanner.Err()
+		switch {
+		case errors.Is(scannerErr, context.Canceled):
+			// The scanner caught the cancellation before the select between
+			// iterations could. This is always a client disconnect — the
+			// parent request context was cancelled.
+			clientDisconnected = true
+		case errors.Is(scannerErr, context.DeadlineExceeded):
+			// A derived context's deadline expired (failover or retry timeout).
+			// Use cancelOrigin to produce a human-readable message.
+			switch cancelOrigin {
+			case "retry_timeout":
+				errMsg = "stream interrupted: param-strip retry timed out"
+			default:
+				errMsg = "stream interrupted: upstream request timed out"
+			}
+		default:
+			errMsg = scannerErr.Error()
+		}
 	}
 	if clientDisconnected {
 		errMsg = "client disconnected"
@@ -909,6 +927,7 @@ func (h *Handler) ChatCompletions(w http.ResponseWriter, r *http.Request) {
 			bodyBytes, err = io.ReadAll(r.Body)
 			if err != nil {
 				debuglog.Warn("proxy: failed to read request body", "error", err)
+				h.failRequest(&requestLogData{state: "pending"}, 400, "failed to read request body", 0, startTime, parseMs, resolveTimings{}, 0)
 				writeOpenAIError(w, "failed to read request body", http.StatusBadRequest)
 				return
 			}
@@ -918,6 +937,7 @@ func (h *Handler) ChatCompletions(w http.ResponseWriter, r *http.Request) {
 		var req ChatCompletionRequest
 		if err := json.Unmarshal(bodyBytes, &req); err != nil {
 			debuglog.Warn("proxy: failed to parse request body", "error", err)
+			h.failRequest(&requestLogData{state: "pending"}, 400, "invalid request body", 0, startTime, parseMs, resolveTimings{}, 0)
 			writeOpenAIError(w, "invalid request body", http.StatusBadRequest)
 			return
 		}
@@ -933,6 +953,7 @@ func (h *Handler) ChatCompletions(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if reqModel == "" {
+		h.failRequest(&requestLogData{state: "pending"}, 400, "model is required", 0, startTime, parseMs, resolveTimings{}, 0)
 		writeOpenAIError(w, "model is required", http.StatusBadRequest)
 		return
 	}
@@ -1169,6 +1190,7 @@ func (h *Handler) ChatCompletions(w http.ResponseWriter, r *http.Request) {
 		}
 
 		var retryCancel context.CancelFunc
+		streamCancelOrigin := "failover_timeout"
 		failoverCtx, failoverCancel := context.WithTimeout(r.Context(), failoverTimeout)
 		failoverCtx = context.WithValue(failoverCtx, ctxkeys.CancelOriginKey, "failover_timeout")
 		proxyReq, err := newRequestWithContext(failoverCtx, "POST", targetURL, bytes.NewReader(upstreamBody))
@@ -1219,7 +1241,7 @@ func (h *Handler) ChatCompletions(w http.ResponseWriter, r *http.Request) {
 						}
 					}
 				}
-				lastErr = fmt.Sprintf("attempt %d: %s: %v", attempt, cancelOrigin, err)
+				lastErr = fmt.Sprintf("attempt %d: %s", attempt, humanReadableCancelOrigin(cancelOrigin))
 				debuglog.Info("proxy: context cancelled during request to provider", "provider", logData.providerName, "provider_id", candidate.provider.ID, "model", logData.modelID, "origin", cancelOrigin, "error", err)
 			} else {
 				lastErr = fmt.Sprintf("attempt %d: provider error: %v", attempt, err)
@@ -1295,6 +1317,7 @@ func (h *Handler) ChatCompletions(w http.ResponseWriter, r *http.Request) {
 							retryCtx = context.WithValue(retryCtx, ctxkeys.CancelOriginKey, "retry_timeout")
 							retryCtx = context.WithValue(retryCtx, ctxkeys.DialMsKey, &dialMs)
 							retryCancel = rc
+							streamCancelOrigin = "retry_timeout"
 							retryReq, retryErr := newRequestWithContext(retryCtx, "POST", targetURL, bytes.NewReader(rebuilt))
 							if retryErr != nil {
 								retryCancel()
@@ -1308,7 +1331,12 @@ func (h *Handler) ChatCompletions(w http.ResponseWriter, r *http.Request) {
 							if retryErr != nil {
 								retryCancel() // no body to consume on retry error
 								debuglog.Warn("proxy: auto-retry request failed", "attempt", attempt+1, "provider", candidate.provider.Name, "provider_id", candidate.provider.ID, "error", retryErr)
-								lastErr = fmt.Sprintf("attempt %d: retry error: %v", attempt, retryErr)
+								retryCtxErr := errors.Is(retryErr, context.Canceled) || errors.Is(retryErr, context.DeadlineExceeded)
+								if retryCtxErr {
+									lastErr = fmt.Sprintf("attempt %d: %s", attempt, humanReadableCancelOrigin("retry_timeout"))
+								} else {
+									lastErr = fmt.Sprintf("attempt %d: retry error: %v", attempt, retryErr)
+								}
 								continue
 							}
 							failoverCancel() // original 400 body already consumed, original context no longer needed
@@ -1389,7 +1417,7 @@ func (h *Handler) ChatCompletions(w http.ResponseWriter, r *http.Request) {
 
 		debuglog.Debug("proxy: upstream responded OK, dispatching to handler", "stream", isStreaming, "model", logData.modelID, "provider", logData.providerName, "provider_id", candidate.provider.ID, "status", resp.StatusCode)
 		if isStreaming {
-			h.handleStreamingResponse(w, r, logData, resp, startTime, proxyOverhead, parseMs, timings.failoverLookupMs, timings.modelLookupMs, timings.providerLookupMs, timings.keyDecryptMs, timings.dialMs, timings.settingsReadMs, ttft, vkHash, attempt)
+			h.handleStreamingResponse(w, r, logData, resp, startTime, proxyOverhead, parseMs, timings.failoverLookupMs, timings.modelLookupMs, timings.providerLookupMs, timings.keyDecryptMs, timings.dialMs, timings.settingsReadMs, ttft, vkHash, attempt, streamCancelOrigin)
 			failoverCancel() // body consumed by handleStreamingResponse
 			if retryCancel != nil {
 				retryCancel()
@@ -1448,4 +1476,22 @@ func mapKeys(m map[string]bool) []string {
 // SillyTavern parse responses as JSON and crash on plain text error messages.
 func writeOpenAIError(w http.ResponseWriter, message string, statusCode int) {
 	util.WriteOpenAIError(w, message, statusCode)
+}
+
+// humanReadableCancelOrigin maps internal cancel origin identifiers to
+// human-readable descriptions for error messages and request logs.
+// Raw Go errors like "context canceled" and "context deadline exceeded" are
+// opaque — callers need to know whether the client disconnected, the failover
+// timeout expired, or a param-strip retry timed out.
+func humanReadableCancelOrigin(origin string) string {
+	switch origin {
+	case "client_disconnect":
+		return "client disconnected"
+	case "failover_timeout":
+		return "upstream request timed out"
+	case "retry_timeout":
+		return "param-strip retry timed out"
+	default:
+		return origin
+	}
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -641,8 +641,11 @@ logUpdate:
 			switch cancelOrigin {
 			case "retry_timeout":
 				errMsg = "stream interrupted: param-strip retry timed out"
-			default:
+			case "failover_timeout":
 				errMsg = "stream interrupted: upstream request timed out"
+			default:
+				// Unknown origin — preserve the value rather than guessing.
+				errMsg = fmt.Sprintf("stream interrupted: %s", humanReadableCancelOrigin(cancelOrigin))
 			}
 		default:
 			errMsg = scannerErr.Error()
@@ -918,6 +921,33 @@ func (h *Handler) ChatCompletions(w http.ResponseWriter, r *http.Request) {
 	// Fallback: if middleware did not provide pre-parsed values (e.g. route
 	// not covered by streamingAwareTimeout), parse from body directly.
 	var bodyBytes []byte
+
+	// Extract virtual key info early from context (available before body parsing).
+	vkName := ""
+	var vkID string
+	var vkHash string
+	if v := r.Context().Value(virtualKeyNameKey); v != nil {
+		vkName = v.(string)
+	}
+	if v := r.Context().Value(virtualKeyIDKey); v != nil {
+		vkID = v.(string)
+	}
+	if v := r.Context().Value(VirtualKeyHashKey); v != nil {
+		vkHash = v.(string)
+	}
+
+	// Create the log entry early so early-return paths can record failures.
+	// modelID may be empty here; it gets updated after body parsing.
+	logData := &requestLogData{
+		modelID:         reqModel,
+		streaming:       isStreaming,
+		virtualKeyName:  vkName,
+		virtualKeyID:    vkID,
+		failoverAttempt: 0,
+		state:           "pending",
+	}
+	h.insertRequestLogAsync(logData)
+
 	if reqModel == "" {
 		parseStart := time.Now()
 		if cached, ok := r.Context().Value(ctxkeys.RequestBodyKey).([]byte); ok {
@@ -927,7 +957,7 @@ func (h *Handler) ChatCompletions(w http.ResponseWriter, r *http.Request) {
 			bodyBytes, err = io.ReadAll(r.Body)
 			if err != nil {
 				debuglog.Warn("proxy: failed to read request body", "error", err)
-				h.failRequest(&requestLogData{state: "pending"}, 400, "failed to read request body", 0, startTime, parseMs, resolveTimings{}, 0)
+				h.failRequest(logData, 400, "failed to read request body", 0, startTime, parseMs, resolveTimings{}, 0)
 				writeOpenAIError(w, "failed to read request body", http.StatusBadRequest)
 				return
 			}
@@ -937,7 +967,7 @@ func (h *Handler) ChatCompletions(w http.ResponseWriter, r *http.Request) {
 		var req ChatCompletionRequest
 		if err := json.Unmarshal(bodyBytes, &req); err != nil {
 			debuglog.Warn("proxy: failed to parse request body", "error", err)
-			h.failRequest(&requestLogData{state: "pending"}, 400, "invalid request body", 0, startTime, parseMs, resolveTimings{}, 0)
+			h.failRequest(logData, 400, "invalid request body", 0, startTime, parseMs, resolveTimings{}, 0)
 			writeOpenAIError(w, "invalid request body", http.StatusBadRequest)
 			return
 		}
@@ -952,37 +982,18 @@ func (h *Handler) ChatCompletions(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Update log entry with model resolved from body parsing (if not set by middleware).
+	logData.modelID = reqModel
+	logData.streaming = isStreaming
+
 	if reqModel == "" {
-		h.failRequest(&requestLogData{state: "pending"}, 400, "model is required", 0, startTime, parseMs, resolveTimings{}, 0)
+		h.failRequest(logData, 400, "model is required", 0, startTime, parseMs, resolveTimings{}, 0)
 		writeOpenAIError(w, "model is required", http.StatusBadRequest)
 		return
 	}
 
-	vkName := ""
-	var vkID string
-	var vkHash string
-	if v := r.Context().Value(virtualKeyNameKey); v != nil {
-		vkName = v.(string)
-	}
-	if v := r.Context().Value(virtualKeyIDKey); v != nil {
-		vkID = v.(string)
-	}
-	if v := r.Context().Value(VirtualKeyHashKey); v != nil {
-		vkHash = v.(string)
-	}
-
 	debuglog.Info("proxy: request start", "model", reqModel, "stream", isStreaming, "key", vkName, "client_ip", r.RemoteAddr)
 	debuglog.Debug("proxy: request details", "model", reqModel, "stream", isStreaming, "key", vkName, "vk_id", vkID, "has_hash", vkHash != "", "body_length", len(bodyBytes))
-
-	logData := &requestLogData{
-		modelID:         reqModel,
-		streaming:       isStreaming,
-		virtualKeyName:  vkName,
-		virtualKeyID:    vkID,
-		failoverAttempt: 0,
-		state:           "pending",
-	}
-	h.insertRequestLogAsync(logData)
 
 	var candidates []modelCandidate
 	var timings resolveTimings
@@ -1331,9 +1342,14 @@ func (h *Handler) ChatCompletions(w http.ResponseWriter, r *http.Request) {
 							if retryErr != nil {
 								retryCancel() // no body to consume on retry error
 								debuglog.Warn("proxy: auto-retry request failed", "attempt", attempt+1, "provider", candidate.provider.Name, "provider_id", candidate.provider.ID, "error", retryErr)
-								retryCtxErr := errors.Is(retryErr, context.Canceled) || errors.Is(retryErr, context.DeadlineExceeded)
-								if retryCtxErr {
-									lastErr = fmt.Sprintf("attempt %d: %s", attempt, humanReadableCancelOrigin("retry_timeout"))
+								if errors.Is(retryErr, context.Canceled) || errors.Is(retryErr, context.DeadlineExceeded) {
+									// Branch like the main failover loop: Canceled = client
+									// disconnect, DeadlineExceeded = retry timeout.
+									origin := "retry_timeout"
+									if errors.Is(retryErr, context.Canceled) {
+										origin = "client_disconnect"
+									}
+									lastErr = fmt.Sprintf("attempt %d: %s", attempt, humanReadableCancelOrigin(origin))
 								} else {
 									lastErr = fmt.Sprintf("attempt %d: retry error: %v", attempt, retryErr)
 								}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -957,6 +957,7 @@ func (h *Handler) ChatCompletions(w http.ResponseWriter, r *http.Request) {
 			bodyBytes, err = io.ReadAll(r.Body)
 			if err != nil {
 				debuglog.Warn("proxy: failed to read request body", "error", err)
+				publishRequestStartedEvent(logData)
 				h.failRequest(logData, 400, "failed to read request body", 0, startTime, parseMs, resolveTimings{}, 0)
 				writeOpenAIError(w, "failed to read request body", http.StatusBadRequest)
 				return
@@ -967,6 +968,7 @@ func (h *Handler) ChatCompletions(w http.ResponseWriter, r *http.Request) {
 		var req ChatCompletionRequest
 		if err := json.Unmarshal(bodyBytes, &req); err != nil {
 			debuglog.Warn("proxy: failed to parse request body", "error", err)
+			publishRequestStartedEvent(logData)
 			h.failRequest(logData, 400, "invalid request body", 0, startTime, parseMs, resolveTimings{}, 0)
 			writeOpenAIError(w, "invalid request body", http.StatusBadRequest)
 			return
@@ -985,6 +987,10 @@ func (h *Handler) ChatCompletions(w http.ResponseWriter, r *http.Request) {
 	// Update log entry with model resolved from body parsing (if not set by middleware).
 	logData.modelID = reqModel
 	logData.streaming = isStreaming
+
+	// Publish the SSE "request.started" event after modelID is resolved
+	// so subscribers always see the correct model (not an empty string).
+	publishRequestStartedEvent(logData)
 
 	if reqModel == "" {
 		h.failRequest(logData, 400, "model is required", 0, startTime, parseMs, resolveTimings{}, 0)

--- a/internal/proxy/proxy_integration_test.go
+++ b/internal/proxy/proxy_integration_test.go
@@ -60,7 +60,7 @@ func TestHandleStreamingResponse_UpstreamError(t *testing.T) {
 	h.insertRequestLogAsync(logData)
 	time.Sleep(100 * time.Millisecond)
 
-	h.handleStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
+	h.handleStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1, "failover_timeout")
 
 	if logData.state != "failed" {
 		t.Errorf("expected state=%q, got %q", "failed", logData.state)
@@ -117,7 +117,7 @@ func TestHandleStreamingResponse_MissingDoneSentinel(t *testing.T) {
 	h.insertRequestLogAsync(logData)
 	time.Sleep(100 * time.Millisecond)
 
-	h.handleStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
+	h.handleStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1, "failover_timeout")
 
 	if logData.state != "completed" {
 		t.Errorf("expected state=%q, got %q", "completed", logData.state)
@@ -304,7 +304,7 @@ func TestHandleStreamingResponse_Basic(t *testing.T) {
 	h.insertRequestLogAsync(logData)
 	time.Sleep(100 * time.Millisecond)
 
-	h.handleStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
+	h.handleStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1, "failover_timeout")
 
 	// Basic verification - the handler should process the stream
 	if inner.Code != http.StatusOK {
@@ -698,7 +698,7 @@ func TestHandleStreamingResponse_ClientDisconnectMidStream(t *testing.T) {
 	// Start streaming in goroutine
 	done := make(chan struct{})
 	go func() {
-		h.handleStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
+		h.handleStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1, "failover_timeout")
 		close(done)
 	}()
 
@@ -775,7 +775,7 @@ func TestHandleStreamingResponse_EmptyLinesSSESep(t *testing.T) {
 	h.insertRequestLogAsync(logData)
 	time.Sleep(100 * time.Millisecond)
 
-	h.handleStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
+	h.handleStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1, "failover_timeout")
 
 	// Should complete successfully
 	if logData.state != "completed" {
@@ -842,7 +842,7 @@ func TestHandleStreamingResponse_TooManyEmptyLines(t *testing.T) {
 	h.insertRequestLogAsync(logData)
 	time.Sleep(100 * time.Millisecond)
 
-	h.handleStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
+	h.handleStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1, "failover_timeout")
 
 	if logData.state != "failed" {
 		t.Errorf("expected state=failed, got %q", logData.state)
@@ -901,7 +901,7 @@ func TestHandleStreamingResponse_UTF8BOM(t *testing.T) {
 	h.insertRequestLogAsync(logData)
 	time.Sleep(100 * time.Millisecond)
 
-	h.handleStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
+	h.handleStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1, "failover_timeout")
 
 	// Should complete successfully - BOM is stripped for parsing
 	if logData.state != "completed" {
@@ -960,7 +960,7 @@ func TestHandleStreamingResponse_LeadingWhitespace(t *testing.T) {
 	h.insertRequestLogAsync(logData)
 	time.Sleep(100 * time.Millisecond)
 
-	h.handleStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
+	h.handleStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1, "failover_timeout")
 
 	// Should complete successfully
 	if logData.state != "completed" {
@@ -1020,7 +1020,7 @@ func TestHandleStreamingResponse_UsageExtraction(t *testing.T) {
 	h.insertRequestLogAsync(logData)
 	time.Sleep(100 * time.Millisecond)
 
-	h.handleStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
+	h.handleStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1, "failover_timeout")
 
 	if logData.state != "completed" {
 		t.Errorf("expected state=completed, got %q", logData.state)
@@ -1081,7 +1081,7 @@ func TestHandleStreamingResponse_AnthropicErrorEvent(t *testing.T) {
 	h.insertRequestLogAsync(logData)
 	time.Sleep(100 * time.Millisecond)
 
-	h.handleStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
+	h.handleStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1, "failover_timeout")
 
 	// The stream captures the Anthropic error and marks the request as failed.
 	if logData.state != "failed" {
@@ -1141,7 +1141,7 @@ func TestHandleStreamingResponse_DuplicateFinishReasonSuppression(t *testing.T) 
 	h.insertRequestLogAsync(logData)
 	time.Sleep(100 * time.Millisecond)
 
-	h.handleStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
+	h.handleStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1, "failover_timeout")
 
 	// Should complete successfully
 	if logData.state != "completed" {
@@ -1199,7 +1199,7 @@ func TestHandleStreamingResponse_RepeatedContentDetection(t *testing.T) {
 	h.insertRequestLogAsync(logData)
 	time.Sleep(100 * time.Millisecond)
 
-	h.handleStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
+	h.handleStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1, "failover_timeout")
 
 	// Should complete (repeated content is just logged, not failed)
 	if logData.state != "completed" {
@@ -1254,7 +1254,7 @@ func TestHandleStreamingResponse_DataWithoutSpace(t *testing.T) {
 	h.insertRequestLogAsync(logData)
 	time.Sleep(100 * time.Millisecond)
 
-	h.handleStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
+	h.handleStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1, "failover_timeout")
 
 	// Verify status code
 	if inner.Code != http.StatusOK {
@@ -1381,7 +1381,7 @@ func TestHandleStreamingResponse_NonErrorAnthropicEvent(t *testing.T) {
 	h.insertRequestLogAsync(logData)
 	time.Sleep(100 * time.Millisecond)
 
-	h.handleStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
+	h.handleStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1, "failover_timeout")
 
 	if logData.state != "completed" {
 		t.Errorf("expected state=%q, got %q", "completed", logData.state)
@@ -1445,7 +1445,7 @@ func TestHandleStreamingResponse_ErrAccumFlushOnNonDataLine(t *testing.T) {
 	h.insertRequestLogAsync(logData)
 	time.Sleep(100 * time.Millisecond)
 
-	h.handleStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
+	h.handleStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1, "failover_timeout")
 
 	if logData.state != "failed" {
 		t.Errorf("expected state=%q, got %q", "failed", logData.state)
@@ -1505,7 +1505,7 @@ func TestHandleStreamingResponse_ErrAccumFlushOnNonErrorDataLine(t *testing.T) {
 	h.insertRequestLogAsync(logData)
 	time.Sleep(100 * time.Millisecond)
 
-	h.handleStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
+	h.handleStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1, "failover_timeout")
 
 	if logData.state != "failed" {
 		t.Errorf("expected state=%q, got %q", "failed", logData.state)
@@ -1565,7 +1565,7 @@ func TestHandleStreamingResponse_PromptCacheHitTokens(t *testing.T) {
 	h.insertRequestLogAsync(logData)
 	time.Sleep(100 * time.Millisecond)
 
-	h.handleStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
+	h.handleStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1, "failover_timeout")
 
 	if logData.state != "completed" {
 		t.Errorf("expected state=%q, got %q", "completed", logData.state)
@@ -1625,7 +1625,7 @@ func TestHandleStreamingResponse_NativeFinishReason(t *testing.T) {
 	h.insertRequestLogAsync(logData)
 	time.Sleep(100 * time.Millisecond)
 
-	h.handleStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
+	h.handleStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1, "failover_timeout")
 
 	if logData.state != "completed" {
 		t.Errorf("expected state=%q, got %q", "completed", logData.state)
@@ -1678,7 +1678,7 @@ func TestHandleStreamingResponse_ErrAccumFlushAtStreamEnd(t *testing.T) {
 	h.insertRequestLogAsync(logData)
 	time.Sleep(100 * time.Millisecond)
 
-	h.handleStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
+	h.handleStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1, "failover_timeout")
 
 	if logData.state != "failed" {
 		t.Errorf("expected state=%q, got %q", "failed", logData.state)
@@ -1735,7 +1735,7 @@ func TestHandleStreamingResponse_FinishReasonNormalization(t *testing.T) {
 	h.insertRequestLogAsync(logData)
 	time.Sleep(100 * time.Millisecond)
 
-	h.handleStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
+	h.handleStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1, "failover_timeout")
 
 	if logData.state != "completed" {
 		t.Errorf("expected state=%q, got %q", "completed", logData.state)
@@ -1941,7 +1941,7 @@ func TestHandleStreamingResponse_HasContentChecks(t *testing.T) {
 	h.insertRequestLogAsync(logData)
 	time.Sleep(100 * time.Millisecond)
 
-	h.handleStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
+	h.handleStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1, "failover_timeout")
 
 	if logData.state != "completed" {
 		t.Errorf("expected state=%q, got %q", "completed", logData.state)
@@ -2005,7 +2005,7 @@ func TestHandleStreamingResponse_RepeatedContentPreviewTruncation(t *testing.T) 
 	h.insertRequestLogAsync(logData)
 	time.Sleep(100 * time.Millisecond)
 
-	h.handleStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
+	h.handleStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1, "failover_timeout")
 
 	if logData.state != "completed" {
 		t.Errorf("expected state=%q, got %q", "completed", logData.state)
@@ -2124,7 +2124,7 @@ func TestHandleStreamingResponse_AddTokensError(t *testing.T) {
 	h.insertRequestLogAsync(logData)
 	time.Sleep(100 * time.Millisecond)
 
-	h.handleStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
+	h.handleStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1, "failover_timeout")
 
 	if logData.state != "completed" {
 		t.Errorf("expected state=%q, got %q", "completed", logData.state)
@@ -2229,7 +2229,7 @@ func TestHandleStreamingResponse_ClientWriteFailureOnDataLine(t *testing.T) {
 	h.insertRequestLogAsync(logData)
 	time.Sleep(100 * time.Millisecond)
 
-	h.handleStreamingResponse(innerRW, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 1)
+	h.handleStreamingResponse(innerRW, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 1, "failover_timeout")
 
 	if logData.state != "failed" {
 		t.Errorf("expected state=%q, got %q", "failed", logData.state)
@@ -2283,7 +2283,7 @@ func TestHandleStreamingResponse_ClientWriteFailureOnDoneLine(t *testing.T) {
 	h.insertRequestLogAsync(logData)
 	time.Sleep(100 * time.Millisecond)
 
-	h.handleStreamingResponse(innerRW, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 1)
+	h.handleStreamingResponse(innerRW, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 1, "failover_timeout")
 
 	if logData.state != "failed" {
 		t.Errorf("expected state=%q, got %q", "failed", logData.state)
@@ -2341,7 +2341,7 @@ func TestHandleStreamingResponse_ClientWriteFailureOnNormalizedChunk(t *testing.
 	h.insertRequestLogAsync(logData)
 	time.Sleep(100 * time.Millisecond)
 
-	h.handleStreamingResponse(innerRW, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 1)
+	h.handleStreamingResponse(innerRW, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 1, "failover_timeout")
 
 	if logData.state != "failed" {
 		t.Errorf("expected state=%q, got %q", "failed", logData.state)
@@ -2399,7 +2399,7 @@ func TestHandleStreamingResponse_ClientWriteFailureOnNonNormalizedChunk(t *testi
 	h.insertRequestLogAsync(logData)
 	time.Sleep(100 * time.Millisecond)
 
-	h.handleStreamingResponse(innerRW, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 1)
+	h.handleStreamingResponse(innerRW, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 1, "failover_timeout")
 
 	if logData.state != "failed" {
 		t.Errorf("expected state=%q, got %q", "failed", logData.state)

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -442,7 +442,7 @@ func TestHandleStreamingResponse_ClientWriteFailureMarksDisconnected(t *testing.
 	h.insertRequestLogAsync(logData)
 	time.Sleep(100 * time.Millisecond) // wait for async DB insert
 
-	h.handleStreamingResponse(innerRW, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
+	h.handleStreamingResponse(innerRW, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1, "failover_timeout")
 
 	if logData.state != "failed" {
 		t.Errorf("expected state=%q, got %q", "failed", logData.state)
@@ -541,7 +541,7 @@ func TestHandleStreamingResponse_EmptyStream(t *testing.T) {
 	h.insertRequestLogAsync(logData)
 	time.Sleep(100 * time.Millisecond)
 
-	h.handleStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
+	h.handleStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1, "failover_timeout")
 
 	// Should complete without error even with empty stream
 	if logData.state != "failed" {
@@ -595,7 +595,7 @@ func TestHandleStreamingResponse_ErrorChunk(t *testing.T) {
 	h.insertRequestLogAsync(logData)
 	time.Sleep(100 * time.Millisecond)
 
-	h.handleStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
+	h.handleStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1, "failover_timeout")
 
 	// Should complete but track error chunks
 	if logData.state != "failed" {
@@ -799,7 +799,7 @@ func TestHandleStreamingResponse_DoneSentinelWriteFailure(t *testing.T) {
 	h.insertRequestLogAsync(logData)
 	time.Sleep(100 * time.Millisecond)
 
-	h.handleStreamingResponse(failWriter, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
+	h.handleStreamingResponse(failWriter, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1, "failover_timeout")
 
 	if logData.state != "failed" {
 		t.Errorf("expected state=failed, got %q", logData.state)
@@ -853,7 +853,7 @@ func TestHandleStreamingResponse_ReasoningNormWriteFailure(t *testing.T) {
 	h.insertRequestLogAsync(logData)
 	time.Sleep(100 * time.Millisecond)
 
-	h.handleStreamingResponse(failWriter, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
+	h.handleStreamingResponse(failWriter, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1, "failover_timeout")
 
 	if logData.state != "failed" {
 		t.Errorf("expected state=failed, got %q", logData.state)
@@ -897,7 +897,7 @@ func TestHandleStreamingResponse_ReasoningNormPayloadWriteFailure(t *testing.T) 
 	h.insertRequestLogAsync(logData)
 	time.Sleep(100 * time.Millisecond)
 
-	h.handleStreamingResponse(failWriter, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
+	h.handleStreamingResponse(failWriter, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1, "failover_timeout")
 
 	if logData.state != "failed" {
 		t.Errorf("expected state=failed, got %q", logData.state)
@@ -941,7 +941,7 @@ func TestHandleStreamingResponse_ReasoningNormNewlineWriteFailure(t *testing.T) 
 	h.insertRequestLogAsync(logData)
 	time.Sleep(100 * time.Millisecond)
 
-	h.handleStreamingResponse(failWriter, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
+	h.handleStreamingResponse(failWriter, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1, "failover_timeout")
 
 	if logData.state != "failed" {
 		t.Errorf("expected state=failed, got %q", logData.state)
@@ -990,7 +990,7 @@ func TestHandleStreamingResponse_FinishReasonNormWriteFailure(t *testing.T) {
 	h.insertRequestLogAsync(logData)
 	time.Sleep(100 * time.Millisecond)
 
-	h.handleStreamingResponse(failWriter, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
+	h.handleStreamingResponse(failWriter, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1, "failover_timeout")
 
 	if logData.state != "failed" {
 		t.Errorf("expected state=failed, got %q", logData.state)
@@ -1042,7 +1042,7 @@ func TestHandleStreamingResponse_TPSFallbackWhenTTFTExceedsDuration(t *testing.T
 	startTime := time.Now()
 	time.Sleep(2 * time.Millisecond)
 	// ttft will be set to totalDuration, making generationDuration = 0
-	h.handleStreamingResponse(inner, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 999999.0, "test-hash", 1)
+	h.handleStreamingResponse(inner, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 999999.0, "test-hash", 1, "failover_timeout")
 
 	if logData.state != "completed" {
 		t.Errorf("expected state=completed, got %q", logData.state)

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -1796,3 +1796,27 @@ func TestChatCompletions_TouchLastUsedGoroutine(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// humanReadableCancelOrigin tests
+// ---------------------------------------------------------------------------
+
+func TestHumanReadableCancelOrigin(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected string
+	}{
+		{"client_disconnect", "client disconnected"},
+		{"failover_timeout", "upstream request timed out"},
+		{"retry_timeout", "param-strip retry timed out"},
+		{"", ""},
+		{"unknown_origin", "unknown_origin"},
+	}
+
+	for _, tc := range cases {
+		got := humanReadableCancelOrigin(tc.input)
+		if got != tc.expected {
+			t.Errorf("humanReadableCancelOrigin(%q) = %q, want %q", tc.input, got, tc.expected)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------

--- a/internal/proxy/response_test.go
+++ b/internal/proxy/response_test.go
@@ -681,7 +681,7 @@ func TestHandleStreamingResponse_WriteFailure(t *testing.T) {
 	logData.insertWg.Add(1)
 
 	startTime := time.Now()
-	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0)
+	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0, "failover_timeout")
 
 	// clientDisconnected should be set, state should reflect the error
 	if logData.state != "failed" {
@@ -721,7 +721,7 @@ func TestHandleStreamingResponse_NewlineWriteFailure(t *testing.T) {
 	logData.insertWg.Add(1)
 
 	startTime := time.Now()
-	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0)
+	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0, "failover_timeout")
 
 	if logData.state != "failed" {
 		t.Errorf("expected state=failed, got %q", logData.state)
@@ -763,7 +763,7 @@ func TestHandleStreamingResponse_DoneWriteFailure(t *testing.T) {
 	logData.insertWg.Add(1)
 
 	startTime := time.Now()
-	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0)
+	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0, "failover_timeout")
 
 	// clientDisconnected should be set due to write failure
 	if logData.state != "failed" {
@@ -806,7 +806,7 @@ data: [DONE]
 	logData.insertWg.Add(1)
 
 	startTime := time.Now()
-	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0)
+	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0, "failover_timeout")
 
 	result := w.Result()
 	defer result.Body.Close()
@@ -863,7 +863,7 @@ data: [DONE]
 	logData.insertWg.Add(1)
 
 	startTime := time.Now()
-	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0)
+	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0, "failover_timeout")
 
 	if logData.state != "failed" {
 		t.Errorf("expected state=failed, got %q", logData.state)
@@ -908,7 +908,7 @@ data: [DONE]
 	logData.insertWg.Add(1)
 
 	startTime := time.Now()
-	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0)
+	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0, "failover_timeout")
 
 	if logData.state != "failed" {
 		t.Errorf("expected state=failed, got %q", logData.state)
@@ -945,7 +945,7 @@ func TestHandleStreamingResponse_ErrAccumAtEnd(t *testing.T) {
 	logData.insertWg.Add(1)
 
 	startTime := time.Now()
-	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0)
+	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0, "failover_timeout")
 
 	// Error should be logged and state should be failed
 	if logData.state != "failed" {
@@ -984,7 +984,7 @@ func TestHandleStreamingResponse_ScannerError(t *testing.T) {
 	logData.insertWg.Add(1)
 
 	startTime := time.Now()
-	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0)
+	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0, "failover_timeout")
 
 	// scanner.Err() should be captured
 	if logData.state != "failed" {
@@ -1093,7 +1093,7 @@ func TestHandleStreamingResponse_NonDataLineFlushesErrAccum(t *testing.T) {
 	logData.insertWg.Add(1)
 
 	startTime := time.Now()
-	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0)
+	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0, "failover_timeout")
 
 	// Error should be captured from errAccum
 	if logData.state != "failed" {
@@ -1130,7 +1130,7 @@ func TestHandleStreamingResponse_BOMStripped(t *testing.T) {
 	logData.insertWg.Add(1)
 
 	startTime := time.Now()
-	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0)
+	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0, "failover_timeout")
 
 	body := w.Body.String()
 	// BOM should be stripped, response should be valid
@@ -1168,7 +1168,7 @@ func TestHandleStreamingResponse_LeadingWhitespaceTrimmed(t *testing.T) {
 	logData.insertWg.Add(1)
 
 	startTime := time.Now()
-	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0)
+	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0, "failover_timeout")
 
 	body := w.Body.String()
 	if !strings.Contains(body, "[DONE]") {
@@ -1207,7 +1207,7 @@ data: [DONE]
 	logData.insertWg.Add(1)
 
 	startTime := time.Now()
-	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0)
+	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0, "failover_timeout")
 
 	if logData.tokensPrompt != 10 {
 		t.Errorf("expected prompt_tokens=10, got %d", logData.tokensPrompt)
@@ -1247,7 +1247,7 @@ data: [DONE]
 	logData.insertWg.Add(1)
 
 	startTime := time.Now()
-	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0)
+	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0, "failover_timeout")
 
 	if logData.tokensCompletion != 50 {
 		t.Errorf("expected completion_tokens=50, got %d", logData.tokensCompletion)
@@ -1291,7 +1291,7 @@ data: [DONE]
 	// Start time 19 seconds ago → totalDuration ≈ 19000ms, no TTFT measured
 	// generationDuration = totalDuration since ttft=0, so TPS = 700/19000*1000 ≈ 36.8
 	startTime := time.Now().Add(-19 * time.Second)
-	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0)
+	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0, "failover_timeout")
 
 	// TPS should use (50 + 650) / totalDuration * 1000 since no TTFT was measured
 	if logData.tokensPerSecond <= 0 {
@@ -1335,7 +1335,7 @@ data: [DONE]
 	logData.insertWg.Add(1)
 
 	startTime := time.Now().Add(-100 * time.Millisecond)
-	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0)
+	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0, "failover_timeout")
 
 	// When generationDuration <= 0, should fallback to totalDuration
 	// TPS = 5 / ~100 * 1000 ≈ 50 (approximate, just verify positive)
@@ -1378,7 +1378,7 @@ data: [DONE]
 	logData.insertWg.Add(1)
 
 	startTime := time.Now()
-	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0)
+	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0, "failover_timeout")
 
 	if logData.tokensPromptCacheHit != 80 {
 		t.Errorf("expected prompt_cache_hit=80, got %d", logData.tokensPromptCacheHit)
@@ -1418,7 +1418,7 @@ func TestHandleStreamingResponse_InjectsDoneSentinel(t *testing.T) {
 	logData.insertWg.Add(1)
 
 	startTime := time.Now()
-	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0)
+	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0, "failover_timeout")
 
 	body := w.Body.String()
 	// [DONE] should be injected
@@ -1465,7 +1465,7 @@ func TestHandleStreamingResponse_NonDataLineWriteFailure(t *testing.T) {
 	logData.insertWg.Add(1)
 
 	startTime := time.Now()
-	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0)
+	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0, "failover_timeout")
 
 	if logData.state != "failed" {
 		t.Errorf("expected state=failed, got %q", logData.state)
@@ -1505,7 +1505,7 @@ func TestHandleStreamingResponse_NonDataLineNewlineWriteFailure(t *testing.T) {
 	logData.insertWg.Add(1)
 
 	startTime := time.Now()
-	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0)
+	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0, "failover_timeout")
 
 	if logData.state != "failed" {
 		t.Errorf("expected state=failed, got %q", logData.state)
@@ -1547,7 +1547,7 @@ data: [DONE]
 	logData.insertWg.Add(1)
 
 	startTime := time.Now()
-	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0)
+	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0, "failover_timeout")
 
 	result := w.Result()
 	defer result.Body.Close()
@@ -1595,7 +1595,7 @@ func TestHandleStreamingResponse_ErrAccumAtStreamEnd(t *testing.T) {
 	logData.insertWg.Add(1)
 
 	startTime := time.Now()
-	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0)
+	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0, "failover_timeout")
 
 	// Error should be captured from errAccum at stream end
 	if logData.state != "failed" {
@@ -1643,7 +1643,7 @@ func TestHandleStreamingResponse_InjectedDoneWriteFailure(t *testing.T) {
 	logData.insertWg.Add(1)
 
 	startTime := time.Now()
-	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0)
+	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0, "failover_timeout")
 
 	// The injected [DONE] write failure is logged but benign - state should still be completed
 	// because the stream content was successfully written
@@ -1682,7 +1682,7 @@ func TestHandleStreamingResponse_SSEEventSeparators(t *testing.T) {
 	logData.insertWg.Add(1)
 
 	startTime := time.Now()
-	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0)
+	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0, "failover_timeout")
 
 	body := w.Body.String()
 
@@ -1832,7 +1832,7 @@ data: [DONE]
 	logData.insertWg.Add(1)
 
 	startTime := time.Now()
-	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0)
+	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0, "failover_timeout")
 
 	body := w.Body.String()
 	if !strings.Contains(body, "reasoning_content") {
@@ -1875,7 +1875,7 @@ data: [DONE]
 	logData.insertWg.Add(1)
 
 	startTime := time.Now()
-	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0)
+	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0, "failover_timeout")
 
 	body := w.Body.String()
 	if !strings.Contains(body, "reasoning_content") {
@@ -1918,7 +1918,7 @@ data: [DONE]
 	logData.insertWg.Add(1)
 
 	startTime := time.Now()
-	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0)
+	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0, "failover_timeout")
 
 	body := w.Body.String()
 	if !strings.Contains(body, "reasoning_content") {
@@ -1964,7 +1964,7 @@ data: [DONE]
 	logData.insertWg.Add(1)
 
 	startTime := time.Now()
-	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0)
+	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0, "failover_timeout")
 
 	body := w.Body.String()
 	if !strings.Contains(body, "reasoning_content") {
@@ -2010,7 +2010,7 @@ data: [DONE]
 	logData.insertWg.Add(1)
 
 	startTime := time.Now()
-	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0)
+	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0, "failover_timeout")
 
 	if logData.tokensPromptCacheHit != 60 {
 		t.Errorf("expected prompt_cache_hit=60, got %d", logData.tokensPromptCacheHit)
@@ -2052,7 +2052,7 @@ data: [DONE]
 	logData.insertWg.Add(1)
 
 	startTime := time.Now()
-	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0)
+	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0, "failover_timeout")
 
 	if logData.tokensPromptCacheHit != 80 {
 		t.Errorf("expected prompt_cache_hit=80 (OpenAI takes precedence), got %d", logData.tokensPromptCacheHit)
@@ -2170,7 +2170,7 @@ data: [DONE]
 	logData.insertWg.Add(1)
 
 	startTime := time.Now()
-	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0)
+	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0, "failover_timeout")
 
 	if logData.tokensPromptCacheHit != 120 {
 		t.Errorf("expected prompt_cache_hit=120, got %d", logData.tokensPromptCacheHit)
@@ -2357,7 +2357,7 @@ data: [DONE]
 	logData.insertWg.Add(1)
 
 	startTime := time.Now()
-	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0)
+	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0, "failover_timeout")
 
 	if logData.tokensPromptCacheHit != 1984 {
 		t.Errorf("expected prompt_cache_hit=1984 (from prompt_tokens_details.cached_tokens), got %d", logData.tokensPromptCacheHit)
@@ -2399,7 +2399,7 @@ data: [DONE]
 	logData.insertWg.Add(1)
 
 	startTime := time.Now()
-	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0)
+	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0, "failover_timeout")
 
 	// Tier 1 (PromptCacheHitTokens) should take precedence
 	if logData.tokensPromptCacheHit != 500 {
@@ -2549,7 +2549,7 @@ data: [DONE]
 	logData.insertWg.Add(1)
 
 	startTime := time.Now()
-	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0)
+	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0, "failover_timeout")
 
 	if logData.tokensPromptCacheHit != 150 {
 		t.Errorf("expected prompt_cache_hit=150 (from prompt_tokens_details.cached_tokens), got %d", logData.tokensPromptCacheHit)
@@ -2668,7 +2668,7 @@ data: [DONE]
 	logData.insertWg.Add(1)
 
 	startTime := time.Now()
-	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0)
+	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0, "failover_timeout")
 
 	// Tier 2 (cache_read_input_tokens) should take precedence over tier 3
 	if logData.tokensPromptCacheHit != 300 {
@@ -2712,7 +2712,7 @@ data: [DONE]
 	logData.insertWg.Add(1)
 
 	startTime := time.Now()
-	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0)
+	h.handleStreamingResponse(w, req, logData, resp, startTime, 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 0, "failover_timeout")
 
 	if logData.tokensPromptCacheHit != 500 {
 		t.Errorf("expected prompt_cache_hit=500 (from prompt_cache_hit_tokens), got %d", logData.tokensPromptCacheHit)

--- a/scripts/reference-transaction
+++ b/scripts/reference-transaction
@@ -10,7 +10,7 @@ if [ "$state" = "committed" ]; then
 		if [ "$old_rev" = "$zero" ]; then
 			branch="${ref_name#refs/heads/}"
 			if [ "$ref_name" != "$branch" ]; then
-				tokensave branch add || true
+				tokensave branch add "$branch" || true
 			fi
 		fi
 	done

--- a/web/src/components/VirtualLogTable.tsx
+++ b/web/src/components/VirtualLogTable.tsx
@@ -26,7 +26,7 @@ const isCancelled = (errorMessage?: string): boolean => {
 	return (
 		msg.includes("cancel") ||
 		msg.includes("disconnect") ||
-		msg.includes("context canceled")
+		msg.includes("timed out")
 	);
 };
 

--- a/web/src/components/VirtualLogTable.tsx
+++ b/web/src/components/VirtualLogTable.tsx
@@ -3,6 +3,7 @@ import { useCallback, useLayoutEffect, useRef, useState } from "react";
 import type { LogEntry } from "../api/types";
 import { formatMs, formatTPS } from "../pages/Logs/utils";
 import { formatNumber } from "../utils/format";
+import { isCancelled } from "../utils/logHelpers";
 import { Badge } from "./Badge";
 import { LOG_COL_WIDTHS } from "./logTableWidths";
 
@@ -19,17 +20,6 @@ interface VirtualLogTableProps {
 	sortDir: string; // "asc" or "desc"
 	onSortToggle: () => void; // toggle sort direction
 }
-
-const isCancelled = (errorMessage?: string) => {
-	if (!errorMessage) return false;
-	const msg = errorMessage.toLowerCase();
-	return (
-		msg.includes("cancel") ||
-		msg.includes("disconnect") ||
-		msg.includes("upstream request timed out") ||
-		msg.includes("param-strip retry timed out")
-	);
-};
 
 const getStatusBadgeVariant = (
 	statusCode: number,

--- a/web/src/components/VirtualLogTable.tsx
+++ b/web/src/components/VirtualLogTable.tsx
@@ -20,13 +20,14 @@ interface VirtualLogTableProps {
 	onSortToggle: () => void; // toggle sort direction
 }
 
-const isCancelled = (errorMessage?: string): boolean => {
+const isCancelled = (errorMessage?: string) => {
 	if (!errorMessage) return false;
 	const msg = errorMessage.toLowerCase();
 	return (
 		msg.includes("cancel") ||
 		msg.includes("disconnect") ||
-		msg.includes("timed out")
+		msg.includes("upstream request timed out") ||
+		msg.includes("param-strip retry timed out")
 	);
 };
 

--- a/web/src/components/__tests__/VirtualLogTable.test.tsx
+++ b/web/src/components/__tests__/VirtualLogTable.test.tsx
@@ -1144,8 +1144,28 @@ describe("VirtualLogTable", () => {
 			expect(screen.getByText("Interrupted")).toBeInTheDocument();
 		});
 
-		it('detects "context canceled" as cancelled error', () => {
-			const entries = [createLogEntry({ error_message: "context canceled" })];
+		it('detects "client disconnected" as cancelled error', () => {
+			const entries = [
+				createLogEntry({ error_message: "client disconnected" }),
+			];
+			mockGetVirtualItems.mockReturnValue([
+				{ index: 0, key: entries[0].id, start: 0, end: 29 },
+			]);
+			mockGetTotalSize.mockReturnValue(29);
+
+			renderWithProviders(
+				<VirtualLogTable {...defaultProps} entries={entries} />,
+			);
+
+			expect(screen.getByText("Interrupted")).toBeInTheDocument();
+		});
+
+		it('detects "timed out" as cancelled error', () => {
+			const entries = [
+				createLogEntry({
+					error_message: "all providers failed: upstream request timed out",
+				}),
+			];
 			mockGetVirtualItems.mockReturnValue([
 				{ index: 0, key: entries[0].id, start: 0, end: 29 },
 			]);

--- a/web/src/pages/Logs.tsx
+++ b/web/src/pages/Logs.tsx
@@ -289,7 +289,8 @@ function RequestLogs() {
 		return (
 			msg.includes("cancel") ||
 			msg.includes("disconnect") ||
-			msg.includes("timed out")
+			msg.includes("upstream request timed out") ||
+			msg.includes("param-strip retry timed out")
 		);
 	};
 

--- a/web/src/pages/Logs.tsx
+++ b/web/src/pages/Logs.tsx
@@ -289,7 +289,7 @@ function RequestLogs() {
 		return (
 			msg.includes("cancel") ||
 			msg.includes("disconnect") ||
-			msg.includes("context canceled")
+			msg.includes("timed out")
 		);
 	};
 

--- a/web/src/pages/Logs.tsx
+++ b/web/src/pages/Logs.tsx
@@ -32,6 +32,7 @@ import { useDateRangePicker } from "../hooks/useDateRangePicker";
 import { useDebounce } from "../hooks/useDebounce";
 import { useLocalStorage } from "../hooks/useLocalStorage";
 import { encodeCursor, formatNumber } from "../utils/format";
+import { isCancelled } from "../utils/logHelpers";
 import { AppLogs } from "./AppLogs";
 import { formatMs, formatTPS } from "./Logs/utils";
 
@@ -282,17 +283,6 @@ function RequestLogs() {
 	// during refetch, so we only need to check if data has arrived.
 	const displayEntries = logsData?.entries ?? [];
 	const displayTotal = logsData?.total ?? 0;
-
-	const isCancelled = (errorMessage?: string) => {
-		if (!errorMessage) return false;
-		const msg = errorMessage.toLowerCase();
-		return (
-			msg.includes("cancel") ||
-			msg.includes("disconnect") ||
-			msg.includes("upstream request timed out") ||
-			msg.includes("param-strip retry timed out")
-		);
-	};
 
 	const getStatusBadgeVariant = (
 		statusCode: number,

--- a/web/src/pages/__tests__/Logs.test.tsx
+++ b/web/src/pages/__tests__/Logs.test.tsx
@@ -1872,14 +1872,14 @@ describe("Logs", () => {
 			expect(screen.getByText("Interrupted")).toBeInTheDocument();
 		});
 
-		it("detects context canceled error as cancelled", async () => {
+		it("detects client disconnected error as cancelled", async () => {
 			server.use(
 				http.get("/api/logs", () =>
 					HttpResponse.json(
 						createMockLogs([
 							createMockLogEntry({
 								request_hash: "cancel-002",
-								error_message: "context canceled",
+								error_message: "client disconnected",
 								state: "completed",
 								status_code: 0,
 							}),
@@ -1892,6 +1892,32 @@ describe("Logs", () => {
 
 			await waitFor(() => {
 				expect(screen.getByText("cancel-002")).toBeInTheDocument();
+			});
+
+			expect(screen.getByText("Interrupted")).toBeInTheDocument();
+		});
+
+		it("detects timed out error as cancelled", async () => {
+			server.use(
+				http.get("/api/logs", () =>
+					HttpResponse.json(
+						createMockLogs([
+							createMockLogEntry({
+								request_hash: "timeout-001",
+								error_message:
+									"all providers failed: upstream request timed out",
+								state: "completed",
+								status_code: 502,
+							}),
+						]),
+					),
+				),
+			);
+
+			renderWithProviders(<Logs />);
+
+			await waitFor(() => {
+				expect(screen.getByText("timeout-001")).toBeInTheDocument();
 			});
 
 			expect(screen.getByText("Interrupted")).toBeInTheDocument();

--- a/web/src/utils/logHelpers.ts
+++ b/web/src/utils/logHelpers.ts
@@ -1,0 +1,15 @@
+/**
+ * Checks whether a request log error message indicates the request was
+ * cancelled or interrupted (client disconnect, timeout, etc.) rather than
+ * failing due to an upstream provider error.
+ */
+export const isCancelled = (errorMessage?: string): boolean => {
+	if (!errorMessage) return false;
+	const msg = errorMessage.toLowerCase();
+	return (
+		msg.includes("cancel") ||
+		msg.includes("disconnect") ||
+		msg.includes("upstream request timed out") ||
+		msg.includes("param-strip retry timed out")
+	);
+};


### PR DESCRIPTION
## Summary

Replace esoteric Go errors (`"context canceled"`, `"context deadline exceeded"`) with human-readable descriptions in request logs and proxy error responses, so operators can tell at a glance whether a client disconnected, a failover timeout expired, or a param-strip retry timed out.

## Changes

### Backend (`internal/proxy/`)

**Streaming race condition fix** — When `bufio.Scanner` catches `context.Canceled` before the `select` between iterations, the handler now correctly identifies this as a client disconnect (sets `clientDisconnected = true`) instead of surfacing `"context canceled"` as the error message.

**Human-readable cancel origin** — New `humanReadableCancelOrigin()` maps internal identifiers to clear messages:
- `client_disconnect` → `"client disconnected"`
- `failover_timeout` → `"upstream request timed out"`
- `retry_timeout` → `"param-strip retry timed out"`

Used in the failover loop, retry path, and streaming timeout handler.

**CancelOrigin propagation** — `CancelOriginKey` now flows into the streaming path via `streamCancelOrigin`, so `handleStreamingResponse` can distinguish failover timeouts from retry timeouts when `context.DeadlineExceeded` fires in the scanner.

**Early-return log entries** — Moved `insertRequestLogAsync` before the early-return paths (body read failure, invalid JSON, missing model) so `failRequest` can actually write to the DB. Added `model_id` to the `updateRequestLog` UPDATE query. Added `dbPool == nil` guards for unit tests.

**Retry path branching** — The 400 auto-retry path now branches `context.Canceled` → `client_disconnect` vs `context.DeadlineExceeded` → `retry_timeout` (matching the main failover loop), instead of mapping both to `retry_timeout`.

**Consistent unknown-origin fallback** — Streaming unknown-origin fallback now delegates to `humanReadableCancelOrigin()` instead of hardcoding `"upstream request timed out"`.

### Frontend (`web/src/`)

**Narrowed `isCancelled` detection** — Replaced overly broad `msg.includes("timed out")` with specific patterns (`"upstream request timed out"`, `"param-strip retry timed out"`) to avoid false positives on provider error bodies containing "timed out".

### Tests

- 71 existing test call sites updated with `cancelOrigin` parameter
- New `TestHumanReadableCancelOrigin` table-driven test (5 cases)
- Frontend test cases updated for new error message patterns
- All 4258 frontend tests pass, all Go tests pass

## Error message before → after

| Scenario | Before | After |
|----------|--------|-------|
| Client disconnect during streaming (scanner path) | `"context canceled"` | `"client disconnected"` |
| Failover timeout in streaming | `"context deadline exceeded"` | `"stream interrupted: upstream request timed out"` |
| Retry timeout in streaming | `"context deadline exceeded"` | `"stream interrupted: param-strip retry timed out"` |
| Client disconnect during retry | `"attempt N: param-strip retry timed out"` | `"attempt N: client disconnected"` |
| Failover timeout in non-streaming | `"...failover_timeout: context deadline exceeded"` | `"...upstream request timed out"` |
| Early-return failures (bad model, etc.) | No log entry (status 0, state pending) | Proper failed log entry with status + message |