### PR TITLE
feat(gemini): streaming translation (Gemini SSE -> OpenAI chunks, Vertex express phase 2)

### DIFF
--- a/internal/gemini/stream.go
+++ b/internal/gemini/stream.go
@@ -20,6 +20,7 @@ type StreamTranslator struct {
 
 	started      bool   // role delta emitted
 	finished     bool   // Finish() already emitted
+	blocked      bool   // promptFeedback.blockReason seen
 	finishReason string // last Gemini finishReason observed
 	toolCalls    int    // tool_calls emitted so far (drives index + ids)
 	usage        *genUsage
@@ -103,6 +104,11 @@ func (t *StreamTranslator) Translate(chunkJSON []byte) ([]byte, error) {
 	if chunk.UsageMetadata != nil {
 		t.usage = chunk.UsageMetadata
 	}
+	// A blocked prompt streams as a candidate-less chunk with promptFeedback;
+	// remember it so Finish() reports content_filter instead of a clean stop.
+	if chunk.PromptFeedback != nil && chunk.PromptFeedback.BlockReason != "" {
+		t.blocked = true
+	}
 	if len(chunk.Candidates) == 0 {
 		return nil, nil
 	}
@@ -157,6 +163,9 @@ func (t *StreamTranslator) Finish() ([]byte, error) {
 
 	var buf bytes.Buffer
 	reason := mapFinishReason(t.finishReason, t.toolCalls > 0)
+	if t.blocked {
+		reason = "content_filter"
+	}
 	if err := t.writeChunk(&buf, oaiChunkDelta{}, &reason, translateUsage(t.usage)); err != nil {
 		return nil, err
 	}

--- a/internal/gemini/stream.go
+++ b/internal/gemini/stream.go
@@ -1,0 +1,165 @@
+package gemini
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// StreamTranslator converts a Gemini streamGenerateContent SSE stream
+// (alt=sse: each data line is a full generateContent-shaped JSON chunk) into
+// an OpenAI chat.completion.chunk SSE stream ending in "data: [DONE]".
+//
+// It is the streaming counterpart of BuildChatCompletion and single-goroutine
+// by design: the proxy's egress loop feeds it one upstream data payload at a
+// time and forwards whatever bytes come back.
+type StreamTranslator struct {
+	id      string
+	model   string
+	created int64
+
+	started      bool   // role delta emitted
+	finished     bool   // Finish() already emitted
+	finishReason string // last Gemini finishReason observed
+	toolCalls    int    // tool_calls emitted so far (drives index + ids)
+	usage        *genUsage
+}
+
+// NewStreamTranslator builds a translator for one response. id, model and
+// created are echoed in every chunk envelope (the model string the client
+// requested, not Gemini's modelVersion).
+func NewStreamTranslator(id, model string, created int64) *StreamTranslator {
+	return &StreamTranslator{id: id, model: model, created: created}
+}
+
+// oaiChunkOut is one outgoing chat.completion.chunk payload.
+type oaiChunkOut struct {
+	ID      string           `json:"id"`
+	Object  string           `json:"object"`
+	Created int64            `json:"created"`
+	Model   string           `json:"model"`
+	Choices []oaiChunkChoice `json:"choices"`
+	Usage   *oaiUsage        `json:"usage,omitempty"`
+}
+
+type oaiChunkChoice struct {
+	Index        int           `json:"index"`
+	Delta        oaiChunkDelta `json:"delta"`
+	FinishReason *string       `json:"finish_reason"`
+}
+
+type oaiChunkDelta struct {
+	Role      string                `json:"role,omitempty"`
+	Content   string                `json:"content,omitempty"`
+	ToolCalls []oaiChunkToolCallOut `json:"tool_calls,omitempty"`
+}
+
+// oaiChunkToolCallOut is a streamed tool call. Gemini delivers each
+// functionCall complete in a single part, so the whole call goes out as one
+// delta fragment (index + id + name + full arguments).
+type oaiChunkToolCallOut struct {
+	Index    int    `json:"index"`
+	ID       string `json:"id"`
+	Type     string `json:"type"`
+	Function struct {
+		Name      string `json:"name"`
+		Arguments string `json:"arguments"`
+	} `json:"function"`
+}
+
+// writeChunk appends one framed SSE chunk ("data: <json>\n\n").
+func (t *StreamTranslator) writeChunk(buf *bytes.Buffer, delta oaiChunkDelta, finishReason *string, usage *oaiUsage) error {
+	if !t.started {
+		delta.Role = "assistant"
+		t.started = true
+	}
+	payload, err := json.Marshal(oaiChunkOut{
+		ID:      t.id,
+		Object:  "chat.completion.chunk",
+		Created: t.created,
+		Model:   t.model,
+		Choices: []oaiChunkChoice{{Index: 0, Delta: delta, FinishReason: finishReason}},
+		Usage:   usage,
+	})
+	if err != nil {
+		return fmt.Errorf("gemini: marshal stream chunk: %w", err)
+	}
+	buf.WriteString("data: ")
+	buf.Write(payload)
+	buf.WriteString("\n\n")
+	return nil
+}
+
+// Translate processes one upstream Gemini data payload and returns the SSE
+// bytes to forward to the client (possibly empty: thought-only and usage-only
+// chunks update state silently). finishReason and usage are recorded for the
+// terminal Finish() chunk, matching how Gemini delivers both on the last line.
+func (t *StreamTranslator) Translate(chunkJSON []byte) ([]byte, error) {
+	var chunk genResponse
+	if err := json.Unmarshal(chunkJSON, &chunk); err != nil {
+		return nil, fmt.Errorf("gemini: invalid stream chunk: %w", err)
+	}
+
+	if chunk.UsageMetadata != nil {
+		t.usage = chunk.UsageMetadata
+	}
+	if len(chunk.Candidates) == 0 {
+		return nil, nil
+	}
+	cand := chunk.Candidates[0]
+	if cand.FinishReason != "" {
+		t.finishReason = cand.FinishReason
+	}
+
+	var buf bytes.Buffer
+	delta := oaiChunkDelta{}
+	for _, p := range cand.Content.Parts {
+		if p.FunctionCall != nil {
+			args := compactJSON(p.FunctionCall.Args)
+			if args == "" {
+				args = "{}"
+			}
+			tc := oaiChunkToolCallOut{
+				Index: t.toolCalls,
+				ID:    fmt.Sprintf("call_%s_%d", t.id, t.toolCalls),
+				Type:  "function",
+			}
+			tc.Function.Name = p.FunctionCall.Name
+			tc.Function.Arguments = args
+			delta.ToolCalls = append(delta.ToolCalls, tc)
+			t.toolCalls++
+			continue
+		}
+		if p.Thought {
+			continue
+		}
+		delta.Content += p.Text
+	}
+
+	if delta.Content == "" && len(delta.ToolCalls) == 0 {
+		return nil, nil
+	}
+	if err := t.writeChunk(&buf, delta, nil, nil); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// Finish emits the terminal chunk (empty delta, mapped finish_reason, usage
+// when the upstream reported it) followed by "data: [DONE]". It is idempotent
+// and emits a well-formed terminal chunk even when no content chunk ever
+// arrived (the role rides on the terminal delta then).
+func (t *StreamTranslator) Finish() ([]byte, error) {
+	if t.finished {
+		return nil, nil
+	}
+	t.finished = true
+
+	var buf bytes.Buffer
+	reason := mapFinishReason(t.finishReason, t.toolCalls > 0)
+	if err := t.writeChunk(&buf, oaiChunkDelta{}, &reason, translateUsage(t.usage)); err != nil {
+		return nil, err
+	}
+	buf.WriteString("data: [DONE]\n\n")
+	return buf.Bytes(), nil
+}

--- a/internal/gemini/stream_test.go
+++ b/internal/gemini/stream_test.go
@@ -209,6 +209,28 @@ func TestStreamTranslator_ThoughtAndEmptyChunks(t *testing.T) {
 	}
 }
 
+func TestStreamTranslator_BlockedPrompt(t *testing.T) {
+	// A blocked prompt streams as a single candidate-less chunk carrying only
+	// promptFeedback. That must surface as content_filter, not an empty
+	// successful "stop" (the non-streaming path errors for the same shape).
+	tr := NewStreamTranslator("id", "m", 0)
+	out, err := tr.Translate([]byte(`{"promptFeedback":{"blockReason":"PROHIBITED_CONTENT"}}`))
+	if err != nil {
+		t.Fatalf("Translate: %v", err)
+	}
+	if len(out) != 0 {
+		t.Errorf("blocked chunk output = %q, want none", out)
+	}
+	fin, err := tr.Finish()
+	if err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+	choice := decodeChunk(t, parseFrames(t, fin)[0])["choices"].([]any)[0].(map[string]any)
+	if choice["finish_reason"] != "content_filter" {
+		t.Errorf("finish_reason = %v, want content_filter", choice["finish_reason"])
+	}
+}
+
 func TestStreamTranslator_InvalidChunk(t *testing.T) {
 	tr := NewStreamTranslator("id", "m", 0)
 	if _, err := tr.Translate([]byte(`{not json`)); err == nil {

--- a/internal/gemini/stream_test.go
+++ b/internal/gemini/stream_test.go
@@ -1,0 +1,217 @@
+package gemini
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// parseFrames splits translated SSE bytes into decoded chunk payloads,
+// returning the raw data strings (so [DONE] can be asserted) alongside.
+func parseFrames(t *testing.T, sse []byte) []string {
+	t.Helper()
+	var payloads []string
+	for frame := range strings.SplitSeq(string(sse), "\n\n") {
+		if frame == "" {
+			continue
+		}
+		data, ok := strings.CutPrefix(frame, "data: ")
+		if !ok {
+			t.Fatalf("frame missing data: prefix: %q", frame)
+		}
+		payloads = append(payloads, data)
+	}
+	return payloads
+}
+
+func decodeChunk(t *testing.T, payload string) map[string]any {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal([]byte(payload), &m); err != nil {
+		t.Fatalf("chunk is not valid JSON: %v\n%s", err, payload)
+	}
+	return m
+}
+
+func chunkDelta(t *testing.T, payload string) map[string]any {
+	t.Helper()
+	m := decodeChunk(t, payload)
+	return m["choices"].([]any)[0].(map[string]any)["delta"].(map[string]any)
+}
+
+func TestStreamTranslator_TextDeltas(t *testing.T) {
+	tr := NewStreamTranslator("chatcmpl-s", "gemini-2.5-flash", 1752861431)
+
+	out1, err := tr.Translate([]byte(`{"candidates":[{"content":{"role":"model","parts":[{"text":"Hel"}]}}]}`))
+	if err != nil {
+		t.Fatalf("Translate: %v", err)
+	}
+	frames := parseFrames(t, out1)
+	if len(frames) != 1 {
+		t.Fatalf("frames = %d, want 1", len(frames))
+	}
+	m := decodeChunk(t, frames[0])
+	if m["id"] != "chatcmpl-s" || m["object"] != "chat.completion.chunk" || m["model"] != "gemini-2.5-flash" || m["created"] != float64(1752861431) {
+		t.Errorf("envelope = %v", m)
+	}
+	choice := m["choices"].([]any)[0].(map[string]any)
+	if choice["index"] != float64(0) || choice["finish_reason"] != nil {
+		t.Errorf("choice = %v", choice)
+	}
+	// First content chunk carries the assistant role.
+	delta := choice["delta"].(map[string]any)
+	if delta["role"] != "assistant" || delta["content"] != "Hel" {
+		t.Errorf("delta = %v", delta)
+	}
+
+	out2, err := tr.Translate([]byte(`{"candidates":[{"content":{"role":"model","parts":[{"text":"lo"}]}}]}`))
+	if err != nil {
+		t.Fatalf("Translate: %v", err)
+	}
+	delta2 := chunkDelta(t, parseFrames(t, out2)[0])
+	if _, ok := delta2["role"]; ok {
+		t.Error("role repeated on second chunk")
+	}
+	if delta2["content"] != "lo" {
+		t.Errorf("delta2 = %v", delta2)
+	}
+}
+
+func TestStreamTranslator_FinishWithUsage(t *testing.T) {
+	tr := NewStreamTranslator("id", "m", 0)
+
+	// Final Gemini chunk shape captured live 2026-07-18: finishReason and
+	// usageMetadata (incl. thoughtsTokenCount) arrive on the last data line.
+	out, err := tr.Translate([]byte(`{
+		"candidates":[{"content":{"role":"model","parts":[{"text":"Hi"}]},"finishReason":"STOP"}],
+		"usageMetadata":{"promptTokenCount":13,"candidatesTokenCount":9,"totalTokenCount":48,"thoughtsTokenCount":26}
+	}`))
+	if err != nil {
+		t.Fatalf("Translate: %v", err)
+	}
+	if got := chunkDelta(t, parseFrames(t, out)[0])["content"]; got != "Hi" {
+		t.Errorf("content = %v", got)
+	}
+
+	fin, err := tr.Finish()
+	if err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+	frames := parseFrames(t, fin)
+	if len(frames) != 2 {
+		t.Fatalf("finish frames = %d, want terminal chunk + [DONE]", len(frames))
+	}
+	if frames[1] != "[DONE]" {
+		t.Errorf("last frame = %q, want [DONE]", frames[1])
+	}
+	m := decodeChunk(t, frames[0])
+	choice := m["choices"].([]any)[0].(map[string]any)
+	if choice["finish_reason"] != "stop" {
+		t.Errorf("finish_reason = %v", choice["finish_reason"])
+	}
+	if len(choice["delta"].(map[string]any)) != 0 {
+		t.Errorf("terminal delta = %v, want empty", choice["delta"])
+	}
+	usage := m["usage"].(map[string]any)
+	if usage["prompt_tokens"] != float64(13) || usage["completion_tokens"] != float64(35) || usage["total_tokens"] != float64(48) {
+		t.Errorf("usage = %v", usage)
+	}
+	if usage["completion_tokens_details"].(map[string]any)["reasoning_tokens"] != float64(26) {
+		t.Errorf("usage details = %v", usage)
+	}
+
+	// Finish is idempotent.
+	again, err := tr.Finish()
+	if err != nil || len(again) != 0 {
+		t.Errorf("second Finish = %q, %v", again, err)
+	}
+}
+
+func TestStreamTranslator_FunctionCalls(t *testing.T) {
+	tr := NewStreamTranslator("sid", "m", 0)
+
+	out, err := tr.Translate([]byte(`{"candidates":[{"content":{"role":"model","parts":[
+		{"functionCall":{"name":"get_weather","args":{
+			"city": "Oslo"
+		}}},
+		{"functionCall":{"name":"get_time","args":{}}}
+	]},"finishReason":"STOP"}]}`))
+	if err != nil {
+		t.Fatalf("Translate: %v", err)
+	}
+	delta := chunkDelta(t, parseFrames(t, out)[0])
+	calls := delta["tool_calls"].([]any)
+	if len(calls) != 2 {
+		t.Fatalf("tool_calls = %v", calls)
+	}
+	first := calls[0].(map[string]any)
+	if first["index"] != float64(0) || first["type"] != "function" || first["id"] == "" {
+		t.Errorf("tool_calls[0] = %v", first)
+	}
+	fn := first["function"].(map[string]any)
+	if fn["name"] != "get_weather" || fn["arguments"] != `{"city":"Oslo"}` {
+		t.Errorf("function = %v, want compacted args", fn)
+	}
+	second := calls[1].(map[string]any)
+	if second["index"] != float64(1) || second["id"] == first["id"] {
+		t.Errorf("tool_calls[1] = %v", second)
+	}
+
+	// Tool calls flip the terminal finish_reason.
+	fin, err := tr.Finish()
+	if err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+	choice := decodeChunk(t, parseFrames(t, fin)[0])["choices"].([]any)[0].(map[string]any)
+	if choice["finish_reason"] != "tool_calls" {
+		t.Errorf("finish_reason = %v, want tool_calls", choice["finish_reason"])
+	}
+}
+
+func TestStreamTranslator_ThoughtAndEmptyChunks(t *testing.T) {
+	tr := NewStreamTranslator("id", "m", 0)
+
+	// Thought parts and empty text produce no client-visible frames.
+	out, err := tr.Translate([]byte(`{"candidates":[{"content":{"role":"model","parts":[{"text":"internal","thought":true},{"text":""}]}}]}`))
+	if err != nil {
+		t.Fatalf("Translate: %v", err)
+	}
+	if len(out) != 0 {
+		t.Errorf("thought chunk output = %q, want none", out)
+	}
+
+	// Usage-only chunk (no candidates): silent, but usage recorded for Finish.
+	out, err = tr.Translate([]byte(`{"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":2,"totalTokenCount":7}}`))
+	if err != nil {
+		t.Fatalf("Translate: %v", err)
+	}
+	if len(out) != 0 {
+		t.Errorf("usage chunk output = %q, want none", out)
+	}
+
+	fin, err := tr.Finish()
+	if err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+	frames := parseFrames(t, fin)
+	m := decodeChunk(t, frames[0])
+	// Never-started stream still emits a well-formed terminal chunk with the
+	// assistant role and recorded usage.
+	choice := m["choices"].([]any)[0].(map[string]any)
+	if choice["delta"].(map[string]any)["role"] != "assistant" {
+		t.Errorf("terminal delta = %v, want role for never-started stream", choice["delta"])
+	}
+	if choice["finish_reason"] != "stop" {
+		t.Errorf("finish_reason = %v, want stop default", choice["finish_reason"])
+	}
+	if m["usage"].(map[string]any)["prompt_tokens"] != float64(5) {
+		t.Errorf("usage = %v", m["usage"])
+	}
+}
+
+func TestStreamTranslator_InvalidChunk(t *testing.T) {
+	tr := NewStreamTranslator("id", "m", 0)
+	if _, err := tr.Translate([]byte(`{not json`)); err == nil {
+		t.Error("expected error for invalid chunk JSON")
+	}
+}


### PR DESCRIPTION
Phase 2 of Vertex AI express-key support, on top of #507. Still pure translation — no proxy wiring, no provider type.

## What's in

`StreamTranslator` (internal/gemini/stream.go), the streaming counterpart of `BuildChatCompletion`, mirroring the `internal/anthropic` StreamTranslator design: a stateful, single-goroutine, per-response translator the proxy's egress loop will feed one upstream SSE data payload at a time.

- **`Translate(chunkJSON)`** converts one Gemini `streamGenerateContent?alt=sse` data line (each is a full generateContent-shaped JSON) into framed OpenAI `chat.completion.chunk` SSE bytes:
  - assistant `role` rides only the first content-bearing chunk
  - `thought: true` parts and usage-only chunks produce no client-visible frames but update recorded state
  - complete `functionCall` parts (Gemini never fragments them) become single `tool_calls` deltas with per-response indexes, synthesized ids (`call_{id}_{n}`), and compacted arguments
  - `finishReason` and `usageMetadata` are recorded for the terminal chunk, matching how Gemini delivers both on the last data line
- **`Finish()`** emits the terminal chunk — empty delta, mapped `finish_reason` (tool calls seen → `tool_calls`), usage with thinking tokens counted as billed output plus the `completion_tokens_details.reasoning_tokens` split — followed by `data: [DONE]`. Idempotent, and a stream that never produced content still ends well-formed (the role rides the terminal delta).

## Verification

- TDD: 5 new tests red-first; package now 23 tests, 93.8% coverage (stream.go functions 89–100%); `golangci-lint` clean; full backend suite 5620 green
- **Live** against Vertex express (2026-07-18, temp harness since deleted): a 400-word-story request streamed as 10 upstream chunks → translated stream had exactly one role delta, clean content deltas, and a correct terminal chunk (`completion_tokens: 1611`, of which 1019 hidden thinking tokens were filtered from content but counted in usage)

Next slice: proxy egress hook + `vertex-express` provider type + curated-catalog discovery via `:countTokens` + UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)