### PR TITLE
feat(bellhop): read-only members dashboard with live fleet health

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -40,6 +40,16 @@ android {
     }
 }
 
+androidComponents {
+    // Compose UI tests launch ui-test-manifest's ComponentActivity, which is a
+    // debugImplementation dependency, so the release-variant unit tests can
+    // never pass (CI runs testDebugUnitTest only). Disable them so a plain
+    // `./gradlew build` stays green instead of failing on a variant nobody runs.
+    beforeVariants(selector().withBuildType("release")) { variant ->
+        variant.hostTests[com.android.build.api.variant.HostTestBuilder.UNIT_TEST_TYPE]?.enable = false
+    }
+}
+
 kotlin {
     jvmToolchain(21)
 }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
@@ -18,6 +18,7 @@ import com.hugalafutro.bellhop.data.FrontDeskClient
 import com.hugalafutro.bellhop.data.LinkState
 import com.hugalafutro.bellhop.data.LinkStore
 import com.hugalafutro.bellhop.ui.dashboard.DashboardScreen
+import com.hugalafutro.bellhop.ui.dashboard.DashboardViewModel
 import com.hugalafutro.bellhop.ui.pairing.PairingScreen
 import com.hugalafutro.bellhop.ui.pairing.PairingViewModel
 import com.hugalafutro.bellhop.ui.theme.BellhopTheme
@@ -156,14 +157,25 @@ fun BellhopApp() {
                 onSubmit = vm::pair,
             )
         }
-        is LinkState.Linked ->
+        is LinkState.Linked -> {
+            // Keyed by the pairing (deviceId): the Activity-scoped ViewModel would
+            // otherwise survive an unlink and keep polling the OLD Front Desk after
+            // a relink to a different one (same trap PairingViewModel.reset fixes).
+            val dashVm: DashboardViewModel =
+                viewModel(
+                    key = "dashboard-${state.deviceId}",
+                    factory = DashboardViewModel.Factory(client, linkStore, state.fdUrl),
+                )
+            val ui by dashVm.state.collectAsStateWithLifecycle()
             DashboardScreen(
                 link = state,
+                ui = ui,
                 unlinking = unlinking,
                 unlinkFailed = unlinkFailed,
                 onUnlink = { runUnlink(state.fdUrl) },
                 onDismissUnlinkError = { unlinkFailed = false },
                 onForceUnlink = { forceUnlink() },
             )
+        }
     }
 }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
