### PR TITLE
fix(ci): use repo bundle token for Codecov bundle analysis upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,8 +175,10 @@ jobs:
       - name: Build
         # CODECOV_TOKEN enables the bundle-analysis plugin's upload (gated on the
         # var being set, so only CI uploads — local/Docker builds stay silent).
+        # Bundle analysis needs the repo-scoped bundle token; the coverage
+        # CODECOV_TOKEN is a different value the bundle endpoint rejects (404).
         env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          CODECOV_TOKEN: ${{ secrets.CODECOV_BUNDLE_TOKEN }}
         run: pnpm run build
 
   # The 5k-test vitest suite was the sole CI wall-clock bottleneck (~7-8 min),


### PR DESCRIPTION
## Problem

The `@codecov/vite-plugin` bundle-analysis wiring has been live on master since `24740239` (+ gating fix `d1a2a708`), but no bundle data ever reached Codecov. The plugin runs correctly in CI — it detects GitHub Actions and POSTs to `api.codecov.io/upload/bundle_analysis/v1` — but every `get-pre-signed-url` attempt returns:

```
[codecov] Failed to get pre-signed URL, bad response: "404 - Not Found"
```

## Root cause

A **token mismatch**, not the code and not Codecov activation. The `CODECOV_TOKEN` GitHub Actions secret held a *different* value than the repo's bundle upload token. Coverage tolerated the old token (the Codecov CLI still resolves the repo), but the bundle endpoint strictly maps token→repo and 404'd.

Confirmed by POSTing the correct repo bundle token directly to the same endpoint → **HTTP 202 + a pre-signed storage URL**, proving the repo, feature, and token all work.

## Fix

Point the frontend **Build** step at the new `CODECOV_BUNDLE_TOKEN` secret. `vite.config.ts` still reads `process.env.CODECOV_TOKEN`, so only the secret *source* changes; the coverage upload steps keep the original `CODECOV_TOKEN`.

## Verification

- Direct curl to `api.codecov.io/upload/bundle_analysis/v1` with the bundle token → `202 queued` + pre-signed URL.
- After merge, the frontend Build job should show the `[codecov]` upload succeeding and bundle data should land in the Codecov **Bundles** tab (first successful upload seeds the baseline; PR size comments start the run after).

🤖 Generated with [Claude Code](https://claude.com/claude-code)