### PR TITLE
fix(ci): count Bellhop-only docs as bellhop for PR labeling

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,7 +2,9 @@
 # only when EVERY changed file is Bellhop-related (single brace glob +
 # any-glob-to-all-files = "one glob matches all files"): release.yml excludes
 # that label from the MH/FD release notes, and a mixed PR that also touches
-# server code must keep appearing there.
+# server code or shared docs (README, DOCKERHUB) must keep appearing there.
+# Bellhop-only docs count as Bellhop: the wiki page and bellhop-named
+# screenshot/icon assets.
 bellhop:
   - changed-files:
-      - any-glob-to-all-files: "{android/**,.github/workflows/android*.yml}"
+      - any-glob-to-all-files: "{android/**,.github/workflows/android*.yml,wiki/Bellhop*,docs/screenshots/bellhop*,docs/icons/bellhop*}"


### PR DESCRIPTION
Extends the labeler glob set with `wiki/Bellhop*`, `docs/screenshots/bellhop*`, and `docs/icons/bellhop*` so pure Bellhop-docs PRs (like #464, a wiki-only edit) get the `bellhop` label and drop out of the MH/FD release notes. Because `any-glob-to-all-files` requires *every* changed file to match, PRs that also touch shared docs like `README.md`/`DOCKERHUB.md` (#462, #463) still correctly appear in the server notes.

Follow-up from eyeballing the v0.9.89 changelog: mixed FD+Bellhop code PRs (#426/#439/#461) stay by design; this only reclassifies Bellhop-only documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)