### PR TITLE
refactor(proxy): decompose attemptCandidate into phase helpers

### DIFF
--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -174,35 +174,7 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		_ = resp.Body.Close()
-		errMsg := util.SanitizeLogBody(string(body), 10000)
-		debuglog.Warn("proxy: upstream non-200", "status", resp.StatusCode, "model", logData.modelID, "provider", logData.providerName, "provider_id", candidate.provider.ID, "body", errMsg)
-		debuglog.Debug("proxy: upstream error response", "status", resp.StatusCode, "model", logData.modelID, "provider", logData.providerName, "provider_id", candidate.provider.ID, "body_length", len(body), "attempt", attempt+1)
-		logData.responseHeaderMs = responseHeaderMs
-		h.failRequest(logData, resp.StatusCode, errMsg, attempt, st.startTime, st.parseMs, st.timings, st.cacheHits, st.proxyOverhead)
-
-		if !hasMoreCandidates {
-			// All failover candidates exhausted — return a generic error.
-			// The full upstream body is logged server-side above but not
-			// forwarded, as it may contain provider-specific details.
-			writeOpenAIError(w, fmt.Sprintf("upstream provider returned HTTP %d", resp.StatusCode), resp.StatusCode)
-			return outcomeFatal
-		}
-
-		// Non-failover-eligible error with remaining candidates — forward
-		// the upstream response so clients can react to semantic errors
-		// (e.g. context_length_exceeded, rate_limit_exceeded).
-		if json.Valid(body) {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(resp.StatusCode)
-			_, _ = w.Write(body)
-		} else {
-			// Body is not JSON (e.g. HTML from a CDN). Wrap in an
-			// OpenAI-compatible envelope so JSON-parsing clients don't crash.
-			writeOpenAIError(w, errMsg, resp.StatusCode)
-		}
-		return outcomeFatal
+		return h.forwardUpstreamError(w, st, candidate, resp, attempt, hasMoreCandidates, responseHeaderMs)
 	}
 
 	debuglog.Debug("proxy: upstream responded OK, dispatching to handler", "stream", st.isStreaming, "model", logData.modelID, "provider", logData.providerName, "provider_id", candidate.provider.ID, "status", resp.StatusCode)
@@ -376,6 +348,45 @@ func (h *Handler) doUpstream(ctx context.Context, req *http.Request, st *request
 	// Log upstream response metadata for debugging.
 	debuglog.Debug("proxy: upstream response received", "provider", candidate.provider.Name, "provider_id", candidate.provider.ID, "model", candidate.model.ModelID, "status", resp.StatusCode, "content_type", resp.Header.Get("Content-Type"), "x_request_id", resp.Header.Get("X-Request-Id"), "x_ratelimit_remaining", resp.Header.Get("X-RateLimit-Remaining"), "attempt", attempt+1)
 	return resp, true
+}
+
+// forwardUpstreamError handles a non-200 upstream response that is NOT being
+// failed over (phase G): log + meter the failure via failRequest, then either
+// return a generic OpenAI error when the candidates are exhausted or forward the
+// upstream body (wrapping non-JSON bodies in an OpenAI envelope) so clients can
+// react to semantic errors. Drains/closes resp.Body exactly once and always
+// returns outcomeFatal.
+func (h *Handler) forwardUpstreamError(w http.ResponseWriter, st *requestState, candidate modelCandidate, resp *http.Response, attempt int, hasMoreCandidates bool, responseHeaderMs float64) candidateOutcome {
+	logData := st.logData
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	errMsg := util.SanitizeLogBody(string(body), 10000)
+	debuglog.Warn("proxy: upstream non-200", "status", resp.StatusCode, "model", logData.modelID, "provider", logData.providerName, "provider_id", candidate.provider.ID, "body", errMsg)
+	debuglog.Debug("proxy: upstream error response", "status", resp.StatusCode, "model", logData.modelID, "provider", logData.providerName, "provider_id", candidate.provider.ID, "body_length", len(body), "attempt", attempt+1)
+	logData.responseHeaderMs = responseHeaderMs
+	h.failRequest(logData, resp.StatusCode, errMsg, attempt, st.startTime, st.parseMs, st.timings, st.cacheHits, st.proxyOverhead)
+
+	if !hasMoreCandidates {
+		// All failover candidates exhausted — return a generic error.
+		// The full upstream body is logged server-side above but not
+		// forwarded, as it may contain provider-specific details.
+		writeOpenAIError(w, fmt.Sprintf("upstream provider returned HTTP %d", resp.StatusCode), resp.StatusCode)
+		return outcomeFatal
+	}
+
+	// Non-failover-eligible error with remaining candidates — forward
+	// the upstream response so clients can react to semantic errors
+	// (e.g. context_length_exceeded, rate_limit_exceeded).
+	if json.Valid(body) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(resp.StatusCode)
+		_, _ = w.Write(body)
+	} else {
+		// Body is not JSON (e.g. HTML from a CDN). Wrap in an
+		// OpenAI-compatible envelope so JSON-parsing clients don't crash.
+		writeOpenAIError(w, errMsg, resp.StatusCode)
+	}
+	return outcomeFatal
 }
 
 // recordBreakerOutcome records the circuit-breaker result for a completed

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -103,22 +103,6 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 			debuglog.Debug("proxy: failed to touch provider last-used", "error", err)
 		}
 	}(candidate.provider.ID)
