### PR TITLE
Exclude pure type files from vitest coverage

### DIFF
--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
 				"src/test/**",
 				"src/main.tsx",
 				"src/**/*.d.ts",
+				"src/**/types.ts",
 			],
 		},
 	},


### PR DESCRIPTION
## What

Add `src/**/types.ts` to the Vitest coverage `exclude` list.

## Why

These three files are pure TypeScript `interface`/`type` declarations with zero runtime code after compilation:

- `web/src/api/types.ts` (477 lines)
- `web/src/pages/Dashboard/types.ts` (43 lines)
- `web/src/pages/Arena/types.ts` (110 lines)

Coverage tools like Vitest/Istanbul can only instrument executable code. These files will always show 0% coverage, which is correct behavior (not a test gap) but creates noise in Codacy quality reports.