### PR TITLE
feat(bellhop): biometric app lock, Settings screen, and a de-pilled event log

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -65,6 +65,9 @@ dependencies {
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
+    // ProcessLifecycleOwner drives the app-lock idle timer off the whole
+    // process's foreground, not any single Activity's (plan section 3.1).
+    implementation(libs.androidx.lifecycle.process)
     implementation(libs.androidx.compose.ui)
     implementation(libs.androidx.compose.material3)
     // The back-arrow vector. material3 currently drags this in transitively,
@@ -75,6 +78,11 @@ dependencies {
     implementation(libs.okhttp.sse)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.androidx.datastore.preferences)
+    // BiometricPrompt gates local access to the stored token; its device-credential
+    // fallback (pattern/PIN) needs no fingerprint sensor. It requires a
+    // FragmentActivity host, hence the explicit fragment dependency (plan 3.1/5.4).
+    implementation(libs.androidx.biometric)
+    implementation(libs.androidx.fragment)
     // QR scan for pairing: ZXing (Apache-2.0, no Google Play Services / Firebase),
     // in keeping with the plan's FOSS stance. Its CaptureActivity requests the
     // CAMERA permission at runtime, so nothing is asked until Scan is tapped.

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -9,6 +9,11 @@
          never a hard requirement). Declared not-required so devices without a
          camera can still install and pair by pasting. -->
     <uses-permission android:name="android.permission.CAMERA" />
+
+    <!-- USE_BIOMETRIC backs the optional app lock (plan section 3.1). The lock
+         is a local access gate the user turns on in Settings; when no biometric
+         or device credential is enrolled the gate simply can't engage. -->
+    <uses-permission android:name="android.permission.USE_BIOMETRIC" />
     <uses-feature
         android:name="android.hardware.camera"
         android:required="false" />

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
@@ -1,11 +1,15 @@
 package com.hugalafutro.bellhop
 
+import android.content.Context
+import android.os.Build
 import android.os.Bundle
-import androidx.activity.ComponentActivity
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.biometric.BiometricManager
+import androidx.biometric.BiometricPrompt
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -14,26 +18,41 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.core.content.ContextCompat
+import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.hugalafutro.bellhop.data.FrontDeskClient
 import com.hugalafutro.bellhop.data.LinkState
 import com.hugalafutro.bellhop.data.LinkStore
+import com.hugalafutro.bellhop.data.LockConfig
+import com.hugalafutro.bellhop.data.LockStore
+import com.hugalafutro.bellhop.data.LockTimeout
+import com.hugalafutro.bellhop.data.shouldLock
 import com.hugalafutro.bellhop.ui.alerts.AlertsScreen
 import com.hugalafutro.bellhop.ui.alerts.AlertsViewModel
 import com.hugalafutro.bellhop.ui.dashboard.DashboardScreen
 import com.hugalafutro.bellhop.ui.dashboard.DashboardViewModel
 import com.hugalafutro.bellhop.ui.events.EventsScreen
 import com.hugalafutro.bellhop.ui.events.EventsViewModel
+import com.hugalafutro.bellhop.ui.lock.LockScreen
 import com.hugalafutro.bellhop.ui.member.MemberDetailScreen
 import com.hugalafutro.bellhop.ui.member.MemberDetailViewModel
 import com.hugalafutro.bellhop.ui.pairing.PairingScreen
 import com.hugalafutro.bellhop.ui.pairing.PairingViewModel
+import com.hugalafutro.bellhop.ui.settings.SettingsScreen
 import com.hugalafutro.bellhop.ui.theme.BellhopTheme
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
-class MainActivity : ComponentActivity() {
+// FragmentActivity (not plain ComponentActivity) because BiometricPrompt hosts
+// its sheet on a FragmentManager; Compose still drives the whole UI.
+class MainActivity : FragmentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
@@ -45,17 +64,76 @@ class MainActivity : ComponentActivity() {
     }
 }
 
