### PR TITLE
test(web): de-vacuum if-guarded assertions; fix hollow tests

### DIFF
--- a/web/src/components/__tests__/AccentCalendar.test.tsx
+++ b/web/src/components/__tests__/AccentCalendar.test.tsx
@@ -111,10 +111,9 @@ describe("AccentCalendar", () => {
 		const user = userEvent.setup();
 		renderWithProviders(<AccentCalendar {...defaultProps} />);
 		const day15Button = screen.getByText("15").closest("button");
-		if (day15Button) {
-			await user.click(day15Button);
-			expect(mockOnSelect).toHaveBeenCalledWith("2024-03-15");
-		}
+		expect(day15Button).not.toBeNull();
+		await user.click(day15Button as HTMLElement);
+		expect(mockOnSelect).toHaveBeenCalledWith("2024-03-15");
 	});
 
 	it("applies isInRange styling for dates within range", () => {

--- a/web/src/components/__tests__/ConversationConfig.test.tsx
+++ b/web/src/components/__tests__/ConversationConfig.test.tsx
@@ -267,10 +267,9 @@ describe("ConversationConfig", () => {
 			const toggleButton = allButtons.find(
 				(btn) => !btn.textContent?.includes("Start"),
 			);
-			if (toggleButton) {
-				await user.click(toggleButton);
-				expect(defaultProps.onToggleCollapsed).toHaveBeenCalledTimes(1);
-			}
+			expect(toggleButton).toBeDefined();
+			await user.click(toggleButton as HTMLElement);
+			expect(defaultProps.onToggleCollapsed).toHaveBeenCalledTimes(1);
 		});
 	});
 

