### PR TITLE
docs(bellhop): fix broken Front Desk wiki link

### DIFF
--- a/wiki/Bellhop.md
+++ b/wiki/Bellhop.md
@@ -1,6 +1,6 @@
 # Bellhop (Android Companion App)
 
-Bellhop is the Android companion app for [[High Availability|Front Desk]]. Pair a phone once and it becomes a pocket view of your fleet: live member health, request traffic, the fleet event log, and, for operator devices, the controls to drain a member, activate it again, or push a config sync, all from a lock screen notification tap. Bellhop talks only to Front Desk, never to Model Hotel members directly, so it holds no provider credentials and no member admin tokens. It authenticates with its own device token that either side can revoke at any time, and like the rest of Model Hotel it moves only routing and metering metadata, never prompt or response content.
+Bellhop is the Android companion app for [[Front Desk|High Availability]]. Pair a phone once and it becomes a pocket view of your fleet: live member health, request traffic, the fleet event log, and, for operator devices, the controls to drain a member, activate it again, or push a config sync, all from a lock screen notification tap. Bellhop talks only to Front Desk, never to Model Hotel members directly, so it holds no provider credentials and no member admin tokens. It authenticates with its own device token that either side can revoke at any time, and like the rest of Model Hotel it moves only routing and metering metadata, never prompt or response content.
 
 ## The app at a glance
 


### PR DESCRIPTION
The Bellhop wiki intro linked to Front Desk with `[[High Availability|Front Desk]]`. GitHub wiki treats the text after the pipe as the target page, so this pointed at a nonexistent "Front Desk" page and rendered red (clicking it offered to create the page). Swapping the pipe order links to the existing High Availability page with "Front Desk" as the display text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)