### PR TITLE
feat(bellhop): sync-drift colour, version row, empty-graph state, lock FAB

### DIFF
--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
@@ -468,6 +468,7 @@ fun BellhopApp() {
                         onUnlink = { runUnlink(state.fdUrl) },
                         onForceUnlink = { forceUnlink() },
                         requireOperatorAuth = { action -> requireOperatorAuth(action) },
+                        onLock = { locked = true },
                     )
             }
         }
@@ -504,6 +505,7 @@ private fun LinkedContent(
     onUnlink: () -> Unit,
     onForceUnlink: () -> Unit,
     requireOperatorAuth: (() -> Unit) -> Unit,
+    onLock: () -> Unit,
 ) {
     // Self-heal the Layer-2 poll: periodic work persists in WorkManager on its
     // own, but re-asserting the schedule here (KEEP policy, so no interval reset)
@@ -698,6 +700,8 @@ private fun LinkedContent(
             onDismissAutoSyncError = { dashVm.dismissAutoSyncError() },
             onVisibleMembers = dashVm::setVisibleMembers,
             holdToCopy = holdToCopy,
+            lockEnabled = lockConfig.enabled,
+            onLock = onLock,
         )
     }
 }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/LockFab.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/LockFab.kt
@@ -1,0 +1,68 @@
+package com.hugalafutro.bellhop.ui.common
+
+import android.widget.Toast
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material3.FloatingActionButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.hugalafutro.bellhop.R
+
+/**
+ * LockFab is the bottom-right "lock now" control on the dashboard, shown only
+ * when the app lock is enabled in Settings. It is styled to match the
+ * [ScrollToTopButton] small FAB, but a plain tap must not lock: that would fire
+ * on any stray brush against the corner. So a tap only shows a "hold to lock"
+ * toast and a long-press actually locks, via [onLock].
+ *
+ * It is a hand-rolled small-FAB lookalike rather than a
+ * [androidx.compose.material3.SmallFloatingActionButton] because that composable
+ * exposes only onClick, and the tap/long-press split is the whole point; the
+ * shape, colour and elevation come from [FloatingActionButtonDefaults] so it
+ * still reads as the same control.
+ */
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun LockFab(
+    onLock: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    val holdHint = stringResource(R.string.lock_fab_hold_hint)
+    val label = stringResource(R.string.lock_fab_label)
+    Surface(
+        shape = FloatingActionButtonDefaults.smallShape,
+        color = MaterialTheme.colorScheme.primaryContainer,
+        contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        shadowElevation = 6.dp,
+        tonalElevation = 6.dp,
+        modifier = modifier.size(40.dp).testTag("lock-fab"),
+    ) {
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier =
+                Modifier.combinedClickable(
+                    onClick = { Toast.makeText(context, holdHint, Toast.LENGTH_SHORT).show() },
+                    onLongClickLabel = label,
+                    onLongClick = onLock,
+                ),
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Lock,
+                contentDescription = label,
+            )
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
@@ -71,6 +71,7 @@ import com.hugalafutro.bellhop.data.LinkState
 import com.hugalafutro.bellhop.data.MemberStatus
 import com.hugalafutro.bellhop.data.MemberTraffic
 import com.hugalafutro.bellhop.ui.common.ConfirmOpenUrlDialog
+import com.hugalafutro.bellhop.ui.common.LockFab
 import com.hugalafutro.bellhop.ui.common.Pill
 import com.hugalafutro.bellhop.ui.common.ScrollToTopButton
 import com.hugalafutro.bellhop.ui.common.StatusBanner
@@ -106,6 +107,10 @@ fun DashboardScreen(
     // When true, a long-press on a member card copies it to the clipboard (tap
     // still opens the member). Off leaves the card tap-only (Settings > Hold to copy).
     holdToCopy: Boolean = false,
+    // When the app lock is enabled in Settings, a bottom-right lock FAB appears;
+    // long-pressing it fires [onLock] (a tap only hints, so a stray touch can't lock).
+    lockEnabled: Boolean = false,
+    onLock: () -> Unit = {},
 ) {
     // Long-press copies a member row as text, with a toast to confirm the
     // otherwise-silent act. Gated on [holdToCopy] so it never fires by accident.
@@ -132,7 +137,12 @@ fun DashboardScreen(
         )
     }
 
-    Scaffold(modifier = modifier.fillMaxSize()) { innerPadding ->
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        // Lives in the Scaffold FAB slot so it stays bottom-right across every
+        // dashboard state (loading, empty, populated), not just the member list.
+        floatingActionButton = { if (lockEnabled) LockFab(onLock = onLock) },
+    ) { innerPadding ->
         Column(
             modifier =
                 Modifier
@@ -308,7 +318,12 @@ fun DashboardScreen(
                                 modifier = Modifier.align(Alignment.BottomCenter),
                             )
                         }
-                        ScrollToTopButton(listState = listState)
+                        ScrollToTopButton(
+                            listState = listState,
+                            // Lifted clear of the lock FAB when it's present, so the
+                            // two never stack on the same bottom-right corner.
+                            modifier = if (lockEnabled) Modifier.padding(bottom = 52.dp) else Modifier,
+                        )
                     }
                 }
             }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreen.kt
