### PR TITLE
perf(bellhop): pause traffic fan-out under overlays; tick the recent-event age

### DIFF
--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
@@ -661,6 +661,14 @@ private fun LinkedContent(
         }
     }
 
+    // Pause the dashboard's traffic sparkline fan-out while any full-screen overlay
+    // (member detail, events, alerts, settings) is on top: those charts aren't
+    // visible, so fetching them just wakes the radio. The list stays warm via the
+    // health poll and SSE, and the fan-out resumes the moment the dashboard shows.
+    LaunchedEffect(showEvents, showAlerts, showSettings, selectedMemberId) {
+        dashVm.setCovered(showEvents || showAlerts || showSettings || selectedMemberId != null)
+    }
+
     if (showEvents) {
         BackHandler { showEvents = false }
         // Keyed like the dashboard VM so a relink gets a fresh log.

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
@@ -81,6 +82,7 @@ import com.hugalafutro.bellhop.ui.common.healthLabel
 import com.hugalafutro.bellhop.ui.common.relativeAgo
 import com.hugalafutro.bellhop.ui.common.severityColors
 import com.hugalafutro.bellhop.ui.theme.BellhopTheme
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.distinctUntilChanged
 import java.time.Instant
 
@@ -590,6 +592,17 @@ private fun MemberCard(
             // into the member.
             recentEvent?.let { ev ->
                 val (evContainer, evContent) = severityColors(ev.severity)
+                // Tick a local clock so the "3 min ago" age recomputes on its own.
+                // Without it the age is frozen: eventAgo is memoized on the event's
+                // timestamp, which doesn't change between refreshes, so a stationary
+                // event's label would never advance. Scoped to cards that actually
+                // show an event, and disposed with the dashboard when it's covered.
+                val now by produceState(System.currentTimeMillis()) {
+                    while (true) {
+                        delay(RELATIVE_TIME_TICK_MS)
+                        value = System.currentTimeMillis()
+                    }
+                }
                 Spacer(modifier = Modifier.height(4.dp))
                 Surface(
                     onClick = onClick,
@@ -610,7 +623,7 @@ private fun MemberCard(
                             modifier = Modifier.weight(1f),
                         )
                         val context = LocalContext.current
-                        remember(ev.createdAt, context) { eventAgo(context, ev.createdAt) }?.let { ago ->
+                        remember(ev.createdAt, now, context) { eventAgo(context, ev.createdAt, now) }?.let { ago ->
                             Spacer(modifier = Modifier.width(8.dp))
                             Text(
                                 text = ago,
@@ -676,6 +689,11 @@ private fun eventAgo(
     } catch (e: Exception) {
         null
     }
+
+// How often the recent-event pill re-evaluates its relative age. 30s keeps the
+// "N min ago" label honest to within half a minute without waking often; it is a
+// CPU-only recomposition of a couple of Text nodes, no network.
+private const val RELATIVE_TIME_TICK_MS = 30_000L
 
 private const val REPO_URL = "https://github.com/hugalafutro/model-hotel"
 

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModel.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModel.kt
@@ -281,9 +281,12 @@ class DashboardViewModel(
             launch {
                 visibleIds.collectLatest { ids ->
                     // collectLatest cancels this delay if the visible set changes
-                    // again, so only a settled viewport triggers a fetch.
+                    // again, so only a settled viewport triggers a fetch. Skip while
+                    // covered (the list is hidden, so nothing needs its sparkline):
+                    // in practice the screen is torn down then and reports no
+                    // changes, but this keeps the fetch honest regardless of caller.
                     delay(TRAFFIC_DEBOUNCE_MS)
-                    fetchVisibleTraffic(ids, force = false)
+                    if (!covered.value) fetchVisibleTraffic(ids, force = false)
                 }
             }
             launch {
@@ -308,16 +311,21 @@ class DashboardViewModel(
             launch {
                 // A range change invalidates every in-flight and cached sparkline
                 // (they cover the old span). Cancel the old-window fetches so a late
-                // response can't overwrite the chart, drop their stamps, then
-                // force-refetch the viewport at the new span so it redraws now
-                // instead of on the next tick. drop(1) skips the initial value the
-                // first fetch already used.
+                // response can't overwrite the chart and drop their stamps
+                // regardless. Only refetch now if the dashboard is actually on
+                // screen: while it's covered there is nothing to redraw, so the
+                // refetch would just wake the radio — the catch-up fetch when it's
+                // uncovered picks up the new span (fetchVisibleTraffic reads the
+                // current window). drop(1) skips the initial value the first fetch
+                // already used.
                 graphWindow.drop(1).collectLatest {
                     if (_state.value.revoked) return@collectLatest
                     trafficJobs.values.forEach { it.cancel() }
                     trafficJobs.clear()
                     trafficFetchedAt.clear()
-                    fetchVisibleTraffic(visibleIds.value, force = true)
+                    if (!covered.value) {
+                        fetchVisibleTraffic(visibleIds.value, force = true)
+                    }
                 }
             }
         }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModel.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModel.kt
@@ -116,6 +116,13 @@ class DashboardViewModel(
     // single /api/fleet/usage rollup, this loop swaps its source for that one call.
     private val visibleIds = MutableStateFlow<List<String>>(emptyList())
 
+    // Whether the dashboard is hidden behind another screen (member detail,
+    // settings, alerts, events). The dashboard ViewModel keeps running under those
+    // overlays so its state stays warm, but the traffic sparklines aren't on screen
+    // then, so [trafficLoop] pauses the per-member fan-out while covered and catches
+    // up when shown again. Reported by the screen via [setCovered].
+    private val covered = MutableStateFlow(false)
+
     // The traffic-graph range (minutes) the sparklines request, driven by the
     // Settings pref via [setGraphRange]. Changing it force-refetches so the
     // charts redraw at the new span.
@@ -245,6 +252,17 @@ class DashboardViewModel(
     }
 
     /**
+     * setCovered tells the ViewModel whether the dashboard is hidden behind another
+     * screen. While covered, [trafficLoop] stops the per-member sparkline fan-out
+     * (those charts aren't on screen, so fetching them just wakes the radio for
+     * nothing); it resumes with an immediate catch-up fetch when shown again. The
+     * health poll and SSE keep running so the list is fresh the moment it reappears.
+     */
+    fun setCovered(value: Boolean) {
+        covered.value = value
+    }
+
+    /**
      * setGraphRange updates the traffic-graph span (minutes) from the Settings
      * pref. The traffic loop watches [graphWindow] and force-refetches the
      * visible sparklines when it changes, so the charts follow the new range.
@@ -269,12 +287,22 @@ class DashboardViewModel(
                 }
             }
             launch {
-                while (true) {
-                    delay(trafficPollMs)
-                    // A dead token can't authenticate; stop ticking like the
-                    // other loops rather than spinning on a no-op fetch.
-                    if (_state.value.revoked) return@launch
-                    fetchVisibleTraffic(visibleIds.value, force = true)
+                // Pause the periodic fan-out while the dashboard is covered — its
+                // sparklines aren't on screen, so fetching them is pure radio waste.
+                // collectLatest cancels the loop the instant it's covered and, when
+                // shown again, restarts with an immediate catch-up fetch before
+                // resuming the tick. Uncovered from the start, the first fetch runs
+                // against the still-empty viewport (a no-op) until the list reports
+                // its visible ids, which the debounce launch above fetches.
+                covered.collectLatest { isCovered ->
+                    if (isCovered) return@collectLatest
+                    while (true) {
+                        // A dead token can't authenticate; stop ticking like the
+                        // other loops rather than spinning on a no-op fetch.
+                        if (_state.value.revoked) return@collectLatest
+                        fetchVisibleTraffic(visibleIds.value, force = true)
+                        delay(trafficPollMs)
+                    }
                 }
             }
             launch {

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModelTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModelTest.kt
@@ -488,6 +488,33 @@ class DashboardViewModelTest {
         }
 
     @Test
+    fun graphRangeChangeWhileCoveredDoesNotFetch() =
+        runBlocking {
+            // Changing the graph range from Settings (which covers the dashboard)
+            // must not fan out traffic; the new span is picked up by the catch-up
+            // fetch when the dashboard is shown again.
+            val client = FakeFleetClient(FetchResult.Success(listOf(member)))
+            client.trafficResults =
+                mapOf("m1" to FetchResult.Success(MemberTraffic(memberId = "m1", reachable = true)))
+            // A long poll keeps the periodic tick out of the window so only the
+            // range change could move the count.
+            val vm = DashboardViewModel(client, linkedStore(), "http://fd:1", trafficPollMs = 10_000)
+            val job = launch { vm.state.collect {} }
+            vm.setVisibleMembers(listOf("m1"))
+            withTimeout(5_000) { while (client.trafficFetched.isEmpty()) delay(20) }
+
+            vm.setCovered(true)
+            delay(200)
+            val settled = client.trafficFetched.size
+
+            // Range change while covered: no fetch.
+            vm.setGraphRange(30)
+            delay(400)
+            assertEquals(settled, client.trafficFetched.size)
+            job.cancel()
+        }
+
+    @Test
     fun graphRangeChangeRefetchesVisibleTrafficWithNewWindow() =
         runBlocking {
             val client = FakeFleetClient(FetchResult.Success(listOf(member)))

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModelTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModelTest.kt
@@ -459,6 +459,35 @@ class DashboardViewModelTest {
         }
 
     @Test
+    fun coveringTheDashboardPausesTrafficThenResumes() =
+        runBlocking {
+            // While the dashboard is covered by another screen its sparklines aren't
+            // visible, so the periodic traffic fan-out must stop; uncovering resumes
+            // it with an immediate catch-up fetch.
+            val client = FakeFleetClient(FetchResult.Success(listOf(member)))
+            client.trafficResults =
+                mapOf("m1" to FetchResult.Success(MemberTraffic(memberId = "m1", reachable = true)))
+            val vm = DashboardViewModel(client, linkedStore(), "http://fd:1", trafficPollMs = 40)
+            val job = launch { vm.state.collect {} }
+            vm.setVisibleMembers(listOf("m1"))
+            // The periodic fetch ticks while the dashboard is shown.
+            withTimeout(5_000) { while (client.trafficFetched.size < 2) delay(20) }
+
+            // Cover it: the fan-out quiesces.
+            vm.setCovered(true)
+            delay(200)
+            val settled = client.trafficFetched.size
+            delay(300)
+            assertEquals(settled, client.trafficFetched.size)
+
+            // Uncover: it resumes with an immediate catch-up fetch.
+            vm.setCovered(false)
+            withTimeout(5_000) { while (client.trafficFetched.size == settled) delay(20) }
+            assertTrue(client.trafficFetched.size > settled)
+            job.cancel()
+        }
+
+    @Test
     fun graphRangeChangeRefetchesVisibleTrafficWithNewWindow() =
         runBlocking {
             val client = FakeFleetClient(FetchResult.Success(listOf(member)))


### PR DESCRIPTION
## What

The last two items from the dashboard battery work (item 4 of the profiling plan).

1. **Pause the traffic fan-out while the dashboard is covered.** The dashboard ViewModel keeps running under a full-screen overlay (member detail, events, alerts, settings) so its list stays warm — but the per-member traffic sparklines aren't on screen then, so the periodic fan-out was waking the radio for charts nobody can see (measured ~2 req/min continuing under overlays). A new `covered` flag, set by the screen when any overlay is shown, gates the traffic tick via `collectLatest`; it resumes with an immediate catch-up fetch when the dashboard reappears. The health poll and SSE keep running, so the list is fresh the instant it returns.

2. **Tick the recent-event pill's relative age.** It was frozen: `eventAgo` is memoized on the event timestamp (`remember(ev.createdAt, …)`), which doesn't change between refreshes, so a stationary event's "3 min ago" never advanced. A local 30s clock (`produceState`, CPU-only, scoped to cards that show an event and disposed with the dashboard) now drives the recompute.

## Tests

New `coveringTheDashboardPausesTrafficThenResumes` (fan-out stops when covered, resumes with a catch-up fetch on uncover), stress-reran 3x. `ktlintCheck` + `compileDebugKotlin` + full `DashboardViewModelTest` green.

Android-only; ships via the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)