### PR TITLE
test(web): Settings reset flows (section pass 5)

### DIFF
--- a/web/src/pages/__tests__/Settings.test.tsx
+++ b/web/src/pages/__tests__/Settings.test.tsx
@@ -165,4 +165,90 @@ describe("Settings", () => {
 			);
 		});
 	});
+
+	describe("Reset flows", () => {
+		it("reset-all requires typing RESET, then calls the reset API", async () => {
+			let resetCalled = false;
+			server.use(
+				http.get("/api/settings", () => HttpResponse.json({})),
+				http.delete("/api/settings", () => {
+					resetCalled = true;
+					return HttpResponse.json({});
+				}),
+			);
+			const { user } = renderWithProviders(<Settings />);
+			await screen.findByText("Settings");
+
+			await user.click(
+				screen.getByRole("button", {
+					name: "Reset all settings to their defaults",
+				}),
+			);
+
+			// The confirm button is gated on the exact "RESET" confirmation text.
+			const confirm = screen.getByRole("button", { name: "Reset to Defaults" });
+			expect(confirm).toBeDisabled();
+			await user.type(
+				screen.getByPlaceholderText("Type RESET to confirm"),
+				"RESET",
+			);
+			expect(confirm).toBeEnabled();
+
+			await user.click(confirm);
+			await waitFor(() => expect(resetCalled).toBe(true));
+		});
+
+		it("reset-all cancel closes the modal without calling the API", async () => {
+			let resetCalled = false;
+			server.use(
+				http.get("/api/settings", () => HttpResponse.json({})),
+				http.delete("/api/settings", () => {
+					resetCalled = true;
+					return HttpResponse.json({});
+				}),
+			);
+			const { user } = renderWithProviders(<Settings />);
+			await screen.findByText("Settings");
+
+			await user.click(
+				screen.getByRole("button", {
+					name: "Reset all settings to their defaults",
+				}),
+			);
+			expect(screen.getByText("Reset All Settings")).toBeInTheDocument();
+			await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+			await waitFor(() =>
+				expect(
+					screen.queryByText("Reset All Settings"),
+				).not.toBeInTheDocument(),
+			);
+			expect(resetCalled).toBe(false);
+		});
+
+		it("section reset confirms and calls the reset API with that section's keys", async () => {
+			let capturedKeys: string[] | undefined;
+			server.use(
+				http.get("/api/settings", () => HttpResponse.json({})),
+				http.delete("/api/settings", async ({ request }) => {
+					capturedKeys = ((await request.json()) as { keys: string[] }).keys;
+					return HttpResponse.json({});
+				}),
+			);
+			const { user } = renderWithProviders(<Settings />);
+			await screen.findByText("Settings");
+
+			// Open the first section's reset confirmation, then confirm it.
+			const sectionResetButtons = screen.getAllByRole("button", {
+				name: "Reset all settings in this section",
+			});
+			await user.click(sectionResetButtons[0]);
+			await user.click(
+				screen.getByRole("button", { name: "Reset to Defaults" }),
+			);
+
+			await waitFor(() => expect(capturedKeys).toBeDefined());
+			expect(capturedKeys?.length).toBeGreaterThan(0);
+		});
+	});
 });

--- a/web/src/pages/__tests__/Settings.test.tsx
+++ b/web/src/pages/__tests__/Settings.test.tsx
@@ -4,7 +4,6 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { server } from "../../test/mocks/server";
 import { renderWithProviders } from "../../test/utils";
 import { Settings } from "../Settings";
