### PR TITLE
chore: exclude ProviderModals barrel file from Codacy coverage

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -51,3 +51,4 @@ exclude_paths:
   - "cmd/server/static/**"
   - "**/test/**"
   - "**/*_test_helpers*.go"
+  - "web/src/components/ProviderModals.tsx"

--- a/.codacy.yml
+++ b/.codacy.yml
@@ -51,4 +51,3 @@ exclude_paths:
   - "cmd/server/static/**"
   - "**/test/**"
   - "**/*_test_helpers*.go"
-  - "web/src/components/ProviderModals.tsx"

--- a/web/src/components/ProviderModals.tsx
+++ b/web/src/components/ProviderModals.tsx
@@ -1,3 +1,4 @@
+/* istanbul ignore file: barrel re-export, no testable logic */
 export { NanoGPTQuotaModal } from "./modals/NanoGPTQuotaModal";
 export { NeuralWattQuotaModal } from "./modals/NeuralWattQuotaModal";
 export { OpenRouterQuotaModal } from "./modals/OpenRouterQuotaModal";

--- a/web/src/components/ProviderModals.tsx
+++ b/web/src/components/ProviderModals.tsx
@@ -1,4 +1,3 @@
-/* istanbul ignore file: barrel re-export, no testable logic */
 export { NanoGPTQuotaModal } from "./modals/NanoGPTQuotaModal";
 export { NeuralWattQuotaModal } from "./modals/NeuralWattQuotaModal";
 export { OpenRouterQuotaModal } from "./modals/OpenRouterQuotaModal";

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
 				"src/**/*.d.ts",
 				"src/**/types.ts",
 				"src/components/logs/index.ts",
+				"src/components/ProviderModals.tsx",
 			],
 		},
 	},


### PR DESCRIPTION
Exclude `web/src/components/ProviderModals.tsx` from Codacy coverage — it's a pure re-export barrel file with no testable logic, shows as 0% covered.