### PR TITLE
feat(bellhop): operator alert-event flip + severity-badge pill + nav affordance

### DIFF
--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
@@ -43,6 +43,7 @@ import com.hugalafutro.bellhop.notify.FleetNotifier
 import com.hugalafutro.bellhop.push.BellhopPush
 import com.hugalafutro.bellhop.ui.alerts.AlertsScreen
 import com.hugalafutro.bellhop.ui.alerts.AlertsViewModel
+import com.hugalafutro.bellhop.ui.alerts.enabledSeverityCounts
 import com.hugalafutro.bellhop.ui.dashboard.DashboardScreen
 import com.hugalafutro.bellhop.ui.dashboard.DashboardViewModel
 import com.hugalafutro.bellhop.ui.events.EventsScreen
@@ -539,6 +540,16 @@ private fun LinkedContent(
         )
     val ui by dashVm.state.collectAsStateWithLifecycle()
 
+    // Alerts VM is hoisted so both the Settings pill (its severity-count badges)
+    // and the Alerts screen share one instance. Created eagerly but only polls
+    // while a branch below actually collects its state (subscription-gated), so it
+    // stays idle on the dashboard. Keyed like dashVm so a relink gets fresh status.
+    val alertsVm: AlertsViewModel =
+        viewModel(
+            key = "alerts-${state.fdUrl}|${state.deviceId}",
+            factory = AlertsViewModel.Factory(client, linkStore, state.fdUrl),
+        )
+
     // Which member's detail is open, if any. Saveable so it survives
     // rotation/process death; keyed on the pairing so a relink lands
     // back on the new Front Desk's dashboard, not a stale detail.
