### PR TITLE
ci(trivy): ignore GO-2026-5932 (unreachable openpgp advisory)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,17 @@
+# Trivy vulnerability ignore list.
+#
+# Each entry MUST document why the finding is not actionable. Keep this list
+# minimal: it hides findings from BOTH the CI gate and the Security-tab SARIF
+# report, so only suppress verified false positives or permanently-unfixable
+# advisories.
+
+# GO-2026-5932 — "golang.org/x/crypto/openpgp is unmaintained".
+# A module-level advisory with NO fixed version: it flags every release of
+# golang.org/x/crypto because the openpgp subpackage lives in that module,
+# regardless of whether the binary links it. We never import openpgp
+# (`go mod why golang.org/x/crypto/openpgp` => "main module does not need
+# package"; govulncheck's call-graph analysis is green). We only use
+# golang.org/x/crypto/argon2, which is why the module is in the binary's
+# buildinfo at all. Trivy's binary scan matches on module+version and cannot
+# see that openpgp is never linked, hence the false positive.
+GO-2026-5932


### PR DESCRIPTION
## What

Adds a documented `.trivyignore` suppressing **GO-2026-5932** ("`golang.org/x/crypto/openpgp` is unmaintained").

## Why

This advisory (published 2026-07-07) surfaced as [code-scanning alert #15](https://github.com/hugalafutro/model-hotel/security/code-scanning/15) via the weekly published-image SARIF report. It is a **false positive for us**:

- It's a module-level advisory with **no fixed version** — it flags *every* release of `golang.org/x/crypto` because the `openpgp` subpackage exists in the module, whether or not the binary links it.
- We never import `openpgp`: `go mod why golang.org/x/crypto/openpgp` → *"main module does not need package"*, grep finds no usage, and `govulncheck`'s call-graph analysis is green.
- We only use `golang.org/x/crypto/argon2`, which is why the module is in the binary's buildinfo at all. Trivy's binary scan matches on module+version and can't tell `openpgp` is unlinked.

Since there's no version to bump to, an ignore entry with a documented reason is the correct resolution. It drops the finding from both the CI gate and the Security-tab SARIF report.

## Note on why it wasn't caught by CI

The Trivy gates only fail on fixable `CRITICAL,HIGH`. GO-2026-5932 is `UNKNOWN` severity and unfixed, so it was never a build failure — it only appeared in the tracking SARIF upload. After this merges, the existing alert will close on the next `image-scan` run (or is dismissed as a false positive in the meantime).

🤖 Generated with [Claude Code](https://claude.com/claude-code)