### PR TITLE
test(proxy): extract newCanonicalHandler to dedupe test wiring

### DIFF
--- a/internal/proxy/chat_integration_test.go
+++ b/internal/proxy/chat_integration_test.go
@@ -140,26 +140,7 @@ func newTestProxyHandler(t *testing.T) *testProxyEnv {
 		t.Fatalf("failed to create virtual key: %v", err)
 	}
 
-	handler := &Handler{
-		cfg:            &config.Config{MasterKey: "test-master-key-for-integration"},
-		settingsRepo:   settingsRepo,
-		failoverRepo:   failoverRepo,
-		modelRepo:      modelRepo,
-		providerRepo:   providerRepo,
-		virtualKeyRepo: WrapVirtualKeyRepo(virtualKeyRepo),
-		rateLimiter:    limiter,
-		ipLimiter:      ipLimiter,
-		circuitBreaker: failover.NewCircuitBreaker(settingsRepo),
-		dbPool:         pool,
-		upstreamTransport: &http.Transport{
-			DialContext:           NewSafeDialer(append(config.KnownProviderHosts(), "127.0.0.1"), nil).DialContext,
-			ResponseHeaderTimeout: 120 * time.Second,
-			IdleConnTimeout:       120 * time.Second,
-			MaxIdleConns:          200,
-			MaxIdleConnsPerHost:   20,
-		},
-		safeDialer: NewSafeDialer(nil, nil),
-	}
+	handler := newCanonicalHandler(t, "test-master-key-for-integration", pool, settingsRepo, failoverRepo, modelRepo, providerRepo, virtualKeyRepo, limiter, ipLimiter)
 
 	return &testProxyEnv{
 		Handler:      handler,
@@ -639,26 +620,7 @@ func TestChatCompletions_NonStreaming_Upstream4xxError(t *testing.T) {
 	}
 	defer func() { _ = virtualKeyRepo.Delete(context.Background(), virtualKey.ID) }()
 
-	handler := &Handler{
-		cfg:            &config.Config{MasterKey: "test-master-key-for-integration"},
-		settingsRepo:   settingsRepo,
-		failoverRepo:   failoverRepo,
-		modelRepo:      modelRepo,
-		providerRepo:   providerRepo,
-		virtualKeyRepo: WrapVirtualKeyRepo(virtualKeyRepo),
-		rateLimiter:    limiter,
-		ipLimiter:      ipLimiter,
-		circuitBreaker: failover.NewCircuitBreaker(settingsRepo),
-		dbPool:         pool,
-		upstreamTransport: &http.Transport{
-			DialContext:           NewSafeDialer(append(config.KnownProviderHosts(), "127.0.0.1"), nil).DialContext,
-			ResponseHeaderTimeout: 120 * time.Second,
-			IdleConnTimeout:       120 * time.Second,
-			MaxIdleConns:          200,
-			MaxIdleConnsPerHost:   20,
-		},
-		safeDialer: NewSafeDialer(nil, nil),
-	}
+	handler := newCanonicalHandler(t, "test-master-key-for-integration", pool, settingsRepo, failoverRepo, modelRepo, providerRepo, virtualKeyRepo, limiter, ipLimiter)
 
 	body := `{"model": "` + providerName + `/error-model", "messages": [{"role": "user", "content": "hello"}], "stream": false}`
 	req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(body))
@@ -751,26 +713,7 @@ func TestChatCompletions_NonStreaming_Upstream5xxError(t *testing.T) {
 	}
 	defer func() { _ = virtualKeyRepo.Delete(context.Background(), virtualKey.ID) }()
 
-	handler := &Handler{
-		cfg:            &config.Config{MasterKey: "test-master-key-for-integration"},
-		settingsRepo:   settingsRepo,
-		failoverRepo:   failoverRepo,
-		modelRepo:      modelRepo,
-		providerRepo:   providerRepo,
-		virtualKeyRepo: WrapVirtualKeyRepo(virtualKeyRepo),
-		rateLimiter:    limiter,
-		ipLimiter:      ipLimiter,
-		circuitBreaker: failover.NewCircuitBreaker(settingsRepo),
-		dbPool:         pool,
-		upstreamTransport: &http.Transport{
-			DialContext:           NewSafeDialer(append(config.KnownProviderHosts(), "127.0.0.1"), nil).DialContext,
-			ResponseHeaderTimeout: 120 * time.Second,
-			IdleConnTimeout:       120 * time.Second,
-			MaxIdleConns:          200,
-			MaxIdleConnsPerHost:   20,
-		},
-		safeDialer: NewSafeDialer(nil, nil),
-	}
+	handler := newCanonicalHandler(t, "test-master-key-for-integration", pool, settingsRepo, failoverRepo, modelRepo, providerRepo, virtualKeyRepo, limiter, ipLimiter)
 
 	body := `{"model": "` + providerName + `/error-model-5xx", "messages": [{"role": "user", "content": "hello"}], "stream": false}`
 	req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(body))
