### PR TITLE
feat(frontdesk): OTLP log export + Observability status panel

### DIFF
--- a/cmd/frontdesk/main.go
+++ b/cmd/frontdesk/main.go
@@ -152,9 +152,14 @@ func main() {
 	if err := httpServer.Shutdown(shutdownCtx); err != nil {
 		debuglog.Error("frontdesk: graceful shutdown failed", "error", err)
 	}
-	// Flush and close the OTLP log exporter so batched records aren't lost.
+	// Flush and close the OTLP log exporter so batched records aren't lost. Use a
+	// fresh context, not shutdownCtx: a slow HTTP drain can consume most or all of
+	// that budget, leaving the exporter no time to flush (or an already-expired
+	// context). Mirrors the main server's dedicated flush deadline.
 	if otelLogShutdown != nil {
-		if err := otelLogShutdown(shutdownCtx); err != nil {
+		flushCtx, flushCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer flushCancel()
+		if err := otelLogShutdown(flushCtx); err != nil {
 			debuglog.Error("frontdesk: OTLP log export shutdown failed", "error", err)
 		}
 	}

--- a/cmd/frontdesk/main.go
+++ b/cmd/frontdesk/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 	"github.com/hugalafutro/model-hotel/internal/events"
 	"github.com/hugalafutro/model-hotel/internal/frontdesk"
+	"github.com/hugalafutro/model-hotel/internal/otelexport"
 	"github.com/hugalafutro/model-hotel/internal/ratelimit"
 	"github.com/hugalafutro/model-hotel/internal/webauthn"
 )
@@ -40,6 +41,29 @@ var version = "dev"
 func main() {
 	dbg := os.Getenv("DEBUG_LOG")
 	debuglog.Init(strings.EqualFold(dbg, "true") || dbg == "1")
+
+	// Root context for process-lifetime background work and log-exporter shutdown.
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	// OTLP log export: when the standard OTEL_EXPORTER_OTLP_* endpoint vars are
+	// set, fan the same structured records Front Desk already logs out to an
+	// OpenTelemetry collector, mirroring the main server. Logs only — no spans,
+	// no OTLP metrics (Prometheus stays the metrics path). Front Desk has no
+	// app-log ring buffer, so the fan-out base is the plain stdout handler.
+	var otelLogShutdown func(context.Context) error
+	if otelexport.LogsEnabled() {
+		otelHandler, shutdown, oerr := otelexport.NewSlogHandler(ctx, "front-desk", debuglog.Level())
+		if oerr != nil {
+			debuglog.Error("frontdesk: OTLP log export init failed; continuing without it", "error", oerr)
+		} else {
+			debuglog.SetHandler(debuglog.NewFanout(debuglog.StdoutHandler(), otelHandler))
+			otelLogShutdown = shutdown
+			// Logged after SetHandler installs the fan-out so the confirmation
+			// itself is also exported to the OTLP collector.
+			debuglog.Info("frontdesk: OTLP log export enabled")
+		}
+	}
 
 	port := envOr("PORT", ":8090")
 	if !strings.HasPrefix(port, ":") {
@@ -104,9 +128,6 @@ func main() {
 		Version:      version,
 	})
 
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
-	defer stop()
-
 	go poller.Run(ctx)
 	go srv.RunAutoSync(ctx)
 	go srv.RunAlerts(ctx)
@@ -130,6 +151,12 @@ func main() {
 	defer cancel()
 	if err := httpServer.Shutdown(shutdownCtx); err != nil {
 		debuglog.Error("frontdesk: graceful shutdown failed", "error", err)
+	}
+	// Flush and close the OTLP log exporter so batched records aren't lost.
+	if otelLogShutdown != nil {
+		if err := otelLogShutdown(shutdownCtx); err != nil {
+			debuglog.Error("frontdesk: OTLP log export shutdown failed", "error", err)
+		}
 	}
 }
 

--- a/frontdesk/web/src/api/client.ts
+++ b/frontdesk/web/src/api/client.ts
@@ -14,6 +14,7 @@ import type {
 	MemberState,
 	MemberTraffic,
 	MemberView,
+	ObservabilityStatus,
 	OidcStatus,
 	Settings,
 	SyncResult,
@@ -140,6 +141,9 @@ export const api = {
 	logout: () => request<void>("/api/logout", { method: "POST" }),
 	// Running-build identity for the footer (version + short commit SHA).
 	getVersion: () => request<VersionInfo>("/api/version"),
+	// Read-only log-export integration status for the Observability panel,
+	// derived server-side from the process environment.
+	getObservability: () => request<ObservabilityStatus>("/api/observability"),
 	// Partial body: the server merges onto the stored row, so each panel PUTs only
 	// the fields it owns and never clobbers the other's (or erases the secret).
 	putSettings: (s: Partial<Settings>) =>

--- a/frontdesk/web/src/api/types.ts
+++ b/frontdesk/web/src/api/types.ts
@@ -95,6 +95,16 @@ export interface VersionInfo {
 	app_commit: string;
 }
 
+// Read-only log-export integration status from GET /api/observability, derived
+// server-side from the process environment. Each integration is enabled by its
+// own environment variable and is not runtime-changeable; the Observability
+// panel only reflects this state. (A Prometheus metrics flag is a planned
+// follow-up; see plans/frontdesk-prometheus-metrics.md.)
+export interface ObservabilityStatus {
+	log_export_json: boolean;
+	log_export_otel: boolean;
+}
+
 // One alertable event in the Front Desk catalog (GET /api/alert/events), mirroring
 // alert.EventDef. The picker is rendered from this list, grouped by category.
 export interface AlertEventDef {

--- a/frontdesk/web/src/components/ObservabilityPanel.tsx
+++ b/frontdesk/web/src/components/ObservabilityPanel.tsx
@@ -1,0 +1,195 @@
+import {
+	BracketsCurlyIcon,
+	BroadcastIcon,
+	CheckIcon,
+	CopyIcon,
+	type Icon,
+} from "@phosphor-icons/react";
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { api } from "../api/client";
+import type { ObservabilityStatus } from "../api/types";
+
+// Exporter is one log-export integration row: its enabled state plus the copy
+// for the status badge and the (copyable) environment variable that turns it on.
+interface Exporter {
+	id: string;
+	icon: Icon;
+	enabled: boolean;
+	name: string;
+	description: string;
+	envVar: string;
+	instructions: string;
+}
+
+// CopyEnvVar renders an environment variable as a copyable mono pill, mirroring
+// the main dashboard's CopyablePill. Copy feedback swaps the icon briefly; a
+// clipboard failure is swallowed (the text is selectable regardless).
+function CopyEnvVar({ text }: { text: string }) {
+	const { t } = useTranslation();
+	const [copied, setCopied] = useState(false);
+
+	const copy = async () => {
+		try {
+			await navigator.clipboard.writeText(text);
+			setCopied(true);
+			setTimeout(() => setCopied(false), 1500);
+		} catch {
+			// Clipboard unavailable (insecure context / denied): leave the text
+			// visible so the operator can select it manually.
+		}
+	};
+
+	return (
+		<button
+			type="button"
+			className="ui-btn ui-btn-ghost fd-mono"
+			onClick={copy}
+			title={t("settings.observability.copy")}
+			aria-label={t("settings.observability.copy")}
+			style={{
+				display: "inline-flex",
+				alignSelf: "flex-start",
+				alignItems: "center",
+				justifyContent: "flex-start",
+				gap: "0.4rem",
+				fontSize: "0.78rem",
+				padding: "0.25rem 0.55rem",
+			}}
+		>
+			{copied ? <CheckIcon size={14} /> : <CopyIcon size={14} />}
+			<span>{text}</span>
+		</button>
+	);
+}
+
+// ObservabilityPanel is a read-only status panel for Front Desk's log-export
+// integrations (JSON stdout logs, OTLP log export). Each is enabled via its own
+// environment variable and resolved server-side; this panel only REFLECTS that
+// state, showing an enabled/disabled badge plus copyable enable instructions
+// when off. It mirrors the main dashboard's ObservabilitySettings section.
+// Prometheus /metrics is a planned follow-up (plans/frontdesk-prometheus-metrics.md).
+export function ObservabilityPanel() {
+	const { t } = useTranslation();
+	const [status, setStatus] = useState<ObservabilityStatus | null>(null);
+	const [error, setError] = useState(false);
+
+	useEffect(() => {
+		api
+			.getObservability()
+			.then(setStatus)
+			.catch(() => setError(true));
+	}, []);
+
+	const exporters: Exporter[] = [
+		{
+			id: "json",
+			icon: BracketsCurlyIcon,
+			enabled: status?.log_export_json ?? false,
+			name: t("settings.observability.json.name"),
+			description: t("settings.observability.json.description"),
+			envVar: "LOG_FORMAT=json",
+			instructions: t("settings.observability.json.instructions"),
+		},
+		{
+			id: "otel",
+			icon: BroadcastIcon,
+			enabled: status?.log_export_otel ?? false,
+			name: t("settings.observability.otel.name"),
+			description: t("settings.observability.otel.description"),
+			envVar: "OTEL_EXPORTER_OTLP_ENDPOINT=<collector-url>",
+			instructions: t("settings.observability.otel.instructions"),
+		},
+	];
+
+	return (
+		<div className="ui-card ui-card-pad fd-stack">
+			<div>
+				<h2 style={{ fontSize: "1rem" }}>
+					{t("settings.observability.title")}
+				</h2>
+				<p
+					className="fd-faint"
+					style={{ fontSize: "0.82rem", margin: "0.3rem 0 0" }}
+				>
+					{t("settings.observability.description")}
+				</p>
+			</div>
+
+			{error ? (
+				<div className="fd-faint" style={{ fontSize: "0.82rem" }}>
+					{t("settings.observability.loadError")}
+				</div>
+			) : (
+				<div className="fd-stack" style={{ gap: "1.1rem" }}>
+					{exporters.map((exp) => {
+						const Icon = exp.icon;
+						return (
+							<div
+								key={exp.id}
+								data-testid={`observability-card-${exp.id}`}
+								className="fd-stack"
+								style={{ gap: "0.4rem" }}
+							>
+								<div
+									className="fd-row"
+									style={{
+										justifyContent: "space-between",
+										alignItems: "flex-start",
+										gap: "0.75rem",
+									}}
+								>
+									<div
+										className="fd-row"
+										style={{ gap: "0.6rem", alignItems: "flex-start" }}
+									>
+										<Icon
+											size={18}
+											style={{
+												marginTop: "0.1rem",
+												flexShrink: 0,
+												color: "var(--accent)",
+											}}
+											aria-hidden="true"
+										/>
+										<div>
+											<div style={{ fontSize: "0.9rem", fontWeight: 500 }}>
+												{exp.name}
+											</div>
+											<div className="fd-faint" style={{ fontSize: "0.78rem" }}>
+												{exp.description}
+											</div>
+										</div>
+									</div>
+									<span
+										data-testid={`observability-status-${exp.id}`}
+										data-enabled={exp.enabled}
+										className={`ui-badge ${exp.enabled ? "ui-badge-ok" : "ui-badge-danger"}`}
+										style={{ flexShrink: 0 }}
+									>
+										{exp.enabled
+											? t("settings.observability.enabled")
+											: t("settings.observability.disabled")}
+									</span>
+								</div>
+
+								{!exp.enabled && (
+									<div
+										data-testid={`observability-instructions-${exp.id}`}
+										className="fd-stack"
+										style={{ gap: "0.4rem", marginLeft: "1.6rem" }}
+									>
+										<div className="fd-faint" style={{ fontSize: "0.78rem" }}>
+											{exp.instructions}
+										</div>
+										<CopyEnvVar text={exp.envVar} />
+									</div>
+								)}
+							</div>
+						);
+					})}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/frontdesk/web/src/components/ObservabilityPanel.tsx
+++ b/frontdesk/web/src/components/ObservabilityPanel.tsx
@@ -120,6 +120,13 @@ export function ObservabilityPanel() {
 				<div className="fd-faint" style={{ fontSize: "0.82rem" }}>
 					{t("settings.observability.loadError")}
 				</div>
+			) : status === null ? (
+				// Until the status resolves, render nothing rather than defaulting to
+				// "disabled": an enabled exporter would otherwise flash a wrong badge
+				// and misleading enable instructions before the response lands.
+				<div className="fd-faint" style={{ fontSize: "0.82rem" }}>
+					{t("common.loading")}
+				</div>
 			) : (
 				<div className="fd-stack" style={{ gap: "1.1rem" }}>
 					{exporters.map((exp) => {

--- a/frontdesk/web/src/components/__tests__/ObservabilityPanel.test.tsx
+++ b/frontdesk/web/src/components/__tests__/ObservabilityPanel.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { HttpResponse, http } from "msw";
+import { expect, it, vi } from "vitest";
+import { server } from "../../test/server";
+import { ObservabilityPanel } from "../ObservabilityPanel";
+
+function mockStatus(json: boolean, otel: boolean) {
+	server.use(
+		http.get("/api/observability", () =>
+			HttpResponse.json({ log_export_json: json, log_export_otel: otel }),
+		),
+	);
+}
+
+it("shows enabled badges and no enable instructions when both are on", async () => {
+	mockStatus(true, true);
+	render(<ObservabilityPanel />);
+
+	await waitFor(() =>
+		expect(screen.getByTestId("observability-status-json")).toHaveAttribute(
+			"data-enabled",
+			"true",
+		),
+	);
+	expect(screen.getByTestId("observability-status-otel")).toHaveAttribute(
+		"data-enabled",
+		"true",
+	);
+	// Enabled exporters hide the env-var instructions.
+	expect(
+		screen.queryByTestId("observability-instructions-json"),
+	).not.toBeInTheDocument();
+	expect(
+		screen.queryByTestId("observability-instructions-otel"),
+	).not.toBeInTheDocument();
+});
+
+it("shows disabled badges with copyable env vars when both are off", async () => {
+	mockStatus(false, false);
+	render(<ObservabilityPanel />);
+
+	await waitFor(() =>
+		expect(screen.getByTestId("observability-status-json")).toHaveAttribute(
+			"data-enabled",
+			"false",
+		),
+	);
+	expect(
+		screen.getByTestId("observability-instructions-json"),
+	).toHaveTextContent("LOG_FORMAT=json");
+	expect(
+		screen.getByTestId("observability-instructions-otel"),
+	).toHaveTextContent("OTEL_EXPORTER_OTLP_ENDPOINT=<collector-url>");
+});
+
+it("copies the env var to the clipboard when the pill is clicked", async () => {
+	const writeText = vi.fn().mockResolvedValue(undefined);
+	Object.assign(navigator, { clipboard: { writeText } });
+
+	mockStatus(false, false);
+	render(<ObservabilityPanel />);
+
+	const pill = await screen.findByText("LOG_FORMAT=json");
+	await userEvent.click(pill);
+	expect(writeText).toHaveBeenCalledWith("LOG_FORMAT=json");
+});
+
+it("renders a graceful error when the status request fails", async () => {
+	server.use(
+		http.get(
+			"/api/observability",
+			() => new HttpResponse(null, { status: 500 }),
+		),
+	);
+	render(<ObservabilityPanel />);
+
+	await waitFor(() =>
+		expect(
+			screen.getByText(/could not load observability status/i),
+		).toBeInTheDocument(),
+	);
+});

--- a/frontdesk/web/src/components/__tests__/ObservabilityPanel.test.tsx
+++ b/frontdesk/web/src/components/__tests__/ObservabilityPanel.test.tsx
@@ -13,6 +13,37 @@ function mockStatus(json: boolean, otel: boolean) {
 	);
 }
 
+it("shows a loading state and no badges until status resolves", async () => {
+	let resolve: (() => void) | undefined;
+	const gate = new Promise<void>((r) => {
+		resolve = r;
+	});
+	server.use(
+		http.get("/api/observability", async () => {
+			await gate;
+			return HttpResponse.json({
+				log_export_json: true,
+				log_export_otel: false,
+			});
+		}),
+	);
+	render(<ObservabilityPanel />);
+
+	// Before the response lands, no status badge is rendered (so an enabled
+	// exporter can't flash as "Disabled").
+	expect(
+		screen.queryByTestId("observability-status-json"),
+	).not.toBeInTheDocument();
+
+	resolve?.();
+	await waitFor(() =>
+		expect(screen.getByTestId("observability-status-json")).toHaveAttribute(
+			"data-enabled",
+			"true",
+		),
+	);
+});
+
 it("shows enabled badges and no enable instructions when both are on", async () => {
 	mockStatus(true, true);
 	render(<ObservabilityPanel />);

--- a/frontdesk/web/src/i18n/locales/en.json
+++ b/frontdesk/web/src/i18n/locales/en.json
@@ -152,6 +152,24 @@
 	"settings": {
 		"title": "Settings",
 		"saved": "Settings saved",
+		"observability": {
+			"title": "Observability",
+			"description": "Log-export integrations, each enabled by an environment variable and reflected here read-only.",
+			"loadError": "Could not load observability status.",
+			"enabled": "Enabled",
+			"disabled": "Disabled",
+			"copy": "Copy to clipboard",
+			"json": {
+				"name": "JSON logs",
+				"description": "Emit one JSON object per log line for external collectors.",
+				"instructions": "Set this environment variable and restart Front Desk to switch stdout logs to JSON."
+			},
+			"otel": {
+				"name": "OTLP log export",
+				"description": "Ship structured log records to an OpenTelemetry collector.",
+				"instructions": "Point Front Desk at your collector with the standard OTEL_EXPORTER_OTLP_* variables and restart."
+			}
+		},
 		"oidc": {
 			"title": "Single sign-on (OIDC)",
 			"hint": "Let admins sign in through an external OpenID Connect provider, a fourth login path alongside the Front Desk token, TOTP, and passkeys. Any standards-compliant provider works, as long as it releases the user's verified email. GitHub login is configured on the main dashboard only.",

--- a/frontdesk/web/src/pages/SettingsPage.tsx
+++ b/frontdesk/web/src/pages/SettingsPage.tsx
@@ -5,6 +5,7 @@ import type { Settings } from "../api/types";
 import { AlertsPanel } from "../components/AlertsPanel";
 import { AutoSyncPanel } from "../components/AutoSyncPanel";
 import { FleetSyncWizard } from "../components/FleetSyncWizard";
+import { ObservabilityPanel } from "../components/ObservabilityPanel";
 import { OidcPanel } from "../components/OidcPanel";
 import { SecurityPanels } from "../components/SecurityPanels";
 import { useToast } from "../context/ToastContext";
@@ -255,6 +256,8 @@ export function SettingsPage() {
 			<SecurityPanels />
 
 			<OidcPanel />
+
+			<ObservabilityPanel />
 		</div>
 	);
 }

--- a/internal/debuglog/debuglog.go
+++ b/internal/debuglog/debuglog.go
@@ -61,14 +61,7 @@ func Init(debug bool) {
 		currentLevel = slog.LevelInfo
 	}
 
-	opts := &slog.HandlerOptions{Level: currentLevel}
-	var handler slog.Handler
-	if JSONFormat() {
-		handler = slog.NewJSONHandler(os.Stdout, opts)
-	} else {
-		handler = slog.NewTextHandler(os.Stdout, opts)
-	}
-	slog.SetDefault(slog.New(maybeScopeFilter(handler)))
+	slog.SetDefault(slog.New(maybeScopeFilter(StdoutHandler())))
 
 	// Confirm scoped debug at startup so the operator sees it took effect. Log
 	// the parsed/normalized scopes (not the raw env string) so a tainted value
@@ -81,6 +74,20 @@ func Init(debug bool) {
 		sort.Strings(scopeList)
 		slog.Info("debuglog: per-scope debug enabled", "scopes", scopeList)
 	}
+}
+
+// StdoutHandler builds the base slog handler that writes to os.Stdout, honouring
+// LOG_FORMAT (JSON vs text) and the level chosen by Init. It is the single
+// source of truth for the stdout log sink, so callers that install their own
+// fan-out (e.g. Front Desk fanning stdout out to an OTLP exporter) start from
+// the exact handler Init would have installed. Call after Init so the level is
+// set; before Init it uses the zero value (Info).
+func StdoutHandler() slog.Handler {
+	opts := &slog.HandlerOptions{Level: currentLevel}
+	if JSONFormat() {
+		return slog.NewJSONHandler(os.Stdout, opts)
+	}
+	return slog.NewTextHandler(os.Stdout, opts)
 }
 
 // maybeScopeFilter wraps h with per-scope Debug filtering, but only when

--- a/internal/debuglog/debuglog_test.go
+++ b/internal/debuglog/debuglog_test.go
@@ -27,6 +27,30 @@ func newCaptureHandler(level slog.Level) *captureHandler {
 	return &captureHandler{level: level}
 }
 
+func TestStdoutHandler(t *testing.T) {
+	t.Run("text handler when LOG_FORMAT unset", func(t *testing.T) {
+		t.Setenv("LOG_FORMAT", "")
+		if _, ok := StdoutHandler().(*slog.TextHandler); !ok {
+			t.Errorf("StdoutHandler() = %T, want *slog.TextHandler", StdoutHandler())
+		}
+	})
+
+	t.Run("json handler when LOG_FORMAT=json", func(t *testing.T) {
+		t.Setenv("LOG_FORMAT", "json")
+		if _, ok := StdoutHandler().(*slog.JSONHandler); !ok {
+			t.Errorf("StdoutHandler() = %T, want *slog.JSONHandler", StdoutHandler())
+		}
+	})
+
+	t.Run("honours the level set by Init", func(t *testing.T) {
+		t.Setenv("DEBUG_LOG", "")
+		Init(true)
+		if !StdoutHandler().Enabled(context.Background(), slog.LevelDebug) {
+			t.Errorf("StdoutHandler() should accept Debug after Init(true)")
+		}
+	})
+}
+
 func TestInit(t *testing.T) {
 	t.Run("debug true sets LevelDebug", func(t *testing.T) {
 		Init(true)

--- a/internal/frontdesk/observability_test.go
+++ b/internal/frontdesk/observability_test.go
@@ -1,0 +1,64 @@
+package frontdesk
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+// TestGetObservability verifies GET /api/observability reflects the log-export
+// integration state derived from the environment. With neither LOG_FORMAT=json
+// nor an OTLP endpoint set, both flags are false.
+func TestGetObservability(t *testing.T) {
+	srv, _ := newTestServer(t)
+	t.Setenv("LOG_FORMAT", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", "")
+
+	rec := do(t, srv, http.MethodGet, "/api/observability", "", true)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /api/observability = %d (%s)", rec.Code, rec.Body.String())
+	}
+	var v map[string]bool
+	if err := json.Unmarshal(rec.Body.Bytes(), &v); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if v["log_export_json"] {
+		t.Errorf("log_export_json = true, want false")
+	}
+	if v["log_export_otel"] {
+		t.Errorf("log_export_otel = true, want false")
+	}
+}
+
+// TestGetObservabilityReflectsEnv confirms the flags flip on when the enabling
+// environment variables are present.
+func TestGetObservabilityReflectsEnv(t *testing.T) {
+	srv, _ := newTestServer(t)
+	t.Setenv("LOG_FORMAT", "json")
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://collector:4318")
+
+	rec := do(t, srv, http.MethodGet, "/api/observability", "", true)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /api/observability = %d (%s)", rec.Code, rec.Body.String())
+	}
+	var v map[string]bool
+	if err := json.Unmarshal(rec.Body.Bytes(), &v); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !v["log_export_json"] {
+		t.Errorf("log_export_json = false, want true")
+	}
+	if !v["log_export_otel"] {
+		t.Errorf("log_export_otel = false, want true")
+	}
+}
+
+// TestGetObservabilityRequiresAuth confirms the endpoint sits behind the admin-
+// or-session gate like the rest of the control-plane API.
+func TestGetObservabilityRequiresAuth(t *testing.T) {
+	srv, _ := newTestServer(t)
+	if rec := do(t, srv, http.MethodGet, "/api/observability", "", false); rec.Code != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated GET /api/observability = %d, want 401", rec.Code)
+	}
+}

--- a/internal/frontdesk/server.go
+++ b/internal/frontdesk/server.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/auth"
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 	"github.com/hugalafutro/model-hotel/internal/events"
+	"github.com/hugalafutro/model-hotel/internal/otelexport"
 	"github.com/hugalafutro/model-hotel/internal/totp"
 	"github.com/hugalafutro/model-hotel/internal/util"
 	"github.com/hugalafutro/model-hotel/internal/webauthn"
@@ -201,6 +202,7 @@ func (s *Server) buildRouter(wa *adminauth.WebAuthnHandler, tp *adminauth.TotpHa
 			r.Get("/settings", s.getSettings)
 			r.Put("/settings", s.putSettings)
 			r.Get("/version", s.getVersion)
+			r.Get("/observability", s.getObservability)
 			r.Get("/alert/events", s.alertEvents)
 			r.Get("/alert/status", s.alertStatus)
 			r.Post("/alert/test", s.alertTest)
@@ -741,6 +743,20 @@ func (s *Server) getVersion(w http.ResponseWriter, _ *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{
 		"app_version": s.version,
 		"app_commit":  util.ShortCommit(buildCommit),
+	})
+}
+
+// getObservability reports which log-export integrations are active, derived
+// read-only from the process environment (LOG_FORMAT, OTEL_EXPORTER_OTLP_*).
+// It mirrors the main server's log_export_* status keys so the Front Desk
+// Observability panel can reflect the same state. Nothing here is runtime-
+// changeable; each integration is enabled by its own environment variable.
+// (Prometheus /metrics — log_export_metrics — is a planned follow-up; see
+// plans/frontdesk-prometheus-metrics.md.)
+func (s *Server) getObservability(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]bool{
+		"log_export_json": debuglog.JSONFormat(),
+		"log_export_otel": otelexport.LogsEnabled(),
 	})
 }
 


### PR DESCRIPTION
## What

Brings Front Desk to parity with the main server's log-export observability story, and lays the groundwork for the Prometheus follow-up.

JSON stdout logs already worked in Front Desk (it calls `debuglog.Init`); this PR adds **OTLP log export** and a read-only **Observability** panel on the Settings page that reflects both integrations.

## Changes

**Backend**
- `internal/debuglog`: extract `StdoutHandler()` as the shared base-sink constructor (`Init` now uses it), so Front Desk can fan stdout out to an OTLP exporter from the exact handler `Init` would install.
- `cmd/frontdesk/main.go`: when the standard `OTEL_EXPORTER_OTLP_*` vars are set, build the exporter (service name `front-desk`), fan stdout → OTLP, log a confirmation through the fan-out, and flush the exporter on graceful shutdown. Logs only: no spans, no OTLP metrics (Prometheus stays the metrics path), mirroring the main server.
- `internal/frontdesk/server.go`: `GET /api/observability` (authed) returns `{log_export_json, log_export_otel}`, derived read-only from the environment like the main server's `log_export_*` keys.

**Frontend (`frontdesk/web`)**
- `ObservabilityStatus` type + `api.getObservability()`.
- `ObservabilityPanel`: read-only card with an enabled/disabled badge per integration and a copyable env-var pill when off, mounted on the Settings page. English strings in `en.json`.

## Follow-up

Prometheus `/metrics` for Front Desk is planned in `plans/frontdesk-prometheus-metrics.md`; it slots a third pill into this same panel. FD is never in the request path, so the proxy's collectors don't apply and it needs FD-domain metrics.

## Testing

- `go test ./internal/frontdesk ./internal/debuglog ./cmd/frontdesk` — pass (new backend handler + `StdoutHandler` tests).
- `go vet` + `golangci-lint` clean.
- `tsc -b` / `typecheck:tests` clean, ESLint clean, biome formatted.
- 4 new vitest cases for `ObservabilityPanel` (enabled/disabled badges, copyable env var, load-error).

Manual smoke suggested before merge: run FD with `OTEL_EXPORTER_OTLP_ENDPOINT` + `LOG_FORMAT=json` against a local collector to eyeball exported records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)