### PR TITLE
feat(bellhop): operator drain/activate/config-sync (Phase A4)

### DIFF
--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
@@ -253,10 +253,11 @@ fun BellhopApp() {
         }
         val act = activity
         if (act == null) {
-            // No host activity to present the prompt (not expected during normal
-            // composition): fall open, same rationale as the no-credential
-            // degrade — Front Desk's 403 is the authoritative guard on the mutation.
-            action()
+            // No host activity to present the presence check (not expected during
+            // normal composition). This gate is a security control, so fail closed:
+            // drop the mutation rather than run it un-gated. This differs from the
+            // no-enrolled-credential case inside promptAppUnlock, which degrades
+            // open by design — here we can't prove owner presence at all.
             return
         }
         act.promptAppUnlock(operatorTitle, operatorSubtitle) {

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
@@ -58,6 +58,15 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
+// The paired-device role that may mutate the fleet (Front Desk's RoleOperator).
+// A monitor device hides the operator controls; the 403 is still the real guard.
+private const val OPERATOR_ROLE = "operator"
+
+// How long one operator biometric check authorizes further operator actions
+// before the next one re-prompts. Deliberately short (a burst window) and tighter
+// than the app-lock's default view window, and in-memory so it resets on a kill.
+private const val OPERATOR_AUTH_WINDOW_MS = 60_000L
+
 // FragmentActivity (not plain ComponentActivity) because BiometricPrompt hosts
 // its sheet on a FragmentManager; Compose still drives the whole UI.
 class MainActivity : FragmentActivity() {
@@ -223,6 +232,33 @@ fun BellhopApp() {
             locked = false
         } else {
             act.promptAppUnlock(unlockTitle, unlockSubtitle) { locked = false }
+        }
+    }
+
+    // Operator-action gate: a per-session biometric check on its own short timer,
+    // tighter than the app-lock's view window and orthogonal to Front Desk's role
+    // check (this proves the phone's owner is here; the token's role is what may
+    // mutate — both are needed). One prompt authorizes a brief burst of operator
+    // taps; after the window lapses the next action re-prompts. Degrades open with
+    // no enrolled credential, like the app lock, since the token at rest is
+    // Keystore-wrapped regardless and Front Desk's 403 is the authoritative guard.
+    var operatorAuthorizedUntil by remember { mutableStateOf(0L) }
+    val operatorTitle = stringResource(R.string.operator_prompt_title)
+    val operatorSubtitle = stringResource(R.string.operator_prompt_subtitle)
+
+    fun requireOperatorAuth(action: () -> Unit) {
+        if (System.currentTimeMillis() < operatorAuthorizedUntil) {
+            action()
+            return
+        }
+        val act = activity
+        if (act == null) {
+            action()
+            return
+        }
+        act.promptAppUnlock(operatorTitle, operatorSubtitle) {
+            operatorAuthorizedUntil = System.currentTimeMillis() + OPERATOR_AUTH_WINDOW_MS
+            action()
         }
     }
 
@@ -413,6 +449,7 @@ fun BellhopApp() {
                         onTogglePush = { togglePush(it) },
                         onUnlink = { runUnlink(state.fdUrl) },
                         onForceUnlink = { forceUnlink() },
+                        requireOperatorAuth = { action -> requireOperatorAuth(action) },
                     )
             }
         }
