### PR TITLE
fix(provider): classify local embedding/rerank models so pickers hide them

### DIFF
--- a/internal/provider/discovery_koboldcpp.go
+++ b/internal/provider/discovery_koboldcpp.go
@@ -83,9 +83,7 @@ func (d *DiscoveryService) discoverKoboldCPP(ctx context.Context, provider *Prov
 	outputMods := `["text"]`
 	if mod := inferNonChatModality(modelID); mod != "" {
 		modality = mod
-		if mod == "embedding" {
-			outputMods = `["embedding"]`
-		}
+		_, outputMods = nonChatModalityArrays(mod)
 	}
 
 	m := &model.Model{

--- a/internal/provider/discovery_koboldcpp.go
+++ b/internal/provider/discovery_koboldcpp.go
@@ -77,6 +77,17 @@ func (d *DiscoveryService) discoverKoboldCPP(ctx context.Context, provider *Prov
 	}
 	capJSON, _ := json.Marshal(caps)
 
+	// KoboldCPP's /models has no type; if an embedding/reranker model is what's
+	// loaded, classify it by name so it stays out of the chat picker.
+	modality := "text"
+	outputMods := `["text"]`
+	if mod := inferNonChatModality(modelID); mod != "" {
+		modality = mod
+		if mod == "embedding" {
+			outputMods = `["embedding"]`
+		}
+	}
+
 	m := &model.Model{
 		ID:               uuid.New(),
 		ProviderID:       provider.ID,
@@ -86,9 +97,9 @@ func (d *DiscoveryService) discoverKoboldCPP(ctx context.Context, provider *Prov
 		Description:      fmt.Sprintf("KoboldCPP %s model", version),
 		Capabilities:     string(capJSON),
 		Params:           "{}",
-		Modality:         "text",
+		Modality:         modality,
 		InputModalities:  `["text"]`,
-		OutputModalities: `["text"]`,
+		OutputModalities: outputMods,
 		ContextLength:    contextLength,
 		OwnedBy:          "koboldcpp",
 		Enabled:          true,

--- a/internal/provider/discovery_live_test.go
+++ b/internal/provider/discovery_live_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -198,6 +199,62 @@ func TestOpenAIDiscoveryLiveAPI(t *testing.T) {
 			}
 			t.Logf("OK: unknown model %s -> display=%s, pricing=nil (minimal entry)", m.ModelID, m.DisplayName)
 			break
+		}
+	}
+}
+
+// TestOllamaEmbeddingModalityLiveAPI runs the real Ollama discoverer against a
+// local Ollama server and verifies an embedding model is classified as
+// modality:"embedding" (hidden from the chat picker) while a chat model stays
+// "text". Point OLLAMA_LIVE_URL at the server, e.g.:
+//
+//	OLLAMA_LIVE_URL=http://localhost:11434 go test -tags live \
+//	    ./internal/provider/ -run OllamaEmbeddingModalityLiveAPI -v
+//
+// with `all-minilm` (embedding) and a small chat model (e.g. qwen2.5:0.5b)
+// pulled beforehand.
+func TestOllamaEmbeddingModalityLiveAPI(t *testing.T) {
+	baseURL := os.Getenv("OLLAMA_LIVE_URL")
+	if baseURL == "" {
+		t.Fatal("OLLAMA_LIVE_URL environment variable is required for live API tests")
+	}
+
+	svc := NewDiscoveryService(nil, nil)
+	// Keyless local provider: empty EncryptedKey routes through the no-decrypt
+	// path in DiscoverModels, and DetectProviderType maps :11434 to "ollama".
+	prov := &Provider{ID: uuid.New(), BaseURL: baseURL}
+
+	models, err := svc.DiscoverModels(context.Background(), prov, "unused-master-key")
+	if err != nil {
+		t.Fatalf("DiscoverModels failed: %v", err)
+	}
+
+	t.Logf("Discovered %d models from live Ollama:", len(models))
+	byID := make(map[string]*model.Model, len(models))
+	for _, m := range models {
+		byID[m.ModelID] = m
+		t.Logf("  %-28s modality=%-10s output_modalities=%s", m.ModelID, m.Modality, m.OutputModalities)
+	}
+
+	// The embedding model must be classified as embedding (matches the frontend
+	// NON_CHAT_MODALITIES set so it's hidden from the chat/arena pickers).
+	embFound := false
+	for id, m := range byID {
+		if strings.Contains(id, "all-minilm") || strings.Contains(id, "embed") {
+			embFound = true
+			if m.Modality != "embedding" {
+				t.Errorf("%s: modality = %q, want embedding", id, m.Modality)
+			}
+		}
+	}
+	if !embFound {
+		t.Error("no embedding model found; pull `all-minilm` before running")
+	}
+
+	// Any model reporting the completion capability must stay a chat model.
+	for id, m := range byID {
+		if strings.Contains(id, "qwen") && m.Modality != "text" {
+			t.Errorf("%s: chat model modality = %q, want text", id, m.Modality)
 		}
 	}
 }

--- a/internal/provider/discovery_lmstudio.go
+++ b/internal/provider/discovery_lmstudio.go
@@ -25,7 +25,147 @@ type LMStudioModelsResponse struct {
 	} `json:"data"`
 }
 
