### PR TITLE
perf(system): keep /api/system cold collect under caller timeouts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -82,7 +82,7 @@ require (
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
-	golang.org/x/sync v0.22.0 // indirect
+	golang.org/x/sync v0.22.0
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 	golang.org/x/time v0.15.0 // direct

--- a/internal/api/system.go
+++ b/internal/api/system.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"golang.org/x/sync/singleflight"
 
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 	"github.com/hugalafutro/model-hotel/internal/util"
@@ -53,6 +54,12 @@ func resetSystemCache() {
 	cachedSystemTime = time.Time{}
 	cachedSystemSince = ""
 	cachedSystemMu.Unlock()
+
+	reqTodayMu.Lock()
+	reqTodayVal = 0
+	reqTodayTime = time.Time{}
+	reqTodaySince = ""
+	reqTodayMu.Unlock()
 }
 
 // Register mounts system API routes.
@@ -120,38 +127,117 @@ var (
 
 const systemCacheTTL = 3 * time.Second
 
+// systemCollectTimeout bounds a single detached collect so a wedged query or
+// docker call cannot pin a background collect open indefinitely.
+const systemCollectTimeout = 15 * time.Second
+
+// systemCollectGroup coalesces concurrent cold collects for the same `since`, so
+// a burst of pollers hitting an expired cache triggers one collect, not a herd.
+var systemCollectGroup singleflight.Group
+
+// requestsTodayTTL caches the requests-today COUNT apart from the 3s system
+// payload. That COUNT is a live aggregate over request_logs which, on a freshly
+// restarted instance whose planner stats are stale, can seq-scan the whole table
+// and dominate the collect (the same heap-scan trap documented in applogs.go). A
+// status widget tolerates a slightly stale count, so run the query at most once
+// per this window instead of on every collect.
+const requestsTodayTTL = 30 * time.Second
+
+var (
+	reqTodayVal   int64
+	reqTodayTime  time.Time
+	reqTodaySince string
+	reqTodayMu    sync.Mutex
+)
+
 // GetSystem returns system health metrics (app, database, Docker).
 func (h *SystemHandler) GetSystem(w http.ResponseWriter, r *http.Request) {
 	since := r.URL.Query().Get("since")
 
-	cachedSystemMu.Lock()
-	if cachedSystem != nil && cachedSystemSince == since && time.Since(cachedSystemTime) < systemCacheTTL {
-		result := *cachedSystem
-		cachedSystemMu.Unlock()
-		w.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode(result); err != nil {
-			respondError(w, "failed to encode response", err, http.StatusInternalServerError)
-		}
+	if stats, ok := cachedSystemFor(since); ok {
+		writeSystemJSON(w, stats)
 		return
 	}
-	cachedSystemMu.Unlock()
 
-	stats, err := h.collect(r.Context(), since)
+	// Cold miss. Coalesce concurrent collects for the same `since`, and run the
+	// shared collect on a context detached from THIS request's cancellation. A
+	// caller that gives up early (e.g. Front Desk's 4s probe timing out while a
+	// freshly restarted, still-slow instance collects) must not abort the collect:
+	// if it did, the 3s cache would never be written and the instance would stay
+	// stuck cold on every poll. Detached, the collect still finishes and warms the
+	// cache, so the next poll is served from it instantly.
+	v, err, _ := systemCollectGroup.Do(since, func() (any, error) {
+		// A concurrent collect may have filled the cache while callers coalesced.
+		if stats, ok := cachedSystemFor(since); ok {
+			return stats, nil
+		}
+		cctx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), systemCollectTimeout)
+		defer cancel()
+		stats, err := h.collect(cctx, since)
+		if err != nil {
+			return nil, err
+		}
+		cachedSystemMu.Lock()
+		cachedSystem = stats
+		cachedSystemTime = time.Now()
+		cachedSystemSince = since
+		cachedSystemMu.Unlock()
+		return stats, nil
+	})
 	if err != nil {
 		respondError(w, "failed to collect system stats", err, http.StatusInternalServerError)
 		return
 	}
+	writeSystemJSON(w, v.(*SystemStats))
+}
 
+// cachedSystemFor returns a copy of the cached payload for `since` when it is
+// still within the TTL, so callers never share the cached pointer.
+func cachedSystemFor(since string) (*SystemStats, bool) {
 	cachedSystemMu.Lock()
-	cachedSystem = stats
-	cachedSystemTime = time.Now()
-	cachedSystemSince = since
-	cachedSystemMu.Unlock()
+	defer cachedSystemMu.Unlock()
+	if cachedSystem != nil && cachedSystemSince == since && time.Since(cachedSystemTime) < systemCacheTTL {
+		result := *cachedSystem
+		return &result, true
+	}
+	return nil, false
+}
 
+func writeSystemJSON(w http.ResponseWriter, stats *SystemStats) {
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(stats); err != nil {
 		respondError(w, "failed to encode response", err, http.StatusInternalServerError)
 	}
+}
+
+// requestsSince returns the number of request_logs rows at or after `since`,
+// cached for requestsTodayTTL under sinceKey. A query error yields 0 and is not
+// cached, so a transient failure is retried on the next collect rather than
+// pinned. Keeping this COUNT off every collect is what stops a stale-planner-stats
+// seq-scan on a freshly restarted primary from tipping the whole status endpoint
+// past a caller's timeout.
+func (h *SystemHandler) requestsSince(ctx context.Context, since time.Time, sinceKey string) int64 {
+	reqTodayMu.Lock()
+	if reqTodaySince == sinceKey && time.Since(reqTodayTime) < requestsTodayTTL {
+		v := reqTodayVal
+		reqTodayMu.Unlock()
+		return v
+	}
+	reqTodayMu.Unlock()
+
+	var n int64
+	if err := h.pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM request_logs WHERE created_at >= $1`, since).Scan(&n); err != nil {
+		debuglog.Error("system: query failed", "query", "requestsToday", "error", err)
+		return 0
+	}
+
+	reqTodayMu.Lock()
+	reqTodayVal = n
+	reqTodayTime = time.Now()
+	reqTodaySince = sinceKey
+	reqTodayMu.Unlock()
+	return n
 }
 
 func (h *SystemHandler) collect(ctx context.Context, sinceParam string) (*SystemStats, error) {
@@ -174,8 +260,6 @@ func (h *SystemHandler) collect(ctx context.Context, sinceParam string) (*System
 	diskReadPerSec, diskWritePerSec := util.ReadCgroupDiskIO()
 	procs := util.ReadCgroupProcs()
 
-	var requestsToday int64
-
 	since := time.Now().Truncate(24 * time.Hour) // fallback: UTC midnight
 	if sinceParam != "" {
 		parsed, err := time.Parse(time.RFC3339, sinceParam)
@@ -184,12 +268,7 @@ func (h *SystemHandler) collect(ctx context.Context, sinceParam string) (*System
 		}
 		since = parsed
 	}
-
-	err := h.pool.QueryRow(ctx, `SELECT COUNT(*) FROM request_logs WHERE created_at >= $1`, since).Scan(&requestsToday)
-	if err != nil {
-		debuglog.Error("system: query failed", "query", "requestsToday", "error", err)
-		requestsToday = 0
-	}
+	requestsToday := h.requestsSince(ctx, since, sinceParam)
 
 	stats.App = AppStats{
 		HeapAllocMB:       float64(heapAlloc) / 1024 / 1024,
@@ -210,7 +289,7 @@ func (h *SystemHandler) collect(ctx context.Context, sinceParam string) (*System
 	}
 
 	var dbSize int64
-	err = h.pool.QueryRow(ctx, `SELECT pg_database_size(current_database())`).Scan(&dbSize)
+	err := h.pool.QueryRow(ctx, `SELECT pg_database_size(current_database())`).Scan(&dbSize)
 	if err != nil {
 		debuglog.Error("system: query failed", "query", "dbSize", "error", err)
 		dbSize = 0

--- a/internal/api/system_test.go
+++ b/internal/api/system_test.go
@@ -368,11 +368,12 @@ func TestGetSystem_ValidSince(t *testing.T) {
 
 func TestGetSystem_CancelledContext(t *testing.T) {
 	// Do NOT use t.Parallel() — mutates package-level cache.
-	// A canceled request now surfaces the settings read failure (from computing
-	// fleet status) as a 500 rather than a gracefully-degraded 200. This is the
-	// cache-poisoning fix: a half-read payload must never be cached and served to
-	// other clients as authoritative. The DB-stat queries still degrade to zero
-	// on cancellation; it is specifically the fleet read that must not be guessed.
+	// A caller that cancels mid-flight must NOT abort the collect. GetSystem runs
+	// the collect on a context detached from the request, so a poller that gives
+	// up early (e.g. Front Desk's 4s probe timing out on a freshly restarted, slow
+	// instance) still lets the collect finish and warm the 3s cache. Without this
+	// the instance stays stuck cold on every poll. So an immediately-canceled
+	// request still returns 200, and — the key property — it warms the cache.
 	resetSystemCache()
 	_, r := newTestHandlerWithRouter(t)
 
@@ -385,17 +386,57 @@ func TestGetSystem_CancelledContext(t *testing.T) {
 	rec := httptest.NewRecorder()
 	r.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusInternalServerError {
-		t.Errorf("expected 500 (canceled fleet read must not be cached), got %d", rec.Code)
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200 (detached collect ignores request cancellation), got %d: %s",
+			rec.Code, rec.Body.String())
 	}
 
-	// Nothing may have been cached: a follow-up healthy request returns fresh 200.
+	// The detached collect must have populated the cache despite the cancellation.
+	cachedSystemMu.Lock()
+	warmed := cachedSystem != nil
+	cachedSystemMu.Unlock()
+	if !warmed {
+		t.Error("canceled request should still warm the cache via the detached collect")
+	}
+
+	// Follow-up healthy request is served (from the warmed cache) as 200.
 	req2 := httptest.NewRequest(http.MethodGet, "/system/", http.NoBody)
 	req2.Header.Set("Authorization", "Bearer test-admin-token")
 	rec2 := httptest.NewRecorder()
 	r.ServeHTTP(rec2, req2)
 	if rec2.Code != http.StatusOK {
-		t.Errorf("follow-up request: expected 200 (no poisoned cache), got %d", rec2.Code)
+		t.Errorf("follow-up request: expected 200, got %d", rec2.Code)
+	}
+}
+
+func TestRequestsSince_CachesWithinTTL(t *testing.T) {
+	// Do NOT use t.Parallel() — mutates the package-level requestsToday cache and
+	// inserts into the shared request_logs table.
+	resetSystemCache()
+	h, _ := newTestHandlerWithRouter(t)
+	sh := h.systemHandler
+	ctx := context.Background()
+
+	const key = "cache-test-window"
+	since := time.Now().Add(-time.Hour)
+
+	baseline := sh.requestsSince(ctx, since, key)
+
+	// Insert a row inside the window AFTER the value was cached. Within the TTL the
+	// cached baseline must come back: the COUNT is not re-run on every collect,
+	// which is what keeps a stale-stats seq-scan off the hot status path.
+	if _, err := sh.pool.Exec(ctx,
+		`INSERT INTO request_logs (created_at) VALUES ($1)`, time.Now()); err != nil {
+		t.Fatalf("insert request_log: %v", err)
+	}
+	if got := sh.requestsSince(ctx, since, key); got != baseline {
+		t.Errorf("within TTL expected cached %d, got %d (COUNT re-ran)", baseline, got)
+	}
+
+	// After a cache reset the fresh COUNT sees the inserted row.
+	resetSystemCache()
+	if got := sh.requestsSince(ctx, since, key); got != baseline+1 {
+		t.Errorf("after reset expected fresh %d, got %d", baseline+1, got)
 	}
 }
 

--- a/internal/util/docker.go
+++ b/internal/util/docker.go
@@ -345,12 +345,31 @@ func CollectDockerStatsWithFilter(filter ContainerFilter) AggregatedDockerStats 
 	var totalBlkRead, totalBlkWrite int64
 	var totalProcs int
 
-	for _, c := range containers {
+	// Fetch each container's stats concurrently. GetContainerStats blocks ~1s on
+	// the daemon's stats?stream=false sampling window, so N sequential calls cost
+	// ~N seconds; this runs on the /api/system hot path, so fan the calls out and
+	// aggregate their results below. Each goroutine writes only its own slot, so
+	// no lock is needed for the collection itself.
+	perContainer := make([]*ContainerStats, len(containers))
+	var wg sync.WaitGroup
+	for i, c := range containers {
 		if c.State != "running" {
 			continue
 		}
-		stats, err := GetContainerStats(c.ID)
-		if err != nil {
+		wg.Add(1)
+		go func(i int, id string) {
+			defer wg.Done()
+			stats, err := GetContainerStats(id)
+			if err != nil {
+				return // leave the slot nil; a failed container is skipped
+			}
+			perContainer[i] = stats
+		}(i, c.ID)
+	}
+	wg.Wait()
+
+	for _, stats := range perContainer {
+		if stats == nil {
 			continue
 		}
 		totalCPU += stats.CPUPercent


### PR DESCRIPTION
## What & why

Follow-up to the live investigation of Front Desk showing the **primary** stuck on "n/a n/a" while the secondary self-healed. Root cause was **not** a code regression (PR #465/#466 don't touch this path) — it was latent latency the last container restart exposed.

FD reads each member's fleet identity from `GET /api/system` with a **4s probe timeout** (`poller.go` `httpProbeTimeout`). On the busy primary a cold (cache-miss) collect took **4-5s**, so FD cancelled every poll. The cancelled request never reached the cache write (`GetSystem` only cached on success), so the primary could **never warm its 3s cache** and stayed stuck; the idle secondary's sub-4s cold collect completed and self-healed. Confirmed live: `failed to collect system stats error=compute fleet status: context canceled`, `status=500 duration=4.397s`.

## The three fixes (bring cold collect comfortably under the timeout)

1. **Detach the collect from the request + coalesce** (`GetSystem`). Runs `collect` on `context.WithoutCancel(r.Context())` under a bounded 15s timeout, wrapped in a `singleflight` group keyed on `since`. A caller that gives up early no longer aborts the collect, so it finishes and warms the cache for the next poll instead of the instance wedging cold forever. Concurrent cold pollers trigger one collect, not a herd.
2. **Parallelize docker stats** (`CollectDockerStatsWithFilter`). `GetContainerStats` blocks ~1s on the daemon's `stats?stream=false` sampling window, so N sequential calls cost ~N seconds on the hot path. Fetches per-container stats concurrently (each goroutine writes only its own slot; aggregation unchanged).
3. **Cache requests-today apart from the 3s payload.** It's a live `COUNT(*)` over `request_logs` that, on a freshly restarted primary with stale planner stats, seq-scans the whole table and dominated the collect — the same heap-scan trap already documented at `applogs.go:431-437`. Now runs at most once per 30s; a status widget tolerates a slightly stale count.

## Testing

- `TestGetSystem_CancelledContext` updated to the new contract: a cancelled request returns 200 and **warms the cache** (direct assertion).
- Added `TestRequestsSince_CachesWithinTTL`: an insert within the TTL returns the cached count; a fresh count after reset sees the new row.
- `go test ./internal/api/ ./internal/util/...` green; system tests race-clean; `golangci-lint` clean.

## Notes

Behavior preserved: a genuine DB/fleet-read error still returns 500 without caching (`TestGetSystem_FleetReadErrorNotCached`, `TestCollect_CancelledContext` unchanged). The operational VACUUM stopgap discussed separately is orthogonal; autovacuum + fix #3 make it unnecessary going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)