@@ -592,16 +603,24 @@ private fun LinkedContent(
         // Alerts can be reached from the dashboard bell or from Settings; back
         // returns to whichever is still open underneath (Settings if it was).
         BackHandler { showAlerts = false }
-        // Keyed like the dashboard VM so a relink gets a fresh status.
-        val alertsVm: AlertsViewModel =
-            viewModel(
-                key = "alerts-${state.fdUrl}|${state.deviceId}",
-                factory = AlertsViewModel.Factory(client, linkStore, state.fdUrl),
-            )
         val alertsUi by alertsVm.state.collectAsStateWithLifecycle()
-        AlertsScreen(onBack = { showAlerts = false }, ui = alertsUi)
+        AlertsScreen(
+            onBack = { showAlerts = false },
+            ui = alertsUi,
+            // Role-hint UI, same as the member-detail card: an operator gets live
+            // switches, a monitor sees them read-only. Front Desk's 403 is still the
+            // real guard. Each flip goes through the biometric operator gate.
+            canOperate = state.role == OPERATOR_ROLE,
+            onToggleEvent = { type, enabled -> requireOperatorAuth { alertsVm.toggleEvent(type, enabled) } },
+            onDismissActionError = { alertsVm.dismissActionError() },
+        )
     } else if (showSettings) {
         BackHandler { showSettings = false }
+        // Collecting the hoisted alerts VM here subscribes it, so its selection is
+        // fetched while Settings is open and the pill badges stay live (including
+        // right after an operator flips events on the Alerts screen and returns).
+        val alertsUi by alertsVm.state.collectAsStateWithLifecycle()
+        val alertCounts = remember(alertsUi.catalog) { enabledSeverityCounts(alertsUi.catalog) }
         SettingsScreen(
             link = state,
             lockConfig = lockConfig,
@@ -625,6 +644,7 @@ private fun LinkedContent(
             onForceUnlink = onForceUnlink,
             holdToCopy = holdToCopy,
             onToggleHoldToCopy = onToggleHoldToCopy,
+            alertCounts = alertCounts,
         )
     } else if (selected != null) {
         BackHandler { selectedMemberId = null }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/FleetModels.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/FleetModels.kt
@@ -196,12 +196,12 @@ data class AlertStatus(
 )
 
 /**
- * AlertEventDef is one row of Front Desk's alertable-event catalog (GET
- * /api/alert/events), mirroring alert.EventDef. Bellhop renders it read-only:
- * which events are actually enabled lives in Front Desk's admin settings (not
- * readable by a device token), so [defaultOn] is shown as the first-run default,
- * not the current selection. [severity] is the display dot; [category] groups
- * the list.
+ * AlertEventDef is one row of Front Desk's alertable-event catalog, mirroring
+ * alert.EventDef. Bellhop reads it from GET /api/alert/selection, which enriches
+ * the catalog with [enabled] — whether Front Desk currently alerts on this event.
+ * An operator device flips [enabled] via POST /api/alert/selection; a monitor
+ * sees it read-only. [defaultOn] is the first-run seed (a reference, not the live
+ * state); [severity] is the display dot; [category] groups the list.
  */
 @Serializable
 data class AlertEventDef(
@@ -209,6 +209,29 @@ data class AlertEventDef(
     val category: String = "",
     val severity: String = "",
     val defaultOn: Boolean = false,
+    val enabled: Boolean = false,
+)
+
+/**
+ * AlertSelectionResponse is the GET/POST /api/alert/selection envelope: the
+ * catalog enriched with each event's current [AlertEventDef.enabled] state.
+ * Mirrors the Front Desk handler, which returns {"events": [...]}.
+ */
+@Serializable
+data class AlertSelectionResponse(
+    val events: List<AlertEventDef> = emptyList(),
+)
+
+/**
+ * AlertSelectionRequest is the POST /api/alert/selection body: flip one event
+ * [type] on or off. A per-event toggle (not a full-set replace) is atomic on
+ * Front Desk and version-skew safe, so a dropped request never leaves the
+ * selection half-applied. Do not rename JSON fields.
+ */
+@Serializable
+data class AlertSelectionRequest(
+    val type: String,
+    val enabled: Boolean,
 )
 
 // Wire models for the Front Desk operator tier a device token with the operator

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/FrontDeskClient.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/FrontDeskClient.kt
@@ -232,14 +232,52 @@ open class FrontDeskClient(
     ): FetchResult<AlertStatus> = get(fdUrl, "/api/alert/status", token)
 
     /**
-     * alertCatalog fetches Front Desk's alertable-event catalog (what it can
-     * notify on, grouped by category). Monitor tier; the enabled subset lives in
-     * admin settings and is not readable here, so the screen shows this read-only.
+     * alertSelection fetches Front Desk's alertable-event catalog enriched with
+     * each event's current enabled state (GET /api/alert/selection). Readable by
+     * any paired device (monitor included), so the Alerts screen can show what
+     * Front Desk alerts on; flipping an event needs the operator role
+     * ([setAlertEvent]). The wire envelope is {"events": [...]}; callers get the
+     * unwrapped list.
      */
-    open suspend fun alertCatalog(
+    open suspend fun alertSelection(
         fdUrl: String,
         token: String,
-    ): FetchResult<List<AlertEventDef>> = get(fdUrl, "/api/alert/events", token)
+    ): FetchResult<List<AlertEventDef>> =
+        when (val r = get<AlertSelectionResponse>(fdUrl, "/api/alert/selection", token)) {
+            is FetchResult.Success -> FetchResult.Success(r.data.events)
+            FetchResult.Unauthorized -> FetchResult.Unauthorized
+            is FetchResult.Failure -> r
+        }
+
+    /**
+     * setAlertEvent flips one alert event on or off via POST /api/alert/selection.
+     * Operator tier: Front Desk enforces the role and echoes back the whole
+     * refreshed selection (the ack doubles as the re-read), so the phone reconciles
+     * from Front Desk's own truth rather than an optimistic guess. A per-event
+     * toggle is atomic on Front Desk, so a dropped request never leaves the
+     * selection half-applied; a retry is a safe no-op. A 403 is [ActionResult.Forbidden]
+     * (a monitor device may not flip it), a 401 is [ActionResult.Unauthorized].
+     */
+    open suspend fun setAlertEvent(
+        fdUrl: String,
+        token: String,
+        type: String,
+        enabled: Boolean,
+    ): ActionResult<List<AlertEventDef>> =
+        when (
+            val r =
+                post<AlertSelectionRequest, AlertSelectionResponse>(
+                    fdUrl,
+                    "/api/alert/selection",
+                    token,
+                    AlertSelectionRequest(type, enabled),
+                )
+        ) {
+            is ActionResult.Success -> ActionResult.Success(r.data.events)
+            ActionResult.Forbidden -> ActionResult.Forbidden
+            ActionResult.Unauthorized -> ActionResult.Unauthorized
+            is ActionResult.Failure -> r
+        }
 
     /**
      * setMemberState drains or activates a member via POST

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/alerts/AlertsScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/alerts/AlertsScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
@@ -20,7 +21,9 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -38,18 +41,23 @@ import com.hugalafutro.bellhop.ui.common.severityColors
 import com.hugalafutro.bellhop.ui.theme.BellhopTheme
 
 /**
- * AlertsScreen renders Front Desk's outbound-alert subsystem, read-only: a
- * delivery-health pill (is the apprise-api reachable and delivering?) and the
- * catalog of events Front Desk can notify on, grouped by category with a
- * severity dot. Which events are actually enabled lives in Front Desk's admin
- * settings, which a device token cannot read, so the catalog is a reference, not
- * a set of live toggles — the footer note says so. State comes from
- * [AlertsViewModel].
+ * AlertsScreen renders Front Desk's outbound-alert subsystem: a delivery-health
+ * pill (is the apprise-api reachable and delivering?) and the events Front Desk
+ * can notify on, grouped by category with a severity dot and a per-event switch
+ * showing its live enabled state. An operator flips a switch (routed through the
+ * biometric operator gate); a monitor sees the switches read-only. State and the
+ * flip action come from [AlertsViewModel].
  */
 @Composable
 fun AlertsScreen(
     onBack: () -> Unit,
     ui: AlertsUiState = AlertsUiState(),
+    // Whether this device is paired as an operator. A monitor sees each event's
+    // state read-only (a disabled switch); an operator can flip it, which routes
+    // through the biometric operator gate in the host before [onToggleEvent] fires.
+    canOperate: Boolean = false,
+    onToggleEvent: (type: String, enabled: Boolean) -> Unit = { _, _ -> },
+    onDismissActionError: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     Scaffold(modifier = modifier.fillMaxSize()) { innerPadding ->
@@ -87,6 +95,29 @@ fun AlertsScreen(
                     text = stringResource(R.string.dashboard_refresh_failed, ui.error),
                     tag = "alerts-error",
                 )
+            }
+            // Operator-flip feedback: a 403 means this monitor device may not flip
+            // (the switch is disabled, but a mid-session role change can still land
+            // one here), and a failed flip surfaces so a tap never vanishes silently.
+            if (ui.action.forbidden) {
+                StatusBanner(text = stringResource(R.string.alerts_flip_forbidden), tag = "alerts-flip-forbidden")
+            }
+            ui.action.error?.let { message ->
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier.padding(bottom = 8.dp),
+                ) {
+                    Text(
+                        text = stringResource(R.string.alerts_flip_failed, message),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error,
+                        modifier = Modifier.weight(1f).testTag("alerts-flip-error"),
+                    )
+                    TextButton(onClick = onDismissActionError, modifier = Modifier.testTag("alerts-flip-dismiss")) {
+                        Text(text = stringResource(R.string.member_op_dismiss))
+                    }
+                }
             }
 
             if (ui.loading) {
@@ -131,7 +162,14 @@ fun AlertsScreen(
                                     modifier = Modifier.padding(top = 8.dp),
                                 )
                             }
-                            items(defs) { def -> AlertRow(def = def) }
+                            items(defs) { def ->
+                                AlertRow(
+                                    def = def,
+                                    canOperate = canOperate,
+                                    toggling = ui.action.togglingType == def.type,
+                                    onToggle = { enabled -> onToggleEvent(def.type, enabled) },
+                                )
+                            }
                         }
                 }
             }
