### PR TITLE
fix(crowdin): use skip_untranslated_strings instead of skip_untranslated_files

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -29,7 +29,7 @@ jobs:
           upload_sources: true
           upload_translations: false
           download_translations: true
-          skip_untranslated_files: true
+          skip_untranslated_strings: true
           localization_branch_name: l10n_crowdin_translations
           create_pull_request: true
           pull_request_title: "New Crowdin translations"


### PR DESCRIPTION
The workflow was downloading translations successfully but producing no output:

```
⚠️ Couldn't find any file to download. Since you are using the 'Skip untranslated files' option, please make sure you have fully translated files
NOTHING TO COMMIT
```

`skip_untranslated_files: true` requires **every** locale file to be 100% translated before it gets downloaded. A single untranslated string in any language means that entire file is skipped.

`skip_untranslated_strings: true` downloads all translation files but skips individual untranslated strings within each file (leaving them as the source English), which is the intended behavior for partial translations.