### PR TITLE
chore(modernize): gopls modernize fixes, remaining packages (2/2)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"slices"
 	"strings"
 	"syscall"
 	"time"
@@ -68,21 +69,21 @@ func publishDiscoveryEvent(source string, result DiscoveryResult) {
 			Type:     "discovery.complete",
 			Severity: "error",
 			Message:  fmt.Sprintf("Discovery failed: %s", result.Errors[0]),
-			Metadata: map[string]interface{}{"source": source, "errors": result.Errors},
+			Metadata: map[string]any{"source": source, "errors": result.Errors},
 		})
 	case result.ProvidersFailed > 0:
 		events.Publish(events.Event{
 			Type:     "discovery.complete",
 			Severity: "warning",
 			Message:  fmt.Sprintf("Discovery partially failed: %d/%d providers OK, %d models found", result.ProvidersScanned-result.ProvidersFailed, result.ProvidersScanned, result.ModelsDiscovered),
-			Metadata: map[string]interface{}{"source": source, "errors": result.Errors},
+			Metadata: map[string]any{"source": source, "errors": result.Errors},
 		})
 	default:
 		events.Publish(events.Event{
 			Type:     "discovery.complete",
 			Severity: "success",
 			Message:  fmt.Sprintf("%s discovery complete: %d models across %d providers", source, result.ModelsDiscovered, result.ProvidersScanned),
-			Metadata: map[string]interface{}{"source": source},
+			Metadata: map[string]any{"source": source},
 		})
 	}
 }
@@ -168,7 +169,7 @@ func main() {
 			Type:     "logs.stale_startup",
 			Severity: "warning",
 			Message:  fmt.Sprintf("Server restart interrupted %d pending requests", tag.RowsAffected()),
-			Metadata: map[string]interface{}{"count": tag.RowsAffected()},
+			Metadata: map[string]any{"count": tag.RowsAffected()},
 		})
 	} else if err != nil {
 		debuglog.Error("startup: stale log cleanup failed", "error", err)
@@ -238,13 +239,7 @@ func main() {
 				return
 			}
 
-			allowed := false
-			for _, pattern := range cfg.CORSOrigins {
-				if origin == pattern {
-					allowed = true
-					break
-				}
-			}
+			allowed := slices.Contains(cfg.CORSOrigins, origin)
 
 			w.Header().Set("Vary", "Origin")
 
@@ -566,7 +561,7 @@ func main() {
 					Type:     "discovery.models_disabled",
 					Severity: "warning",
 					Message:  fmt.Sprintf("%d models no longer available at '%s' and were disabled", len(disabledRefs), p.Name),
-					Metadata: map[string]interface{}{"provider": p.Name, "count": len(disabledRefs)},
+					Metadata: map[string]any{"provider": p.Name, "count": len(disabledRefs)},
 				})
 			}
 
@@ -609,7 +604,7 @@ func main() {
 					Type:     "failover.sync_error",
 					Severity: "warning",
 					Message:  fmt.Sprintf("Failover sync failed for model '%s'", modelID),
-					Metadata: map[string]interface{}{"error": err.Error(), "model_id": modelID},
+					Metadata: map[string]any{"error": err.Error(), "model_id": modelID},
 				})
 				continue
 			}
@@ -645,7 +640,7 @@ func main() {
 				Severity: "info",
 				Source:   "discovery",
 				Message:  "Background discovery recorded model changes",
-				Metadata: map[string]interface{}{"source": source},
+				Metadata: map[string]any{"source": source},
 			})
 		}
 		return result
