### PR TITLE
fix: correct crowdin base_path

### DIFF
--- a/.github/crowdin.yml
+++ b/.github/crowdin.yml
@@ -3,12 +3,12 @@
 
 "project_id_env": CROWDIN_PROJECT_ID
 "api_token_env": CROWDIN_PERSONAL_TOKEN
-"base_path": "."
+"base_path": ".."
 
 "preserve_hierarchy": true
 
 files:
-  - source: web/src/i18n/locales/en.json
-    translation: web/src/i18n/locales/%two_letters_code%.json
+  - source: /web/src/i18n/locales/en.json
+    translation: /web/src/i18n/locales/%two_letters_code%.json
     exclude_languages:
       - en


### PR DESCRIPTION
Fixes the CrowdIn GitHub Action configuration.

`base_path: "." ` resolved to `.github/` (where the config file lives), not the repo root. The CLI was looking for files at `.github/web/src/...` instead of the actual path.

Changes:
- `base_path` set to `".."` to resolve from the repo root
- Restored leading slashes on source/translation paths (correct per CrowdIn docs)