### PR TITLE
security: close SSRF, WebAuthn replay, and cross-user SSE leaks

### DIFF
--- a/internal/adminauth/oidc.go
+++ b/internal/adminauth/oidc.go
@@ -22,9 +22,14 @@ import (
 
 	"github.com/hugalafutro/model-hotel/internal/auth"
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
+	"github.com/hugalafutro/model-hotel/internal/netguard"
 	"github.com/hugalafutro/model-hotel/internal/totp"
 	"github.com/hugalafutro/model-hotel/internal/webauthn"
 )
+
+// oidcHTTPTimeout bounds each outbound OIDC request (discovery, token exchange,
+// UserInfo).
+const oidcHTTPTimeout = 15 * time.Second
 
 // OIDC settings keys (mirrored in settings.AllowedSettings + api.allowedSettings).
 // Exported so callers that store the config elsewhere (e.g. the Front Desk
@@ -71,6 +76,13 @@ type OIDCHandler struct {
 	masterKey  string
 	users      SSOUserResolver // nil = no user email binding (admin allowlist only)
 
+	// httpClient is an SSRF-guarded client used for every outbound OIDC request
+	// (discovery, token exchange, UserInfo). Without it go-oidc/oauth2 fall back
+	// to http.DefaultClient, letting an admin-configured (or fleet-synced) issuer
+	// URL reach cloud-metadata/link-local addresses. It allows private/loopback
+	// so an internal IdP (e.g. Authelia on the docker network) still works.
+	httpClient *http.Client
+
 	// loginThrottle applies per-IP exponential backoff to the callback, mirroring
 	// the TOTP login defense (5 failures, 1s doubling, capped at 5m).
 	loginThrottle *totp.Throttle
@@ -98,6 +110,7 @@ func NewOIDCHandler(
 		ipLimiter:     ipLimiter,
 		masterKey:     masterKey,
 		loginThrottle: totp.NewThrottle(5, time.Second, 5*time.Minute),
+		httpClient:    netguard.NewClient(oidcHTTPTimeout),
 	}
 }
 
@@ -295,6 +308,10 @@ func (h *OIDCHandler) Callback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Route the token exchange and the UserInfo fallback through the same
+	// SSRF-guarded client as discovery (go-oidc/oauth2 read it from the context).
+	ctx = oidc.ClientContext(ctx, h.httpClient)
+
 	// Exchange the code (with the PKCE verifier) for tokens.
 	token, err := rt.oauth2Config.Exchange(ctx, code, oauth2.VerifierOption(st.Verifier))
 	if err != nil {
@@ -485,7 +502,9 @@ func (h *OIDCHandler) build(ctx context.Context, enabled bool, issuer, clientID,
 		clientSecret = dec
 	}
 
-	provider, err := oidc.NewProvider(ctx, issuer)
+	// Run discovery through the SSRF-guarded client so a hostile issuer URL
+	// cannot make the server fetch a cloud-metadata/link-local endpoint.
+	provider, err := oidc.NewProvider(oidc.ClientContext(ctx, h.httpClient), issuer)
 	if err != nil {
 		return nil, fmt.Errorf("oidc discovery: %w", err)
 	}

--- a/internal/adminauth/oidc_test.go
+++ b/internal/adminauth/oidc_test.go
@@ -678,6 +678,30 @@ func TestOIDCCallbackCreateAuthTokenError(t *testing.T) {
 	}
 }
 
