### PR TITLE
feat(xai): discover image-generation models

### DIFF
--- a/internal/provider/discovery_xai.go
+++ b/internal/provider/discovery_xai.go
@@ -65,6 +65,24 @@ func (d *DiscoveryService) discoverXAI(ctx context.Context, provider *Provider, 
 	// any catalog model the listing endpoints do not advertise (xAI keeps older
 	// grok models callable without listing them).
 	merged := mergeLiveAndCatalog(live, catalog)
+
+	// Image-generation models live on a separate endpoint from chat/language
+	// models. Discovery is best-effort: a failure here (e.g. no image scope) must
+	// not drop the language models we already have.
+	if imageModels, imgErr := d.discoverXAIImageModels(ctx, provider, apiKey, baseURL); imgErr != nil {
+		debuglog.Warn("discovery: xai image-model discovery failed", "provider", provider.Name, "provider_id", provider.ID, "error", imgErr)
+	} else {
+		existing := make(map[string]struct{}, len(merged))
+		for _, m := range merged {
+			existing[m.ModelID] = struct{}{}
+		}
+		for _, im := range imageModels {
+			if _, dup := existing[im.ModelID]; !dup {
+				merged = append(merged, im)
+			}
+		}
+	}
+
 	debuglog.Info("discovery: xai merged live + catalog", "provider", provider.Name, "provider_id", provider.ID, "live", len(live), "catalog", len(catalog), "merged", len(merged))
 	return merged, nil
 }
@@ -155,6 +173,82 @@ func (d *DiscoveryService) discoverXAILanguageModels(ctx context.Context, provid
 	}
 
 	debuglog.Info("discovery: xai discovered language models", "models", len(models), "provider", provider.Name, "provider_id", provider.ID)
