### PR TITLE
fix(ui): live in-progress duration, discovery collapse/retest, TOTP date, collapsible overhead

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,10 +143,9 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       # Fails when any locale is missing keys, breaks {{placeholder}} parity,
-      # or ships a new English-only string. This check is OFFLINE (no DeepL).
-      # Fix locally by translating the new keys into all locales by hand
-      # (`make i18n-fill`/DeepL is legacy and quota-exhausted); intentional
-      # English goes into tools/i18n-translate/allow-english.json.
+      # or ships a new English-only string. This check is fully OFFLINE.
+      # Fix locally by translating the new keys into all locales by hand;
+      # intentional English goes into tools/i18n-translate/allow-english.json.
       - name: locale sync check
         run: make i18n-check
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,11 +55,10 @@ pnpm exec tsc -b             # type-check (stricter than the editor; run it)
 ```
 
 CI additionally enforces an **80% coverage threshold** (backend and frontend)
-and **locale parity** via `make i18n-check` (offline, no DeepL). If you add a
+and **locale parity** via `make i18n-check` (fully offline). If you add a
 user-facing string, add it to `en.json` and translate it into the other locales
 by hand (or add intentional English to `tools/i18n-translate/allow-english.json`)
-so the check passes. `make i18n-fill` (DeepL) is legacy and currently
-non-functional - the free quota is exhausted - so translate manually.
+so the check passes.
 
 The repo ships git hooks under `scripts/` (enabled via `core.hooksPath`); on
 push they run go vet, the linters, and `tsc -b` as a fast pre-flight, but the

--- a/Makefile
+++ b/Makefile
@@ -52,16 +52,12 @@ test-db-down:
 	docker compose -f docker-compose.test.yml down -v
 
 # -- i18n (see tools/i18n-translate/translate.py) --
-# i18n-check is the CI gate: OFFLINE locale-parity validation, no network/DeepL.
-# i18n-fill/bootstrap call DeepL (DEEPL_API_KEY) and are LEGACY/optional: the
-# free DeepL quota is exhausted (HTTP 456 until ~2027), so translate new keys by
-# hand into all locales instead (see AGENTS.md "i18n"). check still passes offline.
+# i18n-check is the CI gate: OFFLINE locale-parity validation, no network. New
+# user-facing strings are added to en.json and translated into every other
+# locale by hand (see AGENTS.md "i18n").
 
 i18n-check:
 	python3 tools/i18n-translate/translate.py check
-
-i18n-fill:
-	python3 tools/i18n-translate/translate.py fill
 
 # -- Third-party license notices (see tools/gen-notices) --
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 <div align="center">
   
-<sub>Localised with [DeepL](https://www.deepl.com) - _expect mistakes_ - translation fixes welcome as PRs against [`web/src/i18n/locales/`](https://github.com/hugalafutro/model-hotel/tree/master/web/src/i18n/locales)!<br>Made with [OpenCode](https://opencode.ai) + [oh-my-opencode-slim](https://github.com/alvinunreal/oh-my-opencode-slim) & [Claude Code](https://claude.com/claude-code)</sub>
+<sub>Localised by AI - _expect mistakes_ - translation fixes welcome as PRs against [`web/src/i18n/locales/`](https://github.com/hugalafutro/model-hotel/tree/master/web/src/i18n/locales)!<br>Made with [OpenCode](https://opencode.ai) + [oh-my-opencode-slim](https://github.com/alvinunreal/oh-my-opencode-slim) & [Claude Code](https://claude.com/claude-code)</sub>
 <br>
 
  <a href="https://mh.site19.ddns.net"><img src="https://img.shields.io/badge/%F0%9F%8F%A8%20Live%20Demo-Try%20it%20now-D97757?style=for-the-badge" alt="Live Demo"></a><br>

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -10,6 +10,9 @@ name: model-hotel-test
 services:
     test-db:
         image: postgres:16-alpine
+        # Survive host reboots so the local test DB is always up (it still has no
+        # persistent volume, so data stays ephemeral; only the container restarts).
+        restart: unless-stopped
         environment:
             POSTGRES_USER: modelhotel
             POSTGRES_PASSWORD: changeme

--- a/internal/api/discovery_changes.go
+++ b/internal/api/discovery_changes.go
@@ -13,6 +13,10 @@ import (
 
 // DiscoveryChangeEntry is one provider's recorded background-discovery diff.
 type DiscoveryChangeEntry struct {
+	// ProviderID is empty when the provider was deleted after the row was
+	// recorded (the column is nullable). The dashboard uses it to offer a
+	// per-provider Retest action from the changes modal.
+	ProviderID   string         `json:"provider_id,omitempty"`
 	ProviderName string         `json:"provider_name"`
 	Source       string         `json:"source"`
 	DetectedAt   time.Time      `json:"detected_at"`
@@ -74,18 +78,22 @@ func AppendDiscoveryChange(ctx context.Context, pool *pgxpool.Pool, source strin
 	return true, nil
 }
 
-// scanDiscoveryChangeRows decodes (provider_name, source, detected_at, diff)
-// rows into entries, shared by the list and ack queries.
+// scanDiscoveryChangeRows decodes (provider_id, provider_name, source,
+// detected_at, diff) rows into entries, shared by the list and ack queries.
 func scanDiscoveryChangeRows(rows pgx.Rows) ([]DiscoveryChangeEntry, error) {
 	defer rows.Close()
 	var entries []DiscoveryChangeEntry
 	for rows.Next() {
 		var (
-			entry    DiscoveryChangeEntry
-			diffJSON []byte
+			entry      DiscoveryChangeEntry
+			diffJSON   []byte
+			providerID *string // nullable provider_id::text
 		)
-		if err := rows.Scan(&entry.ProviderName, &entry.Source, &entry.DetectedAt, &diffJSON); err != nil {
+		if err := rows.Scan(&providerID, &entry.ProviderName, &entry.Source, &entry.DetectedAt, &diffJSON); err != nil {
 			return nil, err
+		}
+		if providerID != nil {
+			entry.ProviderID = *providerID
 		}
 		var diff DiscoveryDiff
 		if err := json.Unmarshal(diffJSON, &diff); err != nil {
@@ -100,7 +108,7 @@ func scanDiscoveryChangeRows(rows pgx.Rows) ([]DiscoveryChangeEntry, error) {
 // listPendingDiscoveryChanges returns the unseen recorded diffs, newest-first.
 func listPendingDiscoveryChanges(ctx context.Context, pool *pgxpool.Pool) ([]DiscoveryChangeEntry, error) {
 	rows, err := pool.Query(ctx,
-		`SELECT provider_name, source, detected_at, diff
+		`SELECT provider_id::text, provider_name, source, detected_at, diff
 		   FROM discovery_changes
 		  WHERE NOT seen
 		  ORDER BY detected_at DESC`)
@@ -120,9 +128,9 @@ func markDiscoveryChangesSeen(ctx context.Context, pool *pgxpool.Pool) ([]Discov
 		`WITH updated AS (
 			UPDATE discovery_changes SET seen = true
 			 WHERE NOT seen
-			 RETURNING provider_name, source, detected_at, diff
+			 RETURNING provider_id::text, provider_name, source, detected_at, diff
 		)
-		SELECT provider_name, source, detected_at, diff
+		SELECT provider_id::text, provider_name, source, detected_at, diff
 		  FROM updated
 		 ORDER BY detected_at DESC`)
 	if err != nil {

--- a/internal/api/discovery_changes_test.go
+++ b/internal/api/discovery_changes_test.go
@@ -52,6 +52,9 @@ func TestDiscoveryChangesStore_RoundTrip(t *testing.T) {
 	if got.ProviderName != "DeepSeek" || got.Source != "scheduled" {
 		t.Errorf("entry metadata = %q/%q, want DeepSeek/scheduled", got.ProviderName, got.Source)
 	}
+	if got.ProviderID != providerID.String() {
+		t.Errorf("ProviderID = %q, want %q", got.ProviderID, providerID.String())
+	}
 	if got.Diff == nil || len(got.Diff.Added) != 1 || len(got.Diff.Updated) != 1 {
 		t.Fatalf("decoded diff mismatch: %+v", got.Diff)
 	}
@@ -130,5 +133,9 @@ func TestAppendDiscoveryChange_NilProviderID(t *testing.T) {
 	}
 	if len(entries) != 1 || entries[0].ProviderName != "" {
 		t.Fatalf("expected 1 entry with empty provider name, got %+v", entries)
+	}
+	// A nil provider_id round-trips as an empty string, not a zero UUID.
+	if entries[0].ProviderID != "" {
+		t.Errorf("ProviderID = %q, want empty for a nil provider_id", entries[0].ProviderID)
 	}
 }

--- a/internal/api/totp_handlers.go
+++ b/internal/api/totp_handlers.go
@@ -95,11 +95,26 @@ func (h *TotpHandler) adminOrSessionAuth(next http.Handler) http.Handler {
 	})
 }
 
