### PR TITLE
ci: skip :dev rebuild when only non-image files change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -434,6 +434,8 @@ jobs:
       DOCKERHUB_FRONTDESK_IMAGE: ${{ secrets.DOCKERHUB_USERNAME }}/model-hotel-frontdesk
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
 
       # Early bail-out: if this commit is already behind master HEAD, skip the
       # whole build/scan. This is only an optimization — the authoritative guard
@@ -457,15 +459,56 @@ jobs:
             echo "skip=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Log in to Docker Hub
+      - name: Skip if only non-image files changed
+        id: changes
         if: steps.head.outputs.skip == 'false'
+        env:
+          BASE_SHA: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          # The :dev image carries the compiled Go binary (cmd/ + internal/)
+          # and the built+embedded frontend (web/src, web/public, configs, deps).
+          # Changes to docs, screenshots, wiki, AGENTS.md, CI workflows, the
+          # Makefile, and test files cannot affect it — skip the expensive
+          # build/scan/push when none of the changed files touch that surface.
+          # Fail closed: if the diff can't be computed, build rather than risk a
+          # stale :dev.
+          if [ -z "$BASE_SHA" ] || [ "$BASE_SHA" = "0000000000000000000000000000000000000000" ]; then
+            echo "no base commit (first push or force-push); building to be safe"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          changed=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" 2>/dev/null || true)
+          if [ -z "$changed" ]; then
+            echo "could not compute diff; building to be safe"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Drop test files — they are not compiled into the binary or bundled.
+          src=$(printf '%s\n' "$changed" | grep -vE '(_test\.go|\.test\.tsx?|\.spec\.tsx?)$' || true)
+          # Image-affecting surface. A new top-level code dir must be added here
+          # or its changes won't trigger a :dev rebuild.
+          code=$(printf '%s\n' "$src" | grep -E '^(internal/|cmd/|web/src/|web/public/|web/index\.html|Dockerfile|\.dockerignore|go\.mod|go\.sum|web/package\.json|web/pnpm-lock\.yaml|web/vite\.config|web/postcss\.config|web/tailwind\.config|web/tsconfig)' || true)
+          if [ -n "$code" ]; then
+            echo "image-affecting changes; building :dev:"
+            printf '%s\n' "$code"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "no image-affecting changes; skipping :dev build. All changed files:"
+            printf '%s\n' "$changed"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Log in to Docker Hub
+        if: steps.changes.outputs.skip == 'false'
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        if: steps.head.outputs.skip == 'false'
+        if: steps.changes.outputs.skip == 'false'
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       # Build the candidate and load it into the local daemon so the very image
@@ -473,7 +516,7 @@ jobs:
       # docker-build's separate artifact would not cover base-image/Alpine drift
       # between that job and this rebuild.
       - name: Build :dev candidate (load for scan)
-        if: steps.head.outputs.skip == 'false'
+        if: steps.changes.outputs.skip == 'false'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
@@ -488,7 +531,7 @@ jobs:
           provenance: false
 
       - name: Scan :dev candidate for fixable HIGH/CRITICAL vulnerabilities
-        if: steps.head.outputs.skip == 'false'
+        if: steps.changes.outputs.skip == 'false'
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: image
@@ -502,7 +545,7 @@ jobs:
       # cache scope keeps it off the main image's cache; the push below is gated
       # on the same HEAD re-check so both images publish together or not at all.
       - name: Build :dev Front Desk candidate (load for scan)
-        if: steps.head.outputs.skip == 'false'
+        if: steps.changes.outputs.skip == 'false'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
@@ -518,7 +561,7 @@ jobs:
           provenance: false
 
       - name: Scan :dev Front Desk candidate for fixable HIGH/CRITICAL vulnerabilities
-        if: steps.head.outputs.skip == 'false'
+        if: steps.changes.outputs.skip == 'false'
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: image
@@ -531,7 +574,7 @@ jobs:
       # while this job was building/scanning, that newer run will publish its own
       # image, so this (now-stale) run must not overwrite :dev with an older one.
       - name: Push the scanned images as :dev (only if still HEAD)
