### PR TITLE
fix(discovery): multi-layer proof before disabling missing models

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -541,7 +541,7 @@ func main() {
 			// model.MissingScanThreshold consecutive confirmed-missing scans.
 			var disabledRefs []model.DisabledModelRef
 			if snapErr == nil && !upsertFailed {
-				confirmedIDs, suspect := api.ConfirmMissingModels(ctx, discoverySvc, p, cfg.MasterKey, existingModelIDs, snapshot)
+				confirmedIDs, suspect := api.ConfirmMissingModels(ctx, discoverySvc, p, cfg.MasterKey, existingModelIDs, snapshot, api.NewSuspectStreak(database.Pool()))
 				if suspect {
 					debuglog.Warn("discovery: suspect scan, skipping missing-model recording", "provider", p.Name)
 				} else {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -523,18 +523,40 @@ func main() {
 
 			existingModelIDs := make([]string, 0, len(models))
 			upsertedModels := make([]*model.Model, 0, len(models))
+			upsertFailed := false
 			for _, m := range models {
 				if err := modelRepo.Upsert(ctx, m); err != nil {
 					debuglog.Error("discovery: failed to upsert model", "model_id", m.ModelID, "error", err)
+					upsertFailed = true
 				} else {
 					existingModelIDs = append(existingModelIDs, m.ModelID)
 					upsertedModels = append(upsertedModels, m)
 				}
 			}
-			disabledRefs, err := modelRepo.DisableMissingModels(ctx, p.ID, p.Name, existingModelIDs)
-			if err != nil {
-				debuglog.Error("discovery: failed to disable missing models", "provider", p.Name, "error", err)
-			} else if len(disabledRefs) > 0 {
+			// Miss recording needs a trustworthy membership picture: skip it
+			// when the snapshot is unavailable (absentees cannot be confirmed)
+			// or any upsert failed (a DB error must not count a listed model
+			// as missing). Absent models get a second opinion via confirmation
+			// probes, and a model is disabled only after
+			// model.MissingScanThreshold consecutive confirmed-missing scans.
+			var disabledRefs []model.DisabledModelRef
+			if snapErr == nil && !upsertFailed {
+				confirmedIDs, suspect := api.ConfirmMissingModels(ctx, discoverySvc, p, cfg.MasterKey, existingModelIDs, snapshot)
+				if suspect {
+					debuglog.Warn("discovery: suspect scan, skipping missing-model recording", "provider", p.Name)
+				} else {
+					var pendingRefs []model.DisabledModelRef
+					disabledRefs, pendingRefs, err = modelRepo.RecordMissingModels(ctx, p.ID, p.Name, confirmedIDs)
+					if err != nil {
+						debuglog.Error("discovery: failed to record missing models", "provider", p.Name, "error", err)
+					}
+					if len(pendingRefs) > 0 {
+						debuglog.Info("discovery: models confirmed missing but below disable threshold",
+							"provider", p.Name, "pending", len(pendingRefs), "threshold", model.MissingScanThreshold)
+					}
+				}
+			}
+			if len(disabledRefs) > 0 {
 				result.ModelsDisabled += len(disabledRefs)
 				events.Publish(events.Event{
 					Type:     "discovery.models_disabled",

--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -344,7 +344,11 @@ func (h *Handler) registerAdminOnly(r chi.Router) {
 	// member has providers but no models until discovery runs).
 	NewConfigSyncHandler(h.dbPool, h.settingsRepo, h.cfg.MasterKey, h.appVersion,
 		func(ctx context.Context) error {
-			_, _, _, _, err := h.discoverAllProviders(ctx)
+			// Request-bound (runs inside the config-sync import HTTP handler):
+			// skip miss-recording so the confirmation-probe backoff cannot
+			// overrun the 60s route timeout and make the sync look failed. The
+			// synced member's own scheduled sweep owns disabling.
+			_, _, _, _, err := h.discoverAllProviders(ctx, false)
 			return err
 		}).Register(r)
 

--- a/internal/api/discovery.go
+++ b/internal/api/discovery.go
@@ -431,9 +431,21 @@ func ConfirmMissingModels(ctx context.Context, svc *provider.DiscoveryService, p
 			enabledCount++
 		}
 	}
-	if missing > suspectMissingFloor && float64(missing) > suspectMissingRatio*float64(enabledCount) {
+	// A total blackout - the initial listing and every confirmation probe
+	// returned no models at all while the provider still has enabled models - is
+	// the strongest broken-listing signal there is, so treat it as suspect
+	// regardless of the mass-vanish floor. A small provider (enabled <=
+	// suspectMissingFloor) otherwise slips past the floor+ratio guard below with
+	// suspect=false; RecordMissingModels's empty-list no-op then records nothing,
+	// leaving every stale model enabled indefinitely with no operator signal. An
+	// empty listing is a common provider quirk (see the discovery_*.go
+	// empty-listing guards), so we still disable nothing here; the suspect event
+	// and its escalation surface the condition for an operator instead.
+	blackout := len(confirmedPresent) == 0 && enabledCount > 0
+	massVanish := missing > suspectMissingFloor && float64(missing) > suspectMissingRatio*float64(enabledCount)
+	if blackout || massVanish {
 		debuglog.Warn("discovery: mass-vanish guard tripped, treating scan as suspect",
-			"provider", prov.Name, "provider_id", prov.ID, "missing", missing, "enabled", enabledCount)
+			"provider", prov.Name, "provider_id", prov.ID, "missing", missing, "enabled", enabledCount, "blackout", blackout)
 		events.Publish(events.Event{
 			Type:     "discovery.suspect_scan",
 			Severity: "warning",

--- a/internal/api/discovery.go
+++ b/internal/api/discovery.go
@@ -268,6 +268,79 @@ const (
 	suspectMissingRatio = 0.5
 )
 
+// suspectStreakThreshold is how many consecutive mass-vanish scans a provider
+// must trip before discovery escalates from the quiet per-scan warning to a
+// distinct, actionable "this looks like a real bulk removal" alert. Kept well
+// above MissingScanThreshold so a brief upstream outage never reaches it: a
+// transient broken listing recovers within a scan or two and resets the streak,
+// whereas a genuine catalog sunset stays missing every scan. We never
+// auto-disable on this signal (disabling half a provider's catalog propagates
+// fleet-wide through HA); the alert asks an operator to disable by hand.
+const suspectStreakThreshold = 3
+
+// shouldEscalateSuspect reports whether a just-incremented consecutive
+// mass-vanish count should raise the escalation alert. It fires on the crossing
+// scan and then re-fires once every suspectStreakThreshold scans, so a
+// persistent condition re-pings periodically without alerting on every scan.
+func shouldEscalateSuspect(streak int) bool {
+	return streak >= suspectStreakThreshold && streak%suspectStreakThreshold == 0
+}
+
+// SuspectStreak persists the per-provider consecutive-mass-vanish counter. It is
+// nil on paths that must not touch the counter (unit tests, and any future
+// caller without a pool); ConfirmMissingModels guards every use.
+type SuspectStreak struct {
+	exec func(pool *pgxpool.Pool, ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error)
+	pool *pgxpool.Pool
+}
+
+// NewSuspectStreak builds a pool-backed SuspectStreak for the discovery sweep.
+func NewSuspectStreak(pool *pgxpool.Pool) *SuspectStreak {
+	return &SuspectStreak{exec: dbExec, pool: pool}
+}
+
+// bump increments the provider's consecutive mass-vanish counter and, every
+// suspectStreakThreshold consecutive scans, emits the louder escalation event.
+// Counter errors are logged, not fatal: a missed escalation must never abort a
+// scan.
+func (s *SuspectStreak) bump(ctx context.Context, prov *provider.Provider, missing, enabled int) {
+	if s == nil {
+		return
+	}
+	var streak int
+	if err := s.pool.QueryRow(ctx,
+		`UPDATE providers SET suspect_scans = suspect_scans + 1 WHERE id = $1 RETURNING suspect_scans`,
+		prov.ID,
+	).Scan(&streak); err != nil {
+		debuglog.Warn("discovery: failed to bump provider suspect streak", "provider", prov.Name, "error", err)
+		return
+	}
+	if shouldEscalateSuspect(streak) {
+		debuglog.Warn("discovery: provider suspected of bulk-removing models",
+			"provider", prov.Name, "provider_id", prov.ID, "missing", missing, "enabled", enabled, "consecutive_scans", streak)
+		events.Publish(events.Event{
+			Type:     "discovery.bulk_removal_suspected",
+			Severity: "error",
+			Source:   "discovery",
+			Message:  fmt.Sprintf("Provider '%s' has been missing %d of %d enabled models for %d consecutive scans. This looks like a real bulk removal rather than a broken listing; discovery will not auto-disable them. Review and disable the retired models by hand.", prov.Name, missing, enabled, streak),
+			Metadata: map[string]interface{}{"provider": prov.Name, "provider_id": prov.ID, "missing": missing, "enabled": enabled, "consecutive_scans": streak},
+		})
+	}
+}
+
+// reset clears the counter after a healthy scan (listing recovered). It is a
+// no-op write when the counter is already zero, so the common healthy scan does
+// not churn the row.
+func (s *SuspectStreak) reset(ctx context.Context, prov *provider.Provider) {
+	if s == nil {
+		return
+	}
+	if _, err := s.exec(s.pool, ctx,
+		`UPDATE providers SET suspect_scans = 0 WHERE id = $1 AND suspect_scans <> 0`, prov.ID); err != nil {
+		debuglog.Warn("discovery: failed to reset provider suspect streak", "provider", prov.Name, "error", err)
+	}
+}
+
 // confirmProbeSleep waits for the probe backoff, honouring ctx cancellation.
 // Injectable for tests (which also exercise sleepWithContext directly).
 var confirmProbeSleep = sleepWithContext
@@ -293,7 +366,12 @@ func sleepWithContext(ctx context.Context, d time.Duration) error {
 // cancelled, or the mass-vanish guard tripped) and the caller must skip miss
 // recording entirely. Probes affect membership only; metadata still comes
 // exclusively from the initial listing's upserts.
-func ConfirmMissingModels(ctx context.Context, svc *provider.DiscoveryService, prov *provider.Provider, masterKey string, presentIDs []string, snapshot map[string]ModelSnapshot) (confirmedPresent []string, suspect bool) {
+// streak, when non-nil, tracks consecutive mass-vanish scans per provider: it is
+// reset on any healthy scan and bumped (with escalation) when the mass-vanish
+// guard trips, so a genuine bulk removal eventually raises a loud alert while a
+// one-off broken listing does not. It is nil on paths that must not touch the
+// counter (unit tests).
+func ConfirmMissingModels(ctx context.Context, svc *provider.DiscoveryService, prov *provider.Provider, masterKey string, presentIDs []string, snapshot map[string]ModelSnapshot, streak *SuspectStreak) (confirmedPresent []string, suspect bool) {
 	present := make(map[string]bool, len(presentIDs))
 	for _, id := range presentIDs {
 		present[id] = true
@@ -311,6 +389,7 @@ func ConfirmMissingModels(ctx context.Context, svc *provider.DiscoveryService, p
 	confirmedPresent = presentIDs
 	missing := countMissing()
 	if missing == 0 {
+		streak.reset(ctx, prov)
 		return confirmedPresent, false
 	}
 
@@ -341,6 +420,7 @@ func ConfirmMissingModels(ctx context.Context, svc *provider.DiscoveryService, p
 		if missing == 0 {
 			debuglog.Info("discovery: confirmation probe found all absent models, no misses recorded",
 				"provider", prov.Name, "provider_id", prov.ID, "probe", probe+1)
+			streak.reset(ctx, prov)
 			return confirmedPresent, false
 		}
 	}
@@ -361,9 +441,13 @@ func ConfirmMissingModels(ctx context.Context, svc *provider.DiscoveryService, p
 			Message:  fmt.Sprintf("Discovery scan for %s is missing %d of %d enabled models even after confirmation probes; treating the listing as broken and disabling nothing", prov.Name, missing, enabledCount),
 			Metadata: map[string]interface{}{"provider": prov.Name, "provider_id": prov.ID, "missing": missing, "enabled": enabledCount},
 		})
+		// A recovered listing resets the streak; a persistent one crosses the
+		// escalation threshold and raises the louder bulk-removal alert.
+		streak.bump(ctx, prov, missing, enabledCount)
 		return confirmedPresent, true
 	}
 
+	streak.reset(ctx, prov)
 	return confirmedPresent, false
 }
 
@@ -643,25 +727,16 @@ func (h *Handler) DiscoverProviderModels(w http.ResponseWriter, r *http.Request)
 		upsertedModels = append(upsertedModels, m)
 	}
 
-	// Second opinion before any model is counted missing: re-probe the listing
-	// with backoff, and only feed confirmed membership into the miss recorder.
-	// A model is disabled only after MissingScanThreshold consecutive scans
-	// confirm it missing, so one flaky scan can never disable anything.
-	confirmedIDs, suspect := ConfirmMissingModels(provCtx, discovery, prov, h.cfg.MasterKey, existingModelIDs, snapshot)
-	var disabledRefs, pendingRefs []model.DisabledModelRef
-	if suspect {
-		debuglog.Warn("discovery: suspect scan, skipping missing-model recording", "provider", prov.Name, "provider_id", providerID)
-	} else {
-		disabledRefs, pendingRefs, err = modelRepoRecordMissing(modelRepo, provCtx, providerID, prov.Name, confirmedIDs)
-		if err != nil {
-			respondError(w, fmt.Sprintf("failed to record missing models for provider %s", prov.Name), err, http.StatusInternalServerError)
-			return
-		}
-	}
-	if len(pendingRefs) > 0 {
-		debuglog.Info("discovery: models confirmed missing but below disable threshold",
-			"provider", prov.Name, "provider_id", providerID, "pending", len(pendingRefs), "threshold", model.MissingScanThreshold)
-	}
+	// An interactive Discover never disables models. Disabling requires
+	// MissingScanThreshold consecutive confirmed-missing scans, so a single
+	// on-demand scan can never reach the threshold on its own; the only thing
+	// running the confirmation probes here would achieve is stalling this
+	// request for the full probe backoff (~70s), which overruns the 60s HTTP
+	// timeout on this route and, for the HA config-sync import path, makes the
+	// initiating member's sync appear to fail. The scheduled/background sweep
+	// (cmd/server/main.go) owns miss-recording and disabling; this handler just
+	// fetches, upserts, and syncs failover for the models it did see.
+	var disabledRefs []model.DisabledModelRef
 
 	diff := BuildDiscoveryDiff(snapshot, upsertedModels, disabledRefs)
 
@@ -851,7 +926,9 @@ type DiscoverAllResult struct {
 
 // DiscoverAllModels discovers and imports models from all enabled providers.
 func (h *Handler) DiscoverAllModels(w http.ResponseWriter, r *http.Request) {
-	results, succeeded, failed, totalDiscovered, err := h.discoverAllProviders(r.Context())
+	// Request-bound: skip miss-recording so the confirmation-probe backoff
+	// cannot overrun this route's 60s timeout. The scheduled sweep disables.
+	results, succeeded, failed, totalDiscovered, err := h.discoverAllProviders(r.Context(), false)
 	if err != nil {
 		respondError(w, "failed to list providers", nil, http.StatusInternalServerError)
 		return
@@ -872,7 +949,16 @@ func (h *Handler) DiscoverAllModels(w http.ResponseWriter, r *http.Request) {
 // failures are recorded in the results. ctx governs cancellation; each provider
 // runs under its own detached timeout so one client disconnect does not abort
 // the sweep.
-func (h *Handler) discoverAllProviders(ctx context.Context) (results []DiscoverAllResult, succeeded, failed, totalDiscovered int, err error) {
+//
+// recordMisses gates the confirmation-probe + miss-recording layer. It must be
+// false on any caller that runs under an HTTP request deadline (the manual
+// "Discover All" button and the HA config-sync import), because the probes can
+// sleep for the full backoff (~70s) and overrun the 60s route timeout, writing
+// the response to a dead connection and making a config sync look like it
+// failed. A single on-demand scan can never disable a model anyway (that needs
+// MissingScanThreshold consecutive confirmed scans), so the scheduled/background
+// sweep is the only path that records misses.
+func (h *Handler) discoverAllProviders(ctx context.Context, recordMisses bool) (results []DiscoverAllResult, succeeded, failed, totalDiscovered int, err error) {
 	providers, err := h.providerRepo.List(ctx)
 	if err != nil {
 		return nil, 0, 0, 0, err
@@ -967,9 +1053,11 @@ func (h *Handler) discoverAllProviders(ctx context.Context) (results []DiscoverA
 		// failed (a DB error must not count a listed model as missing), or when
 		// the confirmation probes flag the scan as suspect. Disabling happens
 		// only after MissingScanThreshold consecutive confirmed-missing scans.
+		// recordMisses is false on request-bound callers so the ~70s probe
+		// backoff never overruns their HTTP timeout (see the doc comment).
 		var disabledRefs []model.DisabledModelRef
-		if snapErr == nil && !upsertFailed {
-			confirmedIDs, suspect := ConfirmMissingModels(provCtx, discovery, prov, h.cfg.MasterKey, existingModelIDs, snapshot)
+		if recordMisses && snapErr == nil && !upsertFailed {
+			confirmedIDs, suspect := ConfirmMissingModels(provCtx, discovery, prov, h.cfg.MasterKey, existingModelIDs, snapshot, NewSuspectStreak(h.dbPool.Pool()))
 			if suspect {
 				debuglog.Warn("discovery: suspect scan, skipping missing-model recording", "provider", prov.Name, "provider_id", prov.ID)
 			} else {

--- a/internal/api/discovery.go
+++ b/internal/api/discovery.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"math/rand/v2"
 	"net/http"
 	"time"
 
@@ -35,8 +36,11 @@ var (
 	dbExec          = func(pool *pgxpool.Pool, ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
 		return pool.Exec(ctx, sql, args...)
 	}
-	modelRepoDisableMissing = func(repo *model.Repository, ctx context.Context, providerID uuid.UUID, providerName string, modelIDs []string) ([]model.DisabledModelRef, error) {
-		return repo.DisableMissingModels(ctx, providerID, providerName, modelIDs)
+	modelRepoRecordMissing = func(repo *model.Repository, ctx context.Context, providerID uuid.UUID, providerName string, modelIDs []string) (disabled, pending []model.DisabledModelRef, err error) {
+		return repo.RecordMissingModels(ctx, providerID, providerName, modelIDs)
+	}
+	discoverModelsForConfirm = func(ctx context.Context, svc *provider.DiscoveryService, prov *provider.Provider, masterKey string) ([]*model.Model, error) {
+		return svc.DiscoverModels(ctx, prov, masterKey)
 	}
 	failoverRepoSyncForModel = func(repo *failover.Repository, ctx context.Context, modelID string) (*failover.SyncResult, error) {
 		return repo.SyncForModel(ctx, modelID)
@@ -242,6 +246,125 @@ func BuildDiscoveryDiff(snapshot map[string]ModelSnapshot, upserted []*model.Mod
 		diff.Disabled = append(diff.Disabled, ModelChange{ModelID: ref.ModelID, Reason: changeReasonNotListed})
 	}
 	return diff
+}
+
+// Confirmation-probe schedule for ConfirmMissingModels: a model absent from
+// the initial listing is only counted missing after these many extra listings,
+// each preceded by the given delay (plus up to confirmProbeJitter of random
+// jitter so fleet members and parallel providers don't probe in lockstep).
+// Injectable so tests can zero the delays.
+var confirmProbeDelays = []time.Duration{15 * time.Second, 45 * time.Second}
+
+const confirmProbeJitter = 5 * time.Second
+
+// suspectMissingFloor and suspectMissingRatio form the mass-vanish guard: a
+// scan whose confirmed-missing set exceeds the floor AND the ratio of the
+// provider's enabled models is treated as a broken listing, not a real
+// removal, and records no misses. False-disabling dozens of models (which HA
+// then propagates fleet-wide) is far worse than keeping a stale model enabled
+// until an operator looks at the warning event.
+const (
+	suspectMissingFloor = 5
+	suspectMissingRatio = 0.5
+)
+
+// confirmProbeSleep waits for the probe backoff, honouring ctx cancellation.
+// Injectable for tests (which also exercise sleepWithContext directly).
+var confirmProbeSleep = sleepWithContext
+
+func sleepWithContext(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(d):
+		return nil
+	}
+}
+
+// ConfirmMissingModels gives absent models a second opinion before any miss is
+// recorded. presentIDs is the initial listing's membership; every snapshot
+// model that is enabled but unlisted triggers up to len(confirmProbeDelays)
+// fresh listings with backoff, and the union of all probes' model IDs is
+// returned as the confirmed membership. suspect=true means this scan's
+// membership cannot be trusted (a confirmation probe failed, ctx was
+// cancelled, or the mass-vanish guard tripped) and the caller must skip miss
+// recording entirely. Probes affect membership only; metadata still comes
+// exclusively from the initial listing's upserts.
+func ConfirmMissingModels(ctx context.Context, svc *provider.DiscoveryService, prov *provider.Provider, masterKey string, presentIDs []string, snapshot map[string]ModelSnapshot) (confirmedPresent []string, suspect bool) {
+	present := make(map[string]bool, len(presentIDs))
+	for _, id := range presentIDs {
+		present[id] = true
+	}
+	countMissing := func() int {
+		n := 0
+		for id, snap := range snapshot {
+			if snap.enabled && !present[id] {
+				n++
+			}
+		}
+		return n
+	}
+
+	confirmedPresent = presentIDs
+	missing := countMissing()
+	if missing == 0 {
+		return confirmedPresent, false
+	}
+
+	for probe, delay := range confirmProbeDelays {
+		//nolint:gosec // jitter, not crypto
+		wait := delay + time.Duration(rand.Int64N(int64(confirmProbeJitter)))
+		debuglog.Info("discovery: models absent from listing, running confirmation probe",
+			"provider", prov.Name, "provider_id", prov.ID, "missing", missing,
+			"probe", probe+1, "max_probes", len(confirmProbeDelays), "delay", wait)
+		if err := confirmProbeSleep(ctx, wait); err != nil {
+			return confirmedPresent, true
+		}
+		models, err := discoverModelsForConfirm(ctx, svc, prov, masterKey)
+		if err != nil {
+			// The provider answered the initial listing but not the probe: the
+			// upstream is flapping, so this scan's membership proves nothing.
+			debuglog.Warn("discovery: confirmation probe failed, treating scan as suspect",
+				"provider", prov.Name, "provider_id", prov.ID, "probe", probe+1, "error", err)
+			return confirmedPresent, true
+		}
+		for _, m := range models {
+			if !present[m.ModelID] {
+				present[m.ModelID] = true
+				confirmedPresent = append(confirmedPresent, m.ModelID)
+			}
+		}
+		missing = countMissing()
+		if missing == 0 {
+			debuglog.Info("discovery: confirmation probe found all absent models, no misses recorded",
+				"provider", prov.Name, "provider_id", prov.ID, "probe", probe+1)
+			return confirmedPresent, false
+		}
+	}
+
+	enabledCount := 0
+	for _, snap := range snapshot {
+		if snap.enabled {
+			enabledCount++
+		}
+	}
+	if missing > suspectMissingFloor && float64(missing) > suspectMissingRatio*float64(enabledCount) {
+		debuglog.Warn("discovery: mass-vanish guard tripped, treating scan as suspect",
+			"provider", prov.Name, "provider_id", prov.ID, "missing", missing, "enabled", enabledCount)
+		events.Publish(events.Event{
+			Type:     "discovery.suspect_scan",
+			Severity: "warning",
+			Source:   "discovery",
+			Message:  fmt.Sprintf("Discovery scan for %s is missing %d of %d enabled models even after confirmation probes; treating the listing as broken and disabling nothing", prov.Name, missing, enabledCount),
+			Metadata: map[string]interface{}{"provider": prov.Name, "provider_id": prov.ID, "missing": missing, "enabled": enabledCount},
+		})
+		return confirmedPresent, true
+	}
+
+	return confirmedPresent, false
 }
 
 // diffModelFields compares the pricing/context fields of an existing model's
@@ -520,10 +643,24 @@ func (h *Handler) DiscoverProviderModels(w http.ResponseWriter, r *http.Request)
 		upsertedModels = append(upsertedModels, m)
 	}
 
-	disabledRefs, err := modelRepoDisableMissing(modelRepo, provCtx, providerID, prov.Name, existingModelIDs)
-	if err != nil {
-		respondError(w, fmt.Sprintf("failed to disable missing models for provider %s", prov.Name), err, http.StatusInternalServerError)
-		return
+	// Second opinion before any model is counted missing: re-probe the listing
+	// with backoff, and only feed confirmed membership into the miss recorder.
+	// A model is disabled only after MissingScanThreshold consecutive scans
+	// confirm it missing, so one flaky scan can never disable anything.
+	confirmedIDs, suspect := ConfirmMissingModels(provCtx, discovery, prov, h.cfg.MasterKey, existingModelIDs, snapshot)
+	var disabledRefs, pendingRefs []model.DisabledModelRef
+	if suspect {
+		debuglog.Warn("discovery: suspect scan, skipping missing-model recording", "provider", prov.Name, "provider_id", providerID)
+	} else {
+		disabledRefs, pendingRefs, err = modelRepoRecordMissing(modelRepo, provCtx, providerID, prov.Name, confirmedIDs)
+		if err != nil {
+			respondError(w, fmt.Sprintf("failed to record missing models for provider %s", prov.Name), err, http.StatusInternalServerError)
+			return
+		}
+	}
+	if len(pendingRefs) > 0 {
+		debuglog.Info("discovery: models confirmed missing but below disable threshold",
+			"provider", prov.Name, "provider_id", providerID, "pending", len(pendingRefs), "threshold", model.MissingScanThreshold)
 	}
 
 	diff := BuildDiscoveryDiff(snapshot, upsertedModels, disabledRefs)
@@ -814,18 +951,38 @@ func (h *Handler) discoverAllProviders(ctx context.Context) (results []DiscoverA
 
 		existingModelIDs := make([]string, 0, len(models))
 		upsertedModels := make([]*model.Model, 0, len(models))
+		upsertFailed := false
 		for _, m := range models {
 			if err := modelRepo.Upsert(provCtx, m); err != nil {
 				debuglog.Warn("discovery: failed to upsert model", "model", m.ModelID, "provider", prov.Name, "error", err)
+				upsertFailed = true
 				continue
 			}
 			existingModelIDs = append(existingModelIDs, m.ModelID)
 			upsertedModels = append(upsertedModels, m)
 		}
 
-		disabledRefs, err := modelRepoDisableMissing(modelRepo, provCtx, prov.ID, prov.Name, existingModelIDs)
-		if err != nil {
-			debuglog.Debug("discovery: failed to disable missing models", "provider", prov.Name, "error", err)
+		// Miss recording needs a trustworthy membership picture: skip it when a
+		// snapshot is unavailable (cannot confirm absentees), when any upsert
+		// failed (a DB error must not count a listed model as missing), or when
+		// the confirmation probes flag the scan as suspect. Disabling happens
+		// only after MissingScanThreshold consecutive confirmed-missing scans.
+		var disabledRefs []model.DisabledModelRef
+		if snapErr == nil && !upsertFailed {
+			confirmedIDs, suspect := ConfirmMissingModels(provCtx, discovery, prov, h.cfg.MasterKey, existingModelIDs, snapshot)
+			if suspect {
+				debuglog.Warn("discovery: suspect scan, skipping missing-model recording", "provider", prov.Name, "provider_id", prov.ID)
+			} else {
+				var pendingRefs []model.DisabledModelRef
+				disabledRefs, pendingRefs, err = modelRepoRecordMissing(modelRepo, provCtx, prov.ID, prov.Name, confirmedIDs)
+				if err != nil {
+					debuglog.Debug("discovery: failed to record missing models", "provider", prov.Name, "error", err)
+				}
+				if len(pendingRefs) > 0 {
+					debuglog.Info("discovery: models confirmed missing but below disable threshold",
+						"provider", prov.Name, "provider_id", prov.ID, "pending", len(pendingRefs), "threshold", model.MissingScanThreshold)
+				}
+			}
 		}
 
 		// Without the before-snapshot the diff cannot be classified; the scan

--- a/internal/api/discovery_confirm_test.go
+++ b/internal/api/discovery_confirm_test.go
@@ -1,0 +1,216 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/hugalafutro/model-hotel/internal/model"
+	"github.com/hugalafutro/model-hotel/internal/provider"
+)
+
+// ---------------------------------------------------------------------------
+// ConfirmMissingModels — pure unit tests (no DB, no HTTP): the probe listing
+// is injected via discoverModelsForConfirm and delays are zeroed in TestMain.
+// ---------------------------------------------------------------------------
+
+func confirmTestProvider() *provider.Provider {
+	return &provider.Provider{ID: uuid.New(), Name: "confirm-test"}
+}
+
+func confirmTestSnapshot(enabled ...string) map[string]ModelSnapshot {
+	snap := make(map[string]ModelSnapshot, len(enabled))
+	for _, id := range enabled {
+		snap[id] = ModelSnapshot{enabled: true}
+	}
+	return snap
+}
+
+func modelsForIDs(ids ...string) []*model.Model {
+	out := make([]*model.Model, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, &model.Model{ModelID: id})
+	}
+	return out
+}
+
+// overrideConfirmDiscover replaces the probe listing for one test and restores
+// it afterwards. Each call to the probe returns the next listing in sequence
+// (the last one repeats); errs mark probe calls that fail instead.
+func overrideConfirmDiscover(t *testing.T, listings [][]*model.Model, errs []error) *int {
+	t.Helper()
+	orig := discoverModelsForConfirm
+	t.Cleanup(func() { discoverModelsForConfirm = orig })
+	calls := 0
+	discoverModelsForConfirm = func(ctx context.Context, svc *provider.DiscoveryService, prov *provider.Provider, masterKey string) ([]*model.Model, error) {
+		idx := calls
+		calls++
+		if idx < len(errs) && errs[idx] != nil {
+			return nil, errs[idx]
+		}
+		if len(listings) == 0 {
+			return nil, nil
+		}
+		if idx >= len(listings) {
+			idx = len(listings) - 1
+		}
+		return listings[idx], nil
+	}
+	return &calls
+}
+
+func TestConfirmMissingModels_NothingMissing_NoProbes(t *testing.T) {
+	calls := overrideConfirmDiscover(t, nil, nil)
+
+	present := []string{"m1", "m2"}
+	confirmed, suspect := ConfirmMissingModels(context.Background(), nil, confirmTestProvider(), "", present, confirmTestSnapshot("m1", "m2"))
+	if suspect {
+		t.Fatal("expected suspect=false")
+	}
+	if len(confirmed) != 2 {
+		t.Fatalf("expected confirmed membership unchanged, got %v", confirmed)
+	}
+	if *calls != 0 {
+		t.Fatalf("expected no probe calls, got %d", *calls)
+	}
+}
+
+func TestConfirmMissingModels_DisabledSnapshotModelIgnored(t *testing.T) {
+	calls := overrideConfirmDiscover(t, nil, nil)
+
+	snapshot := confirmTestSnapshot("m1")
+	snapshot["already-off"] = ModelSnapshot{enabled: false}
+	_, suspect := ConfirmMissingModels(context.Background(), nil, confirmTestProvider(), "", []string{"m1"}, snapshot)
+	if suspect || *calls != 0 {
+		t.Fatalf("disabled snapshot model must not trigger probes: suspect=%v calls=%d", suspect, *calls)
+	}
+}
+
+func TestConfirmMissingModels_ReappearsOnProbe(t *testing.T) {
+	// Initial listing dropped m2; the first probe lists it again.
+	calls := overrideConfirmDiscover(t, [][]*model.Model{modelsForIDs("m1", "m2")}, nil)
+
+	confirmed, suspect := ConfirmMissingModels(context.Background(), nil, confirmTestProvider(), "", []string{"m1"}, confirmTestSnapshot("m1", "m2"))
+	if suspect {
+		t.Fatal("expected suspect=false")
+	}
+	if *calls != 1 {
+		t.Fatalf("expected exactly 1 probe (stop early once nothing is missing), got %d", *calls)
+	}
+	found := map[string]bool{}
+	for _, id := range confirmed {
+		found[id] = true
+	}
+	if !found["m1"] || !found["m2"] {
+		t.Fatalf("expected m2 restored to confirmed membership, got %v", confirmed)
+	}
+}
+
+func TestConfirmMissingModels_ReappearsOnSecondProbe(t *testing.T) {
+	calls := overrideConfirmDiscover(t, [][]*model.Model{
+		modelsForIDs("m1"),
+		modelsForIDs("m1", "m2"),
+	}, nil)
+
+	confirmed, suspect := ConfirmMissingModels(context.Background(), nil, confirmTestProvider(), "", []string{"m1"}, confirmTestSnapshot("m1", "m2"))
+	if suspect {
+		t.Fatal("expected suspect=false")
+	}
+	if *calls != 2 {
+		t.Fatalf("expected 2 probes, got %d", *calls)
+	}
+	found := map[string]bool{}
+	for _, id := range confirmed {
+		found[id] = true
+	}
+	if !found["m2"] {
+		t.Fatalf("expected m2 restored on second probe, got %v", confirmed)
+	}
+}
+
+func TestConfirmMissingModels_ConfirmedMissingAfterAllProbes(t *testing.T) {
+	calls := overrideConfirmDiscover(t, [][]*model.Model{modelsForIDs("m1")}, nil)
+
+	confirmed, suspect := ConfirmMissingModels(context.Background(), nil, confirmTestProvider(), "", []string{"m1"}, confirmTestSnapshot("m1", "m2"))
+	if suspect {
+		t.Fatal("expected suspect=false: a single confirmed-missing model is a legitimate miss")
+	}
+	if *calls != len(confirmProbeDelays) {
+		t.Fatalf("expected %d probes, got %d", len(confirmProbeDelays), *calls)
+	}
+	for _, id := range confirmed {
+		if id == "m2" {
+			t.Fatalf("m2 must not be in confirmed membership, got %v", confirmed)
+		}
+	}
+}
+
+func TestConfirmMissingModels_ProbeErrorMarksSuspect(t *testing.T) {
+	overrideConfirmDiscover(t, nil, []error{errors.New("dns flake")})
+
+	_, suspect := ConfirmMissingModels(context.Background(), nil, confirmTestProvider(), "", []string{"m1"}, confirmTestSnapshot("m1", "m2"))
+	if !suspect {
+		t.Fatal("expected suspect=true when a confirmation probe fails")
+	}
+}
+
+func TestConfirmMissingModels_CancelledContextMarksSuspect(t *testing.T) {
+	origSleep := confirmProbeSleep
+	t.Cleanup(func() { confirmProbeSleep = origSleep })
+	confirmProbeSleep = func(ctx context.Context, d time.Duration) error { return context.Canceled }
+
+	calls := overrideConfirmDiscover(t, [][]*model.Model{modelsForIDs("m1", "m2")}, nil)
+
+	_, suspect := ConfirmMissingModels(context.Background(), nil, confirmTestProvider(), "", []string{"m1"}, confirmTestSnapshot("m1", "m2"))
+	if !suspect {
+		t.Fatal("expected suspect=true on cancelled backoff")
+	}
+	if *calls != 0 {
+		t.Fatalf("expected no probe after cancelled backoff, got %d", *calls)
+	}
+}
+
+func TestConfirmMissingModels_MassVanishGuard(t *testing.T) {
+	// 10 enabled models, listing only returns 2: 8 missing is > floor(5) and
+	// > 50% of enabled, so the scan is suspect and records nothing.
+	enabled := make([]string, 10)
+	for i := range enabled {
+		enabled[i] = fmt.Sprintf("m%d", i)
+	}
+	overrideConfirmDiscover(t, [][]*model.Model{modelsForIDs("m0", "m1")}, nil)
+
+	_, suspect := ConfirmMissingModels(context.Background(), nil, confirmTestProvider(), "", []string{"m0", "m1"}, confirmTestSnapshot(enabled...))
+	if !suspect {
+		t.Fatal("expected suspect=true from mass-vanish guard")
+	}
+}
+
+func TestSleepWithContext(t *testing.T) {
+	if err := sleepWithContext(context.Background(), 0); err != nil {
+		t.Errorf("zero delay: expected nil, got %v", err)
+	}
+	if err := sleepWithContext(context.Background(), time.Millisecond); err != nil {
+		t.Errorf("short sleep: expected nil, got %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := sleepWithContext(ctx, time.Hour); !errors.Is(err, context.Canceled) {
+		t.Errorf("cancelled ctx: expected context.Canceled, got %v", err)
+	}
+}
+
+func TestConfirmMissingModels_SmallMissBelowFloorNotSuspect(t *testing.T) {
+	// 4 of 6 missing is >50% but at/below the absolute floor of 5, so it is a
+	// legitimate (confirmable) miss, not a suspect scan.
+	overrideConfirmDiscover(t, [][]*model.Model{modelsForIDs("m0", "m1")}, nil)
+
+	_, suspect := ConfirmMissingModels(context.Background(), nil, confirmTestProvider(), "", []string{"m0", "m1"},
+		confirmTestSnapshot("m0", "m1", "m2", "m3", "m4", "m5"))
+	if suspect {
+		t.Fatal("expected suspect=false below the mass-vanish floor")
+	}
+}

--- a/internal/api/discovery_confirm_test.go
+++ b/internal/api/discovery_confirm_test.go
@@ -67,7 +67,7 @@ func TestConfirmMissingModels_NothingMissing_NoProbes(t *testing.T) {
 	calls := overrideConfirmDiscover(t, nil, nil)
 
 	present := []string{"m1", "m2"}
-	confirmed, suspect := ConfirmMissingModels(context.Background(), nil, confirmTestProvider(), "", present, confirmTestSnapshot("m1", "m2"))
+	confirmed, suspect := ConfirmMissingModels(context.Background(), nil, confirmTestProvider(), "", present, confirmTestSnapshot("m1", "m2"), nil)
 	if suspect {
 		t.Fatal("expected suspect=false")
 	}
@@ -84,7 +84,7 @@ func TestConfirmMissingModels_DisabledSnapshotModelIgnored(t *testing.T) {
 
 	snapshot := confirmTestSnapshot("m1")
 	snapshot["already-off"] = ModelSnapshot{enabled: false}
-	_, suspect := ConfirmMissingModels(context.Background(), nil, confirmTestProvider(), "", []string{"m1"}, snapshot)
+	_, suspect := ConfirmMissingModels(context.Background(), nil, confirmTestProvider(), "", []string{"m1"}, snapshot, nil)
 	if suspect || *calls != 0 {
 		t.Fatalf("disabled snapshot model must not trigger probes: suspect=%v calls=%d", suspect, *calls)
 	}
@@ -94,7 +94,7 @@ func TestConfirmMissingModels_ReappearsOnProbe(t *testing.T) {
 	// Initial listing dropped m2; the first probe lists it again.
 	calls := overrideConfirmDiscover(t, [][]*model.Model{modelsForIDs("m1", "m2")}, nil)
 
-	confirmed, suspect := ConfirmMissingModels(context.Background(), nil, confirmTestProvider(), "", []string{"m1"}, confirmTestSnapshot("m1", "m2"))
+	confirmed, suspect := ConfirmMissingModels(context.Background(), nil, confirmTestProvider(), "", []string{"m1"}, confirmTestSnapshot("m1", "m2"), nil)
 	if suspect {
 		t.Fatal("expected suspect=false")
 	}
@@ -116,7 +116,7 @@ func TestConfirmMissingModels_ReappearsOnSecondProbe(t *testing.T) {
 		modelsForIDs("m1", "m2"),
 	}, nil)
 
-	confirmed, suspect := ConfirmMissingModels(context.Background(), nil, confirmTestProvider(), "", []string{"m1"}, confirmTestSnapshot("m1", "m2"))
+	confirmed, suspect := ConfirmMissingModels(context.Background(), nil, confirmTestProvider(), "", []string{"m1"}, confirmTestSnapshot("m1", "m2"), nil)
 	if suspect {
 		t.Fatal("expected suspect=false")
 	}
@@ -135,7 +135,7 @@ func TestConfirmMissingModels_ReappearsOnSecondProbe(t *testing.T) {
 func TestConfirmMissingModels_ConfirmedMissingAfterAllProbes(t *testing.T) {
 	calls := overrideConfirmDiscover(t, [][]*model.Model{modelsForIDs("m1")}, nil)
 
-	confirmed, suspect := ConfirmMissingModels(context.Background(), nil, confirmTestProvider(), "", []string{"m1"}, confirmTestSnapshot("m1", "m2"))
+	confirmed, suspect := ConfirmMissingModels(context.Background(), nil, confirmTestProvider(), "", []string{"m1"}, confirmTestSnapshot("m1", "m2"), nil)
 	if suspect {
 		t.Fatal("expected suspect=false: a single confirmed-missing model is a legitimate miss")
 	}
@@ -152,7 +152,7 @@ func TestConfirmMissingModels_ConfirmedMissingAfterAllProbes(t *testing.T) {
 func TestConfirmMissingModels_ProbeErrorMarksSuspect(t *testing.T) {
 	overrideConfirmDiscover(t, nil, []error{errors.New("dns flake")})
 
-	_, suspect := ConfirmMissingModels(context.Background(), nil, confirmTestProvider(), "", []string{"m1"}, confirmTestSnapshot("m1", "m2"))
+	_, suspect := ConfirmMissingModels(context.Background(), nil, confirmTestProvider(), "", []string{"m1"}, confirmTestSnapshot("m1", "m2"), nil)
 	if !suspect {
 		t.Fatal("expected suspect=true when a confirmation probe fails")
 	}
@@ -165,7 +165,7 @@ func TestConfirmMissingModels_CancelledContextMarksSuspect(t *testing.T) {
 
 	calls := overrideConfirmDiscover(t, [][]*model.Model{modelsForIDs("m1", "m2")}, nil)
 
-	_, suspect := ConfirmMissingModels(context.Background(), nil, confirmTestProvider(), "", []string{"m1"}, confirmTestSnapshot("m1", "m2"))
+	_, suspect := ConfirmMissingModels(context.Background(), nil, confirmTestProvider(), "", []string{"m1"}, confirmTestSnapshot("m1", "m2"), nil)
 	if !suspect {
 		t.Fatal("expected suspect=true on cancelled backoff")
 	}
@@ -183,9 +183,48 @@ func TestConfirmMissingModels_MassVanishGuard(t *testing.T) {
 	}
 	overrideConfirmDiscover(t, [][]*model.Model{modelsForIDs("m0", "m1")}, nil)
 
-	_, suspect := ConfirmMissingModels(context.Background(), nil, confirmTestProvider(), "", []string{"m0", "m1"}, confirmTestSnapshot(enabled...))
+	_, suspect := ConfirmMissingModels(context.Background(), nil, confirmTestProvider(), "", []string{"m0", "m1"}, confirmTestSnapshot(enabled...), nil)
 	if !suspect {
 		t.Fatal("expected suspect=true from mass-vanish guard")
+	}
+}
+
+func TestConfirmMissingModels_MassVanishFloorBoundary(t *testing.T) {
+	enabled := make([]string, 10)
+	for i := range enabled {
+		enabled[i] = fmt.Sprintf("m%d", i)
+	}
+
+	// Exactly at the floor: 5 of 10 missing. The guard uses a strict `>` on both
+	// the floor (5 > 5 is false) and the ratio (5 > 5.0 is false), so this must
+	// NOT trip: it is a confirmable miss, not a suspect scan.
+	present5 := []string{"m0", "m1", "m2", "m3", "m4"}
+	overrideConfirmDiscover(t, [][]*model.Model{modelsForIDs(present5...)}, nil)
+	if _, suspect := ConfirmMissingModels(context.Background(), nil, confirmTestProvider(), "", present5, confirmTestSnapshot(enabled...), nil); suspect {
+		t.Fatal("5 of 10 missing sits exactly on the floor; expected suspect=false")
+	}
+
+	// One past the floor: 6 of 10 missing clears both `>` checks and trips.
+	present4 := []string{"m0", "m1", "m2", "m3"}
+	overrideConfirmDiscover(t, [][]*model.Model{modelsForIDs(present4...)}, nil)
+	if _, suspect := ConfirmMissingModels(context.Background(), nil, confirmTestProvider(), "", present4, confirmTestSnapshot(enabled...), nil); !suspect {
+		t.Fatal("6 of 10 missing clears the floor; expected suspect=true")
+	}
+}
+
+func TestShouldEscalateSuspect(t *testing.T) {
+	// Fires on the crossing scan and once every threshold thereafter; silent
+	// below the threshold and between multiples.
+	cases := map[int]bool{
+		0: false, 1: false, 2: false,
+		3: true, 4: false, 5: false,
+		6: true, 7: false,
+		9: true,
+	}
+	for streak, want := range cases {
+		if got := shouldEscalateSuspect(streak); got != want {
+			t.Errorf("shouldEscalateSuspect(%d) = %v, want %v", streak, got, want)
+		}
 	}
 }
 
@@ -209,7 +248,7 @@ func TestConfirmMissingModels_SmallMissBelowFloorNotSuspect(t *testing.T) {
 	overrideConfirmDiscover(t, [][]*model.Model{modelsForIDs("m0", "m1")}, nil)
 
 	_, suspect := ConfirmMissingModels(context.Background(), nil, confirmTestProvider(), "", []string{"m0", "m1"},
-		confirmTestSnapshot("m0", "m1", "m2", "m3", "m4", "m5"))
+		confirmTestSnapshot("m0", "m1", "m2", "m3", "m4", "m5"), nil)
 	if suspect {
 		t.Fatal("expected suspect=false below the mass-vanish floor")
 	}

--- a/internal/api/discovery_confirm_test.go
+++ b/internal/api/discovery_confirm_test.go
@@ -212,6 +212,38 @@ func TestConfirmMissingModels_MassVanishFloorBoundary(t *testing.T) {
 	}
 }
 
+func TestConfirmMissingModels_TotalBlackoutBelowFloorIsSuspect(t *testing.T) {
+	// A small provider (3 enabled) whose initial listing and every probe return
+	// nothing at all. 3 missing sits at/below the floor of 5, so the mass-vanish
+	// floor+ratio guard would leave it suspect=false and RecordMissingModels's
+	// empty-list no-op would then silently keep every stale model enabled. The
+	// total-blackout branch must catch it instead: disable nothing, but mark the
+	// scan suspect so it escalates for an operator.
+	overrideConfirmDiscover(t, nil, nil) // every probe returns an empty listing
+
+	confirmed, suspect := ConfirmMissingModels(context.Background(), nil, confirmTestProvider(), "", nil,
+		confirmTestSnapshot("m0", "m1", "m2"), nil)
+	if !suspect {
+		t.Fatal("total blackout on a small provider must be suspect, not a silent no-op")
+	}
+	if len(confirmed) != 0 {
+		t.Fatalf("expected empty confirmed membership, got %v", confirmed)
+	}
+}
+
+func TestConfirmMissingModels_NoEnabledModelsNotSuspect(t *testing.T) {
+	// Empty present list AND no enabled models (e.g. a brand-new provider with an
+	// empty listing): nothing is missing, so this is not a blackout and must not
+	// be flagged suspect.
+	overrideConfirmDiscover(t, nil, nil)
+
+	_, suspect := ConfirmMissingModels(context.Background(), nil, confirmTestProvider(), "", nil,
+		confirmTestSnapshot(), nil)
+	if suspect {
+		t.Fatal("no enabled models means nothing missing; expected suspect=false")
+	}
+}
+
 func TestShouldEscalateSuspect(t *testing.T) {
 	// Fires on the crossing scan and once every threshold thereafter; silent
 	// below the threshold and between multiples.

--- a/internal/api/discovery_diff_test.go
+++ b/internal/api/discovery_diff_test.go
@@ -368,6 +368,21 @@ func TestDiscoverProviderModels_RenameScenario(t *testing.T) {
 	}))
 	defer mockServer.Close()
 
+	// Providers 2 and 3 serve model B unconditionally so its failover group
+	// survives provider 1's rename with two members. They are pointed at this
+	// mock (not api.example.com) because the scan now runs through
+	// discoverAllProviders, which lists every enabled provider.
+	mockB := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.URL.Path != "/v1/models" {
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": []map[string]interface{}{{"id": "rename-model-b", "owned_by": "test", "object": "model"}},
+		})
+	}))
+	defer mockB.Close()
+
 	// Provider 1 is the one being rediscovered.
 	providerData := fmt.Sprintf(`{"name":"rename-scenario-p1","base_url":"%s/v1","api_key":"sk-test"}`, mockServer.URL)
 	req := httptest.NewRequest(http.MethodPost, "/providers", strings.NewReader(providerData))
@@ -389,7 +404,7 @@ func TestDiscoverProviderModels_RenameScenario(t *testing.T) {
 	// provider 1's rename with two members (updated, not deleted).
 	for i, name := range []string{"rename-scenario-p2", "rename-scenario-p3"} {
 		req = httptest.NewRequest(http.MethodPost, "/providers",
-			strings.NewReader(fmt.Sprintf(`{"name":"%s","base_url":"https://api.example.com/v1","api_key":"sk-test"}`, name)))
+			strings.NewReader(fmt.Sprintf(`{"name":"%s","base_url":"%s/v1","api_key":"sk-test"}`, name, mockB.URL)))
 		req.Header.Set("Authorization", "Bearer test-admin-token")
 		req.Header.Set("Content-Type", "application/json")
 		w = httptest.NewRecorder()
@@ -412,16 +427,23 @@ func TestDiscoverProviderModels_RenameScenario(t *testing.T) {
 	}
 	model.InvalidateModelCache()
 
-	discover := func() *httptest.ResponseRecorder {
+	// Miss-recording and disabling live on the background sweep, not the
+	// interactive handler, so drive the real disabling path directly. Providers
+	// 2 and 3 keep serving B, so scanning all three leaves B's group intact
+	// while provider 1's rename is reconciled.
+	discover := func() *DiscoveryDiff {
 		t.Helper()
-		req := httptest.NewRequest(http.MethodPost, "/providers/"+provider1.ID+"/discover", http.NoBody)
-		req.Header.Set("Authorization", "Bearer test-admin-token")
-		w := httptest.NewRecorder()
-		r.ServeHTTP(w, req)
-		if w.Code != http.StatusOK {
-			t.Fatalf("discover: expected 200, got %d: %s", w.Code, w.Body.String())
+		results, _, _, _, err := h.discoverAllProviders(ctx, true)
+		if err != nil {
+			t.Fatalf("discoverAllProviders: %v", err)
 		}
-		return w
+		for i := range results {
+			if results[i].ProviderName == "rename-scenario-p1" {
+				return results[i].Diff
+			}
+		}
+		t.Fatalf("no diff for rename-scenario-p1 in results %+v", results)
+		return nil
 	}
 
 	// First scan: provider 1 lists A and B; the model-b group forms with 3 members.
@@ -450,37 +472,26 @@ func TestDiscoverProviderModels_RenameScenario(t *testing.T) {
 	listingMu.Lock()
 	listing = []string{"rename-model-a", "rename-model-c"}
 	listingMu.Unlock()
-	w = discover()
+	diff := discover()
 
-	var resp struct {
-		Diff DiscoveryDiff `json:"diff"`
+	if len(diff.Added) != 1 || diff.Added[0].ModelID != "rename-model-c" || diff.Added[0].Reason != changeReasonNewModel {
+		t.Errorf("expected added=[rename-model-c/new_model], got %+v", diff.Added)
 	}
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode discover response: %v", err)
-	}
-
-	if len(resp.Diff.Added) != 1 || resp.Diff.Added[0].ModelID != "rename-model-c" || resp.Diff.Added[0].Reason != changeReasonNewModel {
-		t.Errorf("expected added=[rename-model-c/new_model], got %+v", resp.Diff.Added)
-	}
-	if len(resp.Diff.Disabled) != 0 {
-		t.Errorf("expected no disabled models on the first missing scan, got %+v", resp.Diff.Disabled)
+	if len(diff.Disabled) != 0 {
+		t.Errorf("expected no disabled models on the first missing scan, got %+v", diff.Disabled)
 	}
 
 	// Third scan: B misses a second consecutive time and is now disabled.
-	w = discover()
-	resp.Diff = DiscoveryDiff{}
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode discover response: %v", err)
-	}
+	diff = discover()
 
-	if len(resp.Diff.Disabled) != 1 || resp.Diff.Disabled[0].ModelID != "rename-model-b" || resp.Diff.Disabled[0].Reason != changeReasonNotListed {
-		t.Errorf("expected disabled=[rename-model-b/not_listed], got %+v", resp.Diff.Disabled)
+	if len(diff.Disabled) != 1 || diff.Disabled[0].ModelID != "rename-model-b" || diff.Disabled[0].Reason != changeReasonNotListed {
+		t.Errorf("expected disabled=[rename-model-b/not_listed], got %+v", diff.Disabled)
 	}
-	if len(resp.Diff.Reenabled) != 0 {
-		t.Errorf("expected no reenabled models, got %+v", resp.Diff.Reenabled)
+	if len(diff.Reenabled) != 0 {
+		t.Errorf("expected no reenabled models, got %+v", diff.Reenabled)
 	}
 	foundUpdate := false
-	for _, ug := range resp.Diff.FailoverUpdatedGroups {
+	for _, ug := range diff.FailoverUpdatedGroups {
 		if ug.DisplayModel == "rename-model-b" {
 			foundUpdate = true
 			if len(ug.RemovedModelIDs) != 1 || ug.RemovedModelIDs[0] != modelBUUID.String() {
@@ -489,7 +500,7 @@ func TestDiscoverProviderModels_RenameScenario(t *testing.T) {
 		}
 	}
 	if !foundUpdate {
-		t.Errorf("expected failover_updated_groups entry for rename-model-b, got %+v", resp.Diff.FailoverUpdatedGroups)
+		t.Errorf("expected failover_updated_groups entry for rename-model-b, got %+v", diff.FailoverUpdatedGroups)
 	}
 
 	// DB state: B disabled (not manually), C present, B's UUID pruned from the group.
@@ -526,8 +537,32 @@ func TestDiscoverProviderModels_RenameScenario(t *testing.T) {
 
 // TestDiscoverProviderModels_DisabledSyncError verifies that a failover sync
 // failure for a model that just left the listing fails the request.
-func TestDiscoverProviderModels_DisabledSyncError(t *testing.T) {
-	_, r := newTestHandlerWithRouter(t)
+// sweepProviderDiff runs the background discovery sweep (the only path that
+// records misses and disables models) and returns the diff for the named
+// provider. Miss-recording moved off the interactive handlers so their
+// confirmation-probe backoff cannot overrun the 60s route timeout, so tests of
+// disable/suspect behavior drive this seam directly.
+func sweepProviderDiff(t *testing.T, h *Handler, providerName string) *DiscoveryDiff {
+	t.Helper()
+	results, _, _, _, err := h.discoverAllProviders(context.Background(), true)
+	if err != nil {
+		t.Fatalf("discoverAllProviders: %v", err)
+	}
+	for i := range results {
+		if results[i].ProviderName == providerName {
+			return results[i].Diff
+		}
+	}
+	t.Fatalf("no result for provider %q in %+v", providerName, results)
+	return nil
+}
+
+// TestDiscoverSweep_DisabledModelSyncErrorTolerated verifies that when the
+// background sweep disables a model whose failover-group sync then fails, the
+// error is logged and skipped: the scan still completes and the disable is still
+// reported in the diff.
+func TestDiscoverSweep_DisabledModelSyncErrorTolerated(t *testing.T) {
+	h, r := newTestHandlerWithRouter(t)
 
 	var listingMu sync.Mutex
 	listing := []string{"dse-model-a", "dse-model-b"}
@@ -562,19 +597,10 @@ func TestDiscoverProviderModels_DisabledSyncError(t *testing.T) {
 		t.Fatalf("decode created provider: %v", err)
 	}
 
-	discover := func() *httptest.ResponseRecorder {
-		t.Helper()
-		req := httptest.NewRequest(http.MethodPost, "/providers/"+created.ID+"/discover", http.NoBody)
-		req.Header.Set("Authorization", "Bearer test-admin-token")
-		w := httptest.NewRecorder()
-		r.ServeHTTP(w, req)
-		return w
-	}
+	_ = created // provider is discovered via the sweep, not by ID
 
-	// First scan succeeds and imports both models.
-	if w := discover(); w.Code != http.StatusOK {
-		t.Fatalf("first discover: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	// First scan imports both models.
+	sweepProviderDiff(t, h, "disabled-sync-error-test")
 
 	// Fail the sync only for the model that leaves the listing, so the
 	// discovered-models sync loop passes and the disabled-refs loop errors.
@@ -591,27 +617,25 @@ func TestDiscoverProviderModels_DisabledSyncError(t *testing.T) {
 	listing = []string{"dse-model-a"}
 	listingMu.Unlock()
 
-	// First missing scan only records a pending miss (nothing disabled, so the
-	// disabled-refs sync loop is empty and the request succeeds).
-	if w := discover(); w.Code != http.StatusOK {
-		t.Fatalf("pending-miss discover: expected 200, got %d: %s", w.Code, w.Body.String())
+	// First missing scan only records a pending miss (nothing disabled yet).
+	if diff := sweepProviderDiff(t, h, "disabled-sync-error-test"); len(diff.Disabled) != 0 {
+		t.Errorf("first missing scan must not disable, got %+v", diff.Disabled)
 	}
 
-	// Second consecutive miss disables dse-model-b and hits the sync error.
-	w = discover()
-	if w.Code != http.StatusInternalServerError {
-		t.Errorf("expected status 500, got %d: %s", w.Code, w.Body.String())
-	}
-	if !strings.Contains(w.Body.String(), "failed to sync failover group for disabled model") {
-		t.Errorf("expected error about disabled-model sync, got %q", w.Body.String())
+	// Second consecutive miss disables dse-model-b and hits the sync error. The
+	// error is tolerated: the scan completes and still reports the disable.
+	diff := sweepProviderDiff(t, h, "disabled-sync-error-test")
+	if len(diff.Disabled) != 1 || diff.Disabled[0].ModelID != "dse-model-b" {
+		t.Errorf("expected dse-model-b disabled despite its sync error, got %+v", diff.Disabled)
 	}
 }
 
-// TestDiscoverProviderModels_RevalidationErrorIsBestEffort verifies that a
-// custom-group revalidation failure during a scan that disabled a model is
-// logged but does NOT abort the scan (unlike a per-model sync error).
-func TestDiscoverProviderModels_RevalidationErrorIsBestEffort(t *testing.T) {
-	_, r := newTestHandlerWithRouter(t)
+// TestDiscoverSweep_RevalidationErrorIsBestEffort verifies that a custom-group
+// revalidation failure during a sweep that disabled a model is logged but does
+// NOT abort the scan (unlike a per-model sync error, revalidation is
+// best-effort).
+func TestDiscoverSweep_RevalidationErrorIsBestEffort(t *testing.T) {
+	h, r := newTestHandlerWithRouter(t)
 
 	var listingMu sync.Mutex
 	listing := []string{"rev-model-a", "rev-model-b"}
@@ -646,18 +670,9 @@ func TestDiscoverProviderModels_RevalidationErrorIsBestEffort(t *testing.T) {
 		t.Fatalf("decode created provider: %v", err)
 	}
 
-	discover := func() *httptest.ResponseRecorder {
-		t.Helper()
-		req := httptest.NewRequest(http.MethodPost, "/providers/"+created.ID+"/discover", http.NoBody)
-		req.Header.Set("Authorization", "Bearer test-admin-token")
-		w := httptest.NewRecorder()
-		r.ServeHTTP(w, req)
-		return w
-	}
+	_ = created // discovered via the sweep, not by ID
 
-	if w := discover(); w.Code != http.StatusOK {
-		t.Fatalf("first discover: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	sweepProviderDiff(t, h, "revalidation-error-test")
 
 	// Force revalidation to error; dropping a model makes disabledRefs non-empty
 	// so the revalidation branch runs.
@@ -671,16 +686,20 @@ func TestDiscoverProviderModels_RevalidationErrorIsBestEffort(t *testing.T) {
 	listing = []string{"rev-model-a"}
 	listingMu.Unlock()
 
-	if w := discover(); w.Code != http.StatusOK {
-		t.Errorf("expected scan to survive a revalidation error (200), got %d: %s", w.Code, w.Body.String())
+	// First missing scan records a pending miss; the second disables rev-model-b,
+	// which makes disabledRefs non-empty and triggers the failing revalidation.
+	sweepProviderDiff(t, h, "revalidation-error-test")
+	diff := sweepProviderDiff(t, h, "revalidation-error-test")
+	if len(diff.Disabled) != 1 || diff.Disabled[0].ModelID != "rev-model-b" {
+		t.Errorf("expected rev-model-b disabled despite the revalidation error, got %+v", diff.Disabled)
 	}
 }
 
-// TestDiscoverAllModels_DisabledSyncError verifies that in discover-all a
-// failover sync failure for a newly disabled model is logged and skipped
-// without failing the scan, and the rest of the diff is still reported.
+// TestDiscoverAllModels_DisabledSyncError verifies that in the sweep a failover
+// sync failure for a newly disabled model is logged and skipped without failing
+// the scan, and the rest of the diff is still reported.
 func TestDiscoverAllModels_DisabledSyncError(t *testing.T) {
-	_, r := newTestHandlerWithRouter(t)
+	h, r := newTestHandlerWithRouter(t)
 
 	var listingMu sync.Mutex
 	listing := []string{"dase-model-a", "dase-model-b"}
@@ -709,18 +728,7 @@ func TestDiscoverAllModels_DisabledSyncError(t *testing.T) {
 		t.Fatalf("create provider: expected 201, got %d: %s", w.Code, w.Body.String())
 	}
 
-	discoverAll := func() *httptest.ResponseRecorder {
-		t.Helper()
-		req := httptest.NewRequest(http.MethodPost, "/providers/discover-all", http.NoBody)
-		req.Header.Set("Authorization", "Bearer test-admin-token")
-		w := httptest.NewRecorder()
-		r.ServeHTTP(w, req)
-		return w
-	}
-
-	if w := discoverAll(); w.Code != http.StatusOK {
-		t.Fatalf("first discover-all: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	sweepProviderDiff(t, h, "dase-test")
 
 	origFailoverRepoSyncForModel := failoverRepoSyncForModel
 	defer func() { failoverRepoSyncForModel = origFailoverRepoSyncForModel }()
@@ -736,41 +744,23 @@ func TestDiscoverAllModels_DisabledSyncError(t *testing.T) {
 	listingMu.Unlock()
 
 	// First missing scan is pending-only; the second consecutive miss disables
-	// dase-model-b and exercises the disabled-model sync error path.
-	if w := discoverAll(); w.Code != http.StatusOK {
-		t.Fatalf("pending-miss discover-all: expected 200, got %d: %s", w.Code, w.Body.String())
+	// dase-model-b and exercises the disabled-model sync error path, which the
+	// sweep must log and skip while still reporting the disable in the diff.
+	sweepProviderDiff(t, h, "dase-test")
+	diff := sweepProviderDiff(t, h, "dase-test")
+	if diff == nil {
+		t.Fatal("expected diff for dase-test")
 	}
-	w = discoverAll()
-	if w.Code != http.StatusOK {
-		t.Fatalf("second discover-all: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
-
-	var resp struct {
-		Results []DiscoverAllResult `json:"results"`
-	}
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode discover-all response: %v", err)
-	}
-	if len(resp.Results) != 1 {
-		t.Fatalf("expected 1 result, got %+v", resp.Results)
-	}
-	result := resp.Results[0]
-	if result.Error != "" {
-		t.Errorf("expected scan to succeed despite sync error, got error %q", result.Error)
-	}
-	if result.Diff == nil {
-		t.Fatal("expected diff in result")
-	}
-	if len(result.Diff.Disabled) != 1 || result.Diff.Disabled[0].ModelID != "dase-model-b" {
-		t.Errorf("expected disabled=[dase-model-b], got %+v", result.Diff.Disabled)
+	if len(diff.Disabled) != 1 || diff.Disabled[0].ModelID != "dase-model-b" {
+		t.Errorf("expected disabled=[dase-model-b] despite sync error, got %+v", diff.Disabled)
 	}
 }
 
-// TestDiscoverProviderModels_SuspectScanSkipsDisable verifies that when the
-// confirmation probe cannot re-list the provider (a flapping upstream), the
-// scan is treated as suspect: nothing is disabled, nothing appears in the
-// diff, and the request still succeeds.
-func TestDiscoverProviderModels_SuspectScanSkipsDisable(t *testing.T) {
+// TestDiscoverSweep_SuspectScanSkipsDisable verifies that when the confirmation
+// probe cannot re-list the provider (a flapping upstream), the sweep treats the
+// scan as suspect: nothing is disabled, nothing appears in the diff, and the
+// dropped model keeps a zero miss streak so it cannot drift toward a disable.
+func TestDiscoverSweep_SuspectScanSkipsDisable(t *testing.T) {
 	handler, r := newTestHandlerWithRouter(t)
 	pool := handler.dbPool.Pool()
 	ctx := context.Background()
@@ -808,18 +798,9 @@ func TestDiscoverProviderModels_SuspectScanSkipsDisable(t *testing.T) {
 		t.Fatalf("decode created provider: %v", err)
 	}
 
-	discover := func() *httptest.ResponseRecorder {
-		t.Helper()
-		req := httptest.NewRequest(http.MethodPost, "/providers/"+created.ID+"/discover", http.NoBody)
-		req.Header.Set("Authorization", "Bearer test-admin-token")
-		w := httptest.NewRecorder()
-		r.ServeHTTP(w, req)
-		return w
-	}
+	_ = created.ID // discovered via the sweep, not by ID
 
-	if w := discover(); w.Code != http.StatusOK {
-		t.Fatalf("first discover: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	sweepProviderDiff(t, handler, "suspect-scan-test")
 
 	// Drop a model from the listing AND fail the confirmation probe, so the
 	// scan cannot get its second opinion and must record nothing.
@@ -832,43 +813,23 @@ func TestDiscoverProviderModels_SuspectScanSkipsDisable(t *testing.T) {
 	listing = []string{"sus-model-a"}
 	listingMu.Unlock()
 
-	w = discover()
-	if w.Code != http.StatusOK {
-		t.Fatalf("suspect discover: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
-	var resp struct {
-		Diff DiscoveryDiff `json:"diff"`
-	}
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode discover response: %v", err)
-	}
-	if len(resp.Diff.Disabled) != 0 {
-		t.Errorf("expected no disabled models on a suspect scan, got %+v", resp.Diff.Disabled)
+	diff := sweepProviderDiff(t, handler, "suspect-scan-test")
+	if len(diff.Disabled) != 0 {
+		t.Errorf("expected no disabled models on a suspect scan, got %+v", diff.Disabled)
 	}
 
-	checkUntouched := func(label string) {
-		t.Helper()
-		var enabled bool
-		var streak int
-		if err := pool.QueryRow(ctx,
-			`SELECT enabled, missing_scans FROM models WHERE provider_id = $1 AND model_id = 'sus-model-b'`,
-			created.ID,
-		).Scan(&enabled, &streak); err != nil {
-			t.Fatalf("%s: lookup sus-model-b: %v", label, err)
-		}
-		if !enabled || streak != 0 {
-			t.Errorf("%s: expected sus-model-b untouched by suspect scan, got enabled=%v missing_scans=%d", label, enabled, streak)
-		}
+	// The suspect exit must record nothing: the dropped model stays enabled with
+	// a zero miss streak, so the flapping upstream cannot advance it toward a
+	// disable.
+	var enabled bool
+	var streak int
+	if err := pool.QueryRow(ctx,
+		`SELECT enabled, missing_scans FROM models WHERE provider_id = $1 AND model_id = 'sus-model-b'`,
+		created.ID,
+	).Scan(&enabled, &streak); err != nil {
+		t.Fatalf("lookup sus-model-b: %v", err)
 	}
-	checkUntouched("manual discover")
-
-	// The discover-all path must take the same suspect exit.
-	req = httptest.NewRequest(http.MethodPost, "/providers/discover-all", http.NoBody)
-	req.Header.Set("Authorization", "Bearer test-admin-token")
-	w = httptest.NewRecorder()
-	r.ServeHTTP(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("suspect discover-all: expected 200, got %d: %s", w.Code, w.Body.String())
+	if !enabled || streak != 0 {
+		t.Errorf("expected sus-model-b untouched by suspect scan, got enabled=%v missing_scans=%d", enabled, streak)
 	}
-	checkUntouched("discover-all")
 }

--- a/internal/api/discovery_diff_test.go
+++ b/internal/api/discovery_diff_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/hugalafutro/model-hotel/internal/failover"
 	"github.com/hugalafutro/model-hotel/internal/model"
+	"github.com/hugalafutro/model-hotel/internal/provider"
 )
 
 func TestBuildDiscoveryDiff(t *testing.T) {
@@ -444,7 +445,8 @@ func TestDiscoverProviderModels_RenameScenario(t *testing.T) {
 		t.Fatalf("expected provider1 model-b %s in group order %s", modelBUUID, groupOrder)
 	}
 
-	// Second scan: B is renamed to C.
+	// Second scan: B is renamed to C. C shows up as added, but B is only a
+	// first confirmed miss (pending) — nothing is disabled yet.
 	listingMu.Lock()
 	listing = []string{"rename-model-a", "rename-model-c"}
 	listingMu.Unlock()
@@ -460,6 +462,17 @@ func TestDiscoverProviderModels_RenameScenario(t *testing.T) {
 	if len(resp.Diff.Added) != 1 || resp.Diff.Added[0].ModelID != "rename-model-c" || resp.Diff.Added[0].Reason != changeReasonNewModel {
 		t.Errorf("expected added=[rename-model-c/new_model], got %+v", resp.Diff.Added)
 	}
+	if len(resp.Diff.Disabled) != 0 {
+		t.Errorf("expected no disabled models on the first missing scan, got %+v", resp.Diff.Disabled)
+	}
+
+	// Third scan: B misses a second consecutive time and is now disabled.
+	w = discover()
+	resp.Diff = DiscoveryDiff{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode discover response: %v", err)
+	}
+
 	if len(resp.Diff.Disabled) != 1 || resp.Diff.Disabled[0].ModelID != "rename-model-b" || resp.Diff.Disabled[0].Reason != changeReasonNotListed {
 		t.Errorf("expected disabled=[rename-model-b/not_listed], got %+v", resp.Diff.Disabled)
 	}
@@ -578,6 +591,13 @@ func TestDiscoverProviderModels_DisabledSyncError(t *testing.T) {
 	listing = []string{"dse-model-a"}
 	listingMu.Unlock()
 
+	// First missing scan only records a pending miss (nothing disabled, so the
+	// disabled-refs sync loop is empty and the request succeeds).
+	if w := discover(); w.Code != http.StatusOK {
+		t.Fatalf("pending-miss discover: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Second consecutive miss disables dse-model-b and hits the sync error.
 	w = discover()
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("expected status 500, got %d: %s", w.Code, w.Body.String())
@@ -715,6 +735,11 @@ func TestDiscoverAllModels_DisabledSyncError(t *testing.T) {
 	listing = []string{"dase-model-a"}
 	listingMu.Unlock()
 
+	// First missing scan is pending-only; the second consecutive miss disables
+	// dase-model-b and exercises the disabled-model sync error path.
+	if w := discoverAll(); w.Code != http.StatusOK {
+		t.Fatalf("pending-miss discover-all: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
 	w = discoverAll()
 	if w.Code != http.StatusOK {
 		t.Fatalf("second discover-all: expected 200, got %d: %s", w.Code, w.Body.String())
@@ -739,4 +764,111 @@ func TestDiscoverAllModels_DisabledSyncError(t *testing.T) {
 	if len(result.Diff.Disabled) != 1 || result.Diff.Disabled[0].ModelID != "dase-model-b" {
 		t.Errorf("expected disabled=[dase-model-b], got %+v", result.Diff.Disabled)
 	}
+}
+
+// TestDiscoverProviderModels_SuspectScanSkipsDisable verifies that when the
+// confirmation probe cannot re-list the provider (a flapping upstream), the
+// scan is treated as suspect: nothing is disabled, nothing appears in the
+// diff, and the request still succeeds.
+func TestDiscoverProviderModels_SuspectScanSkipsDisable(t *testing.T) {
+	handler, r := newTestHandlerWithRouter(t)
+	pool := handler.dbPool.Pool()
+	ctx := context.Background()
+
+	var listingMu sync.Mutex
+	listing := []string{"sus-model-a", "sus-model-b"}
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.URL.Path != "/v1/models" {
+			return
+		}
+		listingMu.Lock()
+		defer listingMu.Unlock()
+		data := make([]map[string]interface{}, 0, len(listing))
+		for _, id := range listing {
+			data = append(data, map[string]interface{}{"id": id, "owned_by": "test", "object": "model"})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{"data": data})
+	}))
+	defer mockServer.Close()
+
+	providerData := fmt.Sprintf(`{"name":"suspect-scan-test","base_url":"%s/v1","api_key":"sk-test"}`, mockServer.URL)
+	req := httptest.NewRequest(http.MethodPost, "/providers", strings.NewReader(providerData))
+	req.Header.Set("Authorization", "Bearer test-admin-token")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create provider: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var created struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode created provider: %v", err)
+	}
+
+	discover := func() *httptest.ResponseRecorder {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodPost, "/providers/"+created.ID+"/discover", http.NoBody)
+		req.Header.Set("Authorization", "Bearer test-admin-token")
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		return w
+	}
+
+	if w := discover(); w.Code != http.StatusOK {
+		t.Fatalf("first discover: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Drop a model from the listing AND fail the confirmation probe, so the
+	// scan cannot get its second opinion and must record nothing.
+	origDiscoverForConfirm := discoverModelsForConfirm
+	defer func() { discoverModelsForConfirm = origDiscoverForConfirm }()
+	discoverModelsForConfirm = func(ctx context.Context, svc *provider.DiscoveryService, prov *provider.Provider, masterKey string) ([]*model.Model, error) {
+		return nil, errors.New("probe flake")
+	}
+	listingMu.Lock()
+	listing = []string{"sus-model-a"}
+	listingMu.Unlock()
+
+	w = discover()
+	if w.Code != http.StatusOK {
+		t.Fatalf("suspect discover: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Diff DiscoveryDiff `json:"diff"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode discover response: %v", err)
+	}
+	if len(resp.Diff.Disabled) != 0 {
+		t.Errorf("expected no disabled models on a suspect scan, got %+v", resp.Diff.Disabled)
+	}
+
+	checkUntouched := func(label string) {
+		t.Helper()
+		var enabled bool
+		var streak int
+		if err := pool.QueryRow(ctx,
+			`SELECT enabled, missing_scans FROM models WHERE provider_id = $1 AND model_id = 'sus-model-b'`,
+			created.ID,
+		).Scan(&enabled, &streak); err != nil {
+			t.Fatalf("%s: lookup sus-model-b: %v", label, err)
+		}
+		if !enabled || streak != 0 {
+			t.Errorf("%s: expected sus-model-b untouched by suspect scan, got enabled=%v missing_scans=%d", label, enabled, streak)
+		}
+	}
+	checkUntouched("manual discover")
+
+	// The discover-all path must take the same suspect exit.
+	req = httptest.NewRequest(http.MethodPost, "/providers/discover-all", http.NoBody)
+	req.Header.Set("Authorization", "Bearer test-admin-token")
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("suspect discover-all: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	checkUntouched("discover-all")
 }

--- a/internal/api/discovery_integration_test.go
+++ b/internal/api/discovery_integration_test.go
@@ -1732,7 +1732,13 @@ func TestDiscoverProviderModels_UpsertError(t *testing.T) {
 	}
 }
 
-func TestDiscoverProviderModels_DisableMissingError(t *testing.T) {
+// TestDiscoverProviderModels_DoesNotRecordMisses guards the contract that the
+// interactive single-provider handler never records misses (that moved to the
+// background sweep so the confirmation-probe backoff cannot overrun the route's
+// 60s timeout). modelRepoRecordMissing is forced to error: if the handler were
+// to start recording again it would surface as a 500, so a green 200 here proves
+// the handler bypasses recording entirely.
+func TestDiscoverProviderModels_DoesNotRecordMisses(t *testing.T) {
 	_, r := newTestHandlerWithRouter(t)
 
 	// Create a mock OpenAI-compatible server
@@ -1775,17 +1781,16 @@ func TestDiscoverProviderModels_DisableMissingError(t *testing.T) {
 		return nil, nil, errors.New("record missing models error")
 	}
 
-	// Call discover endpoint
+	// Call discover endpoint. The interactive handler must not touch the miss
+	// recorder, so the forced record error is never reached and the scan returns
+	// 200. A 500 here would mean recording crept back onto the request path.
 	req = httptest.NewRequest(http.MethodPost, "/providers/"+created.ID+"/discover", http.NoBody)
 	req.Header.Set("Authorization", "Bearer test-admin-token")
 	w = httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 
-	if w.Code != http.StatusInternalServerError {
-		t.Errorf("expected status 500, got %d: %s", w.Code, w.Body.String())
-	}
-	if !strings.Contains(w.Body.String(), "failed to record missing models") {
-		t.Errorf("expected error about record missing models, got %q", w.Body.String())
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status 200 (handler bypasses miss recording), got %d: %s", w.Code, w.Body.String())
 	}
 }
 
@@ -2405,8 +2410,14 @@ func TestDiscoverAllModels_UpsertError(t *testing.T) {
 	}
 }
 
+// TestDiscoverAllModels_DisableMissingError drives the background sweep
+// (recordMisses=true) with the miss recorder forced to error, and asserts the
+// sweep tolerates it: a per-provider DB hiccup must be logged and skipped, never
+// abort the scan. This is the path that actually records misses now, so it is
+// driven directly rather than through the interactive discover-all handler
+// (which passes recordMisses=false).
 func TestDiscoverAllModels_DisableMissingError(t *testing.T) {
-	_, r := newTestHandlerWithRouter(t)
+	h, r := newTestHandlerWithRouter(t)
 
 	// Create a mock OpenAI-compatible server
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -2441,14 +2452,19 @@ func TestDiscoverAllModels_DisableMissingError(t *testing.T) {
 		return nil, nil, errors.New("record missing models error")
 	}
 
-	// Call discover-all endpoint (should still return 200, just log debug)
-	req = httptest.NewRequest(http.MethodPost, "/providers/discover-all", http.NoBody)
-	req.Header.Set("Authorization", "Bearer test-admin-token")
-	w = httptest.NewRecorder()
-	r.ServeHTTP(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Errorf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	// Drive the recording path directly; a per-provider record error must be
+	// swallowed (logged at debug) rather than abort the sweep.
+	results, _, _, _, err := h.discoverAllProviders(context.Background(), true)
+	if err != nil {
+		t.Fatalf("sweep must tolerate a record-missing error, got %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatalf("expected at least one provider result despite the record error")
+	}
+	for i := range results {
+		if results[i].Error != "" {
+			t.Errorf("provider %s: scan must complete despite record error, got %q", results[i].ProviderName, results[i].Error)
+		}
 	}
 }
 

--- a/internal/api/discovery_integration_test.go
+++ b/internal/api/discovery_integration_test.go
@@ -1767,12 +1767,12 @@ func TestDiscoverProviderModels_DisableMissingError(t *testing.T) {
 		t.Fatalf("decode created provider: %v", err)
 	}
 
-	// Override modelRepoDisableMissing to return error
-	origModelRepoDisableMissing := modelRepoDisableMissing
-	defer func() { modelRepoDisableMissing = origModelRepoDisableMissing }()
+	// Override modelRepoRecordMissing to return error
+	origModelRepoRecordMissing := modelRepoRecordMissing
+	defer func() { modelRepoRecordMissing = origModelRepoRecordMissing }()
 
-	modelRepoDisableMissing = func(repo *model.Repository, ctx context.Context, providerID uuid.UUID, providerName string, modelIDs []string) ([]model.DisabledModelRef, error) {
-		return nil, errors.New("disable missing models error")
+	modelRepoRecordMissing = func(repo *model.Repository, ctx context.Context, providerID uuid.UUID, providerName string, modelIDs []string) ([]model.DisabledModelRef, []model.DisabledModelRef, error) {
+		return nil, nil, errors.New("record missing models error")
 	}
 
 	// Call discover endpoint
@@ -1784,8 +1784,8 @@ func TestDiscoverProviderModels_DisableMissingError(t *testing.T) {
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("expected status 500, got %d: %s", w.Code, w.Body.String())
 	}
-	if !strings.Contains(w.Body.String(), "failed to disable missing models") {
-		t.Errorf("expected error about disable missing models, got %q", w.Body.String())
+	if !strings.Contains(w.Body.String(), "failed to record missing models") {
+		t.Errorf("expected error about record missing models, got %q", w.Body.String())
 	}
 }
 
@@ -2433,12 +2433,12 @@ func TestDiscoverAllModels_DisableMissingError(t *testing.T) {
 		t.Fatalf("create provider: expected 201, got %d: %s", w.Code, w.Body.String())
 	}
 
-	// Override modelRepoDisableMissing to return error
-	origModelRepoDisableMissing := modelRepoDisableMissing
-	defer func() { modelRepoDisableMissing = origModelRepoDisableMissing }()
+	// Override modelRepoRecordMissing to return error
+	origModelRepoRecordMissing := modelRepoRecordMissing
+	defer func() { modelRepoRecordMissing = origModelRepoRecordMissing }()
 
-	modelRepoDisableMissing = func(repo *model.Repository, ctx context.Context, providerID uuid.UUID, providerName string, modelIDs []string) ([]model.DisabledModelRef, error) {
-		return nil, errors.New("disable missing models error")
+	modelRepoRecordMissing = func(repo *model.Repository, ctx context.Context, providerID uuid.UUID, providerName string, modelIDs []string) ([]model.DisabledModelRef, []model.DisabledModelRef, error) {
+		return nil, nil, errors.New("record missing models error")
 	}
 
 	// Call discover-all endpoint (should still return 200, just log debug)

--- a/internal/api/failover_api_test.go
+++ b/internal/api/failover_api_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
@@ -33,6 +34,11 @@ var apiTestDB *db.DB
 var apiTestDBURL string
 
 func TestMain(m *testing.M) {
+	// Zero the confirmation-probe backoff so any test whose mock listing drops
+	// a model exercises the probe logic without real 15/45-second sleeps.
+	confirmProbeDelays = []time.Duration{0, 0}
+	confirmProbeSleep = func(context.Context, time.Duration) error { return nil }
+
 	ctx := context.Background()
 	var err error
 	var setupErr error

--- a/internal/api/handler_failover_test.go
+++ b/internal/api/handler_failover_test.go
@@ -1601,7 +1601,7 @@ func TestFailoverGroupResponse_EffectiveState(t *testing.T) {
 
 	// Disable model 2 directly (discovery-style). The raw SQL bypasses the
 	// repository, so invalidate manually exactly like the production
-	// discovery path (DisableMissingModels) does.
+	// discovery path (RecordMissingModels) does.
 	if _, err := pool.Exec(ctx, `UPDATE models SET enabled = false WHERE id = $1`, modelUUIDs[1]); err != nil {
 		t.Fatalf("disable model 2: %v", err)
 	}

--- a/internal/db/migrations/054_model_missing_scans.sql
+++ b/internal/db/migrations/054_model_missing_scans.sql
@@ -1,0 +1,7 @@
+-- Consecutive-scan miss counter for discovery. A model absent from one provider
+-- listing is no longer disabled immediately: each confirmed-missing scan (after
+-- in-scan confirmation probes) increments missing_scans, and the model is only
+-- disabled when the streak reaches the threshold (model.MissingScanThreshold).
+-- Any sighting (Upsert) resets the counter to 0. This stops one flaky DNS
+-- lookup or partial upstream listing from disabling models fleet-wide.
+ALTER TABLE models ADD COLUMN IF NOT EXISTS missing_scans INTEGER NOT NULL DEFAULT 0;

--- a/internal/db/migrations/055_provider_suspect_scans.sql
+++ b/internal/db/migrations/055_provider_suspect_scans.sql
@@ -1,0 +1,10 @@
+-- Consecutive mass-vanish counter for discovery's bulk-removal escalation. When
+-- a provider's confirmed-missing set trips the mass-vanish guard (more than the
+-- floor AND over half its enabled models absent even after confirmation probes),
+-- the scan records no misses so a transiently broken listing cannot false-disable
+-- models fleet-wide. But a provider that has genuinely sunset that many models
+-- trips the guard every scan and would otherwise stay stale forever. suspect_scans
+-- counts consecutive mass-vanish scans; once it reaches the escalation threshold a
+-- distinct high-severity event is emitted so an operator can disable the sunset
+-- models by hand. Any healthy scan (listing recovered) resets it to 0.
+ALTER TABLE providers ADD COLUMN IF NOT EXISTS suspect_scans INTEGER NOT NULL DEFAULT 0;

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -135,6 +135,10 @@ func (r *Repository) Upsert(ctx context.Context, m *Model) error {
 			output_price_per_million = CASE WHEN $23 THEN COALESCE(EXCLUDED.output_price_per_million, models.output_price_per_million) ELSE COALESCE(models.output_price_per_million, EXCLUDED.output_price_per_million) END,
 			owned_by = EXCLUDED.owned_by,
 			enabled = CASE WHEN models.disabled_manually = false THEN true ELSE models.enabled END,
+			-- Any sighting resets the consecutive-miss streak used by
+			-- RecordMissingModels, so a model that reappears (even via a manual
+			-- re-test between scheduled scans) starts over from zero misses.
+			missing_scans = 0,
 			last_seen_at = now()
 		RETURNING ` + upsertColumns
 
@@ -338,42 +342,75 @@ type DisabledModelRef struct {
 	ModelID string
 }
 
-// DisableMissingModels disables models not present in the current discovery
-// result. Returns only the models that were enabled before this call.
-func (r *Repository) DisableMissingModels(ctx context.Context, providerID uuid.UUID, providerName string, existingModelIDs []string) ([]DisabledModelRef, error) {
-	if len(existingModelIDs) == 0 {
-		return nil, nil
-	}
-	query := `
-		UPDATE models
-		SET enabled = false
-		WHERE provider_id = $1 AND model_id != ALL($2) AND enabled = true
-		RETURNING id, model_id
-	`
+// MissingScanThreshold is how many consecutive confirmed-missing discovery
+// scans it takes before a model is disabled. Each scan-level miss is already
+// triple-checked by in-scan confirmation probes (api.ConfirmMissingModels), so
+// two independent scans missing the same model is strong evidence it is gone,
+// while a single flaky scan (DNS flap, partial upstream listing) never
+// disables anything.
+const MissingScanThreshold = 2
 
-	rows, err := r.pool.Query(ctx, query, providerID, existingModelIDs)
+// RecordMissingModels applies one scan's membership verdict: enabled models
+// absent from presentModelIDs get their consecutive-miss streak incremented,
+// and only those whose streak reaches MissingScanThreshold are disabled (the
+// streak resets so a later reappearance starts clean). Present models have any
+// streak cleared. Returns the newly disabled models and the still-enabled
+// pending ones (streak below threshold). An empty presentModelIDs list is a
+// no-op guard: an empty listing is far more likely a broken scan than a
+// provider that removed every model.
+func (r *Repository) RecordMissingModels(ctx context.Context, providerID uuid.UUID, providerName string, presentModelIDs []string) (disabled, pending []DisabledModelRef, err error) {
+	if len(presentModelIDs) == 0 {
+		return nil, nil, nil
+	}
+
+	// One atomic statement: the CTE clears the streak of every present model
+	// (Upsert also does this, but "present" here includes reappeared models a
+	// confirmation probe found that the caller did not re-upsert), while the
+	// main UPDATE records one confirmed miss for every enabled model the scan
+	// did not list. Rows that reach the threshold are disabled with their
+	// streak reset (a later reappearance must not sit one flaky scan away
+	// from another disable); the rest keep counting into the next scan.
+	rows, err := r.pool.Query(ctx, `
+		WITH reset AS (
+			UPDATE models SET missing_scans = 0
+			WHERE provider_id = $1 AND model_id = ANY($2) AND missing_scans > 0
+		)
+		UPDATE models
+		SET missing_scans = CASE WHEN missing_scans + 1 >= $3 THEN 0 ELSE missing_scans + 1 END,
+		    enabled = CASE WHEN missing_scans + 1 >= $3 THEN false ELSE enabled END
+		WHERE provider_id = $1 AND model_id != ALL($2) AND enabled = true
+		RETURNING id, model_id, NOT enabled
+	`, providerID, presentModelIDs, MissingScanThreshold)
 	if err != nil {
-		debuglog.Error("model: disable missing failed", "provider", providerName, "provider_id", providerID, "error", err)
-		return nil, err
+		debuglog.Error("model: record missing failed", "provider", providerName, "provider_id", providerID, "error", err)
+		return nil, nil, err
 	}
 	defer rows.Close()
-
-	var refs []DisabledModelRef
 	for rows.Next() {
 		var ref DisabledModelRef
-		if err := rows.Scan(&ref.ID, &ref.ModelID); err != nil {
-			debuglog.Error("model: disable missing scan failed", "provider", providerName, "provider_id", providerID, "error", err)
-			return nil, err
+		var wasDisabled bool
+		if err := rows.Scan(&ref.ID, &ref.ModelID, &wasDisabled); err != nil {
+			debuglog.Error("model: record missing scan failed", "provider", providerName, "provider_id", providerID, "error", err)
+			return nil, nil, err
 		}
-		refs = append(refs, ref)
+		if wasDisabled {
+			disabled = append(disabled, ref)
+		} else {
+			pending = append(pending, ref)
+		}
 	}
 	if err := rows.Err(); err != nil {
-		debuglog.Error("model: disable missing failed", "provider", providerName, "provider_id", providerID, "error", err)
-		return nil, err
+		debuglog.Error("model: record missing failed", "provider", providerName, "provider_id", providerID, "error", err)
+		return nil, nil, err
 	}
-	debuglog.Info("model: disabled missing models", "provider", providerName, "provider_id", providerID, "count", len(refs))
+
+	if len(disabled) > 0 || len(pending) > 0 {
+		debuglog.Info("model: recorded missing models",
+			"provider", providerName, "provider_id", providerID,
+			"disabled", len(disabled), "pending", len(pending), "threshold", MissingScanThreshold)
+	}
 	InvalidateModelCache()
-	return refs, nil
+	return disabled, pending, nil
 }
 
 // SetEnabled enables or disables a model by its UUID.

--- a/internal/model/model_crud_test.go
+++ b/internal/model/model_crud_test.go
@@ -1444,10 +1444,10 @@ func TestRepository_GetByModelID_NotFound(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// TestDisableMissingModels edge cases
+// TestRecordMissingModels edge cases
 // ---------------------------------------------------------------------------
 
-func TestRepository_DisableMissingModels_WithProviderAndModel(t *testing.T) {
+func TestRepository_RecordMissingModels_WithProviderAndModel(t *testing.T) {
 	ctx := context.Background()
 	repo := NewRepository(testPool)
 
@@ -1472,13 +1472,21 @@ func TestRepository_DisableMissingModels_WithProviderAndModel(t *testing.T) {
 		t.Fatalf("insert model2 failed: %v", err)
 	}
 
-	// Call DisableMissingModels with only modelID1 in the list - should disable modelID2
-	refs, err := repo.DisableMissingModels(ctx, providerID, "test-provider", []string{"keep-this-model"})
+	// Two consecutive scans missing modelID2 disable it: the first records a
+	// pending miss, the second reaches MissingScanThreshold.
+	disabled, pending, err := repo.RecordMissingModels(ctx, providerID, "test-provider", []string{"keep-this-model"})
 	if err != nil {
-		t.Fatalf("DisableMissingModels failed: %v", err)
+		t.Fatalf("RecordMissingModels first scan failed: %v", err)
 	}
-	if len(refs) != 1 || refs[0].ModelID != "remove-this-model" || refs[0].ID != modelID2 {
-		t.Errorf("expected single ref for remove-this-model (%s), got %v", modelID2, refs)
+	if len(disabled) != 0 || len(pending) != 1 || pending[0].ModelID != "remove-this-model" {
+		t.Errorf("expected pending ref for remove-this-model, got disabled=%v pending=%v", disabled, pending)
+	}
+	disabled, _, err = repo.RecordMissingModels(ctx, providerID, "test-provider", []string{"keep-this-model"})
+	if err != nil {
+		t.Fatalf("RecordMissingModels second scan failed: %v", err)
+	}
+	if len(disabled) != 1 || disabled[0].ModelID != "remove-this-model" || disabled[0].ID != modelID2 {
+		t.Errorf("expected single disabled ref for remove-this-model (%s), got %v", modelID2, disabled)
 	}
 
 	// Verify modelID1 is still enabled
@@ -1498,7 +1506,7 @@ func TestRepository_DisableMissingModels_WithProviderAndModel(t *testing.T) {
 		t.Fatalf("failed to query model2: %v", err)
 	}
 	if enabled2 {
-		t.Error("model2 should be disabled after DisableMissingModels")
+		t.Error("model2 should be disabled after two consecutive missing scans")
 	}
 }
 
@@ -1630,12 +1638,12 @@ func TestGetByProviderAndModelID_CancelledContext(t *testing.T) {
 	}
 }
 
-func TestDisableMissingModels_CancelledContext(t *testing.T) {
+func TestRecordMissingModels_CancelledContext(t *testing.T) {
 	repo := NewRepository(testPool)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err := repo.DisableMissingModels(ctx, uuid.New(), "test-provider", []string{"some-model"})
+	_, _, err := repo.RecordMissingModels(ctx, uuid.New(), "test-provider", []string{"some-model"})
 	if err == nil {
 		t.Error("expected error with cancelled context, got nil")
 	}

--- a/internal/model/model_db_test.go
+++ b/internal/model/model_db_test.go
@@ -90,235 +90,286 @@ func cleanupProvider(ctx context.Context, t *testing.T, providerID uuid.UUID) {
 }
 
 // ---------------------------------------------------------------------------
-// TestDisableMissingModels
+// TestRecordMissingModels
 // ---------------------------------------------------------------------------
 
-func TestDisableMissingModels_EmptyList(t *testing.T) {
+func TestRecordMissingModels_EmptyList(t *testing.T) {
 	ctx := context.Background()
-
 	repo := NewRepository(testPool)
 
-	// Empty list should return (nil, nil) without executing any query.
-	refs, err := repo.DisableMissingModels(ctx, uuid.New(), "test-provider", nil)
+	// Empty list should return (nil, nil, nil) without executing any query: an
+	// empty listing is far more likely a broken scan than a real full removal.
+	disabled, pending, err := repo.RecordMissingModels(ctx, uuid.New(), "test-provider", nil)
 	if err != nil {
-		t.Fatalf("DisableMissingModels with nil list: %v", err)
+		t.Fatalf("RecordMissingModels nil list: %v", err)
 	}
-	if len(refs) != 0 {
-		t.Errorf("expected 0 disabled refs, got %d", len(refs))
+	if len(disabled) != 0 || len(pending) != 0 {
+		t.Errorf("expected no refs, got disabled=%v pending=%v", disabled, pending)
 	}
 
-	refs, err = repo.DisableMissingModels(ctx, uuid.New(), "test-provider", []string{})
+	disabled, pending, err = repo.RecordMissingModels(ctx, uuid.New(), "test-provider", []string{})
 	if err != nil {
-		t.Fatalf("DisableMissingModels with empty list: %v", err)
+		t.Fatalf("RecordMissingModels empty list: %v", err)
 	}
-	if len(refs) != 0 {
-		t.Errorf("expected 0 disabled refs, got %d", len(refs))
+	if len(disabled) != 0 || len(pending) != 0 {
+		t.Errorf("expected no refs, got disabled=%v pending=%v", disabled, pending)
 	}
 }
 
-func TestDisableMissingModels_DisablesMissing(t *testing.T) {
+func TestRecordMissingModels_FirstMissIsPendingOnly(t *testing.T) {
 	ctx := context.Background()
 	repo := NewRepository(testPool)
 
-	providerID := insertTestProvider(ctx, t, "test-disable-missing-disables")
+	providerID := insertTestProvider(ctx, t, "test-record-missing-pending")
 	t.Cleanup(func() { cleanupProvider(ctx, t, providerID) })
 
-	// Create 4 models for this provider.
 	insertTestModel(ctx, t, providerID, "model-a")
 	insertTestModel(ctx, t, providerID, "model-b")
 	insertTestModel(ctx, t, providerID, "model-c")
 	insertTestModel(ctx, t, providerID, "model-d")
 
-	// Mark "model-b" and "model-d" as still existing. "model-a" and "model-c" are missing.
+	// First scan missing model-a and model-c: nothing may be disabled yet.
 	existing := []string{"model-b", "model-d"}
-
-	refs, err := repo.DisableMissingModels(ctx, providerID, "test-provider", existing)
+	disabled, pending, err := repo.RecordMissingModels(ctx, providerID, "test-provider", existing)
 	if err != nil {
-		t.Fatalf("DisableMissingModels: %v", err)
+		t.Fatalf("RecordMissingModels: %v", err)
 	}
-
-	// 2 models (model-a, model-c) should be disabled and returned.
-	if len(refs) != 2 {
-		t.Fatalf("expected 2 disabled refs, got %d", len(refs))
+	if len(disabled) != 0 {
+		t.Fatalf("expected 0 disabled refs on first miss, got %v", disabled)
 	}
-	disabledIDs := map[string]bool{}
-	for _, ref := range refs {
+	if len(pending) != 2 {
+		t.Fatalf("expected 2 pending refs, got %v", pending)
+	}
+	pendingIDs := map[string]bool{}
+	for _, ref := range pending {
 		if ref.ID == uuid.Nil {
-			t.Errorf("expected non-nil UUID for disabled ref %q", ref.ModelID)
+			t.Errorf("expected non-nil UUID for %s", ref.ModelID)
 		}
-		disabledIDs[ref.ModelID] = true
+		pendingIDs[ref.ModelID] = true
 	}
-	if !disabledIDs["model-a"] || !disabledIDs["model-c"] {
-		t.Errorf("expected refs for model-a and model-c, got %v", disabledIDs)
+	if !pendingIDs["model-a"] || !pendingIDs["model-c"] {
+		t.Errorf("expected model-a and model-c pending, got %v", pendingIDs)
 	}
 
-	// Verify: only model-b and model-d remain enabled.
-	enabled := countEnabledModels(ctx, t, providerID)
-	if enabled != 2 {
+	// All 4 models must still be enabled after a single miss.
+	if enabled := countEnabledModels(ctx, t, providerID); enabled != 4 {
+		t.Errorf("expected 4 enabled models after first miss, got %d", enabled)
+	}
+}
+
+func TestRecordMissingModels_SecondConsecutiveMissDisables(t *testing.T) {
+	ctx := context.Background()
+	repo := NewRepository(testPool)
+
+	providerID := insertTestProvider(ctx, t, "test-record-missing-disables")
+	t.Cleanup(func() { cleanupProvider(ctx, t, providerID) })
+
+	insertTestModel(ctx, t, providerID, "model-a")
+	insertTestModel(ctx, t, providerID, "model-b")
+
+	existing := []string{"model-b"}
+	if _, _, err := repo.RecordMissingModels(ctx, providerID, "test-provider", existing); err != nil {
+		t.Fatalf("RecordMissingModels first scan: %v", err)
+	}
+	disabled, pending, err := repo.RecordMissingModels(ctx, providerID, "test-provider", existing)
+	if err != nil {
+		t.Fatalf("RecordMissingModels second scan: %v", err)
+	}
+	if len(disabled) != 1 || disabled[0].ModelID != "model-a" {
+		t.Fatalf("expected model-a disabled on second consecutive miss, got %v", disabled)
+	}
+	if len(pending) != 0 {
+		t.Errorf("expected 0 pending refs, got %v", pending)
+	}
+	if enabled := countEnabledModels(ctx, t, providerID); enabled != 1 {
+		t.Errorf("expected 1 enabled model, got %d", enabled)
+	}
+
+	// The disabled row's streak must be reset so a later reappearance does not
+	// sit one flaky scan away from another disable.
+	var streak int
+	if err := testPool.QueryRow(ctx, `SELECT missing_scans FROM models WHERE id = $1`, disabled[0].ID).Scan(&streak); err != nil {
+		t.Fatalf("query streak: %v", err)
+	}
+	if streak != 0 {
+		t.Errorf("expected missing_scans reset to 0 after disable, got %d", streak)
+	}
+}
+
+func TestRecordMissingModels_SightingResetsStreak(t *testing.T) {
+	ctx := context.Background()
+	repo := NewRepository(testPool)
+
+	providerID := insertTestProvider(ctx, t, "test-record-missing-reset")
+	t.Cleanup(func() { cleanupProvider(ctx, t, providerID) })
+
+	insertTestModel(ctx, t, providerID, "flappy-model")
+	insertTestModel(ctx, t, providerID, "stable-model")
+
+	// Scan 1: flappy-model missing (streak 1).
+	if _, _, err := repo.RecordMissingModels(ctx, providerID, "test-provider", []string{"stable-model"}); err != nil {
+		t.Fatalf("scan 1: %v", err)
+	}
+	// Scan 2: flappy-model listed again — streak must reset.
+	if _, _, err := repo.RecordMissingModels(ctx, providerID, "test-provider", []string{"stable-model", "flappy-model"}); err != nil {
+		t.Fatalf("scan 2: %v", err)
+	}
+	// Scan 3: flappy-model missing again — still only pending, not disabled.
+	disabled, pending, err := repo.RecordMissingModels(ctx, providerID, "test-provider", []string{"stable-model"})
+	if err != nil {
+		t.Fatalf("scan 3: %v", err)
+	}
+	if len(disabled) != 0 {
+		t.Fatalf("expected no disable after streak reset, got %v", disabled)
+	}
+	if len(pending) != 1 || pending[0].ModelID != "flappy-model" {
+		t.Fatalf("expected flappy-model pending, got %v", pending)
+	}
+	if enabled := countEnabledModels(ctx, t, providerID); enabled != 2 {
 		t.Errorf("expected 2 enabled models, got %d", enabled)
 	}
 }
 
-func TestDisableMissingModels_AllPresent(t *testing.T) {
+func TestRecordMissingModels_AllPresent(t *testing.T) {
 	ctx := context.Background()
 	repo := NewRepository(testPool)
 
-	providerID := insertTestProvider(ctx, t, "test-disable-missing-all-present")
+	providerID := insertTestProvider(ctx, t, "test-record-missing-all-present")
 	t.Cleanup(func() { cleanupProvider(ctx, t, providerID) })
 
-	// Create 3 models.
-	insertTestModel(ctx, t, providerID, "alpha")
-	insertTestModel(ctx, t, providerID, "beta")
-	insertTestModel(ctx, t, providerID, "gamma")
+	insertTestModel(ctx, t, providerID, "model-a")
+	insertTestModel(ctx, t, providerID, "model-b")
+	insertTestModel(ctx, t, providerID, "model-c")
 
-	// All models are "still existing".
-	existing := []string{"alpha", "beta", "gamma"}
-
-	refs, err := repo.DisableMissingModels(ctx, providerID, "test-provider", existing)
+	disabled, pending, err := repo.RecordMissingModels(ctx, providerID, "test-provider", []string{"model-a", "model-b", "model-c"})
 	if err != nil {
-		t.Fatalf("DisableMissingModels: %v", err)
+		t.Fatalf("RecordMissingModels: %v", err)
 	}
-
-	// 0 models should be disabled.
-	if len(refs) != 0 {
-		t.Errorf("expected 0 disabled refs, got %d", len(refs))
+	if len(disabled) != 0 || len(pending) != 0 {
+		t.Errorf("expected no refs, got disabled=%v pending=%v", disabled, pending)
 	}
-
-	// All models should still be enabled.
-	enabled := countEnabledModels(ctx, t, providerID)
-	if enabled != 3 {
+	if enabled := countEnabledModels(ctx, t, providerID); enabled != 3 {
 		t.Errorf("expected 3 enabled models, got %d", enabled)
 	}
 }
 
-func TestDisableMissingModels_IgnoresOtherProviders(t *testing.T) {
+func TestRecordMissingModels_IgnoresOtherProviders(t *testing.T) {
 	ctx := context.Background()
 	repo := NewRepository(testPool)
 
-	providerA := insertTestProvider(ctx, t, "test-disable-missing-provider-a")
-	providerB := insertTestProvider(ctx, t, "test-disable-missing-provider-b")
+	providerA := insertTestProvider(ctx, t, "test-record-missing-provider-a")
+	providerB := insertTestProvider(ctx, t, "test-record-missing-provider-b")
 	t.Cleanup(func() {
 		cleanupProvider(ctx, t, providerA)
 		cleanupProvider(ctx, t, providerB)
 	})
 
-	// Provider A: model-a1, model-a2
 	insertTestModel(ctx, t, providerA, "model-a1")
 	insertTestModel(ctx, t, providerA, "model-a2")
-
-	// Provider B: model-b1, model-b2
 	insertTestModel(ctx, t, providerB, "model-b1")
 	insertTestModel(ctx, t, providerB, "model-b2")
 
-	// Disable missing on provider A, saying only model-a1 still exists.
-	refs, err := repo.DisableMissingModels(ctx, providerA, "test-provider-a", []string{"model-a1"})
+	// Two consecutive misses of model-a2 on provider A disable it.
+	if _, _, err := repo.RecordMissingModels(ctx, providerA, "test-provider-a", []string{"model-a1"}); err != nil {
+		t.Fatalf("scan 1: %v", err)
+	}
+	disabled, _, err := repo.RecordMissingModels(ctx, providerA, "test-provider-a", []string{"model-a1"})
 	if err != nil {
-		t.Fatalf("DisableMissingModels: %v", err)
+		t.Fatalf("scan 2: %v", err)
+	}
+	if len(disabled) != 1 || disabled[0].ModelID != "model-a2" {
+		t.Errorf("expected single ref for model-a2, got %v", disabled)
 	}
 
-	// Only model-a2 should be disabled.
-	if len(refs) != 1 || refs[0].ModelID != "model-a2" {
-		t.Errorf("expected single ref for model-a2, got %v", refs)
-	}
-
-	// Provider B should be untouched — both models still enabled.
-	enabledB := countEnabledModels(ctx, t, providerB)
-	if enabledB != 2 {
+	// Provider B untouched — both models still enabled with zero streak.
+	if enabledB := countEnabledModels(ctx, t, providerB); enabledB != 2 {
 		t.Errorf("expected 2 enabled models for provider B, got %d", enabledB)
 	}
 }
 
-func TestDisableMissingModels_AlreadyDisabledUnaffected(t *testing.T) {
+func TestRecordMissingModels_AlreadyDisabledUnaffected(t *testing.T) {
 	ctx := context.Background()
 	repo := NewRepository(testPool)
 
-	providerID := insertTestProvider(ctx, t, "test-disable-missing-already-disabled")
+	providerID := insertTestProvider(ctx, t, "test-record-missing-already-disabled")
 	t.Cleanup(func() { cleanupProvider(ctx, t, providerID) })
 
-	// Create 3 models, then manually disable one.
 	insertTestModel(ctx, t, providerID, "active-1")
 	insertTestModel(ctx, t, providerID, "active-2")
 	insertTestModel(ctx, t, providerID, "already-off")
-
-	_, err := testPool.Exec(ctx,
-		`UPDATE models SET enabled = false WHERE provider_id = $1 AND model_id = $2`,
-		providerID, "already-off",
-	)
-	if err != nil {
-		t.Fatalf("pre-disable model: %v", err)
+	if _, err := testPool.Exec(ctx, `UPDATE models SET enabled = false WHERE provider_id = $1 AND model_id = $2`, providerID, "already-off"); err != nil {
+		t.Fatalf("pre-disable failed: %v", err)
 	}
 
-	// Only "active-1" and "active-2" are in the existing list.
-	// "already-off" is not in the list, but it was already disabled — the
-	// AND enabled = true guard means it is NOT reported as newly disabled.
+	// Two scans listing both active models: already-off is never returned as
+	// disabled or pending (it is not enabled, so it accrues no misses).
 	existing := []string{"active-1", "active-2"}
-
-	refs, err := repo.DisableMissingModels(ctx, providerID, "test-provider", existing)
-	if err != nil {
-		t.Fatalf("DisableMissingModels: %v", err)
-	}
-
-	if len(refs) != 0 {
-		t.Errorf("expected 0 disabled refs (already-off was disabled before), got %v", refs)
+	for i := range 2 {
+		disabled, pending, err := repo.RecordMissingModels(ctx, providerID, "test-provider", existing)
+		if err != nil {
+			t.Fatalf("scan %d: %v", i+1, err)
+		}
+		if len(disabled) != 0 || len(pending) != 0 {
+			t.Errorf("scan %d: expected no refs, got disabled=%v pending=%v", i+1, disabled, pending)
+		}
 	}
 }
 
-func TestDisableMissingModels_SecondScanReturnsNothing(t *testing.T) {
+func TestRecordMissingModels_DisabledModelNotReturnedAgain(t *testing.T) {
 	ctx := context.Background()
 	repo := NewRepository(testPool)
 
-	providerID := insertTestProvider(ctx, t, "test-disable-missing-second-scan")
+	providerID := insertTestProvider(ctx, t, "test-record-missing-third-scan")
 	t.Cleanup(func() { cleanupProvider(ctx, t, providerID) })
 
 	insertTestModel(ctx, t, providerID, "kept-model")
 	insertTestModel(ctx, t, providerID, "gone-model")
 
 	existing := []string{"kept-model"}
-
-	// First scan: "gone-model" is newly disabled and returned.
-	refs, err := repo.DisableMissingModels(ctx, providerID, "test-provider", existing)
+	if _, _, err := repo.RecordMissingModels(ctx, providerID, "test-provider", existing); err != nil {
+		t.Fatalf("first scan: %v", err)
+	}
+	disabled, _, err := repo.RecordMissingModels(ctx, providerID, "test-provider", existing)
 	if err != nil {
-		t.Fatalf("DisableMissingModels first scan: %v", err)
+		t.Fatalf("second scan: %v", err)
 	}
-	if len(refs) != 1 || refs[0].ModelID != "gone-model" {
-		t.Fatalf("expected single ref for gone-model on first scan, got %v", refs)
+	if len(disabled) != 1 || disabled[0].ModelID != "gone-model" {
+		t.Fatalf("expected single ref for gone-model on second scan, got %v", disabled)
 	}
 
-	// Second scan with the same listing: gone-model is already disabled and
-	// must not be returned again.
-	refs, err = repo.DisableMissingModels(ctx, providerID, "test-provider", existing)
+	// Third scan with the same listing: gone-model is already disabled and must
+	// not be returned again.
+	disabled, pending, err := repo.RecordMissingModels(ctx, providerID, "test-provider", existing)
 	if err != nil {
-		t.Fatalf("DisableMissingModels second scan: %v", err)
+		t.Fatalf("third scan: %v", err)
 	}
-	if len(refs) != 0 {
-		t.Errorf("expected 0 disabled refs on second scan, got %v", refs)
+	if len(disabled) != 0 || len(pending) != 0 {
+		t.Errorf("expected no refs on third scan, got disabled=%v pending=%v", disabled, pending)
 	}
 }
 
-func TestDisableMissingModels_NonExistentProvider(t *testing.T) {
+func TestRecordMissingModels_NonExistentProvider(t *testing.T) {
 	ctx := context.Background()
-
 	repo := NewRepository(testPool)
 
-	// A provider UUID that does not exist should result in no disabled refs.
-	refs, err := repo.DisableMissingModels(ctx, uuid.New(), "test-provider", []string{"some-model"})
+	disabled, pending, err := repo.RecordMissingModels(ctx, uuid.New(), "test-provider", []string{"some-model"})
 	if err != nil {
-		t.Fatalf("DisableMissingModels with non-existent provider: %v", err)
+		t.Fatalf("RecordMissingModels with non-existent provider: %v", err)
 	}
-	if len(refs) != 0 {
-		t.Errorf("expected 0 disabled refs, got %d", len(refs))
+	if len(disabled) != 0 || len(pending) != 0 {
+		t.Errorf("expected no refs, got disabled=%v pending=%v", disabled, pending)
 	}
 }
 
-func TestDisableMissingModels_InvalidatesCache(t *testing.T) {
-	// Verify that InvalidateModelCache is called by checking that cached entries
-	// are cleared after the operation.
+func TestRecordMissingModels_InvalidatesCache(t *testing.T) {
+	// Verify InvalidateModelCache is called by checking cached entries are
+	// cleared by the operation.
 	InvalidateModelCache()
 
 	ctx := context.Background()
 	repo := NewRepository(testPool)
 
-	providerID := insertTestProvider(ctx, t, "test-disable-missing-cache")
+	providerID := insertTestProvider(ctx, t, "test-record-missing-cache")
 	t.Cleanup(func() { cleanupProvider(ctx, t, providerID) })
 
 	insertTestModel(ctx, t, providerID, "cache-model-a")
@@ -336,15 +387,15 @@ func TestDisableMissingModels_InvalidatesCache(t *testing.T) {
 		t.Fatal("expected model to be cached after GetByProviderAndModelID")
 	}
 
-	// Now run DisableMissingModels — should invalidate the cache.
-	_, err = repo.DisableMissingModels(ctx, providerID, "test-provider", []string{"cache-model-a"})
+	// Now run RecordMissingModels — should invalidate the cache.
+	_, _, err = repo.RecordMissingModels(ctx, providerID, "test-provider", []string{"cache-model-a"})
 	if err != nil {
-		t.Fatalf("DisableMissingModels: %v", err)
+		t.Fatalf("RecordMissingModels: %v", err)
 	}
 
 	// The cached entry should be gone.
 	_, ok = GetCachedByUUID(m.ID)
 	if ok {
-		t.Error("expected cache to be invalidated after DisableMissingModels")
+		t.Error("expected cache to be invalidated after RecordMissingModels")
 	}
 }

--- a/internal/provider/discovery.go
+++ b/internal/provider/discovery.go
@@ -67,22 +67,82 @@ func (d *DiscoveryService) SetRetryBaseDelay(dur time.Duration) {
 	d.retryBaseDelay = dur
 }
 
+// maxDiscoveryRetries bounds attempts for a single discovery HTTP call.
+const maxDiscoveryRetries = 3
+
+// doDiscoveryRequest executes a discovery HTTP request with retries for
+// transient network errors (DNS flaps, timeouts, connection resets) and
+// retryable HTTP statuses (429, 5xx), so one network hiccup cannot turn into
+// a failed or partial model listing. newReq rebuilds the request for each
+// attempt so request bodies (e.g. the ollama /api/show POST) replay correctly.
+// A response with a non-retryable status is returned as-is for the caller to
+// interpret; only the request host is logged (query strings can carry keys).
+func (d *DiscoveryService) doDiscoveryRequest(ctx context.Context, newReq func() (*http.Request, error)) (*http.Response, error) {
+	var lastErr error
+	for attempt := range maxDiscoveryRetries {
+		req, err := newReq()
+		if err != nil {
+			return nil, err
+		}
+		if attempt > 0 {
+			backoff := retryBackoff(d.retryBaseDelay, attempt)
+			debuglog.Info("discovery: retrying fetch",
+				"host", req.URL.Host, "backoff", backoff, "attempt", attempt+1, "max_attempts", maxDiscoveryRetries)
+			select {
+			case <-ctx.Done():
+				return nil, fmt.Errorf("context cancelled during discovery retry: %w", lastErr)
+			case <-time.After(backoff):
+			}
+		}
+
+		resp, err := d.httpClient.Do(req)
+		if err != nil {
+			if isTransientNetworkError(err) {
+				lastErr = err
+				debuglog.Info("discovery: transient fetch error, will retry",
+					"host", req.URL.Host, "attempt", attempt+1, "error", err)
+				continue
+			}
+			return nil, err
+		}
+		if isRetryableStatus(resp.StatusCode) {
+			body, _ := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			lastErr = fmt.Errorf("retryable HTTP status %d: %s", resp.StatusCode, util.SanitizeLogBody(string(body), 200))
+			debuglog.Info("discovery: retryable fetch status, will retry",
+				"host", req.URL.Host, "status", resp.StatusCode, "attempt", attempt+1)
+			continue
+		}
+		return resp, nil
+	}
+	return nil, fmt.Errorf("discovery fetch failed after %d attempts: %w", maxDiscoveryRetries, lastErr)
+}
+
+// doDiscoveryRequestPrebuilt retries a prebuilt body-less request (GETs).
+// Requests carrying a body must go through doDiscoveryRequest with a factory
+// so the body replays on retry.
+func (d *DiscoveryService) doDiscoveryRequestPrebuilt(ctx context.Context, req *http.Request) (*http.Response, error) {
+	return d.doDiscoveryRequest(ctx, func() (*http.Request, error) { return req, nil })
+}
+
 // fetchURL makes an HTTP request with the given headers, reads the full
 // response body, and checks for a 200 OK status. Returns the response body
 // bytes on success. The caller is responsible for unmarshaling the result.
+// Transient network errors and 429/5xx are retried via doDiscoveryRequest.
 func (d *DiscoveryService) fetchURL(ctx context.Context, method, url string, headers http.Header) ([]byte, error) {
 	//nolint:gocritic // url variable shadows import but context makes it clear
-	req, err := http.NewRequestWithContext(ctx, method, url, http.NoBody)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-	for k, vs := range headers {
-		for _, v := range vs {
-			req.Header.Add(k, v)
+	resp, err := d.doDiscoveryRequest(ctx, func() (*http.Request, error) {
+		req, err := http.NewRequestWithContext(ctx, method, url, http.NoBody)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create request: %w", err)
 		}
-	}
-
-	resp, err := d.httpClient.Do(req)
+		for k, vs := range headers {
+			for _, v := range vs {
+				req.Header.Add(k, v)
+			}
+		}
+		return req, nil
+	})
 	if err != nil {
 		return nil, fmt.Errorf("http request failed: %w", err)
 	}

--- a/internal/provider/discovery_anthropic.go
+++ b/internal/provider/discovery_anthropic.go
@@ -36,7 +36,7 @@ func (d *DiscoveryService) discoverAnthropic(ctx context.Context, provider *Prov
 		req.Header.Set("anthropic-version", "2023-06-01")
 		req.Header.Set("Content-Type", "application/json")
 
-		resp, err := d.httpClient.Do(req)
+		resp, err := d.doDiscoveryRequestPrebuilt(ctx, req)
 		if err != nil {
 			debuglog.Error("discovery: anthropic fetch models failed", "provider", provider.Name, "provider_id", provider.ID, "error", err)
 			return nil, fmt.Errorf("failed to fetch models: %w", err)

--- a/internal/provider/discovery_cohere.go
+++ b/internal/provider/discovery_cohere.go
@@ -65,7 +65,7 @@ func (d *DiscoveryService) fetchCohereModels(ctx context.Context, provider *Prov
 		req.Header.Set("Authorization", "Bearer "+apiKey)
 		req.Header.Set("Content-Type", "application/json")
 
-		resp, err := d.httpClient.Do(req)
+		resp, err := d.doDiscoveryRequestPrebuilt(ctx, req)
 		if err != nil {
 			debuglog.Error("discovery: cohere http request failed", "provider", provider.Name, "provider_id", provider.ID, "endpoint", endpoint, "error", err)
 			return nil, fmt.Errorf("failed to fetch models: %w", err)

--- a/internal/provider/discovery_deepseek.go
+++ b/internal/provider/discovery_deepseek.go
@@ -40,7 +40,7 @@ func (d *DiscoveryService) discoverDeepSeek(ctx context.Context, provider *Provi
 		live = append(live, liveModelStub(m.ID, m.OwnedBy, provider.ID))
 	}
 	// Empty-but-successful listing: return empty rather than the catalog so
-	// DisableMissingModels stays a no-op instead of disabling live-only models.
+	// RecordMissingModels stays a no-op instead of disabling live-only models.
 	if len(live) == 0 {
 		debuglog.Warn("discovery: deepseek /models returned no models, skipping", "provider", provider.Name, "provider_id", provider.ID)
 		return live, nil

--- a/internal/provider/discovery_deepseek_http_test.go
+++ b/internal/provider/discovery_deepseek_http_test.go
@@ -133,7 +133,7 @@ func TestDiscoverDeepSeek_EmptyResponse(t *testing.T) {
 		t.Fatalf("discoverDeepSeek failed: %v", err)
 	}
 	// Empty-but-successful listing returns empty (no catalog union), so the
-	// discovered set stays empty and DisableMissingModels is a no-op.
+	// discovered set stays empty and RecordMissingModels is a no-op.
 	if len(models) != 0 {
 		t.Errorf("Expected 0 models for empty live response, got %d", len(models))
 	}

--- a/internal/provider/discovery_google.go
+++ b/internal/provider/discovery_google.go
@@ -32,7 +32,7 @@ func (d *DiscoveryService) discoverGoogleAIStudio(ctx context.Context, provider 
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := d.httpClient.Do(req)
+	resp, err := d.doDiscoveryRequestPrebuilt(ctx, req)
 	if err != nil {
 		debuglog.Error("discovery: google http request failed", "provider", provider.Name, "provider_id", provider.ID, "error", err)
 		return nil, fmt.Errorf("google: failed to fetch models for provider %s: %w", provider.Name, err)

--- a/internal/provider/discovery_http_test.go
+++ b/internal/provider/discovery_http_test.go
@@ -270,7 +270,7 @@ func TestDiscoverOpenCodeGo_EmptyResponse(t *testing.T) {
 		t.Fatalf("discoverOpenCodeGo failed: %v", err)
 	}
 	// Empty-but-successful listing returns empty (no catalog union), so the
-	// discovered set stays empty and DisableMissingModels is a no-op.
+	// discovered set stays empty and RecordMissingModels is a no-op.
 	if len(models) != 0 {
 		t.Errorf("expected 0 models for empty live response, got %d", len(models))
 	}

--- a/internal/provider/discovery_koboldcpp.go
+++ b/internal/provider/discovery_koboldcpp.go
@@ -119,7 +119,7 @@ func (d *DiscoveryService) koboldcppVersion(ctx context.Context, apiBase string)
 		return "", err
 	}
 
-	resp, err := d.httpClient.Do(req)
+	resp, err := d.doDiscoveryRequestPrebuilt(ctx, req)
 	if err != nil {
 		return "", fmt.Errorf("http request failed: %w", err)
 	}
@@ -151,7 +151,7 @@ func (d *DiscoveryService) koboldcppLoadedModel(ctx context.Context, baseURL, ap
 		req.Header.Set("Authorization", "Bearer "+apiKey)
 	}
 
-	resp, err := d.httpClient.Do(req)
+	resp, err := d.doDiscoveryRequestPrebuilt(ctx, req)
 	if err != nil {
 		return "", fmt.Errorf("http request failed: %w", err)
 	}
@@ -181,7 +181,7 @@ func (d *DiscoveryService) koboldcppPerf(ctx context.Context, apiBase string) (*
 		return nil, err
 	}
 
-	resp, err := d.httpClient.Do(req)
+	resp, err := d.doDiscoveryRequestPrebuilt(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("http request failed: %w", err)
 	}

--- a/internal/provider/discovery_lmstudio.go
+++ b/internal/provider/discovery_lmstudio.go
@@ -74,7 +74,7 @@ func (d *DiscoveryService) discoverLMStudioNative(ctx context.Context, provider 
 		req.Header.Set("Authorization", "Bearer "+apiKey)
 	}
 
-	resp, err := d.httpClient.Do(req)
+	resp, err := d.doDiscoveryRequestPrebuilt(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("lmstudio: native request failed for provider %s: %w", provider.Name, err)
 	}
@@ -177,7 +177,7 @@ func (d *DiscoveryService) discoverLMStudioOpenAI(ctx context.Context, provider 
 		req.Header.Set("Authorization", "Bearer "+apiKey)
 	}
 
-	resp, err := d.httpClient.Do(req)
+	resp, err := d.doDiscoveryRequestPrebuilt(ctx, req)
 	if err != nil {
 		debuglog.Error("discovery: lmstudio http request failed", "provider", provider.Name, "provider_id", provider.ID, "error", err)
 		return nil, fmt.Errorf("lmstudio: failed to fetch models for provider %s: %w", provider.Name, err)

--- a/internal/provider/discovery_ollama.go
+++ b/internal/provider/discovery_ollama.go
@@ -28,7 +28,7 @@ func (d *DiscoveryService) discoverOllama(ctx context.Context, provider *Provide
 	}
 	req.Header.Set("Authorization", "Bearer "+apiKey)
 
-	resp, err := d.httpClient.Do(req)
+	resp, err := d.doDiscoveryRequestPrebuilt(ctx, req)
 	if err != nil {
 		debuglog.Error("discovery: ollama http request failed", "provider", provider.Name, "provider_id", provider.ID, "error", err)
 		return nil, fmt.Errorf("ollama: failed to fetch models for provider %s: %w", provider.Name, err)
@@ -87,13 +87,19 @@ func (d *DiscoveryService) discoverOllama(ctx context.Context, provider *Provide
 	models := make([]*model.Model, 0, len(tagsResp.Models))
 	skipped := 0
 	for _, r := range results {
+		show := r.show
 		if r.err != nil {
-			debuglog.Warn("discovery: ollama show model failed", "provider", provider.Name, "provider_id", provider.ID, "model", r.modelID, "error", r.err)
+			// The model IS listed by /api/tags; a failed detail probe must not
+			// drop it from the results, or RecordMissingModels would disable a
+			// model that merely had a flaky metadata fetch. Emit it with an
+			// empty show response: capabilities default to streaming-only and
+			// context length stays nil (fill-only, preserved at upsert).
+			debuglog.Warn("discovery: ollama show model failed, keeping model with default metadata", "provider", provider.Name, "provider_id", provider.ID, "model", r.modelID, "error", r.err)
 			skipped++
-			continue
+			show = &OllamaShowResponse{}
 		}
 
-		m := d.buildOllamaModel(provider, r.modelID, r.show)
+		m := d.buildOllamaModel(provider, r.modelID, show)
 		models = append(models, m)
 	}
 
@@ -115,14 +121,16 @@ func (d *DiscoveryService) ollamaShowModel(ctx context.Context, apiBase, apiKey,
 	showURL := apiBase + "/api/show"
 	body := fmt.Sprintf(`{"model":%q}`, modelName)
 
-	req, err := http.NewRequestWithContext(ctx, "POST", showURL, strings.NewReader(body))
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Authorization", "Bearer "+apiKey)
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := d.httpClient.Do(req)
+	// Rebuild the request per attempt so the POST body replays on retry.
+	resp, err := d.doDiscoveryRequest(ctx, func() (*http.Request, error) {
+		req, err := http.NewRequestWithContext(ctx, "POST", showURL, strings.NewReader(body))
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+		req.Header.Set("Content-Type", "application/json")
+		return req, nil
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/provider/discovery_ollama_http_test.go
+++ b/internal/provider/discovery_ollama_http_test.go
@@ -508,12 +508,28 @@ func TestDiscoverOllama_ShowModelFails(t *testing.T) {
 	if err != nil {
 		t.Fatalf("discoverOllama should not fail when show fails for individual models: %v", err)
 	}
-	// Only the good model should be returned
-	if len(models) != 1 {
-		t.Errorf("Expected 1 model (bad-model skipped), got %d", len(models))
+	// Both models must be returned: bad-model is listed by /api/tags, so a
+	// failed detail probe keeps it with default metadata instead of dropping
+	// it (a dropped model would be disabled as "missing" by the scan).
+	if len(models) != 2 {
+		t.Fatalf("Expected 2 models (bad-model kept with default metadata), got %d", len(models))
 	}
-	if models[0].ModelID != "good-model" {
-		t.Errorf("Expected ModelID 'good-model', got '%s'", models[0].ModelID)
+	byID := map[string]*model.Model{}
+	for _, m := range models {
+		byID[m.ModelID] = m
+	}
+	good, bad := byID["good-model"], byID["bad-model"]
+	if good == nil || bad == nil {
+		t.Fatalf("expected good-model and bad-model, got %v", models)
+	}
+	if good.ContextLength == nil || *good.ContextLength != 8192 {
+		t.Errorf("expected good-model context length 8192, got %v", good.ContextLength)
+	}
+	if bad.ContextLength != nil {
+		t.Errorf("expected bad-model context length nil (fill-only), got %v", *bad.ContextLength)
+	}
+	if !bad.Enabled {
+		t.Error("expected bad-model to stay enabled")
 	}
 }
 

--- a/internal/provider/discovery_openai.go
+++ b/internal/provider/discovery_openai.go
@@ -54,7 +54,7 @@ func (d *DiscoveryService) discoverOpenAI(ctx context.Context, provider *Provide
 	// phantom OpenAI models to a custom provider. For real OpenAI the catalog is
 	// a subset of the live listing, so there is nothing to union regardless.
 	// models.dev still enriches the rest. An empty listing stays empty, so
-	// DisableMissingModels is a no-op.
+	// RecordMissingModels is a no-op.
 	backfilled := backfillLiveFromCatalog(live, openaiCatalogModels(provider.ID))
 	debuglog.Info("discovery: openai discovered models", "provider", provider.Name, "provider_id", provider.ID, "live", len(live), "catalog", len(GetOpenAIModels()))
 	return backfilled, nil

--- a/internal/provider/discovery_opencode_go.go
+++ b/internal/provider/discovery_opencode_go.go
@@ -22,7 +22,7 @@ func (d *DiscoveryService) discoverOpenCodeGo(ctx context.Context, provider *Pro
 	req.Header.Set("Authorization", "Bearer "+apiKey)
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := d.httpClient.Do(req)
+	resp, err := d.doDiscoveryRequestPrebuilt(ctx, req)
 	if err != nil {
 		debuglog.Error("discovery: opencode-go http request failed", "provider", provider.Name, "provider_id", provider.ID, "error", err)
 		return nil, fmt.Errorf("opencode-go: failed to fetch models for provider %s: %w", provider.Name, err)
@@ -62,7 +62,7 @@ func (d *DiscoveryService) discoverOpenCodeGo(ctx context.Context, provider *Pro
 		live = append(live, liveModelStub(m.ID, m.OwnedBy, provider.ID))
 	}
 	// Empty-but-successful listing: return empty rather than the catalog so
-	// DisableMissingModels stays a no-op instead of disabling live-only models.
+	// RecordMissingModels stays a no-op instead of disabling live-only models.
 	if len(live) == 0 {
 		debuglog.Warn("discovery: opencode-go /models returned no models, skipping", "provider", provider.Name, "provider_id", provider.ID)
 		return live, nil

--- a/internal/provider/discovery_opencode_zen.go
+++ b/internal/provider/discovery_opencode_zen.go
@@ -58,7 +58,7 @@ func (d *DiscoveryService) discoverOpenCodeZen(ctx context.Context, provider *Pr
 		live = append(live, liveModelStub(m.ID, m.OwnedBy, provider.ID))
 	}
 	// Empty-but-successful listing: return empty rather than the catalog so
-	// DisableMissingModels stays a no-op instead of disabling live-only models.
+	// RecordMissingModels stays a no-op instead of disabling live-only models.
 	if len(live) == 0 {
 		debuglog.Warn("discovery: opencode-zen /models returned no models, skipping", "provider", provider.Name, "provider_id", provider.ID)
 		return live, nil

--- a/internal/provider/discovery_retry_test.go
+++ b/internal/provider/discovery_retry_test.go
@@ -3,15 +3,55 @@ package provider
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 )
+
+// cancelOnFirstTransport returns a transient network error on the first call
+// (driving doDiscoveryRequest into its backoff) and cancels ctx as it does, so
+// the retry's backoff select must take the ctx.Done() arm rather than sleeping.
+type cancelOnFirstTransport struct {
+	calls  atomic.Int32
+	cancel context.CancelFunc
+}
+
+func (c *cancelOnFirstTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	if c.calls.Add(1) == 1 {
+		c.cancel()
+		return nil, &net.OpError{Op: "dial", Err: errors.New("transient flap")}
+	}
+	return nil, errors.New("second attempt must never be dialed")
+}
+
+func TestDoDiscoveryRequest_ContextCancelledDuringBackoff(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	tr := &cancelOnFirstTransport{cancel: cancel}
+	// A long base delay guarantees the select would block on time.After, so a
+	// prompt return proves the ctx.Done() arm fired rather than the timer.
+	d := &DiscoveryService{httpClient: &http.Client{Transport: tr}, retryBaseDelay: time.Hour}
+
+	_, err := d.doDiscoveryRequest(ctx, func() (*http.Request, error) {
+		return http.NewRequestWithContext(ctx, "GET", "http://example.invalid", http.NoBody)
+	})
+	if err == nil {
+		t.Fatal("expected an error when the context is cancelled during backoff")
+	}
+	if !strings.Contains(err.Error(), "context cancelled during discovery retry") {
+		t.Fatalf("expected the backoff-cancel error, got %v", err)
+	}
+	if got := tr.calls.Load(); got != 1 {
+		t.Errorf("expected exactly one attempt before the cancelled backoff, got %d", got)
+	}
+}
 
 // ---------------------------------------------------------------------------
 // doDiscoveryRequest — retry behavior for discovery fetches. All services are

--- a/internal/provider/discovery_retry_test.go
+++ b/internal/provider/discovery_retry_test.go
@@ -1,0 +1,184 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// ---------------------------------------------------------------------------
+// doDiscoveryRequest — retry behavior for discovery fetches. All services are
+// built with retryBaseDelay left at its zero value so backoffs are instant.
+// ---------------------------------------------------------------------------
+
+func retryTestService(server *httptest.Server) *DiscoveryService {
+	return &DiscoveryService{httpClient: server.Client()}
+}
+
+func TestDoDiscoveryRequest_RetriesRetryableStatusThenSucceeds(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if calls.Add(1) < 3 {
+			http.Error(w, "upstream hiccup", http.StatusBadGateway)
+			return
+		}
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer server.Close()
+
+	d := retryTestService(server)
+	resp, err := d.doDiscoveryRequest(context.Background(), func() (*http.Request, error) {
+		return http.NewRequestWithContext(context.Background(), "GET", server.URL, http.NoBody)
+	})
+	if err != nil {
+		t.Fatalf("expected success after retries, got %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if got := calls.Load(); got != 3 {
+		t.Errorf("expected 3 attempts, got %d", got)
+	}
+}
+
+func TestDoDiscoveryRequest_ExhaustsRetries(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		http.Error(w, "rate limited", http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	d := retryTestService(server)
+	_, err := d.doDiscoveryRequest(context.Background(), func() (*http.Request, error) {
+		return http.NewRequestWithContext(context.Background(), "GET", server.URL, http.NoBody)
+	})
+	if err == nil {
+		t.Fatal("expected error after exhausting retries")
+	}
+	if got := calls.Load(); got != maxDiscoveryRetries {
+		t.Errorf("expected %d attempts, got %d", maxDiscoveryRetries, got)
+	}
+}
+
+func TestDoDiscoveryRequest_NonRetryableStatusReturnedImmediately(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	d := retryTestService(server)
+	resp, err := d.doDiscoveryRequest(context.Background(), func() (*http.Request, error) {
+		return http.NewRequestWithContext(context.Background(), "GET", server.URL, http.NoBody)
+	})
+	if err != nil {
+		t.Fatalf("expected the 401 response returned as-is, got error %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", resp.StatusCode)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Errorf("expected a single attempt for a non-retryable status, got %d", got)
+	}
+}
+
+func TestDoDiscoveryRequest_PostBodyReplaysOnRetry(t *testing.T) {
+	// The ollama /api/show path POSTs a JSON body; every retry must carry the
+	// full body, which is why doDiscoveryRequest rebuilds the request.
+	var calls atomic.Int32
+	var bodies []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		bodies = append(bodies, string(b))
+		if calls.Add(1) < 2 {
+			http.Error(w, "flap", http.StatusServiceUnavailable)
+			return
+		}
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer server.Close()
+
+	d := retryTestService(server)
+	resp, err := d.doDiscoveryRequest(context.Background(), func() (*http.Request, error) {
+		return http.NewRequestWithContext(context.Background(), "POST", server.URL, strings.NewReader(`{"model":"m"}`))
+	})
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if len(bodies) != 2 || bodies[0] != `{"model":"m"}` || bodies[1] != `{"model":"m"}` {
+		t.Fatalf("expected the body on every attempt, got %q", bodies)
+	}
+}
+
+func TestFetchURL_RetriesTransient5xx(t *testing.T) {
+	// End-to-end through fetchURL: one flaky 500 must not fail a listing.
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if calls.Add(1) == 1 {
+			http.Error(w, "transient", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": []any{}})
+	}))
+	defer server.Close()
+
+	d := retryTestService(server)
+	body, err := d.fetchURL(context.Background(), "GET", server.URL, nil)
+	if err != nil {
+		t.Fatalf("expected fetchURL to retry the 500, got %v", err)
+	}
+	if !strings.Contains(string(body), "data") {
+		t.Errorf("unexpected body %q", body)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Errorf("expected 2 attempts, got %d", got)
+	}
+}
+
+func TestDiscoverOllama_TagsRetriesTransientFailure(t *testing.T) {
+	// The whole discovery flow: a 503 on the first /api/tags fetch is retried,
+	// so the scan succeeds instead of aborting on a network hiccup.
+	var tagCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/tags":
+			if tagCalls.Add(1) == 1 {
+				http.Error(w, "flap", http.StatusServiceUnavailable)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(OllamaTagsResponse{Models: []OllamaTagsModel{{Name: "m1"}}})
+		case "/api/show":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(OllamaShowResponse{Capabilities: []string{"completion"}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	d := retryTestService(server)
+	models, err := d.discoverOllama(context.Background(), &Provider{ID: uuid.New(), BaseURL: server.URL}, "key")
+	if err != nil {
+		t.Fatalf("expected discovery to survive one flaky tags fetch, got %v", err)
+	}
+	if len(models) != 1 || models[0].ModelID != "m1" {
+		t.Fatalf("expected m1 discovered, got %v", models)
+	}
+	if got := tagCalls.Load(); got != 2 {
+		t.Errorf("expected 2 tags attempts, got %d", got)
+	}
+}

--- a/internal/provider/discovery_test.go
+++ b/internal/provider/discovery_test.go
@@ -1963,9 +1963,16 @@ func TestDiscoverOllama_ShowModelFailure(t *testing.T) {
 		t.Fatalf("discoverOllama failed: %v", err)
 	}
 
-	// Should have 2 models (1 skipped due to show failure)
-	if len(models) != 2 {
-		t.Errorf("Expected 2 models (1 skipped), got %d", len(models))
+	// All 3 models must be returned: failing-model is listed by /api/tags, so
+	// its failed detail probe keeps it with default metadata instead of
+	// dropping it (which would get it disabled as "missing").
+	if len(models) != 3 {
+		t.Fatalf("Expected 3 models (failing-model kept with default metadata), got %d", len(models))
+	}
+	for _, m := range models {
+		if m.ModelID == "failing-model" && m.ContextLength != nil {
+			t.Errorf("expected failing-model context length nil, got %v", *m.ContextLength)
+		}
 	}
 }
 

--- a/internal/provider/discovery_xai.go
+++ b/internal/provider/discovery_xai.go
@@ -53,7 +53,7 @@ func (d *DiscoveryService) discoverXAI(ctx context.Context, provider *Provider, 
 
 	// Both endpoints succeeded but listed no models (distinct from the no-access
 	// 403/429 path above, which intentionally returns the catalog). Return empty
-	// rather than unioning the catalog, so DisableMissingModels stays a no-op
+	// rather than unioning the catalog, so RecordMissingModels stays a no-op
 	// instead of disabling every live-only model.
 	if len(live) == 0 {
 		debuglog.Warn("discovery: xai endpoints returned no models, skipping", "provider", provider.Name, "provider_id", provider.ID)
@@ -77,7 +77,7 @@ func (d *DiscoveryService) discoverXAILanguageModels(ctx context.Context, provid
 	req.Header.Set("Authorization", "Bearer "+apiKey)
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := d.httpClient.Do(req)
+	resp, err := d.doDiscoveryRequestPrebuilt(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("xAI: http request failed for provider %s: %w", provider.Name, err)
 	}
@@ -166,7 +166,7 @@ func (d *DiscoveryService) discoverXAIMinimalModels(ctx context.Context, provide
 	req.Header.Set("Authorization", "Bearer "+apiKey)
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := d.httpClient.Do(req)
+	resp, err := d.doDiscoveryRequestPrebuilt(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("xAI: http request failed for provider %s: %w", provider.Name, err)
 	}

--- a/internal/provider/discovery_xai_http_test.go
+++ b/internal/provider/discovery_xai_http_test.go
@@ -1036,7 +1036,7 @@ func TestDiscoverXAI_LanguageModelsEmpty_MinimalModelsEmpty(t *testing.T) {
 		t.Fatalf("expected no error with empty live, got: %v", err)
 	}
 	// Empty-but-successful endpoints return empty (not the catalog) so
-	// DisableMissingModels stays a no-op; the no-access 403/429 path still
+	// RecordMissingModels stays a no-op; the no-access 403/429 path still
 	// returns the catalog (covered by TestDiscoverXAI_RateLimitFallback).
 	if len(models) != 0 {
 		t.Errorf("expected 0 models when live is empty, got %d", len(models))

--- a/internal/provider/discovery_zai.go
+++ b/internal/provider/discovery_zai.go
@@ -21,7 +21,7 @@ func (d *DiscoveryService) discoverZAICoding(ctx context.Context, provider *Prov
 	live, err := d.discoverZAICodingLive(ctx, provider, apiKey)
 	if err != nil {
 		// Abort the scan rather than falling back to the catalog: a transient
-		// failure must not let DisableMissingModels disable models that are only
+		// failure must not let RecordMissingModels disable models that are only
 		// in the live listing (the Z.ai catalog is a subset). Aborting preserves
 		// the existing models; the catalog union still runs on a successful fetch.
 		debuglog.Error("discovery: zai-coding live /models failed, aborting scan", "provider", provider.Name, "provider_id", provider.ID, "error", err)
@@ -29,7 +29,7 @@ func (d *DiscoveryService) discoverZAICoding(ctx context.Context, provider *Prov
 	}
 	if len(live) == 0 {
 		// Successful fetch but empty list: return empty (not the catalog) so the
-		// discovered set stays empty and DisableMissingModels is a no-op,
+		// discovered set stays empty and RecordMissingModels is a no-op,
 		// instead of disabling every live-only model.
 		debuglog.Warn("discovery: zai-coding live /models returned no models, skipping", "provider", provider.Name, "provider_id", provider.ID)
 		return live, nil

--- a/internal/provider/discovery_zai_test.go
+++ b/internal/provider/discovery_zai_test.go
@@ -123,7 +123,7 @@ func TestDiscoverZAICoding_VisionModelCapabilities(t *testing.T) {
 
 // TestDiscoverZAICoding_LiveFailureAborts verifies that when the live /models
 // endpoint errors, discovery aborts (returns an error) rather than falling back
-// to the catalog — so DisableMissingModels never runs and existing models are
+// to the catalog — so RecordMissingModels never runs and existing models are
 // preserved instead of having live-only models disabled.
 func TestDiscoverZAICoding_LiveFailureAborts(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/wiki/Model-Discovery.md
+++ b/wiki/Model-Discovery.md
@@ -83,7 +83,7 @@ Two manual discovery endpoints are available:
 | `/api/providers/{id}/discover` | POST | Single provider | Discover models for one provider; disables models no longer present |
 | `/api/providers/discover-all` | POST | All providers | Discover models for every enabled provider; skips disabled providers |
 
-Both endpoints upsert discovered models and call `DisableMissingModels` to disable any models that were previously known but are no longer returned by the provider API. The failover groups of newly disabled models are re-synced in the same scan, so a model that leaves a provider's listing is also pruned from its group instead of lingering as a stale entry (the same cleanup a manual failover sync performs).
+Both endpoints upsert discovered models and feed the confirmed listing into `RecordMissingModels`, which disables a model only after two consecutive scans (each with in-scan confirmation probes) fail to list it - see [Missing models: three layers of proof before a disable](#missing-models-three-layers-of-proof-before-a-disable). The failover groups of newly disabled models are re-synced in the same scan, so a model that leaves a provider's listing is also pruned from its group instead of lingering as a stale entry (the same cleanup a manual failover sync performs).
 
 Both endpoints also return a `diff` describing what the scan changed - models added, re-enabled, or disabled (with machine-readable reason codes `new_model`, `reappeared`, `not_listed`) plus any failover groups updated or deleted as a result. It also reports `updated` models whose live pricing or context-length metadata moved since the previous scan: each entry carries per-field `changes` (codes `input_price`, `output_price`, `input_price_cache`, `context_length`, each with `old`/`new` numbers). Only fields the provider's own live API supplied this scan are compared (tracked via transient per-field live provenance), so catalog/models.dev backfills, flaky probes, and manual price edits never surface as spurious changes. The dashboard renders this diff as a post-scan summary modal after manual Discover / Discover All runs; an all-empty diff still confirms "scanned, nothing changed".
 
@@ -707,6 +707,7 @@ CREATE TABLE IF NOT EXISTS models (
     owned_by    TEXT,
     enabled     BOOLEAN DEFAULT true,
     disabled_manually BOOLEAN DEFAULT false,
+    missing_scans INTEGER NOT NULL DEFAULT 0,
     created_at  TIMESTAMPTZ DEFAULT now(),
     last_seen_at TIMESTAMPTZ DEFAULT now(),
     UNIQUE(provider_id, model_id)
@@ -722,6 +723,7 @@ CREATE TABLE IF NOT EXISTS models (
 - `002_model_seen_and_settings.sql` - Added `last_seen_at`, `owned_by`, `context_length`, `input_price_per_million`, `output_price_per_million`
 - `003_model_details.sql` - Added `name`, `description`, `max_output_tokens`, `modality`, `input_modalities`, `output_modalities`
 - `021_model_disabled_manually.sql` - Added `disabled_manually` column
+- `054_model_missing_scans.sql` - Added `missing_scans` consecutive-miss counter
 
 ### Settings Table (Discovery Configuration)
 
@@ -781,7 +783,7 @@ When discovery upserts a model, it uses an `ON CONFLICT` strategy:
 
 - **New models** are inserted with `enabled = true`.
 - **Existing models** (matched by `provider_id + model_id` unique constraint) are updated with all new metadata. The `enabled` flag is set based on the `disabled_manually` flag:
-  - If `disabled_manually = false`, the model is **re-enabled** (it may have been previously disabled by `DisableMissingModels` but is now back).
+  - If `disabled_manually = false`, the model is **re-enabled** (it may have been previously disabled by `RecordMissingModels` but is now back).
   - If `disabled_manually = true`, the model **stays disabled** - the user's manual override is respected even if the model reappears in the provider API.
 - `last_seen_at` is always updated to `now()`.
 
@@ -789,13 +791,42 @@ When discovery upserts a model, it uses an `ON CONFLICT` strategy:
 enabled = CASE WHEN models.disabled_manually = false THEN true ELSE models.enabled END
 ```
 
-### DisableMissingModels
+### Missing models: three layers of proof before a disable
 
-After each discovery run, `DisableMissingModels` is called. This sets `enabled = false` for any model belonging to the provider that was **not** in the discovered set (and was still enabled - already-disabled rows are not touched again on repeat scans). It returns the list of newly disabled models, which the discovery handlers use to (a) re-sync the failover groups those models belonged to, pruning their stale entries, and (b) report them in the scan's `diff` with reason `not_listed`.
+A model absent from one listing is **never** disabled immediately. Discovery
+requires three independent layers of evidence, so one DNS flap, transient 5xx,
+or partial upstream listing cannot disable models (which, in an HA fleet,
+would then propagate to every member):
 
-Note: `DisableMissingModels` sets `enabled = false` but does **not** set `disabled_manually = true`. This means the model will be automatically re-enabled on the next discovery run if it reappears. On the Models page, discovery-disabled models (`enabled = false`, `disabled_manually = false`) show a tooltip on the status badge: "Not listed by the provider since {date}" (based on `last_seen_at`).
+1. **Transport retries.** Every discovery HTTP call (listings and per-model
+   detail probes) retries transient network errors and 429/5xx responses up to
+   3 attempts with linear backoff and jitter. Ollama-family per-model
+   `/api/show` failures no longer drop the model from the results either: the
+   model was listed by `/api/tags`, so it is kept with default metadata.
+2. **In-scan confirmation probes (`ConfirmMissingModels`).** If the listing is
+   missing any previously enabled model, discovery re-runs the full listing up
+   to 2 more times (after ~15s and ~45s backoff plus jitter) and takes the
+   union of all probes' model IDs as the scan's membership. A model only
+   counts as *missing this scan* if every probe missed it. If a confirmation
+   probe itself fails, or if the confirmed-missing set is implausibly large
+   (more than 5 models AND more than half the provider's enabled models - the
+   *mass-vanish guard*, which emits a `discovery.suspect_scan` warning event),
+   the whole scan is treated as suspect and records no misses at all.
+3. **Cross-scan miss streak (`RecordMissingModels`).** A confirmed miss
+   increments the model's `missing_scans` counter. Only when the streak
+   reaches 2 consecutive scans is the model disabled (`enabled = false`). Any
+   sighting - a scheduled scan, a manual re-test, even a confirmation probe -
+   resets the streak to 0.
 
-`DisableMissingModels` can only run after a **successful** listing, and it early-returns when the discovered list is empty - a provider outage or auth error aborts the scan before anything is disabled, so "disabled by discovery" always means *"the provider responded and did not list this model"*.
+`RecordMissingModels` returns the newly disabled models, which the discovery
+handlers use to (a) re-sync the failover groups those models belonged to,
+pruning their stale entries, and (b) report them in the scan's `diff` with
+reason `not_listed`. Models missing but below the threshold are only logged
+("pending"); they appear nowhere in the diff and stay fully routable.
+
+Note: `RecordMissingModels` sets `enabled = false` but does **not** set `disabled_manually = true`. This means the model will be automatically re-enabled on the next discovery run if it reappears. On the Models page, discovery-disabled models (`enabled = false`, `disabled_manually = false`) show a tooltip on the status badge: "Not listed by the provider since {date}" (based on `last_seen_at`).
+
+Miss recording can only run after a **successful** listing, and it is skipped entirely when the discovered list is empty, when the pre-scan snapshot could not be read, or when any model upsert failed - a provider outage, auth error, or DB hiccup aborts the scan before anything is counted missing, so "disabled by discovery" always means *"the provider repeatedly responded and did not list this model"*.
 
 In summary:
 - **Auto-disabled** models (removed from the provider API) have `disabled_manually = false` and are re-enabled if they reappear.
@@ -959,7 +990,7 @@ The cache is **invalidated on every write operation**:
 - `SetEnabled()` - Manual enable/disable
 - `Update()` - Partial updates
 - `DeleteByID()` - Model deletion
-- `DisableMissingModels()` - Bulk disable
+- `RecordMissingModels()` - Miss-streak recording / threshold disable
 
 This ensures cache consistency at the cost of cache hit rate during active discovery runs.
 

--- a/wiki/Model-Discovery.md
+++ b/wiki/Model-Discovery.md
@@ -80,12 +80,12 @@ Two manual discovery endpoints are available:
 
 | Endpoint | Method | Scope | Description |
 |----------|--------|-------|-------------|
-| `/api/providers/{id}/discover` | POST | Single provider | Discover models for one provider; disables models no longer present |
-| `/api/providers/discover-all` | POST | All providers | Discover models for every enabled provider; skips disabled providers |
+| `/api/providers/{id}/discover` | POST | Single provider | Discover and import models for one provider |
+| `/api/providers/discover-all` | POST | All providers | Discover and import models for every enabled provider; skips disabled providers |
 
-Both endpoints upsert discovered models and feed the confirmed listing into `RecordMissingModels`, which disables a model only after two consecutive scans (each with in-scan confirmation probes) fail to list it - see [Missing models: three layers of proof before a disable](#missing-models-three-layers-of-proof-before-a-disable). The failover groups of newly disabled models are re-synced in the same scan, so a model that leaves a provider's listing is also pruned from its group instead of lingering as a stale entry (the same cleanup a manual failover sync performs).
+Both endpoints upsert discovered models and re-sync failover groups for what they saw. They do **not** disable missing models: disabling requires two consecutive confirmed-missing scans, so a single on-demand click can never reach that threshold, and running the in-scan confirmation probes (up to ~70s of backoff) on a request would overrun the route's 60s HTTP timeout - which also made the HA config-sync import look like it failed. Miss-recording and disabling are therefore owned exclusively by the scheduled/startup background sweep - see [Missing models: three layers of proof before a disable](#missing-models-three-layers-of-proof-before-a-disable). When the background sweep does disable a model, its failover group is re-synced in the same scan so the model is pruned instead of lingering as a stale entry.
 
-Both endpoints also return a `diff` describing what the scan changed - models added, re-enabled, or disabled (with machine-readable reason codes `new_model`, `reappeared`, `not_listed`) plus any failover groups updated or deleted as a result. It also reports `updated` models whose live pricing or context-length metadata moved since the previous scan: each entry carries per-field `changes` (codes `input_price`, `output_price`, `input_price_cache`, `context_length`, each with `old`/`new` numbers). Only fields the provider's own live API supplied this scan are compared (tracked via transient per-field live provenance), so catalog/models.dev backfills, flaky probes, and manual price edits never surface as spurious changes. The dashboard renders this diff as a post-scan summary modal after manual Discover / Discover All runs; an all-empty diff still confirms "scanned, nothing changed".
+Both endpoints also return a `diff` describing what the scan changed - models added or re-enabled (with machine-readable reason codes `new_model`, `reappeared`) plus any failover groups updated as a result. (The background sweep's diff can also carry `disabled` entries with reason `not_listed`; manual scans never disable, so theirs will not.) It also reports `updated` models whose live pricing or context-length metadata moved since the previous scan: each entry carries per-field `changes` (codes `input_price`, `output_price`, `input_price_cache`, `context_length`, each with `old`/`new` numbers). Only fields the provider's own live API supplied this scan are compared (tracked via transient per-field live provenance), so catalog/models.dev backfills, flaky probes, and manual price edits never surface as spurious changes. The dashboard renders this diff as a post-scan summary modal after manual Discover / Discover All runs; an all-empty diff still confirms "scanned, nothing changed".
 
 Scheduled/startup background discovery does not pop the modal (SSE events cover it). Instead, any changes it records are persisted to a `discovery_changes` store (migration `047`) and surfaced as a count badge on the **Models** sidebar item; clicking the badge opens a summary modal of the recorded changes and acks the unseen rows server-side (clearing the badge). A `discovery.changes_pending` SSE event fires when a background scan records changes. See the [API Reference](https://github.com/hugalafutro/model-hotel/wiki/API-Reference) for the `GET /api/discovery/changes` and `POST /api/discovery/changes/ack` endpoints.
 
@@ -796,7 +796,9 @@ enabled = CASE WHEN models.disabled_manually = false THEN true ELSE models.enabl
 A model absent from one listing is **never** disabled immediately. Discovery
 requires three independent layers of evidence, so one DNS flap, transient 5xx,
 or partial upstream listing cannot disable models (which, in an HA fleet,
-would then propagate to every member):
+would then propagate to every member). Only the scheduled/startup background
+sweep applies these layers and disables; manual `Discover` scans just import
+what they see (see [Manual Discovery](#manual-discovery)).
 
 1. **Transport retries.** Every discovery HTTP call (listings and per-model
    detail probes) retries transient network errors and 429/5xx responses up to
@@ -811,7 +813,15 @@ would then propagate to every member):
    probe itself fails, or if the confirmed-missing set is implausibly large
    (more than 5 models AND more than half the provider's enabled models - the
    *mass-vanish guard*, which emits a `discovery.suspect_scan` warning event),
-   the whole scan is treated as suspect and records no misses at all.
+   the whole scan is treated as suspect and records no misses at all. A provider
+   that genuinely retires that many models would otherwise trip the guard on
+   every scan and stay stale forever, so a per-provider `suspect_scans` counter
+   tracks consecutive mass-vanish scans; once it reaches 3 (and every 3 after),
+   discovery raises a distinct high-severity `discovery.bulk_removal_suspected`
+   event asking an operator to review and disable the retired models by hand. It
+   never auto-disables on this signal - disabling half a provider's catalog is
+   too destructive to do unattended when it fans out across an HA fleet. A
+   healthy scan (the listing recovered) resets the counter to 0.
 3. **Cross-scan miss streak (`RecordMissingModels`).** A confirmed miss
    increments the model's `missing_scans` counter. Only when the streak
    reaches 2 consecutive scans is the model disabled (`enabled = false`). Any


### PR DESCRIPTION
## What

Discovery could disable live models off a single flaky provider scan (one DNS flap, transient 5xx, or partial upstream listing). In an HA fleet that mistake then propagates to every member. This makes a model's disappearance require **multiple independent layers of evidence** before it is ever disabled, and keeps that (potentially slow) evidence-gathering off request-bound code paths.

## Three layers of proof before a disable

1. **HTTP-level retries** on each provider discovery probe, so a transient network blip no longer reads as an empty catalog.
2. **In-scan confirmation probes**: a model that appears to have vanished is re-checked with backoff before it counts as missing.
3. **Cross-scan miss streak**: a model must be absent for `MissingScanThreshold` (2) consecutive confirmed scans, plus a **mass-vanish guard** that treats an implausibly large disappearance (>5 models AND >50% of a provider's enabled set) as a suspect scan that records nothing.

Migration `054` adds the per-model `missing_scans` streak counter.

## Disabling is owned by the background sweep only

The confirmation probes can sleep for the full backoff (~70s). They previously ran synchronously inside three handler paths bounded by `middleware.Timeout(60s)`: the single-provider **Discover** button, **Discover-All**, and the **HA config-sync import**. On a missing-model scan they overran the timeout and wrote the response to a dead connection, making a config sync look failed even though the decoupled work completed.

Since a single interactive scan can never reach the 2-scan threshold anyway, miss-recording and disabling now run **only on the scheduled/startup sweep**. Interactive Discover just fetches, upserts, and re-syncs failover for what it saw. `discoverAllProviders` gates recording behind a `recordMisses` flag (false for both HTTP callers).

## Bulk-removal escalation

A provider that genuinely sunsets >50% of its models trips the mass-vanish guard on every scan and would otherwise stay stale forever. A per-provider `suspect_scans` counter (migration `055`) tracks consecutive mass-vanish scans; once it reaches 3 (and every 3 after) discovery raises a distinct high-severity `discovery.bulk_removal_suspected` event asking an operator to disable the retired models by hand. It **never auto-disables** on this signal, since disabling half a catalog fans out across an HA fleet. A healthy scan resets the counter.

## Tests

- Disable/suspect behaviour is exercised through the real sweep (`discoverAllProviders`) via a new `sweepProviderDiff` helper, rather than the interactive handler.
- Regression guard that the interactive handler does **not** record misses.
- Added coverage for the retry backoff's context-cancel arm, the mass-vanish floor boundary (5 vs 6 of 10), and the escalation predicate.
- Full `go test ./...` green; `golangci-lint` clean.

Wiki `Model-Discovery.md` updated (auto-publishes on merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)