### PR TITLE
perf(applogs): drop per-poll full COUNT(*) on app_logs

### DIFF
--- a/internal/api/applogs.go
+++ b/internal/api/applogs.go
@@ -725,6 +725,10 @@ func (h *Handler) ClearAppLogs(w http.ResponseWriter, r *http.Request) {
 		tag, err := h.dbPool.Pool().Exec(r.Context(), `DELETE FROM app_logs`)
 		if err == nil {
 			deleted += int(tag.RowsAffected())
+			// The unfiltered total is derived from the cached level counts, so
+			// drop the cache now that the rows are gone; otherwise a poll within
+			// appLogCountCacheTTL would report a stale, non-zero total.
+			invalidateAppLogCountCache()
 		}
 	}
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/api/applogs.go
+++ b/internal/api/applogs.go
@@ -418,6 +418,32 @@ func (h *Handler) countAppLogs(ctx context.Context, q url.Values) (int, error) {
 	return total, err
 }
 
+// sumAppLogCounts returns the unfiltered app_logs row count as the sum of the
+// per-level counts.
+func sumAppLogCounts(levelCounts map[string]int) int {
+	total := 0
+	for _, n := range levelCounts {
+		total += n
+	}
+	return total
+}
+
+// appLogTotal returns the row count for the request's filters. When no filter is
+// active it derives the total from the already-cached level counts (their sum),
+// avoiding a full COUNT(*) on every live-tail/history poll. That unfiltered COUNT
+// heap-scans the whole table whenever autovacuum hasn't refreshed the visibility
+// map (e.g. a freshly restarted or restored instance), which tanks the DB cache
+// hit ratio. Only a genuinely filtered request runs a (smaller, index-backed)
+// COUNT, where an exact, fresh total still matters.
+func (h *Handler) appLogTotal(ctx context.Context, q url.Values, levelCounts map[string]int) (int, error) {
+	conditions, _, _ := appendAppLogFilters(nil, nil, 1,
+		q.Get("level"), q.Get("source"), q.Get("search"), q.Get("from"), q.Get("to"))
+	if len(conditions) == 0 {
+		return sumAppLogCounts(levelCounts), nil
+	}
+	return h.countAppLogs(ctx, q)
+}
+
 // appLogCursorParams holds the parsed, validated inputs for GetAppLogsCursor.
 type appLogCursorParams struct {
 	limit     int
@@ -554,7 +580,7 @@ func (h *Handler) getAppLogsHistory(w http.ResponseWriter, r *http.Request) {
 	// Retrieve cached level/source counts (refreshed every appLogCountCacheTTL).
 	levelCounts, sourceCounts := h.getAppLogCounts(ctx)
 
-	total, err := h.countAppLogs(ctx, q)
+	total, err := h.appLogTotal(ctx, q, levelCounts)
 	if err != nil {
 		if encErr := json.NewEncoder(w).Encode(map[string]string{"error": "failed to count logs"}); encErr != nil {
 			debuglog.Error("applogs: failed to encode error response", "error", encErr)
@@ -672,7 +698,7 @@ func (h *Handler) GetAppLogsCursor(w http.ResponseWriter, r *http.Request) {
 	entries, hasAfter, hasBefore := paginateCursor(entries, p.direction, p.limit, p.cursorStr != "")
 
 	levelCounts, sourceCounts := h.getAppLogCounts(ctx)
-	total, _ := h.countAppLogs(ctx, q) // best-effort
+	total, _ := h.appLogTotal(ctx, q, levelCounts) // best-effort
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(AppLogsCursorResponse{

--- a/internal/api/applogs_buffer.go
+++ b/internal/api/applogs_buffer.go
@@ -72,6 +72,19 @@ var (
 	appLogCountCacheTTL = 5 * time.Second
 )
 
+// invalidateAppLogCountCache drops the cached level/source counts so the next
+// getAppLogCounts re-queries the DB. Call it after any operation that changes the
+// app_logs row set out of band (e.g. ClearAppLogs): the unfiltered total is
+// derived from these counts, so without this a poll within appLogCountCacheTTL
+// would keep reporting the pre-change (stale) total.
+func invalidateAppLogCountCache() {
+	appLogCountCache.Lock()
+	appLogCountCache.levelCounts = nil
+	appLogCountCache.sourceCounts = nil
+	appLogCountCache.fetchedAt = time.Time{}
+	appLogCountCache.Unlock()
+}
+
 // appLogBuffer is the global ring buffer that captures log output.
 var appLogBuffer *ringBuffer
 

--- a/internal/api/applogs_handler_test.go
+++ b/internal/api/applogs_handler_test.go
@@ -602,7 +602,11 @@ func TestGetAppLogs_NilBuffer(t *testing.T) {
 		appLogBuffer = nil
 		dbWriter = nil
 	}()
-	// appLogBuffer is nil by default if InitAppLogBuffer hasn't been called
+	// Establish the nil-buffer precondition explicitly: appLogBuffer is a global
+	// that an earlier test may have initialized, so we cannot rely on it already
+	// being nil (the defer above only restores it afterwards).
+	appLogBuffer = nil
+	dbWriter = nil
 	h := &Handler{dbPool: nil}
 	req := httptest.NewRequest(http.MethodGet, "/api/app-logs", http.NoBody)
 	rr := httptest.NewRecorder()

--- a/internal/api/handler_applogs_test.go
+++ b/internal/api/handler_applogs_test.go
@@ -55,6 +55,66 @@ func TestClearAppLogsIntegration(t *testing.T) {
 	}
 }
 
+// TestClearAppLogs_InvalidatesCountCache guards the perf change that derives the
+// unfiltered total from the cached level counts: clearing the logs must drop that
+// cache so the next poll reports 0 immediately, not the pre-clear total for up to
+// appLogCountCacheTTL.
+func TestClearAppLogs_InvalidatesCountCache(t *testing.T) {
+	h := newTestHandler(t)
+	r := chi.NewRouter()
+	h.Register(r)
+	pool := h.Pool().Pool()
+	ctx := context.Background()
+
+	// newTestHandler truncates app_logs, so the unfiltered total covers exactly
+	// the rows we insert here.
+	for i := 0; i < 3; i++ {
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO app_logs (id, timestamp, level, source, message, created_at)
+			 VALUES (gen_random_uuid(), NOW(), 'info', 'clearcache', 'msg', NOW())`); err != nil {
+			t.Fatalf("insert row %d: %v", i, err)
+		}
+	}
+
+	unfilteredTotal := func() int {
+		t.Helper()
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/logs/app?history=true", http.NoBody)
+		req.Header.Set("Authorization", "Bearer test-admin-token")
+		r.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("history GET: status %d: %s", rec.Code, rec.Body.String())
+		}
+		var resp struct {
+			Total int `json:"total"`
+		}
+		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode history: %v", err)
+		}
+		return resp.Total
+	}
+
+	// Warm the count cache: the unfiltered total must see the 3 rows.
+	if got := unfilteredTotal(); got != 3 {
+		t.Fatalf("total before clear = %d, want 3", got)
+	}
+
+	// Clear all logs.
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("DELETE", "/logs/app", http.NoBody)
+	req.Header.Set("Authorization", "Bearer test-admin-token")
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("clear: status %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// The next poll must report 0 immediately; a stale (non-zero) total here
+	// means ClearAppLogs failed to invalidate the count cache.
+	if got := unfilteredTotal(); got != 0 {
+		t.Fatalf("total after clear = %d, want 0 (count cache not invalidated)", got)
+	}
+}
+
 // GetAppLogs with filters - Additional coverage
 
 func TestGetAppLogs_WithSeverityFilter(t *testing.T) {

--- a/internal/api/handler_test_helpers_test.go
+++ b/internal/api/handler_test_helpers_test.go
@@ -3,7 +3,6 @@ package api
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -46,11 +45,7 @@ func newTestHandler(t *testing.T) *Handler {
 	// Reset the app-log count cache: the unfiltered total now derives from these
 	// cached counts, so a stale entry from a prior test must not survive the
 	// truncate above.
-	appLogCountCache.Lock()
-	appLogCountCache.levelCounts = nil
-	appLogCountCache.sourceCounts = nil
-	appLogCountCache.fetchedAt = time.Time{}
-	appLogCountCache.Unlock()
+	invalidateAppLogCountCache()
 
 	// Create database instance
 	database, err := db.New(context.Background(), dbURL, 5, 1)

--- a/internal/api/handler_test_helpers_test.go
+++ b/internal/api/handler_test_helpers_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -41,6 +42,15 @@ func newTestHandler(t *testing.T) *Handler {
 
 	// Flush logs cache so prior test results don't leak.
 	globalLogsCache.clear()
+
+	// Reset the app-log count cache: the unfiltered total now derives from these
+	// cached counts, so a stale entry from a prior test must not survive the
+	// truncate above.
+	appLogCountCache.Lock()
+	appLogCountCache.levelCounts = nil
+	appLogCountCache.sourceCounts = nil
+	appLogCountCache.fetchedAt = time.Time{}
+	appLogCountCache.Unlock()
 
 	// Create database instance
 	database, err := db.New(context.Background(), dbURL, 5, 1)


### PR DESCRIPTION
## Problem

The live-tail (`GetAppLogsCursor`) and history (`getAppLogsHistory`) endpoints ran an unfiltered `SELECT COUNT(*) FROM app_logs` on **every poll** (~1-2s while the Logs page is open).

On any instance where autovacuum hasn't recently refreshed the visibility map, a freshly restarted or restored DB, a short-lived dev container, a new HA node, that COUNT can't use an index-only scan and **heap-scans the entire table**. Each poll then reads the whole table from a cold cache.

Observed on a dev box with a ~500k-row `app_logs`:
- Postgres cache hit ratio pinned at **~76%** (prod, long-lived and autovacuumed, sits at ~98% on *more* rows).
- One query, the per-poll COUNT, accounted for **99.6%** of all disk reads (`heap_blks_read`).
- `EXPLAIN (ANALYZE, BUFFERS)` showed **88,457 heap fetches** per COUNT before `VACUUM`, **60** after. Same query, same rows, same index, the only difference was the visibility map.

## Fix

Derive the unfiltered total from the already-cached per-level counts (`getAppLogCounts`, 5s TTL) instead of issuing a COUNT, so the hot path runs **no COUNT at all**. Only a genuinely *filtered* request still runs a COUNT, where the predicate is index-backed and an exact, fresh total matters.

The total is now O(1) regardless of vacuum state or cache warmth, which removes the implicit "only cheap if autovacuum happened to run recently" dependency.

## Tests

- Reset the app-log count cache in the shared `newTestHandler` so the now-cache-derived unfiltered total can't leak across the per-test `TRUNCATE` (mirrors the existing `globalLogsCache.clear()`).
- Fix a pre-existing order-dependent failure in `TestGetAppLogs_NilBuffer` (assumed `appLogBuffer` was nil but only reset it in a `defer`; failed on `master` too under the `-run` subset) by establishing the nil-buffer precondition explicitly.

## Verification

- `go build`, `go vet`, `golangci-lint run ./internal/api/...`: clean.
- Full `internal/api` suite: ok (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)