### PR TITLE
build: bump Go 1.26.4 -> 1.26.5 (GO-2026-5856)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hugalafutro/model-hotel
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/anthropics/anthropic-sdk-go v1.53.0


### PR DESCRIPTION
## Summary

Fixes the `Go Vulncheck` CI job that started failing on every run after **Jul 07 2026**.

**GO-2026-5856 (CVE-2026-42505)** — `crypto/tls`: ECH handshakes could be de-anonymized by a passive network observer because PSK identities leaked in the *unencrypted* ClientHello.
- Affects: `go1.26.0` – `<go1.26.5`
- Fixed in: `go1.26.5`
- Published: Jul 07 2026

This is why #376 passed vulncheck but #377 (and every PR scanned after Jul 07) fails: the vulnerable `crypto/tls` code was always in go1.26.4, but govulncheck only flags advisories that exist in the DB at scan time. No code change — just the toolchain pin.

### Change
`go.mod`: `go 1.26.4` -> `go 1.26.5` (one line). `go.mod` is the single source CI reads (`go-version-file: go.mod`); the Dockerfiles use the floating `golang:1.26-alpine` tag and already pick up 1.26.5 automatically.

### Unblocks
#377 (docs) — once this merges, rebase #377 onto master and its vulncheck job goes green.

🤖 Generated with [OpenCode](https://opencode.ai)