### PR TITLE
perf(totp): memoize confirmed_at so /totp/status stops a per-poll DB read

### DIFF
--- a/internal/api/totp_handlers.go
+++ b/internal/api/totp_handlers.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"strconv"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -31,9 +32,11 @@ type TotpHandler struct {
 	loginThrottle      *totp.Throttle        // per-IP exponential backoff on failed /totp/login
 	// confirmed_at cache for /totp/status. The stamp is set once at enrollment
 	// and never changes until disable/re-enroll, so a polled status endpoint can
-	// serve it from memory instead of reading the DB on every call. Populated
-	// lazily on the first enabled read; cleared on enable and disable.
+	// serve it from memory instead of reading the DB on every call. Read lock-free
+	// off the hot path; populated lazily on the first enabled read and cleared on
+	// enable/disable, both serialized by enabledAtMu.
 	enabledAtCache atomic.Pointer[time.Time]
+	enabledAtMu    sync.Mutex
 }
 
 // NewTotpHandler constructs a TotpHandler wired to the shared TOTP-enabled cache.
@@ -133,12 +136,28 @@ func (h *TotpHandler) cachedEnabledAt(ctx context.Context) string {
 	if h.totpRepo == nil {
 		return ""
 	}
+	// Hold the lock across the read+store so a since-replaced enrollment can't be
+	// published after an invalidation: invalidateEnabledAt takes the same lock, so
+	// a racing enable/disable runs either fully before this read (we then read the
+	// fresh value) or fully after the store (it clears our value). The miss path
+	// runs at most once per enable, so the lock is effectively uncontended.
+	h.enabledAtMu.Lock()
+	defer h.enabledAtMu.Unlock()
 	at, ok, err := h.totpRepo.EnabledAt(ctx)
 	if err != nil || !ok {
 		return ""
 	}
 	h.enabledAtCache.Store(&at)
 	return at.UTC().Format(time.RFC3339)
+}
+
+// invalidateEnabledAt drops the cached confirmed_at under the same lock
+// cachedEnabledAt holds while populating, so an in-flight miss reading a
+// since-replaced enrollment can never republish its stale stamp afterward.
+func (h *TotpHandler) invalidateEnabledAt() {
+	h.enabledAtMu.Lock()
+	h.enabledAtCache.Store(nil)
+	h.enabledAtMu.Unlock()
 }
 
 // EnrollStart generates a new TOTP secret and returns the otpauth URI + secret.
@@ -195,7 +214,7 @@ func (h *TotpHandler) EnrollVerify(w http.ResponseWriter, r *http.Request) {
 	h.refreshTotpEnabled(r.Context())
 	// Drop the stale confirmed_at so the next status read picks up this
 	// enrollment's fresh stamp.
-	h.enabledAtCache.Store(nil)
+	h.invalidateEnabledAt()
 	// Mint a session token so the admin who just enabled 2FA stays logged in.
 	// Enabling invalidates the raw admin token their browser was using, so
 	// without this the dashboard's next calls 401 and it looks like the app
@@ -238,7 +257,7 @@ func (h *TotpHandler) Disable(w http.ResponseWriter, r *http.Request) {
 	}
 	h.refreshTotpEnabled(r.Context())
 	// Clear the cached stamp so a later re-enrollment doesn't serve this one.
-	h.enabledAtCache.Store(nil)
+	h.invalidateEnabledAt()
 	writeJSON(w, map[string]bool{"disabled": true})
 }
 

--- a/internal/api/totp_handlers.go
+++ b/internal/api/totp_handlers.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"strconv"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -28,6 +29,11 @@ type TotpHandler struct {
 	totpEnabled        func() bool           // shared cached state (Handler.TotpEnabled)
 	refreshTotpEnabled func(context.Context) // refresh cache after mutations (Handler.RefreshTotpEnabled)
 	loginThrottle      *totp.Throttle        // per-IP exponential backoff on failed /totp/login
+	// confirmed_at cache for /totp/status. The stamp is set once at enrollment
+	// and never changes until disable/re-enroll, so a polled status endpoint can
+	// serve it from memory instead of reading the DB on every call. Populated
+	// lazily on the first enabled read; cleared on enable and disable.
+	enabledAtCache atomic.Pointer[time.Time]
 }
 
 // NewTotpHandler constructs a TotpHandler wired to the shared TOTP-enabled cache.