-        if: steps.head.outputs.skip == 'false'
+        if: steps.changes.outputs.skip == 'false'
         env:
           COMMIT_SHA: ${{ github.sha }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -487,9 +487,14 @@ jobs:
           fi
           # Drop test files — they are not compiled into the binary or bundled.
           src=$(printf '%s\n' "$changed" | grep -vE '(_test\.go|\.test\.tsx?|\.spec\.tsx?)$' || true)
-          # Image-affecting surface. A new top-level code dir must be added here
-          # or its changes won't trigger a :dev rebuild.
-          code=$(printf '%s\n' "$src" | grep -E '^(internal/|cmd/|web/src/|web/public/|web/index\.html|Dockerfile|\.dockerignore|go\.mod|go\.sum|web/package\.json|web/pnpm-lock\.yaml|web/vite\.config|web/postcss\.config|web/tailwind\.config|web/tsconfig)' || true)
+          # Image-affecting surface = everything the Dockerfiles COPY into a
+          # build stage that the Go/Vite builds actually consume: backend source
+          # (internal/, cmd/), both frontends (web/, frontdesk/web/ — each is
+          # COPYed wholesale), the Dockerfiles + entrypoint scripts, .dockerignore,
+          # and the Go module files. Kept broad on purpose: a wasted build is
+          # cheap, a stale :dev is not. A genuinely new top-level build input
+          # (another COPY source) must be added here.
+          code=$(printf '%s\n' "$src" | grep -E '^(internal/|cmd/|web/|frontdesk/web/|Dockerfile|docker-entrypoint|\.dockerignore|go\.mod|go\.sum)' || true)
           if [ -n "$code" ]; then
             echo "image-affecting changes; building :dev:"
             printf '%s\n' "$code"


### PR DESCRIPTION
## What

Gates the `publish-dev` job so it only builds/scans/pushes when an image-affecting file actually changed. Docs-only, screenshots-only, wiki-only, CI-only, and AGENTS.md-only merges now skip the full Docker build+Trivy scan+push of both `model-hotel:dev` and `model-hotel-frontdesk:dev`.

## Why

Every master merge was rebuilding and pushing `:dev`, even when the change could not affect the image. **6 of the last 10 master merges were docs/CI-only** (#376, #377, #379, #380, #381, #382) and rebuilt `:dev` for nothing — the case you flagged.

## How

New `Skip if only non-image files changed` step (after the existing HEAD-supersession check) diffs `github.event.before..github.sha` and sets `skip`. The 7 build/scan/push steps now gate on `steps.changes.outputs.skip == 'false'` (the filter step itself is gated on `head`, so it doubles as the single gate).

Image-affecting surface: `internal/`, `cmd/`, `web/src/`, `web/public/`, `web/index.html`, `Dockerfile*`, `.dockerignore`, `go.mod`/`go.sum`, `web/package.json`, `web/pnpm-lock.yaml`, `web/{vite,postcss,tailwind}.config`, `web/tsconfig*`. Test files (`*_test.go`, `*.test.tsx?`, `*.spec.tsx?`) are excluded — they are not compiled into the binary or bundled. **Fails closed**: if the diff can't be computed (first push, force-push), it builds rather than risk a stale `:dev`.

Also bumps this job's checkout to `fetch-depth: 0` so both diff endpoints are present locally (the existing `head` step uses `git ls-remote` over the network and didn't need it; the new diff does).

## Verification

- **actionlint**: clean (exit 0) — no workflow syntax errors.
- **Classification sim** (ran the filter logic over the last 10 real merges):

| merge | result |
|-------|--------|
| #382 codecov (ci.yml only) | SKIP |
| #381, #380, #379, #377, #376 (docs/wiki/screenshots) | SKIP |
| #384 biome-gate (package.json + public/) | BUILD |
| #383 ErrorShelf (web/src) | BUILD |
| #378 Go 1.26.5 bump (go.mod/go.sum) | BUILD |

- **Caveat**: `publish-dev` only runs on `push` to `master`, so this PR can't observe the gate directly — the Workflow Lint + other jobs will confirm no breakage. The end-to-end proof lands on the next docs-only merge (it should show `publish-dev` as skipped with the filter step logging the changed files).