### PR TITLE
feat(gemini): OpenAI<->Gemini generateContent translation layer (Vertex express phase 1)

### DIFF
--- a/internal/gemini/request.go
+++ b/internal/gemini/request.go
@@ -1,0 +1,397 @@
+// Package gemini translates between the OpenAI chat-completions wire shape and
+// Google's Gemini generateContent shape. It is MH's first *egress* dialect
+// adapter (the mirror image of internal/anthropic, which translates on
+// ingress): Vertex AI express-mode API keys only work on the native
+// publisher routes, so requests leaving MH for a vertex-express provider are
+// rewritten here and the responses translated back.
+package gemini
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// --- Incoming OpenAI chat-completions request shape ---
+//
+// Only the fields the translation needs are decoded; unknown fields are
+// dropped (Gemini would reject them anyway, and the proxy's param-rewrite
+// machinery never sees this path).
+
+type oaiRequest struct {
+	Model               string          `json:"model"`
+	Messages            []oaiMessage    `json:"messages"`
+	MaxTokens           int             `json:"max_tokens"`
+	MaxCompletionTokens int             `json:"max_completion_tokens"`
+	Stream              bool            `json:"stream"`
+	Temperature         *float64        `json:"temperature"`
+	TopP                *float64        `json:"top_p"`
+	Stop                json.RawMessage `json:"stop"` // string OR []string
+	Tools               []oaiTool       `json:"tools"`
+	ToolChoice          json.RawMessage `json:"tool_choice"`
+	ReasoningEffort     string          `json:"reasoning_effort"`
+	ResponseFormat      *oaiRespFormat  `json:"response_format"`
+}
+
+type oaiMessage struct {
+	Role       string          `json:"role"`
+	Content    json.RawMessage `json:"content"` // string OR []oaiContentPart OR null
+	ToolCalls  []oaiToolCall   `json:"tool_calls"`
+	ToolCallID string          `json:"tool_call_id"`
+}
+
+type oaiContentPart struct {
+	Type     string `json:"type"` // "text" | "image_url"
+	Text     string `json:"text"`
+	ImageURL *struct {
+		URL string `json:"url"`
+	} `json:"image_url"`
+}
+
+type oaiToolCall struct {
+	ID       string `json:"id"`
+	Function struct {
+		Name      string `json:"name"`
+		Arguments string `json:"arguments"`
+	} `json:"function"`
+}
+
+type oaiTool struct {
+	Function struct {
+		Name        string          `json:"name"`
+		Description string          `json:"description"`
+		Parameters  json.RawMessage `json:"parameters"`
+	} `json:"function"`
+}
+
+type oaiRespFormat struct {
+	Type string `json:"type"` // "text" | "json_object" | "json_schema"
+}
+
+// --- Outgoing Gemini generateContent request shape ---
+
+type genRequest struct {
+	Contents          []genContent   `json:"contents"`
+	SystemInstruction *genContent    `json:"systemInstruction,omitempty"`
+	Tools             []genTool      `json:"tools,omitempty"`
+	ToolConfig        *genToolConfig `json:"toolConfig,omitempty"`
+	GenerationConfig  *genConfig     `json:"generationConfig,omitempty"`
+}
+
+type genContent struct {
+	Role  string    `json:"role,omitempty"`
+	Parts []genPart `json:"parts"`
+}
+
+type genPart struct {
+	Text             string           `json:"text,omitempty"`
+	InlineData       *genBlob         `json:"inlineData,omitempty"`
+	FileData         *genFileData     `json:"fileData,omitempty"`
+	FunctionCall     *genFunctionCall `json:"functionCall,omitempty"`
+	FunctionResponse *genFunctionResp `json:"functionResponse,omitempty"`
+}
+
+type genBlob struct {
+	MimeType string `json:"mimeType"`
+	Data     string `json:"data"`
+}
+
+type genFileData struct {
+	MimeType string `json:"mimeType,omitempty"`
+	FileURI  string `json:"fileUri"`
+}
+
+type genFunctionCall struct {
+	Name string          `json:"name"`
+	Args json.RawMessage `json:"args"`
+}
+
+type genFunctionResp struct {
+	Name     string `json:"name"`
+	Response any    `json:"response"`
+}
+
+type genTool struct {
+	FunctionDeclarations []genFunctionDecl `json:"functionDeclarations"`
+}
+
+type genFunctionDecl struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	Parameters  json.RawMessage `json:"parameters,omitempty"`
+}
+
+type genToolConfig struct {
+	FunctionCallingConfig genFunctionCallingConfig `json:"functionCallingConfig"`
+}
+
+type genFunctionCallingConfig struct {
+	Mode                 string   `json:"mode"` // AUTO | ANY | NONE
+	AllowedFunctionNames []string `json:"allowedFunctionNames,omitempty"`
+}
+
+type genConfig struct {
+	MaxOutputTokens  int                `json:"maxOutputTokens,omitempty"`
+	Temperature      *float64           `json:"temperature,omitempty"`
+	TopP             *float64           `json:"topP,omitempty"`
+	StopSequences    []string           `json:"stopSequences,omitempty"`
+	ResponseMimeType string             `json:"responseMimeType,omitempty"`
+	ThinkingConfig   *genThinkingConfig `json:"thinkingConfig,omitempty"`
+}
+
+type genThinkingConfig struct {
+	ThinkingBudget int `json:"thinkingBudget"`
+}
+
+// reasoningBudgets maps OpenAI reasoning_effort to a Gemini thinking budget
+// (tokens). "none" pins the budget to 0, which disables thinking on models
+// that allow it; absent effort omits thinkingConfig so the model default wins.
+var reasoningBudgets = map[string]int{
+	"none":    0,
+	"minimal": 0,
+	"low":     1024,
+	"medium":  8192,
+	"high":    24576,
+}
+
+// TranslateRequest converts an OpenAI chat-completions request body into a
+// Gemini generateContent request body. It returns the Gemini JSON, the model
+// string (verbatim — the caller builds the :generateContent /
+// :streamGenerateContent URL from it), and the stream flag.
+func TranslateRequest(body []byte) (geminiBody []byte, model string, stream bool, err error) {
+	var req oaiRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, "", false, fmt.Errorf("gemini: invalid request body: %w", err)
+	}
+	if req.Model == "" {
+		return nil, "", false, fmt.Errorf("gemini: model is required")
+	}
+
+	out := genRequest{}
+
+	// Gemini has no tool_call IDs; functionResponse is keyed by function name.
+	// Track the id->name mapping from assistant tool_calls so role:"tool"
+	// messages can be resolved back to the function they answer.
+	callNames := map[string]string{}
+
+	var systemParts []genPart
+	for _, m := range req.Messages {
+		switch m.Role {
+		case "system", "developer":
+			if text := decodeTextContent(m.Content); text != "" {
+				systemParts = append(systemParts, genPart{Text: text})
+			}
+		case "tool":
+			name := callNames[m.ToolCallID]
+			if name == "" {
+				name = m.ToolCallID
+			}
+			out.Contents = append(out.Contents, genContent{
+				Role:  "user",
+				Parts: []genPart{{FunctionResponse: &genFunctionResp{Name: name, Response: toolResponseValue(m.Content)}}},
+			})
+		case "assistant":
+			parts, err := translateParts(m.Content)
+			if err != nil {
+				return nil, "", false, err
+			}
+			for _, tc := range m.ToolCalls {
+				callNames[tc.ID] = tc.Function.Name
+				args := json.RawMessage(tc.Function.Arguments)
+				if len(args) == 0 || !json.Valid(args) {
+					args = json.RawMessage("{}")
+				}
+				parts = append(parts, genPart{FunctionCall: &genFunctionCall{Name: tc.Function.Name, Args: args}})
+			}
+			if len(parts) > 0 {
+				out.Contents = append(out.Contents, genContent{Role: "model", Parts: parts})
+			}
+		default: // "user"
+			parts, err := translateParts(m.Content)
+			if err != nil {
+				return nil, "", false, err
+			}
+			if len(parts) > 0 {
+				out.Contents = append(out.Contents, genContent{Role: "user", Parts: parts})
+			}
+		}
+	}
+	if len(systemParts) > 0 {
+		out.SystemInstruction = &genContent{Parts: systemParts}
+	}
+
+	for _, t := range req.Tools {
+		out.Tools = append(out.Tools, genTool{FunctionDeclarations: []genFunctionDecl{{
+			Name:        t.Function.Name,
+			Description: t.Function.Description,
+			Parameters:  t.Function.Parameters,
+		}}})
+	}
+
+	if tc, ok := translateToolChoice(req.ToolChoice); ok {
+		out.ToolConfig = &genToolConfig{FunctionCallingConfig: tc}
+	}
+
+	out.GenerationConfig = buildGenerationConfig(&req)
+
+	geminiBody, err = json.Marshal(out)
+	if err != nil {
+		return nil, "", false, fmt.Errorf("gemini: marshal generateContent request: %w", err)
+	}
+	return geminiBody, req.Model, req.Stream, nil
+}
+
+// buildGenerationConfig maps sampling/output knobs; returns nil when nothing
+// is set so the field is omitted entirely.
+func buildGenerationConfig(req *oaiRequest) *genConfig {
+	gc := genConfig{
+		Temperature:   req.Temperature,
+		TopP:          req.TopP,
+		StopSequences: decodeStop(req.Stop),
+	}
+	// max_completion_tokens is the modern OpenAI field and wins over the
+	// deprecated max_tokens when both are present.
+	gc.MaxOutputTokens = req.MaxCompletionTokens
+	if gc.MaxOutputTokens == 0 {
+		gc.MaxOutputTokens = req.MaxTokens
+	}
+	if req.ResponseFormat != nil && (req.ResponseFormat.Type == "json_object" || req.ResponseFormat.Type == "json_schema") {
+		gc.ResponseMimeType = "application/json"
+	}
+	if budget, ok := reasoningBudgets[strings.ToLower(req.ReasoningEffort)]; ok && req.ReasoningEffort != "" {
+		gc.ThinkingConfig = &genThinkingConfig{ThinkingBudget: budget}
+	}
+
+	if gc.MaxOutputTokens == 0 && gc.Temperature == nil && gc.TopP == nil &&
+		len(gc.StopSequences) == 0 && gc.ResponseMimeType == "" && gc.ThinkingConfig == nil {
+		return nil
+	}
+	return &gc
+}
+
+// translateParts converts an OpenAI message content field (string, part array,
+// or null) into Gemini parts.
+func translateParts(raw json.RawMessage) ([]genPart, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil, nil
+	}
+	var s string
+	if json.Unmarshal(raw, &s) == nil {
+		if s == "" {
+			return nil, nil
+		}
+		return []genPart{{Text: s}}, nil
+	}
+
+	var oaiParts []oaiContentPart
+	if err := json.Unmarshal(raw, &oaiParts); err != nil {
+		return nil, fmt.Errorf("gemini: invalid message content: %w", err)
+	}
+	var parts []genPart
+	for _, p := range oaiParts {
+		switch p.Type {
+		case "text":
+			parts = append(parts, genPart{Text: p.Text})
+		case "image_url":
+			if p.ImageURL == nil || p.ImageURL.URL == "" {
+				continue
+			}
+			if part, ok := imagePart(p.ImageURL.URL); ok {
+				parts = append(parts, part)
+			}
+		}
+	}
+	return parts, nil
+}
+
+// imagePart maps an OpenAI image_url value to inlineData (data: URIs) or
+// fileData (plain URLs).
+func imagePart(u string) (genPart, bool) {
+	if rest, ok := strings.CutPrefix(u, "data:"); ok {
+		mime, data, found := strings.Cut(rest, ";base64,")
+		if !found || data == "" {
+			return genPart{}, false
+		}
+		return genPart{InlineData: &genBlob{MimeType: mime, Data: data}}, true
+	}
+	return genPart{FileData: &genFileData{FileURI: u}}, true
+}
+
+// decodeTextContent flattens a content field to plain text (for system turns).
+func decodeTextContent(raw json.RawMessage) string {
+	var s string
+	if json.Unmarshal(raw, &s) == nil {
+		return s
+	}
+	var oaiParts []oaiContentPart
+	if json.Unmarshal(raw, &oaiParts) == nil {
+		var sb strings.Builder
+		for _, p := range oaiParts {
+			if p.Type == "" || p.Type == "text" {
+				sb.WriteString(p.Text)
+			}
+		}
+		return sb.String()
+	}
+	return ""
+}
+
+// toolResponseValue builds the functionResponse.response object from a tool
+// message's content: a JSON object passes through, anything else is wrapped
+// as {"result": <text>} because Gemini requires an object here.
+func toolResponseValue(raw json.RawMessage) any {
+	text := decodeTextContent(raw)
+	var obj map[string]any
+	if json.Unmarshal([]byte(text), &obj) == nil && obj != nil {
+		return obj
+	}
+	return map[string]any{"result": text}
+}
+
+// decodeStop accepts OpenAI's string-or-array stop field.
+func decodeStop(raw json.RawMessage) []string {
+	if len(raw) == 0 {
+		return nil
+	}
+	var s string
+	if json.Unmarshal(raw, &s) == nil {
+		if s == "" {
+			return nil
+		}
+		return []string{s}
+	}
+	var list []string
+	if json.Unmarshal(raw, &list) == nil {
+		return list
+	}
+	return nil
+}
+
+// translateToolChoice maps the OpenAI tool_choice union onto Gemini's
+// functionCallingConfig.
+func translateToolChoice(raw json.RawMessage) (genFunctionCallingConfig, bool) {
+	if len(raw) == 0 {
+		return genFunctionCallingConfig{}, false
+	}
+	var s string
+	if json.Unmarshal(raw, &s) == nil {
+		switch s {
+		case "auto":
+			return genFunctionCallingConfig{Mode: "AUTO"}, true
+		case "none":
+			return genFunctionCallingConfig{Mode: "NONE"}, true
+		case "required":
+			return genFunctionCallingConfig{Mode: "ANY"}, true
+		}
+		return genFunctionCallingConfig{}, false
+	}
+	var tc struct {
+		Function struct {
+			Name string `json:"name"`
+		} `json:"function"`
+	}
+	if json.Unmarshal(raw, &tc) == nil && tc.Function.Name != "" {
+		return genFunctionCallingConfig{Mode: "ANY", AllowedFunctionNames: []string{tc.Function.Name}}, true
+	}
+	return genFunctionCallingConfig{}, false
+}

