### PR TITLE
refactor(proxy): extract 4 helpers to reduce duplication in proxy.go

### DIFF
--- a/internal/proxy/helpers.go
+++ b/internal/proxy/helpers.go
@@ -127,9 +127,9 @@ func normalizeFinishReasonInChoices(choices []map[string]json.RawMessage, lastRe
 // Usage struct. It checks three provider-specific fields in precedence order:
 // PromptCacheHitTokens (OpenAI), CacheReadInputTokens (Anthropic-native),
 // and PromptTokensDetails.CachedTokens (OpenAI nested format).
-// Returns (0, 0) when no cache fields are present; callers should only
-// assign the results when at least one value is non-zero to preserve any
-// previously accumulated cache counts from earlier usage chunks.
+// Returns (0, 0) when no cache fields are present. Streaming callers should
+// guard the assignment (hit > 0 || miss > 0) to avoid zeroing out cache counts
+// from an earlier usage chunk; non-streaming callers can assign unconditionally
 func extractCacheTokens(u Usage) (hitTokens, missTokens int) {
 	if u.PromptCacheHitTokens > 0 {
 		return u.PromptCacheHitTokens, max(0, u.PromptTokens-u.PromptCacheHitTokens)

--- a/internal/proxy/helpers.go
+++ b/internal/proxy/helpers.go
@@ -2,10 +2,17 @@ package proxy
 
 import (
 	"bufio"
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
+	"io"
 	"strings"
+	"time"
+
+	"github.com/hugalafutro/model-hotel/internal/debuglog"
+	"github.com/hugalafutro/model-hotel/internal/events"
 )
 
 func extractStreamingUsage(data string) *Usage {
@@ -91,6 +98,48 @@ func normalizeFinishReason(reason string) string {
 	return reason
 }
 
+// normalizeFinishReasonInChoices normalizes the finish_reason value in the
+// first choice of a parsed SSE chunk. It maps provider-specific values (e.g.
+// "end_turn", "STOP") to OpenAI-compatible equivalents in-place, and updates
+// lastReason with the final value. Replaces 3 identical inline blocks.
+func normalizeFinishReasonInChoices(choices []map[string]json.RawMessage, lastReason *string) {
+	if len(choices) == 0 {
+		return
+	}
+	frRaw, ok := choices[0]["finish_reason"]
+	if !ok {
+		return
+	}
+	var frStr string
+	if json.Unmarshal(frRaw, &frStr) != nil || frStr == "" {
+		return
+	}
+	normalized := normalizeFinishReason(frStr)
+	if normalized != frStr {
+		choices[0]["finish_reason"] = json.RawMessage(`"` + normalized + `"`)
+		debuglog.Debug("proxy: normalized finish_reason", "original", frStr, "normalized", normalized)
+	}
+	*lastReason = normalized
+}
+
+// extractCacheTokens returns prompt cache hit and miss token counts from a
+// Usage struct. It checks three provider-specific fields in precedence order:
+// PromptCacheHitTokens (OpenAI), CacheReadInputTokens (Anthropic-native),
+// and PromptTokensDetails.CachedTokens (OpenAI nested format).
+// Replaces 2 identical if-else chains in streaming and non-streaming paths.
+func extractCacheTokens(u Usage) (hitTokens, missTokens int) {
+	if u.PromptCacheHitTokens > 0 {
+		return u.PromptCacheHitTokens, max(0, u.PromptTokens-u.PromptCacheHitTokens)
+	}
+	if u.CacheReadInputTokens > 0 {
+		return u.CacheReadInputTokens, max(0, u.PromptTokens-u.CacheReadInputTokens)
+	}
+	if u.PromptTokensDetails != nil && u.PromptTokensDetails.CachedTokens > 0 {
+		return u.PromptTokensDetails.CachedTokens, max(0, u.PromptTokens-u.PromptTokensDetails.CachedTokens)
+	}
+	return 0, 0
+}
+
 // parsedChunk holds the decomposed fields from an SSE data line payload.
 // Instead of nesting 5-6 levels of json.Unmarshal checks, parseChunkPayload
 // returns all three maps in a single call.
@@ -165,4 +214,47 @@ func generateRequestHash() string {
 	b := make([]byte, 8)
 	rand.Read(b)
 	return hex.EncodeToString(b)
+}
+
+// recordTokenUsage adds the total token count to a virtual key's usage counter.
+// On failure, it publishes a tokens.error event for the frontend toast system.
+// Extracted from identical blocks in handleStreamingResponse and
+// handleNonStreamingResponse.
+func (h *Handler) recordTokenUsage(vkHash string, promptTokens, completionTokens, reasoningTokens int, virtualKeyName string) {
+	totalTokens := promptTokens + completionTokens + reasoningTokens
+	tokCtx, tokCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer tokCancel()
+	if err := h.virtualKeyRepo.AddTokens(tokCtx, vkHash, totalTokens); err != nil {
+		keyLabel := vkHash
+		if virtualKeyName != "" {
+			keyLabel = virtualKeyName
+		}
+		events.Publish(events.Event{
+			Type:     "tokens.error",
+			Severity: "error",
+			Source:   "proxy",
+			Message:  fmt.Sprintf("Token counting failed for key %q", keyLabel),
+			Metadata: map[string]interface{}{"error": err.Error(), "key": keyLabel},
+		})
+	}
+}
+
+// writeSSEDataChunk writes an SSE "data: <payload>\n\n" sequence to w,
+// updating bytesWritten with the number of bytes written. Returns an error
+// if any write fails. The caller is responsible for flushing and setting
+// skipNextEmptyLine/written flags. Replaces 4 identical inline write blocks.
+func writeSSEDataChunk(w io.Writer, payload []byte, bytesWritten *int64) error {
+	n, err := w.Write([]byte("data: "))
+	*bytesWritten += int64(n)
+	if err != nil {
+		return err
+	}
+	n, err = w.Write(payload)
+	*bytesWritten += int64(n)
+	if err != nil {
+		return err
+	}
+	n, err = w.Write([]byte("\n\n"))
+	*bytesWritten += int64(n)
+	return err
 }

--- a/internal/proxy/helpers.go
+++ b/internal/proxy/helpers.go
@@ -101,8 +101,9 @@ func normalizeFinishReason(reason string) string {
 // normalizeFinishReasonInChoices normalizes the finish_reason value in the
 // first choice of a parsed SSE chunk. It maps provider-specific values (e.g.
 // "end_turn", "STOP") to OpenAI-compatible equivalents in-place, and updates
-// lastReason with the final value. Replaces 3 identical inline blocks.
-func normalizeFinishReasonInChoices(choices []map[string]json.RawMessage, lastReason *string) {
+// lastReason with the final value. The model and provider params are included
+// in the debug log for traceability. Replaces 3 identical inline blocks.
+func normalizeFinishReasonInChoices(choices []map[string]json.RawMessage, lastReason *string, modelID, providerName string) {
 	if len(choices) == 0 {
 		return
 	}
@@ -117,7 +118,7 @@ func normalizeFinishReasonInChoices(choices []map[string]json.RawMessage, lastRe
 	normalized := normalizeFinishReason(frStr)
 	if normalized != frStr {
 		choices[0]["finish_reason"] = json.RawMessage(`"` + normalized + `"`)
-		debuglog.Debug("proxy: normalized finish_reason", "original", frStr, "normalized", normalized)
+		debuglog.Debug("proxy: normalized finish_reason", "original", frStr, "normalized", normalized, "model", modelID, "provider", providerName)
 	}
 	*lastReason = normalized
 }
@@ -126,7 +127,9 @@ func normalizeFinishReasonInChoices(choices []map[string]json.RawMessage, lastRe
 // Usage struct. It checks three provider-specific fields in precedence order:
 // PromptCacheHitTokens (OpenAI), CacheReadInputTokens (Anthropic-native),
 // and PromptTokensDetails.CachedTokens (OpenAI nested format).
-// Replaces 2 identical if-else chains in streaming and non-streaming paths.
+// Returns (0, 0) when no cache fields are present; callers should only
+// assign the results when at least one value is non-zero to preserve any
+// previously accumulated cache counts from earlier usage chunks.
 func extractCacheTokens(u Usage) (hitTokens, missTokens int) {
 	if u.PromptCacheHitTokens > 0 {
 		return u.PromptCacheHitTokens, max(0, u.PromptTokens-u.PromptCacheHitTokens)

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -522,7 +522,7 @@ func (h *Handler) handleStreamingResponse(w http.ResponseWriter, r *http.Request
 				// re-serializing, so non-standard values
 				// (e.g., "end_turn", "STOP") are mapped to
 				// OpenAI equivalents.
-				normalizeFinishReasonInChoices(p.choices, &lastFinishReason)
+				normalizeFinishReasonInChoices(p.choices, &lastFinishReason, logData.modelID, logData.providerName)
 				newChoices, _ := json.Marshal(p.choices)
 				p.raw["choices"] = json.RawMessage(newChoices)
 				newPayload, _ := json.Marshal(p.raw)
@@ -596,7 +596,7 @@ func (h *Handler) handleStreamingResponse(w http.ResponseWriter, r *http.Request
 						// re-serializing. The written=true below
 						// would skip the finish_reason normalization
 						// block later in this loop iteration.
-						normalizeFinishReasonInChoices(chunkParsed.choices, &lastFinishReason)
+						normalizeFinishReasonInChoices(chunkParsed.choices, &lastFinishReason, logData.modelID, logData.providerName)
 						newChoices, _ := json.Marshal(chunkParsed.choices)
 						chunkParsed.raw["choices"] = json.RawMessage(newChoices)
 						newPayload, _ := json.Marshal(chunkParsed.raw)
@@ -630,7 +630,7 @@ func (h *Handler) handleStreamingResponse(w http.ResponseWriter, r *http.Request
 						// re-serializing. The written=true below
 						// would skip the finish_reason normalization
 						// block later in this loop iteration.
-						normalizeFinishReasonInChoices(p.choices, &lastFinishReason)
+						normalizeFinishReasonInChoices(p.choices, &lastFinishReason, logData.modelID, logData.providerName)
 						newChoices, _ := json.Marshal(p.choices)
 						p.raw["choices"] = json.RawMessage(newChoices)
 						newPayload, _ := json.Marshal(p.raw)
@@ -655,7 +655,10 @@ func (h *Handler) handleStreamingResponse(w http.ResponseWriter, r *http.Request
 				if chunk.Usage.CompletionTokensDetails != nil && chunk.Usage.CompletionTokensDetails.ReasoningTokens > 0 {
 					reasoningTokens = chunk.Usage.CompletionTokensDetails.ReasoningTokens
 				}
-				promptCacheHitTokens, promptCacheMissTokens = extractCacheTokens(*chunk.Usage)
+				if hit, miss := extractCacheTokens(*chunk.Usage); hit > 0 || miss > 0 {
+					promptCacheHitTokens = hit
+					promptCacheMissTokens = miss
+				}
 			}
 			// P2-7: Log native_finish_reason from OpenRouter for debugging.
 			// OpenRouter includes this field alongside the normalized finish_reason,

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/hugalafutro/model-hotel/internal/ctxkeys"
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
-	"github.com/hugalafutro/model-hotel/internal/events"
 	"github.com/hugalafutro/model-hotel/internal/provider"
 	"github.com/hugalafutro/model-hotel/internal/util"
 )
@@ -522,43 +521,14 @@ func (h *Handler) handleStreamingResponse(w http.ResponseWriter, r *http.Request
 				// Normalize finish_reason in-place before
 				// re-serializing, so non-standard values
 				// (e.g., "end_turn", "STOP") are mapped to
-				// OpenAI equivalents. Without this, the
-				// continue below would skip the normalization
-				// block at line ~809.
-				if frRaw, okFR := p.choices[0]["finish_reason"]; okFR {
-					var frStr string
-					if json.Unmarshal(frRaw, &frStr) == nil && frStr != "" {
-						if normalized := normalizeFinishReason(frStr); normalized != frStr {
-							p.choices[0]["finish_reason"] = json.RawMessage(`"` + normalized + `"`)
-							lastFinishReason = normalized
-							debuglog.Debug("proxy: normalized finish_reason in strip_reasoning path", "original", frStr, "normalized", normalized, "model", logData.modelID, "provider", logData.providerName)
-						} else {
-							lastFinishReason = frStr
-						}
-					}
-				}
+				// OpenAI equivalents.
+				normalizeFinishReasonInChoices(p.choices, &lastFinishReason)
 				newChoices, _ := json.Marshal(p.choices)
 				p.raw["choices"] = json.RawMessage(newChoices)
 				newPayload, _ := json.Marshal(p.raw)
-				n, err := w.Write([]byte("data: "))
-				bytesWritten += int64(n)
-				if err != nil {
+				if err := writeSSEDataChunk(w, newPayload, &bytesWritten); err != nil {
 					clientDisconnected = true
 					debuglog.Warn("proxy: client write failed during reasoning strip", "error", err, "model", logData.modelID, "provider", logData.providerName, "chunks", chunkCount)
-					goto logUpdate
-				}
-				n, err = w.Write(newPayload)
-				bytesWritten += int64(n)
-				if err != nil {
-					clientDisconnected = true
-					debuglog.Warn("proxy: client write failed during reasoning strip", "error", err, "model", logData.modelID, "provider", logData.providerName, "chunks", chunkCount)
-					goto logUpdate
-				}
-				n, err = w.Write([]byte("\n\n"))
-				bytesWritten += int64(n)
-				if err != nil {
-					clientDisconnected = true
-					debuglog.Warn("proxy: client write failed during reasoning strip (newline)", "error", err, "model", logData.modelID, "provider", logData.providerName, "chunks", chunkCount)
 					goto logUpdate
 				}
 				if canFlush {
@@ -626,39 +596,13 @@ func (h *Handler) handleStreamingResponse(w http.ResponseWriter, r *http.Request
 						// re-serializing. The written=true below
 						// would skip the finish_reason normalization
 						// block later in this loop iteration.
-						if frRaw, okFR := chunkParsed.choices[0]["finish_reason"]; okFR {
-							var frStr string
-							if json.Unmarshal(frRaw, &frStr) == nil && frStr != "" {
-								if normalized := normalizeFinishReason(frStr); normalized != frStr {
-									chunkParsed.choices[0]["finish_reason"] = json.RawMessage(`"` + normalized + `"`)
-									lastFinishReason = normalized
-								} else {
-									lastFinishReason = frStr
-								}
-							}
-						}
+						normalizeFinishReasonInChoices(chunkParsed.choices, &lastFinishReason)
 						newChoices, _ := json.Marshal(chunkParsed.choices)
 						chunkParsed.raw["choices"] = json.RawMessage(newChoices)
 						newPayload, _ := json.Marshal(chunkParsed.raw)
-						n, err := w.Write([]byte("data: "))
-						bytesWritten += int64(n)
-						if err != nil {
+						if err := writeSSEDataChunk(w, newPayload, &bytesWritten); err != nil {
 							clientDisconnected = true
 							debuglog.Warn("proxy: client write failed during reasoning normalization", "error", err, "model", logData.modelID, "provider", logData.providerName, "chunks", chunkCount)
-							goto logUpdate
-						}
-						n, err = w.Write(newPayload)
-						bytesWritten += int64(n)
-						if err != nil {
-							clientDisconnected = true
-							debuglog.Warn("proxy: client write failed during reasoning normalization", "error", err, "model", logData.modelID, "provider", logData.providerName, "chunks", chunkCount)
-							goto logUpdate
-						}
-						n, err = w.Write([]byte("\n\n"))
-						bytesWritten += int64(n)
-						if err != nil {
-							clientDisconnected = true
-							debuglog.Warn("proxy: client write failed during reasoning normalization (newline)", "error", err, "model", logData.modelID, "provider", logData.providerName, "chunks", chunkCount)
 							goto logUpdate
 						}
 						if canFlush {
@@ -686,39 +630,13 @@ func (h *Handler) handleStreamingResponse(w http.ResponseWriter, r *http.Request
 						// re-serializing. The written=true below
 						// would skip the finish_reason normalization
 						// block later in this loop iteration.
-						if frRaw, okFR := p.choices[0]["finish_reason"]; okFR {
-							var frStr string
-							if json.Unmarshal(frRaw, &frStr) == nil && frStr != "" {
-								if normalized := normalizeFinishReason(frStr); normalized != frStr {
-									p.choices[0]["finish_reason"] = json.RawMessage(`"` + normalized + `"`)
-									lastFinishReason = normalized
-								} else {
-									lastFinishReason = frStr
-								}
-							}
-						}
+						normalizeFinishReasonInChoices(p.choices, &lastFinishReason)
 						newChoices, _ := json.Marshal(p.choices)
 						p.raw["choices"] = json.RawMessage(newChoices)
 						newPayload, _ := json.Marshal(p.raw)
-						n, err := w.Write([]byte("data: "))
-						bytesWritten += int64(n)
-						if err != nil {
+						if err := writeSSEDataChunk(w, newPayload, &bytesWritten); err != nil {
 							clientDisconnected = true
 							debuglog.Warn("proxy: client write failed during empty content strip", "error", err, "model", logData.modelID, "provider", logData.providerName, "chunks", chunkCount)
-							goto logUpdate
-						}
-						n, err = w.Write(newPayload)
-						bytesWritten += int64(n)
-						if err != nil {
-							clientDisconnected = true
-							debuglog.Warn("proxy: client write failed during empty content strip", "error", err, "model", logData.modelID, "provider", logData.providerName, "chunks", chunkCount)
-							goto logUpdate
-						}
-						n, err = w.Write([]byte("\n\n"))
-						bytesWritten += int64(n)
-						if err != nil {
-							clientDisconnected = true
-							debuglog.Warn("proxy: client write failed during empty content strip (newline)", "error", err, "model", logData.modelID, "provider", logData.providerName, "chunks", chunkCount)
 							goto logUpdate
 						}
 						if canFlush {
@@ -737,22 +655,7 @@ func (h *Handler) handleStreamingResponse(w http.ResponseWriter, r *http.Request
 				if chunk.Usage.CompletionTokensDetails != nil && chunk.Usage.CompletionTokensDetails.ReasoningTokens > 0 {
 					reasoningTokens = chunk.Usage.CompletionTokensDetails.ReasoningTokens
 				}
-				//nolint:gocritic // if-else chain is clearer than switch for multi-field precedence check
-				if chunk.Usage.PromptCacheHitTokens > 0 {
-					promptCacheHitTokens = chunk.Usage.PromptCacheHitTokens
-					promptCacheMissTokens = max(0, chunk.Usage.PromptTokens-chunk.Usage.PromptCacheHitTokens)
-				} else if chunk.Usage.CacheReadInputTokens > 0 {
-					// Anthropic-native cache fields: cache_read_input_tokens maps to
-					// cache hit, remainder is cache miss (includes cache_creation tokens).
-					promptCacheHitTokens = chunk.Usage.CacheReadInputTokens
-					promptCacheMissTokens = max(0, chunk.Usage.PromptTokens-chunk.Usage.CacheReadInputTokens)
-				} else if chunk.Usage.PromptTokensDetails != nil && chunk.Usage.PromptTokensDetails.CachedTokens > 0 {
-					// OpenAI's official format: cached_tokens inside prompt_tokens_details.
-					// Many third-party proxies (Wafer AI, OpenRouter, NanoGPT) normalise
-					// to this structure instead of using top-level prompt_cache_hit_tokens.
-					promptCacheHitTokens = chunk.Usage.PromptTokensDetails.CachedTokens
-					promptCacheMissTokens = max(0, chunk.Usage.PromptTokens-chunk.Usage.PromptTokensDetails.CachedTokens)
-				}
+				promptCacheHitTokens, promptCacheMissTokens = extractCacheTokens(*chunk.Usage)
 			}
 			// P2-7: Log native_finish_reason from OpenRouter for debugging.
 			// OpenRouter includes this field alongside the normalized finish_reason,
@@ -863,25 +766,9 @@ func (h *Handler) handleStreamingResponse(w http.ResponseWriter, r *http.Request
 								if newChoices, err2 := json.Marshal(choices); err2 == nil {
 									raw["choices"] = json.RawMessage(newChoices)
 									if newPayload, err3 := json.Marshal(raw); err3 == nil {
-										n, err := w.Write([]byte("data: "))
-										bytesWritten += int64(n)
-										if err != nil {
+										if err := writeSSEDataChunk(w, newPayload, &bytesWritten); err != nil {
 											clientDisconnected = true
 											debuglog.Warn("proxy: client write failed during stream", "error", err, "model", logData.modelID, "provider", logData.providerName, "chunks", chunkCount)
-											goto logUpdate
-										}
-										n, err = w.Write(newPayload)
-										bytesWritten += int64(n)
-										if err != nil {
-											clientDisconnected = true
-											debuglog.Warn("proxy: client write failed during stream", "error", err, "model", logData.modelID, "provider", logData.providerName, "chunks", chunkCount)
-											goto logUpdate
-										}
-										n, err = w.Write([]byte("\n\n"))
-										bytesWritten += int64(n)
-										if err != nil {
-											clientDisconnected = true
-											debuglog.Warn("proxy: client write failed during stream (newline)", "error", err, "model", logData.modelID, "provider", logData.providerName, "chunks", chunkCount, "bytes_written", bytesWritten)
 											goto logUpdate
 										}
 										if canFlush {
@@ -1079,22 +966,7 @@ logUpdate:
 	}
 
 	if opts.vkHash != "" && !clientDisconnected {
-		totalTokens := promptTokens + completionTokens + reasoningTokens
-		tokCtx, tokCancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer tokCancel()
-		if err := h.virtualKeyRepo.AddTokens(tokCtx, opts.vkHash, totalTokens); err != nil {
-			keyLabel := opts.vkHash
-			if logData.virtualKeyName != "" {
-				keyLabel = logData.virtualKeyName
-			}
-			events.Publish(events.Event{
-				Type:     "tokens.error",
-				Severity: "error",
-				Source:   "proxy",
-				Message:  fmt.Sprintf("Token counting failed for key %q", keyLabel),
-				Metadata: map[string]interface{}{"error": err.Error(), "key": keyLabel},
-			})
-		}
+		h.recordTokenUsage(opts.vkHash, promptTokens, completionTokens, reasoningTokens, logData.virtualKeyName)
 	}
 }
 
@@ -1142,43 +1014,13 @@ func (h *Handler) handleNonStreamingResponse(w http.ResponseWriter, r *http.Requ
 		logData.tokensPrompt = chatResp.Usage.PromptTokens
 		logData.tokensCompletion = chatResp.Usage.CompletionTokens
 		logData.tokensCompletionReasoning = reasoningTokens
-		//nolint:gocritic // if-else chain is clearer than switch for multi-field precedence check
-		if chatResp.Usage.PromptCacheHitTokens > 0 {
-			logData.tokensPromptCacheHit = chatResp.Usage.PromptCacheHitTokens
-			logData.tokensPromptCacheMiss = max(0, chatResp.Usage.PromptTokens-chatResp.Usage.PromptCacheHitTokens)
-		} else if chatResp.Usage.CacheReadInputTokens > 0 {
-			// Anthropic-native cache fields: cache_read_input_tokens maps to
-			// cache hit, remainder is cache miss (includes cache_creation tokens).
-			logData.tokensPromptCacheHit = chatResp.Usage.CacheReadInputTokens
-			logData.tokensPromptCacheMiss = max(0, chatResp.Usage.PromptTokens-chatResp.Usage.CacheReadInputTokens)
-		} else if chatResp.Usage.PromptTokensDetails != nil && chatResp.Usage.PromptTokensDetails.CachedTokens > 0 {
-			// OpenAI's official format: cached_tokens inside prompt_tokens_details.
-			// Many third-party proxies (Wafer AI, OpenRouter, NanoGPT) normalise
-			// to this structure instead of using top-level prompt_cache_hit_tokens.
-			logData.tokensPromptCacheHit = chatResp.Usage.PromptTokensDetails.CachedTokens
-			logData.tokensPromptCacheMiss = max(0, chatResp.Usage.PromptTokens-chatResp.Usage.PromptTokensDetails.CachedTokens)
-		}
+		logData.tokensPromptCacheHit, logData.tokensPromptCacheMiss = extractCacheTokens(chatResp.Usage)
 		logData.failoverAttempt = attempt
 		logData.state = "completed"
 		h.updateRequestLog(logData)
 
 		if vkHash != "" {
-			totalTokens := chatResp.Usage.PromptTokens + chatResp.Usage.CompletionTokens + reasoningTokens
-			tokCtx, tokCancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer tokCancel()
-			if err := h.virtualKeyRepo.AddTokens(tokCtx, vkHash, totalTokens); err != nil {
-				keyLabel := vkHash
-				if logData.virtualKeyName != "" {
-					keyLabel = logData.virtualKeyName
-				}
-				events.Publish(events.Event{
-					Type:     "tokens.error",
-					Severity: "error",
-					Source:   "proxy",
-					Message:  fmt.Sprintf("Token counting failed for key %q", keyLabel),
-					Metadata: map[string]interface{}{"error": err.Error(), "key": keyLabel},
-				})
-			}
+			h.recordTokenUsage(vkHash, chatResp.Usage.PromptTokens, chatResp.Usage.CompletionTokens, reasoningTokens, logData.virtualKeyName)
 		}
 
 		// Normalize reasoning fields in the response message so that


### PR DESCRIPTION
## Summary

Extracts 4 helper functions from duplicated inline patterns in `proxy.go` into `helpers.go`, reducing the file from 2137 to 1982 lines (-155, -7.3%) with no behavioral changes.

### Helpers extracted

| Helper | Sites replaced | Pattern |
|--------|---------------|---------|
| `normalizeFinishReasonInChoices` | 3 | Finish-reason JSON normalization with debug logging |
| `extractCacheTokens` | 2 | Cache token precedence if-else chain |
| `recordTokenUsage` | 2 | AddTokens + events.Publish error handling |
| `writeSSEDataChunk` | 4 | SSE `data: payload\n\n` write + error-check |

### Notable side effect

`recordTokenUsage` now cancels its 5-second timeout context promptly when the function returns, rather than holding it until the outer handler function exits. This is a minor improvement in resource cleanup.

### What was NOT extracted

Remaining clone patterns (context-key extraction, logData population across failover attempts) were assessed as too entangled with control flow or too small (2-3 lines with different vars) to extract without hurting readability.

### Verification

- All proxy tests pass
- Full `go test ./...` passes
- `golangci-lint` clean
- `go vet` clean
- Pre-commit hooks pass