### PR TITLE
feat(frontdesk): attach each member's newest event to the members list

### DIFF
--- a/internal/frontdesk/server_members.go
+++ b/internal/frontdesk/server_members.go
@@ -19,6 +19,10 @@ import (
 type memberView struct {
 	*Member
 	Status MemberStatus `json:"status"`
+	// NewestEvent is this member's most recent member-scoped event, attached so a
+	// monitor client renders its latest-event pill without a per-member events
+	// fetch. Omitted when the member has no events yet.
+	NewestEvent *Event `json:"newest_event,omitempty"`
 }
 
 func (s *Server) listMembers(w http.ResponseWriter, r *http.Request) {
@@ -28,9 +32,23 @@ func (s *Server) listMembers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	snap := s.poller.Snapshot()
+	// Each member's newest event is read in one grouped query and attached inline
+	// so a monitor client can render every card's latest-event pill without a
+	// per-member events fetch. This read is best-effort: a failure must not fail
+	// the members list, so it degrades to no inline pills (clients then fall back
+	// to their own per-member fetch) rather than 500ing the whole tab.
+	newest, err := s.store.NewestEventPerMember(r.Context())
+	if err != nil {
+		debuglog.Warn("frontdesk: could not read newest events for members list", "error", err)
+		newest = nil
+	}
 	views := make([]memberView, len(members))
 	for i, m := range members {
 		views[i] = memberView{Member: m, Status: snap[m.ID]}
+		if e, ok := newest[m.ID]; ok {
+			ev := e
+			views[i].NewestEvent = &ev
+		}
 	}
 	writeJSON(w, http.StatusOK, views)
 }

--- a/internal/frontdesk/server_test.go
+++ b/internal/frontdesk/server_test.go
@@ -227,6 +227,47 @@ func TestServerMemberCRUD(t *testing.T) {
 	}
 }
 
