### PR TITLE
fix(ui): centre FD fleet-state badge; compact dashboard owner filter

### DIFF
--- a/frontdesk/web/src/index.css
+++ b/frontdesk/web/src/index.css
@@ -174,11 +174,19 @@ h3 {
 	font-size: 1.25rem;
 	margin-bottom: 1rem;
 }
-/* Aligns the page title with the fleet-state badge on the Members header. */
+/* Aligns the page title with the fleet-state badge on the Members header.
+   The title's own bottom margin is carried by the row instead: otherwise
+   align-items:center centres the badge on the h1's text-plus-margin box,
+   dropping it below the middle of the visible title text. Row margin +
+   .fd-stack gap keep the same total space below the header as before. */
 .fd-page-title-row {
 	display: flex;
 	align-items: center;
 	gap: 0.75rem;
+	margin-bottom: 1rem;
+}
+.fd-page-title-row .fd-page-title {
+	margin-bottom: 0;
 }
 
 /* --- footer (build version + wiki link), centered at the bottom of the shell --- */

--- a/web/src/components/FilterDropdown.tsx
+++ b/web/src/components/FilterDropdown.tsx
@@ -15,6 +15,13 @@ interface FilterDropdownProps {
 	 * required selector (e.g. a form field) where every choice is a real value.
 	 */
 	allowClear?: boolean;
+	/**
+	 * Trigger sizing. "input" (default) matches a form field (ui-input, h-9).
+	 * "compact" drops ui-input for a 10px, minimally-padded trigger that sits
+	 * flush with the dashboard's segmented toggles (ui-tab) rather than towering
+	 * over them. Only the trigger changes; the popup menu is shared.
+	 */
+	variant?: "input" | "compact";
 }
 
 export function FilterDropdown({
@@ -25,6 +32,7 @@ export function FilterDropdown({
 	allLabel,
 	className = "",
 	allowClear = true,
+	variant = "input",
 }: FilterDropdownProps) {
 	const { t } = useTranslation();
 	const effectivePlaceholder =
@@ -52,6 +60,15 @@ export function FilterDropdown({
 		? (selectedOption?.label ?? value)
 		: effectiveAllLabel;
 
+	const compact = variant === "compact";
+	// Compact avoids ui-input (whose themed base font/padding beat Tailwind
+	// utilities) so it can shrink to the 10px, py-px scale of the ui-tab toggles
+	// it sits beside; the default keeps the form-field look.
+	const triggerClass = compact
+		? "text-[10px] leading-[1.6] font-semibold py-px px-1.5 rounded-(--radius-button) border border-(--border-input) bg-(--surface-input) hover:border-(--accent) transition-colors flex items-center justify-between gap-1"
+		: "ui-input text-xs py-1.5 px-2.5 h-9 w-full flex items-center justify-between gap-2";
+	const iconSize = compact ? 12 : 14;
+
 	return (
 		<div ref={containerRef} className={`relative inline-block ${className}`}>
 			<button
@@ -62,7 +79,7 @@ export function FilterDropdown({
 						? `${effectivePlaceholder}: ${displayLabel}`
 						: effectivePlaceholder
 				}
-				className="ui-input text-xs py-1.5 px-2.5 h-9 w-full flex items-center justify-between gap-2"
+				className={triggerClass}
 			>
 				<span
 					className={`truncate ${value === "" ? "text-(--text-secondary)" : "text-(--text-primary)"}`}
@@ -89,11 +106,11 @@ export function FilterDropdown({
 							}}
 							title={t("common.clearFilter")}
 						>
-							<X size={14} />
+							<X size={iconSize} />
 						</span>
 					)}
 					<ChevronDown
-						size={14}
+						size={iconSize}
 						className={`text-(--text-tertiary) transition-transform ${open ? "rotate-180" : ""}`}
 					/>
 				</span>

--- a/web/src/components/FilterDropdown.tsx
+++ b/web/src/components/FilterDropdown.tsx
@@ -63,9 +63,11 @@ export function FilterDropdown({
 	const compact = variant === "compact";
 	// Compact avoids ui-input (whose themed base font/padding beat Tailwind
 	// utilities) so it can shrink to the 10px, py-px scale of the ui-tab toggles
-	// it sits beside; the default keeps the form-field look.
+	// it sits beside; the default keeps the form-field look. w-full lets the
+	// button fill (and so truncate within) a width-capped wrapper such as the
+	// dashboard's max-w-32 rather than growing to a long owner label.
 	const triggerClass = compact
-		? "text-[10px] leading-[1.6] font-semibold py-px px-1.5 rounded-(--radius-button) border border-(--border-input) bg-(--surface-input) hover:border-(--accent) transition-colors flex items-center justify-between gap-1"
+		? "text-[10px] leading-[1.6] font-semibold py-px px-1.5 rounded-(--radius-button) border border-(--border-input) bg-(--surface-input) hover:border-(--accent) transition-colors flex items-center justify-between gap-1 w-full"
 		: "ui-input text-xs py-1.5 px-2.5 h-9 w-full flex items-center justify-between gap-2";
 	const iconSize = compact ? 12 : 14;
 

--- a/web/src/components/__tests__/FilterDropdown.test.tsx
+++ b/web/src/components/__tests__/FilterDropdown.test.tsx
@@ -207,4 +207,37 @@ describe("FilterDropdown", () => {
 		// ChevronDown icon should be present
 		expect(triggerButton.querySelector("svg")).toBeInTheDocument();
 	});
+
+	it("compact variant drops ui-input for the toggle-sized trigger", () => {
+		render(
+			<FilterDropdown
+				options={options}
+				value=""
+				onChange={onChange}
+				variant="compact"
+			/>,
+		);
+		const trigger = screen.getByRole("button", { name: "Filter" });
+		// Compact matches the 10px ui-tab toggles beside it, not the ui-input field.
+		expect(trigger).toHaveClass("text-[10px]");
+		expect(trigger).not.toHaveClass("ui-input");
+		// w-full lets a long label truncate within a width-capped wrapper
+		// (e.g. the dashboard's max-w-32) instead of overflowing.
+		expect(trigger).toHaveClass("w-full");
+	});
+
+	it("compact variant renders a smaller (12px) chevron", () => {
+		render(
+			<FilterDropdown
+				options={options}
+				value=""
+				onChange={onChange}
+				variant="compact"
+			/>,
+		);
+		const svg = screen
+			.getByRole("button", { name: "Filter" })
+			.querySelector("svg");
+		expect(svg).toHaveAttribute("width", "12");
+	});
 });

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -195,6 +195,7 @@ export function Dashboard() {
 							<MetricToggle value={globalMetric} onChange={setGlobalMetric} />
 							{isAdmin && (ownerOptions?.length ?? 0) > 0 && (
 								<FilterDropdown
+									variant="compact"
 									value={ownerUserID}
 									onChange={setOwnerUserID}
 									placeholder={t("logs.filters.owner")}
@@ -203,7 +204,7 @@ export function Dashboard() {
 										value: u.id,
 										label: u.username,
 									}))}
-									className="w-32"
+									className="max-w-32"
 								/>
 							)}
 						</div>


### PR DESCRIPTION
Two small UI fixes across both frontends.

## Front Desk — fleet-state badge vertical alignment
`.fd-page-title` carried a `margin-bottom: 1rem`. Inside the `align-items: center` `.fd-page-title-row`, that margin enlarged the `<h1>`'s box downward, so the badge centred on *text + margin* and sat visibly below the middle of the "Members" title text. The margin now lives on the row (zeroed on the title inside it), so the badge centres on the visible text. Space below the header is unchanged: row `margin-bottom` + `.fd-stack` gap match the previous total.

## Model Hotel — compact dashboard owner filter
The shared `FilterDropdown` trigger is `ui-input`-based, and `[data-ui-style] .ui-input` (specificity 0,2,0) overrode its Tailwind `text-xs`/`py-1.5`, forcing the 14px base font (12px mono in the terminal theme) and a fixed `h-9` height. Next to the dashboard's 10px `ui-tab` toggles it looked oversized, worst in the terminal theme.

Added an opt-in `variant="compact"` that renders a non-`ui-input` trigger at the toggles' scale (`text-[10px]`, `py-px px-1.5`, thin `--border-input` border, 12px icons). The shared default (`variant="input"`) is untouched, so Logs / Providers / Failover Groups look identical. Only the dashboard owner filter opts in (`max-w-32` so long usernames truncate).

## Verification
- `tsc -b` clean; Biome clean; 16 `FilterDropdown` tests pass.
- Confirmed visually in a rebuilt container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)