### PR TITLE
fix(i18n): stop Crowdin translation syncs from breaking CI (locale-independent language-selector tests)

### DIFF
--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -749,6 +749,7 @@ function LanguageSelector() {
 				className="sidebar-footer-link flex items-center justify-center px-1.5 py-1.5 text-xs text-gray-400 hover:text-white transition-colors rounded-lg hover:bg-white/5 cursor-pointer"
 				title={t("layout.language.label")}
 				aria-label={t("layout.language.label")}
+				data-testid="language-trigger"
 			>
 				<Languages size={14} strokeWidth={2} />
 			</button>
@@ -758,6 +759,7 @@ function LanguageSelector() {
 						<button
 							key={lang.code}
 							type="button"
+							data-testid={`language-option-${lang.code}`}
 							onClick={() => {
 								i18next.changeLanguage(lang.code);
 								setOpen(false);

--- a/web/src/components/__tests__/Layout.language-selector.test.tsx
+++ b/web/src/components/__tests__/Layout.language-selector.test.tsx
@@ -88,11 +88,12 @@ describe("Layout", () => {
 				i18next.changeLanguage("cs-CZ");
 			});
 
-			// After switching to Czech, the button label is "Jazyk" not "Language"
-			await user.click(screen.getByLabelText("Jazyk"));
+			// Select by stable test id, not translated label text — the trigger's
+			// aria-label is localized and changes whenever translations are updated.
+			await user.click(screen.getByTestId("language-trigger"));
 
 			// Czech should be highlighted because resolvedLanguage === "cs"
-			const czechBtn = screen.getByText("Čeština");
+			const czechBtn = screen.getByTestId("language-option-cs");
 			expect(czechBtn).toHaveClass("bg-white/10");
 		});
 
@@ -153,20 +154,16 @@ describe("Layout", () => {
 			const user = userEvent.setup();
 			renderWithProviders(<Layout>{mockChildren}</Layout>);
 
-			await user.click(screen.getByLabelText("Language"));
-			await user.click(screen.getByText("العربية"));
+			await user.click(screen.getByTestId("language-trigger"));
+			await user.click(screen.getByTestId("language-option-ar"));
 			await waitFor(() => {
 				expect(document.documentElement.dir).toBe("rtl");
 			});
 
-			// After switching to Arabic, the label falls back to English "Language"
-			// because ar.json doesn't have layout.language.label translated yet
-			const langButton =
-				document.querySelector('[aria-label="Language"]') ??
-				document.querySelector('[aria-label="اللغة"]');
-			if (!langButton) throw new Error("Language button not found");
-			await user.click(langButton);
-			await user.click(screen.getByText("English"));
+			// Reopen via stable test id — the trigger's aria-label is localized
+			// once Arabic is active, so don't match on label text.
+			await user.click(screen.getByTestId("language-trigger"));
+			await user.click(screen.getByTestId("language-option-en"));
 			await waitFor(() => {
 				expect(document.documentElement.dir).toBe("ltr");
 			});


### PR DESCRIPTION
## Why

Every Crowdin translation PR was failing CI on **Frontend Lint & Build**, blocking merge. Two tests in `Layout.language-selector.test.tsx` switched the UI into Czech/Arabic and then asserted on **translatable** strings:

- `getByText("Čeština")`, `getByText("English")` — the dropdown options render `t(lang.labelKey)`, which is translated.
- `getByLabelText("Jazyk")` — the trigger's `aria-label` is `t("layout.language.label")`, also translated.

These only matched while the locale files were still empty (falling back to English). Once translations are filled (e.g. `ar.json` `layout.language.czech` → `سيشيتينا`), the queries find nothing → CI fails on **every** translation sync. That's the real reason the Crowdin PRs looked "stuck."

## Fix

- Add stable `data-testid="language-trigger"` and `data-testid="language-option-<code>"` hooks to the language selector.
- Rewrite the two brittle tests to select by test id + language code instead of translatable text.

No visual or behavioral change (additive `data-testid` only). Verified the file passes against **both** empty and fully-translated locales (all 12 pass), and all 123 `Layout.*` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)