### PR TITLE
test(bellhop): keep SyncAge/AppLocale tests pure JVM, not Robolectric

### DIFF
--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/RelativeTime.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/RelativeTime.kt
@@ -3,23 +3,46 @@ package com.hugalafutro.bellhop.ui.common
 import android.content.Context
 import com.hugalafutro.bellhop.R
 
-// relativeAgo turns an elapsed span (millis) into a terse, localized human string:
-// "just now" under a minute, then minutes, hours, and days. It resolves strings
-// through the given context, so the wording follows the in-app language (and the
-// day count pluralizes correctly per locale). Shared by the member-detail SYNCED /
-// VERIFIED / ADDED rows and the dashboard cards' recent-event pills.
+// Ago is the bucketed elapsed span the UI shows as a relative age. It is a pure
+// value so the bucketing thresholds stay unit-testable without Android resources;
+// [relativeAgo] renders it to a localized string.
+sealed interface Ago {
+    data object JustNow : Ago
+
+    data class Minutes(val n: Int) : Ago
+
+    data class Hours(val n: Int) : Ago
+
+    data class Days(val n: Int) : Ago
+}
+
+// agoBucket picks the coarse unit for an elapsed span (millis): "just now" under a
+// minute, then whole minutes, hours, and days.
+fun agoBucket(elapsedMs: Long): Ago {
+    val minutes = (elapsedMs / 60_000L).toInt()
+    val hours = (elapsedMs / 3_600_000L).toInt()
+    val days = (elapsedMs / 86_400_000L).toInt()
+    return when {
+        minutes < 1 -> Ago.JustNow
+        minutes < 60 -> Ago.Minutes(minutes)
+        hours < 24 -> Ago.Hours(hours)
+        else -> Ago.Days(days)
+    }
+}
+
+// relativeAgo renders [agoBucket] as a terse, localized string through the given
+// context, so the wording follows the in-app language and pluralizes per locale.
+// Shared by the member-detail SYNCED / VERIFIED / ADDED rows and the dashboard
+// cards' recent-event pills.
 fun relativeAgo(
     context: Context,
     elapsedMs: Long,
 ): String {
-    val minutes = (elapsedMs / 60_000L).toInt()
-    val hours = (elapsedMs / 3_600_000L).toInt()
-    val days = (elapsedMs / 86_400_000L).toInt()
     val res = context.resources
-    return when {
-        minutes < 1 -> res.getString(R.string.time_just_now)
-        minutes < 60 -> res.getQuantityString(R.plurals.time_min_ago, minutes, minutes)
-        hours < 24 -> res.getQuantityString(R.plurals.time_hr_ago, hours, hours)
-        else -> res.getQuantityString(R.plurals.time_day_ago, days, days)
+    return when (val ago = agoBucket(elapsedMs)) {
+        Ago.JustNow -> res.getString(R.string.time_just_now)
+        is Ago.Minutes -> res.getQuantityString(R.plurals.time_min_ago, ago.n, ago.n)
+        is Ago.Hours -> res.getQuantityString(R.plurals.time_hr_ago, ago.n, ago.n)
+        is Ago.Days -> res.getQuantityString(R.plurals.time_day_ago, ago.n, ago.n)
     }
 }

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/AppLocaleTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/AppLocaleTest.kt
@@ -1,31 +1,10 @@
 package com.hugalafutro.bellhop.data
 
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
-import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
-import java.util.Locale
 
-@RunWith(RobolectricTestRunner::class)
 class AppLocaleTest {
-    private lateinit var savedDefault: Locale
-
-    @Before
-    fun capture() {
-        // wrap() mutates the process-global default locale; snapshot it so this test
-        // can't leak German into locale-sensitive tests that run after it.
-        savedDefault = Locale.getDefault()
-    }
-
-    @After
-    fun restore() {
-        Locale.setDefault(savedDefault)
-    }
-
     @Test
     fun supportedMatchesFrontDeskSet() {
         // Bellhop offers the same limited set as Front Desk; en is the source locale.
@@ -47,21 +26,5 @@ class AppLocaleTest {
     @Test
     fun systemSentinelIsEmpty() {
         assertEquals("", AppLocale.SYSTEM)
-    }
-
-    @Test
-    fun revertingToSystemRestoresTheDefaultLocale() {
-        val context = RuntimeEnvironment.getApplication()
-        val system = context.resources.configuration.locales[0]
-
-        // Choosing a language applies it to the JVM default (the date formatters read it).
-        AppLocale.store(context, "de")
-        AppLocale.wrap(context)
-        assertEquals(Locale.GERMAN.language, Locale.getDefault().language)
-
-        // Reverting to system default must un-freeze the default, not leave it German.
-        AppLocale.store(context, AppLocale.SYSTEM)
-        AppLocale.wrap(context)
-        assertEquals(system.language, Locale.getDefault().language)
     }
 }

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/AppLocaleWrapTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/AppLocaleWrapTest.kt
@@ -1,0 +1,46 @@
+package com.hugalafutro.bellhop.data
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import java.util.Locale
+
+// Isolated so the pure AppLocale checks stay fast: only wrap() needs a real
+// Context (to reach a Configuration's locale), so only this one test pays for
+// Robolectric.
+@RunWith(RobolectricTestRunner::class)
+class AppLocaleWrapTest {
+    private lateinit var savedDefault: Locale
+
+    @Before
+    fun capture() {
+        // wrap() mutates the process-global default locale; snapshot it so this test
+        // can't leak a language into locale-sensitive tests that run after it.
+        savedDefault = Locale.getDefault()
+    }
+
+    @After
+    fun restore() {
+        Locale.setDefault(savedDefault)
+    }
+
+    @Test
+    fun revertingToSystemRestoresTheDefaultLocale() {
+        val context = RuntimeEnvironment.getApplication()
+        val system = context.resources.configuration.locales[0]
+
+        // Choosing a language applies it to the JVM default (the date formatters read it).
+        AppLocale.store(context, "de")
+        AppLocale.wrap(context)
+        assertEquals(Locale.GERMAN.language, Locale.getDefault().language)
+
+        // Reverting to system default must un-freeze the default, not leave it German.
+        AppLocale.store(context, AppLocale.SYSTEM)
+        AppLocale.wrap(context)
+        assertEquals(system.language, Locale.getDefault().language)
+    }
+}

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/SyncAgeTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/SyncAgeTest.kt
@@ -1,30 +1,25 @@
 package com.hugalafutro.bellhop.ui.member
 
 import androidx.compose.ui.graphics.Color
-import com.hugalafutro.bellhop.ui.common.relativeAgo
+import com.hugalafutro.bellhop.ui.common.Ago
+import com.hugalafutro.bellhop.ui.common.agoBucket
 import org.junit.Assert.assertEquals
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 
-@RunWith(RobolectricTestRunner::class)
 class SyncAgeTest {
     private val minute = 60_000L
     private val hour = 3_600_000L
     private val day = 86_400_000L
 
-    // Robolectric's default locale is English, so relativeAgo resolves the English
-    // strings here; the localized forms are covered by the lint parity gate.
-    private val context = RuntimeEnvironment.getApplication()
-
     @Test
-    fun relativeAgoReadsHumanAtEachScale() {
-        assertEquals("just now", relativeAgo(context, 30_000L))
-        assertEquals("5 min ago", relativeAgo(context, 5 * minute))
-        assertEquals("3 hr ago", relativeAgo(context, 3 * hour))
-        assertEquals("1 day ago", relativeAgo(context, day))
-        assertEquals("3 days ago", relativeAgo(context, 3 * day))
+    fun agoBucketPicksTheRightUnitAtEachScale() {
+        // Pure bucketing (no resources): the localized wording is a thin wrapper in
+        // relativeAgo, and locale parity is enforced by lint.
+        assertEquals(Ago.JustNow, agoBucket(30_000L))
+        assertEquals(Ago.Minutes(5), agoBucket(5 * minute))
+        assertEquals(Ago.Hours(3), agoBucket(3 * hour))
+        assertEquals(Ago.Days(1), agoBucket(day))
+        assertEquals(Ago.Days(3), agoBucket(3 * day))
     }
 
     @Test


### PR DESCRIPTION
Follow-up to #444. While localizing `relativeAgo` I gave it a `Context` and, to test it, made the previously-**pure** `SyncAgeTest` (and the new `AppLocaleTest`) Robolectric — pulling Robolectric bootstrap into tests that shouldn't need it.

This splits `relativeAgo`'s pure bucketing from its resource lookup:
- New `agoBucket(elapsedMs): Ago` (sealed value) holds the thresholds; `relativeAgo` just maps `Ago` → localized string.
- `SyncAgeTest` asserts `agoBucket` and is **pure JVM** again (as before #444).
- `AppLocaleTest` (SUPPORTED / endonyms / SYSTEM) is **pure JVM** again.
- Only the `wrap()` System-default-revert check (the #444 P1) genuinely needs a `Context`, so it moves to its own `AppLocaleWrapTest` — the lone Robolectric test.

Runtime behavior is unchanged. `ktlintCheck` + `testDebugUnitTest` green.

Note: master's Android job for the #444 merge ran in **3m42s** (in line with the ~3.4-min baseline), so this is about keeping fast tests fast, not recovering a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)