### PR TITLE
feat(bellhop): Alerts screen, event-filter polish, and member/dashboard redesign

### DIFF
--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
@@ -19,6 +19,8 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.hugalafutro.bellhop.data.FrontDeskClient
 import com.hugalafutro.bellhop.data.LinkState
 import com.hugalafutro.bellhop.data.LinkStore
+import com.hugalafutro.bellhop.ui.alerts.AlertsScreen
+import com.hugalafutro.bellhop.ui.alerts.AlertsViewModel
 import com.hugalafutro.bellhop.ui.dashboard.DashboardScreen
 import com.hugalafutro.bellhop.ui.dashboard.DashboardViewModel
 import com.hugalafutro.bellhop.ui.events.EventsScreen
@@ -186,6 +188,10 @@ fun BellhopApp() {
             var showEvents by rememberSaveable(state.fdUrl, state.deviceId) {
                 mutableStateOf(false)
             }
+            // Whether the alerts screen is open. Same saveable/keying rationale.
+            var showAlerts by rememberSaveable(state.fdUrl, state.deviceId) {
+                mutableStateOf(false)
+            }
             val selected = ui.members.find { it.id == selectedMemberId }
             // The member left the fleet while its detail was open: drop the
             // selection (once the list has actually loaded) so the detail
@@ -215,6 +221,16 @@ fun BellhopApp() {
                     onRange = eventsVm::setRange,
                     onLoadMore = eventsVm::loadMore,
                 )
+            } else if (showAlerts) {
+                BackHandler { showAlerts = false }
+                // Keyed like the dashboard VM so a relink gets a fresh status.
+                val alertsVm: AlertsViewModel =
+                    viewModel(
+                        key = "alerts-${state.fdUrl}|${state.deviceId}",
+                        factory = AlertsViewModel.Factory(client, linkStore, state.fdUrl),
+                    )
+                val alertsUi by alertsVm.state.collectAsStateWithLifecycle()
+                AlertsScreen(onBack = { showAlerts = false }, ui = alertsUi)
             } else if (selected != null) {
                 BackHandler { selectedMemberId = null }
                 // Keyed like the dashboard VM, plus the member id, so flipping
@@ -242,6 +258,8 @@ fun BellhopApp() {
                     onForceUnlink = { forceUnlink() },
                     onMemberClick = { selectedMemberId = it },
                     onEventsClick = { showEvents = true },
+                    onAlertsClick = { showAlerts = true },
+                    onVisibleMembers = dashVm::setVisibleMembers,
                 )
             }
         }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/FleetModels.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/FleetModels.kt
