### PR TITLE
docs: HA wiki 2x2 thumb grid, link every screenshot, hotel-N pill

### DIFF
--- a/wiki/High-Availability.md
+++ b/wiki/High-Availability.md
@@ -8,10 +8,14 @@ control-plane app where you manage membership in a browser.
 Front Desk is **never in the request path**. If it stops, Traefik keeps serving
 with the last config it fetched; only membership changes pause until it returns.
 
-<p align="center"><img src="screenshots/frontdesk_members.png" width="800" alt="Front Desk Members tab with two healthy members"></p>
+<p align="center"><a href="screenshots/frontdesk_members.png"><img src="screenshots/frontdesk_members.png" width="800" alt="Front Desk Members tab with two healthy members"></a></p>
 
-<p align="center"><a href="screenshots/frontdesk_settings.png"><img src="screenshots/frontdesk_settings_security_thumb.png" width="200" alt="Security (passkeys + TOTP)"></a><a href="screenshots/frontdesk_settings.png"><img src="screenshots/frontdesk_settings_configsync_thumb.png" width="200" alt="Fleet config sync"></a><a href="screenshots/frontdesk_settings.png"><img src="screenshots/frontdesk_settings_alerts_thumb.png" width="200" alt="Alerts"></a><a href="screenshots/frontdesk_settings.png"><img src="screenshots/frontdesk_settings_observability_thumb.png" width="200" alt="Observability"></a></p>
-<p align="center"><sub>Front Desk settings — security, fleet config sync, alerting, observability. Click any panel for the full page.</sub></p>
+<p align="center"><a href="screenshots/frontdesk_settings.png"><img src="screenshots/frontdesk_settings_security_thumb.png" width="395" alt="Security (passkeys + TOTP)"></a>&nbsp;&nbsp;<a href="screenshots/frontdesk_settings.png"><img src="screenshots/frontdesk_settings_configsync_thumb.png" width="395" alt="Fleet config sync"></a></p>
+<p align="center"><sub>Security (passkeys + TOTP)&nbsp;&nbsp;·&nbsp;&nbsp;Fleet config sync</sub></p>
+
+<p align="center"><a href="screenshots/frontdesk_settings.png"><img src="screenshots/frontdesk_settings_alerts_thumb.png" width="395" alt="Alerts"></a>&nbsp;&nbsp;<a href="screenshots/frontdesk_settings.png"><img src="screenshots/frontdesk_settings_observability_thumb.png" width="395" alt="Observability"></a></p>
+<p align="center"><sub>Alerts&nbsp;&nbsp;·&nbsp;&nbsp;Observability</sub></p>
+<p align="center"><sub><em>Click any panel for the full settings page.</em></sub></p>
 
 ---
 
@@ -121,7 +125,7 @@ You have one instance at `ip1:8080`. Move it aside and let the HA stack take ove
 7. Maintenance: drain a member in Front Desk, rebuild it, re-activate. Re-run the
    config sync after any provider/key/settings change on the primary.
 
-![Front Desk — add a member](screenshots/frontdesk_addmember.png)
+[![Front Desk — add a member](screenshots/frontdesk_addmember.png)](screenshots/frontdesk_addmember.png)
 
 ---
 
@@ -193,7 +197,7 @@ Two things are worth understanding about authentication in an HA deployment:
   button, because no credential is registered yet. Register one under Settings →
   Security and the button appears on the next login.
 
-![Front Desk Settings — Security (passkeys + TOTP)](screenshots/frontdesk_settings_security.png)
+[![Front Desk Settings — Security (passkeys + TOTP)](screenshots/frontdesk_settings_security.png)](screenshots/frontdesk_settings_security.png)
 
 ---
 
@@ -240,7 +244,7 @@ provider IDs.
    reported. Each member is independent, and re-running retries any left behind.
    Request logs and metering are never touched.
 
-![Front Desk Settings — Fleet config sync (preview with diff)](screenshots/frontdesk_settings_configsync.png)
+[![Front Desk Settings — Fleet config sync (preview with diff)](screenshots/frontdesk_settings_configsync.png)](screenshots/frontdesk_settings_configsync.png)
 
 ### Automatic config sync (set and forget)
 

--- a/wiki/ha-architecture.svg
+++ b/wiki/ha-architecture.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 360" font-family="'Segoe UI', system-ui, -apple-system, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 430" font-family="'Segoe UI', system-ui, -apple-system, sans-serif">
   <defs>
     <marker id="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
       <path d="M 0 0 L 10 5 L 0 10 z" fill="#94a3b8"/>
@@ -12,14 +12,14 @@
   </defs>
 
   <!-- Background (transparent) -->
-  <rect width="780" height="360" fill="none" rx="8"/>
+  <rect width="780" height="430" fill="none" rx="8"/>
 
   <!-- Plane labels -->
   <text x="24" y="26" fill="#64748b" font-size="11" font-weight="600" letter-spacing="1">DATA PLANE  ·  request path</text>
-  <text x="24" y="232" fill="#64748b" font-size="11" font-weight="600" letter-spacing="1">CONTROL PLANE  ·  never in the request path</text>
+  <text x="24" y="292" fill="#64748b" font-size="11" font-weight="600" letter-spacing="1">CONTROL PLANE  ·  never in the request path</text>
 
   <!-- Divider between planes -->
-  <line x1="24" y1="205" x2="756" y2="205" stroke="#334155" stroke-width="1" stroke-dasharray="6,4"/>
+  <line x1="24" y1="265" x2="756" y2="265" stroke="#334155" stroke-width="1" stroke-dasharray="6,4"/>
 
   <!-- Clients -->
   <rect x="24" y="48" width="120" height="64" rx="10" fill="#1e293b" stroke="#3b82f6" stroke-width="1.5" filter="url(#shadow)"/>
