### PR TITLE
feat(bellhop): pause/unpause auto-sync + stale-sync alert (Phase A4b)

### DIFF
--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
@@ -643,10 +643,16 @@ private fun LinkedContent(
         DashboardScreen(
             link = state,
             ui = ui,
+            // Role-hint UI, same as the member-detail card: an operator device gets
+            // the pause/resume toggle, a monitor doesn't. Front Desk's 403 is still
+            // the real guard. The toggle goes through the biometric operator gate.
+            canOperate = state.role == OPERATOR_ROLE,
             onMemberClick = { selectedMemberId = it },
             onEventsClick = { showEvents = true },
             onAlertsClick = { showAlerts = true },
             onSettingsClick = { showSettings = true },
+            onSetAutoSync = { enabled -> requireOperatorAuth { dashVm.setAutoSync(enabled) } },
+            onDismissAutoSyncError = { dashVm.dismissAutoSyncError() },
             onVisibleMembers = dashVm::setVisibleMembers,
         )
     }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/FleetModels.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/FleetModels.kt
@@ -56,14 +56,33 @@ data class HealthStatus(
 )
 
 /**
- * AutoSyncConfig is GET /api/fleet/autosync: the auto-sync toggle plus the
- * designated primary member (empty when none is chosen). The dashboard only
- * uses primaryId, for the Primary badge.
+ * AutoSyncConfig is GET/PUT /api/fleet/autosync: the auto-sync toggle, the
+ * designated primary member (empty when none is chosen), and Front Desk's
+ * computed [stale] flag (auto-sync off and the fleet unsynced for over a day, so
+ * the replicas may be drifting). The dashboard uses primaryId for the Primary
+ * badge and enabled for the pause/unpause control; the background monitor reads
+ * stale to raise a drift notification.
  */
 @Serializable
 data class AutoSyncConfig(
     val enabled: Boolean = false,
     @SerialName("primary_id") val primaryId: String = "",
+    val stale: Boolean = false,
+)
+
+/**
+ * AutoSyncRequest is the PUT /api/fleet/autosync body (operator tier). Bellhop
+ * only ever toggles [enabled] on the already-designated [primaryId] and so sends
+ * an empty [confirmToken]: repointing or clearing the primary needs the raw Front
+ * Desk admin token (which a phone never holds) and stays a web-only action, but
+ * toggling an unchanged primary is applied without one. Choosing a primary is
+ * deliberately not a phone capability.
+ */
+@Serializable
+data class AutoSyncRequest(
+    val enabled: Boolean,
+    @SerialName("primary_id") val primaryId: String,
+    @SerialName("confirm_token") val confirmToken: String = "",
 )
 
 /**

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/FleetSnapshot.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/FleetSnapshot.kt
@@ -38,16 +38,34 @@ fun healthStateOf(member: FleetMember): MemberHealthState =
 @Serializable
 data class FleetSnapshot(
     val states: Map<String, String> = emptyMap(),
+    // Fleet-wide: Front Desk's auto-sync-stale flag (auto-sync off and the fleet
+    // unsynced for over a day). Persisted alongside member health so the same
+    // snapshot-diff that pages on health edges also notifies on drift onset.
+    val autosyncStale: Boolean = false,
 ) {
     /** stateOf returns the stored state for a member, or null if it wasn't seen. */
     fun stateOf(id: String): MemberHealthState? =
         states[id]?.let { name -> runCatching { MemberHealthState.valueOf(name) }.getOrNull() }
 
     companion object {
-        fun of(members: List<FleetMember>): FleetSnapshot =
-            FleetSnapshot(members.associate { it.id to healthStateOf(it).name })
+        fun of(
+            members: List<FleetMember>,
+            autosyncStale: Boolean = false,
+        ): FleetSnapshot =
+            FleetSnapshot(
+                states = members.associate { it.id to healthStateOf(it).name },
+                autosyncStale = autosyncStale,
+            )
     }
 }
+
+/**
+ * FleetAlert is one thing worth a background notification, the unit the notifier
+ * renders. It spans member health edges ([MemberTransition]) and the fleet-wide
+ * auto-sync drift signal ([AutoSyncAlert]), so a single diff pass can hand both to
+ * the same notify path.
+ */
+sealed interface FleetAlert
 
 /**
  * MemberTransition is a health edge worth a notification. Only the two edges that
@@ -55,7 +73,7 @@ data class FleetSnapshot(
  * recovered. Drain/activate is an operator action (not an alert), and moves
  * to/from UNKNOWN are noise (a reconnecting poller), so neither is a transition.
  */
