### PR TITLE
fix(auth): bind SSO logins to a provider identity, not just email

### DIFF
--- a/internal/adminauth/github.go
+++ b/internal/adminauth/github.go
@@ -345,8 +345,12 @@ func (h *GitHubHandler) Callback(w http.ResponseWriter, r *http.Request) {
 	// downgraded to a user identity by a stray user row.
 	sessionHandle := []byte("admin")
 	if matched == "" {
+		// Bind on GitHub's numeric account id -- stable and never reassigned,
+		// unlike the email set -- so the account locks to this GitHub user, not
+		// to whoever can next assert one of these verified addresses.
+		subject := strconv.FormatInt(user.ID, 10)
 		for _, e := range verified {
-			if u := resolveSSOUser(ctx, h.users, e); u != nil {
+			if u := resolveSSOUser(ctx, h.users, "github", subject, e); u != nil {
 				matched = e
 				sessionHandle = []byte(u.ID.String())
 				break

--- a/internal/adminauth/oidc.go
+++ b/internal/adminauth/oidc.go
@@ -381,7 +381,10 @@ func (h *OIDCHandler) Callback(w http.ResponseWriter, r *http.Request) {
 	// downgraded to a user identity by a stray user row.
 	sessionHandle := []byte("admin")
 	if !rt.allowed[email] {
-		u := resolveSSOUser(ctx, h.users, email)
+		// Bind on the IdP's stable (iss, sub) -- issuer-qualified so two OIDC
+		// issuers can never collide on a bare subject -- not on the email, which
+		// any provider can assert.
+		u := resolveSSOUser(ctx, h.users, "oidc", idToken.Issuer+"#"+idToken.Subject, email)
 		if u == nil {
 			debuglog.Warn("oidc: login denied: email not allowlisted or user-bound",
 				"email_masked", maskEmail(email), "sub", idToken.Subject, "iss", idToken.Issuer)

--- a/internal/adminauth/ssobinding.go
+++ b/internal/adminauth/ssobinding.go
@@ -3,15 +3,18 @@ package adminauth
 import (
 	"context"
 
+	"github.com/hugalafutro/model-hotel/internal/debuglog"
+	"github.com/hugalafutro/model-hotel/internal/events"
 	"github.com/hugalafutro/model-hotel/internal/user"
 )
 
 // SSOUserResolver binds an OIDC/GitHub login to a user account by verified
 // email, enforcing one external identity per account so a second provider
-// cannot take over an account by asserting its email. Implemented by
+// cannot take over an account by asserting its email. The bool it returns is
+// true only when this call recorded a first-ever binding. Implemented by
 // *user.Repository.
 type SSOUserResolver interface {
-	ResolveSSOIdentity(ctx context.Context, provider, subject, email string) (*user.User, error)
+	ResolveSSOIdentity(ctx context.Context, provider, subject, email string) (*user.User, bool, error)
 }
 
 // resolveSSOUser returns the enabled user bound to (provider, subject, email),
@@ -25,9 +28,30 @@ func resolveSSOUser(ctx context.Context, users SSOUserResolver, provider, subjec
 	if users == nil {
 		return nil
 	}
-	u, err := users.ResolveSSOIdentity(ctx, provider, subject, email)
+	u, bound, err := users.ResolveSSOIdentity(ctx, provider, subject, email)
 	if err != nil || u == nil || !u.Enabled {
 		return nil
+	}
+	if bound {
+		// First-ever SSO login for this account. A legitimate onboarding produces
+		// exactly one of these; an *unexpected* one is the fingerprint of the
+		// cross-provider takeover this binding defends against, so make it loud in
+		// the server log and on the events bus (dashboard stream + opt-in Apprise
+		// alert). The subject is deliberately omitted; it is an opaque provider id
+		// and the (provider, user) pair is enough to investigate.
+		debuglog.Warn("sso: account bound to a provider identity for the first time",
+			"provider", provider, "user_id", u.ID.String(), "email_masked", maskEmail(email))
+		events.Publish(events.Event{
+			Type:     "auth.sso_identity_bound",
+			Severity: "warning",
+			Source:   provider,
+			Message:  "A user account was linked to an SSO identity for the first time",
+			Metadata: map[string]any{
+				"provider": provider,
+				"user_id":  u.ID.String(),
+				"username": u.Username,
+			},
+		})
 	}
 	return u
 }

--- a/internal/adminauth/ssobinding.go
+++ b/internal/adminauth/ssobinding.go
@@ -6,23 +6,26 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/user"
 )
 
-// SSOUserResolver looks up a user account by verified email so OIDC/GitHub
-// logins can bind to a user row instead of the admin identity. Implemented by
+// SSOUserResolver binds an OIDC/GitHub login to a user account by verified
+// email, enforcing one external identity per account so a second provider
+// cannot take over an account by asserting its email. Implemented by
 // *user.Repository.
 type SSOUserResolver interface {
-	GetByEmail(ctx context.Context, email string) (*user.User, error)
+	ResolveSSOIdentity(ctx context.Context, provider, subject, email string) (*user.User, error)
 }
 
-// resolveSSOUser returns the enabled user bound to the verified email, or nil
-// when there is no binding (nil resolver, no row, or a disabled account).
-// Precedence is decided by the callers: the admin allowlist is checked first
-// and keeps its historical meaning, so an operator whose email is allowlisted
-// can never be silently downgraded to a user identity by a stray user row.
-func resolveSSOUser(ctx context.Context, users SSOUserResolver, email string) *user.User {
+// resolveSSOUser returns the enabled user bound to (provider, subject, email),
+// or nil when there is no valid binding: a nil resolver, no matching row, a
+// disabled account, or -- crucially -- an account already bound to a different
+// provider identity (ErrSSOMismatch). Precedence is decided by the callers: the
+// admin allowlist is checked first and keeps its historical meaning, so an
+// operator whose email is allowlisted can never be silently downgraded to a
+// user identity by a stray user row.
+func resolveSSOUser(ctx context.Context, users SSOUserResolver, provider, subject, email string) *user.User {
 	if users == nil {
 		return nil
 	}
-	u, err := users.GetByEmail(ctx, email)
+	u, err := users.ResolveSSOIdentity(ctx, provider, subject, email)
 	if err != nil || u == nil || !u.Enabled {
 		return nil
 	}

--- a/internal/adminauth/ssobinding_test.go
+++ b/internal/adminauth/ssobinding_test.go
@@ -6,9 +6,11 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 
+	"github.com/hugalafutro/model-hotel/internal/events"
 	"github.com/hugalafutro/model-hotel/internal/user"
 )
 
@@ -20,13 +22,13 @@ type fakeResolver struct {
 	bound   map[uuid.UUID][2]string // user id -> {provider, subject}
 }
 
-func (f *fakeResolver) ResolveSSOIdentity(_ context.Context, provider, subject, email string) (*user.User, error) {
+func (f *fakeResolver) ResolveSSOIdentity(_ context.Context, provider, subject, email string) (*user.User, bool, error) {
 	u, ok := f.byEmail[strings.ToLower(strings.TrimSpace(email))]
 	if !ok {
-		return nil, user.ErrNotFound
+		return nil, false, user.ErrNotFound
 	}
 	if !u.Enabled {
-		return nil, user.ErrNotFound
+		return nil, false, user.ErrNotFound
 	}
 	if f.bound == nil {
 		f.bound = map[uuid.UUID][2]string{}
@@ -34,12 +36,12 @@ func (f *fakeResolver) ResolveSSOIdentity(_ context.Context, provider, subject, 
 	id := [2]string{provider, subject}
 	if cur, ok := f.bound[u.ID]; ok {
 		if cur != id {
-			return nil, user.ErrSSOMismatch
+			return nil, false, user.ErrSSOMismatch
 		}
-	} else {
-		f.bound[u.ID] = id
+		return u, false, nil
 	}
-	return u, nil
+	f.bound[u.ID] = id
+	return u, true, nil
 }
 
 func boundUser(email string, enabled bool) (*user.User, *fakeResolver) {
@@ -67,6 +69,38 @@ func TestResolveSSOUser(t *testing.T) {
 	_, disabledRes := boundUser("off@example.com", false)
 	if got := resolveSSOUser(context.Background(), disabledRes, "oidc", "sub-1", "off@example.com"); got != nil {
 		t.Errorf("disabled user must not bind, got %v", got)
+	}
+}
+
+// A first-ever bind is surfaced on the events bus (guard #1: make an
+// unexpected first-bind loud), while a routine re-login of the same identity is
+// not.
+func TestResolveSSOUser_FirstBindPublishesEvent(t *testing.T) {
+	_, res := boundUser("worker@example.com", true)
+
+	ch := events.Subscribe()
+	defer events.Unsubscribe(ch)
+
+	if got := resolveSSOUser(context.Background(), res, "oidc", "iss#abc", "worker@example.com"); got == nil {
+		t.Fatal("first login should succeed")
+	}
+	select {
+	case ev := <-ch:
+		if ev.Type != "auth.sso_identity_bound" || ev.Severity != "warning" {
+			t.Fatalf("unexpected event: %+v", ev)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected an auth.sso_identity_bound event on first bind")
+	}
+
+	// Re-login with the same identity must NOT publish another bind event.
+	if got := resolveSSOUser(context.Background(), res, "oidc", "iss#abc", "worker@example.com"); got == nil {
+		t.Fatal("re-login should succeed")
+	}
+	select {
+	case ev := <-ch:
+		t.Fatalf("re-login must not publish a bind event, got %+v", ev)
+	case <-time.After(100 * time.Millisecond):
 	}
 }
 
@@ -101,8 +135,8 @@ type errResolver struct {
 	err error
 }
 
-func (e *errResolver) ResolveSSOIdentity(context.Context, string, string, string) (*user.User, error) {
-	return e.u, e.err
+func (e *errResolver) ResolveSSOIdentity(context.Context, string, string, string) (*user.User, bool, error) {
+	return e.u, false, e.err
 }
 
 // A transient lookup error (e.g. a DB blip during the OIDC/GitHub callback)

--- a/internal/adminauth/ssobinding_test.go
+++ b/internal/adminauth/ssobinding_test.go
@@ -12,16 +12,34 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/user"
 )
 
-// fakeResolver implements SSOUserResolver in memory (emails pre-normalized).
+// fakeResolver implements SSOUserResolver in memory (emails pre-normalized),
+// mirroring the repository's trust-on-first-use binding: the first (provider,
+// subject) to log in for an account locks it, and a later mismatch is denied.
 type fakeResolver struct {
 	byEmail map[string]*user.User
+	bound   map[uuid.UUID][2]string // user id -> {provider, subject}
 }
 
-func (f *fakeResolver) GetByEmail(_ context.Context, email string) (*user.User, error) {
-	if u, ok := f.byEmail[strings.ToLower(strings.TrimSpace(email))]; ok {
-		return u, nil
+func (f *fakeResolver) ResolveSSOIdentity(_ context.Context, provider, subject, email string) (*user.User, error) {
+	u, ok := f.byEmail[strings.ToLower(strings.TrimSpace(email))]
+	if !ok {
+		return nil, user.ErrNotFound
 	}
-	return nil, user.ErrNotFound
+	if !u.Enabled {
+		return nil, user.ErrNotFound
+	}
+	if f.bound == nil {
+		f.bound = map[uuid.UUID][2]string{}
+	}
+	id := [2]string{provider, subject}
+	if cur, ok := f.bound[u.ID]; ok {
+		if cur != id {
+			return nil, user.ErrSSOMismatch
+		}
+	} else {
+		f.bound[u.ID] = id
+	}
+	return u, nil
 }
 
 func boundUser(email string, enabled bool) (*user.User, *fakeResolver) {
@@ -37,18 +55,42 @@ func boundUser(email string, enabled bool) (*user.User, *fakeResolver) {
 
 func TestResolveSSOUser(t *testing.T) {
 	u, res := boundUser("worker@example.com", true)
-	if got := resolveSSOUser(context.Background(), res, "worker@example.com"); got == nil || got.ID != u.ID {
+	if got := resolveSSOUser(context.Background(), res, "oidc", "sub-1", "worker@example.com"); got == nil || got.ID != u.ID {
 		t.Errorf("expected binding, got %v", got)
 	}
-	if got := resolveSSOUser(context.Background(), res, "other@example.com"); got != nil {
+	if got := resolveSSOUser(context.Background(), res, "oidc", "sub-1", "other@example.com"); got != nil {
 		t.Errorf("unexpected binding for unknown email: %v", got)
 	}
-	if got := resolveSSOUser(context.Background(), nil, "worker@example.com"); got != nil {
+	if got := resolveSSOUser(context.Background(), nil, "oidc", "sub-1", "worker@example.com"); got != nil {
 		t.Errorf("nil resolver must yield nil, got %v", got)
 	}
 	_, disabledRes := boundUser("off@example.com", false)
-	if got := resolveSSOUser(context.Background(), disabledRes, "off@example.com"); got != nil {
+	if got := resolveSSOUser(context.Background(), disabledRes, "oidc", "sub-1", "off@example.com"); got != nil {
 		t.Errorf("disabled user must not bind, got %v", got)
+	}
+}
+
+// The core of vuln-0001: once an account is bound to one provider identity, a
+// second provider asserting the same verified email is denied, even though the
+// email matches a real, enabled account.
+func TestResolveSSOUser_CrossProviderDenied(t *testing.T) {
+	u, res := boundUser("worker@example.com", true)
+
+	// First login via OIDC binds the account.
+	if got := resolveSSOUser(context.Background(), res, "oidc", "iss#abc", "worker@example.com"); got == nil || got.ID != u.ID {
+		t.Fatalf("first OIDC login should bind, got %v", got)
+	}
+	// Same identity logs in again: still fine.
+	if got := resolveSSOUser(context.Background(), res, "oidc", "iss#abc", "worker@example.com"); got == nil {
+		t.Fatalf("same identity re-login should succeed, got nil")
+	}
+	// A GitHub login for the same email is a different identity: denied.
+	if got := resolveSSOUser(context.Background(), res, "github", "424242", "worker@example.com"); got != nil {
+		t.Errorf("cross-provider login must be denied, got %v", got)
+	}
+	// A different OIDC subject (same provider) is also denied.
+	if got := resolveSSOUser(context.Background(), res, "oidc", "iss#other", "worker@example.com"); got != nil {
+		t.Errorf("same provider, different subject must be denied, got %v", got)
 	}
 }
 
@@ -59,7 +101,7 @@ type errResolver struct {
 	err error
 }
 
-func (e *errResolver) GetByEmail(context.Context, string) (*user.User, error) {
+func (e *errResolver) ResolveSSOIdentity(context.Context, string, string, string) (*user.User, error) {
 	return e.u, e.err
 }
 
@@ -67,12 +109,12 @@ func (e *errResolver) GetByEmail(context.Context, string) (*user.User, error) {
 // must deny the login cleanly, never panic dereferencing a nil user.
 func TestResolveSSOUser_LookupErrorDenies(t *testing.T) {
 	res := &errResolver{err: errors.New("db unavailable")}
-	if got := resolveSSOUser(context.Background(), res, "worker@example.com"); got != nil {
+	if got := resolveSSOUser(context.Background(), res, "oidc", "sub-1", "worker@example.com"); got != nil {
 		t.Errorf("lookup error must yield nil, got %v", got)
 	}
 	// Defensive: a resolver that returns (nil, nil) must also be handled without
 	// a panic, regardless of the repository's not-found contract.
-	if got := resolveSSOUser(context.Background(), &errResolver{}, "worker@example.com"); got != nil {
+	if got := resolveSSOUser(context.Background(), &errResolver{}, "oidc", "sub-1", "worker@example.com"); got != nil {
 		t.Errorf("nil user with nil error must yield nil, got %v", got)
 	}
 }

--- a/internal/alert/catalog.go
+++ b/internal/alert/catalog.go
@@ -36,6 +36,7 @@ var catalog = []EventDef{
 	{Type: "failover.sync_error", Category: "Failover", Severity: "warning", DefaultOn: true},
 	{Type: "discovery.provider_failed", Category: "Discovery", Severity: "error", DefaultOn: false},
 	{Type: "fleet.conflict", Category: "High Availability", Severity: "warning", DefaultOn: true},
+	{Type: "auth.sso_identity_bound", Category: "Security", Severity: "warning", DefaultOn: false},
 }
 
 // Catalog returns a copy of the event registry, safe for the caller to mutate.

--- a/internal/db/migrations/057_user_sso_binding.sql
+++ b/internal/db/migrations/057_user_sso_binding.sql
@@ -1,0 +1,16 @@
+-- SSO provider identity binding. Previously an OIDC/GitHub login resolved a user
+-- account by verified email alone (idx_users_email), so ANY configured provider
+-- that could assert a victim's verified email would authenticate as that account
+-- -- cross-provider identity confusion (a low-trust second IdP impersonating an
+-- account provisioned via a trusted one). Record the (provider, subject) that
+-- first logs in for an account and reject later logins whose identity differs,
+-- even when the email matches. Columns stay NULL until an account's first SSO
+-- login (trust-on-first-use); password-only accounts never set them.
+ALTER TABLE users ADD COLUMN IF NOT EXISTS sso_provider TEXT;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS sso_subject  TEXT;
+
+-- One account per external identity: a given (provider, subject) binds to at
+-- most one user row, so a stolen subject cannot be pointed at a second account.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_sso_identity
+    ON users (sso_provider, sso_subject)
+    WHERE sso_provider IS NOT NULL;

--- a/internal/user/ssoidentity_test.go
+++ b/internal/user/ssoidentity_test.go
@@ -1,0 +1,93 @@
+package user
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// TestResolveSSOIdentity exercises the trust-on-first-use provider binding that
+// closes the cross-provider account-takeover hole: an account locks to the
+// first (provider, subject) that logs in, and any later identity is denied even
+// when the verified email matches.
+func TestResolveSSOIdentity(t *testing.T) {
+	repo := NewRepository(testDB.Pool())
+	ctx := context.Background()
+
+	email := "worker-" + uuid.NewString() + "@example.com"
+	u := mustCreate(t, repo, "worker-"+uuid.NewString(), &email, RoleUser, []string{"chat"})
+
+	// Unknown email: not found.
+	if _, err := repo.ResolveSSOIdentity(ctx, "oidc", "sub-1", "nobody@example.com"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("unknown email: got %v, want ErrNotFound", err)
+	}
+
+	// First login binds the identity and returns the account.
+	got, err := repo.ResolveSSOIdentity(ctx, "oidc", "iss#abc", email)
+	if err != nil {
+		t.Fatalf("first login: %v", err)
+	}
+	if got.ID != u.ID {
+		t.Fatalf("bound wrong account: %s want %s", got.ID, u.ID)
+	}
+	if got.SSOProvider == nil || *got.SSOProvider != "oidc" || got.SSOSubject == nil || *got.SSOSubject != "iss#abc" {
+		t.Fatalf("binding not recorded on returned user: %+v", got.SSOProvider)
+	}
+	// The binding persisted.
+	if reload, _ := repo.Get(ctx, u.ID); reload.SSOProvider == nil || *reload.SSOProvider != "oidc" {
+		t.Fatalf("binding not persisted: %+v", reload.SSOProvider)
+	}
+
+	// Same identity re-login: allowed.
+	if _, err := repo.ResolveSSOIdentity(ctx, "oidc", "iss#abc", email); err != nil {
+		t.Fatalf("same-identity re-login: %v", err)
+	}
+
+	// Different provider, same email: denied.
+	if _, err := repo.ResolveSSOIdentity(ctx, "github", "424242", email); !errors.Is(err, ErrSSOMismatch) {
+		t.Fatalf("cross-provider: got %v, want ErrSSOMismatch", err)
+	}
+	// Same provider, different subject: denied.
+	if _, err := repo.ResolveSSOIdentity(ctx, "oidc", "iss#other", email); !errors.Is(err, ErrSSOMismatch) {
+		t.Fatalf("different subject: got %v, want ErrSSOMismatch", err)
+	}
+}
+
+// A disabled account never binds or authenticates, matching GetByEmail's
+// enabled-only contract.
+func TestResolveSSOIdentity_DisabledDenied(t *testing.T) {
+	repo := NewRepository(testDB.Pool())
+	ctx := context.Background()
+
+	email := "off-" + uuid.NewString() + "@example.com"
+	u := mustCreate(t, repo, "off-"+uuid.NewString(), &email, RoleUser, []string{"chat"})
+	if _, err := repo.Update(ctx, u.ID, u.Username, u.DisplayName, &email, u.Role, u.Grants, false, Limits{}); err != nil {
+		t.Fatalf("disable: %v", err)
+	}
+	if _, err := repo.ResolveSSOIdentity(ctx, "oidc", "iss#abc", email); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("disabled account: got %v, want ErrNotFound", err)
+	}
+}
+
+// The same external identity cannot be pointed at a second account: the unique
+// index rejects the bind, surfaced as ErrSSOMismatch rather than a raw DB error.
+func TestResolveSSOIdentity_IdentityBindsAtMostOneAccount(t *testing.T) {
+	repo := NewRepository(testDB.Pool())
+	ctx := context.Background()
+
+	emailA := "a-" + uuid.NewString() + "@example.com"
+	emailB := "b-" + uuid.NewString() + "@example.com"
+	mustCreate(t, repo, "a-"+uuid.NewString(), &emailA, RoleUser, []string{"chat"})
+	mustCreate(t, repo, "b-"+uuid.NewString(), &emailB, RoleUser, []string{"chat"})
+
+	// Bind the GitHub identity 42 to account A.
+	if _, err := repo.ResolveSSOIdentity(ctx, "github", "42", emailA); err != nil {
+		t.Fatalf("bind A: %v", err)
+	}
+	// The same GitHub identity now asserting account B's email must be denied.
+	if _, err := repo.ResolveSSOIdentity(ctx, "github", "42", emailB); !errors.Is(err, ErrSSOMismatch) {
+		t.Fatalf("identity reuse across accounts: got %v, want ErrSSOMismatch", err)
+	}
+}

--- a/internal/user/ssoidentity_test.go
+++ b/internal/user/ssoidentity_test.go
@@ -20,14 +20,17 @@ func TestResolveSSOIdentity(t *testing.T) {
 	u := mustCreate(t, repo, "worker-"+uuid.NewString(), &email, RoleUser, []string{"chat"})
 
 	// Unknown email: not found.
-	if _, err := repo.ResolveSSOIdentity(ctx, "oidc", "sub-1", "nobody@example.com"); !errors.Is(err, ErrNotFound) {
+	if _, _, err := repo.ResolveSSOIdentity(ctx, "oidc", "sub-1", "nobody@example.com"); !errors.Is(err, ErrNotFound) {
 		t.Fatalf("unknown email: got %v, want ErrNotFound", err)
 	}
 
-	// First login binds the identity and returns the account.
-	got, err := repo.ResolveSSOIdentity(ctx, "oidc", "iss#abc", email)
+	// First login binds the identity, reports bound=true, returns the account.
+	got, bound, err := repo.ResolveSSOIdentity(ctx, "oidc", "iss#abc", email)
 	if err != nil {
 		t.Fatalf("first login: %v", err)
+	}
+	if !bound {
+		t.Fatalf("first login should report a new binding (bound=true)")
 	}
 	if got.ID != u.ID {
 		t.Fatalf("bound wrong account: %s want %s", got.ID, u.ID)
@@ -40,17 +43,17 @@ func TestResolveSSOIdentity(t *testing.T) {
 		t.Fatalf("binding not persisted: %+v", reload.SSOProvider)
 	}
 
-	// Same identity re-login: allowed.
-	if _, err := repo.ResolveSSOIdentity(ctx, "oidc", "iss#abc", email); err != nil {
-		t.Fatalf("same-identity re-login: %v", err)
+	// Same identity re-login: allowed, and NOT reported as a fresh binding.
+	if _, bound, err := repo.ResolveSSOIdentity(ctx, "oidc", "iss#abc", email); err != nil || bound {
+		t.Fatalf("same-identity re-login: err=%v bound=%v (want nil, false)", err, bound)
 	}
 
 	// Different provider, same email: denied.
-	if _, err := repo.ResolveSSOIdentity(ctx, "github", "424242", email); !errors.Is(err, ErrSSOMismatch) {
+	if _, _, err := repo.ResolveSSOIdentity(ctx, "github", "424242", email); !errors.Is(err, ErrSSOMismatch) {
 		t.Fatalf("cross-provider: got %v, want ErrSSOMismatch", err)
 	}
 	// Same provider, different subject: denied.
-	if _, err := repo.ResolveSSOIdentity(ctx, "oidc", "iss#other", email); !errors.Is(err, ErrSSOMismatch) {
+	if _, _, err := repo.ResolveSSOIdentity(ctx, "oidc", "iss#other", email); !errors.Is(err, ErrSSOMismatch) {
 		t.Fatalf("different subject: got %v, want ErrSSOMismatch", err)
 	}
 }
@@ -66,7 +69,7 @@ func TestResolveSSOIdentity_DisabledDenied(t *testing.T) {
 	if _, err := repo.Update(ctx, u.ID, u.Username, u.DisplayName, &email, u.Role, u.Grants, false, Limits{}); err != nil {
 		t.Fatalf("disable: %v", err)
 	}
-	if _, err := repo.ResolveSSOIdentity(ctx, "oidc", "iss#abc", email); !errors.Is(err, ErrNotFound) {
+	if _, _, err := repo.ResolveSSOIdentity(ctx, "oidc", "iss#abc", email); !errors.Is(err, ErrNotFound) {
 		t.Fatalf("disabled account: got %v, want ErrNotFound", err)
 	}
 }
@@ -83,11 +86,11 @@ func TestResolveSSOIdentity_IdentityBindsAtMostOneAccount(t *testing.T) {
 	mustCreate(t, repo, "b-"+uuid.NewString(), &emailB, RoleUser, []string{"chat"})
 
 	// Bind the GitHub identity 42 to account A.
-	if _, err := repo.ResolveSSOIdentity(ctx, "github", "42", emailA); err != nil {
+	if _, _, err := repo.ResolveSSOIdentity(ctx, "github", "42", emailA); err != nil {
 		t.Fatalf("bind A: %v", err)
 	}
 	// The same GitHub identity now asserting account B's email must be denied.
-	if _, err := repo.ResolveSSOIdentity(ctx, "github", "42", emailB); !errors.Is(err, ErrSSOMismatch) {
+	if _, _, err := repo.ResolveSSOIdentity(ctx, "github", "42", emailB); !errors.Is(err, ErrSSOMismatch) {
 		t.Fatalf("identity reuse across accounts: got %v, want ErrSSOMismatch", err)
 	}
 }

--- a/internal/user/user.go
+++ b/internal/user/user.go
@@ -163,15 +163,17 @@ func (r *Repository) GetByEmail(ctx context.Context, email string) (*User, error
 // rejected with ErrSSOMismatch even when the verified email matches, which
 // stops a second, lower-trust provider from impersonating the account. Unknown
 // emails and disabled accounts yield ErrNotFound. provider is a short constant
-// ("oidc", "github"); subject is the provider's stable, opaque per-user id.
-func (r *Repository) ResolveSSOIdentity(ctx context.Context, provider, subject, email string) (*User, error) {
+// ("oidc", "github"); subject is the provider's stable, opaque per-user id. The
+// returned bool is true only when this call recorded a first-ever binding, so
+// callers can surface that (audit/alert) distinctly from a routine re-login.
+func (r *Repository) ResolveSSOIdentity(ctx context.Context, provider, subject, email string) (*User, bool, error) {
 	e := NormalizeEmail(&email)
 	if e == nil {
-		return nil, ErrNotFound
+		return nil, false, ErrNotFound
 	}
 	tx, err := r.pool.Begin(ctx)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	defer func() { _ = tx.Rollback(ctx) }() // no-op once the tx commits
 
@@ -180,12 +182,13 @@ func (r *Repository) ResolveSSOIdentity(ctx context.Context, provider, subject, 
 	// different identities could both observe NULL and each overwrite the other.
 	u, err := scanUser(tx.QueryRow(ctx, `SELECT `+userColumns+` FROM users WHERE email = $1 FOR UPDATE`, *e))
 	if err != nil {
-		return nil, err // ErrNotFound when no row matches
+		return nil, false, err // ErrNotFound when no row matches
 	}
 	if !u.Enabled {
-		return nil, ErrNotFound
+		return nil, false, ErrNotFound
 	}
 
+	bound := false
 	switch {
 	case u.SSOProvider == nil:
 		// Trust-on-first-use: bind this identity to the account. A unique-index
@@ -195,20 +198,21 @@ func (r *Repository) ResolveSSOIdentity(ctx context.Context, provider, subject, 
 			`UPDATE users SET sso_provider = $2, sso_subject = $3 WHERE id = $1`,
 			u.ID, provider, subject); err != nil {
 			if isUniqueViolation(err) {
-				return nil, ErrSSOMismatch
+				return nil, false, ErrSSOMismatch
 			}
-			return nil, err
+			return nil, false, err
 		}
 		u.SSOProvider = &provider
 		u.SSOSubject = &subject
+		bound = true
 	case *u.SSOProvider != provider || u.SSOSubject == nil || *u.SSOSubject != subject:
-		return nil, ErrSSOMismatch
+		return nil, false, ErrSSOMismatch
 	}
 
 	if err := tx.Commit(ctx); err != nil {
-		return nil, err
+		return nil, false, err
 	}
-	return u, nil
+	return u, bound, nil
 }
 
 // isUniqueViolation reports whether err is a PostgreSQL unique-constraint

--- a/internal/user/user.go
+++ b/internal/user/user.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -26,6 +27,12 @@ const (
 
 // ErrNotFound is returned when no user matches the lookup.
 var ErrNotFound = errors.New("user not found")
+
+// ErrSSOMismatch is returned when a verified SSO email matches an account that
+// is already bound to a different provider identity. It denies cross-provider
+// takeover: an account first entered via one provider can never be assumed by
+// another provider that merely asserts the same verified email.
+var ErrSSOMismatch = errors.New("sso identity mismatch")
 
 // User is a dashboard account. PasswordHash never leaves the backend.
 type User struct {
@@ -49,6 +56,13 @@ type User struct {
 	// Derived from user_totp by the API layer (ListUsers), never scanned from
 	// the users table; false in Create/Update responses (the UI refetches).
 	TotpEnabled bool `json:"totp_enabled"`
+	// SSOProvider/SSOSubject lock the account to one external identity. NULL
+	// until the account's first OIDC/GitHub login, then the account can only be
+	// re-entered by that same (provider, subject) -- a second provider asserting
+	// the same verified email is rejected (see ResolveSSOIdentity). Never
+	// exposed over the API.
+	SSOProvider *string `json:"-"`
+	SSOSubject  *string `json:"-"`
 }
 
 // Repository provides CRUD over the users table.
@@ -61,13 +75,13 @@ func NewRepository(pool *pgxpool.Pool) *Repository {
 	return &Repository{pool: pool}
 }
 
-const userColumns = `id, username, display_name, email, password_hash, role, grants, enabled, created_at, updated_at, last_login_at, rate_limit_rps, rate_limit_burst, rate_limit_tpm`
+const userColumns = `id, username, display_name, email, password_hash, role, grants, enabled, created_at, updated_at, last_login_at, rate_limit_rps, rate_limit_burst, rate_limit_tpm, sso_provider, sso_subject`
 
 func scanUser(row pgx.Row) (*User, error) {
 	var u User
 	err := row.Scan(&u.ID, &u.Username, &u.DisplayName, &u.Email, &u.PasswordHash,
 		&u.Role, &u.Grants, &u.Enabled, &u.CreatedAt, &u.UpdatedAt, &u.LastLoginAt,
-		&u.RateLimitRPS, &u.RateLimitBurst, &u.RateLimitTPM)
+		&u.RateLimitRPS, &u.RateLimitBurst, &u.RateLimitTPM, &u.SSOProvider, &u.SSOSubject)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, ErrNotFound
 	}
@@ -140,6 +154,71 @@ func (r *Repository) GetByEmail(ctx context.Context, email string) (*User, error
 		return nil, ErrNotFound
 	}
 	return scanUser(r.pool.QueryRow(ctx, `SELECT `+userColumns+` FROM users WHERE email = $1`, *e))
+}
+
+// ResolveSSOIdentity binds an OIDC/GitHub login to a user account by verified
+// email while enforcing exactly one external identity per account. On an
+// account's first SSO login the (provider, subject) is recorded
+// (trust-on-first-use); afterwards a login whose (provider, subject) differs is
+// rejected with ErrSSOMismatch even when the verified email matches, which
+// stops a second, lower-trust provider from impersonating the account. Unknown
+// emails and disabled accounts yield ErrNotFound. provider is a short constant
+// ("oidc", "github"); subject is the provider's stable, opaque per-user id.
+func (r *Repository) ResolveSSOIdentity(ctx context.Context, provider, subject, email string) (*User, error) {
+	e := NormalizeEmail(&email)
+	if e == nil {
+		return nil, ErrNotFound
+	}
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }() // no-op once the tx commits
+
+	// FOR UPDATE serializes concurrent first-logins for the same email so the
+	// "is it bound yet?" check and the bind are atomic; without the row lock two
+	// different identities could both observe NULL and each overwrite the other.
+	u, err := scanUser(tx.QueryRow(ctx, `SELECT `+userColumns+` FROM users WHERE email = $1 FOR UPDATE`, *e))
+	if err != nil {
+		return nil, err // ErrNotFound when no row matches
+	}
+	if !u.Enabled {
+		return nil, ErrNotFound
+	}
+
+	switch {
+	case u.SSOProvider == nil:
+		// Trust-on-first-use: bind this identity to the account. A unique-index
+		// conflict means the identity is already bound to a different account,
+		// which is itself a cross-account mismatch, not a fresh binding.
+		if _, err := tx.Exec(ctx,
+			`UPDATE users SET sso_provider = $2, sso_subject = $3 WHERE id = $1`,
+			u.ID, provider, subject); err != nil {
+			if isUniqueViolation(err) {
+				return nil, ErrSSOMismatch
+			}
+			return nil, err
+		}
+		u.SSOProvider = &provider
+		u.SSOSubject = &subject
+	case *u.SSOProvider != provider || u.SSOSubject == nil || *u.SSOSubject != subject:
+		return nil, ErrSSOMismatch
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, err
+	}
+	return u, nil
+}
+
+// isUniqueViolation reports whether err is a PostgreSQL unique-constraint
+// violation (SQLSTATE 23505).
+func isUniqueViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		return pgErr.Code == "23505"
+	}
+	return false
 }
 
 // HasEnabled reports whether at least one enabled user exists, so the login


### PR DESCRIPTION
## What

Closes the cross-provider SSO identity-confusion hole (Strix vuln-0001) by binding each account to one external identity instead of resolving purely by verified email.

## Why

An OIDC/GitHub login resolved a user account by verified email alone (`resolveSSOUser` → `GetByEmail`), with no record of which provider owns the account. Any configured provider that could assert a victim's verified email would authenticate as that account and inherit its role, including admin. A low-trust second IdP could thus impersonate an account provisioned via a trusted one.

## Change

- **Migration 057**: nullable `sso_provider` / `sso_subject` on `users`, plus a partial unique index so one external identity binds to at most one account.
- **`user.ResolveSSOIdentity`**: transactional, row-locked trust-on-first-use bind. Records `(provider, subject)` on an account's first SSO login; rejects later logins whose identity differs with `ErrSSOMismatch`, even when the email matches. Replaces `GetByEmail` in the `SSOUserResolver` contract.
- OIDC binds on issuer-qualified `iss#sub`; GitHub on the stable numeric account id.
- **Guard #1 (defense-in-depth)**: a first-ever bind is legitimate during onboarding but an *unexpected* one is the fingerprint of the attack, so `ResolveSSOIdentity` reports whether it just bound; the callback logs a warning and publishes an `auth.sso_identity_bound` event (bus + dashboard stream + opt-in Apprise alert, default-off catalog entry). Re-logins publish nothing.

## Scope / notes

- Front Desk is unaffected: it wires no user resolver (admin-allowlist only).
- SSO never auto-provisions users; only admins create accounts, so the attack surface is "admin-created accounts whose email a configured provider will verify for an attacker." TOFU locks any account once its real user logs in; the only residual gap is an account that has never used SSO combined with a low-trust IdP.
- A pretty i18n label for the new alert event can follow via the translate workflow; the picker falls back to the raw type until then.

## Test

`go test ./internal/user ./internal/adminauth ./internal/alert ./internal/api ./internal/db` all pass; `golangci-lint` clean. New DB-backed tests cover TOFU bind, re-login, cross-provider deny, disabled, one-identity-one-account; adminauth tests cover cross-provider denial and the first-bind event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)