+	return models, nil
+}
+
+// discoverXAIImageModels fetches the xAI image-generation catalog and maps it to
+// models with an "image" output modality. xAI serves image generation on the
+// same base as chat (/v1/images/generations), so unlike NanoGPT no base rewrite
+// is needed; only registration was missing. Image models bill per image, not per
+// token, so token price fields stay nil and the xAI image price (in xAI's native
+// units) is preserved in params.
+func (d *DiscoveryService) discoverXAIImageModels(ctx context.Context, provider *Provider, apiKey, baseURL string) ([]*model.Model, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", baseURL+"/image-generation-models", http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("xAI: failed to create image-models request for provider %s: %w", provider.Name, err)
+	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := d.doDiscoveryRequestPrebuilt(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("xAI: image-models request failed for provider %s: %w", provider.Name, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("xAI: failed to read image-models response for provider %s: %w", provider.Name, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("xAI: unexpected status %d from image-models for provider %s", resp.StatusCode, provider.Name)
+	}
+
+	var imgResp XAIImageGenerationModelsResponse
+	if err := json.Unmarshal(bodyBytes, &imgResp); err != nil {
+		return nil, fmt.Errorf("xAI: failed to decode image-models response: %w", err)
+	}
+
+	models := make([]*model.Model, 0, len(imgResp.Models))
+	for _, im := range imgResp.Models {
+		inputMods := im.InputModalities
+		if len(inputMods) == 0 {
+			inputMods = []string{"text"}
+		}
+		outputMods := im.OutputModalities
+		if len(outputMods) == 0 {
+			outputMods = []string{"image"}
+		}
+		modality := "text->image"
+		if slices.Contains(inputMods, "image") {
+			modality = "text+image->image"
+		}
+		inputModJSON, _ := json.Marshal(inputMods)
+		outputModJSON, _ := json.Marshal(outputMods)
+
+		paramsMap := map[string]any{"image_generation": true}
+		if im.ImagePrice > 0 {
+			paramsMap["image_price"] = im.ImagePrice
+		}
+		paramsJSON, _ := json.Marshal(paramsMap)
+
+		models = append(models, &model.Model{
+			ID:               uuid.New(),
+			ProviderID:       provider.ID,
+			ModelID:          im.ID,
+			Name:             im.ID,
+			DisplayName:      im.ID,
+			Capabilities:     "{}",
+			Params:           string(paramsJSON),
+			Modality:         modality,
+			InputModalities:  string(inputModJSON),
+			OutputModalities: string(outputModJSON),
+			OwnedBy:          im.OwnedBy,
+			Enabled:          true,
+		})
+	}
+
+	debuglog.Info("discovery: xai discovered image models", "models", len(models), "provider", provider.Name, "provider_id", provider.ID)
 	return models, nil
 }
 

--- a/internal/provider/discovery_xai_http_test.go
+++ b/internal/provider/discovery_xai_http_test.go
@@ -1122,3 +1122,158 @@ func TestDiscoverXAIImageModels_Non200IsError(t *testing.T) {
 		t.Fatal("expected error on non-200 image-models response")
 	}
 }
+
+// TestDiscoverXAI_UnionsImageModels drives the full discoverXAI path with both
+// the language and image endpoints populated, covering the best-effort image
+// append/dedup wiring in the merged path.
+func TestDiscoverXAI_UnionsImageModels(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/language-models":
+			_ = json.NewEncoder(w).Encode(XAILanguageModelsResponse{
+				Models: []XAILanguageModel{{
+					ID:               "grok-lang",
+					Object:           "model",
+					OwnedBy:          "xai",
+					Version:          "1.0",
+					InputModalities:  []string{"text"},
+					OutputModalities: []string{"text"},
+				}},
+			})
+		case "/image-generation-models":
+			_ = json.NewEncoder(w).Encode(XAIImageGenerationModelsResponse{
+				Models: []XAIImageGenerationModel{{
+					ID:               "grok-imagine-image",
+					Object:           "model",
+					OwnedBy:          "xai",
+					InputModalities:  []string{"text", "image"},
+					OutputModalities: []string{"image"},
+					ImagePrice:       200000000,
+				}},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	svc := &DiscoveryService{httpClient: server.Client()}
+	provider := &Provider{ID: uuid.New(), BaseURL: server.URL}
+
+	models, err := svc.discoverXAI(context.Background(), provider, "test-api-key")
+	if err != nil {
+		t.Fatalf("discoverXAI failed: %v", err)
+	}
+	var img *model.Model
+	for _, m := range models {
+		if m.ModelID == "grok-imagine-image" {
+			img = m
+		}
+	}
+	if img == nil {
+		t.Fatal("expected image model to be unioned into discoverXAI results")
+	}
+	if !strings.Contains(img.OutputModalities, "image") {
+		t.Errorf("image model output modalities = %q, want to contain image", img.OutputModalities)
+	}
+}
+
+// TestDiscoverXAIImageModels_EmptyModalitiesFallback covers the input/output
+// modality fallbacks and the text->image modality default.
+func TestDiscoverXAIImageModels_EmptyModalitiesFallback(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/image-generation-models" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(XAIImageGenerationModelsResponse{
+			Models: []XAIImageGenerationModel{{ID: "bare-image", OwnedBy: "xai"}},
+		})
+	}))
+	defer server.Close()
+
+	svc := &DiscoveryService{httpClient: server.Client()}
+	provider := &Provider{ID: uuid.New(), BaseURL: server.URL}
+
+	models, err := svc.discoverXAIImageModels(context.Background(), provider, "test-api-key", server.URL)
+	if err != nil {
+		t.Fatalf("discoverXAIImageModels failed: %v", err)
+	}
+	if len(models) != 1 {
+		t.Fatalf("expected 1 model, got %d", len(models))
+	}
+	m := models[0]
+	if m.InputModalities != `["text"]` {
+		t.Errorf("input modalities = %q, want [\"text\"] fallback", m.InputModalities)
+	}
+	if m.OutputModalities != `["image"]` {
+		t.Errorf("output modalities = %q, want [\"image\"] fallback", m.OutputModalities)
+	}
+	if m.Modality != "text->image" {
+		t.Errorf("modality = %q, want text->image", m.Modality)
+	}
+	if strings.Contains(m.Params, "image_price") {
+		t.Errorf("params = %q, should omit image_price when zero", m.Params)
+	}
+}
+
+// TestDiscoverXAIImageModels_InvalidJSONIsError covers the decode error path.
+func TestDiscoverXAIImageModels_InvalidJSONIsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("{not json"))
+	}))
+	defer server.Close()
+
+	svc := &DiscoveryService{httpClient: server.Client()}
+	provider := &Provider{ID: uuid.New(), BaseURL: server.URL}
+
+	if _, err := svc.discoverXAIImageModels(context.Background(), provider, "test-api-key", server.URL); err == nil {
+		t.Fatal("expected error decoding invalid JSON")
+	}
+}
+
+// TestDiscoverXAIImageModels_RequestBuildError covers the request-construction
+// error path via a base URL containing a control character.
+func TestDiscoverXAIImageModels_RequestBuildError(t *testing.T) {
+	svc := &DiscoveryService{httpClient: http.DefaultClient}
+	provider := &Provider{ID: uuid.New(), BaseURL: "http://\x7fbad"}
+
+	if _, err := svc.discoverXAIImageModels(context.Background(), provider, "test-api-key", "http://\x7fbad"); err == nil {
+		t.Fatal("expected error building request from an invalid base URL")
+	}
+}
+
+// TestDiscoverXAIImageModels_TransportError covers the transport-failure path by
+// pointing at a server that has already been closed.
+func TestDiscoverXAIImageModels_TransportError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	url := server.URL
+	server.Close()
+
+	svc := &DiscoveryService{httpClient: server.Client()}
+	provider := &Provider{ID: uuid.New(), BaseURL: url}
+
+	if _, err := svc.discoverXAIImageModels(context.Background(), provider, "test-api-key", url); err == nil {
+		t.Fatal("expected transport error against a closed server")
+	}
+}
+
+// TestDiscoverXAIImageModels_BodyReadError covers the response-read error path by
+// declaring a Content-Length larger than the body actually written, so the
+// client's io.ReadAll fails with an unexpected EOF.
+func TestDiscoverXAIImageModels_BodyReadError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Length", "1000")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("short"))
+	}))
+	defer server.Close()
+
+	svc := &DiscoveryService{httpClient: server.Client()}
+	provider := &Provider{ID: uuid.New(), BaseURL: server.URL}
+
+	if _, err := svc.discoverXAIImageModels(context.Background(), provider, "test-api-key", server.URL); err == nil {
+		t.Fatal("expected read error when the body is shorter than Content-Length")
+	}
+}

