### PR TITLE
fix(bellhop): legible off-state colours for the auto-sync toggle

### DIFF
--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -324,6 +325,15 @@ private fun AutoSyncControl(
                         checked = effective,
                         onCheckedChange = onSetAutoSync,
                         enabled = !action.inProgress,
+                        // Same off-state colours as the Settings toggles so a paused
+                        // (unchecked) switch stays legible instead of a grey blob that
+                        // blends into the card.
+                        colors =
+                            SwitchDefaults.colors(
+                                uncheckedThumbColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                                uncheckedTrackColor = MaterialTheme.colorScheme.surface,
+                                uncheckedBorderColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                            ),
                         modifier = Modifier.testTag("autosync-toggle"),
                     )
                 }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
@@ -327,12 +327,20 @@ private fun AutoSyncControl(
                         enabled = !action.inProgress,
                         // Same off-state colours as the Settings toggles so a paused
                         // (unchecked) switch stays legible instead of a grey blob that
-                        // blends into the card.
+                        // blends into the card. The disabled-unchecked trio mirrors it
+                        // (dimmed) because the switch is disabled while a pause/resume
+                        // is in flight, and Material's default disabled-unchecked grey
+                        // would otherwise reintroduce the very blend this fixes.
                         colors =
                             SwitchDefaults.colors(
                                 uncheckedThumbColor = MaterialTheme.colorScheme.onSurfaceVariant,
                                 uncheckedTrackColor = MaterialTheme.colorScheme.surface,
                                 uncheckedBorderColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                                disabledUncheckedThumbColor =
+                                    MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                                disabledUncheckedTrackColor = MaterialTheme.colorScheme.surface,
+                                disabledUncheckedBorderColor =
+                                    MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
                             ),
                         modifier = Modifier.testTag("autosync-toggle"),
                     )


### PR DESCRIPTION
## What

The Phase A4b pause/resume auto-sync `Switch` (`DashboardScreen.AutoSyncControl`) used Material 3's default `SwitchColors`, so an **unchecked (paused)** toggle rendered as a grey blob that blended into the dark card and was hard to read.

This applies the same off-state colours the Settings toggles already use:

```
uncheckedThumbColor  = onSurfaceVariant
uncheckedTrackColor  = surface
uncheckedBorderColor = onSurfaceVariant
```

so a paused switch stays legible and visually consistent with the rest of the app.

## Verification

- `:app:ktlintCheck :app:testDebugUnitTest :app:lintDebug :app:assembleDebug` — all green (JDK 21).
- Reinstalled on the emulator and pixel-checked the toggle row: off-state thumb/border now renders light (`onSurfaceVariant`) against the dark card instead of a grey blob; on-state keeps the copper accent.
- Confirmed during the live emulator↔prod e2e of the A4b pause/unpause flow (both flips verified against real Front Desk, app reconciled both ways).

🤖 Generated with [Claude Code](https://claude.com/claude-code)