### PR TITLE
fix(frontdesk): set browser security headers on the admin UI

### DIFF
--- a/internal/frontdesk/hardening_test.go
+++ b/internal/frontdesk/hardening_test.go
@@ -50,6 +50,41 @@ func TestTotpEnabledCacheFailsClosed(t *testing.T) {
 	})
 }
 
+// TestSecurityHeaders guards the clickjacking fix: every Front Desk response,
+// including the unauthenticated Traefik-config endpoint, must carry the frame,
+// content-type, referrer, and CSP hardening headers. Front Desk stores its
+// bearer in localStorage, so a framed same-origin copy would auto-authenticate
+// without frame-ancestors 'none' / X-Frame-Options: DENY.
+func TestSecurityHeaders(t *testing.T) {
+	srv, _ := newTestServer(t)
+	want := map[string]string{
+		"X-Content-Type-Options":  "nosniff",
+		"X-Frame-Options":         "DENY",
+		"Referrer-Policy":         "strict-origin-when-cross-origin",
+		"Content-Security-Policy": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'",
+	}
+	// Cover both an authenticated API route and the unauthenticated,
+	// compose-internal Traefik-config endpoint.
+	for _, tc := range []struct {
+		path string
+		auth bool
+	}{
+		{"/api/members", true},
+		{"/traefik/config", false},
+	} {
+		rec := do(t, srv, http.MethodGet, tc.path, "", tc.auth)
+		for h, v := range want {
+			if got := rec.Header().Get(h); got != v {
+				t.Errorf("%s: header %s = %q, want %q", tc.path, h, got, v)
+			}
+		}
+		// Plain HTTP (no TLS) must not advertise HSTS.
+		if got := rec.Header().Get("Strict-Transport-Security"); got != "" {
+			t.Errorf("%s: HSTS set on plain HTTP: %q", tc.path, got)
+		}
+	}
+}
+
 func TestIsProbeBlockedIP(t *testing.T) {
 	cases := []struct {
 		ip      string

--- a/internal/frontdesk/hardening_test.go
+++ b/internal/frontdesk/hardening_test.go
@@ -187,7 +187,7 @@ func TestVersionFetchFailureRaisesEvent(t *testing.T) {
 	}
 
 	// Below threshold: no event yet.
-	for i := 0; i < versionFetchFailThreshold-1; i++ {
+	for range versionFetchFailThreshold - 1 {
 		p.PollVersionsOnce(ctx)
 	}
 	if n := countEvents(t, s, "version.fetch_failed"); n != 0 {

--- a/internal/frontdesk/hardening_test.go
+++ b/internal/frontdesk/hardening_test.go
@@ -2,12 +2,14 @@ package frontdesk
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
+	"testing/fstest"
 )
 
 // stubTotpReader is a totpStatusReader whose IsEnabled result is fully scripted,
@@ -50,39 +52,71 @@ func TestTotpEnabledCacheFailsClosed(t *testing.T) {
 	})
 }
 
-// TestSecurityHeaders guards the clickjacking fix: every Front Desk response,
-// including the unauthenticated Traefik-config endpoint, must carry the frame,
-// content-type, referrer, and CSP hardening headers. Front Desk stores its
-// bearer in localStorage, so a framed same-origin copy would auto-authenticate
-// without frame-ancestors 'none' / X-Frame-Options: DENY.
+// TestSecurityHeaders guards the clickjacking fix: every Front Desk response
+// must carry the frame, content-type, referrer, and CSP hardening headers. The
+// middleware runs ahead of routing and auth, so this holds on the embedded SPA
+// (the framed surface), the authenticated API, the unauthenticated
+// compose-internal Traefik-config endpoint, and error responses (401/404)
+// alike. Front Desk stores its bearer in localStorage, so a framed same-origin
+// copy would auto-authenticate without frame-ancestors 'none' /
+// X-Frame-Options: DENY.
 func TestSecurityHeaders(t *testing.T) {
-	srv, _ := newTestServer(t)
+	// Mount a stand-in SPA so "/" serves the real UI surface, not a 404.
+	ui := fstest.MapFS{
+		"index.html": &fstest.MapFile{Data: []byte("<!doctype html><title>fd</title>")},
+	}
+	srv, _ := newTestServerUI(t, ui)
+
 	want := map[string]string{
 		"X-Content-Type-Options":  "nosniff",
 		"X-Frame-Options":         "DENY",
 		"Referrer-Policy":         "strict-origin-when-cross-origin",
 		"Content-Security-Policy": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'",
 	}
-	// Cover both an authenticated API route and the unauthenticated,
-	// compose-internal Traefik-config endpoint.
+
 	for _, tc := range []struct {
-		path string
-		auth bool
+		name     string
+		path     string
+		auth     bool
+		wantCode int
 	}{
-		{"/api/members", true},
-		{"/traefik/config", false},
+		{"spa index (the framed page)", "/", false, http.StatusOK},
+		{"authenticated API", "/api/members", true, http.StatusOK},
+		{"unauthenticated 401", "/api/members", false, http.StatusUnauthorized},
+		{"unauth compose-internal traefik config", "/traefik/config", false, http.StatusOK},
 	} {
-		rec := do(t, srv, http.MethodGet, tc.path, "", tc.auth)
-		for h, v := range want {
-			if got := rec.Header().Get(h); got != v {
-				t.Errorf("%s: header %s = %q, want %q", tc.path, h, got, v)
+		t.Run(tc.name, func(t *testing.T) {
+			rec := do(t, srv, http.MethodGet, tc.path, "", tc.auth)
+			if rec.Code != tc.wantCode {
+				t.Fatalf("%s: status = %d, want %d", tc.path, rec.Code, tc.wantCode)
 			}
-		}
-		// Plain HTTP (no TLS) must not advertise HSTS.
-		if got := rec.Header().Get("Strict-Transport-Security"); got != "" {
-			t.Errorf("%s: HSTS set on plain HTTP: %q", tc.path, got)
-		}
+			for h, v := range want {
+				if got := rec.Header().Get(h); got != v {
+					t.Errorf("%s: header %s = %q, want %q", tc.path, h, got, v)
+				}
+			}
+			// Plain HTTP (no TLS) must not advertise HSTS, or browsers cache a
+			// broken redirect to a non-existent HTTPS listener.
+			if got := rec.Header().Get("Strict-Transport-Security"); got != "" {
+				t.Errorf("%s: HSTS set on plain HTTP: %q", tc.path, got)
+			}
+		})
 	}
+
+	// Over TLS the same middleware advertises HSTS.
+	t.Run("hsts set over tls", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/traefik/config", http.NoBody)
+		req.TLS = &tls.ConnectionState{} // mark the request as TLS-terminated
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, req)
+		if got := rec.Header().Get("Strict-Transport-Security"); got != "max-age=63072000; includeSubDomains; preload" {
+			t.Errorf("HSTS over TLS = %q, want the preload max-age", got)
+		}
+		// Frame protection is still present over TLS.
+		if got := rec.Header().Get("X-Frame-Options"); got != "DENY" {
+			t.Errorf("X-Frame-Options over TLS = %q, want DENY", got)
+		}
+	})
 }
 
 func TestIsProbeBlockedIP(t *testing.T) {

--- a/internal/frontdesk/server.go
+++ b/internal/frontdesk/server.go
@@ -183,6 +183,32 @@ func (s *Server) SessionManager() *webauthn.SessionManager { return s.sessionMgr
 func (s *Server) buildRouter(wa *adminauth.WebAuthnHandler, tp *adminauth.TotpHandler, oidc *adminauth.OIDCHandler, ui fs.FS) http.Handler {
 	r := chi.NewRouter()
 
+	// Security headers. The Front Desk admin UI manages the whole HA fleet
+	// (member admin tokens, device pairing, config sync, OIDC/alert settings)
+	// and keeps its bearer in localStorage, so a framed copy of this origin
+	// auto-authenticates. Deny framing outright and mirror the main server's
+	// content-type / referrer / CSP hardening (cmd/server/main.go). Front Desk
+	// is never embedded, so there is no ALLOW_EMBED escape hatch here.
+	r.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("X-Content-Type-Options", "nosniff")
+			w.Header().Set("X-Frame-Options", "DENY")
+			w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
+			// HSTS only over TLS. Front Desk serves plain HTTP behind a proxy
+			// that terminates TLS, so this guard is a forward-compatible
+			// placeholder: setting HSTS on plain HTTP would cache a broken
+			// redirect to a non-existent HTTPS listener.
+			if r.TLS != nil {
+				w.Header().Set("Strict-Transport-Security", "max-age=63072000; includeSubDomains; preload")
+			}
+			// Same-origin scripts (Vite module output, no inline scripts).
+			// style 'unsafe-inline' is required for Vite's injected style tags;
+			// img data:/blob: covers QR codes and canvas-rendered previews.
+			w.Header().Set("Content-Security-Policy", "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'")
+			next.ServeHTTP(w, r)
+		})
+	})
+
 	// Unauthenticated, compose-internal: Traefik's HTTP provider polls this.
 	r.Get("/traefik/config", s.handleTraefikConfig)
 

