### PR TITLE
fix(bellhop): humanize event titles, cap link tap targets, label the traffic chart

### DIFF
--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/alerts/AlertsScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/alerts/AlertsScreen.kt
@@ -38,6 +38,7 @@ import com.hugalafutro.bellhop.data.AlertStatus
 import com.hugalafutro.bellhop.ui.common.Pill
 import com.hugalafutro.bellhop.ui.common.StatusBanner
 import com.hugalafutro.bellhop.ui.common.bellhopSwitchColors
+import com.hugalafutro.bellhop.ui.common.eventTypeLabel
 import com.hugalafutro.bellhop.ui.common.severityColors
 import com.hugalafutro.bellhop.ui.theme.BellhopTheme
 
@@ -292,27 +293,6 @@ private fun severityLabel(severity: String): String =
         "warning" -> stringResource(R.string.events_sev_warning)
         "error" -> stringResource(R.string.events_sev_error)
         else -> severity
-    }
-
-// eventTypeLabel gives a readable name for a catalog event type, falling back to
-// the raw type so a brand-new server-side event still renders before a string is
-// added (matches the Front Desk web picker's defaultValue behaviour).
-@Composable
-private fun eventTypeLabel(type: String): String =
-    when (type) {
-        "health.down" -> stringResource(R.string.alerts_event_health_down)
-        "health.up" -> stringResource(R.string.alerts_event_health_up)
-        "config.sync_failed" -> stringResource(R.string.alerts_event_config_sync_failed)
-        "config.synced" -> stringResource(R.string.alerts_event_config_synced)
-        "config.auto_synced" -> stringResource(R.string.alerts_event_config_auto_synced)
-        "config.autosync_stale" -> stringResource(R.string.alerts_event_config_autosync_stale)
-        "version.fetch_failed" -> stringResource(R.string.alerts_event_version_fetch_failed)
-        "version.fetch_recovered" -> stringResource(R.string.alerts_event_version_fetch_recovered)
-        "traefik.stale" -> stringResource(R.string.alerts_event_traefik_stale)
-        "member.added" -> stringResource(R.string.alerts_event_member_added)
-        "member.removed" -> stringResource(R.string.alerts_event_member_removed)
-        "member.state_changed" -> stringResource(R.string.alerts_event_member_state_changed)
-        else -> type
     }
 
 @Preview(showBackground = true)

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/EventLabels.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/EventLabels.kt
@@ -1,0 +1,34 @@
+package com.hugalafutro.bellhop.ui.common
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.hugalafutro.bellhop.R
+
+/**
+ * eventTypeLabel is the human name for a control-plane event type, shared by
+ * the alert catalog and both event logs so the same event reads identically
+ * everywhere. The raw dotted code stays available in the log rows' mono meta
+ * line (and in the long-press copy text); a brand-new server-side type this
+ * build doesn't know yet falls back to that raw code as the title.
+ */
+@Composable
+internal fun eventTypeLabel(type: String): String =
+    when (type) {
+        "health.down" -> stringResource(R.string.alerts_event_health_down)
+        "health.up" -> stringResource(R.string.alerts_event_health_up)
+        "config.sync_failed" -> stringResource(R.string.alerts_event_config_sync_failed)
+        "config.synced" -> stringResource(R.string.alerts_event_config_synced)
+        "config.auto_synced" -> stringResource(R.string.alerts_event_config_auto_synced)
+        "config.autosync_stale" -> stringResource(R.string.alerts_event_config_autosync_stale)
+        "config.regenerated" -> stringResource(R.string.event_config_regenerated)
+        "version.fetch_failed" -> stringResource(R.string.alerts_event_version_fetch_failed)
+        "version.fetch_recovered" -> stringResource(R.string.alerts_event_version_fetch_recovered)
+        "traefik.stale" -> stringResource(R.string.alerts_event_traefik_stale)
+        "member.added" -> stringResource(R.string.alerts_event_member_added)
+        "member.removed" -> stringResource(R.string.alerts_event_member_removed)
+        "member.state_changed" -> stringResource(R.string.alerts_event_member_state_changed)
+        "device.paired" -> stringResource(R.string.event_device_paired)
+        "device.revoked" -> stringResource(R.string.event_device_revoked)
+        "settings.changed" -> stringResource(R.string.event_settings_changed)
+        else -> type
+    }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/SeverityRailRow.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/SeverityRailRow.kt
@@ -14,7 +14,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 
@@ -24,7 +23,7 @@ private val RAIL_WIDTH = 3.dp
 /**
  * SeverityRailRow is the shared "log line" chrome for both event lists: a
  * severity-coloured rail down the left edge plus a faint tint of the same
- * colour, wrapping caller [content] (which receives the matching type colour).
+ * colour, wrapping caller [content].
  *
  * The rail is painted with drawBehind on a matchParentSize overlay instead of
  * being a fillMaxHeight sibling. That removes the per-row height(IntrinsicSize.Min)
@@ -44,9 +43,9 @@ fun SeverityRailRow(
     // stray tap while scrolling the log doesn't copy. When set, the row wires
     // combinedClickable; a plain [onClick] alone still uses clickable.
     onLongClick: (() -> Unit)? = null,
-    content: @Composable ColumnScope.(typeColor: Color) -> Unit,
+    content: @Composable ColumnScope.() -> Unit,
 ) {
-    val (accent, typeColor) = severityColors(severity)
+    val (accent, _) = severityColors(severity)
     Box(
         modifier =
             modifier
@@ -83,7 +82,7 @@ fun SeverityRailRow(
             modifier = Modifier.fillMaxWidth().padding(start = 15.dp, end = 12.dp, top = 10.dp, bottom = 10.dp),
             verticalArrangement = Arrangement.spacedBy(3.dp),
         ) {
-            content(typeColor)
+            content()
         }
     }
 }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/TightTouchTarget.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/TightTouchTarget.kt
@@ -1,0 +1,27 @@
+package com.hugalafutro.bellhop.ui.common
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalViewConfiguration
+import androidx.compose.ui.platform.ViewConfiguration
+import androidx.compose.ui.unit.DpSize
+
+/**
+ * TightTouchTarget keeps [content]'s tap targets at their drawn bounds by
+ * turning off the 48dp minimum touch-target expansion (ViewConfiguration's
+ * minimumTouchTargetSize, applied by every clickable). The expansion is meant
+ * for isolated controls; on links that sit closer than 48dp to other tap
+ * targets it silently steals their taps instead.
+ */
+@Composable
+internal fun TightTouchTarget(content: @Composable () -> Unit) {
+    val base = LocalViewConfiguration.current
+    val tight =
+        remember(base) {
+            object : ViewConfiguration by base {
+                override val minimumTouchTargetSize: DpSize get() = DpSize.Zero
+            }
+        }
+    CompositionLocalProvider(LocalViewConfiguration provides tight, content = content)
+}

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -75,6 +74,7 @@ import com.hugalafutro.bellhop.ui.common.LockFab
 import com.hugalafutro.bellhop.ui.common.Pill
 import com.hugalafutro.bellhop.ui.common.ScrollToTopButton
 import com.hugalafutro.bellhop.ui.common.StatusBanner