@@ -184,6 +222,9 @@ private fun DeliveryStatusCard(
 @Composable
 private fun AlertRow(
     def: AlertEventDef,
+    canOperate: Boolean,
+    toggling: Boolean,
+    onToggle: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val (container, content) = severityColors(def.severity)
@@ -206,14 +247,25 @@ private fun AlertRow(
                 overflow = TextOverflow.Ellipsis,
                 modifier = Modifier.weight(1f),
             )
-            Text(
-                text =
-                    stringResource(
-                        if (def.defaultOn) R.string.alerts_default_on else R.string.alerts_default_off,
-                    ),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
+            // A flip in flight shows a spinner in the switch's place so a double-tap
+            // can't fire a second request. A monitor device gets a disabled switch that
+            // still reflects the true on/off state (read-only); an operator can flip it.
+            if (toggling) {
+                CircularProgressIndicator(
+                    strokeWidth = 2.dp,
+                    modifier = Modifier.size(24.dp).testTag("alert-toggle-spinner-${def.type}"),
+                )
+            } else {
+                // Keep onCheckedChange non-null even for a monitor so the switch keeps
+                // its toggleable semantics (and reads as disabled, not merely inert);
+                // enabled=false blocks the tap, and Front Desk's 403 is the real guard.
+                Switch(
+                    checked = def.enabled,
+                    onCheckedChange = onToggle,
+                    enabled = canOperate,
+                    modifier = Modifier.testTag("alert-toggle-${def.type}"),
+                )
+            }
         }
     }
 }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/alerts/AlertsViewModel.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/alerts/AlertsViewModel.kt
@@ -3,6 +3,7 @@ package com.hugalafutro.bellhop.ui.alerts
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import com.hugalafutro.bellhop.data.ActionResult
 import com.hugalafutro.bellhop.data.AlertEventDef
 import com.hugalafutro.bellhop.data.AlertStatus
 import com.hugalafutro.bellhop.data.FetchResult