@@ -961,26 +904,7 @@ func TestChatCompletions_FailoverWithBackoff(t *testing.T) {
 	virtualKey, _ := virtualKeyRepo.Create(context.Background(), "test-key", virtualkey.Hash("test-vk-failover"), "sk-tes...", nil, nil, nil, nil)
 	defer func() { _ = virtualKeyRepo.Delete(context.Background(), virtualKey.ID) }()
 
-	handler := &Handler{
-		cfg:            &config.Config{MasterKey: "test-master-key-for-integration"},
-		settingsRepo:   settingsRepo,
-		failoverRepo:   failoverRepo,
-		modelRepo:      modelRepo,
-		providerRepo:   providerRepo,
-		virtualKeyRepo: WrapVirtualKeyRepo(virtualKeyRepo),
-		rateLimiter:    limiter,
-		ipLimiter:      ipLimiter,
-		circuitBreaker: failover.NewCircuitBreaker(settingsRepo),
-		dbPool:         pool,
-		upstreamTransport: &http.Transport{
-			DialContext:           NewSafeDialer(append(config.KnownProviderHosts(), "127.0.0.1"), nil).DialContext,
-			ResponseHeaderTimeout: 120 * time.Second,
-			IdleConnTimeout:       120 * time.Second,
-			MaxIdleConns:          200,
-			MaxIdleConnsPerHost:   20,
-		},
-		safeDialer: NewSafeDialer(nil, nil),
-	}
+	handler := newCanonicalHandler(t, "test-master-key-for-integration", pool, settingsRepo, failoverRepo, modelRepo, providerRepo, virtualKeyRepo, limiter, ipLimiter)
 
 	body := `{"model": "hotel/` + groupName + `", "messages": [{"role": "user", "content": "hello"}], "stream": false}`
 	req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(body))
@@ -1099,26 +1023,7 @@ func TestChatCompletions_ClientDisconnectDuringBackoff(t *testing.T) {
 	virtualKey, _ := virtualKeyRepo.Create(context.Background(), "test-key", virtualkey.Hash("test-vk-disconnect"), "sk-tes...", nil, nil, nil, nil)
 	defer func() { _ = virtualKeyRepo.Delete(context.Background(), virtualKey.ID) }()
 
-	handler := &Handler{
-		cfg:            &config.Config{MasterKey: "test-master-key-for-integration"},
-		settingsRepo:   settingsRepo,
-		failoverRepo:   failoverRepo,
-		modelRepo:      modelRepo,
-		providerRepo:   providerRepo,
-		virtualKeyRepo: WrapVirtualKeyRepo(virtualKeyRepo),
-		rateLimiter:    limiter,
-		ipLimiter:      ipLimiter,
-		circuitBreaker: failover.NewCircuitBreaker(settingsRepo),
-		dbPool:         pool,
-		upstreamTransport: &http.Transport{
-			DialContext:           NewSafeDialer(append(config.KnownProviderHosts(), "127.0.0.1"), nil).DialContext,
-			ResponseHeaderTimeout: 120 * time.Second,
-			IdleConnTimeout:       120 * time.Second,
-			MaxIdleConns:          200,
-			MaxIdleConnsPerHost:   20,
-		},
-		safeDialer: NewSafeDialer(nil, nil),
-	}
+	handler := newCanonicalHandler(t, "test-master-key-for-integration", pool, settingsRepo, failoverRepo, modelRepo, providerRepo, virtualKeyRepo, limiter, ipLimiter)
 
 	body := `{"model": "hotel/` + groupName + `", "messages": [{"role": "user", "content": "hello"}], "stream": false}`
 	req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(body))
