### PR TITLE
fix(api,web): extend managed-member lockout to dashboard user management

### DIFF
--- a/internal/api/managedwrite.go
+++ b/internal/api/managedwrite.go
@@ -10,7 +10,7 @@ import (
 // already shows for a managed fleet member. When this instance is an actively
 // managed member (Front Desk in contact, non-primary, fresh heartbeat), its
 // synced entities (providers, virtual keys, custom failover groups, syncable
-// settings) are declaratively replaced on the next config sync. The UI hides the
+// settings, user accounts) are declaratively replaced on the next config sync. The UI hides the
 // create/edit/delete affordances for those (see web/src/hooks/useManaged.ts), but
 // a direct API call, a second tab, or a page loaded before enrollment can still
 // reach the write handlers. Such a write would "succeed" and then be silently
@@ -25,8 +25,9 @@ import (
 // managedWriteMsg is the 403 body returned when a synced-entity write is refused
 // because this instance is a managed fleet member.
 const managedWriteMsg = "this instance is managed by the fleet primary; " +
-	"providers, virtual keys, failover groups, and synced settings are replaced " +
-	"on the next sync and cannot be edited here. Change them on the primary."
+	"providers, virtual keys, failover groups, synced settings, and user " +
+	"accounts are replaced on the next sync and cannot be edited here. " +
+	"Change them on the primary."
 
 // isManagedMember reports whether this instance is an actively managed fleet
 // member: Front Desk is in contact AND this node is a non-primary member with a
@@ -66,8 +67,9 @@ func managedBlocksSyncableSettings(ctx context.Context, fs fleetSettings, keys [
 
 // managedWriteGuard returns middleware that refuses a request with 403 when this
 // instance is a managed fleet member. Mount it ONLY on synced-entity write routes
-// (providers, virtual keys, custom failover group CRUD): every request that
-// reaches it is treated as such a write, so it does no method or path inspection.
+// (providers, virtual keys, custom failover group CRUD, user accounts): every
+// request that reaches it is treated as such a write, so it does no method or
+// path inspection.
 func managedWriteGuard(fs fleetSettings) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/managedwrite_test.go
+++ b/internal/api/managedwrite_test.go
@@ -7,6 +7,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/hugalafutro/model-hotel/internal/user"
+	"github.com/hugalafutro/model-hotel/internal/webauthn"
 )
 
 // memberFleetSettings seeds a fakeFleetSettings to the "member" state: a fresh
@@ -129,6 +132,11 @@ func TestHandlerRegister_ManagedMember(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Wire the multi-user store so the /users read handlers (ListUsers,
+	// ListGrantCatalog) don't hit a nil userRepo in this harness.
+	pool := h.Pool().Pool()
+	h.SetUserAuth(user.NewRepository(pool), webauthn.NewRepository(pool))
+
 	auth := func(req *http.Request) *http.Request {
 		req.Header.Set("Authorization", "Bearer test-admin-token")
 		return req
@@ -149,6 +157,10 @@ func TestHandlerRegister_ManagedMember(t *testing.T) {
 		{"POST /providers", http.MethodPost, "/providers", `{"name":"x","base_url":"http://localhost:1234"}`},
 		{"POST /virtual-keys", http.MethodPost, "/virtual-keys", `{}`},
 		{"POST /failover-groups", http.MethodPost, "/failover-groups", `{}`},
+		{"POST /users", http.MethodPost, "/users", `{"username":"x","password":"password123","role":"user"}`},
+		{"PUT /users/{id}", http.MethodPut, "/users/00000000-0000-0000-0000-000000000001", `{}`},
+		{"POST /users/{id}/password", http.MethodPost, "/users/00000000-0000-0000-0000-000000000001/password", `{}`},
+		{"DELETE /users/{id}", http.MethodDelete, "/users/00000000-0000-0000-0000-000000000001", ""},
 		{"PUT /settings (syncable)", http.MethodPut, "/settings", `{"alert_enabled":"true"}`},
 		{"DELETE /settings (reset all)", http.MethodDelete, "/settings", `{}`},
 	} {
@@ -160,6 +172,13 @@ func TestHandlerRegister_ManagedMember(t *testing.T) {
 	// Reads, failover sync, and instance-local apprise settings stay usable.
 	if code, _ := do(http.MethodGet, "/providers", ""); code != http.StatusOK {
 		t.Errorf("managed GET /providers: expected 200, got %d", code)
+	}
+	// /users reads stay open on a member (writes are guarded above).
+	if code, _ := do(http.MethodGet, "/users", ""); code != http.StatusOK {
+		t.Errorf("managed GET /users: expected 200, got %d", code)
+	}
+	if code, _ := do(http.MethodGet, "/users/grants", ""); code != http.StatusOK {
+		t.Errorf("managed GET /users/grants: expected 200, got %d", code)
 	}
 	if code, _ := do(http.MethodPost, "/failover-groups/sync", ""); code == http.StatusForbidden {
 		t.Errorf("managed POST /failover-groups/sync: must be exempt, got 403")

--- a/internal/api/users.go
+++ b/internal/api/users.go
@@ -18,15 +18,24 @@ const minPasswordLen = 8
 
 // RegisterUsers mounts the user management API. Admin-only: users cannot see
 // or edit each other, and grants never unlock this surface.
+//
+// Reads (the roster, the grant catalog) stay open on a managed fleet member:
+// the list matches the primary's, and the operator may browse it. Writes are
+// guarded by managedWriteGuard because the user roster is synced config —
+// applyUsers deletes any account absent from the primary's export on the next
+// sync, so a local create/edit/delete would "succeed" and then be undone.
 func (h *Handler) RegisterUsers(r chi.Router) {
 	r.Route("/users", func(r chi.Router) {
 		r.Use(requireAdmin)
 		r.Get("/", h.ListUsers)
 		r.Get("/grants", h.ListGrantCatalog)
-		r.Post("/", h.CreateUser)
-		r.Put("/{id}", h.UpdateUser)
-		r.Post("/{id}/password", h.SetUserPassword)
-		r.Delete("/{id}", h.DeleteUser)
+		r.Group(func(r chi.Router) {
+			r.Use(managedWriteGuard(h.settingsRepo))
+			r.Post("/", h.CreateUser)
+			r.Put("/{id}", h.UpdateUser)
+			r.Post("/{id}/password", h.SetUserPassword)
+			r.Delete("/{id}", h.DeleteUser)
+		})
 	})
 }
 

--- a/web/src/pages/Users/UserModal.tsx
+++ b/web/src/pages/Users/UserModal.tsx
@@ -19,11 +19,13 @@ function errMessage(err: unknown, fallback: string): string {
 
 export function UserModal({
 	user,
+	managed = false,
 	onClose,
 	onToast,
 }: {
 	/** null opens the modal in create mode. */
 	user: DashboardUser | null;
+	managed?: boolean;
 	onClose: () => void;
 	onToast: (msg: string, type: "success" | "error" | "info") => void;
 }) {
@@ -152,6 +154,7 @@ export function UserModal({
 						className="ui-input"
 						maxLength={64}
 						autoComplete="off"
+						disabled={managed}
 					/>
 				</div>
 
@@ -169,6 +172,7 @@ export function UserModal({
 						onChange={(e) => setDisplayName(e.target.value)}
 						className="ui-input"
 						maxLength={128}
+						disabled={managed}
 					/>
 				</div>
 
@@ -186,6 +190,7 @@ export function UserModal({
 						onChange={(e) => setEmail(e.target.value)}
 						className="ui-input"
 						autoComplete="off"
+						disabled={managed}
 					/>
 					<p className="text-xs text-gray-500 mt-1">
 						{t("users.modal.emailHint")}
@@ -208,6 +213,7 @@ export function UserModal({
 							className="ui-input"
 							autoComplete="new-password"
 							placeholder={t("users.modal.passwordPlaceholder")}
+							disabled={managed}
 						/>
 					</div>
 				)}
@@ -224,7 +230,7 @@ export function UserModal({
 						value={role}
 						onChange={(e) => setRole(e.target.value as "admin" | "user")}
 						className="ui-input"
-						disabled={isSelf}
+						disabled={isSelf || managed}
 					>
 						<option value="user">{t("users.role.user")}</option>
 						<option value="admin">{t("users.role.admin")}</option>
@@ -253,6 +259,7 @@ export function UserModal({
 										onChange={() => toggleGrant(g)}
 										className="ui-checkbox"
 										data-testid={`grant-${g}`}
+										disabled={managed}
 									/>
 									{t(`users.grant.${g}`, { defaultValue: g })}
 								</label>
@@ -269,28 +276,36 @@ export function UserModal({
 						<Toggle
 							checked={enabled}
 							onChange={setEnabled}
-							disabled={isSelf}
+							disabled={isSelf || managed}
 							ariaLabel={t("users.modal.enabled")}
 						/>
 					</div>
 				)}
 
 				<div className="flex gap-3 pt-2">
-					<button
-						type="button"
-						onClick={handleSave}
-						disabled={saveMutation.isPending}
-						className="ui-btn ui-btn-primary flex-1 disabled:opacity-50"
-						data-testid="user-modal-save"
-					>
-						{isEdit ? t("users.modal.save") : t("users.modal.create")}
-					</button>
+					{!managed && (
+						<button
+							type="button"
+							onClick={handleSave}
+							disabled={saveMutation.isPending}
+							className="ui-btn ui-btn-primary flex-1 disabled:opacity-50"
+							data-testid="user-modal-save"
+						>
+							{isEdit ? t("users.modal.save") : t("users.modal.create")}
+						</button>
+					)}
 					<button type="button" onClick={onClose} className="ui-btn flex-1">
 						{t("users.modal.cancel")}
 					</button>
 				</div>
 
-				{isEdit && (
+				{managed && isEdit && (
+					<p data-testid="managed-note" className="text-xs text-(--text-muted)">
+						{t("settings.managed.sectionNote")}
+					</p>
+				)}
+
+				{isEdit && !managed && (
 					<div className="border-t border-gray-700 pt-4 space-y-4">
 						<div>
 							<label

--- a/web/src/pages/Users/__tests__/Users.managed.test.tsx
+++ b/web/src/pages/Users/__tests__/Users.managed.test.tsx
@@ -1,0 +1,97 @@
+import { screen, waitFor, within } from "@testing-library/react";
+import { HttpResponse, http } from "msw";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { DashboardUser } from "../../../api/types";
+import { mockSystemStats } from "../../../test/mocks/data";
+import { server } from "../../../test/mocks/server";
+import { renderWithProviders } from "../../../test/utils";
+import { Users } from "../index";
+
+const mockUser: DashboardUser = {
+	id: "11111111-2222-4333-8444-555555555555",
+	username: "alice",
+	display_name: "Alice A",
+	email: "alice@example.com",
+	role: "user",
+	grants: ["chat", "logs"],
+	enabled: true,
+	created_at: "2026-07-01T10:00:00Z",
+	updated_at: "2026-07-01T10:00:00Z",
+	last_login_at: null,
+};
+
+const systemWithFleet = (state: "primary" | "member") => ({
+	...mockSystemStats,
+	fleet: { state, is_primary: state === "primary" },
+});
+
+function mockUsersApi(users: DashboardUser[]) {
+	server.use(
+		http.get("/api/users", () => HttpResponse.json(users)),
+		http.get("/api/users/grants", () =>
+			HttpResponse.json({
+				grants: ["chat", "usage", "logs", "models", "virtual_keys"],
+			}),
+		),
+	);
+}
+
+describe("Users managed (fleet member) mode", () => {
+	beforeEach(() => {
+		server.resetHandlers();
+		vi.clearAllMocks();
+	});
+
+	it("hides the create button and shows the managed banner for a member", async () => {
+		server.use(
+			http.get("/api/system", () =>
+				HttpResponse.json(systemWithFleet("member")),
+			),
+		);
+		mockUsersApi([mockUser]);
+		renderWithProviders(<Users />);
+
+		expect(await screen.findByTestId("managed-banner")).toBeInTheDocument();
+		await waitFor(() =>
+			expect(screen.queryByTestId("add-user-button")).not.toBeInTheDocument(),
+		);
+	});
+
+	it("shows a read-only note and hides save/delete/reset inside the edit modal for a member", async () => {
+		server.use(
+			http.get("/api/system", () =>
+				HttpResponse.json(systemWithFleet("member")),
+			),
+		);
+		mockUsersApi([mockUser]);
+		const { user } = renderWithProviders(<Users />);
+
+		await user.click(await screen.findByText("alice"));
+		const dialog = await screen.findByRole("dialog", {
+			name: "Edit user",
+		});
+		expect(within(dialog).getByTestId("managed-note")).toBeInTheDocument();
+		expect(
+			within(dialog).queryByTestId("user-modal-save"),
+		).not.toBeInTheDocument();
+		expect(
+			within(dialog).queryByTestId("user-modal-delete"),
+		).not.toBeInTheDocument();
+		expect(
+			within(dialog).queryByTestId("user-reset-password"),
+		).not.toBeInTheDocument();
+	});
+
+	it("keeps the create button and shows no banner when this instance is the primary", async () => {
+		server.use(
+			http.get("/api/system", () =>
+				HttpResponse.json(systemWithFleet("primary")),
+			),
+		);
+		mockUsersApi([mockUser]);
+		renderWithProviders(<Users />);
+
+		expect(await screen.findByTestId("add-user-button")).toBeInTheDocument();
+		expect(screen.queryByTestId("managed-banner")).not.toBeInTheDocument();
+	});
+});

--- a/web/src/pages/Users/__tests__/Users.managed.test.tsx
+++ b/web/src/pages/Users/__tests__/Users.managed.test.tsx
@@ -77,8 +77,13 @@ describe("Users managed (fleet member) mode", () => {
 		expect(
 			within(dialog).queryByTestId("user-modal-delete"),
 		).not.toBeInTheDocument();
+		// The reset-password field's label ("Reset password") maps to its input
+		// via htmlFor, so queryByLabelText actually resolves to the element when
+		// present (unlike a testId the field never carried). This makes the
+		// absence assertion non-vacuous: it fails if the !managed gate on the
+		// reset section is ever dropped.
 		expect(
-			within(dialog).queryByTestId("user-reset-password"),
+			within(dialog).queryByLabelText("Reset password"),
 		).not.toBeInTheDocument();
 	});
 

--- a/web/src/pages/Users/index.tsx
+++ b/web/src/pages/Users/index.tsx
@@ -9,8 +9,10 @@ import type { SortState } from "../../components/DataTable";
 import { Row, SortableHeader, StaticHeader } from "../../components/DataTable";
 import { EmptyState } from "../../components/EmptyState";
 import { LoadingSpinner } from "../../components/LoadingSpinner";
+import { ManagedBanner } from "../../components/ManagedBanner";
 import { PageHeader } from "../../components/PageHeader";
 import { useToast } from "../../context/ToastContext";
+import { useManaged } from "../../hooks/useManaged";
 import { useReadOnly } from "../../hooks/useReadOnly";
 import { formatRelativeTime } from "../../utils/format";
 import { UserModal } from "./UserModal";
@@ -21,6 +23,7 @@ export function Users() {
 	const { t } = useTranslation();
 	const { toast } = useToast();
 	const readOnly = useReadOnly();
+	const managed = useManaged();
 	const [showCreate, setShowCreate] = useState(false);
 	const [selected, setSelected] = useState<DashboardUser | null>(null);
 	const [sort, setSort] = useState<SortState<UserSortField>>({
@@ -73,7 +76,8 @@ export function Users() {
 				title={t("users.title")}
 				description={t("users.description")}
 				actions={
-					!readOnly && (
+					!readOnly &&
+					!managed && (
 						<button
 							type="button"
 							onClick={() => setShowCreate(true)}
@@ -85,6 +89,7 @@ export function Users() {
 					)
 				}
 			/>
+			<ManagedBanner />
 
 			{sorted.length > 0 ? (
 				<div className="ui-card overflow-hidden">
@@ -185,6 +190,7 @@ export function Users() {
 			{showCreate && (
 				<UserModal
 					user={null}
+					managed={managed}
 					onClose={() => setShowCreate(false)}
 					onToast={toast}
 				/>
@@ -192,6 +198,7 @@ export function Users() {
 			{selected && (
 				<UserModal
 					user={selected}
+					managed={managed}
 					onClose={() => setSelected(null)}
 					onToast={toast}
 				/>


### PR DESCRIPTION
## Problem

Dashboard user accounts are a fleet-synced entity, but the managed-member (HA) lockout was never extended to user management. `config-sync` exports users (`exportUsers`) and `applyUsers` runs `DELETE FROM users WHERE username <> ALL($1)` on import, so a managed (non-primary) member's local create/edit/delete/reset would "succeed" then be **silently wiped** on the next sync — the exact data-loss hazard `managedWriteGuard` exists to prevent for the other synced entities. The frontend Users page/modal also checked only demo read-only mode (`useReadOnly`), not fleet-managed mode (`useManaged`).

Demo mode (`DEMO_READONLY`) was already correct server-side (the top-level `readOnlyGuard` covers `/users`).

## Changes

**Backend** (`internal/api/`)
- `users.go`: `RegisterUsers` splits reads (GET `/users`, GET `/users/grants`) from writes; writes (create / update / set-password / delete) are now in a group guarded by `managedWriteGuard(h.settingsRepo)`. Reads stay open on a member; `requireAdmin` still covers the whole surface.
- `managedwrite.go`: `managedWriteMsg` and the package/guard doc comments now name user accounts among the synced entities.

**Frontend** (`web/src/pages/Users/`)
- `index.tsx`: `useManaged` + `<ManagedBanner />`; Add button gated `!readOnly && !managed`; `managed` passed to both modals.
- `UserModal.tsx`: `managed` prop. When managed, Save/Delete/reset-password are hidden, all form inputs are `disabled`, and a managed note (`settings.managed.sectionNote`) is shown. Mirrors the VirtualKeys reference pattern. Reuses existing i18n keys — no new translations.

**Tests**
- Backend `managedwrite_test.go`: member-refusal cases for every `/users` write (403), plus read-open assertions (GET `/users`, `/users/grants` stay 200 on a member). Wires `userRepo` into the harness so the read handlers don't nil-panic.
- Frontend `Users.managed.test.tsx` (new): member hides create + shows banner; member hides save/delete/reset in the edit modal + shows note; primary keeps create + no banner.

## Verification
- `go test ./internal/api/...` (managed/users suites) green; `make lint` 0 issues.
- `pnpm vitest run src/pages/Users` (3 files, 12 tests) green; `pnpm biome check` + `pnpm lint` clean.
- Oracle blind review: GO, no blockers; both should-fix items addressed (modal inputs now disabled when managed; read-open regression test added).