### PR TITLE
feat(frontdesk): fleet-status state machine (Slice A, backend)

### DIFF
--- a/cmd/frontdesk/main.go
+++ b/cmd/frontdesk/main.go
@@ -142,6 +142,7 @@ func main() {
 
 	go poller.Run(ctx)
 	go srv.RunAutoSync(ctx)
+	go srv.RunFleetState(ctx)
 	go srv.RunAlerts(ctx)
 
 	httpServer := &http.Server{

--- a/internal/frontdesk/alerts.go
+++ b/internal/frontdesk/alerts.go
@@ -45,6 +45,9 @@ var fdCatalog = []alert.EventDef{
 	{Type: "version.fetch_recovered", Category: "Member Reads", Severity: "success", DefaultOn: false},
 	// Traefik dynamic-config staleness.
 	{Type: "traefik.stale", Category: "Routing", Severity: "warning", DefaultOn: false},
+	// The fleet state machine crossed a boundary (ok/degraded/faulty). Reason
+	// codes ride the event metadata; severity mirrors the state entered.
+	{Type: "fleet.state_changed", Category: "Health", Severity: "warning", DefaultOn: false},
 	// Fleet roster + drain/active changes.
 	{Type: "member.added", Category: "Membership", Severity: "info", DefaultOn: false},
 	{Type: "member.removed", Category: "Membership", Severity: "info", DefaultOn: false},

--- a/internal/frontdesk/autosync.go
+++ b/internal/frontdesk/autosync.go
@@ -63,24 +63,48 @@ const (
 	// primary. A day is long enough that a brief manual-sync gap never trips it,
 	// short enough that a fleet left un-synced surfaces within the same day.
 	autoSyncStaleThreshold = 24 * time.Hour
+
+	// autoSyncFaultyThreshold is the second staleness tier: with auto-sync off, a
+	// fleet unsynced this long is treated as faulty by the fleet state machine
+	// (fleetstate.go), not merely degraded. Three days: long enough that a weekend
+	// gap alone never trips it, short enough that a forgotten fleet escalates
+	// within the working week.
+	autoSyncFaultyThreshold = 72 * time.Hour
 )
 
-// autoSyncStale reports whether the fleet's config is at risk of silent drift: a
-// primary is designated but auto-sync is off, and the last successful fleet sync
-// is older than autoSyncStaleThreshold (or never ran). It is deliberately false
-// when auto-sync is on (the loop keeps the fleet fresh and reports its own
-// failures via config.sync_failed) and when no primary is configured — the
-// operator never opted into the sync model, so "stale" would be meaningless and,
-// since auto-sync is off by default, would otherwise fire on every fresh install.
-// haveSync is false when no successful sync has ever been recorded.
-func autoSyncStale(cfg AutoSyncConfig, lastSync time.Time, haveSync bool, now time.Time) bool {
+// autoSyncStaleTier grades the fleet's silent-drift risk: 0 fresh (or auto-sync
+// on / no primary designated, where staleness is meaningless), 1 unsynced beyond
+// autoSyncStaleThreshold (degraded), 2 beyond autoSyncFaultyThreshold (faulty).
+// A fleet with no recorded sync at all is tier 1: there is no timestamp to age
+// against, so it cannot honestly escalate to tier 2. haveSync is false when no
+// successful sync has ever been recorded.
+func autoSyncStaleTier(cfg AutoSyncConfig, lastSync time.Time, haveSync bool, now time.Time) int {
 	if cfg.Enabled || cfg.PrimaryID == "" {
-		return false
+		return 0
 	}
 	if !haveSync {
-		return true
+		return 1
 	}
-	return now.Sub(lastSync) > autoSyncStaleThreshold
+	switch age := now.Sub(lastSync); {
+	case age > autoSyncFaultyThreshold:
+		return 2
+	case age > autoSyncStaleThreshold:
+		return 1
+	}
+	return 0
+}
+
+// autoSyncStale reports whether the fleet's config is at risk of silent drift. It
+// delegates to autoSyncStaleTier and is true for tier >= 1: a primary is
+// designated but auto-sync is off, and the last successful fleet sync is older
+// than autoSyncStaleThreshold (or never ran). It is deliberately false when
+// auto-sync is on (the loop keeps the fleet fresh and reports its own failures
+// via config.sync_failed) and when no primary is configured — the operator never
+// opted into the sync model, so "stale" would be meaningless and, since auto-sync
+// is off by default, would otherwise fire on every fresh install. haveSync is
+// false when no successful sync has ever been recorded.
+func autoSyncStale(cfg AutoSyncConfig, lastSync time.Time, haveSync bool, now time.Time) bool {
+	return autoSyncStaleTier(cfg, lastSync, haveSync, now) >= 1
 }
 
 // RunAutoSync samples the designated primary on a fixed tick and propagates its

--- a/internal/frontdesk/autosync.go
+++ b/internal/frontdesk/autosync.go
@@ -94,15 +94,10 @@ func autoSyncStaleTier(cfg AutoSyncConfig, lastSync time.Time, haveSync bool, no
 	return 0
 }
 
-// autoSyncStale reports whether the fleet's config is at risk of silent drift. It
-// delegates to autoSyncStaleTier and is true for tier >= 1: a primary is
-// designated but auto-sync is off, and the last successful fleet sync is older
-// than autoSyncStaleThreshold (or never ran). It is deliberately false when
-// auto-sync is on (the loop keeps the fleet fresh and reports its own failures
-// via config.sync_failed) and when no primary is configured — the operator never
-// opted into the sync model, so "stale" would be meaningless and, since auto-sync
-// is off by default, would otherwise fire on every fresh install. haveSync is
-// false when no successful sync has ever been recorded.
+// autoSyncStale reports whether the fleet's config is at risk of silent drift:
+// true exactly when autoSyncStaleTier returns 1 or higher (see it for the full
+// rule and rationale). Retained as the boolean that the config.autosync_stale
+// watchdog and the autosync payload's Stale flag consume.
 func autoSyncStale(cfg AutoSyncConfig, lastSync time.Time, haveSync bool, now time.Time) bool {
 	return autoSyncStaleTier(cfg, lastSync, haveSync, now) >= 1
 }

--- a/internal/frontdesk/autosync_test.go
+++ b/internal/frontdesk/autosync_test.go
@@ -1355,3 +1355,30 @@ func TestAutoSyncHoldsVersionSkew(t *testing.T) {
 		t.Error("aligned member was not synced once the hold cleared")
 	}
 }
+
+func TestAutoSyncStaleTier(t *testing.T) {
+	now := time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC)
+	off := AutoSyncConfig{Enabled: false, PrimaryID: "p1"}
+	cases := []struct {
+		name     string
+		cfg      AutoSyncConfig
+		lastSync time.Time
+		haveSync bool
+		want     int
+	}{
+		{"enabled is never stale", AutoSyncConfig{Enabled: true, PrimaryID: "p1"}, now.Add(-100 * time.Hour), true, 0},
+		{"no primary is never stale", AutoSyncConfig{}, now.Add(-100 * time.Hour), true, 0},
+		{"fresh sync", off, now.Add(-1 * time.Hour), true, 0},
+		{"never synced caps at tier 1", off, time.Time{}, false, 1},
+		{"just over a day", off, now.Add(-25 * time.Hour), true, 1},
+		{"just under three days", off, now.Add(-71 * time.Hour), true, 1},
+		{"over three days", off, now.Add(-73 * time.Hour), true, 2},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := autoSyncStaleTier(tc.cfg, tc.lastSync, tc.haveSync, now); got != tc.want {
+				t.Errorf("tier = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/frontdesk/fleetstate.go
+++ b/internal/frontdesk/fleetstate.go
@@ -1,5 +1,14 @@
 package frontdesk
 
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hugalafutro/model-hotel/internal/debuglog"
+)
+
 // This file computes the fleet-wide state machine: one server-side judgment of
 // "how is the fleet doing" (ok / degraded / faulty) with machine-readable
 // reason codes, so every client (Front Desk web, Bellhop) translates the same
@@ -116,4 +125,112 @@ func computeFleetState(in fleetStateInput) (FleetState, []string) {
 		}
 	}
 	return state, reasons
+}
+
+// fleetStateInterval is how often RunFleetState re-judges the fleet. Matches
+// the default poll cadence; the inputs are in-memory snapshots plus three
+// cheap settings reads, so a tight tick costs little.
+const fleetStateInterval = 5 * time.Second
+
+// heldSnapshot copies the autosync version-skew hold set under its lock.
+func (s *Server) heldSnapshot() map[string]bool {
+	s.syncHeldMu.Lock()
+	defer s.syncHeldMu.Unlock()
+	out := make(map[string]bool, len(s.syncHeld))
+	for k, v := range s.syncHeld {
+		out[k] = v
+	}
+	return out
+}
+
+// fleetStateNow gathers the live inputs and computes the current fleet state.
+func (s *Server) fleetStateNow(ctx context.Context) (FleetState, []string, error) {
+	members, err := s.store.ListMembers(ctx)
+	if err != nil {
+		return "", nil, err
+	}
+	cfg, err := s.store.GetAutoSync(ctx)
+	if err != nil {
+		return "", nil, err
+	}
+	syncState, haveSync, err := s.store.GetFleetSyncState(ctx)
+	if err != nil {
+		return "", nil, err
+	}
+	statuses := s.poller.Snapshot()
+	held := s.heldSnapshot()
+	facts := make([]memberFleetFacts, 0, len(members))
+	for _, m := range members {
+		st := statuses[m.ID]
+		facts = append(facts, memberFleetFacts{
+			Known:    st.Health.Known,
+			Healthy:  st.Health.Healthy,
+			Syncable: m.HasToken && m.ID != cfg.PrimaryID,
+			Held:     held[m.ID],
+		})
+	}
+	state, reasons := computeFleetState(fleetStateInput{
+		Members:      facts,
+		AutoSyncTier: autoSyncStaleTier(cfg, syncState.LastRunAt, haveSync, time.Now().UTC()),
+		TraefikStale: s.poller.ConfigPollStale(ctx),
+	})
+	return state, reasons, nil
+}
+
+// checkFleetState computes the state and emits fleet.state_changed exactly on
+// transitions. Split from RunFleetState so tests drive ticks directly.
+func (s *Server) checkFleetState(ctx context.Context) {
+	cur, reasons, err := s.fleetStateNow(ctx)
+	if err != nil {
+		debuglog.Warn("frontdesk: fleet state", "error", err)
+		return
+	}
+	s.fleetStateMu.Lock()
+	prev := s.fleetStatePrev
+	if prev == "" {
+		prev = FleetOK
+	}
+	changed := cur != prev
+	s.fleetStatePrev = cur
+	s.fleetStateMu.Unlock()
+	if changed {
+		s.emit(ctx, fleetStateEvent(prev, cur, reasons))
+	}
+}
+
+// fleetStateEvent shapes the edge-triggered transition event. The message is
+// operator-log prose; clients translate from the metadata reason codes, never
+// from this string.
+func fleetStateEvent(from, to FleetState, reasons []string) Event {
+	sev := "success"
+	switch to {
+	case FleetDegraded:
+		sev = "warning"
+	case FleetFaulty:
+		sev = "error"
+	}
+	msg := fmt.Sprintf("Fleet state changed: %s to %s", from, to)
+	if len(reasons) > 0 {
+		msg += " (" + strings.Join(reasons, ", ") + ")"
+	}
+	return Event{
+		Type: "fleet.state_changed", Severity: sev, Source: "frontdesk",
+		Message:  msg,
+		Metadata: map[string]any{"from": string(from), "to": string(to), "reasons": reasons},
+	}
+}
+
+// RunFleetState re-judges the fleet on a fixed tick until ctx is cancelled.
+// Started once at startup, alongside RunAutoSync.
+func (s *Server) RunFleetState(ctx context.Context) {
+	ticker := time.NewTicker(fleetStateInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.checkFleetState(ctx)
+		}
+	}
 }

--- a/internal/frontdesk/fleetstate.go
+++ b/internal/frontdesk/fleetstate.go
@@ -1,0 +1,119 @@
+package frontdesk
+
+// This file computes the fleet-wide state machine: one server-side judgment of
+// "how is the fleet doing" (ok / degraded / faulty) with machine-readable
+// reason codes, so every client (Front Desk web, Bellhop) translates the same
+// verdict instead of re-deriving its own from raw member rows. Severity is by
+// blast radius, never by comparing version strings (dev builds are
+// unorderable): some tokened members sync-held means those members drift
+// (degraded); ALL of them held means the primary itself is the odd one out and
+// nothing can converge (faulty). Distinct file from fleetstatus.go, which is
+// the sync wizard's per-member convergence probe.
+
+// FleetState is the server-computed fleet condition, spelled exactly as it
+// travels on the wire (fleet_state on GET /api/fleet/autosync).
+type FleetState string
+
+// The three fleet conditions, ordered by severity.
+const (
+	FleetOK       FleetState = "ok"
+	FleetDegraded FleetState = "degraded"
+	FleetFaulty   FleetState = "faulty"
+)
+
+// Reason codes carried in fleet_state_reasons and the fleet.state_changed
+// event. Wire constants: clients key translations off them, so never rename.
+const (
+	reasonMemberDown        = "member_down"
+	reasonAllMembersDown    = "all_members_down"
+	reasonSyncHeld          = "sync_held"
+	reasonAllSyncHeld       = "all_sync_held"
+	reasonAutosyncStale     = "autosync_stale"
+	reasonAutosyncStaleLong = "autosync_stale_long"
+	reasonTraefikStale      = "traefik_stale"
+)
+
+// fleetFaultyReasons is the subset of reason codes that escalate the state to
+// faulty; every other reason yields degraded.
+var fleetFaultyReasons = map[string]bool{
+	reasonAllMembersDown:    true,
+	reasonAllSyncHeld:       true,
+	reasonAutosyncStaleLong: true,
+	reasonTraefikStale:      true,
+}
+
+// memberFleetFacts is the per-member slice of the state machine's input:
+// health as confirmed by the poller (Known false means never probed, which
+// counts as neither up nor down), and whether the member is a sync-hold
+// candidate (tokened, non-primary) currently held for version skew.
+type memberFleetFacts struct {
+	Known    bool
+	Healthy  bool
+	Syncable bool
+	Held     bool
+}
+
+// fleetStateInput bundles everything computeFleetState judges: member facts,
+// the autosync staleness tier (autoSyncStaleTier), and whether Traefik has
+// stopped fetching the dynamic config (Poller.ConfigPollStale).
+type fleetStateInput struct {
+	Members      []memberFleetFacts
+	AutoSyncTier int
+	TraefikStale bool
+}
+
+// computeFleetState reduces the input to a state plus the active reason codes,
+// in a fixed order (health, sync holds, autosync staleness, Traefik) so equal
+// inputs always serialize identically. Pure: all live reads happen in the
+// Server wrapper (fleetStateNow), keeping this exhaustively table-testable.
+func computeFleetState(in fleetStateInput) (FleetState, []string) {
+	var down, held, syncable int
+	for _, m := range in.Members {
+		if m.Known && !m.Healthy {
+			down++
+		}
+		if m.Syncable {
+			syncable++
+			if m.Held {
+				held++
+			}
+		}
+	}
+
+	var reasons []string
+	switch {
+	case len(in.Members) > 0 && down == len(in.Members):
+		reasons = append(reasons, reasonAllMembersDown)
+	case down > 0:
+		reasons = append(reasons, reasonMemberDown)
+	}
+	switch {
+	// With a single candidate there is no way to tell which side of the skew is
+	// the odd one out, so it stays a per-member degradation.
+	case syncable >= 2 && held == syncable:
+		reasons = append(reasons, reasonAllSyncHeld)
+	case held > 0:
+		reasons = append(reasons, reasonSyncHeld)
+	}
+	switch in.AutoSyncTier {
+	case 2:
+		reasons = append(reasons, reasonAutosyncStaleLong)
+	case 1:
+		reasons = append(reasons, reasonAutosyncStale)
+	}
+	if in.TraefikStale {
+		reasons = append(reasons, reasonTraefikStale)
+	}
+
+	state := FleetOK
+	if len(reasons) > 0 {
+		state = FleetDegraded
+	}
+	for _, r := range reasons {
+		if fleetFaultyReasons[r] {
+			state = FleetFaulty
+			break
+		}
+	}
+	return state, reasons
+}

--- a/internal/frontdesk/fleetstate.go
+++ b/internal/frontdesk/fleetstate.go
@@ -144,6 +144,8 @@ func (s *Server) heldSnapshot() map[string]bool {
 }
 
 // fleetStateNow gathers the live inputs and computes the current fleet state.
+// The background loop uses this self-contained form; autoSyncStatusNow reuses
+// reads it has already made by calling fleetStateFrom directly.
 func (s *Server) fleetStateNow(ctx context.Context) (FleetState, []string, error) {
 	members, err := s.store.ListMembers(ctx)
 	if err != nil {
@@ -157,6 +159,16 @@ func (s *Server) fleetStateNow(ctx context.Context) (FleetState, []string, error
 	if err != nil {
 		return "", nil, err
 	}
+	state, reasons := s.fleetStateFrom(ctx, members, cfg, syncState.LastRunAt, haveSync)
+	return state, reasons, nil
+}
+
+// fleetStateFrom assembles the per-member facts from already-read store data
+// (member list, auto-sync config, last-sync marker) and computes the state,
+// folding in the live poller snapshots (health, Traefik staleness) and the
+// version-skew hold set. Callers that already hold those reads pass them in so
+// the polled /api/fleet/autosync endpoint does not re-query the store.
+func (s *Server) fleetStateFrom(ctx context.Context, members []*Member, cfg AutoSyncConfig, lastSync time.Time, haveSync bool) (FleetState, []string) {
 	statuses := s.poller.Snapshot()
 	held := s.heldSnapshot()
 	facts := make([]memberFleetFacts, 0, len(members))
@@ -169,12 +181,11 @@ func (s *Server) fleetStateNow(ctx context.Context) (FleetState, []string, error
 			Held:     held[m.ID],
 		})
 	}
-	state, reasons := computeFleetState(fleetStateInput{
+	return computeFleetState(fleetStateInput{
 		Members:      facts,
-		AutoSyncTier: autoSyncStaleTier(cfg, syncState.LastRunAt, haveSync, time.Now().UTC()),
+		AutoSyncTier: autoSyncStaleTier(cfg, lastSync, haveSync, time.Now().UTC()),
 		TraefikStale: s.poller.ConfigPollStale(ctx),
 	})
-	return state, reasons, nil
 }
 
 // checkFleetState computes the state and emits fleet.state_changed exactly on

--- a/internal/frontdesk/fleetstate.go
+++ b/internal/frontdesk/fleetstate.go
@@ -39,16 +39,20 @@ const (
 	reasonAllSyncHeld       = "all_sync_held"
 	reasonAutosyncStale     = "autosync_stale"
 	reasonAutosyncStaleLong = "autosync_stale_long"
-	reasonTraefikStale      = "traefik_stale"
+	// traefik_config_stale is config-poll staleness specifically (Traefik stopped
+	// fetching the dynamic config), not a member's data-plane serverStatus; named
+	// to keep it distinct from the traefik.stale alert event and the per-member
+	// traefik_status badge.
+	reasonTraefikConfigStale = "traefik_config_stale"
 )
 
 // fleetFaultyReasons is the subset of reason codes that escalate the state to
 // faulty; every other reason yields degraded.
 var fleetFaultyReasons = map[string]bool{
-	reasonAllMembersDown:    true,
-	reasonAllSyncHeld:       true,
-	reasonAutosyncStaleLong: true,
-	reasonTraefikStale:      true,
+	reasonAllMembersDown:     true,
+	reasonAllSyncHeld:        true,
+	reasonAutosyncStaleLong:  true,
+	reasonTraefikConfigStale: true,
 }
 
 // memberFleetFacts is the per-member slice of the state machine's input:
@@ -111,7 +115,7 @@ func computeFleetState(in fleetStateInput) (FleetState, []string) {
 		reasons = append(reasons, reasonAutosyncStale)
 	}
 	if in.TraefikStale {
-		reasons = append(reasons, reasonTraefikStale)
+		reasons = append(reasons, reasonTraefikConfigStale)
 	}
 
 	state := FleetOK
@@ -132,7 +136,12 @@ func computeFleetState(in fleetStateInput) (FleetState, []string) {
 // cheap settings reads, so a tight tick costs little.
 const fleetStateInterval = 5 * time.Second
 
-// heldSnapshot copies the autosync version-skew hold set under its lock.
+// heldSnapshot copies the autosync version-skew hold set under its lock. The
+// auto-sync loop owns the set; if auto-sync is disabled while members are held,
+// the set stays frozen rather than clearing, so those members keep contributing
+// sync_held / all_sync_held. That direction is deliberate: a stale hold degrades
+// the fleet state, it never reports a false ok, and it clears when auto-sync
+// resumes or the skew resolves.
 func (s *Server) heldSnapshot() map[string]bool {
 	s.syncHeldMu.Lock()
 	defer s.syncHeldMu.Unlock()
@@ -193,7 +202,7 @@ func (s *Server) fleetStateFrom(ctx context.Context, members []*Member, cfg Auto
 func (s *Server) checkFleetState(ctx context.Context) {
 	cur, reasons, err := s.fleetStateNow(ctx)
 	if err != nil {
-		debuglog.Warn("frontdesk: fleet state", "error", err)
+		debuglog.Warn("frontdesk: compute fleet state", "error", err)
 		return
 	}
 	s.fleetStateMu.Lock()
@@ -213,6 +222,12 @@ func (s *Server) checkFleetState(ctx context.Context) {
 // operator-log prose; clients translate from the metadata reason codes, never
 // from this string.
 func fleetStateEvent(from, to FleetState, reasons []string) Event {
+	// Serialize reasons as [] rather than null on a recovery (to=ok carries no
+	// active reasons), so a client reading the event metadata never has to
+	// special-case a null array.
+	if reasons == nil {
+		reasons = []string{}
+	}
 	sev := "success"
 	switch to {
 	case FleetDegraded:

--- a/internal/frontdesk/fleetstate_test.go
+++ b/internal/frontdesk/fleetstate_test.go
@@ -1,6 +1,7 @@
 package frontdesk
 
 import (
+	"context"
 	"reflect"
 	"testing"
 )
@@ -62,5 +63,97 @@ func TestComputeFleetState(t *testing.T) {
 				t.Errorf("reasons = %v, want %v", reasons, tc.wantReasons)
 			}
 		})
+	}
+}
+
+// setHealth marks a member healthy or down in the poller's in-memory status map,
+// exactly as PollHealthOnce would, so checkFleetState reads a confirmed verdict.
+func setHealth(s *Server, id string, healthy bool) {
+	s.poller.mu.Lock()
+	s.poller.statuses[id] = MemberStatus{Health: HealthStatus{Known: true, Healthy: healthy}}
+	s.poller.mu.Unlock()
+}
+
+// fleetStateEvents returns every persisted fleet.state_changed row, newest first.
+func fleetStateEvents(ctx context.Context, t *testing.T, s *Server) []Event {
+	t.Helper()
+	evs, _, err := s.store.ListEvents(ctx, EventFilter{Type: "fleet.state_changed"})
+	if err != nil {
+		t.Fatalf("ListEvents: %v", err)
+	}
+	return evs
+}
+
+// reasonsContain reports whether the round-tripped metadata reasons (a JSON
+// array decodes to []any) include the given code.
+func reasonsContain(meta map[string]any, code string) bool {
+	raw, ok := meta["reasons"].([]any)
+	if !ok {
+		return false
+	}
+	for _, r := range raw {
+		if s, _ := r.(string); s == code {
+			return true
+		}
+	}
+	return false
+}
+
+func TestCheckFleetStateEmitsOnTransitions(t *testing.T) {
+	srv, store := newTestServer(t)
+	ctx := context.Background()
+
+	m1, err := store.CreateMember(ctx, "hotel-1", "https://h1.example", "tok1")
+	if err != nil {
+		t.Fatalf("create m1: %v", err)
+	}
+	m2, err := store.CreateMember(ctx, "hotel-2", "https://h2.example", "tok2")
+	if err != nil {
+		t.Fatalf("create m2: %v", err)
+	}
+	setHealth(srv, m1.ID, true)
+	setHealth(srv, m2.ID, true)
+
+	// Baseline ok: the empty-prev is treated as ok, so no transition, no event.
+	srv.checkFleetState(ctx)
+	if evs := fleetStateEvents(ctx, t, srv); len(evs) != 0 {
+		t.Fatalf("baseline emitted %d fleet.state_changed events, want 0", len(evs))
+	}
+
+	// One member confirmed down -> degraded: exactly one event.
+	setHealth(srv, m1.ID, false)
+	srv.checkFleetState(ctx)
+	evs := fleetStateEvents(ctx, t, srv)
+	if len(evs) != 1 {
+		t.Fatalf("after member down: %d events, want 1", len(evs))
+	}
+	if evs[0].Severity != "warning" {
+		t.Errorf("severity = %q, want warning", evs[0].Severity)
+	}
+	if got := evs[0].Metadata["to"]; got != "degraded" {
+		t.Errorf(`metadata["to"] = %v, want "degraded"`, got)
+	}
+	if !reasonsContain(evs[0].Metadata, reasonMemberDown) {
+		t.Errorf("reasons %v missing %q", evs[0].Metadata["reasons"], reasonMemberDown)
+	}
+
+	// A repeat check while nothing changed must not re-emit (edge-triggered).
+	srv.checkFleetState(ctx)
+	if evs := fleetStateEvents(ctx, t, srv); len(evs) != 1 {
+		t.Fatalf("unchanged re-check emitted again: %d events, want 1", len(evs))
+	}
+
+	// Recovery -> ok: a second event whose newest row reads ok/success.
+	setHealth(srv, m1.ID, true)
+	srv.checkFleetState(ctx)
+	evs = fleetStateEvents(ctx, t, srv)
+	if len(evs) != 2 {
+		t.Fatalf("after recovery: %d events, want 2", len(evs))
+	}
+	if got := evs[0].Metadata["to"]; got != "ok" {
+		t.Errorf(`recovery metadata["to"] = %v, want "ok"`, got)
+	}
+	if evs[0].Severity != "success" {
+		t.Errorf("recovery severity = %q, want success", evs[0].Severity)
 	}
 }

--- a/internal/frontdesk/fleetstate_test.go
+++ b/internal/frontdesk/fleetstate_test.go
@@ -45,13 +45,13 @@ func TestComputeFleetState(t *testing.T) {
 		{"stale tier 2 is faulty", fleetStateInput{AutoSyncTier: 2},
 			FleetFaulty, []string{"autosync_stale_long"}},
 		{"traefik stale is faulty", fleetStateInput{TraefikStale: true},
-			FleetFaulty, []string{"traefik_stale"}},
+			FleetFaulty, []string{"traefik_config_stale"}},
 		{"reasons accumulate and worst severity wins",
 			fleetStateInput{
 				Members:      []memberFleetFacts{up, down, heldOf(up), syncable(up)},
 				AutoSyncTier: 1, TraefikStale: true,
 			},
-			FleetFaulty, []string{"member_down", "sync_held", "autosync_stale", "traefik_stale"}},
+			FleetFaulty, []string{"member_down", "sync_held", "autosync_stale", "traefik_config_stale"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -155,5 +155,50 @@ func TestCheckFleetStateEmitsOnTransitions(t *testing.T) {
 	}
 	if evs[0].Severity != "success" {
 		t.Errorf("recovery severity = %q, want success", evs[0].Severity)
+	}
+}
+
+// TestCheckFleetStateEmitsFaultyTransition covers the to=faulty branch of
+// fleetStateEvent (severity "error"), which the ok/degraded/ok path above never
+// exercises: with every member confirmed down the state is faulty via
+// all_members_down.
+func TestCheckFleetStateEmitsFaultyTransition(t *testing.T) {
+	srv, store := newTestServer(t)
+	ctx := context.Background()
+
+	m1, err := store.CreateMember(ctx, "hotel-1", "https://h1.example", "tok1")
+	if err != nil {
+		t.Fatalf("create m1: %v", err)
+	}
+	m2, err := store.CreateMember(ctx, "hotel-2", "https://h2.example", "tok2")
+	if err != nil {
+		t.Fatalf("create m2: %v", err)
+	}
+	setHealth(srv, m1.ID, true)
+	setHealth(srv, m2.ID, true)
+
+	// Baseline ok: no transition, no event.
+	srv.checkFleetState(ctx)
+	if evs := fleetStateEvents(ctx, t, srv); len(evs) != 0 {
+		t.Fatalf("baseline emitted %d events, want 0", len(evs))
+	}
+
+	// Every member confirmed down -> faulty via all_members_down: one event,
+	// severity error.
+	setHealth(srv, m1.ID, false)
+	setHealth(srv, m2.ID, false)
+	srv.checkFleetState(ctx)
+	evs := fleetStateEvents(ctx, t, srv)
+	if len(evs) != 1 {
+		t.Fatalf("after all-down: %d events, want 1", len(evs))
+	}
+	if evs[0].Severity != "error" {
+		t.Errorf("severity = %q, want error", evs[0].Severity)
+	}
+	if got := evs[0].Metadata["to"]; got != "faulty" {
+		t.Errorf(`metadata["to"] = %v, want "faulty"`, got)
+	}
+	if !reasonsContain(evs[0].Metadata, reasonAllMembersDown) {
+		t.Errorf("reasons %v missing %q", evs[0].Metadata["reasons"], reasonAllMembersDown)
 	}
 }

--- a/internal/frontdesk/fleetstate_test.go
+++ b/internal/frontdesk/fleetstate_test.go
@@ -1,0 +1,66 @@
+package frontdesk
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestComputeFleetState(t *testing.T) {
+	up := memberFleetFacts{Known: true, Healthy: true}
+	down := memberFleetFacts{Known: true, Healthy: false}
+	heldOf := func(f memberFleetFacts) memberFleetFacts { f.Syncable = true; f.Held = true; return f }
+	syncable := func(f memberFleetFacts) memberFleetFacts { f.Syncable = true; return f }
+
+	cases := []struct {
+		name        string
+		in          fleetStateInput
+		wantState   FleetState
+		wantReasons []string
+	}{
+		{"empty fleet is ok", fleetStateInput{}, FleetOK, nil},
+		{"all up is ok", fleetStateInput{Members: []memberFleetFacts{up, up}}, FleetOK, nil},
+		{"unknown members are neither up nor down",
+			fleetStateInput{Members: []memberFleetFacts{{}, {}}}, FleetOK, nil},
+		{"one down degrades",
+			fleetStateInput{Members: []memberFleetFacts{up, down}},
+			FleetDegraded, []string{"member_down"}},
+		{"all down is faulty",
+			fleetStateInput{Members: []memberFleetFacts{down, down}},
+			FleetFaulty, []string{"all_members_down"}},
+		{"unknown member blocks all-down escalation",
+			fleetStateInput{Members: []memberFleetFacts{down, {}}},
+			FleetDegraded, []string{"member_down"}},
+		{"some held degrades",
+			fleetStateInput{Members: []memberFleetFacts{up, heldOf(up), syncable(up)}},
+			FleetDegraded, []string{"sync_held"}},
+		{"all held (2+) is faulty: primary is the odd one out",
+			fleetStateInput{Members: []memberFleetFacts{up, heldOf(up), heldOf(up)}},
+			FleetFaulty, []string{"all_sync_held"}},
+		{"single held candidate cannot prove the primary is odd",
+			fleetStateInput{Members: []memberFleetFacts{up, heldOf(up)}},
+			FleetDegraded, []string{"sync_held"}},
+		{"stale tier 1 degrades", fleetStateInput{AutoSyncTier: 1},
+			FleetDegraded, []string{"autosync_stale"}},
+		{"stale tier 2 is faulty", fleetStateInput{AutoSyncTier: 2},
+			FleetFaulty, []string{"autosync_stale_long"}},
+		{"traefik stale is faulty", fleetStateInput{TraefikStale: true},
+			FleetFaulty, []string{"traefik_stale"}},
+		{"reasons accumulate and worst severity wins",
+			fleetStateInput{
+				Members:      []memberFleetFacts{up, down, heldOf(up), syncable(up)},
+				AutoSyncTier: 1, TraefikStale: true,
+			},
+			FleetFaulty, []string{"member_down", "sync_held", "autosync_stale", "traefik_stale"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			state, reasons := computeFleetState(tc.in)
+			if state != tc.wantState {
+				t.Errorf("state = %s, want %s", state, tc.wantState)
+			}
+			if !reflect.DeepEqual(reasons, tc.wantReasons) {
+				t.Errorf("reasons = %v, want %v", reasons, tc.wantReasons)
+			}
+		})
+	}
+}

--- a/internal/frontdesk/poller.go
+++ b/internal/frontdesk/poller.go
@@ -523,8 +523,8 @@ func (p *Poller) noteTraefikAPIFailure(ctx context.Context) {
 	p.mu.Lock()
 	if p.traefikBlanked {
 		// Already blanked by an earlier poll in this outage: nothing left to blank,
-		// so skip the member re-read and stop advancing the counter. A successful
-		// poll (which resets both flags) re-arms this.
+		// so stop advancing the counter. A successful poll (which resets both
+		// flags) re-arms this.
 		p.mu.Unlock()
 		return
 	}
@@ -533,24 +533,18 @@ func (p *Poller) noteTraefikAPIFailure(ctx context.Context) {
 		p.mu.Unlock()
 		return
 	}
-	p.mu.Unlock()
-	// Exactly crossed the threshold: blank every member's badge. Read members
-	// outside the lock; on a read error leave traefikBlanked false so the next
-	// failed poll retries the blank.
-	members, err := p.store.ListMembers(ctx)
-	if err != nil {
-		return
-	}
-	p.mu.Lock()
+	// Crossed the threshold: blank every live badge. Only members that were
+	// actually polled hold a non-empty TraefikStatus, so iterate the in-memory
+	// statuses directly rather than re-reading the store (a member absent from
+	// this map already renders as "unknown"). Publishing happens after unlock.
 	var changed []string
-	for _, m := range members {
-		cur := p.statuses[m.ID]
+	for id, cur := range p.statuses {
 		if cur.TraefikStatus != "" {
 			cur.TraefikStatus = ""
-			p.statuses[m.ID] = cur
-			changed = append(changed, m.ID)
+			p.statuses[id] = cur
+			changed = append(changed, id)
 		}
-		delete(p.traefikNonUp, m.ID)
+		delete(p.traefikNonUp, id)
 	}
 	p.traefikBlanked = true
 	p.mu.Unlock()

--- a/internal/frontdesk/poller.go
+++ b/internal/frontdesk/poller.go
@@ -90,6 +90,7 @@ type Poller struct {
 	healthFailures        map[string]int  // consecutive failed health polls, keyed by member ID
 	traefikNonUp          map[string]int  // consecutive non-UP Traefik observations, keyed by member ID
 	traefikAPIFails       int             // consecutive failed Traefik API polls (whole-API, not per member)
+	traefikBlanked        bool            // true once a Traefik outage has blanked all badges; skips re-blank + member re-reads until recovery
 	conflictNotified      map[string]bool // members that rejected our announce (409), keyed by member ID
 }
 
@@ -484,6 +485,7 @@ func (p *Poller) PollTraefikOnce(ctx context.Context) {
 	threshold := p.healthFailThreshold(ctx)
 	p.mu.Lock()
 	p.traefikAPIFails = 0
+	p.traefikBlanked = false
 	var changed []string
 	for _, m := range members {
 		cur := p.statuses[m.ID]
@@ -518,16 +520,28 @@ func (p *Poller) PollTraefikOnce(ctx context.Context) {
 // UP->DOWN flip so a restart blip of Traefik does not blank the column.
 func (p *Poller) noteTraefikAPIFailure(ctx context.Context) {
 	threshold := p.healthFailThreshold(ctx)
-	members, err := p.store.ListMembers(ctx)
-	if err != nil {
+	p.mu.Lock()
+	if p.traefikBlanked {
+		// Already blanked by an earlier poll in this outage: nothing left to blank,
+		// so skip the member re-read and stop advancing the counter. A successful
+		// poll (which resets both flags) re-arms this.
+		p.mu.Unlock()
 		return
 	}
-	p.mu.Lock()
 	p.traefikAPIFails++
 	if p.traefikAPIFails < threshold {
 		p.mu.Unlock()
 		return
 	}
+	p.mu.Unlock()
+	// Exactly crossed the threshold: blank every member's badge. Read members
+	// outside the lock; on a read error leave traefikBlanked false so the next
+	// failed poll retries the blank.
+	members, err := p.store.ListMembers(ctx)
+	if err != nil {
+		return
+	}
+	p.mu.Lock()
 	var changed []string
 	for _, m := range members {
 		cur := p.statuses[m.ID]
@@ -538,6 +552,7 @@ func (p *Poller) noteTraefikAPIFailure(ctx context.Context) {
 		}
 		delete(p.traefikNonUp, m.ID)
 	}
+	p.traefikBlanked = true
 	p.mu.Unlock()
 	for _, id := range changed {
 		p.publishMemberStatus(id)

--- a/internal/frontdesk/poller.go
+++ b/internal/frontdesk/poller.go
@@ -696,6 +696,19 @@ func (p *Poller) checkConfigStaleness(ctx context.Context) {
 	}
 }
 
+// ConfigPollStale reports whether Traefik has stopped fetching the dynamic
+// config past the configured threshold: the same rule checkConfigStaleness
+// alerts on, exposed side-effect-free for the fleet state machine
+// (fleetstate.go). False while unarmed (nothing has ever polled), matching the
+// watchdog's fresh-start grace.
+func (p *Poller) ConfigPollStale(ctx context.Context) bool {
+	threshold := secs(p.settings(ctx).TraefikStaleSecs, 30)
+	p.mu.RLock()
+	last := p.lastConfigPollAt
+	p.mu.RUnlock()
+	return !last.IsZero() && p.now().Sub(last) > threshold
+}
+
 // checkAutoSyncStale emits a single warning when auto-sync is off and the fleet
 // has not been synced within autoSyncStaleThreshold (see autoSyncStale for the
 // exact rule). Like checkConfigStaleness it de-dups on an in-memory flag so it

--- a/internal/frontdesk/poller.go
+++ b/internal/frontdesk/poller.go
@@ -89,6 +89,7 @@ type Poller struct {
 	versionFailures       map[string]int  // consecutive version-fetch failures, keyed by member ID
 	healthFailures        map[string]int  // consecutive failed health polls, keyed by member ID
 	traefikNonUp          map[string]int  // consecutive non-UP Traefik observations, keyed by member ID
+	traefikAPIFails       int             // consecutive failed Traefik API polls (whole-API, not per member)
 	conflictNotified      map[string]bool // members that rejected our announce (409), keyed by member ID
 }
 
@@ -468,6 +469,7 @@ func (p *Poller) PollTraefikOnce(ctx context.Context) {
 	statusByURL, err := p.fetchTraefikServerStatus(ctx)
 	if err != nil {
 		debuglog.Debug("frontdesk: poll traefik status", "error", err)
+		p.noteTraefikAPIFailure(ctx)
 		return
 	}
 	members, err := p.store.ListMembers(ctx)
@@ -481,6 +483,7 @@ func (p *Poller) PollTraefikOnce(ctx context.Context) {
 	// `threshold` polls in a row.
 	threshold := p.healthFailThreshold(ctx)
 	p.mu.Lock()
+	p.traefikAPIFails = 0
 	var changed []string
 	for _, m := range members {
 		cur := p.statuses[m.ID]
@@ -502,6 +505,40 @@ func (p *Poller) PollTraefikOnce(ctx context.Context) {
 	p.mu.Unlock()
 	// Traefik's view caught up to a new/changed member (it needs to re-poll the
 	// config before it lists one), so refresh the UI without a manual reload.
+	for _, id := range changed {
+		p.publishMemberStatus(id)
+	}
+}
+
+// noteTraefikAPIFailure counts consecutive failed polls of Traefik's own API
+// and, once they cross the health-fail threshold, blanks every member's
+// TraefikStatus. Without this the badges freeze at their last value while the
+// API is down, painting a live-looking status from a dead data source; blank
+// renders as the existing faint "unknown". Damped by the same threshold as the
+// UP->DOWN flip so a restart blip of Traefik does not blank the column.
+func (p *Poller) noteTraefikAPIFailure(ctx context.Context) {
+	threshold := p.healthFailThreshold(ctx)
+	members, err := p.store.ListMembers(ctx)
+	if err != nil {
+		return
+	}
+	p.mu.Lock()
+	p.traefikAPIFails++
+	if p.traefikAPIFails < threshold {
+		p.mu.Unlock()
+		return
+	}
+	var changed []string
+	for _, m := range members {
+		cur := p.statuses[m.ID]
+		if cur.TraefikStatus != "" {
+			cur.TraefikStatus = ""
+			p.statuses[m.ID] = cur
+			changed = append(changed, m.ID)
+		}
+		delete(p.traefikNonUp, m.ID)
+	}
+	p.mu.Unlock()
 	for _, id := range changed {
 		p.publishMemberStatus(id)
 	}

--- a/internal/frontdesk/poller_coverage_test.go
+++ b/internal/frontdesk/poller_coverage_test.go
@@ -164,3 +164,47 @@ func TestPollTraefikOnceDampsDownFlip(t *testing.T) {
 		t.Errorf("recovery to UP should be immediate, got %q", got)
 	}
 }
+
+// TestPollTraefikOnceBlanksStatusAfterAPIFailures covers the Traefik-API-down
+// path: once the Traefik API itself stops answering for `health_fail_threshold`
+// polls in a row, every member's TraefikStatus must blank (rendering as the
+// faint "unknown") instead of freezing at its last live-looking value.
+func TestPollTraefikOnceBlanksStatusAfterAPIFailures(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	m, err := store.CreateMember(ctx, "m1", "http://m1:8081", "")
+	if err != nil {
+		t.Fatalf("CreateMember: %v", err)
+	}
+
+	// The Traefik services response references the member's stored URL so the
+	// status maps back onto it.
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == traefikServicesAPI {
+			_, _ = w.Write([]byte(`[{"name":"hotel@http","serverStatus":{"` + m.URL + `":"UP"}}]`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer stub.Close()
+
+	p := NewPoller(store, events.NewBus(), stub.URL)
+
+	p.PollTraefikOnce(ctx) // seeds "UP"
+	if got := p.Snapshot()[m.ID].TraefikStatus; got != "UP" {
+		t.Fatalf("seed status = %q, want UP", got)
+	}
+	stub.Close() // Traefik API now unreachable; last value must not freeze forever
+
+	threshold := p.healthFailThreshold(ctx)
+	for i := 0; i < threshold-1; i++ {
+		p.PollTraefikOnce(ctx)
+		if got := p.Snapshot()[m.ID].TraefikStatus; got != "UP" {
+			t.Fatalf("blanked after %d failures, want hold until %d", i+1, threshold)
+		}
+	}
+	p.PollTraefikOnce(ctx)
+	if got := p.Snapshot()[m.ID].TraefikStatus; got != "" {
+		t.Fatalf("status after %d failed polls = %q, want blank", threshold, got)
+	}
+}

--- a/internal/frontdesk/poller_coverage_test.go
+++ b/internal/frontdesk/poller_coverage_test.go
@@ -177,35 +177,73 @@ func TestPollTraefikOnceBlanksStatusAfterAPIFailures(t *testing.T) {
 		t.Fatalf("CreateMember: %v", err)
 	}
 
-	// The Traefik services response references the member's stored URL so the
-	// status maps back onto it.
+	// apiDown toggles the Traefik API between answering (200 with the member's UP
+	// status) and failing (500), so the outage and the recovery can both be driven
+	// without tearing the server down. The services response references the
+	// member's stored URL so the status maps back onto it.
+	var apiDown atomic.Bool
 	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if apiDown.Load() {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
 		if r.URL.Path == traefikServicesAPI {
 			_, _ = w.Write([]byte(`[{"name":"hotel@http","serverStatus":{"` + m.URL + `":"UP"}}]`))
 			return
 		}
 		w.WriteHeader(http.StatusNotFound)
 	}))
-	// Closed explicitly mid-test to simulate the outage (below); no defer, so the
-	// server is not double-closed.
+	defer stub.Close()
 
 	p := NewPoller(store, events.NewBus(), stub.URL)
+	threshold := p.healthFailThreshold(ctx)
 
 	p.PollTraefikOnce(ctx) // seeds "UP"
 	if got := p.Snapshot()[m.ID].TraefikStatus; got != "UP" {
 		t.Fatalf("seed status = %q, want UP", got)
 	}
-	stub.Close() // Traefik API now unreachable; last value must not freeze forever
 
-	threshold := p.healthFailThreshold(ctx)
+	// Traefik's API goes down. Below the threshold the last live value is held.
+	apiDown.Store(true)
 	for i := 0; i < threshold-1; i++ {
 		p.PollTraefikOnce(ctx)
 		if got := p.Snapshot()[m.ID].TraefikStatus; got != "UP" {
 			t.Fatalf("blanked after %d failures, want hold until %d", i+1, threshold)
 		}
 	}
+	// The threshold-th consecutive failure blanks the badge.
 	p.PollTraefikOnce(ctx)
 	if got := p.Snapshot()[m.ID].TraefikStatus; got != "" {
 		t.Fatalf("status after %d failed polls = %q, want blank", threshold, got)
+	}
+	p.mu.Lock()
+	blanked, fails := p.traefikBlanked, p.traefikAPIFails
+	p.mu.Unlock()
+	if !blanked || fails != threshold {
+		t.Fatalf("after blanking: traefikBlanked=%v traefikAPIFails=%d, want true and %d", blanked, fails, threshold)
+	}
+
+	// Further failed polls while blanked neither re-blank nor advance the counter.
+	p.PollTraefikOnce(ctx)
+	p.mu.Lock()
+	fails = p.traefikAPIFails
+	p.mu.Unlock()
+	if fails != threshold {
+		t.Fatalf("counter advanced past threshold while blanked: got %d, want %d", fails, threshold)
+	}
+
+	// Recovery: the API answers again, so the next successful poll repopulates the
+	// badge and resets the outage flags (a regression deleting either reset would
+	// leave the badge blank or the flags stuck).
+	apiDown.Store(false)
+	p.PollTraefikOnce(ctx)
+	if got := p.Snapshot()[m.ID].TraefikStatus; got != "UP" {
+		t.Fatalf("recovery status = %q, want UP", got)
+	}
+	p.mu.Lock()
+	blanked, fails = p.traefikBlanked, p.traefikAPIFails
+	p.mu.Unlock()
+	if blanked || fails != 0 {
+		t.Fatalf("after recovery: traefikBlanked=%v traefikAPIFails=%d, want false and 0", blanked, fails)
 	}
 }

--- a/internal/frontdesk/poller_coverage_test.go
+++ b/internal/frontdesk/poller_coverage_test.go
@@ -186,7 +186,8 @@ func TestPollTraefikOnceBlanksStatusAfterAPIFailures(t *testing.T) {
 		}
 		w.WriteHeader(http.StatusNotFound)
 	}))
-	defer stub.Close()
+	// Closed explicitly mid-test to simulate the outage (below); no defer, so the
+	// server is not double-closed.
 
 	p := NewPoller(store, events.NewBus(), stub.URL)
 

--- a/internal/frontdesk/poller_test.go
+++ b/internal/frontdesk/poller_test.go
@@ -463,3 +463,24 @@ func TestMemberVersion(t *testing.T) {
 		t.Errorf("MemberVersion = %q, want v1.2.3", v)
 	}
 }
+
+func TestConfigPollStaleAccessor(t *testing.T) {
+	store := newTestStore(t)       // reuse this file's existing store fixture helper
+	p := NewPoller(store, nil, "") // nil bus falls back to events.DefaultBus
+	base := time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC)
+	now := base
+	p.now = func() time.Time { return now }
+
+	// Never polled: not stale (unarmed), matching checkConfigStaleness.
+	if p.ConfigPollStale(context.Background()) {
+		t.Fatal("unarmed poller reported stale")
+	}
+	p.RecordConfigPoll()
+	if p.ConfigPollStale(context.Background()) {
+		t.Fatal("fresh poll reported stale")
+	}
+	now = base.Add(10 * time.Minute) // default threshold is 30s
+	if !p.ConfigPollStale(context.Background()) {
+		t.Fatal("10-minute-old poll not reported stale")
+	}
+}

--- a/internal/frontdesk/server.go
+++ b/internal/frontdesk/server.go
@@ -84,8 +84,9 @@ type Server struct {
 	syncHeld   map[string]bool
 	// fleetStatePrev is the last state checkFleetState saw, guarding the
 	// edge-triggered fleet.state_changed emission. Empty until the first check
-	// (treated as ok, so a fleet that starts unhealthy alerts once on startup,
-	// the same restart trade-off as the staleness watchdogs).
+	// (treated as ok, so a fleet that starts unhealthy alerts once on startup).
+	// This mirrors checkAutoSyncStale, which re-alerts on a stale start, not
+	// checkConfigStaleness, which stays quiet until it has armed.
 	fleetStateMu   sync.Mutex
 	fleetStatePrev FleetState
 	router         http.Handler

--- a/internal/frontdesk/server.go
+++ b/internal/frontdesk/server.go
@@ -82,7 +82,13 @@ type Server struct {
 	// bounded by fleet size; a restart re-emits at most once per still-held member.
 	syncHeldMu sync.Mutex
 	syncHeld   map[string]bool
-	router     http.Handler
+	// fleetStatePrev is the last state checkFleetState saw, guarding the
+	// edge-triggered fleet.state_changed emission. Empty until the first check
+	// (treated as ok, so a fleet that starts unhealthy alerts once on startup,
+	// the same restart trade-off as the staleness watchdogs).
+	fleetStateMu   sync.Mutex
+	fleetStatePrev FleetState
+	router         http.Handler
 	// bgWG tracks detached background goroutines (e.g. the auto-sync kick) so
 	// callers can drain them on shutdown. Without it, a kick fired by an enable
 	// keeps writing to the store after a caller (or a test) has moved on, which

--- a/internal/frontdesk/server_settings.go
+++ b/internal/frontdesk/server_settings.go
@@ -140,6 +140,13 @@ type autoSyncStatus struct {
 	// "Sync fleet from primary" action so the operator sees when the fleet
 	// truly last synced, not when a button was last pressed.
 	LastSyncAt string `json:"last_sync_at,omitempty"`
+	// FleetState / FleetStateReasons are the fleet state machine's verdict
+	// (fleetstate.go), ridden on this payload because it is the one endpoint
+	// Bellhop's background monitor already polls. Reason codes are wire
+	// constants the clients translate. Optional: an older client ignores them,
+	// and an internal error omits them rather than failing the status read.
+	FleetState        FleetState `json:"fleet_state,omitempty"`
+	FleetStateReasons []string   `json:"fleet_state_reasons,omitempty"`
 }
 
 // autoSyncStatusNow reads the auto-sync config and last-sync marker and folds in
@@ -157,6 +164,13 @@ func (s *Server) autoSyncStatusNow(ctx context.Context) (autoSyncStatus, error) 
 	status := autoSyncStatus{
 		AutoSyncConfig: cfg,
 		Stale:          autoSyncStale(cfg, state.LastRunAt, found, time.Now().UTC()),
+	}
+	// Best-effort, like last_sync_at below: a failed state read must not fail
+	// the status endpoint (PUT already persisted its toggle by the time this
+	// runs), so degrade to an absent field instead.
+	if fs, reasons, err := s.fleetStateNow(ctx); err == nil {
+		status.FleetState = fs
+		status.FleetStateReasons = reasons
 	}
 	// last_sync_at is best-effort garnish: the max of members' real-write
 	// stamps. A failed members read must not fail the status itself, or the

--- a/internal/frontdesk/server_settings.go
+++ b/internal/frontdesk/server_settings.go
@@ -165,18 +165,13 @@ func (s *Server) autoSyncStatusNow(ctx context.Context) (autoSyncStatus, error) 
 		AutoSyncConfig: cfg,
 		Stale:          autoSyncStale(cfg, state.LastRunAt, found, time.Now().UTC()),
 	}
-	// Best-effort, like last_sync_at below: a failed state read must not fail
-	// the status endpoint (PUT already persisted its toggle by the time this
-	// runs), so degrade to an absent field instead.
-	if fs, reasons, err := s.fleetStateNow(ctx); err == nil {
-		status.FleetState = fs
-		status.FleetStateReasons = reasons
-	}
-	// last_sync_at is best-effort garnish: the max of members' real-write
-	// stamps. A failed members read must not fail the status itself, or the
-	// PUT /api/fleet/autosync response would report a failure for a toggle that
-	// already persisted. Degrade to an empty stamp instead.
+	// The member list feeds both the fleet-state fields and the last_sync_at
+	// garnish, so it is read once here and reused for both (and both then see one
+	// consistent snapshot). Best-effort, like Stale above: a failed read must not
+	// fail the status endpoint (the PUT toggle already persisted by the time this
+	// runs), so both derived fields degrade to absent instead.
 	if members, err := s.store.ListMembers(ctx); err == nil {
+		status.FleetState, status.FleetStateReasons = s.fleetStateFrom(ctx, members, cfg, state.LastRunAt, found)
 		var lastSync time.Time
 		for _, m := range members {
 			if m.LastConfigSyncAt != nil && m.LastConfigSyncAt.After(lastSync) {

--- a/internal/frontdesk/server_test.go
+++ b/internal/frontdesk/server_test.go
@@ -417,6 +417,69 @@ func TestServerAutoSyncPrimaryGate(t *testing.T) {
 	}
 }
 
+// TestGetAutoSyncFleetState confirms the fleet state machine's verdict rides on
+// the GET /api/fleet/autosync payload (the one endpoint Bellhop already polls):
+// a confirmed-down member surfaces fleet_state=="degraded" with a "member_down"
+// reason code, while an all-healthy fleet is "ok" and omits the reasons key
+// entirely (omitempty).
+func TestGetAutoSyncFleetState(t *testing.T) {
+	srv, store := newTestServer(t)
+	ctx := context.Background()
+
+	m1, err := store.CreateMember(ctx, "hotel-1", "https://h1.example", "tok1")
+	if err != nil {
+		t.Fatalf("create m1: %v", err)
+	}
+	m2, err := store.CreateMember(ctx, "hotel-2", "https://h2.example", "tok2")
+	if err != nil {
+		t.Fatalf("create m2: %v", err)
+	}
+
+	getBody := func() map[string]any {
+		t.Helper()
+		rec := do(t, srv, http.MethodGet, "/api/fleet/autosync", "", true)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("GET /api/fleet/autosync = %d; body=%s", rec.Code, rec.Body.String())
+		}
+		var body map[string]any
+		if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		return body
+	}
+
+	// One member confirmed down -> degraded with a member_down reason code.
+	setHealth(srv, m1.ID, false)
+	setHealth(srv, m2.ID, true)
+	body := getBody()
+	if got := body["fleet_state"]; got != "degraded" {
+		t.Errorf("fleet_state = %v, want degraded", got)
+	}
+	reasons, ok := body["fleet_state_reasons"].([]any)
+	if !ok {
+		t.Fatalf("fleet_state_reasons missing or wrong type: %#v", body["fleet_state_reasons"])
+	}
+	found := false
+	for _, r := range reasons {
+		if s, _ := r.(string); s == "member_down" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("fleet_state_reasons = %v, want to contain member_down", reasons)
+	}
+
+	// All members healthy -> ok, and the reasons key is omitted entirely.
+	setHealth(srv, m1.ID, true)
+	body = getBody()
+	if got := body["fleet_state"]; got != "ok" {
+		t.Errorf("fleet_state = %v, want ok", got)
+	}
+	if _, present := body["fleet_state_reasons"]; present {
+		t.Errorf("fleet_state_reasons should be absent when ok, got %v", body["fleet_state_reasons"])
+	}
+}
+
 // TestServerRepointSameHostRejected covers the same-host guard: repointing the
 // primary onto a member row that is actually the same physical host (it
 // self-reports is_primary=true) is refused with 409 even with a valid token, so


### PR DESCRIPTION
First of three slices for a server-side fleet-status state machine. This is the Front Desk backend; Front Desk web (Slice B) and Bellhop (Slice C) render the result and follow in separate PRs.

## What this adds

Front Desk now computes a single fleet-wide verdict, `ok | degraded | faulty`, with machine-readable reason codes that clients translate. It is derived from facts the poller and auto-syncer already track:

| Reason code | Severity | Trigger |
|---|---|---|
| `member_down` | degraded | ≥1 member confirmed down, not all |
| `all_members_down` | faulty | every member confirmed down |
| `sync_held` | degraded | ≥1 tokened non-primary member held for version skew |
| `all_sync_held` | faulty | ≥2 candidates and all held (primary is the odd one out) |
| `autosync_stale` | degraded | auto-sync off, primary set, unsynced >24h (or never) |
| `autosync_stale_long` | faulty | same, unsynced >72h |
| `traefik_config_stale` | faulty | Traefik stopped fetching the dynamic config |

Severity is by blast radius, not by comparing version strings (dev builds are unorderable).

## Surfaces

- **`fleet_state` + `fleet_state_reasons`** ride the existing `GET/PUT /api/fleet/autosync` payload (both `omitempty`, so older clients ignore them). It is the one endpoint Bellhop already polls.
- **`fleet.state_changed`** is an edge-triggered event (emitted only on transitions), added to the Apprise alert catalog as `DefaultOn: false`. Metadata carries `{from, to, reasons}`; severity mirrors the state entered.

## Also fixes

A preexisting bug: per-member `traefik_status` badges froze at their last value when Traefik's own API stopped answering. They now blank to the existing "unknown" rendering after the same consecutive-failure threshold that damps the UP→DOWN flip, and repopulate on recovery.

## Testing

`computeFleetState` is a pure, exhaustively table-tested function; the loop, event emission (including recovery and faulty transitions), the Traefik outage/recovery cycle, and the payload fields all have coverage. Full `internal/frontdesk` package passes (278 tests), race-clean on the touched concurrency paths, `golangci-lint` clean.

## Notes for reviewers

- Judgment calls baked in: `all_sync_held` needs ≥2 candidates (a lone held member can't reveal which side is skewed); a never-synced fleet caps at the degraded stale tier (no timestamp to age); never-probed members count as neither up nor down.
- The new event's friendly Alerts-picker label lands in Slice B; until then the FD-web picker falls back to rendering the raw type string (its existing `defaultValue` path), so this merging alone is not a broken state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)