### PR TITLE
feat(frontdesk): favicon logo brand + per-member Traffic refresh

### DIFF
--- a/frontdesk/web/src/App.tsx
+++ b/frontdesk/web/src/App.tsx
@@ -14,6 +14,7 @@ import {
 	onUnauthorized,
 } from "./api/client";
 import { Login } from "./components/Login";
+import { Logo } from "./components/Logo";
 import { VersionFooter } from "./components/VersionFooter";
 import { ToastProvider } from "./context/ToastContext";
 import { useIdleLogout } from "./hooks/useIdleLogout";
@@ -89,10 +90,15 @@ function Shell() {
 	return (
 		<div className="fd-shell">
 			<header className="fd-header">
-				<div className="fd-brand">
-					<span className="fd-dot" />
-					{t("app.title")}
-				</div>
+				<button
+					type="button"
+					className="fd-brand"
+					onClick={() => setTab("members")}
+					aria-label={t("app.title")}
+					title={t("app.title")}
+				>
+					<Logo className="fd-logo" />
+				</button>
 				<div className="fd-tabs" role="tablist">
 					{tabs.map((tb) => (
 						<button

--- a/frontdesk/web/src/__tests__/App.test.tsx
+++ b/frontdesk/web/src/__tests__/App.test.tsx
@@ -82,6 +82,29 @@ describe("App auth gating", () => {
 		expect(screen.queryByRole("alert")).not.toBeInTheDocument();
 	});
 
+	it("returns to the Members tab when the brand logo is clicked", async () => {
+		server.use(...authHandlers("good"));
+		render(<App />);
+		await userEvent.type(screen.getByLabelText(/Front Desk token/i), "good");
+		await userEvent.click(screen.getByRole("button", { name: /sign in/i }));
+		await waitFor(() =>
+			expect(screen.getByRole("tab", { name: /members/i })).toBeInTheDocument(),
+		);
+
+		// Move off the default tab, then click the top-left brand logo.
+		await userEvent.click(screen.getByRole("tab", { name: /settings/i }));
+		expect(screen.getByRole("tab", { name: /settings/i })).toHaveAttribute(
+			"aria-selected",
+			"true",
+		);
+		await userEvent.click(screen.getByRole("button", { name: /front desk/i }));
+
+		expect(screen.getByRole("tab", { name: /members/i })).toHaveAttribute(
+			"aria-selected",
+			"true",
+		);
+	});
+
 	it("drops back to login when an authed request later 401s", async () => {
 		// First /api/members call (login validation) succeeds; the next one (the
 		// authed shell's own fetch) 401s, which must bounce back to login.

--- a/frontdesk/web/src/components/Logo.tsx
+++ b/frontdesk/web/src/components/Logo.tsx
@@ -1,24 +1,27 @@
 import { memo } from "react";
-import { useTranslation } from "react-i18next";
 
 // Front Desk wordmark: the app's favicon (the service-bell mark on its dark
 // badge, kept in the favicon's own colours so the header logo matches the
 // browser-tab icon exactly) followed by a two-tone wordmark. "Front" is
 // neutral, "Desk" picks up the accent, mirroring the Model / Hotel split on the
 // main dashboard logo.
+//
+// Purely decorative: the graphic is always rendered inside the header brand
+// button, which carries the accessible name. Labelling the SVG too would make
+// assistive tech announce "Front Desk" twice for one control.
 export const Logo = memo(function Logo({
 	className = "",
 }: {
 	className?: string;
 }) {
-	const { t } = useTranslation();
 	return (
 		<svg
 			xmlns="http://www.w3.org/2000/svg"
 			viewBox="0 0 176 48"
 			className={className}
 			fill="none"
-			aria-label={t("app.title")}
+			aria-hidden="true"
+			focusable="false"
 		>
 			{/* Favicon mark (public/favicon.svg), scaled to the 48-tall canvas and
 			    nudged in so it reads as an app icon beside the wordmark. */}

--- a/frontdesk/web/src/components/Logo.tsx
+++ b/frontdesk/web/src/components/Logo.tsx
@@ -1,0 +1,72 @@
+import { memo } from "react";
+import { useTranslation } from "react-i18next";
+
+// Front Desk wordmark: the app's favicon (the service-bell mark on its dark
+// badge, kept in the favicon's own colours so the header logo matches the
+// browser-tab icon exactly) followed by a two-tone wordmark. "Front" is
+// neutral, "Desk" picks up the accent, mirroring the Model / Hotel split on the
+// main dashboard logo.
+export const Logo = memo(function Logo({
+	className = "",
+}: {
+	className?: string;
+}) {
+	const { t } = useTranslation();
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 176 48"
+			className={className}
+			fill="none"
+			aria-label={t("app.title")}
+		>
+			{/* Favicon mark (public/favicon.svg), scaled to the 48-tall canvas and
+			    nudged in so it reads as an app icon beside the wordmark. */}
+			<g transform="translate(2 4) scale(0.8333)">
+				<rect width="48" height="48" rx="10" fill="#0b0c0f" />
+				<rect
+					x="22.6"
+					y="13"
+					width="2.8"
+					height="7"
+					rx="1.4"
+					fill="#e0823f"
+					opacity="0.9"
+				/>
+				<circle cx="24" cy="12" r="2.6" fill="#e0823f" />
+				<path d="M10 31C10 17 38 17 38 31Z" fill="#e0823f" opacity="0.9" />
+				<rect
+					x="7"
+					y="31"
+					width="34"
+					height="4"
+					rx="2"
+					fill="#e0823f"
+					opacity="0.7"
+				/>
+				<rect
+					x="13"
+					y="37"
+					width="22"
+					height="2.6"
+					rx="1.3"
+					fill="#e0823f"
+					opacity="0.45"
+				/>
+			</g>
+
+			{/* Wordmark: Front Desk */}
+			<text
+				x="54"
+				y="32"
+				fontFamily="ui-sans-serif, system-ui, -apple-system, sans-serif"
+				fontSize="22"
+				fontWeight="600"
+				letterSpacing="-0.01em"
+			>
+				<tspan fill="currentColor">Front </tspan>
+				<tspan fill="var(--accent)">Desk</tspan>
+			</text>
+		</svg>
+	);
+});

--- a/frontdesk/web/src/index.css
+++ b/frontdesk/web/src/index.css
@@ -114,18 +114,28 @@ h3 {
 	z-index: 10;
 }
 .fd-brand {
-	display: flex;
+	display: inline-flex;
 	align-items: center;
-	gap: 0.6rem;
-	font-weight: 600;
-	font-size: 1.05rem;
+	padding: 0.15rem 0.25rem;
+	margin: -0.15rem -0.25rem;
+	background: none;
+	border: 0;
+	border-radius: 0.5rem;
+	color: inherit;
+	cursor: pointer;
+	transition: opacity 0.15s ease;
 }
-.fd-brand .fd-dot {
-	width: 0.6rem;
-	height: 0.6rem;
-	border-radius: 50%;
-	background: var(--accent);
-	box-shadow: 0 0 0 3px rgba(194, 112, 61, 0.2);
+.fd-brand:hover {
+	opacity: 0.85;
+}
+.fd-brand:focus-visible {
+	outline: 2px solid var(--accent);
+	outline-offset: 2px;
+}
+.fd-logo {
+	height: 2.4rem;
+	width: auto;
+	display: block;
 }
 .fd-tabs {
 	display: flex;

--- a/frontdesk/web/src/pages/TrafficPage.tsx
+++ b/frontdesk/web/src/pages/TrafficPage.tsx
@@ -34,8 +34,12 @@ function MemberTrafficCard({
 	// server-side "generated at" on the traffic payload, so this is simply the
 	// moment the UI pulled it - which is exactly the freshness the operator wants.
 	const [updatedAt, setUpdatedAt] = useState<string | null>(null);
+	// Per-card refetch nonce. The page-level Refresh reloads every card via
+	// reloadKey; this lets a single unreachable member be retried on its own,
+	// right where the "could not read metrics" message appears.
+	const [localReload, setLocalReload] = useState(0);
 
-	// biome-ignore lint/correctness/useExhaustiveDependencies: reloadKey is a refetch nonce - it isn't read in the body, its only job is to re-run the fetch when the Refresh button bumps it
+	// biome-ignore lint/correctness/useExhaustiveDependencies: reloadKey and localReload are refetch nonces - they aren't read in the body, their only job is to re-run the fetch when a Refresh button bumps them
 	useEffect(() => {
 		// Re-runs on member id change and whenever reloadKey is bumped by the
 		// page-level Refresh button. Stale data stays on screen during a refetch
@@ -61,7 +65,7 @@ function MemberTrafficCard({
 		return () => {
 			active = false;
 		};
-	}, [member.id, reloadKey]);
+	}, [member.id, reloadKey, localReload]);
 
 	return (
 		<div className="ui-card ui-card-pad">
@@ -77,7 +81,25 @@ function MemberTrafficCard({
 			{loading ? (
 				<div className="fd-empty">{t("common.loading")}</div>
 			) : !data?.reachable ? (
-				<div className="fd-empty fd-faint">{t("traffic.unreachable")}</div>
+				<div
+					className="fd-empty fd-faint"
+					style={{
+						display: "flex",
+						flexDirection: "column",
+						alignItems: "center",
+						gap: "0.75rem",
+					}}
+				>
+					<span>{t("traffic.unreachable")}</span>
+					<button
+						type="button"
+						className="ui-btn ui-btn-ghost ui-btn-sm"
+						onClick={() => setLocalReload((n) => n + 1)}
+						data-testid="traffic-member-refresh"
+					>
+						{t("traffic.refresh")}
+					</button>
+				</div>
 			) : data.total_requests === 0 ? (
 				<div className="fd-empty fd-faint">{t("traffic.noData")}</div>
 			) : (

--- a/frontdesk/web/src/pages/__tests__/TrafficPage.test.tsx
+++ b/frontdesk/web/src/pages/__tests__/TrafficPage.test.tsx
@@ -168,4 +168,38 @@ describe("TrafficPage", () => {
 			await screen.findByText(/Could not read metrics/i),
 		).toBeInTheDocument();
 	});
+
+	it("retries a single unreachable member from its own Refresh button", async () => {
+		let call = 0;
+		server.use(
+			http.get("/api/members", () =>
+				HttpResponse.json([member({ id: "1", name: "hotel-1" })]),
+			),
+			http.get("/api/members/1/traffic", () => {
+				call += 1;
+				// Unreachable on first read, recovers on the retry.
+				return HttpResponse.json(
+					call === 1
+						? traffic({ member_id: "1", reachable: false })
+						: traffic({
+								member_id: "1",
+								reachable: true,
+								total_requests: 100,
+							}),
+				);
+			}),
+		);
+		const user = userEvent.setup();
+		renderPage();
+
+		await screen.findByText(/Could not read metrics/i);
+		// The refresh sits inside the unreachable card, next to the reason
+		// (distinct from the page-level refresh in the header).
+		await user.click(screen.getByTestId("traffic-member-refresh"));
+
+		expect(await screen.findByText("100")).toBeInTheDocument();
+		expect(
+			screen.queryByText(/Could not read metrics/i),
+		).not.toBeInTheDocument();
+	});
 });


### PR DESCRIPTION
## What

Two small Front Desk UI improvements.

### 1. Top-left brand becomes a real logo
The old dot + plain "Front Desk" text is now an SVG logo built in the same spirit as the main Model Hotel logo:

- The mark is the app **favicon** (the service-bell glyph on its dark rounded badge), kept in the favicon's own colours so the header logo matches the browser-tab icon exactly.
- Followed by a two-tone "**Front** Desk" wordmark ("Front" neutral, "Desk" accent), mirroring the Model/Hotel split.
- The brand is now a **button** that returns to the **Members** tab (Front Desk's main page; it has no URL routing).
- The logo is enlarged.

### 2. Retry an unreachable member from where the error shows
When a member goes unavailable, the Traffic card showed only "Could not read metrics from this member" with no fix nearby (only the page-level Refresh, which reloads every card). Now a **Refresh** button sits inside the unreachable card, right next to the reason, and re-pulls just that member via a per-card refetch nonce.

## Tests

- New App test: clicking the brand logo returns to the Members tab.
- New TrafficPage test: the per-card Refresh retries a single unreachable member and recovers.
- Full Front Desk suite green (118 passing); tsc / Biome / ESLint clean.

## Notes
- Front Desk is embedded in the Go binary, so this needs a container rebuild to see live (`make docker-build`).
- No new i18n keys (reuses `app.title` and `traffic.refresh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)