-// Status reports the cached TOTP-enabled state. Uses the shared cached value so
-// the login UI's view matches what AuthMiddleware enforces. No DB hit.
-func (h *TotpHandler) Status(w http.ResponseWriter, _ *http.Request) {
+// statusResponse is the GET /api/totp/status payload. EnabledAt is the RFC3339
+// confirmation time, omitted when TOTP is disabled.
+type statusResponse struct {
+	Enabled   bool   `json:"enabled"`
+	EnabledAt string `json:"enabled_at,omitempty"`
+}
+
+// Status reports the TOTP-enabled state. The enabled flag comes from the shared
+// cached value so the login UI's view matches what AuthMiddleware enforces; when
+// enabled it also surfaces confirmed_at (one indexed single-row read) so the
+// settings panel can show when 2FA was turned on.
+func (h *TotpHandler) Status(w http.ResponseWriter, r *http.Request) {
 	enabled := h.totpEnabled != nil && h.totpEnabled()
-	writeJSON(w, map[string]bool{"enabled": enabled})
+	resp := statusResponse{Enabled: enabled}
+	if enabled && h.totpRepo != nil {
+		if at, ok, err := h.totpRepo.EnabledAt(r.Context()); err == nil && ok {
+			resp.EnabledAt = at.UTC().Format(time.RFC3339)
+		}
+	}
+	writeJSON(w, resp)
 }
 
 // EnrollStart generates a new TOTP secret and returns the otpauth URI + secret.

--- a/internal/api/totp_handlers_test.go
+++ b/internal/api/totp_handlers_test.go
@@ -132,12 +132,19 @@ func TestTotpStatus_Disabled(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
-	var resp map[string]bool
+	var resp struct {
+		Enabled   bool   `json:"enabled"`
+		EnabledAt string `json:"enabled_at"`
+	}
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if resp["enabled"] != false {
-		t.Errorf("expected enabled=false, got %v", resp["enabled"])
+	if resp.Enabled != false {
+		t.Errorf("expected enabled=false, got %v", resp.Enabled)
+	}
+	// The disabled response must not leak an enabled_at timestamp.
+	if resp.EnabledAt != "" {
+		t.Errorf("expected empty enabled_at when disabled, got %q", resp.EnabledAt)
 	}
 }
 

--- a/internal/api/totp_handlers_test.go
+++ b/internal/api/totp_handlers_test.go
@@ -155,12 +155,22 @@ func TestTotpStatus_Enabled(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
-	var resp map[string]bool
+	var resp struct {
+		Enabled   bool   `json:"enabled"`
+		EnabledAt string `json:"enabled_at"`
+	}
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if resp["enabled"] != true {
-		t.Errorf("expected enabled=true, got %v", resp["enabled"])
+	if !resp.Enabled {
+		t.Errorf("expected enabled=true, got %v", resp.Enabled)
+	}
+	// Enabling stamps confirmed_at, so status surfaces a parseable RFC3339 time.
+	if resp.EnabledAt == "" {
+		t.Fatal("expected enabled_at to be set when TOTP is enabled")
+	}
+	if _, err := time.Parse(time.RFC3339, resp.EnabledAt); err != nil {
+		t.Errorf("enabled_at %q is not RFC3339: %v", resp.EnabledAt, err)
 	}
 }
 

--- a/internal/totp/totp.go
+++ b/internal/totp/totp.go
@@ -270,6 +270,26 @@ func (r *Repository) IsEnabled(ctx context.Context) (bool, error) {
 	return enabled, nil
 }
 
+// EnabledAt returns when TOTP was last confirmed (the confirmed_at stamp set by
+// Enable). The bool is false when no enrollment exists or it is not yet
+// confirmed, so callers can omit the timestamp from a disabled-state response.
+func (r *Repository) EnabledAt(ctx context.Context) (time.Time, bool, error) {
+	var confirmedAt *time.Time
+	err := r.db.QueryRow(ctx,
+		`SELECT confirmed_at FROM admin_totp WHERE id = 1 AND enabled`,
+	).Scan(&confirmedAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return time.Time{}, false, nil
+		}
+		return time.Time{}, false, fmt.Errorf("totp: enabled_at: %w", err)
+	}
+	if confirmedAt == nil {
+		return time.Time{}, false, nil
+	}
+	return *confirmedAt, true, nil
+}
+
 // GenerateRecoveryCodes generates 10 single-use recovery codes, stores their
 // SHA-256 hashes (replacing any existing set), and returns the plaintext codes
 // in order for one-time display. The codes are never logged.

--- a/internal/totp/totp_test.go
+++ b/internal/totp/totp_test.go
@@ -217,6 +217,33 @@ func TestEnableDisableLifecycle(t *testing.T) {
 	assert.False(t, enabled)
 }
 
+func TestEnabledAt(t *testing.T) {
+	repo := newTestRepo(t, "test-master-key-very-long-32b+")
+	ctx := context.Background()
+
+	// No row -> not enabled, zero time, no error.
+	at, ok, err := repo.EnabledAt(ctx)
+	require.NoError(t, err)
+	assert.False(t, ok)
+	assert.True(t, at.IsZero())
+
+	_, _, err = repo.Enroll(ctx)
+	require.NoError(t, err)
+
+	// Provisional enrollment (confirmed_at NULL) -> still reports not enabled.
+	_, ok, err = repo.EnabledAt(ctx)
+	require.NoError(t, err)
+	assert.False(t, ok)
+
+	before := time.Now().Add(-time.Second)
+	require.NoError(t, repo.Enable(ctx))
+	at, ok, err = repo.EnabledAt(ctx)
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.False(t, at.IsZero())
+	assert.False(t, at.Before(before), "confirmed_at should be ~now, got %v", at)
+}
+
 func TestEnableWithoutEnroll(t *testing.T) {
 	repo := newTestRepo(t, "test-master-key-very-long-32b+")
 	ctx := context.Background()

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -8,6 +8,32 @@ set -euo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
+# README/DOCKERHUB.md sync guard - mirrors .github/workflows/dockerhub-readme-guard.yml
+# so the "you touched README.md, touch DOCKERHUB.md too" decision happens here
+# instead of after a wasted CI cycle. DOCKERHUB.md is the Hub-tailored copy uploaded
+# on release. Diff this branch against its merge-base with the default branch (same
+# base..head model the CI uses). Set DOCKERHUB_README_NOT_NEEDED=1 to acknowledge a
+# README change that genuinely doesn't apply to Docker Hub (local stand-in for the
+# 'dockerhub-readme-not-needed' PR label).
+DEFAULT_BRANCH="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##')"
+DEFAULT_BRANCH="${DEFAULT_BRANCH:-master}"
+SYNC_BASE="$(git merge-base "origin/${DEFAULT_BRANCH}" HEAD 2>/dev/null || true)"
+if [ -n "$SYNC_BASE" ]; then
+	CHANGED="$(git diff --name-only "$SYNC_BASE" HEAD)"
+	if printf '%s\n' "$CHANGED" | grep -qx "README.md" &&
+		! printf '%s\n' "$CHANGED" | grep -qx "DOCKERHUB.md"; then
+		if [ "${DOCKERHUB_README_NOT_NEEDED:-}" = "1" ]; then
+			echo "pre-push: README.md changed without DOCKERHUB.md - acknowledged (DOCKERHUB_README_NOT_NEEDED=1)"
+		else
+			echo "pre-push: FAILED - README.md changed but DOCKERHUB.md did not." >&2
+			echo "  Mirror the change into DOCKERHUB.md (the Docker Hub copy), or re-run as" >&2
+			echo "  DOCKERHUB_README_NOT_NEEDED=1 git push  if it doesn't apply to Docker Hub" >&2
+			echo "  (then add the 'dockerhub-readme-not-needed' label to the PR)." >&2
+			exit 1
+		fi
+	fi
+fi
+
 echo "pre-push: go vet ./..."
 if ! go vet ./cmd/... ./internal/...; then
 	echo "pre-push: FAILED - go vet" >&2

--- a/tools/i18n-translate/translate.py
+++ b/tools/i18n-translate/translate.py
@@ -1,57 +1,31 @@
 #!/usr/bin/env python3
 """
-i18n locale maintenance (stdlib only, no dependencies).
+i18n locale maintenance (stdlib only, no dependencies, no network).
 
-NOTE (2026-06): the free DeepL quota is exhausted (1M-char Developer allotment,
-no refresh until ~May 2027), so `fill` and `bootstrap` will fail with HTTP 456.
-Translate new keys BY HAND into all locales instead; the quickest correct way is
-a one-off script that reuses load_locale/set_path/save_locale below (preserves
-nesting + tab/ensure_ascii formatting). `check` is unaffected: it is fully
-offline and remains the CI gate.
+New user-facing strings are added to en.json and translated into every other
+locale by hand (the assistant/contributor does this directly). The quickest
+correct way to bulk-apply a batch of translations is a one-off script that
+reuses the load_locale/set_path/save_locale helpers below, which preserve each
+file's nesting and tab/ensure_ascii formatting.
 
 Subcommands:
     check        CI gate: fail when any locale is missing keys, has extra
                  keys, breaks {{placeholder}} parity, carries a non-string
                  value, or carries an English-equal value that is not
                  allowlisted.
-    fill         Fix what `check` flags, in place: translate missing and
-                 non-allowlisted English keys, delete stale keys that left
-                 en.json. Review the printed report before committing -
-                 DeepL gets word order and temporal/causal "since" wrong
-                 sometimes.
-    bootstrap    Translate the full en.json into one new language
-                 (the original behavior of this script).
     grandfather  Snapshot all current English-equal values into the
                  allowlist so `check` only flags future additions.
-    usage        Show DeepL quota.
 
 Intentionally-English values (brand names, loanwords like "Failover") live
 in allow-english.json next to this script: {"dot.key": ["af", "da"]} or
-{"dot.key": ["*"]}. Remove entries to force retranslation on next `fill`.
-
-Requires DEEPL_API_KEY for fill/bootstrap/usage; `check` needs no network.
+{"dot.key": ["*"]}. Remove entries to force retranslation later.
 """
 
 import argparse
-import copy
 import json
 import os
 import re
 import sys
-import time
-import urllib.error
-import urllib.parse
-import urllib.request
-
-API_KEY = os.environ.get("DEEPL_API_KEY", "")
-if API_KEY.endswith(":fx"):
-    API_URL = "https://api-free.deepl.com/v2"
-else:
-    API_URL = "https://api.deepl.com/v2"
-
-BATCH_SIZE = 40
-RETRY_MAX = 3
-RETRY_BASE_WAIT = 2
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 LOCALES_DIR = os.path.normpath(
@@ -59,132 +33,18 @@ LOCALES_DIR = os.path.normpath(
 )
 ALLOWLIST_PATH = os.path.join(SCRIPT_DIR, "allow-english.json")
 
-# Repo locale code -> DeepL target code. Regional variants are collapsed to
-# one per language across the app; these are the only non-identity mappings.
-DEEPL_LANG = {"no": "NB", "pt": "PT-BR", "zh": "ZH-HANS"}
 
-# Domain context passed to DeepL; measurably improves term choice.
-CONTEXT = (
-    "UI strings in an admin dashboard for an AI/LLM gateway. "
-    "'Provider' means an LLM API provider (like OpenAI). 'Model' means an "
-    "AI model. 'Failover group' is a routing group of interchangeable "
-    "models; keep the word 'failover' as commonly used in that language's "
-    "technical UI. 'Listed' refers to a model appearing in the provider's "
-    "published model listing. Keep placeholders exactly as they are."
-)
-
-
-# ── API ──────────────────────────────────────────────────────────────────────
-
-def deepl_translate(texts: list[str], target_lang: str, source_lang: str = "EN") -> list[str]:
-    """Translate a batch of texts via DeepL API (header-based auth)."""
-    if not texts:
-        return []
-    if not API_KEY:
-        print("DEEPL_API_KEY not set", file=sys.stderr)
-        sys.exit(1)
-
-    data = urllib.parse.urlencode({
-        "text": texts,
-        "source_lang": source_lang,
-        "target_lang": target_lang,
-        "context": CONTEXT,
-    }, doseq=True).encode("utf-8")
-
-    req = urllib.request.Request(
-        f"{API_URL}/translate",
-        data=data,
-        headers={
-            "Content-Type": "application/x-www-form-urlencoded",
-            "Authorization": f"DeepL-Auth-Key {API_KEY}",
-        },
-        method="POST",
-    )
-
-    for attempt in range(RETRY_MAX):
-        last_attempt = attempt == RETRY_MAX - 1
-        try:
-            with urllib.request.urlopen(req, timeout=30) as resp:
-                result = json.loads(resp.read().decode("utf-8"))
-                return [t["text"] for t in result["translations"]]
-        except urllib.error.HTTPError as e:
-            if e.code not in (429, *range(500, 600)) or last_attempt:
-                body = e.read().decode("utf-8", errors="replace")
-                print(f"DeepL API error {e.code}: {body}", file=sys.stderr)
-                sys.exit(1)
-            retry_after = e.headers.get("Retry-After", "")
-            wait = int(retry_after) if retry_after.isdigit() else RETRY_BASE_WAIT ** (attempt + 1)
-            print(f"  HTTP {e.code}, retry {attempt+1}/{RETRY_MAX} in {wait}s...", file=sys.stderr)
-            time.sleep(wait)
-        except urllib.error.URLError as e:
-            if last_attempt:
-                raise
-            wait = RETRY_BASE_WAIT ** (attempt + 1)
-            print(f"  Network error: {e}, retry in {wait}s...", file=sys.stderr)
-            time.sleep(wait)
-
-    raise AssertionError("unreachable: the last attempt returns, exits, or raises")
-
-
-def check_usage() -> dict:
-    """Return DeepL usage stats."""
-    if not API_KEY:
-        return {"error": "DEEPL_API_KEY not set"}
-    try:
-        req = urllib.request.Request(
-            f"{API_URL}/usage",
-            headers={"Authorization": f"DeepL-Auth-Key {API_KEY}"},
-        )
-        with urllib.request.urlopen(req, timeout=10) as resp:
-            return json.loads(resp.read().decode("utf-8"))
-    except Exception as e:
-        return {"error": str(e)}
-
-
-# ── Interpolation protection ────────────────────────────────────────────────
-
-def protect(text: str) -> tuple[str, dict[str, str]]:
-    """Replace {{vars}} and <markup> tags with stable placeholders."""
-    placeholders = {}
-    counter = [0]
-
-    def repl(m):
-        counter[0] += 1
-        ph = f"XPHL{counter[0]}X"
-        placeholders[ph] = m.group(0)
-        return ph
-
-    protected = re.sub(PROTECTED_RE, repl, text)
-    return protected, placeholders
-
-
-def restore(text: str, placeholders: dict[str, str]) -> str:
-    """Restore {{vars}} from placeholders."""
-    for ph, orig in placeholders.items():
-        text = text.replace(ph, orig)
-    return text
-
+# ── Interpolation parity ─────────────────────────────────────────────────────
 
 # {{interpolations}} plus <Trans> markup tags (e.g. <code>...</code>); both
-# must survive translation verbatim, so both are protected from DeepL and
-# compared against en.json by the check.
+# must survive translation verbatim, so the check compares each locale's set
+# against en.json.
 PROTECTED_RE = r"\{\{[^}]+\}\}|</?[a-zA-Z][a-zA-Z0-9]*>"
 
 
 def interpolations(text: str) -> set[str]:
     """The set of {{placeholders}} and markup tags a string uses."""
     return set(re.findall(PROTECTED_RE, text))
-
-
-def translate_batch(values: list[str], target_lang: str) -> list[str]:
-    """Protect {{vars}} in a batch of source strings, translate, restore."""
-    protected, all_ph = [], []
-    for value in values:
-        pv, ph = protect(value)
-        protected.append(pv)
-        all_ph.append(ph)
-    translated = deepl_translate(protected, target_lang)
-    return [restore(text, ph) for text, ph in zip(translated, all_ph)]
 
 
 # ── Locale file helpers ─────────────────────────────────────────────────────
@@ -339,67 +199,15 @@ def cmd_check() -> int:
             print(f"  {code}: {key}")
     print(
         f"\ni18n check FAILED ({total} problems)."
-        "\nFix: translate the listed keys into the listed locales BY HAND and commit."
-        "\n(`make i18n-fill` uses DeepL and is legacy/quota-exhausted - do not rely on it;"
-        "\nreuse this script's load_locale/set_path/save_locale from a one-off script.)"
+        "\nFix: translate the listed keys into the listed locales by hand and commit"
+        "\n(reuse this script's load_locale/set_path/save_locale from a one-off script)."
         "\nIntentionally-English values go into tools/i18n-translate/allow-english.json."
     )
     if problems["malformed"]:
         print(
-            "Note: `malformed` entries (value is not a string) are NOT fixed by"
-            "\ni18n-fill - edit those locale files by hand."
+            "Note: `malformed` entries (value is not a string) must be edited by hand."
         )
     return 1
-
-
-# ── fill ────────────────────────────────────────────────────────────────────
-
-def cmd_fill(only_langs: list[str] | None) -> int:
-    allow = load_allowlist()
-    en = load_locale("en")
-    en_flat = flatten(en)
-    problems = find_problems(allow)
-    work: dict[str, list[str]] = {}
-    for kind in ("missing", "untranslated", "placeholders"):
-        for code, key in problems[kind]:
-            if only_langs and code not in only_langs:
-                continue
-            work.setdefault(code, []).append(key)
-    removals: dict[str, list[str]] = {}
-    for code, key in problems["extra"]:
-        if only_langs and code not in only_langs:
-            continue
-        removals.setdefault(code, []).append(key)
-
-    if not work and not removals:
-        print("nothing to fill - all locales in sync")
-        return 0
-
-    for code in sorted(set(work) | set(removals)):
-        data = load_locale(code)
-        for key in sorted(set(removals.get(code, []))):
-            if delete_path(data, key):
-                print(f"{code}: removed stale key {key}")
-        keys = sorted(set(work.get(code, [])))
-        if keys:
-            target = DEEPL_LANG.get(code, code.upper())
-            print(f"{code} ({target}): translating {len(keys)} strings")
-            for i in range(0, len(keys), BATCH_SIZE):
-                chunk = keys[i:i + BATCH_SIZE]
-                for key, value in zip(chunk, translate_batch([en_flat[k] for k in chunk], target)):
-                    set_path(data, en, key, value)
-                    print(f"  {key} = {value}")
-                    if interpolations(value) != interpolations(en_flat[key]):
-                        print(f"  WARNING: DeepL broke placeholder parity in {key}; fix by hand", file=sys.stderr)
-                if i + BATCH_SIZE < len(keys):
-                    time.sleep(0.3)
-        save_locale(code, data)
-
-    print(
-        "\nDone. REVIEW THE DIFF before committing - check word order around"
-        "\nplaceholders and that temporal 'since' did not become causal."
-    )
-    return 0
 
 
 # ── grandfather ─────────────────────────────────────────────────────────────
@@ -420,43 +228,6 @@ def cmd_grandfather() -> int:
     return 0
 
 
-# ── bootstrap (full-file translation for a new language) ────────────────────
-
-def cmd_bootstrap(target_lang: str, output: str | None) -> int:
-    source = load_locale("en")
-    target = copy.deepcopy(source)
-
-    items = []
-
-    def collect(obj):
-        for k in obj:
-            if isinstance(obj[k], str):
-                items.append((obj, k, obj[k]))
-            elif isinstance(obj[k], dict):
-                collect(obj[k])
-
-    collect(target)
-    to_translate = [(p, k, v) for p, k, v in items if not should_skip(v)]
-    print(f"Total strings: {len(items)}, translating: {len(to_translate)}, skipping: {len(items) - len(to_translate)}")
-
-    deepl_code = DEEPL_LANG.get(target_lang.lower(), target_lang.upper())
-    total = len(to_translate)
-    for i in range(0, total, BATCH_SIZE):
-        chunk = to_translate[i:i + BATCH_SIZE]
-        for (parent, key, _), value in zip(chunk, translate_batch([v for _, _, v in chunk], deepl_code)):
-            parent[key] = value
-        print(f"  Batch {i // BATCH_SIZE + 1}/{(total + BATCH_SIZE - 1) // BATCH_SIZE} done")
-        if i + BATCH_SIZE < total:
-            time.sleep(0.3)
-
-    out = output or os.path.join(LOCALES_DIR, f"{target_lang.lower()}.json")
-    with open(out, "w", encoding="utf-8") as f:
-        json.dump(target, f, ensure_ascii=False, indent="\t")
-        f.write("\n")
-    print(f"Written: {out}")
-    return 0
-
-
 # ── CLI ──────────────────────────────────────────────────────────────────────
 
 def main():
@@ -464,38 +235,14 @@ def main():
     sub = parser.add_subparsers(dest="cmd", required=True)
 
     sub.add_parser("check", help="verify all locales are in sync with en.json (CI gate)")
-
-    p_fill = sub.add_parser("fill", help="DeepL-translate missing/untranslated keys in place")
-    p_fill.add_argument("--langs", help="comma-separated locale codes (default: all)")
-
-    p_boot = sub.add_parser("bootstrap", help="translate full en.json into a new language")
-    p_boot.add_argument("lang", help="locale code, e.g. cs")
-    p_boot.add_argument("--output", default=None, help="output file (default: locales/<lang>.json)")
-
     sub.add_parser("grandfather", help="allowlist all current English-equal values")
-    sub.add_parser("usage", help="show DeepL quota")
 
     args = parser.parse_args()
 
     if args.cmd == "check":
         sys.exit(cmd_check())
-    if args.cmd == "fill":
-        langs = args.langs.split(",") if args.langs else None
-        sys.exit(cmd_fill(langs))
-    if args.cmd == "bootstrap":
-        sys.exit(cmd_bootstrap(args.lang, args.output))
     if args.cmd == "grandfather":
         sys.exit(cmd_grandfather())
-    if args.cmd == "usage":
-        usage = check_usage()
-        if "error" in usage:
-            print(f"Error: {usage['error']}")
-        else:
-            count = usage.get("character_count", 0)
-            limit = usage.get("character_limit", 0)
-            pct = (count / limit * 100) if limit else 0
-            print(f"DeepL quota: {count:,} / {limit:,} chars ({pct:.1f}%)")
-        sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -487,6 +487,8 @@ export interface DiscoveryDiff {
 
 /** One provider's recorded background-discovery diff (GET /api/discovery/changes). */
 export interface DiscoveryChangeEntry {
+	/** Empty when the provider was deleted after the change was recorded. */
+	provider_id?: string;
 	provider_name: string;
 	source: string;
 	detected_at: string;
@@ -654,6 +656,8 @@ export interface WebAuthnCredential {
 
 export interface TotpStatus {
 	enabled: boolean;
+	/** RFC3339 confirmation time; absent when TOTP is disabled. */
+	enabled_at?: string;
 }
 
 export interface TotpEnrollStart {

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -33,6 +33,7 @@ import {
 	type DiscoverySummaryEntry,
 	DiscoverySummaryModal,
 } from "../pages/Providers/DiscoverySummaryModal";
+import { useDiscoveryRetest } from "../pages/Providers/useDiscoveryRetest";
 import { isWebAuthnAvailable } from "../utils/webauthn";
 import { CollapsibleToggle, useCollapsible } from "./CollapsibleToggle";
 import { ConfirmDialog } from "./ConfirmDialog";
@@ -665,6 +666,14 @@ export function Layout({ children }: LayoutProps) {
 	const [discoveryChangeEntries, setDiscoveryChangeEntries] = useState<
 		DiscoverySummaryEntry[]
 	>([]);
+	const { onRetest: onRetestDiscovery, retestingKey: discoveryRetestingKey } =
+		useDiscoveryRetest((key, diff) =>
+			setDiscoveryChangeEntries((prev) =>
+				prev.map((e) =>
+					(e.entryKey ?? e.providerName) === key ? { ...e, diff } : e,
+				),
+			),
+		);
 	// Guards against a re-entrant open (rapid double-click / repeated Enter) while
 	// the ack is in flight: the first ack returns and clears the rows, a second
 	// would return an empty list and blank the modal. A ref (not state) so the
@@ -705,6 +714,7 @@ export function Layout({ children }: LayoutProps) {
 				providerName: entry.provider_name || failoverLabel,
 				diff: entry.diff,
 				entryKey: `${entry.provider_name}-${entry.detected_at}-${i}`,
+				providerId: entry.provider_id,
 			})),
 		);
 		setShowDiscoveryChanges(true);
@@ -936,6 +946,9 @@ export function Layout({ children }: LayoutProps) {
 														count: discoveryChangeCount,
 													})}
 												>
+													<span aria-hidden="true" className="opacity-70 mr-px">
+														±
+													</span>
 													{discoveryChangeCount}
 												</span>
 											</span>
@@ -1041,6 +1054,8 @@ export function Layout({ children }: LayoutProps) {
 				<DiscoverySummaryModal
 					results={discoveryChangeEntries}
 					onClose={() => setShowDiscoveryChanges(false)}
+					onRetest={onRetestDiscovery}
+					retestingKey={discoveryRetestingKey}
 				/>
 			)}
 		</div>

--- a/web/src/components/RequestLogDetail.tsx
+++ b/web/src/components/RequestLogDetail.tsx
@@ -1,8 +1,11 @@
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
 	AlertTriangle,
 	Box,
 	Calendar,
+	ChevronDown,
+	ChevronRight,
 	Clock,
 	Gauge,
 	Hash,
@@ -31,6 +34,17 @@ export function RequestLogDetail({
 	onClose: () => void;
 }) {
 	const { t } = useTranslation();
+	// Proxy overhead breakdown starts collapsed: the header shows the total, and
+	// expanding reveals the per-step split.
+	const [overheadOpen, setOverheadOpen] = useState(false);
+	const totalOverheadMs =
+		(requestLog.parse_ms || 0) +
+		(requestLog.failover_lookup_ms || 0) +
+		(requestLog.model_lookup_ms || 0) +
+		(requestLog.provider_lookup_ms || 0) +
+		(requestLog.key_decrypt_ms || 0) +
+		(requestLog.dial_ms || 0) +
+		(requestLog.settings_read_ms || 0);
 	const totalTokens =
 		requestLog.tokens_prompt +
 		requestLog.tokens_completion +
@@ -289,106 +303,135 @@ export function RequestLogDetail({
 			{/* Overhead Breakdown */}
 			{requestLog.proxy_overhead_ms > 0 && (
 				<div className="mb-6 p-4 rounded-(--radius-box) bg-(--surface-bg) border border-(--border-subtle)">
-					<h4 className="text-sm font-semibold text-(--text-primary) mb-3 flex items-center gap-2">
+					<button
+						type="button"
+						onClick={() => setOverheadOpen((o) => !o)}
+						aria-expanded={overheadOpen}
+						data-testid="proxy-overhead-toggle"
+						className="flex w-full items-center gap-2 text-sm font-semibold text-(--text-primary)"
+					>
 						<Gauge size={14} className="text-(--accent)" />
 						{t("components.requestLogDetail.proxyOverheadBreakdown")}
-					</h4>
-					<div className="space-y-2">
-						{[
-							{
-								label: t("components.requestLogDetail.requestParsing"),
-								value: requestLog.parse_ms,
-								tooltip: t("components.requestLogDetail.timeToParseRequest"),
-								cacheHit: null as boolean | null,
-							},
-							{
-								label: t("components.requestLogDetail.failoverGroupLookup"),
-								value: requestLog.failover_lookup_ms,
-								tooltip: t("components.requestLogDetail.timeToResolveFailover"),
-								cacheHit: requestLog.cache_hits?.failover ?? null,
-							},
-							{
-								label: t("components.requestLogDetail.modelLookup"),
-								value: requestLog.model_lookup_ms,
-								tooltip: t("components.requestLogDetail.timeToLookupModel"),
-								cacheHit: requestLog.cache_hits?.model ?? null,
-							},
-							{
-								label: t("components.requestLogDetail.providerLookup"),
-								value: requestLog.provider_lookup_ms,
-								tooltip: t("components.requestLogDetail.timeToLookupProvider"),
-								cacheHit: requestLog.cache_hits?.provider ?? null,
-							},
-							{
-								label: t("components.requestLogDetail.keyDecryption"),
-								value: requestLog.key_decrypt_ms,
-								tooltip: t("components.requestLogDetail.timeToDecryptKey"),
-								cacheHit: requestLog.cache_hits?.key ?? null,
-							},
-							{
-								label: t("components.requestLogDetail.dialDnsTcp"),
-								value: requestLog.dial_ms,
-								tooltip: t("components.requestLogDetail.timeToEstablishTcp"),
-								cacheHit: null as boolean | null,
-							},
-							{
-								label: t("components.requestLogDetail.settingsReads"),
-								value: requestLog.settings_read_ms,
-								tooltip: t("components.requestLogDetail.timeToReadSettings"),
-								cacheHit: requestLog.cache_hits?.settings ?? null,
-							},
-						].map(
-							({ label, value, tooltip, cacheHit }) =>
-								(value > 0 ||
-									(label === t("components.requestLogDetail.dialDnsTcp") &&
-										value === 0)) && (
-									<div key={label} className="flex justify-between text-sm">
-										<span className="flex items-center gap-1 text-(--text-secondary)">
-											{label}
-											<InfoHint
-												tooltip={
-													cacheHit === null
-														? tooltip
-														: cacheHit
-															? `${tooltip} ${t("components.requestLogDetail.overheadCacheHit")}`
-															: `${tooltip} ${t("components.requestLogDetail.overheadCacheMiss")}`
-												}
-											/>
-										</span>
-										<span
-											className={`font-mono ${
-												cacheHit === true
-													? "text-emerald-400"
-													: cacheHit === false
-														? "text-amber-400"
-														: "text-(--text-primary)"
-											}`}
-										>
-											{label === t("components.requestLogDetail.dialDnsTcp") &&
-											value === 0
-												? t("components.requestLogDetail.reused")
-												: formatMs(value, 3)}
-										</span>
-									</div>
-								),
+						{!overheadOpen && (
+							<InfoHint
+								tooltip={t("components.requestLogDetail.expandForBreakdown")}
+							/>
 						)}
-						<div className="border-t border-(--border-default) my-2" />
-						<div className="flex justify-between text-sm font-semibold">
-							<span className="text-(--text-primary)">
-								{t("components.requestLogDetail.totalOverhead")}
-							</span>
-							<span className="font-mono text-(--accent)">
-								{formatMs(
-									(requestLog.parse_ms || 0) +
-										(requestLog.failover_lookup_ms || 0) +
-										(requestLog.model_lookup_ms || 0) +
-										(requestLog.provider_lookup_ms || 0) +
-										(requestLog.key_decrypt_ms || 0) +
-										(requestLog.dial_ms || 0) +
-										(requestLog.settings_read_ms || 0),
-									3,
+						<span className="ml-auto font-mono text-(--accent)">
+							{formatMs(totalOverheadMs, 3)}
+						</span>
+						{overheadOpen ? (
+							<ChevronDown size={14} className="text-(--accent)" />
+						) : (
+							<ChevronRight size={14} className="text-(--accent)" />
+						)}
+					</button>
+					<div
+						className={`grid transition-[grid-template-rows] duration-300 ease-in-out ${
+							overheadOpen ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
+						}`}
+					>
+						<div className="overflow-hidden">
+							<div className="space-y-2 mt-3">
+								{[
+									{
+										label: t("components.requestLogDetail.requestParsing"),
+										value: requestLog.parse_ms,
+										tooltip: t(
+											"components.requestLogDetail.timeToParseRequest",
+										),
+										cacheHit: null as boolean | null,
+									},
+									{
+										label: t("components.requestLogDetail.failoverGroupLookup"),
+										value: requestLog.failover_lookup_ms,
+										tooltip: t(
+											"components.requestLogDetail.timeToResolveFailover",
+										),
+										cacheHit: requestLog.cache_hits?.failover ?? null,
+									},
+									{
+										label: t("components.requestLogDetail.modelLookup"),
+										value: requestLog.model_lookup_ms,
+										tooltip: t("components.requestLogDetail.timeToLookupModel"),
+										cacheHit: requestLog.cache_hits?.model ?? null,
+									},
+									{
+										label: t("components.requestLogDetail.providerLookup"),
+										value: requestLog.provider_lookup_ms,
+										tooltip: t(
+											"components.requestLogDetail.timeToLookupProvider",
+										),
+										cacheHit: requestLog.cache_hits?.provider ?? null,
+									},
+									{
+										label: t("components.requestLogDetail.keyDecryption"),
+										value: requestLog.key_decrypt_ms,
+										tooltip: t("components.requestLogDetail.timeToDecryptKey"),
+										cacheHit: requestLog.cache_hits?.key ?? null,
+									},
+									{
+										label: t("components.requestLogDetail.dialDnsTcp"),
+										value: requestLog.dial_ms,
+										tooltip: t(
+											"components.requestLogDetail.timeToEstablishTcp",
+										),
+										cacheHit: null as boolean | null,
+									},
+									{
+										label: t("components.requestLogDetail.settingsReads"),
+										value: requestLog.settings_read_ms,
+										tooltip: t(
+											"components.requestLogDetail.timeToReadSettings",
+										),
+										cacheHit: requestLog.cache_hits?.settings ?? null,
+									},
+								].map(
+									({ label, value, tooltip, cacheHit }) =>
+										(value > 0 ||
+											(label === t("components.requestLogDetail.dialDnsTcp") &&
+												value === 0)) && (
+											<div key={label} className="flex justify-between text-sm">
+												<span className="flex items-center gap-1 text-(--text-secondary)">
+													{label}
+													<InfoHint
+														tooltip={
+															cacheHit === null
+																? tooltip
+																: cacheHit
+																	? `${tooltip} ${t("components.requestLogDetail.overheadCacheHit")}`
+																	: `${tooltip} ${t("components.requestLogDetail.overheadCacheMiss")}`
+														}
+													/>
+												</span>
+												<span
+													className={`font-mono ${
+														cacheHit === true
+															? "text-emerald-400"
+															: cacheHit === false
+																? "text-amber-400"
+																: "text-(--text-primary)"
+													}`}
+												>
+													{label ===
+														t("components.requestLogDetail.dialDnsTcp") &&
+													value === 0
+														? t("components.requestLogDetail.reused")
+														: formatMs(value, 3)}
+												</span>
+											</div>
+										),
 								)}
-							</span>
+								<div className="border-t border-(--border-default) my-2" />
+								<div className="flex justify-between text-sm font-semibold">
+									<span className="text-(--text-primary)">
+										{t("components.requestLogDetail.totalOverhead")}
+									</span>
+									<span className="font-mono text-(--accent)">
+										{formatMs(totalOverheadMs, 3)}
+									</span>
+								</div>
+							</div>
 						</div>
 					</div>
 				</div>

--- a/web/src/components/VirtualLogTable.tsx
+++ b/web/src/components/VirtualLogTable.tsx
@@ -5,10 +5,12 @@ import type { LogEntry } from "../api/types";
 import { formatMs, formatTPS } from "../pages/Logs/utils";
 import { formatNumber } from "../utils/format";
 import {
+	formatDurationCell,
 	getRowStatusVariant,
 	isCancelled,
 	isInProgress,
 	isStale,
+	liveDurationMs,
 } from "../utils/logHelpers";
 import { Badge } from "./Badge";
 import { EndpointTypeBadge } from "./logs";
@@ -420,13 +422,13 @@ export function VirtualLogTable(props: VirtualLogTableProps) {
 									</td>
 									<td className="px-2 py-1 whitespace-nowrap text-xs text-gray-400 font-mono">
 										{inProgress && log.duration_ms === 0 ? (
-											<span className="inline-block text-blue-400">-</span>
+											<span className="inline-block text-blue-400">
+												{formatDurationCell(
+													liveDurationMs(log.created_at, nowMs),
+												)}
+											</span>
 										) : log.duration_ms > 0 ? (
-											log.duration_ms >= 1000 ? (
-												`${(log.duration_ms / 1000).toFixed(1)}s`
-											) : (
-												`${log.duration_ms.toFixed(0)}ms`
-											)
+											formatDurationCell(log.duration_ms)
 										) : (
 											"-"
 										)}

--- a/web/src/components/__tests__/LogDetailModal.test.tsx
+++ b/web/src/components/__tests__/LogDetailModal.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from "@testing-library/react";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AppLogEntry, LogEntry } from "../../api/types";
@@ -379,7 +379,16 @@ describe("LogDetailModal", () => {
 				/>,
 			);
 
+			// The breakdown header is always visible; the per-step rows live in a
+			// collapsed-by-default region that animates open (grid-rows trick keeps
+			// it mounted), so assert the accessible expanded state, not DOM presence.
 			expect(screen.getByText("Proxy Overhead Breakdown")).toBeInTheDocument();
+			const overheadToggle = screen.getByTestId("proxy-overhead-toggle");
+			expect(overheadToggle).toHaveAttribute("aria-expanded", "false");
+
+			fireEvent.click(overheadToggle);
+
+			expect(overheadToggle).toHaveAttribute("aria-expanded", "true");
 			expect(screen.getByText("Request Parsing")).toBeInTheDocument();
 			expect(screen.getByText("Failover Group Lookup")).toBeInTheDocument();
 			expect(screen.getByText("Model Lookup")).toBeInTheDocument();
@@ -853,6 +862,7 @@ describe("LogDetailModal", () => {
 			renderWithProviders(
 				<LogDetailModal log={overheadLog} type="request" onClose={onClose} />,
 			);
+			fireEvent.click(screen.getByTestId("proxy-overhead-toggle"));
 
 			const tooltip = screen.getByTitle(
 				"Time to parse and validate the incoming request body",
@@ -865,6 +875,7 @@ describe("LogDetailModal", () => {
 			renderWithProviders(
 				<LogDetailModal log={overheadLog} type="request" onClose={onClose} />,
 			);
+			fireEvent.click(screen.getByTestId("proxy-overhead-toggle"));
 
 			const tooltip = screen.getByTitle(
 				"Time to resolve the failover group to a specific model and provider",
@@ -877,6 +888,7 @@ describe("LogDetailModal", () => {
 			renderWithProviders(
 				<LogDetailModal log={overheadLog} type="request" onClose={onClose} />,
 			);
+			fireEvent.click(screen.getByTestId("proxy-overhead-toggle"));
 
 			const tooltip = screen.getByTitle(
 				"Time to look up the model configuration in the database",
@@ -889,6 +901,7 @@ describe("LogDetailModal", () => {
 			renderWithProviders(
 				<LogDetailModal log={overheadLog} type="request" onClose={onClose} />,
 			);
+			fireEvent.click(screen.getByTestId("proxy-overhead-toggle"));
 
 			const tooltip = screen.getByTitle(
 				"Time to look up the provider details in the database",
@@ -901,6 +914,7 @@ describe("LogDetailModal", () => {
 			renderWithProviders(
 				<LogDetailModal log={overheadLog} type="request" onClose={onClose} />,
 			);
+			fireEvent.click(screen.getByTestId("proxy-overhead-toggle"));
 
 			const tooltip = screen.getByTitle("Time to decrypt the provider API key");
 			expect(tooltip).toBeInTheDocument();
@@ -911,6 +925,7 @@ describe("LogDetailModal", () => {
 			renderWithProviders(
 				<LogDetailModal log={overheadLog} type="request" onClose={onClose} />,
 			);
+			fireEvent.click(screen.getByTestId("proxy-overhead-toggle"));
 
 			const tooltip = screen.getByTitle(
 				"Time to establish the TCP connection to the upstream provider",
@@ -923,6 +938,7 @@ describe("LogDetailModal", () => {
 			renderWithProviders(
 				<LogDetailModal log={overheadLog} type="request" onClose={onClose} />,
 			);
+			fireEvent.click(screen.getByTestId("proxy-overhead-toggle"));
 
 			// Translated: "Time to read settings from the database" (without "proxy")
 			const tooltip = screen.getByTitle(
@@ -936,6 +952,7 @@ describe("LogDetailModal", () => {
 			renderWithProviders(
 				<LogDetailModal log={overheadLog} type="request" onClose={onClose} />,
 			);
+			fireEvent.click(screen.getByTestId("proxy-overhead-toggle"));
 
 			// Find the Total Overhead label
 			const totalLabel = screen.getByText("Total Overhead");
@@ -1065,6 +1082,7 @@ describe("LogDetailModal", () => {
 			renderWithProviders(
 				<LogDetailModal log={dialReusedLog} type="request" onClose={onClose} />,
 			);
+			fireEvent.click(screen.getByTestId("proxy-overhead-toggle"));
 
 			expect(screen.getByText("Dial (DNS+TCP)")).toBeInTheDocument();
 			expect(screen.getByText("reused")).toBeInTheDocument();
@@ -1095,6 +1113,7 @@ describe("LogDetailModal", () => {
 					onClose={onClose}
 				/>,
 			);
+			fireEvent.click(screen.getByTestId("proxy-overhead-toggle"));
 
 			// Total = 5 (parse) + 0 (others) = 5 → shown as accent-colored value
 			const totalLabel = screen.getByText("Total Overhead");
@@ -1120,6 +1139,7 @@ describe("LogDetailModal", () => {
 			renderWithProviders(
 				<LogDetailModal log={nullFieldsLog} type="request" onClose={onClose} />,
 			);
+			fireEvent.click(screen.getByTestId("proxy-overhead-toggle"));
 
 			expect(screen.getByText("Proxy Overhead Breakdown")).toBeInTheDocument();
 			const totalLabel = screen.getByText("Total Overhead");

--- a/web/src/components/__tests__/RequestLogDetail.cacheHits.test.tsx
+++ b/web/src/components/__tests__/RequestLogDetail.cacheHits.test.tsx
@@ -1,4 +1,4 @@
-import { waitFor } from "@testing-library/react";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import type { LogEntry } from "../../api/types";
 import { renderWithProviders } from "../../test/utils";
@@ -57,6 +57,7 @@ describe("RequestLogDetail cache hit coloring", () => {
 		renderWithProviders(
 			<RequestLogDetail requestLog={log} onClose={onClose} />,
 		);
+		fireEvent.click(screen.getByTestId("proxy-overhead-toggle"));
 
 		await waitFor(() => {
 			const emeraldElements = document.querySelectorAll(".text-emerald-400");
@@ -78,6 +79,7 @@ describe("RequestLogDetail cache hit coloring", () => {
 		renderWithProviders(
 			<RequestLogDetail requestLog={log} onClose={onClose} />,
 		);
+		fireEvent.click(screen.getByTestId("proxy-overhead-toggle"));
 
 		await waitFor(() => {
 			const amberElements = document.querySelectorAll(".text-amber-400");
@@ -89,6 +91,7 @@ describe("RequestLogDetail cache hit coloring", () => {
 		renderWithProviders(
 			<RequestLogDetail requestLog={baseLog} onClose={onClose} />,
 		);
+		fireEvent.click(screen.getByTestId("proxy-overhead-toggle"));
 
 		await waitFor(() => {
 			expect(document.querySelectorAll(".text-emerald-400").length).toBe(0);
@@ -104,6 +107,7 @@ describe("RequestLogDetail cache hit coloring", () => {
 		renderWithProviders(
 			<RequestLogDetail requestLog={log} onClose={onClose} />,
 		);
+		fireEvent.click(screen.getByTestId("proxy-overhead-toggle"));
 
 		await waitFor(() => {
 			const hitTitles = Array.from(document.querySelectorAll("[title]"))
@@ -121,6 +125,7 @@ describe("RequestLogDetail cache hit coloring", () => {
 		renderWithProviders(
 			<RequestLogDetail requestLog={log} onClose={onClose} />,
 		);
+		fireEvent.click(screen.getByTestId("proxy-overhead-toggle"));
 
 		await waitFor(() => {
 			const missTitles = Array.from(document.querySelectorAll("[title]"))

--- a/web/src/components/__tests__/VirtualLogTable.test.tsx
+++ b/web/src/components/__tests__/VirtualLogTable.test.tsx
@@ -193,6 +193,29 @@ describe("VirtualLogTable", () => {
 			expect(screen.getByText("500")).toBeInTheDocument();
 		});
 
+		it("shows a live ticking duration for in-progress rows instead of a dash", () => {
+			const now = new Date("2026-05-23T10:00:05.000Z").getTime();
+			const entries = [
+				createLogEntry({
+					id: "live-1",
+					state: "streaming",
+					duration_ms: 0,
+					created_at: "2026-05-23T10:00:02.000Z", // 3s before now
+				}),
+			];
+			mockGetVirtualItems.mockReturnValue([
+				{ index: 0, key: "live-1", start: 0, end: 29 },
+			]);
+			mockGetTotalSize.mockReturnValue(29);
+
+			renderWithProviders(
+				<VirtualLogTable {...defaultProps} entries={entries} nowMs={now} />,
+			);
+
+			// 3s elapsed since created_at → live "3.0s", not the "-" placeholder.
+			expect(screen.getByText("3.0s")).toBeInTheDocument();
+		});
+
 		it("calls onRowClick with correct entry when row is clicked", async () => {
 			const onRowClick = vi.fn();
 			const entries = [createLogEntry({ id: "log-123" })];

--- a/web/src/i18n/locales/af.json
+++ b/web/src/i18n/locales/af.json
@@ -806,7 +806,12 @@
 			},
 			"unset": "—",
 			"updated": "Metagegewens bygewerk",
-			"unchanged": "Onveranderd"
+			"unchanged": "Onveranderd",
+			"retest": "Hertoets",
+			"retesting": "Hertoets tans…",
+			"retestTooltip": "Voer ontdekking vir hierdie verskaffer weer uit om gedeaktiveerde modelle weer te toets.",
+			"retestDone": "{{provider}} hertoets",
+			"toggleSection": "Wissel {{provider}}-afdeling"
 		}
 	},
 	"models": {
@@ -1861,7 +1866,8 @@
 			"verifying": "Verifikasie...",
 			"downloadCodes": "Laai af as .txt",
 			"downloadCodesAriaLabel": "Laai herstelkodes af as 'n tekslêer",
-			"failedToStart": "Kon nie inskrywing begin nie: {{message}}"
+			"failedToStart": "Kon nie inskrywing begin nie: {{message}}",
+			"enabledOn": "Geaktiveer op {{date}}"
 		}
 	},
 	"components": {
@@ -2298,7 +2304,8 @@
 			"reused": "hergebruik",
 			"totalOverhead": "Totaal oorhoofse koste",
 			"error": "Fout",
-			"copyErrorMessage": "Kopieer foutboodskap"
+			"copyErrorMessage": "Kopieer foutboodskap",
+			"expandForBreakdown": "Brei uit vir die stap-vir-stap-uiteensetting"
 		},
 		"statusBadge": {
 			"streaming": "Stroom",

--- a/web/src/i18n/locales/ar.json
+++ b/web/src/i18n/locales/ar.json
@@ -806,7 +806,12 @@
 			},
 			"unset": "—",
 			"updated": "تم تحديث البيانات الوصفية",
-			"unchanged": "لم يتغير"
+			"unchanged": "لم يتغير",
+			"retest": "إعادة الاختبار",
+			"retesting": "جارٍ إعادة الاختبار…",
+			"retestTooltip": "أعد تشغيل الاكتشاف لهذا المزوّد لإعادة فحص النماذج التي تم تعطيلها.",
+			"retestDone": "تمت إعادة اختبار {{provider}}",
+			"toggleSection": "تبديل قسم {{provider}}"
 		}
 	},
 	"models": {
@@ -1861,7 +1866,8 @@
 			"verifying": "جاري التحقق...",
 			"downloadCodes": "تنزيل بصيغة ‎.txt",
 			"downloadCodesAriaLabel": "تنزيل رموز الاسترداد كملف نصي",
-			"failedToStart": "تعذّر بدء التسجيل: {{message}}"
+			"failedToStart": "تعذّر بدء التسجيل: {{message}}",
+			"enabledOn": "تم التفعيل في {{date}}"
 		}
 	},
 	"components": {
@@ -2298,7 +2304,8 @@
 			"reused": "إعادة الاستخدام",
 			"totalOverhead": "إجمالي النفقات العامة",
 			"error": "خطأ",
-			"copyErrorMessage": "نسخ رسالة الخطأ"
+			"copyErrorMessage": "نسخ رسالة الخطأ",
+			"expandForBreakdown": "وسّع لعرض التفصيل لكل خطوة"
 		},
 		"statusBadge": {
 			"streaming": "البث",

--- a/web/src/i18n/locales/ca.json
+++ b/web/src/i18n/locales/ca.json
@@ -806,7 +806,12 @@
 			},
 			"unset": "—",
 			"updated": "Metadades actualitzades",
-			"unchanged": "Sense canvis"
+			"unchanged": "Sense canvis",
+			"retest": "Reprova",
+			"retesting": "S'està reprovant…",
+			"retestTooltip": "Torna a executar el descobriment d'aquest proveïdor per tornar a provar els models desactivats.",
+			"retestDone": "S'ha reprovat {{provider}}",
+			"toggleSection": "Mostra o amaga la secció {{provider}}"
 		}
 	},
 	"models": {
@@ -1861,7 +1866,8 @@
 			"verifying": "Verificant...",
 			"downloadCodes": "Baixa com a .txt",
 			"downloadCodesAriaLabel": "Baixa els codis de recuperació com a fitxer de text",
-			"failedToStart": "No s'ha pogut iniciar la inscripció: {{message}}"
+			"failedToStart": "No s'ha pogut iniciar la inscripció: {{message}}",
+			"enabledOn": "Activat el {{date}}"
 		}
 	},
 	"components": {
@@ -2298,7 +2304,8 @@
 			"reused": "reutilitzat",
 			"totalOverhead": "Despeses generals totals",
 			"error": "Error",
-			"copyErrorMessage": "Copiar missatge d'error"
+			"copyErrorMessage": "Copiar missatge d'error",
+			"expandForBreakdown": "Desplega per veure el desglossament per passos"
 		},
 		"statusBadge": {
 			"streaming": "Streaming",

--- a/web/src/i18n/locales/cs.json
+++ b/web/src/i18n/locales/cs.json
@@ -806,7 +806,12 @@
 			},
 			"unset": "—",
 			"updated": "Aktualizovaná metadata",
-			"unchanged": "Beze změn"
+			"unchanged": "Beze změn",
+			"retest": "Otestovat znovu",
+			"retesting": "Probíhá nový test…",
+			"retestTooltip": "Spusťte zjišťování pro tohoto poskytovatele znovu a otestujte zakázané modely.",
+			"retestDone": "{{provider}} otestováno znovu",
+			"toggleSection": "Přepnout sekci {{provider}}"
 		}
 	},
 	"models": {
@@ -1861,7 +1866,8 @@
 			"verifying": "Ověřování...",
 			"downloadCodes": "Stáhnout jako .txt",
 			"downloadCodesAriaLabel": "Stáhnout kódy pro obnovení jako textový soubor",
-			"failedToStart": "Nepodařilo se zahájit registraci: {{message}}"
+			"failedToStart": "Nepodařilo se zahájit registraci: {{message}}",
+			"enabledOn": "Aktivováno {{date}}"
 		}
 	},
 	"components": {
@@ -2298,7 +2304,8 @@
 			"reused": "znovu použité",
 			"totalOverhead": "Celkový overhead",
 			"error": "Chyba",
-			"copyErrorMessage": "Zkopírujte chybovou zprávu"
+			"copyErrorMessage": "Zkopírujte chybovou zprávu",
+			"expandForBreakdown": "Rozbalte pro podrobné rozdělení podle kroků"
 		},
 		"statusBadge": {
 			"streaming": "Streamování",

--- a/web/src/i18n/locales/da.json
+++ b/web/src/i18n/locales/da.json
@@ -806,7 +806,12 @@
 			},
 			"unset": "—",
 			"updated": "Metadata opdateret",
-			"unchanged": "Uændret"
+			"unchanged": "Uændret",
+			"retest": "Test igen",
+			"retesting": "Tester igen…",
+			"retestTooltip": "Kør registrering for denne udbyder igen for at teste deaktiverede modeller på ny.",
+			"retestDone": "{{provider}} testet igen",
+			"toggleSection": "Skift {{provider}}-sektion"
 		}
 	},
 	"models": {
@@ -1861,7 +1866,8 @@
 			"verifying": "Bekræfter...",
 			"downloadCodes": "Download som .txt",
 			"downloadCodesAriaLabel": "Download gendannelseskoder som en tekstfil",
-			"failedToStart": "Kunne ikke starte tilmelding: {{message}}"
+			"failedToStart": "Kunne ikke starte tilmelding: {{message}}",
+			"enabledOn": "Aktiveret den {{date}}"
 		}
 	},
 	"components": {
@@ -2298,7 +2304,8 @@
 			"reused": "genbrugt",
 			"totalOverhead": "Samlet Overhead",
 			"error": "Fejl",
-			"copyErrorMessage": "Kopiér fejlmeddelelse"
+			"copyErrorMessage": "Kopiér fejlmeddelelse",
+			"expandForBreakdown": "Udvid for at se opdelingen pr. trin"
 		},
 		"statusBadge": {
 			"streaming": "Streaming",

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -806,7 +806,12 @@
 			},
 			"unset": "—",
 			"updated": "Metadaten aktualisiert",
-			"unchanged": "Unverändert"
+			"unchanged": "Unverändert",
+			"retest": "Erneut testen",
+			"retesting": "Wird erneut getestet…",
+			"retestTooltip": "Erkennung für diesen Anbieter erneut ausführen, um deaktivierte Modelle neu zu prüfen.",
+			"retestDone": "{{provider}} erneut getestet",
+			"toggleSection": "Abschnitt {{provider}} umschalten"
 		}
 	},
 	"models": {
@@ -1861,7 +1866,8 @@
 			"verifying": "Wird überprüft...",
 			"downloadCodes": "Als .txt herunterladen",
 			"downloadCodesAriaLabel": "Wiederherstellungscodes als Textdatei herunterladen",
-			"failedToStart": "Einrichtung konnte nicht gestartet werden: {{message}}"
+			"failedToStart": "Einrichtung konnte nicht gestartet werden: {{message}}",
+			"enabledOn": "Aktiviert am {{date}}"
 		}
 	},
 	"components": {
@@ -2298,7 +2304,8 @@
 			"reused": "wiederverwendet",
 			"totalOverhead": "Gesamt Overhead",
 			"error": "Fehler",
-			"copyErrorMessage": "Fehlermeldung kopieren"
+			"copyErrorMessage": "Fehlermeldung kopieren",
+			"expandForBreakdown": "Für die Aufschlüsselung pro Schritt ausklappen"
 		},
 		"statusBadge": {
 			"streaming": "Streaming",

--- a/web/src/i18n/locales/el.json
+++ b/web/src/i18n/locales/el.json
@@ -806,7 +806,12 @@
 			},
 			"unset": "—",
 			"updated": "Ενημερωμένα μεταδεδομένα",
-			"unchanged": "Χωρίς αλλαγές"
+			"unchanged": "Χωρίς αλλαγές",
+			"retest": "Επανέλεγχος",
+			"retesting": "Επανέλεγχος…",
+			"retestTooltip": "Εκτελέστε ξανά την ανίχνευση για αυτόν τον πάροχο ώστε να επανελεγχθούν τα απενεργοποιημένα μοντέλα.",
+			"retestDone": "Έγινε επανέλεγχος του {{provider}}",
+			"toggleSection": "Εναλλαγή ενότητας {{provider}}"
 		}
 	},
 	"models": {
@@ -1861,7 +1866,8 @@
 			"verifying": "Επαλήθευση...",
 			"downloadCodes": "Λήψη ως .txt",
 			"downloadCodesAriaLabel": "Λήψη κωδικών ανάκτησης ως αρχείο κειμένου",
-			"failedToStart": "Δεν ήταν δυνατή η έναρξη της εγγραφής: {{message}}"
+			"failedToStart": "Δεν ήταν δυνατή η έναρξη της εγγραφής: {{message}}",
+			"enabledOn": "Ενεργοποιήθηκε στις {{date}}"
 		}
 	},
 	"components": {
@@ -2298,7 +2304,8 @@
 			"reused": "επαναχρησιμοποίηση",
 			"totalOverhead": "Σύνολο Υπερβάσεων",
 			"error": "Σφάλμα",
-			"copyErrorMessage": "Αντιγραφή μηνύματος σφάλματος"
+			"copyErrorMessage": "Αντιγραφή μηνύματος σφάλματος",
+			"expandForBreakdown": "Αναπτύξτε για την ανάλυση ανά βήμα"
 		},
 		"statusBadge": {
 			"streaming": "Ροή",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -806,7 +806,12 @@
 				"noProviders": "No enabled providers remain",
 				"onlyOne": "Only one enabled provider remains (failover needs at least two)"
 			},
-			"error": "Error"
+			"error": "Error",
+			"retest": "Retest",
+			"retesting": "Retesting…",
+			"retestTooltip": "Re-run discovery for this provider to re-probe models that were disabled.",
+			"retestDone": "Retested {{provider}}",
+			"toggleSection": "Toggle {{provider}} section"
 		}
 	},
 	"models": {
@@ -1861,7 +1866,8 @@
 			"cancelEnrollAriaLabel": "Cancel TOTP enrollment",
 			"downloadCodes": "Download as .txt",
 			"downloadCodesAriaLabel": "Download recovery codes as a text file",
-			"failedToStart": "Could not start enrollment: {{message}}"
+			"failedToStart": "Could not start enrollment: {{message}}",
+			"enabledOn": "Enabled on {{date}}"
 		}
 	},
 	"components": {
@@ -2298,7 +2304,8 @@
 			"reused": "reused",
 			"totalOverhead": "Total Overhead",
 			"error": "Error",
-			"copyErrorMessage": "Copy error message"
+			"copyErrorMessage": "Copy error message",
+			"expandForBreakdown": "Expand for the per-step breakdown"
 		},
 		"statusBadge": {
 			"streaming": "Streaming",

--- a/web/src/i18n/locales/es.json
+++ b/web/src/i18n/locales/es.json
@@ -806,7 +806,12 @@
 			},
 			"unset": "—",
 			"updated": "Metadatos actualizados",
-			"unchanged": "Sin cambios"
+			"unchanged": "Sin cambios",
+			"retest": "Volver a probar",
+			"retesting": "Volviendo a probar…",
+			"retestTooltip": "Vuelve a ejecutar el descubrimiento de este proveedor para volver a comprobar los modelos desactivados.",
+			"retestDone": "Se ha vuelto a probar {{provider}}",
+			"toggleSection": "Mostrar u ocultar la sección {{provider}}"
 		}
 	},
 	"models": {
@@ -1861,7 +1866,8 @@
 			"verifying": "Comprobando...",
 			"downloadCodes": "Descargar como .txt",
 			"downloadCodesAriaLabel": "Descargar los códigos de recuperación como archivo de texto",
-			"failedToStart": "No se pudo iniciar el registro: {{message}}"
+			"failedToStart": "No se pudo iniciar el registro: {{message}}",
+			"enabledOn": "Activado el {{date}}"
 		}
 	},
 	"components": {
@@ -2298,7 +2304,8 @@
 			"reused": "reutilizado",
 			"totalOverhead": "Total general",
 			"error": "Error",
-			"copyErrorMessage": "Copiar mensaje de error"
+			"copyErrorMessage": "Copiar mensaje de error",
+			"expandForBreakdown": "Expande para ver el desglose por pasos"
 		},
 		"statusBadge": {
 			"streaming": "Transmisión",

--- a/web/src/i18n/locales/fi.json
+++ b/web/src/i18n/locales/fi.json
@@ -806,7 +806,12 @@
 			},
 			"unset": "—",
 			"updated": "Metatiedot päivitetty",
-			"unchanged": "Muuttumaton"
+			"unchanged": "Muuttumaton",
+			"retest": "Testaa uudelleen",
+			"retesting": "Testataan uudelleen…",
+			"retestTooltip": "Suorita tämän palveluntarjoajan tunnistus uudelleen ja testaa käytöstä poistetut mallit.",
+			"retestDone": "{{provider}} testattu uudelleen",
+			"toggleSection": "Näytä tai piilota osio {{provider}}"
 		}
 	},
 	"models": {
@@ -1861,7 +1866,8 @@
 			"verifying": "Tarkistetaan...",
 			"downloadCodes": "Lataa .txt-tiedostona",
 			"downloadCodesAriaLabel": "Lataa palautuskoodit tekstitiedostona",
-			"failedToStart": "Rekisteröinnin aloittaminen epäonnistui: {{message}}"
+			"failedToStart": "Rekisteröinnin aloittaminen epäonnistui: {{message}}",
+			"enabledOn": "Otettu käyttöön {{date}}"
 		}
 	},
 	"components": {
@@ -2298,7 +2304,8 @@
 			"reused": "uudelleenkäytetty",
 			"totalOverhead": "Ilmapiiri Yhteensä",
 			"error": "Virhe",
-			"copyErrorMessage": "Kopioi virheviesti"
+			"copyErrorMessage": "Kopioi virheviesti",
+			"expandForBreakdown": "Laajenna nähdäksesi vaihekohtaisen erittelyn"
 		},
 		"statusBadge": {
 			"streaming": "Suoratoistaminen",

--- a/web/src/i18n/locales/fr.json
+++ b/web/src/i18n/locales/fr.json
@@ -806,7 +806,12 @@
 			},
 			"unset": "—",
 			"updated": "Métadonnées mises à jour",
-			"unchanged": "Inchangé"
+			"unchanged": "Inchangé",
+			"retest": "Retester",
+			"retesting": "Nouveau test…",
+			"retestTooltip": "Relancez la découverte pour ce fournisseur afin de retester les modèles désactivés.",
+			"retestDone": "{{provider}} retesté",
+			"toggleSection": "Afficher ou masquer la section {{provider}}"
 		}
 	},
 	"models": {
@@ -1861,7 +1866,8 @@
 			"verifying": "Vérification en cours...",
 			"downloadCodes": "Télécharger en .txt",
 			"downloadCodesAriaLabel": "Télécharger les codes de récupération dans un fichier texte",
-			"failedToStart": "Impossible de démarrer l'enregistrement : {{message}}"
+			"failedToStart": "Impossible de démarrer l'enregistrement : {{message}}",
+			"enabledOn": "Activé le {{date}}"
 		}
 	},
 	"components": {
@@ -2298,7 +2304,8 @@
 			"reused": "réutilisé",
 			"totalOverhead": "Total au dessus",
 			"error": "Erreur",
-			"copyErrorMessage": "Copier le message d'erreur"
+			"copyErrorMessage": "Copier le message d'erreur",
+			"expandForBreakdown": "Développez pour voir le détail par étape"
 		},
 		"statusBadge": {
 			"streaming": "Streaming en cours",

--- a/web/src/i18n/locales/he.json
+++ b/web/src/i18n/locales/he.json
@@ -806,7 +806,12 @@
 			},
 			"unset": "—",
 			"updated": "מטא-נתונים עודכנו",
-			"unchanged": "ללא שינוי"
+			"unchanged": "ללא שינוי",
+			"retest": "בדיקה חוזרת",
+			"retesting": "מבצע בדיקה חוזרת…",
+			"retestTooltip": "הרץ שוב את הגילוי עבור ספק זה כדי לבדוק מחדש מודלים שהושבתו.",
+			"retestDone": "{{provider}} נבדק מחדש",
+			"toggleSection": "החלף את מקטע {{provider}}"
 		}
 	},
 	"models": {
@@ -1861,7 +1866,8 @@
 			"verifying": "בודקים...",
 			"downloadCodes": "הורד כקובץ ‎.txt",
 			"downloadCodesAriaLabel": "הורד את קודי השחזור כקובץ טקסט",
-			"failedToStart": "לא ניתן להתחיל את הרישום: {{message}}"
+			"failedToStart": "לא ניתן להתחיל את הרישום: {{message}}",
+			"enabledOn": "הופעל בתאריך {{date}}"
 		}
 	},
 	"components": {
@@ -2298,7 +2304,8 @@
 			"reused": "בשימוש חוזר",
 			"totalOverhead": "הוצאות כלליות",
 			"error": "שגיאה",
-			"copyErrorMessage": "העתק את הודעת השגיאה"
+			"copyErrorMessage": "העתק את הודעת השגיאה",
+			"expandForBreakdown": "הרחב לפירוט לפי שלבים"
 		},
 		"statusBadge": {
 			"streaming": "סטרימינג",

--- a/web/src/i18n/locales/hu.json
+++ b/web/src/i18n/locales/hu.json
@@ -806,7 +806,12 @@
 			},
 			"unset": "—",
 			"updated": "Frissített metaadatok",
-			"unchanged": "Változatlan"
+			"unchanged": "Változatlan",
+			"retest": "Újratesztelés",
+			"retesting": "Újratesztelés…",
+			"retestTooltip": "Futtassa újra a felfedezést ehhez a szolgáltatóhoz a letiltott modellek újbóli ellenőrzéséhez.",
+			"retestDone": "{{provider}} újratesztelve",
+			"toggleSection": "{{provider}} szakasz be- és kikapcsolása"
 		}
 	},
 	"models": {
@@ -1861,7 +1866,8 @@
 			"verifying": "Ellenőrzés folyamatban...",
 			"downloadCodes": "Letöltés .txt-ként",
 			"downloadCodesAriaLabel": "Helyreállítási kódok letöltése szövegfájlként",
-			"failedToStart": "Nem sikerült elindítani a regisztrációt: {{message}}"
+			"failedToStart": "Nem sikerült elindítani a regisztrációt: {{message}}",
+			"enabledOn": "Engedélyezve: {{date}}"
 		}
 	},
 	"components": {
@@ -2298,7 +2304,8 @@
 			"reused": "újrahasznosított",
 			"totalOverhead": "Teljes általános költség",
 			"error": "Hiba",
-			"copyErrorMessage": "Hibaüzenet másolása"
+			"copyErrorMessage": "Hibaüzenet másolása",
+			"expandForBreakdown": "Bontsa ki a lépésenkénti bontáshoz"
 		},
 		"statusBadge": {
 			"streaming": "Streaming",

--- a/web/src/i18n/locales/it.json
+++ b/web/src/i18n/locales/it.json
@@ -806,7 +806,12 @@
 			},
 			"unset": "—",
 			"updated": "Metadati aggiornati",
-			"unchanged": "Invariato"
+			"unchanged": "Invariato",
+			"retest": "Riprova",
+			"retesting": "Nuovo test…",
+			"retestTooltip": "Riesegui il rilevamento per questo provider per riprovare i modelli disattivati.",
+			"retestDone": "{{provider}} ritestato",
+			"toggleSection": "Mostra o nascondi la sezione {{provider}}"
 		}
 	},
 	"models": {
@@ -1861,7 +1866,8 @@
 			"verifying": "Verifica in corso...",
 			"downloadCodes": "Scarica come .txt",
 			"downloadCodesAriaLabel": "Scarica i codici di recupero come file di testo",
-			"failedToStart": "Impossibile avviare la registrazione: {{message}}"
+			"failedToStart": "Impossibile avviare la registrazione: {{message}}",
+			"enabledOn": "Attivato il {{date}}"
 		}
 	},
 	"components": {
@@ -2298,7 +2304,8 @@
 			"reused": "riutilizzato",
 			"totalOverhead": "Totale Overhead",
 			"error": "Errore",
-			"copyErrorMessage": "Copia messaggio di errore"
+			"copyErrorMessage": "Copia messaggio di errore",
+			"expandForBreakdown": "Espandi per il dettaglio per passaggio"
 		},
 		"statusBadge": {
 			"streaming": "Streaming",

--- a/web/src/i18n/locales/ja.json
+++ b/web/src/i18n/locales/ja.json
@@ -806,7 +806,12 @@
 			},
 			"unset": "—",
 			"updated": "メタデータが更新されました",
-			"unchanged": "変更なし"
+			"unchanged": "変更なし",
+			"retest": "再テスト",
+			"retesting": "再テスト中…",
+			"retestTooltip": "このプロバイダーの探索を再実行して、無効化されたモデルを再確認します。",
+			"retestDone": "{{provider}} を再テストしました",
+			"toggleSection": "{{provider}} セクションの表示切り替え"
 		}
 	},
 	"models": {
@@ -1861,7 +1866,8 @@
 			"verifying": "確認中...",
 			"downloadCodes": ".txt でダウンロード",
 			"downloadCodesAriaLabel": "リカバリーコードをテキストファイルとしてダウンロード",
-			"failedToStart": "登録を開始できませんでした: {{message}}"
+			"failedToStart": "登録を開始できませんでした: {{message}}",
+			"enabledOn": "{{date}} に有効化"
 		}
 	},
 	"components": {
@@ -2298,7 +2304,8 @@
 			"reused": "再利用しました",
 			"totalOverhead": "総オーバーヘッド数",
 			"error": "エラー",
-			"copyErrorMessage": "エラーメッセージをコピー"
+			"copyErrorMessage": "エラーメッセージをコピー",
+			"expandForBreakdown": "ステップごとの内訳を表示するには展開してください"
 		},
 		"statusBadge": {
 			"streaming": "ストリーミング",

--- a/web/src/i18n/locales/ko.json
+++ b/web/src/i18n/locales/ko.json
@@ -806,7 +806,12 @@
 			},
 			"unset": "—",
 			"updated": "메타데이터 업데이트됨",
-			"unchanged": "변경 없음"
+			"unchanged": "변경 없음",
+			"retest": "다시 테스트",
+			"retesting": "다시 테스트 중…",
+			"retestTooltip": "이 공급자에 대한 검색을 다시 실행하여 비활성화된 모델을 다시 확인합니다.",
+			"retestDone": "{{provider}} 다시 테스트함",
+			"toggleSection": "{{provider}} 섹션 전환"
 		}
 	},
 	"models": {
@@ -1861,7 +1866,8 @@
 			"verifying": "확인 중...",
 			"downloadCodes": ".txt로 다운로드",
 			"downloadCodesAriaLabel": "복구 코드를 텍스트 파일로 다운로드",
-			"failedToStart": "등록을 시작할 수 없습니다: {{message}}"
+			"failedToStart": "등록을 시작할 수 없습니다: {{message}}",
+			"enabledOn": "{{date}}에 활성화됨"
 		}
 	},
 	"components": {
@@ -2298,7 +2304,8 @@
 			"reused": "재사용된",
 			"totalOverhead": "총 간접비",
 			"error": "오류",
-			"copyErrorMessage": "오류 메시지 복사"
+			"copyErrorMessage": "오류 메시지 복사",
+			"expandForBreakdown": "단계별 분석을 보려면 펼치세요"
 		},
 		"statusBadge": {
 			"streaming": "스트리밍",

--- a/web/src/i18n/locales/nl.json
+++ b/web/src/i18n/locales/nl.json
@@ -806,7 +806,12 @@
 			},
 			"unset": "—",
 			"updated": "Metadata bijgewerkt",
-			"unchanged": "Ongewijzigd"
+			"unchanged": "Ongewijzigd",
+			"retest": "Opnieuw testen",
+			"retesting": "Opnieuw testen…",
+			"retestTooltip": "Voer detectie voor deze provider opnieuw uit om uitgeschakelde modellen opnieuw te testen.",
+			"retestDone": "{{provider}} opnieuw getest",
+			"toggleSection": "Sectie {{provider}} in-/uitklappen"
 		}
 	},
 	"models": {
@@ -1861,7 +1866,8 @@
 			"verifying": "Wordt gecontroleerd...",
 			"downloadCodes": "Downloaden als .txt",
 			"downloadCodesAriaLabel": "Herstelcodes downloaden als tekstbestand",
-			"failedToStart": "Kan inschrijving niet starten: {{message}}"
+			"failedToStart": "Kan inschrijving niet starten: {{message}}",
+			"enabledOn": "Ingeschakeld op {{date}}"
 		}
 	},
 	"components": {
@@ -2298,7 +2304,8 @@
 			"reused": "hergebruikt",
 			"totalOverhead": "Totale overschrijving",
 			"error": "Foutmelding",
-			"copyErrorMessage": "Foutmelding kopiëren"
+			"copyErrorMessage": "Foutmelding kopiëren",
+			"expandForBreakdown": "Vouw uit voor de uitsplitsing per stap"
 		},
 		"statusBadge": {
 			"streaming": "Streamen",

--- a/web/src/i18n/locales/no.json
+++ b/web/src/i18n/locales/no.json
@@ -806,7 +806,12 @@
 			},
 			"unset": "—",
 			"updated": "Metadata oppdatert",
-			"unchanged": "Uendret"
+			"unchanged": "Uendret",
+			"retest": "Test på nytt",
+			"retesting": "Tester på nytt…",
+			"retestTooltip": "Kjør oppdagelse for denne leverandøren på nytt for å teste deaktiverte modeller igjen.",
+			"retestDone": "{{provider}} testet på nytt",
+			"toggleSection": "Veksle {{provider}}-seksjon"
 		}
 	},
 	"models": {
@@ -1861,7 +1866,8 @@
 			"verifying": "Bekrefter...",
 			"downloadCodes": "Last ned som .txt",
 			"downloadCodesAriaLabel": "Last ned gjenopprettingskoder som en tekstfil",
-			"failedToStart": "Kunne ikke starte registrering: {{message}}"
+			"failedToStart": "Kunne ikke starte registrering: {{message}}",
+			"enabledOn": "Aktivert {{date}}"
 		}
 	},
 	"components": {
@@ -2298,7 +2304,8 @@
 			"reused": "gjenbrukt",
 			"totalOverhead": "Totalt overhode",
 			"error": "Feil",
-			"copyErrorMessage": "Kopier feilmelding"
+			"copyErrorMessage": "Kopier feilmelding",
+			"expandForBreakdown": "Utvid for fordelingen per trinn"
 		},
 		"statusBadge": {
 			"streaming": "Strømming",

--- a/web/src/i18n/locales/pl.json
+++ b/web/src/i18n/locales/pl.json
@@ -806,7 +806,12 @@
 			},
 			"unset": "—",
 			"updated": "Zaktualizowane metadane",
-			"unchanged": "Bez zmian"
+			"unchanged": "Bez zmian",
+			"retest": "Przetestuj ponownie",
+			"retesting": "Ponowne testowanie…",
+			"retestTooltip": "Uruchom ponownie wykrywanie dla tego dostawcy, aby ponownie sprawdzić wyłączone modele.",
+			"retestDone": "Ponownie przetestowano {{provider}}",
+			"toggleSection": "Przełącz sekcję {{provider}}"
 		}
 	},
 	"models": {
@@ -1861,7 +1866,8 @@
 			"verifying": "W trakcie weryfikacji...",
 			"downloadCodes": "Pobierz jako .txt",
 			"downloadCodesAriaLabel": "Pobierz kody odzyskiwania jako plik tekstowy",
-			"failedToStart": "Nie można rozpocząć rejestracji: {{message}}"
+			"failedToStart": "Nie można rozpocząć rejestracji: {{message}}",
+			"enabledOn": "Włączono {{date}}"
 		}
 	},
 	"components": {
@@ -2298,7 +2304,8 @@
 			"reused": "ponownie wykorzystane",
 			"totalOverhead": "Łącznie",
 			"error": "Błąd",
-			"copyErrorMessage": "Kopiuj komunikat o błędzie"
+			"copyErrorMessage": "Kopiuj komunikat o błędzie",
+			"expandForBreakdown": "Rozwiń, aby zobaczyć podział na kroki"
 		},
 		"statusBadge": {
 			"streaming": "Strumieniowanie",

--- a/web/src/i18n/locales/pt.json
+++ b/web/src/i18n/locales/pt.json
@@ -806,7 +806,12 @@
 			},
 			"unset": "—",
 			"updated": "Metadados atualizados",
-			"unchanged": "Sem alterações"
+			"unchanged": "Sem alterações",
+			"retest": "Testar novamente",
+			"retesting": "Testando novamente…",
+			"retestTooltip": "Execute novamente a descoberta deste provedor para testar de novo os modelos desativados.",
+			"retestDone": "{{provider}} testado novamente",
+			"toggleSection": "Alternar a seção {{provider}}"
 		}
 	},
 	"models": {
@@ -1861,7 +1866,8 @@
 			"verifying": "Verificando...",
 			"downloadCodes": "Baixar como .txt",
 			"downloadCodesAriaLabel": "Baixar os códigos de recuperação como arquivo de texto",
-			"failedToStart": "Não foi possível iniciar o registo: {{message}}"
+			"failedToStart": "Não foi possível iniciar o registo: {{message}}",
+			"enabledOn": "Ativado em {{date}}"
 		}
 	},
 	"components": {
@@ -2298,7 +2304,8 @@
 			"reused": "reutilizado",
 			"totalOverhead": "Sobrecarga total",
 			"error": "ERRO",
-			"copyErrorMessage": "Copiar mensagem de erro"
+			"copyErrorMessage": "Copiar mensagem de erro",
+			"expandForBreakdown": "Expanda para ver o detalhamento por etapa"
 		},
 		"statusBadge": {
 			"streaming": "Transmitindo",

--- a/web/src/i18n/locales/ro.json
+++ b/web/src/i18n/locales/ro.json
@@ -806,7 +806,12 @@
 			},
 			"unset": "—",
 			"updated": "Metadate actualizate",
-			"unchanged": "Neschimbat"
+			"unchanged": "Neschimbat",
+			"retest": "Retestează",
+			"retesting": "Se retestează…",
+			"retestTooltip": "Rulează din nou descoperirea pentru acest furnizor pentru a retesta modelele dezactivate.",
+			"retestDone": "{{provider}} a fost retestat",
+			"toggleSection": "Comută secțiunea {{provider}}"
 		}
 	},
 	"models": {
@@ -1861,7 +1866,8 @@
 			"verifying": "Se verifică...",
 			"downloadCodes": "Descarcă ca .txt",
 			"downloadCodesAriaLabel": "Descarcă codurile de recuperare ca fișier text",
-			"failedToStart": "Nu s-a putut începe înregistrarea: {{message}}"
+			"failedToStart": "Nu s-a putut începe înregistrarea: {{message}}",
+			"enabledOn": "Activat la {{date}}"
 		}
 	},
 	"components": {
@@ -2298,7 +2304,8 @@
 			"reused": "reutilizat",
 			"totalOverhead": "Total cheltuieli",
 			"error": "Eroare",
-			"copyErrorMessage": "Copiază mesajul de eroare"
+			"copyErrorMessage": "Copiază mesajul de eroare",
+			"expandForBreakdown": "Extinde pentru defalcarea pe pași"
 		},
 		"statusBadge": {
 			"streaming": "Streaming",

--- a/web/src/i18n/locales/ru.json
+++ b/web/src/i18n/locales/ru.json
@@ -806,7 +806,12 @@
 			},
 			"unset": "—",
 			"updated": "Метаданные обновлены",
