### PR TITLE
fix(proxy): auto-add /v1 for self-hosted OpenAI-compat providers

### DIFF
--- a/internal/util/httputil.go
+++ b/internal/util/httputil.go
@@ -116,10 +116,15 @@ func BuildProviderTargetURL(baseURL, providerType, endpoint string) string {
 		// configured base URL omits it (e.g. a bare http://host:11434, which
 		// discovery accepts but proxying would otherwise 404), and avoid a double
 		// /v1 when the user already included it.
-		if strings.HasSuffix(sanitized, "/v1") {
-			return sanitized + endpoint
+		//
+		// SanitizeBaseURL only strips a single trailing slash, so normalize any
+		// remaining ones here before the suffix check; otherwise an input like
+		// http://host/v1// would slip past the guard and get a second /v1.
+		versioned := strings.TrimRight(sanitized, "/")
+		if strings.HasSuffix(versioned, "/v1") {
+			return versioned + endpoint
 		}
-		return sanitized + "/v1" + endpoint
+		return versioned + "/v1" + endpoint
 	default:
 		// Pass the user's base URL as-is. The user is responsible for
 		// including the correct path prefix (e.g. /v1) in the base URL.

--- a/internal/util/httputil.go
+++ b/internal/util/httputil.go
@@ -109,8 +109,13 @@ func WriteOpenAIError(w http.ResponseWriter, message string, statusCode int) {
 func BuildProviderTargetURL(baseURL, providerType, endpoint string) string {
 	sanitized := SanitizeBaseURL(baseURL)
 	switch providerType {
-	case "anthropic":
-		// Avoid double /v1 if the user configured https://api.anthropic.com/v1
+	case "anthropic", "ollama", "lmstudio", "koboldcpp":
+		// These providers expose their OpenAI-compatible API under /v1: Ollama,
+		// LM Studio and KoboldCPP all serve /v1/chat/completions, and Anthropic's
+		// compatibility layer lives under /v1. Auto-add the prefix when the
+		// configured base URL omits it (e.g. a bare http://host:11434, which
+		// discovery accepts but proxying would otherwise 404), and avoid a double
+		// /v1 when the user already included it.
 		if strings.HasSuffix(sanitized, "/v1") {
 			return sanitized + endpoint
 		}

--- a/internal/util/httputil_test.go
+++ b/internal/util/httputil_test.go
@@ -833,6 +833,49 @@ func TestBuildProviderTargetURL(t *testing.T) {
 			providerType: "",
 			expected:     "https://api.example.com/v1/chat/completions",
 		},
+		{
+			name:         "Ollama (self-hosted) bare host gets /v1",
+			baseURL:      "http://ollama-a1:11434",
+			providerType: "ollama",
+			expected:     "http://ollama-a1:11434/v1/chat/completions",
+		},
+		{
+			name:         "Ollama (self-hosted) with /v1 not doubled",
+			baseURL:      "http://ollama-a1:11434/v1",
+			providerType: "ollama",
+			expected:     "http://ollama-a1:11434/v1/chat/completions",
+		},
+		{
+			name:         "Ollama (self-hosted) trailing slash bare host gets /v1",
+			baseURL:      "http://ollama-a1:11434/",
+			providerType: "ollama",
+			expected:     "http://ollama-a1:11434/v1/chat/completions",
+		},
+		{
+			name:         "LM Studio bare host gets /v1",
+			baseURL:      "http://localhost:1234",
+			providerType: "lmstudio",
+			endpoint:     "/embeddings",
+			expected:     "http://localhost:1234/v1/embeddings",
+		},
+		{
+			name:         "LM Studio with /v1 not doubled",
+			baseURL:      "http://localhost:1234/v1",
+			providerType: "lmstudio",
+			expected:     "http://localhost:1234/v1/chat/completions",
+		},
+		{
+			name:         "KoboldCPP bare host gets /v1",
+			baseURL:      "http://localhost:5001",
+			providerType: "koboldcpp",
+			expected:     "http://localhost:5001/v1/chat/completions",
+		},
+		{
+			name:         "Ollama Cloud stays on default branch (already has /v1)",
+			baseURL:      "https://ollama.com/v1",
+			providerType: "ollama-cloud",
+			expected:     "https://ollama.com/v1/chat/completions",
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/util/httputil_test.go
+++ b/internal/util/httputil_test.go
@@ -876,6 +876,18 @@ func TestBuildProviderTargetURL(t *testing.T) {
 			providerType: "ollama-cloud",
 			expected:     "https://ollama.com/v1/chat/completions",
 		},
+		{
+			name:         "Ollama (self-hosted) repeated trailing slashes after /v1 not doubled",
+			baseURL:      "http://ollama-a1:11434/v1//",
+			providerType: "ollama",
+			expected:     "http://ollama-a1:11434/v1/chat/completions",
+		},
+		{
+			name:         "Ollama (self-hosted) repeated trailing slashes bare host gets single /v1",
+			baseURL:      "http://ollama-a1:11434//",
+			providerType: "ollama",
+			expected:     "http://ollama-a1:11434/v1/chat/completions",
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
## What

`BuildProviderTargetURL` only auto-prepended `/v1` for the `anthropic` provider type. `ollama`, `lmstudio`, and `koboldcpp` fell through to the pass-through default, even though all three serve their OpenAI-compatible API under `/v1/chat/completions` and the port heuristic in `DetectProviderType` already classifies them (`:11434`, `:1234`, `:5001`).

This commit adds those three types to the `/v1` branch, keeping the existing double-`/v1` guard so a base URL that already ends in `/v1` is unchanged. `ollama-cloud` (fixed host-based base URL) is unaffected.

## Why

The asymmetry was a real trap for self-hosted providers: a bare base URL like `http://host:11434` **passed model discovery** (which strips `/v1` via `SanitizeAPIURL` and hits the native `/api/tags` path) but **404'd on every proxied request**, because proxying appends `/chat/completions` to the bare host. So the provider looked healthy (models enumerated, failover group formed) yet no inference worked. Hit while deploying the demo stack against four self-hosted Ollamas.

## Tests

Added table-driven cases to `TestBuildProviderTargetURL`: bare host gets `/v1`, existing `/v1` not doubled, trailing-slash bare host, a non-chat endpoint (lmstudio `/embeddings`), koboldcpp, and an `ollama-cloud` case proving it stays on the default branch. `gofmt`/`go vet`/`golangci-lint` clean; `internal/util` and `internal/proxy` tests pass locally.

## Note on a related non-issue

While investigating I also looked at `discovery_on_provider_create` (no Go consumer). It is **not** a bug: the setting is read by the frontend (`AddProviderModal.tsx`), which calls `POST /api/providers/{id}/discover` after a create. API-direct creation (e.g. scripts) must trigger discovery explicitly. No change needed here; flagging only because it came up alongside the `/v1` trap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)