### PR TITLE
ci: surface vitest failures as Actions annotations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,11 +230,15 @@ jobs:
 
       # blob feeds the coverage merge in frontend-coverage; junit feeds Codecov
       # Test Analytics (one report per shard, aggregated by commit on Codecov).
+      # github-actions surfaces failures as inline log annotations so a flaky or
+      # failing test is named directly in the Actions log (blob and junit write
+      # only to files, leaving the console silent on failure).
       - name: Test (shard ${{ matrix.shard }}/3)
         run: >-
           pnpm exec vitest run --coverage
           --reporter=blob --outputFile.blob=.vitest-reports/blob-${{ matrix.shard }}.json
           --reporter=junit --outputFile.junit=vitest-${{ matrix.shard }}.junit.xml
+          --reporter=github-actions
           --shard=${{ matrix.shard }}/3
 
       - name: Upload blob report


### PR DESCRIPTION
## What

The frontend shard test step ran only `--reporter=blob` (feeds the coverage merge) and `--reporter=junit` (feeds Codecov Test Analytics). **Both write to files**, so the Actions console is silent on failure: when a test failed (e.g. the recent transient flake on a docs-only PR) the log showed only `Process completed with exit code 1` with no test name. Codecov has the junit but its Test Analytics lags hours, so it's not a timely diagnosis path.

Add `--reporter=github-actions` so failures are emitted as **inline log annotations** naming the failing test and assertion, right in the Actions run.

## Notes
- Purely additive: `blob`/`junit` outputs are unchanged, and `retry: 2` (vitest.config.ts) stays as the flake safety net. No masking.
- Motivated by a transient frontend-shard failure that passed on rerun and couldn't be reproduced locally (4x green); this just ensures the *next* occurrence is immediately diagnosable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
