### PR TITLE
fix(audit): scroll table body, not the whole page

### DIFF
--- a/web/src/pages/Audit/__tests__/Audit.test.tsx
+++ b/web/src/pages/Audit/__tests__/Audit.test.tsx
@@ -177,6 +177,79 @@ describe("Audit page", () => {
 		expect(screen.getByText("/first-page")).toBeInTheDocument();
 	});
 
+	it("does not fetch the next page when the sentinel is not intersecting", async () => {
+		let requests = 0;
+		server.use(
+			http.get("/api/audit", ({ request }) => {
+				requests += 1;
+				const cursor = new URL(request.url).searchParams.get("cursor");
+				return HttpResponse.json({
+					entries: [entry({ route: cursor ? "/second-page" : "/first-page" })],
+					total: 2,
+					has_more: !cursor,
+					next_cursor: cursor ? undefined : "cur-1",
+				});
+			}),
+		);
+		renderWithProviders(<Audit />);
+
+		expect(await screen.findByText("/first-page")).toBeInTheDocument();
+		const requestsAfterFirst = requests;
+		// The sentinel reports as leaving view (isIntersecting false): the observer
+		// must no-op, not pull another page.
+		act(() => {
+			MockIntersectionObserver.instances.at(-1)?.trigger(false);
+		});
+		await waitFor(() => {
+			expect(requests).toBe(requestsAfterFirst);
+		});
+		expect(screen.queryByText("/second-page")).not.toBeInTheDocument();
+	});
+
+	it("shows a loading spinner while the next scroll page is fetching", async () => {
+		// Hold the second page open so isFetchingNextPage stays true long enough to
+		// assert the in-flight spinner, then release it.
+		let releaseSecondPage: () => void = () => {};
+		const secondPageGate = new Promise<void>((resolve) => {
+			releaseSecondPage = resolve;
+		});
+		server.use(
+			http.get("/api/audit", async ({ request }) => {
+				const cursor = new URL(request.url).searchParams.get("cursor");
+				if (cursor === "cur-1") {
+					await secondPageGate;
+					return HttpResponse.json({
+						entries: [entry({ route: "/second-page" })],
+						total: 2,
+						has_more: false,
+					});
+				}
+				return HttpResponse.json({
+					entries: [entry({ route: "/first-page" })],
+					total: 2,
+					has_more: true,
+					next_cursor: "cur-1",
+				});
+			}),
+		);
+		renderWithProviders(<Audit />);
+
+		expect(await screen.findByText("/first-page")).toBeInTheDocument();
+		act(() => {
+			MockIntersectionObserver.instances.at(-1)?.trigger();
+		});
+		// Spinner is visible while the next page is in flight.
+		expect(
+			await screen.findByRole("status", { name: "Loading" }),
+		).toBeInTheDocument();
+
+		releaseSecondPage();
+		expect(await screen.findByText("/second-page")).toBeInTheDocument();
+		expect(
+			screen.queryByRole("status", { name: "Loading" }),
+		).not.toBeInTheDocument();
+	});
+
 	it("navigates by page in pagination mode", async () => {
 		server.use(
 			http.get("/api/audit", ({ request }) => {

--- a/web/src/pages/Audit/index.tsx
+++ b/web/src/pages/Audit/index.tsx
@@ -108,17 +108,25 @@ export function Audit() {
 	// Sentinel at the list foot: when it scrolls into view (scroll mode only),
 	// pull the next page. Re-armed whenever the fetch state changes so it keeps
 	// firing down a long list.
+	const scrollRef = useRef<HTMLDivElement>(null);
 	const sentinelRef = useRef<HTMLDivElement>(null);
 	const { hasNextPage, isFetchingNextPage, fetchNextPage } = scroll;
 	useEffect(() => {
 		if (!isScroll) return;
 		const el = sentinelRef.current;
 		if (!el) return;
-		const observer = new IntersectionObserver((observed) => {
-			if (observed[0]?.isIntersecting && hasNextPage && !isFetchingNextPage) {
-				fetchNextPage();
-			}
-		});
+		// Root is the table's own scroll box, not the viewport: the page is pinned
+		// to the viewport height and only the table body scrolls, so intersection
+		// must be measured against that inner scroller. rootMargin pulls the next
+		// page in a little before the foot is actually reached.
+		const observer = new IntersectionObserver(
+			(observed) => {
+				if (observed[0]?.isIntersecting && hasNextPage && !isFetchingNextPage) {
+					fetchNextPage();
+				}
+			},
+			{ root: scrollRef.current, rootMargin: "300px" },
+		);
 		observer.observe(el);
 		return () => observer.disconnect();
 	}, [isScroll, hasNextPage, isFetchingNextPage, fetchNextPage]);
@@ -140,7 +148,11 @@ export function Audit() {
 	}
 
 	return (
-		<div className="space-y-6 pb-8">
+		<div
+			className={`space-y-6 flex flex-col ${
+				isScroll ? "h-[calc(100dvh-1rem)] overflow-hidden" : "flex-1 min-h-0"
+			}`}
+		>
 			<PageHeader
 				icon={History}
 				title={t("audit.title")}
@@ -182,7 +194,10 @@ export function Audit() {
 
 			{entries.length > 0 ? (
 				<>
-					<div className="ui-card overflow-hidden">
+					<div
+						ref={scrollRef}
+						className="ui-card overflow-y-auto flex-1 min-h-0"
+					>
 						<table className="w-full table-fixed ui-table">
 							<colgroup>
 								<col className="w-[9%]" />
@@ -193,7 +208,7 @@ export function Audit() {
 								<col className="w-[13%]" />
 								<col className="w-[7%]" />
 							</colgroup>
-							<thead>
+							<thead className="sticky top-0 z-10">
 								<tr>
 									<StaticHeader>{t("audit.table.time")}</StaticHeader>
 									<StaticHeader>{t("audit.table.actor")}</StaticHeader>
@@ -260,30 +275,25 @@ export function Audit() {
 								))}
 							</tbody>
 						</table>
+						{/* Foot marker the observer watches (scroll mode). It lives inside
+						   the scroll box so it enters view as the table body scrolls, not
+						   the page. */}
+						{isScroll && (
+							<div ref={sentinelRef} aria-hidden="true" className="h-px" />
+						)}
 					</div>
 
-					{isScroll ? (
-						<>
-							<div className="flex items-center justify-between text-sm text-gray-500">
-								<span>
-									{t("audit.showing", { count: entries.length, total })}
-								</span>
-								{isFetchingNextPage && (
-									<span
-										role="status"
-										aria-label={t("common.loading")}
-										className="animate-spin rounded-full h-4 w-4 border-b-2 border-(--accent)"
-									/>
-								)}
-							</div>
-							{/* Foot marker the observer watches to load the next page. */}
-							<div ref={sentinelRef} aria-hidden="true" className="h-px" />
-						</>
-					) : (
-						<div className="flex items-center justify-between text-sm text-gray-500">
-							<span>
-								{t("audit.showing", { count: entries.length, total })}
-							</span>
+					<div className="flex items-center justify-between text-sm text-gray-500 shrink-0">
+						<span>{t("audit.showing", { count: entries.length, total })}</span>
+						{isScroll ? (
+							isFetchingNextPage && (
+								<span
+									role="status"
+									aria-label={t("common.loading")}
+									className="animate-spin rounded-full h-4 w-4 border-b-2 border-(--accent)"
+								/>
+							)
+						) : (
 							<PaginationBar
 								page={page}
 								totalPages={totalPages}
@@ -296,8 +306,8 @@ export function Audit() {
 								}}
 								hideCount
 							/>
-						</div>
-					)}
+						)}
+					</div>
 				</>
 			) : (
 				<EmptyState message={t("audit.emptyState")} />


### PR DESCRIPTION
## What

The Audit page (added in #503) grew the document instead of scrolling internally, so the whole page scrolled in infinite-scroll mode rather than just the table body — unlike the Logs/Requests pages.

## Fix

Match the Logs scroll layout exactly:

- **Page pinned to viewport height.** The outer wrapper is now `flex flex-col`, `h-[calc(100dvh-1rem)] overflow-hidden` in scroll mode and `flex-1 min-h-0` in paginate mode — so the page itself never scrolls at 1440p.
- **Table gets its own scroll box.** The `ui-card` is now `flex-1 min-h-0 overflow-y-auto` and the `<thead>` is `sticky top-0` (the `.ui-table thead tr` background is already opaque), so the header stays put while the rows scroll.
- **Sentinel moved inside the scroller.** The IntersectionObserver's `root` is now the table's scroll box (not the viewport), with a `300px` rootMargin to prefetch the next keyset page as the body — not the page — nears the bottom.

The footer (showing count + spinner in scroll mode, `PaginationBar` in paginate mode) sits below the scroll box as `shrink-0` and is always visible.

## Test

- `web` Audit page suite: 5/5 pass (sentinel-triggers-next-page and mode-toggle behavior unchanged).
- `pnpm lint`, `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)