### PR TITLE
test(api): de-flake TestDBLogWriter_BatchSizeFlush with a poll deadline

### DIFF
--- a/internal/api/applogs_test.go
+++ b/internal/api/applogs_test.go
@@ -789,14 +789,21 @@ func TestDBLogWriter_BatchSizeFlush(t *testing.T) {
 		}
 	}
 
-	// Give the goroutine time to process
-	time.Sleep(200 * time.Millisecond)
-
-	// Verify entries were written to DB
+	// Poll until the batch-size flush lands in the DB or we time out. A fixed
+	// sleep is flaky: the writer goroutine's schedule plus the 50-row INSERT can
+	// exceed a short sleep under CI load, so a single check races the flush (this
+	// mirrors TestDBLogWriter_TickerFlush).
+	deadline := time.Now().Add(5 * time.Second)
 	var count int
-	err = pool.QueryRow(context.Background(), "SELECT COUNT(*) FROM app_logs WHERE source = 'test'").Scan(&count)
-	if err != nil {
-		t.Fatalf("failed to query app_logs: %v", err)
+	for time.Now().Before(deadline) {
+		err = pool.QueryRow(context.Background(), "SELECT COUNT(*) FROM app_logs WHERE source = 'test'").Scan(&count)
+		if err != nil {
+			t.Fatalf("failed to query app_logs: %v", err)
+		}
+		if count >= 50 {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
 	}
 	if count < 50 {
 		t.Errorf("expected at least 50 entries in DB, got %d", count)


### PR DESCRIPTION
## What

`TestDBLogWriter_BatchSizeFlush` sent 50 log entries, did a fixed `time.Sleep(200ms)`, then checked the DB row count once. Replace that with a poll on a 5s deadline (100ms interval), mirroring the sibling `TestDBLogWriter_TickerFlush` which was already converted for the same reason.

## Why

Under CI load the async writer goroutine's schedule plus the 50-row batch INSERT can exceed 200ms, so the single check races the batch-size flush and sees 0 rows. Observed failing on an unrelated PR's Go Test run:

```
applogs_test.go:802: expected at least 50 entries in DB, got 0
```

The poll makes it deterministic (passes as soon as the flush lands, only fails if it truly never happens within 5s) and is actually faster in the common case (~0.11s vs a fixed 200ms).

## Test

`go test ./internal/api/ -run TestDBLogWriter_BatchSizeFlush -count=5` passes 5/5 locally against the test DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)