### PR TITLE
Add CrowdIn GitHub Action for i18n synchronization

### DIFF
--- a/.github/crowdin.yml
+++ b/.github/crowdin.yml
@@ -10,3 +10,5 @@
 files:
   - source: /web/src/i18n/locales/en.json
     translation: /web/src/i18n/locales/%two_letters_code%.json
+    exclude_languages:
+      - en

--- a/.github/crowdin.yml
+++ b/.github/crowdin.yml
@@ -1,0 +1,12 @@
+# Crowdin configuration for Model Hotel i18n
+# https://crowdin.github.io/crowdin-cli/configuration-file
+
+"project_id_env": CROWDIN_PROJECT_ID
+"api_token_env": CROWDIN_PERSONAL_TOKEN
+"base_path": "."
+
+"preserve_hierarchy": true
+
+files:
+  - source: /web/src/i18n/locales/en.json
+    translation: /web/src/i18n/locales/%two_letters_code%.json

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Crowdin Sync
-        uses: crowdin/github-action@v2
+        uses: crowdin/github-action@8868a33591d21088edfc398968173a3b98d51706 # v2
         with:
           # Upload source strings when en.json changes on master
           upload_sources: true

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -1,0 +1,50 @@
+name: Crowdin Translations
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "web/src/i18n/locales/en.json"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: crowdin-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  synchronize-with-crowdin:
+    name: Sync Crowdin
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Crowdin Sync
+        uses: crowdin/github-action@v2
+        with:
+          # Upload source strings when en.json changes on master
+          upload_sources: true
+          # Upload existing translations so Crowdin has the latest
+          upload_translations: true
+          # Download translated files and create a PR
+          download_translations: true
+          # Only include fully translated + approved strings
+          skip_untranslated_strings: true
+          export_only_approved: true
+          # PR configuration
+          localization_branch_name: l10n_crowdin_translations
+          create_pull_request: true
+          pull_request_title: "New Crowdin translations"
+          pull_request_labels: "i18n"
+          pull_request_base_branch_name: master
+          # Use .github/crowdin.yml for file mapping
+          config: ".github/crowdin.yml"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}


### PR DESCRIPTION
## CrowdIn GitHub Action Integration

Adds CrowdIn synchronization for i18n translations. When `en.json` is updated on `master`, this workflow automatically:

1. **Uploads sources** — pushes the latest `en.json` to CrowdIn
2. **Uploads existing translations** — syncs any local translation changes back to CrowdIn  
3. **Downloads approved translations** — creates a PR with new/updated translations (only approved, fully translated strings)

### Files

- `.github/crowdin.yml` — CrowdIn CLI config (maps `en.json` → `%two_letters_code%.json`)
- `.github/workflows/crowdin.yml` — **Separate workflow** (does not modify `ci.yml`)

### Safety

- Triggered only on `push` to `master` when `web/src/i18n/locales/en.json` changes, plus `workflow_dispatch`
- Own permissions scope — no impact on existing CI
- Concurrency group prevents parallel runs
- Only downloads `skip_untranslated_strings: true` + `export_only_approved: true`
- Creates PRs with `i18n` label for review before merge

### Required GitHub Secrets (already set)

- `CROWDIN_PROJECT_ID` — 903719
- `CROWDIN_PERSONAL_TOKEN` — from CrowdIn account settings