### PR TITLE
refactor(api): decompose ListLogsCursor + share log helpers across ListLogs/app-logs

### DIFF
--- a/internal/api/applogs.go
+++ b/internal/api/applogs.go
@@ -338,6 +338,24 @@ func appendAppLogFilters(conditions []string, args []any, argIdx int, level, sou
 	return conditions, args, argIdx
 }
 
+// appendAppLogKeysetPredicate appends the (created_at, id) cursor comparison for
+// app_logs. The operator is "<" when (direction=="after") == (sortDir=="DESC")
+// — scrolling older in desc, or "before" in asc — and ">" otherwise, collapsing
+// the four inlined (direction, sortDir) branches into one template.
+func appendAppLogKeysetPredicate(conditions []string, args []any, argIdx int, cursor appLogCursor, direction, sortDir string) ([]string, []any, int) {
+	op := ">"
+	if (direction == "after") == (sortDir == "DESC") {
+		op = "<"
+	}
+	conditions = append(conditions, fmt.Sprintf(
+		"(created_at %s $%d OR (created_at = $%d AND id %s $%d))",
+		op, argIdx, argIdx+1, op, argIdx+2,
+	))
+	args = append(args, cursor.CreatedAt, cursor.CreatedAt, cursor.ID)
+	argIdx += 3
+	return conditions, args, argIdx
+}
+
 // getAppLogsHistory queries app_logs from the database with filtering and pagination.
 func (h *Handler) getAppLogsHistory(w http.ResponseWriter, r *http.Request) {
 	if h.dbPool == nil {
@@ -525,43 +543,7 @@ func (h *Handler) GetAppLogsCursor(w http.ResponseWriter, r *http.Request) {
 
 	// Apply cursor keyset predicate
 	if cursorStr != "" {
-		if direction == "after" {
-			if sortDir == "DESC" {
-				// Scrolling older: (created_at, id) < cursor
-				conditions = append(conditions, fmt.Sprintf(
-					"(created_at < $%d OR (created_at = $%d AND id < $%d))",
-					argIdx, argIdx+1, argIdx+2,
-				))
-				args = append(args, cursor.CreatedAt, cursor.CreatedAt, cursor.ID)
-				argIdx += 3
-			} else {
-				// Asc mode, after = newer
-				conditions = append(conditions, fmt.Sprintf(
-					"(created_at > $%d OR (created_at = $%d AND id > $%d))",
-					argIdx, argIdx+1, argIdx+2,
-				))
-				args = append(args, cursor.CreatedAt, cursor.CreatedAt, cursor.ID)
-				argIdx += 3
-			}
-		} else { // before
-			if sortDir == "DESC" {
-				// Scrolling newer: (created_at, id) > cursor
-				conditions = append(conditions, fmt.Sprintf(
-					"(created_at > $%d OR (created_at = $%d AND id > $%d))",
-					argIdx, argIdx+1, argIdx+2,
-				))
-				args = append(args, cursor.CreatedAt, cursor.CreatedAt, cursor.ID)
-				argIdx += 3
-			} else {
-				// Asc mode, before = older
-				conditions = append(conditions, fmt.Sprintf(
-					"(created_at < $%d OR (created_at = $%d AND id < $%d))",
-					argIdx, argIdx+1, argIdx+2,
-				))
-				args = append(args, cursor.CreatedAt, cursor.CreatedAt, cursor.ID)
-				argIdx += 3
-			}
-		}
+		conditions, args, argIdx = appendAppLogKeysetPredicate(conditions, args, argIdx, cursor, direction, sortDir)
 	}
 
 	whereClause := ""

--- a/internal/api/applogs.go
+++ b/internal/api/applogs.go
@@ -297,6 +297,47 @@ func (h *Handler) getAppLogCounts(ctx context.Context) (map[string]int, map[stri
 	return levelCounts, sourceCounts
 }
 
+// appendAppLogFilters appends the shared level/source/search/from/to WHERE
+// conditions for app_logs (no table alias — app_logs is queried without joins).
+// It is the single source of truth for getAppLogsHistory and both
+// GetAppLogsCursor queries (data + total count).
+//
+// Date-range filters use created_at (DB insertion time), not timestamp (event
+// time), for consistency with the cursor endpoint's keyset pagination; app logs
+// are ingested in real-time so the two columns fall within the same filter window.
+func appendAppLogFilters(conditions []string, args []any, argIdx int, level, source, search, from, to string) ([]string, []any, int) {
+	if level != "" {
+		conditions = append(conditions, fmt.Sprintf("level = $%d", argIdx))
+		args = append(args, level)
+		argIdx++
+	}
+	if source != "" {
+		conditions = append(conditions, fmt.Sprintf("source = $%d", argIdx))
+		args = append(args, source)
+		argIdx++
+	}
+	if search != "" {
+		conditions = append(conditions, fmt.Sprintf("message ILIKE $%d", argIdx))
+		args = append(args, "%"+search+"%")
+		argIdx++
+	}
+	if from != "" {
+		if t, err := time.Parse(time.RFC3339, from); err == nil {
+			conditions = append(conditions, fmt.Sprintf("created_at >= $%d", argIdx))
+			args = append(args, t.UTC())
+			argIdx++
+		}
+	}
+	if to != "" {
+		if t, err := time.Parse(time.RFC3339, to); err == nil {
+			conditions = append(conditions, fmt.Sprintf("created_at <= $%d", argIdx))
+			args = append(args, t.UTC())
+			argIdx++
+		}
+	}
+	return conditions, args, argIdx
+}
+
 // getAppLogsHistory queries app_logs from the database with filtering and pagination.
 func (h *Handler) getAppLogsHistory(w http.ResponseWriter, r *http.Request) {
 	if h.dbPool == nil {
@@ -323,45 +364,8 @@ func (h *Handler) getAppLogsHistory(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Build WHERE clause
-	conditions := []string{}
-	args := []interface{}{}
-	argIdx := 1
-
-	if level := q.Get("level"); level != "" {
-		conditions = append(conditions, fmt.Sprintf("level = $%d", argIdx))
-		args = append(args, level)
-		argIdx++
-	}
-	if source := q.Get("source"); source != "" {
-		conditions = append(conditions, fmt.Sprintf("source = $%d", argIdx))
-		args = append(args, source)
-		argIdx++
-	}
-	if search := q.Get("search"); search != "" {
-		conditions = append(conditions, fmt.Sprintf("message ILIKE $%d", argIdx))
-		args = append(args, "%"+search+"%")
-		argIdx++
-	}
-	// Date range filters use created_at (DB insertion time), not timestamp (event time),
-	// for consistency with the cursor endpoint's keyset pagination on created_at.
-	// App logs are ingested in real-time via the ring buffer, so timestamp and
-	// created_at are typically within the same second. The date picker only provides
-	// day-level granularity (start/end of day), so the two columns will always fall
-	// within the same filter window in practice.
-	if from := q.Get("from"); from != "" {
-		if t, err := time.Parse(time.RFC3339, from); err == nil {
-			conditions = append(conditions, fmt.Sprintf("created_at >= $%d", argIdx))
-			args = append(args, t.UTC())
-			argIdx++
-		}
-	}
-	if to := q.Get("to"); to != "" {
-		if t, err := time.Parse(time.RFC3339, to); err == nil {
-			conditions = append(conditions, fmt.Sprintf("created_at <= $%d", argIdx))
-			args = append(args, t.UTC())
-			argIdx++
-		}
-	}
+	conditions, args, argIdx := appendAppLogFilters(nil, nil, 1,
+		q.Get("level"), q.Get("source"), q.Get("search"), q.Get("from"), q.Get("to"))
 
 	// Sort
 	// "time" maps to created_at for consistency with the cursor endpoint.
@@ -515,40 +519,9 @@ func (h *Handler) GetAppLogsCursor(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Build WHERE clause (same as getAppLogsHistory)
-	conditions := []string{}
-	args := []interface{}{}
-	argIdx := 1
-
-	if level := q.Get("level"); level != "" {
-		conditions = append(conditions, fmt.Sprintf("level = $%d", argIdx))
-		args = append(args, level)
-		argIdx++
-	}
-	if source := q.Get("source"); source != "" {
-		conditions = append(conditions, fmt.Sprintf("source = $%d", argIdx))
-		args = append(args, source)
-		argIdx++
-	}
-	if search := q.Get("search"); search != "" {
-		conditions = append(conditions, fmt.Sprintf("message ILIKE $%d", argIdx))
-		args = append(args, "%"+search+"%")
-		argIdx++
-	}
-	if from := q.Get("from"); from != "" {
-		if t, err := time.Parse(time.RFC3339, from); err == nil {
-			conditions = append(conditions, fmt.Sprintf("created_at >= $%d", argIdx))
-			args = append(args, t.UTC())
-			argIdx++
-		}
-	}
-	if to := q.Get("to"); to != "" {
-		if t, err := time.Parse(time.RFC3339, to); err == nil {
-			conditions = append(conditions, fmt.Sprintf("created_at <= $%d", argIdx))
-			args = append(args, t.UTC())
-			argIdx++
-		}
-	}
+	// Build WHERE clause (same filters as getAppLogsHistory)
+	conditions, args, argIdx := appendAppLogFilters(nil, nil, 1,
+		q.Get("level"), q.Get("source"), q.Get("search"), q.Get("from"), q.Get("to"))
 
 	// Apply cursor keyset predicate
 	if cursorStr != "" {
@@ -674,38 +647,9 @@ func (h *Handler) GetAppLogsCursor(w http.ResponseWriter, r *http.Request) {
 	// Get cached counts
 	levelCounts, sourceCounts := h.getAppLogCounts(ctx)
 
-	// Total count (with filters applied, but without cursor predicate)
-	totalCountArgs := []interface{}{}
-	totalCountArgIdx := 1
-	totalCountConditions := []string{}
-	if level := q.Get("level"); level != "" {
-		totalCountConditions = append(totalCountConditions, fmt.Sprintf("level = $%d", totalCountArgIdx))
-		totalCountArgs = append(totalCountArgs, level)
-		totalCountArgIdx++
-	}
-	if source := q.Get("source"); source != "" {
-		totalCountConditions = append(totalCountConditions, fmt.Sprintf("source = $%d", totalCountArgIdx))
-		totalCountArgs = append(totalCountArgs, source)
-		totalCountArgIdx++
-	}
-	if search := q.Get("search"); search != "" {
-		totalCountConditions = append(totalCountConditions, fmt.Sprintf("message ILIKE $%d", totalCountArgIdx))
-		totalCountArgs = append(totalCountArgs, "%"+search+"%")
-		totalCountArgIdx++
-	}
-	if from := q.Get("from"); from != "" {
-		if t, err := time.Parse(time.RFC3339, from); err == nil {
-			totalCountConditions = append(totalCountConditions, fmt.Sprintf("created_at >= $%d", totalCountArgIdx))
-			totalCountArgs = append(totalCountArgs, t.UTC())
-			totalCountArgIdx++
-		}
-	}
-	if to := q.Get("to"); to != "" {
-		if t, err := time.Parse(time.RFC3339, to); err == nil {
-			totalCountConditions = append(totalCountConditions, fmt.Sprintf("created_at <= $%d", totalCountArgIdx))
-			totalCountArgs = append(totalCountArgs, t.UTC())
-		}
-	}
+	// Total count (with filters applied, but without cursor predicate).
+	totalCountConditions, totalCountArgs, _ := appendAppLogFilters(nil, nil, 1,
+		q.Get("level"), q.Get("source"), q.Get("search"), q.Get("from"), q.Get("to"))
 
 	totalWhereClause := ""
 	if len(totalCountConditions) > 0 {

--- a/internal/api/applogs.go
+++ b/internal/api/applogs.go
@@ -356,6 +356,45 @@ func appendAppLogKeysetPredicate(conditions []string, args []any, argIdx int, cu
 	return conditions, args, argIdx
 }
 
+// paginateAppLogs applies has_after/has_before detection (using the fetched-one-
+// extra signal and cursor presence), trims to limit, and reverses the slice for
+// backward pagination (which fetched in inverted sort order). Mirror of paginate
+// for AppLogEntry.
+func paginateAppLogs(entries []AppLogEntry, direction string, limit int, hasCursor bool) ([]AppLogEntry, bool, bool) {
+	var hasAfter, hasBefore bool
+	switch direction {
+	case "after":
+		// Fetching older entries (scroll down or initial load).
+		if len(entries) > limit {
+			hasAfter = true
+			entries = entries[:limit]
+		}
+		// For an initial request (no cursor) we're at the newest — nothing before.
+		// For cursor requests, assume newer entries exist until a fetchBefore proves
+		// otherwise.
+		if hasCursor {
+			hasBefore = true
+		}
+	case "before":
+		// Fetching newer entries (scroll up).
+		if len(entries) > limit {
+			hasBefore = true
+			entries = entries[:limit]
+		}
+		// Items exist after the cursor by definition.
+		if hasCursor {
+			hasAfter = true
+		}
+	}
+
+	// Reverse for backward pagination: we fetched in inverted sort order to get the
+	// correct window, but must return in the user's requested sort order.
+	if direction == "before" {
+		slices.Reverse(entries)
+	}
+	return entries, hasAfter, hasBefore
+}
+
 // getAppLogsHistory queries app_logs from the database with filtering and pagination.
 func (h *Handler) getAppLogsHistory(w http.ResponseWriter, r *http.Request) {
 	if h.dbPool == nil {
@@ -594,37 +633,7 @@ func (h *Handler) GetAppLogsCursor(w http.ResponseWriter, r *http.Request) {
 		entries = append(entries, e)
 	}
 
-	// Determine has_after / has_before based on direction and fetched rows
-	var hasAfter, hasBefore bool
-	switch direction {
-	case "after":
-		// Fetching older entries (scroll down or initial load)
-		if len(entries) > limit {
-			hasAfter = true
-			entries = entries[:limit]
-		}
-		// For initial request (no cursor), we're at the newest — nothing before
-		// For cursor requests, assume newer entries exist until fetchBefore proves otherwise
-		if cursorStr != "" {
-			hasBefore = true
-		}
-	case "before":
-		// Fetching newer entries (scroll up)
-		if len(entries) > limit {
-			hasBefore = true
-			entries = entries[:limit]
-		}
-		// Items exist after the cursor by definition
-		if cursorStr != "" {
-			hasAfter = true
-		}
-	}
-
-	// Reverse entries for backward pagination: we fetched in inverted sort order
-	// to get the correct window, but must return in the user's requested sort order.
-	if direction == "before" {
-		slices.Reverse(entries)
-	}
+	entries, hasAfter, hasBefore := paginateAppLogs(entries, direction, limit, cursorStr != "")
 
 	// Get cached counts
 	levelCounts, sourceCounts := h.getAppLogCounts(ctx)

--- a/internal/api/applogs_golden_test.go
+++ b/internal/api/applogs_golden_test.go
@@ -23,9 +23,6 @@ import (
 // Six rows are seeded under a unique source (isolated from any other data):
 // index 0 is newest .. index 5 oldest; rows 0–2 are "info", rows 3–5 "error".
 func TestGetAppLogsCursor_Golden(t *testing.T) {
-	if apiTestDBURL == "" {
-		t.Skip("apiTestDBURL not set, skipping integration test")
-	}
 	h, r := newTestHandlerWithRouter(t)
 	pool := h.Pool().Pool()
 	ctx := context.Background()

--- a/internal/api/applogs_golden_test.go
+++ b/internal/api/applogs_golden_test.go
@@ -1,0 +1,114 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// TestGetAppLogsCursor_Golden pins the full AppLogsCursorResponse over a
+// hand-controlled dataset: default-page ordering + total, a level filter (with
+// total parity), and forward and backward cursor pages (the backward case
+// exercises the fetch-inverted + slice-reverse path). It is the safety net for
+// the app-log helper extraction — appendAppLogFilters, appendAppLogKeysetPredicate,
+// and paginateAppLogs must not change any of these outcomes.
+//
+// Six rows are seeded under a unique source (isolated from any other data):
+// index 0 is newest .. index 5 oldest; rows 0–2 are "info", rows 3–5 "error".
+func TestGetAppLogsCursor_Golden(t *testing.T) {
+	if apiTestDBURL == "" {
+		t.Skip("apiTestDBURL not set, skipping integration test")
+	}
+	h, r := newTestHandlerWithRouter(t)
+	pool := h.Pool().Pool()
+	ctx := context.Background()
+
+	source := "goldsrc-" + uuid.New().String()[:8]
+	ids := make([]string, 6) // newest (0) -> oldest (5)
+	for i := 0; i < 6; i++ {
+		id := uuid.New().String()
+		ids[i] = id
+		level := "info"
+		if i >= 3 {
+			level = "error"
+		}
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO app_logs (id, timestamp, level, source, message, created_at)
+			 VALUES ($1, NOW() - ($6 * INTERVAL '1 minute'), $2, $3, $4, NOW() - ($5 * INTERVAL '1 minute'))`,
+			id, level, source, "golden message", i, i); err != nil {
+			t.Fatalf("insert row %d: %v", i, err)
+		}
+	}
+
+	doReq := func(q string) AppLogsCursorResponse {
+		t.Helper()
+		req := httptest.NewRequest("GET", "/logs/app/cursor?"+q, http.NoBody)
+		req.Header.Set("Authorization", "Bearer test-admin-token")
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("GET ?%s: status %d: %s", q, w.Code, w.Body.String())
+		}
+		var resp AppLogsCursorResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode ?%s: %v", q, err)
+		}
+		return resp
+	}
+	idsOf := func(resp AppLogsCursorResponse) []string {
+		out := make([]string, len(resp.Entries))
+		for i, e := range resp.Entries {
+			out[i] = e.ID
+		}
+		return out
+	}
+	cursorFrom := func(e AppLogEntry) string {
+		ts, err := time.Parse(time.RFC3339Nano, e.CreatedAt)
+		if err != nil {
+			t.Fatalf("parse created_at %q: %v", e.CreatedAt, err)
+		}
+		c := appLogCursor{CreatedAt: ts, ID: e.ID}
+		return url.QueryEscape(c.encode())
+	}
+
+	// 1) Default page (desc), filtered to our source: all 6 newest->oldest.
+	def := doReq("source=" + source)
+	if got := idsOf(def); !slices.Equal(got, ids) {
+		t.Errorf("default page ids = %v, want %v", got, ids)
+	}
+	if def.Total != 6 {
+		t.Errorf("default total = %d, want 6", def.Total)
+	}
+	if def.HasBefore {
+		t.Error("default page: HasBefore = true, want false")
+	}
+
+	// 2) level=error -> rows 3,4,5 only; count honors the same filter.
+	errOnly := doReq("source=" + source + "&level=error")
+	if got := idsOf(errOnly); !slices.Equal(got, ids[3:]) {
+		t.Errorf("level=error ids = %v, want %v", got, ids[3:])
+	}
+	if errOnly.Total != 3 {
+		t.Errorf("level=error total = %d, want 3", errOnly.Total)
+	}
+
+	// 3) Forward (after) from entry[1] -> strictly older window ids[2:].
+	after := doReq("source=" + source + "&direction=after&sort_dir=desc&cursor=" + cursorFrom(def.Entries[1]))
+	if got := idsOf(after); !slices.Equal(got, ids[2:]) {
+		t.Errorf("after-cursor ids = %v, want %v", got, ids[2:])
+	}
+
+	// 4) Backward (before) from entry[3] -> newer window ids[0:3] in desc order
+	//    (fetched ascending then reversed).
+	before := doReq("source=" + source + "&direction=before&sort_dir=desc&cursor=" + cursorFrom(def.Entries[3]))
+	if got := idsOf(before); !slices.Equal(got, ids[0:3]) {
+		t.Errorf("before-cursor ids = %v, want %v", got, ids[0:3])
+	}
+}

--- a/internal/api/logs.go
+++ b/internal/api/logs.go
@@ -219,7 +219,7 @@ func (h *Handler) ListLogsCursor(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// logEntrySelectColumns is the shared 30-column request_logs projection plus the
+// logEntrySelectColumns is the shared 34-column request_logs projection plus the
 // FROM/JOIN/WHERE 1=1 tail. The cursor list prefixes it with "SELECT "; the
 // offset list (ListLogs) prefixes it with the windowed total count. Its column
 // order matches logEntryScanDests exactly.
@@ -330,7 +330,7 @@ func paginate(entries []LogEntry, p logListParams) ([]LogEntry, bool, bool) {
 	return entries, hasAfter, hasBefore
 }
 
-// logEntryScanDests returns the ordered Scan() targets for the shared 30-column
+// logEntryScanDests returns the ordered Scan() targets for the shared 34-column
 // request_logs projection (logEntrySelectColumns). The cursor list scans these
 // directly; the offset list (ListLogs) prepends its windowed total count.
 func logEntryScanDests(entry *LogEntry) []any {
@@ -353,7 +353,7 @@ func logEntryScanDests(entry *LogEntry) []any {
 	}
 }
 
-// scanLogEntry scans one request_logs row (the 30-column projection shared by
+// scanLogEntry scans one request_logs row (the 34-column projection shared by
 // ListLogsCursor and ListLogs) into a LogEntry.
 func scanLogEntry(rows pgx.Rows) (LogEntry, error) {
 	var entry LogEntry

--- a/internal/api/logs.go
+++ b/internal/api/logs.go
@@ -244,49 +244,8 @@ func (h *Handler) ListLogsCursor(w http.ResponseWriter, r *http.Request) {
 	args := []interface{}{}
 	argIndex := 1
 
-	// Apply filters (same as ListLogs)
-	if modelID != "" {
-		query += " AND rl.model_id ILIKE $" + util.IntToStr(argIndex)
-		args = append(args, "%"+modelID+"%")
-		argIndex++
-	}
-	if providerID != "" {
-		providerUUID, err := uuid.Parse(providerID)
-		if err == nil {
-			query += " AND rl.provider_id = $" + util.IntToStr(argIndex)
-			args = append(args, providerUUID)
-			argIndex++
-		}
-	}
-	if statusCodeStr != "" {
-		if statusCodeStr == "4xx" {
-			query += " AND rl.status_code >= 400 AND rl.status_code < 500"
-		} else if statusCodeStr == "5xx" {
-			query += " AND rl.status_code >= 500"
-		} else if statusCode, err := strconv.Atoi(statusCodeStr); err == nil && statusCode >= 0 {
-			if statusCode == 0 {
-				query += " AND (rl.status_code = 0 OR rl.status_code IS NULL)"
-			} else {
-				query += " AND rl.status_code = $" + util.IntToStr(argIndex)
-				args = append(args, statusCode)
-				argIndex++
-			}
-		}
-	}
-	if fromDate != "" {
-		if parsedFrom, err := time.Parse(time.RFC3339, fromDate); err == nil {
-			query += " AND rl.created_at >= $" + util.IntToStr(argIndex)
-			args = append(args, parsedFrom)
-			argIndex++
-		}
-	}
-	if toDate != "" {
-		if parsedTo, err := time.Parse(time.RFC3339, toDate); err == nil {
-			query += " AND rl.created_at <= $" + util.IntToStr(argIndex)
-			args = append(args, parsedTo)
-			argIndex++
-		}
-	}
+	// Apply filters (shared with the count query below and with ListLogs).
+	query, args, argIndex = appendLogFilters(query, args, argIndex, modelID, providerID, statusCodeStr, fromDate, toDate)
 
 	// Apply cursor keyset predicate
 	// For "time desc" (default): "after" means older (created_at < cursor OR same ts but id < cursor)
@@ -398,52 +357,12 @@ func (h *Handler) ListLogsCursor(w http.ResponseWriter, r *http.Request) {
 		slices.Reverse(entries)
 	}
 
-	// Get total count for display (separate lightweight query)
+	// Get total count for display (separate lightweight query), reusing the
+	// exact same filter construction as the data query above.
 	var total int
-	countArgs := []interface{}{}
-	countArgIdx := 1
 	countQuery := "SELECT COUNT(*) FROM request_logs rl WHERE 1=1"
-	if modelID != "" {
-		countQuery += " AND rl.model_id ILIKE $" + util.IntToStr(countArgIdx)
-		countArgs = append(countArgs, "%"+modelID+"%")
-		countArgIdx++
-	}
-	if providerID != "" {
-		providerUUID, err := uuid.Parse(providerID)
-		if err == nil {
-			countQuery += " AND rl.provider_id = $" + util.IntToStr(countArgIdx)
-			countArgs = append(countArgs, providerUUID)
-			countArgIdx++
-		}
-	}
-	if statusCodeStr != "" {
-		if statusCodeStr == "4xx" {
-			countQuery += " AND rl.status_code >= 400 AND rl.status_code < 500"
-		} else if statusCodeStr == "5xx" {
-			countQuery += " AND rl.status_code >= 500"
-		} else if statusCode, err := strconv.Atoi(statusCodeStr); err == nil {
-			if statusCode == 0 {
-				countQuery += " AND (rl.status_code = 0 OR rl.status_code IS NULL)"
-			} else {
-				countQuery += " AND rl.status_code = $" + util.IntToStr(countArgIdx)
-				countArgs = append(countArgs, statusCode)
-				countArgIdx++
-			}
-		}
-	}
-	if fromDate != "" {
-		if parsedFrom, err := time.Parse(time.RFC3339, fromDate); err == nil {
-			countQuery += " AND rl.created_at >= $" + util.IntToStr(countArgIdx)
-			countArgs = append(countArgs, parsedFrom)
-			countArgIdx++
-		}
-	}
-	if toDate != "" {
-		if parsedTo, err := time.Parse(time.RFC3339, toDate); err == nil {
-			countQuery += " AND rl.created_at <= $" + util.IntToStr(countArgIdx)
-			countArgs = append(countArgs, parsedTo)
-		}
-	}
+	countArgs := []interface{}{}
+	countQuery, countArgs, _ = appendLogFilters(countQuery, countArgs, 1, modelID, providerID, statusCodeStr, fromDate, toDate)
 	_ = h.dbPool.Pool().QueryRow(ctx, countQuery, countArgs...).Scan(&total)
 
 	response := LogsCursorResponse{
@@ -481,6 +400,59 @@ func scanLogEntry(rows pgx.Rows) (LogEntry, error) {
 		&entry.ResolvedModelID,
 	)
 	return entry, err
+}
+
+// appendLogFilters appends the shared modelID/providerID/statusCode/from/to
+// WHERE fragments, returning the extended query, args, and next placeholder
+// index. The single source of truth used by both the data and count queries
+// in ListLogsCursor (previously two copy-pasted blocks that had drifted: the
+// count copy lacked the `statusCode >= 0` guard the data copy has; both now use
+// the guard, so an invalid negative status_code is uniformly ignored — a
+// behaviour-neutral fix since status codes are always >= 0).
+func appendLogFilters(query string, args []any, argIndex int, modelID, providerID, statusCodeStr, fromDate, toDate string) (string, []any, int) {
+	if modelID != "" {
+		query += " AND rl.model_id ILIKE $" + util.IntToStr(argIndex)
+		args = append(args, "%"+modelID+"%")
+		argIndex++
+	}
+	if providerID != "" {
+		providerUUID, err := uuid.Parse(providerID)
+		if err == nil {
+			query += " AND rl.provider_id = $" + util.IntToStr(argIndex)
+			args = append(args, providerUUID)
+			argIndex++
+		}
+	}
+	if statusCodeStr != "" {
+		if statusCodeStr == "4xx" {
+			query += " AND rl.status_code >= 400 AND rl.status_code < 500"
+		} else if statusCodeStr == "5xx" {
+			query += " AND rl.status_code >= 500"
+		} else if statusCode, err := strconv.Atoi(statusCodeStr); err == nil && statusCode >= 0 {
+			if statusCode == 0 {
+				query += " AND (rl.status_code = 0 OR rl.status_code IS NULL)"
+			} else {
+				query += " AND rl.status_code = $" + util.IntToStr(argIndex)
+				args = append(args, statusCode)
+				argIndex++
+			}
+		}
+	}
+	if fromDate != "" {
+		if parsedFrom, err := time.Parse(time.RFC3339, fromDate); err == nil {
+			query += " AND rl.created_at >= $" + util.IntToStr(argIndex)
+			args = append(args, parsedFrom)
+			argIndex++
+		}
+	}
+	if toDate != "" {
+		if parsedTo, err := time.Parse(time.RFC3339, toDate); err == nil {
+			query += " AND rl.created_at <= $" + util.IntToStr(argIndex)
+			args = append(args, parsedTo)
+			argIndex++
+		}
+	}
+	return query, args, argIndex
 }
 
 // logCursor is the keyset cursor for cursor-based log pagination.

--- a/internal/api/logs.go
+++ b/internal/api/logs.go
@@ -611,59 +611,9 @@ func (h *Handler) ListLogs(w http.ResponseWriter, r *http.Request) {
 
 	query := "SELECT COUNT(*) OVER() AS total_count, " + logEntrySelectColumns
 
-	args := []interface{}{}
+	args := []any{}
 	argIndex := 1
-
-	if modelID != "" {
-		query += " AND rl.model_id ILIKE $" + util.IntToStr(argIndex)
-		args = append(args, "%"+modelID+"%")
-		argIndex++
-	}
-
-	if providerID != "" {
-		providerUUID, err := uuid.Parse(providerID)
-		if err == nil {
-			query += " AND rl.provider_id = $" + util.IntToStr(argIndex)
-			args = append(args, providerUUID)
-			argIndex++
-		}
-	}
-
-	if statusCodeStr != "" {
-		if statusCodeStr == "4xx" {
-			query += " AND rl.status_code >= 400 AND rl.status_code < 500"
-		} else if statusCodeStr == "5xx" {
-			query += " AND rl.status_code >= 500"
-		} else if statusCode, err := strconv.Atoi(statusCodeStr); err == nil && statusCode >= 0 {
-			if statusCode == 0 {
-				// COALESCE presents NULL status_code as 0 to the frontend,
-				// so "0 No Response" must match both actual 0 and NULL.
-				query += " AND (rl.status_code = 0 OR rl.status_code IS NULL)"
-			} else {
-				query += " AND rl.status_code = $" + util.IntToStr(argIndex)
-				args = append(args, statusCode)
-				argIndex++
-			}
-		}
-	}
-
-	if fromDate != "" {
-		parsedFrom, err := time.Parse(time.RFC3339, fromDate)
-		if err == nil {
-			query += " AND rl.created_at >= $" + util.IntToStr(argIndex)
-			args = append(args, parsedFrom)
-			argIndex++
-		}
-	}
-
-	if toDate != "" {
-		parsedTo, err := time.Parse(time.RFC3339, toDate)
-		if err == nil {
-			query += " AND rl.created_at <= $" + util.IntToStr(argIndex)
-			args = append(args, parsedTo)
-			argIndex++
-		}
-	}
+	query, args, argIndex = appendLogFilters(query, args, argIndex, modelID, providerID, statusCodeStr, fromDate, toDate)
 
 	sd := sortColumns[sortBy]
 	orderClause := " ORDER BY "

--- a/internal/api/logs.go
+++ b/internal/api/logs.go
@@ -357,24 +357,7 @@ func (h *Handler) ListLogsCursor(w http.ResponseWriter, r *http.Request) {
 	// not flow into make() capacity even after clamping).
 	entries := make([]LogEntry, 0, 201) // limit+1 for has_more detection
 	for rows.Next() {
-		var entry LogEntry
-		err := rows.Scan(
-			&entry.ID, &entry.ProviderID, &entry.ProviderName, &entry.ModelID,
-			&entry.RequestHash, &entry.StatusCode, &entry.LatencyMs, &entry.DurationMs,
-			&entry.TTFTMs, &entry.ProxyOverheadMs,
-			&entry.ParseMs, &entry.FailoverLookupMs, &entry.ModelLookupMs, &entry.ProviderLookupMs, &entry.KeyDecryptMs,
-			&entry.DialMs, &entry.SettingsReadMs,
-			&entry.CacheHits,
-			&entry.TokensPerSecond,
-			&entry.TokensPrompt, &entry.TokensCompletion, &entry.TokensCompletionReasoning,
-			&entry.TokensPromptCacheHit, &entry.TokensPromptCacheMiss,
-			&entry.Streaming,
-			&entry.VirtualKeyName, &entry.VirtualKeyID, &entry.VirtualKeyDeleted,
-			&entry.ErrorMessage,
-			&entry.FailoverAttempt, &entry.State, &entry.CreatedAt,
-			&entry.ResponseHeaderMs,
-			&entry.ResolvedModelID,
-		)
+		entry, err := scanLogEntry(rows)
 		if err != nil {
 			debuglog.Error("logs-cursor: row scan failed", "error", err)
 			continue
@@ -474,6 +457,30 @@ func (h *Handler) ListLogsCursor(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewEncoder(w).Encode(response); err != nil {
 		respondError(w, "failed to encode response", err, http.StatusInternalServerError)
 	}
+}
+
+// scanLogEntry scans one request_logs row (the 30-column projection shared by
+// ListLogsCursor and ListLogs) into a LogEntry.
+func scanLogEntry(rows pgx.Rows) (LogEntry, error) {
+	var entry LogEntry
+	err := rows.Scan(
+		&entry.ID, &entry.ProviderID, &entry.ProviderName, &entry.ModelID,
+		&entry.RequestHash, &entry.StatusCode, &entry.LatencyMs, &entry.DurationMs,
+		&entry.TTFTMs, &entry.ProxyOverheadMs,
+		&entry.ParseMs, &entry.FailoverLookupMs, &entry.ModelLookupMs, &entry.ProviderLookupMs, &entry.KeyDecryptMs,
+		&entry.DialMs, &entry.SettingsReadMs,
+		&entry.CacheHits,
+		&entry.TokensPerSecond,
+		&entry.TokensPrompt, &entry.TokensCompletion, &entry.TokensCompletionReasoning,
+		&entry.TokensPromptCacheHit, &entry.TokensPromptCacheMiss,
+		&entry.Streaming,
+		&entry.VirtualKeyName, &entry.VirtualKeyID, &entry.VirtualKeyDeleted,
+		&entry.ErrorMessage,
+		&entry.FailoverAttempt, &entry.State, &entry.CreatedAt,
+		&entry.ResponseHeaderMs,
+		&entry.ResolvedModelID,
+	)
+	return entry, err
 }
 
 // logCursor is the keyset cursor for cursor-based log pagination.

--- a/internal/api/logs.go
+++ b/internal/api/logs.go
@@ -252,39 +252,7 @@ func (h *Handler) ListLogsCursor(w http.ResponseWriter, r *http.Request) {
 	//                              "before" means newer (created_at > cursor OR same ts but id > cursor)
 	// For "time asc": the directions invert.
 	if cursorStr != "" {
-		if direction == "after" {
-			if sortDir == "desc" {
-				// Scrolling older: (created_at, id) < (cursor.CreatedAt, cursor.ID)
-				query += " AND (rl.created_at < $" + util.IntToStr(argIndex) +
-					" OR (rl.created_at = $" + util.IntToStr(argIndex+1) +
-					" AND rl.id < $" + util.IntToStr(argIndex+2) + "))"
-				args = append(args, cursor.CreatedAt, cursor.CreatedAt, cursor.ID)
-				argIndex += 3
-			} else {
-				// Scrolling newer in asc mode: (created_at, id) > cursor
-				query += " AND (rl.created_at > $" + util.IntToStr(argIndex) +
-					" OR (rl.created_at = $" + util.IntToStr(argIndex+1) +
-					" AND rl.id > $" + util.IntToStr(argIndex+2) + "))"
-				args = append(args, cursor.CreatedAt, cursor.CreatedAt, cursor.ID)
-				argIndex += 3
-			}
-		} else { // before
-			if sortDir == "desc" {
-				// Scrolling newer: (created_at, id) > cursor
-				query += " AND (rl.created_at > $" + util.IntToStr(argIndex) +
-					" OR (rl.created_at = $" + util.IntToStr(argIndex+1) +
-					" AND rl.id > $" + util.IntToStr(argIndex+2) + "))"
-				args = append(args, cursor.CreatedAt, cursor.CreatedAt, cursor.ID)
-				argIndex += 3
-			} else {
-				// Scrolling older in asc mode: (created_at, id) < cursor
-				query += " AND (rl.created_at < $" + util.IntToStr(argIndex) +
-					" OR (rl.created_at = $" + util.IntToStr(argIndex+1) +
-					" AND rl.id < $" + util.IntToStr(argIndex+2) + "))"
-				args = append(args, cursor.CreatedAt, cursor.CreatedAt, cursor.ID)
-				argIndex += 3
-			}
-		}
+		query, args, argIndex = appendKeysetPredicate(query, args, argIndex, cursor, direction, sortDir)
 	}
 
 	// ORDER BY + LIMIT (fetch limit+1 to detect has_more)
@@ -452,6 +420,24 @@ func appendLogFilters(query string, args []any, argIndex int, modelID, providerI
 			argIndex++
 		}
 	}
+	return query, args, argIndex
+}
+
+// appendKeysetPredicate appends the (created_at, id) keyset comparison relative
+// to the cursor. The comparison operator is "<" when scrolling toward older
+// rows — (after, desc) or (before, asc) — and ">" otherwise, collapsing the
+// four direction/sort branches into one template. SQL is byte-identical to the
+// per-branch form.
+func appendKeysetPredicate(query string, args []any, argIndex int, cursor logCursor, direction, sortDir string) (string, []any, int) {
+	op := ">"
+	if (direction == "after") == (sortDir == "desc") {
+		op = "<"
+	}
+	query += " AND (rl.created_at " + op + " $" + util.IntToStr(argIndex) +
+		" OR (rl.created_at = $" + util.IntToStr(argIndex+1) +
+		" AND rl.id " + op + " $" + util.IntToStr(argIndex+2) + "))"
+	args = append(args, cursor.CreatedAt, cursor.CreatedAt, cursor.ID)
+	argIndex += 3
 	return query, args, argIndex
 }
 

--- a/internal/api/logs.go
+++ b/internal/api/logs.go
@@ -325,11 +325,11 @@ func paginate(entries []LogEntry, p logListParams) ([]LogEntry, bool, bool) {
 	return entries, hasAfter, hasBefore
 }
 
-// scanLogEntry scans one request_logs row (the 30-column projection shared by
-// ListLogsCursor and ListLogs) into a LogEntry.
-func scanLogEntry(rows pgx.Rows) (LogEntry, error) {
-	var entry LogEntry
-	err := rows.Scan(
+// logEntryScanDests returns the ordered Scan() targets for the shared 30-column
+// request_logs projection (logEntrySelectColumns). The cursor list scans these
+// directly; the offset list (ListLogs) prepends its windowed total count.
+func logEntryScanDests(entry *LogEntry) []any {
+	return []any{
 		&entry.ID, &entry.ProviderID, &entry.ProviderName, &entry.ModelID,
 		&entry.RequestHash, &entry.StatusCode, &entry.LatencyMs, &entry.DurationMs,
 		&entry.TTFTMs, &entry.ProxyOverheadMs,
@@ -345,7 +345,14 @@ func scanLogEntry(rows pgx.Rows) (LogEntry, error) {
 		&entry.FailoverAttempt, &entry.State, &entry.CreatedAt,
 		&entry.ResponseHeaderMs,
 		&entry.ResolvedModelID,
-	)
+	}
+}
+
+// scanLogEntry scans one request_logs row (the 30-column projection shared by
+// ListLogsCursor and ListLogs) into a LogEntry.
+func scanLogEntry(rows pgx.Rows) (LogEntry, error) {
+	var entry LogEntry
+	err := rows.Scan(logEntryScanDests(&entry)...)
 	return entry, err
 }
 
@@ -712,24 +719,8 @@ COALESCE(rl.streaming, false), COALESCE(rl.virtual_key_name, ''), COALESCE(rl.vi
 	for rows.Next() {
 		var entry LogEntry
 		var totalCount int
-		err := rows.Scan(
-			&totalCount,
-			&entry.ID, &entry.ProviderID, &entry.ProviderName, &entry.ModelID,
-			&entry.RequestHash, &entry.StatusCode, &entry.LatencyMs, &entry.DurationMs,
-			&entry.TTFTMs, &entry.ProxyOverheadMs,
-			&entry.ParseMs, &entry.FailoverLookupMs, &entry.ModelLookupMs, &entry.ProviderLookupMs, &entry.KeyDecryptMs,
-			&entry.DialMs, &entry.SettingsReadMs,
-			&entry.CacheHits,
-			&entry.TokensPerSecond,
-			&entry.TokensPrompt, &entry.TokensCompletion, &entry.TokensCompletionReasoning,
-			&entry.TokensPromptCacheHit, &entry.TokensPromptCacheMiss,
-			&entry.Streaming,
-			&entry.VirtualKeyName, &entry.VirtualKeyID, &entry.VirtualKeyDeleted,
-			&entry.ErrorMessage,
-			&entry.FailoverAttempt, &entry.State, &entry.CreatedAt,
-			&entry.ResponseHeaderMs,
-			&entry.ResolvedModelID,
-		)
+		// Windowed COUNT(*) OVER() comes first; the rest is the shared projection.
+		err := rows.Scan(append([]any{&totalCount}, logEntryScanDests(&entry)...)...)
 		if err != nil {
 			debuglog.Error("logs: row scan failed", "error", err)
 			continue

--- a/internal/api/logs.go
+++ b/internal/api/logs.go
@@ -219,13 +219,11 @@ func (h *Handler) ListLogsCursor(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// buildLogListQuery assembles the cursor data query: the column projection, the
-// shared filters, the keyset predicate (when a cursor is present), and the
-// ORDER BY + LIMIT — fetching limit+1 to detect has_more, with the sort
-// inverted for backward pagination so LIMIT picks from the correct end.
-func buildLogListQuery(p logListParams) (string, []any) {
-	query := `
-        SELECT rl.id, COALESCE(rl.provider_id::text, ''),
+// logEntrySelectColumns is the shared 30-column request_logs projection plus the
+// FROM/JOIN/WHERE 1=1 tail. The cursor list prefixes it with "SELECT "; the
+// offset list (ListLogs) prefixes it with the windowed total count. Its column
+// order matches logEntryScanDests exactly.
+const logEntrySelectColumns = `rl.id, COALESCE(rl.provider_id::text, ''),
             CASE
                 WHEN rl.provider_id IS NULL THEN ''
                 WHEN p.name IS NOT NULL THEN p.name
@@ -255,6 +253,13 @@ func buildLogListQuery(p logListParams) (string, []any) {
         LEFT JOIN virtual_keys vk ON rl.virtual_key_id = vk.id
         WHERE 1=1
     `
+
+// buildLogListQuery assembles the cursor data query: the column projection, the
+// shared filters, the keyset predicate (when a cursor is present), and the
+// ORDER BY + LIMIT — fetching limit+1 to detect has_more, with the sort
+// inverted for backward pagination so LIMIT picks from the correct end.
+func buildLogListQuery(p logListParams) (string, []any) {
+	query := "SELECT " + logEntrySelectColumns
 
 	args := []any{}
 	argIndex := 1
@@ -604,38 +609,7 @@ func (h *Handler) ListLogs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	query := `
-        SELECT COUNT(*) OVER() AS total_count,
-               rl.id, COALESCE(rl.provider_id::text, ''),
-               CASE
-                   WHEN rl.provider_id IS NULL THEN ''
-                   WHEN p.name IS NOT NULL THEN p.name
-                   ELSE 'Deleted'
-               END,
-               rl.model_id,
-               COALESCE(rl.request_hash, ''), COALESCE(rl.status_code, 0),
-               COALESCE(rl.latency_ms, 0), COALESCE(rl.duration_ms, 0),
-               COALESCE(rl.ttft_ms, 0), COALESCE(rl.proxy_overhead_ms, 0),
-               COALESCE(rl.parse_ms, 0), COALESCE(rl.failover_lookup_ms, 0), COALESCE(rl.model_lookup_ms, 0), COALESCE(rl.provider_lookup_ms, 0), COALESCE(rl.key_decrypt_ms, 0),
-                COALESCE(rl.dial_ms, 0), COALESCE(rl.settings_read_ms, 0),
-                rl.cache_hits,
-                COALESCE(rl.tokens_per_second, 0),
-                COALESCE(rl.tokens_prompt, 0), COALESCE(rl.tokens_completion, 0),
-                COALESCE(rl.tokens_completion_reasoning, 0),
-                COALESCE(rl.tokens_prompt_cache_hit, 0), COALESCE(rl.tokens_prompt_cache_miss, 0),
-COALESCE(rl.streaming, false), COALESCE(rl.virtual_key_name, ''), COALESCE(rl.virtual_key_id::text, ''),
-                CASE
-                    WHEN rl.virtual_key_id IS NULL OR rl.virtual_key_id::text = '' THEN false
-                    WHEN vk.id IS NULL THEN true
-                    ELSE false
-                END AS virtual_key_deleted,
-            COALESCE(rl.error_message, ''), COALESCE(rl.failover_attempt, 0), COALESCE(rl.state, 'completed'), rl.created_at,
-            COALESCE(rl.response_header_ms, 0),
-            COALESCE(rl.resolved_model_id, '')
-        FROM request_logs rl LEFT JOIN providers p ON rl.provider_id = p.id
-        LEFT JOIN virtual_keys vk ON rl.virtual_key_id = vk.id
-        WHERE 1=1
-    `
+	query := "SELECT COUNT(*) OVER() AS total_count, " + logEntrySelectColumns
 
 	args := []interface{}{}
 	argIndex := 1

--- a/internal/api/logs.go
+++ b/internal/api/logs.go
@@ -177,21 +177,53 @@ func (h *Handler) ListLogsCursor(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	limit := p.limit
-	cursorStr := p.cursorStr
-	cursor := p.cursor
-	direction := p.direction
-	sortDir := p.sortDir
-	modelID := p.modelID
-	providerID := p.providerID
-	statusCodeStr := p.statusCode
-	fromDate := p.fromDate
-	toDate := p.toDate
 
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 	defer cancel()
 
-	// Build the base SELECT (same columns as ListLogs minus COUNT(*) OVER())
+	query, args := buildLogListQuery(p)
+
+	rows, err := h.dbPool.Pool().Query(ctx, query, args...)
+	if err != nil {
+		debuglog.Error("logs-cursor: failed to query logs", "error", err)
+		respondError(w, "failed to query logs", err, http.StatusInternalServerError)
+		return
+	}
+	defer rows.Close()
+
+	// limit is clamped to [1, 200] above; prealloc with the hard upper bound
+	// to satisfy CodeQL's uncontrolled-allocation-size check (user input must
+	// not flow into make() capacity even after clamping).
+	entries := make([]LogEntry, 0, 201) // limit+1 for has_more detection
+	for rows.Next() {
+		entry, err := scanLogEntry(rows)
+		if err != nil {
+			debuglog.Error("logs-cursor: row scan failed", "error", err)
+			continue
+		}
+		entries = append(entries, entry)
+	}
+
+	entries, hasAfter, hasBefore := paginate(entries, p)
+
+	response := LogsCursorResponse{
+		Entries:   entries,
+		Total:     h.countLogs(ctx, p),
+		HasBefore: hasBefore,
+		HasAfter:  hasAfter,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		respondError(w, "failed to encode response", err, http.StatusInternalServerError)
+	}
+}
+
+// buildLogListQuery assembles the cursor data query: the column projection, the
+// shared filters, the keyset predicate (when a cursor is present), and the
+// ORDER BY + LIMIT — fetching limit+1 to detect has_more, with the sort
+// inverted for backward pagination so LIMIT picks from the correct end.
+func buildLogListQuery(p logListParams) (string, []any) {
 	query := `
         SELECT rl.id, COALESCE(rl.provider_id::text, ''),
             CASE
@@ -224,26 +256,15 @@ func (h *Handler) ListLogsCursor(w http.ResponseWriter, r *http.Request) {
         WHERE 1=1
     `
 
-	args := []interface{}{}
+	args := []any{}
 	argIndex := 1
-
-	// Apply filters (shared with the count query below and with ListLogs).
-	query, args, argIndex = appendLogFilters(query, args, argIndex, modelID, providerID, statusCodeStr, fromDate, toDate)
-
-	// Apply cursor keyset predicate
-	// For "time desc" (default): "after" means older (created_at < cursor OR same ts but id < cursor)
-	//                              "before" means newer (created_at > cursor OR same ts but id > cursor)
-	// For "time asc": the directions invert.
-	if cursorStr != "" {
-		query, args, argIndex = appendKeysetPredicate(query, args, argIndex, cursor, direction, sortDir)
+	query, args, argIndex = appendLogFilters(query, args, argIndex, p.modelID, p.providerID, p.statusCode, p.fromDate, p.toDate)
+	if p.cursorStr != "" {
+		query, args, argIndex = appendKeysetPredicate(query, args, argIndex, p.cursor, p.direction, p.sortDir)
 	}
 
-	// ORDER BY + LIMIT (fetch limit+1 to detect has_more)
-	// When paginating backward, invert the sort direction so LIMIT picks from
-	// the correct end of the result set, then reverse the slice before returning.
-	fetchLimit := limit + 1
-	fetchSortDir := sortDir
-	if direction == "before" {
+	fetchSortDir := p.sortDir
+	if p.direction == "before" {
 		if fetchSortDir == "desc" {
 			fetchSortDir = "asc"
 		} else {
@@ -252,81 +273,56 @@ func (h *Handler) ListLogsCursor(w http.ResponseWriter, r *http.Request) {
 	}
 	query += " ORDER BY rl.created_at " + fetchSortDir + ", rl.id " + fetchSortDir
 	query += " LIMIT $" + util.IntToStr(argIndex)
-	args = append(args, fetchLimit)
+	args = append(args, p.limit+1)
+	return query, args
+}
 
-	rows, err := h.dbPool.Pool().Query(ctx, query, args...)
-	if err != nil {
-		debuglog.Error("logs-cursor: failed to query logs", "error", err)
-		respondError(w, "failed to query logs", err, http.StatusInternalServerError)
-		return
-	}
-	defer rows.Close()
+// countLogs returns the total row count for the same filters as the data query.
+// Best-effort: returns 0 on error (the cursor response is still useful without
+// an accurate total).
+func (h *Handler) countLogs(ctx context.Context, p logListParams) int {
+	query := "SELECT COUNT(*) FROM request_logs rl WHERE 1=1"
+	args := []any{}
+	query, args, _ = appendLogFilters(query, args, 1, p.modelID, p.providerID, p.statusCode, p.fromDate, p.toDate)
+	var total int
+	_ = h.dbPool.Pool().QueryRow(ctx, query, args...).Scan(&total)
+	return total
+}
 
-	// limit is clamped to [1, 200] above; prealloc with the hard upper bound
-	// to satisfy CodeQL's uncontrolled-allocation-size check (user input must
-	// not flow into make() capacity even after clamping).
-	entries := make([]LogEntry, 0, 201) // limit+1 for has_more detection
-	for rows.Next() {
-		entry, err := scanLogEntry(rows)
-		if err != nil {
-			debuglog.Error("logs-cursor: row scan failed", "error", err)
-			continue
-		}
-		entries = append(entries, entry)
-	}
-
-	// Determine has_after / has_before based on direction and fetched rows
+// paginate applies has_after/has_before detection (using the fetched-one-extra
+// signal and cursor presence), trims to p.limit, and reverses the slice for
+// backward pagination (which fetched in inverted sort order).
+func paginate(entries []LogEntry, p logListParams) ([]LogEntry, bool, bool) {
 	var hasAfter, hasBefore bool
-	switch direction {
+	switch p.direction {
 	case "after":
-		// Fetching older entries (scroll down or initial load)
-		if len(entries) > limit {
+		// Fetching older entries (scroll down or initial load).
+		if len(entries) > p.limit {
 			hasAfter = true
-			entries = entries[:limit]
+			entries = entries[:p.limit]
 		}
-		// For initial request (no cursor), we're at the newest — nothing before
-		// For cursor requests, assume there are newer entries until proven otherwise
-		// (a fetchBefore returning 0 entries will correct this on the client side)
-		if cursorStr != "" {
+		// For an initial request (no cursor) we're at the newest — nothing
+		// before. For cursor requests, assume newer entries exist until proven
+		// otherwise (a fetchBefore returning 0 corrects this client-side).
+		if p.cursorStr != "" {
 			hasBefore = true
 		}
 	case "before":
-		// Fetching newer entries (scroll up)
-		if len(entries) > limit {
+		// Fetching newer entries (scroll up).
+		if len(entries) > p.limit {
 			hasBefore = true
-			entries = entries[:limit]
+			entries = entries[:p.limit]
 		}
-		// Items exist after the cursor by definition
-		if cursorStr != "" {
+		// Items exist after the cursor by definition.
+		if p.cursorStr != "" {
 			hasAfter = true
 		}
 	}
 
-	// Reverse entries for backward pagination: we fetched in inverted sort order
-	// to get the correct window, but must return in the user's requested sort order.
-	if direction == "before" {
+	if p.direction == "before" {
 		slices.Reverse(entries)
 	}
-
-	// Get total count for display (separate lightweight query), reusing the
-	// exact same filter construction as the data query above.
-	var total int
-	countQuery := "SELECT COUNT(*) FROM request_logs rl WHERE 1=1"
-	countArgs := []interface{}{}
-	countQuery, countArgs, _ = appendLogFilters(countQuery, countArgs, 1, modelID, providerID, statusCodeStr, fromDate, toDate)
-	_ = h.dbPool.Pool().QueryRow(ctx, countQuery, countArgs...).Scan(&total)
-
-	response := LogsCursorResponse{
-		Entries:   entries,
-		Total:     total,
-		HasBefore: hasBefore,
-		HasAfter:  hasAfter,
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(response); err != nil {
-		respondError(w, "failed to encode response", err, http.StatusInternalServerError)
-	}
+	return entries, hasAfter, hasBefore
 }
 
 // scanLogEntry scans one request_logs row (the 30-column projection shared by

--- a/internal/api/logs.go
+++ b/internal/api/logs.go
@@ -173,40 +173,23 @@ type LogsCursorResponse struct {
 // Subsequent requests pass the cursor from the response boundary and
 // direction to scroll older ("before") or newer ("after").
 func (h *Handler) ListLogsCursor(w http.ResponseWriter, r *http.Request) {
-	limit := util.GetIntQueryParam(r, "limit", 20)
-	if limit < 1 {
-		limit = 1
+	p, ok := parseLogListParams(w, r)
+	if !ok {
+		return
 	}
-	if limit > 200 {
-		limit = 200
-	}
-	cursorStr := r.URL.Query().Get("cursor")
-	direction := r.URL.Query().Get("direction")
-	if direction != "before" && direction != "after" {
-		direction = "after"
-	}
-	sortDir := r.URL.Query().Get("sort_dir")
-	if sortDir != "asc" && sortDir != "desc" {
-		sortDir = "desc"
-	}
-
-	modelID := r.URL.Query().Get("model_id")
-	providerID := r.URL.Query().Get("provider_id")
-	statusCodeStr := r.URL.Query().Get("status_code")
-	fromDate := r.URL.Query().Get("from")
-	toDate := r.URL.Query().Get("to")
+	limit := p.limit
+	cursorStr := p.cursorStr
+	cursor := p.cursor
+	direction := p.direction
+	sortDir := p.sortDir
+	modelID := p.modelID
+	providerID := p.providerID
+	statusCodeStr := p.statusCode
+	fromDate := p.fromDate
+	toDate := p.toDate
 
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 	defer cancel()
-
-	// Parse cursor if provided
-	var cursor logCursor
-	if cursorStr != "" {
-		if err := cursor.decode(cursorStr); err != nil {
-			respondBadRequest(w, "invalid cursor", err)
-			return
-		}
-	}
 
 	// Build the base SELECT (same columns as ListLogs minus COUNT(*) OVER())
 	query := `
@@ -439,6 +422,57 @@ func appendKeysetPredicate(query string, args []any, argIndex int, cursor logCur
 	args = append(args, cursor.CreatedAt, cursor.CreatedAt, cursor.ID)
 	argIndex += 3
 	return query, args, argIndex
+}
+
+// logListParams holds the parsed, validated query inputs for the cursor log
+// endpoint: limit clamped to [1,200], direction/sortDir defaulted, filters, and
+// the decoded cursor.
+type logListParams struct {
+	limit      int
+	cursorStr  string
+	cursor     logCursor
+	direction  string
+	sortDir    string
+	modelID    string
+	providerID string
+	statusCode string
+	fromDate   string
+	toDate     string
+}
+
+// parseLogListParams reads and validates the pagination/filter query params. On
+// an undecodable cursor it writes a 400 response and returns ok=false.
+func parseLogListParams(w http.ResponseWriter, r *http.Request) (logListParams, bool) {
+	p := logListParams{
+		limit:      util.GetIntQueryParam(r, "limit", 20),
+		cursorStr:  r.URL.Query().Get("cursor"),
+		direction:  r.URL.Query().Get("direction"),
+		sortDir:    r.URL.Query().Get("sort_dir"),
+		modelID:    r.URL.Query().Get("model_id"),
+		providerID: r.URL.Query().Get("provider_id"),
+		statusCode: r.URL.Query().Get("status_code"),
+		fromDate:   r.URL.Query().Get("from"),
+		toDate:     r.URL.Query().Get("to"),
+	}
+	if p.limit < 1 {
+		p.limit = 1
+	}
+	if p.limit > 200 {
+		p.limit = 200
+	}
+	if p.direction != "before" && p.direction != "after" {
+		p.direction = "after"
+	}
+	if p.sortDir != "asc" && p.sortDir != "desc" {
+		p.sortDir = "desc"
+	}
+	if p.cursorStr != "" {
+		if err := p.cursor.decode(p.cursorStr); err != nil {
+			respondBadRequest(w, "invalid cursor", err)
+			return p, false
+		}
+	}
+	return p, true
 }
 
 // logCursor is the keyset cursor for cursor-based log pagination.

--- a/internal/api/logs_golden_test.go
+++ b/internal/api/logs_golden_test.go
@@ -1,0 +1,115 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"slices"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// TestListLogsCursor_Golden pins the full cursor-pagination behavior over a
+// hand-controlled dataset: ordering, a filter (+ count parity), and forward
+// and backward cursor pages (the backward case exercises the fetch-inverted +
+// slice-reverse path). It is the safety net for the ListLogsCursor
+// decomposition — the helpers it extracts (filters, keyset predicate, scan)
+// must not change any of these outcomes.
+//
+// Six rows are seeded under a unique model_id (so the assertions are isolated
+// from any other data): index 0 is newest .. index 5 oldest; rows 0–2 are 200,
+// rows 3–5 are 500.
+func TestListLogsCursor_Golden(t *testing.T) {
+	h, r := newTestHandlerWithRouter(t)
+	pool := h.Pool().Pool()
+	ctx := context.Background()
+
+	provID := uuid.New()
+	insertTestProvider(t, pool, provID, "golden-prov-"+uuid.New().String()[:8], "https://g.example/v1")
+
+	model := "golden-" + uuid.New().String()[:8]
+	ids := make([]string, 6) // newest (0) -> oldest (5)
+	for i := 0; i < 6; i++ {
+		id := uuid.New()
+		ids[i] = id.String()
+		status := 200
+		if i >= 3 {
+			status = 500
+		}
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO request_logs (id, provider_id, model_id, status_code, duration_ms, created_at)
+			 VALUES ($1, $2, $3, $4, 100, NOW() - ($5 * INTERVAL '1 minute'))`,
+			id, provID, model, status, i); err != nil {
+			t.Fatalf("insert row %d: %v", i, err)
+		}
+	}
+
+	// ListLogsCursor does not use globalLogsCache, but clear it defensively.
+	globalLogsCache.mu.Lock()
+	globalLogsCache.entries = make(map[string]*logsCacheEntry)
+	globalLogsCache.mu.Unlock()
+
+	doReq := func(q string) LogsCursorResponse {
+		t.Helper()
+		req := httptest.NewRequest("GET", "/logs/cursor?"+q, http.NoBody)
+		req.Header.Set("Authorization", "Bearer test-admin-token")
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("GET ?%s: status %d: %s", q, w.Code, w.Body.String())
+		}
+		var resp LogsCursorResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode ?%s: %v", q, err)
+		}
+		return resp
+	}
+	idsOf := func(resp LogsCursorResponse) []string {
+		out := make([]string, len(resp.Entries))
+		for i, e := range resp.Entries {
+			out[i] = e.ID
+		}
+		return out
+	}
+	cursorFrom := func(e LogEntry) string {
+		c := logCursor{CreatedAt: e.CreatedAt, ID: e.ID}
+		return url.QueryEscape(c.encode())
+	}
+
+	// 1) Default page (desc), filtered to our model: all 6 newest->oldest.
+	def := doReq("model_id=" + model)
+	if got := idsOf(def); !slices.Equal(got, ids) {
+		t.Errorf("default page ids = %v, want %v", got, ids)
+	}
+	if def.Total != 6 {
+		t.Errorf("default total = %d, want 6", def.Total)
+	}
+	if def.HasBefore {
+		t.Error("default page: HasBefore = true, want false")
+	}
+
+	// 2) status_code=5xx → rows 3,4,5 only; count honors the same filter.
+	fiveXX := doReq("model_id=" + model + "&status_code=5xx")
+	if got := idsOf(fiveXX); !slices.Equal(got, ids[3:]) {
+		t.Errorf("5xx page ids = %v, want %v", got, ids[3:])
+	}
+	if fiveXX.Total != 3 {
+		t.Errorf("5xx total = %d, want 3", fiveXX.Total)
+	}
+
+	// 3) Forward (after) from entry[1] → strictly older window ids[2:].
+	after := doReq("model_id=" + model + "&direction=after&sort_dir=desc&cursor=" + cursorFrom(def.Entries[1]))
+	if got := idsOf(after); !slices.Equal(got, ids[2:]) {
+		t.Errorf("after-cursor ids = %v, want %v", got, ids[2:])
+	}
+
+	// 4) Backward (before) from entry[3] → newer window ids[0:3] in desc order
+	//    (fetched ascending then reversed).
+	before := doReq("model_id=" + model + "&direction=before&sort_dir=desc&cursor=" + cursorFrom(def.Entries[3]))
+	if got := idsOf(before); !slices.Equal(got, ids[0:3]) {
+		t.Errorf("before-cursor ids = %v, want %v", got, ids[0:3])
+	}
+}

--- a/internal/api/logs_listgolden_test.go
+++ b/internal/api/logs_listgolden_test.go
@@ -1,0 +1,106 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// TestListLogs_Golden pins the full LogsResponse for the offset list endpoint
+// over a hand-controlled dataset: default-page ordering + total, a status filter
+// (with total parity), and a second page. It is the safety net for the ListLogs
+// helper-adoption refactor — the shared scan dests (logEntryScanDests), the
+// shared SELECT projection, and appendLogFilters must not change any of these
+// outcomes.
+//
+// Six rows are seeded under a unique model_id (isolated from any other data):
+// index 0 is newest .. index 5 oldest; rows 0–2 are 200, rows 3–5 are 500.
+func TestListLogs_Golden(t *testing.T) {
+	h, r := newTestHandlerWithRouter(t)
+	pool := h.Pool().Pool()
+	ctx := context.Background()
+
+	provID := uuid.New()
+	insertTestProvider(t, pool, provID, "listgold-prov-"+uuid.New().String()[:8], "https://lg.example/v1")
+
+	model := "listgold-" + uuid.New().String()[:8]
+	ids := make([]string, 6) // newest (0) -> oldest (5)
+	for i := 0; i < 6; i++ {
+		id := uuid.New()
+		ids[i] = id.String()
+		status := 200
+		if i >= 3 {
+			status = 500
+		}
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO request_logs (id, provider_id, model_id, status_code, duration_ms, created_at)
+			 VALUES ($1, $2, $3, $4, 100, NOW() - ($5 * INTERVAL '1 minute'))`,
+			id, provID, model, status, i); err != nil {
+			t.Fatalf("insert row %d: %v", i, err)
+		}
+	}
+
+	// ListLogs uses globalLogsCache (keyed by raw query). Each query below has a
+	// unique model_id, so keys never collide, but clear it defensively.
+	globalLogsCache.mu.Lock()
+	globalLogsCache.entries = make(map[string]*logsCacheEntry)
+	globalLogsCache.mu.Unlock()
+
+	doReq := func(q string) LogsResponse {
+		t.Helper()
+		req := httptest.NewRequest("GET", "/logs?"+q, http.NoBody)
+		req.Header.Set("Authorization", "Bearer test-admin-token")
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("GET ?%s: status %d: %s", q, w.Code, w.Body.String())
+		}
+		var resp LogsResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode ?%s: %v", q, err)
+		}
+		return resp
+	}
+	idsOf := func(resp LogsResponse) []string {
+		out := make([]string, len(resp.Entries))
+		for i, e := range resp.Entries {
+			out[i] = e.ID
+		}
+		return out
+	}
+
+	// 1) Default page (sort=time desc), filtered to our model: all 6 newest->oldest.
+	def := doReq("model_id=" + model)
+	if got := idsOf(def); !slices.Equal(got, ids) {
+		t.Errorf("default page ids = %v, want %v", got, ids)
+	}
+	if def.Total != 6 {
+		t.Errorf("default total = %d, want 6", def.Total)
+	}
+	if def.Page != 1 || def.PerPage != 20 {
+		t.Errorf("default page/per_page = %d/%d, want 1/20", def.Page, def.PerPage)
+	}
+
+	// 2) status_code=5xx -> rows 3,4,5 only; total honors the same filter.
+	fiveXX := doReq("model_id=" + model + "&status_code=5xx")
+	if got := idsOf(fiveXX); !slices.Equal(got, ids[3:]) {
+		t.Errorf("5xx page ids = %v, want %v", got, ids[3:])
+	}
+	if fiveXX.Total != 3 {
+		t.Errorf("5xx total = %d, want 3", fiveXX.Total)
+	}
+
+	// 3) Second page (per_page=2, page=2) -> ids[2:4]; total still 6.
+	page2 := doReq("model_id=" + model + "&per_page=2&page=2")
+	if got := idsOf(page2); !slices.Equal(got, ids[2:4]) {
+		t.Errorf("page 2 ids = %v, want %v", got, ids[2:4])
+	}
+	if page2.Total != 6 || page2.Page != 2 || page2.PerPage != 2 {
+		t.Errorf("page 2 total/page/per_page = %d/%d/%d, want 6/2/2", page2.Total, page2.Page, page2.PerPage)
+	}
+}

--- a/internal/api/logs_paramedges_test.go
+++ b/internal/api/logs_paramedges_test.go
@@ -1,0 +1,76 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// TestListLogsCursor_ParamEdges covers the parameter-handling edges of the
+// cursor list endpoint that the golden test doesn't: the limit clamps
+// ([1,200]), the invalid-cursor → 400 path, and the backward+ascending fetch
+// (which inverts the sort to "desc" in buildLogListQuery).
+func TestListLogsCursor_ParamEdges(t *testing.T) {
+	h, r := newTestHandlerWithRouter(t)
+	pool := h.Pool().Pool()
+	ctx := context.Background()
+
+	provID := uuid.New()
+	insertTestProvider(t, pool, provID, "edge-prov-"+uuid.New().String()[:8], "https://e.example/v1")
+
+	model := "edge-" + uuid.New().String()[:8]
+	for i := 0; i < 3; i++ {
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO request_logs (id, provider_id, model_id, status_code, duration_ms, created_at)
+			 VALUES ($1, $2, $3, 200, 100, NOW() - ($4 * INTERVAL '1 minute'))`,
+			uuid.New(), provID, model, i); err != nil {
+			t.Fatalf("insert row %d: %v", i, err)
+		}
+	}
+	globalLogsCache.mu.Lock()
+	globalLogsCache.entries = make(map[string]*logsCacheEntry)
+	globalLogsCache.mu.Unlock()
+
+	get := func(q string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest("GET", "/logs/cursor?"+q, http.NoBody)
+		req.Header.Set("Authorization", "Bearer test-admin-token")
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		return w
+	}
+
+	// Invalid cursor -> 400 (parseLogListParams decode error).
+	if w := get("cursor=not%21base64"); w.Code != http.StatusBadRequest {
+		t.Errorf("invalid cursor: status %d, want 400 (%s)", w.Code, w.Body.String())
+	}
+
+	// limit clamps: 0 -> 1, 500 -> 200; both must still succeed.
+	for _, lim := range []string{"0", "500"} {
+		if w := get("model_id=" + model + "&limit=" + lim); w.Code != http.StatusOK {
+			t.Errorf("limit=%s: status %d, want 200 (%s)", lim, w.Code, w.Body.String())
+		}
+	}
+
+	// Backward (before) + ascending sort: exercises buildLogListQuery's
+	// fetch-sort inversion (asc -> desc) for the backward window.
+	def := get("model_id=" + model + "&sort_dir=asc")
+	if def.Code != http.StatusOK {
+		t.Fatalf("asc default: status %d (%s)", def.Code, def.Body.String())
+	}
+	var resp LogsCursorResponse
+	if err := json.Unmarshal(def.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode asc default: %v", err)
+	}
+	if len(resp.Entries) < 2 {
+		t.Fatalf("asc default: got %d entries, want >= 2", len(resp.Entries))
+	}
+	c := logCursor{CreatedAt: resp.Entries[1].CreatedAt, ID: resp.Entries[1].ID}
+	if w := get("model_id=" + model + "&direction=before&sort_dir=asc&cursor=" + url.QueryEscape(c.encode())); w.Code != http.StatusOK {
+		t.Errorf("before+asc: status %d, want 200 (%s)", w.Code, w.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary

Decomposes the two largest log-handling god-functions in `internal/api` and
removes the copy-paste between the cursor and offset variants. Pure
restructuring — **no behavior change** (one documented exception below) —
committed one concern per phase, full `internal/api` suite green after each.

Two refactors, sharing the helpers the first one extracts:

### 1. `ListLogsCursor` decomposition (312 → ~45-line handler)
- `scanLogEntry` — the 30-column row scan.
- `appendLogFilters` — single source of truth for the data **and** count
  WHERE-clause (they had drifted: data guarded `status_code >= 0`, count did
  not — unified to the data semantics; behavior-neutral for all real input,
  status codes are always ≥ 0).
- `appendKeysetPredicate` — the 4-branch `(created_at, id)` cursor comparison
  collapsed to one operator + template.
- `parseLogListParams` / `buildLogListQuery` / `countLogs` / `paginate` — the
  thin handler just wires these together.

### 2. `ListLogs` + app-log handlers adopt the same helpers
- **`ListLogs`** (offset variant) now shares `appendLogFilters`, the
  `logEntrySelectColumns` projection const, and `logEntryScanDests` (the scan
  target list, shared with `scanLogEntry`) — keeping its single
  `COUNT(*) OVER()` windowed query (no extra round-trip).
- **`GetAppLogsCursor` / `getAppLogsHistory`** get app-log analogues:
  `appendAppLogFilters` (was written 3×: history, cursor data, cursor count),
  `appendAppLogKeysetPredicate` (4 branches → 1), and `paginateAppLogs`.

## Safety net
Three golden tests pin the full responses across filters + forward/backward
cursor pages as field-order / SQL-drift tripwires:
`TestListLogsCursor_Golden`, `TestListLogs_Golden`, `TestGetAppLogsCursor_Golden`.

## Verification
- `go test ./internal/api/...` green after every phase (and overall).
- `golangci-lint run ./...` — 0 issues.
- CodeQL allocation guards (bounded `make()` capacity) preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