+import com.hugalafutro.bellhop.ui.common.TightTouchTarget
 import com.hugalafutro.bellhop.ui.common.TrafficChart
 import com.hugalafutro.bellhop.ui.common.bellhopSwitchColors
 import com.hugalafutro.bellhop.ui.common.healthColor
@@ -534,18 +534,24 @@ private fun MemberCard(
                 }
             }
             // The URL is its own tap target (opens the "open externally" popup),
-            // separate from the card tap that drills into the member.
-            Text(
-                text = member.url,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.primary,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                modifier =
-                    Modifier
-                        .clickable(onClick = onUrlClick)
-                        .testTag("member-url-${member.name}"),
-            )
+            // separate from the card tap that drills into the member. Its touch
+            // target is capped to the text bounds: the default 48dp minimum
+            // spills over the name row above and the health row below, so taps
+            // meant to open the member land on the link instead. The card around
+            // it stays the big target.
+            TightTouchTarget {
+                Text(
+                    text = member.url,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.primary,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier =
+                        Modifier
+                            .clickable(onClick = onUrlClick)
+                            .testTag("member-url-${member.name}"),
+                )
+            }
             Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
                 Text(
                     text = healthLabel(health),
@@ -603,11 +609,13 @@ private fun MemberCard(
                     }
                 }
             }
