### PR TITLE
perf(bellhop): slacken the dashboard poll while the SSE stream is healthy

### DIFF
--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModel.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModel.kt
@@ -90,6 +90,7 @@ class DashboardViewModel(
     private val linkStore: LinkStore,
     private val fdUrl: String,
     private val pollIntervalMs: Long = POLL_INTERVAL_MS,
+    private val sseHealthyPollIntervalMs: Long = SSE_HEALTHY_POLL_INTERVAL_MS,
     private val trafficPollMs: Long = TRAFFIC_POLL_MS,
     private val now: () -> Long = System::currentTimeMillis,
 ) : ViewModel() {
@@ -99,6 +100,13 @@ class DashboardViewModel(
     // Conflated: rapid nudges from the poll and the event stream coalesce into at
     // most one queued refresh instead of stacking sequential fetches.
     private val refreshTrigger = Channel<Unit>(Channel.CONFLATED)
+
+    // Whether the SSE stream is currently connected. It drives the fallback poll
+    // cadence: while the stream is live it carries changes, so [pollLoop] slackens
+    // to save the radio; while it's down the poll tightens to stay the sole
+    // freshness source. A StateFlow so pollLoop reacts the instant it flips (via
+    // collectLatest) instead of waiting out a slow delay. [streamLoop] owns it.
+    private val sseConnected = MutableStateFlow(false)
 
     // The member ids currently visible in the list, reported by the screen. Only
     // these get their traffic sparkline fetched, so the per-member fan-out is
@@ -162,40 +170,67 @@ class DashboardViewModel(
     }
 
     // pollLoop is the fallback safety net: with the stream carrying live changes,
-    // this only has to catch a missed event and keep the view from going stale.
+    // this only has to catch a missed event and keep the view from going stale. It
+    // runs slack while the stream is healthy (the radio can idle between ticks) and
+    // tight while the stream is down (the poll is then the only freshness source).
+    // Keyed on [sseConnected] via collectLatest so a disconnect re-tightens the
+    // cadence at once — the pending slack delay is cancelled, not waited out.
     private suspend fun pollLoop() {
-        while (true) {
-            delay(pollIntervalMs)
-            refreshTrigger.trySend(Unit)
+        sseConnected.collectLatest { connected ->
+            val interval = if (connected) sseHealthyPollIntervalMs else pollIntervalMs
+            while (true) {
+                delay(interval)
+                refreshTrigger.trySend(Unit)
+            }
         }
     }
 
     // streamLoop holds a live SSE subscription while the dashboard is shown,
     // reconnecting with capped exponential backoff. It nudges a refresh on any
-    // event that changes what the list shows and stops for good on a dead token.
+    // event that changes what the list shows, resyncs on every reconnect (a gap
+    // may have dropped events the slack poll hasn't caught yet), and stops for good
+    // on a dead token.
     private suspend fun streamLoop() {
+        // A fresh active-collector cycle starts disconnected until Open fires, so
+        // pollLoop doesn't inherit a stale "connected" from a prior cycle.
+        sseConnected.value = false
         // No readable token means no request can ever succeed; the poll's
         // refreshOnce already flags this as revoked, so just stay off the stream.
         val token = linkStore.token() ?: return
         var backoff = SSE_BACKOFF_MIN_MS
+        // The first Open is the initial connect, which runRefreshes already
+        // covered with its startup read; only subsequent Opens are reconnects that
+        // need a resync. Tracks across reconnects within this loop, not per socket.
+        var firstConnect = true
         while (true) {
             var revoked = false
+            var connectedAt: Long? = null
             client.streamEvents(fdUrl, token).collect { msg ->
                 when (msg) {
-                    // A fresh connection: reset backoff so the next drop reconnects
-                    // fast even after a long, quiet, healthy stream.
-                    SseMessage.Open -> backoff = SSE_BACKOFF_MIN_MS
+                    SseMessage.Open -> {
+                        connectedAt = now()
+                        sseConnected.value = true
+                        if (!firstConnect) refreshTrigger.trySend(Unit)
+                        firstConnect = false
+                    }
                     is SseMessage.Event ->
                         if (triggersRefresh(msg.event.type)) refreshTrigger.trySend(Unit)
                     SseMessage.Unauthorized -> revoked = true
                 }
             }
+            sseConnected.value = false
             if (revoked) {
                 _state.update { it.copy(revoked = true) }
                 return
             }
+            // Reset the backoff only when the connection proved durable. If Open
+            // alone reset it, a server (or proxy) that accepts the stream then
+            // drops it immediately would spin a ~1s reconnect loop forever; keying
+            // the reset on how long the connection lasted keeps a flapping endpoint
+            // backing off instead.
+            val lasted = connectedAt?.let { now() - it } ?: 0L
+            backoff = nextBackoff(backoff, lasted)
             delay(backoff)
-            backoff = (backoff * 2).coerceAtMost(SSE_BACKOFF_MAX_MS)
         }
     }
 
@@ -458,9 +493,17 @@ class DashboardViewModel(
     }
 
     companion object {
-        // Fallback cadence now that the SSE stream carries live changes: slow
-        // enough to be polite from a phone, fast enough to backstop a missed event.
+        // Fallback cadence while the SSE stream is DOWN: the poll is then the only
+        // freshness source, so it stays tight. Once the stream is live, pollLoop
+        // switches to [SSE_HEALTHY_POLL_INTERVAL_MS] instead.
         const val POLL_INTERVAL_MS = 15_000L
+
+        // Fallback cadence while the SSE stream is healthy: the stream carries live
+        // changes, so the poll only has to backstop a rare missed event and keep
+        // relative times honest. Four times slacker than the disconnected cadence,
+        // which is what lets the radio idle between ticks instead of waking every
+        // 15s for the whole time the dashboard is open.
+        const val SSE_HEALTHY_POLL_INTERVAL_MS = 60_000L
 
         // Traffic sparklines refresh slower than the health poll: the series is
         // 5-minute buckets, so a per-minute tick keeps the current bucket moving
@@ -478,6 +521,29 @@ class DashboardViewModel(
         // SSE reconnect backoff, mirroring the web dashboard's 1s..30s range.
         const val SSE_BACKOFF_MIN_MS = 1_000L
         const val SSE_BACKOFF_MAX_MS = 30_000L
+
+        // A stream must stay connected at least this long to count as durable and
+        // earn a fast reconnect (see [nextBackoff]). Above the 25s server heartbeat
+        // so a genuinely live stream qualifies, while an accept-then-drop (which
+        // fails in well under a second) never does.
+        const val SSE_STABLE_MS = 30_000L
+
+        // nextBackoff picks the wait before the next SSE reconnect. A connection
+        // that lasted at least [SSE_STABLE_MS] is healthy and resets to the floor
+        // for a prompt reconnect; a shorter-lived one (including one that never
+        // opened, or a server that accepts then drops at once) doubles the backoff
+        // up to the cap, so a flapping endpoint can't spin a tight reconnect loop.
+        // internal so the decision is unit-testable without driving the stream in
+        // real time.
+        internal fun nextBackoff(
+            current: Long,
+            connectedMs: Long,
+        ): Long =
+            if (connectedMs >= SSE_STABLE_MS) {
+                SSE_BACKOFF_MIN_MS
+            } else {
+                (current * 2).coerceAtMost(SSE_BACKOFF_MAX_MS)
+            }
 
         // triggersRefresh mirrors the Front Desk web dashboard: only membership,
         // config, health, and version events change what a member card shows, so

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModelTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModelTest.kt
@@ -628,4 +628,91 @@ class DashboardViewModelTest {
             assertTrue(s.revoked)
             job.cancel()
         }
+
+    @Test
+    fun nextBackoffResetsOnlyForDurableConnections() {
+        // A connection that outlived the stable threshold is healthy: reset to the
+        // floor so the next reconnect is prompt.
+        assertEquals(
+            DashboardViewModel.SSE_BACKOFF_MIN_MS,
+            DashboardViewModel.nextBackoff(current = 8_000L, connectedMs = DashboardViewModel.SSE_STABLE_MS),
+        )
+        // A short-lived connection (accept-then-drop) doubles the backoff...
+        assertEquals(2_000L, DashboardViewModel.nextBackoff(current = 1_000L, connectedMs = 200L))
+        // ...capped at the ceiling so a flapping endpoint can't spin faster.
+        assertEquals(
+            DashboardViewModel.SSE_BACKOFF_MAX_MS,
+            DashboardViewModel.nextBackoff(current = 20_000L, connectedMs = 200L),
+        )
+        // A connection that never opened (0ms) counts as short-lived, not durable.
+        assertEquals(2_000L, DashboardViewModel.nextBackoff(current = 1_000L, connectedMs = 0L))
+    }
+
+    @Test
+    fun liveStreamSlackensTheFallbackPoll() =
+        runBlocking {
+            // While the stream is Open it carries live changes, so the fallback poll
+            // must back off to the slack cadence. With a tight base poll and a slack
+            // healthy poll, an open stream means the members read stops climbing.
+            val events = MutableSharedFlow<SseMessage>(extraBufferCapacity = 8)
+            val client = FakeFleetClient(FetchResult.Success(listOf(member)), sseFlow = events)
+            val vm =
+                DashboardViewModel(
+                    client,
+                    linkedStore(),
+                    "http://fd:1",
+                    pollIntervalMs = 30,
+                    sseHealthyPollIntervalMs = 10_000,
+                )
+
+            val job = launch { vm.state.collect {} }
+            // Disconnected, the tight base poll fires repeatedly.
+            withTimeout(5_000) { while (client.memberCalls.get() < 3) delay(20) }
+
+            // The stream connects: pollLoop switches to the slack cadence and quiesces.
+            withTimeout(5_000) { events.subscriptionCount.first { it > 0 } }
+            events.emit(SseMessage.Open)
+            delay(200)
+            val settled = client.memberCalls.get()
+            delay(400)
+            // At the 10s healthy cadence, no further poll fires in this window.
+            assertEquals(settled, client.memberCalls.get())
+            job.cancel()
+        }
+
+    @Test
+    fun reconnectResyncsButTheFirstConnectDoesNot() =
+        runBlocking {
+            // The first Open is the initial connect, already covered by the startup
+            // read, so it must not double it. A later Open is a reconnect whose gap
+            // may have dropped events, so it must resync without waiting for the poll.
+            val events = MutableSharedFlow<SseMessage>(extraBufferCapacity = 8)
+            val client = FakeFleetClient(FetchResult.Success(listOf(member)), sseFlow = events)
+            val vm =
+                DashboardViewModel(
+                    client,
+                    linkedStore(),
+                    "http://fd:1",
+                    // Both poll cadences are held out of the window so only the
+                    // reconnect nudge can move the members read.
+                    pollIntervalMs = 10_000,
+                    sseHealthyPollIntervalMs = 10_000,
+                )
+
+            val job = launch { vm.state.collect {} }
+            withTimeout(5_000) { vm.state.first { !it.loading } }
+            withTimeout(5_000) { events.subscriptionCount.first { it > 0 } }
+            val afterInitial = client.memberCalls.get()
+
+            // First Open: no extra read.
+            events.emit(SseMessage.Open)
+            delay(200)
+            assertEquals(afterInitial, client.memberCalls.get())
+
+            // Second Open (a reconnect): resyncs.
+            events.emit(SseMessage.Open)
+            withTimeout(5_000) { while (client.memberCalls.get() == afterInitial) delay(20) }
+            assertTrue(client.memberCalls.get() > afterInitial)
+            job.cancel()
+        }
 }


### PR DESCRIPTION
## What

While the dashboard is open, the fallback poll fired every 15s the whole time, so with the SSE stream also live the radio never got to idle. Since the stream already carries live changes:

- Back the poll off to a **60s slack cadence while the stream is connected**, and only tighten back to 15s when the stream drops (the poll is then the sole freshness source). `pollLoop` is keyed on the stream's connected state via `collectLatest`, so a disconnect re-tightens at once instead of waiting out the slack delay.
- Keep freshness while slack by **resyncing on every reconnect** (a gap may have dropped events the slow poll hasn't caught), skipping only the initial connect that the startup read already covered.
- Fix the SSE reconnect backoff: resetting it on `Open` alone let a server (or proxy) that accepts the stream then drops it immediately spin a ~1s reconnect loop forever. The reset is now gated on the connection having lasted long enough to count as durable (`nextBackoff`), so a flapping endpoint backs off instead.

## Why

Foreground request cadence was the dominant battery cost: profiling showed ~18.9 req/min on the dashboard (a request every ~3s), which keeps the LTE radio out of idle for the whole time the app is open. Backing off the poll while SSE is healthy is the biggest single lever.

## Tests

3 new (`nextBackoffResetsOnlyForDurableConnections`, `liveStreamSlackensTheFallbackPoll`, `reconnectResyncsButTheFirstConnectDoesNot`), ktlint + suite green, stress-reran.

Independent of the other two Bellhop/Front Desk battery PRs; can merge in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)