### PR TITLE
feat(frontdesk): stamp + show build version; prune FD image tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -502,6 +502,9 @@ jobs:
           file: Dockerfile.frontdesk
           load: true
           tags: model-hotel-frontdesk:dev-candidate
+          # VERSION stays at its `dev` default; stamp the source SHA so the
+          # footer can show which commit this :dev image was built from.
+          build-args: COMMIT=${{ github.sha }}
           cache-from: type=gha,scope=frontdesk
           cache-to: type=gha,mode=max,scope=frontdesk
           platforms: linux/amd64

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -110,8 +110,6 @@ jobs:
       # registries under the -frontdesk repo. Reuses the Buildx instance and
       # registry logins above; a distinct gha cache scope keeps it off the
       # server image's cache so neither build evicts the other's layers.
-      # Dockerfile.frontdesk does not consume a VERSION arg (plain go build), so
-      # none is passed.
       - name: Extract metadata (Front Desk)
         if: steps.version.outputs.skip_existing == 'false'
         id: meta-frontdesk
@@ -136,6 +134,9 @@ jobs:
           push: true
           tags: ${{ steps.meta-frontdesk.outputs.tags }}
           labels: ${{ steps.meta-frontdesk.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.version.outputs.tag }}
+            COMMIT=${{ github.sha }}
           cache-from: type=gha,scope=frontdesk
           cache-to: type=gha,mode=max,scope=frontdesk
           platforms: linux/amd64

--- a/.github/workflows/dockerhub-prune.yml
+++ b/.github/workflows/dockerhub-prune.yml
@@ -1,11 +1,13 @@
 name: Prune Docker Hub Tags
 
-# Keeps the Docker Hub repository tidy after a release. Retains the newest
-# KEEP version tags (vX.Y.Z) plus every protected moving tag (latest, X.Y),
-# and deletes older releases. Each release pushes a vX.Y.Z tag *and* a sha-
-# tag at the same image digest, so a sha- tag is pruned only when no retained
-# tag still points at its digest — this drops a release's sha- tag together
-# with the release, without parsing commit SHAs.
+# Keeps the Docker Hub repositories tidy after a release. Both the server image
+# (model-hotel) and the Front Desk control-plane image (model-hotel-frontdesk)
+# are released together under the same tag scheme, so both are pruned here with
+# identical retention. Retains the newest KEEP version tags (vX.Y.Z) plus every
+# protected moving tag (latest, X.Y), and deletes older releases. Each release
+# pushes a vX.Y.Z tag *and* a sha- tag at the same image digest, so a sha- tag
+# is pruned only when no retained tag still points at its digest — this drops a
+# release's sha- tag together with the release, without parsing commit SHAs.
 #
 # Runs automatically after "Publish Docker Image" succeeds. The manual
 # (workflow_dispatch) trigger defaults to dry_run=true: it lists what *would*
@@ -56,7 +58,6 @@ jobs:
           set -euo pipefail
 
           NS="${DOCKERHUB_USERNAME}"
-          REPO="model-hotel"
 
           # Guard against keep=0 (or non-numeric), which would leave every
           # version tag unprotected and eligible for deletion.
@@ -64,9 +65,6 @@ jobs:
             echo "::error::keep must be an integer >= 1 (got '${KEEP}')"
             exit 1
           fi
