### PR TITLE
fix: move crowdin.yml to repo root for CI

### DIFF
--- a/.github/crowdin.yml
+++ b/.github/crowdin.yml
@@ -9,8 +9,7 @@
 
 "files": [
   {
-    "source": "/web/src/i18n/locales/en.json",
-    "translation": "/web/src/i18n/locales/%two_letters_code%.json",
-    "excluded_target_languages": ["en"]
+    "source": "web/src/i18n/locales/en.json",
+    "translation": "web/src/i18n/locales/%two_letters_code%.json"
   }
 ]

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -42,8 +42,8 @@ jobs:
           pull_request_title: "New Crowdin translations"
           pull_request_labels: "i18n"
           pull_request_base_branch_name: master
-          # Use .github/crowdin.yml for file mapping
-          config: ".github/crowdin.yml"
+          # Use crowdin.yml at repo root for file mapping
+          config: "crowdin.yml"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -3,13 +3,13 @@
 
 "project_id_env": CROWDIN_PROJECT_ID
 "api_token_env": CROWDIN_PERSONAL_TOKEN
-"base_path": ".."
+"base_path": "."
 
 "preserve_hierarchy": true
 
 "files": [
   {
-    "source": "web/src/i18n/locales/en.json",
-    "translation": "web/src/i18n/locales/%two_letters_code%.json"
+    "source": "/web/src/i18n/locales/en.json",
+    "translation": "/web/src/i18n/locales/%two_letters_code%.json"
   }
 ]


### PR DESCRIPTION
Moves crowdin.yml from .github/ to repo root so base_path resolves correctly in the CI Docker container.

- Config at repo root: base_path "." = workspace root (no ambiguity)
- Removed excluded_target_languages (causes "Project doesn't have en language" error, and CrowdIn already excludes source language from downloads)
- Verified locally: upload sources ✔, upload translations ✔, download translations ✔
- Previous CI failures were caused by base_path ".." resolving incorrectly inside the Docker container