### PR TITLE
Gate auto-sync primary changes; FD footer tooltip & Apprise link; MH settings layout

### DIFF
--- a/frontdesk/web/src/api/client.ts
+++ b/frontdesk/web/src/api/client.ts
@@ -168,8 +168,16 @@ export const api = {
 	// primary. Front Desk's poller watches that primary and re-syncs the fleet
 	// when its config changes.
 	getAutoSync: () => request<AutoSyncConfig>("/api/fleet/autosync"),
-	putAutoSync: (cfg: AutoSyncConfig) =>
-		request<AutoSyncConfig>("/api/fleet/autosync", jsonInit("PUT", cfg)),
+	// confirmToken re-authenticates the operator when repointing or clearing an
+	// already-configured primary; the backend rejects that change without it.
+	putAutoSync: (cfg: AutoSyncConfig, confirmToken?: string) =>
+		request<AutoSyncConfig>(
+			"/api/fleet/autosync",
+			jsonInit(
+				"PUT",
+				confirmToken ? { ...cfg, confirm_token: confirmToken } : cfg,
+			),
+		),
 
 	configSync: (primaryId: string) =>
 		request<SyncResult>(

--- a/frontdesk/web/src/components/AlertsPanel.tsx
+++ b/frontdesk/web/src/components/AlertsPanel.tsx
@@ -1,3 +1,4 @@
+import { ArrowSquareOut } from "@phosphor-icons/react";
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ApiError, api } from "../api/client";
@@ -8,6 +9,10 @@ import { useToast } from "../context/ToastContext";
 // unchanged preserves the stored secret; any other value replaces it. Must match
 // the server's alertMaskValue.
 const MASK = "********";
+
+// Official Apprise docs listing every supported service and its URL shape, the
+// same reference the main dashboard links from its alert settings.
+const APPRISE_SERVICES_URL = "https://AppriseIt.com/services/";
 
 // Display dot colour per event/display severity, using the Front Desk palette.
 const SEVERITY_COLOR: Record<string, string> = {
@@ -231,7 +236,19 @@ export function AlertsPanel() {
 				>
 					{target === MASK
 						? t("settings.alerts.targetStoredNote")
-						: t("settings.alerts.targetHint")}
+						: t("settings.alerts.targetHint")}{" "}
+					<a
+						className="fd-link"
+						href={APPRISE_SERVICES_URL}
+						target="_blank"
+						rel="noreferrer"
+					>
+						{t("settings.alerts.browseServices")}
+						<ArrowSquareOut
+							size={12}
+							style={{ marginLeft: 3, verticalAlign: "-1px" }}
+						/>
+					</a>
 				</div>
 			</div>
 

--- a/frontdesk/web/src/components/AutoSyncPanel.tsx
+++ b/frontdesk/web/src/components/AutoSyncPanel.tsx
@@ -100,13 +100,12 @@ export function AutoSyncPanel({ members }: { members: MemberView[] }) {
 		setConfirmError("");
 		setSaving(true);
 		try {
-			// Re-read first so a confirmed primary change carries the server's current
-			// enabled flag, not the snapshot from when the modal opened: another admin
-			// could have toggled auto-sync while the operator was entering the token,
-			// and this write would otherwise silently revert that.
-			const latest = await api.getAutoSync();
+			// Only the primary changes here. The server preserves the stored enabled
+			// flag on a repoint (see SetAutoSyncGuarded), so a concurrent enable/
+			// disable is never reverted by this write, and we adopt whatever enabled
+			// state the server returns.
 			const saved = await api.putAutoSync(
-				{ ...latest, primary_id: pendingPrimary },
+				{ ...cfg, primary_id: pendingPrimary },
 				confirmToken.trim(),
 			);
 			setCfg(saved);

--- a/frontdesk/web/src/components/AutoSyncPanel.tsx
+++ b/frontdesk/web/src/components/AutoSyncPanel.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { ApiError, api } from "../api/client";
 import type { AutoSyncConfig, MemberView } from "../api/types";
 import { useToast } from "../context/ToastContext";
+import { ConfirmModal } from "./ConfirmModal";
 import { Notice } from "./Notice";
 
 // AutoSyncPanel is the "set and forget" control for HA config replication: pick a
@@ -22,6 +23,11 @@ export function AutoSyncPanel({ members }: { members: MemberView[] }) {
 	const [loadError, setLoadError] = useState(false);
 	const [saving, setSaving] = useState(false);
 	const [saveError, setSaveError] = useState("");
+	// Candidate primary awaiting admin-token confirmation (null = no prompt). "" is
+	// a real candidate meaning "clear the primary", so it must stay distinct.
+	const [pendingPrimary, setPendingPrimary] = useState<string | null>(null);
+	const [confirmToken, setConfirmToken] = useState("");
+	const [confirmError, setConfirmError] = useState("");
 
 	useEffect(() => {
 		api
@@ -32,18 +38,60 @@ export function AutoSyncPanel({ members }: { members: MemberView[] }) {
 
 	if (loadError || !cfg) return null; // stay quiet on load; the wizard still works
 
-	const persist = async (next: AutoSyncConfig) => {
+	const errorMessage = (err: unknown): string =>
+		err instanceof ApiError && (err.status === 400 || err.status === 403)
+			? err.message
+			: t("errors.generic");
+
+	const persist = async (next: AutoSyncConfig, confirm?: string) => {
 		setSaveError("");
 		setSaving(true);
 		try {
-			setCfg(await api.putAutoSync(next));
+			setCfg(await api.putAutoSync(next, confirm));
 			toast(t("settings.autoSync.saved"), "success");
+			return true;
 		} catch (err) {
-			setSaveError(
-				err instanceof ApiError && err.status === 400
-					? err.message
-					: t("errors.generic"),
+			setSaveError(errorMessage(err));
+			return false;
+		} finally {
+			setSaving(false);
+		}
+	};
+
+	// Repointing or clearing a primary that is already set is high-impact, so route
+	// it through an admin-token confirmation. The first selection (none set yet)
+	// applies immediately.
+	const onSelectPrimary = (value: string) => {
+		if (cfg.primary_id !== "" && value !== cfg.primary_id) {
+			setConfirmToken("");
+			setConfirmError("");
+			setPendingPrimary(value);
+			return;
+		}
+		void persist({ ...cfg, primary_id: value });
+	};
+
+	const closeConfirm = () => {
+		setPendingPrimary(null);
+		setConfirmToken("");
+		setConfirmError("");
+	};
+
+	const confirmPrimaryChange = async () => {
+		if (pendingPrimary === null) return;
+		setConfirmError("");
+		setSaving(true);
+		try {
+			setCfg(
+				await api.putAutoSync(
+					{ ...cfg, primary_id: pendingPrimary },
+					confirmToken.trim(),
+				),
 			);
+			toast(t("settings.autoSync.saved"), "success");
+			closeConfirm();
+		} catch (err) {
+			setConfirmError(errorMessage(err));
 		} finally {
 			setSaving(false);
 		}
@@ -70,7 +118,7 @@ export function AutoSyncPanel({ members }: { members: MemberView[] }) {
 					className="ui-input"
 					value={cfg.primary_id}
 					disabled={saving}
-					onChange={(e) => persist({ ...cfg, primary_id: e.target.value })}
+					onChange={(e) => onSelectPrimary(e.target.value)}
 				>
 					<option value="">{t("settings.autoSync.primaryNone")}</option>
 					{tokenedMembers.map((m) => (
@@ -114,6 +162,42 @@ export function AutoSyncPanel({ members }: { members: MemberView[] }) {
 				<div className="fd-error-text" role="alert">
 					{saveError}
 				</div>
+			)}
+
+			{pendingPrimary !== null && (
+				<ConfirmModal
+					title={t("settings.autoSync.confirmPrimaryTitle")}
+					confirmLabel={t("settings.autoSync.confirmPrimaryAction")}
+					confirmDisabled={!confirmToken.trim()}
+					busy={saving}
+					onConfirm={() => void confirmPrimaryChange()}
+					onClose={closeConfirm}
+				>
+					<p style={{ marginTop: 0 }}>
+						{pendingPrimary === ""
+							? t("settings.autoSync.confirmPrimaryClearBody")
+							: t("settings.autoSync.confirmPrimaryChangeBody")}
+					</p>
+					<div className="ui-field">
+						<label className="ui-label" htmlFor="fd-autosync-confirm-token">
+							{t("settings.autoSync.confirmTokenLabel")}
+						</label>
+						<input
+							id="fd-autosync-confirm-token"
+							className="ui-input"
+							type="password"
+							autoComplete="current-password"
+							value={confirmToken}
+							onChange={(e) => setConfirmToken(e.target.value)}
+							placeholder={t("settings.autoSync.confirmTokenPlaceholder")}
+						/>
+					</div>
+					{confirmError && (
+						<div className="fd-error-text" role="alert">
+							{confirmError}
+						</div>
+					)}
+				</ConfirmModal>
 			)}
 		</div>
 	);

--- a/frontdesk/web/src/components/AutoSyncPanel.tsx
+++ b/frontdesk/web/src/components/AutoSyncPanel.tsx
@@ -39,7 +39,8 @@ export function AutoSyncPanel({ members }: { members: MemberView[] }) {
 	if (loadError || !cfg) return null; // stay quiet on load; the wizard still works
 
 	const errorMessage = (err: unknown): string =>
-		err instanceof ApiError && (err.status === 400 || err.status === 403)
+		err instanceof ApiError &&
+		(err.status === 400 || err.status === 403 || err.status === 409)
 			? err.message
 			: t("errors.generic");
 
@@ -83,6 +84,9 @@ export function AutoSyncPanel({ members }: { members: MemberView[] }) {
 			setPendingPrimary(value);
 			return;
 		}
+		// First selection (none set yet). If our snapshot is stale because a primary
+		// was set concurrently, the server gates this PUT with a 403 and persist()
+		// opens the confirmation modal to recover, so we never dead-end.
 		void persist({ ...cfg, primary_id: value });
 	};
 

--- a/frontdesk/web/src/components/AutoSyncPanel.tsx
+++ b/frontdesk/web/src/components/AutoSyncPanel.tsx
@@ -39,8 +39,7 @@ export function AutoSyncPanel({ members }: { members: MemberView[] }) {
 	if (loadError || !cfg) return null; // stay quiet on load; the wizard still works
 
 	const errorMessage = (err: unknown): string =>
-		err instanceof ApiError &&
-		(err.status === 400 || err.status === 403 || err.status === 409)
+		err instanceof ApiError && (err.status === 400 || err.status === 403)
 			? err.message
 			: t("errors.generic");
 

--- a/frontdesk/web/src/components/AutoSyncPanel.tsx
+++ b/frontdesk/web/src/components/AutoSyncPanel.tsx
@@ -63,6 +63,8 @@ export function AutoSyncPanel({ members }: { members: MemberView[] }) {
 	// applies immediately.
 	const onSelectPrimary = (value: string) => {
 		if (cfg.primary_id !== "" && value !== cfg.primary_id) {
+			// Drop any stale persist error so it doesn't linger beneath the modal.
+			setSaveError("");
 			setConfirmToken("");
 			setConfirmError("");
 			setPendingPrimary(value);

--- a/frontdesk/web/src/components/AutoSyncPanel.tsx
+++ b/frontdesk/web/src/components/AutoSyncPanel.tsx
@@ -51,6 +51,19 @@ export function AutoSyncPanel({ members }: { members: MemberView[] }) {
 			toast(t("settings.autoSync.saved"), "success");
 			return true;
 		} catch (err) {
+			// A primary was configured concurrently (another admin), so the server
+			// now gates this change even though our snapshot showed none set. Recover
+			// by prompting for the admin token instead of dead-ending on an error.
+			if (
+				err instanceof ApiError &&
+				err.status === 403 &&
+				confirm === undefined
+			) {
+				setConfirmToken("");
+				setConfirmError("");
+				setPendingPrimary(next.primary_id);
+				return false;
+			}
 			setSaveError(errorMessage(err));
 			return false;
 		} finally {

--- a/frontdesk/web/src/components/AutoSyncPanel.tsx
+++ b/frontdesk/web/src/components/AutoSyncPanel.tsx
@@ -43,29 +43,36 @@ export function AutoSyncPanel({ members }: { members: MemberView[] }) {
 			? err.message
 			: t("errors.generic");
 
-	const persist = async (next: AutoSyncConfig, confirm?: string) => {
+	// gateRecovery: true only for a deliberate primary selection. If that save is
+	// gated 403 because the primary changed under us, escalate to the confirmation
+	// modal. A non-primary save (e.g. an enabled toggle) must never escalate: it
+	// would offer to repoint the fleet to the stale primary the operator never
+	// chose to change.
+	const persist = async (next: AutoSyncConfig, gateRecovery = false) => {
 		setSaveError("");
 		setSaving(true);
 		try {
-			setCfg(await api.putAutoSync(next, confirm));
+			setCfg(await api.putAutoSync(next));
 			toast(t("settings.autoSync.saved"), "success");
 			return true;
 		} catch (err) {
-			// A primary was configured concurrently (another admin), so the server
-			// now gates this change even though our snapshot showed none set. Recover
-			// by prompting for the admin token instead of dead-ending on an error.
-			// Never do this while a confirmation is already pending: that would
-			// overwrite the operator's chosen primary with this save's value.
-			if (
-				err instanceof ApiError &&
-				err.status === 403 &&
-				confirm === undefined &&
-				pendingPrimary === null
-			) {
-				setConfirmToken("");
-				setConfirmError("");
-				setPendingPrimary(next.primary_id);
-				return false;
+			if (err instanceof ApiError && err.status === 403) {
+				// Our snapshot of the primary is stale (another operator changed it).
+				// Resync so the panel reflects the current primary and enabled state.
+				try {
+					setCfg(await api.getAutoSync());
+				} catch {
+					/* keep the last known config */
+				}
+				// Only a deliberate primary selection opens the confirmation modal, and
+				// never one that is already open (that would overwrite the operator's
+				// pending choice).
+				if (gateRecovery && pendingPrimary === null) {
+					setConfirmToken("");
+					setConfirmError("");
+					setPendingPrimary(next.primary_id);
+					return false;
+				}
 			}
 			setSaveError(errorMessage(err));
 			return false;
@@ -88,8 +95,8 @@ export function AutoSyncPanel({ members }: { members: MemberView[] }) {
 		}
 		// First selection (none set yet). If our snapshot is stale because a primary
 		// was set concurrently, the server gates this PUT with a 403 and persist()
-		// opens the confirmation modal to recover, so we never dead-end.
-		void persist({ ...cfg, primary_id: value });
+		// escalates to the confirmation modal to recover, so we never dead-end.
+		void persist({ ...cfg, primary_id: value }, true);
 	};
 
 	const closeConfirm = () => {

--- a/frontdesk/web/src/components/AutoSyncPanel.tsx
+++ b/frontdesk/web/src/components/AutoSyncPanel.tsx
@@ -100,12 +100,16 @@ export function AutoSyncPanel({ members }: { members: MemberView[] }) {
 		setConfirmError("");
 		setSaving(true);
 		try {
-			setCfg(
-				await api.putAutoSync(
-					{ ...cfg, primary_id: pendingPrimary },
-					confirmToken.trim(),
-				),
+			// Re-read first so a confirmed primary change carries the server's current
+			// enabled flag, not the snapshot from when the modal opened: another admin
+			// could have toggled auto-sync while the operator was entering the token,
+			// and this write would otherwise silently revert that.
+			const latest = await api.getAutoSync();
+			const saved = await api.putAutoSync(
+				{ ...latest, primary_id: pendingPrimary },
+				confirmToken.trim(),
 			);
+			setCfg(saved);
 			toast(t("settings.autoSync.saved"), "success");
 			closeConfirm();
 		} catch (err) {

--- a/frontdesk/web/src/components/AutoSyncPanel.tsx
+++ b/frontdesk/web/src/components/AutoSyncPanel.tsx
@@ -54,10 +54,13 @@ export function AutoSyncPanel({ members }: { members: MemberView[] }) {
 			// A primary was configured concurrently (another admin), so the server
 			// now gates this change even though our snapshot showed none set. Recover
 			// by prompting for the admin token instead of dead-ending on an error.
+			// Never do this while a confirmation is already pending: that would
+			// overwrite the operator's chosen primary with this save's value.
 			if (
 				err instanceof ApiError &&
 				err.status === 403 &&
-				confirm === undefined
+				confirm === undefined &&
+				pendingPrimary === null
 			) {
 				setConfirmToken("");
 				setConfirmError("");
@@ -119,6 +122,10 @@ export function AutoSyncPanel({ members }: { members: MemberView[] }) {
 	};
 
 	const tokenedMembers = members.filter((m) => m.has_token);
+	// While a primary-change confirmation is open, freeze the other controls: an
+	// unrelated save (e.g. toggling enabled) could otherwise fire, hit the gate,
+	// and clobber the operator's pending choice.
+	const confirming = pendingPrimary !== null;
 
 	return (
 		<div className="ui-card ui-card-pad fd-stack">
@@ -138,7 +145,7 @@ export function AutoSyncPanel({ members }: { members: MemberView[] }) {
 					id="autosync-primary"
 					className="ui-input"
 					value={cfg.primary_id}
-					disabled={saving}
+					disabled={saving || confirming}
 					onChange={(e) => onSelectPrimary(e.target.value)}
 				>
 					<option value="">{t("settings.autoSync.primaryNone")}</option>
@@ -160,7 +167,7 @@ export function AutoSyncPanel({ members }: { members: MemberView[] }) {
 				<input
 					type="checkbox"
 					checked={cfg.enabled}
-					disabled={saving || !cfg.primary_id}
+					disabled={saving || !cfg.primary_id || confirming}
 					onChange={(e) => persist({ ...cfg, enabled: e.target.checked })}
 				/>
 				<span>

--- a/frontdesk/web/src/components/VersionFooter.tsx
+++ b/frontdesk/web/src/components/VersionFooter.tsx
@@ -18,9 +18,10 @@ function isDevVersion(v: string): boolean {
 }
 
 // VersionFooter shows which Front Desk build is running, centered at the bottom
-// of the shell, plus a link to the HA wiki. The version (or "dev · <sha>") links
-// to GitHub: a stamped dev build deep-links to its exact commit, anything else
-// to the repo. The probe is non-critical, so a failure just hides the footer.
+// of the shell, plus a link to the HA wiki. The version (e.g. "dev") links to
+// GitHub: a stamped dev build deep-links to its exact commit and surfaces the
+// SHA in its hover tooltip, anything else links to the repo. The probe is
+// non-critical, so a failure just hides the footer.
 export function VersionFooter() {
 	const { t } = useTranslation();
 	const [info, setInfo] = useState<VersionInfo | null>(null);
@@ -45,14 +46,17 @@ export function VersionFooter() {
 	const dev = isDevVersion(info.app_version);
 	const hasCommit = info.app_commit !== "" && info.app_commit !== "unknown";
 
-	// A release shows its tag; a dev build shows "dev · <sha>" (or just "dev" when
-	// no commit was stamped).
-	const label =
-		dev && hasCommit
-			? `${info.app_version} · ${info.app_commit}`
-			: info.app_version;
+	// The label always shows just the version (e.g. "dev" or "v1.2.3"); the build
+	// commit lives in the tooltip rather than inline, matching the main dashboard.
+	const label = info.app_version;
 
-	// A stamped dev build deep-links to its commit; everything else to the repo.
+	// A stamped dev build surfaces its source commit in the hover tooltip and
+	// deep-links to it; everything else links to the repo and keeps the generic
+	// tooltip.
+	const title =
+		dev && hasCommit
+			? t("footer.builtFromCommit", { commit: info.app_commit })
+			: t("footer.viewOnGitHub");
 	const href =
 		dev && hasCommit ? `${REPO_URL}/commit/${info.app_commit}` : REPO_URL;
 
@@ -63,7 +67,7 @@ export function VersionFooter() {
 				href={href}
 				target="_blank"
 				rel="noreferrer"
-				title={t("footer.viewOnGitHub")}
+				title={title}
 			>
 				{t("app.title")} <span className="fd-mono">{label}</span>
 			</a>

--- a/frontdesk/web/src/components/__tests__/AutoSyncPanel.test.tsx
+++ b/frontdesk/web/src/components/__tests__/AutoSyncPanel.test.tsx
@@ -177,6 +177,39 @@ it("freezes the other controls while a primary-change confirmation is open", asy
 	);
 });
 
+it("does not offer a repoint when an enabled toggle hits the gate", async () => {
+	// Panel has primary 1 + auto-sync off; another admin repointed concurrently,
+	// so the toggle's stale primary is refused with a 403. The toggle must surface
+	// an error and resync, never pop a primary-change modal that could repoint.
+	server.use(
+		http.get("/api/fleet/autosync", () =>
+			HttpResponse.json({ enabled: false, primary_id: "1" }),
+		),
+		http.put("/api/fleet/autosync", async ({ request }) => {
+			const body = (await request.json()) as { confirm_token?: string };
+			if (!body.confirm_token) {
+				return new HttpResponse("confirm the admin token", { status: 403 });
+			}
+			return HttpResponse.json({ enabled: false, primary_id: "1" });
+		}),
+	);
+	render(
+		<ToastProvider>
+			<AutoSyncPanel
+				members={[member("1", "hotel-1"), member("3", "hotel-3")]}
+			/>
+		</ToastProvider>,
+	);
+
+	const checkbox = await screen.findByRole("checkbox");
+	await waitFor(() => expect(checkbox).toBeEnabled());
+	await userEvent.click(checkbox);
+
+	// The refusal shows an error and opens no confirmation dialog.
+	expect(await screen.findByRole("alert")).toBeTruthy();
+	expect(screen.queryByRole("dialog")).toBeNull();
+});
+
 it("recovers when a primary was set concurrently (stale snapshot)", async () => {
 	// The client loaded with no primary, but another admin configured one in the
 	// meantime, so the server gates the first un-tokened PUT with a 403.

--- a/frontdesk/web/src/components/__tests__/AutoSyncPanel.test.tsx
+++ b/frontdesk/web/src/components/__tests__/AutoSyncPanel.test.tsx
@@ -131,3 +131,42 @@ it("gates repointing an already-set primary behind the admin token", async () =>
 		}),
 	);
 });
+
+it("recovers when a primary was set concurrently (stale snapshot)", async () => {
+	// The client loaded with no primary, but another admin configured one in the
+	// meantime, so the server gates the first un-tokened PUT with a 403.
+	const puts: Array<{ primary_id: string; confirm_token?: string }> = [];
+	server.use(
+		http.put("/api/fleet/autosync", async ({ request }) => {
+			const body = (await request.json()) as (typeof puts)[number];
+			puts.push(body);
+			if (!body.confirm_token) {
+				return new HttpResponse("confirm the admin token", { status: 403 });
+			}
+			return HttpResponse.json({ enabled: false, primary_id: body.primary_id });
+		}),
+	);
+	renderPanel();
+
+	// Selecting a primary PUTs without a token and is refused; instead of an
+	// error, the confirmation modal opens so the operator can recover.
+	await userEvent.selectOptions(await screen.findByRole("combobox"), "1");
+	const dialog = await screen.findByRole("dialog");
+	await waitFor(() => expect(puts).toHaveLength(1));
+
+	await userEvent.type(
+		within(dialog).getByLabelText(/admin token/i),
+		"s3cret-token",
+	);
+	await userEvent.click(
+		within(dialog).getByRole("button", { name: /confirm change/i }),
+	);
+
+	await waitFor(() =>
+		expect(puts).toContainEqual({
+			enabled: false,
+			primary_id: "1",
+			confirm_token: "s3cret-token",
+		}),
+	);
+});

--- a/frontdesk/web/src/components/__tests__/AutoSyncPanel.test.tsx
+++ b/frontdesk/web/src/components/__tests__/AutoSyncPanel.test.tsx
@@ -170,3 +170,52 @@ it("recovers when a primary was set concurrently (stale snapshot)", async () => 
 		}),
 	);
 });
+
+it("re-reads the enabled flag before confirming, so a concurrent toggle survives", async () => {
+	const puts: Array<{
+		enabled: boolean;
+		primary_id: string;
+		confirm_token?: string;
+	}> = [];
+	let getCount = 0;
+	server.use(
+		http.get("/api/fleet/autosync", () => {
+			getCount += 1;
+			// First load: primary set, auto-sync off. Another admin enables it while
+			// the confirm modal is open, so the re-read (2nd GET) reports enabled.
+			return HttpResponse.json({ enabled: getCount > 1, primary_id: "1" });
+		}),
+		http.put("/api/fleet/autosync", async ({ request }) => {
+			const body = (await request.json()) as (typeof puts)[number];
+			puts.push(body);
+			return HttpResponse.json({
+				enabled: body.enabled,
+				primary_id: body.primary_id,
+			});
+		}),
+	);
+	render(
+		<ToastProvider>
+			<AutoSyncPanel
+				members={[member("1", "hotel-1"), member("3", "hotel-3")]}
+			/>
+		</ToastProvider>,
+	);
+
+	await userEvent.selectOptions(await screen.findByRole("combobox"), "3");
+	const dialog = await screen.findByRole("dialog");
+	await userEvent.type(within(dialog).getByLabelText(/admin token/i), "tok");
+	await userEvent.click(
+		within(dialog).getByRole("button", { name: /confirm change/i }),
+	);
+
+	// The confirmed write must carry the freshly-read enabled:true, not the stale
+	// enabled:false captured when the modal opened.
+	await waitFor(() =>
+		expect(puts).toContainEqual({
+			enabled: true,
+			primary_id: "3",
+			confirm_token: "tok",
+		}),
+	);
+});

--- a/frontdesk/web/src/components/__tests__/AutoSyncPanel.test.tsx
+++ b/frontdesk/web/src/components/__tests__/AutoSyncPanel.test.tsx
@@ -77,3 +77,57 @@ it("requires a primary before enabling, then warns when active", async () => {
 	// The amber warning appears once auto-sync is active.
 	expect(await screen.findByText(/Automatic sync is on/i)).toBeTruthy();
 });
+
+it("gates repointing an already-set primary behind the admin token", async () => {
+	const puts: Array<{
+		enabled: boolean;
+		primary_id: string;
+		confirm_token?: string;
+	}> = [];
+	server.use(
+		http.get("/api/fleet/autosync", () =>
+			HttpResponse.json({ enabled: true, primary_id: "1" }),
+		),
+		http.put("/api/fleet/autosync", async ({ request }) => {
+			const body = (await request.json()) as (typeof puts)[number];
+			puts.push(body);
+			// Mirror the backend: refuse a primary change without the admin token.
+			if (!body.confirm_token) {
+				return new HttpResponse("confirm the admin token", { status: 403 });
+			}
+			return HttpResponse.json({ enabled: true, primary_id: body.primary_id });
+		}),
+	);
+	render(
+		<ToastProvider>
+			<AutoSyncPanel
+				members={[member("1", "hotel-1"), member("3", "hotel-3")]}
+			/>
+		</ToastProvider>,
+	);
+
+	// Pick a different primary: the change must be held, not persisted yet.
+	await userEvent.selectOptions(await screen.findByRole("combobox"), "3");
+	const dialog = await screen.findByRole("dialog");
+	expect(puts).toHaveLength(0);
+
+	// Confirm stays blocked until a token is entered.
+	const confirmBtn = within(dialog).getByRole("button", {
+		name: /confirm change/i,
+	});
+	expect(confirmBtn).toBeDisabled();
+
+	await userEvent.type(
+		within(dialog).getByLabelText(/admin token/i),
+		"s3cret-token",
+	);
+	await userEvent.click(confirmBtn);
+
+	await waitFor(() =>
+		expect(puts).toContainEqual({
+			enabled: true,
+			primary_id: "3",
+			confirm_token: "s3cret-token",
+		}),
+	);
+});

--- a/frontdesk/web/src/components/__tests__/AutoSyncPanel.test.tsx
+++ b/frontdesk/web/src/components/__tests__/AutoSyncPanel.test.tsx
@@ -132,6 +132,51 @@ it("gates repointing an already-set primary behind the admin token", async () =>
 	);
 });
 
+it("freezes the other controls while a primary-change confirmation is open", async () => {
+	const puts: Array<{ primary_id: string; confirm_token?: string }> = [];
+	server.use(
+		http.get("/api/fleet/autosync", () =>
+			HttpResponse.json({ enabled: true, primary_id: "1" }),
+		),
+		http.put("/api/fleet/autosync", async ({ request }) => {
+			const body = (await request.json()) as (typeof puts)[number];
+			puts.push(body);
+			return HttpResponse.json({ enabled: true, primary_id: body.primary_id });
+		}),
+	);
+	render(
+		<ToastProvider>
+			<AutoSyncPanel
+				members={[member("1", "hotel-1"), member("3", "hotel-3")]}
+			/>
+		</ToastProvider>,
+	);
+
+	const select = await screen.findByRole("combobox");
+	await userEvent.selectOptions(select, "3");
+	const dialog = await screen.findByRole("dialog");
+
+	// With the confirmation open, the select and the enable toggle are frozen, so
+	// no unrelated save can fire and overwrite the pending choice of "3".
+	expect(select).toBeDisabled();
+	expect(screen.getByRole("checkbox")).toBeDisabled();
+	expect(puts).toHaveLength(0);
+
+	await userEvent.type(within(dialog).getByLabelText(/admin token/i), "tok");
+	await userEvent.click(
+		within(dialog).getByRole("button", { name: /confirm change/i }),
+	);
+
+	// The confirmed write still carries the operator's intended primary, "3".
+	await waitFor(() =>
+		expect(puts).toContainEqual({
+			enabled: true,
+			primary_id: "3",
+			confirm_token: "tok",
+		}),
+	);
+});
+
 it("recovers when a primary was set concurrently (stale snapshot)", async () => {
 	// The client loaded with no primary, but another admin configured one in the
 	// meantime, so the server gates the first un-tokened PUT with a 403.

--- a/frontdesk/web/src/components/__tests__/AutoSyncPanel.test.tsx
+++ b/frontdesk/web/src/components/__tests__/AutoSyncPanel.test.tsx
@@ -171,27 +171,17 @@ it("recovers when a primary was set concurrently (stale snapshot)", async () => 
 	);
 });
 
-it("re-reads the enabled flag before confirming, so a concurrent toggle survives", async () => {
-	const puts: Array<{
-		enabled: boolean;
-		primary_id: string;
-		confirm_token?: string;
-	}> = [];
-	let getCount = 0;
+it("adopts the server's enabled state after confirming a primary change", async () => {
+	// The panel loaded with auto-sync off, but the server reports it on after the
+	// repoint (it preserved a concurrent enable). The panel must reflect server
+	// truth, not its stale local snapshot.
 	server.use(
-		http.get("/api/fleet/autosync", () => {
-			getCount += 1;
-			// First load: primary set, auto-sync off. Another admin enables it while
-			// the confirm modal is open, so the re-read (2nd GET) reports enabled.
-			return HttpResponse.json({ enabled: getCount > 1, primary_id: "1" });
-		}),
+		http.get("/api/fleet/autosync", () =>
+			HttpResponse.json({ enabled: false, primary_id: "1" }),
+		),
 		http.put("/api/fleet/autosync", async ({ request }) => {
-			const body = (await request.json()) as (typeof puts)[number];
-			puts.push(body);
-			return HttpResponse.json({
-				enabled: body.enabled,
-				primary_id: body.primary_id,
-			});
+			const body = (await request.json()) as { primary_id: string };
+			return HttpResponse.json({ enabled: true, primary_id: body.primary_id });
 		}),
 	);
 	render(
@@ -209,13 +199,7 @@ it("re-reads the enabled flag before confirming, so a concurrent toggle survives
 		within(dialog).getByRole("button", { name: /confirm change/i }),
 	);
 
-	// The confirmed write must carry the freshly-read enabled:true, not the stale
-	// enabled:false captured when the modal opened.
-	await waitFor(() =>
-		expect(puts).toContainEqual({
-			enabled: true,
-			primary_id: "3",
-			confirm_token: "tok",
-		}),
-	);
+	// The active-auto-sync warning appears because the panel took the server's
+	// enabled:true, proving it did not clobber the concurrent enable.
+	expect(await screen.findByText(/Automatic sync is on/i)).toBeTruthy();
 });

--- a/frontdesk/web/src/components/__tests__/VersionFooter.test.tsx
+++ b/frontdesk/web/src/components/__tests__/VersionFooter.test.tsx
@@ -16,7 +16,7 @@ function buildLink(): HTMLAnchorElement {
 	return link;
 }
 
-it("dev build with a commit: shows dev + sha and deep-links to the commit", async () => {
+it("dev build with a commit: shows dev, puts the sha in the tooltip, deep-links to the commit", async () => {
 	server.use(
 		http.get("/api/version", () =>
 			HttpResponse.json({ app_version: "dev", app_commit: "abc123def456" }),
@@ -24,9 +24,17 @@ it("dev build with a commit: shows dev + sha and deep-links to the commit", asyn
 	);
 	render(<VersionFooter />);
 
-	const link = await screen.findByRole("link", { name: /abc123def456/ });
-	expect(link).toHaveAttribute("href", `${REPO}/commit/abc123def456`);
+	await waitFor(() =>
+		expect(buildLink()).toHaveAttribute("href", `${REPO}/commit/abc123def456`),
+	);
+	const link = buildLink();
 	expect(link.textContent).toContain("dev");
+	// The commit SHA lives in the hover tooltip, not the visible label.
+	expect(link.textContent).not.toContain("abc123def456");
+	expect(link).toHaveAttribute(
+		"title",
+		expect.stringContaining("abc123def456"),
+	);
 
 	// The HA wiki link is always present alongside the build link.
 	const wiki = screen.getByRole("link", { name: /HA Wiki/ });
@@ -62,8 +70,15 @@ it("git-describe build (tag + commits): treated as dev, shows + deep-links the c
 	);
 	render(<VersionFooter />);
 
-	const link = await screen.findByRole("link", { name: /abc123def456/ });
-	expect(link).toHaveAttribute("href", `${REPO}/commit/abc123def456`);
+	await waitFor(() =>
+		expect(buildLink()).toHaveAttribute("href", `${REPO}/commit/abc123def456`),
+	);
+	// Dev build: the describe string shows, the SHA sits in the tooltip.
+	expect(buildLink().textContent).toContain("v1.2.3-15-gabc123");
+	expect(buildLink()).toHaveAttribute(
+		"title",
+		expect.stringContaining("abc123def456"),
+	);
 });
 
 it("dev build without a stamped commit: shows only dev, links to the repo", async () => {

--- a/frontdesk/web/src/i18n/locales/en.json
+++ b/frontdesk/web/src/i18n/locales/en.json
@@ -25,6 +25,7 @@
 	},
 	"footer": {
 		"viewOnGitHub": "View this build on GitHub",
+		"builtFromCommit": "Built from commit {{commit}}",
 		"wiki": "HA Wiki"
 	},
 	"tabs": {
@@ -175,7 +176,13 @@
 			"enableLabel": "Keep the fleet synced to the primary automatically",
 			"enableHint": "Checks the primary every few seconds and re-syncs members when its config changes.",
 			"activeWarning": "Automatic sync is on. A change on the primary replaces config on every other member, which can remove providers or keys they have but the primary does not. Each member is backed up first so a bad change can be rolled back.",
-			"saved": "Auto-sync updated"
+			"saved": "Auto-sync updated",
+			"confirmPrimaryTitle": "Confirm primary change",
+			"confirmPrimaryChangeBody": "Repointing the primary changes which instance's config is pushed to the whole fleet. Enter the admin token to confirm.",
+			"confirmPrimaryClearBody": "Clearing the primary turns off automatic config sync for the fleet. Enter the admin token to confirm.",
+			"confirmPrimaryAction": "Confirm change",
+			"confirmTokenLabel": "Admin token",
+			"confirmTokenPlaceholder": "Enter the Front Desk admin token"
 		},
 		"alerts": {
 			"title": "Alerts",
@@ -186,6 +193,7 @@
 			"targetLabel": "Notification target(s)",
 			"targetHint": "One or more Apprise URLs, separated by ; (e.g. tgram://token/chat_id). Stored encrypted.",
 			"targetStoredNote": "A target is stored (hidden). Leave as-is to keep it, type a new value to replace it, or clear it to remove.",
+			"browseServices": "Browse all 80+ services",
 			"eventsLabel": "Notify on",
 			"eventsHint": "Choose which fleet events send a notification.",
 			"event": {

--- a/internal/frontdesk/autosync_test.go
+++ b/internal/frontdesk/autosync_test.go
@@ -595,46 +595,55 @@ func TestSetAutoSyncClearsAppliedHash(t *testing.T) {
 	}
 }
 
-// TestSetAutoSyncCAS covers the compare-and-swap guard that closes the
-// read-modify-write race in putAutoSync: the write only lands when the stored
-// primary still matches the value the caller gated against.
-func TestSetAutoSyncCAS(t *testing.T) {
+// TestSetAutoSyncGuarded covers the atomic repoint guard: an unauthorized write
+// may set the first primary or leave it unchanged, but may not repoint a
+// configured one; an authorized (valid-token) write may repoint freely.
+func TestSetAutoSyncGuarded(t *testing.T) {
 	_, store := newTestServer(t)
 	a, _ := store.CreateMember(t.Context(), "a", "http://127.0.0.1:9", "tok")
 	b, _ := store.CreateMember(t.Context(), "b", "http://127.0.0.1:8", "tok")
 
-	// First set from the empty state: expect "" matches, so it applies.
-	applied, err := store.SetAutoSyncCAS(t.Context(), true, a.ID, "")
+	// First set from the empty state needs no token.
+	applied, err := store.SetAutoSyncGuarded(t.Context(), true, a.ID, false)
 	if err != nil {
-		t.Fatalf("SetAutoSyncCAS first: %v", err)
+		t.Fatalf("guarded first: %v", err)
 	}
 	if !applied {
-		t.Fatal("first CAS from empty primary should apply")
+		t.Fatal("first set from empty primary should apply without a token")
 	}
 
-	// A repoint whose expected primary is stale (someone else already moved it to
-	// a.ID) must not apply and must leave the stored primary untouched.
-	applied, err = store.SetAutoSyncCAS(t.Context(), true, b.ID, "stale-id")
+	// Toggling enabled while leaving the primary unchanged needs no token.
+	applied, err = store.SetAutoSyncGuarded(t.Context(), false, a.ID, false)
 	if err != nil {
-		t.Fatalf("SetAutoSyncCAS stale: %v", err)
+		t.Fatalf("guarded unchanged: %v", err)
+	}
+	if !applied {
+		t.Fatal("unchanged-primary write should apply without a token")
+	}
+
+	// Repointing a configured primary without a valid token must not apply and
+	// must leave the stored primary untouched.
+	applied, err = store.SetAutoSyncGuarded(t.Context(), true, b.ID, false)
+	if err != nil {
+		t.Fatalf("guarded unauthorized repoint: %v", err)
 	}
 	if applied {
-		t.Fatal("CAS with a stale expected primary must not apply")
+		t.Fatal("repoint without a token must not apply")
 	}
 	if cfg, _ := store.GetAutoSync(t.Context()); cfg.PrimaryID != a.ID {
-		t.Fatalf("primary = %q after refused CAS, want %q", cfg.PrimaryID, a.ID)
+		t.Fatalf("primary = %q after refused repoint, want %q", cfg.PrimaryID, a.ID)
 	}
 
-	// Repoint with the correct expected primary applies.
-	applied, err = store.SetAutoSyncCAS(t.Context(), true, b.ID, a.ID)
+	// The same repoint with a valid token applies.
+	applied, err = store.SetAutoSyncGuarded(t.Context(), true, b.ID, true)
 	if err != nil {
-		t.Fatalf("SetAutoSyncCAS repoint: %v", err)
+		t.Fatalf("guarded authorized repoint: %v", err)
 	}
 	if !applied {
-		t.Fatal("CAS with the correct expected primary should apply")
+		t.Fatal("repoint with a valid token should apply")
 	}
 	if cfg, _ := store.GetAutoSync(t.Context()); cfg.PrimaryID != b.ID {
-		t.Fatalf("primary = %q after repoint, want %q", cfg.PrimaryID, b.ID)
+		t.Fatalf("primary = %q after authorized repoint, want %q", cfg.PrimaryID, b.ID)
 	}
 }
 
@@ -712,9 +721,8 @@ func TestGetAutoSyncHandlerDBError(t *testing.T) {
 	}
 }
 
-// TestPutAutoSyncDBError: a store failure surfaces as a 500. The handler reads the
-// current config first (to gate primary changes), so on a closed DB it fails on
-// that read before reaching validation or the persist.
+// TestPutAutoSyncDBError: a store failure surfaces as a 500. Clearing the primary
+// skips member validation, so on a closed DB the guarded write is what fails.
 func TestPutAutoSyncDBError(t *testing.T) {
 	srv, store := newTestServer(t)
 	if err := store.db.Close(); err != nil {

--- a/internal/frontdesk/autosync_test.go
+++ b/internal/frontdesk/autosync_test.go
@@ -669,8 +669,9 @@ func TestGetAutoSyncHandlerDBError(t *testing.T) {
 	}
 }
 
-// TestPutAutoSyncDBError: a store write failure surfaces as a 500. primary_id is
-// empty so the handler skips validation and fails on the persist itself.
+// TestPutAutoSyncDBError: a store failure surfaces as a 500. The handler reads the
+// current config first (to gate primary changes), so on a closed DB it fails on
+// that read before reaching validation or the persist.
 func TestPutAutoSyncDBError(t *testing.T) {
 	srv, store := newTestServer(t)
 	if err := store.db.Close(); err != nil {
@@ -689,7 +690,10 @@ func TestPutAutoSyncDisable(t *testing.T) {
 	if err := store.SetAutoSync(t.Context(), true, pm.ID); err != nil {
 		t.Fatalf("SetAutoSync: %v", err)
 	}
-	rec := do(t, srv, http.MethodPut, "/api/fleet/autosync", `{"enabled":false,"primary_id":""}`, true)
+	// Clearing the configured primary is gated on a fresh admin-token confirmation
+	// (TestServerAutoSyncPrimaryGate covers the refusal path), so pass the token.
+	rec := do(t, srv, http.MethodPut, "/api/fleet/autosync",
+		`{"enabled":false,"primary_id":"","confirm_token":"`+testFrontdeskToken+`"}`, true)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("disable = %d (%s)", rec.Code, rec.Body.String())
 	}

--- a/internal/frontdesk/autosync_test.go
+++ b/internal/frontdesk/autosync_test.go
@@ -612,13 +612,17 @@ func TestSetAutoSyncGuarded(t *testing.T) {
 		t.Fatal("first set from empty primary should apply without a token")
 	}
 
-	// Toggling enabled while leaving the primary unchanged needs no token.
-	applied, err = store.SetAutoSyncGuarded(t.Context(), false, a.ID, false)
+	// Toggling enabled while leaving the primary unchanged needs no token and is
+	// honored (this is the enable/disable control).
+	applied, err = store.SetAutoSyncGuarded(t.Context(), true, a.ID, false)
 	if err != nil {
 		t.Fatalf("guarded unchanged: %v", err)
 	}
 	if !applied {
 		t.Fatal("unchanged-primary write should apply without a token")
+	}
+	if cfg, _ := store.GetAutoSync(t.Context()); !cfg.Enabled {
+		t.Fatal("unchanged-primary toggle should have enabled auto-sync")
 	}
 
 	// Repointing a configured primary without a valid token must not apply and
@@ -634,16 +638,22 @@ func TestSetAutoSyncGuarded(t *testing.T) {
 		t.Fatalf("primary = %q after refused repoint, want %q", cfg.PrimaryID, a.ID)
 	}
 
-	// The same repoint with a valid token applies.
-	applied, err = store.SetAutoSyncGuarded(t.Context(), true, b.ID, true)
+	// The same repoint with a valid token applies, and must preserve the stored
+	// enabled flag: a confirmed primary change carries enabled=false here (a stale
+	// snapshot), but auto-sync is on, so it must stay on.
+	applied, err = store.SetAutoSyncGuarded(t.Context(), false, b.ID, true)
 	if err != nil {
 		t.Fatalf("guarded authorized repoint: %v", err)
 	}
 	if !applied {
 		t.Fatal("repoint with a valid token should apply")
 	}
-	if cfg, _ := store.GetAutoSync(t.Context()); cfg.PrimaryID != b.ID {
+	cfg, _ := store.GetAutoSync(t.Context())
+	if cfg.PrimaryID != b.ID {
 		t.Fatalf("primary = %q after authorized repoint, want %q", cfg.PrimaryID, b.ID)
+	}
+	if !cfg.Enabled {
+		t.Fatal("repoint must preserve the stored enabled flag, not the request's stale value")
 	}
 }
 

--- a/internal/frontdesk/autosync_test.go
+++ b/internal/frontdesk/autosync_test.go
@@ -655,6 +655,23 @@ func TestSetAutoSyncGuarded(t *testing.T) {
 	if !cfg.Enabled {
 		t.Fatal("repoint must preserve the stored enabled flag, not the request's stale value")
 	}
+
+	// Clearing the primary forces auto-sync off regardless of the request's flag:
+	// it cannot run without a primary, so even a stale enabled=true must not stick.
+	applied, err = store.SetAutoSyncGuarded(t.Context(), true, "", true)
+	if err != nil {
+		t.Fatalf("guarded clear: %v", err)
+	}
+	if !applied {
+		t.Fatal("clear with a valid token should apply")
+	}
+	cfg, _ = store.GetAutoSync(t.Context())
+	if cfg.PrimaryID != "" {
+		t.Fatalf("primary = %q after clear, want empty", cfg.PrimaryID)
+	}
+	if cfg.Enabled {
+		t.Fatal("clearing the primary must force auto-sync off")
+	}
 }
 
 // TestAutoSyncReEnableConvergesDriftedReplica is the activation-gap fix (Greptile

--- a/internal/frontdesk/autosync_test.go
+++ b/internal/frontdesk/autosync_test.go
@@ -595,6 +595,49 @@ func TestSetAutoSyncClearsAppliedHash(t *testing.T) {
 	}
 }
 
+// TestSetAutoSyncCAS covers the compare-and-swap guard that closes the
+// read-modify-write race in putAutoSync: the write only lands when the stored
+// primary still matches the value the caller gated against.
+func TestSetAutoSyncCAS(t *testing.T) {
+	_, store := newTestServer(t)
+	a, _ := store.CreateMember(t.Context(), "a", "http://127.0.0.1:9", "tok")
+	b, _ := store.CreateMember(t.Context(), "b", "http://127.0.0.1:8", "tok")
+
+	// First set from the empty state: expect "" matches, so it applies.
+	applied, err := store.SetAutoSyncCAS(t.Context(), true, a.ID, "")
+	if err != nil {
+		t.Fatalf("SetAutoSyncCAS first: %v", err)
+	}
+	if !applied {
+		t.Fatal("first CAS from empty primary should apply")
+	}
+
+	// A repoint whose expected primary is stale (someone else already moved it to
+	// a.ID) must not apply and must leave the stored primary untouched.
+	applied, err = store.SetAutoSyncCAS(t.Context(), true, b.ID, "stale-id")
+	if err != nil {
+		t.Fatalf("SetAutoSyncCAS stale: %v", err)
+	}
+	if applied {
+		t.Fatal("CAS with a stale expected primary must not apply")
+	}
+	if cfg, _ := store.GetAutoSync(t.Context()); cfg.PrimaryID != a.ID {
+		t.Fatalf("primary = %q after refused CAS, want %q", cfg.PrimaryID, a.ID)
+	}
+
+	// Repoint with the correct expected primary applies.
+	applied, err = store.SetAutoSyncCAS(t.Context(), true, b.ID, a.ID)
+	if err != nil {
+		t.Fatalf("SetAutoSyncCAS repoint: %v", err)
+	}
+	if !applied {
+		t.Fatal("CAS with the correct expected primary should apply")
+	}
+	if cfg, _ := store.GetAutoSync(t.Context()); cfg.PrimaryID != b.ID {
+		t.Fatalf("primary = %q after repoint, want %q", cfg.PrimaryID, b.ID)
+	}
+}
+
 // TestAutoSyncReEnableConvergesDriftedReplica is the activation-gap fix (Greptile
 // P1): a replica that drifted while sync was off is brought back in line when the
 // operator re-enables auto-sync, even though the primary's config never changed.

--- a/internal/frontdesk/server.go
+++ b/internal/frontdesk/server.go
@@ -558,8 +558,18 @@ func (s *Server) putAutoSync(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "choose a primary before enabling auto-sync", http.StatusBadRequest)
 		return
 	}
-	if err := s.store.SetAutoSync(r.Context(), req.Enabled, req.PrimaryID); err != nil {
+	// Compare-and-swap against the primary we gated on: if another request
+	// repointed it between the read above and here, refuse rather than clobber a
+	// change this caller never confirmed against.
+	applied, err := s.store.SetAutoSyncCAS(r.Context(), req.Enabled, req.PrimaryID, cur.PrimaryID)
+	if err != nil {
 		writeError(w, err)
+		return
+	}
+	if !applied {
+		debuglog.Warn("frontdesk: auto-sync primary changed under a concurrent update; conflict",
+			"expected", cur.PrimaryID, "to", req.PrimaryID)
+		http.Error(w, "the configured primary changed; reload and try again", http.StatusConflict)
 		return
 	}
 	s.emit(r.Context(), Event{

--- a/internal/frontdesk/server.go
+++ b/internal/frontdesk/server.go
@@ -525,21 +525,6 @@ func (s *Server) putAutoSync(w http.ResponseWriter, r *http.Request) {
 	if !decodeJSON(w, r, &req) {
 		return
 	}
-	cur, err := s.store.GetAutoSync(r.Context())
-	if err != nil {
-		writeError(w, err)
-		return
-	}
-	if cur.PrimaryID != "" && req.PrimaryID != cur.PrimaryID &&
-		!s.adminMgr.Validate(strings.TrimSpace(req.ConfirmToken)) {
-		// Audit-worthy: someone tried to repoint or clear the fleet's config
-		// source without the admin token. No secrets are logged (the token is a
-		// pass/fail check), only the attempted transition.
-		debuglog.Warn("frontdesk: refused unconfirmed auto-sync primary change",
-			"from", cur.PrimaryID, "to", req.PrimaryID)
-		http.Error(w, "confirm the admin token to change or clear the configured primary", http.StatusForbidden)
-		return
-	}
 	if req.PrimaryID != "" {
 		m, err := s.store.GetMember(r.Context(), req.PrimaryID)
 		if err != nil {
@@ -558,18 +543,25 @@ func (s *Server) putAutoSync(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "choose a primary before enabling auto-sync", http.StatusBadRequest)
 		return
 	}
-	// Compare-and-swap against the primary we gated on: if another request
-	// repointed it between the read above and here, refuse rather than clobber a
-	// change this caller never confirmed against.
-	applied, err := s.store.SetAutoSyncCAS(r.Context(), req.Enabled, req.PrimaryID, cur.PrimaryID)
+	// Repointing or clearing an already-configured primary is high-impact (it
+	// changes which instance's config the whole fleet copies), so it requires a
+	// valid admin token. The bearer here may be a passkey/TOTP session token
+	// rather than the raw FRONTDESK_TOKEN, so the operator re-supplies the token
+	// in the body and we check it against AdminMgr. The guard is enforced inside
+	// the same UPDATE that writes (SetAutoSyncGuarded), so there is no
+	// read-modify-write window for a concurrent repoint to slip through.
+	tokenValid := s.adminMgr.Validate(strings.TrimSpace(req.ConfirmToken))
+	applied, err := s.store.SetAutoSyncGuarded(r.Context(), req.Enabled, req.PrimaryID, tokenValid)
 	if err != nil {
 		writeError(w, err)
 		return
 	}
 	if !applied {
-		debuglog.Warn("frontdesk: auto-sync primary changed under a concurrent update; conflict",
-			"expected", cur.PrimaryID, "to", req.PrimaryID)
-		http.Error(w, "the configured primary changed; reload and try again", http.StatusConflict)
+		// The change would repoint/clear a configured primary without a valid
+		// token (or lost a concurrent repoint). No secrets are logged, only that a
+		// confirmation-required change was refused.
+		debuglog.Warn("frontdesk: refused unconfirmed auto-sync primary change", "to", req.PrimaryID)
+		http.Error(w, "confirm the admin token to change or clear the configured primary", http.StatusForbidden)
 		return
 	}
 	s.emit(r.Context(), Event{

--- a/internal/frontdesk/server.go
+++ b/internal/frontdesk/server.go
@@ -508,12 +508,31 @@ func (s *Server) getAutoSync(w http.ResponseWriter, r *http.Request) {
 // a primary, or naming a primary that is unknown or has no stored admin token, is
 // rejected: the loop could not authenticate to pull its config, so the choice
 // would silently do nothing.
+//
+// Repointing or clearing an already-configured primary is high-impact (it changes
+// which instance's config gets pushed across the whole fleet), so it is gated on a
+// fresh admin-token confirmation. The bearer may be a passkey/TOTP session token
+// rather than the raw FRONTDESK_TOKEN, so the check happens here against AdminMgr
+// rather than client-side. The first primary selection (none configured yet) and
+// changes that leave the primary untouched (e.g. just toggling enabled) need no
+// confirmation.
 func (s *Server) putAutoSync(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		Enabled   bool   `json:"enabled"`
-		PrimaryID string `json:"primary_id"`
+		Enabled      bool   `json:"enabled"`
+		PrimaryID    string `json:"primary_id"`
+		ConfirmToken string `json:"confirm_token"`
 	}
 	if !decodeJSON(w, r, &req) {
+		return
+	}
+	cur, err := s.store.GetAutoSync(r.Context())
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	if cur.PrimaryID != "" && req.PrimaryID != cur.PrimaryID &&
+		!s.adminMgr.Validate(strings.TrimSpace(req.ConfirmToken)) {
+		http.Error(w, "confirm the admin token to change or clear the configured primary", http.StatusForbidden)
 		return
 	}
 	if req.PrimaryID != "" {

--- a/internal/frontdesk/server.go
+++ b/internal/frontdesk/server.go
@@ -532,6 +532,11 @@ func (s *Server) putAutoSync(w http.ResponseWriter, r *http.Request) {
 	}
 	if cur.PrimaryID != "" && req.PrimaryID != cur.PrimaryID &&
 		!s.adminMgr.Validate(strings.TrimSpace(req.ConfirmToken)) {
+		// Audit-worthy: someone tried to repoint or clear the fleet's config
+		// source without the admin token. No secrets are logged (the token is a
+		// pass/fail check), only the attempted transition.
+		debuglog.Warn("frontdesk: refused unconfirmed auto-sync primary change",
+			"from", cur.PrimaryID, "to", req.PrimaryID)
 		http.Error(w, "confirm the admin token to change or clear the configured primary", http.StatusForbidden)
 		return
 	}

--- a/internal/frontdesk/server_test.go
+++ b/internal/frontdesk/server_test.go
@@ -229,6 +229,66 @@ func TestServerLogout(t *testing.T) {
 	}
 }
 
+func TestServerAutoSyncPrimaryGate(t *testing.T) {
+	srv, store := newTestServer(t)
+	ctx := context.Background()
+	m1, err := store.CreateMember(ctx, "hotel-1", "https://h1.example.com", "tok1")
+	if err != nil {
+		t.Fatalf("create m1: %v", err)
+	}
+	m2, err := store.CreateMember(ctx, "hotel-2", "https://h2.example.com", "tok2")
+	if err != nil {
+		t.Fatalf("create m2: %v", err)
+	}
+
+	put := func(body string) *httptest.ResponseRecorder {
+		return do(t, srv, http.MethodPut, "/api/fleet/autosync", body, true)
+	}
+	primaryNow := func() string {
+		rec := do(t, srv, http.MethodGet, "/api/fleet/autosync", "", true)
+		var cfg struct {
+			PrimaryID string `json:"primary_id"`
+		}
+		_ = json.Unmarshal(rec.Body.Bytes(), &cfg)
+		return cfg.PrimaryID
+	}
+
+	// First selection (none configured yet) needs no confirmation.
+	if rec := put(`{"enabled":false,"primary_id":"` + m1.ID + `"}`); rec.Code != http.StatusOK {
+		t.Fatalf("initial primary = %d; body=%s", rec.Code, rec.Body.String())
+	}
+
+	// Repointing an already-set primary without the admin token is refused.
+	if rec := put(`{"enabled":false,"primary_id":"` + m2.ID + `"}`); rec.Code != http.StatusForbidden {
+		t.Errorf("repoint without token = %d, want 403; body=%s", rec.Code, rec.Body.String())
+	}
+	// A wrong token is equally refused.
+	if rec := put(`{"enabled":false,"primary_id":"` + m2.ID + `","confirm_token":"nope"}`); rec.Code != http.StatusForbidden {
+		t.Errorf("repoint wrong token = %d, want 403", rec.Code)
+	}
+	if got := primaryNow(); got != m1.ID {
+		t.Errorf("primary changed despite refusal: got %q, want %q", got, m1.ID)
+	}
+	// The correct admin token lets the repoint through.
+	if rec := put(`{"enabled":false,"primary_id":"` + m2.ID + `","confirm_token":"` + testFrontdeskToken + `"}`); rec.Code != http.StatusOK {
+		t.Fatalf("repoint with token = %d; body=%s", rec.Code, rec.Body.String())
+	}
+	if got := primaryNow(); got != m2.ID {
+		t.Errorf("primary after confirmed repoint: got %q, want %q", got, m2.ID)
+	}
+
+	// Clearing the primary is gated the same way.
+	if rec := put(`{"enabled":false,"primary_id":""}`); rec.Code != http.StatusForbidden {
+		t.Errorf("clear without token = %d, want 403", rec.Code)
+	}
+	if rec := put(`{"enabled":false,"primary_id":"","confirm_token":"` + testFrontdeskToken + `"}`); rec.Code != http.StatusOK {
+		t.Fatalf("clear with token = %d; body=%s", rec.Code, rec.Body.String())
+	}
+	if got := primaryNow(); got != "" {
+		t.Errorf("primary after confirmed clear: got %q, want empty", got)
+	}
+}
+
 func TestServerEventsAndStatus(t *testing.T) {
 	srv, _ := newTestServer(t)
 

--- a/internal/frontdesk/store.go
+++ b/internal/frontdesk/store.go
@@ -492,26 +492,33 @@ func (s *Store) SetAutoSync(ctx context.Context, enabled bool, primaryID string)
 	return nil
 }
 
-// SetAutoSyncCAS persists the auto-sync choice only if the stored primary still
-// equals expectPrimaryID. This closes the read-modify-write race in putAutoSync:
-// the admin-token gate validates against the primary observed at read time, so
-// the write must not land if another request repointed the primary in between
-// (which would silently clobber a change we never confirmed against). Reports
-// whether the row was updated; false means a concurrent change won and the
-// caller should treat it as a conflict. Clears the last-applied hash like
-// SetAutoSync, for the same re-arm reason.
-func (s *Store) SetAutoSyncCAS(ctx context.Context, enabled bool, primaryID, expectPrimaryID string) (bool, error) {
-	res, err := s.db.ExecContext(ctx,
-		`UPDATE settings SET auto_sync_enabled = ?, auto_sync_primary_id = ?, auto_sync_last_hash = ''
-		 WHERE id = 1 AND auto_sync_primary_id = ?`,
-		boolToInt(enabled), primaryID, expectPrimaryID,
-	)
+// SetAutoSyncGuarded persists the auto-sync choice while enforcing the repoint
+// guard in the same statement that writes, so there is no read-modify-write
+// window a concurrent repoint could slip through. When the caller is authorized
+// (tokenValid, a valid admin token), the choice is written unconditionally.
+// Otherwise the write only applies when it does not repoint an already-configured
+// primary: either none is set yet, or the request leaves the primary unchanged
+// (e.g. just toggling enabled). Reports whether the row was updated; false means
+// the change needed admin confirmation (or lost a concurrent repoint) and the
+// caller must refuse it. Clears the last-applied hash like SetAutoSync, for the
+// same re-arm reason.
+func (s *Store) SetAutoSyncGuarded(ctx context.Context, enabled bool, primaryID string, tokenValid bool) (bool, error) {
+	const set = `UPDATE settings SET auto_sync_enabled = ?, auto_sync_primary_id = ?, auto_sync_last_hash = '' WHERE id = 1`
+	query := set
+	args := []any{boolToInt(enabled), primaryID}
+	if !tokenValid {
+		// Unauthorized writes may not repoint a configured primary: apply only when
+		// none is set yet or the primary is left unchanged.
+		query = set + ` AND (auto_sync_primary_id = '' OR auto_sync_primary_id = ?)`
+		args = append(args, primaryID)
+	}
+	res, err := s.db.ExecContext(ctx, query, args...)
 	if err != nil {
-		return false, fmt.Errorf("frontdesk: set auto-sync (cas): %w", err)
+		return false, fmt.Errorf("frontdesk: set auto-sync (guarded): %w", err)
 	}
 	n, err := res.RowsAffected()
 	if err != nil {
-		return false, fmt.Errorf("frontdesk: set auto-sync (cas) rows: %w", err)
+		return false, fmt.Errorf("frontdesk: set auto-sync (guarded) rows: %w", err)
 	}
 	return n > 0, nil
 }

--- a/internal/frontdesk/store.go
+++ b/internal/frontdesk/store.go
@@ -492,6 +492,30 @@ func (s *Store) SetAutoSync(ctx context.Context, enabled bool, primaryID string)
 	return nil
 }
 
+// SetAutoSyncCAS persists the auto-sync choice only if the stored primary still
+// equals expectPrimaryID. This closes the read-modify-write race in putAutoSync:
+// the admin-token gate validates against the primary observed at read time, so
+// the write must not land if another request repointed the primary in between
+// (which would silently clobber a change we never confirmed against). Reports
+// whether the row was updated; false means a concurrent change won and the
+// caller should treat it as a conflict. Clears the last-applied hash like
+// SetAutoSync, for the same re-arm reason.
+func (s *Store) SetAutoSyncCAS(ctx context.Context, enabled bool, primaryID, expectPrimaryID string) (bool, error) {
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE settings SET auto_sync_enabled = ?, auto_sync_primary_id = ?, auto_sync_last_hash = ''
+		 WHERE id = 1 AND auto_sync_primary_id = ?`,
+		boolToInt(enabled), primaryID, expectPrimaryID,
+	)
+	if err != nil {
+		return false, fmt.Errorf("frontdesk: set auto-sync (cas): %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("frontdesk: set auto-sync (cas) rows: %w", err)
+	}
+	return n > 0, nil
+}
+
 // SetAutoSyncLastHash records the primary config hash the poller just applied to
 // the fleet, so the next tick can detect a change cheaply.
 func (s *Store) SetAutoSyncLastHash(ctx context.Context, hash string) error {

--- a/internal/frontdesk/store.go
+++ b/internal/frontdesk/store.go
@@ -503,13 +503,27 @@ func (s *Store) SetAutoSync(ctx context.Context, enabled bool, primaryID string)
 // caller must refuse it. Clears the last-applied hash like SetAutoSync, for the
 // same re-arm reason.
 func (s *Store) SetAutoSyncGuarded(ctx context.Context, enabled bool, primaryID string, tokenValid bool) (bool, error) {
-	const set = `UPDATE settings SET auto_sync_enabled = ?, auto_sync_primary_id = ?, auto_sync_last_hash = '' WHERE id = 1`
+	// auto_sync_enabled is honored only when the request is about the enabled flag
+	// itself: a first set (no primary yet), a clear (new primary empty), or a
+	// toggle that leaves the primary unchanged. On a true repoint (new primary
+	// differs from the stored one) the CASE keeps the stored value, so a confirmed
+	// primary change can never overwrite an enable/disable another operator made
+	// concurrently. The CASE compares against the row's pre-update primary, since
+	// SQLite evaluates SET right-hand sides against the original row.
+	const set = `UPDATE settings SET
+		auto_sync_primary_id = ?,
+		auto_sync_enabled = CASE
+			WHEN ? = '' OR auto_sync_primary_id = '' OR auto_sync_primary_id = ? THEN ?
+			ELSE auto_sync_enabled
+		END,
+		auto_sync_last_hash = ''
+	WHERE id = 1`
 	query := set
-	args := []any{boolToInt(enabled), primaryID}
+	args := []any{primaryID, primaryID, primaryID, boolToInt(enabled)}
 	if !tokenValid {
 		// Unauthorized writes may not repoint a configured primary: apply only when
 		// none is set yet or the primary is left unchanged.
-		query = set + ` AND (auto_sync_primary_id = '' OR auto_sync_primary_id = ?)`
+		query += ` AND (auto_sync_primary_id = '' OR auto_sync_primary_id = ?)`
 		args = append(args, primaryID)
 	}
 	res, err := s.db.ExecContext(ctx, query, args...)

--- a/internal/frontdesk/store.go
+++ b/internal/frontdesk/store.go
@@ -503,17 +503,21 @@ func (s *Store) SetAutoSync(ctx context.Context, enabled bool, primaryID string)
 // caller must refuse it. Clears the last-applied hash like SetAutoSync, for the
 // same re-arm reason.
 func (s *Store) SetAutoSyncGuarded(ctx context.Context, enabled bool, primaryID string, tokenValid bool) (bool, error) {
-	// auto_sync_enabled is honored only when the request is about the enabled flag
-	// itself: a first set (no primary yet), a clear (new primary empty), or a
-	// toggle that leaves the primary unchanged. On a true repoint (new primary
-	// differs from the stored one) the CASE keeps the stored value, so a confirmed
-	// primary change can never overwrite an enable/disable another operator made
-	// concurrently. The CASE compares against the row's pre-update primary, since
-	// SQLite evaluates SET right-hand sides against the original row.
+	// auto_sync_enabled rules, evaluated in order against the row's pre-update
+	// primary (SQLite reads SET right-hand sides from the original row):
+	//   - clearing the primary (new primary empty) forces it off: auto-sync cannot
+	//     run without a primary, so this holds the invariant regardless of the
+	//     request's flag and independent of any concurrent enable.
+	//   - a first set (no primary yet) or an unchanged-primary toggle honors the
+	//     requested value: these are the enable/disable control itself.
+	//   - a true repoint (new primary differs from the stored one) keeps the stored
+	//     value, so a confirmed primary change can never overwrite an enable/disable
+	//     another operator made concurrently.
 	const set = `UPDATE settings SET
 		auto_sync_primary_id = ?,
 		auto_sync_enabled = CASE
-			WHEN ? = '' OR auto_sync_primary_id = '' OR auto_sync_primary_id = ? THEN ?
+			WHEN ? = '' THEN 0
+			WHEN auto_sync_primary_id = '' OR auto_sync_primary_id = ? THEN ?
 			ELSE auto_sync_enabled
 		END,
 		auto_sync_last_hash = ''

--- a/web/src/pages/Settings/AuthenticationSettings.tsx
+++ b/web/src/pages/Settings/AuthenticationSettings.tsx
@@ -15,10 +15,11 @@ interface AuthenticationSettingsProps {
 
 /**
  * Authentication groups the admin sign-in hardening methods, passkeys and TOTP
- * two-factor, side by side, with a session auto-logout control beneath them.
- * Each method keeps its own panel/logic (PasskeyPanel, TotpPanel); the session
- * timeout is a stored setting (session_idle_timeout_minutes) consumed by
- * useIdleLogout to sign the admin out after inactivity (0 = never).
+ * two-factor, side by side. The session auto-logout control sits in the right
+ * column beneath TOTP so it doesn't stretch across both columns. Each method
+ * keeps its own panel/logic (PasskeyPanel, TotpPanel); the session timeout is a
+ * stored setting (session_idle_timeout_minutes) consumed by useIdleLogout to
+ * sign the admin out after inactivity (0 = never).
  */
 export function AuthenticationSettings({
 	collapsed,
@@ -40,39 +41,38 @@ export function AuthenticationSettings({
 			collapsed={collapsed}
 			onToggle={onToggle}
 		>
-			<div className="space-y-5">
-				<div className="grid grid-cols-2 gap-x-6 gap-y-5 [align-items:start]">
-					<SettingsGroup title={t("settings.passkeys.title")}>
-						<PasskeyPanel />
-					</SettingsGroup>
+			<div className="grid grid-cols-2 gap-x-6 gap-y-5 [align-items:start]">
+				<SettingsGroup title={t("settings.passkeys.title")}>
+					<PasskeyPanel />
+				</SettingsGroup>
+				<div className="space-y-5">
 					<SettingsGroup title={t("settings.totp.title")}>
 						<TotpPanel />
 					</SettingsGroup>
+					<SettingsGroup title={t("settings.sessionTimeout.title")}>
+						<SettingsSlider
+							id="session-idle-timeout"
+							label={t("settings.sessionTimeout.label")}
+							value={Number.isFinite(idleMinutes) ? idleMinutes : 60}
+							min={0}
+							max={240}
+							step={5}
+							clampStep={5}
+							infinityValue={0}
+							unit="m"
+							onChange={(v) =>
+								updateMutation.mutate({
+									session_idle_timeout_minutes: String(v),
+								})
+							}
+							description={t("settings.sessionTimeout.hint")}
+							onReset={() =>
+								resetSettingMutation.mutate(["session_idle_timeout_minutes"])
+							}
+							resetTooltip={t("settings.common.resetSetting")}
+						/>
+					</SettingsGroup>
 				</div>
-
-				<SettingsGroup title={t("settings.sessionTimeout.title")}>
-					<SettingsSlider
-						id="session-idle-timeout"
-						label={t("settings.sessionTimeout.label")}
-						value={Number.isFinite(idleMinutes) ? idleMinutes : 60}
-						min={0}
-						max={240}
-						step={5}
-						clampStep={5}
-						infinityValue={0}
-						unit="m"
-						onChange={(v) =>
-							updateMutation.mutate({
-								session_idle_timeout_minutes: String(v),
-							})
-						}
-						description={t("settings.sessionTimeout.hint")}
-						onReset={() =>
-							resetSettingMutation.mutate(["session_idle_timeout_minutes"])
-						}
-						resetTooltip={t("settings.common.resetSetting")}
-					/>
-				</SettingsGroup>
 			</div>
 		</SettingsSection>
 	);


### PR DESCRIPTION
Four small UI/safety polish items across Model Hotel (MH) and Front Desk (FD).

## Front Desk

**Gate changing/clearing the auto-sync primary behind admin-token confirmation.**
Repointing or clearing an already-configured primary is high-impact (it changes
which instance's config gets pushed across the whole fleet). `putAutoSync` now
requires a fresh admin-token confirmation for that transition, validated
server-side against `AdminMgr` (constant-time) because the bearer may be a
passkey/TOTP session token rather than the raw `FRONTDESK_TOKEN`. First-time
selection and changes that leave the primary untouched (e.g. just toggling
enabled) are not gated. The panel routes a primary change through a
`ConfirmModal` that collects the token. A refused 403 is audit-logged
(transition only, no secrets).

**Footer commit tooltip.** The footer shows just the version (e.g. `dev`) with
the build commit SHA moved into the hover tooltip, matching the main dashboard.
Still deep-links to the exact commit.

**Apprise services link.** Added a "Browse all 80+ services" link to the alerts
panel, mirroring the main app.

## Model Hotel

**Settings layout.** Moved the session auto-logout card into the right column
under TOTP instead of a full-width row spanning both columns.

## Tests
- New `TestServerAutoSyncPrimaryGate` (repoint/clear without/with wrong/with
  correct token). Updated `TestPutAutoSyncDisable` / `TestPutAutoSyncDBError`
  for the now-gated clear path.
- New FD vitest covering the confirm-modal gate and footer tooltip behavior.
- Go build/test/lint, both frontends `tsc -b`, FD + MH touched vitest suites,
  biome + eslint all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)