@@ -23,11 +24,12 @@ import kotlinx.coroutines.launch
 
 /**
  * AlertsUiState is what the Alerts screen renders: Front Desk's outbound-notifier
- * delivery health ([status]) and its alertable-event catalog ([catalog], grouped
- * by category in the screen). A failed refresh keeps the last good data on screen
- * (stale beats blank on a phone) and raises [error]; [revoked] means the device
- * token itself no longer authenticates, same remedy as the dashboard: unlink and
- * re-pair.
+ * delivery health ([status]) and its alertable-event catalog enriched with the
+ * live enabled state ([catalog], grouped by category in the screen). A failed
+ * refresh keeps the last good data on screen (stale beats blank on a phone) and
+ * raises [error]; [revoked] means the device token itself no longer authenticates,
+ * same remedy as the dashboard: unlink and re-pair. [action] tracks an in-flight
+ * operator flip.
  */
 data class AlertsUiState(
     val loading: Boolean = true,
@@ -35,7 +37,36 @@ data class AlertsUiState(
     val catalog: List<AlertEventDef> = emptyList(),
     val error: String? = null,
     val revoked: Boolean = false,
+    val action: AlertActionState = AlertActionState(),
 )
+
+/**
+ * AlertActionState is the overlay for an operator flipping an event on or off.
+ * [togglingType] is the event whose POST is in flight (its row shows a spinner
+ * and is disabled); [forbidden] is Front Desk's 403 (this device paired as
+ * monitor may not flip); [busy] flags a tap that arrived while another flip was
+ * still in flight (dropped, not queued); [error] is the last flip failure.
+ */
+data class AlertActionState(
+    val togglingType: String? = null,
+    val forbidden: Boolean = false,
+    val busy: Boolean = false,
+    val error: String? = null,
+)
+
+/**
+ * ALERT_SEVERITIES is the fixed pill order for the enabled-count badges, most
+ * severe first, matching the severity-dot palette.
+ */
+val ALERT_SEVERITIES = listOf("error", "warning", "info", "success")
+
+/**
+ * enabledSeverityCounts tallies how many currently-enabled events fall under each
+ * severity, always returning all four keys (0 when none) so the Settings pill can
+ * render a full badge row regardless of the selection.
+ */
+fun enabledSeverityCounts(catalog: List<AlertEventDef>): Map<String, Int> =
+    ALERT_SEVERITIES.associateWith { severity -> catalog.count { it.enabled && it.severity == severity } }
 
 /**
  * AlertsViewModel keeps Front Desk's alert delivery status fresh while the
@@ -45,9 +76,9 @@ data class AlertsUiState(
  * catalog (static per Front Desk version). Both are read on every refresh for
  * simplicity; the catalog re-read is cheap and picks up a Front Desk upgrade.
  *
- * The catalog is a *reference* of what Front Desk can alert on, not which events
- * are currently enabled: the enabled subset lives in admin settings, which a
- * device token cannot read. The screen labels it accordingly.
+ * The catalog now carries each event's live enabled state (read from Front Desk's
+ * /api/alert/selection), so an operator can flip events straight from the phone
+ * ([toggleEvent]); a monitor device sees them read-only.
  */
 class AlertsViewModel(
     private val client: FrontDeskClient,
@@ -112,8 +143,8 @@ class AlertsViewModel(
         }
         coroutineScope {
             val statusDeferred = async { client.alertStatus(fdUrl, token) }
-            val catalogDeferred = async { client.alertCatalog(fdUrl, token) }
-            fold(statusDeferred.await(), catalogDeferred.await())
+            val selectionDeferred = async { client.alertSelection(fdUrl, token) }
+            fold(statusDeferred.await(), selectionDeferred.await())
         }
     }
 
@@ -133,14 +164,69 @@ class AlertsViewModel(
             val failure =
                 (status as? FetchResult.Failure)?.message
                     ?: (catalog as? FetchResult.Failure)?.message
+            // A poll landing mid-flip must not clobber the catalog with a pre-flip
+            // read; the toggle's own ack (which carries Front Desk's authoritative
+            // selection) owns the catalog until it clears togglingType.
+            val nextCatalog =
+                if (st.action.togglingType == null) {
+                    (catalog as? FetchResult.Success)?.data ?: st.catalog
+                } else {
+                    st.catalog
+                }
             st.copy(
                 loading = false,
                 status = (status as? FetchResult.Success)?.data ?: st.status,
-                catalog = (catalog as? FetchResult.Success)?.data ?: st.catalog,
+                catalog = nextCatalog,
                 error = failure,
                 revoked = false,
             )
         }
+    }
+
+    /**
+     * toggleEvent flips one alert event on or off. It follows the same operator-action
+     * idiom as member drain/activate: one flip at a time (a tap arriving mid-flight is
+     * dropped and flagged [AlertActionState.busy], never queued), and rather than guess
+     * optimistically it adopts the selection Front Desk echoes back — so if the phone
+     * dies mid-request the next refresh simply re-reads Front Desk's truth and nothing is
+     * left half-applied. A 403 surfaces as [AlertActionState.forbidden] (a monitor device
+     * may not flip); a 401 is the revoked remedy.
+     */
+    fun toggleEvent(
+        type: String,
+        enabled: Boolean,
+    ) {
+        val current = _state.value
+        if (current.action.togglingType != null) {
+            _state.update { it.copy(action = it.action.copy(busy = true)) }
+            return
+        }
+        if (current.revoked) return
+        _state.update { it.copy(action = it.action.copy(togglingType = type, error = null, busy = false)) }
+        viewModelScope.launch {
+            val token = linkStore.token()
+            if (token == null) {
+                _state.update { it.copy(revoked = true, action = it.action.copy(togglingType = null)) }
+                return@launch
+            }
+            val result = client.setAlertEvent(fdUrl, token, type, enabled)
+            _state.update { st ->
+                val cleared = st.copy(action = st.action.copy(togglingType = null))
+                when (result) {
+                    is ActionResult.Success ->
+                        // Adopt Front Desk's echoed selection wholesale: the ack is the re-read.
+                        cleared.copy(catalog = result.data, action = cleared.action.copy(forbidden = false))
+                    ActionResult.Forbidden -> cleared.copy(action = cleared.action.copy(forbidden = true))
+                    ActionResult.Unauthorized -> cleared.copy(revoked = true)
+                    is ActionResult.Failure -> cleared.copy(action = cleared.action.copy(error = result.message))
+                }
+            }
+        }
+    }
+
+    /** dismissActionError clears the last flip-failure banner. */
+    fun dismissActionError() {
+        _state.update { it.copy(action = it.action.copy(error = null)) }
     }
 
     class Factory(

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/NavChevron.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/NavChevron.kt
@@ -1,0 +1,33 @@
+package com.hugalafutro.bellhop.ui.common
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+
+/**
+ * NavChevron is the one affordance that marks a card or row whose tap navigates
+ * to another screen: a trailing chevron tinted with the brass accent. Static
+ * cards omit it, and a card whose tap is an inline action (a toggle, a copy)
+ * keeps its own control instead — so a brass chevron always reads as "tap to go
+ * there", never "tap to do something here". [contentDescription] should name the
+ * destination for screen readers.
+ */
+@Composable
+fun NavChevron(
+    contentDescription: String,
+    modifier: Modifier = Modifier,
+    tag: String = "nav-chevron",
+) {
+    Icon(
+        imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+        contentDescription = contentDescription,
+        tint = MaterialTheme.colorScheme.primary,
+        modifier = modifier.size(24.dp).testTag(tag),
+    )
+}

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreen.kt
@@ -36,6 +36,8 @@ import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -45,7 +47,11 @@ import com.hugalafutro.bellhop.R
 import com.hugalafutro.bellhop.data.LinkState
 import com.hugalafutro.bellhop.data.LockConfig
 import com.hugalafutro.bellhop.data.LockTimeout
+import com.hugalafutro.bellhop.ui.alerts.ALERT_SEVERITIES
 import com.hugalafutro.bellhop.ui.common.FilterPill
+import com.hugalafutro.bellhop.ui.common.NavChevron
+import com.hugalafutro.bellhop.ui.common.Pill
+import com.hugalafutro.bellhop.ui.common.severityColors
 import com.hugalafutro.bellhop.ui.theme.BellhopTheme
 import java.time.Instant
 import java.time.ZoneId
@@ -86,6 +92,10 @@ fun SettingsScreen(
     onForceUnlink: () -> Unit = {},
     holdToCopy: Boolean = false,
     onToggleHoldToCopy: (Boolean) -> Unit = {},
+    // Enabled-alert counts per severity (error/warning/info/success), sourced from
+    // Front Desk's live selection. Always rendered as badges on the Alerts pill,
+    // even at 0, so the pill reads as a live, tappable destination.
+    alertCounts: Map<String, Int> = emptyMap(),
 ) {
     var confirmUnlink by remember { mutableStateOf(false) }
     var confirmCopyAddress by remember { mutableStateOf(false) }
@@ -523,18 +533,28 @@ fun SettingsScreen(
             Spacer(modifier = Modifier.height(16.dp))
 
             // Alerts stays reachable here even when all is green (the dashboard bell
-            // only appears when a member is down).
+            // only appears when a member is down). The severity badges tally what
+            // Front Desk currently alerts on; the brass chevron marks the tap as a
+            // jump to the Alerts screen (where an operator can flip them).
             Card(modifier = Modifier.fillMaxWidth().clickable(onClick = onAlertsClick).testTag("settings-alerts")) {
-                Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(2.dp)) {
-                    Text(
-                        text = stringResource(R.string.settings_alerts_title),
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                    Text(
-                        text = stringResource(R.string.settings_alerts_subtitle),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
+                Row(
+                    modifier = Modifier.padding(16.dp).fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                        Text(
+                            text = stringResource(R.string.settings_alerts_title),
+                            style = MaterialTheme.typography.titleMedium,
+                        )
+                        Text(
+                            text = stringResource(R.string.settings_alerts_subtitle),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        AlertSeverityBadges(counts = alertCounts)
+                    }
+                    NavChevron(contentDescription = stringResource(R.string.settings_alerts_title))
                 }
             }
 
@@ -551,6 +571,48 @@ fun SettingsScreen(
         }
     }
 }
+
+/**
+ * AlertSeverityBadges renders one small coloured badge per severity (error,
+ * warning, info, success), each carrying the count of currently-enabled events of
+ * that severity. All four are always shown, even at 0, so the pill reads as a live
+ * summary and a tappable destination rather than an inert label. Colour encodes
+ * severity (matching the log-rail palette); the count and a per-badge content
+ * description carry the meaning for screen readers.
+ */
+@Composable
+private fun AlertSeverityBadges(
+    counts: Map<String, Int>,
+    modifier: Modifier = Modifier,
+) {
+    Row(modifier = modifier.testTag("settings-alert-badges"), horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+        ALERT_SEVERITIES.forEach { severity ->
+            val (container, content) = severityColors(severity)
+            val count = counts[severity] ?: 0
+            val label = severityBadgeLabel(severity)
+            // Resolve the description here: the semantics lambda is not composable.
+            val desc = stringResource(R.string.settings_alerts_badge_desc, count, label)
+            Pill(
+                text = count.toString(),
+                container = container,
+                content = content,
+                tag = "settings-alert-badge-$severity",
+                modifier = Modifier.semantics { contentDescription = desc },
+            )
+        }
+    }
+}
+
+// severityBadgeLabel names a severity for the badge's accessibility description,
+// reusing the shared event-severity strings.
+@Composable
+private fun severityBadgeLabel(severity: String): String =
+    when (severity) {
+        "success" -> stringResource(R.string.events_sev_success)
+        "warning" -> stringResource(R.string.events_sev_warning)
+        "error" -> stringResource(R.string.events_sev_error)
+        else -> stringResource(R.string.events_sev_info)
+    }
 
 // A localized "Jul 14, 2026"-style date for when the link was paired, or null
 // when the stamp is absent (links saved before linkedAt existed) so the row hides.

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -108,9 +108,9 @@
     <string name="alerts_status_unhealthy">Notifier unhealthy</string>
     <string name="alerts_status_delivering">Delivering</string>
     <string name="alerts_catalog_title">What Front Desk alerts on</string>
-    <string name="alerts_catalog_note">Enable or mute specific alerts in Front Desk → Settings → Alerts. This list shows every event Front Desk can notify on and its first-run default.</string>
-    <string name="alerts_default_on">On by default</string>
-    <string name="alerts_default_off">Off by default</string>
+    <string name="alerts_catalog_note">Flip the switch to enable or mute an alert. Changes apply to Front Desk right away.</string>
+    <string name="alerts_flip_forbidden">This device is paired as a monitor and can\'t change alerts. Re-pair with an operator code in Front Desk.</string>
+    <string name="alerts_flip_failed">Couldn\'t change that alert: %1$s</string>
     <string name="alerts_event_health_down">Member went down</string>
     <string name="alerts_event_health_up">Member recovered</string>
     <string name="alerts_event_config_sync_failed">Config sync failed</string>
@@ -156,6 +156,8 @@
     <string name="settings_lock_1h">1 hr</string>
     <string name="settings_alerts_title">Alerts</string>
     <string name="settings_alerts_subtitle">Notification delivery and what Front Desk alerts on.</string>
+    <!-- Accessibility label for a severity count badge on the Alerts pill, e.g. "2 error enabled". -->
+    <string name="settings_alerts_badge_desc">%1$d %2$s enabled</string>
     <string name="settings_monitor_title">Background monitoring</string>
     <string name="settings_monitor_subtitle">Check the fleet every 15 minutes and notify you here when a member goes down or recovers, even when Bellhop is closed.</string>
     <string name="settings_monitor_note">Front Desk\'s own alerts are faster; this is a backstop for when Bellhop is your only view. It checks roughly every 15 minutes, so a change can be up to that late.</string>

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/FrontDeskClientTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/FrontDeskClientTest.kt
@@ -462,41 +462,97 @@ class FrontDeskClientTest {
         }
 
     @Test
-    fun alertCatalogParsesGroupsAndSendsBearer() =
+    fun alertSelectionUnwrapsEnvelopeAndSendsBearer() =
         runBlocking {
+            // GET /api/alert/selection returns {"events":[...]} with each event's
+            // live enabled state; the client unwraps to the bare list.
             server.enqueue(
                 MockResponse().setBody(
-                    """[{"type":"health.down","category":"Health","severity":"error","defaultOn":true},""" +
-                        """{"type":"config.synced","category":"Config Sync","severity":"info","defaultOn":false}]""",
+                    """{"events":[{"type":"health.down","category":"Health",""" +
+                        """"severity":"error","defaultOn":true,"enabled":true},""" +
+                        """{"type":"config.synced","category":"Config Sync",""" +
+                        """"severity":"info","defaultOn":false,"enabled":false}]}""",
                 ),
             )
 
-            val result = client.alertCatalog(server.url("/").toString(), "tok-1")
+            val result = client.alertSelection(server.url("/").toString(), "tok-1")
 
             assertTrue(result is FetchResult.Success)
             result as FetchResult.Success
             assertEquals(2, result.data.size)
             assertEquals("health.down", result.data[0].type)
-            assertEquals("Health", result.data[0].category)
-            assertTrue(result.data[0].defaultOn)
-            assertFalse(result.data[1].defaultOn)
+            assertTrue(result.data[0].enabled)
+            assertFalse(result.data[1].enabled)
 
             val request = server.takeRequest()
             assertEquals("GET", request.method)
-            assertEquals("/api/alert/events", request.path)
+            assertEquals("/api/alert/selection", request.path)
             assertEquals("Bearer tok-1", request.getHeader("Authorization"))
         }
 
     @Test
-    fun alertCatalogMapsUnauthorizedToItsOwnArm() =
+    fun alertSelectionMapsUnauthorizedToItsOwnArm() =
         runBlocking {
             server.enqueue(
                 MockResponse().setResponseCode(401).setBody(
                     """{"error":{"code":"unauthorized","message":"bad token"}}""",
                 ),
             )
-            val result = client.alertCatalog(server.url("/").toString(), "dead")
+            val result = client.alertSelection(server.url("/").toString(), "dead")
             assertEquals(FetchResult.Unauthorized, result)
+        }
+
+    @Test
+    fun setAlertEventPostsBodyAndAdoptsEchoedSelection() =
+        runBlocking {
+            // The POST echoes the whole refreshed selection: that echo is the ack
+            // the phone reconciles from, so a dropped request is never half-applied.
+            server.enqueue(
+                MockResponse().setBody(
+                    """{"events":[{"type":"health.down","category":"Health",""" +
+                        """"severity":"error","defaultOn":true,"enabled":false}]}""",
+                ),
+            )
+
+            val result = client.setAlertEvent(server.url("/").toString(), "tok-1", "health.down", false)
+
+            assertTrue(result is ActionResult.Success)
+            result as ActionResult.Success
+            assertEquals(1, result.data.size)
+            assertFalse(result.data[0].enabled)
+
+            val request = server.takeRequest()
+            assertEquals("POST", request.method)
+            assertEquals("/api/alert/selection", request.path)
+            assertEquals("Bearer tok-1", request.getHeader("Authorization"))
+            val body = request.body.readUtf8()
+            assertTrue(body.contains("\"type\":\"health.down\""))
+            assertTrue(body.contains("\"enabled\":false"))
+        }
+
+    @Test
+    fun setAlertEventMapsForbiddenToItsOwnArm() =
+        runBlocking {
+            // 403 device_role_forbidden: a monitor device may not flip an alert.
+            server.enqueue(
+                MockResponse().setResponseCode(403).setBody(
+                    """{"code":"device_role_forbidden","error":"nope"}""",
+                ),
+            )
+            val result = client.setAlertEvent(server.url("/").toString(), "dead", "health.down", true)
+            assertEquals(ActionResult.Forbidden, result)
+        }
+
+    @Test
+    fun setAlertEventMapsUnauthorizedToItsOwnArm() =
+        runBlocking {
+            server.enqueue(
+                MockResponse().setResponseCode(401).setBody(
+                    """{"error":{"code":"unauthorized","message":"bad token"}}""",
+                ),
+            )
+            val result = client.setAlertEvent(server.url("/").toString(), "dead", "health.down", true)
+            assertEquals(ActionResult.Unauthorized, result)
         }
 
     @Test

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/alerts/AlertsScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/alerts/AlertsScreenTest.kt
@@ -1,6 +1,7 @@
 package com.hugalafutro.bellhop.ui.alerts
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
@@ -127,5 +128,60 @@ class AlertsScreenTest {
         }
         composeTestRule.onNodeWithTag("alerts-back").performClick()
         assertEquals(1, backs)
+    }
+
+    @Test
+    fun operatorFlipFiresToggleWithNewState() {
+        var toggled: Pair<String, Boolean>? = null
+        val ui = loaded.copy(catalog = listOf(AlertEventDef("health.down", "Health", "error", enabled = false)))
+        composeTestRule.setContent {
+            BellhopTheme {
+                AlertsScreen(onBack = {}, ui = ui, canOperate = true, onToggleEvent = { t, e -> toggled = t to e })
+            }
+        }
+        composeTestRule.onNodeWithTag("alerts-list").performScrollToNode(hasTestTag("alert-toggle-health.down"))
+        composeTestRule.onNodeWithTag("alert-toggle-health.down").performClick()
+        // A disabled event flipped on: the switch reports the new target, not the old state.
+        assertEquals("health.down" to true, toggled)
+    }
+
+    @Test
+    fun monitorTogglesAreDisabled() {
+        val ui = loaded.copy(catalog = listOf(AlertEventDef("health.down", "Health", "error", enabled = true)))
+        composeTestRule.setContent {
+            BellhopTheme {
+                AlertsScreen(onBack = {}, ui = ui, canOperate = false)
+            }
+        }
+        composeTestRule.onNodeWithTag("alerts-list").performScrollToNode(hasTestTag("alert-toggle-health.down"))
+        composeTestRule.onNodeWithTag("alert-toggle-health.down").assertIsNotEnabled()
+    }
+
+    @Test
+    fun flipInFlightShowsSpinnerInPlaceOfSwitch() {
+        val ui =
+            loaded.copy(
+                catalog = listOf(AlertEventDef("health.down", "Health", "error", enabled = false)),
+                action = AlertActionState(togglingType = "health.down"),
+            )
+        composeTestRule.setContent {
+            BellhopTheme {
+                AlertsScreen(onBack = {}, ui = ui, canOperate = true)
+            }
+        }
+        composeTestRule.onNodeWithTag("alerts-list").performScrollToNode(hasTestTag("alert-toggle-spinner-health.down"))
+        composeTestRule.onNodeWithTag("alert-toggle-spinner-health.down", useUnmergedTree = true).assertIsDisplayed()
+        // The switch is replaced by the spinner, so a double-tap can't fire a second request.
+        assertTrue(composeTestRule.onAllNodesWithTag("alert-toggle-health.down").fetchSemanticsNodes().isEmpty())
+    }
+
+    @Test
+    fun forbiddenFlipShowsBanner() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                AlertsScreen(onBack = {}, ui = loaded.copy(action = AlertActionState(forbidden = true)))
+            }
+        }
+        composeTestRule.onNodeWithTag("alerts-flip-forbidden").assertIsDisplayed()
     }
 }

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/alerts/AlertsViewModelTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/alerts/AlertsViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.hugalafutro.bellhop.ui.alerts
 