-			"unchanged": "Без изменений"
+			"unchanged": "Без изменений",
+			"retest": "Повторить проверку",
+			"retesting": "Повторная проверка…",
+			"retestTooltip": "Запустите обнаружение для этого провайдера повторно, чтобы перепроверить отключённые модели.",
+			"retestDone": "{{provider}} повторно проверен",
+			"toggleSection": "Переключить раздел {{provider}}"
 		}
 	},
 	"models": {
@@ -1861,7 +1866,8 @@
 			"verifying": "Проверка...",
 			"downloadCodes": "Скачать как .txt",
 			"downloadCodesAriaLabel": "Скачать коды восстановления в виде текстового файла",
-			"failedToStart": "Не удалось начать регистрацию: {{message}}"
+			"failedToStart": "Не удалось начать регистрацию: {{message}}",
+			"enabledOn": "Включено {{date}}"
 		}
 	},
 	"components": {
@@ -2298,7 +2304,8 @@
 			"reused": "повторно использовано",
 			"totalOverhead": "Всего накладных",
 			"error": "Ошибка",
-			"copyErrorMessage": "Копировать сообщение об ошибке"
+			"copyErrorMessage": "Копировать сообщение об ошибке",
+			"expandForBreakdown": "Разверните для пошаговой разбивки"
 		},
 		"statusBadge": {
 			"streaming": "Вещание",

--- a/web/src/i18n/locales/sk.json
+++ b/web/src/i18n/locales/sk.json
@@ -806,7 +806,12 @@
 			},
 			"unset": "—",
 			"updated": "Aktualizované metadáta",
