### PR TITLE
feat(frontdesk): honest fleet-sync status and disconnect-proof config sync

### DIFF
--- a/internal/frontdesk/configsync.go
+++ b/internal/frontdesk/configsync.go
@@ -92,18 +92,24 @@ func (s *Server) configSync(w http.ResponseWriter, r *http.Request) {
 	if !decodeJSON(w, r, &req) {
 		return
 	}
-	primary, primaryToken, err := s.memberTokenOrErr(r.Context(), req.PrimaryID)
+	// Once the sync is requested it runs to completion detached from the
+	// client's connection: a caller with a short HTTP timeout (Bellhop, a
+	// proxy) hanging up would otherwise cancel r.Context() mid-run and abort
+	// member imports, event emits and sync stamps half-way, leaving no trace
+	// of the run at all.
+	ctx := context.WithoutCancel(r.Context())
+	primary, primaryToken, err := s.memberTokenOrErr(ctx, req.PrimaryID)
 	if err != nil {
 		writeError(w, err)
 		return
 	}
-	export, err := s.fetchMemberExport(r.Context(), primary, primaryToken)
+	export, err := s.fetchMemberExport(ctx, primary, primaryToken)
 	if err != nil {
 		http.Error(w, "could not read the primary's config", http.StatusBadGateway)
 		return
 	}
 
-	members, err := s.store.ListMembers(r.Context())
+	members, err := s.store.ListMembers(ctx)
 	if err != nil {
 		writeError(w, err)
 		return
@@ -114,7 +120,7 @@ func (s *Server) configSync(w http.ResponseWriter, r *http.Request) {
 	// ran the wizard cannot regress a member to the older config afterwards. The
 	// generation only increases on a rearm, so it is never older than one a prior
 	// auto-sync applied, and an equal generation still applies (not refused).
-	gen, err := s.store.AutoSyncGen(r.Context())
+	gen, err := s.store.AutoSyncGen(ctx)
 	if err != nil {
 		writeError(w, err)
 		return
@@ -125,7 +131,7 @@ func (s *Server) configSync(w http.ResponseWriter, r *http.Request) {
 		if m.ID == primary.ID || !m.HasToken {
 			continue // the source, and token-less members (flagged in preview), are skipped
 		}
-		token, ok, err := s.store.MemberToken(r.Context(), m.ID)
+		token, ok, err := s.store.MemberToken(ctx, m.ID)
 		if err != nil || !ok {
 			continue
 		}
@@ -133,13 +139,13 @@ func (s *Server) configSync(w http.ResponseWriter, r *http.Request) {
 		// change is snapshotted first (the same recoverability guarantee the
 		// auto-syncer gives), an already-converged member is reported without an
 		// import, and a member whose backup fails is left untouched and reported.
-		if item, proceed := s.prepareMemberSync(r.Context(), m, token, export); !proceed {
+		if item, proceed := s.prepareMemberSync(ctx, m, token, export); !proceed {
 			results = append(results, *item)
 			continue
 		}
-		results = append(results, s.applyMemberConfig(r.Context(), m, token, export, wizardSyncReason, true, gen))
+		results = append(results, s.applyMemberConfig(ctx, m, token, export, wizardSyncReason, true, gen))
 	}
-	s.recordFleetSyncRun(r.Context(), primary, results)
+	s.recordFleetSyncRun(ctx, primary, results)
 	writeJSON(w, http.StatusOK, map[string]any{"primary_id": primary.ID, "results": results})
 }
 

--- a/internal/frontdesk/configsync_test.go
+++ b/internal/frontdesk/configsync_test.go
@@ -1,6 +1,7 @@
 package frontdesk
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -445,5 +446,115 @@ func TestConfigSyncStampFailureFailsResult(t *testing.T) {
 	}
 	if sawSynced {
 		t.Error("a config.synced event must not fire when the stamp failed")
+	}
+}
+
+// A client that hangs up mid-run (Bellhop's HTTP timeout, an impatient reverse
+// proxy) must not abort a sync in flight: the run is detached from the request
+// context, so the import still applies, the config.synced event is recorded and
+// the member's last-sync stamp moves. Without the detach, the cancel aborted
+// all three, leaving no trace of the run at all. The primary's export stub
+// cancels the request context to simulate the disconnect at the earliest
+// mid-run moment, so everything after it runs under a cancelled parent.
+func TestConfigSyncSurvivesClientDisconnect(t *testing.T) {
+	srv, store := newTestServer(t)
+	replica := newStubConfigMember(t, "rtoken")
+
+	ctx, cancel := context.WithCancel(t.Context())
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer ptoken" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if r.Method == http.MethodGet && r.URL.Path == "/api/config/export" {
+			cancel() // the requester is gone; the sync must keep going
+			_, _ = w.Write([]byte(`{"schema_version":1,"app_version":"v-test","config":{"providers":[{"name":"openai","base_url":"https://o"}]}}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(primary.Close)
+
+	pm, _ := store.CreateMember(t.Context(), "primary", primary.URL, "ptoken")
+	rm, _ := store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/config/sync", strings.NewReader(`{"primary_id":"`+pm.ID+`"}`)).WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer "+testFrontdeskToken)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("sync = %d (%s), want 200 despite the disconnect", rec.Code, rec.Body.String())
+	}
+	if !replica.gotImport {
+		t.Fatal("the replica import must run to completion after the client disconnected")
+	}
+	members, err := store.ListMembers(t.Context())
+	if err != nil {
+		t.Fatalf("list members: %v", err)
+	}
+	for _, m := range members {
+		if m.ID == rm.ID && m.LastConfigSyncAt == nil {
+			t.Error("the replica's last-sync stamp must move even though the client hung up")
+		}
+	}
+	evs, _, err := store.ListEvents(t.Context(), EventFilter{})
+	if err != nil {
+		t.Fatalf("list events: %v", err)
+	}
+	var sawSynced bool
+	for _, e := range evs {
+		if e.Type == "config.synced" && e.MemberID == rm.ID {
+			sawSynced = true
+		}
+	}
+	if !sawSynced {
+		t.Error("expected a config.synced event despite the disconnect")
+	}
+}
+
+// The autosync status carries last_sync_at: when a sync (manual or automatic)
+// last actually wrote config to any member — the max of the per-member stamps,
+// not when a sync was last attempted. Empty until a sync really changes a
+// member; Bellhop renders it under its sync action.
+func TestAutoSyncStatusReportsLastSyncAt(t *testing.T) {
+	srv, store := newTestServer(t)
+	primary := newStubConfigMember(t, "ptoken")
+	replica := newStubConfigMember(t, "rtoken")
+
+	pm, _ := store.CreateMember(t.Context(), "primary", primary.srv.URL, "ptoken")
+	_, _ = store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken")
+
+	read := func() autoSyncStatus {
+		t.Helper()
+		rec := do(t, srv, http.MethodGet, "/api/fleet/autosync", "", true)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("autosync status = %d (%s)", rec.Code, rec.Body.String())
+		}
+		var got autoSyncStatus
+		if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+			t.Fatalf("decode status: %v", err)
+		}
+		return got
+	}
+
+	if got := read(); got.LastSyncAt != "" {
+		t.Fatalf("last_sync_at before any sync = %q, want empty", got.LastSyncAt)
+	}
+
+	if rec := do(t, srv, http.MethodPost, "/api/config/sync", `{"primary_id":"`+pm.ID+`"}`, true); rec.Code != http.StatusOK {
+		t.Fatalf("sync = %d (%s)", rec.Code, rec.Body.String())
+	}
+
+	got := read()
+	if got.LastSyncAt == "" {
+		t.Fatal("last_sync_at must be set after a sync wrote config")
+	}
+	at, err := time.Parse(time.RFC3339Nano, got.LastSyncAt)
+	if err != nil {
+		t.Fatalf("last_sync_at %q is not RFC3339: %v", got.LastSyncAt, err)
+	}
+	if time.Since(at) > time.Minute {
+		t.Errorf("last_sync_at %v is stale, want ~now", at)
 	}
 }

--- a/internal/frontdesk/server_settings.go
+++ b/internal/frontdesk/server_settings.go
@@ -133,6 +133,13 @@ func (s *Server) resolveAlertTarget(ctx context.Context, submitted string) (stri
 type autoSyncStatus struct {
 	AutoSyncConfig
 	Stale bool `json:"stale"`
+	// LastSyncAt is when any member's config was last actually written by a
+	// sync (manual wizard run or the automatic loop): the max of the members'
+	// last_config_sync_at stamps, which only move on a real write. Empty when
+	// no sync has ever changed a member. Bellhop shows this under its
+	// "Sync fleet from primary" action so the operator sees when the fleet
+	// truly last synced, not when a button was last pressed.
+	LastSyncAt string `json:"last_sync_at,omitempty"`
 }
 
 // autoSyncStatusNow reads the auto-sync config and last-sync marker and folds in
@@ -147,10 +154,24 @@ func (s *Server) autoSyncStatusNow(ctx context.Context) (autoSyncStatus, error) 
 	if err != nil {
 		return autoSyncStatus{}, err
 	}
-	return autoSyncStatus{
+	members, err := s.store.ListMembers(ctx)
+	if err != nil {
+		return autoSyncStatus{}, err
+	}
+	var lastSync time.Time
+	for _, m := range members {
+		if m.LastConfigSyncAt != nil && m.LastConfigSyncAt.After(lastSync) {
+			lastSync = *m.LastConfigSyncAt
+		}
+	}
+	status := autoSyncStatus{
 		AutoSyncConfig: cfg,
 		Stale:          autoSyncStale(cfg, state.LastRunAt, found, time.Now().UTC()),
-	}, nil
+	}
+	if !lastSync.IsZero() {
+		status.LastSyncAt = lastSync.UTC().Format(time.RFC3339Nano)
+	}
+	return status, nil
 }
 
 func (s *Server) getAutoSync(w http.ResponseWriter, r *http.Request) {

--- a/internal/frontdesk/server_settings.go
+++ b/internal/frontdesk/server_settings.go
@@ -154,22 +154,24 @@ func (s *Server) autoSyncStatusNow(ctx context.Context) (autoSyncStatus, error) 
 	if err != nil {
 		return autoSyncStatus{}, err
 	}
-	members, err := s.store.ListMembers(ctx)
-	if err != nil {
-		return autoSyncStatus{}, err
-	}
-	var lastSync time.Time
-	for _, m := range members {
-		if m.LastConfigSyncAt != nil && m.LastConfigSyncAt.After(lastSync) {
-			lastSync = *m.LastConfigSyncAt
-		}
-	}
 	status := autoSyncStatus{
 		AutoSyncConfig: cfg,
 		Stale:          autoSyncStale(cfg, state.LastRunAt, found, time.Now().UTC()),
 	}
-	if !lastSync.IsZero() {
-		status.LastSyncAt = lastSync.UTC().Format(time.RFC3339Nano)
+	// last_sync_at is best-effort garnish: the max of members' real-write
+	// stamps. A failed members read must not fail the status itself, or the
+	// PUT /api/fleet/autosync response would report a failure for a toggle that
+	// already persisted. Degrade to an empty stamp instead.
+	if members, err := s.store.ListMembers(ctx); err == nil {
+		var lastSync time.Time
+		for _, m := range members {
+			if m.LastConfigSyncAt != nil && m.LastConfigSyncAt.After(lastSync) {
+				lastSync = *m.LastConfigSyncAt
+			}
+		}
+		if !lastSync.IsZero() {
+			status.LastSyncAt = lastSync.UTC().Format(time.RFC3339Nano)
+		}
 	}
 	return status, nil
 }


### PR DESCRIPTION
## What

Backend half of the Bellhop member-detail work, split out so Front Desk can
deploy independently of the Android app (the app degrades gracefully until this
is live).

- **`last_sync_at` on `GET /api/fleet/autosync`** — the max of members'
  `last_config_sync_at`, so a client can show when a sync last actually wrote
  config instead of inferring it from the toggle.
- **Disconnect-proof config sync** — `configSync` now runs on
  `context.WithoutCancel`. A client hanging up mid-request (e.g. Bellhop's short
  read timeout) used to cancel the request context and abort the sync with zero
  trace (no event, no stamp). Covered by `TestConfigSyncSurvivesClientDisconnect`.
- **Longer-lived manual sync client** — the whole-fleet manual sync uses a
  client with a longer read timeout so a slow pass isn't cut off.
- Kept the auto-sync "sync now" kick on the explicit `Add`/`go`/`Done`
  wait-group form (dropped an unrelated `WaitGroup.Go` refactor).

## Testing

`go test ./internal/frontdesk/` — 216 passed. `go vet` + build clean.

## Companion PR

The Android member-detail redesign that consumes `last_sync_at` is in a
separate PR so it can be built and verified against a Front Desk that already
has this deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)