### PR TITLE
test: backfill backend + frontend coverage (meaningful gaps)

### DIFF
--- a/internal/api/discovery_changes_pure_test.go
+++ b/internal/api/discovery_changes_pure_test.go
@@ -1,0 +1,88 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/hugalafutro/model-hotel/internal/failover"
+)
+
+// TestDiffIsEmpty covers the gate that decides whether a discovery run records a
+// row: a nil or all-empty diff is empty, while any single populated field (a
+// model change or a failover-group change) makes it non-empty.
+func TestDiffIsEmpty(t *testing.T) {
+	if !diffIsEmpty(nil) {
+		t.Error("nil diff should be empty")
+	}
+	if !diffIsEmpty(&DiscoveryDiff{}) {
+		t.Error("zero-value diff should be empty")
+	}
+
+	cases := map[string]*DiscoveryDiff{
+		"added":             {Added: []ModelChange{{ModelID: "m"}}},
+		"reenabled":         {Reenabled: []ModelChange{{ModelID: "m"}}},
+		"disabled":          {Disabled: []ModelChange{{ModelID: "m"}}},
+		"updated":           {Updated: []ModelUpdate{{ModelID: "m"}}},
+		"failover deleted":  {FailoverDeletedGroups: []failover.DeletedGroupInfo{{}}},
+		"failover updated":  {FailoverUpdatedGroups: []failover.UpdatedGroupInfo{{}}},
+		"failover disabled": {FailoverDisabledGroups: []failover.DisabledGroupInfo{{}}},
+	}
+	for name, d := range cases {
+		if diffIsEmpty(d) {
+			t.Errorf("%s diff should NOT be empty", name)
+		}
+	}
+}
+
+// TestCountAffected sums every diff bucket into the badge number. A nil diff is
+// 0; a diff touching one entity in each bucket is the bucket count.
+func TestCountAffected(t *testing.T) {
+	if got := countAffected(nil); got != 0 {
+		t.Errorf("countAffected(nil) = %d, want 0", got)
+	}
+	if got := countAffected(&DiscoveryDiff{}); got != 0 {
+		t.Errorf("countAffected(empty) = %d, want 0", got)
+	}
+
+	d := &DiscoveryDiff{
+		Added:                  []ModelChange{{ModelID: "a"}},
+		Reenabled:              []ModelChange{{ModelID: "b"}},
+		Disabled:               []ModelChange{{ModelID: "c"}},
+		Updated:                []ModelUpdate{{ModelID: "d"}, {ModelID: "e"}},
+		FailoverDeletedGroups:  []failover.DeletedGroupInfo{{}},
+		FailoverUpdatedGroups:  []failover.UpdatedGroupInfo{{}},
+		FailoverDisabledGroups: []failover.DisabledGroupInfo{{}},
+	}
+	// Three single-entry buckets, two updated models, three single-entry failover
+	// buckets sum to eight affected entities.
+	if got := countAffected(d); got != 8 {
+		t.Errorf("countAffected = %d, want 8", got)
+	}
+}
+
+// TestFloatPtrEq covers the pointer-aware, float32-precision price equality used
+// to fold discovery round-trips: both-nil is equal, exactly-one-nil is not, and
+// equal-vs-different values compare at float32 precision.
+func TestFloatPtrEq(t *testing.T) {
+	f := func(v float64) *float64 { return &v }
+
+	if !floatPtrEq(nil, nil) {
+		t.Error("both nil should be equal (field unset on both ends)")
+	}
+	if floatPtrEq(f(1), nil) {
+		t.Error("one nil should not equal a set value (a fill is a real change)")
+	}
+	if floatPtrEq(nil, f(1)) {
+		t.Error("one nil should not equal a set value (a clear is a real change)")
+	}
+	if !floatPtrEq(f(0.182), f(0.182)) {
+		t.Error("equal values should compare equal")
+	}
+	if floatPtrEq(f(0.182), f(0.49)) {
+		t.Error("different values should compare unequal")
+	}
+	// Values that differ only below float32 precision are treated as equal, since
+	// the price columns are REAL and the original diff recorded at float32.
+	if !floatPtrEq(f(0.1), f(0.1+1e-9)) {
+		t.Error("sub-float32 differences should be treated as equal")
+	}
+}