-	providerType := provider.DetectProviderType(candidate.provider.BaseURL)
-	debuglog.Debug("proxy: detected provider type", "provider_type", providerType, "base_url", util.SanitizeBaseURL(candidate.provider.BaseURL))
-	targetURL := util.BuildProviderTargetURL(candidate.provider.BaseURL, providerType)
-	debuglog.Debug("proxy: built target URL", "target_url", targetURL)
-
-	upstreamBody := st.bodyBytes
-	needsRewrite := st.reqModel != candidate.model.ModelID || providerType == "anthropic" || NeedsProviderInjection(providerType) || st.isStreaming
-	debuglog.Debug("proxy: request rewrite check", "needs_rewrite", needsRewrite, "request_model", logData.modelID, "provider", logData.providerName, "resolved_model", candidate.model.ModelID, "provider_type", providerType)
-	if needsRewrite {
-		upstreamBody = buildUpstreamBody(st.bodyBytes, providerType, candidate.model.ModelID, st.reqModel, st.isStreaming, &h.deprecationCache, nil)
-	}
-	// Log the actual model name in the upstream body for debugging rewrite issues.
-	if upstreamModel, _, _ := strings.Cut(string(upstreamBody), ","); strings.Contains(upstreamModel, `"model"`) {
-		debuglog.Debug("proxy: upstream body model", "upstream_model_snippet", upstreamModel)
-	}
-
 	// Per-attempt DNS resolution timing. SafeDialer's DialContext writes into
 	// this via context, avoiding cross-request races on a shared field.
 	var dialMs float64
@@ -137,15 +121,12 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 		}
 	}()
 	failoverCtx = context.WithValue(failoverCtx, ctxkeys.CancelOriginKey, "failover_timeout")
-	proxyReq, err := newRequestWithContext(failoverCtx, "POST", targetURL, bytes.NewReader(upstreamBody))
+
+	proxyReq, providerType, targetURL, err := h.buildCandidateRequest(failoverCtx, st, candidate)
 	if err != nil {
 		st.lastErr = fmt.Sprintf("attempt %d: failed to create request: %v", attempt, err)
 		return outcomeFailover
 	}
-
-	util.SetProviderAuthHeaders(proxyReq, providerType, candidate.apiKey)
-	proxyReq.Header.Set("Content-Type", "application/json")
-	debuglog.Debug("proxy: sending upstream request", "method", proxyReq.Method, "url", targetURL, "content_length", len(upstreamBody), "has_api_key", candidate.apiKey != "")
 
 	// Reuse the shared upstream Transport instead of creating a new one
 	// per request. A fresh Transport spawns persistent readLoop/writeLoop
@@ -342,6 +323,41 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 
 	h.handleNonStreamingResponse(w, r, logData, resp, st.startTime, st.proxyOverhead, st.parseMs, st.timings.failoverLookupMs, st.timings.modelLookupMs, st.timings.providerLookupMs, st.timings.keyDecryptMs, st.timings.dialMs, st.timings.settingsReadMs, responseHeaderMs, st.vkHash, attempt)
 	return outcomeServed