@@ -1237,26 +1142,7 @@ func TestChatCompletions_ParamRejectionAutoRetry(t *testing.T) {
 	virtualKey, _ := virtualKeyRepo.Create(context.Background(), "test-key", virtualkey.Hash("test-vk-retry"), "sk-tes...", nil, nil, nil, nil)
 	defer func() { _ = virtualKeyRepo.Delete(context.Background(), virtualKey.ID) }()
 
-	handler := &Handler{
-		cfg:            &config.Config{MasterKey: "test-master-key-for-integration"},
-		settingsRepo:   settingsRepo,
-		failoverRepo:   failoverRepo,
-		modelRepo:      modelRepo,
-		providerRepo:   providerRepo,
-		virtualKeyRepo: WrapVirtualKeyRepo(virtualKeyRepo),
-		rateLimiter:    limiter,
-		ipLimiter:      ipLimiter,
-		circuitBreaker: failover.NewCircuitBreaker(settingsRepo),
-		dbPool:         pool,
-		upstreamTransport: &http.Transport{
-			DialContext:           NewSafeDialer(append(config.KnownProviderHosts(), "127.0.0.1"), nil).DialContext,
-			ResponseHeaderTimeout: 120 * time.Second,
-			IdleConnTimeout:       120 * time.Second,
-			MaxIdleConns:          200,
-			MaxIdleConnsPerHost:   20,
-		},
-		safeDialer: NewSafeDialer(nil, nil),
-	}
+	handler := newCanonicalHandler(t, "test-master-key-for-integration", pool, settingsRepo, failoverRepo, modelRepo, providerRepo, virtualKeyRepo, limiter, ipLimiter)
 
 	// Request with temperature parameter
 	body := `{"model": "` + providerName + `/retry-model", "messages": [{"role": "user", "content": "hello"}], "stream": false, "temperature": 0.7}`

--- a/internal/proxy/models_test.go
+++ b/internal/proxy/models_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/hugalafutro/model-hotel/internal/auth"
-	"github.com/hugalafutro/model-hotel/internal/config"
 	"github.com/hugalafutro/model-hotel/internal/failover"
 	"github.com/hugalafutro/model-hotel/internal/model"
 	"github.com/hugalafutro/model-hotel/internal/provider"
@@ -1575,26 +1574,7 @@ func TestListModels_MultipleProviders(t *testing.T) {
 	limiter := ratelimit.NewLimiter(settingsRepo)
 	ipLimiter := ratelimit.NewIPLimiter(30, 60, nil, nil)
 
-	handler := &Handler{
-		cfg:            &config.Config{MasterKey: "test-master-key"},
-		settingsRepo:   settingsRepo,
-		failoverRepo:   failoverRepo,
-		modelRepo:      modelRepo,
-		providerRepo:   providerRepo,
-		virtualKeyRepo: WrapVirtualKeyRepo(virtualKeyRepo),
-		rateLimiter:    limiter,
-		ipLimiter:      ipLimiter,
-		dbPool:         pool,
-		circuitBreaker: failover.NewCircuitBreaker(settingsRepo),
-		upstreamTransport: &http.Transport{
-			DialContext:           NewSafeDialer(append(config.KnownProviderHosts(), "127.0.0.1"), nil).DialContext,
-			ResponseHeaderTimeout: 120 * time.Second,
-			IdleConnTimeout:       120 * time.Second,
-			MaxIdleConns:          200,
-			MaxIdleConnsPerHost:   20,
-		},
-		safeDialer: NewSafeDialer(nil, nil),
-	}
+	handler := newCanonicalHandler(t, "test-master-key", pool, settingsRepo, failoverRepo, modelRepo, providerRepo, virtualKeyRepo, limiter, ipLimiter)
 
 	// Create two providers
 	keyPair1, err := auth.Encrypt("test-api-key-1", "test-master-key")
@@ -1743,26 +1723,7 @@ func TestListModels_NoModels(t *testing.T) {
 	limiter := ratelimit.NewLimiter(settingsRepo)
 	ipLimiter := ratelimit.NewIPLimiter(30, 60, nil, nil)
 
-	handler := &Handler{
-		cfg:            &config.Config{MasterKey: "test-master-key"},
-		settingsRepo:   settingsRepo,
-		failoverRepo:   failoverRepo,
-		modelRepo:      modelRepo,
-		providerRepo:   providerRepo,
-		virtualKeyRepo: WrapVirtualKeyRepo(virtualKeyRepo),
-		rateLimiter:    limiter,
-		ipLimiter:      ipLimiter,
-		dbPool:         pool,
-		circuitBreaker: failover.NewCircuitBreaker(settingsRepo),
-		upstreamTransport: &http.Transport{
-			DialContext:           NewSafeDialer(append(config.KnownProviderHosts(), "127.0.0.1"), nil).DialContext,
-			ResponseHeaderTimeout: 120 * time.Second,
-			IdleConnTimeout:       120 * time.Second,
-			MaxIdleConns:          200,
-			MaxIdleConnsPerHost:   20,
-		},
-		safeDialer: NewSafeDialer(nil, nil),
-	}
+	handler := newCanonicalHandler(t, "test-master-key", pool, settingsRepo, failoverRepo, modelRepo, providerRepo, virtualKeyRepo, limiter, ipLimiter)
 
 	req := httptest.NewRequest("GET", "/v1/models", http.NoBody)
 	req = withAuthContext(req)
@@ -1821,26 +1782,7 @@ func TestListModels_DisabledModelsFiltered(t *testing.T) {
 	limiter := ratelimit.NewLimiter(settingsRepo)
 	ipLimiter := ratelimit.NewIPLimiter(30, 60, nil, nil)
 
-	handler := &Handler{
-		cfg:            &config.Config{MasterKey: "test-master-key"},
-		settingsRepo:   settingsRepo,
-		failoverRepo:   failoverRepo,
-		modelRepo:      modelRepo,
-		providerRepo:   providerRepo,
-		virtualKeyRepo: WrapVirtualKeyRepo(virtualKeyRepo),
-		rateLimiter:    limiter,
-		ipLimiter:      ipLimiter,
-		dbPool:         pool,
-		circuitBreaker: failover.NewCircuitBreaker(settingsRepo),
-		upstreamTransport: &http.Transport{
-			DialContext:           NewSafeDialer(append(config.KnownProviderHosts(), "127.0.0.1"), nil).DialContext,
-			ResponseHeaderTimeout: 120 * time.Second,
-			IdleConnTimeout:       120 * time.Second,
-			MaxIdleConns:          200,
-			MaxIdleConnsPerHost:   20,
-		},
-		safeDialer: NewSafeDialer(nil, nil),
-	}
+	handler := newCanonicalHandler(t, "test-master-key", pool, settingsRepo, failoverRepo, modelRepo, providerRepo, virtualKeyRepo, limiter, ipLimiter)
 
 	// Create a provider
 	keyPair, err := auth.Encrypt("test-api-key", "test-master-key")
@@ -1976,26 +1918,7 @@ func TestListModels_WithFailoverGroups(t *testing.T) {
 	limiter := ratelimit.NewLimiter(settingsRepo)
 	ipLimiter := ratelimit.NewIPLimiter(30, 60, nil, nil)
 
-	handler := &Handler{
-		cfg:            &config.Config{MasterKey: "test-master-key"},
-		settingsRepo:   settingsRepo,
-		failoverRepo:   failoverRepo,
-		modelRepo:      modelRepo,
-		providerRepo:   providerRepo,
-		virtualKeyRepo: WrapVirtualKeyRepo(virtualKeyRepo),
-		rateLimiter:    limiter,
-		ipLimiter:      ipLimiter,
-		dbPool:         pool,
-		circuitBreaker: failover.NewCircuitBreaker(settingsRepo),
-		upstreamTransport: &http.Transport{
-			DialContext:           NewSafeDialer(append(config.KnownProviderHosts(), "127.0.0.1"), nil).DialContext,
-			ResponseHeaderTimeout: 120 * time.Second,
-			IdleConnTimeout:       120 * time.Second,
-			MaxIdleConns:          200,
-			MaxIdleConnsPerHost:   20,
-		},
-		safeDialer: NewSafeDialer(nil, nil),
-	}
+	handler := newCanonicalHandler(t, "test-master-key", pool, settingsRepo, failoverRepo, modelRepo, providerRepo, virtualKeyRepo, limiter, ipLimiter)
 
 	// Create a provider
 	keyPair, err := auth.Encrypt("test-api-key", "test-master-key")
@@ -2106,26 +2029,7 @@ func TestListModels_FilterByProvider(t *testing.T) {
 	limiter := ratelimit.NewLimiter(settingsRepo)
 	ipLimiter := ratelimit.NewIPLimiter(30, 60, nil, nil)
 
-	handler := &Handler{
-		cfg:            &config.Config{MasterKey: "test-master-key"},
-		settingsRepo:   settingsRepo,
-		failoverRepo:   failoverRepo,
-		modelRepo:      modelRepo,
-		providerRepo:   providerRepo,
-		virtualKeyRepo: WrapVirtualKeyRepo(virtualKeyRepo),
-		rateLimiter:    limiter,
-		ipLimiter:      ipLimiter,
-		dbPool:         pool,
-		circuitBreaker: failover.NewCircuitBreaker(settingsRepo),
-		upstreamTransport: &http.Transport{
-			DialContext:           NewSafeDialer(append(config.KnownProviderHosts(), "127.0.0.1"), nil).DialContext,
-			ResponseHeaderTimeout: 120 * time.Second,
-			IdleConnTimeout:       120 * time.Second,
-			MaxIdleConns:          200,
-			MaxIdleConnsPerHost:   20,
-		},
-		safeDialer: NewSafeDialer(nil, nil),
-	}
+	handler := newCanonicalHandler(t, "test-master-key", pool, settingsRepo, failoverRepo, modelRepo, providerRepo, virtualKeyRepo, limiter, ipLimiter)
 
 	// Create a provider
 	keyPair, err := auth.Encrypt("test-api-key", "test-master-key")

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/hugalafutro/model-hotel/internal/auth"
 	"github.com/hugalafutro/model-hotel/internal/config"
@@ -66,25 +67,61 @@ func newIntegrationHandler() *Handler {
 	limiter := ratelimit.NewLimiter(settingsRepo)
 	ipLimiter := ratelimit.NewIPLimiter(30, 60, nil, nil)
 	return &Handler{
-		cfg:            &config.Config{MasterKey: "test-master-key-for-proxy-tests"},
-		settingsRepo:   settingsRepo,
-		failoverRepo:   failoverRepo,
-		modelRepo:      modelRepo,
-		providerRepo:   providerRepo,
-		virtualKeyRepo: &virtualKeyRepoAdapter{repo: virtualKeyRepo},
-		rateLimiter:    limiter,
-		ipLimiter:      ipLimiter,
-		dbPool:         pool,
-		circuitBreaker: failover.NewCircuitBreaker(settingsRepo),
-		upstreamTransport: &http.Transport{
-			DialContext:           NewSafeDialer(append(config.KnownProviderHosts(), "127.0.0.1"), nil).DialContext,
-			ResponseHeaderTimeout: 120 * time.Second,
-			IdleConnTimeout:       120 * time.Second,
-			MaxIdleConns:          200,
-			MaxIdleConnsPerHost:   20,
-		},
-		safeDialer: NewSafeDialer(nil, nil),
+		cfg:               &config.Config{MasterKey: "test-master-key-for-proxy-tests"},
+		settingsRepo:      settingsRepo,
+		failoverRepo:      failoverRepo,
+		modelRepo:         modelRepo,
+		providerRepo:      providerRepo,
+		virtualKeyRepo:    &virtualKeyRepoAdapter{repo: virtualKeyRepo},
+		rateLimiter:       limiter,
+		ipLimiter:         ipLimiter,
+		dbPool:            pool,
+		circuitBreaker:    failover.NewCircuitBreaker(settingsRepo),
+		upstreamTransport: newCanonicalTransport(),
+		safeDialer:        NewSafeDialer(nil, nil),
 	}
+}
+
+// newCanonicalTransport returns the standard upstream transport used by proxy
+// integration tests: loopback plus known provider hosts allowed, 120s timeouts.
+func newCanonicalTransport() *http.Transport {
+	return &http.Transport{
+		DialContext:           NewSafeDialer(append(config.KnownProviderHosts(), "127.0.0.1"), nil).DialContext,
+		ResponseHeaderTimeout: 120 * time.Second,
+		IdleConnTimeout:       120 * time.Second,
+		MaxIdleConns:          200,
+		MaxIdleConnsPerHost:   20,
+	}
+}
+
+// newCanonicalHandler assembles a fully-wired proxy Handler from the standard
+// set of test repositories and rate limiters. It is the shared replacement for
+// the ~20-line &Handler{...} literal that integration tests would otherwise
+// repeat verbatim. The upstream transport's idle connections are closed via
+// t.Cleanup, and a fresh circuit breaker is created from settingsRepo.
+func newCanonicalHandler(t *testing.T, masterKey string, pool *pgxpool.Pool,
+	settingsRepo *settings.Repository, failoverRepo *failover.Repository,
+	modelRepo ModelRepository, providerRepo *provider.Repository,
+	virtualKeyRepo *virtualkey.Repository,
+	limiter *ratelimit.Limiter, ipLimiter *ratelimit.IPLimiter,
+) *Handler {
+	t.Helper()
+	h := &Handler{
+		cfg:               &config.Config{MasterKey: masterKey},
+		settingsRepo:      settingsRepo,
+		failoverRepo:      failoverRepo,
+		modelRepo:         modelRepo,
+		providerRepo:      providerRepo,
+		virtualKeyRepo:    WrapVirtualKeyRepo(virtualKeyRepo),
+		rateLimiter:       limiter,
+		ipLimiter:         ipLimiter,
+		circuitBreaker:    failover.NewCircuitBreaker(settingsRepo),
+		dbPool:            pool,
+		upstreamTransport: newCanonicalTransport(),
+		safeDialer:        NewSafeDialer(nil, nil),
+	}
+	t.Cleanup(func() { h.upstreamTransport.CloseIdleConnections() })
+	return h
 }
 
 // ---------------------------------------------------------------------------
@@ -1481,27 +1518,7 @@ func TestChatCompletions_FailoverAllProvidersExhausted(t *testing.T) {
 		t.Fatalf("failed to create virtual key: %v", err)
 	}
 
-	handler := &Handler{
-		cfg:            &config.Config{MasterKey: masterKey},
-		settingsRepo:   settingsRepo,
-		failoverRepo:   failoverRepo,
-		modelRepo:      modelRepo,
-		providerRepo:   providerRepo,
-		virtualKeyRepo: WrapVirtualKeyRepo(virtualKeyRepo),
-		rateLimiter:    limiter,
-		ipLimiter:      ipLimiter,
-		circuitBreaker: failover.NewCircuitBreaker(settingsRepo),
-		dbPool:         pool,
-		upstreamTransport: &http.Transport{
-			DialContext:           NewSafeDialer(append(config.KnownProviderHosts(), "127.0.0.1"), nil).DialContext,
-			ResponseHeaderTimeout: 120 * time.Second,
-			IdleConnTimeout:       120 * time.Second,
-			MaxIdleConns:          200,
-			MaxIdleConnsPerHost:   20,
-		},
-		safeDialer: NewSafeDialer(nil, nil),
-	}
-	defer handler.upstreamTransport.CloseIdleConnections()
+	handler := newCanonicalHandler(t, masterKey, pool, settingsRepo, failoverRepo, modelRepo, providerRepo, virtualKeyRepo, limiter, ipLimiter)
 
 	body := `{"model": "hotel/` + modelName + `", "messages": [{"role": "user", "content": "hello"}], "stream": false}`
 	req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(body))
@@ -1570,27 +1587,7 @@ func TestChatCompletions_SpecificProviderAllProvidersFail(t *testing.T) {
 		t.Fatalf("failed to create virtual key: %v", err)
 	}
 
-	handler := &Handler{
-		cfg:            &config.Config{MasterKey: masterKey},
-		settingsRepo:   settingsRepo,
-		failoverRepo:   failoverRepo,
-		modelRepo:      modelRepo,
-		providerRepo:   providerRepo,
-		virtualKeyRepo: WrapVirtualKeyRepo(virtualKeyRepo),
-		rateLimiter:    limiter,
-		ipLimiter:      ipLimiter,
-		circuitBreaker: failover.NewCircuitBreaker(settingsRepo),
-		dbPool:         pool,
-		upstreamTransport: &http.Transport{
-			DialContext:           NewSafeDialer(append(config.KnownProviderHosts(), "127.0.0.1"), nil).DialContext,
-			ResponseHeaderTimeout: 120 * time.Second,
-			IdleConnTimeout:       120 * time.Second,
-			MaxIdleConns:          200,
-			MaxIdleConnsPerHost:   20,
-		},
-		safeDialer: NewSafeDialer(nil, nil),
-	}
-	defer handler.upstreamTransport.CloseIdleConnections()
+	handler := newCanonicalHandler(t, masterKey, pool, settingsRepo, failoverRepo, modelRepo, providerRepo, virtualKeyRepo, limiter, ipLimiter)
 
 	// Use specific provider format (not hotel/) → single candidate → non-200 error forwarded
 	body := `{"model": "` + prov.Name + `/` + modelName + `", "messages": [{"role": "user", "content": "hello"}], "stream": false}`
@@ -1766,27 +1763,7 @@ func TestChatCompletions_RetryCancelDuringFailover(t *testing.T) {
 		t.Fatalf("failed to create virtual key: %v", err)
 	}
 
-	handler := &Handler{
-		cfg:            &config.Config{MasterKey: masterKey},
-		settingsRepo:   settingsRepo,
-		failoverRepo:   failoverRepo,
-		modelRepo:      modelRepo,
-		providerRepo:   providerRepo,
-		virtualKeyRepo: WrapVirtualKeyRepo(virtualKeyRepo),
-		rateLimiter:    limiter,
-		ipLimiter:      ipLimiter,
-		circuitBreaker: failover.NewCircuitBreaker(settingsRepo),
-		dbPool:         pool,
-		upstreamTransport: &http.Transport{
-			DialContext:           NewSafeDialer(append(config.KnownProviderHosts(), "127.0.0.1"), nil).DialContext,
-			ResponseHeaderTimeout: 120 * time.Second,
-			IdleConnTimeout:       120 * time.Second,
-			MaxIdleConns:          200,
-			MaxIdleConnsPerHost:   20,
-		},
-		safeDialer: NewSafeDialer(nil, nil),
-	}
-	defer handler.upstreamTransport.CloseIdleConnections()
+	handler := newCanonicalHandler(t, masterKey, pool, settingsRepo, failoverRepo, modelRepo, providerRepo, virtualKeyRepo, limiter, ipLimiter)
 
 	body := `{"model": "hotel/` + modelName + `", "stream": false, "messages": [{"role": "user", "content": "hello"}], "top_p": 0.9}`
 	req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(body))
@@ -1946,27 +1923,7 @@ func TestChatCompletions_TTFTProbeSuccess(t *testing.T) {
 		t.Fatalf("failed to create virtual key: %v", err)
 	}
 
-	handler := &Handler{
-		cfg:            &config.Config{MasterKey: masterKey},
-		settingsRepo:   settingsRepo,
-		failoverRepo:   failoverRepo,
-		modelRepo:      modelRepo,
-		providerRepo:   providerRepo,
-		virtualKeyRepo: WrapVirtualKeyRepo(virtualKeyRepo),
-		rateLimiter:    ratelimit.NewLimiter(settingsRepo),
-		ipLimiter:      ratelimit.NewIPLimiter(30, 60, nil, nil),
-		circuitBreaker: failover.NewCircuitBreaker(settingsRepo),
-		dbPool:         pool,
-		upstreamTransport: &http.Transport{
-			DialContext:           NewSafeDialer(append(config.KnownProviderHosts(), "127.0.0.1"), nil).DialContext,
-			ResponseHeaderTimeout: 120 * time.Second,
-			IdleConnTimeout:       120 * time.Second,
-			MaxIdleConns:          200,
-			MaxIdleConnsPerHost:   20,
-		},
-		safeDialer: NewSafeDialer(nil, nil),
-	}
-	defer handler.upstreamTransport.CloseIdleConnections()
+	handler := newCanonicalHandler(t, masterKey, pool, settingsRepo, failoverRepo, modelRepo, providerRepo, virtualKeyRepo, ratelimit.NewLimiter(settingsRepo), ratelimit.NewIPLimiter(30, 60, nil, nil))
 
 	body := fmt.Sprintf(`{"model":"%s/%s","messages":[{"role":"user","content":"hi"}],"stream":true}`, prov.Name, modelName)
 	req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(body))
@@ -2061,27 +2018,7 @@ func TestChatCompletions_TTFTProbeTimeout(t *testing.T) {
 		t.Fatalf("failed to create virtual key: %v", err)
 	}
 
-	handler := &Handler{
-		cfg:            &config.Config{MasterKey: masterKey},
-		settingsRepo:   settingsRepo,
-		failoverRepo:   failoverRepo,
-		modelRepo:      modelRepo,
-		providerRepo:   providerRepo,
-		virtualKeyRepo: WrapVirtualKeyRepo(virtualKeyRepo),
-		rateLimiter:    ratelimit.NewLimiter(settingsRepo),
-		ipLimiter:      ratelimit.NewIPLimiter(30, 60, nil, nil),
-		circuitBreaker: failover.NewCircuitBreaker(settingsRepo),
-		dbPool:         pool,
-		upstreamTransport: &http.Transport{
-			DialContext:           NewSafeDialer(append(config.KnownProviderHosts(), "127.0.0.1"), nil).DialContext,
-			ResponseHeaderTimeout: 120 * time.Second,
-			IdleConnTimeout:       120 * time.Second,
-			MaxIdleConns:          200,
-			MaxIdleConnsPerHost:   20,
-		},
-		safeDialer: NewSafeDialer(nil, nil),
-	}
-	defer handler.upstreamTransport.CloseIdleConnections()
+	handler := newCanonicalHandler(t, masterKey, pool, settingsRepo, failoverRepo, modelRepo, providerRepo, virtualKeyRepo, ratelimit.NewLimiter(settingsRepo), ratelimit.NewIPLimiter(30, 60, nil, nil))
 
 	body := fmt.Sprintf(`{"model":"%s/%s","messages":[{"role":"user","content":"hi"}],"stream":true}`, prov.Name, modelName)
 	req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(body))
@@ -2173,27 +2110,7 @@ func TestChatCompletions_TTFTDisabled_CBRecordsSuccess(t *testing.T) {
 		t.Fatalf("failed to create virtual key: %v", err)
 	}
 
-	handler := &Handler{
-		cfg:            &config.Config{MasterKey: masterKey},
-		settingsRepo:   settingsRepo,
-		failoverRepo:   failoverRepo,
-		modelRepo:      modelRepo,
-		providerRepo:   providerRepo,
-		virtualKeyRepo: WrapVirtualKeyRepo(virtualKeyRepo),
-		rateLimiter:    ratelimit.NewLimiter(settingsRepo),
-		ipLimiter:      ratelimit.NewIPLimiter(30, 60, nil, nil),
-		circuitBreaker: failover.NewCircuitBreaker(settingsRepo),
-		dbPool:         pool,
-		upstreamTransport: &http.Transport{
-			DialContext:           NewSafeDialer(append(config.KnownProviderHosts(), "127.0.0.1"), nil).DialContext,
-			ResponseHeaderTimeout: 120 * time.Second,
-			IdleConnTimeout:       120 * time.Second,
-			MaxIdleConns:          200,
-			MaxIdleConnsPerHost:   20,
-		},
-		safeDialer: NewSafeDialer(nil, nil),
-	}
-	defer handler.upstreamTransport.CloseIdleConnections()
+	handler := newCanonicalHandler(t, masterKey, pool, settingsRepo, failoverRepo, modelRepo, providerRepo, virtualKeyRepo, ratelimit.NewLimiter(settingsRepo), ratelimit.NewIPLimiter(30, 60, nil, nil))
 
 	body := fmt.Sprintf(`{"model":"%s/%s","messages":[{"role":"user","content":"hi"}],"stream":true}`, prov.Name, modelName)
 	req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(body))
@@ -2336,27 +2253,7 @@ func TestChatCompletions_AllowedProviders_FilterAllowed(t *testing.T) {
 		t.Fatalf("failed to create virtual key: %v", err)
 	}
 
-	handler := &Handler{
-		cfg:            &config.Config{MasterKey: masterKey},
-		settingsRepo:   settingsRepo,
-		failoverRepo:   failoverRepo,
-		modelRepo:      modelRepo,
-		providerRepo:   providerRepo,
-		virtualKeyRepo: WrapVirtualKeyRepo(virtualKeyRepo),
-		rateLimiter:    limiter,
-		ipLimiter:      ipLimiter,
-		circuitBreaker: failover.NewCircuitBreaker(settingsRepo),
-		dbPool:         pool,
-		upstreamTransport: &http.Transport{
-			DialContext:           NewSafeDialer(append(config.KnownProviderHosts(), "127.0.0.1"), nil).DialContext,
-			ResponseHeaderTimeout: 120 * time.Second,
-			IdleConnTimeout:       120 * time.Second,
-			MaxIdleConns:          200,
-			MaxIdleConnsPerHost:   20,
-		},
-		safeDialer: NewSafeDialer(nil, nil),
-	}
-	defer handler.upstreamTransport.CloseIdleConnections()
+	handler := newCanonicalHandler(t, masterKey, pool, settingsRepo, failoverRepo, modelRepo, providerRepo, virtualKeyRepo, limiter, ipLimiter)
 
 	body := `{"model": "hotel/` + modelName + `", "messages": [{"role": "user", "content": "hello"}], "stream": false}`
 	req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(body))
