### PR TITLE
test(proxy): deflake TestStallWatchdog_Timeout timing bound

### DIFF
--- a/internal/proxy/ttft_stall_test.go
+++ b/internal/proxy/ttft_stall_test.go
@@ -276,6 +276,10 @@ func TestStallWatchdog_Timeout(t *testing.T) {
 
 	// Body sends one chunk then blocks longer than the stall timeout.
 	// The watchdog should fire and close the body before the second write.
+	// The writer's fallback timeout is deliberately huge relative to the 50ms
+	// stall timeout: it only matters when the watchdog is broken, and a wide
+	// gap keeps the duration assertion below meaningful on loaded CI runners
+	// (this test once flaked at 287ms against a 150ms bound).
 	closeCh := make(chan struct{})
 	pr, pw := io.Pipe()
 	go func() {
@@ -283,7 +287,7 @@ func TestStallWatchdog_Timeout(t *testing.T) {
 		select {
 		case <-closeCh:
 			// Body was closed by watchdog, pipe write will fail
-		case <-time.After(200 * time.Millisecond):
+		case <-time.After(2 * time.Second):
 			// Timeout reached — watchdog did NOT fire, write the [DONE]
 			pw.Write([]byte("data: [DONE]\n\n"))
 		}
@@ -331,10 +335,12 @@ func TestStallWatchdog_Timeout(t *testing.T) {
 	if logData.errorMessage == "" {
 		t.Error("expected non-empty error message after stall")
 	}
-	// Duration should be much less than 200ms (the sleep in the goroutine)
-	// since watchdog fires at ~50ms
-	if logData.durationMs > 150 {
-		t.Errorf("expected duration < 150ms (stall fired early), got %.1fms", logData.durationMs)
+	// The watchdog fires at ~50ms; well under the writer's 2s fallback even
+	// with heavy scheduler delay. The state/error assertions above are the
+	// functional proof — this bound only guards against the stream having
+	// waited out the writer instead of being cut by the watchdog.
+	if logData.durationMs > 1000 {
+		t.Errorf("expected duration well under the 2s writer fallback (stall fired early), got %.1fms", logData.durationMs)
 	}
 }
 


### PR DESCRIPTION
Master CI went red after #510 merged on `TestStallWatchdog_Timeout` — a timing flake in a file the vertex work never touched: the test asserted total duration < 150ms against a 50ms watchdog and a 200ms writer fallback, and a loaded runner clocked 287ms while the functional assertions (state `failed`, non-empty error) still passed. The watchdog behaved correctly; only the wall-clock heuristic tripped.

Fix widens the discrimination gap rather than just bumping the number: the writer's did-not-fire fallback moves 200ms → 2s (it is only ever reached when the watchdog is broken, so the healthy-path test still completes in ~50ms) and the duration bound moves 150ms → 1s. The bound still proves the stream was cut by the watchdog instead of waiting out the writer, with 20x margin over the timer instead of 3x.

Verified: `-count=10` locally green (80 runs across the stall watchdog tests), lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)