### PR TITLE
fix(discovery): dedupe providers in the Unchanged summary section

### DIFF
--- a/web/src/pages/Providers/DiscoverySummaryModal.tsx
+++ b/web/src/pages/Providers/DiscoverySummaryModal.tsx
@@ -430,12 +430,17 @@ export function DiscoverySummaryModal({
 
 	const showHeaders = results.length > 1;
 	const visible = results.filter((r) => !entryIsUnchanged(r));
-	// The Unchanged section is a flat name cloud, so it dedupes by provider name:
-	// the same provider can produce several summary entries (e.g. separate
-	// background runs recorded for a price change and a model change), and once
-	// they resolve to no net change they'd otherwise list the same name twice.
-	// Providers already shown above as Changed are dropped too, so a name never
-	// appears in both places at once.
+	// The Unchanged section is a flat name cloud, so it dedupes by the *displayed
+	// label* (providerName): the same provider can produce several summary entries
+	// (e.g. separate background runs recorded for a price change and a model
+	// change), and once they resolve to no net change they'd otherwise list the
+	// same name twice. Names already shown above as Changed are dropped too, so a
+	// name never appears in both places at once.
+	//
+	// Collapsing by label is deliberate, including for failover-group entries that
+	// share the "Failover" fallback label: an unchanged chip carries no per-entry
+	// detail (its diff is empty by definition), so two entries that render the
+	// identical chip are indistinguishable and merging them only removes noise.
 	const changedNames = new Set(visible.map((r) => r.providerName));
 	const seenUnchanged = new Set<string>();
 	const unchanged = results.filter((r) => {

--- a/web/src/pages/Providers/DiscoverySummaryModal.tsx
+++ b/web/src/pages/Providers/DiscoverySummaryModal.tsx
@@ -430,7 +430,20 @@ export function DiscoverySummaryModal({
 
 	const showHeaders = results.length > 1;
 	const visible = results.filter((r) => !entryIsUnchanged(r));
-	const unchanged = results.filter(entryIsUnchanged);
+	// The Unchanged section is a flat name cloud, so it dedupes by provider name:
+	// the same provider can produce several summary entries (e.g. separate
+	// background runs recorded for a price change and a model change), and once
+	// they resolve to no net change they'd otherwise list the same name twice.
+	// Providers already shown above as Changed are dropped too, so a name never
+	// appears in both places at once.
+	const changedNames = new Set(visible.map((r) => r.providerName));
+	const seenUnchanged = new Set<string>();
+	const unchanged = results.filter((r) => {
+		if (!entryIsUnchanged(r) || changedNames.has(r.providerName)) return false;
+		if (seenUnchanged.has(r.providerName)) return false;
+		seenUnchanged.add(r.providerName);
+		return true;
+	});
 	// A lone unchanged provider keeps the full reassuring sentence; in a batch,
 	// the unchanged providers collapse into one line so they don't drown the
 	// providers that actually changed.

--- a/web/src/pages/Providers/__tests__/DiscoverySummaryModal.test.tsx
+++ b/web/src/pages/Providers/__tests__/DiscoverySummaryModal.test.tsx
@@ -171,6 +171,47 @@ describe("DiscoverySummaryModal", () => {
 		).not.toBeInTheDocument();
 	});
 
+	it("lists an unchanged provider only once even with multiple entries", () => {
+		renderWithProviders(
+			<DiscoverySummaryModal
+				results={[
+					// Same provider recorded twice (e.g. one price run, one model run),
+					// both resolving to no net change.
+					{ providerName: "Provider A", entryKey: "a-1", diff: {} },
+					{ providerName: "Provider A", entryKey: "a-2", diff: {} },
+					{ providerName: "Provider B", entryKey: "b-1", diff: {} },
+				]}
+				onClose={vi.fn()}
+			/>,
+		);
+
+		const unchanged = screen.getByTestId("discovery-summary-unchanged");
+		expect(within(unchanged).getAllByText("Provider A")).toHaveLength(1);
+		expect(within(unchanged).getByText("Provider B")).toBeInTheDocument();
+		// Two distinct providers, not three entries.
+		expect(unchanged).toHaveTextContent("2");
+	});
+
+	it("omits a provider from Unchanged when it also has a changed entry", () => {
+		renderWithProviders(
+			<DiscoverySummaryModal
+				results={[
+					{ providerName: "Provider A", entryKey: "a-1", diff: fullDiff },
+					// A second entry for the same provider that has no net change must
+					// not resurface below as "unchanged".
+					{ providerName: "Provider A", entryKey: "a-2", diff: {} },
+					{ providerName: "Provider B", entryKey: "b-1", diff: {} },
+				]}
+				onClose={vi.fn()}
+			/>,
+		);
+
+		const unchanged = screen.getByTestId("discovery-summary-unchanged");
+		expect(within(unchanged).queryByText("Provider A")).not.toBeInTheDocument();
+		expect(within(unchanged).getByText("Provider B")).toBeInTheDocument();
+		expect(unchanged).toHaveTextContent("1");
+	});
+
 	it("hides the provider header for a single-provider summary", () => {
 		renderWithProviders(
 			<DiscoverySummaryModal

--- a/web/src/pages/Providers/__tests__/DiscoverySummaryModal.test.tsx
+++ b/web/src/pages/Providers/__tests__/DiscoverySummaryModal.test.tsx
@@ -212,6 +212,28 @@ describe("DiscoverySummaryModal", () => {
 		expect(unchanged).toHaveTextContent("1");
 	});
 
+	it("collapses failover-fallback entries sharing the same label", () => {
+		// Background failover-group changes have no provider name and all render
+		// under the shared "Failover" fallback label. Since an unchanged chip has
+		// no per-entry detail, several such entries must collapse to one chip
+		// rather than repeat "Failover" — the same noise the dedupe removes for
+		// real providers.
+		renderWithProviders(
+			<DiscoverySummaryModal
+				results={[
+					{ providerName: "Failover", entryKey: "fo-1", diff: {} },
+					{ providerName: "Failover", entryKey: "fo-2", diff: {} },
+					{ providerName: "Failover", entryKey: "fo-3", diff: {} },
+				]}
+				onClose={vi.fn()}
+			/>,
+		);
+
+		const unchanged = screen.getByTestId("discovery-summary-unchanged");
+		expect(within(unchanged).getAllByText("Failover")).toHaveLength(1);
+		expect(unchanged).toHaveTextContent("1");
+	});
+
 	it("hides the provider header for a single-provider summary", () => {
 		renderWithProviders(
 			<DiscoverySummaryModal


### PR DESCRIPTION
## What

The background discovery-changes modal builds one summary entry per stored change *row* (`Layout.tsx`), so a single provider can accumulate several entries across background runs: e.g. one run records a price change, another records a model removal. The **Unchanged** section keyed its chips by the unique per-row key, so once those entries resolved to no net change the same provider name rendered as two identical chips ("Provider A, Provider A").

Retesting is what surfaces it: confirming a removal that already happened turns that entry's diff empty, dropping it into Unchanged next to the sibling row.

## Fix

- Dedupe the Unchanged list by provider name.
- Drop any provider from Unchanged that already appears in the Changed section above, so a name shows at most once and never in both places.

## Tests

Added two cases to `DiscoverySummaryModal.test.tsx`:
- an unchanged provider with multiple entries lists once
- a provider with a real change is omitted from Unchanged

File suite green (12/12), `tsc -b` clean, biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)