### PR TITLE
test(web): Models + components section coverage (section pass 3)

### DIFF
--- a/web/src/components/__tests__/ProviderQuotaPanel.test.tsx
+++ b/web/src/components/__tests__/ProviderQuotaPanel.test.tsx
@@ -75,6 +75,31 @@ function setupPanel(overrides?: Partial<QuotaDataResult>) {
 }
 
 describe("ProviderQuotaPanel", () => {
+	it("falls back to defaults when its localStorage reads throw", () => {
+		// Privacy/locked-down browsers can make localStorage access throw. The
+		// disabled/collapsed/refresh init readers must swallow that and use
+		// defaults (enabled, expanded), so the panel still renders its controls.
+		const blocked = new Set([
+			"sidebarQuotaDisabled",
+			"sidebarQuotaCollapsed",
+			"sidebarQuotaRefreshMin",
+		]);
+		const realGetItem = Storage.prototype.getItem;
+		const spy = vi
+			.spyOn(Storage.prototype, "getItem")
+			.mockImplementation(function (this: Storage, key: string) {
+				if (blocked.has(key)) throw new Error("localStorage blocked");
+				return realGetItem.call(this, key);
+			});
+
+		try {
+			setupPanel();
+			expect(screen.getByTitle("Collapse")).toBeInTheDocument();
+		} finally {
+			spy.mockRestore();
+		}
+	});
+
 	const mockNanoUsage: import("../../api/types").NanoGPTUsage = {
 		active: true,
 		provider: "nanogpt",

--- a/web/src/pages/Models/__tests__/ModelDetailModal.test.tsx
+++ b/web/src/pages/Models/__tests__/ModelDetailModal.test.tsx
@@ -528,6 +528,58 @@ describe("ModelDetailModal", () => {
 		expect(revertBtn).toHaveClass("shrink-0");
 	});
 
+	it("reverts display_name to the discovered value when its revert button is clicked", async () => {
+		const user = userEvent.setup();
+		renderWithProviders(<ModelDetailModal {...defaultProps} />);
+		await user.click(screen.getByText("Edit"));
+
+		// display_name differs from the discovered default, so exactly one revert
+		// button is shown. Clicking it resets editData to the discovered value, so
+		// the button condition becomes false and it disappears.
+		await user.click(screen.getByTitle("Revert to discovered value"));
+		await waitFor(() =>
+			expect(
+				screen.queryByTitle("Revert to discovered value"),
+			).not.toBeInTheDocument(),
+		);
+	});
+
+	it("reverts a changed input price when its revert button is clicked", async () => {
+		const user = userEvent.setup();
+		renderWithProviders(<ModelDetailModal {...defaultProps} />);
+		await user.click(screen.getByText("Edit"));
+
+		const inputPrice = screen.getAllByPlaceholderText("0.00")[0];
+		await user.clear(inputPrice);
+		await user.type(inputPrice, "9.99");
+		const row = inputPrice.closest("div")?.parentElement as HTMLElement;
+		await user.click(within(row).getByTitle("Revert to discovered value"));
+
+		await waitFor(() =>
+			expect(
+				within(row).queryByTitle("Revert to discovered value"),
+			).not.toBeInTheDocument(),
+		);
+	});
+
+	it("reverts a changed output price when its revert button is clicked", async () => {
+		const user = userEvent.setup();
+		renderWithProviders(<ModelDetailModal {...defaultProps} />);
+		await user.click(screen.getByText("Edit"));
+
+		const outputPrice = screen.getAllByPlaceholderText("0.00")[1];
+		await user.clear(outputPrice);
+		await user.type(outputPrice, "12.50");
+		const row = outputPrice.closest("div")?.parentElement as HTMLElement;
+		await user.click(within(row).getByTitle("Revert to discovered value"));
+
+		await waitFor(() =>
+			expect(
+				within(row).queryByTitle("Revert to discovered value"),
+			).not.toBeInTheDocument(),
+		);
+	});
+
 	// parseParams catch branch - invalid JSON
 	it("does not render subscription section when params is invalid JSON", () => {
 		const modelWithInvalidParams = {


### PR DESCRIPTION
Third slice of the section-by-section pass. Test-only.

## ModelDetailModal (90% -> 94% lines)
The existing tests asserted the per-field "Revert to discovered value" button *renders* when a value differs, but never *clicked* it, so the `revertField` handlers were uncovered. Added tests that click revert for display_name, input price, and output price, asserting the button disappears once editData matches the discovered default. (max_output's input isn't label-linked for a clean selector, and the cooldown `setInterval` needs fake timers; both left for later.)

## ProviderQuotaPanel (~91% -> 95.6% lines)
The disabled/collapsed/refresh-interval init readers each swallow a localStorage access error (privacy/locked-down browsers); those catch branches were uncovered. Added a test that makes `getItem` throw for the panel's own keys and asserts it still renders its controls.

No production code changed. More sections to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)