### PR TITLE
feat: prefer local pnpm/biome in git hooks, fall back to Docker

### DIFF
--- a/internal/provider/discovery_types.go
+++ b/internal/provider/discovery_types.go
@@ -1,5 +1,63 @@
 package provider
 
+// NeuralWattQuotaBalance contains balance/credit information.
+type NeuralWattQuotaBalance struct {
+	CreditsRemainingUSD float64 `json:"credits_remaining_usd"`
+	TotalCreditsUSD     float64 `json:"total_credits_usd"`
+	CreditsUsedUSD      float64 `json:"credits_used_usd"`
+	AccountingMethod    string  `json:"accounting_method"`
+}
+
+// NeuralWattQuotaUsagePeriod contains cost/request/token/energy usage.
+type NeuralWattQuotaUsagePeriod struct {
+	CostUSD   float64 `json:"cost_usd"`
+	Requests  int64   `json:"requests"`
+	Tokens    int64   `json:"tokens"`
+	EnergyKWh float64 `json:"energy_kwh"`
+}
+
+// NeuralWattQuotaUsage contains lifetime and current_month usage.
+type NeuralWattQuotaUsage struct {
+	Lifetime     NeuralWattQuotaUsagePeriod `json:"lifetime"`
+	CurrentMonth NeuralWattQuotaUsagePeriod `json:"current_month"`
+}
+
+// NeuralWattQuotaLimits contains rate limit tier info.
+type NeuralWattQuotaLimits struct {
+	OverageLimitUSD *float64 `json:"overage_limit_usd"`
+	RateLimitTier   string   `json:"rate_limit_tier"`
+}
+
+// NeuralWattQuotaSubscription contains plan and billing details.
+type NeuralWattQuotaSubscription struct {
+	Plan               string  `json:"plan"`
+	Status             string  `json:"status"`
+	BillingInterval    string  `json:"billing_interval"`
+	CurrentPeriodStart string  `json:"current_period_start"`
+	CurrentPeriodEnd   string  `json:"current_period_end"`
+	AutoRenew          bool    `json:"auto_renew"`
+	KWhIncluded        float64 `json:"kwh_included"`
+	KWhUsed            float64 `json:"kwh_used"`
+	KWhRemaining       float64 `json:"kwh_remaining"`
+	InOverage          bool    `json:"in_overage"`
+}
+
+// NeuralWattQuotaKey contains key metadata.
+type NeuralWattQuotaKey struct {
+	Name      string   `json:"name"`
+	Allowance *float64 `json:"allowance"`
+}
+
+// NeuralWattQuotaResponse is the API response from NeuralWatt /v1/quota.
+type NeuralWattQuotaResponse struct {
+	SnapshotAt   string                      `json:"snapshot_at"`
+	Balance      NeuralWattQuotaBalance      `json:"balance"`
+	Usage        NeuralWattQuotaUsage        `json:"usage"`
+	Limits       NeuralWattQuotaLimits       `json:"limits"`
+	Subscription NeuralWattQuotaSubscription `json:"subscription"`
+	Key          NeuralWattQuotaKey          `json:"key"`
+}
+
 // OpenAIModel represents a model from the OpenAI API.
 type OpenAIModel struct {
 	ID      string `json:"id"`

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -2,9 +2,8 @@
 # Pre-commit: fast formatting only. Real checks run in CI.
 # Goal: under 10 seconds, never blocks for slow tests.
 #
-# Frontend checks (biome) run inside Docker — no local node_modules needed.
-# The web/node_modules directory is a 000-permission block to prevent
-# accidental local pnpm usage.
+# Frontend checks (biome) use local pnpm when web/node_modules exists,
+# otherwise fall back to Docker.
 
 set -euo pipefail
 
@@ -54,20 +53,29 @@ if [ -n "$staged_go" ]; then
 	fi
 fi
 
-# ── Frontend: biome --write on staged TS/TSX (via Docker) ──
-	if [ -n "$staged_ts" ]; then
+# ── Frontend: biome --write on staged TS/TSX ──
+if [ -n "$staged_ts" ]; then
 	rel_paths=()
 	for f in $staged_ts; do
 		rel_paths+=("${f#web/}")
 	done
-	echo "pre-commit: biome --write ${rel_paths[*]} (Docker)"
-	if ! docker run --rm \
-		-v "$REPO_ROOT/web":/app \
-		-w /app \
-		node:22-alpine \
-		sh -c "npm install -g @biomejs/biome@2.4.16 >/dev/null 2>&1 && biome check --write \"\$@\"" -- "${rel_paths[@]}" >/dev/null 2>&1; then
-		echo "pre-commit: FAILED - biome check" >&2
-		exit 1
+
+	if [ -d "$REPO_ROOT/web/node_modules" ]; then
+		echo "pre-commit: biome --write ${rel_paths[*]} (local)"
+		if ! (cd "$REPO_ROOT/web" && npx biome check --write "${rel_paths[@]}" >/dev/null 2>&1); then
+			echo "pre-commit: FAILED - biome check" >&2
+			exit 1
+		fi
+	else
+		echo "pre-commit: biome --write ${rel_paths[*]} (Docker)"
+		if ! docker run --rm \
+			-v "$REPO_ROOT/web":/app \
+			-w /app \
+			node:22-alpine \
+			sh -c "npm install -g @biomejs/biome@2.4.16 >/dev/null 2>&1 && biome check --write \"\$@\"" -- "${rel_paths[@]}" >/dev/null 2>&1; then
+			echo "pre-commit: FAILED - biome check" >&2
+			exit 1
+		fi
 	fi
 	# Re-stage any files biome rewrote.
 	changed=""

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -1,32 +1,38 @@
 #!/usr/bin/env bash
 # Pre-push: smoke test only (~30s). GitHub CI is the real gatekeeper.
 #
-# Frontend checks run inside Docker with --tmpfs for node_modules,
-# so no local node_modules directory is needed or created.
+# Frontend checks use local pnpm when web/node_modules exists,
+# otherwise fall back to Docker.
 
 set -euo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
 echo "pre-push: go vet ./..."
-# web/node_modules is a root-owned 000 directory that blocks `go vet ./...`.
-# Only vet the Go packages we actually have.
 if ! go vet ./cmd/... ./internal/...; then
 	echo "pre-push: FAILED - go vet" >&2
 	exit 1
 fi
 
-echo "pre-push: pnpm lint (Docker)..."
-if ! docker run --rm \
-	-v "$REPO_ROOT/web":/app \
-	-v model-hotel-pnpm-store:/pnpm/store \
-	--tmpfs /app/node_modules:exec \
-	-e PNPM_HOME=/root/.local/share/pnpm \
-	-w /app \
-	node:22-alpine \
-	sh -c "npm install -g pnpm@10 >/dev/null 2>&1 && pnpm config set store-dir /pnpm/store >/dev/null && pnpm install --frozen-lockfile >/dev/null 2>&1 && pnpm run lint" 2>&1; then
-	echo "pre-push: FAILED - pnpm lint" >&2
-	exit 1
+if [ -d "$REPO_ROOT/web/node_modules" ]; then
+	echo "pre-push: pnpm lint (local)..."
+	if ! (cd "$REPO_ROOT/web" && pnpm run lint); then
+		echo "pre-push: FAILED - pnpm lint" >&2
+		exit 1
+	fi
+else
+	echo "pre-push: pnpm lint (Docker)..."
+	if ! docker run --rm \
+		-v "$REPO_ROOT/web":/app \
+		-v model-hotel-pnpm-store:/pnpm/store \
+		--tmpfs /app/node_modules:exec \
+		-e PNPM_HOME=/root/.local/share/pnpm \
+		-w /app \
+		node:22-alpine \
+		sh -c "npm install -g pnpm@10 >/dev/null 2>&1 && pnpm config set store-dir /pnpm/store >/dev/null && pnpm install --frozen-lockfile >/dev/null 2>&1 && pnpm run lint" 2>&1; then
+		echo "pre-push: FAILED - pnpm lint" >&2
+		exit 1
+	fi
 fi
 
 echo "pre-push: smoke ok (full CI runs on GitHub)"


### PR DESCRIPTION
Split from #102.

- Git hooks (pre-commit, pre-push) now prefer local pnpm/biome when node_modules exists, falling back to Docker
- Fixes missing NeuralWatt type definitions that broke go vet on master