### PR TITLE
feat(bellhop): member detail screen with last-hour traffic chart

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -25,6 +25,9 @@ jobs:
   android:
     name: Bellhop (lint + test + build)
     runs-on: ubuntu-latest
+    # The whole job normally finishes in ~5 min; a deadlocked test JVM once
+    # sat silent for hours, so cap it well above normal and far below never.
+    timeout-minutes: 30
     defaults:
       run:
         working-directory: android

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.time.Duration
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
@@ -43,7 +45,7 @@ android {
                 test.testLogging.events("started", "failed", "skipped")
                 // And kill a wedged test task long before the CI job cap: the
                 // whole suite runs in well under a minute.
-                test.timeout.set(java.time.Duration.ofMinutes(10))
+                test.timeout.set(Duration.ofMinutes(10))
             }
         }
     }

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -36,6 +36,15 @@ android {
     testOptions {
         unitTests {
             isIncludeAndroidResources = true
+            all { test ->
+                // Print each test as it starts, not just failures: when the
+                // test JVM wedges, the CI log then ends at the culprit's name
+                // instead of going silent for the whole job timeout.
+                test.testLogging.events("started", "failed", "skipped")
+                // And kill a wedged test task long before the CI job cap: the
+                // whole suite runs in well under a minute.
+                test.timeout.set(java.time.Duration.ofMinutes(10))
+            }
         }
     }
 }

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -62,6 +62,9 @@ dependencies {
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.compose.ui)
     implementation(libs.androidx.compose.material3)
+    // The back-arrow vector. material3 currently drags this in transitively,
+    // but the icons the app uses must not ride on someone else's dependency.
+    implementation(libs.androidx.compose.material.icons.core)
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.okhttp)
     implementation(libs.okhttp.sse)

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
@@ -2,6 +2,7 @@ package com.hugalafutro.bellhop
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.runtime.Composable
@@ -10,6 +11,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -19,6 +21,8 @@ import com.hugalafutro.bellhop.data.LinkState
 import com.hugalafutro.bellhop.data.LinkStore
 import com.hugalafutro.bellhop.ui.dashboard.DashboardScreen
 import com.hugalafutro.bellhop.ui.dashboard.DashboardViewModel
+import com.hugalafutro.bellhop.ui.member.MemberDetailScreen
+import com.hugalafutro.bellhop.ui.member.MemberDetailViewModel
 import com.hugalafutro.bellhop.ui.pairing.PairingScreen
 import com.hugalafutro.bellhop.ui.pairing.PairingViewModel
 import com.hugalafutro.bellhop.ui.theme.BellhopTheme
@@ -169,15 +173,51 @@ fun BellhopApp() {
                     factory = DashboardViewModel.Factory(client, linkStore, state.fdUrl),
                 )
             val ui by dashVm.state.collectAsStateWithLifecycle()
-            DashboardScreen(
-                link = state,
-                ui = ui,
-                unlinking = unlinking,
-                unlinkFailed = unlinkFailed,
-                onUnlink = { runUnlink(state.fdUrl) },
-                onDismissUnlinkError = { unlinkFailed = false },
-                onForceUnlink = { forceUnlink() },
-            )
+
+            // Which member's detail is open, if any. Saveable so it survives
+            // rotation/process death; keyed on the pairing so a relink lands
+            // back on the new Front Desk's dashboard, not a stale detail.
+            var selectedMemberId by rememberSaveable(state.fdUrl, state.deviceId) {
+                mutableStateOf<String?>(null)
+            }
+            val selected = ui.members.find { it.id == selectedMemberId }
+            // The member left the fleet while its detail was open: drop the
+            // selection (once the list has actually loaded) so the detail
+            // doesn't silently reopen if the same id ever reappears.
+            LaunchedEffect(selectedMemberId, selected, ui.loading) {
+                if (selectedMemberId != null && selected == null && !ui.loading) {
+                    selectedMemberId = null
+                }
+            }
+
+            if (selected != null) {
+                BackHandler { selectedMemberId = null }
+                // Keyed like the dashboard VM, plus the member id, so flipping
+                // between members never shows another member's series.
+                val detailVm: MemberDetailViewModel =
+                    viewModel(
+                        key = "member-${state.fdUrl}|${state.deviceId}|${selected.id}",
+                        factory = MemberDetailViewModel.Factory(client, linkStore, state.fdUrl, selected.id),
+                    )
+                val detailUi by detailVm.state.collectAsStateWithLifecycle()
+                MemberDetailScreen(
+                    member = selected,
+                    isPrimary = selected.id == ui.primaryId,
+                    ui = detailUi,
+                    onBack = { selectedMemberId = null },
+                )
+            } else {
+                DashboardScreen(
+                    link = state,
+                    ui = ui,
+                    unlinking = unlinking,
+                    unlinkFailed = unlinkFailed,
+                    onUnlink = { runUnlink(state.fdUrl) },
+                    onDismissUnlinkError = { unlinkFailed = false },
+                    onForceUnlink = { forceUnlink() },
+                    onMemberClick = { selectedMemberId = it },
+                )
+            }
         }
     }
 }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/FleetModels.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/FleetModels.kt
