### PR TITLE
feat(audit): scroll/paginate toggle + detail tweaks; fix FD traffic flicker

### DIFF
--- a/frontdesk/web/src/pages/TrafficPage.tsx
+++ b/frontdesk/web/src/pages/TrafficPage.tsx
@@ -36,8 +36,9 @@ function MemberTrafficCard({
 	// Reports this card's fetch time (or null on a failed read) up to the page so
 	// it can collapse identical stamps into a single page-level one.
 	onUpdated: (id: string, iso: string | null) => void;
-	// True only when the cards disagree on their last-updated time, in which case
-	// each card carries its own stamp; otherwise the page shows one shared stamp.
+	// True only when another card's read failed, so the page can't show a single
+	// trustworthy shared stamp and each card carries its own instead (this card's
+	// own stamp is still hidden when its data is null).
 	showLocalUpdated: boolean;
 }) {
 	const { t } = useTranslation();
@@ -271,28 +272,30 @@ export function TrafficPage() {
 		return () => clearInterval(id);
 	}, [paused, refresh]);
 
-	// Each card reports its last fetch time here (null when its read failed). The
-	// page shows one shared "updated" line only when EVERY token card has reported
-	// a time and they all match - the common case, where all cards refresh on the
-	// same tick, mirroring the Members tab. If any card is still loading or failed
-	// its read, a shared stamp would falsely imply that card is fresh too, so each
-	// card falls back to its own stamp instead (the failed one showing none).
+	// Each card reports its last fetch time here (null when its read failed, or
+	// still absent before its first load). The page shows one shared "updated"
+	// line whenever every token card holds a fresh reachable time, using the most
+	// recent of them - mirroring the Members tab. Only a genuinely failed card
+	// (an explicit null) splits the page into per-card stamps; a card that is
+	// merely mid-refetch keeps its previous time, so a refresh tick where one card
+	// commits its new time a beat before the other does NOT flip the layout to
+	// per-card and back (which showed up as a ~15px jump under the second graph).
 	const [updatedAts, setUpdatedAts] = useState<Record<string, string | null>>(
 		{},
 	);
 	const onUpdated = useCallback((id: string, iso: string | null) => {
 		setUpdatedAts((prev) => ({ ...prev, [id]: iso }));
 	}, []);
-	const cardStamps = tokenMembers.map((m) => {
-		const iso = updatedAts[m.id];
-		return iso ? formatTimeOfDay(iso) : null;
-	});
-	const allStamped =
-		cardStamps.length > 0 && cardStamps.every((tv) => tv !== null);
+	const cardStamps = tokenMembers.map((m) => updatedAts[m.id]);
+	const anyFailed = cardStamps.some((v) => v === null);
+	const anyLoading = cardStamps.some((v) => v === undefined);
+	// Latest reported ISO wins for the shared line; ISO strings sort chronologically.
+	const latestIso = cardStamps.reduce<string | null>(
+		(latest, v) => (v && (!latest || v > latest) ? v : latest),
+		null,
+	);
 	const sharedTime =
