### PR TITLE
fix(audit): keep audit trail in request order

### DIFF
--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -160,6 +160,11 @@ func (rec *Recorder) Middleware(next http.Handler) http.Handler {
 		// goroutine or tie up server concurrency. Best-effort by design. The
 		// goroutine is tracked by rec.wg so Wait can drain it on shutdown.
 		entry := Entry{
+			// Stamped here, at request completion, so the trail's order reflects
+			// when actions happened. The insert runs on a background goroutine, so
+			// leaving created_at to the DB default would let two rapid mutations
+			// race and land out of request order.
+			CreatedAt:  time.Now(),
 			Actor:      actor,
 			ActorRole:  role,
 			Method:     r.Method,
@@ -193,12 +198,18 @@ func isFleetHeartbeat(route string) bool {
 // disconnect cannot lose the row, and piggybacks the throttled retention
 // sweep.
 func (rec *Recorder) record(e Entry) {
+	// The middleware stamps CreatedAt at request completion so the trail keeps
+	// request order despite the async insert. Fall back to now for any direct
+	// caller that left it zero, so no row lands with a year-0001 timestamp.
+	if e.CreatedAt.IsZero() {
+		e.CreatedAt = time.Now()
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	_, err := rec.pool.Exec(ctx,
-		`INSERT INTO audit_log (actor, actor_role, method, route, path, entity_id, status_code, remote_addr)
-		 VALUES ($1, $2, $3, $4, $5, NULLIF($6, ''), $7, $8)`,
-		e.Actor, e.ActorRole, e.Method, e.Route, e.Path, e.EntityID, e.StatusCode, e.RemoteAddr)
+		`INSERT INTO audit_log (created_at, actor, actor_role, method, route, path, entity_id, status_code, remote_addr)
+		 VALUES ($1, $2, $3, $4, $5, $6, NULLIF($7, ''), $8, $9)`,
+		e.CreatedAt, e.Actor, e.ActorRole, e.Method, e.Route, e.Path, e.EntityID, e.StatusCode, e.RemoteAddr)
 	if err != nil {
 		debuglog.Error("audit: failed to record entry", "error", err, "route", e.Route)
 		return


### PR DESCRIPTION
## Problem

CI failed on `TestAudit_RecordsMutationsWithActor` (run 29132681100, master). The failure is a real ordering bug, not just test flake.

Audit rows are inserted on background goroutines and relied on the `audit_log.created_at` column default (`NOW()`) for their timestamp. Two mutations in quick succession could therefore insert out of request order, so a `created_at DESC` listing returned them reversed. In the failing run the user-create landed at `.593727`, after the later key-create at `.590975`, flipping the expected newest-first order.

Beyond the test, this meant the real audit trail could misorder near-simultaneous admin actions.

## Fix

- Stamp `created_at` in the middleware at request completion (synchronous, before the record goroutine is spawned) and insert it explicitly, so ordering reflects when actions happened rather than when the async writer happened to flush.
- `record()` also defaults a zero `created_at` to now, so no direct caller can land a year-0001 row.

No schema change: the column keeps its `DEFAULT NOW()` as a fallback.

## Verification

- `internal/audit` and `internal/api` audit tests pass; previously-failing test survives repeated runs (`-count=5`).
- `golangci-lint` clean on the package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)