### PR TITLE
docs(readme): give Bellhop its own section header with icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Run several instances behind one client endpoint with no client-side change: a *
 
 Full deployment in the [High Availability wiki](https://github.com/hugalafutro/model-hotel/wiki/High-Availability).
 
+### [<img src="docs/icons/bellhop.svg" width="20" height="20" style="vertical-align:middle;margin-right:6px;" alt=""> Bellhop Companion App](#-bellhop-companion-app)
+
 **Bellhop**, the native Android companion app for Front Desk, turns a paired phone into a pocket view of the fleet: live member health, request traffic, the event log, and, for operator devices, one-tap drain, activate, and config-sync behind a biometric prompt. It talks only to Front Desk, holds no provider credentials, and authenticates with a device token you can revoke from either side.
 
 <p align="center">
@@ -460,6 +462,7 @@ and how to enable the rest. See the [Configuration wiki](https://github.com/huga
 - [Request Logging](https://github.com/hugalafutro/model-hotel/wiki/Request-Logging): Log fields, overhead breakdown, retention
 - [Backup & Restore](#-backup--restore): Creating backups, restoring, critical requirements
 - [High Availability](https://github.com/hugalafutro/model-hotel/wiki/High-Availability): Front Desk control plane + Traefik, drop-in HA across multiple instances
+- [Bellhop](https://github.com/hugalafutro/model-hotel/wiki/Bellhop): Android companion app, pairing, roles, monitoring and operator controls
 - [Development](https://github.com/hugalafutro/model-hotel/wiki/Development): Local setup, build commands, contributing
 
 ### [<img src="docs/icons/backup.svg" width="20" height="20" style="vertical-align:middle;margin-right:6px;" alt=""> Backup & Restore](#-backup--restore)

--- a/docs/icons/bellhop.svg
+++ b/docs/icons/bellhop.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#e5e7eb" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="14" height="20" x="5" y="2" rx="2" ry="2"/><path d="M12 18h.01"/></svg>


### PR DESCRIPTION
Follow-up to #462. The Bellhop blurb was nested under High Availability without a section header. This promotes it to a peer feature section using the exact same icon-linked header format as the other sections, so it renders consistently.

- Add the `### [<img ...> Bellhop Companion App](#-bellhop-companion-app)` header.
- Add `docs/icons/bellhop.svg`, a Lucide-style smartphone glyph matching the existing icon set (viewBox 24, stroke #e5e7eb, width 2).
- Add a Bellhop entry to the documentation links list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)