### PR TITLE
fix: CrowdIn empty strings and i18next fallback

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -33,9 +33,10 @@ jobs:
           upload_translations: true
           # Download translated files and create a PR
           download_translations: true
-          # Only include fully translated + approved strings
+          # Skip keys with no translation (prevents empty string values
+          # that would blank out the UI instead of falling back to English)
           skip_untranslated_strings: true
-          export_only_approved: true
+          skip_untranslated_files: true
           # PR configuration
           localization_branch_name: l10n_crowdin_translations
           create_pull_request: true

--- a/web/src/i18n/index.ts
+++ b/web/src/i18n/index.ts
@@ -13,6 +13,7 @@ i18next
 			en: { translation: en },
 		},
 		fallbackLng: "en",
+		returnEmptyString: false,
 		detection: {
 			order: ["localStorage", "navigator"],
 			caches: ["localStorage"],


### PR DESCRIPTION
Two fixes:

1. `returnEmptyString: false` in i18next config — empty string translations fall back to English instead of rendering blank
2. CrowdIn workflow: removed `export_only_approved` (caused 1870 empty strings in cs.json), added `skip_untranslated_files: true`\n\nCloses the broken PR #142 — do not merge that one.