### PR TITLE
chore(modernize): gopls modernize fixes, internal/api + internal/proxy (1/2)

### DIFF
--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -744,8 +744,7 @@ func providerTypeAllowsEmptyKey(baseURL string) bool {
 
 // isUniqueViolation checks if the error is a PostgreSQL unique constraint violation (error code 23505).
 func isUniqueViolation(err error) bool {
-	var pgErr *pgconn.PgError
-	if errors.As(err, &pgErr) {
+	if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok {
 		return pgErr.Code == "23505"
 	}
 	return false
@@ -753,8 +752,7 @@ func isUniqueViolation(err error) bool {
 
 // isForeignKeyViolation checks if the error is a PostgreSQL foreign key violation (error code 23503).
 func isForeignKeyViolation(err error) bool {
-	var pgErr *pgconn.PgError
-	if errors.As(err, &pgErr) {
+	if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok {
 		return pgErr.Code == "23503"
 	}
 	return false

--- a/internal/api/admin_test.go
+++ b/internal/api/admin_test.go
@@ -248,7 +248,7 @@ func newChiRequest(method, path string, body io.Reader) (*http.Request, *httptes
 	return req, httptest.NewRecorder()
 }
 
-func parseJSON(t *testing.T, w *httptest.ResponseRecorder, v interface{}) {
+func parseJSON(t *testing.T, w *httptest.ResponseRecorder, v any) {
 	t.Helper()
 	if err := json.NewDecoder(w.Body).Decode(v); err != nil {
 		t.Fatalf("failed to decode JSON response: %v", err)
@@ -1584,7 +1584,7 @@ func TestListProviders_Integration(t *testing.T) {
 		t.Fatalf("expected status 200 OK, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var response []map[string]interface{}
+	var response []map[string]any
 	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}

--- a/internal/api/applogs_buffer.go
+++ b/internal/api/applogs_buffer.go
@@ -41,7 +41,7 @@ var stderrSuppressSources = map[string]bool{}
 func (f *stderrLogFilter) Write(p []byte) (n int, err error) {
 	text := string(p)
 	debugEnabled := debuglog.Level() <= slog.LevelDebug
-	for _, line := range strings.Split(strings.TrimRight(text, "\n"), "\n") {
+	for line := range strings.SplitSeq(strings.TrimRight(text, "\n"), "\n") {
 		if line == "" {
 			continue
 		}
@@ -170,7 +170,7 @@ func (w *dbLogWriter) flush(entries []AppLogEntry) {
 	// Build batch INSERT
 	builder := strings.Builder{}
 	builder.WriteString("INSERT INTO app_logs (timestamp, level, source, message) VALUES ")
-	args := make([]interface{}, 0, len(entries)*4)
+	args := make([]any, 0, len(entries)*4)
 	for i, e := range entries {
 		if i > 0 {
 			builder.WriteString(", ")

--- a/internal/api/applogs_golden_test.go
+++ b/internal/api/applogs_golden_test.go
@@ -29,7 +29,7 @@ func TestGetAppLogsCursor_Golden(t *testing.T) {
 
 	source := "goldsrc-" + uuid.New().String()[:8]
 	ids := make([]string, 6) // newest (0) -> oldest (5)
-	for i := 0; i < 6; i++ {
+	for i := range 6 {
 		id := uuid.New().String()
 		ids[i] = id
 		level := "info"

--- a/internal/api/applogs_handler_test.go
+++ b/internal/api/applogs_handler_test.go
@@ -50,7 +50,7 @@ func TestRingBufferWriteEntry_WrapAround(t *testing.T) {
 	}()
 
 	// Fill the buffer to capacity
-	for i := 0; i < appLogBufferSize; i++ {
+	for i := range appLogBufferSize {
 		entry := AppLogEntry{
 			Timestamp: time.Now().UTC().Add(time.Duration(i) * time.Second).Format(time.RFC3339Nano),
 			Level:     "info",
@@ -106,7 +106,7 @@ func TestRingBufferGetEntries_Order(t *testing.T) {
 	}()
 
 	// Add entries in order
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		entry := AppLogEntry{
 			Timestamp: time.Now().UTC().Add(time.Duration(i) * time.Second).Format(time.RFC3339Nano),
 			Level:     "info",
@@ -122,7 +122,7 @@ func TestRingBufferGetEntries_Order(t *testing.T) {
 	}
 
 	// Should be in chronological order (oldest first)
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		if !strings.Contains(entries[i].Message, fmt.Sprintf("message %d", i)) {
 			t.Errorf("entry %d should contain 'message %d', got %q", i, i, entries[i].Message)
 		}
@@ -137,7 +137,7 @@ func TestRingBufferClear(t *testing.T) {
 	}()
 
 	// Add some entries
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		entry := AppLogEntry{
 			Timestamp: time.Now().UTC().Add(time.Duration(i) * time.Second).Format(time.RFC3339Nano),
 			Level:     "info",
@@ -722,7 +722,7 @@ func TestGetAppLogs_WithLimitAndAfter(t *testing.T) {
 
 	// Add 15 entries with different timestamps
 	baseTime := time.Now().UTC()
-	for i := 0; i < 15; i++ {
+	for i := range 15 {
 		entry := AppLogEntry{
 			Timestamp: baseTime.Add(time.Duration(i) * time.Second).Format(time.RFC3339Nano),
 			Level:     "info",
@@ -784,7 +784,7 @@ func TestClearAppLogs_WithBuffer(t *testing.T) {
 	}()
 
 	// Add some entries
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		entry := AppLogEntry{
 			Timestamp: time.Now().UTC().Add(time.Duration(i) * time.Second).Format(time.RFC3339Nano),
 			Level:     "info",
@@ -828,7 +828,7 @@ func TestGetAppLogs_HistoryWithDB(t *testing.T) {
 	ctx := context.Background()
 
 	// Insert a few app log entries
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		_, err := pool.Exec(ctx,
 			`INSERT INTO app_logs (timestamp, level, source, message)
 			 VALUES (NOW(), $1, $2, $3)`,
@@ -881,7 +881,7 @@ func TestGetAppLogs_HistorySuccessWithDB(t *testing.T) {
 	// Insert app log entries with varied levels and sources
 	levels := []string{"info", "warning", "error"}
 	sources := []string{"proxy", "auth"}
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		level := levels[i%len(levels)]
 		source := sources[i%len(sources)]
 		_, err := pool.Exec(ctx,
@@ -952,7 +952,7 @@ func TestGetAppLogs_HistoryPagination(t *testing.T) {
 	ctx := context.Background()
 
 	// Insert more entries than one page can hold
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		_, err := pool.Exec(ctx,
 			`INSERT INTO app_logs (timestamp, level, source, message)
 			 VALUES (NOW() + ($1 || ' seconds')::interval, $2, $3, $4)`,

--- a/internal/api/applogs_slog.go
+++ b/internal/api/applogs_slog.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"maps"
 	"os"
 	"slices"
 	"strings"
@@ -131,9 +132,7 @@ func (h *appSlogHandler) Handle(_ context.Context, r slog.Record) error {
 // attr key so the line's shape is always predictable for collectors.
 func (h *appSlogHandler) renderJSONLine(t time.Time, level, source, msg string, fields map[string]string) []byte {
 	obj := make(map[string]string, len(fields)+4)
-	for k, v := range fields {
-		obj[k] = v
-	}
+	maps.Copy(obj, fields)
 	obj["time"] = t.UTC().Format(time.RFC3339Nano)
 	obj["level"] = level
 	obj["source"] = source

--- a/internal/api/applogs_test.go
+++ b/internal/api/applogs_test.go
@@ -780,7 +780,7 @@ func TestDBLogWriter_BatchSizeFlush(t *testing.T) {
 	defer w.stop()
 
 	// Send 50 entries to trigger the batch-size flush path (lines 127-130)
-	for i := 0; i < 50; i++ {
+	for i := range 50 {
 		w.ch <- AppLogEntry{
 			Timestamp: time.Now().UTC().Format(time.RFC3339Nano),
 			Level:     "info",
@@ -828,7 +828,7 @@ func TestDBLogWriter_TickerFlush(t *testing.T) {
 	defer w.stop()
 
 	// Send a few entries (less than 50) and wait for the ticker to flush
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		w.ch <- AppLogEntry{
 			Timestamp: time.Now().UTC().Format(time.RFC3339Nano),
 			Level:     "info",
@@ -877,7 +877,7 @@ func TestDBLogWriter_FlushDBError(t *testing.T) {
 	defer w.stop()
 
 	// Send entries — they'll be flushed but the DB write will fail silently
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		w.ch <- AppLogEntry{
 			Timestamp: time.Now().UTC().Format(time.RFC3339Nano),
 			Level:     "info",
@@ -971,7 +971,7 @@ func TestGetAppLogsCursor_Default(t *testing.T) {
 	pool := h.Pool().Pool()
 
 	// Insert test app logs with different timestamp and created_at values
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		logID := uuid.New().String()
 		eventTs := time.Now().Add(-time.Duration(i) * time.Minute).UTC()
 		createdAt := eventTs.Add(time.Duration(i) * time.Second)
@@ -1035,7 +1035,7 @@ func TestGetAppLogsCursor_WithCursor(t *testing.T) {
 	// Use different values for timestamp (event time) and created_at (insertion time)
 	// to ensure cursor pagination uses created_at, not timestamp
 	now := time.Now().UTC()
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		logID := uuid.New().String()
 		eventTs := now.Add(-time.Duration(i) * 24 * time.Hour)
 		createdAt := eventTs.Add(time.Duration(i) * time.Second)
@@ -1654,7 +1654,7 @@ func TestGetAppLogsCursor_BackwardPagination(t *testing.T) {
 
 	now := time.Now().UTC()
 	ids := make([]string, 10)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		ids[i] = uuid.New().String()
 		eventTs := now.Add(-time.Duration(i) * time.Hour)
 		createdAt := eventTs.Add(time.Duration(i) * time.Second)
@@ -1983,7 +1983,7 @@ func TestGetAppLogsCursor_CancelledContext(t *testing.T) {
 
 // mockAppLogRows implements pgx.Rows for testing scanAppLogRow error paths.
 type mockAppLogRows struct {
-	scanFn  func(dest ...interface{}) error
+	scanFn  func(dest ...any) error
 	closeFn func()
 }
 
@@ -1993,17 +1993,17 @@ func (m *mockAppLogRows) CommandTag() pgconn.CommandTag { return pgconn.NewComma
 func (m *mockAppLogRows) FieldDescriptions() []pgconn.FieldDescription {
 	return nil
 }
-func (m *mockAppLogRows) Next() bool                     { return false }
-func (m *mockAppLogRows) Scan(dest ...interface{}) error { return m.scanFn(dest...) }
-func (m *mockAppLogRows) Values() ([]interface{}, error) { return nil, nil }
-func (m *mockAppLogRows) RawValues() [][]byte            { return nil }
-func (m *mockAppLogRows) Conn() *pgx.Conn                { return nil }
+func (m *mockAppLogRows) Next() bool             { return false }
+func (m *mockAppLogRows) Scan(dest ...any) error { return m.scanFn(dest...) }
+func (m *mockAppLogRows) Values() ([]any, error) { return nil, nil }
+func (m *mockAppLogRows) RawValues() [][]byte    { return nil }
+func (m *mockAppLogRows) Conn() *pgx.Conn        { return nil }
 
 // TestScanAppLogRow_ScanError tests that scanAppLogRow returns an error
 // when the underlying row scan fails (e.g. wrong column count or type mismatch).
 func TestScanAppLogRow_ScanError(t *testing.T) {
 	rows := &mockAppLogRows{
-		scanFn: func(dest ...interface{}) error {
+		scanFn: func(dest ...any) error {
 			return errors.New("scan error: wrong column count")
 		},
 		closeFn: func() {},
@@ -2025,7 +2025,7 @@ func TestScanAppLogRow_Success(t *testing.T) {
 	catTime := now.Add(-time.Second)
 
 	rows := &mockAppLogRows{
-		scanFn: func(dest ...interface{}) error {
+		scanFn: func(dest ...any) error {
 			*(dest[0].(*string)) = "test-id-123"
 			*(dest[1].(*time.Time)) = catTime
 			*(dest[2].(*time.Time)) = now

--- a/internal/api/authz.go
+++ b/internal/api/authz.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"net/http"
+	"slices"
 
 	"github.com/google/uuid"
 
@@ -80,11 +81,9 @@ func requireGrant(grants ...user.Grant) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			id := user.IdentityFrom(r.Context())
-			for _, g := range grants {
-				if id.Can(g) {
-					next.ServeHTTP(w, r)
-					return
-				}
+			if slices.ContainsFunc(grants, id.Can) {
+				next.ServeHTTP(w, r)
+				return
 			}
 			forbid(w, r, id)
 		})

--- a/internal/api/backup.go
+++ b/internal/api/backup.go
@@ -145,7 +145,7 @@ func (h *BackupHandler) CreateBackup(w http.ResponseWriter, r *http.Request) {
 		Severity: "success",
 		Source:   "backup",
 		Message:  fmt.Sprintf("Database backup created: %s (%s)", filename, util.FormatBytes(info.Size())),
-		Metadata: map[string]interface{}{"filename": filename, "size_bytes": info.Size()},
+		Metadata: map[string]any{"filename": filename, "size_bytes": info.Size()},
 	})
 
 	writeJSONCreated(w, backupEntry{
@@ -334,7 +334,7 @@ func (h *BackupHandler) DeleteBackup(w http.ResponseWriter, r *http.Request) {
 		Severity: "info",
 		Source:   "backup",
 		Message:  fmt.Sprintf("Backup deleted: %s", filename),
-		Metadata: map[string]interface{}{"filename": filename},
+		Metadata: map[string]any{"filename": filename},
 	})
 
 	w.WriteHeader(http.StatusNoContent)

--- a/internal/api/backup_restore.go
+++ b/internal/api/backup_restore.go
@@ -298,7 +298,7 @@ func (h *BackupHandler) RestoreBackup(w http.ResponseWriter, r *http.Request) {
 		Severity: "success",
 		Source:   "backup",
 		Message:  "Database restored successfully. Restarting...",
-		Metadata: map[string]interface{}{"migration_count": len(dumpMigrations)},
+		Metadata: map[string]any{"migration_count": len(dumpMigrations)},
 	})
 
 	// Respond before exiting so the client gets the success response

--- a/internal/api/backup_retention.go
+++ b/internal/api/backup_retention.go
@@ -66,7 +66,7 @@ func classifyBackups(backups []backupEntry, sonRetention, fatherRetention, grand
 	// ── Son (daily) ──
 	// Keep the most recent backup from each of the last sonRetention calendar days.
 	dayKeys := make(map[string]bool)
-	for i := 0; i < sonRetention; i++ {
+	for i := range sonRetention {
 		dayKeys[now.AddDate(0, 0, -i).Format("2006-01-02")] = true
 	}
 	result.Son = keepMostRecentPerBucket(backups, timestamps, kept, dayKeys, func(ts time.Time) string {
@@ -83,7 +83,7 @@ func classifyBackups(backups []backupEntry, sonRetention, fatherRetention, grand
 	}
 	isoWeekSet := make(map[string]bool)
 	t := now
-	for i := 0; i < fatherRetention; i++ {
+	for range fatherRetention {
 		isoWeekSet[isoWeekKey(t)] = true
 		t = t.AddDate(0, 0, -7)
 	}
@@ -93,7 +93,7 @@ func classifyBackups(backups []backupEntry, sonRetention, fatherRetention, grand
 	// Keep the most recent backup from each of the last grandfatherRetention months
 	// that is NOT already kept as a son or father.
 	monthKeys := make(map[string]bool)
-	for i := 0; i < grandfatherRetention; i++ {
+	for i := range grandfatherRetention {
 		monthKeys[now.AddDate(0, -i, 0).Format("2006-01")] = true
 	}
 	result.Grandfather = keepMostRecentPerBucket(backups, timestamps, kept, monthKeys, func(ts time.Time) string {
@@ -258,7 +258,7 @@ func (h *BackupHandler) ApplyPrune(w http.ResponseWriter, r *http.Request) {
 			Severity: "info",
 			Source:   "backup",
 			Message:  fmt.Sprintf("Pruned %d backup(s): %s", len(pruned), strings.Join(pruned, ", ")),
-			Metadata: map[string]interface{}{"pruned_count": len(pruned), "filenames": pruned},
+			Metadata: map[string]any{"pruned_count": len(pruned), "filenames": pruned},
 		})
 	}
 

--- a/internal/api/backup_retention_test.go
+++ b/internal/api/backup_retention_test.go
@@ -278,7 +278,7 @@ func TestClassifyBackups(t *testing.T) {
 		for _, s := range result.Son {
 			sonFiles[s.Filename] = true
 		}
-		for i := 0; i < 2; i++ {
+		for i := range 2 {
 			if sonFiles[backups[i].Filename] {
 				t.Errorf("backup %q should NOT be in son tier (only most recent per day)", backups[i].Filename)
 			}

--- a/internal/api/backup_scheduler.go
+++ b/internal/api/backup_scheduler.go
@@ -69,10 +69,7 @@ func (h *BackupHandler) StartScheduler(ctx context.Context) {
 			sleep := backupSchedulerIdlePoll
 			if enabled {
 				h.runScheduledBackup(schedCtx)
-				sleep = h.settingsRepo.GetDuration(schedCtx, "backup_interval", 24*time.Hour)
-				if sleep < 5*time.Minute {
-					sleep = 5 * time.Minute
-				}
+				sleep = max(h.settingsRepo.GetDuration(schedCtx, "backup_interval", 24*time.Hour), 5*time.Minute)
 			}
 
 			select {
@@ -141,7 +138,7 @@ func (h *BackupHandler) runScheduledBackup(ctx context.Context) {
 		Severity: "success",
 		Source:   "backup",
 		Message:  fmt.Sprintf("Scheduled backup created: %s (%s)", filename, util.FormatBytes(info.Size())),
-		Metadata: map[string]interface{}{"filename": filename, "size_bytes": info.Size()},
+		Metadata: map[string]any{"filename": filename, "size_bytes": info.Size()},
 	})
 
 	// Apply rotation

--- a/internal/api/backup_scheduler_test.go
+++ b/internal/api/backup_scheduler_test.go
@@ -69,8 +69,7 @@ func TestStopScheduler(t *testing.T) {
 	}
 	h := NewBackupHandler("postgres://x", t.TempDir(), &mockAdminAuth{}, ss)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	h.StartScheduler(ctx)
 	if h.schedulerCancel == nil {
@@ -214,8 +213,7 @@ func TestStartBackupScheduler_NonNilBackupScheduler(t *testing.T) {
 	backupH := NewBackupHandler("postgres://x", t.TempDir(), &mockAdminAuth{}, ss)
 	h := &Handler{backupScheduler: backupH}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	h.StartBackupScheduler(ctx)
 	// Verify the scheduler was started by checking the backupHandler's schedulerCancel
@@ -474,8 +472,7 @@ func TestStartScheduler_RestartAfterStop(t *testing.T) {
 	}
 	h := NewBackupHandler("postgres://x", t.TempDir(), &mockAdminAuth{}, ss)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	// First start
 	h.StartScheduler(ctx)
@@ -1017,8 +1014,7 @@ func TestStartScheduler_PanicResetsCancelForRestart(t *testing.T) {
 		},
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	dir := t.TempDir()
 	h := NewBackupHandler("postgres://x", dir, &mockAdminAuth{}, ss)

--- a/internal/api/backup_test.go
+++ b/internal/api/backup_test.go
@@ -936,8 +936,8 @@ exit 0
 		// Verify 1: Password should NOT appear in command-line args
 		if strings.Contains(capturedStr, "secret") {
 			// Check if it's in an ARG line (bad) vs PGPASSWORD line (ok)
-			lines := strings.Split(capturedStr, "\n")
-			for _, line := range lines {
+			lines := strings.SplitSeq(capturedStr, "\n")
+			for line := range lines {
 				if strings.HasPrefix(line, "ARG:") && strings.Contains(line, "secret") {
 					t.Errorf("password 'secret' found in command-line args: %s", line)
 				}
@@ -952,7 +952,7 @@ exit 0
 		// Verify 3: The connection URL should have user but no password
 		// Should be something like: postgresql://user@localhost:5432/dbname
 		hasUserOnlyURL := false
-		for _, line := range strings.Split(capturedStr, "\n") {
+		for line := range strings.SplitSeq(capturedStr, "\n") {
 			if strings.HasPrefix(line, "ARG:postgresql://user@") && !strings.Contains(line, ":secret") {
 				hasUserOnlyURL = true
 				break
@@ -999,7 +999,7 @@ exit 0
 
 		// Verify: PGPASSWORD should NOT be set (empty)
 		if strings.Contains(capturedStr, "PGPASSWORD:") {
-			for _, line := range strings.Split(capturedStr, "\n") {
+			for line := range strings.SplitSeq(capturedStr, "\n") {
 				if line == "PGPASSWORD:" {
 					// Empty PGPASSWORD is correct (not set)
 					return

--- a/internal/api/configsync_fence_test.go
+++ b/internal/api/configsync_fence_test.go
@@ -77,8 +77,6 @@ func withExtraProvider(env ConfigEnvelope, name string) ConfigEnvelope {
 	return out
 }
 
-func gptr(v int64) *int64 { return &v }
-
 // TestConfigSync_CommitFenceRejectsStaleSourceGen exercises the member-side
 // commit fence end to end: an import older than the last applied generation is
 // refused (config untouched), an equal or newer one applies, the marker advances
@@ -92,7 +90,7 @@ func TestConfigSync_CommitFenceRejectsStaleSourceGen(t *testing.T) {
 	withExtra := withExtraProvider(base, "extra")
 
 	// gen=5: first fenced import applies and records the marker.
-	if resp, rec := doImportGen(t, r, base, gptr(5)); rec.Code != http.StatusOK || !resp.Applied || resp.Stale {
+	if resp, rec := doImportGen(t, r, base, new(int64(5))); rec.Code != http.StatusOK || !resp.Applied || resp.Stale {
 		t.Fatalf("gen=5 import: code=%d applied=%v stale=%v, want 200 applied not-stale", rec.Code, resp.Applied, resp.Stale)
 	}
 	if got := storedSourceGen(t); got != "5" {
@@ -102,7 +100,7 @@ func TestConfigSync_CommitFenceRejectsStaleSourceGen(t *testing.T) {
 	// gen=4: older than the applied generation, so the fence refuses it. The
 	// response is a benign "stale", not an error, and the carried change (the extra
 	// provider) must NOT land.
-	resp, rec := doImportGen(t, r, withExtra, gptr(4))
+	resp, rec := doImportGen(t, r, withExtra, new(int64(4)))
 	if rec.Code != http.StatusOK || resp.Applied || !resp.Stale || !resp.SchemaVersionOK || !resp.MasterKeyOK {
 		t.Fatalf("gen=4 import: code=%d applied=%v stale=%v schemaOK=%v keyOK=%v, want 200 not-applied stale schemaOK keyOK",
 			rec.Code, resp.Applied, resp.Stale, resp.SchemaVersionOK, resp.MasterKeyOK)
@@ -116,7 +114,7 @@ func TestConfigSync_CommitFenceRejectsStaleSourceGen(t *testing.T) {
 
 	// gen=5 again: an equal generation is allowed (a legitimate same-generation
 	// config change), so the extra provider now lands.
-	if resp, rec := doImportGen(t, r, withExtra, gptr(5)); rec.Code != http.StatusOK || !resp.Applied || resp.Stale {
+	if resp, rec := doImportGen(t, r, withExtra, new(int64(5))); rec.Code != http.StatusOK || !resp.Applied || resp.Stale {
 		t.Fatalf("gen=5 (equal) import: code=%d applied=%v stale=%v, want 200 applied not-stale", rec.Code, resp.Applied, resp.Stale)
 	}
 	if !providerNames(t)["extra"] {
@@ -125,7 +123,7 @@ func TestConfigSync_CommitFenceRejectsStaleSourceGen(t *testing.T) {
 
 	// gen=6: newer generation applies and declaratively removes the extra provider
 	// again, advancing the marker.
-	if resp, rec := doImportGen(t, r, base, gptr(6)); rec.Code != http.StatusOK || !resp.Applied || resp.Stale {
+	if resp, rec := doImportGen(t, r, base, new(int64(6))); rec.Code != http.StatusOK || !resp.Applied || resp.Stale {
 		t.Fatalf("gen=6 import: code=%d applied=%v stale=%v, want 200 applied not-stale", rec.Code, resp.Applied, resp.Stale)
 	}
 	if providerNames(t)["extra"] {
@@ -194,7 +192,7 @@ func TestConfigSync_CommitFenceGenZeroIsFenced(t *testing.T) {
 	base := doExport(t, r)
 
 	// Fenced import at generation 0 applies and records the marker as "0".
-	if resp, rec := doImportGen(t, r, base, gptr(0)); rec.Code != http.StatusOK || !resp.Applied || resp.Stale {
+	if resp, rec := doImportGen(t, r, base, new(int64(0))); rec.Code != http.StatusOK || !resp.Applied || resp.Stale {
 		t.Fatalf("gen=0 import: code=%d applied=%v stale=%v, want 200 applied not-stale", rec.Code, resp.Applied, resp.Stale)
 	}
 	if got := storedSourceGen(t); got != "0" {
@@ -261,7 +259,7 @@ func TestConfigSync_CommitFenceCorruptMarkerStillFences(t *testing.T) {
 
 	// A fenced import applies (the corrupt marker floors to 0, so any generation is
 	// accepted) and rewrites a clean value.
-	if resp, rec := doImportGen(t, r, base, gptr(3)); rec.Code != http.StatusOK || !resp.Applied || resp.Stale {
+	if resp, rec := doImportGen(t, r, base, new(int64(3))); rec.Code != http.StatusOK || !resp.Applied || resp.Stale {
 		t.Fatalf("fenced import over corrupt marker: code=%d applied=%v stale=%v, want 200 applied not-stale", rec.Code, resp.Applied, resp.Stale)
 	}
 	if got := storedSourceGen(t); got != "3" {
@@ -320,7 +318,7 @@ func TestConfigSync_CommitFenceDryRunNeverFenced(t *testing.T) {
 	base := doExport(t, r)
 
 	// Apply at gen=10 so the marker is well above the dry-run's generation.
-	if _, rec := doImportGen(t, r, base, gptr(10)); rec.Code != http.StatusOK {
+	if _, rec := doImportGen(t, r, base, new(int64(10))); rec.Code != http.StatusOK {
 		t.Fatalf("seed apply gen=10: code=%d", rec.Code)
 	}
 

--- a/internal/api/configsync_test.go
+++ b/internal/api/configsync_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
@@ -768,10 +769,5 @@ func TestConfigSync_HelperDBErrors(t *testing.T) {
 
 // contains reports whether s is in xs.
 func contains(xs []string, s string) bool {
-	for _, x := range xs {
-		if x == s {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(xs, s)
 }

--- a/internal/api/discovery.go
+++ b/internal/api/discovery.go
@@ -148,7 +148,7 @@ func (h *Handler) DiscoverProviderModels(w http.ResponseWriter, r *http.Request)
 		Severity: "success",
 		Source:   "discovery",
 		Message:  fmt.Sprintf("Fetched %d models from %s", len(models), prov.Name),
-		Metadata: map[string]interface{}{"provider": prov.Name, "count": len(models)},
+		Metadata: map[string]any{"provider": prov.Name, "count": len(models)},
 	})
 
 	// Enrich models with data from models.dev (fills gaps for models not
@@ -161,7 +161,7 @@ func (h *Handler) DiscoverProviderModels(w http.ResponseWriter, r *http.Request)
 				Severity: "info",
 				Source:   "discovery",
 				Message:  fmt.Sprintf("Enriched %d/%d models from models.dev catalogue", enriched, len(models)),
-				Metadata: map[string]interface{}{"provider": prov.Name, "enriched": enriched, "total": len(models)},
+				Metadata: map[string]any{"provider": prov.Name, "enriched": enriched, "total": len(models)},
 			})
 		}
 	}
@@ -222,7 +222,7 @@ func (h *Handler) DiscoverProviderModels(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	response := map[string]interface{}{
+	response := map[string]any{
 		"discovered": len(models),
 		"models":     models,
 		"diff":       diff,
@@ -395,7 +395,7 @@ func (h *Handler) DiscoverAllModels(w http.ResponseWriter, r *http.Request) {
 		respondError(w, "failed to list providers", nil, http.StatusInternalServerError)
 		return
 	}
-	writeJSON(w, map[string]interface{}{
+	writeJSON(w, map[string]any{
 		"results":    results,
 		"succeeded":  succeeded,
 		"failed":     failed,
@@ -440,7 +440,7 @@ func (h *Handler) discoverAllProviders(ctx context.Context, recordMisses bool) (
 			Severity: "info",
 			Source:   "proxy",
 			Message:  fmt.Sprintf("Discovering models from %s…", prov.Name),
-			Metadata: map[string]interface{}{"provider_id": prov.ID, "provider": prov.Name},
+			Metadata: map[string]any{"provider_id": prov.ID, "provider": prov.Name},
 		})
 
 		provCtx, provCancel := context.WithTimeout(context.WithoutCancel(ctx), 180*time.Second)
@@ -459,7 +459,7 @@ func (h *Handler) discoverAllProviders(ctx context.Context, recordMisses bool) (
 				Severity: "error",
 				Source:   "discovery",
 				Message:  fmt.Sprintf("Failed to discover models from %s: %s", prov.Name, discoverErr.Error()),
-				Metadata: map[string]interface{}{"provider": prov.Name, "error": discoverErr.Error()},
+				Metadata: map[string]any{"provider": prov.Name, "error": discoverErr.Error()},
 			})
 			results = append(results, result)
 			continue
@@ -474,7 +474,7 @@ func (h *Handler) discoverAllProviders(ctx context.Context, recordMisses bool) (
 			Severity: "success",
 			Source:   "discovery",
 			Message:  fmt.Sprintf("Fetched %d models from %s", len(models), prov.Name),
-			Metadata: map[string]interface{}{"provider": prov.Name, "count": len(models)},
+			Metadata: map[string]any{"provider": prov.Name, "count": len(models)},
 		})
 
 		// Enrich models with data from models.dev.
@@ -486,7 +486,7 @@ func (h *Handler) discoverAllProviders(ctx context.Context, recordMisses bool) (
 					Severity: "info",
 					Source:   "discovery",
 					Message:  fmt.Sprintf("Enriched %d/%d models from models.dev catalogue", enriched, len(models)),
-					Metadata: map[string]interface{}{"provider": prov.Name, "enriched": enriched, "total": len(models)},
+					Metadata: map[string]any{"provider": prov.Name, "enriched": enriched, "total": len(models)},
 				})
 			}
 		}
@@ -675,7 +675,7 @@ func (h *Handler) RefreshAllQuotas(w http.ResponseWriter, r *http.Request) {
 		results = append(results, result)
 	}
 
-	writeJSON(w, map[string]interface{}{
+	writeJSON(w, map[string]any{
 		"results":   results,
 		"refreshed": refreshed,
 		"failed":    failed,

--- a/internal/api/discovery_changes_test.go
+++ b/internal/api/discovery_changes_test.go
@@ -32,7 +32,7 @@ func TestDiscoveryChangesStore_RoundTrip(t *testing.T) {
 		Added: []ModelChange{{ModelID: "new-model", Reason: changeReasonNewModel}},
 		Updated: []ModelUpdate{{
 			ModelID: "priced-model",
-			Changes: []FieldChange{{Field: changeFieldInputPrice, Old: fptr(1), New: fptr(2)}},
+			Changes: []FieldChange{{Field: changeFieldInputPrice, Old: new(float64(1)), New: new(float64(2))}},
 		}},
 	}
 
@@ -100,7 +100,7 @@ func TestDiscoveryChangesHandlers_HTTP(t *testing.T) {
 		Added: []ModelChange{{ModelID: "fresh-model", Reason: changeReasonNewModel}},
 		Updated: []ModelUpdate{{
 			ModelID: "repriced",
-			Changes: []FieldChange{{Field: changeFieldInputPrice, Old: fptr(1), New: fptr(2)}},
+			Changes: []FieldChange{{Field: changeFieldInputPrice, Old: new(float64(1)), New: new(float64(2))}},
 		}},
 	}
 	if _, err := AppendDiscoveryChange(ctx, pool, "scheduled", &providerID, "DeepSeek", diff); err != nil {

--- a/internal/api/discovery_confirm.go
+++ b/internal/api/discovery_confirm.go
@@ -89,7 +89,7 @@ func (s *SuspectStreak) bump(ctx context.Context, prov *provider.Provider, missi
 			Severity: "error",
 			Source:   "discovery",
 			Message:  fmt.Sprintf("Provider '%s' has been missing %d of %d enabled models for %d consecutive scans. This looks like a real bulk removal rather than a broken listing; discovery will not auto-disable them. Review and disable the retired models by hand.", prov.Name, missing, enabled, streak),
-			Metadata: map[string]interface{}{"provider": prov.Name, "provider_id": prov.ID, "missing": missing, "enabled": enabled, "consecutive_scans": streak},
+			Metadata: map[string]any{"provider": prov.Name, "provider_id": prov.ID, "missing": missing, "enabled": enabled, "consecutive_scans": streak},
 		})
 	}
 }
@@ -217,7 +217,7 @@ func ConfirmMissingModels(ctx context.Context, svc *provider.DiscoveryService, p
 			Severity: "warning",
 			Source:   "discovery",
 			Message:  fmt.Sprintf("Discovery scan for %s is missing %d of %d enabled models even after confirmation probes; treating the listing as broken and disabling nothing", prov.Name, missing, enabledCount),
-			Metadata: map[string]interface{}{"provider": prov.Name, "provider_id": prov.ID, "missing": missing, "enabled": enabledCount},
+			Metadata: map[string]any{"provider": prov.Name, "provider_id": prov.ID, "missing": missing, "enabled": enabledCount},
 		})
 		// A recovered listing resets the streak; a persistent one crosses the
 		// escalation threshold and raises the louder bulk-removal alert.

--- a/internal/api/discovery_diff_test.go
+++ b/internal/api/discovery_diff_test.go
@@ -118,9 +118,6 @@ func models(ids ...string) []*model.Model {
 	return out
 }
 
-func fptr(v float64) *float64 { return &v }
-func iptr(v int) *int         { return &v }
-
 func TestBuildDiscoveryDiff_MetadataChanges(t *testing.T) {
 	// An existing, still-enabled model whose pricing/context fields shift is
 	// reported as an Updated entry — not Added or Reenabled.
@@ -134,13 +131,13 @@ func TestBuildDiscoveryDiff_MetadataChanges(t *testing.T) {
 			// A live (provider-reported) price change overwrites on upsert, so it
 			// is reported.
 			name: "live input price changed",
-			prev: ModelSnapshot{enabled: true, inputPrice: fptr(1)},
+			prev: ModelSnapshot{enabled: true, inputPrice: new(float64(1))},
 			model: &model.Model{
-				ModelID: "m", InputPricePerMillion: fptr(2),
+				ModelID: "m", InputPricePerMillion: new(float64(2)),
 				LiveMeta: model.LiveMetaFields{InputPrice: true},
 			},
 			wantChanges: []FieldChange{
-				{Field: changeFieldInputPrice, Old: fptr(1), New: fptr(2)},
+				{Field: changeFieldInputPrice, Old: new(float64(1)), New: new(float64(2))},
 			},
 		},
 		{
@@ -149,8 +146,8 @@ func TestBuildDiscoveryDiff_MetadataChanges(t *testing.T) {
 			// reported. This is the cross-restart source oscillation that used to
 			// flood the modal with phantom price flips.
 			name:        "non-live value change is not reported",
-			prev:        ModelSnapshot{enabled: true, inputPrice: fptr(1)},
-			model:       &model.Model{ModelID: "m", InputPricePerMillion: fptr(2)},
+			prev:        ModelSnapshot{enabled: true, inputPrice: new(float64(1))},
+			model:       &model.Model{ModelID: "m", InputPricePerMillion: new(float64(2))},
 			wantChanges: nil,
 		},
 		{
@@ -158,43 +155,43 @@ func TestBuildDiscoveryDiff_MetadataChanges(t *testing.T) {
 			// Upsert fills the gap, so it is a genuine new value.
 			name:  "context length set from unset (non-live fill)",
 			prev:  ModelSnapshot{enabled: true},
-			model: &model.Model{ModelID: "m", ContextLength: iptr(8192)},
+			model: &model.Model{ModelID: "m", ContextLength: new(8192)},
 			wantChanges: []FieldChange{
-				{Field: changeFieldContextLength, Old: nil, New: fptr(8192)},
+				{Field: changeFieldContextLength, Old: nil, New: new(float64(8192))},
 			},
 		},
 		{
 			// A scan that omits a value must NOT report "value → unset": Upsert
 			// preserves the stored value, so the diff stays quiet.
 			name:        "scan omits a value — preserved, not reported",
-			prev:        ModelSnapshot{enabled: true, outputPrice: fptr(5)},
+			prev:        ModelSnapshot{enabled: true, outputPrice: new(float64(5))},
 			model:       &model.Model{ModelID: "m"},
 			wantChanges: nil,
 		},
 		{
 			name:  "value gained from unset",
 			prev:  ModelSnapshot{enabled: true},
-			model: &model.Model{ModelID: "m", OutputPricePerMillion: fptr(3)},
+			model: &model.Model{ModelID: "m", OutputPricePerMillion: new(float64(3))},
 			wantChanges: []FieldChange{
-				{Field: changeFieldOutputPrice, Old: nil, New: fptr(3)},
+				{Field: changeFieldOutputPrice, Old: nil, New: new(float64(3))},
 			},
 		},
 		{
 			name: "multiple live fields change at once",
 			prev: ModelSnapshot{
 				enabled:         true,
-				inputPriceCache: fptr(0.5),
-				contextLength:   iptr(131072),
+				inputPriceCache: new(0.5),
+				contextLength:   new(131072),
 			},
 			model: &model.Model{
 				ModelID:                      "m",
-				InputPricePerMillionCacheHit: fptr(0.25),
-				ContextLength:                iptr(262144),
+				InputPricePerMillionCacheHit: new(0.25),
+				ContextLength:                new(262144),
 				LiveMeta:                     model.LiveMetaFields{InputPriceCache: true, ContextLength: true},
 			},
 			wantChanges: []FieldChange{
-				{Field: changeFieldInputPriceCache, Old: fptr(0.5), New: fptr(0.25)},
-				{Field: changeFieldContextLength, Old: fptr(131072), New: fptr(262144)},
+				{Field: changeFieldInputPriceCache, Old: new(0.5), New: new(0.25)},
+				{Field: changeFieldContextLength, Old: new(float64(131072)), New: new(float64(262144))},
 			},
 		},
 		{
@@ -202,7 +199,7 @@ func TestBuildDiscoveryDiff_MetadataChanges(t *testing.T) {
 			// alone produces no update.
 			name: "max output tokens change is ignored",
 			prev: ModelSnapshot{enabled: true},
-			model: &model.Model{ModelID: "m", MaxOutputTokens: iptr(8192),
+			model: &model.Model{ModelID: "m", MaxOutputTokens: new(8192),
 				LiveMeta: model.LiveMetaFields{MaxOutputTokens: true}},
 			wantChanges: nil,
 		},
@@ -210,8 +207,8 @@ func TestBuildDiscoveryDiff_MetadataChanges(t *testing.T) {
 			// Binary-vs-decimal unit noise (262144 vs 262000) is within tolerance,
 			// even for a live field.
 			name: "context length unit difference is ignored",
-			prev: ModelSnapshot{enabled: true, contextLength: iptr(262144)},
-			model: &model.Model{ModelID: "m", ContextLength: iptr(262000),
+			prev: ModelSnapshot{enabled: true, contextLength: new(262144)},
+			model: &model.Model{ModelID: "m", ContextLength: new(262000),
 				LiveMeta: model.LiveMetaFields{ContextLength: true}},
 			wantChanges: nil,
 		},
@@ -219,25 +216,25 @@ func TestBuildDiscoveryDiff_MetadataChanges(t *testing.T) {
 			// A real context-window jump (200K → 256K) on a live field is well
 			// past tolerance.
 			name: "real live context length jump is reported",
-			prev: ModelSnapshot{enabled: true, contextLength: iptr(200000)},
-			model: &model.Model{ModelID: "m", ContextLength: iptr(256000),
+			prev: ModelSnapshot{enabled: true, contextLength: new(200000)},
+			model: &model.Model{ModelID: "m", ContextLength: new(256000),
 				LiveMeta: model.LiveMetaFields{ContextLength: true}},
 			wantChanges: []FieldChange{
-				{Field: changeFieldContextLength, Old: fptr(200000), New: fptr(256000)},
+				{Field: changeFieldContextLength, Old: new(float64(200000)), New: new(float64(256000))},
 			},
 		},
 		{
 			// Float32 storage jitter on a live price must not register.
 			name: "price float32 jitter is ignored",
-			prev: ModelSnapshot{enabled: true, inputPrice: fptr(float64(float32(0.28)))},
-			model: &model.Model{ModelID: "m", InputPricePerMillion: fptr(0.28),
+			prev: ModelSnapshot{enabled: true, inputPrice: new(float64(float32(0.28)))},
+			model: &model.Model{ModelID: "m", InputPricePerMillion: new(0.28),
 				LiveMeta: model.LiveMetaFields{InputPrice: true}},
 			wantChanges: nil,
 		},
 		{
 			name: "unchanged live values produce no update",
-			prev: ModelSnapshot{enabled: true, inputPrice: fptr(1), contextLength: iptr(8192)},
-			model: &model.Model{ModelID: "m", InputPricePerMillion: fptr(1), ContextLength: iptr(8192),
+			prev: ModelSnapshot{enabled: true, inputPrice: new(float64(1)), contextLength: new(8192)},
+			model: &model.Model{ModelID: "m", InputPricePerMillion: new(float64(1)), ContextLength: new(8192),
 				LiveMeta: model.LiveMetaFields{InputPrice: true, ContextLength: true}},
 			wantChanges: nil,
 		},
@@ -251,9 +248,9 @@ func TestBuildDiscoveryDiff_MetadataChanges(t *testing.T) {
 			// A model the user has manually disabled is skipped entirely: even a
 			// genuine live price change on a hidden model must not raise the badge.
 			name: "manually disabled model is not reported",
-			prev: ModelSnapshot{enabled: false, disabledManually: true, inputPrice: fptr(1)},
+			prev: ModelSnapshot{enabled: false, disabledManually: true, inputPrice: new(float64(1))},
 			model: &model.Model{
-				ModelID: "m", InputPricePerMillion: fptr(2),
+				ModelID: "m", InputPricePerMillion: new(float64(2)),
 				LiveMeta: model.LiveMetaFields{InputPrice: true},
 			},
 			wantChanges: nil,
@@ -292,11 +289,11 @@ func TestBuildDiscoveryDiff_NewAndReenabledSkipMetadata(t *testing.T) {
 	// A brand-new or reappearing model is classified by membership only; its
 	// field values are not also diffed (no snapshot baseline to compare).
 	snapshot := map[string]ModelSnapshot{
-		"back": {enabled: false, disabledManually: false, inputPrice: fptr(1)},
+		"back": {enabled: false, disabledManually: false, inputPrice: new(float64(1))},
 	}
 	upserted := []*model.Model{
-		{ModelID: "new", InputPricePerMillion: fptr(9)},
-		{ModelID: "back", InputPricePerMillion: fptr(2)},
+		{ModelID: "new", InputPricePerMillion: new(float64(9))},
+		{ModelID: "back", InputPricePerMillion: new(float64(2))},
 	}
 	diff := BuildDiscoveryDiff(snapshot, upserted, nil)
 
@@ -359,12 +356,12 @@ func TestDiscoverProviderModels_RenameScenario(t *testing.T) {
 		}
 		listingMu.Lock()
 		defer listingMu.Unlock()
-		data := make([]map[string]interface{}, 0, len(listing))
+		data := make([]map[string]any, 0, len(listing))
 		for _, id := range listing {
-			data = append(data, map[string]interface{}{"id": id, "owned_by": "test", "object": "model"})
+			data = append(data, map[string]any{"id": id, "owned_by": "test", "object": "model"})
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]interface{}{"data": data})
+		json.NewEncoder(w).Encode(map[string]any{"data": data})
 	}))
 	defer mockServer.Close()
 
@@ -377,8 +374,8 @@ func TestDiscoverProviderModels_RenameScenario(t *testing.T) {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]interface{}{
-			"data": []map[string]interface{}{{"id": "rename-model-b", "owned_by": "test", "object": "model"}},
+		json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]any{{"id": "rename-model-b", "owned_by": "test", "object": "model"}},
 		})
 	}))
 	defer mockB.Close()
@@ -572,12 +569,12 @@ func TestDiscoverSweep_DisabledModelSyncErrorTolerated(t *testing.T) {
 		}
 		listingMu.Lock()
 		defer listingMu.Unlock()
-		data := make([]map[string]interface{}, 0, len(listing))
+		data := make([]map[string]any, 0, len(listing))
 		for _, id := range listing {
-			data = append(data, map[string]interface{}{"id": id, "owned_by": "test", "object": "model"})
+			data = append(data, map[string]any{"id": id, "owned_by": "test", "object": "model"})
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]interface{}{"data": data})
+		json.NewEncoder(w).Encode(map[string]any{"data": data})
 	}))
 	defer mockServer.Close()
 
@@ -645,12 +642,12 @@ func TestDiscoverSweep_RevalidationErrorIsBestEffort(t *testing.T) {
 		}
 		listingMu.Lock()
 		defer listingMu.Unlock()
-		data := make([]map[string]interface{}, 0, len(listing))
+		data := make([]map[string]any, 0, len(listing))
 		for _, id := range listing {
-			data = append(data, map[string]interface{}{"id": id, "owned_by": "test", "object": "model"})
+			data = append(data, map[string]any{"id": id, "owned_by": "test", "object": "model"})
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]interface{}{"data": data})
+		json.NewEncoder(w).Encode(map[string]any{"data": data})
 	}))
 	defer mockServer.Close()
 
@@ -709,12 +706,12 @@ func TestDiscoverAllModels_DisabledSyncError(t *testing.T) {
 		}
 		listingMu.Lock()
 		defer listingMu.Unlock()
-		data := make([]map[string]interface{}, 0, len(listing))
+		data := make([]map[string]any, 0, len(listing))
 		for _, id := range listing {
-			data = append(data, map[string]interface{}{"id": id, "owned_by": "test", "object": "model"})
+			data = append(data, map[string]any{"id": id, "owned_by": "test", "object": "model"})
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]interface{}{"data": data})
+		json.NewEncoder(w).Encode(map[string]any{"data": data})
 	}))
 	defer mockServer.Close()
 
@@ -773,12 +770,12 @@ func TestDiscoverSweep_SuspectScanSkipsDisable(t *testing.T) {
 		}
 		listingMu.Lock()
 		defer listingMu.Unlock()
-		data := make([]map[string]interface{}, 0, len(listing))
+		data := make([]map[string]any, 0, len(listing))
 		for _, id := range listing {
-			data = append(data, map[string]interface{}{"id": id, "owned_by": "test", "object": "model"})
+			data = append(data, map[string]any{"id": id, "owned_by": "test", "object": "model"})
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]interface{}{"data": data})
+		json.NewEncoder(w).Encode(map[string]any{"data": data})
 	}))
 	defer mockServer.Close()
 

--- a/internal/api/discovery_integration_quota_test.go
+++ b/internal/api/discovery_integration_quota_test.go
@@ -117,7 +117,7 @@ func TestRefreshAllQuotas_AllDisabled(t *testing.T) {
 	_, r := newTestHandlerWithRouter(t)
 
 	// Create multiple disabled providers
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		providerData := fmt.Sprintf(`{"name": "test-quota-disabled-%d", "base_url": "https://api.nanogpt.com", "api_key": "test-key", "enabled": false}`, i)
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodPost, "/providers", strings.NewReader(providerData))
@@ -141,10 +141,10 @@ func TestRefreshAllQuotas_AllDisabled(t *testing.T) {
 	}
 
 	var response struct {
-		Results   []interface{} `json:"results"`
-		Refreshed int           `json:"refreshed"`
-		Failed    int           `json:"failed"`
-		Skipped   int           `json:"skipped"`
+		Results   []any `json:"results"`
+		Refreshed int   `json:"refreshed"`
+		Failed    int   `json:"failed"`
+		Skipped   int   `json:"skipped"`
 	}
 	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
 		t.Fatalf("Failed to parse response: %v", err)
@@ -306,10 +306,10 @@ func TestRefreshAllQuotas_UnsupportedType(t *testing.T) {
 	}
 
 	var response struct {
-		Results   []interface{} `json:"results"`
-		Refreshed int           `json:"refreshed"`
-		Failed    int           `json:"failed"`
-		Skipped   int           `json:"skipped"`
+		Results   []any `json:"results"`
+		Refreshed int   `json:"refreshed"`
+		Failed    int   `json:"failed"`
+		Skipped   int   `json:"skipped"`
 	}
 	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
 		t.Fatalf("Failed to parse response: %v", err)
@@ -1111,7 +1111,7 @@ func TestGetProviderUsage_NanoGPTSuccess(t *testing.T) {
 		t.Errorf("expected status 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
@@ -1179,7 +1179,7 @@ func TestGetProviderUsage_OpenRouterSuccess(t *testing.T) {
 		t.Errorf("expected status 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
@@ -1244,7 +1244,7 @@ func TestGetProviderBalance_DeepSeekSuccess(t *testing.T) {
 		t.Errorf("expected status 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
@@ -1308,7 +1308,7 @@ func TestGetOllamaCloudAccount_Success(t *testing.T) {
 		t.Errorf("expected status 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
@@ -1393,7 +1393,7 @@ func TestRefreshAllQuotas_NanoGPTSuccess(t *testing.T) {
 		t.Errorf("expected status 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
@@ -1449,7 +1449,7 @@ func TestRefreshAllQuotas_ZAICodingError(t *testing.T) {
 		t.Errorf("expected status 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
@@ -1506,7 +1506,7 @@ func TestRefreshAllQuotas_ZAICodingSuccess(t *testing.T) {
 		t.Errorf("expected status 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
@@ -1571,7 +1571,7 @@ func TestRefreshAllQuotas_OpenRouterSuccess(t *testing.T) {
 		t.Errorf("expected status 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
@@ -1628,7 +1628,7 @@ func TestRefreshAllQuotas_DeepSeekSuccess(t *testing.T) {
 		t.Errorf("expected status 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
@@ -1685,7 +1685,7 @@ func TestRefreshAllQuotas_OllamaCloudSuccess(t *testing.T) {
 		t.Errorf("expected status 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
@@ -1746,7 +1746,7 @@ func TestGetProviderUsage_NeuralWattSuccess(t *testing.T) {
 		t.Errorf("expected status 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
@@ -1911,7 +1911,7 @@ func TestRefreshAllQuotas_MixedResults(t *testing.T) {
 		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
@@ -1924,7 +1924,7 @@ func TestRefreshAllQuotas_MixedResults(t *testing.T) {
 		t.Errorf("expected 1 failed, got %v", resp["failed"])
 	}
 
-	results := resp["results"].([]interface{})
+	results := resp["results"].([]any)
 	if len(results) != 2 {
 		t.Fatalf("expected 2 results, got %d", len(results))
 	}
@@ -1972,7 +1972,7 @@ func TestRefreshAllQuotas_NeuralWattSuccess(t *testing.T) {
 		t.Errorf("expected status 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
@@ -2022,7 +2022,7 @@ func TestRefreshAllQuotas_NeuralWattError(t *testing.T) {
 		t.Errorf("expected status 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}

--- a/internal/api/discovery_integration_test.go
+++ b/internal/api/discovery_integration_test.go
@@ -28,7 +28,7 @@ func TestDiscoverAllModels_AllDisabled(t *testing.T) {
 
 	// Create providers and then disable them (CreateProviderRequest doesn't have enabled field)
 	var providerIDs []string
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		providerData := fmt.Sprintf(`{"name": "test-disabled-all-%d", "base_url": "https://api.openai.com", "api_key": "sk-test123"}`, i)
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodPost, "/providers", strings.NewReader(providerData))
@@ -74,10 +74,10 @@ func TestDiscoverAllModels_AllDisabled(t *testing.T) {
 	}
 
 	var response struct {
-		Results    []interface{} `json:"results"`
-		Succeeded  int           `json:"succeeded"`
-		Failed     int           `json:"failed"`
-		Discovered int           `json:"discovered"`
+		Results    []any `json:"results"`
+		Succeeded  int   `json:"succeeded"`
+		Failed     int   `json:"failed"`
+		Discovered int   `json:"discovered"`
 	}
 	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
 		t.Fatalf("Failed to parse response: %v", err)
@@ -237,8 +237,8 @@ func TestDiscoverProviderModels_SuccessWithMockServer(t *testing.T) {
 	// Create mock OpenAI-compatible server
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/models" && r.Method == "GET" {
-			response := map[string]interface{}{
-				"data": []map[string]interface{}{
+			response := map[string]any{
+				"data": []map[string]any{
 					{"id": "gpt-4-test", "owned_by": "openai"},
 					{"id": "gpt-3.5-test", "owned_by": "openai"},
 				},
@@ -281,8 +281,8 @@ func TestDiscoverProviderModels_SuccessWithMockServer(t *testing.T) {
 	}
 
 	var response struct {
-		Discovered int           `json:"discovered"`
-		Models     []interface{} `json:"models"`
+		Discovered int   `json:"discovered"`
+		Models     []any `json:"models"`
 	}
 	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
 		t.Fatalf("Failed to parse response: %v", err)
@@ -304,8 +304,8 @@ func TestDiscoverAllModels_WithEnabledProvider(t *testing.T) {
 	// Create mock OpenAI-compatible server
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/models" && r.Method == "GET" {
-			response := map[string]interface{}{
-				"data": []map[string]interface{}{
+			response := map[string]any{
+				"data": []map[string]any{
 					{"id": "model-1", "owned_by": "test"},
 				},
 			}
@@ -475,8 +475,8 @@ func TestDiscoverProviderModels_WithModelsDevCache(t *testing.T) {
 	// Create mock OpenAI-compatible server that returns models matching the cache
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/models" && r.Method == "GET" {
-			response := map[string]interface{}{
-				"data": []map[string]interface{}{
+			response := map[string]any{
+				"data": []map[string]any{
 					{"id": "gpt-4", "owned_by": "openai"},
 					{"id": "gpt-3.5-test", "owned_by": "openai"},
 				},
@@ -624,8 +624,8 @@ func TestDiscoverProviderModels_ModelRepoError(t *testing.T) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/v1/models" {
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"data": []map[string]interface{}{
+			json.NewEncoder(w).Encode(map[string]any{
+				"data": []map[string]any{
 					{"id": "test-model-1", "owned_by": "test", "object": "model"},
 				},
 			})
@@ -687,8 +687,8 @@ func TestDiscoverProviderModels_UpsertError(t *testing.T) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/v1/models" {
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"data": []map[string]interface{}{
+			json.NewEncoder(w).Encode(map[string]any{
+				"data": []map[string]any{
 					{"id": "upsert-error-model", "owned_by": "test", "object": "model"},
 				},
 			})
@@ -760,8 +760,8 @@ func TestDiscoverProviderModels_DoesNotRecordMisses(t *testing.T) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/v1/models" {
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"data": []map[string]interface{}{
+			json.NewEncoder(w).Encode(map[string]any{
+				"data": []map[string]any{
 					{"id": "test-model-1", "owned_by": "test", "object": "model"},
 				},
 			})
@@ -816,8 +816,8 @@ func TestDiscoverProviderModels_SyncForModelError(t *testing.T) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/v1/models" {
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"data": []map[string]interface{}{
+			json.NewEncoder(w).Encode(map[string]any{
+				"data": []map[string]any{
 					{"id": "test-model-1", "owned_by": "test", "object": "model"},
 				},
 			})
@@ -873,8 +873,8 @@ func TestDiscoverProviderModels_DBExecError(t *testing.T) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/v1/models" {
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"data": []map[string]interface{}{
+			json.NewEncoder(w).Encode(map[string]any{
+				"data": []map[string]any{
 					{"id": "test-model-1", "owned_by": "test", "object": "model"},
 				},
 			})
@@ -1016,8 +1016,8 @@ func TestDiscoverAllModels_ModelsDevCacheEnrichment(t *testing.T) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/v1/models" {
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"data": []map[string]interface{}{
+			json.NewEncoder(w).Encode(map[string]any{
+				"data": []map[string]any{
 					{"id": "gpt-4", "owned_by": "openai", "object": "model"},
 				},
 			})
@@ -1049,7 +1049,7 @@ func TestDiscoverAllModels_ModelsDevCacheEnrichment(t *testing.T) {
 		t.Errorf("expected status 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
@@ -1065,8 +1065,8 @@ func TestDiscoverAllModels_UpsertError(t *testing.T) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/v1/models" {
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"data": []map[string]interface{}{
+			json.NewEncoder(w).Encode(map[string]any{
+				"data": []map[string]any{
 					{"id": "test-model-1", "owned_by": "test", "object": "model"},
 				},
 			})
@@ -1122,8 +1122,8 @@ func TestDiscoverAllModels_DisableMissingError(t *testing.T) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/v1/models" {
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"data": []map[string]interface{}{
+			json.NewEncoder(w).Encode(map[string]any{
+				"data": []map[string]any{
 					{"id": "test-model-1", "owned_by": "test", "object": "model"},
 				},
 			})
@@ -1174,8 +1174,8 @@ func TestDiscoverAllModels_SyncForModelError(t *testing.T) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/v1/models" {
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"data": []map[string]interface{}{
+			json.NewEncoder(w).Encode(map[string]any{
+				"data": []map[string]any{
 					{"id": "test-model-1", "owned_by": "test", "object": "model"},
 				},
 			})
@@ -1221,8 +1221,8 @@ func TestDiscoverAllModels_DBExecError(t *testing.T) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/v1/models" {
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"data": []map[string]interface{}{
+			json.NewEncoder(w).Encode(map[string]any{
+				"data": []map[string]any{
 					{"id": "test-model-1", "owned_by": "test", "object": "model"},
 				},
 			})

--- a/internal/api/discovery_pricestability_test.go
+++ b/internal/api/discovery_pricestability_test.go
@@ -31,8 +31,8 @@ func TestCollapseRoundTrips(t *testing.T) {
 		// Newest-first, as listPendingDiscoveryChanges returns: the later run
 		// ($0.182 -> $0.49) sits above the earlier run ($0.49 -> $0.182).
 		entries := []DiscoveryChangeEntry{
-			updEntry("p1", "OR", t1, "z-ai/glm-5.1", fc("input_price_cache", fptr(0.182), fptr(0.49))),
-			updEntry("p1", "OR", t0, "z-ai/glm-5.1", fc("input_price_cache", fptr(0.49), fptr(0.182))),
+			updEntry("p1", "OR", t1, "z-ai/glm-5.1", fc("input_price_cache", new(0.182), new(0.49))),
+			updEntry("p1", "OR", t0, "z-ai/glm-5.1", fc("input_price_cache", new(0.49), new(0.182))),
 		}
 		got := collapseRoundTrips(entries)
 		if len(got) != 0 {
@@ -42,7 +42,7 @@ func TestCollapseRoundTrips(t *testing.T) {
 
 	t.Run("one-directional change is kept", func(t *testing.T) {
 		entries := []DiscoveryChangeEntry{
-			updEntry("p1", "OR", t0, "z-ai/glm-5.1", fc("input_price_cache", fptr(0.49), fptr(0.182))),
+			updEntry("p1", "OR", t0, "z-ai/glm-5.1", fc("input_price_cache", new(0.49), new(0.182))),
 		}
 		got := collapseRoundTrips(entries)
 		if len(got) != 1 || len(got[0].Diff.Updated) != 1 {
@@ -54,12 +54,12 @@ func TestCollapseRoundTrips(t *testing.T) {
 		// input_price returns to its start; output_price ends changed.
 		entries := []DiscoveryChangeEntry{
 			updEntry("p1", "OR", t1, "m",
-				fc("input_price", fptr(2.0), fptr(1.0)),
-				fc("output_price", fptr(8.0), fptr(9.0)),
+				fc("input_price", new(2.0), new(1.0)),
+				fc("output_price", new(8.0), new(9.0)),
 			),
 			updEntry("p1", "OR", t0, "m",
-				fc("input_price", fptr(1.0), fptr(2.0)),
-				fc("output_price", fptr(7.0), fptr(8.0)),
+				fc("input_price", new(1.0), new(2.0)),
+				fc("output_price", new(7.0), new(8.0)),
 			),
 		}
 		got := collapseRoundTrips(entries)
@@ -81,8 +81,8 @@ func TestCollapseRoundTrips(t *testing.T) {
 		// Two distinct providers each show one genuine, opposite move. They must
 		// NOT chain into a false round-trip.
 		entries := []DiscoveryChangeEntry{
-			updEntry("pA", "A", t0, "openai/gpt-5-mini", fc("input_price_cache", fptr(0.49), fptr(0.182))),
-			updEntry("pB", "B", t0, "openai/gpt-5-mini", fc("input_price_cache", fptr(0.182), fptr(0.49))),
+			updEntry("pA", "A", t0, "openai/gpt-5-mini", fc("input_price_cache", new(0.49), new(0.182))),
+			updEntry("pB", "B", t0, "openai/gpt-5-mini", fc("input_price_cache", new(0.182), new(0.49))),
 		}
 		got := collapseRoundTrips(entries)
 		if len(got) != 2 {
@@ -92,9 +92,9 @@ func TestCollapseRoundTrips(t *testing.T) {
 
 	t.Run("three-run bounce A->B->C->A collapses", func(t *testing.T) {
 		entries := []DiscoveryChangeEntry{
-			updEntry("p1", "OR", t2, "m", fc("input_price", fptr(3.0), fptr(1.0))),
-			updEntry("p1", "OR", t1, "m", fc("input_price", fptr(2.0), fptr(3.0))),
-			updEntry("p1", "OR", t0, "m", fc("input_price", fptr(1.0), fptr(2.0))),
+			updEntry("p1", "OR", t2, "m", fc("input_price", new(3.0), new(1.0))),
+			updEntry("p1", "OR", t1, "m", fc("input_price", new(2.0), new(3.0))),
+			updEntry("p1", "OR", t0, "m", fc("input_price", new(1.0), new(2.0))),
 		}
 		got := collapseRoundTrips(entries)
 		if len(got) != 0 {
@@ -115,8 +115,8 @@ func TestCollapseRoundTrips(t *testing.T) {
 
 	t.Run("provider keyed by name when id is empty", func(t *testing.T) {
 		entries := []DiscoveryChangeEntry{
-			updEntry("", "Deleted OR", t1, "m", fc("input_price", fptr(0.182), fptr(0.49))),
-			updEntry("", "Deleted OR", t0, "m", fc("input_price", fptr(0.49), fptr(0.182))),
+			updEntry("", "Deleted OR", t1, "m", fc("input_price", new(0.182), new(0.49))),
+			updEntry("", "Deleted OR", t0, "m", fc("input_price", new(0.49), new(0.182))),
 		}
 		got := collapseRoundTrips(entries)
 		if len(got) != 0 {
@@ -129,11 +129,11 @@ func TestCollapseRoundTrips(t *testing.T) {
 			{
 				ProviderID: "p1", ProviderName: "OR", DetectedAt: t1,
 				Diff: &DiscoveryDiff{
-					Updated:  []ModelUpdate{{ModelID: "m", Changes: []FieldChange{fc("input_price", fptr(0.182), fptr(0.49))}}},
+					Updated:  []ModelUpdate{{ModelID: "m", Changes: []FieldChange{fc("input_price", new(0.182), new(0.49))}}},
 					Disabled: []ModelChange{{ModelID: "x", Reason: "not_listed"}},
 				},
 			},
-			updEntry("p1", "OR", t0, "m", fc("input_price", fptr(0.49), fptr(0.182))),
+			updEntry("p1", "OR", t0, "m", fc("input_price", new(0.49), new(0.182))),
 		}
 		got := collapseRoundTrips(entries)
 		if len(got) != 1 {
@@ -151,8 +151,8 @@ func TestCollapseRoundTrips(t *testing.T) {
 		// Same timestamp on both runs: first/last resolve by slice order, and the
 		// earliest "from" ($0.49) still equals the latest "to" ($0.49).
 		entries := []DiscoveryChangeEntry{
-			updEntry("p1", "OR", t0, "m", fc("input_price", fptr(0.49), fptr(0.182))),
-			updEntry("p1", "OR", t0, "m", fc("input_price", fptr(0.182), fptr(0.49))),
+			updEntry("p1", "OR", t0, "m", fc("input_price", new(0.49), new(0.182))),
+			updEntry("p1", "OR", t0, "m", fc("input_price", new(0.182), new(0.49))),
 		}
 		got := collapseRoundTrips(entries)
 		if len(got) != 0 {
@@ -164,8 +164,8 @@ func TestCollapseRoundTrips(t *testing.T) {
 		// A provider deleted mid-review: one entry carries its ID, a later one only
 		// the name. Different keys, so the two opposite moves must NOT cancel.
 		entries := []DiscoveryChangeEntry{
-			updEntry("", "OR", t1, "m", fc("input_price", fptr(0.182), fptr(0.49))),
-			updEntry("p1", "OR", t0, "m", fc("input_price", fptr(0.49), fptr(0.182))),
+			updEntry("", "OR", t1, "m", fc("input_price", new(0.182), new(0.49))),
+			updEntry("p1", "OR", t0, "m", fc("input_price", new(0.49), new(0.182))),
 		}
 		got := collapseRoundTrips(entries)
 		if len(got) != 2 {
@@ -178,8 +178,8 @@ func TestCollapseRoundTrips_DoesNotMutateInput(t *testing.T) {
 	t0 := time.Date(2026, 6, 21, 10, 0, 0, 0, time.UTC)
 	t1 := t0.Add(time.Hour)
 	entries := []DiscoveryChangeEntry{
-		updEntry("p1", "OR", t1, "m", fc("input_price", fptr(0.182), fptr(0.49))),
-		updEntry("p1", "OR", t0, "m", fc("input_price", fptr(0.49), fptr(0.182))),
+		updEntry("p1", "OR", t1, "m", fc("input_price", new(0.182), new(0.49))),
+		updEntry("p1", "OR", t0, "m", fc("input_price", new(0.49), new(0.182))),
 	}
 	origDiff0 := entries[0].Diff
 	origUpdatedLen := len(entries[0].Diff.Updated)
@@ -208,8 +208,8 @@ func TestDampenOpenRouterPriceJitter(t *testing.T) {
 	}
 
 	t.Run("within tolerance demotes the field to fill-only", func(t *testing.T) {
-		snap := map[string]ModelSnapshot{"m": {inputPriceCache: fptr(0.50)}}
-		m := liveModel("m", fptr(0.48)) // 4% drift, under 7%
+		snap := map[string]ModelSnapshot{"m": {inputPriceCache: new(0.50)}}
+		m := liveModel("m", new(0.48)) // 4% drift, under 7%
 		DampenOpenRouterPriceJitter(orURL, snap, []*model.Model{m})
 		if m.LiveMeta.InputPriceCache {
 			t.Fatal("sub-tolerance wiggle should have cleared the live flag")
@@ -217,8 +217,8 @@ func TestDampenOpenRouterPriceJitter(t *testing.T) {
 	})
 
 	t.Run("beyond tolerance stays live", func(t *testing.T) {
-		snap := map[string]ModelSnapshot{"m": {inputPriceCache: fptr(0.49)}}
-		m := liveModel("m", fptr(0.182)) // 63% drop, real upstream switch
+		snap := map[string]ModelSnapshot{"m": {inputPriceCache: new(0.49)}}
+		m := liveModel("m", new(0.182)) // 63% drop, real upstream switch
 		DampenOpenRouterPriceJitter(orURL, snap, []*model.Model{m})
 		if !m.LiveMeta.InputPriceCache {
 			t.Fatal("a large genuine price move must remain live")
@@ -226,8 +226,8 @@ func TestDampenOpenRouterPriceJitter(t *testing.T) {
 	})
 
 	t.Run("non-openrouter provider is a no-op", func(t *testing.T) {
-		snap := map[string]ModelSnapshot{"m": {inputPriceCache: fptr(0.50)}}
-		m := liveModel("m", fptr(0.48))
+		snap := map[string]ModelSnapshot{"m": {inputPriceCache: new(0.50)}}
+		m := liveModel("m", new(0.48))
 		DampenOpenRouterPriceJitter("https://api.deepseek.com", snap, []*model.Model{m})
 		if !m.LiveMeta.InputPriceCache {
 			t.Fatal("damping must only apply to openrouter providers")
@@ -235,7 +235,7 @@ func TestDampenOpenRouterPriceJitter(t *testing.T) {
 	})
 
 	t.Run("model absent from snapshot is untouched", func(t *testing.T) {
-		m := liveModel("m", fptr(0.48))
+		m := liveModel("m", new(0.48))
 		DampenOpenRouterPriceJitter(orURL, map[string]ModelSnapshot{}, []*model.Model{m})
 		if !m.LiveMeta.InputPriceCache {
 			t.Fatal("first-seen model has no prior value to compare; flag must stay")
@@ -244,7 +244,7 @@ func TestDampenOpenRouterPriceJitter(t *testing.T) {
 
 	t.Run("filling a previously-unset price is kept", func(t *testing.T) {
 		snap := map[string]ModelSnapshot{"m": {inputPriceCache: nil}}
-		m := liveModel("m", fptr(0.48))
+		m := liveModel("m", new(0.48))
 		DampenOpenRouterPriceJitter(orURL, snap, []*model.Model{m})
 		if !m.LiveMeta.InputPriceCache {
 			t.Fatal("filling an unset field is a genuine change, not jitter")
@@ -255,13 +255,13 @@ func TestDampenOpenRouterPriceJitter(t *testing.T) {
 		// A model whose input price wiggled under tolerance but whose output price
 		// genuinely jumped: only the input flag should be demoted.
 		snap := map[string]ModelSnapshot{"m": {
-			inputPrice:  fptr(2.00),
-			outputPrice: fptr(6.00),
+			inputPrice:  new(2.00),
+			outputPrice: new(6.00),
 		}}
 		m := &model.Model{
 			ModelID:               "m",
-			InputPricePerMillion:  fptr(1.96), // 2% drift -> jitter
-			OutputPricePerMillion: fptr(3.00), // 50% drop -> real move
+			InputPricePerMillion:  new(1.96), // 2% drift -> jitter
+			OutputPricePerMillion: new(3.00), // 50% drop -> real move
 		}
 		m.LiveMeta.InputPrice = true
 		m.LiveMeta.OutputPrice = true
@@ -278,13 +278,13 @@ func TestDampenOpenRouterPriceJitter(t *testing.T) {
 
 	t.Run("both input and output sub-tolerance wiggles are damped", func(t *testing.T) {
 		snap := map[string]ModelSnapshot{"m": {
-			inputPrice:  fptr(2.00),
-			outputPrice: fptr(6.00),
+			inputPrice:  new(2.00),
+			outputPrice: new(6.00),
 		}}
 		m := &model.Model{
 			ModelID:               "m",
-			InputPricePerMillion:  fptr(2.02),
-			OutputPricePerMillion: fptr(5.90),
+			InputPricePerMillion:  new(2.02),
+			OutputPricePerMillion: new(5.90),
 		}
 		m.LiveMeta.InputPrice = true
 		m.LiveMeta.OutputPrice = true
@@ -302,7 +302,7 @@ func TestDampenOpenRouterPriceJitter(t *testing.T) {
 // and a nil pointer reports -1 (no real price is negative, so it reads
 // unambiguously as "unset" in the damping debug log).
 func TestFloatPtrVal(t *testing.T) {
-	if got := floatPtrVal(fptr(0.5)); got != 0.5 {
+	if got := floatPtrVal(new(0.5)); got != 0.5 {
 		t.Errorf("floatPtrVal(0.5) = %v, want 0.5", got)
 	}
 	if got := floatPtrVal(nil); got != -1 {
@@ -316,16 +316,16 @@ func TestWithinPriceTolerance(t *testing.T) {
 		old, new *float64
 		want     bool
 	}{
-		{"equal", fptr(1.0), fptr(1.0), true},
-		{"within band", fptr(1.0), fptr(1.05), true},
+		{"equal", new(1.0), new(1.0), true},
+		{"within band", new(1.0), new(1.05), true},
 		// denom is the larger value, so exactly 7% is 0.93 -> 1.0 (0.07/1.0).
-		{"exactly on the 7% edge", fptr(0.93), fptr(1.0), true},
-		{"just past the edge", fptr(0.92), fptr(1.0), false},
-		{"beyond band", fptr(1.0), fptr(1.5), false},
-		{"old nil", nil, fptr(1.0), false},
-		{"new nil", fptr(1.0), nil, false},
+		{"exactly on the 7% edge", new(0.93), new(1.0), true},
+		{"just past the edge", new(0.92), new(1.0), false},
+		{"beyond band", new(1.0), new(1.5), false},
+		{"old nil", nil, new(1.0), false},
+		{"new nil", new(1.0), nil, false},
 		{"both nil", nil, nil, false},
-		{"both zero", fptr(0), fptr(0), true},
+		{"both zero", new(float64(0)), new(float64(0)), true},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/internal/api/events_filter_test.go
+++ b/internal/api/events_filter_test.go
@@ -25,9 +25,9 @@ func TestEventVisible(t *testing.T) {
 
 	// own scopes an event to ownerID; other scopes it to a different user; unowned
 	// carries no owner (admin-only, like an admin/unowned virtual key).
-	own := map[string]interface{}{"owner_user_id": ownerID.String()}
-	other := map[string]interface{}{"owner_user_id": otherID.String()}
-	unowned := map[string]interface{}{"owner_user_id": ""}
+	own := map[string]any{"owner_user_id": ownerID.String()}
+	other := map[string]any{"owner_user_id": otherID.String()}
+	unowned := map[string]any{"owner_user_id": ""}
 
 	cases := []struct {
 		name string
@@ -97,8 +97,8 @@ func TestStreamEvents_OwnerScoping(t *testing.T) {
 
 	// Own request (owner_user_id == this user) is visible; another user's request
 	// and operational/discovery events are not.
-	events.Publish(events.Event{Type: "request.completed", Severity: "info", Message: "mine done", Metadata: map[string]interface{}{"owner_user_id": id}})
-	events.Publish(events.Event{Type: "request.completed", Severity: "info", Message: "theirs done", Metadata: map[string]interface{}{"owner_user_id": uuid.NewString()}})
+	events.Publish(events.Event{Type: "request.completed", Severity: "info", Message: "mine done", Metadata: map[string]any{"owner_user_id": id}})
+	events.Publish(events.Event{Type: "request.completed", Severity: "info", Message: "theirs done", Metadata: map[string]any{"owner_user_id": uuid.NewString()}})
 	events.Publish(events.Event{Type: "backup.created", Severity: "success", Message: "backup done"})
 	events.Publish(events.Event{Type: "request.discovery.provider_starting", Severity: "info", Message: "discovering"})
 	time.Sleep(100 * time.Millisecond)

--- a/internal/api/events_integration_test.go
+++ b/internal/api/events_integration_test.go
@@ -71,7 +71,7 @@ func TestStreamEvents_EventDelivery(t *testing.T) {
 		Type:     "test.event",
 		Severity: "info",
 		Message:  "Test message",
-		Metadata: map[string]interface{}{"test": true},
+		Metadata: map[string]any{"test": true},
 	})
 
 	// Give time for event to be delivered
@@ -190,7 +190,7 @@ func TestStreamEvents_MarshalError(t *testing.T) {
 		Type:     "test.bad_event",
 		Severity: "info",
 		Message:  "Bad event with channel",
-		Metadata: map[string]interface{}{"ch": make(chan int)},
+		Metadata: map[string]any{"ch": make(chan int)},
 	})
 
 	// Give time for the bad event to be processed
@@ -201,7 +201,7 @@ func TestStreamEvents_MarshalError(t *testing.T) {
 		Type:     "test.good_event",
 		Severity: "info",
 		Message:  "Good event after bad",
-		Metadata: map[string]interface{}{"test": true},
+		Metadata: map[string]any{"test": true},
 	})
 
 	// Give time for the good event to be delivered

--- a/internal/api/failover_api_test.go
+++ b/internal/api/failover_api_test.go
@@ -1414,7 +1414,7 @@ func TestFailoverHandler_Update_InvalidEntryEnabled(t *testing.T) {
 
 	// Build entry_enabled with 101 entries
 	entryEnabled := make(map[string]bool)
-	for i := 0; i < 101; i++ {
+	for range 101 {
 		entryEnabled[uuid.New().String()] = true
 	}
 	eeJSON, _ := json.Marshal(entryEnabled)
@@ -1566,7 +1566,7 @@ func TestFailoverSync_Integration(t *testing.T) {
 		t.Fatalf("expected status 200 OK, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var response map[string]interface{}
+	var response map[string]any
 	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}

--- a/internal/api/fleet.go
+++ b/internal/api/fleet.go
@@ -321,7 +321,7 @@ func (h *FleetHandler) rejectConflict(_ context.Context, storedID, rejectedID st
 		Severity: "warning",
 		Source:   "fleet",
 		Message:  "Rejected a fleet announce from a Front Desk that does not own this instance",
-		Metadata: map[string]interface{}{
+		Metadata: map[string]any{
 			"stored_frontdesk_id":   storedID,
 			"rejected_frontdesk_id": rejectedID,
 		},

--- a/internal/api/fleet_test.go
+++ b/internal/api/fleet_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"maps"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -208,9 +209,7 @@ func TestFleetAnnounce_Ownership(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fs := &fakeFleetSettings{values: map[string]string{}}
-			for k, v := range tt.stored {
-				fs.values[k] = v
-			}
+			maps.Copy(fs.values, tt.stored)
 			h := NewFleetHandler(fs)
 			req := httptest.NewRequest(http.MethodPost, "/fleet/announce", strings.NewReader(tt.body))
 			rec := httptest.NewRecorder()
@@ -260,7 +259,7 @@ func TestFleetAnnounce_ConflictDebounced(t *testing.T) {
 	defer events.Unsubscribe(sub)
 
 	// Two back-to-back rejections from the same rogue FD: exactly one event.
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		req := httptest.NewRequest(http.MethodPost, "/fleet/announce",
 			strings.NewReader(`{"is_primary":false,"frontdesk_id":"fd-2"}`))
 		rec := httptest.NewRecorder()

--- a/internal/api/handler_applogs_test.go
+++ b/internal/api/handler_applogs_test.go
@@ -32,7 +32,7 @@ func TestGetAppLogsIntegration(t *testing.T) {
 		t.Fatalf("Expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
 
-	var response []map[string]interface{}
+	var response []map[string]any
 	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
 		t.Fatalf("Failed to parse response: %v", err)
 	}
@@ -68,7 +68,7 @@ func TestClearAppLogs_InvalidatesCountCache(t *testing.T) {
 
 	// newTestHandler truncates app_logs, so the unfiltered total covers exactly
 	// the rows we insert here.
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		if _, err := pool.Exec(ctx,
 			`INSERT INTO app_logs (id, timestamp, level, source, message, created_at)
 			 VALUES (gen_random_uuid(), NOW(), 'info', 'clearcache', 'msg', NOW())`); err != nil {
@@ -125,7 +125,7 @@ func TestClearAppLogs_OlderThanRange(t *testing.T) {
 	ctx := context.Background()
 
 	// Two stale rows (8 days old) and one fresh row (1 hour old).
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		if _, err := pool.Exec(ctx,
 			`INSERT INTO app_logs (id, timestamp, level, source, message, created_at)
 			 VALUES (gen_random_uuid(), NOW() - INTERVAL '8 days', 'info', 'rangetest', 'old', NOW() - INTERVAL '8 days')`); err != nil {
@@ -190,7 +190,7 @@ func TestGetAppLogs_WithSeverityFilter(t *testing.T) {
 	}
 
 	var response struct {
-		Entries []map[string]interface{} `json:"entries"`
+		Entries []map[string]any `json:"entries"`
 	}
 	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
 		t.Fatalf("Failed to parse response: %v", err)
@@ -214,7 +214,7 @@ func TestGetAppLogs_WithSearchFilter(t *testing.T) {
 	}
 
 	var response struct {
-		Entries []map[string]interface{} `json:"entries"`
+		Entries []map[string]any `json:"entries"`
 	}
 	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
 		t.Fatalf("Failed to parse response: %v", err)
@@ -238,7 +238,7 @@ func TestGetAppLogs_WithTimeRangeFilter(t *testing.T) {
 	}
 
 	var response struct {
-		Entries []map[string]interface{} `json:"entries"`
+		Entries []map[string]any `json:"entries"`
 	}
 	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
 		t.Fatalf("Failed to parse response: %v", err)
@@ -262,7 +262,7 @@ func TestGetAppLogs(t *testing.T) {
 		t.Fatalf("Expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
 
-	var response []map[string]interface{}
+	var response []map[string]any
 	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
 		t.Fatalf("Failed to parse response: %v", err)
 	}
@@ -498,7 +498,7 @@ func TestGetAppLogs_WithLimit(t *testing.T) {
 	debuglog.SetHandler(slogHandler)
 
 	// Write multiple log messages
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		debuglog.Info(fmt.Sprintf("test message %d", i), "source", "test")
 	}
 
@@ -541,12 +541,12 @@ func TestGetAppLogsHistory(t *testing.T) {
 	}
 
 	var response struct {
-		Entries      []map[string]interface{} `json:"entries"`
-		Total        int                      `json:"total"`
-		Page         int                      `json:"page"`
-		PerPage      int                      `json:"per_page"`
-		LevelCounts  map[string]int           `json:"level_counts"`
-		SourceCounts map[string]int           `json:"source_counts"`
+		Entries      []map[string]any `json:"entries"`
+		Total        int              `json:"total"`
+		Page         int              `json:"page"`
+		PerPage      int              `json:"per_page"`
+		LevelCounts  map[string]int   `json:"level_counts"`
+		SourceCounts map[string]int   `json:"source_counts"`
 	}
 	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
 		t.Fatalf("Failed to parse response: %v", err)
@@ -773,7 +773,7 @@ func TestGetAppLogs_EmptyResult(t *testing.T) {
 	}
 
 	// Default mode returns a JSON array of log entries (may be empty)
-	var response []interface{}
+	var response []any
 	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}

--- a/internal/api/handler_backup_test.go
+++ b/internal/api/handler_backup_test.go
@@ -57,7 +57,7 @@ func TestListBackups_EmptyDirectory_Integration(t *testing.T) {
 		t.Errorf("Expected 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var backups []interface{}
+	var backups []any
 	if err := json.Unmarshal(w.Body.Bytes(), &backups); err != nil {
 		t.Fatalf("Failed to parse response: %v", err)
 	}

--- a/internal/api/handler_discovery_test.go
+++ b/internal/api/handler_discovery_test.go
@@ -179,7 +179,7 @@ func TestDiscoverAllModelsIntegration(t *testing.T) {
 		t.Fatalf("Expected 200 for discover all, got %d: %s", rec.Code, rec.Body.String())
 	}
 
-	var response map[string]interface{}
+	var response map[string]any
 	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
 		t.Fatalf("Failed to parse response: %v", err)
 	}
@@ -227,7 +227,7 @@ func TestRefreshAllQuotasIntegration(t *testing.T) {
 		t.Fatalf("Expected 200 for refresh quotas, got %d: %s", rec.Code, rec.Body.String())
 	}
 
-	var response map[string]interface{}
+	var response map[string]any
 	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
 		t.Fatalf("Failed to parse response: %v", err)
 	}
@@ -426,7 +426,7 @@ func TestDiscoverAllModels_MultipleProviders(t *testing.T) {
 		t.Fatalf("Expected 200 for discover all, got %d: %s", rec.Code, rec.Body.String())
 	}
 
-	var response map[string]interface{}
+	var response map[string]any
 	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
 		t.Fatalf("Failed to parse response: %v", err)
 	}
@@ -475,7 +475,7 @@ func TestGetProviderUsage_NanoGPT(t *testing.T) {
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	json.NewDecoder(w.Body).Decode(&resp)
 	providerID := resp["id"].(string)
 
@@ -502,7 +502,7 @@ func TestGetProviderUsage_OpenRouter(t *testing.T) {
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	json.NewDecoder(w.Body).Decode(&resp)
 	providerID := resp["id"].(string)
 
@@ -535,7 +535,7 @@ func TestGetProviderBalance_DefaultUnsupported(t *testing.T) {
 		t.Fatalf("Failed to create provider: %d: %s", w.Code, w.Body.String())
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	json.NewDecoder(w.Body).Decode(&resp)
 	providerID, ok := resp["id"].(string)
 	if !ok {
@@ -565,7 +565,7 @@ func TestGetProviderBalance_DeepSeek(t *testing.T) {
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	json.NewDecoder(w.Body).Decode(&resp)
 	providerID := resp["id"].(string)
 
@@ -609,7 +609,7 @@ func TestRefreshAllQuotas_NanoGPT(t *testing.T) {
 		t.Errorf("expected 200, got %d", w2.Code)
 	}
 
-	var resp2 map[string]interface{}
+	var resp2 map[string]any
 	json.NewDecoder(w2.Body).Decode(&resp2)
 	resultsInterface, ok := resp2["results"]
 	if !ok {
@@ -620,7 +620,7 @@ func TestRefreshAllQuotas_NanoGPT(t *testing.T) {
 		// This is acceptable - no providers support quotas
 		return
 	}
-	results := resultsInterface.([]interface{})
+	results := resultsInterface.([]any)
 
 	// Should have one result
 	if len(results) != 1 {
@@ -650,7 +650,7 @@ func TestRefreshAllQuotas_ZAICoding(t *testing.T) {
 		t.Errorf("expected 200, got %d", w2.Code)
 	}
 
-	var resp2 map[string]interface{}
+	var resp2 map[string]any
 	json.NewDecoder(w2.Body).Decode(&resp2)
 	resultsInterface, ok := resp2["results"]
 	if !ok {
@@ -661,7 +661,7 @@ func TestRefreshAllQuotas_ZAICoding(t *testing.T) {
 		// This is acceptable - no providers support quotas
 		return
 	}
-	results := resultsInterface.([]interface{})
+	results := resultsInterface.([]any)
 
 	// Should have one result
 	if len(results) != 1 {
@@ -691,7 +691,7 @@ func TestRefreshAllQuotas_DeepSeek(t *testing.T) {
 		t.Errorf("expected 200, got %d", w2.Code)
 	}
 
-	var resp2 map[string]interface{}
+	var resp2 map[string]any
 	json.NewDecoder(w2.Body).Decode(&resp2)
 	resultsInterface, ok := resp2["results"]
 	if !ok {
@@ -702,7 +702,7 @@ func TestRefreshAllQuotas_DeepSeek(t *testing.T) {
 		// This is acceptable - no providers support quotas
 		return
 	}
-	results := resultsInterface.([]interface{})
+	results := resultsInterface.([]any)
 
 	// Should have one result
 	if len(results) != 1 {
@@ -732,7 +732,7 @@ func TestRefreshAllQuotas_OpenRouter(t *testing.T) {
 		t.Errorf("expected 200, got %d", w2.Code)
 	}
 
-	var resp2 map[string]interface{}
+	var resp2 map[string]any
 	json.NewDecoder(w2.Body).Decode(&resp2)
 	resultsInterface, ok := resp2["results"]
 	if !ok {
@@ -742,7 +742,7 @@ func TestRefreshAllQuotas_OpenRouter(t *testing.T) {
 		t.Fatal("results field is nil")
 		return
 	}
-	results := resultsInterface.([]interface{})
+	results := resultsInterface.([]any)
 
 	// Should have one result
 	if len(results) != 1 {
@@ -772,7 +772,7 @@ func TestRefreshAllQuotas_SkippedProvider(t *testing.T) {
 		t.Errorf("expected 200, got %d", w2.Code)
 	}
 
-	var resp2 map[string]interface{}
+	var resp2 map[string]any
 	json.NewDecoder(w2.Body).Decode(&resp2)
 	resultsInterface, ok := resp2["results"]
 	if !ok {
@@ -783,14 +783,14 @@ func TestRefreshAllQuotas_SkippedProvider(t *testing.T) {
 		// This is acceptable - no providers support quotas
 		return
 	}
-	results := resultsInterface.([]interface{})
+	results := resultsInterface.([]any)
 
 	// Should have one result with refreshed=false
 	if len(results) != 1 {
 		t.Errorf("expected 1 result, got %d", len(results))
 	}
 
-	result := results[0].(map[string]interface{})
+	result := results[0].(map[string]any)
 	if result["refreshed"].(bool) != false {
 		t.Errorf("expected refreshed=false, got %v", result["refreshed"])
 	}
@@ -807,7 +807,7 @@ func TestRefreshAllQuotas_DisabledProvider(t *testing.T) {
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	json.NewDecoder(w.Body).Decode(&resp)
 	providerID := resp["id"].(string)
 
@@ -825,7 +825,7 @@ func TestRefreshAllQuotas_DisabledProvider(t *testing.T) {
 		t.Errorf("expected 200, got %d", w2.Code)
 	}
 
-	var resp2 map[string]interface{}
+	var resp2 map[string]any
 	json.NewDecoder(w2.Body).Decode(&resp2)
 	resultsInterface, ok := resp2["results"]
 	if !ok {
@@ -836,7 +836,7 @@ func TestRefreshAllQuotas_DisabledProvider(t *testing.T) {
 		// This is acceptable - no providers support quotas
 		return
 	}
-	results := resultsInterface.([]interface{})
+	results := resultsInterface.([]any)
 
 	// Should have no results since disabled provider is skipped
 	if len(results) != 0 {
@@ -956,7 +956,7 @@ func TestDiscoverAllModels_NoProviders(t *testing.T) {
 		t.Fatalf("Expected 200 for discover all with no providers, got %d: %s", rec.Code, rec.Body.String())
 	}
 
-	var response map[string]interface{}
+	var response map[string]any
 	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
 		t.Fatalf("Failed to parse response: %v", err)
 	}
@@ -993,7 +993,7 @@ func TestDiscoverProviderModels_DisabledProviderExplicit(t *testing.T) {
 		t.Fatalf("Expected 201, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
 		t.Fatalf("Failed to parse response: %v", err)
 	}
@@ -1041,7 +1041,7 @@ func TestDiscoverProviderModels_AutodiscoveryDisabled(t *testing.T) {
 		t.Fatalf("Expected 201, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
 		t.Fatalf("Failed to parse response: %v", err)
 	}
@@ -1115,7 +1115,7 @@ func TestGetProviderUsage_Error(t *testing.T) {
 		t.Fatalf("Expected 201, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	json.NewDecoder(w.Body).Decode(&resp)
 	providerID := resp["id"].(string)
 
@@ -1150,7 +1150,7 @@ func TestGetProviderBalance_Error(t *testing.T) {
 		t.Fatalf("Expected 201, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	json.NewDecoder(w.Body).Decode(&resp)
 	providerID := resp["id"].(string)
 
@@ -1185,7 +1185,7 @@ func TestDiscoverProviderModels_WithInvalidProviderType(t *testing.T) {
 		t.Fatalf("Expected 201, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	json.NewDecoder(w.Body).Decode(&resp)
 	providerID := resp["id"].(string)
 
@@ -1220,7 +1220,7 @@ func TestGetProviderBalance_UnsupportedProvider(t *testing.T) {
 		t.Fatalf("Expected 201, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	json.NewDecoder(w.Body).Decode(&resp)
 	providerID := resp["id"].(string)
 
@@ -1253,7 +1253,7 @@ func TestDiscoverProviderModels_SuccessPath(t *testing.T) {
 		t.Fatalf("Expected 201, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	json.NewDecoder(w.Body).Decode(&resp)
 	providerID := resp["id"].(string)
 
@@ -1287,7 +1287,7 @@ func TestGetProviderUsage_ZAICoding(t *testing.T) {
 		t.Fatalf("Expected 201, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	json.NewDecoder(w.Body).Decode(&resp)
 	providerID := resp["id"].(string)
 
@@ -1322,7 +1322,7 @@ func TestGetProviderBalance_UnsupportedType_Integration(t *testing.T) {
 		t.Fatalf("Expected 201, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	json.NewDecoder(w.Body).Decode(&resp)
 	providerID := resp["id"].(string)
 
@@ -1355,7 +1355,7 @@ func TestGetProviderBalance_OpenRouterError_Integration(t *testing.T) {
 		t.Fatalf("Expected 201, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	json.NewDecoder(w.Body).Decode(&resp)
 	providerID := resp["id"].(string)
 

--- a/internal/api/handler_failover_test.go
+++ b/internal/api/handler_failover_test.go
@@ -53,7 +53,7 @@ func TestListFailoverGroups(t *testing.T) {
 	}
 
 	var response struct {
-		Groups []map[string]interface{} `json:"groups"`
+		Groups []map[string]any `json:"groups"`
 	}
 	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
 		t.Fatalf("Failed to parse response: %v", err)
@@ -179,7 +179,7 @@ func TestSyncFailoverGroups(t *testing.T) {
 		t.Fatalf("Expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
 
-	var response map[string]interface{}
+	var response map[string]any
 	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
 		t.Fatalf("Failed to parse response: %v", err)
 	}
@@ -202,7 +202,7 @@ func TestFailoverCandidates(t *testing.T) {
 		t.Fatalf("Expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
 
-	var response []map[string]interface{}
+	var response []map[string]any
 	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
 		t.Fatalf("Failed to parse response: %v", err)
 	}
@@ -219,7 +219,7 @@ func TestSyncFailoverGroups_WithModels(t *testing.T) {
 	var req *http.Request
 
 	// Create providers and models
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		providerData := fmt.Sprintf(`{"name": "test-failover-provider-%d", "base_url": "https://api.openai.com", "api_key": "test-api-key"}`, i)
 		rec = httptest.NewRecorder()
 		req = httptest.NewRequest("POST", "/providers", strings.NewReader(providerData))
@@ -239,7 +239,7 @@ func TestSyncFailoverGroups_WithModels(t *testing.T) {
 		}
 
 		// Insert models with same model_id (for failover grouping)
-		for j := 0; j < 2; j++ {
+		for j := range 2 {
 			modelID := uuid.New().String()
 			pool := h.Pool().Pool()
 			_, err := pool.Exec(context.Background(),
@@ -261,7 +261,7 @@ func TestSyncFailoverGroups_WithModels(t *testing.T) {
 		t.Fatalf("Expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
 
-	var response map[string]interface{}
+	var response map[string]any
 	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
 		t.Fatalf("Failed to parse response: %v", err)
 	}
@@ -507,7 +507,7 @@ func TestFailoverCandidates_Empty(t *testing.T) {
 		t.Errorf("expected 200 OK, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var candidates []interface{}
+	var candidates []any
 	if err := json.NewDecoder(w.Body).Decode(&candidates); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
@@ -534,7 +534,7 @@ func TestFailoverCandidates_WithModels(t *testing.T) {
 		t.Fatalf("Expected 201, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	json.NewDecoder(w.Body).Decode(&resp)
 	providerID := resp["id"].(string)
 
@@ -565,7 +565,7 @@ func TestFailoverCandidates_WithModels(t *testing.T) {
 		t.Errorf("expected 200 OK, got %d: %s", w2.Code, w2.Body.String())
 	}
 
-	var candidates []map[string]interface{}
+	var candidates []map[string]any
 	if err := json.NewDecoder(w2.Body).Decode(&candidates); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
@@ -592,7 +592,7 @@ func TestFailoverCandidates_DisabledModels(t *testing.T) {
 		t.Fatalf("Expected 201, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	json.NewDecoder(w.Body).Decode(&resp)
 	providerID := resp["id"].(string)
 
@@ -623,7 +623,7 @@ func TestFailoverCandidates_DisabledModels(t *testing.T) {
 		t.Errorf("expected 200 OK, got %d: %s", w2.Code, w2.Body.String())
 	}
 
-	var candidates []map[string]interface{}
+	var candidates []map[string]any
 	if err := json.NewDecoder(w2.Body).Decode(&candidates); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
@@ -655,7 +655,7 @@ func TestFailoverSync_Success(t *testing.T) {
 		t.Fatalf("Expected 201, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	json.NewDecoder(w.Body).Decode(&resp)
 	providerID := resp["id"].(string)
 
@@ -770,7 +770,7 @@ func TestCircuitBreakerStatus_WithDetail(t *testing.T) {
 			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 		}
 
-		var resp map[string]interface{}
+		var resp map[string]any
 		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
 			t.Fatalf("failed to decode: %v", err)
 		}
@@ -800,18 +800,18 @@ func TestCircuitBreakerStatus_WithDetail(t *testing.T) {
 			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 		}
 
-		var resp map[string]interface{}
+		var resp map[string]any
 		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
 			t.Fatalf("failed to decode: %v", err)
 		}
 
-		providers, ok := resp["providers"].([]interface{})
+		providers, ok := resp["providers"].([]any)
 		if !ok || len(providers) != 3 {
 			t.Fatalf("expected 3 providers, got %v", resp["providers"])
 		}
 
 		// First provider should be open with cooldown_ms and next_retry_at.
-		first := providers[0].(map[string]interface{})
+		first := providers[0].(map[string]any)
 		if first["state"] != "open" {
 			t.Errorf("expected state=open, got %v", first["state"])
 		}
@@ -824,7 +824,7 @@ func TestCircuitBreakerStatus_WithDetail(t *testing.T) {
 
 		// Second provider should be half-open with opened_at but no cooldown_ms or next_retry_at
 		// (cooldown has elapsed, provider is actively probing).
-		second := providers[1].(map[string]interface{})
+		second := providers[1].(map[string]any)
 		if second["state"] != "half-open" {
 			t.Errorf("expected state=half-open, got %v", second["state"])
 		}
@@ -836,7 +836,7 @@ func TestCircuitBreakerStatus_WithDetail(t *testing.T) {
 		}
 
 		// Third provider should be closed without cooldown fields.
-		third := providers[2].(map[string]interface{})
+		third := providers[2].(map[string]any)
 		if third["state"] != "closed" {
 			t.Errorf("expected state=closed, got %v", third["state"])
 		}
@@ -858,7 +858,7 @@ func TestCircuitBreakerStatus_NoCircuitBreaker(t *testing.T) {
 		t.Errorf("expected 200 OK, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
@@ -948,7 +948,7 @@ func TestCircuitBreakerStatus_UntrackedMembers(t *testing.T) {
 		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
@@ -1052,7 +1052,7 @@ func TestCircuitBreakerStatus_TrackedProviderNotDoubleCounted(t *testing.T) {
 		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
@@ -1143,7 +1143,7 @@ func TestCircuitBreakerStatus_MissingModelInGroup(t *testing.T) {
 		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatalf("failed to decode: %v", err)
 	}
@@ -1230,7 +1230,7 @@ func TestCircuitBreakerStatus_DuplicateModelAcrossGroups(t *testing.T) {
 		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatalf("failed to decode: %v", err)
 	}
@@ -1315,7 +1315,7 @@ func TestCircuitBreakerStatus_AggregateCacheHit(t *testing.T) {
 		t.Fatalf("first request: expected 200, got %d", rec1.Code)
 	}
 
-	var resp1 map[string]interface{}
+	var resp1 map[string]any
 	if err := json.NewDecoder(rec1.Body).Decode(&resp1); err != nil {
 		t.Fatalf("failed to decode first response: %v", err)
 	}
@@ -1329,7 +1329,7 @@ func TestCircuitBreakerStatus_AggregateCacheHit(t *testing.T) {
 		t.Fatalf("second request: expected 200, got %d", rec2.Code)
 	}
 
-	var resp2 map[string]interface{}
+	var resp2 map[string]any
 	if err := json.NewDecoder(rec2.Body).Decode(&resp2); err != nil {
 		t.Fatalf("failed to decode: %v", err)
 	}
@@ -1434,17 +1434,17 @@ func TestCircuitBreakerStatus_DetailCached(t *testing.T) {
 		t.Fatalf("second request: expected 200, got %d: %s", rec2.Code, rec2.Body.String())
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.NewDecoder(rec2.Body).Decode(&resp); err != nil {
 		t.Fatalf("failed to decode second response: %v", err)
 	}
 
-	providers, ok := resp["providers"].([]interface{})
+	providers, ok := resp["providers"].([]any)
 	if !ok || len(providers) != 1 {
 		t.Fatalf("cached response should still include providers, got %v", resp["providers"])
 	}
 
-	p := providers[0].(map[string]interface{})
+	p := providers[0].(map[string]any)
 	name, _ := p["provider_name"].(string)
 	if !strings.Contains(name, "test-cb-cache-provider") {
 		t.Errorf("cached response should include provider_name, got %q", name)
@@ -1527,17 +1527,17 @@ func TestCircuitBreakerStatus_ProviderName(t *testing.T) {
 		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatalf("failed to decode: %v", err)
 	}
 
-	providers, ok := resp["providers"].([]interface{})
+	providers, ok := resp["providers"].([]any)
 	if !ok || len(providers) != 1 {
 		t.Fatalf("expected 1 provider, got %v", resp["providers"])
 	}
 
-	p := providers[0].(map[string]interface{})
+	p := providers[0].(map[string]any)
 	name, _ := p["provider_name"].(string)
 	if !strings.Contains(name, "test-cb-name-provider") {
 		t.Errorf("expected provider_name to contain 'test-cb-name-provider', got %q", name)

--- a/internal/api/handler_logs_test.go
+++ b/internal/api/handler_logs_test.go
@@ -64,10 +64,10 @@ func TestListLogs(t *testing.T) {
 	}
 
 	var response struct {
-		Entries []map[string]interface{} `json:"entries"`
-		Total   int                      `json:"total"`
-		Page    int                      `json:"page"`
-		PerPage int                      `json:"per_page"`
+		Entries []map[string]any `json:"entries"`
+		Total   int              `json:"total"`
+		Page    int              `json:"page"`
+		PerPage int              `json:"per_page"`
 	}
 	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
 		t.Fatalf("Failed to parse response: %v", err)
@@ -104,7 +104,7 @@ func TestListLogs_WithProviderIDFilter(t *testing.T) {
 	w2 := httptest.NewRecorder()
 	r.ServeHTTP(w2, req2)
 
-	var resp1, resp2 map[string]interface{}
+	var resp1, resp2 map[string]any
 	json.NewDecoder(w1.Body).Decode(&resp1)
 	json.NewDecoder(w2.Body).Decode(&resp2)
 	providerID1 := resp1["id"].(string)
@@ -139,9 +139,9 @@ func TestListLogs_WithProviderIDFilter(t *testing.T) {
 		t.Errorf("expected 200 OK, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var response map[string]interface{}
+	var response map[string]any
 	json.NewDecoder(w.Body).Decode(&response)
-	entries := response["entries"].([]interface{})
+	entries := response["entries"].([]any)
 	if len(entries) != 1 {
 		t.Errorf("expected 1 log entry for provider 1, got %d", len(entries))
 	}
@@ -160,7 +160,7 @@ func TestListLogs_WithEndpointTypeFilter(t *testing.T) {
 	wCreate := httptest.NewRecorder()
 	r.ServeHTTP(wCreate, reqCreate)
 
-	var created map[string]interface{}
+	var created map[string]any
 	json.NewDecoder(wCreate.Body).Decode(&created)
 	providerID := created["id"].(string)
 
@@ -256,7 +256,7 @@ func TestListLogs_WithModelIDFilter(t *testing.T) {
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	json.NewDecoder(w.Body).Decode(&resp)
 	providerID := resp["id"].(string)
 
@@ -288,9 +288,9 @@ func TestListLogs_WithModelIDFilter(t *testing.T) {
 		t.Errorf("expected 200 OK, got %d: %s", w2.Code, w2.Body.String())
 	}
 
-	var response map[string]interface{}
+	var response map[string]any
 	json.NewDecoder(w2.Body).Decode(&response)
-	entries := response["entries"].([]interface{})
+	entries := response["entries"].([]any)
 	if len(entries) != 1 {
 		t.Errorf("expected 1 log entry for gpt-4 model, got %d", len(entries))
 	}
@@ -309,7 +309,7 @@ func TestListLogs_WithVirtualKeyFilter(t *testing.T) {
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	json.NewDecoder(w.Body).Decode(&resp)
 	providerID := resp["id"].(string)
 
@@ -321,7 +321,7 @@ func TestListLogs_WithVirtualKeyFilter(t *testing.T) {
 	w2 := httptest.NewRecorder()
 	r.ServeHTTP(w2, req2)
 
-	var vkResp map[string]interface{}
+	var vkResp map[string]any
 	json.NewDecoder(w2.Body).Decode(&vkResp)
 	virtualKeyID := vkResp["id"].(string)
 	virtualKeyName := vkResp["name"].(string)
@@ -346,9 +346,9 @@ func TestListLogs_WithVirtualKeyFilter(t *testing.T) {
 		t.Errorf("expected 200 OK, got %d: %s", w3.Code, w3.Body.String())
 	}
 
-	var response map[string]interface{}
+	var response map[string]any
 	json.NewDecoder(w3.Body).Decode(&response)
-	entries := response["entries"].([]interface{})
+	entries := response["entries"].([]any)
 	if len(entries) != 1 {
 		t.Errorf("expected 1 log entry, got %d", len(entries))
 	}
@@ -367,7 +367,7 @@ func TestListLogs_WithStatusCodeFilter(t *testing.T) {
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	json.NewDecoder(w.Body).Decode(&resp)
 	providerID := resp["id"].(string)
 
@@ -399,9 +399,9 @@ func TestListLogs_WithStatusCodeFilter(t *testing.T) {
 		t.Errorf("expected 200 OK, got %d: %s", w2.Code, w2.Body.String())
 	}
 
-	var response map[string]interface{}
+	var response map[string]any
 	json.NewDecoder(w2.Body).Decode(&response)
-	entries := response["entries"].([]interface{})
+	entries := response["entries"].([]any)
 	if len(entries) != 1 {
 		t.Errorf("expected 1 log entry with 5xx status, got %d", len(entries))
 	}
@@ -420,7 +420,7 @@ func TestListLogs_WithDateRangeFilter(t *testing.T) {
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	json.NewDecoder(w.Body).Decode(&resp)
 	providerID := resp["id"].(string)
 
@@ -458,9 +458,9 @@ func TestListLogs_WithDateRangeFilter(t *testing.T) {
 		t.Errorf("expected 200 OK, got %d: %s", w2.Code, w2.Body.String())
 	}
 
-	var response map[string]interface{}
+	var response map[string]any
 	json.NewDecoder(w2.Body).Decode(&response)
-	entries := response["entries"].([]interface{})
+	entries := response["entries"].([]any)
 	// Should only get the newTime log (1 entry)
 	if len(entries) != 1 {
 		t.Errorf("expected 1 log entry in date range, got %d", len(entries))
@@ -480,13 +480,13 @@ func TestListLogs_WithPagination(t *testing.T) {
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	json.NewDecoder(w.Body).Decode(&resp)
 	providerID := resp["id"].(string)
 
 	// Insert multiple test logs
 	pool := h.Pool().Pool()
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		_, err := pool.Exec(context.Background(), `
 			INSERT INTO request_logs (provider_id, model_id, status_code, duration_ms, tokens_prompt, tokens_completion, created_at)
 			VALUES ($1, $2, $3, $4, $5, $6, $7)`,
@@ -506,9 +506,9 @@ func TestListLogs_WithPagination(t *testing.T) {
 		t.Errorf("expected 200 OK, got %d: %s", w2.Code, w2.Body.String())
 	}
 
-	var response map[string]interface{}
+	var response map[string]any
 	json.NewDecoder(w2.Body).Decode(&response)
-	entries := response["entries"].([]interface{})
+	entries := response["entries"].([]any)
 	total := response["total"].(float64)
 	page := response["page"].(float64)
 	perPage := response["per_page"].(float64)
@@ -541,7 +541,7 @@ func TestListLogs_With4xxStatusCodeFilter(t *testing.T) {
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	json.NewDecoder(w.Body).Decode(&resp)
 	providerID := resp["id"].(string)
 
@@ -573,9 +573,9 @@ func TestListLogs_With4xxStatusCodeFilter(t *testing.T) {
 		t.Errorf("expected 200 OK, got %d: %s", w2.Code, w2.Body.String())
 	}
 
-	var response map[string]interface{}
+	var response map[string]any
 	json.NewDecoder(w2.Body).Decode(&response)
-	entries := response["entries"].([]interface{})
+	entries := response["entries"].([]any)
 	if len(entries) != 1 {
 		t.Errorf("expected 1 log entry with 4xx status, got %d", len(entries))
 	}

--- a/internal/api/handler_misc_test.go
+++ b/internal/api/handler_misc_test.go
@@ -45,7 +45,7 @@ func TestUpdateVirtualKey(t *testing.T) {
 			t.Fatalf("Failed to create virtual key: %d: %s", rec.Code, rec.Body.String())
 		}
 
-		var createResp map[string]interface{}
+		var createResp map[string]any
 		if err := json.Unmarshal(rec.Body.Bytes(), &createResp); err != nil {
 			t.Fatalf("Failed to parse create response: %v", err)
 		}
@@ -63,7 +63,7 @@ func TestUpdateVirtualKey(t *testing.T) {
 			t.Fatalf("Expected 200, got %d: %s", rec.Code, rec.Body.String())
 		}
 
-		var updateResp map[string]interface{}
+		var updateResp map[string]any
 		if err := json.Unmarshal(rec.Body.Bytes(), &updateResp); err != nil {
 			t.Fatalf("Failed to parse update response: %v", err)
 		}
@@ -85,7 +85,7 @@ func TestUpdateVirtualKey(t *testing.T) {
 			t.Fatalf("Failed to create virtual key: %d: %s", rec.Code, rec.Body.String())
 		}
 
-		var createResp map[string]interface{}
+		var createResp map[string]any
 		if err := json.Unmarshal(rec.Body.Bytes(), &createResp); err != nil {
 			t.Fatalf("Failed to parse create response: %v", err)
 		}
@@ -120,7 +120,7 @@ func TestUpdateVirtualKey(t *testing.T) {
 			t.Fatalf("Failed to create virtual key: %d: %s", rec.Code, rec.Body.String())
 		}
 
-		var createResp map[string]interface{}
+		var createResp map[string]any
 		if err := json.Unmarshal(rec.Body.Bytes(), &createResp); err != nil {
 			t.Fatalf("Failed to parse create response: %v", err)
 		}
@@ -167,7 +167,7 @@ func TestUpdateVirtualKey(t *testing.T) {
 			t.Fatalf("Failed to create virtual key: %d: %s", rec.Code, rec.Body.String())
 		}
 
-		var createResp map[string]interface{}
+		var createResp map[string]any
 		if err := json.Unmarshal(rec.Body.Bytes(), &createResp); err != nil {
 			t.Fatalf("Failed to parse create response: %v", err)
 		}
@@ -185,7 +185,7 @@ func TestUpdateVirtualKey(t *testing.T) {
 			t.Fatalf("Expected 200, got %d: %s", rec.Code, rec.Body.String())
 		}
 
-		var updateResp map[string]interface{}
+		var updateResp map[string]any
 		if err := json.Unmarshal(rec.Body.Bytes(), &updateResp); err != nil {
 			t.Fatalf("Failed to parse update response: %v", err)
 		}

--- a/internal/api/handler_models_test.go
+++ b/internal/api/handler_models_test.go
@@ -136,7 +136,7 @@ func TestListModels_WithPagination(t *testing.T) {
 
 	// Insert multiple models directly via DB
 	pool := h.Pool().Pool()
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		modelID := uuid.New().String()
 		_, err := pool.Exec(context.Background(),
 			`INSERT INTO models (id, provider_id, model_id, name, enabled) VALUES ($1, $2, $3, $4, $5)`,
@@ -175,8 +175,8 @@ func TestTestModel_Success(t *testing.T) {
 		if strings.Contains(r.URL.Path, "/chat/completions") {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusUnauthorized)
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"error": map[string]interface{}{
+			json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]any{
 					"message": "invalid api key",
 					"type":    "invalid_request_error",
 				},
@@ -380,7 +380,7 @@ func TestTestModel(t *testing.T) {
 		t.Fatalf("Expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
 
-	var testResp map[string]interface{}
+	var testResp map[string]any
 	if err := json.Unmarshal(rec.Body.Bytes(), &testResp); err != nil {
 		t.Fatalf("Failed to parse test response: %v", err)
 	}
@@ -558,7 +558,7 @@ func TestUpdateModel_EnableDisable_Integration(t *testing.T) {
 		t.Fatalf("Expected 201, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	json.NewDecoder(w.Body).Decode(&resp)
 	providerID := resp["id"].(string)
 
@@ -586,7 +586,7 @@ func TestUpdateModel_EnableDisable_Integration(t *testing.T) {
 	}
 
 	// Verify the model is disabled
-	var modelResp map[string]interface{}
+	var modelResp map[string]any
 	json.NewDecoder(w2.Body).Decode(&modelResp)
 	if modelResp["enabled"] != false {
 		t.Errorf("expected model to be disabled, got enabled=%v", modelResp["enabled"])
@@ -656,7 +656,7 @@ func TestListModels_WithModels(t *testing.T) {
 
 	// Insert multiple models with different properties
 	pool := h.Pool().Pool()
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		modelID := uuid.New().String()
 		_, err := pool.Exec(context.Background(),
 			`INSERT INTO models (id, provider_id, model_id, name, enabled, context_length) VALUES ($1, $2, $3, $4, $5, $6)`,
@@ -833,8 +833,8 @@ func TestDoTestModelRequest_CustomCheckRedirect(t *testing.T) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Return a successful chat completions response
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]interface{}{
-			"choices": []map[string]interface{}{
+		json.NewEncoder(w).Encode(map[string]any{
+			"choices": []map[string]any{
 				{"message": map[string]string{"content": "Hi"}},
 			},
 			"usage": map[string]int{"prompt_tokens": 5, "completion_tokens": 1},

--- a/internal/api/handler_providers_test.go
+++ b/internal/api/handler_providers_test.go
@@ -470,7 +470,7 @@ func TestListProviders_WithPagination(t *testing.T) {
 	// Create multiple providers
 	var rec *httptest.ResponseRecorder
 	var req *http.Request
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		providerData := fmt.Sprintf(`{"name": "test-provider-%d", "base_url": "https://api.openai.com", "api_key": "test-api-key"}`, i)
 		rec = httptest.NewRecorder()
 		req = httptest.NewRequest("POST", "/providers", strings.NewReader(providerData))
@@ -827,7 +827,7 @@ func TestListProviders_WithSearchFilter(t *testing.T) {
 		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var response []map[string]interface{}
+	var response []map[string]any
 	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
 		t.Fatalf("Failed to parse response: %v", err)
 	}
@@ -855,7 +855,7 @@ func TestUpdateProvider_InvalidBody(t *testing.T) {
 		t.Fatalf("Failed to create provider: %d: %s", w.Code, w.Body.String())
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	json.NewDecoder(w.Body).Decode(&resp)
 	providerID, ok := resp["id"].(string)
 	if !ok {
@@ -888,7 +888,7 @@ func TestUpdateProvider_WithNewAPIKey(t *testing.T) {
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	json.NewDecoder(w.Body).Decode(&resp)
 	providerID := resp["id"].(string)
 
@@ -918,7 +918,7 @@ func TestListProviders_WithPaginationAndModelCounts(t *testing.T) {
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	json.NewDecoder(w.Body).Decode(&resp)
 	providerID := resp["id"].(string)
 
@@ -950,7 +950,7 @@ func TestListProviders_WithPaginationAndModelCounts(t *testing.T) {
 		t.Errorf("expected 200 OK, got %d: %s", w2.Code, w2.Body.String())
 	}
 
-	var response []map[string]interface{}
+	var response []map[string]any
 	json.NewDecoder(w2.Body).Decode(&response)
 	if len(response) < 1 {
 		t.Fatalf("expected at least 1 provider, got %d", len(response))
@@ -996,7 +996,7 @@ func TestUpdateProvider_NameConflict(t *testing.T) {
 	w2 := httptest.NewRecorder()
 	r.ServeHTTP(w2, req2)
 
-	var resp1, resp2 map[string]interface{}
+	var resp1, resp2 map[string]any
 	json.NewDecoder(w1.Body).Decode(&resp1)
 	json.NewDecoder(w2.Body).Decode(&resp2)
 	providerID2 := resp2["id"].(string)
@@ -1054,7 +1054,7 @@ func TestListProviders_SearchFilter_Integration(t *testing.T) {
 	}
 
 	// Response is an array of providers
-	var providers []map[string]interface{}
+	var providers []map[string]any
 	if err := json.NewDecoder(w3.Body).Decode(&providers); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
@@ -1155,7 +1155,7 @@ func TestUpdateProvider_EnableDisable(t *testing.T) {
 			t.Fatalf("Expected 200, got %d: %s", rec.Code, rec.Body.String())
 		}
 
-		var response map[string]interface{}
+		var response map[string]any
 		if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
 			t.Fatalf("Failed to parse response: %v", err)
 		}
@@ -1177,7 +1177,7 @@ func TestUpdateProvider_EnableDisable(t *testing.T) {
 			t.Fatalf("Expected 200, got %d: %s", rec.Code, rec.Body.String())
 		}
 
-		var response map[string]interface{}
+		var response map[string]any
 		if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
 			t.Fatalf("Failed to parse response: %v", err)
 		}
@@ -1230,7 +1230,7 @@ func TestUpdateProvider_PartialUpdate_WithGet(t *testing.T) {
 		req.Header.Set("Authorization", "Bearer test-admin-token")
 		r.ServeHTTP(rec, req)
 
-		var response map[string]interface{}
+		var response map[string]any
 		if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
 			t.Fatalf("Failed to parse response: %v", err)
 		}
@@ -1258,7 +1258,7 @@ func TestUpdateProvider_PartialUpdate_WithGet(t *testing.T) {
 		req.Header.Set("Authorization", "Bearer test-admin-token")
 		r.ServeHTTP(rec, req)
 
-		var response map[string]interface{}
+		var response map[string]any
 		if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
 			t.Fatalf("Failed to parse response: %v", err)
 		}
@@ -1360,7 +1360,7 @@ func TestListProviders_WithTokenCounts_Integration(t *testing.T) {
 	}
 
 	// Parse the provider ID from the create response
-	var createResp map[string]interface{}
+	var createResp map[string]any
 	if err := json.Unmarshal(w.Body.Bytes(), &createResp); err != nil {
 		t.Fatalf("Failed to parse create response: %v", err)
 	}
@@ -1389,7 +1389,7 @@ func TestListProviders_WithTokenCounts_Integration(t *testing.T) {
 		t.Errorf("Expected 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var providers []map[string]interface{}
+	var providers []map[string]any
 	if err := json.Unmarshal(w.Body.Bytes(), &providers); err != nil {
 		t.Fatalf("Failed to parse list response: %v", err)
 	}

--- a/internal/api/handler_settings_test.go
+++ b/internal/api/handler_settings_test.go
@@ -34,7 +34,7 @@ func TestGetSettings(t *testing.T) {
 		t.Fatalf("Expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
 
-	var response map[string]interface{}
+	var response map[string]any
 	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
 		t.Fatalf("Failed to parse response: %v", err)
 	}
@@ -68,7 +68,7 @@ func TestUpdateSettingsIntegration(t *testing.T) {
 		t.Fatalf("Expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
 
-	var response map[string]interface{}
+	var response map[string]any
 	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
 		t.Fatalf("Failed to parse response: %v", err)
 	}
@@ -323,7 +323,7 @@ func TestUpdateSettings_TooManySettings_Integration(t *testing.T) {
 
 	// Create a map with >50 settings
 	settings := make(map[string]string)
-	for i := 0; i < 51; i++ {
+	for i := range 51 {
 		settings[fmt.Sprintf("setting_%d", i)] = "value"
 	}
 	body, _ := json.Marshal(settings)

--- a/internal/api/handler_stats_test.go
+++ b/internal/api/handler_stats_test.go
@@ -30,7 +30,7 @@ func TestGetStats(t *testing.T) {
 		t.Fatalf("Expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
 
-	var response map[string]interface{}
+	var response map[string]any
 	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
 		t.Fatalf("Failed to parse response: %v", err)
 	}
@@ -52,7 +52,7 @@ func TestGetTimeSeries(t *testing.T) {
 		t.Fatalf("Expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
 
-	var response map[string]interface{}
+	var response map[string]any
 	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
 		t.Fatalf("Failed to parse response: %v", err)
 	}
@@ -74,7 +74,7 @@ func TestGetProviderDistribution(t *testing.T) {
 		t.Fatalf("Expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
 
-	var response map[string]interface{}
+	var response map[string]any
 	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
 		t.Fatalf("Failed to parse response: %v", err)
 	}
@@ -174,7 +174,7 @@ func TestGetTimeSeries_DifferentPeriods(t *testing.T) {
 	// Insert some request logs at different times
 	now := time.Now().UTC()
 	pool := h.Pool().Pool()
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		_, err := pool.Exec(context.Background(), `
 			INSERT INTO request_logs (
 				provider_id, model_id, virtual_key_id, status_code, duration_ms, 
@@ -259,7 +259,7 @@ func TestGetProviderDistribution_WithLogs(t *testing.T) {
 	now := time.Now().UTC()
 	pool := h.Pool().Pool()
 	for name, providerID := range providerIDs {
-		for i := 0; i < 3; i++ {
+		for i := range 3 {
 			_, err := pool.Exec(context.Background(), `
 				INSERT INTO request_logs (
 					provider_id, model_id, virtual_key_id, status_code, duration_ms, 
@@ -355,7 +355,7 @@ func TestGetStats_Empty(t *testing.T) {
 		t.Errorf("expected 200 OK, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var response map[string]interface{}
+	var response map[string]any
 	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
@@ -401,7 +401,7 @@ func TestGetStats_WithQueryParams_Integration(t *testing.T) {
 	pool := h.Pool().Pool()
 
 	// Insert logs for last 24 hours with different metrics
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		_, err := pool.Exec(context.Background(), `
 			INSERT INTO request_logs (
 				provider_id, model_id, status_code, duration_ms, 
@@ -526,7 +526,7 @@ func TestGetStats_WithFilters_Integration(t *testing.T) {
 		t.Fatalf("Failed to create provider: %d", w.Code)
 	}
 
-	var createResp map[string]interface{}
+	var createResp map[string]any
 	json.Unmarshal(w.Body.Bytes(), &createResp)
 	provIDStr := createResp["id"].(string)
 	provUUID, _ := uuid.Parse(provIDStr)
@@ -564,7 +564,7 @@ func TestGetStats_WithExcludeDeleted(t *testing.T) {
 		t.Fatalf("Failed to create provider: %d", w.Code)
 	}
 
-	var createResp map[string]interface{}
+	var createResp map[string]any
 	json.Unmarshal(w.Body.Bytes(), &createResp)
 	provIDStr := createResp["id"].(string)
 	provUUID, _ := uuid.Parse(provIDStr)
@@ -613,7 +613,7 @@ func TestGetStats_WithMetricTokens(t *testing.T) {
 		t.Fatalf("Failed to create provider: %d", w.Code)
 	}
 
-	var createResp map[string]interface{}
+	var createResp map[string]any
 	json.Unmarshal(w.Body.Bytes(), &createResp)
 	provIDStr := createResp["id"].(string)
 	provUUID, _ := uuid.Parse(provIDStr)
@@ -629,7 +629,7 @@ func TestGetStats_WithMetricTokens(t *testing.T) {
 		t.Fatalf("Failed to create virtual key: %d", w.Code)
 	}
 
-	var vkResp map[string]interface{}
+	var vkResp map[string]any
 	json.Unmarshal(w.Body.Bytes(), &vkResp)
 	vkIDStr := vkResp["id"].(string)
 	vkUUID, _ := uuid.Parse(vkIDStr)
@@ -684,7 +684,7 @@ func TestGetStats_Period7d(t *testing.T) {
 		t.Fatalf("Failed to create provider: %d", w.Code)
 	}
 
-	var createResp map[string]interface{}
+	var createResp map[string]any
 	json.Unmarshal(w.Body.Bytes(), &createResp)
 	provIDStr := createResp["id"].(string)
 	provUUID, _ := uuid.Parse(provIDStr)
@@ -733,7 +733,7 @@ func TestGetStats_Period1h(t *testing.T) {
 		t.Fatalf("Failed to create provider: %d", w.Code)
 	}
 
-	var createResp map[string]interface{}
+	var createResp map[string]any
 	json.Unmarshal(w.Body.Bytes(), &createResp)
 	provIDStr := createResp["id"].(string)
 	provUUID, _ := uuid.Parse(provIDStr)
@@ -782,7 +782,7 @@ func TestGetStats_WithChatLogs(t *testing.T) {
 		t.Fatalf("Failed to create provider: %d", w.Code)
 	}
 
-	var createResp map[string]interface{}
+	var createResp map[string]any
 	json.Unmarshal(w.Body.Bytes(), &createResp)
 	provIDStr := createResp["id"].(string)
 	provUUID, _ := uuid.Parse(provIDStr)
@@ -831,7 +831,7 @@ func TestGetProviderDistribution_WithMetricTokens(t *testing.T) {
 		t.Fatalf("Failed to create provider: %d", w.Code)
 	}
 
-	var createResp map[string]interface{}
+	var createResp map[string]any
 	json.Unmarshal(w.Body.Bytes(), &createResp)
 	provIDStr := createResp["id"].(string)
 	provUUID, _ := uuid.Parse(provIDStr)
@@ -884,7 +884,7 @@ func TestGetTimeSeries_WithExcludeDeleted(t *testing.T) {
 		t.Fatalf("Failed to create provider: %d", w.Code)
 	}
 
-	var createResp map[string]interface{}
+	var createResp map[string]any
 	json.Unmarshal(w.Body.Bytes(), &createResp)
 	provIDStr := createResp["id"].(string)
 	provUUID, _ := uuid.Parse(provIDStr)
@@ -933,7 +933,7 @@ func TestGetProviderDistribution_WithExcludeDeleted(t *testing.T) {
 		t.Fatalf("Failed to create provider: %d", w.Code)
 	}
 
-	var createResp map[string]interface{}
+	var createResp map[string]any
 	json.Unmarshal(w.Body.Bytes(), &createResp)
 	provIDStr := createResp["id"].(string)
 	provUUID, _ := uuid.Parse(provIDStr)
@@ -975,7 +975,7 @@ func TestGetStats_ProviderLatency(t *testing.T) {
 
 	// Create multiple providers
 	providerIDs := make([]uuid.UUID, 3)
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		provBody := fmt.Sprintf(`{"name":"provider-latency-%d-%s","base_url":"https://api.example.com/v1","api_key":"sk-test"}`, i, uuid.New().String()[:8])
 		req := httptest.NewRequest("POST", "/providers", strings.NewReader(provBody))
 		req.Header.Set("Content-Type", "application/json")
@@ -986,7 +986,7 @@ func TestGetStats_ProviderLatency(t *testing.T) {
 			t.Fatalf("Failed to create provider %d: %d", i, w.Code)
 		}
 
-		var createResp map[string]interface{}
+		var createResp map[string]any
 		json.Unmarshal(w.Body.Bytes(), &createResp)
 		provIDStr := createResp["id"].(string)
 		providerIDs[i], _ = uuid.Parse(provIDStr)
@@ -996,7 +996,7 @@ func TestGetStats_ProviderLatency(t *testing.T) {
 	pool := h.dbPool.Pool()
 	now := time.Now().UTC()
 	for i, provID := range providerIDs {
-		for j := 0; j < 5; j++ {
+		for j := range 5 {
 			duration := float64(1000 + i*500 + j*100) // Different durations per provider
 			overhead := float64(50 + j*5)
 			_, err := pool.Exec(context.Background(), `

--- a/internal/api/handler_system_test.go
+++ b/internal/api/handler_system_test.go
@@ -33,7 +33,7 @@ func TestGetSystem(t *testing.T) {
 		t.Fatalf("Expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
 
-	var response map[string]interface{}
+	var response map[string]any
 	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
 		t.Fatalf("Failed to parse response: %v", err)
 	}
@@ -105,7 +105,7 @@ func TestGetSystem_NoCache(t *testing.T) {
 		t.Errorf("expected 200 OK, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var response map[string]interface{}
+	var response map[string]any
 	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
@@ -171,7 +171,7 @@ func TestGetSystem_Details(t *testing.T) {
 		t.Fatalf("Expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
 
-	var response map[string]interface{}
+	var response map[string]any
 	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
 		t.Fatalf("Failed to parse response: %v", err)
 	}
@@ -184,7 +184,7 @@ func TestGetSystem_Details(t *testing.T) {
 	}
 
 	// Check app section has expected fields
-	if app, ok := response["app"].(map[string]interface{}); ok {
+	if app, ok := response["app"].(map[string]any); ok {
 		for _, field := range []string{"uptime_seconds", "goroutines", "memory_current_bytes"} {
 			if _, exists := app[field]; !exists {
 				t.Errorf("Expected field 'app.%s' in system response", field)
@@ -193,7 +193,7 @@ func TestGetSystem_Details(t *testing.T) {
 	}
 
 	// Check db section has expected fields
-	if db, ok := response["db"].(map[string]interface{}); ok {
+	if db, ok := response["db"].(map[string]any); ok {
 		for _, field := range []string{"connections"} {
 			if _, exists := db[field]; !exists {
 				t.Errorf("Expected field 'db.%s' in system response", field)
@@ -361,7 +361,7 @@ func TestGetOllamaCloudAccount(t *testing.T) {
 			t.Fatalf("Failed to create provider: %d: %s", rec.Code, rec.Body.String())
 		}
 
-		var providerResp map[string]interface{}
+		var providerResp map[string]any
 		if err := json.Unmarshal(rec.Body.Bytes(), &providerResp); err != nil {
 			t.Fatalf("Failed to parse provider response: %v", err)
 		}

--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -63,7 +63,7 @@ func parseUUIDParam(w http.ResponseWriter, r *http.Request, key string, label ..
 }
 
 // writeJSON sets the Content-Type header and encodes the response as JSON.
-func writeJSON(w http.ResponseWriter, v interface{}) {
+func writeJSON(w http.ResponseWriter, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(v); err != nil {
 		logEncodeError(err)
@@ -71,7 +71,7 @@ func writeJSON(w http.ResponseWriter, v interface{}) {
 }
 
 // writeJSONCreated sets the Content-Type header, writes 201 status, and encodes the response.
-func writeJSONCreated(w http.ResponseWriter, v interface{}) {
+func writeJSONCreated(w http.ResponseWriter, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
 	if err := json.NewEncoder(w).Encode(v); err != nil {

--- a/internal/api/logs.go
+++ b/internal/api/logs.go
@@ -660,17 +660,8 @@ func (h *Handler) PurgeLogs(w http.ResponseWriter, r *http.Request) {
 
 // ListLogs returns paginated request logs with filtering and sorting.
 func (h *Handler) ListLogs(w http.ResponseWriter, r *http.Request) {
-	page := util.GetIntQueryParam(r, "page", 1)
-	if page < 1 {
-		page = 1
-	}
-	perPage := util.GetIntQueryParam(r, "per_page", 20)
-	if perPage < 1 {
-		perPage = 1
-	}
-	if perPage > 200 {
-		perPage = 200
-	}
+	page := max(util.GetIntQueryParam(r, "page", 1), 1)
+	perPage := min(max(util.GetIntQueryParam(r, "per_page", 20), 1), 200)
 	ownerUserID := logOwnerScope(r)
 	// The response cache is shared across callers, so the key must carry the
 	// owner scope: a non-admin page and the admin's unscoped page for the same

--- a/internal/api/logs_golden_test.go
+++ b/internal/api/logs_golden_test.go
@@ -32,7 +32,7 @@ func TestListLogsCursor_Golden(t *testing.T) {
 
 	model := "golden-" + uuid.New().String()[:8]
 	ids := make([]string, 6) // newest (0) -> oldest (5)
-	for i := 0; i < 6; i++ {
+	for i := range 6 {
 		id := uuid.New()
 		ids[i] = id.String()
 		status := 200

--- a/internal/api/logs_listgolden_test.go
+++ b/internal/api/logs_listgolden_test.go
@@ -30,7 +30,7 @@ func TestListLogs_Golden(t *testing.T) {
 
 	model := "listgold-" + uuid.New().String()[:8]
 	ids := make([]string, 6) // newest (0) -> oldest (5)
-	for i := 0; i < 6; i++ {
+	for i := range 6 {
 		id := uuid.New()
 		ids[i] = id.String()
 		status := 200

--- a/internal/api/logs_paramedges_test.go
+++ b/internal/api/logs_paramedges_test.go
@@ -24,7 +24,7 @@ func TestListLogsCursor_ParamEdges(t *testing.T) {
 	insertTestProvider(t, pool, provID, "edge-prov-"+uuid.New().String()[:8], "https://e.example/v1")
 
 	model := "edge-" + uuid.New().String()[:8]
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		if _, err := pool.Exec(ctx,
 			`INSERT INTO request_logs (id, provider_id, model_id, status_code, duration_ms, created_at)
 			 VALUES ($1, $2, $3, 200, 100, NOW() - ($4 * INTERVAL '1 minute'))`,

--- a/internal/api/logs_test.go
+++ b/internal/api/logs_test.go
@@ -860,7 +860,7 @@ func TestListLogsCursor_Default(t *testing.T) {
 
 	// Insert test request logs
 	pool := h.Pool().Pool()
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		_, err := pool.Exec(context.Background(),
 			fmt.Sprintf(`INSERT INTO request_logs (id, provider_id, model_id, status_code, duration_ms, created_at)
 			 VALUES ($1, $2, $3, $4, $5, NOW() - INTERVAL '%d minutes')`, i*10),
@@ -927,7 +927,7 @@ func TestListLogsCursor_WithCursor(t *testing.T) {
 
 	// Insert test request logs with known timestamps
 	pool := h.Pool().Pool()
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		logID := uuid.New()
 		// Stagger timestamps
 		ts := time.Now().Add(-time.Duration(i) * time.Minute)
@@ -1127,7 +1127,7 @@ func TestListLogsCursor_BackwardPagination(t *testing.T) {
 	// Insert 10 request logs with staggered timestamps (newest first for DESC)
 	pool := h.Pool().Pool()
 	ids := make([]string, 10)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		ids[i] = uuid.New().String()
 		ts := time.Now().Add(-time.Duration(i) * time.Minute)
 		_, err := pool.Exec(context.Background(),

--- a/internal/api/logscache_test.go
+++ b/internal/api/logscache_test.go
@@ -137,7 +137,7 @@ func TestLogsCacheSet_LazyEviction(t *testing.T) {
 	}
 
 	// Add some expired entries
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		cache.entries[fmt.Sprintf("expired%d", i)] = &logsCacheEntry{
 			response: &LogsResponse{Entries: []LogEntry{}, Total: i},
 			expiry:   time.Now().Add(-1 * time.Second),

--- a/internal/api/managedwrite.go
+++ b/internal/api/managedwrite.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"net/http"
+	"slices"
 	"time"
 
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
@@ -67,12 +68,7 @@ func managedBlocksSyncableSettings(ctx context.Context, fs fleetSettings, keys [
 	if !isManagedMember(ctx, fs) {
 		return false
 	}
-	for _, k := range keys {
-		if isSyncableSetting(k) {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(keys, isSyncableSetting)
 }
 
 // managedWriteGuard returns middleware that refuses a request with 403 when this

--- a/internal/api/models.go
+++ b/internal/api/models.go
@@ -93,7 +93,7 @@ type modelCursor struct {
 	SortBy        string    `json:"sort_by"`
 	Name          string    `json:"name,omitempty"`
 	ModelID       string    `json:"model_id,omitempty"`
-	LastSeenAt    time.Time `json:"last_seen_at,omitempty"`
+	LastSeenAt    time.Time `json:"last_seen_at"`
 	ContextLength *int      `json:"context_length,omitempty"`
 	MaxOutput     *int      `json:"max_output_tokens,omitempty"`
 	ProviderName  string    `json:"provider_name,omitempty"`
@@ -402,7 +402,7 @@ func (h *Handler) decryptTestModelKey(w http.ResponseWriter, prov *provider.Prov
 // OpenAI gpt-5/o-series models that reject max_tokens, the shared self-heal
 // renames it to max_completion_tokens and retries, so the probe succeeds.
 func buildTestModelRequest(m *model.Model, prov *provider.Provider) (baseBody []byte, providerType, targetURL, reqHash string) {
-	body := map[string]interface{}{
+	body := map[string]any{
 		"model": m.ModelID,
 		"messages": []map[string]string{
 			{"role": "user", "content": "Respond only with `Hi`"},

--- a/internal/api/models_cursor.go
+++ b/internal/api/models_cursor.go
@@ -214,7 +214,7 @@ func modelSortColumn(sortBy string) string {
 }
 
 // buildModelKeysetPredicate builds the keyset WHERE clause for cursor pagination.
-func buildModelKeysetPredicate(cursor modelCursor, direction, sortDir string, argIdx *int, args *[]interface{}) string {
+func buildModelKeysetPredicate(cursor modelCursor, direction, sortDir string, argIdx *int, args *[]any) string {
 	if cursor.ID == "" {
 		return ""
 	}
@@ -304,9 +304,9 @@ func joinAnd(conditions []string) string {
 // buildModelFilterConditions builds the WHERE clause conditions and args for
 // search, provider_id, capabilities, and outputs filters. Shared between the
 // main data query and the count query to avoid duplication.
-func buildModelFilterConditions(q url.Values) ([]string, []interface{}) {
+func buildModelFilterConditions(q url.Values) ([]string, []any) {
 	conditions := []string{}
-	args := []interface{}{}
+	args := []any{}
 	argIdx := 1
 
 	if search := q.Get("search"); search != "" {

--- a/internal/api/models_cursor_test.go
+++ b/internal/api/models_cursor_test.go
@@ -1081,7 +1081,7 @@ func TestListModelsCursor_BackwardPagination(t *testing.T) {
 
 func TestBuildModelKeysetPredicate_EmptyCursor(t *testing.T) {
 	argIdx := 1
-	var args []interface{}
+	var args []any
 	result := buildModelKeysetPredicate(modelCursor{}, "after", "ASC", &argIdx, &args)
 	if result != "" {
 		t.Errorf("expected empty string for empty cursor, got %q", result)
@@ -1093,7 +1093,7 @@ func TestBuildModelKeysetPredicate_EmptyCursor(t *testing.T) {
 
 func TestBuildModelKeysetPredicate_EmptyID(t *testing.T) {
 	argIdx := 1
-	var args []interface{}
+	var args []any
 	result := buildModelKeysetPredicate(modelCursor{SortBy: "name"}, "after", "ASC", &argIdx, &args)
 	if result != "" {
 		t.Errorf("expected empty string for empty ID, got %q", result)
@@ -1102,7 +1102,7 @@ func TestBuildModelKeysetPredicate_EmptyID(t *testing.T) {
 
 func TestBuildModelKeysetPredicate_NameSort(t *testing.T) {
 	argIdx := 1
-	var args []interface{}
+	var args []any
 	cursor := modelCursor{SortBy: "name", Name: "my-model", ID: "test-id-1"}
 	result := buildModelKeysetPredicate(cursor, "after", "ASC", &argIdx, &args)
 	if result == "" {
@@ -1127,7 +1127,7 @@ func TestBuildModelKeysetPredicate_NameSort(t *testing.T) {
 
 func TestBuildModelKeysetPredicate_DescAfterUsesLessThan(t *testing.T) {
 	argIdx := 1
-	var args []interface{}
+	var args []any
 	cursor := modelCursor{SortBy: "name", Name: "my-model", ID: "test-id-2"}
 	result := buildModelKeysetPredicate(cursor, "after", "DESC", &argIdx, &args)
 	if !strings.Contains(result, "<") {
@@ -1137,7 +1137,7 @@ func TestBuildModelKeysetPredicate_DescAfterUsesLessThan(t *testing.T) {
 
 func TestBuildModelKeysetPredicate_BeforeAscUsesLessThan(t *testing.T) {
 	argIdx := 1
-	var args []interface{}
+	var args []any
 	cursor := modelCursor{SortBy: "name", Name: "my-model", ID: "test-id-3"}
 	result := buildModelKeysetPredicate(cursor, "before", "ASC", &argIdx, &args)
 	if !strings.Contains(result, "<") {
@@ -1147,7 +1147,7 @@ func TestBuildModelKeysetPredicate_BeforeAscUsesLessThan(t *testing.T) {
 
 func TestBuildModelKeysetPredicate_DiscoveredSort(t *testing.T) {
 	argIdx := 5
-	var args []interface{}
+	var args []any
 	now := time.Now()
 	cursor := modelCursor{SortBy: "discovered", LastSeenAt: now, ID: "test-id-disc"}
 	result := buildModelKeysetPredicate(cursor, "after", "ASC", &argIdx, &args)
@@ -1164,7 +1164,7 @@ func TestBuildModelKeysetPredicate_DiscoveredSort(t *testing.T) {
 
 func TestBuildModelKeysetPredicate_DiscoveredSortZeroTime(t *testing.T) {
 	argIdx := 1
-	var args []interface{}
+	var args []any
 	cursor := modelCursor{SortBy: "discovered", ID: "test-id-zero"}
 	result := buildModelKeysetPredicate(cursor, "after", "ASC", &argIdx, &args)
 	if result != "" {
@@ -1174,7 +1174,7 @@ func TestBuildModelKeysetPredicate_DiscoveredSortZeroTime(t *testing.T) {
 
 func TestBuildModelKeysetPredicate_ContextSort(t *testing.T) {
 	argIdx := 3
-	var args []interface{}
+	var args []any
 	ctxLen := 8192
 	cursor := modelCursor{SortBy: "context", ContextLength: &ctxLen, ID: "test-id-ctx"}
 	result := buildModelKeysetPredicate(cursor, "after", "ASC", &argIdx, &args)
@@ -1188,7 +1188,7 @@ func TestBuildModelKeysetPredicate_ContextSort(t *testing.T) {
 
 func TestBuildModelKeysetPredicate_ContextSortNilLength(t *testing.T) {
 	argIdx := 1
-	var args []interface{}
+	var args []any
 	cursor := modelCursor{SortBy: "context", ID: "test-id-ctx-nil"}
 	result := buildModelKeysetPredicate(cursor, "after", "ASC", &argIdx, &args)
 	if result != "" {
@@ -1198,7 +1198,7 @@ func TestBuildModelKeysetPredicate_ContextSortNilLength(t *testing.T) {
 
 func TestBuildModelKeysetPredicate_OutputSort(t *testing.T) {
 	argIdx := 1
-	var args []interface{}
+	var args []any
 	maxOut := 4096
 	cursor := modelCursor{SortBy: "output", MaxOutput: &maxOut, ID: "test-id-out"}
 	result := buildModelKeysetPredicate(cursor, "after", "ASC", &argIdx, &args)
@@ -1212,7 +1212,7 @@ func TestBuildModelKeysetPredicate_OutputSort(t *testing.T) {
 
 func TestBuildModelKeysetPredicate_OutputSortNilOutput(t *testing.T) {
 	argIdx := 1
-	var args []interface{}
+	var args []any
 	cursor := modelCursor{SortBy: "output", ID: "test-id-out-nil"}
 	result := buildModelKeysetPredicate(cursor, "after", "ASC", &argIdx, &args)
 	if result != "" {
@@ -1222,7 +1222,7 @@ func TestBuildModelKeysetPredicate_OutputSortNilOutput(t *testing.T) {
 
 func TestBuildModelKeysetPredicate_ProviderSort(t *testing.T) {
 	argIdx := 1
-	var args []interface{}
+	var args []any
 	cursor := modelCursor{SortBy: "provider", ProviderName: "OpenAI", ID: "test-id-prov"}
 	result := buildModelKeysetPredicate(cursor, "after", "ASC", &argIdx, &args)
 	if result == "" {
@@ -1235,7 +1235,7 @@ func TestBuildModelKeysetPredicate_ProviderSort(t *testing.T) {
 
 func TestBuildModelKeysetPredicate_ProviderSortEmptyName(t *testing.T) {
 	argIdx := 1
-	var args []interface{}
+	var args []any
 	cursor := modelCursor{SortBy: "provider", ID: "test-id-prov-empty"}
 	result := buildModelKeysetPredicate(cursor, "after", "ASC", &argIdx, &args)
 	if result != "" {
@@ -1245,7 +1245,7 @@ func TestBuildModelKeysetPredicate_ProviderSortEmptyName(t *testing.T) {
 
 func TestBuildModelKeysetPredicate_StatusSort(t *testing.T) {
 	argIdx := 1
-	var args []interface{}
+	var args []any
 	statusSort := 0
 	cursor := modelCursor{SortBy: "status", StatusSort: &statusSort, ID: "test-id-status"}
 	result := buildModelKeysetPredicate(cursor, "after", "ASC", &argIdx, &args)
@@ -1259,7 +1259,7 @@ func TestBuildModelKeysetPredicate_StatusSort(t *testing.T) {
 
 func TestBuildModelKeysetPredicate_StatusSortNil(t *testing.T) {
 	argIdx := 1
-	var args []interface{}
+	var args []any
 	cursor := modelCursor{SortBy: "status", ID: "test-id-status-nil"}
 	result := buildModelKeysetPredicate(cursor, "after", "ASC", &argIdx, &args)
 	if result != "" {
@@ -1269,7 +1269,7 @@ func TestBuildModelKeysetPredicate_StatusSortNil(t *testing.T) {
 
 func TestBuildModelKeysetPredicate_DefaultSortFallsBackToModelID(t *testing.T) {
 	argIdx := 1
-	var args []interface{}
+	var args []any
 	cursor := modelCursor{SortBy: "name", ModelID: "gpt-4", ID: "test-id-fallback"}
 	result := buildModelKeysetPredicate(cursor, "after", "ASC", &argIdx, &args)
 	if result == "" {
@@ -1286,7 +1286,7 @@ func TestBuildModelKeysetPredicate_DefaultSortFallsBackToModelID(t *testing.T) {
 
 func TestBuildModelKeysetPredicate_ArgIdxAdvances(t *testing.T) {
 	argIdx := 10
-	var args []interface{}
+	var args []any
 	ctxLen := 128
 	cursor := modelCursor{SortBy: "context", ContextLength: &ctxLen, ID: "test-id-idx"}
 	buildModelKeysetPredicate(cursor, "after", "ASC", &argIdx, &args)

--- a/internal/api/models_helpers_test.go
+++ b/internal/api/models_helpers_test.go
@@ -162,11 +162,11 @@ func TestModelToResponse(t *testing.T) {
 				Modality:                     "text",
 				InputModalities:              `["text"]`,
 				OutputModalities:             `["text"]`,
-				ContextLength:                intPtr(128000),
-				MaxOutputTokens:              intPtr(4096),
-				InputPricePerMillion:         float64Ptr(10.0),
-				InputPricePerMillionCacheHit: float64Ptr(5.0),
-				OutputPricePerMillion:        float64Ptr(30.0),
+				ContextLength:                new(128000),
+				MaxOutputTokens:              new(4096),
+				InputPricePerMillion:         new(10.0),
+				InputPricePerMillionCacheHit: new(5.0),
+				OutputPricePerMillion:        new(30.0),
 				OwnedBy:                      "OpenAI",
 				Enabled:                      true,
 				CreatedAt:                    time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC),
@@ -185,11 +185,11 @@ func TestModelToResponse(t *testing.T) {
 				Modality:                     "text",
 				InputModalities:              `["text"]`,
 				OutputModalities:             `["text"]`,
-				ContextLength:                intPtr(128000),
-				MaxOutputTokens:              intPtr(4096),
-				InputPricePerMillion:         float64Ptr(10.0),
-				InputPricePerMillionCacheHit: float64Ptr(5.0),
-				OutputPricePerMillion:        float64Ptr(30.0),
+				ContextLength:                new(128000),
+				MaxOutputTokens:              new(4096),
+				InputPricePerMillion:         new(10.0),
+				InputPricePerMillionCacheHit: new(5.0),
+				OutputPricePerMillion:        new(30.0),
 				OwnedBy:                      "OpenAI",
 				Enabled:                      true,
 				CreatedAt:                    "2024-01-15T10:30:00Z",
@@ -344,16 +344,7 @@ func TestModelToResponse(t *testing.T) {
 	}
 }
 
-// Helper functions for testing
-func intPtr(i int) *int {
-	return &i
-}
-
-func float64Ptr(f float64) *float64 {
-	return &f
-}
-
-func ptrEqual(a, b interface{}) bool {
+func ptrEqual(a, b any) bool {
 	// Handle nil cases - this handles when the interface{} itself is nil
 	if a == nil && b == nil {
 		return true

--- a/internal/api/settings_test.go
+++ b/internal/api/settings_test.go
@@ -368,7 +368,7 @@ func TestUpdateSettings_TooManyKeys(t *testing.T) {
 	// Build a request with more than 50 unique keys
 	// The >50 check happens before key validation, so keys don't need to be valid
 	body := `{`
-	for i := 0; i < 55; i++ {
+	for i := range 55 {
 		if i > 0 {
 			body += `,`
 		}

--- a/internal/api/stats_calculate_test.go
+++ b/internal/api/stats_calculate_test.go
@@ -454,7 +454,7 @@ func TestCalculateStats_IncludeLatencyWithData(t *testing.T) {
 	insertTestProvider(t, pool, providerID, "test-provider-lat-data", "https://api.example.com/v1")
 
 	// Insert 3 requests for a single model to meet the HAVING COUNT(*) >= 3 threshold
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		insertRichTestRequestLog(t, pool, uuid.New(), providerID, "lat-model", 200, 150, 10, 20, requestLogOpts{
 			ProxyOverheadMs: 15.0,
 			LatencyMs:       135.0,
@@ -583,7 +583,7 @@ func TestCalculateStats_WithLatency(t *testing.T) {
 	// Insert enough request logs to populate latency data (>=3 for HAVING clause)
 	providerID := uuid.New()
 	insertTestProvider(t, pool, providerID, "latency-provider", "https://api.example.com/v1")
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		insertRichTestRequestLog(t, pool, uuid.New(), providerID, "latency-model", 200, 100+i*10, 10, 20, requestLogOpts{
 			ResponseHeaderMs: float64(50 + i*5),
 			ProxyOverheadMs:  float64(10 + i*2),
@@ -666,7 +666,7 @@ func TestCalculateStats_7dWithLatency(t *testing.T) {
 
 	providerID := uuid.New()
 	insertTestProvider(t, pool, providerID, "latency-7d-provider", "https://api.example.com/v1")
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		insertRichTestRequestLog(t, pool, uuid.New(), providerID, "latency-7d-model", 200, 100+i*10, 10, 20, requestLogOpts{
 			ResponseHeaderMs: float64(50 + i*5),
 			ProxyOverheadMs:  float64(10 + i*2),

--- a/internal/api/stats_handlers_test.go
+++ b/internal/api/stats_handlers_test.go
@@ -849,13 +849,13 @@ func TestGetStats_MultipleProviders(t *testing.T) {
 	insertTestProvider(t, pool, providerC, "provider-c", "https://api.c.com/v1")
 
 	// Insert request logs: 2 for A, 3 for B, 5 for C (total=10)
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		insertTestRequestLog(t, pool, uuid.New(), providerA, "model-a", 200, 100, 10, 20)
 	}
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		insertTestRequestLog(t, pool, uuid.New(), providerB, "model-b", 200, 100, 10, 20)
 	}
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		insertTestRequestLog(t, pool, uuid.New(), providerC, "model-c", 200, 100, 10, 20)
 	}
 
@@ -998,7 +998,7 @@ func TestGetStats_ModelLatency(t *testing.T) {
 	// Model D: 2 requests only (should NOT appear due to HAVING COUNT(*) >= 3)
 
 	// Model A - 3 requests with high latency
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		insertRichTestRequestLog(t, pool, uuid.New(), providerID, "model-a", 200, 300, 10, 20, requestLogOpts{
 			ProxyOverheadMs: 30.0,
 			LatencyMs:       270.0, // Provider latency = 270ms
@@ -1006,7 +1006,7 @@ func TestGetStats_ModelLatency(t *testing.T) {
 	}
 
 	// Model B - 3 requests with medium latency
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		insertRichTestRequestLog(t, pool, uuid.New(), providerID, "model-b", 200, 200, 10, 20, requestLogOpts{
 			ProxyOverheadMs: 20.0,
 			LatencyMs:       180.0, // Provider latency = 180ms
@@ -1014,7 +1014,7 @@ func TestGetStats_ModelLatency(t *testing.T) {
 	}
 
 	// Model C - 3 requests with low latency
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		insertRichTestRequestLog(t, pool, uuid.New(), providerID, "model-c", 200, 100, 10, 20, requestLogOpts{
 			ProxyOverheadMs: 10.0,
 			LatencyMs:       90.0, // Provider latency = 90ms
@@ -1022,7 +1022,7 @@ func TestGetStats_ModelLatency(t *testing.T) {
 	}
 
 	// Model D - Only 2 requests (should be excluded by HAVING COUNT(*) >= 3)
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		insertRichTestRequestLog(t, pool, uuid.New(), providerID, "model-d", 200, 500, 10, 20, requestLogOpts{
 			ProxyOverheadMs: 50.0,
 			LatencyMs:       450.0,
@@ -1220,10 +1220,10 @@ func TestGetProviderDistribution_MultipleProviders_ShareRounding(t *testing.T) {
 	insertTestProvider(t, pool, providerC, "provider-c", "https://api.c.com/v1")
 
 	// Insert request logs: 7 for A, 2 for B, 1 for C (total=10)
-	for i := 0; i < 7; i++ {
+	for range 7 {
 		insertTestRequestLog(t, pool, uuid.New(), providerA, "model-a", 200, 100, 10, 20)
 	}
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		insertTestRequestLog(t, pool, uuid.New(), providerB, "model-b", 200, 100, 10, 20)
 	}
 	insertTestRequestLog(t, pool, uuid.New(), providerC, "model-c", 200, 100, 10, 20)

--- a/internal/api/stats_test.go
+++ b/internal/api/stats_test.go
@@ -306,7 +306,7 @@ func TestFillEmptyBuckets_Hourly_FullCoverage(t *testing.T) {
 	end := timeMustParse(time.RFC3339, "2026-01-16T09:00:00Z")
 
 	points := make([]TimeSeriesPoint, 24)
-	for i := 0; i < 24; i++ {
+	for i := range 24 {
 		points[i] = makePoint(bucketFormat(start.Add(time.Duration(i)*time.Hour)), i+1, i*10, i%3)
 	}
 
@@ -418,7 +418,7 @@ func TestFillEmptyBuckets_Daily_FullCoverage(t *testing.T) {
 	end := timeMustParse(time.RFC3339, "2026-01-16T00:00:00Z") // 7 days
 
 	points := make([]TimeSeriesPoint, 7)
-	for i := 0; i < 7; i++ {
+	for i := range 7 {
 		points[i] = makePoint(bucketFormat(start.Add(time.Duration(i)*24*time.Hour)), i*5, i*50, i)
 	}
 

--- a/internal/proxy/chat_integration_test.go
+++ b/internal/proxy/chat_integration_test.go
@@ -48,7 +48,7 @@ func newTestProxyHandler(t *testing.T) *testProxyEnv {
 			return
 		}
 
-		var reqBody map[string]interface{}
+		var reqBody map[string]any
 		if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
 			http.Error(w, "bad request", http.StatusBadRequest)
 			return
@@ -63,15 +63,15 @@ func newTestProxyHandler(t *testing.T) *testProxyEnv {
 			fmt.Fprintf(w, "data: {\"id\":\"chatcmpl-test\",\"object\":\"chat.completion.chunk\",\"choices\":[],\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":7,\"total_tokens\":12}}\n\n")
 			fmt.Fprintf(w, "data: [DONE]\n\n")
 		} else {
-			response := map[string]interface{}{
+			response := map[string]any{
 				"id":      "chatcmpl-test",
 				"object":  "chat.completion",
 				"created": time.Now().Unix(),
 				"model":   reqBody["model"].(string),
-				"choices": []map[string]interface{}{
-					{"index": 0, "message": map[string]interface{}{"role": "assistant", "content": "hello world"}, "finish_reason": "stop"},
+				"choices": []map[string]any{
+					{"index": 0, "message": map[string]any{"role": "assistant", "content": "hello world"}, "finish_reason": "stop"},
 				},
-				"usage": map[string]interface{}{
+				"usage": map[string]any{
 					"prompt_tokens":     5,
 					"completion_tokens": 7,
 					"total_tokens":      12,
@@ -182,7 +182,7 @@ func TestChatCompletions_NonStreaming(t *testing.T) {
 		t.Errorf("expected 200, got %d", w.Code)
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Errorf("failed to parse response: %v", err)
 	}
@@ -191,7 +191,7 @@ func TestChatCompletions_NonStreaming(t *testing.T) {
 		t.Errorf("expected model '%s', got %v", modelName, resp["model"])
 	}
 
-	choices := resp["choices"].([]interface{})
+	choices := resp["choices"].([]any)
 	if len(choices) == 0 {
 		t.Error("expected at least one choice")
 	}
@@ -268,7 +268,7 @@ func TestChatCompletions_HotelModel(t *testing.T) {
 		t.Errorf("expected 200, got %d", w.Code)
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Errorf("failed to parse response: %v", err)
 	}
@@ -373,7 +373,7 @@ func TestChatCompletions_StreamFalseWithStreamOptions(t *testing.T) {
 		t.Errorf("expected 200, got %d", w.Code)
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Errorf("failed to parse response: %v", err)
 	}
@@ -499,7 +499,7 @@ func TestChatCompletions_AdditionalParameters(t *testing.T) {
 		t.Errorf("expected 200, got %d", w.Code)
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Errorf("failed to parse response: %v", err)
 	}
@@ -538,7 +538,7 @@ func TestChatCompletions_NonStreaming_Success(t *testing.T) {
 		t.Errorf("expected Content-Type 'application/json', got %v", contentType)
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("failed to parse response: %v", err)
 	}
@@ -547,12 +547,12 @@ func TestChatCompletions_NonStreaming_Success(t *testing.T) {
 		t.Errorf("expected model '%s', got %v", modelName, resp["model"])
 	}
 
-	choices := resp["choices"].([]interface{})
+	choices := resp["choices"].([]any)
 	if len(choices) != 1 {
 		t.Errorf("expected 1 choice, got %d", len(choices))
 	}
 
-	usage := resp["usage"].(map[string]interface{})
+	usage := resp["usage"].(map[string]any)
 	if usage["prompt_tokens"] != float64(5) {
 		t.Errorf("expected prompt_tokens=5, got %v", usage["prompt_tokens"])
 	}
@@ -577,8 +577,8 @@ func TestChatCompletions_NonStreaming_Upstream4xxError(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
-		json.NewEncoder(w).Encode(map[string]interface{}{
-			"error": map[string]interface{}{
+		json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{
 				"message": "invalid request",
 				"type":    "invalid_request_error",
 			},
@@ -643,7 +643,7 @@ func TestChatCompletions_NonStreaming_Upstream4xxError(t *testing.T) {
 		t.Errorf("expected 400, got %d", w.Code)
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("failed to parse response: %v", err)
 	}
@@ -670,8 +670,8 @@ func TestChatCompletions_NonStreaming_Upstream5xxError(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusServiceUnavailable)
-		json.NewEncoder(w).Encode(map[string]interface{}{
-			"error": map[string]interface{}{
+		json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{
 				"message": "service unavailable",
 				"type":    "server_error",
 			},
@@ -736,7 +736,7 @@ func TestChatCompletions_NonStreaming_Upstream5xxError(t *testing.T) {
 		t.Errorf("expected 503, got %d", w.Code)
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("failed to parse response: %v", err)
 	}
@@ -820,8 +820,8 @@ func TestChatCompletions_FailoverWithBackoff(t *testing.T) {
 	upstream1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(map[string]interface{}{
-			"error": map[string]interface{}{
+		json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{
 				"message": "internal error",
 				"type":    "server_error",
 			},
@@ -833,15 +833,15 @@ func TestChatCompletions_FailoverWithBackoff(t *testing.T) {
 	upstream2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		json.NewEncoder(w).Encode(map[string]any{
 			"id":      "chatcmpl-test",
 			"object":  "chat.completion",
 			"created": time.Now().Unix(),
 			"model":   "success-model",
-			"choices": []map[string]interface{}{
-				{"index": 0, "message": map[string]interface{}{"role": "assistant", "content": "success"}, "finish_reason": "stop"},
+			"choices": []map[string]any{
+				{"index": 0, "message": map[string]any{"role": "assistant", "content": "success"}, "finish_reason": "stop"},
 			},
-			"usage": map[string]interface{}{
+			"usage": map[string]any{
 				"prompt_tokens":     5,
 				"completion_tokens": 7,
 				"total_tokens":      12,
@@ -927,7 +927,7 @@ func TestChatCompletions_FailoverWithBackoff(t *testing.T) {
 		t.Errorf("expected 200 after failover, got %d", w.Code)
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("failed to parse response: %v", err)
 	}
@@ -1055,8 +1055,8 @@ func TestChatCompletions_ClientDisconnectDuringBackoff(t *testing.T) {
 	upstream1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(map[string]interface{}{
-			"error": map[string]interface{}{
+		json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{
 				"message": "error1",
 			},
 		})
@@ -1068,9 +1068,9 @@ func TestChatCompletions_ClientDisconnectDuringBackoff(t *testing.T) {
 		time.Sleep(500 * time.Millisecond)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		json.NewEncoder(w).Encode(map[string]any{
 			"id":      "chatcmpl-test",
-			"choices": []map[string]interface{}{{"message": map[string]interface{}{"content": "success"}}},
+			"choices": []map[string]any{{"message": map[string]any{"content": "success"}}},
 		})
 	}))
 	defer upstream2.Close()
@@ -1188,15 +1188,15 @@ func TestChatCompletions_ParamRejectionAutoRetry(t *testing.T) {
 	// Create provider that rejects temperature on first request, succeeds on retry
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		retryCount.Add(1)
-		var body map[string]interface{}
+		var body map[string]any
 		json.NewDecoder(r.Body).Decode(&body)
 
 		// First request has temperature - reject it with quoted param name
 		if retryCount.Load() == 1 && body["temperature"] != nil {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusBadRequest)
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"error": map[string]interface{}{
+			json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]any{
 					"message": "Unsupported parameter: \"temperature\" is not supported for this model",
 					"type":    "invalid_request_error",
 				},
@@ -1207,15 +1207,15 @@ func TestChatCompletions_ParamRejectionAutoRetry(t *testing.T) {
 		// Retry or request without temperature - succeed
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		json.NewEncoder(w).Encode(map[string]any{
 			"id":      "chatcmpl-test",
 			"object":  "chat.completion",
 			"created": time.Now().Unix(),
 			"model":   body["model"].(string),
-			"choices": []map[string]interface{}{
-				{"index": 0, "message": map[string]interface{}{"role": "assistant", "content": "success"}, "finish_reason": "stop"},
+			"choices": []map[string]any{
+				{"index": 0, "message": map[string]any{"role": "assistant", "content": "success"}, "finish_reason": "stop"},
 			},
-			"usage": map[string]interface{}{
+			"usage": map[string]any{
 				"prompt_tokens":     5,
 				"completion_tokens": 7,
 				"total_tokens":      12,
@@ -1366,7 +1366,7 @@ func TestChatCompletions_NonJSONErrorBody(t *testing.T) {
 	}
 
 	// Body should be valid JSON with error object (not raw HTML)
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("expected JSON response, got: %s", w.Body.String())
 	}

--- a/internal/proxy/deprecation_cache_test.go
+++ b/internal/proxy/deprecation_cache_test.go
@@ -33,7 +33,7 @@ func TestDeprecationCache_ConcurrentMerges(t *testing.T) {
 	var mu sync.Mutex
 
 	var wg sync.WaitGroup
-	for i := 0; i < numGoroutines; i++ {
+	for i := range numGoroutines {
 		params := map[string]bool{
 			fmt.Sprintf("param_%d", i): true,
 		}

--- a/internal/proxy/handler_test.go
+++ b/internal/proxy/handler_test.go
@@ -263,9 +263,9 @@ func TestProxyKeyMiddleware_ValidKey_Integration(t *testing.T) {
 	}()
 
 	called := false
-	var capturedVKName interface{}
-	var capturedVKID interface{}
-	var capturedVKHash interface{}
+	var capturedVKName any
+	var capturedVKID any
+	var capturedVKHash any
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		called = true
 		capturedVKName = r.Context().Value(virtualKeyNameKey)
@@ -483,7 +483,7 @@ func TestRegisterAdminChat_SetsVirtualKeyContext(t *testing.T) {
 	h.RegisterAdminChat(r)
 
 	// Test that /chat route sets virtual key context to "chat"
-	var capturedVKName interface{}
+	var capturedVKName any
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		capturedVKName = r.Context().Value(virtualKeyNameKey)
 	})
@@ -879,7 +879,7 @@ func TestProxyKeyMiddleware_MissingAuth(t *testing.T) {
 	}
 
 	// Verify response is JSON
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
 		t.Errorf("response should be valid JSON: %v", err)
 	}
@@ -918,11 +918,11 @@ func TestProxyKeyMiddleware_InvalidAuth(t *testing.T) {
 	}
 
 	// Verify response is JSON with expected message
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
 		t.Errorf("response should be valid JSON: %v", err)
 	}
-	if msg, ok := resp["error"].(map[string]interface{}); !ok {
+	if msg, ok := resp["error"].(map[string]any); !ok {
 		t.Error("response should have error object")
 	} else if msg["message"] != "invalid virtual key" {
 		t.Errorf("expected error message 'invalid virtual key', got %v", msg["message"])

--- a/internal/proxy/hedging.go
+++ b/internal/proxy/hedging.go
@@ -96,7 +96,7 @@ func (h *Handler) runHedgedStreaming(w http.ResponseWriter, r *http.Request, st 
 		}()
 	}
 	cancelExcept := func(except int) {
-		for i := 0; i < len(cancels); i++ {
+		for i := range cancels {
 			if i != except && cancels[i] != nil {
 				cancels[i]()
 			}
@@ -296,7 +296,7 @@ func commitHedgeWin(ctx context.Context, res hedgeResult, resp *http.Response, p
 // already closed its own); closing here releases that connection instead of
 // holding it until the transport idle timeout.
 func drainHedgeResults(results <-chan hedgeResult, n int) {
-	for i := 0; i < n; i++ {
+	for range n {
 		res := <-results
 		if res.resp != nil {
 			_ = res.resp.Body.Close()

--- a/internal/proxy/helpers.go
+++ b/internal/proxy/helpers.go
@@ -22,8 +22,8 @@ func extractStreamingUsage(data string) *Usage {
 		line := scanner.Text()
 		var payload string
 		//nolint:gocritic // if-else chain is clearer than switch for SSE prefix matching
-		if strings.HasPrefix(line, "data: ") {
-			payload = strings.TrimPrefix(line, "data: ")
+		if after, ok := strings.CutPrefix(line, "data: "); ok {
+			payload = after
 		} else if strings.HasPrefix(line, "data:") && len(line) > 5 {
 			// "data:" with no space — LM Studio compatibility.
 			payload = strings.TrimLeft(line[5:], " \t")
@@ -243,7 +243,7 @@ func (h *Handler) recordTokenUsage(vkHash string, promptTokens, completionTokens
 			Severity: "error",
 			Source:   "proxy",
 			Message:  fmt.Sprintf("Token counting failed for key %q", keyLabel),
-			Metadata: map[string]interface{}{"error": err.Error(), "key": keyLabel},
+			Metadata: map[string]any{"error": err.Error(), "key": keyLabel},
 		})
 	}
 }

--- a/internal/proxy/helpers_test.go
+++ b/internal/proxy/helpers_test.go
@@ -582,7 +582,7 @@ func TestGenerateRequestHash_IsHexString(t *testing.T) {
 
 func TestGenerateRequestHash_Unique(t *testing.T) {
 	hashes := make(map[string]bool)
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		hash := generateRequestHash()
 		if hashes[hash] {
 			t.Errorf("generateRequestHash produced duplicate hash: %q", hash)

--- a/internal/proxy/logging.go
+++ b/internal/proxy/logging.go
@@ -74,7 +74,7 @@ func (h *Handler) insertRequestLogAsync(logEntry *requestLogData) {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
-		var vkID interface{}
+		var vkID any
 		if virtualKeyID != "" {
 			vkID = virtualKeyID
 		}
@@ -99,7 +99,7 @@ func publishRequestStartedEvent(logEntry *requestLogData) {
 		Severity: "info",
 		Source:   "proxy",
 		Message:  fmt.Sprintf("Request started: %s", logEntry.modelID),
-		Metadata: map[string]interface{}{
+		Metadata: map[string]any{
 			"request_id":    logEntry.id,
 			"model_id":      logEntry.modelID,
 			"streaming":     logEntry.streaming,
@@ -124,7 +124,7 @@ func publishRequestStreamingEvent(logEntry *requestLogData) {
 		Severity: "info",
 		Source:   "proxy",
 		Message:  fmt.Sprintf("Request streaming: %s", logEntry.modelID),
-		Metadata: map[string]interface{}{
+		Metadata: map[string]any{
 			"request_id":    logEntry.id,
 			"model_id":      logEntry.modelID,
 			"provider_name": logEntry.providerName,
@@ -188,13 +188,13 @@ func (h *Handler) updateRequestLog(logEntry *requestLogData, opts ...updateLogOp
 		h.WaitForInsert(logEntry)
 	}
 
-	var providerID interface{}
+	var providerID any
 	if logEntry.providerID != uuid.Nil {
 		providerID = logEntry.providerID
 	}
 	// NULL (not "") when unclassified, so the dashboard can distinguish "no kind
 	// recorded" (fall back to substring matching) from a real classification.
-	var errKind interface{}
+	var errKind any
 	if logEntry.errorKind != "" {
 		errKind = string(logEntry.errorKind)
 	}
@@ -292,7 +292,7 @@ func (h *Handler) updateRequestLog(logEntry *requestLogData, opts ...updateLogOp
 			Severity: severity,
 			Source:   "proxy",
 			Message:  msg,
-			Metadata: map[string]interface{}{
+			Metadata: map[string]any{
 				"request_id":    logEntry.id,
 				"model_id":      logEntry.modelID,
 				"provider_name": logEntry.providerName,

--- a/internal/proxy/logging_test.go
+++ b/internal/proxy/logging_test.go
@@ -373,13 +373,11 @@ func TestWaitForInsert_Completes(t *testing.T) {
 		virtualKeyName: "test-key",
 		state:          "pending",
 	}
-	logData.insertWg.Add(1)
 
 	// Call Done() in a goroutine after a brief delay
-	go func() {
+	logData.insertWg.Go(func() {
 		time.Sleep(10 * time.Millisecond)
-		logData.insertWg.Done()
-	}()
+	})
 
 	start := time.Now()
 	h.WaitForInsert(logData)

--- a/internal/proxy/models.go
+++ b/internal/proxy/models.go
@@ -18,7 +18,7 @@ func (h *Handler) ListModels(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	openAIModels := make([]map[string]interface{}, 0, len(models))
+	openAIModels := make([]map[string]any, 0, len(models))
 	for _, m := range models {
 		modelID := provider.NormalizeName(m.ProviderName) + "/" + m.ModelID
 		openAIModels = append(openAIModels, modelToOpenAIItem(m, modelID, m.ProviderName))
@@ -49,7 +49,7 @@ func (h *Handler) ListModels(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	response := map[string]interface{}{
+	response := map[string]any{
 		"object": "list",
 		"data":   openAIModels,
 	}
@@ -61,13 +61,13 @@ func (h *Handler) ListModels(w http.ResponseWriter, r *http.Request) {
 }
 
 // modelToOpenAIItem builds an OpenAI-compatible model object from a model entity.
-func modelToOpenAIItem(m *model.Model, id, providerName string) map[string]interface{} {
+func modelToOpenAIItem(m *model.Model, id, providerName string) map[string]any {
 	ownedBy := m.OwnedBy
 	if ownedBy == "" {
 		ownedBy = m.ProviderName
 	}
 
-	item := map[string]interface{}{
+	item := map[string]any{
 		"id":       id,
 		"object":   "model",
 		"created":  m.CreatedAt.Unix(),
@@ -94,7 +94,7 @@ func modelToOpenAIItem(m *model.Model, id, providerName string) map[string]inter
 		item["modality"] = m.Modality
 	}
 	if m.Capabilities != "" && m.Capabilities != "{}" {
-		var caps map[string]interface{}
+		var caps map[string]any
 		if err := json.Unmarshal([]byte(m.Capabilities), &caps); err == nil {
 			item["capabilities"] = caps
 		} else {

--- a/internal/proxy/models_test.go
+++ b/internal/proxy/models_test.go
@@ -45,7 +45,7 @@ func TestListModels_EmptyDB(t *testing.T) {
 		t.Errorf("expected Content-Type application/json, got %s", contentType)
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
@@ -112,12 +112,12 @@ func TestListModels_WithProviderAndModel(t *testing.T) {
 		t.Errorf("expected 200, got %d", rr.Code)
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
 
-	data, ok := resp["data"].([]interface{})
+	data, ok := resp["data"].([]any)
 	if !ok {
 		t.Fatal("response 'data' should be an array")
 	}
@@ -125,7 +125,7 @@ func TestListModels_WithProviderAndModel(t *testing.T) {
 	// Find our model in the response
 	found := false
 	for _, item := range data {
-		itemMap, ok := item.(map[string]interface{})
+		itemMap, ok := item.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -197,19 +197,19 @@ func TestListModels_WithOwnedBy(t *testing.T) {
 		t.Fatalf("expected 200, got %d", rr.Code)
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
 
-	data, ok := resp["data"].([]interface{})
+	data, ok := resp["data"].([]any)
 	if !ok {
 		t.Fatal("response 'data' should be an array")
 	}
 
 	found := false
 	for _, item := range data {
-		itemMap, ok := item.(map[string]interface{})
+		itemMap, ok := item.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -283,19 +283,19 @@ func TestListModels_WithOptionalFields(t *testing.T) {
 		t.Fatalf("expected 200, got %d", rr.Code)
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
 
-	data, ok := resp["data"].([]interface{})
+	data, ok := resp["data"].([]any)
 	if !ok {
 		t.Fatal("response 'data' should be an array")
 	}
 
 	found := false
 	for _, item := range data {
-		itemMap, ok := item.(map[string]interface{})
+		itemMap, ok := item.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -414,12 +414,12 @@ func TestListModels_FailoverGroupWithDisabledEntry(t *testing.T) {
 		t.Fatalf("expected 200, got %d", rr.Code)
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
 
-	data, ok := resp["data"].([]interface{})
+	data, ok := resp["data"].([]any)
 	if !ok {
 		t.Fatal("response 'data' should be an array")
 	}
@@ -432,7 +432,7 @@ func TestListModels_FailoverGroupWithDisabledEntry(t *testing.T) {
 	// Verify the failover model points to the enabled entry (model-2)
 	foundFailover := false
 	for _, item := range data {
-		itemMap, ok := item.(map[string]interface{})
+		itemMap, ok := item.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -515,12 +515,12 @@ func TestListModels_FailoverGroupEntryNotFound(t *testing.T) {
 		t.Fatalf("expected 200, got %d", rr.Code)
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
 
-	data, ok := resp["data"].([]interface{})
+	data, ok := resp["data"].([]any)
 	if !ok {
 		t.Fatal("response 'data' should be an array")
 	}
@@ -533,7 +533,7 @@ func TestListModels_FailoverGroupEntryNotFound(t *testing.T) {
 	// Verify the failover model is present
 	foundFailover := false
 	for _, item := range data {
-		itemMap, ok := item.(map[string]interface{})
+		itemMap, ok := item.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -616,7 +616,7 @@ func TestListModels_ResponseFormat(t *testing.T) {
 		t.Errorf("expected 200, got %d", rr.Code)
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
@@ -690,19 +690,19 @@ func TestListModels_CapabilitiesAndModalities(t *testing.T) {
 		t.Fatalf("expected 200, got %d", rr.Code)
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
 
-	data, ok := resp["data"].([]interface{})
+	data, ok := resp["data"].([]any)
 	if !ok {
 		t.Fatal("response 'data' should be an array")
 	}
 
 	found := false
 	for _, item := range data {
-		itemMap, ok := item.(map[string]interface{})
+		itemMap, ok := item.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -710,7 +710,7 @@ func TestListModels_CapabilitiesAndModalities(t *testing.T) {
 			found = true
 
 			// Verify capabilities object is present and has expected fields
-			caps, ok := itemMap["capabilities"].(map[string]interface{})
+			caps, ok := itemMap["capabilities"].(map[string]any)
 			if !ok {
 				t.Fatal("expected 'capabilities' to be a map in response")
 			}
@@ -728,7 +728,7 @@ func TestListModels_CapabilitiesAndModalities(t *testing.T) {
 			}
 
 			// Verify input_modalities array
-			inputMods, ok := itemMap["input_modalities"].([]interface{})
+			inputMods, ok := itemMap["input_modalities"].([]any)
 			if !ok {
 				t.Fatal("expected 'input_modalities' to be an array in response")
 			}
@@ -743,7 +743,7 @@ func TestListModels_CapabilitiesAndModalities(t *testing.T) {
 			}
 
 			// Verify output_modalities array
-			outputMods, ok := itemMap["output_modalities"].([]interface{})
+			outputMods, ok := itemMap["output_modalities"].([]any)
 			if !ok {
 				t.Fatal("expected 'output_modalities' to be an array in response")
 			}
@@ -827,18 +827,18 @@ func TestListModels_EmptyCapabilitiesOmitted(t *testing.T) {
 		t.Fatalf("expected 200, got %d", rr.Code)
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
 
-	data, ok := resp["data"].([]interface{})
+	data, ok := resp["data"].([]any)
 	if !ok {
 		t.Fatal("response 'data' should be an array")
 	}
 
 	for _, item := range data {
-		itemMap, ok := item.(map[string]interface{})
+		itemMap, ok := item.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -903,19 +903,19 @@ func TestListModels_InvalidCapabilitiesJSON(t *testing.T) {
 		t.Fatalf("expected 200, got %d", rr.Code)
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
 
-	data, ok := resp["data"].([]interface{})
+	data, ok := resp["data"].([]any)
 	if !ok {
 		t.Fatal("response 'data' should be an array")
 	}
 
 	found := false
 	for _, item := range data {
-		itemMap, ok := item.(map[string]interface{})
+		itemMap, ok := item.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -978,19 +978,19 @@ func TestListModels_InvalidModalitiesJSON(t *testing.T) {
 		t.Fatalf("expected 200, got %d", rr.Code)
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
 
-	data, ok := resp["data"].([]interface{})
+	data, ok := resp["data"].([]any)
 	if !ok {
 		t.Fatal("response 'data' should be an array")
 	}
 
 	found := false
 	for _, item := range data {
-		itemMap, ok := item.(map[string]interface{})
+		itemMap, ok := item.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -1086,19 +1086,19 @@ func TestListModels_FailoverGroupWithFullModel(t *testing.T) {
 		t.Fatalf("expected 200, got %d", rr.Code)
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
 
-	data, ok := resp["data"].([]interface{})
+	data, ok := resp["data"].([]any)
 	if !ok {
 		t.Fatal("response 'data' should be an array")
 	}
 
 	foundFailover := false
 	for _, item := range data {
-		itemMap, ok := item.(map[string]interface{})
+		itemMap, ok := item.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -1132,7 +1132,7 @@ func TestListModels_FailoverGroupWithFullModel(t *testing.T) {
 				t.Errorf("modality = %v, want 'text->text'", mod)
 			}
 
-			caps, ok := itemMap["capabilities"].(map[string]interface{})
+			caps, ok := itemMap["capabilities"].(map[string]any)
 			if !ok {
 				t.Fatal("expected 'capabilities' to be a map")
 			}
@@ -1140,7 +1140,7 @@ func TestListModels_FailoverGroupWithFullModel(t *testing.T) {
 				t.Error("capabilities.streaming should be true")
 			}
 
-			inputMods, ok := itemMap["input_modalities"].([]interface{})
+			inputMods, ok := itemMap["input_modalities"].([]any)
 			if !ok {
 				t.Fatal("expected 'input_modalities' to be an array")
 			}
@@ -1148,7 +1148,7 @@ func TestListModels_FailoverGroupWithFullModel(t *testing.T) {
 				t.Errorf("input_modalities = %v, want ['text','image']", inputMods)
 			}
 
-			outputMods, ok := itemMap["output_modalities"].([]interface{})
+			outputMods, ok := itemMap["output_modalities"].([]any)
 			if !ok {
 				t.Fatal("expected 'output_modalities' to be an array")
 			}
@@ -1261,19 +1261,19 @@ func TestListModels_FailoverGroupInvalidJSON(t *testing.T) {
 		t.Fatalf("expected 200, got %d", rr.Code)
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
 
-	data, ok := resp["data"].([]interface{})
+	data, ok := resp["data"].([]any)
 	if !ok {
 		t.Fatal("response 'data' should be an array")
 	}
 
 	foundFailover := false
 	for _, item := range data {
-		itemMap, ok := item.(map[string]interface{})
+		itemMap, ok := item.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -1327,12 +1327,12 @@ func TestListModels_FailoverRepoError(t *testing.T) {
 		t.Errorf("expected 200, got %d", rr.Code)
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
 
-	data, ok := resp["data"].([]interface{})
+	data, ok := resp["data"].([]any)
 	if !ok {
 		t.Fatal("response 'data' should be an array")
 	}
@@ -1407,11 +1407,11 @@ func TestListModels_DBError(t *testing.T) {
 	}
 
 	// Verify response is JSON with expected message
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
 		t.Errorf("response should be valid JSON: %v", err)
 	}
-	if msg, ok := resp["error"].(map[string]interface{}); !ok {
+	if msg, ok := resp["error"].(map[string]any); !ok {
 		t.Error("response should have error object")
 	} else if msg["message"] != "failed to list models" {
 		t.Errorf("expected error message 'failed to list models', got %v", msg["message"])
@@ -1479,7 +1479,7 @@ func TestListModels_MockListEnabledError(t *testing.T) {
 	}
 
 	// Verify response is JSON
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
 		t.Errorf("response should be valid JSON: %v", err)
 	}
@@ -1527,7 +1527,7 @@ func TestListModels_ValidProviderIDQuery(t *testing.T) {
 	}
 
 	// Verify response is valid JSON
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
 		t.Errorf("response should be valid JSON: %v", err)
 	}
@@ -1661,7 +1661,7 @@ func TestListModels_MultipleProviders(t *testing.T) {
 		t.Errorf("expected 200, got %d", rr.Code)
 	}
 
-	var response map[string]interface{}
+	var response map[string]any
 	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
@@ -1671,7 +1671,7 @@ func TestListModels_MultipleProviders(t *testing.T) {
 		t.Errorf("expected object=list, got %v", response["object"])
 	}
 
-	data, ok := response["data"].([]interface{})
+	data, ok := response["data"].([]any)
 	if !ok {
 		t.Fatal("expected data to be an array")
 	}
@@ -1684,7 +1684,7 @@ func TestListModels_MultipleProviders(t *testing.T) {
 	// Verify model IDs are in the expected format
 	modelIDs := make([]string, 0, len(data))
 	for _, item := range data {
-		m := item.(map[string]interface{})
+		m := item.(map[string]any)
 		modelIDs = append(modelIDs, m["id"].(string))
 	}
 
@@ -1735,7 +1735,7 @@ func TestListModels_NoModels(t *testing.T) {
 		t.Errorf("expected 200, got %d", rr.Code)
 	}
 
-	var response map[string]interface{}
+	var response map[string]any
 	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
@@ -1744,14 +1744,14 @@ func TestListModels_NoModels(t *testing.T) {
 		t.Errorf("expected object=list, got %v", response["object"])
 	}
 
-	data, ok := response["data"].([]interface{})
+	data, ok := response["data"].([]any)
 	if !ok {
 		t.Fatal("expected data to be an array")
 	}
 
 	// Verify no test provider models are present (exact count is fragile in parallel test suite)
 	for _, item := range data {
-		m := item.(map[string]interface{})
+		m := item.(map[string]any)
 		modelID := m["id"].(string)
 		if containsTestProviderPrefix(modelID) {
 			t.Errorf("unexpected test provider model in response: %s", modelID)
@@ -1855,12 +1855,12 @@ func TestListModels_DisabledModelsFiltered(t *testing.T) {
 		t.Errorf("expected 200, got %d", rr.Code)
 	}
 
-	var response map[string]interface{}
+	var response map[string]any
 	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
 
-	data, ok := response["data"].([]interface{})
+	data, ok := response["data"].([]any)
 	if !ok {
 		t.Fatal("expected data to be an array")
 	}
@@ -1874,7 +1874,7 @@ func TestListModels_DisabledModelsFiltered(t *testing.T) {
 	foundEnabled := false
 	foundDisabled := false
 	for _, item := range data {
-		m := item.(map[string]interface{})
+		m := item.(map[string]any)
 		modelID := m["id"].(string)
 		if modelID == provider.NormalizeName(providerName)+"/enabled-model" {
 			foundEnabled = true
@@ -1891,7 +1891,7 @@ func TestListModels_DisabledModelsFiltered(t *testing.T) {
 	}
 
 	// Verify it's the enabled model
-	m := data[0].(map[string]interface{})
+	m := data[0].(map[string]any)
 	if m["id"] != provider.NormalizeName(providerName)+"/enabled-model" {
 		t.Errorf("expected enabled-model, got %v", m["id"])
 	}
@@ -1974,12 +1974,12 @@ func TestListModels_WithFailoverGroups(t *testing.T) {
 		t.Errorf("expected 200, got %d", rr.Code)
 	}
 
-	var response map[string]interface{}
+	var response map[string]any
 	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
 
-	data, ok := response["data"].([]interface{})
+	data, ok := response["data"].([]any)
 	if !ok {
 		t.Fatal("expected data to be an array")
 	}
@@ -1993,7 +1993,7 @@ func TestListModels_WithFailoverGroups(t *testing.T) {
 	foundFailover := false
 	foundRegular := false
 	for _, item := range data {
-		m := item.(map[string]interface{})
+		m := item.(map[string]any)
 		modelID := m["id"].(string)
 		if modelID == "hotel/my-failover-model" {
 			foundFailover = true
@@ -2091,12 +2091,12 @@ func TestListModels_FilterByProvider(t *testing.T) {
 		t.Errorf("expected 200, got %d", rr.Code)
 	}
 
-	var response map[string]interface{}
+	var response map[string]any
 	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
 
-	data, ok := response["data"].([]interface{})
+	data, ok := response["data"].([]any)
 	if !ok {
 		t.Fatal("expected data to be an array")
 	}
@@ -2109,7 +2109,7 @@ func TestListModels_FilterByProvider(t *testing.T) {
 	// Verify model IDs
 	foundModels := make(map[string]bool)
 	for _, item := range data {
-		m := item.(map[string]interface{})
+		m := item.(map[string]any)
 		modelID := m["id"].(string)
 		foundModels[modelID] = true
 	}

--- a/internal/proxy/multimodal.go
+++ b/internal/proxy/multimodal.go
@@ -150,7 +150,7 @@ func makeJSONModelRewriter(body []byte, requestModel string) func(string) ([]byt
 			// (mirrors paramrewrite.BuildUpstreamBody).
 			dec := json.NewDecoder(bytes.NewReader(body))
 			dec.UseNumber()
-			var raw map[string]interface{}
+			var raw map[string]any
 			if dec.Decode(&raw) == nil {
 				raw["model"] = resolvedModelID
 				if rewritten, err := json.Marshal(raw); err == nil {
@@ -656,7 +656,7 @@ func extractPassthroughUsage(body []byte) (promptTokens, completionTokens int) {
 // final (small) event, so scanning the retained tail is enough. A leading
 // partial line (cut by the tail cap) simply fails to parse and is skipped.
 func extractPassthroughSSEUsage(tail []byte) (promptTokens, completionTokens int) {
-	for _, line := range strings.Split(string(tail), "\n") {
+	for line := range strings.SplitSeq(string(tail), "\n") {
 		payload, ok := strings.CutPrefix(strings.TrimSpace(line), "data:")
 		if !ok {
 			continue

--- a/internal/proxy/multimodal_passthrough_test.go
+++ b/internal/proxy/multimodal_passthrough_test.go
@@ -142,7 +142,7 @@ func TestEmbeddings_PassthroughAndModelRewrite(t *testing.T) {
 	env := newMultimodalEnv(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotPath.Store(r.URL.Path)
 		gotAuth.Store(r.Header.Get("Authorization"))
-		var req map[string]interface{}
+		var req map[string]any
 		_ = json.NewDecoder(r.Body).Decode(&req)
 		if m, ok := req["model"].(string); ok {
 			gotModel.Store(m)
@@ -274,7 +274,7 @@ func TestRerank_PassthroughAndModelRewrite(t *testing.T) {
 	env := newMultimodalEnv(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotPath.Store(r.URL.Path)
 		gotAuth.Store(r.Header.Get("Authorization"))
-		var req map[string]interface{}
+		var req map[string]any
 		_ = json.NewDecoder(r.Body).Decode(&req)
 		if m, ok := req["model"].(string); ok {
 			gotModel.Store(m)

--- a/internal/proxy/multimodal_unit_test.go
+++ b/internal/proxy/multimodal_unit_test.go
@@ -25,7 +25,7 @@ func TestMakeJSONModelRewriter_RewritesModel(t *testing.T) {
 	if contentType != "application/json" {
 		t.Errorf("contentType = %q, want application/json", contentType)
 	}
-	var raw map[string]interface{}
+	var raw map[string]any
 	if err := json.Unmarshal(out, &raw); err != nil {
 		t.Fatalf("rewritten body is not valid JSON: %v", err)
 	}
@@ -35,7 +35,7 @@ func TestMakeJSONModelRewriter_RewritesModel(t *testing.T) {
 	if raw["dimensions"] != float64(256) {
 		t.Errorf("dimensions = %v, want 256 (other fields must survive the rewrite)", raw["dimensions"])
 	}
-	input, ok := raw["input"].([]interface{})
+	input, ok := raw["input"].([]any)
 	if !ok || len(input) != 2 {
 		t.Errorf("input = %v, want 2-element array", raw["input"])
 	}

--- a/internal/proxy/provider_helpers_test.go
+++ b/internal/proxy/provider_helpers_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -474,11 +475,11 @@ func TestWriteOpenAIError(t *testing.T) {
 		t.Errorf("expected status 400, got %d", rr.Code)
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("response is not valid JSON: %v", err)
 	}
-	errObj, ok := resp["error"].(map[string]interface{})
+	errObj, ok := resp["error"].(map[string]any)
 	if !ok {
 		t.Fatal("response missing 'error' object")
 	}
@@ -498,11 +499,11 @@ func TestWriteOpenAIError_502(t *testing.T) {
 		t.Errorf("expected status 502, got %d", rr.Code)
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("response is not valid JSON: %v", err)
 	}
-	errObj := resp["error"].(map[string]interface{})
+	errObj := resp["error"].(map[string]any)
 	if errObj["message"] != "all providers failed for model test" {
 		t.Errorf("unexpected message: %v", errObj["message"])
 	}
@@ -708,13 +709,7 @@ func TestProviderUnsupportedParams_ReasoningEffort(t *testing.T) {
 			t.Errorf("provider %q: missing from paramrewrite.ProviderUnsupportedParams", provider)
 			continue
 		}
-		found := false
-		for _, p := range params {
-			if p == "reasoning_effort" {
-				found = true
-				break
-			}
-		}
+		found := slices.Contains(params, "reasoning_effort")
 		if !found {
 			t.Errorf("provider %q: reasoning_effort not listed in unsupported params", provider)
 		}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -759,7 +759,7 @@ func (h *Handler) probeFirstToken(
 		if probeCtx.Err() == nil {
 			probeSucceeded.Store(true) // mirror line 1680: store before any processing
 			bufStr := buf.String()
-			for _, rawLine := range strings.Split(bufStr, "\n") {
+			for rawLine := range strings.SplitSeq(bufStr, "\n") {
 				if l := strings.TrimSpace(rawLine); strings.HasPrefix(l, "data:") {
 					// Reject partial lines: a complete SSE line must be
 					// followed by \n in the buffer. Without this guard a
@@ -794,10 +794,7 @@ func (h *Handler) probeFirstToken(
 // base is the starting delay, capacity is the maximum delay, attempt is the 1-indexed attempt number.
 // Jitter of [0, base) is added to spread retries from concurrent requests hitting the same cascade.
 func failoverBackoff(base, capacity time.Duration, attempt int) time.Duration {
-	exp := time.Duration(float64(base) * math.Pow(2, float64(attempt-1)))
-	if exp > capacity {
-		exp = capacity
-	}
+	exp := min(time.Duration(float64(base)*math.Pow(2, float64(attempt-1))), capacity)
 	jitter := time.Duration(rand.Int64N(int64(base)))
 	return exp + jitter
 }

--- a/internal/proxy/proxy_chat_completions_test.go
+++ b/internal/proxy/proxy_chat_completions_test.go
@@ -107,7 +107,7 @@ func TestChatCompletions_FailoverWithTimeout(t *testing.T) {
 
 	// Create a second provider that will succeed
 	upstream2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var reqBody map[string]interface{}
+		var reqBody map[string]any
 		if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
 			http.Error(w, "bad request", http.StatusBadRequest)
 			return
@@ -121,15 +121,15 @@ func TestChatCompletions_FailoverWithTimeout(t *testing.T) {
 			fmt.Fprintf(w, "data: {\"id\":\"chatcmpl-test\",\"object\":\"chat.completion.chunk\",\"choices\":[],\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":7,\"total_tokens\":12}}\n\n")
 			fmt.Fprintf(w, "data: [DONE]\n\n")
 		} else {
-			response := map[string]interface{}{
+			response := map[string]any{
 				"id":      "chatcmpl-test",
 				"object":  "chat.completion",
 				"created": time.Now().Unix(),
 				"model":   reqBody["model"].(string),
-				"choices": []map[string]interface{}{
-					{"index": 0, "message": map[string]interface{}{"role": "assistant", "content": "hello world"}, "finish_reason": "stop"},
+				"choices": []map[string]any{
+					{"index": 0, "message": map[string]any{"role": "assistant", "content": "hello world"}, "finish_reason": "stop"},
 				},
-				"usage": map[string]interface{}{
+				"usage": map[string]any{
 					"prompt_tokens":     5,
 					"completion_tokens": 7,
 					"total_tokens":      12,
@@ -180,7 +180,7 @@ func TestChatCompletions_StreamOptionsInjection_Integration(t *testing.T) {
 	req = req.WithContext(ctx)
 
 	// Capture the upstream request
-	var capturedBody map[string]interface{}
+	var capturedBody map[string]any
 	upstream.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewDecoder(r.Body).Decode(&capturedBody); err != nil {
 			http.Error(w, "bad request", http.StatusBadRequest)
@@ -188,7 +188,7 @@ func TestChatCompletions_StreamOptionsInjection_Integration(t *testing.T) {
 		}
 
 		// Verify stream_options was injected
-		if so, ok := capturedBody["stream_options"].(map[string]interface{}); !ok {
+		if so, ok := capturedBody["stream_options"].(map[string]any); !ok {
 			http.Error(w, "stream_options not found", http.StatusBadRequest)
 			return
 		} else if so["include_usage"] != true {
@@ -232,7 +232,7 @@ func TestChatCompletions_ParamStripping(t *testing.T) {
 	req = req.WithContext(ctx)
 
 	// Capture what was sent upstream
-	var capturedBody map[string]interface{}
+	var capturedBody map[string]any
 	upstream.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewDecoder(r.Body).Decode(&capturedBody); err != nil {
 			http.Error(w, "bad request", http.StatusBadRequest)
@@ -240,15 +240,15 @@ func TestChatCompletions_ParamStripping(t *testing.T) {
 		}
 
 		// Return a valid response
-		response := map[string]interface{}{
+		response := map[string]any{
 			"id":      "chatcmpl-test",
 			"object":  "chat.completion",
 			"created": time.Now().Unix(),
 			"model":   capturedBody["model"].(string),
-			"choices": []map[string]interface{}{
-				{"index": 0, "message": map[string]interface{}{"role": "assistant", "content": "hello world"}, "finish_reason": "stop"},
+			"choices": []map[string]any{
+				{"index": 0, "message": map[string]any{"role": "assistant", "content": "hello world"}, "finish_reason": "stop"},
 			},
-			"usage": map[string]interface{}{
+			"usage": map[string]any{
 				"prompt_tokens":     5,
 				"completion_tokens": 7,
 				"total_tokens":      12,
@@ -322,7 +322,7 @@ func TestChatCompletions_DeprecationCacheStripping(t *testing.T) {
 	req = req.WithContext(ctx)
 
 	// Capture the upstream request body
-	var capturedBody map[string]interface{}
+	var capturedBody map[string]any
 	upstream.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewDecoder(r.Body).Decode(&capturedBody); err != nil {
 			http.Error(w, "bad request", http.StatusBadRequest)
@@ -331,13 +331,13 @@ func TestChatCompletions_DeprecationCacheStripping(t *testing.T) {
 
 		// Return success response
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		json.NewEncoder(w).Encode(map[string]any{
 			"id":     "chatcmpl-test",
 			"object": "chat.completion",
-			"choices": []map[string]interface{}{
-				{"index": 0, "message": map[string]interface{}{"role": "assistant", "content": "hello"}, "finish_reason": "stop"},
+			"choices": []map[string]any{
+				{"index": 0, "message": map[string]any{"role": "assistant", "content": "hello"}, "finish_reason": "stop"},
 			},
-			"usage": map[string]interface{}{"prompt_tokens": 5, "completion_tokens": 7, "total_tokens": 12},
+			"usage": map[string]any{"prompt_tokens": 5, "completion_tokens": 7, "total_tokens": 12},
 		})
 	})
 
@@ -393,7 +393,7 @@ func TestChatCompletions_NonJSONUpstreamError(t *testing.T) {
 	}
 
 	// Verify response is valid JSON (OpenAI error format)
-	var response map[string]interface{}
+	var response map[string]any
 	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
 		t.Errorf("expected response to be valid JSON, got:\n%s\nerror: %v", w.Body.String(), err)
 	}
@@ -494,15 +494,15 @@ func TestChatCompletions_UpstreamTimeout(t *testing.T) {
 	slowUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(2 * time.Second) // longer than the 250ms request_timeout
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		json.NewEncoder(w).Encode(map[string]any{
 			"id":      "chatcmpl-test",
 			"object":  "chat.completion",
 			"created": time.Now().Unix(),
 			"model":   modelName,
-			"choices": []map[string]interface{}{
-				{"index": 0, "message": map[string]interface{}{"role": "assistant", "content": "hello world"}, "finish_reason": "stop"},
+			"choices": []map[string]any{
+				{"index": 0, "message": map[string]any{"role": "assistant", "content": "hello world"}, "finish_reason": "stop"},
 			},
-			"usage": map[string]interface{}{
+			"usage": map[string]any{
 				"prompt_tokens":     5,
 				"completion_tokens": 7,
 				"total_tokens":      12,
@@ -703,8 +703,8 @@ func TestChatCompletions_FailoverOnRateLimit(t *testing.T) {
 	// Create a mock upstream server that returns 429
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusTooManyRequests)
-		json.NewEncoder(w).Encode(map[string]interface{}{
-			"error": map[string]interface{}{
+		json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{
 				"message": "rate limit exceeded",
 				"type":    "rate_limit_exceeded",
 			},
@@ -763,8 +763,8 @@ func TestChatCompletions_FailoverOnAuthError(t *testing.T) {
 	// Create a mock upstream server that returns 401
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
-		json.NewEncoder(w).Encode(map[string]interface{}{
-			"error": map[string]interface{}{
+		json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{
 				"message": "invalid api key",
 				"type":    "invalid_request_error",
 			},
@@ -823,8 +823,8 @@ func TestChatCompletions_FailoverOn5xxError(t *testing.T) {
 	// Create a mock upstream server that returns 500
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(map[string]interface{}{
-			"error": map[string]interface{}{
+		json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{
 				"message": "internal server error",
 				"type":    "server_error",
 			},
@@ -927,13 +927,13 @@ func TestChatCompletions_DeprecationCache_InitialToMerged(t *testing.T) {
 
 	// Phase 1: Upstream returns 400 with param rejection on first request,
 	// then 200 on retry. This simulates learning rejected params from a 400.
-	var requestCount int32
-	var firstRequestBody map[string]interface{}
+	var requestCount atomic.Int32
+	var firstRequestBody map[string]any
 
 	upstream.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		count := atomic.AddInt32(&requestCount, 1)
+		count := requestCount.Add(1)
 
-		var reqBody map[string]interface{}
+		var reqBody map[string]any
 		if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
 			http.Error(w, "bad request", http.StatusBadRequest)
 			return
@@ -944,8 +944,8 @@ func TestChatCompletions_DeprecationCache_InitialToMerged(t *testing.T) {
 			firstRequestBody = reqBody
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusBadRequest)
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"error": map[string]interface{}{
+			json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]any{
 					"message": "Unknown parameter `temperature`",
 					"type":    "invalid_request_error",
 				},
@@ -954,15 +954,15 @@ func TestChatCompletions_DeprecationCache_InitialToMerged(t *testing.T) {
 		}
 
 		// Retry (count 2) and subsequent requests: return success
-		response := map[string]interface{}{
+		response := map[string]any{
 			"id":      "chatcmpl-test",
 			"object":  "chat.completion",
 			"created": time.Now().Unix(),
 			"model":   modelName,
-			"choices": []map[string]interface{}{
-				{"index": 0, "message": map[string]interface{}{"role": "assistant", "content": "hello world"}, "finish_reason": "stop"},
+			"choices": []map[string]any{
+				{"index": 0, "message": map[string]any{"role": "assistant", "content": "hello world"}, "finish_reason": "stop"},
 			},
-			"usage": map[string]interface{}{
+			"usage": map[string]any{
 				"prompt_tokens": 5, "completion_tokens": 7, "total_tokens": 12,
 			},
 		}
@@ -1009,18 +1009,18 @@ func TestChatCompletions_DeprecationCache_InitialToMerged(t *testing.T) {
 
 	// Phase 2: Send another request with temperature — it should be stripped
 	// before sending to upstream (pre-emptive stripping from cache).
-	var secondRequestBody map[string]interface{}
+	var secondRequestBody map[string]any
 	upstream.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		json.NewDecoder(r.Body).Decode(&secondRequestBody)
-		response := map[string]interface{}{
+		response := map[string]any{
 			"id":      "chatcmpl-test-2",
 			"object":  "chat.completion",
 			"created": time.Now().Unix(),
 			"model":   modelName,
-			"choices": []map[string]interface{}{
-				{"index": 0, "message": map[string]interface{}{"role": "assistant", "content": "cached strip works"}, "finish_reason": "stop"},
+			"choices": []map[string]any{
+				{"index": 0, "message": map[string]any{"role": "assistant", "content": "cached strip works"}, "finish_reason": "stop"},
 			},
-			"usage": map[string]interface{}{
+			"usage": map[string]any{
 				"prompt_tokens": 5, "completion_tokens": 7, "total_tokens": 12,
 			},
 		}
@@ -1073,15 +1073,15 @@ func TestChatCompletions_DeprecationCache_MergedRejections(t *testing.T) {
 	var requestCount int32
 	upstream.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		count := atomic.AddInt32(&requestCount, 1)
-		var reqBody map[string]interface{}
+		var reqBody map[string]any
 		json.NewDecoder(r.Body).Decode(&reqBody)
 
 		if count == 1 {
 			// First request: reject temperature
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusBadRequest)
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"error": map[string]interface{}{
+			json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]any{
 					"message": "Unknown parameter `temperature`",
 				},
 			})
@@ -1105,15 +1105,15 @@ func TestChatCompletions_DeprecationCache_MergedRejections(t *testing.T) {
 	requestCount = 0
 	upstream.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		count := atomic.AddInt32(&requestCount, 1)
-		var reqBody map[string]interface{}
+		var reqBody map[string]any
 		json.NewDecoder(r.Body).Decode(&reqBody)
 
 		if count == 1 {
 			// Reject top_p (temperature already stripped from cache, so this is new)
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusBadRequest)
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"error": map[string]interface{}{
+			json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]any{
 					"message": "Unknown parameter `top_p`",
 				},
 			})
@@ -1135,7 +1135,7 @@ func TestChatCompletions_DeprecationCache_MergedRejections(t *testing.T) {
 	}
 
 	// Phase 3: Third request should strip both cached params preemptively.
-	var capturedBody map[string]interface{}
+	var capturedBody map[string]any
 	upstream.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		json.NewDecoder(r.Body).Decode(&capturedBody)
 		successResponse(t, w, modelName)
@@ -1157,15 +1157,15 @@ func TestChatCompletions_DeprecationCache_MergedRejections(t *testing.T) {
 
 func successResponse(t *testing.T, w http.ResponseWriter, modelName string) {
 	t.Helper()
-	response := map[string]interface{}{
+	response := map[string]any{
 		"id":      "chatcmpl-test",
 		"object":  "chat.completion",
 		"created": time.Now().Unix(),
 		"model":   modelName,
-		"choices": []map[string]interface{}{
-			{"index": 0, "message": map[string]interface{}{"role": "assistant", "content": "ok"}, "finish_reason": "stop"},
+		"choices": []map[string]any{
+			{"index": 0, "message": map[string]any{"role": "assistant", "content": "ok"}, "finish_reason": "stop"},
 		},
-		"usage": map[string]interface{}{
+		"usage": map[string]any{
 			"prompt_tokens": 5, "completion_tokens": 7, "total_tokens": 12,
 		},
 	}
@@ -1227,8 +1227,8 @@ func TestChatCompletions_DeprecationCache_UnexpectedTypeInHandler(t *testing.T) 
 	upstream.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
-		json.NewEncoder(w).Encode(map[string]interface{}{
-			"error": map[string]interface{}{
+		json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{
 				"message": "Unknown parameter `temperature`",
 			},
 		})

--- a/internal/proxy/proxy_chat_test.go
+++ b/internal/proxy/proxy_chat_test.go
@@ -111,22 +111,22 @@ func TestChatCompletions_SpecificProviderNotFound(t *testing.T) {
 
 func TestChatCompletions_StreamOptionsInjection(t *testing.T) {
 	body := `{"model":"test","stream":true,"messages":[]}`
-	var raw map[string]interface{}
+	var raw map[string]any
 	if err := json.Unmarshal([]byte(body), &raw); err != nil {
 		t.Fatal(err)
 	}
-	raw["stream_options"] = map[string]interface{}{
+	raw["stream_options"] = map[string]any{
 		"include_usage": true,
 	}
 	injected, err := json.Marshal(raw)
 	if err != nil {
 		t.Fatal(err)
 	}
-	var parsed map[string]interface{}
+	var parsed map[string]any
 	if err := json.Unmarshal(injected, &parsed); err != nil {
 		t.Fatal(err)
 	}
-	so, ok := parsed["stream_options"].(map[string]interface{})
+	so, ok := parsed["stream_options"].(map[string]any)
 	if !ok {
 		t.Fatal("stream_options should be a map")
 	}
@@ -564,7 +564,7 @@ func TestChatCompletions_RetryCancelDuringFailover(t *testing.T) {
 	callCount := 0
 	upstream1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		callCount++
-		var reqBody map[string]interface{}
+		var reqBody map[string]any
 		json.NewDecoder(r.Body).Decode(&reqBody)
 		if _, hasTopP := reqBody["top_p"]; hasTopP {
 			// First request: return 400 with param rejection
@@ -679,15 +679,15 @@ func TestChatCompletions_TouchLastUsedGoroutine(t *testing.T) {
 	// reach the TouchLastUsed goroutine at line 1081.
 	upstream.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		json.NewEncoder(w).Encode(map[string]any{
 			"id":      "chatcmpl-test",
 			"object":  "chat.completion",
 			"created": time.Now().Unix(),
 			"model":   modelName,
-			"choices": []map[string]interface{}{
-				{"index": 0, "message": map[string]interface{}{"role": "assistant", "content": "hello"}, "finish_reason": "stop"},
+			"choices": []map[string]any{
+				{"index": 0, "message": map[string]any{"role": "assistant", "content": "hello"}, "finish_reason": "stop"},
 			},
-			"usage": map[string]interface{}{
+			"usage": map[string]any{
 				"prompt_tokens": 5, "completion_tokens": 7, "total_tokens": 12,
 			},
 		})
@@ -1017,15 +1017,15 @@ func TestChatCompletions_AllowedProviders_FilterAllowed(t *testing.T) {
 	prov1Server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		json.NewEncoder(w).Encode(map[string]any{
 			"id":      "chatcmpl-allowed",
 			"object":  "chat.completion",
 			"created": time.Now().Unix(),
 			"model":   "test",
-			"choices": []map[string]interface{}{
-				{"index": 0, "message": map[string]interface{}{"role": "assistant", "content": "hi"}, "finish_reason": "stop"},
+			"choices": []map[string]any{
+				{"index": 0, "message": map[string]any{"role": "assistant", "content": "hi"}, "finish_reason": "stop"},
 			},
-			"usage": map[string]interface{}{"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+			"usage": map[string]any{"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
 		})
 	}))
 	defer prov1Server.Close()
@@ -1243,15 +1243,15 @@ func TestChatCompletions_AllowedProviders_EmptySliceAllowsAll(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		json.NewEncoder(w).Encode(map[string]any{
 			"id":      "chatcmpl-test",
 			"object":  "chat.completion",
 			"created": time.Now().Unix(),
 			"model":   "test",
-			"choices": []map[string]interface{}{
-				{"index": 0, "message": map[string]interface{}{"role": "assistant", "content": "hi"}, "finish_reason": "stop"},
+			"choices": []map[string]any{
+				{"index": 0, "message": map[string]any{"role": "assistant", "content": "hi"}, "finish_reason": "stop"},
 			},
-			"usage": map[string]interface{}{"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+			"usage": map[string]any{"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
 		})
 	}))
 	defer upstream.Close()

--- a/internal/proxy/proxy_nonstreaming_test.go
+++ b/internal/proxy/proxy_nonstreaming_test.go
@@ -20,15 +20,15 @@ func TestHandleNonStreamingResponse_Success_Integration(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		response := map[string]interface{}{
+		response := map[string]any{
 			"id":      "chatcmpl-test",
 			"object":  "chat.completion",
 			"created": time.Now().Unix(),
 			"model":   "test-model",
-			"choices": []map[string]interface{}{
-				{"index": 0, "message": map[string]interface{}{"role": "assistant", "content": "hello world"}, "finish_reason": "stop"},
+			"choices": []map[string]any{
+				{"index": 0, "message": map[string]any{"role": "assistant", "content": "hello world"}, "finish_reason": "stop"},
 			},
-			"usage": map[string]interface{}{
+			"usage": map[string]any{
 				"prompt_tokens":     5,
 				"completion_tokens": 7,
 				"total_tokens":      12,
@@ -86,13 +86,13 @@ func TestHandleNonStreamingResponse_PromptCacheHitTokens(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		response := map[string]interface{}{
+		response := map[string]any{
 			"id":     "chatcmpl-test",
 			"object": "chat.completion",
-			"choices": []map[string]interface{}{
-				{"index": 0, "message": map[string]interface{}{"role": "assistant", "content": "hello"}, "finish_reason": "stop"},
+			"choices": []map[string]any{
+				{"index": 0, "message": map[string]any{"role": "assistant", "content": "hello"}, "finish_reason": "stop"},
 			},
-			"usage": map[string]interface{}{
+			"usage": map[string]any{
 				"prompt_tokens":           100,
 				"completion_tokens":       5,
 				"total_tokens":            105,
@@ -184,7 +184,7 @@ func TestHandleNonStreamingResponse_NonJSONError(t *testing.T) {
 	}
 
 	// Verify response is valid JSON (OpenAI error format)
-	var response map[string]interface{}
+	var response map[string]any
 	if err := json.Unmarshal(inner.Body.Bytes(), &response); err != nil {
 		t.Errorf("expected response to be valid JSON, got:\n%s\nerror: %v", inner.Body.String(), err)
 	}

--- a/internal/proxy/proxy_request.go
+++ b/internal/proxy/proxy_request.go
@@ -304,10 +304,7 @@ func (h *Handler) loadFailoverConfig(r *http.Request, st *requestState) {
 	// Read once here so every attempt in the request sees a consistent value.
 	hedgeStart := time.Now()
 	st.hedgingEnabled = h.settingsRepo.GetBool(r.Context(), "hedging_enabled", false)
-	st.hedgeDelay = h.settingsRepo.GetDuration(r.Context(), "hedge_delay", 4*time.Second)
-	if st.hedgeDelay < minHedgeDelay {
-		st.hedgeDelay = minHedgeDelay
-	}
+	st.hedgeDelay = max(h.settingsRepo.GetDuration(r.Context(), "hedge_delay", 4*time.Second), minHedgeDelay)
 	ctxkeys.AddSettingsReadMs(r.Context(), hedgeStart)
 
 	// Overall request deadline: caps total time across all failover candidates

--- a/internal/proxy/proxy_resolve_test.go
+++ b/internal/proxy/proxy_resolve_test.go
@@ -247,7 +247,7 @@ func TestResolveHotelModel_CircuitBreakerOpen_Integration(t *testing.T) {
 	}
 
 	// Open the circuit breaker for the provider (threshold=5 by default)
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		handler.circuitBreaker.RecordFailure(providerID, "test-provider")
 	}
 

--- a/internal/proxy/proxy_response_test.go
+++ b/internal/proxy/proxy_response_test.go
@@ -23,7 +23,7 @@ func TestHandleStreamingResponse_ClientWriteFailureMarksDisconnected(t *testing.
 			t.Fatal("upstream response writer must support flushing")
 		}
 
-		for i := 0; i < 50; i++ {
+		for range 50 {
 			chunk := fmt.Sprintf(`data: {"id":"chatcmpl-test","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"x"},"finish_reason":null}]}` + "\n\n")
 			fmt.Fprint(w, chunk)
 			flusher.Flush()

--- a/internal/proxy/proxy_streaming_test.go
+++ b/internal/proxy/proxy_streaming_test.go
@@ -386,7 +386,7 @@ func TestHandleStreamingResponse_TooManyEmptyLines(t *testing.T) {
 		// Send 1002 empty lines. bufio.Scanner splits on \n, so each
 		// \n is a separate scan line. The implementation aborts when
 		// emptyLines > 1000.
-		for i := 0; i < 1002; i++ {
+		for range 1002 {
 			fmt.Fprint(w, "\n")
 		}
 		flusher.Flush()
@@ -747,7 +747,7 @@ func TestHandleStreamingResponse_RepeatedContentDetection(t *testing.T) {
 		}
 
 		// Send same content 12 times (exceeds threshold of 10)
-		for i := 0; i < 12; i++ {
+		for range 12 {
 			fmt.Fprint(w, "data: {\"id\":\"chatcmpl-test\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"reasoning_content\":\"thinking...\"},\"finish_reason\":null}]}\n\n")
 			flusher.Flush()
 		}
@@ -1367,7 +1367,7 @@ func TestHandleStreamingResponse_RepeatedContentPreviewTruncation(t *testing.T) 
 		}
 
 		// Send 12 identical chunks (exceeds threshold of 10)
-		for i := 0; i < 12; i++ {
+		for range 12 {
 			fmt.Fprintf(w, "data: {\"id\":\"chatcmpl-test\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"%s\"},\"finish_reason\":null}]}\n\n", longContent)
 			flusher.Flush()
 		}

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -216,7 +216,7 @@ func TestFailoverBackoff_Sequence(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		for i := 0; i < 100; i++ {
+		for i := range 100 {
 			got := failoverBackoff(base, capacity, tc.attempt)
 			if got < tc.minBackoff || got >= tc.maxBackoff {
 				t.Errorf("attempt %d (sample %d): backoff = %v, want in [%v, %v)", tc.attempt, i, got, tc.minBackoff, tc.maxBackoff)
@@ -327,11 +327,11 @@ func TestWriteOpenAIError_429WithType(t *testing.T) {
 		t.Errorf("expected status %d, got %d", http.StatusTooManyRequests, rec.Code)
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("failed to unmarshal response: %v", err)
 	}
-	errObj := resp["error"].(map[string]interface{})
+	errObj := resp["error"].(map[string]any)
 	if errObj["message"] != "rate limit exceeded" {
 		t.Errorf("expected message 'rate limit exceeded', got %q", errObj["message"])
 	}
@@ -348,11 +348,11 @@ func TestWriteOpenAIError_500WithType(t *testing.T) {
 		t.Errorf("expected status %d, got %d", http.StatusInternalServerError, rec.Code)
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("failed to unmarshal response: %v", err)
 	}
-	errObj := resp["error"].(map[string]interface{})
+	errObj := resp["error"].(map[string]any)
 	if errObj["message"] != "internal server error" {
 		t.Errorf("expected message 'internal server error', got %q", errObj["message"])
 	}
@@ -466,7 +466,7 @@ func TestCacheHits_RoundTrip(t *testing.T) {
 	}
 
 	// Parse the JSON to verify the values round-tripped correctly.
-	var parsed map[string]interface{}
+	var parsed map[string]any
 	if err := json.Unmarshal(rawJSON, &parsed); err != nil {
 		t.Fatalf("cache_hits is not valid JSON: %v (raw: %s)", err, string(rawJSON))
 	}

--- a/internal/proxy/resolve_test.go
+++ b/internal/proxy/resolve_test.go
@@ -712,7 +712,7 @@ func TestResolveHotelModel_CircuitBreakerOpen(t *testing.T) {
 	defer func() { _ = h.failoverRepo.Delete(context.Background(), "cb-fg") }()
 
 	// Open the circuit breaker for the provider (threshold=5 by default)
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		h.circuitBreaker.RecordFailure(createdProvider.ID, createdProvider.Name)
 	}
 

--- a/internal/proxy/response_streaming_test.go
+++ b/internal/proxy/response_streaming_test.go
@@ -1029,8 +1029,8 @@ data: [DONE]
 	assert.NotContains(t, body, `"choices":[{"delta":{"content"`)
 
 	// Verify no broken JSON in output (every data: line contains valid JSON or [DONE])
-	lines := strings.Split(body, "\n\n")
-	for _, event := range lines {
+	lines := strings.SplitSeq(body, "\n\n")
+	for event := range lines {
 		event = strings.TrimSpace(event)
 		if event == "" || !strings.HasPrefix(event, "data: ") {
 			continue
@@ -1256,7 +1256,7 @@ func TestHandleStreamingResponse_ValidJSONForwardedUnchanged(t *testing.T) {
 	assert.Contains(t, body, "data: [DONE]")
 
 	// Verify JSON is valid
-	var chunk map[string]interface{}
+	var chunk map[string]any
 	require.NoError(t, json.Unmarshal([]byte(validChunk), &chunk))
 }
 

--- a/internal/proxy/response_test.go
+++ b/internal/proxy/response_test.go
@@ -277,11 +277,11 @@ func TestHandleNonStreamingResponse_InvalidJSON(t *testing.T) {
 	assert.Equal(t, http.StatusOK, result.StatusCode)
 	assert.Equal(t, "application/json", result.Header.Get("Content-Type"))
 
-	var responseBody map[string]interface{}
+	var responseBody map[string]any
 	err := json.NewDecoder(result.Body).Decode(&responseBody)
 	require.NoError(t, err)
 
-	errorObj, ok := responseBody["error"].(map[string]interface{})
+	errorObj, ok := responseBody["error"].(map[string]any)
 	require.True(t, ok, "Should have error object in response")
 	assert.Contains(t, errorObj["message"], "upstream provider returned HTTP 200")
 
@@ -326,11 +326,11 @@ func TestHandleNonStreamingResponse_EmptyBody(t *testing.T) {
 	assert.Equal(t, http.StatusOK, result.StatusCode)
 	assert.Equal(t, "application/json", result.Header.Get("Content-Type"))
 
-	var responseBody map[string]interface{}
+	var responseBody map[string]any
 	err := json.NewDecoder(result.Body).Decode(&responseBody)
 	require.NoError(t, err)
 
-	errorObj, ok := responseBody["error"].(map[string]interface{})
+	errorObj, ok := responseBody["error"].(map[string]any)
 	require.True(t, ok, "Should have error object in response")
 	assert.Contains(t, errorObj["message"], "upstream provider returned HTTP 200")
 

--- a/internal/proxy/stream_reader.go
+++ b/internal/proxy/stream_reader.go
@@ -55,7 +55,7 @@ type streamReader struct {
 	body         io.ReadCloser // closed by the watchdog on stall, to unblock the scanner
 	stallTimeout time.Duration
 
-	streamStalledFlag int32 // set to 1 by the watchdog on timeout
+	streamStalledFlag atomic.Int32 // set to 1 by the watchdog on timeout
 	stallCh           chan time.Duration
 	watchdogDone      chan struct{}
 
@@ -113,7 +113,7 @@ func (r *streamReader) runWatchdog() {
 			}
 			timer.Reset(d)
 		case <-timer.C:
-			atomic.StoreInt32(&r.streamStalledFlag, 1)
+			r.streamStalledFlag.Store(1)
 			_ = r.body.Close() // unblock scanner
 			return
 		case <-r.watchdogDone:
@@ -204,7 +204,7 @@ func dataEvent(line []byte, payload string) sseEvent {
 
 // stalled reports whether the watchdog fired. Read after Close().
 func (r *streamReader) stalled() bool {
-	return atomic.LoadInt32(&r.streamStalledFlag) == 1
+	return r.streamStalledFlag.Load() == 1
 }
 
 // err returns the scanner's terminal error, if any.

--- a/internal/proxy/stream_transforms.go
+++ b/internal/proxy/stream_transforms.go
@@ -81,11 +81,11 @@ func computeStripReasoning(payload string, lastFinishReason *string, logData *re
 				keepAliveID = idStr
 			}
 		}
-		keepAlivePayload := map[string]interface{}{
+		keepAlivePayload := map[string]any{
 			"id":     keepAliveID,
 			"object": "chat.completion.chunk",
-			"choices": []map[string]interface{}{
-				{"index": 0, "delta": map[string]interface{}{}},
+			"choices": []map[string]any{
+				{"index": 0, "delta": map[string]any{}},
 			},
 		}
 		keepAliveJSON, err := json.Marshal(keepAlivePayload)
@@ -229,7 +229,7 @@ func stripEmptyReasoningContent(payload string, lastFinishReason *string, logDat
 // finish_reason is normalized in place via lastFinishReason.
 func normalizeReasoningChunk(content, reasoningContent *string, payload string, lastFinishReason *string, logData *requestLogData) ([]byte, bool) {
 	// Build a map from the typed delta fields for normalization.
-	deltaMap := make(map[string]interface{})
+	deltaMap := make(map[string]any)
 	if content != nil {
 		deltaMap["content"] = *content
 	}
@@ -249,7 +249,7 @@ func normalizeReasoningChunk(content, reasoningContent *string, payload string, 
 		}
 		// Extract reasoning_details (OpenRouter, MiniMax).
 		if rdRaw, ok := chunkParsed.delta["reasoning_details"]; ok {
-			var rdArr []interface{}
+			var rdArr []any
 			if json.Unmarshal(rdRaw, &rdArr) == nil {
 				deltaMap["reasoning_details"] = rdArr
 			}

--- a/internal/proxy/thinking.go
+++ b/internal/proxy/thinking.go
@@ -114,7 +114,7 @@ type ReasoningDetail struct {
 //  3. delta.content with <thinking> tags → extract to delta.reasoning_content (MiniMax native, some vLLM)
 //
 // Original fields are preserved (dual representation) for backward compatibility.
-func NormalizeReasoningFields(delta map[string]interface{}) bool {
+func NormalizeReasoningFields(delta map[string]any) bool {
 	changed := false
 
 	// Get current reasoning_content value.
@@ -131,10 +131,10 @@ func NormalizeReasoningFields(delta map[string]interface{}) bool {
 
 	// Rule 2: reasoning_details text → reasoning_content
 	if rcEmpty {
-		if details, ok := delta["reasoning_details"].([]interface{}); ok && len(details) > 0 {
+		if details, ok := delta["reasoning_details"].([]any); ok && len(details) > 0 {
 			var texts []string
 			for _, d := range details {
-				if dm, ok := d.(map[string]interface{}); ok {
+				if dm, ok := d.(map[string]any); ok {
 					if t, _ := dm["type"].(string); t == "reasoning.text" {
 						if txt, _ := dm["text"].(string); txt != "" {
 							texts = append(texts, txt)
@@ -174,7 +174,7 @@ func extractThinkingFromContent(content string) (string, string, bool) {
 
 // NormalizeMessageReasoning applies the same normalization rules to
 // a non-streaming message object. Returns true if modified.
-func NormalizeMessageReasoning(msg map[string]interface{}) bool {
+func NormalizeMessageReasoning(msg map[string]any) bool {
 	changed := false
 
 	rc, _ := msg["reasoning_content"].(string)
@@ -190,10 +190,10 @@ func NormalizeMessageReasoning(msg map[string]interface{}) bool {
 
 	// Rule 2: reasoning_details text → reasoning_content
 	if rcEmpty {
-		if details, ok := msg["reasoning_details"].([]interface{}); ok && len(details) > 0 {
+		if details, ok := msg["reasoning_details"].([]any); ok && len(details) > 0 {
 			var texts []string
 			for _, d := range details {
-				if dm, ok := d.(map[string]interface{}); ok {
+				if dm, ok := d.(map[string]any); ok {
 					if t, _ := dm["type"].(string); t == "reasoning.text" {
 						if txt, _ := dm["text"].(string); txt != "" {
 							texts = append(texts, txt)

--- a/internal/proxy/thinking_test.go
+++ b/internal/proxy/thinking_test.go
@@ -128,7 +128,7 @@ func TestIsPartialThinkingTag(t *testing.T) {
 
 func TestNormalizeReasoningFields_ReasoningToReasoningContent(t *testing.T) {
 	// Ollama-style: delta.reasoning present, delta.reasoning_content absent
-	delta := map[string]interface{}{
+	delta := map[string]any{
 		"content":   "",
 		"reasoning": "Let me think about this",
 	}
@@ -148,7 +148,7 @@ func TestNormalizeReasoningFields_ReasoningToReasoningContent(t *testing.T) {
 
 func TestNormalizeReasoningFields_ReasoningContentAlreadyPresent(t *testing.T) {
 	// DeepSeek-style: reasoning_content already present, no change needed
-	delta := map[string]interface{}{
+	delta := map[string]any{
 		"content":           "",
 		"reasoning_content": "Already here",
 		"reasoning":         "Should not override",
@@ -165,15 +165,15 @@ func TestNormalizeReasoningFields_ReasoningContentAlreadyPresent(t *testing.T) {
 
 func TestNormalizeReasoningFields_ReasoningDetailsToReasoningContent(t *testing.T) {
 	// OpenRouter/MiniMax-style: reasoning_details with text entries
-	delta := map[string]interface{}{
+	delta := map[string]any{
 		"content": "",
-		"reasoning_details": []interface{}{
-			map[string]interface{}{
+		"reasoning_details": []any{
+			map[string]any{
 				"type":   "reasoning.text",
 				"text":   "Step 1: Analyze",
 				"format": "google-gemini-v1",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"type":   "reasoning.encrypted",
 				"text":   "",
 				"format": "anthropic-claude-v1",
@@ -192,7 +192,7 @@ func TestNormalizeReasoningFields_ReasoningDetailsToReasoningContent(t *testing.
 
 func TestNormalizeReasoningFields_ThinkingTagsInContent(t *testing.T) {
 	// MiniMax native-style: <thinking> tags in content
-	delta := map[string]interface{}{
+	delta := map[string]any{
 		"content": "<thinking>My reasoning</thinking>The answer",
 	}
 
@@ -210,7 +210,7 @@ func TestNormalizeReasoningFields_ThinkingTagsInContent(t *testing.T) {
 
 func TestNormalizeReasoningFields_NoChangeNeeded(t *testing.T) {
 	// Standard DeepSeek-style: reasoning_content already present, no tags
-	delta := map[string]interface{}{
+	delta := map[string]any{
 		"content":           "Hello",
 		"reasoning_content": "I thought about it",
 	}
@@ -222,7 +222,7 @@ func TestNormalizeReasoningFields_NoChangeNeeded(t *testing.T) {
 }
 
 func TestNormalizeReasoningFields_EmptyDelta(t *testing.T) {
-	delta := map[string]interface{}{
+	delta := map[string]any{
 		"role": "assistant",
 	}
 
@@ -233,7 +233,7 @@ func TestNormalizeReasoningFields_EmptyDelta(t *testing.T) {
 }
 
 func TestNormalizeMessageReasoning_ReasoningToReasoningContent(t *testing.T) {
-	msg := map[string]interface{}{
+	msg := map[string]any{
 		"role":      "assistant",
 		"content":   "The answer",
 		"reasoning": "My thought process",
@@ -249,11 +249,11 @@ func TestNormalizeMessageReasoning_ReasoningToReasoningContent(t *testing.T) {
 }
 
 func TestNormalizeMessageReasoning_ReasoningDetailsToReasoningContent(t *testing.T) {
-	msg := map[string]interface{}{
+	msg := map[string]any{
 		"role":    "assistant",
 		"content": "",
-		"reasoning_details": []interface{}{
-			map[string]interface{}{
+		"reasoning_details": []any{
+			map[string]any{
 				"type": "reasoning.text",
 				"text": "Structured reasoning",
 			},
@@ -270,7 +270,7 @@ func TestNormalizeMessageReasoning_ReasoningDetailsToReasoningContent(t *testing
 }
 
 func TestNormalizeMessageReasoning_ThinkingTagsInContent(t *testing.T) {
-	msg := map[string]interface{}{
+	msg := map[string]any{
 		"role":    "assistant",
 		"content": "<thinking>Hidden reasoning</thinking>Visible answer",
 	}

--- a/internal/proxy/transient_retry_test.go
+++ b/internal/proxy/transient_retry_test.go
@@ -112,18 +112,18 @@ func TestChatCompletions_TransientResetRetriesSameProvider(t *testing.T) {
 	// Two RSTs then success: a single-provider model must survive transient
 	// connection resets via same-provider retries (no failover candidates).
 	upstream, calls := newResettingUpstream(t, maxTransientRetries, func(w http.ResponseWriter, r *http.Request) {
-		var reqBody map[string]interface{}
+		var reqBody map[string]any
 		_ = json.NewDecoder(r.Body).Decode(&reqBody)
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"id":      "chatcmpl-test",
 			"object":  "chat.completion",
 			"created": time.Now().Unix(),
 			"model":   reqBody["model"],
-			"choices": []map[string]interface{}{
-				{"index": 0, "message": map[string]interface{}{"role": "assistant", "content": "recovered"}, "finish_reason": "stop"},
+			"choices": []map[string]any{
+				{"index": 0, "message": map[string]any{"role": "assistant", "content": "recovered"}, "finish_reason": "stop"},
 			},
-			"usage": map[string]interface{}{"prompt_tokens": 5, "completion_tokens": 7, "total_tokens": 12},
+			"usage": map[string]any{"prompt_tokens": 5, "completion_tokens": 7, "total_tokens": 12},
 		})
 	})
 	defer upstream.Close()
@@ -138,11 +138,11 @@ func TestChatCompletions_TransientResetRetriesSameProvider(t *testing.T) {
 	if got := calls.Load(); got != int32(maxTransientRetries+1) {
 		t.Errorf("expected %d upstream calls (1 + %d retries), got %d", maxTransientRetries+1, maxTransientRetries, got)
 	}
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("failed to parse response: %v", err)
 	}
-	choices, ok := resp["choices"].([]interface{})
+	choices, ok := resp["choices"].([]any)
 	if !ok || len(choices) == 0 {
 		t.Errorf("expected at least one choice, got %v", resp["choices"])
 	}

--- a/internal/proxy/ttft_stall_test.go
+++ b/internal/proxy/ttft_stall_test.go
@@ -682,7 +682,7 @@ func TestStallWatchdog_RapidChunksNoPanic(t *testing.T) {
 	stallTimeout := 10 * time.Millisecond
 	pr, pw := io.Pipe()
 	go func() {
-		for i := 0; i < 50; i++ {
+		for range 50 {
 			pw.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"x\"}}]}\n\n"))
 			time.Sleep(3 * time.Millisecond) // much faster than stallTimeout
 		}
@@ -964,7 +964,7 @@ func TestStallWatchdog_ProgressiveTimeout(t *testing.T) {
 	pr, pw := io.Pipe()
 	go func() {
 		// Send 51 chunks rapidly to cross the 50-chunk threshold
-		for i := 0; i < 51; i++ {
+		for range 51 {
 			pw.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"x\"}}]}\n\n"))
 			time.Sleep(time.Millisecond) // tiny delay
 		}
@@ -1039,7 +1039,7 @@ func TestStallWatchdog_ProgressiveTimeout_Boundary50(t *testing.T) {
 	pr, pw := io.Pipe()
 	go func() {
 		// Send exactly 50 chunks — NOT enough to trigger progressive timeout
-		for i := 0; i < 50; i++ {
+		for range 50 {
 			pw.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"x\"}}]}\n\n"))
 		}
 		// Block until either: watchdog closes the body (closeCh) or a

--- a/internal/proxy/types.go
+++ b/internal/proxy/types.go
@@ -274,15 +274,15 @@ type ChatCompletionResponse struct {
 // Choice represents a single completion choice in the response.
 type Choice struct {
 	Index        int     `json:"index"`
-	Message      Message `json:"message,omitempty"`
-	Delta        Message `json:"delta,omitempty"`
+	Message      Message `json:"message"`
+	Delta        Message `json:"delta"`
 	FinishReason *string `json:"finish_reason,omitempty"`
 }
 
 // Message represents a chat message with role and content.
 type Message struct {
-	Role    string      `json:"role"`
-	Content interface{} `json:"content"`
+	Role    string `json:"role"`
+	Content any    `json:"content"`
 	// ToolCalls/ToolCallID must round-trip through the non-streaming decode +
 	// re-encode in handleNonStreamingResponse, or function calls are silently
 	// dropped (finish_reason:"tool_calls" with no tool_calls array) for every


### PR DESCRIPTION
## Summary

Part 1 of 2 applying the gopls **modernize** analyzer's auto-fixes across the Go codebase (the source of the IDE's `interface{}` → `any` hints). Split at package granularity to stay under Greptile's 100-file review limit; part 2 covers the remaining packages and follows once this merges.

All rewrites are mechanical and behavior-preserving:

- `interface{}` → `any`
- C-style index loops → `range n`
- hand-rolled pointer helpers → `new(expr)` (Go 1.26), remaining call sites inlined to typed `new(T(v))`, orphaned test helpers deleted
- `slices.Contains` / `maps.Copy` / `strings.CutPrefix` idioms

The analyzer's behavior-changing suggestions (`omitempty` → `omitzero`) were **not** applied.

## Test plan

- `golangci-lint run ./...` — 0 issues
- `go vet ./...` clean, `make build` clean
- `go test ./internal/api/... ./internal/proxy/...` — 2596 passed
- Full-tree verification (lint + build + entire suite) was done on the combined branch before splitting

🤖 Generated with [Claude Code](https://claude.com/claude-code)