### PR TITLE
feat(proxy): retry transient network errors against the same provider

### DIFF
--- a/internal/proxy/chat_integration_test.go
+++ b/internal/proxy/chat_integration_test.go
@@ -39,16 +39,6 @@ type testProxyEnv struct {
 // newTestProxyHandler creates a Handler with test data for ChatCompletions testing.
 // Returns a testProxyEnv struct containing all test fixtures.
 func newTestProxyHandler(t *testing.T) *testProxyEnv {
-
-	pool := testDB.Pool()
-	settingsRepo := settings.NewRepository(pool)
-	failoverRepo := failover.NewRepository(pool)
-	modelRepo := model.NewRepository(pool)
-	providerRepo := provider.NewRepository(pool)
-	virtualKeyRepo := virtualkey.NewRepository(pool)
-	limiter := ratelimit.NewLimiter(settingsRepo)
-	ipLimiter := ratelimit.NewIPLimiter(30, 60, nil, nil)
-
 	// Create a mock upstream server that returns a simple chat completion
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Verify auth header
@@ -91,6 +81,22 @@ func newTestProxyHandler(t *testing.T) *testProxyEnv {
 			json.NewEncoder(w).Encode(response)
 		}
 	}))
+
+	return newTestProxyEnvWithUpstream(t, upstream)
+}
+
+// newTestProxyEnvWithUpstream builds the standard single-provider test fixtures
+// (provider, model, virtual key, handler) around a caller-supplied upstream.
+// The provider's API key is "test-api-key".
+func newTestProxyEnvWithUpstream(t *testing.T, upstream *httptest.Server) *testProxyEnv {
+	pool := testDB.Pool()
+	settingsRepo := settings.NewRepository(pool)
+	failoverRepo := failover.NewRepository(pool)
+	modelRepo := model.NewRepository(pool)
+	providerRepo := provider.NewRepository(pool)
+	virtualKeyRepo := virtualkey.NewRepository(pool)
+	limiter := ratelimit.NewLimiter(settingsRepo)
+	ipLimiter := ratelimit.NewIPLimiter(30, 60, nil, nil)
 
 	// Create test provider
 	keyPair, err := auth.Encrypt("test-api-key", "test-master-key-for-integration")

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -8,7 +8,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptrace"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -330,11 +332,14 @@ func (h *Handler) buildCandidateRequest(ctx context.Context, st *requestState, c
 }
 
 // doUpstream executes the built request against the shared upstream transport
-// (phase D): inject the per-request dial-timing pointer, run the request, fold
-// the dial sample into the running timings (and reset it to 0 for any retry),
-// and recompute proxy overhead. On failure it classifies the cause — client
-// disconnect vs failover/retry timeout vs provider error — and records a breaker
-// failure only for real provider errors, never for context cancellation.
+// (phase D): inject the per-request dial-timing pointer, run the request —
+// retrying up to maxTransientRetries times against the same provider on
+// transient network errors (see isRetryableUpstreamError) — fold each try's
+// dial sample into the running timings, and recompute proxy overhead. Retries
+// share the per-attempt failover timeout, replay the body via GetBody, and
+// back off briefly between tries. On final failure it classifies the cause —
+// client disconnect vs failover/retry timeout vs provider error — and records a
+// breaker failure only for real provider errors, never for context cancellation.
 // Returns (resp, true) on a usable response; (nil, false) after setting
 // st.lastErr on a failover-worthy failure. The caller retains ownership of ctx
 // cancellation.
