### PR TITLE
fix(ci): set skip_untranslated_strings to false

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -30,7 +30,7 @@ jobs:
           upload_translations: false
           auto_approve_imported: true
           download_translations: true
-          skip_untranslated_strings: true
+          skip_untranslated_strings: false
           localization_branch_name: l10n_crowdin_translations
           create_pull_request: true
           pull_request_title: "New Crowdin translations"


### PR DESCRIPTION
DeepL machine translations are stored as suggestions in CrowdIn, not approved translations. `skip_untranslated_strings: true` filters them all out, resulting in empty downloads.