+// LMStudioV0ModelsResponse is LM Studio's native REST API model listing
+// (GET /api/v0/models). Unlike the OpenAI-compatible /v1/models, it reports a
+// model `type` ("llm" | "vlm" | "embeddings") and a max_context_length, letting
+// discovery hide embedding models from the chat picker and fill a context
+// length the OpenAI listing never provides.
+type LMStudioV0ModelsResponse struct {
+	Object string            `json:"object"`
+	Data   []LMStudioV0Model `json:"data"`
+}
+
+// LMStudioV0Model is a single entry from LM Studio's /api/v0/models.
+type LMStudioV0Model struct {
+	ID               string `json:"id"`
+	Type             string `json:"type"` // "llm" | "vlm" | "embeddings"
+	Publisher        string `json:"publisher"`
+	Arch             string `json:"arch"`
+	MaxContextLength int    `json:"max_context_length"`
+}
+
 func (d *DiscoveryService) discoverLMStudio(ctx context.Context, provider *Provider, apiKey string) ([]*model.Model, error) {
+	// Prefer LM Studio's native /api/v0/models: it reports the model type
+	// (llm/vlm/embeddings) and a context length. Fall back to the
+	// OpenAI-compatible /v1/models listing when the native endpoint isn't
+	// available (older LM Studio, or a different OpenAI-compatible server that
+	// happens to sit on the LM Studio port).
+	models, err := d.discoverLMStudioNative(ctx, provider, apiKey)
+	if err == nil {
+		return models, nil
+	}
+	debuglog.Info("discovery: lmstudio native endpoint unavailable, falling back to /v1/models",
+		"provider", provider.Name, "provider_id", provider.ID, "error", err)
+	return d.discoverLMStudioOpenAI(ctx, provider, apiKey)
+}
+
+// discoverLMStudioNative queries LM Studio's native /api/v0/models endpoint.
+func (d *DiscoveryService) discoverLMStudioNative(ctx context.Context, provider *Provider, apiKey string) ([]*model.Model, error) {
+	// The native REST API is rooted at /api/v0, sibling to the OpenAI-compatible
+	// /v1 mount, so strip any /v1 suffix before appending it.
+	apiBase := util.SanitizeAPIURL(provider.BaseURL)
+	url := apiBase + "/api/v0/models"
+
+	req, err := http.NewRequestWithContext(ctx, "GET", url, http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("lmstudio: failed to create native request for provider %s: %w", provider.Name, err)
+	}
+	if apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+
+	resp, err := d.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("lmstudio: native request failed for provider %s: %w", provider.Name, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("lmstudio: native endpoint status %d for provider %s: %s", resp.StatusCode, provider.Name, string(body))
+	}
+
+	var modelsResp LMStudioV0ModelsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&modelsResp); err != nil {
+		return nil, fmt.Errorf("lmstudio: failed to decode native response for provider %s: %w", provider.Name, err)
+	}
+	// A well-formed but empty payload from a non-LM-Studio server would leave us
+	// with nothing; treat it as "endpoint not really there" and let the caller
+	// fall back to /v1/models.
+	if len(modelsResp.Data) == 0 {
+		return nil, fmt.Errorf("lmstudio: native endpoint returned no models for provider %s", provider.Name)
+	}
+
+	models := make([]*model.Model, 0, len(modelsResp.Data))
+	for _, m := range modelsResp.Data {
+		models = append(models, buildLMStudioNativeModel(provider, m))
+	}
+
+	// Context length comes from the live native probe, so mark it live: a model
+	// reloaded with a different context window propagates and is reported.
+	markLiveMeta(models)
+
+	debuglog.Info("discovery: lmstudio discovered models (native)", "models", len(models), "provider", provider.Name, "provider_id", provider.ID)
+	return models, nil
+}
+
+// buildLMStudioNativeModel maps a native /api/v0 model entry to a model.Model,
+// using the reported type to set the modality (so embedding models are hidden
+// from the chat picker).
+func buildLMStudioNativeModel(provider *Provider, m LMStudioV0Model) *model.Model {
+	caps := model.Capability{
+		Streaming:        true,
+		StructuredOutput: true, // LM Studio supports response_format with JSON schema
+	}
+
+	modality := "text"
+	inputMods := `["text"]`
+	outputMods := `["text"]`
+	switch m.Type {
+	case "embeddings":
+		modality = "embedding"
+		outputMods = `["embedding"]`
+	case "vlm":
+		caps.Vision = true
+		modality = "vision"
+		inputMods = `["text","image"]`
+	}
+	capJSON, _ := json.Marshal(caps)
+
+	ownedBy := m.Publisher
+	if ownedBy == "" {
+		ownedBy = "lmstudio"
+	}
+
+	var contextLength *int
+	if m.MaxContextLength > 0 {
+		cl := m.MaxContextLength
+		contextLength = &cl
+	}
+
+	return &model.Model{
+		ID:               uuid.New(),
+		ProviderID:       provider.ID,
+		ModelID:          m.ID,
+		Name:             m.ID,
+		DisplayName:      m.ID,
+		Description:      "LM Studio local model",
+		Capabilities:     string(capJSON),
+		Params:           "{}",
+		Modality:         modality,
+		InputModalities:  inputMods,
+		OutputModalities: outputMods,
+		ContextLength:    contextLength,
+		OwnedBy:          ownedBy,
+		Enabled:          true,
+	}
+}
+
+// discoverLMStudioOpenAI is the fallback that reads the OpenAI-compatible
+// /v1/models listing. That listing carries no model type, so embedding and
+// reranker models are classified by name heuristic to keep them out of the
+// chat picker.
+func (d *DiscoveryService) discoverLMStudioOpenAI(ctx context.Context, provider *Provider, apiKey string) ([]*model.Model, error) {
 	baseURL := util.SanitizeBaseURL(provider.BaseURL)
 
 	url := baseURL + "/models"
@@ -69,6 +209,17 @@ func (d *DiscoveryService) discoverLMStudio(ctx context.Context, provider *Provi
 			ownedBy = "lmstudio"
 		}
 
+		modality := "text"
+		outputMods := `["text"]`
+		// The OpenAI listing has no type, so recognise embedding/reranker models
+		// by name to keep them out of the chat picker.
+		if mod := inferNonChatModality(m.ID); mod != "" {
+			modality = mod
+			if mod == "embedding" {
+				outputMods = `["embedding"]`
+			}
+		}
+
 		//nolint:gocritic // model variable shadows import but context makes it clear
 		model := &model.Model{
 			ID:               uuid.New(),
@@ -79,9 +230,9 @@ func (d *DiscoveryService) discoverLMStudio(ctx context.Context, provider *Provi
 			Description:      "LM Studio local model",
 			Capabilities:     string(capJSON),
 			Params:           "{}",
-			Modality:         "text",
+			Modality:         modality,
 			InputModalities:  `["text"]`,
-			OutputModalities: `["text"]`,
+			OutputModalities: outputMods,
 			OwnedBy:          ownedBy,
 			Enabled:          true,
 		}

--- a/internal/provider/discovery_lmstudio.go
+++ b/internal/provider/discovery_lmstudio.go
@@ -215,9 +215,7 @@ func (d *DiscoveryService) discoverLMStudioOpenAI(ctx context.Context, provider 
 		// by name to keep them out of the chat picker.
 		if mod := inferNonChatModality(m.ID); mod != "" {
 			modality = mod
-			if mod == "embedding" {
-				outputMods = `["embedding"]`
-			}
+			_, outputMods = nonChatModalityArrays(mod)
 		}
 
 		//nolint:gocritic // model variable shadows import but context makes it clear

--- a/internal/provider/discovery_lmstudio_test.go
+++ b/internal/provider/discovery_lmstudio_test.go
@@ -191,11 +191,19 @@ func TestDiscoverLMStudio_Fallback_EmbeddingByName(t *testing.T) {
 	if got := byID["llama-3-8b"].Modality; got != "text" {
 		t.Errorf("chat model modality: got %q, want text", got)
 	}
-	if got := byID["nomic-embed-text-v1.5"].Modality; got != "embedding" {
-		t.Errorf("embedding modality: got %q, want embedding", got)
+	emb := byID["nomic-embed-text-v1.5"]
+	if emb.Modality != "embedding" {
+		t.Errorf("embedding modality: got %q, want embedding", emb.Modality)
 	}
-	if got := byID["bge-reranker-v2-m3"].Modality; got != "rerank" {
-		t.Errorf("reranker modality: got %q, want rerank", got)
+	if emb.OutputModalities != `["embedding"]` {
+		t.Errorf("embedding output modalities: got %q, want [\"embedding\"]", emb.OutputModalities)
+	}
+	rer := byID["bge-reranker-v2-m3"]
+	if rer.Modality != "rerank" {
+		t.Errorf("reranker modality: got %q, want rerank", rer.Modality)
+	}
+	if rer.OutputModalities != `["rerank"]` {
+		t.Errorf("reranker output modalities: got %q, want [\"rerank\"]", rer.OutputModalities)
 	}
 }
 

--- a/internal/provider/discovery_lmstudio_test.go
+++ b/internal/provider/discovery_lmstudio_test.go
@@ -13,30 +13,130 @@ import (
 )
 
 // ---------------------------------------------------------------------------
-// discoverLMStudio
+// discoverLMStudio — native /api/v0/models path
 // ---------------------------------------------------------------------------
 
-func TestDiscoverLMStudio_SuccessMultiple(t *testing.T) {
+// nativeBody is a representative LM Studio /api/v0/models payload with one model
+// of each type. Text-embedding-nomic is an embeddings model, qwen2-vl a vlm.
+const lmStudioNativeBody = `{
+	"object":"list",
+	"data":[
+		{"id":"llama-3-8b","object":"model","type":"llm","publisher":"meta","arch":"llama","max_context_length":8192},
+		{"id":"qwen2-vl-7b","object":"model","type":"vlm","publisher":"qwen","arch":"qwen2_vl","max_context_length":32768},
+		{"id":"text-embedding-nomic-embed-text-v1.5","object":"model","type":"embeddings","publisher":"nomic-ai","max_context_length":2048}
+	]
+}`
+
+func TestDiscoverLMStudio_Native_TypesAndContext(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/models" {
+		if r.URL.Path != "/api/v0/models" {
 			t.Errorf("unexpected path: %s", r.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{
-			"object":"list",
-			"data":[
-				{"id":"llama-3-8b","object":"model","created":1700000000,"owned_by":"meta"},
-				{"id":"mistral-7b","object":"model","created":1700000001,"owned_by":"mistral"}
-			]
-		}`))
+		_, _ = w.Write([]byte(lmStudioNativeBody))
 	}))
 	defer srv.Close()
 
 	svc := &DiscoveryService{httpClient: srv.Client()}
-	provider := &Provider{
-		ID:      uuid.New(),
-		BaseURL: srv.URL,
+	provider := &Provider{ID: uuid.New(), BaseURL: srv.URL + "/v1"}
+
+	models, err := svc.discoverLMStudio(context.Background(), provider, "")
+	if err != nil {
+		t.Fatalf("discoverLMStudio failed: %v", err)
 	}
+	if len(models) != 3 {
+		t.Fatalf("expected 3 models, got %d", len(models))
+	}
+
+	byID := make(map[string]*model.Model, len(models))
+	for _, m := range models {
+		byID[m.ModelID] = m
+	}
+
+	llm := byID["llama-3-8b"]
+	if llm.Modality != "text" {
+		t.Errorf("llm modality: got %q, want text", llm.Modality)
+	}
+	if llm.ContextLength == nil || *llm.ContextLength != 8192 {
+		t.Errorf("llm context length: got %v, want 8192", llm.ContextLength)
+	}
+	if llm.OwnedBy != "meta" {
+		t.Errorf("llm owned_by: got %q, want meta", llm.OwnedBy)
+	}
+
+	vlm := byID["qwen2-vl-7b"]
+	if vlm.Modality != "vision" {
+		t.Errorf("vlm modality: got %q, want vision", vlm.Modality)
+	}
+	var vcaps model.Capability
+	_ = json.Unmarshal([]byte(vlm.Capabilities), &vcaps)
+	if !vcaps.Vision {
+		t.Error("vlm should have Vision capability")
+	}
+
+	emb := byID["text-embedding-nomic-embed-text-v1.5"]
+	if emb.Modality != "embedding" {
+		t.Errorf("embedding modality: got %q, want embedding", emb.Modality)
+	}
+	if emb.OutputModalities != `["embedding"]` {
+		t.Errorf("embedding output modalities: got %q", emb.OutputModalities)
+	}
+}
+
+func TestDiscoverLMStudio_Native_SendsAPIKey(t *testing.T) {
+	var authHeader string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeader = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(lmStudioNativeBody))
+	}))
+	defer srv.Close()
+
+	svc := &DiscoveryService{httpClient: srv.Client()}
+	provider := &Provider{ID: uuid.New(), BaseURL: srv.URL + "/v1"}
+
+	if _, err := svc.discoverLMStudio(context.Background(), provider, "sk-test-key"); err != nil {
+		t.Fatalf("discoverLMStudio failed: %v", err)
+	}
+	if authHeader != "Bearer sk-test-key" {
+		t.Errorf("expected Authorization header 'Bearer sk-test-key', got %q", authHeader)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// discoverLMStudio — fallback to OpenAI-compatible /v1/models
+// ---------------------------------------------------------------------------
+
+// lmStudioFallbackHandler serves 404 on the native endpoint and the given
+// OpenAI-compatible body on /models, forcing the fallback path.
+func lmStudioFallbackHandler(t *testing.T, openaiBody string) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v0/models":
+			w.WriteHeader(http.StatusNotFound)
+		case "/v1/models":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(openaiBody))
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+	}
+}
+
+func TestDiscoverLMStudio_Fallback_SuccessMultiple(t *testing.T) {
+	body := `{
+		"object":"list",
+		"data":[
+			{"id":"llama-3-8b","object":"model","created":1700000000,"owned_by":"meta"},
+			{"id":"mistral-7b","object":"model","created":1700000001,"owned_by":"mistral"}
+		]
+	}`
+	srv := httptest.NewServer(lmStudioFallbackHandler(t, body))
+	defer srv.Close()
+
+	svc := &DiscoveryService{httpClient: srv.Client()}
+	provider := &Provider{ID: uuid.New(), BaseURL: srv.URL + "/v1"}
 
 	models, err := svc.discoverLMStudio(context.Background(), provider, "")
 	if err != nil {
@@ -45,36 +145,87 @@ func TestDiscoverLMStudio_SuccessMultiple(t *testing.T) {
 	if len(models) != 2 {
 		t.Fatalf("expected 2 models, got %d", len(models))
 	}
-	if models[0].ModelID != "llama-3-8b" {
-		t.Errorf("expected first model 'llama-3-8b', got %q", models[0].ModelID)
+	if models[0].ModelID != "llama-3-8b" || models[0].OwnedBy != "meta" {
+		t.Errorf("unexpected first model: %+v", models[0])
 	}
-	if models[0].OwnedBy != "meta" {
-		t.Errorf("expected first model owned_by 'meta', got %q", models[0].OwnedBy)
+	if models[1].ModelID != "mistral-7b" || models[1].OwnedBy != "mistral" {
+		t.Errorf("unexpected second model: %+v", models[1])
 	}
-	if models[1].ModelID != "mistral-7b" {
-		t.Errorf("expected second model 'mistral-7b', got %q", models[1].ModelID)
-	}
-	if models[1].OwnedBy != "mistral" {
-		t.Errorf("expected second model owned_by 'mistral', got %q", models[1].OwnedBy)
-	}
-	if models[0].ProviderID != provider.ID {
-		t.Errorf("expected provider ID %v, got %v", provider.ID, models[0].ProviderID)
+	if models[0].Modality != "text" {
+		t.Errorf("chat model modality: got %q, want text", models[0].Modality)
 	}
 
-	// verify capabilities
 	var caps model.Capability
 	if err := json.Unmarshal([]byte(models[0].Capabilities), &caps); err != nil {
 		t.Fatalf("failed to unmarshal capabilities: %v", err)
 	}
-	if !caps.Streaming {
-		t.Error("expected Streaming=true")
-	}
-	if !caps.StructuredOutput {
-		t.Error("expected StructuredOutput=true")
+	if !caps.Streaming || !caps.StructuredOutput {
+		t.Errorf("expected Streaming and StructuredOutput, got %+v", caps)
 	}
 }
 
+func TestDiscoverLMStudio_Fallback_EmbeddingByName(t *testing.T) {
+	body := `{
+		"object":"list",
+		"data":[
+			{"id":"llama-3-8b","object":"model","owned_by":"meta"},
+			{"id":"nomic-embed-text-v1.5","object":"model","owned_by":"nomic"},
+			{"id":"bge-reranker-v2-m3","object":"model","owned_by":"baai"}
+		]
+	}`
+	srv := httptest.NewServer(lmStudioFallbackHandler(t, body))
+	defer srv.Close()
+
+	svc := &DiscoveryService{httpClient: srv.Client()}
+	provider := &Provider{ID: uuid.New(), BaseURL: srv.URL + "/v1"}
+
+	models, err := svc.discoverLMStudio(context.Background(), provider, "")
+	if err != nil {
+		t.Fatalf("discoverLMStudio failed: %v", err)
+	}
+
+	byID := make(map[string]*model.Model, len(models))
+	for _, m := range models {
+		byID[m.ModelID] = m
+	}
+	if got := byID["llama-3-8b"].Modality; got != "text" {
+		t.Errorf("chat model modality: got %q, want text", got)
+	}
+	if got := byID["nomic-embed-text-v1.5"].Modality; got != "embedding" {
+		t.Errorf("embedding modality: got %q, want embedding", got)
+	}
+	if got := byID["bge-reranker-v2-m3"].Modality; got != "rerank" {
+		t.Errorf("reranker modality: got %q, want rerank", got)
+	}
+}
+
+func TestDiscoverLMStudio_Fallback_ModelWithEmptyOwnedBy(t *testing.T) {
+	body := `{"object":"list","data":[{"id":"custom-model","object":"model","owned_by":""}]}`
+	srv := httptest.NewServer(lmStudioFallbackHandler(t, body))
+	defer srv.Close()
+
+	svc := &DiscoveryService{httpClient: srv.Client()}
+	provider := &Provider{ID: uuid.New(), BaseURL: srv.URL + "/v1"}
+
+	models, err := svc.discoverLMStudio(context.Background(), provider, "")
+	if err != nil {
+		t.Fatalf("discoverLMStudio failed: %v", err)
+	}
+	if len(models) != 1 {
+		t.Fatalf("expected 1 model, got %d", len(models))
+	}
+	if models[0].OwnedBy != "lmstudio" {
+		t.Errorf("expected owned_by to default to 'lmstudio', got %q", models[0].OwnedBy)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// error handling — both endpoints fail
+// ---------------------------------------------------------------------------
+
 func TestDiscoverLMStudio_EmptyModels(t *testing.T) {
+	// Native returns an empty list (treated as "not really LM Studio") and the
+	// OpenAI fallback is also empty: no models, no error.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"object":"list","data":[]}`))
@@ -82,10 +233,7 @@ func TestDiscoverLMStudio_EmptyModels(t *testing.T) {
 	defer srv.Close()
 
 	svc := &DiscoveryService{httpClient: srv.Client()}
-	provider := &Provider{
-		ID:      uuid.New(),
-		BaseURL: srv.URL,
-	}
+	provider := &Provider{ID: uuid.New(), BaseURL: srv.URL + "/v1"}
 
 	models, err := svc.discoverLMStudio(context.Background(), provider, "")
 	if err != nil {
@@ -104,15 +252,10 @@ func TestDiscoverLMStudio_HTTPError(t *testing.T) {
 	defer srv.Close()
 
 	svc := &DiscoveryService{httpClient: srv.Client()}
-	provider := &Provider{
-		ID:      uuid.New(),
-		BaseURL: srv.URL,
-	}
+	provider := &Provider{ID: uuid.New(), BaseURL: srv.URL + "/v1"}
 
-	_, err := svc.discoverLMStudio(context.Background(), provider, "")
-	if err == nil {
+	if _, err := svc.discoverLMStudio(context.Background(), provider, ""); err == nil {
 		t.Fatal("expected error for non-200 status")
-		return
 	}
 }
 
@@ -124,92 +267,33 @@ func TestDiscoverLMStudio_InvalidJSON(t *testing.T) {
 	defer srv.Close()
 
 	svc := &DiscoveryService{httpClient: srv.Client()}
-	provider := &Provider{
-		ID:      uuid.New(),
-		BaseURL: srv.URL,
-	}
+	provider := &Provider{ID: uuid.New(), BaseURL: srv.URL + "/v1"}
 
-	_, err := svc.discoverLMStudio(context.Background(), provider, "")
-	if err == nil {
+	if _, err := svc.discoverLMStudio(context.Background(), provider, ""); err == nil {
 		t.Fatal("expected error for invalid JSON")
-		return
-	}
-}
-
-func TestDiscoverLMStudio_ModelWithEmptyOwnedBy(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{
-			"object":"list",
-			"data":[
-				{"id":"custom-model","object":"model","created":1700000000,"owned_by":""}
-			]
-		}`))
-	}))
-	defer srv.Close()
-
-	svc := &DiscoveryService{httpClient: srv.Client()}
-	provider := &Provider{
-		ID:      uuid.New(),
-		BaseURL: srv.URL,
-	}
-
-	models, err := svc.discoverLMStudio(context.Background(), provider, "")
-	if err != nil {
-		t.Fatalf("discoverLMStudio failed: %v", err)
-	}
-	if len(models) != 1 {
-		t.Fatalf("expected 1 model, got %d", len(models))
-	}
-	if models[0].OwnedBy != "lmstudio" {
-		t.Errorf("expected owned_by to default to 'lmstudio', got %q", models[0].OwnedBy)
-	}
-}
-
-func TestDiscoverLMStudio_SendsAPIKey(t *testing.T) {
-	var authHeader string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		authHeader = r.Header.Get("Authorization")
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"object":"list","data":[]}`))
-	}))
-	defer srv.Close()
-
-	svc := &DiscoveryService{httpClient: srv.Client()}
-	provider := &Provider{
-		ID:      uuid.New(),
-		BaseURL: srv.URL,
-	}
-
-	_, err := svc.discoverLMStudio(context.Background(), provider, "sk-test-key")
-	if err != nil {
-		t.Fatalf("discoverLMStudio failed: %v", err)
-	}
-	if authHeader != "Bearer sk-test-key" {
-		t.Errorf("expected Authorization header 'Bearer sk-test-key', got %q", authHeader)
 	}
 }
 
 func TestDiscoverLMStudio_NoAPIKey(t *testing.T) {
 	var authHeader string
+	var sawHeader bool
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		authHeader = r.Header.Get("Authorization")
+		if h := r.Header.Get("Authorization"); h != "" {
+			authHeader = h
+			sawHeader = true
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"object":"list","data":[]}`))
 	}))
 	defer srv.Close()
 
 	svc := &DiscoveryService{httpClient: srv.Client()}
-	provider := &Provider{
-		ID:      uuid.New(),
-		BaseURL: srv.URL,
-	}
+	provider := &Provider{ID: uuid.New(), BaseURL: srv.URL + "/v1"}
 
-	_, err := svc.discoverLMStudio(context.Background(), provider, "")
-	if err != nil {
+	if _, err := svc.discoverLMStudio(context.Background(), provider, ""); err != nil {
 		t.Fatalf("discoverLMStudio failed: %v", err)
 	}
-	if authHeader != "" {
+	if sawHeader {
 		t.Errorf("expected no Authorization header when apiKey is empty, got %q", authHeader)
 	}
 }

--- a/internal/provider/discovery_ollama.go
+++ b/internal/provider/discovery_ollama.go
@@ -176,10 +176,11 @@ func (d *DiscoveryService) buildOllamaModel(provider *Provider, modelID string, 
 		switch {
 		case hasEmbedding:
 			modality = "embedding"
-			outputMods = `["embedding"]`
+			_, outputMods = nonChatModalityArrays(modality)
 		default:
 			if inferred := inferNonChatModality(modelID); inferred != "" {
 				modality = inferred
+				_, outputMods = nonChatModalityArrays(inferred)
 			}
 		}
 	}

--- a/internal/provider/discovery_ollama.go
+++ b/internal/provider/discovery_ollama.go
@@ -145,7 +145,9 @@ func (d *DiscoveryService) buildOllamaModel(provider *Provider, modelID string, 
 	caps := model.Capability{Streaming: true}
 	modality := "text"
 	inputMods := `["text"]`
+	outputMods := "[]"
 
+	hasCompletion, hasEmbedding := false, false
 	for _, c := range show.Capabilities {
 		switch c {
 		case "tools":
@@ -156,9 +158,31 @@ func (d *DiscoveryService) buildOllamaModel(provider *Provider, modelID string, 
 			caps.Vision = true
 			modality = "vision"
 			inputMods = `["text","image"]`
+		case "completion":
+			hasCompletion = true
+		case "embedding":
+			hasEmbedding = true
 		}
 	}
 	capJSON, _ := json.Marshal(caps)
+
+	// Ollama reports capabilities authoritatively: an embedding-only model lists
+	// "embedding" and not "completion", so it must be hidden from the chat
+	// picker. Applies equally to local Ollama and Ollama Cloud (same code path).
+	// If a model reports no completion capability at all (older Ollama returns an
+	// empty list), fall back to a name heuristic so embed/rerank models are still
+	// caught without misclassifying a normal chat model.
+	if !hasCompletion && modality == "text" {
+		switch {
+		case hasEmbedding:
+			modality = "embedding"
+			outputMods = `["embedding"]`
+		default:
+			if inferred := inferNonChatModality(modelID); inferred != "" {
+				modality = inferred
+			}
+		}
+	}
 
 	var contextLength *int
 	for k, v := range show.ModelInfo {
@@ -188,7 +212,7 @@ func (d *DiscoveryService) buildOllamaModel(provider *Provider, modelID string, 
 		Params:           "{}",
 		Modality:         modality,
 		InputModalities:  inputMods,
-		OutputModalities: "[]",
+		OutputModalities: outputMods,
 		ContextLength:    contextLength,
 		OwnedBy:          ownedBy,
 		Enabled:          true,

--- a/internal/provider/discovery_ollama_http_test.go
+++ b/internal/provider/discovery_ollama_http_test.go
@@ -623,6 +623,62 @@ func TestBuildOllamaModel_ThinkingCapabilityHTTP(t *testing.T) {
 	}
 }
 
+func TestBuildOllamaModel_EmbeddingCapabilityHTTP(t *testing.T) {
+	service := &DiscoveryService{}
+	// Ollama reports an embedding-only model as capabilities:["embedding"] with
+	// no "completion" — it must be classified as embedding, not text, so it is
+	// hidden from the chat picker.
+	show := &OllamaShowResponse{
+		Capabilities: []string{"embedding"},
+		ModelInfo:    map[string]interface{}{},
+		Details:      OllamaShowDetails{Family: "nomic-bert"},
+	}
+	provider := &Provider{ID: uuid.New()}
+
+	m := service.buildOllamaModel(provider, "nomic-embed-text", show)
+	if m.Modality != "embedding" {
+		t.Errorf("Expected Modality 'embedding', got '%s'", m.Modality)
+	}
+	if m.OutputModalities != `["embedding"]` {
+		t.Errorf("Expected OutputModalities '[\"embedding\"]', got '%s'", m.OutputModalities)
+	}
+}
+
+func TestBuildOllamaModel_CompletionStaysTextHTTP(t *testing.T) {
+	service := &DiscoveryService{}
+	// A normal chat model reports "completion"; even if its name happened to
+	// contain an embedding-ish token, an authoritative completion capability
+	// keeps it as a chat model.
+	show := &OllamaShowResponse{
+		Capabilities: []string{"completion", "tools"},
+		ModelInfo:    map[string]interface{}{},
+		Details:      OllamaShowDetails{Family: "llama"},
+	}
+	provider := &Provider{ID: uuid.New()}
+
+	m := service.buildOllamaModel(provider, "llama3-embed-tutor", show)
+	if m.Modality != "text" {
+		t.Errorf("Expected Modality 'text' for a completion model, got '%s'", m.Modality)
+	}
+}
+
+func TestBuildOllamaModel_EmbeddingByNameFallbackHTTP(t *testing.T) {
+	service := &DiscoveryService{}
+	// Older Ollama returns no capabilities at all; fall back to the name
+	// heuristic so an embedding model is still caught.
+	show := &OllamaShowResponse{
+		Capabilities: []string{},
+		ModelInfo:    map[string]interface{}{},
+		Details:      OllamaShowDetails{Family: "bert"},
+	}
+	provider := &Provider{ID: uuid.New()}
+
+	m := service.buildOllamaModel(provider, "mxbai-embed-large", show)
+	if m.Modality != "embedding" {
+		t.Errorf("Expected Modality 'embedding' from name fallback, got '%s'", m.Modality)
+	}
+}
+
 func TestGetOllamaCloudAccount_ContextCancellation(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(50 * time.Millisecond)

--- a/internal/provider/discovery_openai.go
+++ b/internal/provider/discovery_openai.go
@@ -44,6 +44,7 @@ func (d *DiscoveryService) discoverOpenAI(ctx context.Context, provider *Provide
 		// models.dev enrichment, which only fills empty/"text" modalities.
 		if mod := inferNonChatModality(m.ID); mod != "" {
 			stub.Modality = mod
+			stub.InputModalities, stub.OutputModalities = nonChatModalityArrays(mod)
 		}
 		live = append(live, stub)
 	}

--- a/internal/provider/discovery_openai.go
+++ b/internal/provider/discovery_openai.go
@@ -36,7 +36,16 @@ func (d *DiscoveryService) discoverOpenAI(ctx context.Context, provider *Provide
 	// old fabricated "text"/"[]" minimal entry).
 	live := make([]*model.Model, 0, len(openAIResp.Data))
 	for _, m := range openAIResp.Data {
-		live = append(live, liveModelStub(m.ID, m.OwnedBy, provider.ID))
+		stub := liveModelStub(m.ID, m.OwnedBy, provider.ID)
+		// A plain /models listing carries no model type, so self-hosted
+		// embedding/reranker models (and OpenAI's own text-embedding-* models)
+		// would otherwise be enriched to modality:"text" and appear in the chat
+		// picker. Classify the obvious ones by name; a set modality survives
+		// models.dev enrichment, which only fills empty/"text" modalities.
+		if mod := inferNonChatModality(m.ID); mod != "" {
+			stub.Modality = mod
+		}
+		live = append(live, stub)
 	}
 
 	// Backfill-only (no union): discoverOpenAI is the fallback for unknown/custom

--- a/internal/provider/local_modality.go
+++ b/internal/provider/local_modality.go
@@ -45,6 +45,15 @@ func inferNonChatModality(modelID string) string {
 	return ""
 }
 
+// nonChatModalityArrays returns the input/output modality JSON arrays to store
+// for a non-chat modality (as returned by inferNonChatModality). Embedding and
+// reranker models both take text input and produce their own output type, so
+// the output_modalities advertised on /v1/models matches the classification
+// instead of defaulting to text or empty.
+func nonChatModalityArrays(modality string) (input, output string) {
+	return `["text"]`, `["` + modality + `"]`
+}
+
 // splitModelIDSegments splits a lower-cased model ID on the separators commonly
 // found in HuggingFace-style IDs (org/name-with-parts).
 func splitModelIDSegments(id string) []string {

--- a/internal/provider/local_modality.go
+++ b/internal/provider/local_modality.go
@@ -1,0 +1,59 @@
+package provider
+
+import "strings"
+
+// inferNonChatModality guesses a non-chat modality ("embedding" or "rerank")
+// from a model ID when the provider does not report one.
+//
+// Self-hosted OpenAI-compatible servers (LM Studio's /v1/models, KoboldCPP,
+// llama.cpp, vLLM, LocalAI, text-generation-webui, ...) list embedding and
+// reranker models with no type information. Without this they land as
+// modality:"text" and wrongly appear in the chat/arena pickers, where they can
+// never work. Local Ollama and LM Studio's native /api/v0 endpoint report the
+// type authoritatively and don't need this; it is the fallback for the plain
+// OpenAI /models listing.
+//
+// It returns "" for anything that does not clearly look like an embedding or
+// reranker, so a normal chat model is never hidden. The returned strings must
+// stay in sync with the frontend's NON_CHAT_MODALITIES set
+// (web/src/utils/model.ts).
+func inferNonChatModality(modelID string) string {
+	id := strings.ToLower(modelID)
+
+	// Rerankers: "bge-reranker", "jina-reranker", "mxbai-rerank", "cohere-rerank".
+	if strings.Contains(id, "rerank") {
+		return "rerank"
+	}
+
+	// Embedding models almost always carry "embed" in the name: nomic-embed-text,
+	// mxbai-embed-large, text-embedding-3-small, snowflake-arctic-embed,
+	// embeddinggemma, gte-*-embedding, ...
+	if strings.Contains(id, "embed") {
+		return "embedding"
+	}
+
+	// Well-known embedding families that don't spell out "embed". Match them as
+	// whole segments (split on the usual id separators) so a substring can't
+	// trip a chat model that merely contains these letters.
+	for _, seg := range splitModelIDSegments(id) {
+		switch seg {
+		case "bge", "gte", "e5", "minilm":
+			return "embedding"
+		}
+	}
+
+	return ""
+}
+
+// splitModelIDSegments splits a lower-cased model ID on the separators commonly
+// found in HuggingFace-style IDs (org/name-with-parts).
+func splitModelIDSegments(id string) []string {
+	return strings.FieldsFunc(id, func(r rune) bool {
+		switch r {
+		case '/', '-', '_', '.', ':', ' ':
+			return true
+		default:
+			return false
+		}
+	})
+}

--- a/internal/provider/local_modality_test.go
+++ b/internal/provider/local_modality_test.go
@@ -1,0 +1,52 @@
+package provider
+
+import "testing"
+
+func TestInferNonChatModality(t *testing.T) {
+	tests := []struct {
+		id   string
+		want string
+	}{
+		// Embedding models: "embed" in the name.
+		{"nomic-embed-text", "embedding"},
+		{"nomic-embed-text-v1.5", "embedding"},
+		{"mxbai-embed-large", "embedding"},
+		{"text-embedding-3-small", "embedding"},
+		{"text-embedding-ada-002", "embedding"},
+		{"snowflake-arctic-embed2", "embedding"},
+		{"embeddinggemma", "embedding"},
+		{"nomic-ai/nomic-embed-text-v1.5-GGUF", "embedding"},
+
+		// Well-known embedding families without "embed" in the name.
+		{"bge-m3", "embedding"},
+		{"BAAI/bge-large-en-v1.5", "embedding"},
+		{"gte-large", "embedding"},
+		{"Alibaba-NLP/gte-Qwen2-7B-instruct", "embedding"},
+		{"intfloat/e5-large-v2", "embedding"},
+		{"multilingual-e5-large", "embedding"},
+		{"all-MiniLM-L6-v2", "embedding"},
+
+		// Rerankers.
+		{"bge-reranker-v2-m3", "rerank"},
+		{"jina-reranker-v2-base-multilingual", "rerank"},
+		{"mxbai-rerank-large-v1", "rerank"},
+
+		// Chat / other models must not be hidden.
+		{"llama-3.1-8b-instruct", ""},
+		{"qwen2.5-coder-7b", ""},
+		{"mistral-7b-instruct", ""},
+		{"gpt-4o", ""},
+		{"gemma3:4b", ""},
+		{"deepseek-r1", ""},
+		{"", ""},
+		// "gte"/"e5"/"bge" only match as whole segments, not substrings.
+		{"together-large", ""},
+		{"the5th-model", ""},
+	}
+
+	for _, tt := range tests {
+		if got := inferNonChatModality(tt.id); got != tt.want {
+			t.Errorf("inferNonChatModality(%q) = %q, want %q", tt.id, got, tt.want)
+		}
+	}
+}

--- a/internal/provider/openai_discovery_test.go
+++ b/internal/provider/openai_discovery_test.go
@@ -240,8 +240,16 @@ func TestOpenAIDiscovery_EmbeddingClassifiedByName(t *testing.T) {
 	}
 	if emb, ok := byID["text-embedding-3-small"]; !ok {
 		t.Fatal("text-embedding-3-small missing from results")
-	} else if emb.Modality != "embedding" {
-		t.Errorf("embedding modality: got %q, want embedding", emb.Modality)
+	} else {
+		if emb.Modality != "embedding" {
+			t.Errorf("embedding modality: got %q, want embedding", emb.Modality)
+		}
+		if emb.InputModalities != `["text"]` {
+			t.Errorf("embedding input modalities: got %q, want [\"text\"]", emb.InputModalities)
+		}
+		if emb.OutputModalities != `["embedding"]` {
+			t.Errorf("embedding output modalities: got %q, want [\"embedding\"]", emb.OutputModalities)
+		}
 	}
 	if chat, ok := byID["my-local-chat-7b"]; !ok {
 		t.Fatal("my-local-chat-7b missing from results")

--- a/internal/provider/openai_discovery_test.go
+++ b/internal/provider/openai_discovery_test.go
@@ -212,4 +212,42 @@ func TestOpenAIDiscoveryWithMockServer(t *testing.T) {
 	t.Logf("Mock server discovery test passed - %d models discovered", len(models))
 }
 
+func TestOpenAIDiscovery_EmbeddingClassifiedByName(t *testing.T) {
+	// A generic OpenAI-compatible server (or OpenAI itself) lists embedding
+	// models with no type. Discovery must classify them as modality:"embedding"
+	// by name so they stay out of the chat picker, while chat models remain text.
+	apiResponse := `{"object":"list","data":[` +
+		`{"id":"text-embedding-3-small","object":"model","owned_by":"openai"},` +
+		`{"id":"my-local-chat-7b","object":"model","owned_by":"local"}]}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(apiResponse))
+	}))
+	defer server.Close()
+
+	svc := NewDiscoveryService(nil, nil)
+	prov := &Provider{ID: uuid.New(), BaseURL: server.URL + "/v1"}
+
+	models, err := svc.discoverOpenAI(context.Background(), prov, "test-key")
+	if err != nil {
+		t.Fatalf("discoverOpenAI failed: %v", err)
+	}
+
+	byID := make(map[string]*model.Model, len(models))
+	for _, m := range models {
+		byID[m.ModelID] = m
+	}
+	if emb, ok := byID["text-embedding-3-small"]; !ok {
+		t.Fatal("text-embedding-3-small missing from results")
+	} else if emb.Modality != "embedding" {
+		t.Errorf("embedding modality: got %q, want embedding", emb.Modality)
+	}
+	if chat, ok := byID["my-local-chat-7b"]; !ok {
+		t.Fatal("my-local-chat-7b missing from results")
+	} else if chat.Modality == "embedding" || chat.Modality == "rerank" {
+		t.Errorf("chat model wrongly classified as %q", chat.Modality)
+	}
+}
+
 // TestOpenAIDiscoveryLiveAPI moved to discovery_live_test.go (//go:build live).


### PR DESCRIPTION
## Problem

Locally-discovered embedding and reranker models (LM Studio, Ollama, KoboldCPP, and generic OpenAI-compatible local servers like llama.cpp / vLLM / LocalAI) were stored with `modality:"text"`. The chat/arena picker filter added in #353 (`NON_CHAT_MODALITIES` in `web/src/utils/model.ts`) therefore couldn't catch them, so they wrongly appeared in the chat and arena model pickers where they can never work. This hurts exactly the homelab hosters this project targets.

## Fix

Set the correct non-chat modality at discovery time (backend-only; the frontend already filters on `modality`):

- **Ollama** (local **and** Ollama Cloud, shared code path) — read the authoritative `/api/show` `capabilities` array (same runtime strings as the existing `vision`/`tools`/`thinking` handling). An embedding-only model reports `"embedding"` and no `"completion"` → `modality:"embedding"`. A name-heuristic fallback covers older servers that return no capabilities. Host-agnostic: keys off what the server returns, not the URL.
- **LM Studio** — query the native `GET /api/v0/models` first, which authoritatively reports the model `type` (`llm`/`vlm`/`embeddings`) **and** a `max_context_length` (the OpenAI-compat listing provides neither). Falls back to `/v1/models` + name heuristic if the native endpoint is unavailable (older LM Studio, or a different server on that port).
- **Generic OpenAI-compatible + KoboldCPP** — classify by name heuristic. This also correctly hides OpenAI's own `text-embedding-*` models; a set modality survives models.dev enrichment (which only fills empty/`"text"`).

New shared `inferNonChatModality` helper: matches `"embed"` / `"rerank"` plus the `bge`/`gte`/`e5`/`minilm` families as whole ID segments (not substrings, so a chat model isn't tripped). Returns `""` for anything unclear, so a normal chat model is never hidden. Returned strings stay in sync with the frontend `NON_CHAT_MODALITIES` set.

## Verification

API behavior was web-verified against primary sources (Ollama `/api/show`, LM Studio `/api/v0/models`, KoboldCPP), not guessed.

Proven **end-to-end against a live local Ollama** (Dockerized `ollama/ollama`, real `/api/tags` + `/api/show`):

```
Discovered 2 models from live Ollama:
  qwen2.5:0.5b        modality=text       output_modalities=[]
  all-minilm:latest   modality=embedding  output_modalities=["embedding"]
```

Real capability payloads confirmed: `all-minilm` → `["embedding"]`, `qwen2.5:0.5b` → `["completion","tools"]`.

## Tests

- New `inferNonChatModality` unit table (embedding/rerank families + chat negatives + segment-vs-substring guards).
- LM Studio native (`type` + context length) and fallback (heuristic) paths.
- Ollama embedding-by-capability, completion-stays-text, and embedding-by-name fallback.
- Generic OpenAI embedding-by-name.
- Env-gated live Ollama discovery test (`//go:build live`, `OLLAMA_LIVE_URL`), excluded from the default suite/CI.

`go test ./internal/provider/...` → 775 passed; `golangci-lint run ./internal/provider/...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)