### PR TITLE
fix(hooks): gc tokensave branch DBs on branch deletion

### DIFF
--- a/scripts/reference-transaction
+++ b/scripts/reference-transaction
@@ -1,17 +1,25 @@
 #!/usr/bin/env bash
-# reference-transaction: run tokensave branch add on new branch creation
+# reference-transaction: keep tokensave branch DBs in sync with git branches
+#   new branch     (old_rev == 0) -> tokensave branch add
+#   deleted branch (new_rev == 0) -> tokensave branch gc
+# Fires for any tool that goes through git, not just Claude Code.
 set -uo pipefail
 
 state="$1"
 
 if [ "$state" = "committed" ]; then
+	zero="0000000000000000000000000000000000000000"
 	while read -r old_rev new_rev ref_name; do
-		zero="0000000000000000000000000000000000000000"
-		if [ "$old_rev" = "$zero" ]; then
-			branch="${ref_name#refs/heads/}"
-			if [ "$ref_name" != "$branch" ]; then
-				tokensave branch add "$branch" || true
-			fi
+		branch="${ref_name#refs/heads/}"
+		# only local branch refs (skip tags, remotes, etc.)
+		[ "$ref_name" != "$branch" ] || continue
+		# Check delete first: git reports a deletion as new_rev == 0
+		# (and old_rev == 0 too in the committed txn), so an old_rev
+		# test alone would misfire as a create.
+		if [ "$new_rev" = "$zero" ]; then
+			tokensave branch gc || true
+		elif [ "$old_rev" = "$zero" ]; then
+			tokensave branch add "$branch" || true
 		fi
 	done
 fi


### PR DESCRIPTION
## What

The `scripts/reference-transaction` git hook now runs `tokensave branch gc` when a branch is **deleted**, so tracked branch DBs stay in sync with git regardless of which tool performs the delete (terminal, IDE, or Claude Code). Previously the hook only handled branch **creation** (`tokensave branch add`).

## Why the old hook missed deletions (and misfired)

The hook keyed the create case on `old_rev == 0`. But git reports a branch deletion's *committed* `reference-transaction` as `old_rev == 0` **and** `new_rev == 0` (verified on git 2.55). So every deletion fell into the `old_rev == 0` branch and ran `tokensave branch add` on the just-deleted branch instead of pruning its stale DB.

The fix checks `new_rev == 0` **first** (deletion → `gc`), then `old_rev == 0` (creation → `add`). Normal commits, resets, tags, and remote refs trigger nothing.

## Verification

- Synthetic `reference-transaction` payloads for delete / create / normal-commit / tag-delete / non-committed state each did the right thing.
- Real `git branch` + `git branch -D`: create tracked the DB; delete ran `gc`, pruning the test branch (and a genuinely-stale merged-branch DB). Confirmed no live branch's DB was removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)