### PR TITLE
fix(proxy): share param self-heal so the Test button heals gpt-5/o-series 400s

### DIFF
--- a/internal/api/models.go
+++ b/internal/api/models.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"bytes"
 	"context"
 	"crypto/rand"
 	"encoding/base64"
@@ -21,6 +20,7 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 	"github.com/hugalafutro/model-hotel/internal/failover"
 	"github.com/hugalafutro/model-hotel/internal/model"
+	"github.com/hugalafutro/model-hotel/internal/paramrewrite"
 	"github.com/hugalafutro/model-hotel/internal/provider"
 	"github.com/hugalafutro/model-hotel/internal/user"
 	"github.com/hugalafutro/model-hotel/internal/util"
@@ -304,10 +304,10 @@ func (h *Handler) TestModel(w http.ResponseWriter, r *http.Request) {
 	keyDecryptMs := float64(time.Since(keyDecryptStart).Microseconds()) / 1000.0
 	proxyOverheadMs := float64(time.Since(start).Microseconds()) / 1000.0
 
-	proxyReq, reqHash := buildTestModelRequest(r.Context(), m, prov, apiKey)
+	baseBody, providerType, targetURL, reqHash := buildTestModelRequest(m, prov)
 
 	startRequest := time.Now()
-	resp, err := h.doTestModelRequest(proxyReq)
+	resp, err := h.doTestModelRequest(r.Context(), providerType, targetURL, m.ModelID, apiKey, baseBody)
 	if err != nil {
 		durationMs := float64(time.Since(start).Milliseconds())
 		h.logTestModelRequestError(r.Context(), m, reqHash, durationMs, proxyOverheadMs, keyDecryptMs, err.Error())
@@ -387,15 +387,21 @@ func (h *Handler) decryptTestModelKey(w http.ResponseWriter, prov *provider.Prov
 	return apiKey, true
 }
 
-// buildTestModelRequest constructs the upstream chat-completions probe request
-// (a short "Respond only with `Hi`" prompt) with provider-appropriate auth
-// headers, and returns it alongside a fresh random request hash for logging.
+// buildTestModelRequest constructs the OpenAI-shaped chat-completions probe
+// body (a short "Respond only with `Hi`" prompt) and resolves the provider type
+// and target URL, returning them alongside a fresh random request hash for
+// logging. The body is left un-rewritten here: doTestModelRequest sends it
+// through paramrewrite.BuildUpstreamBody so the probe applies the exact same
+// provider rewrites (param injection/stripping, learned renames) as live proxy
+// traffic instead of maintaining a second, drift-prone body.
 //
 // max_tokens is kept small: the test only confirms the model responds. A
 // reasoning model may spend the whole budget on reasoning and return empty
 // content — that still counts as success, and the UI omits the response text
-// when it's empty rather than paying for a full reasoning generation.
-func buildTestModelRequest(ctx context.Context, m *model.Model, prov *provider.Provider, apiKey string) (*http.Request, string) {
+// when it's empty rather than paying for a full reasoning generation. For
+// OpenAI gpt-5/o-series models that reject max_tokens, the shared self-heal
+// renames it to max_completion_tokens and retries, so the probe succeeds.
+func buildTestModelRequest(m *model.Model, prov *provider.Provider) (baseBody []byte, providerType, targetURL, reqHash string) {
 	body := map[string]interface{}{
 		"model": m.ModelID,
 		"messages": []map[string]string{
@@ -403,25 +409,24 @@ func buildTestModelRequest(ctx context.Context, m *model.Model, prov *provider.P
 		},
 		"max_tokens": 10,
 	}
-	bodyBytes, _ := json.Marshal(body)
+	baseBody, _ = json.Marshal(body)
 
-	providerType := provider.DetectProviderType(prov.BaseURL)
-	targetURL := util.BuildProviderTargetURL(prov.BaseURL, providerType, "/chat/completions")
-	//nolint:gosec // provider URL is admin-configured, not arbitrary user input
-	proxyReq, _ := http.NewRequestWithContext(ctx, "POST", targetURL, bytes.NewReader(bodyBytes))
-	util.SetProviderAuthHeaders(proxyReq, providerType, apiKey)
-	proxyReq.Header.Set("Content-Type", "application/json")
+	providerType = provider.DetectProviderType(prov.BaseURL)
+	targetURL = util.BuildProviderTargetURL(prov.BaseURL, providerType, "/chat/completions")
 
 	reqHashBytes := make([]byte, 8)
 	rand.Read(reqHashBytes)
-	reqHash := hex.EncodeToString(reqHashBytes)
+	reqHash = hex.EncodeToString(reqHashBytes)
 
-	return proxyReq, reqHash
+	return baseBody, providerType, targetURL, reqHash
 }
 
-// doTestModelRequest executes the probe request with a 30s-timeout client,
-// honoring the test-only transport/redirect hooks when set.
-func (h *Handler) doTestModelRequest(proxyReq *http.Request) (*http.Response, error) {
+// doTestModelRequest sends the probe through the shared self-heal executor with
+// a 30s-timeout client, honoring the test-only transport/redirect hooks when
+// set. Routing through paramrewrite.SelfHealChatCompletion means the probe uses
+// the same body-rewrite and 400 param-retry (e.g. max_tokens ->
+// max_completion_tokens) that the proxy failover loop uses for live traffic.
+func (h *Handler) doTestModelRequest(ctx context.Context, providerType, targetURL, modelID, apiKey string, baseBody []byte) (*http.Response, error) {
 	testClient := &http.Client{Timeout: 30 * time.Second}
 	if h.testModelTransport != nil {
 		testClient.Transport = h.testModelTransport
@@ -429,8 +434,10 @@ func (h *Handler) doTestModelRequest(proxyReq *http.Request) (*http.Response, er
 	if h.testModelCheckRedirect != nil {
 		testClient.CheckRedirect = h.testModelCheckRedirect
 	}
-	//nolint:gosec // provider URL is admin-configured, not arbitrary user input
-	return testClient.Do(proxyReq)
+	return paramrewrite.SelfHealChatCompletion(ctx, testClient, targetURL, providerType, modelID, baseBody, func(req *http.Request) {
+		util.SetProviderAuthHeaders(req, providerType, apiKey)
+		req.Header.Set("Content-Type", "application/json")
+	})
 }
 
 // parseTestModelResponse extracts the assistant content and computes

--- a/internal/paramrewrite/build.go
+++ b/internal/paramrewrite/build.go
@@ -1,0 +1,178 @@
+package paramrewrite
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/hugalafutro/model-hotel/internal/debuglog"
+)
+
+// ProviderSupportsStreamOptions returns true for provider types that accept
+// the OpenAI stream_options parameter in their Chat Completions endpoint.
+// Providers with non-OpenAI APIs (Anthropic, Google, Cohere) or those that
+// strict-validate unknown fields should return false to avoid 400 errors.
+func ProviderSupportsStreamOptions(providerType string) bool {
+	switch providerType {
+	case "anthropic", "google", "cohere", "opencode-go", "opencode-zen":
+		return false
+	default:
+		// All OpenAI-compatible providers (openai, deepseek, xai, openrouter,
+		// ollama, ollama-cloud, nanogpt, zai-coding, lmstudio, koboldcpp,
+		// neuralwatt, etc.) accept or silently ignore stream_options.
+		return true
+	}
+}
+
+// BuildUpstreamBody rewrites the client request body for a specific provider
+// candidate. This is the single shared rewrite path used by the initial proxy
+// attempt, the proxy 400 auto-retry, and the admin "Test model" probe,
+// preventing drift between them.
+//
+// Steps (applied in order):
+//  1. Model rename (client model → resolved model)
+//  2. stream_options injection (streaming + OpenAI-compatible providers only)
+//  3. Provider-specific param injection (InjectProviderParams)
+//  4. Learned param renaming (renameCache, e.g. max_tokens → max_completion_tokens)
+//  5. Universal param stripping (ProviderUnsupportedParams)
+//  6. Learned param stripping (deprecationCache)
+//  7. Extra param stripping (additional rejected params, e.g. from 400 auto-retry)
+//  8. Message sanitization (drop empty tool_calls arrays)
+//
+// Injection (step 3) runs before all stripping (steps 5-7) so that a param a
+// provider injects but the upstream then rejects (learned into the deprecation
+// cache) is removed and stays removed on subsequent requests. Were injection
+// last, a learned rejection would be re-added on every fresh request, forcing a
+// 400+retry round-trip every time instead of just the first.
+//
+// Renaming (step 4) runs before stripping so the moved value lands under its new
+// key before any strip phase could delete the old key — a rename must preserve
+// the caller's value (e.g. their token budget), unlike a strip which discards it.
+func BuildUpstreamBody(
+	proxyReqBody []byte,
+	providerType string,
+	resolvedModelID string,
+	requestModel string,
+	isStreaming bool,
+	deprecationCache *sync.Map,
+	renameCache *sync.Map,
+	extraStrip map[string]bool,
+) []byte {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(proxyReqBody, &raw); err != nil {
+		return proxyReqBody // unparseable — forward as-is
+	}
+
+	// 1. Model rename
+	if requestModel != resolvedModelID {
+		raw["model"] = resolvedModelID
+	}
+
+	// 2. stream_options injection
+	if isStreaming && ProviderSupportsStreamOptions(providerType) {
+		raw["stream_options"] = map[string]interface{}{
+			"include_usage": true,
+		}
+	}
+
+	// 3. Provider-specific param injection.
+	// Runs before all stripping so a learned/extra rejection of an injected
+	// param (e.g. chat_template_args) removes it and keeps it removed, rather
+	// than the param being re-added after the strip phases.
+	InjectProviderParams(raw, providerType, resolvedModelID)
+
+	cacheKey := fmt.Sprintf("%s:%s", providerType, resolvedModelID)
+
+	// 4. Learned param renaming (runs before stripping to preserve the value).
+	// Each rename moves old→new only when old is present and new is not already
+	// set, so an explicit caller value under the new key is never overwritten.
+	if renames := cachedRenames(renameCache, cacheKey); renames != nil {
+		for oldName, newName := range renames {
+			if v, ok := raw[oldName]; ok {
+				if _, exists := raw[newName]; !exists {
+					raw[newName] = v
+				}
+				delete(raw, oldName)
+			}
+		}
+	}
+
+	// 5. Universal param stripping
+	if params, ok := ProviderUnsupportedParams[providerType]; ok {
+		for _, p := range params {
+			delete(raw, p)
+		}
+	}
+
+	// 6. Learned param stripping
+	if cached := CachedRejectedParams(deprecationCache, cacheKey); cached != nil {
+		for param := range cached {
+			delete(raw, param)
+		}
+	}
+
+	// 7. Extra param stripping (e.g. newly-learned rejections from 400 auto-retry)
+	for param := range extraStrip {
+		delete(raw, param)
+	}
+
+	// 8. Message sanitization
+	stripEmptyToolCalls(raw)
+
+	if b, err := json.Marshal(raw); err == nil {
+		return b
+	}
+	return proxyReqBody
+}
+
+// stripEmptyToolCalls removes "tool_calls": [] from every message in the
+// request. Some clients serialize an assistant turn whose tool calls were
+// aborted or filtered out as an empty array instead of omitting the field;
+// the OpenAI spec requires min length 1 and strict providers (DeepSeek,
+// OpenCode Zen) reject the whole request with a 400, permanently bricking any
+// conversation that has such a turn in its history. No provider needs the
+// empty array, so dropping it is always safe.
+func stripEmptyToolCalls(raw map[string]interface{}) {
+	msgs, ok := raw["messages"].([]interface{})
+	if !ok {
+		return
+	}
+	for _, m := range msgs {
+		msg, ok := m.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if tc, ok := msg["tool_calls"].([]interface{}); ok && len(tc) == 0 {
+			delete(msg, "tool_calls")
+		}
+	}
+}
+
+// MergeLearnedParamCache merges newly-learned per-model param metadata into a
+// sync.Map cache keyed by "providerType:modelID", race-free under concurrent
+// goroutines via CompareAndSwap. Values are stored as *map[string]V (pointers,
+// because maps are not comparable and CompareAndSwap requires comparable values).
+func MergeLearnedParamCache[V any](cache *sync.Map, key string, learned map[string]V) {
+	for {
+		existing, loaded := cache.LoadOrStore(key, &learned)
+		if !loaded {
+			return // first entry for this key — we just stored 'learned'
+		}
+		existingMap, ok := existing.(*map[string]V)
+		if !ok {
+			debuglog.Error("learned param cache: unexpected type", "key", key, "type", fmt.Sprintf("%T", existing))
+			return
+		}
+		merged := make(map[string]V, len(*existingMap)+len(learned))
+		for k, v := range *existingMap {
+			merged[k] = v
+		}
+		for k, v := range learned {
+			merged[k] = v
+		}
+		if cache.CompareAndSwap(key, existing, &merged) {
+			return
+		}
+		// CompareAndSwap failed — another goroutine updated it, retry.
+	}
+}

--- a/internal/paramrewrite/build_upstream_body_test.go
+++ b/internal/paramrewrite/build_upstream_body_test.go
@@ -1,4 +1,4 @@
-package proxy
+package paramrewrite
 
 import (
 	"encoding/json"
@@ -70,7 +70,7 @@ func TestBuildUpstreamBody(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := buildUpstreamBody([]byte(inputBody), tt.providerType, tt.wantModel, "gpt-4", tt.isStreaming, cache, &sync.Map{}, tt.extraStrip)
+			result := BuildUpstreamBody([]byte(inputBody), tt.providerType, tt.wantModel, "gpt-4", tt.isStreaming, cache, &sync.Map{}, tt.extraStrip)
 
 			var raw map[string]interface{}
 			if err := json.Unmarshal(result, &raw); err != nil {
@@ -114,7 +114,7 @@ func TestBuildUpstreamBody_ExtraStripOnRetry(t *testing.T) {
 	inputBody := `{"model":"gpt-4","messages":[{"role":"user","content":"hi"}],"stream":true,"min_p":0.8}`
 	cache := &sync.Map{}
 
-	result := buildUpstreamBody(
+	result := BuildUpstreamBody(
 		[]byte(inputBody), "openai", "gpt-4o", "gpt-4",
 		true, cache, &sync.Map{},
 		map[string]bool{"min_p": true}, // extra strip from 400 auto-retry
@@ -151,7 +151,7 @@ func TestBuildUpstreamBody_OpenCodeInjectsChatTemplateArgs(t *testing.T) {
 	inputBody := `{"model":"glm-5.2","messages":[{"role":"user","content":"hi"}],"stream":false}`
 	cache := &sync.Map{}
 
-	result := buildUpstreamBody([]byte(inputBody), "opencode-go", "glm-5.2", "glm-5.2", false, cache, &sync.Map{}, nil)
+	result := BuildUpstreamBody([]byte(inputBody), "opencode-go", "glm-5.2", "glm-5.2", false, cache, &sync.Map{}, nil)
 
 	var raw map[string]interface{}
 	if err := json.Unmarshal(result, &raw); err != nil {
@@ -174,7 +174,7 @@ func TestBuildUpstreamBody_LearnedChatTemplateArgsRejectionStays(t *testing.T) {
 	rejected := map[string]bool{"chat_template_args": true}
 	cache.Store("opencode-go:glm-5.2", &rejected)
 
-	result := buildUpstreamBody([]byte(inputBody), "opencode-go", "glm-5.2", "glm-5.2", false, cache, &sync.Map{}, nil)
+	result := BuildUpstreamBody([]byte(inputBody), "opencode-go", "glm-5.2", "glm-5.2", false, cache, &sync.Map{}, nil)
 
 	var raw map[string]interface{}
 	if err := json.Unmarshal(result, &raw); err != nil {
@@ -193,7 +193,7 @@ func TestBuildUpstreamBody_ExtraStripChatTemplateArgsOnRetry(t *testing.T) {
 	inputBody := `{"model":"glm-5.2","messages":[{"role":"user","content":"hi"}],"stream":false}`
 	cache := &sync.Map{}
 
-	result := buildUpstreamBody(
+	result := BuildUpstreamBody(
 		[]byte(inputBody), "opencode-go", "glm-5.2", "glm-5.2", false, cache, &sync.Map{},
 		map[string]bool{"chat_template_args": true},
 	)
@@ -220,7 +220,7 @@ func TestBuildUpstreamBody_LearnedRenameMovesValue(t *testing.T) {
 	renames := map[string]string{"max_tokens": "max_completion_tokens"}
 	renameCache.Store("openai:gpt-5-nano", &renames)
 
-	result := buildUpstreamBody([]byte(inputBody), "openai", "gpt-5-nano", "gpt-5-nano", false, &sync.Map{}, renameCache, nil)
+	result := BuildUpstreamBody([]byte(inputBody), "openai", "gpt-5-nano", "gpt-5-nano", false, &sync.Map{}, renameCache, nil)
 
 	var raw map[string]interface{}
 	if err := json.Unmarshal(result, &raw); err != nil {
@@ -246,7 +246,7 @@ func TestBuildUpstreamBody_RenameDoesNotOverwriteExplicitTarget(t *testing.T) {
 	renames := map[string]string{"max_tokens": "max_completion_tokens"}
 	renameCache.Store("openai:gpt-5-nano", &renames)
 
-	result := buildUpstreamBody([]byte(inputBody), "openai", "gpt-5-nano", "gpt-5-nano", false, &sync.Map{}, renameCache, nil)
+	result := BuildUpstreamBody([]byte(inputBody), "openai", "gpt-5-nano", "gpt-5-nano", false, &sync.Map{}, renameCache, nil)
 
 	var raw map[string]interface{}
 	if err := json.Unmarshal(result, &raw); err != nil {
@@ -270,7 +270,7 @@ func TestBuildUpstreamBody_NoRenameWhenSourceAbsent(t *testing.T) {
 	renames := map[string]string{"max_tokens": "max_completion_tokens"}
 	renameCache.Store("openai:gpt-5-nano", &renames)
 
-	result := buildUpstreamBody([]byte(inputBody), "openai", "gpt-5-nano", "gpt-5-nano", false, &sync.Map{}, renameCache, nil)
+	result := BuildUpstreamBody([]byte(inputBody), "openai", "gpt-5-nano", "gpt-5-nano", false, &sync.Map{}, renameCache, nil)
 
 	var raw map[string]interface{}
 	if err := json.Unmarshal(result, &raw); err != nil {
@@ -285,7 +285,7 @@ func TestBuildUpstreamBody_UnparseableInput(t *testing.T) {
 	t.Parallel()
 
 	cache := &sync.Map{}
-	result := buildUpstreamBody([]byte("not json"), "openai", "gpt-4o", "gpt-4", true, cache, &sync.Map{}, nil)
+	result := BuildUpstreamBody([]byte("not json"), "openai", "gpt-4o", "gpt-4", true, cache, &sync.Map{}, nil)
 	if string(result) != "not json" {
 		t.Errorf("unparseable input should be returned as-is, got %q", string(result))
 	}
@@ -300,7 +300,7 @@ func TestBuildUpstreamBody_StripsEmptyToolCalls(t *testing.T) {
 		`{"role":"assistant","content":null,"tool_calls":[{"id":"c1","type":"function","function":{"name":"f","arguments":"{}"}}]},` +
 		`{"role":"tool","tool_call_id":"c1","content":"ok"}]}`
 
-	result := buildUpstreamBody([]byte(inputBody), "openai", "gpt-4o", "gpt-4", false, &sync.Map{}, &sync.Map{}, nil)
+	result := BuildUpstreamBody([]byte(inputBody), "openai", "gpt-4o", "gpt-4", false, &sync.Map{}, &sync.Map{}, nil)
 
 	var raw map[string]interface{}
 	if err := json.Unmarshal(result, &raw); err != nil {
@@ -336,7 +336,7 @@ func TestBuildUpstreamBody_StripEmptyToolCallsTolerantOfShapes(t *testing.T) {
 		`{"model":"gpt-4","messages":"weird"}`,
 		`{"model":"gpt-4","messages":[42,{"role":"user","content":"hi","tool_calls":"nope"}]}`,
 	} {
-		result := buildUpstreamBody([]byte(body), "openai", "gpt-4", "gpt-4", false, &sync.Map{}, &sync.Map{}, nil)
+		result := BuildUpstreamBody([]byte(body), "openai", "gpt-4", "gpt-4", false, &sync.Map{}, &sync.Map{}, nil)
 		var raw map[string]interface{}
 		if err := json.Unmarshal(result, &raw); err != nil {
 			t.Fatalf("result is not valid JSON for input %s: %v", body, err)

--- a/internal/paramrewrite/inject.go
+++ b/internal/paramrewrite/inject.go
@@ -1,4 +1,4 @@
-package proxy
+package paramrewrite
 
 import (
 	"strings"

--- a/internal/paramrewrite/inject_test.go
+++ b/internal/paramrewrite/inject_test.go
@@ -1,4 +1,4 @@
-package proxy
+package paramrewrite
 
 import (
 	"encoding/json"

--- a/internal/paramrewrite/params.go
+++ b/internal/paramrewrite/params.go
@@ -1,4 +1,12 @@
-package proxy
+// Package paramrewrite is the single shared implementation of model-hotel's
+// request/response parameter self-healing: rewriting an OpenAI-style chat
+// completion body for a specific provider (model rename, stream_options and
+// provider-specific injection, universal + learned param stripping, learned
+// param renaming) and parsing upstream 400 bodies to learn which params a
+// provider rejects or wants renamed. Both the streaming proxy failover loop and
+// the admin "Test model" probe build their upstream bodies and self-heal 400s
+// through this package so the two paths can never drift.
+package paramrewrite
 
 import (
 	"encoding/json"
@@ -6,11 +14,11 @@ import (
 	"sync"
 )
 
-// providerUnsupportedParams lists OpenAI Chat Completions parameters that are
+// ProviderUnsupportedParams lists OpenAI Chat Completions parameters that are
 // universally unsupported (cause 400 errors) per provider type. These are
 // preemptively stripped from requests to avoid a wasted round-trip.
 // Sources: official provider docs + empirical testing.
-var providerUnsupportedParams = map[string][]string{
+var ProviderUnsupportedParams = map[string][]string{
 	"anthropic": {
 		"top_p",             // deprecated on all current Anthropic models
 		"frequency_penalty", // Anthropic uses a single penalties param, not separate freq/presence
@@ -76,11 +84,11 @@ var providerUnsupportedParams = map[string][]string{
 	},
 }
 
-// getCachedRejectedParams returns params known to be rejected for a provider+model,
+// CachedRejectedParams returns params known to be rejected for a provider+model,
 // learned from previous 400 responses.
 // NOTE: Values are stored as *map[string]bool in sync.Map to support CompareAndSwap
 // (maps are not comparable, so pointers are required).
-func getCachedRejectedParams(cache *sync.Map, cacheKey string) map[string]bool {
+func CachedRejectedParams(cache *sync.Map, cacheKey string) map[string]bool {
 	if v, ok := cache.Load(cacheKey); ok {
 		if ptr, ok := v.(*map[string]bool); ok {
 			return *ptr
@@ -93,12 +101,12 @@ func getCachedRejectedParams(cache *sync.Map, cacheKey string) map[string]bool {
 	return nil
 }
 
-// getCachedRenames returns param renames known to be required for a
+// cachedRenames returns param renames known to be required for a
 // provider+model, learned from previous 400 responses (e.g. an OpenAI gpt-5/o
 // model that rejects max_tokens and demands max_completion_tokens).
 // NOTE: Values are stored as *map[string]string in sync.Map to support
 // CompareAndSwap (maps are not comparable, so pointers are required).
-func getCachedRenames(cache *sync.Map, cacheKey string) map[string]string {
+func cachedRenames(cache *sync.Map, cacheKey string) map[string]string {
 	if v, ok := cache.Load(cacheKey); ok {
 		if ptr, ok := v.(*map[string]string); ok {
 			return *ptr
@@ -107,7 +115,7 @@ func getCachedRenames(cache *sync.Map, cacheKey string) map[string]string {
 	return nil
 }
 
-// parseProviderParamRename parses 400 error bodies for params the upstream wants
+// ParseProviderParamRename parses 400 error bodies for params the upstream wants
 // renamed rather than dropped. Unlike a rejected param (which we strip), a
 // renamed param carries a value we must preserve under the new name — stripping
 // it would silently discard the caller's intent (e.g. their token budget).
@@ -117,7 +125,7 @@ func getCachedRenames(cache *sync.Map, cacheKey string) map[string]string {
 // ("Unsupported parameter: 'max_tokens' is not supported with this model. Use
 // 'max_completion_tokens' instead."). These reach model-hotel directly via the
 // openai provider and indirectly via passthrough gateways (e.g. OpenCode Zen).
-func parseProviderParamRename(body []byte) map[string]string {
+func ParseProviderParamRename(body []byte) map[string]string {
 	var errResp struct {
 		Error struct {
 			Message string `json:"message"`
@@ -148,11 +156,11 @@ func parseProviderParamRename(body []byte) map[string]string {
 	return renames
 }
 
-// parseProviderParamError parses 400 error bodies for rejected sampling/param names.
+// ParseProviderParamError parses 400 error bodies for rejected sampling/param names.
 // Any LLM API mentioning these param names in a 400 error can only be referring
 // to the request parameter — there is no other meaning in this context.
 // This works universally across all providers, not just Anthropic.
-func parseProviderParamError(body []byte) map[string]bool {
+func ParseProviderParamError(body []byte) map[string]bool {
 	var errResp struct {
 		Error struct {
 			Message string `json:"message"`

--- a/internal/paramrewrite/selfheal.go
+++ b/internal/paramrewrite/selfheal.go
@@ -1,0 +1,87 @@
+package paramrewrite
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"sync"
+
+	"github.com/hugalafutro/model-hotel/internal/debuglog"
+)
+
+// SelfHealChatCompletion sends a non-streaming chat-completions request and,
+// when the upstream answers 400 with an error that names rejected or renamed
+// params, rebuilds the body through BuildUpstreamBody (applying the learned
+// rejects/renames) and retries once. It is the standalone, single-candidate
+// analog of the proxy failover loop's retryWithStrippedParams: both learn the
+// same way (ParseProviderParamError / ParseProviderParamRename) and rewrite
+// through the same BuildUpstreamBody, so a probe (e.g. the admin "Test model"
+// button) heals the exact same 400s live traffic does — most importantly the
+// OpenAI gpt-5/o-series max_tokens -> max_completion_tokens rename.
+//
+// baseBody is the OpenAI-shaped request body. providerType/modelID drive the
+// rewrite. applyHeaders is invoked on every request to (re)apply auth and
+// content-type headers, since each attempt uses a fresh *http.Request.
+//
+// On success (or a non-param 400, or a transport error) it returns the response
+// with its Body still readable; the caller owns closing it. When a retry is
+// issued the first 400 response body is drained and closed internally.
+func SelfHealChatCompletion(
+	ctx context.Context,
+	client *http.Client,
+	targetURL string,
+	providerType string,
+	modelID string,
+	baseBody []byte,
+	applyHeaders func(*http.Request),
+) (*http.Response, error) {
+	// Per-call learned caches. A probe is one-shot, so these start empty and
+	// only carry a rename learned from this call's own first-attempt 400 into
+	// its retry — no cross-request state, unlike the proxy's Handler-scoped caches.
+	var deprecationCache, renameCache sync.Map
+
+	body := BuildUpstreamBody(baseBody, providerType, modelID, modelID, false, &deprecationCache, &renameCache, nil)
+	resp, err := postChatCompletion(ctx, client, targetURL, body, applyHeaders)
+	if err != nil || resp.StatusCode != http.StatusBadRequest {
+		return resp, err
+	}
+
+	// 400: read the error body so we can learn from it, then decide whether to
+	// retry. A read error only leaves errBody empty/partial, which the parsers
+	// below treat as "not a param error" — so we fall through and hand the 400
+	// back rather than masking it.
+	errBody, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+
+	rejected := ParseProviderParamError(errBody)
+	renames := ParseProviderParamRename(errBody)
+	if rejected == nil && renames == nil {
+		// Not a param error we know how to heal — hand back the original 400
+		// with its body restored so the caller can surface the upstream message.
+		resp.Body = io.NopCloser(bytes.NewReader(errBody))
+		return resp, nil
+	}
+
+	if renames != nil {
+		MergeLearnedParamCache(&renameCache, providerType+":"+modelID, renames)
+	}
+	debuglog.Debug("paramrewrite: self-heal retry", "provider_type", providerType, "model", modelID, "rejected", rejected, "renames", renames)
+
+	rebuilt := BuildUpstreamBody(baseBody, providerType, modelID, modelID, false, &deprecationCache, &renameCache, rejected)
+	return postChatCompletion(ctx, client, targetURL, rebuilt, applyHeaders)
+}
+
+// postChatCompletion builds and sends a single POST with the given body,
+// applying caller-supplied headers.
+func postChatCompletion(ctx context.Context, client *http.Client, targetURL string, body []byte, applyHeaders func(*http.Request)) (*http.Response, error) {
+	//nolint:gosec // targetURL is admin-configured provider base, not user input
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, targetURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	if applyHeaders != nil {
+		applyHeaders(req)
+	}
+	return client.Do(req)
+}

--- a/internal/paramrewrite/selfheal_test.go
+++ b/internal/paramrewrite/selfheal_test.go
@@ -1,0 +1,129 @@
+package paramrewrite
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// decodeBody reads and JSON-decodes an upstream request body.
+func decodeBody(t *testing.T, r *http.Request) map[string]interface{} {
+	t.Helper()
+	b, err := io.ReadAll(r.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("unmarshal body %q: %v", b, err)
+	}
+	return m
+}
+
+func jsonHeaders(req *http.Request) { req.Header.Set("Content-Type", "application/json") }
+
+// TestSelfHeal_MaxTokensRename is the regression test for the broken "Test
+// model" button: an OpenAI gpt-5/o-series model rejects max_tokens with a
+// rename directive; the executor must rename to max_completion_tokens (keeping
+// the value) and retry, ending in a 200.
+func TestSelfHeal_MaxTokensRename(t *testing.T) {
+	var attempts int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		body := decodeBody(t, r)
+		if _, hasOld := body["max_tokens"]; hasOld {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = io.WriteString(w, `{"error":{"message":"Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.","type":"invalid_request_error"}}`)
+			return
+		}
+		v, ok := body["max_completion_tokens"]
+		if !ok {
+			t.Errorf("retry missing max_completion_tokens: %v", body)
+		}
+		if v != float64(10) {
+			t.Errorf("value not preserved across rename: got %v want 10", v)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"choices":[{"message":{"content":"Hi"}}]}`)
+	}))
+	defer srv.Close()
+
+	base := []byte(`{"model":"gpt-5.4","messages":[{"role":"user","content":"hi"}],"max_tokens":10}`)
+	resp, err := SelfHealChatCompletion(context.Background(), srv.Client(), srv.URL, "openai", "gpt-5.4", base, jsonHeaders)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200 (body %s)", resp.StatusCode, b)
+	}
+	if attempts != 2 {
+		t.Fatalf("attempts = %d, want 2 (one 400 + one healed retry)", attempts)
+	}
+}
+
+// TestSelfHeal_RejectedParamStripped covers the strip path: a provider rejects
+// a sampling param by name; the executor strips it and retries to a 200.
+func TestSelfHeal_RejectedParamStripped(t *testing.T) {
+	var attempts int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		body := decodeBody(t, r)
+		if _, has := body["temperature"]; has {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = io.WriteString(w, `{"error":{"message":"Unsupported value: `+"`temperature`"+` is not supported."}}`)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"choices":[{"message":{"content":"Hi"}}]}`)
+	}))
+	defer srv.Close()
+
+	base := []byte(`{"model":"m","messages":[{"role":"user","content":"hi"}],"temperature":0.7}`)
+	resp, err := SelfHealChatCompletion(context.Background(), srv.Client(), srv.URL, "openai", "m", base, jsonHeaders)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if attempts != 2 {
+		t.Fatalf("attempts = %d, want 2", attempts)
+	}
+}
+
+// TestSelfHeal_NonParam400NoRetry ensures a 400 that is not a param error is
+// returned as-is with its body intact and does not trigger a second request.
+func TestSelfHeal_NonParam400NoRetry(t *testing.T) {
+	var attempts int
+	const msg = `{"error":{"message":"You exceeded your quota."}}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts++
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(w, msg)
+	}))
+	defer srv.Close()
+
+	base := []byte(`{"model":"m","messages":[{"role":"user","content":"hi"}]}`)
+	resp, err := SelfHealChatCompletion(context.Background(), srv.Client(), srv.URL, "openai", "m", base, jsonHeaders)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+	if attempts != 1 {
+		t.Fatalf("attempts = %d, want 1 (no retry on non-param 400)", attempts)
+	}
+	b, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(b), "exceeded your quota") {
+		t.Fatalf("original 400 body not preserved: %s", b)
+	}
+}

--- a/internal/proxy/deprecation_cache_test.go
+++ b/internal/proxy/deprecation_cache_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
+	"github.com/hugalafutro/model-hotel/internal/paramrewrite"
 )
 
 // TestDeprecationCache_ConcurrentMerges tests the race-free CAS loop that merges
@@ -222,7 +223,7 @@ func TestDeprecationCache_DirectGetCachedRejectedParams(t *testing.T) {
 	cacheKey := "cohere:command-r"
 
 	// Nothing cached yet
-	got := getCachedRejectedParams(&cache, cacheKey)
+	got := paramrewrite.CachedRejectedParams(&cache, cacheKey)
 	if got != nil {
 		t.Errorf("expected nil for missing key, got %v", got)
 	}
@@ -232,7 +233,7 @@ func TestDeprecationCache_DirectGetCachedRejectedParams(t *testing.T) {
 	cache.Store(cacheKey, &expected)
 
 	// Retrieve it
-	got = getCachedRejectedParams(&cache, cacheKey)
+	got = paramrewrite.CachedRejectedParams(&cache, cacheKey)
 	if got == nil {
 		t.Fatal("unexpected nil for cached key")
 		return

--- a/internal/proxy/helpers.go
+++ b/internal/proxy/helpers.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
@@ -269,22 +268,6 @@ func writeSSEDataChunk(w io.Writer, payload []byte, bytesWritten *int64) error {
 	return err
 }
 
-// providerSupportsStreamOptions returns true for provider types that accept
-// the OpenAI stream_options parameter in their Chat Completions endpoint.
-// Providers with non-OpenAI APIs (Anthropic, Google, Cohere) or those that
-// strict-validate unknown fields should return false to avoid 400 errors.
-func providerSupportsStreamOptions(providerType string) bool {
-	switch providerType {
-	case "anthropic", "google", "cohere", "opencode-go", "opencode-zen":
-		return false
-	default:
-		// All OpenAI-compatible providers (openai, deepseek, xai, openrouter,
-		// ollama, ollama-cloud, nanogpt, zai-coding, lmstudio, koboldcpp,
-		// neuralwatt, etc.) accept or silently ignore stream_options.
-		return true
-	}
-}
-
 // breakerAction represents the circuit-breaker recording decision for a
 // given upstream HTTP status code.
 type breakerAction int
@@ -325,128 +308,5 @@ func breakerRecordAction(statusCode int) breakerAction {
 	default:
 		// Any other response (200, 400, etc.) indicates the provider is alive.
 		return breakerActionSuccess
-	}
-}
-
-// buildUpstreamBody rewrites the client request body for a specific provider
-// candidate. This is the single shared rewrite path used by both the initial
-// attempt and the 400 auto-retry, preventing drift between the two.
-//
-// Steps (applied in order):
-//  1. Model rename (client model → resolved model)
-//  2. stream_options injection (streaming + OpenAI-compatible providers only)
-//  3. Provider-specific param injection (InjectProviderParams)
-//  4. Learned param renaming (paramRenameCache, e.g. max_tokens → max_completion_tokens)
-//  5. Universal param stripping (providerUnsupportedParams)
-//  6. Learned param stripping (deprecationCache)
-//  7. Extra param stripping (additional rejected params, e.g. from 400 auto-retry)
-//  8. Message sanitization (drop empty tool_calls arrays)
-//
-// Injection (step 3) runs before all stripping (steps 5-7) so that a param a
-// provider injects but the upstream then rejects (learned into the deprecation
-// cache) is removed and stays removed on subsequent requests. Were injection
-// last, a learned rejection would be re-added on every fresh request, forcing a
-// 400+retry round-trip every time instead of just the first.
-//
-// Renaming (step 4) runs before stripping so the moved value lands under its new
-// key before any strip phase could delete the old key — a rename must preserve
-// the caller's value (e.g. their token budget), unlike a strip which discards it.
-func buildUpstreamBody(
-	proxyReqBody []byte,
-	providerType string,
-	resolvedModelID string,
-	requestModel string,
-	isStreaming bool,
-	deprecationCache *sync.Map,
-	renameCache *sync.Map,
-	extraStrip map[string]bool,
-) []byte {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(proxyReqBody, &raw); err != nil {
-		return proxyReqBody // unparseable — forward as-is
-	}
-
-	// 1. Model rename
-	if requestModel != resolvedModelID {
-		raw["model"] = resolvedModelID
-	}
-
-	// 2. stream_options injection
-	if isStreaming && providerSupportsStreamOptions(providerType) {
-		raw["stream_options"] = map[string]interface{}{
-			"include_usage": true,
-		}
-	}
-
-	// 3. Provider-specific param injection.
-	// Runs before all stripping so a learned/extra rejection of an injected
-	// param (e.g. chat_template_args) removes it and keeps it removed, rather
-	// than the param being re-added after the strip phases.
-	InjectProviderParams(raw, providerType, resolvedModelID)
-
-	cacheKey := fmt.Sprintf("%s:%s", providerType, resolvedModelID)
-
-	// 4. Learned param renaming (runs before stripping to preserve the value).
-	// Each rename moves old→new only when old is present and new is not already
-	// set, so an explicit caller value under the new key is never overwritten.
-	if renames := getCachedRenames(renameCache, cacheKey); renames != nil {
-		for oldName, newName := range renames {
-			if v, ok := raw[oldName]; ok {
-				if _, exists := raw[newName]; !exists {
-					raw[newName] = v
-				}
-				delete(raw, oldName)
-			}
-		}
-	}
-
-	// 5. Universal param stripping
-	if params, ok := providerUnsupportedParams[providerType]; ok {
-		for _, p := range params {
-			delete(raw, p)
-		}
-	}
-
-	// 6. Learned param stripping
-	if cached := getCachedRejectedParams(deprecationCache, cacheKey); cached != nil {
-		for param := range cached {
-			delete(raw, param)
-		}
-	}
-
-	// 7. Extra param stripping (e.g. newly-learned rejections from 400 auto-retry)
-	for param := range extraStrip {
-		delete(raw, param)
-	}
-
-	// 8. Message sanitization
-	stripEmptyToolCalls(raw)
-
-	if b, err := json.Marshal(raw); err == nil {
-		return b
-	}
-	return proxyReqBody
-}
-
-// stripEmptyToolCalls removes "tool_calls": [] from every message in the
-// request. Some clients serialize an assistant turn whose tool calls were
-// aborted or filtered out as an empty array instead of omitting the field;
-// the OpenAI spec requires min length 1 and strict providers (DeepSeek,
-// OpenCode Zen) reject the whole request with a 400, permanently bricking any
-// conversation that has such a turn in its history. No provider needs the
-// empty array, so dropping it is always safe.
-func stripEmptyToolCalls(raw map[string]interface{}) {
-	msgs, ok := raw["messages"].([]interface{})
-	if !ok {
-		return
-	}
-	for _, m := range msgs {
-		msg, ok := m.(map[string]interface{})
-		if !ok {
-			continue
-		}
-		if tc, ok := msg["tool_calls"].([]interface{}); ok && len(tc) == 0 {
-			delete(msg, "tool_calls")
-		}
 	}
 }

--- a/internal/proxy/helpers_test.go
+++ b/internal/proxy/helpers_test.go
@@ -2,6 +2,8 @@ package proxy
 
 import (
 	"testing"
+
+	"github.com/hugalafutro/model-hotel/internal/paramrewrite"
 )
 
 // ---------------------------------------------------------------------------
@@ -639,8 +641,8 @@ func TestProviderSupportsStreamOptions(t *testing.T) {
 	// Providers with non-OpenAI APIs that reject stream_options.
 	for _, pt := range []string{"anthropic", "google", "cohere", "opencode-go", "opencode-zen"} {
 		t.Run(pt+"_unsupported", func(t *testing.T) {
-			if providerSupportsStreamOptions(pt) {
-				t.Errorf("providerSupportsStreamOptions(%q) = true, want false", pt)
+			if paramrewrite.ProviderSupportsStreamOptions(pt) {
+				t.Errorf("paramrewrite.ProviderSupportsStreamOptions(%q) = true, want false", pt)
 			}
 		})
 	}
@@ -652,15 +654,15 @@ func TestProviderSupportsStreamOptions(t *testing.T) {
 		"lmstudio", "koboldcpp", "neuralwatt",
 	} {
 		t.Run(pt+"_supported", func(t *testing.T) {
-			if !providerSupportsStreamOptions(pt) {
-				t.Errorf("providerSupportsStreamOptions(%q) = false, want true", pt)
+			if !paramrewrite.ProviderSupportsStreamOptions(pt) {
+				t.Errorf("paramrewrite.ProviderSupportsStreamOptions(%q) = false, want true", pt)
 			}
 		})
 	}
 
 	// Unknown provider types default to supported (OpenAI-compatible assumption).
 	t.Run("unknown_supported", func(t *testing.T) {
-		if !providerSupportsStreamOptions("some-new-provider") {
+		if !paramrewrite.ProviderSupportsStreamOptions("some-new-provider") {
 			t.Error("unknown provider type should default to supported=true")
 		}
 	})

--- a/internal/proxy/multimodal.go
+++ b/internal/proxy/multimodal.go
@@ -141,13 +141,13 @@ func (h *Handler) servePassthroughPipeline(w http.ResponseWriter, r *http.Reques
 // everything else untouched. Numbers are decoded as json.Number so large
 // integers (e.g. 64-bit seeds beyond 2^53) survive the round-trip without
 // float64 precision loss. An unparseable body is forwarded as-is, mirroring
-// chat's buildUpstreamBody behavior.
+// chat's paramrewrite.BuildUpstreamBody behavior.
 func makeJSONModelRewriter(body []byte, requestModel string) func(string) ([]byte, string, error) {
 	return func(resolvedModelID string) ([]byte, string, error) {
 		out := body
 		if requestModel != resolvedModelID {
 			// Best-effort rewrite: an unparseable body is forwarded as-is
-			// (mirrors buildUpstreamBody).
+			// (mirrors paramrewrite.BuildUpstreamBody).
 			dec := json.NewDecoder(bytes.NewReader(body))
 			dec.UseNumber()
 			var raw map[string]interface{}

--- a/internal/proxy/provider_helpers_test.go
+++ b/internal/proxy/provider_helpers_test.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/hugalafutro/model-hotel/internal/paramrewrite"
 	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
@@ -103,12 +104,12 @@ func TestBuildProviderTargetURL(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// getCachedRejectedParams
+// paramrewrite.CachedRejectedParams
 // ---------------------------------------------------------------------------
 
 func TestGetCachedRejectedParams_EmptyCache(t *testing.T) {
 	var cache sync.Map
-	got := getCachedRejectedParams(&cache, "nonexistent")
+	got := paramrewrite.CachedRejectedParams(&cache, "nonexistent")
 	if got != nil {
 		t.Errorf("expected nil for empty cache, got %v", got)
 	}
@@ -119,7 +120,7 @@ func TestGetCachedRejectedParams_KeyExists(t *testing.T) {
 	expected := map[string]bool{"top_p": true, "temperature": true}
 	cache.Store("anthropic:claude-3-opus", expected)
 
-	got := getCachedRejectedParams(&cache, "anthropic:claude-3-opus")
+	got := paramrewrite.CachedRejectedParams(&cache, "anthropic:claude-3-opus")
 	if !reflect.DeepEqual(got, expected) {
 		t.Errorf("got %v, want %v", got, expected)
 	}
@@ -129,7 +130,7 @@ func TestGetCachedRejectedParams_WrongType(t *testing.T) {
 	var cache sync.Map
 	cache.Store("key", "not a map")
 
-	got := getCachedRejectedParams(&cache, "key")
+	got := paramrewrite.CachedRejectedParams(&cache, "key")
 	if got != nil {
 		t.Errorf("expected nil for wrong type value, got %v", got)
 	}
@@ -139,12 +140,12 @@ func TestGetCachedRejectedParams_NilMapValue(t *testing.T) {
 	var cache sync.Map
 	cache.Store("key", map[string]bool(nil))
 
-	got := getCachedRejectedParams(&cache, "key")
+	got := paramrewrite.CachedRejectedParams(&cache, "key")
 	// A nil map[string]bool passes the type assertion in Load, but the
 	// returned value is still nil (a nil map is nil in Go). Verify the
 	// function returns nil rather than a sentinel or empty map.
 	if got != nil {
-		t.Errorf("getCachedRejectedParams should return nil for nil map value, got %v", got)
+		t.Errorf("paramrewrite.CachedRejectedParams should return nil for nil map value, got %v", got)
 	}
 }
 
@@ -153,7 +154,7 @@ func TestGetCachedRejectedParams_MultipleKeys(t *testing.T) {
 	cache.Store("provider-a:model-1", map[string]bool{"top_p": true})
 	cache.Store("provider-b:model-2", map[string]bool{"temperature": true, "top_k": true})
 
-	got := getCachedRejectedParams(&cache, "provider-b:model-2")
+	got := paramrewrite.CachedRejectedParams(&cache, "provider-b:model-2")
 	expected := map[string]bool{"temperature": true, "top_k": true}
 	if !reflect.DeepEqual(got, expected) {
 		t.Errorf("got %v, want %v", got, expected)
@@ -161,25 +162,25 @@ func TestGetCachedRejectedParams_MultipleKeys(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// parseProviderParamError
+// paramrewrite.ParseProviderParamError
 // ---------------------------------------------------------------------------
 
 func TestParseProviderParamError_InvalidJSON(t *testing.T) {
-	got := parseProviderParamError([]byte(`{invalid json`))
+	got := paramrewrite.ParseProviderParamError([]byte(`{invalid json`))
 	if got != nil {
 		t.Errorf("expected nil for invalid JSON, got %v", got)
 	}
 }
 
 func TestParseProviderParamError_ValidJSONNoMatch(t *testing.T) {
-	got := parseProviderParamError([]byte(`{"error": {"message": "some unrelated error"}}`))
+	got := paramrewrite.ParseProviderParamError([]byte(`{"error": {"message": "some unrelated error"}}`))
 	if got != nil {
 		t.Errorf("expected nil for unrelated error, got %v", got)
 	}
 }
 
 func TestParseProviderParamError_TemperatureBacktick(t *testing.T) {
-	got := parseProviderParamError([]byte(`{"error":{"message":"` + "`temperature`" + ` is deprecated for this model"}}`))
+	got := paramrewrite.ParseProviderParamError([]byte(`{"error":{"message":"` + "`temperature`" + ` is deprecated for this model"}}`))
 	expected := map[string]bool{"temperature": true}
 	if !reflect.DeepEqual(got, expected) {
 		t.Errorf("got %v, want %v", got, expected)
@@ -187,7 +188,7 @@ func TestParseProviderParamError_TemperatureBacktick(t *testing.T) {
 }
 
 func TestParseProviderParamError_TopPQuoted(t *testing.T) {
-	got := parseProviderParamError([]byte(`{"error":{"message":"\"top_p\" is not supported"}}`))
+	got := paramrewrite.ParseProviderParamError([]byte(`{"error":{"message":"\"top_p\" is not supported"}}`))
 	expected := map[string]bool{"top_p": true}
 	if !reflect.DeepEqual(got, expected) {
 		t.Errorf("got %v, want %v", got, expected)
@@ -195,7 +196,7 @@ func TestParseProviderParamError_TopPQuoted(t *testing.T) {
 }
 
 func TestParseProviderParamError_TopKBacktick(t *testing.T) {
-	got := parseProviderParamError([]byte(`{"error":{"message":"` + "`top_k`" + ` is not supported on this endpoint"}}`))
+	got := paramrewrite.ParseProviderParamError([]byte(`{"error":{"message":"` + "`top_k`" + ` is not supported on this endpoint"}}`))
 	expected := map[string]bool{"top_k": true}
 	if !reflect.DeepEqual(got, expected) {
 		t.Errorf("got %v, want %v", got, expected)
@@ -203,7 +204,7 @@ func TestParseProviderParamError_TopKBacktick(t *testing.T) {
 }
 
 func TestParseProviderParamError_CannotBothBeSpecified(t *testing.T) {
-	got := parseProviderParamError([]byte(`{"error":{"message":"cannot both be specified"}}`))
+	got := paramrewrite.ParseProviderParamError([]byte(`{"error":{"message":"cannot both be specified"}}`))
 	expected := map[string]bool{"top_p": true}
 	if !reflect.DeepEqual(got, expected) {
 		t.Errorf("got %v, want %v", got, expected)
@@ -211,7 +212,7 @@ func TestParseProviderParamError_CannotBothBeSpecified(t *testing.T) {
 }
 
 func TestParseProviderParamError_TemperatureAndTopP(t *testing.T) {
-	got := parseProviderParamError([]byte(`{"error":{"message":"` + "`temperature` and `top_p`" + ` cannot both be specified"}}`))
+	got := paramrewrite.ParseProviderParamError([]byte(`{"error":{"message":"` + "`temperature` and `top_p`" + ` cannot both be specified"}}`))
 	expected := map[string]bool{"temperature": true, "top_p": true}
 	if !reflect.DeepEqual(got, expected) {
 		t.Errorf("got %v, want %v", got, expected)
@@ -219,14 +220,14 @@ func TestParseProviderParamError_TemperatureAndTopP(t *testing.T) {
 }
 
 func TestParseProviderParamError_TemperatureNotWrapped(t *testing.T) {
-	got := parseProviderParamError([]byte(`{"error":{"message":"invalid request for temperature value"}}`))
+	got := paramrewrite.ParseProviderParamError([]byte(`{"error":{"message":"invalid request for temperature value"}}`))
 	if got != nil {
 		t.Errorf("expected nil when temperature is not backtick/quote-wrapped, got %v", got)
 	}
 }
 
 func TestParseProviderParamError_ShortParamN(t *testing.T) {
-	got := parseProviderParamError([]byte(`{"error":{"message":"` + "`n`" + ` must be exactly 1"}}`))
+	got := paramrewrite.ParseProviderParamError([]byte(`{"error":{"message":"` + "`n`" + ` must be exactly 1"}}`))
 	expected := map[string]bool{"n": true}
 	if !reflect.DeepEqual(got, expected) {
 		t.Errorf("got %v, want %v", got, expected)
@@ -234,14 +235,14 @@ func TestParseProviderParamError_ShortParamN(t *testing.T) {
 }
 
 func TestParseProviderParamError_ShortParamNNotWrapped(t *testing.T) {
-	got := parseProviderParamError([]byte(`{"error":{"message":"n completions not supported"}}`))
+	got := paramrewrite.ParseProviderParamError([]byte(`{"error":{"message":"n completions not supported"}}`))
 	if got != nil {
 		t.Errorf("expected nil when n is not wrapped, got %v", got)
 	}
 }
 
 func TestParseProviderParamError_TopABacktick(t *testing.T) {
-	got := parseProviderParamError([]byte(`{"error":{"message":"` + "`top_a`" + ` is not supported"}}`))
+	got := paramrewrite.ParseProviderParamError([]byte(`{"error":{"message":"` + "`top_a`" + ` is not supported"}}`))
 	expected := map[string]bool{"top_a": true}
 	if !reflect.DeepEqual(got, expected) {
 		t.Errorf("got %v, want %v", got, expected)
@@ -249,7 +250,7 @@ func TestParseProviderParamError_TopABacktick(t *testing.T) {
 }
 
 func TestParseProviderParamError_TopZQuoted(t *testing.T) {
-	got := parseProviderParamError([]byte(`{"error":{"message":"\"top_z\" is unsupported"}}`))
+	got := paramrewrite.ParseProviderParamError([]byte(`{"error":{"message":"\"top_z\" is unsupported"}}`))
 	expected := map[string]bool{"top_z": true}
 	if !reflect.DeepEqual(got, expected) {
 		t.Errorf("got %v, want %v", got, expected)
@@ -257,7 +258,7 @@ func TestParseProviderParamError_TopZQuoted(t *testing.T) {
 }
 
 func TestParseProviderParamError_EmptyMessage(t *testing.T) {
-	got := parseProviderParamError([]byte(`{"error":{"message":""}}`))
+	got := paramrewrite.ParseProviderParamError([]byte(`{"error":{"message":""}}`))
 	if got != nil {
 		t.Errorf("expected nil for empty message, got %v", got)
 	}
@@ -265,7 +266,7 @@ func TestParseProviderParamError_EmptyMessage(t *testing.T) {
 
 func TestParseProviderParamError_BacktickBoundary(t *testing.T) {
 	// Message ending right at the closing backtick
-	got := parseProviderParamError([]byte(`{"error":{"message":"` + "`top_p`" + `"}}`))
+	got := paramrewrite.ParseProviderParamError([]byte(`{"error":{"message":"` + "`top_p`" + `"}}`))
 	expected := map[string]bool{"top_p": true}
 	if !reflect.DeepEqual(got, expected) {
 		t.Errorf("got %v, want %v", got, expected)
@@ -274,14 +275,14 @@ func TestParseProviderParamError_BacktickBoundary(t *testing.T) {
 
 func TestParseProviderParamError_TopNotWrapped(t *testing.T) {
 	// Message contains top_ but NOT backtick/quote-wrapped
-	got := parseProviderParamError([]byte(`{"error":{"message":"the top_p parameter is not supported"}}`))
+	got := paramrewrite.ParseProviderParamError([]byte(`{"error":{"message":"the top_p parameter is not supported"}}`))
 	if got != nil {
 		t.Errorf("expected nil when top_ is not wrapped, got %v", got)
 	}
 }
 
 func TestParseProviderParamError_FrequencyPenalty(t *testing.T) {
-	got := parseProviderParamError([]byte(`{"error":{"message":"` + "`frequency_penalty`" + ` not supported by this model"}}`))
+	got := paramrewrite.ParseProviderParamError([]byte(`{"error":{"message":"` + "`frequency_penalty`" + ` not supported by this model"}}`))
 	expected := map[string]bool{"frequency_penalty": true}
 	if !reflect.DeepEqual(got, expected) {
 		t.Errorf("got %v, want %v", got, expected)
@@ -289,7 +290,7 @@ func TestParseProviderParamError_FrequencyPenalty(t *testing.T) {
 }
 
 func TestParseProviderParamError_PresencePenalty(t *testing.T) {
-	got := parseProviderParamError([]byte(`{"error":{"message":"\"presence_penalty\" is invalid for this endpoint"}}`))
+	got := paramrewrite.ParseProviderParamError([]byte(`{"error":{"message":"\"presence_penalty\" is invalid for this endpoint"}}`))
 	expected := map[string]bool{"presence_penalty": true}
 	if !reflect.DeepEqual(got, expected) {
 		t.Errorf("got %v, want %v", got, expected)
@@ -297,7 +298,7 @@ func TestParseProviderParamError_PresencePenalty(t *testing.T) {
 }
 
 func TestParseProviderParamError_MultipleParams(t *testing.T) {
-	got := parseProviderParamError([]byte(`{"error":{"message":"` +
+	got := paramrewrite.ParseProviderParamError([]byte(`{"error":{"message":"` +
 		"`temperature`, `top_p`, `top_k`" +
 		` are not allowed with this model"}}`))
 	expected := map[string]bool{"temperature": true, "top_p": true, "top_k": true}
@@ -307,14 +308,14 @@ func TestParseProviderParamError_MultipleParams(t *testing.T) {
 }
 
 func TestParseProviderParamError_NoErrorField(t *testing.T) {
-	got := parseProviderParamError([]byte(`{"id": "123"}`))
+	got := paramrewrite.ParseProviderParamError([]byte(`{"id": "123"}`))
 	if got != nil {
 		t.Errorf("expected nil when no error field, got %v", got)
 	}
 }
 
 func TestParseProviderParamError_StopBacktick(t *testing.T) {
-	got := parseProviderParamError([]byte(`{"error":{"message":"` + "`stop`" + ` is not supported"}}`))
+	got := paramrewrite.ParseProviderParamError([]byte(`{"error":{"message":"` + "`stop`" + ` is not supported"}}`))
 	expected := map[string]bool{"stop": true}
 	if !reflect.DeepEqual(got, expected) {
 		t.Errorf("got %v, want %v", got, expected)
@@ -322,7 +323,7 @@ func TestParseProviderParamError_StopBacktick(t *testing.T) {
 }
 
 func TestParseProviderParamError_SeedBacktick(t *testing.T) {
-	got := parseProviderParamError([]byte(`{"error":{"message":"` + "`seed`" + ` cannot be set on this endpoint"}}`))
+	got := paramrewrite.ParseProviderParamError([]byte(`{"error":{"message":"` + "`seed`" + ` cannot be set on this endpoint"}}`))
 	expected := map[string]bool{"seed": true}
 	if !reflect.DeepEqual(got, expected) {
 		t.Errorf("got %v, want %v", got, expected)
@@ -330,7 +331,7 @@ func TestParseProviderParamError_SeedBacktick(t *testing.T) {
 }
 
 func TestParseProviderParamError_MaxTokensBacktick(t *testing.T) {
-	got := parseProviderParamError([]byte(`{"error":{"message":"` + "`max_tokens`" + ` exceeds model limit"}}`))
+	got := paramrewrite.ParseProviderParamError([]byte(`{"error":{"message":"` + "`max_tokens`" + ` exceeds model limit"}}`))
 	expected := map[string]bool{"max_tokens": true}
 	if !reflect.DeepEqual(got, expected) {
 		t.Errorf("got %v, want %v", got, expected)
@@ -338,7 +339,7 @@ func TestParseProviderParamError_MaxTokensBacktick(t *testing.T) {
 }
 
 func TestParseProviderParamError_LogprobsQuoted(t *testing.T) {
-	got := parseProviderParamError([]byte(`{"error":{"message":"\"logprobs\" is not available"}}`))
+	got := paramrewrite.ParseProviderParamError([]byte(`{"error":{"message":"\"logprobs\" is not available"}}`))
 	expected := map[string]bool{"logprobs": true}
 	if !reflect.DeepEqual(got, expected) {
 		t.Errorf("got %v, want %v", got, expected)
@@ -346,7 +347,7 @@ func TestParseProviderParamError_LogprobsQuoted(t *testing.T) {
 }
 
 func TestParseProviderParamError_ReasoningEffortBacktick(t *testing.T) {
-	got := parseProviderParamError([]byte(`{"error":{"message":"` + "`reasoning_effort`" + ` is not supported"}}`))
+	got := paramrewrite.ParseProviderParamError([]byte(`{"error":{"message":"` + "`reasoning_effort`" + ` is not supported"}}`))
 	expected := map[string]bool{"reasoning_effort": true}
 	if !reflect.DeepEqual(got, expected) {
 		t.Errorf("got %v, want %v", got, expected)
@@ -358,7 +359,7 @@ func TestParseProviderParamError_ReasoningEffortBacktick(t *testing.T) {
 
 func TestParseProviderParamError_ChatTemplateArgsVLLMSingleQuote(t *testing.T) {
 	// vLLM/pydantic format (e.g. opencode-go/glm-5.2): single-quoted field name.
-	got := parseProviderParamError([]byte(`{"error":{"message":"Error from provider: Extra inputs are not permitted, field: 'chat_template_args'"}}`))
+	got := paramrewrite.ParseProviderParamError([]byte(`{"error":{"message":"Error from provider: Extra inputs are not permitted, field: 'chat_template_args'"}}`))
 	expected := map[string]bool{"chat_template_args": true}
 	if !reflect.DeepEqual(got, expected) {
 		t.Errorf("got %v, want %v", got, expected)
@@ -367,7 +368,7 @@ func TestParseProviderParamError_ChatTemplateArgsVLLMSingleQuote(t *testing.T) {
 
 func TestParseProviderParamError_ChatTemplateArgsBare(t *testing.T) {
 	// OpenAI-style passthrough (e.g. opencode-zen/gpt-5-nano): bare field name.
-	got := parseProviderParamError([]byte(`{"error":{"message":"Unrecognized request argument supplied: chat_template_args"}}`))
+	got := paramrewrite.ParseProviderParamError([]byte(`{"error":{"message":"Unrecognized request argument supplied: chat_template_args"}}`))
 	expected := map[string]bool{"chat_template_args": true}
 	if !reflect.DeepEqual(got, expected) {
 		t.Errorf("got %v, want %v", got, expected)
@@ -375,14 +376,14 @@ func TestParseProviderParamError_ChatTemplateArgsBare(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// parseProviderParamRename
+// paramrewrite.ParseProviderParamRename
 // ---------------------------------------------------------------------------
 
 func TestParseProviderParamRename_MaxCompletionTokens(t *testing.T) {
 	// OpenAI gpt-5/o-series deprecation (also reaches us via OpenCode Zen
 	// passthrough): max_tokens must be renamed to max_completion_tokens, not
 	// dropped — dropping would silently discard the caller's token budget.
-	got := parseProviderParamRename([]byte(`{"error":{"message":"Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.","type":"invalid_request_error","param":"max_tokens","code":"unsupported_parameter"}}`))
+	got := paramrewrite.ParseProviderParamRename([]byte(`{"error":{"message":"Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.","type":"invalid_request_error","param":"max_tokens","code":"unsupported_parameter"}}`))
 	expected := map[string]string{"max_tokens": "max_completion_tokens"}
 	if !reflect.DeepEqual(got, expected) {
 		t.Errorf("got %v, want %v", got, expected)
@@ -392,7 +393,7 @@ func TestParseProviderParamRename_MaxCompletionTokens(t *testing.T) {
 func TestParseProviderParamRename_NoRenameSignal(t *testing.T) {
 	// An ordinary rejection that doesn't mention max_completion_tokens must not
 	// trigger a rename.
-	got := parseProviderParamRename([]byte(`{"error":{"message":"Unrecognized request argument supplied: chat_template_args"}}`))
+	got := paramrewrite.ParseProviderParamRename([]byte(`{"error":{"message":"Unrecognized request argument supplied: chat_template_args"}}`))
 	if got != nil {
 		t.Errorf("expected nil (no rename), got %v", got)
 	}
@@ -409,14 +410,14 @@ func TestParseProviderParamRename_ValidationErrorNotRename(t *testing.T) {
 		`{"error":{"message":"Only one of max_tokens or max_completion_tokens may be specified."}}`,
 	}
 	for _, body := range cases {
-		if got := parseProviderParamRename([]byte(body)); got != nil {
+		if got := paramrewrite.ParseProviderParamRename([]byte(body)); got != nil {
 			t.Errorf("expected nil (not a rename directive) for %q, got %v", body, got)
 		}
 	}
 }
 
 func TestParseProviderParamRename_Unparseable(t *testing.T) {
-	if got := parseProviderParamRename([]byte("not json")); got != nil {
+	if got := paramrewrite.ParseProviderParamRename([]byte("not json")); got != nil {
 		t.Errorf("expected nil for unparseable body, got %v", got)
 	}
 }
@@ -702,9 +703,9 @@ func TestProviderUnsupportedParams_ReasoningEffort(t *testing.T) {
 	}
 
 	for _, provider := range providersWithReasoningEffort {
-		params, ok := providerUnsupportedParams[provider]
+		params, ok := paramrewrite.ProviderUnsupportedParams[provider]
 		if !ok {
-			t.Errorf("provider %q: missing from providerUnsupportedParams", provider)
+			t.Errorf("provider %q: missing from paramrewrite.ProviderUnsupportedParams", provider)
 			continue
 		}
 		found := false
@@ -723,7 +724,7 @@ func TestProviderUnsupportedParams_ReasoningEffort(t *testing.T) {
 func TestProviderUnsupportedParams_OpenAISupportsReasoningEffort(t *testing.T) {
 	// OpenAI and xAI support reasoning_effort — it should NOT be in their unsupported list
 	for _, provider := range []string{"openai", "xai"} {
-		params, ok := providerUnsupportedParams[provider]
+		params, ok := paramrewrite.ProviderUnsupportedParams[provider]
 		if !ok {
 			continue // no entry is fine (means nothing is unsupported)
 		}
@@ -756,7 +757,7 @@ func TestProviderUnsupportedParams_StripsFromRequestBody(t *testing.T) {
 	}
 
 	// Strip anthropic-unsupported params (includes reasoning_effort)
-	if params, ok := providerUnsupportedParams["anthropic"]; ok {
+	if params, ok := paramrewrite.ProviderUnsupportedParams["anthropic"]; ok {
 		for _, p := range params {
 			delete(rawMap, p)
 		}

--- a/internal/proxy/proxy_chat_test.go
+++ b/internal/proxy/proxy_chat_test.go
@@ -496,7 +496,7 @@ func TestChatCompletions_DeprecationCacheFirstEntry(t *testing.T) {
 	defer stopUnitHandlerIntegration(handler)
 
 	// Configure upstream to return 400 with a param rejection for "top_p".
-	// The backtick-wrapped param name is recognized by parseProviderParamError.
+	// The backtick-wrapped param name is recognized by paramrewrite.ParseProviderParamError.
 	upstream.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte(`{"error":{"message":"` + "`top_p`" + ` is not supported for this model"}}`))

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"net/http/httptrace"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -18,6 +17,7 @@ import (
 
 	"github.com/hugalafutro/model-hotel/internal/ctxkeys"
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
+	"github.com/hugalafutro/model-hotel/internal/paramrewrite"
 	"github.com/hugalafutro/model-hotel/internal/provider"
 	"github.com/hugalafutro/model-hotel/internal/util"
 )
@@ -112,7 +112,7 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 	// in a 400 error can only mean the sampling parameter.
 	//
 	// Skipped for native Anthropic passthrough: this self-heal rebuilds the
-	// OpenAI-shaped st.bodyBytes via buildUpstreamBody and re-POSTs it, but a
+	// OpenAI-shaped st.bodyBytes via paramrewrite.BuildUpstreamBody and re-POSTs it, but a
 	// native attempt's targetURL is the provider's /v1/messages (Anthropic wire
 	// format). Stripping OpenAI params off the wrong body and sending it to the
 	// native endpoint would be malformed; a native 400 is forwarded as-is.
@@ -325,7 +325,7 @@ func (h *Handler) touchProviderLastUsed(pid uuid.UUID) {
 // can thread them into the 400 auto-retry path.
 //
 // Chat requests (st.makeUpstreamBody == nil) go through the chat-specific
-// rewrite (buildUpstreamBody: model rename, stream_options, param stripping).
+// rewrite (paramrewrite.BuildUpstreamBody: model rename, stream_options, param stripping).
 // Multimodal requests provide st.makeUpstreamBody, which owns the body rewrite
 // and its Content-Type (JSON model rename, or multipart reconstruction).
 func (h *Handler) buildCandidateRequest(ctx context.Context, st *requestState, candidate modelCandidate) (*http.Request, string, string, error) {
@@ -361,10 +361,10 @@ func (h *Handler) buildCandidateRequest(ctx context.Context, st *requestState, c
 			return nil, providerType, targetURL, err
 		}
 	} else {
-		needsRewrite := st.reqModel != candidate.model.ModelID || providerType == "anthropic" || NeedsProviderInjection(providerType) || st.isStreaming
+		needsRewrite := st.reqModel != candidate.model.ModelID || providerType == "anthropic" || paramrewrite.NeedsProviderInjection(providerType) || st.isStreaming
 		debuglog.Debug("proxy: request rewrite check", "needs_rewrite", needsRewrite, "request_model", logData.modelID, "provider", logData.providerName, "resolved_model", candidate.model.ModelID, "provider_type", providerType)
 		if needsRewrite {
-			upstreamBody = buildUpstreamBody(st.bodyBytes, providerType, candidate.model.ModelID, st.reqModel, st.isStreaming, &h.deprecationCache, &h.paramRenameCache, nil)
+			upstreamBody = paramrewrite.BuildUpstreamBody(st.bodyBytes, providerType, candidate.model.ModelID, st.reqModel, st.isStreaming, &h.deprecationCache, &h.paramRenameCache, nil)
 		}
 		// Log the actual model name in the upstream body for debugging rewrite
 		// issues. Chat-only: multipart bodies must never reach debug logs.
@@ -644,8 +644,8 @@ func (h *Handler) retryWithStrippedParams(
 	// A 400 can ask us to drop a param (rejected → strip) and/or move a param to
 	// a new name (rename → preserve value). Both feed the same self-heal: learn,
 	// cache for future preemptive application, and retry once.
-	rejected := parseProviderParamError(body)
-	renames := parseProviderParamRename(body)
+	rejected := paramrewrite.ParseProviderParamError(body)
+	renames := paramrewrite.ParseProviderParamRename(body)
 	if rejected == nil && renames == nil {
 		return res
 	}
@@ -655,10 +655,10 @@ func (h *Handler) retryWithStrippedParams(
 	// data races from concurrent goroutines mutating the same map.
 	cacheKey := fmt.Sprintf("%s:%s", providerType, candidate.model.ModelID)
 	if rejected != nil {
-		mergeLearnedParamCache(&h.deprecationCache, cacheKey, rejected)
+		paramrewrite.MergeLearnedParamCache(&h.deprecationCache, cacheKey, rejected)
 	}
 	if renames != nil {
-		mergeLearnedParamCache(&h.paramRenameCache, cacheKey, renames)
+		paramrewrite.MergeLearnedParamCache(&h.paramRenameCache, cacheKey, renames)
 	}
 
 	// Rebuild the request body using the shared rewrite path. This ensures
@@ -667,7 +667,7 @@ func (h *Handler) retryWithStrippedParams(
 	// from the initial attempt path. The renames just cached are picked up from
 	// paramRenameCache; the freshly-rejected params are also passed as extraStrip
 	// so the immediate retry strips them even before the cache write is observed.
-	rebuilt := buildUpstreamBody(st.bodyBytes, providerType, candidate.model.ModelID, st.reqModel, st.isStreaming, &h.deprecationCache, &h.paramRenameCache, rejected)
+	rebuilt := paramrewrite.BuildUpstreamBody(st.bodyBytes, providerType, candidate.model.ModelID, st.reqModel, st.isStreaming, &h.deprecationCache, &h.paramRenameCache, rejected)
 	retryCtx, rc := context.WithTimeout(r.Context(), st.failoverTimeout)
 	retryCtx = context.WithValue(retryCtx, ctxkeys.CancelOriginKey, "retry_timeout")
 	retryCtx = context.WithValue(retryCtx, ctxkeys.DialMsKey, dialMs)
@@ -713,35 +713,6 @@ func (h *Handler) retryWithStrippedParams(
 	res.retried = true
 	debuglog.Info("proxy: auto-retry succeeded", "model", candidate.model.ModelID, "rejected_params", mapKeys(rejected), "renamed_params", renameKeys(renames))
 	return res
-}
-
-// mergeLearnedParamCache merges newly-learned per-model param metadata into a
-// sync.Map cache keyed by "providerType:modelID", race-free under concurrent
-// goroutines via CompareAndSwap. Values are stored as *map[string]V (pointers,
-// because maps are not comparable and CompareAndSwap requires comparable values).
-func mergeLearnedParamCache[V any](cache *sync.Map, key string, learned map[string]V) {
-	for {
-		existing, loaded := cache.LoadOrStore(key, &learned)
-		if !loaded {
-			return // first entry for this key — we just stored 'learned'
-		}
-		existingMap, ok := existing.(*map[string]V)
-		if !ok {
-			debuglog.Error("learned param cache: unexpected type", "key", key, "type", fmt.Sprintf("%T", existing))
-			return
-		}
-		merged := make(map[string]V, len(*existingMap)+len(learned))
-		for k, v := range *existingMap {
-			merged[k] = v
-		}
-		for k, v := range learned {
-			merged[k] = v
-		}
-		if cache.CompareAndSwap(key, existing, &merged) {
-			return
-		}
-		// CompareAndSwap failed — another goroutine updated it, retry.
-	}
 }
 
 // renameKeys returns the old param names from a rename map, for log fields.


### PR DESCRIPTION
## Problem

The Models-page **Test** button (`POST /api/models/{id}/test`) failed for the **entire OpenAI gpt-5 / o-series family** with:

> `HTTP 400: Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.`

Root cause: `TestModel` hand-built its probe (`buildTestModelRequest`) with a hardcoded `max_tokens: 10` and fired it once, with no param-rename and no retry. That diverged from the real proxy path (`/v1/chat/completions`), which already self-heals this exact 400 in-request (`internal/proxy/param_error.go` + `retryWithStrippedParams`: rename the param, rebuild the body, retry once). So live traffic worked but the probe never did. Repro'd live for `gpt-5.1` through `gpt-5.6`, plus o-series.

## Fix — one shared implementation, no divergence

Extract the request-rewrite and 400 param-heal into a new leaf package **`internal/paramrewrite`** (deps: `debuglog` + stdlib only):

- `BuildUpstreamBody` (moved from `proxy/helpers.go`) — the single body rewriter
- `ParseProviderParamError` / `ParseProviderParamRename` + learned-param caches (moved from `proxy/param_error.go`)
- `InjectProviderParams` (moved from `proxy/provider_params.go`)
- new `SelfHealChatCompletion` — standalone "fire once; on a param-400 rebuild via `BuildUpstreamBody` and retry once", the single-candidate analog of the failover loop's retry

The proxy failover loop and the admin Test probe now build bodies and heal 400s through the **same** functions, so the two paths can't drift again. `git mv` preserves history; the proxy failover behavior is unchanged (it just calls `paramrewrite.*`).

## Verification

- `go build ./...`, `go vet ./...`, `golangci-lint` (0 issues), proxy + api + paramrewrite suites green
- New `selfheal_test.go`: max_tokens→max_completion_tokens rename+retry (replays the exact prod 400), rejected-param strip+retry, and non-param-400 no-retry
- **Live** on a rebuilt box against real OpenAI: all `gpt-5.1..5.6` Test probes now succeed; normal proxy path unaffected (before/after on identical config)

## Not in this PR

A separate follow-up will handle gpt-5.6 **function tools**, which OpenAI rejects on `/v1/chat/completions` unless `reasoning_effort: "none"` is set — a distinct, model-specific rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)