### PR TITLE
fix(ci): match unprefixed X.Y.Z tags in Docker Hub prune

### DIFF
--- a/.github/workflows/dockerhub-prune.yml
+++ b/.github/workflows/dockerhub-prune.yml
@@ -3,9 +3,9 @@ name: Prune Docker Hub Tags
 # Keeps the Docker Hub repositories tidy after a release. Both the server image
 # (model-hotel) and the Front Desk control-plane image (model-hotel-frontdesk)
 # are released together under the same tag scheme, so both are pruned here with
-# identical retention. Retains the newest KEEP version tags (vX.Y.Z) plus every
+# identical retention. Retains the newest KEEP version tags (X.Y.Z) plus every
 # protected moving tag (latest, X.Y), and deletes older releases. Each release
-# pushes a vX.Y.Z tag *and* a sha- tag at the same image digest, so a sha- tag
+# pushes an X.Y.Z tag *and* a sha- tag at the same image digest, so a sha- tag
 # is pruned only when no retained tag still points at its digest — this drops a
 # release's sha- tag together with the release, without parsing commit SHAs.
 #
@@ -103,7 +103,9 @@ jobs:
           # Delete:     version tags beyond KEEP, and sha- tags whose digest is
           #             not shared by any retained tag. Unknown tags are left alone.
           to_delete=$(jq -rs --argjson keep "$KEEP" '
-            def isVersion: test("^v[0-9]+\\.[0-9]+\\.[0-9]+$");
+            # Docker Hub release tags carry no v prefix (docker/metadata-action
+            # type=semver strips it; only the git tag is vX.Y.Z), so accept both.
+            def isVersion: test("^v?[0-9]+\\.[0-9]+\\.[0-9]+$");
             def isProtected: (. == "latest") or test("^[0-9]+\\.[0-9]+$");
             def isSha: startswith("sha-");
 


### PR DESCRIPTION
## Problem

The prune workflow's version matcher expected `vX.Y.Z` Docker Hub tags, but `docker/metadata-action`'s `type=semver` pattern strips the `v` (only the git tag carries it). Every release tag therefore fell into the 'unknown, leave alone' bucket and no version tag was ever pruned: `model-hotel` accumulated 43 version tags (back to 0.9.39, June 4) against `keep=20`. Only the orphaned `sha-` cleanup ever fired, so the workflow ran green every release and looked healthy.

## Fix

Accept an optional `v` prefix in the version matcher, `^v?[0-9]+\.[0-9]+\.[0-9]+$`, and correct the header comment that claimed releases push `vX.Y.Z` Docker tags.

## Verification

- actionlint passes.
- Replayed the workflow's jq locally against the live tag list: targets exactly `0.9.39`..`0.9.68` (23 tags), keeps the newest 20 versions plus `latest`, `0.9`, `dev`, `sha-331f6ff`.
- Real dry-run dispatched from this branch confirms the same: https://github.com/hugalafutro/model-hotel/actions/runs/29523177248 (23 tags targeted on `model-hotel`, 'Nothing to prune' on `model-hotel-frontdesk`).

After merge, a manual dispatch with `dry_run=false` clears the backlog (~900 MB); otherwise the next release's auto-prune does it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)