@@ -2429,27 +2326,7 @@ func TestChatCompletions_AllowedProviders_BlockAllReturns403(t *testing.T) {
 		t.Fatalf("failed to create virtual key: %v", err)
 	}
 
-	handler := &Handler{
-		cfg:            &config.Config{MasterKey: masterKey},
-		settingsRepo:   settingsRepo,
-		failoverRepo:   failoverRepo,
-		modelRepo:      modelRepo,
-		providerRepo:   providerRepo,
-		virtualKeyRepo: WrapVirtualKeyRepo(virtualKeyRepo),
-		rateLimiter:    limiter,
-		ipLimiter:      ipLimiter,
-		circuitBreaker: failover.NewCircuitBreaker(settingsRepo),
-		dbPool:         pool,
-		upstreamTransport: &http.Transport{
-			DialContext:           NewSafeDialer(append(config.KnownProviderHosts(), "127.0.0.1"), nil).DialContext,
-			ResponseHeaderTimeout: 120 * time.Second,
-			IdleConnTimeout:       120 * time.Second,
-			MaxIdleConns:          200,
-			MaxIdleConnsPerHost:   20,
-		},
-		safeDialer: NewSafeDialer(nil, nil),
-	}
-	defer handler.upstreamTransport.CloseIdleConnections()
+	handler := newCanonicalHandler(t, masterKey, pool, settingsRepo, failoverRepo, modelRepo, providerRepo, virtualKeyRepo, limiter, ipLimiter)
 
 	body := `{"model": "` + prov.Name + `/` + modelName + `", "messages": [{"role": "user", "content": "hello"}], "stream": false}`
 	req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(body))