@@ -158,12 +158,14 @@ fun BellhopApp() {
             )
         }
         is LinkState.Linked -> {
-            // Keyed by the pairing (deviceId): the Activity-scoped ViewModel would
-            // otherwise survive an unlink and keep polling the OLD Front Desk after
-            // a relink to a different one (same trap PairingViewModel.reset fixes).
+            // Keyed by the full pairing (FD URL + deviceId): the Activity-scoped
+            // ViewModel would otherwise survive an unlink and keep polling the OLD
+            // Front Desk after a relink (same trap PairingViewModel.reset fixes).
+            // deviceId alone is a UUID minted by the FD, but including the URL
+            // costs nothing and holds even if some FD echoes a chosen id back.
             val dashVm: DashboardViewModel =
                 viewModel(
-                    key = "dashboard-${state.deviceId}",
+                    key = "dashboard-${state.fdUrl}|${state.deviceId}",
                     factory = DashboardViewModel.Factory(client, linkStore, state.fdUrl),
                 )
             val ui by dashVm.state.collectAsStateWithLifecycle()

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/FleetModels.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/FleetModels.kt
@@ -1,0 +1,57 @@
+package com.hugalafutro.bellhop.data
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+// Wire models for the Front Desk read tier a device token can reach:
+// GET /api/members (internal/frontdesk/server_members.go memberView) and
+// GET /api/fleet/autosync. These mirror the FD contract exactly; do not rename
+// JSON fields. Unknown keys are ignored, so FD may grow fields freely.
+
+/**
+ * FleetMember is one row of GET /api/members: the stored member plus the
+ * poller's live view of it. Only the fields the dashboard renders are modeled.
+ */
+@Serializable
+data class FleetMember(
+    val id: String,
+    val name: String = "",
+    val url: String = "",
+    val state: String = "active",
+    val status: MemberStatus = MemberStatus(),
+) {
+    val drained: Boolean get() = state == "drained"
+}
+
+/** MemberStatus mirrors FD's poller MemberStatus (internal/frontdesk/poller.go). */
+@Serializable
+data class MemberStatus(
+    val health: HealthStatus = HealthStatus(),
+    @SerialName("traefik_status") val traefikStatus: String = "",
+    val version: String = "",
+)
+
+/**
+ * HealthStatus is the poller's view of a member's /health endpoint. known=false
+ * means the member has not been probed yet (a fresh FD start), which the UI
+ * renders as "not checked yet", not as down.
+ */
+@Serializable
+data class HealthStatus(
+    val known: Boolean = false,
+    val healthy: Boolean = false,
+    @SerialName("latency_ms") val latencyMs: Long = 0,
+    @SerialName("checked_at") val checkedAt: String = "",
+    val error: String = "",
+)
+
+/**
+ * AutoSyncConfig is GET /api/fleet/autosync: the auto-sync toggle plus the
+ * designated primary member (empty when none is chosen). The dashboard only
+ * uses primaryId, for the Primary badge.
+ */
+@Serializable
+data class AutoSyncConfig(
+    val enabled: Boolean = false,
+    @SerialName("primary_id") val primaryId: String = "",
+)

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/FrontDeskClient.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/FrontDeskClient.kt
@@ -24,9 +24,27 @@ sealed interface PairResult {
 }
 
 /**
- * FrontDeskClient is Bellhop's one HTTP entry point to a Front Desk. This slice
- * only needs the public pairing exchange and self-unlink; the SSE/members
- * client arrives in a later slice on the same OkHttp stack.
+ * FetchResult is the outcome of an authenticated read. Unauthorized is its own
+ * arm because it means the device token itself no longer works (revoked on
+ * Front Desk, most likely), which the dashboard surfaces very differently from
+ * a transient network failure.
+ */
+sealed interface FetchResult<out T> {
+    data class Success<T>(
+        val data: T,
+    ) : FetchResult<T>
+
+    data object Unauthorized : FetchResult<Nothing>
+
+    data class Failure(
+        val message: String,
+    ) : FetchResult<Nothing>
+}
+
+/**
+ * FrontDeskClient is Bellhop's one HTTP entry point to a Front Desk: the public
+ * pairing exchange, self-unlink, and the authenticated read tier (members,
+ * auto-sync). The SSE client arrives in a later slice on the same OkHttp stack.
  */
 open class FrontDeskClient(
     private val http: OkHttpClient = OkHttpClient(),
@@ -93,6 +111,48 @@ open class FrontDeskClient(
             }.getOrElse { e ->
                 if (e is CancellationException) throw e
                 false
+            }
+        }
+
+    /** members fetches the fleet: every member plus its live poller status. */
+    open suspend fun members(
+        fdUrl: String,
+        token: String,
+    ): FetchResult<List<FleetMember>> = get(fdUrl, "/api/members", token)
+
+    /** autoSync fetches the auto-sync config; the dashboard badges its primary. */
+    open suspend fun autoSync(
+        fdUrl: String,
+        token: String,
+    ): FetchResult<AutoSyncConfig> = get(fdUrl, "/api/fleet/autosync", token)
+
+    // get is the shared authenticated GET: bearer token, decode the 2xx body as
+    // T, map 401 to Unauthorized (dead token), and keep every other throwable
+    // inside the modeled result set exactly like pair() does.
+    private suspend inline fun <reified T> get(
+        fdUrl: String,
+        path: String,
+        token: String,
+    ): FetchResult<T> =
+        withContext(Dispatchers.IO) {
+            runCatching {
+                val request =
+                    Request
+                        .Builder()
+                        .url("${base(fdUrl)}$path")
+                        .header("Authorization", "Bearer $token")
+                        .build()
+                http.newCall(request).execute().use { resp ->
+                    val text = resp.body?.string().orEmpty()
+                    when {
+                        resp.isSuccessful -> FetchResult.Success(json.decodeFromString<T>(text))
+                        resp.code == 401 -> FetchResult.Unauthorized
+                        else -> FetchResult.Failure(errorMessage(text, resp.code))
+                    }
+                }
+            }.getOrElse { e ->
+                if (e is CancellationException) throw e
+                FetchResult.Failure(e.message ?: "could not reach the Front Desk")
             }
         }
 

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
@@ -1,15 +1,27 @@
 package com.hugalafutro.bellhop.ui.dashboard
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -19,18 +31,24 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.hugalafutro.bellhop.R
+import com.hugalafutro.bellhop.data.FleetMember
+import com.hugalafutro.bellhop.data.HealthStatus
 import com.hugalafutro.bellhop.data.LinkState
+import com.hugalafutro.bellhop.data.MemberStatus
 import com.hugalafutro.bellhop.ui.theme.BellhopTheme
 
 /**
- * DashboardScreen is the linked-state home. For the A2 pairing slice it just
- * confirms the link (Front Desk name + role) and offers Unlink; the read-only
- * member list, events, and alerts land in the next slice.
+ * DashboardScreen is the linked-state home: the fleet's members with their live
+ * health, plus Unlink. Member data arrives via [DashboardViewModel]'s poll; a
+ * refresh failure keeps the stale list visible under an error banner.
  */
 @Composable
 fun DashboardScreen(
@@ -38,6 +56,7 @@ fun DashboardScreen(
     onUnlink: () -> Unit,
     unlinking: Boolean,
     modifier: Modifier = Modifier,
+    ui: DashboardUiState = DashboardUiState(),
     unlinkFailed: Boolean = false,
     onDismissUnlinkError: () -> Unit = {},
     onForceUnlink: () -> Unit = {},
@@ -119,37 +138,255 @@ fun DashboardScreen(
                 Modifier
                     .fillMaxSize()
                     .padding(innerPadding)
-                    .padding(24.dp),
-            verticalArrangement = Arrangement.Center,
-            horizontalAlignment = Alignment.CenterHorizontally,
+                    .padding(horizontal = 16.dp),
         ) {
-            Text(
-                text = stringResource(R.string.app_name),
-                style = MaterialTheme.typography.displayMedium,
-                color = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.testTag("dashboard-title"),
-            )
             Spacer(modifier = Modifier.height(8.dp))
-            Text(
-                text = stringResource(R.string.dashboard_linked, link.fdName.ifBlank { link.fdUrl }),
-                style = MaterialTheme.typography.bodyLarge,
-                color = MaterialTheme.colorScheme.onSurface,
-                modifier = Modifier.testTag("dashboard-linked"),
-            )
-            Text(
-                text = stringResource(R.string.dashboard_role, link.role),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            Spacer(modifier = Modifier.height(24.dp))
-            OutlinedButton(
-                onClick = { confirmUnlink = true },
-                enabled = !unlinking,
-                modifier = Modifier.testTag("dashboard-unlink"),
-            ) {
-                Text(stringResource(R.string.dashboard_unlink))
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = link.fdName.ifBlank { link.fdUrl },
+                        style = MaterialTheme.typography.titleLarge,
+                        color = MaterialTheme.colorScheme.primary,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.testTag("dashboard-title"),
+                    )
+                    Text(
+                        text = stringResource(R.string.dashboard_linked_as, link.label, link.role),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.testTag("dashboard-linked"),
+                    )
+                }
+                TextButton(
+                    onClick = { confirmUnlink = true },
+                    enabled = !unlinking,
+                    modifier = Modifier.testTag("dashboard-unlink"),
+                ) {
+                    Text(stringResource(R.string.dashboard_unlink))
+                }
+            }
+            Spacer(modifier = Modifier.height(12.dp))
+
+            if (ui.revoked) {
+                StatusBanner(
+                    text = stringResource(R.string.dashboard_revoked),
+                    tag = "dashboard-revoked",
+                )
+            } else if (ui.error != null) {
+                StatusBanner(
+                    text = stringResource(R.string.dashboard_refresh_failed, ui.error),
+                    tag = "dashboard-error",
+                )
+            }
+
+            when {
+                ui.loading ->
+                    Box(
+                        modifier = Modifier.fillMaxWidth().weight(1f),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        CircularProgressIndicator(modifier = Modifier.testTag("dashboard-loading"))
+                    }
+                ui.members.isEmpty() ->
+                    Box(
+                        modifier = Modifier.fillMaxWidth().weight(1f),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Text(
+                            text = stringResource(R.string.dashboard_empty),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.testTag("dashboard-empty"),
+                        )
+                    }
+                else -> {
+                    FleetSummary(members = ui.members)
+                    LazyColumn(
+                        modifier = Modifier.weight(1f),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                        contentPadding = PaddingValues(bottom = 24.dp),
+                    ) {
+                        items(ui.members, key = { it.id }) { member ->
+                            MemberCard(member = member, isPrimary = member.id == ui.primaryId)
+                        }
+                    }
+                }
             }
         }
+    }
+}
+
+/** FleetSummary is the one-line rollup above the list: all up, or how many down. */
+@Composable
+private fun FleetSummary(
+    members: List<FleetMember>,
+    modifier: Modifier = Modifier,
+) {
+    val down = members.count { it.status.health.known && !it.status.health.healthy }
+    val unknown = members.count { !it.status.health.known }
+    val (text, color) =
+        when {
+            down > 0 ->
+                stringResource(R.string.dashboard_summary_down, down, members.size) to
+                    MaterialTheme.colorScheme.error
+            unknown == members.size ->
+                stringResource(R.string.dashboard_summary_checking) to
+                    MaterialTheme.colorScheme.onSurfaceVariant
+            else ->
+                stringResource(R.string.dashboard_summary_all_up) to
+                    MaterialTheme.colorScheme.tertiary
+        }
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelLarge,
+        color = color,
+        modifier = modifier.padding(bottom = 8.dp).testTag("dashboard-summary"),
+    )
+}
+
+@Composable
+private fun MemberCard(
+    member: FleetMember,
+    isPrimary: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val health = member.status.health
+    val healthColor =
+        when {
+            !health.known -> MaterialTheme.colorScheme.outline
+            health.healthy -> MaterialTheme.colorScheme.tertiary
+            else -> MaterialTheme.colorScheme.error
+        }
+    Card(modifier = modifier.fillMaxWidth().testTag("member-card-${member.name}")) {
+        Column(
+            modifier = Modifier.padding(14.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Box(
+                    modifier =
+                        Modifier
+                            .size(10.dp)
+                            .clip(CircleShape)
+                            .background(healthColor),
+                )
+                Text(
+                    text = member.name,
+                    style = MaterialTheme.typography.titleMedium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f),
+                )
+                if (isPrimary) {
+                    Pill(
+                        text = stringResource(R.string.member_primary),
+                        container = MaterialTheme.colorScheme.secondaryContainer,
+                        content = MaterialTheme.colorScheme.onSecondaryContainer,
+                        tag = "member-primary",
+                    )
+                }
+                if (member.drained) {
+                    Pill(
+                        text = stringResource(R.string.member_state_drained),
+                        container = MaterialTheme.colorScheme.errorContainer,
+                        content = MaterialTheme.colorScheme.onErrorContainer,
+                        tag = "member-drained",
+                    )
+                }
+            }
+            Text(
+                text = member.url,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                Text(
+                    text = healthLabel(health),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = healthColor,
+                )
+                if (health.known && member.status.traefikStatus.isNotBlank()) {
+                    Text(
+                        text = stringResource(R.string.member_traefik, member.status.traefikStatus),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                if (member.status.version.isNotBlank()) {
+                    Text(
+                        text = member.status.version,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            if (health.known && !health.healthy && health.error.isNotBlank()) {
+                Text(
+                    text = health.error,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun healthLabel(health: HealthStatus): String =
+    when {
+        !health.known -> stringResource(R.string.member_health_unknown)
+        health.healthy -> stringResource(R.string.member_health_up, health.latencyMs)
+        else -> stringResource(R.string.member_health_down)
+    }
+
+@Composable
+private fun Pill(
+    text: String,
+    container: Color,
+    content: Color,
+    tag: String,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        color = container,
+        contentColor = content,
+        shape = RoundedCornerShape(999.dp),
+        modifier = modifier.testTag(tag),
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelSmall,
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
+        )
+    }
+}
+
+/** StatusBanner is the stale-data warning strip: refresh failed or token dead. */
+@Composable
+private fun StatusBanner(
+    text: String,
+    tag: String,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        color = MaterialTheme.colorScheme.errorContainer,
+        contentColor = MaterialTheme.colorScheme.onErrorContainer,
+        shape = MaterialTheme.shapes.medium,
+        modifier = modifier.fillMaxWidth().padding(bottom = 12.dp).testTag(tag),
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodySmall,
+            modifier = Modifier.padding(12.dp),
+        )
     }
 }
 
@@ -168,6 +405,41 @@ private fun DashboardScreenPreview() {
                 ),
             onUnlink = {},
             unlinking = false,
+            ui =
+                DashboardUiState(
+                    loading = false,
+                    primaryId = "m1",
+                    members =
+                        listOf(
+                            FleetMember(
+                                id = "m1",
+                                name = "hotel-1",
+                                url = "http://10.0.0.10:8080",
+                                status =
+                                    MemberStatus(
+                                        health = HealthStatus(known = true, healthy = true, latencyMs = 12),
+                                        traefikStatus = "UP",
+                                        version = "0.31.0",
+                                    ),
+                            ),
+                            FleetMember(
+                                id = "m2",
+                                name = "hotel-2",
+                                url = "http://10.0.0.11:8080",
+                                state = "drained",
+                                status =
+                                    MemberStatus(
+                                        health =
+                                            HealthStatus(
+                                                known = true,
+                                                healthy = false,
+                                                error = "connection refused",
+                                            ),
+                                        traefikStatus = "DOWN",
+                                    ),
+                            ),
+                        ),
+                ),
         )
     }
 }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
@@ -207,7 +207,11 @@ fun DashboardScreen(
                         verticalArrangement = Arrangement.spacedBy(8.dp),
                         contentPadding = PaddingValues(bottom = 24.dp),
                     ) {
-                        items(ui.members, key = { it.id }) { member ->
+                        // Deliberately unkeyed: member ids are FD database primary
+                        // keys so duplicates shouldn't happen, but a buggy response
+                        // with duplicate ids would crash a keyed LazyColumn outright.
+                        // Positional identity is fine for a small stateless list.
+                        items(ui.members) { member ->
                             MemberCard(member = member, isPrimary = member.id == ui.primaryId)
                         }
                     }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModel.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModel.kt
@@ -1,0 +1,114 @@
+package com.hugalafutro.bellhop.ui.dashboard
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.hugalafutro.bellhop.data.FetchResult
+import com.hugalafutro.bellhop.data.FleetMember
+import com.hugalafutro.bellhop.data.FrontDeskClient
+import com.hugalafutro.bellhop.data.LinkStore
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * DashboardUiState is what the linked home renders. A failed refresh keeps the
+ * last good member list on screen (stale beats blank on a phone) and raises
+ * [error]; [revoked] means the device token itself no longer authenticates
+ * (revoked on Front Desk, or unreadable locally), which only unlinking fixes.
+ */
+data class DashboardUiState(
+    val loading: Boolean = true,
+    val members: List<FleetMember> = emptyList(),
+    val primaryId: String = "",
+    val error: String? = null,
+    val revoked: Boolean = false,
+)
+
+/**
+ * DashboardViewModel polls the Front Desk read tier while the dashboard is on
+ * screen: GET /api/members every [pollIntervalMs], plus the auto-sync config for
+ * the Primary badge. Polling is gated on active collectors so a backgrounded
+ * app stops hitting the network; the SSE slice will replace this loop with a
+ * push stream on the same state.
+ */
+class DashboardViewModel(
+    private val client: FrontDeskClient,
+    private val linkStore: LinkStore,
+    private val fdUrl: String,
+    private val pollIntervalMs: Long = POLL_INTERVAL_MS,
+) : ViewModel() {
+    private val _state = MutableStateFlow(DashboardUiState())
+    val state: StateFlow<DashboardUiState> = _state.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            _state.subscriptionCount
+                .map { it > 0 }
+                .distinctUntilChanged()
+                .collectLatest { active ->
+                    if (active) {
+                        while (true) {
+                            refreshOnce()
+                            delay(pollIntervalMs)
+                        }
+                    }
+                }
+        }
+    }
+
+    /**
+     * refreshOnce performs one members fetch. The auto-sync fetch is best-effort:
+     * the Primary badge going stale must not fail an otherwise good refresh.
+     */
+    suspend fun refreshOnce() {
+        val token = linkStore.token()
+        if (token == null) {
+            // Still linked but the token can't be read back (e.g. the Keystore
+            // key is gone): no request can ever succeed, same operator remedy as
+            // a remote revoke, so surface it through the same flag.
+            _state.update { it.copy(loading = false, revoked = true) }
+            return
+        }
+        when (val result = client.members(fdUrl, token)) {
+            is FetchResult.Success -> {
+                val autoSync = client.autoSync(fdUrl, token) as? FetchResult.Success
+                _state.update {
+                    it.copy(
+                        loading = false,
+                        members = result.data,
+                        primaryId = autoSync?.data?.primaryId ?: it.primaryId,
+                        error = null,
+                        revoked = false,
+                    )
+                }
+            }
+            FetchResult.Unauthorized ->
+                _state.update { it.copy(loading = false, revoked = true) }
+            is FetchResult.Failure ->
+                _state.update { it.copy(loading = false, error = result.message) }
+        }
+    }
+
+    class Factory(
+        private val client: FrontDeskClient,
+        private val linkStore: LinkStore,
+        private val fdUrl: String,
+    ) : ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>): T = DashboardViewModel(client, linkStore, fdUrl) as T
+    }
+
+    companion object {
+        // Matches Front Desk's own paired-devices list poll cadence family: fast
+        // enough that a member going down shows within seconds, slow enough to be
+        // polite from a phone.
+        const val POLL_INTERVAL_MS = 15_000L
+    }
+}

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -14,9 +14,20 @@
     <string name="pairing_error_invalid_code">Invalid or expired pairing code. Generate a new one in Front Desk and paste the fresh string.</string>
 
     <!-- Dashboard (linked state) -->
