### PR TITLE
fix(deps): patch undici advisories and clear codecov peer warning

### DIFF
--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -6,6 +6,8 @@ settings:
 
 overrides:
   '@babel/core': ^7.29.6
+  undici@6: ^6.27.0
+  undici@7: ^7.28.0
 
 importers:
 
@@ -2485,12 +2487,12 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  undici@6.26.0:
-    resolution: {integrity: sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==}
+  undici@6.27.0:
+    resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
     engines: {node: '>=18.17'}
 
-  undici@7.25.0:
-    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unified@11.0.5:
@@ -2759,17 +2761,17 @@ snapshots:
       '@octokit/plugin-rest-endpoint-methods': 17.0.0(@octokit/core@7.0.6)
       '@octokit/request': 10.0.10
       '@octokit/request-error': 7.1.0
-      undici: 6.26.0
+      undici: 6.27.0
 
   '@actions/http-client@3.0.2':
     dependencies:
       tunnel: 0.0.6
-      undici: 6.26.0
+      undici: 6.27.0
 
   '@actions/http-client@4.0.1':
     dependencies:
       tunnel: 0.0.6
-      undici: 6.26.0
+      undici: 6.27.0
 
   '@actions/io@3.0.2': {}
 
@@ -4288,7 +4290,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.25.0
+      undici: 7.28.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -5260,9 +5262,9 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  undici@6.26.0: {}
+  undici@6.27.0: {}
 
-  undici@7.25.0: {}
+  undici@7.28.0: {}
 
   unified@11.0.5:
     dependencies:

--- a/web/pnpm-workspace.yaml
+++ b/web/pnpm-workspace.yaml
@@ -9,3 +9,18 @@ packages: []
 # dependency requires >=7.29.6 on its own.
 overrides:
   "@babel/core": "^7.29.6"
+  # Force transitive undici to patched releases (both lines are test/build-time
+  # only: 6.x via @actions/http-client, 7.x via jsdom). Fixes Dependabot
+  # advisories for Set-Cookie SameSite downgrade, Set-Cookie header injection,
+  # SOCKS5 cross-origin routing, and keep-alive response-queue poisoning.
+  # Remove each line once a direct dependency requires the patched range itself.
+  "undici@6": "^6.27.0"
+  "undici@7": "^7.28.0"
+
+# @codecov/vite-plugin still declares a stale peer range (vite 4-6) even on its
+# latest release, but it runs fine on vite 8 (the Bundle Report comments on PRs
+# confirm it works). Tell pnpm vite 8 is vetted so the peer warning stops.
+# Drop this once the plugin publishes a version whose peer range includes vite 8.
+peerDependencyRules:
+  allowedVersions:
+    "@codecov/vite-plugin>vite": "8"


### PR DESCRIPTION
## What

Resolves all **9 open Dependabot alerts**, all of which are the transitive npm package `undici` in `web/`. Two version lines are present, both **build/test-time only** (never shipped at runtime):

- **6.x** (`6.26.0 → 6.27.0`) — pulled in via `@actions/http-client`
- **7.x** (`7.25.0 → 7.28.0`) — pulled in via `jsdom` (vitest's DOM)

Fixed by adding scoped `undici@6` / `undici@7` entries to the pnpm `overrides:` in `web/pnpm-workspace.yaml` (the pnpm-10 location, already COPYed in the Dockerfile frontend stage).

### Advisories cleared
| Severity | Issue |
|---|---|
| high | SOCKS5 proxy pool reuse → cross-origin request routing (7.x) |
| medium | Set-Cookie percent-decoding → HTTP header injection (6.x + 7.x) |
| low | Set-Cookie SameSite attribute downgrade (6.x + 7.x) |
| low | keep-alive socket reuse → response queue poisoning (7.x) |

## Also

Stopped ignoring the long-standing `@codecov/vite-plugin` peer-dependency warning. Its latest release (`2.0.1`) still declares a stale `vite@"4.x || 5.x || 6.x"` peer range, but it runs fine on vite 8 (the PR Bundle Report comments confirm it works). Added a `peerDependencyRules.allowedVersions` entry marking vite 8 as vetted so the warning stops. Drop it once upstream publishes a version whose peer range includes vite 8.

## Verification

- `pnpm install --frozen-lockfile` passes (so the Docker build won't hit a lockfile mismatch).
- No more peer-dependency warning on install.
- Changes are lockfile/metadata only; no source changes.

> Note: these are transitive deps, so Dependabot may not auto-close the alerts until this lockfile lands on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)