+func TestListMembersAttachesNewestEvent(t *testing.T) {
+	srv, store := newTestServer(t)
+	ctx := context.Background()
+
+	withEvents, err := store.CreateMember(ctx, "hotel-1", "https://h1.example", "")
+	if err != nil {
+		t.Fatalf("CreateMember: %v", err)
+	}
+	noEvents, err := store.CreateMember(ctx, "hotel-2", "https://h2.example", "")
+	if err != nil {
+		t.Fatalf("CreateMember: %v", err)
+	}
+	if _, err := store.InsertEvent(ctx, Event{
+		Type: "health.up", Severity: "success", Source: "poller", Message: "up", MemberID: withEvents.ID,
+	}); err != nil {
+		t.Fatalf("InsertEvent: %v", err)
+	}
+
+	rec := do(t, srv, http.MethodGet, "/api/members", "", true)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /api/members = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var views []memberView
+	if err := json.Unmarshal(rec.Body.Bytes(), &views); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	byID := make(map[string]memberView, len(views))
+	for _, v := range views {
+		byID[v.ID] = v
+	}
+	if got := byID[withEvents.ID].NewestEvent; got == nil || got.Type != "health.up" {
+		t.Errorf("member with events: newest_event = %+v, want type health.up", got)
+	}
+	// A member with no events omits the field entirely (omitempty), so a client
+	// can tell a genuinely event-free member from an older Front Desk that never
+	// sends it.
+	if byID[noEvents.ID].NewestEvent != nil {
+		t.Errorf("member with no events should omit newest_event, got %+v", byID[noEvents.ID].NewestEvent)
+	}
+}
+
 func TestServerSettings(t *testing.T) {
 	srv, _ := newTestServer(t)
 

--- a/internal/frontdesk/store_errors_test.go
+++ b/internal/frontdesk/store_errors_test.go
@@ -54,6 +54,9 @@ func TestStoreMethodsErrorWhenDBClosed(t *testing.T) {
 	if _, _, err := s.ListEvents(ctx, EventFilter{Limit: 10}); err == nil {
 		t.Error("ListEvents: want error")
 	}
+	if _, err := s.NewestEventPerMember(ctx); err == nil {
+		t.Error("NewestEventPerMember: want error")
+	}
 	if _, err := s.PruneEvents(ctx, 30); err == nil {
 		t.Error("PruneEvents: want error")
 	}

--- a/internal/frontdesk/store_events.go
+++ b/internal/frontdesk/store_events.go
@@ -79,6 +79,37 @@ func (s *Store) ListEvents(ctx context.Context, f EventFilter) ([]Event, int, er
 	return events, total, rows.Err()
 }
 
+// NewestEventPerMember returns each member's most recent member-scoped event,
+// keyed by member id. Fleet-wide events (those with no member_id) are excluded,
+// matching a per-member events read. It backs the members list's inline newest
+// event so a monitor client can render every card's latest-event pill from one
+// read instead of a per-member fan-out. A member with no events is simply absent
+// from the map. The id tiebreak keeps the pick deterministic when two events
+// share a timestamp.
+func (s *Store) NewestEventPerMember(ctx context.Context) (map[string]Event, error) {
+	const query = `SELECT id, type, severity, source, message, metadata, member_id, created_at FROM (
+		SELECT id, type, severity, source, message, metadata, member_id, created_at,
+		       ROW_NUMBER() OVER (PARTITION BY member_id ORDER BY created_at DESC, id DESC) AS rn
+		FROM events
+		WHERE member_id IS NOT NULL AND member_id <> ''
+	) WHERE rn = 1`
+	rows, err := s.db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("frontdesk: newest event per member: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := make(map[string]Event)
+	for rows.Next() {
+		e, err := scanEvent(rows)
+		if err != nil {
+			return nil, err
+		}
+		out[e.MemberID] = e
+	}
+	return out, rows.Err()
+}
+
 // PruneEvents deletes events older than retentionDays and returns the count
 // removed.
 func (s *Store) PruneEvents(ctx context.Context, retentionDays int) (int64, error) {

--- a/internal/frontdesk/store_test.go
+++ b/internal/frontdesk/store_test.go
@@ -304,6 +304,48 @@ func TestEventsInsertListFilter(t *testing.T) {
 	}
 }
 
+func TestNewestEventPerMember(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	a, _ := s.CreateMember(ctx, "a", "http://a:8081", "")
+	b, _ := s.CreateMember(ctx, "b", "http://b:8081", "")
+
+	base := time.Now().UTC()
+	// a has two events; the newer one (health.up) must win. Explicit timestamps
+	// keep the pick deterministic rather than leaning on insert-time spacing.
+	_, _ = s.InsertEvent(ctx, Event{Type: "member.added", Severity: "info", Source: "frontdesk", Message: "added", MemberID: a.ID, CreatedAt: base})
+	_, _ = s.InsertEvent(ctx, Event{Type: "health.up", Severity: "success", Source: "poller", Message: "up", MemberID: a.ID, CreatedAt: base.Add(time.Minute)})
+	// b has one event.
+	_, _ = s.InsertEvent(ctx, Event{Type: "health.down", Severity: "error", Source: "poller", Message: "down", MemberID: b.ID, CreatedAt: base})
+	// A fleet-wide event (no member_id) must never appear in the map.
+	_, _ = s.InsertEvent(ctx, Event{Type: "config.regenerated", Severity: "info", Source: "frontdesk", Message: "regen", CreatedAt: base})
+
+	got, err := s.NewestEventPerMember(ctx)
+	if err != nil {
+		t.Fatalf("NewestEventPerMember: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d members, want 2 (fleet-wide event must be excluded): %+v", len(got), got)
+	}
+	if got[a.ID].Type != "health.up" {
+		t.Errorf("member a newest = %q, want health.up", got[a.ID].Type)
+	}
+	if got[b.ID].Type != "health.down" {
+		t.Errorf("member b newest = %q, want health.down", got[b.ID].Type)
+	}
+
+	// A fleet with no member-scoped events yields an empty (non-nil) map.
+	empty := newTestStore(t)
+	m, err := empty.NewestEventPerMember(ctx)
+	if err != nil {
+		t.Fatalf("NewestEventPerMember (empty): %v", err)
+	}
+	if len(m) != 0 {
+		t.Errorf("empty store: got %d, want 0", len(m))
+	}
+}
+
 func TestEventsPagination(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()


### PR DESCRIPTION
## What

`GET /api/members` now attaches each member's newest member-scoped event inline as `newest_event`, read in one grouped SQLite query (`Store.NewestEventPerMember`, `ROW_NUMBER() PARTITION BY member_id`). Fleet-wide events (no `member_id`) are excluded, matching a per-member events read.

## Why

A monitor client (Bellhop) that wants each card's latest-event pill had to make one `/api/events` fetch per member on top of the members read. On a phone polling on a cadence, that turned every refresh into a per-member radio wake and was the largest share of the app's foreground request traffic. Serving the newest event inline lets the whole list plus every pill come back in one request.

## Notes

- Additive and backward-compatible: the field is `omitempty`, so a member with no events omits it and existing clients are unaffected.
- The read is best-effort: if it fails, the list still returns without the inline events (the warning is logged) and clients fall back to their own per-member fetch, rather than 500ing the whole tab.
- **This is the prerequisite for the Bellhop "inline newest event" PR**, which drops its per-member fetch once this is deployed.

## Tests

New `TestNewestEventPerMember` (newest-wins, fleet-wide excluded, empty store). Full frontdesk suite (228) and golangci-lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)