--- a/internal/api/discovery_changes_test.go
+++ b/internal/api/discovery_changes_test.go
@@ -2,6 +2,9 @@ package api
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/google/uuid"
@@ -77,6 +80,72 @@ func TestDiscoveryChangesStore_RoundTrip(t *testing.T) {
 	}
 	if len(entries) != 0 {
 		t.Fatalf("expected no pending entries after ack, got %d", len(entries))
+	}
+}
+
+// TestDiscoveryChangesHandlers_HTTP exercises the GET /discovery/changes and
+// POST /discovery/changes/ack endpoints over the full router: the badge GET
+// reports the affected-model count, and ack clears the pending rows while
+// returning the just-cleared snapshot for the review modal.
+func TestDiscoveryChangesHandlers_HTTP(t *testing.T) {
+	h, r := newTestHandlerWithRouter(t)
+	pool := h.dbPool.Pool()
+	if _, err := pool.Exec(context.Background(), `TRUNCATE discovery_changes`); err != nil {
+		t.Fatalf("truncate discovery_changes: %v", err)
+	}
+
+	ctx := context.Background()
+	providerID := uuid.New()
+	diff := &DiscoveryDiff{
+		Added: []ModelChange{{ModelID: "fresh-model", Reason: changeReasonNewModel}},
+		Updated: []ModelUpdate{{
+			ModelID: "repriced",
+			Changes: []FieldChange{{Field: changeFieldInputPrice, Old: fptr(1), New: fptr(2)}},
+		}},
+	}
+	if _, err := AppendDiscoveryChange(ctx, pool, "scheduled", &providerID, "DeepSeek", diff); err != nil {
+		t.Fatalf("seed discovery change: %v", err)
+	}
+
+	doReq := func(method, path string) DiscoveryChangesResponse {
+		t.Helper()
+		req := httptest.NewRequest(method, path, http.NoBody)
+		req.Header.Set("Authorization", "Bearer test-admin-token")
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("%s %s = %d, want 200; body: %s", method, path, rec.Code, rec.Body.String())
+		}
+		var resp DiscoveryChangesResponse
+		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode %s response: %v", path, err)
+		}
+		return resp
+	}
+
+	// GET surfaces the pending entry and its affected-model count (2: one added,
+	// one updated).
+	got := doReq("GET", "/discovery/changes")
+	if got.Count != 2 {
+		t.Errorf("GET count = %d, want 2", got.Count)
+	}
+	if len(got.Entries) != 1 || got.Entries[0].ProviderName != "DeepSeek" {
+		t.Fatalf("GET entries = %+v, want one DeepSeek entry", got.Entries)
+	}
+
+	// Ack clears the badge (Count 0) but echoes the cleared rows for the modal.
+	acked := doReq("POST", "/discovery/changes/ack")
+	if acked.Count != 0 {
+		t.Errorf("ack count = %d, want 0", acked.Count)
+	}
+	if len(acked.Entries) != 1 {
+		t.Fatalf("ack entries = %+v, want the one cleared row", acked.Entries)
+	}
+
+	// A second GET now sees nothing pending and reports an empty (non-nil) list.
+	after := doReq("GET", "/discovery/changes")
+	if after.Count != 0 || len(after.Entries) != 0 {
+		t.Errorf("post-ack GET = %+v, want empty", after)
 	}
 }
 

--- a/internal/api/discovery_pricestability_test.go
+++ b/internal/api/discovery_pricestability_test.go
@@ -250,6 +250,64 @@ func TestDampenOpenRouterPriceJitter(t *testing.T) {
 			t.Fatal("filling an unset field is a genuine change, not jitter")
 		}
 	})
