### PR TITLE
feat(frontdesk): HA error category in the sidebar error shelf

### DIFF
--- a/web/src/components/ErrorShelf/ErrorShelf.tsx
+++ b/web/src/components/ErrorShelf/ErrorShelf.tsx
@@ -13,7 +13,7 @@ import { useToast } from "../../context/ToastContext";
 import { formatRelativeTime, formatTimestamp } from "../../utils/format";
 import { truncateWithEllipsis } from "../../utils/truncate";
 import { LogDetailModal } from "../LogDetailModal";
-import { type ShelfError, useErrorShelf } from "./useErrorShelf";
+import { isHaSource, type ShelfError, useErrorShelf } from "./useErrorShelf";
 
 /**
  * Sidebar error shelf — a collapsible header that expands into a newest-first,
@@ -174,67 +174,77 @@ export function ErrorShelf() {
 							</button>
 						</div>
 						<ul className="ui-error-shelf-list max-h-[40vh] divide-y divide-[var(--error-border)] overflow-y-auto">
-							{unacked.map((err, i) => (
-								<li
-									key={err.key}
-									className={`ui-error-shelf-row ui-error-shelf-row--${err.kind} group/row px-2.5 py-1.5`}
-									style={{ animationDelay: `${Math.min(i, 10) * 28}ms` }}
-									data-testid="error-shelf-row"
-								>
-									<div className="flex items-center gap-1.5">
-										<span
-											className={`ui-error-shelf-chip ui-error-shelf-chip--${err.kind} shrink-0`}
-											data-testid={`error-shelf-chip-${err.kind}`}
-										>
-											{err.kind === "request"
-												? t("layout.errorShelf.requestKind")
-												: t("layout.errorShelf.appKind")}
-										</span>
-										<span
-											className="text-[10px] text-[var(--error-text-muted)] tabular-nums"
-											title={formatTimestamp(err.timestamp)}
-										>
-											{formatRelativeTime(err.timestamp)}
-										</span>
-										<span className="flex-1" />
-										<div className="flex shrink-0 items-center gap-0.5 opacity-70 transition-opacity group-hover/row:opacity-100">
-											<button
-												type="button"
-												onClick={() => handleCopy(err.message)}
-												className="ui-error-shelf-rowbtn"
-												title={t("layout.errorShelf.copyError")}
-											>
-												<Copy size={11} />
-											</button>
-											<button
-												type="button"
-												onClick={() => handleViewDetails(err)}
-												className="ui-error-shelf-rowbtn"
-												title={t("layout.errorShelf.viewDetails")}
-											>
-												<ExternalLink size={11} />
-											</button>
-											<button
-												type="button"
-												onClick={() => handleAck(err.key)}
-												className="ui-error-shelf-rowbtn"
-												title={t("layout.errorShelf.acknowledge")}
-												data-testid="error-shelf-ack"
-											>
-												<X size={11} />
-											</button>
-										</div>
-									</div>
-									<p
-										className="ui-error-shelf-msg mt-0.5 break-words font-mono text-[9.5px] leading-relaxed text-[var(--error-text-muted)]"
-										title={err.message}
+							{unacked.map((err, i) => {
+								// HA membership failures are app errors whose source is the
+								// fleet config-sync receiver; they get their own chip + accent
+								// while still opening as an "app" log in the detail modal.
+								const category = isHaSource(err.source) ? "ha" : err.kind;
+								const chipLabel =
+									category === "ha"
+										? t("layout.errorShelf.haKind")
+										: category === "request"
+											? t("layout.errorShelf.requestKind")
+											: t("layout.errorShelf.appKind");
+								return (
+									<li
+										key={err.key}
+										className={`ui-error-shelf-row ui-error-shelf-row--${category} group/row px-2.5 py-1.5`}
+										style={{ animationDelay: `${Math.min(i, 10) * 28}ms` }}
+										data-testid="error-shelf-row"
 									>
-										{err.message.length > 200
-											? truncateWithEllipsis(err.message, 200)
-											: err.message}
-									</p>
-								</li>
-							))}
+										<div className="flex items-center gap-1.5">
+											<span
+												className={`ui-error-shelf-chip ui-error-shelf-chip--${category} shrink-0`}
+												data-testid={`error-shelf-chip-${category}`}
+											>
+												{chipLabel}
+											</span>
+											<span
+												className="text-[10px] text-[var(--error-text-muted)] tabular-nums"
+												title={formatTimestamp(err.timestamp)}
+											>
+												{formatRelativeTime(err.timestamp)}
+											</span>
+											<span className="flex-1" />
+											<div className="flex shrink-0 items-center gap-0.5 opacity-70 transition-opacity group-hover/row:opacity-100">
+												<button
+													type="button"
+													onClick={() => handleCopy(err.message)}
+													className="ui-error-shelf-rowbtn"
+													title={t("layout.errorShelf.copyError")}
+												>
+													<Copy size={11} />
+												</button>
+												<button
+													type="button"
+													onClick={() => handleViewDetails(err)}
+													className="ui-error-shelf-rowbtn"
+													title={t("layout.errorShelf.viewDetails")}
+												>
+													<ExternalLink size={11} />
+												</button>
+												<button
+													type="button"
+													onClick={() => handleAck(err.key)}
+													className="ui-error-shelf-rowbtn"
+													title={t("layout.errorShelf.acknowledge")}
+													data-testid="error-shelf-ack"
+												>
+													<X size={11} />
+												</button>
+											</div>
+										</div>
+										<p
+											className="ui-error-shelf-msg mt-0.5 break-words font-mono text-[9.5px] leading-relaxed text-[var(--error-text-muted)]"
+											title={err.message}
+										>
+											{err.message.length > 200
+												? truncateWithEllipsis(err.message, 200)
+												: err.message}
+										</p>
+									</li>
+								);
+							})}
 						</ul>
 					</div>
 				)}

--- a/web/src/components/ErrorShelf/__tests__/ErrorShelf.test.tsx
+++ b/web/src/components/ErrorShelf/__tests__/ErrorShelf.test.tsx
@@ -30,17 +30,17 @@ function seedRequestError(message: string, createdAt: string) {
 	);
 }
 
-/** Seed the app-log history endpoint with one error row. */
-function seedAppError(message: string, timestamp: string) {
+/** Seed the app-log history endpoint with one error row. The source defaults
+ * to "server"; pass a fleet source ("configsync"/"fleet") to exercise the HA
+ * sub-category. */
+function seedAppError(message: string, timestamp: string, source = "server") {
 	server.use(
 		http.get("/api/logs/app", ({ request }) => {
 			if (new URL(request.url).searchParams.get("history") !== "true") {
 				return HttpResponse.json([]);
 			}
 			return HttpResponse.json({
-				entries: [
-					{ id: "app-1", timestamp, level: "error", source: "server", message },
-				],
+				entries: [{ id: "app-1", timestamp, level: "error", source, message }],
 				total: 1,
 				page: 1,
 				per_page: 15,
@@ -117,6 +117,21 @@ describe("ErrorShelf", () => {
 		expect(within(rows[0]).getByText("req boom")).toBeTruthy();
 		expect(within(rows[1]).getByTestId("error-shelf-chip-app")).toBeTruthy();
 		expect(within(rows[1]).getByText("app boom")).toBeTruthy();
+	});
+
+	it("tags fleet config-sync app errors with the HA chip", async () => {
+		seedAppError("apply import failed", "2024-02-01T09:00:00Z", "configsync");
+		renderWithProviders(<ErrorShelf />);
+
+		await screen.findByTestId("error-shelf-count");
+		await expand();
+
+		const rows = await screen.findAllByTestId("error-shelf-row");
+		expect(rows).toHaveLength(1);
+		// An HA-sourced app error gets the HA chip, not the generic app chip.
+		expect(within(rows[0]).getByTestId("error-shelf-chip-ha")).toBeTruthy();
+		expect(within(rows[0]).queryByTestId("error-shelf-chip-app")).toBeNull();
+		expect(within(rows[0]).getByText("apply import failed")).toBeTruthy();
 	});
 
 	it("acknowledges a single row, persists it, and hides when none remain", async () => {

--- a/web/src/components/ErrorShelf/__tests__/ErrorShelf.test.tsx
+++ b/web/src/components/ErrorShelf/__tests__/ErrorShelf.test.tsx
@@ -4,6 +4,21 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { server } from "../../../test/mocks/server";
 import { renderWithProviders } from "../../../test/utils";
 import { ErrorShelf } from "../ErrorShelf";
+import { isHaSource } from "../useErrorShelf";
+
+describe("isHaSource", () => {
+	it("flags the fleet config-sync sources", () => {
+		expect(isHaSource("configsync")).toBe(true);
+		expect(isHaSource("fleet")).toBe(true);
+	});
+
+	it("rejects non-fleet and missing sources", () => {
+		expect(isHaSource("server")).toBe(false);
+		expect(isHaSource("proxy")).toBe(false);
+		expect(isHaSource(undefined)).toBe(false);
+		expect(isHaSource("")).toBe(false);
+	});
+});
 
 /** Seed the request-log (5xx) endpoint with one error row. */
 function seedRequestError(message: string, createdAt: string) {
@@ -132,6 +147,22 @@ describe("ErrorShelf", () => {
 		expect(within(rows[0]).getByTestId("error-shelf-chip-ha")).toBeTruthy();
 		expect(within(rows[0]).queryByTestId("error-shelf-chip-app")).toBeNull();
 		expect(within(rows[0]).getByText("apply import failed")).toBeTruthy();
+	});
+
+	it("opens an HA error in the app log-detail modal", async () => {
+		// HA stays kind="app", so "View details" must route to the app modal,
+		// which surfaces the source ("configsync") and message.
+		seedAppError("apply import failed", "2024-02-01T09:00:00Z", "configsync");
+		const { user } = renderWithProviders(<ErrorShelf />);
+
+		await screen.findByTestId("error-shelf-count");
+		await expand();
+		const row = await screen.findByTestId("error-shelf-row");
+		await user.click(within(row).getByTitle("View details"));
+
+		const dialog = await screen.findByRole("dialog");
+		expect(within(dialog).getByText("configsync")).toBeTruthy();
+		expect(within(dialog).getByText("apply import failed")).toBeTruthy();
 	});
 
 	it("acknowledges a single row, persists it, and hides when none remain", async () => {

--- a/web/src/components/ErrorShelf/useErrorShelf.ts
+++ b/web/src/components/ErrorShelf/useErrorShelf.ts
@@ -18,6 +18,17 @@ const LEGACY_KEYS = ["dismissedAppErrorKey", "dismissedReqErrorKey"] as const;
 
 export type ShelfErrorKind = "request" | "app";
 
+/** App-log sources emitted by the HA member-side config-sync receiver. An app
+ * error from one of these is surfaced as a distinct "HA" category (a member
+ * failing to apply config pushed by the fleet primary) rather than a generic
+ * internal app error. Proxy/request errors never originate here. */
+const HA_SOURCES = new Set(["configsync", "fleet"]);
+
+/** True when an app-log source identifies a fleet/HA membership failure. */
+export function isHaSource(source: string | undefined): boolean {
+	return source !== undefined && HA_SOURCES.has(source);
+}
+
 export interface ShelfError {
 	/** Stable id used for acknowledgement + React keys. Mirrors the old
 	 * `${timestamp}:${msg[:50]}` scheme, kind-prefixed so app/request errors
@@ -30,6 +41,8 @@ export interface ShelfError {
 	entry: LogEntry | AppLogEntry;
 	/** Machine-readable failure classification (request errors only). */
 	errorKind?: string;
+	/** App-log emitter source (app errors only); drives the HA sub-category. */
+	source?: string;
 }
 
 function makeKey(kind: ShelfErrorKind, timestamp: string, message: string) {
@@ -147,6 +160,7 @@ export function useErrorShelf(): UseErrorShelf {
 				message: entry.message,
 				timestamp: entry.timestamp,
 				entry,
+				source: entry.source || undefined,
 			});
 		}
 

--- a/web/src/i18n/locales/af.json
+++ b/web/src/i18n/locales/af.json
@@ -189,6 +189,7 @@
 		"errorShelf": {
 			"acknowledge": "Verwerp",
 			"appKind": "App",
+			"haKind": "HA",
 			"clearAll": "Maak alles skoon",
 			"copyError": "Kopieer fout",
 			"requestKind": "Req",

--- a/web/src/i18n/locales/ar.json
+++ b/web/src/i18n/locales/ar.json
@@ -189,6 +189,7 @@
 		"errorShelf": {
 			"acknowledge": "تجاهل",
 			"appKind": "App",
+			"haKind": "HA",
 			"clearAll": "مسح الكل",
 			"copyError": "نسخ الخطأ",
 			"requestKind": "Req",

--- a/web/src/i18n/locales/ca.json
+++ b/web/src/i18n/locales/ca.json
@@ -189,6 +189,7 @@
 		"errorShelf": {
 			"acknowledge": "Descartar",
 			"appKind": "App",
+			"haKind": "HA",
 			"clearAll": "Esborrar tot",
 			"copyError": "Còpia d'error",
 			"requestKind": "Req",

--- a/web/src/i18n/locales/cs.json
+++ b/web/src/i18n/locales/cs.json
@@ -189,6 +189,7 @@
 		"errorShelf": {
 			"acknowledge": "Zavřít",
 			"appKind": "App",
+			"haKind": "HA",
 			"clearAll": "Vymazat vše",
 			"copyError": "Chyba kopírování",
 			"requestKind": "Req",

--- a/web/src/i18n/locales/da.json
+++ b/web/src/i18n/locales/da.json
@@ -189,6 +189,7 @@
 		"errorShelf": {
 			"acknowledge": "Afvis",
 			"appKind": "App",
+			"haKind": "HA",
 			"clearAll": "Ryd alt",
 			"copyError": "Kopieringsfejl",
 			"requestKind": "Req",

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -189,6 +189,7 @@
 		"errorShelf": {
 			"acknowledge": "Schließen",
 			"appKind": "App",
+			"haKind": "HA",
 			"clearAll": "Alle löschen",
 			"copyError": "Kopierfehler",
 			"requestKind": "Req",

--- a/web/src/i18n/locales/el.json
+++ b/web/src/i18n/locales/el.json
@@ -189,6 +189,7 @@
 		"errorShelf": {
 			"acknowledge": "Απόρριψη",
 			"appKind": "App",
+			"haKind": "HA",
 			"clearAll": "Εκκαθάριση όλων",
 			"copyError": "Σφάλμα αντιγραφής",
 			"requestKind": "Req",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -187,6 +187,7 @@
 			"clearAllConfirm": "Click again to confirm",
 			"requestKind": "Req",
 			"appKind": "App",
+			"haKind": "HA",
 			"copyError": "Copy error",
 			"viewDetails": "View details",
 			"acknowledge": "Dismiss"

--- a/web/src/i18n/locales/es.json
+++ b/web/src/i18n/locales/es.json
@@ -189,6 +189,7 @@
 		"errorShelf": {
 			"acknowledge": "Descartar",
 			"appKind": "App",
+			"haKind": "HA",
 			"clearAll": "Borrar todo",
 			"copyError": "Error de copia",
 			"requestKind": "Req",

--- a/web/src/i18n/locales/fi.json
+++ b/web/src/i18n/locales/fi.json
@@ -189,6 +189,7 @@
 		"errorShelf": {
 			"acknowledge": "Hylkää",
 			"appKind": "App",
+			"haKind": "HA",
 			"clearAll": "Tyhjennä kaikki",
 			"copyError": "Kopioi virhe",
 			"requestKind": "Req",

--- a/web/src/i18n/locales/fr.json
+++ b/web/src/i18n/locales/fr.json
@@ -189,6 +189,7 @@
 		"errorShelf": {
 			"acknowledge": "Ignorer",
 			"appKind": "App",
+			"haKind": "HA",
 			"clearAll": "Tout effacer",
 			"copyError": "Copier l'erreur",
 			"requestKind": "Req",

--- a/web/src/i18n/locales/he.json
+++ b/web/src/i18n/locales/he.json
@@ -189,6 +189,7 @@
 		"errorShelf": {
 			"acknowledge": "בטל",
 			"appKind": "App",
+			"haKind": "HA",
 			"clearAll": "נקה הכל",
 			"copyError": "שגיאת העתקה",
 			"requestKind": "Req",

--- a/web/src/i18n/locales/hu.json
+++ b/web/src/i18n/locales/hu.json
@@ -189,6 +189,7 @@
 		"errorShelf": {
 			"acknowledge": "Elutasítás",
 			"appKind": "App",
+			"haKind": "HA",
 			"clearAll": "Összes törlése",
 			"copyError": "Másolási hiba",
 			"requestKind": "Req",

--- a/web/src/i18n/locales/it.json
+++ b/web/src/i18n/locales/it.json
@@ -189,6 +189,7 @@
 		"errorShelf": {
 			"acknowledge": "Ignora",
 			"appKind": "App",
+			"haKind": "HA",
 			"clearAll": "Cancella tutto",
 			"copyError": "Errore di copia",
 			"requestKind": "Req",

--- a/web/src/i18n/locales/ja.json
+++ b/web/src/i18n/locales/ja.json
@@ -189,6 +189,7 @@
 		"errorShelf": {
 			"acknowledge": "閉じる",
 			"appKind": "App",
+			"haKind": "HA",
 			"clearAll": "すべてクリア",
 			"copyError": "コピーエラー",
 			"requestKind": "Req",

--- a/web/src/i18n/locales/ko.json
+++ b/web/src/i18n/locales/ko.json
@@ -189,6 +189,7 @@
 		"errorShelf": {
 			"acknowledge": "닫기",
 			"appKind": "App",
+			"haKind": "HA",
 			"clearAll": "모두 지우기",
 			"copyError": "복사 오류",
 			"requestKind": "Req",

--- a/web/src/i18n/locales/nl.json
+++ b/web/src/i18n/locales/nl.json
@@ -189,6 +189,7 @@
 		"errorShelf": {
 			"acknowledge": "Sluiten",
 			"appKind": "App",
+			"haKind": "HA",
 			"clearAll": "Alles wissen",
 			"copyError": "Kopieerfout",
 			"requestKind": "Req",

--- a/web/src/i18n/locales/no.json
+++ b/web/src/i18n/locales/no.json
@@ -189,6 +189,7 @@
 		"errorShelf": {
 			"acknowledge": "Avvis",
 			"appKind": "App",
+			"haKind": "HA",
 			"clearAll": "Fjern alt",
 			"copyError": "Kopieringsfeil",
 			"requestKind": "Req",

--- a/web/src/i18n/locales/pl.json
+++ b/web/src/i18n/locales/pl.json
@@ -189,6 +189,7 @@
 		"errorShelf": {
 			"acknowledge": "Odrzuć",
 			"appKind": "App",
+			"haKind": "HA",
 			"clearAll": "Wyczyść wszystko",
 			"copyError": "Błąd kopiowania",
 			"requestKind": "Req",

--- a/web/src/i18n/locales/pt.json
+++ b/web/src/i18n/locales/pt.json
@@ -189,6 +189,7 @@
 		"errorShelf": {
 			"acknowledge": "Ignorar",
 			"appKind": "App",
+			"haKind": "HA",
 			"clearAll": "Limpar tudo",
 			"copyError": "Erro de cópia",
 			"requestKind": "Req",

--- a/web/src/i18n/locales/ro.json
+++ b/web/src/i18n/locales/ro.json
@@ -189,6 +189,7 @@
 		"errorShelf": {
 			"acknowledge": "Ignorați",
 			"appKind": "App",
+			"haKind": "HA",
 			"clearAll": "Ștergeți tot",
 			"copyError": "Eroare de copiere",
 			"requestKind": "Req",

--- a/web/src/i18n/locales/ru.json
+++ b/web/src/i18n/locales/ru.json
@@ -189,6 +189,7 @@
 		"errorShelf": {
 			"acknowledge": "Отклонить",
 			"appKind": "App",
+			"haKind": "HA",
 			"clearAll": "Очистить все",
 			"copyError": "Ошибка копирования",
 			"requestKind": "Req",

--- a/web/src/i18n/locales/sk.json
+++ b/web/src/i18n/locales/sk.json
@@ -189,6 +189,7 @@
 		"errorShelf": {
 			"acknowledge": "Zatvoriť",
 			"appKind": "App",
+			"haKind": "HA",
 			"clearAll": "Vymazať všetko",
 			"copyError": "Chyba kopírovania",
 			"requestKind": "Req",

--- a/web/src/i18n/locales/sr.json
+++ b/web/src/i18n/locales/sr.json
@@ -189,6 +189,7 @@
 		"errorShelf": {
 			"acknowledge": "Одбаци",
 			"appKind": "App",
+			"haKind": "HA",
 			"clearAll": "Очисти све",
 			"copyError": "Копирајте грешку",
 			"requestKind": "Req",

--- a/web/src/i18n/locales/sv.json
+++ b/web/src/i18n/locales/sv.json
@@ -189,6 +189,7 @@
 		"errorShelf": {
 			"acknowledge": "Avvisa",
 			"appKind": "App",
+			"haKind": "HA",
 			"clearAll": "Rensa allt",
 			"copyError": "Kopiera fel",
 			"requestKind": "Req",

--- a/web/src/i18n/locales/tr.json
+++ b/web/src/i18n/locales/tr.json
@@ -189,6 +189,7 @@
 		"errorShelf": {
 			"acknowledge": "Kapat",
 			"appKind": "App",
+			"haKind": "HA",
 			"clearAll": "Tümünü temizle",
 			"copyError": "Hata kopyalama",
 			"requestKind": "Req",

--- a/web/src/i18n/locales/uk.json
+++ b/web/src/i18n/locales/uk.json
@@ -189,6 +189,7 @@
 		"errorShelf": {
 			"acknowledge": "Закрити",
 			"appKind": "App",
+			"haKind": "HA",
 			"clearAll": "Очистити все",
 			"copyError": "Копіювати помилку",
 			"requestKind": "Req",

--- a/web/src/i18n/locales/vi.json
+++ b/web/src/i18n/locales/vi.json
@@ -189,6 +189,7 @@
 		"errorShelf": {
 			"acknowledge": "Bỏ qua",
 			"appKind": "App",
+			"haKind": "HA",
 			"clearAll": "Xóa tất cả",
 			"copyError": "Lỗi sao chép",
 			"requestKind": "Req",

--- a/web/src/i18n/locales/zh.json
+++ b/web/src/i18n/locales/zh.json
@@ -189,6 +189,7 @@
 		"errorShelf": {
 			"acknowledge": "关闭",
 			"appKind": "App",
+			"haKind": "HA",
 			"clearAll": "清除所有",
 			"copyError": "复制错误",
 			"requestKind": "Req",

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1127,6 +1127,19 @@ html[data-ui-style="cyber-terminal"] .sidebar-quota-pill {
 	background: color-mix(in srgb, var(--warning-text) 20%, transparent);
 	border-color: color-mix(in srgb, var(--warning-text) 48%, transparent);
 }
+/* HA (fleet config-sync) errors take an indigo hue, distinct from the error-red
+   and warning-amber of the request/app chips. Indigo (#6366f1) is fixed rather
+   than theme-tokenized; only the text needs a light/dark contrast swap. */
+.ui-error-shelf-chip--ha {
+	color: #a5b4fc;
+	background: color-mix(in srgb, #6366f1 22%, transparent);
+	border-color: color-mix(in srgb, #6366f1 48%, transparent);
+}
+html.light .ui-error-shelf-chip--ha {
+	color: #4338ca;
+	background: color-mix(in srgb, #6366f1 16%, transparent);
+	border-color: color-mix(in srgb, #6366f1 42%, transparent);
+}
 
 /* Per-row action buttons reuse the muted→strong error text ramp. */
 .ui-error-shelf-rowbtn {
@@ -1153,6 +1166,9 @@ html[data-ui-style="cyber-terminal"] .sidebar-quota-pill {
 }
 .ui-error-shelf-row--app {
 	border-left-color: color-mix(in srgb, var(--warning-text) 70%, transparent);
+}
+.ui-error-shelf-row--ha {
+	border-left-color: color-mix(in srgb, #6366f1 70%, transparent);
 }
 @keyframes error-shelf-row-in {
 	from {

--- a/web/src/utils/logBadgeUtils.test.ts
+++ b/web/src/utils/logBadgeUtils.test.ts
@@ -83,6 +83,20 @@ describe("getSourceBadgeClasses", () => {
 		expect(result).toContain("text-indigo-400");
 	});
 
+	it("returns a bolder indigo for configsync (HA), distinct from settings", () => {
+		const result = getSourceBadgeClasses("configsync");
+		expect(result).toContain("bg-indigo-500/30");
+		expect(result).toContain("text-indigo-200");
+		// Must not collide with the muted indigo used for `settings`.
+		expect(result).not.toBe(getSourceBadgeClasses("settings"));
+	});
+
+	it("returns the same HA classes for fleet as for configsync", () => {
+		expect(getSourceBadgeClasses("fleet")).toBe(
+			getSourceBadgeClasses("configsync"),
+		);
+	});
+
 	it("returns violet classes for events", () => {
 		const result = getSourceBadgeClasses("events");
 		expect(result).toContain("bg-violet-900/30");

--- a/web/src/utils/logBadgeUtils.ts
+++ b/web/src/utils/logBadgeUtils.ts
@@ -53,6 +53,10 @@ export const getSourceBadgeClasses = (source: string) => {
 			return "bg-blue-900/30 text-blue-400";
 		case "circuit-breaker":
 			return "bg-orange-900/30 text-orange-400";
+		case "configsync":
+		case "fleet":
+			// HA / fleet membership — matches the indigo HA chip in the error shelf.
+			return "bg-indigo-900/30 text-indigo-400";
 		case "modelsdev":
 			return "bg-rose-900/30 text-rose-400";
 		case "applogs":

--- a/web/src/utils/logBadgeUtils.ts
+++ b/web/src/utils/logBadgeUtils.ts
@@ -55,8 +55,10 @@ export const getSourceBadgeClasses = (source: string) => {
 			return "bg-orange-900/30 text-orange-400";
 		case "configsync":
 		case "fleet":
-			// HA / fleet membership — matches the indigo HA chip in the error shelf.
-			return "bg-indigo-900/30 text-indigo-400";
+			// HA / fleet membership — indigo family to echo the error-shelf HA chip,
+			// but a brighter, bolder shade than the muted indigo `settings` uses, so
+			// the two stay distinguishable when both appear in the source column.
+			return "bg-indigo-500/30 text-indigo-200";
 		case "modelsdev":
 			return "bg-rose-900/30 text-rose-400";
 		case "applogs":


### PR DESCRIPTION
## What

Fleet/HA membership failures now render as a distinct indigo **HA** chip in the sidebar error shelf, instead of being lumped into the generic amber **App** chip.

![chip categories: Req / App / HA]

## How we distinguish HA errors

These errors only ever reach the shelf through the **app-log** path with a `source` of `configsync` or `fleet` (the member-side config-sync receiver in `internal/api/configsync.go`). The proxy/request path never originates them, so there's no ambiguity:

- The shelf keys a presentation sub-category on `entry.source` (`isHaSource()`), while keeping `kind: "app"` so the log-detail modal still opens correctly.
- Only `configsync` logs at error level today, so that's what actually surfaces; `fleet` is included for completeness.

**Scope:** this covers *member-side* HA errors (an instance failing to apply config pushed to it). The primary/orchestrator auto-sync runs in the separate Front Desk binary with its own dashboard, so it's outside this shelf by design.

## Changes

- **`useErrorShelf`** — expose `entry.source` on `ShelfError`; add `isHaSource()` + `HA_SOURCES`.
- **`ErrorShelf`** — derive an HA category driving chip label, class, row accent, and testid (`error-shelf-chip-ha`).
- **`index.css`** — indigo `.ui-error-shelf-chip--ha` / `.ui-error-shelf-row--ha` with an `html.light` contrast override.
- **`logBadgeUtils`** — boy-scout: color `configsync`/`fleet` sources indigo on the AppLogs page to match.
- **i18n** — `layout.errorShelf.haKind` ("HA") added to all locales (acronym, verbatim).
- **test** — asserts a `configsync`-sourced app error gets the HA chip, not the app chip.

## Verification

- `pnpm vitest run src/components/ErrorShelf src/utils/logBadgeUtils` — 46/46 pass
- `pnpm exec tsc -b` — clean
- biome + eslint — clean
- `i18n-translate check` — 28 locales in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)