--- a/internal/provider/discovery_xai_http_test.go
+++ b/internal/provider/discovery_xai_http_test.go
@@ -1042,3 +1042,83 @@ func TestDiscoverXAI_LanguageModelsEmpty_MinimalModelsEmpty(t *testing.T) {
 		t.Errorf("expected 0 models when live is empty, got %d", len(models))
 	}
 }
+
+func TestDiscoverXAIImageModels(t *testing.T) {
+	imageServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/image-generation-models" || r.Method != "GET" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Header.Get("Authorization") != "Bearer test-api-key" {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+		response := XAIImageGenerationModelsResponse{
+			Models: []XAIImageGenerationModel{
+				{
+					ID:               "grok-imagine-image",
+					Object:           "model",
+					OwnedBy:          "xai",
+					Version:          "1.0",
+					InputModalities:  []string{"text", "image"},
+					OutputModalities: []string{"image"},
+					ImagePrice:       200000000,
+					Aliases:          []string{"grok-imagine-image-2026-03-02"},
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(response)
+	}))
+	defer imageServer.Close()
+
+	service := &DiscoveryService{httpClient: imageServer.Client()}
+	provider := &Provider{ID: uuid.New(), BaseURL: imageServer.URL}
+
+	models, err := service.discoverXAIImageModels(context.Background(), provider, "test-api-key", imageServer.URL)
+	if err != nil {
+		t.Fatalf("discoverXAIImageModels failed: %v", err)
+	}
+	if len(models) != 1 {
+		t.Fatalf("expected 1 image model, got %d", len(models))
+	}
+	m := models[0]
+	if m.ModelID != "grok-imagine-image" {
+		t.Errorf("model ID = %q, want grok-imagine-image", m.ModelID)
+	}
+	if !strings.Contains(m.OutputModalities, "image") {
+		t.Errorf("output modalities = %q, want to contain image", m.OutputModalities)
+	}
+	if !strings.Contains(m.InputModalities, "image") {
+		t.Errorf("input modalities = %q, want to contain image (grok image models take image input)", m.InputModalities)
+	}
+	if m.Modality != "text+image->image" {
+		t.Errorf("modality = %q, want text+image->image", m.Modality)
+	}
+	if !strings.Contains(m.Params, `"image_generation":true`) {
+		t.Errorf("params = %q, want image_generation true", m.Params)
+	}
+	if !strings.Contains(m.Params, `"image_price":200000000`) {
+		t.Errorf("params = %q, want image_price 200000000", m.Params)
+	}
+	if m.InputPricePerMillion != nil || m.OutputPricePerMillion != nil {
+		t.Error("image models must not carry token pricing")
+	}
+	if !m.Enabled {
+		t.Error("discovered image model should be enabled")
+	}
+}
+
+func TestDiscoverXAIImageModels_Non200IsError(t *testing.T) {
+	imageServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+	}))
+	defer imageServer.Close()
+
+	service := &DiscoveryService{httpClient: imageServer.Client()}
+	provider := &Provider{ID: uuid.New(), BaseURL: imageServer.URL}
+
+	if _, err := service.discoverXAIImageModels(context.Background(), provider, "test-api-key", imageServer.URL); err == nil {
+		t.Fatal("expected error on non-200 image-models response")
+	}
+}