-    <string name="dashboard_linked">Linked to %1$s</string>
-    <string name="dashboard_role">Role: %1$s</string>
-    <string name="dashboard_unlink">Unlink this device</string>
+    <string name="dashboard_linked_as">Linked as %1$s (%2$s)</string>
+    <string name="dashboard_summary_all_up">All members up</string>
+    <string name="dashboard_summary_down">%1$d of %2$d members down</string>
+    <string name="dashboard_summary_checking">Checking members…</string>
+    <string name="dashboard_empty">No members yet. Add them in Front Desk.</string>
+    <string name="dashboard_refresh_failed">Couldn\'t refresh: %1$s</string>
+    <string name="dashboard_revoked">This device can no longer authenticate to Front Desk. Its access may have been revoked; unlink and pair again with a new code.</string>
+    <string name="member_health_up">Up · %1$d ms</string>
+    <string name="member_health_down">Down</string>
+    <string name="member_health_unknown">Not checked yet</string>
+    <string name="member_traefik">Traefik %1$s</string>
+    <string name="member_state_drained">Drained</string>
+    <string name="member_primary">Primary</string>
+    <string name="dashboard_unlink">Unlink</string>
     <string name="dashboard_unlink_confirm_title">Unlink this device?</string>
     <string name="dashboard_unlink_confirm_body">This device will stop monitoring %1$s and its token will be revoked. You can pair again anytime with a new code.</string>
     <string name="dashboard_unlink_failed_title">Couldn\'t reach Front Desk</string>

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/FrontDeskClientTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/FrontDeskClientTest.kt
@@ -97,6 +97,78 @@ class FrontDeskClientTest {
         }
 
     @Test
