### PR TITLE
fix(totp): enroll-start error key + base32 recovery-code charset (#254 review P2s)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,7 @@ web/.pnpm-store/
 # Local-only agent tooling (omo-slim / opencode implementation harness)
 .slim/
 /.ignore
+
+# Python bytecode cache (i18n tooling under tools/)
+__pycache__/
+*.pyc

--- a/internal/totp/totp.go
+++ b/internal/totp/totp.go
@@ -354,13 +354,14 @@ func generateRecoveryCode() (string, error) {
 
 // normalizeRecoveryCode canonicalizes user-entered codes so a valid code still
 // matches when typed lowercase, with spaces, or without the grouping dashes.
-// It uppercases, drops every non-alphanumeric rune, and regroups exactly 16
-// characters as XXXX-XXXX-XXXX-XXXX (the stored format). Non-16-length input is
-// returned cleaned-but-ungrouped, which simply will not match any stored hash.
+// It uppercases, keeps only RFC 4648 base32 characters (A-Z, 2-7) to match the
+// generated codes, and regroups exactly 16 characters as XXXX-XXXX-XXXX-XXXX
+// (the stored format). Non-16-length input is returned cleaned-but-ungrouped,
+// which simply will not match any stored hash.
 func normalizeRecoveryCode(code string) string {
 	var b strings.Builder
 	for _, c := range strings.ToUpper(code) {
-		if (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') {
+		if (c >= 'A' && c <= 'Z') || (c >= '2' && c <= '7') {
 			b.WriteRune(c)
 		}
 	}

--- a/internal/totp/totp_test.go
+++ b/internal/totp/totp_test.go
@@ -300,11 +300,13 @@ func TestVerifyRejectsReplay(t *testing.T) {
 func TestNormalizeRecoveryCode(t *testing.T) {
 	const canonical = "ABCD-EFGH-IJKL-MNOP"
 	cases := []struct{ in, want string }{
-		{"abcd-efgh-ijkl-mnop", canonical},     // lowercase
-		{"ABCDEFGHIJKLMNOP", canonical},        // missing dashes
-		{"abcd efgh ijkl mnop", canonical},     // spaces instead of dashes
-		{"  ABCD-EFGH-IJKL-MNOP  ", canonical}, // surrounding whitespace
-		{"ABCD-EFGH", "ABCDEFGH"},              // wrong length -> cleaned, ungrouped
+		{"abcd-efgh-ijkl-mnop", canonical},             // lowercase
+		{"ABCDEFGHIJKLMNOP", canonical},                // missing dashes
+		{"abcd efgh ijkl mnop", canonical},             // spaces instead of dashes
+		{"  ABCD-EFGH-IJKL-MNOP  ", canonical},         // surrounding whitespace
+		{"ABCD-EFGH", "ABCDEFGH"},                      // wrong length -> cleaned, ungrouped
+		{"2345-6723-4567-2345", "2345-6723-4567-2345"}, // base32 digits 2-7 kept
+		{"AB01-89CD", "ABCD"},                          // non-base32 digits 0/1/8/9 dropped
 	}
 	for _, c := range cases {
 		if got := normalizeRecoveryCode(c.in); got != c.want {

--- a/web/src/i18n/locales/af.json
+++ b/web/src/i18n/locales/af.json
@@ -1855,7 +1855,8 @@
 			"verifyAriaLabel": "Verifieer TOTP-kode en aktiveer",
 			"verifying": "Verifikasie...",
 			"downloadCodes": "Laai af as .txt",
-			"downloadCodesAriaLabel": "Laai herstelkodes af as 'n tekslêer"
+			"downloadCodesAriaLabel": "Laai herstelkodes af as 'n tekslêer",
+			"failedToStart": "Kon nie inskrywing begin nie: {{message}}"
 		}
 	},
 	"components": {

--- a/web/src/i18n/locales/ar.json
+++ b/web/src/i18n/locales/ar.json
@@ -1855,7 +1855,8 @@
 			"verifyAriaLabel": "تحقق من رمز TOTP وقم بتمكينه",
 			"verifying": "جاري التحقق...",
 			"downloadCodes": "تنزيل بصيغة ‎.txt",
-			"downloadCodesAriaLabel": "تنزيل رموز الاسترداد كملف نصي"
+			"downloadCodesAriaLabel": "تنزيل رموز الاسترداد كملف نصي",
+			"failedToStart": "تعذّر بدء التسجيل: {{message}}"
 		}
 	},
 	"components": {

--- a/web/src/i18n/locales/ca.json
+++ b/web/src/i18n/locales/ca.json
@@ -1855,7 +1855,8 @@
 			"verifyAriaLabel": "Verifica el codi TOTP i activa",
 			"verifying": "Verificant...",
 			"downloadCodes": "Baixa com a .txt",
-			"downloadCodesAriaLabel": "Baixa els codis de recuperació com a fitxer de text"
+			"downloadCodesAriaLabel": "Baixa els codis de recuperació com a fitxer de text",
+			"failedToStart": "No s'ha pogut iniciar la inscripció: {{message}}"
 		}
 	},
 	"components": {

--- a/web/src/i18n/locales/cs.json
+++ b/web/src/i18n/locales/cs.json
@@ -1855,7 +1855,8 @@
 			"verifyAriaLabel": "Ověřte kód TOTP a povolte",
 			"verifying": "Ověřování...",
 			"downloadCodes": "Stáhnout jako .txt",
-			"downloadCodesAriaLabel": "Stáhnout kódy pro obnovení jako textový soubor"
+			"downloadCodesAriaLabel": "Stáhnout kódy pro obnovení jako textový soubor",
+			"failedToStart": "Nepodařilo se zahájit registraci: {{message}}"
 		}
 	},
 	"components": {

--- a/web/src/i18n/locales/da.json
+++ b/web/src/i18n/locales/da.json
@@ -1855,7 +1855,8 @@
 			"verifyAriaLabel": "Bekræft TOTP-koden og aktiver",
 			"verifying": "Bekræfter...",
 			"downloadCodes": "Download som .txt",
-			"downloadCodesAriaLabel": "Download gendannelseskoder som en tekstfil"
+			"downloadCodesAriaLabel": "Download gendannelseskoder som en tekstfil",
+			"failedToStart": "Kunne ikke starte tilmelding: {{message}}"
 		}
 	},
 	"components": {

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -1855,7 +1855,8 @@
 			"verifyAriaLabel": "TOTP-Code überprüfen und aktivieren",
 			"verifying": "Wird überprüft...",
 			"downloadCodes": "Als .txt herunterladen",
-			"downloadCodesAriaLabel": "Wiederherstellungscodes als Textdatei herunterladen"
+			"downloadCodesAriaLabel": "Wiederherstellungscodes als Textdatei herunterladen",
+			"failedToStart": "Einrichtung konnte nicht gestartet werden: {{message}}"
 		}
 	},
 	"components": {

--- a/web/src/i18n/locales/el.json
+++ b/web/src/i18n/locales/el.json
@@ -1855,7 +1855,8 @@
 			"verifyAriaLabel": "Επαληθεύστε τον κωδικό TOTP και ενεργοποιήστε",
 			"verifying": "Επαλήθευση...",
 			"downloadCodes": "Λήψη ως .txt",
-			"downloadCodesAriaLabel": "Λήψη κωδικών ανάκτησης ως αρχείο κειμένου"
+			"downloadCodesAriaLabel": "Λήψη κωδικών ανάκτησης ως αρχείο κειμένου",
+			"failedToStart": "Δεν ήταν δυνατή η έναρξη της εγγραφής: {{message}}"
 		}
 	},
 	"components": {

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1855,7 +1855,8 @@
 			"disableCodeAriaLabel": "TOTP or recovery code to disable",
 			"cancelEnrollAriaLabel": "Cancel TOTP enrollment",
 			"downloadCodes": "Download as .txt",
-			"downloadCodesAriaLabel": "Download recovery codes as a text file"
+			"downloadCodesAriaLabel": "Download recovery codes as a text file",
+			"failedToStart": "Could not start enrollment: {{message}}"
 		}
 	},
 	"components": {

--- a/web/src/i18n/locales/es.json
+++ b/web/src/i18n/locales/es.json
@@ -1855,7 +1855,8 @@
 			"verifyAriaLabel": "Verificar el código TOTP y habilitar",
 			"verifying": "Comprobando...",
 			"downloadCodes": "Descargar como .txt",
-			"downloadCodesAriaLabel": "Descargar los códigos de recuperación como archivo de texto"
+			"downloadCodesAriaLabel": "Descargar los códigos de recuperación como archivo de texto",
+			"failedToStart": "No se pudo iniciar el registro: {{message}}"
 		}
 	},
 	"components": {

--- a/web/src/i18n/locales/fi.json
+++ b/web/src/i18n/locales/fi.json
@@ -1855,7 +1855,8 @@
 			"verifyAriaLabel": "Vahvista TOTP-koodi ja ota käyttöön",
 			"verifying": "Tarkistetaan...",
 			"downloadCodes": "Lataa .txt-tiedostona",
-			"downloadCodesAriaLabel": "Lataa palautuskoodit tekstitiedostona"
+			"downloadCodesAriaLabel": "Lataa palautuskoodit tekstitiedostona",
+			"failedToStart": "Rekisteröinnin aloittaminen epäonnistui: {{message}}"
 		}
 	},
 	"components": {

--- a/web/src/i18n/locales/fr.json
+++ b/web/src/i18n/locales/fr.json
@@ -1855,7 +1855,8 @@
 			"verifyAriaLabel": "Vérifier le code TOTP et l'activer",
 			"verifying": "Vérification en cours...",
 			"downloadCodes": "Télécharger en .txt",
-			"downloadCodesAriaLabel": "Télécharger les codes de récupération dans un fichier texte"
+			"downloadCodesAriaLabel": "Télécharger les codes de récupération dans un fichier texte",
+			"failedToStart": "Impossible de démarrer l'enregistrement : {{message}}"
 		}
 	},
 	"components": {

--- a/web/src/i18n/locales/he.json
+++ b/web/src/i18n/locales/he.json
@@ -1855,7 +1855,8 @@
 			"verifyAriaLabel": "אמת את קוד ה-TOTP והפעל",
 			"verifying": "בודקים...",
 			"downloadCodes": "הורד כקובץ ‎.txt",
-			"downloadCodesAriaLabel": "הורד את קודי השחזור כקובץ טקסט"
+			"downloadCodesAriaLabel": "הורד את קודי השחזור כקובץ טקסט",
+			"failedToStart": "לא ניתן להתחיל את הרישום: {{message}}"
 		}
 	},
 	"components": {

--- a/web/src/i18n/locales/hu.json
+++ b/web/src/i18n/locales/hu.json
@@ -1855,7 +1855,8 @@
 			"verifyAriaLabel": "Ellenőrizze a TOTP-kódot, és engedélyezze",
 			"verifying": "Ellenőrzés folyamatban...",
 			"downloadCodes": "Letöltés .txt-ként",
-			"downloadCodesAriaLabel": "Helyreállítási kódok letöltése szövegfájlként"
+			"downloadCodesAriaLabel": "Helyreállítási kódok letöltése szövegfájlként",
+			"failedToStart": "Nem sikerült elindítani a regisztrációt: {{message}}"
 		}
 	},
 	"components": {

--- a/web/src/i18n/locales/it.json
+++ b/web/src/i18n/locales/it.json
@@ -1855,7 +1855,8 @@
 			"verifyAriaLabel": "Verifica il codice TOTP e abilita",
 			"verifying": "Verifica in corso...",
 			"downloadCodes": "Scarica come .txt",
-			"downloadCodesAriaLabel": "Scarica i codici di recupero come file di testo"
+			"downloadCodesAriaLabel": "Scarica i codici di recupero come file di testo",
+			"failedToStart": "Impossibile avviare la registrazione: {{message}}"
 		}
 	},
 	"components": {

--- a/web/src/i18n/locales/ja.json
+++ b/web/src/i18n/locales/ja.json
@@ -1855,7 +1855,8 @@
 			"verifyAriaLabel": "TOTPコードを確認し、有効にする",
 			"verifying": "確認中...",
 			"downloadCodes": ".txt でダウンロード",
-			"downloadCodesAriaLabel": "リカバリーコードをテキストファイルとしてダウンロード"
+			"downloadCodesAriaLabel": "リカバリーコードをテキストファイルとしてダウンロード",
+			"failedToStart": "登録を開始できませんでした: {{message}}"
 		}
 	},
 	"components": {

--- a/web/src/i18n/locales/ko.json
+++ b/web/src/i18n/locales/ko.json
@@ -1855,7 +1855,8 @@
 			"verifyAriaLabel": "TOTP 코드 확인 및 활성화",
 			"verifying": "확인 중...",
 			"downloadCodes": ".txt로 다운로드",
-			"downloadCodesAriaLabel": "복구 코드를 텍스트 파일로 다운로드"
+			"downloadCodesAriaLabel": "복구 코드를 텍스트 파일로 다운로드",
+			"failedToStart": "등록을 시작할 수 없습니다: {{message}}"
 		}
 	},
 	"components": {

--- a/web/src/i18n/locales/nl.json
+++ b/web/src/i18n/locales/nl.json
@@ -1855,7 +1855,8 @@
 			"verifyAriaLabel": "Controleer de TOTP-code en schakel deze in",
 			"verifying": "Wordt gecontroleerd...",
 			"downloadCodes": "Downloaden als .txt",
-			"downloadCodesAriaLabel": "Herstelcodes downloaden als tekstbestand"
+			"downloadCodesAriaLabel": "Herstelcodes downloaden als tekstbestand",
+			"failedToStart": "Kan inschrijving niet starten: {{message}}"
 		}
 	},
 	"components": {

--- a/web/src/i18n/locales/no.json
+++ b/web/src/i18n/locales/no.json
@@ -1855,7 +1855,8 @@
 			"verifyAriaLabel": "Bekreft TOTP-koden og aktiver",
 			"verifying": "Bekrefter...",
 			"downloadCodes": "Last ned som .txt",
-			"downloadCodesAriaLabel": "Last ned gjenopprettingskoder som en tekstfil"
+			"downloadCodesAriaLabel": "Last ned gjenopprettingskoder som en tekstfil",
+			"failedToStart": "Kunne ikke starte registrering: {{message}}"
 		}
 	},
 	"components": {

--- a/web/src/i18n/locales/pl.json
+++ b/web/src/i18n/locales/pl.json
@@ -1855,7 +1855,8 @@
 			"verifyAriaLabel": "Zweryfikuj kod TOTP i włącz",
 			"verifying": "W trakcie weryfikacji...",
 			"downloadCodes": "Pobierz jako .txt",
-			"downloadCodesAriaLabel": "Pobierz kody odzyskiwania jako plik tekstowy"
+			"downloadCodesAriaLabel": "Pobierz kody odzyskiwania jako plik tekstowy",
+			"failedToStart": "Nie można rozpocząć rejestracji: {{message}}"
 		}
 	},
 	"components": {

--- a/web/src/i18n/locales/pt.json
+++ b/web/src/i18n/locales/pt.json
@@ -1855,7 +1855,8 @@
 			"verifyAriaLabel": "Verifique o código TOTP e habilite",
 			"verifying": "Verificando...",
 			"downloadCodes": "Baixar como .txt",
-			"downloadCodesAriaLabel": "Baixar os códigos de recuperação como arquivo de texto"
+			"downloadCodesAriaLabel": "Baixar os códigos de recuperação como arquivo de texto",
+			"failedToStart": "Não foi possível iniciar o registo: {{message}}"
 		}
 	},
 	"components": {

--- a/web/src/i18n/locales/ro.json
+++ b/web/src/i18n/locales/ro.json
@@ -1855,7 +1855,8 @@
 			"verifyAriaLabel": "Verificați codul TOTP și activați",
 			"verifying": "Se verifică...",
 			"downloadCodes": "Descarcă ca .txt",
-			"downloadCodesAriaLabel": "Descarcă codurile de recuperare ca fișier text"
+			"downloadCodesAriaLabel": "Descarcă codurile de recuperare ca fișier text",
+			"failedToStart": "Nu s-a putut începe înregistrarea: {{message}}"
 		}
 	},
 	"components": {

--- a/web/src/i18n/locales/ru.json
+++ b/web/src/i18n/locales/ru.json
@@ -1855,7 +1855,8 @@
 			"verifyAriaLabel": "Проверить код TOTP и включить",
 			"verifying": "Проверка...",
 			"downloadCodes": "Скачать как .txt",
-			"downloadCodesAriaLabel": "Скачать коды восстановления в виде текстового файла"
+			"downloadCodesAriaLabel": "Скачать коды восстановления в виде текстового файла",
+			"failedToStart": "Не удалось начать регистрацию: {{message}}"
 		}
 	},
 	"components": {

--- a/web/src/i18n/locales/sk.json
+++ b/web/src/i18n/locales/sk.json
@@ -1855,7 +1855,8 @@
 			"verifyAriaLabel": "Overte kód TOTP a aktivujte",
 			"verifying": "Overovanie...",
 			"downloadCodes": "Stiahnuť ako .txt",
-			"downloadCodesAriaLabel": "Stiahnuť obnovovacie kódy ako textový súbor"
+			"downloadCodesAriaLabel": "Stiahnuť obnovovacie kódy ako textový súbor",
+			"failedToStart": "Nepodarilo sa spustiť registráciu: {{message}}"
 		}
 	},
 	"components": {

--- a/web/src/i18n/locales/sr.json
+++ b/web/src/i18n/locales/sr.json
@@ -1855,7 +1855,8 @@
 			"verifyAriaLabel": "Потврди TOTP код и омогући",
 			"verifying": "Верификација...",
 			"downloadCodes": "Преузми као .txt",
-			"downloadCodesAriaLabel": "Преузми кодове за опоравак као текстуалну датотеку"
+			"downloadCodesAriaLabel": "Преузми кодове за опоравак као текстуалну датотеку",
+			"failedToStart": "Није могуће започети регистрацију: {{message}}"
 		}
 	},
 	"components": {

--- a/web/src/i18n/locales/sv.json
+++ b/web/src/i18n/locales/sv.json
@@ -1855,7 +1855,8 @@
 			"verifyAriaLabel": "Verifiera TOTP-kod och aktivera",
 			"verifying": "Verifierar...",
 			"downloadCodes": "Ladda ner som .txt",
-			"downloadCodesAriaLabel": "Ladda ner återställningskoder som en textfil"
+			"downloadCodesAriaLabel": "Ladda ner återställningskoder som en textfil",
+			"failedToStart": "Det gick inte att starta registreringen: {{message}}"
 		}
 	},
 	"components": {

--- a/web/src/i18n/locales/tr.json
+++ b/web/src/i18n/locales/tr.json
@@ -1855,7 +1855,8 @@
 			"verifyAriaLabel": "TOTP kodunu doğrula ve etkinleştir",
 			"verifying": "Doğrulanıyor...",
 			"downloadCodes": ".txt olarak indir",
-			"downloadCodesAriaLabel": "Kurtarma kodlarını metin dosyası olarak indir"
+			"downloadCodesAriaLabel": "Kurtarma kodlarını metin dosyası olarak indir",
+			"failedToStart": "Kayıt başlatılamadı: {{message}}"
 		}
 	},
 	"components": {

--- a/web/src/i18n/locales/uk.json
+++ b/web/src/i18n/locales/uk.json
@@ -1855,7 +1855,8 @@
 			"verifyAriaLabel": "Підтвердити код TOTP та ввімкнути",
 			"verifying": "Перевірка...",
 			"downloadCodes": "Завантажити як .txt",
-			"downloadCodesAriaLabel": "Завантажити коди відновлення як текстовий файл"
+			"downloadCodesAriaLabel": "Завантажити коди відновлення як текстовий файл",
+			"failedToStart": "Не вдалося почати реєстрацію: {{message}}"
 		}
 	},
 	"components": {

--- a/web/src/i18n/locales/vi.json
+++ b/web/src/i18n/locales/vi.json
@@ -1855,7 +1855,8 @@
 			"verifyAriaLabel": "Xác minh mã TOTP và bật",
 			"verifying": "Đang xác minh...",
 			"downloadCodes": "Tải xuống dạng .txt",
-			"downloadCodesAriaLabel": "Tải mã khôi phục xuống dưới dạng tệp văn bản"
+			"downloadCodesAriaLabel": "Tải mã khôi phục xuống dưới dạng tệp văn bản",
+			"failedToStart": "Không thể bắt đầu đăng ký: {{message}}"
 		}
 	},
 	"components": {

--- a/web/src/i18n/locales/zh.json
+++ b/web/src/i18n/locales/zh.json
@@ -1855,7 +1855,8 @@
 			"verifyAriaLabel": "验证 TOTP 代码并启用",
 			"verifying": "正在验证...",
 			"downloadCodes": "下载为 .txt",
-			"downloadCodesAriaLabel": "将恢复码下载为文本文件"
+			"downloadCodesAriaLabel": "将恢复码下载为文本文件",
+			"failedToStart": "无法开始注册：{{message}}"
 		}
 	},
 	"components": {

--- a/web/src/pages/Settings/TotpSettings.tsx
+++ b/web/src/pages/Settings/TotpSettings.tsx
@@ -62,7 +62,7 @@ export function TotpSettings({ collapsed, onToggle }: TotpSettingsProps) {
 		},
 		onError: (err: Error) => {
 			toast(
-				t("settings.totp.failedToVerify", { message: err.message }),
+				t("settings.totp.failedToStart", { message: err.message }),
 				"error",
 			);
 		},


### PR DESCRIPTION
## What

Two non-blocking **P2** items Greptile noted in the #254 5/5 review (neither affected correctness or security; cleaning them up rather than leaving them on `master`).

### 1. Wrong i18n key on enroll-start failure
`enrollStartMutation.onError` toasted `settings.totp.failedToVerify` ("Invalid TOTP code") for an *enroll-start* failure, and passed a `{{message}}` interpolation that key doesn't have. Added `settings.totp.failedToStart` ("Could not start enrollment: {{message}}"), hand-translated into all 28 locales, and pointed the handler at it.

### 2. Overly permissive recovery-code charset
`normalizeRecoveryCode` kept `[A-Z0-9]`, but recovery codes are RFC 4648 base32 (`A-Z2-7`). Restricted the kept set so `0/1/8/9` (which can never appear in a generated code) are dropped. Behavior is unchanged for valid codes (a typo'd code fails either way); just precise. Added test cases proving `2-7` are kept and `0/1/8/9` dropped.

### Drive-by
Gitignore `__pycache__/` + `*.pyc` (the i18n tooling under `tools/` generates them).

## Tests
`go test ./internal/totp/...`, golangci-lint, `tsc -b`, biome, `i18n-check` (28 locales in sync), and the TotpSettings/LoginScreen vitest suites all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
