### PR TITLE
feat(frontdesk): operator-facing alert-event selection API

### DIFF
--- a/internal/frontdesk/alerts.go
+++ b/internal/frontdesk/alerts.go
@@ -3,6 +3,7 @@ package frontdesk
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/hugalafutro/model-hotel/internal/alert"
 	"github.com/hugalafutro/model-hotel/internal/auth"
@@ -84,4 +85,29 @@ func (p alertConfigProvider) APIBaseURL(ctx context.Context) (string, error) {
 		return "", err
 	}
 	return set.AlertAppriseAPIURL, nil
+}
+
+// fdCatalogHas reports whether t is a known alertable Type. A single-event toggle
+// rejects anything not in the catalog rather than persist config for an event
+// Front Desk never emits.
+func fdCatalogHas(t string) bool {
+	for _, def := range fdCatalog {
+		if def.Type == t {
+			return true
+		}
+	}
+	return false
+}
+
+// enabledCSV serializes an enabled-event set back to the stored alert_events CSV
+// in catalog order, dropping any Type not in fdCatalog so a stale row self-heals
+// on the next write.
+func enabledCSV(enabled map[string]bool) string {
+	on := make([]string, 0, len(fdCatalog))
+	for _, def := range fdCatalog {
+		if enabled[def.Type] {
+			on = append(on, def.Type)
+		}
+	}
+	return strings.Join(on, ",")
 }

--- a/internal/frontdesk/alerts_test.go
+++ b/internal/frontdesk/alerts_test.go
@@ -397,3 +397,125 @@ func TestAlertTestEndpointFailsWithoutConfig(t *testing.T) {
 		t.Fatalf("POST /api/alert/test (unconfigured) = %d, want 502", rec.Code)
 	}
 }
