### PR TITLE
refactor(ha): remove vestigial sticky sessions

### DIFF
--- a/frontdesk/web/src/api/types.ts
+++ b/frontdesk/web/src/api/types.ts
@@ -54,7 +54,6 @@ export interface Settings {
 	traefik_stale_secs: number;
 	event_retention_days: number;
 	retry_attempts: number;
-	sticky_enabled: boolean;
 }
 
 export type Severity = "info" | "success" | "warning" | "error";

--- a/frontdesk/web/src/i18n/locales/en.json
+++ b/frontdesk/web/src/i18n/locales/en.json
@@ -148,8 +148,6 @@
 		"retention": "Event retention (days)",
 		"retryAttempts": "Retry attempts",
 		"retryHint": "Retries that failed before any response byte (safe to retry).",
-		"sticky": "Sticky sessions",
-		"stickyHint": "Pin a browser dashboard (and its SSE stream) to one instance.",
 		"configSyncConfirmTitle_one": "Replace config on {{count}} member?",
 		"configSyncConfirmTitle_other": "Replace config on {{count}} members?",
 		"configSyncConfirmBody": "This makes each member below match the primary's providers, virtual keys, and settings. Items the primary does not have are removed from the member; its request logs and metering are untouched.",

--- a/frontdesk/web/src/pages/SettingsPage.tsx
+++ b/frontdesk/web/src/pages/SettingsPage.tsx
@@ -186,26 +186,6 @@ export function SettingsPage() {
 					</div>
 				</div>
 
-				<label
-					className="fd-row"
-					style={{ marginTop: "0.5rem", cursor: "pointer" }}
-				>
-					<input
-						type="checkbox"
-						checked={settings.sticky_enabled}
-						onChange={(e) => patch({ sticky_enabled: e.target.checked })}
-					/>
-					<span>
-						<span style={{ fontWeight: 500 }}>{t("settings.sticky")}</span>
-						<span
-							className="fd-faint"
-							style={{ display: "block", fontSize: "0.78rem" }}
-						>
-							{t("settings.stickyHint")}
-						</span>
-					</span>
-				</label>
-
 				{saveError && (
 					<div
 						className="fd-error-text"

--- a/frontdesk/web/src/pages/__tests__/SettingsPage.test.tsx
+++ b/frontdesk/web/src/pages/__tests__/SettingsPage.test.tsx
@@ -14,7 +14,6 @@ const defaults: Settings = {
 	traefik_stale_secs: 30,
 	event_retention_days: 90,
 	retry_attempts: 2,
-	sticky_enabled: true,
 };
 
 function renderPage() {
@@ -74,23 +73,6 @@ describe("SettingsPage", () => {
 		await userEvent.click(screen.getByRole("button", { name: /^Save$/i }));
 		// The saved value is the minimum (1), not NaN — a cleared field is coerced.
 		await waitFor(() => expect(saved?.traefik_stale_secs).toBe(1));
-	});
-
-	it("toggles sticky sessions", async () => {
-		let saved: Settings | null = null;
-		server.use(
-			http.get("/api/settings", () => HttpResponse.json(defaults)),
-			http.put("/api/settings", async ({ request }) => {
-				saved = (await request.json()) as Settings;
-				return new HttpResponse(null, { status: 204 });
-			}),
-		);
-		renderPage();
-		const sticky = (await screen.findByRole("checkbox")) as HTMLInputElement;
-		expect(sticky.checked).toBe(true);
-		await userEvent.click(sticky);
-		await userEvent.click(screen.getByRole("button", { name: /^Save$/i }));
-		await waitFor(() => expect(saved?.sticky_enabled).toBe(false));
 	});
 
 	it("surfaces a validation error from the API", async () => {

--- a/internal/frontdesk/coverage_test.go
+++ b/internal/frontdesk/coverage_test.go
@@ -122,7 +122,7 @@ func TestServerSettingsEventsAndMemberMutations(t *testing.T) {
 		t.Errorf("get settings = %d", rec.Code)
 	}
 	if rec := do(t, srv, http.MethodPut, "/api/settings",
-		`{"health_poll_secs":10,"traefik_poll_secs":10,"traefik_stale_secs":30,"event_retention_days":30,"retry_attempts":3,"sticky_enabled":true}`,
+		`{"health_poll_secs":10,"traefik_poll_secs":10,"traefik_stale_secs":30,"event_retention_days":30,"retry_attempts":3}`,
 		true); rec.Code != http.StatusOK {
 		t.Errorf("put settings = %d: %s", rec.Code, rec.Body.String())
 	}

--- a/internal/frontdesk/migrations/006_drop_sticky.sql
+++ b/internal/frontdesk/migrations/006_drop_sticky.sql
@@ -1,0 +1,7 @@
+-- Remove sticky sessions. The setting pinned a browser dashboard (and its SSE
+-- stream) to one backend, but the load balancer now serves only the
+-- OpenAI-compatible proxy (router rule PathPrefix(`/v1`)): dashboards are reached
+-- per-member by their own URL and never traverse the LB, and /v1 API clients do
+-- not carry the mh_lb cookie. The toggle therefore did nothing useful, so the
+-- column, its Traefik config, and the UI control are all removed.
+ALTER TABLE settings DROP COLUMN sticky_enabled;

--- a/internal/frontdesk/server_test.go
+++ b/internal/frontdesk/server_test.go
@@ -171,14 +171,14 @@ func TestServerSettings(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("get settings = %d", rec.Code)
 	}
-	body := `{"health_poll_secs":9,"traefik_poll_secs":9,"traefik_stale_secs":40,"event_retention_days":30,"retry_attempts":3,"sticky_enabled":false}`
+	body := `{"health_poll_secs":9,"traefik_poll_secs":9,"traefik_stale_secs":40,"event_retention_days":30,"retry_attempts":3}`
 	if rec := do(t, srv, http.MethodPut, "/api/settings", body, true); rec.Code != http.StatusOK {
 		t.Fatalf("put settings = %d; body=%s", rec.Code, rec.Body.String())
 	}
 	rec = do(t, srv, http.MethodGet, "/api/settings", "", true)
 	var got Settings
 	_ = json.Unmarshal(rec.Body.Bytes(), &got)
-	if got.HealthPollSecs != 9 || got.StickyEnabled {
+	if got.HealthPollSecs != 9 || got.RetryAttempts != 3 {
 		t.Errorf("settings not updated: %+v", got)
 	}
 

--- a/internal/frontdesk/store.go
+++ b/internal/frontdesk/store.go
@@ -74,12 +74,11 @@ type Member struct {
 // Settings shape the generated Traefik config and the pollers. The single row
 // (id = 1) is seeded with defaults by the first migration.
 type Settings struct {
-	HealthPollSecs     int  `json:"health_poll_secs"`
-	TraefikPollSecs    int  `json:"traefik_poll_secs"`
-	TraefikStaleSecs   int  `json:"traefik_stale_secs"`
-	EventRetentionDays int  `json:"event_retention_days"`
-	RetryAttempts      int  `json:"retry_attempts"`
-	StickyEnabled      bool `json:"sticky_enabled"`
+	HealthPollSecs     int `json:"health_poll_secs"`
+	TraefikPollSecs    int `json:"traefik_poll_secs"`
+	TraefikStaleSecs   int `json:"traefik_stale_secs"`
+	EventRetentionDays int `json:"event_retention_days"`
+	RetryAttempts      int `json:"retry_attempts"`
 }
 
 // Event is a control-plane fact (membership change, health transition, config
@@ -383,15 +382,13 @@ func (s *Store) encryptToken(token string) (cipher, nonce, salt []byte, err erro
 // GetSettings returns the single settings row.
 func (s *Store) GetSettings(ctx context.Context) (Settings, error) {
 	var set Settings
-	var sticky int
 	err := s.db.QueryRowContext(ctx,
-		`SELECT health_poll_secs, traefik_poll_secs, traefik_stale_secs, event_retention_days, retry_attempts, sticky_enabled
+		`SELECT health_poll_secs, traefik_poll_secs, traefik_stale_secs, event_retention_days, retry_attempts
 		 FROM settings WHERE id = 1`,
-	).Scan(&set.HealthPollSecs, &set.TraefikPollSecs, &set.TraefikStaleSecs, &set.EventRetentionDays, &set.RetryAttempts, &sticky)
+	).Scan(&set.HealthPollSecs, &set.TraefikPollSecs, &set.TraefikStaleSecs, &set.EventRetentionDays, &set.RetryAttempts)
 	if err != nil {
 		return Settings{}, fmt.Errorf("frontdesk: get settings: %w", err)
 	}
-	set.StickyEnabled = sticky != 0
 	return set, nil
 }
 
@@ -408,9 +405,9 @@ func (s *Store) UpdateSettings(ctx context.Context, set Settings) error {
 	}
 	_, err := s.db.ExecContext(ctx,
 		`UPDATE settings SET health_poll_secs = ?, traefik_poll_secs = ?, traefik_stale_secs = ?,
-		 event_retention_days = ?, retry_attempts = ?, sticky_enabled = ? WHERE id = 1`,
+		 event_retention_days = ?, retry_attempts = ? WHERE id = 1`,
 		set.HealthPollSecs, set.TraefikPollSecs, set.TraefikStaleSecs,
-		set.EventRetentionDays, set.RetryAttempts, boolToInt(set.StickyEnabled),
+		set.EventRetentionDays, set.RetryAttempts,
 	)
 	if err != nil {
 		return fmt.Errorf("frontdesk: update settings: %w", err)

--- a/internal/frontdesk/store_test.go
+++ b/internal/frontdesk/store_test.go
@@ -208,13 +208,13 @@ func TestSettingsDefaultsAndUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetSettings: %v", err)
 	}
-	if def.HealthPollSecs != 5 || def.EventRetentionDays != 90 || def.RetryAttempts != 2 || !def.StickyEnabled {
+	if def.HealthPollSecs != 5 || def.EventRetentionDays != 90 || def.RetryAttempts != 2 {
 		t.Errorf("unexpected defaults: %+v", def)
 	}
 
 	updated := Settings{
 		HealthPollSecs: 10, TraefikPollSecs: 7, TraefikStaleSecs: 60,
-		EventRetentionDays: 30, RetryAttempts: 0, StickyEnabled: false,
+		EventRetentionDays: 30, RetryAttempts: 0,
 	}
 	if err := s.UpdateSettings(ctx, updated); err != nil {
 		t.Fatalf("UpdateSettings: %v", err)

--- a/internal/frontdesk/traefik.go
+++ b/internal/frontdesk/traefik.go
@@ -15,7 +15,6 @@ const (
 	traefikServiceName     = "hotel"
 	traefikRetryMiddleware = "hotel-retry"
 	traefikEntryPoint      = "web"
-	traefikStickyCookie    = "mh_lb"
 	traefikHealthPath      = "/health"
 	// traefikRouterRule scopes the data plane to the OpenAI-compatible proxy
 	// only. The LB is a streaming front door, NOT a way to reach member
@@ -50,7 +49,7 @@ type TraefikService struct {
 	LoadBalancer TraefikLoadBalancer `json:"loadBalancer"`
 }
 
-// TraefikLoadBalancer is the backend pool with optional health check + sticky.
+// TraefikLoadBalancer is the backend pool with an optional active health check.
 type TraefikLoadBalancer struct {
 	Servers []TraefikServer `json:"servers"`
 	// PassHostHeader is deliberately false: each member is addressed by its own
@@ -63,7 +62,6 @@ type TraefikLoadBalancer struct {
 	// Traefik defaults this to true, so the false must be emitted explicitly.
 	PassHostHeader bool                `json:"passHostHeader"`
 	HealthCheck    *TraefikHealthCheck `json:"healthCheck,omitempty"`
-	Sticky         *TraefikSticky      `json:"sticky,omitempty"`
 }
 
 // TraefikServer is one backend URL.
@@ -76,16 +74,6 @@ type TraefikHealthCheck struct {
 	Path     string `json:"path"`
 	Interval string `json:"interval"`
 	Timeout  string `json:"timeout"`
-}
-
-// TraefikSticky pins a browser session (and its SSE) to one backend via cookie.
-type TraefikSticky struct {
-	Cookie TraefikCookie `json:"cookie"`
-}
-
-// TraefikCookie names the sticky cookie.
-type TraefikCookie struct {
-	Name string `json:"name"`
 }
 
 // TraefikMiddleware is a single middleware entry; only retry is used.
@@ -101,8 +89,7 @@ type TraefikRetry struct {
 // BuildTraefikConfig renders the dynamic config from the current members and
 // settings. Only active members enter the backend pool: a drained member is
 // removed from servers so its established streams finish while new requests go
-// elsewhere. Retry is included only when attempts >= 1; sticky only when the
-// setting is on.
+// elsewhere. Retry is included only when attempts >= 1.
 func BuildTraefikConfig(members []*Member, set Settings) TraefikConfig {
 	servers := make([]TraefikServer, 0, len(members))
 	for _, m := range members {
@@ -115,9 +102,6 @@ func BuildTraefikConfig(members []*Member, set Settings) TraefikConfig {
 		Servers:        servers,
 		PassHostHeader: false, // address each member by its own host; see field doc
 		HealthCheck:    buildHealthCheck(set),
-	}
-	if set.StickyEnabled {
-		lb.Sticky = &TraefikSticky{Cookie: TraefikCookie{Name: traefikStickyCookie}}
 	}
 
 	router := TraefikRouter{

--- a/internal/frontdesk/traefik_test.go
+++ b/internal/frontdesk/traefik_test.go
@@ -9,7 +9,7 @@ import (
 func defaultSettings() Settings {
 	return Settings{
 		HealthPollSecs: 5, TraefikPollSecs: 5, TraefikStaleSecs: 30,
-		EventRetentionDays: 90, RetryAttempts: 2, StickyEnabled: true,
+		EventRetentionDays: 90, RetryAttempts: 2,
 	}
 }
 
@@ -73,13 +73,10 @@ func TestBuildTraefikConfigDoesNotPassHostHeader(t *testing.T) {
 	}
 }
 
-func TestBuildTraefikConfigStickyAndHealthCheck(t *testing.T) {
+func TestBuildTraefikConfigHealthCheck(t *testing.T) {
 	cfg := BuildTraefikConfig(nil, defaultSettings())
 	lb := cfg.HTTP.Services[traefikServiceName].LoadBalancer
 
-	if lb.Sticky == nil || lb.Sticky.Cookie.Name != traefikStickyCookie {
-		t.Errorf("sticky cookie not set: %+v", lb.Sticky)
-	}
 	if lb.HealthCheck == nil || lb.HealthCheck.Path != "/health" {
 		t.Fatalf("health check missing: %+v", lb.HealthCheck)
 	}
@@ -88,12 +85,15 @@ func TestBuildTraefikConfigStickyAndHealthCheck(t *testing.T) {
 	}
 }
 
-func TestBuildTraefikConfigStickyDisabled(t *testing.T) {
-	set := defaultSettings()
-	set.StickyEnabled = false
-	cfg := BuildTraefikConfig(nil, set)
-	if cfg.HTTP.Services[traefikServiceName].LoadBalancer.Sticky != nil {
-		t.Error("sticky should be omitted when disabled")
+// Sticky sessions were removed: the LB serves only /v1, which never carries the
+// dashboard cookie, so the generated config must not emit a sticky stanza.
+func TestBuildTraefikConfigNoSticky(t *testing.T) {
+	out, err := json.Marshal(BuildTraefikConfig(nil, defaultSettings()))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(out), "sticky") {
+		t.Errorf("serialized config still mentions sticky: %s", out)
 	}
 }
 


### PR DESCRIPTION
Sticky sessions pinned a browser dashboard (and its SSE stream) to one backend via the `mh_lb` cookie. That mattered when the load balancer fronted the dashboard, but the LB now serves only the OpenAI-compatible proxy (router rule `PathPrefix(`/v1`)`): dashboards are reached per-member by their own URL and never traverse the LB, and `/v1` API clients do not carry the cookie. The toggle therefore did nothing, so this removes it end to end.

## Changes

**Backend**
- Drop `StickyEnabled` from `Settings` (struct, `GetSettings`, `UpdateSettings`).
- Remove the `Sticky` / `TraefikSticky` / `TraefikCookie` types and the `mh_lb` cookie wiring in `traefik.go`.
- Add migration `006_drop_sticky.sql` to `DROP COLUMN sticky_enabled` (`001_init.sql` left immutable; fresh installs create-then-drop, existing installs just drop).

**Frontend**
- Remove the Settings toggle, the `sticky_enabled` type field, and the two i18n strings.

**Tests**
- Rework the Traefik sticky tests into a health-check test plus a regression asserting the generated config emits no sticky stanza.
- Drop sticky assertions and request bodies from `store_test`, `server_test`, `coverage_test`, and `SettingsPage.test`.

## Verification
- `go test ./internal/frontdesk/...` green (migration 006 exercised), `golangci-lint` clean.
- Front Desk web: `tsc -b` exit 0, `biome` clean, full suite 61/61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)