### PR TITLE
ci: run the pg_dump backup tests instead of skipping them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,14 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      - name: Install pg_dump / pg_restore for backup tests
+        # The backup integration tests (internal/api/backup_test.go) exec
+        # pg_dump and pg_restore; without these binaries ~26 tests t.Skip and
+        # the backup/restore round-trip goes entirely untested. ubuntu-latest's
+        # postgresql-client meta-package ships v16, matching the postgres:16
+        # service container.
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends postgresql-client
+
       - name: Run tests
         env:
           TEST_DATABASE_URL: postgres://modelhotel:${{ env.POSTGRES_PASSWORD }}@localhost:5433/testdb?sslmode=disable

--- a/wiki/Development.md
+++ b/wiki/Development.md
@@ -210,6 +210,8 @@ The test database uses `docker-compose.test.yml` which creates an isolated `test
 - Integration tests: Use `internal/db/testdb.go` helpers
 - Handler tests: Use `newTestHandler()` from `internal/api/handler_integration_test.go`
 
+> **⚠️ No skipped tests:** Tests must pass or fail — never `t.Skip`/`it.skip`/`describe.skip`/`.only`/`it.todo`, and no environment-gated skips that silently no-op in CI. If a test needs an external dependency (PostgreSQL, `pg_dump`, docker), CI must provide it rather than skip it. (Policy: PR #340.)
+
 Example test structure:
 
 ```go


### PR DESCRIPTION
## What

Installs `postgresql-client` in the `go-test` CI job so the 26 backup integration tests that `t.Skip("pg_dump not installed")` actually run instead of silently skipping on every CI run.

## Why

`internal/api/backup_test.go` execs `pg_dump` and `pg_restore`; 26 of its tests skip when those binaries are absent, and CI never installed them. So the backup/restore round-trip — the most data-integrity-sensitive path in the repo — went **entirely untested in CI**. This survived the PR #340 "no skipped tests" cleanup because the skips look environment-gated rather than broken.

## Changes

- **`.github/workflows/ci.yml`**: new `Install pg_dump / pg_restore for backup tests` step in `go-test` (`sudo apt-get install postgresql-client` — ubuntu-latest ships v16, matching the `postgres:16-alpine` service).
- **`wiki/Development.md`**: documents the no-skip policy ("tests must pass or fail, never `t.Skip`/`it.skip`/`.only`"; CI must provide external deps rather than skip), referencing PR #340.

## Verification

Ran the backup suite locally with `pg_dump` present (CI-equivalent: test DB on :5433 + `pg_dump`/`pg_restore` on PATH):

```
TEST_DATABASE_URL=… go test ./internal/api/... -run='Backup|Migration|Restore|Dump|Extract' -v -timeout 3m
→ 167 PASS, 0 SKIP, 0 FAIL   (zero "pg_dump not installed" skips)
```

All previously-skipped tests now run and pass — no latent failures surfaced. CI will confirm the same.