### PR TITLE
fix(anthropic): finalize log row on native read error; tolerate array content

### DIFF
--- a/internal/anthropic/response.go
+++ b/internal/anthropic/response.go
@@ -3,6 +3,7 @@ package anthropic
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 )
 
 // --- Incoming OpenAI non-streaming response shape ---
@@ -20,11 +21,41 @@ type oaiChoice struct {
 }
 
 type oaiRespMessage struct {
-	Role      string            `json:"role"`
-	Content   string            `json:"content"`
+	Role string `json:"role"`
+	// Content is normally a JSON string, but some OpenAI-compatible providers
+	// emit an array of content parts. Decoded via decodeRespContent so a
+	// structured-array response does not fail the whole translation.
+	Content   json.RawMessage   `json:"content"`
 	ToolCalls []oaiRespToolCall `json:"tool_calls"`
 	// reasoning_content is surfaced by some OpenAI-compatible providers; v1
 	// drops it on the translated path (thinking-block mapping is deferred).
+}
+
+// decodeRespContent extracts assistant text from an OpenAI chat-completion
+// message "content": a JSON string (the norm), an array of {type,text} content
+// parts (some providers), or null/absent (-> ""). Non-text parts are ignored.
+func decodeRespContent(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	if json.Unmarshal(raw, &s) == nil {
+		return s
+	}
+	var parts []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if json.Unmarshal(raw, &parts) == nil {
+		var b strings.Builder
+		for _, p := range parts {
+			if p.Type == "" || p.Type == "text" {
+				b.WriteString(p.Text)
+			}
+		}
+		return b.String()
+	}
+	return ""
 }
 
 type oaiRespToolCall struct {
@@ -61,10 +92,10 @@ func BuildMessageResponse(body []byte, messageID, model string) ([]byte, error) 
 		choice := resp.Choices[0]
 		finish = choice.FinishReason
 
-		if choice.Message.Content != "" {
+		if text := decodeRespContent(choice.Message.Content); text != "" {
 			msg.Content = append(msg.Content, contentBlock{
 				Type: "text",
-				Text: choice.Message.Content,
+				Text: text,
 			})
 		}
 		for _, tc := range choice.Message.ToolCalls {

--- a/internal/anthropic/response_test.go
+++ b/internal/anthropic/response_test.go
@@ -38,6 +38,37 @@ func TestBuildMessageResponse_Text(t *testing.T) {
 	}
 }
 
+func TestBuildMessageResponse_ArrayContent(t *testing.T) {
+	// Some OpenAI-compatible providers return content as an array of parts
+	// instead of a string; the translation must extract the text, not 502.
+	oai := []byte(`{"choices":[{"message":{"role":"assistant","content":[{"type":"text","text":"Hello "},{"type":"text","text":"world"}]},"finish_reason":"stop"}]}`)
+	out, err := BuildMessageResponse(oai, "msg_a", "m")
+	if err != nil {
+		t.Fatalf("BuildMessageResponse: %v", err)
+	}
+	var m map[string]any
+	_ = json.Unmarshal(out, &m)
+	content := m["content"].([]any)
+	if len(content) != 1 || content[0].(map[string]any)["text"] != "Hello world" {
+		t.Errorf("array content not flattened: %v", content)
+	}
+}
+
+func TestBuildMessageResponse_NullContent(t *testing.T) {
+	// content:null (tool-only assistant turn) must not panic or add an empty block.
+	oai := []byte(`{"choices":[{"message":{"role":"assistant","content":null,"tool_calls":[{"id":"c","type":"function","function":{"name":"f","arguments":"{}"}}]},"finish_reason":"tool_calls"}]}`)
+	out, err := BuildMessageResponse(oai, "msg_n", "m")
+	if err != nil {
+		t.Fatalf("BuildMessageResponse: %v", err)
+	}
+	var m map[string]any
+	_ = json.Unmarshal(out, &m)
+	content := m["content"].([]any)
+	if len(content) != 1 || content[0].(map[string]any)["type"] != "tool_use" {
+		t.Errorf("null content should yield only the tool_use block: %v", content)
+	}
+}
+
 func TestBuildMessageResponse_InvalidToolArgsAndError(t *testing.T) {
 	// Invalid tool-call arguments fall back to an empty object.
 	oai := []byte(`{"choices":[{"message":{"role":"assistant","tool_calls":[{"id":"c1","type":"function","function":{"name":"f","arguments":"not json"}}]},"finish_reason":"tool_calls"}]}`)

--- a/internal/proxy/anthropic_native.go
+++ b/internal/proxy/anthropic_native.go
@@ -47,6 +47,16 @@ func (h *Handler) handleNativeNonStreaming(w http.ResponseWriter, r *http.Reques
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		debuglog.Warn("proxy: native anthropic read failed", "error", err, "provider", logData.providerName)
+		// Finalize the log row so it does not orphan in the in-flight state: a
+		// read failure on a 200 body is a provider/transport fault.
+		logData.statusCode = http.StatusBadGateway
+		logData.durationMs = float64(time.Since(st.startTime).Microseconds()) / 1000.0
+		logData.responseHeaderMs = responseHeaderMs
+		logData.failoverAttempt = attempt
+		logData.errorKind = KindProviderError
+		logData.errorMessage = "failed to read upstream response: " + err.Error()
+		logData.state = "failed"
+		h.updateRequestLog(logData, updateLogOption{skipWaitForInsert: true})
 		writeAnthropicError(w, "failed to read upstream response", http.StatusBadGateway)
 		return outcomeFatal
 	}

--- a/internal/proxy/anthropic_native_test.go
+++ b/internal/proxy/anthropic_native_test.go
@@ -90,6 +90,56 @@ func TestHandleNativeNonStreaming(t *testing.T) {
 	}
 }
 
+// errorReadCloser fails on Read, simulating an upstream body that drops
+// mid-transfer after a 200 header.
+type errorReadCloser struct{}
+
+func (errorReadCloser) Read([]byte) (int, error) { return 0, io.ErrUnexpectedEOF }
+func (errorReadCloser) Close() error             { return nil }
+
+// A read failure on the native non-streaming 200 body must finalize the log row
+// (state=failed) instead of leaving it orphaned in the in-flight state.
+func TestHandleNativeNonStreaming_ReadErrorFinalizesLog(t *testing.T) {
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+
+	resp := &http.Response{StatusCode: http.StatusOK, Body: errorReadCloser{}, Header: make(http.Header)}
+	rec := httptest.NewRecorder()
+	native := true
+	aw := newAnthropicResponseWriter(rec, "msg_e", "m")
+	aw.bindNativeFlag(&native)
+	req := httptest.NewRequest("POST", "/v1/messages", http.NoBody)
+	logData := &requestLogData{
+		id:             uuid.New().String(),
+		modelID:        "claude-x",
+		virtualKeyName: "test-key",
+		virtualKeyID:   "00000000-0000-0000-0000-000000000001",
+		state:          "streaming",
+	}
+	st := &requestState{startTime: time.Now(), logData: logData}
+	h.insertRequestLogAsync(logData)
+	time.Sleep(100 * time.Millisecond)
+
+	outcome := h.handleNativeNonStreaming(aw, req, st, resp, 1, 10.0)
+	aw.Finalize()
+
+	if outcome != outcomeFatal {
+		t.Errorf("outcome = %v, want outcomeFatal", outcome)
+	}
+	if logData.state != "failed" {
+		t.Errorf("state = %q, want failed (log row must not orphan)", logData.state)
+	}
+	if logData.errorKind != KindProviderError {
+		t.Errorf("errorKind = %v, want KindProviderError", logData.errorKind)
+	}
+	if logData.statusCode != http.StatusBadGateway {
+		t.Errorf("statusCode = %d, want 502", logData.statusCode)
+	}
+	if rec.Code != http.StatusBadGateway {
+		t.Errorf("client status = %d, want 502", rec.Code)
+	}
+}
+
 // runNativeStream drives a complete Anthropic SSE body through the real streaming
 // pipeline with rawPassthrough enabled (the native passthrough path), returning
 // the forwarded client bytes and the finalized log row. It mirrors the harness in


### PR DESCRIPTION
Two non-blocking robustness follow-ups Greptile noted on #334 (it still rated that PR 5/5; neither affects correctness on the current provider set).

## 1. Orphaned log row on native read error
`handleNativeNonStreaming` wrote a 502 and returned when `io.ReadAll` on the upstream 200 body failed, but never finalized the request log row — leaving it stuck in the in-flight state forever (an observability gap for a routing/metering gateway). It now sets `state=failed` + `KindProviderError` + status/duration and calls `updateRequestLog`, mirroring the OK path. No client-visible change.

## 2. `Content string` 502s on array content
`BuildMessageResponse` decoded the OpenAI message `content` as a Go `string`, so a provider returning a structured-content array (or `null`) would fail `json.Unmarshal` and 502 the whole response. `content` is now `json.RawMessage` decoded via `decodeRespContent`, which accepts a string, an array of `{type,text}` parts (concatenated), or null (→ `""`). Not known to occur on the translated path today, but tolerating diverse providers is the gateway's job.

## Tests
- `TestHandleNativeNonStreaming_ReadErrorFinalizesLog` (erroring body → state=failed, KindProviderError, 502).
- `TestBuildMessageResponse_ArrayContent` + `_NullContent`.

`go vet`, full `go test` (proxy + anthropic), and `golangci-lint` clean. No version bump (per repo policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)