### PR TITLE
test(web): Chat + Settings section coverage (section pass 2)

### DIFF
--- a/web/src/pages/Chat/__tests__/useChat.test.tsx
+++ b/web/src/pages/Chat/__tests__/useChat.test.tsx
@@ -1382,6 +1382,60 @@ describe("useChat", () => {
 			expect(userMessages[0].content).toBe("First");
 			expect(userMessages[1].content).toBe("Second");
 		});
+
+		it("shows a toast when regenerate resolves with an error result", async () => {
+			// streamModelResponse resolves (does not throw) with a non-aborted error,
+			// e.g. an upstream provider error surfaced on the stream.
+			mockGetApiMessagesForModel.mockReturnValue([
+				{ role: "user", content: "Second" },
+			]);
+			mockStreamModelResponse.mockResolvedValue({
+				rawContent: "",
+				content: "",
+				thinkingContent: "",
+				tokensPerSecond: 0,
+				durationMs: 0,
+				promptTokens: 0,
+				completionTokens: 0,
+				error: "Upstream provider error",
+				aborted: false,
+			});
+			const { result } = renderHook(() => useChat());
+			act(() => {
+				result.current.setMessages([
+					{ role: "user", content: "Second", timestamp: 1 },
+					{ role: "assistant", content: "Second response", timestamp: 2 },
+				]);
+				result.current.setChatSelectedModel("test/model");
+			});
+			await act(async () => {
+				await result.current.handleRegenerate();
+			});
+			expect(mockToast).toHaveBeenCalledWith(
+				"Upstream provider error",
+				"error",
+			);
+		});
+
+		it("shows a toast when regenerate throws a non-abort error", async () => {
+			mockGetApiMessagesForModel.mockReturnValue([
+				{ role: "user", content: "Second" },
+			]);
+			mockStreamModelResponse.mockRejectedValue(new Error("Network down"));
+			const { result } = renderHook(() => useChat());
+			act(() => {
+				result.current.setMessages([
+					{ role: "user", content: "Second", timestamp: 1 },
+					{ role: "assistant", content: "Second response", timestamp: 2 },
+				]);
+				result.current.setChatSelectedModel("test/model");
+			});
+			await act(async () => {
+				await result.current.handleRegenerate();
+			});
+			expect(mockToast).toHaveBeenCalledWith("Network down", "error");
+			expect(result.current.isStreaming).toBe(false);
+		});
 	});
 
 	describe("messages initializer", () => {

--- a/web/src/pages/Settings/__tests__/DataStorageSettings.test.tsx
+++ b/web/src/pages/Settings/__tests__/DataStorageSettings.test.tsx
@@ -975,6 +975,54 @@ describe("Delete Request Logs", () => {
 		});
 	});
 
+	it.each([
+		["1d", "24h"],
+		["1w", "168h"],
+		["1m", "720h"],
+		["all", "all"],
+	])("maps the %s selection to older_than=%s in the purge request", async (selection, expected) => {
+		let capturedOlderThan: string | undefined;
+		server.use(
+			http.delete("/api/logs/purge", async ({ request }) => {
+				capturedOlderThan = ((await request.json()) as { older_than: string })
+					.older_than;
+				return HttpResponse.json({ deleted: 1 });
+			}),
+		);
+		const user = userEvent.setup();
+		renderWithProviders(
+			<DataStorageSettings collapsed={false} onToggle={onToggle} />,
+		);
+
+		await user.click(screen.getByRole("button", { name: /delete requests/i }));
+		await user.selectOptions(screen.getByRole("combobox"), selection);
+		await user.click(screen.getByRole("button", { name: /confirm delete/i }));
+
+		await waitFor(() => expect(capturedOlderThan).toBe(expected));
+	});
+
+	it("shows an error toast when purging requests fails", async () => {
+		server.use(
+			http.delete("/api/logs/purge", () =>
+				HttpResponse.json({ error: "boom" }, { status: 500 }),
+			),
+		);
+		const user = userEvent.setup();
+		renderWithProviders(
+			<DataStorageSettings collapsed={false} onToggle={onToggle} />,
+		);
+
+		await user.click(screen.getByRole("button", { name: /delete requests/i }));
+		await user.selectOptions(screen.getByRole("combobox"), "1d");
+		await user.click(screen.getByRole("button", { name: /confirm delete/i }));
+
+		await waitFor(() => {
+			expect(screen.getByText(/failed to delete/i)).toBeInTheDocument();
+		});
+		// The confirm UI is dismissed on error.
+		expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+	});
+
 	it("cancels delete when cancel clicked", async () => {
 		const user = userEvent.setup();
 		renderWithProviders(
@@ -1052,6 +1100,25 @@ describe("Delete App Logs", () => {
 		// Verify the confirm button was clicked (mutation called via MSW handler)
 		await waitFor(() => {
 			expect(confirmButton).not.toBeInTheDocument();
+		});
+	});
+
+	it("shows an error toast when purging app logs fails", async () => {
+		server.use(
+			http.delete("/api/logs/app", () =>
+				HttpResponse.json({ error: "boom" }, { status: 500 }),
+			),
+		);
+		const user = userEvent.setup();
+		renderWithProviders(
+			<DataStorageSettings collapsed={false} onToggle={onToggle} />,
+		);
+
+		await user.click(screen.getByRole("button", { name: /delete logs/i }));
+		await user.click(screen.getByRole("button", { name: /^confirm$/i }));
+
+		await waitFor(() => {
+			expect(screen.getByText(/failed to delete/i)).toBeInTheDocument();
 		});
 	});
 


### PR DESCRIPTION
Second slice of the section-by-section pass (continues #276). Test-only.

## Chat section
**useChat `handleRegenerate` error paths (464-468).** The existing abort/error tests only exercise `handleSend`; regenerate's own error handling was uncovered:
- `streamModelResponse` resolves with a non-aborted error result -> toast.
- it throws a non-abort error -> toast + streaming cleared.

## Settings section
**DataStorageSettings: 88.9% -> 98.1% lines.** Covered the purge controls that previously only had success-path tests:
- parametrized mapping test: each window selection sends the right `older_than` (1d->24h, 1w->168h, 1m->720h, all->all), covering `getDeleteOlderThan`.
- requests-purge failure shows the error toast and dismisses the confirm UI.
- app-logs-purge failure shows the error toast.

(Only an unreachable default switch case and one slider reset callback remain there.)

No production code changed. More sections to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)