### PR TITLE
feat(bellhop): de-pill member detail, event range filters, infinite scroll, honest fleet sync

### DIFF
--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
@@ -577,6 +577,7 @@ private fun LinkedContent(
             memberNames = ui.members.associate { it.id to it.name },
             onSeverity = eventsVm::setSeverity,
             onRange = eventsVm::setRange,
+            onCustomRange = eventsVm::setCustomRange,
             onLoadMore = eventsVm::loadMore,
         )
     } else if (showAlerts) {
@@ -638,6 +639,9 @@ private fun LinkedContent(
             onSyncFleet = { requireOperatorAuth { detailVm.syncFleet(ui.primaryId) } },
             onReconcile = { liveState -> detailVm.reconcile(liveState) },
             onDismissActionError = { detailVm.dismissActionError() },
+            onRange = detailVm::setRange,
+            onCustomRange = detailVm::setCustomRange,
+            onLoadMoreEvents = detailVm::loadMore,
         )
     } else {
         DashboardScreen(

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/FleetModels.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/FleetModels.kt
@@ -68,6 +68,10 @@ data class AutoSyncConfig(
     val enabled: Boolean = false,
     @SerialName("primary_id") val primaryId: String = "",
     val stale: Boolean = false,
+    // When a sync (manual or automatic) last actually wrote config to any
+    // member; empty until one has. Member detail shows it under the fleet-sync
+    // action so the operator sees when the fleet truly last synced.
+    @SerialName("last_sync_at") val lastSyncAt: String = "",
 )
 
 /**
@@ -150,6 +154,9 @@ data class EventQuery(
     val severity: String = "",
     // RFC3339; empty = no lower bound.
     val since: String = "",
+    // RFC3339; empty = no upper bound. With [since] this carries the calendar
+    // date-range filter.
+    val until: String = "",
     val limit: Int = 0,
     val offset: Int = 0,
 )

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/FrontDeskClient.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/FrontDeskClient.kt
@@ -114,6 +114,16 @@ open class FrontDeskClient(
         )
     }
 
+    // Front Desk runs the whole fleet sync (export, per-member dry-run, backup,
+    // import with member-side model discovery) before answering POST
+    // /api/config/sync, which routinely outlives OkHttp's default 10s read
+    // timeout. A premature client hang-up used to abort the run mid-flight
+    // server-side, so syncFleet gets its own patient client. Derived from the
+    // injected client so it inherits any test/prod wiring.
+    private val slowSyncHttp: OkHttpClient by lazy {
+        http.newBuilder().readTimeout(SYNC_READ_TIMEOUT_SECONDS, TimeUnit.SECONDS).build()
+    }
+
     /**
      * pair exchanges a one-time code for a device token at
      * POST {fdUrl}/api/pair. On success the token is returned exactly once.
@@ -255,7 +265,7 @@ open class FrontDeskClient(
         fdUrl: String,
         token: String,
         primaryId: String,
-    ): ActionResult<SyncResponse> = post(fdUrl, "/api/config/sync", token, ConfigSyncRequest(primaryId))
+    ): ActionResult<SyncResponse> = post(fdUrl, "/api/config/sync", token, ConfigSyncRequest(primaryId), slowSyncHttp)
 
     /**
      * setAutoSync pauses or resumes auto-sync via PUT /api/fleet/autosync.
@@ -380,7 +390,8 @@ open class FrontDeskClient(
         path: String,
         token: String,
         body: B,
-    ): ActionResult<T> = mutate(fdUrl, path, token, body, "POST")
+        client: OkHttpClient = http,
+    ): ActionResult<T> = mutate(fdUrl, path, token, body, "POST", client)
 
     private suspend inline fun <reified B, reified T> put(
         fdUrl: String,
@@ -399,6 +410,7 @@ open class FrontDeskClient(
         token: String,
         body: B,
         method: String,
+        client: OkHttpClient = http,
     ): ActionResult<T> =
         withContext(Dispatchers.IO) {
             runCatching {
@@ -410,7 +422,7 @@ open class FrontDeskClient(
                         .header("Authorization", "Bearer $token")
                         .method(method, requestBody)
                         .build()
-                http.newCall(request).execute().use { resp ->
+                client.newCall(request).execute().use { resp ->
                     val text = resp.body?.string().orEmpty()
                     when {
                         resp.isSuccessful -> ActionResult.Success(json.decodeFromString<T>(text))
@@ -443,6 +455,13 @@ open class FrontDeskClient(
         // times out but a half-open socket is detected within a heartbeat or two.
         private const val SSE_READ_TIMEOUT_SECONDS = 60L
 
+        // Generous ceiling for the synchronous fleet sync: per-member imports
+        // run model discovery and Front Desk answers only after every member is
+        // done, so this must comfortably cover a few slow members. Front Desk
+        // also detaches the run from the connection, so even tripping this
+        // no longer aborts the sync — it only stops the phone waiting.
+        private const val SYNC_READ_TIMEOUT_SECONDS = 180L
+
         // eventQueryString renders an EventQuery as an encoded query string
         // ("" when every field is unset). Internal so the omission and encoding
         // rules can be unit-tested without a server round-trip.
@@ -453,6 +472,7 @@ open class FrontDeskClient(
                     if (q.type.isNotEmpty()) add("type" to q.type)
                     if (q.severity.isNotEmpty()) add("severity" to q.severity)
                     if (q.since.isNotEmpty()) add("since" to q.since)
+                    if (q.until.isNotEmpty()) add("until" to q.until)
                     if (q.limit > 0) add("limit" to q.limit.toString())
                     if (q.offset > 0) add("offset" to q.offset.toString())
                 }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/EventFilters.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/EventFilters.kt
@@ -54,7 +54,8 @@ enum class EventRange(val ms: Long) {
 /**
  * CustomDateRange is an absolute calendar range from the date picker: UTC
  * midnights of the first and last selected day. [untilRfc3339] extends past the
- * end day so it stays inclusive against the server's exclusive upper bound.
+ * end day's midnight so the whole final day is covered by the server's
+ * inclusive (created_at <= ?) upper bound.
  */
 data class CustomDateRange(
     val startMs: Long,

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/EventFilters.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/EventFilters.kt
@@ -1,0 +1,218 @@
+package com.hugalafutro.bellhop.ui.common
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.DateRange
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.DateRangePicker
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberDateRangePickerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.hugalafutro.bellhop.R
+import com.hugalafutro.bellhop.ui.theme.MonoFamily
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+// Shared event time filtering: the relative preset pills plus an absolute
+// calendar range, used by both the Events screen and member detail's recent
+// events. Presets and calendar are mutually exclusive; picking one clears the
+// other.
+
+/**
+ * EventRange is the relative "since" presets offered as time filters,
+ * mirroring the Front Desk web Events page (0 = no lower bound).
+ */
+enum class EventRange(val ms: Long) {
+    ALL(0),
+    H1(3_600_000),
+    H24(86_400_000),
+    D7(604_800_000),
+    D30(2_592_000_000),
+}
+
+/**
+ * CustomDateRange is an absolute calendar range from the date picker: UTC
+ * midnights of the first and last selected day. [untilRfc3339] extends past the
+ * end day so it stays inclusive against the server's exclusive upper bound.
+ */
+data class CustomDateRange(
+    val startMs: Long,
+    val endMs: Long,
+) {
+    fun sinceRfc3339(): String = Instant.ofEpochMilli(startMs).toString()
+
+    fun untilRfc3339(): String = Instant.ofEpochMilli(endMs + DAY_MS).toString()
+
+    /** label renders "Jul 1 – Jul 14" for the active-filter line. */
+    fun label(): String =
+        "${DAY_FORMAT.format(
+            Instant.ofEpochMilli(startMs),
+        )} – ${DAY_FORMAT.format(Instant.ofEpochMilli(endMs))}"
+
+    private companion object {
+        const val DAY_MS = 86_400_000L
+
+        // The picker hands out UTC midnights, so format in UTC too: a zoned
+        // format would shift the labelled day for anyone east of Greenwich.
+        val DAY_FORMAT: DateTimeFormatter =
+            DateTimeFormatter.ofPattern("MMM d", Locale.getDefault()).withZone(ZoneOffset.UTC)
+    }
+}
+
+/** rangeLabel is the chip text for a preset (ALL reads "All"). */
+@Composable
+fun rangeLabel(range: EventRange): String =
+    when (range) {
+        EventRange.ALL -> stringResource(R.string.events_range_all)
+        EventRange.H1 -> stringResource(R.string.events_range_1h)
+        EventRange.H24 -> stringResource(R.string.events_range_24h)
+        EventRange.D7 -> stringResource(R.string.events_range_7d)
+        EventRange.D30 -> stringResource(R.string.events_range_30d)
+    }
+
+/**
+ * EventRangeRow is the shared time filter: preset pills in an equal-weight row
+ * (a segmented control that always fits one phone-width line) with a calendar
+ * icon at the end opening a date-range picker. An active calendar range
+ * deselects every preset, tints the icon brass, and shows a clearable
+ * "Jul 1 – Jul 14" line under the row. Tags are "$tagPrefix-<preset>",
+ * "$tagPrefix-calendar", "$tagPrefix-apply", "$tagPrefix-custom-label" and
+ * "$tagPrefix-custom-clear", so the Events screen keeps its historical
+ * "events-range-*" tags.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun EventRangeRow(
+    selected: EventRange,
+    custom: CustomDateRange?,
+    onRange: (EventRange) -> Unit,
+    onCustomRange: (CustomDateRange?) -> Unit,
+    tagPrefix: String,
+    modifier: Modifier = Modifier,
+) {
+    var showPicker by remember { mutableStateOf(false) }
+    Column(
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            EventRange.entries.forEach { range ->
+                FilterPill(
+                    text = rangeLabel(range),
+                    selected = custom == null && selected == range,
+                    onClick = { onRange(range) },
+                    tag = "$tagPrefix-${range.name.lowercase()}",
+                    modifier = Modifier.weight(1f),
+                )
+            }
+            IconButton(
+                onClick = { showPicker = true },
+                modifier = Modifier.size(28.dp).testTag("$tagPrefix-calendar"),
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.DateRange,
+                    contentDescription = stringResource(R.string.events_range_calendar),
+                    tint =
+                        if (custom != null) {
+                            MaterialTheme.colorScheme.primary
+                        } else {
+                            MaterialTheme.colorScheme.onSurfaceVariant
+                        },
+                    modifier = Modifier.size(18.dp),
+                )
+            }
+        }
+        if (custom != null) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                Text(
+                    text = custom.label(),
+                    style = MaterialTheme.typography.labelSmall,
+                    fontFamily = MonoFamily,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.testTag("$tagPrefix-custom-label"),
+                )
+                IconButton(
+                    onClick = { onCustomRange(null) },
+                    modifier = Modifier.size(20.dp).testTag("$tagPrefix-custom-clear"),
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.Close,
+                        contentDescription = stringResource(R.string.events_range_clear),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(14.dp),
+                    )
+                }
+            }
+        }
+    }
+    if (showPicker) {
+        val pickerState =
+            rememberDateRangePickerState(
+                initialSelectedStartDateMillis = custom?.startMs,
+                initialSelectedEndDateMillis = custom?.endMs,
+            )
+        DatePickerDialog(
+            onDismissRequest = { showPicker = false },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        // A single tapped day is a valid one-day range.
+                        pickerState.selectedStartDateMillis?.let { start ->
+                            onCustomRange(
+                                CustomDateRange(
+                                    startMs = start,
+                                    endMs = pickerState.selectedEndDateMillis ?: start,
+                                ),
+                            )
+                        }
+                        showPicker = false
+                    },
+                    modifier = Modifier.testTag("$tagPrefix-apply"),
+                ) {
+                    Text(stringResource(R.string.events_range_apply))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showPicker = false }) {
+                    Text(stringResource(R.string.common_cancel))
+                }
+            },
+        ) {
+            // weight keeps the picker from pushing the dialog's buttons
+            // off-screen on small phones.
+            DateRangePicker(
+                state = pickerState,
+                showModeToggle = false,
+                modifier = Modifier.weight(1f),
+            )
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/LoadMoreBackoff.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/LoadMoreBackoff.kt
@@ -1,0 +1,14 @@
+package com.hugalafutro.bellhop.ui.common
+
+/**
+ * loadMoreBackoffMillis is the delay before retrying a failed infinite-scroll
+ * page. The list sentinel re-arms the instant `loadingMore` clears, so a
+ * persistent fetch error would otherwise re-fire loadMore in a tight loop and
+ * hammer Front Desk. Consecutive failures back off exponentially from 1s,
+ * capped at 30s; the caller resets its failure count on the first success.
+ */
+internal fun loadMoreBackoffMillis(failures: Int): Long {
+    if (failures <= 0) return 0L
+    val steps = (failures - 1).coerceAtMost(5)
+    return (1_000L shl steps).coerceAtMost(30_000L)
+}

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/OpenUrlDialog.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/OpenUrlDialog.kt
@@ -1,0 +1,61 @@
+package com.hugalafutro.bellhop.ui.common
+
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import com.hugalafutro.bellhop.R
+
+/**
+ * ConfirmOpenUrlDialog is the "open this member's address?" confirmation shared
+ * by the dashboard card and the member-detail ledger: leaving the app for a
+ * browser must be a deliberate second tap, never the same tap that could also
+ * be a mis-tap on the row itself.
+ */
+@Composable
+fun ConfirmOpenUrlDialog(
+    url: String,
+    onDismiss: () -> Unit,
+) {
+    val context = LocalContext.current
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.member_url_title)) },
+        text = {
+            Text(
+                text = url,
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.testTag("member-url-dialog-text"),
+            )
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    // ACTION_VIEW lets Android resolve the URL (browser or a
+                    // matching app), showing its own chooser when several match.
+                    // runCatching: a device with nothing that can open it must
+                    // not crash the app.
+                    runCatching {
+                        context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+                    }
+                    onDismiss()
+                },
+                modifier = Modifier.testTag("member-url-open"),
+            ) {
+                Text(stringResource(R.string.member_url_open))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.common_cancel))
+            }
+        },
+    )
+}

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
@@ -1,7 +1,5 @@
 package com.hugalafutro.bellhop.ui.dashboard
 