+
+	t.Run("input and output price jitter are damped independently", func(t *testing.T) {
+		// A model whose input price wiggled under tolerance but whose output price
+		// genuinely jumped: only the input flag should be demoted.
+		snap := map[string]ModelSnapshot{"m": {
+			inputPrice:  fptr(2.00),
+			outputPrice: fptr(6.00),
+		}}
+		m := &model.Model{
+			ModelID:               "m",
+			InputPricePerMillion:  fptr(1.96), // 2% drift -> jitter
+			OutputPricePerMillion: fptr(3.00), // 50% drop -> real move
+		}
+		m.LiveMeta.InputPrice = true
+		m.LiveMeta.OutputPrice = true
+
+		DampenOpenRouterPriceJitter(orURL, snap, []*model.Model{m})
+
+		if m.LiveMeta.InputPrice {
+			t.Error("sub-tolerance input price wiggle should be demoted to fill-only")
+		}
+		if !m.LiveMeta.OutputPrice {
+			t.Error("a real output price move must stay live")
+		}
+	})
+
+	t.Run("both input and output sub-tolerance wiggles are damped", func(t *testing.T) {
+		snap := map[string]ModelSnapshot{"m": {
+			inputPrice:  fptr(2.00),
+			outputPrice: fptr(6.00),
+		}}
+		m := &model.Model{
+			ModelID:               "m",
+			InputPricePerMillion:  fptr(2.02),
+			OutputPricePerMillion: fptr(5.90),
+		}
+		m.LiveMeta.InputPrice = true
+		m.LiveMeta.OutputPrice = true
+
+		DampenOpenRouterPriceJitter(orURL, snap, []*model.Model{m})
+
+		if m.LiveMeta.InputPrice || m.LiveMeta.OutputPrice {
+			t.Errorf("both jittered prices should be demoted, got input=%v output=%v",
+				m.LiveMeta.InputPrice, m.LiveMeta.OutputPrice)
+		}
+	})
+}
+
+// TestFloatPtrVal covers the price-logging sentinel: a real price dereferences,
+// and a nil pointer reports -1 (no real price is negative, so it reads
+// unambiguously as "unset" in the damping debug log).
+func TestFloatPtrVal(t *testing.T) {
+	if got := floatPtrVal(fptr(0.5)); got != 0.5 {
+		t.Errorf("floatPtrVal(0.5) = %v, want 0.5", got)
+	}
+	if got := floatPtrVal(nil); got != -1 {
+		t.Errorf("floatPtrVal(nil) = %v, want -1 sentinel", got)
+	}
 }
 
 func TestWithinPriceTolerance(t *testing.T) {

--- a/internal/debuglog/scope_handler_test.go
+++ b/internal/debuglog/scope_handler_test.go
@@ -1,0 +1,63 @@
+package debuglog
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+)
+
+// TestScopeFilterHandler_DerivedHandlersKeepFilter guards the WithAttrs/WithGroup
+// paths of scopeFilterHandler: a logger derived with extra attrs or a group must
+// still drop Debug records whose scope is not enabled. If either method returned
+// the bare inner handler, scope filtering would silently leak on derived loggers.
+func TestScopeFilterHandler_DerivedHandlersKeepFilter(t *testing.T) {
+	t.Setenv("DEBUG_LOG_SCOPES", "failover")
+	Init(false) // global debug off, scopes = {failover} -> wrapping is active
+	t.Cleanup(func() {
+		os.Unsetenv("DEBUG_LOG_SCOPES")
+		Init(false)
+	})
+
+	capH := newCaptureHandler(slog.LevelDebug)
+	wrapped := maybeScopeFilter(capH)
+	if _, ok := wrapped.(scopeFilterHandler); !ok {
+		t.Fatalf("maybeScopeFilter returned %T, want scopeFilterHandler", wrapped)
+	}
+
+	// Derive through both WithAttrs and WithGroup; the scope filter must survive.
+	derived := wrapped.
+		WithAttrs([]slog.Attr{slog.String("request_id", "abc")}).
+		WithGroup("net")
+
+	if _, ok := derived.(scopeFilterHandler); !ok {
+		t.Fatalf("derived handler is %T, want scopeFilterHandler", derived)
+	}
+
+	ctx := context.Background()
+	mkDebug := func(msg string) slog.Record {
+		return slog.NewRecord(time.Now(), slog.LevelDebug, msg, 0)
+	}
+
+	if err := derived.Handle(ctx, mkDebug("failover: kept")); err != nil {
+		t.Fatalf("Handle(failover) error: %v", err)
+	}
+	if err := derived.Handle(ctx, mkDebug("proxy: dropped")); err != nil {
+		t.Fatalf("Handle(proxy) error: %v", err)
+	}
+	// A non-Debug record always passes, regardless of scope.
+	infoRec := slog.NewRecord(time.Now(), slog.LevelInfo, "proxy: info always passes", 0)
+	if err := derived.Handle(ctx, infoRec); err != nil {
+		t.Fatalf("Handle(info) error: %v", err)
+	}
+
+	if len(capH.records) != 2 {
+		t.Fatalf("expected 2 records (scoped debug + info), got %d: %+v", len(capH.records), capH.records)
+	}
+	for _, r := range capH.records {
+		if r.Level == slog.LevelDebug && scopeOf(r.Message) != "failover" {
+			t.Errorf("derived handler leaked an out-of-scope debug record: %q", r.Message)
+		}
+	}
+}

--- a/internal/debuglog/scope_handler_test.go
+++ b/internal/debuglog/scope_handler_test.go
@@ -3,7 +3,6 @@ package debuglog
 import (
 	"context"
 	"log/slog"
-	"os"
 	"testing"
 	"time"
 )
