### PR TITLE
fix(docker): pin LF line endings via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# Force LF on files that must stay LF inside the Docker image.
+#
+# The container ENTRYPOINT is docker-entrypoint.sh. If a contributor checks the
+# repo out on Windows with core.autocrlf=true (the platform default), the script
+# is rewritten to CRLF on disk, COPYed into the image verbatim, and its shebang
+# becomes "#!/bin/sh\r". The kernel then tries to exec the interpreter "/bin/sh\r",
+# which does not exist, and the container dies at startup. Pinning eol=lf here makes
+# the checkout LF regardless of platform or autocrlf setting, fixing it at the source.
+*.sh text eol=lf
+docker-entrypoint.sh text eol=lf
+Dockerfile text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -9,3 +9,8 @@
 *.sh text eol=lf
 docker-entrypoint.sh text eol=lf
 Dockerfile text eol=lf
+
+# Git hooks live in scripts/ (core.hooksPath=scripts) and are extensionless
+# bash scripts, so the *.sh rule above misses them. A CRLF checkout would break
+# their shebang and silently disable the hooks on Windows.
+scripts/* text eol=lf


### PR DESCRIPTION
## Problem

The repo has no `.gitattributes`, so git applies no line-ending policy. `docker-entrypoint.sh` is committed as LF, but a contributor who checks out on Windows with `core.autocrlf=true` (the platform default) gets it rewritten to CRLF on disk. The Dockerfile then `COPY`s it verbatim into the image, so the shebang becomes `#!/bin/sh\r`. At startup the kernel tries to exec the interpreter `/bin/sh\r`, which does not exist, and the container dies.

This is the underlying issue behind the CRLF concern raised in #287 (which only proposed patching it downstream in the build, and didn't actually include the change).

## Fix

Add a tightly-scoped `.gitattributes` pinning `eol=lf` on shell scripts, the entrypoint, and the Dockerfile. This normalizes line endings at the source on every checkout regardless of platform or `autocrlf`, so the file `COPY`'d into the image is always LF. Cleaner and more robust than a build-time `sed`/`dos2unix`, and scoped to avoid a repo-wide renormalization diff.

## Testing (local)

- `git check-attr -a docker-entrypoint.sh` now reports `text: set` / `eol: lf`.
- Simulated a Windows checkout: corrupted the entrypoint to CRLF (43 CR bytes), `git add` → the index stores 0 CR bytes (normalized to LF).
- `docker compose build app` rebuilds cleanly; the entrypoint inside the freshly built image has 0 CR bytes. Verified without disrupting the running dev container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)