### PR TITLE
Reduce React act() warnings in frontend tests

### DIFF
--- a/web/src/__tests__/App.test.tsx
+++ b/web/src/__tests__/App.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from "@testing-library/react";
+import { act, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { HttpResponse, http } from "msw";
 import { lazy, Suspense } from "react";
@@ -276,7 +276,7 @@ describe("AppContent", () => {
 		expect(screen.getByRole("button", { name: "Sign In" })).toBeInTheDocument();
 	});
 
-	it("renders Layout with routes when token present", () => {
+	it("renders Layout with routes when token present", async () => {
 		localStorage.setItem("adminToken", "existing-token");
 
 		renderWithProviders(<App />);
@@ -289,17 +289,23 @@ describe("AppContent", () => {
 		expect(screen.getByText("Virtual Keys")).toBeInTheDocument();
 		expect(screen.getByText("Logs")).toBeInTheDocument();
 		expect(screen.getByText("Settings")).toBeInTheDocument();
+
+		// Flush Layout's background data hooks so their state updates settle
+		// inside act() (avoids "not wrapped in act" warnings under CI timing).
+		await act(async () => {});
 	});
 
-	it("calls setAdminToken with token from localStorage on mount", () => {
+	it("calls setAdminToken with token from localStorage on mount", async () => {
 		localStorage.setItem("adminToken", "stored-token");
 
 		renderWithProviders(<App />);
 
 		expect(setAdminToken).toHaveBeenCalledWith("stored-token");
+
+		await act(async () => {});
 	});
 
-	it("navigates to dashboard by default when token present", () => {
+	it("navigates to dashboard by default when token present", async () => {
 		localStorage.setItem("adminToken", "test-token");
 
 		renderWithProviders(<App />);
@@ -308,6 +314,8 @@ describe("AppContent", () => {
 		expect(window.location.pathname).toBe("/");
 		// Dashboard content should be visible
 		expect(screen.getByText("Dashboard")).toBeInTheDocument();
+
+		await act(async () => {});
 	});
 });
 

--- a/web/src/components/__tests__/Layout.last-error-pills.test.tsx
+++ b/web/src/components/__tests__/Layout.last-error-pills.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from "@testing-library/react";
+import { act, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { HttpResponse, http } from "msw";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -265,7 +265,9 @@ describe("Layout", () => {
 					screen.queryByTitle("Acknowledge (dismiss)"),
 				).not.toBeInTheDocument();
 			});
-			window.dispatchEvent(new Event("dismissedErrorsReset"));
+			await act(async () => {
+				window.dispatchEvent(new Event("dismissedErrorsReset"));
+			});
 			await waitFor(() => {
 				expect(screen.getByTitle("Acknowledge (dismiss)")).toBeInTheDocument();
 			});

--- a/web/src/components/__tests__/Layout.navigation.test.tsx
+++ b/web/src/components/__tests__/Layout.navigation.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from "@testing-library/react";
+import { act, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { HttpResponse, http } from "msw";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -712,7 +712,9 @@ describe("Layout", () => {
 			const event = new CustomEvent("server-event", {
 				detail: { type: "circuit_breaker.open", message: "Provider down" },
 			});
-			window.dispatchEvent(event);
+			await act(async () => {
+				window.dispatchEvent(event);
+			});
 
 			await waitFor(() => {
 				expect(fetchCount).toBeGreaterThan(initialCount);
@@ -723,7 +725,9 @@ describe("Layout", () => {
 			const nonMatchingEvent = new CustomEvent("server-event", {
 				detail: { type: "provider.created", message: "New provider" },
 			});
-			window.dispatchEvent(nonMatchingEvent);
+			await act(async () => {
+				window.dispatchEvent(nonMatchingEvent);
+			});
 
 			// Give a tick for any potential refetch
 			await new Promise((r) => setTimeout(r, 100));

--- a/web/src/components/__tests__/ProviderQuotaPanel.test.tsx
+++ b/web/src/components/__tests__/ProviderQuotaPanel.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from "@testing-library/react";
+import { act, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { QuotaDataResult } from "../../hooks/useQuotaData";
@@ -315,7 +315,9 @@ describe("ProviderQuotaPanel", () => {
 			localStorage.setItem("sidebarQuotaDisabled", "true");
 
 			// Dispatch toggle event
-			window.dispatchEvent(new CustomEvent("sidebarQuotaToggle"));
+			await act(async () => {
+				window.dispatchEvent(new CustomEvent("sidebarQuotaToggle"));
+			});
 
 			// Panel should be hidden when disabled
 			await vi.waitFor(() => {
@@ -327,7 +329,9 @@ describe("ProviderQuotaPanel", () => {
 			setupPanel();
 
 			localStorage.setItem("sidebarQuotaRefreshMin", "10");
-			window.dispatchEvent(new CustomEvent("sidebarQuotaRefreshChange"));
+			await act(async () => {
+				window.dispatchEvent(new CustomEvent("sidebarQuotaRefreshChange"));
+			});
 
 			// The handler calls setRefreshIntervalMin which triggers a
 			// re-render with the updated refetchInterval passed to
@@ -355,7 +359,9 @@ describe("ProviderQuotaPanel", () => {
 			// The production handler re-reads localStorage directly and
 			// does not inspect event.key or event.newValue, so those
 			// fields are omitted to avoid implying key-based filtering.
-			window.dispatchEvent(new StorageEvent("storage"));
+			await act(async () => {
+				window.dispatchEvent(new StorageEvent("storage"));
+			});
 
 			// Panel should be hidden when disabled via cross-tab
 			await vi.waitFor(() => {

--- a/web/src/components/__tests__/QuotaBadge.test.tsx
+++ b/web/src/components/__tests__/QuotaBadge.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import type {
 	DeepSeekBalance,
 	NanoGPTUsage,
@@ -697,11 +697,13 @@ describe("QuotaBadges", () => {
 		expect(screen.getByText("800K/1M")).toBeInTheDocument();
 
 		localStorage.setItem("quota-bar-mode", "used");
-		window.dispatchEvent(
-			new CustomEvent("localStorageChange", {
-				detail: { key: "quota-bar-mode" },
-			}),
-		);
+		await act(async () => {
+			window.dispatchEvent(
+				new CustomEvent("localStorageChange", {
+					detail: { key: "quota-bar-mode" },
+				}),
+			);
+		});
 
 		await waitFor(() => {
 			expect(screen.getByText("200K/1M")).toBeInTheDocument();

--- a/web/src/pages/Chat/__tests__/useChat.test.tsx
+++ b/web/src/pages/Chat/__tests__/useChat.test.tsx
@@ -259,7 +259,7 @@ describe("useChat", () => {
 			expect(result.current.isStreaming).toBe(false);
 		});
 
-		it("calls handleSend when Enter pressed without shift in chat mode and not streaming", () => {
+		it("calls handleSend when Enter pressed without shift in chat mode and not streaming", async () => {
 			mockStreamModelResponse.mockResolvedValue({
 				rawContent: "",
 				content: "Response",
@@ -291,6 +291,9 @@ describe("useChat", () => {
 			expect(result.current.isStreaming).toBe(true);
 			expect(result.current.messages.length).toBeGreaterThanOrEqual(1);
 			expect(result.current.messages[0].content).toBe("Hello");
+
+			// Flush the async handleSend resolution inside act().
+			await act(async () => {});
 		});
 
 		it("does nothing when Shift+Enter is pressed (no-op branch)", () => {
@@ -1147,7 +1150,7 @@ describe("useChat", () => {
 	});
 
 	describe("handleSend", () => {
-		it("includes pendingImage in the message when present", () => {
+		it("includes pendingImage in the message when present", async () => {
 			const pendingImageData = {
 				dataUrl: "data:image/png;base64,test",
 				format: "png",
@@ -1193,6 +1196,9 @@ describe("useChat", () => {
 			const userMsg = result.current.messages.find((m) => m.role === "user");
 			expect(userMsg?.imageUrl).toBe("data:image/png;base64,test");
 			expect(mockSetPendingImage).toHaveBeenCalledWith(null);
+
+			// Flush the async handleSend resolution inside act().
+			await act(async () => {});
 		});
 
 		it("returns early when already sending (sendingRef)", () => {

--- a/web/src/pages/Dashboard/__tests__/useDashboard.test.tsx
+++ b/web/src/pages/Dashboard/__tests__/useDashboard.test.tsx
@@ -184,6 +184,41 @@ describe("useDashboard", () => {
 			nowSpy.mockRestore();
 		});
 
+		it("clears the previous cooldown timer when refreshed again and on unmount", async () => {
+			const { result, unmount } = renderHook(() => useDashboard(), {
+				wrapper: AllProviders,
+			});
+			await waitFor(() => {
+				expect(result.current.stats).toBeDefined();
+			});
+
+			const clearSpy = vi.spyOn(globalThis, "clearTimeout");
+			const fixedNow = 1_000_000;
+			const nowSpy = vi.spyOn(Date, "now").mockReturnValue(fixedNow);
+
+			// First refresh schedules the cooldown timer.
+			act(() => {
+				result.current.handleRefresh();
+			});
+			expect(result.current.isRefreshing).toBe(true);
+
+			// Advance past the 5s cooldown so a second refresh is allowed; it must
+			// clear the previously scheduled timer before scheduling a new one.
+			nowSpy.mockReturnValue(fixedNow + 6000);
+			act(() => {
+				result.current.handleRefresh();
+			});
+			expect(clearSpy).toHaveBeenCalled();
+
+			// Unmounting clears the outstanding timer via the cleanup effect.
+			const callsBeforeUnmount = clearSpy.mock.calls.length;
+			unmount();
+			expect(clearSpy.mock.calls.length).toBeGreaterThan(callsBeforeUnmount);
+
+			nowSpy.mockRestore();
+			clearSpy.mockRestore();
+		});
+
 		it("handleRefresh invalidates all relevant queries", async () => {
 			const { result } = renderHook(() => useDashboard(), {
 				wrapper: AllProviders,

--- a/web/src/pages/Dashboard/useDashboard.ts
+++ b/web/src/pages/Dashboard/useDashboard.ts
@@ -297,7 +297,20 @@ export function useDashboard(): UseDashboardReturn {
 	const { toast } = useToast();
 	const lastManualRefresh = useRef(0);
 	const refreshCooldownMs = 5000;
+	const refreshCooldownTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+		null,
+	);
 	const [isRefreshing, setIsRefreshing] = useState(false);
+
+	// Clear the cooldown timer on unmount so the deferred setIsRefreshing(false)
+	// never fires after the component is gone (avoids a leaked state update).
+	useEffect(() => {
+		return () => {
+			if (refreshCooldownTimerRef.current) {
+				clearTimeout(refreshCooldownTimerRef.current);
+			}
+		};
+	}, []);
 
 	const [dashboardRefreshMs, setDashboardRefreshMs] = useState(() => {
 		try {
@@ -357,7 +370,13 @@ export function useDashboard(): UseDashboardReturn {
 		queryClient.invalidateQueries({ queryKey: ["stats-usage"] });
 		queryClient.invalidateQueries({ queryKey: ["stats-tokens"] });
 		toast(t("settings.dashboard.refreshingDashboard"), "info");
-		setTimeout(() => setIsRefreshing(false), refreshCooldownMs);
+		if (refreshCooldownTimerRef.current) {
+			clearTimeout(refreshCooldownTimerRef.current);
+		}
+		refreshCooldownTimerRef.current = setTimeout(
+			() => setIsRefreshing(false),
+			refreshCooldownMs,
+		);
 	}, [queryClient, toast, t]);
 
 	// Hide manual refresh when auto-refresh is 10s or faster

--- a/web/src/pages/Providers/__tests__/Providers.test.tsx
+++ b/web/src/pages/Providers/__tests__/Providers.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor, within } from "@testing-library/react";
+import { act, screen, waitFor, within } from "@testing-library/react";
 import { HttpResponse, http } from "msw";
 import type { Provider } from "../../../api/types";
 import { mockAllDefaults } from "../../../test/helpers";
@@ -38,7 +38,9 @@ describe("Providers", () => {
 					metadata: { provider_id: mockProvider.id },
 				},
 			});
-			window.dispatchEvent(event);
+			await act(async () => {
+				window.dispatchEvent(event);
+			});
 
 			// The provider card should now show "Discovering..." state
 			// We can verify this by checking the button text and styling


### PR DESCRIPTION
Reduces the `An update to <X> inside a test was not wrapped in act(...)` warnings emitted by the frontend test run. Tests pass and CI is green throughout — these are stderr warnings, not failures.

## Fixed (CI-verified: ~50 → 29 warnings)
- **dispatchEvent triggers** wrapped in `await act(async () => {...})` — Layout last-error-pills/navigation, QuotaBadge, ProviderQuotaPanel, Providers. (matches the existing pattern in `Logs.sse-display.test.tsx`.)
- **App `AppContent` tests** — the three authenticated tests render `<App/>` (mounting Layout) but asserted synchronously; added a trailing `await act(async () => {})` flush so Layout's background data settles in act. Assertions unchanged.
- **useChat** — two subtests (`handleKeyDown > calls handleSend`, `handleSend > includes pendingImage`) trigger an async `handleSend` in a sync `act()`; added the trailing flush. Reproduced in isolation and verified 4 → 0.
- **useDashboard** (production fix) — `handleRefresh` scheduled `setTimeout(() => setIsRefreshing(false), 5000)` with no cleanup; the deferred update fired after unmount. Now tracked in a ref and cleared on unmount / before re-scheduling. A leaked-update bug regardless of the warning.

## Not fixed (and why)
The remaining ~29 are **cross-file, real-timer-timing teardown bleeds**: a test's deferred update fires during a *later* test file, but only under CI's slower CPU. They do **not** reproduce locally via any method tried (default, `--coverage`, sequential, file pairs, all renderHook files scanned in isolation, injected MSW latency). Without local reproduction they can't be pinpointed or verified, so further fixes would be blind CI round-trips. Stopping at the verified reduction; the rest are cosmetic CI-only warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)