+// appLockAuthenticators is the authenticator set the app lock prompts with. The
+// STRONG|DEVICE_CREDENTIAL combination isn't supported below API 30, so fall back
+// to WEAK|DEVICE_CREDENTIAL there (no CryptoObject is used, so Class 2 is fine).
+private fun appLockAuthenticators(): Int =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        BiometricManager.Authenticators.BIOMETRIC_STRONG or BiometricManager.Authenticators.DEVICE_CREDENTIAL
+    } else {
+        BiometricManager.Authenticators.BIOMETRIC_WEAK or BiometricManager.Authenticators.DEVICE_CREDENTIAL
+    }
+
+/** canAppLock reports whether a biometric or device credential can gate the app. */
+private fun canAppLock(context: Context): Boolean =
+    BiometricManager.from(context).canAuthenticate(appLockAuthenticators()) == BiometricManager.BIOMETRIC_SUCCESS
+
+/**
+ * promptAppUnlock shows the BiometricPrompt for the ambient app lock. It only
+ * gates local access (the token at rest is Keystore-wrapped regardless), so if
+ * no authenticator can be presented it degrades to success rather than stranding
+ * the user behind an un-openable lock. A cancel or failure calls neither branch;
+ * the caller stays locked and the lock screen offers a retry.
+ */
+private fun FragmentActivity.promptAppUnlock(
+    title: String,
+    subtitle: String,
+    onSuccess: () -> Unit,
+) {
+    val authenticators = appLockAuthenticators()
+    if (BiometricManager.from(this).canAuthenticate(authenticators) != BiometricManager.BIOMETRIC_SUCCESS) {
+        onSuccess()
+        return
+    }
+    val prompt =
+        BiometricPrompt(
+            this,
+            ContextCompat.getMainExecutor(this),
+            object : BiometricPrompt.AuthenticationCallback() {
+                override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
+                    onSuccess()
+                }
+            },
+        )
+    prompt.authenticate(
+        BiometricPrompt.PromptInfo
+            .Builder()
+            .setTitle(title)
+            .setSubtitle(subtitle)
+            .setAllowedAuthenticators(authenticators)
+            .build(),
+    )
+}
+
 /**
  * BellhopApp is the top-level gate: it observes the persisted link and shows the
  * pairing screen when unlinked or the dashboard when linked. Loading renders
- * nothing so neither screen flashes before the link is read back from disk.
+ * nothing so neither screen flashes before the link is read back from disk. When
+ * linked, an enabled app lock covers the fleet UI until the user authenticates.
  */
 @Composable
 fun BellhopApp() {
     val context = LocalContext.current
+    val activity = context as? FragmentActivity
     val linkStore = remember { LinkStore.create(context) }
+    val lockStore = remember { LockStore.create(context) }
     val client = remember { FrontDeskClient() }
     val linkState by linkStore.state.collectAsStateWithLifecycle(initialValue = LinkState.Loading)
+    val lockConfig by
+        lockStore.config.collectAsStateWithLifecycle(
+            initialValue = LockConfig(enabled = false, timeoutMs = LockTimeout.DEFAULT.millis),
+        )
+    val lockAvailable = remember(activity) { activity != null && canAppLock(activity) }
     val scope = rememberCoroutineScope()
     var unlinking by remember { mutableStateOf(false) }
     var unlinkFailed by remember { mutableStateOf(false) }
@@ -65,10 +143,60 @@ fun BellhopApp() {
     // forever) and just re-attempt the clear. Reset on return to Unlinked.
     var revokedRemotely by remember { mutableStateOf(false) }
 
+    // App-lock gate. locked survives process death (rememberSaveable) so a killed
+    // app comes back locked; lockEvaluated defers the linked UI on cold start
+    // until the idle window has been checked, so no fleet data flashes first.
+    var locked by rememberSaveable { mutableStateOf(false) }
+    var lockEvaluated by rememberSaveable { mutableStateOf(false) }
+    val unlockTitle = stringResource(R.string.lock_prompt_title)
+    val unlockSubtitle = stringResource(R.string.lock_prompt_subtitle)
+
+    fun requestUnlock() {
+        val act = activity
+        if (act == null) {
+            locked = false
+        } else {
+            act.promptAppUnlock(unlockTitle, unlockSubtitle) { locked = false }
+        }
+    }
+
+    // Cold-start decision: a freshly added lifecycle observer is not replayed the
+    // current state, and the process is already foregrounded when we compose, so
+    // the first gate check has to happen here rather than on ON_START.
+    LaunchedEffect(Unit) {
+        val snap = lockStore.snapshot()
+        if (shouldLock(snap.config, snap.lastForegroundExit, System.currentTimeMillis())) locked = true
+        lockEvaluated = true
+    }
+
+    // Foreground lifecycle: stamp the exit when Bellhop is backgrounded and
+    // re-evaluate the gate when it returns. ProcessLifecycleOwner scopes this to
+    // the whole process's foreground, not any one Activity (plan section 3.1).
+    DisposableEffect(lockStore) {
+        val owner = ProcessLifecycleOwner.get()
+        val observer =
+            LifecycleEventObserver { _, event ->
+                when (event) {
+                    Lifecycle.Event.ON_STOP -> scope.launch { lockStore.stampExit(System.currentTimeMillis()) }
+                    Lifecycle.Event.ON_START ->
+                        scope.launch {
+                            val snap = lockStore.snapshot()
+                            if (shouldLock(snap.config, snap.lastForegroundExit, System.currentTimeMillis())) {
+                                locked = true
+                            }
+                        }
+                    else -> Unit
+                }
+            }
+        owner.lifecycle.addObserver(observer)
+        onDispose { owner.lifecycle.removeObserver(observer) }
+    }
+
     // Revoke the device token on Front Desk, THEN clear the local link. Only a
     // confirmed remote revoke clears locally: if the DELETE can't reach Front
     // Desk (or is refused) we keep the link and surface a retry, so a dropped
-    // request can't silently orphan the device row on Front Desk.
+    // request can't silently orphan the device row on Front Desk. On success the
+    // lock policy is cleared too, so a re-pair starts from lock-off.
     fun runUnlink(fdUrl: String) {
         if (unlinking) return
         unlinking = true
@@ -104,6 +232,7 @@ fun BellhopApp() {
                     // retry skips the now-dead Front Desk call and only re-clears.
                     revokedRemotely = true
                     linkStore.clear()
+                    lockStore.clear()
                 } else {
                     unlinkFailed = true
                 }
@@ -132,6 +261,7 @@ fun BellhopApp() {
         scope.launch {
             try {
                 linkStore.clear()
+                lockStore.clear()
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Throwable) {
@@ -155,6 +285,7 @@ fun BellhopApp() {
                 unlinking = false
                 unlinkFailed = false
                 revokedRemotely = false
+                locked = false
                 vm.reset()
             }
             val ui by vm.state.collectAsStateWithLifecycle()
@@ -167,102 +298,163 @@ fun BellhopApp() {
             )
         }
         is LinkState.Linked -> {
-            // Keyed by the full pairing (FD URL + deviceId): the Activity-scoped
-            // ViewModel would otherwise survive an unlink and keep polling the OLD
-            // Front Desk after a relink (same trap PairingViewModel.reset fixes).
-            // deviceId alone is a UUID minted by the FD, but including the URL
-            // costs nothing and holds even if some FD echoes a chosen id back.
-            val dashVm: DashboardViewModel =
-                viewModel(
-                    key = "dashboard-${state.fdUrl}|${state.deviceId}",
-                    factory = DashboardViewModel.Factory(client, linkStore, state.fdUrl),
-                )
-            val ui by dashVm.state.collectAsStateWithLifecycle()
-
-            // Which member's detail is open, if any. Saveable so it survives
-            // rotation/process death; keyed on the pairing so a relink lands
-            // back on the new Front Desk's dashboard, not a stale detail.
-            var selectedMemberId by rememberSaveable(state.fdUrl, state.deviceId) {
-                mutableStateOf<String?>(null)
-            }
-            // Whether the event log is open. Same saveable/keying rationale.
-            var showEvents by rememberSaveable(state.fdUrl, state.deviceId) {
-                mutableStateOf(false)
-            }
-            // Whether the alerts screen is open. Same saveable/keying rationale.
-            var showAlerts by rememberSaveable(state.fdUrl, state.deviceId) {
-                mutableStateOf(false)
-            }
-            val selected = ui.members.find { it.id == selectedMemberId }
-            // The member left the fleet while its detail was open: drop the
-            // selection (once the list has actually loaded) so the detail
-            // doesn't silently reopen if the same id ever reappears.
-            LaunchedEffect(selectedMemberId, selected, ui.loading) {
-                if (selectedMemberId != null && selected == null && !ui.loading) {
-                    selectedMemberId = null
-                }
-            }
-
-            if (showEvents) {
-                BackHandler { showEvents = false }
-                // Keyed like the dashboard VM so a relink gets a fresh log.
-                val eventsVm: EventsViewModel =
-                    viewModel(
-                        key = "events-${state.fdUrl}|${state.deviceId}",
-                        factory = EventsViewModel.Factory(client, linkStore, state.fdUrl),
+            when {
+                // Deciding whether the idle window has lapsed; render nothing so no
+                // fleet data flashes before the lock (if any) engages.
+                !lockEvaluated -> Unit
+                locked -> LockScreen(onUnlock = { requestUnlock() })
+                else ->
+                    LinkedContent(
+                        state = state,
+                        client = client,
+                        linkStore = linkStore,
+                        lockStore = lockStore,
+                        lockConfig = lockConfig,
+                        lockAvailable = lockAvailable,
+                        scope = scope,
+                        unlinking = unlinking,
+                        unlinkFailed = unlinkFailed,
+                        onDismissUnlinkError = { unlinkFailed = false },
+                        onUnlink = { runUnlink(state.fdUrl) },
+                        onForceUnlink = { forceUnlink() },
                     )
-                val eventsUi by eventsVm.state.collectAsStateWithLifecycle()
-                EventsScreen(
-                    onBack = { showEvents = false },
-                    ui = eventsUi,
-                    // Member names ride the dashboard's live state; an unknown
-                    // id (member since removed) falls back to the raw id.
-                    memberNames = ui.members.associate { it.id to it.name },
-                    onSeverity = eventsVm::setSeverity,
-                    onRange = eventsVm::setRange,
-                    onLoadMore = eventsVm::loadMore,
-                )
-            } else if (showAlerts) {
-                BackHandler { showAlerts = false }
-                // Keyed like the dashboard VM so a relink gets a fresh status.
-                val alertsVm: AlertsViewModel =
-                    viewModel(
-                        key = "alerts-${state.fdUrl}|${state.deviceId}",
-                        factory = AlertsViewModel.Factory(client, linkStore, state.fdUrl),
-                    )
-                val alertsUi by alertsVm.state.collectAsStateWithLifecycle()
-                AlertsScreen(onBack = { showAlerts = false }, ui = alertsUi)
-            } else if (selected != null) {
-                BackHandler { selectedMemberId = null }
-                // Keyed like the dashboard VM, plus the member id, so flipping
-                // between members never shows another member's series.
-                val detailVm: MemberDetailViewModel =
-                    viewModel(
-                        key = "member-${state.fdUrl}|${state.deviceId}|${selected.id}",
-                        factory = MemberDetailViewModel.Factory(client, linkStore, state.fdUrl, selected.id),
-                    )
-                val detailUi by detailVm.state.collectAsStateWithLifecycle()
-                MemberDetailScreen(
-                    member = selected,
-                    isPrimary = selected.id == ui.primaryId,
-                    ui = detailUi,
-                    onBack = { selectedMemberId = null },
-                )
-            } else {
-                DashboardScreen(
-                    link = state,
-                    ui = ui,
-                    unlinking = unlinking,
-                    unlinkFailed = unlinkFailed,
-                    onUnlink = { runUnlink(state.fdUrl) },
-                    onDismissUnlinkError = { unlinkFailed = false },
-                    onForceUnlink = { forceUnlink() },
-                    onMemberClick = { selectedMemberId = it },
-                    onEventsClick = { showEvents = true },
-                    onAlertsClick = { showAlerts = true },
-                    onVisibleMembers = dashVm::setVisibleMembers,
-                )
             }
         }
+    }
+}
+
+/**
+ * LinkedContent is the whole linked-state surface: dashboard plus the screens it
+ * pushes (events, alerts, member detail, settings). It is only shown once the
+ * app lock has cleared, so nothing here is visible while locked.
+ */
+@Composable
+private fun LinkedContent(
+    state: LinkState.Linked,
+    client: FrontDeskClient,
+    linkStore: LinkStore,
+    lockStore: LockStore,
+    lockConfig: LockConfig,
+    lockAvailable: Boolean,
+    scope: CoroutineScope,
+    unlinking: Boolean,
+    unlinkFailed: Boolean,
+    onDismissUnlinkError: () -> Unit,
+    onUnlink: () -> Unit,
+    onForceUnlink: () -> Unit,
+) {
+    // Keyed by the full pairing (FD URL + deviceId): the Activity-scoped
+    // ViewModel would otherwise survive an unlink and keep polling the OLD
+    // Front Desk after a relink (same trap PairingViewModel.reset fixes).
+    // deviceId alone is a UUID minted by the FD, but including the URL
+    // costs nothing and holds even if some FD echoes a chosen id back.
+    val dashVm: DashboardViewModel =
+        viewModel(
+            key = "dashboard-${state.fdUrl}|${state.deviceId}",
+            factory = DashboardViewModel.Factory(client, linkStore, state.fdUrl),
+        )
+    val ui by dashVm.state.collectAsStateWithLifecycle()
+
+    // Which member's detail is open, if any. Saveable so it survives
+    // rotation/process death; keyed on the pairing so a relink lands
+    // back on the new Front Desk's dashboard, not a stale detail.
+    var selectedMemberId by rememberSaveable(state.fdUrl, state.deviceId) {
+        mutableStateOf<String?>(null)
+    }
+    // Whether the event log is open. Same saveable/keying rationale.
+    var showEvents by rememberSaveable(state.fdUrl, state.deviceId) {
+        mutableStateOf(false)
+    }
+    // Whether the alerts screen is open. Same saveable/keying rationale.
+    var showAlerts by rememberSaveable(state.fdUrl, state.deviceId) {
+        mutableStateOf(false)
+    }
+    // Whether the settings screen is open. Same saveable/keying rationale.
+    var showSettings by rememberSaveable(state.fdUrl, state.deviceId) {
+        mutableStateOf(false)
+    }
+    val selected = ui.members.find { it.id == selectedMemberId }
+    // The member left the fleet while its detail was open: drop the
+    // selection (once the list has actually loaded) so the detail
+    // doesn't silently reopen if the same id ever reappears.
+    LaunchedEffect(selectedMemberId, selected, ui.loading) {
+        if (selectedMemberId != null && selected == null && !ui.loading) {
+            selectedMemberId = null
+        }
+    }
+
+    if (showEvents) {
+        BackHandler { showEvents = false }
+        // Keyed like the dashboard VM so a relink gets a fresh log.
+        val eventsVm: EventsViewModel =
+            viewModel(
+                key = "events-${state.fdUrl}|${state.deviceId}",
+                factory = EventsViewModel.Factory(client, linkStore, state.fdUrl),
+            )
+        val eventsUi by eventsVm.state.collectAsStateWithLifecycle()
+        EventsScreen(
+            onBack = { showEvents = false },
+            ui = eventsUi,
+            // Member names ride the dashboard's live state; an unknown
+            // id (member since removed) falls back to the raw id.
+            memberNames = ui.members.associate { it.id to it.name },
+            onSeverity = eventsVm::setSeverity,
+            onRange = eventsVm::setRange,
+            onLoadMore = eventsVm::loadMore,
+        )
+    } else if (showAlerts) {
+        // Alerts can be reached from the dashboard bell or from Settings; back
+        // returns to whichever is still open underneath (Settings if it was).
+        BackHandler { showAlerts = false }
+        // Keyed like the dashboard VM so a relink gets a fresh status.
+        val alertsVm: AlertsViewModel =
+            viewModel(
+                key = "alerts-${state.fdUrl}|${state.deviceId}",
+                factory = AlertsViewModel.Factory(client, linkStore, state.fdUrl),
+            )
+        val alertsUi by alertsVm.state.collectAsStateWithLifecycle()
+        AlertsScreen(onBack = { showAlerts = false }, ui = alertsUi)
+    } else if (showSettings) {
+        BackHandler { showSettings = false }
+        SettingsScreen(
+            link = state,
+            lockConfig = lockConfig,
+            lockAvailable = lockAvailable,
+            onBack = { showSettings = false },
+            onToggleLock = { enabled -> scope.launch { lockStore.setEnabled(enabled) } },
+            onSelectTimeout = { option -> scope.launch { lockStore.setTimeout(option.millis) } },
+            onAlertsClick = { showAlerts = true },
+            onUnlink = onUnlink,
+            unlinking = unlinking,
+            unlinkFailed = unlinkFailed,
+            onDismissUnlinkError = onDismissUnlinkError,
+            onForceUnlink = onForceUnlink,
+        )
+    } else if (selected != null) {
+        BackHandler { selectedMemberId = null }
+        // Keyed like the dashboard VM, plus the member id, so flipping
+        // between members never shows another member's series.
+        val detailVm: MemberDetailViewModel =
+            viewModel(
+                key = "member-${state.fdUrl}|${state.deviceId}|${selected.id}",
+                factory = MemberDetailViewModel.Factory(client, linkStore, state.fdUrl, selected.id),
+            )
+        val detailUi by detailVm.state.collectAsStateWithLifecycle()
+        MemberDetailScreen(
+            member = selected,
+            isPrimary = selected.id == ui.primaryId,
+            ui = detailUi,
+            onBack = { selectedMemberId = null },
+        )
+    } else {
+        DashboardScreen(
+            link = state,
+            ui = ui,
+            onMemberClick = { selectedMemberId = it },
+            onEventsClick = { showEvents = true },
+            onAlertsClick = { showAlerts = true },
+            onSettingsClick = { showSettings = true },
+            onVisibleMembers = dashVm::setVisibleMembers,
+        )
     }
 }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
@@ -101,6 +101,11 @@ private fun FragmentActivity.promptAppUnlock(
             ContextCompat.getMainExecutor(this),
             object : BiometricPrompt.AuthenticationCallback() {
                 override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
+                    // No CryptoObject is bound to the result on purpose: this is a
+                    // UI-only gate. The token at rest is Keystore-wrapped regardless
+                    // and the gate degrades open when no credential is enrolled, so
+                    // tying decryption to the biometric result would misstate the
+                    // security model. (CodeQL java/android/insecure-local-authentication.)
                     onSuccess()
                 }
             },

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/AppLock.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/AppLock.kt
@@ -1,0 +1,49 @@
+package com.hugalafutro.bellhop.data
+
+/**
+ * LockConfig is the app-lock policy the user controls in Settings: whether the
+ * lock is on at all, and the idle grace window (how long Bellhop may sit in the
+ * background before the next foreground demands a fresh unlock). The window is
+ * measured from when Bellhop last held the foreground, not from device-screen
+ * lock, so unrelated screen unlocks never extend it (plan section 3.1).
+ */
+data class LockConfig(
+    val enabled: Boolean,
+    val timeoutMs: Long,
+)
+
+/**
+ * LockTimeout is the fixed set of grace windows the Settings picker offers. The
+ * millis are the on-disk representation, so an unknown stored value (e.g. a
+ * future build's option this build doesn't know) falls back to [DEFAULT] rather
+ * than crashing the picker.
+ */
+enum class LockTimeout(
+    val millis: Long,
+) {
+    IMMEDIATELY(0L),
+    ONE_MINUTE(60_000L),
+    FIVE_MINUTES(5 * 60_000L),
+    FIFTEEN_MINUTES(15 * 60_000L),
+    THIRTY_MINUTES(30 * 60_000L),
+    ONE_HOUR(60 * 60_000L),
+    ;
+
+    companion object {
+        val DEFAULT = THIRTY_MINUTES
+
+        fun fromMillis(millis: Long): LockTimeout = entries.firstOrNull { it.millis == millis } ?: DEFAULT
+    }
+}
+
+/**
+ * shouldLock is the pure gate decision: an enabled lock trips once more than
+ * [LockConfig.timeoutMs] has elapsed since Bellhop last held the foreground
+ * ([lastForegroundExit]). A disabled lock never trips. Kept side-effect-free so
+ * the timing rule is unit-testable without a real clock or lifecycle.
+ */
+fun shouldLock(
+    config: LockConfig,
+    lastForegroundExit: Long,
+    now: Long,
+): Boolean = config.enabled && now - lastForegroundExit > config.timeoutMs

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/LockStore.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/LockStore.kt
@@ -1,0 +1,89 @@
+package com.hugalafutro.bellhop.data
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+
+/**
+ * LockSnapshot is a one-shot read of everything the gate decision needs: the
+ * current [LockConfig] plus the persisted last-foreground-exit stamp. The stamp
+ * is read on demand rather than carried on the config flow because it churns on
+ * every background, while the config only changes when the user edits Settings.
+ */
+data class LockSnapshot(
+    val config: LockConfig,
+    val lastForegroundExit: Long,
+)
+
+// Separate from the link DataStore so lock policy and the token record have
+// independent lifecycles; unlink clears both explicitly.
+private val Context.lockDataStore: DataStore<Preferences> by
+    preferencesDataStore(name = "bellhop_lock")
+
+/**
+ * LockStore persists the app-lock policy and the last-foreground-exit timestamp
+ * that the idle timer measures from. The stamp is deliberately in DataStore, not
+ * in memory, so it survives OS process death: a cold start after a long absence
+ * still sees the stale exit and locks (plan section 3.1).
+ */
+class LockStore(
+    private val dataStore: DataStore<Preferences>,
+) {
+    /** config emits the policy, defaulting to disabled with a 30-minute window. */
+    val config: Flow<LockConfig> = dataStore.data.map { it.toConfig() }
+
+    /** snapshot reads the policy and exit stamp together for a gate decision. */
+    suspend fun snapshot(): LockSnapshot {
+        val prefs = dataStore.data.first()
+        return LockSnapshot(prefs.toConfig(), prefs[LAST_EXIT] ?: 0L)
+    }
+
+    /**
+     * setEnabled toggles the lock. Enabling stamps the exit to [now] so a policy
+     * turned on while foregrounded can't retroactively lock from an old exit the
+     * next time the gate is evaluated; the real exit is restamped on background.
+     */
+    suspend fun setEnabled(
+        enabled: Boolean,
+        now: Long = System.currentTimeMillis(),
+    ) {
+        dataStore.edit { prefs ->
+            prefs[ENABLED] = enabled
+            if (enabled) prefs[LAST_EXIT] = now
+        }
+    }
+
+    suspend fun setTimeout(timeoutMs: Long) {
+        dataStore.edit { it[TIMEOUT] = timeoutMs }
+    }
+
+    /** stampExit records when Bellhop last left the foreground. */
+    suspend fun stampExit(now: Long) {
+        dataStore.edit { it[LAST_EXIT] = now }
+    }
+
+    suspend fun clear() {
+        dataStore.edit { it.clear() }
+    }
+
+    private fun Preferences.toConfig(): LockConfig =
+        LockConfig(
+            enabled = this[ENABLED] ?: false,
+            timeoutMs = this[TIMEOUT] ?: LockTimeout.DEFAULT.millis,
+        )
+
+    companion object {
+        fun create(context: Context): LockStore = LockStore(context.applicationContext.lockDataStore)
+
+        private val ENABLED = booleanPreferencesKey("enabled")
+        private val TIMEOUT = longPreferencesKey("timeout_ms")
+        private val LAST_EXIT = longPreferencesKey("last_foreground_exit")
+    }
+}

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/FleetUi.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/FleetUi.kt
@@ -1,5 +1,6 @@
 package com.hugalafutro.bellhop.ui.common
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -100,8 +101,12 @@ internal fun FilterPill(
     tag: String,
     modifier: Modifier = Modifier,
 ) {
-    val container =
-        if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surfaceVariant
+    // Selected fills with the brass accent; unselected is an outlined toggle
+    // (transparent with a hairline border) rather than a grey fill, so the set
+    // reads as an interactive segmented control instead of another static badge —
+    // the severity badges on log rows are rails, not pills, so pills now always
+    // mean "tap me".
+    val container = if (selected) MaterialTheme.colorScheme.primary else Color.Transparent
     val content =
         if (selected) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurfaceVariant
     Surface(
@@ -109,6 +114,7 @@ internal fun FilterPill(
         color = container,
         contentColor = content,
         shape = RoundedCornerShape(999.dp),
+        border = if (selected) null else BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
         modifier = modifier.testTag(tag),
     ) {
         Text(

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
@@ -64,26 +65,22 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 
 /**
  * DashboardScreen is the linked-state home: the fleet's members with their live
- * health, plus Unlink. Member data arrives via [DashboardViewModel]'s poll; a
- * refresh failure keeps the stale list visible under an error banner.
+ * health. Member data arrives via [DashboardViewModel]'s poll; a refresh failure
+ * keeps the stale list visible under an error banner. Settings (link status, app
+ * lock, Unlink) lives behind the gear; the bell into Alerts appears only when a
+ * member is down.
  */
 @Composable
 fun DashboardScreen(
     link: LinkState.Linked,
-    onUnlink: () -> Unit,
-    unlinking: Boolean,
     modifier: Modifier = Modifier,
     ui: DashboardUiState = DashboardUiState(),
-    unlinkFailed: Boolean = false,
-    onDismissUnlinkError: () -> Unit = {},
-    onForceUnlink: () -> Unit = {},
     onMemberClick: (String) -> Unit = {},
     onEventsClick: () -> Unit = {},
     onAlertsClick: () -> Unit = {},
+    onSettingsClick: () -> Unit = {},
     onVisibleMembers: (List<String>) -> Unit = {},
 ) {
-    var confirmUnlink by remember { mutableStateOf(false) }
-
     // Which member's URL the "open externally" popup is showing, if any. Tapping
     // a card's address opens this confirm dialog rather than firing an intent on
     // the same tap that could also be a mis-tap on the card itself.
@@ -127,75 +124,6 @@ fun DashboardScreen(
         )
     }
 
-    // The remote revoke couldn't reach Front Desk (or the token can't be read to
-    // revoke at all). The device is still linked and nothing was cleared, so
-    // offer a retry AND an "unlink anyway" escape: with a dead/unreachable token a
-    // retry can loop forever, so the operator needs a way to clear locally (and is
-    // told to revoke on Front Desk) rather than being stranded on this screen.
-    if (unlinkFailed) {
-        AlertDialog(
-            onDismissRequest = onDismissUnlinkError,
-            title = { Text(stringResource(R.string.dashboard_unlink_failed_title)) },
-            text = { Text(stringResource(R.string.dashboard_unlink_failed_body)) },
-            confirmButton = {
-                TextButton(
-                    enabled = !unlinking,
-                    onClick = {
-                        onDismissUnlinkError()
-                        onUnlink()
-                    },
-                    modifier = Modifier.testTag("dashboard-unlink-retry"),
-                ) {
-                    Text(stringResource(R.string.dashboard_unlink_retry))
-                }
-            },
-            dismissButton = {
-                TextButton(
-                    enabled = !unlinking,
-                    onClick = {
-                        onDismissUnlinkError()
-                        onForceUnlink()
-                    },
-                    modifier = Modifier.testTag("dashboard-unlink-force"),
-                ) {
-                    Text(stringResource(R.string.dashboard_unlink_force))
-                }
-            },
-        )
-    }
-
-    if (confirmUnlink) {
-        AlertDialog(
-            onDismissRequest = { confirmUnlink = false },
-            title = { Text(stringResource(R.string.dashboard_unlink_confirm_title)) },
-            text = {
-                Text(
-                    stringResource(
-                        R.string.dashboard_unlink_confirm_body,
-                        link.fdName.ifBlank { link.fdUrl },
-                    ),
-                )
-            },
-            confirmButton = {
-                TextButton(
-                    enabled = !unlinking,
-                    onClick = {
-                        confirmUnlink = false
-                        onUnlink()
-                    },
-                    modifier = Modifier.testTag("dashboard-unlink-confirm"),
-                ) {
-                    Text(stringResource(R.string.dashboard_unlink))
-                }
-            },
-            dismissButton = {
-                TextButton(onClick = { confirmUnlink = false }) {
-                    Text(stringResource(R.string.common_cancel))
-                }
-            },
-        )
-    }
-
     Scaffold(modifier = modifier.fillMaxSize()) { innerPadding ->
         Column(
             modifier =
@@ -205,23 +133,19 @@ fun DashboardScreen(
                     .padding(horizontal = 16.dp),
         ) {
             Spacer(modifier = Modifier.height(8.dp))
+            // A member being down is the "something needs attention" signal, so the
+            // bell into Alerts appears only then; the event log and the gear
+            // (Settings, which also reaches Alerts when all is green) are always on.
+            val hasAlert = ui.members.any { it.status.health.known && !it.status.health.healthy }
             Row(verticalAlignment = Alignment.CenterVertically) {
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        text = link.fdName.ifBlank { link.fdUrl },
-                        style = MaterialTheme.typography.titleLarge,
-                        color = MaterialTheme.colorScheme.primary,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                        modifier = Modifier.testTag("dashboard-title"),
-                    )
-                    Text(
-                        text = stringResource(R.string.dashboard_linked_as, link.label, link.role),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.testTag("dashboard-linked"),
-                    )
-                }
+                Text(
+                    text = link.fdName.ifBlank { link.fdUrl },
+                    style = MaterialTheme.typography.titleLarge,
+                    color = MaterialTheme.colorScheme.primary,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f).testTag("dashboard-title"),
+                )
                 IconButton(
                     onClick = onEventsClick,
                     modifier = Modifier.testTag("dashboard-events"),
@@ -231,21 +155,26 @@ fun DashboardScreen(
                         contentDescription = stringResource(R.string.events_open),
                     )
                 }
+                if (hasAlert) {
+                    IconButton(
+                        onClick = onAlertsClick,
+                        modifier = Modifier.testTag("dashboard-alerts"),
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.Notifications,
+                            contentDescription = stringResource(R.string.alerts_open),
+                            tint = MaterialTheme.colorScheme.error,
+                        )
+                    }
+                }
                 IconButton(
-                    onClick = onAlertsClick,
-                    modifier = Modifier.testTag("dashboard-alerts"),
+                    onClick = onSettingsClick,
+                    modifier = Modifier.testTag("dashboard-settings"),
                 ) {
                     Icon(
-                        imageVector = Icons.Filled.Notifications,
-                        contentDescription = stringResource(R.string.alerts_open),
+                        imageVector = Icons.Filled.Settings,
+                        contentDescription = stringResource(R.string.settings_open),
                     )
-                }
-                TextButton(
-                    onClick = { confirmUnlink = true },
-                    enabled = !unlinking,
-                    modifier = Modifier.testTag("dashboard-unlink"),
-                ) {
-                    Text(stringResource(R.string.dashboard_unlink))
                 }
             }
             Spacer(modifier = Modifier.height(12.dp))
@@ -477,8 +406,6 @@ private fun DashboardScreenPreview() {
                     deviceId = "dev-1",
                     label = "Pixel 8",
                 ),
-            onUnlink = {},
-            unlinking = false,
             ui =
                 DashboardUiState(
                     loading = false,

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/events/EventsScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/events/EventsScreen.kt
@@ -308,7 +308,7 @@ private fun rangeLabel(range: EventRange): String =
     }
 
 private val EVENT_TIME_FORMAT =
-    DateTimeFormatter.ofPattern("MMM d · HH:mm", Locale.getDefault())
+    DateTimeFormatter.ofPattern("MMM d, yyyy · HH:mm", Locale.getDefault())
 
 // formatEventTime renders the stored RFC3339 timestamp in local time, falling
 // back to the raw string on anything unparseable (garbage in, garbage shown —

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/events/EventsScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/events/EventsScreen.kt
@@ -1,22 +1,27 @@
 package com.hugalafutro.bellhop.ui.events
 
 import android.widget.Toast
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -38,10 +43,10 @@ import androidx.compose.ui.unit.dp
 import com.hugalafutro.bellhop.R
 import com.hugalafutro.bellhop.data.FdEvent
 import com.hugalafutro.bellhop.ui.common.FilterPill
-import com.hugalafutro.bellhop.ui.common.Pill
 import com.hugalafutro.bellhop.ui.common.StatusBanner
 import com.hugalafutro.bellhop.ui.common.severityColors
 import com.hugalafutro.bellhop.ui.theme.BellhopTheme
+import com.hugalafutro.bellhop.ui.theme.MonoFamily
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -144,18 +149,18 @@ fun EventsScreen(
                 else ->
                     LazyColumn(
                         modifier = Modifier.weight(1f).testTag("events-list"),
-                        verticalArrangement = Arrangement.spacedBy(8.dp),
                         contentPadding = PaddingValues(bottom = 24.dp),
                     ) {
                         // Unkeyed on purpose, like the dashboard list: ids are
                         // primary keys server-side, but a buggy duplicate must
                         // degrade to a double row, not a crash.
                         items(ui.events) { event ->
-                            EventCard(
+                            EventRow(
                                 event = event,
                                 memberName = memberNames[event.memberId],
                                 onCopy = { onCopy(event) },
                             )
+                            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
                         }
                         if (ui.canLoadMore) {
                             item {
@@ -236,33 +241,53 @@ private fun RangeChips(
 }
 
 @Composable
-private fun EventCard(
+private fun EventRow(
     event: FdEvent,
     memberName: String?,
     onCopy: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val (container, content) = severityColors(event.severity)
-    Card(modifier = modifier.fillMaxWidth().testTag("event-card")) {
+    // A log line, not a card: a colour-coded severity rail down the left edge and
+    // a faint tint of the same colour, so severity reads at a glance without a
+    // pill. The whole row taps to copy (the rail carries the severity test tag).
+    val accent = severityColors(event.severity).first
+    Row(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .clickable(onClick = onCopy)
+                .background(accent.copy(alpha = 0.06f))
+                .height(IntrinsicSize.Min)
+                .testTag("event-card"),
+    ) {
+        Box(
+            modifier =
+                Modifier
+                    .width(3.dp)
+                    .fillMaxHeight()
+                    .background(accent)
+                    .testTag("event-sev-${event.severity}"),
+        )
         Column(
-            modifier = Modifier.padding(14.dp),
-            verticalArrangement = Arrangement.spacedBy(4.dp),
+            modifier = Modifier.weight(1f).padding(horizontal = 12.dp, vertical = 10.dp),
+            verticalArrangement = Arrangement.spacedBy(3.dp),
         ) {
             Row(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                Pill(
-                    text = severityLabel(event.severity),
-                    container = container,
-                    content = content,
-                    tag = "event-sev-${event.severity}",
-                    onClick = onCopy,
+                Text(
+                    text = event.type,
+                    style = MaterialTheme.typography.titleSmall,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f),
                 )
-                Spacer(modifier = Modifier.weight(1f))
+                // Time in the brand mono so the column aligns and reads as a metric.
                 Text(
                     text = formatEventTime(event.createdAt),
-                    style = MaterialTheme.typography.bodySmall,
+                    style = MaterialTheme.typography.labelSmall,
+                    fontFamily = MonoFamily,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
@@ -270,17 +295,21 @@ private fun EventCard(
                 text = event.message,
                 style = MaterialTheme.typography.bodyMedium,
             )
-            Text(
-                text =
-                    listOfNotNull(
-                        event.source.ifEmpty { null },
-                        memberName ?: event.memberId.ifEmpty { null },
-                    ).joinToString(" · "),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
+            val who =
+                listOfNotNull(
+                    event.source.ifEmpty { null },
+                    memberName ?: event.memberId.ifEmpty { null },
+                ).joinToString(" · ")
+            if (who.isNotEmpty()) {
+                Text(
+                    text = who,
+                    style = MaterialTheme.typography.bodySmall,
+                    fontFamily = MonoFamily,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
         }
     }
 }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/lock/LockScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/lock/LockScreen.kt
@@ -1,0 +1,85 @@
+package com.hugalafutro.bellhop.ui.lock
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.hugalafutro.bellhop.R
+import com.hugalafutro.bellhop.ui.theme.BellhopTheme
+
+/**
+ * LockScreen is the local access gate shown when the idle window has lapsed. It
+ * covers the linked UI entirely so no fleet data is visible until the user
+ * authenticates. [onUnlock] fires the BiometricPrompt; it's invoked once
+ * automatically on first show and again from the button, which is the retry path
+ * after a cancelled or failed prompt. The screen never authenticates by itself —
+ * it only ever asks the host to prompt, and stays put until the host clears the
+ * lock on success.
+ */
+@Composable
+fun LockScreen(
+    onUnlock: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    // Prompt straight away so an unlock is one glance/touch, not two taps. The
+    // button below is the retry once the sheet has been dismissed.
+    LaunchedEffect(Unit) { onUnlock() }
+    Scaffold(modifier = modifier.fillMaxSize().testTag("lock-screen")) { innerPadding ->
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding)
+                    .padding(horizontal = 32.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterVertically),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Lock,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(48.dp),
+            )
+            Text(
+                text = stringResource(R.string.lock_title),
+                style = MaterialTheme.typography.titleLarge,
+                color = MaterialTheme.colorScheme.primary,
+                textAlign = TextAlign.Center,
+            )
+            Text(
+                text = stringResource(R.string.lock_subtitle),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+            Button(onClick = onUnlock, modifier = Modifier.testTag("lock-unlock")) {
+                Text(stringResource(R.string.lock_unlock))
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun LockScreenPreview() {
+    BellhopTheme {
+        LockScreen(onUnlock = {})
+    }
+}

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreen.kt
@@ -4,13 +4,16 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
@@ -46,6 +49,7 @@ import com.hugalafutro.bellhop.ui.common.healthColor
 import com.hugalafutro.bellhop.ui.common.severityColors
 import com.hugalafutro.bellhop.ui.events.formatEventTime
 import com.hugalafutro.bellhop.ui.theme.BellhopTheme
+import com.hugalafutro.bellhop.ui.theme.MonoFamily
 
 /**
  * MemberDetailScreen is one member up close — deliberately *not* a repeat of the
@@ -301,37 +305,56 @@ private fun TrafficCard(
     }
 }
 
-/** MemberEventRow is one compact event under the graph: severity pill, message, time. */
+/**
+ * MemberEventRow is one event under the graph, in the same log language as the
+ * Events screen: a severity-coloured rail down the card's left edge (no pill) and
+ * the type as the heading with a mono timestamp, then the message.
+ */
 @Composable
 private fun MemberEventRow(
     event: FdEvent,
     modifier: Modifier = Modifier,
 ) {
-    val (container, content) = severityColors(event.severity)
+    val accent = severityColors(event.severity).first
     Card(modifier = modifier.fillMaxWidth().testTag("member-event-row")) {
-        Row(
-            modifier = Modifier.padding(12.dp).fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(10.dp),
-        ) {
-            Pill(
-                text = event.severity,
-                container = container,
-                content = content,
-                tag = "member-event-sev-${event.severity}",
+        Row(modifier = Modifier.height(IntrinsicSize.Min)) {
+            Box(
+                modifier =
+                    Modifier
+                        .width(3.dp)
+                        .fillMaxHeight()
+                        .background(accent)
+                        .testTag("member-event-sev-${event.severity}"),
             )
-            Text(
-                text = event.message,
-                style = MaterialTheme.typography.bodySmall,
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.weight(1f),
-            )
-            Text(
-                text = formatEventTime(event.createdAt),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
+            Column(
+                modifier = Modifier.weight(1f).padding(horizontal = 12.dp, vertical = 10.dp),
+                verticalArrangement = Arrangement.spacedBy(3.dp),
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Text(
+                        text = event.type,
+                        style = MaterialTheme.typography.titleSmall,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f),
+                    )
+                    Text(
+                        text = formatEventTime(event.createdAt),
+                        style = MaterialTheme.typography.labelSmall,
+                        fontFamily = MonoFamily,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Text(
+                    text = event.message,
+                    style = MaterialTheme.typography.bodyMedium,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
         }
     }
 }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -217,6 +218,17 @@ fun SettingsScreen(
                             checked = lockConfig.enabled,
                             onCheckedChange = onToggleLock,
                             enabled = lockAvailable,
+                            // The default unchecked track is surfaceContainerHighest
+                            // (the Card's own colour) with an outline thumb/border, so
+                            // an off switch blends into the card. Give the off state a
+                            // light thumb + border over a surface track so it stays
+                            // legible on both the ink and paper schemes.
+                            colors =
+                                SwitchDefaults.colors(
+                                    uncheckedThumbColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    uncheckedTrackColor = MaterialTheme.colorScheme.surface,
+                                    uncheckedBorderColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                                ),
                             modifier = Modifier.testTag("settings-lock-toggle"),
                         )
                     }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreen.kt
@@ -1,0 +1,320 @@
+package com.hugalafutro.bellhop.ui.settings
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Card
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.hugalafutro.bellhop.R
+import com.hugalafutro.bellhop.data.LinkState
+import com.hugalafutro.bellhop.data.LockConfig
+import com.hugalafutro.bellhop.data.LockTimeout
+import com.hugalafutro.bellhop.ui.common.FilterPill
+import com.hugalafutro.bellhop.ui.theme.BellhopTheme
+
+/**
+ * SettingsScreen is where the link's status and the two things the dashboard
+ * shouldn't clutter itself with live: the app lock and Unlink. It renders the
+ * linked Front Desk (name, address, this device's label and role), the app-lock
+ * policy (toggle + idle window), a shortcut into Alerts, and the Unlink flow —
+ * confirm, plus the failure/force-unlink escape moved here from the dashboard.
+ * It holds only the confirm-dialog visibility locally; the unlink work and its
+ * failure state are the host's, so the same revoke-first guarantees apply.
+ */
+@Composable
+fun SettingsScreen(
+    link: LinkState.Linked,
+    lockConfig: LockConfig,
+    lockAvailable: Boolean,
+    onBack: () -> Unit,
+    onToggleLock: (Boolean) -> Unit,
+    onSelectTimeout: (LockTimeout) -> Unit,
+    onAlertsClick: () -> Unit,
+    onUnlink: () -> Unit,
+    modifier: Modifier = Modifier,
+    unlinking: Boolean = false,
+    unlinkFailed: Boolean = false,
+    onDismissUnlinkError: () -> Unit = {},
+    onForceUnlink: () -> Unit = {},
+) {
+    var confirmUnlink by remember { mutableStateOf(false) }
+
+    if (unlinkFailed) {
+        AlertDialog(
+            onDismissRequest = onDismissUnlinkError,
+            title = { Text(stringResource(R.string.dashboard_unlink_failed_title)) },
+            text = { Text(stringResource(R.string.dashboard_unlink_failed_body)) },
+            confirmButton = {
+                TextButton(
+                    enabled = !unlinking,
+                    onClick = {
+                        onDismissUnlinkError()
+                        onUnlink()
+                    },
+                    modifier = Modifier.testTag("settings-unlink-retry"),
+                ) {
+                    Text(stringResource(R.string.dashboard_unlink_retry))
+                }
+            },
+            dismissButton = {
+                TextButton(
+                    enabled = !unlinking,
+                    onClick = {
+                        onDismissUnlinkError()
+                        onForceUnlink()
+                    },
+                    modifier = Modifier.testTag("settings-unlink-force"),
+                ) {
+                    Text(stringResource(R.string.dashboard_unlink_force))
+                }
+            },
+        )
+    }
+
+    if (confirmUnlink) {
+        AlertDialog(
+            onDismissRequest = { confirmUnlink = false },
+            title = { Text(stringResource(R.string.dashboard_unlink_confirm_title)) },
+            text = {
+                Text(
+                    stringResource(
+                        R.string.dashboard_unlink_confirm_body,
+                        link.fdName.ifBlank { link.fdUrl },
+                    ),
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    enabled = !unlinking,
+                    onClick = {
+                        confirmUnlink = false
+                        onUnlink()
+                    },
+                    modifier = Modifier.testTag("settings-unlink-confirm"),
+                ) {
+                    Text(stringResource(R.string.dashboard_unlink))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { confirmUnlink = false }) {
+                    Text(stringResource(R.string.common_cancel))
+                }
+            },
+        )
+    }
+
+    Scaffold(modifier = modifier.fillMaxSize()) { innerPadding ->
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding)
+                    .padding(horizontal = 16.dp)
+                    .verticalScroll(rememberScrollState()),
+        ) {
+            Spacer(modifier = Modifier.height(8.dp))
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
+            ) {
+                IconButton(onClick = onBack, modifier = Modifier.testTag("settings-back")) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = stringResource(R.string.settings_back),
+                    )
+                }
+                Text(
+                    text = stringResource(R.string.settings_title),
+                    style = MaterialTheme.typography.titleLarge,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.weight(1f).testTag("settings-title"),
+                )
+            }
+
+            // Front Desk link status (moved off the dashboard toolbar).
+            Card(modifier = Modifier.fillMaxWidth()) {
+                Column(
+                    modifier = Modifier.padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    Text(
+                        text = stringResource(R.string.settings_fd_title),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Text(
+                        text = link.fdName.ifBlank { link.fdUrl },
+                        style = MaterialTheme.typography.titleMedium,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.testTag("settings-fd-name"),
+                    )
+                    Text(
+                        text = link.fdUrl,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    Text(
+                        text = stringResource(R.string.dashboard_linked_as, link.label, link.role),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.testTag("settings-linked"),
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // App lock: on/off plus the idle window it measures from foreground exit.
+            Card(modifier = Modifier.fillMaxWidth()) {
+                Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = stringResource(R.string.settings_lock_title),
+                                style = MaterialTheme.typography.titleMedium,
+                            )
+                            Text(
+                                text = stringResource(R.string.settings_lock_subtitle),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                        Switch(
+                            checked = lockConfig.enabled,
+                            onCheckedChange = onToggleLock,
+                            enabled = lockAvailable,
+                            modifier = Modifier.testTag("settings-lock-toggle"),
+                        )
+                    }
+                    if (!lockAvailable) {
+                        // No biometric or device credential enrolled: the gate can't
+                        // engage, so say why the toggle is inert rather than failing
+                        // silently when it's flipped on.
+                        Text(
+                            text = stringResource(R.string.settings_lock_unavailable),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.error,
+                            modifier = Modifier.testTag("settings-lock-unavailable"),
+                        )
+                    }
+                    if (lockConfig.enabled && lockAvailable) {
+                        Text(
+                            text = stringResource(R.string.settings_lock_window),
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        val selected = LockTimeout.fromMillis(lockConfig.timeoutMs)
+                        Row(horizontalArrangement = Arrangement.spacedBy(6.dp), modifier = Modifier.fillMaxWidth()) {
+                            LockTimeout.entries.forEach { option ->
+                                FilterPill(
+                                    text = stringResource(timeoutLabel(option)),
+                                    selected = option == selected,
+                                    onClick = { onSelectTimeout(option) },
+                                    tag = "settings-lock-timeout-${option.name}",
+                                    modifier = Modifier.weight(1f),
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Alerts stays reachable here even when all is green (the dashboard bell
+            // only appears when a member is down).
+            Card(modifier = Modifier.fillMaxWidth().clickable(onClick = onAlertsClick).testTag("settings-alerts")) {
+                Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                    Text(
+                        text = stringResource(R.string.settings_alerts_title),
+                        style = MaterialTheme.typography.titleMedium,
+                    )
+                    Text(
+                        text = stringResource(R.string.settings_alerts_subtitle),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            OutlinedButton(
+                onClick = { confirmUnlink = true },
+                enabled = !unlinking,
+                modifier = Modifier.fillMaxWidth().testTag("settings-unlink"),
+            ) {
+                Text(stringResource(R.string.dashboard_unlink))
+            }
+            Spacer(modifier = Modifier.height(24.dp))
+        }
+    }
+}
+
+private fun timeoutLabel(option: LockTimeout): Int =
+    when (option) {
+        LockTimeout.IMMEDIATELY -> R.string.settings_lock_now
+        LockTimeout.ONE_MINUTE -> R.string.settings_lock_1m
+        LockTimeout.FIVE_MINUTES -> R.string.settings_lock_5m
+        LockTimeout.FIFTEEN_MINUTES -> R.string.settings_lock_15m
+        LockTimeout.THIRTY_MINUTES -> R.string.settings_lock_30m
+        LockTimeout.ONE_HOUR -> R.string.settings_lock_1h
+    }
+
+@Preview(showBackground = true)
+@Composable
+private fun SettingsScreenPreview() {
+    BellhopTheme {
+        SettingsScreen(
+            link =
+                LinkState.Linked(
+                    fdUrl = "http://10.0.2.2:8080",
+                    fdName = "Home Front Desk",
+                    role = "operator",
+                    deviceId = "dev-1",
+                    label = "Pixel 8",
+                ),
+            lockConfig = LockConfig(enabled = true, timeoutMs = LockTimeout.THIRTY_MINUTES.millis),
+            lockAvailable = true,
+            onBack = {},
+            onToggleLock = {},
+            onSelectTimeout = {},
+            onAlertsClick = {},
+            onUnlink = {},
+        )
+    }
+}

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -92,6 +92,31 @@
     <string name="alerts_event_member_removed">Member removed</string>
     <string name="alerts_event_member_state_changed">Member drained or activated</string>
 
+    <!-- App lock -->
+    <string name="lock_title">Bellhop is locked</string>
+    <string name="lock_subtitle">Unlock to see the fleet.</string>
+    <string name="lock_unlock">Unlock</string>
+    <string name="lock_prompt_title">Unlock Bellhop</string>
+    <string name="lock_prompt_subtitle">Confirm it\'s you to see the fleet.</string>
+
+    <!-- Settings -->
+    <string name="settings_open">Settings</string>
+    <string name="settings_title">Settings</string>
+    <string name="settings_back">Back</string>
+    <string name="settings_fd_title">Linked Front Desk</string>
+    <string name="settings_lock_title">App lock</string>
+    <string name="settings_lock_subtitle">Require a fingerprint or device PIN to open Bellhop.</string>
+    <string name="settings_lock_unavailable">Set up a fingerprint or a screen lock on this device to enable the app lock.</string>
+    <string name="settings_lock_window">Lock after inactivity</string>
+    <string name="settings_lock_now">Now</string>
+    <string name="settings_lock_1m">1 min</string>
+    <string name="settings_lock_5m">5 min</string>
+    <string name="settings_lock_15m">15 min</string>
+    <string name="settings_lock_30m">30 min</string>
+    <string name="settings_lock_1h">1 hr</string>
+    <string name="settings_alerts_title">Alerts</string>
+    <string name="settings_alerts_subtitle">Notification delivery and what Front Desk alerts on.</string>
+
     <string name="dashboard_unlink">Unlink</string>
     <string name="dashboard_unlink_confirm_title">Unlink this device?</string>
     <string name="dashboard_unlink_confirm_body">This device will stop monitoring %1$s and its token will be revoked. You can pair again anytime with a new code.</string>

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/AppLockTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/AppLockTest.kt
@@ -1,0 +1,49 @@
+package com.hugalafutro.bellhop.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AppLockTest {
+    private val thirtyMin = LockTimeout.THIRTY_MINUTES.millis
+
+    @Test
+    fun disabledNeverLocksEvenAfterAges() {
+        val config = LockConfig(enabled = false, timeoutMs = thirtyMin)
+        // A year in the background still doesn't lock when the policy is off.
+        assertFalse(shouldLock(config, lastForegroundExit = 0L, now = 365L * 24 * 3600_000))
+    }
+
+    @Test
+    fun enabledLocksOncePastTheWindow() {
+        val config = LockConfig(enabled = true, timeoutMs = thirtyMin)
+        val exit = 1_000_000L
+        assertTrue(shouldLock(config, lastForegroundExit = exit, now = exit + thirtyMin + 1))
+    }
+
+    @Test
+    fun enabledStaysOpenWithinTheWindow() {
+        val config = LockConfig(enabled = true, timeoutMs = thirtyMin)
+        val exit = 1_000_000L
+        // Exactly at the boundary is not yet past it, so no lock.
+        assertFalse(shouldLock(config, lastForegroundExit = exit, now = exit + thirtyMin))
+        assertFalse(shouldLock(config, lastForegroundExit = exit, now = exit + 1))
+    }
+
+    @Test
+    fun immediatelyLocksOnAnyElapsedTime() {
+        val config = LockConfig(enabled = true, timeoutMs = LockTimeout.IMMEDIATELY.millis)
+        val exit = 1_000_000L
+        assertTrue(shouldLock(config, lastForegroundExit = exit, now = exit + 1))
+        // No elapsed time (same instant) is still open.
+        assertFalse(shouldLock(config, lastForegroundExit = exit, now = exit))
+    }
+
+    @Test
+    fun fromMillisRoundTripsKnownAndFallsBackForUnknown() {
+        assertEquals(LockTimeout.FIVE_MINUTES, LockTimeout.fromMillis(LockTimeout.FIVE_MINUTES.millis))
+        // A value no option matches (e.g. a future build's window) falls back.
+        assertEquals(LockTimeout.DEFAULT, LockTimeout.fromMillis(123_456L))
+    }
+}

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/LockStoreTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/LockStoreTest.kt
@@ -1,0 +1,73 @@
+package com.hugalafutro.bellhop.data
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class LockStoreTest {
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    private fun newStore(): LockStore {
+        val scope = CoroutineScope(Dispatchers.IO + Job())
+        val ds: DataStore<Preferences> =
+            PreferenceDataStoreFactory.create(scope = scope) {
+                File(tmp.newFolder(), "lock.preferences_pb")
+            }
+        return LockStore(ds)
+    }
+
+    @Test
+    fun defaultsToDisabledWithThirtyMinuteWindow() =
+        runBlocking {
+            val config = newStore().config.first()
+            assertFalse(config.enabled)
+            assertEquals(LockTimeout.THIRTY_MINUTES.millis, config.timeoutMs)
+        }
+
+    @Test
+    fun enablingStampsExitToNow() =
+        runBlocking {
+            val store = newStore()
+            store.setEnabled(true, now = 5_000L)
+            val snap = store.snapshot()
+            assertTrue(snap.config.enabled)
+            assertEquals(5_000L, snap.lastForegroundExit)
+        }
+
+    @Test
+    fun timeoutAndExitRoundTrip() =
+        runBlocking {
+            val store = newStore()
+            store.setTimeout(LockTimeout.FIVE_MINUTES.millis)
+            store.stampExit(12_345L)
+            val snap = store.snapshot()
+            assertEquals(LockTimeout.FIVE_MINUTES.millis, snap.config.timeoutMs)
+            assertEquals(12_345L, snap.lastForegroundExit)
+        }
+
+    @Test
+    fun clearResetsToDefaults() =
+        runBlocking {
+            val store = newStore()
+            store.setEnabled(true, now = 1L)
+            store.setTimeout(LockTimeout.ONE_HOUR.millis)
+            store.clear()
+            val snap = store.snapshot()
+            assertFalse(snap.config.enabled)
+            assertEquals(LockTimeout.THIRTY_MINUTES.millis, snap.config.timeoutMs)
+            assertEquals(0L, snap.lastForegroundExit)
+        }
+}

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreenTest.kt
@@ -9,7 +9,6 @@ import com.hugalafutro.bellhop.data.HealthStatus
 import com.hugalafutro.bellhop.data.LinkState
 import com.hugalafutro.bellhop.data.MemberStatus
 import com.hugalafutro.bellhop.ui.theme.BellhopTheme
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -17,8 +16,10 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
 /**
- * Linked-state dashboard: confirms the link summary renders and Unlink fires.
- * Asserts on test tags, not display text, so English copy never breaks tests.
+ * Linked-state dashboard, post toolbar-trim: the title plus the events and
+ * settings icons are always present, the Alerts bell only when a member is down,
+ * and Unlink/status now live in Settings. Asserts on test tags, not display
+ * text, so English copy never breaks tests.
  */
 @RunWith(RobolectricTestRunner::class)
 class DashboardScreenTest {
@@ -34,60 +35,13 @@ class DashboardScreenTest {
             label = "Pixel 8",
         )
 
-    @Test
-    fun showsLinkSummary() {
-        composeTestRule.setContent {
-            BellhopTheme { DashboardScreen(link = link, onUnlink = {}, unlinking = false) }
-        }
-        composeTestRule.onNodeWithTag("dashboard-title").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("dashboard-linked").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("dashboard-unlink").assertIsDisplayed()
-    }
-
-    @Test
-    fun unlinkAsksForConfirmationBeforeFiring() {
-        var clicked = false
-        composeTestRule.setContent {
-            BellhopTheme {
-                DashboardScreen(link = link, onUnlink = { clicked = true }, unlinking = false)
-            }
-        }
-        // Tapping Unlink only opens the confirm dialog; the callback must not
-        // fire until the dialog is confirmed.
-        composeTestRule.onNodeWithTag("dashboard-unlink").performClick()
-        assertFalse(clicked)
-        composeTestRule.onNodeWithTag("dashboard-unlink-confirm").performClick()
-        assertTrue(clicked)
-    }
-
-    @Test
-    fun failedUnlinkOffersRetryThatRefiresUnlink() {
-        var retries = 0
-        var dismissed = false
-        composeTestRule.setContent {
-            BellhopTheme {
-                DashboardScreen(
-                    link = link,
-                    onUnlink = { retries++ },
-                    unlinking = false,
-                    unlinkFailed = true,
-                    onDismissUnlinkError = { dismissed = true },
-                )
-            }
-        }
-        // A failed remote revoke surfaces the error dialog; "Try again" dismisses
-        // it and re-fires the unlink so the orphaned row can still be cleared.
-        composeTestRule.onNodeWithTag("dashboard-unlink-retry").performClick()
-        assertTrue(dismissed)
-        assertTrue(retries == 1)
-    }
-
     private val members =
         listOf(
             FleetMember(
                 id = "m1",
                 name = "alpha",
                 url = "http://a:8080",
+                state = "active",
                 status =
                     MemberStatus(
                         health = HealthStatus(known = true, healthy = true, latencyMs = 3),
@@ -107,14 +61,61 @@ class DashboardScreenTest {
             ),
         )
 
+    private val allUp = listOf(members[0])
+
+    @Test
+    fun showsTitleAndToolbar() {
+        composeTestRule.setContent {
+            BellhopTheme { DashboardScreen(link = link) }
+        }
+        composeTestRule.onNodeWithTag("dashboard-title").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("dashboard-events").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("dashboard-settings").assertIsDisplayed()
+    }
+
+    @Test
+    fun settingsButtonFiresCallback() {
+        var opened = 0
+        composeTestRule.setContent {
+            BellhopTheme { DashboardScreen(link = link, onSettingsClick = { opened++ }) }
+        }
+        composeTestRule.onNodeWithTag("dashboard-settings").performClick()
+        assertTrue(opened == 1)
+    }
+
+    @Test
+    fun bellShownAndFiresWhenAMemberIsDown() {
+        var opened = 0
+        composeTestRule.setContent {
+            BellhopTheme {
+                DashboardScreen(
+                    link = link,
+                    ui = DashboardUiState(loading = false, members = members),
+                    onAlertsClick = { opened++ },
+                )
+            }
+        }
+        composeTestRule.onNodeWithTag("dashboard-alerts").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("dashboard-alerts").performClick()
+        assertTrue(opened == 1)
+    }
+
+    @Test
+    fun bellHiddenWhenAllMembersUp() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                DashboardScreen(link = link, ui = DashboardUiState(loading = false, members = allUp))
+            }
+        }
+        composeTestRule.onNodeWithTag("dashboard-alerts").assertDoesNotExist()
+    }
+
     @Test
     fun rendersMemberCardsWithPrimaryAndDrainedBadges() {
         composeTestRule.setContent {
             BellhopTheme {
                 DashboardScreen(
                     link = link,
-                    onUnlink = {},
-                    unlinking = false,
                     ui = DashboardUiState(loading = false, members = members, primaryId = "m1"),
                 )
             }
@@ -133,8 +134,6 @@ class DashboardScreenTest {
             BellhopTheme {
                 DashboardScreen(
                     link = link,
-                    onUnlink = {},
-                    unlinking = false,
                     ui = DashboardUiState(loading = false, members = members),
                     onMemberClick = { clicked = it },
                 )
@@ -151,8 +150,6 @@ class DashboardScreenTest {
             BellhopTheme {
                 DashboardScreen(
                     link = link,
-                    onUnlink = {},
-                    unlinking = false,
                     ui = DashboardUiState(loading = false, members = members),
                     onEventsClick = { opened++ },
                 )
@@ -163,38 +160,29 @@ class DashboardScreenTest {
     }
 
     @Test
-    fun firstLoadShowsSpinnerThenEmptyStateWithoutMembers() {
+    fun loadingShowsSpinner() {
         composeTestRule.setContent {
-            BellhopTheme {
-                DashboardScreen(link = link, onUnlink = {}, unlinking = false)
-            }
+            BellhopTheme { DashboardScreen(link = link, ui = DashboardUiState(loading = true)) }
         }
         composeTestRule.onNodeWithTag("dashboard-loading").assertIsDisplayed()
     }
 
     @Test
-    fun emptyFleetShowsEmptyState() {
+    fun emptyShowsMessage() {
         composeTestRule.setContent {
             BellhopTheme {
-                DashboardScreen(
-                    link = link,
-                    onUnlink = {},
-                    unlinking = false,
-                    ui = DashboardUiState(loading = false),
-                )
+                DashboardScreen(link = link, ui = DashboardUiState(loading = false, members = emptyList()))
             }
         }
         composeTestRule.onNodeWithTag("dashboard-empty").assertIsDisplayed()
     }
 
     @Test
-    fun refreshErrorShowsBannerAndKeepsStaleList() {
+    fun errorShowsBannerOverStaleList() {
         composeTestRule.setContent {
             BellhopTheme {
                 DashboardScreen(
                     link = link,
-                    onUnlink = {},
-                    unlinking = false,
                     ui = DashboardUiState(loading = false, members = members, error = "boom"),
                 )
             }
@@ -209,35 +197,10 @@ class DashboardScreenTest {
             BellhopTheme {
                 DashboardScreen(
                     link = link,
-                    onUnlink = {},
-                    unlinking = false,
                     ui = DashboardUiState(loading = false, members = members, revoked = true),
                 )
             }
         }
         composeTestRule.onNodeWithTag("dashboard-revoked").assertIsDisplayed()
-    }
-
-    @Test
-    fun failedUnlinkOffersForceUnlinkEscapeHatch() {
-        var forced = 0
-        var dismissed = false
-        composeTestRule.setContent {
-            BellhopTheme {
-                DashboardScreen(
-                    link = link,
-                    onUnlink = {},
-                    unlinking = false,
-                    unlinkFailed = true,
-                    onDismissUnlinkError = { dismissed = true },
-                    onForceUnlink = { forced++ },
-                )
-            }
-        }
-        // When a revoke is impossible (dead/unreadable token), "Unlink anyway"
-        // clears locally so the operator is never stranded on the dashboard.
-        composeTestRule.onNodeWithTag("dashboard-unlink-force").performClick()
-        assertTrue(dismissed)
-        assertTrue(forced == 1)
     }
 }

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/lock/LockScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/lock/LockScreenTest.kt
@@ -1,0 +1,43 @@
+package com.hugalafutro.bellhop.ui.lock
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import com.hugalafutro.bellhop.ui.theme.BellhopTheme
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Lock screen: covers the fleet UI and asks the host to prompt. It prompts once
+ * automatically on show and again from the retry button; it never unlocks itself.
+ */
+@RunWith(RobolectricTestRunner::class)
+class LockScreenTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun promptsOnceAutomaticallyOnShow() {
+        var prompts = 0
+        composeTestRule.setContent {
+            BellhopTheme { LockScreen(onUnlock = { prompts++ }) }
+        }
+        composeTestRule.onNodeWithTag("lock-screen").assertIsDisplayed()
+        assertEquals(1, prompts)
+    }
+
+    @Test
+    fun retryButtonPromptsAgain() {
+        var prompts = 0
+        composeTestRule.setContent {
+            BellhopTheme { LockScreen(onUnlock = { prompts++ }) }
+        }
+        // One auto-prompt on show, then the button is the retry after a cancel.
+        composeTestRule.onNodeWithTag("lock-unlock").performClick()
+        assertEquals(2, prompts)
+    }
+}

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreenTest.kt
@@ -1,0 +1,137 @@
+package com.hugalafutro.bellhop.ui.settings
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import com.hugalafutro.bellhop.data.LinkState
+import com.hugalafutro.bellhop.data.LockConfig
+import com.hugalafutro.bellhop.data.LockTimeout
+import com.hugalafutro.bellhop.ui.theme.BellhopTheme
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Settings screen: link status, app-lock toggle/window, and the Unlink flow
+ * moved off the dashboard. Asserts on test tags, not display text, so English
+ * copy never breaks tests.
+ */
+@RunWith(RobolectricTestRunner::class)
+class SettingsScreenTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val link =
+        LinkState.Linked(
+            fdUrl = "http://10.0.2.2:8080",
+            fdName = "Home Front Desk",
+            role = "operator",
+            deviceId = "dev-1",
+            label = "Pixel 8",
+        )
+
+    private fun content(
+        lockConfig: LockConfig = LockConfig(enabled = false, timeoutMs = LockTimeout.THIRTY_MINUTES.millis),
+        lockAvailable: Boolean = true,
+        unlinkFailed: Boolean = false,
+        onToggleLock: (Boolean) -> Unit = {},
+        onSelectTimeout: (LockTimeout) -> Unit = {},
+        onAlertsClick: () -> Unit = {},
+        onUnlink: () -> Unit = {},
+        onForceUnlink: () -> Unit = {},
+        onDismissUnlinkError: () -> Unit = {},
+    ) {
+        composeTestRule.setContent {
+            BellhopTheme {
+                SettingsScreen(
+                    link = link,
+                    lockConfig = lockConfig,
+                    lockAvailable = lockAvailable,
+                    onBack = {},
+                    onToggleLock = onToggleLock,
+                    onSelectTimeout = onSelectTimeout,
+                    onAlertsClick = onAlertsClick,
+                    onUnlink = onUnlink,
+                    unlinkFailed = unlinkFailed,
+                    onDismissUnlinkError = onDismissUnlinkError,
+                    onForceUnlink = onForceUnlink,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun showsLinkStatus() {
+        content()
+        composeTestRule.onNodeWithTag("settings-title").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("settings-fd-name").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("settings-linked").assertIsDisplayed()
+    }
+
+    @Test
+    fun togglingLockFiresCallback() {
+        var toggledTo: Boolean? = null
+        content(onToggleLock = { toggledTo = it })
+        composeTestRule.onNodeWithTag("settings-lock-toggle").performClick()
+        assertEquals(true, toggledTo)
+    }
+
+    @Test
+    fun unavailableLockShowsHint() {
+        content(lockAvailable = false)
+        composeTestRule.onNodeWithTag("settings-lock-unavailable").assertIsDisplayed()
+    }
+
+    @Test
+    fun timeoutPillsShowWhenEnabledAndFireSelection() {
+        var picked: LockTimeout? = null
+        content(
+            lockConfig = LockConfig(enabled = true, timeoutMs = LockTimeout.THIRTY_MINUTES.millis),
+            onSelectTimeout = { picked = it },
+        )
+        composeTestRule.onNodeWithTag("settings-lock-timeout-FIVE_MINUTES").performClick()
+        assertEquals(LockTimeout.FIVE_MINUTES, picked)
+    }
+
+    @Test
+    fun timeoutPillsHiddenWhenLockDisabled() {
+        content(lockConfig = LockConfig(enabled = false, timeoutMs = LockTimeout.THIRTY_MINUTES.millis))
+        composeTestRule.onNodeWithTag("settings-lock-timeout-THIRTY_MINUTES").assertDoesNotExist()
+    }
+
+    @Test
+    fun alertsRowFiresCallback() {
+        var opened = 0
+        content(onAlertsClick = { opened++ })
+        composeTestRule.onNodeWithTag("settings-alerts").performScrollTo().performClick()
+        assertTrue(opened == 1)
+    }
+
+    @Test
+    fun unlinkAsksForConfirmationBeforeFiring() {
+        var unlinked = 0
+        content(onUnlink = { unlinked++ })
+        composeTestRule.onNodeWithTag("settings-unlink").performScrollTo().performClick()
+        // The tap only opens the confirm dialog; nothing fires yet.
+        assertTrue(unlinked == 0)
+        composeTestRule.onNodeWithTag("settings-unlink-confirm").performClick()
+        assertTrue(unlinked == 1)
+    }
+
+    @Test
+    fun failedUnlinkOffersForceUnlinkEscapeHatch() {
+        var forced = 0
+        var dismissed = false
+        content(unlinkFailed = true, onForceUnlink = { forced++ }, onDismissUnlinkError = { dismissed = true })
+        // With a dead/unreachable token, "Unlink anyway" clears locally so the
+        // operator is never stranded.
+        composeTestRule.onNodeWithTag("settings-unlink-force").performClick()
+        assertTrue(dismissed)
+        assertTrue(forced == 1)
+    }
+}

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -13,12 +13,15 @@ kotlinxSerialization = "1.7.3"
 datastore = "1.1.1"
 coroutines = "1.9.0"
 zxingEmbedded = "4.3.0"
+biometric = "1.1.0"
+fragment = "1.8.5"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycle" }
 androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycle" }
+androidx-lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "lifecycle" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
 androidx-compose-ui = { group = "androidx.compose.ui", name = "ui" }
 androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
@@ -36,6 +39,8 @@ kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-
 androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
 zxing-android-embedded = { group = "com.journeyapps", name = "zxing-android-embedded", version.ref = "zxingEmbedded" }
+androidx-biometric = { group = "androidx.biometric", name = "biometric", version.ref = "biometric" }
+androidx-fragment = { group = "androidx.fragment", name = "fragment-ktx", version.ref = "fragment" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Bellhop A2 slice: app lock + Settings, plus a design pass on the event surfaces

Follows the QR-scan slice (#417). Two things land together: the app-lock/Settings feature and a UI de-clutter of the log screens.

### App lock (opt-in, off by default)
- `data/AppLock.kt` — `LockConfig`, `LockTimeout` enum, and a pure `shouldLock` (unit-tested).
- `data/LockStore.kt` — its own `bellhop_lock` DataStore (enabled + timeoutMs + last-foreground-exit stamp) that survives process death.
- Gate wired in `MainActivity`/`BellhopApp` via `ProcessLifecycleOwner` (ON_STOP stamps, ON_START re-evaluates) plus a cold-start `LaunchedEffect`. `LockScreen` overlay auto-prompts with a retry button.
- `MainActivity` is now a `FragmentActivity` (BiometricPrompt requirement). Authenticators = STRONG|DEVICE_CREDENTIAL (WEAK below API 30). **No enrolled credential → the gate degrades to OPEN** — the token at rest is still Keystore-wrapped; app lock is a UI gate only.
- New deps: `androidx.biometric:1.1.0`, `androidx.fragment:fragment-ktx:1.8.5`, `androidx.lifecycle:lifecycle-process`.

### Settings screen
- Link status, the lock toggle + idle-window picker, an Alerts shortcut, and Unlink (with its confirm / failure / force dialogs, moved here off the dashboard). A successful unlink also clears the lock store.
- **Dashboard toolbar trimmed**: title + events + gear always; the Alerts bell only when a member is down; the "linked as" status and Unlink moved into Settings.

### Design pass — the event log is no longer a wall of pills
Interactive and static elements now read differently:
- **Log rows** (Events screen + member-detail log) use a colored **severity rail** down the left edge, the event type as the heading, and a **Plex Mono timestamp** (now including the year). Compact divided list on Events; left-railed cards on member detail. No more severity pills.
- **Filters** are **outlined toggles** (transparent + hairline border unselected, filled brass selected), so a filter set reads as a segmented control. Applies to the Events filters and the Settings lock-window picker.
- Net: the only remaining pills are the ones you tap. `Primary`/`Drained` on member cards stay as small static badges — they no longer collide with the (outlined) filters.

### Tests
New unit/Robolectric coverage for `AppLock`, `LockStore`, `LockScreen`, `SettingsScreen`, plus updated `DashboardScreen` tests for the trimmed toolbar. Full `:app:testDebugUnitTest`, ktlint, `:app:lintDebug`, and `:app:assembleDebug` green under JDK 21. Emulator-verified end to end: FragmentActivity migration doesn't crash, trimmed toolbar, all Settings sections, the lock-unavailable degraded path, and (after enrolling a device PIN) toggle → window picker → background/foreground → BiometricPrompt → unlock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)