+import com.hugalafutro.bellhop.data.ActionResult
 import com.hugalafutro.bellhop.data.AlertEventDef
 import com.hugalafutro.bellhop.data.AlertStatus
 import com.hugalafutro.bellhop.data.FakeCipher
@@ -25,15 +26,18 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import java.util.concurrent.atomic.AtomicInteger
 
-// FakeAlertsClient stubs the two reads the alerts ViewModel makes; each result
-// is swappable so a test can flip a call from success to failure between refreshes.
+// FakeAlertsClient stubs the reads the alerts ViewModel makes plus the flip
+// action; each result is swappable so a test can move a call from success to
+// failure between refreshes.
 private class FakeAlertsClient(
     var status: FetchResult<AlertStatus>,
     var catalog: FetchResult<List<AlertEventDef>>,
+    var toggleResult: ActionResult<List<AlertEventDef>> = ActionResult.Failure("unset"),
 ) : FrontDeskClient() {
     val statusCalls = AtomicInteger(0)
     val catalogCalls = AtomicInteger(0)
     var lastToken: String? = null
+    var lastToggle: Pair<String, Boolean>? = null
 
     override suspend fun alertStatus(
         fdUrl: String,
@@ -44,13 +48,24 @@ private class FakeAlertsClient(
         return status
     }
 
-    override suspend fun alertCatalog(
+    override suspend fun alertSelection(
         fdUrl: String,
         token: String,
     ): FetchResult<List<AlertEventDef>> {
         catalogCalls.incrementAndGet()
         lastToken = token
         return catalog
+    }
+
+    override suspend fun setAlertEvent(
+        fdUrl: String,
+        token: String,
+        type: String,
+        enabled: Boolean,
+    ): ActionResult<List<AlertEventDef>> {
+        lastToggle = type to enabled
+        lastToken = token
+        return toggleResult
     }
 }
 
@@ -177,4 +192,100 @@ class AlertsViewModelTest {
             assertEquals(0, client.statusCalls.get())
             assertEquals(0, client.catalogCalls.get())
         }
+
+    @Test
+    fun toggleAdoptsEchoedSelection() =
+        runBlocking {
+            // Front Desk echoes the whole refreshed selection; the VM adopts it
+            // wholesale (the ack doubles as the re-read) rather than guessing.
+            val echoed = listOf(AlertEventDef("health.down", "Health", "error", defaultOn = true, enabled = true))
+            val client =
+                FakeAlertsClient(
+                    FetchResult.Success(okStatus),
+                    FetchResult.Success(okCatalog),
+                    toggleResult = ActionResult.Success(echoed),
+                )
+            val vm = newVm(client, linkedStore())
+            vm.refreshOnce()
+
+            vm.toggleEvent("health.down", true)
+
+            assertEquals("health.down" to true, client.lastToggle)
+            assertEquals(echoed, vm.state.value.catalog)
+            assertNull(vm.state.value.action.togglingType)
+            assertFalse(vm.state.value.action.forbidden)
+        }
+
+    @Test
+    fun toggleForbiddenSetsFlagAndKeepsCatalog() =
+        runBlocking {
+            val client =
+                FakeAlertsClient(
+                    FetchResult.Success(okStatus),
+                    FetchResult.Success(okCatalog),
+                    toggleResult = ActionResult.Forbidden,
+                )
+            val vm = newVm(client, linkedStore())
+            vm.refreshOnce()
+
+            vm.toggleEvent("health.down", false)
+
+            assertTrue(vm.state.value.action.forbidden)
+            assertEquals(okCatalog, vm.state.value.catalog)
+            assertNull(vm.state.value.action.togglingType)
+        }
+
+    @Test
+    fun toggleUnauthorizedRevokes() =
+        runBlocking {
+            val client =
+                FakeAlertsClient(
+                    FetchResult.Success(okStatus),
+                    FetchResult.Success(okCatalog),
+                    toggleResult = ActionResult.Unauthorized,
+                )
+            val vm = newVm(client, linkedStore())
+            vm.refreshOnce()
+
+            vm.toggleEvent("health.down", true)
+
+            assertTrue(vm.state.value.revoked)
+        }
+
+    @Test
+    fun toggleFailureSurfacesErrorThenDismiss() =
+        runBlocking {
+            val client =
+                FakeAlertsClient(
+                    FetchResult.Success(okStatus),
+                    FetchResult.Success(okCatalog),
+                    toggleResult = ActionResult.Failure("nope"),
+                )
+            val vm = newVm(client, linkedStore())
+            vm.refreshOnce()
+
+            vm.toggleEvent("health.down", true)
+            assertEquals("nope", vm.state.value.action.error)
+
+            vm.dismissActionError()
+            assertNull(vm.state.value.action.error)
+        }
+
+    @Test
+    fun enabledSeverityCountsAlwaysReturnsAllFourKeys() {
+        val catalog =
+            listOf(
+                AlertEventDef("health.down", "Health", "error", enabled = true),
+                AlertEventDef("config.sync_failed", "Config", "warning", enabled = true),
+                AlertEventDef("config.synced", "Config", "info", enabled = false),
+                AlertEventDef("health.up", "Health", "success", enabled = true),
+                AlertEventDef("member.added", "Membership", "warning", enabled = true),
+            )
+        val counts = enabledSeverityCounts(catalog)
+        assertEquals(setOf("error", "warning", "info", "success"), counts.keys)
+        assertEquals(1, counts["error"])
+        assertEquals(2, counts["warning"]) // enabled warnings only
+        assertEquals(0, counts["info"]) // present as 0 even though nothing enabled
+        assertEquals(1, counts["success"])
+    }
 }

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreenTest.kt
@@ -47,6 +47,7 @@ class SettingsScreenTest {
         pushNotificationsBlocked: Boolean = false,
         unlinkFailed: Boolean = false,
         holdToCopy: Boolean = false,
+        alertCounts: Map<String, Int> = emptyMap(),
         onToggleLock: (Boolean) -> Unit = {},
         onSelectTimeout: (LockTimeout) -> Unit = {},
         onToggleMonitor: (Boolean) -> Unit = {},
@@ -81,6 +82,7 @@ class SettingsScreenTest {
                     onForceUnlink = onForceUnlink,
                     holdToCopy = holdToCopy,
                     onToggleHoldToCopy = onToggleHoldToCopy,
+                    alertCounts = alertCounts,
                 )
             }
         }
