### PR TITLE
refactor(proxy,api): decompose four god-functions into phase helpers

### DIFF
--- a/internal/api/backup.go
+++ b/internal/api/backup.go
@@ -540,12 +540,12 @@ func (h *BackupHandler) RestoreBackup(w http.ResponseWriter, r *http.Request) {
 	//nolint:errcheck // cleanup: temp file removed after processing
 	defer os.Remove(tmpPath)
 
-	dumpMigrations, ok := validateRestoreDump(w, tmpPath)
+	pgRestorePath, dumpMigrations, ok := validateRestoreDump(w, tmpPath)
 	if !ok {
 		return
 	}
 
-	if !h.runPgRestore(w, tmpPath) {
+	if !h.runPgRestore(w, pgRestorePath, tmpPath) {
 		return
 	}
 
@@ -634,12 +634,12 @@ func (h *BackupHandler) saveUploadedDump(w http.ResponseWriter, r *http.Request)
 // objects, contains schema_migrations, and no migrations newer than this build.
 // It writes the appropriate HTTP error and returns ok=false on rejection;
 // otherwise it returns the dump's migration names.
-func validateRestoreDump(w http.ResponseWriter, tmpPath string) (dumpMigrations []string, ok bool) {
+func validateRestoreDump(w http.ResponseWriter, tmpPath string) (pgRestorePath string, dumpMigrations []string, ok bool) {
 	// Step 1: Validate dump format with pg_restore --list
 	pgRestorePath, err := exec.LookPath("pg_restore")
 	if err != nil {
 		respondError(w, "pg_restore not found - install postgresql-client package", err, http.StatusPreconditionFailed)
-		return nil, false
+		return "", nil, false
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -653,7 +653,7 @@ func validateRestoreDump(w http.ResponseWriter, tmpPath string) (dumpMigrations 
 
 	if err := listCmd.Run(); err != nil {
 		respondBadRequest(w, "invalid dump file: pg_restore --list failed", err)
-		return nil, false
+		return "", nil, false
 	}
 
 	// Step 2: Check for dangerous objects
@@ -662,7 +662,7 @@ func validateRestoreDump(w http.ResponseWriter, tmpPath string) (dumpMigrations 
 	if len(dangerous) > 0 {
 		debuglog.Warn("backup: restore rejected - dangerous objects in dump", "objects", strings.Join(dangerous, ", "))
 		respondBadRequest(w, fmt.Sprintf("dump contains dangerous objects: %s", strings.Join(dangerous, ", ")), nil)
-		return nil, false
+		return "", nil, false
 	}
 
 	// Step 3: Extract and compare migrations
@@ -670,13 +670,13 @@ func validateRestoreDump(w http.ResponseWriter, tmpPath string) (dumpMigrations 
 	if schemaEntry == 0 {
 		debuglog.Warn("backup: restore rejected - no schema_migrations in dump")
 		respondBadRequest(w, "dump does not contain schema_migrations table - not a model-hotel backup", nil)
-		return nil, false
+		return "", nil, false
 	}
 
 	dumpMigrations, err = extractMigrationNames(tmpPath, schemaEntry)
 	if err != nil {
 		respondError(w, "failed to extract migration info from dump", err, http.StatusInternalServerError)
-		return nil, false
+		return "", nil, false
 	}
 
 	unknownMigrations := compareMigrations(dumpMigrations)
@@ -686,22 +686,17 @@ func validateRestoreDump(w http.ResponseWriter, tmpPath string) (dumpMigrations 
 			"dump is from a newer version (unknown migrations: %s). Downgrade restore is not supported.",
 			strings.Join(unknownMigrations, ", "),
 		), nil)
-		return nil, false
+		return "", nil, false
 	}
 
-	return dumpMigrations, true
+	return pgRestorePath, dumpMigrations, true
 }
 
 // runPgRestore runs pg_restore --clean --if-exists against the configured
-// database, stripping the password from the connection URL onto PGPASSWORD. It
+// database, stripping the password from the connection URL onto PGPASSWORD. The
+// pg_restore path is resolved once by validateRestoreDump and threaded in. It
 // writes an HTTP error and returns false if the restore command fails.
-func (h *BackupHandler) runPgRestore(w http.ResponseWriter, tmpPath string) bool {
-	pgRestorePath, err := exec.LookPath("pg_restore")
-	if err != nil {
-		respondError(w, "pg_restore not found - install postgresql-client package", err, http.StatusPreconditionFailed)
-		return false
-	}
-
+func (h *BackupHandler) runPgRestore(w http.ResponseWriter, pgRestorePath, tmpPath string) bool {
 	restoreCtx, restoreCancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer restoreCancel()
 

--- a/internal/api/backup.go
+++ b/internal/api/backup.go
@@ -533,27 +533,73 @@ func (h *BackupHandler) RestoreBackup(w http.ResponseWriter, r *http.Request) {
 	}
 	defer h.backupMu.Unlock()
 
+	tmpPath, ok := h.saveUploadedDump(w, r)
+	if !ok {
+		return
+	}
+	//nolint:errcheck // cleanup: temp file removed after processing
+	defer os.Remove(tmpPath)
+
+	dumpMigrations, ok := validateRestoreDump(w, tmpPath)
+	if !ok {
+		return
+	}
+
+	if !h.runPgRestore(w, tmpPath) {
+		return
+	}
+
+	debuglog.Info("backup: restored", "migrations_in_dump", len(dumpMigrations))
+	events.Publish(events.Event{
+		Type:     "backup.restored",
+		Severity: "success",
+		Source:   "backup",
+		Message:  "Database restored successfully. Restarting...",
+		Metadata: map[string]interface{}{"migration_count": len(dumpMigrations)},
+	})
+
+	// Respond before exiting so the client gets the success response
+	result := restoreResult{
+		MigrationCount: len(dumpMigrations),
+		KnownCount:     len(db.KnownMigrations()),
+	}
+	writeJSON(w, result)
+
+	// Exit the process so Docker restarts it with fresh caches and
+	// re-runs any missing migrations against the restored database.
+	go func() {
+		time.Sleep(500 * time.Millisecond) // give the HTTP response time to flush
+		os.Remove(tmpPath)                 //nolint:errcheck,gosec // best-effort cleanup before exit
+		os.Exit(0)
+	}()
+}
+
+// saveUploadedDump validates the multipart upload (size limit, admin token,
+// dump file) and streams it to a temp file in the backup dir, returning the temp
+// path for the caller to clean up. It writes the appropriate HTTP error and
+// returns ok=false on any failure (removing the temp file if it was created).
+func (h *BackupHandler) saveUploadedDump(w http.ResponseWriter, r *http.Request) (tmpPath string, ok bool) {
 	// Limit upload size (100MB)
 	r.Body = http.MaxBytesReader(w, r.Body, 100*1024*1024)
 
 	// Parse multipart form (32MB max in-memory)
 	if err := r.ParseMultipartForm(32 << 20); err != nil { //nolint:gosec // bounded by MaxBytesReader above
 		respondBadRequest(w, "failed to parse multipart form", err)
-		return
+		return "", false
 	}
 
 	// Validate admin token from form field
 	adminToken := r.FormValue("admin_token")
 	if adminToken == "" || !h.adminMgr.Validate(adminToken) {
 		respondError(w, "invalid admin token", nil, http.StatusUnauthorized)
-		return
+		return "", false
 	}
 
 	// Get uploaded file
 	file, _, err := r.FormFile("dump")
 	if err != nil {
 		respondBadRequest(w, "missing dump file", err)
-		return
+		return "", false
 	}
 	//nolint:errcheck // cleanup: multipart file handle
 	defer file.Close()
@@ -561,32 +607,39 @@ func (h *BackupHandler) RestoreBackup(w http.ResponseWriter, r *http.Request) {
 	// Ensure backup directory exists
 	if err := os.MkdirAll(h.backupDir, 0o750); err != nil {
 		respondError(w, "failed to create backup directory", err, http.StatusInternalServerError)
-		return
+		return "", false
 	}
 
 	// Save to temp file
 	tmpFile, err := os.CreateTemp(h.backupDir, "restore-*.dump")
 	if err != nil {
 		respondError(w, "failed to create temp file", err, http.StatusInternalServerError)
-		return
+		return "", false
 	}
-	tmpPath := tmpFile.Name()
-	//nolint:errcheck // cleanup: temp file removed after processing
-	defer os.Remove(tmpPath)
+	tmpPath = tmpFile.Name()
 
 	if _, err := io.Copy(tmpFile, file); err != nil {
-		//nolint:errcheck // error path: closing after copy failure
-		tmpFile.Close() //nolint:errcheck,gosec // error path: closing after copy failure
+		tmpFile.Close()        //nolint:errcheck,gosec // error path: closing after copy failure
+		_ = os.Remove(tmpPath) // error path: discard partial temp file
 		respondError(w, "failed to save uploaded file", err, http.StatusInternalServerError)
-		return
+		return "", false
 	}
 	tmpFile.Close() //nolint:errcheck,gosec // cleanup: file fully written, closing for pg_restore
 
+	return tmpPath, true
+}
+
+// validateRestoreDump inspects a saved dump with pg_restore --list and rejects
+// it unless it is a safe, same-or-older model-hotel backup: no dangerous
+// objects, contains schema_migrations, and no migrations newer than this build.
+// It writes the appropriate HTTP error and returns ok=false on rejection;
+// otherwise it returns the dump's migration names.
+func validateRestoreDump(w http.ResponseWriter, tmpPath string) (dumpMigrations []string, ok bool) {
 	// Step 1: Validate dump format with pg_restore --list
 	pgRestorePath, err := exec.LookPath("pg_restore")
 	if err != nil {
 		respondError(w, "pg_restore not found - install postgresql-client package", err, http.StatusPreconditionFailed)
-		return
+		return nil, false
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -600,7 +653,7 @@ func (h *BackupHandler) RestoreBackup(w http.ResponseWriter, r *http.Request) {
 
 	if err := listCmd.Run(); err != nil {
 		respondBadRequest(w, "invalid dump file: pg_restore --list failed", err)
-		return
+		return nil, false
 	}
 
 	// Step 2: Check for dangerous objects
@@ -609,7 +662,7 @@ func (h *BackupHandler) RestoreBackup(w http.ResponseWriter, r *http.Request) {
 	if len(dangerous) > 0 {
 		debuglog.Warn("backup: restore rejected - dangerous objects in dump", "objects", strings.Join(dangerous, ", "))
 		respondBadRequest(w, fmt.Sprintf("dump contains dangerous objects: %s", strings.Join(dangerous, ", ")), nil)
-		return
+		return nil, false
 	}
 
 	// Step 3: Extract and compare migrations
@@ -617,13 +670,13 @@ func (h *BackupHandler) RestoreBackup(w http.ResponseWriter, r *http.Request) {
 	if schemaEntry == 0 {
 		debuglog.Warn("backup: restore rejected - no schema_migrations in dump")
 		respondBadRequest(w, "dump does not contain schema_migrations table - not a model-hotel backup", nil)
-		return
+		return nil, false
 	}
 
-	dumpMigrations, err := extractMigrationNames(tmpPath, schemaEntry)
+	dumpMigrations, err = extractMigrationNames(tmpPath, schemaEntry)
 	if err != nil {
 		respondError(w, "failed to extract migration info from dump", err, http.StatusInternalServerError)
-		return
+		return nil, false
 	}
 
 	unknownMigrations := compareMigrations(dumpMigrations)
@@ -633,10 +686,22 @@ func (h *BackupHandler) RestoreBackup(w http.ResponseWriter, r *http.Request) {
 			"dump is from a newer version (unknown migrations: %s). Downgrade restore is not supported.",
 			strings.Join(unknownMigrations, ", "),
 		), nil)
-		return
+		return nil, false
 	}
 
-	// Step 4: Run pg_restore --clean --if-exists
+	return dumpMigrations, true
+}
+
+// runPgRestore runs pg_restore --clean --if-exists against the configured
+// database, stripping the password from the connection URL onto PGPASSWORD. It
+// writes an HTTP error and returns false if the restore command fails.
+func (h *BackupHandler) runPgRestore(w http.ResponseWriter, tmpPath string) bool {
+	pgRestorePath, err := exec.LookPath("pg_restore")
+	if err != nil {
+		respondError(w, "pg_restore not found - install postgresql-client package", err, http.StatusPreconditionFailed)
+		return false
+	}
+
 	restoreCtx, restoreCancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer restoreCancel()
 
@@ -669,32 +734,10 @@ func (h *BackupHandler) RestoreBackup(w http.ResponseWriter, r *http.Request) {
 	if err := restoreCmd.Run(); err != nil {
 		debuglog.Error("backup: pg_restore failed", "output", strings.TrimSpace(restoreStderr.String()), "error", err)
 		respondError(w, "pg_restore failed - check server logs for details", err, http.StatusInternalServerError)
-		return
+		return false
 	}
 
-	debuglog.Info("backup: restored", "migrations_in_dump", len(dumpMigrations))
-	events.Publish(events.Event{
-		Type:     "backup.restored",
-		Severity: "success",
-		Source:   "backup",
-		Message:  "Database restored successfully. Restarting...",
-		Metadata: map[string]interface{}{"migration_count": len(dumpMigrations)},
-	})
-
-	// Respond before exiting so the client gets the success response
-	result := restoreResult{
-		MigrationCount: len(dumpMigrations),
-		KnownCount:     len(db.KnownMigrations()),
-	}
-	writeJSON(w, result)
-
-	// Exit the process so Docker restarts it with fresh caches and
-	// re-runs any missing migrations against the restored database.
-	go func() {
-		time.Sleep(500 * time.Millisecond) // give the HTTP response time to flush
-		os.Remove(tmpPath)                 //nolint:errcheck,gosec // best-effort cleanup before exit
-		os.Exit(0)
-	}()
+	return true
 }
 
 // ── Son/Father/Grandfather Rotation ──────────────────────────────────

--- a/internal/api/models.go
+++ b/internal/api/models.go
@@ -280,47 +280,102 @@ type TestModelResponse struct {
 
 // TestModel tests a model by making a test request and returning latency metrics.
 func (h *Handler) TestModel(w http.ResponseWriter, r *http.Request) {
-	id, ok := parseUUIDParam(w, r, "id", "model ID")
+	m, prov, ok := h.resolveTestModelTarget(w, r)
 	if !ok {
 		return
+	}
+
+	start := time.Now()
+	keyDecryptStart := time.Now()
+	apiKey, ok := h.decryptTestModelKey(w, prov)
+	if !ok {
+		return
+	}
+	keyDecryptMs := float64(time.Since(keyDecryptStart).Microseconds()) / 1000.0
+	proxyOverheadMs := float64(time.Since(start).Microseconds()) / 1000.0
+
+	proxyReq, reqHash := buildTestModelRequest(r.Context(), m, prov, apiKey)
+
+	startRequest := time.Now()
+	resp, err := h.doTestModelRequest(proxyReq)
+	if err != nil {
+		durationMs := float64(time.Since(start).Milliseconds())
+		h.logTestModelRequestError(r.Context(), m, reqHash, durationMs, proxyOverheadMs, keyDecryptMs, err.Error())
+		writeJSON(w, TestModelResponse{Error: err.Error()})
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	duration := time.Since(startRequest).Milliseconds()
+
+	if resp.StatusCode != http.StatusOK {
+		errMsg := util.SanitizeLogBody(fmt.Sprintf("HTTP %d: %s", resp.StatusCode, string(respBody)), 10000)
+		h.logTestModelHTTPError(r.Context(), m, reqHash, resp.StatusCode, float64(duration), proxyOverheadMs, keyDecryptMs, errMsg)
+		writeJSON(w, TestModelResponse{DurationMs: duration, Error: errMsg})
+		return
+	}
+
+	content, tps, promptTokens, completionTokens := parseTestModelResponse(respBody, duration)
+	h.logTestModelCompleted(r.Context(), m, reqHash, resp.StatusCode, float64(duration), proxyOverheadMs, keyDecryptMs, tps, promptTokens, completionTokens)
+	writeJSON(w, TestModelResponse{
+		Success:          true,
+		Streaming:        false,
+		ResponseHeaderMs: &duration,
+		DurationMs:       duration,
+		Response:         content,
+	})
+}
+
+// resolveTestModelTarget loads and validates the model + provider for a test
+// request: parse the id param, fetch the (enabled) model, fetch its provider. It
+// writes the appropriate HTTP error and returns ok=false on any failure.
+func (h *Handler) resolveTestModelTarget(w http.ResponseWriter, r *http.Request) (m *model.Model, prov *provider.Provider, ok bool) {
+	id, ok := parseUUIDParam(w, r, "id", "model ID")
+	if !ok {
+		return nil, nil, false
 	}
 
 	modelRepo := model.NewRepository(h.dbPool.Pool())
 	m, err := modelRepo.Get(r.Context(), id)
 	if err != nil {
 		http.Error(w, "model not found", http.StatusNotFound)
-		return
+		return nil, nil, false
 	}
 
 	if !m.Enabled {
 		http.Error(w, "model is disabled", http.StatusBadRequest)
-		return
+		return nil, nil, false
 	}
 
-	prov, err := h.providerRepo.Get(r.Context(), m.ProviderID)
+	prov, err = h.providerRepo.Get(r.Context(), m.ProviderID)
 	if err != nil {
 		respondError(w, "provider not found", nil, http.StatusInternalServerError)
-		return
+		return nil, nil, false
 	}
+	return m, prov, true
+}
 
-	start := time.Now()
-	keyDecryptStart := time.Now()
-
+// decryptTestModelKey decrypts the provider API key for a test request. Keyless
+// providers (nil encrypted bytes) yield an empty key. It writes an HTTP error
+// and returns ok=false if decryption fails.
+func (h *Handler) decryptTestModelKey(w http.ResponseWriter, prov *provider.Provider) (apiKey string, ok bool) {
 	// Keyless providers store nil encrypted key bytes — skip decryption.
-	var apiKey string
 	if len(prov.EncryptedKey) == 0 {
-		apiKey = ""
-	} else {
-		var err error
-		apiKey, err = auth.Decrypt(prov.EncryptedKey, prov.KeyNonce, prov.KeySalt, h.cfg.MasterKey)
-		if err != nil {
-			respondError(w, "failed to decrypt API key", nil, http.StatusInternalServerError)
-			return
-		}
+		return "", true
 	}
-	keyDecryptMs := float64(time.Since(keyDecryptStart).Microseconds()) / 1000.0
-	proxyOverheadMs := float64(time.Since(start).Microseconds()) / 1000.0
+	apiKey, err := auth.Decrypt(prov.EncryptedKey, prov.KeyNonce, prov.KeySalt, h.cfg.MasterKey)
+	if err != nil {
+		respondError(w, "failed to decrypt API key", nil, http.StatusInternalServerError)
+		return "", false
+	}
+	return apiKey, true
+}
 
+// buildTestModelRequest constructs the upstream chat-completions probe request
+// (a one-token "Respond only with `Hi`" prompt) with provider-appropriate auth
+// headers, and returns it alongside a fresh random request hash for logging.
+func buildTestModelRequest(ctx context.Context, m *model.Model, prov *provider.Provider, apiKey string) (*http.Request, string) {
 	body := map[string]interface{}{
 		"model": m.ModelID,
 		"messages": []map[string]string{
@@ -333,7 +388,7 @@ func (h *Handler) TestModel(w http.ResponseWriter, r *http.Request) {
 	providerType := provider.DetectProviderType(prov.BaseURL)
 	targetURL := util.BuildProviderTargetURL(prov.BaseURL, providerType)
 	//nolint:gosec // provider URL is admin-configured, not arbitrary user input
-	proxyReq, _ := http.NewRequestWithContext(r.Context(), "POST", targetURL, bytes.NewReader(bodyBytes))
+	proxyReq, _ := http.NewRequestWithContext(ctx, "POST", targetURL, bytes.NewReader(bodyBytes))
 	util.SetProviderAuthHeaders(proxyReq, providerType, apiKey)
 	proxyReq.Header.Set("Content-Type", "application/json")
 
@@ -341,7 +396,12 @@ func (h *Handler) TestModel(w http.ResponseWriter, r *http.Request) {
 	rand.Read(reqHashBytes)
 	reqHash := hex.EncodeToString(reqHashBytes)
 
-	startRequest := time.Now()
+	return proxyReq, reqHash
+}
+
+// doTestModelRequest executes the probe request with a 30s-timeout client,
+// honoring the test-only transport/redirect hooks when set.
+func (h *Handler) doTestModelRequest(proxyReq *http.Request) (*http.Response, error) {
 	testClient := &http.Client{Timeout: 30 * time.Second}
 	if h.testModelTransport != nil {
 		testClient.Transport = h.testModelTransport
@@ -350,63 +410,13 @@ func (h *Handler) TestModel(w http.ResponseWriter, r *http.Request) {
 		testClient.CheckRedirect = h.testModelCheckRedirect
 	}
 	//nolint:gosec // provider URL is admin-configured, not arbitrary user input
-	resp, err := testClient.Do(proxyReq)
-	if err != nil {
-		logQuery := `
-			INSERT INTO request_logs (
-				provider_id, model_id, request_hash, status_code,
-				latency_ms, duration_ms, response_header_ms, ttft_ms,
-				proxy_overhead_ms, parse_ms, failover_lookup_ms, model_lookup_ms, provider_lookup_ms, key_decrypt_ms, dial_ms, settings_read_ms,
-				error_message, streaming, virtual_key_name, virtual_key_id, failover_attempt, state
-			)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, 0, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)
-		`
-		durationMs := float64(time.Since(start).Milliseconds())
-		_, logErr := h.dbPool.Pool().Exec(r.Context(), logQuery,
-			m.ProviderID, m.ModelID, reqHash, 502,
-			durationMs, durationMs, 0,
-			proxyOverheadMs, 0, 0, 0, 0, keyDecryptMs, 0, 0,
-			err.Error(), false, "internal", nil, 0, "failed",
-		)
-		if logErr != nil {
-			debuglog.Error("admin: TestModel log insert failed", "error", logErr)
-		}
+	return testClient.Do(proxyReq)
+}
 
-		writeJSON(w, TestModelResponse{Error: err.Error()})
-		return
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	respBody, _ := io.ReadAll(resp.Body)
-	duration := time.Since(startRequest).Milliseconds()
-
-	if resp.StatusCode != http.StatusOK {
-		errMsg := util.SanitizeLogBody(fmt.Sprintf("HTTP %d: %s", resp.StatusCode, string(respBody)), 10000)
-
-		logQuery := `
-			INSERT INTO request_logs (
-				provider_id, model_id, request_hash, status_code,
-				latency_ms, duration_ms, response_header_ms, ttft_ms,
-				proxy_overhead_ms, parse_ms, failover_lookup_ms, model_lookup_ms, provider_lookup_ms, key_decrypt_ms, dial_ms, settings_read_ms,
-				error_message, tokens_per_second, tokens_prompt, tokens_completion, streaming, virtual_key_name, virtual_key_id, failover_attempt, state
-			)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, 0, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24)
-		`
-		durationMs := float64(duration)
-		_, logErr := h.dbPool.Pool().Exec(r.Context(), logQuery,
-			m.ProviderID, m.ModelID, reqHash, resp.StatusCode,
-			durationMs, durationMs, 0,
-			proxyOverheadMs, 0, 0, 0, 0, keyDecryptMs, 0, 0,
-			errMsg, 0, 0, 0, false, "internal", nil, 0, "failed",
-		)
-		if logErr != nil {
-			debuglog.Error("admin: TestModel log insert failed", "error", logErr)
-		}
-
-		writeJSON(w, TestModelResponse{DurationMs: duration, Error: errMsg})
-		return
-	}
-
+// parseTestModelResponse extracts the assistant content and computes
+// tokens-per-second from a successful test response body. A parse failure is
+// logged and yields empty content / zero usage.
+func parseTestModelResponse(respBody []byte, duration int64) (content string, tps float64, promptTokens, completionTokens int) {
 	var chatResp struct {
 		Choices []struct {
 			Message struct {
@@ -422,16 +432,68 @@ func (h *Handler) TestModel(w http.ResponseWriter, r *http.Request) {
 		debuglog.Debug("admin: failed to parse test model chat response", "error", err)
 	}
 
-	content := ""
 	if len(chatResp.Choices) > 0 {
 		content = chatResp.Choices[0].Message.Content
 	}
 
-	var tps float64
 	if chatResp.Usage.CompletionTokens > 0 && duration > 0 {
 		tps = float64(chatResp.Usage.CompletionTokens) / float64(duration) * 1000
 	}
 
+	return content, tps, chatResp.Usage.PromptTokens, chatResp.Usage.CompletionTokens
+}
+
+// logTestModelRequestError records a failed test request (the upstream call
+// never completed) as a 502 "failed" request_logs row.
+func (h *Handler) logTestModelRequestError(ctx context.Context, m *model.Model, reqHash string, durationMs, proxyOverheadMs, keyDecryptMs float64, errMsg string) {
+	logQuery := `
+		INSERT INTO request_logs (
+			provider_id, model_id, request_hash, status_code,
+			latency_ms, duration_ms, response_header_ms, ttft_ms,
+			proxy_overhead_ms, parse_ms, failover_lookup_ms, model_lookup_ms, provider_lookup_ms, key_decrypt_ms, dial_ms, settings_read_ms,
+			error_message, streaming, virtual_key_name, virtual_key_id, failover_attempt, state
+		)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, 0, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)
+	`
+	_, logErr := h.dbPool.Pool().Exec(ctx, logQuery,
+		m.ProviderID, m.ModelID, reqHash, 502,
+		durationMs, durationMs, 0,
+		proxyOverheadMs, 0, 0, 0, 0, keyDecryptMs, 0, 0,
+		errMsg, false, "internal", nil, 0, "failed",
+	)
+	if logErr != nil {
+		debuglog.Error("admin: TestModel log insert failed", "error", logErr)
+	}
+}
+
+// logTestModelHTTPError records a test request that reached the upstream but
+// returned a non-200 status as a "failed" request_logs row.
+func (h *Handler) logTestModelHTTPError(ctx context.Context, m *model.Model, reqHash string, statusCode int, durationMs, proxyOverheadMs, keyDecryptMs float64, errMsg string) {
+	logQuery := `
+		INSERT INTO request_logs (
+			provider_id, model_id, request_hash, status_code,
+			latency_ms, duration_ms, response_header_ms, ttft_ms,
+			proxy_overhead_ms, parse_ms, failover_lookup_ms, model_lookup_ms, provider_lookup_ms, key_decrypt_ms, dial_ms, settings_read_ms,
+			error_message, tokens_per_second, tokens_prompt, tokens_completion, streaming, virtual_key_name, virtual_key_id, failover_attempt, state
+		)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, 0, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24)
+	`
+	_, logErr := h.dbPool.Pool().Exec(ctx, logQuery,
+		m.ProviderID, m.ModelID, reqHash, statusCode,
+		durationMs, durationMs, 0,
+		proxyOverheadMs, 0, 0, 0, 0, keyDecryptMs, 0, 0,
+		errMsg, 0, 0, 0, false, "internal", nil, 0, "failed",
+	)
+	if logErr != nil {
+		debuglog.Error("admin: TestModel log insert failed", "error", logErr)
+	}
+}
+
+// logTestModelCompleted records a successful (HTTP 200) test request as a
+// "completed" request_logs row. For a non-streaming test, response_header_ms
+// equals total duration (no separate streaming phase) and ttft_ms is stored as
+// 0 to indicate non-streaming.
+func (h *Handler) logTestModelCompleted(ctx context.Context, m *model.Model, reqHash string, statusCode int, durationMs, proxyOverheadMs, keyDecryptMs, tps float64, promptTokens, completionTokens int) {
 	logQuery := `
 		INSERT INTO request_logs (
 			provider_id, model_id, request_hash, status_code,
@@ -441,27 +503,15 @@ func (h *Handler) TestModel(w http.ResponseWriter, r *http.Request) {
 		)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, 0, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23)
 	`
-	durationMs := float64(duration)
-	// For a non-streaming test request, response_header_ms equals total duration
-	// (no separate streaming phase). The log stores ttft_ms = 0 to
-	// indicate non-streaming. The API response reports duration as response_header_ms.
-	_, logErr := h.dbPool.Pool().Exec(r.Context(), logQuery,
-		m.ProviderID, m.ModelID, reqHash, resp.StatusCode,
+	_, logErr := h.dbPool.Pool().Exec(ctx, logQuery,
+		m.ProviderID, m.ModelID, reqHash, statusCode,
 		durationMs, durationMs, durationMs,
 		proxyOverheadMs, 0, 0, 0, 0, keyDecryptMs, 0, 0,
-		tps, chatResp.Usage.PromptTokens, chatResp.Usage.CompletionTokens, false, "internal", nil, 0, "completed",
+		tps, promptTokens, completionTokens, false, "internal", nil, 0, "completed",
 	)
 	if logErr != nil {
 		debuglog.Error("admin: TestModel log insert failed", "error", logErr)
 	}
-
-	writeJSON(w, TestModelResponse{
-		Success:          true,
-		Streaming:        false,
-		ResponseHeaderMs: &duration,
-		DurationMs:       duration,
-		Response:         content,
-	})
 }
 
 // See util.BuildProviderTargetURL for URL construction and util.SetProviderAuthHeaders for auth.

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -41,30 +41,7 @@ func (h *Handler) handleStreamingResponse(w http.ResponseWriter, r *http.Request
 	}()
 	debuglog.Debug("proxy: handleStreamingResponse entered", "model", logData.modelID, "provider", logData.providerName, "upstream_status", resp.StatusCode, "attempt", opts.attempt, "response_header_ms", opts.responseHeaderMs, "true_ttft_ms", opts.trueTtftMs, "has_probe_buf", opts.preReadBuf != nil)
 
-	w.Header().Set("Content-Type", "text/event-stream")
-	w.Header().Set("Cache-Control", "no-cache")
-	w.Header().Set("Connection", "keep-alive")
-	w.Header().Set("X-Accel-Buffering", "no")
-	w.WriteHeader(http.StatusOK)
-	debuglog.Debug("proxy: streaming headers sent", "model", logData.modelID, "provider", logData.providerName)
-
-	logData.statusCode = resp.StatusCode
-	logData.proxyOverheadMs = opts.proxyOverheadMs
-	logData.parseMs = opts.parseMs
-	logData.failoverLookupMs = opts.failoverLookupMs
-	logData.modelLookupMs = opts.modelLookupMs
-	logData.providerLookupMs = opts.providerLookupMs
-	logData.keyDecryptMs = opts.keyDecryptMs
-	logData.dialMs = opts.dialMs
-	logData.settingsReadMs = opts.settingsReadMs
-	logData.responseHeaderMs = opts.responseHeaderMs
-	logData.ttftMs = opts.trueTtftMs
-	logData.failoverAttempt = opts.attempt
-	logData.state = "streaming"
-	// Fire-and-forget: the interim "streaming" state update runs before
-	// the first streamed byte. Blocking on WaitForInsert (up to 5s) would
-	// delay the client. The final update (completed/failed) waits properly.
-	h.updateRequestLog(logData, updateLogOption{skipWaitForInsert: true})
+	h.initStreamResponse(w, logData, opts, resp)
 
 	// streamSink owns w/flusher and the running bytesWritten total (Phase 1
 	// of the streaming-pipeline refactor). All emit paths go through it.
@@ -110,7 +87,6 @@ func (h *Handler) handleStreamingResponse(w http.ResponseWriter, r *http.Request
 			break
 		}
 		chunkCount := reader.chunkCount
-		line := ev.raw
 
 		// Periodic streaming progress log for observability.
 		if chunkCount%chunkLogInterval == 0 {
@@ -118,78 +94,23 @@ func (h *Handler) handleStreamingResponse(w http.ResponseWriter, r *http.Request
 		}
 
 		if ev.kind == sseBlank {
-			// When strip_reasoning skips a reasoning chunk, the SSE
-			// separator (empty line) that followed it must also be
-			// suppressed. Bare \n events break parsers like openai-go's
-			// ssestream (Warp's backend). Only forward the separator
-			// when the preceding data line was actually forwarded.
-			if sink.swallowBlank {
-				sink.swallowBlank = false
-				continue
-			}
-			// Forward empty lines — they are SSE event separators required by
-			// the spec. Clients like eventsource-parser dispatch events on
-			// blank lines; omitting them causes all data lines to be
-			// concatenated into one invalid event.
-			if err := sink.write([]byte("\n")); err != nil {
-				st.clientDisconnected = true
-				debuglog.Warn("proxy: client write failed during stream (blank line)", "error", err, "model", logData.modelID, "provider", logData.providerName, "chunks", chunkCount, "bytes_written", sink.bytesWritten)
+			if h.emitBlank(sink, st, chunkCount, logData) {
 				goto logUpdate
 			}
-			sink.flush()
 			continue
 		}
 
 		if ev.kind == sseComment {
-			// Not a data line — an SSE comment (": ..."), an event/id/retry
-			// directive, etc. Pass through without parsing.
-			lineStr := ev.clean
-			// P1-C: Detect Anthropic-style "event: error" lines for logging.
-			// Anthropic streams use typed events like:
-			//   event: error
-			//   data: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}
-			// We track "event: error" so the next data line is known to be an
-			// error payload, allowing us to extract the message for logging.
-			if strings.HasPrefix(lineStr, "event:") {
-				evt := strings.TrimSpace(lineStr[6:])
-				if evt == "error" {
-					st.lastAnthropicEvent = "error"
-				} else {
-					st.lastAnthropicEvent = ""
-				}
-			}
-			// Flush any accumulated error when a non-data line arrives
-			// (the error payload has already been captured in the data line).
-			st.flushAccumulatedError(chunkCount, logData)
-			if err := sink.write(line); err != nil {
-				st.clientDisconnected = true
-				debuglog.Warn("proxy: client write failed during stream", "error", err, "model", logData.modelID, "provider", logData.providerName, "chunks", chunkCount, "bytes_written", sink.bytesWritten)
+			if h.emitComment(sink, st, ev, chunkCount, logData) {
 				goto logUpdate
 			}
-			if err := sink.write([]byte("\n")); err != nil {
-				st.clientDisconnected = true
-				debuglog.Warn("proxy: client write failed during stream (newline)", "error", err, "model", logData.modelID, "provider", logData.providerName, "chunks", chunkCount, "bytes_written", sink.bytesWritten)
-				goto logUpdate
-			}
-			sink.flush()
 			continue
 		}
 
 		if ev.kind == sseDone {
-			st.sawDone = true
-			// Write [DONE] sentinel to the downstream client.
-			if err := sink.write(line); err != nil {
-				st.clientDisconnected = true
-				debuglog.Warn("proxy: client write failed during stream", "error", err, "model", logData.modelID, "provider", logData.providerName, "chunks", chunkCount, "bytes_written", sink.bytesWritten)
+			if h.emitDone(sink, st, ev, chunkCount, logData) {
 				goto logUpdate
 			}
-			if err := sink.write([]byte("\n\n")); err != nil {
-				st.clientDisconnected = true
-				debuglog.Warn("proxy: client write failed during stream (newline)", "error", err, "model", logData.modelID, "provider", logData.providerName, "chunks", chunkCount, "bytes_written", sink.bytesWritten)
-				goto logUpdate
-			}
-			sink.flush()
-			debuglog.Debug("proxy: received [DONE] sentinel", "model", logData.modelID, "provider", logData.providerName, "chunks", chunkCount)
 			break
 		}
 
@@ -218,6 +139,126 @@ logUpdate:
 	st.chunkCount = reader.chunkCount
 	st.stalled = reader.stalled()
 	h.finalizeStream(st, sink, reader.err(), logData, opts, resp.StatusCode, startTime)
+}
+
+// initStreamResponse writes the SSE response headers and populates the interim
+// "streaming" logData (timings + status/attempt), then fires the fire-and-forget
+// interim updateRequestLog. Headers are written before any streamed byte, and
+// the interim log update must NOT wait for the async INSERT (blocking on
+// WaitForInsert would delay the client); the final update waits properly.
+func (h *Handler) initStreamResponse(w http.ResponseWriter, logData *requestLogData, opts streamOptions, resp *http.Response) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+	w.WriteHeader(http.StatusOK)
+	debuglog.Debug("proxy: streaming headers sent", "model", logData.modelID, "provider", logData.providerName)
+
+	logData.statusCode = resp.StatusCode
+	logData.proxyOverheadMs = opts.proxyOverheadMs
+	logData.parseMs = opts.parseMs
+	logData.failoverLookupMs = opts.failoverLookupMs
+	logData.modelLookupMs = opts.modelLookupMs
+	logData.providerLookupMs = opts.providerLookupMs
+	logData.keyDecryptMs = opts.keyDecryptMs
+	logData.dialMs = opts.dialMs
+	logData.settingsReadMs = opts.settingsReadMs
+	logData.responseHeaderMs = opts.responseHeaderMs
+	logData.ttftMs = opts.trueTtftMs
+	logData.failoverAttempt = opts.attempt
+	logData.state = "streaming"
+	// Fire-and-forget: the interim "streaming" state update runs before
+	// the first streamed byte. Blocking on WaitForInsert (up to 5s) would
+	// delay the client. The final update (completed/failed) waits properly.
+	h.updateRequestLog(logData, updateLogOption{skipWaitForInsert: true})
+}
+
+// emitBlank forwards or swallows a blank SSE separator line. When the preceding
+// data line was stripped (sink.swallowBlank), the trailing separator is
+// suppressed so downstream parsers don't see a bare "\n" event. Returns
+// stop=true on a client write failure (the caller jumps to finalize).
+func (h *Handler) emitBlank(sink *streamSink, st *streamState, chunkCount int, logData *requestLogData) (stop bool) {
+	// When strip_reasoning skips a reasoning chunk, the SSE separator (empty
+	// line) that followed it must also be suppressed. Bare \n events break
+	// parsers like openai-go's ssestream (Warp's backend). Only forward the
+	// separator when the preceding data line was actually forwarded.
+	if sink.swallowBlank {
+		sink.swallowBlank = false
+		return false
+	}
+	// Forward empty lines — they are SSE event separators required by the spec.
+	// Clients like eventsource-parser dispatch events on blank lines; omitting
+	// them causes all data lines to be concatenated into one invalid event.
+	if err := sink.write([]byte("\n")); err != nil {
+		st.clientDisconnected = true
+		debuglog.Warn("proxy: client write failed during stream (blank line)", "error", err, "model", logData.modelID, "provider", logData.providerName, "chunks", chunkCount, "bytes_written", sink.bytesWritten)
+		return true
+	}
+	sink.flush()
+	return false
+}
+
+// emitComment passes through a non-data SSE line (comment, event/id/retry
+// directive) verbatim, capturing the Anthropic-style "event: error" marker so
+// the next data line is known to be an error payload, and flushing any
+// accumulated split-error first. Returns stop=true on a client write failure.
+func (h *Handler) emitComment(sink *streamSink, st *streamState, ev sseEvent, chunkCount int, logData *requestLogData) (stop bool) {
+	line := ev.raw
+	// Not a data line — an SSE comment (": ..."), an event/id/retry directive,
+	// etc. Pass through without parsing.
+	lineStr := ev.clean
+	// P1-C: Detect Anthropic-style "event: error" lines for logging. Anthropic
+	// streams use typed events like:
+	//   event: error
+	//   data: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}
+	// We track "event: error" so the next data line is known to be an error
+	// payload, allowing us to extract the message for logging.
+	if strings.HasPrefix(lineStr, "event:") {
+		evt := strings.TrimSpace(lineStr[6:])
+		if evt == "error" {
+			st.lastAnthropicEvent = "error"
+		} else {
+			st.lastAnthropicEvent = ""
+		}
+	}
+	// Flush any accumulated error when a non-data line arrives
+	// (the error payload has already been captured in the data line).
+	st.flushAccumulatedError(chunkCount, logData)
+	if err := sink.write(line); err != nil {
+		st.clientDisconnected = true
+		debuglog.Warn("proxy: client write failed during stream", "error", err, "model", logData.modelID, "provider", logData.providerName, "chunks", chunkCount, "bytes_written", sink.bytesWritten)
+		return true
+	}
+	if err := sink.write([]byte("\n")); err != nil {
+		st.clientDisconnected = true
+		debuglog.Warn("proxy: client write failed during stream (newline)", "error", err, "model", logData.modelID, "provider", logData.providerName, "chunks", chunkCount, "bytes_written", sink.bytesWritten)
+		return true
+	}
+	sink.flush()
+	return false
+}
+
+// emitDone forwards the [DONE] sentinel to the client. It sets st.sawDone before
+// the write — verbatim ordering — so a disconnect mid-[DONE] still leaves sawDone
+// set for finalizeStream's missing-[DONE] decision. Returns stop=true on a client
+// write failure; on success the caller breaks the loop into finalize.
+func (h *Handler) emitDone(sink *streamSink, st *streamState, ev sseEvent, chunkCount int, logData *requestLogData) (stop bool) {
+	line := ev.raw
+	st.sawDone = true
+	// Write [DONE] sentinel to the downstream client.
+	if err := sink.write(line); err != nil {
+		st.clientDisconnected = true
+		debuglog.Warn("proxy: client write failed during stream", "error", err, "model", logData.modelID, "provider", logData.providerName, "chunks", chunkCount, "bytes_written", sink.bytesWritten)
+		return true
+	}
+	if err := sink.write([]byte("\n\n")); err != nil {
+		st.clientDisconnected = true
+		debuglog.Warn("proxy: client write failed during stream (newline)", "error", err, "model", logData.modelID, "provider", logData.providerName, "chunks", chunkCount, "bytes_written", sink.bytesWritten)
+		return true
+	}
+	sink.flush()
+	debuglog.Debug("proxy: received [DONE] sentinel", "model", logData.modelID, "provider", logData.providerName, "chunks", chunkCount)
+	return false
 }
 
 // handleDataChunk processes one sseData event end-to-end: capture split/Anthropic

--- a/internal/proxy/resolve.go
+++ b/internal/proxy/resolve.go
@@ -42,72 +42,126 @@ func (h *Handler) resolveHotelModel(ctx context.Context, displayModel string) ([
 	debuglog.Debug("resolve: resolving hotel model", "model", displayModel)
 	var t resolveTimings
 	var ch resolveCacheHits
-	failoverLookupStart := time.Now()
 
+	// A — failover-group lookup + validation. Stamp ch.Failover / failoverLookupMs
+	// only after success so the early-error ledger leaves them zero.
+	failoverLookupStart := time.Now()
+	fg, failoverHit, err := h.lookupFailoverGroup(ctx, displayModel)
+	if err != nil {
+		return nil, t, ch, err
+	}
+	ch.Failover = &failoverHit
+	t.failoverLookupMs = float64(time.Since(failoverLookupStart).Microseconds()) / 1000.0
+	debuglog.Debug("resolve: failover group found", "model", displayModel, "entries", len(fg.PriorityOrder), "enabled", fg.GroupEnabled)
+
+	// B — enabled-model collection + batch model lookup.
+	modelLookupStart := time.Now()
+	enabledModelIDs := enabledEntryIDs(fg)
+	ch.Model = batchCacheHit(enabledModelIDs, model.IsCachedByUUID)
+	models, err := h.modelRepo.GetByIDs(ctx, enabledModelIDs)
+	if err != nil {
+		return nil, t, ch, err
+	}
+	t.modelLookupMs = float64(time.Since(modelLookupStart).Microseconds()) / 1000.0
+
+	// C — provider collection + batch provider lookup. providerLookupStart opens
+	// the window that physically contains the settings read (D) and every key
+	// decrypt (E); providerLookupMs is derived by subtracting those below.
+	providerLookupStart := time.Now()
+	var settingsReadInWindow float64
+
+	providerIDs := providerIDsFor(enabledModelIDs, models)
+	ch.Provider = batchCacheHit(providerIDs, provider.IsCachedByID)
+	providers, err := h.providerRepo.GetByIDs(ctx, providerIDs)
+	if err != nil {
+		return nil, t, ch, err
+	}
+
+	// D — read circuit_breaker_enabled once before the loop to avoid
+	// per-candidate settings reads. The single elapsed sample is accounted for
+	// in both settingsReadMs (via the context accumulator) and
+	// settingsReadInWindow (subtracted from providerLookupMs below) — keep both
+	// adds here, off one pre-computed cbElapsed, so the dual accounting stays
+	// visible in one place. Only track settings actually read during resolve;
+	// failover_on_rate_limit is read later in shouldFailover (outside the resolve
+	// phase) so checking it here would show a false amber for requests that
+	// never trigger 429.
+	cbEnabled, settingsHit, cbElapsed := h.readCircuitBreakerFlag(ctx)
+	settingsReadInWindow += cbElapsed
+	if v := ctx.Value(ctxkeys.SettingsReadMsKey); v != nil {
+		if p, ok := v.(*float64); ok {
+			*p += cbElapsed
+		}
+	}
+	ch.Settings = &settingsHit
+
+	// E — candidate-build loop (no window math inside; it only returns the
+	// running key-decrypt total the caller subtracts).
+	debuglog.Debug("resolve: building candidates from failover group", "model", displayModel, "priority_order_count", len(fg.PriorityOrder))
+	candidates, keyDecryptTotal, decryptFailures, keyHit := h.buildFailoverCandidates(fg, models, providers, cbEnabled)
+
+	// F — finalize timings + terminal error.
+	// Only record key cache hit if there were keys to decrypt.
+	if keyDecryptTotal > 0 {
+		ch.Key = &keyHit
+	}
+	t.providerLookupMs = max(0, float64(time.Since(providerLookupStart).Microseconds())/1000.0-keyDecryptTotal-settingsReadInWindow)
+	t.keyDecryptMs = keyDecryptTotal
+	if len(candidates) == 0 && decryptFailures > 0 {
+		return nil, t, ch, fmt.Errorf("all %d candidate(s) failed key decryption (wrong master key?)", decryptFailures)
+	}
+	debuglog.Debug("resolve: hotel model resolved", "model", displayModel, "candidates", len(candidates), "decrypt_failures", decryptFailures)
+	return candidates, t, ch, nil
+}
+
+// lookupFailoverGroup performs phase A: the failover cache probe, the repo
+// lookup, and the group-enabled / non-empty validations. It returns the group
+// and the cache-hit bool but does NOT stamp ch.Failover / failoverLookupMs —
+// the caller does that only on success, preserving the "zero on early error"
+// contract.
+func (h *Handler) lookupFailoverGroup(ctx context.Context, displayModel string) (*failover.FailoverGroup, bool, error) {
 	// Check failover cache before lookup (lookup populates cache on miss).
 	failoverHit := failover.IsCachedByModel(displayModel)
 
 	fg, err := h.failoverRepo.GetByModel(ctx, displayModel)
 	if err != nil {
-		return nil, t, ch, err
+		return nil, false, err
 	}
 
 	if !fg.GroupEnabled {
 		debuglog.Warn("resolve: failover group disabled", "model", displayModel)
-		return nil, t, ch, fmt.Errorf("failover group disabled")
+		return nil, false, fmt.Errorf("failover group disabled")
 	}
 
 	if len(fg.PriorityOrder) == 0 {
 		debuglog.Warn("resolve: empty failover group", "model", displayModel)
-		return nil, t, ch, fmt.Errorf("no entries in failover group")
+		return nil, false, fmt.Errorf("no entries in failover group")
 	}
 
-	ch.Failover = &failoverHit
-	t.failoverLookupMs = float64(time.Since(failoverLookupStart).Microseconds()) / 1000.0
-	debuglog.Debug("resolve: failover group found", "model", displayModel, "entries", len(fg.PriorityOrder), "enabled", fg.GroupEnabled)
+	return fg, failoverHit, nil
+}
 
-	modelLookupStart := time.Now()
-
-	// Collect enabled model UUIDs for batch lookup
-	enabledModelIDs := make([]uuid.UUID, 0, len(fg.PriorityOrder))
+// enabledEntryIDs collects the model UUIDs whose failover entry is enabled,
+// preserving PriorityOrder. Pure selector (phase B-collect).
+func enabledEntryIDs(fg *failover.FailoverGroup) []uuid.UUID {
+	ids := make([]uuid.UUID, 0, len(fg.PriorityOrder))
 	for _, modelUUID := range fg.PriorityOrder {
 		entryEnabled := true
 		if val, ok := fg.EntryEnabled[modelUUID.String()]; ok {
 			entryEnabled = val
 		}
 		if entryEnabled {
-			enabledModelIDs = append(enabledModelIDs, modelUUID)
+			ids = append(ids, modelUUID)
 		}
 	}
+	return ids
+}
 
-	// Check model cache before lookup (batch: all must hit to count as hit).
-	// Skip setting the field when there are no models to check; an empty
-	// set would otherwise default to "hit" which is misleading.
-	if len(enabledModelIDs) > 0 {
-		modelHit := true
-		for _, id := range enabledModelIDs {
-			if !model.IsCachedByUUID(id) {
-				modelHit = false
-				break
-			}
-		}
-		ch.Model = &modelHit
-	}
-
-	models, err := h.modelRepo.GetByIDs(ctx, enabledModelIDs)
-	if err != nil {
-		return nil, t, ch, err
-	}
-
-	t.modelLookupMs = float64(time.Since(modelLookupStart).Microseconds()) / 1000.0
-
-	providerLookupStart := time.Now()
-	var keyDecryptTotal float64
-	var settingsReadInWindow float64
-
-	// Collect unique provider IDs for batch lookup
+// providerIDsFor collects the unique provider IDs of the enabled+provider-enabled
+// models among ids. Pure selector (phase C-collect).
+func providerIDsFor(ids []uuid.UUID, models map[uuid.UUID]*model.Model) []uuid.UUID {
 	providerIDSet := make(map[uuid.UUID]struct{})
-	for _, modelUUID := range enabledModelIDs {
+	for _, modelUUID := range ids {
 		if m, ok := models[modelUUID]; ok && m.Enabled && m.ProviderEnabled {
 			providerIDSet[m.ProviderID] = struct{}{}
 		}
@@ -116,52 +170,48 @@ func (h *Handler) resolveHotelModel(ctx context.Context, displayModel string) ([
 	for pid := range providerIDSet {
 		providerIDs = append(providerIDs, pid)
 	}
+	return providerIDs
+}
 
-	// Check provider cache before lookup (batch: all must hit to count as hit).
-	// Skip setting the field when there are no providers to check; an empty
-	// set would otherwise default to "hit" which is misleading.
-	if len(providerIDs) > 0 {
-		providerHit := true
-		for _, id := range providerIDs {
-			if !provider.IsCachedByID(id) {
-				providerHit = false
-				break
-			}
+// batchCacheHit reports whether every id is cached (all-must-hit). It returns
+// nil for an empty batch so the caller skips the cache-hit field — an empty
+// all-must-hit set would otherwise falsely read "hit".
+func batchCacheHit[T comparable](ids []T, cached func(T) bool) *bool {
+	if len(ids) == 0 {
+		return nil
+	}
+	hit := true
+	for _, id := range ids {
+		if !cached(id) {
+			hit = false
+			break
 		}
-		ch.Provider = &providerHit
 	}
+	return &hit
+}
 
-	providers, err := h.providerRepo.GetByIDs(ctx, providerIDs)
-	if err != nil {
-		return nil, t, ch, err
-	}
-
-	// Read circuit_breaker_enabled once before the loop to avoid
-	// per-candidate settings reads. This single read is still accounted
-	// for in both settingsReadMs (via context accumulator) and
-	// settingsReadInWindow (subtracted from providerLookupMs below).
-	// Only track settings actually read during resolve; failover_on_rate_limit
-	// is read later in shouldFailover (outside the resolve phase) so checking
-	// it here would show a false amber for requests that never trigger 429.
-	settingsHit := h.settingsRepo.IsCached("circuit_breaker_enabled")
+// readCircuitBreakerFlag performs phase D: the single circuit_breaker_enabled
+// settings read. It returns the flag, the cache-hit, and the elapsed sample so
+// the caller can do the dual accounting (settingsReadInWindow + the context
+// accumulator) off one pre-computed value.
+func (h *Handler) readCircuitBreakerFlag(ctx context.Context) (enabled, hit bool, elapsedMs float64) {
+	hit = h.settingsRepo.IsCached("circuit_breaker_enabled")
 	cbStart := time.Now()
-	cbEnabled := h.settingsRepo.GetBool(ctx, "circuit_breaker_enabled", true)
-	cbElapsed := float64(time.Since(cbStart).Microseconds()) / 1000.0
-	settingsReadInWindow += cbElapsed
-	// Add the same pre-computed elapsed value to the context accumulator
-	// to avoid a second time.Since(cbStart) call that would diverge
-	// from settingsReadInWindow (which is subtracted from providerLookupMs).
-	if v := ctx.Value(ctxkeys.SettingsReadMsKey); v != nil {
-		if p, ok := v.(*float64); ok {
-			*p += cbElapsed
-		}
-	}
-	ch.Settings = &settingsHit
+	enabled = h.settingsRepo.GetBool(ctx, "circuit_breaker_enabled", true)
+	elapsedMs = float64(time.Since(cbStart).Microseconds()) / 1000.0
+	return enabled, hit, elapsedMs
+}
 
-	candidates := make([]modelCandidate, 0, len(fg.PriorityOrder))
-	var decryptFailures int
-	keyHit := true
-	debuglog.Debug("resolve: building candidates from failover group", "model", displayModel, "priority_order_count", len(fg.PriorityOrder))
+// buildFailoverCandidates performs phase E: walk PriorityOrder, skip
+// disabled/missing/circuit-broken entries, decrypt keys (keyless → ""), and
+// build the candidate list. It owns only the per-key decrypt timing, returning
+// the running total so the caller subtracts it from providerLookupMs; it does
+// no window math itself.
+func (h *Handler) buildFailoverCandidates(fg *failover.FailoverGroup, models map[uuid.UUID]*model.Model,
+	providers map[uuid.UUID]*provider.Provider, cbEnabled bool,
+) (candidates []modelCandidate, keyDecryptTotal float64, decryptFailures int, keyHit bool) {
+	candidates = make([]modelCandidate, 0, len(fg.PriorityOrder))
+	keyHit = true
 	for _, modelUUID := range fg.PriorityOrder {
 		entryEnabled := true
 		if val, ok := fg.EntryEnabled[modelUUID.String()]; ok {
@@ -222,19 +272,7 @@ func (h *Handler) resolveHotelModel(ctx context.Context, displayModel string) ([
 		}
 		candidates = append(candidates, modelCandidate{model: m, provider: prov, apiKey: apiKey})
 	}
-
-	// Only record key cache hit if there were keys to decrypt.
-	if keyDecryptTotal > 0 {
-		ch.Key = &keyHit
-	}
-
-	t.providerLookupMs = max(0, float64(time.Since(providerLookupStart).Microseconds())/1000.0-keyDecryptTotal-settingsReadInWindow)
-	t.keyDecryptMs = keyDecryptTotal
-	if len(candidates) == 0 && decryptFailures > 0 {
-		return nil, t, ch, fmt.Errorf("all %d candidate(s) failed key decryption (wrong master key?)", decryptFailures)
-	}
-	debuglog.Debug("resolve: hotel model resolved", "model", displayModel, "candidates", len(candidates), "decrypt_failures", decryptFailures)
-	return candidates, t, ch, nil
+	return candidates, keyDecryptTotal, decryptFailures, keyHit
 }
 
 func (h *Handler) resolveSpecificProvider(ctx context.Context, providerName, modelID string) ([]modelCandidate, resolveTimings, resolveCacheHits, error) {


### PR DESCRIPTION
Pure-restructuring pass that decomposes the four largest production functions in the repo into thin orchestrators over named, single-purpose helpers. **No behavior, byte-output, or timing change** in any function; full suites green and lint clean after each commit.

## Commits

1. **`resolveHotelModel`** (`internal/proxy/resolve.go`, 198 → 75-line orchestrator) — split into `lookupFailoverGroup`, `enabledEntryIDs`, `providerIDsFor`, `batchCacheHit[T]`, `readCircuitBreakerFlag`, `buildFailoverCandidates`. Timing-window math and dual settings accounting kept inline; cache-hit nil-vs-set semantics and post-success-only stamping of `ch.Failover`/`failoverLookupMs` preserved.

2. **`handleStreamingResponse`** (`internal/proxy/proxy.go`, ~196 → 117 lines) — extracted the blank/comment/`[DONE]` emitters (`emitBlank`/`emitComment`/`emitDone`, mirroring `handleDataChunk`'s `(stop bool)` contract) plus `initStreamResponse` (headers + logData + interim fire-and-forget log). The loop is now a four-way `Next()` dispatch. `st.sawDone` set-before-write, `swallowBlank` ownership, and `clientDisconnected`-on-write-error all preserved; the 3 byte-exact SSE goldens are unchanged.

3. **`TestModel` + `RestoreBackup`** (`internal/api/`, 184 → 47 and 170 → 47 lines):
   - `TestModel` → `resolveTestModelTarget`, `decryptTestModelKey`, `buildTestModelRequest`, `doTestModelRequest`, `parseTestModelResponse`, and three **verbatim** `request_logs` writers (the three INSERTs use distinct column sets, so they were *not* merged — avoids default-vs-explicit value drift).
   - `RestoreBackup` → `saveUploadedDump`, `validateRestoreDump`, `runPgRestore`; orchestrator reads as save → validate → restore → publish/exit.

## Verification

- `make build` clean
- `go test ./internal/proxy/... ./internal/failover/... ./internal/api/...` green
- `golangci-lint run ./...` — 0 issues

Decomposition plans for commits 1 and 2 are tracked in `plans/already-implemented/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)