### PR TITLE
Never translate the sidebar Wiki label

### DIFF
--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -1050,7 +1050,11 @@ export function Layout({ children }: LayoutProps) {
 							className="sidebar-footer-link flex items-center gap-2 px-2 py-1.5 text-xs text-gray-400 hover:text-white transition-colors rounded-lg hover:bg-white/5"
 						>
 							<BookOpen size={14} strokeWidth={2} />
-							{t("layout.docs")}
+							{/* "Wiki" is a fixed brand/proper-noun label for the link to
+							    the GitHub wiki — intentionally not translated, so it
+							    reads the same in every locale (and Crowdin can't mangle
+							    it). Not routed through t(); see the autonym pattern above. */}
+							Wiki
 						</a>
 						<button
 							type="button"

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -166,7 +166,6 @@
 			"acknowledge": "Acknowledge (dismiss)",
 			"request": "Request"
 		},
-		"docs": "Wiki",
 		"running": "Running {{running}}",
 		"runningLatest": "Running latest ({{running}})",
 		"updateAvailable": "Update available: {{running}} → {{latest}}",


### PR DESCRIPTION
The wiki-link label was being machine-translated in every locale (Chinese `维基`, Russian `Вики`, Korean `위키`, Portuguese `Documentação`, …). "Wiki" is a fixed brand / proper-noun label for the link to the GitHub wiki and should read the same everywhere.

- Hardcode `Wiki` in `Layout.tsx` instead of `t("layout.docs")`.
- Remove the now-unused `layout.docs` key from `en.json` so Crowdin stops translating it.

Same approach as the language autonyms. The translated `docs` values still sitting in the locale files (incl. the open Crowdin PR #168) become dead/unused and drop out on the next sync.

tsc, biome, eslint clean; Layout navigation tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)