### PR TITLE
feat(version): stamp source commit SHA into builds, show in sidebar tooltip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -472,6 +472,9 @@ jobs:
           context: .
           load: true
           tags: model-hotel:dev-candidate
+          # VERSION is left at its `dev` default; stamp the source SHA so the
+          # dashboard can show which commit this :dev image was built from.
+          build-args: COMMIT=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -98,7 +98,9 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: VERSION=${{ steps.version.outputs.tag }}
+          build-args: |
+            VERSION=${{ steps.version.outputs.tag }}
+            COMMIT=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,9 +32,13 @@ COPY . .
 COPY --from=frontend-builder /app/web/dist ./cmd/server/static/
 
 ARG VERSION=dev
+# Short SHA of the source commit. The .git dir is excluded from the build
+# context (.dockerignore), so it is passed in as a build arg rather than
+# derived in-image.
+ARG COMMIT=unknown
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    go build -ldflags "-X main.version=$VERSION" -o server ./cmd/server/
+    go build -ldflags "-X main.version=$VERSION -X github.com/hugalafutro/model-hotel/internal/api.buildCommit=$COMMIT" -o server ./cmd/server/
 
 # Stage 3: Minimal runtime image
 FROM alpine:3.24

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,9 +32,9 @@ COPY . .
 COPY --from=frontend-builder /app/web/dist ./cmd/server/static/
 
 ARG VERSION=dev
-# Short SHA of the source commit. The .git dir is excluded from the build
-# context (.dockerignore), so it is passed in as a build arg rather than
-# derived in-image.
+# Source commit SHA. The .git dir is excluded from the build context
+# (.dockerignore), so it is passed in as a build arg rather than derived
+# in-image. The backend shortens it for display.
 ARG COMMIT=unknown
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,12 @@
 .PHONY: build run clean test lint fmt deps docker-up docker-build docker-down docker-logs totp-disable test-db-up test-db-down setup notices frontdesk-build ha-up ha-down ha-logs
 
 VERSION := $(shell cat .version 2>/dev/null || git describe --tags --always --dirty 2>/dev/null || echo dev)
+# Short SHA of the commit this binary is built from, stamped into the API package
+# so the dashboard can show exactly which commit a `dev` build corresponds to.
+COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
 
 build:
-	go build -ldflags "-X main.version=$(VERSION)" -o bin/server ./cmd/server/
+	go build -ldflags "-X main.version=$(VERSION) -X github.com/hugalafutro/model-hotel/internal/api.buildCommit=$(COMMIT)" -o bin/server ./cmd/server/
 
 run: build
 	./bin/server
@@ -30,7 +33,7 @@ docker-up:
 
 docker-build:
 	docker compose -f docker-compose.yml -f compose.dev.yml down
-	VERSION=$(VERSION) docker compose -f docker-compose.yml -f compose.dev.yml up -d --build
+	VERSION=$(VERSION) COMMIT=$(COMMIT) docker compose -f docker-compose.yml -f compose.dev.yml up -d --build
 
 docker-down:
 	docker compose -f docker-compose.yml -f compose.dev.yml down

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
 .PHONY: build run clean test lint fmt deps docker-up docker-build docker-down docker-logs totp-disable test-db-up test-db-down setup notices frontdesk-build ha-up ha-down ha-logs
 
 VERSION := $(shell cat .version 2>/dev/null || git describe --tags --always --dirty 2>/dev/null || echo dev)
-# Short SHA of the commit this binary is built from, stamped into the API package
+# Full SHA of the commit this binary is built from, stamped into the API package
 # so the dashboard can show exactly which commit a `dev` build corresponds to.
-COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
+# CI passes the full ${{ github.sha }} too; the backend shortens it for display,
+# so every build path feeds the same input and yields the same app_commit.
+COMMIT := $(shell git rev-parse HEAD 2>/dev/null || echo unknown)
 
 build:
 	go build -ldflags "-X main.version=$(VERSION) -X github.com/hugalafutro/model-hotel/internal/api.buildCommit=$(COMMIT)" -o bin/server ./cmd/server/

--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ ADMIN_TOKEN=
                 context: .
                 args:
                     VERSION: ${VERSION:-dev}
+                    COMMIT: ${COMMIT:-unknown}
             # Prebuilt images (uncomment 1 image according to registry preference, comment out build above):
             # image: ghcr.io/hugalafutro/model-hotel:latest
             # image: hugalafutro/model-hotel:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
             context: .
             args:
                 VERSION: ${VERSION:-dev}
