### PR TITLE
test(web): fix no-assertion tests that verified nothing

### DIFF
--- a/web/src/components/__tests__/AccentCalendar.test.tsx
+++ b/web/src/components/__tests__/AccentCalendar.test.tsx
@@ -152,14 +152,26 @@ describe("AccentCalendar", () => {
 		expect(day20Button).toHaveClass("bg-(--accent)");
 	});
 
-	it("applies today styling for current day", () => {
-		// todayISO is mocked to return "2024-03-15"
+	it("applies today border styling when today is outside the selected range", () => {
+		// todayISO is mocked to 2024-03-15. The in-range fill outranks the today
+		// border, so pick a range that excludes the 15th to see the today styling.
+		renderWithProviders(
+			<AccentCalendar {...defaultProps} from="2024-03-01" to="2024-03-10" />,
+		);
+		const todayCell = screen.getByText("15").closest("button");
+		expect(todayCell?.className).toContain("border-(--accent)/50");
+		// A non-today, out-of-range day keeps plain styling, not the today border.
+		const otherCell = screen.getByText("25").closest("button");
+		expect(otherCell?.className).not.toContain("border-(--accent)/50");
+	});
+
+	it("in-range fill overrides today border when today is within the range", () => {
+		// Default range 10-20 includes the mocked today (15), so it gets the
+		// in-range fill instead of the today border.
 		renderWithProviders(<AccentCalendar {...defaultProps} />);
-		screen.getByText("15").closest("button");
-		// Today has border and accent color, but is overridden by isSelected if it's start/end
-		// Day 15 is in range but not start/end, so should show today styling if not in range
-		// Since day 15 is in range, the inRange styling takes precedence
-		// Let's test a day that's today but not in range
+		const todayCell = screen.getByText("15").closest("button");
+		expect(todayCell?.className).toContain("bg-(--accent)/20");
+		expect(todayCell?.className).not.toContain("border-(--accent)/50");
 	});
 
 	it("applies default styling for dates outside range", () => {

--- a/web/src/components/__tests__/ModelReplyCard.test.tsx
+++ b/web/src/components/__tests__/ModelReplyCard.test.tsx
@@ -220,19 +220,20 @@ describe("ModelReplyCard", () => {
 		});
 
 		it("calls onDisableModel when disable button is clicked", async () => {
+			const onDisableModel = vi.fn();
 			const { user } = renderWithProviders(
 				<ModelReplyCard
 					{...defaultProps}
 					error="502 Bad Gateway"
 					content=""
-					onDisableModel={vi.fn()}
+					onDisableModel={onDisableModel}
 				/>,
 			);
 			const disableButton = screen.getByRole("button", {
 				name: "Disable model",
 			});
 			await user.click(disableButton);
-			// onDisableModel should be called
+			expect(onDisableModel).toHaveBeenCalledTimes(1);
 		});
 
 		it("does not show disable button for non-5xx errors", () => {
@@ -347,8 +348,12 @@ describe("ModelReplyCard", () => {
 			});
 			await user.click(maximizeButton);
 			const copyButton = screen.getByRole("button", { name: "Copy" });
+			const writeText = vi
+				.spyOn(navigator.clipboard, "writeText")
+				.mockResolvedValue(undefined);
 			await user.click(copyButton);
-			// Clipboard copy is tested separately
+			expect(writeText).toHaveBeenCalledWith(defaultProps.content);
+			writeText.mockRestore();
 		});
 	});
 
@@ -434,16 +439,20 @@ describe("ModelReplyCard", () => {
 		});
 
 		it("calls onModelNameClick when model name is clicked", async () => {
+			const onModelNameClick = vi.fn();
 			const { user } = renderWithProviders(
-				<ModelReplyCard {...defaultProps} onModelNameClick={vi.fn()} />,
+				<ModelReplyCard
+					{...defaultProps}
+					onModelNameClick={onModelNameClick}
+				/>,
 			);
 			const modelNameButton = screen
 				.getByText("gemma3:4b")
 				.closest("[role='button']");
-			if (modelNameButton) {
-				await user.click(modelNameButton);
-				// onModelNameClick should be called
-			}
+			// The clickable model-name button must exist (no silent skip).
+			expect(modelNameButton).not.toBeNull();
+			await user.click(modelNameButton as HTMLElement);
+			expect(onModelNameClick).toHaveBeenCalledTimes(1);
 		});
 
 		it("shows info icon when showInfoIcon is true", () => {

--- a/web/src/components/__tests__/ModelReplyCard.test.tsx
+++ b/web/src/components/__tests__/ModelReplyCard.test.tsx
@@ -351,9 +351,14 @@ describe("ModelReplyCard", () => {
 			const writeText = vi
 				.spyOn(navigator.clipboard, "writeText")
 				.mockResolvedValue(undefined);
-			await user.click(copyButton);
-			expect(writeText).toHaveBeenCalledWith(defaultProps.content);
-			writeText.mockRestore();
+			try {
+				await user.click(copyButton);
+				expect(writeText).toHaveBeenCalledWith(defaultProps.content);
+			} finally {
+				// Restore in finally so a failed click/assertion can't leak the spy
+				// onto navigator.clipboard for the next test.
+				writeText.mockRestore();
+			}
 		});
 	});
 

--- a/web/src/hooks/__tests__/useDebounce.test.ts
+++ b/web/src/hooks/__tests__/useDebounce.test.ts
@@ -104,19 +104,20 @@ describe("useDebounce", () => {
 		expect(result.current).toEqual(updated);
 	});
 
-	it("cleans up timer on unmount", () => {
+	it("clears the pending debounce timer on unmount", () => {
 		const { unmount, rerender } = renderHook(
 			({ value, delay }) => useDebounce(value, delay),
 			{ initialProps: { value: "a", delay: 300 } },
 		);
 
+		// Changing the value schedules a pending debounce timer.
 		rerender({ value: "b", delay: 300 });
-		unmount();
+		expect(vi.getTimerCount()).toBe(1);
 
-		// No error should be thrown by the timer callback after unmount
-		act(() => {
-			vi.advanceTimersByTime(500);
-		});
+		// Unmount must run the effect cleanup, clearing that timer so it can never
+		// fire setState on an unmounted component.
+		unmount();
+		expect(vi.getTimerCount()).toBe(0);
 	});
 
 	it("respects changing delay", () => {

--- a/web/src/hooks/__tests__/useGitHubVersion.test.ts
+++ b/web/src/hooks/__tests__/useGitHubVersion.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { mockSettings, mockVersionLatest } from "../../test/helpers";
 import { server } from "../../test/mocks/server";
@@ -69,11 +69,15 @@ describe("useGitHubVersion", () => {
 
 		server.use(...mockVersionLatest({ body: { tag_name: "v0.2" } }));
 
-		renderHook(() => useGitHubVersion());
+		const { result } = renderHook(() => useGitHubVersion());
+		// Starts from the stale cached tag...
+		expect(result.current.latest).toBe("v0.1.1");
 
-		await act(async () => {
-			await new Promise((r) => setTimeout(r, 0));
-		});
+		// ...then the stale cache triggers a refetch that updates to the new tag
+		// and rewrites the cache.
+		await waitFor(() => expect(result.current.latest).toBe("v0.2"));
+		const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "{}");
+		expect(stored.tag).toBe("v0.2");
 	});
 
 	it("updates latest from API response", async () => {

--- a/web/src/pages/Providers/__tests__/AddProviderModal.test.tsx
+++ b/web/src/pages/Providers/__tests__/AddProviderModal.test.tsx
@@ -334,22 +334,10 @@ describe("AddProviderModal", () => {
 	});
 
 	describe("submit functionality", () => {
-		it("calls create mutation on form submit", async () => {
-			const { user } = renderWithProviders(
-				<AddProviderModal {...defaultProps} />,
-			);
-			const nameInput = screen.getByLabelText("Name");
-			const baseUrlInput = screen.getByLabelText("Base URL");
-			const apiKeyInput = screen.getByLabelText("API Key");
-			await user.type(nameInput, "Test Provider");
-			await user.type(baseUrlInput, "https://api.test.com/v1");
-			await user.type(apiKeyInput, "sk-test-key");
-			const submitButton = screen.getByRole("button", {
-				name: "Add Provider",
-			});
-			await user.click(submitButton);
-			// Form should submit
-		});
+		// Removed a no-assertion "calls create mutation on form submit" test: the
+		// submit -> create-mutation path is covered with real assertions by
+		// "calls onToast with success message on successful creation" and
+		// "calls onClose after successful creation" below.
 
 		it("calls onToast with success message on successful creation", async () => {
 			server.use(
@@ -625,29 +613,12 @@ describe("AddProviderModal", () => {
 			expect(onClose).toHaveBeenCalledTimes(1);
 		});
 
-		it("resets form data after cancel", async () => {
-			const { user } = renderWithProviders(
-				<AddProviderModal {...defaultProps} />,
-			);
-			const nameInput = screen.getByLabelText("Name");
-			await user.type(nameInput, "Test");
-			const cancelButton = screen.getByRole("button", { name: "Cancel" });
-			await user.click(cancelButton);
-			// Form should be reset
-		});
-
-		it("hides API key visibility state on cancel", async () => {
-			const { user } = renderWithProviders(
-				<AddProviderModal {...defaultProps} />,
-			);
-			const toggleButton = screen.getByRole("button", {
-				name: "Show API key",
-			});
-			await user.click(toggleButton);
-			const cancelButton = screen.getByRole("button", { name: "Cancel" });
-			await user.click(cancelButton);
-			// Visibility state should be reset
-		});
+		// Removed two no-assertion cancel tests ("resets form data after cancel",
+		// "hides API key visibility state on cancel"): the reset runs inside the
+		// same closeAndReset handler exercised by "calls onClose when cancel button
+		// is clicked" above, and the internal state is not observable after the
+		// modal closes, so the tests asserted nothing. The API-key toggle itself is
+		// covered by the Show/Hide visibility tests.
 
 		it("clears error on cancel", async () => {
 			server.use(

--- a/web/src/pages/Providers/__tests__/EditProviderModal.test.tsx
+++ b/web/src/pages/Providers/__tests__/EditProviderModal.test.tsx
@@ -209,8 +209,9 @@ describe("EditProviderModal", () => {
 				/>,
 			);
 			const toggle = screen.getByLabelText("Provider enabled");
+			expect(toggle).toBeChecked();
 			await user.click(toggle);
-			// Toggle should be unchecked after click
+			expect(toggle).not.toBeChecked();
 		});
 
 		it("toggles autodiscovery switch when clicked", async () => {
@@ -274,14 +275,9 @@ describe("EditProviderModal", () => {
 	});
 
 	describe("save functionality", () => {
-		it("calls update mutation on form submit", async () => {
-			const { user } = renderWithProviders(
-				<EditProviderModal {...defaultProps} />,
-			);
-			const saveButton = screen.getByRole("button", { name: "Save Changes" });
-			await user.click(saveButton);
-			// Form should submit
-		});
+		// (The submit -> update-mutation path is covered with real assertions by
+		// "calls onClose after successful update" and the payload-capture tests
+		// below; a no-assertion "form should submit" duplicate was removed.)
 
 		it("calls onToast with success message on successful update", async () => {
 			server.use(

--- a/web/src/pages/__tests__/Arena.streaming.test.tsx
+++ b/web/src/pages/__tests__/Arena.streaming.test.tsx
@@ -92,12 +92,12 @@ describe("Arena", () => {
 			const { user } = renderWithProviders(<Arena />);
 			await waitForArenaLoad();
 
+			// setupAndRunArena runs the arena and waits for the run control to flip
+			// to the "Stop All" button (its final waitFor), which is exactly the
+			// transition this test covers. Re-checking the transient button here
+			// raced the short mock stream's completion and was flaky, so the helper's
+			// wait is the assertion.
 			await setupAndRunArena(user, { mode: "compare" });
-
-			// While streaming is in flight the run control becomes a Stop button.
-			expect(
-				await screen.findByRole("button", { name: "Stop All" }),
-			).toBeInTheDocument();
 		});
 
 		it("shows generating message during running phase", async () => {
@@ -233,12 +233,9 @@ describe("Arena", () => {
 			const { user } = renderWithProviders(<Arena />);
 			await waitForArenaLoad();
 
+			// As above: setupAndRunArena's final waitFor already asserts the run
+			// control becomes "Stop All" once streaming starts.
 			await setupAndRunArena(user);
-
-			// While streaming is in flight the run control becomes a Stop button.
-			expect(
-				await screen.findByRole("button", { name: "Stop All" }),
-			).toBeInTheDocument();
 		});
 
 		it("phase transitions to voting after streaming completes in competition mode", {

--- a/web/src/pages/__tests__/Arena.streaming.test.tsx
+++ b/web/src/pages/__tests__/Arena.streaming.test.tsx
@@ -93,6 +93,11 @@ describe("Arena", () => {
 			await waitForArenaLoad();
 
 			await setupAndRunArena(user, { mode: "compare" });
+
+			// While streaming is in flight the run control becomes a Stop button.
+			expect(
+				await screen.findByRole("button", { name: "Stop All" }),
+			).toBeInTheDocument();
 		});
 
 		it("shows generating message during running phase", async () => {
@@ -229,6 +234,11 @@ describe("Arena", () => {
 			await waitForArenaLoad();
 
 			await setupAndRunArena(user);
+
+			// While streaming is in flight the run control becomes a Stop button.
+			expect(
+				await screen.findByRole("button", { name: "Stop All" }),
+			).toBeInTheDocument();
 		});
 
 		it("phase transitions to voting after streaming completes in competition mode", {


### PR DESCRIPTION
Independent of #271 (based directly on master). Hunts down frontend tests that exercised a code path but asserted nothing (comments like "should be called" / "form should submit" with no expect), and either makes them verify real behavior or removes them when an equivalent meaningful test already exists.

## Fixed to assert real behavior
- **ModelReplyCard**: assert onDisableModel/onModelNameClick actually fire; assert the modal Copy button calls clipboard.writeText with the content (spy locally, since the global navigator stub is unstubbed between tests); drop a silent `if (button)` skip that passed when the element was missing.
- **EditProviderModal**: assert the enabled toggle flips.
- **AccentCalendar**: the "applies today styling" test had only musing comments and no assertion (today was in range, so the styling it described never applied). Split into two real tests covering both the today-border and the in-range-fill-overrides-it cases.
- **useDebounce**: assert the pending timer count drops to 0 on unmount.
- **useGitHubVersion**: assert the stale-cache path starts from the cached tag, refetches to the new tag, and rewrites the cache.
- **Arena.streaming**: the two "button changes to Stop" tests never checked the button; assert the "Stop All" control appears while streaming.

## Removed (redundant + no-assertion)
- EditProviderModal "calls update mutation on form submit" and AddProviderModal "calls create mutation on form submit" / the two reset-on-cancel tests: all covered with real assertions by existing onClose/onToast/visibility tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)