### PR TITLE
feat(ha): automatic config sync from a designated primary

### DIFF
--- a/cmd/frontdesk/main.go
+++ b/cmd/frontdesk/main.go
@@ -101,6 +101,7 @@ func main() {
 	defer stop()
 
 	go poller.Run(ctx)
+	go srv.RunAutoSync(ctx)
 
 	httpServer := &http.Server{
 		Addr:              port,

--- a/docs/HA.md
+++ b/docs/HA.md
@@ -181,6 +181,12 @@ It reuses the same machinery as the wizard, with two safety properties:
   skipped untouched, and a member that is unreachable or `MASTER_KEY`-blocked is
   retried on the next check rather than overwritten.
 
+It reacts to *changes on the primary*, it is not a continuous reconciler. If you
+edit a replica directly (you shouldn't, managed members are read-only), that drift
+sits until the **primary** next changes, at which point the full config is pushed
+and the replica is brought back in line. There is no constant revert loop watching
+each replica.
+
 Automatic sync is **off by default** and is the opposite trade-off from the
 wizard: convenience over the per-change diff review. Leave it off if you want a
 human to approve every fleet-wide change; turn it on once you trust the primary as

--- a/docs/HA.md
+++ b/docs/HA.md
@@ -161,6 +161,31 @@ Runbook:
    and is reported; re-run to retry. Request logs and metering are never touched
    (a removed provider's logs are kept, with the provider link nulled).
 
+### Automatic config sync (set and forget)
+
+The wizard above is the manual path. For an unattended fleet, turn on **automatic
+config sync** (Front Desk -> Settings -> **Automatic config sync**): designate a
+primary, flip it on, and you only ever manage the primary. Front Desk watches the
+primary's config and, whenever its providers, virtual keys, or syncable settings
+change, propagates the change to the rest of the fleet for you. The Members table
+shows a **Last Config Sync** column so you can see when each member last
+converged and why.
+
+It reuses the same machinery as the wizard, with two safety properties:
+
+- **Backed up first.** Before overwriting a member, Front Desk asks it to take a
+  backup (badged **FD** in that member's backup list, and spared from GFS
+  rotation like a manual backup), so a bad propagation can be rolled back.
+- **Converges, does not thrash.** A change is only propagated once it has settled
+  (the same config two checks running), members already matching the primary are
+  skipped untouched, and a member that is unreachable or `MASTER_KEY`-blocked is
+  retried on the next check rather than overwritten.
+
+Automatic sync is **off by default** and is the opposite trade-off from the
+wizard: convenience over the per-change diff review. Leave it off if you want a
+human to approve every fleet-wide change; turn it on once you trust the primary as
+the source of truth.
+
 ## TLS proxy
 
 Put a real TLS proxy in front of both published ports. Example nginx, two
@@ -224,8 +249,9 @@ HTTP-provider design). No request or prompt content is ever logged.
   new requests go elsewhere.
 - **Not** Postgres HA, **not** LB redundancy: the HA host and each member's
   Postgres remain single points of failure for their own scope (accepted at
-  homelab scale). No automated cross-instance config sync yet, so keep config in
-  step with backup/restore and runbook discipline.
+  homelab scale). Cross-instance config replication is built in (the fleet-sync
+  wizard, or automatic config sync), but member databases themselves still rely
+  on per-member backup/restore discipline.
 
 ## Acceptance checks (two machines)
 

--- a/frontdesk/web/src/api/client.ts
+++ b/frontdesk/web/src/api/client.ts
@@ -3,6 +3,7 @@ import type {
 	PublicKeyCredentialRequestOptionsJSON,
 } from "@simplewebauthn/browser";
 import type {
+	AutoSyncConfig,
 	EventsPage,
 	FdEvent,
 	FleetStatus,
@@ -147,6 +148,13 @@ export const api = {
 		),
 	// Last successful wizard run (timestamp + primary), or null when never run.
 	fleetLastSync: () => request<FleetSyncState | null>("/api/fleet/last-sync"),
+
+	// Automatic config propagation: read and update the toggle + designated
+	// primary. Front Desk's poller watches that primary and re-syncs the fleet
+	// when its config changes.
+	getAutoSync: () => request<AutoSyncConfig>("/api/fleet/autosync"),
+	putAutoSync: (cfg: AutoSyncConfig) =>
+		request<AutoSyncConfig>("/api/fleet/autosync", jsonInit("PUT", cfg)),
 
 	configSync: (primaryId: string) =>
 		request<SyncResult>(

--- a/frontdesk/web/src/api/types.ts
+++ b/frontdesk/web/src/api/types.ts
@@ -14,6 +14,19 @@ export interface Member {
 	// Set after add/edit when the admin token was saved but could not be
 	// confirmed (member offline, or an older build). A refused token is a 400.
 	token_warning?: string;
+	// When Front Desk last applied config to this member (wizard or automatic),
+	// RFC3339; absent until the first sync. last_config_sync_reason explains why
+	// (e.g. the primary's config changed). Both drive the "Last Config Sync"
+	// column on the Members tab.
+	last_config_sync_at?: string;
+	last_config_sync_reason?: string;
+}
+
+// AutoSyncConfig is the automatic config-propagation setup: a master on/off plus
+// the designated source-of-truth member (empty when none is chosen).
+export interface AutoSyncConfig {
+	enabled: boolean;
+	primary_id: string;
 }
 
 export interface HealthStatus {

--- a/frontdesk/web/src/components/AutoSyncPanel.tsx
+++ b/frontdesk/web/src/components/AutoSyncPanel.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { ApiError, api } from "../api/client";
+import type { AutoSyncConfig, MemberView } from "../api/types";
+import { useToast } from "../context/ToastContext";
+import { Notice } from "./Notice";
+
+// AutoSyncPanel is the "set and forget" control for HA config replication: pick a
+// primary and flip auto-sync on, and Front Desk's poller propagates the primary's
+// config to the rest of the fleet whenever it changes, snapshotting each member
+// first. It sits beside the manual wizard, which stays for first-time setup and
+// for forcing a sync on demand.
+//
+// Changes persist immediately (no separate Save button) so the toggle behaves
+// like a switch. Enabling is only offered once a primary with a stored admin
+// token is chosen, because the loop needs that token to read the primary's
+// config; the backend enforces the same rule.
+export function AutoSyncPanel({ members }: { members: MemberView[] }) {
+	const { t } = useTranslation();
+	const { toast } = useToast();
+	const [cfg, setCfg] = useState<AutoSyncConfig | null>(null);
+	const [loadError, setLoadError] = useState(false);
+	const [saving, setSaving] = useState(false);
+	const [saveError, setSaveError] = useState("");
+
+	useEffect(() => {
+		api
+			.getAutoSync()
+			.then(setCfg)
+			.catch(() => setLoadError(true));
+	}, []);
+
+	if (loadError || !cfg) return null; // stay quiet on load; the wizard still works
+
+	const persist = async (next: AutoSyncConfig) => {
+		setSaveError("");
+		setSaving(true);
+		try {
+			setCfg(await api.putAutoSync(next));
+			toast(t("settings.autoSync.saved"), "success");
+		} catch (err) {
+			setSaveError(
+				err instanceof ApiError && err.status === 400
+					? err.message
+					: t("errors.generic"),
+			);
+		} finally {
+			setSaving(false);
+		}
+	};
+
+	const tokenedMembers = members.filter((m) => m.has_token);
+
+	return (
+		<div className="ui-card ui-card-pad fd-stack">
+			<h2 style={{ fontSize: "1rem" }}>{t("settings.autoSync.title")}</h2>
+			<p
+				className="fd-faint"
+				style={{ fontSize: "0.82rem", margin: "0.3rem 0 0.6rem" }}
+			>
+				{t("settings.autoSync.hint")}
+			</p>
+
+			<div className="ui-field">
+				<label className="ui-label" htmlFor="autosync-primary">
+					{t("settings.autoSync.primaryLabel")}
+				</label>
+				<select
+					id="autosync-primary"
+					className="ui-input"
+					value={cfg.primary_id}
+					disabled={saving}
+					onChange={(e) => persist({ ...cfg, primary_id: e.target.value })}
+				>
+					<option value="">{t("settings.autoSync.primaryNone")}</option>
+					{tokenedMembers.map((m) => (
+						<option key={m.id} value={m.id}>
+							{m.name}
+						</option>
+					))}
+				</select>
+				<div
+					className="fd-faint"
+					style={{ fontSize: "0.78rem", marginTop: "0.3rem" }}
+				>
+					{t("settings.autoSync.primaryHint")}
+				</div>
+			</div>
+
+			<label className="fd-row" style={{ cursor: "pointer" }}>
+				<input
+					type="checkbox"
+					checked={cfg.enabled}
+					disabled={saving || !cfg.primary_id}
+					onChange={(e) => persist({ ...cfg, enabled: e.target.checked })}
+				/>
+				<span>
+					<span style={{ fontWeight: 500 }}>
+						{t("settings.autoSync.enableLabel")}
+					</span>
+					<span
+						className="fd-faint"
+						style={{ display: "block", fontSize: "0.78rem" }}
+					>
+						{t("settings.autoSync.enableHint")}
+					</span>
+				</span>
+			</label>
+
+			{cfg.enabled && (
+				<Notice variant="warn">{t("settings.autoSync.activeWarning")}</Notice>
+			)}
+			{saveError && (
+				<div className="fd-error-text" role="alert">
+					{saveError}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/frontdesk/web/src/components/FleetSyncWizard.tsx
+++ b/frontdesk/web/src/components/FleetSyncWizard.tsx
@@ -246,10 +246,10 @@ export function FleetSyncWizard({
 				>
 					<p className="fd-muted">{t("settings.configSyncConfirmBody")}</p>
 					{busy && (
-						<p className="fd-muted" style={{ margin: "0.5rem 0" }}>
+						<Notice variant="warn" style={{ margin: "0.5rem 0" }}>
 							<span className="fd-spinner" aria-hidden="true" />{" "}
 							{t("settings.configSyncProgress")}
-						</p>
+						</Notice>
 					)}
 					{totalRemoved > 0 && (
 						<p className="fd-error-text" style={{ margin: "0.5rem 0" }}>

--- a/frontdesk/web/src/components/__tests__/AutoSyncPanel.test.tsx
+++ b/frontdesk/web/src/components/__tests__/AutoSyncPanel.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { HttpResponse, http } from "msw";
+import { beforeEach, expect, it } from "vitest";
+import type { MemberView } from "../../api/types";
+import { ToastProvider } from "../../context/ToastContext";
+import { server } from "../../test/server";
+import { AutoSyncPanel } from "../AutoSyncPanel";
+
+function member(id: string, name: string, hasToken = true): MemberView {
+	return {
+		id,
+		name,
+		url: `https://${name}.example.com`,
+		state: "active",
+		has_token: hasToken,
+		created_at: "",
+		updated_at: "",
+		status: {
+			health: { known: true, healthy: true, latency_ms: 1, checked_at: "" },
+		},
+	};
+}
+
+const members = [member("1", "hotel-1"), member("2", "hotel-2", false)];
+
+function renderPanel() {
+	render(
+		<ToastProvider>
+			<AutoSyncPanel members={members} />
+		</ToastProvider>,
+	);
+}
+
+beforeEach(() => {
+	localStorage.setItem("fdAuthToken", "tok");
+	server.use(
+		http.get("/api/fleet/autosync", () =>
+			HttpResponse.json({ enabled: false, primary_id: "" }),
+		),
+	);
+});
+
+it("only offers token-holding members as primary", async () => {
+	renderPanel();
+	const select = await screen.findByRole("combobox");
+	// hotel-1 has a token; hotel-2 does not, so it must not be selectable.
+	expect(within(select).getByRole("option", { name: "hotel-1" })).toBeTruthy();
+	expect(within(select).queryByRole("option", { name: "hotel-2" })).toBeNull();
+});
+
+it("requires a primary before enabling, then warns when active", async () => {
+	let lastPut: { enabled: boolean; primary_id: string } | null = null;
+	server.use(
+		http.put("/api/fleet/autosync", async ({ request }) => {
+			lastPut = (await request.json()) as typeof lastPut;
+			return HttpResponse.json(lastPut);
+		}),
+	);
+	renderPanel();
+
+	// The enable toggle is disabled until a primary is chosen.
+	const checkbox = await screen.findByRole("checkbox");
+	expect(checkbox).toBeDisabled();
+
+	await userEvent.selectOptions(screen.getByRole("combobox"), "1");
+	await waitFor(() =>
+		expect(lastPut).toEqual({ enabled: false, primary_id: "1" }),
+	);
+	await waitFor(() => expect(screen.getByRole("checkbox")).toBeEnabled());
+
+	await userEvent.click(screen.getByRole("checkbox"));
+	await waitFor(() =>
+		expect(lastPut).toEqual({ enabled: true, primary_id: "1" }),
+	);
+
+	// The amber warning appears once auto-sync is active.
+	expect(await screen.findByText(/Automatic sync is on/i)).toBeTruthy();
+});

--- a/frontdesk/web/src/i18n/locales/en.json
+++ b/frontdesk/web/src/i18n/locales/en.json
@@ -55,6 +55,10 @@
 		"colFrontdesk": "Front Desk",
 		"colTraefik": "Traefik",
 		"colVersion": "Version",
+		"colLastSync": "Last Config Sync",
+		"lastSyncNever": "Never",
+		"lastSyncReasonUnknown": "a config sync",
+		"lastSyncTip": "Synced {{when}} · {{reason}}",
 		"colLatency": "Latency",
 		"colActions": "",
 		"stateActive": "Active",
@@ -158,6 +162,17 @@
 		"configSyncProgress": "Replacing config and rediscovering models on each member. This can take up to a minute; keep this window open.",
 		"configSyncDone_one": "Synced config to {{ok}} of {{total}} member",
 		"configSyncDone_other": "Synced config to {{ok}} of {{total}} members",
+		"autoSync": {
+			"title": "Automatic config sync",
+			"hint": "Designate one member as the primary and Front Desk keeps the rest of the fleet matched to it: whenever the primary's providers, virtual keys, or settings change, it propagates the change for you. You only manage the primary.",
+			"primaryLabel": "Primary (source of truth)",
+			"primaryNone": "None (automatic sync off)",
+			"primaryHint": "Only members with a stored admin token can be the primary, since Front Desk needs it to read their config.",
+			"enableLabel": "Keep the fleet synced to the primary automatically",
+			"enableHint": "Checks the primary every few seconds and re-syncs members when its config changes.",
+			"activeWarning": "Automatic sync is on. A change on the primary replaces config on every other member, which can remove providers or keys they have but the primary does not. Each member is backed up first so a bad change can be rolled back.",
+			"saved": "Auto-sync updated"
+		},
 		"wizard": {
 			"title": "Fleet sync wizard",
 			"intro": "Converge your whole fleet onto one primary, one step at a time. Each step unlocks only once the one before it is done for every reachable instance.",

--- a/frontdesk/web/src/pages/MembersPage.tsx
+++ b/frontdesk/web/src/pages/MembersPage.tsx
@@ -128,6 +128,7 @@ export function MembersPage() {
 								<th>{t("members.colFrontdesk")}</th>
 								<th>{t("members.colTraefik")}</th>
 								<th>{t("members.colVersion")}</th>
+								<th>{t("members.colLastSync")}</th>
 								<th>{t("members.colState")}</th>
 								<th />
 							</tr>
@@ -259,6 +260,24 @@ function MemberRow({
 				) : (
 					<span className="fd-faint">
 						{m.has_token ? "—" : t("members.noToken")}
+					</span>
+				)}
+			</td>
+			<td>
+				{m.last_config_sync_at ? (
+					<span
+						className="fd-faint"
+						title={t("members.lastSyncTip", {
+							when: formatRelative(m.last_config_sync_at),
+							reason:
+								m.last_config_sync_reason ?? t("members.lastSyncReasonUnknown"),
+						})}
+					>
+						{formatRelative(m.last_config_sync_at)}
+					</span>
+				) : (
+					<span className="fd-faint">
+						{isPrimary ? "—" : t("members.lastSyncNever")}
 					</span>
 				)}
 			</td>

--- a/frontdesk/web/src/pages/SettingsPage.tsx
+++ b/frontdesk/web/src/pages/SettingsPage.tsx
@@ -2,6 +2,7 @@ import { type FormEvent, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ApiError, api } from "../api/client";
 import type { Settings } from "../api/types";
+import { AutoSyncPanel } from "../components/AutoSyncPanel";
 import { FleetSyncWizard } from "../components/FleetSyncWizard";
 import { SecurityPanels } from "../components/SecurityPanels";
 import { useToast } from "../context/ToastContext";
@@ -224,6 +225,8 @@ export function SettingsPage() {
 					</button>
 				</div>
 			</form>
+
+			<AutoSyncPanel members={members} />
 
 			<FleetSyncWizard members={members} onChanged={refetchMembers} />
 

--- a/internal/api/backup.go
+++ b/internal/api/backup.go
@@ -89,8 +89,16 @@ type backupEntry struct {
 	Origin string `json:"origin"`
 }
 
-// CreateBackup runs pg_dump and saves the output to a timestamped file.
+// CreateBackup runs pg_dump and saves the output to a timestamped file. An
+// operator-initiated call records origin "manual"; Front Desk passes
+// ?origin=frontdesk so the snapshot it takes before an HA config sync is badged
+// distinctly (and, like manual backups, spared from GFS rotation). "auto" is
+// scheduler-internal and never accepted here.
 func (h *BackupHandler) CreateBackup(w http.ResponseWriter, r *http.Request) {
+	origin := "manual"
+	if r.URL.Query().Get("origin") == backupOriginFrontDesk {
+		origin = backupOriginFrontDesk
+	}
 	if !h.backupMu.TryLock() {
 		respondError(w, "backup already in progress", nil, http.StatusConflict)
 		return
@@ -110,7 +118,7 @@ func (h *BackupHandler) CreateBackup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	filename := generateBackupFilename("manual")
+	filename := generateBackupFilename(origin)
 	path := filepath.Join(h.backupDir, filename)
 
 	// Use a dedicated 10-minute timeout so large databases don't get killed
@@ -149,7 +157,7 @@ func (h *BackupHandler) CreateBackup(w http.ResponseWriter, r *http.Request) {
 		Filename:  filename,
 		SizeBytes: info.Size(),
 		CreatedAt: info.ModTime().Format(time.RFC3339),
-		Origin:    "manual",
+		Origin:    backupOrigin(filename),
 	})
 }
 
@@ -268,16 +276,27 @@ func generateBackupFilename(origin string) string {
 	)
 }
 
-// backupOrigin reports who created a backup. Only files the scheduler wrote
-// carry the "_auto" marker and count as "scheduled"; everything else, manual
-// "_manual" files and any predating origin tracking, reads as "manual". Erring
-// toward manual keeps GFS rotation from pruning backups it cannot prove it
-// created, which is the safe default for legacy files.
+// backupOriginFrontDesk marks a backup taken by Front Desk before an HA config
+// sync. It is both the ?origin= value CreateBackup accepts and the value
+// backupOrigin reports for "_frontdesk" files.
+const backupOriginFrontDesk = "frontdesk"
+
+// backupOrigin reports who created a backup. The scheduler's files carry "_auto"
+// and read as "scheduled"; Front Desk's pre-sync snapshots carry "_frontdesk" and
+// read as "frontdesk"; everything else, manual "_manual" files and any predating
+// origin tracking, reads as "manual". Erring toward manual keeps GFS rotation
+// from pruning backups it cannot prove it created, which is the safe default for
+// legacy files; like manual, "frontdesk" files are never rotation targets.
 func backupOrigin(filename string) string {
-	if strings.HasSuffix(strings.TrimSuffix(filename, ".dump"), "_auto") {
+	stem := strings.TrimSuffix(filename, ".dump")
+	switch {
+	case strings.HasSuffix(stem, "_auto"):
 		return "scheduled"
+	case strings.HasSuffix(stem, "_"+backupOriginFrontDesk):
+		return backupOriginFrontDesk
+	default:
+		return "manual"
 	}
-	return "manual"
 }
 
 // scheduledBackups drops manual (and legacy, which read as manual) backups so

--- a/internal/api/backup_test.go
+++ b/internal/api/backup_test.go
@@ -2753,10 +2753,11 @@ func TestParseBackupTimestamp(t *testing.T) {
 
 func TestBackupOrigin(t *testing.T) {
 	cases := map[string]string{
-		"backup_20240115_120000_0010_manual.dump": "manual",
-		"backup_20240115_120000_0010_auto.dump":   "scheduled",
-		"backup_20240115_120000_0010.dump":        "manual", // predates origin tracking
-		"backup_20240115_120000_manual.dump":      "manual",
+		"backup_20240115_120000_0010_manual.dump":    "manual",
+		"backup_20240115_120000_0010_auto.dump":      "scheduled",
+		"backup_20240115_120000_0010_frontdesk.dump": "frontdesk",
+		"backup_20240115_120000_0010.dump":           "manual", // predates origin tracking
+		"backup_20240115_120000_manual.dump":         "manual",
 	}
 	for name, want := range cases {
 		if got := backupOrigin(name); got != want {
@@ -2775,6 +2776,15 @@ func TestGenerateBackupFilenameOrigin(t *testing.T) {
 	}
 	if got := backupOrigin(generateBackupFilename("auto")); got != "scheduled" {
 		t.Errorf("auto backup origin = %q, want scheduled", got)
+	}
+	// Front Desk's pre-sync snapshots round-trip to "frontdesk" and, like manual,
+	// are not GFS rotation targets (only "_auto" files are scheduled).
+	fd := generateBackupFilename(backupOriginFrontDesk)
+	if got := backupOrigin(fd); got != backupOriginFrontDesk {
+		t.Errorf("frontdesk backup origin = %q, want %q", got, backupOriginFrontDesk)
+	}
+	if _, err := parseBackupTimestamp(fd); err != nil {
+		t.Errorf("parseBackupTimestamp(%q) failed: %v", fd, err)
 	}
 	// The origin segment must not break timestamp parsing (GFS classification).
 	if _, err := parseBackupTimestamp(manual); err != nil {

--- a/internal/api/configsync.go
+++ b/internal/api/configsync.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -78,10 +80,11 @@ func NewConfigSyncHandler(database *db.DB, settingsRepo SettingsStore, masterKey
 	}
 }
 
-// Register mounts GET/POST /config/{export,import}. The parent router must apply
-// admin auth (see type doc).
+// Register mounts GET/POST /config/{export,import} and GET /config/version. The
+// parent router must apply admin auth (see type doc).
 func (h *ConfigSyncHandler) Register(r chi.Router) {
 	r.Get("/config/export", h.Export)
+	r.Get("/config/version", h.Version)
 	r.Post("/config/import", h.Import)
 }
 
@@ -194,6 +197,33 @@ func (h *ConfigSyncHandler) Export(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, env)
+}
+
+// Version returns a stable content hash of this member's syncable config, so
+// Front Desk's auto-sync poller can cheaply detect that the primary's config
+// changed without pulling and diffing the full export every tick. The hash
+// covers only the Config payload (providers, virtual keys, syncable settings,
+// custom failover groups), never the volatile envelope fields (exported_at), so
+// it changes if and only if a synced entity changed. Same auth as Export.
+func (h *ConfigSyncHandler) Version(w http.ResponseWriter, r *http.Request) {
+	env, err := h.buildEnvelope(r.Context())
+	if err != nil {
+		debuglog.Error("configsync: build version envelope", "error", err)
+		http.Error(w, "could not read config", http.StatusInternalServerError)
+		return
+	}
+	// Marshal only the Config payload: providers come out ORDER BY name, virtual
+	// keys ORDER BY created_at, failover groups ORDER BY display_model, and the
+	// settings map is key-sorted by encoding/json, so the bytes are deterministic
+	// for an unchanged config and the hash is stable across calls.
+	payload, err := json.Marshal(env.Config)
+	if err != nil {
+		debuglog.Error("configsync: marshal config for version", "error", err)
+		http.Error(w, "could not read config", http.StatusInternalServerError)
+		return
+	}
+	sum := sha256.Sum256(payload)
+	writeJSON(w, map[string]string{"version": hex.EncodeToString(sum[:])})
 }
 
 // buildEnvelope reads this member's full config (providers with key ciphertext,

--- a/internal/api/configsync_test.go
+++ b/internal/api/configsync_test.go
@@ -556,6 +556,17 @@ func TestConfigSync_ExportDBError(t *testing.T) {
 	}
 }
 
+func TestConfigSync_VersionDBError(t *testing.T) {
+	cleanConfigTables(t)
+	r := newConfigSyncRouter(t, configSyncMasterKey)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/config/version", http.NoBody).WithContext(cancelledCtx())
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("version with DB error = %d, want 500", rec.Code)
+	}
+}
+
 func TestConfigSync_ImportDBError(t *testing.T) {
 	cleanConfigTables(t)
 	r := newConfigSyncRouter(t, configSyncMasterKey)

--- a/internal/api/configsync_test.go
+++ b/internal/api/configsync_test.go
@@ -91,6 +91,45 @@ func doImport(t *testing.T, r chi.Router, env ConfigEnvelope, query string) *htt
 	return rec
 }
 
+func doVersion(t *testing.T, r chi.Router) string {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/config/version", http.NoBody))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("version status = %d, body %s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode version: %v", err)
+	}
+	return resp.Version
+}
+
+// TestConfigSync_VersionStableAndChanges: the config-version hash is the auto-sync
+// drift signal, so it must be stable for an unchanged config and change when a
+// synced entity changes.
+func TestConfigSync_VersionStableAndChanges(t *testing.T) {
+	cleanConfigTables(t)
+	r := newConfigSyncRouter(t, configSyncMasterKey)
+
+	seedProvider(t, "openai", "sk-secret-value", configSyncMasterKey)
+	v1 := doVersion(t, r)
+	if v1 == "" {
+		t.Fatal("version hash is empty")
+	}
+	if v2 := doVersion(t, r); v2 != v1 {
+		t.Errorf("version changed without a config change: %q -> %q", v1, v2)
+	}
+
+	// Adding a provider must change the hash.
+	seedProvider(t, "anthropic", "sk-other-value", configSyncMasterKey)
+	if v3 := doVersion(t, r); v3 == v1 {
+		t.Errorf("version unchanged after adding a provider: still %q", v1)
+	}
+}
+
 func TestConfigSync_ExportImportRoundTrip(t *testing.T) {
 	cleanConfigTables(t)
 	ctx := context.Background()

--- a/internal/auth/encryption.go
+++ b/internal/auth/encryption.go
@@ -85,6 +85,13 @@ func decryptWithKey(ciphertext, nonce, key []byte) (string, error) {
 		return "", fmt.Errorf("failed to create GCM: %w", err)
 	}
 
+	// gcm.Open panics (rather than erroring) on a wrong-length nonce, so guard it:
+	// a corrupt or truncated stored nonce must surface as an error the caller can
+	// handle, not crash the process.
+	if len(nonce) != gcm.NonceSize() {
+		return "", fmt.Errorf("failed to decrypt: invalid nonce length %d (want %d)", len(nonce), gcm.NonceSize())
+	}
+
 	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
 	if err != nil {
 		return "", fmt.Errorf("failed to decrypt: %w", err)

--- a/internal/auth/encryption_test.go
+++ b/internal/auth/encryption_test.go
@@ -205,6 +205,19 @@ func TestDecrypt_InvalidCiphertext(t *testing.T) {
 	}
 }
 
+func TestDecrypt_WrongNonceLength(t *testing.T) {
+	masterKey := "test-master-key-123"
+	salt := make([]byte, 32)
+	ciphertext := []byte("some-ciphertext")
+
+	// A nonce of the wrong length must return an error, not panic the GCM Open.
+	for _, n := range []int{0, 1, nonceLength - 1, nonceLength + 1} {
+		if _, err := Decrypt(ciphertext, make([]byte, n), salt, masterKey); err == nil {
+			t.Errorf("Decrypt with nonce length %d should fail, got nil", n)
+		}
+	}
+}
+
 func TestDecrypt_MissingSalt(t *testing.T) {
 	masterKey := "test-master-key-123"
 	ciphertext := []byte("some-ciphertext")

--- a/internal/frontdesk/autosync.go
+++ b/internal/frontdesk/autosync.go
@@ -145,8 +145,17 @@ func (s *Server) applyAutoSync(ctx context.Context, primary *Member, primaryToke
 
 	allConverged = true
 	for _, m := range members {
-		if m.ID == primary.ID || !m.HasToken {
-			continue // the source and token-less members are never written
+		if m.ID == primary.ID {
+			continue // the source is never written to
+		}
+		if !m.HasToken {
+			// A tokenless member can't be authenticated to, so it is skipped without
+			// flipping allConverged: counting it as not-converged would re-probe the
+			// whole fleet every tick for as long as it stayed tokenless. The skip is
+			// safe because the tokenless -> tokened transition only happens through
+			// createMember / patchMember, both of which call rearmAutoSync to clear the
+			// applied hash and force this pass to re-run once the member is syncable.
+			continue
 		}
 		token, ok, err := s.store.MemberToken(ctx, m.ID)
 		if err != nil || !ok {

--- a/internal/frontdesk/autosync.go
+++ b/internal/frontdesk/autosync.go
@@ -1,0 +1,236 @@
+package frontdesk
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/hugalafutro/model-hotel/internal/debuglog"
+)
+
+// This file implements HA auto config sync: the "set and forget" half of fleet
+// config replication. Where configsync.go runs a manual, wizard-driven, double-
+// confirmed sync, the auto-syncer watches the operator-designated primary on a
+// background tick and, when its config changes, propagates it to every other
+// member by itself, snapshotting each member first so a bad propagation is
+// recoverable.
+//
+// Drift is detected by the primary's own config hash (GET /api/config/version):
+// the hash is compared against the hash last applied to the fleet, both read
+// from the same instance, so it is a valid same-instance "changed since" signal.
+// Whether an individual member needs the new config is decided by the member's
+// own dry-run diff (never by comparing hashes across instances, which embed
+// instance-local ids/timestamps), so an already-converged member is skipped with
+// no backup and no import.
+//
+// No request or prompt content is ever read; only provider/key names and counts
+// flow, exactly as in the manual sync.
+
+const (
+	memberConfigVersionPath = "/api/config/version"
+	memberBackupsPath       = "/api/backups"
+
+	// frontDeskBackupOrigin is the ?origin= value Front Desk passes so its
+	// pre-sync snapshots are badged "FD" on the member and spared GFS rotation.
+	// It must match internal/api.backupOriginFrontDesk.
+	frontDeskBackupOrigin = "frontdesk"
+
+	// autoSyncIntervalSecs is how often the auto-syncer samples the primary. It
+	// is deliberately slower than the health poll: each apply runs member-side
+	// discovery, so a tight loop would be wasteful, and "set and forget"
+	// convergence within a few tens of seconds of an edit is ample.
+	autoSyncIntervalSecs = 15
+
+	// autoSyncReason is stamped on each member's last-sync record and shown in the
+	// Members table tooltip, so the operator sees why an automatic sync fired.
+	autoSyncReason = "the primary's config changed"
+)
+
+// RunAutoSync samples the designated primary on a fixed tick and propagates its
+// config to the fleet when it changes. It blocks until ctx is cancelled and is
+// started once, alongside the poller. The loop owns the small amount of state
+// (the previously observed hash) used to coalesce a burst of edits into one sync.
+func (s *Server) RunAutoSync(ctx context.Context) {
+	ticker := time.NewTicker(autoSyncIntervalSecs * time.Second)
+	defer ticker.Stop()
+	var prev string // primary hash seen on the previous tick (coalescing window)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			prev = s.autoSyncOnce(ctx, prev)
+		}
+	}
+}
+
+// autoSyncOnce performs one auto-sync sample. prev is the primary config hash
+// observed on the previous tick; the returned value is the hash to carry into
+// the next tick. It never returns an error: every failure path logs and leaves
+// the fleet untouched, to be retried on the next tick.
+func (s *Server) autoSyncOnce(ctx context.Context, prev string) string {
+	cfg, err := s.store.GetAutoSync(ctx)
+	if err != nil {
+		debuglog.Warn("frontdesk: auto-sync: read config", "error", err)
+		return ""
+	}
+	if !cfg.Enabled || cfg.PrimaryID == "" {
+		return "" // disabled or no primary designated: nothing to do
+	}
+
+	primary, primaryToken, err := s.memberTokenOrErr(ctx, cfg.PrimaryID)
+	if err != nil {
+		// The designated primary was removed or lost its token. The loop cannot
+		// proceed without a source; stay quiet at debug and reset the window.
+		debuglog.Debug("frontdesk: auto-sync: primary unavailable", "error", err)
+		return ""
+	}
+
+	hash, err := s.fetchMemberConfigVersion(ctx, primary, primaryToken)
+	if err != nil {
+		debuglog.Debug("frontdesk: auto-sync: read primary version", "member", primary.Name, "error", err)
+		return ""
+	}
+
+	// Unchanged since the last fleet-wide apply: nothing to propagate.
+	if hash == cfg.LastHash {
+		return hash
+	}
+	// Coalesce: only act once the primary's config has settled (the same hash two
+	// ticks running), so a multi-step edit session triggers one sync rather than
+	// one per intermediate save.
+	if hash != prev {
+		return hash
+	}
+
+	applied, allConverged := s.applyAutoSync(ctx, primary, primaryToken)
+	// Record the hash as applied only once every reachable member converged onto
+	// it. If a member was unreachable, leave the marker so the next tick retries;
+	// already-converged members are skipped by their dry-run diff, so the retry
+	// costs only cheap probes, never repeated backups or imports.
+	if allConverged {
+		if err := s.store.SetAutoSyncLastHash(ctx, hash); err != nil {
+			debuglog.Warn("frontdesk: auto-sync: record applied hash", "error", err)
+		}
+	}
+	if applied > 0 {
+		s.emit(ctx, Event{
+			Type: "config.auto_synced", Severity: "info", Source: "frontdesk",
+			Message: fmt.Sprintf("Auto-synced %d member(s): %s", applied, autoSyncReason),
+		})
+	}
+	return hash
+}
+
+// applyAutoSync pushes the primary's config to every other tokened member that
+// needs it. It returns how many members it actually re-synced and whether every
+// reachable member ended up converged (the signal autoSyncOnce uses to decide
+// whether to record the applied hash). Each member that needs the new config is
+// snapshotted first; a member whose pre-sync backup fails is skipped, not
+// overwritten.
+func (s *Server) applyAutoSync(ctx context.Context, primary *Member, primaryToken string) (applied int, allConverged bool) {
+	export, err := s.fetchMemberExport(ctx, primary, primaryToken)
+	if err != nil {
+		debuglog.Warn("frontdesk: auto-sync: read primary export", "member", primary.Name, "error", err)
+		return 0, false
+	}
+	members, err := s.store.ListMembers(ctx)
+	if err != nil {
+		debuglog.Warn("frontdesk: auto-sync: list members", "error", err)
+		return 0, false
+	}
+
+	allConverged = true
+	for _, m := range members {
+		if m.ID == primary.ID || !m.HasToken {
+			continue // the source and token-less members are never written
+		}
+		token, ok, err := s.store.MemberToken(ctx, m.ID)
+		if err != nil || !ok {
+			continue
+		}
+		// Decide whether this member needs the new config from its own dry-run
+		// diff, which compares by name and so is valid across instances.
+		res, status, err := s.pushMemberImport(ctx, m, token, export, true)
+		if err != nil {
+			debuglog.Debug("frontdesk: auto-sync: member unreachable, will retry", "member", m.Name, "status", status, "error", err)
+			allConverged = false
+			continue
+		}
+		if !res.SchemaVersionOK || !res.MasterKeyOK {
+			// A version skew or MASTER_KEY mismatch blocks this member. The manual
+			// wizard surfaces these explicitly; here we just hold off and retry.
+			debuglog.Debug("frontdesk: auto-sync: member not syncable", "member", m.Name)
+			allConverged = false
+			continue
+		}
+		added, updated, removed := res.Diff.counts()
+		if added+updated+removed == 0 {
+			continue // already converged: no backup, no import
+		}
+
+		// Snapshot before overwriting so a bad propagation is recoverable. A failed
+		// backup blocks this member's overwrite rather than risking an unrecoverable
+		// replace.
+		if err := s.backupMember(ctx, m, token); err != nil {
+			debuglog.Warn("frontdesk: auto-sync: pre-sync backup failed, skipping member", "member", m.Name, "error", err)
+			s.emit(ctx, Event{
+				Type: "config.sync_failed", Severity: "warning", Source: "frontdesk",
+				Message: fmt.Sprintf("Skipped %s: pre-sync backup failed", m.Name), MemberID: m.ID,
+			})
+			allConverged = false
+			continue
+		}
+
+		// applyMemberConfig stamps the member's last-sync marker with this reason on
+		// success, so the Members table shows when and why it last converged.
+		out := s.applyMemberConfig(ctx, m, token, export, autoSyncReason)
+		if !out.OK {
+			allConverged = false
+			continue // applyMemberConfig already emitted the per-member failure
+		}
+		applied++
+	}
+	return applied, allConverged
+}
+
+// fetchMemberConfigVersion reads a member's syncable-config hash from
+// GET /api/config/version. The hash changes if and only if a synced entity
+// changed, so it is the cheap drift signal for the designated primary.
+func (s *Server) fetchMemberConfigVersion(ctx context.Context, m *Member, token string) (string, error) {
+	status, body, err := s.callMember(ctx, http.MethodGet, m.URL, memberConfigVersionPath, token, nil)
+	if err != nil {
+		return "", err
+	}
+	if status != http.StatusOK {
+		return "", fmt.Errorf("member config-version returned %d", status)
+	}
+	var v struct {
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal(body, &v); err != nil {
+		return "", fmt.Errorf("frontdesk: parse member config-version: %w", err)
+	}
+	if v.Version == "" {
+		return "", errors.New("frontdesk: empty member config-version")
+	}
+	return v.Version, nil
+}
+
+// backupMember asks a member to snapshot itself before Front Desk overwrites its
+// config, tagging the backup with origin=frontdesk so it is badged distinctly and
+// spared from GFS rotation. It uses the longer import-relay deadline because
+// pg_dump can outlast the health-probe timeout.
+func (s *Server) backupMember(ctx context.Context, m *Member, token string) error {
+	status, _, err := s.callMemberWith(ctx, s.syncClient, http.MethodPost, m.URL, memberBackupsPath+"?origin="+frontDeskBackupOrigin, token, nil)
+	if err != nil {
+		return err
+	}
+	if status != http.StatusOK && status != http.StatusCreated {
+		return fmt.Errorf("member backup returned %d", status)
+	}
+	return nil
+}

--- a/internal/frontdesk/autosync.go
+++ b/internal/frontdesk/autosync.go
@@ -159,6 +159,13 @@ func (s *Server) applyAutoSync(ctx context.Context, primary *Member, primaryToke
 		}
 		token, ok, err := s.store.MemberToken(ctx, m.ID)
 		if err != nil || !ok {
+			// The member has token ciphertext (HasToken was true) but it could not be
+			// loaded or decrypted: a MASTER_KEY mismatch on the stored token, a transient
+			// DB error, or the token cleared in the race after the snapshot. Unlike a
+			// tokenless member there is no membership event that will re-arm the loop, so
+			// this must NOT count as converged: hold off and retry on the next tick.
+			debuglog.Debug("frontdesk: auto-sync: member token unavailable, will retry", "member", m.Name, "loaded", ok, "error", err)
+			allConverged = false
 			continue
 		}
 		// Decide whether this member needs the new config from its own dry-run

--- a/internal/frontdesk/autosync.go
+++ b/internal/frontdesk/autosync.go
@@ -186,8 +186,10 @@ func (s *Server) applyAutoSync(ctx context.Context, primary *Member, primaryToke
 		}
 
 		// applyMemberConfig stamps the member's last-sync marker with this reason on
-		// success, so the Members table shows when and why it last converged.
-		out := s.applyMemberConfig(ctx, m, token, export, autoSyncReason)
+		// success, so the Members table shows when and why it last converged. Per-
+		// member success events are suppressed here (emitSuccessEvent=false); the
+		// loop emits one roll-up below so a fleet sync does not toast per member.
+		out := s.applyMemberConfig(ctx, m, token, export, autoSyncReason, false)
 		if !out.OK {
 			allConverged = false
 			continue // applyMemberConfig already emitted the per-member failure
@@ -222,10 +224,11 @@ func (s *Server) fetchMemberConfigVersion(ctx context.Context, m *Member, token 
 
 // backupMember asks a member to snapshot itself before Front Desk overwrites its
 // config, tagging the backup with origin=frontdesk so it is badged distinctly and
-// spared from GFS rotation. It uses the longer import-relay deadline because
-// pg_dump can outlast the health-probe timeout.
+// spared from GFS rotation. It uses backupClient, whose deadline exceeds the
+// member's own pg_dump budget, so a large member completes its snapshot rather
+// than timing out every tick and leaving an orphaned dump holding the backup lock.
 func (s *Server) backupMember(ctx context.Context, m *Member, token string) error {
-	status, _, err := s.callMemberWith(ctx, s.syncClient, http.MethodPost, m.URL, memberBackupsPath+"?origin="+frontDeskBackupOrigin, token, nil)
+	status, _, err := s.callMemberWith(ctx, s.backupClient, http.MethodPost, m.URL, memberBackupsPath+"?origin="+frontDeskBackupOrigin, token, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/frontdesk/autosync_test.go
+++ b/internal/frontdesk/autosync_test.go
@@ -19,6 +19,8 @@ type stubAutoMember struct {
 	versionHash string
 	exportBody  string
 	dryDiff     string // diff object returned on a dry-run import
+	importCode  int    // status for the dry-run import (default 200)
+	importBody  string // full dry-run import body; overrides dryDiff when set
 	backupCode  int
 	gotBackup   bool
 	gotRealSync bool
@@ -31,6 +33,7 @@ func newStubAutoMember(t *testing.T, token string) *stubAutoMember {
 		versionHash: "hash-A",
 		exportBody:  fleetExportWithKey,
 		dryDiff:     `{"providers":{},"virtual_keys":{},"settings":{}}`, // converged
+		importCode:  http.StatusOK,
 		backupCode:  http.StatusCreated,
 	}
 	sm.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -47,6 +50,11 @@ func newStubAutoMember(t *testing.T, token string) *stubAutoMember {
 			_, _ = w.Write([]byte(sm.exportBody))
 		case r.Method == http.MethodPost && r.URL.Path == "/api/config/import":
 			if r.URL.Query().Get("dryRun") != "" {
+				w.WriteHeader(sm.importCode)
+				if sm.importBody != "" {
+					_, _ = w.Write([]byte(sm.importBody))
+					return
+				}
 				_, _ = w.Write([]byte(`{"schema_version_ok":true,"master_key_ok":true,"applied":false,"diff":` + sm.dryDiff + `}`))
 				return
 			}
@@ -180,6 +188,54 @@ func TestAutoSyncBackupFailureSkipsMember(t *testing.T) {
 	cfg, _ := store.GetAutoSync(t.Context())
 	if cfg.LastHash != "hash-A" {
 		t.Errorf("applied hash = %q, want it left at hash-A so the next tick retries", cfg.LastHash)
+	}
+}
+
+// TestAutoSyncUnreachableMemberHoldsHash: a member whose import probe fails (its
+// server is down) is left untouched and the applied hash is not recorded, so the
+// next tick retries rather than declaring the fleet converged.
+func TestAutoSyncUnreachableMemberHoldsHash(t *testing.T) {
+	srv, store := newTestServer(t)
+	primary := newStubAutoMember(t, "ptoken")
+	primary.versionHash = "hash-B"
+
+	pm, _ := store.CreateMember(t.Context(), "primary", primary.srv.URL, "ptoken")
+	// A dead URL: the dry-run import is a transport failure, not an HTTP answer.
+	store.CreateMember(t.Context(), "down", "http://127.0.0.1:9", "dtoken") //nolint:errcheck // presence is the point
+	enableAutoSync(t, store, pm.ID, "hash-A")
+
+	srv.autoSyncOnce(t.Context(), "hash-B")
+
+	cfg, _ := store.GetAutoSync(t.Context())
+	if cfg.LastHash != "hash-A" {
+		t.Errorf("applied hash = %q, want it held at hash-A so the next tick retries", cfg.LastHash)
+	}
+}
+
+// TestAutoSyncSchemaBlockedMemberSkipped: a member that reports a schema or
+// MASTER_KEY mismatch is held off (not backed up, not overwritten) and the fleet
+// is not marked converged.
+func TestAutoSyncSchemaBlockedMemberSkipped(t *testing.T) {
+	srv, store := newTestServer(t)
+	primary := newStubAutoMember(t, "ptoken")
+	primary.versionHash = "hash-B"
+	blocked := newStubAutoMember(t, "btoken")
+	blocked.dryDiff = driftDiff
+	blocked.importCode = http.StatusUnprocessableEntity // 422: schema mismatch
+	blocked.importBody = `{"schema_version_ok":false,"master_key_ok":false}`
+
+	pm, _ := store.CreateMember(t.Context(), "primary", primary.srv.URL, "ptoken")
+	store.CreateMember(t.Context(), "blocked", blocked.srv.URL, "btoken") //nolint:errcheck // presence is the point
+	enableAutoSync(t, store, pm.ID, "hash-A")
+
+	srv.autoSyncOnce(t.Context(), "hash-B")
+
+	if blocked.didBackup() || blocked.didRealSync() {
+		t.Error("a schema-blocked member must not be backed up or overwritten")
+	}
+	cfg, _ := store.GetAutoSync(t.Context())
+	if cfg.LastHash != "hash-A" {
+		t.Errorf("applied hash = %q, want it held at hash-A (member not syncable)", cfg.LastHash)
 	}
 }
 

--- a/internal/frontdesk/autosync_test.go
+++ b/internal/frontdesk/autosync_test.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/hugalafutro/model-hotel/internal/auth"
 )
 
 // stubAutoMember plays a member for the auto-sync loop: it answers the config
@@ -534,6 +536,41 @@ func TestGetAutoSyncHandler(t *testing.T) {
 	}
 	if !got.Enabled || got.PrimaryID != pm.ID {
 		t.Errorf("autosync = %+v, want enabled at %s", got, pm.ID)
+	}
+}
+
+// TestAutoSyncTokenLoadFailureHoldsHash (Greptile P1): a member whose stored token
+// ciphertext can't be decrypted (e.g. a MASTER_KEY mismatch) has HasToken true but
+// fails MemberToken. It must not be recorded as converged, since nothing re-arms it
+// later; the applied hash is held so the loop keeps retrying.
+func TestAutoSyncTokenLoadFailureHoldsHash(t *testing.T) {
+	srv, store := newTestServer(t)
+	primary := newStubAutoMember(t, "ptoken")
+	primary.versionHash = "hash-B"
+
+	pm, _ := store.CreateMember(t.Context(), "primary", primary.srv.URL, "ptoken")
+	rm, _ := store.CreateMember(t.Context(), "replica", "http://127.0.0.1:9", "rtoken")
+	// Replace the replica's token with ciphertext encrypted under a DIFFERENT master
+	// key: the fields are correctly sized (so decrypt fails authentication rather than
+	// panicking) and HasToken stays true, reproducing a MASTER_KEY-mismatch token that
+	// MemberToken cannot decrypt.
+	kp, err := auth.Encrypt("rtoken", testMasterKey+"-mismatch")
+	if err != nil {
+		t.Fatalf("encrypt under mismatched key: %v", err)
+	}
+	if _, err := store.db.ExecContext(t.Context(),
+		`UPDATE members SET token_cipher = ?, token_nonce = ?, token_salt = ? WHERE id = ?`,
+		kp.Ciphertext, kp.Nonce, kp.Salt, rm.ID,
+	); err != nil {
+		t.Fatalf("write mismatched token: %v", err)
+	}
+	enableAutoSync(t, store, pm.ID, "hash-A")
+
+	srv.autoSyncOnce(t.Context(), "hash-B") // settled: reach the apply stage
+
+	cfg, _ := store.GetAutoSync(t.Context())
+	if cfg.LastHash != "hash-A" {
+		t.Errorf("applied hash = %q, want held at hash-A (replica token could not be loaded)", cfg.LastHash)
 	}
 }
 

--- a/internal/frontdesk/autosync_test.go
+++ b/internal/frontdesk/autosync_test.go
@@ -1,11 +1,13 @@
 package frontdesk
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"sync"
 	"testing"
+	"time"
 )
 
 // stubAutoMember plays a member for the auto-sync loop: it answers the config
@@ -17,7 +19,10 @@ type stubAutoMember struct {
 	srv         *httptest.Server
 	token       string
 	versionHash string
+	versionCode int    // status for the version GET (default 200)
+	versionRaw  string // raw version body; overrides the {"version":...} JSON when set
 	exportBody  string
+	exportCode  int    // status for the export GET (default 200)
 	dryDiff     string // diff object returned on a dry-run import
 	importCode  int    // status for the dry-run import (default 200)
 	importBody  string // full dry-run import body; overrides dryDiff when set
@@ -33,6 +38,8 @@ func newStubAutoMember(t *testing.T, token string) *stubAutoMember {
 		versionHash: "hash-A",
 		exportBody:  fleetExportWithKey,
 		dryDiff:     `{"providers":{},"virtual_keys":{},"settings":{}}`, // converged
+		versionCode: http.StatusOK,
+		exportCode:  http.StatusOK,
 		importCode:  http.StatusOK,
 		backupCode:  http.StatusCreated,
 	}
@@ -45,8 +52,14 @@ func newStubAutoMember(t *testing.T, token string) *stubAutoMember {
 		defer sm.mu.Unlock()
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/api/config/version":
+			w.WriteHeader(sm.versionCode)
+			if sm.versionRaw != "" {
+				_, _ = w.Write([]byte(sm.versionRaw))
+				return
+			}
 			_ = json.NewEncoder(w).Encode(map[string]string{"version": sm.versionHash})
 		case r.Method == http.MethodGet && r.URL.Path == "/api/config/export":
+			w.WriteHeader(sm.exportCode)
 			_, _ = w.Write([]byte(sm.exportBody))
 		case r.Method == http.MethodPost && r.URL.Path == "/api/config/import":
 			if r.URL.Query().Get("dryRun") != "" {
@@ -60,6 +73,9 @@ func newStubAutoMember(t *testing.T, token string) *stubAutoMember {
 			}
 			sm.gotRealSync = true
 			_, _ = w.Write([]byte(`{"schema_version_ok":true,"master_key_ok":true,"applied":true,"diff":` + sm.dryDiff + `}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/settings":
+			// The token probe (createMember/patchMember) hits this; 200 = accepted.
+			_, _ = w.Write([]byte(`{}`))
 		case r.Method == http.MethodPost && r.URL.Path == "/api/backups":
 			sm.gotBackup = true
 			w.WriteHeader(sm.backupCode)
@@ -152,6 +168,9 @@ func TestAutoSyncSkipsConvergedMember(t *testing.T) {
 
 	pm, _ := store.CreateMember(t.Context(), "primary", primary.srv.URL, "ptoken")
 	store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken") //nolint:errcheck // presence is the point
+	// A tokenless member is present too: it must be skipped without blocking the
+	// fleet from being recorded as converged.
+	store.CreateMember(t.Context(), "tokenless", "http://127.0.0.1:9", "") //nolint:errcheck // presence is the point
 	enableAutoSync(t, store, pm.ID, "hash-A")
 
 	srv.autoSyncOnce(t.Context(), "hash-B") // already settled: act this tick
@@ -305,5 +324,232 @@ func TestAutoSyncDisabledIsNoop(t *testing.T) {
 	}
 	if replica.didBackup() || replica.didRealSync() {
 		t.Error("disabled auto-sync touched a member")
+	}
+}
+
+// TestAutoSyncNoChangeWhenHashUnchanged: when the primary's hash already equals
+// the last applied hash, the loop short-circuits without touching any member.
+func TestAutoSyncNoChangeWhenHashUnchanged(t *testing.T) {
+	srv, store := newTestServer(t)
+	primary := newStubAutoMember(t, "ptoken")
+	primary.versionHash = "hash-A"
+	replica := newStubAutoMember(t, "rtoken")
+	replica.dryDiff = driftDiff
+
+	pm, _ := store.CreateMember(t.Context(), "primary", primary.srv.URL, "ptoken")
+	store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken") //nolint:errcheck // presence is the point
+	enableAutoSync(t, store, pm.ID, "hash-A")                             // last applied == current
+
+	if got := srv.autoSyncOnce(t.Context(), "hash-A"); got != "hash-A" {
+		t.Errorf("autoSyncOnce = %q, want hash-A carried forward", got)
+	}
+	if replica.didBackup() || replica.didRealSync() {
+		t.Error("an unchanged primary triggered a sync")
+	}
+}
+
+// TestAutoSyncPrimaryTokenlessIsNoop: a designated primary with no stored token
+// can't be read, so the loop does nothing rather than erroring.
+func TestAutoSyncPrimaryTokenlessIsNoop(t *testing.T) {
+	srv, store := newTestServer(t)
+	// Point auto-sync at a tokenless member directly (the handler would reject this,
+	// but the loop must still be defensive if the token is later cleared).
+	pm, _ := store.CreateMember(t.Context(), "primary", "http://127.0.0.1:9", "")
+	if err := store.SetAutoSync(t.Context(), true, pm.ID); err != nil {
+		t.Fatalf("SetAutoSync: %v", err)
+	}
+	if got := srv.autoSyncOnce(t.Context(), ""); got != "" {
+		t.Errorf("tokenless primary returned %q, want empty", got)
+	}
+}
+
+// TestAutoSyncPrimaryVersionUnreadable: if the primary's version endpoint errors,
+// the loop holds the applied hash and propagates nothing.
+func TestAutoSyncPrimaryVersionUnreadable(t *testing.T) {
+	srv, store := newTestServer(t)
+	primary := newStubAutoMember(t, "ptoken")
+	primary.versionCode = http.StatusInternalServerError
+
+	pm, _ := store.CreateMember(t.Context(), "primary", primary.srv.URL, "ptoken")
+	enableAutoSync(t, store, pm.ID, "hash-A")
+
+	if got := srv.autoSyncOnce(t.Context(), ""); got != "" {
+		t.Errorf("unreadable version returned %q, want empty", got)
+	}
+	cfg, _ := store.GetAutoSync(t.Context())
+	if cfg.LastHash != "hash-A" {
+		t.Errorf("applied hash = %q, want it held at hash-A", cfg.LastHash)
+	}
+}
+
+// TestAutoSyncPrimaryExportUnreadable: a primary whose export fails at the apply
+// stage leaves the fleet untouched and the hash unrecorded.
+func TestAutoSyncPrimaryExportUnreadable(t *testing.T) {
+	srv, store := newTestServer(t)
+	primary := newStubAutoMember(t, "ptoken")
+	primary.versionHash = "hash-B"
+	primary.exportCode = http.StatusInternalServerError
+	replica := newStubAutoMember(t, "rtoken")
+	replica.dryDiff = driftDiff
+
+	pm, _ := store.CreateMember(t.Context(), "primary", primary.srv.URL, "ptoken")
+	store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken") //nolint:errcheck // presence is the point
+	enableAutoSync(t, store, pm.ID, "hash-A")
+
+	srv.autoSyncOnce(t.Context(), "hash-B") // settled: reach the apply stage
+
+	if replica.didBackup() || replica.didRealSync() {
+		t.Error("a member was touched despite the primary export failing")
+	}
+	cfg, _ := store.GetAutoSync(t.Context())
+	if cfg.LastHash != "hash-A" {
+		t.Errorf("applied hash = %q, want it held at hash-A", cfg.LastHash)
+	}
+}
+
+// TestFetchMemberConfigVersionRejectsBadResponses: the drift probe rejects a
+// non-200, malformed JSON, and an empty version string.
+func TestFetchMemberConfigVersionRejectsBadResponses(t *testing.T) {
+	srv, store := newTestServer(t)
+	stub := newStubAutoMember(t, "tok")
+	created, _ := store.CreateMember(t.Context(), "m", stub.srv.URL, "tok")
+	m, err := store.GetMember(t.Context(), created.ID)
+	if err != nil {
+		t.Fatalf("GetMember: %v", err)
+	}
+
+	for name, mutate := range map[string]func(){
+		"non-200":    func() { stub.versionCode = http.StatusInternalServerError },
+		"bad json":   func() { stub.versionCode = http.StatusOK; stub.versionRaw = "not json" },
+		"empty hash": func() { stub.versionCode = http.StatusOK; stub.versionRaw = `{"version":""}` },
+	} {
+		t.Run(name, func(t *testing.T) {
+			stub.mu.Lock()
+			stub.versionCode = http.StatusOK
+			stub.versionRaw = ""
+			stub.mu.Unlock()
+			mutate()
+			if _, err := srv.fetchMemberConfigVersion(t.Context(), m, "tok"); err == nil {
+				t.Errorf("%s: expected an error, got nil", name)
+			}
+		})
+	}
+}
+
+// TestAutoSyncRearmsOnTokenAdd is the Greptile fix: a tokenless member is skipped
+// while the fleet is recorded converged, but the moment it gains an admin token the
+// applied hash is cleared so the next tick brings it in line, without waiting for
+// the primary's config to change again.
+func TestAutoSyncRearmsOnTokenAdd(t *testing.T) {
+	srv, store := newTestServer(t)
+	primary := newStubAutoMember(t, "ptoken")
+	primary.versionHash = "hash-B"
+	replica := newStubAutoMember(t, "rtoken")
+	replica.dryDiff = driftDiff
+
+	pm, _ := store.CreateMember(t.Context(), "primary", primary.srv.URL, "ptoken")
+	// Replica is added without a token, so it is not yet syncable.
+	rm, _ := store.CreateMember(t.Context(), "replica", replica.srv.URL, "")
+	if err := store.SetAutoSync(t.Context(), true, pm.ID); err != nil {
+		t.Fatalf("SetAutoSync: %v", err)
+	}
+	// Simulate the fleet having converged at hash-B while the replica was tokenless.
+	if err := store.SetAutoSyncLastHash(t.Context(), "hash-B"); err != nil {
+		t.Fatalf("SetAutoSyncLastHash: %v", err)
+	}
+
+	// Give the replica an admin token via the API. This must re-arm auto-sync.
+	rec := do(t, srv, http.MethodPatch, "/api/members/"+rm.ID, `{"token":"rtoken"}`, true)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("patch token = %d (%s)", rec.Code, rec.Body.String())
+	}
+	cfg, _ := store.GetAutoSync(t.Context())
+	if cfg.LastHash != "" {
+		t.Fatalf("applied hash = %q, want cleared so the new token triggers a sync", cfg.LastHash)
+	}
+
+	// The next settled pass now converges the freshly-tokened replica.
+	prev := srv.autoSyncOnce(t.Context(), "")
+	srv.autoSyncOnce(t.Context(), prev)
+	if !replica.didRealSync() {
+		t.Error("newly-tokened replica was not synced after re-arm")
+	}
+}
+
+// TestAutoSyncRearmsOnMemberAdd: adding a new member with a token re-arms the loop
+// so the newcomer is converged without waiting for the primary to change.
+func TestAutoSyncRearmsOnMemberAdd(t *testing.T) {
+	srv, store := newTestServer(t)
+	primary := newStubAutoMember(t, "ptoken")
+	newcomer := newStubAutoMember(t, "ntoken")
+
+	pm, _ := store.CreateMember(t.Context(), "primary", primary.srv.URL, "ptoken")
+	if err := store.SetAutoSync(t.Context(), true, pm.ID); err != nil {
+		t.Fatalf("SetAutoSync: %v", err)
+	}
+	if err := store.SetAutoSyncLastHash(t.Context(), "hash-A"); err != nil {
+		t.Fatalf("SetAutoSyncLastHash: %v", err)
+	}
+
+	body := `{"name":"newcomer","url":"` + newcomer.srv.URL + `","token":"ntoken"}`
+	rec := do(t, srv, http.MethodPost, "/api/members", body, true)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create member = %d (%s)", rec.Code, rec.Body.String())
+	}
+	cfg, _ := store.GetAutoSync(t.Context())
+	if cfg.LastHash != "" {
+		t.Errorf("applied hash = %q, want cleared after adding a tokened member", cfg.LastHash)
+	}
+}
+
+// TestRunAutoSyncStopsOnContextCancel: the loop returns promptly when its context
+// is cancelled.
+func TestRunAutoSyncStopsOnContextCancel(t *testing.T) {
+	srv, _ := newTestServer(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	done := make(chan struct{})
+	go func() { srv.RunAutoSync(ctx); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("RunAutoSync did not return after context cancel")
+	}
+}
+
+// TestGetAutoSyncHandler: the GET endpoint returns the current setup.
+func TestGetAutoSyncHandler(t *testing.T) {
+	srv, store := newTestServer(t)
+	pm, _ := store.CreateMember(t.Context(), "primary", "http://127.0.0.1:9", "tok")
+	if err := store.SetAutoSync(t.Context(), true, pm.ID); err != nil {
+		t.Fatalf("SetAutoSync: %v", err)
+	}
+	rec := do(t, srv, http.MethodGet, "/api/fleet/autosync", "", true)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("get autosync = %d", rec.Code)
+	}
+	var got AutoSyncConfig
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !got.Enabled || got.PrimaryID != pm.ID {
+		t.Errorf("autosync = %+v, want enabled at %s", got, pm.ID)
+	}
+}
+
+// TestPutAutoSyncDisable: turning auto-sync off is accepted and persisted.
+func TestPutAutoSyncDisable(t *testing.T) {
+	srv, store := newTestServer(t)
+	pm, _ := store.CreateMember(t.Context(), "primary", "http://127.0.0.1:9", "tok")
+	if err := store.SetAutoSync(t.Context(), true, pm.ID); err != nil {
+		t.Fatalf("SetAutoSync: %v", err)
+	}
+	rec := do(t, srv, http.MethodPut, "/api/fleet/autosync", `{"enabled":false,"primary_id":""}`, true)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("disable = %d (%s)", rec.Code, rec.Body.String())
+	}
+	cfg, _ := store.GetAutoSync(t.Context())
+	if cfg.Enabled {
+		t.Error("auto-sync still enabled after disable")
 	}
 }

--- a/internal/frontdesk/autosync_test.go
+++ b/internal/frontdesk/autosync_test.go
@@ -537,6 +537,65 @@ func TestGetAutoSyncHandler(t *testing.T) {
 	}
 }
 
+// TestSetAutoSyncClearsAppliedHash: changing the auto-sync setup resets the
+// last-applied hash, so the next poll always runs a convergence pass.
+func TestSetAutoSyncClearsAppliedHash(t *testing.T) {
+	_, store := newTestServer(t)
+	pm, _ := store.CreateMember(t.Context(), "primary", "http://127.0.0.1:9", "tok")
+	if err := store.SetAutoSync(t.Context(), true, pm.ID); err != nil {
+		t.Fatalf("SetAutoSync: %v", err)
+	}
+	if err := store.SetAutoSyncLastHash(t.Context(), "hash-X"); err != nil {
+		t.Fatalf("SetAutoSyncLastHash: %v", err)
+	}
+	// Re-applying the setup (re-enable, or any primary change) must clear the hash.
+	if err := store.SetAutoSync(t.Context(), true, pm.ID); err != nil {
+		t.Fatalf("SetAutoSync: %v", err)
+	}
+	cfg, _ := store.GetAutoSync(t.Context())
+	if cfg.LastHash != "" {
+		t.Errorf("LastHash = %q after re-applying setup, want cleared", cfg.LastHash)
+	}
+}
+
+// TestAutoSyncReEnableConvergesDriftedReplica is the activation-gap fix (Greptile
+// P1): a replica that drifted while sync was off is brought back in line when the
+// operator re-enables auto-sync, even though the primary's config never changed.
+func TestAutoSyncReEnableConvergesDriftedReplica(t *testing.T) {
+	srv, store := newTestServer(t)
+	primary := newStubAutoMember(t, "ptoken")
+	primary.versionHash = "hash-B"
+	replica := newStubAutoMember(t, "rtoken")
+	replica.dryDiff = driftDiff
+
+	pm, _ := store.CreateMember(t.Context(), "primary", primary.srv.URL, "ptoken")
+	store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken") //nolint:errcheck // presence is the point
+	// Simulate a prior convergence at hash-B that is now stale (replica drifted).
+	if err := store.SetAutoSync(t.Context(), true, pm.ID); err != nil {
+		t.Fatalf("SetAutoSync: %v", err)
+	}
+	if err := store.SetAutoSyncLastHash(t.Context(), "hash-B"); err != nil {
+		t.Fatalf("SetAutoSyncLastHash: %v", err)
+	}
+
+	// Operator re-applies the setup through the API; this must re-arm the loop.
+	rec := do(t, srv, http.MethodPut, "/api/fleet/autosync", `{"enabled":true,"primary_id":"`+pm.ID+`"}`, true)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("put autosync = %d (%s)", rec.Code, rec.Body.String())
+	}
+	cfg, _ := store.GetAutoSync(t.Context())
+	if cfg.LastHash != "" {
+		t.Fatalf("LastHash = %q after re-enable, want cleared", cfg.LastHash)
+	}
+
+	// A settled pass now converges the drifted replica without the primary changing.
+	prev := srv.autoSyncOnce(t.Context(), "")
+	srv.autoSyncOnce(t.Context(), prev)
+	if !replica.didRealSync() {
+		t.Error("re-enabling auto-sync did not converge a replica that drifted while off")
+	}
+}
+
 // TestStoreAutoSyncDBErrors: the auto-sync store methods surface DB failures
 // rather than swallowing them. Closing the handle forces every query to fail.
 func TestStoreAutoSyncDBErrors(t *testing.T) {

--- a/internal/frontdesk/autosync_test.go
+++ b/internal/frontdesk/autosync_test.go
@@ -1,0 +1,253 @@
+package frontdesk
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+)
+
+// stubAutoMember plays a member for the auto-sync loop: it answers the config
+// version GET (the drift signal), the export GET, the dry-run and real config
+// imports, and the pre-sync backup POST. Each is independently configurable so a
+// single stub can be a primary or a replica in any disposition.
+type stubAutoMember struct {
+	mu          sync.Mutex
+	srv         *httptest.Server
+	token       string
+	versionHash string
+	exportBody  string
+	dryDiff     string // diff object returned on a dry-run import
+	backupCode  int
+	gotBackup   bool
+	gotRealSync bool
+}
+
+func newStubAutoMember(t *testing.T, token string) *stubAutoMember {
+	t.Helper()
+	sm := &stubAutoMember{
+		token:       token,
+		versionHash: "hash-A",
+		exportBody:  fleetExportWithKey,
+		dryDiff:     `{"providers":{},"virtual_keys":{},"settings":{}}`, // converged
+		backupCode:  http.StatusCreated,
+	}
+	sm.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer "+sm.token {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		sm.mu.Lock()
+		defer sm.mu.Unlock()
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/config/version":
+			_ = json.NewEncoder(w).Encode(map[string]string{"version": sm.versionHash})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/config/export":
+			_, _ = w.Write([]byte(sm.exportBody))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/config/import":
+			if r.URL.Query().Get("dryRun") != "" {
+				_, _ = w.Write([]byte(`{"schema_version_ok":true,"master_key_ok":true,"applied":false,"diff":` + sm.dryDiff + `}`))
+				return
+			}
+			sm.gotRealSync = true
+			_, _ = w.Write([]byte(`{"schema_version_ok":true,"master_key_ok":true,"applied":true,"diff":` + sm.dryDiff + `}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/backups":
+			sm.gotBackup = true
+			w.WriteHeader(sm.backupCode)
+			_, _ = w.Write([]byte(`{"filename":"backup_x_frontdesk.dump"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(sm.srv.Close)
+	return sm
+}
+
+func (sm *stubAutoMember) didBackup() bool { sm.mu.Lock(); defer sm.mu.Unlock(); return sm.gotBackup }
+func (sm *stubAutoMember) didRealSync() bool {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	return sm.gotRealSync
+}
+
+const driftDiff = `{"providers":{"added":["anthropic"]},"virtual_keys":{},"settings":{}}`
+
+// enableAutoSync points auto-sync at primaryID with a stale last-applied hash, so
+// the loop sees the primary as changed.
+func enableAutoSync(t *testing.T, store *Store, primaryID, lastHash string) {
+	t.Helper()
+	if err := store.SetAutoSync(t.Context(), true, primaryID); err != nil {
+		t.Fatalf("SetAutoSync: %v", err)
+	}
+	if err := store.SetAutoSyncLastHash(t.Context(), lastHash); err != nil {
+		t.Fatalf("SetAutoSyncLastHash: %v", err)
+	}
+}
+
+// TestAutoSyncCoalescesThenApplies: a drifted primary is not synced on the first
+// observation (the config might still be mid-edit); only once the hash repeats on
+// the next tick does Front Desk propagate it, backing each changed member up
+// first and stamping its last-sync marker.
+func TestAutoSyncCoalescesThenApplies(t *testing.T) {
+	srv, store := newTestServer(t)
+	primary := newStubAutoMember(t, "ptoken")
+	primary.versionHash = "hash-B" // changed vs the recorded last hash
+	replica := newStubAutoMember(t, "rtoken")
+	replica.dryDiff = driftDiff // this member needs the new config
+
+	pm, _ := store.CreateMember(t.Context(), "primary", primary.srv.URL, "ptoken")
+	rm, _ := store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken")
+	enableAutoSync(t, store, pm.ID, "hash-A")
+
+	// First tick: observe the change, do not act yet (coalescing window).
+	prev := srv.autoSyncOnce(t.Context(), "")
+	if prev != "hash-B" {
+		t.Fatalf("first tick prev = %q, want hash-B", prev)
+	}
+	if replica.didRealSync() || replica.didBackup() {
+		t.Fatal("replica synced on the first observation; should wait for the hash to settle")
+	}
+
+	// Second tick: the hash settled, so propagate.
+	srv.autoSyncOnce(t.Context(), prev)
+	if !replica.didBackup() {
+		t.Error("replica was not backed up before the auto-sync")
+	}
+	if !replica.didRealSync() {
+		t.Error("replica did not receive the config")
+	}
+	got, err := store.GetMember(t.Context(), rm.ID)
+	if err != nil {
+		t.Fatalf("GetMember: %v", err)
+	}
+	if got.LastConfigSyncAt == nil {
+		t.Error("replica last-sync timestamp not stamped")
+	}
+	if got.LastConfigSyncReason != autoSyncReason {
+		t.Errorf("last-sync reason = %q, want %q", got.LastConfigSyncReason, autoSyncReason)
+	}
+	cfg, _ := store.GetAutoSync(t.Context())
+	if cfg.LastHash != "hash-B" {
+		t.Errorf("applied hash = %q, want hash-B recorded after convergence", cfg.LastHash)
+	}
+}
+
+// TestAutoSyncSkipsConvergedMember: a member whose dry-run diff is empty is left
+// untouched (no backup, no import), but the fleet still counts as converged so the
+// new hash is recorded and the loop quiesces.
+func TestAutoSyncSkipsConvergedMember(t *testing.T) {
+	srv, store := newTestServer(t)
+	primary := newStubAutoMember(t, "ptoken")
+	primary.versionHash = "hash-B"
+	replica := newStubAutoMember(t, "rtoken") // default dryDiff is empty (converged)
+
+	pm, _ := store.CreateMember(t.Context(), "primary", primary.srv.URL, "ptoken")
+	store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken") //nolint:errcheck // presence is the point
+	enableAutoSync(t, store, pm.ID, "hash-A")
+
+	srv.autoSyncOnce(t.Context(), "hash-B") // already settled: act this tick
+
+	if replica.didBackup() || replica.didRealSync() {
+		t.Error("a converged member must not be backed up or re-imported")
+	}
+	cfg, _ := store.GetAutoSync(t.Context())
+	if cfg.LastHash != "hash-B" {
+		t.Errorf("applied hash = %q, want hash-B (fleet converged)", cfg.LastHash)
+	}
+}
+
+// TestAutoSyncBackupFailureSkipsMember: if a member's pre-sync backup fails, its
+// config is NOT overwritten, the fleet is not marked converged, and the applied
+// hash is left stale so the next tick retries.
+func TestAutoSyncBackupFailureSkipsMember(t *testing.T) {
+	srv, store := newTestServer(t)
+	primary := newStubAutoMember(t, "ptoken")
+	primary.versionHash = "hash-B"
+	replica := newStubAutoMember(t, "rtoken")
+	replica.dryDiff = driftDiff
+	replica.backupCode = http.StatusInternalServerError // backup fails
+
+	pm, _ := store.CreateMember(t.Context(), "primary", primary.srv.URL, "ptoken")
+	store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken") //nolint:errcheck // presence is the point
+	enableAutoSync(t, store, pm.ID, "hash-A")
+
+	srv.autoSyncOnce(t.Context(), "hash-B")
+
+	if replica.didRealSync() {
+		t.Error("member was overwritten despite a failed pre-sync backup")
+	}
+	cfg, _ := store.GetAutoSync(t.Context())
+	if cfg.LastHash != "hash-A" {
+		t.Errorf("applied hash = %q, want it left at hash-A so the next tick retries", cfg.LastHash)
+	}
+}
+
+// TestPutAutoSyncValidation: enabling needs a primary, and the primary must be a
+// known member with a stored admin token (the loop authenticates with it).
+func TestPutAutoSyncValidation(t *testing.T) {
+	srv, store := newTestServer(t)
+	withTok, _ := store.CreateMember(t.Context(), "with-token", "http://127.0.0.1:9", "tok")
+	noTok, _ := store.CreateMember(t.Context(), "no-token", "http://127.0.0.1:10", "")
+
+	// Enable without a primary: rejected.
+	if rec := do(t, srv, http.MethodPut, "/api/fleet/autosync", `{"enabled":true,"primary_id":""}`, true); rec.Code != http.StatusBadRequest {
+		t.Errorf("enable without primary = %d, want 400", rec.Code)
+	}
+	// Primary with no stored token: rejected.
+	if rec := do(t, srv, http.MethodPut, "/api/fleet/autosync", `{"enabled":true,"primary_id":"`+noTok.ID+`"}`, true); rec.Code != http.StatusBadRequest {
+		t.Errorf("tokenless primary = %d, want 400", rec.Code)
+	}
+	// Unknown primary: rejected.
+	if rec := do(t, srv, http.MethodPut, "/api/fleet/autosync", `{"enabled":true,"primary_id":"00000000-0000-0000-0000-000000000000"}`, true); rec.Code != http.StatusBadRequest {
+		t.Errorf("unknown primary = %d, want 400", rec.Code)
+	}
+	// Valid: a tokened primary.
+	rec := do(t, srv, http.MethodPut, "/api/fleet/autosync", `{"enabled":true,"primary_id":"`+withTok.ID+`"}`, true)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("valid enable = %d (%s)", rec.Code, rec.Body.String())
+	}
+	cfg, _ := store.GetAutoSync(t.Context())
+	if !cfg.Enabled || cfg.PrimaryID != withTok.ID {
+		t.Errorf("auto-sync = %+v, want enabled at %s", cfg, withTok.ID)
+	}
+}
+
+// TestDeleteMemberClearsPrimary: removing the designated primary clears the
+// pointer so the auto-sync loop stops treating a gone member as the source.
+func TestDeleteMemberClearsPrimary(t *testing.T) {
+	_, store := newTestServer(t)
+	pm, _ := store.CreateMember(t.Context(), "primary", "http://127.0.0.1:9", "tok")
+	if err := store.SetAutoSync(t.Context(), true, pm.ID); err != nil {
+		t.Fatalf("SetAutoSync: %v", err)
+	}
+	if err := store.DeleteMember(t.Context(), pm.ID); err != nil {
+		t.Fatalf("DeleteMember: %v", err)
+	}
+	cfg, _ := store.GetAutoSync(t.Context())
+	if cfg.PrimaryID != "" {
+		t.Errorf("primary_id = %q after deleting the primary, want cleared", cfg.PrimaryID)
+	}
+}
+
+// TestAutoSyncDisabledIsNoop: with auto-sync off, the loop touches nothing.
+func TestAutoSyncDisabledIsNoop(t *testing.T) {
+	srv, store := newTestServer(t)
+	primary := newStubAutoMember(t, "ptoken")
+	replica := newStubAutoMember(t, "rtoken")
+	replica.dryDiff = driftDiff
+
+	pm, _ := store.CreateMember(t.Context(), "primary", primary.srv.URL, "ptoken")
+	store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken") //nolint:errcheck // presence is the point
+	// Designate a primary but leave auto-sync disabled.
+	if err := store.SetAutoSync(t.Context(), false, pm.ID); err != nil {
+		t.Fatalf("SetAutoSync: %v", err)
+	}
+
+	if got := srv.autoSyncOnce(t.Context(), "hash-B"); got != "" {
+		t.Errorf("disabled autoSyncOnce returned %q, want empty", got)
+	}
+	if replica.didBackup() || replica.didRealSync() {
+		t.Error("disabled auto-sync touched a member")
+	}
+}

--- a/internal/frontdesk/autosync_test.go
+++ b/internal/frontdesk/autosync_test.go
@@ -537,6 +537,55 @@ func TestGetAutoSyncHandler(t *testing.T) {
 	}
 }
 
+// TestStoreAutoSyncDBErrors: the auto-sync store methods surface DB failures
+// rather than swallowing them. Closing the handle forces every query to fail.
+func TestStoreAutoSyncDBErrors(t *testing.T) {
+	_, store := newTestServer(t)
+	if err := store.db.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+	ctx := context.Background()
+	if _, err := store.GetAutoSync(ctx); err == nil {
+		t.Error("GetAutoSync: want error on a closed DB")
+	}
+	if err := store.SetAutoSync(ctx, true, "x"); err == nil {
+		t.Error("SetAutoSync: want error on a closed DB")
+	}
+	if err := store.SetAutoSyncLastHash(ctx, "h"); err == nil {
+		t.Error("SetAutoSyncLastHash: want error on a closed DB")
+	}
+	if err := store.SetMemberLastSync(ctx, "id", time.Now(), "r"); err == nil {
+		t.Error("SetMemberLastSync: want error on a closed DB")
+	}
+}
+
+// TestGetAutoSyncHandlerDBError: a store failure surfaces as a 500, not a silent
+// empty body. The admin token authenticates without a DB read, so the error comes
+// from the handler's own GetAutoSync call.
+func TestGetAutoSyncHandlerDBError(t *testing.T) {
+	srv, store := newTestServer(t)
+	if err := store.db.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+	rec := do(t, srv, http.MethodGet, "/api/fleet/autosync", "", true)
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("get autosync on closed DB = %d, want 500", rec.Code)
+	}
+}
+
+// TestPutAutoSyncDBError: a store write failure surfaces as a 500. primary_id is
+// empty so the handler skips validation and fails on the persist itself.
+func TestPutAutoSyncDBError(t *testing.T) {
+	srv, store := newTestServer(t)
+	if err := store.db.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+	rec := do(t, srv, http.MethodPut, "/api/fleet/autosync", `{"enabled":false,"primary_id":""}`, true)
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("put autosync on closed DB = %d, want 500", rec.Code)
+	}
+}
+
 // TestPutAutoSyncDisable: turning auto-sync off is accepted and persisted.
 func TestPutAutoSyncDisable(t *testing.T) {
 	srv, store := newTestServer(t)

--- a/internal/frontdesk/configsync.go
+++ b/internal/frontdesk/configsync.go
@@ -24,6 +24,10 @@ import (
 const (
 	memberConfigExportPath = "/api/config/export"
 	memberConfigImportPath = "/api/config/import"
+
+	// wizardSyncReason is stamped on a member's last-config-sync marker when the
+	// operator drives the sync through the wizard (vs the automatic loop).
+	wizardSyncReason = "manual sync from the wizard"
 )
 
 // syncResultItem is one member's outcome from a fleet sync action.
@@ -102,7 +106,7 @@ func (s *Server) configSync(w http.ResponseWriter, r *http.Request) {
 		if err != nil || !ok {
 			continue
 		}
-		results = append(results, s.applyMemberConfig(r.Context(), m, token, export))
+		results = append(results, s.applyMemberConfig(r.Context(), m, token, export, wizardSyncReason))
 	}
 	s.recordFleetSyncRun(r.Context(), primary, results)
 	writeJSON(w, http.StatusOK, map[string]any{"primary_id": primary.ID, "results": results})
@@ -129,8 +133,10 @@ func (s *Server) recordFleetSyncRun(ctx context.Context, primary *Member, result
 }
 
 // applyMemberConfig imports the primary's config onto one member and records an
-// audit event for the outcome.
-func (s *Server) applyMemberConfig(ctx context.Context, m *Member, token string, export []byte) syncResultItem {
+// audit event for the outcome. On success it stamps the member's last-config-sync
+// marker with reason (shown in the Members table), so both the wizard and the
+// auto-sync loop record why and when a member last converged.
+func (s *Server) applyMemberConfig(ctx context.Context, m *Member, token string, export []byte, reason string) syncResultItem {
 	res := syncResultItem{MemberID: m.ID, Name: m.Name}
 	out, status, err := s.pushMemberImport(ctx, m, token, export, false)
 	switch {
@@ -153,6 +159,9 @@ func (s *Server) applyMemberConfig(ctx context.Context, m *Member, token string,
 	}
 
 	if res.OK {
+		if err := s.store.SetMemberLastSync(ctx, m.ID, time.Now().UTC(), reason); err != nil {
+			debuglog.Warn("frontdesk: stamp member last-sync", "member", m.Name, "error", err)
+		}
 		s.emit(ctx, Event{
 			Type: "config.synced", Severity: "info", Source: "frontdesk",
 			Message: fmt.Sprintf("Config synced to %s", m.Name), MemberID: m.ID,

--- a/internal/frontdesk/configsync.go
+++ b/internal/frontdesk/configsync.go
@@ -106,7 +106,7 @@ func (s *Server) configSync(w http.ResponseWriter, r *http.Request) {
 		if err != nil || !ok {
 			continue
 		}
-		results = append(results, s.applyMemberConfig(r.Context(), m, token, export, wizardSyncReason))
+		results = append(results, s.applyMemberConfig(r.Context(), m, token, export, wizardSyncReason, true))
 	}
 	s.recordFleetSyncRun(r.Context(), primary, results)
 	writeJSON(w, http.StatusOK, map[string]any{"primary_id": primary.ID, "results": results})
@@ -136,7 +136,13 @@ func (s *Server) recordFleetSyncRun(ctx context.Context, primary *Member, result
 // audit event for the outcome. On success it stamps the member's last-config-sync
 // marker with reason (shown in the Members table), so both the wizard and the
 // auto-sync loop record why and when a member last converged.
-func (s *Server) applyMemberConfig(ctx context.Context, m *Member, token string, export []byte, reason string) syncResultItem {
+//
+// emitSuccessEvent controls only the per-member success event: the wizard wants
+// one event per member (it is a deliberate operator action), but the background
+// auto-syncer sets it false and emits a single roll-up instead, so a fleet sync
+// does not toast once per member. Failure events always fire regardless, since a
+// member left behind is worth surfacing in either path.
+func (s *Server) applyMemberConfig(ctx context.Context, m *Member, token string, export []byte, reason string, emitSuccessEvent bool) syncResultItem {
 	res := syncResultItem{MemberID: m.ID, Name: m.Name}
 	out, status, err := s.pushMemberImport(ctx, m, token, export, false)
 	switch {
@@ -162,10 +168,12 @@ func (s *Server) applyMemberConfig(ctx context.Context, m *Member, token string,
 		if err := s.store.SetMemberLastSync(ctx, m.ID, time.Now().UTC(), reason); err != nil {
 			debuglog.Warn("frontdesk: stamp member last-sync", "member", m.Name, "error", err)
 		}
-		s.emit(ctx, Event{
-			Type: "config.synced", Severity: "info", Source: "frontdesk",
-			Message: fmt.Sprintf("Config synced to %s", m.Name), MemberID: m.ID,
-		})
+		if emitSuccessEvent {
+			s.emit(ctx, Event{
+				Type: "config.synced", Severity: "info", Source: "frontdesk",
+				Message: fmt.Sprintf("Config synced to %s", m.Name), MemberID: m.ID,
+			})
+		}
 	} else {
 		debuglog.Warn("frontdesk: config sync failed", "member", m.Name, "error", res.Error)
 		s.emit(ctx, Event{

--- a/internal/frontdesk/memberapi.go
+++ b/internal/frontdesk/memberapi.go
@@ -70,6 +70,13 @@ const memberReadTimeout = 15 * time.Second
 // deadline; it is still capped so a hung member cannot stall the sync forever.
 const memberSyncTimeout = 120 * time.Second
 
+// memberBackupTimeout bounds the pre-sync backup relay the auto-syncer makes
+// before overwriting a member. It must exceed the member's own pg_dump budget
+// (10 minutes, internal/api.backup.go) or a large member would time out every
+// tick and leave an orphaned dump holding the member's backup lock. One extra
+// minute covers the round trip and dump teardown.
+const memberBackupTimeout = 11 * time.Minute
+
 // tokenProbe is the outcome of checking a member's admin token at add/edit time,
 // before the background poller would otherwise catch a mistake.
 type tokenProbe struct {

--- a/internal/frontdesk/migrations/005_auto_sync.sql
+++ b/internal/frontdesk/migrations/005_auto_sync.sql
@@ -1,0 +1,19 @@
+-- HA auto config sync: let Front Desk propagate the primary's config to the
+-- fleet automatically when it changes, instead of only through the manual
+-- wizard. The operator designates a primary and flips auto-sync on; the poller
+-- then watches the primary's config hash and re-syncs replicas on a change.
+--
+-- auto_sync_enabled    : master on/off for the automatic propagation loop.
+-- auto_sync_primary_id  : the designated source-of-truth member (empty = none).
+-- auto_sync_last_hash   : the primary config hash last applied to the fleet, so
+--                         the poller can tell "changed since last sync" cheaply.
+ALTER TABLE settings ADD COLUMN auto_sync_enabled    INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE settings ADD COLUMN auto_sync_primary_id TEXT    NOT NULL DEFAULT '';
+ALTER TABLE settings ADD COLUMN auto_sync_last_hash  TEXT    NOT NULL DEFAULT '';
+
+-- Per-member record of the last config sync Front Desk applied to it (wizard or
+-- automatic), powering the Members table "Last Config Sync" column and tooltip.
+-- last_config_sync_at is INTEGER Unix nanoseconds (NULL until first sync); the
+-- reason explains why it synced (e.g. the primary's config changed).
+ALTER TABLE members ADD COLUMN last_config_sync_at     INTEGER;
+ALTER TABLE members ADD COLUMN last_config_sync_reason TEXT NOT NULL DEFAULT '';

--- a/internal/frontdesk/server.go
+++ b/internal/frontdesk/server.go
@@ -51,18 +51,19 @@ type ServerConfig struct {
 
 // Server is the Front Desk HTTP server.
 type Server struct {
-	store      *Store
-	poller     *Poller
-	bus        *events.Bus
-	adminMgr   *admin.Manager
-	sessionMgr *webauthn.SessionManager
-	totpRepo   *totp.Repository
-	totpStatus *totpEnabledCache
-	probe      *http.Client // guarded client for proxying member admin APIs
-	readClient *http.Client // guarded client for interactive member admin reads (e.g. Traffic timeseries); longer deadline than the health probe, shorter than the import relay
-	syncClient *http.Client // guarded client for the config-import relay (longer deadline; import runs member-side discovery)
-	lbPort     string       // host port of the data-plane load balancer, surfaced to the wizard
-	router     http.Handler
+	store        *Store
+	poller       *Poller
+	bus          *events.Bus
+	adminMgr     *admin.Manager
+	sessionMgr   *webauthn.SessionManager
+	totpRepo     *totp.Repository
+	totpStatus   *totpEnabledCache
+	probe        *http.Client // guarded client for proxying member admin APIs
+	readClient   *http.Client // guarded client for interactive member admin reads (e.g. Traffic timeseries); longer deadline than the health probe, shorter than the import relay
+	syncClient   *http.Client // guarded client for the config-import relay (longer deadline; import runs member-side discovery)
+	backupClient *http.Client // guarded client for the pre-sync backup relay (deadline exceeds the member's pg_dump budget)
+	lbPort       string       // host port of the data-plane load balancer, surfaced to the wizard
+	router       http.Handler
 }
 
 // defaultLBPort is the load-balancer host port assumed when FLEET_LB_PORT is
@@ -84,17 +85,18 @@ func NewServer(cfg ServerConfig) *Server {
 	}
 
 	s := &Server{
-		store:      cfg.Store,
-		poller:     cfg.Poller,
-		bus:        cfg.Bus,
-		adminMgr:   cfg.AdminMgr,
-		sessionMgr: sessionMgr,
-		totpRepo:   totpRepo,
-		totpStatus: newTotpEnabledCache(totpRepo),
-		probe:      newProbeClient(httpProbeTimeout),
-		readClient: newProbeClient(memberReadTimeout),
-		syncClient: newProbeClient(memberSyncTimeout),
-		lbPort:     lbPort,
+		store:        cfg.Store,
+		poller:       cfg.Poller,
+		bus:          cfg.Bus,
+		adminMgr:     cfg.AdminMgr,
+		sessionMgr:   sessionMgr,
+		totpRepo:     totpRepo,
+		totpStatus:   newTotpEnabledCache(totpRepo),
+		probe:        newProbeClient(httpProbeTimeout),
+		readClient:   newProbeClient(memberReadTimeout),
+		syncClient:   newProbeClient(memberSyncTimeout),
+		backupClient: newProbeClient(memberBackupTimeout),
+		lbPort:       lbPort,
 	}
 
 	webauthnHandler := adminauth.NewWebAuthnHandler(

--- a/internal/frontdesk/server.go
+++ b/internal/frontdesk/server.go
@@ -142,6 +142,8 @@ func (s *Server) buildRouter(wa *adminauth.WebAuthnHandler, tp *adminauth.TotpHa
 			r.Get("/traefik-status", s.traefikStatus)
 			r.Get("/fleet/status", s.fleetStatus)
 			r.Get("/fleet/last-sync", s.fleetLastSync)
+			r.Get("/fleet/autosync", s.getAutoSync)
+			r.Put("/fleet/autosync", s.putAutoSync)
 			r.Post("/config/sync", s.configSync)
 			r.Get("/sse", s.sse)
 		})
@@ -378,6 +380,70 @@ func (s *Server) putSettings(w http.ResponseWriter, r *http.Request) {
 		Message: "Settings updated",
 	})
 	writeJSON(w, http.StatusOK, set)
+}
+
+// getAutoSync returns the automatic config-propagation setup (enabled + the
+// designated primary). The internal drift hash is never included.
+func (s *Server) getAutoSync(w http.ResponseWriter, r *http.Request) {
+	cfg, err := s.store.GetAutoSync(r.Context())
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, cfg)
+}
+
+// putAutoSync sets the auto-sync toggle and designated primary. Enabling without
+// a primary, or naming a primary that is unknown or has no stored admin token, is
+// rejected: the loop could not authenticate to pull its config, so the choice
+// would silently do nothing.
+func (s *Server) putAutoSync(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Enabled   bool   `json:"enabled"`
+		PrimaryID string `json:"primary_id"`
+	}
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	if req.PrimaryID != "" {
+		m, err := s.store.GetMember(r.Context(), req.PrimaryID)
+		if err != nil {
+			if errors.Is(err, ErrNotFound) {
+				http.Error(w, "that primary is not a known member", http.StatusBadRequest)
+				return
+			}
+			writeError(w, err)
+			return
+		}
+		if !m.HasToken {
+			http.Error(w, "store an admin token for that primary first; auto-sync needs it to read the primary's config", http.StatusBadRequest)
+			return
+		}
+	} else if req.Enabled {
+		http.Error(w, "choose a primary before enabling auto-sync", http.StatusBadRequest)
+		return
+	}
+	if err := s.store.SetAutoSync(r.Context(), req.Enabled, req.PrimaryID); err != nil {
+		writeError(w, err)
+		return
+	}
+	s.emit(r.Context(), Event{
+		Type: "settings.changed", Severity: "info", Source: "frontdesk",
+		Message: fmt.Sprintf("Auto-sync %s", enabledWord(req.Enabled)),
+	})
+	cfg, err := s.store.GetAutoSync(r.Context())
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, cfg)
+}
+
+func enabledWord(b bool) string {
+	if b {
+		return "enabled"
+	}
+	return "disabled"
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/frontdesk/server.go
+++ b/internal/frontdesk/server.go
@@ -250,6 +250,9 @@ func (s *Server) createMember(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		tokenWarning = p.warning()
+		// A newly added member with a valid token is stale relative to the primary;
+		// re-arm auto-sync so the next tick brings it in line (no-op when disabled).
+		s.rearmAutoSync(r.Context())
 	}
 	s.emit(r.Context(), Event{
 		Type: "member.added", Severity: "info", Source: "frontdesk",
@@ -296,6 +299,11 @@ func (s *Server) patchMember(w http.ResponseWriter, r *http.Request) {
 		if err := s.store.SetMemberToken(r.Context(), id, *req.Token); err != nil {
 			writeError(w, err)
 			return
+		}
+		if *req.Token != "" {
+			// The member just gained an admin token: it is now syncable but stale, so
+			// re-arm auto-sync to converge it (no-op when disabled).
+			s.rearmAutoSync(r.Context())
 		}
 	}
 	m, err := s.store.GetMember(r.Context(), id)
@@ -446,6 +454,20 @@ func enabledWord(b bool) string {
 		return "enabled"
 	}
 	return "disabled"
+}
+
+// rearmAutoSync clears the last-applied config hash so the auto-sync loop runs a
+// full convergence pass on its next tick. The loop's fast path skips work when the
+// primary's hash is unchanged, so a member that becomes newly syncable (just
+// added, or just given an admin token) would otherwise stay stale until the
+// primary's config next changed. Clearing the marker re-arms the loop; members
+// already matching the primary are still skipped by their own dry-run diff, so the
+// re-run only syncs the one(s) that actually need it. It is a no-op in effect when
+// auto-sync is disabled (the loop reads the marker but does nothing).
+func (s *Server) rearmAutoSync(ctx context.Context) {
+	if err := s.store.SetAutoSyncLastHash(ctx, ""); err != nil {
+		debuglog.Warn("frontdesk: re-arm auto-sync after membership change", "error", err)
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/frontdesk/store.go
+++ b/internal/frontdesk/store.go
@@ -176,15 +176,37 @@ func (s *Store) migrate(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("frontdesk: read migration %s: %w", e.Name(), err)
 		}
-		if _, err := s.db.ExecContext(ctx, string(content)); err != nil {
-			return fmt.Errorf("frontdesk: apply migration %s: %w", e.Name(), err)
-		}
-		if _, err := s.db.ExecContext(ctx,
-			`INSERT INTO schema_migrations (name, applied_at) VALUES (?, ?)`, e.Name(), time.Now().UTC().UnixNano(),
-		); err != nil {
-			return fmt.Errorf("frontdesk: record migration %s: %w", e.Name(), err)
+		if err := s.applyMigration(ctx, e.Name(), string(content)); err != nil {
+			return err
 		}
 		debuglog.Info("frontdesk: applied migration", "name", e.Name())
+	}
+	return nil
+}
+
+// applyMigration runs one migration's statements and records it in
+// schema_migrations within a single transaction. Bundling the two means a crash
+// between them can never leave a migration applied-but-unrecorded, which on the
+// next start would re-run it: harmless for an idempotent CREATE ... IF NOT
+// EXISTS, but fatal for an ALTER TABLE ADD COLUMN (duplicate column, bricked
+// binary). SQLite executes DDL transactionally, so a failure rolls the whole
+// migration back.
+func (s *Store) applyMigration(ctx context.Context, name, content string) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("frontdesk: begin migration %s: %w", name, err)
+	}
+	defer tx.Rollback() //nolint:errcheck // rollback after a successful commit is a no-op
+	if _, err := tx.ExecContext(ctx, content); err != nil {
+		return fmt.Errorf("frontdesk: apply migration %s: %w", name, err)
+	}
+	if _, err := tx.ExecContext(ctx,
+		`INSERT INTO schema_migrations (name, applied_at) VALUES (?, ?)`, name, time.Now().UTC().UnixNano(),
+	); err != nil {
+		return fmt.Errorf("frontdesk: record migration %s: %w", name, err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("frontdesk: commit migration %s: %w", name, err)
 	}
 	return nil
 }

--- a/internal/frontdesk/store.go
+++ b/internal/frontdesk/store.go
@@ -445,10 +445,15 @@ func (s *Store) GetAutoSync(ctx context.Context) (AutoSyncConfig, error) {
 }
 
 // SetAutoSync persists the operator's auto-sync choice (enabled + designated
-// primary). It does not touch the last-applied hash; the poller owns that.
+// primary) and clears the last-applied hash in the same write. Resetting the
+// marker re-arms the poller: without it, re-enabling auto-sync or switching to a
+// primary whose config hash already equals the stored value would return early on
+// the next tick and never run a convergence pass, leaving replicas that drifted
+// while sync was off (or that should now follow the new primary) stale until the
+// primary's config next changed.
 func (s *Store) SetAutoSync(ctx context.Context, enabled bool, primaryID string) error {
 	_, err := s.db.ExecContext(ctx,
-		`UPDATE settings SET auto_sync_enabled = ?, auto_sync_primary_id = ? WHERE id = 1`,
+		`UPDATE settings SET auto_sync_enabled = ?, auto_sync_primary_id = ?, auto_sync_last_hash = '' WHERE id = 1`,
 		boolToInt(enabled), primaryID,
 	)
 	if err != nil {

--- a/internal/frontdesk/store.go
+++ b/internal/frontdesk/store.go
@@ -63,6 +63,12 @@ type Member struct {
 	HasToken  bool        `json:"has_token"`
 	CreatedAt time.Time   `json:"created_at"`
 	UpdatedAt time.Time   `json:"updated_at"`
+	// LastConfigSyncAt is when Front Desk last applied config to this member
+	// (wizard or automatic); nil until the first sync. LastConfigSyncReason
+	// explains why (e.g. the primary's config changed). Both power the Members
+	// table "Last Config Sync" column.
+	LastConfigSyncAt     *time.Time `json:"last_config_sync_at,omitempty"`
+	LastConfigSyncReason string     `json:"last_config_sync_reason,omitempty"`
 }
 
 // Settings shape the generated Traefik config and the pollers. The single row
@@ -225,7 +231,7 @@ func (s *Store) CreateMember(ctx context.Context, name, rawURL, token string) (*
 // ListMembers returns all members ordered by creation time.
 func (s *Store) ListMembers(ctx context.Context) ([]*Member, error) {
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT id, name, url, state, token_cipher, created_at, updated_at FROM members ORDER BY created_at ASC`,
+		`SELECT id, name, url, state, token_cipher, created_at, updated_at, last_config_sync_at, last_config_sync_reason FROM members ORDER BY created_at ASC`,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("frontdesk: list members: %w", err)
@@ -246,7 +252,7 @@ func (s *Store) ListMembers(ctx context.Context) ([]*Member, error) {
 // GetMember returns one member by id, or ErrNotFound.
 func (s *Store) GetMember(ctx context.Context, id string) (*Member, error) {
 	row := s.db.QueryRowContext(ctx,
-		`SELECT id, name, url, state, token_cipher, created_at, updated_at FROM members WHERE id = ?`, id,
+		`SELECT id, name, url, state, token_cipher, created_at, updated_at, last_config_sync_at, last_config_sync_reason FROM members WHERE id = ?`, id,
 	)
 	m, err := scanMember(row)
 	if err != nil {
@@ -292,7 +298,15 @@ func (s *Store) SetMemberState(ctx context.Context, id string, state MemberState
 // DeleteMember removes a member by id.
 func (s *Store) DeleteMember(ctx context.Context, id string) error {
 	res, err := s.db.ExecContext(ctx, `DELETE FROM members WHERE id = ?`, id)
-	return affectedOrNotFound(res, err)
+	if err := affectedOrNotFound(res, err); err != nil {
+		return err
+	}
+	// If the removed member was the designated auto-sync primary, clear the
+	// pointer so the auto-sync loop stops treating a now-gone member as the
+	// source of truth. Best-effort: a failure here only leaves a dangling id the
+	// loop already guards against.
+	_, _ = s.db.ExecContext(ctx, `UPDATE settings SET auto_sync_primary_id = '' WHERE auto_sync_primary_id = ?`, id)
+	return nil
 }
 
 // MemberToken decrypts and returns a member's stored admin token. ok is false
@@ -380,6 +394,67 @@ func (s *Store) UpdateSettings(ctx context.Context, set Settings) error {
 		return fmt.Errorf("frontdesk: update settings: %w", err)
 	}
 	return nil
+}
+
+// AutoSyncConfig is the operator's automatic config-propagation setup: a master
+// on/off plus the designated source-of-truth member. LastHash is the internal
+// drift marker (the primary config hash last applied to the fleet) and is never
+// surfaced to the UI.
+type AutoSyncConfig struct {
+	Enabled   bool   `json:"enabled"`
+	PrimaryID string `json:"primary_id"`
+	LastHash  string `json:"-"`
+}
+
+// GetAutoSync reads the automatic config-sync setup from the settings row.
+func (s *Store) GetAutoSync(ctx context.Context) (AutoSyncConfig, error) {
+	var (
+		cfg     AutoSyncConfig
+		enabled int
+	)
+	err := s.db.QueryRowContext(ctx,
+		`SELECT auto_sync_enabled, auto_sync_primary_id, auto_sync_last_hash FROM settings WHERE id = 1`,
+	).Scan(&enabled, &cfg.PrimaryID, &cfg.LastHash)
+	if err != nil {
+		return AutoSyncConfig{}, fmt.Errorf("frontdesk: get auto-sync: %w", err)
+	}
+	cfg.Enabled = enabled != 0
+	return cfg, nil
+}
+
+// SetAutoSync persists the operator's auto-sync choice (enabled + designated
+// primary). It does not touch the last-applied hash; the poller owns that.
+func (s *Store) SetAutoSync(ctx context.Context, enabled bool, primaryID string) error {
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE settings SET auto_sync_enabled = ?, auto_sync_primary_id = ? WHERE id = 1`,
+		boolToInt(enabled), primaryID,
+	)
+	if err != nil {
+		return fmt.Errorf("frontdesk: set auto-sync: %w", err)
+	}
+	return nil
+}
+
+// SetAutoSyncLastHash records the primary config hash the poller just applied to
+// the fleet, so the next tick can detect a change cheaply.
+func (s *Store) SetAutoSyncLastHash(ctx context.Context, hash string) error {
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE settings SET auto_sync_last_hash = ? WHERE id = 1`, hash,
+	)
+	if err != nil {
+		return fmt.Errorf("frontdesk: set auto-sync hash: %w", err)
+	}
+	return nil
+}
+
+// SetMemberLastSync stamps when Front Desk last applied config to a member and
+// why, for the Members table "Last Config Sync" column.
+func (s *Store) SetMemberLastSync(ctx context.Context, id string, at time.Time, reason string) error {
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE members SET last_config_sync_at = ?, last_config_sync_reason = ? WHERE id = ?`,
+		at.UTC().UnixNano(), reason, id,
+	)
+	return affectedOrNotFound(res, err)
 }
 
 // ---------------------------------------------------------------------------
@@ -549,19 +624,26 @@ type scanner interface {
 
 func scanMember(sc scanner) (*Member, error) {
 	var (
-		m         Member
-		state     string
-		cipher    []byte
-		createdAt int64
-		updatedAt int64
+		m          Member
+		state      string
+		cipher     []byte
+		createdAt  int64
+		updatedAt  int64
+		lastSyncAt sql.NullInt64
+		syncReason string
 	)
-	if err := sc.Scan(&m.ID, &m.Name, &m.URL, &state, &cipher, &createdAt, &updatedAt); err != nil {
+	if err := sc.Scan(&m.ID, &m.Name, &m.URL, &state, &cipher, &createdAt, &updatedAt, &lastSyncAt, &syncReason); err != nil {
 		return nil, err
 	}
 	m.State = MemberState(state)
 	m.HasToken = len(cipher) > 0
 	m.CreatedAt = time.Unix(0, createdAt).UTC()
 	m.UpdatedAt = time.Unix(0, updatedAt).UTC()
+	if lastSyncAt.Valid {
+		t := time.Unix(0, lastSyncAt.Int64).UTC()
+		m.LastConfigSyncAt = &t
+	}
+	m.LastConfigSyncReason = syncReason
 	return &m, nil
 }
 

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -537,10 +537,11 @@ export interface BackupEntry {
 	filename: string;
 	size_bytes: number;
 	created_at: string;
-	/** "manual" (operator-created) or "scheduled" (GFS rotation). Absent on
-	 *  responses from servers predating origin tracking; treat as manual, matching
-	 *  the backend's default for filenames without an origin marker. */
-	origin?: "manual" | "scheduled";
+	/** "manual" (operator-created), "scheduled" (GFS rotation), or "frontdesk"
+	 *  (snapshot Front Desk took before an HA config sync). Absent on responses
+	 *  from servers predating origin tracking; treat as manual, matching the
+	 *  backend's default for filenames without an origin marker. */
+	origin?: "manual" | "scheduled" | "frontdesk";
 }
 
 export interface BackupClassification {

--- a/web/src/i18n/locales/af.json
+++ b/web/src/i18n/locales/af.json
@@ -1665,7 +1665,8 @@
 				"pruneSuccess": "Periodieke rugsteun geaktiveer. {{count}} ou rugsteun(e) verwyder."
 			},
 			"availableBackupsTitle": "Beskikbare rugsteun",
-			"manuallyCreated": "Handmatig"
+			"manuallyCreated": "Handmatig",
+			"frontDeskCreated": "Deur Front Desk geskep voor 'n HA-konfigurasiesinkronisasie"
 		},
 		"appearance": {
 			"title": "Uiterlike voorkoms",

--- a/web/src/i18n/locales/ar.json
+++ b/web/src/i18n/locales/ar.json
@@ -1665,7 +1665,8 @@
 				"pruneSuccess": "تم تفعيل النسخ الاحتياطي الدوري. تمت إزالة {{count}} نسخة احتياطية قديمة."
 			},
 			"availableBackupsTitle": "النسخ الاحتياطي المتوفر",
-			"manuallyCreated": "يدوي"
+			"manuallyCreated": "يدوي",
+			"frontDeskCreated": "أنشأه Front Desk قبل مزامنة إعدادات الـ HA"
 		},
 		"appearance": {
 			"title": "المظهر",

--- a/web/src/i18n/locales/ca.json
+++ b/web/src/i18n/locales/ca.json
@@ -1665,7 +1665,8 @@
 				"pruneSuccess": "Còpia de seguretat periòdica activada. S'han eliminat {{count}} còpia/es antiga/es."
 			},
 			"availableBackupsTitle": "Copies de seguretat disponibles",
-			"manuallyCreated": "Manual"
+			"manuallyCreated": "Manual",
+			"frontDeskCreated": "Creat per Front Desk abans d'una sincronització de configuració HA"
 		},
 		"appearance": {
 			"title": "Aparença",

--- a/web/src/i18n/locales/cs.json
+++ b/web/src/i18n/locales/cs.json
@@ -1665,7 +1665,8 @@
 				"pruneSuccess": "Pravidelné zálohování povoleno. Odstraněno {{count}} starých záloh."
 			},
 			"availableBackupsTitle": "Dostupné zálohy",
-			"manuallyCreated": "Ručne"
+			"manuallyCreated": "Ručne",
+			"frontDeskCreated": "Vytvořeno nástrojem Front Desk před synchronizací konfigurace HA"
 		},
 		"appearance": {
 			"title": "Vzhled",

--- a/web/src/i18n/locales/da.json
+++ b/web/src/i18n/locales/da.json
@@ -1665,7 +1665,8 @@
 				"pruneSuccess": "Periodisk sikkerhedskopiering aktiveret. {{count}} gamle sikkerhedskopi(er) fjernet."
 			},
 			"availableBackupsTitle": "Tilgængelige sikkerhedskopier",
-			"manuallyCreated": "Manuel"
+			"manuallyCreated": "Manuel",
+			"frontDeskCreated": "Oprettet af Front Desk før en HA-konfigurationssynkronisering"
 		},
 		"appearance": {
 			"title": "Udseende",

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -1665,7 +1665,8 @@
 				"pruneSuccess": "Periodische Sicherung aktiviert. {{count}} alte Sicherung(en) entfernt."
 			},
 			"availableBackupsTitle": "Verfügbare Sicherungen",
-			"manuallyCreated": "Manuell"
+			"manuallyCreated": "Manuell",
+			"frontDeskCreated": "Von Front Desk vor einer HA-Konfigurationssynchronisierung erstellt"
 		},
 		"appearance": {
 			"title": "Erscheinung",

--- a/web/src/i18n/locales/el.json
+++ b/web/src/i18n/locales/el.json
@@ -1665,7 +1665,8 @@
 				"pruneSuccess": "Τα περιοδικά αντίγραφα ασφαλείας ενεργοποιήθηκαν. Αφαιρέθηκαν {{count}} παλιά αντίγραφα ασφαλείας."
 			},
 			"availableBackupsTitle": "Διαθέσιμα Αντίγραφα Ασφαλείας",
-			"manuallyCreated": "Χειροκίνητο"
+			"manuallyCreated": "Χειροκίνητο",
+			"frontDeskCreated": "Δημιουργήθηκε από το Front Desk πριν από συγχρονισμό ρυθμίσεων HA"
 		},
 		"appearance": {
 			"title": "Εμφάνιση",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1708,7 +1708,8 @@
 				"pruneSuccess": "Periodic backup enabled. Removed {{count}} old backup(s)."
 			},
 			"availableBackupsTitle": "Available backups",
-			"manuallyCreated": "Manual"
+			"manuallyCreated": "Manual",
+			"frontDeskCreated": "Created by Front Desk before an HA config sync"
 		},
 		"appearance": {
 			"title": "Appearance",

--- a/web/src/i18n/locales/es.json
+++ b/web/src/i18n/locales/es.json
@@ -1665,7 +1665,8 @@
 				"pruneSuccess": "Copia de seguridad periódica activada. Se han eliminado {{count}} copia(s) antigua(s)."
 			},
 			"availableBackupsTitle": "Copias de seguridad disponibles",
-			"manuallyCreated": "Manual"
+			"manuallyCreated": "Manual",
+			"frontDeskCreated": "Creado por Front Desk antes de una sincronización de configuración de HA"
 		},
 		"appearance": {
 			"title": "Apariencia",

--- a/web/src/i18n/locales/fi.json
+++ b/web/src/i18n/locales/fi.json
@@ -1665,7 +1665,8 @@
 				"pruneSuccess": "Säännöllinen varmuuskopiointi käytössä. Poistettu {{count}} vanhaa varmuuskopiota."
 			},
 			"availableBackupsTitle": "Saatavilla Olevat Varmuuskopiot",
-			"manuallyCreated": "Manuaalinen"
+			"manuallyCreated": "Manuaalinen",
+			"frontDeskCreated": "Front Deskin luoma ennen HA-määritysten synkronointia"
 		},
 		"appearance": {
 			"title": "Ulkoasu",

--- a/web/src/i18n/locales/fr.json
+++ b/web/src/i18n/locales/fr.json
@@ -1665,7 +1665,8 @@
 				"pruneSuccess": "Sauvegarde périodique activée. {{count}} ancienne(s) sauvegarde(s) supprimée(s)."
 			},
 			"availableBackupsTitle": "Sauvegardes disponibles",
-			"manuallyCreated": "Manuel"
+			"manuallyCreated": "Manuel",
+			"frontDeskCreated": "Créé par Front Desk avant une synchronisation de configuration HA"
 		},
 		"appearance": {
 			"title": "Apparence",

--- a/web/src/i18n/locales/he.json
+++ b/web/src/i18n/locales/he.json
@@ -1665,7 +1665,8 @@
 				"pruneSuccess": "גיבוי תקופתי הופעל. הוסרו {{count}} גיבויים ישנים."
 			},
 			"availableBackupsTitle": "גיבויים זמינים",
-			"manuallyCreated": "ידני"
+			"manuallyCreated": "ידני",
+			"frontDeskCreated": "נוצר על ידי Front Desk לפני סנכרון תצורת HA"
 		},
 		"appearance": {
 			"title": "מראה",

--- a/web/src/i18n/locales/hu.json
+++ b/web/src/i18n/locales/hu.json
@@ -1665,7 +1665,8 @@
 				"pruneSuccess": "Időszakos biztonsági mentés engedélyezve. {{count}} régi mentés eltávolítva."
 			},
 			"availableBackupsTitle": "Elérhető biztonsági másolatok",
-			"manuallyCreated": "Kézi"
+			"manuallyCreated": "Kézi",
+			"frontDeskCreated": "A Front Desk hozta létre egy HA-konfigurációszinkronizálás előtt"
 		},
 		"appearance": {
 			"title": "Megjelenés",

--- a/web/src/i18n/locales/it.json
+++ b/web/src/i18n/locales/it.json
@@ -1665,7 +1665,8 @@
 				"pruneSuccess": "Backup periodico attivato. Rimossi {{count}} backup obsoleti."
 			},
 			"availableBackupsTitle": "Backup Disponibili",
-			"manuallyCreated": "Manuale"
+			"manuallyCreated": "Manuale",
+			"frontDeskCreated": "Creato da Front Desk prima di una sincronizzazione della configurazione HA"
 		},
 		"appearance": {
 			"title": "Aspetto",

--- a/web/src/i18n/locales/ja.json
+++ b/web/src/i18n/locales/ja.json
@@ -1665,7 +1665,8 @@
 				"pruneSuccess": "定期バックアップを有効にしました。{{count}} 件の古いバックアップを削除しました。"
 			},
 			"availableBackupsTitle": "利用可能なバックアップ",
-			"manuallyCreated": "手動"
+			"manuallyCreated": "手動",
+			"frontDeskCreated": "HA 設定同期の前に Front Desk が作成"
 		},
 		"appearance": {
 			"title": "外観",

--- a/web/src/i18n/locales/ko.json
+++ b/web/src/i18n/locales/ko.json
@@ -1665,7 +1665,8 @@
 				"pruneSuccess": "정기 백업이 활성화되었습니다. 오래된 백업 {{count}}개를 삭제했습니다."
 			},
 			"availableBackupsTitle": "사용 가능한 백업",
-			"manuallyCreated": "수동"
+			"manuallyCreated": "수동",
+			"frontDeskCreated": "HA 구성 동기화 전에 Front Desk에서 생성함"
 		},
 		"appearance": {
 			"title": "외관",

--- a/web/src/i18n/locales/nl.json
+++ b/web/src/i18n/locales/nl.json
@@ -1665,7 +1665,8 @@
 				"pruneSuccess": "Periodieke back-up ingeschakeld. {{count}} oude back-up(s) verwijderd."
 			},
 			"availableBackupsTitle": "Beschikbare back-ups",
-			"manuallyCreated": "Handmatig"
+			"manuallyCreated": "Handmatig",
+			"frontDeskCreated": "Gemaakt door Front Desk vóór een HA-configuratiesynchronisatie"
 		},
 		"appearance": {
 			"title": "Uiterlijk",

--- a/web/src/i18n/locales/no.json
+++ b/web/src/i18n/locales/no.json
@@ -1665,7 +1665,8 @@
 				"pruneSuccess": "Periodisk sikkerhetskopiering aktivert. Fjernet {{count}} gamle sikkerhetskopier."
 			},
 			"availableBackupsTitle": "Tilgjengelige sikkerhetskopier",
-			"manuallyCreated": "Manuell"
+			"manuallyCreated": "Manuell",
+			"frontDeskCreated": "Opprettet av Front Desk før en HA-konfigurasjonssynkronisering"
 		},
 		"appearance": {
 			"title": "Utseende",

--- a/web/src/i18n/locales/pl.json
+++ b/web/src/i18n/locales/pl.json
@@ -1665,7 +1665,8 @@
 				"pruneSuccess": "Okresowa kopia zapasowa włączona. Usunięto {{count}} starych kopii zapasowych."
 			},
 			"availableBackupsTitle": "Dostępne kopie zapasowe",
-			"manuallyCreated": "Ręczne"
+			"manuallyCreated": "Ręczne",
+			"frontDeskCreated": "Utworzone przez Front Desk przed synchronizacją konfiguracji HA"
 		},
 		"appearance": {
 			"title": "Wygląd",

--- a/web/src/i18n/locales/pt.json
+++ b/web/src/i18n/locales/pt.json
@@ -1665,7 +1665,8 @@
 				"pruneSuccess": "Cópia de segurança periódica ativada. Removidas {{count}} cópia(s) antiga(s)."
 			},
 			"availableBackupsTitle": "Backups disponíveis",
-			"manuallyCreated": "Manual"
+			"manuallyCreated": "Manual",
+			"frontDeskCreated": "Criado pelo Front Desk antes de uma sincronização de configuração de HA"
 		},
 		"appearance": {
 			"title": "Aparência",

--- a/web/src/i18n/locales/ro.json
+++ b/web/src/i18n/locales/ro.json
@@ -1665,7 +1665,8 @@
 				"pruneSuccess": "Backup periodic activat. Au fost eliminate {{count}} backupuri vechi."
 			},
 			"availableBackupsTitle": "Backup-uri disponibile",
-			"manuallyCreated": "Manual"
+			"manuallyCreated": "Manual",
+			"frontDeskCreated": "Creat de Front Desk înainte de o sincronizare a configurației HA"
 		},
 		"appearance": {
 			"title": "Aspectul",

--- a/web/src/i18n/locales/ru.json
+++ b/web/src/i18n/locales/ru.json
@@ -1665,7 +1665,8 @@
 				"pruneSuccess": "Периодическое резервное копирование включено. Удалено {{count}} старых резервных копий."
 			},
 			"availableBackupsTitle": "Доступные резервные копии",
-			"manuallyCreated": "Вручную"
+			"manuallyCreated": "Вручную",
+			"frontDeskCreated": "Создано Front Desk перед синхронизацией конфигурации HA"
 		},
 		"appearance": {
 			"title": "Внешний вид",

--- a/web/src/i18n/locales/sk.json
+++ b/web/src/i18n/locales/sk.json
@@ -1665,7 +1665,8 @@
 				"pruneSuccess": "Pravidelné zálohovanie povolené. Odstránených {{count}} starých záloh."
 			},
 			"availableBackupsTitle": "Dostupné zálohy",
-			"manuallyCreated": "Ručne"
+			"manuallyCreated": "Ručne",
+			"frontDeskCreated": "Vytvorené nástrojom Front Desk pred synchronizáciou konfigurácie HA"
 		},
 		"appearance": {
 			"title": "Vzhľad",

--- a/web/src/i18n/locales/sr.json
+++ b/web/src/i18n/locales/sr.json
@@ -1665,7 +1665,8 @@
 				"pruneSuccess": "Периодично резервно копирање је омогућено. Уклоњено {{count}} старих резервних копија."
 			},
 			"availableBackupsTitle": "Доступне резервне копије",
-			"manuallyCreated": "Ручно"
+			"manuallyCreated": "Ручно",
+			"frontDeskCreated": "Направио Front Desk пре синхронизације HA конфигурације"
 		},
 		"appearance": {
 			"title": "Изглед",

--- a/web/src/i18n/locales/sv.json
+++ b/web/src/i18n/locales/sv.json
@@ -1665,7 +1665,8 @@
 				"pruneSuccess": "Periodisk säkerhetskopiering aktiverad. Tog bort {{count}} gamla säkerhetskopior."
 			},
 			"availableBackupsTitle": "Tillgängliga säkerhetskopior",
-			"manuallyCreated": "Manuell"
+			"manuallyCreated": "Manuell",
+			"frontDeskCreated": "Skapad av Front Desk före en HA-konfigurationssynkronisering"
 		},
 		"appearance": {
 			"title": "Utseende",

--- a/web/src/i18n/locales/tr.json
+++ b/web/src/i18n/locales/tr.json
@@ -1665,7 +1665,8 @@
 				"pruneSuccess": "Periyodik yedekleme etkinleştirildi. {{count}} eski yedek kaldırıldı."
 			},
 			"availableBackupsTitle": "Mevcut Yedeklemeler",
-			"manuallyCreated": "Manuel"
+			"manuallyCreated": "Manuel",
+			"frontDeskCreated": "HA yapılandırma eşitlemesinden önce Front Desk tarafından oluşturuldu"
 		},
 		"appearance": {
 			"title": "Görünüm",

--- a/web/src/i18n/locales/uk.json
+++ b/web/src/i18n/locales/uk.json
@@ -1665,7 +1665,8 @@
 				"pruneSuccess": "Періодичне резервне копіювання увімкнено. Видалено {{count}} старих резервних копій."
 			},
 			"availableBackupsTitle": "Доступні резервні копії",
-			"manuallyCreated": "Вручну"
+			"manuallyCreated": "Вручну",
+			"frontDeskCreated": "Створено Front Desk перед синхронізацією конфігурації HA"
 		},
 		"appearance": {
 			"title": "Зовнішній вигляд",

--- a/web/src/i18n/locales/vi.json
+++ b/web/src/i18n/locales/vi.json
@@ -1665,7 +1665,8 @@
 				"pruneSuccess": "Đã bật sao lưu định kỳ. Đã xóa {{count}} bản sao lưu cũ."
 			},
 			"availableBackupsTitle": "Các bản sao lưu hiện có",
-			"manuallyCreated": "Thủ công"
+			"manuallyCreated": "Thủ công",
+			"frontDeskCreated": "Được Front Desk tạo trước khi đồng bộ cấu hình HA"
 		},
 		"appearance": {
 			"title": "Hình thức",

--- a/web/src/i18n/locales/zh.json
+++ b/web/src/i18n/locales/zh.json
@@ -1665,7 +1665,8 @@
 				"pruneSuccess": "已启用定期备份。已删除 {{count}} 个旧备份。"
 			},
 			"availableBackupsTitle": "可用备份",
-			"manuallyCreated": "手动"
+			"manuallyCreated": "手动",
+			"frontDeskCreated": "由 Front Desk 在 HA 配置同步前创建"
 		},
 		"appearance": {
 			"title": "外观",

--- a/web/src/pages/Settings/DatabaseBackupSettings.tsx
+++ b/web/src/pages/Settings/DatabaseBackupSettings.tsx
@@ -574,6 +574,14 @@ export function DatabaseBackupSettings({
 														{gfsLabel.get(backup.filename)}
 													</span>
 												)}
+											{backup.origin === "frontdesk" && (
+												<span
+													className="shrink-0 inline-flex h-4 items-center justify-center rounded px-1 text-[10px] font-bold bg-(--accent)/15 text-(--accent)"
+													title={t("settings.backup.frontDeskCreated")}
+												>
+													FD
+												</span>
+											)}
 											<p className="text-sm font-medium text-(--text-primary) truncate">
 												{backup.filename}
 											</p>

--- a/web/src/pages/Settings/__tests__/DatabaseBackupSettings.test.tsx
+++ b/web/src/pages/Settings/__tests__/DatabaseBackupSettings.test.tsx
@@ -95,6 +95,29 @@ describe("DatabaseBackupSettings", () => {
 		).toBeInTheDocument();
 	});
 
+	it("tags Front Desk pre-sync snapshots with an FD badge", async () => {
+		const frontdesk = {
+			filename: "backup_20260117_103000_0010_frontdesk.dump",
+			size_bytes: 4096,
+			created_at: "2026-01-17T10:30:00Z",
+			origin: "frontdesk",
+		};
+		server.use(
+			http.get("/api/backups", () => HttpResponse.json([frontdesk])),
+			http.post("/api/backups/prune-preview", () =>
+				HttpResponse.json({ son: [], father: [], grandfather: [], prune: [] }),
+			),
+		);
+		renderWithProviders(
+			<DatabaseBackupSettings collapsed={false} onToggle={onToggle} />,
+		);
+
+		const row = (await screen.findByText(frontdesk.filename)).closest("div");
+		expect(
+			await within(row as HTMLElement).findByText("FD"),
+		).toBeInTheDocument();
+	});
+
 	it("shows Create Backup button", async () => {
 		renderWithProviders(
 			<DatabaseBackupSettings collapsed={false} onToggle={onToggle} />,

--- a/wiki/High-Availability.md
+++ b/wiki/High-Availability.md
@@ -238,6 +238,28 @@ provider IDs.
 
 <!-- TODO screenshot: Front Desk Settings → Config sync (preview with diff) -->
 
+### Automatic config sync (set and forget)
+
+The runbook above is the manual path. For an unattended fleet, Front Desk →
+Settings → **Automatic config sync** lets you designate a primary and flip
+auto-sync on; from then on you only manage the primary. Front Desk watches the
+primary's config and propagates any change to providers, virtual keys, or
+syncable settings across the fleet by itself. The Members table's **Last Config
+Sync** column shows when each member last converged and why.
+
+Two safety properties make this safe to leave running:
+
+- **Backed up first.** Each member is asked to snapshot itself before being
+  overwritten (badged **FD** in its backup list and spared from GFS rotation),
+  so a bad propagation can be rolled back.
+- **Converges, does not thrash.** A change is propagated only after it settles,
+  members already matching the primary are skipped, and an unreachable or
+  `MASTER_KEY`-blocked member is retried later rather than overwritten.
+
+Automatic sync is **off by default**: it trades the per-change diff review for
+convenience. Leave it off to approve every fleet-wide change by hand, or turn it
+on once you trust the primary as the source of truth.
+
 ---
 
 ## TLS Proxy
@@ -307,8 +329,9 @@ HTTP-provider design). No request or prompt content is ever logged.
   new requests go elsewhere.
 - **Not** Postgres HA, **not** LB redundancy: the HA host and each member's
   Postgres remain single points of failure for their own scope (accepted at
-  homelab scale). There is no automated cross-instance config sync yet, so keep
-  config in step with backup/restore and runbook discipline.
+  homelab scale). Cross-instance config replication is built in (the fleet-sync
+  wizard, or automatic config sync), but member databases themselves still rely
+  on per-member backup/restore discipline.
 
 ---
 

--- a/wiki/High-Availability.md
+++ b/wiki/High-Availability.md
@@ -256,6 +256,11 @@ Two safety properties make this safe to leave running:
   members already matching the primary are skipped, and an unreachable or
   `MASTER_KEY`-blocked member is retried later rather than overwritten.
 
+It reacts to *changes on the primary*; it is not a continuous reconciler. A direct
+edit on a replica (managed members are read-only, so you shouldn't) sits until the
+**primary** next changes, when the full config is pushed and the replica is
+brought back in line. There is no constant per-replica revert loop.
+
 Automatic sync is **off by default**: it trades the per-change diff review for
 convenience. Leave it off to approve every fleet-wide change by hand, or turn it
 on once you trust the primary as the source of truth.


### PR DESCRIPTION
## What

Adds a "set and forget" path for HA config replication alongside the existing manual fleet-sync wizard. Designate a primary member and Front Desk propagates its config to the rest of the fleet by itself whenever the primary changes, snapshotting each member first.

Off by default. Enabling requires a primary with a stored admin token (the loop authenticates with it).

## How it works

- **Drift signal:** new member endpoint `GET /api/config/version` returns a stable SHA-256 over the syncable config only (excludes the volatile `exported_at`), so the hash changes iff a synced entity changes. The poller compares the primary's current hash to the last one applied to the fleet (same-instance comparison, always valid).
- **Coalesced:** a change is propagated only once it settles (same hash two checks running, ~15s cadence), so a multi-step edit fires one sync, not one per save.
- **Backed up first:** before overwriting a member, Front Desk has it snapshot itself via `POST /api/backups?origin=frontdesk`, badged **FD** in that member's backup list and spared from GFS rotation. A failed backup blocks that member's overwrite.
- **Converges without thrash:** members already matching the primary are skipped untouched (decided by their own dry-run diff, valid across instances); an unreachable or `MASTER_KEY`-blocked member is retried next tick rather than overwritten; the applied hash is recorded only once the reachable fleet converges.
- **Visibility:** Members table gains a **Last Config Sync** column with a per-member time + reason tooltip. Settings gains an **Automatic config sync** card (primary picker + toggle + active warning).
- Also: the wizard's "keep this window open" progress is now an amber warning pill (UX nit from earlier).

## Review fixes (second commit)

- **Crash-safe migrations:** each migration apply + its `schema_migrations` record now run in one transaction, so a crash between them can't leave a non-idempotent `ALTER TABLE ADD COLUMN` applied-but-unrecorded and re-run on restart.
- **Backup timeout:** the pre-sync backup relay uses a dedicated client whose deadline (11m) exceeds the member's `pg_dump` budget (10m), so a large member finishes its snapshot instead of timing out every tick and orphaning a dump.
- **Quieter events:** per-member success events are suppressed in the auto path (one roll-up instead); failures still surface.
- Added tests for the unreachable-member and schema/`MASTER_KEY`-blocked hold-off branches.

## Scope / deferred

- **Server-side managed-write enforcement** (rejecting direct API writes on managed members) is deliberately deferred to its own PR. Not needed for auto-sync: the client-side lockdown already hides the controls, and any out-of-band drift is corrected on the next sync.

## Operational note

Members need a `make docker-build` to expose the two new member-side endpoints (`/api/config/version` and the `?origin=frontdesk` backup). Until a member is rebuilt, auto-sync treats it as unreachable and skips it safely.

## Testing

- Go: `go build`/`vet`, `golangci-lint ./...` (0 issues), frontdesk + api suites incl. new autosync/putAutoSync/version-endpoint/FD-origin/branch tests.
- Frontend: Front Desk tsc/biome/vitest (incl. new AutoSyncPanel test); main dashboard tsc/biome/5133 vitest (incl. new FD-badge test).
- i18n parity OK (28 locales filled for the FD badge).
- docs/HA.md + wiki updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)