### PR TITLE
chore: exclude test infrastructure from Codacy

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -22,11 +22,15 @@ engines:
       - "**/__tests__/**"
       - "**/*.test.*"
       - "**/*_test.go"
+      - "**/test/**"
+      - "**/*_test_helpers*.go"
   metric:
     exclude_paths:
       - "**/__tests__/**"
       - "**/*.test.*"
       - "**/*_test.go"
+      - "**/test/**"
+      - "**/*_test_helpers*.go"
   markdownlint:
     exclude_paths:
       - "README.md"
@@ -38,3 +42,5 @@ exclude_paths:
   - "web/dist/**"
   - "web/coverage/**"
   - "cmd/server/static/**"  # embedded frontend bundle
+  - "**/test/**"            # test infrastructure (mocks, helpers, setup)
+  - "**/*_test_helpers*.go" # Go test helpers


### PR DESCRIPTION
Excludes test infrastructure files from Codacy analysis (duplication, metrics, and global paths).

These are test helpers/mocks/setup, not production code:
- `web/src/test/**` (MSW handlers, renderWithProviders, setup, helpers)
- `internal/**/*_test_helpers*.go` (Go test helper files)