@@ -43,7 +43,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
@@ -303,10 +302,11 @@ private fun SectionHeader(
 }
 
 /**
- * MetaLedger is the info the dashboard card has no room for: the full probe
- * error when down, config-sync provenance, the in-sync heartbeat, and when the
- * member was added. Flat label/value register lines under the graph — not a
- * card — with the values in mono so timestamps and the address align. Each
+ * MetaLedger is the info the dashboard card has no room for, in read order:
+ * when the member was added, config-sync provenance, and the in-sync heartbeat
+ * — plus the full probe error when down. Flat label/value register lines under
+ * the graph — not a card — with the values in mono so timestamps and the
+ * address align. Each
  * line only shows when it has a value, so a healthy never-synced member stays
  * terse.
  */
@@ -339,7 +339,28 @@ private fun MetaLedger(
                 tag = "member-detail-down-reason",
             )
         }
+        if (member.status.version.isNotBlank()) {
+            // Build the member reports running — the dashboard card shows it, so the
+            // detail screen carries it too. Static identity, no age suffix.
+            LedgerRow(
+                label = stringResource(R.string.member_detail_label_version),
+                value = member.status.version,
+                tag = "member-detail-version",
+            )
+        }
+        if (member.createdAt.isNotBlank()) {
+            LedgerRow(
+                label = stringResource(R.string.member_detail_label_added),
+                value = formatEventTime(member.createdAt),
+                trailing = remember(member.createdAt, context) { ageParenthetical(context, member.createdAt) },
+                tag = "member-detail-created",
+            )
+        }
         if (member.lastConfigSyncAt.isNotBlank()) {
+            // Provenance, not health: the SYNCED stamp only moves on a real config
+            // write, so a member whose config has simply been stable legitimately
+            // reads old here. Kept muted — staleness that actually means something
+            // lives on VERIFIED below, where a frozen heartbeat signals drift.
             LedgerRow(
                 label = stringResource(R.string.member_detail_label_synced),
                 value = formatEventTime(member.lastConfigSyncAt),
@@ -348,7 +369,6 @@ private fun MetaLedger(
                         member.lastConfigSyncAt,
                         context,
                     ) { ageParenthetical(context, member.lastConfigSyncAt) },
-                trailingColor = syncAgeColorFor(member.lastConfigSyncAt),
                 tag = "member-detail-synced",
             )
             if (member.lastConfigSyncReason.isNotBlank()) {
@@ -362,6 +382,11 @@ private fun MetaLedger(
             }
         }
         if (member.status.autoSyncVerifiedAt.isNotBlank()) {
+            // The live in-sync heartbeat: it advances on every auto-sync tick while
+            // the member is reachable and freezes the moment it isn't — or auto-sync
+            // is paused/left off. That makes its age the honest drift signal, so this
+            // is the row whose suffix grades toward red: a stale VERIFIED is the cue
+            // the fleet MIGHT have drifted, not a week-old config that never changed.
             LedgerRow(
                 label = stringResource(R.string.member_detail_label_verified),
                 value = formatEventTime(member.status.autoSyncVerifiedAt),
@@ -369,15 +394,8 @@ private fun MetaLedger(
                     remember(member.status.autoSyncVerifiedAt, context) {
                         ageParenthetical(context, member.status.autoSyncVerifiedAt)
                     },
+                trailingColor = syncAgeColorFor(member.status.autoSyncVerifiedAt),
                 tag = "member-detail-verified",
-            )
-        }
-        if (member.createdAt.isNotBlank()) {
-            LedgerRow(
-                label = stringResource(R.string.member_detail_label_added),
-                value = formatEventTime(member.createdAt),
-                trailing = remember(member.createdAt, context) { ageParenthetical(context, member.createdAt) },
-                tag = "member-detail-created",
             )
         }
     }
@@ -399,7 +417,7 @@ private fun LedgerRow(
     // Right-aligned relative-age suffix (e.g. "(3 days ago)") for the date rows;
     // null omits it. The value keeps the left, weight(1f) pushes this to the right
     // edge, so the suffixes line up in their own column. [trailingColor] tints it —
-    // the SYNCED row grades it by staleness, the others use the muted default.
+    // the VERIFIED row grades it by staleness, the others use the muted default.
     trailing: String? = null,
     trailingColor: Color? = null,
 ) {
@@ -442,7 +460,8 @@ private val SyncAgeRed = Color(0xFFC62828)
 
 // ageParenthetical is the right-aligned relative-age suffix a date row shows,
 // e.g. "(3 days ago)", or null when the timestamp can't be parsed (the row then
-// just shows the date). Shared by the SYNCED, VERIFIED and ADDED rows.
+// just shows the date). Shared by the SYNCED, VERIFIED and ADDED rows and the
+// operator "last config change synced" line.
 private fun ageParenthetical(
     context: Context,
     timestamp: String,
@@ -457,7 +476,7 @@ private fun ageParenthetical(
     return "(" + relativeAgo(context, (now - ts).coerceAtLeast(0L)) + ")"
 }
 
-// syncAgeColorFor grades the SYNCED row's age suffix by staleness (see
+// syncAgeColorFor grades the VERIFIED row's age suffix by staleness (see
 // [syncAgeColor]); the other date rows leave [trailingColor] null (muted default).
 // Falls back to the muted colour on an unparseable stamp, though the suffix is
 // then absent anyway.
@@ -476,19 +495,20 @@ private fun syncAgeColorFor(
     return syncAgeColor((now - ts).coerceAtLeast(0L), MaterialTheme.colorScheme.onSurface)
 }
 
-// syncAgeColor grades the age suffix from [base] (fresh) through amber to orange
-// as it nears a week, then red at a week or older.
+// syncAgeColor bands the age suffix by how long the verify heartbeat has been
+// frozen: [base] while it is fresh (under an hour, still ticking), amber past an
+// hour, orange from the 2nd day, red from the 3rd day on. Discrete stops, not a
+// gradient — the point is to snap to a band the moment auto-sync stops ticking.
 internal fun syncAgeColor(
     elapsedMs: Long,
     base: Color,
 ): Color {
-    val days = elapsedMs / 86_400_000.0
-    if (days >= 7.0) return SyncAgeRed
-    val f = (days / 7.0).coerceIn(0.0, 1.0).toFloat()
-    return if (f < 0.5f) {
-        lerp(base, SyncAgeYellow, f / 0.5f)
-    } else {
-        lerp(SyncAgeYellow, SyncAgeOrange, (f - 0.5f) / 0.5f)
+    val hours = elapsedMs / 3_600_000.0
+    return when {
+        hours >= 72.0 -> SyncAgeRed // 3+ days without a verified tick
+        hours >= 48.0 -> SyncAgeOrange // into the 2nd day
+        hours >= 1.0 -> SyncAgeYellow // more than an hour stale
+        else -> base // fresh — heartbeat is ticking
     }
 }
 
@@ -514,6 +534,7 @@ private fun OperatorControls(
     onDismissActionError: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val context = LocalContext.current
     Column(
         modifier = modifier.fillMaxWidth().testTag("member-operator-card"),
         verticalArrangement = Arrangement.spacedBy(8.dp),
@@ -574,12 +595,27 @@ private fun OperatorControls(
         if (isPrimary && lastFleetSyncAt.isNotBlank()) {
             // When a sync last actually wrote config somewhere, not when the
             // button was last pressed; a run that changed nothing doesn't move it.
-            Text(
-                text = stringResource(R.string.member_op_last_sync, formatEventTime(lastFleetSyncAt)),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.testTag("member-op-last-sync"),
-            )
+            // The relative age sits right-aligned in its own column, matching the
+            // ledger's ADDED row, so "how long ago" reads without decoding the date.
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth().testTag("member-op-last-sync"),
+            ) {
+                Text(
+                    text = stringResource(R.string.member_op_last_sync, formatEventTime(lastFleetSyncAt)),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.weight(1f),
+                )
+                ageParenthetical(context, lastFleetSyncAt)?.let { age ->
+                    Text(
+                        text = age,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(start = 8.dp),
+                    )
+                }
+            }
         }
         if (action.pendingState != null) {
             Text(
@@ -678,13 +714,21 @@ private fun TrafficCard(
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier = Modifier.testTag("member-traffic-unreachable"),
                     )
-                traffic.points.isEmpty() ->
-                    Text(
-                        text = stringResource(R.string.member_detail_traffic_empty),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.testTag("member-traffic-empty"),
-                    )
+                traffic.points.isEmpty() || traffic.totalRequests == 0 ->
+                    // No buckets at all, or buckets that are all zero: the bar chart
+                    // would just be a flat idle stub along the bottom, which reads as
+                    // "broken" rather than "quiet". Show a dimmed label centred in the
+                    // same graph-height box instead, so the empty state is unmistakable.
+                    Box(
+                        modifier = Modifier.fillMaxWidth().height(140.dp).testTag("member-traffic-empty"),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Text(
+                            text = stringResource(R.string.member_detail_traffic_empty),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
                 else -> {
                     Text(
                         text =

--- a/android/app/src/main/res/values-cs/strings.xml
+++ b/android/app/src/main/res/values-cs/strings.xml
@@ -43,6 +43,7 @@
     <string name="member_detail_label_reason">Důvod</string>
     <string name="member_detail_label_verified">Ověřeno</string>
     <string name="member_detail_label_added">Přidáno</string>
+    <string name="member_detail_label_version">Verze</string>
     <string name="member_url_title">Otevřít adresu člena</string>
     <string name="member_url_open">Otevřít</string>
     <string name="open_url_title">Otevřít odkaz</string>
@@ -79,6 +80,8 @@
     <string name="events_copied">Událost zkopírována do schránky</string>
     <string name="dashboard_member_copied">Člen zkopírován do schránky</string>
     <string name="scroll_to_top">Přejít nahoru</string>
+    <string name="lock_fab_label">Zamknout aplikaci</string>
+    <string name="lock_fab_hold_hint">Podržením zamknete</string>
     <plurals name="events_total">
         <item quantity="one">%1$d událost</item>
         <item quantity="few">%1$d události</item>

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -43,6 +43,7 @@
     <string name="member_detail_label_reason">Grund</string>
     <string name="member_detail_label_verified">Verifiziert</string>
     <string name="member_detail_label_added">Hinzugefügt</string>
+    <string name="member_detail_label_version">Version</string>
     <string name="member_url_title">Mitgliedsadresse öffnen</string>
     <string name="member_url_open">Öffnen</string>
     <string name="open_url_title">Link öffnen</string>
@@ -79,6 +80,8 @@
     <string name="events_copied">Ereignis in die Zwischenablage kopiert</string>
     <string name="dashboard_member_copied">Mitglied in die Zwischenablage kopiert</string>
     <string name="scroll_to_top">Nach oben scrollen</string>
+    <string name="lock_fab_label">App sperren</string>
+    <string name="lock_fab_hold_hint">Zum Sperren halten</string>
     <plurals name="events_total">
         <item quantity="one">%1$d Ereignis</item>
         <item quantity="other">%1$d Ereignisse</item>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -43,6 +43,7 @@
     <string name="member_detail_label_reason">Motivo</string>
     <string name="member_detail_label_verified">Verificado</string>
     <string name="member_detail_label_added">Añadido</string>
+    <string name="member_detail_label_version">Versión</string>
     <string name="member_url_title">Abrir dirección del miembro</string>
     <string name="member_url_open">Abrir</string>
     <string name="open_url_title">Abrir enlace</string>
@@ -79,6 +80,8 @@
     <string name="events_copied">Evento copiado al portapapeles</string>
     <string name="dashboard_member_copied">Miembro copiado al portapapeles</string>
     <string name="scroll_to_top">Desplazar arriba</string>
+    <string name="lock_fab_label">Bloquear la app</string>
+    <string name="lock_fab_hold_hint">Mantén pulsado para bloquear</string>
     <plurals name="events_total">
         <item quantity="one">%1$d evento</item>
         <item quantity="other">%1$d eventos</item>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -43,6 +43,7 @@
     <string name="member_detail_label_reason">Raison</string>
     <string name="member_detail_label_verified">Vérifié</string>
     <string name="member_detail_label_added">Ajouté</string>
+    <string name="member_detail_label_version">Version</string>
     <string name="member_url_title">Ouvrir l\'adresse du membre</string>
     <string name="member_url_open">Ouvrir</string>
     <string name="open_url_title">Ouvrir le lien</string>
@@ -79,6 +80,8 @@
     <string name="events_copied">Événement copié dans le presse-papiers</string>
     <string name="dashboard_member_copied">Membre copié dans le presse-papiers</string>
     <string name="scroll_to_top">Défiler vers le haut</string>
+    <string name="lock_fab_label">Verrouiller l\'appli</string>
+    <string name="lock_fab_hold_hint">Maintenir pour verrouiller</string>
     <plurals name="events_total">
         <item quantity="one">%1$d événement</item>
         <item quantity="other">%1$d événements</item>

--- a/android/app/src/main/res/values-ja/strings.xml
+++ b/android/app/src/main/res/values-ja/strings.xml
@@ -43,6 +43,7 @@
     <string name="member_detail_label_reason">理由</string>
     <string name="member_detail_label_verified">検証済み</string>
     <string name="member_detail_label_added">追加</string>
+    <string name="member_detail_label_version">バージョン</string>
     <string name="member_url_title">メンバーのアドレスを開く</string>
     <string name="member_url_open">開く</string>
     <string name="open_url_title">リンクを開く</string>
@@ -79,6 +80,8 @@
     <string name="events_copied">イベントをクリップボードにコピーしました</string>
     <string name="dashboard_member_copied">メンバーをクリップボードにコピーしました</string>
     <string name="scroll_to_top">上にスクロール</string>
+    <string name="lock_fab_label">アプリをロック</string>
+    <string name="lock_fab_hold_hint">長押しでロック</string>
     <plurals name="events_total">
         <item quantity="other">%1$d 件のイベント</item>
     </plurals>

--- a/android/app/src/main/res/values-nl/strings.xml
+++ b/android/app/src/main/res/values-nl/strings.xml
@@ -43,6 +43,7 @@
     <string name="member_detail_label_reason">Reden</string>
     <string name="member_detail_label_verified">Geverifieerd</string>
     <string name="member_detail_label_added">Toegevoegd</string>
+    <string name="member_detail_label_version">Versie</string>
     <string name="member_url_title">Lidadres openen</string>
     <string name="member_url_open">Openen</string>
     <string name="open_url_title">Link openen</string>
@@ -79,6 +80,8 @@
     <string name="events_copied">Gebeurtenis gekopieerd naar klembord</string>
     <string name="dashboard_member_copied">Lid gekopieerd naar klembord</string>
     <string name="scroll_to_top">Naar boven scrollen</string>
+    <string name="lock_fab_label">App vergrendelen</string>
+    <string name="lock_fab_hold_hint">Ingedrukt houden om te vergrendelen</string>
     <plurals name="events_total">
         <item quantity="one">%1$d gebeurtenis</item>
         <item quantity="other">%1$d gebeurtenissen</item>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -43,6 +43,7 @@
     <string name="member_detail_label_reason">Powód</string>
     <string name="member_detail_label_verified">Zweryfikowano</string>
     <string name="member_detail_label_added">Dodano</string>
+    <string name="member_detail_label_version">Wersja</string>
     <string name="member_url_title">Otwórz adres węzła</string>
     <string name="member_url_open">Otwórz</string>
     <string name="open_url_title">Otwórz link</string>
@@ -79,6 +80,8 @@
     <string name="events_copied">Skopiowano zdarzenie do schowka</string>
     <string name="dashboard_member_copied">Skopiowano węzeł do schowka</string>
     <string name="scroll_to_top">Przewiń do góry</string>
+    <string name="lock_fab_label">Zablokuj aplikację</string>
+    <string name="lock_fab_hold_hint">Przytrzymaj, aby zablokować</string>
     <plurals name="events_total">
         <item quantity="one">%1$d zdarzenie</item>
         <item quantity="few">%1$d zdarzenia</item>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -43,6 +43,7 @@
     <string name="member_detail_label_reason">Причина</string>
     <string name="member_detail_label_verified">Проверено</string>
     <string name="member_detail_label_added">Добавлено</string>
+    <string name="member_detail_label_version">Версия</string>
     <string name="member_url_title">Открыть адрес узла</string>
     <string name="member_url_open">Открыть</string>
     <string name="open_url_title">Открыть ссылку</string>
@@ -79,6 +80,8 @@
     <string name="events_copied">Событие скопировано в буфер обмена</string>
     <string name="dashboard_member_copied">Узел скопирован в буфер обмена</string>
     <string name="scroll_to_top">Прокрутить вверх</string>
+    <string name="lock_fab_label">Заблокировать приложение</string>
+    <string name="lock_fab_hold_hint">Удерживайте, чтобы заблокировать</string>
     <plurals name="events_total">
         <item quantity="one">%1$d событие</item>
         <item quantity="few">%1$d события</item>

--- a/android/app/src/main/res/values-sk/strings.xml
+++ b/android/app/src/main/res/values-sk/strings.xml
@@ -43,6 +43,7 @@
     <string name="member_detail_label_reason">Dôvod</string>
     <string name="member_detail_label_verified">Overené</string>
     <string name="member_detail_label_added">Pridané</string>
+    <string name="member_detail_label_version">Verzia</string>
     <string name="member_url_title">Otvoriť adresu člena</string>
     <string name="member_url_open">Otvoriť</string>
     <string name="open_url_title">Otvoriť odkaz</string>
@@ -79,6 +80,8 @@
     <string name="events_copied">Udalosť skopírovaná do schránky</string>
     <string name="dashboard_member_copied">Člen skopírovaný do schránky</string>
     <string name="scroll_to_top">Prejsť nahor</string>
+    <string name="lock_fab_label">Uzamknúť aplikáciu</string>
+    <string name="lock_fab_hold_hint">Podržaním uzamknete</string>
     <plurals name="events_total">
         <item quantity="one">%1$d udalosť</item>
         <item quantity="few">%1$d udalosti</item>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -43,6 +43,7 @@
     <string name="member_detail_label_reason">原因</string>
     <string name="member_detail_label_verified">已验证</string>
     <string name="member_detail_label_added">已添加</string>
+    <string name="member_detail_label_version">版本</string>
     <string name="member_url_title">打开成员地址</string>
     <string name="member_url_open">打开</string>
     <string name="open_url_title">打开链接</string>
@@ -79,6 +80,8 @@
     <string name="events_copied">已将事件复制到剪贴板</string>
     <string name="dashboard_member_copied">已将成员复制到剪贴板</string>
     <string name="scroll_to_top">滚动到顶部</string>
+    <string name="lock_fab_label">锁定应用</string>
+    <string name="lock_fab_hold_hint">长按以锁定</string>
     <plurals name="events_total">
         <item quantity="other">%1$d 个事件</item>
     </plurals>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -44,6 +44,7 @@
     <string name="member_detail_label_reason">Reason</string>
     <string name="member_detail_label_verified">Verified</string>
     <string name="member_detail_label_added">Added</string>
+    <string name="member_detail_label_version">Version</string>
     <string name="member_url_title">Open member address</string>
     <string name="member_url_open">Open</string>
     <string name="open_url_title">Open link</string>
@@ -80,6 +81,8 @@
     <string name="events_copied">Event copied to clipboard</string>
     <string name="dashboard_member_copied">Member copied to clipboard</string>
     <string name="scroll_to_top">Scroll to top</string>
+    <string name="lock_fab_label">Lock app</string>
+    <string name="lock_fab_hold_hint">Hold to lock</string>
     <!-- Relative age shown on member sync/verified/added rows and recent-event pills -->
     <string name="time_just_now">just now</string>
     <plurals name="time_min_ago">

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreenTest.kt
@@ -14,6 +14,7 @@ import com.hugalafutro.bellhop.data.LinkState
 import com.hugalafutro.bellhop.data.MemberStatus
 import com.hugalafutro.bellhop.ui.theme.BellhopTheme
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -234,6 +235,40 @@ class DashboardScreenTest {
         }
         composeTestRule.onNodeWithTag("dashboard-events").performClick()
         assertTrue(opened == 1)
+    }
+
+    @Test
+    fun lockFabHiddenWhenLockDisabled() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                DashboardScreen(link = link, ui = DashboardUiState(loading = false, members = members))
+            }
+        }
+        composeTestRule.onNodeWithTag("lock-fab").assertDoesNotExist()
+    }
+
+    @Test
+    fun lockFabTapHintsAndLongPressLocks() {
+        var locked = false
+        composeTestRule.setContent {
+            BellhopTheme {
+                DashboardScreen(
+                    link = link,
+                    ui = DashboardUiState(loading = false, members = members),
+                    lockEnabled = true,
+                    onLock = { locked = true },
+                )
+            }
+        }
+        val fab = composeTestRule.onNodeWithTag("lock-fab")
+        fab.assertIsDisplayed()
+        // A tap must not lock: it only hints via a toast, so a stray touch is safe.
+        fab.performClick()
+        assertEquals(1, ShadowToast.shownToastCount())
+        assertFalse(locked)
+        // A long-press is the deliberate gesture that actually locks.
+        fab.performTouchInput { longClick() }
+        assertTrue(locked)
     }
 
     @Test

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreenTest.kt
@@ -289,6 +289,58 @@ class MemberDetailScreenTest {
     }
 
     @Test
+    fun allZeroBucketsShowEmptyStateNotFlatChart() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                MemberDetailScreen(
+                    member = member,
+                    isPrimary = false,
+                    onBack = {},
+                    ui =
+                        MemberDetailUiState(
+                            loading = false,
+                            // Buckets exist but every one is zero: this used to draw a
+                            // flat idle stub along the bottom; it must read as the empty
+                            // state, not a chart.
+                            traffic =
+                                MemberTraffic(
+                                    memberId = "m1",
+                                    reachable = true,
+                                    totalRequests = 0,
+                                    totalErrors = 0,
+                                    points =
+                                        listOf(
+                                            TrafficPoint(bucket = "b0", requests = 0, errors = 0),
+                                            TrafficPoint(bucket = "b1", requests = 0, errors = 0),
+                                        ),
+                                ),
+                        ),
+                )
+            }
+        }
+        composeTestRule.onNodeWithTag("member-traffic-empty").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("member-traffic-chart").assertDoesNotExist()
+    }
+
+    @Test
+    fun memberDetailShowsVersion() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                MemberDetailScreen(
+                    member = member,
+                    isPrimary = false,
+                    onBack = {},
+                    ui = MemberDetailUiState(loading = false, traffic = reachableTraffic),
+                )
+            }
+        }
+        composeTestRule
+            .onNodeWithTag("member-detail-list")
+            .performScrollToNode(hasTestTag("member-detail-version"))
+        composeTestRule.onNodeWithTag("member-detail-version").assertIsDisplayed()
+    }
+
+    @Test
     fun refreshErrorShowsBannerAndKeepsStaleChart() {
         composeTestRule.setContent {
             BellhopTheme {

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/SyncAgeTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/SyncAgeTest.kt
@@ -23,23 +23,34 @@ class SyncAgeTest {
     }
 
     @Test
-    fun freshSyncKeepsTheBaseColour() {
+    fun freshTickUnderAnHourKeepsTheBaseColour() {
+        // While the heartbeat is still ticking (under an hour) the suffix stays muted.
         val base = Color(0xFF102030)
         assertEquals(base, syncAgeColor(0L, base))
+        assertEquals(base, syncAgeColor(59 * minute, base))
     }
 
     @Test
-    fun weekOldOrOlderTurnsRed() {
+    fun pastAnHourTurnsYellow() {
+        val base = Color(0xFF102030)
+        val yellow = Color(0xFFFBC02D)
+        assertEquals(yellow, syncAgeColor(hour, base))
+        assertEquals(yellow, syncAgeColor(25 * hour, base)) // still under 2 days
+    }
+
+    @Test
+    fun secondDayTurnsOrange() {
+        val base = Color(0xFF102030)
+        val orange = Color(0xFFF57C00)
+        assertEquals(orange, syncAgeColor(2 * day, base))
+        assertEquals(orange, syncAgeColor((2.5 * day).toLong(), base))
+    }
+
+    @Test
+    fun thirdDayOrOlderTurnsRed() {
         val base = Color(0xFF102030)
         val red = Color(0xFFC62828)
-        assertEquals(red, syncAgeColor(7 * day, base))
+        assertEquals(red, syncAgeColor(3 * day, base))
         assertEquals(red, syncAgeColor(30 * day, base))
-    }
-
-    @Test
-    fun halfwayHitsTheAmberStop() {
-        // At 3.5 days (half of the 7-day window) the grade reaches the amber stop.
-        val base = Color(0xFF102030)
-        assertEquals(Color(0xFFFBC02D), syncAgeColor((3.5 * day).toLong(), base))
     }
 }


### PR DESCRIPTION
Phase 1 of 3 (cosmetic, Bellhop-only). The configurable graph time range is deliberately **not** here: it needs a Front Desk backend window parameter that does not exist yet, so it follows in a later PR once the backend lands.

## Member detail
- **Sync-drift signal.** The sync-age severity colour moved off the SYNCED (config-push) timestamp, which is legitimately old whenever a fleet's config is simply stable, onto the VERIFIED heartbeat (`auto_sync_verified_at`) whose staleness genuinely signals possible drift (auto-sync paused/off, or the member unreachable). The ramp now snaps by heartbeat age: base under an hour, amber past an hour, orange from day 2, red from day 3.
- Ledger reordered to **Address → Added → Synced → Reason → Verified**.
- The operator **"Last config change synced"** line gains the same right-aligned relative age the Added row already had.
- The member's reported **version** now shows on the detail screen (previously only on the dashboard card).

## Traffic graph
- When every bucket is zero, draw a dimmed **"no requests"** label centred in the graph instead of a confusing flat idle line along the bottom.

## Dashboard
- A bottom-right **lock FAB**, shown only when app lock is enabled in Settings, styled like the scroll-to-top button. A tap only shows a "hold to lock" hint toast; a long-press actually locks, so a stray touch can't lock the app.

## Tests / checks
- MemberDetailScreenTest 32/32, DashboardScreenTest 22/22, SyncAgeTest 5/5.
- ktlint (main + test) clean; i18n parity 11/11 for all new strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
