### PR TITLE
ci: image vuln scanning (gate + weekly SARIF), govulncheck, actionlint, run cancellation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,12 @@ on:
 permissions:
   contents: read
 
+# Cancel superseded runs when a PR branch is force-pushed/updated, but never
+# cancel in-flight runs on master itself.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   go-test:
     name: Go Test
@@ -96,6 +102,37 @@ jobs:
 
       - name: go vet
         run: go vet ./...
+
+  # Unlike the image scan's gobinary check, govulncheck does reachability
+  # analysis: it only fails on vulnerable functions our code actually calls.
+  govulncheck:
+    name: Go Vulncheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: govulncheck
+        run: go run golang.org/x/vuln/cmd/govulncheck@v1.3.0 ./...
+
+  workflow-lint:
+    name: Workflow Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      # Uses the preinstalled shellcheck on the runner for run: blocks
+      - name: actionlint
+        run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color
 
   frontend:
     name: Frontend Lint & Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,4 +164,17 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Build Docker image
-        run: docker build .
+        run: docker build -t model-hotel:ci .
+
+      # Gate on fixable HIGH/CRITICAL vulns only: ignore-unfixed keeps CI green
+      # when a CVE has no upstream patch yet (nothing actionable), and the
+      # `apk upgrade` in the Dockerfile means a fixable Alpine CVE usually
+      # clears on rebuild alone.
+      - name: Scan image for fixable HIGH/CRITICAL vulnerabilities
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: image
+          image-ref: model-hotel:ci
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: 1

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -16,12 +16,32 @@ on:
 
 permissions:
   contents: read
+  security-events: write
 
 jobs:
   scan:
     name: Trivy Scan (latest)
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      # Full-picture report (all severities, unfixed included) for the GitHub
+      # Security tab, so findings are tracked over time — deliberately broader
+      # than the gate below, which only fails on what is actionable.
+      - name: Scan published image (SARIF report)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: image
+          image-ref: docker.io/hugalafutro/model-hotel:latest
+          format: sarif
+          output: trivy-image.sarif
+
+      - name: Upload SARIF to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@1a818fd5f97ed0ee9a823421bd5b171add01227f # v4.36.2
+        with:
+          sarif_file: trivy-image.sarif
+          category: published-image
+
       # Same actionable-only policy as the CI gate: fixable HIGH/CRITICAL only.
       - name: Scan published image for fixable HIGH/CRITICAL vulnerabilities
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -1,0 +1,33 @@
+# Weekly vulnerability scan of the published image.
+#
+# The CI gate only runs when a PR is open, but CVEs land in already-published
+# images (this is exactly how the OpenSSL 3.5.6 flags appeared on Docker Hub:
+# no code changed, the world did). A failed run here means a rebuild/release
+# would fix something — the docker-publish workflow's apk upgrade pulls current
+# Alpine patches — so it doubles as the signal to cut a patch release. It also
+# catches the publish workflow's GHA layer cache serving a stale apk upgrade
+# layer.
+name: Scan Published Image
+
+on:
+  schedule:
+    - cron: '17 6 * * 1' # Mondays 06:17 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: Trivy Scan (latest)
+    runs-on: ubuntu-latest
+    steps:
+      # Same actionable-only policy as the CI gate: fixable HIGH/CRITICAL only.
+      - name: Scan published image for fixable HIGH/CRITICAL vulnerabilities
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: image
+          image-ref: docker.io/hugalafutro/model-hotel:latest
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: 1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hugalafutro/model-hotel
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/go-chi/chi/v5 v5.3.0


### PR DESCRIPTION
## Why

PR #197 fixed the OpenSSL CVEs flagged on Docker Hub, but nothing prevents a recurrence: CVEs appear in already-published images with no code change, and nothing in CI would catch a regression that reintroduces vulnerable packages. Follow-up discussed on #197, expanded per discussion to carry the other agreed CI improvements in one PR.

## What

**Image vulnerability scanning** — two layers of Trivy, both gating with the same **actionable-only** policy (fail only on HIGH/CRITICAL findings that have an upstream fix, `ignore-unfixed`):

1. **PR/branch gate** (`ci.yml`, existing `docker-build` job): scans the freshly built image. `ignore-unfixed` is the make-or-break setting — without it, a new unpatched CVE upstream would block every PR with nothing anyone can do. With it, and with the `apk upgrade` from #197 pulling current Alpine patches at build time, a red gate means something real: a Go-module vuln in the binary or a Dockerfile regression.
2. **Weekly scan of published `latest`** (`image-scan.yml`, Mondays 06:17 UTC + manual dispatch): covers the gap the PR gate can't — the published image aging while no PR is open (exactly how the OpenSSL flags appeared). A failure means a rebuild/release would fix something, so it doubles as the signal to cut a patch release. It also catches the publish workflow's GHA layer cache serving a stale `apk upgrade` layer. Per review feedback, the weekly scan also uploads a **SARIF report to the Security tab** (category `published-image`) — deliberately broader than the gate (all severities, unfixed included) so findings are tracked over time.

Trivy over Docker Scout: no Docker Hub login required, so the gate also works on PRs from forks; both scanners agreed on findings in #197's verification.

**Other CI hardening** (`ci.yml`):

- **govulncheck job** (pinned v1.3.0): complements the image scan's gobinary check with reachability analysis — fails only on vulnerable functions the code actually calls.
- **actionlint job** (pinned v1.7.12): lints the workflow files, using the runner's preinstalled shellcheck for `run:` blocks.
- **Concurrency group**: cancels superseded CI runs when a PR branch is updated; pushes to master always run to completion.

## Verification

All gates run locally with the exact CI settings:

| Check | Result |
|---|---|
| Trivy on `model-hotel:ci` built from this branch (PR gate) | **0 findings, exit 0** |
| Trivy on `docker.io/hugalafutro/model-hotel:latest` (weekly scan) | **2 HIGH (OpenSSL 3.5.6, fixed in 3.5.7-r0), exit 1** |
| govulncheck `./...` | **No vulnerabilities found** |
| actionlint (all 5 workflows, incl. the ones added here) | **0 issues** |

⚠️ The published-image result means the weekly scan **will be red until the next release** is published with the #197 fix — that's the workflow doing its job (a release would clear it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)