### PR TITLE
fix(bellhop): label the config.autosync_stale alert event (11 locales)

### DIFF
--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/alerts/AlertsScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/alerts/AlertsScreen.kt
@@ -305,6 +305,7 @@ private fun eventTypeLabel(type: String): String =
         "config.sync_failed" -> stringResource(R.string.alerts_event_config_sync_failed)
         "config.synced" -> stringResource(R.string.alerts_event_config_synced)
         "config.auto_synced" -> stringResource(R.string.alerts_event_config_auto_synced)
+        "config.autosync_stale" -> stringResource(R.string.alerts_event_config_autosync_stale)
         "version.fetch_failed" -> stringResource(R.string.alerts_event_version_fetch_failed)
         "version.fetch_recovered" -> stringResource(R.string.alerts_event_version_fetch_recovered)
         "traefik.stale" -> stringResource(R.string.alerts_event_traefik_stale)

--- a/android/app/src/main/res/values-cs/strings.xml
+++ b/android/app/src/main/res/values-cs/strings.xml
@@ -120,6 +120,7 @@
     <string name="alerts_event_config_sync_failed">Synchronizace konfigurace selhala</string>
     <string name="alerts_event_config_synced">Konfigurace synchronizována</string>
     <string name="alerts_event_config_auto_synced">Konfigurace automaticky synchronizována</string>
+    <string name="alerts_event_config_autosync_stale">Automatická synchronizace vypnutá, flotila nesynchronizovaná</string>
     <string name="alerts_event_version_fetch_failed">Čtení verze selhalo</string>
     <string name="alerts_event_version_fetch_recovered">Čtení verze obnoveno</string>
     <string name="alerts_event_traefik_stale">Konfigurace Traefiku zastaralá</string>

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -118,6 +118,7 @@
     <string name="alerts_event_config_sync_failed">Konfigurationssynchronisierung fehlgeschlagen</string>
     <string name="alerts_event_config_synced">Konfiguration synchronisiert</string>
     <string name="alerts_event_config_auto_synced">Konfiguration automatisch synchronisiert</string>
+    <string name="alerts_event_config_autosync_stale">Auto-Sync aus, Flotte nicht synchronisiert</string>
     <string name="alerts_event_version_fetch_failed">Versionsabruf fehlgeschlagen</string>
     <string name="alerts_event_version_fetch_recovered">Versionsabruf wiederhergestellt</string>
     <string name="alerts_event_traefik_stale">Traefik-Konfiguration veraltet</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -118,6 +118,7 @@
     <string name="alerts_event_config_sync_failed">Fallo al sincronizar la configuración</string>
     <string name="alerts_event_config_synced">Configuración sincronizada</string>
     <string name="alerts_event_config_auto_synced">Configuración sincronizada automáticamente</string>
+    <string name="alerts_event_config_autosync_stale">Sincronización automática desactivada, flota sin sincronizar</string>
     <string name="alerts_event_version_fetch_failed">Fallo al leer la versión</string>
     <string name="alerts_event_version_fetch_recovered">Lectura de versión recuperada</string>
     <string name="alerts_event_traefik_stale">Configuración de Traefik obsoleta</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -118,6 +118,7 @@
     <string name="alerts_event_config_sync_failed">Échec de la synchro de config</string>
     <string name="alerts_event_config_synced">Config synchronisée</string>
     <string name="alerts_event_config_auto_synced">Config synchronisée automatiquement</string>
+    <string name="alerts_event_config_autosync_stale">Synchronisation automatique désactivée, flotte non synchronisée</string>
     <string name="alerts_event_version_fetch_failed">Échec de lecture de la version</string>
     <string name="alerts_event_version_fetch_recovered">Lecture de la version rétablie</string>
     <string name="alerts_event_traefik_stale">Config Traefik obsolète</string>

--- a/android/app/src/main/res/values-ja/strings.xml
+++ b/android/app/src/main/res/values-ja/strings.xml
@@ -117,6 +117,7 @@
     <string name="alerts_event_config_sync_failed">設定の同期に失敗</string>
     <string name="alerts_event_config_synced">設定を同期</string>
     <string name="alerts_event_config_auto_synced">設定を自動同期</string>
+    <string name="alerts_event_config_autosync_stale">自動同期オフ、フリート未同期</string>
     <string name="alerts_event_version_fetch_failed">バージョン取得に失敗</string>
     <string name="alerts_event_version_fetch_recovered">バージョン取得が復旧</string>
     <string name="alerts_event_traefik_stale">Traefik 設定が古い</string>

--- a/android/app/src/main/res/values-nl/strings.xml
+++ b/android/app/src/main/res/values-nl/strings.xml
@@ -118,6 +118,7 @@
     <string name="alerts_event_config_sync_failed">Configuratiesynchronisatie mislukt</string>
     <string name="alerts_event_config_synced">Configuratie gesynchroniseerd</string>
     <string name="alerts_event_config_auto_synced">Configuratie automatisch gesynchroniseerd</string>