+                COMMIT: ${COMMIT:-unknown}
         # Prebuilt images (uncomment 1 image according to registry preference, comment out build above):
         # image: ghcr.io/hugalafutro/model-hotel:latest
         # image: hugalafutro/model-hotel:latest

--- a/internal/api/handler_settings_test.go
+++ b/internal/api/handler_settings_test.go
@@ -387,6 +387,11 @@ func TestResetSettings_AllKeys(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
 		t.Fatalf("Failed to parse response: %v", err)
 	}
+	// app_commit is read-only and always present (defaults to "unknown" when
+	// the build was not stamped with a source SHA).
+	if result["app_commit"] == "" {
+		t.Error("app_commit should always be present")
+	}
 	// app_version is read-only and always present
 	if result["app_version"] == "" {
 		t.Error("app_version should always be present")

--- a/internal/api/handler_settings_test.go
+++ b/internal/api/handler_settings_test.go
@@ -19,6 +19,34 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/db"
 )
 
+func TestShortCommit(t *testing.T) {
+	full := "7a5eeac6aa758c56432a7dbc8cd059909800e390"
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty passes through", "", ""},
+		{"unknown sentinel passes through", "unknown", "unknown"},
+		{"full SHA truncated to 12", full, "7a5eeac6aa75"},
+		{"short SHA shorter than limit kept", "7a5eeac", "7a5eeac"},
+		{"exactly 12 kept", "7a5eeac6aa75", "7a5eeac6aa75"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shortCommit(tc.in); got != tc.want {
+				t.Errorf("shortCommit(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+	// A full and a short stamp of the same commit must normalize identically so
+	// app_commit reads the same across build paths.
+	if shortCommit(full) != shortCommit(full[:12]) {
+		t.Errorf("full and short stamps of the same commit diverge: %q vs %q",
+			shortCommit(full), shortCommit(full[:12]))
+	}
+}
+
 func TestGetSettings(t *testing.T) {
 
 	h := newTestHandler(t)

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -66,17 +66,37 @@ func (h *Handler) RegisterSettings(r chi.Router) {
 	})
 }
 
-// buildCommit is the short SHA of the source commit this binary was built from.
-// It is stamped at build time via -ldflags -X (see the Makefile / Dockerfile)
-// and surfaced read-only as app_commit so the dashboard can show which commit a
+// buildCommit is the SHA of the source commit this binary was built from. It is
+// stamped at build time via -ldflags -X (see the Makefile / Dockerfile) and
+// surfaced read-only as app_commit so the dashboard can show which commit a
 // `dev` build corresponds to. Defaults to "unknown" for un-stamped builds.
+//
+// Different build paths stamp different SHA lengths (local `make build` derives
+// a full SHA via git, CI passes the full ${{ github.sha }}), so the value is
+// normalized through shortCommit before it reaches the API to keep the
+// app_commit contract identical for the same commit regardless of build path.
 var buildCommit = "unknown"
+
+// shortCommit normalizes a stamped commit SHA to a fixed-length short prefix so
+// app_commit reads the same across build paths. The "unknown" sentinel and any
+// empty value pass through unchanged.
+func shortCommit(c string) string {
+	const shortLen = 12
+	if c == "" || c == "unknown" {
+		return c
+	}
+	if len(c) > shortLen {
+		return c[:shortLen]
+	}
+	return c
+}
 
 // injectReadOnlyStatus adds server-derived, read-only fields to a settings map
 // before it is returned to the client. These keys are deliberately excluded
 // from allowedSettings so they cannot be written via PUT /api/settings:
 //   - app_version: the running build (set via ldflags).
-//   - app_commit: the source commit SHA the build was stamped with (ldflags).
+//   - app_commit: the source commit SHA the build was stamped with (ldflags),
+//     normalized to a short prefix via shortCommit.
 //   - log_export_json/metrics/otel: which log-export integrations are active,
 //     derived from process environment (LOG_FORMAT, METRICS_TOKEN, OTLP endpoint),
 //     for the Observability settings section to reflect.
@@ -88,7 +108,7 @@ func (h *Handler) injectReadOnlyStatus(all map[string]string) map[string]string 
 		all = make(map[string]string)
 	}
 	all["app_version"] = h.appVersion
-	all["app_commit"] = buildCommit
+	all["app_commit"] = shortCommit(buildCommit)
 	all["log_export_json"] = strconv.FormatBool(debuglog.JSONFormat())
 	all["log_export_metrics"] = strconv.FormatBool(h.cfg != nil && h.cfg.MetricsToken != "")
 	all["log_export_otel"] = strconv.FormatBool(otelexport.LogsEnabled())

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -66,10 +66,17 @@ func (h *Handler) RegisterSettings(r chi.Router) {
 	})
 }
 
