### PR TITLE
fix(web): handle clipboard write failures honestly in copy actions

### DIFF
--- a/web/src/components/ErrorShelf/ErrorShelf.tsx
+++ b/web/src/components/ErrorShelf/ErrorShelf.tsx
@@ -62,8 +62,12 @@ export function ErrorShelf() {
 
 	const handleCopy = useCallback(
 		(message: string) => {
-			navigator.clipboard
-				.writeText(message)
+			// Run the write inside a promise chain so a missing Clipboard API
+			// (navigator.clipboard is undefined in non-secure/HTTP contexts)
+			// surfaces as a rejection and hits the failure toast, rather than
+			// throwing synchronously and bypassing it.
+			Promise.resolve()
+				.then(() => navigator.clipboard.writeText(message))
 				.then(() => toast(t("common.copiedToClipboard"), "info"))
 				.catch(() => toast(t("common.failedToCopy"), "error"));
 		},

--- a/web/src/components/ErrorShelf/ErrorShelf.tsx
+++ b/web/src/components/ErrorShelf/ErrorShelf.tsx
@@ -62,8 +62,10 @@ export function ErrorShelf() {
 
 	const handleCopy = useCallback(
 		(message: string) => {
-			navigator.clipboard.writeText(message);
-			toast(t("common.copiedToClipboard"), "info");
+			navigator.clipboard
+				.writeText(message)
+				.then(() => toast(t("common.copiedToClipboard"), "info"))
+				.catch(() => toast(t("common.failedToCopy"), "error"));
 		},
 		[toast, t],
 	);

--- a/web/src/components/ErrorShelf/__tests__/ErrorShelf.test.tsx
+++ b/web/src/components/ErrorShelf/__tests__/ErrorShelf.test.tsx
@@ -214,6 +214,23 @@ describe("ErrorShelf", () => {
 		expect(await screen.findByText("Failed to copy")).toBeInTheDocument();
 	});
 
+	it("toasts an error when the Clipboard API is unavailable", async () => {
+		seedRequestError("copy me", "2024-02-01T10:00:00Z");
+		const { user } = renderWithProviders(<ErrorShelf />);
+
+		await screen.findByTestId("error-shelf-count");
+		await expand();
+		const row = await screen.findByTestId("error-shelf-row");
+		// A missing Clipboard API throws synchronously on access; the handler
+		// must still route that to the failure toast.
+		vi.spyOn(navigator.clipboard, "writeText").mockImplementationOnce(() => {
+			throw new TypeError("clipboard unavailable");
+		});
+		await user.click(within(row).getByTitle("Copy error"));
+
+		expect(await screen.findByText("Failed to copy")).toBeInTheDocument();
+	});
+
 	it("stays hidden for an already-acknowledged error", async () => {
 		const ts = "2024-02-01T10:00:00Z";
 		const msg = "already seen";

--- a/web/src/components/ErrorShelf/__tests__/ErrorShelf.test.tsx
+++ b/web/src/components/ErrorShelf/__tests__/ErrorShelf.test.tsx
@@ -199,6 +199,21 @@ describe("ErrorShelf", () => {
 		expect(writeSpy).toHaveBeenCalledWith("copy me");
 	});
 
+	it("toasts an error when the clipboard write fails", async () => {
+		seedRequestError("copy me", "2024-02-01T10:00:00Z");
+		const { user } = renderWithProviders(<ErrorShelf />);
+
+		await screen.findByTestId("error-shelf-count");
+		await expand();
+		const row = await screen.findByTestId("error-shelf-row");
+		vi.spyOn(navigator.clipboard, "writeText").mockRejectedValueOnce(
+			new Error("denied"),
+		);
+		await user.click(within(row).getByTitle("Copy error"));
+
+		expect(await screen.findByText("Failed to copy")).toBeInTheDocument();
+	});
+
 	it("stays hidden for an already-acknowledged error", async () => {
 		const ts = "2024-02-01T10:00:00Z";
 		const msg = "already seen";

--- a/web/src/components/ErrorShelf/useErrorShelf.ts
+++ b/web/src/components/ErrorShelf/useErrorShelf.ts
@@ -150,7 +150,12 @@ export function useErrorShelf(): UseErrorShelf {
 			});
 		}
 
-		merged.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+		// Timestamps are fixed-width ISO 8601 UTC strings, so a direct
+		// lexicographic compare is correct, deterministic, and faster than
+		// the locale-sensitive localeCompare.
+		merged.sort((a, b) =>
+			b.timestamp < a.timestamp ? -1 : b.timestamp > a.timestamp ? 1 : 0,
+		);
 		return merged.slice(0, ERROR_SHELF_LIMIT);
 	}, [ready, reqLogData, appLogData]);
 

--- a/web/src/pages/FailoverGroups/FailoverGroupCard.tsx
+++ b/web/src/pages/FailoverGroups/FailoverGroupCard.tsx
@@ -99,8 +99,10 @@ export function FailoverGroupCard({
 
 	const handleCopyModel = () => {
 		const modelRef = `hotel/${group.display_model}`;
-		navigator.clipboard
-			.writeText(modelRef)
+		// Promise-wrap so a missing Clipboard API (undefined in non-secure/HTTP
+		// contexts) rejects into the failure toast instead of throwing synchronously.
+		Promise.resolve()
+			.then(() => navigator.clipboard.writeText(modelRef))
 			.then(() =>
 				toast(t("failover.copied_model", { model: modelRef }), "success"),
 			)

--- a/web/src/pages/FailoverGroups/FailoverGroupCard.tsx
+++ b/web/src/pages/FailoverGroups/FailoverGroupCard.tsx
@@ -99,8 +99,12 @@ export function FailoverGroupCard({
 
 	const handleCopyModel = () => {
 		const modelRef = `hotel/${group.display_model}`;
-		navigator.clipboard.writeText(modelRef);
-		toast(t("failover.copied_model", { model: modelRef }), "success");
+		navigator.clipboard
+			.writeText(modelRef)
+			.then(() =>
+				toast(t("failover.copied_model", { model: modelRef }), "success"),
+			)
+			.catch(() => toast(t("common.failedToCopy"), "error"));
 	};
 
 	return (

--- a/web/src/pages/FailoverGroups/__tests__/FailoverGroupCard.test.tsx
+++ b/web/src/pages/FailoverGroups/__tests__/FailoverGroupCard.test.tsx
@@ -430,6 +430,27 @@ describe("FailoverGroupCard", () => {
 			});
 		});
 
+		it("toasts an error when the clipboard write fails", async () => {
+			const group = {
+				...mockFailoverGroup,
+				display_model: "test-model",
+			};
+
+			const { user } = renderWithProviders(
+				<FailoverGroupCard {...defaultProps} group={group} />,
+			);
+
+			// Reject on the live clipboard impl (userEvent.setup installs its own).
+			vi.spyOn(navigator.clipboard, "writeText").mockRejectedValueOnce(
+				new Error("denied"),
+			);
+			await user.click(screen.getByText("hotel/test-model"));
+
+			await waitFor(() => {
+				expect(screen.getByText("Failed to copy")).toBeInTheDocument();
+			});
+		});
+
 		it("calls onToggleEntry when entry toggle is clicked", async () => {
 			const onToggleEntry = vi.fn();
 			const group = {

--- a/web/src/pages/FailoverGroups/__tests__/FailoverGroupCard.test.tsx
+++ b/web/src/pages/FailoverGroups/__tests__/FailoverGroupCard.test.tsx
@@ -451,6 +451,28 @@ describe("FailoverGroupCard", () => {
 			});
 		});
 
+		it("toasts an error when the Clipboard API is unavailable", async () => {
+			const group = {
+				...mockFailoverGroup,
+				display_model: "test-model",
+			};
+
+			const { user } = renderWithProviders(
+				<FailoverGroupCard {...defaultProps} group={group} />,
+			);
+
+			// A missing Clipboard API throws synchronously on access; the handler
+			// must still route that to the failure toast.
+			vi.spyOn(navigator.clipboard, "writeText").mockImplementationOnce(() => {
+				throw new TypeError("clipboard unavailable");
+			});
+			await user.click(screen.getByText("hotel/test-model"));
+
+			await waitFor(() => {
+				expect(screen.getByText("Failed to copy")).toBeInTheDocument();
+			});
+		});
+
 		it("calls onToggleEntry when entry toggle is clicked", async () => {
 			const onToggleEntry = vi.fn();
 			const group = {


### PR DESCRIPTION
Addresses the two Greptile findings on #237 (error shelf).

## P1 — clipboard success toast fired even on failure
`navigator.clipboard.writeText` returns a Promise that can reject (denied permission, or a non-secure context — Model Hotel often runs over plain HTTP on a LAN). Both the **error shelf** copy and the **failover-group "copy model"** handlers toasted success unconditionally.

Now they await the write and report the real outcome, matching the existing `CopyablePill` convention (success toast on resolve, `Failed to copy` on reject). The unconditional pattern existed in `FailoverGroupCard` too, so both are fixed for consistency.

## P2 — locale-sensitive timestamp sort
Swapped `localeCompare` for a direct lexicographic compare in the error-shelf timestamp sort. These are fixed-width ISO 8601 UTC strings, so `<`/`>` is correct, deterministic, and faster.

## Tests
Adds failure-path tests for both copy handlers (clipboard rejects → `Failed to copy` toast). Existing suites unchanged otherwise.

- `pnpm biome check` clean
- `pnpm exec tsc -b` clean
- ErrorShelf + FailoverGroupCard suites: all green (incl. 2 new tests)

No new i18n keys (`common.failedToCopy` already exists in all 29 locales).

🤖 Generated with [Claude Code](https://claude.com/claude-code)