### PR TITLE
fix(discovery): classify image-generation models as image modality

### DIFF
--- a/internal/provider/discovery_nanogpt.go
+++ b/internal/provider/discovery_nanogpt.go
@@ -162,10 +162,8 @@ func (d *DiscoveryService) discoverNanoGPTImageModels(ctx context.Context, provi
 		}
 
 		inputMods := []string{"text"}
-		modality := "text->image"
 		if nanoGPTImageAcceptsImageInput(im.IconLabel) {
 			inputMods = []string{"text", "image"}
-			modality = "text+image->image"
 		}
 		inputModJSON, _ := json.Marshal(inputMods)
 		outputModJSON, _ := json.Marshal([]string{"image"})
@@ -196,7 +194,7 @@ func (d *DiscoveryService) discoverNanoGPTImageModels(ctx context.Context, provi
 			DisplayName:      displayName,
 			Capabilities:     "{}",
 			Params:           string(paramsJSON),
-			Modality:         modality,
+			Modality:         "image",
 			InputModalities:  string(inputModJSON),
 			OutputModalities: string(outputModJSON),
 			OwnedBy:          im.OwnedBy,

--- a/internal/provider/discovery_nanogpt_test.go
+++ b/internal/provider/discovery_nanogpt_test.go
@@ -684,8 +684,8 @@ func TestDiscoverNanoGPTImageModels_SubscriptionBaseFiltersIncluded(t *testing.T
 	if !strings.Contains(chroma.OutputModalities, "image") {
 		t.Errorf("chroma output modalities = %q, want to contain image", chroma.OutputModalities)
 	}
-	if chroma.Modality != "text->image" {
-		t.Errorf("chroma modality = %q, want text->image", chroma.Modality)
+	if chroma.Modality != "image" {
+		t.Errorf("chroma modality = %q, want image", chroma.Modality)
 	}
 	if !strings.Contains(chroma.Params, `"subscription_included":true`) {
 		t.Errorf("chroma params = %q, want subscription_included true", chroma.Params)
@@ -740,10 +740,12 @@ func TestDiscoverNanoGPTImageModels_EditModelAcceptsImageInput(t *testing.T) {
 		t.Fatal("expected step-image-edit-2 to be registered")
 	}
 	if !strings.Contains(edit.InputModalities, "image") {
-		t.Errorf("edit model input modalities = %q, want to contain image", edit.InputModalities)
+		t.Errorf("edit model input modalities = %q, want to contain image (editing model takes image input)", edit.InputModalities)
 	}
-	if edit.Modality != "text+image->image" {
-		t.Errorf("edit model modality = %q, want text+image->image", edit.Modality)
+	// Modality is the coarse non-chat classifier and is "image" for every image
+	// model regardless of whether it also accepts image input.
+	if edit.Modality != "image" {
+		t.Errorf("edit model modality = %q, want image", edit.Modality)
 	}
 }
 

--- a/internal/provider/discovery_xai.go
+++ b/internal/provider/discovery_xai.go
@@ -26,7 +26,7 @@ func (d *DiscoveryService) discoverXAI(ctx context.Context, provider *Provider, 
 		// Step 2: 403/429 (zero-balance or rate-limited account) -> catalog only.
 		if isNoAccessError(err) {
 			debuglog.Warn("discovery: xai /language-models returned no-access, using catalog", "status", errorStatusCode(err), "provider", provider.Name, "provider_id", provider.ID)
-			return catalog, nil
+			return d.appendXAIImageModels(ctx, provider, apiKey, baseURL, catalog), nil
 		}
 		// Step 3: Other failure -> try the minimal /models endpoint.
 		live, err = d.discoverXAIMinimalModels(ctx, provider, apiKey, baseURL)
@@ -34,7 +34,7 @@ func (d *DiscoveryService) discoverXAI(ctx context.Context, provider *Provider, 
 			// Step 4: /models also no-access -> catalog only.
 			if isNoAccessError(err) {
 				debuglog.Warn("discovery: xai /models also returned no-access, using catalog", "status", errorStatusCode(err), "provider", provider.Name, "provider_id", provider.ID)
-				return catalog, nil
+				return d.appendXAIImageModels(ctx, provider, apiKey, baseURL, catalog), nil
 			}
 			return nil, fmt.Errorf("xAI: failed to discover models for provider %s: both endpoints returned errors", provider.Name)
 		}
@@ -65,26 +65,34 @@ func (d *DiscoveryService) discoverXAI(ctx context.Context, provider *Provider, 
 	// any catalog model the listing endpoints do not advertise (xAI keeps older
 	// grok models callable without listing them).
 	merged := mergeLiveAndCatalog(live, catalog)
-
-	// Image-generation models live on a separate endpoint from chat/language
-	// models. Discovery is best-effort: a failure here (e.g. no image scope) must
-	// not drop the language models we already have.
-	if imageModels, imgErr := d.discoverXAIImageModels(ctx, provider, apiKey, baseURL); imgErr != nil {
-		debuglog.Warn("discovery: xai image-model discovery failed", "provider", provider.Name, "provider_id", provider.ID, "error", imgErr)
-	} else {
-		existing := make(map[string]struct{}, len(merged))
-		for _, m := range merged {
-			existing[m.ModelID] = struct{}{}
-		}
-		for _, im := range imageModels {
-			if _, dup := existing[im.ModelID]; !dup {
-				merged = append(merged, im)
-			}
-		}
-	}
+	merged = d.appendXAIImageModels(ctx, provider, apiKey, baseURL, merged)
 
 	debuglog.Info("discovery: xai merged live + catalog", "provider", provider.Name, "provider_id", provider.ID, "live", len(live), "catalog", len(catalog), "merged", len(merged))
 	return merged, nil
+}
+
+// appendXAIImageModels unions image-generation models onto base, deduplicated by
+// model ID. Image models live on a separate endpoint (/image-generation-models)
+// with its own access from chat/language models, so this runs on every return
+// path including the catalog-only no-access fallback: an account can lack
+// /language-models access while still generating images. Best-effort: a failure
+// (e.g. no image scope) leaves base untouched.
+func (d *DiscoveryService) appendXAIImageModels(ctx context.Context, provider *Provider, apiKey, baseURL string, base []*model.Model) []*model.Model {
+	imageModels, err := d.discoverXAIImageModels(ctx, provider, apiKey, baseURL)
+	if err != nil {
+		debuglog.Warn("discovery: xai image-model discovery failed", "provider", provider.Name, "provider_id", provider.ID, "error", err)
+		return base
+	}
+	existing := make(map[string]struct{}, len(base))
+	for _, m := range base {
+		existing[m.ModelID] = struct{}{}
+	}
+	for _, im := range imageModels {
+		if _, dup := existing[im.ModelID]; !dup {
+			base = append(base, im)
+		}
+	}
+	return base
 }
 
 func (d *DiscoveryService) discoverXAILanguageModels(ctx context.Context, provider *Provider, apiKey, baseURL string) ([]*model.Model, error) {
@@ -219,10 +227,6 @@ func (d *DiscoveryService) discoverXAIImageModels(ctx context.Context, provider 
 		if len(outputMods) == 0 {
 			outputMods = []string{"image"}
 		}
-		modality := "text->image"
-		if slices.Contains(inputMods, "image") {
-			modality = "text+image->image"
-		}
 		inputModJSON, _ := json.Marshal(inputMods)
 		outputModJSON, _ := json.Marshal(outputMods)
 
@@ -240,7 +244,7 @@ func (d *DiscoveryService) discoverXAIImageModels(ctx context.Context, provider 
 			DisplayName:      im.ID,
 			Capabilities:     "{}",
 			Params:           string(paramsJSON),
-			Modality:         modality,
+			Modality:         "image",
 			InputModalities:  string(inputModJSON),
 			OutputModalities: string(outputModJSON),
 			OwnedBy:          im.OwnedBy,

--- a/internal/provider/discovery_xai_http_test.go
+++ b/internal/provider/discovery_xai_http_test.go
@@ -1092,8 +1092,8 @@ func TestDiscoverXAIImageModels(t *testing.T) {
 	if !strings.Contains(m.InputModalities, "image") {
 		t.Errorf("input modalities = %q, want to contain image (grok image models take image input)", m.InputModalities)
 	}
-	if m.Modality != "text+image->image" {
-		t.Errorf("modality = %q, want text+image->image", m.Modality)
+	if m.Modality != "image" {
+		t.Errorf("modality = %q, want image", m.Modality)
 	}
 	if !strings.Contains(m.Params, `"image_generation":true`) {
 		t.Errorf("params = %q, want image_generation true", m.Params)
@@ -1179,7 +1179,7 @@ func TestDiscoverXAI_UnionsImageModels(t *testing.T) {
 }
 
 // TestDiscoverXAIImageModels_EmptyModalitiesFallback covers the input/output
-// modality fallbacks and the text->image modality default.
+// modality fallbacks and the "image" modality classification.
 func TestDiscoverXAIImageModels_EmptyModalitiesFallback(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/image-generation-models" {
@@ -1209,8 +1209,8 @@ func TestDiscoverXAIImageModels_EmptyModalitiesFallback(t *testing.T) {
 	if m.OutputModalities != `["image"]` {
 		t.Errorf("output modalities = %q, want [\"image\"] fallback", m.OutputModalities)
 	}
-	if m.Modality != "text->image" {
-		t.Errorf("modality = %q, want text->image", m.Modality)
+	if m.Modality != "image" {
+		t.Errorf("modality = %q, want image", m.Modality)
 	}
 	if strings.Contains(m.Params, "image_price") {
 		t.Errorf("params = %q, should omit image_price when zero", m.Params)
@@ -1275,5 +1275,50 @@ func TestDiscoverXAIImageModels_BodyReadError(t *testing.T) {
 
 	if _, err := svc.discoverXAIImageModels(context.Background(), provider, "test-api-key", server.URL); err == nil {
 		t.Fatal("expected read error when the body is shorter than Content-Length")
+	}
+}
+
+// TestDiscoverXAI_ImageModelsOnCatalogFallback verifies image models are still
+// unioned in when /language-models returns no-access (403) and discovery falls
+// back to the catalog: image generation has its own endpoint access.
+func TestDiscoverXAI_ImageModelsOnCatalogFallback(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/language-models", "/models":
+			http.Error(w, "forbidden", http.StatusForbidden)
+		case "/image-generation-models":
+			_ = json.NewEncoder(w).Encode(XAIImageGenerationModelsResponse{
+				Models: []XAIImageGenerationModel{{
+					ID:               "grok-imagine-image",
+					OwnedBy:          "xai",
+					InputModalities:  []string{"text", "image"},
+					OutputModalities: []string{"image"},
+					ImagePrice:       200000000,
+				}},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	svc := &DiscoveryService{httpClient: server.Client()}
+	provider := &Provider{ID: uuid.New(), BaseURL: server.URL}
+
+	models, err := svc.discoverXAI(context.Background(), provider, "test-api-key")
+	if err != nil {
+		t.Fatalf("discoverXAI failed: %v", err)
+	}
+	var img *model.Model
+	for _, m := range models {
+		if m.ModelID == "grok-imagine-image" {
+			img = m
+		}
+	}
+	if img == nil {
+		t.Fatal("expected image model to be unioned in on the catalog no-access fallback")
+	}
+	if img.Modality != "image" {
+		t.Errorf("image model modality = %q, want image", img.Modality)
 	}
 }

--- a/internal/provider/local_modality.go
+++ b/internal/provider/local_modality.go
@@ -2,8 +2,8 @@ package provider
 
 import "strings"
 
-// inferNonChatModality guesses a non-chat modality ("embedding" or "rerank")
-// from a model ID when the provider does not report one.
+// inferNonChatModality guesses a non-chat modality ("embedding", "rerank" or
+// "image") from a model ID when the provider does not report one.
 //
 // Self-hosted OpenAI-compatible servers (LM Studio's /v1/models, KoboldCPP,
 // llama.cpp, vLLM, LocalAI, text-generation-webui, ...) list embedding and
@@ -30,6 +30,14 @@ func inferNonChatModality(modelID string) string {
 	// embeddinggemma, gte-*-embedding, ...
 	if strings.Contains(id, "embed") {
 		return "embedding"
+	}
+
+	// Image-generation families: gpt-image-1/-mini/-2, chatgpt-image-*, dall-e-2/3.
+	// These emit images from a text prompt and — unlike vision (image *input*)
+	// chat models — can never serve /chat/completions, so they must be classified
+	// out of the chat/arena pickers rather than left to enrich to a chat modality.
+	if strings.Contains(id, "gpt-image") || strings.Contains(id, "dall-e") || strings.Contains(id, "dalle") {
+		return "image"
 	}
 
 	// Well-known embedding families that don't spell out "embed". Match them as

--- a/internal/provider/local_modality_test.go
+++ b/internal/provider/local_modality_test.go
@@ -31,11 +31,22 @@ func TestInferNonChatModality(t *testing.T) {
 		{"jina-reranker-v2-base-multilingual", "rerank"},
 		{"mxbai-rerank-large-v1", "rerank"},
 
+		// Image-generation families.
+		{"gpt-image-1", "image"},
+		{"gpt-image-1-mini", "image"},
+		{"gpt-image-1.5", "image"},
+		{"gpt-image-2", "image"},
+		{"chatgpt-image-latest", "image"},
+		{"dall-e-3", "image"},
+		{"dall-e-2", "image"},
+		{"dalle3", "image"},
+
 		// Chat / other models must not be hidden.
 		{"llama-3.1-8b-instruct", ""},
 		{"qwen2.5-coder-7b", ""},
 		{"mistral-7b-instruct", ""},
 		{"gpt-4o", ""},
+		{"gpt-4-vision-preview", ""}, // vision = image *input* chat, not image gen
 		{"gemma3:4b", ""},
 		{"deepseek-r1", ""},
 		{"", ""},


### PR DESCRIPTION
## What

Image-generation models were leaking into the chat/arena pickers. The picker filter (`isChatModel`, `web/src/utils/model.ts`) hides a model only when its `modality` is exactly one of `NON_CHAT_MODALITIES = {embedding, rerank, image, tts, stt}` — the pills predate non-chat models, so anything not classified out shows up where it can never work.

None of the image models set the canonical `image` modality:

| provider | was | now |
|---|---|---|
| OpenAI (gpt-image-\*, chatgpt-image-latest) | `vision` (enriched) | `image` |
| NanoGPT (chroma, hidream, …) | `text->image` | `image` |
| xAI (grok-imagine-image\*) | `text+image->image` | `image` |

## Changes

- **OpenAI:** `inferNonChatModality` now recognises the `gpt-image` and `dall-e`/`dalle` families and returns `image`. A set modality survives models.dev enrichment (same mechanism embeddings/rerank already rely on), so these no longer enrich to `vision`. Vision (image *input*) chat models like `gpt-4-vision-preview` are unaffected.
- **NanoGPT / xAI:** discovery now sets `modality: "image"` (the input/output modality arrays are unchanged, so editing models keep image input).
- **xAI no-access path:** image-generation models live on a separate endpoint (`/image-generation-models`) with its own access. `appendXAIImageModels` now runs on **every** `discoverXAI` return path — including the catalog-only 403/429 fallback — not just the merged live path. An account can lack `/language-models` access while still generating images (this repo's test account does exactly that).

No frontend change (`NON_CHAT_MODALITIES` already includes `image`); no migration.

## Tests

- `inferNonChatModality`: gpt-image/dall-e families → `image`; `gpt-4-vision-preview` stays chat.
- NanoGPT / xAI discovery: assert `modality "image"`.
- New `TestDiscoverXAI_ImageModelsOnCatalogFallback`: `/language-models` 403 → image models still unioned in with `modality "image"`.

## Live E2E

Rebuilt the dev container, rediscovered all three providers:

- OpenAI (6), NanoGPT (5), xAI (2) image models all report `modality "image"` and are excluded from the chat/arena pickers (`isChatModel = false`).
- Image generation still works through `POST /v1/images/generations` for all three.

## Follow-up (not in this PR)

xAI's `grok-imagine-video` (output `["video"]`, enriched to `modality "vision"`) also leaks into the chat picker — same class of bug, but fixing it needs a new `video` entry in `NON_CHAT_MODALITIES` on both sides. Flagging for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)