### PR TITLE
Bellhop event-list polish + sync/action initiator attribution

### DIFF
--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/events/EventsScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/events/EventsScreen.kt
@@ -238,7 +238,7 @@ private fun EventRow(
     // A log line, not a card: a colour-coded severity rail down the left edge and
     // a faint tint of the same colour, so severity reads at a glance without a
     // pill. The whole row taps to copy (the rail carries the severity test tag).
-    val accent = severityColors(event.severity).first
+    val (accent, typeColor) = severityColors(event.severity)
     Row(
         modifier =
             modifier
@@ -264,9 +264,13 @@ private fun EventRow(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
+                // Machine event type in mono + the severity colour, so the code
+                // token reads apart from the human message on the next line.
                 Text(
                     text = event.type,
                     style = MaterialTheme.typography.titleSmall,
+                    fontFamily = MonoFamily,
+                    color = typeColor,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier.weight(1f),

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreen.kt
@@ -333,13 +333,12 @@ private fun MetaLedger(
                 tag = "member-detail-synced",
             )
             if (member.lastConfigSyncReason.isNotBlank()) {
-                // Why the last sync ran, indented to the value column (label
-                // width + gap) so it hangs off the SYNCED entry.
-                Text(
-                    text = member.lastConfigSyncReason,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(start = 88.dp),
+                // Why the last sync ran, on its own ledger line under SYNCED so
+                // the label column reads REASON rather than a hanging sentence.
+                LedgerRow(
+                    label = stringResource(R.string.member_detail_label_reason),
+                    value = member.lastConfigSyncReason,
+                    tag = "member-detail-sync-reason",
                 )
             }
         }
@@ -625,7 +624,7 @@ private fun MemberEventRow(
     event: FdEvent,
     modifier: Modifier = Modifier,
 ) {
-    val accent = severityColors(event.severity).first
+    val (accent, typeColor) = severityColors(event.severity)
     Row(
         modifier =
             modifier
@@ -650,9 +649,13 @@ private fun MemberEventRow(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
+                // Machine event type in mono + the severity colour, so the code
+                // token reads apart from the human message on the next line.
                 Text(
                     text = event.type,
                     style = MaterialTheme.typography.titleSmall,
+                    fontFamily = MonoFamily,
+                    color = typeColor,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier.weight(1f),
@@ -670,6 +673,18 @@ private fun MemberEventRow(
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis,
             )
+            // The emitting subsystem (poller, autosync…) in muted mono, a third
+            // visual register below the coloured type and the plain message.
+            if (event.source.isNotBlank()) {
+                Text(
+                    text = event.source,
+                    style = MaterialTheme.typography.bodySmall,
+                    fontFamily = MonoFamily,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
         }
     }
 }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -41,6 +41,7 @@
     <string name="member_detail_no_events">No recent events for this member.</string>
     <string name="member_detail_label_address">Address</string>
     <string name="member_detail_label_synced">Synced</string>
+    <string name="member_detail_label_reason">Reason</string>
     <string name="member_detail_label_verified">In sync</string>
     <string name="member_detail_label_added">Added</string>
     <string name="member_url_title">Open member address</string>
@@ -51,7 +52,7 @@
     <string name="member_op_activate">Activate</string>
     <string name="member_op_draining">Draining… waiting for the fleet to catch up.</string>
     <string name="member_op_activating">Activating… waiting for the fleet to catch up.</string>
-    <string name="member_op_sync">Sync fleet from primary</string>
+    <string name="member_op_sync">Sync fleet config</string>
     <string name="member_op_synced">Synced %1$d members from the primary.</string>
     <string name="member_op_sync_failed">Sync finished with %1$d of %2$d members failing.</string>
     <string name="member_op_error">Couldn\'t apply: %1$s</string>

--- a/internal/frontdesk/configsync.go
+++ b/internal/frontdesk/configsync.go
@@ -31,11 +31,16 @@ const (
 	// stale push. It must match internal/api.fleetSourceGenHeader. An older member
 	// ignores it, so sending it is always safe.
 	fleetSourceGenHeader = "X-Fleet-Source-Gen"
-
-	// wizardSyncReason is stamped on a member's last-config-sync marker when the
-	// operator drives the sync through the wizard (vs the automatic loop).
-	wizardSyncReason = "manual sync from the wizard"
 )
+
+// manualSyncReason is stamped on a member's last-config-sync marker (and the
+// audit event) when an operator drives the sync (vs the automatic loop). It
+// names who triggered it — a paired device or the dashboard — so the Members
+// table and event log attribute the run instead of the old anonymous "from the
+// wizard" phrasing, which read wrongly for a phone-initiated sync.
+func manualSyncReason(actor string) string {
+	return "manual sync by " + actor
+}
 
 // syncResultItem is one member's outcome from a fleet sync action.
 type syncResultItem struct {
@@ -98,6 +103,10 @@ func (s *Server) configSync(w http.ResponseWriter, r *http.Request) {
 	// member imports, event emits and sync stamps half-way, leaving no trace
 	// of the run at all.
 	ctx := context.WithoutCancel(r.Context())
+	// Attribute the run to whoever authenticated it (a paired device or the
+	// dashboard). WithoutCancel keeps the context values, so the device is still
+	// resolvable off ctx. Stamped on each member and carried in the audit event.
+	reason := manualSyncReason(actorFromContext(ctx))
 	primary, primaryToken, err := s.memberTokenOrErr(ctx, req.PrimaryID)
 	if err != nil {
 		writeError(w, err)
@@ -143,7 +152,7 @@ func (s *Server) configSync(w http.ResponseWriter, r *http.Request) {
 			results = append(results, *item)
 			continue
 		}
-		results = append(results, s.applyMemberConfig(ctx, m, token, export, wizardSyncReason, true, gen))
+		results = append(results, s.applyMemberConfig(ctx, m, token, export, reason, true, gen))
 	}
 	s.recordFleetSyncRun(ctx, primary, results)
 	writeJSON(w, http.StatusOK, map[string]any{"primary_id": primary.ID, "results": results})
@@ -279,6 +288,9 @@ func (s *Server) applyMemberConfig(ctx context.Context, m *Member, token string,
 			s.emit(ctx, Event{
 				Type: "config.synced", Severity: "info", Source: "frontdesk",
 				Message: fmt.Sprintf("Config synced to %s", m.Name), MemberID: m.ID,
+				// reason carries who/why (e.g. "manual sync by Pixel (operator)" or
+				// "the primary's config changed"), so the event log attributes the run.
+				Metadata: map[string]any{"reason": reason},
 			})
 		}
 	} else {
@@ -287,6 +299,7 @@ func (s *Server) applyMemberConfig(ctx context.Context, m *Member, token string,
 		s.emit(ctx, Event{
 			Type: "config.sync_failed", Severity: "warning", Source: "frontdesk",
 			Message: fmt.Sprintf("Failed to sync config to %s", m.Name), MemberID: m.ID,
+			Metadata: map[string]any{"reason": reason},
 		})
 	}
 	return res

--- a/internal/frontdesk/configsync.go
+++ b/internal/frontdesk/configsync.go
@@ -148,7 +148,7 @@ func (s *Server) configSync(w http.ResponseWriter, r *http.Request) {
 		// change is snapshotted first (the same recoverability guarantee the
 		// auto-syncer gives), an already-converged member is reported without an
 		// import, and a member whose backup fails is left untouched and reported.
-		if item, proceed := s.prepareMemberSync(ctx, m, token, export); !proceed {
+		if item, proceed := s.prepareMemberSync(ctx, m, token, export, reason); !proceed {
 			results = append(results, *item)
 			continue
 		}
@@ -177,7 +177,7 @@ func (s *Server) configSync(w http.ResponseWriter, r *http.Request) {
 // dry-run and the real import gets overwritten without the snapshot this gate is
 // meant to guarantee. This mirrors the auto-syncer, which also skips converged
 // members outright.
-func (s *Server) prepareMemberSync(ctx context.Context, m *Member, token string, export []byte) (*syncResultItem, bool) {
+func (s *Server) prepareMemberSync(ctx context.Context, m *Member, token string, export []byte, reason string) (*syncResultItem, bool) {
 	preview, status, err := s.pushMemberImport(ctx, m, token, export, true, 0) // dry-run: gen unused (no fence header)
 	if err != nil || status != http.StatusOK || !preview.SchemaVersionOK || !preview.MasterKeyOK {
 		return nil, true // unreachable or blocked: let applyMemberConfig report the real cause
@@ -195,6 +195,7 @@ func (s *Server) prepareMemberSync(ctx context.Context, m *Member, token string,
 		s.emit(ctx, Event{
 			Type: "config.sync_failed", Severity: "warning", Source: "frontdesk",
 			Message: fmt.Sprintf("Skipped %s: pre-sync backup failed", m.Name), MemberID: m.ID,
+			Metadata: map[string]any{"reason": reason},
 		})
 		return &syncResultItem{MemberID: m.ID, Name: m.Name, Error: "pre-sync backup failed; this member was left unchanged"}, false
 	}

--- a/internal/frontdesk/configsync_test.go
+++ b/internal/frontdesk/configsync_test.go
@@ -270,10 +270,19 @@ func TestConfigSyncBackupFailureSkipsMember(t *testing.T) {
 		t.Error("the destructive import must be skipped when the backup fails")
 	}
 	evs, _, _ := store.ListEvents(t.Context(), EventFilter{})
+	var failReason any
 	for _, e := range evs {
 		if e.Type == "config.synced" && e.MemberID == rm.ID {
 			t.Error("a member left unchanged must not emit config.synced")
 		}
+		if e.Type == "config.sync_failed" && e.MemberID == rm.ID {
+			failReason = e.Metadata["reason"]
+		}
+	}
+	// The backup-failure skip is attributed like every other sync outcome, so the
+	// log distinguishes who triggered the run that could not back up.
+	if want := manualSyncReason("the dashboard"); failReason != want {
+		t.Errorf("config.sync_failed reason metadata = %v, want %q", failReason, want)
 	}
 }
 

--- a/internal/frontdesk/configsync_test.go
+++ b/internal/frontdesk/configsync_test.go
@@ -113,6 +113,67 @@ func TestConfigSyncApplies(t *testing.T) {
 	}
 }
 
+// TestConfigSyncAttributesInitiator proves a manual sync stamps who ran it on
+// both the member's sync-reason marker (surfaced in the Members table / member
+// detail) and the audit event's metadata, so the log can tell an admin-driven
+// run from a phone-driven one. An admin bearer carries no paired device, so it
+// is attributed to the dashboard.
+func TestConfigSyncAttributesInitiator(t *testing.T) {
+	srv, store := newTestServer(t)
+	primary := newStubConfigMember(t, "ptoken")
+	replica := newStubConfigMember(t, "rtoken")
+
+	pm, _ := store.CreateMember(t.Context(), "primary", primary.srv.URL, "ptoken")
+	rm, _ := store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken")
+
+	rec := do(t, srv, http.MethodPost, "/api/config/sync", `{"primary_id":"`+pm.ID+`"}`, true)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("sync = %d (%s)", rec.Code, rec.Body.String())
+	}
+
+	want := manualSyncReason("the dashboard")
+
+	got, err := store.GetMember(t.Context(), rm.ID)
+	if err != nil {
+		t.Fatalf("get member: %v", err)
+	}
+	if got.LastConfigSyncReason != want {
+		t.Errorf("member sync reason = %q, want %q", got.LastConfigSyncReason, want)
+	}
+
+	evs, _, err := store.ListEvents(t.Context(), EventFilter{})
+	if err != nil {
+		t.Fatalf("list events: %v", err)
+	}
+	var eventReason any
+	for _, e := range evs {
+		if e.Type == "config.synced" && e.MemberID == rm.ID {
+			eventReason = e.Metadata["reason"]
+		}
+	}
+	if eventReason != want {
+		t.Errorf("config.synced reason metadata = %v, want %q", eventReason, want)
+	}
+}
+
+// TestActorFromContext covers the three attribution branches: no device (admin
+// or dashboard session), a labelled device, and the defensive blank-label path.
+func TestActorFromContext(t *testing.T) {
+	if got := actorFromContext(t.Context()); got != "the dashboard" {
+		t.Errorf("no-device actor = %q, want %q", got, "the dashboard")
+	}
+
+	withDevice := context.WithValue(t.Context(), deviceCtxKey{}, &PairedDevice{Label: "Pixel", Role: RoleOperator})
+	if got := actorFromContext(withDevice); got != "Pixel (operator)" {
+		t.Errorf("device actor = %q, want %q", got, "Pixel (operator)")
+	}
+
+	blankLabel := context.WithValue(t.Context(), deviceCtxKey{}, &PairedDevice{Role: RoleMonitor})
+	if got := actorFromContext(blankLabel); got != "a paired device (monitor)" {
+		t.Errorf("blank-label actor = %q, want %q", got, "a paired device (monitor)")
+	}
+}
+
 // A slow import (the member runs model discovery on apply, which routinely
 // exceeds the fast health-probe timeout) must still be reported as applied: the
 // import relay uses a separate client with a far longer deadline. Here the probe

--- a/internal/frontdesk/server_devices.go
+++ b/internal/frontdesk/server_devices.go
@@ -159,6 +159,24 @@ func deviceFromContext(ctx context.Context) *PairedDevice {
 	return d
 }
 
+// actorFromContext names who initiated a control-plane mutation, for the audit
+// event log. A device token resolves to its pairing label and role (e.g.
+// "Pixel (operator)"); an admin token or dashboard session carries no device
+// and is recorded as "the dashboard". Kept human-readable because it is
+// surfaced verbatim in event metadata and the member sync-reason stamp, never
+// parsed. A blank label (shouldn't happen — pairing requires one) degrades to a
+// generic phrase rather than an empty parenthetical.
+func actorFromContext(ctx context.Context) string {
+	d := deviceFromContext(ctx)
+	if d == nil {
+		return "the dashboard"
+	}
+	if d.Label == "" {
+		return fmt.Sprintf("a paired device (%s)", d.Role)
+	}
+	return fmt.Sprintf("%s (%s)", d.Label, d.Role)
+}
+
 // requireAuth gates control-plane endpoints. The bearer is accepted when it is
 // (in order) a valid, unrevoked device token (role ceiling applied downstream
 // by requireOperator/requireAdmin), the raw FRONTDESK_TOKEN, or a

--- a/internal/frontdesk/server_members.go
+++ b/internal/frontdesk/server_members.go
@@ -270,7 +270,7 @@ func (s *Server) setMemberState(w http.ResponseWriter, r *http.Request) {
 	s.emit(r.Context(), Event{
 		Type: "member.state_changed", Severity: severity, Source: "frontdesk",
 		Message: m.Name + " set to " + string(req.State), MemberID: m.ID,
-		Metadata: map[string]any{"state": string(req.State)},
+		Metadata: map[string]any{"state": string(req.State), "initiated_by": actorFromContext(r.Context())},
 	})
 	writeJSON(w, http.StatusOK, m)
 }

--- a/internal/frontdesk/server_test.go
+++ b/internal/frontdesk/server_test.go
@@ -204,6 +204,20 @@ func TestServerMemberCRUD(t *testing.T) {
 		t.Fatalf("state = %d, want 200; body=%s", rec.Code, rec.Body.String())
 	}
 
+	// The state change is attributed in its audit event. An admin bearer carries
+	// no paired device, so it is recorded as the dashboard.
+	rec = do(t, srv, http.MethodGet, "/api/events?type=member.state_changed", "", true)
+	var stateEvents struct {
+		Events []Event `json:"events"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &stateEvents)
+	if len(stateEvents.Events) == 0 {
+		t.Fatal("expected a member.state_changed event")
+	}
+	if got := stateEvents.Events[0].Metadata["initiated_by"]; got != "the dashboard" {
+		t.Errorf("state_changed initiated_by = %v, want %q", got, "the dashboard")
+	}
+
 	// Delete.
 	if rec := do(t, srv, http.MethodDelete, "/api/members/"+created.ID, "", true); rec.Code != http.StatusNoContent {
 		t.Fatalf("delete = %d, want 204", rec.Code)


### PR DESCRIPTION
## What & why

Two related slices from testing Bellhop on-device.

### Bellhop UI polish
- **Rename the fleet-sync button** "Sync fleet from primary" → **"Sync fleet config"**. The old label leaked primary-only framing and confused; the button already only shows on the primary. Pure string change.
- **REASON row on member detail.** The config-sync reason was a sentence hanging indented under SYNCED; it's now its own `LedgerRow` (label reads REASON), which is exactly where the new attribution lands (below).
- **Event-list separation.** Both the events log and the member-detail event list now read in three registers: the machine `type` in monospace + the severity colour, the human `message` in plain body, and the emitting `source` in muted mono. Member-detail rows gained the source line for parity.

### Front Desk: attribute who initiated an action (no new endpoint)
The mutating control-plane handlers already had the authenticated device in context but discarded it, so the event log and the member sync-reason marker couldn't tell an admin-driven run from a phone-driven one. The manual-sync reason was a flat "manual sync from the wizard", which read wrongly for a Bellhop-initiated sync.

- `actorFromContext`: a device token resolves to its pairing label + role (e.g. `Pixel (operator)`); an admin/session bearer resolves to `the dashboard`.
- Manual syncs are stamped **"manual sync by \<actor\>"** on each member's `last_config_sync_reason` (surfaced in the new REASON row) and carried in `config.synced` / `config.sync_failed` event `Metadata["reason"]`.
- Drain/activate (`member.state_changed`) gained `Metadata["initiated_by"]`.

No new API surface or wire-format change — the existing device-auth context is the only new input.

## Where it shows
On the phone, the member-detail **REASON** row now reads e.g. *"manual sync by Pixel (operator)"* (via `last_config_sync_reason`, which Bellhop already renders). The richer `initiated_by` audit metadata is visible via the FD web dashboard / `GET /api/events`; Bellhop's `FdEvent` intentionally doesn't model event metadata, so the REASON row is the phone-side attribution.

## Tests
- `TestConfigSyncAttributesInitiator` — manual sync stamps the member marker + `config.synced` metadata.
- `TestActorFromContext` — all three branches (no device, labelled device, blank-label fallback).
- `TestServerMemberCRUD` — asserts `member.state_changed` carries `initiated_by`.

`go vet`, `golangci-lint`, and the affected frontdesk suite are green locally.

## Out of scope (follow-up)
Member/event list scroll stutter is dominated by the debug APK (no R8/baseline profile) — recommend testing a release build before any code perf work. The one remaining code lever (per-row `IntrinsicSize.Min` on the severity rail) is left intact here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)