### PR TITLE
test(bellhop): fix flaky ViewModel revoked-path tests (in-memory DataStore)

### DIFF
--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/InMemoryPreferencesDataStore.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/InMemoryPreferencesDataStore.kt
@@ -1,0 +1,38 @@
+package com.hugalafutro.bellhop.data
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.emptyPreferences
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * In-memory [DataStore] of [Preferences] for unit tests: no disk file and no
+ * Dispatchers.IO hop, so a read replays the current value synchronously.
+ *
+ * The file-backed store from PreferenceDataStoreFactory put a real IO read on
+ * Dispatchers.IO into the token path ([LinkStore.token]); the ViewModel tests
+ * drive that path under Dispatchers.setMain(Unconfined) + runBlocking and wait
+ * on the result with a wall-clock withTimeout, so under CI load that IO hop
+ * could occasionally starve past the bound and fail an otherwise-correct test.
+ * Backing reads with a StateFlow removes the timing entirely.
+ */
+class InMemoryPreferencesDataStore(
+    initial: Preferences = emptyPreferences(),
+) : DataStore<Preferences> {
+    private val state = MutableStateFlow(initial)
+    private val writeLock = Mutex()
+
+    override val data: Flow<Preferences> = state
+
+    override suspend fun updateData(transform: suspend (t: Preferences) -> Preferences): Preferences =
+        // Serialize writers like the real store does, so a read-modify-write can't
+        // interleave and lose an update.
+        writeLock.withLock {
+            val updated = transform(state.value).toPreferences()
+            state.value = updated
+            updated
+        }
+}

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/alerts/AlertsViewModelTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/alerts/AlertsViewModelTest.kt
@@ -1,16 +1,14 @@
 package com.hugalafutro.bellhop.ui.alerts
 
-import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import com.hugalafutro.bellhop.data.AlertEventDef
 import com.hugalafutro.bellhop.data.AlertStatus
 import com.hugalafutro.bellhop.data.FakeCipher
 import com.hugalafutro.bellhop.data.FetchResult
 import com.hugalafutro.bellhop.data.FrontDeskClient
+import com.hugalafutro.bellhop.data.InMemoryPreferencesDataStore
 import com.hugalafutro.bellhop.data.LinkStore
 import com.hugalafutro.bellhop.data.PairedDevice
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
@@ -25,7 +23,6 @@ import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import java.io.File
 import java.util.concurrent.atomic.AtomicInteger
 
 // FakeAlertsClient stubs the two reads the alerts ViewModel makes; each result
@@ -77,14 +74,10 @@ class AlertsViewModelTest {
         Dispatchers.resetMain()
     }
 