-		allStamped && cardStamps.every((tv) => tv === cardStamps[0])
-			? cardStamps[0]
-			: null;
+		!anyFailed && !anyLoading && latestIso ? formatTimeOfDay(latestIso) : null;
 
 	return (
 		<div className="fd-stack">
@@ -330,7 +333,7 @@ export function TrafficPage() {
 								member={m}
 								reloadKey={reloadKey}
 								onUpdated={onUpdated}
-								showLocalUpdated={sharedTime === null}
+								showLocalUpdated={anyFailed}
 							/>
 						))}
 						{hasTokenless && (

--- a/frontdesk/web/src/pages/__tests__/TrafficPage.test.tsx
+++ b/frontdesk/web/src/pages/__tests__/TrafficPage.test.tsx
@@ -53,6 +53,7 @@ beforeEach(() => {
 afterEach(() => {
 	// Tests that opt into fake timers reset here; a no-op for the real-timer ones.
 	vi.useRealTimers();
+	vi.restoreAllMocks();
 });
 
 // settle drives the fake-timer clock forward a little, flushing the mount fetch
@@ -229,6 +230,55 @@ describe("TrafficPage", () => {
 		expect(screen.queryByTestId("traffic-updated")).not.toBeInTheDocument();
 		// The healthy card keeps exactly one local stamp; the failed one has none.
 		expect(screen.getAllByTestId("traffic-updated-local")).toHaveLength(1);
+	});
+
+	it("keeps one shared stamp when reachable cards report different times", async () => {
+		// Regression: two reachable cards can commit slightly different fetch times
+		// (one lands a beat after the other on a refresh tick). That difference must
+		// NOT split the page into per-card stamps - which flashed a ~15px line under
+		// the second graph - since both are fresh. The page keeps a single shared
+		// stamp using the latest time. Distinct per-call times are forced here.
+		let tick = 0;
+		vi.spyOn(Date.prototype, "toISOString").mockImplementation(() => {
+			tick += 1;
+			return `2026-01-01T00:00:0${tick}.000Z`;
+		});
+		vi.useFakeTimers();
+		server.use(
+			http.get("/api/members", () =>
+				HttpResponse.json([
+					member({ id: "1", name: "hotel-1" }),
+					member({ id: "2", name: "hotel-2" }),
+				]),
+			),
+			http.get("/api/members/1/traffic", () =>
+				HttpResponse.json(
+					traffic({
+						member_id: "1",
+						total_requests: 10,
+						points: [{ bucket: "b1", requests: 10, errors: 0 }],
+					}),
+				),
+			),
+			http.get("/api/members/2/traffic", () =>
+				HttpResponse.json(
+					traffic({
+						member_id: "2",
+						total_requests: 20,
+						points: [{ bucket: "b1", requests: 20, errors: 0 }],
+					}),
+				),
+			),
+		);
+		renderPage();
+		await settle();
+
+		expect(screen.getByText("10")).toBeInTheDocument();
+		expect(screen.getByText("20")).toBeInTheDocument();
+		// Both reachable but with different reported times: still exactly one shared
+		// stamp, and no per-card stamp flashed in.
+		expect(screen.getByTestId("traffic-updated")).toBeInTheDocument();
+		expect(screen.queryAllByTestId("traffic-updated-local")).toHaveLength(0);
 	});
 
 	it("auto-refreshes every graph on an interval with no user action", async () => {

--- a/internal/api/audit.go
+++ b/internal/api/audit.go
@@ -36,9 +36,9 @@ type AuditListResponse struct {
 	NextCursor string `json:"next_cursor,omitempty"`
 }
 
-// ListAudit returns audit entries newest-first with keyset pagination.
-// Query params: cursor (base64 of {created_at,id}), limit (default 50, max
-// 200), actor, method, from, to (RFC3339).
+// ListAudit returns audit entries newest-first. Query params: cursor (base64 of
+// {created_at,id}) for infinite scroll, or offset for the page-numbered view;
+// limit (default 50, max 200), actor, method, from, to (RFC3339).
 func (h *Handler) ListAudit(w http.ResponseWriter, r *http.Request) {
 	if h.audit == nil {
 		http.Error(w, "audit log is not available", http.StatusNotFound)
@@ -47,6 +47,7 @@ func (h *Handler) ListAudit(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
 	p := audit.ListParams{
 		Limit:  util.GetIntQueryParam(r, "limit", 50),
+		Offset: util.GetIntQueryParam(r, "offset", 0),
 		Actor:  q.Get("actor"),
 		Method: q.Get("method"),
 	}

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -57,10 +57,15 @@ type ListParams struct {
 	CursorCreatedAt time.Time
 	CursorID        string
 	Limit           int
-	Actor           string
-	Method          string
-	From            time.Time
-	To              time.Time
+	// Offset skips this many rows before the page (0 = from the top). Used by the
+	// dashboard's page-numbered view; the keyset cursor above is used by infinite
+	// scroll. They are mutually exclusive in practice - a caller sends one or the
+	// other - but both may be set and are simply ANDed.
+	Offset int
+	Actor  string
+	Method string
+	From   time.Time
+	To     time.Time
 }
 
 // Recorder persists audit entries and prunes old ones. Wired over the shared
@@ -267,6 +272,9 @@ func (rec *Recorder) List(ctx context.Context, p ListParams) ([]Entry, error) {
 	if p.Limit > 200 {
 		p.Limit = 200
 	}
+	if p.Offset < 0 {
+		p.Offset = 0
+	}
 	query := `SELECT id, created_at, actor, actor_role, method, route, path, COALESCE(entity_id, ''), status_code, remote_addr
 		FROM audit_log WHERE 1=1`
 	args := []any{}
@@ -295,6 +303,12 @@ func (rec *Recorder) List(ctx context.Context, p ListParams) ([]Entry, error) {
 	}
 	query += fmt.Sprintf(" ORDER BY created_at DESC, id DESC LIMIT $%d", idx)
 	args = append(args, p.Limit+1)
+	// Offset-based paging for the page-numbered view. The +1 lookahead above still
+	// gives HasMore for the current page.
+	if p.Offset > 0 {
+		query += fmt.Sprintf(" OFFSET $%d", idx+1)
+		args = append(args, p.Offset)
+	}
 
 	rows, err := rec.pool.Query(ctx, query, args...)
 	if err != nil {

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -282,6 +282,18 @@ func TestListFiltersCursorAndLimits(t *testing.T) {
 		}
 	}
 
+	// Offset paging (page-numbered view): skipping the first two rows returns the
+	// next window and never the rows it skipped.
+	offsetPage, _ := rec.List(ctx, ListParams{Limit: 2, Offset: 2})
+	if len(offsetPage) != 3 { // 2 requested + 1 lookahead
+		t.Fatalf("offset page = %d entries, want 3", len(offsetPage))
+	}
+	for _, e := range offsetPage {
+		if e.ID == page1[0].ID || e.ID == page1[1].ID {
+			t.Errorf("offset page overlaps the first two rows: %s", e.ID)
+		}
+	}
+
 	// Count honors the same filters, without the cursor.
 	if n := rec.Count(ctx, ListParams{Actor: "alice"}); n != 5 {
 		t.Errorf("count actor=alice = %d", n)

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1374,6 +1374,7 @@ export const api = {
 		list: async (params?: {
 			cursor?: string;
 			limit?: number;
+			offset?: number;
 			actor?: string;
 			method?: string;
 			from?: string;
@@ -1383,6 +1384,7 @@ export const api = {
 				buildUrl("/api/audit", {
 					cursor: params?.cursor,
 					limit: params?.limit,
+					offset: params?.offset,
 					actor: params?.actor,
 					method: params?.method,
 					from: params?.from,

--- a/web/src/components/AuditDetailModal.tsx
+++ b/web/src/components/AuditDetailModal.tsx
@@ -46,8 +46,9 @@ export function AuditDetailModal({ entry, onClose }: AuditDetailModalProps) {
 				>
 					<CopyablePill
 						text={entry.created_at}
-						displayText={formatDateTime(entry.created_at)}
-						textClassName="text-sm text-(--text-primary)"
+						displayText={formatDateTime(entry.created_at).replace(", ", "\n")}
+						lines={2}
+						textClassName="text-sm text-(--text-primary) whitespace-pre-line leading-tight"
 					/>
 					<div className="text-xs text-(--text-tertiary) mt-1 pl-[3px]">
 						{formatRelativeTime(entry.created_at)}
@@ -74,19 +75,13 @@ export function AuditDetailModal({ entry, onClose }: AuditDetailModalProps) {
 						</Badge>
 					</div>
 				</DetailItem>
-				<DetailItem
-					icon={Server}
-					label={t("components.auditDetail.remoteAddr")}
-				>
-					<CopyablePill
-						text={entry.remote_addr}
-						textClassName="text-sm font-mono text-(--text-primary)"
-					/>
-				</DetailItem>
+				{/* Entity sits in the half-width slot: whether a UUID or a human name,
+				    it is still legible when truncated. Remote address moves to the
+				    full-width row below so an ip:port is never clipped into a useless
+				    pill. */}
 				<DetailItem
 					icon={Tag}
 					label={t("components.auditDetail.entity")}
-					className="col-span-2"
 					value={entry.entity_name || entry.entity_id ? undefined : "-"}
 				>
 					{(entry.entity_name || entry.entity_id) && (
@@ -105,6 +100,16 @@ export function AuditDetailModal({ entry, onClose }: AuditDetailModalProps) {
 							)}
 						</div>
 					)}
+				</DetailItem>
+				<DetailItem
+					icon={Server}
+					label={t("components.auditDetail.remoteAddr")}
+					className="col-span-2"
+				>
+					<CopyablePill
+						text={entry.remote_addr}
+						textClassName="text-sm font-mono text-(--text-primary)"
+					/>
 				</DetailItem>
 				<DetailItem
 					icon={Hash}

--- a/web/src/pages/Audit/__tests__/Audit.test.tsx
+++ b/web/src/pages/Audit/__tests__/Audit.test.tsx
@@ -147,10 +147,10 @@ describe("Audit page", () => {
 	it("appends the next page when the scroll sentinel comes into view", async () => {
 		server.use(
 			http.get("/api/audit", ({ request }) => {
-				const offset = Number(
-					new URL(request.url).searchParams.get("offset") ?? "0",
-				);
-				if (offset > 0) {
+				// Scroll mode pages by keyset cursor, not offset, so inserts at the top
+				// of this newest-first log never shift the window.
+				const cursor = new URL(request.url).searchParams.get("cursor");
+				if (cursor === "cur-1") {
 					return HttpResponse.json({
 						entries: [entry({ route: "/second-page" })],
 						total: 2,
@@ -161,6 +161,7 @@ describe("Audit page", () => {
 					entries: [entry({ route: "/first-page" })],
 					total: 2,
 					has_more: true,
+					next_cursor: "cur-1",
 				});
 			}),
 		);

--- a/web/src/pages/Audit/__tests__/Audit.test.tsx
+++ b/web/src/pages/Audit/__tests__/Audit.test.tsx
@@ -1,10 +1,38 @@
-import { screen, waitFor } from "@testing-library/react";
+import { act, screen, waitFor } from "@testing-library/react";
 import { HttpResponse, http } from "msw";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AuditEntry } from "../../../api/types";
 import { server } from "../../../test/mocks/server";
 import { renderWithProviders } from "../../../test/utils";
 import { Audit } from "../index";
+
+// Controllable IntersectionObserver: the page arms one on its scroll-foot
+// sentinel, and tests call trigger() to simulate it scrolling into view.
+class MockIntersectionObserver {
+	static instances: MockIntersectionObserver[] = [];
+	private readonly cb: IntersectionObserverCallback;
+	private elements: Element[] = [];
+	constructor(cb: IntersectionObserverCallback) {
+		this.cb = cb;
+		MockIntersectionObserver.instances.push(this);
+	}
+	observe(el: Element) {
+		this.elements.push(el);
+	}
+	unobserve() {}
+	disconnect() {}
+	takeRecords() {
+		return [];
+	}
+	trigger(isIntersecting = true) {
+		this.cb(
+			this.elements.map(
+				(target) => ({ isIntersecting, target }) as IntersectionObserverEntry,
+			),
+			this as unknown as IntersectionObserver,
+		);
+	}
+}
 
 function entry(overrides: Partial<AuditEntry>): AuditEntry {
 	return {
@@ -24,6 +52,13 @@ function entry(overrides: Partial<AuditEntry>): AuditEntry {
 describe("Audit page", () => {
 	beforeEach(() => {
 		server.resetHandlers();
+		localStorage.clear();
+		MockIntersectionObserver.instances = [];
+		vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
 	});
 
 	it("renders entries with actor, action, entity, remote address, and status", async () => {
@@ -109,11 +144,13 @@ describe("Audit page", () => {
 		});
 	});
 
-	it("loads the next page through the cursor", async () => {
+	it("appends the next page when the scroll sentinel comes into view", async () => {
 		server.use(
 			http.get("/api/audit", ({ request }) => {
-				const cursor = new URL(request.url).searchParams.get("cursor");
-				if (cursor === "cur-1") {
+				const offset = Number(
+					new URL(request.url).searchParams.get("offset") ?? "0",
+				);
+				if (offset > 0) {
 					return HttpResponse.json({
 						entries: [entry({ route: "/second-page" })],
 						total: 2,
@@ -124,18 +161,45 @@ describe("Audit page", () => {
 					entries: [entry({ route: "/first-page" })],
 					total: 2,
 					has_more: true,
-					next_cursor: "cur-1",
+				});
+			}),
+		);
+		renderWithProviders(<Audit />);
+
+		expect(await screen.findByText("/first-page")).toBeInTheDocument();
+		// Simulate the foot sentinel scrolling into view -> next page loads.
+		act(() => {
+			MockIntersectionObserver.instances.at(-1)?.trigger();
+		});
+		expect(await screen.findByText("/second-page")).toBeInTheDocument();
+		// The first page stays appended above the second.
+		expect(screen.getByText("/first-page")).toBeInTheDocument();
+	});
+
+	it("navigates by page in pagination mode", async () => {
+		server.use(
+			http.get("/api/audit", ({ request }) => {
+				const offset = Number(
+					new URL(request.url).searchParams.get("offset") ?? "0",
+				);
+				return HttpResponse.json({
+					entries: [entry({ route: offset > 0 ? "/page-two" : "/page-one" })],
+					// Two pages' worth so the pager renders a second page button.
+					total: 60,
+					has_more: offset === 0,
 				});
 			}),
 		);
 		const { user } = renderWithProviders(<Audit />);
 
-		expect(await screen.findByText("/first-page")).toBeInTheDocument();
-		await user.click(screen.getByTestId("audit-load-more"));
-		expect(await screen.findByText("/second-page")).toBeInTheDocument();
-		// First page stays visible; the load-more button is gone.
-		expect(screen.getByText("/first-page")).toBeInTheDocument();
-		expect(screen.queryByTestId("audit-load-more")).not.toBeInTheDocument();
+		expect(await screen.findByText("/page-one")).toBeInTheDocument();
+		// Switch from infinite scroll to the paginated static table.
+		await user.click(
+			screen.getByRole("button", { name: "Switch to pagination mode" }),
+		);
+		// Jump to page two -> the next offset is requested.
+		await user.click(await screen.findByRole("button", { name: "2" }));
+		expect(await screen.findByText("/page-two")).toBeInTheDocument();
 	});
 
 	it("purges after confirmation", async () => {

--- a/web/src/pages/Audit/index.tsx
+++ b/web/src/pages/Audit/index.tsx
@@ -1,5 +1,10 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useState } from "react";
+import {
+	keepPreviousData,
+	useInfiniteQuery,
+	useQuery,
+	useQueryClient,
+} from "@tanstack/react-query";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { History } from "@/lib/icons";
 import { api } from "../../api/client";
@@ -11,22 +16,27 @@ import {
 } from "../../components/auditUtils";
 import { Badge } from "../../components/Badge";
 import { ConfirmDialog } from "../../components/ConfirmDialog";
-import { Row, StaticHeader } from "../../components/DataTable";
+import { PaginationBar, Row, StaticHeader } from "../../components/DataTable";
 import { EmptyState } from "../../components/EmptyState";
 import { FilterDropdown } from "../../components/FilterDropdown";
 import { FilterInput } from "../../components/FilterInput";
 import { LoadingSpinner } from "../../components/LoadingSpinner";
+import { ViewModeToggle } from "../../components/logs/ViewModeToggle";
 import { PageHeader } from "../../components/PageHeader";
 import { useToast } from "../../context/ToastContext";
 import { useDebounce } from "../../hooks/useDebounce";
+import { useLocalStorage } from "../../hooks/useLocalStorage";
 import { formatRelativeTime } from "../../utils/format";
 
 const METHODS = ["POST", "PUT", "PATCH", "DELETE"] as const;
+const PAGE_SIZE = 50;
 
 /**
- * Admin-only audit trail: who did what on the dashboard API, newest first,
- * with actor/method filters and cursor-based "load more" pagination. The
- * server records mutations only and never stores request bodies.
+ * Admin-only audit trail: who did what on the dashboard API, newest first, with
+ * actor/method filters. Two viewing modes matching the Logs pages: infinite
+ * scroll (default) that appends pages as you reach the bottom, and a paginated
+ * static table. The server records mutations only and never stores request
+ * bodies.
  */
 export function Audit() {
 	const { t } = useTranslation();
@@ -36,51 +46,79 @@ export function Audit() {
 	const [method, setMethod] = useState("");
 	const [confirmPurge, setConfirmPurge] = useState(false);
 	const [selected, setSelected] = useState<AuditEntry | null>(null);
-	// Pages loaded past the first are appended here; each "Load more" click
-	// fetches exactly one page and merges it, rather than replaying cursors.
-	const [extra, setExtra] = useState<{
-		entries: AuditEntry[];
-		hasMore: boolean;
-		nextCursor: string;
-	} | null>(null);
+	const [viewMode, setViewMode] = useLocalStorage<"paginate" | "scroll">(
+		"auditViewMode",
+		"scroll",
+	);
+	const [page, setPage] = useState(1);
+	const [pageSize, setPageSize] = useState(PAGE_SIZE);
 	const debouncedActor = useDebounce(actor, 300);
+	const isScroll = viewMode === "scroll";
 
-	const resetPaging = () => setExtra(null);
+	const filters = {
+		actor: debouncedActor || undefined,
+		method: method || undefined,
+	};
 
-	const { data: firstPage, isLoading } = useQuery({
-		queryKey: ["audit", debouncedActor, method],
+	// Infinite-scroll mode: one offset page per fetch, appended. getNextPageParam
+	// returns the count loaded so far as the next offset, and stops once every
+	// row is in hand.
+	const scroll = useInfiniteQuery({
+		queryKey: ["audit", "scroll", debouncedActor, method],
+		queryFn: ({ pageParam }) =>
+			api.audit.list({ ...filters, limit: PAGE_SIZE, offset: pageParam }),
+		initialPageParam: 0,
+		getNextPageParam: (lastPage, pages) => {
+			const loaded = pages.reduce((n, p) => n + p.entries.length, 0);
+			return loaded < lastPage.total ? loaded : undefined;
+		},
+		enabled: isScroll,
+	});
+
+	// Pagination mode: a single offset page, keeping the previous page visible
+	// while the next one loads so the table does not blank out on navigation.
+	const paginated = useQuery({
+		queryKey: ["audit", "page", debouncedActor, method, page, pageSize],
 		queryFn: () =>
 			api.audit.list({
-				actor: debouncedActor || undefined,
-				method: method || undefined,
-				limit: 50,
+				...filters,
+				limit: pageSize,
+				offset: (page - 1) * pageSize,
 			}),
+		enabled: !isScroll,
+		placeholderData: keepPreviousData,
 	});
 
-	const entries: AuditEntry[] = [
-		...(firstPage?.entries ?? []),
-		...(extra?.entries ?? []),
-	];
-	const hasMore = extra ? extra.hasMore : (firstPage?.has_more ?? false);
-	const nextCursor = extra ? extra.nextCursor : (firstPage?.next_cursor ?? "");
-	const total = firstPage?.total ?? 0;
+	const entries: AuditEntry[] = isScroll
+		? (scroll.data?.pages.flatMap((p) => p.entries) ?? [])
+		: (paginated.data?.entries ?? []);
+	const total = isScroll
+		? (scroll.data?.pages[0]?.total ?? 0)
+		: (paginated.data?.total ?? 0);
+	const isLoading = isScroll ? scroll.isLoading : paginated.isLoading;
+	const totalPages = Math.max(1, Math.ceil(total / pageSize));
 
-	// One fetch per click: append the returned page to the accumulated list.
-	const loadMore = useMutation({
-		mutationFn: (cursor: string) =>
-			api.audit.list({
-				actor: debouncedActor || undefined,
-				method: method || undefined,
-				limit: 50,
-				cursor,
-			}),
-		onSuccess: (page) =>
-			setExtra((prev) => ({
-				entries: [...(prev?.entries ?? []), ...page.entries],
-				hasMore: page.has_more,
-				nextCursor: page.next_cursor ?? "",
-			})),
-	});
+	// Any filter change restarts both views: the scroll query re-keys itself, and
+	// the paginated view jumps back to page one.
+	const resetPaging = () => setPage(1);
+
+	// Sentinel at the list foot: when it scrolls into view (scroll mode only),
+	// pull the next page. Re-armed whenever the fetch state changes so it keeps
+	// firing down a long list.
+	const sentinelRef = useRef<HTMLDivElement>(null);
+	const { hasNextPage, isFetchingNextPage, fetchNextPage } = scroll;
+	useEffect(() => {
+		if (!isScroll) return;
+		const el = sentinelRef.current;
+		if (!el) return;
+		const observer = new IntersectionObserver((observed) => {
+			if (observed[0]?.isIntersecting && hasNextPage && !isFetchingNextPage) {
+				fetchNextPage();
+			}
+		});
+		observer.observe(el);
+		return () => observer.disconnect();
+	}, [isScroll, hasNextPage, isFetchingNextPage, fetchNextPage]);
 
 	const handlePurge = async () => {
 		setConfirmPurge(false);
@@ -126,6 +164,7 @@ export function Audit() {
 							options={METHODS.map((m) => ({ value: m, label: m }))}
 							className="w-32"
 						/>
+						<ViewModeToggle viewMode={viewMode} onChange={setViewMode} />
 						<button
 							type="button"
 							onClick={() => setConfirmPurge(true)}
@@ -219,20 +258,43 @@ export function Audit() {
 							</tbody>
 						</table>
 					</div>
-					<div className="flex items-center justify-between text-sm text-gray-500">
-						<span>{t("audit.showing", { count: entries.length, total })}</span>
-						{hasMore && nextCursor && (
-							<button
-								type="button"
-								onClick={() => loadMore.mutate(nextCursor)}
-								disabled={loadMore.isPending}
-								className="ui-btn"
-								data-testid="audit-load-more"
-							>
-								{t("audit.loadMore")}
-							</button>
-						)}
-					</div>
+
+					{isScroll ? (
+						<>
+							<div className="flex items-center justify-between text-sm text-gray-500">
+								<span>
+									{t("audit.showing", { count: entries.length, total })}
+								</span>
+								{isFetchingNextPage && (
+									<span
+										role="status"
+										aria-label={t("common.loading")}
+										className="animate-spin rounded-full h-4 w-4 border-b-2 border-(--accent)"
+									/>
+								)}
+							</div>
+							{/* Foot marker the observer watches to load the next page. */}
+							<div ref={sentinelRef} aria-hidden="true" className="h-px" />
+						</>
+					) : (
+						<div className="flex items-center justify-between text-sm text-gray-500">
+							<span>
+								{t("audit.showing", { count: entries.length, total })}
+							</span>
+							<PaginationBar
+								page={page}
+								totalPages={totalPages}
+								totalItems={total}
+								pageSize={pageSize}
+								onPageChange={setPage}
+								onPageSizeChange={(s) => {
+									setPageSize(s);
+									setPage(1);
+								}}
+								hideCount
+							/>
+						</div>
+					)}
 				</>
 			) : (
 				<EmptyState message={t("audit.emptyState")} />

--- a/web/src/pages/Audit/index.tsx
+++ b/web/src/pages/Audit/index.tsx
@@ -60,18 +60,21 @@ export function Audit() {
 		method: method || undefined,
 	};
 
-	// Infinite-scroll mode: one offset page per fetch, appended. getNextPageParam
-	// returns the count loaded so far as the next offset, and stops once every
-	// row is in hand.
+	// Infinite-scroll mode: keyset-cursor pagination, one page per fetch, appended.
+	// The cursor (last row's created_at+id) is stable under inserts, so a new audit
+	// row landing at the top mid-scroll never shifts the window - unlike offset,
+	// which would duplicate or skip rows on this newest-first, actively-written log.
 	const scroll = useInfiniteQuery({
 		queryKey: ["audit", "scroll", debouncedActor, method],
 		queryFn: ({ pageParam }) =>
-			api.audit.list({ ...filters, limit: PAGE_SIZE, offset: pageParam }),
-		initialPageParam: 0,
-		getNextPageParam: (lastPage, pages) => {
-			const loaded = pages.reduce((n, p) => n + p.entries.length, 0);
-			return loaded < lastPage.total ? loaded : undefined;
-		},
+			api.audit.list({
+				...filters,
+				limit: PAGE_SIZE,
+				cursor: pageParam || undefined,
+			}),
+		initialPageParam: "",
+		getNextPageParam: (lastPage) =>
+			lastPage.has_more ? (lastPage.next_cursor ?? undefined) : undefined,
 		enabled: isScroll,
 	});
 


### PR DESCRIPTION
Bundles the Model Hotel Audit page work with a small Front Desk drive-by fix.

## Model Hotel — Audit page
- **Scroll/Pages toggle.** Retires the single "Load more" button for the same `ViewModeToggle` the Logs/App-logs pages use: **infinite scroll by default** (an `IntersectionObserver` foot-sentinel appends the next offset page as you reach the bottom), toggleable to a **paginated static table** with a page-size selector. Mode persists in `localStorage` (`auditViewMode`).
- **Backend offset paging.** Added `audit.ListParams.Offset` + `?offset=` on the list endpoint (alongside the existing keyset cursor) so the page-numbered view can jump to any page. New backend test covers it.

## Model Hotel — Audit detail modal
- **Two-line timestamp.** The date/time no longer truncates (`17/07/2026, 21:…`); it wraps to `17/07/2026` / `21:43:05`.
- **Entity ↔ Remote Address swap.** The `ip:port` now takes the full-width row so it's never clipped into a useless pill; the entity (a UUID or human name, still legible truncated) moves to the half-width slot.

## Front Desk — Traffic page (drive-by)
- Fixes a ~15px jump under the second graph on every refresh. The shared "Updated" stamp logic split into per-card stamps whenever the two cards' reported times momentarily differed mid-refresh (one commits a beat before the other). Now a single shared stamp (latest time) holds whenever every reachable card is fresh; only a genuinely failed card splits the page into per-card stamps.

## Verification
- Backend: `go test ./internal/audit ./internal/api` (audit) green incl. new offset test; `go vet` + `golangci-lint` clean.
- Frontend: Audit page vitest 5/5 (scroll-sentinel + paginate navigation), Front Desk TrafficPage 13/13 (incl. new mid-refresh flicker guard); `tsc -b` (web + FD), Biome, and the offline i18n parity gate all pass. No new i18n keys (reuses the shared `ViewModeToggle` strings).

Note: the frontend is embedded in the Go binary, so previewing in the running app needs a container rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)