### PR TITLE
fix(logging): stop fleet heartbeat from flooding app_logs and audit_log

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1002,22 +1002,29 @@ func silentLogger(next http.Handler) http.Handler {
 
 		path := r.URL.Path
 		isStatic := strings.HasPrefix(path, "/assets/") || strings.HasPrefix(path, "/favicon")
-		isNoisy := path == "/health" ||
-			strings.HasPrefix(path, "/api/logs/app") ||
-			(path == "/api/logs" && r.Method == "GET") ||
-			(path == "/api/system" && r.Method == "GET") ||
-			(path == "/api/events" && r.Method == "GET") ||
-			(path == "/api/stats" && r.Method == "GET") ||
-			(path == "/api/stats/timeseries" && r.Method == "GET") ||
-			(path == "/api/stats/provider-distribution" && r.Method == "GET") ||
-			(path == "/api/models" && r.Method == "GET") ||
-			(path == "/api/providers" && r.Method == "GET") ||
+		// Match the noise allowlist against a slash-normalized path so a trailing
+		// slash (from a client or a reverse proxy) can't defeat an exact match and
+		// leak the request back to Info. Root "/" is preserved.
+		np := path
+		if len(np) > 1 {
+			np = strings.TrimRight(np, "/")
+		}
+		isNoisy := np == "/health" ||
+			strings.HasPrefix(np, "/api/logs/app") ||
+			(np == "/api/logs" && r.Method == "GET") ||
+			(np == "/api/system" && r.Method == "GET") ||
+			(np == "/api/events" && r.Method == "GET") ||
+			(np == "/api/stats" && r.Method == "GET") ||
+			(np == "/api/stats/timeseries" && r.Method == "GET") ||
+			(np == "/api/stats/provider-distribution" && r.Method == "GET") ||
+			(np == "/api/models" && r.Method == "GET") ||
+			(np == "/api/providers" && r.Method == "GET") ||
 			// Fleet heartbeat: Front Desk pings every member ~every 2.5s with an
 			// announce POST and polls its version via GET /api/settings. Both are
 			// machine-to-machine liveness traffic, not human activity, and at
 			// ~24/min/member they otherwise flood app_logs (the App Logs page).
-			path == "/api/fleet/announce" ||
-			(path == "/api/settings" && r.Method == "GET")
+			np == "/api/fleet/announce" ||
+			(np == "/api/settings" && r.Method == "GET")
 		if isStatic && ww.Status() < 400 {
 			return
 		}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1011,7 +1011,13 @@ func silentLogger(next http.Handler) http.Handler {
 			(path == "/api/stats/timeseries" && r.Method == "GET") ||
 			(path == "/api/stats/provider-distribution" && r.Method == "GET") ||
 			(path == "/api/models" && r.Method == "GET") ||
-			(path == "/api/providers" && r.Method == "GET")
+			(path == "/api/providers" && r.Method == "GET") ||
+			// Fleet heartbeat: Front Desk pings every member ~every 2.5s with an
+			// announce POST and polls its version via GET /api/settings. Both are
+			// machine-to-machine liveness traffic, not human activity, and at
+			// ~24/min/member they otherwise flood app_logs (the App Logs page).
+			path == "/api/fleet/announce" ||
+			(path == "/api/settings" && r.Method == "GET")
 		if isStatic && ww.Status() < 400 {
 			return
 		}

--- a/cmd/server/middleware_test.go
+++ b/cmd/server/middleware_test.go
@@ -524,6 +524,9 @@ func TestSilentLogger_NoisyEndpoints(t *testing.T) {
 		{"api providers GET", "/api/providers", "GET"},
 		{"fleet announce POST", "/api/fleet/announce", "POST"},
 		{"api settings GET (fleet version poll)", "/api/settings", "GET"},
+		// Trailing slashes must not defeat the exact-path noise match.
+		{"fleet announce POST trailing slash", "/api/fleet/announce/", "POST"},
+		{"api settings GET trailing slash", "/api/settings/", "GET"},
 	}
 
 	for _, tc := range tests {

--- a/cmd/server/middleware_test.go
+++ b/cmd/server/middleware_test.go
@@ -369,8 +369,10 @@ func TestSilentLogger_NoisyEndpointsAtDebugLevel(t *testing.T) {
 	req.Host = "test"
 	handler.ServeHTTP(httptest.NewRecorder(), req)
 
-	// Request to normal endpoint (not in noisy list)
-	req2 := httptest.NewRequest(http.MethodGet, "/api/settings", http.NoBody)
+	// Request to normal endpoint (not in noisy list). A settings *mutation*
+	// is a real admin action: only GET /api/settings is demoted (the fleet
+	// version poll), so POST stays at Info.
+	req2 := httptest.NewRequest(http.MethodPost, "/api/settings", http.NoBody)
 	req2.Host = "test"
 	handler.ServeHTTP(httptest.NewRecorder(), req2)
 
@@ -520,6 +522,8 @@ func TestSilentLogger_NoisyEndpoints(t *testing.T) {
 		{"api stats provider-distribution GET", "/api/stats/provider-distribution", "GET"},
 		{"api models GET", "/api/models", "GET"},
 		{"api providers GET", "/api/providers", "GET"},
+		{"fleet announce POST", "/api/fleet/announce", "POST"},
+		{"api settings GET (fleet version poll)", "/api/settings", "GET"},
 	}
 
 	for _, tc := range tests {

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -142,6 +142,14 @@ func (rec *Recorder) Middleware(next http.Handler) http.Handler {
 			}
 			entityID = rctx.URLParam("id")
 		}
+		// Fleet heartbeat announces are machine-to-machine liveness pings, not
+		// human admin actions. Front Desk POSTs one to every member ~every 2.5s;
+		// auditing them adds ~24 rows/min/member that bury real mutations (a live
+		// instance was 99.99% announce rows). They carry no entity and no state
+		// change worth an audit trail, so skip them.
+		if isFleetHeartbeat(route) {
+			return
+		}
 		actor, role := actorOf(user.IdentityFrom(r.Context()))
 		status := sw.status
 		if status == 0 {
@@ -170,6 +178,14 @@ func (rec *Recorder) Middleware(next http.Handler) http.Handler {
 			rec.record(entry)
 		}()
 	})
+}
+
+// isFleetHeartbeat reports whether a resolved route is a fleet liveness ping
+// that should be excluded from the audit trail. Only the member-side announce
+// endpoint qualifies today; it is matched on the router's route pattern so a
+// literal path check cannot be fooled by trailing slashes or query strings.
+func isFleetHeartbeat(route string) bool {
+	return route == "/api/fleet/announce"
 }
 
 // record inserts one entry, best-effort: an audit failure never fails the

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -143,6 +143,60 @@ func TestMiddlewareRecordsThroughChi(t *testing.T) {
 	}
 }
 
+func TestMiddlewareSkipsFleetHeartbeat(t *testing.T) {
+	rec := newRecorder(t, nil)
+	r := chi.NewRouter()
+	r.Use(rec.Middleware)
+	// Mount under /api so the resolved route pattern is /api/fleet/announce,
+	// exactly as the server wires the member-side fleet handler.
+	r.Route("/api", func(r chi.Router) {
+		r.Post("/fleet/announce", func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		})
+		// A non-heartbeat mutation under the same prefix must still be audited.
+		r.Post("/settings", func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+	})
+
+	ident := &user.Identity{Role: user.RoleAdmin}
+	do := func(path string) {
+		req := httptest.NewRequest(http.MethodPost, path, http.NoBody)
+		req = req.WithContext(user.WithIdentity(req.Context(), ident))
+		r.ServeHTTP(httptest.NewRecorder(), req)
+	}
+	// Fire the heartbeat several times; none of them may be recorded.
+	for range 5 {
+		do("/api/fleet/announce")
+	}
+	do("/api/settings")
+
+	// Only the settings mutation lands. Wait first so a would-be announce row
+	// has time to appear (proving absence, not just a timing race).
+	eventually(t, func() bool { return countRows(t, `path = '/api/settings'`) == 1 })
+	if n := countRows(t, `path = '/api/fleet/announce'`); n != 0 {
+		t.Errorf("fleet announce was audited (%d rows), want 0", n)
+	}
+	if n := countRows(t, "1=1"); n != 1 {
+		t.Errorf("total audit rows = %d, want 1 (only /api/settings)", n)
+	}
+}
+
+func TestIsFleetHeartbeat(t *testing.T) {
+	cases := map[string]bool{
+		"/api/fleet/announce": true,
+		"/api/settings":       false,
+		"/fleet/announce":     false, // unmounted pattern is not the real route
+		"/api/fleet/members":  false,
+		"":                    false,
+	}
+	for route, want := range cases {
+		if got := isFleetHeartbeat(route); got != want {
+			t.Errorf("isFleetHeartbeat(%q) = %v, want %v", route, got, want)
+		}
+	}
+}
+
 func TestWaitDrainsBackgroundRecords(t *testing.T) {
 	rec := newRecorder(t, nil)
 	r := chi.NewRouter()


### PR DESCRIPTION
## Problem

Front Desk pings every member roughly every 2.5s: an announce `POST /api/fleet/announce` plus a `GET /api/settings` version poll. Nothing skipped these, so **two** logging subsystems each recorded them independently:

- **audit_log** was **99.99% announce rows** on a live instance (14,880 of 14,881 rows; the single non-announce row was one real admin action), completely burying the audit trail.
- **app_logs** was ~half heartbeat traffic (announce and settings-poll each ~24 rows/min/member, ~equal shares).

These weren't visible in `docker logs` because the app-log slog handler filters access lines off stderr while still persisting them to the DB, so the flood only showed up in Postgres.

## Fix

Two independent skip rules, one per subsystem:

- **`silentLogger` (access log):** demote `POST /api/fleet/announce` and `GET /api/settings` to `Debug`, so with Debug off in production they stop persisting to `app_logs`. (Same tradeoff already accepted for `/api/models` / `/api/providers` GETs.)
- **audit middleware:** skip `/api/fleet/announce` via `isFleetHeartbeat`, matched on the **chi route pattern** (not raw path) so trailing slashes or query strings can't slip past. `GET /api/settings` needs no audit rule (GETs aren't audited); a settings **mutation** (POST) still audits and still logs at Info.

The member side only exposes `/fleet/announce`, so that single route is the whole member heartbeat surface.

## Tests

- New `TestMiddlewareSkipsFleetHeartbeat` (fires 5 announces + 1 settings POST, asserts only the settings mutation is audited) and `TestIsFleetHeartbeat`.
- Extended the `silentLogger` noisy-path table with the two new paths; switched the existing control assertion to a settings **POST** to prove mutations still log at Info.
- `go build`, `go vet`, `golangci-lint`, and both affected packages pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)