### PR TITLE
fix(web): hide media-generation models from chat pickers by output

### DIFF
--- a/web/src/utils/__tests__/model.test.ts
+++ b/web/src/utils/__tests__/model.test.ts
@@ -302,4 +302,33 @@ describe("isChatModel", () => {
 		expect(isChatModel({ modality: "" })).toBe(true);
 		expect(isChatModel({})).toBe(true);
 	});
+
+	it("excludes media-generation models by non-text output", () => {
+		// Video generator mislabelled "vision" (from image input): still excluded.
+		expect(
+			isChatModel({ modality: "vision", output_modalities: '["video"]' }),
+		).toBe(false);
+		expect(isChatModel({ output_modalities: '["image"]' })).toBe(false);
+		expect(isChatModel({ output_modalities: '["image","video"]' })).toBe(false);
+	});
+
+	it("keeps chat models that also emit media, and video-input chat models", () => {
+		// Outputs text alongside images → chat.
+		expect(
+			isChatModel({
+				modality: "vision",
+				output_modalities: '["text","image"]',
+			}),
+		).toBe(true);
+		// Video *input* chat model (outputs text) stays visible.
+		expect(
+			isChatModel({ modality: "video", output_modalities: '["text"]' }),
+		).toBe(true);
+	});
+
+	it("default-allows empty or malformed output_modalities", () => {
+		expect(isChatModel({ output_modalities: "" })).toBe(true);
+		expect(isChatModel({ output_modalities: "not-json" })).toBe(true);
+		expect(isChatModel({ output_modalities: "[]" })).toBe(true);
+	});
 });

--- a/web/src/utils/model.ts
+++ b/web/src/utils/model.ts
@@ -49,13 +49,37 @@ export const NON_CHAT_MODALITIES = new Set([
 	"stt",
 ]);
 
+/** Parse a model's output_modalities (a JSON array string) to a lowercased list. */
+function parseOutputModalities(raw: string | undefined): string[] {
+	if (!raw) return [];
+	try {
+		const arr = JSON.parse(raw);
+		if (Array.isArray(arr)) return arr.map((s) => String(s).toLowerCase());
+	} catch {
+		// Not a JSON array — treat as unknown (default-allow below).
+	}
+	return [];
+}
+
 /**
  * True when a model can serve /v1/chat/completions. Default-allow: unknown or
  * empty modalities are treated as chat so a new modality never silently
  * disappears from the picker.
+ *
+ * Two exclusions: an explicit non-chat modality (embedding/rerank/image/tts/stt),
+ * or an output that is non-text media only. The latter catches generation models
+ * (e.g. video output) whose modality string is a misleading chat label — an
+ * image->video model reported as "vision" from its image input — since a model
+ * that cannot emit text can never serve chat.
  */
-export function isChatModel(m: { modality?: string }): boolean {
-	return !NON_CHAT_MODALITIES.has((m.modality ?? "").toLowerCase());
+export function isChatModel(m: {
+	modality?: string;
+	output_modalities?: string;
+}): boolean {
+	if (NON_CHAT_MODALITIES.has((m.modality ?? "").toLowerCase())) return false;
+	const output = parseOutputModalities(m.output_modalities);
+	if (output.length > 0 && !output.includes("text")) return false;
+	return true;
 }
 
 export function formatPrice(n: number | null | undefined): string {


### PR DESCRIPTION
## What

Video-generation models (xAI `grok-imagine-image`/`grok-imagine-video`) leaked into the chat/arena pickers. `isChatModel` keyed only on the `modality` string, which is unreliable for this:
- `grok-imagine-video` is reported as `vision` (from its image *input*), so a modality allowlist misses it.
- 20+ real chat models legitimately carry `modality "video"` — that's video *input* (Gemini, Kimi, MiniMax, …), and they output text. Adding `video` to the non-chat set would wrongly hide all of them.

## Fix

`isChatModel` now also excludes a model whose **output** modalities are non-text media only (e.g. `["image"]`, `["video"]`). A model that cannot emit text can never serve `/chat/completions`, regardless of a misleading modality label. Chat models (any text output) and models with unknown/empty output stay visible (default-allow).

This is output-driven rather than a risky reclassification of the messy, multi-sourced `modality` field — so it needs no backend/discovery changes and can't collaterally hide video-*input* chat models.

## Why not the backend

I prototyped classifying `modality` at discovery time, but the modality string is set inconsistently across providers and an enrichment guard blocks re-classifying an already-set value, so it both missed `grok-imagine-video` (still `vision`) and would have hidden ~20 video-*input* chat models until every provider re-discovered. Output is the reliable signal.

## Tests

- `isChatModel`: excludes `{modality:"vision", output:["video"]}`, `["image"]`, `["image","video"]`; keeps `["text","image"]` and video-input chat (`{modality:"video", output:["text"]}`); default-allows empty/malformed output.

## Verification

Simulated the exact `isChatModel` logic over the live `/api/models` catalogue:
- `grok-imagine-video` → excluded.
- All 20 non-text-output generation models (image gen, video gen, embeddings) → excluded.
- **Zero** text-output chat models affected (Gemini/Kimi/MiniMax stay visible).

Plus `tsc -b`, eslint, and 49 unit tests green; production frontend build embeds cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)