### PR TITLE
fix(docker): apk upgrade runtime base to pull OpenSSL security patches

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,10 @@ RUN go build -ldflags "-X main.version=$VERSION" -o server ./cmd/server/
 # Stage 3: Minimal runtime image
 FROM alpine:3.23
 
-RUN apk add --no-cache ca-certificates postgresql16-client su-exec
+# Upgrade base packages so security patches in the 3.23 line (e.g. OpenSSL)
+# land even when the alpine:3.23 tag itself lags behind
+RUN apk upgrade --no-cache && \
+    apk add --no-cache ca-certificates postgresql16-client su-exec
 
 # Create non-root user (uid 1000 matches typical host user)
 RUN adduser -D -u 1000 -H appuser

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,10 @@ RUN go build -ldflags "-X main.version=$VERSION" -o server ./cmd/server/
 FROM alpine:3.23
 
 # Upgrade base packages so security patches in the 3.23 line (e.g. OpenSSL)
-# land even when the alpine:3.23 tag itself lags behind
+# land even when the alpine:3.23 tag itself lags behind.
+# Deliberate trade-off: builds are not reproducible across time (each build picks
+# up the current v3.23 patch level). Preferred over pinning package versions,
+# which Alpine purges from its repos once superseded, breaking the build.
 RUN apk upgrade --no-cache && \
     apk add --no-cache ca-certificates postgresql16-client su-exec
 


### PR DESCRIPTION
## Why

Docker Hub flags `hugalafutro/model-hotel:latest` with **1 critical / 8 high / 4 medium / 2 low** CVEs. Every one of them comes from a single package: **OpenSSL 3.5.6-r0** shipped in the `alpine:3.23` base image (tag 3.23.4). Alpine already published the fixed **3.5.7-r0** in the v3.23 package repo, but the Docker base tag hasn't been rebuilt with it yet.

## What

One-liner in the runtime stage: `apk upgrade --no-cache` before `apk add`. This pulls current patch-level security fixes from the v3.23 repo at every image build, so the image no longer depends on how quickly the `alpine:3.23` tag itself is refreshed. Patch-level package updates only — no functional change.

## Verification

Built the image locally from this branch and scanned:

| Scanner | Before (published `latest`) | After (this branch) |
|---|---|---|
| Docker Scout (what Docker Hub uses) | 1C / 8H / 5M / 2L | 0C / 0H / **1M** / 0L |
| trivy | 10 findings (openssl) | 0 findings |

The single remaining medium is busybox CVE-2025-60876, which has **no upstream fix** — the same long-standing finding the image always had. The Go binary (`app/server`) scans clean in both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)