### PR TITLE
fix(failover): report logical half-open in CB status badge

### DIFF
--- a/internal/failover/circuitbreaker.go
+++ b/internal/failover/circuitbreaker.go
@@ -279,18 +279,28 @@ func (cb *CircuitBreaker) Status() []ProviderStatus {
 	cooldown := cb.effectiveCooldown()
 	statuses := make([]ProviderStatus, 0, len(cb.circuits))
 	for id, c := range cb.circuits {
+		// Apply the same logical cooldown transition as GetState: an open
+		// circuit whose cooldown has elapsed is "ready to probe" and is
+		// reported as half-open, even though the internal state only flips to
+		// StateHalfOpen for the brief duration of an in-flight probe request.
+		// Without this the half-open bucket is effectively unobservable from
+		// the status API (and the sidebar badge's middle count never moves).
+		state := c.state
+		if state == StateOpen && !c.openedAt.IsZero() && time.Since(c.openedAt) >= cooldown {
+			state = StateHalfOpen
+		}
 		s := ProviderStatus{
 			ProviderID:       id,
-			State:            c.state.String(),
+			State:            state.String(),
 			ConsecutiveFails: c.consecutiveFails,
 		}
-		if c.state == StateOpen && !c.openedAt.IsZero() {
+		if state == StateOpen && !c.openedAt.IsZero() {
 			s.OpenedAt = c.openedAt.Format(time.RFC3339)
 			s.CooldownMs = cooldown.Milliseconds()
 			nextRetry := c.openedAt.Add(cooldown)
 			s.NextRetryAt = nextRetry.Format(time.RFC3339)
 		}
-		if c.state == StateHalfOpen && !c.openedAt.IsZero() {
+		if state == StateHalfOpen && !c.openedAt.IsZero() {
 			s.OpenedAt = c.openedAt.Format(time.RFC3339)
 		}
 		statuses = append(statuses, s)

--- a/internal/failover/circuitbreaker_test.go
+++ b/internal/failover/circuitbreaker_test.go
@@ -177,6 +177,40 @@ func TestCircuitBreaker_Status(t *testing.T) {
 	}
 }
 
+// TestCircuitBreaker_Status_ReportsLogicalHalfOpen verifies that Status mirrors
+// GetState's logical cooldown transition: an open circuit whose cooldown has
+// elapsed (and is therefore ready to be probed) is reported as "half-open"
+// without an in-flight probe request. The internal state only flips to
+// StateHalfOpen for the duration of a probe, so without this the half-open
+// bucket would be unobservable from the status API.
+func TestCircuitBreaker_Status_ReportsLogicalHalfOpen(t *testing.T) {
+	cb := newTestCB(1, 50*time.Millisecond)
+	pid := uuid.New()
+
+	cb.RecordFailure(pid, "test-provider") // opens
+
+	// Before cooldown elapses, it reports as open.
+	if statuses := cb.Status(); statuses[0].State != "open" {
+		t.Fatalf("expected 'open' before cooldown, got %q", statuses[0].State)
+	}
+
+	// After cooldown elapses, it should report as half-open even though no
+	// probe request has flipped the internal state.
+	time.Sleep(60 * time.Millisecond)
+	statuses := cb.Status()
+	if len(statuses) != 1 {
+		t.Fatalf("expected 1 status, got %d", len(statuses))
+	}
+	if statuses[0].State != "half-open" {
+		t.Errorf("expected 'half-open' after cooldown, got %q", statuses[0].State)
+	}
+	// A logically-half-open circuit is ready to probe now, so it must not
+	// carry the open-only next-retry hint.
+	if statuses[0].NextRetryAt != "" {
+		t.Errorf("expected empty NextRetryAt for half-open, got %q", statuses[0].NextRetryAt)
+	}
+}
+
 func TestCircuitBreaker_Concurrent(t *testing.T) {
 	cb := newTestCB(100, 30*time.Second)
 	pid := uuid.New()

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -616,7 +616,11 @@ export function Layout({ children }: LayoutProps) {
 	const { t } = useTranslation();
 	const location = useLocation();
 	const navigate = useNavigate();
-	const { theme, setTheme } = useTheme();
+	const { theme, setTheme, uiStyle } = useTheme();
+	// Separator between paired labels/counts in the sidebar. The terminal theme
+	// keeps a literal "/" (fits its monospace aesthetic); other themes use a
+	// middle dot, which reads as two independent values rather than a fraction.
+	const navSep = uiStyle === "cyber-terminal" ? "/" : "·";
 
 	const {
 		chatSubMode,
@@ -850,7 +854,7 @@ export function Layout({ children }: LayoutProps) {
 													{currentSubLabel}
 												</span>
 												<span className="text-(--text-muted) text-[10px] opacity-60">
-													/
+													{navSep}
 												</span>
 												<span className="text-[11px] text-(--text-tertiary)">
 													{otherSub?.label}
@@ -858,9 +862,7 @@ export function Layout({ children }: LayoutProps) {
 											</span>
 										) : item.href === "/failover" &&
 											cbStatus &&
-											(cbStatus.closed > 0 ||
-												cbStatus.half_open > 0 ||
-												cbStatus.open > 0) ? (
+											(cbStatus.half_open > 0 || cbStatus.open > 0) ? (
 											<span className="flex items-center gap-1.5">
 												<span>{item.name}</span>
 												<span
@@ -893,14 +895,12 @@ export function Layout({ children }: LayoutProps) {
 														)}`;
 													})()}
 												>
-													<span className="text-emerald-400 badge-text">
-														{cbStatus.closed}
-													</span>
-													<span className="text-(--text-secondary)">/</span>
 													<span className="text-amber-400 badge-text">
 														{cbStatus.half_open}
 													</span>
-													<span className="text-(--text-secondary)">/</span>
+													<span className="text-(--text-secondary)">
+														{navSep}
+													</span>
 													<span className="text-red-400 badge-text">
 														{cbStatus.open}
 													</span>

--- a/web/src/components/__tests__/Layout.navigation.test.tsx
+++ b/web/src/components/__tests__/Layout.navigation.test.tsx
@@ -596,7 +596,7 @@ describe("Layout", () => {
 			expect(countElements?.length).toBe(0);
 		});
 
-		it("shows CB badge with colored counts when breakers are active", async () => {
+		it("shows CB badge with half-open/open counts when breakers are active", async () => {
 			server.use(
 				http.get("/api/failover-groups/circuit-breaker-status", () =>
 					HttpResponse.json({ closed: 3, half_open: 1, open: 2 }),
@@ -605,9 +605,6 @@ describe("Layout", () => {
 			renderWithProviders(<Layout>{mockChildren}</Layout>);
 
 			await waitFor(() => {
-				// Green closed count - use getAllByText since Badge wraps text in inner span
-				const closedCounts = screen.getAllByText("3");
-				expect(closedCounts.length).toBeGreaterThan(0);
 				// Amber half-open count
 				const halfOpenCounts = screen.getAllByText("1");
 				expect(halfOpenCounts.length).toBeGreaterThan(0);
@@ -615,9 +612,14 @@ describe("Layout", () => {
 				const openCounts = screen.getAllByText("2");
 				expect(openCounts.length).toBeGreaterThan(0);
 			});
+
+			// The healthy (closed) count is no longer surfaced in the badge —
+			// it was almost always just the provider count and confused users.
+			const failoverLink = screen.getByText("Failover").closest("a");
+			expect(failoverLink?.textContent).not.toContain("3");
 		});
 
-		it("shows only non-zero counts in badge", async () => {
+		it("does not show the badge when only healthy (closed) providers exist", async () => {
 			server.use(
 				http.get("/api/failover-groups/circuit-breaker-status", () =>
 					HttpResponse.json({ closed: 5, half_open: 0, open: 0 }),
@@ -625,14 +627,13 @@ describe("Layout", () => {
 			);
 			renderWithProviders(<Layout>{mockChildren}</Layout>);
 
+			// The badge only appears when something is recovering or tripped, so a
+			// fully-healthy fleet shows no badge and never surfaces the count "5".
+			const failoverLink = screen.getByText("Failover").closest("a");
 			await waitFor(() => {
-				const closedCounts = screen.getAllByText("5");
-				expect(closedCounts.length).toBeGreaterThan(0);
-				// 0 counts are still rendered in the badge structure
-				// Check that 0 is present (it may appear twice due to inner span)
-				const zeroCounts = screen.getAllByText("0");
-				expect(zeroCounts.length).toBeGreaterThan(0);
+				expect(failoverLink?.querySelectorAll("[title]").length).toBe(0);
 			});
+			expect(failoverLink?.textContent).not.toContain("5");
 		});
 
 		it("shows tooltip with open/half-open provider names", async () => {


### PR DESCRIPTION
## What & why

Two related fixes to the sidebar **Failover** circuit-breaker badge.

### 1. Bug: the middle (half-open) count was stuck on `0`

`CircuitBreaker.Status()` reported the **raw internal** `c.state`. The internal state only flips to `StateHalfOpen` for the brief duration of an in-flight probe request, so against the 5s server-side status cache + 15s frontend poll that window was effectively impossible to observe — the middle count never moved.

Fix: `Status()` now applies the **same logical cooldown transition** that `GetState()` already uses — an open circuit whose cooldown has elapsed (i.e. ready to be probed) is reported as `half-open`. This matches the user's mental model (middle = "recovering") and makes the count actually informative. A logically-half-open circuit drops the open-only `NextRetryAt` hint since it's ready to retry now.

### 2. Badge redesign

- **Dropped the leading healthy (`closed`) count.** It was almost always just the provider count and confused more than it informed.
- The badge now shows only `half_open · open` and **only appears when something is recovering or tripped** — no `0 · 0` noise on a healthy fleet.
- **Theme-aware separator:** the terminal theme keeps the literal `/` (fits its monospace aesthetic); other themes use a middle dot `·`, which reads as two independent counts rather than a fraction. Applied to both the badge and the sidebar sub-mode label (e.g. `Chat · Conversations`).

The hover tooltip still gives the full healthy / recovering / tripped breakdown, so no locale strings changed.

## Tests
- New `TestCircuitBreaker_Status_ReportsLogicalHalfOpen` covers the open→half-open reporting transition after cooldown.
- Updated the Layout navigation tests for the new badge behaviour (closed count no longer surfaced; closed-only fleet shows no badge).

## Verification
`go test ./internal/failover ./internal/api` ✅ · golangci-lint ✅ · `tsc -b` ✅ · biome + eslint ✅ · vitest Layout suite (63) ✅

No version bump (intentional — to be bumped separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)