### PR TITLE
fix(frontdesk): stamp Last Config Sync on verified reconciliations

### DIFF
--- a/internal/frontdesk/autosync.go
+++ b/internal/frontdesk/autosync.go
@@ -53,6 +53,14 @@ const (
 	// reflects the deliberate enable rather than a primary edit.
 	autoSyncKickReason = "auto-sync was enabled"
 
+	// verifiedInSyncReason is stamped when a propagation pass confirms a member
+	// already matches the primary (typically because it self-converged via its
+	// own discovery) and so needs no write. Stamping it keeps the Members table
+	// "Last Config Sync" column reflecting the last reconciliation against the
+	// primary, not just the last actual write, which would otherwise leave the
+	// column stale for as long as members happened to converge on their own.
+	verifiedInSyncReason = "verified in sync with the primary"
+
 	// autoSyncKickTimeout caps the detached convergence pass fired when auto-sync
 	// is enabled, so a stuck member cannot leak the goroutine. Generous: a pass
 	// snapshots and imports config on every drifted member in turn.
@@ -291,7 +299,15 @@ func (s *Server) applyAutoSync(ctx context.Context, primary *Member, primaryToke
 		}
 		added, updated, removed := res.Diff.counts()
 		if added+updated+removed == 0 {
-			continue // already converged: no backup, no import
+			// Already in sync (the member self-converged via its own discovery, or
+			// a prior pass wrote it). This is still a successful reconciliation
+			// against the primary, so stamp the last-sync marker even though no
+			// write is needed. No backup, no import, not counted as applied, and no
+			// per-member event: only the timestamp/reason move.
+			if err := s.store.SetMemberLastSync(ctx, m.ID, time.Now().UTC(), verifiedInSyncReason); err != nil {
+				debuglog.Warn("frontdesk: auto-sync: stamp verified-in-sync marker", "member", m.Name, "error", err)
+			}
+			continue
 		}
 
 		// Snapshot before overwriting so a bad propagation is recoverable. A failed

--- a/internal/frontdesk/autosync.go
+++ b/internal/frontdesk/autosync.go
@@ -194,6 +194,21 @@ func (s *Server) convergeFleet(ctx context.Context, primary *Member, primaryToke
 	}
 }
 
+// stampVerifiedInSync records that a propagation pass confirmed a member already
+// matches the primary, so the Members table "Last Config Sync" column advances on
+// a reconciliation even when no write was needed. Both the auto-sync and wizard
+// paths funnel their converged-member case here. It returns the store error (also
+// logged) so callers can treat a failed stamp as a member that did not fully
+// reconcile: a converged member whose marker did not persist must be retried, or
+// the column stays stale, which is exactly what this whole path exists to prevent.
+func (s *Server) stampVerifiedInSync(ctx context.Context, memberID, memberName string) error {
+	if err := s.store.SetMemberLastSync(ctx, memberID, time.Now().UTC(), verifiedInSyncReason); err != nil {
+		debuglog.Warn("frontdesk: stamp verified-in-sync marker", "member", memberName, "error", err)
+		return err
+	}
+	return nil
+}
+
 // applyAutoSync pushes the primary's config to every other tokened member that
 // needs it. It returns how many members it actually re-synced and whether every
 // reachable member ended up converged (the signal autoSyncOnce uses to decide
@@ -303,9 +318,11 @@ func (s *Server) applyAutoSync(ctx context.Context, primary *Member, primaryToke
 			// a prior pass wrote it). This is still a successful reconciliation
 			// against the primary, so stamp the last-sync marker even though no
 			// write is needed. No backup, no import, not counted as applied, and no
-			// per-member event: only the timestamp/reason move.
-			if err := s.store.SetMemberLastSync(ctx, m.ID, time.Now().UTC(), verifiedInSyncReason); err != nil {
-				debuglog.Warn("frontdesk: auto-sync: stamp verified-in-sync marker", "member", m.Name, "error", err)
+			// per-member event: only the timestamp/reason move. If the stamp itself
+			// fails, hold the fleet hash back (like every other per-member failure
+			// above) so the next tick retries rather than leaving the column stale.
+			if err := s.stampVerifiedInSync(ctx, m.ID, m.Name); err != nil {
+				allConverged = false
 			}
 			continue
 		}

--- a/internal/frontdesk/autosync_test.go
+++ b/internal/frontdesk/autosync_test.go
@@ -432,6 +432,74 @@ func TestAutoSyncSkipsConvergedMember(t *testing.T) {
 	}
 }
 
