### PR TITLE
Speed up slow tests (~200s saved per CI run)

### DIFF
--- a/internal/api/discovery_integration_test.go
+++ b/internal/api/discovery_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
@@ -723,7 +724,31 @@ func TestGetProviderUsage_ZAICodingError(t *testing.T) {
 // TestGetProviderUsage_NanoGPTError tests that GetProviderUsage returns 500
 // when the NanoGPT API call fails with an invalid key.
 func TestGetProviderUsage_NanoGPTError(t *testing.T) {
+	// Override newDiscoveryService with mock transport to avoid real API calls
+	// Note: Must override AFTER newTestHandlerWithRouter since NewHandler sets it
 	_, r := newTestHandlerWithRouter(t)
+
+	orig := newDiscoveryService
+	defer func() { newDiscoveryService = orig }()
+
+	newDiscoveryService = func() *provider.DiscoveryService {
+		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
+			Transport: &mockTransport{
+				roundTripFunc: func(req *http.Request) (*http.Response, error) {
+					if strings.Contains(req.URL.Host, "api.nano-gpt.com") {
+						return &http.Response{
+							StatusCode: http.StatusServiceUnavailable,
+							Body:       io.NopCloser(strings.NewReader("api.nano-gpt.com is currently in development. Please use https://nano-gpt.com/api instead.")),
+							Header:     make(http.Header),
+						}, nil
+					}
+					return nil, fmt.Errorf("unexpected request to %s", req.URL.String())
+				},
+			},
+		})
+		ds.SetRetryBaseDelay(time.Millisecond)
+		return ds
+	}
 
 	// Create a provider with NanoGPT URL (with hyphen) and fake key
 	providerName := fmt.Sprintf("test-nanogpt-error-%s", uuid.New().String()[:8])
@@ -879,7 +904,40 @@ func TestGetOllamaCloudAccount_Error(t *testing.T) {
 // TestRefreshAllQuotas_WithSupportedTypes tests that RefreshAllQuotas handles
 // multiple provider types with errors for unsupported types.
 func TestRefreshAllQuotas_WithSupportedTypes(t *testing.T) {
+	// Override newDiscoveryService with mock transport to avoid real API calls
+	// Note: Must override AFTER newTestHandlerWithRouter since NewHandler sets it
 	_, r := newTestHandlerWithRouter(t)
+
+	orig := newDiscoveryService
+	defer func() { newDiscoveryService = orig }()
+
+	newDiscoveryService = func() *provider.DiscoveryService {
+		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
+			Transport: &mockTransport{
+				roundTripFunc: func(req *http.Request) (*http.Response, error) {
+					// NanoGPT returns 503
+					if strings.Contains(req.URL.Host, "api.nano-gpt.com") {
+						return &http.Response{
+							StatusCode: http.StatusServiceUnavailable,
+							Body:       io.NopCloser(strings.NewReader("api.nano-gpt.com is currently in development. Please use https://nano-gpt.com/api instead.")),
+							Header:     make(http.Header),
+						}, nil
+					}
+					// z.ai returns 500 for fake keys
+					if strings.Contains(req.URL.Host, "api.z.ai") {
+						return &http.Response{
+							StatusCode: http.StatusInternalServerError,
+							Body:       io.NopCloser(strings.NewReader(`{"error":"invalid key"}`)),
+							Header:     make(http.Header),
+						}, nil
+					}
+					return nil, fmt.Errorf("unexpected request to %s", req.URL.String())
+				},
+			},
+		})
+		ds.SetRetryBaseDelay(time.Millisecond)
+		return ds
+	}
 
 	// Create Provider A: nanogpt type (will fail with fake key)
 	// Note: z.ai returns 200 with error JSON for invalid keys, so it may succeed
@@ -1616,7 +1674,7 @@ func TestGetProviderUsage_ZAICodingQuotaError(t *testing.T) {
 	defer func() { newDiscoveryService = orig }()
 
 	newDiscoveryService = func() *provider.DiscoveryService {
-		return provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
+		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{
 				roundTripFunc: func(req *http.Request) (*http.Response, error) {
 					// ZAI Coding uses hardcoded URL
@@ -1631,6 +1689,8 @@ func TestGetProviderUsage_ZAICodingQuotaError(t *testing.T) {
 				},
 			},
 		})
+		ds.SetRetryBaseDelay(time.Millisecond)
+		return ds
 	}
 
 	// Create handler with mock provider store