@@ -13,12 +12,13 @@ import (
 // still drop Debug records whose scope is not enabled. If either method returned
 // the bare inner handler, scope filtering would silently leak on derived loggers.
 func TestScopeFilterHandler_DerivedHandlersKeepFilter(t *testing.T) {
+	// Register the global-state reset BEFORE t.Setenv so it runs AFTER t.Setenv's
+	// own env restore (t.Cleanup is LIFO): Init then recomputes enabledScopes from
+	// the restored DEBUG_LOG_SCOPES rather than from the unset value. t.Setenv
+	// already restores/unsets the variable itself, so no manual os.Unsetenv.
+	t.Cleanup(func() { Init(false) })
 	t.Setenv("DEBUG_LOG_SCOPES", "failover")
 	Init(false) // global debug off, scopes = {failover} -> wrapping is active
-	t.Cleanup(func() {
-		os.Unsetenv("DEBUG_LOG_SCOPES")
-		Init(false)
-	})
 
 	capH := newCaptureHandler(slog.LevelDebug)
 	wrapped := maybeScopeFilter(capH)

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -105,3 +105,22 @@ func TestBreakerCollector(t *testing.T) {
 		t.Errorf("missing closed breaker gauge:\n%s", out)
 	}
 }
+
+// TestLabelOrUnknown verifies the empty-label fallback used for the provider and
+// model metric labels: an empty value becomes "unknown" so a series is never
+// emitted with a blank label, while a real value passes through untouched.
+func TestLabelOrUnknown(t *testing.T) {
+	if got := labelOrUnknown(""); got != "unknown" {
+		t.Errorf(`labelOrUnknown("") = %q, want "unknown"`, got)
+	}
+	if got := labelOrUnknown("openai"); got != "openai" {
+		t.Errorf(`labelOrUnknown("openai") = %q, want "openai"`, got)
+	}
+}
+
+// TestRegisterBreakerCollector_NilIsNoop guards the documented nil-collector
+// contract: passing nil must be ignored (no registration, no panic) so callers
+// without a breaker source can pass through unconditionally.
+func TestRegisterBreakerCollector_NilIsNoop(t *testing.T) {
+	RegisterBreakerCollector(nil)
+}

--- a/internal/model/livemeta_test.go
+++ b/internal/model/livemeta_test.go
@@ -1,0 +1,81 @@
+package model
+
+import "testing"
+
+// TestMarkLiveMetaFromCurrent verifies that only the pricing/context fields that
+// are actually populated (non-nil) get flagged as live-sourced. Discoverers rely
+// on this to distinguish provider-reported values from later catalog/models.dev
+// fills, so a field that is nil must never be marked live.
+func TestMarkLiveMetaFromCurrent(t *testing.T) {
+	t.Run("all fields set flags every meta bit", func(t *testing.T) {
+		m := &Model{
+			InputPricePerMillion:         float64Ptr(1),
+			InputPricePerMillionCacheHit: float64Ptr(0.5),
+			OutputPricePerMillion:        float64Ptr(2),
+			ContextLength:                intPtr(8192),
+			MaxOutputTokens:              intPtr(4096),
+		}
+		m.MarkLiveMetaFromCurrent()
+
+		want := LiveMetaFields{
+			InputPrice:      true,
+			InputPriceCache: true,
+			OutputPrice:     true,
+			ContextLength:   true,
+			MaxOutputTokens: true,
+		}
+		if m.LiveMeta != want {
+			t.Errorf("LiveMeta = %+v, want %+v", m.LiveMeta, want)
+		}
+	})
+
+	t.Run("no fields set leaves every meta bit false", func(t *testing.T) {
+		m := &Model{}
+		m.MarkLiveMetaFromCurrent()
+		if m.LiveMeta != (LiveMetaFields{}) {
+			t.Errorf("LiveMeta = %+v, want zero value", m.LiveMeta)
+		}
+	})
+
+	t.Run("flags only the populated fields", func(t *testing.T) {
+		// Live payload carried a price and context length but no cache-hit price
+		// or max-output cap. Only the two present fields may be flagged live.
+		m := &Model{
+			InputPricePerMillion: float64Ptr(3),
+			ContextLength:        intPtr(32768),
+		}
+		m.MarkLiveMetaFromCurrent()
+
+		if !m.LiveMeta.InputPrice {
+			t.Error("InputPrice should be flagged live (field was set)")
+		}
+		if !m.LiveMeta.ContextLength {
+			t.Error("ContextLength should be flagged live (field was set)")
+		}
+		if m.LiveMeta.InputPriceCache {
+			t.Error("InputPriceCache must stay false (field was nil)")
+		}
+		if m.LiveMeta.OutputPrice {
+			t.Error("OutputPrice must stay false (field was nil)")
+		}
+		if m.LiveMeta.MaxOutputTokens {
+			t.Error("MaxOutputTokens must stay false (field was nil)")
+		}
+	})
+
+	t.Run("recomputes from current state, clearing stale flags", func(t *testing.T) {
+		// A field that was live earlier but is now nil must be un-flagged: the
+		// method is a full recompute, not an additive merge.
+		m := &Model{InputPricePerMillion: float64Ptr(1)}
+		m.MarkLiveMetaFromCurrent()
+		if !m.LiveMeta.InputPrice {
+			t.Fatal("precondition: InputPrice should be live")
+		}
+
+		m.InputPricePerMillion = nil
+		m.MarkLiveMetaFromCurrent()
+		if m.LiveMeta.InputPrice {
+			t.Error("InputPrice must be cleared once the field is nil again")
+		}
+	})
+}

--- a/internal/otelexport/otelexport_test.go
+++ b/internal/otelexport/otelexport_test.go
@@ -1,14 +1,77 @@
 package otelexport
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"log/slog"
+	"strings"
 	"testing"
+	"time"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/resource"
 )
