### PR TITLE
feat(ha): enforce managed-member read-only on the server

### DIFF
--- a/docs/HA.md
+++ b/docs/HA.md
@@ -184,11 +184,15 @@ It reuses the same machinery as the wizard, with the same safety properties:
   skipped untouched, and a member that is unreachable or `MASTER_KEY`-blocked is
   retried on the next check rather than overwritten.
 
-It reacts to *changes on the primary*, it is not a continuous reconciler. If you
-edit a replica directly (you shouldn't, managed members are read-only), that drift
-sits until the **primary** next changes, at which point the full config is pushed
-and the replica is brought back in line. There is no constant revert loop watching
-each replica.
+It reacts to *changes on the primary*, it is not a continuous reconciler. A managed
+member is read-only for synced config: the dashboard hides the create/edit/delete
+controls, and the API itself refuses those writes with a 403 (providers, virtual
+keys, custom failover groups, and synced settings), so a stale tab or a direct
+`curl` cannot quietly change config the next sync would overwrite. Instance-local
+settings (Apprise alert routing, observability) and the failover **Sync** action
+stay editable. Any drift you do manage to introduce sits until the **primary** next
+changes, at which point the full config is pushed and the replica is brought back
+in line. There is no constant revert loop watching each replica.
 
 Automatic sync is **off by default** and is the opposite trade-off from the
 wizard: convenience over the per-change diff review. Leave it off if you want a

--- a/docs/HA.md
+++ b/docs/HA.md
@@ -189,8 +189,8 @@ member is read-only for synced config: the dashboard hides the create/edit/delet
 controls, and the API itself refuses those writes with a 403 (providers, virtual
 keys, custom failover groups, and synced settings), so a stale tab or a direct
 `curl` cannot quietly change config the next sync would overwrite. Instance-local
-settings (Apprise alert routing, observability) and the failover **Sync** action
-stay editable. Any drift you do manage to introduce sits until the **primary** next
+Apprise alert routing and the failover **Sync** action stay editable. Any drift you
+do manage to introduce sits until the **primary** next
 changes, at which point the full config is pushed and the replica is brought back
 in line. There is no constant revert loop watching each replica.
 

--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -231,11 +231,18 @@ func (h *Handler) Register(r chi.Router) {
 	}
 
 	r.Route("/providers", func(r chi.Router) {
-		r.Post("/", h.CreateProvider)
 		r.Get("/", h.ListProviders)
 		r.Get("/{id}", h.GetProvider)
-		r.Put("/{id}", h.UpdateProvider)
-		r.Delete("/{id}", h.DeleteProvider)
+		// Provider CRUD is synced config: a managed fleet member must not edit it
+		// locally (the primary owns it and replaces it on the next sync). Discovery
+		// routes under /providers (mounted via RegisterProviderDiscovery) are
+		// deliberately outside this group: models regenerate and are not synced.
+		r.Group(func(r chi.Router) {
+			r.Use(managedWriteGuard(h.settingsRepo))
+			r.Post("/", h.CreateProvider)
+			r.Put("/{id}", h.UpdateProvider)
+			r.Delete("/{id}", h.DeleteProvider)
+		})
 	})
 
 	h.RegisterModels(r)

--- a/internal/api/failover.go
+++ b/internal/api/failover.go
@@ -112,14 +112,21 @@ type FailoverGroupBrief struct {
 func (h *FailoverHandler) Register(r chi.Router) {
 	r.Route("/failover-groups", func(r chi.Router) {
 		r.Get("/", h.List)
-		r.Post("/", h.Create)
 		r.Post("/sync", h.Sync)
 		r.Get("/candidates", h.Candidates)
 		r.Get("/by-model/{model_uuid}", h.GetByModelUUID)
 		r.Get("/circuit-breaker-status", h.CircuitBreakerStatus)
 		r.Get("/{id}", h.Get)
-		r.Put("/{id}", h.Update)
-		r.Delete("/{id}", h.Delete)
+		// Custom failover groups are synced config: a managed fleet member must not
+		// create/edit/delete them locally (the primary owns them and replaces them
+		// on the next sync). Sync is exempt: it only regenerates auto-created groups
+		// from the already-synced providers, which the UI also keeps available.
+		r.Group(func(r chi.Router) {
+			r.Use(managedWriteGuard(h.settingsRepo))
+			r.Post("/", h.Create)
+			r.Put("/{id}", h.Update)
+			r.Delete("/{id}", h.Delete)
+		})
 	})
 }
 

--- a/internal/api/managedwrite.go
+++ b/internal/api/managedwrite.go
@@ -1,0 +1,76 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+// This file enforces, on the server, the same read-only contract the dashboard
+// already shows for a managed fleet member. When this instance is an actively
+// managed member (Front Desk in contact, non-primary, fresh heartbeat), its
+// synced entities (providers, virtual keys, custom failover groups, syncable
+// settings) are declaratively replaced on the next config sync. The UI hides the
+// create/edit/delete affordances for those (see web/src/hooks/useManaged.ts), but
+// a direct API call, a second tab, or a page loaded before enrollment can still
+// reach the write handlers. Such a write would "succeed" and then be silently
+// undone on the next sync, which looks like data loss. We refuse it instead.
+//
+// The guard mirrors readOnlyGuard (readonly.go) but differs in two ways: it is
+// dynamic (the managed state is computed per request, not a startup flag), and it
+// is mounted only on the synced-entity write routes rather than the whole admin
+// surface, so models/discovery, failover sync, config import, fleet announce,
+// backups, and auth stay usable on a managed member.
+
+// managedWriteMsg is the 403 body returned when a synced-entity write is refused
+// because this instance is a managed fleet member.
+const managedWriteMsg = "this instance is managed by the fleet primary; " +
+	"providers, virtual keys, failover groups, and synced settings are replaced " +
+	"on the next sync and cannot be edited here. Change them on the primary."
+
+// isManagedMember reports whether this instance is an actively managed fleet
+// member: Front Desk is in contact AND this node is a non-primary member with a
+// fresh heartbeat (fleet state "member"). It reads the cached _fleet_* settings
+// via computeFleetStatus, so it is cheap enough to call on a write request.
+// "primary", "warning" (stale heartbeat), and standalone (nil) all return false,
+// matching useManaged: an operator is never locked out when Front Desk is away.
+func isManagedMember(ctx context.Context, fs fleetSettings) bool {
+	st := computeFleetStatus(ctx, fs, time.Now())
+	return st != nil && st.State == "member"
+}
+
+// managedBlocksSyncableSettings reports whether a settings write touching the
+// given keys must be refused because this instance is a managed member. A write
+// is refused only when at least one key is syncable (config-sync replicates it);
+// instance-local keys (Apprise routing, Observability) are always allowed, which
+// is why settings cannot use the route-level managedWriteGuard: one PUT carries a
+// mix of synced and instance-local keys.
+func managedBlocksSyncableSettings(ctx context.Context, fs fleetSettings, keys []string) bool {
+	if !isManagedMember(ctx, fs) {
+		return false
+	}
+	for _, k := range keys {
+		if isSyncableSetting(k) {
+			return true
+		}
+	}
+	return false
+}
+
+// managedWriteGuard returns middleware that refuses a request with 403 when this
+// instance is a managed fleet member. Mount it ONLY on synced-entity write routes
+// (providers, virtual keys, custom failover group CRUD): every request that
+// reaches it is treated as such a write, so it does no method or path inspection.
+func managedWriteGuard(fs fleetSettings) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if isManagedMember(r.Context(), fs) {
+				// nil err + a 4xx code: respondError does not log this (it is a
+				// client-facing policy rejection, not a server fault).
+				respondError(w, managedWriteMsg, nil, http.StatusForbidden)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/internal/api/managedwrite.go
+++ b/internal/api/managedwrite.go
@@ -34,6 +34,13 @@ const managedWriteMsg = "this instance is managed by the fleet primary; " +
 // via computeFleetStatus, so it is cheap enough to call on a write request.
 // "primary", "warning" (stale heartbeat), and standalone (nil) all return false,
 // matching useManaged: an operator is never locked out when Front Desk is away.
+//
+// The guard is not instantaneous: the _fleet_* reads go through the settings
+// cache (~30s TTL), so a node that has just become a member can briefly still
+// accept a write. That fail-open-on-stale window is the correct posture here, not
+// a bug. The enforcement is defense-in-depth for the read-only UI, not a
+// consistency boundary, and any write that slips through is reconciled by the
+// next config sync (the primary remains the source of truth).
 func isManagedMember(ctx context.Context, fs fleetSettings) bool {
 	st := computeFleetStatus(ctx, fs, time.Now())
 	return st != nil && st.State == "member"

--- a/internal/api/managedwrite_test.go
+++ b/internal/api/managedwrite_test.go
@@ -1,0 +1,172 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// memberFleetSettings seeds a fakeFleetSettings to the "member" state: a fresh
+// heartbeat (well within fleetManagedTTL) from a non-primary node. isManagedMember
+// uses the real clock, so the timestamp is relative to time.Now().
+func memberFleetSettings() *fakeFleetSettings {
+	return &fakeFleetSettings{values: map[string]string{
+		keyFleetManagedSeenAt: time.Now().Add(-5 * time.Second).Format(time.RFC3339),
+		keyFleetIsPrimary:     "false",
+	}}
+}
+
+func TestIsManagedMember(t *testing.T) {
+	fresh := func() string { return time.Now().Add(-5 * time.Second).Format(time.RFC3339) }
+	stale := func() string { return time.Now().Add(-(fleetManagedTTL + time.Minute)).Format(time.RFC3339) }
+
+	tests := []struct {
+		name   string
+		values map[string]string
+		want   bool
+	}{
+		{"member: fresh non-primary", map[string]string{keyFleetManagedSeenAt: fresh(), keyFleetIsPrimary: "false"}, true},
+		{"primary: fresh primary", map[string]string{keyFleetManagedSeenAt: fresh(), keyFleetIsPrimary: "true"}, false},
+		{"warning: stale heartbeat", map[string]string{keyFleetManagedSeenAt: stale(), keyFleetIsPrimary: "false"}, false},
+		{"standalone: never contacted", map[string]string{}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := &fakeFleetSettings{values: tt.values}
+			if got := isManagedMember(context.Background(), fs); got != tt.want {
+				t.Errorf("isManagedMember = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestManagedWriteGuard verifies the middleware in isolation: on a managed member
+// it refuses the request with 403 and never calls next; otherwise it passes
+// through. The guard is mounted only on write routes, so it is intentionally
+// method-agnostic (every request that reaches it is already a synced-entity write).
+func TestManagedWriteGuard(t *testing.T) {
+	var called bool
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// Managed member: refused.
+	called = false
+	rec := httptest.NewRecorder()
+	managedWriteGuard(memberFleetSettings())(next).ServeHTTP(
+		rec, httptest.NewRequest(http.MethodPost, "/providers", http.NoBody))
+	if called {
+		t.Error("managed member: next handler must not be called")
+	}
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("managed member: expected 403, got %d", rec.Code)
+	}
+
+	// Primary / standalone: passes through.
+	for _, fs := range []*fakeFleetSettings{
+		{values: map[string]string{keyFleetManagedSeenAt: time.Now().Add(-5 * time.Second).Format(time.RFC3339), keyFleetIsPrimary: "true"}},
+		newFakeFleetSettings(), // standalone
+	} {
+		called = false
+		rec = httptest.NewRecorder()
+		managedWriteGuard(fs)(next).ServeHTTP(
+			rec, httptest.NewRequest(http.MethodPost, "/providers", http.NoBody))
+		if !called || rec.Code != http.StatusOK {
+			t.Errorf("non-member: expected pass-through 200, got code=%d called=%v", rec.Code, called)
+		}
+	}
+}
+
+// TestManagedBlocksSyncableSettings covers the per-key settings policy: a managed
+// member is blocked only when a write touches a syncable key. An instance-local
+// apprise key passes (mirroring the mixed Alerts section in the dashboard), and a
+// non-member is never blocked.
+func TestManagedBlocksSyncableSettings(t *testing.T) {
+	member := memberFleetSettings()
+	primary := &fakeFleetSettings{values: map[string]string{
+		keyFleetManagedSeenAt: time.Now().Add(-5 * time.Second).Format(time.RFC3339),
+		keyFleetIsPrimary:     "true",
+	}}
+
+	tests := []struct {
+		name string
+		fs   *fakeFleetSettings
+		keys []string
+		want bool
+	}{
+		{"member + syncable key", member, []string{"alert_enabled"}, true},
+		{"member + apprise-only key", member, []string{"alert_apprise_api_url"}, false},
+		{"member + mixed batch", member, []string{"alert_apprise_api_url", "alert_enabled"}, true},
+		{"member + no keys", member, nil, false},
+		{"primary + syncable key", primary, []string{"alert_enabled"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := managedBlocksSyncableSettings(context.Background(), tt.fs, tt.keys); got != tt.want {
+				t.Errorf("managedBlocksSyncableSettings(%v) = %v, want %v", tt.keys, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestHandlerRegister_ManagedMember verifies the wiring end to end on a real
+// router: while this instance is a managed member, synced-entity writes are
+// refused with 403, but reads, the failover sync (auto-group regeneration), and
+// instance-local apprise settings stay usable. Flipping to primary lifts the lock.
+func TestHandlerRegister_ManagedMember(t *testing.T) {
+	h, r := newTestHandlerWithRouter(t) // skips if no test DB
+	ctx := context.Background()
+
+	// Enroll this instance as a fresh, non-primary fleet member.
+	if err := h.settingsRepo.Set(ctx, keyFleetManagedSeenAt, time.Now().Format(time.RFC3339)); err != nil {
+		t.Fatal(err)
+	}
+	if err := h.settingsRepo.Set(ctx, keyFleetIsPrimary, "false"); err != nil {
+		t.Fatal(err)
+	}
+
+	auth := func(req *http.Request) *http.Request {
+		req.Header.Set("Authorization", "Bearer test-admin-token")
+		return req
+	}
+	do := func(method, path, body string) int {
+		rec := httptest.NewRecorder()
+		req := auth(httptest.NewRequest(method, path, strings.NewReader(body)))
+		if body != "" {
+			req.Header.Set("Content-Type", "application/json")
+		}
+		r.ServeHTTP(rec, req)
+		return rec.Code
+	}
+
+	// Synced-entity writes are refused.
+	if code := do(http.MethodPost, "/providers", `{"name":"x","base_url":"http://localhost:1234"}`); code != http.StatusForbidden {
+		t.Errorf("managed POST /providers: expected 403, got %d", code)
+	}
+	if code := do(http.MethodPut, "/settings", `{"alert_enabled":"true"}`); code != http.StatusForbidden {
+		t.Errorf("managed PUT /settings (syncable): expected 403, got %d", code)
+	}
+
+	// Reads, failover sync, and instance-local apprise settings stay usable.
+	if code := do(http.MethodGet, "/providers", ""); code != http.StatusOK {
+		t.Errorf("managed GET /providers: expected 200, got %d", code)
+	}
+	if code := do(http.MethodPost, "/failover-groups/sync", ""); code == http.StatusForbidden {
+		t.Errorf("managed POST /failover-groups/sync: must be exempt, got 403")
+	}
+	if code := do(http.MethodPut, "/settings", `{"alert_apprise_api_url":"http://apprise:8000"}`); code != http.StatusOK {
+		t.Errorf("managed PUT /settings (apprise-only): expected 200, got %d", code)
+	}
+
+	// Promotion to primary lifts the lock.
+	if err := h.settingsRepo.Set(ctx, keyFleetIsPrimary, "true"); err != nil {
+		t.Fatal(err)
+	}
+	if code := do(http.MethodPost, "/providers", `{"name":"y","base_url":"http://localhost:1234"}`); code == http.StatusForbidden {
+		t.Errorf("primary POST /providers: must not be refused with 403")
+	}
+}

--- a/internal/api/managedwrite_test.go
+++ b/internal/api/managedwrite_test.go
@@ -133,40 +133,55 @@ func TestHandlerRegister_ManagedMember(t *testing.T) {
 		req.Header.Set("Authorization", "Bearer test-admin-token")
 		return req
 	}
-	do := func(method, path, body string) int {
+	do := func(method, path, body string) (int, string) {
 		rec := httptest.NewRecorder()
 		req := auth(httptest.NewRequest(method, path, strings.NewReader(body)))
 		if body != "" {
 			req.Header.Set("Content-Type", "application/json")
 		}
 		r.ServeHTTP(rec, req)
-		return rec.Code
+		return rec.Code, rec.Body.String()
 	}
 
-	// Synced-entity writes are refused.
-	if code := do(http.MethodPost, "/providers", `{"name":"x","base_url":"http://localhost:1234"}`); code != http.StatusForbidden {
-		t.Errorf("managed POST /providers: expected 403, got %d", code)
-	}
-	if code := do(http.MethodPut, "/settings", `{"alert_enabled":"true"}`); code != http.StatusForbidden {
-		t.Errorf("managed PUT /settings (syncable): expected 403, got %d", code)
+	// Synced-entity writes are refused across every guarded route. Bodies can be
+	// minimal: the guard middleware runs before the handler parses them.
+	for _, w := range []struct{ name, method, path, body string }{
+		{"POST /providers", http.MethodPost, "/providers", `{"name":"x","base_url":"http://localhost:1234"}`},
+		{"POST /virtual-keys", http.MethodPost, "/virtual-keys", `{}`},
+		{"POST /failover-groups", http.MethodPost, "/failover-groups", `{}`},
+		{"PUT /settings (syncable)", http.MethodPut, "/settings", `{"alert_enabled":"true"}`},
+		{"DELETE /settings (reset all)", http.MethodDelete, "/settings", `{}`},
+	} {
+		if code, _ := do(w.method, w.path, w.body); code != http.StatusForbidden {
+			t.Errorf("managed %s: expected 403, got %d", w.name, code)
+		}
 	}
 
 	// Reads, failover sync, and instance-local apprise settings stay usable.
-	if code := do(http.MethodGet, "/providers", ""); code != http.StatusOK {
+	if code, _ := do(http.MethodGet, "/providers", ""); code != http.StatusOK {
 		t.Errorf("managed GET /providers: expected 200, got %d", code)
 	}
-	if code := do(http.MethodPost, "/failover-groups/sync", ""); code == http.StatusForbidden {
+	if code, _ := do(http.MethodPost, "/failover-groups/sync", ""); code == http.StatusForbidden {
 		t.Errorf("managed POST /failover-groups/sync: must be exempt, got 403")
 	}
-	if code := do(http.MethodPut, "/settings", `{"alert_apprise_api_url":"http://apprise:8000"}`); code != http.StatusOK {
+	if code, _ := do(http.MethodPut, "/settings", `{"alert_apprise_api_url":"http://apprise:8000"}`); code != http.StatusOK {
 		t.Errorf("managed PUT /settings (apprise-only): expected 200, got %d", code)
 	}
+	// Reset of an instance-local key only (no syncable key in the batch) is allowed.
+	if code, _ := do(http.MethodDelete, "/settings", `{"keys":["alert_apprise_api_url"]}`); code != http.StatusOK {
+		t.Errorf("managed DELETE /settings (apprise-only): expected 200, got %d", code)
+	}
 
-	// Promotion to primary lifts the lock.
+	// Promotion to primary lifts the lock: the write is not just un-refused, it
+	// persists (the provider is created and then listed).
 	if err := h.settingsRepo.Set(ctx, keyFleetIsPrimary, "true"); err != nil {
 		t.Fatal(err)
 	}
-	if code := do(http.MethodPost, "/providers", `{"name":"y","base_url":"http://localhost:1234"}`); code == http.StatusForbidden {
-		t.Errorf("primary POST /providers: must not be refused with 403")
+	if code, _ := do(http.MethodPost, "/providers", `{"name":"primary-prov","base_url":"http://localhost:1234"}`); code != http.StatusCreated {
+		t.Errorf("primary POST /providers: expected 201 Created, got %d", code)
+	}
+	code, body := do(http.MethodGet, "/providers", "")
+	if code != http.StatusOK || !strings.Contains(body, "primary-prov") {
+		t.Errorf("primary GET /providers: expected the created provider to persist, got code=%d body=%q", code, body)
 	}
 }

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -211,6 +211,19 @@ func (h *Handler) UpdateSettings(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// A managed fleet member must not edit synced settings locally: the primary
+	// owns them and replaces them on the next sync. Instance-local keys (Apprise,
+	// Observability) are allowed through, mirroring the mixed Alerts section in the
+	// dashboard. Checked after validation so an unknown key still reports 400.
+	reqKeys := make([]string, 0, len(req))
+	for key := range req {
+		reqKeys = append(reqKeys, key)
+	}
+	if managedBlocksSyncableSettings(r.Context(), h.settingsRepo, reqKeys) {
+		respondError(w, managedWriteMsg, nil, http.StatusForbidden)
+		return
+	}
+
 	// Encrypt secret values at rest. A masked (unchanged) submission is dropped
 	// so the stored ciphertext is preserved; an empty value clears the secret.
 	if err := h.encryptSecretSettings(req); err != nil {
@@ -291,6 +304,15 @@ func (h *Handler) ResetSettings(w http.ResponseWriter, r *http.Request) {
 			respondBadRequest(w, fmt.Sprintf("unknown setting: %s", key), nil)
 			return
 		}
+	}
+
+	// A managed fleet member must not reset synced settings locally (including the
+	// "reset all" expansion, which covers syncable keys): the primary owns them
+	// and replaces them on the next sync. An Apprise/Observability-only reset is
+	// allowed through.
+	if managedBlocksSyncableSettings(r.Context(), h.settingsRepo, keys) {
+		respondError(w, managedWriteMsg, nil, http.StatusForbidden)
+		return
 	}
 
 	tx, err := h.dbPool.Begin(r.Context())

--- a/internal/api/virtualkeys.go
+++ b/internal/api/virtualkeys.go
@@ -60,11 +60,16 @@ func (r *UpdateVirtualKeyRequest) UnmarshalJSON(data []byte) error {
 // RegisterVirtualKeys mounts virtual key management routes.
 func (h *Handler) RegisterVirtualKeys(r chi.Router) {
 	r.Route("/virtual-keys", func(r chi.Router) {
-		r.Post("/", h.CreateVirtualKey)
 		r.Get("/", h.ListVirtualKeys)
 		r.Get("/{id}", h.GetVirtualKey)
-		r.Put("/{id}", h.UpdateVirtualKey)
-		r.Delete("/{id}", h.DeleteVirtualKey)
+		// Virtual keys are synced config: a managed fleet member must not edit them
+		// locally (the primary owns them and replaces them on the next sync).
+		r.Group(func(r chi.Router) {
+			r.Use(managedWriteGuard(h.settingsRepo))
+			r.Post("/", h.CreateVirtualKey)
+			r.Put("/{id}", h.UpdateVirtualKey)
+			r.Delete("/{id}", h.DeleteVirtualKey)
+		})
 	})
 }
 


### PR DESCRIPTION
## What & why

PR #303 made a managed fleet member's synced config read-only **in the dashboard UI**: when an instance is an actively-managed member (`fleet.state == "member"`), the create/edit/delete affordances on Providers, Virtual Keys, custom Failover Groups, and the synced Settings sections are hidden.

That guard was **client-only**. A direct API call, a second tab, or a page loaded before enrollment could still POST/PUT/DELETE those entities. The write "succeeds" and is then silently undone on the next config sync, which looks like data loss. This PR adds the matching **server-side** enforcement so the backend itself refuses those writes while the instance is a managed member: defense-in-depth that makes the UI's read-only contract real.

## How

- New `internal/api/managedwrite.go`: `managedWriteGuard(fs)` middleware (modeled on the existing `readOnlyGuard`) plus `isManagedMember()` and `managedBlocksSyncableSettings()`. Refuses with `403` only when fleet state is `"member"`; `primary`, `warning` (stale heartbeat), and standalone all pass, so an operator is never locked out when Front Desk is away.
- **Mounted only on the synced-entity write routes** via chi route groups: provider CRUD (`admin.go`), virtual-key CRUD (`virtualkeys.go`), and custom failover-group CRUD (`failover.go`). Models/discovery, the failover **Sync** action, config import, fleet announce, backups, and auth are deliberately left open (none are synced / overwritten).
- **Settings is gated per key** (`settings.go`, `UpdateSettings` + `ResetSettings`): a write is refused only when it touches a *syncable* key (`isSyncableSetting`). Instance-local Apprise routing stays editable, mirroring the dashboard's mixed Alerts section. The "reset all" expansion is covered.

The guard is fail-open-on-stale by design: the `_fleet_*` reads go through the settings cache (~30s), so a just-enrolled member can briefly still write; that window self-heals on the next sync (the primary is the source of truth). Noted in a code comment.

## Tests

`internal/api/managedwrite_test.go`:
- Unit: `isManagedMember` across member/primary/warning/standalone; the middleware in isolation; the per-key settings policy (syncable / apprise-only / mixed / empty).
- Router wiring (DB-gated): managed member gets `403` on provider / virtual-key / failover-group CRUD and on syncable + "reset all" settings writes; `GET`, failover `Sync`, and apprise-only settings stay usable; promotion to primary lifts the lock and the provider **persists** (created + listed).

No frontend, migration, or version change.

## Verification

- `go test ./internal/api/` → ok (full package, no regressions)
- `golangci-lint run ./...` → 0 issues