### PR TITLE
fix(dashboard): align Token Mix legend values into columns

### DIFF
--- a/web/src/pages/Dashboard/TokenSplitBar.tsx
+++ b/web/src/pages/Dashboard/TokenSplitBar.tsx
@@ -169,27 +169,29 @@ export function TokenSplitBar({
 					/>
 				))}
 			</div>
-			<div className="flex flex-col gap-1.5 mt-3 text-sm" data-testid="legend">
-				<div className="flex items-center gap-1.5">
-					<span
-						className="w-2 h-2 rounded-full"
-						style={{ backgroundColor: CACHE_HIT_COLOR }}
-					/>
-					<span className="text-(--text-tertiary)">
-						{t("dashboard.tokens.cacheHit")}
-					</span>
-					<span
-						className="font-medium text-(--text-primary) ml-1"
-						title={formatWithCommas(cacheHit)}
-					>
-						{formatTokens(cacheHit)}
-					</span>
-					<span className="text-(--text-muted) text-xs ml-1">
-						{formatPercent(cacheHitPct)}
-					</span>
-				</div>
-				<div className="flex justify-between">
-					<div className="flex items-center gap-1.5">
+			<div className="flex justify-between mt-3 text-sm" data-testid="legend">
+				{/* Cache hit + Prompt stack: token values share a left-aligned
+				    column and percents a right-aligned column via the grid. */}
+				<div className="grid grid-cols-[auto_auto_auto_auto] items-center gap-x-1.5 gap-y-1.5">
+					<div className="contents">
+						<span
+							className="w-2 h-2 rounded-full"
+							style={{ backgroundColor: CACHE_HIT_COLOR }}
+						/>
+						<span className="text-(--text-tertiary)">
+							{t("dashboard.tokens.cacheHit")}
+						</span>
+						<span
+							className="font-medium text-(--text-primary)"
+							title={formatWithCommas(cacheHit)}
+						>
+							{formatTokens(cacheHit)}
+						</span>
+						<span className="text-(--text-muted) text-xs tabular-nums justify-self-end">
+							{formatPercent(cacheHitPct)}
+						</span>
+					</div>
+					<div className="contents">
 						<span
 							className="w-2 h-2 rounded-full"
 							style={{ backgroundColor: PROMPT_COLOR }}
@@ -198,33 +200,33 @@ export function TokenSplitBar({
 							{t("dashboard.tokens.prompt")}
 						</span>
 						<span
-							className="font-medium text-(--text-primary) ml-1"
+							className="font-medium text-(--text-primary)"
 							title={formatWithCommas(uncachedPrompt)}
 						>
 							{formatTokens(uncachedPrompt)}
 						</span>
-						<span className="text-(--text-muted) text-xs ml-1">
+						<span className="text-(--text-muted) text-xs tabular-nums justify-self-end">
 							{formatPercent(uncachedPct)}
 						</span>
 					</div>
-					<div className="flex items-center gap-1.5">
-						<span
-							className="w-2 h-2 rounded-full"
-							style={{ backgroundColor: COMPLETION_COLOR }}
-						/>
-						<span className="text-(--text-tertiary)">
-							{t("dashboard.tokens.completion")}
-						</span>
-						<span
-							className="font-medium text-(--text-primary) ml-1"
-							title={formatWithCommas(completion)}
-						>
-							{formatTokens(completion)}
-						</span>
-						<span className="text-(--text-muted) text-xs ml-1">
-							{formatPercent(completionPct)}
-						</span>
-					</div>
+				</div>
+				<div className="flex items-center gap-1.5 self-end">
+					<span
+						className="w-2 h-2 rounded-full"
+						style={{ backgroundColor: COMPLETION_COLOR }}
+					/>
+					<span className="text-(--text-tertiary)">
+						{t("dashboard.tokens.completion")}
+					</span>
+					<span
+						className="font-medium text-(--text-primary) ml-1"
+						title={formatWithCommas(completion)}
+					>
+						{formatTokens(completion)}
+					</span>
+					<span className="text-(--text-muted) text-xs ml-1 tabular-nums">
+						{formatPercent(completionPct)}
+					</span>
 				</div>
 			</div>
 		</div>

--- a/web/src/pages/Dashboard/__tests__/TokenSplitBar.test.tsx
+++ b/web/src/pages/Dashboard/__tests__/TokenSplitBar.test.tsx
@@ -58,24 +58,23 @@ describe("TokenSplitBar", () => {
 		expect(within(cacheHitEntry!).getByText("300")).toBeInTheDocument();
 	});
 
-	it("splits the legend into two rows: cache hit alone, prompt and completion paired", () => {
+	it("groups cache hit and prompt in a left column, completion on the right", () => {
 		render(<TokenSplitBar {...defaultProps} cacheHit={100} />);
 
 		const legend = screen.getByTestId("legend");
-		const rows = legend.children;
-		expect(rows).toHaveLength(2);
+		const groups = legend.children;
+		expect(groups).toHaveLength(2);
 
-		// Row 1: cache hit entry (left-aligned, alone).
-		const cacheHitRow = rows[0] as HTMLElement;
-		expect(within(cacheHitRow).getByText("Cache hit")).toBeInTheDocument();
+		// Left group: cache hit + prompt share an aligned grid so their token
+		// values and percentages line up in columns.
+		const leftGroup = groups[0] as HTMLElement;
+		expect(leftGroup).toHaveClass("grid");
+		expect(within(leftGroup).getByText("Cache hit")).toBeInTheDocument();
+		expect(within(leftGroup).getByText("Prompt")).toBeInTheDocument();
 
-		// Row 2: prompt (left) + completion (right) in a justify-between wrapper.
-		const promptCompletionRow = rows[1] as HTMLElement;
-		expect(promptCompletionRow).toHaveClass("justify-between");
-		expect(within(promptCompletionRow).getByText("Prompt")).toBeInTheDocument();
-		expect(
-			within(promptCompletionRow).getByText("Completion"),
-		).toBeInTheDocument();
+		// Right group: completion, standalone.
+		const completionGroup = groups[1] as HTMLElement;
+		expect(within(completionGroup).getByText("Completion")).toBeInTheDocument();
 	});
 
 	it("shows uncached prompt count (prompt minus cache hit)", () => {


### PR DESCRIPTION
## What

Adjusts the Token Mix pill's two-line legend so the numbers align in columns:

```
Cache hit 134.5M 83.8%
Prompt    25.1M   5.6%          Completion 971.6K 0.6%
```

Token values share a left-aligned column and percentages a right-aligned column (the inverse of what the waffle-box pill next to it already does).

## How

Cache hit + Prompt now sit in a shared 4-column CSS grid (dot · label · token · percent), so their token values land in the same auto-sized column regardless of label width, and the percents use `justify-self-end` + `tabular-nums` to right-align. Completion stays standalone on the right of the row.

Updated the layout-structure test to match the new grouping; all 30 TokenSplitBar tests pass, `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)