-			"unchanged": "Bez zmien"
+			"unchanged": "Bez zmien",
+			"retest": "Otestovať znova",
+			"retesting": "Prebieha nový test…",
+			"retestTooltip": "Znova spustite zisťovanie pre tohto poskytovateľa a otestujte zakázané modely.",
+			"retestDone": "{{provider}} znova otestované",
+			"toggleSection": "Prepnúť sekciu {{provider}}"
 		}
 	},
 	"models": {
@@ -1861,7 +1866,8 @@
 			"verifying": "Overovanie...",
 			"downloadCodes": "Stiahnuť ako .txt",
 			"downloadCodesAriaLabel": "Stiahnuť obnovovacie kódy ako textový súbor",
-			"failedToStart": "Nepodarilo sa spustiť registráciu: {{message}}"
+			"failedToStart": "Nepodarilo sa spustiť registráciu: {{message}}",
+			"enabledOn": "Aktivované {{date}}"
 		}
 	},
 	"components": {
@@ -2298,7 +2304,8 @@
 			"reused": "opätovne použitý",
 			"totalOverhead": "Celkové režijné náklady",
 			"error": "Chyba",
-			"copyErrorMessage": "Skopírujte chybovú správu"
+			"copyErrorMessage": "Skopírujte chybovú správu",
+			"expandForBreakdown": "Rozbaľte pre podrobné rozdelenie podľa krokov"
 		},
 		"statusBadge": {
 			"streaming": "Streamovanie",

--- a/web/src/i18n/locales/sr.json
+++ b/web/src/i18n/locales/sr.json
@@ -806,7 +806,12 @@
 			},
 			"unset": "—",
 			"updated": "Метаподаци ажурирани",