+// TestStampVerifiedInSync covers the shared helper both call sites use: a real
+// member gets the verified-in-sync marker, and a stamp against a missing member
+// is swallowed (logged, not fatal) so a propagation pass is never aborted by a
+// display-only write failing.
+func TestStampVerifiedInSync(t *testing.T) {
+	srv, store := newTestServer(t)
+	m, _ := store.CreateMember(t.Context(), "member", "http://127.0.0.1:9", "tok")
+
+	if err := srv.stampVerifiedInSync(t.Context(), m.ID, m.Name); err != nil {
+		t.Fatalf("stamp existing member: %v", err)
+	}
+
+	got, err := store.GetMember(t.Context(), m.ID)
+	if err != nil {
+		t.Fatalf("get member: %v", err)
+	}
+	if got.LastConfigSyncAt == nil {
+		t.Error("LastConfigSyncAt = nil, want stamped")
+	}
+	if got.LastConfigSyncReason != verifiedInSyncReason {
+		t.Errorf("reason = %q, want %q", got.LastConfigSyncReason, verifiedInSyncReason)
+	}
+
+	// Missing member: SetMemberLastSync errors; the helper logs it and returns the
+	// error so callers can hold the member back rather than claim a reconciliation.
+	if err := srv.stampVerifiedInSync(t.Context(), "no-such-member", "ghost"); err == nil {
+		t.Error("stamp of a missing member returned nil, want an error")
+	}
+}
+
+// failLastSyncStamp installs a SQLite trigger that makes any write to
+// members.last_config_sync_at fail, so a test can exercise the stamp-failure
+// branches without racing a real DB fault.
+func failLastSyncStamp(t *testing.T, store *Store) {
+	t.Helper()
+	if _, err := store.db.ExecContext(t.Context(),
+		`CREATE TRIGGER fail_last_sync BEFORE UPDATE OF last_config_sync_at ON members
+		 BEGIN SELECT RAISE(FAIL, 'stamp blocked by test'); END`,
+	); err != nil {
+		t.Fatalf("install fail trigger: %v", err)
+	}
+}
+
+// TestAutoSyncStampFailureHoldsHash: if stamping a converged member's verified
+// marker fails, the fleet hash must NOT be recorded, so the next tick retries
+// rather than leaving the Members column stale.
+func TestAutoSyncStampFailureHoldsHash(t *testing.T) {
+	srv, store := newTestServer(t)
+	primary := newStubAutoMember(t, "ptoken")
+	primary.versionHash = "hash-B"
+	replica := newStubAutoMember(t, "rtoken") // empty dryDiff: converged
+
+	pm, _ := store.CreateMember(t.Context(), "primary", primary.srv.URL, "ptoken")
+	store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken") //nolint:errcheck // presence is the point
+	enableAutoSync(t, store, pm.ID, "hash-A")
+	failLastSyncStamp(t, store)
+
+	srv.autoSyncOnce(t.Context(), "hash-B")
+
+	if replica.didBackup() || replica.didRealSync() {
+		t.Error("a converged member must not be backed up or re-imported")
+	}
+	cfg, _ := store.GetAutoSync(t.Context())
+	if cfg.LastHash != "hash-A" {
+		t.Errorf("applied hash = %q, want it left at hash-A so the next tick retries the failed stamp", cfg.LastHash)
+	}
+}
+
 // TestAutoSyncBackupFailureSkipsMember: if a member's pre-sync backup fails, its
 // config is NOT overwritten, the fleet is not marked converged, and the applied
 // hash is left stale so the next tick retries.