@@ -2561,27 +2438,7 @@ func TestChatCompletions_AllowedProviders_EmptySliceAllowsAll(t *testing.T) {
 		t.Fatalf("failed to create virtual key: %v", err)
 	}
 
-	handler := &Handler{
-		cfg:            &config.Config{MasterKey: masterKey},
-		settingsRepo:   settingsRepo,
-		failoverRepo:   failoverRepo,
-		modelRepo:      modelRepo,
-		providerRepo:   providerRepo,
-		virtualKeyRepo: WrapVirtualKeyRepo(virtualKeyRepo),
-		rateLimiter:    limiter,
-		ipLimiter:      ipLimiter,
-		circuitBreaker: failover.NewCircuitBreaker(settingsRepo),
-		dbPool:         pool,
-		upstreamTransport: &http.Transport{
-			DialContext:           NewSafeDialer(append(config.KnownProviderHosts(), "127.0.0.1"), nil).DialContext,
-			ResponseHeaderTimeout: 120 * time.Second,
-			IdleConnTimeout:       120 * time.Second,
-			MaxIdleConns:          200,
-			MaxIdleConnsPerHost:   20,
-		},
-		safeDialer: NewSafeDialer(nil, nil),
-	}
-	defer handler.upstreamTransport.CloseIdleConnections()
+	handler := newCanonicalHandler(t, masterKey, pool, settingsRepo, failoverRepo, modelRepo, providerRepo, virtualKeyRepo, limiter, ipLimiter)
 
 	body := `{"model": "` + prov.Name + `/` + modelName + `", "messages": [{"role": "user", "content": "hello"}], "stream": false}`
 	req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(body))