+
+// TestLevelHandler_HandleAndDerivedPreserveLevel covers the Handle/WithAttrs/
+// WithGroup methods of levelHandler. Handle must forward records verbatim to the
+// inner handler, and both derivation methods must keep the configured level gate
+// in place (otherwise a DEBUG record could reach OTLP off a derived logger even
+// when the app level is Warn) while still attaching the attrs/group to output.
+func TestLevelHandler_HandleAndDerivedPreserveLevel(t *testing.T) {
+	var buf bytes.Buffer
+	inner := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	h := &levelHandler{level: slog.LevelWarn, inner: inner}
+	ctx := context.Background()
+
+	// Handle forwards the record to the inner handler.
+	if err := h.Handle(ctx, slog.NewRecord(time.Now(), slog.LevelError, "boom", 0)); err != nil {
+		t.Fatalf("Handle error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "boom") {
+		t.Errorf("Handle did not forward record to inner: %q", buf.String())
+	}
+
+	// WithAttrs preserves the Warn gate and attaches the attribute to output.
+	wa, ok := h.WithAttrs([]slog.Attr{slog.String("svc", "mh")}).(*levelHandler)
+	if !ok {
+		t.Fatal("WithAttrs did not return a *levelHandler")
+	}
+	if wa.level != slog.LevelWarn {
+		t.Errorf("WithAttrs dropped the level gate: got %v", wa.level)
+	}
+	if wa.Enabled(ctx, slog.LevelInfo) {
+		t.Error("derived handler must still gate Info below Warn")
+	}
+	if !wa.Enabled(ctx, slog.LevelWarn) {
+		t.Error("derived handler must allow Warn")
+	}
+	buf.Reset()
+	if err := wa.Handle(ctx, slog.NewRecord(time.Now(), slog.LevelWarn, "warned", 0)); err != nil {
+		t.Fatalf("derived Handle error: %v", err)
+	}
+	if !strings.Contains(buf.String(), `"svc":"mh"`) {
+		t.Errorf("WithAttrs did not attach the attribute to output: %q", buf.String())
+	}
+
+	// WithGroup preserves the gate and nests record attrs under the group name.
+	wg, ok := h.WithGroup("grp").(*levelHandler)
+	if !ok {
+		t.Fatal("WithGroup did not return a *levelHandler")
+	}
+	if wg.level != slog.LevelWarn {
+		t.Errorf("WithGroup dropped the level gate: got %v", wg.level)
+	}
+	buf.Reset()
+	rec := slog.NewRecord(time.Now(), slog.LevelError, "grouped", 0)
+	rec.AddAttrs(slog.String("k", "v"))
+	if err := wg.Handle(ctx, rec); err != nil {
+		t.Fatalf("grouped Handle error: %v", err)
+	}
+	if !strings.Contains(buf.String(), `"grp":{`) {
+		t.Errorf("WithGroup did not nest attrs under the group: %q", buf.String())
+	}
+}
 
 // serviceNameOf extracts the service.name attribute from a resource, or "".
 func serviceNameOf(res *resource.Resource) string {

--- a/internal/provider/catalog_merge_test.go
+++ b/internal/provider/catalog_merge_test.go
@@ -213,3 +213,73 @@ func TestMergeLiveAndCatalog_DedupesLive(t *testing.T) {
 		t.Errorf("first live entry should win, got %q", out[0].Name)
 	}
 }
+
+// TestBackfillFromCatalog_NilSrcIsNoop guards the nil-catalog-match guard: a
+// live model with no catalog counterpart must be returned untouched.
+func TestBackfillFromCatalog_NilSrcIsNoop(t *testing.T) {
+	dst := &model.Model{ModelID: "m", Name: "Live Name"}
+	backfillFromCatalog(dst, nil)
+	if dst.Name != "Live Name" {
+		t.Errorf("nil src must not mutate dst, got Name=%q", dst.Name)
+	}
+}
+
+// TestBackfillFromCatalog_FillsEmptyTextFields verifies the catalog fills the
+// empty Name/Description/OwnedBy of a sparse live model without overwriting the
+// values the live API did provide.
+func TestBackfillFromCatalog_FillsEmptyTextFields(t *testing.T) {
+	dst := &model.Model{
+		ModelID:     "glm-5.2",
+		Name:        "", // empty -> catalog wins
+		Description: "", // empty -> catalog wins
+		OwnedBy:     "zai",
+	}
+	src := &model.Model{
+		ModelID:     "glm-5.2",
+		Name:        "GLM 5.2",
+		Description: "Flagship model",
+		OwnedBy:     "should-not-overwrite",
+	}
+	backfillFromCatalog(dst, src)
+
+	if dst.Name != "GLM 5.2" {
+		t.Errorf("empty Name should be backfilled, got %q", dst.Name)
+	}
+	if dst.Description != "Flagship model" {
+		t.Errorf("empty Description should be backfilled, got %q", dst.Description)
+	}
+	if dst.OwnedBy != "zai" {
+		t.Errorf("non-empty OwnedBy must be preserved, got %q", dst.OwnedBy)
+	}
+}
+
+// TestBackfillLiveFromCatalog_EmptyCatalogReturnsLive covers the early return
+// for an empty catalog: the live slice is handed back unchanged (and its live
+// meta still flagged), with no nil-map dereference.
+func TestBackfillLiveFromCatalog_EmptyCatalogReturnsLive(t *testing.T) {
+	pid := uuid.New()
+	live := []*model.Model{{ProviderID: pid, ModelID: "m1", InputPricePerMillion: floatPtr(3)}}
+
+	got := backfillLiveFromCatalog(live, nil)
+
+	if len(got) != 1 || got[0].ModelID != "m1" {
+		t.Fatalf("empty catalog should return live unchanged, got %+v", got)
+	}
+	// markLiveMeta ran before the early return, so the provider-set price is live.
+	if !got[0].LiveMeta.InputPrice {
+		t.Error("live-set price should be flagged live even with an empty catalog")
+	}
+}
+
+// TestIsEmptyModalities covers both the empty-sentinel set and a real payload,
+// which must report false so a genuine modalities value is never discarded.
+func TestIsEmptyModalities(t *testing.T) {
+	for _, s := range []string{"", " ", "[]", "{}", "null"} {
+		if !isEmptyModalities(s) {
+			t.Errorf("isEmptyModalities(%q) = false, want true", s)
+		}
+	}
+	if isEmptyModalities(`["text","image"]`) {
+		t.Error(`isEmptyModalities(["text","image"]) = true, want false`)
+	}
+}

--- a/internal/proxy/thinking_test.go
+++ b/internal/proxy/thinking_test.go
@@ -286,3 +286,38 @@ func TestNormalizeMessageReasoning_ThinkingTagsInContent(t *testing.T) {
 		t.Errorf("content = %v, want 'Visible answer'", msg["content"])
 	}
 }