+
+// selectionResp is the wire shape of GET/POST /api/alert/selection in tests.
+type selectionResp struct {
+	Events []struct {
+		Type    string `json:"type"`
+		Enabled bool   `json:"enabled"`
+	} `json:"events"`
+}
+
+func decodeSelection(t *testing.T, rec *httptest.ResponseRecorder) selectionResp {
+	t.Helper()
+	var out selectionResp
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode selection: %v", err)
+	}
+	return out
+}
+
+func (s selectionResp) enabledOf(typ string) (on, found bool) {
+	for _, e := range s.Events {
+		if e.Type == typ {
+			return e.Enabled, true
+		}
+	}
+	return false, false
+}
+
+// TestAlertSelectionEndpoint covers the operator-facing picker: a monitor may
+// read the selection but not flip it, an operator flips events on and off, the
+// stored CSV follows, and an unknown event Type is rejected.
+func TestAlertSelectionEndpoint(t *testing.T) {
+	srv, store := newTestServer(t)
+	ctx := context.Background()
+	opToken, _ := pairDevice(t, srv, RoleOperator, "Pixel")
+	monToken, _ := pairDevice(t, srv, RoleMonitor, "Tablet")
+
+	// A monitor device can read the selection; it mirrors the seeded catalog
+	// defaults (health.down is default-on, member.added default-off).
+	rec := doDevice(t, srv, http.MethodGet, "/api/alert/selection", "", monToken)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("monitor GET selection = %d: %s", rec.Code, rec.Body.String())
+	}
+	sel := decodeSelection(t, rec)
+	if len(sel.Events) != len(fdCatalog) {
+		t.Fatalf("selection has %d events, want %d", len(sel.Events), len(fdCatalog))
+	}
+	if on, ok := sel.enabledOf("health.down"); !ok || !on {
+		t.Errorf("health.down should be enabled by default (on=%v ok=%v)", on, ok)
+	}
+	if on, ok := sel.enabledOf("member.added"); !ok || on {
+		t.Errorf("member.added should be default-off (on=%v ok=%v)", on, ok)
+	}
+
+	// A monitor may not flip it.
+	if rec := doDevice(t, srv, http.MethodPost, "/api/alert/selection",
+		`{"type":"health.down","enabled":false}`, monToken); rec.Code != http.StatusForbidden {
+		t.Fatalf("monitor POST selection = %d, want 403", rec.Code)
+	}
+
+	// An operator turns health.down off; the response and the stored CSV both follow.
+	rec = doDevice(t, srv, http.MethodPost, "/api/alert/selection",
+		`{"type":"health.down","enabled":false}`, opToken)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("operator disable = %d: %s", rec.Code, rec.Body.String())
+	}
+	if on, _ := decodeSelection(t, rec).enabledOf("health.down"); on {
+		t.Error("health.down still enabled in POST response")
+	}
+	set, err := store.GetSettings(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if alert.ParseEnabled(set.AlertEvents)["health.down"] {
+		t.Errorf("health.down still enabled in stored CSV %q", set.AlertEvents)
+	}
+
+	// An operator turns a default-off event on.
+	rec = doDevice(t, srv, http.MethodPost, "/api/alert/selection",
+		`{"type":"member.added","enabled":true}`, opToken)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("operator enable = %d: %s", rec.Code, rec.Body.String())
+	}
+	if on, _ := decodeSelection(t, rec).enabledOf("member.added"); !on {
+		t.Error("member.added not enabled after toggle-on")
+	}
+
+	// An unknown event Type is rejected, not silently persisted.
+	if rec := doDevice(t, srv, http.MethodPost, "/api/alert/selection",
+		`{"type":"not.real","enabled":true}`, opToken); rec.Code != http.StatusBadRequest {
+		t.Fatalf("unknown event POST = %d, want 400", rec.Code)
+	}
+}
+
+// TestAlertSelectionPreservesSecret proves flipping an event via the operator
+// endpoint rewrites only alert_events and never round-trips (and so never
+// clobbers) the encrypted Apprise target sharing the settings row.
+func TestAlertSelectionPreservesSecret(t *testing.T) {
+	srv, store := newTestServer(t)
+	ctx := context.Background()
+	opToken, _ := pairDevice(t, srv, RoleOperator, "Pixel")
+
+	// Admin stores an encrypted target.
+	if rec := do(t, srv, http.MethodPut, "/api/settings",
+		`{"alert_apprise_targets":"tgram://tok/chat"}`, true); rec.Code != http.StatusOK {
+		t.Fatalf("PUT settings = %d: %s", rec.Code, rec.Body.String())
+	}
+	// Operator flips an event.
+	if rec := doDevice(t, srv, http.MethodPost, "/api/alert/selection",
+		`{"type":"config.synced","enabled":true}`, opToken); rec.Code != http.StatusOK {
+		t.Fatalf("operator toggle = %d: %s", rec.Code, rec.Body.String())
+	}
+	set, err := store.GetSettings(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := auth.DecryptString(set.AlertAppriseTargets, testMasterKey); got != "tgram://tok/chat" {
+		t.Errorf("toggle clobbered target: %q", got)
+	}
+	if !alert.ParseEnabled(set.AlertEvents)["config.synced"] {
+		t.Error("config.synced not enabled after toggle")
+	}
+}

--- a/internal/frontdesk/alerts_test.go
+++ b/internal/frontdesk/alerts_test.go
@@ -488,6 +488,12 @@ func TestAlertSelectionEndpoint(t *testing.T) {
 		`{"type":"not.real","enabled":true}`, opToken); rec.Code != http.StatusBadRequest {
 		t.Fatalf("unknown event POST = %d, want 400", rec.Code)
 	}
+
+	// A malformed body is rejected before any settings read.
+	if rec := doDevice(t, srv, http.MethodPost, "/api/alert/selection",
+		`not json`, opToken); rec.Code != http.StatusBadRequest {
+		t.Fatalf("malformed POST = %d, want 400", rec.Code)
+	}
 }
 
 // TestAlertSelectionPreservesSecret proves flipping an event via the operator
