### PR TITLE
Fix dashboard deleted provider clicks, duplicate backup toast, and VirtualModelTable refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,28 +36,28 @@ Made in [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad) with [OpenCode]
 ┌────────────────────────────────────────────────────────┐
 │                       OVERVIEW                         │
 ├────────────────────────────────────────────────────────┤
-│Sessions                                          2,034 │
-│Messages                                         73,587 │
-│Days                                                 42 │
+│Sessions                                          2,123 │
+│Messages                                         77,463 │
+│Days                                                 44 │
 └────────────────────────────────────────────────────────┘
 
 ┌────────────────────────────────────────────────────────┐
 │                    COST & TOKENS                       │
 ├────────────────────────────────────────────────────────┤
 │Total Cost                                      $112.90 │
-│Avg Cost/Day                                      $2.69 │
+│Avg Cost/Day                                      $2.57 │
 │Avg Tokens/Session                                 2.8M │
-│Median Tokens/Session                            580.9K │
-│Input                                           2695.8M │
-│Output                                            18.6M │
-│Cache Read                                      2977.3M │
+│Median Tokens/Session                            585.5K │
+│Input                                           2789.1M │
+│Output                                            19.6M │
+│Cache Read                                      3195.9M │
 │Cache Write                                        4.1M │
 └────────────────────────────────────────────────────────┘
 ```
 </details>
 
 <a href="https://github.com/aovestdipaperino/tokensave">![Tokens Saved](https://img.shields.io/endpoint?url=https://tokens.o5.ddns.net/&cacheSeconds=1800)<a><br><br>
-Meet the [oh-my-opencode-slim](https://github.com/alvinunreal/oh-my-opencode-slim) team:<br><br><img src="https://img.shields.io/badge/GLM_5.1-orchestrator,%20council-8B5CF6?style=flat" alt="GLM 5.1"> <img src="https://img.shields.io/badge/Kimi_K2.6-designer,%20council-06B6D4?style=flat" alt="Kimi K2.6"> <img src="https://img.shields.io/badge/DeepSeek_V4_Pro-oracle,%20council-E53E3E?style=flat" alt="DeepSeek V4 Pro"><br><img src="https://img.shields.io/badge/Qwen3.5_397B-fixer-F59E0B?style=flat" alt="Qwen3.5 397B"> <img src="https://img.shields.io/badge/DeepSeek_V4_Pro-librarian-E53E3E?style=flat" alt="DeepSeek V4 Pro"> <img src="https://img.shields.io/badge/Gemini_3_Flash-observer-4285F4?style=flat" alt="Gemini 3 Flash">
+Meet the [oh-my-opencode-slim](https://github.com/alvinunreal/oh-my-opencode-slim) team:<br><br><img src="https://img.shields.io/badge/GLM_5.1-orchestrator,%20council-8B5CF6?style=flat" alt="GLM 5.1"> <img src="https://img.shields.io/badge/Kimi_K2.6-designer,%20council-06B6D4?style=flat" alt="Kimi K2.6"> <img src="https://img.shields.io/badge/DeepSeek_V4_Pro-oracle,%20council-E53E3E?style=flat" alt="DeepSeek V4 Pro"><br><img src="https://img.shields.io/badge/Qwen3.5_397B-fixer-F59E0B?style=flat" alt="Qwen3.5 397B"> <img src="https://img.shields.io/badge/DeepSeek_V4_Pro-librarian-E53E3E?style=flat" alt="DeepSeek V4 Pro"> <img src="https://img.shields.io/badge/MiniMax_M2.7-explorer-10B981?style=flat" alt="MiniMax M2.7"> <img src="https://img.shields.io/badge/Gemini_3_Flash-observer-4285F4?style=flat" alt="Gemini 3 Flash">
 </div><br>
 
 A single OpenAI-compatible endpoint that sits in front of all your LLM providers. Models are auto-discovered the moment you add a provider and optionally on schedule; failover groups form automatically around shared model names and retry transparently when a provider goes down; no prompt data is ever stored.

--- a/web/src/pages/Dashboard/UsageBarPanel.tsx
+++ b/web/src/pages/Dashboard/UsageBarPanel.tsx
@@ -55,11 +55,11 @@ export function UsageBarPanel({
 						return (
 							<div key={entry.label} className="space-y-1.5">
 								<div className="flex justify-between items-center text-sm">
-									{onEntryClick && !entry.failoverGroup ? (
+									{onEntryClick && !entry.failoverGroup && !entry.deleted ? (
 										<button
 											type="button"
 											onClick={() => onEntryClick(entry.label)}
-											className={`truncate max-w-[70%] text-left cursor-pointer transition-colors hover:text-(--accent) hover:drop-shadow-[var(--glow-accent)] ${entry.deleted ? "text-red-400 italic pr-1" : "text-(--text-secondary)"}`}
+											className="truncate max-w-[70%] text-left cursor-pointer transition-colors hover:text-(--accent) hover:drop-shadow-[var(--glow-accent)] text-(--text-secondary)"
 											title={`View details for ${entry.label}`}
 											aria-label={`View details for ${entry.label}`}
 										>

--- a/web/src/pages/Dashboard/__tests__/UsageBarPanel.test.tsx
+++ b/web/src/pages/Dashboard/__tests__/UsageBarPanel.test.tsx
@@ -222,7 +222,7 @@ describe("UsageBarPanel", () => {
 		expect(modelA).not.toHaveClass("italic");
 	});
 
-	it("applies deleted styling to clickable deleted entries", async () => {
+	it("renders deleted entries as non-clickable spans with styling", () => {
 		const deletedEntries: UsageEntry[] = [
 			{ label: "Deleted Clickable", value: 100, deleted: true },
 		];
@@ -238,7 +238,8 @@ describe("UsageBarPanel", () => {
 		const deletedLabel = screen.getByText("Deleted Clickable");
 		expect(deletedLabel).toHaveClass("text-red-400");
 		expect(deletedLabel).toHaveClass("italic");
-		expect(deletedLabel).toHaveClass("cursor-pointer");
+		// Deleted entries are rendered as spans, not buttons
+		expect(deletedLabel.tagName).toBe("SPAN");
 	});
 
 	it("renders failover group entries as non-interactive spans even when onEntryClick is provided", () => {

--- a/web/src/pages/Dashboard/__tests__/useDashboard.test.tsx
+++ b/web/src/pages/Dashboard/__tests__/useDashboard.test.tsx
@@ -655,17 +655,20 @@ describe("useDashboard", () => {
 			await waitFor(() => {
 				expect(result.current.byModel).toHaveLength(5);
 				// Default globalMetric is "tokens", so suffix is " tokens"
+				// All entries have deleted: true since model keys don't match mockModel
 				expect(result.current.byModel[0]).toEqual({
 					label: "model-e",
 					value: 300,
 					suffix: " tokens",
 					failoverGroup: false,
+					deleted: true,
 				});
 				expect(result.current.byModel[1]).toEqual({
 					label: "model-b",
 					value: 200,
 					suffix: " tokens",
 					failoverGroup: false,
+					deleted: true,
 				});
 				// model-c with 0 should be filtered out
 			});

--- a/web/src/pages/Dashboard/__tests__/useDashboard.test.tsx
+++ b/web/src/pages/Dashboard/__tests__/useDashboard.test.tsx
@@ -674,6 +674,37 @@ describe("useDashboard", () => {
 			});
 		});
 
+		it("byModel does not mark hotel/ failover groups as deleted", async () => {
+			server.use(
+				http.get("/api/stats", () => {
+					return HttpResponse.json({
+						...mockStats,
+						by_model: { "hotel/my-group": 150, "model-x": 50 },
+					} as Stats);
+				}),
+			);
+
+			const { result } = renderHook(() => useDashboard(), {
+				wrapper: AllProviders,
+			});
+
+			await waitFor(() => {
+				expect(result.current.byModel).toHaveLength(2);
+			});
+
+			const failoverEntry = result.current.byModel.find(
+				(e) => e.label === "hotel/my-group",
+			);
+			expect(failoverEntry?.failoverGroup).toBe(true);
+			expect(failoverEntry?.deleted).toBe(false);
+
+			const regularEntry = result.current.byModel.find(
+				(e) => e.label === "model-x",
+			);
+			expect(regularEntry?.failoverGroup).toBe(false);
+			expect(regularEntry?.deleted).toBe(true);
+		});
+
 		it("byModel uses 'tokens' suffix when modelsMetric is 'tokens'", async () => {
 			server.use(
 				http.get("/api/stats", () => {

--- a/web/src/pages/Dashboard/useDashboard.ts
+++ b/web/src/pages/Dashboard/useDashboard.ts
@@ -563,12 +563,19 @@ export function useDashboard(): UseDashboardReturn {
 				.filter(([, v]) => Number(v) > 0)
 				.sort(([, a], [, b]) => Number(b) - Number(a))
 				.slice(0, 5)
-				.map(([k, v]) => ({
-					label: k,
-					value: Number(v),
-					suffix: modelsMetric === "tokens" ? " tokens" : " requests",
-					failoverGroup: k.startsWith("hotel/"),
-				}))
+				.map(([k, v]) => {
+					const normalized = k.replace(/ /g, "-");
+					const exists = models?.some(
+						(m) => proxyModelID(m.provider_name, m.model_id) === normalized,
+					);
+					return {
+						label: k,
+						value: Number(v),
+						suffix: modelsMetric === "tokens" ? " tokens" : " requests",
+						failoverGroup: k.startsWith("hotel/"),
+						deleted: !exists,
+					};
+				})
 		: [];
 	const byProvider = providersUsageStats
 		? Object.entries(providersUsageStats.by_provider)

--- a/web/src/pages/Dashboard/useDashboard.ts
+++ b/web/src/pages/Dashboard/useDashboard.ts
@@ -568,7 +568,8 @@ export function useDashboard(): UseDashboardReturn {
 					const normalized = k.replace(/ /g, "-");
 					const exists =
 						isFailoverGroup ||
-						models?.some(
+						models === undefined ||
+						models.some(
 							(m) => proxyModelID(m.provider_name, m.model_id) === normalized,
 						);
 					return {

--- a/web/src/pages/Dashboard/useDashboard.ts
+++ b/web/src/pages/Dashboard/useDashboard.ts
@@ -564,15 +564,18 @@ export function useDashboard(): UseDashboardReturn {
 				.sort(([, a], [, b]) => Number(b) - Number(a))
 				.slice(0, 5)
 				.map(([k, v]) => {
+					const isFailoverGroup = k.startsWith("hotel/");
 					const normalized = k.replace(/ /g, "-");
-					const exists = models?.some(
-						(m) => proxyModelID(m.provider_name, m.model_id) === normalized,
-					);
+					const exists =
+						isFailoverGroup ||
+						models?.some(
+							(m) => proxyModelID(m.provider_name, m.model_id) === normalized,
+						);
 					return {
 						label: k,
 						value: Number(v),
 						suffix: modelsMetric === "tokens" ? " tokens" : " requests",
-						failoverGroup: k.startsWith("hotel/"),
+						failoverGroup: isFailoverGroup,
 						deleted: !exists,
 					};
 				})

--- a/web/src/pages/Models.tsx
+++ b/web/src/pages/Models.tsx
@@ -96,6 +96,7 @@ export function Models() {
 			const result = await api.providers.discover(providerId);
 			queryClient.invalidateQueries({ queryKey: ["models"] });
 			queryClient.invalidateQueries({ queryKey: ["providers"] });
+			setModelRefreshTrigger((n) => n + 1);
 			return result;
 		},
 		[queryClient],

--- a/web/src/pages/Models.tsx
+++ b/web/src/pages/Models.tsx
@@ -73,7 +73,7 @@ export function Models() {
 				},
 			);
 		},
-		[toggleMutation, toast, setModelRefreshTrigger],
+		[toggleMutation, toast],
 	);
 
 	const handleUpdateModel = useCallback(
@@ -109,6 +109,7 @@ export function Models() {
 		mutationFn: (id: string) => api.models.delete(id),
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: ["models"] });
+			setModelRefreshTrigger((n) => n + 1);
 			toast("Model deleted successfully", "success");
 		},
 		onError: (err: Error) => {
@@ -127,6 +128,7 @@ export function Models() {
 				),
 			);
 			queryClient.invalidateQueries({ queryKey: ["models"] });
+			setModelRefreshTrigger((n) => n + 1);
 			if (failed === 0) {
 				toast(
 					`Deleted ${ids.length} disabled model${ids.length === 1 ? "" : "s"}`,

--- a/web/src/pages/Settings/DatabaseBackupSettings.tsx
+++ b/web/src/pages/Settings/DatabaseBackupSettings.tsx
@@ -40,7 +40,6 @@ export function DatabaseBackupSettings({
 		mutationFn: () => api.backups.create(),
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: ["backups"] });
-			toast("Backup created", "success");
 		},
 		onError: (err: Error) => {
 			toast(`Backup failed: ${err.message}`, "error");

--- a/web/src/pages/Settings/__tests__/DatabaseBackupSettings.test.tsx
+++ b/web/src/pages/Settings/__tests__/DatabaseBackupSettings.test.tsx
@@ -246,7 +246,7 @@ describe("DatabaseBackupSettings", () => {
 		});
 	});
 
-	it("Create shows success toast", async () => {
+	it("Create refreshes backup list on success", async () => {
 		const user = userEvent.setup();
 		renderWithProviders(
 			<DatabaseBackupSettings collapsed={false} onToggle={onToggle} />,
@@ -258,8 +258,9 @@ describe("DatabaseBackupSettings", () => {
 		});
 		const createButton = screen.getByRole("button", { name: /create backup/i });
 		await user.click(createButton);
+		// Button returns to normal state after mutation completes
 		await waitFor(() => {
-			expect(screen.getByText("Backup created")).toBeInTheDocument();
+			expect(createButton).not.toBeDisabled();
 		});
 	});
 

--- a/web/src/pages/__tests__/Dashboard.test.tsx
+++ b/web/src/pages/__tests__/Dashboard.test.tsx
@@ -375,12 +375,11 @@ describe("Dashboard", () => {
 
 		it("displays models in Top Models panel", async () => {
 			// Top Models panel uses stats.by_model from /api/stats?metric=tokens&period=24h
-			// The proxyModelID normalizes provider names (spaces -> hyphens)
-			// So "Test Provider" becomes "test-provider"
+			// Backend returns by_model keys as "Provider Name/model-id" (raw name with spaces).
 			const statsWithModelUsage = {
 				...mockStats,
 				by_model: {
-					"test-provider/test-model-v1": 1000,
+					"Test Provider/test-model-v1": 1000,
 				},
 			};
 			server.use(
@@ -396,9 +395,8 @@ describe("Dashboard", () => {
 				expect(screen.getByText("Dashboard")).toBeInTheDocument();
 			});
 
-			// Model label is normalized: test-provider/test-model-v1
 			expect(
-				screen.getByText("test-provider/test-model-v1"),
+				screen.getByText("Test Provider/test-model-v1"),
 			).toBeInTheDocument();
 		});
 	});
@@ -455,12 +453,12 @@ describe("Dashboard", () => {
 
 	describe("Model Detail Modal", () => {
 		it("renders model detail modal when model is selected", async () => {
-			// Need stats with model usage data for the panel to show the model
-			// The proxyModelID normalizes provider names (spaces -> hyphens)
+			// Need stats with model usage data for the panel to show the model.
+			// Backend returns by_model keys as "Provider Name/model-id" (raw name with spaces).
 			const statsWithModelUsage = {
 				...mockStats,
 				by_model: {
-					"test-provider/test-model-v1": 1000,
+					"Test Provider/test-model-v1": 1000,
 				},
 			};
 			server.use(
@@ -475,17 +473,43 @@ describe("Dashboard", () => {
 				expect(screen.getByText("Dashboard")).toBeInTheDocument();
 			});
 
-			// Model label is normalized: test-provider/test-model-v1
 			// Verify the model entry is rendered as clickable (has button parent)
 			expect(
 				screen.getByRole("button", {
-					name: /View details for test-provider\/test-model-v1/i,
+					name: /View details for Test Provider\/test-model-v1/i,
 				}),
 			).toBeInTheDocument();
 		});
 	});
 
 	describe("Data Refresh", () => {
+		it("deleted provider model is not clickable in Top Models", async () => {
+			// Stats returns a model key for a provider that no longer exists
+			const statsWithDeletedProvider = {
+				...mockStats,
+				by_model: {
+					"Deleted Provider/some-model": 500,
+				},
+			};
+			server.use(
+				http.get("/api/stats", () =>
+					HttpResponse.json(statsWithDeletedProvider),
+				),
+				http.get("/api/models", () => HttpResponse.json([])),
+				http.get("/api/providers", () => HttpResponse.json([])),
+			);
+
+			renderWithProviders(<Dashboard />);
+
+			await waitFor(() => {
+				expect(screen.getByText("Dashboard")).toBeInTheDocument();
+			});
+
+			// Entry text is rendered but NOT as a button (deleted provider)
+			const entryText = screen.getByText("Deleted Provider/some-model");
+			expect(entryText.tagName).not.toBe("BUTTON");
+		});
+
 		it("refreshes data when refresh button is clicked", async () => {
 			let callCount = 0;
 			server.use(


### PR DESCRIPTION
## Fixes

### Dashboard Top Models: deleted provider models no longer clickable
- `byModel` entries check if model exists in the live models list via `proxyModelID` normalization, marking orphaned entries as `deleted: true`
- `UsageBarPanel` renders deleted entries as non-interactive spans (red, italic) instead of clickable buttons
- Removed dead-code ternary from the button branch (unreachable after the `!entry.deleted` guard)

### Duplicate backup toast
- Removed direct `toast("Backup created")` from the backup creation mutation's `onSuccess` — the SSE `backup.created` event already triggers a toast via `EventContext` with full filename/size details

### VirtualModelTable not refreshing after model changes
- `VirtualModelTable` uses `useBidirectionalFetch` (internal `useState`, not React Query), so `queryClient.invalidateQueries` alone had no effect
- Added `setModelRefreshTrigger((n) => n + 1)` to all model-modifying paths:
  - Single delete (`deleteMutation.onSuccess`)
  - Bulk delete disabled models (`handleDeleteDisabled`)
  - Model discovery (`handleDiscover`)
  - Toggle and update were already covered

### Test updates
- Dashboard test data uses realistic backend format (`"Provider Name/model-id"` with spaces)
- New test: deleted provider model is not clickable in Top Models
- UsageBarPanel test: deleted entries render as `<span>`, not `<button>`
- useDashboard test: `byModel` entries include `deleted` field
- DatabaseBackupSettings test: verifies mutation completion instead of toast text