### PR TITLE
chore(lint): enforce warnings as errors, ratchet gocyclo onto prod code

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,7 +14,7 @@ linters:
     - gosec        # Security issues (hardcoded credentials, SQL injection, weak crypto)
     - gocritic     # Style and performance checks (unchecked range values, sloppy realloc)
     - revive       # Drop-in golint replacement with extra rules
-    - gocyclo      # Cyclomatic complexity (warning-only via severity)
+    - gocyclo      # Cyclomatic complexity (prod code only; tests + generated migrations excluded below)
     - errorlint    # Proper error wrapping/inspection (errors.Is, errors.As)
     - nilerr       # Checks for returning nil even if err != nil
     - bodyclose    # HTTP response body must be closed
@@ -24,7 +24,11 @@ linters:
       check-type-assertions: false
 
     gocyclo:
-      min-complexity: 15
+      # Ceiling for prod code (tests + generated migrations excluded below).
+      # 30 is the current ratchet: 6 known hotspots above it carry justified
+      # inline nolints (see gocyclo refactor shortlist); lower this as they
+      # get refactored.
+      min-complexity: 30
 
     gocritic:
       enabled-tags:
@@ -79,15 +83,18 @@ linters:
         linters:
           - gocyclo
 
-      # gocyclo is advisory, not CI-blocking (any file)
-      - path: ".*"
-        linters:
-          - gocyclo
-
       # gocritic style/performance suggestions are advisory
       - linters:
           - gocritic
-        text: "hugeParam|rangeValCopy|importShadow|unnamedResult|nestingReduce|exitAfterDefer|deferInLoop|sprintfQuotedString"
+        text: "hugeParam|rangeValCopy|importShadow|unnamedResult|nestingReduce|sprintfQuotedString"
+
+      # deferInLoop/exitAfterDefer stay active in prod code (they catch real
+      # leaks) but are noise in tests: defer-per-iteration cleanup and
+      # os.Exit in TestMain are deliberate patterns there.
+      - path: _test\.go
+        linters:
+          - gocritic
+        text: "deferInLoop|exitAfterDefer"
 
       # revive unused-parameter and package-comments are advisory
       - linters:

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -87,6 +87,7 @@ func publishDiscoveryEvent(source string, result DiscoveryResult) {
 	}
 }
 
+//nolint:gocyclo // complexity 114: linear startup wiring (config, DI, route registration), not branching logic; on the gocyclo refactor shortlist
 func main() {
 	cfg, err := config.Load()
 	if err != nil {

--- a/frontdesk/web/biome.json
+++ b/frontdesk/web/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.1/schema.json",
 	"vcs": {
 		"enabled": true,
 		"clientKind": "git",
@@ -17,7 +17,7 @@
 		"rules": {
 			"recommended": true,
 			"correctness": {
-				"useExhaustiveDependencies": "warn"
+				"useExhaustiveDependencies": "error"
 			}
 		}
 	},

--- a/frontdesk/web/eslint.config.js
+++ b/frontdesk/web/eslint.config.js
@@ -19,8 +19,10 @@ export default defineConfig([
 			ecmaVersion: 2020,
 			globals: globals.browser,
 		},
+		// Kept at "error" (plugin default is warn): warn-level findings pass
+		// `pnpm lint` silently, so genuine missing deps would never block CI.
 		rules: {
-			"react-hooks/exhaustive-deps": "warn",
+			"react-hooks/exhaustive-deps": "error",
 		},
 	},
 ]);