@@ -517,5 +523,50 @@ func TestAlertSelectionPreservesSecret(t *testing.T) {
 	}
 	if !alert.ParseEnabled(set.AlertEvents)["config.synced"] {
 		t.Error("config.synced not enabled after toggle")
+	}
+}
+
+// TestAlertSelectionStoreErrors covers the store-failure branches. It drives the
+// endpoints with the admin bearer (its auth never touches the DB, so a broken
+// store still reaches the handler): a closed DB fails the settings read on both
+// verbs, and a read-only (query_only) DB fails only the alert_events write.
+func TestAlertSelectionStoreErrors(t *testing.T) {
+	t.Run("read failure", func(t *testing.T) {
+		srv, store := newTestServer(t)
+		if err := store.Close(); err != nil {
+			t.Fatalf("close store: %v", err)
+		}
+		if rec := do(t, srv, http.MethodGet, "/api/alert/selection", "", true); rec.Code != http.StatusInternalServerError {
+			t.Errorf("GET on closed store = %d, want 500", rec.Code)
+		}
+		if rec := do(t, srv, http.MethodPost, "/api/alert/selection",
+			`{"type":"health.down","enabled":false}`, true); rec.Code != http.StatusInternalServerError {
+			t.Errorf("POST on closed store = %d, want 500", rec.Code)
+		}
+	})
+
+	t.Run("write failure", func(t *testing.T) {
+		srv, store := newTestServer(t)
+		// Pin to a single connection so the read-only pragma sticks, then make that
+		// connection reject writes: GetSettings still reads, SetAlertEvents fails.
+		store.DB().SetMaxOpenConns(1)
+		if _, err := store.DB().Exec("PRAGMA query_only = ON"); err != nil {
+			t.Fatalf("query_only: %v", err)
+		}
+		if rec := do(t, srv, http.MethodPost, "/api/alert/selection",
+			`{"type":"health.down","enabled":false}`, true); rec.Code != http.StatusInternalServerError {
+			t.Errorf("POST on read-only store = %d, want 500: %s", rec.Code, rec.Body.String())
+		}
+	})
+}
+
+// TestSetAlertEventsClosedStore exercises the store method's own error path.
+func TestSetAlertEventsClosedStore(t *testing.T) {
+	store := newTestStore(t)
+	if err := store.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+	if err := store.SetAlertEvents(context.Background(), "health.down"); err == nil {
+		t.Error("SetAlertEvents on closed store returned nil error")
 	}
 }

--- a/internal/frontdesk/server.go
+++ b/internal/frontdesk/server.go
@@ -223,6 +223,7 @@ func (s *Server) buildRouter(wa *adminauth.WebAuthnHandler, tp *adminauth.TotpHa
 			r.Get("/observability", s.getObservability)
 			r.Get("/alert/events", s.alertEvents)
 			r.Get("/alert/status", s.alertStatus)
+			r.Get("/alert/selection", s.getAlertSelection)
 			r.Get("/events", s.listEvents)
 			r.Get("/traefik-status", s.traefikStatus)
 			r.Get("/fleet/status", s.fleetStatus)
@@ -237,6 +238,7 @@ func (s *Server) buildRouter(wa *adminauth.WebAuthnHandler, tp *adminauth.TotpHa
 				r.Post("/members/{id}/state", s.setMemberState)
 				r.Put("/fleet/autosync", s.putAutoSync)
 				r.Post("/config/sync", s.configSync)
+				r.Post("/alert/selection", s.putAlertSelection)
 			})
 
 			r.Group(func(r chi.Router) {

--- a/internal/frontdesk/server_alerts.go
+++ b/internal/frontdesk/server_alerts.go
@@ -73,12 +73,18 @@ func (s *Server) alertSelection(ctx context.Context) ([]alertEventState, error) 
 	if err != nil {
 		return nil, err
 	}
-	enabled := alert.ParseEnabled(set.AlertEvents)
+	return selectionFrom(alert.ParseEnabled(set.AlertEvents)), nil
+}
+
+// selectionFrom projects an enabled-event set onto the catalog, in catalog order,
+// so both the read handler and a just-applied toggle render the same shape without
+// a second settings read.
+func selectionFrom(enabled map[string]bool) []alertEventState {
 	out := make([]alertEventState, len(fdCatalog))
 	for i, def := range fdCatalog {
 		out[i] = alertEventState{EventDef: def, Enabled: enabled[def.Type]}
 	}
-	return out, nil
+	return out
 }
 
 // getAlertSelection (GET /api/alert/selection) returns the catalog with each
@@ -133,10 +139,5 @@ func (s *Server) putAlertSelection(w http.ResponseWriter, r *http.Request) {
 		Type: "settings.changed", Severity: "info", Source: "frontdesk",
 		Message: fmt.Sprintf("Alerting for %s %s by %s", req.Type, enabledWord(req.Enabled), actorFromContext(r.Context())),
 	})