-            // Recent-event pill: a severity-tinted, one-line preview of this
-            // member's latest event with its age right-aligned, tappable straight
-            // into the member.
+            // Recent-event line: a quiet, one-line preview of this member's
+            // latest event with its age right-aligned, tappable straight into
+            // the member. A small dot plus a faint tint carry severity (the
+            // saturated palette is badges-only); the line itself stays
+            // surface-toned so it reads as a log line, not a button.
             recentEvent?.let { ev ->
-                val (evContainer, evContent) = severityColors(ev.severity)
+                val (evAccent, _) = severityColors(ev.severity)
                 // Tick a local clock so the "3 min ago" age recomputes on its own.
                 // Without it the age is frozen: eventAgo is memoized on the event's
                 // timestamp, which doesn't change between refreshes, so a stationary
@@ -622,15 +630,23 @@ private fun MemberCard(
                 Spacer(modifier = Modifier.height(4.dp))
                 Surface(
                     onClick = onClick,
-                    color = evContainer,
-                    contentColor = evContent,
+                    color = evAccent.copy(alpha = 0.06f),
+                    contentColor = MaterialTheme.colorScheme.onSurface,
                     shape = RoundedCornerShape(8.dp),
                     modifier = Modifier.fillMaxWidth().testTag("member-recent-event-${member.name}"),
                 ) {
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
                         modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
                     ) {
+                        Box(
+                            modifier =
+                                Modifier
+                                    .size(8.dp)
+                                    .clip(CircleShape)
+                                    .background(evAccent),
+                        )
                         Text(
                             text = ev.message.ifBlank { ev.type },
                             style = MaterialTheme.typography.bodySmall,
@@ -640,10 +656,10 @@ private fun MemberCard(
                         )
                         val context = LocalContext.current
                         remember(ev.createdAt, now, context) { eventAgo(context, ev.createdAt, now) }?.let { ago ->
-                            Spacer(modifier = Modifier.width(8.dp))
                             Text(
                                 text = ago,
                                 style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
                                 maxLines = 1,
                             )
                         }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/events/EventsScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/events/EventsScreen.kt
@@ -44,6 +44,7 @@ import com.hugalafutro.bellhop.ui.common.FilterPill
 import com.hugalafutro.bellhop.ui.common.ScrollToTopButton
 import com.hugalafutro.bellhop.ui.common.SeverityRailRow
 import com.hugalafutro.bellhop.ui.common.StatusBanner
+import com.hugalafutro.bellhop.ui.common.eventTypeLabel
 import com.hugalafutro.bellhop.ui.common.loadMoreSentinel
 import com.hugalafutro.bellhop.ui.theme.BellhopTheme
 import com.hugalafutro.bellhop.ui.theme.MonoFamily
@@ -245,18 +246,17 @@ private fun EventRow(
         railTag = "event-sev-${event.severity}",
         modifier = modifier,
         onLongClick = if (holdToCopy) onCopy else null,
-    ) { typeColor ->
+    ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            // Machine event type in mono + the severity colour, so the code
-            // token reads apart from the human message on the next line.
+            // The human name leads in full-contrast text (the rail + tint carry
+            // severity); the machine code is demoted to the mono meta line below,
+            // so the title never truncates mid-code.
             Text(
-                text = event.type,
+                text = eventTypeLabel(event.type),
                 style = MaterialTheme.typography.titleSmall,
-                fontFamily = MonoFamily,
-                color = typeColor,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
                 modifier = Modifier.weight(1f),
@@ -275,6 +275,7 @@ private fun EventRow(
         )
         val who =
             listOfNotNull(
+                event.type.ifEmpty { null },
                 event.source.ifEmpty { null },
                 memberName ?: event.memberId.ifEmpty { null },
             ).joinToString(" · ")

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreen.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextOverflow
@@ -67,7 +68,9 @@ import com.hugalafutro.bellhop.ui.common.Pill
 import com.hugalafutro.bellhop.ui.common.ScrollToTopButton
 import com.hugalafutro.bellhop.ui.common.SeverityRailRow
 import com.hugalafutro.bellhop.ui.common.StatusBanner
+import com.hugalafutro.bellhop.ui.common.TightTouchTarget
 import com.hugalafutro.bellhop.ui.common.TrafficChart
+import com.hugalafutro.bellhop.ui.common.eventTypeLabel
 import com.hugalafutro.bellhop.ui.common.healthColor
 import com.hugalafutro.bellhop.ui.common.loadMoreSentinel
 import com.hugalafutro.bellhop.ui.common.relativeAgo
@@ -76,6 +79,9 @@ import com.hugalafutro.bellhop.ui.events.formatEventTime
 import com.hugalafutro.bellhop.ui.theme.BellhopTheme
 import com.hugalafutro.bellhop.ui.theme.MonoFamily
 import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.Locale
 
 /**
  * MemberDetailScreen is one member up close — deliberately *not* a repeat of the
@@ -421,33 +427,38 @@ private fun LedgerRow(
     trailing: String? = null,
     trailingColor: Color? = null,
 ) {
-    Row(
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
-        modifier =
-            modifier
-                .fillMaxWidth()
-                .then(if (tag != null) Modifier.testTag(tag) else Modifier)
-                .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier),
-    ) {
-        Text(
-            text = label.uppercase(),
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.width(76.dp),
-        )
-        Text(
-            text = value,
-            style = MaterialTheme.typography.bodySmall,
-            fontFamily = MonoFamily,
-            color = valueColor,
-            modifier = Modifier.weight(1f),
-        )
-        trailing?.let {
+    // The clickable rows keep their touch target at the row's own bounds: the
+    // default 48dp minimum would spill over the ledger rows above and below
+    // (they sit ~17dp apart), sending taps on VERSION into the ADDRESS popup.
+    TightTouchTarget {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            modifier =
+                modifier
+                    .fillMaxWidth()
+                    .then(if (tag != null) Modifier.testTag(tag) else Modifier)
+                    .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier),
+        ) {
             Text(
-                text = it,
-                style = MaterialTheme.typography.bodySmall,
-                color = trailingColor ?: MaterialTheme.colorScheme.onSurfaceVariant,
+                text = label.uppercase(),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.width(76.dp),
             )
+            Text(
+                text = value,
+                style = MaterialTheme.typography.bodySmall,
+                fontFamily = MonoFamily,
+                color = valueColor,
+                modifier = Modifier.weight(1f),
+            )
+            trailing?.let {
+                Text(
+                    text = it,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = trailingColor ?: MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
         }
     }
 }
@@ -732,33 +743,103 @@ private fun TrafficCard(
                         )
                     }
                 else -> {
-                    Text(
-                        text =
-                            stringResource(
-                                R.string.member_detail_traffic_totals,
-                                traffic.totalRequests,
-                                traffic.totalErrors,
-                            ),
-                        style = MaterialTheme.typography.bodySmall,
-                        fontFamily = MonoFamily,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    // The totals double as the chart legend: each count sits behind
+                    // a dot in the colour its bars are drawn in, so the red error
+                    // overlay is explained right where the numbers are. Counts go
+                    // through plurals so one error never reads "1 errors".
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(6.dp),
                         modifier = Modifier.testTag("member-traffic-totals"),
-                    )
+                    ) {
+                        LegendDot(color = MaterialTheme.colorScheme.primary)
+                        Text(
+                            text =
+                                pluralStringResource(
+                                    R.plurals.member_detail_traffic_requests,
+                                    traffic.totalRequests,
+                                    traffic.totalRequests,
+                                ),
+                            style = MaterialTheme.typography.bodySmall,
+                            fontFamily = MonoFamily,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        LegendDot(color = MaterialTheme.colorScheme.error)
+                        Text(
+                            text =
+                                pluralStringResource(
+                                    R.plurals.member_detail_traffic_errors,
+                                    traffic.totalErrors,
+                                    traffic.totalErrors,
+                                ),
+                            style = MaterialTheme.typography.bodySmall,
+                            fontFamily = MonoFamily,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
                     TrafficChart(
                         points = traffic.points,
                         modifier = Modifier.height(140.dp).testTag("member-traffic-chart"),
                     )
+                    // Wall-clock times under the chart edges, so the bars are
+                    // anchored in time instead of floating unlabeled. Omitted when
+                    // the bucket timestamps don't parse.
+                    trafficAxisLabels(traffic.points)?.let { (start, end) ->
+                        Row(modifier = Modifier.fillMaxWidth().testTag("member-traffic-axis")) {
+                            Text(
+                                text = start,
+                                style = MaterialTheme.typography.labelSmall,
+                                fontFamily = MonoFamily,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                            Spacer(modifier = Modifier.weight(1f))
+                            Text(
+                                text = end,
+                                style = MaterialTheme.typography.labelSmall,
+                                fontFamily = MonoFamily,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    }
                 }
             }
         }
     }
 }
 
+/** LegendDot is a small colour swatch keying a legend entry to its bars. */
+@Composable
+private fun LegendDot(
+    color: Color,
+    modifier: Modifier = Modifier,
+) {
+    Box(modifier = modifier.size(8.dp).clip(CircleShape).background(color))
+}
+
+/**
+ * trafficAxisLabels turns the first and last bucket timestamps into local
+ * wall-clock "HH:mm" labels for the chart's time axis, or null when the buckets
+ * don't parse (the axis row is then omitted rather than showing raw strings).
+ * The formatter is built per call, not held in a static, so an in-app language
+ * switch is picked up.
+ */
+private fun trafficAxisLabels(points: List<TrafficPoint>): Pair<String, String>? =
+    try {
+        val fmt =
+            DateTimeFormatter
+                .ofPattern("HH:mm", Locale.getDefault())
+                .withZone(ZoneId.systemDefault())
+        fmt.format(Instant.parse(points.first().bucket)) to fmt.format(Instant.parse(points.last().bucket))
+    } catch (e: Exception) {
+        null
+    }
+
 /**
  * MemberEventRow is one event under the graph, in the same log language as the
  * Events screen: a flat line — no card — with a severity-coloured rail down the
- * left edge and a faint tint of the same colour, the type as the heading with a
- * mono timestamp, then the message.
+ * left edge and a faint tint of the same colour, the event's human name as the
+ * heading with a mono timestamp, then the message, then the raw type + source
+ * in the mono meta line.
  */
 @Composable
 private fun MemberEventRow(
@@ -773,18 +854,17 @@ private fun MemberEventRow(
         railTag = "member-event-sev-${event.severity}",
         onLongClick = onCopy,
         modifier = modifier,
-    ) { typeColor ->
+    ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            // Machine event type in mono + the severity colour, so the code
-            // token reads apart from the human message on the next line.
+            // The human name leads in full-contrast text (the rail + tint carry
+            // severity); the machine code is demoted to the mono meta line below,
+            // so the title never truncates mid-code.
             Text(
-                text = event.type,
+                text = eventTypeLabel(event.type),
                 style = MaterialTheme.typography.titleSmall,
-                fontFamily = MonoFamily,
-                color = typeColor,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
                 modifier = Modifier.weight(1f),
@@ -802,11 +882,16 @@ private fun MemberEventRow(
             maxLines = 2,
             overflow = TextOverflow.Ellipsis,
         )
-        // The emitting subsystem (poller, autosync…) in muted mono, a third
-        // visual register below the coloured type and the plain message.
-        if (event.source.isNotBlank()) {
+        // The raw event code and the emitting subsystem (poller, autosync…) in
+        // muted mono, a third visual register below the name and the message.
+        val who =
+            listOfNotNull(
+                event.type.ifEmpty { null },
+                event.source.ifEmpty { null },
+            ).joinToString(" · ")
+        if (who.isNotEmpty()) {
             Text(
-                text = event.source,
+                text = who,
                 style = MaterialTheme.typography.bodySmall,
                 fontFamily = MonoFamily,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/pairing/PairingScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/pairing/PairingScreen.kt
@@ -127,10 +127,18 @@ fun PairingScreen(
             )
 
             // Once the string is read, confirm which Front Desk it points at and
-            // let the operator name this device before pairing.
+            // let the operator name this device before pairing. Most pairing
+            // strings carry the host as the name, so the two-line form (name +
+            // address) collapses to just the address instead of repeating it.
             if (state.parsed) {
+                val host = state.fdUrl.substringAfter("://").trimEnd('/')
                 Text(
-                    text = stringResource(R.string.pairing_target, state.fdName, state.fdUrl),
+                    text =
+                        if (state.fdName.isBlank() || state.fdName == host) {
+                            stringResource(R.string.pairing_target_short, state.fdUrl)
+                        } else {
+                            stringResource(R.string.pairing_target, state.fdName, state.fdUrl)
+                        },
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.primary,
                     modifier = Modifier.testTag("pairing-target"),

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreen.kt
@@ -412,11 +412,13 @@ fun SettingsScreen(
                     if (!lockAvailable) {
                         // No biometric or device credential enrolled: the gate can't
                         // engage, so say why the toggle is inert rather than failing
-                        // silently when it's flipped on.
+                        // silently when it's flipped on. Muted, not red: this is
+                        // guidance about a precondition, unlike the monitor/push
+                        // "delivery is blocked" notes where something is broken.
                         Text(
                             text = stringResource(R.string.settings_lock_unavailable),
                             style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.error,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
                             modifier = Modifier.testTag("settings-lock-unavailable"),
                         )
                     }

--- a/android/app/src/main/res/values-cs/strings.xml
+++ b/android/app/src/main/res/values-cs/strings.xml
@@ -10,6 +10,7 @@
     <string name="pairing_paste_label">Párovací řetězec</string>
     <string name="pairing_paste_hint">Vložte sem zkopírovaný párovací řetězec</string>
     <string name="pairing_target">Front Desk: %1$s\n%2$s</string>
+    <string name="pairing_target_short">Front Desk: %1$s</string>
     <string name="pairing_label_label">Název tohoto zařízení</string>
     <string name="pairing_submit">Spárovat</string>
     <string name="pairing_error_bad_string">To nevypadá jako párovací řetězec. Zkopírujte ho znovu z Front Desku → Nastavení → Spárovaná zařízení.</string>
@@ -33,7 +34,18 @@
     <!-- Member detail -->
     <string name="member_detail_back">Zpět</string>
     <string name="member_detail_traffic_title">Provoz · posledních %1$d h</string>
-    <string name="member_detail_traffic_totals">%1$d požadavků · %2$d chyb</string>
+    <plurals name="member_detail_traffic_requests">
+        <item quantity="one">%1$d požadavek</item>
+        <item quantity="few">%1$d požadavky</item>
+        <item quantity="many">%1$d požadavku</item>
+        <item quantity="other">%1$d požadavků</item>
+    </plurals>
+    <plurals name="member_detail_traffic_errors">
+        <item quantity="one">%1$d chyba</item>
+        <item quantity="few">%1$d chyby</item>
+        <item quantity="many">%1$d chyby</item>
+        <item quantity="other">%1$d chyb</item>
+    </plurals>
     <string name="member_detail_traffic_unreachable">Provoz není dostupný. Front Desk možná nemá pro tohoto člena admin token, nebo člen neodpověděl.</string>
     <string name="member_detail_traffic_empty">V tomto okně žádné požadavky.</string>
     <string name="member_detail_events_title">Nedávné události</string>
@@ -127,6 +139,10 @@
     <string name="alerts_event_member_added">Člen přidán</string>
     <string name="alerts_event_member_removed">Člen odebrán</string>
     <string name="alerts_event_member_state_changed">Člen odstaven nebo aktivován</string>
+    <string name="event_device_paired">Zařízení spárováno</string>
+    <string name="event_device_revoked">Spárování zařízení zrušeno</string>
+    <string name="event_settings_changed">Nastavení změněno</string>
+    <string name="event_config_regenerated">Konfigurace směrování znovu vygenerována</string>
 
     <!-- App lock -->
     <string name="lock_title">Bellhop je uzamčen</string>

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -10,6 +10,7 @@
     <string name="pairing_paste_label">Kopplungszeichenfolge</string>
     <string name="pairing_paste_hint">Kopierte Kopplungszeichenfolge hier einfügen</string>
     <string name="pairing_target">Front Desk: %1$s\n%2$s</string>
+    <string name="pairing_target_short">Front Desk: %1$s</string>
     <string name="pairing_label_label">Name dieses Geräts</string>
     <string name="pairing_submit">Koppeln</string>
     <string name="pairing_error_bad_string">Das sieht nicht nach einer Kopplungszeichenfolge aus. Kopiere sie in Front Desk → Einstellungen → Gekoppelte Geräte erneut.</string>
@@ -33,7 +34,14 @@
     <!-- Member detail -->
     <string name="member_detail_back">Zurück</string>
     <string name="member_detail_traffic_title">Traffic · letzte %1$d h</string>
-    <string name="member_detail_traffic_totals">%1$d Anfragen · %2$d Fehler</string>
+    <plurals name="member_detail_traffic_requests">
+        <item quantity="one">%1$d Anfrage</item>
+        <item quantity="other">%1$d Anfragen</item>
+    </plurals>
+    <plurals name="member_detail_traffic_errors">
+        <item quantity="one">%1$d Fehler</item>
+        <item quantity="other">%1$d Fehler</item>
+    </plurals>
     <string name="member_detail_traffic_unreachable">Traffic ist nicht verfügbar. Front Desk hat für dieses Mitglied möglicherweise kein Admin-Token, oder das Mitglied hat nicht geantwortet.</string>
     <string name="member_detail_traffic_empty">Keine Anfragen in diesem Zeitraum.</string>
     <string name="member_detail_events_title">Letzte Ereignisse</string>
@@ -125,6 +133,10 @@
     <string name="alerts_event_member_added">Mitglied hinzugefügt</string>
     <string name="alerts_event_member_removed">Mitglied entfernt</string>
     <string name="alerts_event_member_state_changed">Mitglied stillgelegt oder aktiviert</string>
+    <string name="event_device_paired">Gerät gekoppelt</string>
+    <string name="event_device_revoked">Gerätekopplung widerrufen</string>
+    <string name="event_settings_changed">Einstellungen geändert</string>
+    <string name="event_config_regenerated">Routing-Konfiguration neu generiert</string>
 
     <!-- App lock -->
     <string name="lock_title">Bellhop ist gesperrt</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -10,6 +10,7 @@
     <string name="pairing_paste_label">Cadena de vinculación</string>
     <string name="pairing_paste_hint">Pega aquí la cadena de vinculación copiada</string>
     <string name="pairing_target">Front Desk: %1$s\n%2$s</string>
+    <string name="pairing_target_short">Front Desk: %1$s</string>
     <string name="pairing_label_label">Nombre de este dispositivo</string>
     <string name="pairing_submit">Vincular</string>
     <string name="pairing_error_bad_string">Eso no parece una cadena de vinculación. Cópiala de nuevo desde Front Desk → Configuración → Dispositivos vinculados.</string>
@@ -33,7 +34,14 @@
     <!-- Member detail -->
     <string name="member_detail_back">Atrás</string>
     <string name="member_detail_traffic_title">Tráfico · últimos %1$d h</string>
-    <string name="member_detail_traffic_totals">%1$d solicitudes · %2$d errores</string>
+    <plurals name="member_detail_traffic_requests">
+        <item quantity="one">%1$d solicitud</item>
+        <item quantity="other">%1$d solicitudes</item>
+    </plurals>
+    <plurals name="member_detail_traffic_errors">
+        <item quantity="one">%1$d error</item>
+        <item quantity="other">%1$d errores</item>
+    </plurals>
     <string name="member_detail_traffic_unreachable">El tráfico no está disponible. Puede que Front Desk no tenga un token de administrador para este miembro, o que el miembro no respondiera.</string>
     <string name="member_detail_traffic_empty">Sin solicitudes en este intervalo.</string>
     <string name="member_detail_events_title">Eventos recientes</string>
@@ -125,6 +133,10 @@
     <string name="alerts_event_member_added">Miembro añadido</string>
     <string name="alerts_event_member_removed">Miembro eliminado</string>
     <string name="alerts_event_member_state_changed">Miembro drenado o activado</string>
+    <string name="event_device_paired">Dispositivo emparejado</string>
+    <string name="event_device_revoked">Dispositivo revocado</string>
+    <string name="event_settings_changed">Ajustes modificados</string>
+    <string name="event_config_regenerated">Configuración de enrutamiento regenerada</string>
 
     <!-- App lock -->
     <string name="lock_title">Bellhop está bloqueado</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -10,6 +10,7 @@
     <string name="pairing_paste_label">Chaîne d\'association</string>
     <string name="pairing_paste_hint">Collez ici la chaîne d\'association copiée</string>
     <string name="pairing_target">Front Desk : %1$s\n%2$s</string>
+    <string name="pairing_target_short">Front Desk : %1$s</string>
     <string name="pairing_label_label">Nom de cet appareil</string>
     <string name="pairing_submit">Associer</string>
     <string name="pairing_error_bad_string">Cela ne ressemble pas à une chaîne d\'association. Copiez-la à nouveau depuis Front Desk → Paramètres → Appareils associés.</string>
@@ -33,7 +34,14 @@
     <!-- Member detail -->
     <string name="member_detail_back">Retour</string>
     <string name="member_detail_traffic_title">Trafic · %1$d dernières h</string>
-    <string name="member_detail_traffic_totals">%1$d requêtes · %2$d erreurs</string>
+    <plurals name="member_detail_traffic_requests">
+        <item quantity="one">%1$d requête</item>
+        <item quantity="other">%1$d requêtes</item>
+    </plurals>
+    <plurals name="member_detail_traffic_errors">
+        <item quantity="one">%1$d erreur</item>
+        <item quantity="other">%1$d erreurs</item>
+    </plurals>
     <string name="member_detail_traffic_unreachable">Le trafic n\'est pas disponible. Front Desk ne possède peut-être aucun jeton admin pour ce membre, ou le membre n\'a pas répondu.</string>
     <string name="member_detail_traffic_empty">Aucune requête sur cette période.</string>
     <string name="member_detail_events_title">Événements récents</string>
@@ -125,6 +133,10 @@
     <string name="alerts_event_member_added">Membre ajouté</string>
     <string name="alerts_event_member_removed">Membre supprimé</string>
     <string name="alerts_event_member_state_changed">Membre drainé ou activé</string>
+    <string name="event_device_paired">Appareil appairé</string>
+    <string name="event_device_revoked">Appareil révoqué</string>
+    <string name="event_settings_changed">Paramètres modifiés</string>
+    <string name="event_config_regenerated">Configuration de routage régénérée</string>
 
     <!-- App lock -->
     <string name="lock_title">Bellhop est verrouillé</string>

--- a/android/app/src/main/res/values-ja/strings.xml
+++ b/android/app/src/main/res/values-ja/strings.xml
@@ -10,6 +10,7 @@
     <string name="pairing_paste_label">ペアリング文字列</string>
     <string name="pairing_paste_hint">コピーしたペアリング文字列をここに貼り付け</string>
     <string name="pairing_target">Front Desk: %1$s\n%2$s</string>
+    <string name="pairing_target_short">Front Desk: %1$s</string>
     <string name="pairing_label_label">このデバイスの名前</string>
     <string name="pairing_submit">ペア設定</string>
     <string name="pairing_error_bad_string">ペアリング文字列ではないようです。Front Desk → 設定 → ペア設定済みデバイス からもう一度コピーしてください。</string>
@@ -33,7 +34,12 @@
     <!-- Member detail -->
     <string name="member_detail_back">戻る</string>
     <string name="member_detail_traffic_title">トラフィック · 直近 %1$d 時間</string>
-    <string name="member_detail_traffic_totals">%1$d リクエスト · %2$d エラー</string>
+    <plurals name="member_detail_traffic_requests">
+        <item quantity="other">%1$d リクエスト</item>
+    </plurals>
+    <plurals name="member_detail_traffic_errors">
+        <item quantity="other">%1$d エラー</item>
+    </plurals>
     <string name="member_detail_traffic_unreachable">トラフィックを利用できません。Front Desk がこのメンバーの管理者トークンを持っていないか、メンバーが応答しなかった可能性があります。</string>
     <string name="member_detail_traffic_empty">この期間にリクエストはありません。</string>
     <string name="member_detail_events_title">最近のイベント</string>
@@ -124,6 +130,10 @@
     <string name="alerts_event_member_added">メンバーを追加</string>
     <string name="alerts_event_member_removed">メンバーを削除</string>
     <string name="alerts_event_member_state_changed">メンバーをドレインまたは有効化</string>
+    <string name="event_device_paired">デバイスをペアリング</string>
+    <string name="event_device_revoked">デバイスのペアリングを取り消し</string>
+    <string name="event_settings_changed">設定を変更</string>
+    <string name="event_config_regenerated">ルーティング設定を再生成</string>
 
     <!-- App lock -->
     <string name="lock_title">Bellhop はロックされています</string>

--- a/android/app/src/main/res/values-nl/strings.xml
+++ b/android/app/src/main/res/values-nl/strings.xml
@@ -10,6 +10,7 @@
     <string name="pairing_paste_label">Koppelreeks</string>
     <string name="pairing_paste_hint">Plak hier de gekopieerde koppelreeks</string>
     <string name="pairing_target">Front Desk: %1$s\n%2$s</string>
+    <string name="pairing_target_short">Front Desk: %1$s</string>
     <string name="pairing_label_label">Naam van dit apparaat</string>
     <string name="pairing_submit">Koppelen</string>
     <string name="pairing_error_bad_string">Dat lijkt geen koppelreeks. Kopieer die opnieuw vanuit Front Desk → Instellingen → Gekoppelde apparaten.</string>
@@ -33,7 +34,14 @@
     <!-- Member detail -->
     <string name="member_detail_back">Terug</string>
     <string name="member_detail_traffic_title">Verkeer · laatste %1$d u</string>
-    <string name="member_detail_traffic_totals">%1$d verzoeken · %2$d fouten</string>
+    <plurals name="member_detail_traffic_requests">
+        <item quantity="one">%1$d verzoek</item>
+        <item quantity="other">%1$d verzoeken</item>
+    </plurals>
+    <plurals name="member_detail_traffic_errors">
+        <item quantity="one">%1$d fout</item>
+        <item quantity="other">%1$d fouten</item>
+    </plurals>
     <string name="member_detail_traffic_unreachable">Verkeer is niet beschikbaar. Front Desk heeft mogelijk geen admin-token voor dit lid, of het lid antwoordde niet.</string>
     <string name="member_detail_traffic_empty">Geen verzoeken in dit venster.</string>
     <string name="member_detail_events_title">Recente gebeurtenissen</string>
@@ -125,6 +133,10 @@
     <string name="alerts_event_member_added">Lid toegevoegd</string>
     <string name="alerts_event_member_removed">Lid verwijderd</string>
     <string name="alerts_event_member_state_changed">Lid gedraineerd of geactiveerd</string>
+    <string name="event_device_paired">Apparaat gekoppeld</string>
+    <string name="event_device_revoked">Apparaatkoppeling ingetrokken</string>
+    <string name="event_settings_changed">Instellingen gewijzigd</string>
+    <string name="event_config_regenerated">Routeringsconfiguratie opnieuw gegenereerd</string>
 
     <!-- App lock -->
     <string name="lock_title">Bellhop is vergrendeld</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -10,6 +10,7 @@
     <string name="pairing_paste_label">Ciąg parowania</string>
     <string name="pairing_paste_hint">Wklej tutaj skopiowany ciąg parowania</string>
     <string name="pairing_target">Front Desk: %1$s\n%2$s</string>
+    <string name="pairing_target_short">Front Desk: %1$s</string>
     <string name="pairing_label_label">Nazwa tego urządzenia</string>
     <string name="pairing_submit">Sparuj</string>
     <string name="pairing_error_bad_string">To nie wygląda na ciąg parowania. Skopiuj go ponownie z Front Desk → Ustawienia → Sparowane urządzenia.</string>
@@ -33,7 +34,18 @@
     <!-- Member detail -->
     <string name="member_detail_back">Wstecz</string>
     <string name="member_detail_traffic_title">Ruch · ostatnie %1$d godz.</string>
-    <string name="member_detail_traffic_totals">%1$d żądań · %2$d błędów</string>
+    <plurals name="member_detail_traffic_requests">
+        <item quantity="one">%1$d żądanie</item>
+        <item quantity="few">%1$d żądania</item>
+        <item quantity="many">%1$d żądań</item>
+        <item quantity="other">%1$d żądania</item>
+    </plurals>
+    <plurals name="member_detail_traffic_errors">
+        <item quantity="one">%1$d błąd</item>
+        <item quantity="few">%1$d błędy</item>
+        <item quantity="many">%1$d błędów</item>
+        <item quantity="other">%1$d błędu</item>
+    </plurals>
     <string name="member_detail_traffic_unreachable">Ruch jest niedostępny. Front Desk może nie mieć tokena administratora dla tego węzła lub węzeł nie odpowiedział.</string>
     <string name="member_detail_traffic_empty">Brak żądań w tym oknie.</string>
     <string name="member_detail_events_title">Ostatnie zdarzenia</string>
@@ -127,6 +139,10 @@
     <string name="alerts_event_member_added">Węzeł dodany</string>
     <string name="alerts_event_member_removed">Węzeł usunięty</string>
     <string name="alerts_event_member_state_changed">Węzeł wygaszony lub aktywowany</string>
+    <string name="event_device_paired">Urządzenie sparowane</string>
+    <string name="event_device_revoked">Sparowanie urządzenia cofnięte</string>
+    <string name="event_settings_changed">Ustawienia zmienione</string>
+    <string name="event_config_regenerated">Konfiguracja routingu wygenerowana ponownie</string>
 
     <!-- App lock -->
     <string name="lock_title">Bellhop jest zablokowany</string>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -10,6 +10,7 @@
     <string name="pairing_paste_label">Строка связывания</string>
     <string name="pairing_paste_hint">Вставьте сюда скопированную строку связывания</string>
     <string name="pairing_target">Front Desk: %1$s\n%2$s</string>
+    <string name="pairing_target_short">Front Desk: %1$s</string>
     <string name="pairing_label_label">Имя этого устройства</string>
     <string name="pairing_submit">Связать</string>
     <string name="pairing_error_bad_string">Это не похоже на строку связывания. Скопируйте её заново из Front Desk → Настройки → Связанные устройства.</string>
@@ -33,7 +34,18 @@
     <!-- Member detail -->
     <string name="member_detail_back">Назад</string>
     <string name="member_detail_traffic_title">Трафик · последние %1$d ч</string>
-    <string name="member_detail_traffic_totals">%1$d запросов · %2$d ошибок</string>
+    <plurals name="member_detail_traffic_requests">
+        <item quantity="one">%1$d запрос</item>
+        <item quantity="few">%1$d запроса</item>
+        <item quantity="many">%1$d запросов</item>
+        <item quantity="other">%1$d запроса</item>
+    </plurals>
+    <plurals name="member_detail_traffic_errors">
+        <item quantity="one">%1$d ошибка</item>
+        <item quantity="few">%1$d ошибки</item>
+        <item quantity="many">%1$d ошибок</item>
+        <item quantity="other">%1$d ошибки</item>
+    </plurals>
     <string name="member_detail_traffic_unreachable">Трафик недоступен. Возможно, у Front Desk нет токена администратора для этого узла, или узел не ответил.</string>
     <string name="member_detail_traffic_empty">Нет запросов в этом окне.</string>
     <string name="member_detail_events_title">Недавние события</string>
@@ -127,6 +139,10 @@
     <string name="alerts_event_member_added">Узел добавлен</string>
     <string name="alerts_event_member_removed">Узел удалён</string>
     <string name="alerts_event_member_state_changed">Узел выведен или активирован</string>
+    <string name="event_device_paired">Устройство сопряжено</string>
+    <string name="event_device_revoked">Сопряжение устройства отозвано</string>
+    <string name="event_settings_changed">Настройки изменены</string>
+    <string name="event_config_regenerated">Конфигурация маршрутизации создана заново</string>
 
     <!-- App lock -->
     <string name="lock_title">Bellhop заблокирован</string>

--- a/android/app/src/main/res/values-sk/strings.xml
+++ b/android/app/src/main/res/values-sk/strings.xml
@@ -10,6 +10,7 @@
     <string name="pairing_paste_label">Párovací reťazec</string>
     <string name="pairing_paste_hint">Sem vložte skopírovaný párovací reťazec</string>
     <string name="pairing_target">Front Desk: %1$s\n%2$s</string>
+    <string name="pairing_target_short">Front Desk: %1$s</string>
     <string name="pairing_label_label">Názov tohto zariadenia</string>
     <string name="pairing_submit">Spárovať</string>
     <string name="pairing_error_bad_string">Toto nevyzerá ako párovací reťazec. Skopírujte ho znova z Front Desku → Nastavenia → Spárované zariadenia.</string>
@@ -33,7 +34,18 @@
     <!-- Member detail -->
     <string name="member_detail_back">Späť</string>
     <string name="member_detail_traffic_title">Prevádzka · posledných %1$d h</string>
-    <string name="member_detail_traffic_totals">%1$d požiadaviek · %2$d chýb</string>
+    <plurals name="member_detail_traffic_requests">
+        <item quantity="one">%1$d požiadavka</item>
+        <item quantity="few">%1$d požiadavky</item>
+        <item quantity="many">%1$d požiadavky</item>
+        <item quantity="other">%1$d požiadaviek</item>
+    </plurals>
+    <plurals name="member_detail_traffic_errors">
+        <item quantity="one">%1$d chyba</item>
+        <item quantity="few">%1$d chyby</item>
+        <item quantity="many">%1$d chyby</item>
+        <item quantity="other">%1$d chýb</item>
+    </plurals>
     <string name="member_detail_traffic_unreachable">Prevádzka nie je dostupná. Front Desk možno nemá pre tohto člena admin token, alebo člen neodpovedal.</string>
     <string name="member_detail_traffic_empty">V tomto okne žiadne požiadavky.</string>
     <string name="member_detail_events_title">Nedávne udalosti</string>
@@ -127,6 +139,10 @@
     <string name="alerts_event_member_added">Člen pridaný</string>
     <string name="alerts_event_member_removed">Člen odstránený</string>
     <string name="alerts_event_member_state_changed">Člen odstavený alebo aktivovaný</string>
+    <string name="event_device_paired">Zariadenie spárované</string>
+    <string name="event_device_revoked">Spárovanie zariadenia zrušené</string>
+    <string name="event_settings_changed">Nastavenia zmenené</string>
+    <string name="event_config_regenerated">Konfigurácia smerovania znovu vygenerovaná</string>
 
     <!-- App lock -->
     <string name="lock_title">Bellhop je uzamknutý</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -10,6 +10,7 @@
     <string name="pairing_paste_label">配对字符串</string>
     <string name="pairing_paste_hint">在此粘贴复制的配对字符串</string>
     <string name="pairing_target">Front Desk：%1$s\n%2$s</string>
+    <string name="pairing_target_short">Front Desk：%1$s</string>
     <string name="pairing_label_label">此设备的名称</string>
     <string name="pairing_submit">配对</string>
     <string name="pairing_error_bad_string">这看起来不像配对字符串。请从 Front Desk → 设置 → 已配对设备 重新复制。</string>
@@ -33,7 +34,12 @@
     <!-- Member detail -->
     <string name="member_detail_back">返回</string>
     <string name="member_detail_traffic_title">流量 · 最近 %1$d 小时</string>
-    <string name="member_detail_traffic_totals">%1$d 个请求 · %2$d 个错误</string>
+    <plurals name="member_detail_traffic_requests">
+        <item quantity="other">%1$d 个请求</item>
+    </plurals>
+    <plurals name="member_detail_traffic_errors">
+        <item quantity="other">%1$d 个错误</item>
+    </plurals>
     <string name="member_detail_traffic_unreachable">流量不可用。Front Desk 可能没有此成员的管理员令牌，或该成员未响应。</string>
     <string name="member_detail_traffic_empty">此时段内没有请求。</string>
     <string name="member_detail_events_title">近期事件</string>
@@ -124,6 +130,10 @@
     <string name="alerts_event_member_added">成员已添加</string>
     <string name="alerts_event_member_removed">成员已移除</string>
     <string name="alerts_event_member_state_changed">成员已排空或激活</string>
+    <string name="event_device_paired">设备已配对</string>
+    <string name="event_device_revoked">设备配对已撤销</string>
+    <string name="event_settings_changed">设置已更改</string>
+    <string name="event_config_regenerated">路由配置已重新生成</string>
 
     <!-- App lock -->
     <string name="lock_title">Bellhop 已锁定</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -11,6 +11,8 @@
     <string name="pairing_paste_label">Pairing string</string>
     <string name="pairing_paste_hint">Paste the copied pairing string here</string>
     <string name="pairing_target">Front Desk: %1$s\n%2$s</string>
+    <!-- Used instead of pairing_target when the Front Desk name is just its host, so the address isn't shown twice. -->
+    <string name="pairing_target_short">Front Desk: %1$s</string>
     <string name="pairing_label_label">This device\'s name</string>
     <string name="pairing_submit">Pair</string>
     <string name="pairing_error_bad_string">That doesn\'t look like a pairing string. Copy it again from Front Desk → Settings → Paired devices.</string>
@@ -34,7 +36,14 @@
     <!-- Member detail -->
     <string name="member_detail_back">Back</string>
     <string name="member_detail_traffic_title">Traffic · last %1$d h</string>
-    <string name="member_detail_traffic_totals">%1$d requests · %2$d errors</string>
+    <plurals name="member_detail_traffic_requests">
+        <item quantity="one">%1$d request</item>
+        <item quantity="other">%1$d requests</item>
+    </plurals>
+    <plurals name="member_detail_traffic_errors">
+        <item quantity="one">%1$d error</item>
+        <item quantity="other">%1$d errors</item>
+    </plurals>
     <string name="member_detail_traffic_unreachable">Traffic isn\'t available. Front Desk may hold no admin token for this member, or the member didn\'t answer.</string>
     <string name="member_detail_traffic_empty">No requests in this window.</string>
     <string name="member_detail_events_title">Recent events</string>
@@ -140,6 +149,11 @@
     <string name="alerts_event_member_added">Member added</string>
     <string name="alerts_event_member_removed">Member removed</string>
     <string name="alerts_event_member_state_changed">Member drained or activated</string>
+    <!-- Event-log-only types (not in the alert catalog), used by the shared event-title map. -->
+    <string name="event_device_paired">Device paired</string>
+    <string name="event_device_revoked">Device revoked</string>
+    <string name="event_settings_changed">Settings changed</string>
+    <string name="event_config_regenerated">Routing config regenerated</string>
 
     <!-- App lock -->
     <string name="lock_title">Bellhop is locked</string>

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreenTest.kt
@@ -75,6 +75,35 @@ class MemberDetailScreenTest {
         composeTestRule.onNodeWithTag("member-detail-meta").assertIsDisplayed()
         composeTestRule.onNodeWithTag("member-traffic-totals").assertIsDisplayed()
         composeTestRule.onNodeWithTag("member-traffic-chart").assertIsDisplayed()
+        // Unparseable fixture buckets: the time axis stays off rather than
+        // rendering raw strings.
+        composeTestRule.onNodeWithTag("member-traffic-axis").assertDoesNotExist()
+    }
+
+    @Test
+    fun trafficAxisShownWhenBucketsParse() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                MemberDetailScreen(
+                    member = member,
+                    isPrimary = false,
+                    onBack = {},
+                    ui =
+                        MemberDetailUiState(
+                            loading = false,
+                            traffic =
+                                reachableTraffic.copy(
+                                    points =
+                                        listOf(
+                                            TrafficPoint(bucket = "2026-07-16T12:00:00Z", requests = 5, errors = 0),
+                                            TrafficPoint(bucket = "2026-07-16T12:55:00Z", requests = 7, errors = 2),
+                                        ),
+                                ),
+                        ),
+                )
+            }
+        }
+        composeTestRule.onNodeWithTag("member-traffic-axis").assertIsDisplayed()
     }
 
     @Test

--- a/internal/frontdesk/autosync.go
+++ b/internal/frontdesk/autosync.go
@@ -209,9 +209,13 @@ func (s *Server) convergeFleet(ctx context.Context, primary *Member, primaryToke
 		}
 	}
 	if applied > 0 {
+		noun := "members"
+		if applied == 1 {
+			noun = "member"
+		}
 		s.emit(ctx, Event{
 			Type: "config.auto_synced", Severity: "info", Source: "frontdesk",
-			Message: fmt.Sprintf("Auto-synced %d member(s): %s", applied, reason),
+			Message: fmt.Sprintf("Auto-synced %d %s: %s", applied, noun, reason),
 		})
 	}
 }


### PR DESCRIPTION
Born from a design walkthrough of the app on a live fleet: the theme and copy hold up, but the interaction layer had a handful of tells. This PR fixes what the walkthrough surfaced, verified on the emulator against a live Front Desk.

## Event logs (Events screen + member detail)

- Rows now lead with the event's human name ("Member went down") instead of the raw dotted code; the code moves to the mono meta line (`health.down · frontdesk-poller · member`) so it stays visible and copyable but never truncates mid-code as a title.
- One shared label map (`ui/common/EventLabels.kt`) feeds the alert catalog and both logs, with new labels for the log-only types: device paired/revoked, settings changed, config regenerated.
- Titles render in full-contrast text; severity rides the rail and tint. This removes the dim-orange-on-tinted-row titles that were borderline unreadable on warning rows.

## Tap targets

- New `ui/common/TightTouchTarget.kt` caps a clickable's touch target at its drawn bounds. The member card's URL link was expanding to the 48dp minimum and swallowing taps aimed at the member name and card body (two of the first three taps in the walkthrough landed wrong); the detail screen's ADDRESS ledger row did the same to its neighbors.
- Implementation note: material3's `LocalMinimumInteractiveComponentSize` has no effect on plain `Modifier.clickable`; the expansion comes from `ViewConfiguration.minimumTouchTargetSize`, so the helper provides a delegating ViewConfiguration with a zero minimum.

## Traffic card (member detail)

- Totals are proper plurals ("1 error", was "1 errors") in all 11 languages, and each count carries a legend dot in the colour its bars are drawn in, so the red error overlay is explained where the numbers are.
- Wall-clock start/end labels under the chart anchor the bars in time. Omitted when bucket timestamps do not parse (covered by a new test).

## Smaller fixes

- Dashboard recent-event pill restyled as a quiet log line (severity dot + faint tint, muted age) instead of a saturated badge-coloured surface that read as a button and truncated its own sentence.
- App-lock "set up a fingerprint first" hint is muted guidance now, not error red (nothing is broken; the monitor/push blocked notes stay red because there something is).
- Pairing confirmation no longer prints the host twice when the Front Desk name is just its host (new `pairing_target_short`).
- Front Desk's auto-sync event message pluralizes "member" properly (`internal/frontdesk/autosync.go`; changed lines are covered).

All new strings hand-translated in the 10 locales with per-language plural quantities (one/few/many/other for cs/sk/pl/ru; other-only for ja/zh). `make android-test` and `make android-lint` (MissingTranslation as error) green; frontdesk Go suite and golangci-lint clean.

Deliberately not changed, as documented decisions from earlier PRs: the dashboard build footer (FD parity, #441), always-visible zero-count severity badges on the Settings Alerts pill (#443), and no confirm on the auto-sync toggle (already behind the biometric operator gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)