### PR TITLE
fix(frontdesk): stamp version/commit in the HA build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ frontdesk-build:
 	CGO_ENABLED=0 go build -ldflags "-X main.version=$(VERSION) -X github.com/hugalafutro/model-hotel/internal/frontdesk.buildCommit=$(COMMIT)" -o bin/frontdesk ./cmd/frontdesk/
 
 ha-up:
-	docker compose -f $(HA_COMPOSE) up -d --build
+	VERSION=$(VERSION) COMMIT=$(COMMIT) docker compose -f $(HA_COMPOSE) up -d --build
 
 ha-down:
 	docker compose -f $(HA_COMPOSE) down

--- a/deploy/ha/docker-compose.yml
+++ b/deploy/ha/docker-compose.yml
@@ -6,6 +6,11 @@
 # Desk serves its admin UI on :8090. Add/drain/remove members in the Front Desk
 # UI; Traefik follows within seconds.
 #
+# Build stamping: prefer `make ha-up` when building from source. It passes
+# VERSION/COMMIT into the build so the Front Desk footer shows the real build; a
+# bare `docker compose up -d` falls back to a `dev` footer (the prebuilt image
+# carries its own release stamp).
+#
 # HTTPS-ONLY INGRESS: this stack speaks plain HTTP. A TLS-terminating reverse
 # proxy (e.g. nginx with a real cert) MUST sit in front of both published ports
 # so browsers and clients only ever reach the stack over HTTPS. See docs/HA.md.

--- a/deploy/ha/docker-compose.yml
+++ b/deploy/ha/docker-compose.yml
@@ -50,6 +50,12 @@ services:
         build:
             context: ../..
             dockerfile: Dockerfile.frontdesk
+            # Stamp the build version/commit so the Front Desk footer shows the
+            # real build (the Makefile ha-up target exports these). Without them
+            # the Dockerfile defaults (dev/unknown) win and the footer reads "dev".
+            args:
+                VERSION: ${VERSION:-dev}
+                COMMIT: ${COMMIT:-unknown}
         # Prebuilt image (uncomment to pin a published tag instead of building):
         # image: ghcr.io/hugalafutro/model-hotel-frontdesk:latest
         labels:

--- a/docs/HA.md
+++ b/docs/HA.md
@@ -47,6 +47,12 @@ docker compose up -d        # or, from the repo root: make ha-up
 docker compose logs -f      # capture the generated FRONTDESK_TOKEN if you left it blank
 ```
 
+> Build stamping: the Front Desk footer shows the version and commit stamped in
+> at build time. `make ha-up` (from the repo root) passes both into the build; a
+> bare `docker compose up -d` built from source does not, so its footer reads
+> `dev`. The prebuilt image (uncomment `image:` in the compose file) carries its
+> own release stamp.
+
 Traefik now answers client traffic on `:8080`; Front Desk's UI is on `:8090`.
 Point your external TLS proxy at both (see "TLS proxy" below).
 

--- a/wiki/High-Availability.md
+++ b/wiki/High-Availability.md
@@ -92,6 +92,12 @@ docker compose up -d        # or, from the repo root: make ha-up
 docker compose logs -f      # capture the generated FRONTDESK_TOKEN if you left it blank
 ```
 
+> Build stamping: the Front Desk footer shows the version and commit stamped in
+> at build time. `make ha-up` (from the repo root) passes both into the build; a
+> bare `docker compose up -d` built from source does not, so its footer reads
+> `dev`. The prebuilt image (uncomment `image:` in the compose file) carries its
+> own release stamp.
+
 Traefik answers client traffic on `:8080`; Front Desk's UI is on `:8090`. Point
 your external TLS proxy at both (see [TLS Proxy](#tls-proxy)).
 


### PR DESCRIPTION
## What

`make ha-up` built the Front Desk image without passing `VERSION`/`COMMIT`, so the Dockerfile's `ARG VERSION=dev` / `ARG COMMIT=unknown` defaults won. The footer therefore always read **dev** with no commit, on every HA build, regardless of what was checked out. This had nothing to do with `:dev` vs prebuilt images: the build wiring simply never stamped the values.

The main stack threads these two ways; the HA stack was missing both:
- `docker-compose.yml` app service has `build.args: { VERSION, COMMIT }` → HA compose's `frontdesk` build block had none.
- `make docker-build` runs `VERSION=… COMMIT=… docker compose … --build` → `make ha-up` ran a plain `docker compose … --build`.

## Fix

Mirror the main stack:
- `deploy/ha/docker-compose.yml`: add `build.args` (`VERSION`/`COMMIT`) to the `frontdesk` service.
- `Makefile` `ha-up`: export `VERSION=$(VERSION) COMMIT=$(COMMIT)` so the args populate.

## Behavior after the fix

- A clean tracked `.version` (e.g. `0.9.80`) renders as a **release** per `isDevVersion()`: the footer shows the tag, links to the repo root, and does not advertise the commit. This is by-design and matches the main dashboard footer.
- A dev build (`make ha-up VERSION=dev`) now surfaces the real commit in the footer tooltip and deep-links to it, instead of `dev`/`unknown`.

## Verification

`docker compose -f deploy/ha/docker-compose.yml config` renders the populated args (`VERSION=0.9.80`, real `COMMIT`); rebuilt HA stack confirmed showing the stamped build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)