+// buildCommit is the short SHA of the source commit this binary was built from.
+// It is stamped at build time via -ldflags -X (see the Makefile / Dockerfile)
+// and surfaced read-only as app_commit so the dashboard can show which commit a
+// `dev` build corresponds to. Defaults to "unknown" for un-stamped builds.
+var buildCommit = "unknown"
+
 // injectReadOnlyStatus adds server-derived, read-only fields to a settings map
 // before it is returned to the client. These keys are deliberately excluded
 // from allowedSettings so they cannot be written via PUT /api/settings:
 //   - app_version: the running build (set via ldflags).
+//   - app_commit: the source commit SHA the build was stamped with (ldflags).
 //   - log_export_json/metrics/otel: which log-export integrations are active,
 //     derived from process environment (LOG_FORMAT, METRICS_TOKEN, OTLP endpoint),
 //     for the Observability settings section to reflect.
@@ -81,6 +88,7 @@ func (h *Handler) injectReadOnlyStatus(all map[string]string) map[string]string 
 		all = make(map[string]string)
 	}
 	all["app_version"] = h.appVersion
+	all["app_commit"] = buildCommit
 	all["log_export_json"] = strconv.FormatBool(debuglog.JSONFormat())
 	all["log_export_metrics"] = strconv.FormatBool(h.cfg != nil && h.cfg.MetricsToken != "")
 	all["log_export_otel"] = strconv.FormatBool(otelexport.LogsEnabled())

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -673,7 +673,7 @@ export function Layout({ children }: LayoutProps) {
 		setLogsSubMode,
 	} = useSidebarMode();
 
