### PR TITLE
feat(bellhop): Settings battery-optimization row for reliable alerts

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
 
@@ -21,6 +22,11 @@
          33, requested when the user turns the backstop on in Settings; below 33
          notifications post without it. -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <!-- Lets the Settings "Battery" row open the direct "allow unrestricted
+         battery" prompt so background alert delivery isn't deferred or killed by
+         Doze. Flagged by Play policy; Bellhop is side-loaded, so it's fine here. -->
+    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"
+        tools:ignore="BatteryLife" />
     <uses-feature
         android:name="android.hardware.camera"
         android:required="false" />

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
@@ -1,10 +1,15 @@
 package com.hugalafutro.bellhop
 
 import android.Manifest
+import android.annotation.SuppressLint
 import android.content.Context
+import android.content.Intent
 import android.content.pm.PackageManager
+import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import android.os.PowerManager
+import android.provider.Settings
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
@@ -108,6 +113,26 @@ private fun appLockAuthenticators(): Int =
 private fun canAppLock(context: Context): Boolean =
     BiometricManager.from(context).canAuthenticate(appLockAuthenticators()) == BiometricManager.BIOMETRIC_SUCCESS
 
+// isBatteryUnrestricted reports whether Bellhop is exempt from Doze battery
+// optimisation, so background alert delivery (the Layer-2 poll and Layer-3 push
+// wake) isn't deferred or killed by the OS.
+private fun isBatteryUnrestricted(context: Context): Boolean =
+    (context.getSystemService(Context.POWER_SERVICE) as PowerManager)
+        .isIgnoringBatteryOptimizations(context.packageName)
+
+// requestBatteryExemption opens the system "allow unrestricted battery" prompt for
+// Bellhop. Side-loaded, so the Play-flagged direct-request intent is fine here;
+// aggressive OEM auto-start killers have no reliable deep link and aren't covered.
+@SuppressLint("BatteryLife")
+private fun requestBatteryExemption(context: Context) {
+    context.startActivity(
+        Intent(
+            Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS,
+            Uri.parse("package:${context.packageName}"),
+        ),
+    )
+}
+
 // hasPostNotificationPermission reports whether Bellhop may post notifications.
 // POST_NOTIFICATIONS is a runtime permission from API 33; below that it is granted
 // at install, so the backstop can always post.