@@ -18,6 +18,12 @@ data class FleetMember(
     val name: String = "",
     val url: String = "",
     val state: String = "active",
+    @SerialName("has_token") val hasToken: Boolean = false,
+    @SerialName("created_at") val createdAt: String = "",
+    // Set only on a non-primary member Front Desk has actually synced; empty
+    // otherwise. The detail screen surfaces both (when and why config was pushed).
+    @SerialName("last_config_sync_at") val lastConfigSyncAt: String = "",
+    @SerialName("last_config_sync_reason") val lastConfigSyncReason: String = "",
     val status: MemberStatus = MemberStatus(),
 ) {
     val drained: Boolean get() = state == "drained"
@@ -29,6 +35,10 @@ data class MemberStatus(
     val health: HealthStatus = HealthStatus(),
     @SerialName("traefik_status") val traefikStatus: String = "",
     val version: String = "",
+    // The auto-syncer's "still in sync with the primary" heartbeat: advances
+    // ~every tick while the member is reachable, distinct from lastConfigSyncAt
+    // (which only moves on a real config write). Empty until first verified.
+    @SerialName("auto_sync_verified_at") val autoSyncVerifiedAt: String = "",
 )
 
 /**
@@ -141,4 +151,36 @@ data class FleetEvent(
     val source: String = "",
     val message: String = "",
     val timestamp: String = "",
+)
+
+/**
+ * AlertStatus is the reachability of Front Desk's outbound notifier (GET
+ * /api/alert/status), mirroring the backend's alert.Status. [configured] is
+ * false when no apprise-api URL is set (nothing can deliver); when configured,
+ * [reachable] then [healthy] narrow down where a green pill turns amber or red,
+ * and [detail] carries the human reason ("no notification target configured",
+ * "master key rotated?") so Bellhop shows a cause, not just a colour.
+ */
+@Serializable
+data class AlertStatus(
+    val configured: Boolean = false,
+    val reachable: Boolean = false,
+    val healthy: Boolean = false,
+    val detail: String = "",
+)
+
+/**
+ * AlertEventDef is one row of Front Desk's alertable-event catalog (GET
+ * /api/alert/events), mirroring alert.EventDef. Bellhop renders it read-only:
+ * which events are actually enabled lives in Front Desk's admin settings (not
+ * readable by a device token), so [defaultOn] is shown as the first-run default,
+ * not the current selection. [severity] is the display dot; [category] groups
+ * the list.
+ */
+@Serializable
+data class AlertEventDef(
+    val type: String = "",
+    val category: String = "",
+    val severity: String = "",
+    val defaultOn: Boolean = false,
 )

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/FrontDeskClient.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/FrontDeskClient.kt
@@ -188,6 +188,26 @@ open class FrontDeskClient(
     ): FetchResult<AutoSyncConfig> = get(fdUrl, "/api/fleet/autosync", token)
 
     /**
+     * alertStatus reports whether Front Desk's outbound notifier is reachable
+     * and delivering. Monitor tier, like [members]; the Alerts screen renders it
+     * as a delivery-health pill.
+     */
+    open suspend fun alertStatus(
+        fdUrl: String,
+        token: String,
+    ): FetchResult<AlertStatus> = get(fdUrl, "/api/alert/status", token)
+
+    /**
+     * alertCatalog fetches Front Desk's alertable-event catalog (what it can
+     * notify on, grouped by category). Monitor tier; the enabled subset lives in
+     * admin settings and is not readable here, so the screen shows this read-only.
+     */
+    open suspend fun alertCatalog(
+        fdUrl: String,
+        token: String,
+    ): FetchResult<List<AlertEventDef>> = get(fdUrl, "/api/alert/events", token)
+
+    /**
      * streamEvents subscribes to GET {fdUrl}/api/sse and emits each frame as an
      * [SseMessage]. Comment heartbeats are swallowed by the SSE parser, so only
      * real events surface. The flow completes on disconnect; a 401 first emits

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/alerts/AlertsScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/alerts/AlertsScreen.kt
@@ -1,0 +1,283 @@
+package com.hugalafutro.bellhop.ui.alerts
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.hugalafutro.bellhop.R
+import com.hugalafutro.bellhop.data.AlertEventDef
+import com.hugalafutro.bellhop.data.AlertStatus
+import com.hugalafutro.bellhop.ui.common.Pill
+import com.hugalafutro.bellhop.ui.common.StatusBanner
+import com.hugalafutro.bellhop.ui.common.severityColors
+import com.hugalafutro.bellhop.ui.theme.BellhopTheme
+
+/**
+ * AlertsScreen renders Front Desk's outbound-alert subsystem, read-only: a
+ * delivery-health pill (is the apprise-api reachable and delivering?) and the
+ * catalog of events Front Desk can notify on, grouped by category with a
+ * severity dot. Which events are actually enabled lives in Front Desk's admin
+ * settings, which a device token cannot read, so the catalog is a reference, not
+ * a set of live toggles — the footer note says so. State comes from
+ * [AlertsViewModel].
+ */
+@Composable
+fun AlertsScreen(
+    onBack: () -> Unit,
+    ui: AlertsUiState = AlertsUiState(),
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(modifier = modifier.fillMaxSize()) { innerPadding ->
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding)
+                    .padding(horizontal = 16.dp),
+        ) {
+            Spacer(modifier = Modifier.height(8.dp))
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
+            ) {
+                IconButton(onClick = onBack, modifier = Modifier.testTag("alerts-back")) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = stringResource(R.string.alerts_back),
+                    )
+                }
+                Text(
+                    text = stringResource(R.string.alerts_title),
+                    style = MaterialTheme.typography.titleLarge,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.weight(1f).testTag("alerts-title"),
+                )
+            }
+
+            if (ui.revoked) {
+                StatusBanner(text = stringResource(R.string.dashboard_revoked), tag = "alerts-revoked")
+            } else if (ui.error != null) {
+                StatusBanner(
+                    text = stringResource(R.string.dashboard_refresh_failed, ui.error),
+                    tag = "alerts-error",
+                )
+            }
+
+            if (ui.loading) {
+                Box(
+                    modifier = Modifier.fillMaxWidth().weight(1f),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator(modifier = Modifier.testTag("alerts-loading"))
+                }
+            } else {
+                LazyColumn(
+                    modifier = Modifier.weight(1f).testTag("alerts-list"),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                    contentPadding = PaddingValues(bottom = 24.dp),
+                ) {
+                    item { DeliveryStatusCard(status = ui.status) }
+                    item {
+                        Text(
+                            text = stringResource(R.string.alerts_catalog_title),
+                            style = MaterialTheme.typography.titleMedium,
+                            modifier = Modifier.padding(top = 8.dp).testTag("alerts-catalog-title"),
+                        )
+                    }
+                    item {
+                        Text(
+                            text = stringResource(R.string.alerts_catalog_note),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                    // Group by category, preserving the server's order (a
+                    // LinkedHashMap keeps first-seen category order, mirroring the
+                    // Front Desk web picker).
+                    ui.catalog
+                        .groupByTo(LinkedHashMap()) { it.category }
+                        .forEach { (category, defs) ->
+                            item {
+                                Text(
+                                    text = category,
+                                    style = MaterialTheme.typography.labelLarge,
+                                    color = MaterialTheme.colorScheme.primary,
+                                    modifier = Modifier.padding(top = 8.dp),
+                                )
+                            }
+                            items(defs) { def -> AlertRow(def = def) }
+                        }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DeliveryStatusCard(
+    status: AlertStatus?,
+    modifier: Modifier = Modifier,
+) {
+    val (severity, labelRes) = statusSeverityAndLabel(status)
+    val (container, content) = severityColors(severity)
+    // The probe detail is only meaningful (and only carries a reason) once the
+    // notifier is configured but not fully healthy; a green "delivering" pill and
+    // an unconfigured notifier both need no note (mirrors Front Desk web).
+    val showDetail =
+        status?.configured == true &&
+            status.detail.isNotBlank() &&
+            (!status.reachable || !status.healthy)
+    Card(modifier = modifier.fillMaxWidth().testTag("alerts-status-card")) {
+        Column(
+            modifier = Modifier.padding(14.dp),
+            verticalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.alerts_delivery_title),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Pill(
+                text = stringResource(labelRes),
+                container = container,
+                content = content,
+                tag = "alerts-status-pill",
+            )
+            if (showDetail) {
+                Text(
+                    text = status.detail,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.testTag("alerts-status-detail"),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun AlertRow(
+    def: AlertEventDef,
+    modifier: Modifier = Modifier,
+) {
+    val (container, content) = severityColors(def.severity)
+    Card(modifier = modifier.fillMaxWidth().testTag("alert-row")) {
+        Row(
+            modifier = Modifier.padding(14.dp).fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            Pill(
+                text = severityLabel(def.severity),
+                container = container,
+                content = content,
+                tag = "alert-sev-${def.severity}",
+            )
+            Text(
+                text = eventTypeLabel(def.type),
+                style = MaterialTheme.typography.bodyMedium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f),
+            )
+            Text(
+                text =
+                    stringResource(
+                        if (def.defaultOn) R.string.alerts_default_on else R.string.alerts_default_off,
+                    ),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+// statusSeverityAndLabel narrows the AlertStatus into a (severity-key, label)
+// pair, mirroring Front Desk web's StatusPill: unconfigured is neutral info,
+// then unreachable (danger) and unhealthy (warning) before a green "delivering".
+private fun statusSeverityAndLabel(status: AlertStatus?): Pair<String, Int> =
+    when {
+        status == null || !status.configured -> "info" to R.string.alerts_status_not_configured
+        !status.reachable -> "error" to R.string.alerts_status_unreachable
+        !status.healthy -> "warning" to R.string.alerts_status_unhealthy
+        else -> "success" to R.string.alerts_status_delivering
+    }
+
+/** severityLabel is the badge text for a display severity, falling back to the raw value. */
+@Composable
+private fun severityLabel(severity: String): String =
+    when (severity) {
+        "info" -> stringResource(R.string.events_sev_info)
+        "success" -> stringResource(R.string.events_sev_success)
+        "warning" -> stringResource(R.string.events_sev_warning)
+        "error" -> stringResource(R.string.events_sev_error)
+        else -> severity
+    }
+
+// eventTypeLabel gives a readable name for a catalog event type, falling back to
+// the raw type so a brand-new server-side event still renders before a string is
+// added (matches the Front Desk web picker's defaultValue behaviour).
+@Composable
+private fun eventTypeLabel(type: String): String =
+    when (type) {
+        "health.down" -> stringResource(R.string.alerts_event_health_down)
+        "health.up" -> stringResource(R.string.alerts_event_health_up)
+        "config.sync_failed" -> stringResource(R.string.alerts_event_config_sync_failed)
+        "config.synced" -> stringResource(R.string.alerts_event_config_synced)
+        "config.auto_synced" -> stringResource(R.string.alerts_event_config_auto_synced)
+        "version.fetch_failed" -> stringResource(R.string.alerts_event_version_fetch_failed)
+        "version.fetch_recovered" -> stringResource(R.string.alerts_event_version_fetch_recovered)
+        "traefik.stale" -> stringResource(R.string.alerts_event_traefik_stale)
+        "member.added" -> stringResource(R.string.alerts_event_member_added)
+        "member.removed" -> stringResource(R.string.alerts_event_member_removed)
+        "member.state_changed" -> stringResource(R.string.alerts_event_member_state_changed)
+        else -> type
+    }
+
+@Preview(showBackground = true)
+@Composable
+private fun AlertsScreenPreview() {
+    BellhopTheme {
+        AlertsScreen(
+            onBack = {},
+            ui =
+                AlertsUiState(
+                    loading = false,
+                    status = AlertStatus(configured = true, reachable = true, healthy = true),
+                    catalog =
+                        listOf(
+                            AlertEventDef("health.down", "Health", "error", defaultOn = true),
+                            AlertEventDef("health.up", "Health", "success", defaultOn = true),
+                            AlertEventDef("config.sync_failed", "Config Sync", "warning", defaultOn = true),
+                            AlertEventDef("config.synced", "Config Sync", "info", defaultOn = false),
+                        ),
+                ),
+        )
+    }
+}

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/alerts/AlertsViewModel.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/alerts/AlertsViewModel.kt
@@ -1,0 +1,160 @@
+package com.hugalafutro.bellhop.ui.alerts
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.hugalafutro.bellhop.data.AlertEventDef
+import com.hugalafutro.bellhop.data.AlertStatus
+import com.hugalafutro.bellhop.data.FetchResult
+import com.hugalafutro.bellhop.data.FrontDeskClient
+import com.hugalafutro.bellhop.data.LinkStore
+import kotlinx.coroutines.async
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * AlertsUiState is what the Alerts screen renders: Front Desk's outbound-notifier
+ * delivery health ([status]) and its alertable-event catalog ([catalog], grouped
+ * by category in the screen). A failed refresh keeps the last good data on screen
+ * (stale beats blank on a phone) and raises [error]; [revoked] means the device
+ * token itself no longer authenticates, same remedy as the dashboard: unlink and
+ * re-pair.
+ */
+data class AlertsUiState(
+    val loading: Boolean = true,
+    val status: AlertStatus? = null,
+    val catalog: List<AlertEventDef> = emptyList(),
+    val error: String? = null,
+    val revoked: Boolean = false,
+)
+
+/**
+ * AlertsViewModel keeps Front Desk's alert delivery status fresh while the
+ * Alerts screen is on screen. Same subscription-gated refresh + slow poll shape
+ * as the events screen, minus filters and paging: there is no feed to page, only
+ * a status pill (which can flap when the apprise-api container stops) and a
+ * catalog (static per Front Desk version). Both are read on every refresh for
+ * simplicity; the catalog re-read is cheap and picks up a Front Desk upgrade.
+ *
+ * The catalog is a *reference* of what Front Desk can alert on, not which events
+ * are currently enabled: the enabled subset lives in admin settings, which a
+ * device token cannot read. The screen labels it accordingly.
+ */
+class AlertsViewModel(
+    private val client: FrontDeskClient,
+    private val linkStore: LinkStore,
+    private val fdUrl: String,
+    private val pollIntervalMs: Long = POLL_INTERVAL_MS,
+) : ViewModel() {
+    private val _state = MutableStateFlow(AlertsUiState())
+    val state: StateFlow<AlertsUiState> = _state.asStateFlow()
+
+    // Conflated: a poll tick landing while a refresh is queued coalesces into at
+    // most one pending refresh instead of stacking fetches.
+    private val refreshTrigger = Channel<Unit>(Channel.CONFLATED)
+
+    init {
+        viewModelScope.launch {
+            _state.subscriptionCount
+                .map { it > 0 }
+                .distinctUntilChanged()
+                .collectLatest { active ->
+                    if (active) {
+                        coroutineScope {
+                            launch { runRefreshes() }
+                            launch { pollLoop() }
+                        }
+                    }
+                }
+        }
+    }
+
+    // runRefreshes is the sole refresher: one refresh on subscribe, then one per
+    // nudge. A dead token can never authenticate again, so stop the radio once
+    // revoked (matches the dashboard/events loops).
+    private suspend fun runRefreshes() {
+        if (!_state.value.revoked) refreshOnce()
+        for (ignored in refreshTrigger) {
+            if (_state.value.revoked) continue
+            refreshOnce()
+        }
+    }
+
+    private suspend fun pollLoop() {
+        while (true) {
+            delay(pollIntervalMs)
+            refreshTrigger.trySend(Unit)
+        }
+    }
+
+    /**
+     * refreshOnce re-reads status and catalog together. A failure keeps the last
+     * good data and raises [error]; an Unauthorized (or an unreadable token) sets
+     * [revoked]. The two reads run concurrently since neither depends on the other.
+     */
+    suspend fun refreshOnce() {
+        val token = linkStore.token()
+        if (token == null) {
+            // Still linked but the token can't be read back (e.g. the Keystore
+            // key is gone): no request can ever succeed, same remedy as a remote
+            // revoke, so surface it through the same flag.
+            _state.update { it.copy(loading = false, revoked = true) }
+            return
+        }
+        coroutineScope {
+            val statusDeferred = async { client.alertStatus(fdUrl, token) }
+            val catalogDeferred = async { client.alertCatalog(fdUrl, token) }
+            fold(statusDeferred.await(), catalogDeferred.await())
+        }
+    }
+
+    // fold merges the two reads into the state. Either 401 means the token is
+    // dead, so revoked wins over a partial success. Otherwise each read updates
+    // its slice, and a failure on either raises the error while keeping whatever
+    // last loaded. Both succeeding clears the error.
+    private fun fold(
+        status: FetchResult<AlertStatus>,
+        catalog: FetchResult<List<AlertEventDef>>,
+    ) {
+        if (status is FetchResult.Unauthorized || catalog is FetchResult.Unauthorized) {
+            _state.update { it.copy(loading = false, revoked = true) }
+            return
+        }
+        _state.update { st ->
+            val failure =
+                (status as? FetchResult.Failure)?.message
+                    ?: (catalog as? FetchResult.Failure)?.message
+            st.copy(
+                loading = false,
+                status = (status as? FetchResult.Success)?.data ?: st.status,
+                catalog = (catalog as? FetchResult.Success)?.data ?: st.catalog,
+                error = failure,
+                revoked = false,
+            )
+        }
+    }
+
+    class Factory(
+        private val client: FrontDeskClient,
+        private val linkStore: LinkStore,
+        private val fdUrl: String,
+    ) : ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>): T = AlertsViewModel(client, linkStore, fdUrl) as T
+    }
+
+    companion object {
+        // Delivery health can flap when the apprise-api container stops; a slow
+        // poll keeps the pill honest without hammering Front Desk from a phone.
+        const val POLL_INTERVAL_MS = 30_000L
+    }
+}

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/FleetUi.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/FleetUi.kt
@@ -1,5 +1,7 @@
 package com.hugalafutro.bellhop.ui.common
 
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -8,12 +10,25 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.hugalafutro.bellhop.R
 import com.hugalafutro.bellhop.data.HealthStatus
+import com.hugalafutro.bellhop.data.TrafficPoint
+import com.hugalafutro.bellhop.ui.theme.SeverityErrorBg
+import com.hugalafutro.bellhop.ui.theme.SeverityErrorFg
+import com.hugalafutro.bellhop.ui.theme.SeverityInfoBg
+import com.hugalafutro.bellhop.ui.theme.SeverityInfoFg
+import com.hugalafutro.bellhop.ui.theme.SeveritySuccessBg
+import com.hugalafutro.bellhop.ui.theme.SeveritySuccessFg
+import com.hugalafutro.bellhop.ui.theme.SeverityWarnBg
+import com.hugalafutro.bellhop.ui.theme.SeverityWarnFg
 
 // Small fleet-rendering pieces shared by the dashboard cards and the member
 // detail screen, so both spell a member's health and badges the same way.
@@ -39,7 +54,10 @@ internal fun StatusBanner(
     }
 }
 
-/** Pill is a compact rounded badge (Primary, Drained). */
+/**
+ * Pill is a compact rounded badge (Primary, Drained). Pass [onClick] to make it
+ * tappable (e.g. a severity pill that copies its event); left null it is inert.
+ */
 @Composable
 internal fun Pill(
     text: String,
@@ -47,8 +65,47 @@ internal fun Pill(
     content: Color,
     tag: String,
     modifier: Modifier = Modifier,
+    onClick: (() -> Unit)? = null,
 ) {
     Surface(
+        color = container,
+        contentColor = content,
+        shape = RoundedCornerShape(999.dp),
+        modifier =
+            modifier
+                .testTag(tag)
+                .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier),
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelSmall,
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
+        )
+    }
+}
+
+/**
+ * FilterPill is a compact selectable filter chip: a rounded pill that fills with
+ * the accent when [selected]. Deliberately lighter than Material's FilterChip
+ * (smaller font, tighter padding). Meant to sit in an equal-weight Row so a set
+ * of them reads as a segmented control that always fits one phone-width line
+ * instead of wrapping or scrolling off-screen — the caller passes a weight
+ * [modifier] and the label centers and ellipsizes within its share.
+ */
+@Composable
+internal fun FilterPill(
+    text: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+    tag: String,
+    modifier: Modifier = Modifier,
+) {
+    val container =
+        if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surfaceVariant
+    val content =
+        if (selected) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurfaceVariant
+    Surface(
+        onClick = onClick,
         color = container,
         contentColor = content,
         shape = RoundedCornerShape(999.dp),
@@ -57,8 +114,67 @@ internal fun Pill(
         Text(
             text = text,
             style = MaterialTheme.typography.labelSmall,
-            modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
+            textAlign = TextAlign.Center,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 4.dp, vertical = 6.dp),
         )
+    }
+}
+
+/**
+ * severityColors maps an event/alert severity onto the (container, content)
+ * badge palette using the conventional red/orange/blue/green severity colours
+ * (see Color.kt), not the brand's warm roles — a status level must read
+ * unambiguously. Shared so the events log and the alert catalog dot the same
+ * severity the same colour. Unknown severities fall back to info (blue).
+ */
+internal fun severityColors(severity: String): Pair<Color, Color> =
+    when (severity) {
+        "success" -> SeveritySuccessBg to SeveritySuccessFg
+        "warning" -> SeverityWarnBg to SeverityWarnFg
+        "error" -> SeverityErrorBg to SeverityErrorFg
+        else -> SeverityInfoBg to SeverityInfoFg
+    }
+
+/**
+ * TrafficChart is a plain Canvas bar chart, one bar per bucket oldest to newest:
+ * bar height is that bucket's requests against the window maximum, with the
+ * error subset overlaid from the baseline in the error colour. Shared by the
+ * dashboard card sparkline (short, via a height modifier) and the member-detail
+ * graph (tall). No chart library by design (plan section 5.4). The caller sets
+ * the height through [modifier].
+ */
+@Composable
+internal fun TrafficChart(
+    points: List<TrafficPoint>,
+    modifier: Modifier = Modifier,
+) {
+    val barColor = MaterialTheme.colorScheme.primary
+    val errorColor = MaterialTheme.colorScheme.error
+    val idleColor = MaterialTheme.colorScheme.outlineVariant
+    Canvas(modifier = modifier.fillMaxWidth()) {
+        val max = points.maxOf { it.requests }.coerceAtLeast(1)
+        val gap = 3.dp.toPx()
+        val barWidth = (size.width - gap * (points.size - 1)) / points.size
+        val stub = 2.dp.toPx()
+        points.forEachIndexed { i, p ->
+            val x = i * (barWidth + gap)
+            if (p.requests <= 0) {
+                // Zero bucket: a faint stub so the timeline stays readable
+                // instead of leaving holes.
+                drawRect(idleColor, Offset(x, size.height - stub), Size(barWidth, stub))
+                return@forEachIndexed
+            }
+            val h = (size.height * p.requests / max).coerceAtLeast(stub)
+            drawRect(barColor, Offset(x, size.height - h), Size(barWidth, h))
+            if (p.errors > 0) {
+                // Errors are a subset of requests, so the overlay shares the
+                // scale and can never outgrow its bar.
+                val eh = (size.height * p.errors / max).coerceAtLeast(stub)
+                drawRect(errorColor, Offset(x, size.height - eh), Size(barWidth, eh))
+            }
+        }
     }
 }
 

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
@@ -286,14 +287,19 @@ fun DashboardScreen(
                     val listState = rememberLazyListState()
                     // Report which members are on screen so the ViewModel fetches
                     // traffic only for them (viewport-bounded fan-out; a big fleet
-                    // never triggers a call per member). Recomputed as the visible
-                    // index set settles or the list changes.
-                    LaunchedEffect(listState, ui.members) {
-                        snapshotFlow { listState.layoutInfo.visibleItemsInfo.map { it.index } }
+                    // never triggers a call per member). Keyed on listState only so
+                    // the collector isn't torn down every health poll; members are
+                    // read live via rememberUpdatedState, and mapping index->id
+                    // inside snapshotFlow means a roster change with the same
+                    // visible indices still re-reports the (now different) ids.
+                    val liveMembers = rememberUpdatedState(ui.members)
+                    LaunchedEffect(listState) {
+                        snapshotFlow {
+                            listState.layoutInfo.visibleItemsInfo
+                                .mapNotNull { liveMembers.value.getOrNull(it.index)?.id }
+                        }
                             .distinctUntilChanged()
-                            .collect { indices ->
-                                onVisibleMembers(indices.mapNotNull { ui.members.getOrNull(it)?.id })
-                            }
+                            .collect(onVisibleMembers)
                     }
                     LazyColumn(
                         state = listState,

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
@@ -1,6 +1,9 @@
 package com.hugalafutro.bellhop.ui.dashboard
 
+import android.content.Intent
+import android.net.Uri
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -14,9 +17,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.List
+import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
@@ -27,13 +32,16 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
@@ -44,11 +52,14 @@ import com.hugalafutro.bellhop.data.FleetMember
 import com.hugalafutro.bellhop.data.HealthStatus
 import com.hugalafutro.bellhop.data.LinkState
 import com.hugalafutro.bellhop.data.MemberStatus
+import com.hugalafutro.bellhop.data.MemberTraffic
 import com.hugalafutro.bellhop.ui.common.Pill
 import com.hugalafutro.bellhop.ui.common.StatusBanner
+import com.hugalafutro.bellhop.ui.common.TrafficChart
 import com.hugalafutro.bellhop.ui.common.healthColor
 import com.hugalafutro.bellhop.ui.common.healthLabel
 import com.hugalafutro.bellhop.ui.theme.BellhopTheme
+import kotlinx.coroutines.flow.distinctUntilChanged
 
 /**
  * DashboardScreen is the linked-state home: the fleet's members with their live
@@ -67,8 +78,53 @@ fun DashboardScreen(
     onForceUnlink: () -> Unit = {},
     onMemberClick: (String) -> Unit = {},
     onEventsClick: () -> Unit = {},
+    onAlertsClick: () -> Unit = {},
+    onVisibleMembers: (List<String>) -> Unit = {},
 ) {
     var confirmUnlink by remember { mutableStateOf(false) }
+
+    // Which member's URL the "open externally" popup is showing, if any. Tapping
+    // a card's address opens this confirm dialog rather than firing an intent on
+    // the same tap that could also be a mis-tap on the card itself.
+    var urlDialogFor by remember { mutableStateOf<FleetMember?>(null) }
+    val context = LocalContext.current
+    urlDialogFor?.let { member ->
+        AlertDialog(
+            onDismissRequest = { urlDialogFor = null },
+            title = { Text(stringResource(R.string.member_url_title)) },
+            text = {
+                Text(
+                    text = member.url,
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.testTag("member-url-dialog-text"),
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        // ACTION_VIEW lets Android resolve the URL (browser or a
+                        // matching app), showing its own chooser when several match.
+                        // runCatching: a device with nothing that can open it must
+                        // not crash the app.
+                        runCatching {
+                            context.startActivity(
+                                Intent(Intent.ACTION_VIEW, Uri.parse(member.url)),
+                            )
+                        }
+                        urlDialogFor = null
+                    },
+                    modifier = Modifier.testTag("member-url-open"),
+                ) {
+                    Text(stringResource(R.string.member_url_open))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { urlDialogFor = null }) {
+                    Text(stringResource(R.string.common_cancel))
+                }
+            },
+        )
+    }
 
     // The remote revoke couldn't reach Front Desk (or the token can't be read to
     // revoke at all). The device is still linked and nothing was cleared, so
@@ -174,6 +230,15 @@ fun DashboardScreen(
                         contentDescription = stringResource(R.string.events_open),
                     )
                 }
+                IconButton(
+                    onClick = onAlertsClick,
+                    modifier = Modifier.testTag("dashboard-alerts"),
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.Notifications,
+                        contentDescription = stringResource(R.string.alerts_open),
+                    )
+                }
                 TextButton(
                     onClick = { confirmUnlink = true },
                     enabled = !unlinking,
@@ -218,7 +283,20 @@ fun DashboardScreen(
                     }
                 else -> {
                     FleetSummary(members = ui.members)
+                    val listState = rememberLazyListState()
+                    // Report which members are on screen so the ViewModel fetches
+                    // traffic only for them (viewport-bounded fan-out; a big fleet
+                    // never triggers a call per member). Recomputed as the visible
+                    // index set settles or the list changes.
+                    LaunchedEffect(listState, ui.members) {
+                        snapshotFlow { listState.layoutInfo.visibleItemsInfo.map { it.index } }
+                            .distinctUntilChanged()
+                            .collect { indices ->
+                                onVisibleMembers(indices.mapNotNull { ui.members.getOrNull(it)?.id })
+                            }
+                    }
                     LazyColumn(
+                        state = listState,
                         modifier = Modifier.weight(1f),
                         verticalArrangement = Arrangement.spacedBy(8.dp),
                         contentPadding = PaddingValues(bottom = 24.dp),
@@ -231,7 +309,9 @@ fun DashboardScreen(
                             MemberCard(
                                 member = member,
                                 isPrimary = member.id == ui.primaryId,
+                                traffic = ui.traffic[member.id],
                                 onClick = { onMemberClick(member.id) },
+                                onUrlClick = { urlDialogFor = member },
                             )
                         }
                     }
@@ -273,7 +353,9 @@ private fun FleetSummary(
 private fun MemberCard(
     member: FleetMember,
     isPrimary: Boolean,
+    traffic: MemberTraffic?,
     onClick: () -> Unit,
+    onUrlClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val health = member.status.health
@@ -318,12 +400,18 @@ private fun MemberCard(
                     )
                 }
             }
+            // The URL is its own tap target (opens the "open externally" popup),
+            // separate from the card tap that drills into the member.
             Text(
                 text = member.url,
                 style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                color = MaterialTheme.colorScheme.primary,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
+                modifier =
+                    Modifier
+                        .clickable(onClick = onUrlClick)
+                        .testTag("member-url-${member.name}"),
             )
             Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
                 Text(
@@ -353,6 +441,17 @@ private fun MemberCard(
                     color = MaterialTheme.colorScheme.error,
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis,
+                )
+            }
+            // Inline last-hour sparkline: shown once its (viewport-lazy) traffic
+            // has arrived and there is something to draw. Absent/empty just leaves
+            // the card compact rather than reserving blank space. Tapping the card
+            // (including here) opens the detail with the full graph + event log.
+            traffic?.points?.takeIf { traffic.reachable && it.isNotEmpty() }?.let { points ->
+                Spacer(modifier = Modifier.height(2.dp))
+                TrafficChart(
+                    points = points,
+                    modifier = Modifier.height(28.dp).testTag("member-sparkline-${member.name}"),
                 )
             }
         }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModel.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModel.kt
@@ -7,6 +7,7 @@ import com.hugalafutro.bellhop.data.FetchResult
 import com.hugalafutro.bellhop.data.FleetMember
 import com.hugalafutro.bellhop.data.FrontDeskClient
 import com.hugalafutro.bellhop.data.LinkStore
+import com.hugalafutro.bellhop.data.MemberTraffic
 import com.hugalafutro.bellhop.data.SseMessage
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
@@ -31,6 +32,11 @@ data class DashboardUiState(
     val loading: Boolean = true,
     val members: List<FleetMember> = emptyList(),
     val primaryId: String = "",
+    // Per-member traffic for the inline card sparkline, keyed by member id and
+    // filled lazily for whichever members are currently on screen (see
+    // [DashboardViewModel.setVisibleMembers]). A member absent from the map just
+    // renders without a sparkline yet.
+    val traffic: Map<String, MemberTraffic> = emptyMap(),
     val error: String? = null,
     val revoked: Boolean = false,
 )
@@ -54,6 +60,8 @@ class DashboardViewModel(
     private val linkStore: LinkStore,
     private val fdUrl: String,
     private val pollIntervalMs: Long = POLL_INTERVAL_MS,
+    private val trafficPollMs: Long = TRAFFIC_POLL_MS,
+    private val now: () -> Long = System::currentTimeMillis,
 ) : ViewModel() {
     private val _state = MutableStateFlow(DashboardUiState())
     val state: StateFlow<DashboardUiState> = _state.asStateFlow()
@@ -61,6 +69,18 @@ class DashboardViewModel(
     // Conflated: rapid nudges from the poll and the event stream coalesce into at
     // most one queued refresh instead of stacking sequential fetches.
     private val refreshTrigger = Channel<Unit>(Channel.CONFLATED)
+
+    // The member ids currently visible in the list, reported by the screen. Only
+    // these get their traffic sparkline fetched, so the per-member fan-out is
+    // bounded by what's on screen (~a handful) rather than the fleet size — a
+    // 100-member fleet never triggers 100 traffic calls. When Front Desk grows a
+    // single /api/fleet/usage rollup, this loop swaps its source for that one call.
+    private val visibleIds = MutableStateFlow<List<String>>(emptyList())
+
+    // When each member's traffic was last fetched, so a re-tick or a re-scroll
+    // past an already-fresh member doesn't refetch within the TTL. Only touched
+    // from viewModelScope coroutines (single-threaded Main), so a plain map is safe.
+    private val trafficFetchedAt = mutableMapOf<String, Long>()
 
     init {
         viewModelScope.launch {
@@ -73,6 +93,7 @@ class DashboardViewModel(
                             launch { runRefreshes() }
                             launch { pollLoop() }
                             launch { streamLoop() }
+                            launch { trafficLoop() }
                         }
                     }
                 }
@@ -134,6 +155,69 @@ class DashboardViewModel(
     }
 
     /**
+     * setVisibleMembers is called by the screen with the member ids currently
+     * scrolled into view. Only these have their traffic sparkline fetched, so the
+     * per-member fan-out never exceeds a viewport regardless of fleet size.
+     */
+    fun setVisibleMembers(ids: List<String>) {
+        visibleIds.value = ids
+    }
+
+    // trafficLoop keeps the on-screen members' sparklines fresh on two triggers:
+    // the visible set changing (scroll), debounced so a fast scroll doesn't fetch
+    // every row it flies past; and a slow tick so the current view's sparklines
+    // keep moving. Both go through fetchVisibleTraffic, which skips members still
+    // within the TTL, so overlap is cheap.
+    private suspend fun trafficLoop() =
+        coroutineScope {
+            launch {
+                visibleIds.collectLatest { ids ->
+                    // collectLatest cancels this delay if the visible set changes
+                    // again, so only a settled viewport triggers a fetch.
+                    delay(TRAFFIC_DEBOUNCE_MS)
+                    fetchVisibleTraffic(ids, force = false)
+                }
+            }
+            launch {
+                while (true) {
+                    delay(trafficPollMs)
+                    fetchVisibleTraffic(visibleIds.value, force = true)
+                }
+            }
+        }
+
+    // fetchVisibleTraffic fetches traffic for the given members whose cache is
+    // stale (or all of them when [force]), concurrently — the set is viewport-
+    // bounded, so this is a handful of calls at most. A per-member failure just
+    // leaves that sparkline stale; only a 401 escalates to revoked. Runs on the
+    // Main-confined viewModelScope, so the plain fetched-at map needs no lock.
+    private suspend fun fetchVisibleTraffic(
+        ids: List<String>,
+        force: Boolean,
+    ) {
+        if (_state.value.revoked) return
+        val token = linkStore.token() ?: return
+        val at = now()
+        val due = ids.filter { force || at - (trafficFetchedAt[it] ?: 0L) >= TRAFFIC_TTL_MS }
+        if (due.isEmpty()) return
+        coroutineScope {
+            due.forEach { id ->
+                launch {
+                    when (val result = client.memberTraffic(fdUrl, token, id)) {
+                        is FetchResult.Success -> {
+                            trafficFetchedAt[id] = at
+                            _state.update { it.copy(traffic = it.traffic + (id to result.data)) }
+                        }
+                        FetchResult.Unauthorized -> _state.update { it.copy(revoked = true) }
+                        // A stale sparkline is fine; the card's health still shows.
+                        is FetchResult.Failure -> Unit
+                    }
+                }
+            }
+        }
+    }
+
+    /**
      * refreshOnce performs one members fetch. The auto-sync fetch is best-effort:
      * the Primary badge going stale must not fail an otherwise good refresh.
      */
@@ -149,15 +233,20 @@ class DashboardViewModel(
         when (val result = client.members(fdUrl, token)) {
             is FetchResult.Success -> {
                 val autoSync = client.autoSync(fdUrl, token) as? FetchResult.Success
+                val liveIds = result.data.mapTo(HashSet()) { it.id }
                 _state.update {
                     it.copy(
                         loading = false,
                         members = result.data,
                         primaryId = autoSync?.data?.primaryId ?: it.primaryId,
+                        // Drop cached traffic for members that left the fleet so
+                        // the map can't grow without bound as members churn.
+                        traffic = it.traffic.filterKeys { id -> id in liveIds },
                         error = null,
                         revoked = false,
                     )
                 }
+                trafficFetchedAt.keys.retainAll(liveIds)
             }
             FetchResult.Unauthorized ->
                 _state.update { it.copy(loading = false, revoked = true) }
@@ -179,6 +268,19 @@ class DashboardViewModel(
         // Fallback cadence now that the SSE stream carries live changes: slow
         // enough to be polite from a phone, fast enough to backstop a missed event.
         const val POLL_INTERVAL_MS = 15_000L
+
+        // Traffic sparklines refresh slower than the health poll: the series is
+        // 5-minute buckets, so a per-minute tick keeps the current bucket moving
+        // without a per-member fan-out on every health refresh.
+        const val TRAFFIC_POLL_MS = 60_000L
+
+        // Don't refetch a member's traffic more than once per this window when the
+        // visible set changes (scroll back and forth); the tick force-refreshes.
+        const val TRAFFIC_TTL_MS = 30_000L
+
+        // Settle time before fetching a changed viewport, so a fast scroll doesn't
+        // fetch every row it passes — only where it comes to rest.
+        const val TRAFFIC_DEBOUNCE_MS = 300L
 
         // SSE reconnect backoff, mirroring the web dashboard's 1s..30s range.
         const val SSE_BACKOFF_MIN_MS = 1_000L

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModel.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModel.kt
@@ -82,6 +82,13 @@ class DashboardViewModel(
     // from viewModelScope coroutines (single-threaded Main), so a plain map is safe.
     private val trafficFetchedAt = mutableMapOf<String, Long>()
 
+    // Members with a traffic fetch currently in flight, so the debounce path and
+    // the periodic tick can't both request the same member at once (the TTL only
+    // dedupes sequential fetches, since fetchedAt is stamped on completion). Kept
+    // separate from trafficFetchedAt so a failed fetch still retries immediately
+    // rather than being blocked for a TTL. Main-confined, so a plain set is safe.
+    private val trafficInFlight = mutableSetOf<String>()
+
     init {
         viewModelScope.launch {
             _state.subscriptionCount
@@ -181,6 +188,9 @@ class DashboardViewModel(
             launch {
                 while (true) {
                     delay(trafficPollMs)
+                    // A dead token can't authenticate; stop ticking like the
+                    // other loops rather than spinning on a no-op fetch.
+                    if (_state.value.revoked) return@launch
                     fetchVisibleTraffic(visibleIds.value, force = true)
                 }
             }
@@ -198,19 +208,31 @@ class DashboardViewModel(
         if (_state.value.revoked) return
         val token = linkStore.token() ?: return
         val at = now()
-        val due = ids.filter { force || at - (trafficFetchedAt[it] ?: 0L) >= TRAFFIC_TTL_MS }
+        val due =
+            ids.filter {
+                it !in trafficInFlight && (force || at - (trafficFetchedAt[it] ?: 0L) >= TRAFFIC_TTL_MS)
+            }
         if (due.isEmpty()) return
         coroutineScope {
             due.forEach { id ->
+                // Marked before the launch (synchronously, on Main) so a
+                // concurrent call sees it in flight and skips it.
+                trafficInFlight += id
                 launch {
-                    when (val result = client.memberTraffic(fdUrl, token, id)) {
-                        is FetchResult.Success -> {
-                            trafficFetchedAt[id] = at
-                            _state.update { it.copy(traffic = it.traffic + (id to result.data)) }
+                    try {
+                        when (val result = client.memberTraffic(fdUrl, token, id)) {
+                            is FetchResult.Success -> {
+                                trafficFetchedAt[id] = at
+                                _state.update { it.copy(traffic = it.traffic + (id to result.data)) }
+                            }
+                            FetchResult.Unauthorized -> _state.update { it.copy(revoked = true) }
+                            // A stale sparkline is fine; the card's health still shows.
+                            is FetchResult.Failure -> Unit
                         }
-                        FetchResult.Unauthorized -> _state.update { it.copy(revoked = true) }
-                        // A stale sparkline is fine; the card's health still shows.
-                        is FetchResult.Failure -> Unit
+                    } finally {
+                        // Runs on success, failure, or cancellation, so a member
+                        // is never stuck marked-in-flight after its fetch ends.
+                        trafficInFlight -= id
                     }
                 }
             }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/events/EventsScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/events/EventsScreen.kt
@@ -1,6 +1,6 @@
 package com.hugalafutro.bellhop.ui.events
 
-import androidx.compose.foundation.horizontalScroll
+import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -13,12 +13,10 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -28,17 +26,21 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.hugalafutro.bellhop.R
 import com.hugalafutro.bellhop.data.FdEvent
+import com.hugalafutro.bellhop.ui.common.FilterPill
 import com.hugalafutro.bellhop.ui.common.Pill
 import com.hugalafutro.bellhop.ui.common.StatusBanner
+import com.hugalafutro.bellhop.ui.common.severityColors
 import com.hugalafutro.bellhop.ui.theme.BellhopTheme
 import java.time.Instant
 import java.time.ZoneId
@@ -61,6 +63,15 @@ fun EventsScreen(
     onLoadMore: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
+    // Tapping an event's severity pill copies the whole event as text (handy for
+    // pasting into a bug report), with a toast to confirm the otherwise-silent act.
+    val clipboard = LocalClipboardManager.current
+    val context = LocalContext.current
+    val copiedMsg = stringResource(R.string.events_copied)
+    val onCopy: (FdEvent) -> Unit = { event ->
+        clipboard.setText(AnnotatedString(eventClipboardText(event, memberNames[event.memberId])))
+        Toast.makeText(context, copiedMsg, Toast.LENGTH_SHORT).show()
+    }
     Scaffold(modifier = modifier.fillMaxSize()) { innerPadding ->
         Column(
             modifier =
@@ -140,7 +151,11 @@ fun EventsScreen(
                         // primary keys server-side, but a buggy duplicate must
                         // degrade to a double row, not a crash.
                         items(ui.events) { event ->
-                            EventCard(event = event, memberName = memberNames[event.memberId])
+                            EventCard(
+                                event = event,
+                                memberName = memberNames[event.memberId],
+                                onCopy = { onCopy(event) },
+                            )
                         }
                         if (ui.canLoadMore) {
                             item {
@@ -173,6 +188,9 @@ fun EventsScreen(
 // SEVERITIES list (frontdesk/web/src/pages/EventsPage.tsx).
 private val SEVERITIES = listOf("", "info", "success", "warning", "error")
 
+// Both filter rows are equal-weight Rows, not wrapping FlowRows: a fixed small
+// set of options reads as a segmented control that always fits one line on a
+// phone (each pill takes 1/N of the width, label centered and ellipsized).
 @Composable
 private fun SeverityChips(
     selected: String,
@@ -180,15 +198,16 @@ private fun SeverityChips(
     modifier: Modifier = Modifier,
 ) {
     Row(
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-        modifier = modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+        modifier = modifier.fillMaxWidth(),
     ) {
         SEVERITIES.forEach { sev ->
-            FilterChip(
+            FilterPill(
+                text = severityLabel(sev),
                 selected = selected == sev,
                 onClick = { onSeverity(sev) },
-                label = { Text(severityLabel(sev)) },
-                modifier = Modifier.testTag("events-sev-${sev.ifEmpty { "all" }}"),
+                tag = "events-sev-${sev.ifEmpty { "all" }}",
+                modifier = Modifier.weight(1f),
             )
         }
     }
@@ -201,15 +220,16 @@ private fun RangeChips(
     modifier: Modifier = Modifier,
 ) {
     Row(
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-        modifier = modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+        modifier = modifier.fillMaxWidth(),
     ) {
         EventRange.entries.forEach { range ->
-            FilterChip(
+            FilterPill(
+                text = rangeLabel(range),
                 selected = selected == range,
                 onClick = { onRange(range) },
-                label = { Text(rangeLabel(range)) },
-                modifier = Modifier.testTag("events-range-${range.name.lowercase()}"),
+                tag = "events-range-${range.name.lowercase()}",
+                modifier = Modifier.weight(1f),
             )
         }
     }
@@ -219,6 +239,7 @@ private fun RangeChips(
 private fun EventCard(
     event: FdEvent,
     memberName: String?,
+    onCopy: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val (container, content) = severityColors(event.severity)
@@ -236,6 +257,7 @@ private fun EventCard(
                     container = container,
                     content = content,
                     tag = "event-sev-${event.severity}",
+                    onClick = onCopy,
                 )
                 Spacer(modifier = Modifier.weight(1f))
                 Text(
@@ -285,24 +307,6 @@ private fun rangeLabel(range: EventRange): String =
         EventRange.D30 -> stringResource(R.string.events_range_30d)
     }
 
-/** severityColors maps a severity onto the badge palette FD web uses (ok/warn/danger/info). */
-@Composable
-private fun severityColors(severity: String): Pair<Color, Color> =
-    when (severity) {
-        "success" ->
-            MaterialTheme.colorScheme.tertiaryContainer to
-                MaterialTheme.colorScheme.onTertiaryContainer
-        "warning" ->
-            MaterialTheme.colorScheme.secondaryContainer to
-                MaterialTheme.colorScheme.onSecondaryContainer
-        "error" ->
-            MaterialTheme.colorScheme.errorContainer to
-                MaterialTheme.colorScheme.onErrorContainer
-        else ->
-            MaterialTheme.colorScheme.surfaceVariant to
-                MaterialTheme.colorScheme.onSurfaceVariant
-    }
-
 private val EVENT_TIME_FORMAT =
     DateTimeFormatter.ofPattern("MMM d · HH:mm", Locale.getDefault())
 
@@ -315,6 +319,22 @@ internal fun formatEventTime(createdAt: String): String =
     } catch (e: Exception) {
         createdAt
     }
+
+// eventClipboardText renders one event as a plain-text block for the clipboard:
+// a header (time · severity · type), the message, then a source/member line —
+// blank parts dropped so a memberless system event doesn't trail a dangling dot.
+internal fun eventClipboardText(
+    event: FdEvent,
+    memberName: String?,
+): String {
+    val header = "${formatEventTime(event.createdAt)} · [${event.severity}] ${event.type}"
+    val who =
+        listOfNotNull(
+            event.source.ifEmpty { null },
+            memberName ?: event.memberId.ifEmpty { null },
+        ).joinToString(" · ")
+    return listOf(header, event.message, who).filter { it.isNotEmpty() }.joinToString("\n")
+}
 
 @Preview(showBackground = true)
 @Composable

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreen.kt
@@ -1,20 +1,19 @@
 package com.hugalafutro.bellhop.ui.member
 
-import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.Card
@@ -28,14 +27,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.hugalafutro.bellhop.R
+import com.hugalafutro.bellhop.data.FdEvent
 import com.hugalafutro.bellhop.data.FleetMember
 import com.hugalafutro.bellhop.data.HealthStatus
 import com.hugalafutro.bellhop.data.MemberStatus
@@ -43,15 +41,20 @@ import com.hugalafutro.bellhop.data.MemberTraffic
 import com.hugalafutro.bellhop.data.TrafficPoint
 import com.hugalafutro.bellhop.ui.common.Pill
 import com.hugalafutro.bellhop.ui.common.StatusBanner
+import com.hugalafutro.bellhop.ui.common.TrafficChart
 import com.hugalafutro.bellhop.ui.common.healthColor
-import com.hugalafutro.bellhop.ui.common.healthLabel
+import com.hugalafutro.bellhop.ui.common.severityColors
+import com.hugalafutro.bellhop.ui.events.formatEventTime
 import com.hugalafutro.bellhop.ui.theme.BellhopTheme
 
 /**
- * MemberDetailScreen is one member up close: the same identity and health the
- * dashboard card shows (the [member] arrives live from the dashboard's poll,
- * so badges keep moving here too) plus the last hour of request/error traffic
- * from [MemberDetailViewModel]. Read-only; operator actions are a later phase.
+ * MemberDetailScreen is one member up close — deliberately *not* a repeat of the
+ * dashboard card. A minimal header (name + live health dot) sits above the last
+ * hour of traffic (the full graph the card only sparklines) and the info the
+ * card has no room for: the probe error when down, config-sync provenance, the
+ * in-sync heartbeat, when it was added, and the member's recent event log.
+ * [member] arrives live from the dashboard's poll; [ui] carries the graph +
+ * events from [MemberDetailViewModel].
  */
 @Composable
 fun MemberDetailScreen(
@@ -68,8 +71,7 @@ fun MemberDetailScreen(
                 Modifier
                     .fillMaxSize()
                     .padding(innerPadding)
-                    .padding(horizontal = 16.dp)
-                    .verticalScroll(rememberScrollState()),
+                    .padding(horizontal = 16.dp),
         ) {
             Row(
                 verticalAlignment = Alignment.CenterVertically,
@@ -105,14 +107,6 @@ fun MemberDetailScreen(
                         tag = "member-detail-primary",
                     )
                 }
-                if (member.drained) {
-                    Pill(
-                        text = stringResource(R.string.member_state_drained),
-                        container = MaterialTheme.colorScheme.errorContainer,
-                        content = MaterialTheme.colorScheme.onErrorContainer,
-                        tag = "member-detail-drained",
-                    )
-                }
             }
 
             if (ui.revoked) {
@@ -124,60 +118,128 @@ fun MemberDetailScreen(
                 )
             }
 
-            Card(modifier = Modifier.fillMaxWidth().testTag("member-detail-meta")) {
-                Column(
-                    modifier = Modifier.padding(14.dp),
-                    verticalArrangement = Arrangement.spacedBy(4.dp),
-                ) {
+            LazyColumn(
+                modifier = Modifier.weight(1f).testTag("member-detail-list"),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+                contentPadding = PaddingValues(top = 4.dp, bottom = 24.dp),
+            ) {
+                item { TrafficCard(ui = ui) }
+                item { MetaCard(member = member) }
+                item {
                     Text(
-                        text = member.url,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        text = stringResource(R.string.member_detail_events_title),
+                        style = MaterialTheme.typography.titleMedium,
+                        modifier = Modifier.testTag("member-detail-events-title"),
                     )
-                    Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                        Text(
-                            text = healthLabel(health),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = healthColor(health),
-                        )
-                        if (health.known && member.status.traefikStatus.isNotBlank()) {
+                }
+                when {
+                    ui.loading && ui.events.isEmpty() ->
+                        item {
+                            Box(
+                                modifier = Modifier.fillMaxWidth().padding(vertical = 16.dp),
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                CircularProgressIndicator(modifier = Modifier.testTag("member-detail-events-loading"))
+                            }
+                        }
+                    ui.events.isEmpty() ->
+                        item {
                             Text(
-                                text = stringResource(R.string.member_traefik, member.status.traefikStatus),
-                                style = MaterialTheme.typography.bodySmall,
+                                text = stringResource(R.string.member_detail_no_events),
+                                style = MaterialTheme.typography.bodyMedium,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.testTag("member-detail-no-events"),
                             )
                         }
-                        if (member.status.version.isNotBlank()) {
-                            Text(
-                                text = member.status.version,
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                        }
-                    }
-                    // The card truncates this; up close the operator wants the
-                    // whole probe error.
-                    if (health.known && !health.healthy && health.error.isNotBlank()) {
-                        Text(
-                            text = health.error,
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.error,
-                        )
-                    }
+                    else -> items(ui.events) { event -> MemberEventRow(event = event) }
                 }
             }
-
-            Spacer(modifier = Modifier.height(12.dp))
-            TrafficCard(ui = ui)
-            Spacer(modifier = Modifier.height(16.dp))
         }
     }
 }
 
 /**
- * TrafficCard renders the last-hour series. Unreachable is a normal, explained
- * state, not an error: Front Desk may hold no admin token for this member, or
- * the member didn't answer its stats API.
+ * MetaCard is the info the dashboard card has no room for: the full probe error
+ * when down, config-sync provenance, the in-sync heartbeat, and when the member
+ * was added. Each line only shows when it has a value, so a healthy never-synced
+ * member stays terse.
+ */
+@Composable
+private fun MetaCard(
+    member: FleetMember,
+    modifier: Modifier = Modifier,
+) {
+    val health = member.status.health
+    Card(modifier = modifier.fillMaxWidth().testTag("member-detail-meta")) {
+        Column(
+            modifier = Modifier.padding(14.dp),
+            verticalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            Text(
+                text = member.url,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            if (health.known && !health.healthy && health.error.isNotBlank()) {
+                Text(
+                    text = health.error,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.testTag("member-detail-down-reason"),
+                )
+            }
+            if (member.lastConfigSyncAt.isNotBlank()) {
+                MetaLine(
+                    text = stringResource(R.string.member_detail_synced, formatEventTime(member.lastConfigSyncAt)),
+                    tag = "member-detail-synced",
+                )
+                if (member.lastConfigSyncReason.isNotBlank()) {
+                    Text(
+                        text = member.lastConfigSyncReason,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            if (member.status.autoSyncVerifiedAt.isNotBlank()) {
+                MetaLine(
+                    text =
+                        stringResource(
+                            R.string.member_detail_verified,
+                            formatEventTime(member.status.autoSyncVerifiedAt),
+                        ),
+                    tag = "member-detail-verified",
+                )
+            }
+            if (member.createdAt.isNotBlank()) {
+                MetaLine(
+                    text = stringResource(R.string.member_detail_created, formatEventTime(member.createdAt)),
+                    tag = "member-detail-created",
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun MetaLine(
+    text: String,
+    tag: String,
+) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.testTag(tag),
+    )
+}
+
+/**
+ * TrafficCard renders the last-hour series bigger than the card sparkline.
+ * Unreachable is a normal, explained state, not an error: Front Desk may hold no
+ * admin token for this member, or the member didn't answer its stats API.
  */
 @Composable
 private fun TrafficCard(
@@ -229,54 +291,47 @@ private fun TrafficCard(
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier = Modifier.testTag("member-traffic-totals"),
                     )
-                    TrafficChart(points = traffic.points)
+                    TrafficChart(
+                        points = traffic.points,
+                        modifier = Modifier.height(140.dp).testTag("member-traffic-chart"),
+                    )
                 }
             }
         }
     }
 }
 
-/**
- * TrafficChart is a plain Canvas bar chart, one bar per 5-minute bucket oldest
- * to newest: bar height is that bucket's requests against the window maximum,
- * with the error subset overlaid from the baseline in the error color. No
- * chart library by design (plan section 5.4).
- */
+/** MemberEventRow is one compact event under the graph: severity pill, message, time. */
 @Composable
-private fun TrafficChart(
-    points: List<TrafficPoint>,
+private fun MemberEventRow(
+    event: FdEvent,
     modifier: Modifier = Modifier,
 ) {
-    val barColor = MaterialTheme.colorScheme.primary
-    val errorColor = MaterialTheme.colorScheme.error
-    val idleColor = MaterialTheme.colorScheme.outlineVariant
-    Canvas(
-        modifier =
-            modifier
-                .fillMaxWidth()
-                .height(96.dp)
-                .testTag("member-traffic-chart"),
-    ) {
-        val max = points.maxOf { it.requests }.coerceAtLeast(1)
-        val gap = 3.dp.toPx()
-        val barWidth = (size.width - gap * (points.size - 1)) / points.size
-        val stub = 2.dp.toPx()
-        points.forEachIndexed { i, p ->
-            val x = i * (barWidth + gap)
-            if (p.requests <= 0) {
-                // Zero bucket: a faint stub so the timeline stays readable
-                // instead of leaving holes.
-                drawRect(idleColor, Offset(x, size.height - stub), Size(barWidth, stub))
-                return@forEachIndexed
-            }
-            val h = (size.height * p.requests / max).coerceAtLeast(stub)
-            drawRect(barColor, Offset(x, size.height - h), Size(barWidth, h))
-            if (p.errors > 0) {
-                // Errors are a subset of requests, so the overlay shares the
-                // scale and can never outgrow its bar.
-                val eh = (size.height * p.errors / max).coerceAtLeast(stub)
-                drawRect(errorColor, Offset(x, size.height - eh), Size(barWidth, eh))
-            }
+    val (container, content) = severityColors(event.severity)
+    Card(modifier = modifier.fillMaxWidth().testTag("member-event-row")) {
+        Row(
+            modifier = Modifier.padding(12.dp).fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            Pill(
+                text = event.severity,
+                container = container,
+                content = content,
+                tag = "member-event-sev-${event.severity}",
+            )
+            Text(
+                text = event.message,
+                style = MaterialTheme.typography.bodySmall,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f),
+            )
+            Text(
+                text = formatEventTime(event.createdAt),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
         }
     }
 }
@@ -291,11 +346,15 @@ private fun MemberDetailScreenPreview() {
                     id = "m1",
                     name = "hotel-prime",
                     url = "http://192.168.1.10:8080",
+                    createdAt = "2026-06-28T17:53:27Z",
+                    lastConfigSyncAt = "2026-07-10T20:26:40Z",
+                    lastConfigSyncReason = "the primary's config changed",
                     status =
                         MemberStatus(
                             health = HealthStatus(known = true, healthy = true, latencyMs = 12),
                             traefikStatus = "UP",
                             version = "0.33.0",
+                            autoSyncVerifiedAt = "2026-07-12T13:42:17Z",
                         ),
                 ),
             isPrimary = true,
@@ -317,6 +376,18 @@ private fun MemberDetailScreenPreview() {
                                         errors = if (it % 5 == 0) 2 else 0,
                                     )
                                 },
+                        ),
+                    events =
+                        listOf(
+                            FdEvent(
+                                id = "e1",
+                                type = "health.down",
+                                severity = "error",
+                                source = "frontdesk-poller",
+                                message = "hotel-prime is unreachable after 3 checks",
+                                memberId = "m1",
+                                createdAt = "2026-07-12T10:15:00Z",
+                            ),
                         ),
                 ),
         )

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailViewModel.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailViewModel.kt
@@ -3,10 +3,14 @@ package com.hugalafutro.bellhop.ui.member
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import com.hugalafutro.bellhop.data.EventQuery
+import com.hugalafutro.bellhop.data.FdEvent
 import com.hugalafutro.bellhop.data.FetchResult
 import com.hugalafutro.bellhop.data.FrontDeskClient
 import com.hugalafutro.bellhop.data.LinkStore
 import com.hugalafutro.bellhop.data.MemberTraffic
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -26,6 +30,10 @@ import kotlinx.coroutines.launch
 data class MemberDetailUiState(
     val loading: Boolean = true,
     val traffic: MemberTraffic? = null,
+    // The member's own recent events (newest first), from GET /api/events filtered
+    // to this member. Read-only and unpaged: the full log with filters lives on
+    // the Events screen; here it's just "what happened to this box lately".
+    val events: List<FdEvent> = emptyList(),
     val error: String? = null,
     val revoked: Boolean = false,
 )
@@ -70,7 +78,12 @@ class MemberDetailViewModel(
         }
     }
 
-    /** refreshOnce performs one traffic fetch and folds it into the state. */
+    /**
+     * refreshOnce fetches this member's traffic and its recent events together
+     * (they don't depend on each other) and folds both in. Either 401 means the
+     * token is dead, so revoked wins; a failure on either keeps the last-good
+     * slice and raises the error; both succeeding clears it.
+     */
     suspend fun refreshOnce() {
         val token = linkStore.token()
         if (token == null) {
@@ -80,15 +93,32 @@ class MemberDetailViewModel(
             _state.update { it.copy(loading = false, revoked = true) }
             return
         }
-        when (val result = client.memberTraffic(fdUrl, token, memberId)) {
-            is FetchResult.Success ->
-                _state.update {
-                    it.copy(loading = false, traffic = result.data, error = null, revoked = false)
-                }
-            FetchResult.Unauthorized ->
-                _state.update { it.copy(loading = false, revoked = true) }
-            is FetchResult.Failure ->
-                _state.update { it.copy(loading = false, error = result.message) }
+        val (traffic, events) =
+            coroutineScope {
+                val t = async { client.memberTraffic(fdUrl, token, memberId) }
+                val e = async { client.events(fdUrl, token, EventQuery(memberId = memberId, limit = EVENTS_LIMIT)) }
+                t.await() to e.await()
+            }
+        if (traffic is FetchResult.Unauthorized || events is FetchResult.Unauthorized) {
+            _state.update { it.copy(loading = false, revoked = true) }
+            return
+        }
+        _state.update { st ->
+            val failure =
+                (traffic as? FetchResult.Failure)?.message
+                    ?: (events as? FetchResult.Failure)?.message
+            st.copy(
+                loading = false,
+                traffic = (traffic as? FetchResult.Success)?.data ?: st.traffic,
+                events =
+                    (events as? FetchResult.Success)?.data?.events.orEmpty().ifEmpty {
+                        // Keep the last-good list only when the events fetch itself
+                        // failed; a genuine empty page (success) must clear it.
+                        if (events is FetchResult.Success) emptyList() else st.events
+                    },
+                error = failure,
+                revoked = false,
+            )
         }
     }
 
@@ -107,5 +137,9 @@ class MemberDetailViewModel(
         // The chart's buckets are 5 minutes wide; a minute-ish poll keeps the
         // current bucket moving without hammering the member's stats API.
         const val POLL_INTERVAL_MS = 60_000L
+
+        // Recent events shown under the graph. Enough to see the member's recent
+        // story; the Events screen owns the full, filterable, paged log.
+        const val EVENTS_LIMIT = 25
     }
 }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/theme/Color.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/theme/Color.kt
@@ -51,3 +51,17 @@ val Ember300 = Color(0xFFE89A8A)
 val Ember600 = Color(0xFFB3402B)
 val EmberContainerDark = Color(0xFF44201A)
 val EmberContainerLight = Color(0xFFF6DDD6)
+
+// Semantic severity badges (event / alert levels). Deliberately conventional
+// red/orange/blue/green rather than brass-tinted: a status level must read
+// unambiguously at a glance, so these override the brand's warm palette for
+// badges only. Saturated mid-tones with the paired text colour stay legible on
+// both the ink (dark) and paper (light) surfaces, so one value serves both.
+val SeverityErrorBg = Color(0xFFC62828) // red
+val SeverityErrorFg = Color(0xFFFFFFFF)
+val SeverityWarnBg = Color(0xFFE8820C) // orange
+val SeverityWarnFg = Color(0xFF241100) // near-black: higher contrast on orange than white
+val SeverityInfoBg = Color(0xFF1E6FD9) // blue
+val SeverityInfoFg = Color(0xFFFFFFFF)
+val SeveritySuccessBg = Color(0xFF2E7D32) // green
+val SeveritySuccessFg = Color(0xFFFFFFFF)

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -33,6 +33,13 @@
     <string name="member_detail_traffic_totals">%1$d requests · %2$d errors</string>
     <string name="member_detail_traffic_unreachable">Traffic isn\'t available. Front Desk may hold no admin token for this member, or the member didn\'t answer.</string>
     <string name="member_detail_traffic_empty">No requests in this window.</string>
+    <string name="member_detail_events_title">Recent events</string>
+    <string name="member_detail_no_events">No recent events for this member.</string>
+    <string name="member_detail_synced">Config synced %1$s</string>
+    <string name="member_detail_verified">Verified in sync %1$s</string>
+    <string name="member_detail_created">Added %1$s</string>
+    <string name="member_url_title">Open member address</string>
+    <string name="member_url_open">Open</string>
 
     <!-- Events -->
     <string name="events_title">Events</string>
@@ -40,6 +47,7 @@
     <string name="events_back">Back</string>
     <string name="events_empty">No events match.</string>
     <string name="events_load_more">Load more</string>
+    <string name="events_copied">Event copied to clipboard</string>
     <plurals name="events_total">
         <item quantity="one">%1$d event</item>
         <item quantity="other">%1$d events</item>
@@ -54,6 +62,31 @@
     <string name="events_range_24h">24h</string>
     <string name="events_range_7d">7d</string>
     <string name="events_range_30d">30d</string>
+
+    <!-- Alerts -->
+    <string name="alerts_title">Alerts</string>
+    <string name="alerts_open">Alerts</string>
+    <string name="alerts_back">Back</string>
+    <string name="alerts_delivery_title">Notification delivery</string>
+    <string name="alerts_status_not_configured">Not configured</string>
+    <string name="alerts_status_unreachable">Notifier unreachable</string>
+    <string name="alerts_status_unhealthy">Notifier unhealthy</string>
+    <string name="alerts_status_delivering">Delivering</string>
+    <string name="alerts_catalog_title">What Front Desk alerts on</string>
+    <string name="alerts_catalog_note">Enable or mute specific alerts in Front Desk → Settings → Alerts. This list shows every event Front Desk can notify on and its first-run default.</string>
+    <string name="alerts_default_on">On by default</string>
+    <string name="alerts_default_off">Off by default</string>
+    <string name="alerts_event_health_down">Member went down</string>
+    <string name="alerts_event_health_up">Member recovered</string>
+    <string name="alerts_event_config_sync_failed">Config sync failed</string>
+    <string name="alerts_event_config_synced">Config synced</string>
+    <string name="alerts_event_config_auto_synced">Config auto-synced</string>
+    <string name="alerts_event_version_fetch_failed">Version read failed</string>
+    <string name="alerts_event_version_fetch_recovered">Version read recovered</string>
+    <string name="alerts_event_traefik_stale">Traefik config stale</string>
+    <string name="alerts_event_member_added">Member added</string>
+    <string name="alerts_event_member_removed">Member removed</string>
+    <string name="alerts_event_member_state_changed">Member drained or activated</string>
 
     <string name="dashboard_unlink">Unlink</string>
     <string name="dashboard_unlink_confirm_title">Unlink this device?</string>

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/FrontDeskClientTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/FrontDeskClientTest.kt
@@ -403,4 +403,92 @@ class FrontDeskClientTest {
             val messages = client.streamEvents("not a url", "tok").toList()
             assertTrue(messages.isEmpty())
         }
+
+    @Test
+    fun alertStatusParsesAndSendsBearer() =
+        runBlocking {
+            server.enqueue(
+                MockResponse().setBody(
+                    """{"configured":true,"reachable":true,"healthy":false,""" +
+                        """"detail":"apprise-api returned status 417"}""",
+                ),
+            )
+
+            val result = client.alertStatus(server.url("/").toString(), "tok-1")
+
+            assertTrue(result is FetchResult.Success)
+            result as FetchResult.Success
+            assertTrue(result.data.configured)
+            assertTrue(result.data.reachable)
+            assertFalse(result.data.healthy)
+            assertEquals("apprise-api returned status 417", result.data.detail)
+
+            val request = server.takeRequest()
+            assertEquals("GET", request.method)
+            assertEquals("/api/alert/status", request.path)
+            assertEquals("Bearer tok-1", request.getHeader("Authorization"))
+        }
+
+    @Test
+    fun alertStatusMissingDetailDefaultsEmpty() =
+        runBlocking {
+            // A healthy notifier omits detail (omitempty on the server); it must
+            // decode to "" not fail on the missing field.
+            server.enqueue(
+                MockResponse().setBody("""{"configured":true,"reachable":true,"healthy":true}"""),
+            )
+            val result = client.alertStatus(server.url("/").toString(), "tok-1")
+            assertTrue(result is FetchResult.Success)
+            assertEquals("", (result as FetchResult.Success).data.detail)
+        }
+
+    @Test
+    fun alertStatusMapsUnauthorizedToItsOwnArm() =
+        runBlocking {
+            server.enqueue(
+                MockResponse().setResponseCode(401).setBody(
+                    """{"error":{"code":"unauthorized","message":"bad token"}}""",
+                ),
+            )
+            val result = client.alertStatus(server.url("/").toString(), "dead")
+            assertEquals(FetchResult.Unauthorized, result)
+        }
+
+    @Test
+    fun alertCatalogParsesGroupsAndSendsBearer() =
+        runBlocking {
+            server.enqueue(
+                MockResponse().setBody(
+                    """[{"type":"health.down","category":"Health","severity":"error","defaultOn":true},""" +
+                        """{"type":"config.synced","category":"Config Sync","severity":"info","defaultOn":false}]""",
+                ),
+            )
+
+            val result = client.alertCatalog(server.url("/").toString(), "tok-1")
+
+            assertTrue(result is FetchResult.Success)
+            result as FetchResult.Success
+            assertEquals(2, result.data.size)
+            assertEquals("health.down", result.data[0].type)
+            assertEquals("Health", result.data[0].category)
+            assertTrue(result.data[0].defaultOn)
+            assertFalse(result.data[1].defaultOn)
+
+            val request = server.takeRequest()
+            assertEquals("GET", request.method)
+            assertEquals("/api/alert/events", request.path)
+            assertEquals("Bearer tok-1", request.getHeader("Authorization"))
+        }
+
+    @Test
+    fun alertCatalogMapsUnauthorizedToItsOwnArm() =
+        runBlocking {
+            server.enqueue(
+                MockResponse().setResponseCode(401).setBody(
+                    """{"error":{"code":"unauthorized","message":"bad token"}}""",
+                ),
+            )
+            val result = client.alertCatalog(server.url("/").toString(), "dead")
+            assertEquals(FetchResult.Unauthorized, result)
+        }
 }

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/alerts/AlertsScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/alerts/AlertsScreenTest.kt
@@ -1,0 +1,131 @@
+package com.hugalafutro.bellhop.ui.alerts
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToNode
+import com.hugalafutro.bellhop.data.AlertEventDef
+import com.hugalafutro.bellhop.data.AlertStatus
+import com.hugalafutro.bellhop.ui.theme.BellhopTheme
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Alerts screen: delivery-status pill, catalog rows, revoked banner, back arrow.
+ * Asserts on test tags, not display text, so English copy never breaks tests.
+ */
+@RunWith(RobolectricTestRunner::class)
+class AlertsScreenTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val catalog =
+        listOf(
+            AlertEventDef("health.down", "Health", "error", defaultOn = true),
+            AlertEventDef("health.up", "Health", "success", defaultOn = true),
+            AlertEventDef("config.synced", "Config Sync", "info", defaultOn = false),
+        )
+
+    private val loaded =
+        AlertsUiState(
+            loading = false,
+            status = AlertStatus(configured = true, reachable = true, healthy = true),
+            catalog = catalog,
+        )
+
+    @Test
+    fun rendersStatusPillAndCatalogRows() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                AlertsScreen(onBack = {}, ui = loaded)
+            }
+        }
+        composeTestRule.onNodeWithTag("alerts-status-pill", useUnmergedTree = true).assertIsDisplayed()
+        // The catalog is a LazyColumn, so scroll each row into view before
+        // asserting: off-screen rows are never composed.
+        for (sev in listOf("alert-sev-error", "alert-sev-success", "alert-sev-info")) {
+            composeTestRule.onNodeWithTag("alerts-list").performScrollToNode(hasTestTag(sev))
+            composeTestRule.onNodeWithTag(sev, useUnmergedTree = true).assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun unhealthyStatusShowsDetail() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                AlertsScreen(
+                    onBack = {},
+                    ui =
+                        loaded.copy(
+                            status =
+                                AlertStatus(
+                                    configured = true,
+                                    reachable = true,
+                                    healthy = false,
+                                    detail = "apprise-api returned status 417",
+                                ),
+                        ),
+                )
+            }
+        }
+        composeTestRule
+            .onNodeWithTag("alerts-list")
+            .performScrollToNode(hasTestTag("alerts-status-detail"))
+        composeTestRule.onNodeWithTag("alerts-status-detail", useUnmergedTree = true).assertIsDisplayed()
+    }
+
+    @Test
+    fun healthyStatusHidesDetail() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                AlertsScreen(
+                    onBack = {},
+                    // A healthy notifier carries no reason; the detail line stays hidden.
+                    ui = loaded.copy(status = loaded.status?.copy(detail = "ignored while healthy")),
+                )
+            }
+        }
+        assertTrue(
+            composeTestRule.onAllNodesWithTag("alerts-status-detail").fetchSemanticsNodes().isEmpty(),
+        )
+    }
+
+    @Test
+    fun firstLoadShowsSpinner() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                AlertsScreen(onBack = {}, ui = AlertsUiState())
+            }
+        }
+        composeTestRule.onNodeWithTag("alerts-loading").assertIsDisplayed()
+    }
+
+    @Test
+    fun revokedShowsBanner() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                AlertsScreen(onBack = {}, ui = AlertsUiState(loading = false, revoked = true))
+            }
+        }
+        composeTestRule.onNodeWithTag("alerts-revoked").assertIsDisplayed()
+    }
+
+    @Test
+    fun backArrowFiresCallback() {
+        var backs = 0
+        composeTestRule.setContent {
+            BellhopTheme {
+                AlertsScreen(onBack = { backs++ }, ui = loaded)
+            }
+        }
+        composeTestRule.onNodeWithTag("alerts-back").performClick()
+        assertEquals(1, backs)
+    }
+}

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/alerts/AlertsViewModelTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/alerts/AlertsViewModelTest.kt
@@ -1,0 +1,187 @@
+package com.hugalafutro.bellhop.ui.alerts
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import com.hugalafutro.bellhop.data.AlertEventDef
+import com.hugalafutro.bellhop.data.AlertStatus
+import com.hugalafutro.bellhop.data.FakeCipher
+import com.hugalafutro.bellhop.data.FetchResult
+import com.hugalafutro.bellhop.data.FrontDeskClient
+import com.hugalafutro.bellhop.data.LinkStore
+import com.hugalafutro.bellhop.data.PairedDevice
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.File
+import java.util.concurrent.atomic.AtomicInteger
+
+// FakeAlertsClient stubs the two reads the alerts ViewModel makes; each result
+// is swappable so a test can flip a call from success to failure between refreshes.
+private class FakeAlertsClient(
+    var status: FetchResult<AlertStatus>,
+    var catalog: FetchResult<List<AlertEventDef>>,
+) : FrontDeskClient() {
+    val statusCalls = AtomicInteger(0)
+    val catalogCalls = AtomicInteger(0)
+    var lastToken: String? = null
+
+    override suspend fun alertStatus(
+        fdUrl: String,
+        token: String,
+    ): FetchResult<AlertStatus> {
+        statusCalls.incrementAndGet()
+        lastToken = token
+        return status
+    }
+
+    override suspend fun alertCatalog(
+        fdUrl: String,
+        token: String,
+    ): FetchResult<List<AlertEventDef>> {
+        catalogCalls.incrementAndGet()
+        lastToken = token
+        return catalog
+    }
+}
+
+@RunWith(RobolectricTestRunner::class)
+class AlertsViewModelTest {
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    private fun newVm(
+        client: FrontDeskClient,
+        linkStore: LinkStore,
+    ): AlertsViewModel = AlertsViewModel(client, linkStore, "http://fd:1")
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(Dispatchers.Unconfined)
+    }
+
+    @After
+    fun tearDownMain() {
+        Dispatchers.resetMain()
+    }
+
+    private fun newLinkStore(): LinkStore {
+        val scope = CoroutineScope(Dispatchers.IO + Job())
+        val ds =
+            PreferenceDataStoreFactory.create(scope = scope) {
+                File(tmp.newFolder(), "link.preferences_pb")
+            }
+        return LinkStore(ds, FakeCipher)
+    }
+
+    private fun linkedStore(): LinkStore =
+        newLinkStore().also {
+            runBlocking {
+                it.save(
+                    "http://fd:1",
+                    "FD",
+                    "tok-1",
+                    PairedDevice(id = "d1", label = "Pixel", role = "monitor"),
+                )
+            }
+        }
+
+    private val okStatus = AlertStatus(configured = true, reachable = true, healthy = true)
+    private val okCatalog =
+        listOf(AlertEventDef("health.down", "Health", "error", defaultOn = true))
+
+    @Test
+    fun firstRefreshLoadsStatusAndCatalog() =
+        runBlocking {
+            val client = FakeAlertsClient(FetchResult.Success(okStatus), FetchResult.Success(okCatalog))
+            val vm = newVm(client, linkedStore())
+
+            vm.refreshOnce()
+
+            val s = vm.state.value
+            assertFalse(s.loading)
+            assertEquals(okStatus, s.status)
+            assertEquals(okCatalog, s.catalog)
+            assertNull(s.error)
+            assertFalse(s.revoked)
+            assertEquals("tok-1", client.lastToken)
+        }
+
+    @Test
+    fun failedRefreshKeepsStaleAndRecovers() =
+        runBlocking {
+            val client = FakeAlertsClient(FetchResult.Success(okStatus), FetchResult.Success(okCatalog))
+            val vm = newVm(client, linkedStore())
+            vm.refreshOnce()
+
+            client.status = FetchResult.Failure("boom")
+            vm.refreshOnce()
+            // Stale status stays on screen and the error surfaces.
+            assertEquals(okStatus, vm.state.value.status)
+            assertEquals("boom", vm.state.value.error)
+
+            client.status = FetchResult.Success(okStatus)
+            vm.refreshOnce()
+            assertNull(vm.state.value.error)
+        }
+
+    @Test
+    fun catalogFailureRaisesErrorButKeepsStatus() =
+        runBlocking {
+            // Status read succeeds, catalog read fails: the fresh status still
+            // updates, and the failure is surfaced rather than swallowed.
+            val client =
+                FakeAlertsClient(FetchResult.Success(okStatus), FetchResult.Failure("cat down"))
+            val vm = newVm(client, linkedStore())
+            vm.refreshOnce()
+
+            assertEquals(okStatus, vm.state.value.status)
+            assertEquals("cat down", vm.state.value.error)
+            assertTrue(vm.state.value.catalog.isEmpty())
+        }
+
+    @Test
+    fun statusUnauthorizedFlagsRevoked() =
+        runBlocking {
+            val client = FakeAlertsClient(FetchResult.Unauthorized, FetchResult.Success(okCatalog))
+            val vm = newVm(client, linkedStore())
+            vm.refreshOnce()
+            assertTrue(vm.state.value.revoked)
+            assertFalse(vm.state.value.loading)
+        }
+
+    @Test
+    fun catalogUnauthorizedAlsoFlagsRevoked() =
+        runBlocking {
+            val client = FakeAlertsClient(FetchResult.Success(okStatus), FetchResult.Unauthorized)
+            val vm = newVm(client, linkedStore())
+            vm.refreshOnce()
+            assertTrue(vm.state.value.revoked)
+        }
+
+    @Test
+    fun unreadableTokenFlagsRevokedWithoutCalling() =
+        runBlocking {
+            // Linked in name only (e.g. the Keystore key is gone): no request
+            // can succeed, so surface the same flag a remote revoke raises.
+            val client = FakeAlertsClient(FetchResult.Success(okStatus), FetchResult.Success(okCatalog))
+            val vm = newVm(client, newLinkStore())
+            vm.refreshOnce()
+            assertTrue(vm.state.value.revoked)
+            assertNull(client.lastToken)
+            assertEquals(0, client.statusCalls.get())
+            assertEquals(0, client.catalogCalls.get())
+        }
+}

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModelTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModelTest.kt
@@ -10,6 +10,7 @@ import com.hugalafutro.bellhop.data.FrontDeskClient
 import com.hugalafutro.bellhop.data.HealthStatus
 import com.hugalafutro.bellhop.data.LinkStore
 import com.hugalafutro.bellhop.data.MemberStatus
+import com.hugalafutro.bellhop.data.MemberTraffic
 import com.hugalafutro.bellhop.data.PairedDevice
 import com.hugalafutro.bellhop.data.SseMessage
 import kotlinx.coroutines.CoroutineScope
@@ -72,6 +73,20 @@ private class FakeFleetClient(
         fdUrl: String,
         token: String,
     ): FetchResult<AutoSyncConfig> = autoSyncResult
+
+    // Per-member traffic for the viewport-lazy sparkline. Records every id
+    // fetched so a test can prove only the visible members were requested.
+    var trafficResults: Map<String, FetchResult<MemberTraffic>> = emptyMap()
+    val trafficFetched = java.util.concurrent.CopyOnWriteArrayList<String>()
+
+    override suspend fun memberTraffic(
+        fdUrl: String,
+        token: String,
+        memberId: String,
+    ): FetchResult<MemberTraffic> {
+        trafficFetched.add(memberId)
+        return trafficResults[memberId] ?: FetchResult.Failure("no traffic for $memberId")
+    }
 
     override fun streamEvents(
         fdUrl: String,
@@ -163,6 +178,34 @@ class DashboardViewModelTest {
             client.membersResult = FetchResult.Success(listOf(member))
             vm.refreshOnce()
             assertNull(vm.state.value.error)
+        }
+
+    @Test
+    fun onlyVisibleMembersGetTrafficFetched() =
+        runBlocking {
+            // Two members, but only m1 is reported visible: the off-screen m2
+            // must never have its traffic requested (the whole point of the
+            // viewport-lazy fetch that keeps a big fleet cheap).
+            val m1 = member
+            val m2 = member.copy(id = "m2", name = "beta")
+            val client = FakeFleetClient(FetchResult.Success(listOf(m1, m2)))
+            client.trafficResults =
+                mapOf(
+                    "m1" to
+                        FetchResult.Success(
+                            MemberTraffic(memberId = "m1", reachable = true, totalRequests = 5),
+                        ),
+                )
+            val vm = DashboardViewModel(client, linkedStore(), "http://fd:1")
+            val job = launch { vm.state.collect {} }
+            withTimeout(5_000) { vm.state.first { it.members.size == 2 } }
+
+            vm.setVisibleMembers(listOf("m1"))
+            withTimeout(5_000) { vm.state.first { it.traffic.containsKey("m1") } }
+
+            assertTrue(client.trafficFetched.contains("m1"))
+            assertFalse(client.trafficFetched.contains("m2"))
+            job.cancel()
         }
 
     @Test

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/events/EventsScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/events/EventsScreenTest.kt
@@ -72,6 +72,45 @@ class EventsScreenTest {
     }
 
     @Test
+    fun clipboardTextJoinsHeaderMessageAndWho() {
+        val text =
+            eventClipboardText(
+                ev("e1", severity = "error", memberId = "m1").copy(message = "boom"),
+                memberName = "alpha",
+            )
+        val lines = text.split("\n")
+        assertEquals(3, lines.size)
+        assertTrue(lines[0].contains("[error]"))
+        assertTrue(lines[0].contains("health.down"))
+        assertEquals("boom", lines[1])
+        assertTrue(lines[2].contains("alpha"))
+    }
+
+    @Test
+    fun clipboardTextDropsBlankMemberLineTail() {
+        // A system event with no source and no member must not trail a dangling
+        // separator: only the header and message remain.
+        val bare =
+            ev("e2").copy(source = "", memberId = "", message = "just a message")
+        val lines = eventClipboardText(bare, memberName = null).split("\n")
+        assertEquals(2, lines.size)
+        assertEquals("just a message", lines[1])
+    }
+
+    @Test
+    fun copyPillTapDoesNotCrash() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                EventsScreen(onBack = {}, ui = loaded)
+            }
+        }
+        // The severity pill is the copy affordance; tapping it must stay on the
+        // event log (clipboard + toast are side effects we don't assert here).
+        composeTestRule.onNodeWithTag("event-sev-error", useUnmergedTree = true).performClick()
+        composeTestRule.onNodeWithTag("events-list").assertIsDisplayed()
+    }
+
+    @Test
     fun severityChipFiresCallback() {
         var picked = ""
         composeTestRule.setContent {

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreenTest.kt
@@ -1,9 +1,13 @@
 package com.hugalafutro.bellhop.ui.member
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToNode
+import com.hugalafutro.bellhop.data.FdEvent
 import com.hugalafutro.bellhop.data.FleetMember
 import com.hugalafutro.bellhop.data.HealthStatus
 import com.hugalafutro.bellhop.data.MemberStatus
@@ -67,18 +71,90 @@ class MemberDetailScreenTest {
     }
 
     @Test
-    fun drainedMemberShowsDrainedPill() {
+    fun downMemberShowsProbeErrorAndSyncMetadata() {
         composeTestRule.setContent {
             BellhopTheme {
                 MemberDetailScreen(
-                    member = member.copy(state = "drained"),
+                    member =
+                        member.copy(
+                            createdAt = "2026-06-28T17:53:27Z",
+                            lastConfigSyncAt = "2026-07-10T20:26:40Z",
+                            lastConfigSyncReason = "the primary's config changed",
+                            status =
+                                member.status.copy(
+                                    health =
+                                        HealthStatus(known = true, healthy = false, error = "connection refused"),
+                                    autoSyncVerifiedAt = "2026-07-12T13:42:17Z",
+                                ),
+                        ),
                     isPrimary = false,
                     onBack = {},
                     ui = MemberDetailUiState(loading = false, traffic = reachableTraffic),
                 )
             }
         }
-        composeTestRule.onNodeWithTag("member-detail-drained", useUnmergedTree = true).assertIsDisplayed()
+        // The detail surfaces the info the card can't: full probe error + sync
+        // provenance + in-sync heartbeat + when it was added. All four sit in the
+        // meta card, a LazyColumn item that may start below the fold — scroll it in.
+        for (
+        tag in
+        listOf(
+            "member-detail-down-reason",
+            "member-detail-synced",
+            "member-detail-verified",
+            "member-detail-created",
+        )
+        ) {
+            composeTestRule.onNodeWithTag("member-detail-list").performScrollToNode(hasTestTag(tag))
+            composeTestRule.onNodeWithTag(tag).assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun rendersMemberEventRows() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                MemberDetailScreen(
+                    member = member,
+                    isPrimary = false,
+                    onBack = {},
+                    ui =
+                        MemberDetailUiState(
+                            loading = false,
+                            traffic = reachableTraffic,
+                            events =
+                                listOf(
+                                    FdEvent(id = "e1", severity = "error", message = "down", memberId = "m1"),
+                                    FdEvent(id = "e2", severity = "success", message = "up", memberId = "m1"),
+                                ),
+                        ),
+                )
+            }
+        }
+        composeTestRule
+            .onNodeWithTag("member-detail-list")
+            .performScrollToNode(hasTestTag("member-event-row"))
+        assertTrue(
+            composeTestRule.onAllNodesWithTag("member-event-row").fetchSemanticsNodes().isNotEmpty(),
+        )
+    }
+
+    @Test
+    fun emptyEventsShowsEmptyState() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                MemberDetailScreen(
+                    member = member,
+                    isPrimary = false,
+                    onBack = {},
+                    ui = MemberDetailUiState(loading = false, traffic = reachableTraffic, events = emptyList()),
+                )
+            }
+        }
+        composeTestRule
+            .onNodeWithTag("member-detail-list")
+            .performScrollToNode(hasTestTag("member-detail-no-events"))
+        composeTestRule.onNodeWithTag("member-detail-no-events").assertIsDisplayed()
     }
 
     @Test

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailViewModelTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailViewModelTest.kt
@@ -1,7 +1,10 @@
 package com.hugalafutro.bellhop.ui.member
 
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import com.hugalafutro.bellhop.data.EventQuery
+import com.hugalafutro.bellhop.data.EventsResponse
 import com.hugalafutro.bellhop.data.FakeCipher
+import com.hugalafutro.bellhop.data.FdEvent
 import com.hugalafutro.bellhop.data.FetchResult
 import com.hugalafutro.bellhop.data.FrontDeskClient
 import com.hugalafutro.bellhop.data.LinkStore
@@ -32,13 +35,20 @@ import org.robolectric.RobolectricTestRunner
 import java.io.File
 import java.util.concurrent.atomic.AtomicInteger
 
-// FakeTrafficClient stubs the one read the detail ViewModel makes.
+// FakeTrafficClient stubs the two reads the detail ViewModel makes (traffic +
+// the member's recent events). Events default to a successful empty page so a
+// traffic-focused test needn't set them.
 private class FakeTrafficClient(
     var trafficResult: FetchResult<MemberTraffic>,
+    var eventsResult: FetchResult<EventsResponse> =
+        FetchResult.Success(
+            EventsResponse(events = emptyList(), total = 0),
+        ),
 ) : FrontDeskClient() {
     val trafficCalls = AtomicInteger(0)
     var lastToken: String? = null
     var lastMemberId: String? = null
+    var lastEventQuery: EventQuery? = null
 
     override suspend fun memberTraffic(
         fdUrl: String,
@@ -49,6 +59,15 @@ private class FakeTrafficClient(
         lastToken = token
         lastMemberId = memberId
         return trafficResult
+    }
+
+    override suspend fun events(
+        fdUrl: String,
+        token: String,
+        query: EventQuery,
+    ): FetchResult<EventsResponse> {
+        lastEventQuery = query
+        return eventsResult
     }
 }
 
@@ -111,6 +130,44 @@ class MemberDetailViewModelTest {
             assertFalse(s.revoked)
             assertEquals("tok-1", client.lastToken)
             assertEquals("m1", client.lastMemberId)
+        }
+
+    @Test
+    fun refreshPopulatesMemberEventsFilteredToTheMember() =
+        runBlocking {
+            val client =
+                FakeTrafficClient(
+                    FetchResult.Success(traffic),
+                    eventsResult =
+                        FetchResult.Success(
+                            EventsResponse(
+                                events =
+                                    listOf(
+                                        FdEvent(id = "e1", severity = "error", message = "down", memberId = "m1"),
+                                    ),
+                                total = 1,
+                            ),
+                        ),
+                )
+            val vm = MemberDetailViewModel(client, linkedStore(), "http://fd:1", "m1")
+
+            vm.refreshOnce()
+
+            assertEquals(listOf("e1"), vm.state.value.events.map { it.id })
+            // The events read is scoped to this member so the detail shows only
+            // its own history, not the whole fleet's log.
+            assertEquals("m1", client.lastEventQuery?.memberId)
+            assertEquals(MemberDetailViewModel.EVENTS_LIMIT, client.lastEventQuery?.limit)
+        }
+
+    @Test
+    fun eventsUnauthorizedFlagsRevoked() =
+        runBlocking {
+            val client =
+                FakeTrafficClient(FetchResult.Success(traffic), eventsResult = FetchResult.Unauthorized)
+            val vm = MemberDetailViewModel(client, linkedStore(), "http://fd:1", "m1")
+            vm.refreshOnce()
+            assertTrue(vm.state.value.revoked)
         }
 
     @Test


### PR DESCRIPTION
Phase A2 UI work for the Bellhop Android companion. Three concerns, one commit each (plus a review-fix commit), reviewed and live-verified on the emulator against the homelab-prod Front Desk.

## 1. Compact event filters + tap-to-copy + semantic severity colors
- Events filter chips are now an equal-weight segmented row of a compact `FilterPill` (in `FleetUi`) so severity/range fit one phone line instead of wrapping or scrolling off-screen.
- Tapping an event's severity pill copies the whole event to the clipboard with a toast.
- Severity badges recolored to conventional red/orange/blue/green (`Color.kt`) instead of the brand's warm roles, so a status level reads unambiguously. Shared via `severityColors`.

## 2. Read-only Alerts screen
- New monitor-tier Alerts screen: Front Desk's outbound-notifier delivery health + the catalog of alertable events, via new `FrontDeskClient.alertStatus` / `alertCatalog` (`GET /api/alert/status`, `/api/alert/events`).
- Which events are enabled lives in admin settings a device token cannot read, so the catalog is a read-only reference pointing back to Front Desk. Reached from a new dashboard bell icon.

## 3. Card sparklines, viewport-lazy traffic, and member detail rework
- Each dashboard card gets an inline last-hour traffic sparkline; the URL is its own tap target opening an "open externally" confirm dialog that hands off to `ACTION_VIEW`.
- Traffic is fetched only for members currently on screen (`setVisibleMembers` from the LazyColumn drives a debounced, TTL-cached, in-flight-deduped loop), so a large fleet never fans out one traffic call per member. The eventual server-side `/api/fleet/usage` rollup (plan A5) can swap in as the one source without a UI change.
- Member detail stops repeating the card: minimal header, the full traffic graph, the info the card has no room for (full probe error, config-sync provenance, in-sync heartbeat, added-at), and the member's own recent event log.

## Verification
- ~124 unit tests, ktlint, Android Lint, and assembleDebug all green.
- Code-reviewed (no material bugs); the two efficiency concerns raised became the review-fix commit.
- Live-verified on the emulator (resized to a realistic 1080x2412 @ 420 dpi phone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)