### PR TITLE
docs: link the live demo instance in README + DockerHub

### DIFF
--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -14,6 +14,8 @@
 
 A single OpenAI-compatible endpoint that sits in front of all your LLM providers. Models are auto-discovered the moment you add a provider and optionally on schedule; failover groups form automatically around shared model names and retry transparently when a provider goes down; no prompt data is ever stored.
 
+> **Live demo:** poke around a real instance at [mh.site19.ddns.net](https://mh.site19.ddns.net) - rebuilds fresh every 30 minutes.
+
 ---
 
 ## One Endpoint, Many Providers

--- a/README.md
+++ b/README.md
@@ -26,15 +26,8 @@
 <sub>Localised with [DeepL](https://www.deepl.com) - _expect mistakes_ - translation fixes welcome as PRs against [`web/src/i18n/locales/`](https://github.com/hugalafutro/model-hotel/tree/master/web/src/i18n/locales)!<br>Made with [OpenCode](https://opencode.ai) + [oh-my-opencode-slim](https://github.com/alvinunreal/oh-my-opencode-slim) & [Claude Code](https://claude.com/claude-code)</sub>
 <br>
 
- <img src="https://img.shields.io/badge/GLM_5.2-orchestrator,%20council-8B5CF6?style=flat" alt="GLM 5.2">
- <img src="https://img.shields.io/badge/Kimi_K2.6-designer,%20council-06B6D4?style=flat" alt="Kimi K2.6">
- <img src="https://img.shields.io/badge/DeepSeek_V4_Pro-oracle,%20council-E53E3E?style=flat" alt="DeepSeek V4 Pro">
-<br>
- <img src="https://img.shields.io/badge/DeepSeek_V4_Pro-librarian-E53E3E?style=flat" alt="DeepSeek V4 Pro">
- <img src="https://img.shields.io/badge/GLM_5.1_Fast-fixer,%20explorer-8B5CF6?style=flat" alt="GLM 5.1 Fast">
- <img src="https://img.shields.io/badge/Gemini_3_Flash-observer-4285F4?style=flat" alt="Gemini 3 Flash">
-<br>
- <img src="https://img.shields.io/badge/Claude_Fable_5-refactor,%20code%20review-D97757?style=flat" alt="Claude Fable 5">
+ <a href="https://mh.site19.ddns.net"><img src="https://img.shields.io/badge/%F0%9F%8F%A8%20Live%20Demo-Try%20it%20now-D97757?style=for-the-badge" alt="Live Demo"></a><br>
+ <sub>Poke around a real instance at <a href="https://mh.site19.ddns.net">mh.site19.ddns.net</a> - rebuilds fresh every 30 minutes</sub>
 </div><br>
 
 A single OpenAI-compatible endpoint that sits in front of all your LLM providers. Models are auto-discovered the moment you add a provider and optionally on schedule; failover groups form automatically around shared model names and retry transparently when a provider goes down; no prompt data is ever stored.


### PR DESCRIPTION
Replaces the model-name badge block in the README with a **Live Demo** eye-catcher button linking to the public demo instance, and adds a demo callout near the top of the DockerHub overview.

- README: swaps the 7 orchestrator/council model badges for a `for-the-badge` Live Demo button + subtext line
- DOCKERHUB: blockquote callout after the intro paragraph
- Both note the demo rebuilds fresh every 30 minutes

Demo: https://mh.site19.ddns.net

GitHub is the only place the README markdown renders the way it ships, so this PR is the preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)