### PR TITLE
fix(frontdesk): slow-member-read robustness + config-sync progress UX

### DIFF
--- a/frontdesk/web/src/components/ConfirmModal.tsx
+++ b/frontdesk/web/src/components/ConfirmModal.tsx
@@ -11,6 +11,8 @@ export function ConfirmModal({
 	title,
 	confirmLabel,
 	confirmDisabled,
+	busy,
+	busyLabel,
 	ackLabel,
 	onConfirm,
 	onClose,
@@ -20,6 +22,12 @@ export function ConfirmModal({
 	confirmLabel: string;
 	// True while the confirmed action is in flight, to block a double-submit.
 	confirmDisabled?: boolean;
+	// True while the action runs: shows a spinner + busyLabel on the confirm
+	// button and disables Cancel, so a slow action (e.g. config sync, which runs
+	// model discovery on every member) reads as working rather than frozen.
+	busy?: boolean;
+	// Label shown beside the spinner while busy; falls back to confirmLabel.
+	busyLabel?: string;
 	// When set, an acknowledgement checkbox must be ticked before confirming.
 	ackLabel?: string;
 	onConfirm: () => void;
@@ -28,7 +36,7 @@ export function ConfirmModal({
 }) {
 	const { t } = useTranslation();
 	const [ack, setAck] = useState(false);
-	const blocked = (!!ackLabel && !ack) || !!confirmDisabled;
+	const blocked = (!!ackLabel && !ack) || !!confirmDisabled || !!busy;
 
 	return (
 		<Modal
@@ -36,16 +44,23 @@ export function ConfirmModal({
 			onClose={onClose}
 			actions={
 				<>
-					<button type="button" className="ui-btn" onClick={onClose}>
+					<button
+						type="button"
+						className="ui-btn"
+						disabled={!!busy}
+						onClick={onClose}
+					>
 						{t("common.cancel")}
 					</button>
 					<button
 						type="button"
 						className="ui-btn ui-btn-danger"
 						disabled={blocked}
+						aria-busy={busy}
 						onClick={onConfirm}
 					>
-						{confirmLabel}
+						{busy && <span className="fd-spinner" aria-hidden="true" />}
+						{busy ? (busyLabel ?? confirmLabel) : confirmLabel}
 					</button>
 				</>
 			}

--- a/frontdesk/web/src/components/ConfirmModal.tsx
+++ b/frontdesk/web/src/components/ConfirmModal.tsx
@@ -42,6 +42,7 @@ export function ConfirmModal({
 		<Modal
 			title={title}
 			onClose={onClose}
+			dismissible={!busy}
 			actions={
 				<>
 					<button

--- a/frontdesk/web/src/components/FleetSyncWizard.tsx
+++ b/frontdesk/web/src/components/FleetSyncWizard.tsx
@@ -269,7 +269,8 @@ export function FleetSyncWizard({
 					confirmLabel={t("settings.syncDo", {
 						count: adminTokenBlockers(status as FleetStatus).length,
 					})}
-					confirmDisabled={busy}
+					busy={busy}
+					busyLabel={t("settings.syncDoing")}
 					ackLabel={t("settings.syncAck")}
 					onConfirm={doAdminSync}
 					onClose={() => setConfirm(null)}
@@ -291,12 +292,19 @@ export function FleetSyncWizard({
 					confirmLabel={t("settings.configSyncDo", {
 						count: overwrites.length,
 					})}
-					confirmDisabled={busy}
+					busy={busy}
+					busyLabel={t("settings.configSyncDoing")}
 					ackLabel={t("settings.configSyncAck")}
 					onConfirm={doConfigSync}
 					onClose={() => setConfirm(null)}
 				>
 					<p className="fd-muted">{t("settings.configSyncConfirmBody")}</p>
+					{busy && (
+						<p className="fd-muted" style={{ margin: "0.5rem 0" }}>
+							<span className="fd-spinner" aria-hidden="true" />{" "}
+							{t("settings.configSyncProgress")}
+						</p>
+					)}
 					{totalRemoved > 0 && (
 						<p className="fd-error-text" style={{ margin: "0.5rem 0" }}>
 							{t("settings.configSyncRemovalWarning", { count: totalRemoved })}

--- a/frontdesk/web/src/components/Modal.tsx
+++ b/frontdesk/web/src/components/Modal.tsx
@@ -5,6 +5,11 @@ interface ModalProps {
 	onClose: () => void;
 	children: ReactNode;
 	actions?: ReactNode;
+	// When false, Escape and backdrop click do not dismiss the dialog. Used while
+	// a confirmed action is in flight, so the operator cannot accidentally hide
+	// the in-progress feedback (the work keeps running server-side regardless).
+	// Defaults to true: every existing caller stays dismissible.
+	dismissible?: boolean;
 }
 
 const FOCUSABLE =
@@ -15,7 +20,13 @@ const FOCUSABLE =
 // focus-trap library), but it does trap Tab focus within the dialog while open
 // and restores focus to the trigger on close, so keyboard and screen-reader
 // users aren't dropped behind the modal.
-export function Modal({ title, onClose, children, actions }: ModalProps) {
+export function Modal({
+	title,
+	onClose,
+	children,
+	actions,
+	dismissible = true,
+}: ModalProps) {
 	const dialogRef = useRef<HTMLDivElement>(null);
 
 	// Hold onClose in a ref so the focus effect can run exactly once (open + trap
@@ -27,6 +38,15 @@ export function Modal({ title, onClose, children, actions }: ModalProps) {
 		onCloseRef.current = onClose;
 	}, [onClose]);
 
+	// Same reasoning for dismissible: the keydown listener is registered once, so
+	// it must read the current value through a ref rather than the value captured
+	// at mount (a dialog opens dismissible, then becomes non-dismissible once its
+	// action starts running).
+	const dismissibleRef = useRef(dismissible);
+	useEffect(() => {
+		dismissibleRef.current = dismissible;
+	}, [dismissible]);
+
 	useEffect(() => {
 		const previouslyFocused = document.activeElement as HTMLElement | null;
 		// Focus the first focusable control (or the dialog itself) on open.
@@ -36,7 +56,7 @@ export function Modal({ title, onClose, children, actions }: ModalProps) {
 
 		const onKey = (e: KeyboardEvent) => {
 			if (e.key === "Escape") {
-				onCloseRef.current();
+				if (dismissibleRef.current) onCloseRef.current();
 				return;
 			}
 			if (e.key !== "Tab" || !dialog) return;
@@ -68,7 +88,7 @@ export function Modal({ title, onClose, children, actions }: ModalProps) {
 		<div
 			className="fd-modal-backdrop"
 			onMouseDown={(e) => {
-				if (e.target === e.currentTarget) onClose();
+				if (dismissible && e.target === e.currentTarget) onClose();
 			}}
 		>
 			<div

--- a/frontdesk/web/src/components/__tests__/ConfirmModal.test.tsx
+++ b/frontdesk/web/src/components/__tests__/ConfirmModal.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ConfirmModal } from "../ConfirmModal";
+
+describe("ConfirmModal busy state", () => {
+	it("shows the busy label, disables both buttons, and renders a spinner while busy", () => {
+		const { container } = render(
+			<ConfirmModal
+				title="Replace config?"
+				confirmLabel="Replace now"
+				busy
+				busyLabel="Replacing config..."
+				onConfirm={vi.fn()}
+				onClose={vi.fn()}
+			>
+				<p>body</p>
+			</ConfirmModal>,
+		);
+
+		const confirm = screen.getByRole("button", { name: /Replacing config/ });
+		expect(confirm).toBeDisabled();
+		expect(confirm).toHaveAttribute("aria-busy", "true");
+		// Cancel is disabled too: the action is in flight and the modal closes itself.
+		expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled();
+		expect(container.querySelector(".fd-spinner")).not.toBeNull();
+		// The idle label is not shown while busy.
+		expect(screen.queryByRole("button", { name: "Replace now" })).toBeNull();
+	});
+
+	it("shows the confirm label and an enabled cancel when not busy", () => {
+		render(
+			<ConfirmModal
+				title="Replace config?"
+				confirmLabel="Replace now"
+				busyLabel="Replacing config..."
+				onConfirm={vi.fn()}
+				onClose={vi.fn()}
+			>
+				<p>body</p>
+			</ConfirmModal>,
+		);
+
+		expect(screen.getByRole("button", { name: "Replace now" })).toBeEnabled();
+		expect(screen.getByRole("button", { name: "Cancel" })).toBeEnabled();
+	});
+});

--- a/frontdesk/web/src/components/__tests__/ConfirmModal.test.tsx
+++ b/frontdesk/web/src/components/__tests__/ConfirmModal.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { ConfirmModal } from "../ConfirmModal";
 
@@ -25,6 +26,24 @@ describe("ConfirmModal busy state", () => {
 		expect(container.querySelector(".fd-spinner")).not.toBeNull();
 		// The idle label is not shown while busy.
 		expect(screen.queryByRole("button", { name: "Replace now" })).toBeNull();
+	});
+
+	it("cannot be dismissed by Escape while busy", async () => {
+		const onClose = vi.fn();
+		render(
+			<ConfirmModal
+				title="Replace config?"
+				confirmLabel="Replace now"
+				busy
+				busyLabel="Replacing config..."
+				onConfirm={vi.fn()}
+				onClose={onClose}
+			>
+				<p>body</p>
+			</ConfirmModal>,
+		);
+		await userEvent.keyboard("{Escape}");
+		expect(onClose).not.toHaveBeenCalled();
 	});
 
 	it("shows the confirm label and an enabled cancel when not busy", () => {

--- a/frontdesk/web/src/components/__tests__/Modal.test.tsx
+++ b/frontdesk/web/src/components/__tests__/Modal.test.tsx
@@ -43,6 +43,20 @@ describe("Modal", () => {
 		expect(onClose).toHaveBeenCalled();
 	});
 
+	it("does not close on Escape or backdrop click when not dismissible", async () => {
+		const onClose = vi.fn();
+		render(
+			<Modal title="Busy dialog" onClose={onClose} dismissible={false}>
+				<input aria-label="field" />
+			</Modal>,
+		);
+		await userEvent.keyboard("{Escape}");
+		// The backdrop is the dialog's parent; mousedown on it would normally close.
+		const backdrop = screen.getByRole("dialog").parentElement as HTMLElement;
+		await userEvent.click(backdrop);
+		expect(onClose).not.toHaveBeenCalled();
+	});
+
 	it("does not steal focus when the parent re-renders (new onClose identity)", async () => {
 		// Mirrors the real panels: an inline-arrow onClose plus an in-modal control
 		// that re-renders the parent. Focus must stay where the user put it.

--- a/frontdesk/web/src/i18n/locales/en.json
+++ b/frontdesk/web/src/i18n/locales/en.json
@@ -150,6 +150,7 @@
 		"syncAck": "I understand these members' tokens will be overwritten",
 		"syncDo_one": "Overwrite {{count}} member now",
 		"syncDo_other": "Overwrite {{count}} members now",
+		"syncDoing": "Syncing admin token...",
 		"syncDone_one": "Synced {{ok}} of {{total}} member",
 		"syncDone_other": "Synced {{ok}} of {{total}} members",
 		"configSyncConfirmTitle_one": "Replace config on {{count}} member?",
@@ -160,6 +161,8 @@
 		"configSyncAck": "I understand these members' config will be overwritten to match the primary",
 		"configSyncDo_one": "Replace config on {{count}} member now",
 		"configSyncDo_other": "Replace config on {{count}} members now",
+		"configSyncDoing": "Replacing config...",
+		"configSyncProgress": "Replacing config and rediscovering models on each member. This can take up to a minute; keep this window open.",
 		"configSyncDone_one": "Synced config to {{ok}} of {{total}} member",
 		"configSyncDone_other": "Synced config to {{ok}} of {{total}} members",
 		"wizard": {

--- a/frontdesk/web/src/index.css
+++ b/frontdesk/web/src/index.css
@@ -484,3 +484,38 @@ h3 {
 	cursor: not-allowed;
 	opacity: 0.6;
 }
+
+/* --- inline spinner --- */
+/* A small activity ring sized in em so it rides inside a ui-btn flex row and
+   inherits the button's text color. Used to show a confirm action is in flight
+   (e.g. config sync, which runs model discovery on every member). */
+.fd-spinner {
+	display: inline-block;
+	width: 0.9em;
+	height: 0.9em;
+	border: 2px solid currentColor;
+	border-top-color: transparent;
+	border-radius: 50%;
+	animation: fd-spin 0.7s linear infinite;
+	vertical-align: -0.1em;
+}
+@keyframes fd-spin {
+	to {
+		transform: rotate(360deg);
+	}
+}
+/* Reduced-motion: drop the rotation but still signal activity with a pulse. */
+@media (prefers-reduced-motion: reduce) {
+	.fd-spinner {
+		animation: fd-pulse 1.1s ease-in-out infinite;
+	}
+	@keyframes fd-pulse {
+		0%,
+		100% {
+			opacity: 0.3;
+		}
+		50% {
+			opacity: 1;
+		}
+	}
+}

--- a/internal/frontdesk/memberapi.go
+++ b/internal/frontdesk/memberapi.go
@@ -56,6 +56,14 @@ func (s *Server) callMemberWith(ctx context.Context, client *http.Client, method
 // not reach" (a warning), never as a wrong token.
 const memberProbeTimeout = 6 * time.Second
 
+// memberReadTimeout bounds an interactive member admin read (currently the
+// Traffic tab's stats timeseries). It is more generous than the health probe
+// because a member aggregating an hour of buckets can legitimately take longer
+// than a liveness check, and timing out there mislabels a slow-but-successful
+// read as "could not read metrics"; it stays well under the import relay's
+// deadline so a hung member still fails the Traffic card quickly.
+const memberReadTimeout = 15 * time.Second
+
 // memberSyncTimeout bounds a config import relay. Unlike a health probe, an
 // import runs model discovery on the member (live upstream calls), which easily
 // exceeds the 4s probe timeout, so the import client is given a far more generous

--- a/internal/frontdesk/membertraffic.go
+++ b/internal/frontdesk/membertraffic.go
@@ -69,10 +69,13 @@ func (s *Server) memberTraffic(w http.ResponseWriter, r *http.Request) {
 // fetchMemberTraffic proxies and reshapes one member's time series, returning a
 // reachable=false response on any transport, status, or parse failure (the
 // member may simply be down; the Traffic tab degrades gracefully per member).
+// It uses the longer-deadline read client, not the fast health probe: a member
+// aggregating an hour of buckets can take longer than a liveness check, and the
+// probe timeout would mislabel that slow-but-successful read as unreachable.
 func (s *Server) fetchMemberTraffic(ctx context.Context, m *Member, token string) memberTrafficResponse {
 	out := memberTrafficResponse{MemberID: m.ID, WindowMinutes: 60, Points: []trafficPoint{}}
 
-	status, body, err := s.callMember(ctx, http.MethodGet, m.URL, memberTimeSeriesPath, token, nil)
+	status, body, err := s.callMemberWith(ctx, s.readClient, http.MethodGet, m.URL, memberTimeSeriesPath, token, nil)
 	if err != nil {
 		debuglog.Debug("frontdesk: member traffic fetch failed", "member", m.Name, "error", err)
 		return out

--- a/internal/frontdesk/membertraffic_test.go
+++ b/internal/frontdesk/membertraffic_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 func TestMemberTrafficProxiesAndReshapes(t *testing.T) {
@@ -46,6 +47,44 @@ func TestMemberTrafficProxiesAndReshapes(t *testing.T) {
 	}
 	if gotAuth != "Bearer member-token" {
 		t.Errorf("member saw auth %q, want Bearer member-token", gotAuth)
+	}
+}
+
+// A member whose stats timeseries is slow to assemble (an hour of buckets under
+// load) must still be reported reachable: traffic reads use the longer-deadline
+// read client, not the fast health probe. The probe is deliberately set shorter
+// than the member's delay; a reachable result proves the read did not route
+// through it.
+func TestMemberTrafficUsesLongerDeadlineThanProbe(t *testing.T) {
+	srv, store := newTestServer(t)
+	srv.probe = newProbeClient(50 * time.Millisecond)
+	srv.readClient = newProbeClient(3 * time.Second)
+
+	member := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/stats/timeseries" {
+			time.Sleep(200 * time.Millisecond) // longer than the probe, within the read client
+			_, _ = w.Write([]byte(`{"points":[{"bucket":"b1","count":3,"errors":1}]}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer member.Close()
+
+	m, err := store.CreateMember(t.Context(), "slow-hotel", member.URL, "tok")
+	if err != nil {
+		t.Fatalf("CreateMember: %v", err)
+	}
+	rec := do(t, srv, http.MethodGet, "/api/members/"+m.ID+"/traffic", "", true)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("traffic = %d", rec.Code)
+	}
+	var resp memberTrafficResponse
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	if !resp.Reachable {
+		t.Fatal("slow timeseries must be reachable (read must use the long-deadline client)")
+	}
+	if resp.TotalRequests != 3 {
+		t.Errorf("totals = %d req, want 3", resp.TotalRequests)
 	}
 }
 

--- a/internal/frontdesk/server.go
+++ b/internal/frontdesk/server.go
@@ -59,6 +59,7 @@ type Server struct {
 	totpRepo   *totp.Repository
 	totpStatus *totpEnabledCache
 	probe      *http.Client // guarded client for proxying member admin APIs
+	readClient *http.Client // guarded client for interactive member admin reads (e.g. Traffic timeseries); longer deadline than the health probe, shorter than the import relay
 	syncClient *http.Client // guarded client for the config-import relay (longer deadline; import runs member-side discovery)
 	lbPort     string       // host port of the data-plane load balancer, surfaced to the wizard
 	masterKey  string       // fleet MASTER_KEY, used to confirm the destructive admin-token reset
@@ -92,6 +93,7 @@ func NewServer(cfg ServerConfig) *Server {
 		totpRepo:   totpRepo,
 		totpStatus: newTotpEnabledCache(totpRepo),
 		probe:      newProbeClient(httpProbeTimeout),
+		readClient: newProbeClient(memberReadTimeout),
 		syncClient: newProbeClient(memberSyncTimeout),
 		lbPort:     lbPort,
 		masterKey:  cfg.MasterKey,


### PR DESCRIPTION
Two rough edges surfaced by hands-on use of the rebuilt HA stack, one backend fix and one frontend UX fix.

## Fix A: Traffic reads use a longer-deadline client (backend)

The Traffic tab proxied a member's `/api/stats/timeseries` through the 4s health-probe client. A member aggregating an hour of 5-minute buckets (cold cache / DB under load) can legitimately take longer than a liveness check, so a slow-but-successful read was mislabeled unreachable: the card showed "Could not read metrics" with empty graphs until a warm reload filled them. Same class of bug as the config-import deadline fix in #300.

- New `readClient` (15s) built from the same `newProbeClient`, so the SSRF dial guard and cross-host/https-downgrade redirect policy are preserved. It sits between the 4s probe and the 120s import relay, so a genuinely hung member still fails the Traffic card quickly.
- `fetchMemberTraffic` routes through it via `callMemberWith`.
- Inbound FD server sets no `WriteTimeout`, so the longer read response is not cut off (same reasoning as the import relay).
- Regression test: a stub member that sleeps past a tiny `probe` timeout but within `readClient` still returns `reachable: true` with points.

## Fix B: in-progress state on the confirm modals (frontend)

Confirming "Replace config" posts an import that runs model discovery on every member (the slow path behind the 120s sync client). The confirm button was merely disabled, so the modal looked frozen for up to a minute.

- `ConfirmModal` gains optional `busy` / `busyLabel`: while busy the confirm button shows a spinner + working label, Cancel is disabled (the sync runs server-side and the modal auto-closes on resolution), and `aria-busy` is set.
- The Fleet Sync Wizard passes these to the config and admin-token confirmations; the config modal adds an in-body hint that discovery can take up to a minute.
- New `.fd-spinner` with a `prefers-reduced-motion` opacity-pulse fallback.

Note: the version-fetch `502`s seen in the logs at restart were benign (members rebuilding behind their reverse proxy); the 3-strike escalation + recovery worked as designed. No code change there.

## Verification

- `go test ./internal/frontdesk/...` and `golangci-lint run ./internal/frontdesk/...`: green.
- From `frontdesk/web/`: `pnpm vitest run` (57 tests), `pnpm exec tsc -b`, `pnpm biome check`: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)