--- a/internal/api/configsync_apply.go
+++ b/internal/api/configsync_apply.go
@@ -34,6 +34,8 @@ import (
 // The lock is taken for every import, headed or not, so a headerless push cannot
 // slip past a generation that already committed. That, plus the same-transaction
 // advance, is what makes a newer config win regardless of the order pushes arrive.
+//
+//nolint:gocyclo // complexity 33: staged import pipeline with per-entity guards; on the gocyclo refactor shortlist
 func (h *ConfigSyncHandler) apply(ctx context.Context, env ConfigEnvelope, sourceGen *int64) error {
 	tx, err := h.db.Begin(ctx)
 	if err != nil {

--- a/internal/api/failover.go
+++ b/internal/api/failover.go
@@ -316,6 +316,8 @@ type UpdateFailoverGroupRequest struct {
 }
 
 // Update updates an existing failover group by ID.
+//
+//nolint:gocyclo // complexity 35: sequential validation of many optional PATCH fields; on the gocyclo refactor shortlist
 func (h *FailoverHandler) Update(w http.ResponseWriter, r *http.Request) {
 	id, ok := parseUUIDParam(w, r, "id", "failover group ID")
 	if !ok {

--- a/internal/provider/discovery.go
+++ b/internal/provider/discovery.go
@@ -165,6 +165,8 @@ func (d *DiscoveryService) fetchURL(ctx context.Context, method, url string, hea
 // host matching and suffix matching so that "https://my-proxy.deepseek.com"
 // correctly resolves to "deepseek" rather than matching a substring like
 // strings.Contains would.
+//
+//nolint:gocyclo // complexity 38: flat hostname-matching table over the provider list; on the gocyclo refactor shortlist
 func DetectProviderType(baseURL string) string {
 	u, err := url.Parse(strings.TrimSpace(baseURL))
 	if err != nil || u.Host == "" {

--- a/internal/provider/modelsdev.go
+++ b/internal/provider/modelsdev.go
@@ -296,6 +296,8 @@ func (c *ModelsDevCache) LookupFuzzy(modelID string) *ModelsDevModelSpec {
 // EnrichModel fills gaps in a model.Model using models.dev data.
 // It only overwrites fields that are empty/zero (never replaces existing data).
 // Returns true if at least one field was enriched.
+//
+//nolint:gocyclo // complexity 38: repetitive per-field if-empty gap filling; on the gocyclo refactor shortlist
 func (c *ModelsDevCache) EnrichModel(m *model.Model) bool {
 	if c == nil {
 		return false

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -293,6 +293,8 @@ func (st *streamState) emitData(sink *streamSink, payload []byte, transform stri
 // whole transform dispatch are encapsulated here. Returns stop=true when a client
 // write failed (the caller jumps to finalize), false otherwise (advance to the
 // next event).
+//
+//nolint:gocyclo // complexity 33: SSE transform dispatch for every chunk shape; on the gocyclo refactor shortlist
 func (h *Handler) handleDataChunk(sink *streamSink, st *streamState, ev sseEvent, stripReasoning bool, chunkCount int, logData *requestLogData) (stop bool) {
 	payload := ev.payload
 	line := ev.raw

--- a/web/biome.json
+++ b/web/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.5.2/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.3/schema.json",
 	"vcs": {
 		"enabled": true,
 		"clientKind": "git",
@@ -23,7 +23,7 @@
 		"rules": {
 			"preset": "recommended",
 			"correctness": {
-				"useExhaustiveDependencies": "warn"
+				"useExhaustiveDependencies": "error"
 			}
 		}
 	},

--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -19,23 +19,29 @@ export default defineConfig([
 			ecmaVersion: 2020,
 			globals: globals.browser,
 		},
-		// Downgrade from "error" to "warn": streaming/orchestration hooks
-		// intentionally access mutable refs (abortMapRef, roundsRef, etc.)
-		// inside useCallback bodies without listing them in dep arrays.
-		// Ref identity is stable so they're never needed as deps, but the
-		// linter can't distinguish refs from other values. "warn" catches
-		// genuine missing deps without blocking CI on ref false positives.
-		//
-		// The compiler-enforced purity/refs/set-state-in-effect rules are
-		// overly strict for common patterns like Date.now() in render
-		// (SortableEntry, ToastContext) and ref initialization (ToastContext).
-		// Downgrade to "warn" so they're surfaced without blocking CI.
+		// All react-hooks rules run at "error": the codebase is clean, and
+		// known false positives (stable-ref access in streaming hooks,
+		// Date.now() in render, TanStack Virtual's mutable functions) carry
+		// per-line eslint-disable comments with justifications. Keep it that
+		// way — a warn-level downgrade would let new violations pass CI
+		// silently.
 		rules: {
-			"react-hooks/exhaustive-deps": "warn",
-			"react-hooks/preserve-manual-memoization": "warn",
-			"react-hooks/purity": "warn",
-			"react-hooks/refs": "warn",
-			"react-hooks/set-state-in-effect": "warn",
+			"react-hooks/exhaustive-deps": "error",
+			"react-hooks/preserve-manual-memoization": "error",
+			"react-hooks/purity": "error",
+			"react-hooks/refs": "error",
+			"react-hooks/set-state-in-effect": "error",
+			// Underscore prefix marks intentionally-unused params/vars
+			// (mock interfaces, destructure-to-omit) instead of per-line
+			// disables.
+			"@typescript-eslint/no-unused-vars": [
+				"error",
+				{
+					argsIgnorePattern: "^_",
+					varsIgnorePattern: "^_",
+					caughtErrorsIgnorePattern: "^_",
+				},
+			],
 		},
 	},
 ]);

--- a/web/src/data/__tests__/presets.test.ts
+++ b/web/src/data/__tests__/presets.test.ts
@@ -9,8 +9,7 @@ describe("CHAT_PERSONAS", () => {
 	});
 
 	it("items have required fields: id, icon, label, systemPrompt", () => {
-		// eslint-disable-next-line @typescript-eslint/no-unused-vars
-		CHAT_PERSONAS.forEach((persona: PersonaPreset, _index: number) => {
+		CHAT_PERSONAS.forEach((persona: PersonaPreset) => {
 			expect(persona).toHaveProperty("id");
 			expect(persona).toHaveProperty("icon");
 			expect(persona).toHaveProperty("label");
@@ -25,8 +24,7 @@ describe("CHAT_PERSONAS", () => {
 	});
 
 	it("system prompts are i18n key paths", () => {
-		// eslint-disable-next-line @typescript-eslint/no-unused-vars
-		CHAT_PERSONAS.forEach((persona: PersonaPreset, _index: number) => {
+		CHAT_PERSONAS.forEach((persona: PersonaPreset) => {
 			expect(typeof persona.systemPrompt).toBe("string");
 			expect(persona.systemPrompt).toMatch(
 				/^presets\.personas\.[a-z0-9-]+\.prompt$/,
@@ -42,8 +40,7 @@ describe("ARENA_PROMPTS", () => {
 	});
 
 	it("items have required fields: id, icon, label, prompt", () => {
-		// eslint-disable-next-line @typescript-eslint/no-unused-vars
-		ARENA_PROMPTS.forEach((prompt: ArenaPromptPreset, _index: number) => {
+		ARENA_PROMPTS.forEach((prompt: ArenaPromptPreset) => {
 			expect(prompt).toHaveProperty("id");
 			expect(prompt).toHaveProperty("icon");
 			expect(prompt).toHaveProperty("label");
@@ -58,8 +55,7 @@ describe("ARENA_PROMPTS", () => {
 	});
 
 	it("prompts are i18n key paths", () => {
-		// eslint-disable-next-line @typescript-eslint/no-unused-vars
-		ARENA_PROMPTS.forEach((prompt: ArenaPromptPreset, _index: number) => {
+		ARENA_PROMPTS.forEach((prompt: ArenaPromptPreset) => {
 			expect(typeof prompt.prompt).toBe("string");
 			expect(prompt.prompt).toMatch(/^presets\.prompts\.[a-z0-9-]+\.text$/);
 		});

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -1,4 +1,8 @@
-/* eslint-disable react-hooks/refs */
+/* eslint-disable react-hooks/refs -- useChat() returns refs mixed with state
+   in one object, so the compiler flags every `chat.*` access in the JSX
+   (~90 false positives). Scoping per-line would blanket the whole render;
+   separating refs out of the useChat return is the real fix if this file is
+   ever refactored. */
 
 import { useTranslation } from "react-i18next";
 import {

--- a/web/src/pages/Settings/__tests__/DiscoverySettings.test.tsx
+++ b/web/src/pages/Settings/__tests__/DiscoverySettings.test.tsx
@@ -411,9 +411,17 @@ describe("DiscoverySettings", () => {
 		});
 
 		it("disables settings controls while discovery is in progress", async () => {
+			// Gate the response so the mutation stays pending exactly until the
+			// disabled-state assertions are done, then settles inside the test —
+			// a handler that outlives the test rejects after jsdom teardown and
+			// crashes in the onError toast ("window is not defined").
+			let release: () => void = () => {};
+			const gate = new Promise<void>((resolve) => {
+				release = resolve;
+			});
 			server.use(
 				http.post("/api/providers/discover-all", async () => {
-					await new Promise((resolve) => setTimeout(resolve, 2000));
+					await gate;
 					return HttpResponse.json({
 						succeeded: 1,
 						failed: 0,
@@ -446,6 +454,12 @@ describe("DiscoverySettings", () => {
 			await waitFor(() => {
 				expect(slider).toBeDisabled();
 				expect(discoverOnStartupToggle).toBeDisabled();
+			});
+
+			// Let the mutation settle before the test ends.
+			release();
+			await waitFor(() => {
+				expect(screen.getByText("Discovery complete")).toBeInTheDocument();
 			});
 		});
 	});

--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -65,18 +65,14 @@ class MockEventSource {
 	}
 
 	addEventListener(
-		// eslint-disable-next-line @typescript-eslint/no-unused-vars
 		_event: string,
-		// eslint-disable-next-line @typescript-eslint/no-unused-vars
 		_listener: (event: MessageEvent) => void,
 	): void {
 		// No-op for basic testing
 	}
 
 	removeEventListener(
-		// eslint-disable-next-line @typescript-eslint/no-unused-vars
 		_event: string,
-		// eslint-disable-next-line @typescript-eslint/no-unused-vars
 		_listener: (event: MessageEvent) => void,
 	): void {
 		// No-op for basic testing
@@ -133,7 +129,6 @@ vi.stubGlobal(
 // Mock ResizeObserver (jsdom doesn't implement it)
 if (typeof globalThis.ResizeObserver === "undefined") {
 	globalThis.ResizeObserver = class ResizeObserver {
-		// eslint-disable-next-line @typescript-eslint/no-unused-vars
 		observe(_target: Element, _options?: ResizeObserverOptions) {}
 		unobserve() {}
 		disconnect() {}


### PR DESCRIPTION
## Summary

Follow-up to a full lint/suppression audit: every gate was passing, but several linters were configured so their findings could never block CI. This PR makes them enforce for real, with zero new violations.

- **golangci**: remove the `path: ".*"` exclusion that silently disabled gocyclo everywhere. It now enforces `min-complexity: 30` on prod code (tests + generated migrations stay excluded); the 6 known hotspots above 30 (`main` 114, `EnrichModel` 38, `DetectProviderType` 38, failover `Update` 35, `handleDataChunk` 33, configsync `apply` 33) carry individually justified `//nolint:gocyclo`. Ratchet down as the refactor shortlist lands.
- **golangci**: gocritic `deferInLoop`/`exitAfterDefer` re-enabled for prod code (they catch real leaks); excluded only in `_test.go` where the 5 existing hits are deliberate TestMain/cleanup patterns.
- **ESLint (both frontends)**: react-hooks rules re-promoted from `warn` to `error`. The codebase is clean at error severity, and warn-level findings pass `pnpm lint` silently, so the downgrade only hid future regressions.
- **ESLint (web)**: `argsIgnorePattern: "^_"` replaces nine inline `no-unused-vars` disables on underscore-prefixed params; unused `_index` params dropped in `presets.test.ts`.
- **Biome (both)**: `useExhaustiveDependencies` warn → error; `$schema` pins bumped to the installed CLI versions, killing the per-run version-mismatch notice.
- **Chat.tsx**: the file-wide `react-hooks/refs` disable now documents why file scope is correct (~90 false positives because `useChat()` returns refs mixed with state).
- **DiscoverySettings.test**: fix a flaky unhandled rejection — the 2s-sleeping MSW handler outlived the test and its late rejection hit the mutation's `onError` toast after jsdom teardown. The handler is now gated so the mutation settles in-test.

## Test plan

- `golangci-lint run ./...` clean; `make build` clean
- `go test ./...` 5512 passed (pre-change; Go edits are comments/config only)
- web: ESLint raw 0 errors/0 warnings, Biome clean, `tsc -b` clean, vitest 5333/5333 with 0 unhandled errors
- frontdesk/web: ESLint raw clean at error severity, Biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)