-			"unchanged": "Непромењено"
+			"unchanged": "Непромењено",
+			"retest": "Поново тестирај",
+			"retesting": "Поновно тестирање…",
+			"retestTooltip": "Поново покрените откривање за овог добављача да бисте поново проверили онемогућене моделе.",
+			"retestDone": "{{provider}} поново тестиран",
+			"toggleSection": "Прикажи/сакриј одељак {{provider}}"
 		}
 	},
 	"models": {
@@ -1861,7 +1866,8 @@
 			"verifying": "Верификација...",
 			"downloadCodes": "Преузми као .txt",
 			"downloadCodesAriaLabel": "Преузми кодове за опоравак као текстуалну датотеку",
-			"failedToStart": "Није могуће започети регистрацију: {{message}}"
+			"failedToStart": "Није могуће започети регистрацију: {{message}}",
+			"enabledOn": "Омогућено {{date}}"
 		}
 	},
 	"components": {
@@ -2298,7 +2304,8 @@
 			"reused": "поново искоришћено",
 			"totalOverhead": "Укупни режијски трошкови",
 			"error": "Грешка",
-			"copyErrorMessage": "Копирајте поруку о грешци"
+			"copyErrorMessage": "Копирајте поруку о грешци",
+			"expandForBreakdown": "Прошири за рашчлањавање по корацима"
 		},
 		"statusBadge": {
 			"streaming": "Стриминг",

--- a/web/src/i18n/locales/sv.json
+++ b/web/src/i18n/locales/sv.json
@@ -806,7 +806,12 @@
 			},
 			"unset": "—",
 			"updated": "Metadata uppdaterad",
