### PR TITLE
perf(bellhop): drop per-row IntrinsicSize measure from event lists

### DIFF
--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/SeverityRailRow.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/SeverityRailRow.kt
@@ -1,0 +1,72 @@
+package com.hugalafutro.bellhop.ui.common
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+
+// Width of the coloured severity rail down the left edge of each log line.
+private val RAIL_WIDTH = 3.dp
+
+/**
+ * SeverityRailRow is the shared "log line" chrome for both event lists: a
+ * severity-coloured rail down the left edge plus a faint tint of the same
+ * colour, wrapping caller [content] (which receives the matching type colour).
+ *
+ * The rail is painted with drawBehind on a matchParentSize overlay instead of
+ * being a fillMaxHeight sibling. That removes the per-row height(IntrinsicSize.Min)
+ * measurement pass the old two-child Row needed — the double-measure that made
+ * long event lists stutter while flinging on device. The overlay still fills the
+ * row and carries [railTag], so the tests that assert / tap the rail keep working.
+ */
+@Composable
+fun SeverityRailRow(
+    severity: String,
+    rowTag: String,
+    railTag: String,
+    modifier: Modifier = Modifier,
+    onClick: (() -> Unit)? = null,
+    content: @Composable ColumnScope.(typeColor: Color) -> Unit,
+) {
+    val (accent, typeColor) = severityColors(severity)
+    Box(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier)
+                .background(accent.copy(alpha = 0.06f))
+                .testTag(rowTag),
+    ) {
+        // Full-row overlay that only paints the left rail. matchParentSize keeps it
+        // out of the Box's own sizing (so no intrinsic pass), yet gives the tests a
+        // displayed, tappable node at railTag. Taps fall through to the Box's
+        // clickable, exactly as the old sibling rail did.
+        Box(
+            modifier =
+                Modifier
+                    .matchParentSize()
+                    .drawBehind {
+                        drawRect(color = accent, size = Size(RAIL_WIDTH.toPx(), size.height))
+                    }
+                    .testTag(railTag),
+        )
+        // start clears the rail (was a 3.dp rail + 12.dp content padding = 15.dp).
+        Column(
+            modifier = Modifier.fillMaxWidth().padding(start = 15.dp, end = 12.dp, top = 10.dp, bottom = 10.dp),
+            verticalArrangement = Arrangement.spacedBy(3.dp),
+        ) {
+            content(typeColor)
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/events/EventsScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/events/EventsScreen.kt
@@ -1,21 +1,16 @@
 package com.hugalafutro.bellhop.ui.events
 
 import android.widget.Toast
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
@@ -46,8 +41,8 @@ import com.hugalafutro.bellhop.ui.common.CustomDateRange
 import com.hugalafutro.bellhop.ui.common.EventRange
 import com.hugalafutro.bellhop.ui.common.EventRangeRow
 import com.hugalafutro.bellhop.ui.common.FilterPill
+import com.hugalafutro.bellhop.ui.common.SeverityRailRow
 import com.hugalafutro.bellhop.ui.common.StatusBanner
-import com.hugalafutro.bellhop.ui.common.severityColors
 import com.hugalafutro.bellhop.ui.theme.BellhopTheme
 import com.hugalafutro.bellhop.ui.theme.MonoFamily
 import java.time.Instant
@@ -238,70 +233,54 @@ private fun EventRow(
     // A log line, not a card: a colour-coded severity rail down the left edge and
     // a faint tint of the same colour, so severity reads at a glance without a
     // pill. The whole row taps to copy (the rail carries the severity test tag).
-    val (accent, typeColor) = severityColors(event.severity)
-    Row(
-        modifier =
-            modifier
-                .fillMaxWidth()
-                .clickable(onClick = onCopy)
-                .background(accent.copy(alpha = 0.06f))
-                .height(IntrinsicSize.Min)
-                .testTag("event-card"),
-    ) {
-        Box(
-            modifier =
-                Modifier
-                    .width(3.dp)
-                    .fillMaxHeight()
-                    .background(accent)
-                    .testTag("event-sev-${event.severity}"),
-        )
-        Column(
-            modifier = Modifier.weight(1f).padding(horizontal = 12.dp, vertical = 10.dp),
-            verticalArrangement = Arrangement.spacedBy(3.dp),
+    SeverityRailRow(
+        severity = event.severity,
+        rowTag = "event-card",
+        railTag = "event-sev-${event.severity}",
+        modifier = modifier,
+        onClick = onCopy,
+    ) { typeColor ->
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                // Machine event type in mono + the severity colour, so the code
-                // token reads apart from the human message on the next line.
-                Text(
-                    text = event.type,
-                    style = MaterialTheme.typography.titleSmall,
-                    fontFamily = MonoFamily,
-                    color = typeColor,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.weight(1f),
-                )
-                // Time in the brand mono so the column aligns and reads as a metric.
-                Text(
-                    text = formatEventTime(event.createdAt),
-                    style = MaterialTheme.typography.labelSmall,
-                    fontFamily = MonoFamily,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
+            // Machine event type in mono + the severity colour, so the code
+            // token reads apart from the human message on the next line.
             Text(
-                text = event.message,
-                style = MaterialTheme.typography.bodyMedium,
+                text = event.type,
+                style = MaterialTheme.typography.titleSmall,
+                fontFamily = MonoFamily,
+                color = typeColor,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f),
             )
-            val who =
-                listOfNotNull(
-                    event.source.ifEmpty { null },
-                    memberName ?: event.memberId.ifEmpty { null },
-                ).joinToString(" · ")
-            if (who.isNotEmpty()) {
-                Text(
-                    text = who,
-                    style = MaterialTheme.typography.bodySmall,
-                    fontFamily = MonoFamily,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-            }
+            // Time in the brand mono so the column aligns and reads as a metric.
+            Text(
+                text = formatEventTime(event.createdAt),
+                style = MaterialTheme.typography.labelSmall,
+                fontFamily = MonoFamily,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Text(
+            text = event.message,
+            style = MaterialTheme.typography.bodyMedium,
+        )
+        val who =
+            listOfNotNull(
+                event.source.ifEmpty { null },
+                memberName ?: event.memberId.ifEmpty { null },
+            ).joinToString(" · ")
+        if (who.isNotEmpty()) {
+            Text(
+                text = who,
+                style = MaterialTheme.typography.bodySmall,
+                fontFamily = MonoFamily,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
         }
     }
 }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreen.kt
@@ -5,11 +5,9 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -60,10 +58,10 @@ import com.hugalafutro.bellhop.ui.common.CustomDateRange
 import com.hugalafutro.bellhop.ui.common.EventRange
 import com.hugalafutro.bellhop.ui.common.EventRangeRow
 import com.hugalafutro.bellhop.ui.common.Pill
+import com.hugalafutro.bellhop.ui.common.SeverityRailRow
 import com.hugalafutro.bellhop.ui.common.StatusBanner
 import com.hugalafutro.bellhop.ui.common.TrafficChart
 import com.hugalafutro.bellhop.ui.common.healthColor
-import com.hugalafutro.bellhop.ui.common.severityColors
 import com.hugalafutro.bellhop.ui.events.formatEventTime
 import com.hugalafutro.bellhop.ui.theme.BellhopTheme
 import com.hugalafutro.bellhop.ui.theme.MonoFamily
@@ -624,67 +622,51 @@ private fun MemberEventRow(
     event: FdEvent,
     modifier: Modifier = Modifier,
 ) {
-    val (accent, typeColor) = severityColors(event.severity)
-    Row(
-        modifier =
-            modifier
-                .fillMaxWidth()
-                .background(accent.copy(alpha = 0.06f))
-                .height(IntrinsicSize.Min)
-                .testTag("member-event-row"),
-    ) {
-        Box(
-            modifier =
-                Modifier
-                    .width(3.dp)
-                    .fillMaxHeight()
-                    .background(accent)
-                    .testTag("member-event-sev-${event.severity}"),
-        )
-        Column(
-            modifier = Modifier.weight(1f).padding(horizontal = 12.dp, vertical = 10.dp),
-            verticalArrangement = Arrangement.spacedBy(3.dp),
+    SeverityRailRow(
+        severity = event.severity,
+        rowTag = "member-event-row",
+        railTag = "member-event-sev-${event.severity}",
+        modifier = modifier,
+    ) { typeColor ->
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                // Machine event type in mono + the severity colour, so the code
-                // token reads apart from the human message on the next line.
-                Text(
-                    text = event.type,
-                    style = MaterialTheme.typography.titleSmall,
-                    fontFamily = MonoFamily,
-                    color = typeColor,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.weight(1f),
-                )
-                Text(
-                    text = formatEventTime(event.createdAt),
-                    style = MaterialTheme.typography.labelSmall,
-                    fontFamily = MonoFamily,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
+            // Machine event type in mono + the severity colour, so the code
+            // token reads apart from the human message on the next line.
             Text(
-                text = event.message,
-                style = MaterialTheme.typography.bodyMedium,
-                maxLines = 2,
+                text = event.type,
+                style = MaterialTheme.typography.titleSmall,
+                fontFamily = MonoFamily,
+                color = typeColor,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f),
+            )
+            Text(
+                text = formatEventTime(event.createdAt),
+                style = MaterialTheme.typography.labelSmall,
+                fontFamily = MonoFamily,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Text(
+            text = event.message,
+            style = MaterialTheme.typography.bodyMedium,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+        )
+        // The emitting subsystem (poller, autosync…) in muted mono, a third
+        // visual register below the coloured type and the plain message.
+        if (event.source.isNotBlank()) {
+            Text(
+                text = event.source,
+                style = MaterialTheme.typography.bodySmall,
+                fontFamily = MonoFamily,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
             )
-            // The emitting subsystem (poller, autosync…) in muted mono, a third
-            // visual register below the coloured type and the plain message.
-            if (event.source.isNotBlank()) {
-                Text(
-                    text = event.source,
-                    style = MaterialTheme.typography.bodySmall,
-                    fontFamily = MonoFamily,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-            }
         }
     }
 }


### PR DESCRIPTION
## What

Both Bellhop event lists (the Events screen and the member-detail feed) rendered each row as a `Row` with `height(IntrinsicSize.Min)` so a `fillMaxHeight` severity rail could match the row height. `IntrinsicSize` forces an extra measurement pass on every row, which showed up as visible fling stutter on long lists on device.

## Change

- New shared composable `ui/common/SeverityRailRow.kt` owns the log-line chrome (rail + faint tint + content column). The rail is now a `matchParentSize` overlay painted with `drawBehind` (a 3.dp strip), so each row measures **once** instead of twice.
- The overlay still fills the row and carries the `event-sev-*` / `member-event-sev-*` test tags, so the existing tap/assert tests pass unchanged.
- `EventsScreen` and `MemberDetailScreen` both call it and drop their now-unused imports (`IntrinsicSize`, `fillMaxHeight`, `width`, `background`, `clickable`, `severityColors` as applicable).
- Lists stay intentionally unkeyed (a duplicate id degrades to a double row, not a crash — documented at `EventsScreen.kt:164`).

## Testing

- `ktlintCheck` clean.
- `EventsScreenTest` + `MemberDetailScreenTest` green (rail display + tap-to-copy assertions unchanged).
- Verified on a debug-signed **release** (R8 + baseline profile) build on device: lists are smooth, no regression. The debug-build stutter was dominated by the missing R8/baseline profile; this removes the one remaining code-level measure cost on top.

🤖 Generated with [Claude Code](https://claude.ai/code)