+}
+
+// buildCandidateRequest builds the upstream HTTP request for a single failover
+// candidate (phase C): detect the provider type, build the target URL, rewrite
+// the request body when needed, create the request on the provided context, and
+// set the auth + content-type headers. The caller owns ctx cancellation; this
+// helper never cancels it. providerType and targetURL are returned so the caller
+// can thread them into the 400 auto-retry path.
+func (h *Handler) buildCandidateRequest(ctx context.Context, st *requestState, candidate modelCandidate) (*http.Request, string, string, error) {
+	logData := st.logData
+	providerType := provider.DetectProviderType(candidate.provider.BaseURL)
+	debuglog.Debug("proxy: detected provider type", "provider_type", providerType, "base_url", util.SanitizeBaseURL(candidate.provider.BaseURL))
+	targetURL := util.BuildProviderTargetURL(candidate.provider.BaseURL, providerType)
+	debuglog.Debug("proxy: built target URL", "target_url", targetURL)
+
+	upstreamBody := st.bodyBytes
+	needsRewrite := st.reqModel != candidate.model.ModelID || providerType == "anthropic" || NeedsProviderInjection(providerType) || st.isStreaming
+	debuglog.Debug("proxy: request rewrite check", "needs_rewrite", needsRewrite, "request_model", logData.modelID, "provider", logData.providerName, "resolved_model", candidate.model.ModelID, "provider_type", providerType)
+	if needsRewrite {
+		upstreamBody = buildUpstreamBody(st.bodyBytes, providerType, candidate.model.ModelID, st.reqModel, st.isStreaming, &h.deprecationCache, nil)
+	}
+	// Log the actual model name in the upstream body for debugging rewrite issues.
+	if upstreamModel, _, _ := strings.Cut(string(upstreamBody), ","); strings.Contains(upstreamModel, `"model"`) {
+		debuglog.Debug("proxy: upstream body model", "upstream_model_snippet", upstreamModel)
+	}
+
+	proxyReq, err := newRequestWithContext(ctx, "POST", targetURL, bytes.NewReader(upstreamBody))
+	if err != nil {
+		return nil, providerType, targetURL, err
+	}
+
+	util.SetProviderAuthHeaders(proxyReq, providerType, candidate.apiKey)
+	proxyReq.Header.Set("Content-Type", "application/json")
+	debuglog.Debug("proxy: sending upstream request", "method", proxyReq.Method, "url", targetURL, "content_length", len(upstreamBody), "has_api_key", candidate.apiKey != "")
+	return proxyReq, providerType, targetURL, nil
 }
 
 // recordBreakerOutcome records the circuit-breaker result for a completed

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -179,64 +179,75 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 
 	debuglog.Debug("proxy: upstream responded OK, dispatching to handler", "stream", st.isStreaming, "model", logData.modelID, "provider", logData.providerName, "provider_id", candidate.provider.ID, "status", resp.StatusCode)
 	if st.isStreaming {
-		ttftTimeout := h.settingsRepo.GetDuration(r.Context(), "ttft_timeout", 60*time.Second)
-		stallTimeout := h.settingsRepo.GetDuration(r.Context(), "stream_stall_timeout", 30*time.Second)
-
-		opts := streamOptions{
-			responseHeaderMs:   responseHeaderMs,
-			streamStallTimeout: stallTimeout,
-			providerID:         candidate.provider.ID,
-			providerName:       candidate.provider.Name,
-			circuitBreakerOn:   st.circuitBreakerEnabled,
-			proxyOverheadMs:    st.proxyOverhead,
-			parseMs:            st.parseMs,
-			failoverLookupMs:   st.timings.failoverLookupMs,
-			modelLookupMs:      st.timings.modelLookupMs,
-			providerLookupMs:   st.timings.providerLookupMs,
-			keyDecryptMs:       st.timings.keyDecryptMs,
-			dialMs:             st.timings.dialMs,
-			settingsReadMs:     st.timings.settingsReadMs,
-			vkHash:             st.vkHash,
-			attempt:            attempt,
-			cancelOrigin:       streamCancelOrigin,
-		}
-
-		if ttftTimeout > 0 {
-			// TTFT probe: read until first real data chunk.
-			probeBuf, trueTtftMs, probeErr := h.probeFirstToken(r.Context(), resp.Body, ttftTimeout, st.startTime)
-			if probeErr != nil {
-				// Timeout or read error — failover. probeFirstToken may
-				// or may not have closed the body (only on DeadlineExceeded);
-				// close it unconditionally to release the connection.
-				_ = resp.Body.Close()
-				// Skip circuit-breaker recording when the client disconnected:
-				// the probe failed because r.Context() was cancelled, not because
-				// the provider was unhealthy.
-				if st.circuitBreakerEnabled && r.Context().Err() == nil {
-					h.circuitBreaker.RecordFailure(candidate.provider.ID, candidate.provider.Name)
-				}
-				st.lastErr = fmt.Sprintf("attempt %d: %v", attempt, probeErr)
-				logData.failoverAttempt = attempt
-				logData.responseHeaderMs = responseHeaderMs
-				debuglog.Warn("proxy: TTFT probe failed", "attempt", attempt+1, "provider", candidate.provider.Name, "error", probeErr)
-				return outcomeFailover
-			}
-			// First token confirmed (or [DONE] received).
-			if st.circuitBreakerEnabled {
-				h.circuitBreaker.RecordSuccess(candidate.provider.ID, candidate.provider.Name)
-			}
-			opts.preReadBuf = probeBuf
-			opts.trueTtftMs = trueTtftMs
-		} else if st.circuitBreakerEnabled {
-			// Disabled — immediate commit (backward compat).
-			h.circuitBreaker.RecordSuccess(candidate.provider.ID, candidate.provider.Name)
-		}
-
-		h.handleStreamingResponse(w, r, logData, resp, st.startTime, opts)
-		return outcomeServed
+		return h.dispatchStreaming(w, r, st, candidate, resp, attempt, responseHeaderMs, streamCancelOrigin)
 	}
 
 	h.handleNonStreamingResponse(w, r, logData, resp, st.startTime, st.proxyOverhead, st.parseMs, st.timings.failoverLookupMs, st.timings.modelLookupMs, st.timings.providerLookupMs, st.timings.keyDecryptMs, st.timings.dialMs, st.timings.settingsReadMs, responseHeaderMs, st.vkHash, attempt)