-			"unchanged": "Oförändrat"
+			"unchanged": "Oförändrat",
+			"retest": "Testa igen",
+			"retesting": "Testar igen…",
+			"retestTooltip": "Kör identifiering för den här leverantören igen för att testa inaktiverade modeller på nytt.",
+			"retestDone": "{{provider}} testad igen",
+			"toggleSection": "Växla {{provider}}-sektion"
 		}
 	},
 	"models": {
@@ -1861,7 +1866,8 @@
 			"verifying": "Verifierar...",
 			"downloadCodes": "Ladda ner som .txt",
 			"downloadCodesAriaLabel": "Ladda ner återställningskoder som en textfil",
-			"failedToStart": "Det gick inte att starta registreringen: {{message}}"
+			"failedToStart": "Det gick inte att starta registreringen: {{message}}",
+			"enabledOn": "Aktiverat {{date}}"
 		}
 	},
 	"components": {
@@ -2298,7 +2304,8 @@
 			"reused": "återanvänd",
 			"totalOverhead": "Totalt Overhead",
 			"error": "Fel",
-			"copyErrorMessage": "Kopiera felmeddelande"
+			"copyErrorMessage": "Kopiera felmeddelande",
+			"expandForBreakdown": "Expandera för uppdelningen per steg"
 		},
 		"statusBadge": {
 			"streaming": "Strömning",

--- a/web/src/i18n/locales/tr.json
+++ b/web/src/i18n/locales/tr.json
@@ -806,7 +806,12 @@
 			},
 			"unset": "—",
 			"updated": "Metadata güncellendi",
-			"unchanged": "Değiştirilmedi"
+			"unchanged": "Değiştirilmedi",
+			"retest": "Yeniden test et",
+			"retesting": "Yeniden test ediliyor…",
+			"retestTooltip": "Devre dışı bırakılan modelleri yeniden denemek için bu sağlayıcı için keşfi yeniden çalıştırın.",
+			"retestDone": "{{provider}} yeniden test edildi",
+			"toggleSection": "{{provider}} bölümünü aç/kapat"
 		}
 	},
 	"models": {
@@ -1861,7 +1866,8 @@
 			"verifying": "Doğrulanıyor...",
 			"downloadCodes": ".txt olarak indir",
 			"downloadCodesAriaLabel": "Kurtarma kodlarını metin dosyası olarak indir",
-			"failedToStart": "Kayıt başlatılamadı: {{message}}"
+			"failedToStart": "Kayıt başlatılamadı: {{message}}",
+			"enabledOn": "{{date}} tarihinde etkinleştirildi"
 		}
 	},
 	"components": {
@@ -2298,7 +2304,8 @@
 			"reused": "yeniden kullanılmış",
 			"totalOverhead": "Toplam ek yük",
 			"error": "Hata",
-			"copyErrorMessage": "Hata mesajını kopyala"
+			"copyErrorMessage": "Hata mesajını kopyala",
+			"expandForBreakdown": "Adım adım dökümü görmek için genişletin"
 		},
 		"statusBadge": {
 			"streaming": "Canlı yayın",

--- a/web/src/i18n/locales/uk.json
+++ b/web/src/i18n/locales/uk.json
@@ -806,7 +806,12 @@
 			},
 			"unset": "—",
 			"updated": "Оновлено метадані",
-			"unchanged": "Без змін"
+			"unchanged": "Без змін",
+			"retest": "Повторити перевірку",
+			"retesting": "Повторна перевірка…",
+			"retestTooltip": "Запустіть виявлення для цього постачальника повторно, щоб перевірити вимкнені моделі.",
+			"retestDone": "{{provider}} повторно перевірено",
+			"toggleSection": "Перемкнути розділ {{provider}}"
 		}
 	},
 	"models": {
@@ -1861,7 +1866,8 @@
 			"verifying": "Перевірка...",
 			"downloadCodes": "Завантажити як .txt",
 			"downloadCodesAriaLabel": "Завантажити коди відновлення як текстовий файл",
-			"failedToStart": "Не вдалося почати реєстрацію: {{message}}"
+			"failedToStart": "Не вдалося почати реєстрацію: {{message}}",
+			"enabledOn": "Увімкнено {{date}}"
 		}
 	},
 	"components": {
@@ -2298,7 +2304,8 @@
 			"reused": "повторно використовується",
 			"totalOverhead": "Всього накладних витрат",
 			"error": "Помилка",
-			"copyErrorMessage": "Скопіювати повідомлення про помилку"
+			"copyErrorMessage": "Скопіювати повідомлення про помилку",
+			"expandForBreakdown": "Розгорніть для покрокового розподілу"
 		},
 		"statusBadge": {
 			"streaming": "Трансляція",

--- a/web/src/i18n/locales/vi.json
+++ b/web/src/i18n/locales/vi.json
@@ -806,7 +806,12 @@
 			},
 			"unset": "—",
 			"updated": "Siêu dữ liệu được cập nhật",
-			"unchanged": "Không thay đổi"
+			"unchanged": "Không thay đổi",
+			"retest": "Kiểm tra lại",
+			"retesting": "Đang kiểm tra lại…",
+			"retestTooltip": "Chạy lại quá trình khám phá cho nhà cung cấp này để kiểm tra lại các mô hình đã bị tắt.",
+			"retestDone": "Đã kiểm tra lại {{provider}}",
+			"toggleSection": "Bật/tắt phần {{provider}}"
 		}
 	},
 	"models": {
@@ -1861,7 +1866,8 @@
 			"verifying": "Đang xác minh...",
 			"downloadCodes": "Tải xuống dạng .txt",
 			"downloadCodesAriaLabel": "Tải mã khôi phục xuống dưới dạng tệp văn bản",
-			"failedToStart": "Không thể bắt đầu đăng ký: {{message}}"
+			"failedToStart": "Không thể bắt đầu đăng ký: {{message}}",
+			"enabledOn": "Đã bật vào {{date}}"
 		}
 	},
 	"components": {
@@ -2298,7 +2304,8 @@
 			"reused": "đã được tái sử dụng",
 			"totalOverhead": "Tổng chi phí quản lý",
 			"error": "Lỗi",
-			"copyErrorMessage": "Sao chép thông báo lỗi"
+			"copyErrorMessage": "Sao chép thông báo lỗi",
+			"expandForBreakdown": "Mở rộng để xem chi tiết theo từng bước"
 		},
 		"statusBadge": {
 			"streaming": "Phát trực tuyến",

--- a/web/src/i18n/locales/zh.json
+++ b/web/src/i18n/locales/zh.json
@@ -806,7 +806,12 @@
 			},
 			"unset": "—",
 			"updated": "元数据已更新",
-			"unchanged": "保持不变"
+			"unchanged": "保持不变",
+			"retest": "重新测试",
+			"retesting": "正在重新测试…",
+			"retestTooltip": "重新运行此提供商的发现，以重新探测被禁用的模型。",
+			"retestDone": "已重新测试 {{provider}}",
+			"toggleSection": "切换 {{provider}} 部分"
 		}
 	},
 	"models": {
@@ -1861,7 +1866,8 @@
 			"verifying": "正在验证...",
 			"downloadCodes": "下载为 .txt",
 			"downloadCodesAriaLabel": "将恢复码下载为文本文件",
-			"failedToStart": "无法开始注册：{{message}}"
+			"failedToStart": "无法开始注册：{{message}}",
+			"enabledOn": "于 {{date}} 启用"
 		}
 	},
 	"components": {
@@ -2298,7 +2304,8 @@
 			"reused": "已重新使用",
 			"totalOverhead": "总管理费",
 			"error": "错误",
-			"copyErrorMessage": "复制错误消息"
+			"copyErrorMessage": "复制错误消息",
+			"expandForBreakdown": "展开以查看分步明细"
 		},
 		"statusBadge": {
 			"streaming": "流流",

--- a/web/src/pages/Logs.tsx
+++ b/web/src/pages/Logs.tsx
@@ -39,10 +39,12 @@ import { useDebounce } from "../hooks/useDebounce";
 import { useLocalStorage } from "../hooks/useLocalStorage";
 import { encodeCursor, formatNumber } from "../utils/format";
 import {
+	formatDurationCell,
 	getRowStatusVariant,
 	isCancelled,
 	isInProgress as isInProgressShared,
 	isStale as isStaleShared,
+	liveDurationMs,
 } from "../utils/logHelpers";
 import { AppLogs } from "./AppLogs";
 import { formatMs, formatTPS } from "./Logs/utils";
@@ -319,12 +321,21 @@ function RequestLogs() {
 	const staleMs = parseGoDuration(settings?.stale_request_timeout || "30m0s");
 	const STALE_THRESHOLD_MS = staleMs > 0 ? staleMs : 30 * 60 * 1000;
 	const [nowMs, setNowMs] = useState(() => Date.now());
+	// In-progress rows show a live-ticking duration, so when any are present we
+	// tick every second; otherwise a coarse 60s tick is enough to age rows into
+	// the "stale" state without re-rendering the table needlessly.
+	const hasLiveEntries = displayEntries.some(
+		(log) => log.state === "pending" || log.state === "streaming",
+	);
 	useEffect(() => {
-		const id = setInterval(() => {
-			setNowMs(Date.now());
-		}, 60_000);
+		const id = setInterval(
+			() => {
+				setNowMs(Date.now());
+			},
+			hasLiveEntries ? 1_000 : 60_000,
+		);
 		return () => clearInterval(id);
-	}, []);
+	}, [hasLiveEntries]);
 
 	const isStale = (log: LogEntry) =>
 		isStaleShared(log, nowMs, STALE_THRESHOLD_MS);
