### PR TITLE
fix(bellhop): unlink can't orphan an FD device row + live paired-devices list

### DIFF
--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
@@ -21,6 +21,7 @@ import com.hugalafutro.bellhop.ui.dashboard.DashboardScreen
 import com.hugalafutro.bellhop.ui.pairing.PairingScreen
 import com.hugalafutro.bellhop.ui.pairing.PairingViewModel
 import com.hugalafutro.bellhop.ui.theme.BellhopTheme
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
@@ -48,6 +49,35 @@ fun BellhopApp() {
     val linkState by linkStore.state.collectAsStateWithLifecycle(initialValue = LinkState.Loading)
     val scope = rememberCoroutineScope()
     var unlinking by remember { mutableStateOf(false) }
+    var unlinkFailed by remember { mutableStateOf(false) }
+
+    // Revoke the device token on Front Desk, THEN clear the local link. Only a
+    // confirmed remote revoke clears locally: if the DELETE can't reach Front
+    // Desk (or is refused) we keep the link and surface a retry, so a dropped
+    // request can't silently orphan the device row on Front Desk.
+    fun runUnlink(fdUrl: String) {
+        if (unlinking) return
+        unlinking = true
+        unlinkFailed = false
+        scope.launch {
+            val revoked =
+                try {
+                    // A missing token means nothing is registered to revoke, so the
+                    // local clear below is the whole unlink.
+                    linkStore.token()?.let { client.unlink(fdUrl, it) } ?: true
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Throwable) {
+                    false
+                }
+            if (revoked) {
+                linkStore.clear()
+            } else {
+                unlinkFailed = true
+            }
+            unlinking = false
+        }
+    }
 
     when (val state = linkState) {
         LinkState.Loading -> Unit
@@ -58,6 +88,7 @@ fun BellhopApp() {
             // flag and any stale form state each time we land back here.
             LaunchedEffect(Unit) {
                 unlinking = false
+                unlinkFailed = false
                 vm.reset()
             }
             val ui by vm.state.collectAsStateWithLifecycle()
@@ -72,20 +103,9 @@ fun BellhopApp() {
             DashboardScreen(
                 link = state,
                 unlinking = unlinking,
-                onUnlink = {
-                    if (unlinking) return@DashboardScreen
-                    unlinking = true
-                    scope.launch {
-                        // Best-effort remote revoke, then ALWAYS clear locally so a
-                        // throwing revoke (e.g. malformed stored fdUrl) can't strand
-                        // the user on the linked dashboard after they confirmed.
-                        try {
-                            linkStore.token()?.let { client.unlink(state.fdUrl, it) }
-                        } finally {
-                            linkStore.clear()
-                        }
-                    }
-                },
+                unlinkFailed = unlinkFailed,
+                onUnlink = { runUnlink(state.fdUrl) },
+                onDismissUnlinkError = { unlinkFailed = false },
             )
     }
 }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
@@ -50,6 +50,11 @@ fun BellhopApp() {
     val scope = rememberCoroutineScope()
     var unlinking by remember { mutableStateOf(false) }
     var unlinkFailed by remember { mutableStateOf(false) }
+    // Fence: the remote revoke for this link already succeeded and only the local
+    // clear is still pending (a rare clear() failure). A retry must then SKIP
+    // Front Desk (the token is now revoked, so a second DELETE would 401 and fail
+    // forever) and just re-attempt the clear. Reset on return to Unlinked.
+    var revokedRemotely by remember { mutableStateOf(false) }
 
     // Revoke the device token on Front Desk, THEN clear the local link. Only a
     // confirmed remote revoke clears locally: if the DELETE can't reach Front
@@ -61,25 +66,34 @@ fun BellhopApp() {
         unlinkFailed = false
         scope.launch {
             try {
-                val token = linkStore.token()
                 val revoked =
-                    if (token == null) {
-                        // Still Linked but the stored token can't be read (e.g. the
-                        // Keystore key is gone): the Front Desk row is still live and
-                        // we have no way to revoke it, so treat this as a failed
-                        // unlink and surface the retry path rather than clearing
-                        // locally and orphaning the row.
-                        false
+                    if (revokedRemotely) {
+                        // Already gone from Front Desk on a prior attempt; don't
+                        // re-hit it with the dead token, just fall through to clear.
+                        true
                     } else {
-                        try {
-                            client.unlink(fdUrl, token)
-                        } catch (e: CancellationException) {
-                            throw e
-                        } catch (e: Throwable) {
+                        val token = linkStore.token()
+                        if (token == null) {
+                            // Still Linked but the stored token can't be read (e.g. the
+                            // Keystore key is gone): the Front Desk row is still live and
+                            // we have no way to revoke it, so treat this as a failed
+                            // unlink and surface the retry path rather than clearing
+                            // locally and orphaning the row.
                             false
+                        } else {
+                            try {
+                                client.unlink(fdUrl, token)
+                            } catch (e: CancellationException) {
+                                throw e
+                            } catch (e: Throwable) {
+                                false
+                            }
                         }
                     }
                 if (revoked) {
+                    // Fence the remote side before clearing: if clear() throws, the
+                    // retry skips the now-dead Front Desk call and only re-clears.
+                    revokedRemotely = true
                     linkStore.clear()
                 } else {
                     unlinkFailed = true
@@ -107,6 +121,7 @@ fun BellhopApp() {
             LaunchedEffect(Unit) {
                 unlinking = false
                 unlinkFailed = false
+                revokedRemotely = false
                 vm.reset()
             }
             val ui by vm.state.collectAsStateWithLifecycle()

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
@@ -111,6 +111,30 @@ fun BellhopApp() {
         }
     }
 
+    // Operator escape hatch from the failure dialog: when the token can't be read
+    // or Front Desk can't be reached, a revoke is impossible and a retry can loop
+    // forever, so clear the link locally on request. The dialog already warns that
+    // Front Desk may still list the device and to revoke it there, so this is an
+    // informed choice, not a silent orphan.
+    fun forceUnlink() {
+        if (unlinking) return
+        unlinking = true
+        unlinkFailed = false
+        scope.launch {
+            try {
+                linkStore.clear()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Throwable) {
+                // Even the local clear failed (broken DataStore); re-surface the
+                // dialog so the operator can try once more.
+                unlinkFailed = true
+            } finally {
+                unlinking = false
+            }
+        }
+    }
+
     when (val state = linkState) {
         LinkState.Loading -> Unit
         LinkState.Unlinked -> {
@@ -139,6 +163,7 @@ fun BellhopApp() {
                 unlinkFailed = unlinkFailed,
                 onUnlink = { runUnlink(state.fdUrl) },
                 onDismissUnlinkError = { unlinkFailed = false },
+                onForceUnlink = { forceUnlink() },
             )
     }
 }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
@@ -60,22 +60,40 @@ fun BellhopApp() {
         unlinking = true
         unlinkFailed = false
         scope.launch {
-            val revoked =
-                try {
-                    // A missing token means nothing is registered to revoke, so the
-                    // local clear below is the whole unlink.
-                    linkStore.token()?.let { client.unlink(fdUrl, it) } ?: true
-                } catch (e: CancellationException) {
-                    throw e
-                } catch (e: Throwable) {
-                    false
+            try {
+                val token = linkStore.token()
+                val revoked =
+                    if (token == null) {
+                        // Still Linked but the stored token can't be read (e.g. the
+                        // Keystore key is gone): the Front Desk row is still live and
+                        // we have no way to revoke it, so treat this as a failed
+                        // unlink and surface the retry path rather than clearing
+                        // locally and orphaning the row.
+                        false
+                    } else {
+                        try {
+                            client.unlink(fdUrl, token)
+                        } catch (e: CancellationException) {
+                            throw e
+                        } catch (e: Throwable) {
+                            false
+                        }
+                    }
+                if (revoked) {
+                    linkStore.clear()
+                } else {
+                    unlinkFailed = true
                 }
-            if (revoked) {
-                linkStore.clear()
-            } else {
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Throwable) {
+                // A clear() failure after a confirmed revoke must not strand the
+                // dashboard mid-unlink; surface the retry path (the finally below
+                // always re-enables the controls).
                 unlinkFailed = true
+            } finally {
+                unlinking = false
             }
-            unlinking = false
         }
     }
 

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
@@ -38,8 +38,38 @@ fun DashboardScreen(
     onUnlink: () -> Unit,
     unlinking: Boolean,
     modifier: Modifier = Modifier,
+    unlinkFailed: Boolean = false,
+    onDismissUnlinkError: () -> Unit = {},
 ) {
     var confirmUnlink by remember { mutableStateOf(false) }
+
+    // The remote revoke couldn't reach Front Desk: the device is still linked
+    // (nothing was cleared locally either), so offer a retry rather than leaving
+    // an orphaned device row on Front Desk with no signal.
+    if (unlinkFailed) {
+        AlertDialog(
+            onDismissRequest = onDismissUnlinkError,
+            title = { Text(stringResource(R.string.dashboard_unlink_failed_title)) },
+            text = { Text(stringResource(R.string.dashboard_unlink_failed_body)) },
+            confirmButton = {
+                TextButton(
+                    enabled = !unlinking,
+                    onClick = {
+                        onDismissUnlinkError()
+                        onUnlink()
+                    },
+                    modifier = Modifier.testTag("dashboard-unlink-retry"),
+                ) {
+                    Text(stringResource(R.string.dashboard_unlink_retry))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = onDismissUnlinkError) {
+                    Text(stringResource(R.string.common_cancel))
+                }
+            },
+        )
+    }
 
     if (confirmUnlink) {
         AlertDialog(

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
@@ -40,12 +40,15 @@ fun DashboardScreen(
     modifier: Modifier = Modifier,
     unlinkFailed: Boolean = false,
     onDismissUnlinkError: () -> Unit = {},
+    onForceUnlink: () -> Unit = {},
 ) {
     var confirmUnlink by remember { mutableStateOf(false) }
 
-    // The remote revoke couldn't reach Front Desk: the device is still linked
-    // (nothing was cleared locally either), so offer a retry rather than leaving
-    // an orphaned device row on Front Desk with no signal.
+    // The remote revoke couldn't reach Front Desk (or the token can't be read to
+    // revoke at all). The device is still linked and nothing was cleared, so
+    // offer a retry AND an "unlink anyway" escape: with a dead/unreachable token a
+    // retry can loop forever, so the operator needs a way to clear locally (and is
+    // told to revoke on Front Desk) rather than being stranded on this screen.
     if (unlinkFailed) {
         AlertDialog(
             onDismissRequest = onDismissUnlinkError,
@@ -64,8 +67,15 @@ fun DashboardScreen(
                 }
             },
             dismissButton = {
-                TextButton(onClick = onDismissUnlinkError) {
-                    Text(stringResource(R.string.common_cancel))
+                TextButton(
+                    enabled = !unlinking,
+                    onClick = {
+                        onDismissUnlinkError()
+                        onForceUnlink()
+                    },
+                    modifier = Modifier.testTag("dashboard-unlink-force"),
+                ) {
+                    Text(stringResource(R.string.dashboard_unlink_force))
                 }
             },
         )

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -19,5 +19,8 @@
     <string name="dashboard_unlink">Unlink this device</string>
     <string name="dashboard_unlink_confirm_title">Unlink this device?</string>
     <string name="dashboard_unlink_confirm_body">This device will stop monitoring %1$s and its token will be revoked. You can pair again anytime with a new code.</string>
+    <string name="dashboard_unlink_failed_title">Couldn\'t reach Front Desk</string>
+    <string name="dashboard_unlink_failed_body">This device is still linked. Front Desk may still list it, so nothing was revoked. Check your connection and try again, or revoke this device from Front Desk → Settings → Paired devices.</string>
+    <string name="dashboard_unlink_retry">Try again</string>
     <string name="common_cancel">Cancel</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -20,7 +20,8 @@
     <string name="dashboard_unlink_confirm_title">Unlink this device?</string>
     <string name="dashboard_unlink_confirm_body">This device will stop monitoring %1$s and its token will be revoked. You can pair again anytime with a new code.</string>
     <string name="dashboard_unlink_failed_title">Couldn\'t reach Front Desk</string>
-    <string name="dashboard_unlink_failed_body">This device is still linked. Front Desk may still list it, so nothing was revoked. Check your connection and try again, or revoke this device from Front Desk → Settings → Paired devices.</string>
+    <string name="dashboard_unlink_failed_body">This device is still linked and nothing was revoked. Check your connection and try again. You can unlink here anyway, but Front Desk may still list this device, so revoke it from Front Desk → Settings → Paired devices.</string>
     <string name="dashboard_unlink_retry">Try again</string>
+    <string name="dashboard_unlink_force">Unlink anyway</string>
     <string name="common_cancel">Cancel</string>
 </resources>

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreenTest.kt
@@ -78,4 +78,27 @@ class DashboardScreenTest {
         assertTrue(dismissed)
         assertTrue(retries == 1)
     }
+
+    @Test
+    fun failedUnlinkOffersForceUnlinkEscapeHatch() {
+        var forced = 0
+        var dismissed = false
+        composeTestRule.setContent {
+            BellhopTheme {
+                DashboardScreen(
+                    link = link,
+                    onUnlink = {},
+                    unlinking = false,
+                    unlinkFailed = true,
+                    onDismissUnlinkError = { dismissed = true },
+                    onForceUnlink = { forced++ },
+                )
+            }
+        }
+        // When a revoke is impossible (dead/unreadable token), "Unlink anyway"
+        // clears locally so the operator is never stranded on the dashboard.
+        composeTestRule.onNodeWithTag("dashboard-unlink-force").performClick()
+        assertTrue(dismissed)
+        assertTrue(forced == 1)
+    }
 }

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreenTest.kt
@@ -56,4 +56,26 @@ class DashboardScreenTest {
         composeTestRule.onNodeWithTag("dashboard-unlink-confirm").performClick()
         assertTrue(clicked)
     }
+
+    @Test
+    fun failedUnlinkOffersRetryThatRefiresUnlink() {
+        var retries = 0
+        var dismissed = false
+        composeTestRule.setContent {
+            BellhopTheme {
+                DashboardScreen(
+                    link = link,
+                    onUnlink = { retries++ },
+                    unlinking = false,
+                    unlinkFailed = true,
+                    onDismissUnlinkError = { dismissed = true },
+                )
+            }
+        }
+        // A failed remote revoke surfaces the error dialog; "Try again" dismisses
+        // it and re-fires the unlink so the orphaned row can still be cleared.
+        composeTestRule.onNodeWithTag("dashboard-unlink-retry").performClick()
+        assertTrue(dismissed)
+        assertTrue(retries == 1)
+    }
 }

--- a/frontdesk/web/src/components/PairedDevicesPanel.tsx
+++ b/frontdesk/web/src/components/PairedDevicesPanel.tsx
@@ -24,9 +24,11 @@ function pairingPayload(code: string): string {
 	});
 }
 
-// pairListPollMs is how often the device list refreshes while a pairing code
-// is displayed, so the freshly paired phone shows up on its own.
-const PAIR_LIST_POLL_MS = 5000;
+// deviceListPollMs is how often the device list refreshes. A phone can pair or
+// unlink itself at any time (not just while a code is on screen), so the list
+// polls steadily and rows appear/disappear on their own without a manual reload.
+// A single cheap GET on the same cadence the members dashboard uses.
+const DEVICE_LIST_POLL_MS = 5000;
 
 export function PairedDevicesPanel() {
 	const { t } = useTranslation();
@@ -59,14 +61,20 @@ export function PairedDevicesPanel() {
 		refresh();
 	}, [refresh]);
 
-	// While a live code is displayed: poll the list (the new phone appears on
-	// its own), poll whether THIS code is still outstanding, and flip to the
-	// expired notice when the TTL runs out.
+	// Keep the list live at all times: a phone that pairs or unlinks itself shows
+	// up (or drops off) on its own, so the operator never has to reload the page.
+	useEffect(() => {
+		const id = setInterval(refresh, DEVICE_LIST_POLL_MS);
+		return () => clearInterval(id);
+	}, [refresh]);
+
+	// While a live code is displayed, poll whether THIS code is still outstanding
+	// (the steady poll above already keeps the list fresh) and flip to the expired
+	// notice when the TTL runs out.
 	useEffect(() => {
 		if (!pair || expired) return;
 		let cancelled = false;
 		const tick = () => {
-			refresh();
 			// A consumed code stops being outstanding; another operator pairing a
 			// different device does NOT touch it, so this is the correct signal.
 			api
@@ -76,7 +84,7 @@ export function PairedDevicesPanel() {
 				})
 				.catch(() => {});
 		};
-		const poll = setInterval(tick, PAIR_LIST_POLL_MS);
+		const poll = setInterval(tick, DEVICE_LIST_POLL_MS);
 		// Clamp into setTimeout's signed-32-bit delay range: a delay past ~24.8
 		// days would overflow and fire immediately.
 		const untilExpiry = Math.min(
@@ -89,7 +97,7 @@ export function PairedDevicesPanel() {
 			clearInterval(poll);
 			clearTimeout(expiry);
 		};
-	}, [pair, expired, refresh]);
+	}, [pair, expired]);
 
 	// Render the QR whenever a code is minted. The stale-QR reset happens in
 	// generate() (not here) so the effect never sets state synchronously.

--- a/frontdesk/web/src/components/__tests__/PairedDevicesPanel.test.tsx
+++ b/frontdesk/web/src/components/__tests__/PairedDevicesPanel.test.tsx
@@ -171,6 +171,26 @@ it("keeps the code when another operator's device pairs concurrently", async () 
 	expect(screen.getByLabelText("Pairing string")).toBeInTheDocument();
 }, 10000);
 
+it("drops a device that unlinks itself, without a manual reload", async () => {
+	// The phone self-unlinks: the backing list goes empty with no action in the
+	// panel. The steady poll must pick it up so the row disappears on its own.
+	let list: PairedDevice[] = [device];
+	server.use(
+		http.get("/api/devices", () => HttpResponse.json(list)),
+		http.post("/api/pair/start", () => HttpResponse.json(pairStart)),
+	);
+	renderPanel();
+	await screen.findByText("Pixel 8");
+
+	list = [];
+	await waitFor(
+		() => {
+			expect(screen.getByText("No devices paired yet.")).toBeInTheDocument();
+		},
+		{ timeout: 7000 },
+	);
+}, 10000);
+
 it("copies the pairing string to the clipboard", async () => {
 	server.use(...handlers([]));
 	const writeText = vi.fn().mockResolvedValue(undefined);


### PR DESCRIPTION
Follow-up to #409, found while testing pairing against the prod Front Desk.

## What

Two fixes surfaced during real relink/unlink testing:

### 1. Unlink can no longer silently orphan a device on Front Desk
Bellhop's unlink was best-effort: it ignored whether the remote `DELETE /api/devices/self` landed and **always** cleared the local link. A dropped request (which happened live: the phone showed "unlinked" while the device row survived on FD) left an orphaned row with no signal on the phone.

Now the local link is cleared **only** once the revoke is confirmed. If the DELETE can't reach FD, the device stays linked and a **"Couldn't reach Front Desk / Try again"** dialog lets the operator retry (or revoke it from FD) instead of orphaning the row. This matches the invariant that you're linked when you unlink, so you can always tell FD to delete you first.

### 2. Paired-devices list stays live without a page reload
The Settings panel only polled the device list while a pairing code was on screen, so a phone that unlinked itself (or paired) at any other time didn't appear/drop off until a manual reload. It now polls steadily whenever mounted, the same cheap-GET cadence the members dashboard uses.

## Not changed (verified expected)
`last_seen_at` shows "Never" right after pairing: it's stamped only on an **authenticated** device request (`TouchPairedDevice` from the auth path), and Bellhop makes none yet, that arrives with the read-only dashboard/SSE slice (A3).

## Tests
- Android: new `DashboardScreenTest` covering the failure dialog's retry path; ktlintCheck + testDebugUnitTest + Lint + assembleDebug green (JDK 21).
- FD web: new panel test for live self-unlink removal; 16/16 panel tests, biome, eslint, typecheck, and prod build green.

## Deploy note
The live-list change ships in the FD frontend (embedded in the FD binary), so it needs an FD rebuild to take effect on the homelab prod instance.

_🤖 Generated with [Claude Code](https://claude.com/claude-code)_