@@ -104,17 +110,35 @@ type statusResponse struct {
 
 // Status reports the TOTP-enabled state. The enabled flag comes from the shared
 // cached value so the login UI's view matches what AuthMiddleware enforces; when
-// enabled it also surfaces confirmed_at (one indexed single-row read) so the
-// settings panel can show when 2FA was turned on.
+// enabled it also surfaces confirmed_at (served from the in-memory cache, so a
+// polled status endpoint stays DB-free on the hot path) for the settings panel.
 func (h *TotpHandler) Status(w http.ResponseWriter, r *http.Request) {
 	enabled := h.totpEnabled != nil && h.totpEnabled()
 	resp := statusResponse{Enabled: enabled}
-	if enabled && h.totpRepo != nil {
-		if at, ok, err := h.totpRepo.EnabledAt(r.Context()); err == nil && ok {
-			resp.EnabledAt = at.UTC().Format(time.RFC3339)
-		}
+	if enabled {
+		resp.EnabledAt = h.cachedEnabledAt(r.Context())
 	}
 	writeJSON(w, resp)
+}
+
+// cachedEnabledAt returns the RFC3339 confirmation time, reading the DB at most
+// once per enable: the value never changes while TOTP stays enabled, so it is
+// memoized and cleared on enable/disable. Returns "" when unknown (no repo, or a
+// transient read error), in which case the field is omitted and the next call
+// retries rather than caching the miss.
+func (h *TotpHandler) cachedEnabledAt(ctx context.Context) string {
+	if cached := h.enabledAtCache.Load(); cached != nil {
+		return cached.UTC().Format(time.RFC3339)
+	}
+	if h.totpRepo == nil {
+		return ""
+	}
+	at, ok, err := h.totpRepo.EnabledAt(ctx)
+	if err != nil || !ok {
+		return ""
+	}
+	h.enabledAtCache.Store(&at)
+	return at.UTC().Format(time.RFC3339)
 }
 
 // EnrollStart generates a new TOTP secret and returns the otpauth URI + secret.
@@ -169,6 +193,9 @@ func (h *TotpHandler) EnrollVerify(w http.ResponseWriter, r *http.Request) {
 	// Refresh cache AFTER Enable so the hot path starts rejecting raw admin
 	// tokens immediately.
 	h.refreshTotpEnabled(r.Context())
+	// Drop the stale confirmed_at so the next status read picks up this
+	// enrollment's fresh stamp.
+	h.enabledAtCache.Store(nil)
 	// Mint a session token so the admin who just enabled 2FA stays logged in.
 	// Enabling invalidates the raw admin token their browser was using, so
 	// without this the dashboard's next calls 401 and it looks like the app
@@ -210,6 +237,8 @@ func (h *TotpHandler) Disable(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	h.refreshTotpEnabled(r.Context())
+	// Clear the cached stamp so a later re-enrollment doesn't serve this one.
+	h.enabledAtCache.Store(nil)
 	writeJSON(w, map[string]bool{"disabled": true})
 }
 

--- a/internal/api/totp_handlers.go
+++ b/internal/api/totp_handlers.go
@@ -33,9 +33,13 @@ type TotpHandler struct {
 	// confirmed_at cache for /totp/status. The stamp is set once at enrollment
 	// and never changes until disable/re-enroll, so a polled status endpoint can
 	// serve it from memory instead of reading the DB on every call. Read lock-free
-	// off the hot path; populated lazily on the first enabled read and cleared on
-	// enable/disable, both serialized by enabledAtMu.
+	// off the hot path; populated lazily on the first enabled read. enabledAtGen
+	// bumps on every enable/disable so a read whose DB fetch raced an invalidation
+	// declines to publish its now-stale value (see publishEnabledAt). The DB fetch
+	// itself runs without enabledAtMu, so a slow status read never blocks a
+	// concurrent enroll/disable.
 	enabledAtCache atomic.Pointer[time.Time]
+	enabledAtGen   atomic.Uint64
 	enabledAtMu    sync.Mutex
 }
 
@@ -136,26 +140,35 @@ func (h *TotpHandler) cachedEnabledAt(ctx context.Context) string {
 	if h.totpRepo == nil {
 		return ""
 	}
-	// Hold the lock across the read+store so a since-replaced enrollment can't be
-	// published after an invalidation: invalidateEnabledAt takes the same lock, so
-	// a racing enable/disable runs either fully before this read (we then read the
-	// fresh value) or fully after the store (it clears our value). The miss path
-	// runs at most once per enable, so the lock is effectively uncontended.
-	h.enabledAtMu.Lock()
-	defer h.enabledAtMu.Unlock()
+	// Snapshot the generation before the read. The DB fetch runs without the lock
+	// (so it can't block a concurrent enroll/disable); publishEnabledAt then stores
+	// the result only if no enable/disable bumped the generation meanwhile.
+	gen := h.enabledAtGen.Load()
 	at, ok, err := h.totpRepo.EnabledAt(ctx)
 	if err != nil || !ok {
 		return ""
 	}
-	h.enabledAtCache.Store(&at)
+	h.publishEnabledAt(gen, at)
 	return at.UTC().Format(time.RFC3339)
 }
 
-// invalidateEnabledAt drops the cached confirmed_at under the same lock
-// cachedEnabledAt holds while populating, so an in-flight miss reading a
-// since-replaced enrollment can never republish its stale stamp afterward.
+// publishEnabledAt caches at only if no enable/disable happened since gen was
+// sampled, so an in-flight read of a since-replaced enrollment cannot overwrite a
+// newer invalidation. The lock makes the generation check and the store atomic
+// against invalidateEnabledAt.
+func (h *TotpHandler) publishEnabledAt(gen uint64, at time.Time) {
+	h.enabledAtMu.Lock()
+	if h.enabledAtGen.Load() == gen {
+		h.enabledAtCache.Store(&at)
+	}
+	h.enabledAtMu.Unlock()
+}
+
+// invalidateEnabledAt clears the cached confirmed_at and advances the generation
+// so any read already in flight declines to publish its now-stale value.
 func (h *TotpHandler) invalidateEnabledAt() {
 	h.enabledAtMu.Lock()
+	h.enabledAtGen.Add(1)
 	h.enabledAtCache.Store(nil)
 	h.enabledAtMu.Unlock()
 }

--- a/internal/api/totp_handlers_test.go
+++ b/internal/api/totp_handlers_test.go
@@ -246,6 +246,29 @@ func TestTotpCachedEnabledAt_ReturnsEmptyWhenUnknown(t *testing.T) {
 	}
 }
 
+// TestTotpPublishEnabledAt_GenerationGuard verifies that a publish carrying a
+// stale generation (one an enable/disable advanced after it was sampled) does not
+// resurrect the old confirmed_at: the race a slow lazy read could otherwise lose.
+func TestTotpPublishEnabledAt_GenerationGuard(t *testing.T) {
+	_, th := newTotpTestHandler(t)
+	now := time.Now().UTC()
+
+	// Same generation: the value is published.
+	gen := th.enabledAtGen.Load()
+	th.publishEnabledAt(gen, now)
+	if got := th.enabledAtCache.Load(); got == nil || !got.Equal(now) {
+		t.Fatalf("expected cached %v, got %v", now, got)
+	}
+
+	// An invalidation bumps the generation and clears the cache; a publish still
+	// carrying the old generation must be dropped rather than overwrite it.
+	th.invalidateEnabledAt()
+	th.publishEnabledAt(gen, now.Add(-time.Hour))
+	if got := th.enabledAtCache.Load(); got != nil {
+		t.Errorf("stale-generation publish should be dropped, got %v", got)
+	}
+}
+
 // --- EnrollStart tests ---
 
 func TestTotpEnrollStart_AdminAuth(t *testing.T) {

--- a/internal/api/totp_handlers_test.go
+++ b/internal/api/totp_handlers_test.go
@@ -224,6 +224,28 @@ func TestTotpStatus_EnabledAtCached(t *testing.T) {
 	}
 }
 
+// TestTotpCachedEnabledAt_ReturnsEmptyWhenUnknown covers the two "unknown"
+// branches of cachedEnabledAt: no repository wired, and a repository that reports
+// TOTP as not enabled. Both must return "" without caching, so the field is
+// omitted and a later call retries.
+func TestTotpCachedEnabledAt_ReturnsEmptyWhenUnknown(t *testing.T) {
+	// No repository: returns empty without touching the DB or panicking.
+	bare := &TotpHandler{}
+	if got := bare.cachedEnabledAt(context.Background()); got != "" {
+		t.Errorf("expected empty for nil repo, got %q", got)
+	}
+
+	// Repo present but TOTP not enabled: EnabledAt reports ok=false, so the
+	// helper returns empty and caches nothing (next call retries).
+	_, th := newTotpTestHandler(t)
+	if got := th.cachedEnabledAt(context.Background()); got != "" {
+		t.Errorf("expected empty when not enabled, got %q", got)
+	}
+	if th.enabledAtCache.Load() != nil {
+		t.Error("expected no cache entry after an unknown read")
+	}
+}
+
 // --- EnrollStart tests ---
 
 func TestTotpEnrollStart_AdminAuth(t *testing.T) {

--- a/internal/api/totp_handlers_test.go
+++ b/internal/api/totp_handlers_test.go
@@ -181,6 +181,49 @@ func TestTotpStatus_Enabled(t *testing.T) {
 	}
 }
 
+// TestTotpStatus_EnabledAtCached checks that a second status poll serves the
+// same confirmed_at as the first, exercising both the cache-populate and the
+// cache-hit branches of cachedEnabledAt so the per-poll DB read stays memoized.
+func TestTotpStatus_EnabledAtCached(t *testing.T) {
+	h, th := newTotpTestHandler(t)
+	enrollAndEnable(t, th.totpRepo)
+	h.RefreshTotpEnabled(context.Background())
+
+	r := serveTotpRouter(th)
+	read := func() string {
+		req := httptest.NewRequest(http.MethodGet, "/totp/status", http.NoBody)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+		var resp struct {
+			Enabled   bool   `json:"enabled"`
+			EnabledAt string `json:"enabled_at"`
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if !resp.Enabled || resp.EnabledAt == "" {
+			t.Fatalf("expected enabled with enabled_at, got %+v", resp)
+		}
+		return resp.EnabledAt
+	}
+
+	// Before any read the cache is cold.
+	if th.enabledAtCache.Load() != nil {
+		t.Fatal("expected enabledAtCache to start empty")
+	}
+	first := read()
+	// First read populated the cache; a second poll must serve the same stamp.
+	if th.enabledAtCache.Load() == nil {
+		t.Error("expected enabledAtCache to be populated after a status read")
+	}
+	if second := read(); second != first {
+		t.Errorf("cached enabled_at drifted: first %q, second %q", first, second)
+	}
+}
+
 // --- EnrollStart tests ---
 
 func TestTotpEnrollStart_AdminAuth(t *testing.T) {


### PR DESCRIPTION
Follow-up to the deferred Greptile P2 on #260.

## Problem
`GET /api/totp/status` read `confirmed_at` from the DB on **every** call while TOTP was enabled. The stamp is set once at enrollment and never changes until disable/re-enroll, so the per-poll read was wasted work on what the settings page polls.

## Fix
Cache it in an `atomic.Pointer[time.Time]` on `TotpHandler`:
- Populated lazily on the first enabled status read, served from memory thereafter.
- Cleared on enable (`EnrollVerify`) and disable, so a re-enrollment never serves a stale stamp.
- A transient read error is **not** cached, so the next poll retries rather than memoizing a miss.

Self-contained in `internal/api/totp_handlers.go`: no `NewTotpHandler` / `admin.go` wiring change. The per-request auth hot path already used the cached `totpEnabled` atomic and is untouched.

## Tests
- New `TestTotpStatus_EnabledAtCached`: two consecutive polls return the same stamp, exercising both the cache-populate and cache-hit branches and asserting the cache pointer goes cold → warm.
- Existing `TestTotpEnrollVerify_HappyPath` and `TestTotpDisable_*` cover the invalidation lines.
- `go test ./internal/api/ ./internal/totp/` green; `golangci-lint run ./internal/api/...` 0 issues; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)