--- a/internal/gemini/request.go
+++ b/internal/gemini/request.go
@@ -65,7 +65,10 @@ type oaiTool struct {
 }
 
 type oaiRespFormat struct {
-	Type string `json:"type"` // "text" | "json_object" | "json_schema"
+	Type       string `json:"type"` // "text" | "json_object" | "json_schema"
+	JSONSchema *struct {
+		Schema json.RawMessage `json:"schema"`
+	} `json:"json_schema"`
 }
 
 // --- Outgoing Gemini generateContent request shape ---
@@ -131,12 +134,13 @@ type genFunctionCallingConfig struct {
 }
 
 type genConfig struct {
-	MaxOutputTokens  int                `json:"maxOutputTokens,omitempty"`
-	Temperature      *float64           `json:"temperature,omitempty"`
-	TopP             *float64           `json:"topP,omitempty"`
-	StopSequences    []string           `json:"stopSequences,omitempty"`
-	ResponseMimeType string             `json:"responseMimeType,omitempty"`
-	ThinkingConfig   *genThinkingConfig `json:"thinkingConfig,omitempty"`
+	MaxOutputTokens    int                `json:"maxOutputTokens,omitempty"`
+	Temperature        *float64           `json:"temperature,omitempty"`
+	TopP               *float64           `json:"topP,omitempty"`
+	StopSequences      []string           `json:"stopSequences,omitempty"`
+	ResponseMimeType   string             `json:"responseMimeType,omitempty"`
+	ResponseJSONSchema json.RawMessage    `json:"responseJsonSchema,omitempty"`
+	ThinkingConfig     *genThinkingConfig `json:"thinkingConfig,omitempty"`
 }
 
 type genThinkingConfig struct {
@@ -257,6 +261,12 @@ func buildGenerationConfig(req *oaiRequest) *genConfig {
 	}
 	if req.ResponseFormat != nil && (req.ResponseFormat.Type == "json_object" || req.ResponseFormat.Type == "json_schema") {
 		gc.ResponseMimeType = "application/json"
+		// Structured output: forward the JSON Schema verbatim. Vertex's
+		// responseJsonSchema takes standard JSON Schema (unlike the older
+		// responseSchema OpenAPI subset), so no sanitizing is needed.
+		if js := req.ResponseFormat.JSONSchema; js != nil && len(js.Schema) > 0 {
+			gc.ResponseJSONSchema = js.Schema
+		}
 	}
 	if budget, ok := reasoningBudgets[strings.ToLower(req.ReasoningEffort)]; ok && req.ReasoningEffort != "" {
 		gc.ThinkingConfig = &genThinkingConfig{ThinkingBudget: budget}

--- a/internal/gemini/request.go
+++ b/internal/gemini/request.go
@@ -223,6 +223,11 @@ func TranslateRequest(body []byte) (geminiBody []byte, model string, stream bool
 	if len(systemParts) > 0 {
 		out.SystemInstruction = &genContent{Parts: systemParts}
 	}
+	// Gemini rejects null and empty contents alike ("at least one contents
+	// field is required"); fail fast with a clearer error than the upstream 400.
+	if len(out.Contents) == 0 {
+		return nil, "", false, fmt.Errorf("gemini: at least one user or assistant message with content is required")
+	}
 
 	for _, t := range req.Tools {
 		out.Tools = append(out.Tools, genTool{FunctionDeclarations: []genFunctionDecl{{

--- a/internal/gemini/request.go
+++ b/internal/gemini/request.go
@@ -306,6 +306,11 @@ func translateParts(raw json.RawMessage) ([]genPart, error) {
 	for _, p := range oaiParts {
 		switch p.Type {
 		case "text":
+			// An empty text part would marshal as {} (Text is omitempty),
+			// which Gemini rejects — drop it.
+			if p.Text == "" {
+				continue
+			}
 			parts = append(parts, genPart{Text: p.Text})
 		case "image_url":
 			if p.ImageURL == nil || p.ImageURL.URL == "" {

--- a/internal/gemini/request_test.go
+++ b/internal/gemini/request_test.go
@@ -307,6 +307,39 @@ func TestTranslateRequest_JSONResponseFormat(t *testing.T) {
 	if gc["responseMimeType"] != "application/json" {
 		t.Errorf("responseMimeType = %v, want application/json", gc["responseMimeType"])
 	}
+	if _, ok := gc["responseJsonSchema"]; ok {
+		t.Error("responseJsonSchema present for schemaless json_object")
+	}
+}
+
+func TestTranslateRequest_JSONSchemaResponseFormat(t *testing.T) {
+	// Structured output must forward the schema, not downgrade to generic JSON
+	// mode. Vertex's responseJsonSchema accepts standard JSON Schema verbatim
+	// (live-verified 2026-07-18, incl. additionalProperties).
+	body := []byte(`{
+		"model": "gemini-2.5-flash",
+		"messages": [{"role": "user", "content": "hi"}],
+		"response_format": {"type": "json_schema", "json_schema": {
+			"name": "weather",
+			"strict": true,
+			"schema": {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"], "additionalProperties": false}
+		}}
+	}`)
+	out, _, _, err := TranslateRequest(body)
+	if err != nil {
+		t.Fatalf("TranslateRequest failed: %v", err)
+	}
+	gc := decodeGemini(t, out)["generationConfig"].(map[string]any)
+	if gc["responseMimeType"] != "application/json" {
+		t.Errorf("responseMimeType = %v, want application/json", gc["responseMimeType"])
+	}
+	schema := gc["responseJsonSchema"].(map[string]any)
+	if schema["type"] != "object" || schema["additionalProperties"] != false {
+		t.Errorf("responseJsonSchema = %v, want schema forwarded verbatim", schema)
+	}
+	if _, ok := schema["properties"].(map[string]any)["city"]; !ok {
+		t.Errorf("responseJsonSchema properties = %v", schema["properties"])
+	}
 }
 
 func TestTranslateRequest_SystemAsParts(t *testing.T) {

--- a/internal/gemini/request_test.go
+++ b/internal/gemini/request_test.go
@@ -417,3 +417,18 @@ func TestTranslateRequest_Errors(t *testing.T) {
 		t.Error("expected error for missing model")
 	}
 }
+
+func TestTranslateRequest_NoTranslatableMessages(t *testing.T) {
+	// Gemini requires at least one contents entry (live: 400 "at least one
+	// contents field is required" for both null and []). Fail fast locally
+	// instead of marshaling a request the upstream is guaranteed to reject.
+	for _, body := range []string{
+		`{"model": "m", "messages": []}`,
+		`{"model": "m", "messages": [{"role": "system", "content": "sys only"}]}`,
+		`{"model": "m", "messages": [{"role": "user", "content": ""}]}`,
+	} {
+		if _, _, _, err := TranslateRequest([]byte(body)); err == nil {
+			t.Errorf("expected error for %s", body)
+		}
+	}
+}

--- a/internal/gemini/request_test.go
+++ b/internal/gemini/request_test.go
@@ -418,6 +418,32 @@ func TestTranslateRequest_Errors(t *testing.T) {
 	}
 }
 
+func TestTranslateRequest_EmptyTextPartsSkipped(t *testing.T) {
+	// An empty text part would marshal as {} inside parts (Text has omitempty),
+	// which Gemini rejects. Empty parts are dropped; a message left with no
+	// parts is dropped entirely.
+	body := []byte(`{
+		"model": "m",
+		"messages": [
+			{"role": "user", "content": [{"type": "text", "text": ""}, {"type": "text", "text": "hi"}]},
+			{"role": "assistant", "content": [{"type": "text", "text": ""}]},
+			{"role": "user", "content": [{"type": "text", "text": "bye"}]}
+		]
+	}`)
+	out, _, _, err := TranslateRequest(body)
+	if err != nil {
+		t.Fatalf("TranslateRequest failed: %v", err)
+	}
+	contents := decodeGemini(t, out)["contents"].([]any)
+	if len(contents) != 2 {
+		t.Fatalf("contents = %v, want empty-only assistant turn dropped", contents)
+	}
+	parts := contents[0].(map[string]any)["parts"].([]any)
+	if len(parts) != 1 || parts[0].(map[string]any)["text"] != "hi" {
+		t.Errorf("parts = %v, want empty text part dropped", parts)
+	}
+}
+
 func TestTranslateRequest_NoTranslatableMessages(t *testing.T) {
 	// Gemini requires at least one contents entry (live: 400 "at least one
 	// contents field is required" for both null and []). Fail fast locally

--- a/internal/gemini/request_test.go
+++ b/internal/gemini/request_test.go
@@ -1,0 +1,386 @@
+package gemini
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// decodeGemini unmarshals a translated generateContent body for assertions.
+func decodeGemini(t *testing.T, body []byte) map[string]any {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal(body, &m); err != nil {
+		t.Fatalf("translated body is not valid JSON: %v\n%s", err, body)
+	}
+	return m
+}
+
+func TestTranslateRequest_SystemAndText(t *testing.T) {
+	body := []byte(`{
+		"model": "gemini-2.5-flash",
+		"messages": [
+			{"role": "system", "content": "Be terse."},
+			{"role": "user", "content": "Hello"},
+			{"role": "assistant", "content": "Hi"},
+			{"role": "user", "content": "Bye"}
+		],
+		"max_tokens": 128,
+		"temperature": 0.5,
+		"top_p": 0.9,
+		"stop": "END"
+	}`)
+
+	out, model, stream, err := TranslateRequest(body)
+	if err != nil {
+		t.Fatalf("TranslateRequest failed: %v", err)
+	}
+	if model != "gemini-2.5-flash" {
+		t.Errorf("model = %q, want gemini-2.5-flash", model)
+	}
+	if stream {
+		t.Error("stream = true, want false")
+	}
+
+	m := decodeGemini(t, out)
+	sys := m["systemInstruction"].(map[string]any)
+	parts := sys["parts"].([]any)
+	if parts[0].(map[string]any)["text"] != "Be terse." {
+		t.Errorf("systemInstruction = %v", sys)
+	}
+
+	contents := m["contents"].([]any)
+	if len(contents) != 3 {
+		t.Fatalf("contents len = %d, want 3", len(contents))
+	}
+	first := contents[0].(map[string]any)
+	if first["role"] != "user" {
+		t.Errorf("contents[0] role = %v, want user", first["role"])
+	}
+	second := contents[1].(map[string]any)
+	if second["role"] != "model" {
+		t.Errorf("contents[1] role = %v, want model (assistant must map)", second["role"])
+	}
+	if second["parts"].([]any)[0].(map[string]any)["text"] != "Hi" {
+		t.Errorf("contents[1] parts = %v", second["parts"])
+	}
+
+	gc := m["generationConfig"].(map[string]any)
+	if gc["maxOutputTokens"] != float64(128) {
+		t.Errorf("maxOutputTokens = %v, want 128", gc["maxOutputTokens"])
+	}
+	if gc["temperature"] != 0.5 {
+		t.Errorf("temperature = %v, want 0.5", gc["temperature"])
+	}
+	if gc["topP"] != 0.9 {
+		t.Errorf("topP = %v, want 0.9", gc["topP"])
+	}
+	stops := gc["stopSequences"].([]any)
+	if len(stops) != 1 || stops[0] != "END" {
+		t.Errorf("stopSequences = %v, want [END]", stops)
+	}
+
+	// The OpenAI model/messages keys must not leak into the Gemini body.
+	for _, k := range []string{"model", "messages", "max_tokens"} {
+		if _, ok := m[k]; ok {
+			t.Errorf("OpenAI key %q leaked into gemini body", k)
+		}
+	}
+}
+
+func TestTranslateRequest_StreamFlagAndMaxCompletionTokens(t *testing.T) {
+	body := []byte(`{
+		"model": "gemini-2.5-pro",
+		"messages": [{"role": "user", "content": "hi"}],
+		"stream": true,
+		"max_tokens": 10,
+		"max_completion_tokens": 42,
+		"stop": ["a", "b"]
+	}`)
+
+	out, model, stream, err := TranslateRequest(body)
+	if err != nil {
+		t.Fatalf("TranslateRequest failed: %v", err)
+	}
+	if model != "gemini-2.5-pro" || !stream {
+		t.Errorf("model/stream = %q/%v, want gemini-2.5-pro/true", model, stream)
+	}
+	gc := decodeGemini(t, out)["generationConfig"].(map[string]any)
+	// max_completion_tokens is the modern field and wins over max_tokens.
+	if gc["maxOutputTokens"] != float64(42) {
+		t.Errorf("maxOutputTokens = %v, want 42", gc["maxOutputTokens"])
+	}
+	stops := gc["stopSequences"].([]any)
+	if len(stops) != 2 || stops[0] != "a" || stops[1] != "b" {
+		t.Errorf("stopSequences = %v, want [a b]", stops)
+	}
+}
+
+func TestTranslateRequest_ImageParts(t *testing.T) {
+	body := []byte(`{
+		"model": "gemini-2.5-flash",
+		"messages": [{"role": "user", "content": [
+			{"type": "text", "text": "What is this?"},
+			{"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+			{"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}}
+		]}]
+	}`)
+
+	out, _, _, err := TranslateRequest(body)
+	if err != nil {
+		t.Fatalf("TranslateRequest failed: %v", err)
+	}
+	parts := decodeGemini(t, out)["contents"].([]any)[0].(map[string]any)["parts"].([]any)
+	if len(parts) != 3 {
+		t.Fatalf("parts len = %d, want 3", len(parts))
+	}
+	if parts[0].(map[string]any)["text"] != "What is this?" {
+		t.Errorf("parts[0] = %v", parts[0])
+	}
+	inline := parts[1].(map[string]any)["inlineData"].(map[string]any)
+	if inline["mimeType"] != "image/png" || inline["data"] != "AAAA" {
+		t.Errorf("inlineData = %v", inline)
+	}
+	file := parts[2].(map[string]any)["fileData"].(map[string]any)
+	if file["fileUri"] != "https://example.com/cat.png" {
+		t.Errorf("fileData = %v", file)
+	}
+}
+
+func TestTranslateRequest_ToolsAndToolChoice(t *testing.T) {
+	base := `{
+		"model": "gemini-2.5-flash",
+		"messages": [{"role": "user", "content": "hi"}],
+		"tools": [{"type": "function", "function": {
+			"name": "get_weather",
+			"description": "Get weather",
+			"parameters": {"type": "object", "properties": {"city": {"type": "string"}}}
+		}}],
+		"tool_choice": %s
+	}`
+
+	tests := []struct {
+		choice  string
+		mode    string
+		allowed string
+	}{
+		{`"auto"`, "AUTO", ""},
+		{`"none"`, "NONE", ""},
+		{`"required"`, "ANY", ""},
+		{`{"type": "function", "function": {"name": "get_weather"}}`, "ANY", "get_weather"},
+	}
+	for _, tc := range tests {
+		out, _, _, err := TranslateRequest([]byte(strings.Replace(base, "%s", tc.choice, 1)))
+		if err != nil {
+			t.Fatalf("TranslateRequest(%s) failed: %v", tc.choice, err)
+		}
+		m := decodeGemini(t, out)
+
+		tools := m["tools"].([]any)
+		decls := tools[0].(map[string]any)["functionDeclarations"].([]any)
+		fd := decls[0].(map[string]any)
+		if fd["name"] != "get_weather" || fd["description"] != "Get weather" {
+			t.Errorf("functionDeclaration = %v", fd)
+		}
+		if _, ok := fd["parameters"].(map[string]any)["properties"]; !ok {
+			t.Errorf("parameters not carried: %v", fd["parameters"])
+		}
+
+		fcc := m["toolConfig"].(map[string]any)["functionCallingConfig"].(map[string]any)
+		if fcc["mode"] != tc.mode {
+			t.Errorf("tool_choice %s: mode = %v, want %s", tc.choice, fcc["mode"], tc.mode)
+		}
+		if tc.allowed == "" {
+			if _, ok := fcc["allowedFunctionNames"]; ok {
+				t.Errorf("tool_choice %s: unexpected allowedFunctionNames", tc.choice)
+			}
+		} else {
+			names := fcc["allowedFunctionNames"].([]any)
+			if len(names) != 1 || names[0] != tc.allowed {
+				t.Errorf("tool_choice %s: allowedFunctionNames = %v", tc.choice, names)
+			}
+		}
+	}
+}
+
+func TestTranslateRequest_ToolCallsAndToolResults(t *testing.T) {
+	body := []byte(`{
+		"model": "gemini-2.5-flash",
+		"messages": [
+			{"role": "user", "content": "weather in Oslo?"},
+			{"role": "assistant", "content": null, "tool_calls": [
+				{"id": "call_1", "type": "function", "function": {"name": "get_weather", "arguments": "{\"city\":\"Oslo\"}"}}
+			]},
+			{"role": "tool", "tool_call_id": "call_1", "content": "{\"temp\": -3}"},
+			{"role": "tool", "tool_call_id": "call_unknown", "content": "plain text result"}
+		]
+	}`)
+
+	out, _, _, err := TranslateRequest(body)
+	if err != nil {
+		t.Fatalf("TranslateRequest failed: %v", err)
+	}
+	contents := decodeGemini(t, out)["contents"].([]any)
+	if len(contents) != 4 {
+		t.Fatalf("contents len = %d, want 4", len(contents))
+	}
+
+	// Assistant tool-call turn -> model functionCall part with args as an object.
+	fc := contents[1].(map[string]any)["parts"].([]any)[0].(map[string]any)["functionCall"].(map[string]any)
+	if fc["name"] != "get_weather" {
+		t.Errorf("functionCall name = %v", fc["name"])
+	}
+	if fc["args"].(map[string]any)["city"] != "Oslo" {
+		t.Errorf("functionCall args = %v", fc["args"])
+	}
+
+	// Tool result -> user functionResponse; name resolved via the tool_call_id.
+	toolMsg := contents[2].(map[string]any)
+	if toolMsg["role"] != "user" {
+		t.Errorf("tool message role = %v, want user", toolMsg["role"])
+	}
+	fr := toolMsg["parts"].([]any)[0].(map[string]any)["functionResponse"].(map[string]any)
+	if fr["name"] != "get_weather" {
+		t.Errorf("functionResponse name = %v, want get_weather", fr["name"])
+	}
+	// JSON-object tool output passes through as the response object.
+	if fr["response"].(map[string]any)["temp"] != float64(-3) {
+		t.Errorf("functionResponse response = %v", fr["response"])
+	}
+
+	// Unknown tool_call_id: name falls back to the id; plain text is wrapped.
+	fr2 := contents[3].(map[string]any)["parts"].([]any)[0].(map[string]any)["functionResponse"].(map[string]any)
+	if fr2["name"] != "call_unknown" {
+		t.Errorf("functionResponse name = %v, want call_unknown", fr2["name"])
+	}
+	if fr2["response"].(map[string]any)["result"] != "plain text result" {
+		t.Errorf("functionResponse response = %v", fr2["response"])
+	}
+}
+
+func TestTranslateRequest_ReasoningEffort(t *testing.T) {
+	tests := []struct {
+		effort string
+		budget float64
+	}{
+		{"none", 0},
+		{"low", 1024},
+		{"medium", 8192},
+		{"high", 24576},
+	}
+	for _, tc := range tests {
+		body := []byte(`{"model": "gemini-2.5-flash", "messages": [{"role": "user", "content": "hi"}], "reasoning_effort": "` + tc.effort + `"}`)
+		out, _, _, err := TranslateRequest(body)
+		if err != nil {
+			t.Fatalf("TranslateRequest(%s) failed: %v", tc.effort, err)
+		}
+		gc := decodeGemini(t, out)["generationConfig"].(map[string]any)
+		think := gc["thinkingConfig"].(map[string]any)
+		if think["thinkingBudget"] != tc.budget {
+			t.Errorf("effort %s: thinkingBudget = %v, want %v", tc.effort, think["thinkingBudget"], tc.budget)
+		}
+	}
+
+	// No reasoning_effort -> no thinkingConfig (model default).
+	out, _, _, err := TranslateRequest([]byte(`{"model": "m", "messages": [{"role": "user", "content": "hi"}]}`))
+	if err != nil {
+		t.Fatalf("TranslateRequest failed: %v", err)
+	}
+	if gc, ok := decodeGemini(t, out)["generationConfig"].(map[string]any); ok {
+		if _, ok := gc["thinkingConfig"]; ok {
+			t.Error("thinkingConfig present without reasoning_effort")
+		}
+	}
+}
+
+func TestTranslateRequest_JSONResponseFormat(t *testing.T) {
+	body := []byte(`{
+		"model": "gemini-2.5-flash",
+		"messages": [{"role": "user", "content": "hi"}],
+		"response_format": {"type": "json_object"}
+	}`)
+	out, _, _, err := TranslateRequest(body)
+	if err != nil {
+		t.Fatalf("TranslateRequest failed: %v", err)
+	}
+	gc := decodeGemini(t, out)["generationConfig"].(map[string]any)
+	if gc["responseMimeType"] != "application/json" {
+		t.Errorf("responseMimeType = %v, want application/json", gc["responseMimeType"])
+	}
+}
+
+func TestTranslateRequest_SystemAsParts(t *testing.T) {
+	body := []byte(`{
+		"model": "gemini-2.5-flash",
+		"messages": [
+			{"role": "system", "content": [{"type": "text", "text": "Be "}, {"type": "text", "text": "terse."}]},
+			{"role": "user", "content": "hi"}
+		]
+	}`)
+	out, _, _, err := TranslateRequest(body)
+	if err != nil {
+		t.Fatalf("TranslateRequest failed: %v", err)
+	}
+	sys := decodeGemini(t, out)["systemInstruction"].(map[string]any)
+	if sys["parts"].([]any)[0].(map[string]any)["text"] != "Be terse." {
+		t.Errorf("systemInstruction = %v, want flattened part text", sys)
+	}
+}
+
+func TestTranslateRequest_EdgeCases(t *testing.T) {
+	body := []byte(`{
+		"model": "gemini-2.5-flash",
+		"messages": [
+			{"role": "user", "content": [
+				{"type": "text", "text": "look"},
+				{"type": "image_url", "image_url": {"url": "data:image/png,not-base64"}}
+			]},
+			{"role": "assistant", "content": "", "tool_calls": [
+				{"id": "c1", "type": "function", "function": {"name": "f", "arguments": "not json"}}
+			]}
+		],
+		"stop": "",
+		"tool_choice": "weird"
+	}`)
+	out, _, _, err := TranslateRequest(body)
+	if err != nil {
+		t.Fatalf("TranslateRequest failed: %v", err)
+	}
+	m := decodeGemini(t, out)
+
+	// Malformed data: URI (no ;base64, segment) is dropped, text kept.
+	parts := m["contents"].([]any)[0].(map[string]any)["parts"].([]any)
+	if len(parts) != 1 {
+		t.Errorf("parts = %v, want malformed image dropped", parts)
+	}
+	// Invalid tool_call arguments fall back to {}.
+	fc := m["contents"].([]any)[1].(map[string]any)["parts"].([]any)[0].(map[string]any)["functionCall"].(map[string]any)
+	if len(fc["args"].(map[string]any)) != 0 {
+		t.Errorf("args = %v, want {}", fc["args"])
+	}
+	// Empty stop string and unknown tool_choice are both omitted.
+	if gc, ok := m["generationConfig"]; ok {
+		if _, ok := gc.(map[string]any)["stopSequences"]; ok {
+			t.Error("stopSequences present for empty stop")
+		}
+	}
+	if _, ok := m["toolConfig"]; ok {
+		t.Error("toolConfig present for unknown tool_choice")
+	}
+}
+
+func TestTranslateRequest_InvalidMessageContent(t *testing.T) {
+	body := []byte(`{"model": "m", "messages": [{"role": "user", "content": {"bogus": true}}]}`)
+	if _, _, _, err := TranslateRequest(body); err == nil {
+		t.Error("expected error for object-shaped message content")
+	}
+}
+
+func TestTranslateRequest_Errors(t *testing.T) {
+	if _, _, _, err := TranslateRequest([]byte(`{not json`)); err == nil {
+		t.Error("expected error for invalid JSON")
+	}
+	if _, _, _, err := TranslateRequest([]byte(`{"messages": [{"role": "user", "content": "hi"}]}`)); err == nil {
+		t.Error("expected error for missing model")
+	}
+}

--- a/internal/gemini/response.go
+++ b/internal/gemini/response.go
@@ -1,0 +1,207 @@
+package gemini
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// --- Incoming Gemini generateContent response shape ---
+
+type genResponse struct {
+	Candidates     []genCandidate `json:"candidates"`
+	UsageMetadata  *genUsage      `json:"usageMetadata"`
+	PromptFeedback *struct {
+		BlockReason string `json:"blockReason"`
+	} `json:"promptFeedback"`
+}
+
+type genCandidate struct {
+	Content      genRespContent `json:"content"`
+	FinishReason string         `json:"finishReason"`
+}
+
+type genRespContent struct {
+	Parts []genRespPart `json:"parts"`
+}
+
+type genRespPart struct {
+	Text         string           `json:"text"`
+	Thought      bool             `json:"thought"`
+	FunctionCall *genRespFuncCall `json:"functionCall"`
+}
+
+type genRespFuncCall struct {
+	Name string          `json:"name"`
+	Args json.RawMessage `json:"args"`
+}
+
+type genUsage struct {
+	PromptTokenCount     int `json:"promptTokenCount"`
+	CandidatesTokenCount int `json:"candidatesTokenCount"`
+	TotalTokenCount      int `json:"totalTokenCount"`
+	ThoughtsTokenCount   int `json:"thoughtsTokenCount"`
+}
+
+// --- Outgoing OpenAI chat-completion response shape ---
+
+type oaiCompletion struct {
+	ID      string         `json:"id"`
+	Object  string         `json:"object"`
+	Created int64          `json:"created"`
+	Model   string         `json:"model"`
+	Choices []oaiChoiceOut `json:"choices"`
+	Usage   *oaiUsage      `json:"usage,omitempty"`
+}
+
+type oaiChoiceOut struct {
+	Index        int           `json:"index"`
+	Message      oaiMessageOut `json:"message"`
+	FinishReason string        `json:"finish_reason"`
+}
+
+type oaiMessageOut struct {
+	Role      string           `json:"role"`
+	Content   *string          `json:"content"`
+	ToolCalls []oaiToolCallOut `json:"tool_calls,omitempty"`
+}
+
+type oaiToolCallOut struct {
+	ID       string `json:"id"`
+	Type     string `json:"type"`
+	Function struct {
+		Name      string `json:"name"`
+		Arguments string `json:"arguments"`
+	} `json:"function"`
+}
+
+type oaiUsage struct {
+	PromptTokens            int `json:"prompt_tokens"`
+	CompletionTokens        int `json:"completion_tokens"`
+	TotalTokens             int `json:"total_tokens"`
+	CompletionTokensDetails *struct {
+		ReasoningTokens int `json:"reasoning_tokens"`
+	} `json:"completion_tokens_details,omitempty"`
+}
+
+// BuildChatCompletion converts a non-streaming Gemini generateContent response
+// body into an OpenAI chat-completion body. id, model and created are supplied
+// by the caller (the model string the client requested is echoed back).
+func BuildChatCompletion(body []byte, id, model string, created int64) ([]byte, error) {
+	var resp genResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("gemini: invalid upstream response: %w", err)
+	}
+	if len(resp.Candidates) == 0 {
+		reason := "no candidates in response"
+		if resp.PromptFeedback != nil && resp.PromptFeedback.BlockReason != "" {
+			reason = "prompt blocked: " + resp.PromptFeedback.BlockReason
+		}
+		return nil, fmt.Errorf("gemini: %s", reason)
+	}
+
+	cand := resp.Candidates[0]
+	text, toolCalls := translateCandidateParts(id, cand.Content.Parts)
+
+	msg := oaiMessageOut{Role: "assistant", Content: &text, ToolCalls: toolCalls}
+
+	out := oaiCompletion{
+		ID:      id,
+		Object:  "chat.completion",
+		Created: created,
+		Model:   model,
+		Choices: []oaiChoiceOut{{
+			Index:        0,
+			Message:      msg,
+			FinishReason: mapFinishReason(cand.FinishReason, len(toolCalls) > 0),
+		}},
+		Usage: translateUsage(resp.UsageMetadata),
+	}
+
+	encoded, err := json.Marshal(out)
+	if err != nil {
+		return nil, fmt.Errorf("gemini: marshal chat completion: %w", err)
+	}
+	return encoded, nil
+}
+
+// translateCandidateParts joins visible text parts (thought parts are model
+// internals and must not surface as content) and converts functionCall parts
+// into OpenAI tool_calls. Gemini has no call IDs, so IDs are synthesized from
+// the response id + index; TranslateRequest resolves them back by mapping,
+// falling back to the function name.
+func translateCandidateParts(id string, parts []genRespPart) (string, []oaiToolCallOut) {
+	var sb strings.Builder
+	var toolCalls []oaiToolCallOut
+	for _, p := range parts {
+		if p.FunctionCall != nil {
+			args := compactJSON(p.FunctionCall.Args)
+			if args == "" {
+				args = "{}"
+			}
+			tc := oaiToolCallOut{
+				ID:   fmt.Sprintf("call_%s_%d", id, len(toolCalls)),
+				Type: "function",
+			}
+			tc.Function.Name = p.FunctionCall.Name
+			tc.Function.Arguments = args
+			toolCalls = append(toolCalls, tc)
+			continue
+		}
+		if p.Thought {
+			continue
+		}
+		sb.WriteString(p.Text)
+	}
+	return sb.String(), toolCalls
+}
+
+// compactJSON strips the pretty-print whitespace Vertex puts inside nested
+// raw values (functionCall args). Invalid/empty input returns "".
+func compactJSON(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var buf bytes.Buffer
+	if err := json.Compact(&buf, raw); err != nil {
+		return ""
+	}
+	return buf.String()
+}
+
+// mapFinishReason maps Gemini finishReason values onto OpenAI finish_reason.
+func mapFinishReason(reason string, hasToolCalls bool) string {
+	if hasToolCalls {
+		return "tool_calls"
+	}
+	switch reason {
+	case "MAX_TOKENS":
+		return "length"
+	case "SAFETY", "RECITATION", "BLOCKLIST", "PROHIBITED_CONTENT", "SPII", "IMAGE_SAFETY":
+		return "content_filter"
+	default: // STOP, FINISH_REASON_UNSPECIFIED, MALFORMED_FUNCTION_CALL, ...
+		return "stop"
+	}
+}
+
+// translateUsage maps usageMetadata to OpenAI usage. Thinking tokens are
+// billed output on Gemini, so completion_tokens includes them (this is what
+// MH's metering should count) with the split surfaced in
+// completion_tokens_details.reasoning_tokens, matching OpenAI's convention.
+func translateUsage(u *genUsage) *oaiUsage {
+	if u == nil {
+		return nil
+	}
+	out := &oaiUsage{
+		PromptTokens:     u.PromptTokenCount,
+		CompletionTokens: u.CandidatesTokenCount + u.ThoughtsTokenCount,
+		TotalTokens:      u.TotalTokenCount,
+	}
+	if u.ThoughtsTokenCount > 0 {
+		out.CompletionTokensDetails = &struct {
+			ReasoningTokens int `json:"reasoning_tokens"`
+		}{ReasoningTokens: u.ThoughtsTokenCount}
+	}
+	return out
+}

--- a/internal/gemini/response_test.go
+++ b/internal/gemini/response_test.go
@@ -1,0 +1,154 @@
+package gemini
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func decodeOAI(t *testing.T, body []byte) map[string]any {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal(body, &m); err != nil {
+		t.Fatalf("translated response is not valid JSON: %v\n%s", err, body)
+	}
+	return m
+}
+
+func TestBuildChatCompletion_TextAndUsage(t *testing.T) {
+	// Shape captured live from Vertex express 2026-07-18 (thoughtsTokenCount is
+	// real: totalTokenCount > prompt+candidates when the model thinks).
+	body := []byte(`{
+		"candidates": [{
+			"content": {"role": "model", "parts": [{"text": "Hotel"}]},
+			"finishReason": "STOP"
+		}],
+		"usageMetadata": {
+			"promptTokenCount": 8,
+			"candidatesTokenCount": 1,
+			"totalTokenCount": 31,
+			"thoughtsTokenCount": 22
+		},
+		"modelVersion": "gemini-2.5-flash"
+	}`)
+
+	out, err := BuildChatCompletion(body, "chatcmpl-abc", "gemini-2.5-flash", 1752861431)
+	if err != nil {
+		t.Fatalf("BuildChatCompletion failed: %v", err)
+	}
+	m := decodeOAI(t, out)
+
+	if m["id"] != "chatcmpl-abc" || m["object"] != "chat.completion" || m["model"] != "gemini-2.5-flash" {
+		t.Errorf("envelope = id:%v object:%v model:%v", m["id"], m["object"], m["model"])
+	}
+	if m["created"] != float64(1752861431) {
+		t.Errorf("created = %v", m["created"])
+	}
+
+	choice := m["choices"].([]any)[0].(map[string]any)
+	if choice["index"] != float64(0) || choice["finish_reason"] != "stop" {
+		t.Errorf("choice = %v", choice)
+	}
+	msg := choice["message"].(map[string]any)
+	if msg["role"] != "assistant" || msg["content"] != "Hotel" {
+		t.Errorf("message = %v", msg)
+	}
+
+	usage := m["usage"].(map[string]any)
+	if usage["prompt_tokens"] != float64(8) {
+		t.Errorf("prompt_tokens = %v", usage["prompt_tokens"])
+	}
+	// Thinking tokens are billed output: completion = candidates + thoughts.
+	if usage["completion_tokens"] != float64(23) {
+		t.Errorf("completion_tokens = %v, want 23", usage["completion_tokens"])
+	}
+	if usage["total_tokens"] != float64(31) {
+		t.Errorf("total_tokens = %v", usage["total_tokens"])
+	}
+	details := usage["completion_tokens_details"].(map[string]any)
+	if details["reasoning_tokens"] != float64(22) {
+		t.Errorf("reasoning_tokens = %v", details["reasoning_tokens"])
+	}
+}
+
+func TestBuildChatCompletion_MultiPartTextSkipsThoughts(t *testing.T) {
+	body := []byte(`{
+		"candidates": [{
+			"content": {"role": "model", "parts": [
+				{"text": "secret plan", "thought": true},
+				{"text": "Hello "},
+				{"text": "world"}
+			]},
+			"finishReason": "MAX_TOKENS"
+		}]
+	}`)
+
+	out, err := BuildChatCompletion(body, "id", "m", 0)
+	if err != nil {
+		t.Fatalf("BuildChatCompletion failed: %v", err)
+	}
+	choice := decodeOAI(t, out)["choices"].([]any)[0].(map[string]any)
+	if choice["message"].(map[string]any)["content"] != "Hello world" {
+		t.Errorf("content = %v, want thought part skipped and text joined", choice["message"])
+	}
+	if choice["finish_reason"] != "length" {
+		t.Errorf("finish_reason = %v, want length", choice["finish_reason"])
+	}
+}
+
+func TestBuildChatCompletion_FunctionCalls(t *testing.T) {
+	// Args spread over lines the way Vertex pretty-prints them live; the
+	// translated arguments string must come out compacted.
+	body := []byte(`{
+		"candidates": [{
+			"content": {"role": "model", "parts": [
+				{"functionCall": {"name": "get_weather", "args": {
+					"city": "Oslo"
+				}}}
+			]},
+			"finishReason": "STOP"
+		}]
+	}`)
+
+	out, err := BuildChatCompletion(body, "id", "m", 0)
+	if err != nil {
+		t.Fatalf("BuildChatCompletion failed: %v", err)
+	}
+	choice := decodeOAI(t, out)["choices"].([]any)[0].(map[string]any)
+	// A functionCall response reports tool_calls, not stop.
+	if choice["finish_reason"] != "tool_calls" {
+		t.Errorf("finish_reason = %v, want tool_calls", choice["finish_reason"])
+	}
+	msg := choice["message"].(map[string]any)
+	tc := msg["tool_calls"].([]any)[0].(map[string]any)
+	if tc["type"] != "function" || tc["id"] == "" {
+		t.Errorf("tool_call = %v", tc)
+	}
+	fn := tc["function"].(map[string]any)
+	if fn["name"] != "get_weather" {
+		t.Errorf("function name = %v", fn["name"])
+	}
+	if fn["arguments"] != `{"city":"Oslo"}` {
+		t.Errorf("arguments = %q, want compacted {\"city\":\"Oslo\"}", fn["arguments"])
+	}
+}
+
+func TestBuildChatCompletion_SafetyAndErrors(t *testing.T) {
+	out, err := BuildChatCompletion([]byte(`{
+		"candidates": [{"content": {"role": "model", "parts": []}, "finishReason": "SAFETY"}]
+	}`), "id", "m", 0)
+	if err != nil {
+		t.Fatalf("BuildChatCompletion failed: %v", err)
+	}
+	choice := decodeOAI(t, out)["choices"].([]any)[0].(map[string]any)
+	if choice["finish_reason"] != "content_filter" {
+		t.Errorf("finish_reason = %v, want content_filter", choice["finish_reason"])
+	}
+
+	if _, err := BuildChatCompletion([]byte(`{not json`), "id", "m", 0); err == nil {
+		t.Error("expected error for invalid JSON")
+	}
+	// Prompt blocked: no candidates at all.
+	if _, err := BuildChatCompletion([]byte(`{"promptFeedback": {"blockReason": "SAFETY"}}`), "id", "m", 0); err == nil {
+		t.Error("expected error for zero candidates")
+	}
+}


### PR DESCRIPTION
Phase 1 of Vertex AI express-key support — MH's first **egress** dialect adapter (the mirror image of `internal/anthropic`, which translates on ingress). Vertex express API keys only work on Google's native publisher routes, so requests leaving MH for a future `vertex-express` provider must be rewritten into `generateContent` shape and the responses translated back. This PR is the pure translation layer: no proxy wiring, no provider type, no UI.

## What's in

**`TranslateRequest`** (OpenAI chat-completions body → Gemini `generateContent` body):
- `system`/`developer` messages → `systemInstruction`; `assistant` → role `model`
- content-part arrays → text parts, `data:` URIs → `inlineData`, plain URLs → `fileData`
- `tools` → `functionDeclarations`; `tool_choice` → `functionCallingConfig` (auto/none/required/named → AUTO/NONE/ANY/ANY+allowedFunctionNames)
- assistant `tool_calls` → `functionCall` parts (arguments parsed to objects); `role:"tool"` messages → `functionResponse` — Gemini has no tool-call ids, so the id→name mapping is reconstructed from prior assistant turns (falls back to id-as-name); JSON-object tool output passes through, plain text is wrapped as `{"result": …}`
- `generationConfig`: `max_completion_tokens` (wins over deprecated `max_tokens`), temperature, top_p, stop (string-or-array), `response_format` json → `responseMimeType`, `reasoning_effort` → `thinkingConfig.thinkingBudget` (none/minimal 0, low 1024, medium 8192, high 24576; absent → model default)

**`BuildChatCompletion`** (Gemini response → OpenAI chat completion):
- `thought: true` parts are model internals and never surface as content
- `functionCall` parts → `tool_calls` with synthesized ids (`call_{id}_{n}`) and compacted arguments (Vertex pretty-prints them)
- `finishReason` mapping (MAX_TOKENS → length, SAFETY family → content_filter, tool calls present → tool_calls)
- usage: thinking tokens are billed output on Gemini, so `completion_tokens = candidates + thoughts` (what metering should count), with the split in `completion_tokens_details.reasoning_tokens`; zero-candidate/prompt-blocked responses error

## Verification

- TDD: 15 unit tests written red-first; package coverage 94.1%, all functions ≥90% except one defensive `json.Compact` error branch unreachable via the public API
- Full backend suite: 5612 tests green; `golangci-lint` clean
- **Live round-trip** against Vertex express (2026-07-18, temp test since deleted): two-leg tool conversation — model emitted `functionCall`, tool result fed back through the `functionResponse` path, model answered from it; `thinkingBudget: 0` accepted

## Day-one probe notes (drives the next slices)

Express keys work on `:generateContent`, `:streamGenerateContent?alt=sse`, and `:countTokens`, but **no listing route** accepts them (publishers listing is OAuth-only; Google's OpenAI-compat surface returns `API_KEY_SERVICE_BLOCKED`). Discovery in phase 3 will therefore be a curated catalog validated per-model via cheap `:countTokens` probes. Currently express-eligible: gemini-2.5-pro / 2.5-flash / 2.5-flash-lite / 2.5-flash-image / 3-flash-preview.

Next slices: streaming translation, then proxy egress hook + `vertex-express` provider type + discovery + UI, then fidelity pass + wiki.

🤖 Generated with [Claude Code](https://claude.com/claude-code)