### PR TITLE
fix(ci): keep repo Latest badge on MH/FD, not Bellhop releases

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -168,7 +168,11 @@ jobs:
         run: |
           git tag "${{ steps.version.outputs.tag }}"
           git push origin "${{ steps.version.outputs.tag }}"
+          # --latest=false: the repo's Latest badge belongs to the MH/FD
+          # releases (docker-publish passes --latest); without this a Bellhop
+          # release would steal it until the next server release.
           gh release create "${{ steps.version.outputs.tag }}" \
             "bellhop-${{ steps.version.outputs.ver }}.apk" \
             --title "Bellhop ${{ steps.version.outputs.ver }}" \
+            --latest=false \
             --notes-file "$RUNNER_TEMP/release-notes.md"


### PR DESCRIPTION
`gh release create` defaults the newest release to Latest, so `bellhop-v0.9.0` took the repo's Latest badge from `v0.9.88` (until the next server release would reclaim it via `--latest`). Pass `--latest=false` for Bellhop releases so the badge always tracks MH/FD.

Note: this PR touches only `android-release.yml`, so its own PR run is the workflow's dry-run mode (artifact, no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)