-
-          echo "Repository: ${NS}/${REPO}"
-          echo "Keep newest ${KEEP} version tags; dry_run=${DRY_RUN}"
 
           # --- authenticate (PAT used as password) -----------------------------
           login_payload=$(jq -n --arg u "$NS" --arg p "$DOCKERHUB_TOKEN" \
@@ -78,6 +76,15 @@ jobs:
             echo "::error::Docker Hub login failed"
             exit 1
           fi
+
+          # prune_repo prunes one Docker Hub repo with the shared auth token above.
+          # Called once per repo at the end; the server and Front Desk images use
+          # the same tag scheme, so the same retention logic applies to both.
+          prune_repo() {
+          REPO="$1"
+
+          echo "Repository: ${NS}/${REPO}"
+          echo "Keep newest ${KEEP} version tags; dry_run=${DRY_RUN}"
 
           # --- collect every tag (name, last_updated, digest) ------------------
           tags=$(mktemp)
@@ -127,8 +134,8 @@ jobs:
           ' "$tags")
 
           if [ -z "$to_delete" ]; then
-            echo "Nothing to prune." | tee -a "$GITHUB_STEP_SUMMARY"
-            exit 0
+            echo "Nothing to prune in ${NS}/${REPO}." | tee -a "$GITHUB_STEP_SUMMARY"
+            return 0
           fi
 
           count=$(printf '%s\n' "$to_delete" | grep -c .)
@@ -159,4 +166,8 @@ jobs:
             fi
           done
 
-          echo "Prune complete."
+          echo "Prune complete for ${NS}/${REPO}."
+          }
+
+          prune_repo "model-hotel"
+          prune_repo "model-hotel-frontdesk"

--- a/Dockerfile.frontdesk
+++ b/Dockerfile.frontdesk
@@ -38,10 +38,17 @@ COPY . .
 # placeholder and runs API-only).
 COPY --from=frontend-builder /app/frontdesk/web/dist ./internal/frontdesk/webui/
 
+ARG VERSION=dev
+# Source commit SHA. The .git dir is excluded from the build context
+# (.dockerignore), so it is passed in as a build arg rather than derived
+# in-image. The backend shortens it for display.
+ARG COMMIT=unknown
 # modernc.org/sqlite is pure Go, so CGO is not needed; build a static binary.
+# Stamp version + source commit so the UI footer can show which build is running
+# (mirrors the main Dockerfile; see internal/frontdesk.buildCommit).
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    CGO_ENABLED=0 go build -o frontdesk ./cmd/frontdesk/
+    CGO_ENABLED=0 go build -ldflags "-X main.version=$VERSION -X github.com/hugalafutro/model-hotel/internal/frontdesk.buildCommit=$COMMIT" -o frontdesk ./cmd/frontdesk/
 
 # Stage 3: Minimal runtime image
 FROM alpine:3.24

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ frontdesk-build:
 	cd frontdesk/web && pnpm install --frozen-lockfile && pnpm run build:docker
 	find internal/frontdesk/webui -mindepth 1 ! -name .gitkeep ! -name .gitignore -delete
 	cp -r frontdesk/web/dist/. internal/frontdesk/webui/
-	CGO_ENABLED=0 go build -o bin/frontdesk ./cmd/frontdesk/
+	CGO_ENABLED=0 go build -ldflags "-X main.version=$(VERSION) -X github.com/hugalafutro/model-hotel/internal/frontdesk.buildCommit=$(COMMIT)" -o bin/frontdesk ./cmd/frontdesk/
 
 ha-up:
 	docker compose -f $(HA_COMPOSE) up -d --build

--- a/cmd/frontdesk/main.go
+++ b/cmd/frontdesk/main.go
@@ -31,6 +31,12 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/webauthn"
 )
 
+// version is the running Front Desk build, set at build time via
+// -ldflags -X main.version=... (see the Makefile / Dockerfile.frontdesk). It is
+// surfaced read-only over GET /api/version so the UI footer can show which build
+// is deployed. Defaults to "dev" for un-stamped builds.
+var version = "dev"
+
 func main() {
 	dbg := os.Getenv("DEBUG_LOG")
 	debuglog.Init(strings.EqualFold(dbg, "true") || dbg == "1")
@@ -95,6 +101,7 @@ func main() {
 		IPLimiter:    ipLimiter,
 		UI:           frontdesk.EmbeddedUI(),
 		LBPort:       lbPort,
+		Version:      version,
 	})
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)

--- a/frontdesk/web/src/App.tsx
+++ b/frontdesk/web/src/App.tsx
@@ -9,6 +9,7 @@ import { lazy, Suspense, useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { clearAuthToken, getAuthToken, onUnauthorized } from "./api/client";
 import { Login } from "./components/Login";
+import { VersionFooter } from "./components/VersionFooter";
 import { ToastProvider } from "./context/ToastContext";
 import { EventsPage } from "./pages/EventsPage";
 import { MembersPage } from "./pages/MembersPage";
@@ -97,6 +98,7 @@ function Shell() {
 					{tab === "settings" && <SettingsPage />}
 				</Suspense>
 			</main>
+			<VersionFooter />
 		</div>
 	);
 }