-    private fun newLinkStore(): LinkStore {
-        val scope = CoroutineScope(Dispatchers.IO + Job())
-        val ds =
-            PreferenceDataStoreFactory.create(scope = scope) {
-                File(tmp.newFolder(), "link.preferences_pb")
-            }
-        return LinkStore(ds, FakeCipher)
-    }
+    // An in-memory DataStore (no disk, no Dispatchers.IO hop) keeps the token
+    // read synchronous, so these Unconfined + runBlocking + withTimeout tests
+    // can't flake on IO latency starving past the wall-clock bound.
+    private fun newLinkStore(): LinkStore = LinkStore(InMemoryPreferencesDataStore(), FakeCipher)
 
     private fun linkedStore(): LinkStore =
         newLinkStore().also {

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModelTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModelTest.kt
@@ -1,6 +1,5 @@
 package com.hugalafutro.bellhop.ui.dashboard
 
-import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import com.hugalafutro.bellhop.data.ActionResult
 import com.hugalafutro.bellhop.data.AutoSyncConfig
 import com.hugalafutro.bellhop.data.FakeCipher
@@ -9,14 +8,13 @@ import com.hugalafutro.bellhop.data.FleetEvent
 import com.hugalafutro.bellhop.data.FleetMember
 import com.hugalafutro.bellhop.data.FrontDeskClient
 import com.hugalafutro.bellhop.data.HealthStatus
+import com.hugalafutro.bellhop.data.InMemoryPreferencesDataStore
 import com.hugalafutro.bellhop.data.LinkStore
 import com.hugalafutro.bellhop.data.MemberStatus
 import com.hugalafutro.bellhop.data.MemberTraffic
 import com.hugalafutro.bellhop.data.PairedDevice
 import com.hugalafutro.bellhop.data.SseMessage
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -40,7 +38,6 @@ import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import java.io.File
 import java.util.concurrent.atomic.AtomicInteger
 
 /** FakeFleetClient serves canned read-tier results without touching the network. */
@@ -131,14 +128,10 @@ class DashboardViewModelTest {
         Dispatchers.resetMain()
     }
 
-    private fun newLinkStore(): LinkStore {
-        val scope = CoroutineScope(Dispatchers.IO + Job())
-        val ds =
-            PreferenceDataStoreFactory.create(scope = scope) {
-                File(tmp.newFolder(), "link.preferences_pb")
-            }
-        return LinkStore(ds, FakeCipher)
-    }
+    // An in-memory DataStore (no disk, no Dispatchers.IO hop) keeps the token
+    // read synchronous, so these Unconfined + runBlocking + withTimeout tests
+    // can't flake on IO latency starving past the wall-clock bound.
+    private fun newLinkStore(): LinkStore = LinkStore(InMemoryPreferencesDataStore(), FakeCipher)
 
     private suspend fun linkedStore(): LinkStore =
         newLinkStore().also {

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/events/EventsViewModelTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/events/EventsViewModelTest.kt
@@ -1,19 +1,17 @@
 package com.hugalafutro.bellhop.ui.events
 
-import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import com.hugalafutro.bellhop.data.EventQuery
 import com.hugalafutro.bellhop.data.EventsResponse
 import com.hugalafutro.bellhop.data.FakeCipher
 import com.hugalafutro.bellhop.data.FdEvent
 import com.hugalafutro.bellhop.data.FetchResult
 import com.hugalafutro.bellhop.data.FrontDeskClient
+import com.hugalafutro.bellhop.data.InMemoryPreferencesDataStore
 import com.hugalafutro.bellhop.data.LinkStore
 import com.hugalafutro.bellhop.data.PairedDevice
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -32,7 +30,6 @@ import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import java.io.File
 import java.time.Instant
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -95,14 +92,10 @@ class EventsViewModelTest {
         Dispatchers.resetMain()
     }
 
-    private fun newLinkStore(): LinkStore {
-        val scope = CoroutineScope(Dispatchers.IO + Job())
-        val ds =
-            PreferenceDataStoreFactory.create(scope = scope) {
-                File(tmp.newFolder(), "link.preferences_pb")
-            }
-        return LinkStore(ds, FakeCipher)
-    }
+    // An in-memory DataStore (no disk, no Dispatchers.IO hop) keeps the token
+    // read synchronous, so these Unconfined + runBlocking + withTimeout tests
+    // can't flake on IO latency starving past the wall-clock bound.
+    private fun newLinkStore(): LinkStore = LinkStore(InMemoryPreferencesDataStore(), FakeCipher)
 
     private fun linkedStore(): LinkStore =
         newLinkStore().also {

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailViewModelTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailViewModelTest.kt
@@ -1,6 +1,5 @@
 package com.hugalafutro.bellhop.ui.member
 
-import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import com.hugalafutro.bellhop.data.ActionResult
 import com.hugalafutro.bellhop.data.EventQuery
 import com.hugalafutro.bellhop.data.EventsResponse
@@ -9,6 +8,7 @@ import com.hugalafutro.bellhop.data.FdEvent
 import com.hugalafutro.bellhop.data.FetchResult
 import com.hugalafutro.bellhop.data.FleetMember
 import com.hugalafutro.bellhop.data.FrontDeskClient
+import com.hugalafutro.bellhop.data.InMemoryPreferencesDataStore
 import com.hugalafutro.bellhop.data.LinkStore
 import com.hugalafutro.bellhop.data.MemberTraffic
 import com.hugalafutro.bellhop.data.PairedDevice
@@ -16,9 +16,7 @@ import com.hugalafutro.bellhop.data.SyncResponse
 import com.hugalafutro.bellhop.data.SyncResultItem
 import com.hugalafutro.bellhop.data.TrafficPoint
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -37,7 +35,6 @@ import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import java.io.File
 import java.util.concurrent.atomic.AtomicInteger
 
 // FakeTrafficClient stubs the two reads the detail ViewModel makes (traffic +
@@ -126,14 +123,10 @@ class MemberDetailViewModelTest {
         Dispatchers.resetMain()
     }
 
-    private fun newLinkStore(): LinkStore {
-        val scope = CoroutineScope(Dispatchers.IO + Job())
-        val ds =
-            PreferenceDataStoreFactory.create(scope = scope) {
-                File(tmp.newFolder(), "link.preferences_pb")
-            }
-        return LinkStore(ds, FakeCipher)
-    }
+    // An in-memory DataStore (no disk, no Dispatchers.IO hop) keeps the token
+    // read synchronous, so these Unconfined + runBlocking + withTimeout tests
+    // can't flake on IO latency starving past the wall-clock bound.
+    private fun newLinkStore(): LinkStore = LinkStore(InMemoryPreferencesDataStore(), FakeCipher)
 
     private suspend fun linkedStore(): LinkStore =
         newLinkStore().also {


### PR DESCRIPTION
## Problem

The Bellhop ViewModel unit tests (`Dashboard`/`MemberDetail`/`Events`/`Alerts`) intermittently fail CI with `kotlinx.coroutines.TimeoutCancellationException` — e.g. `setMemberStateUnauthorizedFlagsRevoked`, `sseUnauthorizedFlagsRevoked`. It started landing on **master** after recent merges.

## Root cause

Those tests run under `Dispatchers.setMain(Dispatchers.Unconfined)` + plain `runBlocking`, trigger an action, then wait for the resulting state with a **wall-clock** `withTimeout(5_000/30_000) { vm.state.first { it.revoked } }`.

Their `newLinkStore()` builds a **real file-backed** `LinkStore` via `PreferenceDataStoreFactory.create(scope = CoroutineScope(Dispatchers.IO + Job()))`, so `LinkStore.token()` performs a genuine `Dispatchers.IO` disk read in the revoked path. Under CI load that IO hop can occasionally starve past the timeout and fail an otherwise-correct test. Bumping the bound is a band-aid — one was already 5s→30s and 30s still flaked.

## Fix

- Add `InMemoryPreferencesDataStore` — a `DataStore<Preferences>` backed by a `MutableStateFlow` (no disk, no IO hop; writers serialized via a `Mutex`).
- Point the four ViewModel tests' `newLinkStore()` at it, so the token read resolves synchronously and the waits can't race real IO.

Test-only; production code untouched. The `work/` worker tests (`FleetPollTest`/`FleetBackstopTest`) keep the real file-backed store — they `runBlocking { worker.doWork() }` and await inline (no `withTimeout` race), and legitimately exercise persistence.

## Validation

Reproduced the flake locally by looping the offending tests with `./gradlew :app:testDebugUnitTest --rerun --tests "<fqcn>.<method>" -q`:

- **Before:** 1/15 failed.
- **After:** 0/50 across two stress batches; all four full VM test classes pass; ktlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)