### PR TITLE
fix(crowdin): chmod locale files before fill step

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Fill empty translations from source
         run: |
-          chmod -R u+rw web/src/i18n/locales/
+          sudo chmod -R u+rw web/src/i18n/locales/
           python3 -c '
           import json, glob, os
           with open("web/src/i18n/locales/en.json") as f:

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -44,6 +44,7 @@ jobs:
 
       - name: Fill empty translations from source
         run: |
+          chmod -R u+rw web/src/i18n/locales/
           python3 -c '
           import json, glob, os
           with open("web/src/i18n/locales/en.json") as f:

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Fill empty translations from source
         run: |
-          sudo chmod -R u+rw web/src/i18n/locales/
+          sudo chown -R $(id -u):$(id -g) web/src/i18n/locales/
           python3 -c '
           import json, glob, os
           with open("web/src/i18n/locales/en.json") as f:


### PR DESCRIPTION
The CrowdIn Docker action writes files as root, causing `PermissionError` when the fill step tries to write back. Add `chmod -R u+rw` before the Python script.