### PR TITLE
fix(configsync): refuse provider-wiping imports and harden SSRF/SQL rails

### DIFF
--- a/internal/api/configsync.go
+++ b/internal/api/configsync.go
@@ -73,6 +73,12 @@ const (
 // "superseded" response instead of a 500.
 var errStaleSourceGen = errors.New("configsync: import source generation is older than last applied")
 
+// errWouldWipeProviders is returned by apply when the envelope carries zero
+// providers but this member currently has providers: applying the declarative
+// replace would delete every provider (and, via the users replace, is the
+// reported backdoor-wipe vector). Import maps it to a 400 refusal.
+var errWouldWipeProviders = errors.New("configsync: refusing to wipe every provider off a populated member")
+
 // ConfigSyncHandler serves the member-side config export/import endpoints. It is
 // mounted inside the admin-authenticated /api group, so every call already
 // requires the admin token (or a session when TOTP is on): a caller able to

--- a/internal/api/configsync_apply.go
+++ b/internal/api/configsync_apply.go
@@ -65,6 +65,27 @@ func (h *ConfigSyncHandler) apply(ctx context.Context, env ConfigEnvelope, sourc
 		return errStaleSourceGen
 	}
 
+	// Destructive-wipe rail. The declarative delete below removes every provider
+	// absent from the envelope, so an envelope with zero providers would delete
+	// the member's entire provider set (cascading to discovered models) and,
+	// paired with the users replace further down, is the reported backdoor-wipe
+	// vector. buildEnvelope always ships the full config, so a functioning primary
+	// never legitimately pushes zero providers onto a member that has some.
+	// Refuse here, inside the transaction and before any delete, so the check and
+	// the delete it guards are atomic and no throwaway setting or virtual key can
+	// dress the envelope past it. An empty-provider envelope onto a member that
+	// also has no providers is a harmless no-op and is allowed (fleet bootstrap /
+	// keys-only sync onto an empty member).
+	if len(env.Config.Providers) == 0 {
+		var existing int
+		if err := tx.QueryRow(ctx, `SELECT count(*) FROM providers`).Scan(&existing); err != nil {
+			return err
+		}
+		if existing > 0 {
+			return errWouldWipeProviders
+		}
+	}
+
 	if err := upsertProviders(ctx, tx, env.Config.Providers); err != nil {
 		return err
 	}

--- a/internal/api/configsync_import.go
+++ b/internal/api/configsync_import.go
@@ -33,13 +33,15 @@ func (h *ConfigSyncHandler) Import(w http.ResponseWriter, r *http.Request) {
 	}
 	if len(env.Config.Providers) == 0 && len(env.Config.VirtualKeys) == 0 &&
 		len(env.Config.Settings) == 0 {
-		// A config with no providers, virtual keys, or settings is almost always a
-		// mistake, and applying it would delete everything on the target. Refuse
-		// rather than wipe. Note we deliberately do NOT let a non-empty
-		// failover_groups rescue such an envelope from this guard: groups reference
-		// models which reference providers, so zero providers means the groups are
-		// unresolvable, yet apply would still run the declarative provider/VK
-		// deletes against empty lists and wipe the member clean.
+		// Structural guard: an envelope with no providers, no virtual keys, and no
+		// syncable settings has nothing meaningful to sync (a bare users or
+		// failover-groups list cannot stand on its own, since those reference a
+		// data plane that isn't here). Applying it would only run the declarative
+		// deletes and wipe the member, so refuse rather than write. This is the
+		// "obvious mistake" rail; the destructive-wipe rail that can't be dressed
+		// around lives in apply() (errWouldWipeProviders), which refuses any
+		// envelope whose empty provider list would delete providers this member
+		// actually has, whatever settings/keys/users decorate it.
 		http.Error(w, "refusing to import an empty config", http.StatusBadRequest)
 		return
 	}
@@ -79,6 +81,13 @@ func (h *ConfigSyncHandler) Import(w http.ResponseWriter, r *http.Request) {
 		// so Front Desk does not surface a failure.
 		debuglog.Debug("configsync: refused stale import", "source_gen", sourceGenLabel(sourceGen))
 		writeJSON(w, importResponse{SchemaVersionOK: true, MasterKeyOK: true, Applied: false, Stale: true, Diff: diff})
+		return
+	case errors.Is(err, errWouldWipeProviders):
+		// The envelope carries no providers but this member has some: applying it
+		// would delete every provider (the reported backdoor-wipe vector). Refuse
+		// with a 400 so the caller sees a deliberate rejection, not a server error.
+		debuglog.Warn("configsync: refused provider-wiping import")
+		http.Error(w, "refusing to import a config that would delete every provider on this member", http.StatusBadRequest)
 		return
 	case err != nil:
 		debuglog.Error("configsync: apply import", "error", err)

--- a/internal/api/configsync_test.go
+++ b/internal/api/configsync_test.go
@@ -580,6 +580,79 @@ func TestConfigSync_RefusesUsersOnlyEnvelope(t *testing.T) {
 	}
 }
 
+// TestConfigSync_RefusesProviderWipeBackdoorInjection reproduces the reported
+// critical bypass (CWE-284) AND the one-line variant of it. The declarative
+// replace in apply() deletes every provider absent from the envelope, so an
+// envelope with zero providers wipes the provider set and (via the users
+// declarative replace) injects an attacker-controlled backdoor admin. The
+// original three-field empty-config guard was dodged with one throwaway
+// setting; a providers+virtual_keys guard is dodged just as easily with one
+// throwaway virtual key. The provider-only guard refuses BOTH shapes: any
+// import with no providers is rejected regardless of what settings, keys, or
+// users decorate it, so every existing provider and account survives.
+func TestConfigSync_RefusesProviderWipeBackdoorInjection(t *testing.T) {
+	backdoor := ExportUser{
+		Username:     "backdoor_admin",
+		PasswordHash: "$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$c29tZWhhc2g",
+		Role:         "admin",
+		Grants:       []string{},
+		Enabled:      true,
+	}
+	cases := []struct {
+		name string
+		mut  func(*ConfigEnvelope)
+	}{
+		{
+			// The exact PoC: one trivial setting dresses up the empty envelope.
+			name: "setting-dressed",
+			mut: func(e *ConfigEnvelope) {
+				e.Config.Settings = map[string]string{"log_retention": "30"}
+				e.Config.Users = []ExportUser{backdoor}
+			},
+		},
+		{
+			// The one-line variant: a single junk virtual key dodges any guard
+			// that also inspects the virtual-key count, yet providers==0 still
+			// wipes every provider and still injects the backdoor.
+			name: "virtual-key-dressed",
+			mut: func(e *ConfigEnvelope) {
+				e.Config.VirtualKeys = []ExportVK{{Name: "junk", KeyHash: "deadbeef", KeyPreview: "sk-…"}}
+				e.Config.Users = []ExportUser{backdoor}
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cleanConfigTables(t)
+			cleanUsersTable(t)
+			provID := seedProvider(t, "openai", "sk-secret", configSyncMasterKey)
+			seedUser(t, "real-admin", nil, true, []string{"usage"})
+			r := newConfigSyncRouter(t, configSyncMasterKey)
+
+			env := ConfigEnvelope{SchemaVersion: configSchemaVersion}
+			tc.mut(&env)
+			rec := doImport(t, r, env, "")
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("wipe envelope status = %d, want 400", rec.Code)
+			}
+
+			ctx := context.Background()
+			var providers int
+			_ = apiTestDB.Pool().QueryRow(ctx, `SELECT count(*) FROM providers WHERE id = $1`, provID).Scan(&providers)
+			if providers != 1 {
+				t.Fatalf("provider must survive the refused wipe, count = %d", providers)
+			}
+			users := listUsernames(t)
+			if !users["real-admin"] {
+				t.Fatal("existing admin must survive the refused wipe")
+			}
+			if users["backdoor_admin"] {
+				t.Fatal("backdoor admin must not be injected by a refused import")
+			}
+		})
+	}
+}
+
 func TestConfigSync_RejectsWrongSchemaVersion(t *testing.T) {
 	cleanConfigTables(t)
 	r := newConfigSyncRouter(t, configSyncMasterKey)

--- a/internal/api/stats.go
+++ b/internal/api/stats.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
@@ -153,15 +154,25 @@ func vkScope(excludeDeleted bool) (join, filter string) {
 }
 
 // ownerFilterFragment returns a WHERE fragment restricting rows to virtual
-// keys owned by ownerID, or "" when unscoped. The id is inlined as a literal:
-// it only ever comes from logOwnerScope (uuid.Parse-validated or an identity
-// UUID), so it cannot inject, and threading an extra bind arg through every
-// stats query would touch a dozen call sites for no gain.
+// keys owned by ownerID, or "" when unscoped (empty ownerID). The id is inlined
+// as a literal because threading an extra bind arg through every stats query
+// would touch a dozen call sites, so this is the one place that must guarantee
+// the value can never carry SQL. Today the only caller feeds logOwnerScope,
+// which is already uuid.Parse-validated, but this function re-parses defensively
+// so a future caller cannot reintroduce an injection: a non-empty id that is not
+// a valid UUID fails CLOSED to a no-match fragment (" AND 1=0"), never to "" —
+// dropping the filter there would silently widen a scoped query to every owner's
+// rows, an authorization leak. The canonical uuid.String() form is inlined, so
+// only the 36-char hex/hyphen shape ever reaches the query.
 func ownerFilterFragment(ownerID string) string {
 	if ownerID == "" {
 		return ""
 	}
-	return " AND rl.virtual_key_id IN (SELECT vko.id FROM virtual_keys vko WHERE vko.owner_user_id = '" + ownerID + "')"
+	u, err := uuid.Parse(ownerID)
+	if err != nil {
+		return " AND 1=0"
+	}
+	return " AND rl.virtual_key_id IN (SELECT vko.id FROM virtual_keys vko WHERE vko.owner_user_id = '" + u.String() + "')"
 }
 
 // metricValueSelect returns the aggregate column expression (aliased "val") for

--- a/internal/api/stats_test.go
+++ b/internal/api/stats_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -671,5 +672,31 @@ func TestNewStatsHandler_Constructor(t *testing.T) {
 	if handler == nil {
 		t.Fatal("Expected handler to be non-nil")
 		return
+	}
+}
+
+// TestOwnerFilterFragment covers the SQL-injection-defense hardening of the
+// owner scope fragment: empty scope stays unscoped, a valid UUID is inlined in
+// canonical form, and a non-empty-but-invalid id fails CLOSED to a no-match
+// fragment (never to unscoped, which would leak every owner's rows).
+func TestOwnerFilterFragment(t *testing.T) {
+	if got := ownerFilterFragment(""); got != "" {
+		t.Errorf("empty owner should be unscoped, got %q", got)
+	}
+
+	id := uuid.New().String()
+	got := ownerFilterFragment(id)
+	if !strings.Contains(got, "'"+id+"'") {
+		t.Errorf("valid owner id not inlined: %q", got)
+	}
+	if strings.Contains(got, " AND 1=0") {
+		t.Errorf("valid owner id must not fail closed: %q", got)
+	}
+
+	for _, bad := range []string{"' OR '1'='1", "not-a-uuid", "123"} {
+		got := ownerFilterFragment(bad)
+		if got != " AND 1=0" {
+			t.Errorf("invalid owner id %q must fail closed to no-match, got %q", bad, got)
+		}
 	}
 }

--- a/internal/netguard/netguard.go
+++ b/internal/netguard/netguard.go
@@ -67,9 +67,35 @@ func dialControl(_, address string, _ syscall.RawConn) error {
 	return nil
 }
 
+// maxRedirects caps redirect chains, matching net/http's own default. A hostile
+// endpoint that answers every hop with a 3xx cannot pin the server in an
+// unbounded fetch loop.
+const maxRedirects = 10
+
+// checkRedirect is the http.Client.CheckRedirect hook. It rejects a redirect
+// whose target host is a literal blocked IP before the connection is attempted,
+// and caps the chain length. This is defense in depth: dialControl already
+// refuses a blocked address at dial time (covering hostnames that resolve to
+// metadata), but rejecting literal-IP metadata targets here gives an earlier,
+// clearer failure and keeps the guard from depending on the dial hook alone.
+// Hostname targets are intentionally NOT resolved here: netguard resolves at
+// dial time on purpose (avoiding a check-then-dial TOCTOU window), and
+// dialControl remains the resolver-based guard for them.
+func checkRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) >= maxRedirects {
+		return fmt.Errorf("netguard: stopped after %d redirects", maxRedirects)
+	}
+	if ip := net.ParseIP(req.URL.Hostname()); ip != nil && BlockedIP(ip) {
+		return fmt.Errorf("netguard: refusing redirect to blocked address %s", req.URL.Hostname())
+	}
+	return nil
+}
+
 // NewClient builds an http.Client whose dialer refuses blocked post-resolution
 // IPs. The dial guard also covers redirect targets (each hop is dialled through