@@ -198,6 +223,10 @@ fun BellhopApp() {
     // fires. Refreshed on every return to the foreground, since one may be installed
     // while Bellhop is away.
     var pushDistributorAvailable by remember { mutableStateOf(BellhopPush.hasDistributor(context)) }
+    // Whether Bellhop is exempt from battery optimisation, so background alerts
+    // aren't deferred or killed. Refreshed on every return to the foreground, since
+    // the user may grant it at the system prompt and come back.
+    var batteryUnrestricted by remember { mutableStateOf(isBatteryUnrestricted(context)) }
     // Launcher for the POST_NOTIFICATIONS runtime permission (API 33+), fired when
     // the user turns background monitoring on. A denial is fine: the backstop still
     // polls, and Settings flags that the alerts won't reach them until it's granted.
@@ -305,6 +334,7 @@ fun BellhopApp() {
                         // made in system settings while away.
                         notificationsGranted = hasPostNotificationPermission(context)
                         pushDistributorAvailable = BellhopPush.hasDistributor(context)
+                        batteryUnrestricted = isBatteryUnrestricted(context)
                         // Already locked when we return (e.g. the lock FAB minimised the
                         // app): re-fire the prompt so unlocking is one glance, not a tap
                         // on the lock screen. When the gate below is what flips locked on,
@@ -466,6 +496,8 @@ fun BellhopApp() {
                         pushEndpoint = pushEndpoint,
                         pushDistributorAvailable = pushDistributorAvailable,
                         pushNotificationsBlocked = pushEnabled && !notificationsGranted,
+                        batteryUnrestricted = batteryUnrestricted,
+                        onRequestBatteryExemption = { requestBatteryExemption(context) },
                         scope = scope,
                         unlinking = unlinking,
                         unlinkFailed = unlinkFailed,
@@ -511,6 +543,8 @@ private fun LinkedContent(
     pushEndpoint: String?,
     pushDistributorAvailable: Boolean,
     pushNotificationsBlocked: Boolean,
+    batteryUnrestricted: Boolean,
+    onRequestBatteryExemption: () -> Unit,
     scope: CoroutineScope,
     unlinking: Boolean,
     unlinkFailed: Boolean,
@@ -663,6 +697,8 @@ private fun LinkedContent(
             pushEndpoint = pushEndpoint,
             pushDistributorAvailable = pushDistributorAvailable,
             pushNotificationsBlocked = pushNotificationsBlocked,
+            batteryUnrestricted = batteryUnrestricted,
+            onRequestBatteryExemption = onRequestBatteryExemption,
             onBack = { showSettings = false },
             onToggleLock = { enabled -> scope.launch { lockStore.setEnabled(enabled) } },
             onSelectTimeout = { option -> scope.launch { lockStore.setTimeout(option.millis) } },

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreen.kt
@@ -93,6 +93,8 @@ fun SettingsScreen(
     pushEndpoint: String? = null,
     pushDistributorAvailable: Boolean = false,
     pushNotificationsBlocked: Boolean = false,
+    batteryUnrestricted: Boolean = true,
+    onRequestBatteryExemption: () -> Unit = {},
     unlinking: Boolean = false,
     unlinkFailed: Boolean = false,
     onDismissUnlinkError: () -> Unit = {},
@@ -591,6 +593,50 @@ fun SettingsScreen(
             }
 
             Spacer(modifier = Modifier.height(16.dp))
+
+            // Battery: background alert delivery (the poll + push wake) is only
+            // reliable if Bellhop is exempt from battery optimisation. Shown once
+            // monitoring or push is on, since it's irrelevant otherwise.
+            if (monitorEnabled || pushEnabled) {
+                Card(modifier = Modifier.fillMaxWidth().testTag("settings-battery")) {
+                    Column(
+                        modifier = Modifier.padding(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        Text(
+                            text = stringResource(R.string.settings_battery_title),
+                            style = MaterialTheme.typography.titleMedium,
+                        )
+                        Text(
+                            text = stringResource(R.string.settings_battery_subtitle),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        if (batteryUnrestricted) {
+                            Text(
+                                text = stringResource(R.string.settings_battery_unrestricted),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.testTag("settings-battery-ok"),
+                            )
+                        } else {
+                            Text(
+                                text = stringResource(R.string.settings_battery_optimized),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.error,
+                            )
+                            OutlinedButton(
+                                onClick = onRequestBatteryExemption,
+                                modifier = Modifier.testTag("settings-battery-request"),
+                            ) {
+                                Text(stringResource(R.string.settings_battery_action))
+                            }
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+            }
 
             // Alerts stays reachable here even when all is green (the dashboard bell
             // only appears when a member is down). The severity badges tally what

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreen.kt
@@ -2,6 +2,7 @@ package com.hugalafutro.bellhop.ui.settings
 
 import android.app.Activity
 import android.widget.Toast
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -627,6 +628,10 @@ fun SettingsScreen(
                             )
                             OutlinedButton(
                                 onClick = onRequestBatteryExemption,
+                                // The default outline colour vanishes on the card; use
+                                // primary to match the button's own text and read as an
+                                // action, like the pills' higher-contrast borders.
+                                border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary),
                                 modifier = Modifier.testTag("settings-battery-request"),
                             ) {
                                 Text(stringResource(R.string.settings_battery_action))

--- a/android/app/src/main/res/values-cs/strings.xml
+++ b/android/app/src/main/res/values-cs/strings.xml
@@ -172,6 +172,11 @@
     <string name="settings_monitor_note">Vlastní upozornění Front Desku jsou rychlejší; toto je záloha pro případ, že je Bellhop vaším jediným pohledem. Kontroluje zhruba každých 15 minut, takže změna může přijít až s tímto zpožděním.</string>
     <string name="settings_monitor_blocked">Oznámení pro Bellhop jsou vypnutá, takže se k vám tato upozornění nedostanou. Zapněte je v nastavení systému.</string>
     <string name="settings_push_title">Push v reálném čase</string>
+    <string name="settings_battery_title">Baterie</string>
+    <string name="settings_battery_subtitle">Upozornění na pozadí jsou spolehlivá jen tehdy, když je Bellhop vyňat z optimalizace baterie. Některé telefony také vyžadují povolení automatického spuštění.</string>
+    <string name="settings_battery_unrestricted">Neomezeno. Upozornění mohou běžet na pozadí.</string>
+    <string name="settings_battery_optimized">Optimalizováno. Upozornění na pozadí mohou být opožděná nebo zahozená.</string>
+    <string name="settings_battery_action">Povolit neomezenou baterii</string>
     <string name="settings_push_subtitle">Probudí Bellhop v okamžiku, kdy Front Desk odešle upozornění, přes UnifiedPush a ntfy. Bez Googlu, bez zpoždění dotazování, dobrovolné.</string>
     <string name="settings_push_no_distributor">Nainstalujte distributora UnifiedPush, například ntfy, pro příjem pushů. Bez něj zůstane toto nečinné, dokud ho nepřidáte.</string>
     <string name="settings_push_endpoint_label">Push téma pro Front Desk</string>

--- a/android/app/src/main/res/values-cs/strings.xml
+++ b/android/app/src/main/res/values-cs/strings.xml
@@ -173,8 +173,8 @@
     <string name="settings_monitor_blocked">Oznámení pro Bellhop jsou vypnutá, takže se k vám tato upozornění nedostanou. Zapněte je v nastavení systému.</string>
     <string name="settings_push_title">Push v reálném čase</string>
     <string name="settings_battery_title">Baterie</string>
-    <string name="settings_battery_subtitle">Upozornění na pozadí jsou spolehlivá jen tehdy, když je Bellhop vyňat z optimalizace baterie. Některé telefony také vyžadují povolení automatického spuštění.</string>
-    <string name="settings_battery_unrestricted">Neomezeno. Upozornění mohou běžet na pozadí.</string>
+    <string name="settings_battery_subtitle">Upozornění na pozadí vyžadují, aby byl Bellhop vyňat z optimalizace baterie. Na některých telefonech (OnePlus, Xiaomi a další) to musíte navíc povolit ve vlastním nastavení baterie a automatického spuštění dané aplikace, jinak systém může upozornění zastavit.</string>
+    <string name="settings_battery_unrestricted">Optimalizace baterie je pro Bellhop vypnutá.</string>
     <string name="settings_battery_optimized">Optimalizováno. Upozornění na pozadí mohou být opožděná nebo zahozená.</string>
     <string name="settings_battery_action">Povolit neomezenou baterii</string>
     <string name="settings_push_subtitle">Probudí Bellhop v okamžiku, kdy Front Desk odešle upozornění, přes UnifiedPush a ntfy. Bez Googlu, bez zpoždění dotazování, dobrovolné.</string>

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -171,8 +171,8 @@
     <string name="settings_monitor_blocked">Benachrichtigungen für Bellhop sind ausgeschaltet, daher erreichen dich diese Warnungen nicht. Schalte sie in den Systemeinstellungen ein.</string>
     <string name="settings_push_title">Echtzeit-Push</string>
     <string name="settings_battery_title">Akku</string>
-    <string name="settings_battery_subtitle">Hintergrund-Benachrichtigungen sind nur zuverlässig, wenn Bellhop von der Akku-Optimierung ausgenommen ist. Manche Telefone müssen den Autostart zusätzlich erlauben.</string>
-    <string name="settings_battery_unrestricted">Uneingeschränkt. Benachrichtigungen können im Hintergrund laufen.</string>
+    <string name="settings_battery_subtitle">Hintergrund-Benachrichtigungen erfordern, dass Bellhop von der Akku-Optimierung ausgenommen ist. Auf manchen Telefonen (OnePlus, Xiaomi u.a.) musst du es zusätzlich in den eigenen App-Akku- und Autostart-Einstellungen des Telefons erlauben, sonst kann das System Benachrichtigungen weiterhin stoppen.</string>
+    <string name="settings_battery_unrestricted">Akku-Optimierung ist für Bellhop deaktiviert.</string>
     <string name="settings_battery_optimized">Optimiert. Hintergrund-Benachrichtigungen können verzögert oder verworfen werden.</string>
     <string name="settings_battery_action">Uneingeschränkten Akku erlauben</string>
     <string name="settings_push_subtitle">Weckt Bellhop in dem Moment, in dem Front Desk eine Warnung sendet, über UnifiedPush und ntfy. Kein Google, keine Abrufverzögerung, optional.</string>

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -170,6 +170,11 @@
     <string name="settings_monitor_note">Die eigenen Warnungen von Front Desk sind schneller; dies ist eine Absicherung, wenn Bellhop deine einzige Ansicht ist. Es prüft etwa alle 15 Minuten, eine Änderung kann also bis zu so lange verzögert sein.</string>
     <string name="settings_monitor_blocked">Benachrichtigungen für Bellhop sind ausgeschaltet, daher erreichen dich diese Warnungen nicht. Schalte sie in den Systemeinstellungen ein.</string>
     <string name="settings_push_title">Echtzeit-Push</string>
+    <string name="settings_battery_title">Akku</string>
+    <string name="settings_battery_subtitle">Hintergrund-Benachrichtigungen sind nur zuverlässig, wenn Bellhop von der Akku-Optimierung ausgenommen ist. Manche Telefone müssen den Autostart zusätzlich erlauben.</string>
+    <string name="settings_battery_unrestricted">Uneingeschränkt. Benachrichtigungen können im Hintergrund laufen.</string>
+    <string name="settings_battery_optimized">Optimiert. Hintergrund-Benachrichtigungen können verzögert oder verworfen werden.</string>
+    <string name="settings_battery_action">Uneingeschränkten Akku erlauben</string>
     <string name="settings_push_subtitle">Weckt Bellhop in dem Moment, in dem Front Desk eine Warnung sendet, über UnifiedPush und ntfy. Kein Google, keine Abrufverzögerung, optional.</string>
     <string name="settings_push_no_distributor">Installiere einen UnifiedPush-Distributor wie ntfy, um Pushes zu empfangen. Ohne einen bleibt dies inaktiv, bis du einen hinzufügst.</string>
     <string name="settings_push_endpoint_label">Push-Thema für Front Desk</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -171,8 +171,8 @@
     <string name="settings_monitor_blocked">Las notificaciones de Bellhop están desactivadas, así que estas alertas no te llegarán. Actívalas en los ajustes del sistema.</string>
     <string name="settings_push_title">Push en tiempo real</string>
     <string name="settings_battery_title">Batería</string>
-    <string name="settings_battery_subtitle">Las alertas en segundo plano solo son fiables si Bellhop está exento de la optimización de batería. Algunos teléfonos también necesitan permitir el inicio automático.</string>
-    <string name="settings_battery_unrestricted">Sin restricciones. Las alertas pueden ejecutarse en segundo plano.</string>
+    <string name="settings_battery_subtitle">Las alertas en segundo plano requieren que Bellhop esté exento de la optimización de batería. En algunos teléfonos (OnePlus, Xiaomi y otros) también debes permitirlo en los ajustes de batería por app y de inicio automático del teléfono, o el sistema puede seguir deteniendo las alertas.</string>
+    <string name="settings_battery_unrestricted">La optimización de batería está desactivada para Bellhop.</string>
     <string name="settings_battery_optimized">Optimizado. Las alertas en segundo plano pueden retrasarse o perderse.</string>
     <string name="settings_battery_action">Permitir batería sin restricciones</string>
     <string name="settings_push_subtitle">Despierta Bellhop en el instante en que Front Desk envía una alerta, mediante UnifiedPush y ntfy. Sin Google, sin retardo de sondeo, opcional.</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -170,6 +170,11 @@
     <string name="settings_monitor_note">Las propias alertas de Front Desk son más rápidas; esto es un respaldo para cuando Bellhop es tu única vista. Comprueba aproximadamente cada 15 minutos, así que un cambio puede tardar hasta ese tiempo.</string>
     <string name="settings_monitor_blocked">Las notificaciones de Bellhop están desactivadas, así que estas alertas no te llegarán. Actívalas en los ajustes del sistema.</string>
     <string name="settings_push_title">Push en tiempo real</string>
+    <string name="settings_battery_title">Batería</string>
+    <string name="settings_battery_subtitle">Las alertas en segundo plano solo son fiables si Bellhop está exento de la optimización de batería. Algunos teléfonos también necesitan permitir el inicio automático.</string>
+    <string name="settings_battery_unrestricted">Sin restricciones. Las alertas pueden ejecutarse en segundo plano.</string>
+    <string name="settings_battery_optimized">Optimizado. Las alertas en segundo plano pueden retrasarse o perderse.</string>
+    <string name="settings_battery_action">Permitir batería sin restricciones</string>
     <string name="settings_push_subtitle">Despierta Bellhop en el instante en que Front Desk envía una alerta, mediante UnifiedPush y ntfy. Sin Google, sin retardo de sondeo, opcional.</string>
     <string name="settings_push_no_distributor">Instala un distribuidor de UnifiedPush como ntfy para recibir pushes. Sin uno, esto permanece inactivo hasta que añadas uno.</string>
     <string name="settings_push_endpoint_label">Tema de push para Front Desk</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -171,8 +171,8 @@
     <string name="settings_monitor_blocked">Les notifications sont désactivées pour Bellhop, ces alertes ne vous parviendront donc pas. Activez-les dans les paramètres système.</string>
     <string name="settings_push_title">Push en temps réel</string>
     <string name="settings_battery_title">Batterie</string>
-    <string name="settings_battery_subtitle">Les alertes en arrière-plan ne sont fiables que si Bellhop est exempté de l\'optimisation de la batterie. Certains téléphones doivent aussi autoriser le démarrage automatique.</string>
-    <string name="settings_battery_unrestricted">Sans restriction. Les alertes peuvent s\'exécuter en arrière-plan.</string>
+    <string name="settings_battery_subtitle">Les alertes en arrière-plan nécessitent que Bellhop soit exempté de l\'optimisation de la batterie. Sur certains téléphones (OnePlus, Xiaomi et autres), vous devez aussi l\'autoriser dans les réglages de batterie par appli et de démarrage automatique du téléphone, sinon le système peut quand même arrêter les alertes.</string>
+    <string name="settings_battery_unrestricted">L\'optimisation de la batterie est désactivée pour Bellhop.</string>
     <string name="settings_battery_optimized">Optimisé. Les alertes en arrière-plan peuvent être retardées ou perdues.</string>
     <string name="settings_battery_action">Autoriser la batterie sans restriction</string>
     <string name="settings_push_subtitle">Réveille Bellhop à l\'instant où Front Desk envoie une alerte, via UnifiedPush et ntfy. Sans Google, sans délai de sondage, sur activation.</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -170,6 +170,11 @@
     <string name="settings_monitor_note">Les alertes propres à Front Desk sont plus rapides ; ceci est un filet de sécurité quand Bellhop est votre seule vue. Il vérifie environ toutes les 15 minutes, un changement peut donc arriver avec ce délai.</string>
     <string name="settings_monitor_blocked">Les notifications sont désactivées pour Bellhop, ces alertes ne vous parviendront donc pas. Activez-les dans les paramètres système.</string>
     <string name="settings_push_title">Push en temps réel</string>
+    <string name="settings_battery_title">Batterie</string>
+    <string name="settings_battery_subtitle">Les alertes en arrière-plan ne sont fiables que si Bellhop est exempté de l\'optimisation de la batterie. Certains téléphones doivent aussi autoriser le démarrage automatique.</string>
+    <string name="settings_battery_unrestricted">Sans restriction. Les alertes peuvent s\'exécuter en arrière-plan.</string>
+    <string name="settings_battery_optimized">Optimisé. Les alertes en arrière-plan peuvent être retardées ou perdues.</string>
+    <string name="settings_battery_action">Autoriser la batterie sans restriction</string>
     <string name="settings_push_subtitle">Réveille Bellhop à l\'instant où Front Desk envoie une alerte, via UnifiedPush et ntfy. Sans Google, sans délai de sondage, sur activation.</string>
     <string name="settings_push_no_distributor">Installez un distributeur UnifiedPush tel que ntfy pour recevoir les pushs. Sans lui, ceci reste inactif jusqu\'à ce que vous en ajoutiez un.</string>
     <string name="settings_push_endpoint_label">Sujet push pour Front Desk</string>

--- a/android/app/src/main/res/values-ja/strings.xml
+++ b/android/app/src/main/res/values-ja/strings.xml
@@ -170,8 +170,8 @@
     <string name="settings_monitor_blocked">Bellhop の通知がオフのため、これらのアラートは届きません。システム設定でオンにしてください。</string>
     <string name="settings_push_title">リアルタイム プッシュ</string>
     <string name="settings_battery_title">バッテリー</string>
-    <string name="settings_battery_subtitle">バックグラウンド通知は、Bellhop がバッテリー最適化の対象外の場合のみ確実に届きます。一部の端末では自動起動の許可も必要です。</string>
-    <string name="settings_battery_unrestricted">制限なし。通知はバックグラウンドで動作できます。</string>
+    <string name="settings_battery_subtitle">バックグラウンド通知には、Bellhop をバッテリー最適化の対象外にする必要があります。一部の端末（OnePlus、Xiaomi など）では、端末独自のアプリ別バッテリー設定と自動起動設定でも許可しないと、通知が停止されることがあります。</string>
+    <string name="settings_battery_unrestricted">Bellhop のバッテリー最適化はオフです。</string>
     <string name="settings_battery_optimized">最適化あり。バックグラウンド通知が遅延または破棄される場合があります。</string>
     <string name="settings_battery_action">バッテリー制限を解除</string>
     <string name="settings_push_subtitle">Front Desk がアラートを送信した瞬間に、UnifiedPush と ntfy を通じて Bellhop を起こします。Google 不要、ポーリング遅延なし、任意です。</string>

--- a/android/app/src/main/res/values-ja/strings.xml
+++ b/android/app/src/main/res/values-ja/strings.xml
@@ -169,6 +169,11 @@
     <string name="settings_monitor_note">Front Desk 自身のアラートの方が速いです。これは Bellhop が唯一の表示手段である場合の予備です。約 15 分ごとに確認するため、変更は最大でその程度遅れることがあります。</string>
     <string name="settings_monitor_blocked">Bellhop の通知がオフのため、これらのアラートは届きません。システム設定でオンにしてください。</string>
     <string name="settings_push_title">リアルタイム プッシュ</string>
+    <string name="settings_battery_title">バッテリー</string>
+    <string name="settings_battery_subtitle">バックグラウンド通知は、Bellhop がバッテリー最適化の対象外の場合のみ確実に届きます。一部の端末では自動起動の許可も必要です。</string>
+    <string name="settings_battery_unrestricted">制限なし。通知はバックグラウンドで動作できます。</string>
+    <string name="settings_battery_optimized">最適化あり。バックグラウンド通知が遅延または破棄される場合があります。</string>
+    <string name="settings_battery_action">バッテリー制限を解除</string>
     <string name="settings_push_subtitle">Front Desk がアラートを送信した瞬間に、UnifiedPush と ntfy を通じて Bellhop を起こします。Google 不要、ポーリング遅延なし、任意です。</string>
     <string name="settings_push_no_distributor">プッシュを受け取るには、ntfy などの UnifiedPush ディストリビューターをインストールしてください。ない場合、追加するまでこれは非アクティブのままです。</string>
     <string name="settings_push_endpoint_label">Front Desk 用のプッシュトピック</string>

--- a/android/app/src/main/res/values-nl/strings.xml
+++ b/android/app/src/main/res/values-nl/strings.xml
@@ -170,6 +170,11 @@
     <string name="settings_monitor_note">De eigen waarschuwingen van Front Desk zijn sneller; dit is een vangnet voor wanneer Bellhop je enige zicht is. Het controleert ongeveer elke 15 minuten, dus een wijziging kan tot zo lang later komen.</string>
     <string name="settings_monitor_blocked">Meldingen staan uit voor Bellhop, dus deze waarschuwingen bereiken je niet. Zet ze aan in de systeeminstellingen.</string>
     <string name="settings_push_title">Realtime push</string>
+    <string name="settings_battery_title">Batterij</string>
+    <string name="settings_battery_subtitle">Achtergrondmeldingen zijn alleen betrouwbaar als Bellhop is uitgezonderd van batterijoptimalisatie. Sommige telefoons vereisen ook dat automatisch starten is toegestaan.</string>
+    <string name="settings_battery_unrestricted">Onbeperkt. Meldingen kunnen op de achtergrond draaien.</string>
+    <string name="settings_battery_optimized">Geoptimaliseerd. Achtergrondmeldingen kunnen worden vertraagd of gemist.</string>
+    <string name="settings_battery_action">Onbeperkte batterij toestaan</string>
     <string name="settings_push_subtitle">Wekt Bellhop op het moment dat Front Desk een waarschuwing pusht, via UnifiedPush en ntfy. Geen Google, geen pollvertraging, opt-in.</string>
     <string name="settings_push_no_distributor">Installeer een UnifiedPush-distributeur zoals ntfy om pushes te ontvangen. Zonder een blijft dit inactief tot je er een toevoegt.</string>
     <string name="settings_push_endpoint_label">Push-onderwerp voor Front Desk</string>

--- a/android/app/src/main/res/values-nl/strings.xml
+++ b/android/app/src/main/res/values-nl/strings.xml
@@ -171,8 +171,8 @@
     <string name="settings_monitor_blocked">Meldingen staan uit voor Bellhop, dus deze waarschuwingen bereiken je niet. Zet ze aan in de systeeminstellingen.</string>
     <string name="settings_push_title">Realtime push</string>
     <string name="settings_battery_title">Batterij</string>
-    <string name="settings_battery_subtitle">Achtergrondmeldingen zijn alleen betrouwbaar als Bellhop is uitgezonderd van batterijoptimalisatie. Sommige telefoons vereisen ook dat automatisch starten is toegestaan.</string>
-    <string name="settings_battery_unrestricted">Onbeperkt. Meldingen kunnen op de achtergrond draaien.</string>
+    <string name="settings_battery_subtitle">Achtergrondmeldingen vereisen dat Bellhop is uitgezonderd van batterijoptimalisatie. Op sommige telefoons (OnePlus, Xiaomi e.a.) moet je het ook toestaan in de eigen per-app batterij- en automatisch-startinstellingen van de telefoon, anders kan het systeem meldingen alsnog stoppen.</string>
+    <string name="settings_battery_unrestricted">Batterijoptimalisatie is uit voor Bellhop.</string>
     <string name="settings_battery_optimized">Geoptimaliseerd. Achtergrondmeldingen kunnen worden vertraagd of gemist.</string>
     <string name="settings_battery_action">Onbeperkte batterij toestaan</string>
     <string name="settings_push_subtitle">Wekt Bellhop op het moment dat Front Desk een waarschuwing pusht, via UnifiedPush en ntfy. Geen Google, geen pollvertraging, opt-in.</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -173,8 +173,8 @@
     <string name="settings_monitor_blocked">Powiadomienia dla Bellhop są wyłączone, więc te alerty do Ciebie nie dotrą. Włącz je w ustawieniach systemu.</string>
     <string name="settings_push_title">Push w czasie rzeczywistym</string>
     <string name="settings_battery_title">Bateria</string>
-    <string name="settings_battery_subtitle">Alerty w tle są niezawodne tylko wtedy, gdy Bellhop jest wyłączony z optymalizacji baterii. Niektóre telefony wymagają też zezwolenia na automatyczne uruchamianie.</string>
-    <string name="settings_battery_unrestricted">Bez ograniczeń. Alerty mogą działać w tle.</string>
+    <string name="settings_battery_subtitle">Alerty w tle wymagają wyłączenia Bellhop z optymalizacji baterii. W niektórych telefonach (OnePlus, Xiaomi i innych) trzeba też zezwolić na to we własnych ustawieniach baterii dla aplikacji i autostartu, w przeciwnym razie system może zatrzymać alerty.</string>
+    <string name="settings_battery_unrestricted">Optymalizacja baterii jest wyłączona dla Bellhop.</string>
     <string name="settings_battery_optimized">Zoptymalizowano. Alerty w tle mogą być opóźnione lub pominięte.</string>
     <string name="settings_battery_action">Zezwól na nieograniczoną baterię</string>
     <string name="settings_push_subtitle">Budzi Bellhop w chwili, gdy Front Desk wyśle alert, przez UnifiedPush i ntfy. Bez Google, bez opóźnienia odpytywania, opcjonalne.</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -172,6 +172,11 @@
     <string name="settings_monitor_note">Własne alerty Front Desk są szybsze; to zabezpieczenie na wypadek, gdy Bellhop jest Twoim jedynym widokiem. Sprawdza mniej więcej co 15 minut, więc zmiana może przyjść z takim opóźnieniem.</string>
     <string name="settings_monitor_blocked">Powiadomienia dla Bellhop są wyłączone, więc te alerty do Ciebie nie dotrą. Włącz je w ustawieniach systemu.</string>
     <string name="settings_push_title">Push w czasie rzeczywistym</string>
+    <string name="settings_battery_title">Bateria</string>
+    <string name="settings_battery_subtitle">Alerty w tle są niezawodne tylko wtedy, gdy Bellhop jest wyłączony z optymalizacji baterii. Niektóre telefony wymagają też zezwolenia na automatyczne uruchamianie.</string>
+    <string name="settings_battery_unrestricted">Bez ograniczeń. Alerty mogą działać w tle.</string>
+    <string name="settings_battery_optimized">Zoptymalizowano. Alerty w tle mogą być opóźnione lub pominięte.</string>
+    <string name="settings_battery_action">Zezwól na nieograniczoną baterię</string>
     <string name="settings_push_subtitle">Budzi Bellhop w chwili, gdy Front Desk wyśle alert, przez UnifiedPush i ntfy. Bez Google, bez opóźnienia odpytywania, opcjonalne.</string>
     <string name="settings_push_no_distributor">Zainstaluj dystrybutor UnifiedPush, taki jak ntfy, aby odbierać pushe. Bez niego pozostanie to nieaktywne, dopóki go nie dodasz.</string>
     <string name="settings_push_endpoint_label">Temat push dla Front Desk</string>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -172,6 +172,11 @@
     <string name="settings_monitor_note">Собственные оповещения Front Desk быстрее; это подстраховка на случай, когда Bellhop — ваш единственный обзор. Проверка примерно каждые 15 минут, поэтому изменение может прийти с такой задержкой.</string>
     <string name="settings_monitor_blocked">Уведомления для Bellhop отключены, поэтому эти оповещения до вас не дойдут. Включите их в системных настройках.</string>
     <string name="settings_push_title">Push в реальном времени</string>
+    <string name="settings_battery_title">Батарея</string>
+    <string name="settings_battery_subtitle">Фоновые оповещения надёжны только если Bellhop исключён из оптимизации батареи. На некоторых телефонах также нужно разрешить автозапуск.</string>
+    <string name="settings_battery_unrestricted">Без ограничений. Оповещения могут работать в фоне.</string>
+    <string name="settings_battery_optimized">Оптимизировано. Фоновые оповещения могут задерживаться или теряться.</string>
+    <string name="settings_battery_action">Разрешить работу без ограничений батареи</string>
     <string name="settings_push_subtitle">Будит Bellhop в момент, когда Front Desk отправляет оповещение, через UnifiedPush и ntfy. Без Google, без задержки опроса, по желанию.</string>
     <string name="settings_push_no_distributor">Установите распространитель UnifiedPush, например ntfy, чтобы получать push-уведомления. Без него это остаётся неактивным, пока вы его не добавите.</string>
     <string name="settings_push_endpoint_label">Push-тема для Front Desk</string>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -173,8 +173,8 @@
     <string name="settings_monitor_blocked">Уведомления для Bellhop отключены, поэтому эти оповещения до вас не дойдут. Включите их в системных настройках.</string>
     <string name="settings_push_title">Push в реальном времени</string>
     <string name="settings_battery_title">Батарея</string>
-    <string name="settings_battery_subtitle">Фоновые оповещения надёжны только если Bellhop исключён из оптимизации батареи. На некоторых телефонах также нужно разрешить автозапуск.</string>
-    <string name="settings_battery_unrestricted">Без ограничений. Оповещения могут работать в фоне.</string>
+    <string name="settings_battery_subtitle">Для фоновых оповещений Bellhop должен быть исключён из оптимизации батареи. На некоторых телефонах (OnePlus, Xiaomi и других) это также нужно разрешить в собственных настройках батареи и автозапуска для приложения, иначе система всё равно может останавливать оповещения.</string>
+    <string name="settings_battery_unrestricted">Оптимизация батареи для Bellhop отключена.</string>
     <string name="settings_battery_optimized">Оптимизировано. Фоновые оповещения могут задерживаться или теряться.</string>
     <string name="settings_battery_action">Разрешить работу без ограничений батареи</string>
     <string name="settings_push_subtitle">Будит Bellhop в момент, когда Front Desk отправляет оповещение, через UnifiedPush и ntfy. Без Google, без задержки опроса, по желанию.</string>

--- a/android/app/src/main/res/values-sk/strings.xml
+++ b/android/app/src/main/res/values-sk/strings.xml
@@ -172,6 +172,11 @@
     <string name="settings_monitor_note">Vlastné upozornenia Front Desku sú rýchlejšie; toto je záloha pre prípad, že je Bellhop vaším jediným pohľadom. Kontroluje zhruba každých 15 minút, takže zmena môže prísť až s týmto oneskorením.</string>
     <string name="settings_monitor_blocked">Oznámenia pre Bellhop sú vypnuté, takže sa k vám tieto upozornenia nedostanú. Zapnite ich v nastaveniach systému.</string>
     <string name="settings_push_title">Push v reálnom čase</string>
+    <string name="settings_battery_title">Batéria</string>
+    <string name="settings_battery_subtitle">Upozornenia na pozadí sú spoľahlivé len vtedy, keď je Bellhop vyňatý z optimalizácie batérie. Niektoré telefóny tiež vyžadujú povolenie automatického spustenia.</string>
+    <string name="settings_battery_unrestricted">Bez obmedzení. Upozornenia môžu bežať na pozadí.</string>
+    <string name="settings_battery_optimized">Optimalizované. Upozornenia na pozadí môžu byť oneskorené alebo zahodené.</string>
+    <string name="settings_battery_action">Povoliť neobmedzenú batériu</string>
     <string name="settings_push_subtitle">Zobudí Bellhop v okamihu, keď Front Desk odošle upozornenie, cez UnifiedPush a ntfy. Bez Googlu, bez oneskorenia dopytovania, dobrovoľné.</string>
     <string name="settings_push_no_distributor">Nainštalujte distribútora UnifiedPush, napríklad ntfy, na príjem pushov. Bez neho zostane toto nečinné, kým ho nepridáte.</string>
     <string name="settings_push_endpoint_label">Push téma pre Front Desk</string>

--- a/android/app/src/main/res/values-sk/strings.xml
+++ b/android/app/src/main/res/values-sk/strings.xml
@@ -173,8 +173,8 @@
     <string name="settings_monitor_blocked">Oznámenia pre Bellhop sú vypnuté, takže sa k vám tieto upozornenia nedostanú. Zapnite ich v nastaveniach systému.</string>
     <string name="settings_push_title">Push v reálnom čase</string>
     <string name="settings_battery_title">Batéria</string>
-    <string name="settings_battery_subtitle">Upozornenia na pozadí sú spoľahlivé len vtedy, keď je Bellhop vyňatý z optimalizácie batérie. Niektoré telefóny tiež vyžadujú povolenie automatického spustenia.</string>
-    <string name="settings_battery_unrestricted">Bez obmedzení. Upozornenia môžu bežať na pozadí.</string>
+    <string name="settings_battery_subtitle">Upozornenia na pozadí vyžadujú, aby bol Bellhop vyňatý z optimalizácie batérie. Na niektorých telefónoch (OnePlus, Xiaomi a ďalších) to musíte navyše povoliť vo vlastných nastaveniach batérie pre aplikáciu a automatického spustenia, inak systém môže upozornenia zastaviť.</string>
+    <string name="settings_battery_unrestricted">Optimalizácia batérie je pre Bellhop vypnutá.</string>
     <string name="settings_battery_optimized">Optimalizované. Upozornenia na pozadí môžu byť oneskorené alebo zahodené.</string>
     <string name="settings_battery_action">Povoliť neobmedzenú batériu</string>
     <string name="settings_push_subtitle">Zobudí Bellhop v okamihu, keď Front Desk odošle upozornenie, cez UnifiedPush a ntfy. Bez Googlu, bez oneskorenia dopytovania, dobrovoľné.</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -169,6 +169,11 @@
     <string name="settings_monitor_note">Front Desk 自身的警报更快；这是在 Bellhop 是你唯一视图时的兜底。它大约每 15 分钟检查一次，因此变更最多可能延迟这么久。</string>
     <string name="settings_monitor_blocked">Bellhop 的通知已关闭，因此这些警报无法送达。请在系统设置中开启。</string>
     <string name="settings_push_title">实时推送</string>
+    <string name="settings_battery_title">电池</string>
+    <string name="settings_battery_subtitle">只有当 Bellhop 不受电池优化限制时，后台提醒才可靠。部分手机还需允许自启动。</string>
+    <string name="settings_battery_unrestricted">不受限制。提醒可在后台运行。</string>
+    <string name="settings_battery_optimized">已优化。后台提醒可能被延迟或丢弃。</string>
+    <string name="settings_battery_action">允许不受限制的电池</string>
     <string name="settings_push_subtitle">在 Front Desk 发送警报的那一刻，通过 UnifiedPush 和 ntfy 唤醒 Bellhop。无需 Google，无轮询延迟，可选启用。</string>
     <string name="settings_push_no_distributor">安装 UnifiedPush 分发器（如 ntfy）以接收推送。没有分发器时，此项在你添加之前保持未激活。</string>
     <string name="settings_push_endpoint_label">用于 Front Desk 的推送主题</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -170,8 +170,8 @@
     <string name="settings_monitor_blocked">Bellhop 的通知已关闭，因此这些警报无法送达。请在系统设置中开启。</string>
     <string name="settings_push_title">实时推送</string>
     <string name="settings_battery_title">电池</string>
-    <string name="settings_battery_subtitle">只有当 Bellhop 不受电池优化限制时，后台提醒才可靠。部分手机还需允许自启动。</string>
-    <string name="settings_battery_unrestricted">不受限制。提醒可在后台运行。</string>
+    <string name="settings_battery_subtitle">后台提醒需要将 Bellhop 从电池优化中排除。在部分手机（OnePlus、小米等）上，还需在手机自带的单应用电池和自启动设置中允许，否则系统仍可能停止提醒。</string>
+    <string name="settings_battery_unrestricted">Bellhop 的电池优化已关闭。</string>
     <string name="settings_battery_optimized">已优化。后台提醒可能被延迟或丢弃。</string>
     <string name="settings_battery_action">允许不受限制的电池</string>
     <string name="settings_push_subtitle">在 Front Desk 发送警报的那一刻，通过 UnifiedPush 和 ntfy 唤醒 Bellhop。无需 Google，无轮询延迟，可选启用。</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -185,6 +185,11 @@
     <string name="settings_monitor_note">Front Desk\'s own alerts are faster; this is a backstop for when Bellhop is your only view. It checks roughly every 15 minutes, so a change can be up to that late.</string>
     <string name="settings_monitor_blocked">Notifications are turned off for Bellhop, so these alerts won\'t reach you. Turn them on in system settings.</string>
     <string name="settings_push_title">Real-time push</string>
+    <string name="settings_battery_title">Battery</string>
+    <string name="settings_battery_subtitle">Background alerts are only reliable if Bellhop is exempt from battery optimization. Some phones also need it allowed to auto-start.</string>
+    <string name="settings_battery_unrestricted">Unrestricted. Alerts can run in the background.</string>
+    <string name="settings_battery_optimized">Optimized. Background alerts may be delayed or dropped.</string>
+    <string name="settings_battery_action">Allow unrestricted battery</string>
     <string name="settings_push_subtitle">Wake Bellhop the instant Front Desk pushes an alert, via UnifiedPush and ntfy. No Google, no polling delay, opt-in.</string>
     <string name="settings_push_no_distributor">Install a UnifiedPush distributor such as ntfy to receive pushes. Without one, this stays idle until you add it.</string>
     <string name="settings_push_endpoint_label">Push topic for Front Desk</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -186,8 +186,8 @@
     <string name="settings_monitor_blocked">Notifications are turned off for Bellhop, so these alerts won\'t reach you. Turn them on in system settings.</string>
     <string name="settings_push_title">Real-time push</string>
     <string name="settings_battery_title">Battery</string>
-    <string name="settings_battery_subtitle">Background alerts are only reliable if Bellhop is exempt from battery optimization. Some phones also need it allowed to auto-start.</string>
-    <string name="settings_battery_unrestricted">Unrestricted. Alerts can run in the background.</string>
+    <string name="settings_battery_subtitle">Background alerts need Bellhop exempt from battery optimization. On some phones (OnePlus, Xiaomi and others) you must also allow it in the phone\'s own per-app battery and auto-start settings, or the system can still stop alerts.</string>
+    <string name="settings_battery_unrestricted">Battery optimization is off for Bellhop.</string>
     <string name="settings_battery_optimized">Optimized. Background alerts may be delayed or dropped.</string>
     <string name="settings_battery_action">Allow unrestricted battery</string>
     <string name="settings_push_subtitle">Wake Bellhop the instant Front Desk pushes an alert, via UnifiedPush and ntfy. No Google, no polling delay, opt-in.</string>

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreenTest.kt
@@ -55,6 +55,8 @@ class SettingsScreenTest {
         onToggleHoldToCopy: (Boolean) -> Unit = {},
         graphRangeMinutes: Int = 60,
         onSetGraphRange: (Int) -> Unit = {},
+        batteryUnrestricted: Boolean = true,
+        onRequestBatteryExemption: () -> Unit = {},
         onAlertsClick: () -> Unit = {},
         onUnlink: () -> Unit = {},
         onForceUnlink: () -> Unit = {},
@@ -72,6 +74,8 @@ class SettingsScreenTest {
                     pushEndpoint = pushEndpoint,
                     pushDistributorAvailable = pushDistributorAvailable,
                     pushNotificationsBlocked = pushNotificationsBlocked,
+                    batteryUnrestricted = batteryUnrestricted,
+                    onRequestBatteryExemption = onRequestBatteryExemption,
                     onBack = {},
                     onToggleLock = onToggleLock,
                     onSelectTimeout = onSelectTimeout,
@@ -136,6 +140,24 @@ class SettingsScreenTest {
         content(graphRangeMinutes = 60, onSetGraphRange = { picked = it })
         composeTestRule.onNodeWithTag("settings-graph-range-360").performScrollTo().performClick()
         assertEquals(360, picked)
+    }
+
+    @Test
+    fun batteryRowHiddenWhenBackgroundOff() {
+        content(monitorEnabled = false, pushEnabled = false)
+        composeTestRule.onNodeWithTag("settings-battery").assertDoesNotExist()
+    }
+
+    @Test
+    fun optimizedBatteryOffersRequestThatFires() {
+        var requested = false
+        content(
+            monitorEnabled = true,
+            batteryUnrestricted = false,
+            onRequestBatteryExemption = { requested = true },
+        )
+        composeTestRule.onNodeWithTag("settings-battery-request").performScrollTo().performClick()
+        assertTrue(requested)
     }
 
     @Test


### PR DESCRIPTION
Adds a **Battery** card in Settings so background alert delivery (the Layer-2 poll and Layer-3 push wake) isn't silently killed by Doze.

## What
- Shown only once **background monitoring or push is enabled** (irrelevant otherwise).
- Reports whether Bellhop is exempt from battery optimization via `PowerManager.isIgnoringBatteryOptimizations`; status refreshes on every return to the foreground (`ON_START`).
- When optimized, offers a one-tap **Allow unrestricted battery** button that opens the system `ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` prompt.
- New permission `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` (side-loaded, so the Play-flagged direct request is fine; suppressed via `@SuppressLint` + `tools:ignore="BatteryLife"`).

## Honest about OEMs
The API only sees the **stock AOSP** battery-optimization whitelist. Aggressive OEMs (OnePlus/OxygenOS, Xiaomi/MIUI, …) have their **own** per-app battery + auto-start controls that are decoupled from that flag and invisible to every Android API — verified on a OnePlus 10T (OxygenOS 15), where toggling the OEM control didn't move the flag. So the copy deliberately does **not** over-promise: "unrestricted" reads "Battery optimization is off for Bellhop", and the subtitle spells out that some phones also need their own per-app battery + auto-start allowance or the OS can still stop alerts. The button still does the one genuinely automatable thing (the AOSP exemption).

## Tests
`:app:testDebugUnitTest` green. New SettingsScreenTest cases: the battery card is hidden when background is off, and the request button fires when optimized. ktlint clean; i18n parity 11/11 for the 5 new strings.

## Follow-ups (separate)
- App-lock: optionally require re-auth on a cold start / force-kill, not just the idle window.
- Investigate Bellhop's own battery draw (foreground poll cadence + background worker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