@@ -2660,27 +2517,7 @@ func TestChatCompletions_UpstreamErrorForwarding(t *testing.T) {
 			t.Fatalf("failed to create virtual key: %v", err)
 		}
 
-		handler := &Handler{
-			cfg:            &config.Config{MasterKey: masterKey},
-			settingsRepo:   settingsRepo,
-			failoverRepo:   failoverRepo,
-			modelRepo:      modelRepo,
-			providerRepo:   providerRepo,
-			virtualKeyRepo: WrapVirtualKeyRepo(virtualKeyRepo),
-			rateLimiter:    limiter,
-			ipLimiter:      ipLimiter,
-			circuitBreaker: failover.NewCircuitBreaker(settingsRepo),
-			dbPool:         pool,
-			upstreamTransport: &http.Transport{
-				DialContext:           NewSafeDialer(append(config.KnownProviderHosts(), "127.0.0.1"), nil).DialContext,
-				ResponseHeaderTimeout: 120 * time.Second,
-				IdleConnTimeout:       120 * time.Second,
-				MaxIdleConns:          200,
-				MaxIdleConnsPerHost:   20,
-			},
-			safeDialer: NewSafeDialer(nil, nil),
-		}
-		defer handler.upstreamTransport.CloseIdleConnections()
+		handler := newCanonicalHandler(t, masterKey, pool, settingsRepo, failoverRepo, modelRepo, providerRepo, virtualKeyRepo, limiter, ipLimiter)
 
 		body := `{"model": "` + provName + `/` + modelName + `", "messages": [{"role": "user", "content": "hello"}], "stream": false}`
 		req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(body))