--- a/internal/frontdesk/autosync_test.go
+++ b/internal/frontdesk/autosync_test.go
@@ -401,7 +401,7 @@ func TestAutoSyncSkipsConvergedMember(t *testing.T) {
 	replica := newStubAutoMember(t, "rtoken") // default dryDiff is empty (converged)
 
 	pm, _ := store.CreateMember(t.Context(), "primary", primary.srv.URL, "ptoken")
-	store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken") //nolint:errcheck // presence is the point
+	replicaMember, _ := store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken")
 	// A tokenless member is present too: it must be skipped without blocking the
 	// fleet from being recorded as converged.
 	store.CreateMember(t.Context(), "tokenless", "http://127.0.0.1:9", "") //nolint:errcheck // presence is the point
@@ -415,6 +415,20 @@ func TestAutoSyncSkipsConvergedMember(t *testing.T) {
 	cfg, _ := store.GetAutoSync(t.Context())
 	if cfg.LastHash != "hash-B" {
 		t.Errorf("applied hash = %q, want hash-B (fleet converged)", cfg.LastHash)
+	}
+	// A converged member is still reconciled against the primary, so its last-sync
+	// marker must advance (with the verified-in-sync reason) even without a write:
+	// this is what keeps the Members table "Last Config Sync" column from going stale
+	// when members self-converge via their own discovery.
+	rm, err := store.GetMember(t.Context(), replicaMember.ID)
+	if err != nil {
+		t.Fatalf("get replica: %v", err)
+	}
+	if rm.LastConfigSyncAt == nil {
+		t.Error("converged member LastConfigSyncAt = nil, want stamped after a propagation pass")
+	}
+	if rm.LastConfigSyncReason != verifiedInSyncReason {
+		t.Errorf("converged member reason = %q, want %q", rm.LastConfigSyncReason, verifiedInSyncReason)
 	}
 }
 

--- a/internal/frontdesk/configsync.go
+++ b/internal/frontdesk/configsync.go
@@ -171,8 +171,10 @@ func (s *Server) prepareMemberSync(ctx context.Context, m *Member, token string,
 		// Already in sync: no backup, no import. Still stamp the last-sync marker
 		// so the Members table reflects this reconciliation, matching the auto-sync
 		// path (a converged member is confirmed against the primary, just not written).
-		if err := s.store.SetMemberLastSync(ctx, m.ID, time.Now().UTC(), verifiedInSyncReason); err != nil {
-			debuglog.Warn("frontdesk: wizard sync: stamp verified-in-sync marker", "member", m.Name, "error", err)
+		// If the stamp fails, report the member as not fully synced rather than
+		// claiming OK for a reconciliation whose marker did not persist.
+		if err := s.stampVerifiedInSync(ctx, m.ID, m.Name); err != nil {
+			return &syncResultItem{MemberID: m.ID, Name: m.Name, Error: "in sync with the primary, but recording the last-sync marker failed"}, false
 		}
 		return &syncResultItem{MemberID: m.ID, Name: m.Name, OK: true}, false
 	}

--- a/internal/frontdesk/configsync.go
+++ b/internal/frontdesk/configsync.go
@@ -168,7 +168,13 @@ func (s *Server) prepareMemberSync(ctx context.Context, m *Member, token string,
 		return nil, true // unreachable or blocked: let applyMemberConfig report the real cause
 	}
 	if added, updated, removed := preview.Diff.counts(); added+updated+removed == 0 {
-		return &syncResultItem{MemberID: m.ID, Name: m.Name, OK: true}, false // already in sync: no backup, no import
+		// Already in sync: no backup, no import. Still stamp the last-sync marker
+		// so the Members table reflects this reconciliation, matching the auto-sync
+		// path (a converged member is confirmed against the primary, just not written).
+		if err := s.store.SetMemberLastSync(ctx, m.ID, time.Now().UTC(), verifiedInSyncReason); err != nil {
+			debuglog.Warn("frontdesk: wizard sync: stamp verified-in-sync marker", "member", m.Name, "error", err)
+		}
+		return &syncResultItem{MemberID: m.ID, Name: m.Name, OK: true}, false
 	}
 	if err := s.backupMember(ctx, m, token); err != nil {
 		debuglog.Warn("frontdesk: wizard sync: pre-sync backup failed, skipping member", "member", m.Name, "error", err)

--- a/internal/frontdesk/configsync_test.go
+++ b/internal/frontdesk/configsync_test.go
@@ -259,6 +259,35 @@ func TestConfigSyncConvergedMemberNotBackedUp(t *testing.T) {
 	}
 }
 
+// TestConfigSyncConvergedStampFailureReportsError: if a converged member's
+// verified-in-sync stamp cannot persist, the wizard must report the member as not
+// fully synced rather than claiming OK for a reconciliation whose marker was lost.
+func TestConfigSyncConvergedStampFailureReportsError(t *testing.T) {
+	srv, store := newTestServer(t)
+	primary := newStubConfigMember(t, "ptoken")
+	converged := newStubConfigMember(t, "ctoken")
+	converged.importBody = `{"schema_version_ok":true,"master_key_ok":true,"applied":true,"diff":{}}`
+
+	pm, _ := store.CreateMember(t.Context(), "primary", primary.srv.URL, "ptoken")
+	store.CreateMember(t.Context(), "converged", converged.srv.URL, "ctoken") //nolint:errcheck // presence is the point
+	failLastSyncStamp(t, store)
+
+	rec := do(t, srv, http.MethodPost, "/api/config/sync", `{"primary_id":"`+pm.ID+`"}`, true)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("sync = %d", rec.Code)
+	}
+	var resp struct {
+		Results []syncResultItem `json:"results"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	if len(resp.Results) != 1 || resp.Results[0].OK || resp.Results[0].Error == "" {
+		t.Fatalf("stamp failure should report member not OK with an error, got %+v", resp.Results)
+	}
+	if converged.gotBackup {
+		t.Error("a converged member must not be snapshotted even when the stamp fails")
+	}
+}
+
 func TestConfigSyncUnknownPrimary(t *testing.T) {
 	srv, _ := newTestServer(t)
 	const missing = "00000000-0000-0000-0000-000000000000"

--- a/internal/frontdesk/configsync_test.go
+++ b/internal/frontdesk/configsync_test.go
@@ -223,7 +223,7 @@ func TestConfigSyncConvergedMemberNotBackedUp(t *testing.T) {
 	converged.importBody = `{"schema_version_ok":true,"master_key_ok":true,"applied":true,"diff":{}}`
 
 	pm, _ := store.CreateMember(t.Context(), "primary", primary.srv.URL, "ptoken")
-	store.CreateMember(t.Context(), "converged", converged.srv.URL, "ctoken")
+	cm, _ := store.CreateMember(t.Context(), "converged", converged.srv.URL, "ctoken")
 
 	rec := do(t, srv, http.MethodPost, "/api/config/sync", `{"primary_id":"`+pm.ID+`"}`, true)
 	if rec.Code != http.StatusOK {
@@ -244,6 +244,18 @@ func TestConfigSyncConvergedMemberNotBackedUp(t *testing.T) {
 	// dry-run, so gotDryRun stays true.
 	if !converged.gotDryRun {
 		t.Error("a converged member must not be imported into; only the dry-run should run")
+	}
+	// Even without a write, the reconciliation must stamp the last-sync marker so
+	// the Members table reflects that the wizard confirmed this member in sync.
+	m, err := store.GetMember(t.Context(), cm.ID)
+	if err != nil {
+		t.Fatalf("get converged member: %v", err)
+	}
+	if m.LastConfigSyncAt == nil {
+		t.Error("converged member LastConfigSyncAt = nil, want stamped by the wizard sync")
+	}
+	if m.LastConfigSyncReason != verifiedInSyncReason {
+		t.Errorf("converged member reason = %q, want %q", m.LastConfigSyncReason, verifiedInSyncReason)
 	}
 }
 


### PR DESCRIPTION
## Problem

The Members table **Last Config Sync** column (`LastConfigSyncAt`) shows stale times ("2 days ago") even though HA auto-sync runs every 15s and the primary's config hash changes far more often (auto-discovery over 1000+ models produces price/context drift and provider enable/disable flips roughly every 6h).

Root cause is a semantic mismatch, not a broken loop. Detection is already hash-based and correct: `RunAutoSync` remembers the last hash applied to the fleet (`cfg.LastHash`) and fires a propagation pass only when the primary's hash changes. But the column was stamped in **one place only**: when Front Desk *actually writes* config to a member. Because every member also runs its own auto-discovery, a member usually self-converges to the same catalog before FD's pass sees any difference, the per-member dry-run comes back empty, the member is skipped with no write, and the marker never moves. It measured *writes*, not *reconciliations*.

## Fix

When a propagation pass confirms a member already matches the primary, stamp `LastConfigSyncAt` with a distinct reason `"verified in sync with the primary"`. No backup, no import, no applied-count inflation, no per-member event: only the timestamp/reason move, and only within a real pass (never on an idle tick). That is one cheap UPDATE per member per hash change.

- `internal/frontdesk/autosync.go` - stamp converged members in `applyAutoSync`'s empty-diff branch.
- `internal/frontdesk/configsync.go` - wizard "Sync now" stamps converged members the same way for parity.
- No schema change: reuses `SetMemberLastSync` and the existing columns.

## Tests

Extended `TestAutoSyncSkipsConvergedMember` and the wizard converged-member test to assert the verified stamp while confirming the member is still not backed up or re-imported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)