@@ -446,6 +483,7 @@ private fun LinkedContent(
     onTogglePush: (Boolean) -> Unit,
     onUnlink: () -> Unit,
     onForceUnlink: () -> Unit,
+    requireOperatorAuth: (() -> Unit) -> Unit,
 ) {
     // Self-heal the Layer-2 poll: periodic work persists in WorkManager on its
     // own, but re-asserting the schedule here (KEEP policy, so no interval reset)
@@ -588,6 +626,14 @@ private fun LinkedContent(
             isPrimary = selected.id == ui.primaryId,
             ui = detailUi,
             onBack = { selectedMemberId = null },
+            // Role-hint UI: an operator device gets the controls, a monitor
+            // doesn't. Front Desk's 403 is still the real guard (surfaced in the
+            // card). Each action goes through the biometric operator gate.
+            canOperate = state.role == OPERATOR_ROLE,
+            onSetState = { target -> requireOperatorAuth { detailVm.setMemberState(target) } },
+            onSyncFleet = { requireOperatorAuth { detailVm.syncFleet(ui.primaryId) } },
+            onReconcile = { liveState -> detailVm.reconcile(liveState) },
+            onDismissActionError = { detailVm.dismissActionError() },
         )
     } else {
         DashboardScreen(

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
@@ -253,6 +253,9 @@ fun BellhopApp() {
         }
         val act = activity
         if (act == null) {
+            // No host activity to present the prompt (not expected during normal
+            // composition): fall open, same rationale as the no-credential
+            // degrade — Front Desk's 403 is the authoritative guard on the mutation.
             action()
             return
         }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/FleetModels.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/FleetModels.kt
@@ -184,3 +184,63 @@ data class AlertEventDef(
     val severity: String = "",
     val defaultOn: Boolean = false,
 )
+
+// Wire models for the Front Desk operator tier a device token with the operator
+// role can reach: POST /api/members/{id}/state (drain/activate) and POST
+// /api/config/sync (propagate the primary's config). These mirror the FD
+// contract (internal/frontdesk/server_members.go setMemberState and
+// internal/frontdesk/configsync.go configSync); do not rename JSON fields.
+
+/**
+ * MemberStateRequest is the POST /api/members/{id}/state body. [state] is
+ * "active" or "drained" (see [MemberState]); Front Desk records it and returns
+ * the updated member. Set-state, not toggle, so a retry or double-tap is a safe
+ * no-op.
+ */
+@Serializable
+class MemberStateRequest(
+    val state: String,
+)
+
+/**
+ * MemberState is the two states a member can be set to. Drained excludes a
+ * member from new traffic while in-flight streams finish (the physical drain is
+ * asynchronous; Front Desk records the intent immediately). Kept as the exact
+ * strings Front Desk stores so they round-trip through the wire untouched.
+ */
+object MemberState {
+    const val ACTIVE = "active"
+    const val DRAINED = "drained"
+}
+
+/**
+ * ConfigSyncRequest is the POST /api/config/sync body: the id of the primary
+ * whose config is propagated to the rest of the fleet. Bellhop only ever sends
+ * the already-designated auto-sync primary (choosing a primary is a separate,
+ * later slice), so this is a "sync now from primary" trigger, not a wizard.
+ */
+@Serializable
+class ConfigSyncRequest(
+    @SerialName("primary_id") val primaryId: String,
+)
+
+/**
+ * SyncResponse is the POST /api/config/sync result: the source primary and the
+ * per-member outcomes. Front Desk runs the whole sync before answering 200, so a
+ * success here means the run finished; the phone summarizes [results] rather than
+ * blocking on physical convergence, which the dashboard reconciles afterwards.
+ */
+@Serializable
+data class SyncResponse(
+    @SerialName("primary_id") val primaryId: String = "",
+    val results: List<SyncResultItem> = emptyList(),
+)
+
+/** SyncResultItem is one member's config-sync outcome (frontdesk syncResultItem). */
+@Serializable
+data class SyncResultItem(
+    @SerialName("member_id") val memberId: String = "",
+    val name: String = "",
+    val ok: Boolean = false,
+    val error: String = "",
+)

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/FleetModels.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/FleetModels.kt
@@ -198,7 +198,7 @@ data class AlertEventDef(
  * no-op.
  */
 @Serializable
-class MemberStateRequest(
+data class MemberStateRequest(
     val state: String,
 )
 
@@ -220,7 +220,7 @@ object MemberState {
  * later slice), so this is a "sync now from primary" trigger, not a wizard.
  */
 @Serializable
-class ConfigSyncRequest(
+data class ConfigSyncRequest(
     @SerialName("primary_id") val primaryId: String,
 )
 

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/FrontDeskClient.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/FrontDeskClient.kt
@@ -53,6 +53,30 @@ sealed interface FetchResult<out T> {
 }
 
 /**
+ * ActionResult is the outcome of an operator mutation (drain/activate, config
+ * sync). It has one arm the reads don't: [Forbidden] is Front Desk's 403
+ * device_role_forbidden, meaning this paired device holds the monitor role and
+ * may never mutate. That is the authoritative guard (Bellhop also hides operator
+ * controls on a monitor device, but that is only UX); it is distinct from
+ * [Unauthorized], which is a dead token that even reads can't use, and from a
+ * transient [Failure]. Modeled separately from [FetchResult] so the read call
+ * sites don't have to grow a role branch they can never hit.
+ */
+sealed interface ActionResult<out T> {
+    data class Success<T>(
+        val data: T,
+    ) : ActionResult<T>
+
+    data object Forbidden : ActionResult<Nothing>
+
+    data object Unauthorized : ActionResult<Nothing>
+
+    data class Failure(
+        val message: String,
+    ) : ActionResult<Nothing>
+}
+
+/**
  * SseMessage is what [FrontDeskClient.streamEvents] emits: a connection opened,
  * a decoded control-plane event, or a 401 meaning the device token is dead. The
  * flow completes on any disconnect (heartbeat gap, network drop, clean close),
@@ -208,6 +232,32 @@ open class FrontDeskClient(
     ): FetchResult<List<AlertEventDef>> = get(fdUrl, "/api/alert/events", token)
 
     /**
+     * setMemberState drains or activates a member via POST
+     * /api/members/{id}/state. Operator tier: Front Desk enforces the role and
+     * returns the member with its recorded new state (the ack), so a 200 means
+     * the intent is recorded; the physical drain converges asynchronously and the
+     * dashboard reconciles it. Set-state, not toggle, so a retry is a safe no-op.
+     */
+    open suspend fun setMemberState(
+        fdUrl: String,
+        token: String,
+        memberId: String,
+        state: String,
+    ): ActionResult<FleetMember> = post(fdUrl, "/api/members/$memberId/state", token, MemberStateRequest(state))
+
+    /**
+     * syncFleet propagates [primaryId]'s config to the rest of the fleet via POST
+     * /api/config/sync. Operator tier. Front Desk runs the whole sync before it
+     * answers 200, so a success carries the per-member [SyncResponse.results]; the
+     * phone summarizes them rather than blocking on convergence.
+     */
+    open suspend fun syncFleet(
+        fdUrl: String,
+        token: String,
+        primaryId: String,
+    ): ActionResult<SyncResponse> = post(fdUrl, "/api/config/sync", token, ConfigSyncRequest(primaryId))
+
+    /**
      * streamEvents subscribes to GET {fdUrl}/api/sse and emits each frame as an
      * [SseMessage]. Comment heartbeats are swallowed by the SSE parser, so only
      * real events surface. The flow completes on disconnect; a 401 first emits
@@ -305,6 +355,41 @@ open class FrontDeskClient(
             }.getOrElse { e ->
                 if (e is CancellationException) throw e
                 FetchResult.Failure(e.message ?: "could not reach the Front Desk")
+            }
+        }
+
+    // post is the shared authenticated operator POST: bearer token, a JSON body,
+    // decode the 2xx body as T. It maps 403 to Forbidden (this device's role may
+    // not mutate) and 401 to Unauthorized (dead token) as distinct arms, and keeps
+    // every other throwable inside the modeled result set exactly like get() does.
+    private suspend inline fun <reified B, reified T> post(
+        fdUrl: String,
+        path: String,
+        token: String,
+        body: B,
+    ): ActionResult<T> =
+        withContext(Dispatchers.IO) {
+            runCatching {
+                val requestBody = json.encodeToString(body).toRequestBody(JSON_MEDIA)
+                val request =
+                    Request
+                        .Builder()
+                        .url("${base(fdUrl)}$path")
+                        .header("Authorization", "Bearer $token")
+                        .post(requestBody)
+                        .build()
+                http.newCall(request).execute().use { resp ->
+                    val text = resp.body?.string().orEmpty()
+                    when {
+                        resp.isSuccessful -> ActionResult.Success(json.decodeFromString<T>(text))
+                        resp.code == 403 -> ActionResult.Forbidden
+                        resp.code == 401 -> ActionResult.Unauthorized
+                        else -> ActionResult.Failure(errorMessage(text, resp.code))
+                    }
+                }
+            }.getOrElse { e ->
+                if (e is CancellationException) throw e
+                ActionResult.Failure(e.message ?: "could not reach the Front Desk")
             }
         }
 

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreen.kt
@@ -19,14 +19,18 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -39,6 +43,7 @@ import com.hugalafutro.bellhop.R
 import com.hugalafutro.bellhop.data.FdEvent
 import com.hugalafutro.bellhop.data.FleetMember
 import com.hugalafutro.bellhop.data.HealthStatus
+import com.hugalafutro.bellhop.data.MemberState
 import com.hugalafutro.bellhop.data.MemberStatus
 import com.hugalafutro.bellhop.data.MemberTraffic
 import com.hugalafutro.bellhop.data.TrafficPoint
@@ -67,8 +72,19 @@ fun MemberDetailScreen(
     onBack: () -> Unit,
     modifier: Modifier = Modifier,
     ui: MemberDetailUiState = MemberDetailUiState(),
+    // Whether this paired device holds the operator role (from the link). UX only:
+    // Front Desk's 403 is the real guard (surfaced via [ui.action.forbidden]), but
+    // hiding the controls on a monitor device avoids a pointless denied tap.
+    canOperate: Boolean = false,
+    onSetState: (String) -> Unit = {},
+    onSyncFleet: () -> Unit = {},
+    onReconcile: (String) -> Unit = {},
+    onDismissActionError: () -> Unit = {},
 ) {
     val health = member.status.health
+    // Clear the optimistic pending state once the dashboard's live state (member
+    // arrives live from its poll/SSE) has caught up to the accepted target.
+    LaunchedEffect(member.state) { onReconcile(member.state) }
     Scaffold(modifier = modifier.fillMaxSize()) { innerPadding ->
         Column(
             modifier =
@@ -129,6 +145,18 @@ fun MemberDetailScreen(
             ) {
                 item { TrafficCard(ui = ui) }
                 item { MetaCard(member = member) }
+                if (canOperate) {
+                    item {
+                        OperatorCard(
+                            member = member,
+                            isPrimary = isPrimary,
+                            action = ui.action,
+                            onSetState = onSetState,
+                            onSyncFleet = onSyncFleet,
+                            onDismissActionError = onDismissActionError,
+                        )
+                    }
+                }
                 item {
                     Text(
                         text = stringResource(R.string.member_detail_events_title),
@@ -238,6 +266,127 @@ private fun MetaLine(
         color = MaterialTheme.colorScheme.onSurfaceVariant,
         modifier = Modifier.testTag(tag),
     )
+}
+
+/**
+ * OperatorCard is the drain/activate (and, on the primary, fleet-sync) surface,
+ * shown only to an operator device. The button reflects the effective state:
+ * Front Desk's live state, or the optimistic pending target once an action was
+ * accepted and until the dashboard reconciles it. A 403 from Front Desk collapses
+ * the card to the guard note — the authoritative role check overriding the
+ * role-hint UI. Actions are set-state, so a double-tap is a safe no-op; the
+ * biometric prompt gating them lives in the host (MainActivity).
+ */
+@Composable
+private fun OperatorCard(
+    member: FleetMember,
+    isPrimary: Boolean,
+    action: ActionUiState,
+    onSetState: (String) -> Unit,
+    onSyncFleet: () -> Unit,
+    onDismissActionError: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Card(modifier = modifier.fillMaxWidth().testTag("member-operator-card")) {
+        Column(
+            modifier = Modifier.padding(14.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.member_op_title),
+                style = MaterialTheme.typography.titleSmall,
+            )
+            if (action.forbidden) {
+                // Front Desk refused the device's role: the real guard. Drop the
+                // controls entirely so the note is the only thing left.
+                Text(
+                    text = stringResource(R.string.member_op_forbidden),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.testTag("member-op-forbidden"),
+                )
+                return@Column
+            }
+
+            // Optimistic pending target beats the live state until reconciled, so
+            // a fresh tap flips the button immediately even before the fleet moves.
+            val effectiveState = action.pendingState ?: member.state
+            val drained = effectiveState == MemberState.DRAINED
+            Button(
+                onClick = { onSetState(if (drained) MemberState.ACTIVE else MemberState.DRAINED) },
+                enabled = !action.inProgress,
+                modifier = Modifier.fillMaxWidth().testTag("member-op-state"),
+            ) {
+                if (action.inProgress) {
+                    CircularProgressIndicator(
+                        strokeWidth = 2.dp,
+                        modifier = Modifier.size(16.dp),
+                        color = MaterialTheme.colorScheme.onPrimary,
+                    )
+                } else {
+                    Text(
+                        text =
+                            stringResource(
+                                if (drained) R.string.member_op_activate else R.string.member_op_drain,
+                            ),
+                    )
+                }
+            }
+            if (action.pendingState != null) {
+                Text(
+                    text =
+                        stringResource(
+                            if (drained) R.string.member_op_draining else R.string.member_op_activating,
+                        ),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.testTag("member-op-pending"),
+                )
+            }
+
+            if (isPrimary) {
+                OutlinedButton(
+                    onClick = onSyncFleet,
+                    enabled = !action.inProgress,
+                    modifier = Modifier.fillMaxWidth().testTag("member-op-sync"),
+                ) {
+                    Text(text = stringResource(R.string.member_op_sync))
+                }
+            }
+            action.syncSummary?.let { summary ->
+                Text(
+                    text =
+                        if (summary.failed == 0) {
+                            stringResource(R.string.member_op_synced, summary.total)
+                        } else {
+                            stringResource(R.string.member_op_sync_failed, summary.failed, summary.total)
+                        },
+                    style = MaterialTheme.typography.bodySmall,
+                    color =
+                        if (summary.failed == 0) {
+                            MaterialTheme.colorScheme.onSurfaceVariant
+                        } else {
+                            MaterialTheme.colorScheme.error
+                        },
+                    modifier = Modifier.testTag("member-op-sync-result"),
+                )
+            }
+            action.error?.let { message ->
+                Text(
+                    text = stringResource(R.string.member_op_error, message),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.testTag("member-op-error"),
+                )
+                TextButton(
+                    onClick = onDismissActionError,
+                    modifier = Modifier.testTag("member-op-dismiss"),
+                ) {
+                    Text(text = stringResource(R.string.member_op_dismiss))
+                }
+            }
+        }
+    }
 }
 
 /**

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreen.kt
@@ -353,6 +353,16 @@ private fun OperatorCard(
                     Text(text = stringResource(R.string.member_op_sync))
                 }
             }
+            if (action.busy) {
+                // A tap arrived mid-flight and was dropped: say so rather than
+                // leaving the operator wondering why nothing happened.
+                Text(
+                    text = stringResource(R.string.member_op_busy),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.testTag("member-op-busy"),
+                )
+            }
             action.syncSummary?.let { summary ->
                 Text(
                     text =

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailViewModel.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailViewModel.kt
@@ -50,7 +50,9 @@ data class MemberDetailUiState(
  * [MemberDetailViewModel.reconcile]); [forbidden] is Front Desk's 403 — the
  * device's role may not mutate, the authoritative guard behind the hidden UI;
  * [error] is the last action failure; [syncSummary] is a completed config sync's
- * per-member tally.
+ * per-member tally; [busy] flags a tap that arrived while another mutation was
+ * still in flight (dropped, not queued) so the screen can say so rather than the
+ * tap vanishing silently.
  */
 data class ActionUiState(
     val inProgress: Boolean = false,
@@ -58,6 +60,7 @@ data class ActionUiState(
     val forbidden: Boolean = false,
     val error: String? = null,
     val syncSummary: SyncSummary? = null,
+    val busy: Boolean = false,
 )
 
 /** SyncSummary is a finished config sync's tally: how many members, how many failed. */
@@ -168,10 +171,10 @@ class MemberDetailViewModel(
      * a 401 is a dead token, the same revoked remedy as the reads.
      */
     fun setMemberState(target: String) {
-        if (_state.value.action.inProgress) return
+        if (rejectWhileInFlight()) return
         viewModelScope.launch {
             _state.update {
-                it.copy(action = it.action.copy(inProgress = true, error = null, syncSummary = null))
+                it.copy(action = it.action.copy(inProgress = true, error = null, syncSummary = null, busy = false))
             }
             val token = linkStore.token()
             if (token == null) {
@@ -196,10 +199,10 @@ class MemberDetailViewModel(
      * "last config sync" afterwards.
      */
     fun syncFleet(primaryId: String) {
-        if (_state.value.action.inProgress) return
+        if (rejectWhileInFlight()) return
         viewModelScope.launch {
             _state.update {
-                it.copy(action = it.action.copy(inProgress = true, error = null, syncSummary = null))
+                it.copy(action = it.action.copy(inProgress = true, error = null, syncSummary = null, busy = false))
             }
             val token = linkStore.token()
             if (token == null) {
@@ -218,8 +221,18 @@ class MemberDetailViewModel(
         }
     }
 
+    // A single mutation runs at a time. A tap that lands while one is in flight is
+    // dropped rather than queued (set-state is idempotent, so nothing is lost) but
+    // flagged [ActionUiState.busy] so the screen can nudge the operator instead of
+    // the tap vanishing silently. Returns true when the caller should bail out.
+    private fun rejectWhileInFlight(): Boolean {
+        if (!_state.value.action.inProgress) return false
+        _state.update { it.copy(action = it.action.copy(busy = true)) }
+        return true
+    }
+
     // applyActionResult folds an operator ActionResult into the ui state with the
-    // shared arm handling (clear inProgress; 403 -> forbidden, 401 -> revoked,
+    // shared arm handling (clear inProgress/busy; 403 -> forbidden, 401 -> revoked,
     // failure -> error), delegating only the success shaping to [onSuccess] so
     // drain/activate and sync each stamp their own success field.
     private fun <T> applyActionResult(
@@ -227,7 +240,7 @@ class MemberDetailViewModel(
         onSuccess: (MemberDetailUiState, T) -> MemberDetailUiState,
     ) {
         _state.update { st ->
-            val cleared = st.copy(action = st.action.copy(inProgress = false))
+            val cleared = st.copy(action = st.action.copy(inProgress = false, busy = false))
             when (result) {
                 is ActionResult.Success -> onSuccess(cleared, result.data)
                 ActionResult.Forbidden -> cleared.copy(action = cleared.action.copy(forbidden = true))

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailViewModel.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailViewModel.kt
@@ -83,6 +83,13 @@ class MemberDetailViewModel(
     private val _state = MutableStateFlow(MemberDetailUiState())
     val state: StateFlow<MemberDetailUiState> = _state.asStateFlow()
 
+    // The last live member state seen from the dashboard (via [reconcile]). An
+    // accepted action whose target already matches this needs no optimistic
+    // pending hint: the dashboard's SSE refetch beat our ack, so there is nothing
+    // left to reconcile and a pending hint would strand (member.state won't change
+    // again to re-fire the reconcile effect).
+    private var lastLiveState: String? = null
+
     init {
         viewModelScope.launch {
             _state.subscriptionCount
@@ -172,7 +179,11 @@ class MemberDetailViewModel(
                 return@launch
             }
             applyActionResult(client.setMemberState(fdUrl, token, memberId, target)) { st, ok ->
-                st.copy(action = st.action.copy(pendingState = ok.state, forbidden = false))
+                // If the live state already shows the accepted target (an SSE
+                // refetch landed it before our 200), skip the optimistic hint so
+                // it can't strand: there is nothing left for [reconcile] to clear.
+                val pending = ok.state.takeUnless { it == lastLiveState }
+                st.copy(action = st.action.copy(pendingState = pending, forbidden = false))
             }
         }
     }
@@ -234,6 +245,7 @@ class MemberDetailViewModel(
      * change made elsewhere isn't masked by a stale pending value.
      */
     fun reconcile(liveState: String) {
+        lastLiveState = liveState
         _state.update { st ->
             if (st.action.pendingState != null && st.action.pendingState == liveState) {
                 st.copy(action = st.action.copy(pendingState = null))
@@ -245,7 +257,7 @@ class MemberDetailViewModel(
 
     /** dismissActionError clears the last action failure banner. */
     fun dismissActionError() {
-        _state.update { it.copy(action = it.action.copy(error = null, syncSummary = null)) }
+        _state.update { it.copy(action = it.action.copy(error = null)) }
     }
 
     class Factory(

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailViewModel.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailViewModel.kt
@@ -3,6 +3,7 @@ package com.hugalafutro.bellhop.ui.member
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import com.hugalafutro.bellhop.data.ActionResult
 import com.hugalafutro.bellhop.data.EventQuery
 import com.hugalafutro.bellhop.data.FdEvent
 import com.hugalafutro.bellhop.data.FetchResult
@@ -36,6 +37,33 @@ data class MemberDetailUiState(
     val events: List<FdEvent> = emptyList(),
     val error: String? = null,
     val revoked: Boolean = false,
+    // Operator-action overlay (drain/activate, config sync). Orthogonal to the
+    // read state above, which keeps polling regardless.
+    val action: ActionUiState = ActionUiState(),
+)
+
+/**
+ * ActionUiState is the operator-action overlay on the detail screen. [inProgress]
+ * disables the controls and shows a spinner while a mutation is in flight;
+ * [pendingState] is the optimistic drain/activate target shown once Front Desk
+ * has accepted it (the ack), until the dashboard's live state reconciles it (see
+ * [MemberDetailViewModel.reconcile]); [forbidden] is Front Desk's 403 — the
+ * device's role may not mutate, the authoritative guard behind the hidden UI;
+ * [error] is the last action failure; [syncSummary] is a completed config sync's
+ * per-member tally.
+ */
+data class ActionUiState(
+    val inProgress: Boolean = false,
+    val pendingState: String? = null,
+    val forbidden: Boolean = false,
+    val error: String? = null,
+    val syncSummary: SyncSummary? = null,
+)
+
+/** SyncSummary is a finished config sync's tally: how many members, how many failed. */
+data class SyncSummary(
+    val total: Int,
+    val failed: Int,
 )
 
 /**
@@ -120,6 +148,104 @@ class MemberDetailViewModel(
                 revoked = false,
             )
         }
+    }
+
+    /**
+     * setMemberState drains or activates this member. Pessimistic-accept,
+     * optimistic-reconcile: it waits for Front Desk's 200 (the recorded state is
+     * the ack) and then flips [ActionUiState.pendingState] so the screen shows the
+     * target optimistically; the dashboard's live state reconciles it through
+     * [reconcile], never blocking on physical fleet convergence. Set-state, not
+     * toggle, so a double-tap or retry is a safe no-op. A 403 means the device's
+     * role may not mutate (the real guard, surfaced as [ActionUiState.forbidden]);
+     * a 401 is a dead token, the same revoked remedy as the reads.
+     */
+    fun setMemberState(target: String) {
+        if (_state.value.action.inProgress) return
+        viewModelScope.launch {
+            _state.update {
+                it.copy(action = it.action.copy(inProgress = true, error = null, syncSummary = null))
+            }
+            val token = linkStore.token()
+            if (token == null) {
+                _state.update { it.copy(revoked = true, action = it.action.copy(inProgress = false)) }
+                return@launch
+            }
+            applyActionResult(client.setMemberState(fdUrl, token, memberId, target)) { st, ok ->
+                st.copy(action = st.action.copy(pendingState = ok.state, forbidden = false))
+            }
+        }
+    }
+
+    /**
+     * syncFleet propagates [primaryId]'s config to the rest of the fleet. Only the
+     * designated primary is ever passed (choosing a primary is a later slice). The
+     * ack is Front Desk's 200, which carries the per-member outcomes summarized
+     * into [ActionUiState.syncSummary]; the dashboard reconciles the members'
+     * "last config sync" afterwards.
+     */
+    fun syncFleet(primaryId: String) {
+        if (_state.value.action.inProgress) return
+        viewModelScope.launch {
+            _state.update {
+                it.copy(action = it.action.copy(inProgress = true, error = null, syncSummary = null))
+            }
+            val token = linkStore.token()
+            if (token == null) {
+                _state.update { it.copy(revoked = true, action = it.action.copy(inProgress = false)) }
+                return@launch
+            }
+            applyActionResult(client.syncFleet(fdUrl, token, primaryId)) { st, ok ->
+                st.copy(
+                    action =
+                        st.action.copy(
+                            forbidden = false,
+                            syncSummary = SyncSummary(total = ok.results.size, failed = ok.results.count { !it.ok }),
+                        ),
+                )
+            }
+        }
+    }
+
+    // applyActionResult folds an operator ActionResult into the ui state with the
+    // shared arm handling (clear inProgress; 403 -> forbidden, 401 -> revoked,
+    // failure -> error), delegating only the success shaping to [onSuccess] so
+    // drain/activate and sync each stamp their own success field.
+    private fun <T> applyActionResult(
+        result: ActionResult<T>,
+        onSuccess: (MemberDetailUiState, T) -> MemberDetailUiState,
+    ) {
+        _state.update { st ->
+            val cleared = st.copy(action = st.action.copy(inProgress = false))
+            when (result) {
+                is ActionResult.Success -> onSuccess(cleared, result.data)
+                ActionResult.Forbidden -> cleared.copy(action = cleared.action.copy(forbidden = true))
+                ActionResult.Unauthorized -> cleared.copy(revoked = true)
+                is ActionResult.Failure -> cleared.copy(action = cleared.action.copy(error = result.message))
+            }
+        }
+    }
+
+    /**
+     * reconcile clears the optimistic [ActionUiState.pendingState] once the live
+     * member state (from the dashboard's SSE/poll refresher, passed down by the
+     * screen) has caught up to the accepted target. Until then the screen shows
+     * the pending target; afterwards it shows the live state directly, so a later
+     * change made elsewhere isn't masked by a stale pending value.
+     */
+    fun reconcile(liveState: String) {
+        _state.update { st ->
+            if (st.action.pendingState != null && st.action.pendingState == liveState) {
+                st.copy(action = st.action.copy(pendingState = null))
+            } else {
+                st
+            }
+        }
+    }
+
+    /** dismissActionError clears the last action failure banner. */
+    fun dismissActionError() {
+        _state.update { it.copy(action = it.action.copy(error = null, syncSummary = null)) }
     }
 
     class Factory(

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -44,6 +44,18 @@
     <string name="member_detail_created">Added %1$s</string>
     <string name="member_url_title">Open member address</string>
     <string name="member_url_open">Open</string>
+    <!-- Operator actions -->
+    <string name="member_op_title">Operator controls</string>
+    <string name="member_op_drain">Drain</string>
+    <string name="member_op_activate">Activate</string>
+    <string name="member_op_draining">Draining… waiting for the fleet to catch up.</string>
+    <string name="member_op_activating">Activating… waiting for the fleet to catch up.</string>
+    <string name="member_op_sync">Sync fleet from primary</string>
+    <string name="member_op_synced">Synced %1$d members from the primary.</string>
+    <string name="member_op_sync_failed">Sync finished with %1$d of %2$d members failing.</string>
+    <string name="member_op_error">Couldn\'t apply: %1$s</string>
+    <string name="member_op_dismiss">Dismiss</string>
+    <string name="member_op_forbidden">This device is paired as a monitor and can\'t change the fleet. Re-pair with an operator code in Front Desk to drain, activate, or sync.</string>
 
     <!-- Events -->
     <string name="events_title">Events</string>
@@ -98,6 +110,8 @@
     <string name="lock_unlock">Unlock</string>
     <string name="lock_prompt_title">Unlock Bellhop</string>
     <string name="lock_prompt_subtitle">Confirm it\'s you to see the fleet.</string>
+    <string name="operator_prompt_title">Confirm operator action</string>
+    <string name="operator_prompt_subtitle">Confirm it\'s you before changing the fleet.</string>
 
     <!-- Settings -->
     <string name="settings_open">Settings</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -55,6 +55,7 @@
     <string name="member_op_sync_failed">Sync finished with %1$d of %2$d members failing.</string>
     <string name="member_op_error">Couldn\'t apply: %1$s</string>
     <string name="member_op_dismiss">Dismiss</string>
+    <string name="member_op_busy">Another action is still running. Wait for it to finish, then try again.</string>
     <string name="member_op_forbidden">This device is paired as a monitor and can\'t change the fleet. Re-pair with an operator code in Front Desk to drain, activate, or sync.</string>
 
     <!-- Events -->

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/FrontDeskClientTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/FrontDeskClientTest.kt
@@ -593,4 +593,43 @@ class FrontDeskClientTest {
             val result = client.syncFleet(server.url("/").toString(), "tok-1", "m1")
             assertEquals(ActionResult.Forbidden, result)
         }
+
+    @Test
+    fun syncFleetMapsUnauthorizedToItsOwnArm() =
+        runBlocking {
+            // A dead device token on sync is a revoke, distinct from the role 403.
+            server.enqueue(
+                MockResponse().setResponseCode(401).setBody(
+                    """{"error":{"code":"unauthorized","message":"bad token"}}""",
+                ),
+            )
+            val result = client.syncFleet(server.url("/").toString(), "dead", "m1")
+            assertEquals(ActionResult.Unauthorized, result)
+        }
+
+    @Test
+    fun syncFleetServerErrorIsFailure() =
+        runBlocking {
+            server.enqueue(MockResponse().setResponseCode(500).setBody("boom"))
+            val result = client.syncFleet(server.url("/").toString(), "tok-1", "m1")
+            assertTrue(result is ActionResult.Failure)
+        }
+
+    @Test
+    fun syncFleetMalformedUrlIsFailureNotThrow() =
+        runBlocking {
+            val result = client.syncFleet("not a url", "tok", "m1")
+            assertTrue(result is ActionResult.Failure)
+        }
+
+    @Test
+    fun syncFleetEmptyResultsIsSuccessWithEmptyTally() =
+        runBlocking {
+            // A single-node fleet has nobody to propagate to: Front Desk still
+            // answers 200 with an empty results list, which must parse cleanly.
+            server.enqueue(MockResponse().setBody("""{"primary_id":"m1","results":[]}"""))
+            val result = client.syncFleet(server.url("/").toString(), "tok-1", "m1")
+            assertTrue(result is ActionResult.Success)
+            assertTrue((result as ActionResult.Success).data.results.isEmpty())
+        }
 }

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/FrontDeskClientTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/FrontDeskClientTest.kt
@@ -491,4 +491,106 @@ class FrontDeskClientTest {
             val result = client.alertCatalog(server.url("/").toString(), "dead")
             assertEquals(FetchResult.Unauthorized, result)
         }
+
+    @Test
+    fun setMemberStateParsesRecordedStateAndPostsBody() =
+        runBlocking {
+            // Front Desk answers with the member carrying its recorded new state:
+            // that is the ack the phone waits on.
+            server.enqueue(
+                MockResponse().setBody(
+                    """{"id":"m1","name":"hotel-1","url":"http://h1:8080","state":"drained","has_token":true}""",
+                ),
+            )
+
+            val result = client.setMemberState(server.url("/").toString(), "tok-1", "m1", "drained")
+
+            assertTrue(result is ActionResult.Success)
+            assertEquals("drained", (result as ActionResult.Success).data.state)
+
+            val request = server.takeRequest()
+            assertEquals("POST", request.method)
+            assertEquals("/api/members/m1/state", request.path)
+            assertEquals("Bearer tok-1", request.getHeader("Authorization"))
+            assertTrue(request.body.readUtf8().contains("\"state\":\"drained\""))
+        }
+
+    @Test
+    fun setMemberStateMapsForbiddenToItsOwnArm() =
+        runBlocking {
+            // 403 device_role_forbidden: a monitor-role device may never mutate.
+            // Distinct from a dead token so the UI can say "wrong role", not "relink".
+            server.enqueue(
+                MockResponse().setResponseCode(403).setBody(
+                    """{"error":{"code":"device_role_forbidden","message":"nope"}}""",
+                ),
+            )
+            val result = client.setMemberState(server.url("/").toString(), "tok-1", "m1", "drained")
+            assertEquals(ActionResult.Forbidden, result)
+        }
+
+    @Test
+    fun setMemberStateMapsUnauthorizedToItsOwnArm() =
+        runBlocking {
+            server.enqueue(
+                MockResponse().setResponseCode(401).setBody(
+                    """{"error":{"code":"unauthorized","message":"bad token"}}""",
+                ),
+            )
+            val result = client.setMemberState(server.url("/").toString(), "dead", "m1", "active")
+            assertEquals(ActionResult.Unauthorized, result)
+        }
+
+    @Test
+    fun setMemberStateServerErrorIsFailure() =
+        runBlocking {
+            server.enqueue(MockResponse().setResponseCode(500).setBody("boom"))
+            val result = client.setMemberState(server.url("/").toString(), "tok-1", "m1", "active")
+            assertTrue(result is ActionResult.Failure)
+        }
+
+    @Test
+    fun setMemberStateMalformedUrlIsFailureNotThrow() =
+        runBlocking {
+            val result = client.setMemberState("not a url", "tok", "m1", "active")
+            assertTrue(result is ActionResult.Failure)
+        }
+
+    @Test
+    fun syncFleetParsesResultsAndPostsPrimary() =
+        runBlocking {
+            server.enqueue(
+                MockResponse().setBody(
+                    """{"primary_id":"m1","results":[{"member_id":"m2","name":"hotel-2","ok":true},""" +
+                        """{"member_id":"m3","name":"hotel-3","ok":false,"error":"unreachable"}]}""",
+                ),
+            )
+
+            val result = client.syncFleet(server.url("/").toString(), "tok-1", "m1")
+
+            assertTrue(result is ActionResult.Success)
+            val data = (result as ActionResult.Success).data
+            assertEquals("m1", data.primaryId)
+            assertEquals(2, data.results.size)
+            assertTrue(data.results[0].ok)
+            assertFalse(data.results[1].ok)
+
+            val request = server.takeRequest()
+            assertEquals("POST", request.method)
+            assertEquals("/api/config/sync", request.path)
+            assertEquals("Bearer tok-1", request.getHeader("Authorization"))
+            assertTrue(request.body.readUtf8().contains("\"primary_id\":\"m1\""))
+        }
+
+    @Test
+    fun syncFleetMapsForbiddenToItsOwnArm() =
+        runBlocking {
+            server.enqueue(
+                MockResponse().setResponseCode(403).setBody(
+                    """{"error":{"code":"device_role_forbidden","message":"nope"}}""",
+                ),
+            )
+            val result = client.syncFleet(server.url("/").toString(), "tok-1", "m1")
+            assertEquals(ActionResult.Forbidden, result)
+        }
 }

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreenTest.kt
@@ -492,4 +492,28 @@ class MemberDetailScreenTest {
         composeTestRule.onNodeWithTag("member-op-dismiss").performClick()
         assertTrue(dismissed)
     }
+
+    @Test
+    fun busyNoticeRendersWhenATapIsDropped() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                MemberDetailScreen(
+                    member = member,
+                    isPrimary = false,
+                    onBack = {},
+                    ui =
+                        MemberDetailUiState(
+                            loading = false,
+                            traffic = reachableTraffic,
+                            action = ActionUiState(inProgress = true, busy = true),
+                        ),
+                    canOperate = true,
+                )
+            }
+        }
+        composeTestRule
+            .onNodeWithTag("member-detail-list")
+            .performScrollToNode(hasTestTag("member-op-busy"))
+        composeTestRule.onNodeWithTag("member-op-busy").assertIsDisplayed()
+    }
 }

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreenTest.kt
@@ -257,4 +257,158 @@ class MemberDetailScreenTest {
         }
         composeTestRule.onNodeWithTag("member-detail-revoked").assertIsDisplayed()
     }
+
+    @Test
+    fun operatorCardHiddenForMonitorDevice() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                MemberDetailScreen(
+                    member = member,
+                    isPrimary = false,
+                    onBack = {},
+                    ui = MemberDetailUiState(loading = false, traffic = reachableTraffic),
+                    canOperate = false,
+                )
+            }
+        }
+        assertTrue(
+            composeTestRule.onAllNodesWithTag("member-operator-card").fetchSemanticsNodes().isEmpty(),
+        )
+    }
+
+    @Test
+    fun operatorDrainButtonFiresTargetForActiveMember() {
+        var target: String? = null
+        composeTestRule.setContent {
+            BellhopTheme {
+                MemberDetailScreen(
+                    member = member,
+                    isPrimary = false,
+                    onBack = {},
+                    ui = MemberDetailUiState(loading = false, traffic = reachableTraffic),
+                    canOperate = true,
+                    onSetState = { target = it },
+                )
+            }
+        }
+        composeTestRule
+            .onNodeWithTag("member-detail-list")
+            .performScrollToNode(hasTestTag("member-op-state"))
+        composeTestRule.onNodeWithTag("member-op-state").performClick()
+        assertTrue(target == "drained")
+    }
+
+    @Test
+    fun operatorButtonFiresActivateForDrainedMember() {
+        var target: String? = null
+        composeTestRule.setContent {
+            BellhopTheme {
+                MemberDetailScreen(
+                    member = member.copy(state = "drained"),
+                    isPrimary = false,
+                    onBack = {},
+                    ui = MemberDetailUiState(loading = false, traffic = reachableTraffic),
+                    canOperate = true,
+                    onSetState = { target = it },
+                )
+            }
+        }
+        composeTestRule
+            .onNodeWithTag("member-detail-list")
+            .performScrollToNode(hasTestTag("member-op-state"))
+        composeTestRule.onNodeWithTag("member-op-state").performClick()
+        assertTrue(target == "active")
+    }
+
+    @Test
+    fun pendingStateShowsPendingHint() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                MemberDetailScreen(
+                    member = member,
+                    isPrimary = false,
+                    onBack = {},
+                    ui =
+                        MemberDetailUiState(
+                            loading = false,
+                            traffic = reachableTraffic,
+                            action = ActionUiState(pendingState = "drained"),
+                        ),
+                    canOperate = true,
+                )
+            }
+        }
+        composeTestRule
+            .onNodeWithTag("member-detail-list")
+            .performScrollToNode(hasTestTag("member-op-pending"))
+        composeTestRule.onNodeWithTag("member-op-pending").assertIsDisplayed()
+    }
+
+    @Test
+    fun forbiddenActionCollapsesToGuardNote() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                MemberDetailScreen(
+                    member = member,
+                    isPrimary = false,
+                    onBack = {},
+                    ui =
+                        MemberDetailUiState(
+                            loading = false,
+                            traffic = reachableTraffic,
+                            action = ActionUiState(forbidden = true),
+                        ),
+                    canOperate = true,
+                )
+            }
+        }
+        composeTestRule
+            .onNodeWithTag("member-detail-list")
+            .performScrollToNode(hasTestTag("member-op-forbidden"))
+        composeTestRule.onNodeWithTag("member-op-forbidden").assertIsDisplayed()
+        // The guard overrides the role-hint UI: the mutate button is gone.
+        assertTrue(
+            composeTestRule.onAllNodesWithTag("member-op-state").fetchSemanticsNodes().isEmpty(),
+        )
+    }
+
+    @Test
+    fun syncButtonShownOnPrimaryAndFires() {
+        var synced = false
+        composeTestRule.setContent {
+            BellhopTheme {
+                MemberDetailScreen(
+                    member = member,
+                    isPrimary = true,
+                    onBack = {},
+                    ui = MemberDetailUiState(loading = false, traffic = reachableTraffic),
+                    canOperate = true,
+                    onSyncFleet = { synced = true },
+                )
+            }
+        }
+        composeTestRule
+            .onNodeWithTag("member-detail-list")
+            .performScrollToNode(hasTestTag("member-op-sync"))
+        composeTestRule.onNodeWithTag("member-op-sync").performClick()
+        assertTrue(synced)
+    }
+
+    @Test
+    fun syncButtonAbsentOnNonPrimary() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                MemberDetailScreen(
+                    member = member,
+                    isPrimary = false,
+                    onBack = {},
+                    ui = MemberDetailUiState(loading = false, traffic = reachableTraffic),
+                    canOperate = true,
+                )
+            }
+        }
+        assertTrue(
+            composeTestRule.onAllNodesWithTag("member-op-sync").fetchSemanticsNodes().isEmpty(),
+        )
+    }
 }

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreenTest.kt
@@ -14,6 +14,7 @@ import com.hugalafutro.bellhop.data.MemberStatus
 import com.hugalafutro.bellhop.data.MemberTraffic
 import com.hugalafutro.bellhop.data.TrafficPoint
 import com.hugalafutro.bellhop.ui.theme.BellhopTheme
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -410,5 +411,85 @@ class MemberDetailScreenTest {
         assertTrue(
             composeTestRule.onAllNodesWithTag("member-op-sync").fetchSemanticsNodes().isEmpty(),
         )
+    }
+
+    @Test
+    fun inProgressActionDisablesTheStateButton() {
+        var fired = false
+        composeTestRule.setContent {
+            BellhopTheme {
+                MemberDetailScreen(
+                    member = member,
+                    isPrimary = false,
+                    onBack = {},
+                    ui =
+                        MemberDetailUiState(
+                            loading = false,
+                            traffic = reachableTraffic,
+                            action = ActionUiState(inProgress = true),
+                        ),
+                    canOperate = true,
+                    onSetState = { fired = true },
+                )
+            }
+        }
+        composeTestRule
+            .onNodeWithTag("member-detail-list")
+            .performScrollToNode(hasTestTag("member-op-state"))
+        // Disabled while in flight: a tap must not re-issue the action.
+        composeTestRule.onNodeWithTag("member-op-state").performClick()
+        assertFalse(fired)
+    }
+
+    @Test
+    fun syncSummaryRendersTheTally() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                MemberDetailScreen(
+                    member = member,
+                    isPrimary = true,
+                    onBack = {},
+                    ui =
+                        MemberDetailUiState(
+                            loading = false,
+                            traffic = reachableTraffic,
+                            action = ActionUiState(syncSummary = SyncSummary(total = 3, failed = 1)),
+                        ),
+                    canOperate = true,
+                )
+            }
+        }
+        composeTestRule
+            .onNodeWithTag("member-detail-list")
+            .performScrollToNode(hasTestTag("member-op-sync-result"))
+        composeTestRule.onNodeWithTag("member-op-sync-result").assertIsDisplayed()
+    }
+
+    @Test
+    fun errorBannerRendersAndDismissFires() {
+        var dismissed = false
+        composeTestRule.setContent {
+            BellhopTheme {
+                MemberDetailScreen(
+                    member = member,
+                    isPrimary = false,
+                    onBack = {},
+                    ui =
+                        MemberDetailUiState(
+                            loading = false,
+                            traffic = reachableTraffic,
+                            action = ActionUiState(error = "boom"),
+                        ),
+                    canOperate = true,
+                    onDismissActionError = { dismissed = true },
+                )
+            }
+        }
+        composeTestRule
+            .onNodeWithTag("member-detail-list")
+            .performScrollToNode(hasTestTag("member-op-error"))
+        composeTestRule.onNodeWithTag("member-op-error").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("member-op-dismiss").performClick()
+        assertTrue(dismissed)
     }
 }

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailViewModelTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailViewModelTest.kt
@@ -15,6 +15,7 @@ import com.hugalafutro.bellhop.data.PairedDevice
 import com.hugalafutro.bellhop.data.SyncResponse
 import com.hugalafutro.bellhop.data.SyncResultItem
 import com.hugalafutro.bellhop.data.TrafficPoint
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -61,6 +62,10 @@ private class FakeTrafficClient(
     var lastStateTarget: String? = null
     var lastSyncPrimaryId: String? = null
 
+    // Optional latch to hold setMemberState in flight so a test can fire a second
+    // action while the first is still running.
+    var stateGate: CompletableDeferred<Unit>? = null
+
     override suspend fun memberTraffic(
         fdUrl: String,
         token: String,
@@ -90,6 +95,7 @@ private class FakeTrafficClient(
         lastToken = token
         lastMemberId = memberId
         lastStateTarget = state
+        stateGate?.await()
         return stateResult
     }
 
@@ -506,5 +512,30 @@ class MemberDetailViewModelTest {
             val action = withTimeout(5_000) { vm.state.first { !it.action.inProgress } }.action
             assertNull(action.pendingState)
             assertEquals("drained", client.lastStateTarget)
+        }
+
+    @Test
+    fun secondActionWhileInFlightIsDroppedButFlaggedBusy() =
+        runBlocking {
+            // A tap that lands while a mutation is still running is dropped (not
+            // queued), but must surface a busy flag instead of vanishing silently.
+            val client = FakeTrafficClient(FetchResult.Success(traffic))
+            val gate = CompletableDeferred<Unit>()
+            client.stateGate = gate
+            val vm = MemberDetailViewModel(client, linkedStore(), "http://fd:1", "m1")
+
+            vm.setMemberState("drained")
+            withTimeout(5_000) { vm.state.first { it.action.inProgress } }
+
+            // Second tap on the sync button while the drain POST is still open.
+            vm.syncFleet("m1")
+            val busy = withTimeout(5_000) { vm.state.first { it.action.busy } }.action
+            assertTrue(busy.inProgress)
+            assertNull(client.lastSyncPrimaryId)
+
+            // Once the first action completes the busy nudge clears.
+            gate.complete(Unit)
+            val done = withTimeout(5_000) { vm.state.first { !it.action.inProgress } }.action
+            assertFalse(done.busy)
         }
 }

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailViewModelTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailViewModelTest.kt
@@ -1,15 +1,19 @@
 package com.hugalafutro.bellhop.ui.member
 
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import com.hugalafutro.bellhop.data.ActionResult
 import com.hugalafutro.bellhop.data.EventQuery
 import com.hugalafutro.bellhop.data.EventsResponse
 import com.hugalafutro.bellhop.data.FakeCipher
 import com.hugalafutro.bellhop.data.FdEvent
 import com.hugalafutro.bellhop.data.FetchResult
+import com.hugalafutro.bellhop.data.FleetMember
 import com.hugalafutro.bellhop.data.FrontDeskClient
 import com.hugalafutro.bellhop.data.LinkStore
 import com.hugalafutro.bellhop.data.MemberTraffic
 import com.hugalafutro.bellhop.data.PairedDevice
+import com.hugalafutro.bellhop.data.SyncResponse
+import com.hugalafutro.bellhop.data.SyncResultItem
 import com.hugalafutro.bellhop.data.TrafficPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -50,6 +54,13 @@ private class FakeTrafficClient(
     var lastMemberId: String? = null
     var lastEventQuery: EventQuery? = null
 
+    // Operator-action stubs: what setMemberState/syncFleet return, and what the
+    // ViewModel last sent, so the action tests can assert both directions.
+    var stateResult: ActionResult<FleetMember> = ActionResult.Success(FleetMember(id = "m1", state = "drained"))
+    var syncResult: ActionResult<SyncResponse> = ActionResult.Success(SyncResponse())
+    var lastStateTarget: String? = null
+    var lastSyncPrimaryId: String? = null
+
     override suspend fun memberTraffic(
         fdUrl: String,
         token: String,
@@ -68,6 +79,28 @@ private class FakeTrafficClient(
     ): FetchResult<EventsResponse> {
         lastEventQuery = query
         return eventsResult
+    }
+
+    override suspend fun setMemberState(
+        fdUrl: String,
+        token: String,
+        memberId: String,
+        state: String,
+    ): ActionResult<FleetMember> {
+        lastToken = token
+        lastMemberId = memberId
+        lastStateTarget = state
+        return stateResult
+    }
+
+    override suspend fun syncFleet(
+        fdUrl: String,
+        token: String,
+        primaryId: String,
+    ): ActionResult<SyncResponse> {
+        lastToken = token
+        lastSyncPrimaryId = primaryId
+        return syncResult
     }
 }
 
@@ -260,5 +293,140 @@ class MemberDetailViewModelTest {
 
             val s = withTimeout(5_000) { vm.state.first { !it.loading } }
             assertEquals(traffic, s.traffic)
+        }
+
+    @Test
+    fun setMemberStateAcceptsAndFlipsToPending() =
+        runBlocking {
+            // Pessimistic-accept: on Front Desk's 200 the recorded state becomes the
+            // optimistic pending target, and the action clears its in-flight flag.
+            val client = FakeTrafficClient(FetchResult.Success(traffic))
+            client.stateResult = ActionResult.Success(FleetMember(id = "m1", state = "drained"))
+            val vm = MemberDetailViewModel(client, linkedStore(), "http://fd:1", "m1")
+
+            vm.setMemberState("drained")
+
+            val action = withTimeout(5_000) { vm.state.first { it.action.pendingState != null } }.action
+            assertEquals("drained", action.pendingState)
+            assertFalse(action.inProgress)
+            assertFalse(action.forbidden)
+            assertNull(action.error)
+            assertEquals("drained", client.lastStateTarget)
+            assertEquals("tok-1", client.lastToken)
+        }
+
+    @Test
+    fun setMemberStateForbiddenSurfacesTheGuard() =
+        runBlocking {
+            // A monitor-role token's 403 is the real guard, distinct from revoked.
+            val client = FakeTrafficClient(FetchResult.Success(traffic))
+            client.stateResult = ActionResult.Forbidden
+            val vm = MemberDetailViewModel(client, linkedStore(), "http://fd:1", "m1")
+
+            vm.setMemberState("drained")
+
+            val s = withTimeout(5_000) { vm.state.first { it.action.forbidden } }
+            assertFalse(s.revoked)
+            assertNull(s.action.pendingState)
+        }
+
+    @Test
+    fun setMemberStateUnauthorizedFlagsRevoked() =
+        runBlocking {
+            val client = FakeTrafficClient(FetchResult.Success(traffic))
+            client.stateResult = ActionResult.Unauthorized
+            val vm = MemberDetailViewModel(client, linkedStore(), "http://fd:1", "m1")
+
+            vm.setMemberState("active")
+
+            val s = withTimeout(5_000) { vm.state.first { it.revoked } }
+            assertFalse(s.action.forbidden)
+        }
+
+    @Test
+    fun setMemberStateFailureSurfacesError() =
+        runBlocking {
+            val client = FakeTrafficClient(FetchResult.Success(traffic))
+            client.stateResult = ActionResult.Failure("boom")
+            val vm = MemberDetailViewModel(client, linkedStore(), "http://fd:1", "m1")
+
+            vm.setMemberState("active")
+
+            val s = withTimeout(5_000) { vm.state.first { it.action.error != null } }
+            assertEquals("boom", s.action.error)
+            assertFalse(s.action.inProgress)
+        }
+
+    @Test
+    fun setMemberStateOnUnreadableTokenFlagsRevokedWithoutCall() =
+        runBlocking {
+            // Linked in name only (Keystore key gone): no request can ever succeed,
+            // so surface the revoked flag and never touch Front Desk.
+            val client = FakeTrafficClient(FetchResult.Success(traffic))
+            val vm = MemberDetailViewModel(client, newLinkStore(), "http://fd:1", "m1")
+
+            vm.setMemberState("drained")
+
+            withTimeout(5_000) { vm.state.first { it.revoked } }
+            assertNull(client.lastStateTarget)
+        }
+
+    @Test
+    fun reconcileClearsPendingOnceLiveCatchesUp() =
+        runBlocking {
+            val client = FakeTrafficClient(FetchResult.Success(traffic))
+            client.stateResult = ActionResult.Success(FleetMember(id = "m1", state = "drained"))
+            val vm = MemberDetailViewModel(client, linkedStore(), "http://fd:1", "m1")
+
+            vm.setMemberState("drained")
+            withTimeout(5_000) { vm.state.first { it.action.pendingState == "drained" } }
+
+            // A live state that hasn't caught up leaves the pending target intact.
+            vm.reconcile("active")
+            assertEquals("drained", vm.state.value.action.pendingState)
+
+            // Once the live state matches the accepted target the optimism is done.
+            vm.reconcile("drained")
+            assertNull(vm.state.value.action.pendingState)
+        }
+
+    @Test
+    fun syncFleetTalliesResults() =
+        runBlocking {
+            val client = FakeTrafficClient(FetchResult.Success(traffic))
+            client.syncResult =
+                ActionResult.Success(
+                    SyncResponse(
+                        primaryId = "m1",
+                        results =
+                            listOf(
+                                SyncResultItem(memberId = "m2", ok = true),
+                                SyncResultItem(memberId = "m3", ok = false, error = "unreachable"),
+                            ),
+                    ),
+                )
+            val vm = MemberDetailViewModel(client, linkedStore(), "http://fd:1", "m1")
+
+            vm.syncFleet("m1")
+
+            val summary = withTimeout(5_000) { vm.state.first { it.action.syncSummary != null } }.action.syncSummary
+            assertEquals(2, summary?.total)
+            assertEquals(1, summary?.failed)
+            assertEquals("m1", client.lastSyncPrimaryId)
+        }
+
+    @Test
+    fun dismissActionErrorClearsBanners() =
+        runBlocking {
+            val client = FakeTrafficClient(FetchResult.Success(traffic))
+            client.stateResult = ActionResult.Failure("boom")
+            val vm = MemberDetailViewModel(client, linkedStore(), "http://fd:1", "m1")
+
+            vm.setMemberState("active")
+            withTimeout(5_000) { vm.state.first { it.action.error == "boom" } }
+
+            vm.dismissActionError()
+            assertNull(vm.state.value.action.error)
+            assertNull(vm.state.value.action.syncSummary)
         }
 }

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailViewModelTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailViewModelTest.kt
@@ -429,4 +429,82 @@ class MemberDetailViewModelTest {
             assertNull(vm.state.value.action.error)
             assertNull(vm.state.value.action.syncSummary)
         }
+
+    @Test
+    fun syncFleetForbiddenSurfacesTheGuard() =
+        runBlocking {
+            // Same authority split as setMemberState: a monitor-role sync is a
+            // 403 guard, not a revoke.
+            val client = FakeTrafficClient(FetchResult.Success(traffic))
+            client.syncResult = ActionResult.Forbidden
+            val vm = MemberDetailViewModel(client, linkedStore(), "http://fd:1", "m1")
+
+            vm.syncFleet("m1")
+
+            val s = withTimeout(5_000) { vm.state.first { it.action.forbidden } }
+            assertFalse(s.revoked)
+            assertNull(s.action.syncSummary)
+        }
+
+    @Test
+    fun syncFleetUnauthorizedFlagsRevoked() =
+        runBlocking {
+            val client = FakeTrafficClient(FetchResult.Success(traffic))
+            client.syncResult = ActionResult.Unauthorized
+            val vm = MemberDetailViewModel(client, linkedStore(), "http://fd:1", "m1")
+
+            vm.syncFleet("m1")
+
+            val s = withTimeout(5_000) { vm.state.first { it.revoked } }
+            assertFalse(s.action.forbidden)
+        }
+
+    @Test
+    fun syncFleetFailureSurfacesError() =
+        runBlocking {
+            val client = FakeTrafficClient(FetchResult.Success(traffic))
+            client.syncResult = ActionResult.Failure("boom")
+            val vm = MemberDetailViewModel(client, linkedStore(), "http://fd:1", "m1")
+
+            vm.syncFleet("m1")
+
+            val s = withTimeout(5_000) { vm.state.first { it.action.error != null } }
+            assertEquals("boom", s.action.error)
+            assertFalse(s.action.inProgress)
+        }
+
+    @Test
+    fun syncFleetOnUnreadableTokenFlagsRevokedWithoutCall() =
+        runBlocking {
+            // Linked in name only: surface the revoked flag, never hit Front Desk.
+            val client = FakeTrafficClient(FetchResult.Success(traffic))
+            val vm = MemberDetailViewModel(client, newLinkStore(), "http://fd:1", "m1")
+
+            vm.syncFleet("m1")
+
+            withTimeout(5_000) { vm.state.first { it.revoked } }
+            assertNull(client.lastSyncPrimaryId)
+        }
+
+    @Test
+    fun liveStateBeforeAckSkipsThePendingHint() =
+        runBlocking {
+            // Race: the dashboard's SSE refetch shows the target before our POST
+            // 200 lands. reconcile sees the live state first (pending still null),
+            // then the ack arrives — it must not strand a pending hint that can
+            // never clear, since member.state won't change again to re-fire it.
+            val client = FakeTrafficClient(FetchResult.Success(traffic))
+            client.stateResult = ActionResult.Success(FleetMember(id = "m1", state = "drained"))
+            val vm = MemberDetailViewModel(client, linkedStore(), "http://fd:1", "m1")
+
+            // Live state has already converged to the target before we ack.
+            vm.reconcile("drained")
+            vm.setMemberState("drained")
+
+            // The action completes (in-flight flag clears) but leaves no pending
+            // hint: the live state already matched the accepted target.
+            val action = withTimeout(5_000) { vm.state.first { !it.action.inProgress } }.action
+            assertNull(action.pendingState)
+            assertEquals("drained", client.lastStateTarget)
+        }
 }


