### PR TITLE
fix(crowdin): upload translations to CrowdIn, fill empty from source

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           upload_sources: true
           upload_translations: true
+          auto_approve_imported: true
           download_translations: true
           skip_untranslated_strings: true
           localization_branch_name: l10n_crowdin_translations

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -27,7 +27,7 @@ jobs:
         uses: crowdin/github-action@8868a33591d21088edfc398968173a3b98d51706 # v2
         with:
           upload_sources: true
-          upload_translations: false
+          upload_translations: true
           download_translations: true
           skip_untranslated_strings: true
           localization_branch_name: l10n_crowdin_translations
@@ -41,23 +41,29 @@ jobs:
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
 
-      - name: Strip empty translation values
+      - name: Fill empty translations from source
         run: |
           python3 -c '
           import json, glob, os
-          for f in glob.glob("web/src/i18n/locales/?.json"):
-              with open(f) as fh: d = json.load(fh)
-              def strip(obj):
+          with open("web/src/i18n/locales/en.json") as f:
+              en = json.load(f)
+          for fpath in glob.glob("web/src/i18n/locales/?.json"):
+              if "en.json" in fpath:
+                  continue
+              with open(fpath) as f:
+                  d = json.load(f)
+              def fill(trans, src):
                   out = {}
-                  for k, v in obj.items():
+                  for k, v in src.items():
                       if isinstance(v, dict):
-                          s = strip(v)
-                          if s: out[k] = s
-                      elif v != "": out[k] = v
+                          out[k] = fill(trans.get(k, {}), v)
+                      else:
+                          tv = trans.get(k, "")
+                          out[k] = tv if tv != "" else v
                   return out
-              d = strip(d)
-              with open(f, "w") as fh:
-                  json.dump(d, fh, indent="\t", ensure_ascii=False)
-                  fh.write("\n")
-              print(f"  {os.path.basename(f)}: cleaned")
+              d = fill(d, en)
+              with open(fpath, "w") as f:
+                  json.dump(d, f, indent="\t", ensure_ascii=False)
+                  f.write("\n")
+              print(f"  {os.path.basename(fpath)}: filled")
           '

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -48,7 +48,7 @@ jobs:
           import json, glob, os
           with open("web/src/i18n/locales/en.json") as f:
               en = json.load(f)
-          for fpath in glob.glob("web/src/i18n/locales/?.json"):
+          for fpath in glob.glob("web/src/i18n/locales/??.json"):
               if "en.json" in fpath:
                   continue
               with open(fpath) as f:


### PR DESCRIPTION
PR #154 destroys existing translations. The cs.json on that branch has 1,883 empty strings and only 3 filled (local master has 1,870 filled, 0 empty).

Root cause: `upload_translations: false` means the repo's existing translations are never pushed to CrowdIn. When CrowdIn downloads, it doesn't have the repo's translations (e.g. hand-written Czech) and replaces them with empty machine translations.

Two fixes:

1. **`upload_translations: true`** — pushes the repo's existing translations to CrowdIn before downloading, keeping CrowdIn in sync with the repo.

2. **Replace "Strip empty" with "Fill empty from source"** — instead of removing keys with empty values (which breaks the i18n key structure), empty strings are filled with the English source value as a fallback.

**Do NOT merge PR #154** — it will wipe out all Czech translations.