### PR DESCRIPTION
## What

Makes xAI (Grok) image generation work through the proxy's `POST /v1/images/generations`. The `XAIImageGenerationModel` type existed (written from docs) but nothing ever fetched `/image-generation-models`, so image model names (`grok-imagine-image`, `grok-imagine-image-quality`) 404'd with `model not found`.

## Changes

- `discoverXAI` now also fetches `{base}/image-generation-models` and registers those models with an `image` output modality.
- xAI serves image generation on the **same base** as chat (`api.x.ai/v1/images/generations`), so — unlike the NanoGPT fix (#481) — **no `BuildProviderTargetURL` change is needed**.
- Best-effort: a missing image scope must not drop language models; results are deduped by `model_id` against the merged language + catalog set.
- Per-image pricing does not fit the token-based price schema, so token prices stay nil and the xAI image price (native units) lives in `params`.

No schema/migration change. No frontend change (the `image` modality badge already exists).

## Tests

- `TestDiscoverXAIImageModels`: maps the image catalog, asserts `image` output/input modality, `text+image->image`, params (`image_generation`, `image_price`), nil token pricing, enabled.
- `TestDiscoverXAIImageModels_Non200IsError`: non-200 surfaces an error (so the caller logs and skips, best-effort).

## Live E2E

Confirmed the upstream directly with a funded xAI key, rebuilt the dev container, pointed the dev xAI provider at the key, rediscovered (both image models registered, enabled, `output_modalities: ["image"]`), then `POST /v1/images/generations` with `xAI (Grok)/<model>` through a proxy virtual key:

| model | result |
|---|---|
| grok-imagine-image | 200, valid 1280×720 JPEG |
| grok-imagine-image-quality | 200, valid JPEG |

🤖 Generated with [Claude Code](https://claude.com/claude-code)