+
+// TestExtractThinking_FenceAndUnclosedTag covers the streaming edge where a
+// fence block is followed by an open thinking tag that has not closed yet: the
+// fence reasoning and the partial tag body are concatenated and the content is
+// emptied until the close arrives.
+func TestExtractThinking_FenceAndUnclosedTag(t *testing.T) {
+	input := "<<\nFence part\n>>\n<thinking>still streaming"
+	gotThink, gotCont := ExtractThinking(input)
+	if gotThink != "Fence part\nstill streaming" {
+		t.Errorf("thinking = %q, want combined fence + unclosed tag body", gotThink)
+	}
+	if gotCont != "" {
+		t.Errorf("content = %q, want empty while the tag is still open", gotCont)
+	}
+}
+
+// TestExtractThinking_PartialTagAtEnd covers the trailing-partial-tag cleanup:
+// content ending mid-tag (e.g. "<thinki") during streaming has the partial tag
+// stripped so it never leaks into the visible answer.
+func TestExtractThinking_PartialTagAtEnd(t *testing.T) {
+	gotThink, gotCont := ExtractThinking("Hello <thinki")
+	if gotThink != "" {
+		t.Errorf("thinking = %q, want empty (no complete tag present)", gotThink)
+	}
+	if gotCont != "Hello " {
+		t.Errorf("content = %q, want %q with the partial tag stripped", gotCont, "Hello ")
+	}
+
+	// A trailing partial that cannot be a thinking tag (e.g. "<abc") must be left
+	// untouched: only partials that could grow into a real thinking tag are cut.
+	_, keep := ExtractThinking("see <abc")
+	if keep != "see <abc" {
+		t.Errorf("content = %q, want the non-thinking partial preserved", keep)
+	}
+}

--- a/internal/ratelimit/tpm_limiter_test.go
+++ b/internal/ratelimit/tpm_limiter_test.go
@@ -7,8 +7,74 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/time/rate"
+
 	"github.com/hugalafutro/model-hotel/internal/ctxkeys"
 )
