### PR TITLE
feat(bellhop): background-monitoring backstop (WorkManager poll + notifications)

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -78,6 +78,10 @@ dependencies {
     implementation(libs.okhttp.sse)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.androidx.datastore.preferences)
+    // WorkManager runs the Layer-2 background poll (plan section 5.2): a periodic
+    // worker that diffs fleet health while Bellhop is backgrounded and posts a
+    // local notification on a member going down or recovering. No push infra.
+    implementation(libs.androidx.work.runtime)
     // BiometricPrompt gates local access to the stored token; its device-credential
     // fallback (pattern/PIN) needs no fingerprint sensor. It requires a
     // FragmentActivity host, hence the explicit fragment dependency (plan 3.1/5.4).

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -14,6 +14,13 @@
          is a local access gate the user turns on in Settings; when no biometric
          or device credential is enrolled the gate simply can't engage. -->
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />
+
+    <!-- POST_NOTIFICATIONS backs the optional background-monitoring backstop
+         (plan section 5.2): the periodic fleet poll posts a local notification
+         when a member goes down or recovers. It is a runtime permission from API
+         33, requested when the user turns the backstop on in Settings; below 33
+         notifications post without it. -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-feature
         android:name="android.hardware.camera"
         android:required="false" />

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
@@ -1,11 +1,15 @@
 package com.hugalafutro.bellhop
 
+import android.Manifest
 import android.content.Context
+import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
 import androidx.activity.compose.BackHandler
+import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.biometric.BiometricManager
 import androidx.biometric.BiometricPrompt
 import androidx.compose.runtime.Composable
@@ -32,7 +36,9 @@ import com.hugalafutro.bellhop.data.LinkStore
 import com.hugalafutro.bellhop.data.LockConfig
 import com.hugalafutro.bellhop.data.LockStore
 import com.hugalafutro.bellhop.data.LockTimeout
+import com.hugalafutro.bellhop.data.MonitorStore
 import com.hugalafutro.bellhop.data.shouldLock
+import com.hugalafutro.bellhop.notify.FleetNotifier
 import com.hugalafutro.bellhop.ui.alerts.AlertsScreen
 import com.hugalafutro.bellhop.ui.alerts.AlertsViewModel
 import com.hugalafutro.bellhop.ui.dashboard.DashboardScreen
@@ -46,6 +52,7 @@ import com.hugalafutro.bellhop.ui.pairing.PairingScreen
 import com.hugalafutro.bellhop.ui.pairing.PairingViewModel
 import com.hugalafutro.bellhop.ui.settings.SettingsScreen
 import com.hugalafutro.bellhop.ui.theme.BellhopTheme
+import com.hugalafutro.bellhop.work.FleetPollWorker
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -55,6 +62,9 @@ import kotlinx.coroutines.launch
 class MainActivity : FragmentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        // Register the background-backstop notification channels up front so a