+    <string name="alerts_event_config_autosync_stale">Auto-sync uit, vloot niet gesynchroniseerd</string>
     <string name="alerts_event_version_fetch_failed">Versie lezen mislukt</string>
     <string name="alerts_event_version_fetch_recovered">Versie lezen hersteld</string>
     <string name="alerts_event_traefik_stale">Traefik-configuratie verouderd</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -120,6 +120,7 @@
     <string name="alerts_event_config_sync_failed">Synchronizacja konfiguracji nie powiodła się</string>
     <string name="alerts_event_config_synced">Konfiguracja zsynchronizowana</string>
     <string name="alerts_event_config_auto_synced">Konfiguracja zsynchronizowana automatycznie</string>
+    <string name="alerts_event_config_autosync_stale">Auto-synchronizacja wyłączona, flota niezsynchronizowana</string>
     <string name="alerts_event_version_fetch_failed">Odczyt wersji nie powiódł się</string>
     <string name="alerts_event_version_fetch_recovered">Odczyt wersji przywrócony</string>
     <string name="alerts_event_traefik_stale">Konfiguracja Traefik nieaktualna</string>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -120,6 +120,7 @@
     <string name="alerts_event_config_sync_failed">Сбой синхронизации конфигурации</string>
     <string name="alerts_event_config_synced">Конфигурация синхронизирована</string>
     <string name="alerts_event_config_auto_synced">Конфигурация синхронизирована автоматически</string>
+    <string name="alerts_event_config_autosync_stale">Автосинхронизация выключена, флот не синхронизирован</string>
     <string name="alerts_event_version_fetch_failed">Сбой чтения версии</string>
     <string name="alerts_event_version_fetch_recovered">Чтение версии восстановлено</string>
     <string name="alerts_event_traefik_stale">Конфигурация Traefik устарела</string>

--- a/android/app/src/main/res/values-sk/strings.xml
+++ b/android/app/src/main/res/values-sk/strings.xml
@@ -120,6 +120,7 @@
     <string name="alerts_event_config_sync_failed">Synchronizácia konfigurácie zlyhala</string>
     <string name="alerts_event_config_synced">Konfigurácia synchronizovaná</string>
     <string name="alerts_event_config_auto_synced">Konfigurácia automaticky synchronizovaná</string>
+    <string name="alerts_event_config_autosync_stale">Automatická synchronizácia vypnutá, flotila nesynchronizovaná</string>
     <string name="alerts_event_version_fetch_failed">Čítanie verzie zlyhalo</string>
     <string name="alerts_event_version_fetch_recovered">Čítanie verzie obnovené</string>
     <string name="alerts_event_traefik_stale">Konfigurácia Traefiku zastaraná</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -117,6 +117,7 @@
     <string name="alerts_event_config_sync_failed">配置同步失败</string>
     <string name="alerts_event_config_synced">配置已同步</string>
     <string name="alerts_event_config_auto_synced">配置已自动同步</string>
+    <string name="alerts_event_config_autosync_stale">自动同步已关闭，集群未同步</string>
     <string name="alerts_event_version_fetch_failed">版本读取失败</string>
     <string name="alerts_event_version_fetch_recovered">版本读取已恢复</string>
     <string name="alerts_event_traefik_stale">Traefik 配置已过时</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -133,6 +133,7 @@
     <string name="alerts_event_config_sync_failed">Config sync failed</string>
     <string name="alerts_event_config_synced">Config synced</string>
     <string name="alerts_event_config_auto_synced">Config auto-synced</string>
+    <string name="alerts_event_config_autosync_stale">Auto-sync off, fleet not synced</string>
     <string name="alerts_event_version_fetch_failed">Version read failed</string>
     <string name="alerts_event_version_fetch_recovered">Version read recovered</string>
     <string name="alerts_event_traefik_stale">Traefik config stale</string>


### PR DESCRIPTION
## What

The Bellhop Alerts catalog rendered the `config.autosync_stale` event type as its **raw key** — `eventTypeLabel` had no `when` case for it, so it fell through to `else -> type` and displayed the literal `config.autosync_stale`. Add the case plus the `alerts_event_config_autosync_stale` string in **all 11 locales**.

## Wording

Mirrors Front Desk's translations for the same event (`settings.alerts.event.config_autosync_stale`, en: "Auto-sync off, fleet not synced"), which was fixed for the identical gap earlier — so the event reads consistently across both apps and the non-English strings reuse FD's hand-translations rather than fresh machine output.

## Verified

- Confirmed prod's `/api/alert/selection` sends the type exactly as `config.autosync_stale` (matches the new case).
- `ktlintCheck` + `assembleDebug` + `lintDebug` all green (compiles, XML valid, no MissingTranslation/ExtraTranslation — parity holds across all 11 locales).

Ships via the app (Android-only; no server image involved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)