### PR TITLE
fix(crowdin): stop wiping translations (exportApprovedOnly was the real cause)

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -28,8 +28,13 @@ jobs:
         with:
           upload_sources: true
           upload_translations: false
-          auto_approve_imported: true
           download_translations: true
+          # Export every translated string regardless of approval state.
+          # This hobby project does not proofread/approve translations, so
+          # requiring approval (the Crowdin project default) exported empty
+          # files and wiped translations. Pin it false so a project-setting
+          # flip can never silently re-break the download.
+          export_only_approved: false
           skip_untranslated_strings: false
           localization_branch_name: l10n_crowdin_translations
           create_pull_request: true
@@ -41,31 +46,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
-
-      - name: Fill empty translations from source
-        run: |
-          sudo chown -R $(id -u):$(id -g) web/src/i18n/locales/
-          python3 -c '
-          import json, glob, os
-          with open("web/src/i18n/locales/en.json") as f:
-              en = json.load(f)
-          for fpath in glob.glob("web/src/i18n/locales/??.json"):
-              if "en.json" in fpath:
-                  continue
-              with open(fpath) as f:
-                  d = json.load(f)
-              def fill(trans, src):
-                  out = {}
-                  for k, v in src.items():
-                      if isinstance(v, dict):
-                          out[k] = fill(trans.get(k, {}), v)
-                      else:
-                          tv = trans.get(k, "")
-                          out[k] = tv if tv != "" else v
-                  return out
-              d = fill(d, en)
-              with open(fpath, "w") as f:
-                  json.dump(d, f, indent="\t", ensure_ascii=False)
-                  f.write("\n")
-              print(f"  {os.path.basename(fpath)}: filled")
-          '


### PR DESCRIPTION
## What was wrong

The ~37 prior `fix(crowdin)` commits churned the workflow YAML, but the real cause was a **Crowdin project setting**, not the workflow:

- Project `model-hotel` had **`exportApprovedOnly: true`**.
- All 30 languages are **100% translated** but **~0% approved** (only Czech ~18%).
- "Export only approved" → every unapproved string exports **empty** → the action downloaded empty files → the PR wiped translations.

Proven via the Crowdin API: a default build exported `de/es/fr/ja = 0/1913`, `cs = 528` (its approved subset).

## Fix

1. **Crowdin project (applied live via API):** `exportApprovedOnly=false`, `skipUntranslatedStrings=false`. A fresh build then exported **every language at 1913/1913**.
2. **This PR hardens the workflow:**
   - Adds `export_only_approved: false` so a future project-setting flip can't silently re-break the download.
   - Removes the dead "Fill empty translations from source" step — it ran *after* the action already opened the PR (never committed) and is redundant because the app already falls back to English (`web/src/i18n/index.ts`: `fallbackLng: "en"`, `returnEmptyString: false`).

The pipeline already works after the project-setting change; this PR is the durable insurance + cleanup.

Note: `es-ES`, `pt-BR`/`pt-PT`, `zh-CN`/`zh-TW` collapse onto two-letter `es`/`pt`/`zh` files via `%two_letters_code%`, so one regional variant wins per file. Acceptable for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)