-	sel, err := s.alertSelection(r.Context())
-	if err != nil {
-		writeError(w, err)
-		return
-	}
-	writeJSON(w, http.StatusOK, map[string]any{"events": sel})
+	writeJSON(w, http.StatusOK, map[string]any{"events": selectionFrom(enabled)})
 }

--- a/internal/frontdesk/server_alerts.go
+++ b/internal/frontdesk/server_alerts.go
@@ -2,8 +2,10 @@ package frontdesk
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
+	"github.com/hugalafutro/model-hotel/internal/alert"
 	"github.com/hugalafutro/model-hotel/internal/auth"
 )
 
@@ -53,4 +55,88 @@ func (s *Server) alertTest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// alertEventState is one catalog event plus whether Front Desk currently alerts
+// on it. It is the wire shape for the operator-facing selection endpoints so
+// Bellhop can render (and flip) the picker from a single call, without pulling
+// the whole admin-only settings row.
+type alertEventState struct {
+	alert.EventDef
+	Enabled bool `json:"enabled"`
+}
+
+// alertSelection folds the stored alert_events CSV over the catalog so every
+// event carries its current on/off state, in catalog order.
+func (s *Server) alertSelection(ctx context.Context) ([]alertEventState, error) {
+	set, err := s.store.GetSettings(ctx)
+	if err != nil {
+		return nil, err
+	}
+	enabled := alert.ParseEnabled(set.AlertEvents)
+	out := make([]alertEventState, len(fdCatalog))
+	for i, def := range fdCatalog {
+		out[i] = alertEventState{EventDef: def, Enabled: enabled[def.Type]}
+	}
+	return out, nil
+}
+
+// getAlertSelection (GET /api/alert/selection) returns the catalog with each
+// event's current alert-on state. Any paired device may read it (monitor role
+// included) so Bellhop can show what Front Desk alerts on; flipping it needs the
+// operator role (putAlertSelection).
+func (s *Server) getAlertSelection(w http.ResponseWriter, r *http.Request) {
+	sel, err := s.alertSelection(r.Context())
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"events": sel})
+}
+
+// putAlertSelection (POST /api/alert/selection, operator-only) flips a single
+// event on or off and echoes back the refreshed selection. A per-event toggle
+// (rather than a full-set replace) keeps a Bellhop built against an older or
+// newer catalog from clobbering events it does not know about. Only the
+// alert_events column is rewritten, so the encrypted Apprise target and OIDC
+// secret sharing that row are never round-tripped.
+func (s *Server) putAlertSelection(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Type    string `json:"type"`
+		Enabled bool   `json:"enabled"`
+	}
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	if !fdCatalogHas(req.Type) {
+		writeCodedError(w, http.StatusBadRequest, "unknown_alert_event",
+			fmt.Sprintf("no such alert event: %q", req.Type))
+		return
+	}
+	// Serialize with putSettings' read-merge-write so a concurrent full-settings
+	// save cannot lose this toggle (and this toggle cannot lose that save).
+	s.settingsMu.Lock()
+	defer s.settingsMu.Unlock()
+
+	set, err := s.store.GetSettings(r.Context())
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	enabled := alert.ParseEnabled(set.AlertEvents)
+	enabled[req.Type] = req.Enabled
+	if err := s.store.SetAlertEvents(r.Context(), enabledCSV(enabled)); err != nil {
+		writeError(w, err)
+		return
+	}
+	s.emit(r.Context(), Event{
+		Type: "settings.changed", Severity: "info", Source: "frontdesk",
+		Message: fmt.Sprintf("Alerting for %s %s by %s", req.Type, enabledWord(req.Enabled), actorFromContext(r.Context())),
+	})
+	sel, err := s.alertSelection(r.Context())
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"events": sel})
 }