--- a/web/src/components/__tests__/LogDetailModal.test.tsx
+++ b/web/src/components/__tests__/LogDetailModal.test.tsx
@@ -435,10 +435,8 @@ describe("LogDetailModal", () => {
 				/>,
 			);
 
-			const errorSection = screen.queryByText("Error");
-			if (errorSection) {
-				expect(errorSection).not.toBeInTheDocument();
-			}
+			// The Error section must not render when the log has no error message.
+			expect(screen.queryByText("Error")).not.toBeInTheDocument();
 		});
 
 		it("calls onClose when close button is clicked", async () => {

--- a/web/src/components/__tests__/ModelPicker.test.tsx
+++ b/web/src/components/__tests__/ModelPicker.test.tsx
@@ -326,26 +326,36 @@ describe("ModelPicker", () => {
 			expect(screen.getByText("Llama 3")).toBeInTheDocument();
 		});
 
-		it("disables capability pill when no models match", () => {
-			const modelsWithOnlyVision = mockModels.map((m) => ({
-				...m,
-				capabilities: '{"streaming":true,"vision":true,"audio_input":false}',
-			}));
-			renderWithProviders(
-				<ModelPicker {...defaultProps} models={modelsWithOnlyVision} />,
+		it("disables a capability pill when adding it to the active filter yields no models", async () => {
+			// A pill only renders for a capability present in the data, so give the
+			// two models DISJOINT capabilities: one vision-only, one tools-only. Both
+			// pills render and start enabled, but no model has both, so once Vision is
+			// selected, adding Tools would yield nothing and its pill must disable.
+			const disjoint: Model[] = [
+				{
+					...mockModels[0],
+					model_id: "vision-only",
+					capabilities: '{"vision":true,"tool_calling":false}',
+				},
+				{
+					...mockModels[1],
+					model_id: "tools-only",
+					capabilities: '{"vision":false,"tool_calling":true}',
+				},
+			];
+			const { user } = renderWithProviders(
+				<ModelPicker {...defaultProps} models={disjoint} />,
 			);
-			// Audio button exists in CAP_META but should be disabled since no models have audio_input
-			const audioButton = screen.queryByText("Audio");
-			if (audioButton) {
-				expect(audioButton).toBeDisabled();
-			} else {
-				// Audio pill may not render if no models have any audio capability at all
-				// In that case, check that Tools (another capability no model has) is disabled
-				const toolsButton = screen.queryByText("Tools");
-				if (toolsButton) {
-					expect(toolsButton).toBeDisabled();
-				}
-			}
+
+			const toolsPill = screen.getByText("Tools").closest("button");
+			expect(toolsPill).not.toBeNull();
+			expect(toolsPill).toBeEnabled();
+
+			await user.click(
+				screen.getByText("Vision").closest("button") as HTMLElement,
+			);
+
+			expect(screen.getByText("Tools").closest("button")).toBeDisabled();
 		});
 	});
 

--- a/web/src/components/__tests__/ParamSlider.test.tsx
+++ b/web/src/components/__tests__/ParamSlider.test.tsx
@@ -137,10 +137,9 @@ describe("ParamSlider", () => {
 			/>,
 		);
 		const container = screen.getByText("Temperature").parentElement;
-		if (container) {
-			await user.hover(container);
-			expect(screen.getByText("Feature not available")).toBeInTheDocument();
-		}
+		expect(container).not.toBeNull();
+		await user.hover(container as HTMLElement);
+		expect(screen.getByText("Feature not available")).toBeInTheDocument();
 	});
 
 	it("renders placeholder when value is undefined", () => {
@@ -224,12 +223,11 @@ describe("ParamSlider", () => {
 			/>,
 		);
 		const container = screen.getByText("Temperature").parentElement;
-		if (container) {
-			await user.hover(container);
-			expect(screen.getByRole("tooltip")).toBeInTheDocument();
-			await user.unhover(container);
-			expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
-		}
+		expect(container).not.toBeNull();
+		await user.hover(container as HTMLElement);
+		expect(screen.getByRole("tooltip")).toBeInTheDocument();
+		await user.unhover(container as HTMLElement);
+		expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
 	});
 
 	it("does not show tooltip when disabled but no disabledReason", async () => {
@@ -246,10 +244,9 @@ describe("ParamSlider", () => {
 			/>,
 		);
 		const container = screen.getByText("Temperature").parentElement;
-		if (container) {
-			await user.hover(container);
-			expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
-		}
+		expect(container).not.toBeNull();
+		await user.hover(container as HTMLElement);
+		expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
 	});
 
 	it("does not call onChange from range slider when disabled", () => {

--- a/web/src/components/__tests__/ProviderFilter.test.tsx
+++ b/web/src/components/__tests__/ProviderFilter.test.tsx
@@ -337,10 +337,9 @@ describe("ProviderFilter", () => {
 			/>,
 		);
 		const clearBadge = screen.getByText("2").closest("[role='button']");
-		if (clearBadge) {
-			await user.click(clearBadge);
-			expect(mockOnChange).toHaveBeenCalledWith(new Set());
-		}
+		expect(clearBadge).not.toBeNull();
+		await user.click(clearBadge as HTMLElement);
+		expect(mockOnChange).toHaveBeenCalledWith(new Set());
 	});
 
 	it("shows clear badge count when providers are selected", () => {

--- a/web/src/hooks/__tests__/useQuotaData.test.tsx
+++ b/web/src/hooks/__tests__/useQuotaData.test.tsx
@@ -627,11 +627,10 @@ describe("useQuotaData", () => {
 			expect(result.current.nanogptUsage).toBeDefined();
 		});
 
-		// Check that data was cached
+		// The successful fetch must have written the usage to the cache.
 		const cachedData = localStorage.getItem("model-hotel:nanogpt-usage");
-		if (cachedData) {
-			expect(JSON.parse(cachedData)).toBeDefined();
-		}
+		expect(cachedData).not.toBeNull();
+		expect(JSON.parse(cachedData as string)).toBeDefined();
 	});
 
 	it("uses cached data as initialData on first render", async () => {

--- a/web/src/pages/Arena/__tests__/WinnerSummaryModal.test.tsx
+++ b/web/src/pages/Arena/__tests__/WinnerSummaryModal.test.tsx
@@ -308,12 +308,11 @@ describe("WinnerSummaryModal", () => {
 		const backdrop = document.querySelector(
 			"button[aria-label='Close dialog']",
 		);
-		if (backdrop) {
-			await user.click(backdrop);
-			await waitFor(() => {
-				expect(onCloseMock).toHaveBeenCalledTimes(1);
-			});
-		}
+		expect(backdrop).not.toBeNull();
+		await user.click(backdrop as HTMLElement);
+		await waitFor(() => {
+			expect(onCloseMock).toHaveBeenCalledTimes(1);
+		});
 	});
 
 	it("renders multiple matchups in a round", () => {

--- a/web/src/pages/Dashboard/__tests__/GaugeModal.test.tsx
+++ b/web/src/pages/Dashboard/__tests__/GaugeModal.test.tsx
@@ -134,12 +134,11 @@ describe("GaugeModal", () => {
 		const backdrop = document.querySelector(
 			"button[aria-label='Close dialog']",
 		);
-		if (backdrop) {
-			await user.click(backdrop);
-			await waitFor(() => {
-				expect(onCloseMock).toHaveBeenCalledTimes(1);
-			});
-		}
+		expect(backdrop).not.toBeNull();
+		await user.click(backdrop as HTMLElement);
+		await waitFor(() => {
+			expect(onCloseMock).toHaveBeenCalledTimes(1);
+		});
 	});
 
 	it("fetches time series data when modal opens", async () => {

--- a/web/src/pages/FailoverGroups/__tests__/FailoverGroupCard.test.tsx
+++ b/web/src/pages/FailoverGroups/__tests__/FailoverGroupCard.test.tsx
@@ -509,14 +509,11 @@ describe("FailoverGroupCard", () => {
 				/>,
 			);
 
-			// Find Provider 1 entry and click its toggle button
-			const providerEntry = screen.getByText("Provider 1");
-			// Toggle button is within the entry
-			const toggleButton = providerEntry.closest("li")?.querySelector("button");
-			if (toggleButton) {
-				await user.click(toggleButton);
-				expect(onToggleEntry).toHaveBeenCalledWith("entry-1", false);
-			}
+			// The entry's enable toggle is the only role="switch" (the group toggle
+			// is a plain badge button). Clicking it flips entry-1 off.
+			const toggleButton = screen.getByRole("switch");
+			await user.click(toggleButton);
+			expect(onToggleEntry).toHaveBeenCalledWith("entry-1", false);
 		});
 
 		it("calls onReorder when drag and drop ends", async () => {

--- a/web/src/pages/FailoverGroups/__tests__/SortableEntry.circuit-breaker.test.tsx
+++ b/web/src/pages/FailoverGroups/__tests__/SortableEntry.circuit-breaker.test.tsx
@@ -175,6 +175,7 @@ describe("SortableEntry - Circuit Breaker Fuse Outline", () => {
 
 			// Entry should have overflow: hidden
 			const wrapperDiv = getWrapperDiv(container);
+			expect(wrapperDiv).not.toBeNull();
 			if (wrapperDiv) {
 				expect(wrapperDiv).toHaveStyle("overflow: hidden");
 			}
@@ -216,6 +217,7 @@ describe("SortableEntry - Circuit Breaker Fuse Outline", () => {
 
 			// Entry should have overflow: hidden when showFuse is true
 			const wrapperDiv = getWrapperDiv(container);
+			expect(wrapperDiv).not.toBeNull();
 			if (wrapperDiv) {
 				expect(wrapperDiv).toHaveStyle("overflow: hidden");
 			}
@@ -246,6 +248,7 @@ describe("SortableEntry - Circuit Breaker Fuse Outline", () => {
 
 			// Entry should NOT have overflow: hidden (disabled entries don't show fuse)
 			const wrapperDiv = getWrapperDiv(container);
+			expect(wrapperDiv).not.toBeNull();
 			if (wrapperDiv) {
 				expect(wrapperDiv).not.toHaveStyle("overflow: hidden");
 			}
@@ -277,6 +280,7 @@ describe("SortableEntry - Circuit Breaker Fuse Outline", () => {
 
 			// Entry should have overflow: hidden
 			const wrapperDiv = getWrapperDiv(container);
+			expect(wrapperDiv).not.toBeNull();
 			if (wrapperDiv) {
 				expect(wrapperDiv).toHaveStyle("overflow: hidden");
 			}

--- a/web/src/pages/Settings/__tests__/AppearanceSettings.test.tsx
+++ b/web/src/pages/Settings/__tests__/AppearanceSettings.test.tsx
@@ -152,10 +152,10 @@ describe("AppearanceSettings", () => {
 		const firstColorButton = colorButtons.find(
 			(btn) => btn.getAttribute("title") !== "Custom color",
 		);
-		if (firstColorButton) {
-			await user.click(firstColorButton);
-			expect(firstColorButton).toBeInTheDocument();
-		}
+		expect(firstColorButton).toBeDefined();
+		// Clicking a preset must not throw; the Theme context applies the accent.
+		await user.click(firstColorButton as HTMLElement);
+		expect(firstColorButton).toBeInTheDocument();
 	});
 
 	it("opens color picker modal when custom color button clicked", async () => {

--- a/web/src/pages/__tests__/FailoverGroups.filtering-sorting.test.tsx
+++ b/web/src/pages/__tests__/FailoverGroups.filtering-sorting.test.tsx
@@ -319,26 +319,29 @@ describe("FailoverGroups", () => {
 				expect(screen.getByText("hotel/test-one")).toBeInTheDocument();
 			});
 
-			// Find the collapse toggle for "T" section (test starts with T)
-			const allButtons = screen.getAllByRole("button");
-			const tToggle = allButtons.find((btn) => btn.textContent?.trim() === "T");
+			// The "T" letter-section header is a button whose bold letter sits in its
+			// own span (the button also holds a chevron and a group-count span, so its
+			// full text is not just "T"). Target the letter span and walk to it.
+			const tToggle = screen.getByText("T").closest("button");
+			expect(tToggle).not.toBeNull();
 
-			if (tToggle) {
-				// Collapse
-				await user.click(tToggle);
+			// Collapse is CSS-only (the content grid animates to 0fr and stays in the
+			// DOM), so assert the toggle state via the chevron: it carries "rotate-90"
+			// only while the section is expanded.
+			const chevron = tToggle?.querySelector("svg");
+			expect(chevron?.getAttribute("class")).toContain("rotate-90");
 
-				await waitFor(() => {
-					expect(screen.queryByText("hotel/test-one")).not.toBeInTheDocument();
-				});
+			// Collapse.
+			await user.click(tToggle as HTMLElement);
+			await waitFor(() => {
+				expect(chevron?.getAttribute("class")).not.toContain("rotate-90");
+			});
 
-				// Expand again
-				await user.click(tToggle);
-
-				await waitFor(() => {
-					expect(screen.getByText("hotel/test-one")).toBeInTheDocument();
-					expect(screen.getByText("hotel/test-two")).toBeInTheDocument();
-				});
-			}
+			// Expand again.
+			await user.click(tToggle as HTMLElement);
+			await waitFor(() => {
+				expect(chevron?.getAttribute("class")).toContain("rotate-90");
+			});
 		});
 
 		it("custom groups appear in a Custom section above letter sections", async () => {

--- a/web/src/pages/__tests__/Logs.modal-updates.test.tsx
+++ b/web/src/pages/__tests__/Logs.modal-updates.test.tsx
@@ -131,12 +131,11 @@ describe("Logs", () => {
 
 			// Click on the row
 			const row = screen.getByText("test-model").closest("tr");
-			if (row) {
-				await user.click(row);
-				await waitFor(() => {
-					expect(screen.getByTestId("log-detail-modal")).toBeInTheDocument();
-				});
-			}
+			expect(row).not.toBeNull();
+			await user.click(row as HTMLElement);
+			await waitFor(() => {
+				expect(screen.getByTestId("log-detail-modal")).toBeInTheDocument();
+			});
 		});
 
 		it("closes log detail modal when close button is clicked", async () => {
@@ -173,6 +172,7 @@ describe("Logs", () => {
 
 			// Click on the row
 			const row = screen.getByText("test-model").closest("tr");
+			expect(row).not.toBeNull();
 			if (row) {
 				await user.click(row);
 
@@ -204,6 +204,7 @@ describe("Logs", () => {
 
 			// Click live badge
 			const liveBadge = screen.getByText("Live").closest("button");
+			expect(liveBadge).not.toBeNull();
 			if (liveBadge) {
 				await user.click(liveBadge);
 

--- a/web/src/pages/__tests__/Logs.view-modes.test.tsx
+++ b/web/src/pages/__tests__/Logs.view-modes.test.tsx
@@ -496,6 +496,7 @@ describe("Logs", () => {
 			// In-progress rows show a live-ticking elapsed duration (blue), computed
 			// from created_at, rather than the old dash placeholder.
 			const row = screen.getByText("inprogress-001").closest("tr");
+			expect(row).not.toBeNull();
 			if (row) {
 				const cells = within(row).getAllByRole("cell");
 				const liveCell = cells.find(


### PR DESCRIPTION
Frontend test-quality sweep. Many tests wrapped their only assertions in `if (element) { ...expect }`, so a null/missing element passed the test **hollow** (the same antipattern as the ToastContext hover and recommendedSettings family tests fixed earlier). This converts them to assert the element exists, then act/assert unconditionally (matching the codebase's existing `expect(x).not.toBeNull()`-before-narrowing convention), and repairs three tests that turned out to verify nothing at all.

## De-vacuumed (assert-then-act)
ParamSlider (x3), ConversationConfig, LogDetailModal (was self-contradictory), AccentCalendar, ProviderFilter, WinnerSummaryModal, GaugeModal, AppearanceSettings, Logs (row + live badge + view-modes), useQuotaData cache-write, SortableEntry circuit-breaker (x3).

## Genuinely-broken tests the sweep exposed and fixed
- **FailoverGroupCard "calls onToggleEntry"**: selector `providerEntry.closest("li")?.querySelector("button")` returned `undefined`, so the guarded body never ran. Target the entry's `role="switch"` toggle; now actually asserts `onToggleEntry` fires.
- **ModelPicker "disables capability pill"**: pills only render for capabilities present in the data, so the all-vision setup rendered neither Audio nor Tools and asserted nothing. Rewritten with two disjoint-capability models so selecting Vision genuinely disables the Tools pill.
- **FailoverGroups "toggling letter collapse"**: the toggle was matched by `textContent === "T"`, but the header text is `"T" + count`, so it was never found; and collapse is CSS-only (grid-rows, content stays in the DOM). Target the letter span and assert the chevron's collapse state.

Left untouched: the `if (isCompareMode) {...} else {...}` arena-state tests, which assert in both branches (not vacuous). No production code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)