### PR TITLE
ci: publish a rolling :dev image to Docker Hub on every master commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -385,25 +385,80 @@ jobs:
           ignore-unfixed: true
           exit-code: 1
 
-      # Publish a rolling :dev image to Docker Hub on every master commit, so a
-      # second "staging" instance can track master just by pointing its compose
-      # image: line at <DOCKERHUB_USERNAME>/model-hotel:dev (vs :latest for prod).
-      # Only on direct pushes to master — never PRs, which can't see secrets — and
-      # only after the Trivy gate above passes, so :dev clears the same fixable
-      # HIGH/CRITICAL bar as a release. The image carries no VERSION build-arg, so
-      # it self-reports version "dev". The :dev tag is a moving tag the prune
-      # workflow leaves untouched (it only prunes vX.Y.Z and orphaned sha- tags).
+  # Publish a rolling :dev image to Docker Hub on every master commit, so a
+  # second "staging" instance can track master by pointing its compose image:
+  # line at <DOCKERHUB_USERNAME>/model-hotel:dev (vs :latest for prod).
+  #
+  # This is a dedicated job (not a step in docker-build) so it can `needs:` the
+  # full required gate set: a master commit that fails Go tests, lint, vet,
+  # vulncheck, coverage, i18n, the workflow lint, the frontend gates, or the
+  # Docker build + Trivy scan never becomes a staging image. It runs only on
+  # direct pushes to master (never PRs, which can't see secrets) and skips if
+  # master HEAD has already moved past this commit, so a slow older run can't
+  # overwrite :dev with a stale image after a newer commit already published it.
+  # The image carries no VERSION build-arg, so it self-reports version "dev".
+  # :dev is a moving tag the prune workflow leaves untouched (it only prunes
+  # vX.Y.Z releases and orphaned sha- tags).
+  publish-dev:
+    name: Publish :dev image
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    needs:
+      - go-test
+      - go-lint
+      - go-vet
+      - govulncheck
+      - i18n-check
+      - workflow-lint
+      - frontend-checks
+      - frontend-test
+      - frontend-coverage
+      - notices
+      - docker-build
+    concurrency:
+      group: publish-dev-${{ github.ref }}
+      cancel-in-progress: true
+    permissions:
+      contents: read
+    env:
+      DOCKERHUB_IMAGE: ${{ secrets.DOCKERHUB_USERNAME }}/model-hotel
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      # Guard against a superseded run overwriting :dev with an older image:
+      # only publish when this commit is still master HEAD.
+      - name: Skip if superseded by a newer master commit
+        id: head
+        env:
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          remote_head=$(git ls-remote origin refs/heads/master | cut -f1)
+          if [ "$remote_head" = "$COMMIT_SHA" ]; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "master HEAD is $remote_head, not $COMMIT_SHA; skipping stale :dev push"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Log in to Docker Hub
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        if: steps.head.outputs.skip == 'false'
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Push :dev image to Docker Hub
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-        env:
-          DOCKERHUB_IMAGE: ${{ secrets.DOCKERHUB_USERNAME }}/model-hotel
-        run: |
-          docker tag model-hotel:ci "${DOCKERHUB_IMAGE}:dev"
-          docker push "${DOCKERHUB_IMAGE}:dev"
+      - name: Set up Docker Buildx
+        if: steps.head.outputs.skip == 'false'
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+
+      - name: Build and push :dev
+        if: steps.head.outputs.skip == 'false'
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
+        with:
+          context: .
+          push: true
+          tags: ${{ env.DOCKERHUB_IMAGE }}:dev
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64
+          provenance: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -415,12 +415,11 @@ jobs:
       - frontend-coverage
       - notices
       - docker-build
-    # Serialize publishes (never cancel): combined with the HEAD guard below, a
-    # superseded older run skips its push rather than being cancelled mid-push,
-    # so a newer run failing later never discards the last good gated candidate.
-    concurrency:
-      group: publish-dev-${{ github.ref }}
-      cancel-in-progress: false
+    # No concurrency group on purpose: GitHub keeps only one *pending* job per
+    # group and cancels an older pending one when a newer queues, which could
+    # drop a fully-gated publish candidate. Instead every run builds and the
+    # push step re-checks HEAD, so only the run that is still master HEAD at push
+    # time publishes (newest-wins, never a rollback).
     permissions:
       contents: read
     env:
@@ -428,9 +427,11 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      # Guard against a superseded run overwriting :dev with an older image:
-      # only publish when this commit is still master HEAD.
-      - name: Skip if superseded by a newer master commit
+      # Early bail-out: if this commit is already behind master HEAD, skip the
+      # whole build/scan. This is only an optimization — the authoritative guard
+      # is the re-check in the push step, which closes the window where HEAD
+      # moves while this job is still building.
+      - name: Skip if already superseded by a newer master commit
         id: head
         env:
           COMMIT_SHA: ${{ github.sha }}
@@ -439,7 +440,7 @@ jobs:
           if [ "$remote_head" = "$COMMIT_SHA" ]; then
             echo "skip=false" >> "$GITHUB_OUTPUT"
           else
-            echo "master HEAD is $remote_head, not $COMMIT_SHA; skipping stale :dev push"
+            echo "master HEAD is $remote_head, not $COMMIT_SHA; skipping stale :dev publish"
             echo "skip=true" >> "$GITHUB_OUTPUT"
           fi
 
@@ -480,8 +481,18 @@ jobs:
           ignore-unfixed: true
           exit-code: 1
 