@@ -1669,7 +1729,7 @@ func TestGetProviderUsage_NanoGPTSuccess(t *testing.T) {
 	defer func() { newDiscoveryService = orig }()
 
 	newDiscoveryService = func() *provider.DiscoveryService {
-		return provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
+		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{
 				roundTripFunc: func(req *http.Request) (*http.Response, error) {
 					if strings.HasSuffix(req.URL.Path, "/usage") {
@@ -1684,6 +1744,8 @@ func TestGetProviderUsage_NanoGPTSuccess(t *testing.T) {
 				},
 			},
 		})
+		ds.SetRetryBaseDelay(time.Millisecond)
+		return ds
 	}
 
 	// Create handler with mock provider store - use nano-gpt.com (with hyphen) for detection
@@ -1727,7 +1789,7 @@ func TestGetProviderUsage_OpenRouterSuccess(t *testing.T) {
 	defer func() { newDiscoveryService = orig }()
 
 	newDiscoveryService = func() *provider.DiscoveryService {
-		return provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
+		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{
 				roundTripFunc: func(req *http.Request) (*http.Response, error) {
 					if strings.HasSuffix(req.URL.Path, "/credits") {
@@ -1750,6 +1812,8 @@ func TestGetProviderUsage_OpenRouterSuccess(t *testing.T) {
 				},
 			},
 		})
+		ds.SetRetryBaseDelay(time.Millisecond)
+		return ds
 	}
 
 	// Create handler with mock provider store
@@ -1798,7 +1862,7 @@ func TestGetProviderBalance_DeepSeekSuccess(t *testing.T) {
 	defer func() { newDiscoveryService = orig }()
 
 	newDiscoveryService = func() *provider.DiscoveryService {
-		return provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
+		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{
 				roundTripFunc: func(req *http.Request) (*http.Response, error) {
 					if strings.HasSuffix(req.URL.Path, "/user/balance") {
@@ -1813,6 +1877,8 @@ func TestGetProviderBalance_DeepSeekSuccess(t *testing.T) {
 				},
 			},
 		})
+		ds.SetRetryBaseDelay(time.Millisecond)
+		return ds
 	}
 
 	// Create handler with mock provider store
@@ -1860,7 +1926,7 @@ func TestGetOllamaCloudAccount_Success(t *testing.T) {
 	defer func() { newDiscoveryService = orig }()
 
 	newDiscoveryService = func() *provider.DiscoveryService {
-		return provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
+		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{
 				roundTripFunc: func(req *http.Request) (*http.Response, error) {
 					if strings.HasSuffix(req.URL.Path, "/api/me") {
@@ -1875,6 +1941,8 @@ func TestGetOllamaCloudAccount_Success(t *testing.T) {
 				},
 			},
 		})
+		ds.SetRetryBaseDelay(time.Millisecond)
+		return ds
 	}
 
 	// Create handler with mock provider store - use ollama.com hostname for detection
@@ -2275,7 +2343,7 @@ func TestRefreshAllQuotas_NanoGPTSuccess(t *testing.T) {
 	defer func() { newDiscoveryService = orig }()
 
 	newDiscoveryService = func() *provider.DiscoveryService {
-		return provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
+		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{
 				roundTripFunc: func(req *http.Request) (*http.Response, error) {
 					// NanoGPT usage endpoint
@@ -2288,6 +2356,8 @@ func TestRefreshAllQuotas_NanoGPTSuccess(t *testing.T) {
 				},
 			},
 		})
+		ds.SetRetryBaseDelay(time.Millisecond)
+		return ds
 	}
 
 	// Create handler with mock provider store - use nano-gpt.com (with hyphen) for detection
@@ -2328,7 +2398,7 @@ func TestRefreshAllQuotas_ZAICodingError(t *testing.T) {
 	defer func() { newDiscoveryService = orig }()
 
 	newDiscoveryService = func() *provider.DiscoveryService {
-		return provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
+		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{
 				roundTripFunc: func(req *http.Request) (*http.Response, error) {
 					if strings.Contains(req.URL.Host, "api.z.ai") {
@@ -2342,6 +2412,8 @@ func TestRefreshAllQuotas_ZAICodingError(t *testing.T) {
 				},
 			},
 		})
+		ds.SetRetryBaseDelay(time.Millisecond)
+		return ds
 	}
 
 	// Create handler with mock provider store
@@ -2382,7 +2454,7 @@ func TestRefreshAllQuotas_ZAICodingSuccess(t *testing.T) {
 	defer func() { newDiscoveryService = orig }()
 
 	newDiscoveryService = func() *provider.DiscoveryService {
-		return provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
+		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{
 				roundTripFunc: func(req *http.Request) (*http.Response, error) {
 					if strings.Contains(req.URL.Host, "api.z.ai") {
@@ -2397,6 +2469,8 @@ func TestRefreshAllQuotas_ZAICodingSuccess(t *testing.T) {
 				},
 			},
 		})
+		ds.SetRetryBaseDelay(time.Millisecond)
+		return ds
 	}
 
 	// Create handler with mock provider store
@@ -2437,7 +2511,7 @@ func TestRefreshAllQuotas_OpenRouterSuccess(t *testing.T) {
 	defer func() { newDiscoveryService = orig }()
 
 	newDiscoveryService = func() *provider.DiscoveryService {
-		return provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
+		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{
 				roundTripFunc: func(req *http.Request) (*http.Response, error) {
 					// OpenRouter credits endpoint
@@ -2459,6 +2533,8 @@ func TestRefreshAllQuotas_OpenRouterSuccess(t *testing.T) {
 				},
 			},
 		})
+		ds.SetRetryBaseDelay(time.Millisecond)
+		return ds
 	}
 
 	// Create handler with mock provider store
@@ -2500,7 +2576,7 @@ func TestRefreshAllQuotas_DeepSeekSuccess(t *testing.T) {
 	defer func() { newDiscoveryService = orig }()
 
 	newDiscoveryService = func() *provider.DiscoveryService {
-		return provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
+		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{
 				roundTripFunc: func(req *http.Request) (*http.Response, error) {
 					if strings.HasSuffix(req.URL.Path, "/user/balance") {
@@ -2515,6 +2591,8 @@ func TestRefreshAllQuotas_DeepSeekSuccess(t *testing.T) {
 				},
 			},
 		})
+		ds.SetRetryBaseDelay(time.Millisecond)
+		return ds
 	}
 
 	// Create handler with mock provider store
@@ -2555,7 +2633,7 @@ func TestRefreshAllQuotas_OllamaCloudSuccess(t *testing.T) {
 	defer func() { newDiscoveryService = orig }()
 
 	newDiscoveryService = func() *provider.DiscoveryService {
-		return provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
+		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{
 				roundTripFunc: func(req *http.Request) (*http.Response, error) {
 					if strings.HasSuffix(req.URL.Path, "/api/me") {
@@ -2570,6 +2648,8 @@ func TestRefreshAllQuotas_OllamaCloudSuccess(t *testing.T) {
 				},
 			},
 		})
+		ds.SetRetryBaseDelay(time.Millisecond)
+		return ds
 	}
 
 	// Create handler with mock provider store - use ollama.com hostname for detection

--- a/internal/api/discovery_integration_test.go
+++ b/internal/api/discovery_integration_test.go
@@ -680,7 +680,31 @@ func TestDiscoverAllModels_WithEnabledProvider(t *testing.T) {
 // TestGetProviderUsage_ZAICodingError tests that GetProviderUsage handles
 // z.ai API errors (note: z.ai returns 200 with error JSON for invalid keys).
 func TestGetProviderUsage_ZAICodingError(t *testing.T) {
+	// Override newDiscoveryService with mock transport to avoid real API calls
+	// Note: Must override AFTER newTestHandlerWithRouter since NewHandler sets it
 	_, r := newTestHandlerWithRouter(t)
+
+	orig := newDiscoveryService
+	defer func() { newDiscoveryService = orig }()
+
+	newDiscoveryService = func() *provider.DiscoveryService {
+		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
+			Transport: &mockTransport{
+				roundTripFunc: func(req *http.Request) (*http.Response, error) {
+					if strings.Contains(req.URL.Host, "api.z.ai") {
+						return &http.Response{
+							StatusCode: http.StatusInternalServerError,
+							Body:       io.NopCloser(strings.NewReader(`{"error":"invalid key"}`)),
+							Header:     make(http.Header),
+						}, nil
+					}
+					return nil, fmt.Errorf("unexpected request to %s", req.URL.String())
+				},
+			},
+		})
+		ds.SetRetryBaseDelay(time.Millisecond)
+		return ds
+	}
 
 	// Create a provider with z.ai URL and fake key
 	providerName := fmt.Sprintf("test-zai-error-%s", uuid.New().String()[:8])
@@ -709,15 +733,13 @@ func TestGetProviderUsage_ZAICodingError(t *testing.T) {
 	req.Header.Set("Authorization", "Bearer test-admin-token")
 	r.ServeHTTP(rec, req)
 
-	// Note: z.ai API returns 200 with error JSON body for invalid keys
-	// The response should contain quota-related fields or error indication
-	var quotaResp map[string]interface{}
-	if err := json.Unmarshal(rec.Body.Bytes(), &quotaResp); err != nil {
-		t.Fatalf("Failed to parse quota response: %v", err)
+	// The handler returns 500 with plain text error message when API call fails
+	// Verify the response code is 500 (error case)
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("Expected 500 for z.ai API error, got %d: %s", rec.Code, rec.Body.String())
 	}
-	// Verify the response was processed (either success or error JSON)
-	if rec.Code != http.StatusOK && rec.Code != http.StatusInternalServerError {
-		t.Errorf("Expected 200 or 500 for z.ai API call, got %d: %s", rec.Code, rec.Body.String())
+	if !strings.Contains(rec.Body.String(), "failed to fetch usage") {
+		t.Errorf("Expected error about failed to fetch usage, got: %s", rec.Body.String())
 	}
 }
 
@@ -787,7 +809,31 @@ func TestGetProviderUsage_NanoGPTError(t *testing.T) {
 // TestGetProviderUsage_OpenRouterError tests that GetProviderUsage returns 500
 // when the OpenRouter API call fails with an invalid key.
 func TestGetProviderUsage_OpenRouterError(t *testing.T) {
+	// Override newDiscoveryService with mock transport to avoid real API calls
+	// Note: Must override AFTER newTestHandlerWithRouter since NewHandler sets it
 	_, r := newTestHandlerWithRouter(t)
+
+	orig := newDiscoveryService
+	defer func() { newDiscoveryService = orig }()
+
+	newDiscoveryService = func() *provider.DiscoveryService {
+		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
+			Transport: &mockTransport{
+				roundTripFunc: func(req *http.Request) (*http.Response, error) {
+					if strings.Contains(req.URL.Host, "openrouter.ai") {
+						return &http.Response{
+							StatusCode: http.StatusInternalServerError,
+							Body:       io.NopCloser(strings.NewReader(`{"error":"invalid key"}`)),
+							Header:     make(http.Header),
+						}, nil
+					}
+					return nil, fmt.Errorf("unexpected request to %s", req.URL.String())
+				},
+			},
+		})
+		ds.SetRetryBaseDelay(time.Millisecond)
+		return ds
+	}
 
 	// Create a provider with OpenRouter URL and fake key
 	providerName := fmt.Sprintf("test-openrouter-error-%s", uuid.New().String()[:8])
@@ -826,7 +872,31 @@ func TestGetProviderUsage_OpenRouterError(t *testing.T) {
 // TestGetProviderBalance_DeepSeekError tests that GetProviderBalance returns 500
 // when the DeepSeek API call fails with an invalid key.
 func TestGetProviderBalance_DeepSeekError(t *testing.T) {
+	// Override newDiscoveryService with mock transport to avoid real API calls
+	// Note: Must override AFTER newTestHandlerWithRouter since NewHandler sets it
 	_, r := newTestHandlerWithRouter(t)
+
+	orig := newDiscoveryService
+	defer func() { newDiscoveryService = orig }()
+
+	newDiscoveryService = func() *provider.DiscoveryService {
+		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
+			Transport: &mockTransport{
+				roundTripFunc: func(req *http.Request) (*http.Response, error) {
+					if strings.Contains(req.URL.Host, "api.deepseek.com") {
+						return &http.Response{
+							StatusCode: http.StatusInternalServerError,
+							Body:       io.NopCloser(strings.NewReader(`{"error":"invalid key"}`)),
+							Header:     make(http.Header),
+						}, nil
+					}
+					return nil, fmt.Errorf("unexpected request to %s", req.URL.String())
+				},
+			},
+		})
+		ds.SetRetryBaseDelay(time.Millisecond)
+		return ds
+	}
 
 	// Create a provider with DeepSeek URL and fake key
 	providerName := fmt.Sprintf("test-deepseek-error-%s", uuid.New().String()[:8])
@@ -865,7 +935,31 @@ func TestGetProviderBalance_DeepSeekError(t *testing.T) {
 // TestGetOllamaCloudAccount_Error tests that GetOllamaCloudAccount returns 500
 // when the Ollama Cloud API call fails with an invalid key.
 func TestGetOllamaCloudAccount_Error(t *testing.T) {
+	// Override newDiscoveryService with mock transport to avoid real API calls
+	// Note: Must override AFTER newTestHandlerWithRouter since NewHandler sets it
 	_, r := newTestHandlerWithRouter(t)
+
+	orig := newDiscoveryService
+	defer func() { newDiscoveryService = orig }()
+
+	newDiscoveryService = func() *provider.DiscoveryService {
+		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
+			Transport: &mockTransport{
+				roundTripFunc: func(req *http.Request) (*http.Response, error) {
+					if strings.Contains(req.URL.Host, "ollama.com") {
+						return &http.Response{
+							StatusCode: http.StatusInternalServerError,
+							Body:       io.NopCloser(strings.NewReader(`{"error":"invalid key"}`)),
+							Header:     make(http.Header),
+						}, nil
+					}
+					return nil, fmt.Errorf("unexpected request to %s", req.URL.String())
+				},
+			},
+		})
+		ds.SetRetryBaseDelay(time.Millisecond)
+		return ds
+	}
 
 	// Create a provider with Ollama Cloud URL and fake key
 	providerName := fmt.Sprintf("test-ollama-error-%s", uuid.New().String()[:8])
@@ -1026,7 +1120,31 @@ func TestRefreshAllQuotas_WithSupportedTypes(t *testing.T) {
 // TestRefreshAllQuotas_DeepSeekError tests that RefreshAllQuotas handles
 // DeepSeek API errors correctly.
 func TestRefreshAllQuotas_DeepSeekError(t *testing.T) {
+	// Override newDiscoveryService with mock transport to avoid real API calls
+	// Note: Must override AFTER newTestHandlerWithRouter since NewHandler sets it
 	_, r := newTestHandlerWithRouter(t)
+
+	orig := newDiscoveryService
+	defer func() { newDiscoveryService = orig }()
+
+	newDiscoveryService = func() *provider.DiscoveryService {
+		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
+			Transport: &mockTransport{
+				roundTripFunc: func(req *http.Request) (*http.Response, error) {
+					if strings.Contains(req.URL.Host, "api.deepseek.com") {
+						return &http.Response{
+							StatusCode: http.StatusInternalServerError,
+							Body:       io.NopCloser(strings.NewReader(`{"error":"invalid key"}`)),
+							Header:     make(http.Header),
+						}, nil
+					}
+					return nil, fmt.Errorf("unexpected request to %s", req.URL.String())
+				},
+			},
+		})
+		ds.SetRetryBaseDelay(time.Millisecond)
+		return ds
+	}
 
 	// Create a provider with DeepSeek URL and fake key
 	providerName := fmt.Sprintf("test-quota-deepseek-%s", uuid.New().String()[:8])
@@ -1081,7 +1199,31 @@ func TestRefreshAllQuotas_DeepSeekError(t *testing.T) {
 // TestRefreshAllQuotas_OllamaCloudError tests that RefreshAllQuotas handles
 // Ollama Cloud API errors correctly.
 func TestRefreshAllQuotas_OllamaCloudError(t *testing.T) {
+	// Override newDiscoveryService with mock transport to avoid real API calls
+	// Note: Must override AFTER newTestHandlerWithRouter since NewHandler sets it
 	_, r := newTestHandlerWithRouter(t)
+
+	orig := newDiscoveryService
+	defer func() { newDiscoveryService = orig }()
+
+	newDiscoveryService = func() *provider.DiscoveryService {
+		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
+			Transport: &mockTransport{
+				roundTripFunc: func(req *http.Request) (*http.Response, error) {
+					if strings.Contains(req.URL.Host, "ollama.com") {
+						return &http.Response{
+							StatusCode: http.StatusInternalServerError,
+							Body:       io.NopCloser(strings.NewReader(`{"error":"invalid key"}`)),
+							Header:     make(http.Header),
+						}, nil
+					}
+					return nil, fmt.Errorf("unexpected request to %s", req.URL.String())
+				},
+			},
+		})
+		ds.SetRetryBaseDelay(time.Millisecond)
+		return ds
+	}
 
 	// Create a provider with Ollama Cloud URL and fake key
 	providerName := fmt.Sprintf("test-quota-ollama-%s", uuid.New().String()[:8])
@@ -1136,7 +1278,31 @@ func TestRefreshAllQuotas_OllamaCloudError(t *testing.T) {
 // TestRefreshAllQuotas_OpenRouterError tests that RefreshAllQuotas handles
 // OpenRouter API errors correctly.
 func TestRefreshAllQuotas_OpenRouterError(t *testing.T) {
+	// Override newDiscoveryService with mock transport to avoid real API calls
+	// Note: Must override AFTER newTestHandlerWithRouter since NewHandler sets it
 	_, r := newTestHandlerWithRouter(t)
+
+	orig := newDiscoveryService
+	defer func() { newDiscoveryService = orig }()
+
+	newDiscoveryService = func() *provider.DiscoveryService {
+		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
+			Transport: &mockTransport{
+				roundTripFunc: func(req *http.Request) (*http.Response, error) {
+					if strings.Contains(req.URL.Host, "openrouter.ai") {
+						return &http.Response{
+							StatusCode: http.StatusInternalServerError,
+							Body:       io.NopCloser(strings.NewReader(`{"error":"invalid key"}`)),
+							Header:     make(http.Header),
+						}, nil
+					}
+					return nil, fmt.Errorf("unexpected request to %s", req.URL.String())
+				},
+			},
+		})
+		ds.SetRetryBaseDelay(time.Millisecond)
+		return ds
+	}
 
 	// Create a provider with OpenRouter URL and fake key
 	providerName := fmt.Sprintf("test-quota-openrouter-%s", uuid.New().String()[:8])

--- a/internal/api/handler_discovery_test.go
+++ b/internal/api/handler_discovery_test.go
@@ -812,7 +812,31 @@ func TestRefreshAllQuotas_DisabledProvider(t *testing.T) {
 // Test for admin.go - CreateProvider_KeylessProvider
 
 func TestDiscoverProviderModels_InvalidProvider(t *testing.T) {
+	// Override newDiscoveryService with mock transport to avoid real API calls
+	// Note: Must override AFTER newTestHandlerWithRouter since NewHandler sets it
 	_, r := newTestHandlerWithRouter(t)
+
+	orig := newDiscoveryService
+	defer func() { newDiscoveryService = orig }()
+
+	newDiscoveryService = func() *provider.DiscoveryService {
+		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
+			Transport: &mockTransport{
+				roundTripFunc: func(req *http.Request) (*http.Response, error) {
+					if strings.Contains(req.URL.Host, "httpbin.org") {
+						return &http.Response{
+							StatusCode: http.StatusInternalServerError,
+							Body:       io.NopCloser(strings.NewReader(`{"error":"internal server error"}`)),
+							Header:     make(http.Header),
+						}, nil
+					}
+					return nil, fmt.Errorf("unexpected request to %s", req.URL.String())
+				},
+			},
+		})
+		ds.SetRetryBaseDelay(time.Millisecond)
+		return ds
+	}
 
 	// Create a provider with invalid URL
 	providerData := `{"name": "test-discover-invalid", "base_url": "https://httpbin.org", "api_key": "test-api-key"}`

--- a/internal/api/handler_discovery_test.go
+++ b/internal/api/handler_discovery_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
@@ -293,6 +295,30 @@ func TestDiscoverProviderModels_Success(t *testing.T) {
 func TestGetProviderUsage_Success(t *testing.T) {
 	h, r := newTestHandlerWithRouter(t)
 	_ = h // Use h to avoid unused variable error
+
+	// Override newDiscoveryService with mock transport to avoid real API calls
+	// Note: Must override AFTER newTestHandlerWithRouter since NewHandler sets it
+	orig := newDiscoveryService
+	defer func() { newDiscoveryService = orig }()
+
+	newDiscoveryService = func() *provider.DiscoveryService {
+		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
+			Transport: &mockTransport{
+				roundTripFunc: func(req *http.Request) (*http.Response, error) {
+					if strings.Contains(req.URL.Host, "api.nano-gpt.com") {
+						return &http.Response{
+							StatusCode: http.StatusServiceUnavailable,
+							Body:       io.NopCloser(strings.NewReader("api.nano-gpt.com is currently in development. Please use https://nano-gpt.com/api instead.")),
+							Header:     make(http.Header),
+						}, nil
+					}
+					return nil, fmt.Errorf("unexpected request to %s", req.URL.String())
+				},
+			},
+		})
+		ds.SetRetryBaseDelay(time.Millisecond)
+		return ds
+	}
 
 	// Create a provider with NanoGPT URL (will fail with test API key but tests the handler path)
 	providerData := `{"name": "test-nanogpt-usage", "base_url": "https://api.nano-gpt.com", "api_key": "test-api-key"}`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,6 +42,10 @@ type Config struct {
 	WebAuthnRPID          string
 	WebAuthnRPDisplayName string
 	WebAuthnRPOrigins     []string
+
+	// lookupIP is used for DNS resolution in ValidateProviderURL.
+	// Defaults to net.LookupIP if nil. Used for testing.
+	lookupIP func(host string) ([]net.IP, error)
 }
 
 // defaultKnownProviderHosts are always allowed as provider base_url hosts,
@@ -299,7 +303,11 @@ func (c *Config) ValidateProviderURL(rawURL string) error {
 	// Store the resolved IPs to detect DNS rebinding: if the host later resolves
 	// to a different set of IPs, the provider URL should be re-validated.
 	// For now, we block any host that currently resolves to a loopback address.
-	ips, err := net.LookupIP(host)
+	lookupIP := c.lookupIP
+	if lookupIP == nil {
+		lookupIP = net.LookupIP
+	}
+	ips, err := lookupIP(host)
 	if err == nil {
 		for _, ip := range ips {
 			if ip.IsLoopback() {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -78,7 +78,13 @@ func TestValidateProviderURL_AllowKnownProvider(t *testing.T) {
 }
 
 func TestValidateProviderURL_AllowKnownProviderSubdomain(t *testing.T) {
-	cfg := &Config{}
+	// Use mock DNS to avoid real lookups (which take ~2s per non-existent domain)
+	cfg := &Config{
+		lookupIP: func(host string) ([]net.IP, error) {
+			// Return a public IP to simulate successful resolution
+			return []net.IP{net.ParseIP("1.2.3.4")}, nil
+		},
+	}
 	tests := []struct {
 		name string
 		url  string

--- a/internal/provider/discovery.go
+++ b/internal/provider/discovery.go
@@ -24,7 +24,8 @@ type DiscoveryService struct {
 	httpClient *http.Client
 	// quotaBreaker tracks per-provider circuit breaker state for quota fetches.
 	// Key: providerID string, Value: *quotaCircuitState.
-	quotaBreaker sync.Map
+	quotaBreaker   sync.Map
+	retryBaseDelay time.Duration // configurable retry backoff base delay
 }
 
 // NewDiscoveryService creates a new discovery service instance with optional
@@ -46,14 +47,24 @@ func NewDiscoveryService(dialCtx func(ctx context.Context, network, addr string)
 		client.CheckRedirect = checkRedirect
 	}
 	return &DiscoveryService{
-		httpClient: client,
+		httpClient:     client,
+		retryBaseDelay: 3 * time.Second,
 	}
 }
 
 // NewDiscoveryServiceWithHTTPClient creates a discovery service with a custom
 // HTTP client. This is intended for tests that need to inject a mock transport.
 func NewDiscoveryServiceWithHTTPClient(client *http.Client) *DiscoveryService {
-	return &DiscoveryService{httpClient: client}
+	return &DiscoveryService{
+		httpClient:     client,
+		retryBaseDelay: 3 * time.Second,
+	}
+}
+
+// SetRetryBaseDelay configures the base delay for quota fetch retry backoff.
+// Shorter values are useful in tests.
+func (d *DiscoveryService) SetRetryBaseDelay(dur time.Duration) {
+	d.retryBaseDelay = dur
 }
 
 // fetchURL makes an HTTP request with the given headers, reads the full
@@ -381,6 +392,9 @@ func isRetryableStatus(statusCode int) bool {
 // jitter in [0, base). This prevents thundering herd when multiple providers
 // fail simultaneously.
 func retryBackoff(base time.Duration, attempt int) time.Duration {
+	if base <= 0 {
+		return 0
+	}
 	delay := time.Duration(attempt) * base
 	jitter := time.Duration(rand.Int64N(int64(base)))
 	return delay + jitter
@@ -402,7 +416,7 @@ func (d *DiscoveryService) doQuotaRequestWithRetry(ctx context.Context, req *htt
 	var lastErr error
 	for attempt := range maxQuotaRetries {
 		if attempt > 0 {
-			backoff := retryBackoff(3*time.Second, attempt)
+			backoff := retryBackoff(d.retryBaseDelay, attempt)
 			debuglog.Info("discovery: retrying quota fetch", "type", providerType, "provider", providerName, "provider_id", providerID, "backoff", backoff, "attempt", attempt+1, "max_attempts", maxQuotaRetries)
 			select {
 			case <-ctx.Done():

--- a/internal/provider/discovery_google_http_test.go
+++ b/internal/provider/discovery_google_http_test.go
@@ -144,7 +144,7 @@ func TestDiscoverGoogleAIStudio_Unauthorized(t *testing.T) {
 
 	provider := &Provider{
 		ID:      uuid.New(),
-		BaseURL: "https://generativelanguage.googleapis.com/v1beta/openai",
+		BaseURL: server.URL + "/v1beta/openai",
 	}
 
 	_, err := service.discoverGoogleAIStudio(context.Background(), provider, "wrong-api-key")
@@ -236,7 +236,7 @@ func TestDiscoverGoogleAIStudio_Non200Status(t *testing.T) {
 
 	provider := &Provider{
 		ID:      uuid.New(),
-		BaseURL: "https://generativelanguage.googleapis.com/v1beta/openai",
+		BaseURL: server.URL + "/v1beta/openai",
 	}
 
 	_, err := service.discoverGoogleAIStudio(context.Background(), provider, "test-api-key")
@@ -259,7 +259,7 @@ func TestDiscoverGoogleAIStudio_InvalidResponse(t *testing.T) {
 
 	provider := &Provider{
 		ID:      uuid.New(),
-		BaseURL: "https://generativelanguage.googleapis.com/v1beta/openai",
+		BaseURL: server.URL + "/v1beta/openai",
 	}
 
 	_, err := service.discoverGoogleAIStudio(context.Background(), provider, "test-api-key")

--- a/internal/provider/discovery_http_test.go
+++ b/internal/provider/discovery_http_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -844,6 +845,7 @@ func TestGetZAICodingQuota_Non200Status(t *testing.T) {
 		httpClient: &http.Client{
 			Transport: &testTransport{url: server.URL},
 		},
+		retryBaseDelay: time.Millisecond,
 	}
 
 	masterKey := "test-master-key-1234567890123456"

--- a/internal/provider/discovery_neuralwatt_test.go
+++ b/internal/provider/discovery_neuralwatt_test.go
@@ -174,7 +174,8 @@ func TestGetNeuralWattQuota_Non200Status(t *testing.T) {
 	defer server.Close()
 
 	service := &DiscoveryService{
-		httpClient: server.Client(),
+		httpClient:     server.Client(),
+		retryBaseDelay: time.Millisecond,
 	}
 
 	masterKey := "test-master-key-for-testing-only-32bytes!"

--- a/internal/provider/discovery_ollama_http_test.go
+++ b/internal/provider/discovery_ollama_http_test.go
@@ -370,7 +370,8 @@ func TestGetOllamaCloudAccount_Non200Status(t *testing.T) {
 	defer server.Close()
 
 	service := &DiscoveryService{
-		httpClient: server.Client(),
+		httpClient:     server.Client(),
+		retryBaseDelay: time.Millisecond,
 	}
 
 	masterKey := "test-master-key-1234567890123456"

--- a/internal/provider/discovery_test.go
+++ b/internal/provider/discovery_test.go
@@ -1146,6 +1146,7 @@ func TestQuotaCircuitState_HalfOpenFailureReopens(t *testing.T) {
 
 func TestDoQuotaRequestWithRetry_CircuitBreakerShortCircuits(t *testing.T) {
 	svc := NewDiscoveryService(nil, nil)
+	svc.SetRetryBaseDelay(time.Millisecond)
 	providerID := "test-provider-123"
 
 	// Open the circuit by recording enough failures.
@@ -1182,6 +1183,7 @@ func TestDoQuotaRequestWithRetry_Retries429(t *testing.T) {
 	defer server.Close()
 
 	svc := NewDiscoveryService(nil, nil)
+	svc.SetRetryBaseDelay(time.Millisecond)
 	svc.httpClient = server.Client()
 	req, _ := http.NewRequest("GET", server.URL+"/quota", http.NoBody)
 	ctx := context.Background()
@@ -1210,6 +1212,7 @@ func TestDoQuotaRequestWithRetry_Retries5xx(t *testing.T) {
 	defer server.Close()
 
 	svc := NewDiscoveryService(nil, nil)
+	svc.SetRetryBaseDelay(time.Millisecond)
 	svc.httpClient = server.Client()
 	req, _ := http.NewRequest("GET", server.URL+"/quota", http.NoBody)
 	ctx := context.Background()
@@ -1232,6 +1235,7 @@ func TestDoQuotaRequestWithRetry_NonRetryableStatusNoRetry(t *testing.T) {
 	defer server.Close()
 
 	svc := NewDiscoveryService(nil, nil)
+	svc.SetRetryBaseDelay(time.Millisecond)
 	svc.httpClient = server.Client()
 	req, _ := http.NewRequest("GET", server.URL+"/quota", http.NoBody)
 	ctx := context.Background()
@@ -1275,7 +1279,7 @@ func TestDiscoverModels_UnsupportedProviderTypeFallsBackToOpenAI(t *testing.T) {
 	}))
 	defer server.Close()
 
-	svc := &DiscoveryService{httpClient: server.Client()}
+	svc := &DiscoveryService{httpClient: server.Client(), retryBaseDelay: time.Millisecond}
 	provider := &Provider{
 		ID:           uuid.New(),
 		Name:         "unknown-provider",

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -46,6 +46,9 @@ type Handler struct {
 	// deprecationCache caches rejected parameters learned from HTTP 400 responses,
 	// keyed by "providerType:modelID". Value: map[string]bool of rejected param names.
 	deprecationCache sync.Map
+	// waitInsertTimeout overrides the default 5s WaitForInsert timeout.
+	// Zero means use the default. Set by tests only.
+	waitInsertTimeout time.Duration
 }
 
 // virtualKeyRepoAdapter wraps *virtualkey.Repository to implement VirtualKeyRepository.

--- a/internal/proxy/handler_test.go
+++ b/internal/proxy/handler_test.go
@@ -1219,7 +1219,7 @@ func TestChatCompletions_ContextErrorHandling(t *testing.T) {
 	// Server that delays response to trigger timeout
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		select {
-		case <-time.After(5 * time.Second):
+		case <-time.After(200 * time.Millisecond):
 		case <-r.Context().Done():
 		}
 		w.WriteHeader(http.StatusOK)

--- a/internal/proxy/logging.go
+++ b/internal/proxy/logging.go
@@ -90,7 +90,7 @@ func publishRequestStartedEvent(logEntry *requestLogData) {
 }
 
 // WaitForInsert blocks until the async INSERT goroutine has completed (or
-// timed out after 5 seconds). Callers should invoke this before
+// timed out). Callers should invoke this before
 // updateRequestLog to guarantee the row exists in the database.
 func (h *Handler) WaitForInsert(logEntry *requestLogData) {
 	done := make(chan struct{})
@@ -98,9 +98,13 @@ func (h *Handler) WaitForInsert(logEntry *requestLogData) {
 		defer close(done)
 		logEntry.insertWg.Wait()
 	}()
+	timeout := h.waitInsertTimeout
+	if timeout == 0 {
+		timeout = 5 * time.Second
+	}
 	select {
 	case <-done:
-	case <-time.After(5 * time.Second):
+	case <-time.After(timeout):
 		debuglog.Warn("proxy: timed out waiting for request log INSERT", "request_id", logEntry.id)
 	}
 }

--- a/internal/proxy/logging_test.go
+++ b/internal/proxy/logging_test.go
@@ -288,11 +288,8 @@ func TestUpdateRequestLog_NonexistentID(t *testing.T) {
 // TestWaitForInsert_Timeout tests that WaitForInsert returns after timeout
 // when the insert goroutine never completes.
 func TestWaitForInsert_Timeout(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping timeout test in short mode")
-	}
 	t.Helper()
-	h := &Handler{}
+	h := &Handler{waitInsertTimeout: 50 * time.Millisecond}
 
 	// Create a requestLogData with a WaitGroup that never gets Done()
 	logData := &requestLogData{
@@ -309,12 +306,12 @@ func TestWaitForInsert_Timeout(t *testing.T) {
 	h.WaitForInsert(logData)
 	elapsed := time.Since(start)
 
-	// Should return within ~6 seconds (5s timeout + small margin)
-	if elapsed < 5*time.Second {
-		t.Errorf("WaitForInsert returned too early: %v (expected ~5s timeout)", elapsed)
+	// Should return within ~100ms (50ms timeout + small margin)
+	if elapsed < 40*time.Millisecond {
+		t.Errorf("WaitForInsert returned too early: %v (expected ~50ms timeout)", elapsed)
 	}
-	if elapsed > 7*time.Second {
-		t.Errorf("WaitForInsert took too long: %v (expected ~5s timeout)", elapsed)
+	if elapsed > 100*time.Millisecond {
+		t.Errorf("WaitForInsert took too long: %v (expected ~50ms timeout)", elapsed)
 	}
 }
 

--- a/internal/proxy/logging_test.go
+++ b/internal/proxy/logging_test.go
@@ -310,7 +310,7 @@ func TestWaitForInsert_Timeout(t *testing.T) {
 	if elapsed < 40*time.Millisecond {
 		t.Errorf("WaitForInsert returned too early: %v (expected ~50ms timeout)", elapsed)
 	}
-	if elapsed > 100*time.Millisecond {
+	if elapsed > 500*time.Millisecond {
 		t.Errorf("WaitForInsert took too long: %v (expected ~50ms timeout)", elapsed)
 	}
 }

--- a/internal/proxy/safe_dialer_test.go
+++ b/internal/proxy/safe_dialer_test.go
@@ -253,7 +253,12 @@ func TestSafeDialer_DialTimingContext(t *testing.T) {
 }
 
 func TestSafeDialer_DNSErrorFallback(t *testing.T) {
-	sd := NewSafeDialer(nil, nil)
+	// Use mock resolver to avoid real DNS lookups
+	sd := newSafeDialerWithResolver(nil, &mockResolver{
+		lookupFunc: func(ctx context.Context, host string) ([]net.IPAddr, error) {
+			return nil, fmt.Errorf("DNS lookup failed")
+		},
+	}, nil)
 	ctx := context.Background()
 
 	// Non-existent host should fall through to dial and get a connection error,
@@ -420,7 +425,7 @@ func TestSafeDialer_DialByIPWithMockDNS(t *testing.T) {
 	// Create a SafeDialer with the mock resolver - NOT allowlisting the host
 	// This forces the dial-by-IP path
 	sd := newSafeDialerWithResolver(nil, mockResolver, nil)
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
 
 	// Dial a fake hostname - the mock resolver returns 8.8.8.8 (public, non-blocked)
@@ -522,7 +527,7 @@ func TestSafeDialer_MixedBlockedAndAllowedIPs(t *testing.T) {
 	}
 
 	sd := newSafeDialerWithResolver(nil, mockRes, nil)
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
 
 	_, err := sd.DialContext(ctx, "tcp", "mixed.example.com:80")

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -340,6 +340,7 @@ func TestGetFloat(t *testing.T) {
 
 func TestCacheTTL(t *testing.T) {
 	r := NewRepository(testPool)
+	r.cacheTTL = 100 * time.Millisecond
 	ctx := context.Background()
 	clearSettings(t)
 
@@ -366,7 +367,7 @@ func TestCacheTTL(t *testing.T) {
 		t.Errorf("got %q, want initial (cached)", val)
 	}
 
-	time.Sleep(r.cacheTTL + time.Second)
+	time.Sleep(r.cacheTTL + 50*time.Millisecond)
 
 	val = r.GetWithDefault(ctx, key, "default")
 	if val != "updated" {

--- a/web/src/pages/Chat/__tests__/chatStreaming.test.ts
+++ b/web/src/pages/Chat/__tests__/chatStreaming.test.ts
@@ -509,6 +509,7 @@ describe("streamModelResponse", () => {
 			baseParams,
 			new AbortController(),
 			vi.fn(),
+			{ maxRetries: 0 },
 		);
 
 		expect(result.error).not.toBeNull();
@@ -563,6 +564,7 @@ describe("streamModelResponse", () => {
 			baseParams,
 			abortCtrl,
 			vi.fn(),
+			{ maxRetries: 0 },
 		);
 
 		expect(result.aborted).toBe(true);

--- a/web/src/pages/Chat/chatStreaming.ts
+++ b/web/src/pages/Chat/chatStreaming.ts
@@ -7,7 +7,7 @@ import type {
 } from "../../api/types";
 import { hasAnyParam } from "../../utils/params";
 import { readSSEStream, type StreamChunk } from "../../utils/sse";
-import { fetchWithRetry } from "../../utils/stagger";
+import { fetchWithRetry, type RetryOptions } from "../../utils/stagger";
 import { extractThinking, sanitizeDelta } from "../../utils/thinking";
 
 export function formatTime(ts: number): string {
@@ -104,6 +104,7 @@ export async function streamModelResponse(
 	params: GenerationParams,
 	abortCtrl: AbortController,
 	onDelta: (raw: string, content: string, thinking: string) => void,
+	retryOptions?: RetryOptions,
 ): Promise<StreamResult> {
 	const startTime = performance.now();
 	let promptTokens = 0;
@@ -127,9 +128,7 @@ export async function streamModelResponse(
 				}),
 				signal: abortCtrl.signal,
 			},
-			{
-				maxRetries: 2,
-			},
+			retryOptions ?? { maxRetries: 2 },
 		);
 
 		if (!resp.ok) {

--- a/web/src/pages/__tests__/Chat.flow.test.tsx
+++ b/web/src/pages/__tests__/Chat.flow.test.tsx
@@ -1,6 +1,6 @@
 import { screen, waitFor, within } from "@testing-library/react";
 import { HttpResponse, http } from "msw";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	mockAllDefaults,
 	mockChatStream,
@@ -11,6 +11,17 @@ import { mockModel, mockProvider } from "../../test/mocks/data";
 import { server } from "../../test/mocks/server";
 import { renderWithProviders } from "../../test/utils";
 import { Chat } from "../Chat";
+
+// Disable retries in error-path tests to speed them up
+vi.mock("../../utils/stagger", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../../utils/stagger")>();
+	return {
+		...actual,
+		fetchWithRetry: vi.fn((url, init, options = {}) =>
+			actual.fetchWithRetry(url, init, { ...options, maxRetries: 0 }),
+		),
+	};
+});
 
 describe("Chat", () => {
 	beforeEach(() => {


### PR DESCRIPTION
## Summary

Speed up ~30 slow tests by eliminating real network calls, configurable retry/timeout params, and injectable DNS resolution.

### Commit 1: Configurable retry/timeout params (fdcb90df)

**Backend:**
- Add `retryBaseDelay` field to `DiscoveryService` (default 3s). Tests set `1ms` for instant retries — fixes 9 quota/retry tests (~100s → <1s).
- Add `waitInsertTimeout` field to proxy `Handler` (default 5s). Tests set `50ms` — fixes `TestWaitForInsert_Timeout` (5s → 50ms).
- Settings `TestCacheTTL` uses 100ms TTL instead of 30s (31s → <1s).
- Reduce upstream mock delay in `TestChatCompletions_ContextErrorHandling` (5s → 200ms).
- Guard `retryBackoff` against zero base to prevent `rand.Int64N(0)` panic.

**Frontend:**
- Add optional `retryOptions` parameter to `streamModelResponse` so tests can pass `maxRetries: 0`, disabling exponential backoff in error tests (~10s → <1s).
- Mock `fetchWithRetry` in Chat.flow tests to disable retries.

### Commit 2: Mock external network calls (69ee5871)

- Mock 8 API tests that hit real external APIs (DeepSeek, Ollama, OpenRouter, z.ai, httpbin.org) via mock transport override (~20s → ~2s).
- Make DNS resolution injectable in `Config.ValidateProviderURL`, mock it in `TestValidateProviderURL_AllowKnownProviderSubdomain` (15.3s → 0s).
- Use mock resolver in `TestSafeDialer_DNSErrorFallback` (5s → 0s).
- Reduce dial timeouts in SafeDialer tests (4s → 100ms total).
- Fix 3 Google AI Studio tests using live Google API URL instead of mock server URL (5.3s → 0s).

### Impact

| Metric | Before | After |
|--------|--------|-------|
| Tests >5s | 16 | 0 |
| Tests >1s | ~30 | ~2 |
| Total time saved per CI run | — | ~200s |

All defaults preserve production behavior. No behavior changes outside test code.