### PR TITLE
refactor(gocyclo): bring all prod functions under 30, drop inline nolints

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,9 +25,8 @@ linters:
 
     gocyclo:
       # Ceiling for prod code (tests + generated migrations excluded below).
-      # 30 is the current ratchet: 6 known hotspots above it carry justified
-      # inline nolints (see gocyclo refactor shortlist); lower this as they
-      # get refactored.
+      # 30 is the current ratchet, met with zero inline nolints (worst prod
+      # function is currently 29); lower this as further refactors land.
       min-complexity: 30
 
     gocritic:

--- a/cmd/server/background.go
+++ b/cmd/server/background.go
@@ -1,0 +1,248 @@
+package main
+
+// Background maintenance loops for the server binary: the periodic discovery
+// scheduler, stale request-log cleanup, log retention, and WebAuthn session
+// pruning. Each runs for the app lifetime and exits on ctx cancellation.
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/hugalafutro/model-hotel/internal/debuglog"
+	"github.com/hugalafutro/model-hotel/internal/events"
+	"github.com/hugalafutro/model-hotel/internal/settings"
+	"github.com/hugalafutro/model-hotel/internal/webauthn"
+)
+
+// discoverySchedulerLoop runs periodic discovery based on the settings
+// interval. The first run waits a full interval so it doesn't bypass the
+// discovery_on_startup setting: when that is true, the startup runner already
+// handles immediate discovery; when false, we must not discover on startup
+// either.
+//
+// The timer reacts immediately to discovery_interval changes via the settings
+// subscription channel, instead of waiting for the current timer to expire.
+// An interval of 0 ("Disabled") truly disables periodic discovery rather than
+// resetting to a default: the loop blocks on the subscription channel until a
+// non-zero value arrives.
+func discoverySchedulerLoop(ctx context.Context, settingsRepo *settings.Repository, runDisc func(source string) DiscoveryResult) {
+	const defaultInterval = 6 * time.Hour
+
+	readInterval := func() time.Duration {
+		return settingsRepo.GetDuration(context.Background(), "discovery_interval", defaultInterval)
+	}
+
+	settingsSub := settingsRepo.Subscribe()
+	defer settingsSub.Unsubscribe()
+
+	// applyInterval sets up the timer for the given interval. If the
+	// interval is <= 0 (disabled) the timer is stopped and set to nil.
+	// A nil timer channel blocks forever in select, which is exactly what
+	// we want for the disabled state — only the settings subscription
+	// and the context cancellation can wake us.
+	var timer *time.Timer
+	var timerC <-chan time.Time
+	applyInterval := func(d time.Duration) {
+		if d <= 0 {
+			// Transitioning to disabled: stop and drain the existing timer.
+			if timer != nil {
+				timer.Stop()
+				// Drain the channel if the timer already fired, so the
+				// receive does not leak into the next cycle.
+				select {
+				case <-timer.C:
+				default:
+				}
+				timer = nil
+				timerC = nil
+			}
+		} else {
+			// Transitioning to enabled: reset (or create) the timer.
+			if timer != nil {
+				timer.Stop()
+				select {
+				case <-timer.C:
+				default:
+				}
+				timer.Reset(d)
+			} else {
+				timer = time.NewTimer(d)
+				// NewTimer already starts with duration d; no Reset needed.
+			}
+			timerC = timer.C
+		}
+	}
+
+	interval := readInterval()
+	applyInterval(interval)
+
+	defer func() {
+		if timer != nil {
+			timer.Stop()
+		}
+	}()
+
+	for {
+		if interval <= 0 {
+			// Discovery is disabled. Block until the setting changes
+			// or the server shuts down. We cannot reach the main
+			// select because timerC is nil (blocks forever).
+			select {
+			case <-settingsSub.Events():
+				interval = readInterval()
+				applyInterval(interval)
+			case <-ctx.Done():
+				return
+			}
+			continue
+		}
+
+		select {
+		case <-timerC:
+			result := runDisc("scheduled")
+			publishDiscoveryEvent("Scheduled", result)
+			// Re-read interval in case it changed since the last
+			// subscription event was processed.
+			interval = readInterval()
+			applyInterval(interval)
+
+		case <-settingsSub.Events():
+			// Re-read from DB (the source of truth) rather than
+			// parsing the event value, which may be empty if the
+			// setting was deleted or the lookup failed.
+			newInterval := readInterval()
+			if newInterval != interval {
+				interval = newInterval
+				applyInterval(interval)
+			}
+
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// staleLogCleanupLoop periodically marks rows stuck in "pending"/"streaming"
+// as "failed". Two strategies are combined in a single pass:
+//
+//  1. Server-start-time check: any in-progress row that predates this
+//     process is definitively orphaned (the previous process is dead).
+//     This has zero false-positive risk regardless of request duration.
+//
+//  2. Age-based check: rows older than stale_request_timeout (default
+//     30m, configurable via Settings) are also marked failed. This
+//     catches in-process orphans (e.g. a panic skips the final
+//     updateRequestLog). The timeout is generous to avoid killing
+//     legitimate long-running streaming requests.
+func staleLogCleanupLoop(ctx context.Context, pool *pgxpool.Pool, settingsRepo *settings.Repository, serverStartTime time.Time) {
+	timer := time.NewTimer(5 * time.Minute)
+	defer timer.Stop()
+	for {
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+			return
+		}
+		staleLogCleanupPass(pool, settingsRepo, serverStartTime)
+		timer.Reset(5 * time.Minute)
+	}
+}
+
+// staleLogCleanupPass runs one stale-log sweep; a stale_request_timeout of 0
+// disables the age-based check for this cycle.
+func staleLogCleanupPass(pool *pgxpool.Pool, settingsRepo *settings.Repository, serverStartTime time.Time) {
+	staleTimeout := settingsRepo.GetDuration(context.Background(), "stale_request_timeout", 30*time.Minute)
+	if staleTimeout <= 0 {
+		return
+	}
+	// Build a PostgreSQL-safe interval string from the parsed duration.
+	// Truncate to whole seconds to avoid fractional-unit issues (e.g. "30.5 minutes").
+	totalSecs := int64(staleTimeout.Seconds())
+	hours := totalSecs / 3600
+	mins := (totalSecs % 3600) / 60
+	secs := totalSecs % 60
+	intervalStr := fmt.Sprintf("%d hours %d minutes %d seconds", hours, mins, secs)
+	tag, err := pool.Exec(context.Background(), `
+		UPDATE request_logs
+		SET state = 'failed', error_kind = 'internal', error_message = 'request interrupted (stale)'
+		WHERE state IN ('pending', 'streaming')
+		  AND (created_at < $1 OR created_at < NOW() - $2::interval)`,
+		serverStartTime, intervalStr)
+	if err == nil && tag.RowsAffected() > 0 {
+		debuglog.Info("retention: stale log cleanup", "rows", tag.RowsAffected())
+		events.Publish(events.Event{
+			Type:     "logs.stale_cleanup",
+			Severity: "warning",
+			Message:  fmt.Sprintf("Marked %d stale requests as interrupted", tag.RowsAffected()),
+			Metadata: map[string]any{"count": tag.RowsAffected()},
+		})
+	} else if err != nil {
+		debuglog.Error("retention: stale log cleanup failed", "error", err)
+	}
+}
+
+// logRetentionLoop hourly deletes request_logs and app_logs rows older than
+// the log_retention setting; an empty or unrecognised value (including "0"
+// for disabled) skips the cycle.
+func logRetentionLoop(ctx context.Context, pool *pgxpool.Pool, settingsRepo *settings.Repository) {
+	timer := time.NewTimer(1 * time.Hour)
+	defer timer.Stop()
+	for {
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+			return
+		}
+		logRetentionPass(pool, settingsRepo)
+		timer.Reset(1 * time.Hour)
+	}
+}
+
+// logRetentionPass runs one retention sweep; an empty or unrecognised
+// log_retention value (including "0" for disabled) skips the cycle.
+func logRetentionPass(pool *pgxpool.Pool, settingsRepo *settings.Repository) {
+	retention := settingsRepo.GetWithDefault(context.Background(), "log_retention", "")
+	if retention == "" {
+		return
+	}
+	var cutoff time.Time
+	switch retention {
+	case "1h":
+		cutoff = time.Now().Add(-1 * time.Hour)
+	case "1d", "24h":
+		cutoff = time.Now().Add(-24 * time.Hour)
+	case "1w", "168h":
+		cutoff = time.Now().Add(-7 * 24 * time.Hour)
+	case "1m", "720h":
+		cutoff = time.Now().Add(-30 * 24 * time.Hour)
+	default:
+		return
+	}
+	tag, err := pool.Exec(context.Background(),
+		`DELETE FROM request_logs WHERE created_at < $1`, cutoff)
+	if err == nil {
+		debuglog.Info("retention: log retention deleted old entries", "retention", retention, "rows", tag.RowsAffected())
+	}
+	// Clean app_logs with same retention
+	tag, err = pool.Exec(context.Background(),
+		`DELETE FROM app_logs WHERE created_at < $1`, cutoff)
+	if err == nil {
+		debuglog.Info("retention: app log retention deleted old entries", "retention", retention, "rows", tag.RowsAffected())
+	}
+}
+
+// webauthnSessionCleanupLoop prunes expired WebAuthn sessions hourly.
+func webauthnSessionCleanupLoop(webauthnRepo *webauthn.Repository) {
+	ticker := time.NewTicker(1 * time.Hour)
+	defer ticker.Stop()
+	for range ticker.C {
+		if n, err := webauthnRepo.CleanupExpiredSessions(context.Background()); err != nil {
+			debuglog.Error("webauthn: session cleanup failed", "error", err)
+		} else if n > 0 {
+			debuglog.Info("webauthn: cleaned up expired sessions", "count", n)
+		}
+	}
+}

--- a/cmd/server/background_test.go
+++ b/cmd/server/background_test.go
@@ -1,0 +1,364 @@
+package main
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/hugalafutro/model-hotel/internal/auth"
+	"github.com/hugalafutro/model-hotel/internal/events"
+	"github.com/hugalafutro/model-hotel/internal/failover"
+	"github.com/hugalafutro/model-hotel/internal/model"
+	"github.com/hugalafutro/model-hotel/internal/provider"
+	"github.com/hugalafutro/model-hotel/internal/settings"
+)
+
+func newTestSettingsRepo() *settings.Repository {
+	return settings.NewRepository(cmdTestDB.Pool())
+}
+
+func TestCleanupInterruptedRequests(t *testing.T) {
+	if cmdTestDB == nil {
+		t.Skip("test DB unavailable")
+	}
+	ctx := context.Background()
+	pool := cmdTestDB.Pool()
+	if _, err := pool.Exec(ctx, `DELETE FROM request_logs`); err != nil {
+		t.Fatalf("cleanup failed: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO request_logs (state, created_at) VALUES ('pending', now() - interval '1 hour')`); err != nil {
+		t.Fatalf("insert failed: %v", err)
+	}
+
+	ch := events.DefaultBus.Subscribe()
+	defer events.DefaultBus.Unsubscribe(ch)
+
+	cleanupInterruptedRequests(pool, time.Now())
+
+	var state string
+	if err := pool.QueryRow(ctx, `SELECT state FROM request_logs`).Scan(&state); err != nil {
+		t.Fatalf("query failed: %v", err)
+	}
+	if state != "failed" {
+		t.Errorf("expected interrupted request marked failed, got %q", state)
+	}
+	waitForEvent(t, ch, "logs.stale_startup")
+}
+
+func TestCleanupInterruptedRequestsDBError(t *testing.T) {
+	if cmdTestDB == nil {
+		t.Skip("test DB unavailable")
+	}
+	broken := closedTestPool(t)
+	// Only logs; must not panic on a dead pool.
+	cleanupInterruptedRequests(broken.Pool(), time.Now())
+}
+
+func TestWarmCaches(t *testing.T) {
+	if cmdTestDB == nil {
+		t.Skip("test DB unavailable")
+	}
+	wipeDiscoveryState(t)
+	ctx := context.Background()
+	deps := testDiscoveryDeps(t)
+
+	// One enabled provider with real key material so the Argon2id warm runs.
+	kp, err := auth.Encrypt("sk-test-warm", deps.cfg.MasterKey)
+	if err != nil {
+		t.Fatalf("encrypt failed: %v", err)
+	}
+	if _, err := deps.providerRepo.Create(ctx, provider.CreateProviderRequest{
+		Name:    "cmdserver-warm-test",
+		BaseURL: "http://127.0.0.1:1/v1",
+		APIKey:  "sk-test-warm",
+	}, kp.Ciphertext, kp.Nonce, kp.Salt); err != nil {
+		t.Fatalf("failed to create provider: %v", err)
+	}
+
+	warmCaches(deps, newTestSettingsRepo())
+}
+
+func TestWarmCachesDBErrors(t *testing.T) {
+	if cmdTestDB == nil {
+		t.Skip("test DB unavailable")
+	}
+	deps := testDiscoveryDeps(t)
+	broken := closedTestPool(t)
+	deps.pool = broken.Pool()
+	deps.providerRepo = provider.NewRepository(broken.Pool())
+	deps.modelRepo = model.NewRepository(broken.Pool())
+	deps.failoverRepo = failover.NewRepository(broken.Pool())
+	// Only logs the three list errors; must not panic on a dead pool.
+	warmCaches(deps, newTestSettingsRepo())
+}
+
+func TestInitKeyCacheTTL(t *testing.T) {
+	if cmdTestDB == nil {
+		t.Skip("test DB unavailable")
+	}
+	ctx := context.Background()
+	settingsRepo := newTestSettingsRepo()
+	t.Cleanup(func() {
+		auth.SetKeyCacheTTL(auth.DefaultKeyCacheTTL)
+	})
+
+	initKeyCacheTTL(settingsRepo)
+
+	// A valid change is applied, an invalid one keeps the current value, and
+	// unrelated keys are ignored — all delivered through the change callback.
+	if err := settingsRepo.Set(ctx, "key_cache_ttl", "123ms"); err != nil {
+		t.Fatalf("set failed: %v", err)
+	}
+	if err := settingsRepo.Set(ctx, "key_cache_ttl", "bogus"); err != nil {
+		t.Fatalf("set failed: %v", err)
+	}
+	if err := settingsRepo.Set(ctx, "some_other_key", "x"); err != nil {
+		t.Fatalf("set failed: %v", err)
+	}
+}
+
+func TestDiscoverySchedulerLoop(t *testing.T) {
+	if cmdTestDB == nil {
+		t.Skip("test DB unavailable")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	settingsRepo := newTestSettingsRepo()
+	if err := settingsRepo.Set(ctx, "discovery_interval", "20ms"); err != nil {
+		t.Fatalf("set failed: %v", err)
+	}
+
+	var runs atomic.Int32
+	done := make(chan struct{})
+	go func() {
+		discoverySchedulerLoop(ctx, settingsRepo, func(source string) DiscoveryResult {
+			if source != "scheduled" {
+				t.Errorf("expected scheduled source, got %q", source)
+			}
+			runs.Add(1)
+			return DiscoveryResult{}
+		})
+		close(done)
+	}()
+
+	deadline := time.After(5 * time.Second)
+	for runs.Load() == 0 {
+		select {
+		case <-deadline:
+			t.Fatal("scheduler never ran discovery")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	// A different interval reaches the loop through the settings subscription
+	// and resets the live timer.
+	if err := settingsRepo.Set(ctx, "discovery_interval", "30ms"); err != nil {
+		t.Fatalf("set failed: %v", err)
+	}
+	time.Sleep(50 * time.Millisecond)
+
+	// Interval 0 disables the timer: the loop parks on the settings
+	// subscription until cancellation.
+	if err := settingsRepo.Set(ctx, "discovery_interval", "0s"); err != nil {
+		t.Fatalf("set failed: %v", err)
+	}
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("scheduler did not stop on context cancellation")
+	}
+}
+
+// TestDiscoverySchedulerLoopDisabledAtStart covers the branch where the
+// scheduler starts with discovery disabled: it parks on the settings
+// subscription immediately, wakes when a real interval arrives, and still
+// stops on cancellation.
+func TestDiscoverySchedulerLoopDisabledAtStart(t *testing.T) {
+	if cmdTestDB == nil {
+		t.Skip("test DB unavailable")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	settingsRepo := newTestSettingsRepo()
+	if err := settingsRepo.Set(ctx, "discovery_interval", "0s"); err != nil {
+		t.Fatalf("set failed: %v", err)
+	}
+
+	var runs atomic.Int32
+	done := make(chan struct{})
+	go func() {
+		discoverySchedulerLoop(ctx, settingsRepo, func(string) DiscoveryResult {
+			runs.Add(1)
+			return DiscoveryResult{}
+		})
+		close(done)
+	}()
+
+	// Give the loop a moment to park in the disabled branch, then enable.
+	time.Sleep(50 * time.Millisecond)
+	if runs.Load() != 0 {
+		t.Fatal("disabled scheduler must not run discovery")
+	}
+	if err := settingsRepo.Set(ctx, "discovery_interval", "20ms"); err != nil {
+		t.Fatalf("set failed: %v", err)
+	}
+	deadline := time.After(5 * time.Second)
+	for runs.Load() == 0 {
+		select {
+		case <-deadline:
+			t.Fatal("scheduler never woke from the disabled state")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("scheduler did not stop on context cancellation")
+	}
+}
+
+func TestStaleLogCleanupPass(t *testing.T) {
+	if cmdTestDB == nil {
+		t.Skip("test DB unavailable")
+	}
+	ctx := context.Background()
+	pool := cmdTestDB.Pool()
+	settingsRepo := newTestSettingsRepo()
+
+	t.Run("disabled_by_zero_timeout", func(t *testing.T) {
+		if err := settingsRepo.Set(ctx, "stale_request_timeout", "0s"); err != nil {
+			t.Fatalf("set failed: %v", err)
+		}
+		defer func() { _ = settingsRepo.Set(ctx, "stale_request_timeout", "30m") }()
+		staleLogCleanupPass(pool, settingsRepo, time.Now())
+	})
+
+	t.Run("marks_stale_rows", func(t *testing.T) {
+		if _, err := pool.Exec(ctx, `DELETE FROM request_logs`); err != nil {
+			t.Fatalf("cleanup failed: %v", err)
+		}
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO request_logs (state, created_at) VALUES ('streaming', now() - interval '2 hours')`); err != nil {
+			t.Fatalf("insert failed: %v", err)
+		}
+		ch := events.DefaultBus.Subscribe()
+		defer events.DefaultBus.Unsubscribe(ch)
+
+		staleLogCleanupPass(pool, settingsRepo, time.Now())
+
+		var state string
+		if err := pool.QueryRow(ctx, `SELECT state FROM request_logs`).Scan(&state); err != nil {
+			t.Fatalf("query failed: %v", err)
+		}
+		if state != "failed" {
+			t.Errorf("expected stale request marked failed, got %q", state)
+		}
+		waitForEvent(t, ch, "logs.stale_cleanup")
+	})
+
+	t.Run("db_error_only_logs", func(t *testing.T) {
+		broken := closedTestPool(t)
+		staleLogCleanupPass(broken.Pool(), settingsRepo, time.Now())
+	})
+}
+
+func TestLogRetentionPass(t *testing.T) {
+	if cmdTestDB == nil {
+		t.Skip("test DB unavailable")
+	}
+	ctx := context.Background()
+	pool := cmdTestDB.Pool()
+	settingsRepo := newTestSettingsRepo()
+	setRetention := func(v string) {
+		t.Helper()
+		if err := settingsRepo.Set(ctx, "log_retention", v); err != nil {
+			t.Fatalf("set failed: %v", err)
+		}
+	}
+	t.Cleanup(func() { _ = settingsRepo.Set(ctx, "log_retention", "") })
+
+	t.Run("unset_skips", func(t *testing.T) {
+		setRetention("")
+		logRetentionPass(pool, settingsRepo)
+	})
+
+	t.Run("unrecognised_skips", func(t *testing.T) {
+		if _, err := pool.Exec(ctx, `DELETE FROM request_logs`); err != nil {
+			t.Fatalf("cleanup failed: %v", err)
+		}
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO request_logs (state, created_at) VALUES ('completed', now() - interval '10 days')`); err != nil {
+			t.Fatalf("insert failed: %v", err)
+		}
+		setRetention("0")
+		logRetentionPass(pool, settingsRepo)
+		var n int
+		if err := pool.QueryRow(ctx, `SELECT count(*) FROM request_logs`).Scan(&n); err != nil {
+			t.Fatalf("count failed: %v", err)
+		}
+		if n != 1 {
+			t.Errorf("expected disabled retention to keep the row, got %d rows", n)
+		}
+	})
+
+	t.Run("deletes_old_rows", func(t *testing.T) {
+		// The 10-day-old row from the previous subtest is older than 1 week.
+		setRetention("1w")
+		logRetentionPass(pool, settingsRepo)
+		var n int
+		if err := pool.QueryRow(ctx, `SELECT count(*) FROM request_logs`).Scan(&n); err != nil {
+			t.Fatalf("count failed: %v", err)
+		}
+		if n != 0 {
+			t.Errorf("expected old row deleted, got %d rows", n)
+		}
+	})
+
+	t.Run("other_retention_windows", func(t *testing.T) {
+		for _, v := range []string{"1h", "24h", "720h"} {
+			setRetention(v)
+			logRetentionPass(pool, settingsRepo)
+		}
+	})
+}
+
+func TestStaleLogCleanupLoopStopsOnCancel(t *testing.T) {
+	if cmdTestDB == nil {
+		t.Skip("test DB unavailable")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		staleLogCleanupLoop(ctx, cmdTestDB.Pool(), newTestSettingsRepo(), time.Now())
+		close(done)
+	}()
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("stale log cleanup loop did not stop on cancellation")
+	}
+}
+
+func TestLogRetentionLoopStopsOnCancel(t *testing.T) {
+	if cmdTestDB == nil {
+		t.Skip("test DB unavailable")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		logRetentionLoop(ctx, cmdTestDB.Pool(), newTestSettingsRepo())
+		close(done)
+	}()
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("log retention loop did not stop on cancellation")
+	}
+}

--- a/cmd/server/discovery.go
+++ b/cmd/server/discovery.go
@@ -1,0 +1,313 @@
+package main
+
+// Discovery orchestration for the server binary: the startup/scheduled
+// discovery runs, their per-provider scan stage, and the failover re-sync
+// that follows every run. main wires a discoveryDeps once and hands it to
+// runDiscovery via the scheduler and the startup runner.
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/hugalafutro/model-hotel/internal/api"
+	"github.com/hugalafutro/model-hotel/internal/config"
+	"github.com/hugalafutro/model-hotel/internal/debuglog"
+	"github.com/hugalafutro/model-hotel/internal/events"
+	"github.com/hugalafutro/model-hotel/internal/failover"
+	"github.com/hugalafutro/model-hotel/internal/model"
+	"github.com/hugalafutro/model-hotel/internal/provider"
+	"github.com/hugalafutro/model-hotel/internal/proxy"
+	"github.com/hugalafutro/model-hotel/internal/settings"
+)
+
+type DiscoveryResult struct {
+	ProvidersScanned int
+	ProvidersFailed  int
+	ModelsDiscovered int
+	ModelsDisabled   int
+	FailoverSyncErrs int
+	Errors           []string
+}
+
+// discoveryDeps carries the wiring a discovery run needs; main fills it once
+// and the startup and scheduled runners share it.
+type discoveryDeps struct {
+	cfg          *config.Config
+	pool         *pgxpool.Pool
+	providerRepo *provider.Repository
+	modelRepo    *model.Repository
+	failoverRepo *failover.Repository
+	dialer       *proxy.SafeDialer
+}
+
+func publishDiscoveryEvent(source string, result DiscoveryResult) {
+	switch {
+	case result.ProvidersScanned == 0 && len(result.Errors) > 0:
+		events.Publish(events.Event{
+			Type:     "discovery.complete",
+			Severity: "error",
+			Message:  fmt.Sprintf("Discovery failed: %s", result.Errors[0]),
+			Metadata: map[string]any{"source": source, "errors": result.Errors},
+		})
+	case result.ProvidersFailed > 0:
+		events.Publish(events.Event{
+			Type:     "discovery.complete",
+			Severity: "warning",
+			Message:  fmt.Sprintf("Discovery partially failed: %d/%d providers OK, %d models found", result.ProvidersScanned-result.ProvidersFailed, result.ProvidersScanned, result.ModelsDiscovered),
+			Metadata: map[string]any{"source": source, "errors": result.Errors},
+		})
+	default:
+		events.Publish(events.Event{
+			Type:     "discovery.complete",
+			Severity: "success",
+			Message:  fmt.Sprintf("%s discovery complete: %d models across %d providers", source, result.ModelsDiscovered, result.ProvidersScanned),
+			Metadata: map[string]any{"source": source},
+		})
+	}
+}
+
+// runDiscovery scans every enabled provider, upserts what each scan found,
+// records confirmed-missing models, and re-syncs failover groups afterwards.
+// source labels the trigger ("startup"/"scheduled") in events and the
+// discovery change feed.
+func runDiscovery(deps discoveryDeps, source string) DiscoveryResult {
+	result := DiscoveryResult{}
+	// Set when any background-discovery change row is recorded, so we can
+	// publish a single live-update event for the Models nav badge.
+	changesRecorded := false
+	ctx := context.Background()
+	providers, err := deps.providerRepo.List(ctx)
+	if err != nil {
+		debuglog.Error("discovery: failed to list providers", "error", err)
+		result.Errors = append(result.Errors, fmt.Sprintf("failed to list providers: %v", err))
+		return result
+	}
+	discoverySvc := provider.NewDiscoveryService(deps.dialer.DialContext, deps.dialer.CheckRedirect)
+	for _, p := range providers {
+		if !p.Enabled {
+			continue
+		}
+		if scanProvider(ctx, deps, discoverySvc, p, source, &result) {
+			changesRecorded = true
+		}
+	}
+
+	if syncFailoverAfterDiscovery(ctx, deps, source, providers, &result) {
+		changesRecorded = true
+	}
+
+	// One live-update nudge so the Models nav badge refreshes without a
+	// reload; the badge query re-fetches the authoritative count.
+	if changesRecorded {
+		events.Publish(events.Event{
+			Type:     "discovery.changes_pending",
+			Severity: "info",
+			Source:   "discovery",
+			Message:  "Background discovery recorded model changes",
+			Metadata: map[string]any{"source": source},
+		})
+	}
+	return result
+}
+
+// scanProvider runs one enabled provider's discovery pass: discover, enrich
+// and normalize, upsert, record confirmed-missing models, and append the
+// provider's change-feed entry. It updates result's counters and reports
+// whether a discovery-change row was recorded.
+func scanProvider(ctx context.Context, deps discoveryDeps, discoverySvc *provider.DiscoveryService, p *provider.Provider, source string, result *DiscoveryResult) (changed bool) {
+	result.ProvidersScanned++
+	models, err := discoverySvc.DiscoverModels(ctx, p, deps.cfg.MasterKey)
+	if err != nil {
+		debuglog.Error("discovery: failed for provider", "provider", p.Name, "error", err)
+		result.ProvidersFailed++
+		result.Errors = append(result.Errors, fmt.Sprintf("provider %s: %v", p.Name, err))
+		// Update last_discovered_at even on failure so the UI reflects
+		// that discovery was *attempted*. Without this, a chronically
+		// failing provider shows a stale "Last discovered" timestamp
+		// that makes the scheduled timer appear broken.
+		touchLastDiscovered(ctx, deps.pool, p)
+		return false
+	}
+
+	// Enrich models with data from models.dev.
+	if cache := provider.GetModelsDevCache(); cache != nil {
+		if enriched := cache.EnrichModels(models); enriched > 0 {
+			debuglog.Info("discovery: enriched models from models.dev", "enriched", enriched, "total", len(models), "provider", p.Name)
+		}
+	}
+	// Runs unconditionally: modality arrays and the derived endpoint
+	// class must be consistent even when models.dev is unreachable.
+	provider.NormalizeModels(models)
+	result.ModelsDiscovered += len(models)
+
+	// Snapshot pre-scan state so background metadata/membership changes
+	// can be recorded for the Models nav badge. A snapshot failure only
+	// disables the diff for this provider; the scan itself proceeds.
+	snapshot, snapErr := api.SnapshotProviderModels(ctx, deps.modelRepo, p.ID)
+	if snapErr != nil {
+		debuglog.Debug("discovery: failed to snapshot models", "provider", p.Name, "error", snapErr)
+	}
+	api.DampenOpenRouterPriceJitter(p.BaseURL, snapshot, models)
+
+	existingModelIDs := make([]string, 0, len(models))
+	upsertedModels := make([]*model.Model, 0, len(models))
+	upsertFailed := false
+	for _, m := range models {
+		if err := deps.modelRepo.Upsert(ctx, m); err != nil {
+			debuglog.Error("discovery: failed to upsert model", "model_id", m.ModelID, "error", err)
+			upsertFailed = true
+		} else {
+			existingModelIDs = append(existingModelIDs, m.ModelID)
+			upsertedModels = append(upsertedModels, m)
+		}
+	}
+	// Miss recording needs a trustworthy membership picture: skip it
+	// when the snapshot is unavailable (absentees cannot be confirmed)
+	// or any upsert failed (a DB error must not count a listed model
+	// as missing). Absent models get a second opinion via confirmation
+	// probes, and a model is disabled only after
+	// model.MissingScanThreshold consecutive confirmed-missing scans.
+	var disabledRefs []model.DisabledModelRef
+	if snapErr == nil && !upsertFailed {
+		disabledRefs = recordMissingModels(ctx, deps, discoverySvc, p, existingModelIDs, snapshot)
+	}
+	if len(disabledRefs) > 0 {
+		result.ModelsDisabled += len(disabledRefs)
+		events.Publish(events.Event{
+			Type:     "discovery.models_disabled",
+			Severity: "warning",
+			Message:  fmt.Sprintf("%d models no longer available at '%s' and were disabled", len(disabledRefs), p.Name),
+			Metadata: map[string]any{"provider": p.Name, "count": len(disabledRefs)},
+		})
+	}
+
+	// Record this provider's model-level diff (added/reenabled/disabled/
+	// metadata-updated) for later review. Failover group churn is folded
+	// in once after the global failover sync below.
+	if snapErr == nil {
+		diff := api.BuildDiscoveryDiff(snapshot, upsertedModels, disabledRefs)
+		if wrote, err := api.AppendDiscoveryChange(ctx, deps.pool, source, &p.ID, p.Name, diff); err != nil {
+			debuglog.Error("discovery: failed to record changes", "provider", p.Name, "error", err)
+		} else if wrote {
+			changed = wrote
+		}
+	}
+
+	touchLastDiscovered(ctx, deps.pool, p)
+	debuglog.Info("discovery: discovered models", "count", len(models), "provider", p.Name)
+	return changed
+}
+
+// recordMissingModels confirms which of the snapshot's models this scan no
+// longer sees (via confirmation probes) and records the misses; a model is
+// disabled only after model.MissingScanThreshold consecutive confirmed-missing
+// scans. Returns the refs that crossed the threshold and were disabled.
+func recordMissingModels(ctx context.Context, deps discoveryDeps, discoverySvc *provider.DiscoveryService, p *provider.Provider, existingModelIDs []string, snapshot map[string]api.ModelSnapshot) []model.DisabledModelRef {
+	confirmedIDs, suspect := api.ConfirmMissingModels(ctx, discoverySvc, p, deps.cfg.MasterKey, existingModelIDs, snapshot, api.NewSuspectStreak(deps.pool))
+	if suspect {
+		debuglog.Warn("discovery: suspect scan, skipping missing-model recording", "provider", p.Name)
+		return nil
+	}
+	disabledRefs, pendingRefs, err := deps.modelRepo.RecordMissingModels(ctx, p.ID, p.Name, confirmedIDs)
+	if err != nil {
+		debuglog.Error("discovery: failed to record missing models", "provider", p.Name, "error", err)
+	}
+	if len(pendingRefs) > 0 {
+		debuglog.Info("discovery: models confirmed missing but below disable threshold",
+			"provider", p.Name, "pending", len(pendingRefs), "threshold", model.MissingScanThreshold)
+	}
+	return disabledRefs
+}
+
+// touchLastDiscovered stamps the provider's last_discovered_at, on success and
+// failure alike, so the UI reflects that discovery was attempted.
+func touchLastDiscovered(ctx context.Context, pool *pgxpool.Pool, p *provider.Provider) {
+	now := time.Now()
+	if _, err := pool.Exec(ctx, `UPDATE providers SET last_discovered_at = $1 WHERE id = $2`, now, p.ID); err != nil {
+		debuglog.Error("discovery: failed to update last_discovered_at", "provider", p.Name, "error", err)
+	}
+}
+
+// syncFailoverAfterDiscovery rebuilds auto failover groups for every model
+// visible on an enabled provider, revalidates custom groups, and records the
+// run-wide failover change entry. Reports whether a change row was recorded.
+func syncFailoverAfterDiscovery(ctx context.Context, deps discoveryDeps, source string, providers []*provider.Provider, result *DiscoveryResult) (changed bool) {
+	seenModelIDs := make(map[string]bool)
+	for _, p := range providers {
+		if !p.Enabled {
+			continue
+		}
+		models, _ := deps.modelRepo.List(ctx, &p.ID)
+		for _, m := range models {
+			seenModelIDs[m.ModelID] = true
+		}
+	}
+	failoverDiff := &api.DiscoveryDiff{}
+	for modelID := range seenModelIDs {
+		syncRes, err := deps.failoverRepo.SyncForModel(ctx, modelID)
+		if err != nil {
+			debuglog.Error("discovery: failed to sync failover", "model_id", modelID, "error", err)
+			result.FailoverSyncErrs++
+			events.Publish(events.Event{
+				Type:     "failover.sync_error",
+				Severity: "warning",
+				Message:  fmt.Sprintf("Failover sync failed for model '%s'", modelID),
+				Metadata: map[string]any{"error": err.Error(), "model_id": modelID},
+			})
+			continue
+		}
+		if syncRes != nil {
+			failoverDiff.FailoverDeletedGroups = append(failoverDiff.FailoverDeletedGroups, syncRes.DeletedGroups...)
+			failoverDiff.FailoverUpdatedGroups = append(failoverDiff.FailoverUpdatedGroups, syncRes.UpdatedGroups...)
+		}
+	}
+	// SyncForModel only rebuilds auto-groups; custom groups whose member was
+	// just disabled (not deleted) keep their stale size. Revalidate once per
+	// cycle so background discovery auto-disables any custom group left with
+	// fewer than two routable members — the headless path the manual Sync and
+	// interactive discover already cover.
+	if revRes, err := deps.failoverRepo.RevalidateCustomGroups(ctx); err != nil {
+		debuglog.Error("discovery: failed to revalidate custom failover groups", "error", err)
+	} else if revRes != nil {
+		failoverDiff.FailoverDisabledGroups = append(failoverDiff.FailoverDisabledGroups, revRes.DisabledGroups...)
+	}
+	// Record failover group churn as one aggregate entry (the global sync is
+	// not per-provider). An empty provider_name flags this to the frontend as
+	// the run-wide failover entry, which it labels accordingly.
+	if wrote, err := api.AppendDiscoveryChange(ctx, deps.pool, source, nil, "", failoverDiff); err != nil {
+		debuglog.Error("discovery: failed to record failover changes", "error", err)
+	} else if wrote {
+		changed = wrote
+	}
+	return changed
+}
+
+// maybeStartupDiscovery launches the initial discovery run in the background,
+// unless discovery_on_startup is off or any provider was already discovered
+// within the last 5 minutes (a restart loop must not hammer providers).
+func maybeStartupDiscovery(deps discoveryDeps, settingsRepo *settings.Repository) {
+	if !settingsRepo.GetBool(context.Background(), "discovery_on_startup", true) {
+		return
+	}
+	recentlyDiscovered := false
+	providers, err := deps.providerRepo.List(context.Background())
+	if err == nil {
+		for _, p := range providers {
+			if p.LastDiscoveredAt != nil && time.Since(*p.LastDiscoveredAt) < 5*time.Minute {
+				recentlyDiscovered = true
+				break
+			}
+		}
+	}
+	if recentlyDiscovered {
+		debuglog.Info("discovery: skipping startup — last discovery within 5 minutes")
+		return
+	}
+	go func() {
+		result := runDiscovery(deps, "startup")
+		publishDiscoveryEvent("Startup", result)
+	}()
+}

--- a/cmd/server/discovery_test.go
+++ b/cmd/server/discovery_test.go
@@ -1,0 +1,346 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/hugalafutro/model-hotel/internal/config"
+	"github.com/hugalafutro/model-hotel/internal/db"
+	"github.com/hugalafutro/model-hotel/internal/events"
+	"github.com/hugalafutro/model-hotel/internal/failover"
+	"github.com/hugalafutro/model-hotel/internal/model"
+	"github.com/hugalafutro/model-hotel/internal/provider"
+	"github.com/hugalafutro/model-hotel/internal/proxy"
+	"github.com/hugalafutro/model-hotel/internal/util"
+)
+
+// ---------------------------------------------------------------------------
+// Integration test database setup
+// ---------------------------------------------------------------------------
+
+var cmdTestDB *db.DB
+var cmdTestDBURL string
+
+func TestMain(m *testing.M) {
+	ctx := context.Background()
+	var err error
+	var setupErr error
+	cmdTestDBURL, setupErr = db.SetupTestDB("cmdserver")
+	if setupErr != nil {
+		log.Printf("failed to setup test DB: %v", setupErr)
+		os.Exit(1)
+	}
+	defer db.CleanupTestDB("cmdserver")
+
+	cmdTestDB, err = db.New(ctx, cmdTestDBURL, 25, 5)
+	if err != nil {
+		log.Printf("failed to initialize test DB: %v", err)
+		os.Exit(1) //nolint:gocritic // test-only: os.Exit in TestMain is intentional
+	}
+	defer cmdTestDB.Close()
+
+	util.CloseDockerClient()
+	os.Exit(m.Run()) //nolint:gocritic // test-only: os.Exit in TestMain is intentional
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func testDiscoveryDeps(t *testing.T) discoveryDeps {
+	t.Helper()
+	pool := cmdTestDB.Pool()
+	return discoveryDeps{
+		cfg:          &config.Config{MasterKey: "test-master-key-1234567890abcdef"},
+		pool:         pool,
+		providerRepo: provider.NewRepository(pool),
+		modelRepo:    model.NewRepository(pool),
+		failoverRepo: failover.NewRepository(pool),
+		dialer:       proxy.NewSafeDialer([]string{"127.0.0.1"}, nil),
+	}
+}
+
+// wipeDiscoveryState clears the tables discovery writes to so tests don't
+// bleed into each other (models cascade-delete with their provider).
+func wipeDiscoveryState(t *testing.T) {
+	t.Helper()
+	ctx := context.Background()
+	for _, stmt := range []string{
+		`DELETE FROM model_failover_groups`,
+		`DELETE FROM providers`,
+		`DELETE FROM discovery_changes`,
+	} {
+		if _, err := cmdTestDB.Pool().Exec(ctx, stmt); err != nil {
+			t.Fatalf("cleanup %q failed: %v", stmt, err)
+		}
+	}
+}
+
+// closedTestPool returns a pool whose connections are already closed, for
+// exercising DB-error branches.
+func closedTestPool(t *testing.T) *db.DB {
+	t.Helper()
+	database, err := db.New(context.Background(), cmdTestDBURL, 2, 1)
+	if err != nil {
+		t.Fatalf("failed to open second test DB handle: %v", err)
+	}
+	database.Close()
+	return database
+}
+
+// waitForEvent blocks until an event of the wanted type arrives on ch.
+func waitForEvent(t *testing.T, ch chan events.Event, wantType string) events.Event {
+	t.Helper()
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case ev := <-ch:
+			if ev.Type == wantType {
+				return ev
+			}
+		case <-deadline:
+			t.Fatalf("timed out waiting for %s event", wantType)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+func TestRunDiscoveryNoProviders(t *testing.T) {
+	if cmdTestDB == nil {
+		t.Skip("test DB unavailable")
+	}
+	wipeDiscoveryState(t)
+
+	result := runDiscovery(testDiscoveryDeps(t), "test")
+	if result.ProvidersScanned != 0 || result.ProvidersFailed != 0 || result.ModelsDiscovered != 0 {
+		t.Errorf("expected empty result, got %+v", result)
+	}
+	if len(result.Errors) != 0 {
+		t.Errorf("expected no errors, got %v", result.Errors)
+	}
+}
+
+func TestRunDiscoveryListError(t *testing.T) {
+	if cmdTestDB == nil {
+		t.Skip("test DB unavailable")
+	}
+	deps := testDiscoveryDeps(t)
+	broken := closedTestPool(t)
+	deps.pool = broken.Pool()
+	deps.providerRepo = provider.NewRepository(broken.Pool())
+
+	result := runDiscovery(deps, "test")
+	if len(result.Errors) == 0 {
+		t.Fatal("expected a list-providers error")
+	}
+}
+
+// TestRunDiscoveryHappyPath drives a full discovery cycle against a mock
+// OpenAI-compatible provider: models are discovered, upserted, and the
+// change-feed nudge event fires.
+func TestRunDiscoveryHappyPath(t *testing.T) {
+	if cmdTestDB == nil {
+		t.Skip("test DB unavailable")
+	}
+	wipeDiscoveryState(t)
+	ctx := context.Background()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"object": "list",
+			"data": []map[string]any{
+				{"id": "test-model-a", "object": "model", "owned_by": "tester"},
+				{"id": "test-model-b", "object": "model", "owned_by": "tester"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	deps := testDiscoveryDeps(t)
+	// Keyless provider (nil key material) pointed at the mock server.
+	p, err := deps.providerRepo.Create(ctx, provider.CreateProviderRequest{
+		Name:    "cmdserver-discovery-test",
+		BaseURL: srv.URL + "/v1",
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("failed to create provider: %v", err)
+	}
+	// A second provider serving the same model IDs, so the failover sync
+	// creates an auto group and records run-wide failover churn.
+	if _, err := deps.providerRepo.Create(ctx, provider.CreateProviderRequest{
+		Name:    "cmdserver-discovery-test-b",
+		BaseURL: srv.URL + "/v1b",
+	}, nil, nil, nil); err != nil {
+		t.Fatalf("failed to create second provider: %v", err)
+	}
+	// A disabled provider is skipped entirely (never scanned, never counted).
+	disabled, err := deps.providerRepo.Create(ctx, provider.CreateProviderRequest{
+		Name:    "cmdserver-disabled-test",
+		BaseURL: "http://127.0.0.1:1/v1",
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("failed to create disabled provider: %v", err)
+	}
+	if _, err := deps.pool.Exec(ctx, `UPDATE providers SET enabled = false WHERE id = $1`, disabled.ID); err != nil {
+		t.Fatalf("failed to disable provider: %v", err)
+	}
+
+	ch := events.DefaultBus.Subscribe()
+	defer events.DefaultBus.Unsubscribe(ch)
+
+	result := runDiscovery(deps, "test")
+
+	if result.ProvidersScanned != 2 {
+		t.Errorf("expected 2 providers scanned, got %d", result.ProvidersScanned)
+	}
+	if result.ProvidersFailed != 0 {
+		t.Errorf("expected 0 failures, got %d (%v)", result.ProvidersFailed, result.Errors)
+	}
+	if result.ModelsDiscovered != 4 {
+		t.Errorf("expected 4 models discovered, got %d", result.ModelsDiscovered)
+	}
+
+	models, err := deps.modelRepo.List(ctx, &p.ID)
+	if err != nil {
+		t.Fatalf("failed to list models: %v", err)
+	}
+	if len(models) != 2 {
+		t.Errorf("expected 2 models upserted for the first provider, got %d", len(models))
+	}
+
+	// Both providers expose the same model IDs, so auto failover groups formed.
+	var groups int
+	if err := deps.pool.QueryRow(ctx,
+		`SELECT count(*) FROM model_failover_groups WHERE auto_created = true`).Scan(&groups); err != nil {
+		t.Fatalf("failed to count failover groups: %v", err)
+	}
+	if groups != 2 {
+		t.Errorf("expected 2 auto failover groups, got %d", groups)
+	}
+
+	// The new models produce a change-feed row, which fires the badge nudge.
+	waitForEvent(t, ch, "discovery.changes_pending")
+
+	// last_discovered_at was stamped on the scanned provider only.
+	fresh, err := deps.providerRepo.List(ctx)
+	if err != nil {
+		t.Fatalf("failed to re-list providers: %v", err)
+	}
+	for _, fp := range fresh {
+		switch fp.ID {
+		case p.ID:
+			if fp.LastDiscoveredAt == nil {
+				t.Error("expected last_discovered_at to be stamped after discovery")
+			}
+		case disabled.ID:
+			if fp.LastDiscoveredAt != nil {
+				t.Error("disabled provider must not be scanned")
+			}
+		}
+	}
+}
+
+func TestScanProviderUnreachable(t *testing.T) {
+	if cmdTestDB == nil {
+		t.Skip("test DB unavailable")
+	}
+	wipeDiscoveryState(t)
+	ctx := context.Background()
+
+	deps := testDiscoveryDeps(t)
+	p, err := deps.providerRepo.Create(ctx, provider.CreateProviderRequest{
+		Name:    "cmdserver-unreachable-test",
+		BaseURL: "http://127.0.0.1:1/v1", // nothing listens on port 1
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("failed to create provider: %v", err)
+	}
+
+	svc := provider.NewDiscoveryService(deps.dialer.DialContext, deps.dialer.CheckRedirect)
+	var result DiscoveryResult
+	changed := scanProvider(ctx, deps, svc, p, "test", &result)
+	if changed {
+		t.Error("expected no change row for a failed scan")
+	}
+	if result.ProvidersFailed != 1 || len(result.Errors) != 1 {
+		t.Errorf("expected a recorded failure, got %+v", result)
+	}
+
+	// The failed attempt still stamps last_discovered_at.
+	fresh, err := deps.providerRepo.List(ctx)
+	if err != nil {
+		t.Fatalf("failed to list providers: %v", err)
+	}
+	if len(fresh) != 1 || fresh[0].LastDiscoveredAt == nil {
+		t.Error("expected last_discovered_at to be stamped after a failed scan")
+	}
+}
+
+func TestTouchLastDiscoveredError(t *testing.T) {
+	if cmdTestDB == nil {
+		t.Skip("test DB unavailable")
+	}
+	broken := closedTestPool(t)
+	// Only logs; must not panic on a dead pool.
+	touchLastDiscovered(context.Background(), broken.Pool(), &provider.Provider{Name: "x"})
+}
+
+func TestMaybeStartupDiscovery(t *testing.T) {
+	if cmdTestDB == nil {
+		t.Skip("test DB unavailable")
+	}
+	deps := testDiscoveryDeps(t)
+	settingsRepo := newTestSettingsRepo()
+	ctx := context.Background()
+
+	t.Run("disabled_by_setting", func(t *testing.T) {
+		wipeDiscoveryState(t)
+		if err := settingsRepo.Set(ctx, "discovery_on_startup", "false"); err != nil {
+			t.Fatalf("failed to set setting: %v", err)
+		}
+		defer func() { _ = settingsRepo.Set(ctx, "discovery_on_startup", "true") }()
+		// Must return without launching discovery; nothing observable to
+		// assert beyond not panicking and not touching providers.
+		maybeStartupDiscovery(deps, settingsRepo)
+	})
+
+	t.Run("skips_recently_discovered", func(t *testing.T) {
+		wipeDiscoveryState(t)
+		p, err := deps.providerRepo.Create(ctx, provider.CreateProviderRequest{
+			Name:    "cmdserver-recent-test",
+			BaseURL: "http://127.0.0.1:1/v1",
+		}, nil, nil, nil)
+		if err != nil {
+			t.Fatalf("failed to create provider: %v", err)
+		}
+		touchLastDiscovered(ctx, deps.pool, p)
+		// Recently-discovered guard fires: no background run is launched, so
+		// the unreachable provider is never scanned again.
+		maybeStartupDiscovery(deps, settingsRepo)
+	})
+
+	t.Run("runs_in_background", func(t *testing.T) {
+		wipeDiscoveryState(t)
+		ch := events.DefaultBus.Subscribe()
+		defer events.DefaultBus.Unsubscribe(ch)
+
+		maybeStartupDiscovery(deps, settingsRepo)
+
+		// Zero providers: the background run completes immediately with a
+		// success event.
+		ev := waitForEvent(t, ch, "discovery.complete")
+		if ev.Severity != "success" {
+			t.Errorf("expected success severity, got %q", ev.Severity)
+		}
+	})
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/hugalafutro/model-hotel/internal/admin"
 	"github.com/hugalafutro/model-hotel/internal/adminauth"
@@ -53,42 +54,56 @@ var version = "dev"
 //go:embed all:static
 var staticFiles embed.FS
 
-type DiscoveryResult struct {
-	ProvidersScanned int
-	ProvidersFailed  int
-	ModelsDiscovered int
-	ModelsDisabled   int
-	FailoverSyncErrs int
-	Errors           []string
+// initAppLogging routes slog output through the app log pipeline so debuglog
+// calls reach the ring buffer and database (not just os.Stdout). When OTLP log
+// export is enabled (OTEL_EXPORTER_OTLP_ENDPOINT), fan out to it too so the
+// same structured records are pushed to an OpenTelemetry collector. Returns
+// the OTLP shutdown hook, nil when export is not enabled.
+func initAppLogging(ctx context.Context) func(context.Context) error {
+	appLogHandler := api.NewAppSlogHandler(debuglog.Level())
+	var otelLogShutdown func(context.Context) error
+	if otelexport.LogsEnabled() {
+		otelHandler, shutdown, oerr := otelexport.NewSlogHandler(ctx, "model-hotel", debuglog.Level())
+		if oerr != nil {
+			debuglog.Error("otel: OTLP log export init failed; continuing without it", "error", oerr)
+		} else {
+			appLogHandler = debuglog.NewFanout(appLogHandler, otelHandler)
+			otelLogShutdown = shutdown
+		}
+	}
+	debuglog.SetHandler(appLogHandler)
+	// Logged after SetHandler installs the fan-out, so the confirmation itself
+	// is also exported to the OTLP collector.
+	if otelLogShutdown != nil {
+		debuglog.Info("otel: OTLP log export enabled")
+	}
+	return otelLogShutdown
 }
 
-func publishDiscoveryEvent(source string, result DiscoveryResult) {
-	switch {
-	case result.ProvidersScanned == 0 && len(result.Errors) > 0:
+// cleanupInterruptedRequests marks request logs left in "pending" or
+// "streaming" state from a previous server crash, restart, or unhandled error
+// as failed. Using serverStartTime (captured before DB was ready) means we
+// only reclaim rows that predate this process — a genuine streaming request
+// that happens to be long-running is never touched.
+func cleanupInterruptedRequests(pool *pgxpool.Pool, serverStartTime time.Time) {
+	tag, err := pool.Exec(context.Background(), `
+		UPDATE request_logs
+		SET state = 'failed', error_kind = 'internal', error_message = 'request interrupted (server restart)'
+		WHERE state IN ('pending', 'streaming')
+		  AND created_at < $1`, serverStartTime)
+	if err == nil && tag.RowsAffected() > 0 {
+		debuglog.Info("startup: stale log cleanup", "rows", tag.RowsAffected())
 		events.Publish(events.Event{
-			Type:     "discovery.complete",
-			Severity: "error",
-			Message:  fmt.Sprintf("Discovery failed: %s", result.Errors[0]),
-			Metadata: map[string]any{"source": source, "errors": result.Errors},
-		})
-	case result.ProvidersFailed > 0:
-		events.Publish(events.Event{
-			Type:     "discovery.complete",
+			Type:     "logs.stale_startup",
 			Severity: "warning",
-			Message:  fmt.Sprintf("Discovery partially failed: %d/%d providers OK, %d models found", result.ProvidersScanned-result.ProvidersFailed, result.ProvidersScanned, result.ModelsDiscovered),
-			Metadata: map[string]any{"source": source, "errors": result.Errors},
+			Message:  fmt.Sprintf("Server restart interrupted %d pending requests", tag.RowsAffected()),
+			Metadata: map[string]any{"count": tag.RowsAffected()},
 		})
-	default:
-		events.Publish(events.Event{
-			Type:     "discovery.complete",
-			Severity: "success",
-			Message:  fmt.Sprintf("%s discovery complete: %d models across %d providers", source, result.ModelsDiscovered, result.ProvidersScanned),
-			Metadata: map[string]any{"source": source},
-		})
+	} else if err != nil {
+		debuglog.Error("startup: stale log cleanup failed", "error", err)
 	}
 }
 
-//nolint:gocyclo // complexity 114: linear startup wiring (config, DI, route registration), not branching logic; on the gocyclo refactor shortlist
 func main() {
 	cfg, err := config.Load()
 	if err != nil {
@@ -121,27 +136,7 @@ func main() {
 
 	api.InitAppLogBuffer(database.Pool())
 
-	// Route slog output through the app log pipeline so debuglog calls reach the
-	// ring buffer and database (not just os.Stdout). When OTLP log export is
-	// enabled (OTEL_EXPORTER_OTLP_ENDPOINT), fan out to it too so the same
-	// structured records are pushed to an OpenTelemetry collector.
-	appLogHandler := api.NewAppSlogHandler(debuglog.Level())
-	var otelLogShutdown func(context.Context) error
-	if otelexport.LogsEnabled() {
-		otelHandler, shutdown, oerr := otelexport.NewSlogHandler(ctx, "model-hotel", debuglog.Level())
-		if oerr != nil {
-			debuglog.Error("otel: OTLP log export init failed; continuing without it", "error", oerr)
-		} else {
-			appLogHandler = debuglog.NewFanout(appLogHandler, otelHandler)
-			otelLogShutdown = shutdown
-		}
-	}
-	debuglog.SetHandler(appLogHandler)
-	// Logged after SetHandler installs the fan-out, so the confirmation itself
-	// is also exported to the OTLP collector.
-	if otelLogShutdown != nil {
-		debuglog.Info("otel: OTLP log export enabled")
-	}
+	otelLogShutdown := initAppLogging(ctx)
 
 	debuglog.Info("db: Database connected and migrations applied successfully")
 	debuglog.Info("startup: admin token", "source", func() string {
@@ -152,28 +147,8 @@ func main() {
 	}())
 	debuglog.Info("config: Config loaded")
 
-	// Clean up stale request logs left in "pending" or "streaming" state
-	// from a previous server crash, restart, or unhandled error.
-	// Using serverStartTime (captured before DB was ready) means we only
-	// reclaim rows that predate this process — a genuine streaming request
-	// that happens to be long-running is never touched.
 	serverStartTime := time.Now()
-	tag, err := database.Pool().Exec(context.Background(), `
-		UPDATE request_logs
-		SET state = 'failed', error_kind = 'internal', error_message = 'request interrupted (server restart)'
-		WHERE state IN ('pending', 'streaming')
-		  AND created_at < $1`, serverStartTime)
-	if err == nil && tag.RowsAffected() > 0 {
-		debuglog.Info("startup: stale log cleanup", "rows", tag.RowsAffected())
-		events.Publish(events.Event{
-			Type:     "logs.stale_startup",
-			Severity: "warning",
-			Message:  fmt.Sprintf("Server restart interrupted %d pending requests", tag.RowsAffected()),
-			Metadata: map[string]any{"count": tag.RowsAffected()},
-		})
-	} else if err != nil {
-		debuglog.Error("startup: stale log cleanup failed", "error", err)
-	}
+	cleanupInterruptedRequests(database.Pool(), serverStartTime)
 
 	providerRepo := provider.NewRepository(database.Pool())
 	modelRepo := model.NewRepository(database.Pool())
@@ -197,76 +172,9 @@ func main() {
 	r.Use(middleware.Recoverer)
 	r.Use(middleware.Compress(5))
 
-	// Security headers
-	r.Use(func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("X-Content-Type-Options", "nosniff")
-			// When ALLOW_EMBED=true, X-Frame-Options and CSP frame-ancestors
-			// are omitted entirely so any origin can embed the page in an
-			// iframe (e.g. workspace browsers, Home Assistant).
-			if !cfg.AllowEmbed {
-				w.Header().Set("X-Frame-Options", "DENY")
-			}
-			w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
-			// HSTS only over TLS. Plain HTTP (e.g. behind a reverse proxy that
-			// terminates TLS) must not set HSTS or browsers will cache a broken
-			// redirect to a non-existent HTTPS listener. Currently the server
-			// only serves plain HTTP (ListenAndServe), so this guard is a
-			// forward-compatible placeholder: it will activate automatically if
-			// TLS is added later via ListenAndServeTLS.
-			if r.TLS != nil {
-				w.Header().Set("Strict-Transport-Security", "max-age=63072000; includeSubDomains; preload")
-			}
-			// CSP allows same-origin scripts/styles (needed for embedded SPA).
-			// Style 'unsafe-inline' is required for Vite's injected style tags (CSS-based
-			// animations and dynamic theme overrides). Script 'unsafe-inline' is NOT
-			// needed: Vite outputs module scripts, not inline ones.
-			if cfg.AllowEmbed {
-				w.Header().Set("Content-Security-Policy", "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self'; base-uri 'self'; form-action 'self'")
-			} else {
-				w.Header().Set("Content-Security-Policy", "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'")
-			}
-			next.ServeHTTP(w, r)
-		})
-	})
-
-	// CORS middleware
-	r.Use(func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			origin := r.Header.Get("Origin")
-			if origin == "" {
-				next.ServeHTTP(w, r)
-				return
-			}
-
-			allowed := slices.Contains(cfg.CORSOrigins, origin)
-
-			w.Header().Set("Vary", "Origin")
-
-			if allowed {
-				w.Header().Set("Access-Control-Allow-Origin", origin)
-				w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
-				w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
-				w.Header().Set("Access-Control-Allow-Credentials", "true")
-				w.Header().Set("Access-Control-Max-Age", "86400")
-			}
-
-			if r.Method == "OPTIONS" {
-				w.WriteHeader(http.StatusNoContent)
-				return
-			}
-
-			next.ServeHTTP(w, r)
-		})
-	})
-
-	// Request size limit
-	r.Use(func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			r.Body = http.MaxBytesReader(w, r.Body, cfg.MaxRequestSize)
-			next.ServeHTTP(w, r)
-		})
-	})
+	r.Use(securityHeadersMiddleware(cfg))
+	r.Use(corsMiddleware(cfg))
+	r.Use(maxRequestSizeMiddleware(cfg.MaxRequestSize))
 
 	// Health check: reports database reachability (cached) so a load balancer
 	// stops routing to an instance whose Postgres is down.
@@ -326,17 +234,7 @@ func main() {
 	})
 	apiHandler.SetAudit(auditRecorder)
 
-	go func() {
-		ticker := time.NewTicker(1 * time.Hour)
-		defer ticker.Stop()
-		for range ticker.C {
-			if n, err := webauthnRepo.CleanupExpiredSessions(context.Background()); err != nil {
-				debuglog.Error("webauthn: session cleanup failed", "error", err)
-			} else if n > 0 {
-				debuglog.Info("webauthn: cleaned up expired sessions", "count", n)
-			}
-		}
-	}()
+	go webauthnSessionCleanupLoop(webauthnRepo)
 
 	// TOTP (RFC 6238) second-factor. Always constructed so the public status
 	// and login endpoints are mounted; enforcement is driven by the cached
@@ -465,185 +363,14 @@ func main() {
 	spaHandler := NewSPAHandler()
 	r.Get("/*", spaHandler.ServeHTTP)
 
-	// Startup: run initial discovery for all enabled providers (if enabled)
-	runDiscovery := func(source string) DiscoveryResult {
-		result := DiscoveryResult{}
-		// Set when any background-discovery change row is recorded, so we can
-		// publish a single live-update event for the Models nav badge.
-		changesRecorded := false
-		ctx := context.Background()
-		providers, err := providerRepo.List(ctx)
-		if err != nil {
-			debuglog.Error("discovery: failed to list providers", "error", err)
-			result.Errors = append(result.Errors, fmt.Sprintf("failed to list providers: %v", err))
-			return result
-		}
-		discoverySvc := provider.NewDiscoveryService(sd.DialContext, sd.CheckRedirect)
-		for _, p := range providers {
-			if !p.Enabled {
-				continue
-			}
-			result.ProvidersScanned++
-			models, err := discoverySvc.DiscoverModels(ctx, p, cfg.MasterKey)
-			if err != nil {
-				debuglog.Error("discovery: failed for provider", "provider", p.Name, "error", err)
-				result.ProvidersFailed++
-				result.Errors = append(result.Errors, fmt.Sprintf("provider %s: %v", p.Name, err))
-				// Update last_discovered_at even on failure so the UI reflects
-				// that discovery was *attempted*. Without this, a chronically
-				// failing provider shows a stale "Last discovered" timestamp
-				// that makes the scheduled timer appear broken.
-				now := time.Now()
-				if _, err := database.Pool().Exec(ctx, `UPDATE providers SET last_discovered_at = $1 WHERE id = $2`, now, p.ID); err != nil {
-					debuglog.Error("discovery: failed to update last_discovered_at", "provider", p.Name, "error", err)
-				}
-				continue
-			}
-
-			// Enrich models with data from models.dev.
-			if cache := provider.GetModelsDevCache(); cache != nil {
-				if enriched := cache.EnrichModels(models); enriched > 0 {
-					debuglog.Info("discovery: enriched models from models.dev", "enriched", enriched, "total", len(models), "provider", p.Name)
-				}
-			}
-			// Runs unconditionally: modality arrays and the derived endpoint
-			// class must be consistent even when models.dev is unreachable.
-			provider.NormalizeModels(models)
-			result.ModelsDiscovered += len(models)
-
-			// Snapshot pre-scan state so background metadata/membership changes
-			// can be recorded for the Models nav badge. A snapshot failure only
-			// disables the diff for this provider; the scan itself proceeds.
-			snapshot, snapErr := api.SnapshotProviderModels(ctx, modelRepo, p.ID)
-			if snapErr != nil {
-				debuglog.Debug("discovery: failed to snapshot models", "provider", p.Name, "error", snapErr)
-			}
-			api.DampenOpenRouterPriceJitter(p.BaseURL, snapshot, models)
-
-			existingModelIDs := make([]string, 0, len(models))
-			upsertedModels := make([]*model.Model, 0, len(models))
-			upsertFailed := false
-			for _, m := range models {
-				if err := modelRepo.Upsert(ctx, m); err != nil {
-					debuglog.Error("discovery: failed to upsert model", "model_id", m.ModelID, "error", err)
-					upsertFailed = true
-				} else {
-					existingModelIDs = append(existingModelIDs, m.ModelID)
-					upsertedModels = append(upsertedModels, m)
-				}
-			}
-			// Miss recording needs a trustworthy membership picture: skip it
-			// when the snapshot is unavailable (absentees cannot be confirmed)
-			// or any upsert failed (a DB error must not count a listed model
-			// as missing). Absent models get a second opinion via confirmation
-			// probes, and a model is disabled only after
-			// model.MissingScanThreshold consecutive confirmed-missing scans.
-			var disabledRefs []model.DisabledModelRef
-			if snapErr == nil && !upsertFailed {
-				confirmedIDs, suspect := api.ConfirmMissingModels(ctx, discoverySvc, p, cfg.MasterKey, existingModelIDs, snapshot, api.NewSuspectStreak(database.Pool()))
-				if suspect {
-					debuglog.Warn("discovery: suspect scan, skipping missing-model recording", "provider", p.Name)
-				} else {
-					var pendingRefs []model.DisabledModelRef
-					disabledRefs, pendingRefs, err = modelRepo.RecordMissingModels(ctx, p.ID, p.Name, confirmedIDs)
-					if err != nil {
-						debuglog.Error("discovery: failed to record missing models", "provider", p.Name, "error", err)
-					}
-					if len(pendingRefs) > 0 {
-						debuglog.Info("discovery: models confirmed missing but below disable threshold",
-							"provider", p.Name, "pending", len(pendingRefs), "threshold", model.MissingScanThreshold)
-					}
-				}
-			}
-			if len(disabledRefs) > 0 {
-				result.ModelsDisabled += len(disabledRefs)
-				events.Publish(events.Event{
-					Type:     "discovery.models_disabled",
-					Severity: "warning",
-					Message:  fmt.Sprintf("%d models no longer available at '%s' and were disabled", len(disabledRefs), p.Name),
-					Metadata: map[string]any{"provider": p.Name, "count": len(disabledRefs)},
-				})
-			}
-
-			// Record this provider's model-level diff (added/reenabled/disabled/
-			// metadata-updated) for later review. Failover group churn is folded
-			// in once after the global failover sync below.
-			if snapErr == nil {
-				diff := api.BuildDiscoveryDiff(snapshot, upsertedModels, disabledRefs)
-				if wrote, err := api.AppendDiscoveryChange(ctx, database.Pool(), source, &p.ID, p.Name, diff); err != nil {
-					debuglog.Error("discovery: failed to record changes", "provider", p.Name, "error", err)
-				} else if wrote {
-					changesRecorded = true
-				}
-			}
-
-			now := time.Now()
-			if _, err := database.Pool().Exec(ctx, `UPDATE providers SET last_discovered_at = $1 WHERE id = $2`, now, p.ID); err != nil {
-				debuglog.Error("discovery: failed to update last_discovered_at", "provider", p.Name, "error", err)
-			}
-			debuglog.Info("discovery: discovered models", "count", len(models), "provider", p.Name)
-		}
-
-		seenModelIDs := make(map[string]bool)
-		for _, p := range providers {
-			if !p.Enabled {
-				continue
-			}
-			models, _ := modelRepo.List(ctx, &p.ID)
-			for _, m := range models {
-				seenModelIDs[m.ModelID] = true
-			}
-		}
-		failoverDiff := &api.DiscoveryDiff{}
-		for modelID := range seenModelIDs {
-			syncRes, err := failoverRepo.SyncForModel(ctx, modelID)
-			if err != nil {
-				debuglog.Error("discovery: failed to sync failover", "model_id", modelID, "error", err)
-				result.FailoverSyncErrs++
-				events.Publish(events.Event{
-					Type:     "failover.sync_error",
-					Severity: "warning",
-					Message:  fmt.Sprintf("Failover sync failed for model '%s'", modelID),
-					Metadata: map[string]any{"error": err.Error(), "model_id": modelID},
-				})
-				continue
-			}
-			if syncRes != nil {
-				failoverDiff.FailoverDeletedGroups = append(failoverDiff.FailoverDeletedGroups, syncRes.DeletedGroups...)
-				failoverDiff.FailoverUpdatedGroups = append(failoverDiff.FailoverUpdatedGroups, syncRes.UpdatedGroups...)
-			}
-		}
-		// SyncForModel only rebuilds auto-groups; custom groups whose member was
-		// just disabled (not deleted) keep their stale size. Revalidate once per
-		// cycle so background discovery auto-disables any custom group left with
-		// fewer than two routable members — the headless path the manual Sync and
-		// interactive discover already cover.
-		if revRes, err := failoverRepo.RevalidateCustomGroups(ctx); err != nil {
-			debuglog.Error("discovery: failed to revalidate custom failover groups", "error", err)
-		} else if revRes != nil {
-			failoverDiff.FailoverDisabledGroups = append(failoverDiff.FailoverDisabledGroups, revRes.DisabledGroups...)
-		}
-		// Record failover group churn as one aggregate entry (the global sync is
-		// not per-provider). An empty provider_name flags this to the frontend as
-		// the run-wide failover entry, which it labels accordingly.
-		if wrote, err := api.AppendDiscoveryChange(ctx, database.Pool(), source, nil, "", failoverDiff); err != nil {
-			debuglog.Error("discovery: failed to record failover changes", "error", err)
-		} else if wrote {
-			changesRecorded = true
-		}
-
-		// One live-update nudge so the Models nav badge refreshes without a
-		// reload; the badge query re-fetches the authoritative count.
-		if changesRecorded {
-			events.Publish(events.Event{
-				Type:     "discovery.changes_pending",
-				Severity: "info",
-				Source:   "discovery",
-				Message:  "Background discovery recorded model changes",
-				Metadata: map[string]any{"source": source},
-			})
-		}
-		return result
+	// Discovery wiring shared by the startup run and the periodic scheduler.
+	discDeps := discoveryDeps{
+		cfg:          cfg,
+		pool:         database.Pool(),
+		providerRepo: providerRepo,
+		modelRepo:    modelRepo,
+		failoverRepo: failoverRepo,
+		dialer:       sd,
 	}
 
 	// Load models.dev catalogue synchronously before startup discovery so
@@ -657,298 +384,20 @@ func main() {
 		}
 	}
 
-	if settingsRepo.GetBool(context.Background(), "discovery_on_startup", true) {
-		recentlyDiscovered := false
-		providers, err := providerRepo.List(context.Background())
-		if err == nil {
-			for _, p := range providers {
-				if p.LastDiscoveredAt != nil && time.Since(*p.LastDiscoveredAt) < 5*time.Minute {
-					recentlyDiscovered = true
-					break
-				}
-			}
-		}
-		if recentlyDiscovered {
-			debuglog.Info("discovery: skipping startup — last discovery within 5 minutes")
-		} else {
-			go func() {
-				result := runDiscovery("startup")
-				publishDiscoveryEvent("Startup", result)
-			}()
-		}
-	}
+	// Startup: run initial discovery for all enabled providers (if enabled).
+	maybeStartupDiscovery(discDeps, settingsRepo)
 
-	// Pre-warm caches synchronously before accepting connections.
-	// Provider, model, and failover lookups are fast (simple SELECT queries),
-	// but key warming (Argon2id) can take ~150ms per provider. The total
-	// warm-up cost is typically under 1s for a handful of providers —
-	// far better than letting the first request pay the cold-cache penalty
-	// of ~170ms+ in failover + model + provider + key decryption DB queries.
-	{
-		ctx := context.Background()
+	warmCaches(discDeps, settingsRepo)
+	initKeyCacheTTL(settingsRepo)
 
-		providers, err := providerRepo.List(ctx)
-		if err != nil {
-			debuglog.Error("cache: warm failed to list providers", "error", err)
-		} else {
-			enabledProviders := make([]*provider.Provider, 0, len(providers))
-			for _, p := range providers {
-				if !p.Enabled || !p.AutodiscoveryEnabled {
-					continue
-				}
-				if len(p.EncryptedKey) > 0 {
-					auth.WarmKeyCache(p.EncryptedKey, p.KeyNonce, p.KeySalt, cfg.MasterKey)
-				}
-				enabledProviders = append(enabledProviders, p)
-			}
-			provider.WarmProviderCache(enabledProviders)
-		}
-
-		enabledModels, err := modelRepo.ListEnabled(ctx)
-		if err != nil {
-			debuglog.Error("cache: warm failed to list models", "error", err)
-		} else {
-			model.WarmModelCache(enabledModels)
-		}
-
-		failoverGroups, err := failoverRepo.List(ctx)
-		if err != nil {
-			debuglog.Error("cache: warm failed to list failover groups", "error", err)
-		} else {
-			failover.WarmFailoverCache(failoverGroups)
-		}
-
-		settingsRepo.WarmCache(ctx)
-
-		debuglog.Info("cache: key, provider, model, failover, and settings caches warmed")
-	}
-
-	// Initialize key cache TTL from settings and react to changes.
-	auth.SetKeyCacheTTL(settingsRepo.GetDuration(context.Background(), "key_cache_ttl", auth.DefaultKeyCacheTTL))
-	settingsRepo.RegisterOnChange(func(key, value string) {
-		if key == "key_cache_ttl" {
-			d, err := time.ParseDuration(value)
-			if err != nil || d <= 0 {
-				debuglog.Warn("keycache: invalid key_cache_ttl setting, keeping current value", "value", value, "error", err)
-				return
-			}
-			auth.SetKeyCacheTTL(d)
-			debuglog.Info("keycache: TTL updated", "ttl", d)
-		}
+	// Background maintenance loops (see background.go). The discovery scheduler
+	// sleeps a full interval before its first run so it doesn't bypass the
+	// discovery_on_startup setting handled by maybeStartupDiscovery above.
+	go discoverySchedulerLoop(ctx, settingsRepo, func(source string) DiscoveryResult {
+		return runDiscovery(discDeps, source)
 	})
-
-	// Periodic discovery based on settings interval.
-	// Sleep before the first run so we don't bypass the discovery_on_startup setting.
-	// When discovery_on_startup is true, the startup go runDiscovery() above already
-	// handles immediate discovery; when false, we must not discover on startup either.
-	//
-	// TODO: Extract the three inline goroutines below (discovery loop, stale log
-	// cleanup, log retention) into internal/scheduler/ for maintainability. main.go
-	// is ~800 lines; each goroutine body should be a named function in its own file.
-	//
-	// Bug fixes applied:
-	//   1. Timer now reacts immediately to discovery_interval changes via the
-	//      settings subscription channel, instead of waiting for the current
-	//      timer to expire.
-	//   2. An interval of 0 ("Disabled") now truly disables periodic discovery
-	//      rather than resetting to 1 minute. The goroutine blocks on the
-	//      subscription channel until a non-zero value arrives.
-	go func() {
-		const defaultInterval = 6 * time.Hour
-
-		readInterval := func() time.Duration {
-			return settingsRepo.GetDuration(context.Background(), "discovery_interval", defaultInterval)
-		}
-
-		settingsSub := settingsRepo.Subscribe()
-		defer settingsSub.Unsubscribe()
-
-		// applyInterval sets up the timer for the given interval. If the
-		// interval is <= 0 (disabled) the timer is stopped and set to nil.
-		// A nil timer channel blocks forever in select, which is exactly what
-		// we want for the disabled state — only the settings subscription
-		// and the context cancellation can wake us.
-		var timer *time.Timer
-		var timerC <-chan time.Time
-		applyInterval := func(d time.Duration) {
-			if d <= 0 {
-				// Transitioning to disabled: stop and drain the existing timer.
-				if timer != nil {
-					timer.Stop()
-					// Drain the channel if the timer already fired, so the
-					// receive does not leak into the next cycle.
-					select {
-					case <-timer.C:
-					default:
-					}
-					timer = nil
-					timerC = nil
-				}
-			} else {
-				// Transitioning to enabled: reset (or create) the timer.
-				if timer != nil {
-					timer.Stop()
-					select {
-					case <-timer.C:
-					default:
-					}
-					timer.Reset(d)
-				} else {
-					timer = time.NewTimer(d)
-					// NewTimer already starts with duration d; no Reset needed.
-				}
-				timerC = timer.C
-			}
-		}
-
-		interval := readInterval()
-		applyInterval(interval)
-
-		defer func() {
-			if timer != nil {
-				timer.Stop()
-			}
-		}()
-
-		for {
-			if interval <= 0 {
-				// Discovery is disabled. Block until the setting changes
-				// or the server shuts down. We cannot reach the main
-				// select because timerC is nil (blocks forever).
-				select {
-				case <-settingsSub.Events():
-					interval = readInterval()
-					applyInterval(interval)
-				case <-ctx.Done():
-					return
-				}
-				continue
-			}
-
-			select {
-			case <-timerC:
-				result := runDiscovery("scheduled")
-				publishDiscoveryEvent("Scheduled", result)
-				// Re-read interval in case it changed since the last
-				// subscription event was processed.
-				interval = readInterval()
-				applyInterval(interval)
-
-			case <-settingsSub.Events():
-				// Re-read from DB (the source of truth) rather than
-				// parsing the event value, which may be empty if the
-				// setting was deleted or the lookup failed.
-				newInterval := readInterval()
-				if newInterval != interval {
-					interval = newInterval
-					applyInterval(interval)
-				}
-
-			case <-ctx.Done():
-				return
-			}
-		}
-	}()
-
-	// Periodic stale log cleanup: mark rows stuck in "pending"/"streaming"
-	// as "failed". Two strategies are combined in a single pass:
-	//
-	//   1. Server-start-time check: any in-progress row that predates this
-	//      process is definitively orphaned (the previous process is dead).
-	//      This has zero false-positive risk regardless of request duration.
-	//
-	//   2. Age-based check: rows older than stale_request_timeout (default
-	//      30m, configurable via Settings) are also marked failed. This
-	//      catches in-process orphans (e.g. a panic skips the final
-	//      updateRequestLog). The timeout is generous to avoid killing
-	//      legitimate long-running streaming requests.
-	go func() {
-		timer := time.NewTimer(5 * time.Minute)
-		defer timer.Stop()
-		for {
-			select {
-			case <-timer.C:
-			case <-ctx.Done():
-				return
-			}
-			staleTimeout := settingsRepo.GetDuration(context.Background(), "stale_request_timeout", 30*time.Minute)
-			if staleTimeout <= 0 {
-				timer.Reset(5 * time.Minute)
-				continue
-			}
-			// Build a PostgreSQL-safe interval string from the parsed duration.
-			// Truncate to whole seconds to avoid fractional-unit issues (e.g. "30.5 minutes").
-			totalSecs := int64(staleTimeout.Seconds())
-			hours := totalSecs / 3600
-			mins := (totalSecs % 3600) / 60
-			secs := totalSecs % 60
-			intervalStr := fmt.Sprintf("%d hours %d minutes %d seconds", hours, mins, secs)
-			tag, err := database.Pool().Exec(context.Background(), `
-				UPDATE request_logs
-				SET state = 'failed', error_kind = 'internal', error_message = 'request interrupted (stale)'
-				WHERE state IN ('pending', 'streaming')
-				  AND (created_at < $1 OR created_at < NOW() - $2::interval)`,
-				serverStartTime, intervalStr)
-			if err == nil && tag.RowsAffected() > 0 {
-				debuglog.Info("retention: stale log cleanup", "rows", tag.RowsAffected())
-				events.Publish(events.Event{
-					Type:     "logs.stale_cleanup",
-					Severity: "warning",
-					Message:  fmt.Sprintf("Marked %d stale requests as interrupted", tag.RowsAffected()),
-					Metadata: map[string]any{"count": tag.RowsAffected()},
-				})
-			} else if err != nil {
-				debuglog.Error("retention: stale log cleanup failed", "error", err)
-			}
-			timer.Reset(5 * time.Minute)
-		}
-	}()
-
-	// Log retention cleanup
-	go func() {
-		timer := time.NewTimer(1 * time.Hour)
-		defer timer.Stop()
-		for {
-			select {
-			case <-timer.C:
-			case <-ctx.Done():
-				return
-			}
-			retention := settingsRepo.GetWithDefault(context.Background(), "log_retention", "")
-			if retention == "" {
-				timer.Reset(1 * time.Hour)
-				continue
-			}
-			var cutoff time.Time
-			switch retention {
-			case "1h":
-				cutoff = time.Now().Add(-1 * time.Hour)
-			case "1d", "24h":
-				cutoff = time.Now().Add(-24 * time.Hour)
-			case "1w", "168h":
-				cutoff = time.Now().Add(-7 * 24 * time.Hour)
-			case "1m", "720h":
-				cutoff = time.Now().Add(-30 * 24 * time.Hour)
-			default:
-				// Unrecognised value (including "0" for disabled): skip
-				// cleanup this cycle and re-check next hour.
-				timer.Reset(1 * time.Hour)
-				continue
-			}
-			tag, err := database.Pool().Exec(context.Background(),
-				`DELETE FROM request_logs WHERE created_at < $1`, cutoff)
-			if err == nil {
-				debuglog.Info("retention: log retention deleted old entries", "retention", retention, "rows", tag.RowsAffected())
-			}
-			// Clean app_logs with same retention
-			tag, err = database.Pool().Exec(context.Background(),
-				`DELETE FROM app_logs WHERE created_at < $1`, cutoff)
-			if err == nil {
-				debuglog.Info("retention: app log retention deleted old entries", "retention", retention, "rows", tag.RowsAffected())
-			}
-			timer.Reset(1 * time.Hour)
-		}
-	}()
+	go staleLogCleanupLoop(ctx, database.Pool(), settingsRepo, serverStartTime)
+	go logRetentionLoop(ctx, database.Pool(), settingsRepo)
 
 	server := &http.Server{
 		Addr:              cfg.Port,
@@ -1010,6 +459,146 @@ func main() {
 	auditRecorder.Wait()
 
 	debuglog.Info("server: stopped")
+}
+
+// securityHeadersMiddleware sets the standard security headers on every
+// response.
+func securityHeadersMiddleware(cfg *config.Config) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("X-Content-Type-Options", "nosniff")
+			// When ALLOW_EMBED=true, X-Frame-Options and CSP frame-ancestors
+			// are omitted entirely so any origin can embed the page in an
+			// iframe (e.g. workspace browsers, Home Assistant).
+			if !cfg.AllowEmbed {
+				w.Header().Set("X-Frame-Options", "DENY")
+			}
+			w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
+			// HSTS only over TLS. Plain HTTP (e.g. behind a reverse proxy that
+			// terminates TLS) must not set HSTS or browsers will cache a broken
+			// redirect to a non-existent HTTPS listener. Currently the server
+			// only serves plain HTTP (ListenAndServe), so this guard is a
+			// forward-compatible placeholder: it will activate automatically if
+			// TLS is added later via ListenAndServeTLS.
+			if r.TLS != nil {
+				w.Header().Set("Strict-Transport-Security", "max-age=63072000; includeSubDomains; preload")
+			}
+			// CSP allows same-origin scripts/styles (needed for embedded SPA).
+			// Style 'unsafe-inline' is required for Vite's injected style tags (CSS-based
+			// animations and dynamic theme overrides). Script 'unsafe-inline' is NOT
+			// needed: Vite outputs module scripts, not inline ones.
+			if cfg.AllowEmbed {
+				w.Header().Set("Content-Security-Policy", "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self'; base-uri 'self'; form-action 'self'")
+			} else {
+				w.Header().Set("Content-Security-Policy", "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'")
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// corsMiddleware allows the configured origins (CORS_ORIGINS) and answers
+// preflight requests.
+func corsMiddleware(cfg *config.Config) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			origin := r.Header.Get("Origin")
+			if origin == "" {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			allowed := slices.Contains(cfg.CORSOrigins, origin)
+
+			w.Header().Set("Vary", "Origin")
+
+			if allowed {
+				w.Header().Set("Access-Control-Allow-Origin", origin)
+				w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
+				w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+				w.Header().Set("Access-Control-Allow-Credentials", "true")
+				w.Header().Set("Access-Control-Max-Age", "86400")
+			}
+
+			if r.Method == "OPTIONS" {
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// maxRequestSizeMiddleware caps every request body at maxBytes.
+func maxRequestSizeMiddleware(maxBytes int64) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			r.Body = http.MaxBytesReader(w, r.Body, maxBytes)
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// warmCaches pre-warms caches synchronously before accepting connections.
+// Provider, model, and failover lookups are fast (simple SELECT queries),
+// but key warming (Argon2id) can take ~150ms per provider. The total
+// warm-up cost is typically under 1s for a handful of providers —
+// far better than letting the first request pay the cold-cache penalty
+// of ~170ms+ in failover + model + provider + key decryption DB queries.
+func warmCaches(deps discoveryDeps, settingsRepo *settings.Repository) {
+	ctx := context.Background()
+
+	providers, err := deps.providerRepo.List(ctx)
+	if err != nil {
+		debuglog.Error("cache: warm failed to list providers", "error", err)
+	} else {
+		enabledProviders := make([]*provider.Provider, 0, len(providers))
+		for _, p := range providers {
+			if !p.Enabled || !p.AutodiscoveryEnabled {
+				continue
+			}
+			if len(p.EncryptedKey) > 0 {
+				auth.WarmKeyCache(p.EncryptedKey, p.KeyNonce, p.KeySalt, deps.cfg.MasterKey)
+			}
+			enabledProviders = append(enabledProviders, p)
+		}
+		provider.WarmProviderCache(enabledProviders)
+	}
+
+	enabledModels, err := deps.modelRepo.ListEnabled(ctx)
+	if err != nil {
+		debuglog.Error("cache: warm failed to list models", "error", err)
+	} else {
+		model.WarmModelCache(enabledModels)
+	}
+
+	failoverGroups, err := deps.failoverRepo.List(ctx)
+	if err != nil {
+		debuglog.Error("cache: warm failed to list failover groups", "error", err)
+	} else {
+		failover.WarmFailoverCache(failoverGroups)
+	}
+
+	settingsRepo.WarmCache(ctx)
+
+	debuglog.Info("cache: key, provider, model, failover, and settings caches warmed")
+}
+
+// initKeyCacheTTL seeds the key cache TTL from settings and reacts to changes.
+func initKeyCacheTTL(settingsRepo *settings.Repository) {
+	auth.SetKeyCacheTTL(settingsRepo.GetDuration(context.Background(), "key_cache_ttl", auth.DefaultKeyCacheTTL))
+	settingsRepo.RegisterOnChange(func(key, value string) {
+		if key == "key_cache_ttl" {
+			d, err := time.ParseDuration(value)
+			if err != nil || d <= 0 {
+				debuglog.Warn("keycache: invalid key_cache_ttl setting, keeping current value", "value", value, "error", err)
+				return
+			}
+			auth.SetKeyCacheTTL(d)
+			debuglog.Info("keycache: TTL updated", "ttl", d)
+		}
+	})
 }
 
 // silentLogger is like chi's middleware.Logger but suppresses request log

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -1,11 +1,30 @@
 package main
 
 import (
+	"context"
 	"testing"
 	"time"
 
+	"github.com/hugalafutro/model-hotel/internal/api"
+	"github.com/hugalafutro/model-hotel/internal/debuglog"
 	"github.com/hugalafutro/model-hotel/internal/events"
 )
+
+// TestInitAppLogging covers the non-OTLP path: the app slog handler is
+// installed and no shutdown hook is returned. The stdout handler is restored
+// afterwards so later tests keep the default logging destination.
+func TestInitAppLogging(t *testing.T) {
+	if cmdTestDB == nil {
+		t.Skip("test DB unavailable")
+	}
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+	api.InitAppLogBuffer(cmdTestDB.Pool())
+	defer debuglog.SetHandler(debuglog.StdoutHandler())
+
+	if shutdown := initAppLogging(context.Background()); shutdown != nil {
+		t.Error("expected no OTLP shutdown hook without OTEL_EXPORTER_OTLP_ENDPOINT")
+	}
+}
 
 // TestPublishDiscoveryEvent verifies that publishDiscoveryEvent selects the
 // correct severity for each outcome (all-failed, partial-failure, success) and

--- a/cmd/server/security_middleware_test.go
+++ b/cmd/server/security_middleware_test.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"crypto/tls"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/hugalafutro/model-hotel/internal/config"
+)
+
+func okHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func TestSecurityHeadersMiddleware_Default(t *testing.T) {
+	mw := securityHeadersMiddleware(&config.Config{})
+	rec := httptest.NewRecorder()
+	mw(okHandler()).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", http.NoBody))
+
+	if got := rec.Header().Get("X-Frame-Options"); got != "DENY" {
+		t.Errorf("expected X-Frame-Options DENY, got %q", got)
+	}
+	if got := rec.Header().Get("X-Content-Type-Options"); got != "nosniff" {
+		t.Errorf("expected nosniff, got %q", got)
+	}
+	if got := rec.Header().Get("Strict-Transport-Security"); got != "" {
+		t.Errorf("expected no HSTS over plain HTTP, got %q", got)
+	}
+	if csp := rec.Header().Get("Content-Security-Policy"); !strings.Contains(csp, "frame-ancestors 'none'") {
+		t.Errorf("expected frame-ancestors 'none' in CSP, got %q", csp)
+	}
+}
+
+func TestSecurityHeadersMiddleware_AllowEmbed(t *testing.T) {
+	mw := securityHeadersMiddleware(&config.Config{AllowEmbed: true})
+	rec := httptest.NewRecorder()
+	mw(okHandler()).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", http.NoBody))
+
+	if got := rec.Header().Get("X-Frame-Options"); got != "" {
+		t.Errorf("expected no X-Frame-Options with ALLOW_EMBED, got %q", got)
+	}
+	if csp := rec.Header().Get("Content-Security-Policy"); strings.Contains(csp, "frame-ancestors") {
+		t.Errorf("expected no frame-ancestors in CSP with ALLOW_EMBED, got %q", csp)
+	}
+}
+
+func TestSecurityHeadersMiddleware_HSTSOverTLS(t *testing.T) {
+	mw := securityHeadersMiddleware(&config.Config{})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "https://example.test/", http.NoBody)
+	req.TLS = &tls.ConnectionState{}
+	mw(okHandler()).ServeHTTP(rec, req)
+
+	if got := rec.Header().Get("Strict-Transport-Security"); got == "" {
+		t.Error("expected HSTS header over TLS")
+	}
+}
+
+func TestCORSMiddleware(t *testing.T) {
+	cfg := &config.Config{CORSOrigins: []string{"http://allowed.test"}}
+	mw := corsMiddleware(cfg)
+
+	t.Run("no_origin_passes_through", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		mw(okHandler()).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", http.NoBody))
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", rec.Code)
+		}
+		if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+			t.Errorf("expected no CORS headers without Origin, got %q", got)
+		}
+	})
+
+	t.Run("allowed_origin", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+		req.Header.Set("Origin", "http://allowed.test")
+		mw(okHandler()).ServeHTTP(rec, req)
+		if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "http://allowed.test" {
+			t.Errorf("expected origin echoed, got %q", got)
+		}
+		if got := rec.Header().Get("Vary"); got != "Origin" {
+			t.Errorf("expected Vary: Origin, got %q", got)
+		}
+	})
+
+	t.Run("disallowed_origin", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+		req.Header.Set("Origin", "http://evil.test")
+		mw(okHandler()).ServeHTTP(rec, req)
+		if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+			t.Errorf("expected no allow-origin for disallowed origin, got %q", got)
+		}
+		if got := rec.Header().Get("Vary"); got != "Origin" {
+			t.Errorf("expected Vary: Origin even when disallowed, got %q", got)
+		}
+	})
+
+	t.Run("preflight_short_circuits", func(t *testing.T) {
+		called := false
+		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { called = true })
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodOptions, "/", http.NoBody)
+		req.Header.Set("Origin", "http://allowed.test")
+		mw(next).ServeHTTP(rec, req)
+		if rec.Code != http.StatusNoContent {
+			t.Errorf("expected 204 for preflight, got %d", rec.Code)
+		}
+		if called {
+			t.Error("expected preflight to short-circuit before the handler")
+		}
+	})
+}
+
+func TestMaxRequestSizeMiddleware(t *testing.T) {
+	mw := maxRequestSizeMiddleware(8)
+	var readErr error
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, readErr = io.ReadAll(r.Body)
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("this body is longer than eight bytes"))
+	mw(next).ServeHTTP(rec, req)
+	if readErr == nil {
+		t.Error("expected read error for oversized body")
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPost, "/", strings.NewReader("tiny"))
+	mw(next).ServeHTTP(rec, req)
+	if readErr != nil {
+		t.Errorf("expected small body to read fine, got %v", readErr)
+	}
+}

--- a/internal/api/configsync_apply.go
+++ b/internal/api/configsync_apply.go
@@ -34,8 +34,6 @@ import (
 // The lock is taken for every import, headed or not, so a headerless push cannot
 // slip past a generation that already committed. That, plus the same-transaction
 // advance, is what makes a newer config win regardless of the order pushes arrive.
-//
-//nolint:gocyclo // complexity 33: staged import pipeline with per-entity guards; on the gocyclo refactor shortlist
 func (h *ConfigSyncHandler) apply(ctx context.Context, env ConfigEnvelope, sourceGen *int64) error {
 	tx, err := h.db.Begin(ctx)
 	if err != nil {
@@ -43,49 +41,11 @@ func (h *ConfigSyncHandler) apply(ctx context.Context, env ConfigEnvelope, sourc
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
-	// pg_advisory_xact_lock blocks a concurrent import's fence step until this
-	// transaction ends, so the read-current / reject-or-advance below is atomic
-	// even when two pushes' bytes both arrived before either committed. Released
-	// automatically on commit or rollback.
-	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock($1)`, fleetSourceGenLock); err != nil {
+	if err := enforceSourceGenFence(ctx, tx, sourceGen); err != nil {
 		return err
 	}
-	last, fenced, err := readAppliedSourceGen(ctx, tx)
-	if err != nil {
+	if err := guardAgainstProviderWipe(ctx, tx, env.Config.Providers); err != nil {
 		return err
-	}
-	switch {
-	case sourceGen != nil:
-		if fenced && *sourceGen < last {
-			return errStaleSourceGen // a newer generation already applied; refuse
-		}
-	case fenced:
-		// Headerless (pre-fence) import onto a member any fenced generation already
-		// converged (including generation 0): applying an un-versioned write now
-		// could clobber that config and leave the marker lying. Refuse; the fenced
-		// source reconverges.
-		return errStaleSourceGen
-	}
-
-	// Destructive-wipe rail. The declarative delete below removes every provider
-	// absent from the envelope, so an envelope with zero providers would delete
-	// the member's entire provider set (cascading to discovered models) and,
-	// paired with the users replace further down, is the reported backdoor-wipe
-	// vector. buildEnvelope always ships the full config, so a functioning primary
-	// never legitimately pushes zero providers onto a member that has some.
-	// Refuse here, inside the transaction and before any delete, so the check and
-	// the delete it guards are atomic and no throwaway setting or virtual key can
-	// dress the envelope past it. An empty-provider envelope onto a member that
-	// also has no providers is a harmless no-op and is allowed (fleet bootstrap /
-	// keys-only sync onto an empty member).
-	if len(env.Config.Providers) == 0 {
-		var existing int
-		if err := tx.QueryRow(ctx, `SELECT count(*) FROM providers`).Scan(&existing); err != nil {
-			return err
-		}
-		if existing > 0 {
-			return errWouldWipeProviders
-		}
 	}
 
 	if err := upsertProviders(ctx, tx, env.Config.Providers); err != nil {
@@ -122,23 +82,8 @@ func (h *ConfigSyncHandler) apply(ctx context.Context, env ConfigEnvelope, sourc
 		return err
 	}
 
-	for k, v := range env.Config.Settings {
-		if !isSyncableSetting(k) {
-			continue // skip non-syncable / unknown keys silently
-		}
-		if err := h.settings.SetTx(ctx, tx, k, v); err != nil {
-			return err
-		}
-	}
-	// Declarative replace for settings too: delete any syncable key this member
-	// has that the primary does not, so the replica falls back to the same
-	// built-in default the primary is using. Non-syncable keys (apprise,
-	// observability, instance-local) are never touched.
-	removedSettings, err := h.syncableSettingsToDelete(ctx, tx, env.Config.Settings)
+	removedSettings, err := h.applySettingsTx(ctx, tx, env.Config.Settings)
 	if err != nil {
-		return err
-	}
-	if err := h.settings.DeleteKeysTx(ctx, tx, removedSettings); err != nil {
 		return err
 	}
 
@@ -157,6 +102,91 @@ func (h *ConfigSyncHandler) apply(ctx context.Context, env ConfigEnvelope, sourc
 		return err
 	}
 
+	h.postImportRefresh(ctx, env, removedSettings)
+	return nil
+}
+
+// enforceSourceGenFence takes the fleet source-generation advisory lock and
+// applies the commit fence for this import. pg_advisory_xact_lock blocks a
+// concurrent import's fence step until the surrounding transaction ends, so
+// the read-current / reject-or-advance is atomic even when two pushes' bytes
+// both arrived before either committed. Released automatically on commit or
+// rollback.
+func enforceSourceGenFence(ctx context.Context, tx pgx.Tx, sourceGen *int64) error {
+	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock($1)`, fleetSourceGenLock); err != nil {
+		return err
+	}
+	last, fenced, err := readAppliedSourceGen(ctx, tx)
+	if err != nil {
+		return err
+	}
+	switch {
+	case sourceGen != nil:
+		if fenced && *sourceGen < last {
+			return errStaleSourceGen // a newer generation already applied; refuse
+		}
+	case fenced:
+		// Headerless (pre-fence) import onto a member any fenced generation already
+		// converged (including generation 0): applying an un-versioned write now
+		// could clobber that config and leave the marker lying. Refuse; the fenced
+		// source reconverges.
+		return errStaleSourceGen
+	}
+	return nil
+}
+
+// guardAgainstProviderWipe is the destructive-wipe rail. The declarative
+// delete in apply removes every provider absent from the envelope, so an
+// envelope with zero providers would delete the member's entire provider set
+// (cascading to discovered models) and, paired with the users replace, is the
+// reported backdoor-wipe vector. buildEnvelope always ships the full config,
+// so a functioning primary never legitimately pushes zero providers onto a
+// member that has some. Refuse here, inside the transaction and before any
+// delete, so the check and the delete it guards are atomic and no throwaway
+// setting or virtual key can dress the envelope past it. An empty-provider
+// envelope onto a member that also has no providers is a harmless no-op and is
+// allowed (fleet bootstrap / keys-only sync onto an empty member).
+func guardAgainstProviderWipe(ctx context.Context, tx pgx.Tx, providers []ExportProvider) error {
+	if len(providers) == 0 {
+		var existing int
+		if err := tx.QueryRow(ctx, `SELECT count(*) FROM providers`).Scan(&existing); err != nil {
+			return err
+		}
+		if existing > 0 {
+			return errWouldWipeProviders
+		}
+	}
+	return nil
+}
+
+// applySettingsTx converges syncable settings to the envelope inside the
+// import transaction and returns the keys it deleted. Declarative replace:
+// any syncable key this member has that the primary does not is deleted, so
+// the replica falls back to the same built-in default the primary is using.
+// Non-syncable keys (apprise, observability, instance-local) are never
+// touched, and unknown keys are skipped silently.
+func (h *ConfigSyncHandler) applySettingsTx(ctx context.Context, tx pgx.Tx, want map[string]string) ([]string, error) {
+	for k, v := range want {
+		if !isSyncableSetting(k) {
+			continue // skip non-syncable / unknown keys silently
+		}
+		if err := h.settings.SetTx(ctx, tx, k, v); err != nil {
+			return nil, err
+		}
+	}
+	removedSettings, err := h.syncableSettingsToDelete(ctx, tx, want)
+	if err != nil {
+		return nil, err
+	}
+	if err := h.settings.DeleteKeysTx(ctx, tx, removedSettings); err != nil {
+		return nil, err
+	}
+	return removedSettings, nil
+}
+
+// postImportRefresh runs the best-effort post-commit steps of an import: the
+// core config is already durable, so nothing here can fail the sync.
+func (h *ConfigSyncHandler) postImportRefresh(ctx context.Context, env ConfigEnvelope, removedSettings []string) {
 	// Stamp the HA synced marker AFTER the commit, via Set (not SetTx): this
 	// instance-local, non-syncable key drives the member dashboard's "synced
 	// from primary" readout. It must be written post-commit and through Set
@@ -202,7 +232,6 @@ func (h *ConfigSyncHandler) apply(ctx context.Context, env ConfigEnvelope, sourc
 		h.settings.InvalidateCache(k)
 		h.settings.NotifyDeleted(k)
 	}
-	return nil
 }
 
 // applyFailoverGroups upserts the custom failover groups and declaratively

--- a/internal/api/configsync_import.go
+++ b/internal/api/configsync_import.go
@@ -137,6 +137,45 @@ func (h *ConfigSyncHandler) canDecryptSample(providers []ExportProvider) bool {
 	return true // keyless fleet: nothing to verify
 }
 
+// diffKeyed classifies items against the member's current rows: a key present
+// on both sides is updated, a new key added, and a current row whose key no
+// item carries removed. keyLabel returns an item's identity key and the label
+// the diff reports (virtual keys are keyed by hash but reported by name).
+// includeRemovals=false suppresses the removed bucket, for envelope fields
+// whose nil form the apply side leaves untouched.
+func diffKeyed[T any](cur map[string]string, items []T, keyLabel func(T) (key, label string), includeRemovals bool) entityDiff {
+	var d entityDiff
+	want := make(map[string]struct{}, len(items))
+	for _, it := range items {
+		key, label := keyLabel(it)
+		want[key] = struct{}{}
+		if _, ok := cur[key]; ok {
+			d.Updated = append(d.Updated, label)
+		} else {
+			d.Added = append(d.Added, label)
+		}
+	}
+	if !includeRemovals {
+		return d
+	}
+	for key, label := range cur {
+		if _, ok := want[key]; !ok {
+			d.Removed = append(d.Removed, label)
+		}
+	}
+	return d
+}
+
+// identLabels widens a name set to the key->label form diffKeyed takes, with
+// each name labelling itself.
+func identLabels(set map[string]struct{}) map[string]string {
+	out := make(map[string]string, len(set))
+	for k := range set {
+		out[k] = k
+	}
+	return out
+}
+
 // computeDiff classifies each entity as added (new to this member), updated
 // (present on both), or removed (here but not in the envelope).
 func (h *ConfigSyncHandler) computeDiff(ctx context.Context, env ConfigEnvelope) (configDiff, error) {
@@ -147,94 +186,55 @@ func (h *ConfigSyncHandler) computeDiff(ctx context.Context, env ConfigEnvelope)
 	if err != nil {
 		return d, err
 	}
-	wantProviders := map[string]struct{}{}
-	for _, p := range env.Config.Providers {
-		wantProviders[p.Name] = struct{}{}
-		if _, ok := curProviders[p.Name]; ok {
-			d.Providers.Updated = append(d.Providers.Updated, p.Name)
-		} else {
-			d.Providers.Added = append(d.Providers.Added, p.Name)
-		}
-	}
-	for name := range curProviders {
-		if _, ok := wantProviders[name]; !ok {
-			d.Providers.Removed = append(d.Providers.Removed, name)
-		}
-	}
+	d.Providers = diffKeyed(identLabels(curProviders), env.Config.Providers,
+		func(p ExportProvider) (string, string) { return p.Name, p.Name }, true)
 
 	curVKs, err := hashToName(ctx, pool, `SELECT key_hash, name FROM virtual_keys`)
 	if err != nil {
 		return d, err
 	}
-	wantVKs := map[string]struct{}{}
-	for _, v := range env.Config.VirtualKeys {
-		wantVKs[v.KeyHash] = struct{}{}
-		if _, ok := curVKs[v.KeyHash]; ok {
-			d.VirtualKeys.Updated = append(d.VirtualKeys.Updated, v.Name)
-		} else {
-			d.VirtualKeys.Added = append(d.VirtualKeys.Added, v.Name)
-		}
-	}
-	for hash, name := range curVKs {
-		if _, ok := wantVKs[hash]; !ok {
-			d.VirtualKeys.Removed = append(d.VirtualKeys.Removed, name)
-		}
-	}
+	d.VirtualKeys = diffKeyed(curVKs, env.Config.VirtualKeys,
+		func(v ExportVK) (string, string) { return v.KeyHash, v.Name }, true)
 
 	curSettings, err := nameSet(ctx, pool, `SELECT key FROM settings`)
 	if err != nil {
 		return d, err
 	}
+	// Only syncable keys participate on either side. A syncable setting present
+	// here but not on the primary is removed (the replica falls back to the
+	// built-in default), mirroring providers/VKs.
+	syncableWant := make([]string, 0, len(env.Config.Settings))
 	for k := range env.Config.Settings {
-		if !isSyncableSetting(k) {
-			continue
-		}
-		if _, ok := curSettings[k]; ok {
-			d.Settings.Updated = append(d.Settings.Updated, k)
-		} else {
-			d.Settings.Added = append(d.Settings.Added, k)
+		if isSyncableSetting(k) {
+			syncableWant = append(syncableWant, k)
 		}
 	}
-	// A syncable setting present here but not on the primary is removed (the
-	// replica falls back to the built-in default), mirroring providers/VKs.
+	curSyncable := map[string]string{}
 	for k := range curSettings {
-		if !isSyncableSetting(k) {
-			continue
-		}
-		if _, ok := env.Config.Settings[k]; !ok {
-			d.Settings.Removed = append(d.Settings.Removed, k)
+		if isSyncableSetting(k) {
+			curSyncable[k] = k
 		}
 	}
+	d.Settings = diffKeyed(curSyncable, syncableWant,
+		func(k string) (string, string) { return k, k }, true)
 
 	// Custom failover groups, scoped to auto_created = false to match the apply
 	// side (auto groups regenerate per member and are never synced). The counts
 	// reflect intent: a group the importer later skips for too few resolvable
 	// entries on this member still shows as added/updated here.
+	//
+	// Removals mirror applyFailoverGroups exactly: a nil slice means the field
+	// was absent (a pre-PR primary), which apply leaves untouched, so report no
+	// removals. An explicit empty array reconciles to zero, so its removals are
+	// real. Reporting removals for a nil slice would scare an operator
+	// mid-rolling-upgrade with deletions the apply never performs.
 	curGroups, err := nameSet(ctx, pool, `SELECT display_model FROM model_failover_groups WHERE auto_created = false`)
 	if err != nil {
 		return d, err
 	}
-	wantGroups := map[string]struct{}{}
-	for _, g := range env.Config.FailoverGroups {
-		wantGroups[g.DisplayModel] = struct{}{}
-		if _, ok := curGroups[g.DisplayModel]; ok {
-			d.FailoverGroups.Updated = append(d.FailoverGroups.Updated, g.DisplayModel)
-		} else {
-			d.FailoverGroups.Added = append(d.FailoverGroups.Added, g.DisplayModel)
-		}
-	}
-	// Mirror applyFailoverGroups exactly: a nil slice means the field was absent (a
-	// pre-PR primary), which apply leaves untouched, so report no removals here. An
-	// explicit empty array reconciles to zero, so its removals are real. Reporting
-	// removals for a nil slice would scare an operator mid-rolling-upgrade with
-	// deletions the apply never performs.
-	if env.Config.FailoverGroups != nil {
-		for name := range curGroups {
-			if _, ok := wantGroups[name]; !ok {
-				d.FailoverGroups.Removed = append(d.FailoverGroups.Removed, name)
-			}
-		}
-	}
+	d.FailoverGroups = diffKeyed(identLabels(curGroups), env.Config.FailoverGroups,
+		func(g ExportFailoverGroup) (string, string) { return g.DisplayModel, g.DisplayModel },
+		env.Config.FailoverGroups != nil)
 
 	// Users, keyed by username, with the same nil-guard as failover groups: a
 	// nil slice means the envelope predates the field and apply leaves users
@@ -243,21 +243,9 @@ func (h *ConfigSyncHandler) computeDiff(ctx context.Context, env ConfigEnvelope)
 	if err != nil {
 		return d, err
 	}
-	wantUsers := map[string]struct{}{}
-	for _, u := range env.Config.Users {
-		wantUsers[u.Username] = struct{}{}
-		if _, ok := curUsers[u.Username]; ok {
-			d.Users.Updated = append(d.Users.Updated, u.Username)
-		} else {
-			d.Users.Added = append(d.Users.Added, u.Username)
-		}
-	}
-	if env.Config.Users != nil {
-		for name := range curUsers {
-			if _, ok := wantUsers[name]; !ok {
-				d.Users.Removed = append(d.Users.Removed, name)
-			}
-		}
-	}
+	d.Users = diffKeyed(identLabels(curUsers), env.Config.Users,
+		func(u ExportUser) (string, string) { return u.Username, u.Username },
+		env.Config.Users != nil)
+
 	return d, nil
 }

--- a/internal/api/configsync_test.go
+++ b/internal/api/configsync_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5"
 
 	"github.com/hugalafutro/model-hotel/internal/auth"
 	"github.com/hugalafutro/model-hotel/internal/settings"
@@ -764,6 +765,68 @@ func TestConfigSync_HelperDBErrors(t *testing.T) {
 	}
 	if err := h.apply(cctx, env, nil); err == nil {
 		t.Error("apply should error on cancelled ctx (Begin fails)")
+	}
+}
+
+// TestConfigSync_ApplyHelperDBErrors exercises the DB-error return paths of
+// the transactional apply helpers with transactions that are already finished
+// (every statement errors) or read-only (reads succeed, writes fail).
+func TestConfigSync_ApplyHelperDBErrors(t *testing.T) {
+	cleanConfigTables(t)
+	ctx := context.Background()
+	pool := apiTestDB.Pool()
+	h := NewConfigSyncHandler(apiTestDB, settings.NewRepository(pool), configSyncMasterKey, "v-test", nil)
+
+	deadTx := func() pgx.Tx {
+		tx, err := pool.Begin(ctx)
+		if err != nil {
+			t.Fatalf("begin: %v", err)
+		}
+		_ = tx.Rollback(ctx)
+		return tx
+	}
+
+	if err := enforceSourceGenFence(ctx, deadTx(), nil); err == nil {
+		t.Error("enforceSourceGenFence should error on a finished tx")
+	}
+	// An empty search_path lets the advisory lock succeed but fails the
+	// settings read, covering the fence's marker-read error return.
+	blindTx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	defer func() { _ = blindTx.Rollback(ctx) }()
+	if _, err := blindTx.Exec(ctx, `SET LOCAL search_path TO ''`); err != nil {
+		t.Fatalf("set search_path: %v", err)
+	}
+	if err := enforceSourceGenFence(ctx, blindTx, nil); err == nil {
+		t.Error("enforceSourceGenFence should error when the marker read fails")
+	}
+	if err := guardAgainstProviderWipe(ctx, deadTx(), nil); err == nil {
+		t.Error("guardAgainstProviderWipe should error on a finished tx")
+	}
+	if _, err := h.applySettingsTx(ctx, deadTx(), map[string]string{"discovery_interval": "1h"}); err == nil {
+		t.Error("applySettingsTx should error when SetTx fails")
+	}
+	if _, err := h.applySettingsTx(ctx, deadTx(), nil); err == nil {
+		t.Error("applySettingsTx should error when the settings read fails")
+	}
+
+	// Read-only tx: the settings read succeeds and finds an orphan syncable
+	// key absent from the envelope, so the declarative delete runs and fails.
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO settings (key, value, updated_at) VALUES ('discovery_interval', '6h', now())`); err != nil {
+		t.Fatalf("seed setting: %v", err)
+	}
+	roTx, err := pool.BeginTx(ctx, pgx.TxOptions{AccessMode: pgx.ReadOnly})
+	if err != nil {
+		t.Fatalf("begin read-only: %v", err)
+	}
+	defer func() { _ = roTx.Rollback(ctx) }()
+	// The non-syncable key is skipped (no write attempted); the orphan
+	// syncable key still triggers the failing delete.
+	if _, err := h.applySettingsTx(ctx, roTx, map[string]string{"not_a_syncable_key": "x"}); err == nil {
+		t.Error("applySettingsTx should error when DeleteKeysTx fails on a read-only tx")
 	}
 }
 

--- a/internal/api/failover.go
+++ b/internal/api/failover.go
@@ -315,9 +315,111 @@ type UpdateFailoverGroupRequest struct {
 	EntryEnabled  map[string]bool `json:"entry_enabled"`
 }
 
+// validateDisplayModelPatch validates and canonicalises req.DisplayModel (when
+// provided) and enforces display_model uniqueness across groups. Writes an
+// HTTP error and returns false on failure.
+func (h *FailoverHandler) validateDisplayModelPatch(w http.ResponseWriter, r *http.Request, req *UpdateFailoverGroupRequest, existing *failover.FailoverGroup) bool {
+	if req.DisplayModel == nil {
+		return true
+	}
+	trimmedModel, modelErr := validateNameString("display_model", *req.DisplayModel, 1, 128)
+	if modelErr != nil {
+		respondBadRequest(w, "invalid display model", modelErr)
+		return false
+	}
+	lowerModel := strings.ToLower(trimmedModel)
+	req.DisplayModel = &lowerModel
+
+	// Uniqueness check: no other failover group should have this display_model
+	if *req.DisplayModel != existing.DisplayModel {
+		conflict, err := h.failoverRepo.GetByModel(r.Context(), *req.DisplayModel)
+		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+			respondError(w, "failed to check display_model uniqueness", err, http.StatusInternalServerError)
+			return false
+		}
+		if conflict != nil {
+			http.Error(w, "A failover group for '"+*req.DisplayModel+"' already exists. Choose a different name.", http.StatusConflict)
+			return false
+		}
+	}
+	return true
+}
+
+// resolveGroupUpdateLists merges the request's priority_order / entry_enabled
+// with the existing group's values. Writes an HTTP error and returns ok=false
+// when a priority_order entry is not a valid UUID.
+func resolveGroupUpdateLists(w http.ResponseWriter, req *UpdateFailoverGroupRequest, existing *failover.FailoverGroup) (priorityOrder []uuid.UUID, entryEnabled map[string]bool, ok bool) {
+	priorityOrder = existing.PriorityOrder
+	entryEnabled = existing.EntryEnabled
+
+	if req.PriorityOrder != nil {
+		priorityOrder = make([]uuid.UUID, len(req.PriorityOrder))
+		for i, idStr := range req.PriorityOrder {
+			parsedID, err := uuid.Parse(idStr)
+			if err != nil {
+				http.Error(w, "invalid priority_order entry: "+idStr, http.StatusBadRequest)
+				return nil, nil, false
+			}
+			priorityOrder[i] = parsedID
+		}
+	}
+
+	if req.EntryEnabled != nil {
+		entryEnabled = req.EntryEnabled
+	}
+	return priorityOrder, entryEnabled, true
+}
+
+// validateGroupEnabledState enforces the enabled-group invariants for the
+// post-update state: an active group needs at least one enabled entry, and
+// turning a group on (off->on transition only) requires at least two routable
+// members (model and provider both enabled). The latter complements the
+// auto-disable on sync/discovery so a user cannot re-enable a group that
+// discovery left with a single live member; reorders/renames of an
+// already-enabled group are untouched. Writes an HTTP error and returns false
+// on failure.
+func (h *FailoverHandler) validateGroupEnabledState(w http.ResponseWriter, r *http.Request, req *UpdateFailoverGroupRequest, existing *failover.FailoverGroup, priorityOrder []uuid.UUID, entryEnabled map[string]bool) bool {
+	effectiveGroupEnabled := existing.GroupEnabled
+	if req.GroupEnabled != nil {
+		effectiveGroupEnabled = *req.GroupEnabled
+	}
+	if !effectiveGroupEnabled {
+		return true
+	}
+
+	hasEnabled := false
+	for _, enabled := range entryEnabled {
+		if enabled {
+			hasEnabled = true
+			break
+		}
+	}
+	if !hasEnabled {
+		http.Error(w, "at least one entry must be enabled for an active failover group", http.StatusBadRequest)
+		return false
+	}
+
+	if !existing.GroupEnabled {
+		models, mErr := h.modelRepo.GetByIDs(r.Context(), priorityOrder)
+		if mErr != nil {
+			respondError(w, "failed to validate failover members", mErr, http.StatusInternalServerError)
+			return false
+		}
+		routable := 0
+		for _, mid := range priorityOrder {
+			if m, ok := models[mid]; ok && m.Enabled && m.ProviderEnabled {
+				routable++
+			}
+		}
+		if routable < 2 {
+			http.Error(w, "a failover group needs at least 2 enabled members (model and provider enabled) to be active", http.StatusBadRequest)
+			return false
+		}
+	}
+	return true
+}
+
 // Update updates an existing failover group by ID.
-//
-//nolint:gocyclo // complexity 35: sequential validation of many optional PATCH fields; on the gocyclo refactor shortlist
 func (h *FailoverHandler) Update(w http.ResponseWriter, r *http.Request) {
 	id, ok := parseUUIDParam(w, r, "id", "failover group ID")
 	if !ok {
@@ -336,28 +438,8 @@ func (h *FailoverHandler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate display_model if provided
-	if req.DisplayModel != nil {
-		trimmedModel, modelErr := validateNameString("display_model", *req.DisplayModel, 1, 128)
-		if modelErr != nil {
-			respondBadRequest(w, "invalid display model", modelErr)
-			return
-		}
-		lowerModel := strings.ToLower(trimmedModel)
-		req.DisplayModel = &lowerModel
-
-		// Uniqueness check: no other failover group should have this display_model
-		if *req.DisplayModel != existing.DisplayModel {
-			conflict, err := h.failoverRepo.GetByModel(r.Context(), *req.DisplayModel)
-			if err != nil && !errors.Is(err, pgx.ErrNoRows) {
-				respondError(w, "failed to check display_model uniqueness", err, http.StatusInternalServerError)
-				return
-			}
-			if conflict != nil {
-				http.Error(w, "A failover group for '"+*req.DisplayModel+"' already exists. Choose a different name.", http.StatusConflict)
-				return
-			}
-		}
+	if !h.validateDisplayModelPatch(w, r, &req, existing) {
+		return
 	}
 
 	// Validate field lengths
@@ -380,68 +462,13 @@ func (h *FailoverHandler) Update(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	priorityOrder := existing.PriorityOrder
-	entryEnabled := existing.EntryEnabled
-
-	if req.PriorityOrder != nil {
-		priorityOrder = make([]uuid.UUID, len(req.PriorityOrder))
-		for i, idStr := range req.PriorityOrder {
-			parsedID, err := uuid.Parse(idStr)
-			if err != nil {
-				http.Error(w, "invalid priority_order entry: "+idStr, http.StatusBadRequest)
-				return
-			}
-			priorityOrder[i] = parsedID
-		}
+	priorityOrder, entryEnabled, ok := resolveGroupUpdateLists(w, &req, existing)
+	if !ok {
+		return
 	}
 
-	if req.EntryEnabled != nil {
-		entryEnabled = req.EntryEnabled
-	}
-
-	// Determine the effective group_enabled value
-	effectiveGroupEnabled := existing.GroupEnabled
-	if req.GroupEnabled != nil {
-		effectiveGroupEnabled = *req.GroupEnabled
-	}
-
-	// Validate that at least one entry is enabled for an active failover group
-	if effectiveGroupEnabled {
-		hasEnabled := false
-		for _, enabled := range entryEnabled {
-			if enabled {
-				hasEnabled = true
-				break
-			}
-		}
-		if !hasEnabled {
-			http.Error(w, "at least one entry must be enabled for an active failover group", http.StatusBadRequest)
-			return
-		}
-	}
-
-	// Enforce the failover invariant at the API boundary: turning a group on
-	// requires at least two routable members (model and provider both enabled).
-	// This complements the auto-disable on sync/discovery so a user cannot
-	// re-enable a group that discovery left with a single live member. Scoped to
-	// the off->on transition so reorders/renames of an already-enabled group are
-	// untouched.
-	if effectiveGroupEnabled && !existing.GroupEnabled {
-		models, mErr := h.modelRepo.GetByIDs(r.Context(), priorityOrder)
-		if mErr != nil {
-			respondError(w, "failed to validate failover members", mErr, http.StatusInternalServerError)
-			return
-		}
-		routable := 0
-		for _, mid := range priorityOrder {
-			if m, ok := models[mid]; ok && m.Enabled && m.ProviderEnabled {
-				routable++
-			}
-		}
-		if routable < 2 {
-			http.Error(w, "a failover group needs at least 2 enabled members (model and provider enabled) to be active", http.StatusBadRequest)
-			return
-		}
+	if !h.validateGroupEnabledState(w, r, &req, existing, priorityOrder, entryEnabled) {
+		return
 	}
 
 	// Always invalidate cache so priority reorders and entry changes take

--- a/internal/api/failover_update_helpers_test.go
+++ b/internal/api/failover_update_helpers_test.go
@@ -1,0 +1,52 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/hugalafutro/model-hotel/internal/failover"
+)
+
+// TestFailoverUpdateHelperDBErrors exercises the 500 paths of the Update
+// validation helpers by running their repo lookups on an already-cancelled
+// request context, so a DB failure mid-PATCH is covered without a broken pool.
+func TestFailoverUpdateHelperDBErrors(t *testing.T) {
+	h := newIntegrationFailoverHandler()
+	if h == nil {
+		t.Skip("test DB unavailable")
+	}
+	failover.InvalidateFailoverCache()
+	cctx := cancelledCtx()
+	existing := &failover.FailoverGroup{DisplayModel: "old-model", GroupEnabled: false}
+
+	t.Run("display_model_uniqueness_check_fails", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPatch, "/", http.NoBody).WithContext(cctx)
+		dm := "new-model"
+		body := &UpdateFailoverGroupRequest{DisplayModel: &dm}
+		if h.validateDisplayModelPatch(rec, req, body, existing) {
+			t.Error("expected validation to fail when GetByModel errors")
+		}
+		if rec.Code != http.StatusInternalServerError {
+			t.Errorf("expected 500, got %d", rec.Code)
+		}
+	})
+
+	t.Run("member_lookup_fails_on_enable", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPatch, "/", http.NoBody).WithContext(cctx)
+		enabled := true
+		body := &UpdateFailoverGroupRequest{GroupEnabled: &enabled}
+		priority := []uuid.UUID{uuid.New(), uuid.New()}
+		entries := map[string]bool{"a": true}
+		if h.validateGroupEnabledState(rec, req, body, existing, priority, entries) {
+			t.Error("expected validation to fail when GetByIDs errors")
+		}
+		if rec.Code != http.StatusInternalServerError {
+			t.Errorf("expected 500, got %d", rec.Code)
+		}
+	})
+}

--- a/internal/provider/discovery.go
+++ b/internal/provider/discovery.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -160,13 +161,63 @@ func (d *DiscoveryService) fetchURL(ctx context.Context, method, url string, hea
 	return bodyBytes, nil
 }
 
+// hostTypeRules maps provider hostnames to provider types: exact host names
+// plus suffixes for subdomain matches (api.foo.deepseek.com, custom.nano-gpt.com).
+// Suffix matching (rather than strings.Contains) ensures
+// "https://my-proxy.deepseek.com" resolves to "deepseek" without substring
+// false positives. Providers needing path- or contains-based detection
+// (opencode, google) are handled separately in detectByHost.
+var hostTypeRules = []struct {
+	typ      string
+	exact    []string
+	suffixes []string
+}{
+	{"nanogpt", []string{"api.nano-gpt.com", "nano-gpt.com"}, []string{".nano-gpt.com"}},
+	{"zai-coding", []string{"api.z.ai", "z.ai"}, []string{".z.ai"}},
+	{"deepseek", []string{"api.deepseek.com", "deepseek.com"}, []string{".deepseek.com"}},
+	{"anthropic", []string{"api.anthropic.com", "anthropic.com"}, []string{".anthropic.com"}},
+	{"xai", []string{"api.x.ai", "x.ai"}, []string{".x.ai"}},
+	{"cohere", []string{"api.cohere.com", "api.cohere.ai"}, []string{".cohere.com", ".cohere.ai"}},
+	{"openrouter", []string{"openrouter.ai"}, []string{".openrouter.ai"}},
+	{"ollama-cloud", []string{"ollama.com"}, []string{".ollama.com"}},
+	{"neuralwatt", []string{"api.neuralwatt.com", "neuralwatt.com"}, []string{".neuralwatt.com"}},
+}
+
+// detectByHost resolves a provider type from a lowercased hostname (and URL
+// path, for opencode). Returns "" when no rule matches.
+func detectByHost(host, path string) string {
+	for _, r := range hostTypeRules {
+		if slices.Contains(r.exact, host) {
+			return r.typ
+		}
+		for _, s := range r.suffixes {
+			if strings.HasSuffix(host, s) {
+				return r.typ
+			}
+		}
+	}
+	if host == "generativelanguage.googleapis.com" {
+		return "google"
+	}
+	if strings.HasSuffix(host, ".googleapis.com") &&
+		(strings.Contains(host, "generativelanguage") || strings.Contains(host, "aiplatform")) {
+		return "google"
+	}
+	if host == "opencode.ai" || strings.HasSuffix(host, ".opencode.ai") {
+		// Path-based detection: Go URL contains /zen/go/, Zen contains /zen/.
+		// Must check Go before Zen since /zen/go/ is a subpath of /zen/.
+		if strings.Contains(path, "/zen/go") {
+			return "opencode-go"
+		}
+		if strings.Contains(path, "/zen") {
+			return "opencode-zen"
+		}
+	}
+	return ""
+}
+
 // DetectProviderType parses the provider's base URL and returns a type string
-// based on the hostname and (for some providers) the URL path. It uses exact
-// host matching and suffix matching so that "https://my-proxy.deepseek.com"
-// correctly resolves to "deepseek" rather than matching a substring like
-// strings.Contains would.
-//
-//nolint:gocyclo // complexity 38: flat hostname-matching table over the provider list; on the gocyclo refactor shortlist
+// based on the hostname and (for some providers) the URL path or port.
 func DetectProviderType(baseURL string) string {
 	u, err := url.Parse(strings.TrimSpace(baseURL))
 	if err != nil || u.Host == "" {
@@ -176,80 +227,8 @@ func DetectProviderType(baseURL string) string {
 	host := strings.ToLower(u.Hostname())
 	path := strings.ToLower(u.Path)
 
-	// Exact matches first
-	switch host {
-	case "api.nano-gpt.com", "nano-gpt.com":
-		return "nanogpt"
-	case "api.z.ai", "z.ai":
-		return "zai-coding"
-	case "api.deepseek.com", "deepseek.com":
-		return "deepseek"
-	case "api.anthropic.com", "anthropic.com":
-		return "anthropic"
-	case "api.x.ai", "x.ai":
-		return "xai"
-	case "api.cohere.com", "api.cohere.ai":
-		return "cohere"
-	case "openrouter.ai":
-		return "openrouter"
-	case "generativelanguage.googleapis.com":
-		return "google"
-	case "ollama.com":
-		return "ollama-cloud"
-	case "opencode.ai":
-		// Path-based detection: Go URL contains /zen/go/, Zen contains /zen/
-		// Must check Go before Zen since /zen/go/ is a subpath of /zen/
-		if strings.Contains(path, "/zen/go") {
-			return "opencode-go"
-		}
-		if strings.Contains(path, "/zen") {
-			return "opencode-zen"
-		}
-	case "api.neuralwatt.com", "neuralwatt.com":
-		return "neuralwatt"
-	}
-
-	// Subdomain matching: api.foo.deepseek.com, custom.nano-gpt.com, etc.
-	if strings.HasSuffix(host, ".nano-gpt.com") {
-		return "nanogpt"
-	}
-	if strings.HasSuffix(host, ".z.ai") {
-		return "zai-coding"
-	}
-	if strings.HasSuffix(host, ".deepseek.com") {
-		return "deepseek"
-	}
-	if strings.HasSuffix(host, ".anthropic.com") {
-		return "anthropic"
-	}
-	if strings.HasSuffix(host, ".x.ai") {
-		return "xai"
-	}
-	if strings.HasSuffix(host, ".cohere.com") || strings.HasSuffix(host, ".cohere.ai") {
-		return "cohere"
-	}
-	if strings.HasSuffix(host, ".openrouter.ai") {
-		return "openrouter"
-	}
-	if strings.HasSuffix(host, ".googleapis.com") {
-		if strings.Contains(host, "generativelanguage") || strings.Contains(host, "aiplatform") {
-			return "google"
-		}
-	}
-	if strings.HasSuffix(host, ".ollama.com") {
-		return "ollama-cloud"
-	}
-	if strings.HasSuffix(host, ".opencode.ai") {
-		// Path-based detection for custom opencode.ai subdomains
-		if strings.Contains(path, "/zen/go") {
-			return "opencode-go"
-		}
-		if strings.Contains(path, "/zen") {
-			return "opencode-zen"
-		}
-	}
-	if strings.HasSuffix(host, ".neuralwatt.com") {
-		return "neuralwatt"
+	if typ := detectByHost(host, path); typ != "" {
+		return typ
 	}
 
 	// Port-based heuristics for self-hosted providers (Ollama, LM Studio, KoboldCPP).
@@ -259,8 +238,7 @@ func DetectProviderType(baseURL string) string {
 	// Note: port 5001 is also used by IPFS HTTP API and Apple AirPlay Receiver.
 	// Port 1234 is a common generic dev port. If discovery misclassifies a non-LLM
 	// service on one of these ports, the user can override the provider type manually.
-	port := u.Port()
-	switch port {
+	switch u.Port() {
 	case "11434":
 		return "ollama"
 	case "5001":
@@ -269,11 +247,7 @@ func DetectProviderType(baseURL string) string {
 		return "lmstudio"
 	}
 
-	// Loopback without a recognised local-provider port falls back to openai.
-	if host == "localhost" || host == "127.0.0.1" || host == "::1" {
-		return "openai"
-	}
-
+	// Unrecognised hosts (including bare loopback) fall back to openai.
 	return "openai"
 }
 

--- a/internal/provider/modelsdev.go
+++ b/internal/provider/modelsdev.go
@@ -293,11 +293,54 @@ func (c *ModelsDevCache) LookupFuzzy(modelID string) *ModelsDevModelSpec {
 	return bestMatch
 }
 
+// fillIfEmpty copies v into *dst when *dst is nil and v is positive,
+// reporting whether it did.
+func fillIfEmpty[T int | float64](dst **T, v T) bool {
+	if *dst != nil || v <= 0 {
+		return false
+	}
+	*dst = &v
+	return true
+}
+
+// mergeSpecCapabilities ORs models.dev capability flags into caps (never
+// clears an already-set flag), reporting whether anything changed.
+func mergeSpecCapabilities(spec *ModelsDevModelSpec, caps *model.Capability) bool {
+	merged := false
+	if spec.Reasoning && !caps.Reasoning {
+		caps.Reasoning = true
+		merged = true
+	}
+	if spec.ToolCall && !caps.ToolCalling {
+		caps.ToolCalling = true
+		merged = true
+	}
+	if spec.StructuredOutput != nil && *spec.StructuredOutput && !caps.StructuredOutput {
+		caps.StructuredOutput = true
+		merged = true
+	}
+	// Attachment → Vision mapping.
+	if spec.Attachment && !caps.Vision {
+		caps.Vision = true
+		merged = true
+	}
+	return merged
+}
+
+// fillModalities marshals mods into *dst when *dst is currently empty,
+// reporting whether it did.
+func fillModalities(dst *string, mods []string) bool {
+	if (*dst != "" && *dst != "[]") || len(mods) == 0 {
+		return false
+	}
+	b, _ := json.Marshal(mods)
+	*dst = string(b)
+	return true
+}
+
 // EnrichModel fills gaps in a model.Model using models.dev data.
 // It only overwrites fields that are empty/zero (never replaces existing data).
 // Returns true if at least one field was enriched.
-//
-//nolint:gocyclo // complexity 38: repetitive per-field if-empty gap filling; on the gocyclo refactor shortlist
 func (c *ModelsDevCache) EnrichModel(m *model.Model) bool {
 	if c == nil {
 		return false
@@ -326,73 +369,23 @@ func (c *ModelsDevCache) EnrichModel(m *model.Model) bool {
 		}
 	}
 
-	// Context length: only set if nil.
-	if m.ContextLength == nil && spec.Limit.Context > 0 {
-		ctxLen := spec.Limit.Context
-		m.ContextLength = &ctxLen
-		enriched = true
-	}
-
-	// Max output tokens: only set if nil.
-	if m.MaxOutputTokens == nil && spec.Limit.Output > 0 {
-		maxOut := spec.Limit.Output
-		m.MaxOutputTokens = &maxOut
-		enriched = true
-	}
-
-	// Input price: only set if nil.
-	if m.InputPricePerMillion == nil && spec.Cost.Input > 0 {
-		inPrice := spec.Cost.Input
-		m.InputPricePerMillion = &inPrice
-		enriched = true
-	}
-
-	// Output price: only set if nil.
-	if m.OutputPricePerMillion == nil && spec.Cost.Output > 0 {
-		outPrice := spec.Cost.Output
-		m.OutputPricePerMillion = &outPrice
-		enriched = true
-	}
-
-	// Cache hit price: only set if nil and models.dev has it.
-	if m.InputPricePerMillionCacheHit == nil && spec.Cost.CacheRead != nil && *spec.Cost.CacheRead > 0 {
-		cachePrice := *spec.Cost.CacheRead
-		m.InputPricePerMillionCacheHit = &cachePrice
-		enriched = true
+	// Numeric fields: only set if nil.
+	enriched = fillIfEmpty(&m.ContextLength, spec.Limit.Context) || enriched
+	enriched = fillIfEmpty(&m.MaxOutputTokens, spec.Limit.Output) || enriched
+	enriched = fillIfEmpty(&m.InputPricePerMillion, spec.Cost.Input) || enriched
+	enriched = fillIfEmpty(&m.OutputPricePerMillion, spec.Cost.Output) || enriched
+	if spec.Cost.CacheRead != nil {
+		enriched = fillIfEmpty(&m.InputPricePerMillionCacheHit, *spec.Cost.CacheRead) || enriched
 	}
 
 	// Capabilities: only set individual fields if they're currently false.
-	if spec.Reasoning && !caps.Reasoning {
-		caps.Reasoning = true
-		enriched = true
-	}
-	if spec.ToolCall && !caps.ToolCalling {
-		caps.ToolCalling = true
-		enriched = true
-	}
-	if spec.StructuredOutput != nil && *spec.StructuredOutput && !caps.StructuredOutput {
-		caps.StructuredOutput = true
-		enriched = true
-	}
-	// Attachment → Vision mapping.
-	if spec.Attachment && !caps.Vision {
-		caps.Vision = true
-		enriched = true
-	}
+	enriched = mergeSpecCapabilities(spec, &caps) || enriched
 
 	// Modality arrays: only set if currently empty. The modality *class* is
 	// not set here — NormalizeModelClassification derives it from the arrays
 	// after enrichment.
-	if (m.InputModalities == "" || m.InputModalities == "[]") && len(spec.Modalities.Input) > 0 {
-		inMods, _ := json.Marshal(spec.Modalities.Input)
-		m.InputModalities = string(inMods)
-		enriched = true
-	}
-	if (m.OutputModalities == "" || m.OutputModalities == "[]") && len(spec.Modalities.Output) > 0 {
-		outMods, _ := json.Marshal(spec.Modalities.Output)
-		m.OutputModalities = string(outMods)
-		enriched = true
-	}
+	enriched = fillModalities(&m.InputModalities, spec.Modalities.Input) || enriched
+	enriched = fillModalities(&m.OutputModalities, spec.Modalities.Output) || enriched
 
 	// Owned by / family: only set if empty.
 	if m.OwnedBy == "" && spec.Family != "" {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -286,6 +286,51 @@ func (st *streamState) emitData(sink *streamSink, payload []byte, transform stri
 	return true
 }
 
+// applyReasoningNormalize is the reasoning field normalization transform:
+// ensure reasoning_content is populated regardless of upstream format (Ollama
+// reasoning, OpenRouter/MiniMax reasoning_details, <thinking> tags in
+// content). Emits the rewritten chunk itself; wrote reports that emit and
+// stop=true a client write failure.
+func (st *streamState) applyReasoningNormalize(sink *streamSink, chunk streamChunk, payload string, chunkCount int, logData *requestLogData) (wrote, stop bool) {
+	if len(chunk.Choices) == 0 || chunk.Choices[0].Delta == nil {
+		return false, false
+	}
+	delta := chunk.Choices[0].Delta
+	newPayload, ok := normalizeReasoningChunk(delta.Content, delta.ReasoningContent, payload, &st.lastFinishReason, logData)
+	if !ok {
+		return false, false
+	}
+	if !st.emitData(sink, newPayload, "reasoning normalization", chunkCount, logData) {
+		return false, true
+	}
+	debuglog.Debug("proxy: normalized reasoning fields", "model", logData.modelID, "provider", logData.providerName, "chunk_number", chunkCount)
+	return true, false
+}
+
+// applyEmptyContentStrip strips the noise content:"" that accompanies
+// reasoning-only deltas. Emits the rewritten chunk itself; wrote reports that
+// emit and stop=true a client write failure.
+func (st *streamState) applyEmptyContentStrip(sink *streamSink, chunk streamChunk, payload string, chunkCount int, logData *requestLogData) (wrote, stop bool) {
+	if len(chunk.Choices) == 0 || chunk.Choices[0].Delta == nil {
+		return false, false
+	}
+	delta := chunk.Choices[0].Delta
+	hasReasoning := delta.ReasoningContent != nil && *delta.ReasoningContent != ""
+	hasEmptyContent := delta.Content != nil && *delta.Content == ""
+	if !hasReasoning || !hasEmptyContent {
+		return false, false
+	}
+	newPayload, ok := stripEmptyReasoningContent(payload, &st.lastFinishReason, logData)
+	if !ok {
+		return false, false
+	}
+	if !st.emitData(sink, newPayload, "empty content strip", chunkCount, logData) {
+		return false, true
+	}
+	debuglog.Debug("proxy: stripped empty content from reasoning chunk", "model", logData.modelID, "provider", logData.providerName, "chunk_number", chunkCount)
+	return true, false
+}
+
 // handleDataChunk processes one sseData event end-to-end: capture split/Anthropic
 // SSE errors (P1-B/P1-C), parse the chunk, run the transforms (strip_reasoning,
 // reasoning-normalize, empty-content-strip, finish_reason) and the side-channel
@@ -293,8 +338,6 @@ func (st *streamState) emitData(sink *streamSink, payload []byte, transform stri
 // whole transform dispatch are encapsulated here. Returns stop=true when a client
 // write failed (the caller jumps to finalize), false otherwise (advance to the
 // next event).
-//
-//nolint:gocyclo // complexity 33: SSE transform dispatch for every chunk shape; on the gocyclo refactor shortlist
 func (h *Handler) handleDataChunk(sink *streamSink, st *streamState, ev sseEvent, stripReasoning bool, chunkCount int, logData *requestLogData) (stop bool) {
 	payload := ev.payload
 	line := ev.raw
@@ -333,35 +376,17 @@ func (h *Handler) handleDataChunk(sink *streamSink, st *streamState, ev sseEvent
 		}
 	stripReasoningDone:
 
-		// Reasoning field normalization: ensure reasoning_content is populated
-		// regardless of upstream format (Ollama reasoning, OpenRouter/MiniMax
-		// reasoning_details, <thinking> tags in content).
-		if len(chunk.Choices) > 0 && chunk.Choices[0].Delta != nil {
-			delta := chunk.Choices[0].Delta
-			if newPayload, ok := normalizeReasoningChunk(delta.Content, delta.ReasoningContent, payload, &st.lastFinishReason, logData); ok {
-				if !st.emitData(sink, newPayload, "reasoning normalization", chunkCount, logData) {
-					return true
-				}
-				written = true
-				debuglog.Debug("proxy: normalized reasoning fields", "model", logData.modelID, "provider", logData.providerName, "chunk_number", chunkCount)
-			}
+		wrote, stopStream := st.applyReasoningNormalize(sink, chunk, payload, chunkCount, logData)
+		if stopStream {
+			return true
 		}
+		written = written || wrote
 
-		// Strip the noise content:"" that accompanies reasoning-only deltas.
-		if len(chunk.Choices) > 0 && chunk.Choices[0].Delta != nil {
-			delta := chunk.Choices[0].Delta
-			hasReasoning := delta.ReasoningContent != nil && *delta.ReasoningContent != ""
-			hasEmptyContent := delta.Content != nil && *delta.Content == ""
-			if hasReasoning && hasEmptyContent {
-				if newPayload, ok := stripEmptyReasoningContent(payload, &st.lastFinishReason, logData); ok {
-					if !st.emitData(sink, newPayload, "empty content strip", chunkCount, logData) {
-						return true
-					}
-					written = true
-					debuglog.Debug("proxy: stripped empty content from reasoning chunk", "model", logData.modelID, "provider", logData.providerName, "chunk_number", chunkCount)
-				}
-			}
+		wrote, stopStream = st.applyEmptyContentStrip(sink, chunk, payload, chunkCount, logData)
+		if stopStream {
+			return true
 		}
+		written = written || wrote
 
 		// Normalize provider finish_reason and suppress P2-2 bare duplicates.
 		switch decision, newPayload := computeFinishReason(chunk, payload, &st.lastFinishReason); decision {

--- a/internal/proxy/stream_transforms_test.go
+++ b/internal/proxy/stream_transforms_test.go
@@ -509,3 +509,18 @@ func TestComputeFinishReason(t *testing.T) {
 		}
 	})
 }
+
+// TestApplyEmptyContentStripUnparseablePayload covers the defensive branch
+// where the typed chunk indicates a reasoning-only delta but the raw payload
+// fails to re-parse: the transform declines (no emit, no stop) so the caller
+// forwards the original line. The nil sink proves the branch returns before
+// any write.
+func TestApplyEmptyContentStripUnparseablePayload(t *testing.T) {
+	t.Parallel()
+	c := parseStreamChunk(t, `{"choices":[{"index":0,"delta":{"content":"","reasoning_content":"r"}}]}`)
+	st := &streamState{}
+	wrote, stop := st.applyEmptyContentStrip(nil, c, `{"broken`, 1, &requestLogData{modelID: "m", providerName: "p"})
+	if wrote || stop {
+		t.Errorf("expected no emit and no stop, got wrote=%v stop=%v", wrote, stop)
+	}
+}


### PR DESCRIPTION
## Summary

Completes the gocyclo refactor shortlist: all six functions carrying `//nolint:gocyclo` are refactored below the complexity threshold and the suppressions removed. The worst prod function in the repo is now 29, so `min-complexity: 30` is met with zero inline nolints (config comment updated accordingly).

| Function | Before | After |
|---|---|---|
| `main` (cmd/server) | 112 | 19 |
| `ModelsDevCache.EnrichModel` | 38 | 21 |
| `DetectProviderType` | 38 | 7 |
| `FailoverHandler.Update` | 35 | ~14 |
| `ConfigSyncHandler.apply` | 33 | ~15 |
| `Handler.handleDataChunk` | 33 | ~25 |
| `ConfigSyncHandler.computeDiff` | 30 | ~10 |

## How

Pure structural extraction; behavior is unchanged. Highlights:

- **main**: the inline closures were the bulk of the count. Discovery machinery now lives in `cmd/server/discovery.go` (a `discoveryDeps` struct shared by the startup runner and scheduler), background loops in `cmd/server/background.go` (with the stale-log and retention sweep bodies extracted as pass functions so the timer loops stay thin), and the security/CORS/request-size middlewares are named functions. This also resolves the old TODO about extracting the three inline goroutines.
- **handleDataChunk**: only the reasoning-normalize and empty-content-strip transforms were extracted, per the shortlist note. The transform dispatch order, the `written` flag semantics, and the `goto` are untouched.
- **computeDiff**: five structurally identical classify blocks collapsed into one generic `diffKeyed` helper.
- **DetectProviderType**: table-driven host rules; a dead loopback branch that returned the same fallback as the line below it was removed.

## Testing

- Full backend suite green after every individual function change and at the end (5554 tests, 34 packages), `golangci-lint run ./...` clean.
- `cmd/server` gains a DB-backed `TestMain` (via the shared `db.SetupTestDB` harness) with tests for the full discovery happy path (mock OpenAI-style provider, auto failover group formation, change-feed nudge), failure and skip paths, the discovery scheduler (including the disabled-interval park/wake cycle), the cleanup passes, cache warming, and the three middlewares.
- Error-path tests added for the extracted configsync helpers (rolled-back tx, read-only tx, and an empty `search_path` to fail the fence's marker read while the advisory lock succeeds) and the failover Update helpers (cancelled request context).
- Diff-vs-coverage intersection: uncovered changed lines reduced from 187 to 104. The remainder are `main()` wiring, the WebAuthn hourly ticker, and mid-scan fault-injection branches (suspect streaks, missing-model probes); all of these were equally uncovered before the refactor when they lived inline in `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)