+	return outcomeServed
+}
+
+// dispatchStreaming serves a streaming 200 response (phase H): read the TTFT and
+// stall timeouts, build the streamOptions, run the TTFT probe (on success commit
+// the breaker and stash the pre-read buffer; on failure close the body, record a
+// breaker failure unless the client disconnected, and fail over), then hand off
+// to handleStreamingResponse. Returns outcomeServed on a served stream or
+// outcomeFailover when the probe fails.
+func (h *Handler) dispatchStreaming(w http.ResponseWriter, r *http.Request, st *requestState, candidate modelCandidate, resp *http.Response, attempt int, responseHeaderMs float64, streamCancelOrigin string) candidateOutcome {
+	logData := st.logData
+	ttftTimeout := h.settingsRepo.GetDuration(r.Context(), "ttft_timeout", 60*time.Second)
+	stallTimeout := h.settingsRepo.GetDuration(r.Context(), "stream_stall_timeout", 30*time.Second)
+
+	opts := streamOptions{
+		responseHeaderMs:   responseHeaderMs,
+		streamStallTimeout: stallTimeout,
+		providerID:         candidate.provider.ID,
+		providerName:       candidate.provider.Name,
+		circuitBreakerOn:   st.circuitBreakerEnabled,
+		proxyOverheadMs:    st.proxyOverhead,
+		parseMs:            st.parseMs,
+		failoverLookupMs:   st.timings.failoverLookupMs,
+		modelLookupMs:      st.timings.modelLookupMs,
+		providerLookupMs:   st.timings.providerLookupMs,
+		keyDecryptMs:       st.timings.keyDecryptMs,
+		dialMs:             st.timings.dialMs,
+		settingsReadMs:     st.timings.settingsReadMs,
+		vkHash:             st.vkHash,
+		attempt:            attempt,
+		cancelOrigin:       streamCancelOrigin,
+	}
+
+	if ttftTimeout > 0 {
+		// TTFT probe: read until first real data chunk.
+		probeBuf, trueTtftMs, probeErr := h.probeFirstToken(r.Context(), resp.Body, ttftTimeout, st.startTime)
+		if probeErr != nil {
+			// Timeout or read error — failover. probeFirstToken may
+			// or may not have closed the body (only on DeadlineExceeded);
+			// close it unconditionally to release the connection.
+			_ = resp.Body.Close()
+			// Skip circuit-breaker recording when the client disconnected:
+			// the probe failed because r.Context() was cancelled, not because
+			// the provider was unhealthy.
+			if st.circuitBreakerEnabled && r.Context().Err() == nil {
+				h.circuitBreaker.RecordFailure(candidate.provider.ID, candidate.provider.Name)
+			}
+			st.lastErr = fmt.Sprintf("attempt %d: %v", attempt, probeErr)
+			logData.failoverAttempt = attempt
+			logData.responseHeaderMs = responseHeaderMs
+			debuglog.Warn("proxy: TTFT probe failed", "attempt", attempt+1, "provider", candidate.provider.Name, "error", probeErr)
+			return outcomeFailover
+		}
+		// First token confirmed (or [DONE] received).
+		if st.circuitBreakerEnabled {
+			h.circuitBreaker.RecordSuccess(candidate.provider.ID, candidate.provider.Name)
+		}
+		opts.preReadBuf = probeBuf
+		opts.trueTtftMs = trueTtftMs
+	} else if st.circuitBreakerEnabled {
+		// Disabled — immediate commit (backward compat).
+		h.circuitBreaker.RecordSuccess(candidate.provider.ID, candidate.provider.Name)
+	}
+
+	h.handleStreamingResponse(w, r, logData, resp, st.startTime, opts)
 	return outcomeServed
 }
 

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -128,67 +128,10 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 		return outcomeFailover
 	}
 