+    fun membersParsesFleetAndSendsBearer() =
+        runBlocking {
+            server.enqueue(
+                MockResponse().setBody(
+                    """[{"id":"m1","name":"hotel-1","url":"http://h1:8080","state":"drained","has_token":true,""" +
+                        """"status":{"health":{"known":true,"healthy":true,"latency_ms":12,"checked_at":"t"},""" +
+                        """"traefik_status":"UP","version":"0.31.0"}}]""",
+                ),
+            )
+
+            val result = client.members(server.url("/").toString(), "tok-1")
+
+            assertTrue(result is FetchResult.Success)
+            result as FetchResult.Success
+            val member = result.data.single()
+            assertEquals("m1", member.id)
+            assertTrue(member.drained)
+            assertTrue(member.status.health.healthy)
+            assertEquals(12L, member.status.health.latencyMs)
+            assertEquals("UP", member.status.traefikStatus)
+            assertEquals("0.31.0", member.status.version)
+
+            val request = server.takeRequest()
+            assertEquals("GET", request.method)
+            assertEquals("/api/members", request.path)
+            assertEquals("Bearer tok-1", request.getHeader("Authorization"))
+        }
+
+    @Test
+    fun membersMapsUnauthorizedToItsOwnArm() =
+        runBlocking {
+            // 401 means the device token is dead (revoked), not a transient
+            // failure; it must be distinguishable so the dashboard can say so.
+            server.enqueue(
+                MockResponse().setResponseCode(401).setBody(
+                    """{"error":{"code":"unauthorized","message":"bad token"}}""",
+                ),
+            )
+            val result = client.members(server.url("/").toString(), "dead")
+            assertEquals(FetchResult.Unauthorized, result)
+        }
+
+    @Test
+    fun membersUnexpectedSuccessBodyIsFailure() =
+        runBlocking {
+            server.enqueue(MockResponse().setBody("<html>not json</html>"))
+            val result = client.members(server.url("/").toString(), "tok")
+            assertTrue(result is FetchResult.Failure)
+        }
+
+    @Test
+    fun membersMalformedUrlIsFailureNotThrow() =
+        runBlocking {
+            val result = client.members("not a url", "tok")
+            assertTrue(result is FetchResult.Failure)
+        }
+
+    @Test
+    fun autoSyncParsesPrimary() =
+        runBlocking {
+            server.enqueue(MockResponse().setBody("""{"enabled":true,"primary_id":"m2"}"""))
+
+            val result = client.autoSync(server.url("/").toString(), "tok-1")
+
+            assertTrue(result is FetchResult.Success)
+            result as FetchResult.Success
+            assertTrue(result.data.enabled)
+            assertEquals("m2", result.data.primaryId)
+            assertEquals("/api/fleet/autosync", server.takeRequest().path)
+        }
+
+    @Test
     fun unlinkMalformedUrlIsFalseNotThrow() =
         runBlocking {
             assertFalse(client.unlink("not a url", "tok"))

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreenTest.kt
@@ -4,7 +4,10 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import com.hugalafutro.bellhop.data.FleetMember
+import com.hugalafutro.bellhop.data.HealthStatus
 import com.hugalafutro.bellhop.data.LinkState
+import com.hugalafutro.bellhop.data.MemberStatus
 import com.hugalafutro.bellhop.ui.theme.BellhopTheme
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -77,6 +80,106 @@ class DashboardScreenTest {
         composeTestRule.onNodeWithTag("dashboard-unlink-retry").performClick()
         assertTrue(dismissed)
         assertTrue(retries == 1)
+    }
+
+    private val members =
+        listOf(
+            FleetMember(
+                id = "m1",
+                name = "alpha",
+                url = "http://a:8080",
+                status =
+                    MemberStatus(
+                        health = HealthStatus(known = true, healthy = true, latencyMs = 3),
+                        traefikStatus = "UP",
+                        version = "1.0.0",
+                    ),
+            ),
+            FleetMember(
+                id = "m2",
+                name = "beta",
+                url = "http://b:8080",
+                state = "drained",
+                status =
+                    MemberStatus(
+                        health = HealthStatus(known = true, healthy = false, error = "connection refused"),
+                    ),
+            ),
+        )
+
+    @Test
+    fun rendersMemberCardsWithPrimaryAndDrainedBadges() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                DashboardScreen(
+                    link = link,
+                    onUnlink = {},
+                    unlinking = false,
+                    ui = DashboardUiState(loading = false, members = members, primaryId = "m1"),
+                )
+            }
+        }
+        composeTestRule.onNodeWithTag("dashboard-summary").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("member-card-alpha").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("member-card-beta").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("member-primary", useUnmergedTree = true).assertIsDisplayed()
+        composeTestRule.onNodeWithTag("member-drained", useUnmergedTree = true).assertIsDisplayed()
+    }
+
+    @Test
+    fun firstLoadShowsSpinnerThenEmptyStateWithoutMembers() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                DashboardScreen(link = link, onUnlink = {}, unlinking = false)
+            }
+        }
+        composeTestRule.onNodeWithTag("dashboard-loading").assertIsDisplayed()
+    }
+
+    @Test
+    fun emptyFleetShowsEmptyState() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                DashboardScreen(
+                    link = link,
+                    onUnlink = {},
+                    unlinking = false,
+                    ui = DashboardUiState(loading = false),
+                )
+            }
+        }
+        composeTestRule.onNodeWithTag("dashboard-empty").assertIsDisplayed()
+    }
+
+    @Test
+    fun refreshErrorShowsBannerAndKeepsStaleList() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                DashboardScreen(
+                    link = link,
+                    onUnlink = {},
+                    unlinking = false,
+                    ui = DashboardUiState(loading = false, members = members, error = "boom"),
+                )
+            }
+        }
+        composeTestRule.onNodeWithTag("dashboard-error").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("member-card-alpha").assertIsDisplayed()
+    }
+
+    @Test
+    fun revokedTokenShowsRevokedBanner() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                DashboardScreen(
+                    link = link,
+                    onUnlink = {},
+                    unlinking = false,
+                    ui = DashboardUiState(loading = false, members = members, revoked = true),
+                )
+            }
+        }
+        composeTestRule.onNodeWithTag("dashboard-revoked").assertIsDisplayed()
     }
 
     @Test

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModelTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModelTest.kt
@@ -1,0 +1,187 @@
+package com.hugalafutro.bellhop.ui.dashboard
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import com.hugalafutro.bellhop.data.AutoSyncConfig
+import com.hugalafutro.bellhop.data.FakeCipher
+import com.hugalafutro.bellhop.data.FetchResult
+import com.hugalafutro.bellhop.data.FleetMember
+import com.hugalafutro.bellhop.data.FrontDeskClient
+import com.hugalafutro.bellhop.data.HealthStatus
+import com.hugalafutro.bellhop.data.LinkStore
+import com.hugalafutro.bellhop.data.MemberStatus
+import com.hugalafutro.bellhop.data.PairedDevice
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.withTimeout
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.File
+
+/** FakeFleetClient serves canned read-tier results without touching the network. */
+private class FakeFleetClient(
+    var membersResult: FetchResult<List<FleetMember>>,
+    var autoSyncResult: FetchResult<AutoSyncConfig> = FetchResult.Failure("no autosync"),
+) : FrontDeskClient() {
+    var lastToken: String? = null
+
+    override suspend fun members(
+        fdUrl: String,
+        token: String,
+    ): FetchResult<List<FleetMember>> {
+        lastToken = token
+        return membersResult
+    }
+
+    override suspend fun autoSync(
+        fdUrl: String,
+        token: String,
+    ): FetchResult<AutoSyncConfig> = autoSyncResult
+}
+
+@RunWith(RobolectricTestRunner::class)
+class DashboardViewModelTest {
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    // viewModelScope dispatches on Main; run it inline for tests.
+    @Before
+    fun setUpMain() {
+        Dispatchers.setMain(Dispatchers.Unconfined)
+    }
+
+    @After
+    fun tearDownMain() {
+        Dispatchers.resetMain()
+    }
+
+    private fun newLinkStore(): LinkStore {
+        val scope = CoroutineScope(Dispatchers.IO + Job())
+        val ds =
+            PreferenceDataStoreFactory.create(scope = scope) {
+                File(tmp.newFolder(), "link.preferences_pb")
+            }
+        return LinkStore(ds, FakeCipher)
+    }
+
+    private suspend fun linkedStore(): LinkStore =
+        newLinkStore().also {
+            it.save(
+                fdUrl = "http://fd:1",
+                fdName = "FD",
+                token = "tok-1",
+                device = PairedDevice(id = "d1", label = "Pixel", role = "monitor"),
+            )
+        }
+
+    private val member =
+        FleetMember(
+            id = "m1",
+            name = "hotel-1",
+            url = "http://h1:8080",
+            status = MemberStatus(health = HealthStatus(known = true, healthy = true, latencyMs = 5)),
+        )
+
+    @Test
+    fun refreshPopulatesMembersAndPrimaryWithStoredToken() =
+        runBlocking {
+            val client =
+                FakeFleetClient(
+                    membersResult = FetchResult.Success(listOf(member)),
+                    autoSyncResult = FetchResult.Success(AutoSyncConfig(enabled = true, primaryId = "m1")),
+                )
+            val vm = DashboardViewModel(client, linkedStore(), "http://fd:1")
+
+            vm.refreshOnce()
+
+            val s = vm.state.value
+            assertFalse(s.loading)
+            assertEquals(listOf(member), s.members)
+            assertEquals("m1", s.primaryId)
+            assertNull(s.error)
+            assertFalse(s.revoked)
+            assertEquals("tok-1", client.lastToken)
+        }
+
+    @Test
+    fun failedRefreshKeepsStaleMembersAndRecovers() =
+        runBlocking {
+            val client = FakeFleetClient(FetchResult.Success(listOf(member)))
+            val vm = DashboardViewModel(client, linkedStore(), "http://fd:1")
+            vm.refreshOnce()
+
+            // Stale beats blank: the last good list stays, the error surfaces.
+            client.membersResult = FetchResult.Failure("boom")
+            vm.refreshOnce()
+            assertEquals(listOf(member), vm.state.value.members)
+            assertEquals("boom", vm.state.value.error)
+
+            // The next good refresh clears the error again.
+            client.membersResult = FetchResult.Success(listOf(member))
+            vm.refreshOnce()
+            assertNull(vm.state.value.error)
+        }
+
+    @Test
+    fun unauthorizedFlagsRevoked() =
+        runBlocking {
+            val vm = DashboardViewModel(FakeFleetClient(FetchResult.Unauthorized), linkedStore(), "http://fd:1")
+            vm.refreshOnce()
+            assertTrue(vm.state.value.revoked)
+            assertFalse(vm.state.value.loading)
+        }
+
+    @Test
+    fun missingTokenFlagsRevokedWithoutNetworkCall() =
+        runBlocking {
+            // Linked metadata without a readable token (e.g. lost Keystore key):
+            // no request can succeed, so don't make one.
+            val client = FakeFleetClient(FetchResult.Success(listOf(member)))
+            val vm = DashboardViewModel(client, newLinkStore(), "http://fd:1")
+            vm.refreshOnce()
+            assertTrue(vm.state.value.revoked)
+            assertNull(client.lastToken)
+        }
+
+    @Test
+    fun autoSyncFailureDoesNotFailTheRefresh() =
+        runBlocking {
+            // The Primary badge is best-effort; members must still land.
+            val client =
+                FakeFleetClient(
+                    membersResult = FetchResult.Success(listOf(member)),
+                    autoSyncResult = FetchResult.Failure("nope"),
+                )
+            val vm = DashboardViewModel(client, linkedStore(), "http://fd:1")
+            vm.refreshOnce()
+            val s = vm.state.value
+            assertEquals(listOf(member), s.members)
+            assertEquals("", s.primaryId)
+            assertNull(s.error)
+        }
+
+    @Test
+    fun subscribingStartsThePoll() =
+        runBlocking {
+            // The poll loop is gated on collectors; the first collector must
+            // trigger a refresh on its own, with no manual refreshOnce call.
+            val client = FakeFleetClient(FetchResult.Success(listOf(member)))
+            val vm = DashboardViewModel(client, linkedStore(), "http://fd:1")
+
+            val s = withTimeout(5_000) { vm.state.first { !it.loading } }
+            assertEquals(listOf(member), s.members)
+        }
+}


