### PR TITLE
docs(readme): remove em dashes from the Themeable UI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ For providers that expose it, click a provider's quota badge (on its card or in 
 </p>
 
 ### [<img src="docs/icons/settings.svg" width="20" height="20" style="vertical-align:middle;margin-right:6px;" alt=""> Themeable UI](#-themeable-ui)
-Make the dashboard your own from the Appearance settings: pick one of three **UI styles** — **Clean SaaS** (refined and minimal, the default), **Cyber Terminal** (high-contrast, developer-centric), or **Glassmorphism** (slick translucent surfaces) — toggle **dark / light** mode, and choose an **accent color** (each style ships a tasteful default, or pick your own). Everything persists locally in the browser. The animated dashboard at the top of this page cycles through all three.
+Make the dashboard your own from the Appearance settings. Pick one of three **UI styles**: **Clean SaaS** (refined and minimal, the default), **Cyber Terminal** (high-contrast, developer-centric), or **Glassmorphism** (slick translucent surfaces). Then toggle **dark / light** mode, and choose an **accent color** (each style ships a tasteful default, or pick your own). Everything persists locally in the browser. The animated dashboard at the top of this page cycles through all three.
 
 <p align="center">
   <img src="docs/screenshots/dashboard_saas.png" width="265" alt="Clean SaaS UI style">


### PR DESCRIPTION
Removes the two em dashes in the Themeable UI section (colon to introduce the style list, sentence break before the dark/light toggle), per the no-em-dash copy convention. They were the only em dashes left in the README.

`DOCKERHUB.md` intentionally not touched: it is the pic-less Docker Hub copy, already em-dash-free, and does not carry this phrasing. Labeled `dockerhub-readme-not-needed` so the README/DOCKERHUB sync guard passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)