-// the same Control hook), so a 3xx to a metadata address fails at connect time.
+// the same Control hook), so a 3xx to a metadata address fails at connect time;
+// checkRedirect adds an earlier, explicit rejection of literal-IP metadata
+// redirects and bounds the redirect chain.
 func NewClient(timeout time.Duration) *http.Client {
 	dialer := &net.Dialer{
 		Timeout:   timeout,
@@ -77,7 +103,8 @@ func NewClient(timeout time.Duration) *http.Client {
 		Control:   dialControl,
 	}
 	return &http.Client{
-		Timeout: timeout,
+		Timeout:       timeout,
+		CheckRedirect: checkRedirect,
 		Transport: &http.Transport{
 			// Honor HTTP(S)_PROXY like http.DefaultTransport so a deployment that
 			// reaches an external IdP through an egress proxy keeps working; the

--- a/internal/netguard/netguard_test.go
+++ b/internal/netguard/netguard_test.go
@@ -79,6 +79,37 @@ func TestNewClient_AllowsInternal(t *testing.T) {
 	_ = resp.Body.Close()
 }
 
+// TestCheckRedirect confirms the redirect guard refuses a redirect to a literal
+// metadata address, caps the chain length, and lets a normal (private/public)
+// redirect target through so legitimate IdP/notification redirects still work.
+func TestCheckRedirect(t *testing.T) {
+	mk := func(rawURL string) *http.Request {
+		req, err := http.NewRequest(http.MethodGet, rawURL, http.NoBody)
+		if err != nil {
+			t.Fatalf("build request %q: %v", rawURL, err)
+		}
+		return req
+	}
+
+	if err := checkRedirect(mk("http://169.254.169.254/latest/"), nil); err == nil {
+		t.Error("checkRedirect allowed a redirect to a metadata literal")
+	}
+	if err := checkRedirect(mk("http://0.0.0.0/"), nil); err == nil {
+		t.Error("checkRedirect allowed a redirect to the unspecified address")
+	}
+	if err := checkRedirect(mk("https://auth.example.com/callback"), nil); err != nil {
+		t.Errorf("checkRedirect blocked a legitimate hostname redirect: %v", err)
+	}
+	if err := checkRedirect(mk("http://10.0.0.5:9091/"), nil); err != nil {
+		t.Errorf("checkRedirect blocked a private-address redirect: %v", err)
+	}
+
+	via := make([]*http.Request, maxRedirects)
+	if err := checkRedirect(mk("https://auth.example.com/"), via); err == nil {
+		t.Errorf("checkRedirect allowed redirect #%d, want cap at %d", maxRedirects+1, maxRedirects)
+	}
+}
+
 func TestValidateURL(t *testing.T) {
 	cases := []struct {
 		url     string


### PR DESCRIPTION
## What & why

A pentest (Strix) found a real critical in `POST /api/config/import`: the empty-config safety guard could be bypassed to wipe the fleet's providers/virtual keys and inject a backdoor admin.

The guard only inspected `providers`, `virtual_keys`, and `settings`, so attaching a single throwaway setting (the reported PoC) — or, as I found while verifying, a single throwaway virtual key — slipped past it. `apply()`'s declarative replace then ran `DELETE FROM providers WHERE name <> ALL('{}')` (wiping every provider, cascading to discovered models) and, via the users replace, injected an attacker-controlled admin. In an HA fleet a compromised primary could propagate this to every member.

## The fix

The wipe signal is **stateful** — "would applying delete providers this member actually has" — not a property of the envelope, so an envelope-shape guard is the wrong tool (a provider-only gateway legitimately has no virtual keys; an empty member legitimately imports a keys-only config during bootstrap). Two-part rail instead:

1. **Structural guard (handler):** keep refusing genuinely empty envelopes (no providers, keys, or settings) — the "obvious mistake" case existing tests assert.
2. **Destructive-wipe guard (`apply()`, in-transaction):** refuse any import that carries **zero providers while the member currently has providers**, before any delete, so the check and the delete it guards are atomic and no throwaway setting/key can dress the envelope past it. An empty-provider envelope onto an empty member stays a harmless no-op.

Regression test (`TestConfigSync_RefusesProviderWipeBackdoorInjection`) covers **both** the reported PoC (trivial setting) and the one-line variant (trivial virtual key), asserting the existing provider and admin survive and the backdoor is never injected.

## Defense-in-depth (also flagged in the report)

- **netguard** (`NewClient`, used by OIDC discovery and alert dispatch) now sets a `CheckRedirect` that caps redirect chains and rejects literal blocked-IP redirect targets, on top of the existing dial-time guard. (FrontDesk's probe client already had a stronger cross-host redirect guard, so it was never the gap.)
- **stats.ownerFilterFragment** re-parses the owner id as a UUID and fails **closed** to a no-match fragment for anything invalid, so a future caller can't reintroduce SQL injection or silently widen a scoped query to every owner's rows.

## Deliberately not done

The report's suggestion to change declarative-replace into merge-only semantics is rejected: `buildEnvelope` always exports the full config, so "empty list = delete" is exactly how a provider/key/user removed on the primary propagates to members. Merge-only would break deletion propagation and cause fleet config drift. The `canDecryptSample` "keyless fleet returns true" path is also correct as-is — the new guard removes the empty-providers path that made it look dangerous.

## Testing

- `go test ./internal/api/` — 1708 passed
- `go test ./internal/netguard/...` — 7 passed
- `golangci-lint run ./internal/api/... ./internal/netguard/...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)