@@ -231,6 +233,21 @@ class SettingsScreenTest {
         content(onAlertsClick = { opened++ })
         composeTestRule.onNodeWithTag("settings-alerts").performScrollTo().performClick()
         assertTrue(opened == 1)
+    }
+
+    @Test
+    fun alertSeverityBadgesShowAllFourEvenAtZero() {
+        // Only error and warning enabled; info and success still render (at 0) so the
+        // pill reads as a live, tappable destination.
+        content(alertCounts = mapOf("error" to 2, "warning" to 1, "info" to 0, "success" to 0))
+        // The clickable Alerts card merges its descendants' semantics, so the badge
+        // and chevron tags live in the unmerged tree; scroll the card into view first.
+        composeTestRule.onNodeWithTag("settings-alerts").performScrollTo()
+        for (sev in listOf("error", "warning", "info", "success")) {
+            composeTestRule.onNodeWithTag("settings-alert-badge-$sev", useUnmergedTree = true).assertExists()
+        }
+        // The nav chevron marks the pill as a jump to another screen.
+        composeTestRule.onNodeWithTag("nav-chevron", useUnmergedTree = true).assertExists()
     }
 
     @Test


### PR DESCRIPTION
The Bellhop counterpart to Front Desk's operator alert-selection API (#442). Bellhop now reads Front Desk's live alert selection and lets an **operator** flip which events Front Desk notifies on, straight from the phone. A **monitor** sees everything read-only.

