### PR TITLE
feat(frontdesk): optional window param on member traffic endpoint

### DIFF
--- a/internal/frontdesk/membertraffic.go
+++ b/internal/frontdesk/membertraffic.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strconv"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 
@@ -13,11 +15,27 @@ import (
 
 // This file proxies a member's own request/error time series for the Traffic
 // tab. Front Desk calls the member's admin-authenticated /api/stats/timeseries
-// (last hour, 5-minute buckets) with the stored admin token and reshapes it to
-// the small payload the UI charts. No request or prompt content is read: only
-// per-bucket request and error counts, which are routing/metering metadata.
+// with the stored admin token and reshapes it to the small payload the UI
+// charts. No request or prompt content is read: only per-bucket request and
+// error counts, which are routing/metering metadata.
 
+// memberTimeSeriesPath is the member series we chart: 5-minute buckets. Despite
+// the "1h" period name the member returns roughly the last 24h of buckets (the
+// period only selects bucket granularity, not the span), so a caller asking for
+// a shorter window is served by trimming the tail here rather than by asking the
+// member for less.
 const memberTimeSeriesPath = "/api/stats/timeseries?period=1h"
+
+const (
+	// defaultTrafficWindowMinutes is the window_minutes echoed when the caller
+	// sends no ?window= (e.g. Front Desk's own Traffic page): the legacy
+	// full-series behaviour, kept unchanged.
+	defaultTrafficWindowMinutes = 60
+	// A requested window is clamped to this range: the 5-minute series only spans
+	// ~24h, and a single bucket is the floor.
+	minTrafficWindowMinutes = 5
+	maxTrafficWindowMinutes = 24 * 60
+)
 
 // trafficPoint is one time bucket: total requests and the error subset.
 type trafficPoint struct {
@@ -50,6 +68,7 @@ type memberTimeSeries struct {
 
 func (s *Server) memberTraffic(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
+	windowMin := parseTrafficWindow(r)
 	m, token, err := s.memberTokenOrErr(r.Context(), id)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
@@ -58,12 +77,43 @@ func (s *Server) memberTraffic(w http.ResponseWriter, r *http.Request) {
 		}
 		// No stored token (ErrValidation) or a decrypt failure: not chartable,
 		// but a normal state, so report unreachable rather than erroring.
-		writeJSON(w, http.StatusOK, memberTrafficResponse{MemberID: id, Reachable: false, WindowMinutes: 60})
+		writeJSON(w, http.StatusOK, memberTrafficResponse{MemberID: id, Reachable: false, WindowMinutes: reportedWindow(windowMin)})
 		return
 	}
 
-	resp := s.fetchMemberTraffic(r.Context(), m, token)
+	resp := s.fetchMemberTraffic(r.Context(), m, token, windowMin)
 	writeJSON(w, http.StatusOK, resp)
+}
+
+// parseTrafficWindow reads the optional ?window=<minutes> filter. Absent, blank,
+// non-numeric, or non-positive means "no window" (0): the legacy full-series
+// behaviour, so a caller that never sends the param (Front Desk's own Traffic
+// page) is unaffected. A given value is clamped to [min,max].
+func parseTrafficWindow(r *http.Request) int {
+	q := r.URL.Query().Get("window")
+	if q == "" {
+		return 0
+	}
+	n, err := strconv.Atoi(q)
+	if err != nil || n <= 0 {
+		return 0
+	}
+	if n < minTrafficWindowMinutes {
+		return minTrafficWindowMinutes
+	}
+	if n > maxTrafficWindowMinutes {
+		return maxTrafficWindowMinutes
+	}
+	return n
+}
+
+// reportedWindow is the window_minutes echoed to the caller: the requested
+// window, or the legacy default when none was asked for.
+func reportedWindow(windowMin int) int {
+	if windowMin <= 0 {
+		return defaultTrafficWindowMinutes
+	}
+	return windowMin
 }
 
 // fetchMemberTraffic proxies and reshapes one member's time series, returning a
@@ -72,8 +122,8 @@ func (s *Server) memberTraffic(w http.ResponseWriter, r *http.Request) {
 // It uses the longer-deadline read client, not the fast health probe: a member
 // aggregating an hour of buckets can take longer than a liveness check, and the
 // probe timeout would mislabel that slow-but-successful read as unreachable.
-func (s *Server) fetchMemberTraffic(ctx context.Context, m *Member, token string) memberTrafficResponse {
-	out := memberTrafficResponse{MemberID: m.ID, WindowMinutes: 60, Points: []trafficPoint{}}
+func (s *Server) fetchMemberTraffic(ctx context.Context, m *Member, token string, windowMin int) memberTrafficResponse {
+	out := memberTrafficResponse{MemberID: m.ID, WindowMinutes: reportedWindow(windowMin), Points: []trafficPoint{}}
 
 	status, body, err := s.callMemberWith(ctx, s.readClient, http.MethodGet, m.URL, memberTimeSeriesPath, token, nil)
 	if err != nil {
@@ -91,9 +141,23 @@ func (s *Server) fetchMemberTraffic(ctx context.Context, m *Member, token string
 		return out
 	}
 
+	// A requested window keeps only the tail of the ~24h series; totals are
+	// summed over the kept buckets so they match what's charted. window 0 (no
+	// param) keeps everything, the legacy behaviour. A bucket whose timestamp
+	// can't be parsed is kept rather than aged out, so odd data is never silently
+	// dropped.
+	var cutoff time.Time
+	if windowMin > 0 {
+		cutoff = time.Now().UTC().Add(-time.Duration(windowMin) * time.Minute)
+	}
 	out.Reachable = true
 	out.Points = make([]trafficPoint, 0, len(ts.Points))
 	for _, p := range ts.Points {
+		if windowMin > 0 {
+			if bt, perr := time.Parse(time.RFC3339, p.Bucket); perr == nil && bt.Before(cutoff) {
+				continue
+			}
+		}
 		out.Points = append(out.Points, trafficPoint{Bucket: p.Bucket, Requests: p.Count, Errors: p.Errors})
 		out.TotalRequests += p.Count
 		out.TotalErrors += p.Errors

--- a/internal/frontdesk/membertraffic_test.go
+++ b/internal/frontdesk/membertraffic_test.go
@@ -145,3 +145,98 @@ func TestMemberTrafficUnreadableIsUnreachable(t *testing.T) {
 		})
 	}
 }
+
+// A ?window=<minutes> filter trims the member's ~24h series to the requested
+// tail: buckets older than the window are dropped and totals count only the
+// kept ones, so window_minutes matches what's charted.
+func TestMemberTrafficWindowTrimsToRequestedSpan(t *testing.T) {
+	srv, store := newTestServer(t)
+	now := time.Now().UTC()
+	inWindow := now.Add(-10 * time.Minute).Format(time.RFC3339)
+	outWindow := now.Add(-90 * time.Minute).Format(time.RFC3339)
+	member := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/stats/timeseries" {
+			_, _ = w.Write([]byte(`{"points":[` +
+				`{"bucket":"` + outWindow + `","count":7,"errors":3},` +
+				`{"bucket":"` + inWindow + `","count":4,"errors":1}]}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer member.Close()
+
+	m, err := store.CreateMember(t.Context(), "hotel", member.URL, "tok")
+	if err != nil {
+		t.Fatalf("CreateMember: %v", err)
+	}
+	rec := do(t, srv, http.MethodGet, "/api/members/"+m.ID+"/traffic?window=60", "", true)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("traffic = %d", rec.Code)
+	}
+	var resp memberTrafficResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.WindowMinutes != 60 {
+		t.Errorf("window_minutes = %d, want 60", resp.WindowMinutes)
+	}
+	if len(resp.Points) != 1 {
+		t.Fatalf("points = %d, want 1 (out-of-window bucket trimmed)", len(resp.Points))
+	}
+	if resp.TotalRequests != 4 || resp.TotalErrors != 1 {
+		t.Errorf("totals = %d/%d, want 4/1 (only the in-window bucket counted)", resp.TotalRequests, resp.TotalErrors)
+	}
+}
+
+// No ?window= keeps the legacy full series and window_minutes=60, even for
+// buckets whose labels aren't timestamps: Front Desk's own Traffic page, which
+// never sends the param, must be unaffected.
+func TestMemberTrafficNoWindowKeepsFullSeries(t *testing.T) {
+	srv, store := newTestServer(t)
+	member := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/stats/timeseries" {
+			_, _ = w.Write([]byte(`{"points":[{"bucket":"b1","count":10,"errors":2},{"bucket":"b2","count":5,"errors":0}]}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer member.Close()
+
+	m, err := store.CreateMember(t.Context(), "hotel", member.URL, "tok")
+	if err != nil {
+		t.Fatalf("CreateMember: %v", err)
+	}
+	rec := do(t, srv, http.MethodGet, "/api/members/"+m.ID+"/traffic", "", true)
+	var resp memberTrafficResponse
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	if len(resp.Points) != 2 || resp.WindowMinutes != 60 || resp.TotalRequests != 15 {
+		t.Errorf("no-window = %d points / window %d / %d req, want 2/60/15",
+			len(resp.Points), resp.WindowMinutes, resp.TotalRequests)
+	}
+}
+
+func TestParseTrafficWindowClampsAndDefaults(t *testing.T) {
+	cases := []struct {
+		query string
+		want  int
+	}{
+		{"", 0},          // absent -> legacy full series
+		{"abc", 0},       // non-numeric -> legacy
+		{"0", 0},         // non-positive -> legacy
+		{"-30", 0},       // negative -> legacy
+		{"1", 5},         // below the floor -> clamped up
+		{"60", 60},       // in range -> kept
+		{"1440", 1440},   // ceiling -> kept
+		{"100000", 1440}, // above ceiling -> clamped down
+	}
+	for _, c := range cases {
+		target := "/api/members/x/traffic"
+		if c.query != "" {
+			target += "?window=" + c.query
+		}
+		r := httptest.NewRequest(http.MethodGet, target, http.NoBody)
+		if got := parseTrafficWindow(r); got != c.want {
+			t.Errorf("window=%q -> %d, want %d", c.query, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Phase 2 of 3: the Front Desk backend for the upcoming Bellhop graph-range picker (Phase 3). No visible change on its own; it is intentionally landed first so the Bellhop PR never references an endpoint that does not exist yet.

## What
Adds an optional `?window=<minutes>` filter to `GET /api/members/{id}/traffic`.

- The member's `/api/stats/timeseries?period=1h` returns roughly the last **24h** of 5-minute buckets (the `period` name only selects bucket granularity, not the span), so a shorter window is served by **trimming the tail** in the proxy and summing totals over the kept buckets. `window_minutes` in the response then matches what is charted.
- The value is clamped to **[5, 1440] minutes**. A bucket whose timestamp cannot be parsed is kept rather than aged out, so odd data is never silently dropped.

## Additive / non-breaking
Absent, blank, or invalid `window` keeps the **legacy full-series** behaviour with `window_minutes=60`. Front Desk's own Traffic page sends no `window`, so it is unchanged.

## Note (pre-existing, not touched here)
Because `period=1h` actually returns ~24h, the no-window response still reports `window_minutes=60` while carrying up to 24h of points. That mislabel predates this PR; fixing it would change what Front Desk's Traffic page shows, so it is left for a separate decision.

## Tests
`internal/frontdesk` 227/227. New: window trims to the requested tail (totals recomputed), no-window keeps the full series untouched, and `parseTrafficWindow` clamp/default table. `go vet` + golangci-lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
