### PR TITLE
fix(crowdin): use GH_TOKEN for PR creation, add excluded_target_languages

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -1,4 +1,4 @@
-name: Crowdin Translations
+name: Crowdin Action
 
 on:
   push:
@@ -17,33 +17,27 @@ concurrency:
 
 jobs:
   synchronize-with-crowdin:
-    name: Sync Crowdin
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@v4
 
-      - name: Crowdin Sync
-        uses: crowdin/github-action@8868a33591d21088edfc398968173a3b98d51706 # v2
+      - name: crowdin action
+        uses: crowdin/github-action@v2
         with:
-          # Upload source strings when en.json changes on master
           upload_sources: true
-          # Download translated files and create a PR
+          upload_translations: false
           download_translations: true
-          # Skip locale files that have zero translated strings
-          # (prevents downloading empty JSON scaffolds for new languages)
           skip_untranslated_files: true
-          # PR configuration
           localization_branch_name: l10n_crowdin_translations
           create_pull_request: true
           pull_request_title: "New Crowdin translations"
+          pull_request_body: "New Crowdin translations by [Crowdin GH Action](https://github.com/crowdin/github-action)"
           pull_request_labels: "i18n"
           pull_request_base_branch_name: master
-          # Use crowdin.yml at repo root for file mapping
-          config: "crowdin.yml"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
 

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: crowdin action
-        uses: crowdin/github-action@v2
+        uses: crowdin/github-action@8868a33591d21088edfc398968173a3b98d51706 # v2
         with:
           upload_sources: true
           upload_translations: false

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -10,6 +10,9 @@
 "files": [
   {
     "source": "/web/src/i18n/locales/en.json",
-    "translation": "/web/src/i18n/locales/%two_letters_code%.json"
+    "translation": "/web/src/i18n/locales/%two_letters_code%.json",
+    "excluded_target_languages": [
+      "en"
+    ]
   }
 ]


### PR DESCRIPTION
The CrowdIn workflow was downloading translations and pushing to the branch successfully, but PR creation failed with 403:

`GitHub Actions is not permitted to create or approve pull requests.`

Changes:
- Switch from `secrets.GITHUB_TOKEN` to `secrets.GH_TOKEN` (PAT with repo scope) per the official CrowdIn sample workflow
- Add `excluded_target_languages: ["en"]` to suppress the CLI warning about downloading the source language as a translation
- Remove unnecessary `config:` input (defaults to repo root)
- Add explicit `upload_translations: false` and `pull_request_body`
- Match the official sample structure

Requires: `GH_TOKEN` secret (already added to repo secrets)