### PR TITLE
feat(gemini): tools/params fidelity pass + vertex wiki docs (Vertex express phase 4)

### DIFF
--- a/internal/gemini/request.go
+++ b/internal/gemini/request.go
@@ -26,6 +26,9 @@ type oaiRequest struct {
 	Stream              bool            `json:"stream"`
 	Temperature         *float64        `json:"temperature"`
 	TopP                *float64        `json:"top_p"`
+	FrequencyPenalty    *float64        `json:"frequency_penalty"`
+	PresencePenalty     *float64        `json:"presence_penalty"`
+	Seed                *int64          `json:"seed"`
 	Stop                json.RawMessage `json:"stop"` // string OR []string
 	Tools               []oaiTool       `json:"tools"`
 	ToolChoice          json.RawMessage `json:"tool_choice"`
@@ -118,10 +121,14 @@ type genTool struct {
 	FunctionDeclarations []genFunctionDecl `json:"functionDeclarations"`
 }
 
+// genFunctionDecl carries tool parameters as parametersJsonSchema, which
+// accepts standard JSON Schema verbatim (live-verified 2026-07-18, incl.
+// additionalProperties) — unlike the older `parameters` OpenAPI subset, so
+// strict-mode client schemas survive untouched.
 type genFunctionDecl struct {
-	Name        string          `json:"name"`
-	Description string          `json:"description,omitempty"`
-	Parameters  json.RawMessage `json:"parameters,omitempty"`
+	Name                 string          `json:"name"`
+	Description          string          `json:"description,omitempty"`
+	ParametersJSONSchema json.RawMessage `json:"parametersJsonSchema,omitempty"`
 }
 
 type genToolConfig struct {
@@ -137,6 +144,9 @@ type genConfig struct {
 	MaxOutputTokens    int                `json:"maxOutputTokens,omitempty"`
 	Temperature        *float64           `json:"temperature,omitempty"`
 	TopP               *float64           `json:"topP,omitempty"`
+	FrequencyPenalty   *float64           `json:"frequencyPenalty,omitempty"`
+	PresencePenalty    *float64           `json:"presencePenalty,omitempty"`
+	Seed               *int64             `json:"seed,omitempty"`
 	StopSequences      []string           `json:"stopSequences,omitempty"`
 	ResponseMimeType   string             `json:"responseMimeType,omitempty"`
 	ResponseJSONSchema json.RawMessage    `json:"responseJsonSchema,omitempty"`
@@ -179,6 +189,9 @@ func TranslateRequest(body []byte) (geminiBody []byte, model string, stream bool
 	callNames := map[string]string{}
 
 	var systemParts []genPart
+	// True while the previously emitted content is a coalescing tool-response
+	// content; any other message kind breaks the run.
+	lastToolContent := false
 	for _, m := range req.Messages {
 		switch m.Role {
 		case "system", "developer":
@@ -190,10 +203,18 @@ func TranslateRequest(body []byte) (geminiBody []byte, model string, stream bool
 			if name == "" {
 				name = m.ToolCallID
 			}
-			out.Contents = append(out.Contents, genContent{
-				Role:  "user",
-				Parts: []genPart{{FunctionResponse: &genFunctionResp{Name: name, Response: toolResponseValue(m.Content)}}},
-			})
+			part := genPart{FunctionResponse: &genFunctionResp{Name: name, Response: toolResponseValue(m.Content)}}
+			// Consecutive tool results must share ONE user content: Gemini
+			// requires the function response part count to equal the function
+			// call part count of the preceding model turn and 400s when
+			// parallel results arrive as separate contents.
+			if lastToolContent {
+				out.Contents[len(out.Contents)-1].Parts = append(out.Contents[len(out.Contents)-1].Parts, part)
+			} else {
+				out.Contents = append(out.Contents, genContent{Role: "user", Parts: []genPart{part}})
+			}
+			lastToolContent = true
+			continue
 		case "assistant":
 			parts, err := translateParts(m.Content)
 			if err != nil {
@@ -219,6 +240,7 @@ func TranslateRequest(body []byte) (geminiBody []byte, model string, stream bool
 				out.Contents = append(out.Contents, genContent{Role: "user", Parts: parts})
 			}
 		}
+		lastToolContent = false
 	}
 	if len(systemParts) > 0 {
 		out.SystemInstruction = &genContent{Parts: systemParts}
@@ -229,12 +251,19 @@ func TranslateRequest(body []byte) (geminiBody []byte, model string, stream bool
 		return nil, "", false, fmt.Errorf("gemini: at least one user or assistant message with content is required")
 	}
 
-	for _, t := range req.Tools {
-		out.Tools = append(out.Tools, genTool{FunctionDeclarations: []genFunctionDecl{{
-			Name:        t.Function.Name,
-			Description: t.Function.Description,
-			Parameters:  t.Function.Parameters,
-		}}})
+	// All function declarations share ONE tools entry: Gemini reads multiple
+	// tools array entries as multiple tool *types* (search, code execution,
+	// functions) and rejects the mix.
+	if len(req.Tools) > 0 {
+		decls := make([]genFunctionDecl, 0, len(req.Tools))
+		for _, t := range req.Tools {
+			decls = append(decls, genFunctionDecl{
+				Name:                 t.Function.Name,
+				Description:          t.Function.Description,
+				ParametersJSONSchema: t.Function.Parameters,
+			})
+		}
+		out.Tools = []genTool{{FunctionDeclarations: decls}}
 	}
 
 	if tc, ok := translateToolChoice(req.ToolChoice); ok {
@@ -254,9 +283,12 @@ func TranslateRequest(body []byte) (geminiBody []byte, model string, stream bool
 // is set so the field is omitted entirely.
 func buildGenerationConfig(req *oaiRequest) *genConfig {
 	gc := genConfig{
-		Temperature:   req.Temperature,
-		TopP:          req.TopP,
-		StopSequences: decodeStop(req.Stop),
+		Temperature:      req.Temperature,
+		TopP:             req.TopP,
+		FrequencyPenalty: req.FrequencyPenalty,
+		PresencePenalty:  req.PresencePenalty,
+		Seed:             req.Seed,
+		StopSequences:    decodeStop(req.Stop),
 	}
 	// max_completion_tokens is the modern OpenAI field and wins over the
 	// deprecated max_tokens when both are present.
@@ -278,6 +310,7 @@ func buildGenerationConfig(req *oaiRequest) *genConfig {
 	}
 
 	if gc.MaxOutputTokens == 0 && gc.Temperature == nil && gc.TopP == nil &&
+		gc.FrequencyPenalty == nil && gc.PresencePenalty == nil && gc.Seed == nil &&
 		len(gc.StopSequences) == 0 && gc.ResponseMimeType == "" && gc.ThinkingConfig == nil {
 		return nil
 	}

--- a/internal/gemini/request_test.go
+++ b/internal/gemini/request_test.go
@@ -182,8 +182,13 @@ func TestTranslateRequest_ToolsAndToolChoice(t *testing.T) {
 		if fd["name"] != "get_weather" || fd["description"] != "Get weather" {
 			t.Errorf("functionDeclaration = %v", fd)
 		}
-		if _, ok := fd["parameters"].(map[string]any)["properties"]; !ok {
-			t.Errorf("parameters not carried: %v", fd["parameters"])
+		// Tool params ride parametersJsonSchema (full JSON Schema, verbatim —
+		// live-verified 2026-07-18), not the OpenAPI-subset parameters field.
+		if _, ok := fd["parametersJsonSchema"].(map[string]any)["properties"]; !ok {
+			t.Errorf("parametersJsonSchema not carried: %v", fd["parametersJsonSchema"])
+		}
+		if _, ok := fd["parameters"]; ok {
+			t.Errorf("legacy parameters field present: %v", fd["parameters"])
 		}
 
 		fcc := m["toolConfig"].(map[string]any)["functionCallingConfig"].(map[string]any)
@@ -200,6 +205,36 @@ func TestTranslateRequest_ToolsAndToolChoice(t *testing.T) {
 				t.Errorf("tool_choice %s: allowedFunctionNames = %v", tc.choice, names)
 			}
 		}
+	}
+}
+
+func TestTranslateRequest_MultipleToolsShareOneEntry(t *testing.T) {
+	// All function declarations must ride ONE tools entry: Gemini treats
+	// multiple tools array entries as multiple tool *types* and 400s with
+	// "Multiple tools are supported only when they are all search tools"
+	// (live, 2026-07-18).
+	body := []byte(`{
+		"model": "m",
+		"messages": [{"role": "user", "content": "hi"}],
+		"tools": [
+			{"type": "function", "function": {"name": "f1", "parameters": {"type": "object"}}},
+			{"type": "function", "function": {"name": "f2", "parameters": {"type": "object"}}}
+		]
+	}`)
+	out, _, _, err := TranslateRequest(body)
+	if err != nil {
+		t.Fatalf("TranslateRequest failed: %v", err)
+	}
+	tools := decodeGemini(t, out)["tools"].([]any)
+	if len(tools) != 1 {
+		t.Fatalf("tools entries = %d, want 1", len(tools))
+	}
+	decls := tools[0].(map[string]any)["functionDeclarations"].([]any)
+	if len(decls) != 2 {
+		t.Fatalf("functionDeclarations = %d, want 2", len(decls))
+	}
+	if decls[0].(map[string]any)["name"] != "f1" || decls[1].(map[string]any)["name"] != "f2" {
+		t.Errorf("declarations = %v", decls)
 	}
 }
 
@@ -221,8 +256,11 @@ func TestTranslateRequest_ToolCallsAndToolResults(t *testing.T) {
 		t.Fatalf("TranslateRequest failed: %v", err)
 	}
 	contents := decodeGemini(t, out)["contents"].([]any)
-	if len(contents) != 4 {
-		t.Fatalf("contents len = %d, want 4", len(contents))
+	// Consecutive tool results coalesce into ONE user content: Gemini 400s
+	// ("number of function response parts must equal function call parts")
+	// when parallel results arrive as separate contents (live, 2026-07-18).
+	if len(contents) != 3 {
+		t.Fatalf("contents len = %d, want 3 (tool results coalesced)", len(contents))
 	}
 
 	// Assistant tool-call turn -> model functionCall part with args as an object.
@@ -234,12 +272,17 @@ func TestTranslateRequest_ToolCallsAndToolResults(t *testing.T) {
 		t.Errorf("functionCall args = %v", fc["args"])
 	}
 
-	// Tool result -> user functionResponse; name resolved via the tool_call_id.
+	// Both tool results ride one user content, one functionResponse part each,
+	// names resolved via tool_call_id (falling back to the id when unknown).
 	toolMsg := contents[2].(map[string]any)
 	if toolMsg["role"] != "user" {
 		t.Errorf("tool message role = %v, want user", toolMsg["role"])
 	}
-	fr := toolMsg["parts"].([]any)[0].(map[string]any)["functionResponse"].(map[string]any)
+	parts := toolMsg["parts"].([]any)
+	if len(parts) != 2 {
+		t.Fatalf("tool content parts = %d, want 2", len(parts))
+	}
+	fr := parts[0].(map[string]any)["functionResponse"].(map[string]any)
 	if fr["name"] != "get_weather" {
 		t.Errorf("functionResponse name = %v, want get_weather", fr["name"])
 	}
@@ -247,14 +290,77 @@ func TestTranslateRequest_ToolCallsAndToolResults(t *testing.T) {
 	if fr["response"].(map[string]any)["temp"] != float64(-3) {
 		t.Errorf("functionResponse response = %v", fr["response"])
 	}
-
-	// Unknown tool_call_id: name falls back to the id; plain text is wrapped.
-	fr2 := contents[3].(map[string]any)["parts"].([]any)[0].(map[string]any)["functionResponse"].(map[string]any)
+	fr2 := parts[1].(map[string]any)["functionResponse"].(map[string]any)
 	if fr2["name"] != "call_unknown" {
 		t.Errorf("functionResponse name = %v, want call_unknown", fr2["name"])
 	}
 	if fr2["response"].(map[string]any)["result"] != "plain text result" {
 		t.Errorf("functionResponse response = %v", fr2["response"])
+	}
+}
+
+func TestTranslateRequest_ToolResultsSplitByOtherTurns(t *testing.T) {
+	// Only CONSECUTIVE tool messages coalesce; a tool result after an
+	// intervening turn starts a fresh content.
+	body := []byte(`{
+		"model": "m",
+		"messages": [
+			{"role": "user", "content": "hi"},
+			{"role": "assistant", "content": null, "tool_calls": [{"id": "a", "type": "function", "function": {"name": "f1", "arguments": "{}"}}]},
+			{"role": "tool", "tool_call_id": "a", "content": "r1"},
+			{"role": "assistant", "content": null, "tool_calls": [{"id": "b", "type": "function", "function": {"name": "f2", "arguments": "{}"}}]},
+			{"role": "tool", "tool_call_id": "b", "content": "r2"}
+		]
+	}`)
+	out, _, _, err := TranslateRequest(body)
+	if err != nil {
+		t.Fatalf("TranslateRequest failed: %v", err)
+	}
+	contents := decodeGemini(t, out)["contents"].([]any)
+	if len(contents) != 5 {
+		t.Fatalf("contents len = %d, want 5 (separate rounds stay separate)", len(contents))
+	}
+	for _, idx := range []int{2, 4} {
+		parts := contents[idx].(map[string]any)["parts"].([]any)
+		if len(parts) != 1 {
+			t.Errorf("contents[%d] parts = %d, want 1", idx, len(parts))
+		}
+	}
+}
+
+func TestTranslateRequest_PenaltiesAndSeed(t *testing.T) {
+	body := []byte(`{
+		"model": "gemini-2.5-flash",
+		"messages": [{"role": "user", "content": "hi"}],
+		"frequency_penalty": 0.5,
+		"presence_penalty": -0.3,
+		"seed": 42
+	}`)
+	out, _, _, err := TranslateRequest(body)
+	if err != nil {
+		t.Fatalf("TranslateRequest failed: %v", err)
+	}
+	gc := decodeGemini(t, out)["generationConfig"].(map[string]any)
+	if gc["frequencyPenalty"] != 0.5 {
+		t.Errorf("frequencyPenalty = %v, want 0.5", gc["frequencyPenalty"])
+	}
+	if gc["presencePenalty"] != -0.3 {
+		t.Errorf("presencePenalty = %v, want -0.3", gc["presencePenalty"])
+	}
+	if gc["seed"] != float64(42) {
+		t.Errorf("seed = %v, want 42", gc["seed"])
+	}
+
+	// Absent knobs stay absent (zero values must not be sent).
+	out, _, _, err = TranslateRequest([]byte(`{"model": "m", "messages": [{"role": "user", "content": "hi"}], "max_tokens": 5}`))
+	if err != nil {
+		t.Fatalf("TranslateRequest failed: %v", err)
+	}
+	gc = decodeGemini(t, out)["generationConfig"].(map[string]any)
+	for _, k := range []string{"frequencyPenalty", "presencePenalty", "seed"} {
+		if _, ok := gc[k]; ok {
+			t.Errorf("%s present without being requested", k)
+		}
 	}
 }
 

--- a/wiki/Model-Discovery.md
+++ b/wiki/Model-Discovery.md
@@ -124,7 +124,7 @@ Providers that expose a live model list **and** ship a built-in catalog are comb
 
 models.dev enrichment runs *after* the merge and fills anything still empty, so the final precedence per field is **live → catalog → models.dev → zero value**. If the live fetch fails entirely (network, auth, 403/429 quota), the discoverer falls back to the pure catalog so discovery never goes dark.
 
-Providers on the merge (union): **Z.AI**, **xAI**, **DeepSeek**, **OpenCode Go**, **OpenCode Zen**. **OpenAI** uses the same live-first model but **backfill-only** (no union) via `backfillLiveFromCatalog`, because discoverOpenAI is the fallback for unknown/custom hosts and must not attach catalog-only gpt-5.x models to them. Providers with a *pricing-only* catalog - **Anthropic**, **Google AI Studio**, **Cohere** - keep their own discoverers: the live API is already the rich model-list source and the catalog only backfills pricing, so there is nothing to union. Pure-live providers (NanoGPT, OpenRouter, Ollama, LM Studio, KoboldCPP, NeuralWatt, AWS Bedrock, Azure AI Foundry) have no catalog.
+Providers on the merge (union): **Z.AI**, **xAI**, **DeepSeek**, **OpenCode Go**, **OpenCode Zen**. **OpenAI** uses the same live-first model but **backfill-only** (no union) via `backfillLiveFromCatalog`, because discoverOpenAI is the fallback for unknown/custom hosts and must not attach catalog-only gpt-5.x models to them. Providers with a *pricing-only* catalog - **Anthropic**, **Google AI Studio**, **Cohere** - keep their own discoverers: the live API is already the rich model-list source and the catalog only backfills pricing, so there is nothing to union. Pure-live providers (NanoGPT, OpenRouter, Ollama, LM Studio, KoboldCPP, NeuralWatt, AWS Bedrock, Azure AI Foundry) have no catalog. **Vertex AI express** is the inverse case: Google exposes no listing route for express keys, so discovery starts from a shipped candidate catalog and validates each entry live (see its section below).
 
 ### Provider Type Detection
 
@@ -142,7 +142,8 @@ The `DetectProviderType` function in `internal/provider/discovery.go` uses exact
 | `opencode.ai`, `*.opencode.ai` | `/zen/` | `opencode-zen` |
 | `openrouter.ai`, `*.openrouter.ai` | - | `openrouter` |
 | `api.x.ai`, `x.ai`, `*.x.ai` | - | `xai` |
-| `generativelanguage.googleapis.com`, `*.googleapis.com` | - | `google` |
+| `generativelanguage.googleapis.com` (and `*generativelanguage*.googleapis.com`) | - | `google` |
+| `aiplatform.googleapis.com` (incl. regional `{region}-aiplatform...`) | - | `vertex-express` |
 | `bedrock-mantle.{region}.api.aws` | - | `bedrock` |
 | `*.services.ai.azure.com`, `*.openai.azure.com` | - | `azure` |
 | `api.cohere.com`, `api.cohere.ai`, `*.cohere.com`, `*.cohere.ai` | - | `cohere` |
@@ -235,6 +236,20 @@ Both routes accept the resource API key as a **bearer token** (the legacy `api-k
 **Enrichment for aliased deployments:** the deployment name becomes the model ID (it is the invokable identifier) and the underlying base-model name is kept as the model's internal name. models.dev enrichment matches the deployment name first and falls back to the base-model name, so a deployment called `my-fast-gpt` backing `gpt-4.1-mini` still gets context/pricing metadata.
 
 **Account prerequisites for Azure itself** (not MH-specific): create an Azure AI Foundry resource (or classic Azure OpenAI resource) in the Azure portal, then **deploy at least one model** (Foundry portal → Deployments → Deploy model). A resource with zero deployments discovers zero models (MH logs a warning telling you to deploy first). Azure-sold models (OpenAI family) need no extra agreement; partner/community models (Meta, Mistral, xAI, Anthropic, ...) may require an Azure Marketplace subscription accepted during deployment.
+
+### Vertex AI (express keys)
+
+**Source files:** `discovery_vertex.go`, `vertex_catalog.go`, `catalogs/vertex_express.json`
+
+**Method:** Vertex AI **express-mode** API keys (free-tier keys from [express mode](https://cloud.google.com/vertex-ai/generative-ai/docs/start/express-mode/overview), no billing account needed) only work on Google's *native* publisher routes — every OpenAI-compatible Google surface rejects them, and **no model-listing route accepts them** (the publishers listing wants OAuth). Discovery therefore starts from a shipped candidate list (`catalogs/vertex_express.json`) and validates each entry with a free `POST .../models/{id}:countTokens` probe (parallel, bounded concurrency):
+
+- **200** → the key can invoke the model; it is kept as a clean stub for models.dev enrichment (context, pricing, modalities).
+- **404** → not express-eligible (or retired); dropped silently. Not-yet-eligible candidates stay in the catalog so they light up automatically once Google enables them for express mode.
+- **401/403** → discovery fails loudly, so a bad key reads as an error instead of "zero models".
+
+**Chat traffic is translated, not proxied.** Gemini's native `generateContent` dialect is not OpenAI-shaped, so requests to a vertex-express provider go through MH's Gemini egress adapter (`internal/gemini`): the chat-completions body is rewritten to `generateContent` on the way out (system → `systemInstruction`, tools → `functionDeclarations` with full JSON Schema, images → `inlineData`, `reasoning_effort` → thinking budget, JSON response formats → `responseJsonSchema`, penalties/seed → `generationConfig`) and the response — including SSE streams, tool calls, and thinking-token usage — is translated back to the chat-completions shape before the rest of the pipeline sees it. Failover groups can therefore mix vertex-express with OpenAI-compatible providers transparently. Auth uses the `x-goog-api-key` header.
+
+**Account prerequisites for Vertex itself** (not MH-specific): sign up for Vertex AI express mode with a Google account and copy the express API key (`AQ.`-prefixed). Free-tier keys expire after 90 days and cover a subset of Gemini models under pre-GA terms; a paid Vertex key on the same routes works identically.
 
 ### NanoGPT
 

--- a/wiki/Security.md
+++ b/wiki/Security.md
@@ -348,7 +348,7 @@ The `ValidateProviderURL` function enforces multiple security checks to prevent 
 3. **IP resolution check** - All resolved IPs are checked for loopback addresses (blocks DNS rebinding)
 4. **IPv6 loopback** - `::1` and IPv6-mapped loopback addresses are blocked
 5. **Allowed hosts** - Optional allowlist via `ALLOWED_PROVIDER_HOSTS`:
-   - Built-in provider hosts (`api.openai.com`, `api.nano-gpt.com`, `api.z.ai`, `api.deepseek.com`, `api.anthropic.com`, `ollama.com`, `opencode.ai`, `api.x.ai`, `generativelanguage.googleapis.com`, `api.cohere.com`, `api.cohere.ai`, `openrouter.ai`, `api.neuralwatt.com`, `neuralwatt.com`) are **always allowed** regardless of the allowlist
+   - Built-in provider hosts (`api.openai.com`, `api.nano-gpt.com`, `api.z.ai`, `api.deepseek.com`, `api.anthropic.com`, `ollama.com`, `opencode.ai`, `api.x.ai`, `generativelanguage.googleapis.com`, `aiplatform.googleapis.com`, `api.cohere.com`, `api.cohere.ai`, `openrouter.ai`, `api.neuralwatt.com`, `neuralwatt.com`) are **always allowed** regardless of the allowlist
    - Hosts explicitly listed in `ALLOWED_PROVIDER_HOSTS` bypass the loopback restriction - this is intentional to allow `localhost` for local Ollama or testing scenarios
    - When `ALLOWED_PROVIDER_HOSTS` is empty (the default), any non-loopback HTTPS URL is accepted
 


### PR DESCRIPTION
Final slice of Vertex AI express-key support (#507, #508, #509). The fidelity pass paid off immediately: it caught **two live 400s that shipped in #509**, both only reachable with parallel tool use.

## Bug fixes (found live, fixed test-first)

1. **Parallel tool results were rejected.** Each OpenAI `role:"tool"` message became its own Gemini content, but Gemini requires all results for one model turn in a *single* user content whose `functionResponse` part count equals the turn's `functionCall` part count ("Please ensure that the number of function response parts is equal to the number of function call parts"). Consecutive tool messages now coalesce into one content; separate tool rounds (split by other turns) stay separate.
2. **Declaring two or more tools was rejected.** One `tools` array entry was emitted per function, and Gemini reads multiple entries as multiple tool *types* ("Multiple tools are supported only when they are all search tools"). All function declarations now share one entry.

After both fixes, the exact parallel-tool conversation that 400'd round-trips live: two calls out, two results back, correct final answer synthesized from both.

## Fidelity upgrades (each live-probe-verified before implementing)

- **Tool parameters ride `parametersJsonSchema`** — accepts standard JSON Schema verbatim, so strict-mode client schemas (`additionalProperties: false`, `$defs`, …) survive untouched. The previous `parameters` field is an OpenAPI subset that would have required lossy sanitizing.
- **`frequency_penalty` / `presence_penalty` / `seed`** now map into `generationConfig` (previously dropped silently); absent knobs stay absent.

## Docs

- `wiki/Model-Discovery.md`: new **Vertex AI (express keys)** section (probe-based discovery semantics, the egress-adapter explanation, account prerequisites), corrected host-table rows (`generativelanguage` → google, `aiplatform` → vertex-express), and a catalog-merge note for the inverse catalog-probe model.
- `wiki/Security.md`: built-in always-allowed host list gains `aiplatform.googleapis.com` (matching `defaultKnownProviderHosts` since #509).
- README provider list already updated in #509. Verified-provider screenshot deliberately deferred (it's one more cell on an existing 13-provider grid).

## Verification

- TDD: 4 new/updated tests red-first; gemini package 32 tests, 94.3% coverage; full backend suite 5640 green; golangci-lint clean.
- Live against Vertex express: parallel-tool round-trip (the previously failing shape), `parametersJsonSchema` + penalties + seed probes, and vision + `json_schema` structured output through the running dev-stack proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)