+
+// TestTPMRetryAfter covers the three return paths of tpmRetryAfter: a budget
+// that already has a token (>=1s), a zero-rate limiter (defensive 1s), and a
+// drained low-rate limiter where the wait rounds up to several seconds.
+func TestTPMRetryAfter(t *testing.T) {
+	t.Run("token available returns 1", func(t *testing.T) {
+		lim := rate.NewLimiter(rate.Limit(10), 600) // fresh: full burst available
+		if got := tpmRetryAfter(lim); got != 1 {
+			t.Errorf("tpmRetryAfter(available) = %d, want 1", got)
+		}
+	})
+
+	t.Run("zero rate and no tokens returns 1", func(t *testing.T) {
+		lim := rate.NewLimiter(0, 0) // no tokens, Limit()==0 -> perSec<=0 guard
+		if got := tpmRetryAfter(lim); got != 1 {
+			t.Errorf("tpmRetryAfter(zero-rate) = %d, want 1", got)
+		}
+	})
+
+	t.Run("drained low-rate limiter rounds up the wait", func(t *testing.T) {
+		// 1 TPM => 1/60 token/sec, burst 60. Draining the full burst leaves ~0
+		// tokens, so the wait to reach one token is ceil(1 / (1/60)) = 60s.
+		lim := rate.NewLimiter(rate.Limit(1.0/60.0), 60)
+		lim.ReserveN(time.Now(), 60)
+		got := tpmRetryAfter(lim)
+		if got < 2 {
+			t.Errorf("tpmRetryAfter(drained) = %d, want a multi-second wait (>=2)", got)
+		}
+	})
+}
+
+// TestTPMLimiter_DebitNonPositiveIsNoop guards the tokens<=0 early return: a
+// zero or negative token total must never touch the budget (a failed upstream
+// call reports 0 tokens and must not be charged).
+func TestTPMLimiter_DebitNonPositiveIsNoop(t *testing.T) {
+	l, _ := newTestTPMLimiter(t)
+	tpm := 600
+	l.Allow("k", tpm) // create a bucket at full budget
+
+	l.Debit("k", 0)
+	l.Debit("k", -100)
+
+	if !l.Allow("k", tpm) {
+		t.Fatal("non-positive Debit must leave the budget untouched")
+	}
+}
+
+// TestTPMMiddleware_EmptyKeyPasses covers the keyHash=="" admission branch: a
+// request with neither a virtual-key hash nor a RemoteAddr cannot be metered
+// per key, so it passes through rather than 429ing.
+func TestTPMMiddleware_EmptyKeyPasses(t *testing.T) {
+	l, s := newTestTPMLimiter(t)
+	s.set(settingsKeyTPM, "600") // a global cap is set, yet the keyless req passes
+
+	h := l.Middleware(true)(okHandler())
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", http.NoBody)
+	req.RemoteAddr = "" // no key context + empty RemoteAddr => extractKey returns ""
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("keyless request should pass through, got %d", rec.Code)
+	}
+}
 
 // newTestTPMLimiter builds a TPMLimiter with a stub settings backend and stops
 // its cleanup goroutine via t.Cleanup.

--- a/internal/ratelimit/tpm_limiter_test.go
+++ b/internal/ratelimit/tpm_limiter_test.go
@@ -50,11 +50,24 @@ func TestTPMLimiter_DebitNonPositiveIsNoop(t *testing.T) {
 	tpm := 600
 	l.Allow("k", tpm) // create a bucket at full budget
 
+	tokensOf := func() float64 {
+		l.mu.Lock()
+		defer l.mu.Unlock()
+		return l.buckets["k"].limiter.Tokens()
+	}
+	before := tokensOf()
+
 	l.Debit("k", 0)
 	l.Debit("k", -100)
 
+	// A real debit reserves tokens, reducing the count; a non-positive debit must
+	// reserve nothing. The token count only ever rises (refill), so it must not
+	// have dropped — this precisely catches a wrongful debit, unlike a bare Allow.
+	if after := tokensOf(); after < before {
+		t.Fatalf("non-positive Debit reduced the budget: before=%v after=%v", before, after)
+	}
 	if !l.Allow("k", tpm) {
-		t.Fatal("non-positive Debit must leave the budget untouched")
+		t.Fatal("non-positive Debit must leave the budget admitting requests")
 	}
 }
 