-import { SECTION_SETTINGS } from "../Settings/defaults";
 
 describe("Settings", () => {
 	beforeEach(() => {
@@ -168,12 +167,12 @@ describe("Settings", () => {
 	});
 
 	describe("Reset flows", () => {
-		it("reset-all requires typing RESET, then calls the reset API", async () => {
-			let resetCalled = false;
+		it("reset-all requires typing RESET, then resets every key (empty keys)", async () => {
+			let resetBody: unknown;
 			server.use(
 				http.get("/api/settings", () => HttpResponse.json({})),
-				http.delete("/api/settings", () => {
-					resetCalled = true;
+				http.delete("/api/settings", async ({ request }) => {
+					resetBody = await request.json();
 					return HttpResponse.json({});
 				}),
 			);
@@ -196,7 +195,10 @@ describe("Settings", () => {
 			expect(confirm).toBeEnabled();
 
 			await user.click(confirm);
-			await waitFor(() => expect(resetCalled).toBe(true));
+			// Reset-all sends an empty key list, which the backend treats as
+			// "reset everything". Asserting the literal payload independently
+			// verifies the behavior (not just that some request fired).
+			await waitFor(() => expect(resetBody).toEqual({ keys: [] }));
 		});
 
 		it("reset-all cancel closes the modal without calling the API", async () => {
@@ -239,10 +241,11 @@ describe("Settings", () => {
 			const { user } = renderWithProviders(<Settings />);
 			await screen.findByText("Settings");
 
-			// The first resettable section is Discovery (JSX order). Confirming its
-			// reset must send exactly that section's keys, which both verifies the
-			// payload and pins down which section the first button belongs to (a
-			// wrong button would send different keys and fail this assertion).
+			// The first resettable section is Discovery (JSX order). Assert the
+			// exact discovery keys as a literal list (NOT via SECTION_SETTINGS,
+			// which the production code also reads -- that would be circular and
+			// pass even if a key were dropped from both sides). This independently
+			// verifies the payload and pins down which section the button belongs to.
 			const sectionResetButtons = screen.getAllByRole("button", {
 				name: "Reset all settings in this section",
 			});
@@ -252,7 +255,11 @@ describe("Settings", () => {
 			);
 
 			await waitFor(() =>
-				expect(capturedKeys).toEqual(SECTION_SETTINGS.discovery),
+				expect(capturedKeys).toEqual([
+					"discovery_interval",
+					"discovery_on_startup",
+					"discovery_on_provider_create",
+				]),
 			);
 		});
 	});

--- a/web/src/pages/__tests__/Settings.test.tsx
+++ b/web/src/pages/__tests__/Settings.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { server } from "../../test/mocks/server";
 import { renderWithProviders } from "../../test/utils";
 import { Settings } from "../Settings";
+import { SECTION_SETTINGS } from "../Settings/defaults";
 
 describe("Settings", () => {
 	beforeEach(() => {
@@ -238,7 +239,10 @@ describe("Settings", () => {
 			const { user } = renderWithProviders(<Settings />);
 			await screen.findByText("Settings");
 
-			// Open the first section's reset confirmation, then confirm it.
+			// The first resettable section is Discovery (JSX order). Confirming its
+			// reset must send exactly that section's keys, which both verifies the
+			// payload and pins down which section the first button belongs to (a
+			// wrong button would send different keys and fail this assertion).
 			const sectionResetButtons = screen.getAllByRole("button", {
 				name: "Reset all settings in this section",
 			});
@@ -247,8 +251,9 @@ describe("Settings", () => {
 				screen.getByRole("button", { name: "Reset to Defaults" }),
 			);
 
-			await waitFor(() => expect(capturedKeys).toBeDefined());
-			expect(capturedKeys?.length).toBeGreaterThan(0);
+			await waitFor(() =>
+				expect(capturedKeys).toEqual(SECTION_SETTINGS.discovery),
+			);
 		});
 	});
 });


### PR DESCRIPTION
Fifth slice of the section-by-section pass. Test-only.

## Settings page reset flows
The reset-all and section-reset flows had no interaction coverage. Added:
- **reset-all**: open the modal, the confirm button stays disabled until "RESET" is typed, then confirming calls the reset API.
- **reset-all cancel** closes the modal without calling the API.
- **section reset**: open a section's confirmation and confirm it, asserting the reset API is called with that section's keys.

No production code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)