### PR TITLE
feat(bellhop): selectable traffic graph range (1h to 24h)

### DIFF
--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
@@ -305,6 +305,11 @@ fun BellhopApp() {
                         // made in system settings while away.
                         notificationsGranted = hasPostNotificationPermission(context)
                         pushDistributorAvailable = BellhopPush.hasDistributor(context)
+                        // Already locked when we return (e.g. the lock FAB minimised the
+                        // app): re-fire the prompt so unlocking is one glance, not a tap
+                        // on the lock screen. When the gate below is what flips locked on,
+                        // LockScreen's own auto-prompt covers it, so this avoids a double.
+                        if (locked) requestUnlock()
                         scope.launch {
                             val snap = lockStore.snapshot()
                             if (shouldLock(snap.config, snap.lastForegroundExit, System.currentTimeMillis())) {
@@ -474,7 +479,13 @@ fun BellhopApp() {
                         onUnlink = { runUnlink(state.fdUrl) },
                         onForceUnlink = { forceUnlink() },
                         requireOperatorAuth = { action -> requireOperatorAuth(action) },
-                        onLock = { locked = true },
+                        onLock = {
+                            // Lock, then send Bellhop to the background so the fleet is
+                            // off-screen immediately; the ON_START handler re-fires the
+                            // unlock prompt the next time it's foregrounded.
+                            locked = true
+                            activity?.moveTaskToBack(true)
+                        },
                     )
             }
         }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
@@ -183,6 +183,10 @@ fun BellhopApp() {
     val pushEnabled by monitorStore.pushEnabled.collectAsStateWithLifecycle(initialValue = false)
     val pushEndpoint by monitorStore.endpoint.collectAsStateWithLifecycle(initialValue = null)
     val holdToCopy by prefsStore.holdToCopy.collectAsStateWithLifecycle(initialValue = true)
+    val graphRangeMinutes by
+        prefsStore.graphRangeMinutes.collectAsStateWithLifecycle(
+            initialValue = PrefsStore.DEFAULT_GRAPH_RANGE_MINUTES,
+        )
     val scope = rememberCoroutineScope()
     // Whether Bellhop may post notifications. Tracked so Settings can be honest
     // when monitoring is on but the permission was denied (or later revoked from
@@ -465,6 +469,8 @@ fun BellhopApp() {
                         onToggleMonitor = { toggleMonitor(it) },
                         onTogglePush = { togglePush(it) },
                         onToggleHoldToCopy = { scope.launch { prefsStore.setHoldToCopy(it) } },
+                        graphRangeMinutes = graphRangeMinutes,
+                        onSetGraphRange = { scope.launch { prefsStore.setGraphRangeMinutes(it) } },
                         onUnlink = { runUnlink(state.fdUrl) },
                         onForceUnlink = { forceUnlink() },
                         requireOperatorAuth = { action -> requireOperatorAuth(action) },
@@ -502,6 +508,8 @@ private fun LinkedContent(
     onToggleMonitor: (Boolean) -> Unit,
     onTogglePush: (Boolean) -> Unit,
     onToggleHoldToCopy: (Boolean) -> Unit,
+    graphRangeMinutes: Int,
+    onSetGraphRange: (Int) -> Unit,
     onUnlink: () -> Unit,
     onForceUnlink: () -> Unit,
     requireOperatorAuth: (() -> Unit) -> Unit,
@@ -549,6 +557,9 @@ private fun LinkedContent(
             factory = DashboardViewModel.Factory(client, linkStore, state.fdUrl),
         )
     val ui by dashVm.state.collectAsStateWithLifecycle()
+    // Feed the Settings graph-range pref into the dashboard VM; a change
+    // re-triggers the sparkline fetch at the new span.
+    LaunchedEffect(graphRangeMinutes) { dashVm.setGraphRange(graphRangeMinutes) }
 
     // Alerts VM is hoisted so both the Settings pill (its severity-count badges)
     // and the Alerts screen share one instance. Created eagerly but only polls
@@ -654,6 +665,8 @@ private fun LinkedContent(
             onForceUnlink = onForceUnlink,
             holdToCopy = holdToCopy,
             onToggleHoldToCopy = onToggleHoldToCopy,
+            graphRangeMinutes = graphRangeMinutes,
+            onSetGraphRange = onSetGraphRange,
             alertCounts = alertCounts,
         )
     } else if (selected != null) {
@@ -666,6 +679,7 @@ private fun LinkedContent(
                 factory = MemberDetailViewModel.Factory(client, linkStore, state.fdUrl, selected.id),
             )
         val detailUi by detailVm.state.collectAsStateWithLifecycle()
+        LaunchedEffect(graphRangeMinutes) { detailVm.setGraphRange(graphRangeMinutes) }
         MemberDetailScreen(
             member = selected,
             isPrimary = selected.id == ui.primaryId,

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/FrontDeskClient.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/FrontDeskClient.kt
@@ -195,15 +195,17 @@ open class FrontDeskClient(
     ): FetchResult<List<FleetMember>> = get(fdUrl, "/api/members", token)
 
     /**
-     * memberTraffic fetches one member's last-hour request/error series (the
-     * member-detail chart). Front Desk answers 200 with reachable=false when
-     * the series can't be read, so failures here are FD-transport ones.
+     * memberTraffic fetches one member's request/error series for the charts.
+     * [windowMinutes] is the graph range: Front Desk trims the member series to
+     * that span (default one hour). FD answers 200 with reachable=false when the
+     * series can't be read, so failures here are FD-transport ones.
      */
     open suspend fun memberTraffic(
         fdUrl: String,
         token: String,
         memberId: String,
-    ): FetchResult<MemberTraffic> = get(fdUrl, "/api/members/$memberId/traffic", token)
+        windowMinutes: Int = PrefsStore.DEFAULT_GRAPH_RANGE_MINUTES,
+    ): FetchResult<MemberTraffic> = get(fdUrl, "/api/members/$memberId/traffic?window=$windowMinutes", token)
 
     /**
      * events fetches one page of the Front Desk event log (newest first) with

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/PrefsStore.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/PrefsStore.kt
@@ -5,6 +5,7 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -16,9 +17,9 @@ private val Context.prefsDataStore: DataStore<Preferences> by
 
 /**
  * PrefsStore persists device-local UI preferences that are neither link metadata
- * nor security policy. Today that is just the copy gesture: whether tapping a log
- * or member cell copies it (easy but easy to trigger by accident while scrolling)
- * or a long-press is required (the default, safer against stray copies).
+ * nor security policy: the copy gesture (whether tapping a log or member cell
+ * copies it, or a safer long-press is required, the default) and the traffic
+ * graph range (how far back the request charts reach).
  */
 class PrefsStore(
     private val dataStore: DataStore<Preferences>,
@@ -30,9 +31,36 @@ class PrefsStore(
         dataStore.edit { it[HOLD_TO_COPY] = enabled }
     }
 
+    /**
+     * graphRangeMinutes emits the traffic-graph lookback in minutes, defaulting
+     * to one hour. A stored value that is no longer an offered preset (e.g. after
+     * a version trims the list) falls back to the default rather than sticking on
+     * a range the picker can't show.
+     */
+    val graphRangeMinutes: Flow<Int> =
+        dataStore.data.map {
+            val stored = it[GRAPH_RANGE_MINUTES] ?: DEFAULT_GRAPH_RANGE_MINUTES
+            if (stored in GRAPH_RANGE_OPTIONS) stored else DEFAULT_GRAPH_RANGE_MINUTES
+        }
+
+    suspend fun setGraphRangeMinutes(minutes: Int) {
+        dataStore.edit { it[GRAPH_RANGE_MINUTES] = minutes }
+    }
+
     companion object {
         fun create(context: Context): PrefsStore = PrefsStore(context.applicationContext.prefsDataStore)
 
         private val HOLD_TO_COPY = booleanPreferencesKey("hold_to_copy")
+        private val GRAPH_RANGE_MINUTES = intPreferencesKey("graph_range_minutes")
+
+        /** Default traffic-graph lookback: the last hour. */
+        const val DEFAULT_GRAPH_RANGE_MINUTES = 60
+
+        /**
+         * Coarse presets the graph-range picker offers, in minutes (1h to 24h).
+         * Deliberately sparse: nobody needs to pick an arbitrary span, and 24h is
+         * the ceiling the member's 5-minute series can cover.
+         */
+        val GRAPH_RANGE_OPTIONS = listOf(60, 180, 360, 720, 1440)
     }
 }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/alerts/AlertsScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/alerts/AlertsScreen.kt
@@ -37,6 +37,7 @@ import com.hugalafutro.bellhop.data.AlertEventDef
 import com.hugalafutro.bellhop.data.AlertStatus
 import com.hugalafutro.bellhop.ui.common.Pill
 import com.hugalafutro.bellhop.ui.common.StatusBanner
+import com.hugalafutro.bellhop.ui.common.bellhopSwitchColors
 import com.hugalafutro.bellhop.ui.common.severityColors
 import com.hugalafutro.bellhop.ui.theme.BellhopTheme
 
@@ -263,6 +264,7 @@ private fun AlertRow(
                     checked = def.enabled,
                     onCheckedChange = onToggle,
                     enabled = canOperate,
+                    colors = bellhopSwitchColors(),
                     modifier = Modifier.testTag("alert-toggle-${def.type}"),
                 )
             }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/SwitchColors.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/SwitchColors.kt
@@ -1,0 +1,30 @@
+package com.hugalafutro.bellhop.ui.common
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SwitchColors
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.runtime.Composable
+
+/**
+ * bellhopSwitchColors is the single source of truth for every Switch in the app
+ * (Settings, Alerts, the dashboard auto-sync control), so a toggle reads the same
+ * in every state instead of each call site re-deriving it, and any new switch is
+ * consistent for free.
+ *
+ * Material's default unchecked track is the Card's own colour with an outline
+ * thumb/border, so an off (and especially a disabled-off) switch nearly vanishes
+ * against the card. This gives the off state a light thumb + border over a surface
+ * track so it stays legible on both the ink and paper schemes. The
+ * disabled-unchecked variants are set too (dimmed to 0.6 alpha so it still reads
+ * as disabled) because several of these switches disable themselves mid-flight.
+ */
+@Composable
+fun bellhopSwitchColors(): SwitchColors =
+    SwitchDefaults.colors(
+        uncheckedThumbColor = MaterialTheme.colorScheme.onSurfaceVariant,
+        uncheckedTrackColor = MaterialTheme.colorScheme.surface,
+        uncheckedBorderColor = MaterialTheme.colorScheme.onSurfaceVariant,
+        disabledUncheckedThumbColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+        disabledUncheckedTrackColor = MaterialTheme.colorScheme.surface,
+        disabledUncheckedBorderColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+    )

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
@@ -36,7 +36,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
-import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -76,6 +75,7 @@ import com.hugalafutro.bellhop.ui.common.Pill
 import com.hugalafutro.bellhop.ui.common.ScrollToTopButton
 import com.hugalafutro.bellhop.ui.common.StatusBanner
 import com.hugalafutro.bellhop.ui.common.TrafficChart
+import com.hugalafutro.bellhop.ui.common.bellhopSwitchColors
 import com.hugalafutro.bellhop.ui.common.healthColor
 import com.hugalafutro.bellhop.ui.common.healthLabel
 import com.hugalafutro.bellhop.ui.common.relativeAgo
@@ -381,23 +381,7 @@ private fun AutoSyncControl(
                         checked = effective,
                         onCheckedChange = onSetAutoSync,
                         enabled = !action.inProgress,
-                        // Same off-state colours as the Settings toggles so a paused
-                        // (unchecked) switch stays legible instead of a grey blob that
-                        // blends into the card. The disabled-unchecked trio mirrors it
-                        // (dimmed) because the switch is disabled while a pause/resume
-                        // is in flight, and Material's default disabled-unchecked grey
-                        // would otherwise reintroduce the very blend this fixes.
-                        colors =
-                            SwitchDefaults.colors(
-                                uncheckedThumbColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                                uncheckedTrackColor = MaterialTheme.colorScheme.surface,
-                                uncheckedBorderColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                                disabledUncheckedThumbColor =
-                                    MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
-                                disabledUncheckedTrackColor = MaterialTheme.colorScheme.surface,
-                                disabledUncheckedBorderColor =
-                                    MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
-                            ),
+                        colors = bellhopSwitchColors(),
                         modifier = Modifier.testTag("autosync-toggle"),
                     )
                 }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModel.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModel.kt
@@ -13,6 +13,7 @@ import com.hugalafutro.bellhop.data.LinkStore
 import com.hugalafutro.bellhop.data.MemberTraffic
 import com.hugalafutro.bellhop.data.PrefsStore
 import com.hugalafutro.bellhop.data.SseMessage
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
@@ -116,12 +117,15 @@ class DashboardViewModel(
     // from viewModelScope coroutines (single-threaded Main), so a plain map is safe.
     private val trafficFetchedAt = mutableMapOf<String, Long>()
 
-    // Members with a traffic fetch currently in flight, so the debounce path and
-    // the periodic tick can't both request the same member at once (the TTL only
-    // dedupes sequential fetches, since fetchedAt is stamped on completion). Kept
-    // separate from trafficFetchedAt so a failed fetch still retries immediately
-    // rather than being blocked for a TTL. Main-confined, so a plain set is safe.
-    private val trafficInFlight = mutableSetOf<String>()
+    // The in-flight traffic fetch per member, keyed by id. Doubles as the
+    // "currently fetching" set (so the debounce path and the periodic tick can't
+    // both request the same member at once; the TTL only dedupes sequential
+    // fetches) and as cancellable handles: a graph-range change cancels these
+    // old-window fetches and refetches the viewport at the new span, so a late
+    // old-window response can't overwrite the chart and freeze it until the next
+    // tick. Kept separate from trafficFetchedAt so a failed fetch still retries
+    // immediately. Main-confined, so a plain map is safe.
+    private val trafficJobs = mutableMapOf<String, Job>()
 
     init {
         viewModelScope.launch {
@@ -238,11 +242,17 @@ class DashboardViewModel(
                 }
             }
             launch {
-                // A range change invalidates every cached sparkline (they cover
-                // the old span), so force-refetch the current viewport. drop(1)
-                // skips the initial value the first fetch already used.
+                // A range change invalidates every in-flight and cached sparkline
+                // (they cover the old span). Cancel the old-window fetches so a late
+                // response can't overwrite the chart, drop their stamps, then
+                // force-refetch the viewport at the new span so it redraws now
+                // instead of on the next tick. drop(1) skips the initial value the
+                // first fetch already used.
                 graphWindow.drop(1).collectLatest {
                     if (_state.value.revoked) return@collectLatest
+                    trafficJobs.values.forEach { it.cancel() }
+                    trafficJobs.clear()
+                    trafficFetchedAt.clear()
                     fetchVisibleTraffic(visibleIds.value, force = true)
                 }
             }
@@ -262,31 +272,37 @@ class DashboardViewModel(
         val at = now()
         val due =
             ids.filter {
-                it !in trafficInFlight && (force || at - (trafficFetchedAt[it] ?: 0L) >= TRAFFIC_TTL_MS)
+                it !in trafficJobs && (force || at - (trafficFetchedAt[it] ?: 0L) >= TRAFFIC_TTL_MS)
             }
         if (due.isEmpty()) return
+        // Capture the window for this batch so the request stays aimed at the span
+        // that was current when it was decided, even if the range changes mid-flight
+        // (the observer below cancels these jobs on such a change).
+        val window = graphWindow.value
         coroutineScope {
             due.forEach { id ->
-                // Marked before the launch (synchronously, on Main) so a
-                // concurrent call sees it in flight and skips it.
-                trafficInFlight += id
-                launch {
-                    try {
-                        when (val result = client.memberTraffic(fdUrl, token, id, graphWindow.value)) {
-                            is FetchResult.Success -> {
-                                trafficFetchedAt[id] = at
-                                _state.update { it.copy(traffic = it.traffic + (id to result.data)) }
+                val job =
+                    launch {
+                        try {
+                            when (val result = client.memberTraffic(fdUrl, token, id, window)) {
+                                is FetchResult.Success -> {
+                                    trafficFetchedAt[id] = at
+                                    _state.update { it.copy(traffic = it.traffic + (id to result.data)) }
+                                }
+                                FetchResult.Unauthorized -> _state.update { it.copy(revoked = true) }
+                                // A stale sparkline is fine; the card's health still shows.
+                                is FetchResult.Failure -> Unit
                             }
-                            FetchResult.Unauthorized -> _state.update { it.copy(revoked = true) }
-                            // A stale sparkline is fine; the card's health still shows.
-                            is FetchResult.Failure -> Unit
+                        } finally {
+                            // Runs on success, failure, or cancellation, so a member
+                            // is never stuck marked-in-flight after its fetch ends.
+                            trafficJobs -= id
                         }
-                    } finally {
-                        // Runs on success, failure, or cancellation, so a member
-                        // is never stuck marked-in-flight after its fetch ends.
-                        trafficInFlight -= id
                     }
-                }
+                // Registered right after launch (still synchronous on Main; the body
+                // is dispatched, not run inline) so a concurrent call sees it in
+                // flight and a range change can cancel it.
+                trafficJobs[id] = job
             }
         }
     }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModel.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModel.kt
@@ -11,6 +11,7 @@ import com.hugalafutro.bellhop.data.FleetMember
 import com.hugalafutro.bellhop.data.FrontDeskClient
 import com.hugalafutro.bellhop.data.LinkStore
 import com.hugalafutro.bellhop.data.MemberTraffic
+import com.hugalafutro.bellhop.data.PrefsStore
 import com.hugalafutro.bellhop.data.SseMessage
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
@@ -21,6 +22,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -103,6 +105,11 @@ class DashboardViewModel(
     // 100-member fleet never triggers 100 traffic calls. When Front Desk grows a
     // single /api/fleet/usage rollup, this loop swaps its source for that one call.
     private val visibleIds = MutableStateFlow<List<String>>(emptyList())
+
+    // The traffic-graph range (minutes) the sparklines request, driven by the
+    // Settings pref via [setGraphRange]. Changing it force-refetches so the
+    // charts redraw at the new span.
+    private val graphWindow = MutableStateFlow(PrefsStore.DEFAULT_GRAPH_RANGE_MINUTES)
 
     // When each member's traffic was last fetched, so a re-tick or a re-scroll
     // past an already-fresh member doesn't refetch within the TTL. Only touched
@@ -197,6 +204,15 @@ class DashboardViewModel(
         visibleIds.value = ids
     }
 
+    /**
+     * setGraphRange updates the traffic-graph span (minutes) from the Settings
+     * pref. The traffic loop watches [graphWindow] and force-refetches the
+     * visible sparklines when it changes, so the charts follow the new range.
+     */
+    fun setGraphRange(minutes: Int) {
+        graphWindow.value = minutes
+    }
+
     // trafficLoop keeps the on-screen members' sparklines fresh on two triggers:
     // the visible set changing (scroll), debounced so a fast scroll doesn't fetch
     // every row it flies past; and a slow tick so the current view's sparklines
@@ -218,6 +234,15 @@ class DashboardViewModel(
                     // A dead token can't authenticate; stop ticking like the
                     // other loops rather than spinning on a no-op fetch.
                     if (_state.value.revoked) return@launch
+                    fetchVisibleTraffic(visibleIds.value, force = true)
+                }
+            }
+            launch {
+                // A range change invalidates every cached sparkline (they cover
+                // the old span), so force-refetch the current viewport. drop(1)
+                // skips the initial value the first fetch already used.
+                graphWindow.drop(1).collectLatest {
+                    if (_state.value.revoked) return@collectLatest
                     fetchVisibleTraffic(visibleIds.value, force = true)
                 }
             }
@@ -247,7 +272,7 @@ class DashboardViewModel(
                 trafficInFlight += id
                 launch {
                     try {
-                        when (val result = client.memberTraffic(fdUrl, token, id)) {
+                        when (val result = client.memberTraffic(fdUrl, token, id, graphWindow.value)) {
                             is FetchResult.Success -> {
                                 trafficFetchedAt[id] = at
                                 _state.update { it.copy(traffic = it.traffic + (id to result.data)) }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreen.kt
@@ -695,7 +695,9 @@ private fun TrafficCard(
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             Text(
-                text = stringResource(R.string.member_detail_traffic_title, traffic?.windowMinutes ?: 60),
+                // The window is always a whole number of hours (the range presets), so
+                // show hours to match the Settings picker instead of "1440 min".
+                text = stringResource(R.string.member_detail_traffic_title, (traffic?.windowMinutes ?: 60) / 60),
                 style = MaterialTheme.typography.titleMedium,
             )
             when {

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailViewModel.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailViewModel.kt
@@ -10,6 +10,7 @@ import com.hugalafutro.bellhop.data.FetchResult
 import com.hugalafutro.bellhop.data.FrontDeskClient
 import com.hugalafutro.bellhop.data.LinkStore
 import com.hugalafutro.bellhop.data.MemberTraffic
+import com.hugalafutro.bellhop.data.PrefsStore
 import com.hugalafutro.bellhop.ui.common.CustomDateRange
 import com.hugalafutro.bellhop.ui.common.EventRange
 import com.hugalafutro.bellhop.ui.common.loadMoreBackoffMillis
@@ -123,6 +124,9 @@ class MemberDetailViewModel(
     // ([loadMoreBackoffMillis]); reset to 0 on the first successful page.
     private var loadMoreFailures = 0
 
+    // Traffic-graph range (minutes) from the Settings pref, via [setGraphRange].
+    private val graphWindow = MutableStateFlow(PrefsStore.DEFAULT_GRAPH_RANGE_MINUTES)
+
     init {
         viewModelScope.launch {
             _state.subscriptionCount
@@ -144,6 +148,17 @@ class MemberDetailViewModel(
                     }
                 }
         }
+    }
+
+    /**
+     * setGraphRange updates the traffic-graph span (minutes) from the Settings
+     * pref and refetches so the chart redraws at the new range. No-op if the
+     * range is unchanged.
+     */
+    fun setGraphRange(minutes: Int) {
+        if (graphWindow.value == minutes) return
+        graphWindow.value = minutes
+        viewModelScope.launch { refreshOnce() }
     }
 
     /**
@@ -170,7 +185,7 @@ class MemberDetailViewModel(
             val query = eventsQuery(before, limit = before.events.size.coerceIn(EVENTS_PAGE, MAX_EVENTS_WINDOW))
             val (traffic, events, autoSync) =
                 coroutineScope {
-                    val t = async { client.memberTraffic(fdUrl, token, memberId) }
+                    val t = async { client.memberTraffic(fdUrl, token, memberId, graphWindow.value) }
                     val e = async { client.events(fdUrl, token, query) }
                     val a = async { client.autoSync(fdUrl, token) }
                     Triple(t.await(), e.await(), a.await())

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreen.kt
@@ -5,6 +5,8 @@ import android.widget.Toast
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -75,6 +77,7 @@ import java.util.Locale
  * It holds only the confirm-dialog visibility locally; the unlink work and its
  * failure state are the host's, so the same revoke-first guarantees apply.
  */
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun SettingsScreen(
     link: LinkState.Linked,
@@ -359,8 +362,11 @@ fun SettingsScreen(
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
-                    Row(
+                    // FlowRow so the five chips wrap to a second line instead of
+                    // clipping the later ranges on narrow screens or long-label locales.
+                    FlowRow(
                         horizontalArrangement = Arrangement.spacedBy(6.dp),
+                        verticalArrangement = Arrangement.spacedBy(6.dp),
                         modifier = Modifier.fillMaxWidth(),
                     ) {
                         PrefsStore.GRAPH_RANGE_OPTIONS.forEach { minutes ->

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreen.kt
@@ -5,8 +5,6 @@ import android.widget.Toast
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -20,7 +18,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
-import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -77,7 +74,6 @@ import java.util.Locale
  * It holds only the confirm-dialog visibility locally; the unlink work and its
  * failure state are the host's, so the same revoke-first guarantees apply.
  */
-@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun SettingsScreen(
     link: LinkState.Linked,
@@ -362,21 +358,23 @@ fun SettingsScreen(
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
-                    // FlowRow so the five chips wrap to a second line instead of
-                    // clipping the later ranges on narrow screens or long-label locales.
-                    FlowRow(
+                    // The same FilterPill row as the app-lock window pills, so the two
+                    // pickers read identically. weight(1f) shares the width evenly, so
+                    // the five ranges fit without overflowing the card.
+                    Row(
                         horizontalArrangement = Arrangement.spacedBy(6.dp),
-                        verticalArrangement = Arrangement.spacedBy(6.dp),
                         modifier = Modifier.fillMaxWidth(),
                     ) {
                         PrefsStore.GRAPH_RANGE_OPTIONS.forEach { minutes ->
-                            FilterChip(
+                            FilterPill(
+                                text = stringResource(R.string.settings_graph_range_hours, minutes / 60),
                                 selected = graphRangeMinutes == minutes,
                                 onClick = { onSetGraphRange(minutes) },
-                                label = {
-                                    Text(stringResource(R.string.settings_graph_range_hours, minutes / 60))
-                                },
-                                modifier = Modifier.testTag("settings-graph-range-$minutes"),
+                                tag = "settings-graph-range-$minutes",
+                                modifier = Modifier.weight(1f),
+                                // In a Card the default outline nearly vanishes; match the
+                                // lock pills and use the higher-contrast onSurfaceVariant.
+                                borderColor = MaterialTheme.colorScheme.onSurfaceVariant,
                             )
                         }
                     }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -52,6 +53,7 @@ import com.hugalafutro.bellhop.data.AppLocale
 import com.hugalafutro.bellhop.data.LinkState
 import com.hugalafutro.bellhop.data.LockConfig
 import com.hugalafutro.bellhop.data.LockTimeout
+import com.hugalafutro.bellhop.data.PrefsStore
 import com.hugalafutro.bellhop.ui.alerts.ALERT_SEVERITIES
 import com.hugalafutro.bellhop.ui.common.FilterPill
 import com.hugalafutro.bellhop.ui.common.NavChevron
@@ -98,6 +100,8 @@ fun SettingsScreen(
     onForceUnlink: () -> Unit = {},
     holdToCopy: Boolean = false,
     onToggleHoldToCopy: (Boolean) -> Unit = {},
+    graphRangeMinutes: Int = PrefsStore.DEFAULT_GRAPH_RANGE_MINUTES,
+    onSetGraphRange: (Int) -> Unit = {},
     // Enabled-alert counts per severity (error/warning/info/success), sourced from
     // Front Desk's live selection. Always rendered as badges on the Alerts pill,
     // even at 0, so the pill reads as a live, tappable destination.
@@ -336,6 +340,39 @@ fun SettingsScreen(
                                 ),
                             modifier = Modifier.testTag("settings-hold-copy-toggle"),
                         )
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Traffic graph range: how far back the request charts (the dashboard
+            // sparklines and the member-detail graph) reach. Coarse presets only.
+            Card(modifier = Modifier.fillMaxWidth()) {
+                Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text(
+                        text = stringResource(R.string.settings_graph_range_title),
+                        style = MaterialTheme.typography.titleMedium,
+                    )
+                    Text(
+                        text = stringResource(R.string.settings_graph_range_subtitle),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(6.dp),
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        PrefsStore.GRAPH_RANGE_OPTIONS.forEach { minutes ->
+                            FilterChip(
+                                selected = graphRangeMinutes == minutes,
+                                onClick = { onSetGraphRange(minutes) },
+                                label = {
+                                    Text(stringResource(R.string.settings_graph_range_hours, minutes / 60))
+                                },
+                                modifier = Modifier.testTag("settings-graph-range-$minutes"),
+                            )
+                        }
                     }
                 }
             }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Switch
-import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -57,6 +56,7 @@ import com.hugalafutro.bellhop.ui.alerts.ALERT_SEVERITIES
 import com.hugalafutro.bellhop.ui.common.FilterPill
 import com.hugalafutro.bellhop.ui.common.NavChevron
 import com.hugalafutro.bellhop.ui.common.Pill
+import com.hugalafutro.bellhop.ui.common.bellhopSwitchColors
 import com.hugalafutro.bellhop.ui.common.severityColors
 import com.hugalafutro.bellhop.ui.theme.BellhopTheme
 import java.time.Instant
@@ -331,12 +331,7 @@ fun SettingsScreen(
                             onCheckedChange = onToggleHoldToCopy,
                             // Same off-state colours as the other switches so an off
                             // toggle stays legible on the card.
-                            colors =
-                                SwitchDefaults.colors(
-                                    uncheckedThumbColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                                    uncheckedTrackColor = MaterialTheme.colorScheme.surface,
-                                    uncheckedBorderColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                                ),
+                            colors = bellhopSwitchColors(),
                             modifier = Modifier.testTag("settings-hold-copy-toggle"),
                         )
                     }
@@ -407,12 +402,7 @@ fun SettingsScreen(
                             // an off switch blends into the card. Give the off state a
                             // light thumb + border over a surface track so it stays
                             // legible on both the ink and paper schemes.
-                            colors =
-                                SwitchDefaults.colors(
-                                    uncheckedThumbColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                                    uncheckedTrackColor = MaterialTheme.colorScheme.surface,
-                                    uncheckedBorderColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                                ),
+                            colors = bellhopSwitchColors(),
                             modifier = Modifier.testTag("settings-lock-toggle"),
                         )
                     }
@@ -477,12 +467,7 @@ fun SettingsScreen(
                             onCheckedChange = onToggleMonitor,
                             // Same off-state colours as the lock switch so an off
                             // toggle stays legible on the card (see note above).
-                            colors =
-                                SwitchDefaults.colors(
-                                    uncheckedThumbColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                                    uncheckedTrackColor = MaterialTheme.colorScheme.surface,
-                                    uncheckedBorderColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                                ),
+                            colors = bellhopSwitchColors(),
                             modifier = Modifier.testTag("settings-monitor-toggle"),
                         )
                     }
@@ -533,12 +518,7 @@ fun SettingsScreen(
                             onCheckedChange = onTogglePush,
                             // Same off-state colours as the other switches so an off
                             // toggle stays legible on the card (see note above).
-                            colors =
-                                SwitchDefaults.colors(
-                                    uncheckedThumbColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                                    uncheckedTrackColor = MaterialTheme.colorScheme.surface,
-                                    uncheckedBorderColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                                ),
+                            colors = bellhopSwitchColors(),
                             modifier = Modifier.testTag("settings-push-toggle"),
                         )
                     }

--- a/android/app/src/main/res/values-cs/strings.xml
+++ b/android/app/src/main/res/values-cs/strings.xml
@@ -150,6 +150,9 @@
     <string name="common_copy">Kopírovat</string>
     <string name="settings_hold_copy_title">Podržet pro kopírování</string>
     <string name="settings_hold_copy_subtitle">Když je zapnuto, dlouhým stiskem buňky události nebo člena ji zkopírujete do schránky. Když je vypnuto, buňky nelze kopírovat.</string>
+    <string name="settings_graph_range_title">Rozsah grafu provozu</string>
+    <string name="settings_graph_range_subtitle">Jak daleko do minulosti sahají grafy požadavků.</string>
+    <string name="settings_graph_range_hours">%1$d h</string>
     <string name="settings_lock_title">Zámek aplikace</string>
     <string name="settings_lock_subtitle">Vyžadovat otisk prstu nebo PIN zařízení pro otevření Bellhopu.</string>
     <string name="settings_lock_unavailable">Nastavte na tomto zařízení otisk prstu nebo zámek obrazovky, abyste povolili zámek aplikace.</string>

--- a/android/app/src/main/res/values-cs/strings.xml
+++ b/android/app/src/main/res/values-cs/strings.xml
@@ -32,7 +32,7 @@
     <string name="member_primary">Primární</string>
     <!-- Member detail -->
     <string name="member_detail_back">Zpět</string>
-    <string name="member_detail_traffic_title">Provoz · posledních %1$d min</string>
+    <string name="member_detail_traffic_title">Provoz · posledních %1$d h</string>
     <string name="member_detail_traffic_totals">%1$d požadavků · %2$d chyb</string>
     <string name="member_detail_traffic_unreachable">Provoz není dostupný. Front Desk možná nemá pro tohoto člena admin token, nebo člen neodpověděl.</string>
     <string name="member_detail_traffic_empty">V tomto okně žádné požadavky.</string>

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -148,6 +148,9 @@
     <string name="common_copy">Kopieren</string>
     <string name="settings_hold_copy_title">Zum Kopieren halten</string>
     <string name="settings_hold_copy_subtitle">Wenn aktiviert, kopiert ein langer Druck auf ein Ereignis oder eine Mitgliedszelle diese in die Zwischenablage. Wenn deaktiviert, können Zellen nicht kopiert werden.</string>
+    <string name="settings_graph_range_title">Zeitraum des Traffic-Diagramms</string>
+    <string name="settings_graph_range_subtitle">Wie weit die Anfrage-Diagramme zurückreichen.</string>
+    <string name="settings_graph_range_hours">%1$d h</string>
     <string name="settings_lock_title">App-Sperre</string>
     <string name="settings_lock_subtitle">Fingerabdruck oder Geräte-PIN erforderlich, um Bellhop zu öffnen.</string>
     <string name="settings_lock_unavailable">Richte auf diesem Gerät einen Fingerabdruck oder eine Bildschirmsperre ein, um die App-Sperre zu aktivieren.</string>

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -32,7 +32,7 @@
     <string name="member_primary">Primär</string>
     <!-- Member detail -->
     <string name="member_detail_back">Zurück</string>
-    <string name="member_detail_traffic_title">Traffic · letzte %1$d Min</string>
+    <string name="member_detail_traffic_title">Traffic · letzte %1$d h</string>
     <string name="member_detail_traffic_totals">%1$d Anfragen · %2$d Fehler</string>
     <string name="member_detail_traffic_unreachable">Traffic ist nicht verfügbar. Front Desk hat für dieses Mitglied möglicherweise kein Admin-Token, oder das Mitglied hat nicht geantwortet.</string>
     <string name="member_detail_traffic_empty">Keine Anfragen in diesem Zeitraum.</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -148,6 +148,9 @@
     <string name="common_copy">Copiar</string>
     <string name="settings_hold_copy_title">Mantener para copiar</string>
     <string name="settings_hold_copy_subtitle">Cuando está activado, mantén pulsada una celda de evento o de miembro para copiarla al portapapeles. Cuando está desactivado, las celdas no se pueden copiar.</string>
+    <string name="settings_graph_range_title">Rango del gráfico de tráfico</string>
+    <string name="settings_graph_range_subtitle">Hasta dónde se remontan los gráficos de solicitudes.</string>
+    <string name="settings_graph_range_hours">%1$d h</string>
     <string name="settings_lock_title">Bloqueo de la app</string>
     <string name="settings_lock_subtitle">Requiere una huella o el PIN del dispositivo para abrir Bellhop.</string>
     <string name="settings_lock_unavailable">Configura una huella o un bloqueo de pantalla en este dispositivo para activar el bloqueo de la app.</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -32,7 +32,7 @@
     <string name="member_primary">Primario</string>
     <!-- Member detail -->
     <string name="member_detail_back">Atrás</string>
-    <string name="member_detail_traffic_title">Tráfico · últimos %1$d min</string>
+    <string name="member_detail_traffic_title">Tráfico · últimos %1$d h</string>
     <string name="member_detail_traffic_totals">%1$d solicitudes · %2$d errores</string>
     <string name="member_detail_traffic_unreachable">El tráfico no está disponible. Puede que Front Desk no tenga un token de administrador para este miembro, o que el miembro no respondiera.</string>
     <string name="member_detail_traffic_empty">Sin solicitudes en este intervalo.</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -32,7 +32,7 @@
     <string name="member_primary">Primaire</string>
     <!-- Member detail -->
     <string name="member_detail_back">Retour</string>
-    <string name="member_detail_traffic_title">Trafic · %1$d dernières min</string>
+    <string name="member_detail_traffic_title">Trafic · %1$d dernières h</string>
     <string name="member_detail_traffic_totals">%1$d requêtes · %2$d erreurs</string>
     <string name="member_detail_traffic_unreachable">Le trafic n\'est pas disponible. Front Desk ne possède peut-être aucun jeton admin pour ce membre, ou le membre n\'a pas répondu.</string>
     <string name="member_detail_traffic_empty">Aucune requête sur cette période.</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -148,6 +148,9 @@
     <string name="common_copy">Copier</string>
     <string name="settings_hold_copy_title">Maintenir pour copier</string>
     <string name="settings_hold_copy_subtitle">Lorsque activé, appuyez longuement sur une cellule d\'événement ou de membre pour la copier dans le presse-papiers. Lorsque désactivé, les cellules ne peuvent pas être copiées.</string>
+    <string name="settings_graph_range_title">Plage du graphique de trafic</string>
+    <string name="settings_graph_range_subtitle">Jusqu\'où remontent les graphiques de requêtes.</string>
+    <string name="settings_graph_range_hours">%1$d h</string>
     <string name="settings_lock_title">Verrouillage de l\'app</string>
     <string name="settings_lock_subtitle">Exiger une empreinte ou le code de l\'appareil pour ouvrir Bellhop.</string>
     <string name="settings_lock_unavailable">Configurez une empreinte ou un verrouillage d\'écran sur cet appareil pour activer le verrouillage de l\'app.</string>

--- a/android/app/src/main/res/values-ja/strings.xml
+++ b/android/app/src/main/res/values-ja/strings.xml
@@ -32,7 +32,7 @@
     <string name="member_primary">プライマリ</string>
     <!-- Member detail -->
     <string name="member_detail_back">戻る</string>
-    <string name="member_detail_traffic_title">トラフィック · 直近 %1$d 分</string>
+    <string name="member_detail_traffic_title">トラフィック · 直近 %1$d 時間</string>
     <string name="member_detail_traffic_totals">%1$d リクエスト · %2$d エラー</string>
     <string name="member_detail_traffic_unreachable">トラフィックを利用できません。Front Desk がこのメンバーの管理者トークンを持っていないか、メンバーが応答しなかった可能性があります。</string>
     <string name="member_detail_traffic_empty">この期間にリクエストはありません。</string>

--- a/android/app/src/main/res/values-ja/strings.xml
+++ b/android/app/src/main/res/values-ja/strings.xml
@@ -147,6 +147,9 @@
     <string name="common_copy">コピー</string>
     <string name="settings_hold_copy_title">長押しでコピー</string>
     <string name="settings_hold_copy_subtitle">オンのとき、イベントまたはメンバーのセルを長押しするとクリップボードにコピーします。オフのとき、セルはコピーできません。</string>
+    <string name="settings_graph_range_title">トラフィックグラフの範囲</string>
+    <string name="settings_graph_range_subtitle">リクエストグラフがさかのぼる範囲。</string>
+    <string name="settings_graph_range_hours">%1$d 時間</string>
     <string name="settings_lock_title">アプリロック</string>
     <string name="settings_lock_subtitle">Bellhop を開くのに指紋またはデバイスの PIN を要求します。</string>
     <string name="settings_lock_unavailable">アプリロックを有効にするには、このデバイスに指紋または画面ロックを設定してください。</string>

--- a/android/app/src/main/res/values-nl/strings.xml
+++ b/android/app/src/main/res/values-nl/strings.xml
@@ -148,6 +148,9 @@
     <string name="common_copy">Kopiëren</string>
     <string name="settings_hold_copy_title">Ingedrukt houden om te kopiëren</string>
     <string name="settings_hold_copy_subtitle">Wanneer aan, houd een gebeurtenis- of ledencel ingedrukt om die naar het klembord te kopiëren. Wanneer uit, kunnen cellen niet worden gekopieerd.</string>
+    <string name="settings_graph_range_title">Bereik van verkeersgrafiek</string>
+    <string name="settings_graph_range_subtitle">Hoe ver de verzoekgrafieken teruggaan.</string>
+    <string name="settings_graph_range_hours">%1$d u</string>
     <string name="settings_lock_title">App-vergrendeling</string>
     <string name="settings_lock_subtitle">Vereis een vingerafdruk of apparaat-pincode om Bellhop te openen.</string>
     <string name="settings_lock_unavailable">Stel een vingerafdruk of schermvergrendeling in op dit apparaat om de app-vergrendeling in te schakelen.</string>

--- a/android/app/src/main/res/values-nl/strings.xml
+++ b/android/app/src/main/res/values-nl/strings.xml
@@ -32,7 +32,7 @@
     <string name="member_primary">Primair</string>
     <!-- Member detail -->
     <string name="member_detail_back">Terug</string>
-    <string name="member_detail_traffic_title">Verkeer · laatste %1$d min</string>
+    <string name="member_detail_traffic_title">Verkeer · laatste %1$d u</string>
     <string name="member_detail_traffic_totals">%1$d verzoeken · %2$d fouten</string>
     <string name="member_detail_traffic_unreachable">Verkeer is niet beschikbaar. Front Desk heeft mogelijk geen admin-token voor dit lid, of het lid antwoordde niet.</string>
     <string name="member_detail_traffic_empty">Geen verzoeken in dit venster.</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -150,6 +150,9 @@
     <string name="common_copy">Kopiuj</string>
     <string name="settings_hold_copy_title">Przytrzymaj, aby skopiować</string>
     <string name="settings_hold_copy_subtitle">Gdy włączone, przytrzymaj komórkę zdarzenia lub węzła, aby skopiować ją do schowka. Gdy wyłączone, komórek nie można kopiować.</string>
+    <string name="settings_graph_range_title">Zakres wykresu ruchu</string>
+    <string name="settings_graph_range_subtitle">Jak daleko wstecz sięgają wykresy żądań.</string>
+    <string name="settings_graph_range_hours">%1$d godz.</string>
     <string name="settings_lock_title">Blokada aplikacji</string>
     <string name="settings_lock_subtitle">Wymagaj odcisku palca lub kodu PIN urządzenia, aby otworzyć Bellhop.</string>
     <string name="settings_lock_unavailable">Skonfiguruj odcisk palca lub blokadę ekranu na tym urządzeniu, aby włączyć blokadę aplikacji.</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -32,7 +32,7 @@
     <string name="member_primary">Podstawowy</string>
     <!-- Member detail -->
     <string name="member_detail_back">Wstecz</string>
-    <string name="member_detail_traffic_title">Ruch · ostatnie %1$d min</string>
+    <string name="member_detail_traffic_title">Ruch · ostatnie %1$d godz.</string>
     <string name="member_detail_traffic_totals">%1$d żądań · %2$d błędów</string>
     <string name="member_detail_traffic_unreachable">Ruch jest niedostępny. Front Desk może nie mieć tokena administratora dla tego węzła lub węzeł nie odpowiedział.</string>
     <string name="member_detail_traffic_empty">Brak żądań w tym oknie.</string>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -150,6 +150,9 @@
     <string name="common_copy">Копировать</string>
     <string name="settings_hold_copy_title">Удерживать для копирования</string>
     <string name="settings_hold_copy_subtitle">Когда включено, удерживайте ячейку события или узла, чтобы скопировать её в буфер обмена. Когда выключено, ячейки нельзя копировать.</string>
+    <string name="settings_graph_range_title">Диапазон графика трафика</string>
+    <string name="settings_graph_range_subtitle">Насколько далеко назад простираются графики запросов.</string>
+    <string name="settings_graph_range_hours">%1$d ч</string>
     <string name="settings_lock_title">Блокировка приложения</string>
     <string name="settings_lock_subtitle">Требовать отпечаток пальца или PIN устройства для открытия Bellhop.</string>
     <string name="settings_lock_unavailable">Настройте отпечаток пальца или блокировку экрана на этом устройстве, чтобы включить блокировку приложения.</string>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -32,7 +32,7 @@
     <string name="member_primary">Основной</string>
     <!-- Member detail -->
     <string name="member_detail_back">Назад</string>
-    <string name="member_detail_traffic_title">Трафик · последние %1$d мин</string>
+    <string name="member_detail_traffic_title">Трафик · последние %1$d ч</string>
     <string name="member_detail_traffic_totals">%1$d запросов · %2$d ошибок</string>
     <string name="member_detail_traffic_unreachable">Трафик недоступен. Возможно, у Front Desk нет токена администратора для этого узла, или узел не ответил.</string>
     <string name="member_detail_traffic_empty">Нет запросов в этом окне.</string>

--- a/android/app/src/main/res/values-sk/strings.xml
+++ b/android/app/src/main/res/values-sk/strings.xml
@@ -150,6 +150,9 @@
     <string name="common_copy">Kopírovať</string>
     <string name="settings_hold_copy_title">Podržať pre kopírovanie</string>
     <string name="settings_hold_copy_subtitle">Keď je zapnuté, dlhým stlačením bunky udalosti alebo člena ju skopírujete do schránky. Keď je vypnuté, bunky nemožno kopírovať.</string>
+    <string name="settings_graph_range_title">Rozsah grafu prevádzky</string>
+    <string name="settings_graph_range_subtitle">Ako ďaleko do minulosti siahajú grafy požiadaviek.</string>
+    <string name="settings_graph_range_hours">%1$d h</string>
     <string name="settings_lock_title">Zámok aplikácie</string>
     <string name="settings_lock_subtitle">Vyžadovať odtlačok prsta alebo PIN zariadenia na otvorenie Bellhopu.</string>
     <string name="settings_lock_unavailable">Nastavte na tomto zariadení odtlačok prsta alebo zámku obrazovky, aby ste povolili zámok aplikácie.</string>

--- a/android/app/src/main/res/values-sk/strings.xml
+++ b/android/app/src/main/res/values-sk/strings.xml
@@ -32,7 +32,7 @@
     <string name="member_primary">Primárny</string>
     <!-- Member detail -->
     <string name="member_detail_back">Späť</string>
-    <string name="member_detail_traffic_title">Prevádzka · posledných %1$d min</string>
+    <string name="member_detail_traffic_title">Prevádzka · posledných %1$d h</string>
     <string name="member_detail_traffic_totals">%1$d požiadaviek · %2$d chýb</string>
     <string name="member_detail_traffic_unreachable">Prevádzka nie je dostupná. Front Desk možno nemá pre tohto člena admin token, alebo člen neodpovedal.</string>
     <string name="member_detail_traffic_empty">V tomto okne žiadne požiadavky.</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -147,6 +147,9 @@
     <string name="common_copy">复制</string>
     <string name="settings_hold_copy_title">长按以复制</string>
     <string name="settings_hold_copy_subtitle">开启时，长按事件或成员单元格可将其复制到剪贴板。关闭时，单元格无法复制。</string>
+    <string name="settings_graph_range_title">流量图表范围</string>
+    <string name="settings_graph_range_subtitle">请求图表回溯的时间范围。</string>
+    <string name="settings_graph_range_hours">%1$d 小时</string>
     <string name="settings_lock_title">应用锁</string>
     <string name="settings_lock_subtitle">打开 Bellhop 时需要指纹或设备 PIN。</string>
     <string name="settings_lock_unavailable">请在此设备上设置指纹或屏幕锁，以启用应用锁。</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -32,7 +32,7 @@
     <string name="member_primary">主节点</string>
     <!-- Member detail -->
     <string name="member_detail_back">返回</string>
-    <string name="member_detail_traffic_title">流量 · 最近 %1$d 分钟</string>
+    <string name="member_detail_traffic_title">流量 · 最近 %1$d 小时</string>
     <string name="member_detail_traffic_totals">%1$d 个请求 · %2$d 个错误</string>
     <string name="member_detail_traffic_unreachable">流量不可用。Front Desk 可能没有此成员的管理员令牌，或该成员未响应。</string>
     <string name="member_detail_traffic_empty">此时段内没有请求。</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -163,6 +163,9 @@
     <string name="common_copy">Copy</string>
     <string name="settings_hold_copy_title">Hold to copy</string>
     <string name="settings_hold_copy_subtitle">When on, long-press an event or member cell to copy it to the clipboard. When off, cells can\'t be copied.</string>
+    <string name="settings_graph_range_title">Traffic graph range</string>
+    <string name="settings_graph_range_subtitle">How far back the request charts reach.</string>
+    <string name="settings_graph_range_hours">%1$d h</string>
     <string name="settings_lock_title">App lock</string>
     <string name="settings_lock_subtitle">Require a fingerprint or device PIN to open Bellhop.</string>
     <string name="settings_lock_unavailable">Set up a fingerprint or a screen lock on this device to enable the app lock.</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -33,7 +33,7 @@
     <string name="member_primary">Primary</string>
     <!-- Member detail -->
     <string name="member_detail_back">Back</string>
-    <string name="member_detail_traffic_title">Traffic · last %1$d min</string>
+    <string name="member_detail_traffic_title">Traffic · last %1$d h</string>
     <string name="member_detail_traffic_totals">%1$d requests · %2$d errors</string>
     <string name="member_detail_traffic_unreachable">Traffic isn\'t available. Front Desk may hold no admin token for this member, or the member didn\'t answer.</string>
     <string name="member_detail_traffic_empty">No requests in this window.</string>

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/FrontDeskClientTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/FrontDeskClientTest.kt
@@ -180,8 +180,25 @@ class FrontDeskClientTest {
 
             val request = server.takeRequest()
             assertEquals("GET", request.method)
-            assertEquals("/api/members/m1/traffic", request.path)
+            // The default window (one hour) is sent even when the caller omits it.
+            assertEquals("/api/members/m1/traffic?window=60", request.path)
             assertEquals("Bearer tok-1", request.getHeader("Authorization"))
+        }
+
+    @Test
+    fun memberTrafficSendsRequestedWindow() =
+        runBlocking {
+            server.enqueue(
+                MockResponse().setBody(
+                    """{"member_id":"m1","reachable":true,"window_minutes":360,""" +
+                        """"total_requests":0,"total_errors":0,"points":[]}""",
+                ),
+            )
+
+            client.memberTraffic(server.url("/").toString(), "tok-1", "m1", windowMinutes = 360)
+
+            val request = server.takeRequest()
+            assertEquals("/api/members/m1/traffic?window=360", request.path)
         }
 
     @Test

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModelTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModelTest.kt
@@ -17,6 +17,7 @@ import com.hugalafutro.bellhop.data.MemberStatus
 import com.hugalafutro.bellhop.data.MemberTraffic
 import com.hugalafutro.bellhop.data.PairedDevice
 import com.hugalafutro.bellhop.data.SseMessage
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.delay
@@ -120,6 +121,10 @@ private class FakeFleetClient(
     @Volatile
     var lastTrafficWindow: Int = -1
 
+    // When set, the initial (default-window) traffic fetch parks here so a test can
+    // hold it "in flight" while it changes the range.
+    var firstTrafficGate: CompletableDeferred<Unit>? = null
+
     override suspend fun memberTraffic(
         fdUrl: String,
         token: String,
@@ -128,6 +133,7 @@ private class FakeFleetClient(
     ): FetchResult<MemberTraffic> {
         lastTrafficWindow = windowMinutes
         trafficFetched.add(memberId)
+        if (windowMinutes == 60) firstTrafficGate?.await()
         return trafficResults[memberId] ?: FetchResult.Failure("no traffic for $memberId")
     }
 
@@ -417,6 +423,32 @@ class DashboardViewModelTest {
             assertEquals(60, client.lastTrafficWindow)
 
             // Changing the range force-refetches the visible sparklines at the new span.
+            vm.setGraphRange(360)
+            withTimeout(5_000) { while (client.lastTrafficWindow != 360) delay(20) }
+            assertEquals(360, client.lastTrafficWindow)
+            job.cancel()
+        }
+
+    @Test
+    fun rangeChangeMidFetchRefetchesInsteadOfLeavingStale() =
+        runBlocking {
+            val client = FakeFleetClient(FetchResult.Success(listOf(member)))
+            client.trafficResults =
+                mapOf("m1" to FetchResult.Success(MemberTraffic(memberId = "m1", reachable = true)))
+            // Park the initial default-window fetch so it stays in flight.
+            client.firstTrafficGate = CompletableDeferred()
+            val vm = DashboardViewModel(client, linkedStore(), "http://fd:1")
+            val job = launch { vm.state.collect {} }
+            withTimeout(5_000) { vm.state.first { it.members.size == 1 } }
+
+            vm.setVisibleMembers(listOf("m1"))
+            // Wait until the default-window fetch has entered and parked in flight.
+            withTimeout(5_000) { while (!client.trafficFetched.contains("m1")) delay(20) }
+            assertEquals(60, client.lastTrafficWindow)
+
+            // Change range while that fetch is still parked. The old-window fetch must
+            // be cancelled and m1 refetched at the new span, not skipped as in-flight
+            // (which used to leave the sparkline stale until the next poll).
             vm.setGraphRange(360)
             withTimeout(5_000) { while (client.lastTrafficWindow != 360) delay(20) }
             assertEquals(360, client.lastTrafficWindow)

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModelTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModelTest.kt
@@ -117,11 +117,16 @@ private class FakeFleetClient(
     var trafficResults: Map<String, FetchResult<MemberTraffic>> = emptyMap()
     val trafficFetched = java.util.concurrent.CopyOnWriteArrayList<String>()
 
+    @Volatile
+    var lastTrafficWindow: Int = -1
+
     override suspend fun memberTraffic(
         fdUrl: String,
         token: String,
         memberId: String,
+        windowMinutes: Int,
     ): FetchResult<MemberTraffic> {
+        lastTrafficWindow = windowMinutes
         trafficFetched.add(memberId)
         return trafficResults[memberId] ?: FetchResult.Failure("no traffic for $memberId")
     }
@@ -393,6 +398,28 @@ class DashboardViewModelTest {
 
             assertTrue(client.trafficFetched.contains("m1"))
             assertFalse(client.trafficFetched.contains("m2"))
+            job.cancel()
+        }
+
+    @Test
+    fun graphRangeChangeRefetchesVisibleTrafficWithNewWindow() =
+        runBlocking {
+            val client = FakeFleetClient(FetchResult.Success(listOf(member)))
+            client.trafficResults =
+                mapOf("m1" to FetchResult.Success(MemberTraffic(memberId = "m1", reachable = true)))
+            val vm = DashboardViewModel(client, linkedStore(), "http://fd:1")
+            val job = launch { vm.state.collect {} }
+            withTimeout(5_000) { vm.state.first { it.members.size == 1 } }
+
+            vm.setVisibleMembers(listOf("m1"))
+            withTimeout(5_000) { vm.state.first { it.traffic.containsKey("m1") } }
+            // The first fetch used the default one-hour window.
+            assertEquals(60, client.lastTrafficWindow)
+
+            // Changing the range force-refetches the visible sparklines at the new span.
+            vm.setGraphRange(360)
+            withTimeout(5_000) { while (client.lastTrafficWindow != 360) delay(20) }
+            assertEquals(360, client.lastTrafficWindow)
             job.cancel()
         }
 

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailViewModelTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailViewModelTest.kt
@@ -68,14 +68,19 @@ private class FakeTrafficClient(
     // action while the first is still running.
     var stateGate: CompletableDeferred<Unit>? = null
 
+    @Volatile
+    var lastTrafficWindow: Int = -1
+
     override suspend fun memberTraffic(
         fdUrl: String,
         token: String,
         memberId: String,
+        windowMinutes: Int,
     ): FetchResult<MemberTraffic> {
         trafficCalls.incrementAndGet()
         lastToken = token
         lastMemberId = memberId
+        lastTrafficWindow = windowMinutes
         return trafficResult
     }
 
@@ -173,6 +178,21 @@ class MemberDetailViewModelTest {
             assertFalse(s.revoked)
             assertEquals("tok-1", client.lastToken)
             assertEquals("m1", client.lastMemberId)
+        }
+
+    @Test
+    fun graphRangeChangeRefetchesTrafficWithTheNewWindow() =
+        runBlocking {
+            val client = FakeTrafficClient(FetchResult.Success(traffic))
+            val vm = MemberDetailViewModel(client, linkedStore(), "http://fd:1", "m1")
+
+            vm.refreshOnce()
+            assertEquals(60, client.lastTrafficWindow) // default one hour
+
+            // Picking a new range refetches this member's chart at the new span.
+            vm.setGraphRange(360)
+            withTimeout(5_000) { while (client.lastTrafficWindow != 360) delay(20) }
+            assertEquals(360, client.lastTrafficWindow)
         }
 
     @Test

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreenTest.kt
@@ -53,6 +53,8 @@ class SettingsScreenTest {
         onToggleMonitor: (Boolean) -> Unit = {},
         onTogglePush: (Boolean) -> Unit = {},
         onToggleHoldToCopy: (Boolean) -> Unit = {},
+        graphRangeMinutes: Int = 60,
+        onSetGraphRange: (Int) -> Unit = {},
         onAlertsClick: () -> Unit = {},
         onUnlink: () -> Unit = {},
         onForceUnlink: () -> Unit = {},
@@ -82,6 +84,8 @@ class SettingsScreenTest {
                     onForceUnlink = onForceUnlink,
                     holdToCopy = holdToCopy,
                     onToggleHoldToCopy = onToggleHoldToCopy,
+                    graphRangeMinutes = graphRangeMinutes,
+                    onSetGraphRange = onSetGraphRange,
                     alertCounts = alertCounts,
                 )
             }
@@ -127,17 +131,25 @@ class SettingsScreenTest {
     }
 
     @Test
+    fun pickingGraphRangeFiresCallback() {
+        var picked: Int? = null
+        content(graphRangeMinutes = 60, onSetGraphRange = { picked = it })
+        composeTestRule.onNodeWithTag("settings-graph-range-360").performScrollTo().performClick()
+        assertEquals(360, picked)
+    }
+
+    @Test
     fun togglingLockFiresCallback() {
         var toggledTo: Boolean? = null
         content(onToggleLock = { toggledTo = it })
-        composeTestRule.onNodeWithTag("settings-lock-toggle").performClick()
+        composeTestRule.onNodeWithTag("settings-lock-toggle").performScrollTo().performClick()
         assertEquals(true, toggledTo)
     }
 
     @Test
     fun unavailableLockShowsHint() {
         content(lockAvailable = false)
-        composeTestRule.onNodeWithTag("settings-lock-unavailable").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("settings-lock-unavailable").performScrollTo().assertIsDisplayed()
     }
 
     @Test


### PR DESCRIPTION
Phase 3 of 3: the Bellhop side of the configurable traffic graph range. Consumes the Front Desk `?window=<minutes>` param from #447 (already merged).

## What
A **Settings picker** for how far back the request charts reach: **1h (default), 3h, 6h, 12h, 24h**, persisted as a device preference (`PrefsStore.graphRangeMinutes`). Coarse presets by design.

The choice flows to **both** the dashboard sparklines and the member-detail graph:
- `FrontDeskClient.memberTraffic` gained a `windowMinutes` arg → `?window=<minutes>`.
- `DashboardViewModel` and `MemberDetailViewModel` hold the window and **force-refetch** the visible charts when it changes, so the graphs redraw at the new span immediately.
- `MainActivity` collects the pref and feeds both VMs + the Settings screen.

## Graceful degradation
Against a Front Desk that predates #447, the unknown `window` param is ignored and the charts fall back to the default series. So the picker is safe to ship before FD is redeployed; the range just won't take effect live until then.

## Tests
Full `:app:testDebugUnitTest` green. New: client sends `?window=` (default and explicit), both VMs refetch with the new window on range change, and the Settings picker fires its callback. ktlint clean; i18n parity 11/11 for the 3 new strings.

## Follow-up (not in this PR)
**Front Desk needs a redeploy** (front-desk.zmrd.uk) for the window param to take effect in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