+        // poll that fires while the app is dead has channels to post into.
+        FleetNotifier.ensureChannels(this)
         enableEdgeToEdge()
         setContent {
             BellhopTheme {
@@ -132,6 +142,7 @@ fun BellhopApp() {
     val activity = context as? FragmentActivity
     val linkStore = remember { LinkStore.create(context) }
     val lockStore = remember { LockStore.create(context) }
+    val monitorStore = remember { MonitorStore.create(context) }
     val client = remember { FrontDeskClient() }
     val linkState by linkStore.state.collectAsStateWithLifecycle(initialValue = LinkState.Loading)
     val lockConfig by
@@ -139,7 +150,27 @@ fun BellhopApp() {
             initialValue = LockConfig(enabled = false, timeoutMs = LockTimeout.DEFAULT.millis),
         )
     val lockAvailable = remember(activity) { activity != null && canAppLock(activity) }
+    val monitorEnabled by monitorStore.enabled.collectAsStateWithLifecycle(initialValue = false)
     val scope = rememberCoroutineScope()
+    // Launcher for the POST_NOTIFICATIONS runtime permission (API 33+), fired when
+    // the user turns background monitoring on. A denial is fine: the backstop then
+    // polls silently until the permission is granted from system settings.
+    val notificationPermission =
+        rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { }
+
+    // toggleMonitor persists the opt-in and, on enable, asks for the notification
+    // permission. Scheduling the actual poll is left to LinkedContent's effect so
+    // the DataStore flag stays the single source of truth for whether it runs.
+    fun toggleMonitor(enabled: Boolean) {
+        scope.launch { monitorStore.setEnabled(enabled) }
+        if (enabled &&
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) !=
+            PackageManager.PERMISSION_GRANTED
+        ) {
+            notificationPermission.launch(Manifest.permission.POST_NOTIFICATIONS)
+        }
+    }
     var unlinking by remember { mutableStateOf(false) }
     var unlinkFailed by remember { mutableStateOf(false) }
     // Fence: the remote revoke for this link already succeeded and only the local
@@ -238,6 +269,11 @@ fun BellhopApp() {
                     revokedRemotely = true
                     linkStore.clear()
                     lockStore.clear()
+                    // Stop the backstop and wipe the last-seen fleet so a re-pair
+                    // (possibly to a different Front Desk) starts from a clean
+                    // baseline rather than diffing against the old fleet.
+                    monitorStore.clear()
+                    FleetPollWorker.cancel(context)
                 } else {
                     unlinkFailed = true
                 }
@@ -267,6 +303,8 @@ fun BellhopApp() {
             try {
                 linkStore.clear()
                 lockStore.clear()
+                monitorStore.clear()
+                FleetPollWorker.cancel(context)
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Throwable) {
@@ -316,10 +354,12 @@ fun BellhopApp() {
                         lockStore = lockStore,
                         lockConfig = lockConfig,
                         lockAvailable = lockAvailable,
+                        monitorEnabled = monitorEnabled,
                         scope = scope,
                         unlinking = unlinking,
                         unlinkFailed = unlinkFailed,
                         onDismissUnlinkError = { unlinkFailed = false },
+                        onToggleMonitor = { toggleMonitor(it) },
                         onUnlink = { runUnlink(state.fdUrl) },
                         onForceUnlink = { forceUnlink() },
                     )
@@ -341,13 +381,26 @@ private fun LinkedContent(
     lockStore: LockStore,
     lockConfig: LockConfig,
     lockAvailable: Boolean,
+    monitorEnabled: Boolean,
     scope: CoroutineScope,
     unlinking: Boolean,
     unlinkFailed: Boolean,
     onDismissUnlinkError: () -> Unit,
+    onToggleMonitor: (Boolean) -> Unit,
     onUnlink: () -> Unit,
     onForceUnlink: () -> Unit,
 ) {
+    // Self-heal the Layer-2 poll: periodic work persists in WorkManager on its
+    // own, but re-asserting the schedule here (KEEP policy, so no interval reset)
+    // recovers it after a reinstall and stops it if monitoring was turned off.
+    val monitorContext = LocalContext.current
+    LaunchedEffect(monitorEnabled) {
+        if (monitorEnabled) {
+            FleetPollWorker.schedule(monitorContext)
+        } else {
+            FleetPollWorker.cancel(monitorContext)
+        }
+    }
     // Keyed by the full pairing (FD URL + deviceId): the Activity-scoped
     // ViewModel would otherwise survive an unlink and keep polling the OLD
     // Front Desk after a relink (same trap PairingViewModel.reset fixes).
@@ -425,9 +478,11 @@ private fun LinkedContent(
             link = state,
             lockConfig = lockConfig,
             lockAvailable = lockAvailable,
+            monitorEnabled = monitorEnabled,
             onBack = { showSettings = false },
             onToggleLock = { enabled -> scope.launch { lockStore.setEnabled(enabled) } },
             onSelectTimeout = { option -> scope.launch { lockStore.setTimeout(option.millis) } },
+            onToggleMonitor = onToggleMonitor,
             onAlertsClick = { showAlerts = true },
             onUnlink = onUnlink,
             unlinking = unlinking,

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
@@ -88,6 +88,14 @@ private fun appLockAuthenticators(): Int =
 private fun canAppLock(context: Context): Boolean =
     BiometricManager.from(context).canAuthenticate(appLockAuthenticators()) == BiometricManager.BIOMETRIC_SUCCESS
 
+// hasPostNotificationPermission reports whether Bellhop may post notifications.
+// POST_NOTIFICATIONS is a runtime permission from API 33; below that it is granted
+// at install, so the backstop can always post.
+private fun hasPostNotificationPermission(context: Context): Boolean =
+    Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ||
+        ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) ==
+        PackageManager.PERMISSION_GRANTED
+
 /**
  * promptAppUnlock shows the BiometricPrompt for the ambient app lock. It only
  * gates local access (the token at rest is Keystore-wrapped regardless), so if
@@ -152,22 +160,25 @@ fun BellhopApp() {
     val lockAvailable = remember(activity) { activity != null && canAppLock(activity) }
     val monitorEnabled by monitorStore.enabled.collectAsStateWithLifecycle(initialValue = false)
     val scope = rememberCoroutineScope()
+    // Whether Bellhop may post notifications. Tracked so Settings can be honest
+    // when monitoring is on but the permission was denied (or later revoked from
+    // system settings); refreshed on the permission result and on every return to
+    // the foreground below.
+    var notificationsGranted by remember { mutableStateOf(hasPostNotificationPermission(context)) }
     // Launcher for the POST_NOTIFICATIONS runtime permission (API 33+), fired when
-    // the user turns background monitoring on. A denial is fine: the backstop then
-    // polls silently until the permission is granted from system settings.
+    // the user turns background monitoring on. A denial is fine: the backstop still
+    // polls, and Settings flags that the alerts won't reach them until it's granted.
     val notificationPermission =
-        rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { }
+        rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+            notificationsGranted = granted
+        }
 
     // toggleMonitor persists the opt-in and, on enable, asks for the notification
     // permission. Scheduling the actual poll is left to LinkedContent's effect so
     // the DataStore flag stays the single source of truth for whether it runs.
     fun toggleMonitor(enabled: Boolean) {
         scope.launch { monitorStore.setEnabled(enabled) }
-        if (enabled &&
-            Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
-            ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) !=
-            PackageManager.PERMISSION_GRANTED
-        ) {
+        if (enabled && !hasPostNotificationPermission(context)) {
             notificationPermission.launch(Manifest.permission.POST_NOTIFICATIONS)
         }
     }
@@ -214,13 +225,16 @@ fun BellhopApp() {
             LifecycleEventObserver { _, event ->
                 when (event) {
                     Lifecycle.Event.ON_STOP -> scope.launch { lockStore.stampExit(System.currentTimeMillis()) }
-                    Lifecycle.Event.ON_START ->
+                    Lifecycle.Event.ON_START -> {
+                        // Catch a grant/revoke made in system settings while away.
+                        notificationsGranted = hasPostNotificationPermission(context)
                         scope.launch {
                             val snap = lockStore.snapshot()
                             if (shouldLock(snap.config, snap.lastForegroundExit, System.currentTimeMillis())) {
                                 locked = true
                             }
                         }
+                    }
                     else -> Unit
                 }
             }
@@ -355,6 +369,7 @@ fun BellhopApp() {
                         lockConfig = lockConfig,
                         lockAvailable = lockAvailable,
                         monitorEnabled = monitorEnabled,
+                        notificationsBlocked = monitorEnabled && !notificationsGranted,
                         scope = scope,
                         unlinking = unlinking,
                         unlinkFailed = unlinkFailed,
@@ -382,6 +397,7 @@ private fun LinkedContent(
     lockConfig: LockConfig,
     lockAvailable: Boolean,
     monitorEnabled: Boolean,
+    notificationsBlocked: Boolean,
     scope: CoroutineScope,
     unlinking: Boolean,
     unlinkFailed: Boolean,
@@ -479,6 +495,7 @@ private fun LinkedContent(
             lockConfig = lockConfig,
             lockAvailable = lockAvailable,
             monitorEnabled = monitorEnabled,
+            notificationsBlocked = notificationsBlocked,
             onBack = { showSettings = false },
             onToggleLock = { enabled -> scope.launch { lockStore.setEnabled(enabled) } },
             onSelectTimeout = { option -> scope.launch { lockStore.setTimeout(option.millis) } },

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/FleetSnapshot.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/FleetSnapshot.kt
@@ -1,0 +1,101 @@
+package com.hugalafutro.bellhop.data
+
+import kotlinx.serialization.Serializable
+
+/**
+ * MemberHealthState is the coarse health a background poll cares about: the four
+ * states a member card can be in, collapsed from [FleetMember] so the diff only
+ * has to compare enums. DRAINED and UNKNOWN are deliberately distinct from DOWN
+ * so the diff never mistakes a drained member (an operator choice) or an
+ * unprobed one (a fresh Front Desk start) for an outage.
+ */
+enum class MemberHealthState {
+    UP,
+    DOWN,
+    DRAINED,
+    UNKNOWN,
+}
+
+/**
+ * healthStateOf collapses a [FleetMember] to the one state the backstop diffs on.
+ * Drained wins over health (a drained member isn't "down"); an unprobed member is
+ * UNKNOWN, not DOWN, so a cold Front Desk doesn't look like a fleet-wide outage.
+ */
+fun healthStateOf(member: FleetMember): MemberHealthState =
+    when {
+        member.drained -> MemberHealthState.DRAINED
+        !member.status.health.known -> MemberHealthState.UNKNOWN
+        member.status.health.healthy -> MemberHealthState.UP
+        else -> MemberHealthState.DOWN
+    }
+
+/**
+ * FleetSnapshot is the last-seen health of every member, persisted between
+ * background polls so a stateless worker can tell what changed. States are stored
+ * as the enum name so an unknown value from a future build degrades to "no prior
+ * state" (see [stateOf]) rather than crashing the diff.
+ */
+@Serializable
+data class FleetSnapshot(
+    val states: Map<String, String> = emptyMap(),
+) {
+    /** stateOf returns the stored state for a member, or null if it wasn't seen. */
+    fun stateOf(id: String): MemberHealthState? =
+        states[id]?.let { name -> runCatching { MemberHealthState.valueOf(name) }.getOrNull() }
+
+    companion object {
+        fun of(members: List<FleetMember>): FleetSnapshot =
+            FleetSnapshot(members.associate { it.id to healthStateOf(it).name })
+    }
+}
+
+/**
+ * MemberTransition is a health edge worth a notification. Only the two edges that
+ * matter for a glance are modeled: a member that went down, and one that
+ * recovered. Drain/activate is an operator action (not an alert), and moves
+ * to/from UNKNOWN are noise (a reconnecting poller), so neither is a transition.
+ */
+sealed interface MemberTransition {
+    val id: String
+    val name: String
+
+    data class WentDown(
+        override val id: String,
+        override val name: String,
+    ) : MemberTransition
+
+    data class Recovered(
+        override val id: String,
+        override val name: String,
+    ) : MemberTransition
+}
+
+/**
+ * diffFleet is the pure backstop decision: given the previously persisted
+ * snapshot and the members just fetched, return the health edges to notify on.
+ *
+ * It alerts only on a real UP->DOWN or DOWN->UP edge. On the first ever poll
+ * ([previous] is null) it stays silent so a fresh install doesn't buzz once per
+ * member; a member with no prior state (newly added) is likewise skipped until it
+ * has a baseline. Edges through DRAINED/UNKNOWN never alert, so an operator
+ * draining a box or a poller briefly losing sight of one produces no false page.
+ */
+fun diffFleet(
+    previous: FleetSnapshot?,
+    current: List<FleetMember>,
+): List<MemberTransition> {
+    if (previous == null) return emptyList()
+    val transitions = mutableListOf<MemberTransition>()
+    for (member in current) {
+        val was = previous.stateOf(member.id) ?: continue
+        val now = healthStateOf(member)
+        val label = member.name.ifBlank { member.id }
+        when {
+            was == MemberHealthState.UP && now == MemberHealthState.DOWN ->
+                transitions += MemberTransition.WentDown(member.id, label)
+            was == MemberHealthState.DOWN && now == MemberHealthState.UP ->
+                transitions += MemberTransition.Recovered(member.id, label)
+        }
+    }
+    return transitions
+}

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/MonitorStore.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/MonitorStore.kt
@@ -5,6 +5,7 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import kotlinx.coroutines.flow.Flow
@@ -12,6 +13,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import kotlin.random.Random
 
 // Separate DataStore from the link and lock records so background-monitoring
 // policy has its own lifecycle; unlink clears all three explicitly.
@@ -37,8 +39,19 @@ class MonitorStore(
     val enabled: Flow<Boolean> = dataStore.data.map { it[ENABLED] ?: false }
 
     suspend fun setEnabled(enabled: Boolean) {
-        dataStore.edit { it[ENABLED] = enabled }
+        dataStore.edit { prefs ->
+            prefs[ENABLED] = enabled
+            // Each fresh enable stamps the session with a new random epoch, so a poll
+            // from a previous session (see [saveSnapshot]) can't persist its snapshot
+            // after an unlink + re-enable churned the store. A random id rather than a
+            // counter because clear() wipes the counter, so a monotone one would reset
+            // and collide across the very unlink+re-enable this guards against.
+            if (enabled) prefs[EPOCH] = Random.nextLong()
+        }
     }
+
+    /** epoch identifies the current monitoring session; 0 when never enabled. */
+    suspend fun epoch(): Long = dataStore.data.first()[EPOCH] ?: 0L
 
     /**
      * snapshot reads the last-seen fleet health, or null if none was ever saved
@@ -51,15 +64,22 @@ class MonitorStore(
         return runCatching { json.decodeFromString<FleetSnapshot>(stored) }.getOrNull()
     }
 
-    suspend fun saveSnapshot(snapshot: FleetSnapshot) {
+    /**
+     * saveSnapshot persists the baseline, but only if monitoring is still on AND
+     * still the same session ([epoch]) that started the poll. A poll can finish
+     * after an unlink cleared the store, or after an unlink + re-enable started a
+     * fresh session; a bare "enabled" check would let that late write repopulate a
+     * cleared store or poison the new session's baseline. The epoch the caller
+     * captured before fetching, the enabled flag, and the write all share one
+     * atomic edit, so a concurrent clear/re-enable is either seen (we skip) or
+     * overwrites us.
+     */
+    suspend fun saveSnapshot(
+        snapshot: FleetSnapshot,
+        epoch: Long,
+    ) {
         dataStore.edit { prefs ->
-            // Persist only while monitoring is on. A poll started before unlink can
-            // finish after clear() has run; without this guard that late write
-            // would repopulate a cleared store with the old fleet and poison the
-            // next pairing's baseline. The enabled check and the write share one
-            // atomic edit, so a concurrent clear either precedes it (enabled is
-            // gone, we skip) or follows it (and wipes what we wrote).
-            if (prefs[ENABLED] == true) {
+            if (prefs[ENABLED] == true && (prefs[EPOCH] ?: 0L) == epoch) {
                 prefs[SNAPSHOT] = json.encodeToString(snapshot)
             }
         }
@@ -73,6 +93,7 @@ class MonitorStore(
         fun create(context: Context): MonitorStore = MonitorStore(context.applicationContext.monitorDataStore)
 
         private val ENABLED = booleanPreferencesKey("enabled")
+        private val EPOCH = longPreferencesKey("epoch")
         private val SNAPSHOT = stringPreferencesKey("fleet_snapshot")
     }
 }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/MonitorStore.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/MonitorStore.kt
@@ -52,7 +52,17 @@ class MonitorStore(
     }
 
     suspend fun saveSnapshot(snapshot: FleetSnapshot) {
-        dataStore.edit { it[SNAPSHOT] = json.encodeToString(snapshot) }
+        dataStore.edit { prefs ->
+            // Persist only while monitoring is on. A poll started before unlink can
+            // finish after clear() has run; without this guard that late write
+            // would repopulate a cleared store with the old fleet and poison the
+            // next pairing's baseline. The enabled check and the write share one
+            // atomic edit, so a concurrent clear either precedes it (enabled is
+            // gone, we skip) or follows it (and wipes what we wrote).
+            if (prefs[ENABLED] == true) {
+                prefs[SNAPSHOT] = json.encodeToString(snapshot)
+            }
+        }
     }
 
     suspend fun clear() {

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/MonitorStore.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/MonitorStore.kt
@@ -1,0 +1,68 @@
+package com.hugalafutro.bellhop.data
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+// Separate DataStore from the link and lock records so background-monitoring
+// policy has its own lifecycle; unlink clears all three explicitly.
+private val Context.monitorDataStore: DataStore<Preferences> by
+    preferencesDataStore(name = "bellhop_monitor")
+
+/**
+ * MonitorStore persists the background-backstop policy (plan section 5.2, Layer
+ * 2): whether the periodic fleet poll is enabled, plus the last-seen
+ * [FleetSnapshot] the poll diffs against. The snapshot lives here, not in the
+ * worker, because a periodic worker is torn down between runs; only a persisted
+ * baseline lets it tell what changed since last time.
+ *
+ * Enabled defaults to off: turning it on schedules background work and (on API
+ * 33+) prompts for the notification permission, so it's an explicit opt-in rather
+ * than a surprise on first launch (the same stance the app lock ships with).
+ */
+class MonitorStore(
+    private val dataStore: DataStore<Preferences>,
+    private val json: Json = Json { ignoreUnknownKeys = true },
+) {
+    /** enabled emits the backstop toggle, defaulting to off. */
+    val enabled: Flow<Boolean> = dataStore.data.map { it[ENABLED] ?: false }
+
+    suspend fun setEnabled(enabled: Boolean) {
+        dataStore.edit { it[ENABLED] = enabled }
+    }
+
+    /**
+     * snapshot reads the last-seen fleet health, or null if none was ever saved
+     * (a fresh opt-in) or the stored form can't be parsed (a corrupt or
+     * incompatible record). Null means "no baseline", which [diffFleet] treats as
+     * a silent first poll rather than alerting on every member.
+     */
+    suspend fun snapshot(): FleetSnapshot? {
+        val stored = dataStore.data.first()[SNAPSHOT] ?: return null
+        return runCatching { json.decodeFromString<FleetSnapshot>(stored) }.getOrNull()
+    }
+
+    suspend fun saveSnapshot(snapshot: FleetSnapshot) {
+        dataStore.edit { it[SNAPSHOT] = json.encodeToString(snapshot) }
+    }
+
+    suspend fun clear() {
+        dataStore.edit { it.clear() }
+    }
+
+    companion object {
+        fun create(context: Context): MonitorStore = MonitorStore(context.applicationContext.monitorDataStore)
+
+        private val ENABLED = booleanPreferencesKey("enabled")
+        private val SNAPSHOT = stringPreferencesKey("fleet_snapshot")
+    }
+}

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/notify/FleetNotifier.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/notify/FleetNotifier.kt
@@ -30,6 +30,11 @@ object FleetNotifier {
     const val CHANNEL_DOWN = "member_down"
     const val CHANNEL_UP = "member_up"
 
+    // A constant numeric id: the member id is carried as the notification tag
+    // instead, so two members whose ids collide under String.hashCode() (an int id
+    // would fold them onto one row and drop an alert) still get separate rows.
+    private const val NOTIFICATION_ID = 1
+
     /**
      * ensureChannels registers both notification channels. Safe to call
      * repeatedly (createNotificationChannel is idempotent) and cheap, so it runs
@@ -85,13 +90,14 @@ object FleetNotifier {
                 .setCategory(NotificationCompat.CATEGORY_STATUS)
                 .build()
 
-        // Keyed on the member id so a member flapping down->up->down updates its
-        // one notification in place rather than stacking a fresh row each poll.
-        // canPost checked the permission, but it can be revoked between that check
-        // and here, so swallow the resulting SecurityException rather than crash a
-        // background worker over a lost notification.
+        // Tagged with the member id so a member flapping down->up->down updates its
+        // one notification in place rather than stacking a fresh row each poll, and
+        // so distinct members never share a row. canPost checked the permission,
+        // but it can be revoked between that check and here, so swallow the
+        // resulting SecurityException rather than crash a background worker over a
+        // lost notification.
         try {
-            NotificationManagerCompat.from(context).notify(notificationId(transition.id), notification)
+            NotificationManagerCompat.from(context).notify(transition.id, NOTIFICATION_ID, notification)
         } catch (_: SecurityException) {
         }
     }
@@ -99,10 +105,12 @@ object FleetNotifier {
     // Deep-linking to the specific member's detail is a later slice; for now the
     // tap just brings Bellhop to the front on its current screen.
     private fun openAppIntent(context: Context): android.app.PendingIntent {
-        val intent =
-            Intent(context, MainActivity::class.java).apply {
-                flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
-            }
+        // Explicit target (component + package) so this can only ever launch our
+        // own activity, and immutable so a holder can't rewrite it: an implicit or
+        // mutable PendingIntent could be hijacked by another app (CWE-927).
+        val intent = Intent(context, MainActivity::class.java)
+        intent.setPackage(context.packageName)
+        intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
         return android.app.PendingIntent.getActivity(
             context,
             0,
@@ -111,11 +119,10 @@ object FleetNotifier {
         )
     }
 
-    private fun notificationId(memberId: String): Int = memberId.hashCode()
-
     // POST_NOTIFICATIONS is a runtime permission from API 33; below that a channel
-    // notification always posts. Guarding here keeps the worker unconditional.
-    private fun canPost(context: Context): Boolean =
+    // notification always posts. Exposed so the worker can skip a poll it could
+    // never deliver rather than silently advance its baseline.
+    fun canPost(context: Context): Boolean =
         Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ||
             ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) ==
             PackageManager.PERMISSION_GRANTED

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/notify/FleetNotifier.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/notify/FleetNotifier.kt
@@ -1,0 +1,122 @@
+package com.hugalafutro.bellhop.notify
+
+import android.Manifest
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
+import com.hugalafutro.bellhop.MainActivity
+import com.hugalafutro.bellhop.R
+import com.hugalafutro.bellhop.data.MemberTransition
+
+/**
+ * FleetNotifier renders the background backstop's fleet-health edges as local
+ * notifications (plan section 5.2). It is deliberately not an alert *source*:
+ * Front Desk's own Apprise pipeline already pages on the same events; this exists
+ * so a tap lands the operator back in Bellhop, and so a phone with no real-time
+ * layer still learns "a member went down" within a poll or two.
+ *
+ * Two channels split by severity so Android's per-channel muting works: "member
+ * down" is high importance (it may page), "member recovered" is low (a quiet
+ * status update). Posting is a no-op when the POST_NOTIFICATIONS permission is
+ * absent, so the worker never has to guard the call itself.
+ */
+object FleetNotifier {
+    const val CHANNEL_DOWN = "member_down"
+    const val CHANNEL_UP = "member_up"
+
+    /**
+     * ensureChannels registers both notification channels. Safe to call
+     * repeatedly (createNotificationChannel is idempotent) and cheap, so it runs
+     * at app start and again defensively before each post.
+     */
+    fun ensureChannels(context: Context) {
+        val manager = context.getSystemService(NotificationManager::class.java) ?: return
+        manager.createNotificationChannel(
+            NotificationChannel(
+                CHANNEL_DOWN,
+                context.getString(R.string.notif_channel_down),
+                NotificationManager.IMPORTANCE_HIGH,
+            ),
+        )
+        manager.createNotificationChannel(
+            NotificationChannel(
+                CHANNEL_UP,
+                context.getString(R.string.notif_channel_up),
+                NotificationManager.IMPORTANCE_LOW,
+            ),
+        )
+    }
+
+    /** notify posts one health-edge notification, or does nothing if it can't. */
+    fun notify(
+        context: Context,
+        transition: MemberTransition,
+    ) {
+        if (!canPost(context)) return
+        ensureChannels(context)
+
+        val (channel, title) =
+            when (transition) {
+                is MemberTransition.WentDown ->
+                    CHANNEL_DOWN to context.getString(R.string.notif_down_title, transition.name)
+                is MemberTransition.Recovered ->
+                    CHANNEL_UP to context.getString(R.string.notif_up_title, transition.name)
+            }
+        val body =
+            when (transition) {
+                is MemberTransition.WentDown -> context.getString(R.string.notif_down_body)
+                is MemberTransition.Recovered -> context.getString(R.string.notif_up_body)
+            }
+
+        val notification =
+            NotificationCompat
+                .Builder(context, channel)
+                .setSmallIcon(R.drawable.ic_stat_bellhop)
+                .setContentTitle(title)
+                .setContentText(body)
+                .setContentIntent(openAppIntent(context))
+                .setAutoCancel(true)
+                .setCategory(NotificationCompat.CATEGORY_STATUS)
+                .build()
+
+        // Keyed on the member id so a member flapping down->up->down updates its
+        // one notification in place rather than stacking a fresh row each poll.
+        // canPost checked the permission, but it can be revoked between that check
+        // and here, so swallow the resulting SecurityException rather than crash a
+        // background worker over a lost notification.
+        try {
+            NotificationManagerCompat.from(context).notify(notificationId(transition.id), notification)
+        } catch (_: SecurityException) {
+        }
+    }
+
+    // Deep-linking to the specific member's detail is a later slice; for now the
+    // tap just brings Bellhop to the front on its current screen.
+    private fun openAppIntent(context: Context): android.app.PendingIntent {
+        val intent =
+            Intent(context, MainActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
+            }
+        return android.app.PendingIntent.getActivity(
+            context,
+            0,
+            intent,
+            android.app.PendingIntent.FLAG_IMMUTABLE or android.app.PendingIntent.FLAG_UPDATE_CURRENT,
+        )
+    }
+
+    private fun notificationId(memberId: String): Int = memberId.hashCode()
+
+    // POST_NOTIFICATIONS is a runtime permission from API 33; below that a channel
+    // notification always posts. Guarding here keeps the worker unconditional.
+    private fun canPost(context: Context): Boolean =
+        Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ||
+            ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) ==
+            PackageManager.PERMISSION_GRANTED
+}

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreen.kt
@@ -65,6 +65,7 @@ fun SettingsScreen(
     onAlertsClick: () -> Unit,
     onUnlink: () -> Unit,
     modifier: Modifier = Modifier,
+    notificationsBlocked: Boolean = false,
     unlinking: Boolean = false,
     unlinkFailed: Boolean = false,
     onDismissUnlinkError: () -> Unit = {},
@@ -301,6 +302,18 @@ fun SettingsScreen(
                         )
                     }
                     if (monitorEnabled) {
+                        if (notificationsBlocked) {
+                            // Monitoring polls regardless, but with
+                            // POST_NOTIFICATIONS denied nothing reaches the
+                            // operator, so say so rather than let the switch
+                            // imply working alerts.
+                            Text(
+                                text = stringResource(R.string.settings_monitor_blocked),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.error,
+                                modifier = Modifier.testTag("settings-monitor-blocked"),
+                            )
+                        }
                         Text(
                             text = stringResource(R.string.settings_monitor_note),
                             style = MaterialTheme.typography.bodySmall,

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreen.kt
@@ -57,9 +57,11 @@ fun SettingsScreen(
     link: LinkState.Linked,
     lockConfig: LockConfig,
     lockAvailable: Boolean,
+    monitorEnabled: Boolean,
     onBack: () -> Unit,
     onToggleLock: (Boolean) -> Unit,
     onSelectTimeout: (LockTimeout) -> Unit,
+    onToggleMonitor: (Boolean) -> Unit,
     onAlertsClick: () -> Unit,
     onUnlink: () -> Unit,
     modifier: Modifier = Modifier,
@@ -267,6 +269,50 @@ fun SettingsScreen(
 
             Spacer(modifier = Modifier.height(16.dp))
 
+            // Background monitoring: the Layer-2 backstop (plan section 5.2). Off
+            // by default; turning it on schedules the periodic poll and prompts
+            // for the notification permission.
+            Card(modifier = Modifier.fillMaxWidth()) {
+                Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = stringResource(R.string.settings_monitor_title),
+                                style = MaterialTheme.typography.titleMedium,
+                            )
+                            Text(
+                                text = stringResource(R.string.settings_monitor_subtitle),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                        Switch(
+                            checked = monitorEnabled,
+                            onCheckedChange = onToggleMonitor,
+                            // Same off-state colours as the lock switch so an off
+                            // toggle stays legible on the card (see note above).
+                            colors =
+                                SwitchDefaults.colors(
+                                    uncheckedThumbColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    uncheckedTrackColor = MaterialTheme.colorScheme.surface,
+                                    uncheckedBorderColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                                ),
+                            modifier = Modifier.testTag("settings-monitor-toggle"),
+                        )
+                    }
+                    if (monitorEnabled) {
+                        Text(
+                            text = stringResource(R.string.settings_monitor_note),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.testTag("settings-monitor-note"),
+                        )
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
             // Alerts stays reachable here even when all is green (the dashboard bell
             // only appears when a member is down).
             Card(modifier = Modifier.fillMaxWidth().clickable(onClick = onAlertsClick).testTag("settings-alerts")) {
@@ -322,9 +368,11 @@ private fun SettingsScreenPreview() {
                 ),
             lockConfig = LockConfig(enabled = true, timeoutMs = LockTimeout.THIRTY_MINUTES.millis),
             lockAvailable = true,
+            monitorEnabled = true,
             onBack = {},
             onToggleLock = {},
             onSelectTimeout = {},
+            onToggleMonitor = {},
             onAlertsClick = {},
             onUnlink = {},
         )

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/work/FleetPollWorker.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/work/FleetPollWorker.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.work.Constraints
 import androidx.work.CoroutineWorker
 import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.ListenableWorker.Result
 import androidx.work.NetworkType
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
@@ -64,12 +65,49 @@ suspend fun pollFleet(
     }
 
 /**
+ * runBackstop is the guarded dispatch [FleetPollWorker.doWork] performs each run,
+ * extracted from the worker runtime so its short-circuits are unit-testable (the
+ * same reason [pollFleet] is a free function). It bails to success in the three
+ * steady states the foreground UI already handles — monitoring turned off, the
+ * device unlinked, or the token unreadable — and otherwise polls, notifies on any
+ * health edges, and maps the poll outcome onto a worker [Result].
+ */
+suspend fun runBackstop(
+    monitorStore: MonitorStore,
+    linkStore: LinkStore,
+    client: FrontDeskClient,
+    notify: (MemberTransition) -> Unit,
+): Result {
+    // Disabled or already unscheduled: nothing to do. A stale run can outlive the
+    // toggle being turned off, so re-check rather than trust scheduling.
+    if (!monitorStore.enabled.first()) return Result.success()
+
+    val link = linkStore.state.first()
+    if (link !is LinkState.Linked) return Result.success()
+    // No readable token (unlinked mid-run, or the Keystore key is gone): the
+    // foreground UI surfaces the revoke; the backstop just stops quietly.
+    val token = linkStore.token() ?: return Result.success()
+
+    return when (val result = pollFleet(client, link.fdUrl, token, monitorStore)) {
+        is PollResult.Changed -> {
+            result.transitions.forEach(notify)
+            Result.success()
+        }
+        // A revoked token can never succeed again; retrying would just hammer
+        // Front Desk. The foreground UI flags the revoke, so end quietly.
+        PollResult.Unauthorized -> Result.success()
+        PollResult.Failed -> Result.retry()
+    }
+}
+
+/**
  * FleetPollWorker is the Layer-2 background backstop (plan section 5.2): a periodic
  * poll that, while Bellhop is backgrounded or killed, diffs fleet health against
  * the last poll and posts a local notification on a member going down or
  * recovering. It needs no push infrastructure and no Google dependency; the
  * trade-off is the 15-minute WorkManager floor, so a change is learned up to a
- * poll late.
+ * poll late. The run logic lives in [runBackstop]; this shell only supplies the
+ * real stores, client, and notifier.
  */
 class FleetPollWorker(
     appContext: Context,
@@ -77,28 +115,12 @@ class FleetPollWorker(
 ) : CoroutineWorker(appContext, params) {
     override suspend fun doWork(): Result {
         val context = applicationContext
-        val monitorStore = MonitorStore.create(context)
-        // Disabled or already unscheduled: nothing to do. A stale run can outlive
-        // the toggle being turned off, so re-check rather than trust scheduling.
-        if (!monitorStore.enabled.first()) return Result.success()
-
-        val linkStore = LinkStore.create(context)
-        val link = linkStore.state.first()
-        if (link !is LinkState.Linked) return Result.success()
-        // No readable token (unlinked mid-run, or the Keystore key is gone): the
-        // foreground UI surfaces the revoke; the backstop just stops quietly.
-        val token = linkStore.token() ?: return Result.success()
-
-        return when (val result = pollFleet(FrontDeskClient(), link.fdUrl, token, monitorStore)) {
-            is PollResult.Changed -> {
-                result.transitions.forEach { FleetNotifier.notify(context, it) }
-                Result.success()
-            }
-            // A revoked token can never succeed again; retrying would just hammer
-            // Front Desk. The foreground UI flags the revoke, so end quietly.
-            PollResult.Unauthorized -> Result.success()
-            PollResult.Failed -> Result.retry()
-        }
+        return runBackstop(
+            monitorStore = MonitorStore.create(context),
+            linkStore = LinkStore.create(context),
+            client = FrontDeskClient(),
+            notify = { FleetNotifier.notify(context, it) },
+        )
     }
 
     companion object {

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/work/FleetPollWorker.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/work/FleetPollWorker.kt
@@ -1,0 +1,134 @@
+package com.hugalafutro.bellhop.work
+
+import android.content.Context
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import com.hugalafutro.bellhop.data.FetchResult
+import com.hugalafutro.bellhop.data.FleetSnapshot
+import com.hugalafutro.bellhop.data.FrontDeskClient
+import com.hugalafutro.bellhop.data.LinkState
+import com.hugalafutro.bellhop.data.LinkStore
+import com.hugalafutro.bellhop.data.MemberTransition
+import com.hugalafutro.bellhop.data.MonitorStore
+import com.hugalafutro.bellhop.data.diffFleet
+import com.hugalafutro.bellhop.notify.FleetNotifier
+import kotlinx.coroutines.flow.first
+import java.util.concurrent.TimeUnit
+
+/**
+ * PollResult is the outcome of one backstop poll. It is separate from WorkManager's
+ * Result so [pollFleet] can be unit-tested without the worker runtime: [Changed]
+ * means the fetch succeeded and the snapshot was persisted (with any health edges
+ * to notify on), [Unauthorized] means the device token is dead, and [Failed] is a
+ * transient error worth a retry.
+ */
+sealed interface PollResult {
+    data class Changed(
+        val transitions: List<MemberTransition>,
+    ) : PollResult
+
+    data object Unauthorized : PollResult
+
+    data object Failed : PollResult
+}
+
+/**
+ * pollFleet is the testable core of the background backstop: fetch the fleet,
+ * diff it against the last-seen snapshot, persist the new snapshot, and return the
+ * health edges. It performs no notification or Android I/O itself, so it can run
+ * against a MockWebServer-backed [FrontDeskClient] and a temp [MonitorStore]. The
+ * snapshot is saved on every successful fetch (even with no transitions) so the
+ * baseline keeps advancing; it is left untouched on failure so a transient error
+ * doesn't erase the baseline and re-alert the whole fleet next run.
+ */
+suspend fun pollFleet(
+    client: FrontDeskClient,
+    fdUrl: String,
+    token: String,
+    monitorStore: MonitorStore,
+): PollResult =
+    when (val result = client.members(fdUrl, token)) {
+        is FetchResult.Success -> {
+            val previous = monitorStore.snapshot()
+            val transitions = diffFleet(previous, result.data)
+            monitorStore.saveSnapshot(FleetSnapshot.of(result.data))
+            PollResult.Changed(transitions)
+        }
+        FetchResult.Unauthorized -> PollResult.Unauthorized
+        is FetchResult.Failure -> PollResult.Failed
+    }
+
+/**
+ * FleetPollWorker is the Layer-2 background backstop (plan section 5.2): a periodic
+ * poll that, while Bellhop is backgrounded or killed, diffs fleet health against
+ * the last poll and posts a local notification on a member going down or
+ * recovering. It needs no push infrastructure and no Google dependency; the
+ * trade-off is the 15-minute WorkManager floor, so a change is learned up to a
+ * poll late.
+ */
+class FleetPollWorker(
+    appContext: Context,
+    params: WorkerParameters,
+) : CoroutineWorker(appContext, params) {
+    override suspend fun doWork(): Result {
+        val context = applicationContext
+        val monitorStore = MonitorStore.create(context)
+        // Disabled or already unscheduled: nothing to do. A stale run can outlive
+        // the toggle being turned off, so re-check rather than trust scheduling.
+        if (!monitorStore.enabled.first()) return Result.success()
+
+        val linkStore = LinkStore.create(context)
+        val link = linkStore.state.first()
+        if (link !is LinkState.Linked) return Result.success()
+        // No readable token (unlinked mid-run, or the Keystore key is gone): the
+        // foreground UI surfaces the revoke; the backstop just stops quietly.
+        val token = linkStore.token() ?: return Result.success()
+
+        return when (val result = pollFleet(FrontDeskClient(), link.fdUrl, token, monitorStore)) {
+            is PollResult.Changed -> {
+                result.transitions.forEach { FleetNotifier.notify(context, it) }
+                Result.success()
+            }
+            // A revoked token can never succeed again; retrying would just hammer
+            // Front Desk. The foreground UI flags the revoke, so end quietly.
+            PollResult.Unauthorized -> Result.success()
+            PollResult.Failed -> Result.retry()
+        }
+    }
+
+    companion object {
+        private const val UNIQUE_NAME = "fleet-poll"
+
+        // The 15-minute WorkManager floor is the shortest periodic interval Android
+        // allows; the backstop is explicitly not real-time (plan section 5.2).
+        private const val INTERVAL_MINUTES = 15L
+
+        /**
+         * schedule enqueues the periodic poll, keeping any existing schedule so a
+         * re-schedule on app open (self-heal) doesn't reset the interval clock.
+         * Requires network so a poll doesn't wake only to fail offline.
+         */
+        fun schedule(context: Context) {
+            val request =
+                PeriodicWorkRequestBuilder<FleetPollWorker>(INTERVAL_MINUTES, TimeUnit.MINUTES)
+                    .setConstraints(
+                        Constraints
+                            .Builder()
+                            .setRequiredNetworkType(NetworkType.CONNECTED)
+                            .build(),
+                    ).build()
+            WorkManager
+                .getInstance(context)
+                .enqueueUniquePeriodicWork(UNIQUE_NAME, ExistingPeriodicWorkPolicy.KEEP, request)
+        }
+
+        fun cancel(context: Context) {
+            WorkManager.getInstance(context).cancelUniqueWork(UNIQUE_NAME)
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/work/FleetPollWorker.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/work/FleetPollWorker.kt
@@ -52,17 +52,22 @@ suspend fun pollFleet(
     fdUrl: String,
     token: String,
     monitorStore: MonitorStore,
-): PollResult =
-    when (val result = client.members(fdUrl, token)) {
+): PollResult {
+    // Capture the session epoch before the fetch: if an unlink + re-enable churns
+    // the store while this poll is in flight, saveSnapshot drops our now-stale
+    // write instead of poisoning the new session's baseline.
+    val epoch = monitorStore.epoch()
+    return when (val result = client.members(fdUrl, token)) {
         is FetchResult.Success -> {
             val previous = monitorStore.snapshot()
             val transitions = diffFleet(previous, result.data)
-            monitorStore.saveSnapshot(FleetSnapshot.of(result.data))
+            monitorStore.saveSnapshot(FleetSnapshot.of(result.data), epoch)
             PollResult.Changed(transitions)
         }
         FetchResult.Unauthorized -> PollResult.Unauthorized
         is FetchResult.Failure -> PollResult.Failed
     }
+}
 
 /**
  * runBackstop is the guarded dispatch [FleetPollWorker.doWork] performs each run,

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/work/FleetPollWorker.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/work/FleetPollWorker.kt
@@ -67,20 +67,25 @@ suspend fun pollFleet(
 /**
  * runBackstop is the guarded dispatch [FleetPollWorker.doWork] performs each run,
  * extracted from the worker runtime so its short-circuits are unit-testable (the
- * same reason [pollFleet] is a free function). It bails to success in the three
- * steady states the foreground UI already handles — monitoring turned off, the
- * device unlinked, or the token unreadable — and otherwise polls, notifies on any
- * health edges, and maps the poll outcome onto a worker [Result].
+ * same reason [pollFleet] is a free function). It bails to success in the steady
+ * states the foreground UI already handles — monitoring turned off, notifications
+ * blocked, the device unlinked, or the token unreadable — and otherwise polls,
+ * notifies on any health edges, and maps the poll outcome onto a worker [Result].
  */
 suspend fun runBackstop(
     monitorStore: MonitorStore,
     linkStore: LinkStore,
     client: FrontDeskClient,
+    canNotify: Boolean,
     notify: (MemberTransition) -> Unit,
 ): Result {
     // Disabled or already unscheduled: nothing to do. A stale run can outlive the
     // toggle being turned off, so re-check rather than trust scheduling.
     if (!monitorStore.enabled.first()) return Result.success()
+    // Can't post? Don't poll. Advancing the baseline while alerts are silently
+    // dropped would swallow the very down->up change the operator needs to see
+    // once they grant the permission, so freeze until then (Settings flags it).
+    if (!canNotify) return Result.success()
 
     val link = linkStore.state.first()
     if (link !is LinkState.Linked) return Result.success()
@@ -119,6 +124,7 @@ class FleetPollWorker(
             monitorStore = MonitorStore.create(context),
             linkStore = LinkStore.create(context),
             client = FrontDeskClient(),
+            canNotify = FleetNotifier.canPost(context),
             notify = { FleetNotifier.notify(context, it) },
         )
     }

--- a/android/app/src/main/res/drawable/ic_stat_bellhop.xml
+++ b/android/app/src/main/res/drawable/ic_stat_bellhop.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Status-bar notification icon. Rendered as an alpha mask by Android, so it is
+     a single flat silhouette (a service bell, for "Bellhop"); the fill colour is
+     only used by previews. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#FFFFFFFF">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M12,4.5c-0.55,0 -1,0.45 -1,1v0.58C7.6,6.54 5,9.46 5,13v1H3v2h18v-2h-2v-1c0,-3.54 -2.6,-6.46 -6,-6.92V5.5c0,-0.55 -0.45,-1 -1,-1zM3,18h18v1.5H3z" />
+</vector>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -119,6 +119,7 @@
     <string name="settings_monitor_title">Background monitoring</string>
     <string name="settings_monitor_subtitle">Check the fleet every 15 minutes and notify you here when a member goes down or recovers, even when Bellhop is closed.</string>
     <string name="settings_monitor_note">Front Desk\'s own alerts are faster; this is a backstop for when Bellhop is your only view. It checks roughly every 15 minutes, so a change can be up to that late.</string>
+    <string name="settings_monitor_blocked">Notifications are turned off for Bellhop, so these alerts won\'t reach you. Turn them on in system settings.</string>
 
     <!-- Background-monitoring notifications (Layer 2 backstop) -->
     <string name="notif_channel_down">Member down</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -116,6 +116,17 @@
     <string name="settings_lock_1h">1 hr</string>
     <string name="settings_alerts_title">Alerts</string>
     <string name="settings_alerts_subtitle">Notification delivery and what Front Desk alerts on.</string>
+    <string name="settings_monitor_title">Background monitoring</string>
+    <string name="settings_monitor_subtitle">Check the fleet every 15 minutes and notify you here when a member goes down or recovers, even when Bellhop is closed.</string>
+    <string name="settings_monitor_note">Front Desk\'s own alerts are faster; this is a backstop for when Bellhop is your only view. It checks roughly every 15 minutes, so a change can be up to that late.</string>
+
+    <!-- Background-monitoring notifications (Layer 2 backstop) -->
+    <string name="notif_channel_down">Member down</string>
+    <string name="notif_channel_up">Member recovered</string>
+    <string name="notif_down_title">%1$s is down</string>
+    <string name="notif_down_body">A member stopped responding. Tap to open Bellhop.</string>
+    <string name="notif_up_title">%1$s recovered</string>
+    <string name="notif_up_body">A member is responding again.</string>
 
     <string name="dashboard_unlink">Unlink</string>
     <string name="dashboard_unlink_confirm_title">Unlink this device?</string>

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/FleetSnapshotTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/FleetSnapshotTest.kt
@@ -1,0 +1,103 @@
+package com.hugalafutro.bellhop.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The backstop's diff is pure, so it is tested directly (no worker, no clock, no
+ * counters) the way the SSE filter and the lock timer are: assert the edge set a
+ * snapshot pair produces, so the "what warrants a notification" rule is pinned
+ * without any Android or network machinery.
+ */
+class FleetSnapshotTest {
+    private fun member(
+        id: String,
+        name: String = id,
+        state: String = "active",
+        known: Boolean = true,
+        healthy: Boolean = true,
+    ): FleetMember =
+        FleetMember(
+            id = id,
+            name = name,
+            state = state,
+            status = MemberStatus(health = HealthStatus(known = known, healthy = healthy)),
+        )
+
+    private fun snapshotOf(vararg members: FleetMember): FleetSnapshot = FleetSnapshot.of(members.toList())
+
+    @Test
+    fun healthStateCollapsesTheFourCases() {
+        assertEquals(MemberHealthState.UP, healthStateOf(member("m", healthy = true)))
+        assertEquals(MemberHealthState.DOWN, healthStateOf(member("m", healthy = false)))
+        assertEquals(MemberHealthState.UNKNOWN, healthStateOf(member("m", known = false)))
+        // Drained wins over health: a drained member that still probes healthy is
+        // DRAINED, so draining never reads as an outage.
+        assertEquals(MemberHealthState.DRAINED, healthStateOf(member("m", state = "drained", healthy = true)))
+    }
+
+    @Test
+    fun firstPollHasNoBaselineSoStaysSilent() {
+        // Null previous = fresh opt-in; alerting here would buzz once per member.
+        assertTrue(diffFleet(null, listOf(member("m1", healthy = false))).isEmpty())
+    }
+
+    @Test
+    fun upToDownIsWentDown() {
+        val previous = snapshotOf(member("m1", name = "hotel-1", healthy = true))
+        val transitions = diffFleet(previous, listOf(member("m1", name = "hotel-1", healthy = false)))
+        assertEquals(listOf(MemberTransition.WentDown("m1", "hotel-1")), transitions)
+    }
+
+    @Test
+    fun downToUpIsRecovered() {
+        val previous = snapshotOf(member("m1", name = "hotel-1", healthy = false))
+        val transitions = diffFleet(previous, listOf(member("m1", name = "hotel-1", healthy = true)))
+        assertEquals(listOf(MemberTransition.Recovered("m1", "hotel-1")), transitions)
+    }
+
+    @Test
+    fun steadyStateProducesNoTransition() {
+        val previous = snapshotOf(member("m1", healthy = true))
+        assertTrue(diffFleet(previous, listOf(member("m1", healthy = true))).isEmpty())
+    }
+
+    @Test
+    fun drainingIsNotAnOutage() {
+        val previous = snapshotOf(member("m1", healthy = true))
+        val transitions = diffFleet(previous, listOf(member("m1", state = "drained", healthy = true)))
+        assertTrue(transitions.isEmpty())
+    }
+
+    @Test
+    fun edgesThroughUnknownStayQuiet() {
+        // A poller briefly losing sight of a member (UP -> UNKNOWN -> UP) must not
+        // fire a down/recovered pair, so neither edge is a transition.
+        val wasUp = snapshotOf(member("m1", healthy = true))
+        assertTrue(diffFleet(wasUp, listOf(member("m1", known = false))).isEmpty())
+
+        val wasUnknown = snapshotOf(member("m1", known = false))
+        assertTrue(diffFleet(wasUnknown, listOf(member("m1", healthy = false))).isEmpty())
+    }
+
+    @Test
+    fun newlyAddedMemberHasNoBaselineEdge() {
+        // m2 wasn't in the previous snapshot; it must wait for a baseline before it
+        // can ever produce a transition, even if it appears already down.
+        val previous = snapshotOf(member("m1", healthy = true))
+        val transitions =
+            diffFleet(
+                previous,
+                listOf(member("m1", healthy = true), member("m2", healthy = false)),
+            )
+        assertTrue(transitions.isEmpty())
+    }
+
+    @Test
+    fun transitionLabelFallsBackToIdWhenNameBlank() {
+        val previous = snapshotOf(member("m1", name = "", healthy = true))
+        val transitions = diffFleet(previous, listOf(member("m1", name = "", healthy = false)))
+        assertEquals(listOf(MemberTransition.WentDown("m1", "m1")), transitions)
+    }
+}

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/MonitorStoreTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/MonitorStoreTest.kt
@@ -56,6 +56,7 @@ class MonitorStoreTest {
     fun snapshotRoundTrips() =
         runBlocking {
             val store = newStore()
+            store.setEnabled(true)
             val snapshot =
                 FleetSnapshot(
                     mapOf(
@@ -75,8 +76,19 @@ class MonitorStoreTest {
             // A state name a future build wrote but this one doesn't know must not
             // crash the diff; stateOf returns null so it's treated as "no baseline".
             val store = newStore()
+            store.setEnabled(true)
             store.saveSnapshot(FleetSnapshot(mapOf("m1" to "FROM_THE_FUTURE")))
             assertNull(store.snapshot()?.stateOf("m1"))
+        }
+
+    @Test
+    fun snapshotSaveIsIgnoredWhileMonitoringOff() =
+        runBlocking {
+            // A poll finishing after unlink cleared the store must not resurrect a
+            // baseline: with monitoring off, saveSnapshot is a no-op.
+            val store = newStore()
+            store.saveSnapshot(FleetSnapshot(mapOf("m1" to MemberHealthState.UP.name)))
+            assertNull(store.snapshot())
         }
 
     @Test

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/MonitorStoreTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/MonitorStoreTest.kt
@@ -1,0 +1,92 @@
+package com.hugalafutro.bellhop.data
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class MonitorStoreTest {
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    private fun newStore(): MonitorStore {
+        val scope = CoroutineScope(Dispatchers.IO + Job())
+        val ds: DataStore<Preferences> =
+            PreferenceDataStoreFactory.create(scope = scope) {
+                File(tmp.newFolder(), "monitor.preferences_pb")
+            }
+        return MonitorStore(ds)
+    }
+
+    @Test
+    fun defaultsToDisabled() =
+        runBlocking {
+            assertFalse(newStore().enabled.first())
+        }
+
+    @Test
+    fun enabledFlagRoundTrips() =
+        runBlocking {
+            val store = newStore()
+            store.setEnabled(true)
+            assertTrue(store.enabled.first())
+        }
+
+    @Test
+    fun snapshotIsNullUntilSaved() =
+        runBlocking {
+            // A fresh opt-in has no baseline, which the diff reads as a silent
+            // first poll rather than alerting on every member.
+            assertNull(newStore().snapshot())
+        }
+
+    @Test
+    fun snapshotRoundTrips() =
+        runBlocking {
+            val store = newStore()
+            val snapshot =
+                FleetSnapshot(
+                    mapOf(
+                        "m1" to MemberHealthState.UP.name,
+                        "m2" to MemberHealthState.DOWN.name,
+                    ),
+                )
+            store.saveSnapshot(snapshot)
+            val read = store.snapshot()
+            assertEquals(MemberHealthState.UP, read?.stateOf("m1"))
+            assertEquals(MemberHealthState.DOWN, read?.stateOf("m2"))
+        }
+
+    @Test
+    fun unknownStoredStateDegradesToNull() =
+        runBlocking {
+            // A state name a future build wrote but this one doesn't know must not
+            // crash the diff; stateOf returns null so it's treated as "no baseline".
+            val store = newStore()
+            store.saveSnapshot(FleetSnapshot(mapOf("m1" to "FROM_THE_FUTURE")))
+            assertNull(store.snapshot()?.stateOf("m1"))
+        }
+
+    @Test
+    fun clearResetsEnabledAndSnapshot() =
+        runBlocking {
+            val store = newStore()
+            store.setEnabled(true)
+            store.saveSnapshot(FleetSnapshot(mapOf("m1" to MemberHealthState.UP.name)))
+            store.clear()
+            assertFalse(store.enabled.first())
+            assertNull(store.snapshot())
+        }
+}

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/MonitorStoreTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/MonitorStoreTest.kt
@@ -64,7 +64,7 @@ class MonitorStoreTest {
                         "m2" to MemberHealthState.DOWN.name,
                     ),
                 )
-            store.saveSnapshot(snapshot)
+            store.saveSnapshot(snapshot, store.epoch())
             val read = store.snapshot()
             assertEquals(MemberHealthState.UP, read?.stateOf("m1"))
             assertEquals(MemberHealthState.DOWN, read?.stateOf("m2"))
@@ -77,7 +77,7 @@ class MonitorStoreTest {
             // crash the diff; stateOf returns null so it's treated as "no baseline".
             val store = newStore()
             store.setEnabled(true)
-            store.saveSnapshot(FleetSnapshot(mapOf("m1" to "FROM_THE_FUTURE")))
+            store.saveSnapshot(FleetSnapshot(mapOf("m1" to "FROM_THE_FUTURE")), store.epoch())
             assertNull(store.snapshot()?.stateOf("m1"))
         }
 
@@ -87,7 +87,23 @@ class MonitorStoreTest {
             // A poll finishing after unlink cleared the store must not resurrect a
             // baseline: with monitoring off, saveSnapshot is a no-op.
             val store = newStore()
-            store.saveSnapshot(FleetSnapshot(mapOf("m1" to MemberHealthState.UP.name)))
+            store.saveSnapshot(FleetSnapshot(mapOf("m1" to MemberHealthState.UP.name)), store.epoch())
+            assertNull(store.snapshot())
+        }
+
+    @Test
+    fun snapshotSaveFromAStaleSessionIsDropped() =
+        runBlocking {
+            // An in-flight poll captured this session's epoch...
+            val store = newStore()
+            store.setEnabled(true)
+            val staleEpoch = store.epoch()
+            // ...then the operator unlinked and re-enabled, starting a new session.
+            store.clear()
+            store.setEnabled(true)
+            // The old poll now tries to persist against the stale epoch: it must be
+            // dropped so it can't poison the new session's baseline.
+            store.saveSnapshot(FleetSnapshot(mapOf("m1" to MemberHealthState.UP.name)), staleEpoch)
             assertNull(store.snapshot())
         }
 
@@ -96,7 +112,7 @@ class MonitorStoreTest {
         runBlocking {
             val store = newStore()
             store.setEnabled(true)
-            store.saveSnapshot(FleetSnapshot(mapOf("m1" to MemberHealthState.UP.name)))
+            store.saveSnapshot(FleetSnapshot(mapOf("m1" to MemberHealthState.UP.name)), store.epoch())
             store.clear()
             assertFalse(store.enabled.first())
             assertNull(store.snapshot())

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/notify/FleetNotifierTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/notify/FleetNotifierTest.kt
@@ -1,0 +1,44 @@
+package com.hugalafutro.bellhop.notify
+
+import android.Manifest
+import android.app.Application
+import android.app.NotificationManager
+import com.hugalafutro.bellhop.data.MemberTransition
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+/**
+ * Posting behaviour: alerts stay distinct per member, and nothing posts without
+ * the runtime permission. Pinned to API 34 so the POST_NOTIFICATIONS check is the
+ * one that runs (below 33 it's granted at install and the deny case is moot).
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class FleetNotifierTest {
+    private val app: Application = RuntimeEnvironment.getApplication()
+    private val notifications: NotificationManager
+        get() = app.getSystemService(NotificationManager::class.java)
+
+    @Test
+    fun membersWithCollidingIdHashesEachGetTheirOwnNotification() {
+        shadowOf(app).grantPermissions(Manifest.permission.POST_NOTIFICATIONS)
+        // "Aa" and "BB" share a String.hashCode() (both 2112); a bare int id would
+        // fold them onto one row and drop an alert. The member-id tag keeps them
+        // apart, so both survive.
+        FleetNotifier.notify(app, MemberTransition.WentDown("Aa", "Alpha"))
+        FleetNotifier.notify(app, MemberTransition.WentDown("BB", "Bravo"))
+        assertEquals(2, shadowOf(notifications).size())
+    }
+
+    @Test
+    fun nothingIsPostedWithoutTheNotificationPermission() {
+        shadowOf(app).denyPermissions(Manifest.permission.POST_NOTIFICATIONS)
+        FleetNotifier.notify(app, MemberTransition.WentDown("m1", "One"))
+        assertEquals(0, shadowOf(notifications).size())
+    }
+}

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreenTest.kt
@@ -39,6 +39,7 @@ class SettingsScreenTest {
         lockConfig: LockConfig = LockConfig(enabled = false, timeoutMs = LockTimeout.THIRTY_MINUTES.millis),
         lockAvailable: Boolean = true,
         monitorEnabled: Boolean = false,
+        notificationsBlocked: Boolean = false,
         unlinkFailed: Boolean = false,
         onToggleLock: (Boolean) -> Unit = {},
         onSelectTimeout: (LockTimeout) -> Unit = {},
@@ -55,6 +56,7 @@ class SettingsScreenTest {
                     lockConfig = lockConfig,
                     lockAvailable = lockAvailable,
                     monitorEnabled = monitorEnabled,
+                    notificationsBlocked = notificationsBlocked,
                     onBack = {},
                     onToggleLock = onToggleLock,
                     onSelectTimeout = onSelectTimeout,
@@ -126,6 +128,18 @@ class SettingsScreenTest {
     fun monitorNoteShownWhenEnabled() {
         content(monitorEnabled = true)
         composeTestRule.onNodeWithTag("settings-monitor-note").performScrollTo().assertIsDisplayed()
+    }
+
+    @Test
+    fun monitorBlockedHintShownWhenEnabledButNotificationsDenied() {
+        content(monitorEnabled = true, notificationsBlocked = true)
+        composeTestRule.onNodeWithTag("settings-monitor-blocked").performScrollTo().assertIsDisplayed()
+    }
+
+    @Test
+    fun monitorBlockedHintHiddenWhenNotificationsAllowed() {
+        content(monitorEnabled = true, notificationsBlocked = false)
+        composeTestRule.onNodeWithTag("settings-monitor-blocked").assertDoesNotExist()
     }
 
     @Test

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreenTest.kt
@@ -38,9 +38,11 @@ class SettingsScreenTest {
     private fun content(
         lockConfig: LockConfig = LockConfig(enabled = false, timeoutMs = LockTimeout.THIRTY_MINUTES.millis),
         lockAvailable: Boolean = true,
+        monitorEnabled: Boolean = false,
         unlinkFailed: Boolean = false,
         onToggleLock: (Boolean) -> Unit = {},
         onSelectTimeout: (LockTimeout) -> Unit = {},
+        onToggleMonitor: (Boolean) -> Unit = {},
         onAlertsClick: () -> Unit = {},
         onUnlink: () -> Unit = {},
         onForceUnlink: () -> Unit = {},
@@ -52,9 +54,11 @@ class SettingsScreenTest {
                     link = link,
                     lockConfig = lockConfig,
                     lockAvailable = lockAvailable,
+                    monitorEnabled = monitorEnabled,
                     onBack = {},
                     onToggleLock = onToggleLock,
                     onSelectTimeout = onSelectTimeout,
+                    onToggleMonitor = onToggleMonitor,
                     onAlertsClick = onAlertsClick,
                     onUnlink = onUnlink,
                     unlinkFailed = unlinkFailed,
@@ -102,6 +106,26 @@ class SettingsScreenTest {
     fun timeoutPillsHiddenWhenLockDisabled() {
         content(lockConfig = LockConfig(enabled = false, timeoutMs = LockTimeout.THIRTY_MINUTES.millis))
         composeTestRule.onNodeWithTag("settings-lock-timeout-THIRTY_MINUTES").assertDoesNotExist()
+    }
+
+    @Test
+    fun togglingMonitorFiresCallback() {
+        var toggledTo: Boolean? = null
+        content(onToggleMonitor = { toggledTo = it })
+        composeTestRule.onNodeWithTag("settings-monitor-toggle").performScrollTo().performClick()
+        assertEquals(true, toggledTo)
+    }
+
+    @Test
+    fun monitorNoteHiddenWhenDisabled() {
+        content(monitorEnabled = false)
+        composeTestRule.onNodeWithTag("settings-monitor-note").assertDoesNotExist()
+    }
+
+    @Test
+    fun monitorNoteShownWhenEnabled() {
+        content(monitorEnabled = true)
+        composeTestRule.onNodeWithTag("settings-monitor-note").performScrollTo().assertIsDisplayed()
     }
 
     @Test

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/work/FleetBackstopTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/work/FleetBackstopTest.kt
@@ -146,7 +146,7 @@ class FleetBackstopTest {
             val monitor =
                 monitorStore().apply {
                     setEnabled(true)
-                    saveSnapshot(FleetSnapshot(mapOf("m1" to MemberHealthState.UP.name)))
+                    saveSnapshot(FleetSnapshot(mapOf("m1" to MemberHealthState.UP.name)), epoch())
                 }
             // With no way to deliver, polling would only advance the baseline over a
             // change the operator can't see; freeze instead so it fires once granted.
@@ -164,7 +164,7 @@ class FleetBackstopTest {
             val monitor =
                 monitorStore().apply {
                     setEnabled(true)
-                    saveSnapshot(FleetSnapshot(mapOf("m1" to MemberHealthState.UP.name)))
+                    saveSnapshot(FleetSnapshot(mapOf("m1" to MemberHealthState.UP.name)), epoch())
                 }
             server.enqueue(MockResponse().setBody(memberBody(healthy = false)))
 

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/work/FleetBackstopTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/work/FleetBackstopTest.kt
@@ -101,7 +101,8 @@ class FleetBackstopTest {
     private suspend fun run(
         monitor: MonitorStore,
         link: LinkStore,
-    ): Result = runBackstop(monitor, link, client, notify = { fired += it })
+        canNotify: Boolean = true,
+    ): Result = runBackstop(monitor, link, client, canNotify, notify = { fired += it })
 
     @Test
     fun disabledMonitoringSucceedsWithoutPolling() =
@@ -137,6 +138,24 @@ class FleetBackstopTest {
 
             assertEquals(Result.success(), result)
             assertEquals(0, server.requestCount)
+        }
+
+    @Test
+    fun blockedNotificationsSkipPollAndFreezeBaseline() =
+        runBlocking {
+            val monitor =
+                monitorStore().apply {
+                    setEnabled(true)
+                    saveSnapshot(FleetSnapshot(mapOf("m1" to MemberHealthState.UP.name)))
+                }
+            // With no way to deliver, polling would only advance the baseline over a
+            // change the operator can't see; freeze instead so it fires once granted.
+            val result = run(monitor, linkedTo(server.url("/").toString()), canNotify = false)
+
+            assertEquals(Result.success(), result)
+            assertEquals(0, server.requestCount)
+            assertEquals(MemberHealthState.UP, monitor.snapshot()?.stateOf("m1"))
+            assertTrue(fired.isEmpty())
         }
 
     @Test

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/work/FleetBackstopTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/work/FleetBackstopTest.kt
@@ -1,0 +1,182 @@
+package com.hugalafutro.bellhop.work
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.work.ListenableWorker.Result
+import com.hugalafutro.bellhop.data.FleetSnapshot
+import com.hugalafutro.bellhop.data.FrontDeskClient
+import com.hugalafutro.bellhop.data.LinkStore
+import com.hugalafutro.bellhop.data.MemberHealthState
+import com.hugalafutro.bellhop.data.MemberTransition
+import com.hugalafutro.bellhop.data.MonitorStore
+import com.hugalafutro.bellhop.data.PairedDevice
+import com.hugalafutro.bellhop.data.TokenCipher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.runBlocking
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+/**
+ * The worker's guard/dispatch layer, exercised through [runBackstop] so the three
+ * short-circuits doWork() takes before ever polling are pinned without the
+ * WorkManager runtime: monitoring off, the device unlinked, or the token
+ * unreadable each end in success without touching the network. The remaining
+ * cases cover the PollResult -> worker Result mapping and that a health edge is
+ * handed to the notifier. Fetch/diff/persist itself lives in [FleetPollTest].
+ */
+class FleetBackstopTest {
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    private lateinit var server: MockWebServer
+    private val client = FrontDeskClient()
+    private val fired = mutableListOf<MemberTransition>()
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    // Fake ciphers so LinkStore's persistence runs without an AndroidKeyStore
+    // (Robolectric has no provider): passThrough round-trips the token, nulling
+    // decrypts to a Linked-but-unreadable state for the token-null guard.
+    private val passThrough =
+        object : TokenCipher {
+            override fun encrypt(plaintext: String) = plaintext
+
+            override fun decrypt(stored: String) = stored
+        }
+    private val nulling =
+        object : TokenCipher {
+            override fun encrypt(plaintext: String) = plaintext
+
+            override fun decrypt(stored: String): String? = null
+        }
+
+    private fun preferences(name: String): DataStore<Preferences> {
+        val scope = CoroutineScope(Dispatchers.IO + Job())
+        return PreferenceDataStoreFactory.create(scope = scope) {
+            File(tmp.newFolder(), "$name.preferences_pb")
+        }
+    }
+
+    private fun monitorStore(): MonitorStore = MonitorStore(preferences("monitor"))
+
+    private fun linkStore(cipher: TokenCipher): LinkStore = LinkStore(preferences("link"), cipher)
+
+    private suspend fun linkedTo(
+        url: String,
+        cipher: TokenCipher = passThrough,
+    ): LinkStore =
+        linkStore(cipher).also {
+            it.save(
+                fdUrl = url,
+                fdName = "Home Front Desk",
+                token = "tok-1",
+                device = PairedDevice(id = "dev-1", label = "Pixel 8", role = "operator"),
+            )
+        }
+
+    private fun memberBody(healthy: Boolean): String =
+        """[{"id":"m1","name":"hotel-1","state":"active",""" +
+            """"status":{"health":{"known":true,"healthy":$healthy}}}]"""
+
+    private suspend fun run(
+        monitor: MonitorStore,
+        link: LinkStore,
+    ): Result = runBackstop(monitor, link, client, notify = { fired += it })
+
+    @Test
+    fun disabledMonitoringSucceedsWithoutPolling() =
+        runBlocking {
+            // enabled defaults to off; a linked device must not be probed.
+            val result = run(monitorStore(), linkedTo(server.url("/").toString()))
+
+            assertEquals(Result.success(), result)
+            assertEquals(0, server.requestCount)
+            assertTrue(fired.isEmpty())
+        }
+
+    @Test
+    fun unlinkedDeviceSucceedsWithoutPolling() =
+        runBlocking {
+            val monitor = monitorStore().apply { setEnabled(true) }
+
+            val result = run(monitor, linkStore(passThrough))
+
+            assertEquals(Result.success(), result)
+            assertEquals(0, server.requestCount)
+        }
+
+    @Test
+    fun unreadableTokenSucceedsWithoutPolling() =
+        runBlocking {
+            // Linked (token + url present) but the cipher can't decrypt it: the
+            // foreground UI surfaces the revoke, the backstop just stops.
+            val monitor = monitorStore().apply { setEnabled(true) }
+            val link = linkedTo(server.url("/").toString(), cipher = nulling)
+
+            val result = run(monitor, link)
+
+            assertEquals(Result.success(), result)
+            assertEquals(0, server.requestCount)
+        }
+
+    @Test
+    fun healthEdgeIsNotifiedAndSucceeds() =
+        runBlocking {
+            val monitor =
+                monitorStore().apply {
+                    setEnabled(true)
+                    saveSnapshot(FleetSnapshot(mapOf("m1" to MemberHealthState.UP.name)))
+                }
+            server.enqueue(MockResponse().setBody(memberBody(healthy = false)))
+
+            val result = run(monitor, linkedTo(server.url("/").toString()))
+
+            assertEquals(Result.success(), result)
+            assertEquals(listOf(MemberTransition.WentDown("m1", "hotel-1")), fired)
+        }
+
+    @Test
+    fun revokedTokenSucceedsWithoutRetryOrNotification() =
+        runBlocking {
+            val monitor = monitorStore().apply { setEnabled(true) }
+            server.enqueue(MockResponse().setResponseCode(401).setBody("""{"error":{"code":"unauthorized"}}"""))
+
+            val result = run(monitor, linkedTo(server.url("/").toString()))
+
+            // A dead token can never succeed again, so end quietly rather than retry.
+            assertEquals(Result.success(), result)
+            assertTrue(fired.isEmpty())
+        }
+
+    @Test
+    fun transientFailureRetriesWithoutNotification() =
+        runBlocking {
+            val monitor = monitorStore().apply { setEnabled(true) }
+            server.enqueue(MockResponse().setResponseCode(500).setBody("nope"))
+
+            val result = run(monitor, linkedTo(server.url("/").toString()))
+
+            assertEquals(Result.retry(), result)
+            assertTrue(fired.isEmpty())
+        }
+}

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/work/FleetPollTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/work/FleetPollTest.kt
@@ -68,6 +68,7 @@ class FleetPollTest {
     fun firstPollSavesBaselineWithNoTransitions() =
         runBlocking {
             val store = newStore()
+            store.setEnabled(true)
             server.enqueue(MockResponse().setBody(memberBody(healthy = true)))
 
             val result = poll(store)
@@ -82,6 +83,7 @@ class FleetPollTest {
     fun memberGoingDownAcrossPollsIsNotified() =
         runBlocking {
             val store = newStore()
+            store.setEnabled(true)
             store.saveSnapshot(FleetSnapshot(mapOf("m1" to MemberHealthState.UP.name)))
             server.enqueue(MockResponse().setBody(memberBody(healthy = false)))
 
@@ -98,6 +100,7 @@ class FleetPollTest {
     fun deadTokenReportsUnauthorizedAndLeavesBaseline() =
         runBlocking {
             val store = newStore()
+            store.setEnabled(true)
             store.saveSnapshot(FleetSnapshot(mapOf("m1" to MemberHealthState.UP.name)))
             server.enqueue(
                 MockResponse().setResponseCode(401).setBody(
@@ -114,6 +117,7 @@ class FleetPollTest {
     fun transientFailureReportsFailedAndLeavesBaseline() =
         runBlocking {
             val store = newStore()
+            store.setEnabled(true)
             store.saveSnapshot(FleetSnapshot(mapOf("m1" to MemberHealthState.UP.name)))
             server.enqueue(MockResponse().setResponseCode(500).setBody("nope"))
 

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/work/FleetPollTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/work/FleetPollTest.kt
@@ -84,7 +84,7 @@ class FleetPollTest {
         runBlocking {
             val store = newStore()
             store.setEnabled(true)
-            store.saveSnapshot(FleetSnapshot(mapOf("m1" to MemberHealthState.UP.name)))
+            store.saveSnapshot(FleetSnapshot(mapOf("m1" to MemberHealthState.UP.name)), store.epoch())
             server.enqueue(MockResponse().setBody(memberBody(healthy = false)))
 
             val result = poll(store)
@@ -101,7 +101,7 @@ class FleetPollTest {
         runBlocking {
             val store = newStore()
             store.setEnabled(true)
-            store.saveSnapshot(FleetSnapshot(mapOf("m1" to MemberHealthState.UP.name)))
+            store.saveSnapshot(FleetSnapshot(mapOf("m1" to MemberHealthState.UP.name)), store.epoch())
             server.enqueue(
                 MockResponse().setResponseCode(401).setBody(
                     """{"error":{"code":"unauthorized","message":"bad token"}}""",
@@ -118,7 +118,7 @@ class FleetPollTest {
         runBlocking {
             val store = newStore()
             store.setEnabled(true)
-            store.saveSnapshot(FleetSnapshot(mapOf("m1" to MemberHealthState.UP.name)))
+            store.saveSnapshot(FleetSnapshot(mapOf("m1" to MemberHealthState.UP.name)), store.epoch())
             server.enqueue(MockResponse().setResponseCode(500).setBody("nope"))
 
             assertEquals(PollResult.Failed, poll(store))

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/work/FleetPollTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/work/FleetPollTest.kt
@@ -1,0 +1,125 @@
+package com.hugalafutro.bellhop.work
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import com.hugalafutro.bellhop.data.FleetSnapshot
+import com.hugalafutro.bellhop.data.FrontDeskClient
+import com.hugalafutro.bellhop.data.MemberHealthState
+import com.hugalafutro.bellhop.data.MemberTransition
+import com.hugalafutro.bellhop.data.MonitorStore
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.runBlocking
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+/**
+ * The worker's Android shell (WorkManager runtime, notification posting) is thin;
+ * the fetch/diff/persist logic lives in [pollFleet], so it is tested here against
+ * a MockWebServer-backed client and a temp store. The snapshot side effects are
+ * the point: a success advances the baseline, a failure or dead token leaves it
+ * untouched so a transient blip can't erase the baseline and re-alert everything.
+ */
+class FleetPollTest {
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    private lateinit var server: MockWebServer
+    private val client = FrontDeskClient()
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    private fun newStore(): MonitorStore {
+        val scope = CoroutineScope(Dispatchers.IO + Job())
+        val ds: DataStore<Preferences> =
+            PreferenceDataStoreFactory.create(scope = scope) {
+                File(tmp.newFolder(), "monitor.preferences_pb")
+            }
+        return MonitorStore(ds)
+    }
+
+    private fun memberBody(healthy: Boolean): String =
+        """[{"id":"m1","name":"hotel-1","state":"active",""" +
+            """"status":{"health":{"known":true,"healthy":$healthy}}}]"""
+
+    private suspend fun poll(store: MonitorStore): PollResult =
+        pollFleet(client, server.url("/").toString(), "tok-1", store)
+
+    @Test
+    fun firstPollSavesBaselineWithNoTransitions() =
+        runBlocking {
+            val store = newStore()
+            server.enqueue(MockResponse().setBody(memberBody(healthy = true)))
+
+            val result = poll(store)
+
+            assertTrue(result is PollResult.Changed)
+            assertTrue((result as PollResult.Changed).transitions.isEmpty())
+            // The baseline now exists for the next poll to diff against.
+            assertEquals(MemberHealthState.UP, store.snapshot()?.stateOf("m1"))
+        }
+
+    @Test
+    fun memberGoingDownAcrossPollsIsNotified() =
+        runBlocking {
+            val store = newStore()
+            store.saveSnapshot(FleetSnapshot(mapOf("m1" to MemberHealthState.UP.name)))
+            server.enqueue(MockResponse().setBody(memberBody(healthy = false)))
+
+            val result = poll(store)
+
+            assertEquals(
+                listOf(MemberTransition.WentDown("m1", "hotel-1")),
+                (result as PollResult.Changed).transitions,
+            )
+            assertEquals(MemberHealthState.DOWN, store.snapshot()?.stateOf("m1"))
+        }
+
+    @Test
+    fun deadTokenReportsUnauthorizedAndLeavesBaseline() =
+        runBlocking {
+            val store = newStore()
+            store.saveSnapshot(FleetSnapshot(mapOf("m1" to MemberHealthState.UP.name)))
+            server.enqueue(
+                MockResponse().setResponseCode(401).setBody(
+                    """{"error":{"code":"unauthorized","message":"bad token"}}""",
+                ),
+            )
+
+            assertEquals(PollResult.Unauthorized, poll(store))
+            // A revoked token mustn't wipe the baseline.
+            assertEquals(MemberHealthState.UP, store.snapshot()?.stateOf("m1"))
+        }
+
+    @Test
+    fun transientFailureReportsFailedAndLeavesBaseline() =
+        runBlocking {
+            val store = newStore()
+            store.saveSnapshot(FleetSnapshot(mapOf("m1" to MemberHealthState.UP.name)))
+            server.enqueue(MockResponse().setResponseCode(500).setBody("nope"))
+
+            assertEquals(PollResult.Failed, poll(store))
+            // A blip mustn't advance or clear the baseline, or the next poll would
+            // diff against nothing and re-alert the whole fleet.
+            assertEquals(MemberHealthState.UP, store.snapshot()?.stateOf("m1"))
+        }
+}

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ coroutines = "1.9.0"
 zxingEmbedded = "4.3.0"
 biometric = "1.1.0"
 fragment = "1.8.5"
+work = "2.9.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -41,6 +42,7 @@ kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-cor
 zxing-android-embedded = { group = "com.journeyapps", name = "zxing-android-embedded", version.ref = "zxingEmbedded" }
 androidx-biometric = { group = "androidx.biometric", name = "biometric", version.ref = "biometric" }
 androidx-fragment = { group = "androidx.fragment", name = "fragment-ktx", version.ref = "fragment" }
+androidx-work-runtime = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "work" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Phase A3 **Layer 2** of the Bellhop companion app: a periodic background poll that, while Bellhop is backgrounded or killed, diffs fleet health against the last poll and posts a local notification when a member goes down or recovers. No push infrastructure, no Google dependency; the trade-off is the 15-minute WorkManager floor. Layer 1 (foreground SSE, #413) already covers the live case.

### What ships (all under `android/`)
- **`data/FleetSnapshot.kt`** — pure `healthStateOf` (UP/DOWN/DRAINED/UNKNOWN), a persisted id→state `FleetSnapshot`, and pure `diffFleet(prev, current)` that alerts **only** on real UP→DOWN / DOWN→UP edges. Null-previous is a silent first poll, a newly-seen member has no baseline, and edges through DRAINED/UNKNOWN stay quiet (a drain isn't an outage; a reconnecting poller isn't a flap).
- **`data/MonitorStore.kt`** — DataStore for the opt-in toggle (**default off** — enabling it triggers the permission prompt) plus the last-seen snapshot.
- **`notify/FleetNotifier.kt`** — two channels split by severity (member-down HIGH, recovered LOW); posting is permission-guarded and wrapped against a TOCTOU `SecurityException`.
- **`work/FleetPollWorker.kt`** — a testable free `pollFleet` (fetch→diff→persist; the baseline advances **only** on success, so a blip or dead token can't erase it and re-alert the whole fleet) and `runBackstop` (guard/dispatch), behind a thin `CoroutineWorker` shell + `schedule`/`cancel`.
- **Wiring** — Settings "Background monitoring" card; enabling requests `POST_NOTIFICATIONS` and schedules the poll; unlink wipes the snapshot and cancels work. When monitoring is on but notifications are denied, Settings shows an honest "notifications are turned off" hint (refreshed on the permission result and on every foreground return).

### Tests
`FleetSnapshotTest`, `MonitorStoreTest`, `FleetPollTest` (MockWebServer), `FleetBackstopTest` (guard short-circuits + PollResult→Result mapping), and `SettingsScreenTest`. Green: `testDebugUnitTest`, `ktlintCheck`, `lintDebug`, `assembleDebug` (JDK21).

### Verification
Emulator-driven against a mock Front Desk: the toggle defaults off; enabling raises the `POST_NOTIFICATIONS` prompt and schedules a WorkManager job (`dumpsys jobscheduler`); both channels confirmed via `dumpsys notification`. Denying the prompt surfaces the blocked hint; granting it and returning to the app clears it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)