### PR TITLE
feat(bellhop): in-app i18n with a language picker (10 locales) + In sync→Verified rename

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -55,6 +55,15 @@ android {
         buildConfig = true
     }
 
+    lint {
+        // Locale parity is enforced here, in the existing Bellhop lint job: the
+        // repo's web "i18n Check" only covers the JS/JSON frontends, not Android
+        // resources. A values-<lang>/ that is missing a base key (MissingTranslation)
+        // or supplies one the base lacks (ExtraTranslation) fails the build, so a
+        // half-translated locale can't merge.
+        error += listOf("MissingTranslation", "ExtraTranslation")
+    }
+
     testOptions {
         unitTests {
             isIncludeAndroidResources = true

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
@@ -30,6 +30,7 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.hugalafutro.bellhop.data.AppLocale
 import com.hugalafutro.bellhop.data.FrontDeskClient
 import com.hugalafutro.bellhop.data.LinkState
 import com.hugalafutro.bellhop.data.LinkStore
@@ -72,6 +73,13 @@ private const val OPERATOR_AUTH_WINDOW_MS = 60_000L
 // FragmentActivity (not plain ComponentActivity) because BiometricPrompt hosts
 // its sheet on a FragmentManager; Compose still drives the whole UI.
 class MainActivity : FragmentActivity() {
+    // Apply the in-app language override before any resource resolves. A change
+    // from the Settings picker persists the tag and recreates the activity, which
+    // re-enters here in the new locale.
+    override fun attachBaseContext(newBase: Context) {
+        super.attachBaseContext(AppLocale.wrap(newBase))
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         // Register the background-backstop notification channels up front so a

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/AppLocale.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/AppLocale.kt
@@ -1,0 +1,73 @@
+package com.hugalafutro.bellhop.data
+
+import android.content.Context
+import android.content.res.Configuration
+import androidx.core.content.edit
+import java.util.Locale
+
+/**
+ * AppLocale persists the in-app language override and applies it to a Context.
+ * Bellhop is Compose on a plain FragmentActivity (no AppCompat), so per-app
+ * language uses a base-context wrapper ([wrap], from attachBaseContext) plus an
+ * activity recreate on change, rather than AppCompatDelegate. The tag lives in a
+ * small synchronous SharedPreferences so attachBaseContext can read it before the
+ * UI inflates; an empty tag means "follow the system locale".
+ */
+object AppLocale {
+    private const val PREFS = "bellhop_locale"
+    private const val KEY_TAG = "app_locale_tag"
+
+    // SYSTEM is the sentinel for "follow the system locale" (no override).
+    const val SYSTEM = ""
+
+    // SUPPORTED is the offered language set, matching Front Desk's. The picker
+    // prepends the system-default option; the order here is the picker order.
+    val SUPPORTED = listOf("en", "cs", "de", "es", "fr", "ja", "nl", "pl", "ru", "sk", "zh")
+
+    // endonyms names each language in its own language, so the picker reads the
+    // same whatever the current locale. Not string resources by design: a language
+    // name is never localized (French stays "Français" in a Japanese UI).
+    val endonyms =
+        mapOf(
+            "en" to "English",
+            "cs" to "Čeština",
+            "de" to "Deutsch",
+            "es" to "Español",
+            "fr" to "Français",
+            "ja" to "日本語",
+            "nl" to "Nederlands",
+            "pl" to "Polski",
+            "ru" to "Русский",
+            "sk" to "Slovenčina",
+            "zh" to "中文",
+        )
+
+    /** stored returns the persisted language tag, or [SYSTEM] when none is set. */
+    fun stored(context: Context): String =
+        context.getSharedPreferences(PREFS, Context.MODE_PRIVATE).getString(KEY_TAG, SYSTEM) ?: SYSTEM
+
+    /** store persists the chosen tag; apply() updates the in-memory value at once,
+     * so the recreate that follows reads it back in attachBaseContext. */
+    fun store(
+        context: Context,
+        tag: String,
+    ) {
+        context.getSharedPreferences(PREFS, Context.MODE_PRIVATE).edit { putString(KEY_TAG, tag) }
+    }
+
+    /**
+     * wrap returns a Context configured for the stored language, or [base]
+     * unchanged when following the system. Called from Activity.attachBaseContext,
+     * so the whole resource lookup (strings and, on recreate, everything) resolves
+     * in the chosen language.
+     */
+    fun wrap(base: Context): Context {
+        val tag = stored(base)
+        if (tag == SYSTEM) return base
+        val locale = Locale.forLanguageTag(tag)
+        Locale.setDefault(locale)
+        val config = Configuration(base.resources.configuration)
+        config.setLocale(locale)
+        return base.createConfigurationContext(config)
+    }
+}

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/AppLocale.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/AppLocale.kt
@@ -63,7 +63,17 @@ object AppLocale {
      */
     fun wrap(base: Context): Context {
         val tag = stored(base)
-        if (tag == SYSTEM) return base
+        if (tag == SYSTEM) {
+            // Reverting to system default within the same process: the JVM default may
+            // still hold a previously-chosen in-app language (set below on an earlier
+            // wrap), which the per-call date formatters read via Locale.getDefault().
+            // Restore it to the device locale so dates match the (system-language)
+            // resources again. base is the untouched system context, so its
+            // configuration carries the real device locale.
+            val locales = base.resources.configuration.locales
+            if (!locales.isEmpty) Locale.setDefault(locales[0])
+            return base
+        }
         val locale = Locale.forLanguageTag(tag)
         Locale.setDefault(locale)
         val config = Configuration(base.resources.configuration)

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/EventFilters.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/EventFilters.kt
@@ -67,16 +67,18 @@ data class CustomDateRange(
 
     /** label renders "Jul 1 – Jul 14" for the active-filter line. */
     fun label(): String =
-        "${DAY_FORMAT.format(
-            Instant.ofEpochMilli(startMs),
-        )} – ${DAY_FORMAT.format(Instant.ofEpochMilli(endMs))}"
+        dayFormat().let { fmt ->
+            "${fmt.format(Instant.ofEpochMilli(startMs))} – ${fmt.format(Instant.ofEpochMilli(endMs))}"
+        }
 
     private companion object {
         const val DAY_MS = 86_400_000L
 
-        // The picker hands out UTC midnights, so format in UTC too: a zoned
-        // format would shift the labelled day for anyone east of Greenwich.
-        val DAY_FORMAT: DateTimeFormatter =
+        // dayFormat is built per call from the current default locale (kept in step
+        // with the in-app language by AppLocale) so the month abbreviation follows a
+        // language switch. The picker hands out UTC midnights, so format in UTC too:
+        // a zoned format would shift the labelled day for anyone east of Greenwich.
+        fun dayFormat(): DateTimeFormatter =
             DateTimeFormatter.ofPattern("MMM d", Locale.getDefault()).withZone(ZoneOffset.UTC)
     }
 }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/RelativeTime.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/RelativeTime.kt
@@ -1,17 +1,25 @@
 package com.hugalafutro.bellhop.ui.common
 
-// relativeAgo turns an elapsed span (millis) into a terse human string: "just now"
-// under a minute, then minutes, hours, and days. Shared by the member-detail
-// SYNCED row and the dashboard cards' recent-event pills.
-fun relativeAgo(elapsedMs: Long): String {
-    val minutes = elapsedMs / 60_000L
-    val hours = elapsedMs / 3_600_000L
-    val days = elapsedMs / 86_400_000L
+import android.content.Context
+import com.hugalafutro.bellhop.R
+
+// relativeAgo turns an elapsed span (millis) into a terse, localized human string:
+// "just now" under a minute, then minutes, hours, and days. It resolves strings
+// through the given context, so the wording follows the in-app language (and the
+// day count pluralizes correctly per locale). Shared by the member-detail SYNCED /
+// VERIFIED / ADDED rows and the dashboard cards' recent-event pills.
+fun relativeAgo(
+    context: Context,
+    elapsedMs: Long,
+): String {
+    val minutes = (elapsedMs / 60_000L).toInt()
+    val hours = (elapsedMs / 3_600_000L).toInt()
+    val days = (elapsedMs / 86_400_000L).toInt()
+    val res = context.resources
     return when {
-        minutes < 1 -> "just now"
-        minutes < 60 -> "$minutes min ago"
-        hours < 24 -> "$hours hr ago"
-        days == 1L -> "1 day ago"
-        else -> "$days days ago"
+        minutes < 1 -> res.getString(R.string.time_just_now)
+        minutes < 60 -> res.getQuantityString(R.plurals.time_min_ago, minutes, minutes)
+        hours < 24 -> res.getQuantityString(R.plurals.time_hr_ago, hours, hours)
+        else -> res.getQuantityString(R.plurals.time_day_ago, days, days)
     }
 }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
@@ -1,5 +1,6 @@
 package com.hugalafutro.bellhop.ui.dashboard
 
+import android.content.Context
 import android.widget.Toast
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
@@ -609,7 +610,8 @@ private fun MemberCard(
                             overflow = TextOverflow.Ellipsis,
                             modifier = Modifier.weight(1f),
                         )
-                        remember(ev.createdAt) { eventAgo(ev.createdAt) }?.let { ago ->
+                        val context = LocalContext.current
+                        remember(ev.createdAt, context) { eventAgo(context, ev.createdAt) }?.let { ago ->
                             Spacer(modifier = Modifier.width(8.dp))
                             Text(
                                 text = ago,
@@ -666,11 +668,12 @@ private fun DashboardFooter(
 // for the recent-event pill, or null when it can't be parsed (the pill then just
 // omits the age rather than showing a raw string).
 private fun eventAgo(
+    context: Context,
     createdAt: String,
     now: Long = System.currentTimeMillis(),
 ): String? =
     try {
-        relativeAgo((now - Instant.parse(createdAt).toEpochMilli()).coerceAtLeast(0L))
+        relativeAgo(context, (now - Instant.parse(createdAt).toEpochMilli()).coerceAtLeast(0L))
     } catch (e: Exception) {
         null
     }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/events/EventsScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/events/EventsScreen.kt
@@ -303,15 +303,15 @@ private fun severityLabel(severity: String): String =
         else -> severity
     }
 
-private val EVENT_TIME_FORMAT =
-    DateTimeFormatter.ofPattern("MMM d, yyyy · HH:mm", Locale.getDefault())
-
 // formatEventTime renders the stored RFC3339 timestamp in local time, falling
 // back to the raw string on anything unparseable (garbage in, garbage shown —
-// better than a crash or a blank cell).
+// better than a crash or a blank cell). The formatter is built per call from the
+// current default locale (kept in step with the in-app language by AppLocale), so
+// month names follow a language switch instead of freezing at process start.
 internal fun formatEventTime(createdAt: String): String =
     try {
-        Instant.parse(createdAt).atZone(ZoneId.systemDefault()).format(EVENT_TIME_FORMAT)
+        val format = DateTimeFormatter.ofPattern("MMM d, yyyy · HH:mm", Locale.getDefault())
+        Instant.parse(createdAt).atZone(ZoneId.systemDefault()).format(format)
     } catch (e: Exception) {
         createdAt
     }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreen.kt
@@ -1,5 +1,6 @@
 package com.hugalafutro.bellhop.ui.member
 
+import android.content.Context
 import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -316,6 +317,7 @@ private fun MetaLedger(
     modifier: Modifier = Modifier,
 ) {
     val health = member.status.health
+    val context = LocalContext.current
     Column(
         modifier = modifier.fillMaxWidth().testTag("member-detail-meta"),
         verticalArrangement = Arrangement.spacedBy(6.dp),
@@ -341,7 +343,11 @@ private fun MetaLedger(
             LedgerRow(
                 label = stringResource(R.string.member_detail_label_synced),
                 value = formatEventTime(member.lastConfigSyncAt),
-                trailing = remember(member.lastConfigSyncAt) { ageParenthetical(member.lastConfigSyncAt) },
+                trailing =
+                    remember(
+                        member.lastConfigSyncAt,
+                        context,
+                    ) { ageParenthetical(context, member.lastConfigSyncAt) },
                 trailingColor = syncAgeColorFor(member.lastConfigSyncAt),
                 tag = "member-detail-synced",
             )
@@ -360,8 +366,8 @@ private fun MetaLedger(
                 label = stringResource(R.string.member_detail_label_verified),
                 value = formatEventTime(member.status.autoSyncVerifiedAt),
                 trailing =
-                    remember(member.status.autoSyncVerifiedAt) {
-                        ageParenthetical(member.status.autoSyncVerifiedAt)
+                    remember(member.status.autoSyncVerifiedAt, context) {
+                        ageParenthetical(context, member.status.autoSyncVerifiedAt)
                     },
                 tag = "member-detail-verified",
             )
@@ -370,7 +376,7 @@ private fun MetaLedger(
             LedgerRow(
                 label = stringResource(R.string.member_detail_label_added),
                 value = formatEventTime(member.createdAt),
-                trailing = remember(member.createdAt) { ageParenthetical(member.createdAt) },
+                trailing = remember(member.createdAt, context) { ageParenthetical(context, member.createdAt) },
                 tag = "member-detail-created",
             )
         }
@@ -438,6 +444,7 @@ private val SyncAgeRed = Color(0xFFC62828)
 // e.g. "(3 days ago)", or null when the timestamp can't be parsed (the row then
 // just shows the date). Shared by the SYNCED, VERIFIED and ADDED rows.
 private fun ageParenthetical(
+    context: Context,
     timestamp: String,
     now: Long = System.currentTimeMillis(),
 ): String? {
@@ -447,7 +454,7 @@ private fun ageParenthetical(
         } catch (e: Exception) {
             return null
         }
-    return "(" + relativeAgo((now - ts).coerceAtLeast(0L)) + ")"
+    return "(" + relativeAgo(context, (now - ts).coerceAtLeast(0L)) + ")"
 }
 
 // syncAgeColorFor grades the SYNCED row's age suffix by staleness (see

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreen.kt
@@ -1,5 +1,6 @@
 package com.hugalafutro.bellhop.ui.settings
 
+import android.app.Activity
 import android.widget.Toast
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -9,6 +10,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -20,6 +22,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
@@ -35,6 +38,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -44,6 +48,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.hugalafutro.bellhop.R
+import com.hugalafutro.bellhop.data.AppLocale
 import com.hugalafutro.bellhop.data.LinkState
 import com.hugalafutro.bellhop.data.LockConfig
 import com.hugalafutro.bellhop.data.LockTimeout
@@ -99,8 +104,12 @@ fun SettingsScreen(
 ) {
     var confirmUnlink by remember { mutableStateOf(false) }
     var confirmCopyAddress by remember { mutableStateOf(false) }
+    var showLanguagePicker by remember { mutableStateOf(false) }
     val clipboard = LocalClipboardManager.current
     val context = LocalContext.current
+    // Read once: choosing a different language recreates the activity, so this
+    // never needs to react to a live change.
+    val currentLanguage = remember { AppLocale.stored(context) }
     val pushCopied = stringResource(R.string.settings_push_copied)
     val addressCopied = stringResource(R.string.settings_fd_copied)
 
@@ -194,6 +203,22 @@ fun SettingsScreen(
         )
     }
 
+    if (showLanguagePicker) {
+        LanguagePickerDialog(
+            current = currentLanguage,
+            onSelect = { tag ->
+                showLanguagePicker = false
+                // A no-op pick avoids a pointless recreate; a real change persists
+                // then recreates the activity, which re-reads the tag in the new locale.
+                if (tag != currentLanguage) {
+                    AppLocale.store(context, tag)
+                    (context as? Activity)?.recreate()
+                }
+            },
+            onDismiss = { showLanguagePicker = false },
+        )
+    }
+
     Scaffold(modifier = modifier.fillMaxSize()) { innerPadding ->
         Column(
             modifier =
@@ -221,6 +246,19 @@ fun SettingsScreen(
                     color = MaterialTheme.colorScheme.primary,
                     modifier = Modifier.weight(1f).testTag("settings-title"),
                 )
+                // Language lives up here, not on the dashboard: the settings cog is a
+                // universal-enough entry point that the picker needn't sit on the main
+                // screen. The globe/translate glyph reads across languages.
+                IconButton(
+                    onClick = { showLanguagePicker = true },
+                    modifier = Modifier.testTag("settings-language"),
+                ) {
+                    Icon(
+                        painter = painterResource(R.drawable.ic_translate),
+                        contentDescription = stringResource(R.string.settings_language),
+                        tint = MaterialTheme.colorScheme.primary,
+                    )
+                }
             }
 
             // Front Desk link status (moved off the dashboard toolbar).
@@ -569,6 +607,67 @@ fun SettingsScreen(
             }
             Spacer(modifier = Modifier.height(24.dp))
         }
+    }
+}
+
+/**
+ * LanguagePickerDialog lists the system-default option plus every supported
+ * language by its own name (endonym), with the active one selected. Choosing one
+ * bubbles the tag up; the caller persists it and recreates the activity. The list
+ * scrolls within a capped height so it fits on a short screen.
+ */
+@Composable
+private fun LanguagePickerDialog(
+    current: String,
+    onSelect: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            TextButton(onClick = onDismiss, modifier = Modifier.testTag("language-cancel")) {
+                Text(text = stringResource(R.string.common_cancel))
+            }
+        },
+        title = { Text(text = stringResource(R.string.settings_language)) },
+        text = {
+            Column(modifier = Modifier.fillMaxWidth().heightIn(max = 360.dp).verticalScroll(rememberScrollState())) {
+                LanguageRow(
+                    label = stringResource(R.string.language_system_default),
+                    selected = current == AppLocale.SYSTEM,
+                    onClick = { onSelect(AppLocale.SYSTEM) },
+                    tag = "language-option-system",
+                )
+                AppLocale.SUPPORTED.forEach { tag ->
+                    LanguageRow(
+                        label = AppLocale.endonyms[tag] ?: tag,
+                        selected = current == tag,
+                        onClick = { onSelect(tag) },
+                        tag = "language-option-$tag",
+                    )
+                }
+            }
+        },
+    )
+}
+
+@Composable
+private fun LanguageRow(
+    label: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+    tag: String,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick).padding(vertical = 8.dp).testTag(tag),
+    ) {
+        RadioButton(selected = selected, onClick = onClick)
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyLarge,
+            modifier = Modifier.padding(start = 8.dp),
+        )
     }
 }
 

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreen.kt
@@ -62,6 +62,7 @@ import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
+import java.util.Locale
 
 /**
  * SettingsScreen is where the link's status and the two things the dashboard
@@ -713,13 +714,20 @@ private fun severityBadgeLabel(severity: String): String =
         else -> stringResource(R.string.events_sev_info)
     }
 
-// A localized "Jul 14, 2026"-style date for when the link was paired, or null
-// when the stamp is absent (links saved before linkedAt existed) so the row hides.
-private val linkedOnFormatter: DateTimeFormatter =
-    DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).withZone(ZoneId.systemDefault())
-
-private fun linkedOnLabel(linkedAt: Long): String? =
-    if (linkedAt <= 0L) null else linkedOnFormatter.format(Instant.ofEpochMilli(linkedAt))
+// linkedOnLabel is a localized "Jul 14, 2026"-style date for when the link was
+// paired, or null when the stamp is absent (links saved before linkedAt existed)
+// so the row hides. The formatter is built per call from the current default
+// locale (kept in step with the in-app language by AppLocale), so the date follows
+// a language switch instead of freezing at process start.
+private fun linkedOnLabel(linkedAt: Long): String? {
+    if (linkedAt <= 0L) return null
+    val formatter =
+        DateTimeFormatter
+            .ofLocalizedDate(FormatStyle.MEDIUM)
+            .withLocale(Locale.getDefault())
+            .withZone(ZoneId.systemDefault())
+    return formatter.format(Instant.ofEpochMilli(linkedAt))
+}
 
 private fun timeoutLabel(option: LockTimeout): Int =
     when (option) {

--- a/android/app/src/main/res/drawable/ic_translate.xml
+++ b/android/app/src/main/res/drawable/ic_translate.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12.87,15.07l-2.54,-2.51 0.03,-0.03c1.74,-1.94 2.98,-4.17 3.71,-6.53L17,6L17,4h-7L10,2L8,2v2L1,4v1.99h11.17C11.5,7.92 10.44,9.75 9,11.35 8.07,10.32 7.3,9.19 6.69,8h-2c0.73,1.63 1.73,3.17 2.98,4.56l-5.09,5.02L4,19l5,-5 3.11,3.11 0.76,-2.04zM18.5,10h-2L12,22h2l1.12,-3h4.75L21,22h2l-4.5,-12zM15.88,17l1.62,-4.33L19.12,17h-3.24z"/>
+</vector>

--- a/android/app/src/main/res/values-cs/strings.xml
+++ b/android/app/src/main/res/values-cs/strings.xml
@@ -1,0 +1,200 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- Pairing (unlinked state) -->
+    <string name="pairing_title">Propojit Front Desk</string>
+    <string name="pairing_subtitle">Ve Front Desku otevřete Nastavení → Spárovaná zařízení a vygenerujte kód. Naskenujte zobrazený QR kód, nebo zkopírujte párovací řetězec vedle něj a vložte ho níže.</string>
+    <string name="pairing_scan">Naskenovat QR kód</string>
+    <string name="pairing_scan_prompt">Zamiřte na párovací QR ve Front Desku\n→ Nastavení → Spárovaná zařízení</string>
+    <string name="pairing_or">nebo ho vložte</string>
+    <string name="pairing_paste_label">Párovací řetězec</string>
+    <string name="pairing_paste_hint">Vložte sem zkopírovaný párovací řetězec</string>
+    <string name="pairing_target">Front Desk: %1$s\n%2$s</string>
+    <string name="pairing_label_label">Název tohoto zařízení</string>
+    <string name="pairing_submit">Spárovat</string>
+    <string name="pairing_error_bad_string">To nevypadá jako párovací řetězec. Zkopírujte ho znovu z Front Desku → Nastavení → Spárovaná zařízení.</string>
+    <string name="pairing_error_invalid_code">Neplatný nebo vypršelý párovací kód. Vygenerujte nový ve Front Desku a vložte nový řetězec.</string>
+    <string name="pairing_error_scan_unavailable">Fotoaparát se nepodařilo otevřít, takže skenování není dostupné. Povolte přístup k fotoaparátu, nebo místo toho vložte párovací řetězec níže.</string>
+
+    <!-- Dashboard (linked state) -->
+    <string name="dashboard_linked_as">Propojeno jako %1$s (%2$s)</string>
+    <string name="dashboard_summary_all_up">Všichni členové běží</string>
+    <string name="dashboard_summary_down">%1$d z %2$d členů je mimo provoz</string>
+    <string name="dashboard_summary_checking">Kontrola členů…</string>
+    <string name="dashboard_empty">Zatím žádní členové. Přidejte je ve Front Desku.</string>
+    <string name="dashboard_refresh_failed">Nepodařilo se obnovit: %1$s</string>
+    <string name="dashboard_revoked">Toto zařízení se už nemůže ověřit u Front Desku. Jeho přístup byl možná odvolán; zrušte propojení a spárujte znovu s novým kódem.</string>
+    <string name="member_health_up">Běží · %1$d ms</string>
+    <string name="member_health_down">Mimo provoz</string>
+    <string name="member_health_unknown">Zatím nezkontrolováno</string>
+    <string name="member_traefik">Traefik %1$s</string>
+    <string name="member_state_drained">Odstaveno</string>
+    <string name="member_primary">Primární</string>
+    <!-- Member detail -->
+    <string name="member_detail_back">Zpět</string>
+    <string name="member_detail_traffic_title">Provoz · posledních %1$d min</string>
+    <string name="member_detail_traffic_totals">%1$d požadavků · %2$d chyb</string>
+    <string name="member_detail_traffic_unreachable">Provoz není dostupný. Front Desk možná nemá pro tohoto člena admin token, nebo člen neodpověděl.</string>
+    <string name="member_detail_traffic_empty">V tomto okně žádné požadavky.</string>
+    <string name="member_detail_events_title">Nedávné události</string>
+    <string name="member_detail_no_events">Pro tohoto člena žádné nedávné události.</string>
+    <string name="member_detail_label_address">Adresa</string>
+    <string name="member_detail_label_synced">Synchronizováno</string>
+    <string name="member_detail_label_reason">Důvod</string>
+    <string name="member_detail_label_verified">Ověřeno</string>
+    <string name="member_detail_label_added">Přidáno</string>
+    <string name="member_url_title">Otevřít adresu člena</string>
+    <string name="member_url_open">Otevřít</string>
+    <string name="open_url_title">Otevřít odkaz</string>
+    <!-- Operator actions -->
+    <string name="member_op_title">Ovládání operátora</string>
+    <string name="member_op_drain">Odstavit</string>
+    <string name="member_op_activate">Aktivovat</string>
+    <string name="member_op_draining">Odstavování… čeká se, až se flotila srovná.</string>
+    <string name="member_op_activating">Aktivace… čeká se, až se flotila srovná.</string>
+    <string name="member_op_sync">Synchronizovat konfiguraci flotily</string>
+    <string name="member_op_synced">Synchronizováno %1$d členů z primárního.</string>
+    <string name="member_op_sync_failed">Synchronizace skončila s %1$d z %2$d neúspěšných členů.</string>
+    <string name="member_op_error">Nepodařilo se použít: %1$s</string>
+    <string name="member_op_dismiss">Zavřít</string>
+    <string name="member_op_last_sync">Poslední změna konfigurace synchronizována %1$s</string>
+    <string name="member_op_busy">Ještě běží jiná akce. Počkejte, až skončí, a zkuste to znovu.</string>
+    <string name="member_op_forbidden">Toto zařízení je spárováno jako monitor a nemůže měnit flotilu. Spárujte ho znovu s operátorským kódem ve Front Desku, abyste mohli odstavit, aktivovat nebo synchronizovat.</string>
+
+    <!-- Pause/resume auto-sync (dashboard operator control) -->
+    <string name="autosync_title">Automatická synchronizace</string>
+    <string name="autosync_on">Flotila zůstává synchronizovaná s primárním.</string>
+    <string name="autosync_off">Flotila se nebude synchronizovat, dokud neobnovíte.</string>
+    <string name="autosync_pausing">Pozastavování…</string>
+    <string name="autosync_resuming">Obnovování…</string>
+    <string name="autosync_busy">Ještě běží jiná akce. Počkejte, až skončí, a zkuste to znovu.</string>
+    <string name="autosync_error">Nepodařilo se použít: %1$s</string>
+    <string name="autosync_forbidden">Toto zařízení je spárováno jako monitor a nemůže měnit automatickou synchronizaci. Spárujte ho znovu s operátorským kódem ve Front Desku.</string>
+
+    <!-- Events -->
+    <string name="events_title">Události</string>
+    <string name="events_open">Události</string>
+    <string name="events_back">Zpět</string>
+    <string name="events_empty">Žádné odpovídající události.</string>
+    <string name="events_copied">Událost zkopírována do schránky</string>
+    <string name="dashboard_member_copied">Člen zkopírován do schránky</string>
+    <string name="scroll_to_top">Přejít nahoru</string>
+    <plurals name="events_total">
+        <item quantity="one">%1$d událost</item>
+        <item quantity="few">%1$d události</item>
+        <item quantity="many">%1$d události</item>
+        <item quantity="other">%1$d událostí</item>
+    </plurals>
+    <string name="events_sev_all">Vše</string>
+    <string name="events_sev_info">Info</string>
+    <string name="events_sev_success">Úspěch</string>
+    <string name="events_sev_warning">Varování</string>
+    <string name="events_sev_error">Chyba</string>
+    <string name="events_range_all">Celá doba</string>
+    <string name="events_range_1h">1 h</string>
+    <string name="events_range_24h">24 h</string>
+    <string name="events_range_7d">7 d</string>
+    <string name="events_range_30d">30 d</string>
+    <string name="events_range_calendar">Vybrat rozsah dat</string>
+    <string name="events_range_clear">Vymazat rozsah dat</string>
+    <string name="events_range_apply">Použít</string>
+
+    <!-- Alerts -->
+    <string name="alerts_title">Upozornění</string>
+    <string name="alerts_open">Upozornění</string>
+    <string name="alerts_back">Zpět</string>
+    <string name="alerts_delivery_title">Doručování oznámení</string>
+    <string name="alerts_status_not_configured">Nenakonfigurováno</string>
+    <string name="alerts_status_unreachable">Oznamovatel nedostupný</string>
+    <string name="alerts_status_unhealthy">Oznamovatel nefunkční</string>
+    <string name="alerts_status_delivering">Doručuje se</string>
+    <string name="alerts_catalog_title">Na co Front Desk upozorňuje</string>
+    <string name="alerts_catalog_note">Přepnutím přepínače povolíte nebo ztlumíte upozornění. Změny se na Front Desku projeví okamžitě.</string>
+    <string name="alerts_flip_forbidden">Toto zařízení je spárováno jako monitor a nemůže měnit upozornění. Spárujte ho znovu s operátorským kódem ve Front Desku.</string>
+    <string name="alerts_flip_failed">Toto upozornění se nepodařilo změnit: %1$s</string>
+    <string name="alerts_event_health_down">Člen spadl</string>
+    <string name="alerts_event_health_up">Člen obnoven</string>
+    <string name="alerts_event_config_sync_failed">Synchronizace konfigurace selhala</string>
+    <string name="alerts_event_config_synced">Konfigurace synchronizována</string>
+    <string name="alerts_event_config_auto_synced">Konfigurace automaticky synchronizována</string>
+    <string name="alerts_event_version_fetch_failed">Čtení verze selhalo</string>
+    <string name="alerts_event_version_fetch_recovered">Čtení verze obnoveno</string>
+    <string name="alerts_event_traefik_stale">Konfigurace Traefiku zastaralá</string>
+    <string name="alerts_event_member_added">Člen přidán</string>
+    <string name="alerts_event_member_removed">Člen odebrán</string>
+    <string name="alerts_event_member_state_changed">Člen odstaven nebo aktivován</string>
+
+    <!-- App lock -->
+    <string name="lock_title">Bellhop je uzamčen</string>
+    <string name="lock_subtitle">Odemkněte pro zobrazení flotily.</string>
+    <string name="lock_unlock">Odemknout</string>
+    <string name="lock_prompt_title">Odemknout Bellhop</string>
+    <string name="lock_prompt_subtitle">Potvrďte, že jste to vy, pro zobrazení flotily.</string>
+    <string name="operator_prompt_title">Potvrdit operátorskou akci</string>
+    <string name="operator_prompt_subtitle">Potvrďte, že jste to vy, než změníte flotilu.</string>
+
+    <!-- Settings -->
+    <string name="settings_open">Nastavení</string>
+    <string name="settings_title">Nastavení</string>
+    <string name="settings_back">Zpět</string>
+    <string name="settings_language">Jazyk</string>
+    <string name="language_system_default">Výchozí podle systému</string>
+    <string name="settings_fd_title">Propojený Front Desk</string>
+    <string name="settings_fd_linked_on">Propojeno %1$s</string>
+    <string name="settings_fd_copy_title">Zkopírovat adresu?</string>
+    <string name="settings_fd_copy_body">Zkopírovat %1$s do schránky?</string>
+    <string name="settings_fd_copied">Adresa zkopírována do schránky</string>
+    <string name="common_copy">Kopírovat</string>
+    <string name="settings_hold_copy_title">Podržet pro kopírování</string>
+    <string name="settings_hold_copy_subtitle">Když je zapnuto, dlouhým stiskem buňky události nebo člena ji zkopírujete do schránky. Když je vypnuto, buňky nelze kopírovat.</string>
+    <string name="settings_lock_title">Zámek aplikace</string>
+    <string name="settings_lock_subtitle">Vyžadovat otisk prstu nebo PIN zařízení pro otevření Bellhopu.</string>
+    <string name="settings_lock_unavailable">Nastavte na tomto zařízení otisk prstu nebo zámek obrazovky, abyste povolili zámek aplikace.</string>
+    <string name="settings_lock_window">Uzamknout po nečinnosti</string>
+    <string name="settings_lock_now">Ihned</string>
+    <string name="settings_lock_1m">1 min</string>
+    <string name="settings_lock_5m">5 min</string>
+    <string name="settings_lock_15m">15 min</string>
+    <string name="settings_lock_30m">30 min</string>
+    <string name="settings_lock_1h">1 h</string>
+    <string name="settings_alerts_title">Upozornění</string>
+    <string name="settings_alerts_subtitle">Doručování oznámení a na co Front Desk upozorňuje.</string>
+    <!-- Accessibility label for a severity count badge on the Alerts pill, e.g. "2 error enabled". -->
+    <string name="settings_alerts_badge_desc">%1$d %2$s povoleno</string>
+    <string name="settings_monitor_title">Sledování na pozadí</string>
+    <string name="settings_monitor_subtitle">Kontroluje flotilu každých 15 minut a upozorní vás zde, když člen spadne nebo se obnoví, i když je Bellhop zavřený.</string>
+    <string name="settings_monitor_note">Vlastní upozornění Front Desku jsou rychlejší; toto je záloha pro případ, že je Bellhop vaším jediným pohledem. Kontroluje zhruba každých 15 minut, takže změna může přijít až s tímto zpožděním.</string>
+    <string name="settings_monitor_blocked">Oznámení pro Bellhop jsou vypnutá, takže se k vám tato upozornění nedostanou. Zapněte je v nastavení systému.</string>
+    <string name="settings_push_title">Push v reálném čase</string>
+    <string name="settings_push_subtitle">Probudí Bellhop v okamžiku, kdy Front Desk odešle upozornění, přes UnifiedPush a ntfy. Bez Googlu, bez zpoždění dotazování, dobrovolné.</string>
+    <string name="settings_push_no_distributor">Nainstalujte distributora UnifiedPush, například ntfy, pro příjem pushů. Bez něj zůstane toto nečinné, dokud ho nepřidáte.</string>
+    <string name="settings_push_endpoint_label">Push téma pro Front Desk</string>
+    <string name="settings_push_endpoint_waiting">Čeká se, až distributor vrátí push téma…</string>
+    <string name="settings_push_endpoint_note">Vložte toto do Front Desku → Nastavení → Upozornění jako téma telefonu, aby jeho upozornění probouzela Bellhop.</string>
+    <string name="settings_push_copy">Kopírovat push téma</string>
+    <string name="settings_push_copied">Push téma zkopírováno</string>
+    <string name="settings_push_blocked">Oznámení pro Bellhop jsou vypnutá, takže se k vám pushe nedostanou. Zapněte je v nastavení systému.</string>
+
+    <!-- Background-monitoring notifications (Layer 2 backstop) -->
+    <string name="notif_channel_down">Člen mimo provoz</string>
+    <string name="notif_channel_up">Člen obnoven</string>
+    <string name="notif_down_title">%1$s je mimo provoz</string>
+    <string name="notif_down_body">Člen přestal odpovídat. Klepnutím otevřete Bellhop.</string>
+    <string name="notif_up_title">%1$s obnoven</string>
+    <string name="notif_up_body">Člen zase odpovídá.</string>
+    <string name="notif_channel_stale">Odchylka konfigurace</string>
+    <string name="notif_stale_title">Flotila se možná odchyluje</string>
+    <string name="notif_stale_body">Automatická synchronizace je vypnutá a flotila se nesynchronizovala už přes den. Klepnutím otevřete Bellhop.</string>
+    <string name="notif_stale_resumed_title">Automatická synchronizace obnovena</string>
+    <string name="notif_stale_resumed_body">Flotila je opět udržována synchronizovaná.</string>
+
+    <string name="dashboard_footer">Bellhop %1$s</string>
+    <string name="dashboard_unlink">Zrušit propojení</string>
+    <string name="dashboard_unlink_confirm_title">Zrušit propojení tohoto zařízení?</string>
+    <string name="dashboard_unlink_confirm_body">Toto zařízení přestane sledovat %1$s a jeho token bude odvolán. Kdykoli můžete spárovat znovu s novým kódem.</string>
+    <string name="dashboard_unlink_failed_title">Nepodařilo se spojit s Front Deskem</string>
+    <string name="dashboard_unlink_failed_body">Toto zařízení je stále propojené a nic nebylo odvoláno. Zkontrolujte připojení a zkuste to znovu. Propojení tu můžete zrušit i tak, ale Front Desk může toto zařízení dál zobrazovat, proto ho odvolejte z Front Desku → Nastavení → Spárovaná zařízení.</string>
+    <string name="dashboard_unlink_retry">Zkusit znovu</string>
+    <string name="dashboard_unlink_force">Přesto zrušit propojení</string>
+    <string name="common_cancel">Zrušit</string>
+</resources>

--- a/android/app/src/main/res/values-cs/strings.xml
+++ b/android/app/src/main/res/values-cs/strings.xml
@@ -197,4 +197,23 @@
     <string name="dashboard_unlink_retry">Zkusit znovu</string>
     <string name="dashboard_unlink_force">Přesto zrušit propojení</string>
     <string name="common_cancel">Zrušit</string>
+    <string name="time_just_now">právě teď</string>
+    <plurals name="time_min_ago">
+        <item quantity="one">před %d min</item>
+        <item quantity="few">před %d min</item>
+        <item quantity="many">před %d min</item>
+        <item quantity="other">před %d min</item>
+    </plurals>
+    <plurals name="time_hr_ago">
+        <item quantity="one">před %d h</item>
+        <item quantity="few">před %d h</item>
+        <item quantity="many">před %d h</item>
+        <item quantity="other">před %d h</item>
+    </plurals>
+    <plurals name="time_day_ago">
+        <item quantity="one">před %d dnem</item>
+        <item quantity="few">před %d dny</item>
+        <item quantity="many">před %d dne</item>
+        <item quantity="other">před %d dny</item>
+    </plurals>
 </resources>

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1,0 +1,198 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- Pairing (unlinked state) -->
+    <string name="pairing_title">Front Desk verknüpfen</string>
+    <string name="pairing_subtitle">Öffne in Front Desk Einstellungen → Gekoppelte Geräte und erzeuge einen Code. Scanne den angezeigten QR-Code oder kopiere die Kopplungszeichenfolge daneben und füge sie unten ein.</string>
+    <string name="pairing_scan">QR-Code scannen</string>
+    <string name="pairing_scan_prompt">Auf den Kopplungs-QR in Front Desk richten\n→ Einstellungen → Gekoppelte Geräte</string>
+    <string name="pairing_or">oder einfügen</string>
+    <string name="pairing_paste_label">Kopplungszeichenfolge</string>
+    <string name="pairing_paste_hint">Kopierte Kopplungszeichenfolge hier einfügen</string>
+    <string name="pairing_target">Front Desk: %1$s\n%2$s</string>
+    <string name="pairing_label_label">Name dieses Geräts</string>
+    <string name="pairing_submit">Koppeln</string>
+    <string name="pairing_error_bad_string">Das sieht nicht nach einer Kopplungszeichenfolge aus. Kopiere sie in Front Desk → Einstellungen → Gekoppelte Geräte erneut.</string>
+    <string name="pairing_error_invalid_code">Ungültiger oder abgelaufener Kopplungscode. Erzeuge in Front Desk einen neuen und füge die frische Zeichenfolge ein.</string>
+    <string name="pairing_error_scan_unavailable">Die Kamera konnte nicht geöffnet werden, daher ist das Scannen nicht verfügbar. Erlaube den Kamerazugriff oder füge stattdessen unten die Kopplungszeichenfolge ein.</string>
+
+    <!-- Dashboard (linked state) -->
+    <string name="dashboard_linked_as">Verknüpft als %1$s (%2$s)</string>
+    <string name="dashboard_summary_all_up">Alle Mitglieder aktiv</string>
+    <string name="dashboard_summary_down">%1$d von %2$d Mitgliedern ausgefallen</string>
+    <string name="dashboard_summary_checking">Mitglieder werden geprüft…</string>
+    <string name="dashboard_empty">Noch keine Mitglieder. Füge sie in Front Desk hinzu.</string>
+    <string name="dashboard_refresh_failed">Aktualisieren fehlgeschlagen: %1$s</string>
+    <string name="dashboard_revoked">Dieses Gerät kann sich nicht mehr bei Front Desk authentifizieren. Sein Zugriff wurde möglicherweise widerrufen; Verknüpfung aufheben und mit einem neuen Code erneut koppeln.</string>
+    <string name="member_health_up">Aktiv · %1$d ms</string>
+    <string name="member_health_down">Ausgefallen</string>
+    <string name="member_health_unknown">Noch nicht geprüft</string>
+    <string name="member_traefik">Traefik %1$s</string>
+    <string name="member_state_drained">Stillgelegt</string>
+    <string name="member_primary">Primär</string>
+    <!-- Member detail -->
+    <string name="member_detail_back">Zurück</string>
+    <string name="member_detail_traffic_title">Traffic · letzte %1$d Min</string>
+    <string name="member_detail_traffic_totals">%1$d Anfragen · %2$d Fehler</string>
+    <string name="member_detail_traffic_unreachable">Traffic ist nicht verfügbar. Front Desk hat für dieses Mitglied möglicherweise kein Admin-Token, oder das Mitglied hat nicht geantwortet.</string>
+    <string name="member_detail_traffic_empty">Keine Anfragen in diesem Zeitraum.</string>
+    <string name="member_detail_events_title">Letzte Ereignisse</string>
+    <string name="member_detail_no_events">Keine aktuellen Ereignisse für dieses Mitglied.</string>
+    <string name="member_detail_label_address">Adresse</string>
+    <string name="member_detail_label_synced">Synchronisiert</string>
+    <string name="member_detail_label_reason">Grund</string>
+    <string name="member_detail_label_verified">Verifiziert</string>
+    <string name="member_detail_label_added">Hinzugefügt</string>
+    <string name="member_url_title">Mitgliedsadresse öffnen</string>
+    <string name="member_url_open">Öffnen</string>
+    <string name="open_url_title">Link öffnen</string>
+    <!-- Operator actions -->
+    <string name="member_op_title">Operator-Steuerung</string>
+    <string name="member_op_drain">Entleeren</string>
+    <string name="member_op_activate">Aktivieren</string>
+    <string name="member_op_draining">Wird entleert… warten, bis die Flotte aufgeholt hat.</string>
+    <string name="member_op_activating">Wird aktiviert… warten, bis die Flotte aufgeholt hat.</string>
+    <string name="member_op_sync">Flotten-Konfiguration synchronisieren</string>
+    <string name="member_op_synced">%1$d Mitglieder vom Primärknoten synchronisiert.</string>
+    <string name="member_op_sync_failed">Synchronisierung mit %1$d von %2$d fehlgeschlagenen Mitgliedern beendet.</string>
+    <string name="member_op_error">Anwenden fehlgeschlagen: %1$s</string>
+    <string name="member_op_dismiss">Schließen</string>
+    <string name="member_op_last_sync">Letzte Konfigurationsänderung synchronisiert %1$s</string>
+    <string name="member_op_busy">Eine andere Aktion läuft noch. Warte, bis sie abgeschlossen ist, und versuche es erneut.</string>
+    <string name="member_op_forbidden">Dieses Gerät ist als Monitor gekoppelt und kann die Flotte nicht ändern. Koppele es in Front Desk mit einem Operator-Code neu, um zu entleeren, zu aktivieren oder zu synchronisieren.</string>
+
+    <!-- Pause/resume auto-sync (dashboard operator control) -->
+    <string name="autosync_title">Auto-Sync</string>
+    <string name="autosync_on">Die Flotte bleibt mit dem Primärknoten synchron.</string>
+    <string name="autosync_off">Die Flotte synchronisiert erst wieder, wenn du fortsetzt.</string>
+    <string name="autosync_pausing">Wird pausiert…</string>
+    <string name="autosync_resuming">Wird fortgesetzt…</string>
+    <string name="autosync_busy">Eine andere Aktion läuft noch. Warte, bis sie abgeschlossen ist, und versuche es erneut.</string>
+    <string name="autosync_error">Anwenden fehlgeschlagen: %1$s</string>
+    <string name="autosync_forbidden">Dieses Gerät ist als Monitor gekoppelt und kann Auto-Sync nicht ändern. Koppele es in Front Desk mit einem Operator-Code neu.</string>
+
+    <!-- Events -->
+    <string name="events_title">Ereignisse</string>
+    <string name="events_open">Ereignisse</string>
+    <string name="events_back">Zurück</string>
+    <string name="events_empty">Keine passenden Ereignisse.</string>
+    <string name="events_copied">Ereignis in die Zwischenablage kopiert</string>
+    <string name="dashboard_member_copied">Mitglied in die Zwischenablage kopiert</string>
+    <string name="scroll_to_top">Nach oben scrollen</string>
+    <plurals name="events_total">
+        <item quantity="one">%1$d Ereignis</item>
+        <item quantity="other">%1$d Ereignisse</item>
+    </plurals>
+    <string name="events_sev_all">Alle</string>
+    <string name="events_sev_info">Info</string>
+    <string name="events_sev_success">Erfolg</string>
+    <string name="events_sev_warning">Warnung</string>
+    <string name="events_sev_error">Fehler</string>
+    <string name="events_range_all">Gesamter Zeitraum</string>
+    <string name="events_range_1h">1 Std</string>
+    <string name="events_range_24h">24 Std</string>
+    <string name="events_range_7d">7 T</string>
+    <string name="events_range_30d">30 T</string>
+    <string name="events_range_calendar">Datumsbereich wählen</string>
+    <string name="events_range_clear">Datumsbereich löschen</string>
+    <string name="events_range_apply">Anwenden</string>
+
+    <!-- Alerts -->
+    <string name="alerts_title">Warnungen</string>
+    <string name="alerts_open">Warnungen</string>
+    <string name="alerts_back">Zurück</string>
+    <string name="alerts_delivery_title">Benachrichtigungszustellung</string>
+    <string name="alerts_status_not_configured">Nicht konfiguriert</string>
+    <string name="alerts_status_unreachable">Notifier nicht erreichbar</string>
+    <string name="alerts_status_unhealthy">Notifier fehlerhaft</string>
+    <string name="alerts_status_delivering">Wird zugestellt</string>
+    <string name="alerts_catalog_title">Worüber Front Desk warnt</string>
+    <string name="alerts_catalog_note">Lege den Schalter um, um eine Warnung zu aktivieren oder stummzuschalten. Änderungen werden sofort auf Front Desk angewendet.</string>
+    <string name="alerts_flip_forbidden">Dieses Gerät ist als Monitor gekoppelt und kann Warnungen nicht ändern. Koppele es in Front Desk mit einem Operator-Code neu.</string>
+    <string name="alerts_flip_failed">Warnung konnte nicht geändert werden: %1$s</string>
+    <string name="alerts_event_health_down">Mitglied ausgefallen</string>
+    <string name="alerts_event_health_up">Mitglied wiederhergestellt</string>
+    <string name="alerts_event_config_sync_failed">Konfigurationssynchronisierung fehlgeschlagen</string>
+    <string name="alerts_event_config_synced">Konfiguration synchronisiert</string>
+    <string name="alerts_event_config_auto_synced">Konfiguration automatisch synchronisiert</string>
+    <string name="alerts_event_version_fetch_failed">Versionsabruf fehlgeschlagen</string>
+    <string name="alerts_event_version_fetch_recovered">Versionsabruf wiederhergestellt</string>
+    <string name="alerts_event_traefik_stale">Traefik-Konfiguration veraltet</string>
+    <string name="alerts_event_member_added">Mitglied hinzugefügt</string>
+    <string name="alerts_event_member_removed">Mitglied entfernt</string>
+    <string name="alerts_event_member_state_changed">Mitglied stillgelegt oder aktiviert</string>
+
+    <!-- App lock -->
+    <string name="lock_title">Bellhop ist gesperrt</string>
+    <string name="lock_subtitle">Entsperren, um die Flotte zu sehen.</string>
+    <string name="lock_unlock">Entsperren</string>
+    <string name="lock_prompt_title">Bellhop entsperren</string>
+    <string name="lock_prompt_subtitle">Bestätige, dass du es bist, um die Flotte zu sehen.</string>
+    <string name="operator_prompt_title">Operator-Aktion bestätigen</string>
+    <string name="operator_prompt_subtitle">Bestätige, dass du es bist, bevor du die Flotte änderst.</string>
+
+    <!-- Settings -->
+    <string name="settings_open">Einstellungen</string>
+    <string name="settings_title">Einstellungen</string>
+    <string name="settings_back">Zurück</string>
+    <string name="settings_language">Sprache</string>
+    <string name="language_system_default">Systemstandard</string>
+    <string name="settings_fd_title">Verknüpftes Front Desk</string>
+    <string name="settings_fd_linked_on">Verknüpft am %1$s</string>
+    <string name="settings_fd_copy_title">Adresse kopieren?</string>
+    <string name="settings_fd_copy_body">%1$s in die Zwischenablage kopieren?</string>
+    <string name="settings_fd_copied">Adresse in die Zwischenablage kopiert</string>
+    <string name="common_copy">Kopieren</string>
+    <string name="settings_hold_copy_title">Zum Kopieren halten</string>
+    <string name="settings_hold_copy_subtitle">Wenn aktiviert, kopiert ein langer Druck auf ein Ereignis oder eine Mitgliedszelle diese in die Zwischenablage. Wenn deaktiviert, können Zellen nicht kopiert werden.</string>
+    <string name="settings_lock_title">App-Sperre</string>
+    <string name="settings_lock_subtitle">Fingerabdruck oder Geräte-PIN erforderlich, um Bellhop zu öffnen.</string>
+    <string name="settings_lock_unavailable">Richte auf diesem Gerät einen Fingerabdruck oder eine Bildschirmsperre ein, um die App-Sperre zu aktivieren.</string>
+    <string name="settings_lock_window">Sperren nach Inaktivität</string>
+    <string name="settings_lock_now">Sofort</string>
+    <string name="settings_lock_1m">1 Min</string>
+    <string name="settings_lock_5m">5 Min</string>
+    <string name="settings_lock_15m">15 Min</string>
+    <string name="settings_lock_30m">30 Min</string>
+    <string name="settings_lock_1h">1 Std</string>
+    <string name="settings_alerts_title">Warnungen</string>
+    <string name="settings_alerts_subtitle">Benachrichtigungszustellung und worüber Front Desk warnt.</string>
+    <!-- Accessibility label for a severity count badge on the Alerts pill, e.g. "2 error enabled". -->
+    <string name="settings_alerts_badge_desc">%1$d %2$s aktiviert</string>
+    <string name="settings_monitor_title">Hintergrundüberwachung</string>
+    <string name="settings_monitor_subtitle">Prüft die Flotte alle 15 Minuten und benachrichtigt dich hier, wenn ein Mitglied ausfällt oder sich erholt, selbst wenn Bellhop geschlossen ist.</string>
+    <string name="settings_monitor_note">Die eigenen Warnungen von Front Desk sind schneller; dies ist eine Absicherung, wenn Bellhop deine einzige Ansicht ist. Es prüft etwa alle 15 Minuten, eine Änderung kann also bis zu so lange verzögert sein.</string>
+    <string name="settings_monitor_blocked">Benachrichtigungen für Bellhop sind ausgeschaltet, daher erreichen dich diese Warnungen nicht. Schalte sie in den Systemeinstellungen ein.</string>
+    <string name="settings_push_title">Echtzeit-Push</string>
+    <string name="settings_push_subtitle">Weckt Bellhop in dem Moment, in dem Front Desk eine Warnung sendet, über UnifiedPush und ntfy. Kein Google, keine Abrufverzögerung, optional.</string>
+    <string name="settings_push_no_distributor">Installiere einen UnifiedPush-Distributor wie ntfy, um Pushes zu empfangen. Ohne einen bleibt dies inaktiv, bis du einen hinzufügst.</string>
+    <string name="settings_push_endpoint_label">Push-Thema für Front Desk</string>
+    <string name="settings_push_endpoint_waiting">Warten, bis der Distributor ein Push-Thema zurückgibt…</string>
+    <string name="settings_push_endpoint_note">Füge dies in Front Desk → Einstellungen → Warnungen als Telefon-Thema ein, damit dessen Warnungen Bellhop wecken.</string>
+    <string name="settings_push_copy">Push-Thema kopieren</string>
+    <string name="settings_push_copied">Push-Thema kopiert</string>
+    <string name="settings_push_blocked">Benachrichtigungen für Bellhop sind aus, daher können Pushes dich nicht erreichen. Schalte sie in den Systemeinstellungen ein.</string>
+
+    <!-- Background-monitoring notifications (Layer 2 backstop) -->
+    <string name="notif_channel_down">Mitglied ausgefallen</string>
+    <string name="notif_channel_up">Mitglied wiederhergestellt</string>
+    <string name="notif_down_title">%1$s ist ausgefallen</string>
+    <string name="notif_down_body">Ein Mitglied antwortet nicht mehr. Tippe, um Bellhop zu öffnen.</string>
+    <string name="notif_up_title">%1$s wiederhergestellt</string>
+    <string name="notif_up_body">Ein Mitglied antwortet wieder.</string>
+    <string name="notif_channel_stale">Konfigurationsabweichung</string>
+    <string name="notif_stale_title">Flotte weicht möglicherweise ab</string>
+    <string name="notif_stale_body">Auto-Sync ist aus und die Flotte hat sich seit über einem Tag nicht synchronisiert. Tippe, um Bellhop zu öffnen.</string>
+    <string name="notif_stale_resumed_title">Auto-Sync fortgesetzt</string>
+    <string name="notif_stale_resumed_body">Die Flotte wird wieder synchron gehalten.</string>
+
+    <string name="dashboard_footer">Bellhop %1$s</string>
+    <string name="dashboard_unlink">Verknüpfung aufheben</string>
+    <string name="dashboard_unlink_confirm_title">Verknüpfung dieses Geräts aufheben?</string>
+    <string name="dashboard_unlink_confirm_body">Dieses Gerät hört auf, %1$s zu überwachen, und sein Token wird widerrufen. Du kannst jederzeit mit einem neuen Code erneut koppeln.</string>
+    <string name="dashboard_unlink_failed_title">Front Desk nicht erreichbar</string>
+    <string name="dashboard_unlink_failed_body">Dieses Gerät ist noch verknüpft und nichts wurde widerrufen. Prüfe deine Verbindung und versuche es erneut. Du kannst die Verknüpfung hier trotzdem aufheben, aber Front Desk listet dieses Gerät möglicherweise weiterhin auf; widerrufe es daher unter Front Desk → Einstellungen → Gekoppelte Geräte.</string>
+    <string name="dashboard_unlink_retry">Erneut versuchen</string>
+    <string name="dashboard_unlink_force">Trotzdem Verknüpfung aufheben</string>
+    <string name="common_cancel">Abbrechen</string>
+</resources>

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -195,4 +195,17 @@
     <string name="dashboard_unlink_retry">Erneut versuchen</string>
     <string name="dashboard_unlink_force">Trotzdem Verknüpfung aufheben</string>
     <string name="common_cancel">Abbrechen</string>
+    <string name="time_just_now">gerade eben</string>
+    <plurals name="time_min_ago">
+        <item quantity="one">vor %d Min.</item>
+        <item quantity="other">vor %d Min.</item>
+    </plurals>
+    <plurals name="time_hr_ago">
+        <item quantity="one">vor %d Std.</item>
+        <item quantity="other">vor %d Std.</item>
+    </plurals>
+    <plurals name="time_day_ago">
+        <item quantity="one">vor %d Tag</item>
+        <item quantity="other">vor %d Tagen</item>
+    </plurals>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -195,4 +195,17 @@
     <string name="dashboard_unlink_retry">Reintentar</string>
     <string name="dashboard_unlink_force">Desvincular de todos modos</string>
     <string name="common_cancel">Cancelar</string>
+    <string name="time_just_now">justo ahora</string>
+    <plurals name="time_min_ago">
+        <item quantity="one">hace %d min</item>
+        <item quantity="other">hace %d min</item>
+    </plurals>
+    <plurals name="time_hr_ago">
+        <item quantity="one">hace %d h</item>
+        <item quantity="other">hace %d h</item>
+    </plurals>
+    <plurals name="time_day_ago">
+        <item quantity="one">hace %d día</item>
+        <item quantity="other">hace %d días</item>
+    </plurals>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1,0 +1,198 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- Pairing (unlinked state) -->
+    <string name="pairing_title">Vincular un Front Desk</string>
+    <string name="pairing_subtitle">En Front Desk, abre Configuración → Dispositivos vinculados y genera un código. Escanea el QR que muestra, o copia la cadena de vinculación que aparece al lado y pégala abajo.</string>
+    <string name="pairing_scan">Escanear código QR</string>
+    <string name="pairing_scan_prompt">Apunta al QR de vinculación en Front Desk\n→ Configuración → Dispositivos vinculados</string>
+    <string name="pairing_or">o pégala</string>
+    <string name="pairing_paste_label">Cadena de vinculación</string>
+    <string name="pairing_paste_hint">Pega aquí la cadena de vinculación copiada</string>
+    <string name="pairing_target">Front Desk: %1$s\n%2$s</string>
+    <string name="pairing_label_label">Nombre de este dispositivo</string>
+    <string name="pairing_submit">Vincular</string>
+    <string name="pairing_error_bad_string">Eso no parece una cadena de vinculación. Cópiala de nuevo desde Front Desk → Configuración → Dispositivos vinculados.</string>
+    <string name="pairing_error_invalid_code">Código de vinculación no válido o caducado. Genera uno nuevo en Front Desk y pega la cadena actualizada.</string>
+    <string name="pairing_error_scan_unavailable">No se pudo abrir la cámara, por lo que el escaneo no está disponible. Concede acceso a la cámara o pega la cadena de vinculación abajo.</string>
+
+    <!-- Dashboard (linked state) -->
+    <string name="dashboard_linked_as">Vinculado como %1$s (%2$s)</string>
+    <string name="dashboard_summary_all_up">Todos los miembros activos</string>
+    <string name="dashboard_summary_down">%1$d de %2$d miembros caídos</string>
+    <string name="dashboard_summary_checking">Comprobando miembros…</string>
+    <string name="dashboard_empty">Aún no hay miembros. Añádelos en Front Desk.</string>
+    <string name="dashboard_refresh_failed">No se pudo actualizar: %1$s</string>
+    <string name="dashboard_revoked">Este dispositivo ya no puede autenticarse en Front Desk. Es posible que se haya revocado su acceso; desvincula y vuelve a vincular con un código nuevo.</string>
+    <string name="member_health_up">Activo · %1$d ms</string>
+    <string name="member_health_down">Caído</string>
+    <string name="member_health_unknown">Aún sin comprobar</string>
+    <string name="member_traefik">Traefik %1$s</string>
+    <string name="member_state_drained">Drenado</string>
+    <string name="member_primary">Primario</string>
+    <!-- Member detail -->
+    <string name="member_detail_back">Atrás</string>
+    <string name="member_detail_traffic_title">Tráfico · últimos %1$d min</string>
+    <string name="member_detail_traffic_totals">%1$d solicitudes · %2$d errores</string>
+    <string name="member_detail_traffic_unreachable">El tráfico no está disponible. Puede que Front Desk no tenga un token de administrador para este miembro, o que el miembro no respondiera.</string>
+    <string name="member_detail_traffic_empty">Sin solicitudes en este intervalo.</string>
+    <string name="member_detail_events_title">Eventos recientes</string>
+    <string name="member_detail_no_events">No hay eventos recientes para este miembro.</string>
+    <string name="member_detail_label_address">Dirección</string>
+    <string name="member_detail_label_synced">Sincronizado</string>
+    <string name="member_detail_label_reason">Motivo</string>
+    <string name="member_detail_label_verified">Verificado</string>
+    <string name="member_detail_label_added">Añadido</string>
+    <string name="member_url_title">Abrir dirección del miembro</string>
+    <string name="member_url_open">Abrir</string>
+    <string name="open_url_title">Abrir enlace</string>
+    <!-- Operator actions -->
+    <string name="member_op_title">Controles de operador</string>
+    <string name="member_op_drain">Drenar</string>
+    <string name="member_op_activate">Activar</string>
+    <string name="member_op_draining">Drenando… esperando a que la flota se ponga al día.</string>
+    <string name="member_op_activating">Activando… esperando a que la flota se ponga al día.</string>
+    <string name="member_op_sync">Sincronizar configuración de la flota</string>
+    <string name="member_op_synced">Se sincronizaron %1$d miembros desde el primario.</string>
+    <string name="member_op_sync_failed">La sincronización terminó con %1$d de %2$d miembros fallidos.</string>
+    <string name="member_op_error">No se pudo aplicar: %1$s</string>
+    <string name="member_op_dismiss">Descartar</string>
+    <string name="member_op_last_sync">Último cambio de configuración sincronizado %1$s</string>
+    <string name="member_op_busy">Otra acción sigue en curso. Espera a que termine e inténtalo de nuevo.</string>
+    <string name="member_op_forbidden">Este dispositivo está vinculado como monitor y no puede cambiar la flota. Vuelve a vincularlo con un código de operador en Front Desk para drenar, activar o sincronizar.</string>
+
+    <!-- Pause/resume auto-sync (dashboard operator control) -->
+    <string name="autosync_title">Sincronización automática</string>
+    <string name="autosync_on">La flota se mantiene sincronizada con el primario.</string>
+    <string name="autosync_off">La flota no se sincronizará hasta que la reanudes.</string>
+    <string name="autosync_pausing">Pausando…</string>
+    <string name="autosync_resuming">Reanudando…</string>
+    <string name="autosync_busy">Otra acción sigue en curso. Espera a que termine e inténtalo de nuevo.</string>
+    <string name="autosync_error">No se pudo aplicar: %1$s</string>
+    <string name="autosync_forbidden">Este dispositivo está vinculado como monitor y no puede cambiar la sincronización automática. Vuelve a vincularlo con un código de operador en Front Desk.</string>
+
+    <!-- Events -->
+    <string name="events_title">Eventos</string>
+    <string name="events_open">Eventos</string>
+    <string name="events_back">Atrás</string>
+    <string name="events_empty">Ningún evento coincide.</string>
+    <string name="events_copied">Evento copiado al portapapeles</string>
+    <string name="dashboard_member_copied">Miembro copiado al portapapeles</string>
+    <string name="scroll_to_top">Desplazar arriba</string>
+    <plurals name="events_total">
+        <item quantity="one">%1$d evento</item>
+        <item quantity="other">%1$d eventos</item>
+    </plurals>
+    <string name="events_sev_all">Todos</string>
+    <string name="events_sev_info">Información</string>
+    <string name="events_sev_success">Éxito</string>
+    <string name="events_sev_warning">Advertencia</string>
+    <string name="events_sev_error">Error</string>
+    <string name="events_range_all">Todo el tiempo</string>
+    <string name="events_range_1h">1 h</string>
+    <string name="events_range_24h">24 h</string>
+    <string name="events_range_7d">7 d</string>
+    <string name="events_range_30d">30 d</string>
+    <string name="events_range_calendar">Elegir un intervalo de fechas</string>
+    <string name="events_range_clear">Borrar el intervalo de fechas</string>
+    <string name="events_range_apply">Aplicar</string>
+
+    <!-- Alerts -->
+    <string name="alerts_title">Alertas</string>
+    <string name="alerts_open">Alertas</string>
+    <string name="alerts_back">Atrás</string>
+    <string name="alerts_delivery_title">Entrega de notificaciones</string>
+    <string name="alerts_status_not_configured">Sin configurar</string>
+    <string name="alerts_status_unreachable">Notificador inaccesible</string>
+    <string name="alerts_status_unhealthy">Notificador con problemas</string>
+    <string name="alerts_status_delivering">Entregando</string>
+    <string name="alerts_catalog_title">Sobre qué alerta Front Desk</string>
+    <string name="alerts_catalog_note">Cambia el interruptor para activar o silenciar una alerta. Los cambios se aplican a Front Desk de inmediato.</string>
+    <string name="alerts_flip_forbidden">Este dispositivo está vinculado como monitor y no puede cambiar las alertas. Vuelve a vincularlo con un código de operador en Front Desk.</string>
+    <string name="alerts_flip_failed">No se pudo cambiar esa alerta: %1$s</string>
+    <string name="alerts_event_health_down">Miembro caído</string>
+    <string name="alerts_event_health_up">Miembro recuperado</string>
+    <string name="alerts_event_config_sync_failed">Fallo al sincronizar la configuración</string>
+    <string name="alerts_event_config_synced">Configuración sincronizada</string>
+    <string name="alerts_event_config_auto_synced">Configuración sincronizada automáticamente</string>
+    <string name="alerts_event_version_fetch_failed">Fallo al leer la versión</string>
+    <string name="alerts_event_version_fetch_recovered">Lectura de versión recuperada</string>
+    <string name="alerts_event_traefik_stale">Configuración de Traefik obsoleta</string>
+    <string name="alerts_event_member_added">Miembro añadido</string>
+    <string name="alerts_event_member_removed">Miembro eliminado</string>
+    <string name="alerts_event_member_state_changed">Miembro drenado o activado</string>
+
+    <!-- App lock -->
+    <string name="lock_title">Bellhop está bloqueado</string>
+    <string name="lock_subtitle">Desbloquea para ver la flota.</string>
+    <string name="lock_unlock">Desbloquear</string>
+    <string name="lock_prompt_title">Desbloquear Bellhop</string>
+    <string name="lock_prompt_subtitle">Confirma que eres tú para ver la flota.</string>
+    <string name="operator_prompt_title">Confirmar acción de operador</string>
+    <string name="operator_prompt_subtitle">Confirma que eres tú antes de cambiar la flota.</string>
+
+    <!-- Settings -->
+    <string name="settings_open">Configuración</string>
+    <string name="settings_title">Configuración</string>
+    <string name="settings_back">Atrás</string>
+    <string name="settings_language">Idioma</string>
+    <string name="language_system_default">Predeterminado del sistema</string>
+    <string name="settings_fd_title">Front Desk vinculado</string>
+    <string name="settings_fd_linked_on">Vinculado el %1$s</string>
+    <string name="settings_fd_copy_title">¿Copiar dirección?</string>
+    <string name="settings_fd_copy_body">¿Copiar %1$s al portapapeles?</string>
+    <string name="settings_fd_copied">Dirección copiada al portapapeles</string>
+    <string name="common_copy">Copiar</string>
+    <string name="settings_hold_copy_title">Mantener para copiar</string>
+    <string name="settings_hold_copy_subtitle">Cuando está activado, mantén pulsada una celda de evento o de miembro para copiarla al portapapeles. Cuando está desactivado, las celdas no se pueden copiar.</string>
+    <string name="settings_lock_title">Bloqueo de la app</string>
+    <string name="settings_lock_subtitle">Requiere una huella o el PIN del dispositivo para abrir Bellhop.</string>
+    <string name="settings_lock_unavailable">Configura una huella o un bloqueo de pantalla en este dispositivo para activar el bloqueo de la app.</string>
+    <string name="settings_lock_window">Bloquear tras inactividad</string>
+    <string name="settings_lock_now">Ahora</string>
+    <string name="settings_lock_1m">1 min</string>
+    <string name="settings_lock_5m">5 min</string>
+    <string name="settings_lock_15m">15 min</string>
+    <string name="settings_lock_30m">30 min</string>
+    <string name="settings_lock_1h">1 h</string>
+    <string name="settings_alerts_title">Alertas</string>
+    <string name="settings_alerts_subtitle">Entrega de notificaciones y sobre qué alerta Front Desk.</string>
+    <!-- Accessibility label for a severity count badge on the Alerts pill, e.g. "2 error enabled". -->
+    <string name="settings_alerts_badge_desc">%1$d %2$s activadas</string>
+    <string name="settings_monitor_title">Supervisión en segundo plano</string>
+    <string name="settings_monitor_subtitle">Comprueba la flota cada 15 minutos y te avisa aquí cuando un miembro se cae o se recupera, incluso con Bellhop cerrado.</string>
+    <string name="settings_monitor_note">Las propias alertas de Front Desk son más rápidas; esto es un respaldo para cuando Bellhop es tu única vista. Comprueba aproximadamente cada 15 minutos, así que un cambio puede tardar hasta ese tiempo.</string>
+    <string name="settings_monitor_blocked">Las notificaciones de Bellhop están desactivadas, así que estas alertas no te llegarán. Actívalas en los ajustes del sistema.</string>
+    <string name="settings_push_title">Push en tiempo real</string>
+    <string name="settings_push_subtitle">Despierta Bellhop en el instante en que Front Desk envía una alerta, mediante UnifiedPush y ntfy. Sin Google, sin retardo de sondeo, opcional.</string>
+    <string name="settings_push_no_distributor">Instala un distribuidor de UnifiedPush como ntfy para recibir pushes. Sin uno, esto permanece inactivo hasta que añadas uno.</string>
+    <string name="settings_push_endpoint_label">Tema de push para Front Desk</string>
+    <string name="settings_push_endpoint_waiting">Esperando a que el distribuidor devuelva un tema de push…</string>
+    <string name="settings_push_endpoint_note">Pega esto en Front Desk → Configuración → Alertas como el tema del teléfono, para que sus alertas despierten Bellhop.</string>
+    <string name="settings_push_copy">Copiar tema de push</string>
+    <string name="settings_push_copied">Tema de push copiado</string>
+    <string name="settings_push_blocked">Las notificaciones de Bellhop están desactivadas, así que los pushes no pueden llegarte. Actívalas en los ajustes del sistema.</string>
+
+    <!-- Background-monitoring notifications (Layer 2 backstop) -->
+    <string name="notif_channel_down">Miembro caído</string>
+    <string name="notif_channel_up">Miembro recuperado</string>
+    <string name="notif_down_title">%1$s está caído</string>
+    <string name="notif_down_body">Un miembro dejó de responder. Toca para abrir Bellhop.</string>
+    <string name="notif_up_title">%1$s recuperado</string>
+    <string name="notif_up_body">Un miembro vuelve a responder.</string>
+    <string name="notif_channel_stale">Desviación de configuración</string>
+    <string name="notif_stale_title">La flota puede estar desviándose</string>
+    <string name="notif_stale_body">La sincronización automática está desactivada y la flota no se ha sincronizado en más de un día. Toca para abrir Bellhop.</string>
+    <string name="notif_stale_resumed_title">Sincronización automática reanudada</string>
+    <string name="notif_stale_resumed_body">La flota se mantiene sincronizada de nuevo.</string>
+
+    <string name="dashboard_footer">Bellhop %1$s</string>
+    <string name="dashboard_unlink">Desvincular</string>
+    <string name="dashboard_unlink_confirm_title">¿Desvincular este dispositivo?</string>
+    <string name="dashboard_unlink_confirm_body">Este dispositivo dejará de supervisar %1$s y su token será revocado. Puedes volver a vincular en cualquier momento con un código nuevo.</string>
+    <string name="dashboard_unlink_failed_title">No se pudo contactar con Front Desk</string>
+    <string name="dashboard_unlink_failed_body">Este dispositivo sigue vinculado y no se revocó nada. Comprueba tu conexión e inténtalo de nuevo. Puedes desvincular aquí de todos modos, pero Front Desk podría seguir listando este dispositivo, así que revócalo desde Front Desk → Configuración → Dispositivos vinculados.</string>
+    <string name="dashboard_unlink_retry">Reintentar</string>
+    <string name="dashboard_unlink_force">Desvincular de todos modos</string>
+    <string name="common_cancel">Cancelar</string>
+</resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -195,4 +195,17 @@
     <string name="dashboard_unlink_retry">Réessayer</string>
     <string name="dashboard_unlink_force">Dissocier quand même</string>
     <string name="common_cancel">Annuler</string>
+    <string name="time_just_now">il y a un instant</string>
+    <plurals name="time_min_ago">
+        <item quantity="one">il y a %d min</item>
+        <item quantity="other">il y a %d min</item>
+    </plurals>
+    <plurals name="time_hr_ago">
+        <item quantity="one">il y a %d h</item>
+        <item quantity="other">il y a %d h</item>
+    </plurals>
+    <plurals name="time_day_ago">
+        <item quantity="one">il y a %d jour</item>
+        <item quantity="other">il y a %d jours</item>
+    </plurals>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1,0 +1,198 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- Pairing (unlinked state) -->
+    <string name="pairing_title">Associer un Front Desk</string>
+    <string name="pairing_subtitle">Dans Front Desk, ouvrez Paramètres → Appareils associés et générez un code. Scannez le QR affiché, ou copiez la chaîne d\'association à côté et collez-la ci-dessous.</string>
+    <string name="pairing_scan">Scanner le code QR</string>
+    <string name="pairing_scan_prompt">Visez le QR d\'association dans Front Desk\n→ Paramètres → Appareils associés</string>
+    <string name="pairing_or">ou collez-la</string>
+    <string name="pairing_paste_label">Chaîne d\'association</string>
+    <string name="pairing_paste_hint">Collez ici la chaîne d\'association copiée</string>
+    <string name="pairing_target">Front Desk : %1$s\n%2$s</string>
+    <string name="pairing_label_label">Nom de cet appareil</string>
+    <string name="pairing_submit">Associer</string>
+    <string name="pairing_error_bad_string">Cela ne ressemble pas à une chaîne d\'association. Copiez-la à nouveau depuis Front Desk → Paramètres → Appareils associés.</string>
+    <string name="pairing_error_invalid_code">Code d\'association non valide ou expiré. Générez-en un nouveau dans Front Desk et collez la chaîne actualisée.</string>
+    <string name="pairing_error_scan_unavailable">La caméra n\'a pas pu être ouverte, le scan est donc indisponible. Accordez l\'accès à la caméra, ou collez plutôt la chaîne d\'association ci-dessous.</string>
+
+    <!-- Dashboard (linked state) -->
+    <string name="dashboard_linked_as">Associé en tant que %1$s (%2$s)</string>
+    <string name="dashboard_summary_all_up">Tous les membres actifs</string>
+    <string name="dashboard_summary_down">%1$d membres sur %2$d hors service</string>
+    <string name="dashboard_summary_checking">Vérification des membres…</string>
+    <string name="dashboard_empty">Aucun membre pour l\'instant. Ajoutez-les dans Front Desk.</string>
+    <string name="dashboard_refresh_failed">Échec de l\'actualisation : %1$s</string>
+    <string name="dashboard_revoked">Cet appareil ne peut plus s\'authentifier auprès de Front Desk. Son accès a peut-être été révoqué ; dissociez-le et associez-le à nouveau avec un nouveau code.</string>
+    <string name="member_health_up">Actif · %1$d ms</string>
+    <string name="member_health_down">Hors service</string>
+    <string name="member_health_unknown">Pas encore vérifié</string>
+    <string name="member_traefik">Traefik %1$s</string>
+    <string name="member_state_drained">Drainé</string>
+    <string name="member_primary">Primaire</string>
+    <!-- Member detail -->
+    <string name="member_detail_back">Retour</string>
+    <string name="member_detail_traffic_title">Trafic · %1$d dernières min</string>
+    <string name="member_detail_traffic_totals">%1$d requêtes · %2$d erreurs</string>
+    <string name="member_detail_traffic_unreachable">Le trafic n\'est pas disponible. Front Desk ne possède peut-être aucun jeton admin pour ce membre, ou le membre n\'a pas répondu.</string>
+    <string name="member_detail_traffic_empty">Aucune requête sur cette période.</string>
+    <string name="member_detail_events_title">Événements récents</string>
+    <string name="member_detail_no_events">Aucun événement récent pour ce membre.</string>
+    <string name="member_detail_label_address">Adresse</string>
+    <string name="member_detail_label_synced">Synchronisé</string>
+    <string name="member_detail_label_reason">Raison</string>
+    <string name="member_detail_label_verified">Vérifié</string>
+    <string name="member_detail_label_added">Ajouté</string>
+    <string name="member_url_title">Ouvrir l\'adresse du membre</string>
+    <string name="member_url_open">Ouvrir</string>
+    <string name="open_url_title">Ouvrir le lien</string>
+    <!-- Operator actions -->
+    <string name="member_op_title">Commandes opérateur</string>
+    <string name="member_op_drain">Drainer</string>
+    <string name="member_op_activate">Activer</string>
+    <string name="member_op_draining">Drainage… en attente que la flotte se mette à jour.</string>
+    <string name="member_op_activating">Activation… en attente que la flotte se mette à jour.</string>
+    <string name="member_op_sync">Synchroniser la config de la flotte</string>
+    <string name="member_op_synced">%1$d membres synchronisés depuis le primaire.</string>
+    <string name="member_op_sync_failed">Synchronisation terminée avec %1$d membres sur %2$d en échec.</string>
+    <string name="member_op_error">Impossible d\'appliquer : %1$s</string>
+    <string name="member_op_dismiss">Ignorer</string>
+    <string name="member_op_last_sync">Dernier changement de config synchronisé %1$s</string>
+    <string name="member_op_busy">Une autre action est encore en cours. Attendez qu\'elle se termine, puis réessayez.</string>
+    <string name="member_op_forbidden">Cet appareil est associé en tant que moniteur et ne peut pas modifier la flotte. Réassociez-le avec un code opérateur dans Front Desk pour drainer, activer ou synchroniser.</string>
+
+    <!-- Pause/resume auto-sync (dashboard operator control) -->
+    <string name="autosync_title">Synchro auto</string>
+    <string name="autosync_on">La flotte reste synchronisée avec le primaire.</string>
+    <string name="autosync_off">La flotte ne se synchronisera pas tant que vous ne reprendrez pas.</string>
+    <string name="autosync_pausing">Mise en pause…</string>
+    <string name="autosync_resuming">Reprise…</string>
+    <string name="autosync_busy">Une autre action est encore en cours. Attendez qu\'elle se termine, puis réessayez.</string>
+    <string name="autosync_error">Impossible d\'appliquer : %1$s</string>
+    <string name="autosync_forbidden">Cet appareil est associé en tant que moniteur et ne peut pas modifier la synchro auto. Réassociez-le avec un code opérateur dans Front Desk.</string>
+
+    <!-- Events -->
+    <string name="events_title">Événements</string>
+    <string name="events_open">Événements</string>
+    <string name="events_back">Retour</string>
+    <string name="events_empty">Aucun événement ne correspond.</string>
+    <string name="events_copied">Événement copié dans le presse-papiers</string>
+    <string name="dashboard_member_copied">Membre copié dans le presse-papiers</string>
+    <string name="scroll_to_top">Défiler vers le haut</string>
+    <plurals name="events_total">
+        <item quantity="one">%1$d événement</item>
+        <item quantity="other">%1$d événements</item>
+    </plurals>
+    <string name="events_sev_all">Tous</string>
+    <string name="events_sev_info">Info</string>
+    <string name="events_sev_success">Succès</string>
+    <string name="events_sev_warning">Avertissement</string>
+    <string name="events_sev_error">Erreur</string>
+    <string name="events_range_all">Tout l\'historique</string>
+    <string name="events_range_1h">1 h</string>
+    <string name="events_range_24h">24 h</string>
+    <string name="events_range_7d">7 j</string>
+    <string name="events_range_30d">30 j</string>
+    <string name="events_range_calendar">Choisir une plage de dates</string>
+    <string name="events_range_clear">Effacer la plage de dates</string>
+    <string name="events_range_apply">Appliquer</string>
+
+    <!-- Alerts -->
+    <string name="alerts_title">Alertes</string>
+    <string name="alerts_open">Alertes</string>
+    <string name="alerts_back">Retour</string>
+    <string name="alerts_delivery_title">Distribution des notifications</string>
+    <string name="alerts_status_not_configured">Non configuré</string>
+    <string name="alerts_status_unreachable">Notificateur injoignable</string>
+    <string name="alerts_status_unhealthy">Notificateur en panne</string>
+    <string name="alerts_status_delivering">Distribution en cours</string>
+    <string name="alerts_catalog_title">Ce qui déclenche les alertes de Front Desk</string>
+    <string name="alerts_catalog_note">Basculez l\'interrupteur pour activer ou couper une alerte. Les changements s\'appliquent à Front Desk immédiatement.</string>
+    <string name="alerts_flip_forbidden">Cet appareil est associé en tant que moniteur et ne peut pas modifier les alertes. Réassociez-le avec un code opérateur dans Front Desk.</string>
+    <string name="alerts_flip_failed">Impossible de modifier cette alerte : %1$s</string>
+    <string name="alerts_event_health_down">Membre hors service</string>
+    <string name="alerts_event_health_up">Membre rétabli</string>
+    <string name="alerts_event_config_sync_failed">Échec de la synchro de config</string>
+    <string name="alerts_event_config_synced">Config synchronisée</string>
+    <string name="alerts_event_config_auto_synced">Config synchronisée automatiquement</string>
+    <string name="alerts_event_version_fetch_failed">Échec de lecture de la version</string>
+    <string name="alerts_event_version_fetch_recovered">Lecture de la version rétablie</string>
+    <string name="alerts_event_traefik_stale">Config Traefik obsolète</string>
+    <string name="alerts_event_member_added">Membre ajouté</string>
+    <string name="alerts_event_member_removed">Membre supprimé</string>
+    <string name="alerts_event_member_state_changed">Membre drainé ou activé</string>
+
+    <!-- App lock -->
+    <string name="lock_title">Bellhop est verrouillé</string>
+    <string name="lock_subtitle">Déverrouillez pour voir la flotte.</string>
+    <string name="lock_unlock">Déverrouiller</string>
+    <string name="lock_prompt_title">Déverrouiller Bellhop</string>
+    <string name="lock_prompt_subtitle">Confirmez que c\'est bien vous pour voir la flotte.</string>
+    <string name="operator_prompt_title">Confirmer l\'action opérateur</string>
+    <string name="operator_prompt_subtitle">Confirmez que c\'est bien vous avant de modifier la flotte.</string>
+
+    <!-- Settings -->
+    <string name="settings_open">Paramètres</string>
+    <string name="settings_title">Paramètres</string>
+    <string name="settings_back">Retour</string>
+    <string name="settings_language">Langue</string>
+    <string name="language_system_default">Par défaut du système</string>
+    <string name="settings_fd_title">Front Desk associé</string>
+    <string name="settings_fd_linked_on">Associé le %1$s</string>
+    <string name="settings_fd_copy_title">Copier l\'adresse ?</string>
+    <string name="settings_fd_copy_body">Copier %1$s dans le presse-papiers ?</string>
+    <string name="settings_fd_copied">Adresse copiée dans le presse-papiers</string>
+    <string name="common_copy">Copier</string>
+    <string name="settings_hold_copy_title">Maintenir pour copier</string>
+    <string name="settings_hold_copy_subtitle">Lorsque activé, appuyez longuement sur une cellule d\'événement ou de membre pour la copier dans le presse-papiers. Lorsque désactivé, les cellules ne peuvent pas être copiées.</string>
+    <string name="settings_lock_title">Verrouillage de l\'app</string>
+    <string name="settings_lock_subtitle">Exiger une empreinte ou le code de l\'appareil pour ouvrir Bellhop.</string>
+    <string name="settings_lock_unavailable">Configurez une empreinte ou un verrouillage d\'écran sur cet appareil pour activer le verrouillage de l\'app.</string>
+    <string name="settings_lock_window">Verrouiller après inactivité</string>
+    <string name="settings_lock_now">Maintenant</string>
+    <string name="settings_lock_1m">1 min</string>
+    <string name="settings_lock_5m">5 min</string>
+    <string name="settings_lock_15m">15 min</string>
+    <string name="settings_lock_30m">30 min</string>
+    <string name="settings_lock_1h">1 h</string>
+    <string name="settings_alerts_title">Alertes</string>
+    <string name="settings_alerts_subtitle">Distribution des notifications et ce qui déclenche les alertes de Front Desk.</string>
+    <!-- Accessibility label for a severity count badge on the Alerts pill, e.g. "2 error enabled". -->
+    <string name="settings_alerts_badge_desc">%1$d %2$s activées</string>
+    <string name="settings_monitor_title">Surveillance en arrière-plan</string>
+    <string name="settings_monitor_subtitle">Vérifie la flotte toutes les 15 minutes et vous prévient ici quand un membre tombe en panne ou se rétablit, même quand Bellhop est fermé.</string>
+    <string name="settings_monitor_note">Les alertes propres à Front Desk sont plus rapides ; ceci est un filet de sécurité quand Bellhop est votre seule vue. Il vérifie environ toutes les 15 minutes, un changement peut donc arriver avec ce délai.</string>
+    <string name="settings_monitor_blocked">Les notifications sont désactivées pour Bellhop, ces alertes ne vous parviendront donc pas. Activez-les dans les paramètres système.</string>
+    <string name="settings_push_title">Push en temps réel</string>
+    <string name="settings_push_subtitle">Réveille Bellhop à l\'instant où Front Desk envoie une alerte, via UnifiedPush et ntfy. Sans Google, sans délai de sondage, sur activation.</string>
+    <string name="settings_push_no_distributor">Installez un distributeur UnifiedPush tel que ntfy pour recevoir les pushs. Sans lui, ceci reste inactif jusqu\'à ce que vous en ajoutiez un.</string>
+    <string name="settings_push_endpoint_label">Sujet push pour Front Desk</string>
+    <string name="settings_push_endpoint_waiting">En attente que le distributeur renvoie un sujet push…</string>
+    <string name="settings_push_endpoint_note">Collez ceci dans Front Desk → Paramètres → Alertes comme sujet du téléphone, pour que ses alertes réveillent Bellhop.</string>
+    <string name="settings_push_copy">Copier le sujet push</string>
+    <string name="settings_push_copied">Sujet push copié</string>
+    <string name="settings_push_blocked">Les notifications sont désactivées pour Bellhop, les pushs ne peuvent donc pas vous parvenir. Activez-les dans les paramètres système.</string>
+
+    <!-- Background-monitoring notifications (Layer 2 backstop) -->
+    <string name="notif_channel_down">Membre hors service</string>
+    <string name="notif_channel_up">Membre rétabli</string>
+    <string name="notif_down_title">%1$s est hors service</string>
+    <string name="notif_down_body">Un membre a cessé de répondre. Touchez pour ouvrir Bellhop.</string>
+    <string name="notif_up_title">%1$s rétabli</string>
+    <string name="notif_up_body">Un membre répond à nouveau.</string>
+    <string name="notif_channel_stale">Dérive de configuration</string>
+    <string name="notif_stale_title">La flotte dérive peut-être</string>
+    <string name="notif_stale_body">La synchro auto est désactivée et la flotte ne s\'est pas synchronisée depuis plus d\'un jour. Touchez pour ouvrir Bellhop.</string>
+    <string name="notif_stale_resumed_title">Synchro auto reprise</string>
+    <string name="notif_stale_resumed_body">La flotte est de nouveau maintenue synchronisée.</string>
+
+    <string name="dashboard_footer">Bellhop %1$s</string>
+    <string name="dashboard_unlink">Dissocier</string>
+    <string name="dashboard_unlink_confirm_title">Dissocier cet appareil ?</string>
+    <string name="dashboard_unlink_confirm_body">Cet appareil cessera de surveiller %1$s et son jeton sera révoqué. Vous pouvez le réassocier à tout moment avec un nouveau code.</string>
+    <string name="dashboard_unlink_failed_title">Impossible de joindre Front Desk</string>
+    <string name="dashboard_unlink_failed_body">Cet appareil est toujours associé et rien n\'a été révoqué. Vérifiez votre connexion et réessayez. Vous pouvez le dissocier ici quand même, mais Front Desk peut encore lister cet appareil ; révoquez-le donc depuis Front Desk → Paramètres → Appareils associés.</string>
+    <string name="dashboard_unlink_retry">Réessayer</string>
+    <string name="dashboard_unlink_force">Dissocier quand même</string>
+    <string name="common_cancel">Annuler</string>
+</resources>

--- a/android/app/src/main/res/values-ja/strings.xml
+++ b/android/app/src/main/res/values-ja/strings.xml
@@ -194,4 +194,14 @@
     <string name="dashboard_unlink_retry">再試行</string>
     <string name="dashboard_unlink_force">それでもリンク解除</string>
     <string name="common_cancel">キャンセル</string>
+    <string name="time_just_now">たった今</string>
+    <plurals name="time_min_ago">
+        <item quantity="other">%d 分前</item>
+    </plurals>
+    <plurals name="time_hr_ago">
+        <item quantity="other">%d 時間前</item>
+    </plurals>
+    <plurals name="time_day_ago">
+        <item quantity="other">%d 日前</item>
+    </plurals>
 </resources>

--- a/android/app/src/main/res/values-ja/strings.xml
+++ b/android/app/src/main/res/values-ja/strings.xml
@@ -1,0 +1,197 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- Pairing (unlinked state) -->
+    <string name="pairing_title">Front Desk をリンク</string>
+    <string name="pairing_subtitle">Front Desk で 設定 → ペア設定済みデバイス を開いてコードを生成します。表示された QR コードをスキャンするか、横にあるペアリング文字列をコピーして下に貼り付けてください。</string>
+    <string name="pairing_scan">QR コードをスキャン</string>
+    <string name="pairing_scan_prompt">Front Desk のペアリング QR に向けてください\n→ 設定 → ペア設定済みデバイス</string>
+    <string name="pairing_or">または貼り付け</string>
+    <string name="pairing_paste_label">ペアリング文字列</string>
+    <string name="pairing_paste_hint">コピーしたペアリング文字列をここに貼り付け</string>
+    <string name="pairing_target">Front Desk: %1$s\n%2$s</string>
+    <string name="pairing_label_label">このデバイスの名前</string>
+    <string name="pairing_submit">ペア設定</string>
+    <string name="pairing_error_bad_string">ペアリング文字列ではないようです。Front Desk → 設定 → ペア設定済みデバイス からもう一度コピーしてください。</string>
+    <string name="pairing_error_invalid_code">無効または期限切れのペアリングコードです。Front Desk で新しいコードを生成し、新しい文字列を貼り付けてください。</string>
+    <string name="pairing_error_scan_unavailable">カメラを開けなかったため、スキャンを利用できません。カメラへのアクセスを許可するか、代わりに下にペアリング文字列を貼り付けてください。</string>
+
+    <!-- Dashboard (linked state) -->
+    <string name="dashboard_linked_as">%1$s (%2$s) としてリンク済み</string>
+    <string name="dashboard_summary_all_up">すべてのメンバーが稼働中</string>
+    <string name="dashboard_summary_down">%2$d 台中 %1$d 台のメンバーがダウン</string>
+    <string name="dashboard_summary_checking">メンバーを確認中…</string>
+    <string name="dashboard_empty">メンバーはまだありません。Front Desk で追加してください。</string>
+    <string name="dashboard_refresh_failed">更新に失敗しました: %1$s</string>
+    <string name="dashboard_revoked">このデバイスは Front Desk に認証できなくなりました。アクセスが取り消された可能性があります。リンクを解除し、新しいコードで再ペア設定してください。</string>
+    <string name="member_health_up">稼働中 · %1$d ms</string>
+    <string name="member_health_down">ダウン</string>
+    <string name="member_health_unknown">未確認</string>
+    <string name="member_traefik">Traefik %1$s</string>
+    <string name="member_state_drained">ドレイン済み</string>
+    <string name="member_primary">プライマリ</string>
+    <!-- Member detail -->
+    <string name="member_detail_back">戻る</string>
+    <string name="member_detail_traffic_title">トラフィック · 直近 %1$d 分</string>
+    <string name="member_detail_traffic_totals">%1$d リクエスト · %2$d エラー</string>
+    <string name="member_detail_traffic_unreachable">トラフィックを利用できません。Front Desk がこのメンバーの管理者トークンを持っていないか、メンバーが応答しなかった可能性があります。</string>
+    <string name="member_detail_traffic_empty">この期間にリクエストはありません。</string>
+    <string name="member_detail_events_title">最近のイベント</string>
+    <string name="member_detail_no_events">このメンバーの最近のイベントはありません。</string>
+    <string name="member_detail_label_address">アドレス</string>
+    <string name="member_detail_label_synced">同期済み</string>
+    <string name="member_detail_label_reason">理由</string>
+    <string name="member_detail_label_verified">検証済み</string>
+    <string name="member_detail_label_added">追加</string>
+    <string name="member_url_title">メンバーのアドレスを開く</string>
+    <string name="member_url_open">開く</string>
+    <string name="open_url_title">リンクを開く</string>
+    <!-- Operator actions -->
+    <string name="member_op_title">オペレーター操作</string>
+    <string name="member_op_drain">ドレイン</string>
+    <string name="member_op_activate">有効化</string>
+    <string name="member_op_draining">ドレイン中… フリートが追いつくのを待っています。</string>
+    <string name="member_op_activating">有効化中… フリートが追いつくのを待っています。</string>
+    <string name="member_op_sync">フリートの設定を同期</string>
+    <string name="member_op_synced">プライマリから %1$d 台のメンバーを同期しました。</string>
+    <string name="member_op_sync_failed">同期が完了しました。%2$d 台中 %1$d 台のメンバーが失敗しました。</string>
+    <string name="member_op_error">適用できませんでした: %1$s</string>
+    <string name="member_op_dismiss">閉じる</string>
+    <string name="member_op_last_sync">最後の設定変更を同期: %1$s</string>
+    <string name="member_op_busy">別の操作がまだ実行中です。完了するまで待ってから、もう一度お試しください。</string>
+    <string name="member_op_forbidden">このデバイスはモニターとしてペア設定されており、フリートを変更できません。ドレイン、有効化、同期を行うには、Front Desk でオペレーターコードを使って再ペア設定してください。</string>
+
+    <!-- Pause/resume auto-sync (dashboard operator control) -->
+    <string name="autosync_title">自動同期</string>
+    <string name="autosync_on">フリートはプライマリと同期を保ちます。</string>
+    <string name="autosync_off">再開するまでフリートは同期されません。</string>
+    <string name="autosync_pausing">一時停止中…</string>
+    <string name="autosync_resuming">再開中…</string>
+    <string name="autosync_busy">別の操作がまだ実行中です。完了するまで待ってから、もう一度お試しください。</string>
+    <string name="autosync_error">適用できませんでした: %1$s</string>
+    <string name="autosync_forbidden">このデバイスはモニターとしてペア設定されており、自動同期を変更できません。Front Desk でオペレーターコードを使って再ペア設定してください。</string>
+
+    <!-- Events -->
+    <string name="events_title">イベント</string>
+    <string name="events_open">イベント</string>
+    <string name="events_back">戻る</string>
+    <string name="events_empty">一致するイベントはありません。</string>
+    <string name="events_copied">イベントをクリップボードにコピーしました</string>
+    <string name="dashboard_member_copied">メンバーをクリップボードにコピーしました</string>
+    <string name="scroll_to_top">上にスクロール</string>
+    <plurals name="events_total">
+        <item quantity="other">%1$d 件のイベント</item>
+    </plurals>
+    <string name="events_sev_all">すべて</string>
+    <string name="events_sev_info">情報</string>
+    <string name="events_sev_success">成功</string>
+    <string name="events_sev_warning">警告</string>
+    <string name="events_sev_error">エラー</string>
+    <string name="events_range_all">全期間</string>
+    <string name="events_range_1h">1 時間</string>
+    <string name="events_range_24h">24 時間</string>
+    <string name="events_range_7d">7 日</string>
+    <string name="events_range_30d">30 日</string>
+    <string name="events_range_calendar">日付範囲を選択</string>
+    <string name="events_range_clear">日付範囲をクリア</string>
+    <string name="events_range_apply">適用</string>
+
+    <!-- Alerts -->
+    <string name="alerts_title">アラート</string>
+    <string name="alerts_open">アラート</string>
+    <string name="alerts_back">戻る</string>
+    <string name="alerts_delivery_title">通知の配信</string>
+    <string name="alerts_status_not_configured">未設定</string>
+    <string name="alerts_status_unreachable">通知先に到達不能</string>
+    <string name="alerts_status_unhealthy">通知先が異常</string>
+    <string name="alerts_status_delivering">配信中</string>
+    <string name="alerts_catalog_title">Front Desk がアラートする対象</string>
+    <string name="alerts_catalog_note">スイッチを切り替えてアラートを有効化またはミュートします。変更は Front Desk にすぐに適用されます。</string>
+    <string name="alerts_flip_forbidden">このデバイスはモニターとしてペア設定されており、アラートを変更できません。Front Desk でオペレーターコードを使って再ペア設定してください。</string>
+    <string name="alerts_flip_failed">そのアラートを変更できませんでした: %1$s</string>
+    <string name="alerts_event_health_down">メンバーがダウン</string>
+    <string name="alerts_event_health_up">メンバーが復旧</string>
+    <string name="alerts_event_config_sync_failed">設定の同期に失敗</string>
+    <string name="alerts_event_config_synced">設定を同期</string>
+    <string name="alerts_event_config_auto_synced">設定を自動同期</string>
+    <string name="alerts_event_version_fetch_failed">バージョン取得に失敗</string>
+    <string name="alerts_event_version_fetch_recovered">バージョン取得が復旧</string>
+    <string name="alerts_event_traefik_stale">Traefik 設定が古い</string>
+    <string name="alerts_event_member_added">メンバーを追加</string>
+    <string name="alerts_event_member_removed">メンバーを削除</string>
+    <string name="alerts_event_member_state_changed">メンバーをドレインまたは有効化</string>
+
+    <!-- App lock -->
+    <string name="lock_title">Bellhop はロックされています</string>
+    <string name="lock_subtitle">ロックを解除してフリートを表示します。</string>
+    <string name="lock_unlock">ロック解除</string>
+    <string name="lock_prompt_title">Bellhop のロックを解除</string>
+    <string name="lock_prompt_subtitle">フリートを表示するために本人確認をしてください。</string>
+    <string name="operator_prompt_title">オペレーター操作を確認</string>
+    <string name="operator_prompt_subtitle">フリートを変更する前に本人確認をしてください。</string>
+
+    <!-- Settings -->
+    <string name="settings_open">設定</string>
+    <string name="settings_title">設定</string>
+    <string name="settings_back">戻る</string>
+    <string name="settings_language">言語</string>
+    <string name="language_system_default">システムの既定</string>
+    <string name="settings_fd_title">リンク済みの Front Desk</string>
+    <string name="settings_fd_linked_on">%1$s にリンク</string>
+    <string name="settings_fd_copy_title">アドレスをコピーしますか？</string>
+    <string name="settings_fd_copy_body">%1$s をクリップボードにコピーしますか？</string>
+    <string name="settings_fd_copied">アドレスをクリップボードにコピーしました</string>
+    <string name="common_copy">コピー</string>
+    <string name="settings_hold_copy_title">長押しでコピー</string>
+    <string name="settings_hold_copy_subtitle">オンのとき、イベントまたはメンバーのセルを長押しするとクリップボードにコピーします。オフのとき、セルはコピーできません。</string>
+    <string name="settings_lock_title">アプリロック</string>
+    <string name="settings_lock_subtitle">Bellhop を開くのに指紋またはデバイスの PIN を要求します。</string>
+    <string name="settings_lock_unavailable">アプリロックを有効にするには、このデバイスに指紋または画面ロックを設定してください。</string>
+    <string name="settings_lock_window">無操作後にロック</string>
+    <string name="settings_lock_now">今すぐ</string>
+    <string name="settings_lock_1m">1 分</string>
+    <string name="settings_lock_5m">5 分</string>
+    <string name="settings_lock_15m">15 分</string>
+    <string name="settings_lock_30m">30 分</string>
+    <string name="settings_lock_1h">1 時間</string>
+    <string name="settings_alerts_title">アラート</string>
+    <string name="settings_alerts_subtitle">通知の配信と、Front Desk がアラートする対象。</string>
+    <!-- Accessibility label for a severity count badge on the Alerts pill, e.g. "2 error enabled". -->
+    <string name="settings_alerts_badge_desc">%2$s %1$d 件が有効</string>
+    <string name="settings_monitor_title">バックグラウンド監視</string>
+    <string name="settings_monitor_subtitle">15 分ごとにフリートを確認し、Bellhop を閉じていてもメンバーがダウンまたは復旧したときにここで通知します。</string>
+    <string name="settings_monitor_note">Front Desk 自身のアラートの方が速いです。これは Bellhop が唯一の表示手段である場合の予備です。約 15 分ごとに確認するため、変更は最大でその程度遅れることがあります。</string>
+    <string name="settings_monitor_blocked">Bellhop の通知がオフのため、これらのアラートは届きません。システム設定でオンにしてください。</string>
+    <string name="settings_push_title">リアルタイム プッシュ</string>
+    <string name="settings_push_subtitle">Front Desk がアラートを送信した瞬間に、UnifiedPush と ntfy を通じて Bellhop を起こします。Google 不要、ポーリング遅延なし、任意です。</string>
+    <string name="settings_push_no_distributor">プッシュを受け取るには、ntfy などの UnifiedPush ディストリビューターをインストールしてください。ない場合、追加するまでこれは非アクティブのままです。</string>
+    <string name="settings_push_endpoint_label">Front Desk 用のプッシュトピック</string>
+    <string name="settings_push_endpoint_waiting">ディストリビューターがプッシュトピックを返すのを待っています…</string>
+    <string name="settings_push_endpoint_note">Front Desk → 設定 → アラート に電話トピックとしてこれを貼り付けると、そのアラートが Bellhop を起こします。</string>
+    <string name="settings_push_copy">プッシュトピックをコピー</string>
+    <string name="settings_push_copied">プッシュトピックをコピーしました</string>
+    <string name="settings_push_blocked">Bellhop の通知がオフのため、プッシュは届きません。システム設定でオンにしてください。</string>
+
+    <!-- Background-monitoring notifications (Layer 2 backstop) -->
+    <string name="notif_channel_down">メンバーがダウン</string>
+    <string name="notif_channel_up">メンバーが復旧</string>
+    <string name="notif_down_title">%1$s がダウンしています</string>
+    <string name="notif_down_body">メンバーが応答しなくなりました。タップして Bellhop を開きます。</string>
+    <string name="notif_up_title">%1$s が復旧</string>
+    <string name="notif_up_body">メンバーが再び応答しています。</string>
+    <string name="notif_channel_stale">設定のずれ</string>
+    <string name="notif_stale_title">フリートがずれている可能性があります</string>
+    <string name="notif_stale_body">自動同期がオフで、フリートは 1 日以上同期されていません。タップして Bellhop を開きます。</string>
+    <string name="notif_stale_resumed_title">自動同期を再開</string>
+    <string name="notif_stale_resumed_body">フリートは再び同期が保たれています。</string>
+
+    <string name="dashboard_footer">Bellhop %1$s</string>
+    <string name="dashboard_unlink">リンク解除</string>
+    <string name="dashboard_unlink_confirm_title">このデバイスのリンクを解除しますか？</string>
+    <string name="dashboard_unlink_confirm_body">このデバイスは %1$s の監視を停止し、そのトークンは取り消されます。いつでも新しいコードで再ペア設定できます。</string>
+    <string name="dashboard_unlink_failed_title">Front Desk に接続できませんでした</string>
+    <string name="dashboard_unlink_failed_body">このデバイスはまだリンクされており、何も取り消されていません。接続を確認して、もう一度お試しください。ここでリンク解除することもできますが、Front Desk はこのデバイスをまだ一覧表示している可能性があるため、Front Desk → 設定 → ペア設定済みデバイス で取り消してください。</string>
+    <string name="dashboard_unlink_retry">再試行</string>
+    <string name="dashboard_unlink_force">それでもリンク解除</string>
+    <string name="common_cancel">キャンセル</string>
+</resources>

--- a/android/app/src/main/res/values-nl/strings.xml
+++ b/android/app/src/main/res/values-nl/strings.xml
@@ -1,0 +1,198 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- Pairing (unlinked state) -->
+    <string name="pairing_title">Een Front Desk koppelen</string>
+    <string name="pairing_subtitle">Open in Front Desk Instellingen → Gekoppelde apparaten en genereer een code. Scan de getoonde QR, of kopieer de koppelreeks ernaast en plak die hieronder.</string>
+    <string name="pairing_scan">QR-code scannen</string>
+    <string name="pairing_scan_prompt">Richt op de koppel-QR in Front Desk\n→ Instellingen → Gekoppelde apparaten</string>
+    <string name="pairing_or">of plak de reeks</string>
+    <string name="pairing_paste_label">Koppelreeks</string>
+    <string name="pairing_paste_hint">Plak hier de gekopieerde koppelreeks</string>
+    <string name="pairing_target">Front Desk: %1$s\n%2$s</string>
+    <string name="pairing_label_label">Naam van dit apparaat</string>
+    <string name="pairing_submit">Koppelen</string>
+    <string name="pairing_error_bad_string">Dat lijkt geen koppelreeks. Kopieer die opnieuw vanuit Front Desk → Instellingen → Gekoppelde apparaten.</string>
+    <string name="pairing_error_invalid_code">Ongeldige of verlopen koppelcode. Genereer een nieuwe in Front Desk en plak de verse reeks.</string>
+    <string name="pairing_error_scan_unavailable">De camera kon niet worden geopend, dus scannen is niet beschikbaar. Verleen cameratoegang, of plak in plaats daarvan de koppelreeks hieronder.</string>
+
+    <!-- Dashboard (linked state) -->
+    <string name="dashboard_linked_as">Gekoppeld als %1$s (%2$s)</string>
+    <string name="dashboard_summary_all_up">Alle leden actief</string>
+    <string name="dashboard_summary_down">%1$d van %2$d leden offline</string>
+    <string name="dashboard_summary_checking">Leden controleren…</string>
+    <string name="dashboard_empty">Nog geen leden. Voeg ze toe in Front Desk.</string>
+    <string name="dashboard_refresh_failed">Vernieuwen mislukt: %1$s</string>
+    <string name="dashboard_revoked">Dit apparaat kan zich niet meer bij Front Desk authenticeren. De toegang is mogelijk ingetrokken; ontkoppel en koppel opnieuw met een nieuwe code.</string>
+    <string name="member_health_up">Actief · %1$d ms</string>
+    <string name="member_health_down">Offline</string>
+    <string name="member_health_unknown">Nog niet gecontroleerd</string>
+    <string name="member_traefik">Traefik %1$s</string>
+    <string name="member_state_drained">Gedraineerd</string>
+    <string name="member_primary">Primair</string>
+    <!-- Member detail -->
+    <string name="member_detail_back">Terug</string>
+    <string name="member_detail_traffic_title">Verkeer · laatste %1$d min</string>
+    <string name="member_detail_traffic_totals">%1$d verzoeken · %2$d fouten</string>
+    <string name="member_detail_traffic_unreachable">Verkeer is niet beschikbaar. Front Desk heeft mogelijk geen admin-token voor dit lid, of het lid antwoordde niet.</string>
+    <string name="member_detail_traffic_empty">Geen verzoeken in dit venster.</string>
+    <string name="member_detail_events_title">Recente gebeurtenissen</string>
+    <string name="member_detail_no_events">Geen recente gebeurtenissen voor dit lid.</string>
+    <string name="member_detail_label_address">Adres</string>
+    <string name="member_detail_label_synced">Gesynchroniseerd</string>
+    <string name="member_detail_label_reason">Reden</string>
+    <string name="member_detail_label_verified">Geverifieerd</string>
+    <string name="member_detail_label_added">Toegevoegd</string>
+    <string name="member_url_title">Lidadres openen</string>
+    <string name="member_url_open">Openen</string>
+    <string name="open_url_title">Link openen</string>
+    <!-- Operator actions -->
+    <string name="member_op_title">Operatorbediening</string>
+    <string name="member_op_drain">Draineren</string>
+    <string name="member_op_activate">Activeren</string>
+    <string name="member_op_draining">Draineren… wachten tot de vloot is bijgewerkt.</string>
+    <string name="member_op_activating">Activeren… wachten tot de vloot is bijgewerkt.</string>
+    <string name="member_op_sync">Vlootconfiguratie synchroniseren</string>
+    <string name="member_op_synced">%1$d leden gesynchroniseerd vanaf de primaire.</string>
+    <string name="member_op_sync_failed">Synchronisatie voltooid met %1$d van %2$d leden mislukt.</string>
+    <string name="member_op_error">Kon niet toepassen: %1$s</string>
+    <string name="member_op_dismiss">Sluiten</string>
+    <string name="member_op_last_sync">Laatste configuratiewijziging gesynchroniseerd %1$s</string>
+    <string name="member_op_busy">Er loopt nog een andere actie. Wacht tot die klaar is en probeer het opnieuw.</string>
+    <string name="member_op_forbidden">Dit apparaat is gekoppeld als monitor en kan de vloot niet wijzigen. Koppel het opnieuw met een operatorcode in Front Desk om te draineren, activeren of synchroniseren.</string>
+
+    <!-- Pause/resume auto-sync (dashboard operator control) -->
+    <string name="autosync_title">Auto-sync</string>
+    <string name="autosync_on">De vloot blijft synchroon met de primaire.</string>
+    <string name="autosync_off">De vloot synchroniseert pas weer als je hervat.</string>
+    <string name="autosync_pausing">Pauzeren…</string>
+    <string name="autosync_resuming">Hervatten…</string>
+    <string name="autosync_busy">Er loopt nog een andere actie. Wacht tot die klaar is en probeer het opnieuw.</string>
+    <string name="autosync_error">Kon niet toepassen: %1$s</string>
+    <string name="autosync_forbidden">Dit apparaat is gekoppeld als monitor en kan auto-sync niet wijzigen. Koppel het opnieuw met een operatorcode in Front Desk.</string>
+
+    <!-- Events -->
+    <string name="events_title">Gebeurtenissen</string>
+    <string name="events_open">Gebeurtenissen</string>
+    <string name="events_back">Terug</string>
+    <string name="events_empty">Geen gebeurtenissen komen overeen.</string>
+    <string name="events_copied">Gebeurtenis gekopieerd naar klembord</string>
+    <string name="dashboard_member_copied">Lid gekopieerd naar klembord</string>
+    <string name="scroll_to_top">Naar boven scrollen</string>
+    <plurals name="events_total">
+        <item quantity="one">%1$d gebeurtenis</item>
+        <item quantity="other">%1$d gebeurtenissen</item>
+    </plurals>
+    <string name="events_sev_all">Alle</string>
+    <string name="events_sev_info">Info</string>
+    <string name="events_sev_success">Succes</string>
+    <string name="events_sev_warning">Waarschuwing</string>
+    <string name="events_sev_error">Fout</string>
+    <string name="events_range_all">Alle tijd</string>
+    <string name="events_range_1h">1 u</string>
+    <string name="events_range_24h">24 u</string>
+    <string name="events_range_7d">7 d</string>
+    <string name="events_range_30d">30 d</string>
+    <string name="events_range_calendar">Datumbereik kiezen</string>
+    <string name="events_range_clear">Datumbereik wissen</string>
+    <string name="events_range_apply">Toepassen</string>
+
+    <!-- Alerts -->
+    <string name="alerts_title">Waarschuwingen</string>
+    <string name="alerts_open">Waarschuwingen</string>
+    <string name="alerts_back">Terug</string>
+    <string name="alerts_delivery_title">Bezorging van meldingen</string>
+    <string name="alerts_status_not_configured">Niet geconfigureerd</string>
+    <string name="alerts_status_unreachable">Notifier onbereikbaar</string>
+    <string name="alerts_status_unhealthy">Notifier ongezond</string>
+    <string name="alerts_status_delivering">Bezorgen</string>
+    <string name="alerts_catalog_title">Waarvoor Front Desk waarschuwt</string>
+    <string name="alerts_catalog_note">Zet de schakelaar om om een waarschuwing in of uit te schakelen. Wijzigingen worden direct op Front Desk toegepast.</string>
+    <string name="alerts_flip_forbidden">Dit apparaat is gekoppeld als monitor en kan waarschuwingen niet wijzigen. Koppel het opnieuw met een operatorcode in Front Desk.</string>
+    <string name="alerts_flip_failed">Kon die waarschuwing niet wijzigen: %1$s</string>
+    <string name="alerts_event_health_down">Lid ging offline</string>
+    <string name="alerts_event_health_up">Lid hersteld</string>
+    <string name="alerts_event_config_sync_failed">Configuratiesynchronisatie mislukt</string>
+    <string name="alerts_event_config_synced">Configuratie gesynchroniseerd</string>
+    <string name="alerts_event_config_auto_synced">Configuratie automatisch gesynchroniseerd</string>
+    <string name="alerts_event_version_fetch_failed">Versie lezen mislukt</string>
+    <string name="alerts_event_version_fetch_recovered">Versie lezen hersteld</string>
+    <string name="alerts_event_traefik_stale">Traefik-configuratie verouderd</string>
+    <string name="alerts_event_member_added">Lid toegevoegd</string>
+    <string name="alerts_event_member_removed">Lid verwijderd</string>
+    <string name="alerts_event_member_state_changed">Lid gedraineerd of geactiveerd</string>
+
+    <!-- App lock -->
+    <string name="lock_title">Bellhop is vergrendeld</string>
+    <string name="lock_subtitle">Ontgrendel om de vloot te zien.</string>
+    <string name="lock_unlock">Ontgrendelen</string>
+    <string name="lock_prompt_title">Bellhop ontgrendelen</string>
+    <string name="lock_prompt_subtitle">Bevestig dat jij het bent om de vloot te zien.</string>
+    <string name="operator_prompt_title">Operatoractie bevestigen</string>
+    <string name="operator_prompt_subtitle">Bevestig dat jij het bent voordat je de vloot wijzigt.</string>
+
+    <!-- Settings -->
+    <string name="settings_open">Instellingen</string>
+    <string name="settings_title">Instellingen</string>
+    <string name="settings_back">Terug</string>
+    <string name="settings_language">Taal</string>
+    <string name="language_system_default">Systeemstandaard</string>
+    <string name="settings_fd_title">Gekoppelde Front Desk</string>
+    <string name="settings_fd_linked_on">Gekoppeld op %1$s</string>
+    <string name="settings_fd_copy_title">Adres kopiëren?</string>
+    <string name="settings_fd_copy_body">%1$s naar klembord kopiëren?</string>
+    <string name="settings_fd_copied">Adres gekopieerd naar klembord</string>
+    <string name="common_copy">Kopiëren</string>
+    <string name="settings_hold_copy_title">Ingedrukt houden om te kopiëren</string>
+    <string name="settings_hold_copy_subtitle">Wanneer aan, houd een gebeurtenis- of ledencel ingedrukt om die naar het klembord te kopiëren. Wanneer uit, kunnen cellen niet worden gekopieerd.</string>
+    <string name="settings_lock_title">App-vergrendeling</string>
+    <string name="settings_lock_subtitle">Vereis een vingerafdruk of apparaat-pincode om Bellhop te openen.</string>
+    <string name="settings_lock_unavailable">Stel een vingerafdruk of schermvergrendeling in op dit apparaat om de app-vergrendeling in te schakelen.</string>
+    <string name="settings_lock_window">Vergrendelen na inactiviteit</string>
+    <string name="settings_lock_now">Nu</string>
+    <string name="settings_lock_1m">1 min</string>
+    <string name="settings_lock_5m">5 min</string>
+    <string name="settings_lock_15m">15 min</string>
+    <string name="settings_lock_30m">30 min</string>
+    <string name="settings_lock_1h">1 u</string>
+    <string name="settings_alerts_title">Waarschuwingen</string>
+    <string name="settings_alerts_subtitle">Bezorging van meldingen en waarvoor Front Desk waarschuwt.</string>
+    <!-- Accessibility label for a severity count badge on the Alerts pill, e.g. "2 error enabled". -->
+    <string name="settings_alerts_badge_desc">%1$d %2$s ingeschakeld</string>
+    <string name="settings_monitor_title">Achtergrondbewaking</string>
+    <string name="settings_monitor_subtitle">Controleert de vloot elke 15 minuten en waarschuwt je hier wanneer een lid offline gaat of herstelt, zelfs als Bellhop gesloten is.</string>
+    <string name="settings_monitor_note">De eigen waarschuwingen van Front Desk zijn sneller; dit is een vangnet voor wanneer Bellhop je enige zicht is. Het controleert ongeveer elke 15 minuten, dus een wijziging kan tot zo lang later komen.</string>
+    <string name="settings_monitor_blocked">Meldingen staan uit voor Bellhop, dus deze waarschuwingen bereiken je niet. Zet ze aan in de systeeminstellingen.</string>
+    <string name="settings_push_title">Realtime push</string>
+    <string name="settings_push_subtitle">Wekt Bellhop op het moment dat Front Desk een waarschuwing pusht, via UnifiedPush en ntfy. Geen Google, geen pollvertraging, opt-in.</string>
+    <string name="settings_push_no_distributor">Installeer een UnifiedPush-distributeur zoals ntfy om pushes te ontvangen. Zonder een blijft dit inactief tot je er een toevoegt.</string>
+    <string name="settings_push_endpoint_label">Push-onderwerp voor Front Desk</string>
+    <string name="settings_push_endpoint_waiting">Wachten tot de distributeur een push-onderwerp teruggeeft…</string>
+    <string name="settings_push_endpoint_note">Plak dit in Front Desk → Instellingen → Waarschuwingen als het telefoononderwerp, zodat zijn waarschuwingen Bellhop wekken.</string>
+    <string name="settings_push_copy">Push-onderwerp kopiëren</string>
+    <string name="settings_push_copied">Push-onderwerp gekopieerd</string>
+    <string name="settings_push_blocked">Meldingen staan uit voor Bellhop, dus pushes kunnen je niet bereiken. Zet ze aan in de systeeminstellingen.</string>
+
+    <!-- Background-monitoring notifications (Layer 2 backstop) -->
+    <string name="notif_channel_down">Lid offline</string>
+    <string name="notif_channel_up">Lid hersteld</string>
+    <string name="notif_down_title">%1$s is offline</string>
+    <string name="notif_down_body">Een lid reageert niet meer. Tik om Bellhop te openen.</string>
+    <string name="notif_up_title">%1$s hersteld</string>
+    <string name="notif_up_body">Een lid reageert weer.</string>
+    <string name="notif_channel_stale">Configuratieafwijking</string>
+    <string name="notif_stale_title">Vloot wijkt mogelijk af</string>
+    <string name="notif_stale_body">Auto-sync staat uit en de vloot is al meer dan een dag niet gesynchroniseerd. Tik om Bellhop te openen.</string>
+    <string name="notif_stale_resumed_title">Auto-sync hervat</string>
+    <string name="notif_stale_resumed_body">De vloot wordt weer synchroon gehouden.</string>
+
+    <string name="dashboard_footer">Bellhop %1$s</string>
+    <string name="dashboard_unlink">Ontkoppelen</string>
+    <string name="dashboard_unlink_confirm_title">Dit apparaat ontkoppelen?</string>
+    <string name="dashboard_unlink_confirm_body">Dit apparaat stopt met het bewaken van %1$s en het token wordt ingetrokken. Je kunt op elk moment opnieuw koppelen met een nieuwe code.</string>
+    <string name="dashboard_unlink_failed_title">Kon Front Desk niet bereiken</string>
+    <string name="dashboard_unlink_failed_body">Dit apparaat is nog gekoppeld en er is niets ingetrokken. Controleer je verbinding en probeer het opnieuw. Je kunt hier toch ontkoppelen, maar Front Desk kan dit apparaat nog steeds tonen; trek het daarom in via Front Desk → Instellingen → Gekoppelde apparaten.</string>
+    <string name="dashboard_unlink_retry">Opnieuw proberen</string>
+    <string name="dashboard_unlink_force">Toch ontkoppelen</string>
+    <string name="common_cancel">Annuleren</string>
+</resources>

--- a/android/app/src/main/res/values-nl/strings.xml
+++ b/android/app/src/main/res/values-nl/strings.xml
@@ -195,4 +195,17 @@
     <string name="dashboard_unlink_retry">Opnieuw proberen</string>
     <string name="dashboard_unlink_force">Toch ontkoppelen</string>
     <string name="common_cancel">Annuleren</string>
+    <string name="time_just_now">zojuist</string>
+    <plurals name="time_min_ago">
+        <item quantity="one">%d min geleden</item>
+        <item quantity="other">%d min geleden</item>
+    </plurals>
+    <plurals name="time_hr_ago">
+        <item quantity="one">%d u geleden</item>
+        <item quantity="other">%d u geleden</item>
+    </plurals>
+    <plurals name="time_day_ago">
+        <item quantity="one">%d dag geleden</item>
+        <item quantity="other">%d dagen geleden</item>
+    </plurals>
 </resources>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -197,4 +197,23 @@
     <string name="dashboard_unlink_retry">Ponów</string>
     <string name="dashboard_unlink_force">Rozłącz mimo to</string>
     <string name="common_cancel">Anuluj</string>
+    <string name="time_just_now">przed chwilą</string>
+    <plurals name="time_min_ago">
+        <item quantity="one">%d min temu</item>
+        <item quantity="few">%d min temu</item>
+        <item quantity="many">%d min temu</item>
+        <item quantity="other">%d min temu</item>
+    </plurals>
+    <plurals name="time_hr_ago">
+        <item quantity="one">%d godz. temu</item>
+        <item quantity="few">%d godz. temu</item>
+        <item quantity="many">%d godz. temu</item>
+        <item quantity="other">%d godz. temu</item>
+    </plurals>
+    <plurals name="time_day_ago">
+        <item quantity="one">%d dzień temu</item>
+        <item quantity="few">%d dni temu</item>
+        <item quantity="many">%d dni temu</item>
+        <item quantity="other">%d dnia temu</item>
+    </plurals>
 </resources>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -1,0 +1,200 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- Pairing (unlinked state) -->
+    <string name="pairing_title">Połącz Front Desk</string>
+    <string name="pairing_subtitle">W Front Desk otwórz Ustawienia → Sparowane urządzenia i wygeneruj kod. Zeskanuj wyświetlony kod QR lub skopiuj ciąg parowania obok i wklej go poniżej.</string>
+    <string name="pairing_scan">Zeskanuj kod QR</string>
+    <string name="pairing_scan_prompt">Wyceluj w kod QR parowania w Front Desk\n→ Ustawienia → Sparowane urządzenia</string>
+    <string name="pairing_or">albo wklej</string>
+    <string name="pairing_paste_label">Ciąg parowania</string>
+    <string name="pairing_paste_hint">Wklej tutaj skopiowany ciąg parowania</string>
+    <string name="pairing_target">Front Desk: %1$s\n%2$s</string>
+    <string name="pairing_label_label">Nazwa tego urządzenia</string>
+    <string name="pairing_submit">Sparuj</string>
+    <string name="pairing_error_bad_string">To nie wygląda na ciąg parowania. Skopiuj go ponownie z Front Desk → Ustawienia → Sparowane urządzenia.</string>
+    <string name="pairing_error_invalid_code">Nieprawidłowy lub wygasły kod parowania. Wygeneruj nowy w Front Desk i wklej świeży ciąg.</string>
+    <string name="pairing_error_scan_unavailable">Nie udało się otworzyć aparatu, więc skanowanie jest niedostępne. Przyznaj dostęp do aparatu lub zamiast tego wklej ciąg parowania poniżej.</string>
+
+    <!-- Dashboard (linked state) -->
+    <string name="dashboard_linked_as">Połączono jako %1$s (%2$s)</string>
+    <string name="dashboard_summary_all_up">Wszystkie węzły działają</string>
+    <string name="dashboard_summary_down">%1$d z %2$d węzłów nie działa</string>
+    <string name="dashboard_summary_checking">Sprawdzanie węzłów…</string>
+    <string name="dashboard_empty">Brak węzłów. Dodaj je w Front Desk.</string>
+    <string name="dashboard_refresh_failed">Nie udało się odświeżyć: %1$s</string>
+    <string name="dashboard_revoked">To urządzenie nie może już uwierzytelnić się w Front Desk. Jego dostęp mógł zostać cofnięty; rozłącz i sparuj ponownie z nowym kodem.</string>
+    <string name="member_health_up">Działa · %1$d ms</string>
+    <string name="member_health_down">Nie działa</string>
+    <string name="member_health_unknown">Jeszcze niesprawdzone</string>
+    <string name="member_traefik">Traefik %1$s</string>
+    <string name="member_state_drained">Wygaszony</string>
+    <string name="member_primary">Podstawowy</string>
+    <!-- Member detail -->
+    <string name="member_detail_back">Wstecz</string>
+    <string name="member_detail_traffic_title">Ruch · ostatnie %1$d min</string>
+    <string name="member_detail_traffic_totals">%1$d żądań · %2$d błędów</string>
+    <string name="member_detail_traffic_unreachable">Ruch jest niedostępny. Front Desk może nie mieć tokena administratora dla tego węzła lub węzeł nie odpowiedział.</string>
+    <string name="member_detail_traffic_empty">Brak żądań w tym oknie.</string>
+    <string name="member_detail_events_title">Ostatnie zdarzenia</string>
+    <string name="member_detail_no_events">Brak ostatnich zdarzeń dla tego węzła.</string>
+    <string name="member_detail_label_address">Adres</string>
+    <string name="member_detail_label_synced">Zsynchronizowano</string>
+    <string name="member_detail_label_reason">Powód</string>
+    <string name="member_detail_label_verified">Zweryfikowano</string>
+    <string name="member_detail_label_added">Dodano</string>
+    <string name="member_url_title">Otwórz adres węzła</string>
+    <string name="member_url_open">Otwórz</string>
+    <string name="open_url_title">Otwórz link</string>
+    <!-- Operator actions -->
+    <string name="member_op_title">Sterowanie operatora</string>
+    <string name="member_op_drain">Wygaś</string>
+    <string name="member_op_activate">Aktywuj</string>
+    <string name="member_op_draining">Wygaszanie… czekanie, aż flota nadrobi.</string>
+    <string name="member_op_activating">Aktywowanie… czekanie, aż flota nadrobi.</string>
+    <string name="member_op_sync">Synchronizuj konfigurację floty</string>
+    <string name="member_op_synced">Zsynchronizowano %1$d węzłów z podstawowego.</string>
+    <string name="member_op_sync_failed">Synchronizacja zakończona z %1$d z %2$d węzłów zakończonych błędem.</string>
+    <string name="member_op_error">Nie udało się zastosować: %1$s</string>
+    <string name="member_op_dismiss">Zamknij</string>
+    <string name="member_op_last_sync">Ostatnia zmiana konfiguracji zsynchronizowana %1$s</string>
+    <string name="member_op_busy">Inna akcja wciąż trwa. Poczekaj, aż się zakończy, i spróbuj ponownie.</string>
+    <string name="member_op_forbidden">To urządzenie jest sparowane jako monitor i nie może zmieniać floty. Sparuj je ponownie kodem operatora w Front Desk, aby wygaszać, aktywować lub synchronizować.</string>
+
+    <!-- Pause/resume auto-sync (dashboard operator control) -->
+    <string name="autosync_title">Autosynchronizacja</string>
+    <string name="autosync_on">Flota pozostaje zsynchronizowana z podstawowym.</string>
+    <string name="autosync_off">Flota nie zsynchronizuje się, dopóki nie wznowisz.</string>
+    <string name="autosync_pausing">Wstrzymywanie…</string>
+    <string name="autosync_resuming">Wznawianie…</string>
+    <string name="autosync_busy">Inna akcja wciąż trwa. Poczekaj, aż się zakończy, i spróbuj ponownie.</string>
+    <string name="autosync_error">Nie udało się zastosować: %1$s</string>
+    <string name="autosync_forbidden">To urządzenie jest sparowane jako monitor i nie może zmieniać autosynchronizacji. Sparuj je ponownie kodem operatora w Front Desk.</string>
+
+    <!-- Events -->
+    <string name="events_title">Zdarzenia</string>
+    <string name="events_open">Zdarzenia</string>
+    <string name="events_back">Wstecz</string>
+    <string name="events_empty">Brak pasujących zdarzeń.</string>
+    <string name="events_copied">Skopiowano zdarzenie do schowka</string>
+    <string name="dashboard_member_copied">Skopiowano węzeł do schowka</string>
+    <string name="scroll_to_top">Przewiń do góry</string>
+    <plurals name="events_total">
+        <item quantity="one">%1$d zdarzenie</item>
+        <item quantity="few">%1$d zdarzenia</item>
+        <item quantity="many">%1$d zdarzeń</item>
+        <item quantity="other">%1$d zdarzenia</item>
+    </plurals>
+    <string name="events_sev_all">Wszystkie</string>
+    <string name="events_sev_info">Info</string>
+    <string name="events_sev_success">Sukces</string>
+    <string name="events_sev_warning">Ostrzeżenie</string>
+    <string name="events_sev_error">Błąd</string>
+    <string name="events_range_all">Cały czas</string>
+    <string name="events_range_1h">1 g</string>
+    <string name="events_range_24h">24 g</string>
+    <string name="events_range_7d">7 d</string>
+    <string name="events_range_30d">30 d</string>
+    <string name="events_range_calendar">Wybierz zakres dat</string>
+    <string name="events_range_clear">Wyczyść zakres dat</string>
+    <string name="events_range_apply">Zastosuj</string>
+
+    <!-- Alerts -->
+    <string name="alerts_title">Alerty</string>
+    <string name="alerts_open">Alerty</string>
+    <string name="alerts_back">Wstecz</string>
+    <string name="alerts_delivery_title">Dostarczanie powiadomień</string>
+    <string name="alerts_status_not_configured">Nieskonfigurowane</string>
+    <string name="alerts_status_unreachable">Powiadamiacz nieosiągalny</string>
+    <string name="alerts_status_unhealthy">Powiadamiacz niesprawny</string>
+    <string name="alerts_status_delivering">Dostarczanie</string>
+    <string name="alerts_catalog_title">Na co Front Desk alarmuje</string>
+    <string name="alerts_catalog_note">Przełącz przełącznik, aby włączyć lub wyciszyć alert. Zmiany są stosowane w Front Desk natychmiast.</string>
+    <string name="alerts_flip_forbidden">To urządzenie jest sparowane jako monitor i nie może zmieniać alertów. Sparuj je ponownie kodem operatora w Front Desk.</string>
+    <string name="alerts_flip_failed">Nie udało się zmienić tego alertu: %1$s</string>
+    <string name="alerts_event_health_down">Węzeł przestał działać</string>
+    <string name="alerts_event_health_up">Węzeł przywrócony</string>
+    <string name="alerts_event_config_sync_failed">Synchronizacja konfiguracji nie powiodła się</string>
+    <string name="alerts_event_config_synced">Konfiguracja zsynchronizowana</string>
+    <string name="alerts_event_config_auto_synced">Konfiguracja zsynchronizowana automatycznie</string>
+    <string name="alerts_event_version_fetch_failed">Odczyt wersji nie powiódł się</string>
+    <string name="alerts_event_version_fetch_recovered">Odczyt wersji przywrócony</string>
+    <string name="alerts_event_traefik_stale">Konfiguracja Traefik nieaktualna</string>
+    <string name="alerts_event_member_added">Węzeł dodany</string>
+    <string name="alerts_event_member_removed">Węzeł usunięty</string>
+    <string name="alerts_event_member_state_changed">Węzeł wygaszony lub aktywowany</string>
+
+    <!-- App lock -->
+    <string name="lock_title">Bellhop jest zablokowany</string>
+    <string name="lock_subtitle">Odblokuj, aby zobaczyć flotę.</string>
+    <string name="lock_unlock">Odblokuj</string>
+    <string name="lock_prompt_title">Odblokuj Bellhop</string>
+    <string name="lock_prompt_subtitle">Potwierdź, że to Ty, aby zobaczyć flotę.</string>
+    <string name="operator_prompt_title">Potwierdź akcję operatora</string>
+    <string name="operator_prompt_subtitle">Potwierdź, że to Ty, zanim zmienisz flotę.</string>
+
+    <!-- Settings -->
+    <string name="settings_open">Ustawienia</string>
+    <string name="settings_title">Ustawienia</string>
+    <string name="settings_back">Wstecz</string>
+    <string name="settings_language">Język</string>
+    <string name="language_system_default">Domyślny systemu</string>
+    <string name="settings_fd_title">Połączony Front Desk</string>
+    <string name="settings_fd_linked_on">Połączono %1$s</string>
+    <string name="settings_fd_copy_title">Skopiować adres?</string>
+    <string name="settings_fd_copy_body">Skopiować %1$s do schowka?</string>
+    <string name="settings_fd_copied">Skopiowano adres do schowka</string>
+    <string name="common_copy">Kopiuj</string>
+    <string name="settings_hold_copy_title">Przytrzymaj, aby skopiować</string>
+    <string name="settings_hold_copy_subtitle">Gdy włączone, przytrzymaj komórkę zdarzenia lub węzła, aby skopiować ją do schowka. Gdy wyłączone, komórek nie można kopiować.</string>
+    <string name="settings_lock_title">Blokada aplikacji</string>
+    <string name="settings_lock_subtitle">Wymagaj odcisku palca lub kodu PIN urządzenia, aby otworzyć Bellhop.</string>
+    <string name="settings_lock_unavailable">Skonfiguruj odcisk palca lub blokadę ekranu na tym urządzeniu, aby włączyć blokadę aplikacji.</string>
+    <string name="settings_lock_window">Zablokuj po bezczynności</string>
+    <string name="settings_lock_now">Natychmiast</string>
+    <string name="settings_lock_1m">1 min</string>
+    <string name="settings_lock_5m">5 min</string>
+    <string name="settings_lock_15m">15 min</string>
+    <string name="settings_lock_30m">30 min</string>
+    <string name="settings_lock_1h">1 g</string>
+    <string name="settings_alerts_title">Alerty</string>
+    <string name="settings_alerts_subtitle">Dostarczanie powiadomień i na co Front Desk alarmuje.</string>
+    <!-- Accessibility label for a severity count badge on the Alerts pill, e.g. "2 error enabled". -->
+    <string name="settings_alerts_badge_desc">%1$d %2$s włączonych</string>
+    <string name="settings_monitor_title">Monitorowanie w tle</string>
+    <string name="settings_monitor_subtitle">Sprawdza flotę co 15 minut i powiadamia Cię tutaj, gdy węzeł przestanie działać lub zostanie przywrócony, nawet gdy Bellhop jest zamknięty.</string>
+    <string name="settings_monitor_note">Własne alerty Front Desk są szybsze; to zabezpieczenie na wypadek, gdy Bellhop jest Twoim jedynym widokiem. Sprawdza mniej więcej co 15 minut, więc zmiana może przyjść z takim opóźnieniem.</string>
+    <string name="settings_monitor_blocked">Powiadomienia dla Bellhop są wyłączone, więc te alerty do Ciebie nie dotrą. Włącz je w ustawieniach systemu.</string>
+    <string name="settings_push_title">Push w czasie rzeczywistym</string>
+    <string name="settings_push_subtitle">Budzi Bellhop w chwili, gdy Front Desk wyśle alert, przez UnifiedPush i ntfy. Bez Google, bez opóźnienia odpytywania, opcjonalne.</string>
+    <string name="settings_push_no_distributor">Zainstaluj dystrybutor UnifiedPush, taki jak ntfy, aby odbierać pushe. Bez niego pozostanie to nieaktywne, dopóki go nie dodasz.</string>
+    <string name="settings_push_endpoint_label">Temat push dla Front Desk</string>
+    <string name="settings_push_endpoint_waiting">Czekanie, aż dystrybutor zwróci temat push…</string>
+    <string name="settings_push_endpoint_note">Wklej to w Front Desk → Ustawienia → Alerty jako temat telefonu, aby jego alerty budziły Bellhop.</string>
+    <string name="settings_push_copy">Kopiuj temat push</string>
+    <string name="settings_push_copied">Skopiowano temat push</string>
+    <string name="settings_push_blocked">Powiadomienia dla Bellhop są wyłączone, więc pushe nie mogą do Ciebie dotrzeć. Włącz je w ustawieniach systemu.</string>
+
+    <!-- Background-monitoring notifications (Layer 2 backstop) -->
+    <string name="notif_channel_down">Węzeł nie działa</string>
+    <string name="notif_channel_up">Węzeł przywrócony</string>
+    <string name="notif_down_title">%1$s nie działa</string>
+    <string name="notif_down_body">Węzeł przestał odpowiadać. Dotknij, aby otworzyć Bellhop.</string>
+    <string name="notif_up_title">%1$s przywrócony</string>
+    <string name="notif_up_body">Węzeł znów odpowiada.</string>
+    <string name="notif_channel_stale">Rozjazd konfiguracji</string>
+    <string name="notif_stale_title">Flota może się rozjeżdżać</string>
+    <string name="notif_stale_body">Autosynchronizacja jest wyłączona, a flota nie synchronizowała się od ponad doby. Dotknij, aby otworzyć Bellhop.</string>
+    <string name="notif_stale_resumed_title">Autosynchronizacja wznowiona</string>
+    <string name="notif_stale_resumed_body">Flota jest znów utrzymywana w synchronizacji.</string>
+
+    <string name="dashboard_footer">Bellhop %1$s</string>
+    <string name="dashboard_unlink">Rozłącz</string>
+    <string name="dashboard_unlink_confirm_title">Rozłączyć to urządzenie?</string>
+    <string name="dashboard_unlink_confirm_body">To urządzenie przestanie monitorować %1$s, a jego token zostanie cofnięty. Możesz sparować ponownie w dowolnej chwili nowym kodem.</string>
+    <string name="dashboard_unlink_failed_title">Nie udało się połączyć z Front Desk</string>
+    <string name="dashboard_unlink_failed_body">To urządzenie jest wciąż połączone i nic nie zostało cofnięte. Sprawdź połączenie i spróbuj ponownie. Możesz i tak rozłączyć tutaj, ale Front Desk może nadal wyświetlać to urządzenie, więc cofnij je w Front Desk → Ustawienia → Sparowane urządzenia.</string>
+    <string name="dashboard_unlink_retry">Ponów</string>
+    <string name="dashboard_unlink_force">Rozłącz mimo to</string>
+    <string name="common_cancel">Anuluj</string>
+</resources>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -1,0 +1,200 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- Pairing (unlinked state) -->
+    <string name="pairing_title">Связать Front Desk</string>
+    <string name="pairing_subtitle">В Front Desk откройте Настройки → Связанные устройства и создайте код. Отсканируйте показанный QR-код или скопируйте строку связывания рядом и вставьте её ниже.</string>
+    <string name="pairing_scan">Сканировать QR-код</string>
+    <string name="pairing_scan_prompt">Наведите на QR-код связывания в Front Desk\n→ Настройки → Связанные устройства</string>
+    <string name="pairing_or">или вставьте</string>
+    <string name="pairing_paste_label">Строка связывания</string>
+    <string name="pairing_paste_hint">Вставьте сюда скопированную строку связывания</string>
+    <string name="pairing_target">Front Desk: %1$s\n%2$s</string>
+    <string name="pairing_label_label">Имя этого устройства</string>
+    <string name="pairing_submit">Связать</string>
+    <string name="pairing_error_bad_string">Это не похоже на строку связывания. Скопируйте её заново из Front Desk → Настройки → Связанные устройства.</string>
+    <string name="pairing_error_invalid_code">Недействительный или просроченный код связывания. Создайте новый в Front Desk и вставьте свежую строку.</string>
+    <string name="pairing_error_scan_unavailable">Не удалось открыть камеру, поэтому сканирование недоступно. Разрешите доступ к камере или вставьте строку связывания ниже.</string>
+
+    <!-- Dashboard (linked state) -->
+    <string name="dashboard_linked_as">Связано как %1$s (%2$s)</string>
+    <string name="dashboard_summary_all_up">Все узлы работают</string>
+    <string name="dashboard_summary_down">%1$d из %2$d узлов недоступны</string>
+    <string name="dashboard_summary_checking">Проверка узлов…</string>
+    <string name="dashboard_empty">Пока нет узлов. Добавьте их в Front Desk.</string>
+    <string name="dashboard_refresh_failed">Не удалось обновить: %1$s</string>
+    <string name="dashboard_revoked">Это устройство больше не может пройти аутентификацию в Front Desk. Его доступ мог быть отозван; отвяжите и свяжите заново с новым кодом.</string>
+    <string name="member_health_up">Работает · %1$d мс</string>
+    <string name="member_health_down">Недоступен</string>
+    <string name="member_health_unknown">Ещё не проверено</string>
+    <string name="member_traefik">Traefik %1$s</string>
+    <string name="member_state_drained">Выведен</string>
+    <string name="member_primary">Основной</string>
+    <!-- Member detail -->
+    <string name="member_detail_back">Назад</string>
+    <string name="member_detail_traffic_title">Трафик · последние %1$d мин</string>
+    <string name="member_detail_traffic_totals">%1$d запросов · %2$d ошибок</string>
+    <string name="member_detail_traffic_unreachable">Трафик недоступен. Возможно, у Front Desk нет токена администратора для этого узла, или узел не ответил.</string>
+    <string name="member_detail_traffic_empty">Нет запросов в этом окне.</string>
+    <string name="member_detail_events_title">Недавние события</string>
+    <string name="member_detail_no_events">Нет недавних событий для этого узла.</string>
+    <string name="member_detail_label_address">Адрес</string>
+    <string name="member_detail_label_synced">Синхронизировано</string>
+    <string name="member_detail_label_reason">Причина</string>
+    <string name="member_detail_label_verified">Проверено</string>
+    <string name="member_detail_label_added">Добавлено</string>
+    <string name="member_url_title">Открыть адрес узла</string>
+    <string name="member_url_open">Открыть</string>
+    <string name="open_url_title">Открыть ссылку</string>
+    <!-- Operator actions -->
+    <string name="member_op_title">Управление оператора</string>
+    <string name="member_op_drain">Вывести</string>
+    <string name="member_op_activate">Активировать</string>
+    <string name="member_op_draining">Вывод… ожидание, пока флот догонит.</string>
+    <string name="member_op_activating">Активация… ожидание, пока флот догонит.</string>
+    <string name="member_op_sync">Синхронизировать конфигурацию флота</string>
+    <string name="member_op_synced">Синхронизировано %1$d узлов с основного.</string>
+    <string name="member_op_sync_failed">Синхронизация завершена с %1$d из %2$d узлов с ошибкой.</string>
+    <string name="member_op_error">Не удалось применить: %1$s</string>
+    <string name="member_op_dismiss">Закрыть</string>
+    <string name="member_op_last_sync">Последнее изменение конфигурации синхронизировано %1$s</string>
+    <string name="member_op_busy">Другое действие ещё выполняется. Дождитесь его завершения и повторите попытку.</string>
+    <string name="member_op_forbidden">Это устройство связано как монитор и не может менять флот. Свяжите его заново кодом оператора в Front Desk, чтобы выводить, активировать или синхронизировать.</string>
+
+    <!-- Pause/resume auto-sync (dashboard operator control) -->
+    <string name="autosync_title">Автосинхронизация</string>
+    <string name="autosync_on">Флот остаётся синхронизированным с основным.</string>
+    <string name="autosync_off">Флот не будет синхронизироваться, пока вы не возобновите.</string>
+    <string name="autosync_pausing">Приостановка…</string>
+    <string name="autosync_resuming">Возобновление…</string>
+    <string name="autosync_busy">Другое действие ещё выполняется. Дождитесь его завершения и повторите попытку.</string>
+    <string name="autosync_error">Не удалось применить: %1$s</string>
+    <string name="autosync_forbidden">Это устройство связано как монитор и не может менять автосинхронизацию. Свяжите его заново кодом оператора в Front Desk.</string>
+
+    <!-- Events -->
+    <string name="events_title">События</string>
+    <string name="events_open">События</string>
+    <string name="events_back">Назад</string>
+    <string name="events_empty">Нет подходящих событий.</string>
+    <string name="events_copied">Событие скопировано в буфер обмена</string>
+    <string name="dashboard_member_copied">Узел скопирован в буфер обмена</string>
+    <string name="scroll_to_top">Прокрутить вверх</string>
+    <plurals name="events_total">
+        <item quantity="one">%1$d событие</item>
+        <item quantity="few">%1$d события</item>
+        <item quantity="many">%1$d событий</item>
+        <item quantity="other">%1$d события</item>
+    </plurals>
+    <string name="events_sev_all">Все</string>
+    <string name="events_sev_info">Инфо</string>
+    <string name="events_sev_success">Успех</string>
+    <string name="events_sev_warning">Предупреждение</string>
+    <string name="events_sev_error">Ошибка</string>
+    <string name="events_range_all">За всё время</string>
+    <string name="events_range_1h">1 ч</string>
+    <string name="events_range_24h">24 ч</string>
+    <string name="events_range_7d">7 д</string>
+    <string name="events_range_30d">30 д</string>
+    <string name="events_range_calendar">Выбрать диапазон дат</string>
+    <string name="events_range_clear">Очистить диапазон дат</string>
+    <string name="events_range_apply">Применить</string>
+
+    <!-- Alerts -->
+    <string name="alerts_title">Оповещения</string>
+    <string name="alerts_open">Оповещения</string>
+    <string name="alerts_back">Назад</string>
+    <string name="alerts_delivery_title">Доставка уведомлений</string>
+    <string name="alerts_status_not_configured">Не настроено</string>
+    <string name="alerts_status_unreachable">Уведомитель недоступен</string>
+    <string name="alerts_status_unhealthy">Уведомитель неисправен</string>
+    <string name="alerts_status_delivering">Доставка</string>
+    <string name="alerts_catalog_title">О чём оповещает Front Desk</string>
+    <string name="alerts_catalog_note">Переключите тумблер, чтобы включить или отключить оповещение. Изменения применяются во Front Desk сразу.</string>
+    <string name="alerts_flip_forbidden">Это устройство связано как монитор и не может менять оповещения. Свяжите его заново кодом оператора в Front Desk.</string>
+    <string name="alerts_flip_failed">Не удалось изменить это оповещение: %1$s</string>
+    <string name="alerts_event_health_down">Узел недоступен</string>
+    <string name="alerts_event_health_up">Узел восстановлен</string>
+    <string name="alerts_event_config_sync_failed">Сбой синхронизации конфигурации</string>
+    <string name="alerts_event_config_synced">Конфигурация синхронизирована</string>
+    <string name="alerts_event_config_auto_synced">Конфигурация синхронизирована автоматически</string>
+    <string name="alerts_event_version_fetch_failed">Сбой чтения версии</string>
+    <string name="alerts_event_version_fetch_recovered">Чтение версии восстановлено</string>
+    <string name="alerts_event_traefik_stale">Конфигурация Traefik устарела</string>
+    <string name="alerts_event_member_added">Узел добавлен</string>
+    <string name="alerts_event_member_removed">Узел удалён</string>
+    <string name="alerts_event_member_state_changed">Узел выведен или активирован</string>
+
+    <!-- App lock -->
+    <string name="lock_title">Bellhop заблокирован</string>
+    <string name="lock_subtitle">Разблокируйте, чтобы увидеть флот.</string>
+    <string name="lock_unlock">Разблокировать</string>
+    <string name="lock_prompt_title">Разблокировать Bellhop</string>
+    <string name="lock_prompt_subtitle">Подтвердите, что это вы, чтобы увидеть флот.</string>
+    <string name="operator_prompt_title">Подтвердите действие оператора</string>
+    <string name="operator_prompt_subtitle">Подтвердите, что это вы, прежде чем менять флот.</string>
+
+    <!-- Settings -->
+    <string name="settings_open">Настройки</string>
+    <string name="settings_title">Настройки</string>
+    <string name="settings_back">Назад</string>
+    <string name="settings_language">Язык</string>
+    <string name="language_system_default">Системный по умолчанию</string>
+    <string name="settings_fd_title">Связанный Front Desk</string>
+    <string name="settings_fd_linked_on">Связано %1$s</string>
+    <string name="settings_fd_copy_title">Скопировать адрес?</string>
+    <string name="settings_fd_copy_body">Скопировать %1$s в буфер обмена?</string>
+    <string name="settings_fd_copied">Адрес скопирован в буфер обмена</string>
+    <string name="common_copy">Копировать</string>
+    <string name="settings_hold_copy_title">Удерживать для копирования</string>
+    <string name="settings_hold_copy_subtitle">Когда включено, удерживайте ячейку события или узла, чтобы скопировать её в буфер обмена. Когда выключено, ячейки нельзя копировать.</string>
+    <string name="settings_lock_title">Блокировка приложения</string>
+    <string name="settings_lock_subtitle">Требовать отпечаток пальца или PIN устройства для открытия Bellhop.</string>
+    <string name="settings_lock_unavailable">Настройте отпечаток пальца или блокировку экрана на этом устройстве, чтобы включить блокировку приложения.</string>
+    <string name="settings_lock_window">Блокировать после бездействия</string>
+    <string name="settings_lock_now">Сейчас</string>
+    <string name="settings_lock_1m">1 мин</string>
+    <string name="settings_lock_5m">5 мин</string>
+    <string name="settings_lock_15m">15 мин</string>
+    <string name="settings_lock_30m">30 мин</string>
+    <string name="settings_lock_1h">1 ч</string>
+    <string name="settings_alerts_title">Оповещения</string>
+    <string name="settings_alerts_subtitle">Доставка уведомлений и о чём оповещает Front Desk.</string>
+    <!-- Accessibility label for a severity count badge on the Alerts pill, e.g. "2 error enabled". -->
+    <string name="settings_alerts_badge_desc">%1$d %2$s включено</string>
+    <string name="settings_monitor_title">Фоновый мониторинг</string>
+    <string name="settings_monitor_subtitle">Проверяет флот каждые 15 минут и уведомляет вас здесь, когда узел падает или восстанавливается, даже когда Bellhop закрыт.</string>
+    <string name="settings_monitor_note">Собственные оповещения Front Desk быстрее; это подстраховка на случай, когда Bellhop — ваш единственный обзор. Проверка примерно каждые 15 минут, поэтому изменение может прийти с такой задержкой.</string>
+    <string name="settings_monitor_blocked">Уведомления для Bellhop отключены, поэтому эти оповещения до вас не дойдут. Включите их в системных настройках.</string>
+    <string name="settings_push_title">Push в реальном времени</string>
+    <string name="settings_push_subtitle">Будит Bellhop в момент, когда Front Desk отправляет оповещение, через UnifiedPush и ntfy. Без Google, без задержки опроса, по желанию.</string>
+    <string name="settings_push_no_distributor">Установите распространитель UnifiedPush, например ntfy, чтобы получать push-уведомления. Без него это остаётся неактивным, пока вы его не добавите.</string>
+    <string name="settings_push_endpoint_label">Push-тема для Front Desk</string>
+    <string name="settings_push_endpoint_waiting">Ожидание, пока распространитель вернёт push-тему…</string>
+    <string name="settings_push_endpoint_note">Вставьте это в Front Desk → Настройки → Оповещения как тему телефона, чтобы его оповещения будили Bellhop.</string>
+    <string name="settings_push_copy">Копировать push-тему</string>
+    <string name="settings_push_copied">Push-тема скопирована</string>
+    <string name="settings_push_blocked">Уведомления для Bellhop отключены, поэтому push-уведомления не могут до вас дойти. Включите их в системных настройках.</string>
+
+    <!-- Background-monitoring notifications (Layer 2 backstop) -->
+    <string name="notif_channel_down">Узел недоступен</string>
+    <string name="notif_channel_up">Узел восстановлен</string>
+    <string name="notif_down_title">%1$s недоступен</string>
+    <string name="notif_down_body">Узел перестал отвечать. Нажмите, чтобы открыть Bellhop.</string>
+    <string name="notif_up_title">%1$s восстановлен</string>
+    <string name="notif_up_body">Узел снова отвечает.</string>
+    <string name="notif_channel_stale">Расхождение конфигурации</string>
+    <string name="notif_stale_title">Флот может расходиться</string>
+    <string name="notif_stale_body">Автосинхронизация отключена, и флот не синхронизировался больше суток. Нажмите, чтобы открыть Bellhop.</string>
+    <string name="notif_stale_resumed_title">Автосинхронизация возобновлена</string>
+    <string name="notif_stale_resumed_body">Флот снова поддерживается в синхронизации.</string>
+
+    <string name="dashboard_footer">Bellhop %1$s</string>
+    <string name="dashboard_unlink">Отвязать</string>
+    <string name="dashboard_unlink_confirm_title">Отвязать это устройство?</string>
+    <string name="dashboard_unlink_confirm_body">Это устройство перестанет отслеживать %1$s, и его токен будет отозван. Вы можете связать заново в любое время с новым кодом.</string>
+    <string name="dashboard_unlink_failed_title">Не удалось связаться с Front Desk</string>
+    <string name="dashboard_unlink_failed_body">Это устройство всё ещё связано, и ничего не было отозвано. Проверьте соединение и повторите попытку. Вы всё равно можете отвязать здесь, но Front Desk может по-прежнему показывать это устройство, поэтому отзовите его в Front Desk → Настройки → Связанные устройства.</string>
+    <string name="dashboard_unlink_retry">Повторить</string>
+    <string name="dashboard_unlink_force">Всё равно отвязать</string>
+    <string name="common_cancel">Отмена</string>
+</resources>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -197,4 +197,23 @@
     <string name="dashboard_unlink_retry">Повторить</string>
     <string name="dashboard_unlink_force">Всё равно отвязать</string>
     <string name="common_cancel">Отмена</string>
+    <string name="time_just_now">только что</string>
+    <plurals name="time_min_ago">
+        <item quantity="one">%d минуту назад</item>
+        <item quantity="few">%d минуты назад</item>
+        <item quantity="many">%d минут назад</item>
+        <item quantity="other">%d минуты назад</item>
+    </plurals>
+    <plurals name="time_hr_ago">
+        <item quantity="one">%d час назад</item>
+        <item quantity="few">%d часа назад</item>
+        <item quantity="many">%d часов назад</item>
+        <item quantity="other">%d часа назад</item>
+    </plurals>
+    <plurals name="time_day_ago">
+        <item quantity="one">%d день назад</item>
+        <item quantity="few">%d дня назад</item>
+        <item quantity="many">%d дней назад</item>
+        <item quantity="other">%d дня назад</item>
+    </plurals>
 </resources>

--- a/android/app/src/main/res/values-sk/strings.xml
+++ b/android/app/src/main/res/values-sk/strings.xml
@@ -197,4 +197,23 @@
     <string name="dashboard_unlink_retry">Skúsiť znova</string>
     <string name="dashboard_unlink_force">Napriek tomu zrušiť prepojenie</string>
     <string name="common_cancel">Zrušiť</string>
+    <string name="time_just_now">práve teraz</string>
+    <plurals name="time_min_ago">
+        <item quantity="one">pred %d min</item>
+        <item quantity="few">pred %d min</item>
+        <item quantity="many">pred %d min</item>
+        <item quantity="other">pred %d min</item>
+    </plurals>
+    <plurals name="time_hr_ago">
+        <item quantity="one">pred %d h</item>
+        <item quantity="few">pred %d h</item>
+        <item quantity="many">pred %d h</item>
+        <item quantity="other">pred %d h</item>
+    </plurals>
+    <plurals name="time_day_ago">
+        <item quantity="one">pred %d dňom</item>
+        <item quantity="few">pred %d dňami</item>
+        <item quantity="many">pred %d dňa</item>
+        <item quantity="other">pred %d dňami</item>
+    </plurals>
 </resources>

--- a/android/app/src/main/res/values-sk/strings.xml
+++ b/android/app/src/main/res/values-sk/strings.xml
@@ -1,0 +1,200 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- Pairing (unlinked state) -->
+    <string name="pairing_title">Prepojiť Front Desk</string>
+    <string name="pairing_subtitle">Vo Front Desku otvorte Nastavenia → Spárované zariadenia a vygenerujte kód. Naskenujte zobrazený QR kód, alebo skopírujte párovací reťazec vedľa neho a vložte ho nižšie.</string>
+    <string name="pairing_scan">Naskenovať QR kód</string>
+    <string name="pairing_scan_prompt">Zamierte na párovací QR vo Front Desku\n→ Nastavenia → Spárované zariadenia</string>
+    <string name="pairing_or">alebo ho vložte</string>
+    <string name="pairing_paste_label">Párovací reťazec</string>
+    <string name="pairing_paste_hint">Sem vložte skopírovaný párovací reťazec</string>
+    <string name="pairing_target">Front Desk: %1$s\n%2$s</string>
+    <string name="pairing_label_label">Názov tohto zariadenia</string>
+    <string name="pairing_submit">Spárovať</string>
+    <string name="pairing_error_bad_string">Toto nevyzerá ako párovací reťazec. Skopírujte ho znova z Front Desku → Nastavenia → Spárované zariadenia.</string>
+    <string name="pairing_error_invalid_code">Neplatný alebo vypršaný párovací kód. Vygenerujte nový vo Front Desku a vložte nový reťazec.</string>
+    <string name="pairing_error_scan_unavailable">Fotoaparát sa nepodarilo otvoriť, takže skenovanie nie je dostupné. Povoľte prístup k fotoaparátu, alebo namiesto toho vložte párovací reťazec nižšie.</string>
+
+    <!-- Dashboard (linked state) -->
+    <string name="dashboard_linked_as">Prepojené ako %1$s (%2$s)</string>
+    <string name="dashboard_summary_all_up">Všetci členovia bežia</string>
+    <string name="dashboard_summary_down">%1$d z %2$d členov je mimo prevádzky</string>
+    <string name="dashboard_summary_checking">Kontrola členov…</string>
+    <string name="dashboard_empty">Zatiaľ žiadni členovia. Pridajte ich vo Front Desku.</string>
+    <string name="dashboard_refresh_failed">Nepodarilo sa obnoviť: %1$s</string>
+    <string name="dashboard_revoked">Toto zariadenie sa už nemôže overiť u Front Desku. Jeho prístup mohol byť odvolaný; zrušte prepojenie a spárujte znova s novým kódom.</string>
+    <string name="member_health_up">Beží · %1$d ms</string>
+    <string name="member_health_down">Mimo prevádzky</string>
+    <string name="member_health_unknown">Zatiaľ neskontrolované</string>
+    <string name="member_traefik">Traefik %1$s</string>
+    <string name="member_state_drained">Odstavené</string>
+    <string name="member_primary">Primárny</string>
+    <!-- Member detail -->
+    <string name="member_detail_back">Späť</string>
+    <string name="member_detail_traffic_title">Prevádzka · posledných %1$d min</string>
+    <string name="member_detail_traffic_totals">%1$d požiadaviek · %2$d chýb</string>
+    <string name="member_detail_traffic_unreachable">Prevádzka nie je dostupná. Front Desk možno nemá pre tohto člena admin token, alebo člen neodpovedal.</string>
+    <string name="member_detail_traffic_empty">V tomto okne žiadne požiadavky.</string>
+    <string name="member_detail_events_title">Nedávne udalosti</string>
+    <string name="member_detail_no_events">Pre tohto člena žiadne nedávne udalosti.</string>
+    <string name="member_detail_label_address">Adresa</string>
+    <string name="member_detail_label_synced">Synchronizované</string>
+    <string name="member_detail_label_reason">Dôvod</string>
+    <string name="member_detail_label_verified">Overené</string>
+    <string name="member_detail_label_added">Pridané</string>
+    <string name="member_url_title">Otvoriť adresu člena</string>
+    <string name="member_url_open">Otvoriť</string>
+    <string name="open_url_title">Otvoriť odkaz</string>
+    <!-- Operator actions -->
+    <string name="member_op_title">Ovládanie operátora</string>
+    <string name="member_op_drain">Odstaviť</string>
+    <string name="member_op_activate">Aktivovať</string>
+    <string name="member_op_draining">Odstavovanie… čaká sa, kým sa flotila zosúladí.</string>
+    <string name="member_op_activating">Aktivácia… čaká sa, kým sa flotila zosúladí.</string>
+    <string name="member_op_sync">Synchronizovať konfiguráciu flotily</string>
+    <string name="member_op_synced">Synchronizovaných %1$d členov z primárneho.</string>
+    <string name="member_op_sync_failed">Synchronizácia skončila s %1$d z %2$d neúspešných členov.</string>
+    <string name="member_op_error">Nepodarilo sa použiť: %1$s</string>
+    <string name="member_op_dismiss">Zavrieť</string>
+    <string name="member_op_last_sync">Posledná zmena konfigurácie synchronizovaná %1$s</string>
+    <string name="member_op_busy">Ešte beží iná akcia. Počkajte, kým skončí, a skúste to znova.</string>
+    <string name="member_op_forbidden">Toto zariadenie je spárované ako monitor a nemôže meniť flotilu. Spárujte ho znova s operátorským kódom vo Front Desku, aby ste mohli odstaviť, aktivovať alebo synchronizovať.</string>
+
+    <!-- Pause/resume auto-sync (dashboard operator control) -->
+    <string name="autosync_title">Automatická synchronizácia</string>
+    <string name="autosync_on">Flotila zostáva synchronizovaná s primárnym.</string>
+    <string name="autosync_off">Flotila sa nebude synchronizovať, kým neobnovíte.</string>
+    <string name="autosync_pausing">Pozastavovanie…</string>
+    <string name="autosync_resuming">Obnovovanie…</string>
+    <string name="autosync_busy">Ešte beží iná akcia. Počkajte, kým skončí, a skúste to znova.</string>
+    <string name="autosync_error">Nepodarilo sa použiť: %1$s</string>
+    <string name="autosync_forbidden">Toto zariadenie je spárované ako monitor a nemôže meniť automatickú synchronizáciu. Spárujte ho znova s operátorským kódom vo Front Desku.</string>
+
+    <!-- Events -->
+    <string name="events_title">Udalosti</string>
+    <string name="events_open">Udalosti</string>
+    <string name="events_back">Späť</string>
+    <string name="events_empty">Žiadne zodpovedajúce udalosti.</string>
+    <string name="events_copied">Udalosť skopírovaná do schránky</string>
+    <string name="dashboard_member_copied">Člen skopírovaný do schránky</string>
+    <string name="scroll_to_top">Prejsť nahor</string>
+    <plurals name="events_total">
+        <item quantity="one">%1$d udalosť</item>
+        <item quantity="few">%1$d udalosti</item>
+        <item quantity="many">%1$d udalosti</item>
+        <item quantity="other">%1$d udalostí</item>
+    </plurals>
+    <string name="events_sev_all">Všetko</string>
+    <string name="events_sev_info">Info</string>
+    <string name="events_sev_success">Úspech</string>
+    <string name="events_sev_warning">Varovanie</string>
+    <string name="events_sev_error">Chyba</string>
+    <string name="events_range_all">Celý čas</string>
+    <string name="events_range_1h">1 h</string>
+    <string name="events_range_24h">24 h</string>
+    <string name="events_range_7d">7 d</string>
+    <string name="events_range_30d">30 d</string>
+    <string name="events_range_calendar">Vybrať rozsah dátumov</string>
+    <string name="events_range_clear">Vymazať rozsah dátumov</string>
+    <string name="events_range_apply">Použiť</string>
+
+    <!-- Alerts -->
+    <string name="alerts_title">Upozornenia</string>
+    <string name="alerts_open">Upozornenia</string>
+    <string name="alerts_back">Späť</string>
+    <string name="alerts_delivery_title">Doručovanie oznámení</string>
+    <string name="alerts_status_not_configured">Nenakonfigurované</string>
+    <string name="alerts_status_unreachable">Oznamovateľ nedostupný</string>
+    <string name="alerts_status_unhealthy">Oznamovateľ nefunkčný</string>
+    <string name="alerts_status_delivering">Doručuje sa</string>
+    <string name="alerts_catalog_title">Na čo Front Desk upozorňuje</string>
+    <string name="alerts_catalog_note">Prepnutím prepínača povolíte alebo stlmíte upozornenie. Zmeny sa vo Front Desku prejavia okamžite.</string>
+    <string name="alerts_flip_forbidden">Toto zariadenie je spárované ako monitor a nemôže meniť upozornenia. Spárujte ho znova s operátorským kódom vo Front Desku.</string>
+    <string name="alerts_flip_failed">Toto upozornenie sa nepodarilo zmeniť: %1$s</string>
+    <string name="alerts_event_health_down">Člen spadol</string>
+    <string name="alerts_event_health_up">Člen obnovený</string>
+    <string name="alerts_event_config_sync_failed">Synchronizácia konfigurácie zlyhala</string>
+    <string name="alerts_event_config_synced">Konfigurácia synchronizovaná</string>
+    <string name="alerts_event_config_auto_synced">Konfigurácia automaticky synchronizovaná</string>
+    <string name="alerts_event_version_fetch_failed">Čítanie verzie zlyhalo</string>
+    <string name="alerts_event_version_fetch_recovered">Čítanie verzie obnovené</string>
+    <string name="alerts_event_traefik_stale">Konfigurácia Traefiku zastaraná</string>
+    <string name="alerts_event_member_added">Člen pridaný</string>
+    <string name="alerts_event_member_removed">Člen odstránený</string>
+    <string name="alerts_event_member_state_changed">Člen odstavený alebo aktivovaný</string>
+
+    <!-- App lock -->
+    <string name="lock_title">Bellhop je uzamknutý</string>
+    <string name="lock_subtitle">Odomknite pre zobrazenie flotily.</string>
+    <string name="lock_unlock">Odomknúť</string>
+    <string name="lock_prompt_title">Odomknúť Bellhop</string>
+    <string name="lock_prompt_subtitle">Potvrďte, že ste to vy, pre zobrazenie flotily.</string>
+    <string name="operator_prompt_title">Potvrdiť operátorskú akciu</string>
+    <string name="operator_prompt_subtitle">Potvrďte, že ste to vy, skôr než zmeníte flotilu.</string>
+
+    <!-- Settings -->
+    <string name="settings_open">Nastavenia</string>
+    <string name="settings_title">Nastavenia</string>
+    <string name="settings_back">Späť</string>
+    <string name="settings_language">Jazyk</string>
+    <string name="language_system_default">Predvolené podľa systému</string>
+    <string name="settings_fd_title">Prepojený Front Desk</string>
+    <string name="settings_fd_linked_on">Prepojené %1$s</string>
+    <string name="settings_fd_copy_title">Skopírovať adresu?</string>
+    <string name="settings_fd_copy_body">Skopírovať %1$s do schránky?</string>
+    <string name="settings_fd_copied">Adresa skopírovaná do schránky</string>
+    <string name="common_copy">Kopírovať</string>
+    <string name="settings_hold_copy_title">Podržať pre kopírovanie</string>
+    <string name="settings_hold_copy_subtitle">Keď je zapnuté, dlhým stlačením bunky udalosti alebo člena ju skopírujete do schránky. Keď je vypnuté, bunky nemožno kopírovať.</string>
+    <string name="settings_lock_title">Zámok aplikácie</string>
+    <string name="settings_lock_subtitle">Vyžadovať odtlačok prsta alebo PIN zariadenia na otvorenie Bellhopu.</string>
+    <string name="settings_lock_unavailable">Nastavte na tomto zariadení odtlačok prsta alebo zámku obrazovky, aby ste povolili zámok aplikácie.</string>
+    <string name="settings_lock_window">Uzamknúť po nečinnosti</string>
+    <string name="settings_lock_now">Ihneď</string>
+    <string name="settings_lock_1m">1 min</string>
+    <string name="settings_lock_5m">5 min</string>
+    <string name="settings_lock_15m">15 min</string>
+    <string name="settings_lock_30m">30 min</string>
+    <string name="settings_lock_1h">1 h</string>
+    <string name="settings_alerts_title">Upozornenia</string>
+    <string name="settings_alerts_subtitle">Doručovanie oznámení a na čo Front Desk upozorňuje.</string>
+    <!-- Accessibility label for a severity count badge on the Alerts pill, e.g. "2 error enabled". -->
+    <string name="settings_alerts_badge_desc">%1$d %2$s povolené</string>
+    <string name="settings_monitor_title">Sledovanie na pozadí</string>
+    <string name="settings_monitor_subtitle">Kontroluje flotilu každých 15 minút a upozorní vás tu, keď člen spadne alebo sa obnoví, aj keď je Bellhop zatvorený.</string>
+    <string name="settings_monitor_note">Vlastné upozornenia Front Desku sú rýchlejšie; toto je záloha pre prípad, že je Bellhop vaším jediným pohľadom. Kontroluje zhruba každých 15 minút, takže zmena môže prísť až s týmto oneskorením.</string>
+    <string name="settings_monitor_blocked">Oznámenia pre Bellhop sú vypnuté, takže sa k vám tieto upozornenia nedostanú. Zapnite ich v nastaveniach systému.</string>
+    <string name="settings_push_title">Push v reálnom čase</string>
+    <string name="settings_push_subtitle">Zobudí Bellhop v okamihu, keď Front Desk odošle upozornenie, cez UnifiedPush a ntfy. Bez Googlu, bez oneskorenia dopytovania, dobrovoľné.</string>
+    <string name="settings_push_no_distributor">Nainštalujte distribútora UnifiedPush, napríklad ntfy, na príjem pushov. Bez neho zostane toto nečinné, kým ho nepridáte.</string>
+    <string name="settings_push_endpoint_label">Push téma pre Front Desk</string>
+    <string name="settings_push_endpoint_waiting">Čaká sa, kým distribútor vráti push tému…</string>
+    <string name="settings_push_endpoint_note">Vložte toto do Front Desku → Nastavenia → Upozornenia ako tému telefónu, aby jeho upozornenia zobúdzali Bellhop.</string>
+    <string name="settings_push_copy">Kopírovať push tému</string>
+    <string name="settings_push_copied">Push téma skopírovaná</string>
+    <string name="settings_push_blocked">Oznámenia pre Bellhop sú vypnuté, takže sa k vám pushe nedostanú. Zapnite ich v nastaveniach systému.</string>
+
+    <!-- Background-monitoring notifications (Layer 2 backstop) -->
+    <string name="notif_channel_down">Člen mimo prevádzky</string>
+    <string name="notif_channel_up">Člen obnovený</string>
+    <string name="notif_down_title">%1$s je mimo prevádzky</string>
+    <string name="notif_down_body">Člen prestal odpovedať. Ťuknutím otvorte Bellhop.</string>
+    <string name="notif_up_title">%1$s obnovený</string>
+    <string name="notif_up_body">Člen opäť odpovedá.</string>
+    <string name="notif_channel_stale">Odchýlka konfigurácie</string>
+    <string name="notif_stale_title">Flotila sa možno odchyľuje</string>
+    <string name="notif_stale_body">Automatická synchronizácia je vypnutá a flotila sa nesynchronizovala už viac ako deň. Ťuknutím otvorte Bellhop.</string>
+    <string name="notif_stale_resumed_title">Automatická synchronizácia obnovená</string>
+    <string name="notif_stale_resumed_body">Flotila je opäť udržiavaná synchronizovaná.</string>
+
+    <string name="dashboard_footer">Bellhop %1$s</string>
+    <string name="dashboard_unlink">Zrušiť prepojenie</string>
+    <string name="dashboard_unlink_confirm_title">Zrušiť prepojenie tohto zariadenia?</string>
+    <string name="dashboard_unlink_confirm_body">Toto zariadenie prestane sledovať %1$s a jeho token bude odvolaný. Kedykoľvek môžete spárovať znova s novým kódom.</string>
+    <string name="dashboard_unlink_failed_title">Nepodarilo sa spojiť s Front Deskom</string>
+    <string name="dashboard_unlink_failed_body">Toto zariadenie je stále prepojené a nič nebolo odvolané. Skontrolujte pripojenie a skúste to znova. Prepojenie tu môžete zrušiť aj tak, ale Front Desk môže toto zariadenie naďalej zobrazovať, preto ho odvolajte z Front Desku → Nastavenia → Spárované zariadenia.</string>
+    <string name="dashboard_unlink_retry">Skúsiť znova</string>
+    <string name="dashboard_unlink_force">Napriek tomu zrušiť prepojenie</string>
+    <string name="common_cancel">Zrušiť</string>
+</resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -1,0 +1,197 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- Pairing (unlinked state) -->
+    <string name="pairing_title">关联 Front Desk</string>
+    <string name="pairing_subtitle">在 Front Desk 中打开 设置 → 已配对设备 并生成一个代码。扫描显示的二维码，或复制旁边的配对字符串并粘贴到下方。</string>
+    <string name="pairing_scan">扫描二维码</string>
+    <string name="pairing_scan_prompt">对准 Front Desk 中的配对二维码\n→ 设置 → 已配对设备</string>
+    <string name="pairing_or">或粘贴</string>
+    <string name="pairing_paste_label">配对字符串</string>
+    <string name="pairing_paste_hint">在此粘贴复制的配对字符串</string>
+    <string name="pairing_target">Front Desk：%1$s\n%2$s</string>
+    <string name="pairing_label_label">此设备的名称</string>
+    <string name="pairing_submit">配对</string>
+    <string name="pairing_error_bad_string">这看起来不像配对字符串。请从 Front Desk → 设置 → 已配对设备 重新复制。</string>
+    <string name="pairing_error_invalid_code">配对代码无效或已过期。请在 Front Desk 中生成一个新代码并粘贴最新的字符串。</string>
+    <string name="pairing_error_scan_unavailable">无法打开相机，因此扫描不可用。请授予相机访问权限，或改为在下方粘贴配对字符串。</string>
+
+    <!-- Dashboard (linked state) -->
+    <string name="dashboard_linked_as">已关联为 %1$s（%2$s）</string>
+    <string name="dashboard_summary_all_up">所有成员均在运行</string>
+    <string name="dashboard_summary_down">%2$d 个成员中有 %1$d 个已宕机</string>
+    <string name="dashboard_summary_checking">正在检查成员…</string>
+    <string name="dashboard_empty">还没有成员。请在 Front Desk 中添加。</string>
+    <string name="dashboard_refresh_failed">刷新失败：%1$s</string>
+    <string name="dashboard_revoked">此设备无法再向 Front Desk 进行身份验证。其访问权限可能已被撤销；请取消关联并使用新代码重新配对。</string>
+    <string name="member_health_up">运行中 · %1$d 毫秒</string>
+    <string name="member_health_down">已宕机</string>
+    <string name="member_health_unknown">尚未检查</string>
+    <string name="member_traefik">Traefik %1$s</string>
+    <string name="member_state_drained">已排空</string>
+    <string name="member_primary">主节点</string>
+    <!-- Member detail -->
+    <string name="member_detail_back">返回</string>
+    <string name="member_detail_traffic_title">流量 · 最近 %1$d 分钟</string>
+    <string name="member_detail_traffic_totals">%1$d 个请求 · %2$d 个错误</string>
+    <string name="member_detail_traffic_unreachable">流量不可用。Front Desk 可能没有此成员的管理员令牌，或该成员未响应。</string>
+    <string name="member_detail_traffic_empty">此时段内没有请求。</string>
+    <string name="member_detail_events_title">近期事件</string>
+    <string name="member_detail_no_events">此成员没有近期事件。</string>
+    <string name="member_detail_label_address">地址</string>
+    <string name="member_detail_label_synced">已同步</string>
+    <string name="member_detail_label_reason">原因</string>
+    <string name="member_detail_label_verified">已验证</string>
+    <string name="member_detail_label_added">已添加</string>
+    <string name="member_url_title">打开成员地址</string>
+    <string name="member_url_open">打开</string>
+    <string name="open_url_title">打开链接</string>
+    <!-- Operator actions -->
+    <string name="member_op_title">操作员控制</string>
+    <string name="member_op_drain">排空</string>
+    <string name="member_op_activate">激活</string>
+    <string name="member_op_draining">正在排空… 等待集群跟上。</string>
+    <string name="member_op_activating">正在激活… 等待集群跟上。</string>
+    <string name="member_op_sync">同步集群配置</string>
+    <string name="member_op_synced">已从主节点同步 %1$d 个成员。</string>
+    <string name="member_op_sync_failed">同步完成，%2$d 个成员中有 %1$d 个失败。</string>
+    <string name="member_op_error">无法应用：%1$s</string>
+    <string name="member_op_dismiss">关闭</string>
+    <string name="member_op_last_sync">上次配置变更同步于 %1$s</string>
+    <string name="member_op_busy">另一个操作仍在进行中。请等待其完成后重试。</string>
+    <string name="member_op_forbidden">此设备以监视器身份配对，无法更改集群。请在 Front Desk 中使用操作员代码重新配对，以进行排空、激活或同步。</string>
+
+    <!-- Pause/resume auto-sync (dashboard operator control) -->
+    <string name="autosync_title">自动同步</string>
+    <string name="autosync_on">集群与主节点保持同步。</string>
+    <string name="autosync_off">在你恢复之前，集群不会同步。</string>
+    <string name="autosync_pausing">正在暂停…</string>
+    <string name="autosync_resuming">正在恢复…</string>
+    <string name="autosync_busy">另一个操作仍在进行中。请等待其完成后重试。</string>
+    <string name="autosync_error">无法应用：%1$s</string>
+    <string name="autosync_forbidden">此设备以监视器身份配对，无法更改自动同步。请在 Front Desk 中使用操作员代码重新配对。</string>
+
+    <!-- Events -->
+    <string name="events_title">事件</string>
+    <string name="events_open">事件</string>
+    <string name="events_back">返回</string>
+    <string name="events_empty">没有匹配的事件。</string>
+    <string name="events_copied">已将事件复制到剪贴板</string>
+    <string name="dashboard_member_copied">已将成员复制到剪贴板</string>
+    <string name="scroll_to_top">滚动到顶部</string>
+    <plurals name="events_total">
+        <item quantity="other">%1$d 个事件</item>
+    </plurals>
+    <string name="events_sev_all">全部</string>
+    <string name="events_sev_info">信息</string>
+    <string name="events_sev_success">成功</string>
+    <string name="events_sev_warning">警告</string>
+    <string name="events_sev_error">错误</string>
+    <string name="events_range_all">全部时间</string>
+    <string name="events_range_1h">1 小时</string>
+    <string name="events_range_24h">24 小时</string>
+    <string name="events_range_7d">7 天</string>
+    <string name="events_range_30d">30 天</string>
+    <string name="events_range_calendar">选择日期范围</string>
+    <string name="events_range_clear">清除日期范围</string>
+    <string name="events_range_apply">应用</string>
+
+    <!-- Alerts -->
+    <string name="alerts_title">警报</string>
+    <string name="alerts_open">警报</string>
+    <string name="alerts_back">返回</string>
+    <string name="alerts_delivery_title">通知投递</string>
+    <string name="alerts_status_not_configured">未配置</string>
+    <string name="alerts_status_unreachable">通知器不可达</string>
+    <string name="alerts_status_unhealthy">通知器异常</string>
+    <string name="alerts_status_delivering">投递中</string>
+    <string name="alerts_catalog_title">Front Desk 会就哪些事件发出警报</string>
+    <string name="alerts_catalog_note">拨动开关以启用或静音某个警报。更改会立即应用到 Front Desk。</string>
+    <string name="alerts_flip_forbidden">此设备以监视器身份配对，无法更改警报。请在 Front Desk 中使用操作员代码重新配对。</string>
+    <string name="alerts_flip_failed">无法更改该警报：%1$s</string>
+    <string name="alerts_event_health_down">成员宕机</string>
+    <string name="alerts_event_health_up">成员恢复</string>
+    <string name="alerts_event_config_sync_failed">配置同步失败</string>
+    <string name="alerts_event_config_synced">配置已同步</string>
+    <string name="alerts_event_config_auto_synced">配置已自动同步</string>
+    <string name="alerts_event_version_fetch_failed">版本读取失败</string>
+    <string name="alerts_event_version_fetch_recovered">版本读取已恢复</string>
+    <string name="alerts_event_traefik_stale">Traefik 配置已过时</string>
+    <string name="alerts_event_member_added">成员已添加</string>
+    <string name="alerts_event_member_removed">成员已移除</string>
+    <string name="alerts_event_member_state_changed">成员已排空或激活</string>
+
+    <!-- App lock -->
+    <string name="lock_title">Bellhop 已锁定</string>
+    <string name="lock_subtitle">解锁以查看集群。</string>
+    <string name="lock_unlock">解锁</string>
+    <string name="lock_prompt_title">解锁 Bellhop</string>
+    <string name="lock_prompt_subtitle">请确认是你本人以查看集群。</string>
+    <string name="operator_prompt_title">确认操作员操作</string>
+    <string name="operator_prompt_subtitle">在更改集群前，请确认是你本人。</string>
+
+    <!-- Settings -->
+    <string name="settings_open">设置</string>
+    <string name="settings_title">设置</string>
+    <string name="settings_back">返回</string>
+    <string name="settings_language">语言</string>
+    <string name="language_system_default">系统默认</string>
+    <string name="settings_fd_title">已关联的 Front Desk</string>
+    <string name="settings_fd_linked_on">关联于 %1$s</string>
+    <string name="settings_fd_copy_title">复制地址？</string>
+    <string name="settings_fd_copy_body">将 %1$s 复制到剪贴板？</string>
+    <string name="settings_fd_copied">已将地址复制到剪贴板</string>
+    <string name="common_copy">复制</string>
+    <string name="settings_hold_copy_title">长按以复制</string>
+    <string name="settings_hold_copy_subtitle">开启时，长按事件或成员单元格可将其复制到剪贴板。关闭时，单元格无法复制。</string>
+    <string name="settings_lock_title">应用锁</string>
+    <string name="settings_lock_subtitle">打开 Bellhop 时需要指纹或设备 PIN。</string>
+    <string name="settings_lock_unavailable">请在此设备上设置指纹或屏幕锁，以启用应用锁。</string>
+    <string name="settings_lock_window">无操作后锁定</string>
+    <string name="settings_lock_now">立即</string>
+    <string name="settings_lock_1m">1 分钟</string>
+    <string name="settings_lock_5m">5 分钟</string>
+    <string name="settings_lock_15m">15 分钟</string>
+    <string name="settings_lock_30m">30 分钟</string>
+    <string name="settings_lock_1h">1 小时</string>
+    <string name="settings_alerts_title">警报</string>
+    <string name="settings_alerts_subtitle">通知投递，以及 Front Desk 会就哪些事件发出警报。</string>
+    <!-- Accessibility label for a severity count badge on the Alerts pill, e.g. "2 error enabled". -->
+    <string name="settings_alerts_badge_desc">已启用 %1$d 个%2$s</string>
+    <string name="settings_monitor_title">后台监控</string>
+    <string name="settings_monitor_subtitle">每 15 分钟检查一次集群，并在成员宕机或恢复时在此处通知你，即使 Bellhop 已关闭。</string>
+    <string name="settings_monitor_note">Front Desk 自身的警报更快；这是在 Bellhop 是你唯一视图时的兜底。它大约每 15 分钟检查一次，因此变更最多可能延迟这么久。</string>
+    <string name="settings_monitor_blocked">Bellhop 的通知已关闭，因此这些警报无法送达。请在系统设置中开启。</string>
+    <string name="settings_push_title">实时推送</string>
+    <string name="settings_push_subtitle">在 Front Desk 发送警报的那一刻，通过 UnifiedPush 和 ntfy 唤醒 Bellhop。无需 Google，无轮询延迟，可选启用。</string>
+    <string name="settings_push_no_distributor">安装 UnifiedPush 分发器（如 ntfy）以接收推送。没有分发器时，此项在你添加之前保持未激活。</string>
+    <string name="settings_push_endpoint_label">用于 Front Desk 的推送主题</string>
+    <string name="settings_push_endpoint_waiting">正在等待分发器返回推送主题…</string>
+    <string name="settings_push_endpoint_note">将此粘贴到 Front Desk → 设置 → 警报 中作为手机主题，这样它的警报便能唤醒 Bellhop。</string>
+    <string name="settings_push_copy">复制推送主题</string>
+    <string name="settings_push_copied">已复制推送主题</string>
+    <string name="settings_push_blocked">Bellhop 的通知已关闭，因此推送无法送达。请在系统设置中开启。</string>
+
+    <!-- Background-monitoring notifications (Layer 2 backstop) -->
+    <string name="notif_channel_down">成员宕机</string>
+    <string name="notif_channel_up">成员恢复</string>
+    <string name="notif_down_title">%1$s 已宕机</string>
+    <string name="notif_down_body">某个成员已停止响应。点按以打开 Bellhop。</string>
+    <string name="notif_up_title">%1$s 已恢复</string>
+    <string name="notif_up_body">某个成员已重新响应。</string>
+    <string name="notif_channel_stale">配置漂移</string>
+    <string name="notif_stale_title">集群可能正在漂移</string>
+    <string name="notif_stale_body">自动同步已关闭，且集群已超过一天未同步。点按以打开 Bellhop。</string>
+    <string name="notif_stale_resumed_title">自动同步已恢复</string>
+    <string name="notif_stale_resumed_body">集群正再次保持同步。</string>
+
+    <string name="dashboard_footer">Bellhop %1$s</string>
+    <string name="dashboard_unlink">取消关联</string>
+    <string name="dashboard_unlink_confirm_title">取消关联此设备？</string>
+    <string name="dashboard_unlink_confirm_body">此设备将停止监控 %1$s，其令牌将被撤销。你可以随时使用新代码重新配对。</string>
+    <string name="dashboard_unlink_failed_title">无法连接 Front Desk</string>
+    <string name="dashboard_unlink_failed_body">此设备仍处于关联状态，未撤销任何内容。请检查你的连接并重试。你仍可在此取消关联，但 Front Desk 可能仍会列出此设备，因此请在 Front Desk → 设置 → 已配对设备 中撤销它。</string>
+    <string name="dashboard_unlink_retry">重试</string>
+    <string name="dashboard_unlink_force">仍然取消关联</string>
+    <string name="common_cancel">取消</string>
+</resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -194,4 +194,14 @@
     <string name="dashboard_unlink_retry">重试</string>
     <string name="dashboard_unlink_force">仍然取消关联</string>
     <string name="common_cancel">取消</string>
+    <string name="time_just_now">刚刚</string>
+    <plurals name="time_min_ago">
+        <item quantity="other">%d 分钟前</item>
+    </plurals>
+    <plurals name="time_hr_ago">
+        <item quantity="other">%d 小时前</item>
+    </plurals>
+    <plurals name="time_day_ago">
+        <item quantity="other">%d 天前</item>
+    </plurals>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -42,7 +42,7 @@
     <string name="member_detail_label_address">Address</string>
     <string name="member_detail_label_synced">Synced</string>
     <string name="member_detail_label_reason">Reason</string>
-    <string name="member_detail_label_verified">In sync</string>
+    <string name="member_detail_label_verified">Verified</string>
     <string name="member_detail_label_added">Added</string>
     <string name="member_url_title">Open member address</string>
     <string name="member_url_open">Open</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Bellhop</string>
+    <string name="app_name" translatable="false">Bellhop</string>
 
     <!-- Pairing (unlinked state) -->
     <string name="pairing_title">Link a Front Desk</string>
@@ -136,6 +136,8 @@
     <string name="settings_open">Settings</string>
     <string name="settings_title">Settings</string>
     <string name="settings_back">Back</string>
+    <string name="settings_language">Language</string>
+    <string name="language_system_default">System default</string>
     <string name="settings_fd_title">Linked Front Desk</string>
     <string name="settings_fd_linked_on">Linked on %1$s</string>
     <string name="settings_fd_copy_title">Copy address?</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -80,6 +80,20 @@
     <string name="events_copied">Event copied to clipboard</string>
     <string name="dashboard_member_copied">Member copied to clipboard</string>
     <string name="scroll_to_top">Scroll to top</string>
+    <!-- Relative age shown on member sync/verified/added rows and recent-event pills -->
+    <string name="time_just_now">just now</string>
+    <plurals name="time_min_ago">
+        <item quantity="one">%d min ago</item>
+        <item quantity="other">%d min ago</item>
+    </plurals>
+    <plurals name="time_hr_ago">
+        <item quantity="one">%d hr ago</item>
+        <item quantity="other">%d hr ago</item>
+    </plurals>
+    <plurals name="time_day_ago">
+        <item quantity="one">%d day ago</item>
+        <item quantity="other">%d days ago</item>
+    </plurals>
     <plurals name="events_total">
         <item quantity="one">%1$d event</item>
         <item quantity="other">%1$d events</item>

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/AppLocaleTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/AppLocaleTest.kt
@@ -1,10 +1,31 @@
 package com.hugalafutro.bellhop.data
 
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import java.util.Locale
 
+@RunWith(RobolectricTestRunner::class)
 class AppLocaleTest {
+    private lateinit var savedDefault: Locale
+
+    @Before
+    fun capture() {
+        // wrap() mutates the process-global default locale; snapshot it so this test
+        // can't leak German into locale-sensitive tests that run after it.
+        savedDefault = Locale.getDefault()
+    }
+
+    @After
+    fun restore() {
+        Locale.setDefault(savedDefault)
+    }
+
     @Test
     fun supportedMatchesFrontDeskSet() {
         // Bellhop offers the same limited set as Front Desk; en is the source locale.
@@ -26,5 +47,21 @@ class AppLocaleTest {
     @Test
     fun systemSentinelIsEmpty() {
         assertEquals("", AppLocale.SYSTEM)
+    }
+
+    @Test
+    fun revertingToSystemRestoresTheDefaultLocale() {
+        val context = RuntimeEnvironment.getApplication()
+        val system = context.resources.configuration.locales[0]
+
+        // Choosing a language applies it to the JVM default (the date formatters read it).
+        AppLocale.store(context, "de")
+        AppLocale.wrap(context)
+        assertEquals(Locale.GERMAN.language, Locale.getDefault().language)
+
+        // Reverting to system default must un-freeze the default, not leave it German.
+        AppLocale.store(context, AppLocale.SYSTEM)
+        AppLocale.wrap(context)
+        assertEquals(system.language, Locale.getDefault().language)
     }
 }

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/AppLocaleTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/AppLocaleTest.kt
@@ -1,0 +1,30 @@
+package com.hugalafutro.bellhop.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AppLocaleTest {
+    @Test
+    fun supportedMatchesFrontDeskSet() {
+        // Bellhop offers the same limited set as Front Desk; en is the source locale.
+        assertEquals(
+            listOf("en", "cs", "de", "es", "fr", "ja", "nl", "pl", "ru", "sk", "zh"),
+            AppLocale.SUPPORTED,
+        )
+    }
+
+    @Test
+    fun everySupportedLanguageHasAnEndonym() {
+        // The picker labels each language in its own name, so a supported tag with no
+        // endonym would render as a bare code.
+        for (tag in AppLocale.SUPPORTED) {
+            assertTrue("missing endonym for $tag", AppLocale.endonyms[tag]?.isNotBlank() == true)
+        }
+    }
+
+    @Test
+    fun systemSentinelIsEmpty() {
+        assertEquals("", AppLocale.SYSTEM)
+    }
+}

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/SyncAgeTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/SyncAgeTest.kt
@@ -4,19 +4,27 @@ import androidx.compose.ui.graphics.Color
 import com.hugalafutro.bellhop.ui.common.relativeAgo
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
 
+@RunWith(RobolectricTestRunner::class)
 class SyncAgeTest {
     private val minute = 60_000L
     private val hour = 3_600_000L
     private val day = 86_400_000L
 
+    // Robolectric's default locale is English, so relativeAgo resolves the English
+    // strings here; the localized forms are covered by the lint parity gate.
+    private val context = RuntimeEnvironment.getApplication()
+
     @Test
     fun relativeAgoReadsHumanAtEachScale() {
-        assertEquals("just now", relativeAgo(30_000L))
-        assertEquals("5 min ago", relativeAgo(5 * minute))
-        assertEquals("3 hr ago", relativeAgo(3 * hour))
-        assertEquals("1 day ago", relativeAgo(day))
-        assertEquals("3 days ago", relativeAgo(3 * day))
+        assertEquals("just now", relativeAgo(context, 30_000L))
+        assertEquals("5 min ago", relativeAgo(context, 5 * minute))
+        assertEquals("3 hr ago", relativeAgo(context, 3 * hour))
+        assertEquals("1 day ago", relativeAgo(context, day))
+        assertEquals("3 days ago", relativeAgo(context, 3 * day))
     }
 
     @Test

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreenTest.kt
@@ -236,6 +236,17 @@ class SettingsScreenTest {
     }
 
     @Test
+    fun languageIconOpensPickerWithSystemAndLanguageOptions() {
+        content()
+        composeTestRule.onNodeWithTag("settings-language").performScrollTo().performClick()
+        // The dialog offers the system default plus every supported language.
+        composeTestRule.onNodeWithTag("language-option-system").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("language-option-de").assertExists()
+        composeTestRule.onNodeWithTag("language-option-ja").assertExists()
+        composeTestRule.onNodeWithTag("language-cancel").assertExists()
+    }
+
+    @Test
     fun alertSeverityBadgesShowAllFourEvenAtZero() {
         // Only error and warning enabled; info and success still render (at 0) so the
         // pill reads as a live, tappable destination.


### PR DESCRIPTION
## What

Bellhop gets in-app localization plus a one-word clarity fix.

### 1. `In sync` → `Verified` (member card)
The member-detail card showed a `Synced <time>` stamp next to an `In sync` badge — the two read as the same thing. `Verified` names what the badge means (Front Desk confirmed this member's config against the primary). Its own commit (`b2b7749`).

### 2. In-app i18n (10 locales)
Bellhop now ships the **same language set as Front Desk** — `cs, de, es, fr, ja, nl, pl, ru, sk, zh` — plus the English source, all **hand-translated**.

- **Language picker** lives in the **top-right of Settings** (a translate glyph). The settings cog is a universal-enough entry point that the picker needn't sit on the dashboard.
- **`AppLocale`** persists the chosen tag in a small synchronous `SharedPreferences` and wraps the base context in the target locale. `MainActivity` applies it in `attachBaseContext`; picking a language `recreate()`s the activity so the whole UI re-resolves. Bellhop is a plain `FragmentActivity` (no AppCompat), so this is the base-context-wrapper approach, not `AppCompatDelegate`.
- The picker lists the system default plus each language by its own **endonym**, active one selected; a no-op pick skips the recreate.
- **`ic_translate`** is a bundled vector — Bellhop ships only `material-icons-core`, so the extended Language/Translate glyph isn't available.

## CI / locale parity
Wired into the **existing Bellhop lint job** — the repo's web "i18n Check" only covers the JS frontends. Android lint's `MissingTranslation`/`ExtraTranslation` are pinned **fatal** in `build.gradle.kts`, so a half-translated locale fails the build. All 10 locales are at full parity (171 strings each; `app_name` is `translatable="false"`).

## Verification
`:app:testDebugUnitTest` green (incl. new `AppLocaleTest` + language-picker test), `:app:ktlintCheck` clean, `:app:lintDebug` green (only benign warnings: es/fr optional CLDR `many`, pre-existing `ConstantLocale`, informational `AppBundleLocaleChanges`), `:app:assembleRelease` builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)