### PR TITLE
fix: pre-commit hook covers CSS files, remove Docker fallback

### DIFF
--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -67,7 +67,8 @@ if [ -n "$staged_ts" ]; then
 			exit 1
 		fi
 	else
-		echo "pre-commit: SKIP biome (no web/node_modules - run 'cd web && pnpm install')" >&2
+		echo "pre-commit: FAILED - no web/node_modules (run 'cd web && pnpm install')" >&2
+		exit 1
 	fi
 	# Re-stage any files biome rewrote.
 	changed=""

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -34,7 +34,7 @@ fi
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
 staged_go=$(git diff --cached --name-only --diff-filter=ACM -- '*.go' || true)
-staged_ts=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^web/.*\.tsx?$' || true)
+staged_ts=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^web/.*\.(tsx?|css)$' || true)
 
 # ── Go: gci import order + go vet on staged packages ──
 if [ -n "$staged_go" ]; then
@@ -53,7 +53,7 @@ if [ -n "$staged_go" ]; then
 	fi
 fi
 
-# ── Frontend: biome --write on staged TS/TSX ──
+# ── Frontend: biome --write on staged TS/TSX/CSS ──
 if [ -n "$staged_ts" ]; then
 	rel_paths=()
 	for f in $staged_ts; do
@@ -67,15 +67,7 @@ if [ -n "$staged_ts" ]; then
 			exit 1
 		fi
 	else
-		echo "pre-commit: biome --write ${rel_paths[*]} (Docker)"
-		if ! docker run --rm \
-			-v "$REPO_ROOT/web":/app \
-			-w /app \
-			node:22-alpine \
-			sh -c "npm install -g @biomejs/biome@2.4.16 >/dev/null 2>&1 && biome check --write \"\$@\"" -- "${rel_paths[@]}" >/dev/null 2>&1; then
-			echo "pre-commit: FAILED - biome check" >&2
-			exit 1
-		fi
+		echo "pre-commit: SKIP biome (no web/node_modules - run 'cd web && pnpm install')" >&2
 	fi
 	# Re-stage any files biome rewrote.
 	changed=""

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -2,8 +2,7 @@
 # Pre-commit: fast formatting only. Real checks run in CI.
 # Goal: under 10 seconds, never blocks for slow tests.
 #
-# Frontend checks (biome) use local pnpm when web/node_modules exists,
-# otherwise fall back to Docker.
+# Frontend checks (biome) use local pnpm when web/node_modules exists.
 
 set -euo pipefail
 
@@ -34,7 +33,7 @@ fi
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
 staged_go=$(git diff --cached --name-only --diff-filter=ACM -- '*.go' || true)
-staged_ts=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^web/.*\.(tsx?|css)$' || true)
+staged_fe=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^web/.*\.(tsx?|css)$' || true)
 
 # ── Go: gci import order + go vet on staged packages ──
 if [ -n "$staged_go" ]; then
@@ -54,9 +53,9 @@ if [ -n "$staged_go" ]; then
 fi
 
 # ── Frontend: biome --write on staged TS/TSX/CSS ──
-if [ -n "$staged_ts" ]; then
+if [ -n "$staged_fe" ]; then
 	rel_paths=()
-	for f in $staged_ts; do
+	for f in $staged_fe; do
 		rel_paths+=("${f#web/}")
 	done
 
@@ -72,7 +71,7 @@ if [ -n "$staged_ts" ]; then
 	fi
 	# Re-stage any files biome rewrote.
 	changed=""
-	for f in $staged_ts; do
+	for f in $staged_fe; do
 		if ! git diff --quiet -- "$f"; then
 			changed="$changed $f"
 		fi

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1108,12 +1108,7 @@ html[data-ui-style="clean-saas"] .ui-card {
 	transition: box-shadow 0.2s ease;
 }
 
-html[data-ui-style="clean-saas"]
-	.ui-card
-	> .ui-table
-	tbody
-	tr:last-child
-	td {
+html[data-ui-style="clean-saas"] .ui-card > .ui-table tbody tr:last-child td {
 	border-bottom: none;
 }
 


### PR DESCRIPTION
- Add `.css` to staged file regex so biome formats CSS on commit (previously only covered `.ts`/`.tsx`)
- Remove Docker fallback that mounted `web/` as volume, which created root-owned files that broke the host biome binary
- Skip biome with clear hint (`run 'cd web && pnpm install'`) if `node_modules` missing instead of silently falling back to Docker
- Apply biome formatting to `index.css` (collapsed multi-line CSS selector)