+// TestOIDCDiscoverySSRFBlocked confirms the SSRF-guarded HTTP client refuses
+// OIDC discovery against a cloud-metadata / link-local issuer URL: the dial is
+// rejected before connect, so runtime() surfaces a discovery error rather than
+// letting the server fetch an internal endpoint.
+func TestOIDCDiscoverySSRFBlocked(t *testing.T) {
+	for _, issuer := range []string{"http://169.254.169.254", "http://169.254.0.1:8080"} {
+		h := NewOIDCHandler(newFakeSettings(map[string]string{
+			OIDCEnabledKey:       "true",
+			OIDCIssuerURLKey:     issuer,
+			OIDCClientIDKey:      oidcTestClientID,
+			OIDCAllowedEmailsKey: "admin@example.com",
+			OIDCPublicBaseURLKey: "https://h.example",
+		}), webauthn.NewSessionManager(newMemStore()), mockIPLimiter{}, testMasterKey)
+
+		_, err := h.runtime(context.Background())
+		if err == nil {
+			t.Fatalf("issuer %q: expected discovery to be refused by SSRF guard, got nil error", issuer)
+		}
+		if !strings.Contains(err.Error(), "blocked address") {
+			t.Errorf("issuer %q: expected blocked-address error, got: %v", issuer, err)
+		}
+	}
+}
+
 func TestOIDCAllowlistDenyAndFailClosed(t *testing.T) {
 	t.Run("email not allowlisted", func(t *testing.T) {
 		idp := newMockIDP(t, oidcTestClientID)

--- a/internal/adminauth/webauthn.go
+++ b/internal/adminauth/webauthn.go
@@ -212,8 +212,14 @@ func (h *WebAuthnHandler) RegisterFinish(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	// Consume the session atomically: DeleteSession is the single-use claim. If it
+	// fails (0 rows because a concurrent request or replay already deleted it),
+	// abort instead of continuing to validate the same assertion — mirrors
+	// webauthn.SessionManager.ConsumeLoginState so no ceremony can be replayed.
 	if err := h.webauthnRepo.DeleteSession(r.Context(), sessionID); err != nil {
-		debuglog.Info("webauthn: failed to delete registration session", "session_id", sessionID, "error", err)
+		debuglog.Info("webauthn: registration session already consumed", "session_id", sessionID, "error", err)
+		respondError(w, "session not found", err, http.StatusBadRequest)
+		return
 	}
 
 	var session webauthnx.SessionData
@@ -342,8 +348,14 @@ func (h *WebAuthnHandler) LoginFinish(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Consume the session atomically: DeleteSession is the single-use claim. If it
+	// fails (0 rows because a concurrent request or replay already deleted it),
+	// abort instead of continuing to validate the same assertion — mirrors
+	// webauthn.SessionManager.ConsumeLoginState so no ceremony can be replayed.
 	if err := h.webauthnRepo.DeleteSession(r.Context(), sessionID); err != nil {
-		debuglog.Info("webauthn: failed to delete login session", "session_id", sessionID, "error", err)
+		debuglog.Info("webauthn: login session already consumed", "session_id", sessionID, "error", err)
+		respondError(w, "session not found", err, http.StatusBadRequest)
+		return
 	}
 
 	var session webauthnx.SessionData

--- a/internal/alert/dispatcher.go
+++ b/internal/alert/dispatcher.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 	"github.com/hugalafutro/model-hotel/internal/events"
+	"github.com/hugalafutro/model-hotel/internal/netguard"
 )
 
 // defaultCooldown is the per-(event-type, provider) debounce window: repeat
@@ -102,7 +103,11 @@ func WithResultHook(hook func(ok bool)) Option {
 // options it is the main-app dispatcher; pass options to embed it elsewhere.
 func New(cfg ConfigProvider, client *http.Client, opts ...Option) *Dispatcher {
 	if client == nil {
-		client = &http.Client{Timeout: defaultTimeout}
+		// SSRF-guarded client: the apprise-api base URL is admin-configured, so a
+		// hostile value must not reach cloud-metadata/link-local. It allows
+		// private/loopback because apprise-api normally runs on the internal
+		// docker network (e.g. http://apprise:8000).
+		client = netguard.NewClient(defaultTimeout)
 	}
 	d := &Dispatcher{
 		cfg:          cfg,

--- a/internal/api/configsync_apply.go
+++ b/internal/api/configsync_apply.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strconv"
 	"time"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 	"github.com/hugalafutro/model-hotel/internal/failover"
 	"github.com/hugalafutro/model-hotel/internal/model"
+	"github.com/hugalafutro/model-hotel/internal/netguard"
 	"github.com/hugalafutro/model-hotel/internal/provider"
 )
 
@@ -235,6 +237,13 @@ func (h *ConfigSyncHandler) syncableSettingsToDelete(ctx context.Context, q quer
 
 func upsertProviders(ctx context.Context, tx pgx.Tx, providers []ExportProvider) error {
 	for _, p := range providers {
+		// Defense in depth on the import path: a compromised primary must not be
+		// able to write a provider base_url that points at a link-local/metadata
+		// address. The runtime proxy SafeDialer still blocks it at dial time, but
+		// rejecting it here keeps the poisoned value out of the database entirely.
+		if err := netguard.ValidateURL(p.BaseURL); err != nil {
+			return fmt.Errorf("provider %q has an invalid base_url: %w", p.Name, err)
+		}
 		_, err := tx.Exec(ctx, `
 			INSERT INTO providers (name, base_url, encrypted_key, key_nonce, key_salt, masked_key, enabled, autodiscovery_enabled, updated_at)
 			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, now())

--- a/internal/api/events.go
+++ b/internal/api/events.go
@@ -21,14 +21,31 @@ import (
 // toasts; it is discovery progress, so it stays on the admin side. Default
 // deny: an event type added later is invisible to limited users until someone
 // deliberately maps it to a grant here.
-func eventVisible(id *user.Identity, eventType string) bool {
+func eventVisible(id *user.Identity, ev events.Event) bool {
 	if id.IsAdmin() {
 		return true
 	}
-	if strings.HasPrefix(eventType, "request.") && !strings.HasPrefix(eventType, "request.discovery.") {
-		return id.Can(user.GrantLogs)
+	if strings.HasPrefix(ev.Type, "request.") && !strings.HasPrefix(ev.Type, "request.discovery.") {
+		// The logs grant is necessary but not sufficient: a non-admin may only see
+		// request events for keys they own, matching the owner-scoping the logs
+		// REST API applies (ownerScopeFromIdentity). Without this, any logs-granted
+		// user could tail every other user's live request metadata over SSE.
+		return id.Can(user.GrantLogs) && eventOwnedBy(id, ev)
 	}
 	return false
+}
+
+// eventOwnedBy reports whether a request lifecycle event belongs to the caller's
+// own virtual keys. It compares the event's owner_user_id metadata (the owning
+// dashboard user's UUID, "" for unowned keys) against the caller's user id. A
+// caller with no user id, or an event carrying no owner, is denied — unowned-key
+// activity stays admin-only, exactly as the logs REST API scopes it.
+func eventOwnedBy(id *user.Identity, ev events.Event) bool {
+	if id.UserID == nil {
+		return false
+	}
+	owner, _ := ev.Metadata["owner_user_id"].(string)
+	return owner != "" && owner == id.UserID.String()
 }
 
 // StreamEvents handles server-sent events for real-time dashboard updates.
@@ -60,7 +77,7 @@ func (h *Handler) StreamEvents(w http.ResponseWriter, r *http.Request) {
 		case <-r.Context().Done():
 			return
 		case event := <-ch:
-			if !eventVisible(identity, event.Type) {
+			if !eventVisible(identity, event) {
 				continue
 			}
 			data, err := json.Marshal(event)

--- a/internal/api/events_filter_test.go
+++ b/internal/api/events_filter_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
 
 	"github.com/hugalafutro/model-hotel/internal/events"
 	"github.com/hugalafutro/model-hotel/internal/user"
@@ -16,39 +17,53 @@ import (
 )
 
 func TestEventVisible(t *testing.T) {
-	logsUser := &user.Identity{Role: user.RoleUser, Grants: []string{"logs"}}
-	chatUser := &user.Identity{Role: user.RoleUser, Grants: []string{"chat"}}
+	ownerID := uuid.New()
+	otherID := uuid.New()
+	logsUser := &user.Identity{Role: user.RoleUser, Grants: []string{"logs"}, UserID: &ownerID}
+	logsNoUser := &user.Identity{Role: user.RoleUser, Grants: []string{"logs"}}
+	chatUser := &user.Identity{Role: user.RoleUser, Grants: []string{"chat"}, UserID: &ownerID}
+
+	// own scopes an event to ownerID; other scopes it to a different user; unowned
+	// carries no owner (admin-only, like an admin/unowned virtual key).
+	own := map[string]interface{}{"owner_user_id": ownerID.String()}
+	other := map[string]interface{}{"owner_user_id": otherID.String()}
+	unowned := map[string]interface{}{"owner_user_id": ""}
 
 	cases := []struct {
-		name      string
-		id        *user.Identity
-		eventType string
-		want      bool
+		name string
+		id   *user.Identity
+		ev   events.Event
+		want bool
 	}{
-		{"admin sees request lifecycle", user.AdminIdentity(), "request.completed", true},
-		{"admin sees operational", user.AdminIdentity(), "backup.created", true},
-		{"logs grant sees request lifecycle", logsUser, "request.completed", true},
-		{"logs grant sees streaming", logsUser, "request.streaming", true},
-		{"logs grant denied discovery progress", logsUser, "request.discovery.provider_starting", false},
-		{"logs grant denied operational", logsUser, "backup.created", false},
-		{"logs grant denied fleet", logsUser, "member.state_changed", false},
-		{"chat grant denied request lifecycle", chatUser, "request.started", false},
-		{"future type default-denied", logsUser, "shiny.new_event", false},
-		{"nil identity denied", nil, "request.completed", false},
+		{"admin sees own-scoped request", user.AdminIdentity(), events.Event{Type: "request.completed", Metadata: own}, true},
+		{"admin sees others' requests", user.AdminIdentity(), events.Event{Type: "request.completed", Metadata: other}, true},
+		{"admin sees operational", user.AdminIdentity(), events.Event{Type: "backup.created"}, true},
+		{"logs grant sees own request", logsUser, events.Event{Type: "request.completed", Metadata: own}, true},
+		{"logs grant sees own streaming", logsUser, events.Event{Type: "request.streaming", Metadata: own}, true},
+		{"logs grant denied other user's request", logsUser, events.Event{Type: "request.completed", Metadata: other}, false},
+		{"logs grant denied unowned request", logsUser, events.Event{Type: "request.completed", Metadata: unowned}, false},
+		{"logs grant denied request with no owner metadata", logsUser, events.Event{Type: "request.completed"}, false},
+		{"logs grant without user id denied own-looking request", logsNoUser, events.Event{Type: "request.completed", Metadata: own}, false},
+		{"logs grant denied discovery progress", logsUser, events.Event{Type: "request.discovery.provider_starting", Metadata: own}, false},
+		{"logs grant denied operational", logsUser, events.Event{Type: "backup.created"}, false},
+		{"logs grant denied fleet", logsUser, events.Event{Type: "member.state_changed"}, false},
+		{"chat grant denied own request", chatUser, events.Event{Type: "request.started", Metadata: own}, false},
+		{"future type default-denied", logsUser, events.Event{Type: "shiny.new_event", Metadata: own}, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := eventVisible(tc.id, tc.eventType); got != tc.want {
-				t.Errorf("eventVisible(%v, %q) = %v, want %v", tc.id, tc.eventType, got, tc.want)
+			if got := eventVisible(tc.id, tc.ev); got != tc.want {
+				t.Errorf("eventVisible(%v, %q) = %v, want %v", tc.id, tc.ev.Type, got, tc.want)
 			}
 		})
 	}
 }
 
-// TestStreamEvents_GrantFiltering opens the SSE stream as a logs-granted user
-// and verifies request lifecycle events arrive while admin-operational events
-// are dropped before hitting the wire.
-func TestStreamEvents_GrantFiltering(t *testing.T) {
+// TestStreamEvents_OwnerScoping opens the SSE stream as a logs-granted user and
+// verifies request lifecycle events for that user's own keys arrive, while
+// another user's request events and admin-operational events are dropped before
+// hitting the wire.
+func TestStreamEvents_OwnerScoping(t *testing.T) {
 	h, apiRouter := newTestHandlerWithRouter(t)
 	pool := h.Pool().Pool()
 	if _, err := pool.Exec(context.Background(), `TRUNCATE users, webauthn_sessions CASCADE`); err != nil {
@@ -80,7 +95,10 @@ func TestStreamEvents_GrantFiltering(t *testing.T) {
 	}()
 	time.Sleep(50 * time.Millisecond)
 
-	events.Publish(events.Event{Type: "request.completed", Severity: "info", Message: "req done"})
+	// Own request (owner_user_id == this user) is visible; another user's request
+	// and operational/discovery events are not.
+	events.Publish(events.Event{Type: "request.completed", Severity: "info", Message: "mine done", Metadata: map[string]interface{}{"owner_user_id": id}})
+	events.Publish(events.Event{Type: "request.completed", Severity: "info", Message: "theirs done", Metadata: map[string]interface{}{"owner_user_id": uuid.NewString()}})
 	events.Publish(events.Event{Type: "backup.created", Severity: "success", Message: "backup done"})
 	events.Publish(events.Event{Type: "request.discovery.provider_starting", Severity: "info", Message: "discovering"})
 	time.Sleep(100 * time.Millisecond)
@@ -93,8 +111,11 @@ func TestStreamEvents_GrantFiltering(t *testing.T) {
 	}
 
 	body := rec.Body.String()
-	if !strings.Contains(body, "request.completed") {
-		t.Errorf("logs-granted user missing request.completed, got: %s", body)
+	if !strings.Contains(body, "mine done") {
+		t.Errorf("logs-granted user missing own request.completed, got: %s", body)
+	}
+	if strings.Contains(body, "theirs done") {
+		t.Errorf("another user's request event leaked to logs-granted user: %s", body)
 	}
 	if strings.Contains(body, "backup.created") {
 		t.Errorf("admin-operational event leaked to logs-granted user: %s", body)

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hugalafutro/model-hotel/internal/auth"
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
+	"github.com/hugalafutro/model-hotel/internal/netguard"
 	"github.com/hugalafutro/model-hotel/internal/otelexport"
 	"github.com/hugalafutro/model-hotel/internal/util"
 )
@@ -166,21 +167,21 @@ var allowedSettings = map[string]struct {
 	"backup_father_retention":      {typeName: "int", min: 0, max: 52},
 	"backup_grandfather_retention": {typeName: "int", min: 0, max: 120},
 	"alert_enabled":                {typeName: "string"},                // bool as string
-	"alert_apprise_api_url":        {typeName: "string"},                // base URL of the apprise-api container
+	"alert_apprise_api_url":        {typeName: "url"},                   // base URL of the apprise-api container (SSRF-validated)
 	"alert_apprise_targets":        {typeName: "string"},                // secret: encrypted at rest, masked on read
 	"alert_events":                 {typeName: "string"},                // CSV of enabled event Types (the picker)
 	"session_idle_timeout_minutes": {typeName: "int", min: 0, max: 240}, // dashboard auto-logout window in minutes; 0 = disabled
 	"oidc_enabled":                 {typeName: "string"},                // bool as string
-	"oidc_issuer_url":              {typeName: "string"},                // OIDC discovery base URL
+	"oidc_issuer_url":              {typeName: "url"},                   // OIDC discovery base URL (SSRF-validated)
 	"oidc_client_id":               {typeName: "string"},                // OAuth client id
 	"oidc_client_secret":           {typeName: "string"},                // secret: encrypted at rest, masked on read
 	"oidc_allowed_emails":          {typeName: "string"},                // comma/newline-separated allowlist
-	"oidc_public_base_url":         {typeName: "string"},                // app's external origin for the redirect URI
+	"oidc_public_base_url":         {typeName: "url_public"},            // app's external origin for the redirect URI
 	"github_sso_enabled":           {typeName: "string"},                // bool as string
 	"github_client_id":             {typeName: "string"},                // GitHub OAuth App client id
 	"github_client_secret":         {typeName: "string"},                // secret: encrypted at rest, masked on read
 	"github_allowed_emails":        {typeName: "string"},                // comma/newline-separated allowlist (verified emails)
-	"github_public_base_url":       {typeName: "string"},                // app's external origin for the callback URI
+	"github_public_base_url":       {typeName: "url_public"},            // app's external origin for the callback URI
 }
 
 const maxSettingValueLen = 500
@@ -235,6 +236,22 @@ func (h *Handler) UpdateSettings(w http.ResponseWriter, r *http.Request) {
 			}
 			if v < rule.min || v > rule.max {
 				respondBadRequest(w, fmt.Sprintf("%s must be between %g and %g", key, rule.min, rule.max), nil)
+				return
+			}
+		case "url":
+			// Server-fetched URLs (OIDC issuer, apprise-api base): reject a scheme
+			// other than http/https, a missing host, or a literal link-local/
+			// metadata IP. The runtime netguard client is the DNS-rebinding defense.
+			if err := netguard.ValidateURL(value); err != nil {
+				respondBadRequest(w, fmt.Sprintf("%s is not a valid URL: %s", key, err.Error()), err)
+				return
+			}
+		case "url_public":
+			// Public base URLs (reflected into redirect URIs, never fetched): only
+			// require structural http/https validity so a malformed origin cannot
+			// produce a broken redirect_uri.
+			if err := netguard.ValidatePublicURL(value); err != nil {
+				respondBadRequest(w, fmt.Sprintf("%s is not a valid URL: %s", key, err.Error()), err)
 				return
 			}
 		}

--- a/internal/api/settings_test.go
+++ b/internal/api/settings_test.go
@@ -256,6 +256,41 @@ func TestUpdateSettings_Integration_MultipleKeys(t *testing.T) {
 	}
 }
 
+// TestUpdateSettings_URLValidation rejects SSRF-bait and malformed values for
+// URL-typed settings, and accepts a legitimate internal endpoint.
+func TestUpdateSettings_URLValidation(t *testing.T) {
+	if apiTestDBURL == "" {
+		t.Fatal("test database not available")
+	}
+	cases := []struct {
+		name     string
+		body     string
+		wantCode int
+	}{
+		{"issuer metadata literal", `{"oidc_issuer_url": "http://169.254.169.254/latest"}`, http.StatusBadRequest},
+		{"apprise metadata literal", `{"alert_apprise_api_url": "http://169.254.169.254"}`, http.StatusBadRequest},
+		{"issuer wrong scheme", `{"oidc_issuer_url": "ftp://idp.example.com"}`, http.StatusBadRequest},
+		{"public base malformed", `{"oidc_public_base_url": "notaurl"}`, http.StatusBadRequest},
+		{"issuer internal host ok", `{"oidc_issuer_url": "http://authelia:9091"}`, http.StatusOK},
+		{"apprise internal ok", `{"alert_apprise_api_url": "http://apprise:8000"}`, http.StatusOK},
+		{"public base ok", `{"oidc_public_base_url": "https://app.example.com"}`, http.StatusOK},
+		{"clear issuer ok", `{"oidc_issuer_url": ""}`, http.StatusOK},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, r := newTestHandlerWithRouter(t)
+			req := httptest.NewRequest(http.MethodPut, "/settings", strings.NewReader(tc.body))
+			req.Header.Set("Authorization", "Bearer test-admin-token")
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+			if w.Code != tc.wantCode {
+				t.Errorf("body %s: expected %d, got %d: %s", tc.body, tc.wantCode, w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
 // TestUpdateSettings_FloatValue tests updating a float-type setting.
 func TestUpdateSettings_FloatValue(t *testing.T) {
 	_, r := newTestHandlerWithRouter(t)

--- a/internal/frontdesk/netguard.go
+++ b/internal/frontdesk/netguard.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"syscall"
 	"time"
+
+	"github.com/hugalafutro/model-hotel/internal/netguard"
 )
 
 // newProbeClient builds the HTTP client the pollers use to reach members and
@@ -66,9 +68,8 @@ func checkProbeRedirect(req *http.Request, via []*http.Request) error {
 // isProbeBlockedIP reports addresses that are never a legitimate member and are
 // the classic SSRF targets: the unspecified address, and link-local unicast
 // (which includes the 169.254.169.254 cloud-metadata endpoint) and multicast.
-// Private and loopback ranges are intentionally NOT blocked here.
+// Private and loopback ranges are intentionally NOT blocked here. It delegates
+// to netguard.BlockedIP so Front Desk, OIDC, and alerting share one predicate.
 func isProbeBlockedIP(ip net.IP) bool {
-	return ip.IsUnspecified() ||
-		ip.IsLinkLocalUnicast() ||
-		ip.IsLinkLocalMulticast()
+	return netguard.BlockedIP(ip)
 }

--- a/internal/netguard/netguard.go
+++ b/internal/netguard/netguard.go
@@ -1,0 +1,121 @@
+// Package netguard provides SSRF defenses for outbound HTTP to
+// admin-configured endpoints that legitimately live on the internal network:
+// OIDC identity providers (e.g. an internal Authelia), the apprise-api
+// notification container, and Front Desk members.
+//
+// Unlike the proxy SafeDialer (internal/proxy), which blocks every private
+// range because upstream LLM providers are external SaaS, these guards allow
+// private and loopback addresses and refuse only the addresses that are never a
+// legitimate destination and are the classic SSRF targets: the unspecified
+// address, link-local unicast (which includes the 169.254.169.254 cloud-metadata
+// endpoint), and link-local multicast.
+package netguard
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"syscall"
+	"time"
+)
+
+// parseHTTPURL parses rawURL and requires an http/https scheme and a non-empty
+// host, the shared structural check behind ValidateURL and ValidatePublicURL.
+func parseHTTPURL(rawURL string) (*url.URL, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid URL: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return nil, fmt.Errorf("URL scheme must be http or https, got %q", u.Scheme)
+	}
+	if u.Hostname() == "" {
+		return nil, fmt.Errorf("URL has no host")
+	}
+	return u, nil
+}
+
+// BlockedIP reports whether an IP is one of the SSRF targets that must never be
+// dialled by an internal-facing outbound client: the unspecified address, or
+// link-local unicast/multicast (169.254.0.0/16 and fe80::/10, which cover the
+// cloud-metadata endpoint). Private and loopback ranges are intentionally
+// allowed so internal IdPs, the apprise-api container, and Front Desk members
+// keep working.
+func BlockedIP(ip net.IP) bool {
+	if ip == nil {
+		return false
+	}
+	return ip.IsUnspecified() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast()
+}
+
+// dialControl is the net.Dialer.Control hook that rejects a connection whose
+// resolved address is a blocked IP. It runs after DNS resolution on the actual
+// dial target, so it also catches DNS rebinding (a hostname that resolves to a
+// metadata address between validation and dial) and, because the follow-up dial
+// of a redirect passes through it too, redirect-to-metadata.
+func dialControl(_, address string, _ syscall.RawConn) error {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return err
+	}
+	if ip := net.ParseIP(host); ip != nil && BlockedIP(ip) {
+		return fmt.Errorf("netguard: refusing to connect to blocked address %s", host)
+	}
+	return nil
+}
+
+// NewClient builds an http.Client whose dialer refuses blocked post-resolution
+// IPs. The dial guard also covers redirect targets (each hop is dialled through
+// the same Control hook), so a 3xx to a metadata address fails at connect time.
+func NewClient(timeout time.Duration) *http.Client {
+	dialer := &net.Dialer{
+		Timeout:   timeout,
+		KeepAlive: 30 * time.Second,
+		Control:   dialControl,
+	}
+	return &http.Client{
+		Timeout: timeout,
+		Transport: &http.Transport{
+			// Honor HTTP(S)_PROXY like http.DefaultTransport so a deployment that
+			// reaches an external IdP through an egress proxy keeps working; the
+			// dial guard still runs on the proxy connection.
+			Proxy:       http.ProxyFromEnvironment,
+			DialContext: dialer.DialContext,
+		},
+	}
+}
+
+// ValidateURL parses rawURL for use as an admin-configured outbound endpoint and
+// rejects it when the scheme is not http/https, the host is missing, or the host
+// is a literal blocked IP (unspecified, link-local, or cloud-metadata). An empty
+// string is accepted so operators can clear a setting. DNS is not resolved here
+// (that would block the caller on a network lookup); NewClient's dial guard is
+// the runtime defense against a hostname that resolves to a blocked IP.
+func ValidateURL(rawURL string) error {
+	if rawURL == "" {
+		return nil
+	}
+	u, err := parseHTTPURL(rawURL)
+	if err != nil {
+		return err
+	}
+	if ip := net.ParseIP(u.Hostname()); ip != nil && BlockedIP(ip) {
+		return fmt.Errorf("host %q is a blocked address (link-local/metadata)", u.Hostname())
+	}
+	return nil
+}
+
+// ValidatePublicURL parses rawURL for use as a public base URL (an external
+// origin reflected into a redirect URI, never fetched by the server). It only
+// enforces structural validity: an http/https scheme and a non-empty host. An
+// empty string is accepted so operators can clear the setting.
+func ValidatePublicURL(rawURL string) error {
+	if rawURL == "" {
+		return nil
+	}
+	_, err := parseHTTPURL(rawURL)
+	return err
+}

--- a/internal/netguard/netguard_test.go
+++ b/internal/netguard/netguard_test.go
@@ -1,0 +1,125 @@
+package netguard
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBlockedIP(t *testing.T) {
+	cases := []struct {
+		ip   string
+		want bool
+	}{
+		{"169.254.169.254", true}, // AWS/GCP cloud metadata (link-local)
+		{"169.254.0.1", true},     // link-local unicast
+		{"0.0.0.0", true},         // unspecified
+		{"::", true},              // unspecified v6
+		{"fe80::1", true},         // link-local v6
+		{"127.0.0.1", false},      // loopback allowed (internal services)
+		{"10.0.0.5", false},       // private allowed (docker network)
+		{"192.168.1.10", false},   // private allowed
+		{"172.17.0.2", false},     // docker bridge allowed (apprise-api)
+		{"8.8.8.8", false},        // public
+	}
+	for _, tc := range cases {
+		ip := net.ParseIP(tc.ip)
+		if ip == nil {
+			t.Fatalf("bad test IP %q", tc.ip)
+		}
+		if got := BlockedIP(ip); got != tc.want {
+			t.Errorf("BlockedIP(%s) = %v, want %v", tc.ip, got, tc.want)
+		}
+	}
+	if BlockedIP(nil) {
+		t.Error("BlockedIP(nil) = true, want false")
+	}
+}
+
+// TestNewClient_RejectsMetadataLiteral confirms the dial guard refuses a literal
+// cloud-metadata address, the core SSRF defense for OIDC/alert outbound calls.
+func TestNewClient_RejectsMetadataLiteral(t *testing.T) {
+	client := NewClient(2 * time.Second)
+	_, err := client.Get("http://169.254.169.254/latest/meta-data/")
+	if err == nil {
+		t.Fatal("expected dial to cloud-metadata address to be refused, got nil error")
+	}
+	if !strings.Contains(err.Error(), "blocked address") {
+		t.Errorf("expected blocked-address error, got: %v", err)
+	}
+}
+
+// TestDialControl confirms the guard runs on the resolved dial address, so a
+// hostname that resolves to a metadata address is refused too (DNS rebinding),
+// while a private address is allowed.
+func TestDialControl(t *testing.T) {
+	if err := dialControl("tcp", "169.254.169.254:80", nil); err == nil {
+		t.Error("dialControl allowed a metadata address")
+	}
+	if err := dialControl("tcp", "10.0.0.1:80", nil); err != nil {
+		t.Errorf("dialControl blocked a private address: %v", err)
+	}
+}
+
+// TestNewClient_AllowsInternal confirms a legitimate internal (private) host is
+// reachable — the apprise-api / internal-IdP case must not be blocked.
+func TestNewClient_AllowsInternal(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	// httptest binds to loopback, which the guard allows.
+	resp, err := NewClient(2 * time.Second).Get(srv.URL)
+	if err != nil {
+		t.Fatalf("expected loopback reachable, got: %v", err)
+	}
+	_ = resp.Body.Close()
+}
+
+func TestValidateURL(t *testing.T) {
+	cases := []struct {
+		url     string
+		wantErr bool
+	}{
+		{"", false},
+		{"https://auth.example.com", false},
+		{"http://authelia:9091", false},  // internal IdP hostname
+		{"http://10.0.0.5:8000", false},  // internal literal, allowed
+		{"http://apprise:8000", false},   // internal apprise
+		{"http://169.254.169.254", true}, // cloud metadata literal
+		{"http://169.254.0.1", true},     // link-local literal
+		{"http://0.0.0.0", true},         // unspecified literal
+		{"ftp://example.com", true},      // wrong scheme
+		{"https://", true},               // no host
+		{"://bad", true},                 // unparseable
+	}
+	for _, tc := range cases {
+		err := ValidateURL(tc.url)
+		if (err != nil) != tc.wantErr {
+			t.Errorf("ValidateURL(%q) err=%v, wantErr=%v", tc.url, err, tc.wantErr)
+		}
+	}
+}
+
+func TestValidatePublicURL(t *testing.T) {
+	cases := []struct {
+		url     string
+		wantErr bool
+	}{
+		{"", false},
+		{"https://app.example.com", false},
+		{"http://localhost:8080", false}, // public base only structural
+		{"ftp://example.com", true},
+		{"notaurl", true},
+		{"https://", true},
+	}
+	for _, tc := range cases {
+		err := ValidatePublicURL(tc.url)
+		if (err != nil) != tc.wantErr {
+			t.Errorf("ValidatePublicURL(%q) err=%v, wantErr=%v", tc.url, err, tc.wantErr)
+		}
+	}
+}

--- a/internal/proxy/logging.go
+++ b/internal/proxy/logging.go
@@ -100,10 +100,11 @@ func publishRequestStartedEvent(logEntry *requestLogData) {
 		Source:   "proxy",
 		Message:  fmt.Sprintf("Request started: %s", logEntry.modelID),
 		Metadata: map[string]interface{}{
-			"request_id": logEntry.id,
-			"model_id":   logEntry.modelID,
-			"streaming":  logEntry.streaming,
-			"state":      logEntry.state,
+			"request_id":    logEntry.id,
+			"model_id":      logEntry.modelID,
+			"streaming":     logEntry.streaming,
+			"state":         logEntry.state,
+			"owner_user_id": logEntry.ownerUserID,
 		},
 	})
 }
@@ -128,6 +129,7 @@ func publishRequestStreamingEvent(logEntry *requestLogData) {
 			"model_id":      logEntry.modelID,
 			"provider_name": logEntry.providerName,
 			"state":         logEntry.state,
+			"owner_user_id": logEntry.ownerUserID,
 		},
 	})
 }
@@ -296,6 +298,7 @@ func (h *Handler) updateRequestLog(logEntry *requestLogData, opts ...updateLogOp
 				"provider_name": logEntry.providerName,
 				"state":         logEntry.state,
 				"status_code":   logEntry.statusCode,
+				"owner_user_id": logEntry.ownerUserID,
 			},
 		})
 	}

--- a/internal/proxy/proxy_request.go
+++ b/internal/proxy/proxy_request.go
@@ -135,12 +135,19 @@ func (h *Handler) newPendingRequestLog(r *http.Request, endpointType, modelID st
 	if v := r.Context().Value(VirtualKeyHashKey); v != nil {
 		vkHash, _ = v.(string)
 	}
+	// The owning user's UUID (empty for unowned keys) scopes the SSE request
+	// events to that user, matching the owner-scoping the logs REST API applies.
+	var ownerUserID string
+	if v := r.Context().Value(ctxkeys.VirtualKeyOwnerIDKey); v != nil {
+		ownerUserID, _ = v.(string)
+	}
 
 	logData = &requestLogData{
 		modelID:         modelID,
 		streaming:       isStreaming,
 		virtualKeyName:  vkName,
 		virtualKeyID:    vkID,
+		ownerUserID:     ownerUserID,
 		failoverAttempt: 0,
 		state:           "pending",
 		endpointType:    endpointType,

--- a/internal/proxy/types.go
+++ b/internal/proxy/types.go
@@ -116,6 +116,7 @@ type requestLogData struct {
 	streaming                 bool
 	virtualKeyName            string
 	virtualKeyID              string
+	ownerUserID               string // owning dashboard user's UUID; "" for unowned keys (admin-only visibility)
 	errorMessage              string
 	errorKind                 ErrorKind // machine-readable classification; "" = unclassified (NULL in DB)
 	failoverAttempt           int


### PR DESCRIPTION
Closes four Strix findings plus accompanying hardening recommendations.

## New `internal/netguard` package
A shared SSRF guard for outbound HTTP to admin-configured endpoints that legitimately live on the internal network (OIDC IdPs, apprise-api, Front Desk members). Unlike the proxy `SafeDialer` it allows private/loopback but blocks the true SSRF targets (unspecified, link-local, cloud metadata). Front Desk's `isProbeBlockedIP` now delegates to it.

## Findings addressed
- **vuln-0001 (OIDC SSRF):** route discovery, token exchange, and UserInfo through a netguard client via `oidc.ClientContext`. The handler builds its own client, so the Front Desk nil-dialer gap closes too.
- **vuln-0003 (alert SSRF):** the dispatcher's default client is a netguard client, covering both `Probe` (`/status`) and post (`/notify`).
- **vuln-0004 (WebAuthn replay):** `LoginFinish` and `RegisterFinish` abort on a failed `DeleteSession` instead of swallowing it, making session consumption atomic and single-use (matches `ConsumeLoginState`).
- **vuln-0002 (SSE cross-user leak):** request events carry `owner_user_id`; a non-admin now needs `GrantLogs` AND ownership of the key to see them, matching the logs REST API's owner scoping.

## Defense in depth
- Settings URL validation for `oidc_issuer_url` and `alert_apprise_api_url` (`url` type: block metadata/link-local literals) and `oidc/github_public_base_url` (`url_public`: structural http(s) only).
- Config-sync import validates provider `base_url`s before writing them.

## Tests
netguard unit tests, OIDC discovery-refuses-metadata, per-user SSE scoping, and settings URL validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
