### PR TITLE
build: stamp local dev container builds as `dev`, not the release version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ docker-up:
 
 docker-build:
 	docker compose -f docker-compose.yml -f compose.dev.yml down
-	VERSION=$(VERSION) COMMIT=$(COMMIT) docker compose -f docker-compose.yml -f compose.dev.yml up -d --build
+	VERSION=dev COMMIT=$(COMMIT) docker compose -f docker-compose.yml -f compose.dev.yml up -d --build
 
 docker-down:
 	docker compose -f docker-compose.yml -f compose.dev.yml down
@@ -58,7 +58,7 @@ frontdesk-build:
 	CGO_ENABLED=0 go build -ldflags "-X main.version=$(VERSION) -X github.com/hugalafutro/model-hotel/internal/frontdesk.buildCommit=$(COMMIT)" -o bin/frontdesk ./cmd/frontdesk/
 
 ha-up:
-	VERSION=$(VERSION) COMMIT=$(COMMIT) docker compose -f $(HA_COMPOSE) up -d --build
+	VERSION=dev COMMIT=$(COMMIT) docker compose -f $(HA_COMPOSE) up -d --build
 
 ha-down:
 	docker compose -f $(HA_COMPOSE) down


### PR DESCRIPTION
## What

`make docker-build` and `make ha-up` now pass `VERSION=dev` (instead of `VERSION=$(VERSION)`) to the dev/HA compose builds, so a local working-tree build is stamped `dev` + the HEAD commit SHA rather than the release semver.

## Why

The Makefile computes `VERSION := $(shell cat .version ...)`, so locally building the dev container stamped the binary with the clean release version (e.g. `0.9.80`). A dirty working-tree dev image advertising itself as a released version is misleading.

The CI `:dev` image already follows the right convention: it leaves `VERSION` at its `dev` default and stamps only `COMMIT` with the source SHA (`ci.yml`). This brings the local dev-container targets in line. A local dev build now reports `Model Hotel (dev)` + the commit.

The release image path (`docker-publish.yml`, `:latest` / `:vX.Y.Z`) is untouched and still carries the real semver. `make build` (local `bin/server`) is also left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)