-	const { running, latest, updateAvailable } = useGitHubVersion();
+	const { running, latest, commit, updateAvailable } = useGitHubVersion();
 
 	const { data: cbStatus } = useQuery({
 		queryKey: ["circuit-breaker-status"],
@@ -1041,13 +1041,17 @@ export function Layout({ children }: LayoutProps) {
 							target="_blank"
 							rel="noopener noreferrer"
 							aria-label={t("layout.githubRepo")}
-							title={
-								!updateAvailable && latest !== "GitHub"
-									? t("layout.runningLatest", { running })
-									: updateAvailable
-										? t("layout.updateAvailable", { running, latest })
-										: t("layout.running", { running })
-							}
+							title={(() => {
+								const base =
+									!updateAvailable && latest !== "GitHub"
+										? t("layout.runningLatest", { running })
+										: updateAvailable
+											? t("layout.updateAvailable", { running, latest })
+											: t("layout.running", { running });
+								// Append the source commit SHA (build stamp, not
+								// translatable) so a `dev` build's exact commit is visible.
+								return commit ? `${base} · ${commit.slice(0, 7)}` : base;
+							})()}
 							className={`sidebar-footer-link flex items-center gap-2 px-2 py-1.5 text-xs text-gray-400 hover:text-white transition-colors ui-btn hover:bg-white/5`}
 						>
 							<span

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -1050,7 +1050,8 @@ export function Layout({ children }: LayoutProps) {
 											: t("layout.running", { running });
 								// Append the source commit SHA (build stamp, not
 								// translatable) so a `dev` build's exact commit is visible.
-								return commit ? `${base} · ${commit.slice(0, 7)}` : base;
+								// The backend already returns a normalized short SHA.
+								return commit ? `${base} · ${commit}` : base;
 							})()}
 							className={`sidebar-footer-link flex items-center gap-2 px-2 py-1.5 text-xs text-gray-400 hover:text-white transition-colors ui-btn hover:bg-white/5`}
 						>

--- a/web/src/hooks/__tests__/useGitHubVersion.test.ts
+++ b/web/src/hooks/__tests__/useGitHubVersion.test.ts
@@ -35,6 +35,32 @@ describe("useGitHubVersion", () => {
 		expect(result.current.running).toBe("v1.0.0");
 	});
 
+	it("returns the build commit from settings API", async () => {
+		server.use(
+			...mockSettings({ body: { app_version: "dev", app_commit: "abc1234" } }),
+		);
+		server.use(...mockVersionLatest({ status: 500 }));
+
+		const { result } = renderHook(() => useGitHubVersion());
+
+		await waitFor(() => expect(result.current.commit).toBe("abc1234"));
+	});
+
+	it('treats "unknown" commit as no commit', async () => {
+		server.use(
+			...mockSettings({ body: { app_version: "dev", app_commit: "unknown" } }),
+		);
+		server.use(...mockVersionLatest({ status: 500 }));
+
+		const { result } = renderHook(() => useGitHubVersion());
+
+		await act(async () => {
+			await new Promise((r) => setTimeout(r, 0));
+		});
+
+		expect(result.current.commit).toBe("");
+	});
+
 	it("returns cached latest version from localStorage on mount", () => {
 		const cached = JSON.stringify({ tag: "v0.1.2", timestamp: Date.now() });
 		localStorage.setItem(STORAGE_KEY, cached);

--- a/web/src/hooks/useGitHubVersion.ts
+++ b/web/src/hooks/useGitHubVersion.ts
@@ -14,6 +14,8 @@ export interface VersionInfo {
 	latest: string;
 	/** Running instance version from /api/settings app_version (e.g. "v1.0.0" or "dev") */
 	running: string;
+	/** Source commit SHA the running build was stamped with, or "" if unknown */
+	commit: string;
 	/** True when latest > running (both are semver-like tags) */
 	updateAvailable: boolean;
 }
@@ -55,6 +57,7 @@ export function useGitHubVersion(): VersionInfo {
 	});
 
 	const [running, setRunning] = useState<string>("dev");
+	const [commit, setCommit] = useState<string>("");
 
 	// Fetch running version from settings API once
 	useEffect(() => {
@@ -62,8 +65,13 @@ export function useGitHubVersion(): VersionInfo {
 		api.settings
 			.get()
 			.then((settings) => {
-				if (!cancelled && settings.app_version) {
+				if (cancelled) return;
+				if (settings.app_version) {
 					setRunning(settings.app_version);
+				}
+				// "unknown" is the un-stamped sentinel; treat it as no commit.
+				if (settings.app_commit && settings.app_commit !== "unknown") {
+					setCommit(settings.app_commit);
 				}
 			})
 			.catch(() => {
@@ -117,5 +125,5 @@ export function useGitHubVersion(): VersionInfo {
 	const updateAvailable =
 		latest !== "GitHub" && compareSemverTags(latest, running);
 
-	return { latest, running, updateAvailable };
+	return { latest, running, commit, updateAvailable };
 }


### PR DESCRIPTION
## What & why

A `model-hotel:dev` image reports its version as `dev`, so there's no way to tell which commit a running dev build was actually built from. This stamps the short source commit SHA into every build (parallel to the existing version ldflag) and shows it in the sidebar GitHub button's tooltip.

A `dev` build now reads e.g. **`Running dev · 7a5eeac`** on hover.

## Changes

**Build stamp** (new `commit`, mirroring `version`):
- `Makefile` — derives `COMMIT` (`git rev-parse --short HEAD`), adds `-X .../internal/api.buildCommit=$(COMMIT)` to `build`, passes `COMMIT=` into `docker-build`.
- `Dockerfile` — `ARG COMMIT=unknown` + ldflag. `.git` is excluded from the build context (`.dockerignore`), so the SHA comes in as a build arg rather than derived in-image.
- `docker-compose.yml` — `COMMIT: ${COMMIT:-unknown}` build arg.
- `.github/workflows/ci.yml` — the `:dev` image build passes `COMMIT=${{ github.sha }}` (VERSION stays `dev`).
- `.github/workflows/docker-publish.yml` — release images also stamp `COMMIT=${{ github.sha }}`.

**Backend:** new package var `internal/api.buildCommit`, surfaced read-only as `app_commit` alongside `app_version` in `injectReadOnlyStatus` (defaults to `"unknown"` when unstamped). Kept as a package var rather than widening the already 11-arg `NewHandler`.

**Frontend:** `useGitHubVersion` reads `app_commit` (treats `"unknown"` as none); the GitHub button tooltip appends ` · <sha>` (first 7 chars). The SHA isn't translatable text, so no new i18n key / locale churn.

## Notes
- Unstamped builds (plain `go build`, older images) report `app_commit: "unknown"` → tooltip simply omits the SHA. No breakage.
- Only takes effect for newly built images; the currently-running `:dev` won't show a SHA until rebuilt.

## Verification
- `make build` — compiles; confirmed `buildCommit` embedded in the binary.
- `tsc -b` clean; `useGitHubVersion` suite 15/15 (2 new tests: returns commit / ignores `"unknown"`).
- `go vet` clean; `TestResetSettings_AllKeys` passes with the new `app_commit` assertion.
- biome clean on changed TS files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)