@@ -2801,27 +2638,7 @@ func TestChatCompletions_UpstreamErrorForwarding(t *testing.T) {
 			t.Fatalf("failed to create virtual key: %v", err)
 		}
 
-		handler := &Handler{
-			cfg:            &config.Config{MasterKey: masterKey},
-			settingsRepo:   settingsRepo,
-			failoverRepo:   failoverRepo,
-			modelRepo:      modelRepo,
-			providerRepo:   providerRepo,
-			virtualKeyRepo: WrapVirtualKeyRepo(virtualKeyRepo),
-			rateLimiter:    limiter,
-			ipLimiter:      ipLimiter,
-			circuitBreaker: failover.NewCircuitBreaker(settingsRepo),
-			dbPool:         pool,
-			upstreamTransport: &http.Transport{
-				DialContext:           NewSafeDialer(append(config.KnownProviderHosts(), "127.0.0.1"), nil).DialContext,
-				ResponseHeaderTimeout: 120 * time.Second,
-				IdleConnTimeout:       120 * time.Second,
-				MaxIdleConns:          200,
-				MaxIdleConnsPerHost:   20,
-			},
-			safeDialer: NewSafeDialer(nil, nil),
-		}
-		defer handler.upstreamTransport.CloseIdleConnections()
+		handler := newCanonicalHandler(t, masterKey, pool, settingsRepo, failoverRepo, modelRepo, providerRepo, virtualKeyRepo, limiter, ipLimiter)
 
 		// Use hotel/ format to trigger failover group
 		body := `{"model": "hotel/` + modelName + `", "messages": [{"role": "user", "content": "hello"}], "stream": false}`
