### PR TITLE
fix(web): language selector menu scrolls to show all languages

### DIFF
--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -759,7 +759,7 @@ function LanguageSelector() {
 				<Languages size={14} strokeWidth={2} />
 			</button>
 			{open && (
-				<div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1 py-1 min-w-[120px] bg-gray-800 border border-gray-700 rounded-lg shadow-lg z-50">
+				<div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1 py-1 min-w-[120px] max-h-[calc(100vh-5rem)] overflow-y-auto overscroll-contain bg-gray-800 border border-gray-700 rounded-lg shadow-lg z-50">
 					{SUPPORTED_LANGUAGES.map((lang) => (
 						<button
 							key={lang.code}


### PR DESCRIPTION
## Summary

The language selector dropdown opens upward from the sidebar footer with no
height cap. On shorter viewports (e.g. 1080p) the top of the list ran off the
screen, so only ~20 of the 28 languages were reachable.

Cap the menu at the viewport height (`max-h-[calc(100vh-5rem)]`) with
`overflow-y-auto` + `overscroll-contain`, so the full language list scrolls
within the menu instead of being clipped.

## Verification
- `pnpm biome check src/components/Layout.tsx` — clean.
- `pnpm vitest run src/components/__tests__/Layout.language-selector.test.tsx` — 12/12 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
