### PR TITLE
fix(proxy): strip empty tool_calls arrays from messages

### DIFF
--- a/internal/proxy/build_upstream_body_test.go
+++ b/internal/proxy/build_upstream_body_test.go
@@ -290,3 +290,56 @@ func TestBuildUpstreamBody_UnparseableInput(t *testing.T) {
 		t.Errorf("unparseable input should be returned as-is, got %q", string(result))
 	}
 }
+
+func TestBuildUpstreamBody_StripsEmptyToolCalls(t *testing.T) {
+	t.Parallel()
+
+	inputBody := `{"model":"gpt-4","messages":[` +
+		`{"role":"user","content":"hi"},` +
+		`{"role":"assistant","content":"aborted turn","tool_calls":[]},` +
+		`{"role":"assistant","content":null,"tool_calls":[{"id":"c1","type":"function","function":{"name":"f","arguments":"{}"}}]},` +
+		`{"role":"tool","tool_call_id":"c1","content":"ok"}]}`
+
+	result := buildUpstreamBody([]byte(inputBody), "openai", "gpt-4o", "gpt-4", false, &sync.Map{}, &sync.Map{}, nil)
+
+	var raw map[string]interface{}
+	if err := json.Unmarshal(result, &raw); err != nil {
+		t.Fatalf("result is not valid JSON: %v", err)
+	}
+	msgs, ok := raw["messages"].([]interface{})
+	if !ok || len(msgs) != 4 {
+		t.Fatalf("messages = %v, want 4 entries", raw["messages"])
+	}
+
+	empty := msgs[1].(map[string]interface{})
+	if _, exists := empty["tool_calls"]; exists {
+		t.Error("empty tool_calls array should be stripped")
+	}
+	if empty["content"] != "aborted turn" {
+		t.Errorf("stripped message content = %v, want unchanged", empty["content"])
+	}
+
+	withCalls := msgs[2].(map[string]interface{})
+	tc, ok := withCalls["tool_calls"].([]interface{})
+	if !ok || len(tc) != 1 {
+		t.Errorf("non-empty tool_calls must be preserved, got %v", withCalls["tool_calls"])
+	}
+}
+
+func TestBuildUpstreamBody_StripEmptyToolCallsTolerantOfShapes(t *testing.T) {
+	t.Parallel()
+
+	// No messages key, messages not an array, and a non-object message must
+	// all pass through without panicking or being altered.
+	for _, body := range []string{
+		`{"model":"gpt-4"}`,
+		`{"model":"gpt-4","messages":"weird"}`,
+		`{"model":"gpt-4","messages":[42,{"role":"user","content":"hi","tool_calls":"nope"}]}`,
+	} {
+		result := buildUpstreamBody([]byte(body), "openai", "gpt-4", "gpt-4", false, &sync.Map{}, &sync.Map{}, nil)
+		var raw map[string]interface{}
+		if err := json.Unmarshal(result, &raw); err != nil {
+			t.Fatalf("result is not valid JSON for input %s: %v", body, err)
+		}
+	}
+}

--- a/internal/proxy/helpers.go
+++ b/internal/proxy/helpers.go
@@ -340,6 +340,7 @@ func breakerRecordAction(statusCode int) breakerAction {
 //  5. Universal param stripping (providerUnsupportedParams)
 //  6. Learned param stripping (deprecationCache)
 //  7. Extra param stripping (additional rejected params, e.g. from 400 auto-retry)
+//  8. Message sanitization (drop empty tool_calls arrays)
 //
 // Injection (step 3) runs before all stripping (steps 5-7) so that a param a
 // provider injects but the upstream then rejects (learned into the deprecation
@@ -418,8 +419,34 @@ func buildUpstreamBody(
 		delete(raw, param)
 	}
 
+	// 8. Message sanitization
+	stripEmptyToolCalls(raw)
+
 	if b, err := json.Marshal(raw); err == nil {
 		return b
 	}
 	return proxyReqBody
+}
+
+// stripEmptyToolCalls removes "tool_calls": [] from every message in the
+// request. Some clients serialize an assistant turn whose tool calls were
+// aborted or filtered out as an empty array instead of omitting the field;
+// the OpenAI spec requires min length 1 and strict providers (DeepSeek,
+// OpenCode Zen) reject the whole request with a 400, permanently bricking any
+// conversation that has such a turn in its history. No provider needs the
+// empty array, so dropping it is always safe.
+func stripEmptyToolCalls(raw map[string]interface{}) {
+	msgs, ok := raw["messages"].([]interface{})
+	if !ok {
+		return
+	}
+	for _, m := range msgs {
+		msg, ok := m.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if tc, ok := msg["tool_calls"].([]interface{}); ok && len(tc) == 0 {
+			delete(msg, "tool_calls")
+		}
+	}
 }

--- a/wiki/API-Reference.md
+++ b/wiki/API-Reference.md
@@ -84,6 +84,8 @@ curl -X POST http://localhost:8081/v1/chat/completions \
 | `stop` | array/string | No | Stop sequences |
 | `stream_options` | object | No | Streaming options (e.g. `include_usage: true`). **Note:** The proxy automatically injects `stream_options: {include_usage: true}` for all streaming requests to ensure token usage is reported. |
 
+**Message normalization:** if a message in `messages` carries `tool_calls: []` (an empty array), the proxy removes the field before forwarding. Some clients serialize aborted or filtered tool-call turns this way, and strict providers reject the whole request with a 400 (`Invalid 'messages[N].tool_calls': empty array`), which permanently breaks any conversation carrying such a turn in its history. Non-empty `tool_calls` and all other message content pass through untouched.
+
 **Model Routing:**
 
 - `hotel/<model>` - Failover routing (tries all providers that offer the model, with automatic failover on 5xx and optionally on 429)


### PR DESCRIPTION
## Problem

A client (hermes agent) started failing every request in a long-running conversation with:

```
Invalid 'messages[369].tool_calls': empty array. Expected an array with minimum length 1, but got an empty array instead.
```

Some clients serialize an assistant turn whose tool calls were aborted or filtered out as `tool_calls: []` instead of omitting the field. The OpenAI spec requires min length 1, and strict providers (DeepSeek, OpenCode Zen) reject the whole request with a 400. Since the bad turn stays in the client's history, every subsequent request replays it and the conversation is permanently bricked. Failover cannot help because 400 is a client error.

## Fix

New step 8 in `buildUpstreamBody`: walk `messages` and delete `tool_calls` from any message where it is an empty array. Non-empty tool calls and all other message content pass through untouched. Tolerant of malformed shapes (missing or non-array `messages`, non-object messages, non-array `tool_calls` are left as-is). No provider requires the empty array, so the strip is always safe.

Documented in wiki API-Reference.md next to the existing `stream_options` injection note.

## Testing

- Two new tests: strip behavior plus preservation of real tool calls, and shape-tolerance cases
- Full `internal/proxy` suite passes (921 tests), golangci-lint clean, `make build` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)