@@ -719,14 +730,12 @@ function RequestLogs() {
 												<td className="px-2 py-1 whitespace-nowrap text-xs text-gray-400 font-mono">
 													{isInProgress(log) && log.duration_ms === 0 ? (
 														<span className="inline-block text-blue-400">
-															-
+															{formatDurationCell(
+																liveDurationMs(log.created_at, nowMs),
+															)}
 														</span>
 													) : log.duration_ms > 0 ? (
-														log.duration_ms >= 1000 ? (
-															`${(log.duration_ms / 1000).toFixed(1)}s`
-														) : (
-															`${log.duration_ms.toFixed(0)}ms`
-														)
+														formatDurationCell(log.duration_ms)
 													) : (
 														"-"
 													)}

--- a/web/src/pages/Providers.tsx
+++ b/web/src/pages/Providers.tsx
@@ -35,6 +35,7 @@ import {
 } from "./Providers/DiscoverySummaryModal";
 import { EditProviderModal } from "./Providers/EditProviderModal";
 import { ProviderCard } from "./Providers/ProviderCard";
+import { useDiscoveryRetest } from "./Providers/useDiscoveryRetest";
 
 export function Providers() {
 	const queryClient = useQueryClient();
@@ -135,6 +136,9 @@ export function Providers() {
 						providerName: r.provider_name,
 						diff: r.diff,
 						error: r.error,
+						// discover-all results carry only a name; resolve the ID from the
+						// loaded providers list so the Retest action can re-probe by ID.
+						providerId: providers?.find((p) => p.name === r.provider_name)?.id,
 					})),
 				);
 			}
@@ -189,7 +193,7 @@ export function Providers() {
 			queryClient.invalidateQueries({ queryKey: ["providers"] });
 			queryClient.invalidateQueries({ queryKey: ["models"] });
 			const providerName = providers?.find((p) => p.id === id)?.name ?? id;
-			setDiscoverySummary([{ providerName, diff: data.diff }]);
+			setDiscoverySummary([{ providerName, diff: data.diff, providerId: id }]);
 		},
 		onError: (err: Error) => {
 			toast(
@@ -201,6 +205,21 @@ export function Providers() {
 			setDiscoveringId(null);
 		},
 	});