@@ -2950,27 +2767,7 @@ func TestChatCompletions_UpstreamErrorForwarding(t *testing.T) {
 			t.Fatalf("failed to create virtual key: %v", err)
 		}
 
-		handler := &Handler{
-			cfg:            &config.Config{MasterKey: masterKey},
-			settingsRepo:   settingsRepo,
-			failoverRepo:   failoverRepo,
-			modelRepo:      modelRepo,
-			providerRepo:   providerRepo,
-			virtualKeyRepo: WrapVirtualKeyRepo(virtualKeyRepo),
-			rateLimiter:    limiter,
-			ipLimiter:      ipLimiter,
-			circuitBreaker: failover.NewCircuitBreaker(settingsRepo),
-			dbPool:         pool,
-			upstreamTransport: &http.Transport{
-				DialContext:           NewSafeDialer(append(config.KnownProviderHosts(), "127.0.0.1"), nil).DialContext,
-				ResponseHeaderTimeout: 120 * time.Second,
-				IdleConnTimeout:       120 * time.Second,
-				MaxIdleConns:          200,
-				MaxIdleConnsPerHost:   20,
-			},
-			safeDialer: NewSafeDialer(nil, nil),
-		}
-		defer handler.upstreamTransport.CloseIdleConnections()
+		handler := newCanonicalHandler(t, masterKey, pool, settingsRepo, failoverRepo, modelRepo, providerRepo, virtualKeyRepo, limiter, ipLimiter)
 
 		// Use hotel/ format to trigger failover group
 		body := `{"model": "hotel/` + modelName + `", "messages": [{"role": "user", "content": "hello"}], "stream": false}`
@@ -3097,27 +2894,7 @@ func TestChatCompletions_UpstreamErrorForwarding(t *testing.T) {
 			t.Fatalf("failed to create virtual key: %v", err)
 		}
 
-		handler := &Handler{
-			cfg:            &config.Config{MasterKey: masterKey},
-			settingsRepo:   settingsRepo,
-			failoverRepo:   failoverRepo,
-			modelRepo:      modelRepo,
-			providerRepo:   providerRepo,
-			virtualKeyRepo: WrapVirtualKeyRepo(virtualKeyRepo),
-			rateLimiter:    limiter,
-			ipLimiter:      ipLimiter,
-			circuitBreaker: failover.NewCircuitBreaker(settingsRepo),
-			dbPool:         pool,
-			upstreamTransport: &http.Transport{
-				DialContext:           NewSafeDialer(append(config.KnownProviderHosts(), "127.0.0.1"), nil).DialContext,
-				ResponseHeaderTimeout: 120 * time.Second,
-				IdleConnTimeout:       120 * time.Second,
-				MaxIdleConns:          200,
-				MaxIdleConnsPerHost:   20,
-			},
-			safeDialer: NewSafeDialer(nil, nil),
-		}
-		defer handler.upstreamTransport.CloseIdleConnections()
+		handler := newCanonicalHandler(t, masterKey, pool, settingsRepo, failoverRepo, modelRepo, providerRepo, virtualKeyRepo, limiter, ipLimiter)
 
 		// Use hotel/ format to trigger failover group
 		body := `{"model": "hotel/` + modelName + `", "messages": [{"role": "user", "content": "hello"}], "stream": false}`


### PR DESCRIPTION
## What

Replaces **24** identical ~20-line `&Handler{...}` literals across the proxy integration tests with a shared `newCanonicalHandler` helper (plus a small `newCanonicalTransport` helper, now also reused by the existing `newIntegrationHandler`).

The helper takes the per-test repos, master key, and rate limiters, wires the canonical handler, and registers upstream-transport cleanup via `t.Cleanup`. All argument types are distinct, so a **misordered call is a compile error**, not a silent bug.

## Why

The proxy test package had the same ~20-line handler construction copy-pasted at dozens of sites. After the recent `ChatCompletions` decomposition (phases 1–7 / AC1–AC4), adding or changing a `Handler` field meant touching every one of these literals. This consolidates the genuinely-duplicated construction while leaving the *intentionally* minimal handlers (zero-value handlers for pure-method tests, `cfg`+`ipLimiter` unit handlers, mock-repo handlers) untouched.

## Scope / deliberate non-changes

Two near-canonical sites are intentionally left as literals because they are **not** canonical:

- `breaker_sequence_test.go` — shares a local `cb` it mutates *after* construction; the handler must use that exact instance.
- `chat_integration_test.go` (HTML test) — custom `ResponseHeaderTimeout: 5s` and nil limiters on purpose.

## Impact

- **Test-only change** — no production code touched.
- Net **~433 fewer lines** (512 deletions / 79 insertions).
- Adding a `Handler` field now means editing **one** helper, not 24 call sites.

## Verification

- `go vet ./internal/proxy/` — pass
- `go test ./internal/proxy/` — pass (12.2s, against the test DB)
- `golangci-lint run ./internal/proxy/` — 0 issues
- pre-commit hook (gci + vet) — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)