### PR TITLE
ci: migrate deprecated codecov test-results-action to codecov-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,11 +84,12 @@ jobs:
       # test-results endpoint accepts.
       - name: Upload Go test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: go-test-report.junit.xml
           flags: backend
+          report_type: test_results
 
   go-lint:
     name: Go Lint
@@ -250,11 +251,12 @@ jobs:
 
       - name: Upload frontend test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: web/vitest-${{ matrix.shard }}.junit.xml
           flags: frontend
+          report_type: test_results
 
   frontend-coverage:
     name: Frontend Coverage Gate


### PR DESCRIPTION
## What

Migrates the deprecated `codecov/test-results-action` to `codecov/codecov-action` with `report_type: test_results`, per Codecov's deprecation notice:

> This action is being deprecated in favor of 'codecov-action'. Please update CI accordingly to use 'codecov-action@v5' with `report_type: test_results`.

## Why

The deprecated action emitted a deprecation banner in CI logs on every run. `codecov-action` can be run once for coverage and once for test results, so both upload steps now use the same action + SHA pin already used for the coverage uploads (`fb8b3582… # v7`).

## Changes

Two sites in `.github/workflows/ci.yml`:

| Step | File | Flags |
|------|------|-------|
| Upload Go test results | `go-test-report.junit.xml` | `backend` |
| Upload frontend shard results | `web/vitest-${{ matrix.shard }}.junit.xml` | `frontend` |

Each swaps `codecov/test-results-action@…v1.2.1` → `codecov/codecov-action@…v7` and adds `report_type: test_results`. The existing coverage-upload steps (Go + frontend) are unchanged.

Verified `report_type` is a valid `codecov-action@v7` input (`test_results` / `coverage`) against the published `action.yml`.