### PR TITLE
fix(provider): detect minimaxi.com as Anthropic-compatible endpoint

### DIFF
--- a/internal/provider/discovery.go
+++ b/internal/provider/discovery.go
@@ -160,6 +160,9 @@ func DetectProviderType(baseURL string) string {
 	if strings.HasSuffix(host, ".anthropic.com") {
 		return "anthropic"
 	}
+	if strings.HasSuffix(host, ".minimaxi.com") {
+			return "anthropic"
+	}
 	if strings.HasSuffix(host, ".x.ai") {
 		return "xai"
 	}


### PR DESCRIPTION
## What

api.minimaxi.com/anthropic is MiniMax's official Anthropic-compatible API for their Coding Plan. `DetectProviderType` only matched `.anthropic.com`, causing minimaxi to fall back to OpenAI discovery which returns 404.

Also includes a CRLF fix for docker-entrypoint.sh during build (Windows compatibility).

## Commits

1. `fix(provider): detect minimaxi.com as Anthropic-compatible endpoint` — main fix
2. `fix(docker): strip CRLF from docker-entrypoint.sh during build` — Windows build fix

## Testing

Verified on NAS deployment: MiniMax Coding Plan provider now correctly uses Anthropic-compatible model discovery.

Closes: (add issue number if applicable)