### PR TITLE
fix(ha): tolerate rebuild churn in the HA plane

### DIFF
--- a/frontdesk/web/src/api/types.ts
+++ b/frontdesk/web/src/api/types.ts
@@ -54,6 +54,10 @@ export interface Settings {
 	traefik_stale_secs: number;
 	event_retention_days: number;
 	retry_attempts: number;
+	// Consecutive failed health polls before a member is reported down (an error
+	// event plus, by default, an Apprise alert). Damps routine-rebuild flap; also
+	// governs the Traefik UP->DOWN badge flip. Minimum 1.
+	health_fail_threshold: number;
 	// Admin-UI inactivity auto-logout window in minutes; 0 disables it. Consumed
 	// by useIdleLogout to sign the operator out after inactivity.
 	session_idle_timeout_minutes: number;

--- a/frontdesk/web/src/components/__tests__/AlertsPanel.test.tsx
+++ b/frontdesk/web/src/components/__tests__/AlertsPanel.test.tsx
@@ -34,6 +34,7 @@ const settings: Settings = {
 	traefik_stale_secs: 30,
 	event_retention_days: 90,
 	retry_attempts: 2,
+	health_fail_threshold: 3,
 	session_idle_timeout_minutes: 60,
 	alert_enabled: true,
 	alert_apprise_api_url: "http://apprise:8000",

--- a/frontdesk/web/src/components/__tests__/OidcPanel.test.tsx
+++ b/frontdesk/web/src/components/__tests__/OidcPanel.test.tsx
@@ -17,6 +17,7 @@ function makeSettings(over: Partial<Settings> = {}): Settings {
 		traefik_stale_secs: 30,
 		event_retention_days: 90,
 		retry_attempts: 2,
+		health_fail_threshold: 3,
 		session_idle_timeout_minutes: 60,
 		alert_enabled: false,
 		alert_apprise_api_url: "",

--- a/frontdesk/web/src/i18n/locales/en.json
+++ b/frontdesk/web/src/i18n/locales/en.json
@@ -183,6 +183,8 @@
 		"retention": "Event retention (days)",
 		"retryAttempts": "Retry attempts",
 		"retryHint": "Retries that failed before any response byte (safe to retry).",
+		"healthFailThreshold": "Health-fail threshold",
+		"healthFailThresholdHint": "Consecutive failed health checks before a member is reported down and alerted. Higher tolerates longer rebuilds without flapping. Recovery is immediate.",
 		"sessionTimeout": "Auto-logout after inactivity (minutes)",
 		"sessionTimeoutHint": "Sign out of Front Desk automatically after this many minutes with no activity. 0 keeps the session open.",
 		"configSyncConfirmTitle_one": "Replace config on {{count}} member?",

--- a/frontdesk/web/src/pages/SettingsPage.tsx
+++ b/frontdesk/web/src/pages/SettingsPage.tsx
@@ -116,6 +116,7 @@ export function SettingsPage() {
 				traefik_stale_secs: settings.traefik_stale_secs,
 				event_retention_days: settings.event_retention_days,
 				retry_attempts: settings.retry_attempts,
+				health_fail_threshold: settings.health_fail_threshold,
 				session_idle_timeout_minutes: settings.session_idle_timeout_minutes,
 			});
 			toast(t("settings.saved"), "success");
@@ -201,6 +202,16 @@ export function SettingsPage() {
 							value={settings.retry_attempts}
 							min={0}
 							onChange={(n) => patch({ retry_attempts: n })}
+						/>
+					</div>
+					<div style={{ flex: "1 1 200px" }}>
+						<NumberField
+							id="health-fail-threshold"
+							label={t("settings.healthFailThreshold")}
+							hint={t("settings.healthFailThresholdHint")}
+							value={settings.health_fail_threshold}
+							min={1}
+							onChange={(n) => patch({ health_fail_threshold: n })}
 						/>
 					</div>
 				</div>

--- a/frontdesk/web/src/pages/__tests__/SettingsPage.test.tsx
+++ b/frontdesk/web/src/pages/__tests__/SettingsPage.test.tsx
@@ -14,6 +14,7 @@ const defaults: Settings = {
 	traefik_stale_secs: 30,
 	event_retention_days: 90,
 	retry_attempts: 2,
+	health_fail_threshold: 3,
 	session_idle_timeout_minutes: 60,
 	alert_enabled: false,
 	alert_apprise_api_url: "",

--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -63,6 +63,7 @@ type SettingsStore interface {
 	GetDuration(ctx context.Context, key string, defaultValue time.Duration) time.Duration
 	GetInt(ctx context.Context, key string, defaultValue int) int
 	Set(ctx context.Context, key string, value string) error
+	SetMany(ctx context.Context, kvs [][2]string) error
 	SetTx(ctx context.Context, tx pgx.Tx, key string, value string) error
 	DeleteKeysTx(ctx context.Context, tx pgx.Tx, keys []string) error
 	InvalidateCache(key string)

--- a/internal/api/admin_test.go
+++ b/internal/api/admin_test.go
@@ -140,6 +140,17 @@ func (m *mockSettingsStore) Set(ctx context.Context, key, value string) error {
 	}
 	return errors.New("mock: Set not implemented")
 }
+func (m *mockSettingsStore) SetMany(ctx context.Context, kvs [][2]string) error {
+	if m.setFn != nil {
+		for _, kv := range kvs {
+			if err := m.setFn(ctx, kv[0], kv[1]); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	return errors.New("mock: SetMany not implemented")
+}
 func (m *mockSettingsStore) GetAll(ctx context.Context) (map[string]string, error) {
 	if m.getAllFn != nil {
 		return m.getAllFn(ctx)

--- a/internal/api/fleet.go
+++ b/internal/api/fleet.go
@@ -75,6 +75,7 @@ const (
 type fleetSettings interface {
 	GetWithDefault(ctx context.Context, key, defaultValue string) string
 	Set(ctx context.Context, key, value string) error
+	SetMany(ctx context.Context, kvs [][2]string) error
 }
 
 // FleetStatus is the member's own view of its fleet membership, surfaced on the
@@ -170,17 +171,19 @@ func (h *FleetHandler) Announce(w http.ResponseWriter, r *http.Request) {
 
 	ctx := r.Context()
 	now := time.Now().UTC().Format(time.RFC3339)
+	// One multi-row upsert, not four sequential writes: Front Desk's announce
+	// client gives up after a few seconds, and four round-trips against a
+	// briefly-slow database (e.g. during a simultaneous fleet rebuild) can blow
+	// that budget and surface as a spurious 500 on the member.
 	writes := [][2]string{
 		{keyFleetManagedSeenAt, now},
 		{keyFleetIsPrimary, boolStr(req.IsPrimary)},
 		{keyFleetPrimaryName, req.PrimaryName},
 		{keyFleetFrontdeskID, req.FrontdeskID},
 	}
-	for _, kv := range writes {
-		if err := h.settings.Set(ctx, kv[0], kv[1]); err != nil {
-			respondError(w, "failed to record fleet announce", err, http.StatusInternalServerError)
-			return
-		}
+	if err := h.settings.SetMany(ctx, writes); err != nil {
+		respondError(w, "failed to record fleet announce", err, http.StatusInternalServerError)
+		return
 	}
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/internal/api/fleet_test.go
+++ b/internal/api/fleet_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -15,9 +16,10 @@ import (
 // fakeFleetSettings is an in-memory fleetSettings for tests: a plain map with a
 // recorded write order so assertions can check exactly what Announce persisted.
 type fakeFleetSettings struct {
-	values  map[string]string
-	setErr  error
-	written []string // keys in the order Set was called
+	values   map[string]string
+	setErr   error
+	written  []string // keys in the order they were persisted
+	setCalls int      // number of SetMany calls
 }
 
 func newFakeFleetSettings() *fakeFleetSettings {
@@ -37,6 +39,20 @@ func (f *fakeFleetSettings) Set(_ context.Context, key, value string) error {
 	}
 	f.values[key] = value
 	f.written = append(f.written, key)
+	return nil
+}
+
+// setCalls counts SetMany invocations so a test can assert the announce writes
+// land in a single round-trip rather than one per key.
+func (f *fakeFleetSettings) SetMany(_ context.Context, kvs [][2]string) error {
+	f.setCalls++
+	if f.setErr != nil {
+		return f.setErr // all-or-nothing, like the real multi-row upsert
+	}
+	for _, kv := range kvs {
+		f.values[kv[0]] = kv[1]
+		f.written = append(f.written, kv[0])
+	}
 	return nil
 }
 
@@ -64,6 +80,33 @@ func TestFleetAnnounce_PersistsContact(t *testing.T) {
 	seen := fs.values[keyFleetManagedSeenAt]
 	if _, err := time.Parse(time.RFC3339, seen); err != nil {
 		t.Errorf("%s = %q, not RFC3339: %v", keyFleetManagedSeenAt, seen, err)
+	}
+	// All four keys must persist in one round-trip so a slow database can't
+	// blow Front Desk's announce timeout partway through.
+	if fs.setCalls != 1 {
+		t.Errorf("SetMany called %d times, want 1 (batched write)", fs.setCalls)
+	}
+	if len(fs.written) != 4 {
+		t.Errorf("persisted %d keys, want 4: %v", len(fs.written), fs.written)
+	}
+}
+
+func TestFleetAnnounce_WriteFailureIs500(t *testing.T) {
+	fs := newFakeFleetSettings()
+	fs.setErr = errors.New("db unavailable")
+	h := NewFleetHandler(fs)
+
+	req := httptest.NewRequest(http.MethodPost, "/fleet/announce",
+		strings.NewReader(`{"is_primary":true}`))
+	rec := httptest.NewRecorder()
+	h.Announce(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+	// The batch is all-or-nothing: a failed write leaves nothing persisted.
+	if len(fs.written) != 0 {
+		t.Errorf("persisted %v on failed write; want none", fs.written)
 	}
 }
 

--- a/internal/frontdesk/coverage_test.go
+++ b/internal/frontdesk/coverage_test.go
@@ -71,7 +71,8 @@ func TestPollerPollsHandleStoreErrors(t *testing.T) {
 }
 
 // TestPollHealthOnceReportsDown covers the per-member health loop and the
-// down-transition event path (a first observation that is down is reported).
+// down-transition event path. The threshold is set to 1 so a single poll
+// confirms down (the debounce itself is covered in poller_test.go).
 func TestPollHealthOnceReportsDown(t *testing.T) {
 	down := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusServiceUnavailable)
@@ -83,6 +84,15 @@ func TestPollHealthOnceReportsDown(t *testing.T) {
 	m, err := store.CreateMember(ctx, "m1", down.URL, "")
 	if err != nil {
 		t.Fatalf("CreateMember: %v", err)
+	}
+
+	set, err := store.GetSettings(ctx)
+	if err != nil {
+		t.Fatalf("GetSettings: %v", err)
+	}
+	set.HealthFailThreshold = 1
+	if err := store.UpdateSettings(ctx, set); err != nil {
+		t.Fatalf("UpdateSettings: %v", err)
 	}
 
 	p.PollHealthOnce(ctx)

--- a/internal/frontdesk/migrations/011_health_fail_threshold.sql
+++ b/internal/frontdesk/migrations/011_health_fail_threshold.sql
@@ -1,0 +1,10 @@
+-- Consecutive-failure damping for member reachability. Front Desk must observe
+-- this many failed health polls in a row before it reports a member down (an
+-- error event plus, by default, an Apprise alert). This tolerates the brief
+-- unreachability of a routine container rebuild without flapping; recovery is
+-- immediate (the first healthy poll clears the count). The same threshold damps
+-- the Traefik UP -> DOWN badge flip. Default 3 (~15s at the 5s poll interval).
+--
+-- health_fail_threshold : consecutive failed polls before a member is reported
+--                         down. Bounded to at least 1 by the store.
+ALTER TABLE settings ADD COLUMN health_fail_threshold INTEGER NOT NULL DEFAULT 3;

--- a/internal/frontdesk/poller.go
+++ b/internal/frontdesk/poller.go
@@ -73,6 +73,7 @@ type Poller struct {
 	staleNotified    bool
 	versionFailures  map[string]int // consecutive version-fetch failures, keyed by member ID
 	healthFailures   map[string]int // consecutive failed health polls, keyed by member ID
+	traefikNonUp     map[string]int // consecutive non-UP Traefik observations, keyed by member ID
 }
 
 // NewPoller builds a Poller. traefikAPI is the base URL of the Traefik API
@@ -91,6 +92,7 @@ func NewPoller(store *Store, bus *events.Bus, traefikAPI string) *Poller {
 		statuses:        make(map[string]MemberStatus),
 		versionFailures: make(map[string]int),
 		healthFailures:  make(map[string]int),
+		traefikNonUp:    make(map[string]int),
 	}
 }
 
@@ -357,11 +359,25 @@ func (p *Poller) PollTraefikOnce(ctx context.Context) {
 	if err != nil {
 		return
 	}
+	// Damp the UP->non-UP flip with the same consecutive-miss threshold as health:
+	// Traefik briefly stops listing a member (or marks it DOWN) during a rebuild,
+	// and committing that immediately flaps the badge. "UP" is applied at once
+	// (recovery); a non-UP status is held back until it has been observed
+	// `threshold` polls in a row.
+	threshold := p.healthFailThreshold(ctx)
 	p.mu.Lock()
 	var changed []string
 	for _, m := range members {
 		cur := p.statuses[m.ID]
 		next := statusByURL[m.URL] // "" when Traefik does not list it
+		if next == "UP" {
+			delete(p.traefikNonUp, m.ID)
+		} else {
+			p.traefikNonUp[m.ID]++
+			if p.traefikNonUp[m.ID] < threshold {
+				continue // tolerate a rebuild blink; keep the last reported status
+			}
+		}
 		if cur.TraefikStatus != next {
 			cur.TraefikStatus = next
 			p.statuses[m.ID] = cur

--- a/internal/frontdesk/poller.go
+++ b/internal/frontdesk/poller.go
@@ -72,6 +72,7 @@ type Poller struct {
 	lastConfigPollAt time.Time
 	staleNotified    bool
 	versionFailures  map[string]int // consecutive version-fetch failures, keyed by member ID
+	healthFailures   map[string]int // consecutive failed health polls, keyed by member ID
 }
 
 // NewPoller builds a Poller. traefikAPI is the base URL of the Traefik API
@@ -89,6 +90,7 @@ func NewPoller(store *Store, bus *events.Bus, traefikAPI string) *Poller {
 		now:             time.Now,
 		statuses:        make(map[string]MemberStatus),
 		versionFailures: make(map[string]int),
+		healthFailures:  make(map[string]int),
 	}
 }
 
@@ -152,9 +154,19 @@ func (p *Poller) settings(ctx context.Context) Settings {
 	set, err := p.store.GetSettings(ctx)
 	if err != nil {
 		debuglog.Warn("frontdesk: poller using default settings", "error", err)
-		return Settings{HealthPollSecs: 5, TraefikPollSecs: 5, TraefikStaleSecs: 30}
+		return Settings{HealthPollSecs: 5, TraefikPollSecs: 5, TraefikStaleSecs: 30, HealthFailThreshold: 3}
 	}
 	return set
+}
+
+// healthFailThreshold is the number of consecutive failed polls a member must
+// accrue before it is reported down. It also damps the Traefik UP->DOWN flip.
+// Defaults to 3 when unset or invalid so a bad/zero row never disables damping.
+func (p *Poller) healthFailThreshold(ctx context.Context) int {
+	if t := p.settings(ctx).HealthFailThreshold; t >= 1 {
+		return t
+	}
+	return 3
 }
 
 // PollHealthOnce probes every member's /health and records up/down transitions.
@@ -197,42 +209,67 @@ func (p *Poller) checkHealth(ctx context.Context, baseURL string) HealthStatus {
 	return hs
 }
 
-// applyHealth stores the new status and emits a transition event when the
-// up/down state changed. A first observation that is healthy is recorded
-// silently (baseline); a first observation that is down is reported.
+// applyHealth records a health probe and emits an up/down transition event,
+// debounced so a member must miss `health_fail_threshold` polls in a row before
+// it is reported down (an error event plus, by default, an Apprise alert). This
+// tolerates the brief unreachability of a routine container rebuild without
+// flapping. Recovery is immediate: the first healthy poll clears the count and,
+// if the member had been reported down, announces it back up.
+//
+// The reported badge follows the same rule as the version poller: during the
+// grace window (below threshold) the last known-good status is kept, so the
+// dashboard does not flicker red on every rebuild. A first observation that is
+// healthy is recorded silently (baseline).
 func (p *Poller) applyHealth(ctx context.Context, m *Member, hs HealthStatus) {
+	threshold := p.healthFailThreshold(ctx)
+
 	p.mu.Lock()
 	prev, had := p.statuses[m.ID]
 	cur := prev
-	cur.Health = hs
+	priorFails := p.healthFailures[m.ID]
+
+	var fails int
+	switch {
+	case hs.Healthy:
+		delete(p.healthFailures, m.ID)
+		cur.Health = hs
+	default:
+		p.healthFailures[m.ID]++
+		fails = p.healthFailures[m.ID]
+		// Only let a "down" reach the badge once it is confirmed; below the
+		// threshold keep the last known status (zero-value "unknown" for a
+		// never-seen member) so a rebuild blip does not render red.
+		if fails >= threshold {
+			cur.Health = hs
+		}
+	}
 	p.statuses[m.ID] = cur
 	p.mu.Unlock()
 
-	changed := !had || prev.Health.Healthy != hs.Healthy
-	if !changed {
-		return
-	}
-	// The rendered health badge changed (first observation, or an up/down flip),
-	// so nudge connected UIs to refetch even when we keep the event log silent.
-	// Without this a freshly added, healthy member shows no status until an
-	// unrelated event fires or the operator reloads the page.
-	p.publishMemberStatus(m.ID)
-
-	if !had && hs.Healthy {
-		return // silent baseline (no event-log entry; UI already nudged above)
+	badgeChanged := !had || prev.Health.Healthy != cur.Health.Healthy
+	if badgeChanged {
+		// Nudge connected UIs to refetch the changed badge. Without this a
+		// freshly added, healthy member shows no status until an unrelated event
+		// fires or the operator reloads.
+		p.publishMemberStatus(m.ID)
 	}
 
-	if hs.Healthy {
+	switch {
+	case hs.Healthy && priorFails >= threshold:
+		// Recovered from a state we had actually reported down.
 		p.recordEvent(ctx, Event{
 			Type: "health.up", Severity: "success", Source: "frontdesk-poller",
 			Message: fmt.Sprintf("%s is healthy", m.Name), MemberID: m.ID,
 			Metadata: map[string]any{"latency_ms": hs.LatencyMs},
 		})
-	} else {
+	case !hs.Healthy && fails == threshold:
+		// Crossed into confirmed-down: emit exactly once, not on every later poll.
+		debuglog.Warn("frontdesk: member health failing",
+			"member", m.Name, "consecutive_failures", fails, "error", hs.Error)
 		p.recordEvent(ctx, Event{
 			Type: "health.down", Severity: "error", Source: "frontdesk-poller",
-			Message: fmt.Sprintf("%s is unreachable", m.Name), MemberID: m.ID,
-			Metadata: map[string]any{"error": hs.Error},
+			Message: fmt.Sprintf("%s is unreachable after %d checks", m.Name, fails), MemberID: m.ID,
+			Metadata: map[string]any{"error": hs.Error, "consecutive_failures": fails},
 		})
 	}
 }

--- a/internal/frontdesk/poller.go
+++ b/internal/frontdesk/poller.go
@@ -248,7 +248,13 @@ func (p *Poller) applyHealth(ctx context.Context, m *Member, hs HealthStatus) {
 	p.statuses[m.ID] = cur
 	p.mu.Unlock()
 
-	badgeChanged := !had || prev.Health.Healthy != cur.Health.Healthy
+	// The rendered badge is a function of both Known and Healthy (unknown vs
+	// up vs down), so compare both: a never-seen member that crosses straight
+	// from "unknown" to confirmed-down flips Known without flipping Healthy, and
+	// would otherwise be nudged only by the health.down event, not the badge.
+	badgeChanged := !had ||
+		prev.Health.Healthy != cur.Health.Healthy ||
+		prev.Health.Known != cur.Health.Known
 	if badgeChanged {
 		// Nudge connected UIs to refetch the changed badge. Without this a
 		// freshly added, healthy member shows no status until an unrelated event

--- a/internal/frontdesk/poller_coverage_test.go
+++ b/internal/frontdesk/poller_coverage_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/hugalafutro/model-hotel/internal/events"
@@ -100,5 +101,66 @@ func TestPollTraefikOnceUpdatesStatus(t *testing.T) {
 	p.PollTraefikOnce(ctx)
 	if sawMemberStatus(ch) {
 		t.Error("unchanged Traefik status should not emit a nudge")
+	}
+}
+
+// TestPollTraefikOnceDampsDownFlip covers the rebuild-tolerance path: a member
+// briefly marked DOWN (or unlisted) must not flip the badge until the non-UP
+// status has been seen `health_fail_threshold` polls in a row; recovery to UP
+// is immediate.
+func TestPollTraefikOnceDampsDownFlip(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	m, err := store.CreateMember(ctx, "m1", "http://m1:8081", "")
+	if err != nil {
+		t.Fatalf("CreateMember: %v", err)
+	}
+
+	var status atomic.Value // current serverStatus string, "" = unlisted
+	status.Store("UP")
+	traefik := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != traefikServicesAPI {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		s, _ := status.Load().(string)
+		if s == "" {
+			_, _ = w.Write([]byte(`[]`)) // Traefik no longer lists the member
+			return
+		}
+		_, _ = w.Write([]byte(`[{"name":"hotel@http","serverStatus":{"` + m.URL + `":"` + s + `"}}]`))
+	}))
+	defer traefik.Close()
+
+	p := NewPoller(store, events.NewBus(), traefik.URL)
+	thr := p.healthFailThreshold(ctx)
+	if thr < 2 {
+		t.Skip("no grace window at this threshold")
+	}
+
+	p.PollTraefikOnce(ctx)
+	if got := p.Snapshot()[m.ID].TraefikStatus; got != "UP" {
+		t.Fatalf("baseline traefik status = %q, want UP", got)
+	}
+
+	// Below threshold the DOWN status is held back: the badge stays UP.
+	status.Store("DOWN")
+	for i := 1; i < thr; i++ {
+		p.PollTraefikOnce(ctx)
+		if got := p.Snapshot()[m.ID].TraefikStatus; got != "UP" {
+			t.Errorf("poll %d: badge should stay UP during grace, got %q", i, got)
+		}
+	}
+	// The threshold-th consecutive non-UP observation commits the flip.
+	p.PollTraefikOnce(ctx)
+	if got := p.Snapshot()[m.ID].TraefikStatus; got != "DOWN" {
+		t.Errorf("threshold-th DOWN should commit, got %q", got)
+	}
+
+	// Recovery is immediate.
+	status.Store("UP")
+	p.PollTraefikOnce(ctx)
+	if got := p.Snapshot()[m.ID].TraefikStatus; got != "UP" {
+		t.Errorf("recovery to UP should be immediate, got %q", got)
 	}
 }

--- a/internal/frontdesk/poller_test.go
+++ b/internal/frontdesk/poller_test.go
@@ -147,23 +147,37 @@ func TestApplyHealthTransitions(t *testing.T) {
 }
 
 func TestApplyHealthFirstObservationDownDebounced(t *testing.T) {
-	p, store, _ := newTestPoller(t, "")
+	p, store, bus := newTestPoller(t, "")
 	ctx := context.Background()
 	m, _ := store.CreateMember(ctx, "h", "http://h:8081", "")
 	thr := p.healthFailThreshold(ctx)
 
+	ch := bus.Subscribe()
+	defer bus.Unsubscribe(ch)
+
 	// A member down from its very first observation is not reported until it has
 	// missed `thr` polls in a row (a rebuild started while Front Desk was down).
+	// The grace-window polls emit no event (the first observation nudges the
+	// badge to "unknown"; below-threshold failures are otherwise silent).
 	for i := 1; i < thr; i++ {
 		p.applyHealth(ctx, m, HealthStatus{Known: true, Healthy: false, Error: "down at start"})
 		if _, total, _ := store.ListEvents(ctx, EventFilter{}); total != 0 {
 			t.Fatalf("down before threshold (poll %d) should be silent, got %d events", i, total)
 		}
 	}
+	// Drain the baseline "unknown" nudge from the first observation so the check
+	// below sees only what the confirming poll emits.
+	sawMemberStatus(ch)
+
 	p.applyHealth(ctx, m, HealthStatus{Known: true, Healthy: false, Error: "down at start"})
 	evs, total, _ := store.ListEvents(ctx, EventFilter{})
 	if total != 1 || evs[0].Type != "health.down" {
 		t.Errorf("threshold-th down should emit health.down, got %d events", total)
+	}
+	// The badge crosses unknown -> down (Known flips, Healthy does not), so the
+	// confirming poll must still nudge connected UIs to refetch.
+	if !sawMemberStatus(ch) {
+		t.Error("confirmed-down should nudge the badge even from an unknown start")
 	}
 }
 

--- a/internal/frontdesk/poller_test.go
+++ b/internal/frontdesk/poller_test.go
@@ -247,6 +247,14 @@ func TestPollTraefikOnceMapsByURL(t *testing.T) {
 	a, _ := store.CreateMember(ctx, "a", "http://a:8081", "")
 	b, _ := store.CreateMember(ctx, "b", "http://b:8081", "")
 
+	// Threshold 1 so a single poll commits DOWN; this test covers URL mapping,
+	// not the down-flip damping (which TestPollTraefikOnceDampsDownFlip covers).
+	set, _ := store.GetSettings(ctx)
+	set.HealthFailThreshold = 1
+	if err := store.UpdateSettings(ctx, set); err != nil {
+		t.Fatalf("UpdateSettings: %v", err)
+	}
+
 	p.PollTraefikOnce(ctx)
 	snap := p.Snapshot()
 	if snap[a.ID].TraefikStatus != "UP" {

--- a/internal/frontdesk/poller_test.go
+++ b/internal/frontdesk/poller_test.go
@@ -80,6 +80,11 @@ func TestApplyHealthTransitions(t *testing.T) {
 		}
 	}
 
+	thr := p.healthFailThreshold(ctx)
+	if thr < 2 {
+		t.Fatalf("test assumes a grace window; threshold = %d", thr)
+	}
+
 	// First observation healthy: silent in the event log, but still nudges the UI
 	// so a freshly added healthy member populates without a manual reload.
 	p.applyHealth(ctx, m, HealthStatus{Known: true, Healthy: true})
@@ -91,14 +96,29 @@ func TestApplyHealthTransitions(t *testing.T) {
 		t.Errorf("first healthy should emit a member.status nudge, got %+v", nudge)
 	}
 
-	// healthy -> down: emits health.down (preceded by a member.status nudge).
+	// Below-threshold failures are tolerated: no event, no nudge, and the badge
+	// stays healthy (a rebuild blip must not flip the dashboard red).
+	for i := 1; i < thr; i++ {
+		p.applyHealth(ctx, m, HealthStatus{Known: true, Healthy: false, Error: "boom"})
+		select {
+		case ev := <-ch:
+			t.Errorf("failure %d below threshold should be silent, got %+v", i, ev)
+		default:
+		}
+	}
+	if snap := p.Snapshot(); !snap[m.ID].Health.Healthy {
+		t.Errorf("badge should stay healthy during the grace window: %+v", snap[m.ID])
+	}
+
+	// The threshold-th consecutive failure confirms down: one health.down
+	// (preceded by a member.status nudge).
 	p.applyHealth(ctx, m, HealthStatus{Known: true, Healthy: false, Error: "boom"})
 	ev := nextTransition()
 	if ev.Type != "health.down" || ev.Severity != "error" {
 		t.Errorf("down event: %+v", ev)
 	}
 
-	// down -> up: emits health.up (preceded by a member.status nudge).
+	// Recovery is immediate: the first healthy poll emits health.up.
 	p.applyHealth(ctx, m, HealthStatus{Known: true, Healthy: true, LatencyMs: 12})
 	ev = nextTransition()
 	if ev.Type != "health.up" || ev.Severity != "success" {
@@ -126,15 +146,65 @@ func TestApplyHealthTransitions(t *testing.T) {
 	}
 }
 
-func TestApplyHealthFirstObservationDownEmits(t *testing.T) {
+func TestApplyHealthFirstObservationDownDebounced(t *testing.T) {
+	p, store, _ := newTestPoller(t, "")
+	ctx := context.Background()
+	m, _ := store.CreateMember(ctx, "h", "http://h:8081", "")
+	thr := p.healthFailThreshold(ctx)
+
+	// A member down from its very first observation is not reported until it has
+	// missed `thr` polls in a row (a rebuild started while Front Desk was down).
+	for i := 1; i < thr; i++ {
+		p.applyHealth(ctx, m, HealthStatus{Known: true, Healthy: false, Error: "down at start"})
+		if _, total, _ := store.ListEvents(ctx, EventFilter{}); total != 0 {
+			t.Fatalf("down before threshold (poll %d) should be silent, got %d events", i, total)
+		}
+	}
+	p.applyHealth(ctx, m, HealthStatus{Known: true, Healthy: false, Error: "down at start"})
+	evs, total, _ := store.ListEvents(ctx, EventFilter{})
+	if total != 1 || evs[0].Type != "health.down" {
+		t.Errorf("threshold-th down should emit health.down, got %d events", total)
+	}
+}
+
+func TestApplyHealthBlipBelowThresholdIsSilent(t *testing.T) {
+	p, store, _ := newTestPoller(t, "")
+	ctx := context.Background()
+	m, _ := store.CreateMember(ctx, "h", "http://h:8081", "")
+	thr := p.healthFailThreshold(ctx)
+	if thr < 2 {
+		t.Skip("no grace window at this threshold")
+	}
+
+	p.applyHealth(ctx, m, HealthStatus{Known: true, Healthy: true})
+	for i := 1; i < thr; i++ { // a rebuild blip, one poll short of the threshold
+		p.applyHealth(ctx, m, HealthStatus{Known: true, Healthy: false, Error: "rebuild"})
+	}
+	p.applyHealth(ctx, m, HealthStatus{Known: true, Healthy: true}) // back before it counts
+
+	if _, total, _ := store.ListEvents(ctx, EventFilter{}); total != 0 {
+		t.Errorf("a sub-threshold blip should persist no events, got %d", total)
+	}
+}
+
+func TestApplyHealthThresholdConfigurable(t *testing.T) {
 	p, store, _ := newTestPoller(t, "")
 	ctx := context.Background()
 	m, _ := store.CreateMember(ctx, "h", "http://h:8081", "")
 
-	p.applyHealth(ctx, m, HealthStatus{Known: true, Healthy: false, Error: "down at start"})
-	evs, total, _ := store.ListEvents(ctx, EventFilter{})
-	if total != 1 || evs[0].Type != "health.down" {
-		t.Errorf("first-observation-down should emit health.down, got %d events", total)
+	set, err := store.GetSettings(ctx)
+	if err != nil {
+		t.Fatalf("get settings: %v", err)
+	}
+	set.HealthFailThreshold = 1
+	if err := store.UpdateSettings(ctx, set); err != nil {
+		t.Fatalf("update settings: %v", err)
+	}
+
+	// Threshold 1 restores immediate reporting: the first down emits.
+	p.applyHealth(ctx, m, HealthStatus{Known: true, Healthy: false, Error: "boom"})
+	if _, total, _ := store.ListEvents(ctx, EventFilter{}); total != 1 {
+		t.Errorf("threshold=1 should emit on first down, got %d events", total)
 	}
 }
 

--- a/internal/frontdesk/store.go
+++ b/internal/frontdesk/store.go
@@ -80,6 +80,13 @@ type Settings struct {
 	EventRetentionDays int `json:"event_retention_days"`
 	RetryAttempts      int `json:"retry_attempts"`
 
+	// HealthFailThreshold is the number of consecutive failed health polls a
+	// member must accrue before Front Desk reports it down (an error event plus,
+	// by default, an Apprise alert). It damps the reachability flap of a routine
+	// container rebuild; recovery is immediate. The same threshold governs the
+	// Traefik UP->DOWN badge flip. Bounded to at least 1.
+	HealthFailThreshold int `json:"health_fail_threshold"`
+
 	// Admin-UI inactivity auto-logout window in minutes; 0 disables it. Consumed
 	// by the frontend (useIdleLogout); the server only stores and bounds it.
 	SessionIdleTimeoutMinutes int `json:"session_idle_timeout_minutes"`
@@ -414,12 +421,12 @@ func (s *Store) GetSettings(ctx context.Context) (Settings, error) {
 	)
 	err := s.db.QueryRowContext(ctx,
 		`SELECT health_poll_secs, traefik_poll_secs, traefik_stale_secs, event_retention_days, retry_attempts,
-		        session_idle_timeout_minutes,
+		        health_fail_threshold, session_idle_timeout_minutes,
 		        alert_enabled, alert_apprise_api_url, alert_apprise_targets, alert_events,
 		        oidc_enabled, oidc_issuer_url, oidc_client_id, oidc_client_secret, oidc_public_base_url, oidc_allowed_emails
 		 FROM settings WHERE id = 1`,
 	).Scan(&set.HealthPollSecs, &set.TraefikPollSecs, &set.TraefikStaleSecs, &set.EventRetentionDays, &set.RetryAttempts,
-		&set.SessionIdleTimeoutMinutes,
+		&set.HealthFailThreshold, &set.SessionIdleTimeoutMinutes,
 		&alertEnabled, &set.AlertAppriseAPIURL, &set.AlertAppriseTargets, &set.AlertEvents,
 		&oidcEnabled, &set.OidcIssuerURL, &set.OidcClientID, &set.OidcClientSecret, &set.OidcPublicBaseURL, &set.OidcAllowedEmails)
 	if err != nil {
@@ -441,6 +448,9 @@ func (s *Store) UpdateSettings(ctx context.Context, set Settings) error {
 	if set.RetryAttempts < 0 {
 		return fmt.Errorf("%w: retry attempts cannot be negative", ErrValidation)
 	}
+	if set.HealthFailThreshold < 1 {
+		return fmt.Errorf("%w: health fail threshold must be at least 1", ErrValidation)
+	}
 	if set.SessionIdleTimeoutMinutes < 0 || set.SessionIdleTimeoutMinutes > 240 {
 		return fmt.Errorf("%w: session idle timeout must be between 0 and 240 minutes", ErrValidation)
 	}
@@ -457,12 +467,12 @@ func (s *Store) UpdateSettings(ctx context.Context, set Settings) error {
 	// masked submission.
 	_, err := s.db.ExecContext(ctx,
 		`UPDATE settings SET health_poll_secs = ?, traefik_poll_secs = ?, traefik_stale_secs = ?,
-		 event_retention_days = ?, retry_attempts = ?, session_idle_timeout_minutes = ?,
+		 event_retention_days = ?, retry_attempts = ?, health_fail_threshold = ?, session_idle_timeout_minutes = ?,
 		 alert_enabled = ?, alert_apprise_api_url = ?, alert_apprise_targets = ?, alert_events = ?,
 		 oidc_enabled = ?, oidc_issuer_url = ?, oidc_client_id = ?, oidc_client_secret = ?,
 		 oidc_public_base_url = ?, oidc_allowed_emails = ? WHERE id = 1`,
 		set.HealthPollSecs, set.TraefikPollSecs, set.TraefikStaleSecs,
-		set.EventRetentionDays, set.RetryAttempts, set.SessionIdleTimeoutMinutes,
+		set.EventRetentionDays, set.RetryAttempts, set.HealthFailThreshold, set.SessionIdleTimeoutMinutes,
 		alertEnabled, set.AlertAppriseAPIURL, set.AlertAppriseTargets, set.AlertEvents,
 		oidcEnabled, set.OidcIssuerURL, set.OidcClientID, set.OidcClientSecret,
 		set.OidcPublicBaseURL, set.OidcAllowedEmails,

--- a/internal/frontdesk/store_test.go
+++ b/internal/frontdesk/store_test.go
@@ -214,10 +214,14 @@ func TestSettingsDefaultsAndUpdate(t *testing.T) {
 	if def.SessionIdleTimeoutMinutes != 60 {
 		t.Errorf("session idle timeout default = %d, want 60", def.SessionIdleTimeoutMinutes)
 	}
+	if def.HealthFailThreshold != 3 {
+		t.Errorf("health fail threshold default = %d, want 3", def.HealthFailThreshold)
+	}
 
 	updated := Settings{
 		HealthPollSecs: 10, TraefikPollSecs: 7, TraefikStaleSecs: 60,
 		EventRetentionDays: 30, RetryAttempts: 0, SessionIdleTimeoutMinutes: 30,
+		HealthFailThreshold: 4,
 	}
 	if err := s.UpdateSettings(ctx, updated); err != nil {
 		t.Fatalf("UpdateSettings: %v", err)
@@ -232,11 +236,12 @@ func TestSettingsValidation(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()
 	bad := []Settings{
-		{HealthPollSecs: 0, TraefikPollSecs: 5, TraefikStaleSecs: 5, EventRetentionDays: 1, RetryAttempts: 1},
-		{HealthPollSecs: 5, TraefikPollSecs: 5, TraefikStaleSecs: 5, EventRetentionDays: 0, RetryAttempts: 1},
-		{HealthPollSecs: 5, TraefikPollSecs: 5, TraefikStaleSecs: 5, EventRetentionDays: 1, RetryAttempts: -1},
-		{HealthPollSecs: 5, TraefikPollSecs: 5, TraefikStaleSecs: 5, EventRetentionDays: 1, RetryAttempts: 1, SessionIdleTimeoutMinutes: -1},
-		{HealthPollSecs: 5, TraefikPollSecs: 5, TraefikStaleSecs: 5, EventRetentionDays: 1, RetryAttempts: 1, SessionIdleTimeoutMinutes: 241},
+		{HealthPollSecs: 0, TraefikPollSecs: 5, TraefikStaleSecs: 5, EventRetentionDays: 1, RetryAttempts: 1, HealthFailThreshold: 1},
+		{HealthPollSecs: 5, TraefikPollSecs: 5, TraefikStaleSecs: 5, EventRetentionDays: 0, RetryAttempts: 1, HealthFailThreshold: 1},
+		{HealthPollSecs: 5, TraefikPollSecs: 5, TraefikStaleSecs: 5, EventRetentionDays: 1, RetryAttempts: -1, HealthFailThreshold: 1},
+		{HealthPollSecs: 5, TraefikPollSecs: 5, TraefikStaleSecs: 5, EventRetentionDays: 1, RetryAttempts: 1, HealthFailThreshold: 1, SessionIdleTimeoutMinutes: -1},
+		{HealthPollSecs: 5, TraefikPollSecs: 5, TraefikStaleSecs: 5, EventRetentionDays: 1, RetryAttempts: 1, HealthFailThreshold: 1, SessionIdleTimeoutMinutes: 241},
+		{HealthPollSecs: 5, TraefikPollSecs: 5, TraefikStaleSecs: 5, EventRetentionDays: 1, RetryAttempts: 1, HealthFailThreshold: 0},
 	}
 	for i, b := range bad {
 		if err := s.UpdateSettings(ctx, b); !errors.Is(err, ErrValidation) {

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -284,6 +284,48 @@ func (r *Repository) Set(ctx context.Context, key, value string) error {
 	return nil
 }
 
+// SetMany upserts several settings in a single multi-row statement and
+// invalidates their cache entries. It exists so callers that must persist a
+// small fixed group of keys (e.g. the member-side fleet heartbeat) pay one DB
+// round-trip instead of one per key, which keeps them comfortably inside a
+// caller's request timeout even when the database is briefly slow (a
+// simultaneous multi-container restart, say). Semantics otherwise match Set:
+// no allowlist gate, cache evicted before the write, subscribers notified
+// after it commits. An empty slice is a no-op.
+func (r *Repository) SetMany(ctx context.Context, kvs [][2]string) error {
+	if len(kvs) == 0 {
+		return nil
+	}
+
+	// Evict before the write, exactly as Set does, so a read racing the write
+	// falls through to the DB rather than serving a stale cached value.
+	r.mu.Lock()
+	for _, kv := range kvs {
+		delete(r.cache, kv[0])
+	}
+	r.mu.Unlock()
+
+	var sb strings.Builder
+	sb.WriteString("INSERT INTO settings (key, value, updated_at) VALUES ")
+	args := make([]any, 0, len(kvs)*2)
+	for i, kv := range kvs {
+		if i > 0 {
+			sb.WriteByte(',')
+		}
+		fmt.Fprintf(&sb, "($%d, $%d, now())", i*2+1, i*2+2)
+		args = append(args, kv[0], kv[1])
+	}
+	sb.WriteString(" ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = now()")
+
+	if _, err := r.pool.Exec(ctx, sb.String(), args...); err != nil {
+		return err
+	}
+	for _, kv := range kvs {
+		r.notifyChange(kv[0], kv[1])
+	}
+	return nil
+}
+
 // SetTx updates a setting within an existing transaction.
 func (r *Repository) SetTx(ctx context.Context, tx pgx.Tx, key, value string) error {
 	if !AllowedSettings[key] {

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -320,6 +320,12 @@ func (r *Repository) SetMany(ctx context.Context, kvs [][2]string) error {
 	if _, err := r.pool.Exec(ctx, sb.String(), args...); err != nil {
 		return err
 	}
+	// The row write is atomic (one statement); the notifications are not. We fan
+	// out one change event per key after the commit succeeds, exactly as a loop
+	// of Set calls would, so a subscriber may observe the keys arrive one at a
+	// time. This is fine for the fleet-heartbeat keys, whose consumers read each
+	// independently; a caller needing an all-or-nothing notification should not
+	// use SetMany.
 	for _, kv := range kvs {
 		r.notifyChange(kv[0], kv[1])
 	}

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -95,6 +95,69 @@ func TestGetWithDefault(t *testing.T) {
 	}
 }
 
+func TestSetMany(t *testing.T) {
+	r := NewRepository(testPool)
+	ctx := context.Background()
+	clearSettings(t)
+
+	// Seed one key so the batch exercises both INSERT and ON CONFLICT UPDATE.
+	if err := r.Set(ctx, "k1", "old"); err != nil {
+		t.Fatalf("seed Set failed: %v", err)
+	}
+
+	if err := r.SetMany(ctx, [][2]string{
+		{"k1", "new"},
+		{"k2", "two"},
+		{"k3", "three"},
+	}); err != nil {
+		t.Fatalf("SetMany failed: %v", err)
+	}
+
+	// Read straight from the DB (cache was evicted) to confirm every row landed.
+	want := map[string]string{"k1": "new", "k2": "two", "k3": "three"}
+	for k, v := range want {
+		var got string
+		if err := testPool.QueryRow(ctx,
+			"SELECT value FROM settings WHERE key = $1", k).Scan(&got); err != nil {
+			t.Fatalf("read %s: %v", k, err)
+		}
+		if got != v {
+			t.Errorf("%s = %q, want %q", k, got, v)
+		}
+	}
+
+	// Empty input is a no-op, not an error or a malformed statement.
+	if err := r.SetMany(ctx, nil); err != nil {
+		t.Errorf("SetMany(nil) = %v, want nil", err)
+	}
+}
+
+func TestSetManyNotifiesSubscribers(t *testing.T) {
+	r := NewRepository(testPool)
+	ctx := context.Background()
+	clearSettings(t)
+
+	sub := r.Subscribe()
+	defer sub.Unsubscribe()
+
+	if err := r.SetMany(ctx, [][2]string{{"a", "1"}, {"b", "2"}}); err != nil {
+		t.Fatalf("SetMany failed: %v", err)
+	}
+
+	got := map[string]string{}
+	for range 2 {
+		select {
+		case c := <-sub.Events():
+			got[c.Key] = c.Value
+		case <-time.After(time.Second):
+			t.Fatalf("timeout waiting for change events, got %v", got)
+		}
+	}
+	if got["a"] != "1" || got["b"] != "2" {
+		t.Errorf("change events = %v, want a=1 b=2", got)
+	}
+}
+
 func TestSubscribe(t *testing.T) {
 	r := NewRepository(testPool)
 	ctx := context.Background()

--- a/web/src/components/ErrorShelf/ErrorShelf.tsx
+++ b/web/src/components/ErrorShelf/ErrorShelf.tsx
@@ -14,6 +14,7 @@ import { formatRelativeTime, formatTimestamp } from "../../utils/format";
 import { truncateWithEllipsis } from "../../utils/truncate";
 import { LogDetailModal } from "../LogDetailModal";
 import {
+	isHaAccessLog,
 	isHaSource,
 	isSsoSource,
 	type ShelfError,
@@ -183,12 +184,16 @@ export function ErrorShelf() {
 								// HA membership failures and SSO/OIDC login failures are app
 								// errors whose source identifies the subsystem; each gets its
 								// own chip + accent while still opening as an "app" log in the
-								// detail modal.
-								const category = isHaSource(err.source)
-									? "ha"
-									: isSsoSource(err.source)
-										? "sso"
-										: err.kind;
+								// detail modal. A 5xx access-log line on a /api/fleet/* path is
+								// an HA-plane failure too (e.g. a Front Desk announce the member
+								// couldn't record), so it also takes the HA chip.
+								const category =
+									isHaSource(err.source) ||
+									isHaAccessLog(err.source, err.message)
+										? "ha"
+										: isSsoSource(err.source)
+											? "sso"
+											: err.kind;
 								const chipLabel =
 									category === "ha"
 										? t("layout.errorShelf.haKind")

--- a/web/src/components/ErrorShelf/__tests__/ErrorShelf.test.tsx
+++ b/web/src/components/ErrorShelf/__tests__/ErrorShelf.test.tsx
@@ -4,7 +4,28 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { server } from "../../../test/mocks/server";
 import { renderWithProviders } from "../../../test/utils";
 import { ErrorShelf } from "../ErrorShelf";
-import { isHaSource, isSsoSource } from "../useErrorShelf";
+import { isHaAccessLog, isHaSource, isSsoSource } from "../useErrorShelf";
+
+describe("isHaAccessLog", () => {
+	it("flags access-log 5xx lines on a /api/fleet/* path", () => {
+		expect(
+			isHaAccessLog(
+				"access",
+				"request method=POST host=mh1 path=/api/fleet/announce status=500",
+			),
+		).toBe(true);
+	});
+
+	it("rejects non-fleet paths and non-access sources", () => {
+		expect(
+			isHaAccessLog("access", "request path=/api/providers status=500"),
+		).toBe(false);
+		expect(
+			isHaAccessLog("proxy", "request path=/api/fleet/announce status=500"),
+		).toBe(false);
+		expect(isHaAccessLog(undefined, "path=/api/fleet/announce")).toBe(false);
+	});
+});
 
 describe("isHaSource", () => {
 	it("flags the fleet config-sync sources", () => {
@@ -160,6 +181,25 @@ describe("ErrorShelf", () => {
 		expect(within(rows[0]).getByTestId("error-shelf-chip-ha")).toBeTruthy();
 		expect(within(rows[0]).queryByTestId("error-shelf-chip-app")).toBeNull();
 		expect(within(rows[0]).getByText("apply import failed")).toBeTruthy();
+	});
+
+	it("tags fleet-path access-log errors with the HA chip", async () => {
+		// The access logger stamps source "access" for every request; the fleet
+		// control-plane path in the message is what makes this an HA failure.
+		seedAppError(
+			"request method=POST host=mh1 path=/api/fleet/announce status=500",
+			"2024-02-01T09:00:00Z",
+			"access",
+		);
+		renderWithProviders(<ErrorShelf />);
+
+		await screen.findByTestId("error-shelf-count");
+		await expand();
+
+		const rows = await screen.findAllByTestId("error-shelf-row");
+		expect(rows).toHaveLength(1);
+		expect(within(rows[0]).getByTestId("error-shelf-chip-ha")).toBeTruthy();
+		expect(within(rows[0]).queryByTestId("error-shelf-chip-app")).toBeNull();
 	});
 
 	it("tags OIDC login app errors with the SSO chip", async () => {

--- a/web/src/components/ErrorShelf/useErrorShelf.ts
+++ b/web/src/components/ErrorShelf/useErrorShelf.ts
@@ -29,6 +29,18 @@ export function isHaSource(source: string | undefined): boolean {
 	return source !== undefined && HA_SOURCES.has(source);
 }
 
+/** The HTTP access logger stamps every request line with source "access" and
+ * carries the target path as a `path=/...` field in the message. A 5xx on a
+ * `/api/fleet/*` control-plane endpoint (e.g. the Front Desk announce
+ * heartbeat) is therefore an HA-plane failure that the source alone can't
+ * distinguish from any other request error — this recovers it from the path. */
+export function isHaAccessLog(
+	source: string | undefined,
+	message: string,
+): boolean {
+	return source === "access" && message.includes("path=/api/fleet/");
+}
+
 /** App-log sources emitted by the OIDC single-sign-on admin-login flow. An app
  * error from one of these is surfaced as a distinct "SSO" category (an admin
  * login failing against the identity provider) rather than a generic internal


### PR DESCRIPTION
## Why

Rebuilding an HA member (or several containers at once) to `:dev` produced ~10-15 orange **app** error-shelf entries like:

```
POST host=model-hotel1.zmrd.uk path=/api/fleet/announce status=500 duration=3.99944149s
```

Three separate issues, each fixed in its own commit.

## What

**1. `fix(errorshelf)` — categorize `/api/fleet/*` access-log 5xx as HA, not app**
The shelf colors by slog *source*; the HTTP access logger stamps every request line source `access`, so a fleet control-plane 5xx missed the indigo HA chip (which keyed only on `configsync`/`fleet` sources). `isHaAccessLog(source, message)` recovers the HA classification from the `path=/api/fleet/` field. Frontend-only.

**2. `fix(fleet)` — record the announce heartbeat in one DB round-trip**
The `3.99944149s` was Front Desk's 4s announce-client timeout. The member's `Announce` handler did four sequential `settings.Set` writes; under rebuild DB contention those four round-trips blew the budget, the client cancelled, and the member logged a spurious 500. New `settings.Repository.SetMany` does a single multi-row upsert (same cache-evict + subscriber-notify semantics as `Set`), all-or-nothing. Added to the `SettingsStore` + `fleetSettings` interfaces and both test mocks.

**3. `feat(frontdesk)` — debounce member health-down with a configurable threshold**
`applyHealth` flipped a member down on the *first* failed poll, emitting a `health.down` error event and a default-on Apprise alert — so every routine rebuild raised an alert the instant the container blinked. Now a member must miss `health_fail_threshold` polls in a row before it is reported down (mirrors the existing `versionFetchFailThreshold` debounce). Recovery stays immediate; the last known-good badge is kept during the grace window so the dashboard no longer flickers red. New Front Desk setting (migration 011, default 3 ≈ 15s at the 5s poll interval), tunable on the Settings page.

**4. `feat(frontdesk)` — damp the Traefik UP→DOWN badge flip**
Traefik briefly stops listing a member during a restart; committing that immediately flapped the badge and re-nudged every dashboard. A non-UP status is now held back until observed `health_fail_threshold` polls in a row (same knob); UP still applies at once, so recovery is immediate.

## Testing
- Backend: full `internal/frontdesk` suite + targeted `internal/settings` (`SetMany`) and `internal/api` (fleet) tests pass; `golangci-lint` clean on all touched packages.
- Frontend: `tsc -b` clean on `web/` and `frontdesk/web/`; ErrorShelf, SettingsPage, AlertsPanel, OidcPanel suites pass; biome clean.
- New tests cover: batched announce write + all-or-nothing failure, `SetMany` upsert + subscriber notify, health debounce (grace-window silence, threshold crossing, immediate recovery, configurable threshold, first-observation-down), and Traefik down-flip damping.

## Notes
- If merged: needs a `.version` bump + dev rebuild (the FD Settings field is embedded, so `docker compose restart` won't pick it up).
- Operators who routinely take 30s+ to rebuild can raise `health_fail_threshold` on the FD Settings page rather than tolerate an alert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)