-      - name: Push the scanned image as :dev
+      # Re-check HEAD immediately before pushing: if a newer master commit landed
+      # while this job was building/scanning, that newer run will publish its own
+      # image, so this (now-stale) run must not overwrite :dev with an older one.
+      - name: Push the scanned image as :dev (only if still HEAD)
         if: steps.head.outputs.skip == 'false'
+        env:
+          COMMIT_SHA: ${{ github.sha }}
         run: |
+          remote_head=$(git ls-remote origin refs/heads/master | cut -f1)
+          if [ "$remote_head" != "$COMMIT_SHA" ]; then
+            echo "master HEAD moved to $remote_head; skipping stale :dev push for $COMMIT_SHA"
+            exit 0
+          fi
           docker tag model-hotel:dev-candidate "${DOCKERHUB_IMAGE}:dev"
           docker push "${DOCKERHUB_IMAGE}:dev"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -415,9 +415,12 @@ jobs:
       - frontend-coverage
       - notices
       - docker-build
+    # Serialize publishes (never cancel): combined with the HEAD guard below, a
+    # superseded older run skips its push rather than being cancelled mid-push,
+    # so a newer run failing later never discards the last good gated candidate.
     concurrency:
       group: publish-dev-${{ github.ref }}
-      cancel-in-progress: true
+      cancel-in-progress: false
     permissions:
       contents: read
     env:
@@ -451,14 +454,34 @@ jobs:
         if: steps.head.outputs.skip == 'false'
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
-      - name: Build and push :dev
+      # Build the candidate and load it into the local daemon so the very image
+      # that gets scanned is the image that gets pushed (same digest). Scanning
+      # docker-build's separate artifact would not cover base-image/Alpine drift
+      # between that job and this rebuild.
+      - name: Build :dev candidate (load for scan)
         if: steps.head.outputs.skip == 'false'
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
-          push: true
-          tags: ${{ env.DOCKERHUB_IMAGE }}:dev
+          load: true
+          tags: model-hotel:dev-candidate
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64
           provenance: false
+
+      - name: Scan :dev candidate for fixable HIGH/CRITICAL vulnerabilities
+        if: steps.head.outputs.skip == 'false'
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: image
+          image-ref: model-hotel:dev-candidate
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: 1
+
+      - name: Push the scanned image as :dev
+        if: steps.head.outputs.skip == 'false'
+        run: |
+          docker tag model-hotel:dev-candidate "${DOCKERHUB_IMAGE}:dev"
+          docker push "${DOCKERHUB_IMAGE}:dev"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -384,3 +384,26 @@ jobs:
           severity: CRITICAL,HIGH
           ignore-unfixed: true
           exit-code: 1
+
+      # Publish a rolling :dev image to Docker Hub on every master commit, so a
+      # second "staging" instance can track master just by pointing its compose
+      # image: line at <DOCKERHUB_USERNAME>/model-hotel:dev (vs :latest for prod).
+      # Only on direct pushes to master — never PRs, which can't see secrets — and
+      # only after the Trivy gate above passes, so :dev clears the same fixable
+      # HIGH/CRITICAL bar as a release. The image carries no VERSION build-arg, so
+      # it self-reports version "dev". The :dev tag is a moving tag the prune
+      # workflow leaves untouched (it only prunes vX.Y.Z and orphaned sha- tags).
+      - name: Log in to Docker Hub
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Push :dev image to Docker Hub
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        env:
+          DOCKERHUB_IMAGE: ${{ secrets.DOCKERHUB_USERNAME }}/model-hotel
+        run: |
+          docker tag model-hotel:ci "${DOCKERHUB_IMAGE}:dev"
+          docker push "${DOCKERHUB_IMAGE}:dev"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -436,7 +436,12 @@ jobs:
         env:
           COMMIT_SHA: ${{ github.sha }}
         run: |
+          set -euo pipefail
           remote_head=$(git ls-remote origin refs/heads/master | cut -f1)
+          if [ -z "$remote_head" ]; then
+            echo "::error::could not read master HEAD from origin"
+            exit 1
+          fi
           if [ "$remote_head" = "$COMMIT_SHA" ]; then
             echo "skip=false" >> "$GITHUB_OUTPUT"
           else
@@ -489,7 +494,12 @@ jobs:
         env:
           COMMIT_SHA: ${{ github.sha }}
         run: |
+          set -euo pipefail
           remote_head=$(git ls-remote origin refs/heads/master | cut -f1)
+          if [ -z "$remote_head" ]; then
+            echo "::error::could not read master HEAD from origin"
+            exit 1
+          fi
           if [ "$remote_head" != "$COMMIT_SHA" ]; then
             echo "master HEAD moved to $remote_head; skipping stale :dev push for $COMMIT_SHA"
             exit 0


### PR DESCRIPTION
## What

CI already builds and Trivy-scans the Docker image on every master push but then discards it. This tags that same image as `<DOCKERHUB_USERNAME>/model-hotel:dev` and pushes it, so a second "staging" instance can track master by changing only its compose `image:` line (`:latest` → `:dev`), then `docker compose pull && up -d`.

## Behaviour

- Runs only on **direct pushes to `master`** (i.e. each PR merge) — never on PRs (the `if` excludes `pull_request`, which also can't see secrets).
- Pushes only **after the Trivy gate passes**, so `:dev` clears the same fixable HIGH/CRITICAL bar as a release.
- Reuses the existing `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` secrets — nothing new to configure.
- No `VERSION` build-arg, so the dev image self-reports version `dev`.
- `:dev` is a moving tag; the Docker Hub prune workflow leaves it untouched (it only prunes `vX.Y.Z` releases and orphaned `sha-` tags).

## Note

This `:dev` push will first appear on the next master run after this PR merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)