### PR TITLE
fix: resolve all open code scanning alerts

### DIFF
--- a/internal/api/logs.go
+++ b/internal/api/logs.go
@@ -343,7 +343,11 @@ func (h *Handler) ListLogsCursor(w http.ResponseWriter, r *http.Request) {
 	}
 	defer rows.Close()
 
-	entries := make([]LogEntry, 0, limit)
+	preallocLimit := limit
+	if preallocLimit > 200 {
+		preallocLimit = 200
+	}
+	entries := make([]LogEntry, 0, preallocLimit)
 	for rows.Next() {
 		var entry LogEntry
 		err := rows.Scan(

--- a/internal/api/logs.go
+++ b/internal/api/logs.go
@@ -343,11 +343,10 @@ func (h *Handler) ListLogsCursor(w http.ResponseWriter, r *http.Request) {
 	}
 	defer rows.Close()
 
-	preallocLimit := limit
-	if preallocLimit > 200 {
-		preallocLimit = 200
-	}
-	entries := make([]LogEntry, 0, preallocLimit)
+	// limit is clamped to [1, 200] above; prealloc with the hard upper bound
+	// to satisfy CodeQL's uncontrolled-allocation-size check (user input must
+	// not flow into make() capacity even after clamping).
+	entries := make([]LogEntry, 0, 201) // limit+1 for has_more detection
 	for rows.Next() {
 		var entry LogEntry
 		err := rows.Scan(

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -89,18 +89,16 @@ func Load() (*Config, error) {
 		AllowHTTPProviders:   getBoolEnvWithDefault("ALLOW_HTTP_PROVIDERS", false),
 		RateLimitEnabled:     getBoolEnvWithDefault("RATE_LIMIT_ENABLED", true),
 		RateLimitIPRPS:       clampFloat(getFloatEnvWithDefault("RATE_LIMIT_IP_RPS", 30), 0, 10000),
-		RateLimitIPBurst:     int(clampInt64(getIntEnvWithDefault("RATE_LIMIT_IP_BURST", 60), 1, 10000)),
+		RateLimitIPBurst:     clampInt(getIntEnvAsInt("RATE_LIMIT_IP_BURST", 60), 1, 10000),
 		MaxRequestSize:       clampInt64(getIntEnvWithDefault("MAX_REQUEST_SIZE", 10*1024*1024), 1024, 100*1024*1024), // 1KB–100MB
 		CORSOrigins:          parseCORSOrigins(getEnvWithDefault("CORS_ORIGINS", "http://localhost:5173,http://localhost:8081")),
 		AllowedProviderHosts: parseProviderHosts(getEnvWithDefault("ALLOWED_PROVIDER_HOSTS", "")),
-		//nolint:gosec // port value validated to be within uint16 range
-		DBMaxConns: int32(clampInt64(getIntEnvWithDefault("DATABASE_MAX_CONNS", 25), 1, 1000)),
-		//nolint:gosec // port value validated to be within uint16 range
-		DBMinConns:       int32(clampInt64(getIntEnvWithDefault("DATABASE_MIN_CONNS", 5), 1, 1000)),
-		ModelsDevEnabled: getBoolEnvWithDefault("MODELSDEV_ENABLED", true),
-		DebugLog:         getBoolEnvWithDefault("DEBUG_LOG", false),
-		TrustedProxies:   LoadTrustedProxies(),
-		KnownProxies:     LoadKnownProxies(),
+		DBMaxConns:           clampInt32(getIntEnvAsInt32("DATABASE_MAX_CONNS", 25), 1, 1000),
+		DBMinConns:           clampInt32(getIntEnvAsInt32("DATABASE_MIN_CONNS", 5), 1, 1000),
+		ModelsDevEnabled:     getBoolEnvWithDefault("MODELSDEV_ENABLED", true),
+		DebugLog:             getBoolEnvWithDefault("DEBUG_LOG", false),
+		TrustedProxies:       LoadTrustedProxies(),
+		KnownProxies:         LoadKnownProxies(),
 
 		WebAuthnRPID:          getEnv("WEBAUTHN_RP_ID"),
 		WebAuthnRPDisplayName: getEnvWithDefault("WEBAUTHN_RP_DISPLAY_NAME", "Model Hotel"),
@@ -399,4 +397,48 @@ func clampFloat(value, minVal, maxVal float64) float64 {
 		return maxVal
 	}
 	return value
+}
+
+func clampInt(value, minVal, maxVal int) int {
+	if value < minVal {
+		return minVal
+	}
+	if value > maxVal {
+		return maxVal
+	}
+	return value
+}
+
+func clampInt32(value, minVal, maxVal int32) int32 {
+	if value < minVal {
+		return minVal
+	}
+	if value > maxVal {
+		return maxVal
+	}
+	return value
+}
+
+func getIntEnvAsInt(key string, defaultValue int) int {
+	value := os.Getenv(key)
+	if value == "" {
+		return defaultValue
+	}
+	result, err := strconv.Atoi(value)
+	if err != nil {
+		return defaultValue
+	}
+	return result
+}
+
+func getIntEnvAsInt32(key string, defaultValue int32) int32 {
+	value := os.Getenv(key)
+	if value == "" {
+		return defaultValue
+	}
+	result, err := strconv.ParseInt(value, 10, 32)
+	if err != nil {
+		return defaultValue
+	}
+	return int32(result)
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -499,8 +499,19 @@ func (h *Handler) handleStreamingResponse(w http.ResponseWriter, r *http.Request
 							keepAliveID = idStr
 						}
 					}
-					escapedID, _ := json.Marshal(keepAliveID)
-					keepAlive := []byte("data: {\"id\":" + string(escapedID) + ",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{}}]}\n\n")
+					keepAlivePayload := map[string]interface{}{
+						"id":     keepAliveID,
+						"object": "chat.completion.chunk",
+						"choices": []map[string]interface{}{
+							{"index": 0, "delta": map[string]interface{}{}},
+						},
+					}
+					keepAliveJSON, err := json.Marshal(keepAlivePayload)
+					if err != nil {
+						continue
+					}
+					keepAlive := append([]byte("data: "), keepAliveJSON...)
+					keepAlive = append(keepAlive, "\n\n"...)
 					n, err := w.Write(keepAlive)
 					bytesWritten += int64(n)
 					if err != nil {

--- a/internal/proxy/response_test.go
+++ b/internal/proxy/response_test.go
@@ -3595,10 +3595,8 @@ func TestHandleStreamingResponse_StripReasoning_JSONKeepAlive(t *testing.T) {
 
 	// Verify valid JSON keep-alive chunks ARE sent for stripped reasoning.
 	// The keep-alive reuses the stream's real completion ID.
-	// json.Marshal produces alphabetical keys, so check for each field separately.
-	assert.Contains(t, body, `"id":"c1"`)
-	assert.Contains(t, body, `"object":"chat.completion.chunk"`)
-	assert.Contains(t, body, `"choices":[{"delta":{},"index":0}]`)
+	// json.Marshal produces deterministic alphabetical keys.
+	assert.Contains(t, body, `data: {"choices":[{"delta":{},"index":0}],"id":"c1","object":"chat.completion.chunk"}`)
 
 	// Verify reasoning_content is NOT in output
 	assert.NotContains(t, body, "reasoning_content")

--- a/internal/proxy/response_test.go
+++ b/internal/proxy/response_test.go
@@ -3595,7 +3595,10 @@ func TestHandleStreamingResponse_StripReasoning_JSONKeepAlive(t *testing.T) {
 
 	// Verify valid JSON keep-alive chunks ARE sent for stripped reasoning.
 	// The keep-alive reuses the stream's real completion ID.
-	assert.Contains(t, body, `"id":"c1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{}}]`)
+	// json.Marshal produces alphabetical keys, so check for each field separately.
+	assert.Contains(t, body, `"id":"c1"`)
+	assert.Contains(t, body, `"object":"chat.completion.chunk"`)
+	assert.Contains(t, body, `"choices":[{"delta":{},"index":0}]`)
 
 	// Verify reasoning_content is NOT in output
 	assert.NotContains(t, body, "reasoning_content")

--- a/web/src/hooks/__tests__/useQuotaData.test.tsx
+++ b/web/src/hooks/__tests__/useQuotaData.test.tsx
@@ -29,6 +29,7 @@ const mockProviders: Provider[] = [
 		base_url: "https://api.nano-gpt.com/v1",
 		masked_key: "ngpt_***",
 		enabled: true,
+		autodiscovery_enabled: true,
 		last_discovered_at: null,
 		last_used_at: null,
 		created_at: "2024-01-01T00:00:00Z",
@@ -42,6 +43,7 @@ const mockProviders: Provider[] = [
 		base_url: "https://z.ai/api/v1",
 		masked_key: "zai_***",
 		enabled: true,
+		autodiscovery_enabled: true,
 		last_discovered_at: null,
 		last_used_at: null,
 		created_at: "2024-01-01T00:00:00Z",
@@ -55,6 +57,7 @@ const mockProviders: Provider[] = [
 		base_url: "https://api.deepseek.com/v1",
 		masked_key: "ds_***",
 		enabled: true,
+		autodiscovery_enabled: true,
 		last_discovered_at: null,
 		last_used_at: null,
 		created_at: "2024-01-01T00:00:00Z",
@@ -68,6 +71,7 @@ const mockProviders: Provider[] = [
 		base_url: "https://openrouter.ai/api/v1",
 		masked_key: "or_***",
 		enabled: true,
+		autodiscovery_enabled: true,
 		last_discovered_at: null,
 		last_used_at: null,
 		created_at: "2024-01-01T00:00:00Z",
@@ -81,6 +85,7 @@ const mockProviders: Provider[] = [
 		base_url: "https://ollama.com/api/v1",
 		masked_key: "ollama_***",
 		enabled: true,
+		autodiscovery_enabled: true,
 		last_discovered_at: null,
 		last_used_at: null,
 		created_at: "2024-01-01T00:00:00Z",
@@ -398,9 +403,13 @@ describe("useQuotaData", () => {
 	});
 
 	it("hides badges when provider is missing", async () => {
-		const providersWithoutNano = mockProviders.filter(
-			(p) => !p.base_url.includes("nano-gpt.com"),
-		);
+		const providersWithoutNano = mockProviders.filter((p) => {
+			try {
+				return new URL(p.base_url).hostname !== "nano-gpt.com";
+			} catch {
+				return true;
+			}
+		});
 
 		const { result } = renderHook(() => useQuotaData(providersWithoutNano), {
 			wrapper: createWrapper(),

--- a/web/src/hooks/__tests__/useQuotaData.test.tsx
+++ b/web/src/hooks/__tests__/useQuotaData.test.tsx
@@ -406,7 +406,7 @@ describe("useQuotaData", () => {
 		const providersWithoutNano = mockProviders.filter((p) => {
 			try {
 				const host = new URL(p.base_url).hostname;
-				return !host.endsWith("nano-gpt.com");
+				return host !== "api.nano-gpt.com";
 			} catch {
 				return true;
 			}

--- a/web/src/hooks/__tests__/useQuotaData.test.tsx
+++ b/web/src/hooks/__tests__/useQuotaData.test.tsx
@@ -405,7 +405,8 @@ describe("useQuotaData", () => {
 	it("hides badges when provider is missing", async () => {
 		const providersWithoutNano = mockProviders.filter((p) => {
 			try {
-				return new URL(p.base_url).hostname !== "nano-gpt.com";
+				const host = new URL(p.base_url).hostname;
+				return !host.endsWith("nano-gpt.com");
 			} catch {
 				return true;
 			}


### PR DESCRIPTION
## Code Scanning Alert Fixes

Resolves all 4 open code scanning alert locations (6 alerts total, 1 already fixed).

### Changes

| Alert | Severity | File | Fix |
|-------|----------|------|-----|
| [#7](https://github.com/hugalafutro/model-hotel/security/code-scanning/7) | **critical** | `internal/proxy/proxy.go` | Replace string concatenation with `json.Marshal` for keep-alive SSE payload (unsafe quoting) |
| [#6](https://github.com/hugalafutro/model-hotel/security/code-scanning/6) | high | `internal/api/logs.go` | Add defensive prealloc cap before `make([]LogEntry, 0, limit)` (uncontrolled allocation size) |
| [#4](https://github.com/hugalafutro/model-hotel/security/code-scanning/4) | high | `web/src/hooks/__tests__/useQuotaData.test.tsx` | Replace `.includes()` URL substring check with `new URL().hostname` comparison (incomplete URL sanitization) |
| [#1](https://github.com/hugalafutro/model-hotel/security/code-scanning/1), [#2](https://github.com/hugalafutro/model-hotel/security/code-scanning/2), [#3](https://github.com/hugalafutro/model-hotel/security/code-scanning/3) | high | `internal/config/config.go` | Add typed `clampInt`/`clampInt32`/`getIntEnvAsInt`/`getIntEnvAsInt32` helpers to eliminate int64-to-int/int32 narrowing conversions |

### Bonus fixes
- Add missing `autodiscovery_enabled` to all 5 mock Provider objects in `useQuotaData.test.tsx`
- Update proxy test assertion to match `json.Marshal` alphabetical key ordering