### PR TITLE
feat(ui): show logged-in user on the logout button (+ em-dash sweep)

### DIFF
--- a/frontdesk/web/src/components/FleetSyncWizard.tsx
+++ b/frontdesk/web/src/components/FleetSyncWizard.tsx
@@ -700,7 +700,7 @@ function StepChoosePrimary({
 					{members.map((m) => (
 						<option key={m.id} value={m.id} disabled={!isOnline(m)}>
 							{m.name}
-							{isOnline(m) ? "" : ` — ${t("settings.wizard.offline")}`}
+							{isOnline(m) ? "" : ` (${t("settings.wizard.offline")})`}
 						</option>
 					))}
 				</select>

--- a/internal/adminauth/helpers.go
+++ b/internal/adminauth/helpers.go
@@ -96,7 +96,7 @@ func readOnlyGuard(next http.Handler) http.Handler {
 			}
 			fallthrough
 		default:
-			respondError(w, "this is a read-only demo — creating, editing, and deleting are disabled", nil, http.StatusForbidden)
+			respondError(w, "this is a read-only demo: creating, editing, and deleting are disabled", nil, http.StatusForbidden)
 		}
 	})
 }

--- a/internal/api/readonly.go
+++ b/internal/api/readonly.go
@@ -34,7 +34,7 @@ func readOnlyGuard(next http.Handler) http.Handler {
 		default:
 			// nil err + a 4xx code: respondError does not log this (it is a
 			// client-facing policy rejection, not a server fault).
-			respondError(w, "this is a read-only demo — creating, editing, and deleting are disabled", nil, http.StatusForbidden)
+			respondError(w, "this is a read-only demo: creating, editing, and deleting are disabled", nil, http.StatusForbidden)
 		}
 	})
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -376,7 +376,7 @@ func (c *Config) ValidateProviderURL(rawURL string) error {
 	if err == nil {
 		for _, ip := range ips {
 			if util.IsBlockedIP(ip) {
-				return fmt.Errorf("host %q resolves to private/reserved address %s — not allowed as provider URL (add to ALLOWED_PROVIDER_HOSTS to permit)", host, ip)
+				return fmt.Errorf("host %q resolves to private/reserved address %s: not allowed as provider URL (add to ALLOWED_PROVIDER_HOSTS to permit)", host, ip)
 			}
 		}
 	}

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -13,11 +13,11 @@ import {
 	KeyRound,
 	Languages,
 	LayoutDashboard,
-	LogOut,
 	MessageSquare,
 	MessagesSquare,
 	Moon,
 	PlugZap,
+	PowerOff,
 	ScrollText,
 	Settings,
 	ShieldCheck,
@@ -1155,10 +1155,15 @@ export function Layout({ children }: LayoutProps) {
 					<button
 						type="button"
 						onClick={() => setShowLogoutConfirm(true)}
-						className="w-full sidebar-logout"
+						className="w-full sidebar-logout min-w-0"
+						aria-label={t("layout.auth.logout")}
+						title={t("layout.auth.logout")}
+						data-testid="logout-button"
 					>
-						<LogOut size={14} strokeWidth={2} />
-						{t("layout.auth.logout")}
+						<PowerOff size={14} strokeWidth={2} />
+						<span className="truncate">
+							{me?.display_name || me?.username || t("layout.auth.logout")}
+						</span>
 					</button>
 					<SystemStatus />
 					{showLogoutConfirm && (

--- a/web/src/components/__tests__/Layout.identity.test.tsx
+++ b/web/src/components/__tests__/Layout.identity.test.tsx
@@ -1,0 +1,61 @@
+import { screen } from "@testing-library/react";
+import { HttpResponse, http } from "msw";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { setAdminToken } from "../../api/client";
+import { IdentityProvider } from "../../context/IdentityContext";
+import { server } from "../../test/mocks/server";
+import { renderWithProviders } from "../../test/utils";
+import { Layout } from "../Layout";
+
+// The sidebar logout button doubles as the "who am I" indicator: it shows the
+// logged-in user's name while keeping its accessible name as "Logout". These
+// tests wrap Layout in a real IdentityProvider (AllProviders omits it) so the
+// GET /api/auth/me query actually resolves.
+describe("Layout — logged-in identity", () => {
+	const children = <div data-testid="main-content">Page Content</div>;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		setAdminToken("test-admin-token");
+	});
+
+	it("labels the logout button with the user's display name", async () => {
+		server.use(
+			http.get("/api/auth/me", () =>
+				HttpResponse.json({
+					username: "alice",
+					display_name: "Alice Smith",
+					role: "user",
+					grants: [],
+				}),
+			),
+		);
+
+		renderWithProviders(
+			<IdentityProvider>
+				<Layout>{children}</Layout>
+			</IdentityProvider>,
+		);
+
+		// Visible label is the display name; the button's accessible name (and
+		// tooltip) stay "Logout" so the action is never ambiguous.
+		expect(await screen.findByText("Alice Smith")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Logout" })).toBeInTheDocument();
+	});
+
+	it("falls back to the username when no display name is set", async () => {
+		server.use(
+			http.get("/api/auth/me", () =>
+				HttpResponse.json({ username: "bob", role: "user", grants: [] }),
+			),
+		);
+
+		renderWithProviders(
+			<IdentityProvider>
+				<Layout>{children}</Layout>
+			</IdentityProvider>,
+		);
+
+		expect(await screen.findByText("bob")).toBeInTheDocument();
+	});
+});

--- a/web/src/components/__tests__/Layout.navigation.test.tsx
+++ b/web/src/components/__tests__/Layout.navigation.test.tsx
@@ -218,22 +218,26 @@ describe("Layout", () => {
 			expect(screen.getByTitle("Switch to dark mode")).toBeInTheDocument();
 		});
 
-		it("renders logout button", () => {
+		it("renders the logout button with its accessible Logout name", () => {
 			renderWithProviders(<Layout>{mockChildren}</Layout>);
 
-			expect(screen.getByText("Logout")).toBeInTheDocument();
+			// The button keeps its accessible "Logout" name (aria-label) even though
+			// its visible label is the logged-in user's name. Identity rendering is
+			// locked separately in Layout.identity.test.tsx (this harness has no
+			// IdentityProvider, so `me` is null and the label falls back to "Logout").
+			expect(
+				screen.getByRole("button", { name: "Logout" }),
+			).toBeInTheDocument();
 		});
 
 		it("opens logout confirmation dialog on logout click", async () => {
 			const user = userEvent.setup();
 			renderWithProviders(<Layout>{mockChildren}</Layout>);
 
-			const logoutButton = screen.getByText("Logout").closest("button");
+			const logoutButton = screen.getByRole("button", { name: "Logout" });
 			expect(logoutButton).toBeInTheDocument();
 
-			if (logoutButton) {
-				await user.click(logoutButton);
-			}
+			await user.click(logoutButton);
 
 			expect(screen.getByText("Log out?")).toBeInTheDocument();
 			expect(
@@ -245,7 +249,7 @@ describe("Layout", () => {
 			const user = userEvent.setup();
 			renderWithProviders(<Layout>{mockChildren}</Layout>);
 
-			const logoutButton = screen.getByText("Logout").closest("button");
+			const logoutButton = screen.getByRole("button", { name: "Logout" });
 			expect(logoutButton).toBeInTheDocument();
 
 			if (logoutButton) {
@@ -267,7 +271,7 @@ describe("Layout", () => {
 
 			renderWithProviders(<Layout>{mockChildren}</Layout>);
 
-			const logoutButton = screen.getByText("Logout").closest("button");
+			const logoutButton = screen.getByRole("button", { name: "Logout" });
 			expect(logoutButton).toBeInTheDocument();
 
 			if (logoutButton) {
@@ -477,7 +481,7 @@ describe("Layout", () => {
 				initialEntries: ["/dashboard"],
 			});
 
-			const logoutButton = screen.getByText("Logout").closest("button");
+			const logoutButton = screen.getByRole("button", { name: "Logout" });
 			expect(logoutButton).toBeInTheDocument();
 
 			if (logoutButton) {
@@ -508,7 +512,7 @@ describe("Layout", () => {
 			const user = userEvent.setup();
 			renderWithProviders(<Layout>{mockChildren}</Layout>);
 
-			const logoutButton = screen.getByText("Logout").closest("button");
+			const logoutButton = screen.getByRole("button", { name: "Logout" });
 			expect(logoutButton).toBeInTheDocument();
 
 			if (logoutButton) {
@@ -889,7 +893,7 @@ describe("Layout", () => {
 
 			renderWithProviders(<Layout>{mockChildren}</Layout>);
 
-			const logoutButton = screen.getByText("Logout").closest("button");
+			const logoutButton = screen.getByRole("button", { name: "Logout" });
 			expect(logoutButton).toBeInTheDocument();
 			if (logoutButton) {
 				await user.click(logoutButton);
@@ -927,7 +931,7 @@ describe("Layout", () => {
 
 			renderWithProviders(<Layout>{mockChildren}</Layout>);
 
-			const logoutButton = screen.getByText("Logout").closest("button");
+			const logoutButton = screen.getByRole("button", { name: "Logout" });
 			if (logoutButton) {
 				await user.click(logoutButton);
 			}


### PR DESCRIPTION
## What

Two small, self-contained changes.

### 1. Logged-in user on the sidebar logout button
A multi-user instance never showed *who* is logged in. The sidebar logout button now doubles as the identity indicator:

- Renders a power icon (phosphor `Power`) + the current user's `display_name` (falling back to `username`, and to "Logout" when identity is unresolved, e.g. legacy single-admin).
- Keeps its accessible name and tooltip as **"Logout"** (`aria-label`/`title`) so the action stays unambiguous for screen readers and on hover.
- Name is `truncate`d so a long display name can't overflow the sidebar.
- Always present regardless of Front Desk / standalone (unlike the conditional HA line or the collapsible stats pill).

Identity comes from the existing `useIdentity()` / `/api/auth/me`; no new endpoint.

### 2. Em-dash sweep (drive-by)
Em dashes read as an AI tell in reader-facing copy. Swept the ones that reach users:
- Read-only demo 403 body (`adminauth` + `api` guards) — the string the demo instance shows on edit/delete.
- Provider-URL private/reserved-address validation error.
- Front Desk primary-select offline suffix (now parenthesised).

Left untouched: intentional empty-value `"—"` placeholders, code comments, test-assertion messages, and internal debug logs.

## Tests
- Updated the Layout nav tests to find the logout button by role/accessible name instead of its old visible "Logout" text.
- New `Layout.identity.test.tsx` wraps `Layout` in a real `IdentityProvider` and overrides `/api/auth/me` to lock both the display-name and username-fallback rendering.
- All Layout suites green; `tsc -b` clean; biome clean; edited Go packages build; Front Desk wizard/members tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)