@@ -348,7 +353,6 @@ func (h *Handler) doUpstream(ctx context.Context, req *http.Request, st *request
 	// DNS resolution time into this request's own variable, avoiding
 	// cross-request race conditions on a shared atomic.
 	dialCtx := context.WithValue(ctx, ctxkeys.DialMsKey, dialMs)
-	req = req.WithContext(dialCtx)
 
 	var checkRedirect func(req *http.Request, via []*http.Request) error
 	if h.safeDialer != nil {
@@ -358,10 +362,50 @@ func (h *Handler) doUpstream(ctx context.Context, req *http.Request, st *request
 		Transport:     h.upstreamTransport,
 		CheckRedirect: checkRedirect,
 	}
-	//nolint:gosec // provider URL is admin-configured, not arbitrary user input
-	resp, err := upstreamClient.Do(req)
-	st.timings.dialMs += *dialMs
-	*dialMs = 0
+
+	var resp *http.Response
+	var err error
+	for try := 0; ; try++ {
+		// Track whether any request bytes reached the wire on this try, so
+		// isRetryableUpstreamError can tell provably-safe pre-write failures
+		// from ambiguous post-write ones. WroteHeaders may fire on a transport
+		// goroutine, hence the atomic.
+		var wroteRequest atomic.Bool
+		tryCtx := httptrace.WithClientTrace(dialCtx, &httptrace.ClientTrace{
+			WroteHeaders: func() { wroteRequest.Store(true) },
+		})
+		tryReq := req.WithContext(tryCtx)
+		if try > 0 {
+			// The previous try consumed (and the transport closed) the body.
+			// GetBody is always set: buildCandidateRequest builds the request
+			// from a bytes.Reader.
+			body, gbErr := req.GetBody()
+			if gbErr != nil {
+				break
+			}
+			tryReq.Body = body
+		}
+		//nolint:gosec // provider URL is admin-configured, not arbitrary user input
+		resp, err = upstreamClient.Do(tryReq)
+		st.timings.dialMs += *dialMs
+		*dialMs = 0
+		if err == nil || try == maxTransientRetries || !isRetryableUpstreamError(err, wroteRequest.Load()) {
+			break
+		}
+		backoff := failoverBackoff(100*time.Millisecond, 500*time.Millisecond, try+1)
+		debuglog.Warn("proxy: transient upstream error, retrying same provider", "attempt", attempt+1, "try", try+1, "backoff", backoff, "request_written", wroteRequest.Load(), "provider", candidate.provider.Name, "provider_id", candidate.provider.ID, "error", err)
+		select {
+		case <-time.After(backoff):
+		case <-dialCtx.Done():
+			// Client disconnect or failover timeout during backoff: stop
+			// retrying and let the classification below treat it as a context
+			// error so the circuit breaker is not penalized.
+			err = dialCtx.Err()
+		}
+		if dialCtx.Err() != nil {
+			break
+		}
+	}
 	st.proxyOverhead = st.timings.proxyOverheadMs(st.parseMs)
 	if err != nil {
 		// Determine the origin of context cancellation for actionable errors.
@@ -375,7 +419,7 @@ func (h *Handler) doUpstream(ctx context.Context, req *http.Request, st *request
 		if isContextErr {
 			cancelOrigin := "client_disconnect"
 			if errors.Is(err, context.DeadlineExceeded) {
-				if v := req.Context().Value(ctxkeys.CancelOriginKey); v != nil {
+				if v := dialCtx.Value(ctxkeys.CancelOriginKey); v != nil {
 					if s, ok := v.(string); ok {
 						cancelOrigin = s
 					}
@@ -390,7 +434,10 @@ func (h *Handler) doUpstream(ctx context.Context, req *http.Request, st *request
 		// Client-initiated cancellations and deadline exceeded are not
 		// provider failures. If the caller disconnected (Canceled) or
 		// the request timed out (DeadlineExceeded), we must not penalize
-		// the circuit breaker for that.
+		// the circuit breaker for that. Real provider errors record exactly
+		// one breaker failure per candidate attempt — here, after any
+		// transient retries are exhausted — so a blip that self-heals on
+		// retry never counts against the provider.
 		if !isContextErr {
 			if st.circuitBreakerEnabled {
 				h.circuitBreaker.RecordFailure(candidate.provider.ID, candidate.provider.Name)

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -397,12 +397,14 @@ func (h *Handler) doUpstream(ctx context.Context, req *http.Request, st *request
 		select {
 		case <-time.After(backoff):
 		case <-dialCtx.Done():
-			// Client disconnect or failover timeout during backoff: stop
-			// retrying and let the classification below treat it as a context
-			// error so the circuit breaker is not penalized.
-			err = dialCtx.Err()
 		}
-		if dialCtx.Err() != nil {
+		// Client disconnect or failover timeout during backoff: stop retrying
+		// and surface the context error so the classification below does not
+		// penalize the circuit breaker. Checked outside the select because when
+		// both channels are ready Go picks a branch at random — the timer
+		// branch must not leave the transport error in err.
+		if ctxErr := dialCtx.Err(); ctxErr != nil {
+			err = ctxErr
 			break
 		}
 	}

--- a/internal/proxy/transient_retry.go
+++ b/internal/proxy/transient_retry.go
@@ -1,0 +1,56 @@
+package proxy
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"strings"
+	"syscall"
+)
+
+// maxTransientRetries is the number of additional same-provider tries after a
+// transient network failure, before the failover loop moves on to the next
+// candidate (or, for single-provider models, fails the request). Retries run
+// inside the per-attempt failover timeout, so they never extend the request's
+// total time budget.
+const maxTransientRetries = 2
+
+// isRetryableUpstreamError reports whether a transport-level error from the
+// upstream request may be retried against the same provider.
+//
+// Context cancellations are never retried: the client disconnected or a
+// failover/retry deadline fired. Timeouts (net.Error.Timeout) are never
+// retried either — repeating a slow operation would burn the remaining
+// failover budget for no likely gain.
+//
+// requestWritten is the phase signal (from httptrace): whether any request
+// bytes reached the wire. When false (DNS, dial, TLS-handshake failures), the
+// provider provably never saw the request, so any transport error is safe to
+// retry — a duplicate completion is impossible. Once the request has been
+// written, only connection-interruption errors (reset, broken pipe,
+// unexpected EOF, server closing an idle connection) are retried; these
+// overwhelmingly come from provider-side load-balancer connection churn, and
+// a retry carries the same bounded duplicate risk that cross-provider
+// failover already accepts.
+func isRetryableUpstreamError(err error, requestWritten bool) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return false
+	}
+	if !requestWritten {
+		return true
+	}
+	if errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.EPIPE) ||
+		errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, io.EOF) {
+		return true
+	}
+	// net/http does not export errServerClosedIdle; match its message.
+	return strings.Contains(err.Error(), "server closed idle connection")
+}

--- a/internal/proxy/transient_retry.go
+++ b/internal/proxy/transient_retry.go
@@ -47,6 +47,10 @@ func isRetryableUpstreamError(err error, requestWritten bool) bool {
 	if !requestWritten {
 		return true
 	}
+	// ECONNRESET/EPIPE are the POSIX reset signatures; io.EOF and
+	// io.ErrUnexpectedEOF are the cross-platform catch-all for a connection
+	// the server closed mid-exchange (e.g. on Windows resets surface as
+	// wsarecv errors, not those syscall values).
 	if errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.EPIPE) ||
 		errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, io.EOF) {
 		return true

--- a/internal/proxy/transient_retry_test.go
+++ b/internal/proxy/transient_retry_test.go
@@ -1,0 +1,303 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/hugalafutro/model-hotel/internal/model"
+	"github.com/hugalafutro/model-hotel/internal/provider"
+)
+
+func TestIsRetryableUpstreamError(t *testing.T) {
+	cases := []struct {
+		name           string
+		err            error
+		requestWritten bool
+		want           bool
+	}{
+		{"nil error", nil, false, false},
+		{"context canceled", &url.Error{Op: "Post", URL: "http://x", Err: context.Canceled}, false, false},
+		{"deadline exceeded", &url.Error{Op: "Post", URL: "http://x", Err: context.DeadlineExceeded}, true, false},
+		{"timeout pre-write", &net.DNSError{Err: "timeout", IsTimeout: true}, false, false},
+		{"timeout post-write", &net.DNSError{Err: "timeout", IsTimeout: true}, true, false},
+		{"pre-write any transport error", errors.New("tls: handshake failure"), false, true},
+		{"pre-write connection refused", &net.OpError{Op: "dial", Err: os.NewSyscallError("connect", syscall.ECONNREFUSED)}, false, true},
+		{"post-write connection reset", &url.Error{Op: "Post", URL: "http://x", Err: &net.OpError{Op: "read", Err: os.NewSyscallError("read", syscall.ECONNRESET)}}, true, true},
+		{"post-write broken pipe", &net.OpError{Op: "write", Err: os.NewSyscallError("write", syscall.EPIPE)}, true, true},
+		{"post-write EOF", &url.Error{Op: "Post", URL: "http://x", Err: io.EOF}, true, true},
+		{"post-write unexpected EOF", io.ErrUnexpectedEOF, true, true},
+		{"post-write server closed idle connection", errors.New("http: server closed idle connection"), true, true},
+		{"post-write arbitrary error", errors.New("boom"), true, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isRetryableUpstreamError(tc.err, tc.requestWritten); got != tc.want {
+				t.Errorf("isRetryableUpstreamError(%v, %v) = %v, want %v", tc.err, tc.requestWritten, got, tc.want)
+			}
+		})
+	}
+}
+
+// newResettingUpstream returns an httptest server that hard-resets (TCP RST)
+// the first `failures` connections, then delegates to onSuccess. The returned
+// counter tracks how many requests the upstream received in total.
+func newResettingUpstream(t *testing.T, failures int, onSuccess http.HandlerFunc) (*httptest.Server, *atomic.Int32) {
+	t.Helper()
+	var calls atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if int(calls.Add(1)) <= failures {
+			hj, ok := w.(http.Hijacker)
+			if !ok {
+				t.Error("upstream does not support hijacking")
+				return
+			}
+			conn, _, err := hj.Hijack()
+			if err != nil {
+				t.Errorf("hijack failed: %v", err)
+				return
+			}
+			// SO_LINGER 0 makes Close send RST instead of FIN, so the
+			// proxy sees "connection reset by peer".
+			if tcp, ok := conn.(*net.TCPConn); ok {
+				_ = tcp.SetLinger(0)
+			}
+			_ = conn.Close()
+			return
+		}
+		onSuccess(w, r)
+	}))
+	return upstream, &calls
+}
+
+// doTransientChatRequest sends a chat completion through the proxy with the
+// env's virtual key attached, returning the recorder.
+func doTransientChatRequest(env *testProxyEnv, body string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(body))
+	ctx := context.WithValue(req.Context(), virtualKeyNameKey, "test-key")
+	ctx = context.WithValue(ctx, virtualKeyIDKey, uuid.New().String())
+	ctx = context.WithValue(ctx, VirtualKeyHashKey, env.KeyHash)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	env.Handler.ChatCompletions(w, req)
+	return w
+}
+
+// breakerConsecutiveFails returns the circuit breaker's consecutive failure
+// count for the given provider, or 0 when the breaker has no entry for it.
+func breakerConsecutiveFails(h *Handler, providerID uuid.UUID) int {
+	for _, s := range h.circuitBreaker.Status() {
+		if s.ProviderID == providerID.String() {
+			return s.ConsecutiveFails
+		}
+	}
+	return 0
+}
+
+func TestChatCompletions_TransientResetRetriesSameProvider(t *testing.T) {
+	// Two RSTs then success: a single-provider model must survive transient
+	// connection resets via same-provider retries (no failover candidates).
+	upstream, calls := newResettingUpstream(t, maxTransientRetries, func(w http.ResponseWriter, r *http.Request) {
+		var reqBody map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&reqBody)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"id":      "chatcmpl-test",
+			"object":  "chat.completion",
+			"created": time.Now().Unix(),
+			"model":   reqBody["model"],
+			"choices": []map[string]interface{}{
+				{"index": 0, "message": map[string]interface{}{"role": "assistant", "content": "recovered"}, "finish_reason": "stop"},
+			},
+			"usage": map[string]interface{}{"prompt_tokens": 5, "completion_tokens": 7, "total_tokens": 12},
+		})
+	})
+	defer upstream.Close()
+
+	env := newTestProxyEnvWithUpstream(t, upstream)
+	body := `{"model": "` + env.ProviderName + `/` + env.ModelName + `", "messages": [{"role": "user", "content": "hello"}], "stream": false}`
+	w := doTransientChatRequest(env, body)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 after transient retries, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := calls.Load(); got != int32(maxTransientRetries+1) {
+		t.Errorf("expected %d upstream calls (1 + %d retries), got %d", maxTransientRetries+1, maxTransientRetries, got)
+	}
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	choices, ok := resp["choices"].([]interface{})
+	if !ok || len(choices) == 0 {
+		t.Errorf("expected at least one choice, got %v", resp["choices"])
+	}
+	// A blip that self-heals on retry must not count against the breaker.
+	if fails := breakerConsecutiveFails(env.Handler, env.ProviderID); fails != 0 {
+		t.Errorf("expected 0 breaker failures after self-healed retry, got %d", fails)
+	}
+}
+
+func TestChatCompletions_TransientResetRetriesExhausted(t *testing.T) {
+	// Every connection resets: after 1 + maxTransientRetries tries the single
+	// candidate is exhausted and the request fails with 502 — and the breaker
+	// records exactly one failure for the whole candidate attempt.
+	upstream, calls := newResettingUpstream(t, int(^uint(0)>>1), func(w http.ResponseWriter, r *http.Request) {
+		t.Error("success handler should never be reached")
+	})
+	defer upstream.Close()
+
+	env := newTestProxyEnvWithUpstream(t, upstream)
+	body := `{"model": "` + env.ProviderName + `/` + env.ModelName + `", "messages": [{"role": "user", "content": "hello"}], "stream": false}`
+	w := doTransientChatRequest(env, body)
+
+	if w.Code != http.StatusBadGateway {
+		t.Errorf("expected 502 after retries exhausted, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := calls.Load(); got != int32(maxTransientRetries+1) {
+		t.Errorf("expected exactly %d upstream calls, got %d", maxTransientRetries+1, got)
+	}
+	if fails := breakerConsecutiveFails(env.Handler, env.ProviderID); fails != 1 {
+		t.Errorf("expected exactly 1 breaker failure per candidate attempt, got %d", fails)
+	}
+}
+
+func TestDoUpstream_GetBodyErrorStopsRetry(t *testing.T) {
+	// When the body cannot be replayed, the retry loop must stop and surface
+	// the original transport error instead of retrying with an empty body.
+	h := newIntegrationHandler()
+	defer stopUnitHandler(h)
+
+	upstream, calls := newResettingUpstream(t, int(^uint(0)>>1), func(w http.ResponseWriter, r *http.Request) {
+		t.Error("success handler should never be reached")
+	})
+	defer upstream.Close()
+
+	req, err := http.NewRequest("POST", upstream.URL, bytes.NewReader([]byte(`{"model":"m"}`)))
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+	req.GetBody = func() (io.ReadCloser, error) { return nil, errors.New("body replay failed") }
+
+	var dialMs float64
+	st := &requestState{logData: &requestLogData{modelID: "test-model", providerName: "test-provider"}}
+	cand := modelCandidate{
+		model:    &model.Model{ModelID: "test-model"},
+		provider: &provider.Provider{ID: uuid.New(), Name: "test-provider"},
+	}
+	resp, ok := h.doUpstream(context.Background(), req, st, cand, 0, &dialMs)
+
+	if ok || resp != nil {
+		t.Errorf("expected (nil, false), got (%v, %v)", resp, ok)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Errorf("expected 1 upstream call (no retry without replayable body), got %d", got)
+	}
+	if !strings.Contains(st.lastErr, "provider error") {
+		t.Errorf("expected lastErr to contain the transport error, got %q", st.lastErr)
+	}
+}
+
+func TestChatCompletions_TransientRetryClientDisconnectDuringBackoff(t *testing.T) {
+	// A client disconnect during the retry backoff must stop retrying without
+	// penalizing the circuit breaker (the provider is not at fault).
+	resetHit := make(chan struct{}, 1)
+	var calls atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			t.Error("upstream does not support hijacking")
+			return
+		}
+		conn, _, err := hj.Hijack()
+		if err != nil {
+			t.Errorf("hijack failed: %v", err)
+			return
+		}
+		if tcp, ok := conn.(*net.TCPConn); ok {
+			_ = tcp.SetLinger(0)
+		}
+		_ = conn.Close()
+		select {
+		case resetHit <- struct{}{}:
+		default:
+		}
+	}))
+	defer upstream.Close()
+
+	env := newTestProxyEnvWithUpstream(t, upstream)
+
+	// Cancel the client context shortly after the first reset lands, i.e.
+	// while the proxy sits in the inter-try backoff (>=100ms).
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		<-resetHit
+		time.Sleep(30 * time.Millisecond)
+		cancel()
+	}()
+
+	body := `{"model": "` + env.ProviderName + `/` + env.ModelName + `", "messages": [{"role": "user", "content": "hello"}], "stream": false}`
+	req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(body))
+	vctx := context.WithValue(ctx, virtualKeyNameKey, "test-key")
+	vctx = context.WithValue(vctx, virtualKeyIDKey, uuid.New().String())
+	vctx = context.WithValue(vctx, VirtualKeyHashKey, env.KeyHash)
+	req = req.WithContext(vctx)
+	w := httptest.NewRecorder()
+	env.Handler.ChatCompletions(w, req)
+
+	if w.Code != http.StatusBadGateway {
+		t.Errorf("expected 502 after client disconnect, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := calls.Load(); got != 1 {
+		t.Errorf("expected 1 upstream call (no retry after disconnect), got %d", got)
+	}
+	if fails := breakerConsecutiveFails(env.Handler, env.ProviderID); fails != 0 {
+		t.Errorf("expected 0 breaker failures on client disconnect, got %d", fails)
+	}
+}
+
+func TestChatCompletions_TransientResetRetryStreaming(t *testing.T) {
+	// The retry happens before any response bytes, so streaming requests are
+	// retried the same way: two RSTs, then a normal SSE stream.
+	upstream, calls := newResettingUpstream(t, maxTransientRetries, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("data: {\"id\":\"chatcmpl-test\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"recovered\"},\"finish_reason\":null}]}\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	})
+	defer upstream.Close()
+
+	env := newTestProxyEnvWithUpstream(t, upstream)
+	body := `{"model": "` + env.ProviderName + `/` + env.ModelName + `", "messages": [{"role": "user", "content": "hello"}], "stream": true}`
+	w := doTransientChatRequest(env, body)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 after transient retries, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := calls.Load(); got != int32(maxTransientRetries+1) {
+		t.Errorf("expected %d upstream calls (1 + %d retries), got %d", maxTransientRetries+1, maxTransientRetries, got)
+	}
+	responseBody := w.Body.String()
+	if !strings.Contains(responseBody, "data: {") {
+		t.Error("expected SSE data format")
+	}
+	if !strings.Contains(responseBody, "data: [DONE]") {
+		t.Error("expected [DONE] sentinel")
+	}
+}


### PR DESCRIPTION
## Problem

A connection reset, broken pipe, or EOF from an upstream provider failed the request outright for single-provider models: failover only retries across *different* providers, so with one candidate the client got an immediate 502 on any transient TCP blip (typically provider-side load-balancer connection churn).

## Change

`doUpstream` now retries up to 2 times against the same provider before giving up on that candidate:

- Retries run **inside the existing per-attempt failover timeout** with short jittered backoff (100-200ms), so the request's total time budget never grows.
- The body is replayed via `GetBody`; retries happen before any response bytes, so **streaming requests are covered** and the multimodal pass-through endpoints inherit the behavior through the shared helper.
- After exhausting same-provider retries, the existing cross-provider failover proceeds unchanged.

### Duplicate-completion safety (phase-aware classification)

Providers do not support idempotency keys for completions, so true dedupe is impossible. Instead, retry safety is classified by request phase using `httptrace`:

- **Before any request bytes reach the wire** (DNS, dial, TLS handshake failures): the provider provably never saw the request, so any transport error is retried. Zero duplicate risk.
- **After the request was written**: only connection-interruption errors (reset, broken pipe, unexpected EOF, server closed idle connection) are retried. This carries the same bounded duplicate risk that cross-provider failover already accepts.
- **Never retried**: timeouts (would burn the failover budget on a likely-slow provider) and context cancellations (client disconnect, deadline).

### Circuit breaker semantics

At most **one breaker failure per candidate attempt**, recorded only after intra-provider retries are exhausted. The breaker's event rate (and therefore its trip threshold meaning) is unchanged from before, and a blip that self-heals on retry records no failure.

## Tests

- Classifier unit table (context errors, timeouts, pre/post-write classes).
- Integration: single-provider model survives two TCP RSTs (non-streaming and streaming), asserting exactly 3 upstream calls and 0 breaker failures.
- Integration: permanent resets exhaust retries, return 502, record exactly 1 breaker failure.
- No retry when the body cannot be replayed; client disconnect during backoff stops retrying without penalizing the breaker.

All tests pass under `-race`; `doUpstream` and the classifier are at 100% line coverage (proxy package 97.0%); `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)