### PR TITLE
fix(crowdin): remove excluded_target_languages breaking source uploads

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -10,9 +10,6 @@
 "files": [
   {
     "source": "/web/src/i18n/locales/en.json",
-    "translation": "/web/src/i18n/locales/%two_letters_code%.json",
-    "excluded_target_languages": [
-      "en"
-    ]
+    "translation": "/web/src/i18n/locales/%two_letters_code%.json"
   }
 ]


### PR DESCRIPTION
The `excluded_target_languages: ["en"]` added in #149 causes the CrowdIn CLI to fail:

```
❌ Project doesn't have 'en' language(s)
❌ Current execution finished with errors
```

`en` is the *source* language, not a target language. The CLI trips over this during UPLOAD SOURCES.

The warning this was meant to suppress (downloading en.json as a translation) is harmless and already handled by `skip_untranslated_files: true` in the workflow.