-sealed interface MemberTransition {
+sealed interface MemberTransition : FleetAlert {
     val id: String
     val name: String
 
@@ -68,6 +86,18 @@ sealed interface MemberTransition {
         override val id: String,
         override val name: String,
     ) : MemberTransition
+}
+
+/**
+ * AutoSyncAlert is the fleet-wide config-drift edge: [WentStale] when Front Desk
+ * flips its auto-sync-stale flag on (auto-sync off and unsynced for over a day),
+ * [Resumed] when it clears. It mirrors [MemberTransition]'s down/recovered shape
+ * for a single boolean instead of per-member health.
+ */
+sealed interface AutoSyncAlert : FleetAlert {
+    data object WentStale : AutoSyncAlert
+
+    data object Resumed : AutoSyncAlert
 }
 
 /**
@@ -98,4 +128,23 @@ fun diffFleet(
         }
     }
     return transitions
+}
+
+/**
+ * diffAutoSync is the fleet-wide counterpart to [diffFleet]: given the previously
+ * persisted snapshot and the auto-sync-stale flag just read, return the drift edge
+ * to notify on, or null if nothing crossed. Like diffFleet it stays silent on the
+ * first ever poll ([previous] is null) so a phone that opens onto an
+ * already-stale fleet doesn't buzz for a state it never saw change.
+ */
+fun diffAutoSync(
+    previous: FleetSnapshot?,
+    current: Boolean,
+): AutoSyncAlert? {
+    if (previous == null) return null
+    return when {
+        !previous.autosyncStale && current -> AutoSyncAlert.WentStale
+        previous.autosyncStale && !current -> AutoSyncAlert.Resumed
+        else -> null
+    }
 }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/FrontDeskClient.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/FrontDeskClient.kt
@@ -258,6 +258,21 @@ open class FrontDeskClient(
     ): ActionResult<SyncResponse> = post(fdUrl, "/api/config/sync", token, ConfigSyncRequest(primaryId))
 
     /**
+     * setAutoSync pauses or resumes auto-sync via PUT /api/fleet/autosync.
+     * Operator tier: Front Desk enforces the role. Bellhop only ever toggles
+     * [enabled] on the unchanged [primaryId] (empty confirm token), which Front
+     * Desk applies without an admin confirmation; repointing the primary stays a
+     * web-only action. Front Desk echoes the applied config back, so a 200 is the
+     * ack the dashboard reconciles against.
+     */
+    open suspend fun setAutoSync(
+        fdUrl: String,
+        token: String,
+        enabled: Boolean,
+        primaryId: String,
+    ): ActionResult<AutoSyncConfig> = put(fdUrl, "/api/fleet/autosync", token, AutoSyncRequest(enabled, primaryId))
+
+    /**
      * streamEvents subscribes to GET {fdUrl}/api/sse and emits each frame as an
      * [SseMessage]. Comment heartbeats are swallowed by the SSE parser, so only
      * real events surface. The flow completes on disconnect; a 401 first emits
@@ -358,15 +373,32 @@ open class FrontDeskClient(
             }
         }
 
-    // post is the shared authenticated operator POST: bearer token, a JSON body,
-    // decode the 2xx body as T. It maps 403 to Forbidden (this device's role may
-    // not mutate) and 401 to Unauthorized (dead token) as distinct arms, and keeps
-    // every other throwable inside the modeled result set exactly like get() does.
+    // post/put are the shared authenticated operator mutations (POST for actions,
+    // PUT for the auto-sync toggle); both delegate to mutate with the HTTP method.
     private suspend inline fun <reified B, reified T> post(
         fdUrl: String,
         path: String,
         token: String,
         body: B,
+    ): ActionResult<T> = mutate(fdUrl, path, token, body, "POST")
+
+    private suspend inline fun <reified B, reified T> put(
+        fdUrl: String,
+        path: String,
+        token: String,
+        body: B,
+    ): ActionResult<T> = mutate(fdUrl, path, token, body, "PUT")
+
+    // mutate sends a JSON body with a bearer token and decodes the 2xx body as T.
+    // It maps 403 to Forbidden (this device's role may not mutate) and 401 to
+    // Unauthorized (dead token) as distinct arms, and keeps every other throwable
+    // inside the modeled result set exactly like get() does.
+    private suspend inline fun <reified B, reified T> mutate(
+        fdUrl: String,
+        path: String,
+        token: String,
+        body: B,
+        method: String,
     ): ActionResult<T> =
         withContext(Dispatchers.IO) {
             runCatching {
@@ -376,7 +408,7 @@ open class FrontDeskClient(
                         .Builder()
                         .url("${base(fdUrl)}$path")
                         .header("Authorization", "Bearer $token")
-                        .post(requestBody)
+                        .method(method, requestBody)
                         .build()
                 http.newCall(request).execute().use { resp ->
                     val text = resp.body?.string().orEmpty()

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/notify/FleetNotifier.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/notify/FleetNotifier.kt
@@ -12,6 +12,8 @@ import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
 import com.hugalafutro.bellhop.MainActivity
 import com.hugalafutro.bellhop.R
+import com.hugalafutro.bellhop.data.AutoSyncAlert
+import com.hugalafutro.bellhop.data.FleetAlert
 import com.hugalafutro.bellhop.data.MemberTransition
 
 /**
@@ -29,11 +31,17 @@ import com.hugalafutro.bellhop.data.MemberTransition
 object FleetNotifier {
     const val CHANNEL_DOWN = "member_down"
     const val CHANNEL_UP = "member_up"
+    const val CHANNEL_STALE = "config_stale"
 
     // A constant numeric id: the member id is carried as the notification tag
     // instead, so two members whose ids collide under String.hashCode() (an int id
     // would fold them onto one row and drop an alert) still get separate rows.
     private const val NOTIFICATION_ID = 1
+
+    // The auto-sync drift alert is fleet-wide, not per-member, so it uses one fixed
+    // tag: WentStale and Resumed share it, so the resume updates the stale row in
+    // place instead of stacking a second notification.
+    private const val AUTOSYNC_TAG = "autosync-stale"
 
     /**
      * ensureChannels registers both notification channels. Safe to call
@@ -56,27 +64,60 @@ object FleetNotifier {
                 NotificationManager.IMPORTANCE_LOW,
             ),
         )
+        // The drift warning is a nudge, not a page: default importance so it shows
+        // and can chime, but never heads-up like a member going down.
+        manager.createNotificationChannel(
+            NotificationChannel(
+                CHANNEL_STALE,
+                context.getString(R.string.notif_channel_stale),
+                NotificationManager.IMPORTANCE_DEFAULT,
+            ),
+        )
     }
 
-    /** notify posts one health-edge notification, or does nothing if it can't. */
+    /** notify posts one fleet-alert notification, or does nothing if it can't. */
     fun notify(
         context: Context,
-        transition: MemberTransition,
+        alert: FleetAlert,
     ) {
         if (!canPost(context)) return
         ensureChannels(context)
 
-        val (channel, title) =
-            when (transition) {
+        // Each alert maps to a channel (which drives importance/muting), a title +
+        // body, and a tag. Member alerts tag by member id so distinct members never
+        // share a row and one flapping member updates in place; the fleet-wide
+        // drift alert uses one fixed tag so its resume replaces its stale row.
+        val (channel, title, body) =
+            when (alert) {
                 is MemberTransition.WentDown ->
-                    CHANNEL_DOWN to context.getString(R.string.notif_down_title, transition.name)
+                    Triple(
+                        CHANNEL_DOWN,
+                        context.getString(R.string.notif_down_title, alert.name),
+                        context.getString(R.string.notif_down_body),
+                    )
                 is MemberTransition.Recovered ->
-                    CHANNEL_UP to context.getString(R.string.notif_up_title, transition.name)
+                    Triple(
+                        CHANNEL_UP,
+                        context.getString(R.string.notif_up_title, alert.name),
+                        context.getString(R.string.notif_up_body),
+                    )
+                AutoSyncAlert.WentStale ->
+                    Triple(
+                        CHANNEL_STALE,
+                        context.getString(R.string.notif_stale_title),
+                        context.getString(R.string.notif_stale_body),
+                    )
+                AutoSyncAlert.Resumed ->
+                    Triple(
+                        CHANNEL_STALE,
+                        context.getString(R.string.notif_stale_resumed_title),
+                        context.getString(R.string.notif_stale_resumed_body),
+                    )
             }
-        val body =
-            when (transition) {
-                is MemberTransition.WentDown -> context.getString(R.string.notif_down_body)
-                is MemberTransition.Recovered -> context.getString(R.string.notif_up_body)
+        val tag =
+            when (alert) {
+                is MemberTransition -> alert.id
+                is AutoSyncAlert -> AUTOSYNC_TAG
             }
 
         val notification =
@@ -90,14 +131,11 @@ object FleetNotifier {
                 .setCategory(NotificationCompat.CATEGORY_STATUS)
                 .build()
 
-        // Tagged with the member id so a member flapping down->up->down updates its
-        // one notification in place rather than stacking a fresh row each poll, and
-        // so distinct members never share a row. canPost checked the permission,
-        // but it can be revoked between that check and here, so swallow the
-        // resulting SecurityException rather than crash a background worker over a
-        // lost notification.
+        // canPost checked the permission, but it can be revoked between that check
+        // and here, so swallow the resulting SecurityException rather than crash a
+        // background worker over a lost notification.
         try {
-            NotificationManagerCompat.from(context).notify(transition.id, NOTIFICATION_ID, notification)
+            NotificationManagerCompat.from(context).notify(tag, NOTIFICATION_ID, notification)
         } catch (_: SecurityException) {
         }
     }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -75,10 +76,13 @@ fun DashboardScreen(
     link: LinkState.Linked,
     modifier: Modifier = Modifier,
     ui: DashboardUiState = DashboardUiState(),
+    canOperate: Boolean = false,
     onMemberClick: (String) -> Unit = {},
     onEventsClick: () -> Unit = {},
     onAlertsClick: () -> Unit = {},
     onSettingsClick: () -> Unit = {},
+    onSetAutoSync: (Boolean) -> Unit = {},
+    onDismissAutoSyncError: () -> Unit = {},
     onVisibleMembers: (List<String>) -> Unit = {},
 ) {
     // Which member's URL the "open externally" popup is showing, if any. Tapping
@@ -191,6 +195,20 @@ fun DashboardScreen(
                 )
             }
 
+            // Pause/resume auto-sync: an operator lever, shown only once a primary
+            // is configured (choosing one stays a web action) and only to an
+            // operator device. Front Desk's 403 is still the real guard, collapsing
+            // the card to a note if the role hint is wrong.
+            if (canOperate && ui.primaryId.isNotEmpty()) {
+                AutoSyncControl(
+                    action = ui.autoSync,
+                    enabled = ui.autoSyncEnabled,
+                    onSetAutoSync = onSetAutoSync,
+                    onDismissError = onDismissAutoSyncError,
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+            }
+
             when {
                 ui.loading ->
                     Box(
@@ -249,6 +267,96 @@ fun DashboardScreen(
                                 onUrlClick = { urlDialogFor = member },
                             )
                         }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * AutoSyncControl is the pause/resume operator lever. It shows the effective state
+ * optimistically ([AutoSyncAction.pendingEnabled] over the live value) so the
+ * toggle reflects a just-sent change while it reconciles, collapses to a guard
+ * note when Front Desk returns 403, and surfaces a failure with a dismiss.
+ */
+@Composable
+private fun AutoSyncControl(
+    action: AutoSyncAction,
+    enabled: Boolean,
+    onSetAutoSync: (Boolean) -> Unit,
+    onDismissError: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val effective = action.pendingEnabled ?: enabled
+    Card(modifier = modifier.fillMaxWidth().testTag("autosync-card")) {
+        Column(
+            modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            if (action.forbidden) {
+                // Front Desk's 403 is the authoritative guard: drop the toggle and
+                // show why, the same collapse the member-detail operator card does.
+                Text(
+                    text = stringResource(R.string.autosync_forbidden),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.testTag("autosync-forbidden"),
+                )
+            } else {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = stringResource(R.string.autosync_title),
+                            style = MaterialTheme.typography.titleMedium,
+                        )
+                        Text(
+                            text = stringResource(if (effective) R.string.autosync_on else R.string.autosync_off),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.testTag("autosync-status"),
+                        )
+                    }
+                    Switch(
+                        checked = effective,
+                        onCheckedChange = onSetAutoSync,
+                        enabled = !action.inProgress,
+                        modifier = Modifier.testTag("autosync-toggle"),
+                    )
+                }
+                if (action.pendingEnabled != null) {
+                    Text(
+                        text =
+                            stringResource(
+                                if (action.pendingEnabled) R.string.autosync_resuming else R.string.autosync_pausing,
+                            ),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.testTag("autosync-pending"),
+                    )
+                }
+                if (action.busy) {
+                    Text(
+                        text = stringResource(R.string.autosync_busy),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.testTag("autosync-busy"),
+                    )
+                }
+            }
+            if (action.error != null) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        text = stringResource(R.string.autosync_error, action.error),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error,
+                        modifier = Modifier.weight(1f).testTag("autosync-error"),
+                    )
+                    TextButton(onClick = onDismissError) {
+                        Text(stringResource(R.string.member_op_dismiss))
                     }
                 }
             }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModel.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModel.kt
@@ -3,6 +3,7 @@ package com.hugalafutro.bellhop.ui.dashboard
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import com.hugalafutro.bellhop.data.ActionResult
 import com.hugalafutro.bellhop.data.FetchResult
 import com.hugalafutro.bellhop.data.FleetMember
 import com.hugalafutro.bellhop.data.FrontDeskClient
@@ -32,6 +33,9 @@ data class DashboardUiState(
     val loading: Boolean = true,
     val members: List<FleetMember> = emptyList(),
     val primaryId: String = "",
+    // Auto-sync master toggle, from GET /api/fleet/autosync. Drives the pause/
+    // resume operator control, which is only shown once a primary is configured.
+    val autoSyncEnabled: Boolean = false,
     // Per-member traffic for the inline card sparkline, keyed by member id and
     // filled lazily for whichever members are currently on screen (see
     // [DashboardViewModel.setVisibleMembers]). A member absent from the map just
@@ -39,6 +43,23 @@ data class DashboardUiState(
     val traffic: Map<String, MemberTraffic> = emptyMap(),
     val error: String? = null,
     val revoked: Boolean = false,
+    // Pause/resume operator action state (same shape as the member-detail card).
+    val autoSync: AutoSyncAction = AutoSyncAction(),
+)
+
+/**
+ * AutoSyncAction is the pause/resume operator control's UI state, the fleet-wide
+ * twin of the member-detail operator card: pessimistic-accept Front Desk's 200,
+ * show [pendingEnabled] optimistically until a refresh reconciles the live value,
+ * collapse to a guard note on a 403 ([forbidden]), and surface a failure in
+ * [error]. [busy] flags a tap dropped because one is already in flight.
+ */
+data class AutoSyncAction(
+    val inProgress: Boolean = false,
+    val pendingEnabled: Boolean? = null,
+    val forbidden: Boolean = false,
+    val error: String? = null,
+    val busy: Boolean = false,
 )
 
 /**
@@ -257,15 +278,26 @@ class DashboardViewModel(
                 val autoSync = client.autoSync(fdUrl, token) as? FetchResult.Success
                 val liveIds = result.data.mapTo(HashSet()) { it.id }
                 _state.update {
+                    val liveEnabled = autoSync?.data?.enabled ?: it.autoSyncEnabled
                     it.copy(
                         loading = false,
                         members = result.data,
                         primaryId = autoSync?.data?.primaryId ?: it.primaryId,
+                        autoSyncEnabled = liveEnabled,
                         // Drop cached traffic for members that left the fleet so
                         // the map can't grow without bound as members churn.
                         traffic = it.traffic.filterKeys { id -> id in liveIds },
                         error = null,
                         revoked = false,
+                        // Reconcile the pause/resume control: once a live read shows
+                        // the toggle caught up to the optimistic pending value, drop
+                        // the hint so a change made elsewhere isn't masked by it.
+                        autoSync =
+                            if (autoSync != null && it.autoSync.pendingEnabled == liveEnabled) {
+                                it.autoSync.copy(pendingEnabled = null)
+                            } else {
+                                it.autoSync
+                            },
                     )
                 }
                 trafficFetchedAt.keys.retainAll(liveIds)
@@ -275,6 +307,60 @@ class DashboardViewModel(
             is FetchResult.Failure ->
                 _state.update { it.copy(loading = false, error = result.message) }
         }
+    }
+
+    /**
+     * setAutoSync pauses or resumes auto-sync, the fleet-wide operator action. Same
+     * pessimistic-accept/optimistic-reconcile shape as the member-detail card: wait
+     * for Front Desk's 200 (its echo is the ack), show the applied value
+     * optimistically via [AutoSyncAction.pendingEnabled] until [refreshOnce]
+     * reconciles it, never blocking on physical convergence. A 403 means this
+     * device's role may not mutate (surfaced as [AutoSyncAction.forbidden]); a 401
+     * is a dead token, same revoked remedy as reads. It only ever toggles the
+     * already-configured primary — choosing or repointing one stays a web action.
+     */
+    fun setAutoSync(enabled: Boolean) {
+        // One toggle at a time: a tap while one is in flight is dropped (idempotent
+        // set, so nothing is lost) but flagged busy so the screen can nudge instead
+        // of the tap vanishing silently.
+        if (_state.value.autoSync.inProgress) {
+            _state.update { it.copy(autoSync = it.autoSync.copy(busy = true)) }
+            return
+        }
+        // The control is only shown with a primary configured; guard anyway so a
+        // stray call can't send an empty primary that Front Desk would reject.
+        val primaryId = _state.value.primaryId
+        if (primaryId.isEmpty()) return
+        viewModelScope.launch {
+            _state.update { it.copy(autoSync = it.autoSync.copy(inProgress = true, error = null, busy = false)) }
+            val token = linkStore.token()
+            if (token == null) {
+                _state.update { it.copy(revoked = true, autoSync = it.autoSync.copy(inProgress = false)) }
+                return@launch
+            }
+            val result = client.setAutoSync(fdUrl, token, enabled, primaryId)
+            _state.update { st ->
+                val cleared = st.copy(autoSync = st.autoSync.copy(inProgress = false, busy = false))
+                when (result) {
+                    is ActionResult.Success -> {
+                        // If a live read already shows the applied state (it beat our
+                        // 200), skip the optimistic hint so nothing is left for a
+                        // reconcile to strand.
+                        val applied = result.data.enabled
+                        val pending = applied.takeUnless { it == cleared.autoSyncEnabled }
+                        cleared.copy(autoSync = cleared.autoSync.copy(pendingEnabled = pending, forbidden = false))
+                    }
+                    ActionResult.Forbidden -> cleared.copy(autoSync = cleared.autoSync.copy(forbidden = true))
+                    ActionResult.Unauthorized -> cleared.copy(revoked = true)
+                    is ActionResult.Failure -> cleared.copy(autoSync = cleared.autoSync.copy(error = result.message))
+                }
+            }
+        }
+    }
+
+    /** dismissAutoSyncError clears a failed pause/resume so its notice can be tapped away. */
+    fun dismissAutoSyncError() {
+        _state.update { it.copy(autoSync = it.autoSync.copy(error = null)) }
     }
 
     class Factory(

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModel.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModel.kt
@@ -278,7 +278,12 @@ class DashboardViewModel(
                 val autoSync = client.autoSync(fdUrl, token) as? FetchResult.Success
                 val liveIds = result.data.mapTo(HashSet()) { it.id }
                 _state.update {
-                    val liveEnabled = autoSync?.data?.enabled ?: it.autoSyncEnabled
+                    val pending = it.autoSync.pendingEnabled
+                    // When the auto-sync read fails but the rest of the refresh
+                    // succeeds, fall back to the optimistic pending value (already
+                    // applied per the PUT's 200 echo) rather than the stale baseline,
+                    // so clearing the hint below doesn't revert the toggle on screen.
+                    val liveEnabled = autoSync?.data?.enabled ?: pending ?: it.autoSyncEnabled
                     it.copy(
                         loading = false,
                         members = result.data,
@@ -289,11 +294,14 @@ class DashboardViewModel(
                         traffic = it.traffic.filterKeys { id -> id in liveIds },
                         error = null,
                         revoked = false,
-                        // Reconcile the pause/resume control: once a live read shows
-                        // the toggle caught up to the optimistic pending value, drop
-                        // the hint so a change made elsewhere isn't masked by it.
+                        // Reconcile the pause/resume control: drop the optimistic hint
+                        // once it's resolved. Either a live read shows the toggle
+                        // caught up (so a change made elsewhere isn't masked by it), or
+                        // the confirming endpoint is down and we've promoted the
+                        // PUT-acked value to the baseline above instead of stranding a
+                        // perpetual "pending" against a read that keeps failing.
                         autoSync =
-                            if (autoSync != null && it.autoSync.pendingEnabled == liveEnabled) {
+                            if (pending != null && (autoSync == null || pending == liveEnabled)) {
                                 it.autoSync.copy(pendingEnabled = null)
                             } else {
                                 it.autoSync

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/work/FleetPollWorker.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/work/FleetPollWorker.kt
@@ -14,12 +14,13 @@ import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import androidx.work.workDataOf
 import com.hugalafutro.bellhop.data.FetchResult
+import com.hugalafutro.bellhop.data.FleetAlert
 import com.hugalafutro.bellhop.data.FleetSnapshot
 import com.hugalafutro.bellhop.data.FrontDeskClient
 import com.hugalafutro.bellhop.data.LinkState
 import com.hugalafutro.bellhop.data.LinkStore
-import com.hugalafutro.bellhop.data.MemberTransition
 import com.hugalafutro.bellhop.data.MonitorStore
+import com.hugalafutro.bellhop.data.diffAutoSync
 import com.hugalafutro.bellhop.data.diffFleet
 import com.hugalafutro.bellhop.notify.FleetNotifier
 import kotlinx.coroutines.flow.first
@@ -34,7 +35,7 @@ import java.util.concurrent.TimeUnit
  */
 sealed interface PollResult {
     data class Changed(
-        val transitions: List<MemberTransition>,
+        val alerts: List<FleetAlert>,
     ) : PollResult
 
     data object Unauthorized : PollResult
@@ -64,9 +65,19 @@ suspend fun pollFleet(
     return when (val result = client.members(fdUrl, token)) {
         is FetchResult.Success -> {
             val previous = monitorStore.snapshot()
-            val transitions = diffFleet(previous, result.data)
-            monitorStore.saveSnapshot(FleetSnapshot.of(result.data), epoch)
-            PollResult.Changed(transitions)
+            // Auto-sync staleness is a fleet-wide flag on a separate endpoint. A
+            // failure to read it must not lose the health poll, so fall back to the
+            // last-known value: no phantom drift edge, and the health diff/save still
+            // happens. Only read it after members succeeded, so a dead token still
+            // reports Unauthorized off the first call and never double-fetches.
+            val stale =
+                when (val autoSync = client.autoSync(fdUrl, token)) {
+                    is FetchResult.Success -> autoSync.data.stale
+                    else -> previous?.autosyncStale ?: false
+                }
+            val alerts = diffFleet(previous, result.data) + listOfNotNull(diffAutoSync(previous, stale))
+            monitorStore.saveSnapshot(FleetSnapshot.of(result.data, stale), epoch)
+            PollResult.Changed(alerts)
         }
         FetchResult.Unauthorized -> PollResult.Unauthorized
         is FetchResult.Failure -> PollResult.Failed
@@ -86,7 +97,7 @@ suspend fun runBackstop(
     linkStore: LinkStore,
     client: FrontDeskClient,
     canNotify: Boolean,
-    notify: (MemberTransition) -> Unit,
+    notify: (FleetAlert) -> Unit,
     retryOnFailure: Boolean = true,
 ): Result {
     // Neither layer active: nothing to do. A stale periodic run can outlive the
@@ -107,7 +118,7 @@ suspend fun runBackstop(
 
     return when (val result = pollFleet(client, link.fdUrl, token, monitorStore)) {
         is PollResult.Changed -> {
-            result.transitions.forEach(notify)
+            result.alerts.forEach(notify)
             Result.success()
         }
         // A revoked token can never succeed again; retrying would just hammer

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -58,6 +58,16 @@
     <string name="member_op_busy">Another action is still running. Wait for it to finish, then try again.</string>
     <string name="member_op_forbidden">This device is paired as a monitor and can\'t change the fleet. Re-pair with an operator code in Front Desk to drain, activate, or sync.</string>
 
+    <!-- Pause/resume auto-sync (dashboard operator control) -->
+    <string name="autosync_title">Auto-sync</string>
+    <string name="autosync_on">On — the primary\'s config is kept in sync across the fleet.</string>
+    <string name="autosync_off">Off — the fleet won\'t follow the primary until you resume.</string>
+    <string name="autosync_pausing">Pausing…</string>
+    <string name="autosync_resuming">Resuming…</string>
+    <string name="autosync_busy">Another action is still running. Wait for it to finish, then try again.</string>
+    <string name="autosync_error">Couldn\'t apply: %1$s</string>
+    <string name="autosync_forbidden">This device is paired as a monitor and can\'t change auto-sync. Re-pair with an operator code in Front Desk.</string>
+
     <!-- Events -->
     <string name="events_title">Events</string>
     <string name="events_open">Events</string>
@@ -152,6 +162,11 @@
     <string name="notif_down_body">A member stopped responding. Tap to open Bellhop.</string>
     <string name="notif_up_title">%1$s recovered</string>
     <string name="notif_up_body">A member is responding again.</string>
+    <string name="notif_channel_stale">Config drift</string>
+    <string name="notif_stale_title">Fleet may be drifting</string>
+    <string name="notif_stale_body">Auto-sync is off and the fleet hasn\'t synced in over a day. Tap to open Bellhop.</string>
+    <string name="notif_stale_resumed_title">Auto-sync resumed</string>
+    <string name="notif_stale_resumed_body">The fleet is being kept in sync again.</string>
 
     <string name="dashboard_unlink">Unlink</string>
     <string name="dashboard_unlink_confirm_title">Unlink this device?</string>

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/FleetSnapshotTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/FleetSnapshotTest.kt
@@ -100,4 +100,33 @@ class FleetSnapshotTest {
         val transitions = diffFleet(previous, listOf(member("m1", name = "", healthy = false)))
         assertEquals(listOf(MemberTransition.WentDown("m1", "m1")), transitions)
     }
+
+    @Test
+    fun autoSyncFirstPollHasNoBaselineSoStaysSilent() {
+        assertEquals(null, diffAutoSync(null, current = true))
+    }
+
+    @Test
+    fun autoSyncNotStaleToStaleIsWentStale() {
+        val previous = FleetSnapshot(autosyncStale = false)
+        assertEquals(AutoSyncAlert.WentStale, diffAutoSync(previous, current = true))
+    }
+
+    @Test
+    fun autoSyncStaleToNotStaleIsResumed() {
+        val previous = FleetSnapshot(autosyncStale = true)
+        assertEquals(AutoSyncAlert.Resumed, diffAutoSync(previous, current = false))
+    }
+
+    @Test
+    fun autoSyncSteadyStateProducesNoAlert() {
+        assertEquals(null, diffAutoSync(FleetSnapshot(autosyncStale = true), current = true))
+        assertEquals(null, diffAutoSync(FleetSnapshot(autosyncStale = false), current = false))
+    }
+
+    @Test
+    fun ofCarriesAutoSyncStaleIntoSnapshot() {
+        assertTrue(FleetSnapshot.of(emptyList(), autosyncStale = true).autosyncStale)
+        assertTrue(!FleetSnapshot.of(emptyList()).autosyncStale)
+    }
 }

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/FrontDeskClientTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/FrontDeskClientTest.kt
@@ -632,4 +632,66 @@ class FrontDeskClientTest {
             assertTrue(result is ActionResult.Success)
             assertTrue((result as ActionResult.Success).data.results.isEmpty())
         }
+
+    @Test
+    fun setAutoSyncPutsBodyAndParsesEcho() =
+        runBlocking {
+            // Front Desk echoes the applied config back; that 200 is the ack.
+            server.enqueue(MockResponse().setBody("""{"enabled":false,"primary_id":"m1","stale":false}"""))
+
+            val result = client.setAutoSync(server.url("/").toString(), "tok-1", enabled = false, primaryId = "m1")
+
+            assertTrue(result is ActionResult.Success)
+            assertEquals(false, (result as ActionResult.Success).data.enabled)
+
+            val request = server.takeRequest()
+            assertEquals("PUT", request.method)
+            assertEquals("/api/fleet/autosync", request.path)
+            assertEquals("Bearer tok-1", request.getHeader("Authorization"))
+            val body = request.body.readUtf8()
+            assertTrue(body.contains("\"enabled\":false"))
+            assertTrue(body.contains("\"primary_id\":\"m1\""))
+            // Toggling an unchanged primary carries no confirm token: the empty
+            // default is dropped from the body and Front Desk treats absence as "".
+            assertTrue(!body.contains("confirm_token"))
+        }
+
+    @Test
+    fun setAutoSyncMapsForbiddenToItsOwnArm() =
+        runBlocking {
+            server.enqueue(
+                MockResponse().setResponseCode(403).setBody(
+                    """{"error":{"code":"device_role_forbidden","message":"nope"}}""",
+                ),
+            )
+            val result = client.setAutoSync(server.url("/").toString(), "tok-1", enabled = true, primaryId = "m1")
+            assertEquals(ActionResult.Forbidden, result)
+        }
+
+    @Test
+    fun setAutoSyncMapsUnauthorizedToItsOwnArm() =
+        runBlocking {
+            server.enqueue(
+                MockResponse().setResponseCode(401).setBody(
+                    """{"error":{"code":"unauthorized","message":"bad token"}}""",
+                ),
+            )
+            val result = client.setAutoSync(server.url("/").toString(), "dead", enabled = true, primaryId = "m1")
+            assertEquals(ActionResult.Unauthorized, result)
+        }
+
+    @Test
+    fun setAutoSyncServerErrorIsFailure() =
+        runBlocking {
+            server.enqueue(MockResponse().setResponseCode(500).setBody("boom"))
+            val result = client.setAutoSync(server.url("/").toString(), "tok-1", enabled = true, primaryId = "m1")
+            assertTrue(result is ActionResult.Failure)
+        }
+
+    @Test
+    fun setAutoSyncMalformedUrlIsFailureNotThrow() =
+        runBlocking {
+            val result = client.setAutoSync("not a url", "tok", enabled = true, primaryId = "m1")
+            assertTrue(result is ActionResult.Failure)
+        }
 }

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/notify/FleetNotifierTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/notify/FleetNotifierTest.kt
@@ -3,8 +3,10 @@ package com.hugalafutro.bellhop.notify
 import android.Manifest
 import android.app.Application
 import android.app.NotificationManager
+import com.hugalafutro.bellhop.data.AutoSyncAlert
 import com.hugalafutro.bellhop.data.MemberTransition
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -40,5 +42,26 @@ class FleetNotifierTest {
         shadowOf(app).denyPermissions(Manifest.permission.POST_NOTIFICATIONS)
         FleetNotifier.notify(app, MemberTransition.WentDown("m1", "One"))
         assertEquals(0, shadowOf(notifications).size())
+    }
+
+    @Test
+    fun autoSyncAlertPostsOnTheStaleChannel() {
+        shadowOf(app).grantPermissions(Manifest.permission.POST_NOTIFICATIONS)
+        FleetNotifier.notify(app, AutoSyncAlert.WentStale)
+        val posted = shadowOf(notifications).size()
+        assertEquals(1, posted)
+        assertTrue(
+            shadowOf(notifications).allNotifications.any { it.channelId == FleetNotifier.CHANNEL_STALE },
+        )
+    }
+
+    @Test
+    fun autoSyncResumeReplacesTheStaleRowInPlace() {
+        shadowOf(app).grantPermissions(Manifest.permission.POST_NOTIFICATIONS)
+        // Stale then Resumed share one fixed tag, so the resume updates the row
+        // rather than stacking a second notification.
+        FleetNotifier.notify(app, AutoSyncAlert.WentStale)
+        FleetNotifier.notify(app, AutoSyncAlert.Resumed)
+        assertEquals(1, shadowOf(notifications).size())
     }
 }

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreenTest.kt
@@ -1,6 +1,7 @@
 package com.hugalafutro.bellhop.ui.dashboard
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
@@ -189,6 +190,96 @@ class DashboardScreenTest {
         }
         composeTestRule.onNodeWithTag("dashboard-error").assertIsDisplayed()
         composeTestRule.onNodeWithTag("member-card-alpha").assertIsDisplayed()
+    }
+
+    @Test
+    fun autoSyncControlShownForOperatorAndToggleFires() {
+        var requested: Boolean? = null
+        composeTestRule.setContent {
+            BellhopTheme {
+                DashboardScreen(
+                    link = link,
+                    ui = DashboardUiState(loading = false, members = allUp, primaryId = "m1", autoSyncEnabled = true),
+                    canOperate = true,
+                    onSetAutoSync = { requested = it },
+                )
+            }
+        }
+        composeTestRule.onNodeWithTag("autosync-card").assertIsDisplayed()
+        // Effective state is on; toggling asks to turn it off.
+        composeTestRule.onNodeWithTag("autosync-toggle").performClick()
+        assertTrue(requested == false)
+    }
+
+    @Test
+    fun autoSyncControlHiddenForMonitor() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                DashboardScreen(
+                    link = link,
+                    ui = DashboardUiState(loading = false, members = allUp, primaryId = "m1"),
+                    canOperate = false,
+                )
+            }
+        }
+        composeTestRule.onNodeWithTag("autosync-card").assertDoesNotExist()
+    }
+
+    @Test
+    fun autoSyncControlHiddenWithoutAPrimary() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                DashboardScreen(
+                    link = link,
+                    ui = DashboardUiState(loading = false, members = allUp, primaryId = ""),
+                    canOperate = true,
+                )
+            }
+        }
+        composeTestRule.onNodeWithTag("autosync-card").assertDoesNotExist()
+    }
+
+    @Test
+    fun autoSyncForbiddenCollapsesToNoteWithoutToggle() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                DashboardScreen(
+                    link = link,
+                    ui =
+                        DashboardUiState(
+                            loading = false,
+                            members = allUp,
+                            primaryId = "m1",
+                            autoSync = AutoSyncAction(forbidden = true),
+                        ),
+                    canOperate = true,
+                )
+            }
+        }
+        composeTestRule.onNodeWithTag("autosync-forbidden").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("autosync-toggle").assertDoesNotExist()
+    }
+
+    @Test
+    fun autoSyncPendingHintShownAndToggleDisabledWhileInFlight() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                DashboardScreen(
+                    link = link,
+                    ui =
+                        DashboardUiState(
+                            loading = false,
+                            members = allUp,
+                            primaryId = "m1",
+                            autoSyncEnabled = true,
+                            autoSync = AutoSyncAction(inProgress = true, pendingEnabled = false),
+                        ),
+                    canOperate = true,
+                )
+            }
+        }
+        composeTestRule.onNodeWithTag("autosync-pending").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("autosync-toggle").assertIsNotEnabled()
     }
 
     @Test

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModelTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.hugalafutro.bellhop.ui.dashboard
 
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import com.hugalafutro.bellhop.data.ActionResult
 import com.hugalafutro.bellhop.data.AutoSyncConfig
 import com.hugalafutro.bellhop.data.FakeCipher
 import com.hugalafutro.bellhop.data.FetchResult
@@ -73,6 +74,23 @@ private class FakeFleetClient(
         fdUrl: String,
         token: String,
     ): FetchResult<AutoSyncConfig> = autoSyncResult
+
+    // Pause/resume operator action: canned result plus captured args so a test can
+    // prove the toggle sends the unchanged primary.
+    var setAutoSyncResult: ActionResult<AutoSyncConfig> = ActionResult.Failure("no setAutoSync")
+    var lastSetAutoSyncEnabled: Boolean? = null
+    var lastSetAutoSyncPrimary: String? = null
+
+    override suspend fun setAutoSync(
+        fdUrl: String,
+        token: String,
+        enabled: Boolean,
+        primaryId: String,
+    ): ActionResult<AutoSyncConfig> {
+        lastSetAutoSyncEnabled = enabled
+        lastSetAutoSyncPrimary = primaryId
+        return setAutoSyncResult
+    }
 
     // Per-member traffic for the viewport-lazy sparkline. Records every id
     // fetched so a test can prove only the visible members were requested.
@@ -159,6 +177,93 @@ class DashboardViewModelTest {
             assertNull(s.error)
             assertFalse(s.revoked)
             assertEquals("tok-1", client.lastToken)
+        }
+
+    private fun autoSyncClient(enabled: Boolean = true) =
+        FakeFleetClient(
+            membersResult = FetchResult.Success(listOf(member)),
+            autoSyncResult = FetchResult.Success(AutoSyncConfig(enabled = enabled, primaryId = "m1")),
+        )
+
+    @Test
+    fun setAutoSyncAcceptsAndShowsPendingUntilReconciled() =
+        runBlocking {
+            val client = autoSyncClient(enabled = true)
+            client.setAutoSyncResult = ActionResult.Success(AutoSyncConfig(enabled = false, primaryId = "m1"))
+            val vm = DashboardViewModel(client, linkedStore(), "http://fd:1")
+            vm.refreshOnce()
+            assertTrue(vm.state.value.autoSyncEnabled)
+
+            vm.setAutoSync(false)
+            val pending =
+                withTimeout(5_000) { vm.state.first { !it.autoSync.inProgress && it.autoSync.pendingEnabled != null } }
+            assertEquals(false, pending.autoSync.pendingEnabled)
+            // Toggling the unchanged primary sends it back verbatim.
+            assertEquals(false, client.lastSetAutoSyncEnabled)
+            assertEquals("m1", client.lastSetAutoSyncPrimary)
+
+            // A live read reflecting the paused state reconciles the hint away.
+            client.autoSyncResult = FetchResult.Success(AutoSyncConfig(enabled = false, primaryId = "m1"))
+            vm.refreshOnce()
+            assertNull(vm.state.value.autoSync.pendingEnabled)
+            assertFalse(vm.state.value.autoSyncEnabled)
+        }
+
+    @Test
+    fun setAutoSyncForbiddenSetsFlag() =
+        runBlocking {
+            val client = autoSyncClient()
+            client.setAutoSyncResult = ActionResult.Forbidden
+            val vm = DashboardViewModel(client, linkedStore(), "http://fd:1")
+            vm.refreshOnce()
+
+            vm.setAutoSync(false)
+            val s = withTimeout(5_000) { vm.state.first { it.autoSync.forbidden } }
+            assertTrue(s.autoSync.forbidden)
+        }
+
+    @Test
+    fun setAutoSyncUnauthorizedRevokes() =
+        runBlocking {
+            val client = autoSyncClient()
+            client.setAutoSyncResult = ActionResult.Unauthorized
+            val vm = DashboardViewModel(client, linkedStore(), "http://fd:1")
+            vm.refreshOnce()
+
+            vm.setAutoSync(false)
+            val s = withTimeout(5_000) { vm.state.first { it.revoked } }
+            assertTrue(s.revoked)
+        }
+
+    @Test
+    fun setAutoSyncFailureSurfacesErrorThenDismisses() =
+        runBlocking {
+            val client = autoSyncClient()
+            client.setAutoSyncResult = ActionResult.Failure("boom")
+            val vm = DashboardViewModel(client, linkedStore(), "http://fd:1")
+            vm.refreshOnce()
+
+            vm.setAutoSync(false)
+            val s = withTimeout(5_000) { vm.state.first { it.autoSync.error != null } }
+            assertEquals("boom", s.autoSync.error)
+
+            vm.dismissAutoSyncError()
+            assertNull(vm.state.value.autoSync.error)
+        }
+
+    @Test
+    fun setAutoSyncWithoutAPrimaryIsDroppedBeforeTheClient() =
+        runBlocking {
+            val client =
+                FakeFleetClient(
+                    membersResult = FetchResult.Success(listOf(member)),
+                    autoSyncResult = FetchResult.Success(AutoSyncConfig(enabled = false, primaryId = "")),
+                )
+            val vm = DashboardViewModel(client, linkedStore(), "http://fd:1")
+            vm.refreshOnce()
+
+            vm.setAutoSync(true)
+            assertNull(client.lastSetAutoSyncEnabled)
         }
 
     @Test

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModelTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModelTest.kt
@@ -210,6 +210,27 @@ class DashboardViewModelTest {
         }
 
     @Test
+    fun setAutoSyncReadFailurePromotesPendingInsteadOfStranding() =
+        runBlocking {
+            val client = autoSyncClient(enabled = true)
+            client.setAutoSyncResult = ActionResult.Success(AutoSyncConfig(enabled = false, primaryId = "m1"))
+            val vm = DashboardViewModel(client, linkedStore(), "http://fd:1")
+            vm.refreshOnce()
+
+            vm.setAutoSync(false)
+            withTimeout(5_000) { vm.state.first { !it.autoSync.inProgress && it.autoSync.pendingEnabled != null } }
+
+            // The confirming endpoint goes dark while members still read fine. The
+            // pending hint must not linger forever: the PUT's 200 echo already
+            // applied the paused value, so it's promoted to the baseline and the
+            // hint clears rather than showing "pausing…" against a dead read.
+            client.autoSyncResult = FetchResult.Failure("autosync down")
+            vm.refreshOnce()
+            assertNull(vm.state.value.autoSync.pendingEnabled)
+            assertFalse(vm.state.value.autoSyncEnabled)
+        }
+
+    @Test
     fun setAutoSyncForbiddenSetsFlag() =
         runBlocking {
             val client = autoSyncClient()

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/work/FleetBackstopTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/work/FleetBackstopTest.kt
@@ -4,6 +4,7 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
 import androidx.work.ListenableWorker.Result
+import com.hugalafutro.bellhop.data.FleetAlert
 import com.hugalafutro.bellhop.data.FleetSnapshot
 import com.hugalafutro.bellhop.data.FrontDeskClient
 import com.hugalafutro.bellhop.data.LinkStore
@@ -41,7 +42,7 @@ class FleetBackstopTest {
 
     private lateinit var server: MockWebServer
     private val client = FrontDeskClient()
-    private val fired = mutableListOf<MemberTransition>()
+    private val fired = mutableListOf<FleetAlert>()
 
     @Before
     fun setUp() {
@@ -97,6 +98,12 @@ class FleetBackstopTest {
     private fun memberBody(healthy: Boolean): String =
         """[{"id":"m1","name":"hotel-1","state":"active",""" +
             """"status":{"health":{"known":true,"healthy":$healthy}}}]"""
+
+    // A successful poll reads members then auto-sync; enqueue both.
+    private fun enqueuePoll(healthy: Boolean) {
+        server.enqueue(MockResponse().setBody(memberBody(healthy)))
+        server.enqueue(MockResponse().setBody("""{"enabled":true,"primary_id":"m1","stale":false}"""))
+    }
 
     private suspend fun run(
         monitor: MonitorStore,
@@ -166,7 +173,7 @@ class FleetBackstopTest {
                     setEnabled(true)
                     saveSnapshot(FleetSnapshot(mapOf("m1" to MemberHealthState.UP.name)), epoch())
                 }
-            server.enqueue(MockResponse().setBody(memberBody(healthy = false)))
+            enqueuePoll(healthy = false)
 
             val result = run(monitor, linkedTo(server.url("/").toString()))
 
@@ -185,7 +192,7 @@ class FleetBackstopTest {
                     setPushEnabled(true)
                     saveSnapshot(FleetSnapshot(mapOf("m1" to MemberHealthState.UP.name)), epoch())
                 }
-            server.enqueue(MockResponse().setBody(memberBody(healthy = false)))
+            enqueuePoll(healthy = false)
 
             val result = run(monitor, linkedTo(server.url("/").toString()))
 

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/work/FleetPollTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/work/FleetPollTest.kt
@@ -3,6 +3,7 @@ package com.hugalafutro.bellhop.work
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
+import com.hugalafutro.bellhop.data.AutoSyncAlert
 import com.hugalafutro.bellhop.data.FleetSnapshot
 import com.hugalafutro.bellhop.data.FrontDeskClient
 import com.hugalafutro.bellhop.data.MemberHealthState
@@ -61,6 +62,17 @@ class FleetPollTest {
         """[{"id":"m1","name":"hotel-1","state":"active",""" +
             """"status":{"health":{"known":true,"healthy":$healthy}}}]"""
 
+    private fun autoSyncBody(stale: Boolean): String = """{"enabled":false,"primary_id":"m1","stale":$stale}"""
+
+    // A successful poll fetches members then auto-sync, so enqueue both.
+    private fun enqueuePoll(
+        healthy: Boolean,
+        stale: Boolean = false,
+    ) {
+        server.enqueue(MockResponse().setBody(memberBody(healthy)))
+        server.enqueue(MockResponse().setBody(autoSyncBody(stale)))
+    }
+
     private suspend fun poll(store: MonitorStore): PollResult =
         pollFleet(client, server.url("/").toString(), "tok-1", store)
 
@@ -69,12 +81,12 @@ class FleetPollTest {
         runBlocking {
             val store = newStore()
             store.setEnabled(true)
-            server.enqueue(MockResponse().setBody(memberBody(healthy = true)))
+            enqueuePoll(healthy = true)
 
             val result = poll(store)
 
             assertTrue(result is PollResult.Changed)
-            assertTrue((result as PollResult.Changed).transitions.isEmpty())
+            assertTrue((result as PollResult.Changed).alerts.isEmpty())
             // The baseline now exists for the next poll to diff against.
             assertEquals(MemberHealthState.UP, store.snapshot()?.stateOf("m1"))
         }
@@ -85,15 +97,53 @@ class FleetPollTest {
             val store = newStore()
             store.setEnabled(true)
             store.saveSnapshot(FleetSnapshot(mapOf("m1" to MemberHealthState.UP.name)), store.epoch())
-            server.enqueue(MockResponse().setBody(memberBody(healthy = false)))
+            enqueuePoll(healthy = false)
 
             val result = poll(store)
 
             assertEquals(
                 listOf(MemberTransition.WentDown("m1", "hotel-1")),
-                (result as PollResult.Changed).transitions,
+                (result as PollResult.Changed).alerts,
             )
             assertEquals(MemberHealthState.DOWN, store.snapshot()?.stateOf("m1"))
+        }
+
+    @Test
+    fun autoSyncGoingStaleAcrossPollsIsNotified() =
+        runBlocking {
+            val store = newStore()
+            store.setEnabled(true)
+            // Baseline is healthy and not stale; this poll reports stale.
+            store.saveSnapshot(FleetSnapshot(mapOf("m1" to MemberHealthState.UP.name)), store.epoch())
+            enqueuePoll(healthy = true, stale = true)
+
+            val result = poll(store)
+
+            assertEquals(listOf(AutoSyncAlert.WentStale), (result as PollResult.Changed).alerts)
+            assertEquals(true, store.snapshot()?.autosyncStale)
+        }
+
+    @Test
+    fun autoSyncReadFailureFallsBackWithoutLosingHealthPoll() =
+        runBlocking {
+            val store = newStore()
+            store.setEnabled(true)
+            // Prior stale flag set; the health edge must still fire and the stale
+            // value must be kept (no phantom edge) when the auto-sync read fails.
+            store.saveSnapshot(
+                FleetSnapshot(states = mapOf("m1" to MemberHealthState.UP.name), autosyncStale = true),
+                store.epoch(),
+            )
+            server.enqueue(MockResponse().setBody(memberBody(healthy = false)))
+            server.enqueue(MockResponse().setResponseCode(500).setBody("nope"))
+
+            val result = poll(store)
+
+            assertEquals(
+                listOf(MemberTransition.WentDown("m1", "hotel-1")),
+                (result as PollResult.Changed).alerts,
+            )
+            assertEquals(true, store.snapshot()?.autosyncStale)
         }
 
     @Test

--- a/internal/frontdesk/alerts.go
+++ b/internal/frontdesk/alerts.go
@@ -32,6 +32,9 @@ var fdCatalog = []alert.EventDef{
 	{Type: "config.sync_failed", Category: "Config Sync", Severity: "warning", DefaultOn: true},
 	{Type: "config.synced", Category: "Config Sync", Severity: "info", DefaultOn: false},
 	{Type: "config.auto_synced", Category: "Config Sync", Severity: "info", DefaultOn: false},
+	// Auto-sync is off and the fleet has not been synced in a day: the replicas
+	// are drifting silently, with nothing pushing the primary's config out.
+	{Type: "config.autosync_stale", Category: "Config Sync", Severity: "warning", DefaultOn: true},
 	// Version reads: a persistently failing member URL is surfaced here.
 	{Type: "version.fetch_failed", Category: "Member Reads", Severity: "warning", DefaultOn: true},
 	{Type: "version.fetch_recovered", Category: "Member Reads", Severity: "success", DefaultOn: false},

--- a/internal/frontdesk/autosync.go
+++ b/internal/frontdesk/autosync.go
@@ -57,7 +57,31 @@ const (
 	// is enabled, so a stuck member cannot leak the goroutine. Generous: a pass
 	// snapshots and imports config on every drifted member in turn.
 	autoSyncKickTimeout = 5 * time.Minute
+
+	// autoSyncStaleThreshold is how long the fleet may go unsynced, with auto-sync
+	// off, before Front Desk warns that the replicas may be drifting from the
+	// primary. A day is long enough that a brief manual-sync gap never trips it,
+	// short enough that a fleet left un-synced surfaces within the same day.
+	autoSyncStaleThreshold = 24 * time.Hour
 )
+
+// autoSyncStale reports whether the fleet's config is at risk of silent drift: a
+// primary is designated but auto-sync is off, and the last successful fleet sync
+// is older than autoSyncStaleThreshold (or never ran). It is deliberately false
+// when auto-sync is on (the loop keeps the fleet fresh and reports its own
+// failures via config.sync_failed) and when no primary is configured — the
+// operator never opted into the sync model, so "stale" would be meaningless and,
+// since auto-sync is off by default, would otherwise fire on every fresh install.
+// haveSync is false when no successful sync has ever been recorded.
+func autoSyncStale(cfg AutoSyncConfig, lastSync time.Time, haveSync bool, now time.Time) bool {
+	if cfg.Enabled || cfg.PrimaryID == "" {
+		return false
+	}
+	if !haveSync {
+		return true
+	}
+	return now.Sub(lastSync) > autoSyncStaleThreshold
+}
 
 // RunAutoSync samples the designated primary on a fixed tick and propagates its
 // config to the fleet when it changes. It blocks until ctx is cancelled and is

--- a/internal/frontdesk/autosync_test.go
+++ b/internal/frontdesk/autosync_test.go
@@ -635,6 +635,71 @@ func TestPutAutoSyncValidation(t *testing.T) {
 	}
 }
 
+// TestAutoSyncStale pins the drift rule: off + a designated primary + no (or a
+// stale) recorded sync is stale; an enabled loop, an absent primary, or a recent
+// sync is not.
+func TestAutoSyncStale(t *testing.T) {
+	now := time.Now()
+	cases := []struct {
+		name     string
+		cfg      AutoSyncConfig
+		lastSync time.Time
+		haveSync bool
+		want     bool
+	}{
+		{"enabled is never stale", AutoSyncConfig{Enabled: true, PrimaryID: "m1"}, time.Time{}, false, false},
+		{"no primary is never stale", AutoSyncConfig{Enabled: false, PrimaryID: ""}, time.Time{}, false, false},
+		{"off, primary, never synced", AutoSyncConfig{Enabled: false, PrimaryID: "m1"}, time.Time{}, false, true},
+		{"off, primary, synced recently", AutoSyncConfig{Enabled: false, PrimaryID: "m1"}, now.Add(-time.Hour), true, false},
+		{"off, primary, synced long ago", AutoSyncConfig{Enabled: false, PrimaryID: "m1"}, now.Add(-25 * time.Hour), true, true},
+		{"off, primary, exactly at threshold", AutoSyncConfig{Enabled: false, PrimaryID: "m1"}, now.Add(-24 * time.Hour), true, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := autoSyncStale(tc.cfg, tc.lastSync, tc.haveSync, now); got != tc.want {
+				t.Errorf("autoSyncStale = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestGetAutoSyncReportsStale: the read endpoint folds in the computed staleness
+// so a device that only polls it (Bellhop's background monitor) can raise its own
+// notification.
+func TestGetAutoSyncReportsStale(t *testing.T) {
+	srv, store := newTestServer(t)
+	pm, _ := store.CreateMember(t.Context(), "primary", "http://127.0.0.1:9", "tok")
+
+	read := func() autoSyncStatus {
+		t.Helper()
+		rec := do(t, srv, http.MethodGet, "/api/fleet/autosync", "", true)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("get autosync = %d (%s)", rec.Code, rec.Body.String())
+		}
+		var got autoSyncStatus
+		if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		return got
+	}
+
+	// Off with a designated primary and no sync ever recorded: stale.
+	if err := store.SetAutoSync(t.Context(), false, pm.ID); err != nil {
+		t.Fatalf("SetAutoSync: %v", err)
+	}
+	if got := read(); !got.Stale || got.Enabled || got.PrimaryID != pm.ID {
+		t.Errorf("disabled+never-synced = %+v, want stale", got)
+	}
+
+	// Enabling clears it.
+	if err := store.SetAutoSync(t.Context(), true, pm.ID); err != nil {
+		t.Fatalf("SetAutoSync: %v", err)
+	}
+	if got := read(); got.Stale || !got.Enabled {
+		t.Errorf("enabled = %+v, want not stale", got)
+	}
+}
+
 // TestDeleteMemberClearsPrimary: removing the designated primary clears the
 // pointer so the auto-sync loop stops treating a gone member as the source.
 func TestDeleteMemberClearsPrimary(t *testing.T) {

--- a/internal/frontdesk/migrations/015_autosync_stale_alert.sql
+++ b/internal/frontdesk/migrations/015_autosync_stale_alert.sql
@@ -1,0 +1,15 @@
+-- Add the new default-on alert event config.autosync_stale to the picker seed.
+-- Migration 007 seeded alert_events with the original four default-on events, so
+-- a fresh install runs this right after and lands on the full current default
+-- set. On an existing install this only rewrites the CSV when it still equals the
+-- exact 007 seed, i.e. the operator never touched the picker: a customized
+-- selection (including a deliberately empty one) is left untouched, so this never
+-- clobbers an operator's choices to force the new event on.
+--
+-- Keep the target list in step with the DefaultOn entries in alerts.go
+-- (fdCatalog); TestMigrationSeedMatchesCatalogDefaults guards a fresh install's
+-- seed against the catalog.
+UPDATE settings
+SET alert_events = 'health.down,health.up,config.sync_failed,config.autosync_stale,version.fetch_failed'
+WHERE id = 1
+  AND alert_events = 'health.down,health.up,config.sync_failed,version.fetch_failed';

--- a/internal/frontdesk/poller.go
+++ b/internal/frontdesk/poller.go
@@ -81,14 +81,15 @@ type Poller struct {
 	// then accepts our announces unconditionally, preserving old behaviour).
 	frontdeskID string
 
-	mu               sync.RWMutex
-	statuses         map[string]MemberStatus // keyed by member ID
-	lastConfigPollAt time.Time
-	staleNotified    bool
-	versionFailures  map[string]int  // consecutive version-fetch failures, keyed by member ID
-	healthFailures   map[string]int  // consecutive failed health polls, keyed by member ID
-	traefikNonUp     map[string]int  // consecutive non-UP Traefik observations, keyed by member ID
-	conflictNotified map[string]bool // members that rejected our announce (409), keyed by member ID
+	mu                    sync.RWMutex
+	statuses              map[string]MemberStatus // keyed by member ID
+	lastConfigPollAt      time.Time
+	staleNotified         bool
+	autoSyncStaleNotified bool
+	versionFailures       map[string]int  // consecutive version-fetch failures, keyed by member ID
+	healthFailures        map[string]int  // consecutive failed health polls, keyed by member ID
+	traefikNonUp          map[string]int  // consecutive non-UP Traefik observations, keyed by member ID
+	conflictNotified      map[string]bool // members that rejected our announce (409), keyed by member ID
 }
 
 // NewPoller builds a Poller. traefikAPI is the base URL of the Traefik API
@@ -188,6 +189,7 @@ func (p *Poller) Run(ctx context.Context) {
 		{func(s Settings) time.Duration { return secs(s.TraefikPollSecs, 5) }, p.PollTraefikOnce},
 		{func(s Settings) time.Duration { return secs(s.HealthPollSecs, 5) }, p.PollVersionsOnce},
 		{func(s Settings) time.Duration { return secs(s.TraefikPollSecs, 5) }, p.checkConfigStaleness},
+		{func(s Settings) time.Duration { return secs(s.TraefikPollSecs, 5) }, p.checkAutoSyncStale},
 		{func(s Settings) time.Duration { return secs(s.HealthPollSecs, 5) }, p.PollAnnounceOnce},
 	}
 	for _, l := range loops {
@@ -667,6 +669,42 @@ func (p *Poller) checkConfigStaleness(ctx context.Context) {
 		p.recordEvent(ctx, Event{
 			Type: "traefik.stale", Severity: "warning", Source: "frontdesk-poller",
 			Message: fmt.Sprintf("Traefik has not fetched the config for over %s", threshold),
+		})
+	}
+}
+
+// checkAutoSyncStale emits a single warning when auto-sync is off and the fleet
+// has not been synced within autoSyncStaleThreshold (see autoSyncStale for the
+// exact rule). Like checkConfigStaleness it de-dups on an in-memory flag so it
+// fires once per stale episode, not every tick; the flag disarms silently when
+// the condition clears (auto-sync re-enabled, or a fresh sync recorded), so a
+// later stale episode alerts again. On a restart the flag resets, so a fleet that
+// is already stale re-alerts once — the same best-effort trade-off as the health
+// and Traefik-staleness checks.
+func (p *Poller) checkAutoSyncStale(ctx context.Context) {
+	cfg, err := p.store.GetAutoSync(ctx)
+	if err != nil {
+		debuglog.Warn("frontdesk: auto-sync staleness: read config", "error", err)
+		return
+	}
+	state, found, err := p.store.GetFleetSyncState(ctx)
+	if err != nil {
+		debuglog.Warn("frontdesk: auto-sync staleness: read fleet sync state", "error", err)
+		return
+	}
+	stale := autoSyncStale(cfg, state.LastRunAt, found, p.now())
+
+	p.mu.Lock()
+	notified := p.autoSyncStaleNotified
+	if stale != notified {
+		p.autoSyncStaleNotified = stale
+	}
+	p.mu.Unlock()
+
+	if stale && !notified {
+		p.recordEvent(ctx, Event{
+			Type: "config.autosync_stale", Severity: "warning", Source: "frontdesk-poller",
+			Message: "Auto-sync is off and the fleet has not been synced in over a day; replicas may be drifting from the primary",
 		})
 	}
 }

--- a/internal/frontdesk/poller_test.go
+++ b/internal/frontdesk/poller_test.go
@@ -371,3 +371,50 @@ func TestConfigStalenessWatchdog(t *testing.T) {
 		t.Errorf("after re-arm should warn again: %+v", ev)
 	}
 }
+
+func TestAutoSyncStalenessWatchdog(t *testing.T) {
+	p, store, bus := newTestPoller(t, "")
+	ctx := context.Background()
+
+	ch := bus.Subscribe()
+	defer bus.Unsubscribe(ch)
+
+	// Off with a designated primary and no sync ever recorded: one warning.
+	if err := store.SetAutoSync(ctx, false, "m1"); err != nil {
+		t.Fatal(err)
+	}
+	p.checkAutoSyncStale(ctx)
+	ev := <-ch
+	if ev.Type != "config.autosync_stale" || ev.Severity != "warning" {
+		t.Fatalf("stale event: %+v", ev)
+	}
+
+	// Still stale: no duplicate warning.
+	p.checkAutoSyncStale(ctx)
+	select {
+	case ev := <-ch:
+		t.Errorf("should not warn twice, got %+v", ev)
+	default:
+	}
+
+	// Enabling auto-sync clears the condition and disarms silently.
+	if err := store.SetAutoSync(ctx, true, "m1"); err != nil {
+		t.Fatal(err)
+	}
+	p.checkAutoSyncStale(ctx)
+	select {
+	case ev := <-ch:
+		t.Errorf("enabling should not emit, got %+v", ev)
+	default:
+	}
+
+	// Disabling again re-arms and re-alerts on the next stale episode.
+	if err := store.SetAutoSync(ctx, false, "m1"); err != nil {
+		t.Fatal(err)
+	}
+	p.checkAutoSyncStale(ctx)
+	ev = <-ch
+	if ev.Type != "config.autosync_stale" {
+		t.Errorf("after re-arm should warn again: %+v", ev)
+	}
+}

--- a/internal/frontdesk/server_settings.go
+++ b/internal/frontdesk/server_settings.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/hugalafutro/model-hotel/internal/auth"
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
@@ -123,13 +124,42 @@ func (s *Server) resolveAlertTarget(ctx context.Context, submitted string) (stri
 
 // getAutoSync returns the automatic config-propagation setup (enabled + the
 // designated primary). The internal drift hash is never included.
+// autoSyncStatus is the GET/PUT /api/fleet/autosync body: the stored config plus
+// a computed Stale flag. Stale is the same drift signal the poller alerts on
+// (see autoSyncStale), surfaced here so a device that only polls this endpoint
+// (Bellhop's background monitor) can raise its own notification without consuming
+// the event stream. Embeds AutoSyncConfig so the wire shape stays a superset of
+// the old one (enabled, primary_id, then stale).
+type autoSyncStatus struct {
+	AutoSyncConfig
+	Stale bool `json:"stale"`
+}
+
+// autoSyncStatusNow reads the auto-sync config and last-sync marker and folds in
+// the computed staleness, so getAutoSync and putAutoSync return an identical
+// shape.
+func (s *Server) autoSyncStatusNow(ctx context.Context) (autoSyncStatus, error) {
+	cfg, err := s.store.GetAutoSync(ctx)
+	if err != nil {
+		return autoSyncStatus{}, err
+	}
+	state, found, err := s.store.GetFleetSyncState(ctx)
+	if err != nil {
+		return autoSyncStatus{}, err
+	}
+	return autoSyncStatus{
+		AutoSyncConfig: cfg,
+		Stale:          autoSyncStale(cfg, state.LastRunAt, found, time.Now().UTC()),
+	}, nil
+}
+
 func (s *Server) getAutoSync(w http.ResponseWriter, r *http.Request) {
-	cfg, err := s.store.GetAutoSync(r.Context())
+	status, err := s.autoSyncStatusNow(r.Context())
 	if err != nil {
 		writeError(w, err)
 		return
 	}
-	writeJSON(w, http.StatusOK, cfg)
+	writeJSON(w, http.StatusOK, status)
 }
 
 // putAutoSync sets the auto-sync toggle and designated primary. Enabling without
@@ -288,7 +318,7 @@ func (s *Server) putAutoSync(w http.ResponseWriter, r *http.Request) {
 		Type: "settings.changed", Severity: "info", Source: "frontdesk",
 		Message: fmt.Sprintf("Auto-sync %s", enabledWord(req.Enabled)),
 	})
-	cfg, err := s.store.GetAutoSync(r.Context())
+	status, err := s.autoSyncStatusNow(r.Context())
 	if err != nil {
 		writeError(w, err)
 		return
@@ -299,7 +329,7 @@ func (s *Server) putAutoSync(w http.ResponseWriter, r *http.Request) {
 	// context (which ends when we respond) but time-bounded so a stuck pass cannot
 	// leak the goroutine. A no-op when nothing has drifted; the loop still owns the
 	// steady-state watch. Disabling (or no primary) never kicks.
-	if cfg.Enabled && cfg.PrimaryID != "" {
+	if status.Enabled && status.PrimaryID != "" {
 		kickCtx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), autoSyncKickTimeout)
 		s.bgWG.Add(1)
 		go func() {
@@ -308,7 +338,7 @@ func (s *Server) putAutoSync(w http.ResponseWriter, r *http.Request) {
 			s.forceAutoSyncNow(kickCtx)
 		}()
 	}
-	writeJSON(w, http.StatusOK, cfg)
+	writeJSON(w, http.StatusOK, status)
 }
 
 func enabledWord(b bool) string {


### PR DESCRIPTION
## Phase A4b — pause/unpause auto-sync + stale-sync alert

Implements plans/android-companion-app.md §"Phase A4b". One combined branch (FD + BH) because the BH `stale` field and `setAutoSync` mirror the FD change and are atomic. Set-primary stays FD/web-only per the 2026-07-13 plan revision — no primary choose/change/clear/repoint capability on the phone (the backend auth split already enforces it, so zero BH work).

### Front Desk (Go, `internal/frontdesk/`)
- **`alerts.go`**: new catalog entry `config.autosync_stale` (Category "Config Sync", Severity "warning", DefaultOn), placed right after `config.auto_synced` so the fresh-seed CSV order matches `DefaultEnabledCSVFor`.
- **`migrations/015_autosync_stale_alert.sql`**: guarded UPDATE that rewrites the `alert_events` seed to the new default CSV **only** when it still equals the exact 007 seed — seeds fresh installs and opts-in default installs without clobbering a customized picker.
- **`autosync.go`**: pure `autoSyncStale(cfg, lastSync, haveSync, now)` + `autoSyncStaleThreshold = 24h`. Stale = auto-sync OFF **and** a primary is configured **and** (never synced OR last sync >24h). The `primaryID != ""` guard is required: auto-sync defaults OFF, so without it every fresh install would fire immediately.
- **`poller.go`**: `checkAutoSyncStale` on the Traefik poll cadence with in-memory de-dup mirroring `checkConfigStaleness` (emit only on the OFF→stale edge, reset on restart).
- **`server_settings.go`**: `getAutoSync`/`putAutoSync` now return the `{enabled, primary_id, stale}` superset.

### Bellhop (Kotlin, `android/`)
- **`data/`**: `AutoSyncConfig.stale`, `AutoSyncRequest`, `FrontDeskClient.setAutoSync` (PUT, operator tier), `FleetSnapshot.autosyncStale`, sealed `FleetAlert` (MemberTransition + `AutoSyncAlert.WentStale/Resumed`), pure `diffAutoSync` (silent on first poll).
- **`notify/FleetNotifier.kt`**: new `CHANNEL_STALE` (default importance) + one fixed `AUTOSYNC_TAG` so resume replaces the stale row in place.
- **`work/FleetPollWorker.kt`**: polls `/api/members` then `/api/fleet/autosync`; autosync-read failure falls back to the previous snapshot value (no phantom edge).
- **`ui/dashboard/`**: `AutoSyncControl` toggle, shown only when `canOperate && primaryId.isNotEmpty()`, pessimistic-accept/optimistic-reconcile, 403 collapses to a role note. Wired through the A4 biometric operator gate in `MainActivity`.

### Verification
- FD: `go test ./internal/frontdesk/` (214+ pass) + `golangci-lint run ./...` clean.
- BH: `:app:ktlintCheck :app:testDebugUnitTest :app:lintDebug :app:assembleDebug` (JDK21) all green.
- FD e2e live-verified on a locally-built binary: getAutoSync JSON shape, migration 015 seed, stale true/false transitions, and the poller emitting exactly one `config.autosync_stale` across ticks (de-dup proven).

Live emulator↔prod e2e pending the FD redeploy (prod runs the old binary without the `stale` field).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