@@ -45,6 +45,7 @@
   <!-- Traefik -> members -->
   <line x1="540" y1="72" x2="604" y2="52" stroke="#94a3b8" stroke-width="1.6" marker-end="url(#arr)"/>
   <line x1="540" y1="88" x2="604" y2="132" stroke="#94a3b8" stroke-width="1.6" marker-end="url(#arr)"/>
+  <line x1="540" y1="104" x2="604" y2="212" stroke="#94a3b8" stroke-width="1.6" marker-end="url(#arr)"/>
 
   <!-- hotel-1 -->
   <rect x="608" y="24" width="148" height="56" rx="10" fill="#1e293b" stroke="#f43f5e" stroke-width="1.5" filter="url(#shadow)"/>
@@ -56,22 +57,27 @@
   <text x="682" y="129" text-anchor="middle" fill="#fb7185" font-size="14" font-weight="700">hotel-2</text>
   <text x="682" y="147" text-anchor="middle" fill="#94a3b8" font-size="10">ip2:8081</text>
 
+  <!-- hotel-N: the fleet is not capped at two — dashed to read as "and so on" -->
+  <rect x="608" y="184" width="148" height="56" rx="10" fill="#1e293b" stroke="#f43f5e" stroke-width="1.5" stroke-dasharray="5,4" filter="url(#shadow)"/>
+  <text x="682" y="209" text-anchor="middle" fill="#fb7185" font-size="14" font-weight="700">… hotel-N</text>
+  <text x="682" y="227" text-anchor="middle" fill="#94a3b8" font-size="10">add more members</text>
+
   <!-- You, in a browser -->
-  <rect x="150" y="254" width="150" height="64" rx="10" fill="#1e293b" stroke="#3b82f6" stroke-width="1.5" filter="url(#shadow)"/>
-  <text x="225" y="286" text-anchor="middle" fill="#93c5fd" font-size="14" font-weight="700">You, in a browser</text>
-  <text x="225" y="305" text-anchor="middle" fill="#94a3b8" font-size="10">admin UI</text>
+  <rect x="150" y="314" width="150" height="64" rx="10" fill="#1e293b" stroke="#3b82f6" stroke-width="1.5" filter="url(#shadow)"/>
+  <text x="225" y="346" text-anchor="middle" fill="#93c5fd" font-size="14" font-weight="700">You, in a browser</text>
+  <text x="225" y="365" text-anchor="middle" fill="#94a3b8" font-size="10">admin UI</text>
 
   <!-- You -> Front Desk -->
-  <line x1="300" y1="286" x2="384" y2="286" stroke="#94a3b8" stroke-width="1.6" marker-end="url(#arr)"/>
+  <line x1="300" y1="346" x2="384" y2="346" stroke="#94a3b8" stroke-width="1.6" marker-end="url(#arr)"/>
 
   <!-- Front Desk -->
-  <rect x="384" y="246" width="156" height="80" rx="10" fill="#1e293b" stroke="#a78bfa" stroke-width="1.5" filter="url(#shadow)"/>
-  <text x="462" y="274" text-anchor="middle" fill="#c4b5fd" font-size="15" font-weight="700">Front Desk :8090</text>
-  <text x="462" y="294" text-anchor="middle" fill="#94a3b8" font-size="10">add · drain · remove members</text>
-  <text x="462" y="310" text-anchor="middle" fill="#94a3b8" font-size="10">sync config · watch health</text>
+  <rect x="384" y="306" width="156" height="80" rx="10" fill="#1e293b" stroke="#a78bfa" stroke-width="1.5" filter="url(#shadow)"/>
+  <text x="462" y="334" text-anchor="middle" fill="#c4b5fd" font-size="15" font-weight="700">Front Desk :8090</text>
+  <text x="462" y="354" text-anchor="middle" fill="#94a3b8" font-size="10">add · drain · remove members</text>
+  <text x="462" y="370" text-anchor="middle" fill="#94a3b8" font-size="10">sync config · watch health</text>
 
   <!-- Front Desk -> Traefik (config poll, dashed, upward) -->
-  <line x1="462" y1="246" x2="462" y2="114" stroke="#a78bfa" stroke-width="1.6" stroke-dasharray="6,4" marker-end="url(#arrP)"/>
-  <text x="478" y="172" fill="#c4b5fd" font-size="10" font-weight="600">Traefik polls</text>
-  <text x="478" y="186" fill="#94a3b8" font-size="10">GET /traefik/config  ·  ~5s</text>
+  <line x1="462" y1="306" x2="462" y2="114" stroke="#a78bfa" stroke-width="1.6" stroke-dasharray="6,4" marker-end="url(#arrP)"/>
+  <text x="478" y="205" fill="#c4b5fd" font-size="10" font-weight="600">Traefik polls</text>
+  <text x="478" y="219" fill="#94a3b8" font-size="10">GET /traefik/config  ·  ~5s</text>
 </svg>


### PR DESCRIPTION
Refinements to the HA wiki page after #377.

- **Settings grid → 2x2** (two thumbnails per row, ~800px = the Members image above), with one caption line per row (left · right). Per-image captions aren't possible without a `<table>` (no CSS grid/flex on GitHub), so captions share a line per row by agreement.
- **Every screenshot now links to its full-res source** — the big Members image above the grid, plus the inline add-member / Security / Config-sync shots, are all clickable to open the readable image (a 1440p shot shrunk to 720p is otherwise unreadable).
- **`ha-architecture.svg`**: added a dashed `… hotel-N` pill and expanded the canvas so the diagram reads as 2..N members, not capped at two.

🤖 Generated with [OpenCode](https://opencode.ai)