## What changed

**Data / client**
- `FrontDeskClient.alertSelection` reads `GET /api/alert/selection` (the catalog enriched with each event's live `enabled` state); `setAlertEvent` POSTs a single-event flip. Front Desk echoes the whole refreshed selection, so **the ack doubles as the re-read**: the phone reconciles from Front Desk's own truth, and because each flip is atomic on the server, a dropped request (phone dies / loses network) is never left half-applied. `alertCatalog` is superseded and removed.

**ViewModel**
- `AlertsViewModel.toggleEvent` follows the established member drain/activate idiom: one flip at a time (a mid-flight tap is dropped and flagged `busy`, not queued), `403 → forbidden`, `401 → revoked`, and the echoed selection is adopted wholesale. A poll landing mid-flip can't clobber the in-flight catalog.

**Screens**
- `AlertsScreen` rows are now per-event **switches** showing the live enabled state. An operator flips them (routed through the existing biometric operator gate); a monitor's switches are disabled. A spinner replaces the switch while a flip is in flight so a double-tap can't fire twice.
- The Settings **Alerts pill** gains a coloured **severity-count badge row** (error / warning / info / success), always shown even at 0, sourced from a hoisted alerts VM so it stays live right after a flip.

**Affordance (2nd ask)**
- New reusable `NavChevron`: a single **brass-accent trailing chevron** marks any card whose tap navigates elsewhere, so a navigating pill no longer looks identical to a static one. Applied to the Alerts pill. Static cards get nothing; inline-action cards (toggle/copy) keep their own control.

## Verification
- `:app:testDebugUnitTest` green (incl. new client, VM toggle, screen switch/monitor/spinner/forbidden, and Settings badge tests), `:app:ktlintCheck` clean, `:app:lintDebug` clean, `:app:assembleDebug` builds.
- Probed prod (`front-desk.zmrd.uk`, rebuilt off `:dev`): both `GET`/`POST /api/alert/selection` return `401` (routes live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)