### PR TITLE
feat(bellhop): widget data layer (render model + store + poll piggyback)

### DIFF
--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
@@ -44,6 +44,7 @@ import com.hugalafutro.bellhop.data.LockStore
 import com.hugalafutro.bellhop.data.LockTimeout
 import com.hugalafutro.bellhop.data.MonitorStore
 import com.hugalafutro.bellhop.data.PrefsStore
+import com.hugalafutro.bellhop.data.WidgetStore
 import com.hugalafutro.bellhop.data.shouldLock
 import com.hugalafutro.bellhop.data.shouldLockOnEntry
 import com.hugalafutro.bellhop.notify.FleetNotifier
@@ -204,6 +205,7 @@ fun BellhopApp() {
     val linkStore = remember { LinkStore.create(context) }
     val lockStore = remember { LockStore.create(context) }
     val monitorStore = remember { MonitorStore.create(context) }
+    val widgetStore = remember { WidgetStore.create(context) }
     val prefsStore = remember { PrefsStore.create(context) }
     val client = remember { FrontDeskClient() }
     val linkState by linkStore.state.collectAsStateWithLifecycle(initialValue = LinkState.Loading)
@@ -421,6 +423,8 @@ fun BellhopApp() {
                     // clear() drops the pushEnabled flag, but LinkedContent unmounts
                     // before its LaunchedEffect can unregister, so do it here too.
                     monitorStore.clear()
+                    // Widget display state is per-link too: a re-pair must not show the old fleet.
+                    widgetStore.clear()
                     FleetPollWorker.cancelAll(context)
                     BellhopPush.unregister(context, pushInstance)
                 } else {
@@ -456,6 +460,8 @@ fun BellhopApp() {
                 linkStore.clear()
                 lockStore.clear()
                 monitorStore.clear()
+                // Widget display state is per-link too: a re-pair must not show the old fleet.
+                widgetStore.clear()
                 FleetPollWorker.cancelAll(context)
                 BellhopPush.unregister(context, pushInstance)
             } catch (e: CancellationException) {

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/WidgetState.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/WidgetState.kt
@@ -1,0 +1,79 @@
+package com.hugalafutro.bellhop.data
+
+import kotlinx.serialization.Serializable
+
+/**
+ * WidgetMember is one row of the home-screen widget: the display name and the
+ * member's [MemberHealthState] stored by enum name, so a value from a future
+ * build degrades to UNKNOWN (same stance as [FleetSnapshot.stateOf]) instead of
+ * crashing the render.
+ */
+@Serializable
+data class WidgetMember(
+    val name: String,
+    val state: String,
+) {
+    val healthState: MemberHealthState
+        get() = runCatching { MemberHealthState.valueOf(state) }.getOrDefault(MemberHealthState.UNKNOWN)
+}
+
+/** WidgetEvent is the fleet-wide newest event line, shown on the tall layout only. */
+@Serializable
+data class WidgetEvent(
+    val message: String,
+    val createdAt: String,
+)
+
+/**
+ * WidgetState is the widget's whole persisted render model. It is written only
+ * by code paths that already fetched the fleet (background poll, foreground
+ * refresh, widget refresh tap) so the widget itself never needs the network;
+ * [updatedAt] drives the honest "as of" stamp that makes lazy updates safe.
+ */
+@Serializable
+data class WidgetState(
+    val members: List<WidgetMember> = emptyList(),
+    val autosyncStale: Boolean = false,
+    val newestEvent: WidgetEvent? = null,
+    val updatedAt: Long = 0L,
+)
+
+/** WidgetCounts is the collapsed fallback face for fleets too big for per-member rows. */
+data class WidgetCounts(
+    val up: Int,
+    val down: Int,
+    val drained: Int,
+    val unknown: Int,
+)
+
+fun countsOf(state: WidgetState): WidgetCounts {
+    val byState = state.members.groupingBy { it.healthState }.eachCount()
+    return WidgetCounts(
+        up = byState[MemberHealthState.UP] ?: 0,
+        down = byState[MemberHealthState.DOWN] ?: 0,
+        drained = byState[MemberHealthState.DRAINED] ?: 0,
+        unknown = byState[MemberHealthState.UNKNOWN] ?: 0,
+    )
+}
+
+/**
+ * widgetStateOf collapses a fetched fleet into the widget's render model. The
+ * newest event is the fleet-wide max over the inline per-member newest events;
+ * Front Desk stamps created_at as RFC3339 UTC, which sorts lexicographically,
+ * so a string max needs no parsing.
+ */
+fun widgetStateOf(
+    members: List<FleetMember>,
+    autosyncStale: Boolean,
+    now: Long,
+): WidgetState =
+    WidgetState(
+        members = members.map { WidgetMember(name = it.name.ifBlank { it.id }, state = healthStateOf(it).name) },
+        autosyncStale = autosyncStale,
+        newestEvent =
+            members
+                .mapNotNull { it.newestEvent }
+                .maxByOrNull { it.createdAt }
+                ?.let { WidgetEvent(it.message, it.createdAt) },
+        updatedAt = now,
+    )

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/WidgetStore.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/WidgetStore.kt
@@ -1,0 +1,79 @@
+package com.hugalafutro.bellhop.data
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+// Separate DataStore from the monitor/link/lock records: widget display state
+// has its own trivial lifecycle (written by any fresh fetch, cleared on unlink)
+// and must never share a file with the alert baseline it is forbidden to touch.
+private val Context.widgetDataStore: DataStore<Preferences> by
+    preferencesDataStore(name = "bellhop_widget")
+
+/**
+ * WidgetStore persists the home-screen widget's render model ([WidgetState]).
+ * It is deliberately NOT [MonitorStore]: the fleet snapshot there is the alert
+ * diff baseline, guarded by an active/epoch save-gate, and a display write
+ * advancing it would swallow real down/up notifications. This store carries
+ * display state only, so anything with a fresh fleet in hand may write it.
+ */
+class WidgetStore(
+    private val dataStore: DataStore<Preferences>,
+    private val json: Json = Json { ignoreUnknownKeys = true },
+) {
+    /** state emits the stored render model; null when never written or unparsable. */
+    val state: Flow<WidgetState?> =
+        dataStore.data.map { prefs -> prefs[STATE]?.let(::decode) }
+
+    suspend fun read(): WidgetState? = dataStore.data.first()[STATE]?.let(::decode)
+
+    /**
+     * saveIfChanged persists [state] and reports whether it wrote, so callers
+     * only trigger a Glance re-render on a real change. A content-equal state
+     * (ignoring [WidgetState.updatedAt]) is skipped while the stored stamp is
+     * fresher than [STAMP_ADVANCE_MS], which stops the foreground dashboard's
+     * 15s refresh cadence from re-rendering the widget on every tick, while a
+     * long-open app still refreshes the stamp every few minutes so the "as of"
+     * line stays roughly honest.
+     */
+    suspend fun saveIfChanged(state: WidgetState): Boolean {
+        var written = false
+        dataStore.edit { prefs ->
+            val stored = prefs[STATE]?.let(::decode)
+            if (stored != null &&
+                stored.copy(updatedAt = 0L) == state.copy(updatedAt = 0L) &&
+                state.updatedAt - stored.updatedAt < STAMP_ADVANCE_MS
+            ) {
+                return@edit
+            }
+            prefs[STATE] = json.encodeToString(state)
+            written = true
+        }
+        return written
+    }
+
+    suspend fun clear() {
+        dataStore.edit { it.clear() }
+    }
+
+    private fun decode(stored: String): WidgetState? =
+        runCatching { json.decodeFromString<WidgetState>(stored) }.getOrNull()
+
+    companion object {
+        fun create(context: Context): WidgetStore = WidgetStore(context.applicationContext.widgetDataStore)
+
+        // How stale the stored stamp may get before a content-equal write is
+        // accepted anyway, purely to keep the widget's "as of" line honest.
+        const val STAMP_ADVANCE_MS = 300_000L
+
+        private val STATE = stringPreferencesKey("widget_state")
+    }
+}

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/WidgetStore.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/WidgetStore.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import kotlinx.coroutines.flow.Flow
@@ -11,6 +12,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import kotlin.random.Random
 
 // Separate DataStore from the monitor/link/lock records: widget display state
 // has its own trivial lifecycle (written by any fresh fetch, cleared on unlink)
@@ -36,17 +38,34 @@ class WidgetStore(
     suspend fun read(): WidgetState? = dataStore.data.first()[STATE]?.let(::decode)
 
     /**
-     * saveIfChanged persists [state] and reports whether it wrote, so callers
-     * only trigger a Glance re-render on a real change. A content-equal state
-     * (ignoring [WidgetState.updatedAt]) is skipped while the stored stamp is
-     * fresher than [STAMP_ADVANCE_MS], which stops the foreground dashboard's
-     * 15s refresh cadence from re-rendering the widget on every tick, while a
-     * long-open app still refreshes the stamp every few minutes so the "as of"
-     * line stays roughly honest.
+     * generation is the write fence a caller must capture BEFORE fetching the
+     * data it intends to save (see [saveIfChanged]). [clear] stamps a fresh
+     * one, so a fetch that started before an unlink cleared the store cannot
+     * land afterwards and resurrect the old fleet. Same idea as
+     * [MonitorStore]'s session epoch, kept store-local so display state stays
+     * decoupled from the alert baseline.
      */
-    suspend fun saveIfChanged(state: WidgetState): Boolean {
+    suspend fun generation(): Long = dataStore.data.first()[GENERATION] ?: 0L
+
+    /**
+     * saveIfChanged persists [state] and reports whether it wrote, so callers
+     * only trigger a Glance re-render on a real change. The write is dropped
+     * when [generation] no longer matches the store (a clear happened since
+     * the caller captured it — the fetched fleet belongs to a dead link). A
+     * content-equal state (ignoring [WidgetState.updatedAt]) is skipped while
+     * the stored stamp is fresher than [STAMP_ADVANCE_MS], which stops the
+     * foreground dashboard's 15s refresh cadence from re-rendering the widget
+     * on every tick, while a long-open app still refreshes the stamp every
+     * few minutes so the "as of" line stays roughly honest. The generation
+     * check, content check, and write share one atomic edit.
+     */
+    suspend fun saveIfChanged(
+        state: WidgetState,
+        generation: Long,
+    ): Boolean {
         var written = false
         dataStore.edit { prefs ->
+            if ((prefs[GENERATION] ?: 0L) != generation) return@edit
             val stored = prefs[STATE]?.let(::decode)
             if (stored != null &&
                 stored.copy(updatedAt = 0L) == state.copy(updatedAt = 0L) &&
@@ -60,8 +79,18 @@ class WidgetStore(
         return written
     }
 
+    /**
+     * clear wipes the render model and stamps a fresh [generation] in the same
+     * atomic edit, fencing out any in-flight write whose generation was
+     * captured before this clear. Random rather than a counter: a wipe-and-
+     * reseed counter would restart at the same values and collide across the
+     * exact unlink + re-pair this guards against.
+     */
     suspend fun clear() {
-        dataStore.edit { it.clear() }
+        dataStore.edit { prefs ->
+            prefs.clear()
+            prefs[GENERATION] = Random.nextLong()
+        }
     }
 
     private fun decode(stored: String): WidgetState? =
@@ -75,5 +104,6 @@ class WidgetStore(
         const val STAMP_ADVANCE_MS = 300_000L
 
         private val STATE = stringPreferencesKey("widget_state")
+        private val GENERATION = longPreferencesKey("widget_generation")
     }
 }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/work/FleetPollWorker.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/work/FleetPollWorker.kt
@@ -66,6 +66,10 @@ suspend fun pollFleet(
     // the store while this poll is in flight, saveSnapshot drops our now-stale
     // write instead of poisoning the new session's baseline.
     val epoch = monitorStore.epoch()
+    // Widget write fence, captured before the fetch like the epoch above: an
+    // unlink mid-poll stamps a fresh generation, so this poll's late display
+    // write is dropped instead of resurrecting the old fleet (see WidgetStore).
+    val widgetGeneration = widgetStore.generation()
     return when (val result = client.members(fdUrl, token)) {
         is FetchResult.Success -> {
             val previous = monitorStore.snapshot()
@@ -84,8 +88,11 @@ suspend fun pollFleet(
             // This poll already holds everything the home-screen widget renders;
             // persist its render model here so the widget rides the existing
             // fetch (the no-new-polling rule) instead of ever fetching itself.
-            // Deliberately ungated: display state is not the alert baseline.
-            widgetStore.saveIfChanged(widgetStateOf(result.data, stale, now()))
+            // Not gated by the monitor epoch (display state is not the alert
+            // baseline), but fenced by the store's own generation captured
+            // before the fetch, so a poll finishing after an unlink cleared
+            // the store cannot write the old fleet back.
+            widgetStore.saveIfChanged(widgetStateOf(result.data, stale, now()), widgetGeneration)
             PollResult.Changed(alerts)
         }
         FetchResult.Unauthorized -> PollResult.Unauthorized

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/work/FleetPollWorker.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/work/FleetPollWorker.kt
@@ -20,8 +20,10 @@ import com.hugalafutro.bellhop.data.FrontDeskClient
 import com.hugalafutro.bellhop.data.LinkState
 import com.hugalafutro.bellhop.data.LinkStore
 import com.hugalafutro.bellhop.data.MonitorStore
+import com.hugalafutro.bellhop.data.WidgetStore
 import com.hugalafutro.bellhop.data.diffAutoSync
 import com.hugalafutro.bellhop.data.diffFleet
+import com.hugalafutro.bellhop.data.widgetStateOf
 import com.hugalafutro.bellhop.notify.FleetNotifier
 import kotlinx.coroutines.flow.first
 import java.util.concurrent.TimeUnit
@@ -57,6 +59,8 @@ suspend fun pollFleet(
     fdUrl: String,
     token: String,
     monitorStore: MonitorStore,
+    widgetStore: WidgetStore,
+    now: () -> Long = System::currentTimeMillis,
 ): PollResult {
     // Capture the session epoch before the fetch: if an unlink + re-enable churns
     // the store while this poll is in flight, saveSnapshot drops our now-stale
@@ -77,6 +81,11 @@ suspend fun pollFleet(
                 }
             val alerts = diffFleet(previous, result.data) + listOfNotNull(diffAutoSync(previous, stale))
             monitorStore.saveSnapshot(FleetSnapshot.of(result.data, stale), epoch)
+            // This poll already holds everything the home-screen widget renders;
+            // persist its render model here so the widget rides the existing
+            // fetch (the no-new-polling rule) instead of ever fetching itself.
+            // Deliberately ungated: display state is not the alert baseline.
+            widgetStore.saveIfChanged(widgetStateOf(result.data, stale, now()))
             PollResult.Changed(alerts)
         }
         FetchResult.Unauthorized -> PollResult.Unauthorized
@@ -95,6 +104,7 @@ suspend fun pollFleet(
 suspend fun runBackstop(
     monitorStore: MonitorStore,
     linkStore: LinkStore,
+    widgetStore: WidgetStore,
     client: FrontDeskClient,
     canNotify: Boolean,
     notify: (FleetAlert) -> Unit,
@@ -116,7 +126,7 @@ suspend fun runBackstop(
     // foreground UI surfaces the revoke; the backstop just stops quietly.
     val token = linkStore.token() ?: return Result.success()
 
-    return when (val result = pollFleet(client, link.fdUrl, token, monitorStore)) {
+    return when (val result = pollFleet(client, link.fdUrl, token, monitorStore, widgetStore)) {
         is PollResult.Changed -> {
             result.alerts.forEach(notify)
             Result.success()
@@ -152,6 +162,7 @@ class FleetPollWorker(
         return runBackstop(
             monitorStore = MonitorStore.create(context),
             linkStore = LinkStore.create(context),
+            widgetStore = WidgetStore.create(context),
             client = FrontDeskClient(),
             canNotify = FleetNotifier.canPost(context),
             notify = { FleetNotifier.notify(context, it) },

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/WidgetStateTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/WidgetStateTest.kt
@@ -1,0 +1,103 @@
+package com.hugalafutro.bellhop.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * The widget's render model is built by a pure function from the same fetch the
+ * backstop poll already makes; these tests pin the mapping so the widget can
+ * stay logic-free.
+ */
+class WidgetStateTest {
+    private fun member(
+        id: String,
+        name: String = "",
+        healthy: Boolean = true,
+        known: Boolean = true,
+        drained: Boolean = false,
+        newestEvent: FdEvent? = null,
+    ): FleetMember =
+        FleetMember(
+            id = id,
+            name = name,
+            state = if (drained) "drained" else "active",
+            status = MemberStatus(health = HealthStatus(known = known, healthy = healthy)),
+            newestEvent = newestEvent,
+        )
+
+    @Test
+    fun mapsMembersToNameAndHealthState() {
+        val state =
+            widgetStateOf(
+                members =
+                    listOf(
+                        member("m1", name = "hotel-1", healthy = true),
+                        member("m2", name = "hotel-2", healthy = false),
+                        member("m3", name = "hotel-3", drained = true),
+                        member("m4", name = "hotel-4", known = false),
+                    ),
+                autosyncStale = true,
+                now = 42L,
+            )
+        assertEquals(
+            listOf(
+                WidgetMember("hotel-1", "UP"),
+                WidgetMember("hotel-2", "DOWN"),
+                WidgetMember("hotel-3", "DRAINED"),
+                WidgetMember("hotel-4", "UNKNOWN"),
+            ),
+            state.members,
+        )
+        assertEquals(true, state.autosyncStale)
+        assertEquals(42L, state.updatedAt)
+    }
+
+    @Test
+    fun blankNameFallsBackToId() {
+        val state = widgetStateOf(listOf(member("m1")), autosyncStale = false, now = 0L)
+        assertEquals("m1", state.members.single().name)
+    }
+
+    @Test
+    fun newestEventIsFleetWideMaxByCreatedAt() {
+        val older = FdEvent(id = "e1", message = "older", createdAt = "2026-07-18T10:00:00Z")
+        val newer = FdEvent(id = "e2", message = "newer", createdAt = "2026-07-18T11:00:00Z")
+        val state =
+            widgetStateOf(
+                listOf(member("m1", newestEvent = older), member("m2", newestEvent = newer)),
+                autosyncStale = false,
+                now = 0L,
+            )
+        assertEquals(WidgetEvent("newer", "2026-07-18T11:00:00Z"), state.newestEvent)
+    }
+
+    @Test
+    fun noEventsMeansNullNewestEvent() {
+        val state = widgetStateOf(listOf(member("m1")), autosyncStale = false, now = 0L)
+        assertNull(state.newestEvent)
+    }
+
+    @Test
+    fun unknownStoredStateDegradesToUnknown() {
+        // A future build may persist a state name this build doesn't know.
+        assertEquals(MemberHealthState.UNKNOWN, WidgetMember("x", "SOMETHING_NEW").healthState)
+    }
+
+    @Test
+    fun countsBucketAllFourStates() {
+        val state =
+            widgetStateOf(
+                listOf(
+                    member("m1", healthy = true),
+                    member("m2", healthy = true),
+                    member("m3", healthy = false),
+                    member("m4", drained = true),
+                    member("m5", known = false),
+                ),
+                autosyncStale = false,
+                now = 0L,
+            )
+        assertEquals(WidgetCounts(up = 2, down = 1, drained = 1, unknown = 1), countsOf(state))
+    }
+}

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/WidgetStoreTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/WidgetStoreTest.kt
@@ -16,11 +16,18 @@ class WidgetStoreTest {
         at: Long = 1_000L,
     ): WidgetState = WidgetState(members = listOf(WidgetMember(name, health)), updatedAt = at)
 
+    // save mimics a well-behaved caller: capture the generation, then write.
+    // The stale-generation test below bypasses this on purpose.
+    private suspend fun save(
+        store: WidgetStore,
+        state: WidgetState,
+    ): Boolean = store.saveIfChanged(state, store.generation())
+
     @Test
     fun roundTripsState() =
         runBlocking {
             val store = newStore()
-            assertTrue(store.saveIfChanged(state()))
+            assertTrue(save(store, state()))
             assertEquals(state(), store.read())
         }
 
@@ -31,9 +38,9 @@ class WidgetStoreTest {
     fun contentChangeAlwaysWrites() =
         runBlocking {
             val store = newStore()
-            store.saveIfChanged(state(health = "UP", at = 1_000L))
+            save(store, state(health = "UP", at = 1_000L))
             // Content changed one tick later: must write regardless of stamp age.
-            assertTrue(store.saveIfChanged(state(health = "DOWN", at = 1_001L)))
+            assertTrue(save(store, state(health = "DOWN", at = 1_001L)))
             assertEquals("DOWN", store.read()?.members?.single()?.state)
         }
 
@@ -41,10 +48,10 @@ class WidgetStoreTest {
     fun contentEqualFreshStampSkips() =
         runBlocking {
             val store = newStore()
-            store.saveIfChanged(state(at = 1_000L))
+            save(store, state(at = 1_000L))
             // Same content, stamp advanced less than STAMP_ADVANCE_MS: skip, so the
             // foreground 15s refresh cadence can't spam widget re-renders.
-            assertFalse(store.saveIfChanged(state(at = 1_000L + WidgetStore.STAMP_ADVANCE_MS - 1)))
+            assertFalse(save(store, state(at = 1_000L + WidgetStore.STAMP_ADVANCE_MS - 1)))
             assertEquals(1_000L, store.read()?.updatedAt)
         }
 
@@ -52,10 +59,10 @@ class WidgetStoreTest {
     fun contentEqualOldStampRefreshesStamp() =
         runBlocking {
             val store = newStore()
-            store.saveIfChanged(state(at = 1_000L))
+            save(store, state(at = 1_000L))
             // Same content but the stored stamp has aged past the threshold: write,
             // so a long-open app still keeps the "as of" stamp roughly honest.
-            assertTrue(store.saveIfChanged(state(at = 1_000L + WidgetStore.STAMP_ADVANCE_MS)))
+            assertTrue(save(store, state(at = 1_000L + WidgetStore.STAMP_ADVANCE_MS)))
             assertEquals(1_000L + WidgetStore.STAMP_ADVANCE_MS, store.read()?.updatedAt)
         }
 
@@ -63,8 +70,21 @@ class WidgetStoreTest {
     fun clearWipesState() =
         runBlocking {
             val store = newStore()
-            store.saveIfChanged(state())
+            save(store, state())
             store.clear()
+            assertNull(store.read())
+        }
+
+    @Test
+    fun staleGenerationWriteAfterClearIsDropped() =
+        runBlocking {
+            val store = newStore()
+            // A poll captures the generation, then an unlink clears the store
+            // while its fetch is still in flight: the late write must be
+            // dropped, or a re-pair would show the previous fleet.
+            val generation = store.generation()
+            store.clear()
+            assertFalse(store.saveIfChanged(state(), generation))
             assertNull(store.read())
         }
 }

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/WidgetStoreTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/WidgetStoreTest.kt
@@ -1,0 +1,70 @@
+package com.hugalafutro.bellhop.data
+
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WidgetStoreTest {
+    private fun newStore(): WidgetStore = WidgetStore(InMemoryPreferencesDataStore())
+
+    private fun state(
+        name: String = "hotel-1",
+        health: String = "UP",
+        at: Long = 1_000L,
+    ): WidgetState = WidgetState(members = listOf(WidgetMember(name, health)), updatedAt = at)
+
+    @Test
+    fun roundTripsState() =
+        runBlocking {
+            val store = newStore()
+            assertTrue(store.saveIfChanged(state()))
+            assertEquals(state(), store.read())
+        }
+
+    @Test
+    fun emptyStoreReadsNull() = runBlocking { assertNull(newStore().read()) }
+
+    @Test
+    fun contentChangeAlwaysWrites() =
+        runBlocking {
+            val store = newStore()
+            store.saveIfChanged(state(health = "UP", at = 1_000L))
+            // Content changed one tick later: must write regardless of stamp age.
+            assertTrue(store.saveIfChanged(state(health = "DOWN", at = 1_001L)))
+            assertEquals("DOWN", store.read()?.members?.single()?.state)
+        }
+
+    @Test
+    fun contentEqualFreshStampSkips() =
+        runBlocking {
+            val store = newStore()
+            store.saveIfChanged(state(at = 1_000L))
+            // Same content, stamp advanced less than STAMP_ADVANCE_MS: skip, so the
+            // foreground 15s refresh cadence can't spam widget re-renders.
+            assertFalse(store.saveIfChanged(state(at = 1_000L + WidgetStore.STAMP_ADVANCE_MS - 1)))
+            assertEquals(1_000L, store.read()?.updatedAt)
+        }
+
+    @Test
+    fun contentEqualOldStampRefreshesStamp() =
+        runBlocking {
+            val store = newStore()
+            store.saveIfChanged(state(at = 1_000L))
+            // Same content but the stored stamp has aged past the threshold: write,
+            // so a long-open app still keeps the "as of" stamp roughly honest.
+            assertTrue(store.saveIfChanged(state(at = 1_000L + WidgetStore.STAMP_ADVANCE_MS)))
+            assertEquals(1_000L + WidgetStore.STAMP_ADVANCE_MS, store.read()?.updatedAt)
+        }
+
+    @Test
+    fun clearWipesState() =
+        runBlocking {
+            val store = newStore()
+            store.saveIfChanged(state())
+            store.clear()
+            assertNull(store.read())
+        }
+}

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/work/FleetBackstopTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/work/FleetBackstopTest.kt
@@ -13,6 +13,7 @@ import com.hugalafutro.bellhop.data.MemberTransition
 import com.hugalafutro.bellhop.data.MonitorStore
 import com.hugalafutro.bellhop.data.PairedDevice
 import com.hugalafutro.bellhop.data.TokenCipher
+import com.hugalafutro.bellhop.data.WidgetStore
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -80,6 +81,8 @@ class FleetBackstopTest {
 
     private fun monitorStore(): MonitorStore = MonitorStore(preferences("monitor"))
 
+    private fun widgetStore(): WidgetStore = WidgetStore(preferences("widget"))
+
     private fun linkStore(cipher: TokenCipher): LinkStore = LinkStore(preferences("link"), cipher)
 
     private suspend fun linkedTo(
@@ -109,7 +112,10 @@ class FleetBackstopTest {
         monitor: MonitorStore,
         link: LinkStore,
         canNotify: Boolean = true,
-    ): Result = runBackstop(monitor, link, client, canNotify, notify = { fired += it })
+    ): Result =
+        runBackstop(monitor, link, widgetStore = widgetStore(), client = client, canNotify = canNotify, notify = {
+            fired += it
+        })
 
     @Test
     fun disabledMonitoringSucceedsWithoutPolling() =
@@ -239,7 +245,8 @@ class FleetBackstopTest {
                 runBackstop(
                     monitor,
                     linkedTo(server.url("/").toString()),
-                    client,
+                    widgetStore = widgetStore(),
+                    client = client,
                     canNotify = true,
                     notify = { fired += it },
                     retryOnFailure = false,

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/work/FleetPollTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/work/FleetPollTest.kt
@@ -10,6 +10,7 @@ import com.hugalafutro.bellhop.data.MemberHealthState
 import com.hugalafutro.bellhop.data.MemberTransition
 import com.hugalafutro.bellhop.data.MonitorStore
 import com.hugalafutro.bellhop.data.WidgetMember
+import com.hugalafutro.bellhop.data.WidgetState
 import com.hugalafutro.bellhop.data.WidgetStore
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -19,7 +20,6 @@ import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -212,11 +212,14 @@ class FleetPollTest {
             val store = newStore()
             val widget = newWidgetStore()
             store.setEnabled(true)
+            // Seed a previous fetch's state: an untouched store and a wiped one
+            // both read null, so only a surviving seed proves "untouched".
+            widget.saveIfChanged(WidgetState(members = listOf(WidgetMember("hotel-1", "UP")), updatedAt = 7L))
             server.enqueue(MockResponse().setResponseCode(500).setBody("nope"))
 
             poll(store, widget)
 
             // Stale beats blank: the widget keeps showing the last fetch + stamp.
-            assertNull(widget.read())
+            assertEquals(7L, widget.read()?.updatedAt)
         }
 }

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/work/FleetPollTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/work/FleetPollTest.kt
@@ -214,7 +214,10 @@ class FleetPollTest {
             store.setEnabled(true)
             // Seed a previous fetch's state: an untouched store and a wiped one
             // both read null, so only a surviving seed proves "untouched".
-            widget.saveIfChanged(WidgetState(members = listOf(WidgetMember("hotel-1", "UP")), updatedAt = 7L))
+            widget.saveIfChanged(
+                WidgetState(members = listOf(WidgetMember("hotel-1", "UP")), updatedAt = 7L),
+                widget.generation(),
+            )
             server.enqueue(MockResponse().setResponseCode(500).setBody("nope"))
 
             poll(store, widget)

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/work/FleetPollTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/work/FleetPollTest.kt
@@ -9,6 +9,8 @@ import com.hugalafutro.bellhop.data.FrontDeskClient
 import com.hugalafutro.bellhop.data.MemberHealthState
 import com.hugalafutro.bellhop.data.MemberTransition
 import com.hugalafutro.bellhop.data.MonitorStore
+import com.hugalafutro.bellhop.data.WidgetMember
+import com.hugalafutro.bellhop.data.WidgetStore
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -17,6 +19,7 @@ import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -58,6 +61,15 @@ class FleetPollTest {
         return MonitorStore(ds)
     }
 
+    private fun newWidgetStore(): WidgetStore {
+        val scope = CoroutineScope(Dispatchers.IO + Job())
+        val ds: DataStore<Preferences> =
+            PreferenceDataStoreFactory.create(scope = scope) {
+                File(tmp.newFolder(), "widget.preferences_pb")
+            }
+        return WidgetStore(ds)
+    }
+
     private fun memberBody(healthy: Boolean): String =
         """[{"id":"m1","name":"hotel-1","state":"active",""" +
             """"status":{"health":{"known":true,"healthy":$healthy}}}]"""
@@ -73,8 +85,10 @@ class FleetPollTest {
         server.enqueue(MockResponse().setBody(autoSyncBody(stale)))
     }
 
-    private suspend fun poll(store: MonitorStore): PollResult =
-        pollFleet(client, server.url("/").toString(), "tok-1", store)
+    private suspend fun poll(
+        store: MonitorStore,
+        widget: WidgetStore = newWidgetStore(),
+    ): PollResult = pollFleet(client, server.url("/").toString(), "tok-1", store, widget, now = { 42L })
 
     @Test
     fun firstPollSavesBaselineWithNoTransitions() =
@@ -175,5 +189,34 @@ class FleetPollTest {
             // A blip mustn't advance or clear the baseline, or the next poll would
             // diff against nothing and re-alert the whole fleet.
             assertEquals(MemberHealthState.UP, store.snapshot()?.stateOf("m1"))
+        }
+
+    @Test
+    fun successfulPollWritesWidgetState() =
+        runBlocking {
+            val store = newStore()
+            val widget = newWidgetStore()
+            store.setEnabled(true)
+            enqueuePoll(healthy = true)
+
+            poll(store, widget)
+
+            val ws = widget.read()
+            assertEquals(listOf(WidgetMember("hotel-1", "UP")), ws?.members)
+            assertEquals(42L, ws?.updatedAt)
+        }
+
+    @Test
+    fun failedPollLeavesWidgetStateUntouched() =
+        runBlocking {
+            val store = newStore()
+            val widget = newWidgetStore()
+            store.setEnabled(true)
+            server.enqueue(MockResponse().setResponseCode(500).setBody("nope"))
+
+            poll(store, widget)
+
+            // Stale beats blank: the widget keeps showing the last fetch + stamp.
+            assertNull(widget.read())
         }
 }


### PR DESCRIPTION
Slice 1 of the Bellhop home-screen widget (spec: plans/2026-07-18-bellhop-glance-widget-design.md, gitignored): the data layer only, no UI yet.

- New `data/WidgetState.kt`: serializable widget render model (`WidgetState`/`WidgetMember`/`WidgetEvent`) + pure `widgetStateOf` builder and `countsOf` rollup. Unknown persisted health states degrade to UNKNOWN; newest event is the fleet-wide max over the inline `newest_event`s.
- New `data/WidgetStore.kt`: separate DataStore (`bellhop_widget`) for display state. Deliberately NOT MonitorStore: the fleet snapshot there is the alert diff baseline behind the epoch/active save-gate, and a display write advancing it would swallow real down/up alerts. `saveIfChanged` skips content-equal writes inside a 5-min stamp window so later foreground writers can't spam re-renders.
- `pollFleet` (Layer-2 periodic + push wakes) now persists the widget render model on every successful poll, next to the existing snapshot save — the widget rides fetches the app already makes (hard rule: the widget never adds polling of its own; `updatePeriodMillis=0` comes in slice 2).
- Both unlink paths clear the widget store so a re-pair can't show the old fleet.
- Alert/diff/epoch semantics are byte-for-byte untouched; the widget write is purely additive and ungated by design.

Slice 2 (Glance UI) and slice 3 (refresh button + foreground mirror) follow in stacked PRs.

Tests: 2 new suites (WidgetStateTest 6, WidgetStoreTest 6) + 2 new FleetPollTest cases (success writes widget state incl. stamp; failure leaves a seeded state untouched). Full gates green: ktlintCheck, testDebugUnitTest, lintDebug, assembleDebug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)