+
+	// Retest re-runs discovery for a single provider straight from the summary
+	// modal and patches just that provider's entry with the fresh diff, leaving
+	// the rest of the summary intact.
+	const { onRetest, retestingKey } = useDiscoveryRetest((key, diff) =>
+		setDiscoverySummary((prev) =>
+			prev
+				? prev.map((e) =>
+						(e.entryKey ?? e.providerName) === key
+							? { ...e, diff, error: undefined }
+							: e,
+					)
+				: prev,
+		),
+	);
 
 	const deleteMutation = useMutation({
 		mutationFn: (id: string) => api.providers.delete(id),
@@ -429,6 +448,8 @@ export function Providers() {
 				<DiscoverySummaryModal
 					results={discoverySummary}
 					onClose={() => setDiscoverySummary(null)}
+					onRetest={onRetest}
+					retestingKey={retestingKey}
 				/>
 			)}
 

--- a/web/src/pages/Providers/DiscoverySummaryModal.tsx
+++ b/web/src/pages/Providers/DiscoverySummaryModal.tsx
@@ -451,11 +451,15 @@ export function DiscoverySummaryModal({
 								) : (
 									renderDiffBody(r)
 								)}
-								{!showHeaders && renderRetestButton(r) && (
-									<div className="flex justify-end">
-										{renderRetestButton(r)}
-									</div>
-								)}
+								{!showHeaders &&
+									(() => {
+										// Build the button once; the truthiness check and the
+										// rendered node must not be two separate calls.
+										const retest = renderRetestButton(r);
+										return retest ? (
+											<div className="flex justify-end">{retest}</div>
+										) : null;
+									})()}
 							</div>
 						))}
 						{unchanged.length > 0 && (

--- a/web/src/pages/Providers/DiscoverySummaryModal.tsx
+++ b/web/src/pages/Providers/DiscoverySummaryModal.tsx
@@ -1,7 +1,8 @@
-import type { ReactNode } from "react";
+import { type ReactNode, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { DiscoveryDiff } from "../../api/types";
 import { Modal } from "../../components/Modal";
+import { ChevronDown, ChevronRight, RefreshCw } from "../../lib/icons";
 import { formatTokens } from "../../utils/format";
 import { formatPrice } from "../../utils/model";
 
@@ -33,6 +34,10 @@ export interface DiscoverySummaryEntry {
 	 * (e.g. several background runs recorded before review). Falls back to
 	 * providerName, which is unique for a single discovery response. */
 	entryKey?: string;
+	/** Provider ID, when known. Enables the per-provider "Retest" action that
+	 * re-runs discovery to re-probe models disabled during the original run.
+	 * Background entries that only carry a provider name leave this unset. */
+	providerId?: string;
 }
 
 // The backend stores failover deletion reasons as pre-existing English
@@ -105,7 +110,7 @@ function CategoryGroup({
 function Chip({ label, mono }: { label: string; mono?: boolean }) {
 	return (
 		<span
-			className={`inline-flex max-w-full items-center truncate rounded-md border border-(--border-default) bg-(--surface-elevated) px-1.5 py-0.5 text-[11px] text-(--text-secondary) ${
+			className={`inline-flex max-w-full items-center truncate rounded-(--radius-box) border border-(--border-default) bg-(--surface-elevated) px-1.5 py-0.5 text-[11px] text-(--text-secondary) ${
 				mono ? "font-mono" : ""
 			}`}
 			title={label}
@@ -141,11 +146,52 @@ function DetailRow({
 export function DiscoverySummaryModal({
 	results,
 	onClose,
+	onRetest,
+	retestingKey,
 }: {
 	results: DiscoverySummaryEntry[];
 	onClose: () => void;
+	/** Re-run discovery for one provider (re-probes models disabled during the
+	 * original run). Omit to hide the per-provider Retest action. */
+	onRetest?: (entry: DiscoverySummaryEntry) => void;
+	/** entryKey of the provider whose retest is currently in flight, if any. */
+	retestingKey?: string;
 }) {
 	const { t } = useTranslation();
+
+	// Provider sections start expanded; users collapse the ones they have already
+	// reviewed. Keyed by entryKey so duplicate provider names stay independent.
+	const [collapsed, setCollapsed] = useState<Set<string>>(() => new Set());
+	const toggleCollapsed = (key: string) =>
+		setCollapsed((prev) => {
+			const next = new Set(prev);
+			if (next.has(key)) next.delete(key);
+			else next.add(key);
+			return next;
+		});
+
+	// A small Retest button for providers that had a model disabled this run.
+	// Re-running discovery re-probes those models so a transient provider hiccup
+	// can be cleared without disabling/re-enabling by hand.
+	const renderRetestButton = (r: DiscoverySummaryEntry) => {
+		if (!onRetest || !r.providerId || !r.diff?.disabled?.length) return null;
+		const isRetesting = retestingKey === entryKeyOf(r);
+		return (
+			<button
+				type="button"
+				onClick={() => onRetest(r)}
+				disabled={isRetesting}
+				title={t("providers.discoverySummary.retestTooltip")}
+				className="ui-btn ui-btn-secondary ui-btn-compact inline-flex shrink-0 items-center gap-1.5 disabled:cursor-not-allowed disabled:opacity-50"
+				data-testid="discovery-summary-retest"
+			>
+				<RefreshCw size={13} className={isRetesting ? "animate-spin" : ""} />
+				{isRetesting
+					? t("providers.discoverySummary.retesting")
+					: t("providers.discoverySummary.retest")}
+			</button>
+		);
+	};
 
 	// Membership categories share the chip-cloud body; only the sign/color/label
 	// differ. The reason is implied by the category, so it is not repeated per row.
@@ -177,7 +223,7 @@ export function DiscoverySummaryModal({
 		if (r.error) {
 			return (
 				<div
-					className="flex items-start gap-2 rounded-md border border-(--border-default) bg-(--surface-elevated) px-2.5 py-2 text-sm"
+					className="flex items-start gap-2 rounded-(--radius-box) border border-(--border-default) bg-(--surface-elevated) px-2.5 py-2 text-sm"
 					data-testid="discovery-summary-error"
 				>
 					<span className="ui-badge ui-badge-error shrink-0">
@@ -223,7 +269,7 @@ export function DiscoverySummaryModal({
 							{diff.updated.map((u) => (
 								<div
 									key={u.model_id}
-									className="rounded-md border border-(--border-default) bg-(--surface-elevated) px-2.5 py-2"
+									className="rounded-(--radius-box) border border-(--border-default) bg-(--surface-elevated) px-2.5 py-2"
 								>
 									<div
 										className="truncate font-mono text-xs text-(--text-primary)"
@@ -287,7 +333,7 @@ export function DiscoverySummaryModal({
 						label={t("providers.discoverySummary.failoverDeleted")}
 						testId="discovery-summary-failover-deleted"
 					>
-						<div className="space-y-1 rounded-md border border-(--border-default) bg-(--surface-elevated) px-2.5 py-2">
+						<div className="space-y-1 rounded-(--radius-box) border border-(--border-default) bg-(--surface-elevated) px-2.5 py-2">
 							{diff.failover_deleted_groups.map((g) => (
 								<DetailRow
 									key={g.display_model}
@@ -310,7 +356,7 @@ export function DiscoverySummaryModal({
 						label={t("providers.discoverySummary.failoverUpdated")}
 						testId="discovery-summary-failover-updated"
 					>
-						<div className="space-y-1 rounded-md border border-(--border-default) bg-(--surface-elevated) px-2.5 py-2">
+						<div className="space-y-1 rounded-(--radius-box) border border-(--border-default) bg-(--surface-elevated) px-2.5 py-2">
 							{diff.failover_updated_groups.map((g) => (
 								<DetailRow
 									key={g.display_model}
@@ -368,15 +414,48 @@ export function DiscoverySummaryModal({
 					<>
 						{visible.map((r) => (
 							<div key={entryKeyOf(r)} className="space-y-3">
-								{showHeaders && (
+								{showHeaders ? (
 									<div className="flex items-center gap-2">
-										<span className="text-sm font-semibold text-(--text-primary)">
-											{r.providerName}
-										</span>
-										<span className="h-px flex-1 bg-(--border-default)" />
+										<button
+											type="button"
+											onClick={() => toggleCollapsed(entryKeyOf(r))}
+											aria-expanded={!collapsed.has(entryKeyOf(r))}
+											aria-label={t(
+												"providers.discoverySummary.toggleSection",
+												{ provider: r.providerName },
+											)}
+											className="flex min-w-0 flex-1 items-center gap-2 text-sm font-semibold text-(--text-primary)"
+											data-testid="discovery-summary-toggle"
+										>
+											<span className="truncate">{r.providerName}</span>
+											<span className="h-px flex-1 bg-(--border-default)" />
+											{collapsed.has(entryKeyOf(r)) ? (
+												<ChevronRight size={14} className="shrink-0" />
+											) : (
+												<ChevronDown size={14} className="shrink-0" />
+											)}
+										</button>
+										{renderRetestButton(r)}
+									</div>
+								) : null}
+								{showHeaders ? (
+									<div
+										className={`grid transition-[grid-template-rows] duration-300 ease-in-out ${
+											collapsed.has(entryKeyOf(r))
+												? "grid-rows-[0fr]"
+												: "grid-rows-[1fr]"
+										}`}
+									>
+										<div className="overflow-hidden">{renderDiffBody(r)}</div>
+									</div>
+								) : (
+									renderDiffBody(r)
+								)}
+								{!showHeaders && renderRetestButton(r) && (
+									<div className="flex justify-end">
+										{renderRetestButton(r)}
 									</div>
 								)}
-								{renderDiffBody(r)}
 							</div>
 						))}
 						{unchanged.length > 0 && (

--- a/web/src/pages/Providers/__tests__/DiscoverySummaryModal.test.tsx
+++ b/web/src/pages/Providers/__tests__/DiscoverySummaryModal.test.tsx
@@ -186,4 +186,80 @@ describe("DiscoverySummaryModal", () => {
 			expect(onClose).toHaveBeenCalled();
 		});
 	});
+
+	it("collapses a provider section when its header toggle is clicked", async () => {
+		const { user } = renderWithProviders(
+			<DiscoverySummaryModal
+				results={[
+					{ providerName: "Provider A", diff: fullDiff },
+					{ providerName: "Provider B", diff: fullDiff },
+				]}
+				onClose={vi.fn()}
+			/>,
+		);
+
+		// Both providers expanded by default. The body animates via the
+		// grid-rows trick, so it stays mounted while collapsed; assert the
+		// accessible expanded state rather than DOM presence.
+		const toggles = screen.getAllByTestId("discovery-summary-toggle");
+		expect(toggles[0]).toHaveAttribute("aria-expanded", "true");
+
+		// Collapse the first provider's section.
+		await user.click(toggles[0]);
+
+		expect(toggles[0]).toHaveAttribute("aria-expanded", "false");
+		// The second provider stays expanded.
+		expect(toggles[1]).toHaveAttribute("aria-expanded", "true");
+	});
+
+	it("shows a Retest button for a provider with disabled models and fires onRetest", async () => {
+		const onRetest = vi.fn();
+		const { user } = renderWithProviders(
+			<DiscoverySummaryModal
+				results={[
+					{ providerName: "Flaky Provider", providerId: "p1", diff: fullDiff },
+				]}
+				onClose={vi.fn()}
+				onRetest={onRetest}
+			/>,
+		);
+
+		const retest = screen.getByTestId("discovery-summary-retest");
+		await user.click(retest);
+		expect(onRetest).toHaveBeenCalledWith(
+			expect.objectContaining({ providerId: "p1" }),
+		);
+	});
+
+	it("hides the Retest button without a providerId or when the diff has no disabled models", () => {
+		const noDisabled: DiscoveryDiff = {
+			added: [{ model_id: "model-new", reason: "new_model" }],
+		};
+		const { rerender } = renderWithProviders(
+			<DiscoverySummaryModal
+				results={[
+					{ providerName: "No ID", diff: fullDiff }, // disabled but no providerId
+				]}
+				onClose={vi.fn()}
+				onRetest={vi.fn()}
+			/>,
+		);
+		expect(
+			screen.queryByTestId("discovery-summary-retest"),
+		).not.toBeInTheDocument();
+
+		// providerId present but nothing disabled → still hidden.
+		rerender(
+			<DiscoverySummaryModal
+				results={[
+					{ providerName: "No Disabled", providerId: "p2", diff: noDisabled },
+				]}
+				onClose={vi.fn()}
+				onRetest={vi.fn()}
+			/>,
+		);
+		expect(
+			screen.queryByTestId("discovery-summary-retest"),
+		).not.toBeInTheDocument();
+	});
 });

--- a/web/src/pages/Providers/__tests__/useDiscoveryRetest.test.tsx
+++ b/web/src/pages/Providers/__tests__/useDiscoveryRetest.test.tsx
@@ -1,0 +1,96 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { DiscoveryDiff } from "../../../api/types";
+import { AllProviders } from "../../../test/utils";
+import type { DiscoverySummaryEntry } from "../DiscoverySummaryModal";
+import { useDiscoveryRetest } from "../useDiscoveryRetest";
+
+const discover = vi.fn();
+vi.mock("../../../api/client", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../../../api/client")>();
+	return {
+		...actual,
+		api: {
+			...actual.api,
+			providers: {
+				...actual.api.providers,
+				discover: (id: string) => discover(id),
+			},
+		},
+	};
+});
+
+const diff: DiscoveryDiff = {
+	added: [{ model_id: "m", reason: "new_model" }],
+};
+
+describe("useDiscoveryRetest", () => {
+	beforeEach(() => {
+		discover.mockReset();
+	});
+
+	it("re-runs discovery and patches the entry on success", async () => {
+		discover.mockResolvedValue({ discovered: 1, diff });
+		const patchEntry = vi.fn();
+		const { result } = renderHook(() => useDiscoveryRetest(patchEntry), {
+			wrapper: AllProviders,
+		});
+		const entry: DiscoverySummaryEntry = {
+			providerName: "Prov",
+			providerId: "p1",
+			diff,
+		};
+
+		act(() => {
+			result.current.onRetest(entry);
+		});
+
+		await waitFor(() => expect(patchEntry).toHaveBeenCalledWith("Prov", diff));
+		expect(discover).toHaveBeenCalledWith("p1");
+		// retestingKey clears once the mutation settles.
+		await waitFor(() => expect(result.current.retestingKey).toBeUndefined());
+	});
+
+	it("marks the entryKey as retesting while the request is in flight", async () => {
+		let resolveDiscover: (value: unknown) => void = () => {};
+		discover.mockReturnValue(
+			new Promise((resolve) => {
+				resolveDiscover = resolve;
+			}),
+		);
+		const { result } = renderHook(() => useDiscoveryRetest(vi.fn()), {
+			wrapper: AllProviders,
+		});
+		const entry: DiscoverySummaryEntry = {
+			providerName: "Prov",
+			entryKey: "k1",
+			providerId: "p1",
+		};
+
+		act(() => {
+			result.current.onRetest(entry);
+		});
+
+		await waitFor(() => expect(result.current.retestingKey).toBe("k1"));
+
+		act(() => {
+			resolveDiscover({ discovered: 0, diff: {} });
+		});
+		await waitFor(() => expect(result.current.retestingKey).toBeUndefined());
+	});
+
+	it("never hits the API for an entry without a providerId", async () => {
+		const patchEntry = vi.fn();
+		const { result } = renderHook(() => useDiscoveryRetest(patchEntry), {
+			wrapper: AllProviders,
+		});
+
+		act(() => {
+			result.current.onRetest({ providerName: "NoId" });
+		});
+
+		await waitFor(() => expect(result.current.retestingKey).toBeUndefined());
+		expect(discover).not.toHaveBeenCalled();
+		expect(patchEntry).not.toHaveBeenCalled();
+	});
+});

--- a/web/src/pages/Providers/useDiscoveryRetest.ts
+++ b/web/src/pages/Providers/useDiscoveryRetest.ts
@@ -28,8 +28,15 @@ export function useDiscoveryRetest(
 	);
 
 	const mutation = useMutation({
-		mutationFn: (entry: DiscoverySummaryEntry) =>
-			api.providers.discover(entry.providerId as string),
+		mutationFn: (entry: DiscoverySummaryEntry) => {
+			// Retest is only ever wired up for entries with a providerId (the modal
+			// hides the button otherwise), but guard here instead of casting so a
+			// missing id fails loudly rather than hitting /providers/undefined/discover.
+			if (!entry.providerId) {
+				return Promise.reject(new Error("retest requires a providerId"));
+			}
+			return api.providers.discover(entry.providerId);
+		},
 		onMutate: (entry) => {
 			setRetestingKey(keyOf(entry));
 		},

--- a/web/src/pages/Providers/useDiscoveryRetest.ts
+++ b/web/src/pages/Providers/useDiscoveryRetest.ts
@@ -1,0 +1,62 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { api } from "../../api/client";
+import type { DiscoveryDiff } from "../../api/types";
+import { useToast } from "../../context/ToastContext";
+import type { DiscoverySummaryEntry } from "./DiscoverySummaryModal";
+
+/** Stable key for a summary entry, matching the modal's entryKeyOf. */
+const keyOf = (entry: DiscoverySummaryEntry): string =>
+	entry.entryKey ?? entry.providerName;
+
+/**
+ * Shared "Retest" behaviour for the discovery summary modal: re-runs discovery
+ * for one provider (re-probing models disabled during the original run) and
+ * hands the fresh diff back to `patchEntry` so the caller can update just that
+ * provider's row in place. Used by both the Providers page (foreground discover)
+ * and the global Layout (background changes modal).
+ */
+export function useDiscoveryRetest(
+	patchEntry: (key: string, diff: DiscoveryDiff) => void,
+) {
+	const queryClient = useQueryClient();
+	const { toast } = useToast();
+	const { t } = useTranslation();
+	const [retestingKey, setRetestingKey] = useState<string | undefined>(
+		undefined,
+	);
+
+	const mutation = useMutation({
+		mutationFn: (entry: DiscoverySummaryEntry) =>
+			api.providers.discover(entry.providerId as string),
+		onMutate: (entry) => {
+			setRetestingKey(keyOf(entry));
+		},
+		onSuccess: (data, entry) => {
+			queryClient.invalidateQueries({ queryKey: ["providers"] });
+			queryClient.invalidateQueries({ queryKey: ["models"] });
+			patchEntry(keyOf(entry), data.diff);
+			toast(
+				t("providers.discoverySummary.retestDone", {
+					provider: entry.providerName,
+				}),
+				"success",
+			);
+		},
+		onError: (err: Error) => {
+			toast(
+				t("providers.toast_discover_failed", { message: err.message }),
+				"error",
+			);
+		},
+		onSettled: () => {
+			setRetestingKey(undefined);
+		},
+	});
+
+	return {
+		onRetest: (entry: DiscoverySummaryEntry) => mutation.mutate(entry),
+		retestingKey,
+	};
+}

--- a/web/src/pages/Settings/TotpSettings.tsx
+++ b/web/src/pages/Settings/TotpSettings.tsx
@@ -6,6 +6,7 @@ import { Check, Copy, Download, ShieldCheck, X } from "@/lib/icons";
 import { api, setAdminToken } from "../../api/client";
 import { SettingsSection } from "../../components/SettingsSection";
 import { useToast } from "../../context/ToastContext";
+import { formatDate } from "../../utils/format";
 
 interface TotpSettingsProps {
 	collapsed: boolean;
@@ -342,6 +343,13 @@ export function TotpSettings({ collapsed, onToggle }: TotpSettingsProps) {
 							{t("settings.totp.disable")}
 						</button>
 					</div>
+					{status?.enabled_at && (
+						<p className="text-(--text-tertiary) text-sm">
+							{t("settings.totp.enabledOn", {
+								date: formatDate(status.enabled_at),
+							})}
+						</p>
+					)}
 					{disabling && (
 						<div className="space-y-3">
 							<p className="text-(--text-secondary) text-sm">

--- a/web/src/pages/Settings/__tests__/TotpSettings.test.tsx
+++ b/web/src/pages/Settings/__tests__/TotpSettings.test.tsx
@@ -14,10 +14,14 @@ const RECOVERY_CODES = [
 	"1111-2222-3333-4444",
 ];
 
-/** Register a status handler returning {enabled}. First-match-wins. */
-function mockStatus(enabled: boolean) {
+/** Register a status handler returning {enabled, enabled_at?}. First-match-wins. */
+function mockStatus(enabled: boolean, enabledAt?: string) {
 	server.use(
-		http.get("/api/totp/status", () => HttpResponse.json({ enabled })),
+		http.get("/api/totp/status", () =>
+			HttpResponse.json(
+				enabledAt ? { enabled, enabled_at: enabledAt } : { enabled },
+			),
+		),
 	);
 }
 
@@ -267,6 +271,18 @@ describe("TotpSettings", () => {
 		).toBeInTheDocument();
 		// Enabled badge present
 		expect(screen.getByText("Enabled")).toBeInTheDocument();
+	});
+
+	it("shows when 2FA was enabled, formatted, when enabled_at is present", async () => {
+		mockStatus(true, "2026-04-21T09:30:00Z");
+
+		renderWithProviders(<TotpSettings collapsed={false} onToggle={() => {}} />);
+
+		// "Enabled on {{date}}"; formatDate renders day/short-month/year, whose
+		// component order is locale-dependent, so assert on stable parts.
+		const line = await screen.findByText(/Enabled on/);
+		expect(line.textContent).toMatch(/Apr/);
+		expect(line.textContent).toMatch(/2026/);
 	});
 
 	it("disable flow submits the code", async () => {

--- a/web/src/pages/__tests__/Logs.view-modes.test.tsx
+++ b/web/src/pages/__tests__/Logs.view-modes.test.tsx
@@ -470,7 +470,7 @@ describe("Logs", () => {
 	});
 
 	describe("In-Progress Duration", () => {
-		it("displays blue dash for in-progress requests with zero duration", async () => {
+		it("displays a live blue duration for in-progress requests with zero duration", async () => {
 			server.use(
 				http.get("/api/logs", () =>
 					HttpResponse.json(
@@ -493,18 +493,18 @@ describe("Logs", () => {
 				expect(screen.getByText("inprogress-001")).toBeInTheDocument();
 			});
 
-			// Find the duration cell - should have blue dash
+			// In-progress rows show a live-ticking elapsed duration (blue), computed
+			// from created_at, rather than the old dash placeholder.
 			const row = screen.getByText("inprogress-001").closest("tr");
 			if (row) {
 				const cells = within(row).getAllByRole("cell");
-				// Find cell with dash that has blue styling
-				const dashCell = cells.find(
+				const liveCell = cells.find(
 					(cell) =>
-						cell.textContent === "-" &&
+						/^(\d+ms|\d+\.\d+s)$/.test(cell.textContent?.trim() ?? "") &&
 						(cell.className?.includes("blue") ||
 							cell.querySelector("[class*='blue']")),
 				);
-				expect(dashCell).toBeInTheDocument();
+				expect(liveCell).toBeInTheDocument();
 			}
 		});
 	});

--- a/web/src/utils/__tests__/logHelpers.test.ts
+++ b/web/src/utils/__tests__/logHelpers.test.ts
@@ -1,5 +1,32 @@
 import { describe, expect, it } from "vitest";
-import { isCancelled } from "../logHelpers";
+import { formatDurationCell, isCancelled, liveDurationMs } from "../logHelpers";
+
+describe("liveDurationMs", () => {
+	it("returns the gap between created_at and now", () => {
+		const created = "2026-06-20T12:00:00.000Z";
+		const now = new Date("2026-06-20T12:00:03.500Z").getTime();
+		expect(liveDurationMs(created, now)).toBe(3500);
+	});
+
+	it("clamps to 0 when now precedes created_at (clock skew)", () => {
+		const created = "2026-06-20T12:00:05.000Z";
+		const now = new Date("2026-06-20T12:00:00.000Z").getTime();
+		expect(liveDurationMs(created, now)).toBe(0);
+	});
+});
+
+describe("formatDurationCell", () => {
+	it("formats sub-second durations as whole milliseconds", () => {
+		expect(formatDurationCell(0)).toBe("0ms");
+		expect(formatDurationCell(742)).toBe("742ms");
+		expect(formatDurationCell(999)).toBe("999ms");
+	});
+
+	it("formats >= 1s durations as seconds with one decimal", () => {
+		expect(formatDurationCell(1000)).toBe("1.0s");
+		expect(formatDurationCell(3500)).toBe("3.5s");
+	});
+});
 
 describe("isCancelled", () => {
 	it("returns false for undefined", () => {

--- a/web/src/utils/__tests__/logHelpers.test.ts
+++ b/web/src/utils/__tests__/logHelpers.test.ts
@@ -13,6 +13,11 @@ describe("liveDurationMs", () => {
 		const now = new Date("2026-06-20T12:00:00.000Z").getTime();
 		expect(liveDurationMs(created, now)).toBe(0);
 	});
+
+	it("returns 0 (never NaN) for an unparseable created_at", () => {
+		expect(liveDurationMs("", Date.now())).toBe(0);
+		expect(liveDurationMs("not-a-date", Date.now())).toBe(0);
+	});
 });
 
 describe("formatDurationCell", () => {

--- a/web/src/utils/format.ts
+++ b/web/src/utils/format.ts
@@ -48,6 +48,13 @@ export function formatTimestamp(ts: number | string): string {
 	});
 }
 
+// Defer the singular/plural choice to ICU plural rules (Intl.PluralRules) for the
+// active runtime locale instead of a hardcoded n === 1 check. Kept dependency-free
+// like formatDate below (default locale). Callers pass the two grammatical forms;
+// languages with richer plural systems should use i18next count keys (key_one /
+// key_other) at the call site, as FailoverGroups does, and pass the resolved forms.
+const pluralRules = new Intl.PluralRules();
+
 /**
  * Returns a count-prefixed label with proper singular/plural using ICU plural rules.
  * 0 → just the plural noun (e.g. "Models")
@@ -61,8 +68,9 @@ export function countLabel(
 ): string {
 	const n = count ?? 0;
 	if (n === 0) return plural;
-	if (n === 1) return `1 ${singular}`;
-	return `${n} ${plural}`;
+	return pluralRules.select(n) === "one"
+		? `${n} ${singular}`
+		: `${n} ${plural}`;
 }
 
 export function formatDate(ts: number | string): string {

--- a/web/src/utils/logHelpers.ts
+++ b/web/src/utils/logHelpers.ts
@@ -52,7 +52,8 @@ export const isCancelled = (
  * duration on pending/streaming rows whose final duration_ms is not set yet.
  */
 export const liveDurationMs = (createdAt: string, nowMs: number): number =>
-	Math.max(0, nowMs - new Date(createdAt).getTime());
+	// `|| 0` swallows NaN from an unparseable created_at so we never render "NaNms".
+	Math.max(0, nowMs - new Date(createdAt).getTime() || 0);
 
 /**
  * Formats a request duration for the compact log-table duration cell: seconds

--- a/web/src/utils/logHelpers.ts
+++ b/web/src/utils/logHelpers.ts
@@ -45,6 +45,24 @@ export const isCancelled = (
 	return isCancelledMessage(log.error_message);
 };
 
+/**
+ * Live elapsed time (ms) for an in-progress request: the gap between its
+ * created_at and the caller's ticking "now". Clamped to >= 0 so a slightly
+ * lagging clock never renders a negative duration. Used to show a running
+ * duration on pending/streaming rows whose final duration_ms is not set yet.
+ */
+export const liveDurationMs = (createdAt: string, nowMs: number): number =>
+	Math.max(0, nowMs - new Date(createdAt).getTime());
+
+/**
+ * Formats a request duration for the compact log-table duration cell: seconds
+ * with one decimal at >= 1s, whole milliseconds below that. Shared by both the
+ * paginated and virtualized tables (and live in-progress rows) so they format
+ * identically.
+ */
+export const formatDurationCell = (ms: number): string =>
+	ms >= 1000 ? `${(ms / 1000).toFixed(1)}s` : `${ms.toFixed(0)}ms`;
+
 export type StatusBadgeVariant =
 	| "error"
 	| "warning"

--- a/wiki/Development.md
+++ b/wiki/Development.md
@@ -434,10 +434,10 @@ Before committing changes:
 Locale files in `web/src/i18n/locales/` are the single source of truth (the project previously synced with Crowdin; that integration was removed). The workflow when adding user-facing strings:
 
 1. Add the key to `en.json` AND to all 28 other locales.
-2. **Translate the new keys by hand** into each locale, keeping `{{placeholders}}`, `<tags>`, acronyms, and brand names verbatim. `make i18n-fill` / `bootstrap` (DeepL, needs `DEEPL_API_KEY`) are **legacy and currently non-functional**: the free DeepL quota is exhausted and will not refresh until ~May 2027 (HTTP 456), so do not rely on them. The quickest correct way is a one-off script that reuses `tools/i18n-translate/translate.py`'s `load_locale`/`set_path`/`save_locale` helpers (preserves nesting + formatting).
+2. **Translate the new keys by hand** into each locale, keeping `{{placeholders}}`, `<tags>`, acronyms, and brand names verbatim. The quickest correct way is a one-off script that reuses `tools/i18n-translate/translate.py`'s `load_locale`/`set_path`/`save_locale` helpers (preserves nesting + formatting).
 3. Intentionally-English values (brand names, loanwords like "Failover", or a word genuinely identical in some language) belong in `tools/i18n-translate/allow-english.json`.
 
-`make i18n-check` is the CI gate: it runs **offline** (no network, no DeepL) and fails on missing keys, broken `{{placeholder}}` parity, or non-allowlisted English values. Translation corrections are welcome as plain PRs against the locale files.
+`make i18n-check` is the CI gate: it runs **offline** (no network) and fails on missing keys, broken `{{placeholder}}` parity, or non-allowlisted English values. Translation corrections are welcome as plain PRs against the locale files.
 
 ## Development Workflow
 


### PR DESCRIPTION
Batch of small UI/UX polish fixes the user reported, plus DeepL removal and review-fix follow-ups.

## Changes

**Logs**
- In-progress rows now show a live running duration ticking up from `created_at` (adaptive 1s ticker while any row is pending/streaming) instead of `-` until completion. Shared `formatDurationCell` / `liveDurationMs` helpers, with a NaN guard so an unparseable timestamp never renders `NaNms`.

**Discovery diff modal**
- Collapsible provider sections (chevron at the right end of the line, animated open/close via the project's `grid-rows` accordion convention).
- Per-provider **Retest** button that re-probes models disabled during a run (re-runs discovery for that provider). Discovery already retries transient failures with linear backoff + jitter; a disabled model is otherwise only re-probed on the next run, which Retest triggers.
- Squared pills/chips in the terminal theme (`rounded-(--radius-box)`).

**Models nav badge**
- Prefix the discovery-change count with a `±` sign so it reads as a count of changes ("incidents"), not a total model count.

**TOTP settings**
- Show a human-readable "Enabled on \<date\>" line in the enabled view (new `EnabledAt` repo method + `enabled_at` in the status API). Disabled-path test asserts the timestamp is not leaked.

**Request detail**
- Proxy Overhead Breakdown is now collapsible, collapsed by default showing the total with a hint to expand, animated like the rest. Chevron moved to the right end of the header.

**Tooling/docs**
- Remove DeepL entirely (quota exhausted). `translate.py` keeps the offline `check` + locale/allowlist helpers; new keys are hand-translated across all 29 locales and gated by `make i18n-check`.
- `countLabel` now selects singular/plural via `Intl.PluralRules` instead of a hardcoded `n === 1`, per the AGENTS.md i18n rule.
- `docker-compose.test.yml` test-db gets `restart: unless-stopped` so the local test DB survives reboots (still no volume; data stays ephemeral).

## Testing
- Frontend: `pnpm exec tsc -b` clean, biome clean, affected vitest suites green (logHelpers, format/Models countLabel, DiscoverySummaryModal, LogDetailModal, RequestLogDetail.cacheHits, TotpSettings, Logs view-modes).
- Backend: `go test ./internal/api/ -run TestTotpStatus` green against the test DB.
- i18n: `make i18n-check` in sync.
- Visually verified in a local rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)