### PR TITLE
refactor(api): decompose ListModelsCursor, generic paginateCursor[T], thin app-log handlers

### DIFF
--- a/internal/api/applogs.go
+++ b/internal/api/applogs.go
@@ -458,6 +458,60 @@ func buildAppLogCursorQuery(p appLogCursorParams, q url.Values) (string, []any) 
 	return query, args
 }
 
+// appLogHistoryParams holds the parsed inputs for the offset getAppLogsHistory.
+type appLogHistoryParams struct {
+	page, perPage    int
+	sortCol, sortDir string
+}
+
+// parseAppLogHistoryParams reads page (default 1), per_page (clamp [1,100],
+// default 20), the sort_by column (whitelist, "time" -> created_at), and sort_dir
+// (DESC default).
+func parseAppLogHistoryParams(r *http.Request) appLogHistoryParams {
+	q := r.URL.Query()
+	p := appLogHistoryParams{page: 1, perPage: 20, sortCol: "created_at", sortDir: "DESC"}
+	if v := q.Get("page"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 1 {
+			p.page = n
+		}
+	}
+	if v := q.Get("per_page"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 1 && n <= 100 {
+			p.perPage = n
+		}
+	}
+	// "time" maps to created_at for consistency with the cursor endpoint; the
+	// timestamp column (event time) is still returned for display.
+	allowedSortCols := map[string]string{
+		"time":    "created_at",
+		"level":   "level",
+		"source":  "source",
+		"message": "message",
+	}
+	if v := q.Get("sort_by"); v != "" {
+		if col, ok := allowedSortCols[v]; ok {
+			p.sortCol = col
+		}
+	}
+	if q.Get("sort_dir") == "asc" {
+		p.sortDir = "ASC"
+	}
+	return p
+}
+
+// buildAppLogHistoryQuery assembles the offset data query: shared filters +
+// ORDER BY + LIMIT/OFFSET.
+func buildAppLogHistoryQuery(p appLogHistoryParams, q url.Values) (string, []any) {
+	conditions, args, argIdx := appendAppLogFilters(nil, nil, 1,
+		q.Get("level"), q.Get("source"), q.Get("search"), q.Get("from"), q.Get("to"))
+	query := fmt.Sprintf(
+		"SELECT timestamp, level, source, message FROM app_logs%s ORDER BY %s %s LIMIT $%d OFFSET $%d",
+		appLogWhereClause(conditions), p.sortCol, p.sortDir, argIdx, argIdx+1,
+	)
+	args = append(args, p.perPage, (p.page-1)*p.perPage)
+	return query, args
+}
+
 // getAppLogsHistory queries app_logs from the database with filtering and pagination.
 func (h *Handler) getAppLogsHistory(w http.ResponseWriter, r *http.Request) {
 	if h.dbPool == nil {
@@ -467,50 +521,7 @@ func (h *Handler) getAppLogsHistory(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	q := r.URL.Query()
-
-	// Pagination
-	page := 1
-	if v := q.Get("page"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n >= 1 {
-			page = n
-		}
-	}
-	perPage := 20
-	if v := q.Get("per_page"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n >= 1 && n <= 100 {
-			perPage = n
-		}
-	}
-
-	// Build WHERE clause
-	conditions, args, argIdx := appendAppLogFilters(nil, nil, 1,
-		q.Get("level"), q.Get("source"), q.Get("search"), q.Get("from"), q.Get("to"))
-
-	// Sort
-	// "time" maps to created_at for consistency with the cursor endpoint.
-	// The timestamp column (event time) is still returned for display.
-	allowedSortCols := map[string]string{
-		"time":    "created_at",
-		"level":   "level",
-		"source":  "source",
-		"message": "message",
-	}
-	sortCol := "created_at"
-	if v := q.Get("sort_by"); v != "" {
-		if col, ok := allowedSortCols[v]; ok {
-			sortCol = col
-		}
-	}
-	sortDir := "DESC"
-	if v := q.Get("sort_dir"); v == "asc" {
-		sortDir = "ASC"
-	}
-
-	whereClause := ""
-	if len(conditions) > 0 {
-		whereClause = " WHERE " + strings.Join(conditions, " AND ")
-	}
+	p := parseAppLogHistoryParams(r)
 
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 	defer cancel()
@@ -518,25 +529,16 @@ func (h *Handler) getAppLogsHistory(w http.ResponseWriter, r *http.Request) {
 	// Retrieve cached level/source counts (refreshed every appLogCountCacheTTL).
 	levelCounts, sourceCounts := h.getAppLogCounts(ctx)
 
-	// Count total (with filters applied)
-	countSQL := "SELECT COUNT(*) FROM app_logs" + whereClause
-	var total int
-	if err := h.dbPool.Pool().QueryRow(ctx, countSQL, args...).Scan(&total); err != nil {
+	total, err := h.countAppLogs(ctx, r.URL.Query())
+	if err != nil {
 		if encErr := json.NewEncoder(w).Encode(map[string]string{"error": "failed to count logs"}); encErr != nil {
 			debuglog.Error("applogs: failed to encode error response", "error", encErr)
 		}
 		return
 	}
 
-	// Fetch page
-	offset := (page - 1) * perPage
-	dataSQL := fmt.Sprintf(
-		"SELECT timestamp, level, source, message FROM app_logs%s ORDER BY %s %s LIMIT $%d OFFSET $%d",
-		whereClause, sortCol, sortDir, argIdx, argIdx+1,
-	)
-	args = append(args, perPage, offset)
-
-	rows, err := h.dbPool.Pool().Query(ctx, dataSQL, args...)
+	query, args := buildAppLogHistoryQuery(p, r.URL.Query())
+	rows, err := h.dbPool.Pool().Query(ctx, query, args...)
 	if err != nil {
 		if err := json.NewEncoder(w).Encode(map[string]string{"error": "failed to query logs"}); err != nil {
 			debuglog.Error("applogs: failed to encode error response", "error", err)
@@ -545,7 +547,8 @@ func (h *Handler) getAppLogsHistory(w http.ResponseWriter, r *http.Request) {
 	}
 	defer rows.Close()
 
-	entries := make([]AppLogEntry, 0, perPage)
+	// per_page is clamped to [1, 100]; prealloc with the hard upper bound (CodeQL).
+	entries := make([]AppLogEntry, 0, 100)
 	for rows.Next() {
 		var e AppLogEntry
 		var ts time.Time
@@ -560,8 +563,8 @@ func (h *Handler) getAppLogsHistory(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewEncoder(w).Encode(appLogsHistoryResponse{
 		Entries:      entries,
 		Total:        total,
-		Page:         page,
-		PerPage:      perPage,
+		Page:         p.page,
+		PerPage:      p.perPage,
 		LevelCounts:  levelCounts,
 		SourceCounts: sourceCounts,
 	}); err != nil {

--- a/internal/api/applogs.go
+++ b/internal/api/applogs.go
@@ -6,12 +6,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
 	"unicode"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5"
 
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 )
@@ -355,6 +357,107 @@ func appendAppLogKeysetPredicate(conditions []string, args []any, argIdx int, cu
 	return conditions, args, argIdx
 }
 
+// appLogWhereClause renders the shared filter/keyset conditions as a SQL WHERE
+// clause (empty string for no conditions).
+func appLogWhereClause(conditions []string) string {
+	if len(conditions) == 0 {
+		return ""
+	}
+	return " WHERE " + strings.Join(conditions, " AND ")
+}
+
+// scanAppLogRow scans one row of the cursor projection
+// (id, created_at, timestamp, level, source, message) into an AppLogEntry.
+func scanAppLogRow(rows pgx.Rows) (AppLogEntry, error) {
+	var e AppLogEntry
+	var id string
+	var cat, ts time.Time
+	if err := rows.Scan(&id, &cat, &ts, &e.Level, &e.Source, &e.Message); err != nil {
+		return e, err
+	}
+	e.ID = id
+	e.CreatedAt = cat.UTC().Format(time.RFC3339Nano)
+	e.Timestamp = ts.UTC().Format(time.RFC3339Nano)
+	return e, nil
+}
+
+// countAppLogs returns the total app_logs row count for the request's filters
+// (no keyset predicate). The cursor endpoint treats it as best-effort (ignores
+// the error); getAppLogsHistory surfaces the error.
+func (h *Handler) countAppLogs(ctx context.Context, q url.Values) (int, error) {
+	conditions, args, _ := appendAppLogFilters(nil, nil, 1,
+		q.Get("level"), q.Get("source"), q.Get("search"), q.Get("from"), q.Get("to"))
+	var total int
+	err := h.dbPool.Pool().QueryRow(ctx, "SELECT COUNT(*) FROM app_logs"+appLogWhereClause(conditions), args...).Scan(&total)
+	return total, err
+}
+
+// appLogCursorParams holds the parsed, validated inputs for GetAppLogsCursor.
+type appLogCursorParams struct {
+	limit     int
+	cursorStr string
+	cursor    appLogCursor
+	direction string
+	sortDir   string
+}
+
+// parseAppLogCursorParams reads and validates the cursor query parameters: limit
+// clamp ([1,200], default 20), direction (after default), sort_dir (DESC
+// default), and the cursor (decode error → 400).
+func parseAppLogCursorParams(w http.ResponseWriter, r *http.Request) (appLogCursorParams, bool) {
+	q := r.URL.Query()
+	p := appLogCursorParams{
+		limit:     20,
+		cursorStr: q.Get("cursor"),
+		direction: q.Get("direction"),
+		sortDir:   "DESC",
+	}
+	if v := q.Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 1 && n <= 200 {
+			p.limit = n
+		}
+	}
+	if p.direction != "before" && p.direction != "after" {
+		p.direction = "after"
+	}
+	if q.Get("sort_dir") == "asc" {
+		p.sortDir = "ASC"
+	}
+	if p.cursorStr != "" {
+		if err := p.cursor.decode(p.cursorStr); err != nil {
+			respondBadRequest(w, "invalid cursor", err)
+			return p, false
+		}
+	}
+	return p, true
+}
+
+// buildAppLogCursorQuery assembles the cursor data query: shared filters + keyset
+// predicate (when a cursor is present) + ORDER BY/LIMIT — fetching limit+1 to
+// detect has_more, with the sort inverted for backward pagination.
+func buildAppLogCursorQuery(p appLogCursorParams, q url.Values) (string, []any) {
+	conditions, args, argIdx := appendAppLogFilters(nil, nil, 1,
+		q.Get("level"), q.Get("source"), q.Get("search"), q.Get("from"), q.Get("to"))
+	if p.cursorStr != "" {
+		conditions, args, argIdx = appendAppLogKeysetPredicate(conditions, args, argIdx, p.cursor, p.direction, p.sortDir)
+	}
+
+	fetchSortDir := p.sortDir
+	if p.direction == "before" {
+		if fetchSortDir == "DESC" {
+			fetchSortDir = "ASC"
+		} else {
+			fetchSortDir = "DESC"
+		}
+	}
+	query := fmt.Sprintf(
+		"SELECT id, created_at, timestamp, level, source, message FROM app_logs%s ORDER BY created_at %s, id %s LIMIT $%d",
+		appLogWhereClause(conditions), fetchSortDir, fetchSortDir, argIdx,
+	)
+	args = append(args, p.limit+1)
+	return query, args
+}
+
 // getAppLogsHistory queries app_logs from the database with filtering and pagination.
 func (h *Handler) getAppLogsHistory(w http.ResponseWriter, r *http.Request) {
 	if h.dbPool == nil {
@@ -510,116 +613,47 @@ func (h *Handler) GetAppLogsCursor(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	q := r.URL.Query()
-	limit := 20
-	if v := q.Get("limit"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n >= 1 && n <= 200 {
-			limit = n
-		}
-	}
-	cursorStr := q.Get("cursor")
-	direction := q.Get("direction")
-	if direction != "before" && direction != "after" {
-		direction = "after"
-	}
-	sortDir := "DESC"
-	if q.Get("sort_dir") == "asc" {
-		sortDir = "ASC"
-	}
-
-	// Parse cursor
-	var cursor appLogCursor
-	if cursorStr != "" {
-		if err := cursor.decode(cursorStr); err != nil {
-			respondBadRequest(w, "invalid cursor", err)
-			return
-		}
-	}
-
-	// Build WHERE clause (same filters as getAppLogsHistory)
-	conditions, args, argIdx := appendAppLogFilters(nil, nil, 1,
-		q.Get("level"), q.Get("source"), q.Get("search"), q.Get("from"), q.Get("to"))
-
-	// Apply cursor keyset predicate
-	if cursorStr != "" {
-		conditions, args, argIdx = appendAppLogKeysetPredicate(conditions, args, argIdx, cursor, direction, sortDir)
-	}
-
-	whereClause := ""
-	if len(conditions) > 0 {
-		whereClause = " WHERE " + strings.Join(conditions, " AND ")
+	p, ok := parseAppLogCursorParams(w, r)
+	if !ok {
+		return
 	}
 
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 	defer cancel()
 
-	// Fetch entries (limit+1 to detect has_more)
-	// When paginating backward, invert the sort direction so LIMIT picks from
-	// the correct end of the result set, then reverse the slice before returning.
-	fetchLimit := limit + 1
-	fetchSortDir := sortDir
-	if direction == "before" {
-		if fetchSortDir == "DESC" {
-			fetchSortDir = "ASC"
-		} else {
-			fetchSortDir = "DESC"
-		}
-	}
-	dataSQL := fmt.Sprintf(
-		"SELECT id, created_at, timestamp, level, source, message FROM app_logs%s ORDER BY created_at %s, id %s LIMIT $%d",
-		whereClause, fetchSortDir, fetchSortDir, argIdx,
-	)
-	args = append(args, fetchLimit)
-
-	rows, err := h.dbPool.Pool().Query(ctx, dataSQL, args...)
+	query, args := buildAppLogCursorQuery(p, r.URL.Query())
+	rows, err := h.dbPool.Pool().Query(ctx, query, args...)
 	if err != nil {
 		respondError(w, "failed to query app logs", err, http.StatusInternalServerError)
 		return
 	}
 	defer rows.Close()
 
-	entries := make([]AppLogEntry, 0, limit)
+	// limit is clamped to [1, 200]; prealloc with the hard upper bound so user
+	// input never flows into make() capacity (CodeQL guard).
+	entries := make([]AppLogEntry, 0, 201) // limit+1 for has_more detection
 	for rows.Next() {
-		var id string
-		var e AppLogEntry
-		var ts time.Time
-		var cat time.Time
-		if err := rows.Scan(&id, &cat, &ts, &e.Level, &e.Source, &e.Message); err != nil {
+		e, err := scanAppLogRow(rows)
+		if err != nil {
 			continue
 		}
-		e.ID = id
-		e.CreatedAt = cat.UTC().Format(time.RFC3339Nano)
-		e.Timestamp = ts.UTC().Format(time.RFC3339Nano)
 		entries = append(entries, e)
 	}
 
-	entries, hasAfter, hasBefore := paginateCursor(entries, direction, limit, cursorStr != "")
+	entries, hasAfter, hasBefore := paginateCursor(entries, p.direction, p.limit, p.cursorStr != "")
 
-	// Get cached counts
 	levelCounts, sourceCounts := h.getAppLogCounts(ctx)
+	total, _ := h.countAppLogs(ctx, r.URL.Query()) // best-effort
 
-	// Total count (with filters applied, but without cursor predicate).
-	totalCountConditions, totalCountArgs, _ := appendAppLogFilters(nil, nil, 1,
-		q.Get("level"), q.Get("source"), q.Get("search"), q.Get("from"), q.Get("to"))
-
-	totalWhereClause := ""
-	if len(totalCountConditions) > 0 {
-		totalWhereClause = " WHERE " + strings.Join(totalCountConditions, " AND ")
-	}
-	var total int
-	_ = h.dbPool.Pool().QueryRow(ctx, "SELECT COUNT(*) FROM app_logs"+totalWhereClause, totalCountArgs...).Scan(&total)
-
-	response := AppLogsCursorResponse{
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(AppLogsCursorResponse{
 		Entries:      entries,
 		Total:        total,
 		HasBefore:    hasBefore,
 		HasAfter:     hasAfter,
 		LevelCounts:  levelCounts,
 		SourceCounts: sourceCounts,
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(response); err != nil {
+	}); err != nil {
 		debuglog.Error("applogs-cursor: failed to encode response", "error", err)
 	}
 }

--- a/internal/api/applogs.go
+++ b/internal/api/applogs.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -356,45 +355,6 @@ func appendAppLogKeysetPredicate(conditions []string, args []any, argIdx int, cu
 	return conditions, args, argIdx
 }
 
-// paginateAppLogs applies has_after/has_before detection (using the fetched-one-
-// extra signal and cursor presence), trims to limit, and reverses the slice for
-// backward pagination (which fetched in inverted sort order). Mirror of paginate
-// for AppLogEntry.
-func paginateAppLogs(entries []AppLogEntry, direction string, limit int, hasCursor bool) ([]AppLogEntry, bool, bool) {
-	var hasAfter, hasBefore bool
-	switch direction {
-	case "after":
-		// Fetching older entries (scroll down or initial load).
-		if len(entries) > limit {
-			hasAfter = true
-			entries = entries[:limit]
-		}
-		// For an initial request (no cursor) we're at the newest — nothing before.
-		// For cursor requests, assume newer entries exist until a fetchBefore proves
-		// otherwise.
-		if hasCursor {
-			hasBefore = true
-		}
-	case "before":
-		// Fetching newer entries (scroll up).
-		if len(entries) > limit {
-			hasBefore = true
-			entries = entries[:limit]
-		}
-		// Items exist after the cursor by definition.
-		if hasCursor {
-			hasAfter = true
-		}
-	}
-
-	// Reverse for backward pagination: we fetched in inverted sort order to get the
-	// correct window, but must return in the user's requested sort order.
-	if direction == "before" {
-		slices.Reverse(entries)
-	}
-	return entries, hasAfter, hasBefore
-}
-
 // getAppLogsHistory queries app_logs from the database with filtering and pagination.
 func (h *Handler) getAppLogsHistory(w http.ResponseWriter, r *http.Request) {
 	if h.dbPool == nil {
@@ -633,7 +593,7 @@ func (h *Handler) GetAppLogsCursor(w http.ResponseWriter, r *http.Request) {
 		entries = append(entries, e)
 	}
 
-	entries, hasAfter, hasBefore := paginateAppLogs(entries, direction, limit, cursorStr != "")
+	entries, hasAfter, hasBefore := paginateCursor(entries, direction, limit, cursorStr != "")
 
 	// Get cached counts
 	levelCounts, sourceCounts := h.getAppLogCounts(ctx)

--- a/internal/api/applogs.go
+++ b/internal/api/applogs.go
@@ -404,8 +404,7 @@ type appLogCursorParams struct {
 // parseAppLogCursorParams reads and validates the cursor query parameters: limit
 // clamp ([1,200], default 20), direction (after default), sort_dir (DESC
 // default), and the cursor (decode error → 400).
-func parseAppLogCursorParams(w http.ResponseWriter, r *http.Request) (appLogCursorParams, bool) {
-	q := r.URL.Query()
+func parseAppLogCursorParams(w http.ResponseWriter, q url.Values) (appLogCursorParams, bool) {
 	p := appLogCursorParams{
 		limit:     20,
 		cursorStr: q.Get("cursor"),
@@ -467,8 +466,7 @@ type appLogHistoryParams struct {
 // parseAppLogHistoryParams reads page (default 1), per_page (clamp [1,100],
 // default 20), the sort_by column (whitelist, "time" -> created_at), and sort_dir
 // (DESC default).
-func parseAppLogHistoryParams(r *http.Request) appLogHistoryParams {
-	q := r.URL.Query()
+func parseAppLogHistoryParams(q url.Values) appLogHistoryParams {
 	p := appLogHistoryParams{page: 1, perPage: 20, sortCol: "created_at", sortDir: "DESC"}
 	if v := q.Get("page"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n >= 1 {
@@ -521,7 +519,8 @@ func (h *Handler) getAppLogsHistory(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	p := parseAppLogHistoryParams(r)
+	q := r.URL.Query()
+	p := parseAppLogHistoryParams(q)
 
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 	defer cancel()
@@ -529,7 +528,7 @@ func (h *Handler) getAppLogsHistory(w http.ResponseWriter, r *http.Request) {
 	// Retrieve cached level/source counts (refreshed every appLogCountCacheTTL).
 	levelCounts, sourceCounts := h.getAppLogCounts(ctx)
 
-	total, err := h.countAppLogs(ctx, r.URL.Query())
+	total, err := h.countAppLogs(ctx, q)
 	if err != nil {
 		if encErr := json.NewEncoder(w).Encode(map[string]string{"error": "failed to count logs"}); encErr != nil {
 			debuglog.Error("applogs: failed to encode error response", "error", encErr)
@@ -537,7 +536,7 @@ func (h *Handler) getAppLogsHistory(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	query, args := buildAppLogHistoryQuery(p, r.URL.Query())
+	query, args := buildAppLogHistoryQuery(p, q)
 	rows, err := h.dbPool.Pool().Query(ctx, query, args...)
 	if err != nil {
 		if err := json.NewEncoder(w).Encode(map[string]string{"error": "failed to query logs"}); err != nil {
@@ -616,7 +615,8 @@ func (h *Handler) GetAppLogsCursor(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	p, ok := parseAppLogCursorParams(w, r)
+	q := r.URL.Query()
+	p, ok := parseAppLogCursorParams(w, q)
 	if !ok {
 		return
 	}
@@ -624,7 +624,7 @@ func (h *Handler) GetAppLogsCursor(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 	defer cancel()
 
-	query, args := buildAppLogCursorQuery(p, r.URL.Query())
+	query, args := buildAppLogCursorQuery(p, q)
 	rows, err := h.dbPool.Pool().Query(ctx, query, args...)
 	if err != nil {
 		respondError(w, "failed to query app logs", err, http.StatusInternalServerError)
@@ -646,7 +646,7 @@ func (h *Handler) GetAppLogsCursor(w http.ResponseWriter, r *http.Request) {
 	entries, hasAfter, hasBefore := paginateCursor(entries, p.direction, p.limit, p.cursorStr != "")
 
 	levelCounts, sourceCounts := h.getAppLogCounts(ctx)
-	total, _ := h.countAppLogs(ctx, r.URL.Query()) // best-effort
+	total, _ := h.countAppLogs(ctx, q) // best-effort
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(AppLogsCursorResponse{

--- a/internal/api/logs.go
+++ b/internal/api/logs.go
@@ -204,7 +204,7 @@ func (h *Handler) ListLogsCursor(w http.ResponseWriter, r *http.Request) {
 		entries = append(entries, entry)
 	}
 
-	entries, hasAfter, hasBefore := paginate(entries, p)
+	entries, hasAfter, hasBefore := paginateCursor(entries, p.direction, p.limit, p.cursorStr != "")
 
 	response := LogsCursorResponse{
 		Entries:   entries,
@@ -294,37 +294,39 @@ func (h *Handler) countLogs(ctx context.Context, p logListParams) int {
 	return total
 }
 
-// paginate applies has_after/has_before detection (using the fetched-one-extra
-// signal and cursor presence), trims to p.limit, and reverses the slice for
-// backward pagination (which fetched in inverted sort order).
-func paginate(entries []LogEntry, p logListParams) ([]LogEntry, bool, bool) {
+// paginateCursor applies has_after/has_before detection (using the fetched-one-
+// extra signal and cursor presence), trims to limit, and reverses the slice for
+// backward pagination (which fetched in inverted sort order). It is the single
+// keyset-pagination tail shared by the request-log, app-log, and model cursor
+// endpoints (T = LogEntry | AppLogEntry | ModelResponse).
+func paginateCursor[T any](entries []T, direction string, limit int, hasCursor bool) ([]T, bool, bool) {
 	var hasAfter, hasBefore bool
-	switch p.direction {
+	switch direction {
 	case "after":
 		// Fetching older entries (scroll down or initial load).
-		if len(entries) > p.limit {
+		if len(entries) > limit {
 			hasAfter = true
-			entries = entries[:p.limit]
+			entries = entries[:limit]
 		}
 		// For an initial request (no cursor) we're at the newest — nothing
 		// before. For cursor requests, assume newer entries exist until proven
 		// otherwise (a fetchBefore returning 0 corrects this client-side).
-		if p.cursorStr != "" {
+		if hasCursor {
 			hasBefore = true
 		}
 	case "before":
 		// Fetching newer entries (scroll up).
-		if len(entries) > p.limit {
+		if len(entries) > limit {
 			hasBefore = true
-			entries = entries[:p.limit]
+			entries = entries[:limit]
 		}
 		// Items exist after the cursor by definition.
-		if p.cursorStr != "" {
+		if hasCursor {
 			hasAfter = true
 		}
 	}
 
-	if p.direction == "before" {
+	if direction == "before" {
 		slices.Reverse(entries)
 	}
 	return entries, hasAfter, hasBefore

--- a/internal/api/models_cursor.go
+++ b/internal/api/models_cursor.go
@@ -12,8 +12,10 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
+	"github.com/hugalafutro/model-hotel/internal/model"
 )
 
 // ListModelsCursor returns models using keyset (cursor) pagination.
@@ -110,7 +112,7 @@ func (h *Handler) ListModelsCursor(w http.ResponseWriter, r *http.Request) {
 	}
 	orderClause := fmt.Sprintf(" ORDER BY %s %s, m.id %s", orderCol, fetchSortDir, fetchSortDir)
 
-	dataSQL := "SELECT m.id, m.provider_id, m.model_id, COALESCE(m.name, ''), COALESCE(m.description, ''), COALESCE(m.display_name, ''), COALESCE(m.capabilities, '{}'), COALESCE(m.params, '{}'), COALESCE(m.modality, ''), COALESCE(m.input_modalities, '[]'), COALESCE(m.output_modalities, '[]'), m.context_length, m.max_output_tokens, m.input_price_per_million, m.input_price_per_million_cache_hit, m.output_price_per_million, COALESCE(m.owned_by, ''), m.enabled, m.disabled_manually, m.created_at, COALESCE(m.last_seen_at, m.created_at), p.name FROM models m JOIN providers p ON m.provider_id = p.id" +
+	dataSQL := "SELECT " + modelSelectColumns + modelFromJoin +
 		whereClause + orderClause + fmt.Sprintf(" LIMIT $%d", argIdx)
 	args = append(args, fetchLimit)
 
@@ -123,63 +125,12 @@ func (h *Handler) ListModelsCursor(w http.ResponseWriter, r *http.Request) {
 
 	entries := make([]ModelResponse, 0, limit)
 	for rows.Next() {
-		var m struct {
-			ID                           uuid.UUID
-			ProviderID                   uuid.UUID
-			ModelID                      string
-			Name                         string
-			Description                  string
-			DisplayName                  string
-			Capabilities                 string
-			Params                       string
-			Modality                     string
-			InputModalities              string
-			OutputModalities             string
-			ContextLength                *int
-			MaxOutputTokens              *int
-			InputPricePerMillion         *float64
-			InputPricePerMillionCacheHit *float64
-			OutputPricePerMillion        *float64
-			OwnedBy                      string
-			Enabled                      bool
-			DisabledManually             bool
-			CreatedAt                    time.Time
-			LastSeenAt                   time.Time
-			ProviderName                 string
-		}
-		if err := rows.Scan(
-			&m.ID, &m.ProviderID, &m.ModelID, &m.Name, &m.Description, &m.DisplayName,
-			&m.Capabilities, &m.Params, &m.Modality, &m.InputModalities, &m.OutputModalities,
-			&m.ContextLength, &m.MaxOutputTokens, &m.InputPricePerMillion, &m.InputPricePerMillionCacheHit, &m.OutputPricePerMillion,
-			&m.OwnedBy, &m.Enabled, &m.DisabledManually, &m.CreatedAt, &m.LastSeenAt, &m.ProviderName,
-		); err != nil {
+		m, err := scanModelRow(rows)
+		if err != nil {
 			debuglog.Error("cursor row scan failed", "error", err)
 			continue
 		}
-		entries = append(entries, ModelResponse{
-			ID:                           m.ID.String(),
-			ModelID:                      m.ModelID,
-			Name:                         m.Name,
-			Description:                  m.Description,
-			DisplayName:                  m.DisplayName,
-			ProviderID:                   m.ProviderID.String(),
-			ProviderName:                 m.ProviderName,
-			Capabilities:                 m.Capabilities,
-			Params:                       m.Params,
-			Modality:                     m.Modality,
-			InputModalities:              m.InputModalities,
-			OutputModalities:             m.OutputModalities,
-			ContextLength:                m.ContextLength,
-			MaxOutputTokens:              m.MaxOutputTokens,
-			InputPricePerMillion:         m.InputPricePerMillion,
-			InputPricePerMillionCacheHit: m.InputPricePerMillionCacheHit,
-			OutputPricePerMillion:        m.OutputPricePerMillion,
-			OwnedBy:                      m.OwnedBy,
-			Enabled:                      m.Enabled,
-			DisabledManually:             m.DisabledManually,
-			CreatedAt:                    m.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
-			LastSeenAt:                   m.LastSeenAt.Format("2006-01-02T15:04:05Z07:00"),
-		})
+		entries = append(entries, modelToResponse(m))
 	}
 
 	// Determine has_after / has_before based on direction and fetched rows
@@ -218,7 +169,7 @@ func (h *Handler) ListModelsCursor(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var total int
-	_ = h.dbPool.Pool().QueryRow(ctx, "SELECT COUNT(*) FROM models m JOIN providers p ON m.provider_id = p.id"+totalWhereClause, totalCountArgs...).Scan(&total)
+	_ = h.dbPool.Pool().QueryRow(ctx, "SELECT COUNT(*)"+modelFromJoin+totalWhereClause, totalCountArgs...).Scan(&total)
 
 	writeJSON(w, ModelsCursorResponse{
 		Entries:   entries,
@@ -226,6 +177,27 @@ func (h *Handler) ListModelsCursor(w http.ResponseWriter, r *http.Request) {
 		HasBefore: hasBefore,
 		HasAfter:  hasAfter,
 	})
+}
+
+// modelSelectColumns is the cursor data query's column projection (models joined
+// to providers for p.name). Its order matches scanModelRow exactly.
+const modelSelectColumns = "m.id, m.provider_id, m.model_id, COALESCE(m.name, ''), COALESCE(m.description, ''), COALESCE(m.display_name, ''), COALESCE(m.capabilities, '{}'), COALESCE(m.params, '{}'), COALESCE(m.modality, ''), COALESCE(m.input_modalities, '[]'), COALESCE(m.output_modalities, '[]'), m.context_length, m.max_output_tokens, m.input_price_per_million, m.input_price_per_million_cache_hit, m.output_price_per_million, COALESCE(m.owned_by, ''), m.enabled, m.disabled_manually, m.created_at, COALESCE(m.last_seen_at, m.created_at), p.name"
+
+// modelFromJoin is the shared FROM/JOIN tail for the models cursor data and
+// count queries.
+const modelFromJoin = " FROM models m JOIN providers p ON m.provider_id = p.id"
+
+// scanModelRow scans one row of the modelSelectColumns projection into a
+// model.Model, so modelToResponse can map it — the same mapping ListModels uses.
+func scanModelRow(rows pgx.Rows) (model.Model, error) {
+	var m model.Model
+	err := rows.Scan(
+		&m.ID, &m.ProviderID, &m.ModelID, &m.Name, &m.Description, &m.DisplayName,
+		&m.Capabilities, &m.Params, &m.Modality, &m.InputModalities, &m.OutputModalities,
+		&m.ContextLength, &m.MaxOutputTokens, &m.InputPricePerMillion, &m.InputPricePerMillionCacheHit, &m.OutputPricePerMillion,
+		&m.OwnedBy, &m.Enabled, &m.DisabledManually, &m.CreatedAt, &m.LastSeenAt, &m.ProviderName,
+	)
+	return m, err
 }
 
 // modelSortColumn returns the SQL column expression for a given sort_by value.

--- a/internal/api/models_cursor.go
+++ b/internal/api/models_cursor.go
@@ -40,60 +40,21 @@ func (h *Handler) ListModelsCursor(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	q := r.URL.Query()
-	limit, cursorStr, direction, sortDir, sortBy := p.limit, p.cursorStr, p.direction, p.sortDir, p.sortBy
-
-	// Build WHERE clause (shared with count query)
-	filterConds, filterArgs := buildModelFilterConditions(q)
-	conditions := filterConds
-	args := filterArgs
-	argIdx := len(args) + 1
-
-	// Apply cursor keyset predicate
-	if cursorStr != "" {
-		pred := buildModelKeysetPredicate(p.cursor, direction, sortDir, &argIdx, &args)
-		if pred != "" {
-			conditions = append(conditions, pred)
-		}
-	}
-
-	whereClause := ""
-	if len(conditions) > 0 {
-		whereClause = " WHERE " + joinAnd(conditions)
-	}
 
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 	defer cancel()
 
-	// Fetch entries (limit+1 to detect has_more)
-	fetchLimit := limit + 1
-
-	// Build ORDER BY based on sort_by
-	// When paginating backward, invert the sort direction so LIMIT picks from
-	// the correct end of the result set, then reverse the slice before returning.
-	orderCol := modelSortColumn(sortBy)
-	fetchSortDir := sortDir
-	if direction == "before" {
-		if fetchSortDir == "ASC" {
-			fetchSortDir = "DESC"
-		} else {
-			fetchSortDir = "ASC"
-		}
-	}
-	orderClause := fmt.Sprintf(" ORDER BY %s %s, m.id %s", orderCol, fetchSortDir, fetchSortDir)
-
-	dataSQL := "SELECT " + modelSelectColumns + modelFromJoin +
-		whereClause + orderClause + fmt.Sprintf(" LIMIT $%d", argIdx)
-	args = append(args, fetchLimit)
-
-	rows, err := h.dbPool.Pool().Query(ctx, dataSQL, args...)
+	query, args := buildModelListQuery(p, r.URL.Query())
+	rows, err := h.dbPool.Pool().Query(ctx, query, args...)
 	if err != nil {
 		respondError(w, "failed to query models", err, http.StatusInternalServerError)
 		return
 	}
 	defer rows.Close()
 
-	entries := make([]ModelResponse, 0, limit)
+	// limit is clamped to [1, 200] in parseModelListParams; prealloc with the hard
+	// upper bound so user input never flows into make() capacity (CodeQL guard).
+	entries := make([]ModelResponse, 0, 201) // limit+1 for has_more detection
 	for rows.Next() {
 		m, err := scanModelRow(rows)
 		if err != nil {
@@ -105,23 +66,60 @@ func (h *Handler) ListModelsCursor(w http.ResponseWriter, r *http.Request) {
 
 	entries, hasAfter, hasBefore := paginateModels(entries, p)
 
-	// Get total count (reuses same filter conditions, minus cursor predicate)
-	totalCountConditions, totalCountArgs := buildModelFilterConditions(q)
-
-	totalWhereClause := ""
-	if len(totalCountConditions) > 0 {
-		totalWhereClause = " WHERE " + joinAnd(totalCountConditions)
-	}
-
-	var total int
-	_ = h.dbPool.Pool().QueryRow(ctx, "SELECT COUNT(*)"+modelFromJoin+totalWhereClause, totalCountArgs...).Scan(&total)
-
 	writeJSON(w, ModelsCursorResponse{
 		Entries:   entries,
-		Total:     total,
+		Total:     h.countModels(ctx, r.URL.Query()),
 		HasBefore: hasBefore,
 		HasAfter:  hasAfter,
 	})
+}
+
+// buildModelListQuery assembles the cursor data query: the column projection, the
+// shared filters, the keyset predicate (when a cursor is present), and the
+// ORDER BY + LIMIT — fetching limit+1 to detect has_more, with the sort inverted
+// for backward pagination so LIMIT picks from the correct end.
+func buildModelListQuery(p modelListParams, q url.Values) (string, []any) {
+	conditions, args := buildModelFilterConditions(q)
+	argIdx := len(args) + 1
+
+	if p.cursorStr != "" {
+		pred := buildModelKeysetPredicate(p.cursor, p.direction, p.sortDir, &argIdx, &args)
+		if pred != "" {
+			conditions = append(conditions, pred)
+		}
+	}
+
+	whereClause := ""
+	if len(conditions) > 0 {
+		whereClause = " WHERE " + joinAnd(conditions)
+	}
+
+	fetchSortDir := p.sortDir
+	if p.direction == "before" {
+		if fetchSortDir == "ASC" {
+			fetchSortDir = "DESC"
+		} else {
+			fetchSortDir = "ASC"
+		}
+	}
+	orderClause := fmt.Sprintf(" ORDER BY %s %s, m.id %s", modelSortColumn(p.sortBy), fetchSortDir, fetchSortDir)
+
+	query := "SELECT " + modelSelectColumns + modelFromJoin + whereClause + orderClause + fmt.Sprintf(" LIMIT $%d", argIdx)
+	args = append(args, p.limit+1)
+	return query, args
+}
+
+// countModels returns the total row count for the same filters as the data query
+// (no keyset predicate). Best-effort: returns 0 on error.
+func (h *Handler) countModels(ctx context.Context, q url.Values) int {
+	conditions, args := buildModelFilterConditions(q)
+	whereClause := ""
+	if len(conditions) > 0 {
+		whereClause = " WHERE " + joinAnd(conditions)
+	}
+	var total int
+	_ = h.dbPool.Pool().QueryRow(ctx, "SELECT COUNT(*)"+modelFromJoin+whereClause, args...).Scan(&total)
+	return total
 }
 
 // modelListParams holds the parsed, validated query inputs for ListModelsCursor.

--- a/internal/api/models_cursor.go
+++ b/internal/api/models_cursor.go
@@ -103,32 +103,7 @@ func (h *Handler) ListModelsCursor(w http.ResponseWriter, r *http.Request) {
 		entries = append(entries, modelToResponse(m))
 	}
 
-	// Determine has_after / has_before based on direction and fetched rows
-	var hasAfter, hasBefore bool
-	switch direction {
-	case "after":
-		if len(entries) > limit {
-			hasAfter = true
-			entries = entries[:limit]
-		}
-		if cursorStr != "" {
-			hasBefore = true
-		}
-	case "before":
-		if len(entries) > limit {
-			hasBefore = true
-			entries = entries[:limit]
-		}
-		if cursorStr != "" {
-			hasAfter = true
-		}
-	}
-
-	// Reverse entries for backward pagination: we fetched in inverted sort order
-	// to get the correct window, but must return in the user's requested sort order.
-	if direction == "before" {
-		slices.Reverse(entries)
-	}
+	entries, hasAfter, hasBefore := paginateModels(entries, p)
 
 	// Get total count (reuses same filter conditions, minus cursor predicate)
 	totalCountConditions, totalCountArgs := buildModelFilterConditions(q)
@@ -199,6 +174,38 @@ func parseModelListParams(w http.ResponseWriter, r *http.Request) (modelListPara
 		}
 	}
 	return p, true
+}
+
+// paginateModels applies has_after/has_before detection (using the fetched-one-
+// extra signal and cursor presence), trims to p.limit, and reverses the slice for
+// backward pagination (which fetched in inverted sort order). Mirror of paginate.
+func paginateModels(entries []ModelResponse, p modelListParams) ([]ModelResponse, bool, bool) {
+	var hasAfter, hasBefore bool
+	switch p.direction {
+	case "after":
+		if len(entries) > p.limit {
+			hasAfter = true
+			entries = entries[:p.limit]
+		}
+		if p.cursorStr != "" {
+			hasBefore = true
+		}
+	case "before":
+		if len(entries) > p.limit {
+			hasBefore = true
+			entries = entries[:p.limit]
+		}
+		if p.cursorStr != "" {
+			hasAfter = true
+		}
+	}
+
+	// Reverse for backward pagination: we fetched in inverted sort order to get
+	// the correct window, but must return in the user's requested sort order.
+	if p.direction == "before" {
+		slices.Reverse(entries)
+	}
+	return entries, hasAfter, hasBefore
 }
 
 // modelSelectColumns is the cursor data query's column projection (models joined

--- a/internal/api/models_cursor.go
+++ b/internal/api/models_cursor.go
@@ -36,42 +36,12 @@ func (h *Handler) ListModelsCursor(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	p, ok := parseModelListParams(w, r)
+	if !ok {
+		return
+	}
 	q := r.URL.Query()
-	limit := 50
-	if v := q.Get("limit"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n >= 1 && n <= 200 {
-			limit = n
-		}
-	}
-	cursorStr := q.Get("cursor")
-	direction := q.Get("direction")
-	if direction != "before" && direction != "after" {
-		direction = "after"
-	}
-	sortDir := "ASC"
-	if q.Get("sort_dir") == "desc" {
-		sortDir = "DESC"
-	}
-	sortBy := q.Get("sort_by")
-	switch sortBy {
-	case "discovered", "context", "output", "provider", "status":
-		// valid
-	default:
-		sortBy = "name"
-	}
-
-	// Parse cursor
-	var cursor modelCursor
-	if cursorStr != "" {
-		if err := cursor.decode(cursorStr); err != nil {
-			respondBadRequest(w, "invalid cursor", err)
-			return
-		}
-		// Use sort_by from cursor if present (ensures consistency)
-		if cursor.SortBy != "" {
-			sortBy = cursor.SortBy
-		}
-	}
+	limit, cursorStr, direction, sortDir, sortBy := p.limit, p.cursorStr, p.direction, p.sortDir, p.sortBy
 
 	// Build WHERE clause (shared with count query)
 	filterConds, filterArgs := buildModelFilterConditions(q)
@@ -81,7 +51,7 @@ func (h *Handler) ListModelsCursor(w http.ResponseWriter, r *http.Request) {
 
 	// Apply cursor keyset predicate
 	if cursorStr != "" {
-		pred := buildModelKeysetPredicate(cursor, direction, sortDir, &argIdx, &args)
+		pred := buildModelKeysetPredicate(p.cursor, direction, sortDir, &argIdx, &args)
 		if pred != "" {
 			conditions = append(conditions, pred)
 		}
@@ -177,6 +147,58 @@ func (h *Handler) ListModelsCursor(w http.ResponseWriter, r *http.Request) {
 		HasBefore: hasBefore,
 		HasAfter:  hasAfter,
 	})
+}
+
+// modelListParams holds the parsed, validated query inputs for ListModelsCursor.
+type modelListParams struct {
+	limit              int
+	cursorStr          string
+	cursor             modelCursor
+	direction, sortDir string
+	sortBy             string
+}
+
+// parseModelListParams reads and validates the cursor list query parameters:
+// limit clamp ([1,200], default 50), direction (after default), sort_dir
+// (ASC default), the sort_by whitelist, and the cursor (decode error → 400,
+// with the cursor's own sort_by taking precedence for consistency).
+func parseModelListParams(w http.ResponseWriter, r *http.Request) (modelListParams, bool) {
+	q := r.URL.Query()
+	p := modelListParams{
+		limit:     50,
+		cursorStr: q.Get("cursor"),
+		direction: q.Get("direction"),
+		sortDir:   "ASC",
+		sortBy:    q.Get("sort_by"),
+	}
+	if v := q.Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 1 && n <= 200 {
+			p.limit = n
+		}
+	}
+	if p.direction != "before" && p.direction != "after" {
+		p.direction = "after"
+	}
+	if q.Get("sort_dir") == "desc" {
+		p.sortDir = "DESC"
+	}
+	switch p.sortBy {
+	case "discovered", "context", "output", "provider", "status":
+		// valid
+	default:
+		p.sortBy = "name"
+	}
+	if p.cursorStr != "" {
+		if err := p.cursor.decode(p.cursorStr); err != nil {
+			respondBadRequest(w, "invalid cursor", err)
+			return p, false
+		}
+		// Use sort_by from cursor if present (ensures consistency).
+		if p.cursor.SortBy != "" {
+			p.sortBy = p.cursor.SortBy
+		}
+	}
+	return p, true
 }
 
 // modelSelectColumns is the cursor data query's column projection (models joined

--- a/internal/api/models_cursor.go
+++ b/internal/api/models_cursor.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -64,7 +63,7 @@ func (h *Handler) ListModelsCursor(w http.ResponseWriter, r *http.Request) {
 		entries = append(entries, modelToResponse(m))
 	}
 
-	entries, hasAfter, hasBefore := paginateModels(entries, p)
+	entries, hasAfter, hasBefore := paginateCursor(entries, p.direction, p.limit, p.cursorStr != "")
 
 	writeJSON(w, ModelsCursorResponse{
 		Entries:   entries,
@@ -172,38 +171,6 @@ func parseModelListParams(w http.ResponseWriter, r *http.Request) (modelListPara
 		}
 	}
 	return p, true
-}
-
-// paginateModels applies has_after/has_before detection (using the fetched-one-
-// extra signal and cursor presence), trims to p.limit, and reverses the slice for
-// backward pagination (which fetched in inverted sort order). Mirror of paginate.
-func paginateModels(entries []ModelResponse, p modelListParams) ([]ModelResponse, bool, bool) {
-	var hasAfter, hasBefore bool
-	switch p.direction {
-	case "after":
-		if len(entries) > p.limit {
-			hasAfter = true
-			entries = entries[:p.limit]
-		}
-		if p.cursorStr != "" {
-			hasBefore = true
-		}
-	case "before":
-		if len(entries) > p.limit {
-			hasBefore = true
-			entries = entries[:p.limit]
-		}
-		if p.cursorStr != "" {
-			hasAfter = true
-		}
-	}
-
-	// Reverse for backward pagination: we fetched in inverted sort order to get
-	// the correct window, but must return in the user's requested sort order.
-	if p.direction == "before" {
-		slices.Reverse(entries)
-	}
-	return entries, hasAfter, hasBefore
 }
 
 // modelSelectColumns is the cursor data query's column projection (models joined

--- a/internal/api/models_cursor.go
+++ b/internal/api/models_cursor.go
@@ -35,7 +35,8 @@ func (h *Handler) ListModelsCursor(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	p, ok := parseModelListParams(w, r)
+	q := r.URL.Query()
+	p, ok := parseModelListParams(w, q)
 	if !ok {
 		return
 	}
@@ -43,7 +44,7 @@ func (h *Handler) ListModelsCursor(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 	defer cancel()
 
-	query, args := buildModelListQuery(p, r.URL.Query())
+	query, args := buildModelListQuery(p, q)
 	rows, err := h.dbPool.Pool().Query(ctx, query, args...)
 	if err != nil {
 		respondError(w, "failed to query models", err, http.StatusInternalServerError)
@@ -67,7 +68,7 @@ func (h *Handler) ListModelsCursor(w http.ResponseWriter, r *http.Request) {
 
 	writeJSON(w, ModelsCursorResponse{
 		Entries:   entries,
-		Total:     h.countModels(ctx, r.URL.Query()),
+		Total:     h.countModels(ctx, q),
 		HasBefore: hasBefore,
 		HasAfter:  hasAfter,
 	})
@@ -134,8 +135,7 @@ type modelListParams struct {
 // limit clamp ([1,200], default 50), direction (after default), sort_dir
 // (ASC default), the sort_by whitelist, and the cursor (decode error → 400,
 // with the cursor's own sort_by taking precedence for consistency).
-func parseModelListParams(w http.ResponseWriter, r *http.Request) (modelListParams, bool) {
-	q := r.URL.Query()
+func parseModelListParams(w http.ResponseWriter, q url.Values) (modelListParams, bool) {
 	p := modelListParams{
 		limit:     50,
 		cursorStr: q.Get("cursor"),

--- a/internal/api/models_cursor_golden_test.go
+++ b/internal/api/models_cursor_golden_test.go
@@ -1,0 +1,106 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// TestListModelsCursor_Golden pins the full ModelsCursorResponse over a
+// hand-controlled dataset: default (name asc) ordering + total, a provider_id
+// filter (with total parity), and forward and backward cursor pages (the
+// backward case exercises the fetch-inverted + slice-reverse path). It is the
+// safety net for the ListModelsCursor decomposition — in particular the
+// scanModelRow + modelToResponse swap, which must reproduce every field exactly.
+//
+// Six models are seeded under a fresh provider (so the assertions are isolated
+// via provider_id): names m0..m5, sorted ascending by name.
+func TestListModelsCursor_Golden(t *testing.T) {
+	h, r := newTestHandlerWithRouter(t)
+
+	providerData := fmt.Sprintf(`{"name": "golden-models-%s", "base_url": "https://api.example.com", "api_key": "test-key"}`, uuid.New().String()[:8])
+	rec := httptest.NewRecorder()
+	preq := httptest.NewRequest(http.MethodPost, "/providers", strings.NewReader(providerData))
+	preq.Header.Set("Authorization", "Bearer test-admin-token")
+	preq.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec, preq)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create provider: %d: %s", rec.Code, rec.Body.String())
+	}
+	var pr struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &pr); err != nil {
+		t.Fatalf("parse provider: %v", err)
+	}
+
+	pool := h.Pool().Pool()
+	names := []string{"gm0", "gm1", "gm2", "gm3", "gm4", "gm5"}
+	for i, name := range names {
+		if _, err := pool.Exec(context.Background(),
+			`INSERT INTO models (id, provider_id, model_id, name, capabilities, enabled) VALUES ($1, $2, $3, $4, $5, $6)`,
+			uuid.New(), pr.ID, name, name, `{"vision": true}`, true); err != nil {
+			t.Fatalf("insert model %d: %v", i, err)
+		}
+	}
+
+	doReq := func(q string) ModelsCursorResponse {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodGet, "/models/cursor?"+q, http.NoBody)
+		req.Header.Set("Authorization", "Bearer test-admin-token")
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("GET ?%s: status %d: %s", q, w.Code, w.Body.String())
+		}
+		var resp ModelsCursorResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode ?%s: %v", q, err)
+		}
+		return resp
+	}
+	namesOf := func(resp ModelsCursorResponse) []string {
+		out := make([]string, len(resp.Entries))
+		for i, e := range resp.Entries {
+			out[i] = e.Name
+		}
+		return out
+	}
+	cursorFrom := func(e ModelResponse) string {
+		c := modelCursor{SortBy: "name", Name: e.Name, ModelID: e.ModelID, ID: e.ID}
+		return url.QueryEscape(c.encode())
+	}
+
+	// 1) Default page (name asc), filtered to our provider: gm0..gm5 in order.
+	def := doReq("provider_id=" + pr.ID)
+	if got := namesOf(def); !slices.Equal(got, names) {
+		t.Errorf("default page names = %v, want %v", got, names)
+	}
+	if def.Total != 6 {
+		t.Errorf("default total = %d, want 6", def.Total)
+	}
+	if def.HasBefore {
+		t.Error("default page: HasBefore = true, want false")
+	}
+
+	// 2) Forward (after) from entry[1] (gm1) -> strictly later window gm2..gm5.
+	after := doReq("provider_id=" + pr.ID + "&direction=after&sort_dir=asc&cursor=" + cursorFrom(def.Entries[1]))
+	if got := namesOf(after); !slices.Equal(got, names[2:]) {
+		t.Errorf("after-cursor names = %v, want %v", got, names[2:])
+	}
+
+	// 3) Backward (before) from entry[3] (gm3) -> earlier window gm0..gm2 in asc
+	//    order (fetched descending then reversed).
+	before := doReq("provider_id=" + pr.ID + "&direction=before&sort_dir=asc&cursor=" + cursorFrom(def.Entries[3]))
+	if got := namesOf(before); !slices.Equal(got, names[0:3]) {
+		t.Errorf("before-cursor names = %v, want %v", got, names[0:3])
+	}
+}


### PR DESCRIPTION
## Summary

Completes the cursor-pagination ("scrolling") refactor family: decomposes
`ListModelsCursor`, unifies the three paginate helpers into one generic, and
thins the two app-log handlers. Pure restructuring — **no behavior change** —
committed one concern per phase, full `internal/api` suite green after each.

### 1. `ListModelsCursor` decomposition (200 → 44-line handler)
- **scanModelRow → modelToResponse** — the cursor handler scanned each row into a
  one-off anonymous struct and hand-mapped it to `ModelResponse`, a byte-for-byte
  duplicate of the `modelToResponse(model.Model)` mapper `ListModels` already
  uses. Now scans a `model.Model` and reuses `modelToResponse`. Projection/scan
  share the `modelSelectColumns` / `modelFromJoin` consts.
- **parseModelListParams** (+ `modelListParams`) — limit clamp, defaults/whitelist,
  cursor decode → 400, sort_by-from-cursor override.
- **buildModelListQuery** + **countModels** — filters + keyset + ORDER BY/LIMIT,
  and the shared best-effort count.

### 2. Generic `paginateCursor[T]`
`paginate` (LogEntry), `paginateAppLogs` (AppLogEntry), and `paginateModels`
(ModelResponse) had become byte-identical has_more/trim/reverse logic. Replaced
all three with one generic `paginateCursor[T any]`.

### 3. App-log handlers thinned
- `GetAppLogsCursor` 120 → 51 lines; `getAppLogsHistory` 109 → 58 lines.
- Extracted `parseAppLogCursorParams` / `parseAppLogHistoryParams`,
  `buildAppLogCursorQuery` / `buildAppLogHistoryQuery`, `scanAppLogRow`,
  `countAppLogs`, `appLogWhereClause`.

After this, all four cursor/list handlers are thin and share their
filter/keyset/scan/paginate logic — no duplication remains in the family.

## Safety net
`TestListModelsCursor_Golden` (new) pins the full `ModelsCursorResponse` across a
filter + forward/backward cursor pages. Existing cursor/app-log suites
(`TestListModelsCursor_*`, `TestGetAppLogs*`, `TestGetAppLogsCursor_Golden`)
pass unchanged.

## Verification
- `go test ./internal/api/...` green after every phase.
- `golangci-lint run ./...` — 0 issues.
- CodeQL allocation guards preserved/added on all preallocs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