--- a/frontdesk/web/src/api/client.ts
+++ b/frontdesk/web/src/api/client.ts
@@ -19,6 +19,7 @@ import type {
 	TotpEnrollStart,
 	TotpEnrollVerify,
 	TotpInfo,
+	VersionInfo,
 	WebAuthnCredential,
 } from "./types";
 
@@ -133,6 +134,8 @@ export const api = {
 		),
 
 	getSettings: () => request<Settings>("/api/settings"),
+	// Running-build identity for the footer (version + short commit SHA).
+	getVersion: () => request<VersionInfo>("/api/version"),
 	// Partial body: the server merges onto the stored row, so each panel PUTs only
 	// the fields it owns and never clobbers the other's (or erases the secret).
 	putSettings: (s: Partial<Settings>) =>

--- a/frontdesk/web/src/api/types.ts
+++ b/frontdesk/web/src/api/types.ts
@@ -64,6 +64,14 @@ export interface Settings {
 	alert_events: string;
 }
 
+// Running-build identity from GET /api/version, used by the footer to show which
+// Front Desk build is deployed. app_version is "dev" for un-stamped builds;
+// app_commit is a short SHA, or "unknown" when the build wasn't stamped.
+export interface VersionInfo {
+	app_version: string;
+	app_commit: string;
+}
+
 // One alertable event in the Front Desk catalog (GET /api/alert/events), mirroring
 // alert.EventDef. The picker is rendered from this list, grouped by category.
 export interface AlertEventDef {

--- a/frontdesk/web/src/components/VersionFooter.tsx
+++ b/frontdesk/web/src/components/VersionFooter.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { api } from "../api/client";
+import type { VersionInfo } from "../api/types";
+
+const REPO_URL = "https://github.com/hugalafutro/model-hotel";
+const WIKI_URL =
+	"https://github.com/hugalafutro/model-hotel/wiki/High-Availability";
+
+// isDevVersion treats a build as a "dev" build unless its version looks like a
+// semver release tag (optionally v-prefixed). A `dev` image is rebuilt on every
+// master commit, so it shows its source commit SHA instead of a tag and never
+// claims to be a release. Mirrors the dashboard's useGitHubVersion classifier.
+function isDevVersion(v: string): boolean {
+	return !/^v?\d/.test(v);
+}
+
+// VersionFooter shows which Front Desk build is running, centered at the bottom
+// of the shell, plus a link to the HA wiki. The version (or "dev · <sha>") links
+// to GitHub: a stamped dev build deep-links to its exact commit, anything else
+// to the repo. The probe is non-critical, so a failure just hides the footer.
+export function VersionFooter() {
+	const { t } = useTranslation();
+	const [info, setInfo] = useState<VersionInfo | null>(null);
+
+	useEffect(() => {
+		let active = true;
+		api
+			.getVersion()
+			.then((v) => {
+				if (active) setInfo(v);
+			})
+			.catch(() => {
+				/* footer is non-critical: stay silent if the probe fails */
+			});
+		return () => {
+			active = false;
+		};
+	}, []);
+
+	if (!info) return null;
+
+	const dev = isDevVersion(info.app_version);
+	const hasCommit = info.app_commit !== "" && info.app_commit !== "unknown";
+
+	// A release shows its tag; a dev build shows "dev · <sha>" (or just "dev" when
+	// no commit was stamped).
+	const label =
+		dev && hasCommit
+			? `${info.app_version} · ${info.app_commit}`
+			: info.app_version;
+
+	// A stamped dev build deep-links to its commit; everything else to the repo.
+	const href =
+		dev && hasCommit ? `${REPO_URL}/commit/${info.app_commit}` : REPO_URL;
+
+	return (
+		<footer className="fd-footer">
+			<a
+				className="fd-footer-link"
+				href={href}
+				target="_blank"
+				rel="noreferrer"
+				title={t("footer.viewOnGitHub")}
+			>
+				{t("app.title")} <span className="fd-mono">{label}</span>
+			</a>
+			<span className="fd-footer-sep" aria-hidden="true">
+				·
+			</span>
+			<a
+				className="fd-footer-link"
+				href={WIKI_URL}
+				target="_blank"
+				rel="noreferrer"
+			>
+				{t("footer.wiki")}
+			</a>
+		</footer>
+	);
+}

--- a/frontdesk/web/src/components/VersionFooter.tsx
+++ b/frontdesk/web/src/components/VersionFooter.tsx
@@ -7,12 +7,14 @@ const REPO_URL = "https://github.com/hugalafutro/model-hotel";
 const WIKI_URL =
 	"https://github.com/hugalafutro/model-hotel/wiki/High-Availability";
 
-// isDevVersion treats a build as a "dev" build unless its version looks like a
-// semver release tag (optionally v-prefixed). A `dev` image is rebuilt on every
-// master commit, so it shows its source commit SHA instead of a tag and never
-// claims to be a release. Mirrors the dashboard's useGitHubVersion classifier.
+// isDevVersion treats a build as a "dev" build unless its version is exactly a
+// semver release tag (optionally v-prefixed: "v1.2.3" / "1.2.3"). The match is
+// anchored so a `git describe` fallback like "v1.2.3-15-gabc123" or
+// "v1.2.3-dirty" is correctly classed as dev and shows its commit, rather than
+// masquerading as the v1.2.3 release. A `dev` image is rebuilt on every master
+// commit, so it shows its source commit SHA instead of a tag.
 function isDevVersion(v: string): boolean {
-	return !/^v?\d/.test(v);
+	return !/^v?\d+\.\d+\.\d+$/.test(v);
 }
 
 // VersionFooter shows which Front Desk build is running, centered at the bottom

--- a/frontdesk/web/src/components/__tests__/AlertsPanel.test.tsx
+++ b/frontdesk/web/src/components/__tests__/AlertsPanel.test.tsx
@@ -111,7 +111,10 @@ it("shows the stored target masked, never as raw text", async () => {
 });
 
 it("save preserves the masked secret and writes the current selection", async () => {
-	let putBody: Settings | null = null;
+	// Declared without a `= null` initializer: the only assignment happens inside
+	// the handler closure below, and a null initializer would make TS's control-
+	// flow analysis pin the outer reads to `null` (collapsing putBody?.x to never).
+	let putBody: Settings | undefined;
 	baseHandlers();
 	server.use(
 		http.put("/api/settings", async ({ request }) => {
@@ -125,7 +128,7 @@ it("save preserves the masked secret and writes the current selection", async ()
 		screen.getByRole("button", { name: /save alert settings/i }),
 	);
 
-	await waitFor(() => expect(putBody).not.toBeNull());
+	await waitFor(() => expect(putBody).toBeDefined());
 	// The mask is echoed back unchanged so the backend keeps the stored secret.
 	expect(putBody?.alert_apprise_targets).toBe("********");
 	expect(putBody?.alert_enabled).toBe(true);

--- a/frontdesk/web/src/components/__tests__/VersionFooter.test.tsx
+++ b/frontdesk/web/src/components/__tests__/VersionFooter.test.tsx
@@ -48,6 +48,24 @@ it("release build: shows the tag and links to the repo (no commit deep-link)", a
 	expect(link.textContent).not.toContain("abc123def456");
 });
 
+it("git-describe build (tag + commits): treated as dev, shows + deep-links the commit", async () => {
+	// `make frontdesk-build` falls back to `git describe` when .version is absent,
+	// stamping e.g. "v1.2.3-15-gabc123". That is a dev build, not the v1.2.3
+	// release, so the footer must surface the commit and deep-link to it.
+	server.use(
+		http.get("/api/version", () =>
+			HttpResponse.json({
+				app_version: "v1.2.3-15-gabc123",
+				app_commit: "abc123def456",
+			}),
+		),
+	);
+	render(<VersionFooter />);
+
+	const link = await screen.findByRole("link", { name: /abc123def456/ });
+	expect(link).toHaveAttribute("href", `${REPO}/commit/abc123def456`);
+});
+
 it("dev build without a stamped commit: shows only dev, links to the repo", async () => {
 	server.use(
 		http.get("/api/version", () =>

--- a/frontdesk/web/src/components/__tests__/VersionFooter.test.tsx
+++ b/frontdesk/web/src/components/__tests__/VersionFooter.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { HttpResponse, http } from "msw";
+import { expect, it } from "vitest";
+import { server } from "../../test/server";
+import { VersionFooter } from "../VersionFooter";
+
+const REPO = "https://github.com/hugalafutro/model-hotel";
+
+// The footer renders two links: the build link (repo or a commit under it) and
+// the HA wiki link (/wiki/...). Pick the build link by excluding the wiki one.
+function buildLink(): HTMLAnchorElement {
+	const link = (screen.getAllByRole("link") as HTMLAnchorElement[]).find(
+		(l) => l.href.startsWith(REPO) && !l.href.includes("/wiki/"),
+	);
+	if (!link) throw new Error("build link not found");
+	return link;
+}
+
+it("dev build with a commit: shows dev + sha and deep-links to the commit", async () => {
+	server.use(
+		http.get("/api/version", () =>
+			HttpResponse.json({ app_version: "dev", app_commit: "abc123def456" }),
+		),
+	);
+	render(<VersionFooter />);
+
+	const link = await screen.findByRole("link", { name: /abc123def456/ });
+	expect(link).toHaveAttribute("href", `${REPO}/commit/abc123def456`);
+	expect(link.textContent).toContain("dev");
+
+	// The HA wiki link is always present alongside the build link.
+	const wiki = screen.getByRole("link", { name: /HA Wiki/ });
+	expect(wiki.getAttribute("href")).toContain("/wiki/");
+});
+
+it("release build: shows the tag and links to the repo (no commit deep-link)", async () => {
+	server.use(
+		http.get("/api/version", () =>
+			HttpResponse.json({ app_version: "v1.2.3", app_commit: "abc123def456" }),
+		),
+	);
+	render(<VersionFooter />);
+
+	const link = await screen.findByRole("link", { name: /v1\.2\.3/ });
+	// A release does not advertise its commit, so the link stays on the repo root
+	// and the SHA is not shown.
+	expect(link).toHaveAttribute("href", REPO);
+	expect(link.textContent).not.toContain("abc123def456");
+});
+
+it("dev build without a stamped commit: shows only dev, links to the repo", async () => {
+	server.use(
+		http.get("/api/version", () =>
+			HttpResponse.json({ app_version: "dev", app_commit: "unknown" }),
+		),
+	);
+	render(<VersionFooter />);
+
+	await waitFor(() => expect(buildLink()).toHaveAttribute("href", REPO));
+	expect(buildLink().textContent).not.toMatch(/[0-9a-f]{7,}/);
+});
+
+it("hides the footer when the version probe fails", async () => {
+	server.use(
+		http.get("/api/version", () => new HttpResponse(null, { status: 500 })),
+	);
+	const { container } = render(<VersionFooter />);
+
+	// Give the rejected fetch a tick to settle, then confirm nothing rendered.
+	await new Promise((r) => setTimeout(r, 0));
+	expect(container).toBeEmptyDOMElement();
+});

--- a/frontdesk/web/src/i18n/locales/en.json
+++ b/frontdesk/web/src/i18n/locales/en.json
@@ -23,6 +23,10 @@
 		"subtitle": "Model Hotel HA control plane",
 		"logout": "Log out"
 	},
+	"footer": {
+		"viewOnGitHub": "View this build on GitHub",
+		"wiki": "HA Wiki"
+	},
 	"tabs": {
 		"members": "Members",
 		"traffic": "Traffic",

--- a/frontdesk/web/src/index.css
+++ b/frontdesk/web/src/index.css
@@ -165,6 +165,28 @@ h3 {
 	margin-bottom: 1rem;
 }
 
+/* --- footer (build version + wiki link), centered at the bottom of the shell --- */
+.fd-footer {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 0.6rem;
+	padding: 0.85rem 1.25rem;
+	border-top: 1px solid var(--border);
+	color: var(--text-faint);
+	font-size: 0.8rem;
+}
+.fd-footer-link {
+	color: var(--text-muted);
+	text-decoration: none;
+}
+.fd-footer-link:hover {
+	color: var(--accent-strong);
+}
+.fd-footer-sep {
+	color: var(--text-faint);
+}
+
 /* --- card --- */
 .ui-card {
 	background: var(--surface);

--- a/internal/frontdesk/server.go
+++ b/internal/frontdesk/server.go
@@ -50,6 +50,7 @@ type ServerConfig struct {
 	IPLimiter    adminauth.IPLimiterMiddleware // per-IP limit on login routes
 	UI           fs.FS                         // embedded SPA; nil disables the UI mount
 	LBPort       string                        // host port of the LB (Traefik "web"); shown in the wizard's Done step. Defaults to 8080.
+	Version      string                        // running build, stamped via ldflags; surfaced read-only over GET /api/version. Defaults to "dev".
 }
 
 // Server is the Front Desk HTTP server.
@@ -66,6 +67,7 @@ type Server struct {
 	syncClient   *http.Client // guarded client for the config-import relay (longer deadline; import runs member-side discovery)
 	backupClient *http.Client // guarded client for the pre-sync backup relay (deadline exceeds the member's pg_dump budget)
 	lbPort       string       // host port of the data-plane load balancer, surfaced to the wizard
+	version      string       // running build, surfaced read-only over GET /api/version
 	masterKey    string       // encrypts the Apprise target secret at rest
 	alertDisp    *alert.Dispatcher
 	settingsMu   sync.Mutex // serializes the settings-row read-merge-write
@@ -90,6 +92,11 @@ func NewServer(cfg ServerConfig) *Server {
 		lbPort = defaultLBPort
 	}
 
+	version := cfg.Version
+	if version == "" {
+		version = "dev"
+	}
+
 	s := &Server{
 		store:        cfg.Store,
 		poller:       cfg.Poller,
@@ -103,6 +110,7 @@ func NewServer(cfg ServerConfig) *Server {
 		syncClient:   newProbeClient(memberSyncTimeout),
 		backupClient: newProbeClient(memberBackupTimeout),
 		lbPort:       lbPort,
+		version:      version,
 		masterKey:    cfg.MasterKey,
 	}
 
@@ -158,6 +166,7 @@ func (s *Server) buildRouter(wa *adminauth.WebAuthnHandler, tp *adminauth.TotpHa
 			r.Get("/members/{id}/traffic", s.memberTraffic)
 			r.Get("/settings", s.getSettings)
 			r.Put("/settings", s.putSettings)
+			r.Get("/version", s.getVersion)
 			r.Get("/alert/events", s.alertEvents)
 			r.Get("/alert/status", s.alertStatus)
 			r.Post("/alert/test", s.alertTest)
@@ -577,6 +586,38 @@ func (s *Server) listEvents(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) traefikStatus(w http.ResponseWriter, _ *http.Request) {
 	writeJSON(w, http.StatusOK, s.poller.Snapshot())
+}
+
+// buildCommit is the source commit SHA this Front Desk binary was built from,
+// stamped at build time via -ldflags -X (see the Makefile / Dockerfile.frontdesk)
+// and surfaced read-only as app_commit so the UI footer can show which commit a
+// `dev` build corresponds to. Defaults to "unknown" for un-stamped builds.
+var buildCommit = "unknown"
+
+// shortCommit normalizes a stamped commit SHA to a fixed-length short prefix so
+// app_commit reads the same across build paths (a local git SHA vs CI's full
+// github.sha). The "unknown" sentinel and any empty value pass through unchanged.
+// It mirrors internal/api.shortCommit so both surfaces present the same prefix.
+func shortCommit(c string) string {
+	const shortLen = 12
+	if c == "" || c == "unknown" {
+		return c
+	}
+	if len(c) > shortLen {
+		return c[:shortLen]
+	}
+	return c
+}
+
+// getVersion returns the running build's version and source commit so the UI
+// footer can show which Front Desk build is deployed (and link a `dev` build to
+// its commit on GitHub). app_version is "dev" for un-stamped builds; app_commit
+// is normalized to a short prefix so it reads the same across build paths.
+func (s *Server) getVersion(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]string{
+		"app_version": s.version,
+		"app_commit":  shortCommit(buildCommit),
+	})
 }
 
 // sseHeartbeat keeps idle SSE connections alive through proxies.

--- a/internal/frontdesk/version_test.go
+++ b/internal/frontdesk/version_test.go
@@ -1,0 +1,79 @@
+package frontdesk
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+// TestGetVersion verifies GET /api/version reports the running build and a
+// normalized commit. newTestServer leaves Version unset, so NewServer defaults it
+// to "dev"; buildCommit is the un-stamped "unknown" sentinel under test.
+func TestGetVersion(t *testing.T) {
+	srv, _ := newTestServer(t)
+
+	rec := do(t, srv, http.MethodGet, "/api/version", "", true)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /api/version = %d (%s)", rec.Code, rec.Body.String())
+	}
+	var v map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &v); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if v["app_version"] != "dev" {
+		t.Errorf("app_version = %q, want dev", v["app_version"])
+	}
+	if v["app_commit"] != "unknown" {
+		t.Errorf("app_commit = %q, want unknown", v["app_commit"])
+	}
+}
+
+// TestGetVersionRequiresAuth confirms the endpoint sits behind the admin-or-
+// session gate like the rest of the control-plane API.
+func TestGetVersionRequiresAuth(t *testing.T) {
+	srv, _ := newTestServer(t)
+	if rec := do(t, srv, http.MethodGet, "/api/version", "", false); rec.Code != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated GET /api/version = %d, want 401", rec.Code)
+	}
+}
+
+// TestVersionStamped confirms a stamped build flows through to the response and
+// that a long commit SHA is shortened for display.
+func TestVersionStamped(t *testing.T) {
+	srv, _ := newTestServer(t)
+	srv.version = "v1.2.3"
+	orig := buildCommit
+	buildCommit = "0123456789abcdef0123456789abcdef01234567"
+	t.Cleanup(func() { buildCommit = orig })
+
+	rec := do(t, srv, http.MethodGet, "/api/version", "", true)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /api/version = %d", rec.Code)
+	}
+	var v map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &v); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if v["app_version"] != "v1.2.3" {
+		t.Errorf("app_version = %q, want v1.2.3", v["app_version"])
+	}
+	if v["app_commit"] != "0123456789ab" {
+		t.Errorf("app_commit = %q, want 0123456789ab (12-char prefix)", v["app_commit"])
+	}
+}
+
+// TestShortCommit checks the SHA normalization used for app_commit: the sentinels
+// pass through, a short value is left alone, and a full SHA is truncated.
+func TestShortCommit(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"", ""},
+		{"unknown", "unknown"},
+		{"abc1234", "abc1234"},
+		{"0123456789abcdef0123", "0123456789ab"},
+	}
+	for _, c := range cases {
+		if got := shortCommit(c.in); got != c.want {
+			t.Errorf("shortCommit(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## What

Front Desk now knows which build it is running and shows it, and the Docker Hub prune workflow finally covers the Front Desk image.

### Version stamping + footer
- The `cmd/frontdesk` binary is stamped with `main.version` and `internal/frontdesk.buildCommit` via `-ldflags` across **every** build path: `Makefile` (`frontdesk-build`), `Dockerfile.frontdesk` (`ARG VERSION/COMMIT`), the release publish in `docker-publish.yml`, and the `:dev` candidate in `ci.yml`. Mirrors the main server's stamping.
- New admin-gated `GET /api/version` returns `app_version` + a normalized short `app_commit` (`shortCommit`, same 12-char contract as the dashboard).
- The SPA renders a centered footer in the shell showing the release tag, or `dev · <sha>` for a dev build. The version links to GitHub, a stamped dev build deep-links to its exact commit; everything else to the repo. Alongside it, an **HA Wiki** link. The footer is non-critical and hides itself if the probe fails.

### Docker Hub prune extended to Front Desk
- `dockerhub-prune.yml` previously hardcoded `REPO="model-hotel"`, so `model-hotel-frontdesk`'s `sha-` tags accumulated unbounded. Refactored into a shared `prune_repo()` called for **both** repos, identical retention, since they release together under the same tag scheme.

### Drive-by fix
- Cleared 3 pre-existing `typecheck:tests` errors in `AlertsPanel.test.tsx` (a `let x: T | null = null` closure-only-assignment CFA trap collapsing `x?.field` to `never`).

## Verification
- Go: `go vet` + `golangci-lint` 0 issues; full `internal/frontdesk` package passes (incl. 4 new version tests).
- Frontend: `tsc -b` + `typecheck:tests` clean, biome + eslint clean, full FD suite passes (incl. 4 new footer tests).
- Confirmed both ldflag symbols actually embed in a stamped build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)