### PR TITLE
fix(bellhop): label the dashboard sparkline when a member's window is quiet

### DIFF
--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
@@ -577,15 +577,31 @@ private fun MemberCard(
                 )
             }
             // Inline last-hour sparkline: shown once its (viewport-lazy) traffic
-            // has arrived and there is something to draw. Absent/empty just leaves
-            // the card compact rather than reserving blank space. Tapping the card
-            // (including here) opens the detail with the full graph + event log.
-            traffic?.points?.takeIf { traffic.reachable && it.isNotEmpty() }?.let { points ->
+            // has arrived and is reachable. A quiet window (buckets present but no
+            // requests) draws the idle sparkline with the same "No requests in this
+            // window." label the detail screen uses centred over it, so the flat
+            // line is explained here rather than looking broken. Absent/unreachable
+            // still leaves the card compact. Tapping the card (including here) opens
+            // the detail with the full graph + event log.
+            traffic?.takeIf { it.reachable && it.points.isNotEmpty() }?.let { t ->
                 Spacer(modifier = Modifier.height(2.dp))
-                TrafficChart(
-                    points = points,
-                    modifier = Modifier.height(28.dp).testTag("member-sparkline-${member.name}"),
-                )
+                Box(modifier = Modifier.fillMaxWidth()) {
+                    TrafficChart(
+                        points = t.points,
+                        modifier = Modifier.height(28.dp).testTag("member-sparkline-${member.name}"),
+                    )
+                    if (t.totalRequests == 0) {
+                        Text(
+                            text = stringResource(R.string.member_detail_traffic_empty),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier =
+                                Modifier
+                                    .align(Alignment.Center)
+                                    .testTag("member-sparkline-empty-${member.name}"),
+                        )
+                    }
+                }
             }
             // Recent-event pill: a severity-tinted, one-line preview of this
             // member's latest event with its age right-aligned, tappable straight

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreenTest.kt
@@ -12,6 +12,8 @@ import com.hugalafutro.bellhop.data.FleetMember
 import com.hugalafutro.bellhop.data.HealthStatus
 import com.hugalafutro.bellhop.data.LinkState
 import com.hugalafutro.bellhop.data.MemberStatus
+import com.hugalafutro.bellhop.data.MemberTraffic
+import com.hugalafutro.bellhop.data.TrafficPoint
 import com.hugalafutro.bellhop.ui.theme.BellhopTheme
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -129,6 +131,65 @@ class DashboardScreenTest {
         pill.assertIsDisplayed()
         pill.performClick()
         assertEquals("m1", opened)
+    }
+
+    @Test
+    fun quietTrafficWindowLabelsTheSparklineEmpty() {
+        // Buckets present but no requests: the idle sparkline still draws, with the
+        // same "No requests in this window." label the detail screen uses centred
+        // over it, so the flat line reads as quiet rather than broken.
+        composeTestRule.setContent {
+            BellhopTheme {
+                DashboardScreen(
+                    link = link,
+                    ui =
+                        DashboardUiState(
+                            loading = false,
+                            members = allUp,
+                            traffic =
+                                mapOf(
+                                    "m1" to
+                                        MemberTraffic(
+                                            memberId = "m1",
+                                            reachable = true,
+                                            totalRequests = 0,
+                                            points = listOf(TrafficPoint(bucket = "t0", requests = 0)),
+                                        ),
+                                ),
+                        ),
+                )
+            }
+        }
+        composeTestRule.onNodeWithTag("member-sparkline-alpha", useUnmergedTree = true).assertIsDisplayed()
+        composeTestRule.onNodeWithTag("member-sparkline-empty-alpha", useUnmergedTree = true).assertIsDisplayed()
+    }
+
+    @Test
+    fun busyTrafficWindowDrawsSparklineWithoutEmptyLabel() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                DashboardScreen(
+                    link = link,
+                    ui =
+                        DashboardUiState(
+                            loading = false,
+                            members = allUp,
+                            traffic =
+                                mapOf(
+                                    "m1" to
+                                        MemberTraffic(
+                                            memberId = "m1",
+                                            reachable = true,
+                                            totalRequests = 5,
+                                            points = listOf(TrafficPoint(bucket = "t0", requests = 5, errors = 1)),
+                                        ),
+                                ),
+                        ),
+                )
+            }
+        }
+        composeTestRule.onNodeWithTag("member-sparkline-alpha", useUnmergedTree = true).assertIsDisplayed()
+        composeTestRule.onNodeWithTag("member-sparkline-empty-alpha", useUnmergedTree = true).assertDoesNotExist()
     }
 
     @Test


### PR DESCRIPTION
## What

On the main dashboard, a member whose traffic window has no requests drew a flat idle sparkline on the card with no explanation, while the member-detail screen already showed "No requests in this window." for the same state.

This draws that same label centred over the idle sparkline whenever the window is reachable but `totalRequests == 0`, so the flat line reads as quiet rather than broken. Absent/unreachable traffic still leaves the card compact.

The label reuses the existing `member_detail_traffic_empty` string, so there is no new string and no translation work across the 10 locales.

## Tests

Added two `DashboardScreenTest` cases:
- `quietTrafficWindowLabelsTheSparklineEmpty` — reachable, buckets present, zero requests → sparkline + empty label both shown.
- `busyTrafficWindowDrawsSparklineWithoutEmptyLabel` — requests present → sparkline shown, no empty label.

Both query with `useUnmergedTree = true` since the clickable member `Card` merges child semantics. Full `DashboardScreenTest` suite (24 tests) and ktlint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)