-	// Reuse the shared upstream Transport instead of creating a new one
-	// per request. A fresh Transport spawns persistent readLoop/writeLoop
-	// goroutines per connection that only die after IdleConnTimeout, so
-	// creating one per request causes unbounded goroutine growth.
-	// Inject per-request dial timing pointer so SafeDialer writes
-	// DNS resolution time into this request's own variable, avoiding
-	// cross-request race conditions on a shared atomic.
-	dialCtx := context.WithValue(failoverCtx, ctxkeys.DialMsKey, &dialMs)
-	proxyReq = proxyReq.WithContext(dialCtx)
-
-	var checkRedirect func(req *http.Request, via []*http.Request) error
-	if h.safeDialer != nil {
-		checkRedirect = h.safeDialer.CheckRedirect
-	}
-	upstreamClient := &http.Client{
-		Transport:     h.upstreamTransport,
-		CheckRedirect: checkRedirect,
-	}
-	//nolint:gosec // provider URL is admin-configured, not arbitrary user input
-	resp, err := upstreamClient.Do(proxyReq)
-	st.timings.dialMs += dialMs
-	dialMs = 0
-	st.proxyOverhead = st.timings.proxyOverheadMs(st.parseMs)
-	if err != nil {
-		// Determine the origin of context cancellation for actionable errors.
-		// "context canceled" is opaque — we need to know if the client
-		// disconnected, the failover timeout expired, or the retry timeout expired.
-		// Key insight: context.Canceled means the parent (client) context was
-		// canceled — always a client disconnect. context.DeadlineExceeded means
-		// the derived context's deadline expired — read CancelOriginKey to
-		// distinguish failover_timeout from retry_timeout.
-		isContextErr := errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
-		if isContextErr {
-			cancelOrigin := "client_disconnect"
-			if errors.Is(err, context.DeadlineExceeded) {
-				if v := proxyReq.Context().Value(ctxkeys.CancelOriginKey); v != nil {
-					if s, ok := v.(string); ok {
-						cancelOrigin = s
-					}
-				}
-			}
-			st.lastErr = fmt.Sprintf("attempt %d: %s", attempt, humanReadableCancelOrigin(cancelOrigin))
-			debuglog.Info("proxy: context cancelled during request to provider", "provider", logData.providerName, "provider_id", candidate.provider.ID, "model", logData.modelID, "origin", cancelOrigin, "error", err)
-		} else {
-			st.lastErr = fmt.Sprintf("attempt %d: provider error: %v", attempt, err)
-			debuglog.Warn("proxy: upstream request failed", "attempt", attempt+1, "provider", candidate.provider.Name, "provider_id", candidate.provider.ID, "error", err)
-		}
-		// Client-initiated cancellations and deadline exceeded are not
-		// provider failures. If the caller disconnected (Canceled) or
-		// the request timed out (DeadlineExceeded), we must not penalize
-		// the circuit breaker for that.
-		if !isContextErr {
-			if st.circuitBreakerEnabled {
-				h.circuitBreaker.RecordFailure(candidate.provider.ID, candidate.provider.Name)
-			}
-		}
+	resp, ok := h.doUpstream(failoverCtx, proxyReq, st, candidate, attempt, &dialMs)
+	if !ok {
 		return outcomeFailover
 	}
-
-	// Log upstream response metadata for debugging.
-	debuglog.Debug("proxy: upstream response received", "provider", candidate.provider.Name, "provider_id", candidate.provider.ID, "model", candidate.model.ModelID, "status", resp.StatusCode, "content_type", resp.Header.Get("Content-Type"), "x_request_id", resp.Header.Get("X-Request-Id"), "x_ratelimit_remaining", resp.Header.Get("X-RateLimit-Remaining"), "attempt", attempt+1)
 
 	// Auto-retry param-rejection 400s: parse the error, learn which params
 	// are rejected for this model, strip them, and retry once.
@@ -358,6 +301,81 @@ func (h *Handler) buildCandidateRequest(ctx context.Context, st *requestState, c
 	proxyReq.Header.Set("Content-Type", "application/json")
 	debuglog.Debug("proxy: sending upstream request", "method", proxyReq.Method, "url", targetURL, "content_length", len(upstreamBody), "has_api_key", candidate.apiKey != "")
 	return proxyReq, providerType, targetURL, nil
+}
+
+// doUpstream executes the built request against the shared upstream transport
+// (phase D): inject the per-request dial-timing pointer, run the request, fold
+// the dial sample into the running timings (and reset it to 0 for any retry),
+// and recompute proxy overhead. On failure it classifies the cause — client
+// disconnect vs failover/retry timeout vs provider error — and records a breaker
+// failure only for real provider errors, never for context cancellation.
+// Returns (resp, true) on a usable response; (nil, false) after setting
+// st.lastErr on a failover-worthy failure. The caller retains ownership of ctx
+// cancellation.
+func (h *Handler) doUpstream(ctx context.Context, req *http.Request, st *requestState, candidate modelCandidate, attempt int, dialMs *float64) (*http.Response, bool) {
+	logData := st.logData
+	// Reuse the shared upstream Transport instead of creating a new one
+	// per request. A fresh Transport spawns persistent readLoop/writeLoop
+	// goroutines per connection that only die after IdleConnTimeout, so
+	// creating one per request causes unbounded goroutine growth.
+	// Inject per-request dial timing pointer so SafeDialer writes
+	// DNS resolution time into this request's own variable, avoiding
+	// cross-request race conditions on a shared atomic.
+	dialCtx := context.WithValue(ctx, ctxkeys.DialMsKey, dialMs)
+	req = req.WithContext(dialCtx)
+
+	var checkRedirect func(req *http.Request, via []*http.Request) error
+	if h.safeDialer != nil {
+		checkRedirect = h.safeDialer.CheckRedirect
+	}
+	upstreamClient := &http.Client{
+		Transport:     h.upstreamTransport,
+		CheckRedirect: checkRedirect,
+	}
+	//nolint:gosec // provider URL is admin-configured, not arbitrary user input
+	resp, err := upstreamClient.Do(req)
+	st.timings.dialMs += *dialMs
+	*dialMs = 0
+	st.proxyOverhead = st.timings.proxyOverheadMs(st.parseMs)
+	if err != nil {
+		// Determine the origin of context cancellation for actionable errors.
+		// "context canceled" is opaque — we need to know if the client
+		// disconnected, the failover timeout expired, or the retry timeout expired.
+		// Key insight: context.Canceled means the parent (client) context was
+		// canceled — always a client disconnect. context.DeadlineExceeded means
+		// the derived context's deadline expired — read CancelOriginKey to
+		// distinguish failover_timeout from retry_timeout.
+		isContextErr := errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+		if isContextErr {
+			cancelOrigin := "client_disconnect"
+			if errors.Is(err, context.DeadlineExceeded) {
+				if v := req.Context().Value(ctxkeys.CancelOriginKey); v != nil {
+					if s, ok := v.(string); ok {
+						cancelOrigin = s
+					}
+				}
+			}
+			st.lastErr = fmt.Sprintf("attempt %d: %s", attempt, humanReadableCancelOrigin(cancelOrigin))
+			debuglog.Info("proxy: context cancelled during request to provider", "provider", logData.providerName, "provider_id", candidate.provider.ID, "model", logData.modelID, "origin", cancelOrigin, "error", err)
+		} else {
+			st.lastErr = fmt.Sprintf("attempt %d: provider error: %v", attempt, err)
+			debuglog.Warn("proxy: upstream request failed", "attempt", attempt+1, "provider", candidate.provider.Name, "provider_id", candidate.provider.ID, "error", err)
+		}
+		// Client-initiated cancellations and deadline exceeded are not
+		// provider failures. If the caller disconnected (Canceled) or
+		// the request timed out (DeadlineExceeded), we must not penalize
+		// the circuit breaker for that.
+		if !isContextErr {
+			if st.circuitBreakerEnabled {
+				h.circuitBreaker.RecordFailure(candidate.provider.ID, candidate.provider.Name)
+			}
+		}
+		return nil, false
+	}
+
+	// Log upstream response metadata for debugging.
+	debuglog.Debug("proxy: upstream response received", "provider", candidate.provider.Name, "provider_id", candidate.provider.ID, "model", candidate.model.ModelID, "status", resp.StatusCode, "content_type", resp.Header.Get("Content-Type"), "x_request_id", resp.Header.Get("X-Request-Id"), "x_ratelimit_remaining", resp.Header.Get("X-RateLimit-Remaining"), "attempt", attempt+1)
+	return resp, true
 }
 
 // recordBreakerOutcome records the circuit-breaker result for a completed

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -2851,6 +2851,161 @@ func TestChatCompletions_UpstreamErrorForwarding(t *testing.T) {
 		}
 	})
 
