### PR TITLE
feat(bellhop): render server fleet-state verdict on dashboard (Slice C)

### DIFF
--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/FleetModels.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/FleetModels.kt
@@ -77,6 +77,11 @@ data class AutoSyncConfig(
     // member; empty until one has. Member detail shows it under the fleet-sync
     // action so the operator sees when the fleet truly last synced.
     @SerialName("last_sync_at") val lastSyncAt: String = "",
+    // Server-computed fleet state machine (ok / degraded / faulty) plus its
+    // machine-readable reason codes; empty on an older Front Desk. The
+    // dashboard prefers this verdict over its own local rollup.
+    @SerialName("fleet_state") val fleetState: String = "",
+    @SerialName("fleet_state_reasons") val fleetStateReasons: List<String> = emptyList(),
 )
 
 /**

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/EventLabels.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/EventLabels.kt
@@ -25,6 +25,7 @@ internal fun eventTypeLabel(type: String): String =
         "version.fetch_failed" -> stringResource(R.string.alerts_event_version_fetch_failed)
         "version.fetch_recovered" -> stringResource(R.string.alerts_event_version_fetch_recovered)
         "traefik.stale" -> stringResource(R.string.alerts_event_traefik_stale)
+        "fleet.state_changed" -> stringResource(R.string.alerts_event_fleet_state_changed)
         "member.added" -> stringResource(R.string.alerts_event_member_added)
         "member.removed" -> stringResource(R.string.alerts_event_member_removed)
         "member.state_changed" -> stringResource(R.string.alerts_event_member_state_changed)

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
@@ -50,6 +50,7 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
@@ -82,6 +83,7 @@ import com.hugalafutro.bellhop.ui.common.healthLabel
 import com.hugalafutro.bellhop.ui.common.relativeAgo
 import com.hugalafutro.bellhop.ui.common.severityColors
 import com.hugalafutro.bellhop.ui.theme.BellhopTheme
+import com.hugalafutro.bellhop.ui.theme.SeverityWarnFg
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.distinctUntilChanged
 import java.time.Instant
@@ -246,7 +248,11 @@ fun DashboardScreen(
                         )
                     }
                 else -> {
-                    FleetSummary(members = ui.members)
+                    FleetSummary(
+                        members = ui.members,
+                        fleetState = ui.fleetState,
+                        fleetStateReasons = ui.fleetStateReasons,
+                    )
                     val listState = rememberLazyListState()
                     // Report which members are on screen so the ViewModel fetches
                     // traffic only for them (viewport-bounded fan-out; a big fleet
@@ -424,26 +430,21 @@ private fun AutoSyncControl(
     }
 }
 
-/** FleetSummary is the one-line rollup above the list: all up, or how many down. */
+/** FleetSummary is the one-line rollup above the list. It prefers the server's
+ * fleet-state verdict (state + translated reason codes) and falls back to the
+ * local all-up/down count when Front Desk predates the field. While every
+ * member is still unprobed the local "checking" line wins even over a server
+ * "ok": FD reports ok before its first probes, and "checking" is honester. */
 @Composable
 private fun FleetSummary(
     members: List<FleetMember>,
+    fleetState: String,
+    fleetStateReasons: List<String>,
     modifier: Modifier = Modifier,
 ) {
-    val down = members.count { it.status.health.known && !it.status.health.healthy }
-    val unknown = members.count { !it.status.health.known }
-    val (text, color) =
-        when {
-            down > 0 ->
-                stringResource(R.string.dashboard_summary_down, down, members.size) to
-                    MaterialTheme.colorScheme.error
-            unknown == members.size ->
-                stringResource(R.string.dashboard_summary_checking) to
-                    MaterialTheme.colorScheme.onSurfaceVariant
-            else ->
-                stringResource(R.string.dashboard_summary_all_up) to
-                    MaterialTheme.colorScheme.tertiary
-        }
+    val allUnknown = members.isNotEmpty() && members.all { !it.status.health.known }
+    val server = if (allUnknown) null else serverFleetSummary(fleetState, fleetStateReasons)
+    val (text, color) = server ?: localFleetSummary(members)
     Text(
         text = text,
         style = MaterialTheme.typography.labelLarge,
@@ -451,6 +452,63 @@ private fun FleetSummary(
         modifier = modifier.padding(bottom = 8.dp).testTag("dashboard-summary"),
     )
 }
+
+/** serverFleetSummary renders the server verdict, or null for unknown/absent
+ * states so the caller falls back to the local rollup. */
+@Composable
+private fun serverFleetSummary(
+    state: String,
+    reasons: List<String>,
+): Pair<String, Color>? {
+    val stateText =
+        when (state) {
+            "ok" -> stringResource(R.string.dashboard_summary_all_up)
+            "degraded" -> stringResource(R.string.dashboard_state_degraded)
+            "faulty" -> stringResource(R.string.dashboard_state_faulty)
+            else -> return null
+        }
+    val color =
+        when (state) {
+            "ok" -> MaterialTheme.colorScheme.tertiary
+            "degraded" -> SeverityWarnFg
+            else -> MaterialTheme.colorScheme.error
+        }
+    val suffix = reasons.map { fleetReasonLabel(it) }.joinToString(" · ")
+    return (if (suffix.isEmpty()) stateText else "$stateText · $suffix") to color
+}
+
+/** localFleetSummary is the pre-fleet-state rollup, kept as the fallback. */
+@Composable
+private fun localFleetSummary(members: List<FleetMember>): Pair<String, Color> {
+    val down = members.count { it.status.health.known && !it.status.health.healthy }
+    val unknown = members.count { !it.status.health.known }
+    return when {
+        down > 0 ->
+            stringResource(R.string.dashboard_summary_down, down, members.size) to
+                MaterialTheme.colorScheme.error
+        unknown == members.size ->
+            stringResource(R.string.dashboard_summary_checking) to
+                MaterialTheme.colorScheme.onSurfaceVariant
+        else ->
+            stringResource(R.string.dashboard_summary_all_up) to
+                MaterialTheme.colorScheme.tertiary
+    }
+}
+
+/** fleetReasonLabel translates a wire reason code; unknown codes (a newer
+ * server) fall back to the raw code, mirroring eventTypeLabel. */
+@Composable
+private fun fleetReasonLabel(code: String): String =
+    when (code) {
+        "member_down" -> stringResource(R.string.fleet_reason_member_down)
+        "all_members_down" -> stringResource(R.string.fleet_reason_all_members_down)
+        "sync_held" -> stringResource(R.string.fleet_reason_sync_held)
+        "all_sync_held" -> stringResource(R.string.fleet_reason_all_sync_held)
+        "autosync_stale" -> stringResource(R.string.fleet_reason_autosync_stale)
+        "autosync_stale_long" -> stringResource(R.string.fleet_reason_autosync_stale_long)
+        "traefik_config_stale" -> stringResource(R.string.fleet_reason_traefik_config_stale)
+        else -> code
+    }
 
 // The plain-text a long-press copies for a member: its name and, when known, its
 // URL on the next line, so it pastes cleanly into a note or bug report.

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
@@ -83,7 +83,6 @@ import com.hugalafutro.bellhop.ui.common.healthLabel
 import com.hugalafutro.bellhop.ui.common.relativeAgo
 import com.hugalafutro.bellhop.ui.common.severityColors
 import com.hugalafutro.bellhop.ui.theme.BellhopTheme
-import com.hugalafutro.bellhop.ui.theme.SeverityWarnFg
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.distinctUntilChanged
 import java.time.Instant
@@ -470,7 +469,10 @@ private fun serverFleetSummary(
     val color =
         when (state) {
             "ok" -> MaterialTheme.colorScheme.tertiary
-            "degraded" -> SeverityWarnFg
+            // Brand accent (brass on dark, copper on light) reads on the dashboard
+            // surface in both themes; SeverityWarnFg is near-black and only legible
+            // as the foreground on the orange warn badge, not as standalone text.
+            "degraded" -> MaterialTheme.colorScheme.primary
             else -> MaterialTheme.colorScheme.error
         }
     val suffix = reasons.map { fleetReasonLabel(it) }.joinToString(" · ")

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModel.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModel.kt
@@ -41,6 +41,11 @@ data class DashboardUiState(
     // Auto-sync master toggle, from GET /api/fleet/autosync. Drives the pause/
     // resume operator control, which is only shown once a primary is configured.
     val autoSyncEnabled: Boolean = false,
+    // Server-computed fleet state + reason codes off the autosync payload;
+    // empty until fetched (or on an older Front Desk), which the summary line
+    // treats as "fall back to the local rollup".
+    val fleetState: String = "",
+    val fleetStateReasons: List<String> = emptyList(),
     // Per-member traffic for the inline card sparkline, keyed by member id and
     // filled lazily for whichever members are currently on screen (see
     // [DashboardViewModel.setVisibleMembers]). A member absent from the map just
@@ -446,6 +451,8 @@ class DashboardViewModel(
                         members = result.data,
                         primaryId = autoSync?.data?.primaryId ?: it.primaryId,
                         autoSyncEnabled = liveEnabled,
+                        fleetState = autoSync?.data?.fleetState ?: it.fleetState,
+                        fleetStateReasons = autoSync?.data?.fleetStateReasons ?: it.fleetStateReasons,
                         // Drop cached traffic for members that left the fleet so
                         // the map can't grow without bound as members churn.
                         traffic = it.traffic.filterKeys { id -> id in liveIds },

--- a/android/app/src/main/res/values-cs/strings.xml
+++ b/android/app/src/main/res/values-cs/strings.xml
@@ -22,6 +22,15 @@
     <string name="dashboard_summary_all_up">Všichni členové běží</string>
     <string name="dashboard_summary_down">%1$d z %2$d členů je mimo provoz</string>
     <string name="dashboard_summary_checking">Kontrola členů…</string>
+    <string name="dashboard_state_degraded">Flotila oslabena</string>
+    <string name="dashboard_state_faulty">Flotila chybná</string>
+    <string name="fleet_reason_member_down">člen mimo provoz</string>
+    <string name="fleet_reason_all_members_down">všichni členové mimo provoz</string>
+    <string name="fleet_reason_sync_held">synchronizace pozastavena</string>
+    <string name="fleet_reason_all_sync_held">synchronizace pozastavena v celé flotile</string>
+    <string name="fleet_reason_autosync_stale">nesynchronizováno přes den</string>
+    <string name="fleet_reason_autosync_stale_long">nesynchronizováno přes tři dny</string>
+    <string name="fleet_reason_traefik_config_stale">Traefik nenačítá konfiguraci</string>
     <string name="dashboard_empty">Zatím žádní členové. Přidejte je ve Front Desku.</string>
     <string name="dashboard_refresh_failed">Nepodařilo se obnovit: %1$s</string>
     <string name="dashboard_revoked">Toto zařízení se už nemůže ověřit u Front Desku. Jeho přístup byl možná odvolán; zrušte propojení a spárujte znovu s novým kódem.</string>
@@ -137,6 +146,7 @@
     <string name="alerts_event_version_fetch_failed">Čtení verze selhalo</string>
     <string name="alerts_event_version_fetch_recovered">Čtení verze obnoveno</string>
     <string name="alerts_event_traefik_stale">Konfigurace Traefiku zastaralá</string>
+    <string name="alerts_event_fleet_state_changed">Stav flotily se změnil</string>
     <string name="alerts_event_member_added">Člen přidán</string>
     <string name="alerts_event_member_removed">Člen odebrán</string>
     <string name="alerts_event_member_state_changed">Člen odstaven nebo aktivován</string>

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -22,6 +22,15 @@
     <string name="dashboard_summary_all_up">Alle Mitglieder aktiv</string>
     <string name="dashboard_summary_down">%1$d von %2$d Mitgliedern ausgefallen</string>
     <string name="dashboard_summary_checking">Mitglieder werden geprüft…</string>
+    <string name="dashboard_state_degraded">Flotte beeinträchtigt</string>
+    <string name="dashboard_state_faulty">Flotte fehlerhaft</string>
+    <string name="fleet_reason_member_down">Mitglied ausgefallen</string>
+    <string name="fleet_reason_all_members_down">alle Mitglieder ausgefallen</string>
+    <string name="fleet_reason_sync_held">Sync angehalten</string>
+    <string name="fleet_reason_all_sync_held">Sync flottenweit angehalten</string>
+    <string name="fleet_reason_autosync_stale">seit über einem Tag nicht synchronisiert</string>
+    <string name="fleet_reason_autosync_stale_long">seit über drei Tagen nicht synchronisiert</string>
+    <string name="fleet_reason_traefik_config_stale">Traefik ruft Konfiguration nicht ab</string>
     <string name="dashboard_empty">Noch keine Mitglieder. Füge sie in Front Desk hinzu.</string>
     <string name="dashboard_refresh_failed">Aktualisieren fehlgeschlagen: %1$s</string>
     <string name="dashboard_revoked">Dieses Gerät kann sich nicht mehr bei Front Desk authentifizieren. Sein Zugriff wurde möglicherweise widerrufen; Verknüpfung aufheben und mit einem neuen Code erneut koppeln.</string>
@@ -131,6 +140,7 @@
     <string name="alerts_event_version_fetch_failed">Versionsabruf fehlgeschlagen</string>
     <string name="alerts_event_version_fetch_recovered">Versionsabruf wiederhergestellt</string>
     <string name="alerts_event_traefik_stale">Traefik-Konfiguration veraltet</string>
+    <string name="alerts_event_fleet_state_changed">Flottenstatus geändert</string>
     <string name="alerts_event_member_added">Mitglied hinzugefügt</string>
     <string name="alerts_event_member_removed">Mitglied entfernt</string>
     <string name="alerts_event_member_state_changed">Mitglied stillgelegt oder aktiviert</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -22,6 +22,15 @@
     <string name="dashboard_summary_all_up">Todos los miembros activos</string>
     <string name="dashboard_summary_down">%1$d de %2$d miembros caídos</string>
     <string name="dashboard_summary_checking">Comprobando miembros…</string>
+    <string name="dashboard_state_degraded">Flota degradada</string>
+    <string name="dashboard_state_faulty">Flota defectuosa</string>
+    <string name="fleet_reason_member_down">miembro caído</string>
+    <string name="fleet_reason_all_members_down">todos los miembros caídos</string>
+    <string name="fleet_reason_sync_held">sincronización retenida</string>
+    <string name="fleet_reason_all_sync_held">sincronización retenida en toda la flota</string>
+    <string name="fleet_reason_autosync_stale">sin sincronizar más de un día</string>
+    <string name="fleet_reason_autosync_stale_long">sin sincronizar más de tres días</string>
+    <string name="fleet_reason_traefik_config_stale">Traefik no obtiene la configuración</string>
     <string name="dashboard_empty">Aún no hay miembros. Añádelos en Front Desk.</string>
     <string name="dashboard_refresh_failed">No se pudo actualizar: %1$s</string>
     <string name="dashboard_revoked">Este dispositivo ya no puede autenticarse en Front Desk. Es posible que se haya revocado su acceso; desvincula y vuelve a vincular con un código nuevo.</string>
@@ -131,6 +140,7 @@
     <string name="alerts_event_version_fetch_failed">Fallo al leer la versión</string>
     <string name="alerts_event_version_fetch_recovered">Lectura de versión recuperada</string>
     <string name="alerts_event_traefik_stale">Configuración de Traefik obsoleta</string>
+    <string name="alerts_event_fleet_state_changed">Estado de la flota cambiado</string>
     <string name="alerts_event_member_added">Miembro añadido</string>
     <string name="alerts_event_member_removed">Miembro eliminado</string>
     <string name="alerts_event_member_state_changed">Miembro drenado o activado</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -22,6 +22,15 @@
     <string name="dashboard_summary_all_up">Tous les membres actifs</string>
     <string name="dashboard_summary_down">%1$d membres sur %2$d hors service</string>
     <string name="dashboard_summary_checking">Vérification des membres…</string>
+    <string name="dashboard_state_degraded">Flotte dégradée</string>
+    <string name="dashboard_state_faulty">Flotte défaillante</string>
+    <string name="fleet_reason_member_down">membre hors service</string>
+    <string name="fleet_reason_all_members_down">tous les membres hors service</string>
+    <string name="fleet_reason_sync_held">synchronisation suspendue</string>
+    <string name="fleet_reason_all_sync_held">synchronisation suspendue sur toute la flotte</string>
+    <string name="fleet_reason_autosync_stale">non synchronisée depuis plus d\'un jour</string>
+    <string name="fleet_reason_autosync_stale_long">non synchronisée depuis plus de trois jours</string>
+    <string name="fleet_reason_traefik_config_stale">Traefik ne récupère pas la config</string>
     <string name="dashboard_empty">Aucun membre pour l\'instant. Ajoutez-les dans Front Desk.</string>
     <string name="dashboard_refresh_failed">Échec de l\'actualisation : %1$s</string>
     <string name="dashboard_revoked">Cet appareil ne peut plus s\'authentifier auprès de Front Desk. Son accès a peut-être été révoqué ; dissociez-le et associez-le à nouveau avec un nouveau code.</string>
@@ -131,6 +140,7 @@
     <string name="alerts_event_version_fetch_failed">Échec de lecture de la version</string>
     <string name="alerts_event_version_fetch_recovered">Lecture de la version rétablie</string>
     <string name="alerts_event_traefik_stale">Config Traefik obsolète</string>
+    <string name="alerts_event_fleet_state_changed">État de la flotte modifié</string>
     <string name="alerts_event_member_added">Membre ajouté</string>
     <string name="alerts_event_member_removed">Membre supprimé</string>
     <string name="alerts_event_member_state_changed">Membre drainé ou activé</string>

--- a/android/app/src/main/res/values-ja/strings.xml
+++ b/android/app/src/main/res/values-ja/strings.xml
@@ -22,6 +22,15 @@
     <string name="dashboard_summary_all_up">すべてのメンバーが稼働中</string>
     <string name="dashboard_summary_down">%2$d 台中 %1$d 台のメンバーがダウン</string>
     <string name="dashboard_summary_checking">メンバーを確認中…</string>
+    <string name="dashboard_state_degraded">フリート劣化</string>
+    <string name="dashboard_state_faulty">フリート障害</string>
+    <string name="fleet_reason_member_down">メンバーがダウン</string>
+    <string name="fleet_reason_all_members_down">すべてのメンバーがダウン</string>
+    <string name="fleet_reason_sync_held">同期保留</string>
+    <string name="fleet_reason_all_sync_held">フリート全体で同期保留</string>
+    <string name="fleet_reason_autosync_stale">1 日以上未同期</string>
+    <string name="fleet_reason_autosync_stale_long">3 日以上未同期</string>
+    <string name="fleet_reason_traefik_config_stale">Traefik が設定を取得していません</string>
     <string name="dashboard_empty">メンバーはまだありません。Front Desk で追加してください。</string>
     <string name="dashboard_refresh_failed">更新に失敗しました: %1$s</string>
     <string name="dashboard_revoked">このデバイスは Front Desk に認証できなくなりました。アクセスが取り消された可能性があります。リンクを解除し、新しいコードで再ペア設定してください。</string>
@@ -128,6 +137,7 @@
     <string name="alerts_event_version_fetch_failed">バージョン取得に失敗</string>
     <string name="alerts_event_version_fetch_recovered">バージョン取得が復旧</string>
     <string name="alerts_event_traefik_stale">Traefik 設定が古い</string>
+    <string name="alerts_event_fleet_state_changed">フリートの状態が変化</string>
     <string name="alerts_event_member_added">メンバーを追加</string>
     <string name="alerts_event_member_removed">メンバーを削除</string>
     <string name="alerts_event_member_state_changed">メンバーをドレインまたは有効化</string>

--- a/android/app/src/main/res/values-nl/strings.xml
+++ b/android/app/src/main/res/values-nl/strings.xml
@@ -22,6 +22,15 @@
     <string name="dashboard_summary_all_up">Alle leden actief</string>
     <string name="dashboard_summary_down">%1$d van %2$d leden offline</string>
     <string name="dashboard_summary_checking">Leden controleren…</string>
+    <string name="dashboard_state_degraded">Vloot verslechterd</string>
+    <string name="dashboard_state_faulty">Vloot defect</string>
+    <string name="fleet_reason_member_down">lid offline</string>
+    <string name="fleet_reason_all_members_down">alle leden offline</string>
+    <string name="fleet_reason_sync_held">sync aangehouden</string>
+    <string name="fleet_reason_all_sync_held">sync vlootbreed aangehouden</string>
+    <string name="fleet_reason_autosync_stale">meer dan een dag niet gesynchroniseerd</string>
+    <string name="fleet_reason_autosync_stale_long">meer dan drie dagen niet gesynchroniseerd</string>
+    <string name="fleet_reason_traefik_config_stale">Traefik haalt configuratie niet op</string>
     <string name="dashboard_empty">Nog geen leden. Voeg ze toe in Front Desk.</string>
     <string name="dashboard_refresh_failed">Vernieuwen mislukt: %1$s</string>
     <string name="dashboard_revoked">Dit apparaat kan zich niet meer bij Front Desk authenticeren. De toegang is mogelijk ingetrokken; ontkoppel en koppel opnieuw met een nieuwe code.</string>
@@ -131,6 +140,7 @@
     <string name="alerts_event_version_fetch_failed">Versie lezen mislukt</string>
     <string name="alerts_event_version_fetch_recovered">Versie lezen hersteld</string>
     <string name="alerts_event_traefik_stale">Traefik-configuratie verouderd</string>
+    <string name="alerts_event_fleet_state_changed">Vlootstatus gewijzigd</string>
     <string name="alerts_event_member_added">Lid toegevoegd</string>
     <string name="alerts_event_member_removed">Lid verwijderd</string>
     <string name="alerts_event_member_state_changed">Lid gedraineerd of geactiveerd</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -22,6 +22,15 @@
     <string name="dashboard_summary_all_up">Wszystkie węzły działają</string>
     <string name="dashboard_summary_down">%1$d z %2$d węzłów nie działa</string>
     <string name="dashboard_summary_checking">Sprawdzanie węzłów…</string>
+    <string name="dashboard_state_degraded">Flota osłabiona</string>
+    <string name="dashboard_state_faulty">Flota wadliwa</string>
+    <string name="fleet_reason_member_down">węzeł nie działa</string>
+    <string name="fleet_reason_all_members_down">wszystkie węzły nie działają</string>
+    <string name="fleet_reason_sync_held">synchronizacja wstrzymana</string>
+    <string name="fleet_reason_all_sync_held">synchronizacja wstrzymana w całej flocie</string>
+    <string name="fleet_reason_autosync_stale">niezsynchronizowana ponad dobę</string>
+    <string name="fleet_reason_autosync_stale_long">niezsynchronizowana ponad trzy dni</string>
+    <string name="fleet_reason_traefik_config_stale">Traefik nie pobiera konfiguracji</string>
     <string name="dashboard_empty">Brak węzłów. Dodaj je w Front Desk.</string>
     <string name="dashboard_refresh_failed">Nie udało się odświeżyć: %1$s</string>
     <string name="dashboard_revoked">To urządzenie nie może już uwierzytelnić się w Front Desk. Jego dostęp mógł zostać cofnięty; rozłącz i sparuj ponownie z nowym kodem.</string>
@@ -137,6 +146,7 @@
     <string name="alerts_event_version_fetch_failed">Odczyt wersji nie powiódł się</string>
     <string name="alerts_event_version_fetch_recovered">Odczyt wersji przywrócony</string>
     <string name="alerts_event_traefik_stale">Konfiguracja Traefik nieaktualna</string>
+    <string name="alerts_event_fleet_state_changed">Stan floty zmieniony</string>
     <string name="alerts_event_member_added">Węzeł dodany</string>
     <string name="alerts_event_member_removed">Węzeł usunięty</string>
     <string name="alerts_event_member_state_changed">Węzeł wygaszony lub aktywowany</string>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -22,6 +22,15 @@
     <string name="dashboard_summary_all_up">Все узлы работают</string>
     <string name="dashboard_summary_down">%1$d из %2$d узлов недоступны</string>
     <string name="dashboard_summary_checking">Проверка узлов…</string>
+    <string name="dashboard_state_degraded">Флот деградировал</string>
+    <string name="dashboard_state_faulty">Флот неисправен</string>
+    <string name="fleet_reason_member_down">узел недоступен</string>
+    <string name="fleet_reason_all_members_down">все узлы недоступны</string>
+    <string name="fleet_reason_sync_held">синхронизация приостановлена</string>
+    <string name="fleet_reason_all_sync_held">синхронизация приостановлена во всём флоте</string>
+    <string name="fleet_reason_autosync_stale">не синхронизирован более суток</string>
+    <string name="fleet_reason_autosync_stale_long">не синхронизирован более трёх суток</string>
+    <string name="fleet_reason_traefik_config_stale">Traefik не получает конфигурацию</string>
     <string name="dashboard_empty">Пока нет узлов. Добавьте их в Front Desk.</string>
     <string name="dashboard_refresh_failed">Не удалось обновить: %1$s</string>
     <string name="dashboard_revoked">Это устройство больше не может пройти аутентификацию в Front Desk. Его доступ мог быть отозван; отвяжите и свяжите заново с новым кодом.</string>
@@ -137,6 +146,7 @@
     <string name="alerts_event_version_fetch_failed">Сбой чтения версии</string>
     <string name="alerts_event_version_fetch_recovered">Чтение версии восстановлено</string>
     <string name="alerts_event_traefik_stale">Конфигурация Traefik устарела</string>
+    <string name="alerts_event_fleet_state_changed">Состояние флота изменилось</string>
     <string name="alerts_event_member_added">Узел добавлен</string>
     <string name="alerts_event_member_removed">Узел удалён</string>
     <string name="alerts_event_member_state_changed">Узел выведен или активирован</string>

--- a/android/app/src/main/res/values-sk/strings.xml
+++ b/android/app/src/main/res/values-sk/strings.xml
@@ -22,6 +22,15 @@
     <string name="dashboard_summary_all_up">Všetci členovia bežia</string>
     <string name="dashboard_summary_down">%1$d z %2$d členov je mimo prevádzky</string>
     <string name="dashboard_summary_checking">Kontrola členov…</string>
+    <string name="dashboard_state_degraded">Flotila oslabená</string>
+    <string name="dashboard_state_faulty">Flotila chybná</string>
+    <string name="fleet_reason_member_down">člen mimo prevádzky</string>
+    <string name="fleet_reason_all_members_down">všetci členovia mimo prevádzky</string>
+    <string name="fleet_reason_sync_held">synchronizácia pozastavená</string>
+    <string name="fleet_reason_all_sync_held">synchronizácia pozastavená v celej flotile</string>
+    <string name="fleet_reason_autosync_stale">nesynchronizované viac ako deň</string>
+    <string name="fleet_reason_autosync_stale_long">nesynchronizované viac ako tri dni</string>
+    <string name="fleet_reason_traefik_config_stale">Traefik nenačítava konfiguráciu</string>
     <string name="dashboard_empty">Zatiaľ žiadni členovia. Pridajte ich vo Front Desku.</string>
     <string name="dashboard_refresh_failed">Nepodarilo sa obnoviť: %1$s</string>
     <string name="dashboard_revoked">Toto zariadenie sa už nemôže overiť u Front Desku. Jeho prístup mohol byť odvolaný; zrušte prepojenie a spárujte znova s novým kódom.</string>
@@ -137,6 +146,7 @@
     <string name="alerts_event_version_fetch_failed">Čítanie verzie zlyhalo</string>
     <string name="alerts_event_version_fetch_recovered">Čítanie verzie obnovené</string>
     <string name="alerts_event_traefik_stale">Konfigurácia Traefiku zastaraná</string>
+    <string name="alerts_event_fleet_state_changed">Stav flotily sa zmenil</string>
     <string name="alerts_event_member_added">Člen pridaný</string>
     <string name="alerts_event_member_removed">Člen odstránený</string>
     <string name="alerts_event_member_state_changed">Člen odstavený alebo aktivovaný</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -22,6 +22,15 @@
     <string name="dashboard_summary_all_up">所有成员均在运行</string>
     <string name="dashboard_summary_down">%2$d 个成员中有 %1$d 个已宕机</string>
     <string name="dashboard_summary_checking">正在检查成员…</string>
+    <string name="dashboard_state_degraded">集群已降级</string>
+    <string name="dashboard_state_faulty">集群故障</string>
+    <string name="fleet_reason_member_down">成员宕机</string>
+    <string name="fleet_reason_all_members_down">所有成员宕机</string>
+    <string name="fleet_reason_sync_held">同步已暂停</string>
+    <string name="fleet_reason_all_sync_held">整个集群同步已暂停</string>
+    <string name="fleet_reason_autosync_stale">超过一天未同步</string>
+    <string name="fleet_reason_autosync_stale_long">超过三天未同步</string>
+    <string name="fleet_reason_traefik_config_stale">Traefik 未获取配置</string>
     <string name="dashboard_empty">还没有成员。请在 Front Desk 中添加。</string>
     <string name="dashboard_refresh_failed">刷新失败：%1$s</string>
     <string name="dashboard_revoked">此设备无法再向 Front Desk 进行身份验证。其访问权限可能已被撤销；请取消关联并使用新代码重新配对。</string>
@@ -128,6 +137,7 @@
     <string name="alerts_event_version_fetch_failed">版本读取失败</string>
     <string name="alerts_event_version_fetch_recovered">版本读取已恢复</string>
     <string name="alerts_event_traefik_stale">Traefik 配置已过时</string>
+    <string name="alerts_event_fleet_state_changed">集群状态已更改</string>
     <string name="alerts_event_member_added">成员已添加</string>
     <string name="alerts_event_member_removed">成员已移除</string>
     <string name="alerts_event_member_state_changed">成员已排空或激活</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -24,6 +24,15 @@
     <string name="dashboard_summary_all_up">All members up</string>
     <string name="dashboard_summary_down">%1$d of %2$d members down</string>
     <string name="dashboard_summary_checking">Checking members…</string>
+    <string name="dashboard_state_degraded">Fleet degraded</string>
+    <string name="dashboard_state_faulty">Fleet faulty</string>
+    <string name="fleet_reason_member_down">member down</string>
+    <string name="fleet_reason_all_members_down">all members down</string>
+    <string name="fleet_reason_sync_held">sync held</string>
+    <string name="fleet_reason_all_sync_held">sync held fleet-wide</string>
+    <string name="fleet_reason_autosync_stale">unsynced for over a day</string>
+    <string name="fleet_reason_autosync_stale_long">unsynced for over three days</string>
+    <string name="fleet_reason_traefik_config_stale">Traefik not fetching config</string>
     <string name="dashboard_empty">No members yet. Add them in Front Desk.</string>
     <string name="dashboard_refresh_failed">Couldn\'t refresh: %1$s</string>
     <string name="dashboard_revoked">This device can no longer authenticate to Front Desk. Its access may have been revoked; unlink and pair again with a new code.</string>
@@ -147,6 +156,7 @@
     <string name="alerts_event_version_fetch_failed">Version read failed</string>
     <string name="alerts_event_version_fetch_recovered">Version read recovered</string>
     <string name="alerts_event_traefik_stale">Traefik config stale</string>
+    <string name="alerts_event_fleet_state_changed">Fleet state changed</string>
     <string name="alerts_event_member_added">Member added</string>
     <string name="alerts_event_member_removed">Member removed</string>
     <string name="alerts_event_member_state_changed">Member drained or activated</string>

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/FrontDeskClientTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/FrontDeskClientTest.kt
@@ -354,6 +354,38 @@ class FrontDeskClientTest {
         }
 
     @Test
+    fun autoSyncParsesFleetState() =
+        runBlocking {
+            server.enqueue(
+                MockResponse().setBody(
+                    """{"enabled":true,"primary_id":"p1","stale":false,""" +
+                        """"fleet_state":"degraded","fleet_state_reasons":["member_down","sync_held"]}""",
+                ),
+            )
+
+            val result = client.autoSync(server.url("/").toString(), "tok-1")
+
+            assertTrue(result is FetchResult.Success)
+            result as FetchResult.Success
+            assertEquals("degraded", result.data.fleetState)
+            assertEquals(listOf("member_down", "sync_held"), result.data.fleetStateReasons)
+        }
+
+    @Test
+    fun autoSyncFleetStateDefaultsOnLegacyPayload() =
+        runBlocking {
+            // A Front Desk that predates the state machine omits both fields.
+            server.enqueue(MockResponse().setBody("""{"enabled":true,"primary_id":"p1","stale":false}"""))
+
+            val result = client.autoSync(server.url("/").toString(), "tok-1")
+
+            assertTrue(result is FetchResult.Success)
+            result as FetchResult.Success
+            assertEquals("", result.data.fleetState)
+            assertEquals(emptyList<String>(), result.data.fleetStateReasons)
+        }
+
+    @Test
     fun unlinkMalformedUrlIsFalseNotThrow() =
         runBlocking {
             assertFalse(client.unlink("not a url", "tok"))

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModelTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModelTest.kt
@@ -431,6 +431,59 @@ class DashboardViewModelTest {
         }
 
     @Test
+    fun refreshExposesServerFleetStateAndReasons() =
+        runBlocking {
+            val client =
+                FakeFleetClient(
+                    membersResult = FetchResult.Success(listOf(member)),
+                    autoSyncResult =
+                        FetchResult.Success(
+                            AutoSyncConfig(
+                                enabled = true,
+                                primaryId = "m1",
+                                fleetState = "faulty",
+                                fleetStateReasons = listOf("all_members_down"),
+                            ),
+                        ),
+                )
+            val vm = DashboardViewModel(client, linkedStore(), "http://fd:1")
+
+            vm.refreshOnce()
+
+            val s = vm.state.value
+            assertEquals("faulty", s.fleetState)
+            assertEquals(listOf("all_members_down"), s.fleetStateReasons)
+        }
+
+    @Test
+    fun failedAutoSyncFetchKeepsPreviousFleetState() =
+        runBlocking {
+            val client =
+                FakeFleetClient(
+                    membersResult = FetchResult.Success(listOf(member)),
+                    autoSyncResult =
+                        FetchResult.Success(
+                            AutoSyncConfig(
+                                enabled = true,
+                                primaryId = "m1",
+                                fleetState = "degraded",
+                                fleetStateReasons = listOf("member_down"),
+                            ),
+                        ),
+                )
+            val vm = DashboardViewModel(client, linkedStore(), "http://fd:1")
+            vm.refreshOnce()
+            assertEquals("degraded", vm.state.value.fleetState)
+
+            // A failed autosync read must leave the last good verdict in place,
+            // exactly as primaryId survives the same failure.
+            client.autoSyncResult = FetchResult.Failure("autosync down")
+            vm.refreshOnce()
+            assertEquals("degraded", vm.state.value.fleetState)
+            assertEquals(listOf("member_down"), vm.state.value.fleetStateReasons)
+        }
+
+    @Test
     fun onlyVisibleMembersGetTrafficFetched() =
         runBlocking {
             // Two members, but only m1 is reported visible: the off-screen m2


### PR DESCRIPTION
Final slice of the fleet-status state machine. Slices A (backend, #487) and B (Front Desk web, #488) are merged; this renders the same verdict in the Bellhop Android app.

## What this adds

The dashboard summary line now **prefers the server's fleet-state verdict** over its local all-up/down rollup:

- `AutoSyncConfig` gains `fleet_state` and `fleet_state_reasons` (kotlinx defaults, so a legacy Front Desk payload still decodes and the dashboard keeps working).
- The summary line shows the server state (`ok`/`degraded`/`faulty`) with its translated reason codes, and falls back to the existing local rollup when the backend omits `fleet_state`. The local "checking" line still wins while every member is unprobed (Front Desk reports ok before its first probes, so "checking" is honester).
- Unknown reason codes fall back to the raw code (mirroring `eventTypeLabel`), so a newer backend never crashes or blanks the line.
- The `fleet.state_changed` event gets a label in the events/alerts lists.

## i18n

10 new strings hand-translated into all 10 locales (cs de es fr ja nl pl ru sk zh), reusing each locale's established terminology for member/fleet/sync/primary. `lintDebug` MissingTranslation is clean.

## Testing

Two new ViewModel tests cover the state plumbing (server verdict exposed after refresh; an autosync-fetch failure keeps the previous values). Full gate green: `:app:testDebugUnitTest`, `:app:ktlintCheck`, and `:app:lintDebug` all pass.

## Notes for reviewers

- The degraded summary line uses the theme `primary` role (brass on dark, copper on light), not `SeverityWarnFg` — the latter is a near-black badge foreground that would be invisible as standalone text on the dark dashboard surface (caught in review; see commit c243a30).
- `FleetSummary` was split into server/local paths; the local rollup logic is preserved verbatim for the older-backend fallback.
- Scoped out by design: the Bellhop push notifier does not page on fleet-state changes (fleet-state is a dashboard-render concern here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)