--- a/web/src/components/__tests__/Modal.test.tsx
+++ b/web/src/components/__tests__/Modal.test.tsx
@@ -1,4 +1,10 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import {
+	act,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { getByDialogName } from "../../test/helpers";
 import { Modal } from "../Modal";
@@ -69,6 +75,70 @@ describe("Modal", () => {
 		await waitFor(() => {
 			expect(onClose).toHaveBeenCalledTimes(1);
 		});
+	});
+
+	it("starts closing when Escape is pressed", async () => {
+		render(<Modal onClose={onClose}>Content</Modal>);
+		const dialog = screen.getByRole("dialog");
+		act(() => {
+			fireEvent.keyDown(dialog, { key: "Escape" });
+		});
+		// Escape begins the fade; onClose lands once the fallback timer elapses.
+		await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+	});
+
+	it("closes on the opacity transition end and cancels the fallback timer", () => {
+		vi.useFakeTimers();
+		try {
+			render(<Modal onClose={onClose}>Content</Modal>);
+			const dialog = screen.getByRole("dialog");
+
+			// Start closing via the close button (sets the internal closing flag and
+			// arms the jsdom fallback timer).
+			act(() => {
+				screen.getByRole("button", { name: "Close" }).click();
+			});
+
+			// A non-opacity transition end on the dialog is ignored.
+			act(() => {
+				fireEvent.transitionEnd(dialog, { propertyName: "transform" });
+			});
+			expect(onClose).not.toHaveBeenCalled();
+
+			// The opacity transition completing fires onClose exactly once.
+			act(() => {
+				fireEvent.transitionEnd(dialog, { propertyName: "opacity" });
+			});
+			expect(onClose).toHaveBeenCalledTimes(1);
+
+			// The fallback timer was cancelled, so it does not fire a second onClose.
+			act(() => {
+				vi.advanceTimersByTime(1000);
+			});
+			expect(onClose).toHaveBeenCalledTimes(1);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("ignores a transition end that did not originate on the dialog itself", () => {
+		render(<Modal onClose={onClose}>Content</Modal>);
+		const dialog = screen.getByRole("dialog");
+		act(() => {
+			screen.getByRole("button", { name: "Close" }).click();
+		});
+		// A bubbled opacity transition from a child element (target != dialog) must
+		// not be treated as the dialog's own fade completing.
+		const content = screen.getByText("Content");
+		act(() => {
+			fireEvent.transitionEnd(content, { propertyName: "opacity" });
+		});
+		expect(onClose).not.toHaveBeenCalled();
+		// The dialog's own transition still closes it.
+		act(() => {
+			fireEvent.transitionEnd(dialog, { propertyName: "opacity" });
+		});
+		expect(onClose).toHaveBeenCalledTimes(1);
 	});
 
 	it("calls onClose when backdrop is clicked and closeOnBackdrop is true", async () => {

--- a/web/src/context/__tests__/ToastContext.test.tsx
+++ b/web/src/context/__tests__/ToastContext.test.tsx
@@ -312,28 +312,28 @@ describe("ToastItem", () => {
 			vi.advanceTimersByTime(2000);
 		});
 
-		// Toast still present (not yet expired)
-		expect(screen.getByText("Pause test")).toBeInTheDocument();
+		// Toast still present and not yet fading.
+		expect(toastButton).toHaveClass("opacity-100");
 
-		// Hover to pause
+		// Hover to pause. fireEvent.mouseEnter routes through React's synthetic
+		// onMouseEnter (a raw mouseenter dispatch does not), so this actually
+		// exercises the pause handler rather than silently no-opping.
 		act(() => {
-			toastButton.dispatchEvent(
-				new MouseEvent("mouseenter", { bubbles: true }),
-			);
+			fireEvent.mouseEnter(toastButton);
 		});
 
-		// Advance another 2000ms while paused — should NOT remove toast
+		// Advance past the original 4000ms total while paused: only 2000ms of the
+		// timer elapsed, so the toast must still be present and NOT fading. Without
+		// a working pause it would already be opacity-0.
 		act(() => {
 			vi.advanceTimersByTime(2000);
 		});
 
-		expect(screen.getByText("Pause test")).toBeInTheDocument();
+		expect(screen.getByText("Pause test")).toHaveClass("opacity-100");
 
-		// Unhover to resume
+		// Unhover to resume the remaining time.
 		act(() => {
-			toastButton.dispatchEvent(
-				new MouseEvent("mouseleave", { bubbles: true }),
-			);
+			fireEvent.mouseLeave(toastButton);
 		});
 
 		// Advance past remaining time — should now remove


### PR DESCRIPTION
Claws back some of the steady coverage drift with **meaningful, non-vacuous** tests for genuinely reachable gaps. No production code changed; test files only.

## Backend (real `go test -cover`)
| Package | Before | After |
|---|---|---|
| otelexport | 84.4% | 93.8% |
| metrics | 93.9% | **100%** |
| proxy `ExtractThinking` | 90.6% | **100%** |
| debuglog | 91.1% | 93.7% |
| model | 94.0% | 96.1% |
| ratelimit | 95.7% | 97.2% |
| provider | 96.4% | 96.7% |
| api | 94.4% | 94.7% |

- model `MarkLiveMetaFromCurrent`; debuglog `scopeFilterHandler` WithAttrs/WithGroup; otelexport `levelHandler` Handle/WithAttrs/WithGroup; metrics `labelOrUnknown`/nil breaker-collector; ratelimit `tpmRetryAfter`/non-positive `Debit`/keyless passthrough; provider `backfillFromCatalog`/`isEmptyModalities`; api discovery-changes HTTP path + `diffIsEmpty`/`countAffected`/`floatPtrEq` + price-jitter damping + `floatPtrVal`; proxy `ExtractThinking` streaming edges.

## Frontend (vitest)
- **Modal.tsx**: 80.6% -> 100% lines. New tests fire the opacity `transitionEnd` (close path, fallback-timer cancel, target/property guards) and Escape-to-close.
- **ToastContext.tsx**: the existing hover-pause test dispatched a raw native `mouseenter`, which never triggers React's synthetic `onMouseEnter`, so the pause handlers were uncovered and the assertion proved nothing. Switched to `fireEvent.mouseEnter/Leave` + a fading-state assertion so it genuinely exercises `handleMouseEnter`/`handleMouseLeave`.

Deliberately skipped vacuous/untestable targets: DB-error wrappers and circuit-breaker race branches (would need production test seams), and the shiki lazy-grammar import arrows (covering them just exercises dynamic imports).

🤖 Generated with [Claude Code](https://claude.com/claude-code)