### PR TITLE
feat(ci): per-app changelogs for Bellhop and MH/FD releases

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,8 @@
+# Config for actions/labeler (labeler.yml workflow). A PR is labeled `bellhop`
+# only when EVERY changed file is Bellhop-related (single brace glob +
+# any-glob-to-all-files = "one glob matches all files"): release.yml excludes
+# that label from the MH/FD release notes, and a mixed PR that also touches
+# server code must keep appearing there.
+bellhop:
+  - changed-files:
+      - any-glob-to-all-files: "{android/**,.github/workflows/android*.yml}"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -7,6 +7,10 @@
 # Bot-authored PRs are excluded to keep the notes signal-only.
 changelog:
   exclude:
+    # Pure-Bellhop PRs (auto-labeled by labeler.yml) have their own changelog
+    # on the bellhop-vX.Y.Z releases; keep them out of the MH/FD notes.
+    labels:
+      - bellhop
     authors:
       - dependabot
       - dependabot[bot]

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -57,6 +57,10 @@ jobs:
       DRY_RUN: ${{ !(github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false)) }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Full history + tags: the changelog is generated from the commits
+          # since the previous bellhop-v* tag.
+          fetch-depth: 0
 
       - name: Resolve version and guard against re-release
         id: version
@@ -114,6 +118,46 @@ jobs:
           path: android/bellhop-${{ steps.version.outputs.ver }}.apk
           retention-days: 14
 
+      # Bellhop's changelog can't come from --generate-notes: GitHub would list
+      # every PR since the previous bellhop-v* tag, server ones included. So it
+      # is generated from the first-parent commits since that tag that touch
+      # android/, mirroring the label-based exclusion release.yml applies in
+      # the other direction. Dependabot merges are skipped like release.yml
+      # excludes bot authors.
+      - name: Generate changelog
+        if: steps.version.outputs.skip_existing == 'false' && env.DRY_RUN != 'true'
+        run: |
+          prev=$(git describe --tags --abbrev=0 --match 'bellhop-v*' HEAD^ 2>/dev/null || true)
+          {
+            if [ -z "$prev" ]; then
+              echo "First public release of Bellhop, the Model Hotel fleet companion app."
+            else
+              echo "## Changes"
+              git log --first-parent --format='%s%x1f%b%x1e' "${prev}..HEAD" -- android \
+                | awk 'BEGIN { RS="\x1e"; FS="\x1f" }
+                  NF {
+                    subj = $1; sub(/^\n+/, "", subj)
+                    if (subj == "" || subj ~ /dependabot/) next
+                    if (match(subj, /^Merge pull request #[0-9]+/)) {
+                      num = subj
+                      sub(/^Merge pull request #/, "", num); sub(/ .*/, "", num)
+                      title = $2; sub(/\n.*/, "", title)
+                      if (title == "") title = subj
+                      print "- " title " (#" num ")"
+                    } else {
+                      print "- " subj
+                    }
+                  }'
+              echo ""
+              echo "**Full Changelog**: https://github.com/${{ github.repository }}/compare/${prev}...${{ steps.version.outputs.tag }}"
+            fi
+            echo ""
+            echo "---"
+            echo ""
+            echo "Sideload the attached APK directly or add this repository to [Obtainium](https://github.com/ImranR98/Obtainium) for automatic updates. All releases are signed with the same key, so updates install over previous versions."
+          } > "$RUNNER_TEMP/release-notes.md"
+          cat "$RUNNER_TEMP/release-notes.md"
+
       - name: Tag and publish GitHub release
         if: steps.version.outputs.skip_existing == 'false' && env.DRY_RUN != 'true'
         env:
@@ -124,4 +168,4 @@ jobs:
           gh release create "${{ steps.version.outputs.tag }}" \
             "bellhop-${{ steps.version.outputs.ver }}.apk" \
             --title "Bellhop ${{ steps.version.outputs.ver }}" \
-            --notes "Signed Bellhop APK. Sideload it directly or add this repository to [Obtainium](https://github.com/ImranR98/Obtainium) for automatic updates. All releases are signed with the same key, so updates install over previous versions."
+            --notes-file "$RUNNER_TEMP/release-notes.md"

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -133,7 +133,10 @@ jobs:
               echo "First public release of Bellhop, the Model Hotel fleet companion app."
             else
               echo "## Changes"
-              git log --first-parent --format='%s%x1f%b%x1e' "${prev}..HEAD" -- android \
+              # :/ anchors the pathspec at the repo root: this step runs with
+              # working-directory android/, where a bare "android" pathspec
+              # would mean android/android and match nothing.
+              git log --first-parent --format='%s%x1f%b%x1e' "${prev}..HEAD" -- ':/android' \
                 | awk 'BEGIN { RS="\x1e"; FS="\x1f" }
                   NF {
                     subj = $1; sub(/^\n+/, "", subj)

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,23 @@
+name: Label PRs
+
+# Auto-labels pure-Bellhop PRs (see .github/labeler.yml) so the MH/FD release
+# notes can exclude them via release.yml. pull_request_target runs the workflow
+# definition from master, so a PR cannot alter its own labeling rules; the
+# labeler only reads the PR's changed-file list and never checks out PR code.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/labeler@b8dd2d9be0f68b860e7dae5dae7d772984eacd6d # v6.2.0
+        with:
+          sync-labels: true


### PR DESCRIPTION
## What

Splits release changelogs per app, both directions:

**Bellhop out of MH/FD notes (label-based):** new `labeler.yml` workflow + `.github/labeler.yml` config auto-label a PR `bellhop` when *every* changed file is under `android/` or the android workflows (`any-glob-to-all-files`, so mixed server+android PRs keep appearing in the server notes), and `release.yml` now excludes that label from `--generate-notes`. MH/FD notes keep their existing grouping and bot exclusion. The `bellhop` label exists and is already applied to #469/#470 so the next server release is clean.

**Bellhop's own changelog (git-based, since labels can't express include-only):** `android-release.yml` now generates notes from first-parent commits since the previous `bellhop-v*` tag that touch `android/`: PR titles with linked numbers, dependabot merges skipped (mirroring release.yml's bot exclusion), a Full Changelog compare link, and the sideload/Obtainium blurb. A first release with no prior `bellhop-v*` tag gets a short intro instead of a 60-PR history dump. Checkout gets `fetch-depth: 0` for tag/history access.

**Security note on `pull_request_target`:** the labeler runs the workflow definition from master, never checks out PR code, and only reads the changed-file list; write scope is limited to `pull-requests`.

## Verification

- actionlint passes on both workflows.
- Changelog pipeline validated against real history (`v0.9.85..HEAD -- android`): 35 PRs parsed (initially misclaimed as 36: the count included a stray empty entry the awk guard now filters), titles + numbers correct, no stray entries.
- Fun local-only footgun found while testing: the rtk hook silently returns empty output for `git log --first-parent`; `rtk proxy` confirmed git itself is fine. CI has no rtk, so the workflow is unaffected.

Sequencing: merge this before #470 so the first Bellhop release uses the new notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)