--- a/internal/frontdesk/store_settings.go
+++ b/internal/frontdesk/store_settings.go
@@ -82,6 +82,20 @@ func (s *Store) UpdateSettings(ctx context.Context, set Settings) error {
 	return nil
 }
 
+// SetAlertEvents rewrites only the enabled-events CSV, leaving every other
+// settings column (including the encrypted Apprise target and the OIDC client
+// secret) untouched. The operator alert picker uses this so flipping one event
+// never round-trips a stored secret through GET/UpdateSettings. Callers hold
+// settingsMu to serialize with putSettings' read-merge-write.
+func (s *Store) SetAlertEvents(ctx context.Context, csv string) error {
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE settings SET alert_events = ? WHERE id = 1`, csv)
+	if err != nil {
+		return fmt.Errorf("frontdesk: set alert events: %w", err)
+	}
+	return nil
+}
+
 // AutoSyncConfig is the operator's automatic config-propagation setup: a master
 // on/off plus the designated source-of-truth member. LastHash is the internal
 // drift marker (the primary config hash last applied to the fleet) and is never


### PR DESCRIPTION
## What

Adds a scoped, operator-facing surface for Front Desk's alert-event selection (the "What FD alerts on" picker), previously reachable only from the admin-gated FD settings screen (`GET/PUT /api/settings`). This is the backend half; the Bellhop client is a planned follow-up PR.

## Endpoints (`internal/frontdesk/server.go`)

- **`GET /api/alert/selection`** — behind `requireAuth`, so **any paired device (monitor included) can read** what FD alerts on. Returns the catalog enriched with current on/off state in one call:
  ```json
  {"events":[{"type":"health.down","category":"Health","severity":"error","defaultOn":true,"enabled":true}, ...]}
  ```
- **`POST /api/alert/selection`** — behind `requireOperator`, so **only operator-role devices flip**. Body `{"type":"health.down","enabled":false}`; echoes back the refreshed selection.

## Design

- **Per-event toggle, not full-set replace** — a Bellhop built against an older/newer catalog can't clobber events it doesn't know about (skew-safe). Unknown `type` → `400 unknown_alert_event`.
- **Only the `alert_events` column is rewritten** via a new `Store.SetAlertEvents`, so the encrypted Apprise target and OIDC secret sharing that settings row are never round-tripped. The handler holds `settingsMu` to serialize with `putSettings`' read-merge-write.
- Emits `settings.changed` attributed to the actor (e.g. `"Alerting for health.down disabled by Pixel (operator)"`) for the audit/SSE trail.
- CSV is re-serialized in catalog order, dropping stale/unknown types (self-healing row).

## Tests

- `TestAlertSelectionEndpoint` — monitor reads / monitor `403` on write / operator on+off / stored CSV follows / unknown type `400`.
- `TestAlertSelectionPreservesSecret` — toggling an event does not clobber the encrypted Apprise target.

`internal/frontdesk` + `internal/alert` suites pass (259 tests); `golangci-lint` clean.

## Deploy note

FD prod (front-desk.zmrd.uk) needs a redeploy before Bellhop can hit these routes live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)