+	t.Run("non-JSON error body wrapped in OpenAI envelope", func(t *testing.T) {
+		pool := testDB.Pool()
+		ctx := context.Background()
+
+		settingsRepo := settings.NewRepository(pool)
+		failoverRepo := failover.NewRepository(pool)
+		modelRepo := model.NewRepository(pool)
+		providerRepo := provider.NewRepository(pool)
+		virtualKeyRepo := virtualkey.NewRepository(pool)
+		limiter := ratelimit.NewLimiter(settingsRepo)
+		ipLimiter := ratelimit.NewIPLimiter(30, 60, nil, nil)
+
+		masterKey := "test-master-key-for-nonjson-body"
+
+		// First provider returns a non-failover-eligible status (422) with a
+		// non-JSON body (e.g. HTML from a CDN). With a candidate remaining this
+		// exercises forwardUpstreamError's else branch: wrap the body in an
+		// OpenAI-compatible error envelope rather than forwarding raw HTML.
+		callCount := 0
+		htmlBody := `<html><body>502 Bad Gateway (cloudflare)</body></html>`
+		upstream1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.Header().Set("Content-Type", "text/html")
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			w.Write([]byte(htmlBody))
+		}))
+		defer upstream1.Close()
+
+		upstream2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Second provider succeeds (we should never reach here for 422).
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"id": "cmpl-2", "choices": [{"message": {"content": "success"}}]}`))
+		}))
+		defer upstream2.Close()
+
+		keyPair1, err := auth.Encrypt("test-api-key-1", masterKey)
+		if err != nil {
+			t.Fatalf("failed to encrypt key1: %v", err)
+		}
+		keyPair2, err := auth.Encrypt("test-api-key-2", masterKey)
+		if err != nil {
+			t.Fatalf("failed to encrypt key2: %v", err)
+		}
+
+		provName1 := "nonjson-prov-1-" + uuid.New().String()[:8]
+		prov1, err := providerRepo.Create(ctx, provider.CreateProviderRequest{
+			Name:    provName1,
+			BaseURL: upstream1.URL,
+			APIKey:  "test-api-key-1",
+		}, keyPair1.Ciphertext, keyPair1.Nonce, keyPair1.Salt)
+		if err != nil {
+			t.Fatalf("failed to create provider1: %v", err)
+		}
+
+		provName2 := "nonjson-prov-2-" + uuid.New().String()[:8]
+		prov2, err := providerRepo.Create(ctx, provider.CreateProviderRequest{
+			Name:    provName2,
+			BaseURL: upstream2.URL,
+			APIKey:  "test-api-key-2",
+		}, keyPair2.Ciphertext, keyPair2.Nonce, keyPair2.Salt)
+		if err != nil {
+			t.Fatalf("failed to create provider2: %v", err)
+		}
+
+		modelName := "nonjson-model-" + uuid.New().String()[:8]
+		model1 := &model.Model{
+			ID: uuid.New(), ProviderID: prov1.ID, ModelID: modelName,
+			Name: "NonJSON Model 1", Description: "", Capabilities: "{}",
+			Params: "{}", Modality: "", InputModalities: "[]", OutputModalities: "[]",
+			Enabled: true, ProviderName: provName1, ProviderEnabled: true,
+		}
+		if err := modelRepo.Upsert(ctx, model1); err != nil {
+			t.Fatalf("failed to upsert model1: %v", err)
+		}
+
+		model2 := &model.Model{
+			ID: uuid.New(), ProviderID: prov2.ID, ModelID: modelName,
+			Name: "NonJSON Model 2", Description: "", Capabilities: "{}",
+			Params: "{}", Modality: "", InputModalities: "[]", OutputModalities: "[]",
+			Enabled: true, ProviderName: provName2, ProviderEnabled: true,
+		}
+		if err := modelRepo.Upsert(ctx, model2); err != nil {
+			t.Fatalf("failed to upsert model2: %v", err)
+		}
+
+		// Create failover group with both models
+		if _, err := failoverRepo.UpsertWithConfig(ctx, modelName,
+			[]uuid.UUID{model1.ID, model2.ID},
+			map[string]bool{}, nil, nil, nil, nil,
+		); err != nil {
+			t.Fatalf("failed to create failover group: %v", err)
+		}
+
+		vkName := "nonjson-test-key-" + uuid.New().String()[:8]
+		vkHash := virtualkey.Hash(vkName)
+		if _, err := virtualKeyRepo.Create(ctx, vkName, vkHash, "nj-"+vkHash[:8], nil, nil, nil, nil); err != nil {
+			t.Fatalf("failed to create virtual key: %v", err)
+		}
+
+		handler := &Handler{
+			cfg:            &config.Config{MasterKey: masterKey},
+			settingsRepo:   settingsRepo,
+			failoverRepo:   failoverRepo,
+			modelRepo:      modelRepo,
+			providerRepo:   providerRepo,
+			virtualKeyRepo: WrapVirtualKeyRepo(virtualKeyRepo),
+			rateLimiter:    limiter,
+			ipLimiter:      ipLimiter,
+			circuitBreaker: failover.NewCircuitBreaker(settingsRepo),
+			dbPool:         pool,
+			upstreamTransport: &http.Transport{
+				DialContext:           NewSafeDialer(append(config.KnownProviderHosts(), "127.0.0.1"), nil).DialContext,
+				ResponseHeaderTimeout: 120 * time.Second,
+				IdleConnTimeout:       120 * time.Second,
+				MaxIdleConns:          200,
+				MaxIdleConnsPerHost:   20,
+			},
+			safeDialer: NewSafeDialer(nil, nil),
+		}
+		defer handler.upstreamTransport.CloseIdleConnections()
+
+		// Use hotel/ format to trigger failover group
+		body := `{"model": "hotel/` + modelName + `", "messages": [{"role": "user", "content": "hello"}], "stream": false}`
+		req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(body))
+		rCtx := context.WithValue(req.Context(), virtualKeyNameKey, vkName)
+		rCtx = context.WithValue(rCtx, virtualKeyIDKey, uuid.New().String())
+		rCtx = context.WithValue(rCtx, VirtualKeyHashKey, vkHash)
+		req = req.WithContext(rCtx)
+
+		w := httptest.NewRecorder()
+		handler.ChatCompletions(w, req)
+
+		// 422 is NOT failover-eligible, so the first provider is terminal even
+		// with a candidate remaining; the non-JSON body is wrapped, not raw.
+		if w.Code != http.StatusUnprocessableEntity {
+			t.Errorf("expected status 422, got %d", w.Code)
+		}
+		bodyStr := w.Body.String()
+		// Response must be a valid JSON OpenAI-error envelope, never raw HTML.
+		if !json.Valid([]byte(bodyStr)) {
+			t.Errorf("expected wrapped JSON envelope, got non-JSON: %s", bodyStr)
+		}
+		if strings.HasPrefix(strings.TrimSpace(bodyStr), "<") {
+			t.Errorf("expected wrapped envelope, got raw HTML: %s", bodyStr)
+		}
+		// The sanitized upstream message should be carried in the envelope.
+		if !strings.Contains(bodyStr, "Bad Gateway") {
+			t.Errorf("expected upstream message in envelope, got: %s", bodyStr)
+		}
+		// Verify we only called the first provider (no failover for 422).
+		if callCount != 1 {
+			t.Errorf("expected 1 call (no failover for 422), got %d", callCount)
+		}
+	})
+
 	t.Run("all candidates exhausted returns generic error", func(t *testing.T) {
 		pool := testDB.Pool()
 		ctx := context.Background()


### PR DESCRIPTION
## What

Decomposes `(*Handler).attemptCandidate` in `internal/proxy/proxy_failover.go` — previously the largest production function in the repo (266 lines, 29 branches, on the proxy hot path) — into a thin orchestrator over four well-bounded phase helpers. **Pure restructuring: no behavior, timing, or circuit-breaker change.**

`attemptCandidate` goes from 266 → 108 lines (the remainder being its doc comment, the `TouchLastUsed` goroutine, the `failoverCancel`/`retryCancel` defers, the 400-retry, and the breaker decision — all deliberately kept inline).

## How (one concern per commit)

| Commit | Helper | Extracted |
|--------|--------|-----------|
| AC1 | `buildCandidateRequest` | provider-type detect, target URL, body rewrite, request build, auth headers |
| AC2 | `doUpstream` | client `Do`, dial-timing fold, cancel-origin classification, breaker-on-hard-failure |
| AC3 | `forwardUpstreamError` | non-200 terminal branch (failRequest + forward-or-generic-error) |
| AC4 | `dispatchStreaming` | TTFT probe + breaker commit + `streamOptions` build + handoff |

## Invariants preserved

- The `failoverCtx`/`retryCancel` defers stay in `attemptCandidate` (they guard the whole function); helpers receive the context but never own cancellation.
- The per-attempt `&dialMs` pointer plumbing (`DialMsKey`) and the `st.timings.dialMs` fold + `proxyOverhead` recompute ordering are unchanged; the 400-retry stays inline so its second dial-sample fold keeps the same ordering.
- Cancellation-origin classification (`client_disconnect` / `failover_timeout` / `retry_timeout`) and the "don't penalize the breaker on client cancel" rule move verbatim into `doUpstream`.
- Breaker call sites (hard-failure / decision / TTFT) are not reordered or consolidated; the streaming-200 success stays deferred to the TTFT probe.
- Each terminal path still drains/closes `resp.Body` exactly once.

## Testing

`internal/proxy` is the most heavily-tested package (breaker sequence, failover-with-backoff, client-disconnect, TTFT/stall, param-retry, upstream-error-forwarding). Full `go test ./internal/proxy/...` green after **every** phase; `golangci-lint run ./...` clean; `go build ./...` clean. The test suite is unchanged — it is the contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)