### PR TITLE
feat(bellhop): Layer-3 opt-in UnifiedPush/ntfy push wake

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -82,6 +82,11 @@ dependencies {
     // worker that diffs fleet health while Bellhop is backgrounded and posts a
     // local notification on a member going down or recovering. No push infra.
     implementation(libs.androidx.work.runtime)
+    // UnifiedPush is the Layer-3 real-time wake (plan section 5.2): an opt-in,
+    // Google-free replacement for FCM. A distributor (ntfy) holds the socket and
+    // wakes Bellhop the moment Front Desk's Apprise pipeline pushes to its topic;
+    // the push is only a trigger, the fleet truth is re-fetched from Front Desk.
+    implementation(libs.unifiedpush.connector)
     // BiometricPrompt gates local access to the stored token; its device-credential
     // fallback (pattern/PIN) needs no fingerprint sensor. It requires a
     // FragmentActivity host, hence the explicit fragment dependency (plan 3.1/5.4).

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -25,6 +25,15 @@
         android:name="android.hardware.camera"
         android:required="false" />
 
+    <!-- UnifiedPush (Layer-3 opt-in push, plan section 5.2) discovers distributor
+         apps by querying for the REGISTER action; Android 11+ package visibility
+         needs it declared explicitly for getDistributors to see anything. -->
+    <queries>
+        <intent>
+            <action android:name="org.unifiedpush.android.distributor.REGISTER" />
+        </intent>
+    </queries>
+
     <!-- usesCleartextTraffic: plan section 3.6 assumes plain HTTP on the LAN
          (remote access is the user's VPN), and targetSdk 28+ blocks cleartext
          by default, which would make every http:// Front Desk unpairable. -->
@@ -43,6 +52,18 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <!-- UnifiedPush (Layer-3 opt-in push): the connector delivers endpoint and
+             message events to this PushService via the PUSH_EVENT action. Not
+             exported; only the on-device distributor, brokered by the connector
+             library, ever reaches it. -->
+        <service
+            android:name=".push.BellhopPushService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="org.unifiedpush.android.connector.PUSH_EVENT" />
+            </intent-filter>
+        </service>
     </application>
 
 </manifest>

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
@@ -302,6 +302,9 @@ fun BellhopApp() {
                     // Fence the remote side before clearing: if clear() throws, the
                     // retry skips the now-dead Front Desk call and only re-clears.
                     revokedRemotely = true
+                    // Capture the push registration id before clear() wipes it, so
+                    // the unregister below tears down the exact UnifiedPush instance.
+                    val pushInstance = monitorStore.pushInstance()
                     linkStore.clear()
                     lockStore.clear()
                     // Stop both backstop layers and wipe the last-seen fleet so a
@@ -311,7 +314,7 @@ fun BellhopApp() {
                     // before its LaunchedEffect can unregister, so do it here too.
                     monitorStore.clear()
                     FleetPollWorker.cancel(context)
-                    BellhopPush.unregister(context)
+                    BellhopPush.unregister(context, pushInstance)
                 } else {
                     unlinkFailed = true
                 }
@@ -339,11 +342,14 @@ fun BellhopApp() {
         unlinkFailed = false
         scope.launch {
             try {
+                // Capture the push registration id before clear() wipes it, so the
+                // unregister below tears down the exact UnifiedPush instance.
+                val pushInstance = monitorStore.pushInstance()
                 linkStore.clear()
                 lockStore.clear()
                 monitorStore.clear()
                 FleetPollWorker.cancel(context)
-                BellhopPush.unregister(context)
+                BellhopPush.unregister(context, pushInstance)
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Throwable) {
@@ -460,10 +466,16 @@ private fun LinkedContent(
     // picker), so it's a no-op if we aren't hosted by one.
     val pushActivity = monitorContext as? FragmentActivity
     LaunchedEffect(pushEnabled, pushDistributorAvailable) {
+        // Read the registration id fresh here rather than through a recomposed
+        // param: setPushEnabled writes the flag and a new id in one edit, so by the
+        // time this effect keys off pushEnabled the id is already the current one,
+        // and register/unregister target the same instance the callbacks compare.
+        val store = MonitorStore.create(monitorContext)
         if (pushEnabled) {
-            if (pushActivity != null) BellhopPush.register(pushActivity)
+            val instance = store.pushInstance()
+            if (pushActivity != null && instance != null) BellhopPush.register(pushActivity, instance)
         } else {
-            BellhopPush.unregister(monitorContext)
+            BellhopPush.unregister(monitorContext, store.pushInstance())
         }
     }
     // Keyed by the full pairing (FD URL + deviceId): the Activity-scoped

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
@@ -313,7 +313,7 @@ fun BellhopApp() {
                     // clear() drops the pushEnabled flag, but LinkedContent unmounts
                     // before its LaunchedEffect can unregister, so do it here too.
                     monitorStore.clear()
-                    FleetPollWorker.cancel(context)
+                    FleetPollWorker.cancelAll(context)
                     BellhopPush.unregister(context, pushInstance)
                 } else {
                     unlinkFailed = true
@@ -348,7 +348,7 @@ fun BellhopApp() {
                 linkStore.clear()
                 lockStore.clear()
                 monitorStore.clear()
-                FleetPollWorker.cancel(context)
+                FleetPollWorker.cancelAll(context)
                 BellhopPush.unregister(context, pushInstance)
             } catch (e: CancellationException) {
                 throw e

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
@@ -39,6 +39,7 @@ import com.hugalafutro.bellhop.data.LockTimeout
 import com.hugalafutro.bellhop.data.MonitorStore
 import com.hugalafutro.bellhop.data.shouldLock
 import com.hugalafutro.bellhop.notify.FleetNotifier
+import com.hugalafutro.bellhop.push.BellhopPush
 import com.hugalafutro.bellhop.ui.alerts.AlertsScreen
 import com.hugalafutro.bellhop.ui.alerts.AlertsViewModel
 import com.hugalafutro.bellhop.ui.dashboard.DashboardScreen
@@ -159,12 +160,19 @@ fun BellhopApp() {
         )
     val lockAvailable = remember(activity) { activity != null && canAppLock(activity) }
     val monitorEnabled by monitorStore.enabled.collectAsStateWithLifecycle(initialValue = false)
+    val pushEnabled by monitorStore.pushEnabled.collectAsStateWithLifecycle(initialValue = false)
+    val pushEndpoint by monitorStore.endpoint.collectAsStateWithLifecycle(initialValue = null)
     val scope = rememberCoroutineScope()
     // Whether Bellhop may post notifications. Tracked so Settings can be honest
     // when monitoring is on but the permission was denied (or later revoked from
     // system settings); refreshed on the permission result and on every return to
     // the foreground below.
     var notificationsGranted by remember { mutableStateOf(hasPostNotificationPermission(context)) }
+    // Whether any UnifiedPush distributor (ntfy) is installed, so Settings can point
+    // the user at installing one rather than a push toggle that silently never
+    // fires. Refreshed on every return to the foreground, since one may be installed
+    // while Bellhop is away.
+    var pushDistributorAvailable by remember { mutableStateOf(BellhopPush.hasDistributor(context)) }
     // Launcher for the POST_NOTIFICATIONS runtime permission (API 33+), fired when
     // the user turns background monitoring on. A denial is fine: the backstop still
     // polls, and Settings flags that the alerts won't reach them until it's granted.
@@ -178,6 +186,17 @@ fun BellhopApp() {
     // the DataStore flag stays the single source of truth for whether it runs.
     fun toggleMonitor(enabled: Boolean) {
         scope.launch { monitorStore.setEnabled(enabled) }
+        if (enabled && !hasPostNotificationPermission(context)) {
+            notificationPermission.launch(Manifest.permission.POST_NOTIFICATIONS)
+        }
+    }
+
+    // togglePush persists the Layer-3 opt-in and, on enable, asks for the
+    // notification permission (the push wake posts a notification too). The actual
+    // UnifiedPush register/unregister is left to LinkedContent's effect so the
+    // DataStore flag stays the single source of truth, mirroring toggleMonitor.
+    fun togglePush(enabled: Boolean) {
+        scope.launch { monitorStore.setPushEnabled(enabled) }
         if (enabled && !hasPostNotificationPermission(context)) {
             notificationPermission.launch(Manifest.permission.POST_NOTIFICATIONS)
         }
@@ -226,8 +245,10 @@ fun BellhopApp() {
                 when (event) {
                     Lifecycle.Event.ON_STOP -> scope.launch { lockStore.stampExit(System.currentTimeMillis()) }
                     Lifecycle.Event.ON_START -> {
-                        // Catch a grant/revoke made in system settings while away.
+                        // Catch a grant/revoke, or a distributor install/removal,
+                        // made in system settings while away.
                         notificationsGranted = hasPostNotificationPermission(context)
+                        pushDistributorAvailable = BellhopPush.hasDistributor(context)
                         scope.launch {
                             val snap = lockStore.snapshot()
                             if (shouldLock(snap.config, snap.lastForegroundExit, System.currentTimeMillis())) {
@@ -370,11 +391,16 @@ fun BellhopApp() {
                         lockAvailable = lockAvailable,
                         monitorEnabled = monitorEnabled,
                         notificationsBlocked = monitorEnabled && !notificationsGranted,
+                        pushEnabled = pushEnabled,
+                        pushEndpoint = pushEndpoint,
+                        pushDistributorAvailable = pushDistributorAvailable,
+                        pushNotificationsBlocked = pushEnabled && !notificationsGranted,
                         scope = scope,
                         unlinking = unlinking,
                         unlinkFailed = unlinkFailed,
                         onDismissUnlinkError = { unlinkFailed = false },
                         onToggleMonitor = { toggleMonitor(it) },
+                        onTogglePush = { togglePush(it) },
                         onUnlink = { runUnlink(state.fdUrl) },
                         onForceUnlink = { forceUnlink() },
                     )
@@ -398,11 +424,16 @@ private fun LinkedContent(
     lockAvailable: Boolean,
     monitorEnabled: Boolean,
     notificationsBlocked: Boolean,
+    pushEnabled: Boolean,
+    pushEndpoint: String?,
+    pushDistributorAvailable: Boolean,
+    pushNotificationsBlocked: Boolean,
     scope: CoroutineScope,
     unlinking: Boolean,
     unlinkFailed: Boolean,
     onDismissUnlinkError: () -> Unit,
     onToggleMonitor: (Boolean) -> Unit,
+    onTogglePush: (Boolean) -> Unit,
     onUnlink: () -> Unit,
     onForceUnlink: () -> Unit,
 ) {
@@ -415,6 +446,18 @@ private fun LinkedContent(
             FleetPollWorker.schedule(monitorContext)
         } else {
             FleetPollWorker.cancel(monitorContext)
+        }
+    }
+    // Self-heal the Layer-3 push: UnifiedPush registration is persistent, but
+    // re-registering here refreshes the endpoint and recovers it after a reinstall;
+    // unregister if push was turned off. Registration needs an Activity (choosing a
+    // distributor may show a picker), so it's a no-op if we aren't hosted by one.
+    val pushActivity = monitorContext as? FragmentActivity
+    LaunchedEffect(pushEnabled) {
+        if (pushEnabled) {
+            if (pushActivity != null) BellhopPush.register(pushActivity)
+        } else {
+            BellhopPush.unregister(monitorContext)
         }
     }
     // Keyed by the full pairing (FD URL + deviceId): the Activity-scoped
@@ -496,10 +539,15 @@ private fun LinkedContent(
             lockAvailable = lockAvailable,
             monitorEnabled = monitorEnabled,
             notificationsBlocked = notificationsBlocked,
+            pushEnabled = pushEnabled,
+            pushEndpoint = pushEndpoint,
+            pushDistributorAvailable = pushDistributorAvailable,
+            pushNotificationsBlocked = pushNotificationsBlocked,
             onBack = { showSettings = false },
             onToggleLock = { enabled -> scope.launch { lockStore.setEnabled(enabled) } },
             onSelectTimeout = { option -> scope.launch { lockStore.setTimeout(option.millis) } },
             onToggleMonitor = onToggleMonitor,
+            onTogglePush = onTogglePush,
             onAlertsClick = { showAlerts = true },
             onUnlink = onUnlink,
             unlinking = unlinking,

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
@@ -304,11 +304,14 @@ fun BellhopApp() {
                     revokedRemotely = true
                     linkStore.clear()
                     lockStore.clear()
-                    // Stop the backstop and wipe the last-seen fleet so a re-pair
-                    // (possibly to a different Front Desk) starts from a clean
-                    // baseline rather than diffing against the old fleet.
+                    // Stop both backstop layers and wipe the last-seen fleet so a
+                    // re-pair (possibly to a different Front Desk) starts from a
+                    // clean baseline rather than diffing against the old fleet.
+                    // clear() drops the pushEnabled flag, but LinkedContent unmounts
+                    // before its LaunchedEffect can unregister, so do it here too.
                     monitorStore.clear()
                     FleetPollWorker.cancel(context)
+                    BellhopPush.unregister(context)
                 } else {
                     unlinkFailed = true
                 }
@@ -340,6 +343,7 @@ fun BellhopApp() {
                 lockStore.clear()
                 monitorStore.clear()
                 FleetPollWorker.cancel(context)
+                BellhopPush.unregister(context)
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Throwable) {
@@ -450,10 +454,12 @@ private fun LinkedContent(
     }
     // Self-heal the Layer-3 push: UnifiedPush registration is persistent, but
     // re-registering here refreshes the endpoint and recovers it after a reinstall;
-    // unregister if push was turned off. Registration needs an Activity (choosing a
-    // distributor may show a picker), so it's a no-op if we aren't hosted by one.
+    // unregister if push was turned off. Also keyed on distributor availability so
+    // installing a distributor while push is already on registers without a manual
+    // off/on. Registration needs an Activity (choosing a distributor may show a
+    // picker), so it's a no-op if we aren't hosted by one.
     val pushActivity = monitorContext as? FragmentActivity
-    LaunchedEffect(pushEnabled) {
+    LaunchedEffect(pushEnabled, pushDistributorAvailable) {
         if (pushEnabled) {
             if (pushActivity != null) BellhopPush.register(pushActivity)
         } else {

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/MonitorStore.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/MonitorStore.kt
@@ -2,6 +2,7 @@ package com.hugalafutro.bellhop.data
 
 import android.content.Context
 import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.MutablePreferences
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
@@ -21,33 +22,94 @@ private val Context.monitorDataStore: DataStore<Preferences> by
     preferencesDataStore(name = "bellhop_monitor")
 
 /**
- * MonitorStore persists the background-backstop policy (plan section 5.2, Layer
- * 2): whether the periodic fleet poll is enabled, plus the last-seen
- * [FleetSnapshot] the poll diffs against. The snapshot lives here, not in the
- * worker, because a periodic worker is torn down between runs; only a persisted
- * baseline lets it tell what changed since last time.
+ * MonitorStore persists the background-backstop policy (plan section 5.2): whether
+ * the Layer-2 periodic fleet poll is enabled, whether the Layer-3 real-time push
+ * wake is enabled (plus the distributor [endpoint] it registered), and the
+ * last-seen [FleetSnapshot] both layers diff against. The snapshot lives here, not
+ * in the worker, because a periodic worker is torn down between runs; only a
+ * persisted baseline lets it tell what changed since last time.
  *
- * Enabled defaults to off: turning it on schedules background work and (on API
- * 33+) prompts for the notification permission, so it's an explicit opt-in rather
- * than a surprise on first launch (the same stance the app lock ships with).
+ * Both push flags default to off: turning either on schedules/registers background
+ * work and (on API 33+) prompts for the notification permission, so each is an
+ * explicit opt-in rather than a surprise on first launch (the same stance the app
+ * lock ships with). The two layers share one snapshot and one session [epoch]
+ * because they answer the same question — "has fleet health changed?" — from the
+ * same Front Desk truth; push is just a faster wake for the same poll.
  */
 class MonitorStore(
     private val dataStore: DataStore<Preferences>,
     private val json: Json = Json { ignoreUnknownKeys = true },
 ) {
-    /** enabled emits the backstop toggle, defaulting to off. */
+    /** enabled emits the Layer-2 periodic-poll toggle, defaulting to off. */
     val enabled: Flow<Boolean> = dataStore.data.map { it[ENABLED] ?: false }
+
+    /** pushEnabled emits the Layer-3 real-time push toggle, defaulting to off. */
+    val pushEnabled: Flow<Boolean> = dataStore.data.map { it[PUSH_ENABLED] ?: false }
+
+    /**
+     * active emits whether the backstop is tracking at all: true when either the
+     * Layer-2 periodic poll or the Layer-3 push wake is on. Both drive the same
+     * fetch/diff/notify against one shared [snapshot], so the guards in
+     * [saveSnapshot] and the worker key off this, not either layer alone.
+     */
+    val active: Flow<Boolean> = dataStore.data.map { it[ENABLED] == true || it[PUSH_ENABLED] == true }
+
+    /**
+     * endpoint emits the UnifiedPush endpoint URL the distributor handed back for
+     * Layer 3, or null before one arrives (or after push is turned off). It's shown
+     * in Settings so the user can point Front Desk's Apprise phone-topic at it.
+     */
+    val endpoint: Flow<String?> = dataStore.data.map { it[PUSH_ENDPOINT] }
 
     suspend fun setEnabled(enabled: Boolean) {
         dataStore.edit { prefs ->
+            val wasActive = prefs[ENABLED] == true || prefs[PUSH_ENABLED] == true
             prefs[ENABLED] = enabled
-            // Each fresh enable stamps the session with a new random epoch, so a poll
-            // from a previous session (see [saveSnapshot]) can't persist its snapshot
-            // after an unlink + re-enable churned the store. A random id rather than a
-            // counter because clear() wipes the counter, so a monotone one would reset
-            // and collide across the very unlink+re-enable this guards against.
-            if (enabled) prefs[EPOCH] = Random.nextLong()
+            stampSessionIfNewlyActive(prefs, wasActive)
         }
+    }
+
+    suspend fun setPushEnabled(enabled: Boolean) {
+        dataStore.edit { prefs ->
+            val wasActive = prefs[ENABLED] == true || prefs[PUSH_ENABLED] == true
+            prefs[PUSH_ENABLED] = enabled
+            // Turning push off drops the stale endpoint: it names a distributor
+            // topic we're about to unregister, so leaving it in Settings would be a
+            // lie. A fresh onNewEndpoint repopulates it if push comes back on.
+            if (!enabled) prefs.remove(PUSH_ENDPOINT)
+            stampSessionIfNewlyActive(prefs, wasActive)
+        }
+    }
+
+    /**
+     * saveEndpoint records the distributor's endpoint URL, but only while push is
+     * still on: a late onNewEndpoint arriving after the user turned Layer 3 off (or
+     * unlinked) must not resurrect an endpoint Settings would then display.
+     */
+    suspend fun saveEndpoint(url: String) {
+        dataStore.edit { prefs ->
+            if (prefs[PUSH_ENABLED] == true) prefs[PUSH_ENDPOINT] = url
+        }
+    }
+
+    /** clearEndpoint drops the endpoint on unregister or a registration failure. */
+    suspend fun clearEndpoint() {
+        dataStore.edit { it.remove(PUSH_ENDPOINT) }
+    }
+
+    // stampSessionIfNewlyActive rotates the session epoch on the inactive -> active
+    // edge (the first layer coming on), so a poll from a previous session (see
+    // [saveSnapshot]) can't persist its snapshot after an unlink + re-enable churned
+    // the store. Enabling the second layer mid-session keeps the epoch, so an
+    // in-flight poll's save survives. A random id rather than a counter because
+    // clear() wipes the counter, so a monotone one would reset and collide across
+    // the very unlink + re-enable this guards against.
+    private fun stampSessionIfNewlyActive(
+        prefs: MutablePreferences,
+        wasActive: Boolean,
+    ) {
+        val nowActive = prefs[ENABLED] == true || prefs[PUSH_ENABLED] == true
+        if (!wasActive && nowActive) prefs[EPOCH] = Random.nextLong()
     }
 
     /** epoch identifies the current monitoring session; 0 when never enabled. */
@@ -65,21 +127,22 @@ class MonitorStore(
     }
 
     /**
-     * saveSnapshot persists the baseline, but only if monitoring is still on AND
-     * still the same session ([epoch]) that started the poll. A poll can finish
-     * after an unlink cleared the store, or after an unlink + re-enable started a
-     * fresh session; a bare "enabled" check would let that late write repopulate a
-     * cleared store or poison the new session's baseline. The epoch the caller
-     * captured before fetching, the enabled flag, and the write all share one
-     * atomic edit, so a concurrent clear/re-enable is either seen (we skip) or
-     * overwrites us.
+     * saveSnapshot persists the baseline, but only if the backstop is still active
+     * (either layer on) AND still the same session ([epoch]) that started the poll.
+     * A poll can finish after an unlink cleared the store, or after an unlink +
+     * re-enable started a fresh session; a bare active check would let that late
+     * write repopulate a cleared store or poison the new session's baseline. The
+     * epoch the caller captured before fetching, the active flags, and the write all
+     * share one atomic edit, so a concurrent clear/re-enable is either seen (we skip)
+     * or overwrites us.
      */
     suspend fun saveSnapshot(
         snapshot: FleetSnapshot,
         epoch: Long,
     ) {
         dataStore.edit { prefs ->
-            if (prefs[ENABLED] == true && (prefs[EPOCH] ?: 0L) == epoch) {
+            val active = prefs[ENABLED] == true || prefs[PUSH_ENABLED] == true
+            if (active && (prefs[EPOCH] ?: 0L) == epoch) {
                 prefs[SNAPSHOT] = json.encodeToString(snapshot)
             }
         }
@@ -93,6 +156,8 @@ class MonitorStore(
         fun create(context: Context): MonitorStore = MonitorStore(context.applicationContext.monitorDataStore)
 
         private val ENABLED = booleanPreferencesKey("enabled")
+        private val PUSH_ENABLED = booleanPreferencesKey("push_enabled")
+        private val PUSH_ENDPOINT = stringPreferencesKey("push_endpoint")
         private val EPOCH = longPreferencesKey("epoch")
         private val SNAPSHOT = stringPreferencesKey("fleet_snapshot")
     }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/MonitorStore.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/MonitorStore.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import java.util.UUID
 import kotlin.random.Random
 
 // Separate DataStore from the link and lock records so background-monitoring
@@ -73,6 +74,14 @@ class MonitorStore(
         dataStore.edit { prefs ->
             val wasActive = prefs[ENABLED] == true || prefs[PUSH_ENABLED] == true
             prefs[PUSH_ENABLED] = enabled
+            // Mint a fresh registration id on every enable so endpoint callbacks can
+            // be attributed to the registration that produced them: a late
+            // onNewEndpoint (or onUnregistered) from a superseded registration
+            // carries the OLD id and is dropped rather than overwriting the current
+            // topic (see [saveEndpoint]/[clearEndpoint]). The id is retained on
+            // disable so the pending unregister can still target the right instance;
+            // the next enable overwrites it and clear() wipes it.
+            if (enabled) prefs[PUSH_INSTANCE] = UUID.randomUUID().toString()
             // Turning push off drops the stale endpoint: it names a distributor
             // topic we're about to unregister, so leaving it in Settings would be a
             // lie. A fresh onNewEndpoint repopulates it if push comes back on.
@@ -81,20 +90,38 @@ class MonitorStore(
         }
     }
 
+    /** pushInstance is the id of the current push registration, or null if none. */
+    suspend fun pushInstance(): String? = dataStore.data.first()[PUSH_INSTANCE]
+
     /**
      * saveEndpoint records the distributor's endpoint URL, but only while push is
-     * still on: a late onNewEndpoint arriving after the user turned Layer 3 off (or
-     * unlinked) must not resurrect an endpoint Settings would then display.
+     * still on AND the callback belongs to the current registration [instance]: a
+     * late onNewEndpoint arriving after the user turned Layer 3 off (or unlinked)
+     * must not resurrect an endpoint Settings would then display, and one from a
+     * superseded registration (push toggled off/on, or unlink + re-pair) must not
+     * overwrite the live topic with a stale one the distributor no longer routes.
      */
-    suspend fun saveEndpoint(url: String) {
+    suspend fun saveEndpoint(
+        url: String,
+        instance: String,
+    ) {
         dataStore.edit { prefs ->
-            if (prefs[PUSH_ENABLED] == true) prefs[PUSH_ENDPOINT] = url
+            if (prefs[PUSH_ENABLED] == true && prefs[PUSH_INSTANCE] == instance) {
+                prefs[PUSH_ENDPOINT] = url
+            }
         }
     }
 
-    /** clearEndpoint drops the endpoint on unregister or a registration failure. */
-    suspend fun clearEndpoint() {
-        dataStore.edit { it.remove(PUSH_ENDPOINT) }
+    /**
+     * clearEndpoint drops the endpoint on unregister or a registration failure, but
+     * only when the callback's [instance] is the current registration: an
+     * onUnregistered/onRegistrationFailed for a superseded registration must not wipe
+     * the endpoint a newer registration just published.
+     */
+    suspend fun clearEndpoint(instance: String) {
+        dataStore.edit { prefs ->
+            if (prefs[PUSH_INSTANCE] == instance) prefs.remove(PUSH_ENDPOINT)
+        }
     }
 
     // stampSessionIfNewlyActive rotates the session epoch on the inactive -> active
@@ -158,6 +185,7 @@ class MonitorStore(
         private val ENABLED = booleanPreferencesKey("enabled")
         private val PUSH_ENABLED = booleanPreferencesKey("push_enabled")
         private val PUSH_ENDPOINT = stringPreferencesKey("push_endpoint")
+        private val PUSH_INSTANCE = stringPreferencesKey("push_instance")
         private val EPOCH = longPreferencesKey("epoch")
         private val SNAPSHOT = stringPreferencesKey("fleet_snapshot")
     }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/push/BellhopPush.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/push/BellhopPush.kt
@@ -1,0 +1,34 @@
+package com.hugalafutro.bellhop.push
+
+import android.app.Activity
+import android.content.Context
+import org.unifiedpush.android.connector.UnifiedPush
+
+/**
+ * BellhopPush wraps the UnifiedPush registration dance for Layer 3 (plan section
+ * 5.2) so MainActivity doesn't reach into the connector directly. Registration
+ * needs a *distributor* app installed (ntfy is the recommended, Google-free one);
+ * with none present [hasDistributor] is false and Settings tells the user to
+ * install one instead of silently failing.
+ */
+object BellhopPush {
+    /** hasDistributor reports whether any UnifiedPush distributor is installed. */
+    fun hasDistributor(context: Context): Boolean = UnifiedPush.getDistributors(context).isNotEmpty()
+
+    /**
+     * register picks the saved distributor (or the sole/default one) and registers
+     * Bellhop with it; the resulting endpoint arrives asynchronously in
+     * [BellhopPushService.onNewEndpoint]. Needs an Activity because choosing a
+     * distributor may surface a picker. A no-op when no distributor can be chosen.
+     */
+    fun register(activity: Activity) {
+        UnifiedPush.tryUseCurrentOrDefaultDistributor(activity) { chosen ->
+            if (chosen) UnifiedPush.register(activity.applicationContext)
+        }
+    }
+
+    /** unregister tears down the registration; the distributor stops waking us. */
+    fun unregister(context: Context) {
+        UnifiedPush.unregister(context.applicationContext)
+    }
+}

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/push/BellhopPush.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/push/BellhopPush.kt
@@ -17,18 +17,30 @@ object BellhopPush {
 
     /**
      * register picks the saved distributor (or the sole/default one) and registers
-     * Bellhop with it; the resulting endpoint arrives asynchronously in
+     * Bellhop with it under [instance] (a per-registration id minted by MonitorStore
+     * so endpoint callbacks can be attributed to the registration that produced
+     * them); the resulting endpoint arrives asynchronously in
      * [BellhopPushService.onNewEndpoint]. Needs an Activity because choosing a
      * distributor may surface a picker. A no-op when no distributor can be chosen.
      */
-    fun register(activity: Activity) {
+    fun register(
+        activity: Activity,
+        instance: String,
+    ) {
         UnifiedPush.tryUseCurrentOrDefaultDistributor(activity) { chosen ->
-            if (chosen) UnifiedPush.register(activity.applicationContext)
+            if (chosen) UnifiedPush.register(activity.applicationContext, instance)
         }
     }
 
-    /** unregister tears down the registration; the distributor stops waking us. */
-    fun unregister(context: Context) {
-        UnifiedPush.unregister(context.applicationContext)
+    /**
+     * unregister tears down the registration for [instance] so the distributor stops
+     * waking us. A null instance means nothing was ever registered (push never
+     * enabled), so there is nothing to tear down.
+     */
+    fun unregister(
+        context: Context,
+        instance: String?,
+    ) {
+        if (instance != null) UnifiedPush.unregister(context.applicationContext, instance)
     }
 }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/push/BellhopPushService.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/push/BellhopPushService.kt
@@ -32,8 +32,10 @@ class BellhopPushService : PushService() {
         instance: String,
     ) {
         // Persist the distributor's topic URL so Settings can show it for the user
-        // to point Front Desk's Apprise phone-topic at.
-        runBlocking { MonitorStore.create(applicationContext).saveEndpoint(endpoint.url) }
+        // to point Front Desk's Apprise phone-topic at. Passing the callback's
+        // instance lets the store reject a late endpoint from a superseded
+        // registration instead of displaying a topic that's no longer routed.
+        runBlocking { MonitorStore.create(applicationContext).saveEndpoint(endpoint.url, instance) }
     }
 
     override fun onMessage(
@@ -50,10 +52,12 @@ class BellhopPushService : PushService() {
     ) {
         // No usable endpoint: drop any stale one so Settings stops advertising a
         // topic that can't deliver. The user re-picks a distributor from Settings.
-        runBlocking { MonitorStore.create(applicationContext).clearEndpoint() }
+        // Gated on the callback's instance so a failure for a superseded
+        // registration can't wipe a newer registration's live endpoint.
+        runBlocking { MonitorStore.create(applicationContext).clearEndpoint(instance) }
     }
 
     override fun onUnregistered(instance: String) {
-        runBlocking { MonitorStore.create(applicationContext).clearEndpoint() }
+        runBlocking { MonitorStore.create(applicationContext).clearEndpoint(instance) }
     }
 }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/push/BellhopPushService.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/push/BellhopPushService.kt
@@ -1,0 +1,59 @@
+package com.hugalafutro.bellhop.push
+
+import com.hugalafutro.bellhop.data.MonitorStore
+import com.hugalafutro.bellhop.work.FleetPollWorker
+import kotlinx.coroutines.runBlocking
+import org.unifiedpush.android.connector.FailedReason
+import org.unifiedpush.android.connector.PushService
+import org.unifiedpush.android.connector.data.PushEndpoint
+import org.unifiedpush.android.connector.data.PushMessage
+
+/**
+ * BellhopPushService is the Layer-3 real-time wake (plan section 5.2): the
+ * UnifiedPush entry point a distributor (ntfy) delivers to when Front Desk's
+ * Apprise pipeline pushes to Bellhop's topic. It is opt-in and Google-free — no
+ * FCM, no google-services.json — the distributor holds the persistent socket.
+ *
+ * The push is deliberately treated as a bare wake trigger, not a data source: on a
+ * message it re-runs the same backstop poll Layer 2 uses ([FleetPollWorker.runNow])
+ * so Bellhop's notification always reflects current Front Desk truth rather than a
+ * payload that may be stale, encrypted, or shaped by whatever Apprise sent. That
+ * also means Bellhop never becomes a second, redundant alert source: it renders the
+ * same fleet state, just woken sooner than the 15-minute periodic floor.
+ *
+ * The registration is thin on purpose (the testable pieces are [MonitorStore] and
+ * [FleetPollWorker.runNow], exercised on their own); this shell only wires the
+ * connector callbacks to them. runBlocking is safe here: the endpoint writes are
+ * sub-millisecond DataStore edits and the callback must finish before it returns.
+ */
+class BellhopPushService : PushService() {
+    override fun onNewEndpoint(
+        endpoint: PushEndpoint,
+        instance: String,
+    ) {
+        // Persist the distributor's topic URL so Settings can show it for the user
+        // to point Front Desk's Apprise phone-topic at.
+        runBlocking { MonitorStore.create(applicationContext).saveEndpoint(endpoint.url) }
+    }
+
+    override fun onMessage(
+        message: PushMessage,
+        instance: String,
+    ) {
+        // Payload ignored on purpose (see class doc): the poll re-derives truth.
+        FleetPollWorker.runNow(applicationContext)
+    }
+
+    override fun onRegistrationFailed(
+        reason: FailedReason,
+        instance: String,
+    ) {
+        // No usable endpoint: drop any stale one so Settings stops advertising a
+        // topic that can't deliver. The user re-picks a distributor from Settings.
+        runBlocking { MonitorStore.create(applicationContext).clearEndpoint() }
+    }
+
+    override fun onUnregistered(instance: String) {
+        runBlocking { MonitorStore.create(applicationContext).clearEndpoint() }
+    }
+}

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreen.kt
@@ -383,7 +383,7 @@ fun SettingsScreen(
                     if (pushEnabled) {
                         if (pushNotificationsBlocked) {
                             Text(
-                                text = stringResource(R.string.settings_monitor_blocked),
+                                text = stringResource(R.string.settings_push_blocked),
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.error,
                                 modifier = Modifier.testTag("settings-push-blocked"),

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreen.kt
@@ -1,5 +1,6 @@
 package com.hugalafutro.bellhop.ui.settings
 
+import android.widget.Toast
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -31,8 +32,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -62,16 +66,24 @@ fun SettingsScreen(
     onToggleLock: (Boolean) -> Unit,
     onSelectTimeout: (LockTimeout) -> Unit,
     onToggleMonitor: (Boolean) -> Unit,
+    onTogglePush: (Boolean) -> Unit,
     onAlertsClick: () -> Unit,
     onUnlink: () -> Unit,
     modifier: Modifier = Modifier,
     notificationsBlocked: Boolean = false,
+    pushEnabled: Boolean = false,
+    pushEndpoint: String? = null,
+    pushDistributorAvailable: Boolean = false,
+    pushNotificationsBlocked: Boolean = false,
     unlinking: Boolean = false,
     unlinkFailed: Boolean = false,
     onDismissUnlinkError: () -> Unit = {},
     onForceUnlink: () -> Unit = {},
 ) {
     var confirmUnlink by remember { mutableStateOf(false) }
+    val clipboard = LocalClipboardManager.current
+    val context = LocalContext.current
+    val pushCopied = stringResource(R.string.settings_push_copied)
 
     if (unlinkFailed) {
         AlertDialog(
@@ -326,6 +338,107 @@ fun SettingsScreen(
 
             Spacer(modifier = Modifier.height(16.dp))
 
+            // Real-time push: Layer-3 opt-in (plan section 5.2). Off by default like
+            // monitoring; turning it on registers with a UnifiedPush distributor and
+            // (on API 33+) prompts for the notification permission.
+            Card(modifier = Modifier.fillMaxWidth()) {
+                Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = stringResource(R.string.settings_push_title),
+                                style = MaterialTheme.typography.titleMedium,
+                            )
+                            Text(
+                                text = stringResource(R.string.settings_push_subtitle),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                        Switch(
+                            checked = pushEnabled,
+                            onCheckedChange = onTogglePush,
+                            // Same off-state colours as the other switches so an off
+                            // toggle stays legible on the card (see note above).
+                            colors =
+                                SwitchDefaults.colors(
+                                    uncheckedThumbColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    uncheckedTrackColor = MaterialTheme.colorScheme.surface,
+                                    uncheckedBorderColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                                ),
+                            modifier = Modifier.testTag("settings-push-toggle"),
+                        )
+                    }
+                    if (!pushDistributorAvailable) {
+                        // No distributor app installed: registration can't complete,
+                        // so nothing will ever wake Bellhop. Say so rather than let
+                        // an enabled switch imply working push.
+                        Text(
+                            text = stringResource(R.string.settings_push_no_distributor),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.error,
+                            modifier = Modifier.testTag("settings-push-no-distributor"),
+                        )
+                    }
+                    if (pushEnabled) {
+                        if (pushNotificationsBlocked) {
+                            Text(
+                                text = stringResource(R.string.settings_monitor_blocked),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.error,
+                                modifier = Modifier.testTag("settings-push-blocked"),
+                            )
+                        }
+                        if (pushDistributorAvailable) {
+                            Text(
+                                text = stringResource(R.string.settings_push_endpoint_label),
+                                style = MaterialTheme.typography.labelMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                            val endpoint = pushEndpoint
+                            if (endpoint != null) {
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                    modifier = Modifier.fillMaxWidth(),
+                                ) {
+                                    Text(
+                                        text = endpoint,
+                                        style = MaterialTheme.typography.bodySmall,
+                                        maxLines = 2,
+                                        overflow = TextOverflow.Ellipsis,
+                                        modifier = Modifier.weight(1f).testTag("settings-push-endpoint"),
+                                    )
+                                    TextButton(
+                                        onClick = {
+                                            clipboard.setText(AnnotatedString(endpoint))
+                                            Toast.makeText(context, pushCopied, Toast.LENGTH_SHORT).show()
+                                        },
+                                        modifier = Modifier.testTag("settings-push-copy"),
+                                    ) {
+                                        Text(stringResource(R.string.settings_push_copy))
+                                    }
+                                }
+                                Text(
+                                    text = stringResource(R.string.settings_push_endpoint_note),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            } else {
+                                Text(
+                                    text = stringResource(R.string.settings_push_endpoint_waiting),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.testTag("settings-push-waiting"),
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
             // Alerts stays reachable here even when all is green (the dashboard bell
             // only appears when a member is down).
             Card(modifier = Modifier.fillMaxWidth().clickable(onClick = onAlertsClick).testTag("settings-alerts")) {
@@ -382,10 +495,14 @@ private fun SettingsScreenPreview() {
             lockConfig = LockConfig(enabled = true, timeoutMs = LockTimeout.THIRTY_MINUTES.millis),
             lockAvailable = true,
             monitorEnabled = true,
+            pushEnabled = true,
+            pushEndpoint = "https://ntfy.sh/upExample123",
+            pushDistributorAvailable = true,
             onBack = {},
             onToggleLock = {},
             onSelectTimeout = {},
             onToggleMonitor = {},
+            onTogglePush = {},
             onAlertsClick = {},
             onUnlink = {},
         )

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/work/FleetPollWorker.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/work/FleetPollWorker.kt
@@ -4,8 +4,11 @@ import android.content.Context
 import androidx.work.Constraints
 import androidx.work.CoroutineWorker
 import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.ExistingWorkPolicy
 import androidx.work.ListenableWorker.Result
 import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.OutOfQuotaPolicy
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
@@ -84,9 +87,11 @@ suspend fun runBackstop(
     canNotify: Boolean,
     notify: (MemberTransition) -> Unit,
 ): Result {
-    // Disabled or already unscheduled: nothing to do. A stale run can outlive the
-    // toggle being turned off, so re-check rather than trust scheduling.
-    if (!monitorStore.enabled.first()) return Result.success()
+    // Neither layer active: nothing to do. A stale periodic run can outlive the
+    // Layer-2 toggle, and a push-triggered one-shot can land just after Layer 3
+    // was turned off, so re-check the shared active flag rather than trust
+    // scheduling. Push and periodic share this guard because they share the poll.
+    if (!monitorStore.active.first()) return Result.success()
     // Can't post? Don't poll. Advancing the baseline while alerts are silently
     // dropped would swallow the very down->up change the operator needs to see
     // once they grant the permission, so freeze until then (Settings flags it).
@@ -136,6 +141,7 @@ class FleetPollWorker(
 
     companion object {
         private const val UNIQUE_NAME = "fleet-poll"
+        private const val ONESHOT_NAME = "fleet-poll-now"
 
         // The 15-minute WorkManager floor is the shortest periodic interval Android
         // allows; the backstop is explicitly not real-time (plan section 5.2).
@@ -158,6 +164,32 @@ class FleetPollWorker(
             WorkManager
                 .getInstance(context)
                 .enqueueUniquePeriodicWork(UNIQUE_NAME, ExistingPeriodicWorkPolicy.KEEP, request)
+        }
+
+        /**
+         * runNow fires a single immediate poll off the same worker, used as the
+         * Layer-3 wake when a UnifiedPush message arrives (plan section 5.2): the
+         * push is only a trigger, so it runs [runBackstop] to re-fetch fleet truth
+         * from Front Desk rather than trusting the push payload. Expedited so it
+         * runs promptly, but falling back to a normal request when the app is out of
+         * expedited quota (no foreground-service notification needed for a poll).
+         * KEEP coalesces a burst of pushes onto one in-flight poll rather than
+         * fanning out one network call per push; the periodic backstop and the
+         * push's own re-fetch cover anything a coalesced burst would miss.
+         */
+        fun runNow(context: Context) {
+            val request =
+                OneTimeWorkRequestBuilder<FleetPollWorker>()
+                    .setConstraints(
+                        Constraints
+                            .Builder()
+                            .setRequiredNetworkType(NetworkType.CONNECTED)
+                            .build(),
+                    ).setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+                    .build()
+            WorkManager
+                .getInstance(context)
+                .enqueueUniqueWork(ONESHOT_NAME, ExistingWorkPolicy.KEEP, request)
         }
 
         fun cancel(context: Context) {

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/work/FleetPollWorker.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/work/FleetPollWorker.kt
@@ -12,6 +12,7 @@ import androidx.work.OutOfQuotaPolicy
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
+import androidx.work.workDataOf
 import com.hugalafutro.bellhop.data.FetchResult
 import com.hugalafutro.bellhop.data.FleetSnapshot
 import com.hugalafutro.bellhop.data.FrontDeskClient
@@ -86,6 +87,7 @@ suspend fun runBackstop(
     client: FrontDeskClient,
     canNotify: Boolean,
     notify: (MemberTransition) -> Unit,
+    retryOnFailure: Boolean = true,
 ): Result {
     // Neither layer active: nothing to do. A stale periodic run can outlive the
     // Layer-2 toggle, and a push-triggered one-shot can land just after Layer 3
@@ -111,7 +113,13 @@ suspend fun runBackstop(
         // A revoked token can never succeed again; retrying would just hammer
         // Front Desk. The foreground UI flags the revoke, so end quietly.
         PollResult.Unauthorized -> Result.success()
-        PollResult.Failed -> Result.retry()
+        // A transient failure retries for the periodic backstop, but NOT for a push
+        // one-shot: a retrying one-shot would hold the unique-work slot through its
+        // backoff, and the KEEP policy would then drop every push that arrived during
+        // that window. Ending in success frees the slot immediately, so the next push
+        // (or the periodic poll) schedules a fresh wake instead of being coalesced
+        // onto a poll that is only sitting in backoff.
+        PollResult.Failed -> if (retryOnFailure) Result.retry() else Result.success()
     }
 }
 
@@ -136,12 +144,16 @@ class FleetPollWorker(
             client = FrontDeskClient(),
             canNotify = FleetNotifier.canPost(context),
             notify = { FleetNotifier.notify(context, it) },
+            // The push one-shot must not retry (see runBackstop): a backing-off
+            // one-shot would block later push wakes under the KEEP policy.
+            retryOnFailure = !inputData.getBoolean(KEY_ONESHOT, false),
         )
     }
 
     companion object {
         private const val UNIQUE_NAME = "fleet-poll"
         private const val ONESHOT_NAME = "fleet-poll-now"
+        private const val KEY_ONESHOT = "oneshot"
 
         // The 15-minute WorkManager floor is the shortest periodic interval Android
         // allows; the backstop is explicitly not real-time (plan section 5.2).
@@ -175,7 +187,10 @@ class FleetPollWorker(
          * expedited quota (no foreground-service notification needed for a poll).
          * KEEP coalesces a burst of pushes onto one in-flight poll rather than
          * fanning out one network call per push; the periodic backstop and the
-         * push's own re-fetch cover anything a coalesced burst would miss.
+         * push's own re-fetch cover anything a coalesced burst would miss. The
+         * one-shot is tagged so [runBackstop] ends a transient failure in success
+         * rather than retry, so a backing-off poll can't hold the KEEP slot and drop
+         * pushes that arrive during its backoff.
          */
         fun runNow(context: Context) {
             val request =
@@ -185,7 +200,8 @@ class FleetPollWorker(
                             .Builder()
                             .setRequiredNetworkType(NetworkType.CONNECTED)
                             .build(),
-                    ).setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+                    ).setInputData(workDataOf(KEY_ONESHOT to true))
+                    .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
                     .build()
             WorkManager
                 .getInstance(context)

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/work/FleetPollWorker.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/work/FleetPollWorker.kt
@@ -193,7 +193,12 @@ class FleetPollWorker(
         }
 
         fun cancel(context: Context) {
-            WorkManager.getInstance(context).cancelUniqueWork(UNIQUE_NAME)
+            val wm = WorkManager.getInstance(context)
+            wm.cancelUniqueWork(UNIQUE_NAME)
+            // Also drop any queued push one-shot so a pending wake can't outlive an
+            // unlink (it would bail in runBackstop anyway once active is false, but
+            // cancelling closes the window and mirrors the periodic teardown).
+            wm.cancelUniqueWork(ONESHOT_NAME)
         }
     }
 }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/work/FleetPollWorker.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/work/FleetPollWorker.kt
@@ -208,12 +208,26 @@ class FleetPollWorker(
                 .enqueueUniqueWork(ONESHOT_NAME, ExistingWorkPolicy.KEEP, request)
         }
 
+        /**
+         * cancel stops ONLY the periodic poll, used when Layer-2 monitoring is
+         * turned off. It deliberately leaves the push one-shot alone: push-only mode
+         * (Layer 2 off, Layer 3 on) is supported, so cancelling a queued or running
+         * push wake here would drop the very Front Desk transition Layer 3 exists to
+         * deliver. Full teardown on unlink uses [cancelAll].
+         */
         fun cancel(context: Context) {
+            WorkManager.getInstance(context).cancelUniqueWork(UNIQUE_NAME)
+        }
+
+        /**
+         * cancelAll tears down both the periodic poll and any queued push one-shot,
+         * used on unlink where neither layer should survive: a pending push wake left
+         * behind would bail in runBackstop once active is false, but cancelling closes
+         * the window rather than relying on that guard.
+         */
+        fun cancelAll(context: Context) {
             val wm = WorkManager.getInstance(context)
             wm.cancelUniqueWork(UNIQUE_NAME)
-            // Also drop any queued push one-shot so a pending wake can't outlive an
-            // unlink (it would bail in runBackstop anyway once active is false, but
-            // cancelling closes the window and mirrors the periodic teardown).
             wm.cancelUniqueWork(ONESHOT_NAME)
         }
     }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -128,6 +128,7 @@
     <string name="settings_push_endpoint_note">Paste this into Front Desk → Settings → Alerts as the phone topic, so its alerts wake Bellhop.</string>
     <string name="settings_push_copy">Copy push topic</string>
     <string name="settings_push_copied">Push topic copied</string>
+    <string name="settings_push_blocked">Notifications are off for Bellhop, so pushes can\'t reach you. Turn them on in system settings.</string>
 
     <!-- Background-monitoring notifications (Layer 2 backstop) -->
     <string name="notif_channel_down">Member down</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -120,6 +120,14 @@
     <string name="settings_monitor_subtitle">Check the fleet every 15 minutes and notify you here when a member goes down or recovers, even when Bellhop is closed.</string>
     <string name="settings_monitor_note">Front Desk\'s own alerts are faster; this is a backstop for when Bellhop is your only view. It checks roughly every 15 minutes, so a change can be up to that late.</string>
     <string name="settings_monitor_blocked">Notifications are turned off for Bellhop, so these alerts won\'t reach you. Turn them on in system settings.</string>
+    <string name="settings_push_title">Real-time push</string>
+    <string name="settings_push_subtitle">Wake Bellhop the instant Front Desk pushes an alert, via UnifiedPush and ntfy. No Google, no polling delay, opt-in.</string>
+    <string name="settings_push_no_distributor">Install a UnifiedPush distributor such as ntfy to receive pushes. Without one, this stays idle until you add it.</string>
+    <string name="settings_push_endpoint_label">Push topic for Front Desk</string>
+    <string name="settings_push_endpoint_waiting">Waiting for the distributor to hand back a push topic…</string>
+    <string name="settings_push_endpoint_note">Paste this into Front Desk → Settings → Alerts as the phone topic, so its alerts wake Bellhop.</string>
+    <string name="settings_push_copy">Copy push topic</string>
+    <string name="settings_push_copied">Push topic copied</string>
 
     <!-- Background-monitoring notifications (Layer 2 backstop) -->
     <string name="notif_channel_down">Member down</string>

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/MonitorStoreTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/MonitorStoreTest.kt
@@ -173,7 +173,7 @@ class MonitorStoreTest {
         runBlocking {
             val store = newStore()
             store.setPushEnabled(true)
-            store.saveEndpoint("https://ntfy.sh/upABC123")
+            store.saveEndpoint("https://ntfy.sh/upABC123", store.pushInstance()!!)
             assertEquals("https://ntfy.sh/upABC123", store.endpoint.first())
         }
 
@@ -183,7 +183,41 @@ class MonitorStoreTest {
             // A late onNewEndpoint arriving after push was turned off (or before it
             // was ever on) must not resurrect a topic Settings would then display.
             val store = newStore()
-            store.saveEndpoint("https://ntfy.sh/upABC123")
+            store.saveEndpoint("https://ntfy.sh/upABC123", "any-instance")
+            assertNull(store.endpoint.first())
+        }
+
+    @Test
+    fun endpointFromSupersededRegistrationIgnored() =
+        runBlocking {
+            // A late onNewEndpoint from a registration that was already replaced
+            // (push toggled off/on, or unlink + re-pair) carries the old instance id
+            // and must not overwrite the live topic with a stale one the distributor
+            // no longer routes.
+            val store = newStore()
+            store.setPushEnabled(true)
+            val stale = store.pushInstance()!!
+            store.setPushEnabled(false)
+            store.setPushEnabled(true)
+            val current = store.pushInstance()!!
+            store.saveEndpoint("https://ntfy.sh/upOLD", stale)
+            assertNull(store.endpoint.first())
+            store.saveEndpoint("https://ntfy.sh/upNEW", current)
+            assertEquals("https://ntfy.sh/upNEW", store.endpoint.first())
+        }
+
+    @Test
+    fun clearEndpointFromSupersededRegistrationIgnored() =
+        runBlocking {
+            // An onUnregistered/onRegistrationFailed for a superseded registration
+            // must not wipe the endpoint a newer registration just published.
+            val store = newStore()
+            store.setPushEnabled(true)
+            val current = store.pushInstance()!!
+            store.saveEndpoint("https://ntfy.sh/upABC123", current)
+            store.clearEndpoint("stale-instance")
+            assertEquals("https://ntfy.sh/upABC123", store.endpoint.first())
+            store.clearEndpoint(current)
             assertNull(store.endpoint.first())
         }
 
@@ -192,7 +226,7 @@ class MonitorStoreTest {
         runBlocking {
             val store = newStore()
             store.setPushEnabled(true)
-            store.saveEndpoint("https://ntfy.sh/upABC123")
+            store.saveEndpoint("https://ntfy.sh/upABC123", store.pushInstance()!!)
             store.setPushEnabled(false)
             assertNull(store.endpoint.first())
         }
@@ -202,9 +236,10 @@ class MonitorStoreTest {
         runBlocking {
             val store = newStore()
             store.setPushEnabled(true)
-            store.saveEndpoint("https://ntfy.sh/upABC123")
+            store.saveEndpoint("https://ntfy.sh/upABC123", store.pushInstance()!!)
             store.clear()
             assertFalse(store.pushEnabled.first())
             assertNull(store.endpoint.first())
+            assertNull(store.pushInstance())
         }
 }

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/MonitorStoreTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/MonitorStoreTest.kt
@@ -117,4 +117,94 @@ class MonitorStoreTest {
             assertFalse(store.enabled.first())
             assertNull(store.snapshot())
         }
+
+    @Test
+    fun pushDefaultsToDisabled() =
+        runBlocking {
+            assertFalse(newStore().pushEnabled.first())
+        }
+
+    @Test
+    fun activeIsTrueWhenEitherLayerOn() =
+        runBlocking {
+            // The shared snapshot machinery keys off active, so push alone must
+            // count: a Layer-3-only user still needs the baseline maintained.
+            val store = newStore()
+            assertFalse(store.active.first())
+            store.setPushEnabled(true)
+            assertTrue(store.active.first())
+            store.setPushEnabled(false)
+            store.setEnabled(true)
+            assertTrue(store.active.first())
+        }
+
+    @Test
+    fun pushOnlySessionStampsFreshEpoch() =
+        runBlocking {
+            val store = newStore()
+            assertEquals(0L, store.epoch())
+            store.setPushEnabled(true)
+            assertTrue(store.epoch() != 0L)
+        }
+
+    @Test
+    fun enablingSecondLayerKeepsSessionEpoch() =
+        runBlocking {
+            // Turning push on mid-session must not rotate the epoch, or an in-flight
+            // Layer-2 poll's snapshot save would be dropped for no reason.
+            val store = newStore()
+            store.setEnabled(true)
+            val session = store.epoch()
+            store.setPushEnabled(true)
+            assertEquals(session, store.epoch())
+        }
+
+    @Test
+    fun snapshotPersistsWhenOnlyPushEnabled() =
+        runBlocking {
+            val store = newStore()
+            store.setPushEnabled(true)
+            store.saveSnapshot(FleetSnapshot(mapOf("m1" to MemberHealthState.UP.name)), store.epoch())
+            assertEquals(MemberHealthState.UP, store.snapshot()?.stateOf("m1"))
+        }
+
+    @Test
+    fun endpointRoundTripsWhilePushEnabled() =
+        runBlocking {
+            val store = newStore()
+            store.setPushEnabled(true)
+            store.saveEndpoint("https://ntfy.sh/upABC123")
+            assertEquals("https://ntfy.sh/upABC123", store.endpoint.first())
+        }
+
+    @Test
+    fun endpointIgnoredWhenPushDisabled() =
+        runBlocking {
+            // A late onNewEndpoint arriving after push was turned off (or before it
+            // was ever on) must not resurrect a topic Settings would then display.
+            val store = newStore()
+            store.saveEndpoint("https://ntfy.sh/upABC123")
+            assertNull(store.endpoint.first())
+        }
+
+    @Test
+    fun disablingPushClearsEndpoint() =
+        runBlocking {
+            val store = newStore()
+            store.setPushEnabled(true)
+            store.saveEndpoint("https://ntfy.sh/upABC123")
+            store.setPushEnabled(false)
+            assertNull(store.endpoint.first())
+        }
+
+    @Test
+    fun clearWipesPushState() =
+        runBlocking {
+            val store = newStore()
+            store.setPushEnabled(true)
+            store.saveEndpoint("https://ntfy.sh/upABC123")
+            store.clear()
+            assertFalse(store.pushEnabled.first())
+            assertNull(store.endpoint.first())
+        }
 }

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModelTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModelTest.kt
@@ -355,7 +355,13 @@ class DashboardViewModelTest {
             val vm = DashboardViewModel(client, linkedStore(), "http://fd:1")
 
             val job = launch { vm.state.collect {} }
-            val s = withTimeout(5_000) { vm.state.first { it.revoked } }
+            // revoked here is reached only through streamLoop (the poll succeeds), so
+            // it hangs off the stream subscription's one IO hop with no polling slack.
+            // The wait is a failsafe against a genuine hang, not an expected latency —
+            // it normally completes in milliseconds — so give it the same generous
+            // bound as revokedTokenSwallowsFurtherRefreshNudges rather than a tight 5s
+            // window a loaded CI runner can starve past.
+            val s = withTimeout(30_000) { vm.state.first { it.revoked } }
             assertTrue(s.revoked)
             job.cancel()
         }

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreenTest.kt
@@ -40,10 +40,15 @@ class SettingsScreenTest {
         lockAvailable: Boolean = true,
         monitorEnabled: Boolean = false,
         notificationsBlocked: Boolean = false,
+        pushEnabled: Boolean = false,
+        pushEndpoint: String? = null,
+        pushDistributorAvailable: Boolean = true,
+        pushNotificationsBlocked: Boolean = false,
         unlinkFailed: Boolean = false,
         onToggleLock: (Boolean) -> Unit = {},
         onSelectTimeout: (LockTimeout) -> Unit = {},
         onToggleMonitor: (Boolean) -> Unit = {},
+        onTogglePush: (Boolean) -> Unit = {},
         onAlertsClick: () -> Unit = {},
         onUnlink: () -> Unit = {},
         onForceUnlink: () -> Unit = {},
@@ -57,10 +62,15 @@ class SettingsScreenTest {
                     lockAvailable = lockAvailable,
                     monitorEnabled = monitorEnabled,
                     notificationsBlocked = notificationsBlocked,
+                    pushEnabled = pushEnabled,
+                    pushEndpoint = pushEndpoint,
+                    pushDistributorAvailable = pushDistributorAvailable,
+                    pushNotificationsBlocked = pushNotificationsBlocked,
                     onBack = {},
                     onToggleLock = onToggleLock,
                     onSelectTimeout = onSelectTimeout,
                     onToggleMonitor = onToggleMonitor,
+                    onTogglePush = onTogglePush,
                     onAlertsClick = onAlertsClick,
                     onUnlink = onUnlink,
                     unlinkFailed = unlinkFailed,
@@ -140,6 +150,44 @@ class SettingsScreenTest {
     fun monitorBlockedHintHiddenWhenNotificationsAllowed() {
         content(monitorEnabled = true, notificationsBlocked = false)
         composeTestRule.onNodeWithTag("settings-monitor-blocked").assertDoesNotExist()
+    }
+
+    @Test
+    fun togglingPushFiresCallback() {
+        var toggledTo: Boolean? = null
+        content(onTogglePush = { toggledTo = it })
+        composeTestRule.onNodeWithTag("settings-push-toggle").performScrollTo().performClick()
+        assertEquals(true, toggledTo)
+    }
+
+    @Test
+    fun pushEndpointShownWhenEnabledAndAssigned() {
+        content(pushEnabled = true, pushEndpoint = "https://ntfy.sh/upABC123")
+        composeTestRule.onNodeWithTag("settings-push-endpoint").performScrollTo().assertIsDisplayed()
+    }
+
+    @Test
+    fun pushWaitingHintShownWhenEnabledButNoEndpointYet() {
+        content(pushEnabled = true, pushEndpoint = null)
+        composeTestRule.onNodeWithTag("settings-push-waiting").performScrollTo().assertIsDisplayed()
+    }
+
+    @Test
+    fun pushEndpointHiddenWhenDisabled() {
+        content(pushEnabled = false, pushEndpoint = "https://ntfy.sh/upABC123")
+        composeTestRule.onNodeWithTag("settings-push-endpoint").assertDoesNotExist()
+    }
+
+    @Test
+    fun noDistributorHintShownWhenNoneInstalled() {
+        content(pushDistributorAvailable = false)
+        composeTestRule.onNodeWithTag("settings-push-no-distributor").performScrollTo().assertIsDisplayed()
+    }
+
+    @Test
+    fun pushBlockedHintShownWhenEnabledButNotificationsDenied() {
+        content(pushEnabled = true, pushNotificationsBlocked = true)
+        composeTestRule.onNodeWithTag("settings-push-blocked").performScrollTo().assertIsDisplayed()
     }
 
     @Test

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/work/FleetBackstopTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/work/FleetBackstopTest.kt
@@ -175,6 +175,25 @@ class FleetBackstopTest {
         }
 
     @Test
+    fun pushOnlyEnabledStillPollsAndNotifies() =
+        runBlocking {
+            // Layer 2 (periodic) off but Layer 3 (push) on: a push-triggered
+            // one-shot must still fetch/diff/notify, so the guard keys off the
+            // shared active flag, not the Layer-2 enabled flag alone.
+            val monitor =
+                monitorStore().apply {
+                    setPushEnabled(true)
+                    saveSnapshot(FleetSnapshot(mapOf("m1" to MemberHealthState.UP.name)), epoch())
+                }
+            server.enqueue(MockResponse().setBody(memberBody(healthy = false)))
+
+            val result = run(monitor, linkedTo(server.url("/").toString()))
+
+            assertEquals(Result.success(), result)
+            assertEquals(listOf(MemberTransition.WentDown("m1", "hotel-1")), fired)
+        }
+
+    @Test
     fun revokedTokenSucceedsWithoutRetryOrNotification() =
         runBlocking {
             val monitor = monitorStore().apply { setEnabled(true) }

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/work/FleetBackstopTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/work/FleetBackstopTest.kt
@@ -217,4 +217,28 @@ class FleetBackstopTest {
             assertEquals(Result.retry(), result)
             assertTrue(fired.isEmpty())
         }
+
+    @Test
+    fun pushOneShotTransientFailureSucceedsWithoutRetry() =
+        runBlocking {
+            // The push one-shot passes retryOnFailure = false: a retrying one-shot
+            // would hold the KEEP unique-work slot through its backoff and drop
+            // pushes that land during that window, so it ends in success and frees
+            // the slot for the next wake instead.
+            val monitor = monitorStore().apply { setPushEnabled(true) }
+            server.enqueue(MockResponse().setResponseCode(500).setBody("nope"))
+
+            val result =
+                runBackstop(
+                    monitor,
+                    linkedTo(server.url("/").toString()),
+                    client,
+                    canNotify = true,
+                    notify = { fired += it },
+                    retryOnFailure = false,
+                )
+
+            assertEquals(Result.success(), result)
+            assertTrue(fired.isEmpty())
+        }
 }

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -16,6 +16,10 @@ zxingEmbedded = "4.3.0"
 biometric = "1.1.0"
 fragment = "1.8.5"
 work = "2.9.1"
+# Pinned to the newest 3.x built with Kotlin <= 2.1.0 (this project's compiler):
+# 3.1.0+ ship Kotlin 2.2/2.3 metadata the 2.1.0 compiler can't read. 3.0.10 has
+# the full PushService API we use and stdlib 2.0.21, which resolves cleanly here.
+unifiedpush = "3.0.10"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -43,6 +47,7 @@ zxing-android-embedded = { group = "com.journeyapps", name = "zxing-android-embe
 androidx-biometric = { group = "androidx.biometric", name = "biometric", version.ref = "biometric" }
 androidx-fragment = { group = "androidx.fragment", name = "fragment-ktx", version.ref = "fragment" }
 androidx-work-runtime = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "work" }
+unifiedpush-connector = { group = "org.unifiedpush.android", name = "connector", version.ref = "unifiedpush" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Phase A3 Layer 3: opt-in UnifiedPush/ntfy push wake

Adds the last of Bellhop's three notification layers (plan section 5.2): an **opt-in, Google-free real-time wake** via UnifiedPush with ntfy as the distributor. No FCM, no `google-services.json`.

### Core design: push is a wake trigger, not a data source
`BellhopPushService.onMessage` **ignores the payload** and fires `FleetPollWorker.runNow` (an expedited one-shot of the *same* backstop poll). So Bellhop's notification always reflects current Front Desk truth, and it never becomes a second, redundant alert source: it renders the same fleet state as Layer 2, just woken sooner than the 15-minute periodic floor. That also sidesteps having to decrypt or parse whatever Apprise/ntfy delivered.

Because push and the Layer-2 periodic poll answer the same question from the same source, they share **one snapshot and one session epoch**:
- `MonitorStore` gains a `pushEnabled` flag co-located with the snapshot its atomic save-gate guards, plus an `active = enabled || pushEnabled` flow.
- `runBackstop` and `saveSnapshot` gate on `active` (a push-only-still-polls test pins this).
- The session epoch is stamped only on the **inactive→active edge**, so enabling the second layer mid-session can't drop an in-flight save.

### Registration / UX
- `onNewEndpoint` persists the distributor topic URL (only while push is on); Settings shows it with a copy button and a "paste into Front Desk → Alerts phone-topic" note.
- Registration picks a distributor via `tryUseCurrentOrDefaultDistributor`, with a "no distributor (install ntfy)" hint when none is present; the self-heal effect re-registers if a distributor is installed while push is already on.
- Unlink tears down both layers (worker cancel + `BellhopPush.unregister`), and `FleetPollWorker.cancel` also drops any queued push one-shot.

### Dependency note
Pinned connector **3.0.10**, not 3.3.x: 3.1.0+ ship Kotlin 2.2/2.3 class metadata this project's 2.1.0 compiler can't read (internal compiler error). 3.0.10 has the full `PushService` 3.x API and stdlib 2.0.21, which resolves cleanly. **No Front Desk code changed** (the phone-topic field shipped in F0).

### Verification
- `testDebugUnitTest`, `ktlintCheck`, `lintDebug`, `assembleDebug` all green.
- **Full emulator end-to-end against production Front Desk**: sideloaded ntfy as the UnifiedPush distributor, paired to the live fleet, toggled push on (Settings showed the real `ntfy.sh/up…` endpoint), backgrounded the app and POSTed to the topic. Logcat confirmed ntfy delivered the message, the connector fell back to plain text (payload ignored by design), and `FleetPollWorker` woke and re-polled real FD. All-UP fleet, so no notification (correct; `diffFleet` found no edges). Test device cleaned up via the app's own Unlink.

Closes the three-layer notification plan; Phase A4 (operator actions + Glance widget + release) is next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
