### PR TITLE
Fix CI flake in stall watchdog boundary test

### DIFF
--- a/internal/proxy/ttft_stall_test.go
+++ b/internal/proxy/ttft_stall_test.go
@@ -890,8 +890,9 @@ func TestStallWatchdog_ProgressiveTimeout_Boundary50(t *testing.T) {
 	if logData.errorMessage == "" {
 		t.Error("expected non-empty error message after stall")
 	}
-	// Duration should be well under 200ms since the watchdog fires at ~50ms
-	if logData.durationMs > 200 {
-		t.Errorf("expected duration < 200ms (stall fired early), got %.1fms", logData.durationMs)
+	// Duration should be well under 500ms since the watchdog fires at ~50ms.
+	// Use generous margin for CI scheduling jitter (goroutine wake-up, pipe I/O).
+	if logData.durationMs > 500 {
+		t.Errorf("expected duration < 500ms (stall fired early), got %.1fms", logData.durationMs)
 	}
 }


### PR DESCRIPTION
## Summary

Fix CI flake in `TestStallWatchdog_ProgressiveTimeout_Boundary50` — widened timing assertion from 200ms to 500ms to accommodate goroutine scheduling jitter on loaded CI runners while still verifying the 50ms stall watchdog fires promptly (10× margin).