### PR TITLE
fix(frontdesk): Members table columns, wider layout, styled HA wiki diagram

### DIFF
--- a/frontdesk/web/src/i18n/locales/en.json
+++ b/frontdesk/web/src/i18n/locales/en.json
@@ -64,6 +64,7 @@
 		"colTraefik": "Traefik",
 		"colVersion": "Version",
 		"colLastSync": "Last Config Sync",
+		"colUpdated": "Updated",
 		"lastSyncNever": "Never",
 		"lastSyncPrimary": "n/a",
 		"lastSyncPrimaryTip": "This member is the source of config.",

--- a/frontdesk/web/src/index.css
+++ b/frontdesk/web/src/index.css
@@ -166,7 +166,7 @@ h3 {
 .fd-main {
 	flex: 1;
 	width: 100%;
-	max-width: 1100px;
+	max-width: min(96vw, 1600px);
 	margin: 0 auto;
 	padding: 1.5rem 1.25rem 3rem;
 }
@@ -352,6 +352,7 @@ h3 {
 	padding: 0.6rem 0.75rem;
 	border-bottom: 1px solid var(--border);
 	vertical-align: middle;
+	white-space: nowrap;
 }
 .ui-table tr:last-child td {
 	border-bottom: 0;

--- a/frontdesk/web/src/index.css
+++ b/frontdesk/web/src/index.css
@@ -352,6 +352,12 @@ h3 {
 	padding: 0.6rem 0.75rem;
 	border-bottom: 1px solid var(--border);
 	vertical-align: middle;
+}
+/* Keep every cell on a single line so relative-time columns don't reflow the
+   row height as their text changes, and long member URLs stay on one line.
+   Scoped to tables that opt in (the Members table) so log/message tables keep
+   their default wrapping. */
+.ui-table--nowrap td {
 	white-space: nowrap;
 }
 .ui-table tr:last-child td {

--- a/frontdesk/web/src/pages/MembersPage.tsx
+++ b/frontdesk/web/src/pages/MembersPage.tsx
@@ -121,7 +121,7 @@ export function MembersPage() {
 				) : members.length === 0 ? (
 					<div className="fd-empty">{t("members.empty")}</div>
 				) : (
-					<table className="ui-table">
+					<table className="ui-table ui-table--nowrap">
 						<thead>
 							<tr>
 								<th>{t("members.colName")}</th>

--- a/frontdesk/web/src/pages/MembersPage.tsx
+++ b/frontdesk/web/src/pages/MembersPage.tsx
@@ -131,6 +131,7 @@ export function MembersPage() {
 								<th>{t("members.colVerified")}</th>
 								<th>{t("members.colLastSync")}</th>
 								<th>{t("members.colState")}</th>
+								<th>{t("members.colUpdated")}</th>
 								<th />
 							</tr>
 						</thead>
@@ -148,22 +149,22 @@ export function MembersPage() {
 						</tbody>
 					</table>
 				)}
-				{lastUpdatedAt && !loading && !error && (
-					<div
-						className="fd-faint"
-						style={{
-							fontSize: "0.8rem",
-							textAlign: "right",
-							marginTop: "0.5rem",
-						}}
-						data-testid="members-last-updated"
-					>
-						{t("members.lastUpdated", {
-							when: formatTimeOfDay(lastUpdatedAt),
-						})}
-					</div>
-				)}
 			</div>
+			{lastUpdatedAt && !loading && !error && (
+				<div
+					className="fd-faint"
+					style={{
+						fontSize: "0.8rem",
+						textAlign: "right",
+						marginTop: "-1rem",
+					}}
+					data-testid="members-last-updated"
+				>
+					{t("members.lastUpdated", {
+						when: formatTimeOfDay(lastUpdatedAt),
+					})}
+				</div>
+			)}
 
 			<AddMemberForm
 				firstMember={!loading && members.length === 0}
@@ -332,6 +333,7 @@ function MemberRow({
 					</span>
 				)}
 			</td>
+			<td className="fd-faint">{formatRelative(m.updated_at)}</td>
 			<td>
 				<div className="fd-row" style={{ justifyContent: "flex-end" }}>
 					{m.state === "active" ? (
@@ -361,12 +363,6 @@ function MemberRow({
 					>
 						{t("common.remove")}
 					</button>
-				</div>
-				<div
-					className="fd-faint"
-					style={{ fontSize: "0.72rem", textAlign: "right", marginTop: 2 }}
-				>
-					{formatRelative(m.updated_at)}
 				</div>
 			</td>
 		</tr>

--- a/frontdesk/web/src/pages/__tests__/MembersPage.test.tsx
+++ b/frontdesk/web/src/pages/__tests__/MembersPage.test.tsx
@@ -148,7 +148,7 @@ describe("MembersPage", () => {
 		);
 	});
 
-	it("shows a last-updated footer under the table", async () => {
+	it("shows a last-updated footer below the members card", async () => {
 		server.use(
 			http.get("/api/members", () =>
 				HttpResponse.json([member({ id: "1", name: "hotel-1" })]),

--- a/wiki/High-Availability.md
+++ b/wiki/High-Availability.md
@@ -32,13 +32,7 @@ with the last config it fetched; only membership changes pause until it returns.
 
 ## Architecture Overview
 
-```
-        clients ─▶ TLS proxy (https) ─▶ Traefik :8080 ─┬─▶ hotel-1 (ip1:8081)
-                                                        └─▶ hotel-2 (ip2:8081)
-                                          ▲ polls /traefik/config every ~5s
-                                          │
-                                    Front Desk :8090  ◀── you, in a browser
-```
+![High Availability Architecture](ha-architecture.svg)
 
 - **Traefik (data plane)** carries all client traffic and load-balances across
   members. It pulls its routing config from Front Desk over the internal compose

--- a/wiki/ha-architecture.svg
+++ b/wiki/ha-architecture.svg
@@ -1,0 +1,77 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 360" font-family="'Segoe UI', system-ui, -apple-system, sans-serif">
+  <defs>
+    <marker id="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#94a3b8"/>
+    </marker>
+    <marker id="arrP" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#a78bfa"/>
+    </marker>
+    <filter id="shadow" x="-2%" y="-2%" width="104%" height="104%">
+      <feDropShadow dx="0" dy="2" stdDeviation="3" flood-opacity="0.15"/>
+    </filter>
+  </defs>
+
+  <!-- Background (transparent) -->
+  <rect width="780" height="360" fill="none" rx="8"/>
+
+  <!-- Plane labels -->
+  <text x="24" y="26" fill="#64748b" font-size="11" font-weight="600" letter-spacing="1">DATA PLANE  ·  request path</text>
+  <text x="24" y="232" fill="#64748b" font-size="11" font-weight="600" letter-spacing="1">CONTROL PLANE  ·  never in the request path</text>
+
+  <!-- Divider between planes -->
+  <line x1="24" y1="205" x2="756" y2="205" stroke="#334155" stroke-width="1" stroke-dasharray="6,4"/>
+
+  <!-- Clients -->
+  <rect x="24" y="48" width="120" height="64" rx="10" fill="#1e293b" stroke="#3b82f6" stroke-width="1.5" filter="url(#shadow)"/>
+  <text x="84" y="80" text-anchor="middle" fill="#93c5fd" font-size="15" font-weight="700">Clients</text>
+  <text x="84" y="99" text-anchor="middle" fill="#94a3b8" font-size="10">API traffic</text>
+
+  <!-- Clients -> TLS proxy -->
+  <line x1="144" y1="80" x2="192" y2="80" stroke="#94a3b8" stroke-width="1.6" marker-end="url(#arr)"/>
+
+  <!-- TLS proxy -->
+  <rect x="192" y="48" width="144" height="64" rx="10" fill="#1e293b" stroke="#f59e0b" stroke-width="1.5" filter="url(#shadow)"/>
+  <text x="264" y="80" text-anchor="middle" fill="#fbbf24" font-size="15" font-weight="700">TLS proxy</text>
+  <text x="264" y="99" text-anchor="middle" fill="#94a3b8" font-size="10">HTTPS ingress (you provide)</text>
+
+  <!-- TLS proxy -> Traefik -->
+  <line x1="336" y1="80" x2="384" y2="80" stroke="#94a3b8" stroke-width="1.6" marker-end="url(#arr)"/>
+
+  <!-- Traefik -->
+  <rect x="384" y="48" width="156" height="64" rx="10" fill="#1e293b" stroke="#10b981" stroke-width="1.5" filter="url(#shadow)"/>
+  <text x="462" y="78" text-anchor="middle" fill="#34d399" font-size="15" font-weight="700">Traefik :8080</text>
+  <text x="462" y="99" text-anchor="middle" fill="#94a3b8" font-size="10">load-balances the fleet</text>
+
+  <!-- Traefik -> members -->
+  <line x1="540" y1="72" x2="604" y2="52" stroke="#94a3b8" stroke-width="1.6" marker-end="url(#arr)"/>
+  <line x1="540" y1="88" x2="604" y2="132" stroke="#94a3b8" stroke-width="1.6" marker-end="url(#arr)"/>
+
+  <!-- hotel-1 -->
+  <rect x="608" y="24" width="148" height="56" rx="10" fill="#1e293b" stroke="#f43f5e" stroke-width="1.5" filter="url(#shadow)"/>
+  <text x="682" y="49" text-anchor="middle" fill="#fb7185" font-size="14" font-weight="700">hotel-1</text>
+  <text x="682" y="67" text-anchor="middle" fill="#94a3b8" font-size="10">ip1:8081</text>
+
+  <!-- hotel-2 -->
+  <rect x="608" y="104" width="148" height="56" rx="10" fill="#1e293b" stroke="#f43f5e" stroke-width="1.5" filter="url(#shadow)"/>
+  <text x="682" y="129" text-anchor="middle" fill="#fb7185" font-size="14" font-weight="700">hotel-2</text>
+  <text x="682" y="147" text-anchor="middle" fill="#94a3b8" font-size="10">ip2:8081</text>
+
+  <!-- You, in a browser -->
+  <rect x="150" y="254" width="150" height="64" rx="10" fill="#1e293b" stroke="#3b82f6" stroke-width="1.5" filter="url(#shadow)"/>
+  <text x="225" y="286" text-anchor="middle" fill="#93c5fd" font-size="14" font-weight="700">You, in a browser</text>
+  <text x="225" y="305" text-anchor="middle" fill="#94a3b8" font-size="10">admin UI</text>
+
+  <!-- You -> Front Desk -->
+  <line x1="300" y1="286" x2="384" y2="286" stroke="#94a3b8" stroke-width="1.6" marker-end="url(#arr)"/>
+
+  <!-- Front Desk -->
+  <rect x="384" y="246" width="156" height="80" rx="10" fill="#1e293b" stroke="#a78bfa" stroke-width="1.5" filter="url(#shadow)"/>
+  <text x="462" y="274" text-anchor="middle" fill="#c4b5fd" font-size="15" font-weight="700">Front Desk :8090</text>
+  <text x="462" y="294" text-anchor="middle" fill="#94a3b8" font-size="10">add · drain · remove members</text>
+  <text x="462" y="310" text-anchor="middle" fill="#94a3b8" font-size="10">sync config · watch health</text>
+
+  <!-- Front Desk -> Traefik (config poll, dashed, upward) -->
+  <line x1="462" y1="246" x2="462" y2="114" stroke="#a78bfa" stroke-width="1.6" stroke-dasharray="6,4" marker-end="url(#arrP)"/>
+  <text x="478" y="172" fill="#c4b5fd" font-size="10" font-weight="600">Traefik polls</text>
+  <text x="478" y="186" fill="#94a3b8" font-size="10">GET /traefik/config  ·  ~5s</text>
+</svg>


### PR DESCRIPTION
## Front Desk Members table

The Members table jittered in height as the relative-time cells re-rendered and wrapped, and the URL column broke `https://` links onto two lines. On a 1440p display the table also sat cramped in the middle with roughly half the viewport empty.

- **Dedicated `Updated` column.** The per-row `updated_at` (`x ago`) moved out from under the action buttons into its own column (new `colUpdated` header, placed after **State**).
- **Last-updated footer outside the card.** The table-level last-updated stamp now sits flush beneath the card's bottom border (the `.ui-card` has no padding, so that border is the table's bottom border), instead of stacked inside the card with a margin.
- **Wider app.** `.fd-main` grew from a hard `1100px` cap to `min(96vw, 1600px)`, so Front Desk fills wide displays instead of stranding half the viewport.
- **No more row-height jitter / wrapped URLs.** Added `white-space: nowrap`, scoped to the Members table via a `.ui-table--nowrap` opt-in so relative-time columns no longer reflow rows and member URLs stay on one line. It is deliberately **not** global: the Events page message column keeps its default wrapping.

## HA wiki diagram

`High-Availability.md` opened with an ASCII-art topology while every other wiki page uses the shared dark-slate SVG style. Redrew it as `wiki/ha-architecture.svg` in that language (same palette, tinted boxes, drop shadows, Segoe UI), separating the **data plane** (clients -> TLS proxy -> Traefik -> members) from the **control plane** (Front Desk, polled by Traefik for config, never in the request path).

## Verification
- `pnpm exec tsc -b` clean, Biome + ESLint clean.
- Members + Events test suites green (22/22 across the two files); full MembersPage suite 16/16.
- SVG validated as well-formed and rendered to confirm layout.

Note: `web/src/` changes are embedded in the Go binary, so they need a container rebuild to appear live; the wiki republishes on `master` push via `sync-wiki.yml` once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)