### PR TITLE
feat(bellhop): copy gestures, recent-event pills, infinite scroll, and detail/settings polish

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -6,6 +6,26 @@ plugins {
     alias(libs.plugins.ktlint)
 }
 
+// gitCommit stamps the build with the short HEAD sha (plus a "-dirty" marker when
+// the tree has uncommitted changes), mirroring the Go binaries' `-X …buildCommit`
+// ldflag. Uses providers.exec so it stays compatible with the configuration cache;
+// falls back to "unknown" when git isn't available so a source-tarball build still
+// succeeds. The footer deep-links to this commit on GitHub.
+fun gitOutput(vararg args: String): String? =
+    try {
+        providers
+            .exec { commandLine("git", "-C", rootDir.absolutePath, *args) }
+            .standardOutput.asText.get().trim()
+    } catch (e: Exception) {
+        null
+    }
+
+fun gitCommit(): String {
+    val sha = gitOutput("rev-parse", "--short", "HEAD")?.takeIf { it.isNotEmpty() } ?: return "unknown"
+    val dirty = gitOutput("status", "--porcelain")?.isNotBlank() ?: false
+    return if (dirty) "$sha-dirty" else sha
+}
+
 android {
     namespace = "com.hugalafutro.bellhop"
     compileSdk = 35
@@ -16,6 +36,7 @@ android {
         targetSdk = 35
         versionCode = 1
         versionName = "0.1.0"
+        buildConfigField("String", "GIT_COMMIT", "\"${gitCommit()}\"")
     }
 
     buildTypes {
@@ -31,6 +52,7 @@ android {
 
     buildFeatures {
         compose = true
+        buildConfig = true
     }
 
     testOptions {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -46,7 +46,8 @@
         android:theme="@style/Theme.Bellhop">
         <activity
             android:name=".MainActivity"
-            android:exported="true">
+            android:exported="true"
+            android:screenOrientation="portrait">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
@@ -652,6 +652,7 @@ private fun LinkedContent(
             onRange = detailVm::setRange,
             onCustomRange = detailVm::setCustomRange,
             onLoadMoreEvents = detailVm::loadMore,
+            holdToCopy = holdToCopy,
         )
     } else {
         DashboardScreen(

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
@@ -37,6 +37,7 @@ import com.hugalafutro.bellhop.data.LockConfig
 import com.hugalafutro.bellhop.data.LockStore
 import com.hugalafutro.bellhop.data.LockTimeout
 import com.hugalafutro.bellhop.data.MonitorStore
+import com.hugalafutro.bellhop.data.PrefsStore
 import com.hugalafutro.bellhop.data.shouldLock
 import com.hugalafutro.bellhop.notify.FleetNotifier
 import com.hugalafutro.bellhop.push.BellhopPush
@@ -161,6 +162,7 @@ fun BellhopApp() {
     val linkStore = remember { LinkStore.create(context) }
     val lockStore = remember { LockStore.create(context) }
     val monitorStore = remember { MonitorStore.create(context) }
+    val prefsStore = remember { PrefsStore.create(context) }
     val client = remember { FrontDeskClient() }
     val linkState by linkStore.state.collectAsStateWithLifecycle(initialValue = LinkState.Loading)
     val lockConfig by
@@ -171,6 +173,7 @@ fun BellhopApp() {
     val monitorEnabled by monitorStore.enabled.collectAsStateWithLifecycle(initialValue = false)
     val pushEnabled by monitorStore.pushEnabled.collectAsStateWithLifecycle(initialValue = false)
     val pushEndpoint by monitorStore.endpoint.collectAsStateWithLifecycle(initialValue = null)
+    val holdToCopy by prefsStore.holdToCopy.collectAsStateWithLifecycle(initialValue = true)
     val scope = rememberCoroutineScope()
     // Whether Bellhop may post notifications. Tracked so Settings can be honest
     // when monitoring is on but the permission was denied (or later revoked from
@@ -448,9 +451,11 @@ fun BellhopApp() {
                         scope = scope,
                         unlinking = unlinking,
                         unlinkFailed = unlinkFailed,
+                        holdToCopy = holdToCopy,
                         onDismissUnlinkError = { unlinkFailed = false },
                         onToggleMonitor = { toggleMonitor(it) },
                         onTogglePush = { togglePush(it) },
+                        onToggleHoldToCopy = { scope.launch { prefsStore.setHoldToCopy(it) } },
                         onUnlink = { runUnlink(state.fdUrl) },
                         onForceUnlink = { forceUnlink() },
                         requireOperatorAuth = { action -> requireOperatorAuth(action) },
@@ -482,9 +487,11 @@ private fun LinkedContent(
     scope: CoroutineScope,
     unlinking: Boolean,
     unlinkFailed: Boolean,
+    holdToCopy: Boolean,
     onDismissUnlinkError: () -> Unit,
     onToggleMonitor: (Boolean) -> Unit,
     onTogglePush: (Boolean) -> Unit,
+    onToggleHoldToCopy: (Boolean) -> Unit,
     onUnlink: () -> Unit,
     onForceUnlink: () -> Unit,
     requireOperatorAuth: (() -> Unit) -> Unit,
@@ -579,6 +586,7 @@ private fun LinkedContent(
             onRange = eventsVm::setRange,
             onCustomRange = eventsVm::setCustomRange,
             onLoadMore = eventsVm::loadMore,
+            holdToCopy = holdToCopy,
         )
     } else if (showAlerts) {
         // Alerts can be reached from the dashboard bell or from Settings; back
@@ -615,6 +623,8 @@ private fun LinkedContent(
             unlinkFailed = unlinkFailed,
             onDismissUnlinkError = onDismissUnlinkError,
             onForceUnlink = onForceUnlink,
+            holdToCopy = holdToCopy,
+            onToggleHoldToCopy = onToggleHoldToCopy,
         )
     } else if (selected != null) {
         BackHandler { selectedMemberId = null }
@@ -658,6 +668,7 @@ private fun LinkedContent(
             onSetAutoSync = { enabled -> requireOperatorAuth { dashVm.setAutoSync(enabled) } },
             onDismissAutoSyncError = { dashVm.dismissAutoSyncError() },
             onVisibleMembers = dashVm::setVisibleMembers,
+            holdToCopy = holdToCopy,
         )
     }
 }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/LinkState.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/LinkState.kt
@@ -22,5 +22,8 @@ sealed interface LinkState {
         val role: String,
         val deviceId: String,
         val label: String,
+        // Epoch millis of when this link was paired, for display only. 0 means
+        // unknown (links saved before this field existed carry no stamp).
+        val linkedAt: Long = 0L,
     ) : LinkState
 }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/LinkStore.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/LinkStore.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import kotlinx.coroutines.flow.Flow
@@ -54,6 +55,7 @@ class LinkStore(
                     role = prefs[ROLE].orEmpty(),
                     deviceId = prefs[DEVICE_ID].orEmpty(),
                     label = prefs[LABEL].orEmpty(),
+                    linkedAt = prefs[LINKED_AT] ?: 0L,
                 )
             }
         }
@@ -63,6 +65,8 @@ class LinkStore(
         fdName: String,
         token: String,
         device: PairedDevice,
+        // Injectable so persistence tests get a deterministic stamp.
+        now: Long = System.currentTimeMillis(),
     ) {
         val encrypted = cipher.encrypt(token)
         dataStore.edit { prefs ->
@@ -72,6 +76,7 @@ class LinkStore(
             prefs[ROLE] = device.role
             prefs[DEVICE_ID] = device.id
             prefs[LABEL] = device.label
+            prefs[LINKED_AT] = now
         }
     }
 
@@ -94,5 +99,6 @@ class LinkStore(
         private val ROLE = stringPreferencesKey("role")
         private val DEVICE_ID = stringPreferencesKey("device_id")
         private val LABEL = stringPreferencesKey("label")
+        private val LINKED_AT = longPreferencesKey("linked_at")
     }
 }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/PrefsStore.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/PrefsStore.kt
@@ -1,0 +1,38 @@
+package com.hugalafutro.bellhop.data
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+// Separate DataStore for lightweight, non-secret UI preferences so it survives
+// unlink (they are device-local tastes, not tied to any one Front Desk link).
+private val Context.prefsDataStore: DataStore<Preferences> by
+    preferencesDataStore(name = "bellhop_prefs")
+
+/**
+ * PrefsStore persists device-local UI preferences that are neither link metadata
+ * nor security policy. Today that is just the copy gesture: whether tapping a log
+ * or member cell copies it (easy but easy to trigger by accident while scrolling)
+ * or a long-press is required (the default, safer against stray copies).
+ */
+class PrefsStore(
+    private val dataStore: DataStore<Preferences>,
+) {
+    /** holdToCopy emits whether copy requires a long-press; defaults on. */
+    val holdToCopy: Flow<Boolean> = dataStore.data.map { it[HOLD_TO_COPY] ?: true }
+
+    suspend fun setHoldToCopy(enabled: Boolean) {
+        dataStore.edit { it[HOLD_TO_COPY] = enabled }
+    }
+
+    companion object {
+        fun create(context: Context): PrefsStore = PrefsStore(context.applicationContext.prefsDataStore)
+
+        private val HOLD_TO_COPY = booleanPreferencesKey("hold_to_copy")
+    }
+}

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/FleetUi.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/FleetUi.kt
@@ -100,6 +100,11 @@ internal fun FilterPill(
     onClick: () -> Unit,
     tag: String,
     modifier: Modifier = Modifier,
+    // Unselected border colour. Defaults to `outline`, which reads fine on the
+    // base surface (events/dashboard filter rows). Callers that sit these pills
+    // inside a Card pass `onSurfaceVariant` instead, since `outline` is close
+    // enough to the card's tonal fill to nearly vanish against it.
+    borderColor: Color = MaterialTheme.colorScheme.outline,
 ) {
     // Selected fills with the brass accent; unselected is an outlined toggle
     // (transparent with a hairline border) rather than a grey fill, so the set
@@ -114,7 +119,7 @@ internal fun FilterPill(
         color = container,
         contentColor = content,
         shape = RoundedCornerShape(999.dp),
-        border = if (selected) null else BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
+        border = if (selected) null else BorderStroke(1.dp, borderColor),
         modifier = modifier.testTag(tag),
     ) {
         Text(

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/LoadMoreSentinel.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/LoadMoreSentinel.kt
@@ -1,0 +1,57 @@
+package com.hugalafutro.bellhop.ui.common
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+
+/**
+ * loadMoreSentinel is the shared infinite-scroll tail for a paged [LazyListScope]
+ * feed (the events log and the member-detail event log). While a page is in
+ * flight it shows a centered spinner; otherwise, when more pages exist, it drops a
+ * zero-height sentinel item whose mere composition means the user bottomed out
+ * (lazy items only compose near the viewport), so it fires [onLoadMore]. The
+ * sentinel's key changes with [itemCount], so a fresh one arms after each page —
+ * and a first page too short to fill the screen keeps arming until it does. The
+ * caller's ViewModel is expected to no-op [onLoadMore] while a page is in flight
+ * or nothing more remains, and to back off failed pages (see [loadMoreBackoffMillis]).
+ *
+ * [loadingTag]/[sentinelTag] name the spinner and sentinel nodes so each screen's
+ * tests can target its own; the 1dp sentinel exists only to carry that semantics node.
+ */
+fun LazyListScope.loadMoreSentinel(
+    canLoadMore: Boolean,
+    loadingMore: Boolean,
+    itemCount: Int,
+    onLoadMore: () -> Unit,
+    loadingTag: String,
+    sentinelTag: String,
+) {
+    if (loadingMore) {
+        item(key = loadingTag) {
+            Box(
+                modifier = Modifier.fillMaxWidth().padding(vertical = 12.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                CircularProgressIndicator(
+                    strokeWidth = 2.dp,
+                    modifier = Modifier.size(20.dp).testTag(loadingTag),
+                )
+            }
+        }
+    } else if (canLoadMore) {
+        item(key = "$sentinelTag-$itemCount") {
+            LaunchedEffect(Unit) { onLoadMore() }
+            Spacer(modifier = Modifier.height(1.dp).testTag(sentinelTag))
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/OpenUrlDialog.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/OpenUrlDialog.kt
@@ -23,11 +23,14 @@ import com.hugalafutro.bellhop.R
 fun ConfirmOpenUrlDialog(
     url: String,
     onDismiss: () -> Unit,
+    // Dialog title; defaults to the member-address wording. The footer's GitHub
+    // link passes a generic "Open link" instead.
+    title: String = stringResource(R.string.member_url_title),
 ) {
     val context = LocalContext.current
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text(stringResource(R.string.member_url_title)) },
+        title = { Text(title) },
         text = {
             Text(
                 text = url,

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/RelativeTime.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/RelativeTime.kt
@@ -1,0 +1,17 @@
+package com.hugalafutro.bellhop.ui.common
+
+// relativeAgo turns an elapsed span (millis) into a terse human string: "just now"
+// under a minute, then minutes, hours, and days. Shared by the member-detail
+// SYNCED row and the dashboard cards' recent-event pills.
+fun relativeAgo(elapsedMs: Long): String {
+    val minutes = elapsedMs / 60_000L
+    val hours = elapsedMs / 3_600_000L
+    val days = elapsedMs / 86_400_000L
+    return when {
+        minutes < 1 -> "just now"
+        minutes < 60 -> "$minutes min ago"
+        hours < 24 -> "$hours hr ago"
+        days == 1L -> "1 day ago"
+        else -> "$days days ago"
+    }
+}

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/ScrollToTopButton.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/ScrollToTopButton.kt
@@ -1,0 +1,59 @@
+package com.hugalafutro.bellhop.ui.common
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material3.Icon
+import androidx.compose.material3.SmallFloatingActionButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.hugalafutro.bellhop.R
+import kotlinx.coroutines.launch
+
+/**
+ * ScrollToTopButton overlays a bottom-right "return to top" control on a scrolling
+ * [LazyListState] list (the events log and the dashboard member list). It fades in
+ * once the first item has scrolled off ([LazyListState.firstVisibleItemIndex] > 0)
+ * and fades itself away again on return to the top, so it's absent until it's
+ * useful. Tapping it animates the list back to the top.
+ *
+ * A [BoxScope] extension so the caller drops it straight into the Box that wraps
+ * the list, where it aligns to the bottom-end corner over the content.
+ */
+@Composable
+fun BoxScope.ScrollToTopButton(
+    listState: LazyListState,
+    modifier: Modifier = Modifier,
+) {
+    val scope = rememberCoroutineScope()
+    val visible by remember { derivedStateOf { listState.firstVisibleItemIndex > 0 } }
+    AnimatedVisibility(
+        visible = visible,
+        enter = fadeIn(),
+        exit = fadeOut(),
+        modifier = modifier.align(Alignment.BottomEnd).padding(16.dp),
+    ) {
+        SmallFloatingActionButton(
+            onClick = { scope.launch { listState.animateScrollToItem(0) } },
+            modifier = Modifier.testTag("scroll-to-top"),
+        ) {
+            Icon(
+                imageVector = Icons.Filled.KeyboardArrowUp,
+                contentDescription = stringResource(R.string.scroll_to_top),
+            )
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/SeverityRailRow.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/SeverityRailRow.kt
@@ -1,7 +1,9 @@
 package com.hugalafutro.bellhop.ui.common
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -30,6 +32,7 @@ private val RAIL_WIDTH = 3.dp
  * long event lists stutter while flinging on device. The overlay still fills the
  * row and carries [railTag], so the tests that assert / tap the rail keep working.
  */
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun SeverityRailRow(
     severity: String,
@@ -37,6 +40,10 @@ fun SeverityRailRow(
     railTag: String,
     modifier: Modifier = Modifier,
     onClick: (() -> Unit)? = null,
+    // Long-press handler, used when copy is gated behind a hold gesture so a
+    // stray tap while scrolling the log doesn't copy. When set, the row wires
+    // combinedClickable; a plain [onClick] alone still uses clickable.
+    onLongClick: (() -> Unit)? = null,
     content: @Composable ColumnScope.(typeColor: Color) -> Unit,
 ) {
     val (accent, typeColor) = severityColors(severity)
@@ -44,7 +51,17 @@ fun SeverityRailRow(
         modifier =
             modifier
                 .fillMaxWidth()
-                .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier)
+                .then(
+                    when {
+                        onLongClick != null ->
+                            Modifier.combinedClickable(
+                                onClick = onClick ?: {},
+                                onLongClick = onLongClick,
+                            )
+                        onClick != null -> Modifier.clickable(onClick = onClick)
+                        else -> Modifier
+                    },
+                )
                 .background(accent.copy(alpha = 0.06f))
                 .testTag(rowTag),
     ) {

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
@@ -54,6 +54,7 @@ import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -485,7 +486,11 @@ private fun MemberCard(
             modifier
                 .fillMaxWidth()
                 .testTag("member-card-${member.name}")
-                .combinedClickable(onClick = onClick, onLongClick = onLongClick),
+                .combinedClickable(
+                    role = Role.Button,
+                    onClick = onClick,
+                    onLongClick = onLongClick,
+                ),
     ) {
         Column(
             modifier = Modifier.padding(14.dp),
@@ -604,7 +609,7 @@ private fun MemberCard(
                             overflow = TextOverflow.Ellipsis,
                             modifier = Modifier.weight(1f),
                         )
-                        eventAgo(ev.createdAt)?.let { ago ->
+                        remember(ev.createdAt) { eventAgo(ev.createdAt) }?.let { ago ->
                             Spacer(modifier = Modifier.width(8.dp))
                             Text(
                                 text = ago,

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
@@ -1,7 +1,10 @@
 package com.hugalafutro.bellhop.ui.dashboard
 
+import android.widget.Toast
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -13,26 +16,31 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -42,12 +50,19 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.hugalafutro.bellhop.BuildConfig
 import com.hugalafutro.bellhop.R
+import com.hugalafutro.bellhop.data.FdEvent
 import com.hugalafutro.bellhop.data.FleetMember
 import com.hugalafutro.bellhop.data.HealthStatus
 import com.hugalafutro.bellhop.data.LinkState
@@ -55,12 +70,16 @@ import com.hugalafutro.bellhop.data.MemberStatus
 import com.hugalafutro.bellhop.data.MemberTraffic
 import com.hugalafutro.bellhop.ui.common.ConfirmOpenUrlDialog
 import com.hugalafutro.bellhop.ui.common.Pill
+import com.hugalafutro.bellhop.ui.common.ScrollToTopButton
 import com.hugalafutro.bellhop.ui.common.StatusBanner
 import com.hugalafutro.bellhop.ui.common.TrafficChart
 import com.hugalafutro.bellhop.ui.common.healthColor
 import com.hugalafutro.bellhop.ui.common.healthLabel
+import com.hugalafutro.bellhop.ui.common.relativeAgo
+import com.hugalafutro.bellhop.ui.common.severityColors
 import com.hugalafutro.bellhop.ui.theme.BellhopTheme
 import kotlinx.coroutines.flow.distinctUntilChanged
+import java.time.Instant
 
 /**
  * DashboardScreen is the linked-state home: the fleet's members with their live
@@ -82,13 +101,33 @@ fun DashboardScreen(
     onSetAutoSync: (Boolean) -> Unit = {},
     onDismissAutoSyncError: () -> Unit = {},
     onVisibleMembers: (List<String>) -> Unit = {},
+    // When true, a long-press on a member card copies it to the clipboard (tap
+    // still opens the member). Off leaves the card tap-only (Settings > Hold to copy).
+    holdToCopy: Boolean = false,
 ) {
+    // Long-press copies a member row as text, with a toast to confirm the
+    // otherwise-silent act. Gated on [holdToCopy] so it never fires by accident.
+    val clipboard = LocalClipboardManager.current
+    val context = LocalContext.current
+    val memberCopiedMsg = stringResource(R.string.dashboard_member_copied)
+
     // Which member's URL the "open externally" popup is showing, if any. Tapping
     // a card's address opens this confirm dialog rather than firing an intent on
     // the same tap that could also be a mis-tap on the card itself.
     var urlDialogFor by remember { mutableStateOf<FleetMember?>(null) }
     urlDialogFor?.let { member ->
         ConfirmOpenUrlDialog(url = member.url, onDismiss = { urlDialogFor = null })
+    }
+
+    // Build footer: tapping it confirms before leaving for GitHub. Stamped builds
+    // deep-link the exact commit; an unstamped (source-tarball) build links the repo.
+    var showBuildInfoUrl by remember { mutableStateOf(false) }
+    if (showBuildInfoUrl) {
+        ConfirmOpenUrlDialog(
+            url = buildInfoUrl(),
+            title = stringResource(R.string.open_url_title),
+            onDismiss = { showBuildInfoUrl = false },
+        )
     }
 
     Scaffold(modifier = modifier.fillMaxSize()) { innerPadding ->
@@ -211,25 +250,63 @@ fun DashboardScreen(
                             .distinctUntilChanged()
                             .collect(onVisibleMembers)
                     }
-                    LazyColumn(
-                        state = listState,
-                        modifier = Modifier.weight(1f),
-                        verticalArrangement = Arrangement.spacedBy(8.dp),
-                        contentPadding = PaddingValues(bottom = 24.dp),
-                    ) {
-                        // Deliberately unkeyed: member ids are FD database primary
-                        // keys so duplicates shouldn't happen, but a buggy response
-                        // with duplicate ids would crash a keyed LazyColumn outright.
-                        // Positional identity is fine for a small stateless list.
-                        items(ui.members) { member ->
-                            MemberCard(
-                                member = member,
-                                isPrimary = member.id == ui.primaryId,
-                                traffic = ui.traffic[member.id],
-                                onClick = { onMemberClick(member.id) },
-                                onUrlClick = { urlDialogFor = member },
+                    // Footer placement: when the list overflows the viewport the
+                    // footer rides along as the last item and scrolls off; when it
+                    // fits, the footer is overlaid pinned to the bottom of the screen
+                    // instead. The bottom content padding reserves the footer's height
+                    // so a nearly-full list never hides its last card under the overlay.
+                    val footerScrolls by remember {
+                        derivedStateOf { listState.canScrollForward || listState.canScrollBackward }
+                    }
+                    Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
+                        LazyColumn(
+                            state = listState,
+                            modifier = Modifier.fillMaxSize(),
+                            verticalArrangement = Arrangement.spacedBy(8.dp),
+                            contentPadding = PaddingValues(bottom = 56.dp),
+                        ) {
+                            // Deliberately unkeyed: member ids are FD database primary
+                            // keys so duplicates shouldn't happen, but a buggy response
+                            // with duplicate ids would crash a keyed LazyColumn outright.
+                            // Positional identity is fine for a small stateless list.
+                            items(ui.members) { member ->
+                                MemberCard(
+                                    member = member,
+                                    isPrimary = member.id == ui.primaryId,
+                                    traffic = ui.traffic[member.id],
+                                    recentEvent = ui.recentEvents[member.id],
+                                    onClick = { onMemberClick(member.id) },
+                                    onUrlClick = { urlDialogFor = member },
+                                    onLongClick =
+                                        if (holdToCopy) {
+                                            {
+                                                clipboard.setText(AnnotatedString(memberClipboardText(member)))
+                                                Toast.makeText(context, memberCopiedMsg, Toast.LENGTH_SHORT).show()
+                                            }
+                                        } else {
+                                            null
+                                        },
+                                )
+                            }
+                            // Version/build footer, mimicking Front Desk's: a divider then
+                            // a centered, tappable "Bellhop <version> · <commit>" that opens
+                            // GitHub (the exact commit when stamped) behind the confirm modal.
+                            // It rides the list (and scrolls off) only when the list scrolls.
+                            if (footerScrolls) {
+                                item {
+                                    DashboardFooter(onClick = { showBuildInfoUrl = true })
+                                }
+                            }
+                        }
+                        // Otherwise it's pinned to the bottom of the screen, over the
+                        // empty space the reserved bottom padding leaves below the list.
+                        if (!footerScrolls) {
+                            DashboardFooter(
+                                onClick = { showBuildInfoUrl = true },
+                                modifier = Modifier.align(Alignment.BottomCenter),
                             )
                         }
+                        ScrollToTopButton(listState = listState)
                     }
                 }
             }
@@ -372,6 +449,18 @@ private fun FleetSummary(
     )
 }
 
+// The plain-text a long-press copies for a member: its name and, when known, its
+// URL on the next line, so it pastes cleanly into a note or bug report.
+private fun memberClipboardText(member: FleetMember): String =
+    buildString {
+        append(member.name)
+        if (member.url.isNotBlank()) {
+            append('\n')
+            append(member.url)
+        }
+    }
+
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun MemberCard(
     member: FleetMember,
@@ -380,10 +469,24 @@ private fun MemberCard(
     onClick: () -> Unit,
     onUrlClick: () -> Unit,
     modifier: Modifier = Modifier,
+    // This member's most recent event, shown as a severity-tinted pill under the
+    // sparkline; null hides it. Tapping the pill opens the member (its detail log
+    // is newest-first, so this event sits at the top).
+    recentEvent: FdEvent? = null,
+    // When set, a long-press copies the member; a tap still opens it. Uses
+    // combinedClickable on the Card's own modifier (Card's onClick overload has
+    // no long-press hook).
+    onLongClick: (() -> Unit)? = null,
 ) {
     val health = member.status.health
     val healthColor = healthColor(health)
-    Card(onClick = onClick, modifier = modifier.fillMaxWidth().testTag("member-card-${member.name}")) {
+    Card(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .testTag("member-card-${member.name}")
+                .combinedClickable(onClick = onClick, onLongClick = onLongClick),
+    ) {
         Column(
             modifier = Modifier.padding(14.dp),
             verticalArrangement = Arrangement.spacedBy(4.dp),
@@ -477,9 +580,121 @@ private fun MemberCard(
                     modifier = Modifier.height(28.dp).testTag("member-sparkline-${member.name}"),
                 )
             }
+            // Recent-event pill: a severity-tinted, one-line preview of this
+            // member's latest event with its age right-aligned, tappable straight
+            // into the member.
+            recentEvent?.let { ev ->
+                val (evContainer, evContent) = severityColors(ev.severity)
+                Spacer(modifier = Modifier.height(4.dp))
+                Surface(
+                    onClick = onClick,
+                    color = evContainer,
+                    contentColor = evContent,
+                    shape = RoundedCornerShape(8.dp),
+                    modifier = Modifier.fillMaxWidth().testTag("member-recent-event-${member.name}"),
+                ) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                    ) {
+                        Text(
+                            text = ev.message.ifBlank { ev.type },
+                            style = MaterialTheme.typography.bodySmall,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.weight(1f),
+                        )
+                        eventAgo(ev.createdAt)?.let { ago ->
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text(
+                                text = ago,
+                                style = MaterialTheme.typography.labelSmall,
+                                maxLines = 1,
+                            )
+                        }
+                    }
+                }
+            }
         }
     }
 }
+
+// DashboardFooter mimics Front Desk's footer: a divider, then a centered, tappable
+// "Bellhop <version> · <commit>" build stamp. The tap is handled by the caller
+// (a confirm-before-leaving dialog); this only renders the label.
+@Composable
+private fun DashboardFooter(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        HorizontalDivider(modifier = Modifier.padding(vertical = 12.dp))
+        // Only the version/commit is the link, so brass it; the "Bellhop" label
+        // stays the standard body colour.
+        val label = buildInfoLabel()
+        val full = stringResource(R.string.dashboard_footer, label)
+        val text =
+            buildAnnotatedString {
+                append(full)
+                val start = full.indexOf(label)
+                if (start >= 0) {
+                    addStyle(SpanStyle(color = MaterialTheme.colorScheme.primary), start, start + label.length)
+                }
+            }
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier =
+                Modifier
+                    .clickable(onClick = onClick)
+                    .padding(bottom = 8.dp)
+                    .testTag("dashboard-footer"),
+        )
+    }
+}
+
+// eventAgo turns an event's RFC3339 timestamp into a terse "3 days ago"-style age
+// for the recent-event pill, or null when it can't be parsed (the pill then just
+// omits the age rather than showing a raw string).
+private fun eventAgo(
+    createdAt: String,
+    now: Long = System.currentTimeMillis(),
+): String? =
+    try {
+        relativeAgo((now - Instant.parse(createdAt).toEpochMilli()).coerceAtLeast(0L))
+    } catch (e: Exception) {
+        null
+    }
+
+private const val REPO_URL = "https://github.com/hugalafutro/model-hotel"
+
+// hasCommit is true for a stamped build (any real short sha), false for a source
+// build where GIT_COMMIT fell back to "unknown".
+private fun hasCommit(): Boolean = BuildConfig.GIT_COMMIT.isNotBlank() && BuildConfig.GIT_COMMIT != "unknown"
+
+// buildInfoLabel is the version span: "v0.1.0" plus the commit when stamped.
+private fun buildInfoLabel(): String =
+    buildString {
+        append('v')
+        append(BuildConfig.VERSION_NAME)
+        if (hasCommit()) {
+            append(" · ")
+            append(BuildConfig.GIT_COMMIT)
+        }
+    }
+
+// buildInfoUrl deep-links the exact commit on a stamped build (dropping any
+// "-dirty" marker, which isn't part of a real sha), else the repo root.
+private fun buildInfoUrl(): String =
+    if (hasCommit()) {
+        "$REPO_URL/commit/${BuildConfig.GIT_COMMIT.removeSuffix("-dirty")}"
+    } else {
+        REPO_URL
+    }
 
 @Preview(showBackground = true)
 @Composable

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModel.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModel.kt
@@ -291,13 +291,24 @@ class DashboardViewModel(
                 // handful of members and it keeps refreshOnce a simple linear path. A
                 // member whose read fails or has no events keeps its previous pill via
                 // the merge below rather than blanking.
-                val recentMap =
-                    buildMap {
-                        for (m in result.data) {
-                            val res = client.events(fdUrl, token, EventQuery(memberId = m.id, limit = 1))
-                            (res as? FetchResult.Success)?.data?.events?.firstOrNull()?.let { put(m.id, it) }
+                val recentMap = mutableMapOf<String, FdEvent>()
+                for (m in result.data) {
+                    when (val res = client.events(fdUrl, token, EventQuery(memberId = m.id, limit = 1))) {
+                        is FetchResult.Success ->
+                            res.data.events?.firstOrNull()?.let { recentMap[m.id] = it }
+                        // A token revoked mid-refresh (members succeeded, then this
+                        // authenticated call is rejected) must land in the same
+                        // revoked-unlink recovery state as a members 401, not be
+                        // swallowed into a "healthy" refresh that keeps polling a
+                        // dead token.
+                        FetchResult.Unauthorized -> {
+                            _state.update { it.copy(loading = false, revoked = true) }
+                            return
                         }
+                        // A stale pill is fine; the card's health still shows.
+                        is FetchResult.Failure -> Unit
                     }
+                }
                 _state.update {
                     val pending = it.autoSync.pendingEnabled
                     // When the auto-sync read fails but the rest of the refresh

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModel.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModel.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.hugalafutro.bellhop.data.ActionResult
+import com.hugalafutro.bellhop.data.EventQuery
+import com.hugalafutro.bellhop.data.FdEvent
 import com.hugalafutro.bellhop.data.FetchResult
 import com.hugalafutro.bellhop.data.FleetMember
 import com.hugalafutro.bellhop.data.FrontDeskClient
@@ -41,6 +43,10 @@ data class DashboardUiState(
     // [DashboardViewModel.setVisibleMembers]). A member absent from the map just
     // renders without a sparkline yet.
     val traffic: Map<String, MemberTraffic> = emptyMap(),
+    // Each member's single most recent event, keyed by member id, for the card's
+    // recent-event pill. Built from one member_id-filtered GET /api/events read per
+    // member per refresh; a member with no events is simply absent from the map.
+    val recentEvents: Map<String, FdEvent> = emptyMap(),
     val error: String? = null,
     val revoked: Boolean = false,
     // Pause/resume operator action state (same shape as the member-detail card).
@@ -277,6 +283,21 @@ class DashboardViewModel(
             is FetchResult.Success -> {
                 val autoSync = client.autoSync(fdUrl, token) as? FetchResult.Success
                 val liveIds = result.data.mapTo(HashSet()) { it.id }
+                // Each card's pill shows that member's newest event, exactly what the
+                // member-detail log's first row shows: one member_id-filtered read per
+                // member (limit 1). This works uniformly for the primary too (its
+                // events are just older than the fleet-wide feed's top, so a single
+                // unfiltered read would miss them). Read sequentially — a fleet is a
+                // handful of members and it keeps refreshOnce a simple linear path. A
+                // member whose read fails or has no events keeps its previous pill via
+                // the merge below rather than blanking.
+                val recentMap =
+                    buildMap {
+                        for (m in result.data) {
+                            val res = client.events(fdUrl, token, EventQuery(memberId = m.id, limit = 1))
+                            (res as? FetchResult.Success)?.data?.events?.firstOrNull()?.let { put(m.id, it) }
+                        }
+                    }
                 _state.update {
                     val pending = it.autoSync.pendingEnabled
                     // When the auto-sync read fails but the rest of the refresh
@@ -292,6 +313,10 @@ class DashboardViewModel(
                         // Drop cached traffic for members that left the fleet so
                         // the map can't grow without bound as members churn.
                         traffic = it.traffic.filterKeys { id -> id in liveIds },
+                        // Churn-drop departed members, then overlay this refresh's
+                        // fresh pills; members whose per-member read failed keep their
+                        // prior entry (they're simply absent from recentMap).
+                        recentEvents = it.recentEvents.filterKeys { id -> id in liveIds } + recentMap,
                         error = null,
                         revoked = false,
                         // Reconcile the pause/resume control: drop the optimistic hint

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/events/EventsScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/events/EventsScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.CircularProgressIndicator
@@ -22,7 +23,6 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -41,8 +41,10 @@ import com.hugalafutro.bellhop.ui.common.CustomDateRange
 import com.hugalafutro.bellhop.ui.common.EventRange
 import com.hugalafutro.bellhop.ui.common.EventRangeRow
 import com.hugalafutro.bellhop.ui.common.FilterPill
+import com.hugalafutro.bellhop.ui.common.ScrollToTopButton
 import com.hugalafutro.bellhop.ui.common.SeverityRailRow
 import com.hugalafutro.bellhop.ui.common.StatusBanner
+import com.hugalafutro.bellhop.ui.common.loadMoreSentinel
 import com.hugalafutro.bellhop.ui.theme.BellhopTheme
 import com.hugalafutro.bellhop.ui.theme.MonoFamily
 import java.time.Instant
@@ -66,9 +68,14 @@ fun EventsScreen(
     onCustomRange: (CustomDateRange?) -> Unit = {},
     onLoadMore: () -> Unit = {},
     modifier: Modifier = Modifier,
+    // When true, long-press a row to copy it to the clipboard; when false the row
+    // can't be copied at all, so a stray touch while scrolling never does
+    // (Settings > Hold to copy).
+    holdToCopy: Boolean = false,
 ) {
-    // Tapping an event's severity pill copies the whole event as text (handy for
-    // pasting into a bug report), with a toast to confirm the otherwise-silent act.
+    // A row copies the whole event as text (handy for pasting into a bug report),
+    // with a toast to confirm the otherwise-silent act. Copy is long-press only
+    // and gated on [holdToCopy].
     val clipboard = LocalClipboardManager.current
     val context = LocalContext.current
     val copiedMsg = stringResource(R.string.events_copied)
@@ -151,44 +158,41 @@ fun EventsScreen(
                             modifier = Modifier.testTag("events-empty"),
                         )
                     }
-                else ->
-                    LazyColumn(
-                        modifier = Modifier.weight(1f).testTag("events-list"),
-                        contentPadding = PaddingValues(bottom = 24.dp),
-                    ) {
-                        // Unkeyed on purpose, like the dashboard list: ids are
-                        // primary keys server-side, but a buggy duplicate must
-                        // degrade to a double row, not a crash.
-                        items(ui.events) { event ->
-                            EventRow(
-                                event = event,
-                                memberName = memberNames[event.memberId],
-                                onCopy = { onCopy(event) },
-                            )
-                            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
-                        }
-                        if (ui.canLoadMore) {
-                            item {
-                                Box(
-                                    modifier = Modifier.fillMaxWidth(),
-                                    contentAlignment = Alignment.Center,
-                                ) {
-                                    if (ui.loadingMore) {
-                                        CircularProgressIndicator(
-                                            modifier = Modifier.padding(8.dp).testTag("events-loading-more"),
-                                        )
-                                    } else {
-                                        TextButton(
-                                            onClick = onLoadMore,
-                                            modifier = Modifier.testTag("events-load-more"),
-                                        ) {
-                                            Text(stringResource(R.string.events_load_more))
-                                        }
-                                    }
-                                }
+                else -> {
+                    val listState = rememberLazyListState()
+                    Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
+                        LazyColumn(
+                            state = listState,
+                            modifier = Modifier.fillMaxSize().testTag("events-list"),
+                            contentPadding = PaddingValues(bottom = 24.dp),
+                        ) {
+                            // Unkeyed on purpose, like the dashboard list: ids are
+                            // primary keys server-side, but a buggy duplicate must
+                            // degrade to a double row, not a crash.
+                            items(ui.events) { event ->
+                                EventRow(
+                                    event = event,
+                                    memberName = memberNames[event.memberId],
+                                    onCopy = { onCopy(event) },
+                                    holdToCopy = holdToCopy,
+                                )
+                                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
                             }
+                            // Infinite scroll: the same shared sentinel the member-detail
+                            // log uses. [onLoadMore] fires when the user bottoms out; the
+                            // VM already no-ops in flight / at the end and backs off failures.
+                            loadMoreSentinel(
+                                canLoadMore = ui.canLoadMore,
+                                loadingMore = ui.loadingMore,
+                                itemCount = ui.events.size,
+                                onLoadMore = onLoadMore,
+                                loadingTag = "events-loading-more",
+                                sentinelTag = "events-load-more-sentinel",
+                            )
                         }
+                        ScrollToTopButton(listState = listState)
                     }
+                }
             }
         }
     }
@@ -229,16 +233,18 @@ private fun EventRow(
     memberName: String?,
     onCopy: () -> Unit,
     modifier: Modifier = Modifier,
+    holdToCopy: Boolean = false,
 ) {
     // A log line, not a card: a colour-coded severity rail down the left edge and
     // a faint tint of the same colour, so severity reads at a glance without a
-    // pill. The whole row taps to copy (the rail carries the severity test tag).
+    // pill. Copy is long-press only and opt-in: the row copies when [holdToCopy]
+    // is on, and is otherwise inert (a tap never copies, so scrolling can't).
     SeverityRailRow(
         severity = event.severity,
         rowTag = "event-card",
         railTag = "event-sev-${event.severity}",
         modifier = modifier,
-        onClick = onCopy,
+        onLongClick = if (holdToCopy) onCopy else null,
     ) { typeColor ->
         Row(
             verticalAlignment = Alignment.CenterVertically,

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreen.kt
@@ -319,7 +319,7 @@ private fun MetaLedger(
             LedgerRow(
                 label = stringResource(R.string.member_detail_label_synced),
                 value = formatEventTime(member.lastConfigSyncAt),
-                trailing = ageParenthetical(member.lastConfigSyncAt),
+                trailing = remember(member.lastConfigSyncAt) { ageParenthetical(member.lastConfigSyncAt) },
                 trailingColor = syncAgeColorFor(member.lastConfigSyncAt),
                 tag = "member-detail-synced",
             )
@@ -337,7 +337,10 @@ private fun MetaLedger(
             LedgerRow(
                 label = stringResource(R.string.member_detail_label_verified),
                 value = formatEventTime(member.status.autoSyncVerifiedAt),
-                trailing = ageParenthetical(member.status.autoSyncVerifiedAt),
+                trailing =
+                    remember(member.status.autoSyncVerifiedAt) {
+                        ageParenthetical(member.status.autoSyncVerifiedAt)
+                    },
                 tag = "member-detail-verified",
             )
         }
@@ -345,7 +348,7 @@ private fun MetaLedger(
             LedgerRow(
                 label = stringResource(R.string.member_detail_label_added),
                 value = formatEventTime(member.createdAt),
-                trailing = ageParenthetical(member.createdAt),
+                trailing = remember(member.createdAt) { ageParenthetical(member.createdAt) },
                 tag = "member-detail-created",
             )
         }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreen.kt
@@ -1,5 +1,6 @@
 package com.hugalafutro.bellhop.ui.member
 
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -42,8 +43,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -67,6 +71,7 @@ import com.hugalafutro.bellhop.ui.common.TrafficChart
 import com.hugalafutro.bellhop.ui.common.healthColor
 import com.hugalafutro.bellhop.ui.common.loadMoreSentinel
 import com.hugalafutro.bellhop.ui.common.relativeAgo
+import com.hugalafutro.bellhop.ui.events.eventClipboardText
 import com.hugalafutro.bellhop.ui.events.formatEventTime
 import com.hugalafutro.bellhop.ui.theme.BellhopTheme
 import com.hugalafutro.bellhop.ui.theme.MonoFamily
@@ -101,8 +106,22 @@ fun MemberDetailScreen(
     onRange: (EventRange) -> Unit = {},
     onCustomRange: (CustomDateRange?) -> Unit = {},
     onLoadMoreEvents: () -> Unit = {},
+    // When true, long-press an event row to copy it — same gesture as the Events
+    // screen, so a log cell behaves identically wherever it's shown
+    // (Settings > Hold to copy). When false the row can't be copied at all.
+    holdToCopy: Boolean = false,
 ) {
     val health = member.status.health
+    // A row copies the whole event as text, with a toast to confirm the otherwise-
+    // silent act — the same affordance as the Events screen's log.
+    val clipboard = LocalClipboardManager.current
+    val context = LocalContext.current
+    val copiedMsg = stringResource(R.string.events_copied)
+    val onCopyEvent: (FdEvent) -> Unit = { event ->
+        val name = member.name.takeIf { event.memberId == member.id }
+        clipboard.setText(AnnotatedString(eventClipboardText(event, name)))
+        Toast.makeText(context, copiedMsg, Toast.LENGTH_SHORT).show()
+    }
     // Clear the optimistic pending state once the dashboard's live state (member
     // arrives live from its poll/SSE) has caught up to the accepted target.
     LaunchedEffect(member.state) { onReconcile(member.state) }
@@ -232,7 +251,10 @@ fun MemberDetailScreen(
                             }
                         else ->
                             itemsIndexed(ui.events) { index, event ->
-                                MemberEventRow(event = event)
+                                MemberEventRow(
+                                    event = event,
+                                    onCopy = if (holdToCopy) ({ onCopyEvent(event) }) else null,
+                                )
                                 if (index < ui.events.lastIndex) {
                                     HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
                                 }
@@ -689,11 +711,14 @@ private fun TrafficCard(
 private fun MemberEventRow(
     event: FdEvent,
     modifier: Modifier = Modifier,
+    // Long-press to copy, or null when hold-to-copy is off (the row is inert).
+    onCopy: (() -> Unit)? = null,
 ) {
     SeverityRailRow(
         severity = event.severity,
         rowTag = "member-event-row",
         railTag = "member-event-sev-${event.severity}",
+        onLongClick = onCopy,
         modifier = modifier,
     ) { typeColor ->
         Row(

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -40,6 +41,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
@@ -58,13 +60,17 @@ import com.hugalafutro.bellhop.ui.common.CustomDateRange
 import com.hugalafutro.bellhop.ui.common.EventRange
 import com.hugalafutro.bellhop.ui.common.EventRangeRow
 import com.hugalafutro.bellhop.ui.common.Pill
+import com.hugalafutro.bellhop.ui.common.ScrollToTopButton
 import com.hugalafutro.bellhop.ui.common.SeverityRailRow
 import com.hugalafutro.bellhop.ui.common.StatusBanner
 import com.hugalafutro.bellhop.ui.common.TrafficChart
 import com.hugalafutro.bellhop.ui.common.healthColor
+import com.hugalafutro.bellhop.ui.common.loadMoreSentinel
+import com.hugalafutro.bellhop.ui.common.relativeAgo
 import com.hugalafutro.bellhop.ui.events.formatEventTime
 import com.hugalafutro.bellhop.ui.theme.BellhopTheme
 import com.hugalafutro.bellhop.ui.theme.MonoFamily
+import java.time.Instant
 
 /**
  * MemberDetailScreen is one member up close — deliberately *not* a repeat of the
@@ -157,107 +163,92 @@ fun MemberDetailScreen(
                 )
             }
 
-            LazyColumn(
-                modifier = Modifier.weight(1f).testTag("member-detail-list"),
-                contentPadding = PaddingValues(top = 4.dp, bottom = 24.dp),
-            ) {
-                item { TrafficCard(ui = ui, modifier = Modifier.padding(bottom = 20.dp)) }
-                item {
-                    MetaLedger(
-                        member = member,
-                        onOpenUrl = { showUrlDialog = true },
-                        modifier = Modifier.padding(bottom = 20.dp),
-                    )
-                }
-                if (canOperate) {
+            val listState = rememberLazyListState()
+            Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
+                LazyColumn(
+                    state = listState,
+                    modifier = Modifier.fillMaxSize().testTag("member-detail-list"),
+                    contentPadding = PaddingValues(top = 4.dp, bottom = 24.dp),
+                ) {
+                    item { TrafficCard(ui = ui, modifier = Modifier.padding(bottom = 20.dp)) }
                     item {
-                        OperatorControls(
+                        MetaLedger(
                             member = member,
-                            isPrimary = isPrimary,
-                            action = ui.action,
-                            lastFleetSyncAt = ui.lastFleetSyncAt,
-                            onSetState = onSetState,
-                            onSyncFleet = onSyncFleet,
-                            onDismissActionError = onDismissActionError,
+                            onOpenUrl = { showUrlDialog = true },
                             modifier = Modifier.padding(bottom = 20.dp),
                         )
                     }
-                }
-                item {
-                    SectionHeader(
-                        text = stringResource(R.string.member_detail_events_title),
-                        tag = "member-detail-events-title",
-                        modifier = Modifier.padding(bottom = 6.dp),
-                    )
-                }
-                item {
-                    EventRangeRow(
-                        selected = ui.range,
-                        custom = ui.custom,
-                        onRange = onRange,
-                        onCustomRange = onCustomRange,
-                        tagPrefix = "member-events-range",
-                        modifier = Modifier.padding(bottom = 6.dp),
-                    )
-                }
-                when {
-                    ui.loading && ui.events.isEmpty() ->
+                    if (canOperate) {
                         item {
-                            Box(
-                                modifier = Modifier.fillMaxWidth().padding(vertical = 16.dp),
-                                contentAlignment = Alignment.Center,
-                            ) {
-                                CircularProgressIndicator(modifier = Modifier.testTag("member-detail-events-loading"))
-                            }
-                        }
-                    ui.events.isEmpty() ->
-                        item {
-                            Text(
-                                text = stringResource(R.string.member_detail_no_events),
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                modifier = Modifier.testTag("member-detail-no-events"),
-                            )
-                        }
-                    else ->
-                        itemsIndexed(ui.events) { index, event ->
-                            MemberEventRow(event = event)
-                            if (index < ui.events.lastIndex) {
-                                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
-                            }
-                        }
-                }
-                if (ui.loadingMore) {
-                    item {
-                        Box(
-                            modifier = Modifier.fillMaxWidth().padding(vertical = 12.dp),
-                            contentAlignment = Alignment.Center,
-                        ) {
-                            CircularProgressIndicator(
-                                strokeWidth = 2.dp,
-                                modifier = Modifier.size(20.dp).testTag("member-events-loading-more"),
+                            OperatorControls(
+                                member = member,
+                                isPrimary = isPrimary,
+                                action = ui.action,
+                                lastFleetSyncAt = ui.lastFleetSyncAt,
+                                onSetState = onSetState,
+                                onSyncFleet = onSyncFleet,
+                                onDismissActionError = onDismissActionError,
+                                modifier = Modifier.padding(bottom = 20.dp),
                             )
                         }
                     }
-                } else if (ui.canLoadMore) {
-                    // Infinite scroll: lazy items only compose near the
-                    // viewport, so this sentinel composing at all means the
-                    // user bottomed out — ask for the next page. The key
-                    // changes with the window size, so a fresh sentinel arms
-                    // after each page (and a short first page auto-fills the
-                    // screen). The VM still no-ops when nothing more exists.
-                    // The 1dp spacer gives it a semantics node (tests scroll
-                    // to it); visually it's nothing.
-                    item(key = "member-events-load-more-${ui.events.size}") {
-                        LaunchedEffect(Unit) { onLoadMoreEvents() }
-                        Spacer(
-                            modifier =
-                                Modifier
-                                    .height(1.dp)
-                                    .testTag("member-events-load-more-sentinel"),
+                    item {
+                        SectionHeader(
+                            text = stringResource(R.string.member_detail_events_title),
+                            tag = "member-detail-events-title",
+                            modifier = Modifier.padding(bottom = 6.dp),
                         )
                     }
+                    item {
+                        EventRangeRow(
+                            selected = ui.range,
+                            custom = ui.custom,
+                            onRange = onRange,
+                            onCustomRange = onCustomRange,
+                            tagPrefix = "member-events-range",
+                            modifier = Modifier.padding(bottom = 6.dp),
+                        )
+                    }
+                    when {
+                        ui.loading && ui.events.isEmpty() ->
+                            item {
+                                Box(
+                                    modifier = Modifier.fillMaxWidth().padding(vertical = 16.dp),
+                                    contentAlignment = Alignment.Center,
+                                ) {
+                                    CircularProgressIndicator(
+                                        modifier = Modifier.testTag("member-detail-events-loading"),
+                                    )
+                                }
+                            }
+                        ui.events.isEmpty() ->
+                            item {
+                                Text(
+                                    text = stringResource(R.string.member_detail_no_events),
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.testTag("member-detail-no-events"),
+                                )
+                            }
+                        else ->
+                            itemsIndexed(ui.events) { index, event ->
+                                MemberEventRow(event = event)
+                                if (index < ui.events.lastIndex) {
+                                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+                                }
+                            }
+                    }
+                    // Infinite scroll via the shared sentinel (also used by the events log).
+                    loadMoreSentinel(
+                        canLoadMore = ui.canLoadMore,
+                        loadingMore = ui.loadingMore,
+                        itemCount = ui.events.size,
+                        onLoadMore = onLoadMoreEvents,
+                        loadingTag = "member-events-loading-more",
+                        sentinelTag = "member-events-load-more-sentinel",
+                    )
                 }
+                ScrollToTopButton(listState = listState)
             }
         }
     }
@@ -328,6 +319,8 @@ private fun MetaLedger(
             LedgerRow(
                 label = stringResource(R.string.member_detail_label_synced),
                 value = formatEventTime(member.lastConfigSyncAt),
+                trailing = ageParenthetical(member.lastConfigSyncAt),
+                trailingColor = syncAgeColorFor(member.lastConfigSyncAt),
                 tag = "member-detail-synced",
             )
             if (member.lastConfigSyncReason.isNotBlank()) {
@@ -344,6 +337,7 @@ private fun MetaLedger(
             LedgerRow(
                 label = stringResource(R.string.member_detail_label_verified),
                 value = formatEventTime(member.status.autoSyncVerifiedAt),
+                trailing = ageParenthetical(member.status.autoSyncVerifiedAt),
                 tag = "member-detail-verified",
             )
         }
@@ -351,6 +345,7 @@ private fun MetaLedger(
             LedgerRow(
                 label = stringResource(R.string.member_detail_label_added),
                 value = formatEventTime(member.createdAt),
+                trailing = ageParenthetical(member.createdAt),
                 tag = "member-detail-created",
             )
         }
@@ -370,6 +365,12 @@ private fun LedgerRow(
     valueColor: Color = MaterialTheme.colorScheme.onSurface,
     tag: String? = null,
     onClick: (() -> Unit)? = null,
+    // Right-aligned relative-age suffix (e.g. "(3 days ago)") for the date rows;
+    // null omits it. The value keeps the left, weight(1f) pushes this to the right
+    // edge, so the suffixes line up in their own column. [trailingColor] tints it —
+    // the SYNCED row grades it by staleness, the others use the muted default.
+    trailing: String? = null,
+    trailingColor: Color? = null,
 ) {
     Row(
         horizontalArrangement = Arrangement.spacedBy(12.dp),
@@ -392,6 +393,70 @@ private fun LedgerRow(
             color = valueColor,
             modifier = Modifier.weight(1f),
         )
+        trailing?.let {
+            Text(
+                text = it,
+                style = MaterialTheme.typography.bodySmall,
+                color = trailingColor ?: MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+// Age-suffix colour stops: warm from the normal text colour through amber to
+// orange as a sync ages toward a week, then red once it is a week or more stale.
+private val SyncAgeYellow = Color(0xFFFBC02D)
+private val SyncAgeOrange = Color(0xFFF57C00)
+private val SyncAgeRed = Color(0xFFC62828)
+
+// ageParenthetical is the right-aligned relative-age suffix a date row shows,
+// e.g. "(3 days ago)", or null when the timestamp can't be parsed (the row then
+// just shows the date). Shared by the SYNCED, VERIFIED and ADDED rows.
+private fun ageParenthetical(
+    timestamp: String,
+    now: Long = System.currentTimeMillis(),
+): String? {
+    val ts =
+        try {
+            Instant.parse(timestamp).toEpochMilli()
+        } catch (e: Exception) {
+            return null
+        }
+    return "(" + relativeAgo((now - ts).coerceAtLeast(0L)) + ")"
+}
+
+// syncAgeColorFor grades the SYNCED row's age suffix by staleness (see
+// [syncAgeColor]); the other date rows leave [trailingColor] null (muted default).
+// Falls back to the muted colour on an unparseable stamp, though the suffix is
+// then absent anyway.
+@Composable
+private fun syncAgeColorFor(
+    timestamp: String,
+    now: Long = System.currentTimeMillis(),
+): Color {
+    val muted = MaterialTheme.colorScheme.onSurfaceVariant
+    val ts =
+        try {
+            Instant.parse(timestamp).toEpochMilli()
+        } catch (e: Exception) {
+            return muted
+        }
+    return syncAgeColor((now - ts).coerceAtLeast(0L), MaterialTheme.colorScheme.onSurface)
+}
+
+// syncAgeColor grades the age suffix from [base] (fresh) through amber to orange
+// as it nears a week, then red at a week or older.
+internal fun syncAgeColor(
+    elapsedMs: Long,
+    base: Color,
+): Color {
+    val days = elapsedMs / 86_400_000.0
+    if (days >= 7.0) return SyncAgeRed
+    val f = (days / 7.0).coerceIn(0.0, 1.0).toFloat()
+    return if (f < 0.5f) {
+        lerp(base, SyncAgeYellow, f / 0.5f)
+    } else {
+        lerp(SyncAgeYellow, SyncAgeOrange, (f - 0.5f) / 0.5f)
     }
 }
 

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -46,6 +47,10 @@ import com.hugalafutro.bellhop.data.LockConfig
 import com.hugalafutro.bellhop.data.LockTimeout
 import com.hugalafutro.bellhop.ui.common.FilterPill
 import com.hugalafutro.bellhop.ui.theme.BellhopTheme
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
 
 /**
  * SettingsScreen is where the link's status and the two things the dashboard
@@ -79,11 +84,15 @@ fun SettingsScreen(
     unlinkFailed: Boolean = false,
     onDismissUnlinkError: () -> Unit = {},
     onForceUnlink: () -> Unit = {},
+    holdToCopy: Boolean = false,
+    onToggleHoldToCopy: (Boolean) -> Unit = {},
 ) {
     var confirmUnlink by remember { mutableStateOf(false) }
+    var confirmCopyAddress by remember { mutableStateOf(false) }
     val clipboard = LocalClipboardManager.current
     val context = LocalContext.current
     val pushCopied = stringResource(R.string.settings_push_copied)
+    val addressCopied = stringResource(R.string.settings_fd_copied)
 
     if (unlinkFailed) {
         AlertDialog(
@@ -149,6 +158,32 @@ fun SettingsScreen(
         )
     }
 
+    if (confirmCopyAddress) {
+        val address = link.fdUrl
+        AlertDialog(
+            onDismissRequest = { confirmCopyAddress = false },
+            title = { Text(stringResource(R.string.settings_fd_copy_title)) },
+            text = { Text(stringResource(R.string.settings_fd_copy_body, address)) },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        confirmCopyAddress = false
+                        clipboard.setText(AnnotatedString(address))
+                        Toast.makeText(context, addressCopied, Toast.LENGTH_SHORT).show()
+                    },
+                    modifier = Modifier.testTag("settings-fd-copy-confirm"),
+                ) {
+                    Text(stringResource(R.string.common_copy))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { confirmCopyAddress = false }) {
+                    Text(stringResource(R.string.common_cancel))
+                }
+            },
+        )
+    }
+
     Scaffold(modifier = modifier.fillMaxSize()) { innerPadding ->
         Column(
             modifier =
@@ -189,26 +224,70 @@ fun SettingsScreen(
                         style = MaterialTheme.typography.labelMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
+                    // A Front Desk has no separate name — the pairing string only
+                    // carries its address — so the bold line is its URL, and there
+                    // is no redundant subtext beneath it. Tapping it offers to copy
+                    // the address (confirmed, since a stray tap here is easy).
                     Text(
                         text = link.fdName.ifBlank { link.fdUrl },
                         style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
-                        modifier = Modifier.testTag("settings-fd-name"),
+                        modifier =
+                            Modifier
+                                .clickable { confirmCopyAddress = true }
+                                .testTag("settings-fd-name"),
                     )
-                    Text(
-                        text = link.fdUrl,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
+                    linkedOnLabel(link.linkedAt)?.let { date ->
+                        Text(
+                            text = stringResource(R.string.settings_fd_linked_on, date),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.testTag("settings-fd-linked-on"),
+                        )
+                    }
                     Text(
                         text = stringResource(R.string.dashboard_linked_as, link.label, link.role),
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier = Modifier.testTag("settings-linked"),
                     )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Copy gesture: whether a tap or a long-press copies a log/member cell.
+            // Hold (the default) guards against stray copies while scrolling a list.
+            Card(modifier = Modifier.fillMaxWidth()) {
+                Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = stringResource(R.string.settings_hold_copy_title),
+                                style = MaterialTheme.typography.titleMedium,
+                            )
+                            Text(
+                                text = stringResource(R.string.settings_hold_copy_subtitle),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                        Switch(
+                            checked = holdToCopy,
+                            onCheckedChange = onToggleHoldToCopy,
+                            // Same off-state colours as the other switches so an off
+                            // toggle stays legible on the card.
+                            colors =
+                                SwitchDefaults.colors(
+                                    uncheckedThumbColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    uncheckedTrackColor = MaterialTheme.colorScheme.surface,
+                                    uncheckedBorderColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                                ),
+                            modifier = Modifier.testTag("settings-hold-copy-toggle"),
+                        )
+                    }
                 }
             }
 
@@ -273,6 +352,10 @@ fun SettingsScreen(
                                     onClick = { onSelectTimeout(option) },
                                     tag = "settings-lock-timeout-${option.name}",
                                     modifier = Modifier.weight(1f),
+                                    // These pills sit inside a Card, where the default
+                                    // `outline` border nearly vanishes; use the higher-
+                                    // contrast onSurfaceVariant so the unselected pills read.
+                                    borderColor = MaterialTheme.colorScheme.onSurfaceVariant,
                                 )
                             }
                         }
@@ -468,6 +551,14 @@ fun SettingsScreen(
         }
     }
 }
+
+// A localized "Jul 14, 2026"-style date for when the link was paired, or null
+// when the stamp is absent (links saved before linkedAt existed) so the row hides.
+private val linkedOnFormatter: DateTimeFormatter =
+    DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).withZone(ZoneId.systemDefault())
+
+private fun linkedOnLabel(linkedAt: Long): String? =
+    if (linkedAt <= 0L) null else linkedOnFormatter.format(Instant.ofEpochMilli(linkedAt))
 
 private fun timeoutLabel(option: LockTimeout): Int =
     when (option) {

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -6,7 +6,7 @@
     <string name="pairing_title">Link a Front Desk</string>
     <string name="pairing_subtitle">In Front Desk, open Settings → Paired devices and generate a code. Scan the QR it shows, or copy the pairing string beside it and paste it below.</string>
     <string name="pairing_scan">Scan QR code</string>
-    <string name="pairing_scan_prompt">Point at the pairing QR in Front Desk → Settings → Paired devices</string>
+    <string name="pairing_scan_prompt">Point at the pairing QR in Front Desk\n→ Settings → Paired devices</string>
     <string name="pairing_or">or paste it</string>
     <string name="pairing_paste_label">Pairing string</string>
     <string name="pairing_paste_hint">Paste the copied pairing string here</string>
@@ -46,6 +46,7 @@
     <string name="member_detail_label_added">Added</string>
     <string name="member_url_title">Open member address</string>
     <string name="member_url_open">Open</string>
+    <string name="open_url_title">Open link</string>
     <!-- Operator actions -->
     <string name="member_op_title">Operator controls</string>
     <string name="member_op_drain">Drain</string>
@@ -57,14 +58,14 @@
     <string name="member_op_sync_failed">Sync finished with %1$d of %2$d members failing.</string>
     <string name="member_op_error">Couldn\'t apply: %1$s</string>
     <string name="member_op_dismiss">Dismiss</string>
-    <string name="member_op_last_sync">Fleet last synced %1$s</string>
+    <string name="member_op_last_sync">Last config change synced %1$s</string>
     <string name="member_op_busy">Another action is still running. Wait for it to finish, then try again.</string>
     <string name="member_op_forbidden">This device is paired as a monitor and can\'t change the fleet. Re-pair with an operator code in Front Desk to drain, activate, or sync.</string>
 
     <!-- Pause/resume auto-sync (dashboard operator control) -->
     <string name="autosync_title">Auto-sync</string>
-    <string name="autosync_on">On — the primary\'s config is kept in sync across the fleet.</string>
-    <string name="autosync_off">Off — the fleet won\'t follow the primary until you resume.</string>
+    <string name="autosync_on">The fleet stays in sync with the primary.</string>
+    <string name="autosync_off">The fleet won\'t sync until you resume.</string>
     <string name="autosync_pausing">Pausing…</string>
     <string name="autosync_resuming">Resuming…</string>
     <string name="autosync_busy">Another action is still running. Wait for it to finish, then try again.</string>
@@ -76,8 +77,9 @@
     <string name="events_open">Events</string>
     <string name="events_back">Back</string>
     <string name="events_empty">No events match.</string>
-    <string name="events_load_more">Load more</string>
     <string name="events_copied">Event copied to clipboard</string>
+    <string name="dashboard_member_copied">Member copied to clipboard</string>
+    <string name="scroll_to_top">Scroll to top</string>
     <plurals name="events_total">
         <item quantity="one">%1$d event</item>
         <item quantity="other">%1$d events</item>
@@ -135,6 +137,13 @@
     <string name="settings_title">Settings</string>
     <string name="settings_back">Back</string>
     <string name="settings_fd_title">Linked Front Desk</string>
+    <string name="settings_fd_linked_on">Linked on %1$s</string>
+    <string name="settings_fd_copy_title">Copy address?</string>
+    <string name="settings_fd_copy_body">Copy %1$s to the clipboard?</string>
+    <string name="settings_fd_copied">Address copied to clipboard</string>
+    <string name="common_copy">Copy</string>
+    <string name="settings_hold_copy_title">Hold to copy</string>
+    <string name="settings_hold_copy_subtitle">When on, long-press an event or member cell to copy it to the clipboard. When off, cells can\'t be copied.</string>
     <string name="settings_lock_title">App lock</string>
     <string name="settings_lock_subtitle">Require a fingerprint or device PIN to open Bellhop.</string>
     <string name="settings_lock_unavailable">Set up a fingerprint or a screen lock on this device to enable the app lock.</string>
@@ -174,6 +183,7 @@
     <string name="notif_stale_resumed_title">Auto-sync resumed</string>
     <string name="notif_stale_resumed_body">The fleet is being kept in sync again.</string>
 
+    <string name="dashboard_footer">Bellhop %1$s</string>
     <string name="dashboard_unlink">Unlink</string>
     <string name="dashboard_unlink_confirm_title">Unlink this device?</string>
     <string name="dashboard_unlink_confirm_body">This device will stop monitoring %1$s and its token will be revoked. You can pair again anytime with a new code.</string>

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/LinkStoreTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/LinkStoreTest.kt
@@ -61,4 +61,19 @@ class LinkStoreTest {
             assertEquals(LinkState.Unlinked, store.state.first())
             assertNull(store.token())
         }
+
+    @Test
+    fun saveStampsLinkedAt() =
+        runBlocking {
+            val store = newStore()
+            store.save(
+                fdUrl = "http://10.0.2.2:8080",
+                fdName = "Home Front Desk",
+                token = "device-token",
+                device = PairedDevice(id = "dev-1", label = "Pixel 8", role = "operator"),
+                now = 1_700_000_000_000L,
+            )
+            val state = store.state.first() as LinkState.Linked
+            assertEquals(1_700_000_000_000L, state.linkedAt)
+        }
 }

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreenTest.kt
@@ -3,18 +3,23 @@ package com.hugalafutro.bellhop.ui.dashboard
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import com.hugalafutro.bellhop.data.FdEvent
 import com.hugalafutro.bellhop.data.FleetMember
 import com.hugalafutro.bellhop.data.HealthStatus
 import com.hugalafutro.bellhop.data.LinkState
 import com.hugalafutro.bellhop.data.MemberStatus
 import com.hugalafutro.bellhop.ui.theme.BellhopTheme
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.shadows.ShadowToast
 
 /**
  * Linked-state dashboard, post toolbar-trim: the title plus the events and
@@ -99,6 +104,77 @@ class DashboardScreenTest {
         composeTestRule.onNodeWithTag("dashboard-alerts").assertIsDisplayed()
         composeTestRule.onNodeWithTag("dashboard-alerts").performClick()
         assertTrue(opened == 1)
+    }
+
+    @Test
+    fun recentEventPillShowsAndOpensMember() {
+        var opened = ""
+        composeTestRule.setContent {
+            BellhopTheme {
+                DashboardScreen(
+                    link = link,
+                    ui =
+                        DashboardUiState(
+                            loading = false,
+                            members = allUp,
+                            recentEvents =
+                                mapOf("m1" to FdEvent(id = "e1", severity = "error", message = "health check failed")),
+                        ),
+                    onMemberClick = { opened = it },
+                )
+            }
+        }
+        val pill = composeTestRule.onNodeWithTag("member-recent-event-alpha")
+        pill.assertIsDisplayed()
+        pill.performClick()
+        assertEquals("m1", opened)
+    }
+
+    @Test
+    fun footerOpensGithubBehindConfirm() {
+        // One member: the list doesn't scroll, so the footer is pinned to the
+        // bottom of the screen (not a list item) and is reachable without scrolling.
+        composeTestRule.setContent {
+            BellhopTheme {
+                DashboardScreen(link = link, ui = DashboardUiState(loading = false, members = allUp))
+            }
+        }
+        composeTestRule.onNodeWithTag("dashboard-footer").performClick()
+        // The confirm-before-leaving dialog appears (its URL text carries this tag).
+        composeTestRule.onNodeWithTag("member-url-dialog-text").assertIsDisplayed()
+    }
+
+    @Test
+    fun holdToCopyLongPressCopiesMember() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                DashboardScreen(
+                    link = link,
+                    ui = DashboardUiState(loading = false, members = allUp),
+                    holdToCopy = true,
+                )
+            }
+        }
+        composeTestRule.onNodeWithTag("member-card-alpha").performTouchInput { longClick() }
+        composeTestRule.waitForIdle()
+        assertEquals(1, ShadowToast.shownToastCount())
+    }
+
+    @Test
+    fun memberTapStillOpensMemberUnderHoldToCopy() {
+        var opened = ""
+        composeTestRule.setContent {
+            BellhopTheme {
+                DashboardScreen(
+                    link = link,
+                    ui = DashboardUiState(loading = false, members = allUp),
+                    holdToCopy = true,
+                    onMemberClick = { opened = it },
+                )
+            }
+        }
+        composeTestRule.onNodeWithTag("member-card-alpha").performClick()
+        assertEquals("m1", opened)
     }
 
     @Test

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModelTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModelTest.kt
@@ -2,7 +2,10 @@ package com.hugalafutro.bellhop.ui.dashboard
 
 import com.hugalafutro.bellhop.data.ActionResult
 import com.hugalafutro.bellhop.data.AutoSyncConfig
+import com.hugalafutro.bellhop.data.EventQuery
+import com.hugalafutro.bellhop.data.EventsResponse
 import com.hugalafutro.bellhop.data.FakeCipher
+import com.hugalafutro.bellhop.data.FdEvent
 import com.hugalafutro.bellhop.data.FetchResult
 import com.hugalafutro.bellhop.data.FleetEvent
 import com.hugalafutro.bellhop.data.FleetMember
@@ -71,6 +74,21 @@ private class FakeFleetClient(
         fdUrl: String,
         token: String,
     ): FetchResult<AutoSyncConfig> = autoSyncResult
+
+    // Per-member event log for the cards' pills, keyed by member id (newest first).
+    // events() honours query.memberId and limit, so the dashboard's one-read-per-
+    // member fetch returns that member's own newest event; empty by default.
+    var eventsByMember: Map<String, List<FdEvent>> = emptyMap()
+
+    override suspend fun events(
+        fdUrl: String,
+        token: String,
+        query: EventQuery,
+    ): FetchResult<EventsResponse> {
+        val forMember = eventsByMember[query.memberId].orEmpty()
+        val page = if (query.limit > 0) forMember.take(query.limit) else forMember
+        return FetchResult.Success(EventsResponse(events = page, total = forMember.size))
+    }
 
     // Pause/resume operator action: canned result plus captured args so a test can
     // prove the toggle sends the unchanged primary.
@@ -170,6 +188,52 @@ class DashboardViewModelTest {
             assertNull(s.error)
             assertFalse(s.revoked)
             assertEquals("tok-1", client.lastToken)
+        }
+
+    @Test
+    fun eachCardGetsItsOwnMembersNewestEvent() =
+        runBlocking {
+            val m2 = member.copy(id = "m2", name = "hotel-2")
+            val client =
+                FakeFleetClient(
+                    membersResult = FetchResult.Success(listOf(member, m2)),
+                    autoSyncResult = FetchResult.Success(AutoSyncConfig(enabled = true, primaryId = "m1")),
+                )
+            // Per-member logs (newest first). The dashboard's limit=1 read must pick
+            // each member's own newest, even the primary (m1) whose events are old.
+            client.eventsByMember =
+                mapOf(
+                    "m1" to
+                        listOf(
+                            FdEvent(id = "e4", memberId = "m1", message = "newest m1"),
+                            FdEvent(id = "e3", memberId = "m1", message = "older m1"),
+                        ),
+                    "m2" to listOf(FdEvent(id = "e2", memberId = "m2", message = "only m2")),
+                )
+            val vm = DashboardViewModel(client, linkedStore(), "http://fd:1")
+
+            vm.refreshOnce()
+
+            val recent = vm.state.value.recentEvents
+            assertEquals("newest m1", recent["m1"]?.message)
+            assertEquals("only m2", recent["m2"]?.message)
+            assertEquals(2, recent.size)
+        }
+
+    @Test
+    fun memberWithNoEventsGetsNoPill() =
+        runBlocking {
+            val client =
+                FakeFleetClient(
+                    membersResult = FetchResult.Success(listOf(member)),
+                    autoSyncResult = FetchResult.Success(AutoSyncConfig(enabled = true, primaryId = "m1")),
+                )
+            // No per-member events configured, so the map stays empty (no pill).
+            val vm = DashboardViewModel(client, linkedStore(), "http://fd:1")
+
+            vm.refreshOnce()
+
+            assertTrue(vm.state.value.recentEvents.isEmpty())
         }
 
     private fun autoSyncClient(enabled: Boolean = true) =

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModelTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModelTest.kt
@@ -80,11 +80,16 @@ private class FakeFleetClient(
     // member fetch returns that member's own newest event; empty by default.
     var eventsByMember: Map<String, List<FdEvent>> = emptyMap()
 
+    // When set, every events() call returns this instead of the canned per-member
+    // page — lets a test revoke the token on the pill fetch after members succeeds.
+    var eventsResult: FetchResult<EventsResponse>? = null
+
     override suspend fun events(
         fdUrl: String,
         token: String,
         query: EventQuery,
     ): FetchResult<EventsResponse> {
+        eventsResult?.let { return it }
         val forMember = eventsByMember[query.memberId].orEmpty()
         val page = if (query.limit > 0) forMember.take(query.limit) else forMember
         return FetchResult.Success(EventsResponse(events = page, total = forMember.size))
@@ -395,6 +400,22 @@ class DashboardViewModelTest {
     fun unauthorizedFlagsRevoked() =
         runBlocking {
             val vm = DashboardViewModel(FakeFleetClient(FetchResult.Unauthorized), linkedStore(), "http://fd:1")
+            vm.refreshOnce()
+            assertTrue(vm.state.value.revoked)
+            assertFalse(vm.state.value.loading)
+        }
+
+    @Test
+    fun eventsUnauthorizedMidRefreshFlagsRevoked() =
+        runBlocking {
+            // Token revoked between the members read (still Success) and the per-
+            // member pill fetch: the pill's 401 must trip the same revoked state,
+            // not be swallowed into a healthy refresh that keeps polling.
+            val client =
+                FakeFleetClient(membersResult = FetchResult.Success(listOf(member))).apply {
+                    eventsResult = FetchResult.Unauthorized
+                }
+            val vm = DashboardViewModel(client, linkedStore(), "http://fd:1")
             vm.refreshOnce()
             assertTrue(vm.state.value.revoked)
             assertFalse(vm.state.value.loading)

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/events/EventsScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/events/EventsScreenTest.kt
@@ -3,10 +3,13 @@ package com.hugalafutro.bellhop.ui.events
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToIndex
 import androidx.compose.ui.test.performScrollToNode
+import androidx.compose.ui.test.performTouchInput
 import com.hugalafutro.bellhop.data.FdEvent
 import com.hugalafutro.bellhop.ui.common.EventRange
 import com.hugalafutro.bellhop.ui.theme.BellhopTheme
@@ -16,6 +19,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.shadows.ShadowToast
 
 /**
  * Event log: filter chips, event cards, load-more tail, banners.
@@ -112,6 +116,40 @@ class EventsScreenTest {
     }
 
     @Test
+    fun copyDisabledNeitherTapNorHoldCopies() {
+        // With hold-to-copy off (the default here), the row is inert: neither a
+        // tap nor a long-press copies, so nothing lands on the clipboard.
+        composeTestRule.setContent {
+            BellhopTheme {
+                EventsScreen(onBack = {}, ui = loaded, holdToCopy = false)
+            }
+        }
+        val pill = composeTestRule.onNodeWithTag("event-sev-error", useUnmergedTree = true)
+        pill.performClick()
+        pill.performTouchInput { longClick() }
+        composeTestRule.waitForIdle()
+        assertEquals(0, ShadowToast.shownToastCount())
+    }
+
+    @Test
+    fun holdToCopyRequiresLongPressNotTap() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                EventsScreen(onBack = {}, ui = loaded, holdToCopy = true)
+            }
+        }
+        val pill = composeTestRule.onNodeWithTag("event-sev-error", useUnmergedTree = true)
+        // With the hold gate on, a stray tap is inert: nothing copies, no toast.
+        pill.performClick()
+        composeTestRule.waitForIdle()
+        assertEquals(0, ShadowToast.shownToastCount())
+        // The long-press is what copies, confirmed by the toast.
+        pill.performTouchInput { longClick() }
+        composeTestRule.waitForIdle()
+        assertEquals(1, ShadowToast.shownToastCount())
+    }
+
+    @Test
     fun severityChipFiresCallback() {
         var picked = ""
         composeTestRule.setContent {
@@ -136,7 +174,9 @@ class EventsScreenTest {
     }
 
     @Test
-    fun loadMoreShownOnlyWhileServerHoldsMore() {
+    fun scrollingToTheEndAutoLoadsMore() {
+        // Infinite scroll: composing the sentinel (which only happens at the end of
+        // the list) fires onLoadMore, no button tap.
         var loads = 0
         composeTestRule.setContent {
             BellhopTheme {
@@ -145,25 +185,43 @@ class EventsScreenTest {
         }
         composeTestRule
             .onNodeWithTag("events-list")
-            .performScrollToNode(hasTestTag("events-load-more"))
-        composeTestRule.onNodeWithTag("events-load-more").performClick()
-        assertEquals(1, loads)
+            .performScrollToNode(hasTestTag("events-load-more-sentinel"))
+        assertTrue(loads >= 1)
     }
 
     @Test
-    fun loadMoreHiddenWhenAllRowsLoaded() {
+    fun scrollToTopButtonAppearsWhenScrolledAndReturnsToTop() {
+        val many = loaded.copy(events = List(40) { ev("e$it") }, total = 40)
+        composeTestRule.setContent {
+            BellhopTheme {
+                EventsScreen(onBack = {}, ui = many)
+            }
+        }
+        // At the top the control is absent.
+        composeTestRule.onNodeWithTag("scroll-to-top").assertDoesNotExist()
+        // Scrolling down reveals it.
+        composeTestRule.onNodeWithTag("events-list").performScrollToIndex(30)
+        composeTestRule.onNodeWithTag("scroll-to-top").assertIsDisplayed()
+        // Tapping it returns to the top, and the control hides itself again.
+        composeTestRule.onNodeWithTag("scroll-to-top").performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag("scroll-to-top").assertDoesNotExist()
+    }
+
+    @Test
+    fun noSentinelWhenAllRowsLoaded() {
         composeTestRule.setContent {
             BellhopTheme {
                 EventsScreen(onBack = {}, ui = loaded)
             }
         }
         assertTrue(
-            composeTestRule.onAllNodesWithTag("events-load-more").fetchSemanticsNodes().isEmpty(),
+            composeTestRule.onAllNodesWithTag("events-load-more-sentinel").fetchSemanticsNodes().isEmpty(),
         )
     }
 
     @Test
-    fun loadingMoreSwapsButtonForSpinner() {
+    fun loadingMoreShowsSpinnerNotSentinel() {
         composeTestRule.setContent {
             BellhopTheme {
                 EventsScreen(onBack = {}, ui = loaded.copy(total = 5, loadingMore = true))
@@ -174,7 +232,7 @@ class EventsScreenTest {
             .performScrollToNode(hasTestTag("events-loading-more"))
         composeTestRule.onNodeWithTag("events-loading-more").assertIsDisplayed()
         assertTrue(
-            composeTestRule.onAllNodesWithTag("events-load-more").fetchSemanticsNodes().isEmpty(),
+            composeTestRule.onAllNodesWithTag("events-load-more-sentinel").fetchSemanticsNodes().isEmpty(),
         )
     }
 

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreenTest.kt
@@ -3,11 +3,13 @@ package com.hugalafutro.bellhop.ui.member
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollToIndex
 import androidx.compose.ui.test.performScrollToNode
+import androidx.compose.ui.test.performTouchInput
 import com.hugalafutro.bellhop.data.FdEvent
 import com.hugalafutro.bellhop.data.FleetMember
 import com.hugalafutro.bellhop.data.HealthStatus
@@ -16,12 +18,14 @@ import com.hugalafutro.bellhop.data.MemberTraffic
 import com.hugalafutro.bellhop.data.TrafficPoint
 import com.hugalafutro.bellhop.ui.common.EventRange
 import com.hugalafutro.bellhop.ui.theme.BellhopTheme
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.shadows.ShadowToast
 
 /**
  * Member detail: identity header, traffic states, and the back affordance.
@@ -140,6 +144,65 @@ class MemberDetailScreenTest {
         assertTrue(
             composeTestRule.onAllNodesWithTag("member-event-row").fetchSemanticsNodes().isNotEmpty(),
         )
+    }
+
+    @Test
+    fun holdToCopyLongPressCopiesEventRow() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                MemberDetailScreen(
+                    member = member,
+                    isPrimary = false,
+                    onBack = {},
+                    holdToCopy = true,
+                    ui =
+                        MemberDetailUiState(
+                            loading = false,
+                            traffic = reachableTraffic,
+                            events = listOf(FdEvent(id = "e1", severity = "error", message = "down", memberId = "m1")),
+                        ),
+                )
+            }
+        }
+        composeTestRule
+            .onNodeWithTag("member-detail-list")
+            .performScrollToNode(hasTestTag("member-event-row"))
+        val rail = composeTestRule.onNodeWithTag("member-event-sev-error", useUnmergedTree = true)
+        // A stray tap is inert; only the long-press copies (confirmed by the toast).
+        rail.performClick()
+        composeTestRule.waitForIdle()
+        assertEquals(0, ShadowToast.shownToastCount())
+        rail.performTouchInput { longClick() }
+        composeTestRule.waitForIdle()
+        assertEquals(1, ShadowToast.shownToastCount())
+    }
+
+    @Test
+    fun copyDisabledLeavesEventRowInert() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                MemberDetailScreen(
+                    member = member,
+                    isPrimary = false,
+                    onBack = {},
+                    holdToCopy = false,
+                    ui =
+                        MemberDetailUiState(
+                            loading = false,
+                            traffic = reachableTraffic,
+                            events = listOf(FdEvent(id = "e1", severity = "error", message = "down", memberId = "m1")),
+                        ),
+                )
+            }
+        }
+        composeTestRule
+            .onNodeWithTag("member-detail-list")
+            .performScrollToNode(hasTestTag("member-event-row"))
+        val rail = composeTestRule.onNodeWithTag("member-event-sev-error", useUnmergedTree = true)
+        rail.performClick()
+        rail.performTouchInput { longClick() }
+        composeTestRule.waitForIdle()
+        assertEquals(0, ShadowToast.shownToastCount())
     }
 
     @Test

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreenTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToIndex
 import androidx.compose.ui.test.performScrollToNode
 import com.hugalafutro.bellhop.data.FdEvent
 import com.hugalafutro.bellhop.data.FleetMember
@@ -507,6 +508,35 @@ class MemberDetailScreenTest {
             .performScrollToNode(hasTestTag("member-events-range-h24"))
         composeTestRule.onNodeWithTag("member-events-range-h24").performClick()
         assertTrue(picked == EventRange.H24)
+    }
+
+    @Test
+    fun scrollToTopButtonAppearsOnTheMemberListAndReturnsToTop() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                MemberDetailScreen(
+                    member = member,
+                    isPrimary = false,
+                    onBack = {},
+                    ui =
+                        MemberDetailUiState(
+                            loading = false,
+                            traffic = reachableTraffic,
+                            events =
+                                List(30) {
+                                    FdEvent(id = "e$it", severity = "info", message = "row $it", memberId = "m1")
+                                },
+                            eventsTotal = 30,
+                        ),
+                )
+            }
+        }
+        composeTestRule.onNodeWithTag("scroll-to-top").assertDoesNotExist()
+        composeTestRule.onNodeWithTag("member-detail-list").performScrollToIndex(25)
+        composeTestRule.onNodeWithTag("scroll-to-top").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("scroll-to-top").performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag("scroll-to-top").assertDoesNotExist()
     }
 
     @Test

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/SyncAgeTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/SyncAgeTest.kt
@@ -1,0 +1,42 @@
+package com.hugalafutro.bellhop.ui.member
+
+import androidx.compose.ui.graphics.Color
+import com.hugalafutro.bellhop.ui.common.relativeAgo
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SyncAgeTest {
+    private val minute = 60_000L
+    private val hour = 3_600_000L
+    private val day = 86_400_000L
+
+    @Test
+    fun relativeAgoReadsHumanAtEachScale() {
+        assertEquals("just now", relativeAgo(30_000L))
+        assertEquals("5 min ago", relativeAgo(5 * minute))
+        assertEquals("3 hr ago", relativeAgo(3 * hour))
+        assertEquals("1 day ago", relativeAgo(day))
+        assertEquals("3 days ago", relativeAgo(3 * day))
+    }
+
+    @Test
+    fun freshSyncKeepsTheBaseColour() {
+        val base = Color(0xFF102030)
+        assertEquals(base, syncAgeColor(0L, base))
+    }
+
+    @Test
+    fun weekOldOrOlderTurnsRed() {
+        val base = Color(0xFF102030)
+        val red = Color(0xFFC62828)
+        assertEquals(red, syncAgeColor(7 * day, base))
+        assertEquals(red, syncAgeColor(30 * day, base))
+    }
+
+    @Test
+    fun halfwayHitsTheAmberStop() {
+        // At 3.5 days (half of the 7-day window) the grade reaches the amber stop.
+        val base = Color(0xFF102030)
+        assertEquals(Color(0xFFFBC02D), syncAgeColor((3.5 * day).toLong(), base))
+    }
+}

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreenTest.kt
@@ -36,6 +36,7 @@ class SettingsScreenTest {
         )
 
     private fun content(
+        link: LinkState.Linked = this.link,
         lockConfig: LockConfig = LockConfig(enabled = false, timeoutMs = LockTimeout.THIRTY_MINUTES.millis),
         lockAvailable: Boolean = true,
         monitorEnabled: Boolean = false,
@@ -45,10 +46,12 @@ class SettingsScreenTest {
         pushDistributorAvailable: Boolean = true,
         pushNotificationsBlocked: Boolean = false,
         unlinkFailed: Boolean = false,
+        holdToCopy: Boolean = false,
         onToggleLock: (Boolean) -> Unit = {},
         onSelectTimeout: (LockTimeout) -> Unit = {},
         onToggleMonitor: (Boolean) -> Unit = {},
         onTogglePush: (Boolean) -> Unit = {},
+        onToggleHoldToCopy: (Boolean) -> Unit = {},
         onAlertsClick: () -> Unit = {},
         onUnlink: () -> Unit = {},
         onForceUnlink: () -> Unit = {},
@@ -76,6 +79,8 @@ class SettingsScreenTest {
                     unlinkFailed = unlinkFailed,
                     onDismissUnlinkError = onDismissUnlinkError,
                     onForceUnlink = onForceUnlink,
+                    holdToCopy = holdToCopy,
+                    onToggleHoldToCopy = onToggleHoldToCopy,
                 )
             }
         }
@@ -87,6 +92,36 @@ class SettingsScreenTest {
         composeTestRule.onNodeWithTag("settings-title").assertIsDisplayed()
         composeTestRule.onNodeWithTag("settings-fd-name").assertIsDisplayed()
         composeTestRule.onNodeWithTag("settings-linked").assertIsDisplayed()
+    }
+
+    @Test
+    fun linkedOnRowHiddenWithoutStamp() {
+        // A link saved before linkedAt existed carries no stamp, so the date row hides.
+        content()
+        composeTestRule.onNodeWithTag("settings-fd-linked-on").assertDoesNotExist()
+    }
+
+    @Test
+    fun linkedOnRowShownWithStamp() {
+        content(link = link.copy(linkedAt = 1_700_000_000_000L))
+        composeTestRule.onNodeWithTag("settings-fd-linked-on").assertIsDisplayed()
+    }
+
+    @Test
+    fun tappingFdNameAsksBeforeCopyingAddress() {
+        content()
+        // The name only opens the confirm dialog on tap; the copy is the second step.
+        composeTestRule.onNodeWithTag("settings-fd-copy-confirm").assertDoesNotExist()
+        composeTestRule.onNodeWithTag("settings-fd-name").performClick()
+        composeTestRule.onNodeWithTag("settings-fd-copy-confirm").assertIsDisplayed()
+    }
+
+    @Test
+    fun togglingHoldToCopyFiresCallback() {
+        var toggledTo: Boolean? = null
+        content(holdToCopy = false, onToggleHoldToCopy = { toggledTo = it })
+        composeTestRule.onNodeWithTag("settings-hold-copy-toggle").performScrollTo().performClick()
+        assertEquals(true, toggledTo)
     }
 
     @Test
@@ -110,7 +145,7 @@ class SettingsScreenTest {
             lockConfig = LockConfig(enabled = true, timeoutMs = LockTimeout.THIRTY_MINUTES.millis),
             onSelectTimeout = { picked = it },
         )
-        composeTestRule.onNodeWithTag("settings-lock-timeout-FIVE_MINUTES").performClick()
+        composeTestRule.onNodeWithTag("settings-lock-timeout-FIVE_MINUTES").performScrollTo().performClick()
         assertEquals(LockTimeout.FIVE_MINUTES, picked)
     }
 


### PR DESCRIPTION
A UI-polish pass on the Bellhop Android companion, gathered across several rounds of on-device testing.

## Copy gestures
- New `PrefsStore` ("Hold to copy" Settings toggle, default on). When on, event cells and member cards copy on long-press; when off, they don't copy at all. Hold is now the only copy path.
- Gesture plumbed via `SeverityRailRow.onLongClick` and `MemberCard`'s `combinedClickable`.

## Dashboard
- Recent-event pill under each member's sparkline showing that member's single newest event (per-member `EventQuery(limit=1)` read) with a right-aligned relative age. Tapping the card or pill opens that member's detail log (newest-first, so the event is at top).
- Two-tone version footer (brass link) stamped with the short HEAD sha via `BuildConfig.GIT_COMMIT`, deep-linking the commit on GitHub behind a confirm modal. Pins to the screen bottom when the list fits, scrolls off when it doesn't.
- Portrait-locked (landscape washed out the pill sparklines).

## Lists
- Events screen switched from a manual "Load more" button to sentinel-based infinite scroll, sharing `LoadMoreSentinel` with the member-detail log.
- Floating scroll-to-top button (shared `ScrollToTopButton`) on Events, the dashboard member list, and the member-detail log; auto-hides at the top.

## Member detail
- All three date rows (SYNCED / VERIFIED / ADDED) show a right-aligned "(3 days ago)" relative-age suffix. Only SYNCED grades its suffix by staleness (normal -> amber -> orange -> red at 7 days).

## Settings
- FD card redesign: dropped the redundant address subtext, bold clickable name copies the address via a shared confirm dialog, added a "Linked on <date>" row (new persisted `linkedAt`).
- Lock-timeout pills use a more visible border so the unselected state reads against the card.

## Review follow-ups (last commit)
- Restored `Role.Button` on `MemberCard` (the switch from `Card(onClick=)` to `combinedClickable` had dropped it, breaking TalkBack).
- Cached the RFC3339 -> relative-age parses in `remember` keyed on the timestamp.

Postponed to a future PR (needs backend work to expose the enabled-alert subset): colored severity badges on the Settings Alerts pill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)