### PR TITLE
fix(web): clear in-memory admin token on logout

### DIFF
--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -1,7 +1,7 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Link, useLocation, useNavigate } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import {
 	AlertTriangle,
 	BookOpen,
@@ -23,7 +23,7 @@ import {
 	Sun,
 	Swords,
 } from "@/lib/icons";
-import { api } from "../api/client";
+import { api, setAdminToken } from "../api/client";
 import { useSidebarMode } from "../context/SidebarModeContext";
 import { useTheme } from "../context/ThemeContext";
 import { useGitHubVersion } from "../hooks/useGitHubVersion";
@@ -657,7 +657,6 @@ function ReadOnlyBanner() {
 export function Layout({ children }: LayoutProps) {
 	const { t } = useTranslation();
 	const location = useLocation();
-	const navigate = useNavigate();
 	const { theme, setTheme, uiStyle } = useTheme();
 	// Separator between paired labels/counts in the sidebar. The terminal theme
 	// keeps a literal "/" (fits its monospace aesthetic); other themes use a
@@ -845,8 +844,16 @@ export function Layout({ children }: LayoutProps) {
 		} catch {
 			// Server-side logout failure is non-fatal.
 		}
+		// Tear down the auth state before the reload. Order matters: clear the
+		// in-memory token (the primary source getAuthHeaders() reads) AND the
+		// localStorage fallback, then cancel any in-flight queries. Without
+		// clearing the in-memory token, queries that refetch in the gap before the
+		// reload would still send the now-revoked token, producing a burst of
+		// 401s server-side (and pointless work client-side). With it cleared,
+		// getAuthHeaders() throws locally and those refetches never hit the wire.
+		setAdminToken("");
 		localStorage.removeItem("adminToken");
-		navigate("/dashboard");
+		queryClient.cancelQueries();
 		window.location.reload();
 	};
 

--- a/web/src/components/__tests__/Layout.navigation.test.tsx
+++ b/web/src/components/__tests__/Layout.navigation.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { HttpResponse, http } from "msw";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getAdminToken, setAdminToken } from "../../api/client";
 import { server } from "../../test/mocks/server";
 import { renderWithProviders } from "../../test/utils";
 import * as webauthnUtils from "../../utils/webauthn";
@@ -12,6 +13,10 @@ describe("Layout", () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks();
+		// The admin token is module-global state (seeded once in setup.ts). The
+		// logout tests now clear it (the in-memory token, not just localStorage),
+		// so re-seed before every test to keep the suite order-independent.
+		setAdminToken("test-admin-token");
 	});
 
 	describe("Sidebar Navigation", () => {
@@ -899,6 +904,42 @@ describe("Layout", () => {
 
 			await waitFor(() => {
 				expect(logoutCalled).toBe(true);
+				expect(localStorage.getItem("adminToken")).toBeNull();
+			});
+
+			localStorage.removeItem("adminToken");
+		});
+
+		// Regression: logout must clear the IN-MEMORY token, not just localStorage.
+		// getAuthHeaders() reads the in-memory token first, so leaving it set let
+		// queries refetch with the just-revoked token in the gap before the reload,
+		// producing a burst of 401s server-side.
+		it("clears the in-memory admin token on logout", async () => {
+			const user = userEvent.setup();
+			vi.spyOn(webauthnUtils, "isWebAuthnAvailable").mockResolvedValue(true);
+			setAdminToken("test-token");
+			localStorage.setItem("adminToken", "test-token");
+			server.use(
+				http.post("/api/webauthn/logout", () =>
+					HttpResponse.json({ success: true }),
+				),
+			);
+
+			renderWithProviders(<Layout>{mockChildren}</Layout>);
+
+			const logoutButton = screen.getByText("Logout").closest("button");
+			if (logoutButton) {
+				await user.click(logoutButton);
+			}
+			const confirmButton = screen
+				.getByRole("dialog")
+				.querySelector("button.ui-btn-danger");
+			if (confirmButton) {
+				await user.click(confirmButton as HTMLElement);
+			}
+
+			await waitFor(() => {
+				expect(getAdminToken()).toBe("");
 				expect(localStorage.getItem("adminToken")).toBeNull();
 			});
 


### PR DESCRIPTION
## Problem

`handleLogout` cleared `localStorage` but left the **in-memory** admin token set. `getAuthHeaders()` reads the in-memory token first (localStorage is only a fallback), so in the gap between the server-side session revoke and the page reload, any TanStack Query that refetched still sent the **now-revoked** token. The server logged each as `auth: admin request with invalid token` — a burst of 401s on every logout. The `navigate("/dashboard")` before the reload made it worse by remounting the dashboard's queries right at that moment.

This was spotted as a post-logout 401 burst while testing GitHub SSO; it's a pre-existing logout bug, unrelated to SSO.

## Fix

- Clear the in-memory token (`setAdminToken("")`) alongside `localStorage`, and `queryClient.cancelQueries()` before the reload. Once the in-memory token is empty, `getAuthHeaders()` throws locally and those refetches never reach the wire.
- Remove the redundant `navigate("/dashboard")` (a full `window.location.reload()` re-renders to the login screen regardless) and the now-unused `useNavigate`.

## Tests

- New regression test asserts the in-memory token is cleared on logout.
- The Layout test's `beforeEach` now re-seeds the module-global token so the suite stays order-independent now that the logout tests clear it.
- Full frontend suite green (263 files / 5187 tests), `tsc -b` / biome / eslint clean.

## Merge note

Intended to merge **before** the GitHub SSO PR (#326); that branch will pick this up so its post-login/logout behavior is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)