### PR TITLE
chore: exclude Go test files from Codacy duplication and complexity analysis

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -21,6 +21,10 @@ engines:
     exclude_paths:
       - "**/__tests__/**"
       - "**/*.test.*"
+      - "**/*_test.go"
+  gocyclo:
+    exclude_paths:
+      - "**/*_test.go"
   markdownlint:
     exclude_paths:
       - "README.md"


### PR DESCRIPTION
## Changes
- Added `**/*_test.go` to `duplication` engine exclusions
- Added `gocyclo` engine with `**/*_test.go` exclusion for cyclomatic complexity

## Why
Go test files were inflating Codacy metrics with hundreds of "clones" and high complexity scores. Test code naturally repeats setup/assertion patterns (error-path variants, failover trigger variants, input validation variants, streaming vs non-streaming mirrors). This is expected and desirable for test readability and isolation.

Excluding tests from these metrics will clear the noise so you can see real duplication/complexity in production code.