### PR TITLE
Bump go.mod directive to 1.26.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hugalafutro/model-hotel
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/go-chi/chi/v5 v5.3.0


### PR DESCRIPTION
Updates the `go` directive in `go.mod` from `1.25.0` to `1.26.0` to match the Dockerfile image bump in #71.