@@ -57,6 +57,31 @@ data class AutoSyncConfig(
 )
 
 /**
+ * MemberTraffic is GET /api/members/{id}/traffic (internal/frontdesk/
+ * membertraffic.go memberTrafficResponse): the member's last-hour request and
+ * error series in 5-minute buckets, proxied by Front Desk from the member's
+ * admin stats API. reachable=false is a normal state (FD has no admin token
+ * for the member, or the member didn't answer), not an error.
+ */
+@Serializable
+data class MemberTraffic(
+    @SerialName("member_id") val memberId: String = "",
+    val reachable: Boolean = false,
+    @SerialName("window_minutes") val windowMinutes: Int = 60,
+    @SerialName("total_requests") val totalRequests: Int = 0,
+    @SerialName("total_errors") val totalErrors: Int = 0,
+    val points: List<TrafficPoint> = emptyList(),
+)
+
+/** TrafficPoint is one time bucket: total requests and the error subset. */
+@Serializable
+data class TrafficPoint(
+    val bucket: String = "",
+    val requests: Int = 0,
+    val errors: Int = 0,
+)
+
+/**
  * FleetEvent is one control-plane event off the GET /api/sse stream, mirroring
  * the backend's events.Event envelope (internal/events/bus.go). The dashboard
  * only reads [type] (to decide whether the change warrants a member refetch);

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/FrontDeskClient.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/FrontDeskClient.kt
@@ -159,6 +159,17 @@ open class FrontDeskClient(
         token: String,
     ): FetchResult<List<FleetMember>> = get(fdUrl, "/api/members", token)
 
+    /**
+     * memberTraffic fetches one member's last-hour request/error series (the
+     * member-detail chart). Front Desk answers 200 with reachable=false when
+     * the series can't be read, so failures here are FD-transport ones.
+     */
+    open suspend fun memberTraffic(
+        fdUrl: String,
+        token: String,
+        memberId: String,
+    ): FetchResult<MemberTraffic> = get(fdUrl, "/api/members/$memberId/traffic", token)
+
     /** autoSync fetches the auto-sync config; the dashboard badges its primary. */
     open suspend fun autoSync(
         fdUrl: String,

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/FleetUi.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/FleetUi.kt
@@ -1,0 +1,81 @@
+package com.hugalafutro.bellhop.ui.common
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.hugalafutro.bellhop.R
+import com.hugalafutro.bellhop.data.HealthStatus
+
+// Small fleet-rendering pieces shared by the dashboard cards and the member
+// detail screen, so both spell a member's health and badges the same way.
+
+/** StatusBanner is the stale-data warning strip: refresh failed or token dead. */
+@Composable
+internal fun StatusBanner(
+    text: String,
+    tag: String,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        color = MaterialTheme.colorScheme.errorContainer,
+        contentColor = MaterialTheme.colorScheme.onErrorContainer,
+        shape = MaterialTheme.shapes.medium,
+        modifier = modifier.fillMaxWidth().padding(bottom = 12.dp).testTag(tag),
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodySmall,
+            modifier = Modifier.padding(12.dp),
+        )
+    }
+}
+
+/** Pill is a compact rounded badge (Primary, Drained). */
+@Composable
+internal fun Pill(
+    text: String,
+    container: Color,
+    content: Color,
+    tag: String,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        color = container,
+        contentColor = content,
+        shape = RoundedCornerShape(999.dp),
+        modifier = modifier.testTag(tag),
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelSmall,
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
+        )
+    }
+}
+
+/** healthColor maps the poller's view to the shared up/down/unknown color. */
+@Composable
+internal fun healthColor(health: HealthStatus): Color =
+    when {
+        !health.known -> MaterialTheme.colorScheme.outline
+        health.healthy -> MaterialTheme.colorScheme.tertiary
+        else -> MaterialTheme.colorScheme.error
+    }
+
+/** healthLabel is the one-line human reading of the poller's view. */
+@Composable
+internal fun healthLabel(health: HealthStatus): String =
+    when {
+        !health.known -> stringResource(R.string.member_health_unknown)
+        health.healthy -> stringResource(R.string.member_health_up, health.latencyMs)
+        else -> stringResource(R.string.member_health_down)
+    }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
@@ -15,13 +15,11 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -32,7 +30,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
@@ -43,6 +40,10 @@ import com.hugalafutro.bellhop.data.FleetMember
 import com.hugalafutro.bellhop.data.HealthStatus
 import com.hugalafutro.bellhop.data.LinkState
 import com.hugalafutro.bellhop.data.MemberStatus
