### PR TITLE
feat(bellhop): re-lock on cold start, not just the idle window

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -5,9 +5,9 @@ from your phone. It links to exactly one Front Desk (FD) instance and only ever 
 to that FD; it never holds a member Model Hotel token. The full design lives in
 [`plans/android-companion-app.md`](../plans/android-companion-app.md).
 
-Current status: Phase A1 (project scaffold). The app builds, shows a placeholder
-dashboard, and has the unit-test and CI plumbing in place. Pairing, the real
-dashboard, notifications, and operator actions arrive in later phases.
+Current status: in active use. Pairing (QR/code), the live dashboard and member
+detail, background monitoring, push notifications, operator actions, an app lock,
+alerts, an event log, a settings screen, and full internationalisation have shipped.
 
 ## Stack
 

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
@@ -45,6 +45,7 @@ import com.hugalafutro.bellhop.data.LockTimeout
 import com.hugalafutro.bellhop.data.MonitorStore
 import com.hugalafutro.bellhop.data.PrefsStore
 import com.hugalafutro.bellhop.data.shouldLock
+import com.hugalafutro.bellhop.data.shouldLockOnEntry
 import com.hugalafutro.bellhop.notify.FleetNotifier
 import com.hugalafutro.bellhop.push.BellhopPush
 import com.hugalafutro.bellhop.ui.alerts.AlertsScreen
@@ -108,6 +109,13 @@ private fun appLockAuthenticators(): Int =
     } else {
         BiometricManager.Authenticators.BIOMETRIC_WEAK or BiometricManager.Authenticators.DEVICE_CREDENTIAL
     }
+
+// Process-scoped: false only on the first BellhopApp composition of a fresh process
+// (a cold start, e.g. after a force-kill or a system kill), true thereafter. A
+// config-change recreation keeps the same process, so it stays true and is not
+// treated as a restart; the process dying resets it. Drives the always-relock on a
+// genuine app restart, distinct from the idle-window relock within a session.
+private var lockColdStartHandled = false
 
 /** canAppLock reports whether a biometric or device credential can gate the app. */
 private fun canAppLock(context: Context): Boolean =
@@ -316,7 +324,16 @@ fun BellhopApp() {
     // the first gate check has to happen here rather than on ON_START.
     LaunchedEffect(Unit) {
         val snap = lockStore.snapshot()
-        if (shouldLock(snap.config, snap.lastForegroundExit, System.currentTimeMillis())) locked = true
+        // A cold start (fresh process, e.g. a force-kill and relaunch) always
+        // re-locks when the lock is enabled: restarting the app must require re-auth,
+        // not silently reuse a still-open session. A config-change recreation keeps
+        // the same process, so it isn't a restart and falls through to the idle-window
+        // check instead.
+        val coldStart = !lockColdStartHandled
+        lockColdStartHandled = true
+        if (shouldLockOnEntry(snap.config, snap.lastForegroundExit, System.currentTimeMillis(), coldStart)) {
+            locked = true
+        }
         lockEvaluated = true
     }
 

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/AppLock.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/AppLock.kt
@@ -47,3 +47,14 @@ fun shouldLock(
     lastForegroundExit: Long,
     now: Long,
 ): Boolean = config.enabled && now - lastForegroundExit > config.timeoutMs
+
+// shouldLockOnEntry is the gate when Bellhop is (re)entered and evaluates the lock.
+// A cold start (a fresh process, e.g. after a force-kill) always re-locks when the
+// lock is enabled: restarting the app must require re-auth, not silently reuse a
+// still-open session. Otherwise it falls back to the idle-window rule [shouldLock].
+fun shouldLockOnEntry(
+    config: LockConfig,
+    lastForegroundExit: Long,
+    now: Long,
+    coldStart: Boolean,
+): Boolean = config.enabled && (coldStart || shouldLock(config, lastForegroundExit, now))

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/AppLockTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/AppLockTest.kt
@@ -41,6 +41,30 @@ class AppLockTest {
     }
 
     @Test
+    fun coldStartAlwaysRelocksWhenEnabled() {
+        val config = LockConfig(enabled = true, timeoutMs = thirtyMin)
+        val exit = 1_000_000L
+        // Well within the idle window: a warm entry would stay open...
+        assertFalse(shouldLockOnEntry(config, lastForegroundExit = exit, now = exit + 1, coldStart = false))
+        // ...but a cold start (a restart) re-locks regardless of the window.
+        assertTrue(shouldLockOnEntry(config, lastForegroundExit = exit, now = exit + 1, coldStart = true))
+    }
+
+    @Test
+    fun coldStartNeverLocksWhenDisabled() {
+        val config = LockConfig(enabled = false, timeoutMs = thirtyMin)
+        assertFalse(shouldLockOnEntry(config, lastForegroundExit = 0L, now = 0L, coldStart = true))
+    }
+
+    @Test
+    fun warmEntryFallsBackToTheIdleWindow() {
+        val config = LockConfig(enabled = true, timeoutMs = thirtyMin)
+        val exit = 1_000_000L
+        assertFalse(shouldLockOnEntry(config, lastForegroundExit = exit, now = exit + thirtyMin, coldStart = false))
+        assertTrue(shouldLockOnEntry(config, lastForegroundExit = exit, now = exit + thirtyMin + 1, coldStart = false))
+    }
+
+    @Test
     fun fromMillisRoundTripsKnownAndFallsBackForUnknown() {
         assertEquals(LockTimeout.FIVE_MINUTES, LockTimeout.fromMillis(LockTimeout.FIVE_MINUTES.millis))
         // A value no option matches (e.g. a future build's window) falls back.


### PR DESCRIPTION
Closes a gap where force-killing Bellhop and reopening within the 30-min idle window logged straight in without re-auth.

## What
- A **cold start** (fresh process: force-kill + relaunch, or a system kill) always re-locks when the app lock is enabled, regardless of the idle window.
- A **config-change recreation** (rotate, theme, language) keeps the same process and is **not** treated as a restart, so it doesn't re-lock.
- The decision is a pure, tested `shouldLockOnEntry(config, lastExit, now, coldStart)` in `AppLock.kt`; a process-scoped flag (`lockColdStartHandled`) distinguishes a genuine cold start from a recreation.

## Also
- Refreshes `android/README.md`'s stale "Phase A1 (project scaffold)" status line (reviewer catch).

## Tests
New AppLockTest cases: cold-start re-locks when enabled, never locks when disabled, and a warm entry falls back to the idle window. `:app:testDebugUnitTest` + ktlint green. Verified on-device (OnePlus 10T).

🤖 Generated with [Claude Code](https://claude.com/claude-code)