### PR DESCRIPTION
## What

Slice 1 of the Bellhop dashboard phase: the linked home screen is no longer a placeholder. It polls the Front Desk read tier (GET /api/members, 15s cadence, only while the UI is actually on screen) and renders one card per member with its live health dot, latency, Traefik status, version, and Drained/Primary badges, under an all-up / N-down fleet summary.

## How

- **FleetModels.kt**: wire models mirroring FD's memberView (member + poller status) and /fleet/autosync (Primary badge). Unknown JSON keys are ignored so FD can grow fields freely.
- **FrontDeskClient**: new `FetchResult` (Success / Unauthorized / Failure) plus `members()` / `autoSync()` over a shared authenticated GET. 401 is its own arm because a revoked device token needs very different UI than a network blip.
- **DashboardViewModel**: poll loop gated on active collectors (subscriptionCount), so a backgrounded app stops hitting the network; the SSE slice will replace the loop on the same state. A failed refresh keeps the stale list under an error banner (stale beats blank on a phone); a 401 or unreadable Keystore token raises a revoked banner. The auto-sync fetch is best-effort so the Primary badge can never fail a good refresh.
- **MainActivity**: the ViewModel is keyed by deviceId, so relinking to a different Front Desk never reuses a poller aimed at the old one (same trap PairingViewModel.reset() fixed in #409).
- **Build fix**: `./gradlew build` was permanently red because testReleaseUnitTest can never pass (compose ui-test-manifest is a debugImplementation dependency). Release-variant host tests are now disabled; CI runs testDebugUnitTest only, unchanged.

## Testing

- 40 unit tests green: 6 new DashboardViewModel tests (populate + primary, stale-on-failure + recovery, revoked on 401, revoked on missing token without a network call, best-effort autosync, poll starts on first subscription), 5 new DashboardScreen tests (cards + badges, loading, empty, error banner keeps stale list, revoked banner), 5 new FrontDeskClient tests (parse + bearer header, 401 arm, garbage body, malformed URL, autosync).
- ktlint, Android lint, assembleDebug, and the full `./gradlew build` all pass.
- Verified live on the emulator against a real Front Desk with two Model Hotel members: paired via the UI, dashboard showed both members (Primary badge on the auto-sync primary, Up with latency, Traefik UP, version), then unlinked via the UI and confirmed the FD device row was revoked.