+import com.hugalafutro.bellhop.ui.common.Pill
+import com.hugalafutro.bellhop.ui.common.StatusBanner
+import com.hugalafutro.bellhop.ui.common.healthColor
+import com.hugalafutro.bellhop.ui.common.healthLabel
 import com.hugalafutro.bellhop.ui.theme.BellhopTheme
 
 /**
@@ -60,6 +61,7 @@ fun DashboardScreen(
     unlinkFailed: Boolean = false,
     onDismissUnlinkError: () -> Unit = {},
     onForceUnlink: () -> Unit = {},
+    onMemberClick: (String) -> Unit = {},
 ) {
     var confirmUnlink by remember { mutableStateOf(false) }
 
@@ -212,7 +214,11 @@ fun DashboardScreen(
                         // with duplicate ids would crash a keyed LazyColumn outright.
                         // Positional identity is fine for a small stateless list.
                         items(ui.members) { member ->
-                            MemberCard(member = member, isPrimary = member.id == ui.primaryId)
+                            MemberCard(
+                                member = member,
+                                isPrimary = member.id == ui.primaryId,
+                                onClick = { onMemberClick(member.id) },
+                            )
                         }
                     }
                 }
@@ -253,16 +259,12 @@ private fun FleetSummary(
 private fun MemberCard(
     member: FleetMember,
     isPrimary: Boolean,
+    onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val health = member.status.health
-    val healthColor =
-        when {
-            !health.known -> MaterialTheme.colorScheme.outline
-            health.healthy -> MaterialTheme.colorScheme.tertiary
-            else -> MaterialTheme.colorScheme.error
-        }
-    Card(modifier = modifier.fillMaxWidth().testTag("member-card-${member.name}")) {
+    val healthColor = healthColor(health)
+    Card(onClick = onClick, modifier = modifier.fillMaxWidth().testTag("member-card-${member.name}")) {
         Column(
             modifier = Modifier.padding(14.dp),
             verticalArrangement = Arrangement.spacedBy(4.dp),
@@ -340,57 +342,6 @@ private fun MemberCard(
                 )
             }
         }
-    }
-}
-
-@Composable
-private fun healthLabel(health: HealthStatus): String =
-    when {
-        !health.known -> stringResource(R.string.member_health_unknown)
-        health.healthy -> stringResource(R.string.member_health_up, health.latencyMs)
-        else -> stringResource(R.string.member_health_down)
-    }
-
-@Composable
-private fun Pill(
-    text: String,
-    container: Color,
-    content: Color,
-    tag: String,
-    modifier: Modifier = Modifier,
-) {
-    Surface(
-        color = container,
-        contentColor = content,
-        shape = RoundedCornerShape(999.dp),
-        modifier = modifier.testTag(tag),
-    ) {
-        Text(
-            text = text,
-            style = MaterialTheme.typography.labelSmall,
-            modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
-        )
-    }
-}
-
-/** StatusBanner is the stale-data warning strip: refresh failed or token dead. */
-@Composable
-private fun StatusBanner(
-    text: String,
-    tag: String,
-    modifier: Modifier = Modifier,
-) {
-    Surface(
-        color = MaterialTheme.colorScheme.errorContainer,
-        contentColor = MaterialTheme.colorScheme.onErrorContainer,
-        shape = MaterialTheme.shapes.medium,
-        modifier = modifier.fillMaxWidth().padding(bottom = 12.dp).testTag(tag),
-    ) {
-        Text(
-            text = text,
-            style = MaterialTheme.typography.bodySmall,
-            modifier = Modifier.padding(12.dp),
-        )
     }
 }
 

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModel.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModel.kt
@@ -82,11 +82,14 @@ class DashboardViewModel(
     // runRefreshes is the sole refresher: one refresh on subscribe, then one per
     // nudge. Serial by construction, so the poll and the stream never overlap.
     private suspend fun runRefreshes() {
-        refreshOnce()
+        // A revoked (or unreadable) token can never authenticate again; only
+        // unlinking fixes it, and relinking rebuilds this ViewModel. Swallow
+        // the initial refresh and the nudges instead of hitting Front Desk
+        // forever; gating the initial one also keeps a collector restart
+        // (backgrounding and reopening the app) from firing one more doomed
+        // request per restart.
+        if (!_state.value.revoked) refreshOnce()
         for (ignored in refreshTrigger) {
-            // A revoked (or unreadable) token can never authenticate again;
-            // only unlinking fixes it, and relinking rebuilds this ViewModel.
-            // Swallow the nudges instead of hitting Front Desk forever.
             if (_state.value.revoked) continue
             refreshOnce()
         }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModel.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModel.kt
@@ -84,6 +84,10 @@ class DashboardViewModel(
     private suspend fun runRefreshes() {
         refreshOnce()
         for (ignored in refreshTrigger) {
+            // A revoked (or unreadable) token can never authenticate again;
+            // only unlinking fixes it, and relinking rebuilds this ViewModel.
+            // Swallow the nudges instead of hitting Front Desk forever.
+            if (_state.value.revoked) continue
             refreshOnce()
         }
     }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreen.kt
@@ -1,0 +1,324 @@
+package com.hugalafutro.bellhop.ui.member
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.hugalafutro.bellhop.R
+import com.hugalafutro.bellhop.data.FleetMember
+import com.hugalafutro.bellhop.data.HealthStatus
+import com.hugalafutro.bellhop.data.MemberStatus
+import com.hugalafutro.bellhop.data.MemberTraffic
+import com.hugalafutro.bellhop.data.TrafficPoint
+import com.hugalafutro.bellhop.ui.common.Pill
+import com.hugalafutro.bellhop.ui.common.StatusBanner
+import com.hugalafutro.bellhop.ui.common.healthColor
+import com.hugalafutro.bellhop.ui.common.healthLabel
+import com.hugalafutro.bellhop.ui.theme.BellhopTheme
+
+/**
+ * MemberDetailScreen is one member up close: the same identity and health the
+ * dashboard card shows (the [member] arrives live from the dashboard's poll,
+ * so badges keep moving here too) plus the last hour of request/error traffic
+ * from [MemberDetailViewModel]. Read-only; operator actions are a later phase.
+ */
+@Composable
+fun MemberDetailScreen(
+    member: FleetMember,
+    isPrimary: Boolean,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    ui: MemberDetailUiState = MemberDetailUiState(),
+) {
+    val health = member.status.health
+    Scaffold(modifier = modifier.fillMaxSize()) { innerPadding ->
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding)
+                    .padding(horizontal = 16.dp)
+                    .verticalScroll(rememberScrollState()),
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
+            ) {
+                IconButton(onClick = onBack, modifier = Modifier.testTag("member-detail-back")) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = stringResource(R.string.member_detail_back),
+                    )
+                }
+                Box(
+                    modifier =
+                        Modifier
+                            .size(10.dp)
+                            .clip(CircleShape)
+                            .background(healthColor(health)),
+                )
+                Text(
+                    text = member.name,
+                    style = MaterialTheme.typography.titleLarge,
+                    color = MaterialTheme.colorScheme.primary,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f).testTag("member-detail-title"),
+                )
+                if (isPrimary) {
+                    Pill(
+                        text = stringResource(R.string.member_primary),
+                        container = MaterialTheme.colorScheme.secondaryContainer,
+                        content = MaterialTheme.colorScheme.onSecondaryContainer,
+                        tag = "member-detail-primary",
+                    )
+                }
+                if (member.drained) {
+                    Pill(
+                        text = stringResource(R.string.member_state_drained),
+                        container = MaterialTheme.colorScheme.errorContainer,
+                        content = MaterialTheme.colorScheme.onErrorContainer,
+                        tag = "member-detail-drained",
+                    )
+                }
+            }
+
+            if (ui.revoked) {
+                StatusBanner(text = stringResource(R.string.dashboard_revoked), tag = "member-detail-revoked")
+            } else if (ui.error != null) {
+                StatusBanner(
+                    text = stringResource(R.string.dashboard_refresh_failed, ui.error),
+                    tag = "member-detail-error",
+                )
+            }
+
+            Card(modifier = Modifier.fillMaxWidth().testTag("member-detail-meta")) {
+                Column(
+                    modifier = Modifier.padding(14.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    Text(
+                        text = member.url,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                        Text(
+                            text = healthLabel(health),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = healthColor(health),
+                        )
+                        if (health.known && member.status.traefikStatus.isNotBlank()) {
+                            Text(
+                                text = stringResource(R.string.member_traefik, member.status.traefikStatus),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                        if (member.status.version.isNotBlank()) {
+                            Text(
+                                text = member.status.version,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    }
+                    // The card truncates this; up close the operator wants the
+                    // whole probe error.
+                    if (health.known && !health.healthy && health.error.isNotBlank()) {
+                        Text(
+                            text = health.error,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.error,
+                        )
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+            TrafficCard(ui = ui)
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+    }
+}
+
+/**
+ * TrafficCard renders the last-hour series. Unreachable is a normal, explained
+ * state, not an error: Front Desk may hold no admin token for this member, or
+ * the member didn't answer its stats API.
+ */
+@Composable
+private fun TrafficCard(
+    ui: MemberDetailUiState,
+    modifier: Modifier = Modifier,
+) {
+    val traffic = ui.traffic
+    Card(modifier = modifier.fillMaxWidth().testTag("member-traffic-card")) {
+        Column(
+            modifier = Modifier.padding(14.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.member_detail_traffic_title, traffic?.windowMinutes ?: 60),
+                style = MaterialTheme.typography.titleMedium,
+            )
+            when {
+                traffic == null && ui.loading ->
+                    Box(
+                        modifier = Modifier.fillMaxWidth().padding(vertical = 16.dp),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        CircularProgressIndicator(modifier = Modifier.testTag("member-traffic-loading"))
+                    }
+                traffic == null -> Unit // fetch never landed; the banner above explains why
+                !traffic.reachable ->
+                    Text(
+                        text = stringResource(R.string.member_detail_traffic_unreachable),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.testTag("member-traffic-unreachable"),
+                    )
+                traffic.points.isEmpty() ->
+                    Text(
+                        text = stringResource(R.string.member_detail_traffic_empty),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.testTag("member-traffic-empty"),
+                    )
+                else -> {
+                    Text(
+                        text =
+                            stringResource(
+                                R.string.member_detail_traffic_totals,
+                                traffic.totalRequests,
+                                traffic.totalErrors,
+                            ),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.testTag("member-traffic-totals"),
+                    )
+                    TrafficChart(points = traffic.points)
+                }
+            }
+        }
+    }
+}
+
+/**
+ * TrafficChart is a plain Canvas bar chart, one bar per 5-minute bucket oldest
+ * to newest: bar height is that bucket's requests against the window maximum,
+ * with the error subset overlaid from the baseline in the error color. No
+ * chart library by design (plan section 5.4).
+ */
+@Composable
+private fun TrafficChart(
+    points: List<TrafficPoint>,
+    modifier: Modifier = Modifier,
+) {
+    val barColor = MaterialTheme.colorScheme.primary
+    val errorColor = MaterialTheme.colorScheme.error
+    val idleColor = MaterialTheme.colorScheme.outlineVariant
+    Canvas(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .height(96.dp)
+                .testTag("member-traffic-chart"),
+    ) {
+        val max = points.maxOf { it.requests }.coerceAtLeast(1)
+        val gap = 3.dp.toPx()
+        val barWidth = (size.width - gap * (points.size - 1)) / points.size
+        val stub = 2.dp.toPx()
+        points.forEachIndexed { i, p ->
+            val x = i * (barWidth + gap)
+            if (p.requests <= 0) {
+                // Zero bucket: a faint stub so the timeline stays readable
+                // instead of leaving holes.
+                drawRect(idleColor, Offset(x, size.height - stub), Size(barWidth, stub))
+                return@forEachIndexed
+            }
+            val h = (size.height * p.requests / max).coerceAtLeast(stub)
+            drawRect(barColor, Offset(x, size.height - h), Size(barWidth, h))
+            if (p.errors > 0) {
+                // Errors are a subset of requests, so the overlay shares the
+                // scale and can never outgrow its bar.
+                val eh = (size.height * p.errors / max).coerceAtLeast(stub)
+                drawRect(errorColor, Offset(x, size.height - eh), Size(barWidth, eh))
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun MemberDetailScreenPreview() {
+    BellhopTheme {
+        MemberDetailScreen(
+            member =
+                FleetMember(
+                    id = "m1",
+                    name = "hotel-prime",
+                    url = "http://192.168.1.10:8080",
+                    status =
+                        MemberStatus(
+                            health = HealthStatus(known = true, healthy = true, latencyMs = 12),
+                            traefikStatus = "UP",
+                            version = "0.33.0",
+                        ),
+                ),
+            isPrimary = true,
+            onBack = {},
+            ui =
+                MemberDetailUiState(
+                    loading = false,
+                    traffic =
+                        MemberTraffic(
+                            memberId = "m1",
+                            reachable = true,
+                            totalRequests = 420,
+                            totalErrors = 7,
+                            points =
+                                (0 until 12).map {
+                                    TrafficPoint(
+                                        bucket = "b$it",
+                                        requests = (it * 13) % 40,
+                                        errors = if (it % 5 == 0) 2 else 0,
+                                    )
+                                },
+                        ),
+                ),
+        )
+    }
+}

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailViewModel.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailViewModel.kt
@@ -56,6 +56,10 @@ class MemberDetailViewModel(
                     if (active) {
                         while (true) {
                             refreshOnce()
+                            // A revoked (or unreadable) token can never
+                            // authenticate again; only unlinking fixes it, so
+                            // stop the radio instead of retrying forever.
+                            if (_state.value.revoked) break
                             delay(pollIntervalMs)
                         }
                     }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailViewModel.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailViewModel.kt
@@ -1,0 +1,104 @@
+package com.hugalafutro.bellhop.ui.member
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.hugalafutro.bellhop.data.FetchResult
+import com.hugalafutro.bellhop.data.FrontDeskClient
+import com.hugalafutro.bellhop.data.LinkStore
+import com.hugalafutro.bellhop.data.MemberTraffic
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * MemberDetailUiState is what the member-detail traffic card renders. A failed
+ * refresh keeps the last good series on screen (stale beats blank on a phone)
+ * and raises [error]; [revoked] means the device token itself no longer
+ * authenticates, same remedy as the dashboard's flag: unlink and re-pair.
+ */
+data class MemberDetailUiState(
+    val loading: Boolean = true,
+    val traffic: MemberTraffic? = null,
+    val error: String? = null,
+    val revoked: Boolean = false,
+)
+
+/**
+ * MemberDetailViewModel keeps one member's traffic series fresh while its
+ * detail screen is on screen. The series is hourly 5-minute buckets, so a slow
+ * poll is enough; no SSE here (traffic moves every request, the member's
+ * health/badges on this screen ride the dashboard's live state instead).
+ * The loop is gated on active collectors, so a backgrounded app goes quiet.
+ */
+class MemberDetailViewModel(
+    private val client: FrontDeskClient,
+    private val linkStore: LinkStore,
+    private val fdUrl: String,
+    private val memberId: String,
+    private val pollIntervalMs: Long = POLL_INTERVAL_MS,
+) : ViewModel() {
+    private val _state = MutableStateFlow(MemberDetailUiState())
+    val state: StateFlow<MemberDetailUiState> = _state.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            _state.subscriptionCount
+                .map { it > 0 }
+                .distinctUntilChanged()
+                .collectLatest { active ->
+                    if (active) {
+                        while (true) {
+                            refreshOnce()
+                            delay(pollIntervalMs)
+                        }
+                    }
+                }
+        }
+    }
+
+    /** refreshOnce performs one traffic fetch and folds it into the state. */
+    suspend fun refreshOnce() {
+        val token = linkStore.token()
+        if (token == null) {
+            // Still linked but the token can't be read back (e.g. the Keystore
+            // key is gone): no request can ever succeed, same operator remedy
+            // as a remote revoke, so surface it through the same flag.
+            _state.update { it.copy(loading = false, revoked = true) }
+            return
+        }
+        when (val result = client.memberTraffic(fdUrl, token, memberId)) {
+            is FetchResult.Success ->
+                _state.update {
+                    it.copy(loading = false, traffic = result.data, error = null, revoked = false)
+                }
+            FetchResult.Unauthorized ->
+                _state.update { it.copy(loading = false, revoked = true) }
+            is FetchResult.Failure ->
+                _state.update { it.copy(loading = false, error = result.message) }
+        }
+    }
+
+    class Factory(
+        private val client: FrontDeskClient,
+        private val linkStore: LinkStore,
+        private val fdUrl: String,
+        private val memberId: String,
+    ) : ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>): T =
+            MemberDetailViewModel(client, linkStore, fdUrl, memberId) as T
+    }
+
+    companion object {
+        // The chart's buckets are 5 minutes wide; a minute-ish poll keeps the
+        // current bucket moving without hammering the member's stats API.
+        const val POLL_INTERVAL_MS = 60_000L
+    }
+}

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailViewModel.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailViewModel.kt
@@ -54,11 +54,14 @@ class MemberDetailViewModel(
                 .distinctUntilChanged()
                 .collectLatest { active ->
                     if (active) {
-                        while (true) {
+                        // A revoked (or unreadable) token can never
+                        // authenticate again; only unlinking fixes it, so stop
+                        // the radio instead of retrying forever. The entry
+                        // check keeps a collector restart (backgrounding and
+                        // reopening the screen) from firing one more doomed
+                        // request per restart.
+                        while (!_state.value.revoked) {
                             refreshOnce()
-                            // A revoked (or unreadable) token can never
-                            // authenticate again; only unlinking fixes it, so
-                            // stop the radio instead of retrying forever.
                             if (_state.value.revoked) break
                             delay(pollIntervalMs)
                         }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -27,6 +27,13 @@
     <string name="member_traefik">Traefik %1$s</string>
     <string name="member_state_drained">Drained</string>
     <string name="member_primary">Primary</string>
+    <!-- Member detail -->
+    <string name="member_detail_back">Back</string>
+    <string name="member_detail_traffic_title">Traffic · last %1$d min</string>
+    <string name="member_detail_traffic_totals">%1$d requests · %2$d errors</string>
+    <string name="member_detail_traffic_unreachable">Traffic isn\'t available. Front Desk may hold no admin token for this member, or the member didn\'t answer.</string>
+    <string name="member_detail_traffic_empty">No requests in this window.</string>
+
     <string name="dashboard_unlink">Unlink</string>
     <string name="dashboard_unlink_confirm_title">Unlink this device?</string>
     <string name="dashboard_unlink_confirm_body">This device will stop monitoring %1$s and its token will be revoked. You can pair again anytime with a new code.</string>

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/FrontDeskClientTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/FrontDeskClientTest.kt
@@ -158,6 +158,63 @@ class FrontDeskClientTest {
         }
 
     @Test
+    fun memberTrafficParsesSeries() =
+        runBlocking {
+            server.enqueue(
+                MockResponse().setBody(
+                    """{"member_id":"m1","reachable":true,"window_minutes":60,"total_requests":42,""" +
+                        """"total_errors":3,"points":[{"bucket":"2026-07-11T10:00:00Z","requests":40,"errors":3},""" +
+                        """{"bucket":"2026-07-11T10:05:00Z","requests":2,"errors":0}]}""",
+                ),
+            )
+
+            val result = client.memberTraffic(server.url("/").toString(), "tok-1", "m1")
+
+            assertTrue(result is FetchResult.Success)
+            result as FetchResult.Success
+            assertTrue(result.data.reachable)
+            assertEquals(42, result.data.totalRequests)
+            assertEquals(3, result.data.totalErrors)
+            assertEquals(2, result.data.points.size)
+            assertEquals(40, result.data.points[0].requests)
+
+            val request = server.takeRequest()
+            assertEquals("GET", request.method)
+            assertEquals("/api/members/m1/traffic", request.path)
+            assertEquals("Bearer tok-1", request.getHeader("Authorization"))
+        }
+
+    @Test
+    fun memberTrafficUnreachableIsStillSuccess() =
+        runBlocking {
+            // No stored admin token on the FD side answers 200 with
+            // reachable=false; that's a renderable state, not a Failure.
+            server.enqueue(
+                MockResponse().setBody(
+                    """{"member_id":"m1","reachable":false,"window_minutes":60,"total_requests":0,""" +
+                        """"total_errors":0,"points":[]}""",
+                ),
+            )
+            val result = client.memberTraffic(server.url("/").toString(), "tok-1", "m1")
+            assertTrue(result is FetchResult.Success)
+            result as FetchResult.Success
+            assertFalse(result.data.reachable)
+            assertTrue(result.data.points.isEmpty())
+        }
+
+    @Test
+    fun memberTrafficMapsUnauthorizedToItsOwnArm() =
+        runBlocking {
+            server.enqueue(
+                MockResponse().setResponseCode(401).setBody(
+                    """{"error":{"code":"unauthorized","message":"bad token"}}""",
+                ),
+            )
+            val result = client.memberTraffic(server.url("/").toString(), "dead", "m1")
+            assertEquals(FetchResult.Unauthorized, result)
+        }
+
+    @Test
     fun autoSyncParsesPrimary() =
         runBlocking {
             server.enqueue(MockResponse().setBody("""{"enabled":true,"primary_id":"m2"}"""))

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreenTest.kt
@@ -127,6 +127,24 @@ class DashboardScreenTest {
     }
 
     @Test
+    fun clickingMemberCardFiresCallbackWithId() {
+        var clicked: String? = null
+        composeTestRule.setContent {
+            BellhopTheme {
+                DashboardScreen(
+                    link = link,
+                    onUnlink = {},
+                    unlinking = false,
+                    ui = DashboardUiState(loading = false, members = members),
+                    onMemberClick = { clicked = it },
+                )
+            }
+        }
+        composeTestRule.onNodeWithTag("member-card-beta").performClick()
+        assertTrue(clicked == "m2")
+    }
+
+    @Test
     fun firstLoadShowsSpinnerThenEmptyStateWithoutMembers() {
         composeTestRule.setContent {
             BellhopTheme {

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModelTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModelTest.kt
@@ -13,7 +13,6 @@ import com.hugalafutro.bellhop.data.MemberStatus
 import com.hugalafutro.bellhop.data.PairedDevice
 import com.hugalafutro.bellhop.data.SseMessage
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.awaitCancellation
@@ -272,25 +271,32 @@ class DashboardViewModelTest {
         runBlocking {
             // Revocation is terminal (only unlink fixes it, and relinking
             // rebuilds the ViewModel), so stream/poll nudges after it must not
-            // keep hitting Front Desk with a token that can never work.
-            val events = MutableSharedFlow<SseMessage>(extraBufferCapacity = 8)
-            val client = FakeFleetClient(FetchResult.Unauthorized, sseFlow = events)
-            val vm = DashboardViewModel(client, linkedStore(), "http://fd:1")
+            // keep hitting Front Desk with a token that can never work. The
+            // outer timeout turns any future deadlock in this loop machinery
+            // into a fast failure instead of a hung CI job.
+            withTimeout(30_000) {
+                val events = MutableSharedFlow<SseMessage>(extraBufferCapacity = 8)
+                val client = FakeFleetClient(FetchResult.Unauthorized, sseFlow = events)
+                val vm = DashboardViewModel(client, linkedStore(), "http://fd:1")
 
-            // UNDISPATCHED so this keep-alive collector subscribes before the
-            // transient first{} collectors below; otherwise the subscription
-            // count can bounce through zero between them, restarting the
-            // collector-gated loops, whose initial refresh is deliberately
-            // ungated and would bump the counter after `calls` was sampled.
-            val job = launch(start = CoroutineStart.UNDISPATCHED) { vm.state.collect {} }
-            withTimeout(5_000) { vm.state.first { it.revoked } }
-            val calls = client.memberCalls.get()
+                val job = launch { vm.state.collect {} }
+                withTimeout(5_000) { vm.state.first { it.revoked } }
+                val calls = client.memberCalls.get()
 
-            withTimeout(5_000) { events.subscriptionCount.first { it > 0 } }
-            events.emit(SseMessage.Event(FleetEvent(type = "health.down")))
-            delay(200)
-            assertEquals(calls, client.memberCalls.get())
-            job.cancel()
+                withTimeout(5_000) { events.subscriptionCount.first { it > 0 } }
+                events.emit(SseMessage.Event(FleetEvent(type = "health.down")))
+                delay(200)
+                assertEquals(calls, client.memberCalls.get())
+                job.cancel()
+
+                // A collector restart with the flag already set (backgrounding
+                // and reopening the app) must not fire one more doomed
+                // request: runRefreshes' initial refresh has to be gated too.
+                val restarted = launch { vm.state.collect {} }
+                delay(200)
+                assertEquals(calls, client.memberCalls.get())
+                restarted.cancel()
+            }
         }
 
     @Test

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModelTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModelTest.kt
@@ -13,6 +13,7 @@ import com.hugalafutro.bellhop.data.MemberStatus
 import com.hugalafutro.bellhop.data.PairedDevice
 import com.hugalafutro.bellhop.data.SseMessage
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.awaitCancellation
@@ -276,7 +277,12 @@ class DashboardViewModelTest {
             val client = FakeFleetClient(FetchResult.Unauthorized, sseFlow = events)
             val vm = DashboardViewModel(client, linkedStore(), "http://fd:1")
 
-            val job = launch { vm.state.collect {} }
+            // UNDISPATCHED so this keep-alive collector subscribes before the
+            // transient first{} collectors below; otherwise the subscription
+            // count can bounce through zero between them, restarting the
+            // collector-gated loops, whose initial refresh is deliberately
+            // ungated and would bump the counter after `calls` was sampled.
+            val job = launch(start = CoroutineStart.UNDISPATCHED) { vm.state.collect {} }
             withTimeout(5_000) { vm.state.first { it.revoked } }
             val calls = client.memberCalls.get()
 

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModelTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModelTest.kt
@@ -267,6 +267,27 @@ class DashboardViewModelTest {
         }
 
     @Test
+    fun revokedTokenSwallowsFurtherRefreshNudges() =
+        runBlocking {
+            // Revocation is terminal (only unlink fixes it, and relinking
+            // rebuilds the ViewModel), so stream/poll nudges after it must not
+            // keep hitting Front Desk with a token that can never work.
+            val events = MutableSharedFlow<SseMessage>(extraBufferCapacity = 8)
+            val client = FakeFleetClient(FetchResult.Unauthorized, sseFlow = events)
+            val vm = DashboardViewModel(client, linkedStore(), "http://fd:1")
+
+            val job = launch { vm.state.collect {} }
+            withTimeout(5_000) { vm.state.first { it.revoked } }
+            val calls = client.memberCalls.get()
+
+            withTimeout(5_000) { events.subscriptionCount.first { it > 0 } }
+            events.emit(SseMessage.Event(FleetEvent(type = "health.down")))
+            delay(200)
+            assertEquals(calls, client.memberCalls.get())
+            job.cancel()
+        }
+
+    @Test
     fun sseUnauthorizedFlagsRevoked() =
         runBlocking {
             // A 401 on the stream means the device token is dead; surface it the

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreenTest.kt
@@ -1,0 +1,184 @@
+package com.hugalafutro.bellhop.ui.member
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import com.hugalafutro.bellhop.data.FleetMember
+import com.hugalafutro.bellhop.data.HealthStatus
+import com.hugalafutro.bellhop.data.MemberStatus
+import com.hugalafutro.bellhop.data.MemberTraffic
+import com.hugalafutro.bellhop.data.TrafficPoint
+import com.hugalafutro.bellhop.ui.theme.BellhopTheme
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Member detail: identity header, traffic states, and the back affordance.
+ * Asserts on test tags, not display text, so English copy never breaks tests.
+ */
+@RunWith(RobolectricTestRunner::class)
+class MemberDetailScreenTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val member =
+        FleetMember(
+            id = "m1",
+            name = "alpha",
+            url = "http://a:8080",
+            status =
+                MemberStatus(
+                    health = HealthStatus(known = true, healthy = true, latencyMs = 3),
+                    traefikStatus = "UP",
+                    version = "1.0.0",
+                ),
+        )
+
+    private val reachableTraffic =
+        MemberTraffic(
+            memberId = "m1",
+            reachable = true,
+            totalRequests = 12,
+            totalErrors = 2,
+            points = listOf(TrafficPoint(bucket = "b0", requests = 12, errors = 2)),
+        )
+
+    @Test
+    fun rendersHeaderMetadataAndChart() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                MemberDetailScreen(
+                    member = member,
+                    isPrimary = true,
+                    onBack = {},
+                    ui = MemberDetailUiState(loading = false, traffic = reachableTraffic),
+                )
+            }
+        }
+        composeTestRule.onNodeWithTag("member-detail-title").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("member-detail-primary", useUnmergedTree = true).assertIsDisplayed()
+        composeTestRule.onNodeWithTag("member-detail-meta").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("member-traffic-totals").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("member-traffic-chart").assertIsDisplayed()
+    }
+
+    @Test
+    fun drainedMemberShowsDrainedPill() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                MemberDetailScreen(
+                    member = member.copy(state = "drained"),
+                    isPrimary = false,
+                    onBack = {},
+                    ui = MemberDetailUiState(loading = false, traffic = reachableTraffic),
+                )
+            }
+        }
+        composeTestRule.onNodeWithTag("member-detail-drained", useUnmergedTree = true).assertIsDisplayed()
+    }
+
+    @Test
+    fun backFiresCallback() {
+        var backs = 0
+        composeTestRule.setContent {
+            BellhopTheme {
+                MemberDetailScreen(
+                    member = member,
+                    isPrimary = false,
+                    onBack = { backs++ },
+                    ui = MemberDetailUiState(loading = false, traffic = reachableTraffic),
+                )
+            }
+        }
+        composeTestRule.onNodeWithTag("member-detail-back").performClick()
+        assertTrue(backs == 1)
+    }
+
+    @Test
+    fun firstLoadShowsSpinnerInsideTrafficCard() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                MemberDetailScreen(member = member, isPrimary = false, onBack = {})
+            }
+        }
+        composeTestRule.onNodeWithTag("member-traffic-loading").assertIsDisplayed()
+    }
+
+    @Test
+    fun unreachableTrafficShowsExplainerNotError() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                MemberDetailScreen(
+                    member = member,
+                    isPrimary = false,
+                    onBack = {},
+                    ui =
+                        MemberDetailUiState(
+                            loading = false,
+                            traffic = MemberTraffic(memberId = "m1", reachable = false),
+                        ),
+                )
+            }
+        }
+        composeTestRule.onNodeWithTag("member-traffic-unreachable").assertIsDisplayed()
+    }
+
+    @Test
+    fun reachableButIdleShowsEmptyState() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                MemberDetailScreen(
+                    member = member,
+                    isPrimary = false,
+                    onBack = {},
+                    ui =
+                        MemberDetailUiState(
+                            loading = false,
+                            traffic = MemberTraffic(memberId = "m1", reachable = true),
+                        ),
+                )
+            }
+        }
+        composeTestRule.onNodeWithTag("member-traffic-empty").assertIsDisplayed()
+    }
+
+    @Test
+    fun refreshErrorShowsBannerAndKeepsStaleChart() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                MemberDetailScreen(
+                    member = member,
+                    isPrimary = false,
+                    onBack = {},
+                    ui =
+                        MemberDetailUiState(
+                            loading = false,
+                            traffic = reachableTraffic,
+                            error = "boom",
+                        ),
+                )
+            }
+        }
+        composeTestRule.onNodeWithTag("member-detail-error").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("member-traffic-chart").assertIsDisplayed()
+    }
+
+    @Test
+    fun revokedTokenShowsRevokedBanner() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                MemberDetailScreen(
+                    member = member,
+                    isPrimary = false,
+                    onBack = {},
+                    ui = MemberDetailUiState(loading = false, revoked = true),
+                )
+            }
+        }
+        composeTestRule.onNodeWithTag("member-detail-revoked").assertIsDisplayed()
+    }
+}

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailViewModelTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailViewModelTest.kt
@@ -1,0 +1,170 @@
+package com.hugalafutro.bellhop.ui.member
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import com.hugalafutro.bellhop.data.FakeCipher
+import com.hugalafutro.bellhop.data.FetchResult
+import com.hugalafutro.bellhop.data.FrontDeskClient
+import com.hugalafutro.bellhop.data.LinkStore
+import com.hugalafutro.bellhop.data.MemberTraffic
+import com.hugalafutro.bellhop.data.PairedDevice
+import com.hugalafutro.bellhop.data.TrafficPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.withTimeout
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.File
+import java.util.concurrent.atomic.AtomicInteger
+
+// FakeTrafficClient stubs the one read the detail ViewModel makes.
+private class FakeTrafficClient(
+    var trafficResult: FetchResult<MemberTraffic>,
+) : FrontDeskClient() {
+    val trafficCalls = AtomicInteger(0)
+    var lastToken: String? = null
+    var lastMemberId: String? = null
+
+    override suspend fun memberTraffic(
+        fdUrl: String,
+        token: String,
+        memberId: String,
+    ): FetchResult<MemberTraffic> {
+        trafficCalls.incrementAndGet()
+        lastToken = token
+        lastMemberId = memberId
+        return trafficResult
+    }
+}
+
+@RunWith(RobolectricTestRunner::class)
+class MemberDetailViewModelTest {
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    // viewModelScope launches on Main; run it inline in tests.
+    @Before
+    fun setUpMain() {
+        Dispatchers.setMain(Dispatchers.Unconfined)
+    }
+
+    @After
+    fun tearDownMain() {
+        Dispatchers.resetMain()
+    }
+
+    private fun newLinkStore(): LinkStore {
+        val scope = CoroutineScope(Dispatchers.IO + Job())
+        val ds =
+            PreferenceDataStoreFactory.create(scope = scope) {
+                File(tmp.newFolder(), "link.preferences_pb")
+            }
+        return LinkStore(ds, FakeCipher)
+    }
+
+    private suspend fun linkedStore(): LinkStore =
+        newLinkStore().also {
+            it.save(
+                fdUrl = "http://fd:1",
+                fdName = "FD",
+                token = "tok-1",
+                device = PairedDevice(id = "d1", label = "Pixel", role = "monitor"),
+            )
+        }
+
+    private val traffic =
+        MemberTraffic(
+            memberId = "m1",
+            reachable = true,
+            totalRequests = 10,
+            totalErrors = 1,
+            points = listOf(TrafficPoint(bucket = "b0", requests = 10, errors = 1)),
+        )
+
+    @Test
+    fun refreshPopulatesTrafficWithStoredToken() =
+        runBlocking {
+            val client = FakeTrafficClient(FetchResult.Success(traffic))
+            val vm = MemberDetailViewModel(client, linkedStore(), "http://fd:1", "m1")
+
+            vm.refreshOnce()
+
+            val s = vm.state.value
+            assertFalse(s.loading)
+            assertEquals(traffic, s.traffic)
+            assertNull(s.error)
+            assertFalse(s.revoked)
+            assertEquals("tok-1", client.lastToken)
+            assertEquals("m1", client.lastMemberId)
+        }
+
+    @Test
+    fun failedRefreshKeepsStaleTrafficAndRecovers() =
+        runBlocking {
+            val client = FakeTrafficClient(FetchResult.Success(traffic))
+            val vm = MemberDetailViewModel(client, linkedStore(), "http://fd:1", "m1")
+            vm.refreshOnce()
+
+            client.trafficResult = FetchResult.Failure("boom")
+            vm.refreshOnce()
+            assertEquals(traffic, vm.state.value.traffic)
+            assertEquals("boom", vm.state.value.error)
+
+            client.trafficResult = FetchResult.Success(traffic)
+            vm.refreshOnce()
+            assertNull(vm.state.value.error)
+        }
+
+    @Test
+    fun unauthorizedFlagsRevoked() =
+        runBlocking {
+            val vm =
+                MemberDetailViewModel(
+                    FakeTrafficClient(FetchResult.Unauthorized),
+                    linkedStore(),
+                    "http://fd:1",
+                    "m1",
+                )
+            vm.refreshOnce()
+            assertTrue(vm.state.value.revoked)
+            assertFalse(vm.state.value.loading)
+        }
+
+    @Test
+    fun unreadableTokenFlagsRevokedWithoutCalling() =
+        runBlocking {
+            // Linked in name only (e.g. Keystore key gone): no request can
+            // succeed, so surface the same flag a remote revoke raises.
+            val client = FakeTrafficClient(FetchResult.Success(traffic))
+            val vm = MemberDetailViewModel(client, newLinkStore(), "http://fd:1", "m1")
+            vm.refreshOnce()
+            assertTrue(vm.state.value.revoked)
+            assertNull(client.lastToken)
+            assertEquals(0, client.trafficCalls.get())
+        }
+
+    @Test
+    fun subscribingStartsThePoll() =
+        runBlocking {
+            // The poll loop is gated on collectors; the first collector must
+            // trigger a refresh on its own, with no manual refreshOnce call.
+            val client = FakeTrafficClient(FetchResult.Success(traffic))
+            val vm = MemberDetailViewModel(client, linkedStore(), "http://fd:1", "m1")
+
+            val s = withTimeout(5_000) { vm.state.first { !it.loading } }
+            assertEquals(traffic, s.traffic)
+        }
+}

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailViewModelTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailViewModelTest.kt
@@ -9,6 +9,7 @@ import com.hugalafutro.bellhop.data.MemberTraffic
 import com.hugalafutro.bellhop.data.PairedDevice
 import com.hugalafutro.bellhop.data.TrafficPoint
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -173,7 +174,12 @@ class MemberDetailViewModelTest {
                     pollIntervalMs = 10,
                 )
 