-import android.content.Intent
-import android.net.Uri
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -23,7 +21,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.Settings
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
@@ -45,7 +42,6 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
@@ -57,6 +53,7 @@ import com.hugalafutro.bellhop.data.HealthStatus
 import com.hugalafutro.bellhop.data.LinkState
 import com.hugalafutro.bellhop.data.MemberStatus
 import com.hugalafutro.bellhop.data.MemberTraffic
+import com.hugalafutro.bellhop.ui.common.ConfirmOpenUrlDialog
 import com.hugalafutro.bellhop.ui.common.Pill
 import com.hugalafutro.bellhop.ui.common.StatusBanner
 import com.hugalafutro.bellhop.ui.common.TrafficChart
@@ -90,43 +87,8 @@ fun DashboardScreen(
     // a card's address opens this confirm dialog rather than firing an intent on
     // the same tap that could also be a mis-tap on the card itself.
     var urlDialogFor by remember { mutableStateOf<FleetMember?>(null) }
-    val context = LocalContext.current
     urlDialogFor?.let { member ->
-        AlertDialog(
-            onDismissRequest = { urlDialogFor = null },
-            title = { Text(stringResource(R.string.member_url_title)) },
-            text = {
-                Text(
-                    text = member.url,
-                    style = MaterialTheme.typography.bodyMedium,
-                    modifier = Modifier.testTag("member-url-dialog-text"),
-                )
-            },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        // ACTION_VIEW lets Android resolve the URL (browser or a
-                        // matching app), showing its own chooser when several match.
-                        // runCatching: a device with nothing that can open it must
-                        // not crash the app.
-                        runCatching {
-                            context.startActivity(
-                                Intent(Intent.ACTION_VIEW, Uri.parse(member.url)),
-                            )
-                        }
-                        urlDialogFor = null
-                    },
-                    modifier = Modifier.testTag("member-url-open"),
-                ) {
-                    Text(stringResource(R.string.member_url_open))
-                }
-            },
-            dismissButton = {
-                TextButton(onClick = { urlDialogFor = null }) {
-                    Text(stringResource(R.string.common_cancel))
-                }
-            },
-        )
+        ConfirmOpenUrlDialog(url = member.url, onDismiss = { urlDialogFor = null })
     }
 
     Scaffold(modifier = modifier.fillMaxSize()) { innerPadding ->

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/events/EventsScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/events/EventsScreen.kt
@@ -42,6 +42,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.hugalafutro.bellhop.R
 import com.hugalafutro.bellhop.data.FdEvent
+import com.hugalafutro.bellhop.ui.common.CustomDateRange
+import com.hugalafutro.bellhop.ui.common.EventRange
+import com.hugalafutro.bellhop.ui.common.EventRangeRow
 import com.hugalafutro.bellhop.ui.common.FilterPill
 import com.hugalafutro.bellhop.ui.common.StatusBanner
 import com.hugalafutro.bellhop.ui.common.severityColors
@@ -65,6 +68,7 @@ fun EventsScreen(
     memberNames: Map<String, String> = emptyMap(),
     onSeverity: (String) -> Unit = {},
     onRange: (EventRange) -> Unit = {},
+    onCustomRange: (CustomDateRange?) -> Unit = {},
     onLoadMore: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
@@ -114,7 +118,13 @@ fun EventsScreen(
             }
 
             SeverityChips(selected = ui.severity, onSeverity = onSeverity)
-            RangeChips(selected = ui.range, onRange = onRange)
+            EventRangeRow(
+                selected = ui.range,
+                custom = ui.custom,
+                onRange = onRange,
+                onCustomRange = onCustomRange,
+                tagPrefix = "events-range",
+            )
             Spacer(modifier = Modifier.height(8.dp))
 
             if (ui.revoked) {
@@ -219,28 +229,6 @@ private fun SeverityChips(
 }
 
 @Composable
-private fun RangeChips(
-    selected: EventRange,
-    onRange: (EventRange) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    Row(
-        horizontalArrangement = Arrangement.spacedBy(6.dp),
-        modifier = modifier.fillMaxWidth(),
-    ) {
-        EventRange.entries.forEach { range ->
-            FilterPill(
-                text = rangeLabel(range),
-                selected = selected == range,
-                onClick = { onRange(range) },
-                tag = "events-range-${range.name.lowercase()}",
-                modifier = Modifier.weight(1f),
-            )
-        }
-    }
-}
-
-@Composable
 private fun EventRow(
     event: FdEvent,
     memberName: String?,
@@ -324,16 +312,6 @@ private fun severityLabel(severity: String): String =
         "warning" -> stringResource(R.string.events_sev_warning)
         "error" -> stringResource(R.string.events_sev_error)
         else -> severity
-    }
-
-@Composable
-private fun rangeLabel(range: EventRange): String =
-    when (range) {
-        EventRange.ALL -> stringResource(R.string.events_range_all)
-        EventRange.H1 -> stringResource(R.string.events_range_1h)
-        EventRange.H24 -> stringResource(R.string.events_range_24h)
-        EventRange.D7 -> stringResource(R.string.events_range_7d)
-        EventRange.D30 -> stringResource(R.string.events_range_30d)
     }
 
 private val EVENT_TIME_FORMAT =

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/events/EventsViewModel.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/events/EventsViewModel.kt
@@ -9,6 +9,8 @@ import com.hugalafutro.bellhop.data.FdEvent
 import com.hugalafutro.bellhop.data.FetchResult
 import com.hugalafutro.bellhop.data.FrontDeskClient
 import com.hugalafutro.bellhop.data.LinkStore
+import com.hugalafutro.bellhop.ui.common.CustomDateRange
+import com.hugalafutro.bellhop.ui.common.EventRange
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
@@ -25,18 +27,6 @@ import kotlinx.coroutines.sync.withLock
 import java.time.Instant
 
 /**
- * EventRange is the relative "since" presets offered as time filters,
- * mirroring the Front Desk web Events page (0 = no lower bound).
- */
-enum class EventRange(val ms: Long) {
-    ALL(0),
-    H1(3_600_000),
-    H24(86_400_000),
-    D7(604_800_000),
-    D30(2_592_000_000),
-}
-
-/**
  * EventsUiState is what the event-log screen renders. A failed refresh keeps
  * the last good page on screen (stale beats blank on a phone) and raises
  * [error]; [revoked] means the device token itself no longer authenticates,
@@ -50,6 +40,8 @@ data class EventsUiState(
     // "" = all severities.
     val severity: String = "",
     val range: EventRange = EventRange.ALL,
+    // Absolute calendar range from the picker; non-null overrides [range].
+    val custom: CustomDateRange? = null,
     val loadingMore: Boolean = false,
     val error: String? = null,
     val revoked: Boolean = false,
@@ -139,11 +131,21 @@ class EventsViewModel(
         refreshTrigger.trySend(Unit)
     }
 
-    /** setRange swaps the time-range filter and reloads from scratch. */
+    /** setRange swaps the time-range preset (clearing any calendar range) and reloads. */
     fun setRange(range: EventRange) {
-        if (range == _state.value.range) return
+        val s = _state.value
+        if (range == s.range && s.custom == null) return
         _state.update {
-            it.copy(range = range, loading = true, events = emptyList(), total = 0)
+            it.copy(range = range, custom = null, loading = true, events = emptyList(), total = 0)
+        }
+        refreshTrigger.trySend(Unit)
+    }
+
+    /** setCustomRange swaps the calendar range (null falls back to the preset) and reloads. */
+    fun setCustomRange(range: CustomDateRange?) {
+        if (range == _state.value.custom) return
+        _state.update {
+            it.copy(custom = range, loading = true, events = emptyList(), total = 0)
         }
         refreshTrigger.trySend(Unit)
     }
@@ -211,7 +213,7 @@ class EventsViewModel(
         }
         val result = client.events(fdUrl, token, query)
         _state.update { st ->
-            if (st.severity != before.severity || st.range != before.range) {
+            if (st.severity != before.severity || st.range != before.range || st.custom != before.custom) {
                 return@update st.copy(loadingMore = false)
             }
             when (result) {
@@ -232,11 +234,12 @@ class EventsViewModel(
         EventQuery(
             severity = st.severity,
             since =
-                if (st.range.ms > 0) {
-                    Instant.ofEpochMilli(now() - st.range.ms).toString()
-                } else {
-                    ""
+                when {
+                    st.custom != null -> st.custom.sinceRfc3339()
+                    st.range.ms > 0 -> Instant.ofEpochMilli(now() - st.range.ms).toString()
+                    else -> ""
                 },
+            until = st.custom?.untilRfc3339() ?: "",
             limit = limit,
             offset = offset,
         )

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/events/EventsViewModel.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/events/EventsViewModel.kt
@@ -11,6 +11,7 @@ import com.hugalafutro.bellhop.data.FrontDeskClient
 import com.hugalafutro.bellhop.data.LinkStore
 import com.hugalafutro.bellhop.ui.common.CustomDateRange
 import com.hugalafutro.bellhop.ui.common.EventRange
+import com.hugalafutro.bellhop.ui.common.loadMoreBackoffMillis
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
@@ -87,6 +88,10 @@ class EventsViewModel(
     // window size before a concurrent append landed would reload too few rows
     // and truncate the list the user just paged in.
     private val fetchMutex = Mutex()
+
+    // Consecutive loadMore failures, driving the infinite-scroll retry backoff
+    // ([loadMoreBackoffMillis]); reset to 0 on the first successful page.
+    private var loadMoreFailures = 0
 
     init {
         viewModelScope.launch {
@@ -174,7 +179,12 @@ class EventsViewModel(
             }
         }
 
-    private suspend fun loadMoreOnce() =
+    private suspend fun loadMoreOnce() {
+        // Back off before retrying a failed page: the scroll sentinel re-arms
+        // the instant loadingMore clears, so a persistent error would otherwise
+        // hammer Front Desk. Delay outside the lock so the poll refresh isn't
+        // stalled behind the backoff.
+        if (loadMoreFailures > 0) delay(loadMoreBackoffMillis(loadMoreFailures))
         fetchMutex.withLock {
             val before = _state.value
             // Grow the window by a page and reload it from the top rather than
@@ -183,15 +193,22 @@ class EventsViewModel(
             // fetch would skip the row that slid past the old boundary. Reading
             // the whole window from offset 0 is drift-proof (and dedup-free).
             val limit = (before.events.size + PAGE_SIZE).coerceAtMost(MAX_WINDOW)
-            fetch(before, query(before, limit = limit, offset = 0)) { st, resp ->
-                st.copy(
-                    events = resp.events.orEmpty(),
-                    total = resp.total,
-                    error = null,
-                    revoked = false,
-                )
+            val result =
+                fetch(before, query(before, limit = limit, offset = 0)) { st, resp ->
+                    st.copy(
+                        events = resp.events.orEmpty(),
+                        total = resp.total,
+                        error = null,
+                        revoked = false,
+                    )
+                }
+            when (result) {
+                is FetchResult.Success -> loadMoreFailures = 0
+                is FetchResult.Failure -> loadMoreFailures++
+                FetchResult.Unauthorized -> Unit
             }
         }
+    }
 
     // fetch runs one events call and folds a success into the state via
     // [onSuccess] — unless the filters changed while it was in flight, in
@@ -202,14 +219,14 @@ class EventsViewModel(
         before: EventsUiState,
         query: EventQuery,
         onSuccess: (EventsUiState, EventsResponse) -> EventsUiState,
-    ) {
+    ): FetchResult<EventsResponse> {
         val token = linkStore.token()
         if (token == null) {
             // Still linked but the token can't be read back (e.g. the Keystore
             // key is gone): no request can ever succeed, same operator remedy
             // as a remote revoke, so surface it through the same flag.
             _state.update { it.copy(loading = false, loadingMore = false, revoked = true) }
-            return
+            return FetchResult.Unauthorized
         }
         val result = client.events(fdUrl, token, query)
         _state.update { st ->
@@ -224,6 +241,7 @@ class EventsViewModel(
                     st.copy(loading = false, loadingMore = false, error = result.message)
             }
         }
+        return result
     }
 
     private fun query(

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreen.kt
@@ -17,7 +17,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -222,9 +222,11 @@ fun MemberDetailScreen(
                             )
                         }
                     else ->
-                        items(ui.events) { event ->
+                        itemsIndexed(ui.events) { index, event ->
                             MemberEventRow(event = event)
-                            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+                            if (index < ui.events.lastIndex) {
+                                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+                            }
                         }
                 }
                 if (ui.loadingMore) {

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreen.kt
@@ -1,12 +1,14 @@
 package com.hugalafutro.bellhop.ui.member
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -22,6 +24,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -31,9 +34,14 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
@@ -47,6 +55,10 @@ import com.hugalafutro.bellhop.data.MemberState
 import com.hugalafutro.bellhop.data.MemberStatus
 import com.hugalafutro.bellhop.data.MemberTraffic
 import com.hugalafutro.bellhop.data.TrafficPoint
+import com.hugalafutro.bellhop.ui.common.ConfirmOpenUrlDialog
+import com.hugalafutro.bellhop.ui.common.CustomDateRange
+import com.hugalafutro.bellhop.ui.common.EventRange
+import com.hugalafutro.bellhop.ui.common.EventRangeRow
 import com.hugalafutro.bellhop.ui.common.Pill
 import com.hugalafutro.bellhop.ui.common.StatusBanner
 import com.hugalafutro.bellhop.ui.common.TrafficChart
@@ -62,8 +74,10 @@ import com.hugalafutro.bellhop.ui.theme.MonoFamily
  * hour of traffic (the full graph the card only sparklines) and the info the
  * card has no room for: the probe error when down, config-sync provenance, the
  * in-sync heartbeat, when it was added, and the member's recent event log.
- * [member] arrives live from the dashboard's poll; [ui] carries the graph +
- * events from [MemberDetailViewModel].
+ * The graph is the only card on the page; everything under it is flat ledger
+ * sections so the screen doesn't read as a stack of pills. [member] arrives
+ * live from the dashboard's poll; [ui] carries the graph + events from
+ * [MemberDetailViewModel].
  */
 @Composable
 fun MemberDetailScreen(
@@ -80,11 +94,18 @@ fun MemberDetailScreen(
     onSyncFleet: () -> Unit = {},
     onReconcile: (String) -> Unit = {},
     onDismissActionError: () -> Unit = {},
+    onRange: (EventRange) -> Unit = {},
+    onCustomRange: (CustomDateRange?) -> Unit = {},
+    onLoadMoreEvents: () -> Unit = {},
 ) {
     val health = member.status.health
     // Clear the optimistic pending state once the dashboard's live state (member
     // arrives live from its poll/SSE) has caught up to the accepted target.
     LaunchedEffect(member.state) { onReconcile(member.state) }
+    var showUrlDialog by remember { mutableStateOf(false) }
+    if (showUrlDialog) {
+        ConfirmOpenUrlDialog(url = member.url, onDismiss = { showUrlDialog = false })
+    }
     Scaffold(modifier = modifier.fillMaxSize()) { innerPadding ->
         Column(
             modifier =
@@ -140,28 +161,45 @@ fun MemberDetailScreen(
 
             LazyColumn(
                 modifier = Modifier.weight(1f).testTag("member-detail-list"),
-                verticalArrangement = Arrangement.spacedBy(12.dp),
                 contentPadding = PaddingValues(top = 4.dp, bottom = 24.dp),
             ) {
-                item { TrafficCard(ui = ui) }
-                item { MetaCard(member = member) }
+                item { TrafficCard(ui = ui, modifier = Modifier.padding(bottom = 20.dp)) }
+                item {
+                    MetaLedger(
+                        member = member,
+                        onOpenUrl = { showUrlDialog = true },
+                        modifier = Modifier.padding(bottom = 20.dp),
+                    )
+                }
                 if (canOperate) {
                     item {
-                        OperatorCard(
+                        OperatorControls(
                             member = member,
                             isPrimary = isPrimary,
                             action = ui.action,
+                            lastFleetSyncAt = ui.lastFleetSyncAt,
                             onSetState = onSetState,
                             onSyncFleet = onSyncFleet,
                             onDismissActionError = onDismissActionError,
+                            modifier = Modifier.padding(bottom = 20.dp),
                         )
                     }
                 }
                 item {
-                    Text(
+                    SectionHeader(
                         text = stringResource(R.string.member_detail_events_title),
-                        style = MaterialTheme.typography.titleMedium,
-                        modifier = Modifier.testTag("member-detail-events-title"),
+                        tag = "member-detail-events-title",
+                        modifier = Modifier.padding(bottom = 6.dp),
+                    )
+                }
+                item {
+                    EventRangeRow(
+                        selected = ui.range,
+                        custom = ui.custom,
+                        onRange = onRange,
+                        onCustomRange = onCustomRange,
+                        tagPrefix = "member-events-range",
+                        modifier = Modifier.padding(bottom = 6.dp),
                     )
                 }
                 when {
@@ -183,7 +221,42 @@ fun MemberDetailScreen(
                                 modifier = Modifier.testTag("member-detail-no-events"),
                             )
                         }
-                    else -> items(ui.events) { event -> MemberEventRow(event = event) }
+                    else ->
+                        items(ui.events) { event ->
+                            MemberEventRow(event = event)
+                            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+                        }
+                }
+                if (ui.loadingMore) {
+                    item {
+                        Box(
+                            modifier = Modifier.fillMaxWidth().padding(vertical = 12.dp),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            CircularProgressIndicator(
+                                strokeWidth = 2.dp,
+                                modifier = Modifier.size(20.dp).testTag("member-events-loading-more"),
+                            )
+                        }
+                    }
+                } else if (ui.canLoadMore) {
+                    // Infinite scroll: lazy items only compose near the
+                    // viewport, so this sentinel composing at all means the
+                    // user bottomed out — ask for the next page. The key
+                    // changes with the window size, so a fresh sentinel arms
+                    // after each page (and a short first page auto-fills the
+                    // screen). The VM still no-ops when nothing more exists.
+                    // The 1dp spacer gives it a semantics node (tests scroll
+                    // to it); visually it's nothing.
+                    item(key = "member-events-load-more-${ui.events.size}") {
+                        LaunchedEffect(Unit) { onLoadMoreEvents() }
+                        Spacer(
+                            modifier =
+                                Modifier
+                                    .height(1.dp)
+                                    .testTag("member-events-load-more-sentinel"),
+                        )
+                    }
                 }
             }
         }
@@ -191,202 +264,276 @@ fun MemberDetailScreen(
 }
 
 /**
- * MetaCard is the info the dashboard card has no room for: the full probe error
- * when down, config-sync provenance, the in-sync heartbeat, and when the member
- * was added. Each line only shows when it has a value, so a healthy never-synced
- * member stays terse.
+ * SectionHeader is the flat replacement for a card title: a small brass
+ * overline with a hairline rule running out to the edge, so sections read as
+ * ledger dividers instead of yet more pills.
  */
 @Composable
-private fun MetaCard(
+private fun SectionHeader(
+    text: String,
+    modifier: Modifier = Modifier,
+    tag: String? = null,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+        modifier = modifier.fillMaxWidth().then(if (tag != null) Modifier.testTag(tag) else Modifier),
+    ) {
+        Text(
+            text = text.uppercase(),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.primary,
+        )
+        HorizontalDivider(modifier = Modifier.weight(1f), color = MaterialTheme.colorScheme.outlineVariant)
+    }
+}
+
+/**
+ * MetaLedger is the info the dashboard card has no room for: the full probe
+ * error when down, config-sync provenance, the in-sync heartbeat, and when the
+ * member was added. Flat label/value register lines under the graph — not a
+ * card — with the values in mono so timestamps and the address align. Each
+ * line only shows when it has a value, so a healthy never-synced member stays
+ * terse.
+ */
+@Composable
+private fun MetaLedger(
     member: FleetMember,
+    onOpenUrl: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val health = member.status.health
-    Card(modifier = modifier.fillMaxWidth().testTag("member-detail-meta")) {
-        Column(
-            modifier = Modifier.padding(14.dp),
-            verticalArrangement = Arrangement.spacedBy(6.dp),
-        ) {
-            Text(
-                text = member.url,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
+    Column(
+        modifier = modifier.fillMaxWidth().testTag("member-detail-meta"),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        // Brass + tappable, same affordance as the dashboard card's address:
+        // the tap only raises the confirm dialog, never fires an intent itself.
+        LedgerRow(
+            label = stringResource(R.string.member_detail_label_address),
+            value = member.url,
+            valueColor = MaterialTheme.colorScheme.primary,
+            onClick = onOpenUrl,
+            tag = "member-detail-url",
+        )
+        if (health.known && !health.healthy && health.error.isNotBlank()) {
+            LedgerRow(
+                label = stringResource(R.string.member_health_down),
+                value = health.error,
+                valueColor = MaterialTheme.colorScheme.error,
+                tag = "member-detail-down-reason",
             )
-            if (health.known && !health.healthy && health.error.isNotBlank()) {
+        }
+        if (member.lastConfigSyncAt.isNotBlank()) {
+            LedgerRow(
+                label = stringResource(R.string.member_detail_label_synced),
+                value = formatEventTime(member.lastConfigSyncAt),
+                tag = "member-detail-synced",
+            )
+            if (member.lastConfigSyncReason.isNotBlank()) {
+                // Why the last sync ran, indented to the value column (label
+                // width + gap) so it hangs off the SYNCED entry.
                 Text(
-                    text = health.error,
+                    text = member.lastConfigSyncReason,
                     style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.error,
-                    modifier = Modifier.testTag("member-detail-down-reason"),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(start = 88.dp),
                 )
             }
-            if (member.lastConfigSyncAt.isNotBlank()) {
-                MetaLine(
-                    text = stringResource(R.string.member_detail_synced, formatEventTime(member.lastConfigSyncAt)),
-                    tag = "member-detail-synced",
-                )
-                if (member.lastConfigSyncReason.isNotBlank()) {
-                    Text(
-                        text = member.lastConfigSyncReason,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-            }
-            if (member.status.autoSyncVerifiedAt.isNotBlank()) {
-                MetaLine(
-                    text =
-                        stringResource(
-                            R.string.member_detail_verified,
-                            formatEventTime(member.status.autoSyncVerifiedAt),
-                        ),
-                    tag = "member-detail-verified",
-                )
-            }
-            if (member.createdAt.isNotBlank()) {
-                MetaLine(
-                    text = stringResource(R.string.member_detail_created, formatEventTime(member.createdAt)),
-                    tag = "member-detail-created",
-                )
-            }
+        }
+        if (member.status.autoSyncVerifiedAt.isNotBlank()) {
+            LedgerRow(
+                label = stringResource(R.string.member_detail_label_verified),
+                value = formatEventTime(member.status.autoSyncVerifiedAt),
+                tag = "member-detail-verified",
+            )
+        }
+        if (member.createdAt.isNotBlank()) {
+            LedgerRow(
+                label = stringResource(R.string.member_detail_label_added),
+                value = formatEventTime(member.createdAt),
+                tag = "member-detail-created",
+            )
         }
     }
 }
 
+/**
+ * LedgerRow is one register line of [MetaLedger]: an uppercase muted label in
+ * a fixed column and a mono value, so the block reads as one aligned ledger
+ * instead of a pile of sentences.
+ */
 @Composable
-private fun MetaLine(
-    text: String,
-    tag: String,
+private fun LedgerRow(
+    label: String,
+    value: String,
+    modifier: Modifier = Modifier,
+    valueColor: Color = MaterialTheme.colorScheme.onSurface,
+    tag: String? = null,
+    onClick: (() -> Unit)? = null,
 ) {
-    Text(
-        text = text,
-        style = MaterialTheme.typography.bodySmall,
-        color = MaterialTheme.colorScheme.onSurfaceVariant,
-        modifier = Modifier.testTag(tag),
-    )
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .then(if (tag != null) Modifier.testTag(tag) else Modifier)
+                .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier),
+    ) {
+        Text(
+            text = label.uppercase(),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.width(76.dp),
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodySmall,
+            fontFamily = MonoFamily,
+            color = valueColor,
+            modifier = Modifier.weight(1f),
+        )
+    }
 }
 
 /**
- * OperatorCard is the drain/activate (and, on the primary, fleet-sync) surface,
- * shown only to an operator device. The button reflects the effective state:
- * Front Desk's live state, or the optimistic pending target once an action was
- * accepted and until the dashboard reconciles it. A 403 from Front Desk collapses
- * the card to the guard note — the authoritative role check overriding the
- * role-hint UI. Actions are set-state, so a double-tap is a safe no-op; the
- * biometric prompt gating them lives in the host (MainActivity).
+ * OperatorControls is the drain/activate (and, on the primary, fleet-sync)
+ * surface, shown only to an operator device: a section rule and a compact
+ * button row rather than a card with a full-width button. The button reflects
+ * the effective state: Front Desk's live state, or the optimistic pending
+ * target once an action was accepted and until the dashboard reconciles it.
+ * A 403 from Front Desk collapses the section to the guard note — the
+ * authoritative role check overriding the role-hint UI. Actions are set-state,
+ * so a double-tap is a safe no-op; the biometric prompt gating them lives in
+ * the host (MainActivity).
  */
 @Composable
-private fun OperatorCard(
+private fun OperatorControls(
     member: FleetMember,
     isPrimary: Boolean,
     action: ActionUiState,
+    lastFleetSyncAt: String,
     onSetState: (String) -> Unit,
     onSyncFleet: () -> Unit,
     onDismissActionError: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Card(modifier = modifier.fillMaxWidth().testTag("member-operator-card")) {
-        Column(
-            modifier = Modifier.padding(14.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
+    Column(
+        modifier = modifier.fillMaxWidth().testTag("member-operator-card"),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        SectionHeader(text = stringResource(R.string.member_op_title))
+        if (action.forbidden) {
+            // Front Desk refused the device's role: the real guard. Drop the
+            // controls entirely so the note is the only thing left.
             Text(
-                text = stringResource(R.string.member_op_title),
-                style = MaterialTheme.typography.titleSmall,
+                text = stringResource(R.string.member_op_forbidden),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.error,
+                modifier = Modifier.testTag("member-op-forbidden"),
             )
-            if (action.forbidden) {
-                // Front Desk refused the device's role: the real guard. Drop the
-                // controls entirely so the note is the only thing left.
-                Text(
-                    text = stringResource(R.string.member_op_forbidden),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.error,
-                    modifier = Modifier.testTag("member-op-forbidden"),
-                )
-                return@Column
-            }
+            return@Column
+        }
 
-            // Optimistic pending target beats the live state until reconciled, so
-            // a fresh tap flips the button immediately even before the fleet moves.
-            val effectiveState = action.pendingState ?: member.state
-            val drained = effectiveState == MemberState.DRAINED
+        // Optimistic pending target beats the live state until reconciled, so
+        // a fresh tap flips the button immediately even before the fleet moves.
+        val effectiveState = action.pendingState ?: member.state
+        val drained = effectiveState == MemberState.DRAINED
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
             Button(
                 onClick = { onSetState(if (drained) MemberState.ACTIVE else MemberState.DRAINED) },
                 enabled = !action.inProgress,
-                modifier = Modifier.fillMaxWidth().testTag("member-op-state"),
+                modifier = Modifier.testTag("member-op-state"),
             ) {
                 if (action.inProgress) {
+                    // Spinner joins the label instead of replacing it so the
+                    // button keeps its width and stays legible in flight.
                     CircularProgressIndicator(
                         strokeWidth = 2.dp,
                         modifier = Modifier.size(16.dp),
                         color = MaterialTheme.colorScheme.onPrimary,
                     )
-                } else {
-                    Text(
-                        text =
-                            stringResource(
-                                if (drained) R.string.member_op_activate else R.string.member_op_drain,
-                            ),
-                    )
+                    Spacer(modifier = Modifier.width(8.dp))
                 }
-            }
-            if (action.pendingState != null) {
                 Text(
                     text =
                         stringResource(
-                            if (drained) R.string.member_op_draining else R.string.member_op_activating,
+                            if (drained) R.string.member_op_activate else R.string.member_op_drain,
                         ),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.testTag("member-op-pending"),
                 )
             }
-
             if (isPrimary) {
                 OutlinedButton(
                     onClick = onSyncFleet,
                     enabled = !action.inProgress,
-                    modifier = Modifier.fillMaxWidth().testTag("member-op-sync"),
+                    modifier = Modifier.testTag("member-op-sync"),
                 ) {
                     Text(text = stringResource(R.string.member_op_sync))
                 }
             }
-            if (action.busy) {
-                // A tap arrived mid-flight and was dropped: say so rather than
-                // leaving the operator wondering why nothing happened.
-                Text(
-                    text = stringResource(R.string.member_op_busy),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.testTag("member-op-busy"),
-                )
-            }
-            action.syncSummary?.let { summary ->
-                Text(
-                    text =
-                        if (summary.failed == 0) {
-                            stringResource(R.string.member_op_synced, summary.total)
-                        } else {
-                            stringResource(R.string.member_op_sync_failed, summary.failed, summary.total)
-                        },
-                    style = MaterialTheme.typography.bodySmall,
-                    color =
-                        if (summary.failed == 0) {
-                            MaterialTheme.colorScheme.onSurfaceVariant
-                        } else {
-                            MaterialTheme.colorScheme.error
-                        },
-                    modifier = Modifier.testTag("member-op-sync-result"),
-                )
-            }
-            action.error?.let { message ->
+        }
+        if (isPrimary && lastFleetSyncAt.isNotBlank()) {
+            // When a sync last actually wrote config somewhere, not when the
+            // button was last pressed; a run that changed nothing doesn't move it.
+            Text(
+                text = stringResource(R.string.member_op_last_sync, formatEventTime(lastFleetSyncAt)),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.testTag("member-op-last-sync"),
+            )
+        }
+        if (action.pendingState != null) {
+            Text(
+                text =
+                    stringResource(
+                        if (drained) R.string.member_op_draining else R.string.member_op_activating,
+                    ),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.testTag("member-op-pending"),
+            )
+        }
+        if (action.busy) {
+            // A tap arrived mid-flight and was dropped: say so rather than
+            // leaving the operator wondering why nothing happened.
+            Text(
+                text = stringResource(R.string.member_op_busy),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.testTag("member-op-busy"),
+            )
+        }
+        action.syncSummary?.let { summary ->
+            Text(
+                text =
+                    if (summary.failed == 0) {
+                        stringResource(R.string.member_op_synced, summary.total)
+                    } else {
+                        stringResource(R.string.member_op_sync_failed, summary.failed, summary.total)
+                    },
+                style = MaterialTheme.typography.bodySmall,
+                color =
+                    if (summary.failed == 0) {
+                        MaterialTheme.colorScheme.onSurfaceVariant
+                    } else {
+                        MaterialTheme.colorScheme.error
+                    },
+                modifier = Modifier.testTag("member-op-sync-result"),
+            )
+        }
+        action.error?.let { message ->
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
                 Text(
                     text = stringResource(R.string.member_op_error, message),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.error,
-                    modifier = Modifier.testTag("member-op-error"),
+                    modifier = Modifier.weight(1f).testTag("member-op-error"),
                 )
                 TextButton(
                     onClick = onDismissActionError,
@@ -451,6 +598,7 @@ private fun TrafficCard(
                                 traffic.totalErrors,
                             ),
                         style = MaterialTheme.typography.bodySmall,
+                        fontFamily = MonoFamily,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier = Modifier.testTag("member-traffic-totals"),
                     )
@@ -466,8 +614,9 @@ private fun TrafficCard(
 
 /**
  * MemberEventRow is one event under the graph, in the same log language as the
- * Events screen: a severity-coloured rail down the card's left edge (no pill) and
- * the type as the heading with a mono timestamp, then the message.
+ * Events screen: a flat line — no card — with a severity-coloured rail down the
+ * left edge and a faint tint of the same colour, the type as the heading with a
+ * mono timestamp, then the message.
  */
 @Composable
 private fun MemberEventRow(
@@ -475,45 +624,50 @@ private fun MemberEventRow(
     modifier: Modifier = Modifier,
 ) {
     val accent = severityColors(event.severity).first
-    Card(modifier = modifier.fillMaxWidth().testTag("member-event-row")) {
-        Row(modifier = Modifier.height(IntrinsicSize.Min)) {
-            Box(
-                modifier =
-                    Modifier
-                        .width(3.dp)
-                        .fillMaxHeight()
-                        .background(accent)
-                        .testTag("member-event-sev-${event.severity}"),
-            )
-            Column(
-                modifier = Modifier.weight(1f).padding(horizontal = 12.dp, vertical = 10.dp),
-                verticalArrangement = Arrangement.spacedBy(3.dp),
+    Row(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .background(accent.copy(alpha = 0.06f))
+                .height(IntrinsicSize.Min)
+                .testTag("member-event-row"),
+    ) {
+        Box(
+            modifier =
+                Modifier
+                    .width(3.dp)
+                    .fillMaxHeight()
+                    .background(accent)
+                    .testTag("member-event-sev-${event.severity}"),
+        )
+        Column(
+            modifier = Modifier.weight(1f).padding(horizontal = 12.dp, vertical = 10.dp),
+            verticalArrangement = Arrangement.spacedBy(3.dp),
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                ) {
-                    Text(
-                        text = event.type,
-                        style = MaterialTheme.typography.titleSmall,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                        modifier = Modifier.weight(1f),
-                    )
-                    Text(
-                        text = formatEventTime(event.createdAt),
-                        style = MaterialTheme.typography.labelSmall,
-                        fontFamily = MonoFamily,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
                 Text(
-                    text = event.message,
-                    style = MaterialTheme.typography.bodyMedium,
-                    maxLines = 2,
+                    text = event.type,
+                    style = MaterialTheme.typography.titleSmall,
+                    maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f),
+                )
+                Text(
+                    text = formatEventTime(event.createdAt),
+                    style = MaterialTheme.typography.labelSmall,
+                    fontFamily = MonoFamily,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
+            Text(
+                text = event.message,
+                style = MaterialTheme.typography.bodyMedium,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
         }
     }
 }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailViewModel.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailViewModel.kt
@@ -12,6 +12,7 @@ import com.hugalafutro.bellhop.data.LinkStore
 import com.hugalafutro.bellhop.data.MemberTraffic
 import com.hugalafutro.bellhop.ui.common.CustomDateRange
 import com.hugalafutro.bellhop.ui.common.EventRange
+import com.hugalafutro.bellhop.ui.common.loadMoreBackoffMillis
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
@@ -117,6 +118,10 @@ class MemberDetailViewModel(
     // Serializes the poll refresh, filter-change reloads and loadMore so two
     // window fetches can't interleave and fold out of order.
     private val fetchMutex = Mutex()
+
+    // Consecutive loadMore failures, driving the infinite-scroll retry backoff
+    // ([loadMoreBackoffMillis]); reset to 0 on the first successful page.
+    private var loadMoreFailures = 0
 
     init {
         viewModelScope.launch {
@@ -237,10 +242,20 @@ class MemberDetailViewModel(
                 _state.update { it.copy(loadingMore = false, revoked = true) }
                 return@launch
             }
+            // Back off before retrying a failed page: the scroll sentinel
+            // re-arms the instant loadingMore clears, so a persistent error
+            // would otherwise hammer Front Desk. Delay outside the lock so the
+            // poll refresh isn't stalled behind the backoff.
+            if (loadMoreFailures > 0) delay(loadMoreBackoffMillis(loadMoreFailures))
             fetchMutex.withLock {
                 val before = _state.value
                 val limit = (before.events.size + EVENTS_PAGE).coerceAtMost(MAX_EVENTS_WINDOW)
                 val result = client.events(fdUrl, token, eventsQuery(before, limit))
+                when (result) {
+                    is FetchResult.Success -> loadMoreFailures = 0
+                    is FetchResult.Failure -> loadMoreFailures++
+                    FetchResult.Unauthorized -> Unit
+                }
                 _state.update { st ->
                     if (st.range != before.range || st.custom != before.custom) {
                         return@update st.copy(loadingMore = false)

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailViewModel.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailViewModel.kt
@@ -10,6 +10,8 @@ import com.hugalafutro.bellhop.data.FetchResult
 import com.hugalafutro.bellhop.data.FrontDeskClient
 import com.hugalafutro.bellhop.data.LinkStore
 import com.hugalafutro.bellhop.data.MemberTraffic
+import com.hugalafutro.bellhop.ui.common.CustomDateRange
+import com.hugalafutro.bellhop.ui.common.EventRange
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
@@ -21,6 +23,9 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.time.Instant
 
 /**
  * MemberDetailUiState is what the member-detail traffic card renders. A failed
@@ -32,15 +37,29 @@ data class MemberDetailUiState(
     val loading: Boolean = true,
     val traffic: MemberTraffic? = null,
     // The member's own recent events (newest first), from GET /api/events filtered
-    // to this member. Read-only and unpaged: the full log with filters lives on
-    // the Events screen; here it's just "what happened to this box lately".
+    // to this member. Time-filterable (preset or calendar range) and paged:
+    // bottoming out the list grows the window ([MemberDetailViewModel.loadMore]).
     val events: List<FdEvent> = emptyList(),
+    // Total matching rows server-side; drives [canLoadMore].
+    val eventsTotal: Int = 0,
+    val range: EventRange = EventRange.ALL,
+    // Absolute calendar range from the picker; non-null overrides [range].
+    val custom: CustomDateRange? = null,
+    val loadingMore: Boolean = false,
+    // When a sync last actually wrote config to any member (from
+    // GET /api/fleet/autosync); "" until one has. Shown under the fleet-sync
+    // action on the primary.
+    val lastFleetSyncAt: String = "",
     val error: String? = null,
     val revoked: Boolean = false,
     // Operator-action overlay (drain/activate, config sync). Orthogonal to the
     // read state above, which keeps polling regardless.
     val action: ActionUiState = ActionUiState(),
-)
+) {
+    // More rows exist server-side and the drift-proof window can still grow.
+    val canLoadMore: Boolean
+        get() = events.size < eventsTotal && events.size < MemberDetailViewModel.MAX_EVENTS_WINDOW
+}
 
 /**
  * ActionUiState is the operator-action overlay on the detail screen. [inProgress]
@@ -82,6 +101,8 @@ class MemberDetailViewModel(
     private val fdUrl: String,
     private val memberId: String,
     private val pollIntervalMs: Long = POLL_INTERVAL_MS,
+    // Injectable clock so tests can pin the preset-range "since" bound.
+    private val now: () -> Long = System::currentTimeMillis,
 ) : ViewModel() {
     private val _state = MutableStateFlow(MemberDetailUiState())
     val state: StateFlow<MemberDetailUiState> = _state.asStateFlow()
@@ -92,6 +113,10 @@ class MemberDetailViewModel(
     // left to reconcile and a pending hint would strand (member.state won't change
     // again to re-fire the reconcile effect).
     private var lastLiveState: String? = null
+
+    // Serializes the poll refresh, filter-change reloads and loadMore so two
+    // window fetches can't interleave and fold out of order.
+    private val fetchMutex = Mutex()
 
     init {
         viewModelScope.launch {
@@ -117,10 +142,14 @@ class MemberDetailViewModel(
     }
 
     /**
-     * refreshOnce fetches this member's traffic and its recent events together
-     * (they don't depend on each other) and folds both in. Either 401 means the
-     * token is dead, so revoked wins; a failure on either keeps the last-good
-     * slice and raises the error; both succeeding clears it.
+     * refreshOnce fetches this member's traffic, its recent events and the
+     * fleet's autosync status (for the last-actual-sync stamp) together (none
+     * depend on each other) and folds them in. The events fetch reloads the
+     * whole already-paged window at offset 0 (the same drift-proof shape the
+     * Events screen uses) so a poll can't shear a grown list. A 401 on the
+     * member reads means the token is dead, so revoked wins; a failure keeps
+     * the last-good slice and raises the error. The autosync read is
+     * best-effort garnish: its failure never degrades the screen.
      */
     suspend fun refreshOnce() {
         val token = linkStore.token()
@@ -131,34 +160,123 @@ class MemberDetailViewModel(
             _state.update { it.copy(loading = false, revoked = true) }
             return
         }
-        val (traffic, events) =
-            coroutineScope {
-                val t = async { client.memberTraffic(fdUrl, token, memberId) }
-                val e = async { client.events(fdUrl, token, EventQuery(memberId = memberId, limit = EVENTS_LIMIT)) }
-                t.await() to e.await()
+        fetchMutex.withLock {
+            val before = _state.value
+            val query = eventsQuery(before, limit = before.events.size.coerceIn(EVENTS_PAGE, MAX_EVENTS_WINDOW))
+            val (traffic, events, autoSync) =
+                coroutineScope {
+                    val t = async { client.memberTraffic(fdUrl, token, memberId) }
+                    val e = async { client.events(fdUrl, token, query) }
+                    val a = async { client.autoSync(fdUrl, token) }
+                    Triple(t.await(), e.await(), a.await())
+                }
+            if (traffic is FetchResult.Unauthorized || events is FetchResult.Unauthorized) {
+                _state.update { it.copy(loading = false, revoked = true) }
+                return
             }
-        if (traffic is FetchResult.Unauthorized || events is FetchResult.Unauthorized) {
-            _state.update { it.copy(loading = false, revoked = true) }
-            return
-        }
-        _state.update { st ->
-            val failure =
-                (traffic as? FetchResult.Failure)?.message
-                    ?: (events as? FetchResult.Failure)?.message
-            st.copy(
-                loading = false,
-                traffic = (traffic as? FetchResult.Success)?.data ?: st.traffic,
-                events =
-                    (events as? FetchResult.Success)?.data?.events.orEmpty().ifEmpty {
-                        // Keep the last-good list only when the events fetch itself
-                        // failed; a genuine empty page (success) must clear it.
-                        if (events is FetchResult.Success) emptyList() else st.events
-                    },
-                error = failure,
-                revoked = false,
-            )
+            _state.update { st ->
+                val failure =
+                    (traffic as? FetchResult.Failure)?.message
+                        ?: (events as? FetchResult.Failure)?.message
+                // A filter that changed while this fetch was in flight makes the
+                // events slice stale; keep whatever the newer reload produced.
+                val filtersLive = st.range == before.range && st.custom == before.custom
+                val eventsPage = (events as? FetchResult.Success)?.data
+                st.copy(
+                    loading = false,
+                    traffic = (traffic as? FetchResult.Success)?.data ?: st.traffic,
+                    events =
+                        if (filtersLive && eventsPage != null) {
+                            eventsPage.events.orEmpty()
+                        } else {
+                            st.events
+                        },
+                    eventsTotal =
+                        if (filtersLive && eventsPage != null) eventsPage.total else st.eventsTotal,
+                    lastFleetSyncAt =
+                        (autoSync as? FetchResult.Success)?.data?.lastSyncAt ?: st.lastFleetSyncAt,
+                    error = failure,
+                    revoked = false,
+                )
+            }
         }
     }
+
+    /** setRange swaps the time-range preset (clearing any calendar range) and reloads. */
+    fun setRange(range: EventRange) {
+        val s = _state.value
+        if (range == s.range && s.custom == null) return
+        _state.update {
+            it.copy(range = range, custom = null, loading = true, events = emptyList(), eventsTotal = 0)
+        }
+        viewModelScope.launch { refreshOnce() }
+    }
+
+    /** setCustomRange swaps the calendar range (null falls back to the preset) and reloads. */
+    fun setCustomRange(range: CustomDateRange?) {
+        if (range == _state.value.custom) return
+        _state.update {
+            it.copy(custom = range, loading = true, events = emptyList(), eventsTotal = 0)
+        }
+        viewModelScope.launch { refreshOnce() }
+    }
+
+    /**
+     * loadMore grows the events window by one page when the list bottoms out
+     * (the screen's infinite scroll). Same drift-proof shape as the Events
+     * screen: re-request offset 0 with a bigger limit instead of paging by
+     * offset, so a new event arriving mid-scroll can't duplicate or skip rows.
+     */
+    fun loadMore() {
+        val s = _state.value
+        if (s.loadingMore || s.loading || s.revoked || !s.canLoadMore) return
+        _state.update { it.copy(loadingMore = true) }
+        viewModelScope.launch {
+            val token = linkStore.token()
+            if (token == null) {
+                _state.update { it.copy(loadingMore = false, revoked = true) }
+                return@launch
+            }
+            fetchMutex.withLock {
+                val before = _state.value
+                val limit = (before.events.size + EVENTS_PAGE).coerceAtMost(MAX_EVENTS_WINDOW)
+                val result = client.events(fdUrl, token, eventsQuery(before, limit))
+                _state.update { st ->
+                    if (st.range != before.range || st.custom != before.custom) {
+                        return@update st.copy(loadingMore = false)
+                    }
+                    when (result) {
+                        is FetchResult.Success ->
+                            st.copy(
+                                loadingMore = false,
+                                events = result.data.events.orEmpty(),
+                                eventsTotal = result.data.total,
+                            )
+                        FetchResult.Unauthorized -> st.copy(loadingMore = false, revoked = true)
+                        is FetchResult.Failure -> st.copy(loadingMore = false, error = result.message)
+                    }
+                }
+            }
+        }
+    }
+
+    // eventsQuery builds this member's events query for the current filters:
+    // the calendar range wins over a preset; ALL means no time bounds.
+    private fun eventsQuery(
+        st: MemberDetailUiState,
+        limit: Int,
+    ): EventQuery =
+        EventQuery(
+            memberId = memberId,
+            since =
+                when {
+                    st.custom != null -> st.custom.sinceRfc3339()
+                    st.range.ms > 0 -> Instant.ofEpochMilli(now() - st.range.ms).toString()
+                    else -> ""
+                },
+            until = st.custom?.untilRfc3339() ?: "",
+            limit = limit,
+        )
 
     /**
      * setMemberState drains or activates this member. Pessimistic-accept,
@@ -289,8 +407,12 @@ class MemberDetailViewModel(
         // current bucket moving without hammering the member's stats API.
         const val POLL_INTERVAL_MS = 60_000L
 
-        // Recent events shown under the graph. Enough to see the member's recent
-        // story; the Events screen owns the full, filterable, paged log.
-        const val EVENTS_LIMIT = 25
+        // One page of recent events under the graph; infinite scroll grows the
+        // window a page at a time.
+        const val EVENTS_PAGE = 25
+
+        // Ceiling on the drift-proof reload window, mirroring the Events
+        // screen (and the server's own clamp).
+        const val MAX_EVENTS_WINDOW = 500
     }
 }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -39,9 +39,10 @@
     <string name="member_detail_traffic_empty">No requests in this window.</string>
     <string name="member_detail_events_title">Recent events</string>
     <string name="member_detail_no_events">No recent events for this member.</string>
-    <string name="member_detail_synced">Config synced %1$s</string>
-    <string name="member_detail_verified">Verified in sync %1$s</string>
-    <string name="member_detail_created">Added %1$s</string>
+    <string name="member_detail_label_address">Address</string>
+    <string name="member_detail_label_synced">Synced</string>
+    <string name="member_detail_label_verified">In sync</string>
+    <string name="member_detail_label_added">Added</string>
     <string name="member_url_title">Open member address</string>
     <string name="member_url_open">Open</string>
     <!-- Operator actions -->
@@ -55,6 +56,7 @@
     <string name="member_op_sync_failed">Sync finished with %1$d of %2$d members failing.</string>
     <string name="member_op_error">Couldn\'t apply: %1$s</string>
     <string name="member_op_dismiss">Dismiss</string>
+    <string name="member_op_last_sync">Fleet last synced %1$s</string>
     <string name="member_op_busy">Another action is still running. Wait for it to finish, then try again.</string>
     <string name="member_op_forbidden">This device is paired as a monitor and can\'t change the fleet. Re-pair with an operator code in Front Desk to drain, activate, or sync.</string>
 
@@ -89,6 +91,9 @@
     <string name="events_range_24h">24h</string>
     <string name="events_range_7d">7d</string>
     <string name="events_range_30d">30d</string>
+    <string name="events_range_calendar">Pick a date range</string>
+    <string name="events_range_clear">Clear the date range</string>
+    <string name="events_range_apply">Apply</string>
 
     <!-- Alerts -->
     <string name="alerts_title">Alerts</string>

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/FrontDeskClientTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/FrontDeskClientTest.kt
@@ -313,6 +313,13 @@ class FrontDeskClientTest {
                 ),
             ),
         )
+        // The calendar range's upper bound rides along as until.
+        assertEquals(
+            "?since=2026-07-01T00%3A00%3A00Z&until=2026-07-15T00%3A00%3A00Z",
+            FrontDeskClient.eventQueryString(
+                EventQuery(since = "2026-07-01T00:00:00Z", until = "2026-07-15T00:00:00Z"),
+            ),
+        )
     }
 
     @Test

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/common/LoadMoreBackoffTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/common/LoadMoreBackoffTest.kt
@@ -1,0 +1,27 @@
+package com.hugalafutro.bellhop.ui.common
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class LoadMoreBackoffTest {
+    @Test
+    fun `no failures means no delay`() {
+        assertEquals(0L, loadMoreBackoffMillis(0))
+        assertEquals(0L, loadMoreBackoffMillis(-1))
+    }
+
+    @Test
+    fun `failures back off exponentially from one second`() {
+        assertEquals(1_000L, loadMoreBackoffMillis(1))
+        assertEquals(2_000L, loadMoreBackoffMillis(2))
+        assertEquals(4_000L, loadMoreBackoffMillis(3))
+        assertEquals(8_000L, loadMoreBackoffMillis(4))
+        assertEquals(16_000L, loadMoreBackoffMillis(5))
+    }
+
+    @Test
+    fun `backoff is capped at thirty seconds`() {
+        assertEquals(30_000L, loadMoreBackoffMillis(6))
+        assertEquals(30_000L, loadMoreBackoffMillis(50))
+    }
+}

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/events/EventsScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/events/EventsScreenTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollToNode
 import com.hugalafutro.bellhop.data.FdEvent
+import com.hugalafutro.bellhop.ui.common.EventRange
 import com.hugalafutro.bellhop.ui.theme.BellhopTheme
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/events/EventsViewModelTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/events/EventsViewModelTest.kt
@@ -9,6 +9,8 @@ import com.hugalafutro.bellhop.data.FrontDeskClient
 import com.hugalafutro.bellhop.data.InMemoryPreferencesDataStore
 import com.hugalafutro.bellhop.data.LinkStore
 import com.hugalafutro.bellhop.data.PairedDevice
+import com.hugalafutro.bellhop.ui.common.CustomDateRange
+import com.hugalafutro.bellhop.ui.common.EventRange
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
@@ -302,6 +304,28 @@ class EventsViewModelTest {
             val expected = Instant.ofEpochMilli(nowMs - EventRange.H1.ms).toString()
             withTimeout(5_000) { vm.state.first { !it.loading && it.range == EventRange.H1 } }
             assertEquals(expected, client.lastQuery!!.since)
+            collector.cancel()
+        }
+
+    @Test
+    fun customRangeOverridesPresetAndClears() =
+        runBlocking {
+            val client = FakeEventsClient(page("e1", total = 1))
+            val vm = newVm(client, linkedStore())
+            val collector = launch(start = CoroutineStart.UNDISPATCHED) { vm.state.collect {} }
+            withTimeout(5_000) { vm.state.first { !it.loading } }
+
+            // The calendar range carries both bounds (end day inclusive).
+            val range = CustomDateRange(startMs = 1_751_328_000_000L, endMs = 1_752_451_200_000L)
+            vm.setCustomRange(range)
+            withTimeout(5_000) { vm.state.first { !it.loading && it.custom == range } }
+            assertEquals(range.sinceRfc3339(), client.lastQuery!!.since)
+            assertEquals(range.untilRfc3339(), client.lastQuery!!.until)
+
+            // Picking a preset clears the calendar range again.
+            vm.setRange(EventRange.ALL)
+            withTimeout(5_000) { vm.state.first { !it.loading && it.custom == null } }
+            assertEquals("", client.lastQuery!!.until)
             collector.cancel()
         }
 

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreenTest.kt
@@ -442,6 +442,163 @@ class MemberDetailScreenTest {
     }
 
     @Test
+    fun addressRowOpensConfirmDialog() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                MemberDetailScreen(
+                    member = member,
+                    isPrimary = false,
+                    onBack = {},
+                    ui = MemberDetailUiState(loading = false, traffic = reachableTraffic),
+                )
+            }
+        }
+        composeTestRule
+            .onNodeWithTag("member-detail-list")
+            .performScrollToNode(hasTestTag("member-detail-url"))
+        composeTestRule.onNodeWithTag("member-detail-url").performClick()
+        // Same confirm dialog as the dashboard card: tap never fires an intent
+        // directly.
+        composeTestRule.onNodeWithTag("member-url-dialog-text").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("member-url-open").assertIsDisplayed()
+    }
+
+    @Test
+    fun lastFleetSyncLineRendersUnderTheSyncButton() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                MemberDetailScreen(
+                    member = member,
+                    isPrimary = true,
+                    onBack = {},
+                    ui =
+                        MemberDetailUiState(
+                            loading = false,
+                            traffic = reachableTraffic,
+                            lastFleetSyncAt = "2026-07-13T22:59:49Z",
+                        ),
+                    canOperate = true,
+                )
+            }
+        }
+        composeTestRule
+            .onNodeWithTag("member-detail-list")
+            .performScrollToNode(hasTestTag("member-op-last-sync"))
+        composeTestRule.onNodeWithTag("member-op-last-sync").assertIsDisplayed()
+    }
+
+    @Test
+    fun rangePillsRenderAndFireCallback() {
+        var picked: com.hugalafutro.bellhop.ui.common.EventRange? = null
+        composeTestRule.setContent {
+            BellhopTheme {
+                MemberDetailScreen(
+                    member = member,
+                    isPrimary = false,
+                    onBack = {},
+                    ui = MemberDetailUiState(loading = false, traffic = reachableTraffic),
+                    onRange = { picked = it },
+                )
+            }
+        }
+        composeTestRule
+            .onNodeWithTag("member-detail-list")
+            .performScrollToNode(hasTestTag("member-events-range-h24"))
+        composeTestRule.onNodeWithTag("member-events-range-h24").performClick()
+        assertTrue(picked == com.hugalafutro.bellhop.ui.common.EventRange.H24)
+    }
+
+    @Test
+    fun bottomingOutAsksForMoreEvents() {
+        // Scrolling to the end composes the load-more sentinel (lazy items only
+        // compose near the viewport), which asks for the next page; the
+        // ViewModel is the one that no-ops when nothing more exists.
+        var asked = false
+        composeTestRule.setContent {
+            BellhopTheme {
+                MemberDetailScreen(
+                    member = member,
+                    isPrimary = false,
+                    onBack = {},
+                    ui =
+                        MemberDetailUiState(
+                            loading = false,
+                            traffic = reachableTraffic,
+                            events =
+                                listOf(
+                                    FdEvent(id = "e1", severity = "info", message = "up", memberId = "m1"),
+                                ),
+                            // More rows exist server-side, so the sentinel arms.
+                            eventsTotal = 10,
+                        ),
+                    onLoadMoreEvents = { asked = true },
+                )
+            }
+        }
+        composeTestRule
+            .onNodeWithTag("member-detail-list")
+            .performScrollToNode(hasTestTag("member-events-load-more-sentinel"))
+        composeTestRule.waitUntil(timeoutMillis = 5_000) { asked }
+        assertTrue(asked)
+    }
+
+    @Test
+    fun exhaustedWindowDoesNotAskForMore() {
+        // events.size == eventsTotal: no sentinel, no phantom page requests.
+        var asked = false
+        composeTestRule.setContent {
+            BellhopTheme {
+                MemberDetailScreen(
+                    member = member,
+                    isPrimary = false,
+                    onBack = {},
+                    ui =
+                        MemberDetailUiState(
+                            loading = false,
+                            traffic = reachableTraffic,
+                            events =
+                                listOf(
+                                    FdEvent(id = "e1", severity = "info", message = "up", memberId = "m1"),
+                                ),
+                            eventsTotal = 1,
+                        ),
+                    onLoadMoreEvents = { asked = true },
+                )
+            }
+        }
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag("member-events-load-more-sentinel").assertDoesNotExist()
+        assertFalse(asked)
+    }
+
+    @Test
+    fun loadingMoreShowsFooterSpinner() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                MemberDetailScreen(
+                    member = member,
+                    isPrimary = false,
+                    onBack = {},
+                    ui =
+                        MemberDetailUiState(
+                            loading = false,
+                            traffic = reachableTraffic,
+                            events =
+                                listOf(
+                                    FdEvent(id = "e1", severity = "info", message = "up", memberId = "m1"),
+                                ),
+                            loadingMore = true,
+                        ),
+                )
+            }
+        }
+        composeTestRule
+            .onNodeWithTag("member-detail-list")
+            .performScrollToNode(hasTestTag("member-events-loading-more"))
+        composeTestRule.onNodeWithTag("member-events-loading-more").assertIsDisplayed()
+    }
+
+    @Test
     fun syncSummaryRendersTheTally() {
         composeTestRule.setContent {
             BellhopTheme {

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreenTest.kt
@@ -13,6 +13,7 @@ import com.hugalafutro.bellhop.data.HealthStatus
 import com.hugalafutro.bellhop.data.MemberStatus
 import com.hugalafutro.bellhop.data.MemberTraffic
 import com.hugalafutro.bellhop.data.TrafficPoint
+import com.hugalafutro.bellhop.ui.common.EventRange
 import com.hugalafutro.bellhop.ui.theme.BellhopTheme
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -489,7 +490,7 @@ class MemberDetailScreenTest {
 
     @Test
     fun rangePillsRenderAndFireCallback() {
-        var picked: com.hugalafutro.bellhop.ui.common.EventRange? = null
+        var picked: EventRange? = null
         composeTestRule.setContent {
             BellhopTheme {
                 MemberDetailScreen(
@@ -505,7 +506,7 @@ class MemberDetailScreenTest {
             .onNodeWithTag("member-detail-list")
             .performScrollToNode(hasTestTag("member-events-range-h24"))
         composeTestRule.onNodeWithTag("member-events-range-h24").performClick()
-        assertTrue(picked == com.hugalafutro.bellhop.ui.common.EventRange.H24)
+        assertTrue(picked == EventRange.H24)
     }
 
     @Test

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailViewModelTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.hugalafutro.bellhop.ui.member
 
 import com.hugalafutro.bellhop.data.ActionResult
+import com.hugalafutro.bellhop.data.AutoSyncConfig
 import com.hugalafutro.bellhop.data.EventQuery
 import com.hugalafutro.bellhop.data.EventsResponse
 import com.hugalafutro.bellhop.data.FakeCipher
@@ -15,6 +16,8 @@ import com.hugalafutro.bellhop.data.PairedDevice
 import com.hugalafutro.bellhop.data.SyncResponse
 import com.hugalafutro.bellhop.data.SyncResultItem
 import com.hugalafutro.bellhop.data.TrafficPoint
+import com.hugalafutro.bellhop.ui.common.CustomDateRange
+import com.hugalafutro.bellhop.ui.common.EventRange
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -51,6 +54,7 @@ private class FakeTrafficClient(
     var lastToken: String? = null
     var lastMemberId: String? = null
     var lastEventQuery: EventQuery? = null
+    var autoSyncResult: FetchResult<AutoSyncConfig> = FetchResult.Success(AutoSyncConfig())
 
     // Operator-action stubs: what setMemberState/syncFleet return, and what the
     // ViewModel last sent, so the action tests can assert both directions.
@@ -82,6 +86,11 @@ private class FakeTrafficClient(
         lastEventQuery = query
         return eventsResult
     }
+
+    override suspend fun autoSync(
+        fdUrl: String,
+        token: String,
+    ): FetchResult<AutoSyncConfig> = autoSyncResult
 
     override suspend fun setMemberState(
         fdUrl: String,
@@ -189,7 +198,87 @@ class MemberDetailViewModelTest {
             // The events read is scoped to this member so the detail shows only
             // its own history, not the whole fleet's log.
             assertEquals("m1", client.lastEventQuery?.memberId)
-            assertEquals(MemberDetailViewModel.EVENTS_LIMIT, client.lastEventQuery?.limit)
+            assertEquals(MemberDetailViewModel.EVENTS_PAGE, client.lastEventQuery?.limit)
+        }
+
+    @Test
+    fun rangePresetBoundsTheEventsQuery() =
+        runBlocking {
+            val client = FakeTrafficClient(FetchResult.Success(traffic))
+            val nowMs = 1_752_500_000_000L
+            val vm =
+                MemberDetailViewModel(client, linkedStore(), "http://fd:1", "m1", now = { nowMs })
+
+            vm.setRange(EventRange.H24)
+
+            assertEquals(EventRange.H24, vm.state.value.range)
+            assertEquals(
+                java.time.Instant.ofEpochMilli(nowMs - EventRange.H24.ms).toString(),
+                client.lastEventQuery?.since,
+            )
+            assertEquals("", client.lastEventQuery?.until)
+        }
+
+    @Test
+    fun customRangeWinsOverPresetAndSetsBothBounds() =
+        runBlocking {
+            val client = FakeTrafficClient(FetchResult.Success(traffic))
+            val vm = MemberDetailViewModel(client, linkedStore(), "http://fd:1", "m1")
+            val range = CustomDateRange(startMs = 1_752_000_000_000L, endMs = 1_752_400_000_000L)
+
+            vm.setCustomRange(range)
+
+            assertEquals(range, vm.state.value.custom)
+            assertEquals(range.sinceRfc3339(), client.lastEventQuery?.since)
+            assertEquals(range.untilRfc3339(), client.lastEventQuery?.until)
+        }
+
+    @Test
+    fun loadMoreGrowsTheWindowAndStopsAtTotal() =
+        runBlocking {
+            val page = (1..25).map { FdEvent(id = "e$it", severity = "info", message = "m", memberId = "m1") }
+            val client =
+                FakeTrafficClient(
+                    FetchResult.Success(traffic),
+                    eventsResult = FetchResult.Success(EventsResponse(events = page, total = 30)),
+                )
+            val vm = MemberDetailViewModel(client, linkedStore(), "http://fd:1", "m1")
+            vm.refreshOnce()
+            assertTrue(vm.state.value.canLoadMore)
+
+            // The grown window re-requests offset 0 with a bigger limit
+            // (drift-proof reload), and the response's total ends paging.
+            val grown = page + (26..30).map { FdEvent(id = "e$it", severity = "info", message = "m", memberId = "m1") }
+            client.eventsResult = FetchResult.Success(EventsResponse(events = grown, total = 30))
+            vm.loadMore()
+
+            val s = vm.state.value
+            assertEquals(50, client.lastEventQuery?.limit)
+            assertEquals(0, client.lastEventQuery?.offset)
+            assertEquals(30, s.events.size)
+            assertFalse(s.loadingMore)
+            assertFalse(s.canLoadMore)
+        }
+
+    @Test
+    fun refreshCarriesLastFleetSyncStamp() =
+        runBlocking {
+            val client = FakeTrafficClient(FetchResult.Success(traffic))
+            client.autoSyncResult =
+                FetchResult.Success(
+                    AutoSyncConfig(enabled = true, primaryId = "m1", lastSyncAt = "2026-07-13T22:59:49Z"),
+                )
+            val vm = MemberDetailViewModel(client, linkedStore(), "http://fd:1", "m1")
+
+            vm.refreshOnce()
+            assertEquals("2026-07-13T22:59:49Z", vm.state.value.lastFleetSyncAt)
+
+            // A later autosync read failing must not blank the stamp (best-effort
+            // garnish, never a screen degradation).
+            client.autoSyncResult = FetchResult.Failure("boom")
+            vm.refreshOnce()
+            assertEquals("2026-07-13T22:59:49Z", vm.state.value.lastFleetSyncAt)
+            assertNull(vm.state.value.error)
         }
 
     @Test

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailViewModelTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailViewModelTest.kt
@@ -51,6 +51,7 @@ private class FakeTrafficClient(
         ),
 ) : FrontDeskClient() {
     val trafficCalls = AtomicInteger(0)
+    val eventsCalls = AtomicInteger(0)
     var lastToken: String? = null
     var lastMemberId: String? = null
     var lastEventQuery: EventQuery? = null
@@ -83,6 +84,7 @@ private class FakeTrafficClient(
         token: String,
         query: EventQuery,
     ): FetchResult<EventsResponse> {
+        eventsCalls.incrementAndGet()
         lastEventQuery = query
         return eventsResult
     }
@@ -258,6 +260,35 @@ class MemberDetailViewModelTest {
             assertEquals(30, s.events.size)
             assertFalse(s.loadingMore)
             assertFalse(s.canLoadMore)
+        }
+
+    @Test
+    fun loadMoreBacksOffAfterFailureInsteadOfHammering() =
+        runBlocking {
+            val page = (1..25).map { FdEvent(id = "e$it", severity = "info", message = "m", memberId = "m1") }
+            val client =
+                FakeTrafficClient(
+                    FetchResult.Success(traffic),
+                    eventsResult = FetchResult.Success(EventsResponse(events = page, total = 100)),
+                )
+            val vm = MemberDetailViewModel(client, linkedStore(), "http://fd:1", "m1")
+            vm.refreshOnce()
+            assertTrue(vm.state.value.canLoadMore)
+            val callsBeforeFailure = client.eventsCalls.get()
+
+            // First page fails: the first attempt has no backoff, so it hits the
+            // client once and surfaces the error while the window stays growable.
+            client.eventsResult = FetchResult.Failure("boom")
+            vm.loadMore()
+            assertEquals("boom", vm.state.value.error)
+            assertTrue(vm.state.value.canLoadMore)
+            assertEquals(callsBeforeFailure + 1, client.eventsCalls.get())
+
+            // The scroll sentinel re-fires loadMore the instant loadingMore
+            // clears; the backoff must park the retry on its delay rather than
+            // hammering the client a second time in the same tick.
+            vm.loadMore()
+            assertEquals(callsBeforeFailure + 1, client.eventsCalls.get())
         }
 
     @Test

--- a/internal/frontdesk/configsync.go
+++ b/internal/frontdesk/configsync.go
@@ -92,18 +92,24 @@ func (s *Server) configSync(w http.ResponseWriter, r *http.Request) {
 	if !decodeJSON(w, r, &req) {
 		return
 	}
-	primary, primaryToken, err := s.memberTokenOrErr(r.Context(), req.PrimaryID)
+	// Once the sync is requested it runs to completion detached from the
+	// client's connection: a caller with a short HTTP timeout (Bellhop, a
+	// proxy) hanging up would otherwise cancel r.Context() mid-run and abort
+	// member imports, event emits and sync stamps half-way, leaving no trace
+	// of the run at all.
+	ctx := context.WithoutCancel(r.Context())
+	primary, primaryToken, err := s.memberTokenOrErr(ctx, req.PrimaryID)
 	if err != nil {
 		writeError(w, err)
 		return
 	}
-	export, err := s.fetchMemberExport(r.Context(), primary, primaryToken)
+	export, err := s.fetchMemberExport(ctx, primary, primaryToken)
 	if err != nil {
 		http.Error(w, "could not read the primary's config", http.StatusBadGateway)
 		return
 	}
 
-	members, err := s.store.ListMembers(r.Context())
+	members, err := s.store.ListMembers(ctx)
 	if err != nil {
 		writeError(w, err)
 		return
@@ -114,7 +120,7 @@ func (s *Server) configSync(w http.ResponseWriter, r *http.Request) {
 	// ran the wizard cannot regress a member to the older config afterwards. The
 	// generation only increases on a rearm, so it is never older than one a prior
 	// auto-sync applied, and an equal generation still applies (not refused).
-	gen, err := s.store.AutoSyncGen(r.Context())
+	gen, err := s.store.AutoSyncGen(ctx)
 	if err != nil {
 		writeError(w, err)
 		return
@@ -125,7 +131,7 @@ func (s *Server) configSync(w http.ResponseWriter, r *http.Request) {
 		if m.ID == primary.ID || !m.HasToken {
 			continue // the source, and token-less members (flagged in preview), are skipped
 		}
-		token, ok, err := s.store.MemberToken(r.Context(), m.ID)
+		token, ok, err := s.store.MemberToken(ctx, m.ID)
 		if err != nil || !ok {
 			continue
 		}
@@ -133,13 +139,13 @@ func (s *Server) configSync(w http.ResponseWriter, r *http.Request) {
 		// change is snapshotted first (the same recoverability guarantee the
 		// auto-syncer gives), an already-converged member is reported without an
 		// import, and a member whose backup fails is left untouched and reported.
-		if item, proceed := s.prepareMemberSync(r.Context(), m, token, export); !proceed {
+		if item, proceed := s.prepareMemberSync(ctx, m, token, export); !proceed {
 			results = append(results, *item)
 			continue
 		}
-		results = append(results, s.applyMemberConfig(r.Context(), m, token, export, wizardSyncReason, true, gen))
+		results = append(results, s.applyMemberConfig(ctx, m, token, export, wizardSyncReason, true, gen))
 	}
-	s.recordFleetSyncRun(r.Context(), primary, results)
+	s.recordFleetSyncRun(ctx, primary, results)
 	writeJSON(w, http.StatusOK, map[string]any{"primary_id": primary.ID, "results": results})
 }
 

--- a/internal/frontdesk/configsync_test.go
+++ b/internal/frontdesk/configsync_test.go
@@ -1,6 +1,7 @@
 package frontdesk
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -445,5 +446,115 @@ func TestConfigSyncStampFailureFailsResult(t *testing.T) {
 	}
 	if sawSynced {
 		t.Error("a config.synced event must not fire when the stamp failed")
+	}
+}
+
+// A client that hangs up mid-run (Bellhop's HTTP timeout, an impatient reverse
+// proxy) must not abort a sync in flight: the run is detached from the request
+// context, so the import still applies, the config.synced event is recorded and
+// the member's last-sync stamp moves. Without the detach, the cancel aborted
+// all three, leaving no trace of the run at all. The primary's export stub
+// cancels the request context to simulate the disconnect at the earliest
+// mid-run moment, so everything after it runs under a cancelled parent.
+func TestConfigSyncSurvivesClientDisconnect(t *testing.T) {
+	srv, store := newTestServer(t)
+	replica := newStubConfigMember(t, "rtoken")
+
+	ctx, cancel := context.WithCancel(t.Context())
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer ptoken" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if r.Method == http.MethodGet && r.URL.Path == "/api/config/export" {
+			cancel() // the requester is gone; the sync must keep going
+			_, _ = w.Write([]byte(`{"schema_version":1,"app_version":"v-test","config":{"providers":[{"name":"openai","base_url":"https://o"}]}}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(primary.Close)
+
+	pm, _ := store.CreateMember(t.Context(), "primary", primary.URL, "ptoken")
+	rm, _ := store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/config/sync", strings.NewReader(`{"primary_id":"`+pm.ID+`"}`)).WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer "+testFrontdeskToken)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("sync = %d (%s), want 200 despite the disconnect", rec.Code, rec.Body.String())
+	}
+	if !replica.gotImport {
+		t.Fatal("the replica import must run to completion after the client disconnected")
+	}
+	members, err := store.ListMembers(t.Context())
+	if err != nil {
+		t.Fatalf("list members: %v", err)
+	}
+	for _, m := range members {
+		if m.ID == rm.ID && m.LastConfigSyncAt == nil {
+			t.Error("the replica's last-sync stamp must move even though the client hung up")
+		}
+	}
+	evs, _, err := store.ListEvents(t.Context(), EventFilter{})
+	if err != nil {
+		t.Fatalf("list events: %v", err)
+	}
+	var sawSynced bool
+	for _, e := range evs {
+		if e.Type == "config.synced" && e.MemberID == rm.ID {
+			sawSynced = true
+		}
+	}
+	if !sawSynced {
+		t.Error("expected a config.synced event despite the disconnect")
+	}
+}
+
+// The autosync status carries last_sync_at: when a sync (manual or automatic)
+// last actually wrote config to any member — the max of the per-member stamps,
+// not when a sync was last attempted. Empty until a sync really changes a
+// member; Bellhop renders it under its sync action.
+func TestAutoSyncStatusReportsLastSyncAt(t *testing.T) {
+	srv, store := newTestServer(t)
+	primary := newStubConfigMember(t, "ptoken")
+	replica := newStubConfigMember(t, "rtoken")
+
+	pm, _ := store.CreateMember(t.Context(), "primary", primary.srv.URL, "ptoken")
+	_, _ = store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken")
+
+	read := func() autoSyncStatus {
+		t.Helper()
+		rec := do(t, srv, http.MethodGet, "/api/fleet/autosync", "", true)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("autosync status = %d (%s)", rec.Code, rec.Body.String())
+		}
+		var got autoSyncStatus
+		if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+			t.Fatalf("decode status: %v", err)
+		}
+		return got
+	}
+
+	if got := read(); got.LastSyncAt != "" {
+		t.Fatalf("last_sync_at before any sync = %q, want empty", got.LastSyncAt)
+	}
+
+	if rec := do(t, srv, http.MethodPost, "/api/config/sync", `{"primary_id":"`+pm.ID+`"}`, true); rec.Code != http.StatusOK {
+		t.Fatalf("sync = %d (%s)", rec.Code, rec.Body.String())
+	}
+
+	got := read()
+	if got.LastSyncAt == "" {
+		t.Fatal("last_sync_at must be set after a sync wrote config")
+	}
+	at, err := time.Parse(time.RFC3339Nano, got.LastSyncAt)
+	if err != nil {
+		t.Fatalf("last_sync_at %q is not RFC3339: %v", got.LastSyncAt, err)
+	}
+	if time.Since(at) > time.Minute {
+		t.Errorf("last_sync_at %v is stale, want ~now", at)
 	}
 }

--- a/internal/frontdesk/server_settings.go
+++ b/internal/frontdesk/server_settings.go
@@ -133,6 +133,13 @@ func (s *Server) resolveAlertTarget(ctx context.Context, submitted string) (stri
 type autoSyncStatus struct {
 	AutoSyncConfig
 	Stale bool `json:"stale"`
+	// LastSyncAt is when any member's config was last actually written by a
+	// sync (manual wizard run or the automatic loop): the max of the members'
+	// last_config_sync_at stamps, which only move on a real write. Empty when
+	// no sync has ever changed a member. Bellhop shows this under its
+	// "Sync fleet from primary" action so the operator sees when the fleet
+	// truly last synced, not when a button was last pressed.
+	LastSyncAt string `json:"last_sync_at,omitempty"`
 }
 
 // autoSyncStatusNow reads the auto-sync config and last-sync marker and folds in
@@ -147,10 +154,24 @@ func (s *Server) autoSyncStatusNow(ctx context.Context) (autoSyncStatus, error) 
 	if err != nil {
 		return autoSyncStatus{}, err
 	}
-	return autoSyncStatus{
+	members, err := s.store.ListMembers(ctx)
+	if err != nil {
+		return autoSyncStatus{}, err
+	}
+	var lastSync time.Time
+	for _, m := range members {
+		if m.LastConfigSyncAt != nil && m.LastConfigSyncAt.After(lastSync) {
+			lastSync = *m.LastConfigSyncAt
+		}
+	}
+	status := autoSyncStatus{
 		AutoSyncConfig: cfg,
 		Stale:          autoSyncStale(cfg, state.LastRunAt, found, time.Now().UTC()),
-	}, nil
+	}
+	if !lastSync.IsZero() {
+		status.LastSyncAt = lastSync.UTC().Format(time.RFC3339Nano)
+	}
+	return status, nil
 }
 
 func (s *Server) getAutoSync(w http.ResponseWriter, r *http.Request) {
@@ -331,12 +352,10 @@ func (s *Server) putAutoSync(w http.ResponseWriter, r *http.Request) {
 	// steady-state watch. Disabling (or no primary) never kicks.
 	if status.Enabled && status.PrimaryID != "" {
 		kickCtx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), autoSyncKickTimeout)
-		s.bgWG.Add(1)
-		go func() {
-			defer s.bgWG.Done()
+		s.bgWG.Go(func() {
 			defer cancel()
 			s.forceAutoSyncNow(kickCtx)
-		}()
+		})
 	}
 	writeJSON(w, http.StatusOK, status)
 }


### PR DESCRIPTION
## What

Reworks the Bellhop member-detail screen and the surrounding event/sync plumbing.

- **De-pilled member detail**: ledger-style layout with flat `SectionHeader`
  dividers instead of stacked cards, sharing the event-row language with the
  Events screen.
- **Event range filters**: preset ranges (1h/24h/7d/30d/all) plus an absolute
  calendar range from a date picker, shared between the member-detail and
  Events screens (`EventRange` / `CustomDateRange` in `ui/common`).
- **Infinite scroll**: drift-proof windowed paging (re-request offset 0 with a
  bigger limit so an event arriving mid-scroll can't duplicate or skip rows),
  driven by a lazy sentinel that arms when the list bottoms out.
- **Honest fleet sync**: surfaces the real `last_sync_at` from
  `GET /api/fleet/autosync`, uses `context.WithoutCancel` for config sync, and
  a longer-lived sync client so a slow fleet sync isn't cut off.

## Review fixes (second commit)

- **Infinite-scroll retry backoff**: the sentinel re-arms the instant
  `loadingMore` clears, so a persistent fetch failure used to re-fire
  `loadMore` on every recomposition and hammer Front Desk. Both windows now
  count consecutive failures and back off exponentially (1s to 30s, shared
  `loadMoreBackoffMillis`), resetting on the first success. The delay runs
  outside the fetch mutex so the poll refresh is never stalled behind it.
- **Trailing divider**: the event-row divider now renders only between rows,
  not after the last one.
- **Comment fix**: the `CustomDateRange` doc claimed the server's upper bound
  was exclusive; `store_events` uses `created_at <= ?` (inclusive). Reworded to
  match, and it now explains why `untilRfc3339` still extends past midnight.
- **Test tidy**: `MemberDetailScreenTest` imports `EventRange` rather than
  fully-qualifying it.

## Testing

- `./gradlew testDebugUnitTest` green (full Android unit suite).
- `ktlintMainSourceSetCheck` / `ktlintTestSourceSetCheck` clean.
- New `LoadMoreBackoffTest` covers the backoff curve; new
  `loadMoreBacksOffAfterFailureInsteadOfHammering` proves the retry parks on
  its delay instead of re-hitting the client in the same tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)