@@ -900,7 +895,7 @@ func main() {
 					Type:     "logs.stale_cleanup",
 					Severity: "warning",
 					Message:  fmt.Sprintf("Marked %d stale requests as interrupted", tag.RowsAffected()),
-					Metadata: map[string]interface{}{"count": tag.RowsAffected()},
+					Metadata: map[string]any{"count": tag.RowsAffected()},
 				})
 			} else if err != nil {
 				debuglog.Error("retention: stale log cleanup failed", "error", err)

--- a/cmd/server/middleware_test.go
+++ b/cmd/server/middleware_test.go
@@ -84,10 +84,10 @@ func TestStreamingAwareTimeout_NonStreamingRequest(t *testing.T) {
 }
 
 func TestStreamingAwareTimeout_NonPostSkipsParsing(t *testing.T) {
-	var capturedBody interface{}
-	var capturedParseMs interface{}
-	var capturedModel interface{}
-	var capturedIsStreaming interface{}
+	var capturedBody any
+	var capturedParseMs any
+	var capturedModel any
+	var capturedIsStreaming any
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		capturedBody = r.Context().Value(ctxkeys.RequestBodyKey)
@@ -185,7 +185,7 @@ func TestStreamingAwareTimeout_MalformedJSON(t *testing.T) {
 }
 
 func TestStreamingAwareTimeout_MultipartNotBuffered(t *testing.T) {
-	var capturedBodyVal interface{}
+	var capturedBodyVal any
 	var readBody []byte
 	var hadDeadline bool
 

--- a/cmd/server/spa_test.go
+++ b/cmd/server/spa_test.go
@@ -182,7 +182,7 @@ func TestSPAHandler_ServeHTTP_ConcurrentRequests(t *testing.T) {
 	paths := []string{"/", "/dashboard", "/api/test", "/v1/chat", "/health", "/some/spa/route"}
 	done := make(chan bool)
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		go func() {
 			defer func() { done <- true }()
 			for _, path := range paths {
@@ -193,7 +193,7 @@ func TestSPAHandler_ServeHTTP_ConcurrentRequests(t *testing.T) {
 		}()
 	}
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		select {
 		case <-done:
 		case <-time.After(5 * time.Second):

--- a/frontdesk/web/package.json
+++ b/frontdesk/web/package.json
@@ -9,7 +9,7 @@
 		"build": "tsc -b && vite build",
 		"build:docker": "vite build",
 		"typecheck:tests": "tsc --noEmit -p tsconfig.test.json",
-		"lint": "eslint ${@:-.}",
+		"lint": "eslint --no-warn-ignored ${@:-.}",
 		"format": "biome check --write src",
 		"test": "vitest run"
 	},

--- a/internal/admin/token_test.go
+++ b/internal/admin/token_test.go
@@ -699,7 +699,7 @@ func TestGenerateToken_DeterministicLength(t *testing.T) {
 	}
 
 	// Call generateToken multiple times and verify length
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		token, err := mgr.generateToken()
 		if err != nil {
 			t.Fatalf("generateToken() failed: %v", err)
@@ -719,7 +719,7 @@ func TestGenerateToken_IsHexString(t *testing.T) {
 		t.Fatalf("Failed to create manager: %v", err)
 	}
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		token, err := mgr.generateToken()
 		if err != nil {
 			t.Fatalf("generateToken() failed: %v", err)

--- a/internal/adminauth/github_test.go
+++ b/internal/adminauth/github_test.go
@@ -184,8 +184,8 @@ func runGitHubCallback(t *testing.T, h *GitHubHandler, cookie *http.Cookie, quer
 		t.Fatalf("Callback status = %d, want 302 (body=%s)", res.StatusCode, rec.Body.String())
 	}
 	loc := res.Header.Get("Location")
-	if i := strings.IndexByte(loc, '#'); i >= 0 {
-		return loc[i+1:]
+	if _, after, ok := strings.Cut(loc, "#"); ok {
+		return after
 	}
 	return ""
 }
@@ -428,7 +428,7 @@ func TestGitHubCallbackThrottled(t *testing.T) {
 	// Backoff begins only once failures EXCEED maxFailures (5): the 6th failure
 	// arms the lock, so the 7th callback is throttled before any work.
 	var frag string
-	for i := 0; i < 7; i++ {
+	for range 7 {
 		loc, cookie := runGitHubStart(t, h)
 		frag = runGitHubCallback(t, h, cookie, url.Values{"state": {loc.Query().Get("state")}, "code": {"c"}})
 	}

--- a/internal/adminauth/helpers.go
+++ b/internal/adminauth/helpers.go
@@ -36,7 +36,7 @@ type IPLimiterMiddleware interface {
 }
 
 // writeJSON encodes v as JSON. Copied from internal/api/helpers.go.
-func writeJSON(w http.ResponseWriter, v interface{}) {
+func writeJSON(w http.ResponseWriter, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(v); err != nil {
 		logEncodeError(err)

--- a/internal/adminauth/oidc_test.go
+++ b/internal/adminauth/oidc_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rsa"
 	"encoding/json"
 	"errors"
+	"maps"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -106,9 +107,7 @@ type fakeSettings struct {
 
 func newFakeSettings(kv map[string]string) *fakeSettings {
 	cp := make(map[string]string, len(kv))
-	for k, v := range kv {
-		cp[k] = v
-	}
+	maps.Copy(cp, kv)
 	return &fakeSettings{m: cp}
 }
 
@@ -363,8 +362,8 @@ func runCallback(t *testing.T, h *OIDCHandler, cookie *http.Cookie, query url.Va
 		t.Fatalf("Callback status = %d, want 302 (body=%s)", res.StatusCode, rec.Body.String())
 	}
 	loc := res.Header.Get("Location")
-	if i := strings.IndexByte(loc, '#'); i >= 0 {
-		return loc[i+1:]
+	if _, after, ok := strings.Cut(loc, "#"); ok {
+		return after
 	}
 	return ""
 }
@@ -612,7 +611,7 @@ func TestOIDCCallbackThrottle(t *testing.T) {
 	// constant across httptest requests); the 1s lock easily outlasts the loop.
 	q := url.Values{"state": {"x"}, "code": {"c"}}
 	var frag string
-	for i := 0; i < 7; i++ {
+	for range 7 {
 		frag = runCallback(t, h, nil, q)
 	}
 	if !strings.HasPrefix(frag, "oidc_error=throttled") {

--- a/internal/adminauth/totp_test.go
+++ b/internal/adminauth/totp_test.go
@@ -829,7 +829,7 @@ func TestTotpLogin_Throttled(t *testing.T) {
 	doEnrollVerify(t, th) // enables TOTP so /totp/login is active
 
 	got429 := false
-	for i := 0; i < 8; i++ {
+	for range 8 {
 		req := httptest.NewRequest(http.MethodPost, "/totp/login",
 			bytes.NewReader([]byte(`{"token":"wrong","code":"000000"}`)))
 		req.Header.Set("Content-Type", "application/json")

--- a/internal/adminauth/webauthn.go
+++ b/internal/adminauth/webauthn.go
@@ -174,7 +174,7 @@ func (h *WebAuthnHandler) RegisterStart(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	writeJSON(w, map[string]interface{}{
+	writeJSON(w, map[string]any{
 		"session_id": sessionID.String(),
 		"options":    creation.Response,
 	})
@@ -273,7 +273,7 @@ func (h *WebAuthnHandler) RegisterFinish(w http.ResponseWriter, r *http.Request)
 		Source:   "webauthn",
 		Message:  "Passkey registered successfully",
 	})
-	writeJSON(w, map[string]interface{}{
+	writeJSON(w, map[string]any{
 		"success": true,
 	})
 }
@@ -310,7 +310,7 @@ func (h *WebAuthnHandler) LoginStart(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, map[string]interface{}{
+	writeJSON(w, map[string]any{
 		"session_id": sessionID.String(),
 		"options":    assertion.Response,
 	})
@@ -405,7 +405,7 @@ func (h *WebAuthnHandler) LoginFinish(w http.ResponseWriter, r *http.Request) {
 	}
 
 	debuglog.Info("webauthn: passkey login successful")
-	writeJSON(w, map[string]interface{}{
+	writeJSON(w, map[string]any{
 		"token": token,
 	})
 }
@@ -421,7 +421,7 @@ func (h *WebAuthnHandler) Logout(w http.ResponseWriter, r *http.Request) {
 
 	h.sessionMgr.RevokeAuthToken(r.Context(), token)
 
-	writeJSON(w, map[string]interface{}{
+	writeJSON(w, map[string]any{
 		"success": true,
 	})
 }
@@ -530,5 +530,5 @@ func (h *WebAuthnHandler) RenameCredential(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	writeJSON(w, map[string]interface{}{"success": true})
+	writeJSON(w, map[string]any{"success": true})
 }

--- a/internal/adminauth/webauthn_login_test.go
+++ b/internal/adminauth/webauthn_login_test.go
@@ -366,7 +366,7 @@ func TestWebAuthnHandler_LoginStart_Success(t *testing.T) {
 		t.Fatalf("expected status %d, got %d; body: %s", http.StatusOK, w.Code, w.Body.String())
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
@@ -513,7 +513,7 @@ func TestWebAuthnHandler_LoginFinish_WithSyntacticallyValidCredential(t *testing
 		t.Fatalf("LoginStart failed: %d %s", w.Code, w.Body.String())
 	}
 
-	var startResp map[string]interface{}
+	var startResp map[string]any
 	if err := json.NewDecoder(w.Body).Decode(&startResp); err != nil {
 		t.Fatalf("failed to decode LoginStart response: %v", err)
 	}
@@ -528,7 +528,7 @@ func TestWebAuthnHandler_LoginFinish_WithSyntacticallyValidCredential(t *testing
 	fakeCred := buildFakeLoginCredential(t, "dGVzdA")
 
 	// Step 3: Call LoginFinish with the valid session + fake credential
-	finishBody := map[string]interface{}{
+	finishBody := map[string]any{
 		"session_id": sessionID,
 		"credential": fakeCred,
 	}
@@ -713,7 +713,7 @@ func TestWebAuthnHandler_LoginFinish_WithStoredCredential(t *testing.T) {
 		t.Fatalf("LoginStart failed: %d %s", w.Code, w.Body.String())
 	}
 
-	var startResp map[string]interface{}
+	var startResp map[string]any
 	if err := json.NewDecoder(w.Body).Decode(&startResp); err != nil {
 		t.Fatalf("failed to decode LoginStart response: %v", err)
 	}
@@ -729,7 +729,7 @@ func TestWebAuthnHandler_LoginFinish_WithStoredCredential(t *testing.T) {
 
 	// Step 4: Call LoginFinish - userLookup finds the credential via
 	// GetCredentialByID, but ValidatePasskeyLogin fails (fake signature)
-	finishBody := map[string]interface{}{
+	finishBody := map[string]any{
 		"session_id": sessionID,
 		"credential": fakeCred,
 	}

--- a/internal/adminauth/webauthn_register_test.go
+++ b/internal/adminauth/webauthn_register_test.go
@@ -598,7 +598,7 @@ func TestWebAuthnHandler_RegisterStart_Success(t *testing.T) {
 		t.Fatalf("expected status %d, got %d; body: %s", http.StatusOK, w.Code, w.Body.String())
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
@@ -754,7 +754,7 @@ func TestWebAuthnHandler_RegisterFinish_WithSyntacticallyValidCredential(t *test
 		t.Fatalf("RegisterStart failed: %d %s", w.Code, w.Body.String())
 	}
 
-	var startResp map[string]interface{}
+	var startResp map[string]any
 	if err := json.NewDecoder(w.Body).Decode(&startResp); err != nil {
 		t.Fatalf("failed to decode RegisterStart response: %v", err)
 	}
@@ -773,7 +773,7 @@ func TestWebAuthnHandler_RegisterFinish_WithSyntacticallyValidCredential(t *test
 	fakeCred := buildFakeRegistrationCredential(t, "dGVzdA")
 
 	// Step 3: Call RegisterFinish with the valid session + fake credential
-	finishBody := map[string]interface{}{
+	finishBody := map[string]any{
 		"session_id": sessionID,
 		"credential": json.RawMessage(fakeCred),
 	}
@@ -981,7 +981,7 @@ func TestWebAuthnHandler_RegisterStart_WithExistingCredentials(t *testing.T) {
 		t.Fatalf("expected status %d, got %d; body: %s", http.StatusOK, w.Code, w.Body.String())
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
@@ -1045,7 +1045,7 @@ func TestWebAuthnHandler_RegisterFinish_ListCredentialsErrorAfterSession(t *test
 		t.Fatalf("RegisterStart failed: %d %s", w.Code, w.Body.String())
 	}
 
-	var startResp map[string]interface{}
+	var startResp map[string]any
 	if err := json.NewDecoder(w.Body).Decode(&startResp); err != nil {
 		t.Fatalf("failed to decode RegisterStart response: %v", err)
 	}

--- a/internal/adminauth/webauthn_test.go
+++ b/internal/adminauth/webauthn_test.go
@@ -327,7 +327,7 @@ func buildFakeRegistrationCredential(t *testing.T, credentialIDB64 string) json.
 	t.Helper()
 
 	// Build clientDataJSON as proper JSON
-	clientData := map[string]interface{}{
+	clientData := map[string]any{
 		"type":        "webauthn.create",
 		"challenge":   "",
 		"origin":      "http://localhost",
@@ -350,7 +350,7 @@ func buildFakeRegistrationCredential(t *testing.T, credentialIDB64 string) json.
 	binary.BigEndian.PutUint16(credIDLen, uint16(len(credID)))
 
 	// Minimal COSE key: EC2/P-256 with placeholder coordinates
-	coseKey := map[int]interface{}{
+	coseKey := map[int]any{
 		1:  2,                // kty: EC2
 		3:  -25,              // alg: ES256
 		-1: make([]byte, 32), // x: 32 zero bytes
@@ -374,9 +374,9 @@ func buildFakeRegistrationCredential(t *testing.T, credentialIDB64 string) json.
 	authData = append(authData, coseKeyCBOR...)
 
 	// Build attestation object as CBOR
-	attObj := map[string]interface{}{
+	attObj := map[string]any{
 		"fmt":      "none",
-		"attStmt":  map[string]interface{}{},
+		"attStmt":  map[string]any{},
 		"authData": authData,
 	}
 	attObjCBOR, err := cbor.Marshal(attObj)
@@ -385,11 +385,11 @@ func buildFakeRegistrationCredential(t *testing.T, credentialIDB64 string) json.
 	}
 
 	// Build the credential response JSON
-	cred := map[string]interface{}{
+	cred := map[string]any{
 		"id":    credentialIDB64,
 		"rawId": credentialIDB64,
 		"type":  "public-key",
-		"response": map[string]interface{}{
+		"response": map[string]any{
 			"attestationObject": base64.RawURLEncoding.EncodeToString(attObjCBOR),
 			"clientDataJSON":    base64.RawURLEncoding.EncodeToString(clientDataJSON),
 			"transports":        []string{"internal"},
@@ -409,7 +409,7 @@ func buildFakeLoginCredential(t *testing.T, credentialIDB64 string) json.RawMess
 	t.Helper()
 
 	// Build clientDataJSON
-	clientData := map[string]interface{}{
+	clientData := map[string]any{
 		"type":        "webauthn.get",
 		"challenge":   "",
 		"origin":      "http://localhost",
@@ -433,11 +433,11 @@ func buildFakeLoginCredential(t *testing.T, credentialIDB64 string) json.RawMess
 	authData = append(authData, signCountBytes...)
 
 	// Build the credential assertion response JSON
-	cred := map[string]interface{}{
+	cred := map[string]any{
 		"id":    credentialIDB64,
 		"rawId": credentialIDB64,
 		"type":  "public-key",
-		"response": map[string]interface{}{
+		"response": map[string]any{
 			"authenticatorData": base64.RawURLEncoding.EncodeToString(authData),
 			"clientDataJSON":    base64.RawURLEncoding.EncodeToString(clientDataJSON),
 			"signature":         base64.RawURLEncoding.EncodeToString(make([]byte, 64)),

--- a/internal/alert/catalog.go
+++ b/internal/alert/catalog.go
@@ -79,7 +79,7 @@ func DefaultEnabledCSVFor(defs []EventDef) string {
 // Blank/whitespace entries are ignored.
 func ParseEnabled(csv string) map[string]bool {
 	out := make(map[string]bool)
-	for _, t := range strings.Split(csv, ",") {
+	for t := range strings.SplitSeq(csv, ",") {
 		if t = strings.TrimSpace(t); t != "" {
 			out[t] = true
 		}

--- a/internal/alert/catalog_test.go
+++ b/internal/alert/catalog_test.go
@@ -64,7 +64,7 @@ func TestParseEnabled(t *testing.T) {
 
 func TestDefaultEnabledCSVOnlyKnownTypes(t *testing.T) {
 	idx := catalogIndex()
-	for _, tpe := range strings.Split(DefaultEnabledCSV(), ",") {
+	for tpe := range strings.SplitSeq(DefaultEnabledCSV(), ",") {
 		if _, ok := idx[tpe]; !ok {
 			t.Errorf("DefaultEnabledCSV contains unknown type %q", tpe)
 		}

--- a/internal/alert/dispatcher.go
+++ b/internal/alert/dispatcher.go
@@ -223,7 +223,7 @@ func (d *Dispatcher) suppressed(ev events.Event) bool {
 // failing inside the cooldown window would collapse to a single alert and the
 // second failure would be silently dropped. keys is the most-specific-first list
 // to probe (the dispatcher's configured debounce keys).
-func debounceID(meta map[string]interface{}, keys []string) string {
+func debounceID(meta map[string]any, keys []string) string {
 	for _, k := range keys {
 		if v, ok := meta[k].(string); ok && v != "" {
 			return v

--- a/internal/alert/dispatcher_test.go
+++ b/internal/alert/dispatcher_test.go
@@ -227,7 +227,7 @@ func TestDebounceSuppressesFlapping(t *testing.T) {
 	d := New(fakeCfg{cfg: enabledConfig("http://unused", "tgram://x", "circuit_breaker.open")}, nil)
 	d.cooldown = time.Minute // large window: the decision is synchronous, no real time elapses
 
-	ev := events.Event{Type: "circuit_breaker.open", Severity: "warning", Metadata: map[string]interface{}{"provider_id": "p1"}}
+	ev := events.Event{Type: "circuit_breaker.open", Severity: "warning", Metadata: map[string]any{"provider_id": "p1"}}
 	if !d.handle(context.Background(), ev) {
 		t.Fatal("first event should dispatch")
 	}
@@ -239,7 +239,7 @@ func TestDebounceSuppressesFlapping(t *testing.T) {
 	}
 
 	// Different provider => different debounce key => allowed.
-	ev2 := events.Event{Type: "circuit_breaker.open", Severity: "warning", Metadata: map[string]interface{}{"provider_id": "p2"}}
+	ev2 := events.Event{Type: "circuit_breaker.open", Severity: "warning", Metadata: map[string]any{"provider_id": "p2"}}
 	if !d.handle(context.Background(), ev2) {
 		t.Error("a different provider should not be suppressed")
 	}
@@ -253,7 +253,7 @@ func TestDebounceDistinctEntities(t *testing.T) {
 	d.cooldown = time.Minute
 
 	disc := func(provider string) events.Event {
-		return events.Event{Type: "discovery.provider_failed", Severity: "error", Metadata: map[string]interface{}{"provider": provider}}
+		return events.Event{Type: "discovery.provider_failed", Severity: "error", Metadata: map[string]any{"provider": provider}}
 	}
 	if !d.handle(context.Background(), disc("openai")) {
 		t.Fatal("first provider discovery failure should dispatch")
@@ -266,7 +266,7 @@ func TestDebounceDistinctEntities(t *testing.T) {
 	}
 
 	sync := func(model string) events.Event {
-		return events.Event{Type: "failover.sync_error", Severity: "warning", Metadata: map[string]interface{}{"model_id": model}}
+		return events.Event{Type: "failover.sync_error", Severity: "warning", Metadata: map[string]any{"model_id": model}}
 	}
 	if !d.handle(context.Background(), sync("gpt-4o")) || !d.handle(context.Background(), sync("claude")) {
 		t.Error("distinct model sync errors must alert independently")
@@ -277,7 +277,7 @@ func TestDebounceAllowsAfterCooldown(t *testing.T) {
 	d := New(fakeCfg{cfg: enabledConfig("http://unused", "tgram://x", "circuit_breaker.open")}, nil)
 	d.cooldown = 30 * time.Millisecond
 
-	ev := events.Event{Type: "circuit_breaker.open", Severity: "warning", Metadata: map[string]interface{}{"provider_id": "p1"}}
+	ev := events.Event{Type: "circuit_breaker.open", Severity: "warning", Metadata: map[string]any{"provider_id": "p1"}}
 	if !d.handle(context.Background(), ev) {
 		t.Fatal("first event should dispatch")
 	}
@@ -294,7 +294,7 @@ func TestDebounceRecoveryNotSuppressedByFailure(t *testing.T) {
 	d := New(fakeCfg{cfg: enabledConfig("http://unused", "tgram://x", "circuit_breaker.open", "circuit_breaker.closed")}, nil)
 	d.cooldown = time.Minute
 
-	meta := map[string]interface{}{"provider_id": "p1"}
+	meta := map[string]any{"provider_id": "p1"}
 	open := d.handle(context.Background(), events.Event{Type: "circuit_breaker.open", Severity: "warning", Metadata: meta})
 	closed := d.handle(context.Background(), events.Event{Type: "circuit_breaker.closed", Severity: "success", Metadata: meta})
 	if !open || !closed {
@@ -397,7 +397,7 @@ func TestWithDebounceKeysScopesPerMember(t *testing.T) {
 	d.cooldown = time.Minute
 
 	down := func(member string) events.Event {
-		return events.Event{Type: "health.down", Severity: "error", Metadata: map[string]interface{}{"member_id": member}}
+		return events.Event{Type: "health.down", Severity: "error", Metadata: map[string]any{"member_id": member}}
 	}
 	if !d.handle(context.Background(), down("m1")) {
 		t.Fatal("first member-down should dispatch")
@@ -410,7 +410,7 @@ func TestWithDebounceKeysScopesPerMember(t *testing.T) {
 	}
 	// provider_id is NOT a configured debounce key here, so it does not scope:
 	// two events differing only by provider_id collapse to the empty-id bucket.
-	withProv := events.Event{Type: "health.down", Severity: "error", Metadata: map[string]interface{}{"provider_id": "p1"}}
+	withProv := events.Event{Type: "health.down", Severity: "error", Metadata: map[string]any{"provider_id": "p1"}}
 	if !d.handle(context.Background(), withProv) {
 		t.Fatal("first un-membered event should dispatch")
 	}
@@ -427,8 +427,7 @@ func TestWithBusIsolatesFromDefault(t *testing.T) {
 	d := New(fakeCfg{cfg: enabledConfig(rs.URL, "tgram://x", "health.down")},
 		rs.Client(), WithBus(bus), WithCatalog(cat))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	go d.Run(ctx)
 
 	// An event on the GLOBAL bus must not reach a dispatcher bound to `bus`.

--- a/internal/anthropic/stream_test.go
+++ b/internal/anthropic/stream_test.go
@@ -11,9 +11,6 @@ import (
 	"github.com/anthropics/anthropic-sdk-go/packages/ssestream"
 )
 
-// strPtr is a test helper for OpenAI finish_reason pointers.
-func strPtr(s string) *string { return &s }
-
 // decodeWithSDK feeds raw Anthropic SSE bytes through the real anthropic-sdk-go
 // stream decoder, proving a genuine Anthropic SDK client accepts our output. It
 // returns the ordered event types plus the reconstructed assistant turn.
@@ -95,7 +92,7 @@ func TestStreamTranslator_TextOnly_AcceptedBySDK(t *testing.T) {
 	chunks := []OAStreamChunk{
 		{Choices: []OAStreamChoice{{Delta: OAStreamDelta{Content: "Hello"}}}},
 		{Choices: []OAStreamChoice{{Delta: OAStreamDelta{Content: ", world"}}}},
-		{Choices: []OAStreamChoice{{Delta: OAStreamDelta{Content: "!"}, FinishReason: strPtr("stop")}}},
+		{Choices: []OAStreamChoice{{Delta: OAStreamDelta{Content: "!"}, FinishReason: new("stop")}}},
 		{Usage: &OAUsage{PromptTokens: 9, CompletionTokens: 3}},
 	}
 	sse := runTranslator(t, tr, chunks)
@@ -150,7 +147,7 @@ func TestStreamTranslator_ToolUse_AcceptedBySDK(t *testing.T) {
 		{Choices: []OAStreamChoice{{Delta: OAStreamDelta{ToolCalls: []OAToolCallDelta{
 			{Index: 0, Function: OAFunctionDelta{Arguments: `"Paris"}`}},
 		}}}}},
-		{Choices: []OAStreamChoice{{Delta: OAStreamDelta{}, FinishReason: strPtr("tool_calls")}}},
+		{Choices: []OAStreamChoice{{Delta: OAStreamDelta{}, FinishReason: new("tool_calls")}}},
 		{Usage: &OAUsage{PromptTokens: 20, CompletionTokens: 12}},
 	}
 	sse := runTranslator(t, tr, chunks)
@@ -175,7 +172,7 @@ func TestStreamTranslator_EmptyCompletion_WellFormed(t *testing.T) {
 	tr := NewStreamTranslator("msg_empty", "claude-haiku-4-5")
 	// No content at all, just a terminal finish.
 	chunks := []OAStreamChunk{
-		{Choices: []OAStreamChoice{{Delta: OAStreamDelta{}, FinishReason: strPtr("stop")}}},
+		{Choices: []OAStreamChoice{{Delta: OAStreamDelta{}, FinishReason: new("stop")}}},
 	}
 	sse := runTranslator(t, tr, chunks)
 	got := decodeWithSDK(t, sse)

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -174,14 +174,12 @@ func (rec *Recorder) Middleware(next http.Handler) http.Handler {
 			StatusCode: status,
 			RemoteAddr: r.RemoteAddr,
 		}
-		rec.wg.Add(1)
 		//nolint:gosec // G118: record deliberately uses a background context so a
 		// client disconnect can never drop the audit row; the request context is
 		// the wrong scope here.
-		go func() {
-			defer rec.wg.Done()
+		rec.wg.Go(func() {
 			rec.record(entry)
-		}()
+		})
 	})
 }
 

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -207,7 +207,7 @@ func TestWaitDrainsBackgroundRecords(t *testing.T) {
 
 	ident := &user.Identity{Role: user.RoleAdmin}
 	const n = 5
-	for i := 0; i < n; i++ {
+	for range n {
 		req := httptest.NewRequest(http.MethodPost, "/things", http.NoBody)
 		req = req.WithContext(user.WithIdentity(req.Context(), ident))
 		r.ServeHTTP(httptest.NewRecorder(), req)

--- a/internal/auth/encryption_test.go
+++ b/internal/auth/encryption_test.go
@@ -249,7 +249,7 @@ func TestGenerateRandomKey_Length(t *testing.T) {
 
 func TestGenerateRandomKey_Randomness(t *testing.T) {
 	keys := make(map[string]bool)
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		key, err := GenerateRandomKey()
 		if err != nil {
 			t.Fatalf("GenerateRandomKey failed: %v", err)
@@ -342,7 +342,7 @@ func TestEncryptDecrypt_Concurrent(t *testing.T) {
 	iterations := 100
 
 	results := make(chan string, iterations)
-	for i := 0; i < iterations; i++ {
+	for range iterations {
 		go func() {
 			encrypted, err := Encrypt(plaintext, masterKey)
 			if err != nil {
@@ -358,7 +358,7 @@ func TestEncryptDecrypt_Concurrent(t *testing.T) {
 		}()
 	}
 
-	for i := 0; i < iterations; i++ {
+	for range iterations {
 		result := <-results
 		if result != plaintext {
 			t.Errorf("Concurrent operation failed: expected %q, got %q", plaintext, result)

--- a/internal/auth/key_cache_test.go
+++ b/internal/auth/key_cache_test.go
@@ -361,10 +361,8 @@ func TestDecryptCached_ConcurrentAccess(t *testing.T) {
 	errors := make(chan error, 20)
 
 	// Launch concurrent decrypts
-	for i := 0; i < 20; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range 20 {
+		wg.Go(func() {
 			result, err := DecryptCached(kp.Ciphertext, kp.Nonce, kp.Salt, masterKey)
 			if err != nil {
 				errors <- err
@@ -374,7 +372,7 @@ func TestDecryptCached_ConcurrentAccess(t *testing.T) {
 				errors <- err
 				return
 			}
-		}()
+		})
 	}
 
 	wg.Wait()
@@ -762,10 +760,8 @@ func TestDecryptCached_ConcurrentEvictionAndAccess(t *testing.T) {
 	done := make(chan struct{})
 
 	// Launch 10 goroutines repeatedly calling DecryptCached
-	for i := 0; i < 10; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range 10 {
+		wg.Go(func() {
 			for {
 				select {
 				case <-done:
@@ -782,13 +778,11 @@ func TestDecryptCached_ConcurrentEvictionAndAccess(t *testing.T) {
 					}
 				}
 			}
-		}()
+		})
 	}
 
 	// Launch 1 goroutine repeatedly calling evictExpiredKeyCacheEntries
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for {
 			select {
 			case <-done:
@@ -798,7 +792,7 @@ func TestDecryptCached_ConcurrentEvictionAndAccess(t *testing.T) {
 				time.Sleep(10 * time.Millisecond)
 			}
 		}
-	}()
+	})
 
 	// Run for ~500ms
 	time.Sleep(500 * time.Millisecond)

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -225,7 +225,7 @@ var waitForReadyInterval = 2 * time.Second
 
 // WaitForReady polls the database until it responds or maxAttempts is reached.
 func (db *DB) WaitForReady(ctx context.Context, maxAttempts int) error {
-	for i := 0; i < maxAttempts; i++ {
+	for i := range maxAttempts {
 		err := db.pool.Ping(ctx)
 		if err == nil {
 			return nil

--- a/internal/debuglog/debuglog.go
+++ b/internal/debuglog/debuglog.go
@@ -136,7 +136,7 @@ func parseScopes(raw string) map[string]bool {
 		return nil
 	}
 	scopes := make(map[string]bool)
-	for _, s := range strings.Split(raw, ",") {
+	for s := range strings.SplitSeq(raw, ",") {
 		if s = strings.ToLower(strings.TrimSpace(s)); s != "" {
 			scopes[s] = true
 		}

--- a/internal/events/bus.go
+++ b/internal/events/bus.go
@@ -12,13 +12,13 @@ import (
 
 // Event represents a publishable event for SSE distribution.
 type Event struct {
-	ID        string                 `json:"id"`
-	Type      string                 `json:"type"`
-	Severity  string                 `json:"severity"` // "success", "info", "warning", "error"
-	Source    string                 `json:"source"`
-	Message   string                 `json:"message"`
-	Metadata  map[string]interface{} `json:"metadata,omitempty"`
-	Timestamp time.Time              `json:"timestamp"`
+	ID        string         `json:"id"`
+	Type      string         `json:"type"`
+	Severity  string         `json:"severity"` // "success", "info", "warning", "error"
+	Source    string         `json:"source"`
+	Message   string         `json:"message"`
+	Metadata  map[string]any `json:"metadata,omitempty"`
+	Timestamp time.Time      `json:"timestamp"`
 }
 
 // Bus is an event bus for distributing events to SSE subscribers.

--- a/internal/events/bus_test.go
+++ b/internal/events/bus_test.go
@@ -67,7 +67,7 @@ func TestDropIfFull(t *testing.T) {
 	b.mu.Unlock()
 
 	// Publish more than buffer size
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		b.Publish(Event{Type: "drop"})
 	}
 
@@ -131,23 +131,19 @@ func TestConcurrentSubscribePublish(t *testing.T) {
 	}
 
 	// Concurrent publishers.
-	for i := 0; i < 10; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range 10 {
+		wg.Go(func() {
 			b.Publish(Event{Type: "concurrent"})
-		}()
+		})
 	}
 
 	// Concurrent subscribe/unsubscribe while publishing.
-	for i := 0; i < 3; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range 3 {
+		wg.Go(func() {
 			ch := b.Subscribe()
 			time.Sleep(5 * time.Millisecond)
 			b.Unsubscribe(ch)
-		}()
+		})
 	}
 
 	wg.Wait()

--- a/internal/failover/cache_test.go
+++ b/internal/failover/cache_test.go
@@ -496,7 +496,7 @@ func TestCacheFailoverGroup_ConcurrentAccess(t *testing.T) {
 	errors := make(chan error, 50)
 
 	// Concurrent writes
-	for i := 0; i < 25; i++ {
+	for i := range 25 {
 		wg.Add(1)
 		go func(_ int) {
 			defer wg.Done()
@@ -511,12 +511,10 @@ func TestCacheFailoverGroup_ConcurrentAccess(t *testing.T) {
 	}
 
 	// Concurrent reads
-	for i := 0; i < 25; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range 25 {
+		wg.Go(func() {
 			_, _ = GetCachedFailoverByModel("concurrent-model")
-		}()
+		})
 	}
 
 	wg.Wait()
@@ -541,19 +539,15 @@ func TestInvalidateFailoverCache_ConcurrentWithReads(t *testing.T) {
 	var wg sync.WaitGroup
 	errors := make(chan error, 50)
 
-	for i := 0; i < 25; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range 25 {
+		wg.Go(func() {
 			_, _ = GetCachedFailoverByModel("concurrent-invalidate")
-		}()
+		})
 	}
-	for i := 0; i < 25; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range 25 {
+		wg.Go(func() {
 			InvalidateFailoverCache()
-		}()
+		})
 	}
 
 	wg.Wait()

--- a/internal/failover/circuitbreaker.go
+++ b/internal/failover/circuitbreaker.go
@@ -229,7 +229,7 @@ func (cb *CircuitBreaker) publishEvent(providerID uuid.UUID, providerName, state
 		Severity: cb.severityForState(state),
 		Source:   "failover",
 		Message:  fmt.Sprintf("Provider %s circuit breaker: %s", providerName, state),
-		Metadata: map[string]interface{}{
+		Metadata: map[string]any{
 			"provider_id":       providerID.String(),
 			"provider":          providerName,
 			"state":             state,

--- a/internal/failover/circuitbreaker_404_test.go
+++ b/internal/failover/circuitbreaker_404_test.go
@@ -18,7 +18,7 @@ func TestCircuitBreaker_NoOpPreservesFailureHistory(t *testing.T) {
 	pid := uuid.New()
 
 	// 4 × RecordFailure (simulating 5xx responses)
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		cb.RecordFailure(pid, "test-provider")
 	}
 
@@ -88,7 +88,7 @@ func TestCircuitBreaker_RecordSuccessResetsFailures(t *testing.T) {
 	pid := uuid.New()
 
 	// 4 × RecordFailure (5xx)
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		cb.RecordFailure(pid, "test-provider")
 	}
 
@@ -96,7 +96,7 @@ func TestCircuitBreaker_RecordSuccessResetsFailures(t *testing.T) {
 	cb.RecordSuccess(pid, "test-provider")
 
 	// Counter was reset to 0 — need 5 MORE failures to open
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		cb.RecordFailure(pid, "test-provider")
 	}
 	if cb.IsOpen(pid, "test-provider") {

--- a/internal/failover/circuitbreaker_test.go
+++ b/internal/failover/circuitbreaker_test.go
@@ -55,13 +55,13 @@ func TestCircuitBreaker_SuccessResetsFailures(t *testing.T) {
 	cb := newTestCB(5, 30*time.Second)
 	pid := uuid.New()
 
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		cb.RecordFailure(pid, "test-provider")
 	}
 	cb.RecordSuccess(pid, "test-provider") // resets counter
 
 	// Need 5 more failures to open
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		cb.RecordFailure(pid, "test-provider")
 	}
 	if cb.IsOpen(pid, "test-provider") {
@@ -216,7 +216,7 @@ func TestCircuitBreaker_Concurrent(t *testing.T) {
 	pid := uuid.New()
 
 	var wg sync.WaitGroup
-	for i := 0; i < 50; i++ {
+	for range 50 {
 		wg.Add(2)
 		go func() {
 			defer wg.Done()
@@ -255,7 +255,7 @@ func TestCircuitBreaker_FailureCountAccuracy(t *testing.T) {
 	cb := newTestCB(5, 30*time.Second)
 	pid := uuid.New()
 
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		cb.RecordFailure(pid, "test-provider")
 	}
 	statuses := cb.Status()
@@ -376,7 +376,7 @@ func TestCircuitBreaker_NilSettingsUsesDefaults(t *testing.T) {
 	pid := uuid.New()
 
 	// With nil settings, effective methods should return struct defaults.
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		cb.RecordFailure(pid, "test-provider")
 	}
 	if cb.IsOpen(pid, "test-provider") {
@@ -498,12 +498,10 @@ func TestCircuitBreaker_IsOpen_HalfOpenAllowsProbesConcurrently(t *testing.T) {
 
 	var wg sync.WaitGroup
 	results := make(chan bool, 20)
-	for i := 0; i < 20; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range 20 {
+		wg.Go(func() {
 			results <- cb.IsOpen(pid, "test-provider")
-		}()
+		})
 	}
 	wg.Wait()
 	close(results)
@@ -521,18 +519,16 @@ func TestCircuitBreaker_IsOpen_Concurrent(t *testing.T) {
 	pid := uuid.New()
 
 	// Pre-populate with some failures but not enough to open
-	for i := 0; i < 50; i++ {
+	for range 50 {
 		cb.RecordFailure(pid, "test-provider")
 	}
 
 	var wg sync.WaitGroup
 	isOpenResults := make(chan bool, 100)
-	for i := 0; i < 50; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range 50 {
+		wg.Go(func() {
 			isOpenResults <- cb.IsOpen(pid, "test-provider")
-		}()
+		})
 	}
 	wg.Wait()
 	close(isOpenResults)
@@ -589,7 +585,7 @@ func TestCircuitBreaker_IsOpen_RaceWithRecordSuccess(t *testing.T) {
 
 	var wg sync.WaitGroup
 	errCh := make(chan error, 20)
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		wg.Add(2)
 		go func() {
 			defer wg.Done()
@@ -812,16 +808,14 @@ func TestGetState_ConcurrentReads(t *testing.T) {
 	pid := uuid.New()
 
 	// Pre-populate with some failures
-	for i := 0; i < 50; i++ {
+	for range 50 {
 		cb.RecordFailure(pid, "test-provider")
 	}
 
 	var wg sync.WaitGroup
 	errCh := make(chan error, 100)
-	for i := 0; i < 100; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range 100 {
+		wg.Go(func() {
 			defer func() {
 				if r := recover(); r != nil {
 					errCh <- fmt.Errorf("panic in GetState: %v", r)
@@ -831,7 +825,7 @@ func TestGetState_ConcurrentReads(t *testing.T) {
 			if s != StateClosed && s != StateOpen {
 				errCh <- fmt.Errorf("unexpected state: %v", s)
 			}
-		}()
+		})
 	}
 	wg.Wait()
 	close(errCh)

--- a/internal/failover/errors_test.go
+++ b/internal/failover/errors_test.go
@@ -27,7 +27,7 @@ func TestGetByModel_UnmarshalPriorityError(t *testing.T) {
 	defer func() { jsonUnmarshal = origUnmarshal }()
 
 	callCount := 0
-	jsonUnmarshal = func(data []byte, v interface{}) error {
+	jsonUnmarshal = func(data []byte, v any) error {
 		callCount++
 		if callCount == 1 {
 			return fmt.Errorf("test unmarshal error")
@@ -61,7 +61,7 @@ func TestGetByModel_UnmarshalEntryEnabledError(t *testing.T) {
 	defer func() { jsonUnmarshal = origUnmarshal }()
 
 	callCount := 0
-	jsonUnmarshal = func(data []byte, v interface{}) error {
+	jsonUnmarshal = func(data []byte, v any) error {
 		callCount++
 		if callCount == 2 {
 			return fmt.Errorf("test unmarshal error")
@@ -91,7 +91,7 @@ func TestUpsertWithConfig_UnmarshalPriorityError(t *testing.T) {
 	defer func() { jsonUnmarshal = origUnmarshal }()
 
 	callCount := 0
-	jsonUnmarshal = func(data []byte, v interface{}) error {
+	jsonUnmarshal = func(data []byte, v any) error {
 		callCount++
 		if callCount == 1 {
 			return fmt.Errorf("test unmarshal error")
@@ -119,7 +119,7 @@ func TestUpsertWithConfig_UnmarshalEntryEnabledError(t *testing.T) {
 	defer func() { jsonUnmarshal = origUnmarshal }()
 
 	callCount := 0
-	jsonUnmarshal = func(data []byte, v interface{}) error {
+	jsonUnmarshal = func(data []byte, v any) error {
 		callCount++
 		if callCount == 2 {
 			return fmt.Errorf("test unmarshal error")
@@ -159,7 +159,7 @@ func TestGetByID_UnmarshalPriorityError(t *testing.T) {
 	defer func() { jsonUnmarshal = origUnmarshal }()
 
 	callCount := 0
-	jsonUnmarshal = func(data []byte, v interface{}) error {
+	jsonUnmarshal = func(data []byte, v any) error {
 		callCount++
 		if callCount == 1 {
 			return fmt.Errorf("test unmarshal error")
@@ -193,7 +193,7 @@ func TestGetByID_UnmarshalEntryEnabledError(t *testing.T) {
 	defer func() { jsonUnmarshal = origUnmarshal }()
 
 	callCount := 0
-	jsonUnmarshal = func(data []byte, v interface{}) error {
+	jsonUnmarshal = func(data []byte, v any) error {
 		callCount++
 		if callCount == 2 {
 			return fmt.Errorf("test unmarshal error")
@@ -231,7 +231,7 @@ func TestUpdate_UnmarshalPriorityError(t *testing.T) {
 	defer func() { jsonUnmarshal = origUnmarshal }()
 
 	callCount := 0
-	jsonUnmarshal = func(data []byte, v interface{}) error {
+	jsonUnmarshal = func(data []byte, v any) error {
 		callCount++
 		if callCount == 1 {
 			return fmt.Errorf("test unmarshal error")
@@ -265,7 +265,7 @@ func TestUpdate_UnmarshalEntryEnabledError(t *testing.T) {
 	defer func() { jsonUnmarshal = origUnmarshal }()
 
 	callCount := 0
-	jsonUnmarshal = func(data []byte, v interface{}) error {
+	jsonUnmarshal = func(data []byte, v any) error {
 		callCount++
 		if callCount == 2 {
 			return fmt.Errorf("test unmarshal error")
@@ -290,7 +290,7 @@ func TestUpsertWithConfig_MarshalPriorityError(t *testing.T) {
 	defer func() { jsonMarshal = origMarshal }()
 
 	callCount := 0
-	jsonMarshal = func(v interface{}) ([]byte, error) {
+	jsonMarshal = func(v any) ([]byte, error) {
 		callCount++
 		if callCount == 1 {
 			return nil, fmt.Errorf("test marshal error")
@@ -318,7 +318,7 @@ func TestUpsertWithConfig_MarshalEntryEnabledError(t *testing.T) {
 	defer func() { jsonMarshal = origMarshal }()
 
 	callCount := 0
-	jsonMarshal = func(v interface{}) ([]byte, error) {
+	jsonMarshal = func(v any) ([]byte, error) {
 		callCount++
 		if callCount == 2 {
 			return nil, fmt.Errorf("test marshal error")
@@ -358,7 +358,7 @@ func TestUpdate_MarshalPriorityError(t *testing.T) {
 	defer func() { jsonMarshal = origMarshal }()
 
 	callCount := 0
-	jsonMarshal = func(v interface{}) ([]byte, error) {
+	jsonMarshal = func(v any) ([]byte, error) {
 		callCount++
 		if callCount == 1 {
 			return nil, fmt.Errorf("test marshal error")
@@ -392,7 +392,7 @@ func TestUpdate_MarshalEntryEnabledError(t *testing.T) {
 	defer func() { jsonMarshal = origMarshal }()
 
 	callCount := 0
-	jsonMarshal = func(v interface{}) ([]byte, error) {
+	jsonMarshal = func(v any) ([]byte, error) {
 		callCount++
 		if callCount == 2 {
 			return nil, fmt.Errorf("test marshal error")

--- a/internal/failover/failover.go
+++ b/internal/failover/failover.go
@@ -490,7 +490,7 @@ func (r *Repository) Update(ctx context.Context, id uuid.UUID, priorityOrder []u
 	}
 
 	var setClauses []string
-	var args []interface{}
+	var args []any
 	argIdx := 2 // $1 is reserved for id
 
 	setClauses = append(setClauses, fmt.Sprintf("priority_order = $%d", argIdx))
@@ -529,7 +529,7 @@ func (r *Repository) Update(ctx context.Context, id uuid.UUID, priorityOrder []u
 
 	setClauses = append(setClauses, "updated_at = now()")
 
-	args = append([]interface{}{id}, args...)
+	args = append([]any{id}, args...)
 
 	query := fmt.Sprintf(`UPDATE model_failover_groups SET %s WHERE id = $1
 		RETURNING id, display_model, COALESCE(display_name, ''), COALESCE(description, ''), priority_order,

--- a/internal/failover/repository_syncall_test.go
+++ b/internal/failover/repository_syncall_test.go
@@ -1470,7 +1470,7 @@ func TestSyncAllModels_UpsertError(t *testing.T) {
 	defer func() { jsonMarshal = origMarshal }()
 
 	callCount := 0
-	jsonMarshal = func(v interface{}) ([]byte, error) {
+	jsonMarshal = func(v any) ([]byte, error) {
 		callCount++
 		if callCount == 1 {
 			return nil, fmt.Errorf("test marshal error")

--- a/internal/failover/repository_test.go
+++ b/internal/failover/repository_test.go
@@ -977,7 +977,7 @@ func TestSyncForModel_UpsertError(t *testing.T) {
 	defer func() { jsonMarshal = origMarshal }()
 
 	callCount := 0
-	jsonMarshal = func(v interface{}) ([]byte, error) {
+	jsonMarshal = func(v any) ([]byte, error) {
 		callCount++
 		if callCount == 1 {
 			return nil, fmt.Errorf("test marshal error")

--- a/internal/failover/scan_test.go
+++ b/internal/failover/scan_test.go
@@ -80,8 +80,6 @@ func (m *mockFailoverRows) Conn() *pgx.Conn { return nil }
 // helpers
 // ---------------------------------------------------------------------------
 
-func strPtr(s string) *string { return &s }
-
 func mustUUID(s string) uuid.UUID { return uuid.MustParse(s) }
 
 // ---------------------------------------------------------------------------
@@ -90,7 +88,7 @@ func mustUUID(s string) uuid.UUID { return uuid.MustParse(s) }
 
 func TestScanFailoverGroups_SingleRow(t *testing.T) {
 	id1 := mustUUID("11111111-1111-1111-1111-111111111111")
-	displayName := strPtr("Test Group")
+	displayName := new("Test Group")
 	priority := []uuid.UUID{
 		mustUUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
 		mustUUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
@@ -194,8 +192,8 @@ func TestScanFailoverGroups_MultipleRows(t *testing.T) {
 
 	rows := &mockFailoverRows{
 		rows: [][]any{
-			{id1, "model-a", strPtr("A"), "desc a", emptyPriority, emptyEntry, true, false, now, now},
-			{id2, "model-b", strPtr("B"), "desc b", emptyPriority, emptyEntry, false, true, now, now},
+			{id1, "model-a", new("A"), "desc a", emptyPriority, emptyEntry, true, false, now, now},
+			{id2, "model-b", new("B"), "desc b", emptyPriority, emptyEntry, false, true, now, now},
 		},
 		scanErrOn: -1,
 	}
@@ -257,7 +255,7 @@ func TestScanFailoverGroups_ScanError(t *testing.T) {
 
 	rows := &mockFailoverRows{
 		rows: [][]any{
-			{id1, "model-a", strPtr("A"), "desc", []byte(`[]`), []byte(`{}`), true, false, now, now},
+			{id1, "model-a", new("A"), "desc", []byte(`[]`), []byte(`{}`), true, false, now, now},
 		},
 		scanErrOn: 0,
 	}
@@ -285,7 +283,7 @@ func TestScanFailoverGroups_InvalidPriorityJSON(t *testing.T) {
 
 	rows := &mockFailoverRows{
 		rows: [][]any{
-			{id1, "model-a", strPtr("A"), "desc", []byte(`{invalid`), []byte(`{}`), true, false, now, now},
+			{id1, "model-a", new("A"), "desc", []byte(`{invalid`), []byte(`{}`), true, false, now, now},
 		},
 		scanErrOn: -1,
 	}
@@ -313,7 +311,7 @@ func TestScanFailoverGroups_InvalidEntryEnabledJSON(t *testing.T) {
 
 	rows := &mockFailoverRows{
 		rows: [][]any{
-			{id1, "model-a", strPtr("A"), "desc", []byte(`[]`), []byte(`{invalid`), true, false, now, now},
+			{id1, "model-a", new("A"), "desc", []byte(`[]`), []byte(`{invalid`), true, false, now, now},
 		},
 		scanErrOn: -1,
 	}
@@ -391,7 +389,7 @@ func TestScanFailoverGroups_EmptyPriorityAndEntryEnabled(t *testing.T) {
 
 	rows := &mockFailoverRows{
 		rows: [][]any{
-			{id1, "empty-group", strPtr("Empty"), "", []byte(`[]`), []byte(`{}`), true, false, now, now},
+			{id1, "empty-group", new("Empty"), "", []byte(`[]`), []byte(`{}`), true, false, now, now},
 		},
 		scanErrOn: -1,
 	}
@@ -421,7 +419,7 @@ func TestScanFailoverGroups_GroupEnabledFalse(t *testing.T) {
 
 	rows := &mockFailoverRows{
 		rows: [][]any{
-			{id1, "disabled-group", strPtr("Disabled"), "", []byte(`[]`), []byte(`{}`), false, true, now, now},
+			{id1, "disabled-group", new("Disabled"), "", []byte(`[]`), []byte(`{}`), false, true, now, now},
 		},
 		scanErrOn: -1,
 	}
@@ -461,7 +459,7 @@ func TestScanFailoverGroups_EntryEnabledPreservesValues(t *testing.T) {
 
 	rows := &mockFailoverRows{
 		rows: [][]any{
-			{id1, "mixed-entries", strPtr("Mixed"), "", priorityJSON, entryEnabledJSON, true, false, now, now},
+			{id1, "mixed-entries", new("Mixed"), "", priorityJSON, entryEnabledJSON, true, false, now, now},
 		},
 		scanErrOn: -1,
 	}

--- a/internal/frontdesk/autosync_test.go
+++ b/internal/frontdesk/autosync_test.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -50,7 +49,7 @@ func newStubAutoMember(t *testing.T, token string) *stubAutoMember {
 	t.Helper()
 	sm := &stubAutoMember{
 		token:       token,
-		instanceID:  fmt.Sprintf("iid-auto-%d", atomic.AddInt32(&memberServerSeq, 1)),
+		instanceID:  fmt.Sprintf("iid-auto-%d", memberServerSeq.Add(1)),
 		versionHash: "hash-A",
 		exportBody:  fleetExportWithKey,
 		dryDiff:     `{"providers":{},"virtual_keys":{},"settings":{}}`, // converged

--- a/internal/frontdesk/configsync_test.go
+++ b/internal/frontdesk/configsync_test.go
@@ -461,7 +461,7 @@ func configSyncCount(t *testing.T, srv *Server, result string) float64 {
 	t.Helper()
 	prefix := `frontdesk_config_sync_total{result="` + result + `"} `
 	body := scrape(t, srv, testFrontdeskToken).Body.String()
-	for _, line := range strings.Split(body, "\n") {
+	for line := range strings.SplitSeq(body, "\n") {
 		if rest, ok := strings.CutPrefix(line, prefix); ok {
 			v, err := strconv.ParseFloat(strings.TrimSpace(rest), 64)
 			if err != nil {

--- a/internal/frontdesk/fleetstate.go
+++ b/internal/frontdesk/fleetstate.go
@@ -3,6 +3,7 @@ package frontdesk
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strings"
 	"time"
 
@@ -169,9 +170,7 @@ func (s *Server) heldSnapshot() map[string]bool {
 	s.syncHeldMu.Lock()
 	defer s.syncHeldMu.Unlock()
 	out := make(map[string]bool, len(s.syncHeld))
-	for k, v := range s.syncHeld {
-		out[k] = v
-	}
+	maps.Copy(out, s.syncHeld)
 	return out
 }
 

--- a/internal/frontdesk/fleetstatus_test.go
+++ b/internal/frontdesk/fleetstatus_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http/httptest"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"testing"
 )
 
@@ -37,7 +36,7 @@ func newStubFleetMember(t *testing.T, token string) *stubFleetMember {
 	t.Helper()
 	sm := &stubFleetMember{
 		token:      token,
-		instanceID: fmt.Sprintf("iid-stub-%d", atomic.AddInt32(&memberServerSeq, 1)),
+		instanceID: fmt.Sprintf("iid-stub-%d", memberServerSeq.Add(1)),
 		exportBody: fleetExportWithKey,
 		importCode: http.StatusOK,
 		importBody: importOK,

--- a/internal/frontdesk/metrics_test.go
+++ b/internal/frontdesk/metrics_test.go
@@ -162,7 +162,7 @@ func TestMetricsScrapeMemberSeries(t *testing.T) {
 // seriesValue extracts and parses one series' value from a text-format scrape.
 func seriesValue(t *testing.T, body, series string) float64 {
 	t.Helper()
-	for _, line := range strings.Split(body, "\n") {
+	for line := range strings.SplitSeq(body, "\n") {
 		if rest, found := strings.CutPrefix(line, series+" "); found {
 			v, err := strconv.ParseFloat(strings.TrimSpace(rest), 64)
 			if err != nil {

--- a/internal/frontdesk/poller.go
+++ b/internal/frontdesk/poller.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"strings"
 	"sync"
@@ -136,9 +137,7 @@ func (p *Poller) Snapshot() map[string]MemberStatus {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 	out := make(map[string]MemberStatus, len(p.statuses))
-	for k, v := range p.statuses {
-		out[k] = v
-	}
+	maps.Copy(out, p.statuses)
 	return out
 }
 

--- a/internal/frontdesk/server_settings.go
+++ b/internal/frontdesk/server_settings.go
@@ -363,12 +363,10 @@ func (s *Server) putAutoSync(w http.ResponseWriter, r *http.Request) {
 	// steady-state watch. Disabling (or no primary) never kicks.
 	if status.Enabled && status.PrimaryID != "" {
 		kickCtx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), autoSyncKickTimeout)
-		s.bgWG.Add(1)
-		go func() {
-			defer s.bgWG.Done()
+		s.bgWG.Go(func() {
 			defer cancel()
 			s.forceAutoSyncNow(kickCtx)
-		}()
+		})
 	}
 	writeJSON(w, http.StatusOK, status)
 }

--- a/internal/frontdesk/server_status.go
+++ b/internal/frontdesk/server_status.go
@@ -3,6 +3,7 @@ package frontdesk
 import (
 	"context"
 	"encoding/json"
+	"maps"
 	"net/http"
 	"sync/atomic"
 	"time"
@@ -188,9 +189,7 @@ func busEvent(e Event) events.Event {
 	meta := e.Metadata
 	if e.MemberID != "" {
 		meta = make(map[string]any, len(e.Metadata)+1)
-		for k, v := range e.Metadata {
-			meta[k] = v
-		}
+		maps.Copy(meta, e.Metadata)
 		meta["member_id"] = e.MemberID
 	}
 	return events.Event{

--- a/internal/frontdesk/server_test.go
+++ b/internal/frontdesk/server_test.go
@@ -22,7 +22,7 @@ import (
 
 const testFrontdeskToken = "test-frontdesk-token"
 
-var memberServerSeq int32
+var memberServerSeq atomic.Int32
 
 // systemMemberServer stands in for a member instance: it answers GET
 // /api/system/ with a fleet block reporting the given is_primary plus a unique
@@ -32,7 +32,7 @@ var memberServerSeq int32
 // look like two different hosts unless you use systemMemberServerID.
 func systemMemberServer(t *testing.T, selfReportsPrimary bool) *httptest.Server {
 	t.Helper()
-	id := fmt.Sprintf("iid-%d", atomic.AddInt32(&memberServerSeq, 1))
+	id := fmt.Sprintf("iid-%d", memberServerSeq.Add(1))
 	return systemMemberServerID(t, selfReportsPrimary, id)
 }
 

--- a/internal/frontdesk/store_test.go
+++ b/internal/frontdesk/store_test.go
@@ -386,7 +386,7 @@ func TestNewestEventPerMember(t *testing.T) {
 func TestEventsPagination(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		_, _ = s.InsertEvent(ctx, Event{Type: "t", Severity: "info", Source: "x", Message: "m"})
 	}
 	page, total, _ := s.ListEvents(ctx, EventFilter{Limit: 2, Offset: 0})

--- a/internal/model/cache_test.go
+++ b/internal/model/cache_test.go
@@ -613,25 +613,21 @@ func TestCacheModelByUUID_ConcurrentAccess(t *testing.T) {
 	errors := make(chan error, 50)
 
 	// Concurrent writes
-	for i := 0; i < 25; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range 25 {
+		wg.Go(func() {
 			m := &Model{
 				ID:      uuid.New(),
 				ModelID: "concurrent-model",
 			}
 			cacheModelByUUID(m)
-		}()
+		})
 	}
 
 	// Concurrent reads
-	for i := 0; i < 25; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range 25 {
+		wg.Go(func() {
 			_, _ = GetCachedByUUID(uuid.New())
-		}()
+		})
 	}
 
 	wg.Wait()
@@ -655,19 +651,15 @@ func TestInvalidateModelCache_ConcurrentWithReads(t *testing.T) {
 	var wg sync.WaitGroup
 	errors := make(chan error, 50)
 
-	for i := 0; i < 25; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range 25 {
+		wg.Go(func() {
 			_, _ = GetCachedByUUID(id)
-		}()
+		})
 	}
-	for i := 0; i < 25; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range 25 {
+		wg.Go(func() {
 			InvalidateModelCache()
-		}()
+		})
 	}
 
 	wg.Wait()

--- a/internal/model/livemeta_test.go
+++ b/internal/model/livemeta_test.go
@@ -9,11 +9,11 @@ import "testing"
 func TestMarkLiveMetaFromCurrent(t *testing.T) {
 	t.Run("all fields set flags every meta bit", func(t *testing.T) {
 		m := &Model{
-			InputPricePerMillion:         float64Ptr(1),
-			InputPricePerMillionCacheHit: float64Ptr(0.5),
-			OutputPricePerMillion:        float64Ptr(2),
-			ContextLength:                intPtr(8192),
-			MaxOutputTokens:              intPtr(4096),
+			InputPricePerMillion:         new(float64(1)),
+			InputPricePerMillionCacheHit: new(0.5),
+			OutputPricePerMillion:        new(float64(2)),
+			ContextLength:                new(8192),
+			MaxOutputTokens:              new(4096),
 		}
 		m.MarkLiveMetaFromCurrent()
 
@@ -41,8 +41,8 @@ func TestMarkLiveMetaFromCurrent(t *testing.T) {
 		// Live payload carried a price and context length but no cache-hit price
 		// or max-output cap. Only the two present fields may be flagged live.
 		m := &Model{
-			InputPricePerMillion: float64Ptr(3),
-			ContextLength:        intPtr(32768),
+			InputPricePerMillion: new(float64(3)),
+			ContextLength:        new(32768),
 		}
 		m.MarkLiveMetaFromCurrent()
 
@@ -66,7 +66,7 @@ func TestMarkLiveMetaFromCurrent(t *testing.T) {
 	t.Run("recomputes from current state, clearing stale flags", func(t *testing.T) {
 		// A field that was live earlier but is now nil must be un-flagged: the
 		// method is a full recompute, not an additive merge.
-		m := &Model{InputPricePerMillion: float64Ptr(1)}
+		m := &Model{InputPricePerMillion: new(float64(1))}
 		m.MarkLiveMetaFromCurrent()
 		if !m.LiveMeta.InputPrice {
 			t.Fatal("precondition: InputPrice should be live")

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -449,7 +449,7 @@ type UpdateModelRequest struct {
 // Update applies partial updates to a model.
 func (r *Repository) Update(ctx context.Context, id uuid.UUID, req UpdateModelRequest) (*Model, error) {
 	var setClauses []string
-	var args []interface{}
+	var args []any
 	argIdx := 2 // $1 is reserved for id
 
 	if req.DisplayName != nil {
@@ -497,7 +497,7 @@ func (r *Repository) Update(ctx context.Context, id uuid.UUID, req UpdateModelRe
 		return r.Get(ctx, id)
 	}
 
-	args = append([]interface{}{id}, args...)
+	args = append([]any{id}, args...)
 
 	query := fmt.Sprintf("UPDATE models SET %s WHERE id = $1", strings.Join(setClauses, ", "))
 

--- a/internal/model/model_crud_test.go
+++ b/internal/model/model_crud_test.go
@@ -7,14 +7,6 @@ import (
 	"github.com/google/uuid"
 )
 
-func strPtr(s string) *string {
-	return &s
-}
-
-func boolPtr(b bool) *bool {
-	return &b
-}
-
 // ---------------------------------------------------------------------------
 // TestUpsert
 // ---------------------------------------------------------------------------
@@ -186,7 +178,7 @@ func TestUpsert_PreservesCustomDisplayName(t *testing.T) {
 
 	// User customizes display_name via Update
 	_, err = repo.Update(ctx, model.ID, UpdateModelRequest{
-		DisplayName: strPtr("short-name"),
+		DisplayName: new("short-name"),
 	})
 	if err != nil {
 		t.Fatalf("update display_name failed: %v", err)
@@ -879,12 +871,12 @@ func TestUpdate_AllFields(t *testing.T) {
 
 	// Update all fields
 	updated, err := repo.Update(ctx, modelID, UpdateModelRequest{
-		DisplayName:           strPtr("Updated Display Name"),
-		ContextLength:         intPtr(8192),
-		MaxOutputTokens:       intPtr(1024),
-		InputPricePerMillion:  float64Ptr(0.5),
-		OutputPricePerMillion: float64Ptr(1.5),
-		Enabled:               boolPtr(true),
+		DisplayName:           new("Updated Display Name"),
+		ContextLength:         new(8192),
+		MaxOutputTokens:       new(1024),
+		InputPricePerMillion:  new(0.5),
+		OutputPricePerMillion: new(1.5),
+		Enabled:               new(true),
 	})
 	if err != nil {
 		t.Fatalf("Update failed: %v", err)
@@ -954,7 +946,7 @@ func TestUpdate_SingleField_DisplayName(t *testing.T) {
 
 	// Update only DisplayName
 	updated, err := repo.Update(ctx, modelID, UpdateModelRequest{
-		DisplayName: strPtr("Only Display Name Updated"),
+		DisplayName: new("Only Display Name Updated"),
 	})
 	if err != nil {
 		t.Fatalf("Update failed: %v", err)
@@ -981,7 +973,7 @@ func TestUpdate_EnabledFalse(t *testing.T) {
 
 	// Update to set Enabled to false
 	updated, err := repo.Update(ctx, modelID, UpdateModelRequest{
-		Enabled: boolPtr(false),
+		Enabled: new(false),
 	})
 	if err != nil {
 		t.Fatalf("Update failed: %v", err)
@@ -1011,7 +1003,7 @@ func TestUpdate_NotFound(t *testing.T) {
 	// Try to update non-existent model
 	nonExistentID := uuid.New()
 	updated, err := repo.Update(ctx, nonExistentID, UpdateModelRequest{
-		DisplayName: strPtr("Should Not Be Set"),
+		DisplayName: new("Should Not Be Set"),
 	})
 
 	// Should return error from Get

--- a/internal/model/model_upsert_test.go
+++ b/internal/model/model_upsert_test.go
@@ -8,9 +8,6 @@ import (
 	"github.com/google/uuid"
 )
 
-func f64(v float64) *float64 { return &v }
-func i(v int) *int           { return &v }
-
 // newBareModel builds a Model with valid-JSON defaults for the JSON columns
 // (capabilities/params/modalities), which Upsert writes verbatim.
 func newBareModel(providerID uuid.UUID, modelID string) *Model {
@@ -37,11 +34,11 @@ func TestUpsert_PreservesMetadataOnNullRescan(t *testing.T) {
 	t.Cleanup(func() { cleanupProvider(ctx, t, providerID) })
 
 	base := newBareModel(providerID, "preserve-me")
-	base.ContextLength = i(200000)
-	base.MaxOutputTokens = i(131072)
-	base.InputPricePerMillion = f64(1.4)
-	base.InputPricePerMillionCacheHit = f64(0.26)
-	base.OutputPricePerMillion = f64(4.4)
+	base.ContextLength = new(200000)
+	base.MaxOutputTokens = new(131072)
+	base.InputPricePerMillion = new(1.4)
+	base.InputPricePerMillionCacheHit = new(0.26)
+	base.OutputPricePerMillion = new(4.4)
 	if err := repo.Upsert(ctx, base); err != nil {
 		t.Fatalf("initial upsert: %v", err)
 	}
@@ -65,7 +62,7 @@ func TestUpsert_PreservesMetadataOnNullRescan(t *testing.T) {
 	// value, so a catalog/models.dev value can't flip a provider value across
 	// restarts (the source-oscillation fix).
 	nonLive := newBareModel(providerID, "preserve-me")
-	nonLive.InputPricePerMillion = f64(0.5) // LiveMeta zero value => fill-only
+	nonLive.InputPricePerMillion = new(0.5) // LiveMeta zero value => fill-only
 	if err := repo.Upsert(ctx, nonLive); err != nil {
 		t.Fatalf("non-live update upsert: %v", err)
 	}
@@ -78,7 +75,7 @@ func TestUpsert_PreservesMetadataOnNullRescan(t *testing.T) {
 	// A live rescan value overwrites: a genuine provider-reported change
 	// propagates to the stored (and served) metadata.
 	live := newBareModel(providerID, "preserve-me")
-	live.InputPricePerMillion = f64(0.5)
+	live.InputPricePerMillion = new(0.5)
 	live.LiveMeta.InputPrice = true
 	if err := repo.Upsert(ctx, live); err != nil {
 		t.Fatalf("live update upsert: %v", err)

--- a/internal/model/scan_test.go
+++ b/internal/model/scan_test.go
@@ -183,11 +183,11 @@ func TestScanModels_SingleRow(t *testing.T) {
 		Modality:                     "text",
 		InputModalities:              "[\"text\"]",
 		OutputModalities:             "[\"text\"]",
-		ContextLength:                intPtr(128000),
-		MaxOutputTokens:              intPtr(4096),
-		InputPricePerMillion:         float64Ptr(10.0),
-		InputPricePerMillionCacheHit: float64Ptr(5.0),
-		OutputPricePerMillion:        float64Ptr(30.0),
+		ContextLength:                new(128000),
+		MaxOutputTokens:              new(4096),
+		InputPricePerMillion:         new(10.0),
+		InputPricePerMillionCacheHit: new(5.0),
+		OutputPricePerMillion:        new(30.0),
 		OwnedBy:                      "openai",
 		Enabled:                      true,
 		DisabledManually:             false,
@@ -395,14 +395,6 @@ func TestScanModels_NilableFields(t *testing.T) {
 // ---------------------------------------------------------------------------
 // helpers
 // ---------------------------------------------------------------------------
-
-func intPtr(v int) *int {
-	return &v
-}
-
-func float64Ptr(v float64) *float64 {
-	return &v
-}
 
 func assertModelEqual(t *testing.T, expected, got *Model) {
 	t.Helper()

--- a/internal/otelexport/otelexport.go
+++ b/internal/otelexport/otelexport.go
@@ -98,7 +98,7 @@ func serviceResource(serviceName string) *resource.Resource {
 // the key exactly, so a different key that merely contains the text — notably the
 // standard service.namespace — does not false-positive and suppress our default.
 func resourceAttrsHaveServiceName() bool {
-	for _, kv := range strings.Split(os.Getenv("OTEL_RESOURCE_ATTRIBUTES"), ",") {
+	for kv := range strings.SplitSeq(os.Getenv("OTEL_RESOURCE_ATTRIBUTES"), ",") {
 		if key, _, ok := strings.Cut(kv, "="); ok && strings.TrimSpace(key) == "service.name" {
 			return true
 		}

--- a/internal/paramrewrite/build.go
+++ b/internal/paramrewrite/build.go
@@ -3,6 +3,7 @@ package paramrewrite
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"sync"
 
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
@@ -58,7 +59,7 @@ func BuildUpstreamBody(
 	renameCache *sync.Map,
 	extraStrip map[string]bool,
 ) []byte {
-	var raw map[string]interface{}
+	var raw map[string]any
 	if err := json.Unmarshal(proxyReqBody, &raw); err != nil {
 		return proxyReqBody // unparseable — forward as-is
 	}
@@ -70,7 +71,7 @@ func BuildUpstreamBody(
 
 	// 2. stream_options injection
 	if isStreaming && ProviderSupportsStreamOptions(providerType) {
-		raw["stream_options"] = map[string]interface{}{
+		raw["stream_options"] = map[string]any{
 			"include_usage": true,
 		}
 	}
@@ -132,17 +133,17 @@ func BuildUpstreamBody(
 // OpenCode Zen) reject the whole request with a 400, permanently bricking any
 // conversation that has such a turn in its history. No provider needs the
 // empty array, so dropping it is always safe.
-func stripEmptyToolCalls(raw map[string]interface{}) {
-	msgs, ok := raw["messages"].([]interface{})
+func stripEmptyToolCalls(raw map[string]any) {
+	msgs, ok := raw["messages"].([]any)
 	if !ok {
 		return
 	}
 	for _, m := range msgs {
-		msg, ok := m.(map[string]interface{})
+		msg, ok := m.(map[string]any)
 		if !ok {
 			continue
 		}
-		if tc, ok := msg["tool_calls"].([]interface{}); ok && len(tc) == 0 {
+		if tc, ok := msg["tool_calls"].([]any); ok && len(tc) == 0 {
 			delete(msg, "tool_calls")
 		}
 	}
@@ -164,12 +165,8 @@ func MergeLearnedParamCache[V any](cache *sync.Map, key string, learned map[stri
 			return
 		}
 		merged := make(map[string]V, len(*existingMap)+len(learned))
-		for k, v := range *existingMap {
-			merged[k] = v
-		}
-		for k, v := range learned {
-			merged[k] = v
-		}
+		maps.Copy(merged, *existingMap)
+		maps.Copy(merged, learned)
 		if cache.CompareAndSwap(key, existing, &merged) {
 			return
 		}

--- a/internal/paramrewrite/build_upstream_body_test.go
+++ b/internal/paramrewrite/build_upstream_body_test.go
@@ -72,7 +72,7 @@ func TestBuildUpstreamBody(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := BuildUpstreamBody([]byte(inputBody), tt.providerType, tt.wantModel, "gpt-4", tt.isStreaming, cache, &sync.Map{}, tt.extraStrip)
 
-			var raw map[string]interface{}
+			var raw map[string]any
 			if err := json.Unmarshal(result, &raw); err != nil {
 				t.Fatalf("result is not valid JSON: %v", err)
 			}
@@ -88,7 +88,7 @@ func TestBuildUpstreamBody(t *testing.T) {
 				t.Errorf("stream_options present = %v, want %v", hasOpts, tt.wantStreamOpts)
 			}
 			if hasOpts {
-				opts, ok := raw["stream_options"].(map[string]interface{})
+				opts, ok := raw["stream_options"].(map[string]any)
 				if !ok {
 					t.Error("stream_options is not a map")
 				} else if opts["include_usage"] != true {
@@ -120,7 +120,7 @@ func TestBuildUpstreamBody_ExtraStripOnRetry(t *testing.T) {
 		map[string]bool{"min_p": true}, // extra strip from 400 auto-retry
 	)
 
-	var raw map[string]interface{}
+	var raw map[string]any
 	if err := json.Unmarshal(result, &raw); err != nil {
 		t.Fatalf("result is not valid JSON: %v", err)
 	}
@@ -153,7 +153,7 @@ func TestBuildUpstreamBody_OpenCodeInjectsChatTemplateArgs(t *testing.T) {
 
 	result := BuildUpstreamBody([]byte(inputBody), "opencode-go", "glm-5.2", "glm-5.2", false, cache, &sync.Map{}, nil)
 
-	var raw map[string]interface{}
+	var raw map[string]any
 	if err := json.Unmarshal(result, &raw); err != nil {
 		t.Fatalf("result is not valid JSON: %v", err)
 	}
@@ -176,7 +176,7 @@ func TestBuildUpstreamBody_LearnedChatTemplateArgsRejectionStays(t *testing.T) {
 
 	result := BuildUpstreamBody([]byte(inputBody), "opencode-go", "glm-5.2", "glm-5.2", false, cache, &sync.Map{}, nil)
 
-	var raw map[string]interface{}
+	var raw map[string]any
 	if err := json.Unmarshal(result, &raw); err != nil {
 		t.Fatalf("result is not valid JSON: %v", err)
 	}
@@ -198,7 +198,7 @@ func TestBuildUpstreamBody_ExtraStripChatTemplateArgsOnRetry(t *testing.T) {
 		map[string]bool{"chat_template_args": true},
 	)
 
-	var raw map[string]interface{}
+	var raw map[string]any
 	if err := json.Unmarshal(result, &raw); err != nil {
 		t.Fatalf("result is not valid JSON: %v", err)
 	}
@@ -222,7 +222,7 @@ func TestBuildUpstreamBody_LearnedRenameMovesValue(t *testing.T) {
 
 	result := BuildUpstreamBody([]byte(inputBody), "openai", "gpt-5-nano", "gpt-5-nano", false, &sync.Map{}, renameCache, nil)
 
-	var raw map[string]interface{}
+	var raw map[string]any
 	if err := json.Unmarshal(result, &raw); err != nil {
 		t.Fatalf("result is not valid JSON: %v", err)
 	}
@@ -248,7 +248,7 @@ func TestBuildUpstreamBody_RenameDoesNotOverwriteExplicitTarget(t *testing.T) {
 
 	result := BuildUpstreamBody([]byte(inputBody), "openai", "gpt-5-nano", "gpt-5-nano", false, &sync.Map{}, renameCache, nil)
 
-	var raw map[string]interface{}
+	var raw map[string]any
 	if err := json.Unmarshal(result, &raw); err != nil {
 		t.Fatalf("result is not valid JSON: %v", err)
 	}
@@ -272,7 +272,7 @@ func TestBuildUpstreamBody_NoRenameWhenSourceAbsent(t *testing.T) {
 
 	result := BuildUpstreamBody([]byte(inputBody), "openai", "gpt-5-nano", "gpt-5-nano", false, &sync.Map{}, renameCache, nil)
 
-	var raw map[string]interface{}
+	var raw map[string]any
 	if err := json.Unmarshal(result, &raw); err != nil {
 		t.Fatalf("result is not valid JSON: %v", err)
 	}
@@ -302,16 +302,16 @@ func TestBuildUpstreamBody_StripsEmptyToolCalls(t *testing.T) {
 
 	result := BuildUpstreamBody([]byte(inputBody), "openai", "gpt-4o", "gpt-4", false, &sync.Map{}, &sync.Map{}, nil)
 
-	var raw map[string]interface{}
+	var raw map[string]any
 	if err := json.Unmarshal(result, &raw); err != nil {
 		t.Fatalf("result is not valid JSON: %v", err)
 	}
-	msgs, ok := raw["messages"].([]interface{})
+	msgs, ok := raw["messages"].([]any)
 	if !ok || len(msgs) != 4 {
 		t.Fatalf("messages = %v, want 4 entries", raw["messages"])
 	}
 
-	empty := msgs[1].(map[string]interface{})
+	empty := msgs[1].(map[string]any)
 	if _, exists := empty["tool_calls"]; exists {
 		t.Error("empty tool_calls array should be stripped")
 	}
@@ -319,8 +319,8 @@ func TestBuildUpstreamBody_StripsEmptyToolCalls(t *testing.T) {
 		t.Errorf("stripped message content = %v, want unchanged", empty["content"])
 	}
 
-	withCalls := msgs[2].(map[string]interface{})
-	tc, ok := withCalls["tool_calls"].([]interface{})
+	withCalls := msgs[2].(map[string]any)
+	tc, ok := withCalls["tool_calls"].([]any)
 	if !ok || len(tc) != 1 {
 		t.Errorf("non-empty tool_calls must be preserved, got %v", withCalls["tool_calls"])
 	}
@@ -337,7 +337,7 @@ func TestBuildUpstreamBody_StripEmptyToolCallsTolerantOfShapes(t *testing.T) {
 		`{"model":"gpt-4","messages":[42,{"role":"user","content":"hi","tool_calls":"nope"}]}`,
 	} {
 		result := BuildUpstreamBody([]byte(body), "openai", "gpt-4", "gpt-4", false, &sync.Map{}, &sync.Map{}, nil)
-		var raw map[string]interface{}
+		var raw map[string]any
 		if err := json.Unmarshal(result, &raw); err != nil {
 			t.Fatalf("result is not valid JSON for input %s: %v", body, err)
 		}

--- a/internal/paramrewrite/inject.go
+++ b/internal/paramrewrite/inject.go
@@ -23,7 +23,7 @@ func NeedsProviderInjection(providerType string) bool {
 // This is necessary because model-hotel acts as a transparent proxy;
 // clients like opencode don't know which upstream provider they're
 // really talking to, so they can't send provider-specific options.
-func InjectProviderParams(raw map[string]interface{}, providerType, modelID string) bool {
+func InjectProviderParams(raw map[string]any, providerType, modelID string) bool {
 	modified := false
 
 	switch providerType {
@@ -31,7 +31,7 @@ func InjectProviderParams(raw map[string]interface{}, providerType, modelID stri
 		// Z.ai / ZhipuAI requires thinking config for reasoning models.
 		// Without this, reasoning_content is never returned.
 		if _, exists := raw["thinking"]; !exists {
-			raw["thinking"] = map[string]interface{}{
+			raw["thinking"] = map[string]any{
 				"type":           "enabled",
 				"clear_thinking": false,
 			}
@@ -43,7 +43,7 @@ func InjectProviderParams(raw map[string]interface{}, providerType, modelID stri
 		// Baseten/OpenCode Zen and Go require chat_template_args to enable thinking.
 		// Without this, reasoning_content is never returned.
 		if _, exists := raw["chat_template_args"]; !exists {
-			raw["chat_template_args"] = map[string]interface{}{
+			raw["chat_template_args"] = map[string]any{
 				"enable_thinking": true,
 			}
 			modified = true
@@ -69,15 +69,15 @@ func InjectProviderParams(raw map[string]interface{}, providerType, modelID stri
 // backfillDeepSeekReasoning ensures every assistant message in the messages
 // array has a reasoning_content field. DeepSeek V4/R1 reject requests where
 // any assistant message is missing this field.
-func backfillDeepSeekReasoning(raw map[string]interface{}) bool {
-	messages, ok := raw["messages"].([]interface{})
+func backfillDeepSeekReasoning(raw map[string]any) bool {
+	messages, ok := raw["messages"].([]any)
 	if !ok {
 		return false
 	}
 
 	modified := false
 	for i, msg := range messages {
-		msgMap, ok := msg.(map[string]interface{})
+		msgMap, ok := msg.(map[string]any)
 		if !ok {
 			continue
 		}

--- a/internal/paramrewrite/inject_test.go
+++ b/internal/paramrewrite/inject_test.go
@@ -37,15 +37,15 @@ func TestNeedsProviderInjection(t *testing.T) {
 }
 
 func TestInjectProviderParams_ZaiCoding(t *testing.T) {
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"model":    "glm-5.1",
-		"messages": []interface{}{},
+		"messages": []any{},
 	}
 	modified := InjectProviderParams(raw, "zai-coding", "glm-5.1")
 	if !modified {
 		t.Fatal("expected modification for zai-coding")
 	}
-	thinking, ok := raw["thinking"].(map[string]interface{})
+	thinking, ok := raw["thinking"].(map[string]any)
 	if !ok {
 		t.Fatal("expected thinking map to be injected")
 	}
@@ -58,10 +58,10 @@ func TestInjectProviderParams_ZaiCoding(t *testing.T) {
 }
 
 func TestInjectProviderParams_ZaiCoding_AlreadyPresent(t *testing.T) {
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"model":    "glm-5.1",
-		"thinking": map[string]interface{}{"type": "disabled"},
-		"messages": []interface{}{},
+		"thinking": map[string]any{"type": "disabled"},
+		"messages": []any{},
 	}
 	modified := InjectProviderParams(raw, "zai-coding", "glm-5.1")
 	if modified {
@@ -70,15 +70,15 @@ func TestInjectProviderParams_ZaiCoding_AlreadyPresent(t *testing.T) {
 }
 
 func TestInjectProviderParams_OpencodeZen(t *testing.T) {
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"model":    "kimi-k2-thinking",
-		"messages": []interface{}{},
+		"messages": []any{},
 	}
 	modified := InjectProviderParams(raw, "opencode-zen", "kimi-k2-thinking")
 	if !modified {
 		t.Fatal("expected modification for opencode-zen")
 	}
-	args, ok := raw["chat_template_args"].(map[string]interface{})
+	args, ok := raw["chat_template_args"].(map[string]any)
 	if !ok {
 		t.Fatal("expected chat_template_args map to be injected")
 	}
@@ -88,15 +88,15 @@ func TestInjectProviderParams_OpencodeZen(t *testing.T) {
 }
 
 func TestInjectProviderParams_OpencodeGo(t *testing.T) {
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"model":    "glm-4.6",
-		"messages": []interface{}{},
+		"messages": []any{},
 	}
 	modified := InjectProviderParams(raw, "opencode-go", "glm-4.6")
 	if !modified {
 		t.Fatal("expected modification for opencode-go")
 	}
-	args, ok := raw["chat_template_args"].(map[string]interface{})
+	args, ok := raw["chat_template_args"].(map[string]any)
 	if !ok {
 		t.Fatal("expected chat_template_args map to be injected")
 	}
@@ -106,10 +106,10 @@ func TestInjectProviderParams_OpencodeGo(t *testing.T) {
 }
 
 func TestInjectProviderParams_Opencode_AlreadyPresent(t *testing.T) {
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"model":              "kimi-k2-thinking",
-		"chat_template_args": map[string]interface{}{"enable_thinking": false},
-		"messages":           []interface{}{},
+		"chat_template_args": map[string]any{"enable_thinking": false},
+		"messages":           []any{},
 	}
 	modified := InjectProviderParams(raw, "opencode-zen", "kimi-k2-thinking")
 	if modified {
@@ -118,22 +118,22 @@ func TestInjectProviderParams_Opencode_AlreadyPresent(t *testing.T) {
 }
 
 func TestInjectProviderParams_DeepSeekV4(t *testing.T) {
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"model": "deepseek-v4-pro",
-		"messages": []interface{}{
-			map[string]interface{}{"role": "user", "content": "Hello"},
-			map[string]interface{}{"role": "assistant", "content": "Hi there"},
-			map[string]interface{}{"role": "assistant", "content": "More info", "reasoning_content": "thinking..."},
-			map[string]interface{}{"role": "user", "content": "Follow up"},
+		"messages": []any{
+			map[string]any{"role": "user", "content": "Hello"},
+			map[string]any{"role": "assistant", "content": "Hi there"},
+			map[string]any{"role": "assistant", "content": "More info", "reasoning_content": "thinking..."},
+			map[string]any{"role": "user", "content": "Follow up"},
 		},
 	}
 	modified := InjectProviderParams(raw, "deepseek", "deepseek-v4-pro")
 	if !modified {
 		t.Fatal("expected modification for deepseek v4")
 	}
-	messages := raw["messages"].([]interface{})
+	messages := raw["messages"].([]any)
 	// First assistant message should have reasoning_content backfilled
-	first := messages[1].(map[string]interface{})
+	first := messages[1].(map[string]any)
 	if _, exists := first["reasoning_content"]; !exists {
 		t.Error("first assistant message missing reasoning_content")
 	}
@@ -141,18 +141,18 @@ func TestInjectProviderParams_DeepSeekV4(t *testing.T) {
 		t.Errorf("first assistant reasoning_content = %v, want empty string", first["reasoning_content"])
 	}
 	// Second assistant message already had reasoning_content, should be unchanged
-	second := messages[2].(map[string]interface{})
+	second := messages[2].(map[string]any)
 	if second["reasoning_content"] != "thinking..." {
 		t.Errorf("second assistant reasoning_content = %v, want 'thinking...'", second["reasoning_content"])
 	}
 }
 
 func TestInjectProviderParams_DeepSeekR1(t *testing.T) {
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"model": "deepseek-r1",
-		"messages": []interface{}{
-			map[string]interface{}{"role": "user", "content": "Hello"},
-			map[string]interface{}{"role": "assistant", "content": "Thinking hard"},
+		"messages": []any{
+			map[string]any{"role": "user", "content": "Hello"},
+			map[string]any{"role": "assistant", "content": "Thinking hard"},
 		},
 	}
 	modified := InjectProviderParams(raw, "deepseek", "deepseek-r1")
@@ -162,9 +162,9 @@ func TestInjectProviderParams_DeepSeekR1(t *testing.T) {
 }
 
 func TestInjectProviderParams_DeepSeekNonReasoning(t *testing.T) {
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"model":    "deepseek-chat",
-		"messages": []interface{}{},
+		"messages": []any{},
 	}
 	modified := InjectProviderParams(raw, "deepseek", "deepseek-chat")
 	if modified {
@@ -173,23 +173,23 @@ func TestInjectProviderParams_DeepSeekNonReasoning(t *testing.T) {
 }
 
 func TestInjectProviderParams_DeepSeekV4_AllAssistantBackfilled(t *testing.T) {
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"model": "deepseek-v4-pro",
-		"messages": []interface{}{
-			map[string]interface{}{"role": "user", "content": "Q1"},
-			map[string]interface{}{"role": "assistant", "content": "A1"},
-			map[string]interface{}{"role": "user", "content": "Q2"},
-			map[string]interface{}{"role": "assistant", "content": "A2"},
-			map[string]interface{}{"role": "user", "content": "Q3"},
+		"messages": []any{
+			map[string]any{"role": "user", "content": "Q1"},
+			map[string]any{"role": "assistant", "content": "A1"},
+			map[string]any{"role": "user", "content": "Q2"},
+			map[string]any{"role": "assistant", "content": "A2"},
+			map[string]any{"role": "user", "content": "Q3"},
 		},
 	}
 	modified := InjectProviderParams(raw, "deepseek", "deepseek-v4-pro")
 	if !modified {
 		t.Fatal("expected modification")
 	}
-	messages := raw["messages"].([]interface{})
+	messages := raw["messages"].([]any)
 	for i, msg := range messages {
-		m := msg.(map[string]interface{})
+		m := msg.(map[string]any)
 		if m["role"] == "assistant" {
 			if _, exists := m["reasoning_content"]; !exists {
 				t.Errorf("assistant message at index %d missing reasoning_content", i)
@@ -199,9 +199,9 @@ func TestInjectProviderParams_DeepSeekV4_AllAssistantBackfilled(t *testing.T) {
 }
 
 func TestInjectProviderParams_UnsupportedProvider(t *testing.T) {
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"model":    "gpt-4",
-		"messages": []interface{}{},
+		"messages": []any{},
 	}
 	modified := InjectProviderParams(raw, "openai", "gpt-4")
 	if modified {
@@ -210,7 +210,7 @@ func TestInjectProviderParams_UnsupportedProvider(t *testing.T) {
 }
 
 func TestBackfillDeepSeekReasoning_NoMessages(t *testing.T) {
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"model": "deepseek-v4",
 	}
 	modified := backfillDeepSeekReasoning(raw)
@@ -220,7 +220,7 @@ func TestBackfillDeepSeekReasoning_NoMessages(t *testing.T) {
 }
 
 func TestBackfillDeepSeekReasoning_InvalidMessages(t *testing.T) {
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"model":    "deepseek-v4",
 		"messages": "not an array",
 	}
@@ -232,9 +232,9 @@ func TestBackfillDeepSeekReasoning_InvalidMessages(t *testing.T) {
 
 func TestInjectProviderParams_RoundTrip(t *testing.T) {
 	// Verify that injected params survive JSON round-trip
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"model":    "glm-5.1",
-		"messages": []interface{}{},
+		"messages": []any{},
 	}
 	InjectProviderParams(raw, "zai-coding", "glm-5.1")
 
@@ -243,12 +243,12 @@ func TestInjectProviderParams_RoundTrip(t *testing.T) {
 		t.Fatalf("failed to marshal: %v", err)
 	}
 
-	var decoded map[string]interface{}
+	var decoded map[string]any
 	if err := json.Unmarshal(b, &decoded); err != nil {
 		t.Fatalf("failed to unmarshal: %v", err)
 	}
 
-	thinking, ok := decoded["thinking"].(map[string]interface{})
+	thinking, ok := decoded["thinking"].(map[string]any)
 	if !ok {
 		t.Fatal("thinking field lost in round-trip")
 	}

--- a/internal/paramrewrite/selfheal_test.go
+++ b/internal/paramrewrite/selfheal_test.go
@@ -11,13 +11,13 @@ import (
 )
 
 // decodeBody reads and JSON-decodes an upstream request body.
-func decodeBody(t *testing.T, r *http.Request) map[string]interface{} {
+func decodeBody(t *testing.T, r *http.Request) map[string]any {
 	t.Helper()
 	b, err := io.ReadAll(r.Body)
 	if err != nil {
 		t.Fatalf("read body: %v", err)
 	}
-	var m map[string]interface{}
+	var m map[string]any
 	if err := json.Unmarshal(b, &m); err != nil {
 		t.Fatalf("unmarshal body %q: %v", b, err)
 	}

--- a/internal/provider/catalog_merge_test.go
+++ b/internal/provider/catalog_merge_test.go
@@ -11,8 +11,6 @@ import (
 
 // intPtr is defined in discovery_nanogpt_test.go (same package).
 
-func floatPtr(v float64) *float64 { return &v }
-
 func capsJSON(c model.Capability) string {
 	b, _ := json.Marshal(c)
 	return string(b)
@@ -48,7 +46,7 @@ func TestMergeLiveAndCatalog_LiveWinsCatalogBackfills(t *testing.T) {
 		Capabilities:         "{}",
 		InputModalities:      "[]",
 		ContextLength:        nil, // live omitted -> catalog should fill
-		InputPricePerMillion: floatPtr(1.5),
+		InputPricePerMillion: new(1.5),
 	}}
 	catalog := []*model.Model{{
 		ProviderID:           pid,
@@ -57,9 +55,9 @@ func TestMergeLiveAndCatalog_LiveWinsCatalogBackfills(t *testing.T) {
 		Description:          "Zhipu flagship",
 		Modality:             "text",
 		InputModalities:      `["text"]`,
-		ContextLength:        intPtr(200000),
-		MaxOutputTokens:      intPtr(131072),
-		InputPricePerMillion: floatPtr(99), // live already has a value -> must NOT win
+		ContextLength:        new(200000),
+		MaxOutputTokens:      new(131072),
+		InputPricePerMillion: new(float64(99)), // live already has a value -> must NOT win
 		Capabilities:         capsJSON(model.Capability{Streaming: true, Reasoning: true, ToolCalling: true}),
 	}}
 
@@ -106,7 +104,7 @@ func TestMergeLiveAndCatalog_UnionsCatalogOnlyModels(t *testing.T) {
 	live := []*model.Model{{ProviderID: pid, ModelID: "glm-5.1", Name: "glm-5.1"}}
 	catalog := []*model.Model{
 		{ProviderID: pid, ModelID: "glm-5.1", Name: "glm-5.1"},
-		{ProviderID: pid, ModelID: "glm-5.2", Name: "glm-5.2", ContextLength: intPtr(200000)}, // not in live yet
+		{ProviderID: pid, ModelID: "glm-5.2", Name: "glm-5.2", ContextLength: new(200000)}, // not in live yet
 	}
 
 	out := mergeLiveAndCatalog(live, catalog)
@@ -136,7 +134,7 @@ func TestMergeLiveAndCatalog_LiveOnlyPassesThrough(t *testing.T) {
 func TestMergeLiveAndCatalog_CaseInsensitiveMatch(t *testing.T) {
 	pid := uuid.New()
 	live := []*model.Model{{ProviderID: pid, ModelID: "GLM-5.1", Name: "GLM-5.1"}}
-	catalog := []*model.Model{{ProviderID: pid, ModelID: "glm-5.1", ContextLength: intPtr(200000)}}
+	catalog := []*model.Model{{ProviderID: pid, ModelID: "glm-5.1", ContextLength: new(200000)}}
 
 	out := mergeLiveAndCatalog(live, catalog)
 	if len(out) != 1 {
@@ -159,14 +157,14 @@ func TestMergeLiveAndCatalog_LiveMetaProvenance(t *testing.T) {
 		Name:                 "glm-5.1",
 		Capabilities:         "{}",
 		InputModalities:      "[]",
-		InputPricePerMillion: floatPtr(1.5), // provider-reported -> live
-		ContextLength:        nil,           // catalog will backfill -> NOT live
+		InputPricePerMillion: new(1.5), // provider-reported -> live
+		ContextLength:        nil,      // catalog will backfill -> NOT live
 	}}
 	catalog := []*model.Model{{
 		ProviderID:           pid,
 		ModelID:              "glm-5.1",
-		ContextLength:        intPtr(200000),
-		InputPricePerMillion: floatPtr(99),
+		ContextLength:        new(200000),
+		InputPricePerMillion: new(float64(99)),
 	}}
 
 	out := mergeLiveAndCatalog(live, catalog)
@@ -188,7 +186,7 @@ func TestMergeLiveAndCatalog_CatalogOnlyIsNotLive(t *testing.T) {
 	catalog := []*model.Model{
 		{ProviderID: pid, ModelID: "glm-5.1", Name: "glm-5.1"},
 		{ProviderID: pid, ModelID: "glm-5.2", Name: "glm-5.2",
-			ContextLength: intPtr(200000), InputPricePerMillion: floatPtr(2)},
+			ContextLength: new(200000), InputPricePerMillion: new(float64(2))},
 	}
 
 	out := mergeLiveAndCatalog(live, catalog)
@@ -258,7 +256,7 @@ func TestBackfillFromCatalog_FillsEmptyTextFields(t *testing.T) {
 // meta still flagged), with no nil-map dereference.
 func TestBackfillLiveFromCatalog_EmptyCatalogReturnsLive(t *testing.T) {
 	pid := uuid.New()
-	live := []*model.Model{{ProviderID: pid, ModelID: "m1", InputPricePerMillion: floatPtr(3)}}
+	live := []*model.Model{{ProviderID: pid, ModelID: "m1", InputPricePerMillion: new(float64(3))}}
 
 	got := backfillLiveFromCatalog(live, nil)
 

--- a/internal/provider/discovery.go
+++ b/internal/provider/discovery.go
@@ -426,21 +426,18 @@ func isTransientNetworkError(err error) bool {
 	if err == nil {
 		return false
 	}
-	var dnsErr *net.DNSError
-	if errors.As(err, &dnsErr) {
+	if _, ok := errors.AsType[*net.DNSError](err); ok {
 		return true
 	}
 	var netErr net.Error
 	if errors.As(err, &netErr) && netErr.Timeout() {
 		return true
 	}
-	var opErr *net.OpError
-	if errors.As(err, &opErr) {
+	if _, ok := errors.AsType[*net.OpError](err); ok {
 		return true
 	}
 	// url.Error wraps underlying network errors
-	var urlErr *url.Error
-	if errors.As(err, &urlErr) {
+	if urlErr, ok := errors.AsType[*url.Error](err); ok {
 		return isTransientNetworkError(urlErr.Err)
 	}
 	return false

--- a/internal/provider/discovery_google.go
+++ b/internal/provider/discovery_google.go
@@ -144,8 +144,8 @@ func (d *DiscoveryService) discoverGoogleAIStudio(ctx context.Context, provider 
 // Native: https://generativelanguage.googleapis.com/v1beta
 func toNativeBaseURL(proxyURL string) string {
 	u := strings.TrimSuffix(proxyURL, "/")
-	if strings.HasSuffix(u, "/openai") {
-		return strings.TrimSuffix(u, "/openai")
+	if before, ok := strings.CutSuffix(u, "/openai"); ok {
+		return before
 	}
 	return u
 }

--- a/internal/provider/discovery_nanogpt.go
+++ b/internal/provider/discovery_nanogpt.go
@@ -59,7 +59,7 @@ func (d *DiscoveryService) discoverNanoGPT(ctx context.Context, provider *Provid
 			displayName = m.ID
 		}
 
-		paramsMap := map[string]interface{}{}
+		paramsMap := map[string]any{}
 		if m.Subscription != nil {
 			paramsMap["subscription_included"] = m.Subscription.Included
 			paramsMap["subscription_note"] = m.Subscription.Note

--- a/internal/provider/discovery_nanogpt_test.go
+++ b/internal/provider/discovery_nanogpt_test.go
@@ -40,9 +40,9 @@ func TestGetNanoGPTUsage_Success(t *testing.T) {
 			AllowOverage:       false,
 			State:              "active",
 			Limits: NanoGPTUsageLimits{
-				WeeklyInputTokens: int64Ptr(200000),
-				DailyInputTokens:  int64Ptr(50000),
-				DailyImages:       int64Ptr(10),
+				WeeklyInputTokens: new(int64(200000)),
+				DailyInputTokens:  new(int64(50000)),
+				DailyImages:       new(int64(10)),
 			},
 			Period: NanoGPTUsagePeriod{
 				CurrentPeriodEnd: "2024-01-31T23:59:59Z",
@@ -264,8 +264,8 @@ func TestDiscoverNanoGPT_Success(t *testing.T) {
 					ID:              "gpt-4o",
 					Name:            "GPT-4o",
 					Description:     "OpenAI flagship model",
-					ContextLength:   intPtr(128000),
-					MaxOutputTokens: intPtr(16384),
+					ContextLength:   new(128000),
+					MaxOutputTokens: new(16384),
 					OwnedBy:         "openai",
 					Architecture: NanoGPTArchitecture{
 						Modality:         "text",
@@ -279,8 +279,8 @@ func TestDiscoverNanoGPT_Success(t *testing.T) {
 						StructuredOutput: true,
 					},
 					Pricing: NanoGPTPricing{
-						Prompt:     floatPtr(2.5),
-						Completion: floatPtr(10.0),
+						Prompt:     new(2.5),
+						Completion: new(10.0),
 					},
 				},
 			},
@@ -357,7 +357,7 @@ func TestDiscoverNanoGPT_OmittedPricingStaysNil(t *testing.T) {
 						InputModalities:  []string{"text"},
 						OutputModalities: []string{"text"},
 					},
-					ContextLength: intPtr(128000),
+					ContextLength: new(128000),
 					Pricing:       NanoGPTPricing{}, // prompt/completion omitted -> nil
 				},
 				{
@@ -369,10 +369,10 @@ func TestDiscoverNanoGPT_OmittedPricingStaysNil(t *testing.T) {
 						InputModalities:  []string{"text"},
 						OutputModalities: []string{"text"},
 					},
-					ContextLength: intPtr(128000),
+					ContextLength: new(128000),
 					Pricing: NanoGPTPricing{
-						Prompt:     floatPtr(0), // explicit free price -> kept as &0
-						Completion: floatPtr(0),
+						Prompt:     new(float64(0)), // explicit free price -> kept as &0
+						Completion: new(float64(0)),
 					},
 				},
 			},
@@ -619,14 +619,6 @@ func TestDiscoverNanoGPT_VisionCapability(t *testing.T) {
 	if !strings.Contains(models[0].InputModalities, "image") {
 		t.Errorf("Expected image in InputModalities, got %s", models[0].InputModalities)
 	}
-}
-
-func int64Ptr(v int64) *int64 {
-	return &v
-}
-
-func intPtr(v int) *int {
-	return &v
 }
 
 // nanoGPTImageCatalogBody is a minimal NanoGPT image-catalog payload with two

--- a/internal/provider/discovery_ollama_http_test.go
+++ b/internal/provider/discovery_ollama_http_test.go
@@ -32,7 +32,7 @@ func TestDiscoverOllama_HTTP(t *testing.T) {
 			// Mock show response
 			response := OllamaShowResponse{
 				Capabilities: []string{"tools"},
-				ModelInfo: map[string]interface{}{
+				ModelInfo: map[string]any{
 					"llama.context_length": float64(8192),
 				},
 				Details: OllamaShowDetails{
@@ -129,7 +129,7 @@ func TestDiscoverOllama_ContextCancelled(t *testing.T) {
 		case "/api/show":
 			response := OllamaShowResponse{
 				Capabilities: []string{"tools"},
-				ModelInfo: map[string]interface{}{
+				ModelInfo: map[string]any{
 					"llama.context_length": float64(8192),
 				},
 				Details: OllamaShowDetails{
@@ -200,7 +200,7 @@ func TestOllamaShowModel_Success(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		response := OllamaShowResponse{
 			Capabilities: []string{"tools", "vision"},
-			ModelInfo: map[string]interface{}{
+			ModelInfo: map[string]any{
 				"llama.context_length": float64(16384),
 			},
 			Details: OllamaShowDetails{
@@ -484,7 +484,7 @@ func TestDiscoverOllama_ShowModelFails(t *testing.T) {
 			}
 			response := OllamaShowResponse{
 				Capabilities: []string{"tools"},
-				ModelInfo:    map[string]interface{}{"llama.context_length": float64(8192)},
+				ModelInfo:    map[string]any{"llama.context_length": float64(8192)},
 				Details:      OllamaShowDetails{Family: "llama"},
 			}
 			w.Header().Set("Content-Type", "application/json")
@@ -545,7 +545,7 @@ func TestDiscoverOllama_VisionCapability(t *testing.T) {
 		case "/api/show":
 			response := OllamaShowResponse{
 				Capabilities: []string{"vision", "tools"},
-				ModelInfo:    map[string]interface{}{"llama.context_length": float64(16384)},
+				ModelInfo:    map[string]any{"llama.context_length": float64(16384)},
 				Details:      OllamaShowDetails{Family: "llama"},
 			}
 			w.Header().Set("Content-Type", "application/json")
@@ -596,7 +596,7 @@ func TestBuildOllamaModel_EmptyFamilyHTTP(t *testing.T) {
 	service := &DiscoveryService{}
 	show := &OllamaShowResponse{
 		Capabilities: []string{},
-		ModelInfo:    map[string]interface{}{},
+		ModelInfo:    map[string]any{},
 		Details:      OllamaShowDetails{Family: ""},
 	}
 	provider := &Provider{ID: uuid.New()}
@@ -611,7 +611,7 @@ func TestBuildOllamaModel_ContextLengthFromModelInfoHTTP(t *testing.T) {
 	service := &DiscoveryService{}
 	show := &OllamaShowResponse{
 		Capabilities: []string{},
-		ModelInfo: map[string]interface{}{
+		ModelInfo: map[string]any{
 			"llama.context_length": float64(32768),
 		},
 		Details: OllamaShowDetails{Family: "llama"},
@@ -628,7 +628,7 @@ func TestBuildOllamaModel_ThinkingCapabilityHTTP(t *testing.T) {
 	service := &DiscoveryService{}
 	show := &OllamaShowResponse{
 		Capabilities: []string{"thinking"},
-		ModelInfo:    map[string]interface{}{},
+		ModelInfo:    map[string]any{},
 		Details:      OllamaShowDetails{Family: "llama"},
 	}
 	provider := &Provider{ID: uuid.New()}
@@ -650,7 +650,7 @@ func TestBuildOllamaModel_EmbeddingCapabilityHTTP(t *testing.T) {
 	// hidden from the chat picker.
 	show := &OllamaShowResponse{
 		Capabilities: []string{"embedding"},
-		ModelInfo:    map[string]interface{}{},
+		ModelInfo:    map[string]any{},
 		Details:      OllamaShowDetails{Family: "nomic-bert"},
 	}
 	provider := &Provider{ID: uuid.New()}
@@ -672,7 +672,7 @@ func TestBuildOllamaModel_CompletionStaysTextHTTP(t *testing.T) {
 	// keeps it as a chat model.
 	show := &OllamaShowResponse{
 		Capabilities: []string{"completion", "tools"},
-		ModelInfo:    map[string]interface{}{},
+		ModelInfo:    map[string]any{},
 		Details:      OllamaShowDetails{Family: "llama"},
 	}
 	provider := &Provider{ID: uuid.New()}
@@ -690,7 +690,7 @@ func TestBuildOllamaModel_EmbeddingByNameFallbackHTTP(t *testing.T) {
 	// heuristic so an embedding model is still caught.
 	show := &OllamaShowResponse{
 		Capabilities: []string{},
-		ModelInfo:    map[string]interface{}{},
+		ModelInfo:    map[string]any{},
 		Details:      OllamaShowDetails{Family: "bert"},
 	}
 	provider := &Provider{ID: uuid.New()}

--- a/internal/provider/discovery_test.go
+++ b/internal/provider/discovery_test.go
@@ -1065,7 +1065,7 @@ func TestQuotaCircuitState_ClosedByDefault(t *testing.T) {
 
 func TestQuotaCircuitState_OpensAfterThreshold(t *testing.T) {
 	s := &quotaCircuitState{}
-	for i := 0; i < quotaBreakerThreshold-1; i++ {
+	for i := range quotaBreakerThreshold - 1 {
 		if s.recordFailure() {
 			t.Errorf("circuit should not open at failure %d (threshold=%d)", i+1, quotaBreakerThreshold)
 		}
@@ -1082,12 +1082,12 @@ func TestQuotaCircuitState_OpensAfterThreshold(t *testing.T) {
 func TestQuotaCircuitState_SuccessResets(t *testing.T) {
 	s := &quotaCircuitState{}
 	// Fail a few times (not enough to open).
-	for i := 0; i < quotaBreakerThreshold-1; i++ {
+	for range quotaBreakerThreshold - 1 {
 		s.recordFailure()
 	}
 	s.recordSuccess()
 	// consecFailures reset to 0, so threshold more failures needed.
-	for i := 0; i < quotaBreakerThreshold-1; i++ {
+	for range quotaBreakerThreshold - 1 {
 		if s.isCircuitOpen() {
 			t.Error("circuit should not be open yet")
 		}
@@ -1102,7 +1102,7 @@ func TestQuotaCircuitState_SuccessResets(t *testing.T) {
 func TestQuotaCircuitState_HalfOpenAfterReset(t *testing.T) {
 	s := &quotaCircuitState{}
 	// Open the circuit.
-	for i := 0; i < quotaBreakerThreshold; i++ {
+	for range quotaBreakerThreshold {
 		s.recordFailure()
 	}
 	if !s.isCircuitOpen() {
@@ -1126,7 +1126,7 @@ func TestQuotaCircuitState_HalfOpenAfterReset(t *testing.T) {
 func TestQuotaCircuitState_HalfOpenFailureReopens(t *testing.T) {
 	s := &quotaCircuitState{}
 	// Open the circuit.
-	for i := 0; i < quotaBreakerThreshold; i++ {
+	for range quotaBreakerThreshold {
 		s.recordFailure()
 	}
 	// Expire the open window.
@@ -1153,7 +1153,7 @@ func TestDoQuotaRequestWithRetry_CircuitBreakerShortCircuits(t *testing.T) {
 
 	// Open the circuit by recording enough failures.
 	circuit := svc.getOrCreateCircuit(providerID)
-	for i := 0; i < quotaBreakerThreshold; i++ {
+	for range quotaBreakerThreshold {
 		circuit.recordFailure()
 	}
 
@@ -1934,7 +1934,7 @@ func TestDiscoverOllama_ShowModelFailure(t *testing.T) {
 			// Successful response for other models
 			response := OllamaShowResponse{
 				Capabilities: []string{"tools"},
-				ModelInfo: map[string]interface{}{
+				ModelInfo: map[string]any{
 					"llama.context_length": float64(8192),
 				},
 				Details: OllamaShowDetails{
@@ -1987,7 +1987,7 @@ func TestBuildOllamaModel_ThinkingCapability(t *testing.T) {
 
 	showResponse := &OllamaShowResponse{
 		Capabilities: []string{"tools", "thinking", "vision"},
-		ModelInfo: map[string]interface{}{
+		ModelInfo: map[string]any{
 			"llama.context_length": float64(32768),
 		},
 		Details: OllamaShowDetails{
@@ -2034,7 +2034,7 @@ func TestBuildOllamaModel_EmptyFamily(t *testing.T) {
 
 	showResponse := &OllamaShowResponse{
 		Capabilities: []string{"tools"},
-		ModelInfo: map[string]interface{}{
+		ModelInfo: map[string]any{
 			"llama.context_length": float64(8192),
 		},
 		Details: OllamaShowDetails{

--- a/internal/provider/discovery_zai_test.go
+++ b/internal/provider/discovery_zai_test.go
@@ -276,7 +276,7 @@ func TestGetZAICodingQuota_CircuitBreakerOpen(t *testing.T) {
 	}
 
 	// Exhaust retries to open the circuit breaker
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		_, _ = service.GetZAICodingQuota(context.Background(), provider, masterKey)
 	}
 

--- a/internal/provider/modelsdev.go
+++ b/internal/provider/modelsdev.go
@@ -51,7 +51,7 @@ type ModelsDevModelSpec struct {
 	OpenWeights      bool                 `json:"open_weights"`
 	Cost             ModelsDevCost        `json:"cost"`
 	Limit            ModelsDevLimit       `json:"limit"`
-	Interleaved      ModelsDevInterleaved `json:"interleaved,omitempty"`
+	Interleaved      ModelsDevInterleaved `json:"interleaved"`
 }
 
 // ModelsDevModalities describes input and output modalities for a models.dev model.

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -250,7 +250,7 @@ func TestProviderResponse_JSON(t *testing.T) {
 		t.Fatalf("marshal: %v", err)
 	}
 
-	var decoded map[string]interface{}
+	var decoded map[string]any
 	if err := json.Unmarshal(data, &decoded); err != nil {
 		t.Fatalf("unmarshal to map: %v", err)
 	}
@@ -278,7 +278,7 @@ func TestProviderResponse_JSONNilTimestamps(t *testing.T) {
 		t.Fatalf("marshal: %v", err)
 	}
 
-	var decoded map[string]interface{}
+	var decoded map[string]any
 	if err := json.Unmarshal(data, &decoded); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}

--- a/internal/ratelimit/ip_limiter.go
+++ b/internal/ratelimit/ip_limiter.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"net"
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -267,8 +268,8 @@ func extractClientIP(r *http.Request, trustedProxies []*net.IPNet) string {
 // chain from the proxy-adjacent end toward the client.
 func rightmostUntrustedIP(xff string, trustedProxies []*net.IPNet) string {
 	parts := strings.Split(xff, ",")
-	for i := len(parts) - 1; i >= 0; i-- {
-		ip := strings.TrimSpace(parts[i])
+	for _, part := range slices.Backward(parts) {
+		ip := strings.TrimSpace(part)
 		if ip == "" {
 			continue
 		}

--- a/internal/ratelimit/ip_limiter_test.go
+++ b/internal/ratelimit/ip_limiter_test.go
@@ -68,7 +68,7 @@ func TestIPLimiter_AllowsWithinBurst(t *testing.T) {
 	})
 	handler := lim.Middleware(next)
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		req := httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)
 		req.RemoteAddr = "1.2.3.4:1234"
 		rr := httptest.NewRecorder()
@@ -88,7 +88,7 @@ func TestIPLimiter_BlocksBeyondBurst(t *testing.T) {
 	})
 	handler := lim.Middleware(next)
 
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		req := httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)
 		req.RemoteAddr = "5.6.7.8:5678"
 		rr := httptest.NewRecorder()
@@ -117,7 +117,7 @@ func TestIPLimiter_PerIPIsolation(t *testing.T) {
 	handler := lim.Middleware(next)
 
 	// Exhaust IP-A
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		req := httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)
 		req.RemoteAddr = "10.0.0.1:1000"
 		rr := httptest.NewRecorder()
@@ -564,7 +564,7 @@ func TestIPLimiter_RuntimeSettingsOverrideRPS(t *testing.T) {
 	handler := lim.Middleware(next)
 
 	// With RPS=1000 and burst=1000, 50 rapid requests should all succeed
-	for i := 0; i < 50; i++ {
+	for i := range 50 {
 		req := httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)
 		req.RemoteAddr = "10.0.0.1:1234"
 		rr := httptest.NewRecorder()
@@ -589,7 +589,7 @@ func TestIPLimiter_SettingsFallbackToDefaults(t *testing.T) {
 
 	// Constructor defaults: RPS=0.1, burst=2
 	// Both burst requests should succeed
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		req := httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)
 		req.RemoteAddr = "10.0.0.2:1234"
 		rr := httptest.NewRecorder()
@@ -621,7 +621,7 @@ func TestIPLimiter_ConcurrentAccess(t *testing.T) {
 	var wg sync.WaitGroup
 	errors := make(chan error, 100)
 
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
@@ -682,7 +682,7 @@ func TestIPLimiter_UnlimitedRPS(t *testing.T) {
 	handler := lim.Middleware(next)
 
 	// Fire many requests — none should be rate limited
-	for i := 0; i < 200; i++ {
+	for i := range 200 {
 		req := httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)
 		req.RemoteAddr = "10.10.10.10:1234"
 		rr := httptest.NewRecorder()
@@ -739,7 +739,7 @@ func TestIPLimiter_SettingsChangeRPS(t *testing.T) {
 	lim.mu.Unlock()
 
 	// With new settings, many more requests should succeed
-	for i := 0; i < 50; i++ {
+	for i := range 50 {
 		req = httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)
 		req.RemoteAddr = "172.16.0.1:5000"
 		rr = httptest.NewRecorder()
@@ -1044,7 +1044,7 @@ func TestIPLimiter_MiddlewareNoSettingsPassesThrough(t *testing.T) {
 	handler := lim.Middleware(next)
 
 	// burst=2 from constructor defaults
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		req := httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)
 		req.RemoteAddr = "7.7.7.7:7777"
 		rr := httptest.NewRecorder()

--- a/internal/ratelimit/limiter_test.go
+++ b/internal/ratelimit/limiter_test.go
@@ -164,7 +164,7 @@ func TestMiddleware_AllowsWithinBurst(t *testing.T) {
 	})
 	handler := lim.Middleware(true)(next)
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		req := requestWithKey("key-allow")
 		rr := httptest.NewRecorder()
 		handler.ServeHTTP(rr, req)
@@ -186,7 +186,7 @@ func TestMiddleware_BlocksBeyondBurst(t *testing.T) {
 	})
 	handler := lim.Middleware(true)(next)
 
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		req := requestWithKey("key-block")
 		rr := httptest.NewRecorder()
 		handler.ServeHTTP(rr, req)
@@ -216,7 +216,7 @@ func TestMiddleware_PerKeyIsolation(t *testing.T) {
 	handler := lim.Middleware(true)(next)
 
 	// Exhaust key-a
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		req := requestWithKey("key-a")
 		rr := httptest.NewRecorder()
 		handler.ServeHTTP(rr, req)
@@ -364,7 +364,7 @@ func TestMiddleware_SettingsChangeAtRuntime(t *testing.T) {
 	}
 
 	// Exhaust new burst of 2
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		req = requestWithKey("key-rt")
 		rr = httptest.NewRecorder()
 		handler.ServeHTTP(rr, req)
@@ -436,7 +436,7 @@ func TestMiddleware_UnlimitedRPS(t *testing.T) {
 	handler := lim.Middleware(true)(next)
 
 	// Fire many requests — none should be rate limited
-	for i := 0; i < 200; i++ {
+	for i := range 200 {
 		req := requestWithKey("key-unlimited")
 		rr := httptest.NewRecorder()
 		handler.ServeHTTP(rr, req)
@@ -723,7 +723,7 @@ func TestMiddleware_PerKeyOverrideNil(t *testing.T) {
 	}
 
 	// Should use global burst=5, so we can make 4 more requests (5 total)
-	for i := 0; i < 4; i++ {
+	for i := range 4 {
 		r = r.WithContext(ctx)
 		rr = httptest.NewRecorder()
 		handler.ServeHTTP(rr, r)
@@ -763,7 +763,7 @@ func TestMiddleware_ExtractKeyFallbackToRemoteAddr(t *testing.T) {
 	handler := lim.Middleware(true)(next)
 
 	// Make requests without virtual key hash in context - should use RemoteAddr
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		req := httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)
 		req.RemoteAddr = "192.168.1.100:12345"
 		rr := httptest.NewRecorder()
@@ -844,7 +844,7 @@ func TestMiddleware_DisabledViaEnvNoBackpressure(t *testing.T) {
 	handler := lim.Middleware(false)(next) // enabled=false (env kill-switch)
 
 	// Even though DB says enabled=true with burst=1, many requests should pass
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		req := requestWithKey("key-env-disabled")
 		rr := httptest.NewRecorder()
 		handler.ServeHTTP(rr, req)
@@ -1108,7 +1108,7 @@ func TestCleanupLoop_TickerPathRemovesStaleEntries(t *testing.T) {
 // TestCleanupLoop_ConcurrentStopAndTick verifies that cleanupLoop handles
 // the race between the stop channel and the ticker gracefully.
 func TestCleanupLoop_ConcurrentStopAndTick(t *testing.T) {
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		lim := &Limiter{
 			limiters: make(map[string]*keyEntry),
 			settings: newStubSettings(),

--- a/internal/ratelimit/tpm_limiter.go
+++ b/internal/ratelimit/tpm_limiter.go
@@ -197,10 +197,7 @@ func (l *TPMLimiter) debitBucket(bucketKey string, tokens int) {
 	}
 	now := time.Now()
 	for remaining > 0 {
-		n := remaining
-		if n > burst {
-			n = burst
-		}
+		n := min(remaining, burst)
 		entry.limiter.ReserveN(now, n)
 		remaining -= n
 	}
@@ -276,10 +273,7 @@ func tpmRetryAfter(lim *rate.Limiter) int {
 	if perSec <= 0 {
 		return 1
 	}
-	secs := int(math.Ceil((1 - avail) / perSec))
-	if secs < 1 {
-		secs = 1
-	}
+	secs := max(int(math.Ceil((1-avail)/perSec)), 1)
 	return secs
 }
 

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -79,7 +79,7 @@ type ChangeEvent struct {
 }
 
 // subIDCounter is used to assign unique IDs to each subscription.
-var subIDCounter uint64
+var subIDCounter atomic.Uint64
 
 // subscription ties a unique ID to a channel so that Unsubscribe can find it
 // without relying on channel comparison (which doesn't work across
@@ -149,7 +149,7 @@ func NewRepository(pool *pgxpool.Pool) *Repository {
 //	    if change.Key == "discovery_interval" { … }
 //	}
 func (r *Repository) Subscribe() *Subscription {
-	id := atomic.AddUint64(&subIDCounter, 1)
+	id := subIDCounter.Add(1)
 	ch := make(chan ChangeEvent, 16)
 	r.changeMu.Lock()
 	r.subscriptions = append(r.subscriptions, subscription{id: id, ch: ch})

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -658,7 +658,7 @@ func TestSubscribeMultiSubscriber(t *testing.T) {
 	subs := make([]*Subscription, subCount)
 	dones := make([]chan ChangeEvent, subCount)
 
-	for i := 0; i < subCount; i++ {
+	for i := range subCount {
 		subs[i] = r.Subscribe()
 		dones[i] = make(chan ChangeEvent, 1)
 	}
@@ -669,8 +669,7 @@ func TestSubscribeMultiSubscriber(t *testing.T) {
 		}
 	}()
 
-	for i := 0; i < subCount; i++ {
-		i := i
+	for i := range subCount {
 		go func() {
 			change := <-subs[i].Events()
 			dones[i] <- change
@@ -681,7 +680,7 @@ func TestSubscribeMultiSubscriber(t *testing.T) {
 		t.Fatalf("Set failed: %v", err)
 	}
 
-	for i := 0; i < subCount; i++ {
+	for i := range subCount {
 		select {
 		case change := <-dones[i]:
 			if change.Key != key || change.Value != "broadcast" {
@@ -748,7 +747,7 @@ func TestConcurrentSetGetSubscribe(t *testing.T) {
 	var wg sync.WaitGroup
 
 	// Concurrent writers.
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		wg.Add(1)
 		go func(n int) {
 			defer wg.Done()
@@ -757,7 +756,7 @@ func TestConcurrentSetGetSubscribe(t *testing.T) {
 	}
 
 	// Concurrent readers.
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		wg.Add(1)
 		go func(n int) {
 			defer wg.Done()
@@ -766,9 +765,7 @@ func TestConcurrentSetGetSubscribe(t *testing.T) {
 	}
 
 	// Concurrent subscriber drain.
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		timeout := time.After(100 * time.Millisecond)
 		for {
 			select {
@@ -777,7 +774,7 @@ func TestConcurrentSetGetSubscribe(t *testing.T) {
 				return
 			}
 		}
-	}()
+	})
 
 	wg.Wait()
 }
@@ -1061,7 +1058,7 @@ func TestUnsubscribe_BufferedEventsInChannel(t *testing.T) {
 	sub := r.Subscribe()
 
 	// Send multiple events to buffer them in the channel
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		err := r.Set(ctx, "buffer_test_key", fmt.Sprintf("val_%d", i))
 		if err != nil {
 			t.Fatalf("Set failed: %v", err)

--- a/internal/totp/throttle_test.go
+++ b/internal/totp/throttle_test.go
@@ -8,7 +8,7 @@ import (
 func TestThrottle_AllowsUntilThreshold(t *testing.T) {
 	th := NewThrottle(3, 10*time.Millisecond, time.Second)
 	// First maxFailures failures must not lock (count does not yet exceed).
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		th.RecordFailure("ip")
 		if ok, _ := th.Allowed("ip"); !ok {
 			t.Fatalf("locked after %d failures, expected still allowed", i+1)

--- a/internal/totp/totp_test.go
+++ b/internal/totp/totp_test.go
@@ -83,7 +83,7 @@ func TestVerifyWrongCode(t *testing.T) {
 
 	// "000000" is a 1/1e6 collision candidate; if it validates, regenerate
 	// once and retry so the test is deterministic in practice.
-	for attempt := 0; attempt < 2; attempt++ {
+	for attempt := range 2 {
 		ok, err := repo.Verify(ctx, "000000")
 		require.NoError(t, err)
 		if !ok {

--- a/internal/user/grants.go
+++ b/internal/user/grants.go
@@ -1,6 +1,9 @@
 package user
 
-import "fmt"
+import (
+	"fmt"
+	"slices"
+)
 
 // Grant is a feature key a non-admin user can be given access to. The catalog
 // is the single source of truth: the API validates incoming grants against it
@@ -43,10 +46,5 @@ func ValidateGrants(grants []string) error {
 // HasGrant reports whether the grant list contains g. Role checks live in the
 // middleware; admins bypass grants entirely and never reach this.
 func HasGrant(grants []string, g Grant) bool {
-	for _, have := range grants {
-		if have == string(g) {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(grants, string(g))
 }

--- a/internal/user/user.go
+++ b/internal/user/user.go
@@ -218,8 +218,7 @@ func (r *Repository) ResolveSSOIdentity(ctx context.Context, provider, subject, 
 // isUniqueViolation reports whether err is a PostgreSQL unique-constraint
 // violation (SQLSTATE 23505).
 func isUniqueViolation(err error) bool {
-	var pgErr *pgconn.PgError
-	if errors.As(err, &pgErr) {
+	if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok {
 		return pgErr.Code == "23505"
 	}
 	return false

--- a/internal/util/docker.go
+++ b/internal/util/docker.go
@@ -440,15 +440,15 @@ func getOwnContainerID() string {
 	// Try /proc/self/cgroup (Docker usually writes the container ID here)
 	data, err := os.ReadFile(procSelfCgroup)
 	if err == nil {
-		for _, line := range strings.Split(string(data), "\n") {
+		for line := range strings.SplitSeq(string(data), "\n") {
 			line = strings.TrimSpace(line)
 			if line == "" {
 				continue
 			}
 			// cgroup v2: 0::/system.slice/docker-<id>.scope
 			// cgroup v1: 12:memory:/docker/<id>
-			parts := strings.Split(line, "/")
-			for _, part := range parts {
+			parts := strings.SplitSeq(line, "/")
+			for part := range parts {
 				part = strings.TrimSuffix(part, ".scope")
 				if len(part) >= 12 && isHex(part) {
 					return part

--- a/internal/util/docker_wrapper_compose_test.go
+++ b/internal/util/docker_wrapper_compose_test.go
@@ -72,8 +72,8 @@ func TestDetectComposeProject(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 		case "/containers/abc123def456/json":
 			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"Config": map[string]interface{}{
+			json.NewEncoder(w).Encode(map[string]any{
+				"Config": map[string]any{
 					"Labels": map[string]string{
 						"com.docker.compose.project": "testproject",
 					},
@@ -119,8 +119,8 @@ func TestDetectComposeProject_NoLabels(t *testing.T) {
 		case "/containers/abc123def456/json":
 			w.WriteHeader(http.StatusOK)
 			// Container without compose labels
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"Config": map[string]interface{}{
+			json.NewEncoder(w).Encode(map[string]any{
+				"Config": map[string]any{
 					"Labels": map[string]string{},
 				},
 			})
@@ -232,8 +232,8 @@ func TestDetectComposeProject_WithContainerID(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 		case "/containers/abc123def456/json":
 			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"Config": map[string]interface{}{
+			json.NewEncoder(w).Encode(map[string]any{
+				"Config": map[string]any{
 					"Labels": map[string]string{
 						"com.docker.compose.project": "testproject",
 					},
@@ -466,8 +466,8 @@ func TestDetectComposeProject_HappyPath(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 		case "/containers/abc123def4567890/json":
 			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"Config": map[string]interface{}{
+			json.NewEncoder(w).Encode(map[string]any{
+				"Config": map[string]any{
 					"Labels": map[string]string{
 						"com.docker.compose.project": "myproject",
 					},
@@ -525,8 +525,8 @@ func TestDetectComposeProject_NoLabelsWithID(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 		case "/containers/abc123def4567890/json":
 			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"Config": map[string]interface{}{
+			json.NewEncoder(w).Encode(map[string]any{
+				"Config": map[string]any{
 					"Labels": map[string]string{},
 				},
 			})
@@ -781,8 +781,8 @@ func TestDetectContainerFilter(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 		case "/containers/abc123def456/json":
 			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"Config": map[string]interface{}{
+			json.NewEncoder(w).Encode(map[string]any{
+				"Config": map[string]any{
 					"Labels": map[string]string{
 						"com.docker.compose.project": "testproject",
 					},
@@ -844,8 +844,8 @@ func TestDetectContainerFilter_AppGroupLabel(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 		case "/containers/abc123def456/json":
 			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"Config": map[string]interface{}{
+			json.NewEncoder(w).Encode(map[string]any{
+				"Config": map[string]any{
 					"Labels": map[string]string{
 						"app.group": "model-hotel",
 					},
@@ -970,8 +970,8 @@ func TestDetectContainerFilter_NoLabels(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 		case "/containers/abc123def456/json":
 			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"Config": map[string]interface{}{
+			json.NewEncoder(w).Encode(map[string]any{
+				"Config": map[string]any{
 					"Labels": map[string]string{},
 				},
 			})

--- a/internal/util/docker_wrapper_test.go
+++ b/internal/util/docker_wrapper_test.go
@@ -106,13 +106,13 @@ func TestGetOwnContainerID_CgroupV1(t *testing.T) {
 
 	// Simulate the parsing logic from getOwnContainerID
 	var foundID string
-	for _, line := range strings.Split(string(data), "\n") {
+	for line := range strings.SplitSeq(string(data), "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
 			continue
 		}
-		parts := strings.Split(line, "/")
-		for _, part := range parts {
+		parts := strings.SplitSeq(line, "/")
+		for part := range parts {
 			part = strings.TrimSuffix(part, ".scope")
 			if len(part) >= 12 && isHex(part) {
 				foundID = part
@@ -148,13 +148,13 @@ func TestGetOwnContainerID_CgroupV2(t *testing.T) {
 	}
 
 	var foundID string
-	for _, line := range strings.Split(string(data), "\n") {
+	for line := range strings.SplitSeq(string(data), "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
 			continue
 		}
-		parts := strings.Split(line, "/")
-		for _, part := range parts {
+		parts := strings.SplitSeq(line, "/")
+		for part := range parts {
 			part = strings.TrimSuffix(part, ".scope")
 			if len(part) >= 12 && isHex(part) {
 				foundID = part
@@ -187,13 +187,13 @@ func TestGetOwnContainerID_Empty(t *testing.T) {
 	}
 
 	var foundID string
-	for _, line := range strings.Split(string(data), "\n") {
+	for line := range strings.SplitSeq(string(data), "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
 			continue
 		}
-		parts := strings.Split(line, "/")
-		for _, part := range parts {
+		parts := strings.SplitSeq(line, "/")
+		for part := range parts {
 			part = strings.TrimSuffix(part, ".scope")
 			if len(part) >= 12 && isHex(part) {
 				foundID = part

--- a/internal/util/httputil.go
+++ b/internal/util/httputil.go
@@ -109,8 +109,8 @@ func IntToStr(i int) string {
 func WriteOpenAIError(w http.ResponseWriter, message string, statusCode int) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(statusCode)
-	_ = json.NewEncoder(w).Encode(map[string]interface{}{
-		"error": map[string]interface{}{
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"error": map[string]any{
 			"message": message,
 			"type":    OpenAIErrorType(statusCode),
 			"code":    statusCode,

--- a/internal/util/httputil_test.go
+++ b/internal/util/httputil_test.go
@@ -735,12 +735,12 @@ func TestWriteOpenAIError(t *testing.T) {
 	}
 
 	// Check response body structure
-	var response map[string]interface{}
+	var response map[string]any
 	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
 		t.Fatalf("failed to parse JSON response: %v", err)
 	}
 
-	errorObj, ok := response["error"].(map[string]interface{})
+	errorObj, ok := response["error"].(map[string]any)
 	if !ok {
 		t.Fatal("response should contain 'error' object")
 	}

--- a/internal/util/system.go
+++ b/internal/util/system.go
@@ -67,8 +67,8 @@ func ReadCgroupCPU() float64 {
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
 		line := scanner.Text()
-		if strings.HasPrefix(line, "usage_usec ") {
-			val := strings.TrimPrefix(line, "usage_usec ")
+		if after, ok := strings.CutPrefix(line, "usage_usec "); ok {
+			val := after
 			if v, e := strconv.ParseInt(strings.TrimSpace(val), 10, 64); e == nil {
 				usageUsec = v
 			}
@@ -214,13 +214,13 @@ func ReadCgroupDiskIO() (readBytesPerSec, writeBytesPerSec float64) {
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
 		line := scanner.Text()
-		for _, field := range strings.Fields(line) {
-			if strings.HasPrefix(field, "rbytes=") {
-				if v, e := ParseInt(strings.TrimPrefix(field, "rbytes=")); e == nil {
+		for field := range strings.FieldsSeq(line) {
+			if after, ok := strings.CutPrefix(field, "rbytes="); ok {
+				if v, e := ParseInt(after); e == nil {
 					totalRead += v
 				}
-			} else if strings.HasPrefix(field, "wbytes=") {
-				if v, e := ParseInt(strings.TrimPrefix(field, "wbytes=")); e == nil {
+			} else if after, ok := strings.CutPrefix(field, "wbytes="); ok {
+				if v, e := ParseInt(after); e == nil {
 					totalWrite += v
 				}
 			}

--- a/internal/util/system_test.go
+++ b/internal/util/system_test.go
@@ -665,13 +665,13 @@ func TestCgroupParsing_V1(t *testing.T) {
 10:blkio:/docker/abc123def4567890`
 
 	var foundID string
-	for _, line := range strings.Split(cgroupContent, "\n") {
+	for line := range strings.SplitSeq(cgroupContent, "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
 			continue
 		}
-		parts := strings.Split(line, "/")
-		for _, part := range parts {
+		parts := strings.SplitSeq(line, "/")
+		for part := range parts {
 			part = strings.TrimSuffix(part, ".scope")
 			if len(part) >= 12 && isHex(part) {
 				foundID = part
@@ -694,13 +694,13 @@ func TestCgroupParsing_V2(t *testing.T) {
 	cgroupContent := `0::/abc123def4567890`
 
 	var foundID string
-	for _, line := range strings.Split(cgroupContent, "\n") {
+	for line := range strings.SplitSeq(cgroupContent, "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
 			continue
 		}
-		parts := strings.Split(line, "/")
-		for _, part := range parts {
+		parts := strings.SplitSeq(line, "/")
+		for part := range parts {
 			part = strings.TrimSuffix(part, ".scope")
 			if len(part) >= 12 && isHex(part) {
 				foundID = part
@@ -722,13 +722,13 @@ func TestCgroupParsing_Empty(t *testing.T) {
 	cgroupContent := ""
 
 	var foundID string
-	for _, line := range strings.Split(cgroupContent, "\n") {
+	for line := range strings.SplitSeq(cgroupContent, "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
 			continue
 		}
-		parts := strings.Split(line, "/")
-		for _, part := range parts {
+		parts := strings.SplitSeq(line, "/")
+		for part := range parts {
 			part = strings.TrimSuffix(part, ".scope")
 			if len(part) >= 12 && isHex(part) {
 				foundID = part
@@ -751,13 +751,13 @@ func TestCgroupParsing_NoContainerID(t *testing.T) {
 	cgroupContent := `0::/user.slice/user-1000.slice/session-1.scope`
 
 	var foundID string
-	for _, line := range strings.Split(cgroupContent, "\n") {
+	for line := range strings.SplitSeq(cgroupContent, "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
 			continue
 		}
-		parts := strings.Split(line, "/")
-		for _, part := range parts {
+		parts := strings.SplitSeq(line, "/")
+		for part := range parts {
 			part = strings.TrimSuffix(part, ".scope")
 			if len(part) >= 12 && isHex(part) {
 				foundID = part
@@ -785,7 +785,7 @@ func TestNetworkStatsParsing(t *testing.T) {
 `
 
 	var totalRx, totalTx int64
-	for _, line := range strings.Split(procNetDevContent, "\n") {
+	for line := range strings.SplitSeq(procNetDevContent, "\n") {
 		line = strings.TrimSpace(line)
 		if !strings.Contains(line, ":") {
 			continue
@@ -824,14 +824,14 @@ func TestCgroupIOStatParsing(t *testing.T) {
 8:16 rbytes=111111 wbytes=222222 rios=10 wios=20`
 
 	var totalRead, totalWrite int64
-	for _, line := range strings.Split(ioStatContent, "\n") {
-		for _, field := range strings.Fields(line) {
-			if strings.HasPrefix(field, "rbytes=") {
-				if v, e := ParseInt(strings.TrimPrefix(field, "rbytes=")); e == nil {
+	for line := range strings.SplitSeq(ioStatContent, "\n") {
+		for field := range strings.FieldsSeq(line) {
+			if after, ok := strings.CutPrefix(field, "rbytes="); ok {
+				if v, e := ParseInt(after); e == nil {
 					totalRead += v
 				}
-			} else if strings.HasPrefix(field, "wbytes=") {
-				if v, e := ParseInt(strings.TrimPrefix(field, "wbytes=")); e == nil {
+			} else if after, ok := strings.CutPrefix(field, "wbytes="); ok {
+				if v, e := ParseInt(after); e == nil {
 					totalWrite += v
 				}
 			}
@@ -852,14 +852,14 @@ func TestCgroupIOStatParsing_Empty(t *testing.T) {
 	ioStatContent := ""
 
 	var totalRead, totalWrite int64
-	for _, line := range strings.Split(ioStatContent, "\n") {
-		for _, field := range strings.Fields(line) {
-			if strings.HasPrefix(field, "rbytes=") {
-				if v, e := ParseInt(strings.TrimPrefix(field, "rbytes=")); e == nil {
+	for line := range strings.SplitSeq(ioStatContent, "\n") {
+		for field := range strings.FieldsSeq(line) {
+			if after, ok := strings.CutPrefix(field, "rbytes="); ok {
+				if v, e := ParseInt(after); e == nil {
 					totalRead += v
 				}
-			} else if strings.HasPrefix(field, "wbytes=") {
-				if v, e := ParseInt(strings.TrimPrefix(field, "wbytes=")); e == nil {
+			} else if after, ok := strings.CutPrefix(field, "wbytes="); ok {
+				if v, e := ParseInt(after); e == nil {
 					totalWrite += v
 				}
 			}
@@ -885,9 +885,9 @@ nr_throttled 5
 throttled_usec 50000`
 
 	var usageUsec int64
-	for _, line := range strings.Split(cpuStatContent, "\n") {
-		if strings.HasPrefix(line, "usage_usec ") {
-			val := strings.TrimPrefix(line, "usage_usec ")
+	for line := range strings.SplitSeq(cpuStatContent, "\n") {
+		if after, ok := strings.CutPrefix(line, "usage_usec "); ok {
+			val := after
 			if v, e := ParseInt(strings.TrimSpace(val)); e == nil {
 				usageUsec = v
 			}

--- a/internal/virtualkey/auth_test.go
+++ b/internal/virtualkey/auth_test.go
@@ -31,7 +31,7 @@ func TestGenerateReturnsNonEmptyKey(t *testing.T) {
 
 func TestGenerateProducesUniqueKeys(t *testing.T) {
 	keys := make(map[string]bool)
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		key, err := Generate()
 		if err != nil {
 			t.Fatalf("Generate() failed on iteration %d: %v", i, err)

--- a/internal/virtualkey/virtualkey_test.go
+++ b/internal/virtualkey/virtualkey_test.go
@@ -65,8 +65,7 @@ func TestErrNotFound_IsSentinel(t *testing.T) {
 
 func TestErrNotFound_Type(t *testing.T) {
 	var err error = ErrNotFound
-	var nf *notFoundError
-	if !errors.As(err, &nf) {
+	if _, ok := errors.AsType[*notFoundError](err); !ok {
 		t.Error("errors.As(ErrNotFound, *notFoundError) should be true")
 	}
 }

--- a/internal/webauthn/session_loginstate_test.go
+++ b/internal/webauthn/session_loginstate_test.go
@@ -104,15 +104,13 @@ func TestConsumeLoginStateConcurrent(t *testing.T) {
 	var success int64
 	var wg sync.WaitGroup
 	start := make(chan struct{})
-	for i := 0; i < racers; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range racers {
+		wg.Go(func() {
 			<-start
 			if data, err := sm.ConsumeLoginState(ctx, id); err == nil && string(data) == "blob" {
 				atomic.AddInt64(&success, 1)
 			}
-		}()
+		})
 	}
 	close(start)
 	wg.Wait()

--- a/tools/gen-notices/main.go
+++ b/tools/gen-notices/main.go
@@ -162,11 +162,8 @@ func collectNPM(root string) ([]dep, error) {
 			// installed instance. Emit each so a package present at two
 			// versions is fully attributed (and paired with its own path),
 			// rather than collapsed onto a single version/path.
-			n := len(p.Versions)
-			if len(p.Paths) > n {
-				n = len(p.Paths)
-			}
-			for i := 0; i < n; i++ {
+			n := max(len(p.Paths), len(p.Versions))
+			for i := range n {
 				version := ""
 				if i < len(p.Versions) {
 					version = p.Versions[i]

--- a/web/package.json
+++ b/web/package.json
@@ -9,7 +9,7 @@
 		"build": "tsc -b && vite build",
 		"build:docker": "vite build",
 		"typecheck:tests": "tsc --noEmit -p tsconfig.test.json",
-		"lint": "eslint ${@:-.}",
+		"lint": "eslint --no-warn-ignored ${@:-.}",
 		"format": "biome check",
 		"format:fix": "biome check --write",
 		"preview": "vite preview",


### PR DESCRIPTION
## Summary

Completes the modernize pass started in #497: the same mechanical, behavior-preserving gopls **modernize** rewrites for all remaining Go packages (`cmd/`, `tools/`, rest of `internal/`):

- `interface{}` → `any`
- C-style index loops → `range n`
- pointer helpers → `new(expr)`, remaining call sites inlined to typed `new(T(v))`, orphaned test helpers deleted
- `slices.Contains` / `maps.Copy` / `strings.CutPrefix` / `WaitGroup.Go` idioms

Behavior-changing suggestions (`omitempty` → `omitzero`) were **not** applied.

Also carries the Greptile P2 finding from #496: `eslint --no-warn-ignored` in both frontends' lint scripts, so explicit file lists containing non-lintable files (e.g. `biome.json`) no longer emit warn-level ignored-file noise that exit-0s past gates.

## Test plan

- `golangci-lint run ./...` — 0 issues
- `make build` clean
- `go test ./...` — 5511 passed in 34 packages
- Both frontends: `pnpm lint` clean with the new flag, including explicit-file invocations

🤖 Generated with [Claude Code](https://claude.com/claude-code)