-            val job = launch { vm.state.collect {} }
+            // UNDISPATCHED so this keep-alive collector subscribes before the
+            // transient first{} collector below; a subscription count bouncing
+            // through zero would restart the poll loop, whose initial refresh
+            // runs before the revoked gate and would bump the counter after
+            // `calls` was sampled.
+            val job = launch(start = CoroutineStart.UNDISPATCHED) { vm.state.collect {} }
             withTimeout(5_000) { vm.state.first { it.revoked } }
             val calls = client.trafficCalls.get()
             delay(200)

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailViewModelTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailViewModelTest.kt
@@ -11,7 +11,9 @@ import com.hugalafutro.bellhop.data.TrafficPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
@@ -154,6 +156,29 @@ class MemberDetailViewModelTest {
             assertTrue(vm.state.value.revoked)
             assertNull(client.lastToken)
             assertEquals(0, client.trafficCalls.get())
+        }
+
+    @Test
+    fun revokedTokenStopsThePoll() =
+        runBlocking {
+            // Revocation is terminal (only unlink fixes it), so the loop must
+            // not keep hitting Front Desk with a token that can never work.
+            val client = FakeTrafficClient(FetchResult.Unauthorized)
+            val vm =
+                MemberDetailViewModel(
+                    client,
+                    linkedStore(),
+                    "http://fd:1",
+                    "m1",
+                    pollIntervalMs = 10,
+                )
+
+            val job = launch { vm.state.collect {} }
+            withTimeout(5_000) { vm.state.first { it.revoked } }
+            val calls = client.trafficCalls.get()
+            delay(200)
+            assertEquals(calls, client.trafficCalls.get())
+            job.cancel()
         }
 
     @Test

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailViewModelTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailViewModelTest.kt
@@ -9,7 +9,6 @@ import com.hugalafutro.bellhop.data.MemberTraffic
 import com.hugalafutro.bellhop.data.PairedDevice
 import com.hugalafutro.bellhop.data.TrafficPoint
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -164,27 +163,34 @@ class MemberDetailViewModelTest {
         runBlocking {
             // Revocation is terminal (only unlink fixes it), so the loop must
             // not keep hitting Front Desk with a token that can never work.
-            val client = FakeTrafficClient(FetchResult.Unauthorized)
-            val vm =
-                MemberDetailViewModel(
-                    client,
-                    linkedStore(),
-                    "http://fd:1",
-                    "m1",
-                    pollIntervalMs = 10,
-                )
+            // The outer timeout turns any future deadlock in this loop
+            // machinery into a fast failure instead of a hung CI job.
+            withTimeout(30_000) {
+                val client = FakeTrafficClient(FetchResult.Unauthorized)
+                val vm =
+                    MemberDetailViewModel(
+                        client,
+                        linkedStore(),
+                        "http://fd:1",
+                        "m1",
+                        pollIntervalMs = 10,
+                    )
 
-            // UNDISPATCHED so this keep-alive collector subscribes before the
-            // transient first{} collector below; a subscription count bouncing
-            // through zero would restart the poll loop, whose initial refresh
-            // runs before the revoked gate and would bump the counter after
-            // `calls` was sampled.
-            val job = launch(start = CoroutineStart.UNDISPATCHED) { vm.state.collect {} }
-            withTimeout(5_000) { vm.state.first { it.revoked } }
-            val calls = client.trafficCalls.get()
-            delay(200)
-            assertEquals(calls, client.trafficCalls.get())
-            job.cancel()
+                val job = launch { vm.state.collect {} }
+                withTimeout(5_000) { vm.state.first { it.revoked } }
+                val calls = client.trafficCalls.get()
+                delay(200)
+                assertEquals(calls, client.trafficCalls.get())
+                job.cancel()
+
+                // A collector restart with the flag already set (backgrounding
+                // and reopening the screen) must not fire one more doomed
+                // request: the loop's entry check has to catch it.
+                val restarted = launch { vm.state.collect {} }
+                delay(200)
+                assertEquals(calls, client.trafficCalls.get())
+                restarted.cancel()
+            }
         }
 
     @Test

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ androidx-compose-ui = { group = "androidx.compose.ui", name = "ui" }
 androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-compose-material-icons-core = { group = "androidx.compose.material", name = "material-icons-core" }
 androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }


### PR DESCRIPTION
## What

The next Phase A2 slice from `plans/android-companion-app.md`: tapping a dashboard member card opens a read-only **member detail screen** with the member's last hour of traffic.

- **Detail screen** (`ui/member/MemberDetailScreen.kt`): identity header (health dot, name, Primary/Drained pills, back arrow), metadata card (URL, health with latency, Traefik view, version, and the full probe error the dashboard card truncates), and a traffic card.
- **Traffic chart**: plain Compose Canvas bar chart per plan section 5.4, no chart library. One bar per 5-minute bucket, error subset overlaid from the baseline in the error color, faint stubs keep zero buckets readable. `reachable=false` renders an explanatory empty state (mirroring the FD Traffic tab), not an error.
- **Data**: new `MemberTraffic`/`TrafficPoint` wire models + `FrontDeskClient.memberTraffic()` for `GET /api/members/{id}/traffic`. That route is already in Front Desk's monitor read tier, so **zero backend changes**.
- **ViewModel** (`MemberDetailViewModel`): collector-gated 60s poll with the dashboard's semantics: stale series stays visible under an error banner; a 401 or unreadable Keystore token raises the revoked flag.
- **Navigation**: `rememberSaveable` selection in `MainActivity` + `BackHandler`, no nav library. The detail's member row rides the dashboard's live SSE/poll state, so badges keep updating while open, and a member removed from the fleet auto-pops back to the dashboard.
- **Dedupe**: `StatusBanner`, `Pill`, and the health color/label helpers hoisted from `DashboardScreen` into shared `ui/common/FleetUi.kt`.

## Testing

- `make android-test` green: ktlint clean, 64 unit tests (17 new: client parsing/401/unreachable, ViewModel state transitions, screen states via test tags, dashboard card click).
- Live end-to-end on the emulator against a mock Front Desk: pair, open a healthy member (totals line, chart, Primary pill asserted), back arrow pops, open a drained/down member (Drained pill, full probe error, unreachable explainer), hardware back pops.

| Reachable | Unreachable |
| --- | --- |
| totals + bar chart with error overlay | explanatory empty state |

🤖 Generated with [Claude Code](https://claude.com/claude-code)