--- a/internal/frontdesk/server_test.go
+++ b/internal/frontdesk/server_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -54,6 +55,13 @@ func systemMemberServerID(t *testing.T, selfReportsPrimary bool, instanceID stri
 
 func newTestServer(t *testing.T) (*Server, *Store) {
 	t.Helper()
+	return newTestServerUI(t, nil)
+}
+
+// newTestServerUI is newTestServer with an embedded SPA mounted, so tests can
+// exercise the "/" UI surface (e.g. security headers on the framed page).
+func newTestServerUI(t *testing.T, ui fs.FS) (*Server, *Store) {
+	t.Helper()
 	store := newTestStore(t)
 	bus := events.NewBus()
 	poller := NewPoller(store, bus, "")
@@ -74,6 +82,7 @@ func newTestServer(t *testing.T) (*Server, *Store) {
 		MasterKey:    testMasterKey,
 		RelyingParty: rp,
 		IPLimiter:    ratelimit.NewIPLimiter(1000, 1000, nil, nil),
+		UI:           ui,
 	})
 	// Drain any detached background goroutine (e.g. an auto-sync kick) before
 	// the store and its temp dir are torn down. Registered here so it runs


### PR DESCRIPTION
## What

Adds a security-header middleware to the Front Desk control-plane server, mirroring the main model-hotel server (`cmd/server/main.go`). Fixes a Strix finding (vuln-0002).

## Why

`buildRouter` registered no security headers at all, unlike the main server. The Front Desk SPA keeps its admin bearer in `localStorage`, so a same-origin framed copy of the UI auto-authenticates. With no `X-Frame-Options` / CSP `frame-ancestors`, an authenticated admin visiting an attacker page can be clickjacked into fleet controls (member drain/remove, device pairing, config sync, OIDC/alert settings).

## Change

- `X-Frame-Options: DENY`, CSP `frame-ancestors 'none'`, `X-Content-Type-Options: nosniff`, `Referrer-Policy: strict-origin-when-cross-origin`, and a TLS-gated HSTS placeholder.
- Front Desk is never embedded, so framing is denied unconditionally (no `ALLOW_EMBED` escape hatch, unlike the main server).
- `TestSecurityHeaders` asserts all four headers on both an authenticated API route and the unauthenticated `/traefik/config`, and that HSTS stays off on plain HTTP.
- Drive-by: modernized one counting loop in the touched test file.

## Test

`go test ./internal/frontdesk/` (247 pass), `golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)