### PR DESCRIPTION
## What

Phase A4 of the Bellhop companion app: an operator can **drain / activate** a fleet member and **sync the fleet from the primary**, straight from the phone, each gated behind a biometric prompt. Bellhop-only change — the Front Desk endpoints (`POST /api/members/{id}/state`, `POST /api/config/sync`) are already `requireOperator`-gated, so there is zero backend work here.

Implements `plans/android-companion-app.md` § "Phase A4: Operator actions" per the four agreed design calls.

## Design

- **Ack = pessimistic-accept / optimistic-reconcile.** The action waits for Front Desk's 200 (the recorded state is the ack), flips the row to an optimistic `pendingState`, and lets the existing SSE/poll reconcile it. It never blocks on physical convergence.
- **Per-session biometric operator gate** on its own short timer (`OPERATOR_AUTH_WINDOW_MS = 60s`), tighter than the app-lock window and orthogonal to Front Desk's role check — one prompt authorizes a brief burst of taps, then re-prompts. Reuses `promptAppUnlock` (degrades open with no enrolled credential, same as the app lock; no new local-auth callback region).
- **Idempotent by construction** — set-state, not toggle, so a double-tap or retry is a safe no-op.
- **Role-aware UI is UX only.** Operator controls are hidden on a monitor device to avoid a pointless denied tap, but Front Desk's `403 device_role_forbidden` is the real guard: it collapses the card to a guard note and drops the buttons. `403` / `401`-revoked / `5xx`+timeout map to distinct copy.

`ActionResult<T>` is modeled separately from `FetchResult` (it has a `Forbidden` arm the reads never hit) so read call sites don't grow a role branch.

## Scope

In: drain/activate/config-sync client methods, member-detail operator card, biometric gate, English strings.
Out (later slices): Glance widget, i18n locale wiring, release signing, set-primary (A4b).

## Testing

JVM-first (Robolectric + MockWebServer + Turbine), asserting on testTags not copy. Covers the client mapping (200/403/401/5xx/malformed-URL/empty-results), the ViewModel folding (accept→pending, forbidden, revoked, failure, unreadable-token, reconcile-clears-pending incl. the live-before-ack race, sync tally, dismiss), and the screen (card hidden for monitor, drain/activate fires, pending hint, forbidden collapse, sync-on-primary-only, in-progress disable, sync-summary render, error+dismiss).

Gates green (JDK21, ANDROID_HOME=/opt/android-sdk): `ktlintCheck`, `testDebugUnitTest`, `lintDebug`, `assembleDebug`. Verified end-to-end on the emulator against a live Front Desk: paired as operator, drained a member, watched it reconcile, activated it back, revoked the device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)