### PR TITLE
docs: replace sunset Go Report badge with golangci-lint badge

### DIFF
--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -6,7 +6,7 @@
 
 **Multi-Provider AI Gateway**
 
-![Github CI](https://github.com/hugalafutro/model-hotel/actions/workflows/ci.yml/badge.svg) ![Go Version](https://img.shields.io/github/go-mod/go-version/hugalafutro/model-hotel) ![Go Report](https://goreportcard.com/badge/github.com/hugalafutro/model-hotel) ![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?logo=typescript&logoColor=white) ![React](https://img.shields.io/badge/React-61DAFB?logo=react&logoColor=black) ![PostgreSQL](https://img.shields.io/badge/PostgreSQL-4169E1?logo=postgresql&logoColor=white)  ![Coverage](https://codecov.io/github/hugalafutro/model-hotel/branch/master/graph/badge.svg) ![GitHub Repo stars](https://img.shields.io/github/stars/hugalafutro/model-hotel)
+![Github CI](https://github.com/hugalafutro/model-hotel/actions/workflows/ci.yml/badge.svg) ![Go Version](https://img.shields.io/github/go-mod/go-version/hugalafutro/model-hotel) [![golangci-lint](https://img.shields.io/badge/lint-golangci--lint-00ACD7?logo=go&logoColor=white)](https://golangci-lint.run) ![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?logo=typescript&logoColor=white) ![React](https://img.shields.io/badge/React-61DAFB?logo=react&logoColor=black) ![PostgreSQL](https://img.shields.io/badge/PostgreSQL-4169E1?logo=postgresql&logoColor=white)  ![Coverage](https://codecov.io/github/hugalafutro/model-hotel/branch/master/graph/badge.svg) ![GitHub Repo stars](https://img.shields.io/github/stars/hugalafutro/model-hotel)
 
 
 > **AI-Assisted Project Disclaimer:**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
  <img src="https://img.shields.io/badge/PostgreSQL-4169E1?logo=postgresql&logoColor=white" alt="PostgreSQL">
  <a href="https://hub.docker.com/r/hugalafutro/model-hotel"><img src="https://img.shields.io/docker/pulls/hugalafutro/model-hotel.svg" alt="Docker Pulls"></a>
  <a href="https://github.com/hugalafutro/model-hotel/actions/workflows/ci.yml"><img src="https://github.com/hugalafutro/model-hotel/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
- <a href="https://goreportcard.com/report/github.com/hugalafutro/model-hotel"><img src="https://goreportcard.com/badge/github.com/hugalafutro/model-hotel" alt="Go Report"></a>
+ <a href="https://golangci-lint.run"><img src="https://img.shields.io/badge/lint-golangci--lint-00ACD7?logo=go&logoColor=white" alt="golangci-lint"></a>
  <a href="https://codecov.io/github/hugalafutro/model-hotel"><img src="https://codecov.io/github/hugalafutro/model-hotel/branch/master/graph/badge.svg" alt="Coverage"></a><br>
 </p>
 


### PR DESCRIPTION
## What

[goreportcard.com](https://goreportcard.com/report/github.com/hugalafutro/model-hotel) is being sunset and links to [golangci-lint.run](https://golangci-lint.run/) as its replacement. This swaps the dynamic Go Report grade badge for a static golangci-lint badge in both `README.md` and `DOCKERHUB.md`.

## Why static

golangci-lint has no hosted per-repo scoring service like goreportcard did (it's a linter you run in CI, which this repo already does in `ci.yml`). The conventional replacement is a static badge linking to golangci-lint.run, so **no CI changes are needed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)