### PR TITLE
fix(error-shelf): stop reading browser clock during render

### DIFF
--- a/web/src/components/ErrorShelf/__tests__/ErrorShelf.test.tsx
+++ b/web/src/components/ErrorShelf/__tests__/ErrorShelf.test.tsx
@@ -192,9 +192,10 @@ describe("ErrorShelf", () => {
 	});
 
 	it("clamps to the newest served error when no server clock is available", async () => {
-		// The mock responses carry no `Date` header, so the hook falls back to the
-		// browser clock, which here lags a week behind. Without the newest-served
-		// clamp that would filter everything out; the clamp keeps the fresh rows.
+		// The mock responses carry no `Date` header, so the hook anchors on the
+		// newest served timestamp rather than the server wall-clock. The browser
+		// clock here lags a week behind, but it is never consulted; anchoring on
+		// the newest served time keeps the fresh rows regardless.
 		vi.spyOn(Date, "now").mockReturnValue(
 			new Date("2024-01-25T12:00:30Z").getTime(),
 		);

--- a/web/src/components/ErrorShelf/useErrorShelf.ts
+++ b/web/src/components/ErrorShelf/useErrorShelf.ts
@@ -215,21 +215,18 @@ export function useErrorShelf(): UseErrorShelf {
 		//      clamped up to `newest` in case the sample is a poll interval stale.
 		//   2. otherwise the newest served timestamp — itself server-stamped, so a
 		//      fast/slow browser clock still can't age a served error out of view.
-		//   3. the browser clock only when there is nothing to filter (no rows),
-		//      where its value cannot hide anything.
-		// So a skewed client clock can never wrongly drop a row the server just
-		// returned; in production the header path always wins (same-origin Go
+		// When neither is available `newest` is 0 (no row had a parseable
+		// timestamp), so `cutoff` goes negative and `isRecent` keeps everything
+		// (NaN timestamps are kept unconditionally). A skewed client clock can
+		// never wrongly drop a row, and the browser clock is never read during
+		// render. In production the header path always wins (same-origin Go
 		// responses always carry `Date`). Anything older than the window is stale
 		// noise (e.g. an error from before the last rebuild); an unparseable
 		// timestamp is kept rather than silently dropped.
 		const serverNowMs =
 			reqLogData?.serverNowMs ?? appLogData?.serverNowMs ?? null;
 		const anchor =
-			serverNowMs !== null
-				? Math.max(serverNowMs, newest)
-				: newest > 0
-					? newest
-					: Date.now();
+			serverNowMs !== null ? Math.max(serverNowMs, newest) : newest;
 		const cutoff = anchor - ERROR_SHELF_MAX_AGE_MS;
 		const isRecent = (timestamp: string) => {
 			const t = parseTs(timestamp);


### PR DESCRIPTION
## What

Removes the `react-hooks/purity` warning (impure `Date.now()` call during render) in `useErrorShelf`'s anchor `useMemo`.

## Why

`Date.now()` in render makes the memo non-idempotent. The branch was only reached when no row had a parseable timestamp AND there was no server `Date` header — i.e. nothing to filter — where the cutoff's value is irrelevant (NaN timestamps are kept unconditionally; no valid timestamps exist to age out).

## Change

Collapse the ternary to anchor on `newest` directly. When `newest === 0`, `cutoff` goes negative and `isRecent` keeps everything, so a skewed client clock can never drop a served row and the browser clock is never read during render.

Behavior-preserving: all 28 ErrorShelf tests pass. Updated the one test comment that described the old browser-clock fallback.