### PR TITLE
feat(bellhop): Glance home-screen widget (UI slice)

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -145,6 +145,10 @@ dependencies {
     // worker that diffs fleet health while Bellhop is backgrounded and posts a
     // local notification on a member going down or recovering. No push infra.
     implementation(libs.androidx.work.runtime)
+    // Jetpack Glance renders the home-screen widget. The widget never fetches:
+    // it displays WidgetStore state written by fetches the app already makes
+    // (spec: plans/2026-07-18-bellhop-glance-widget-design.md).
+    implementation(libs.androidx.glance.appwidget)
     // UnifiedPush is the Layer-3 real-time wake (plan section 5.2): an opt-in,
     // Google-free replacement for FCM. A distributor (ntfy) holds the socket and
     // wakes Bellhop the moment Front Desk's Apprise pipeline pushes to its topic;

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -71,6 +71,18 @@
                 <action android:name="org.unifiedpush.android.connector.PUSH_EVENT" />
             </intent-filter>
         </service>
+
+        <receiver
+            android:name=".widget.BellhopWidgetReceiver"
+            android:exported="false"
+            android:label="@string/widget_label">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/bellhop_widget_info" />
+        </receiver>
     </application>
 
 </manifest>

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
@@ -63,6 +63,7 @@ import com.hugalafutro.bellhop.ui.pairing.PairingScreen
 import com.hugalafutro.bellhop.ui.pairing.PairingViewModel
 import com.hugalafutro.bellhop.ui.settings.SettingsScreen
 import com.hugalafutro.bellhop.ui.theme.BellhopTheme
+import com.hugalafutro.bellhop.widget.BellhopWidget
 import com.hugalafutro.bellhop.work.FleetPollWorker
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -249,7 +250,10 @@ fun BellhopApp() {
     // permission. Scheduling the actual poll is left to LinkedContent's effect so
     // the DataStore flag stays the single source of truth for whether it runs.
     fun toggleMonitor(enabled: Boolean) {
-        scope.launch { monitorStore.setEnabled(enabled) }
+        scope.launch {
+            monitorStore.setEnabled(enabled)
+            BellhopWidget.update(context)
+        }
         if (enabled && !hasPostNotificationPermission(context)) {
             notificationPermission.launch(Manifest.permission.POST_NOTIFICATIONS)
         }
@@ -260,7 +264,10 @@ fun BellhopApp() {
     // UnifiedPush register/unregister is left to LinkedContent's effect so the
     // DataStore flag stays the single source of truth, mirroring toggleMonitor.
     fun togglePush(enabled: Boolean) {
-        scope.launch { monitorStore.setPushEnabled(enabled) }
+        scope.launch {
+            monitorStore.setPushEnabled(enabled)
+            BellhopWidget.update(context)
+        }
         if (enabled && !hasPostNotificationPermission(context)) {
             notificationPermission.launch(Manifest.permission.POST_NOTIFICATIONS)
         }
@@ -425,6 +432,8 @@ fun BellhopApp() {
                     monitorStore.clear()
                     // Widget display state is per-link too: a re-pair must not show the old fleet.
                     widgetStore.clear()
+                    // Cleared store must render the unpaired face immediately, not the old fleet.
+                    BellhopWidget.update(context)
                     FleetPollWorker.cancelAll(context)
                     BellhopPush.unregister(context, pushInstance)
                 } else {
@@ -462,6 +471,8 @@ fun BellhopApp() {
                 monitorStore.clear()
                 // Widget display state is per-link too: a re-pair must not show the old fleet.
                 widgetStore.clear()
+                // Cleared store must render the unpaired face immediately, not the old fleet.
+                BellhopWidget.update(context)
                 FleetPollWorker.cancelAll(context)
                 BellhopPush.unregister(context, pushInstance)
             } catch (e: CancellationException) {

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/widget/BellhopWidget.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/widget/BellhopWidget.kt
@@ -1,0 +1,183 @@
+package com.hugalafutro.bellhop.widget
+
+import android.content.Context
+import android.text.format.DateFormat
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.glance.GlanceId
+import androidx.glance.GlanceModifier
+import androidx.glance.ImageProvider
+import androidx.glance.LocalContext
+import androidx.glance.LocalSize
+import androidx.glance.action.actionStartActivity
+import androidx.glance.action.clickable
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.GlanceAppWidgetReceiver
+import androidx.glance.appwidget.SizeMode
+import androidx.glance.appwidget.provideContent
+import androidx.glance.appwidget.updateAll
+import androidx.glance.background
+import androidx.glance.color.ColorProvider
+import androidx.glance.layout.Column
+import androidx.glance.layout.Row
+import androidx.glance.layout.Spacer
+import androidx.glance.layout.fillMaxSize
+import androidx.glance.layout.fillMaxWidth
+import androidx.glance.layout.height
+import androidx.glance.layout.padding
+import androidx.glance.layout.width
+import androidx.glance.text.FontWeight
+import androidx.glance.text.Text
+import androidx.glance.text.TextStyle
+import com.hugalafutro.bellhop.MainActivity
+import com.hugalafutro.bellhop.R
+import com.hugalafutro.bellhop.data.MemberHealthState
+import com.hugalafutro.bellhop.data.MonitorStore
+import com.hugalafutro.bellhop.data.WidgetState
+import com.hugalafutro.bellhop.data.WidgetStore
+import com.hugalafutro.bellhop.data.countsOf
+import com.hugalafutro.bellhop.ui.theme.Brass300
+import com.hugalafutro.bellhop.ui.theme.Brass600
+import com.hugalafutro.bellhop.ui.theme.Ember300
+import com.hugalafutro.bellhop.ui.theme.Ember600
+import com.hugalafutro.bellhop.ui.theme.Ink100
+import com.hugalafutro.bellhop.ui.theme.Ink300
+import com.hugalafutro.bellhop.ui.theme.Moss300
+import com.hugalafutro.bellhop.ui.theme.Moss600
+import com.hugalafutro.bellhop.ui.theme.PaperInk
+import com.hugalafutro.bellhop.ui.theme.PaperInkMuted
+import kotlinx.coroutines.flow.first
+import java.util.Date
+
+/** BellhopWidgetReceiver is the manifest entry point; all logic is in [BellhopWidget]. */
+class BellhopWidgetReceiver : GlanceAppWidgetReceiver() {
+    override val glanceAppWidget: GlanceAppWidget = BellhopWidget()
+}
+
+/**
+ * BellhopWidget renders the persisted [WidgetState] and NOTHING live: no
+ * network, no timers (spec hard rule). It re-renders only when a writer calls
+ * [update] after a store write, or on system broadcasts (placement, reboot).
+ * The "as of" stamp is absolute clock time, never relative, because relative
+ * text would need timed re-renders just to tick.
+ */
+class BellhopWidget : GlanceAppWidget() {
+    override val sizeMode: SizeMode = SizeMode.Responsive(setOf(COMPACT, TALL))
+
+    override suspend fun provideGlance(
+        context: Context,
+        id: GlanceId,
+    ) {
+        // Read once per render; updateAll() re-runs provideGlance, so writers
+        // control freshness and the composition itself stays static.
+        val state = WidgetStore.create(context).read()
+        val monitoringActive = MonitorStore.create(context).active.first()
+        provideContent { WidgetContent(state, monitoringActive) }
+    }
+
+    companion object {
+        // Two responsive tiers: COMPACT = rows + footer; TALL adds the event line.
+        val COMPACT = DpSize(180.dp, 110.dp)
+        val TALL = DpSize(180.dp, 180.dp)
+
+        // Per-member rows up to here; larger fleets collapse to counts.
+        const val MAX_MEMBER_ROWS = 5
+
+        /** update re-renders every placed instance; a no-op when none is placed. */
+        suspend fun update(context: Context) {
+            BellhopWidget().updateAll(context)
+        }
+    }
+}
+
+// Day/night pairs off the app palette (ui/theme/Color.kt); Glance can't read
+// MaterialTheme, so the pairing is repeated here with the same named colors.
+private val TextPrimary = ColorProvider(day = PaperInk, night = Ink100)
+private val TextMuted = ColorProvider(day = PaperInkMuted, night = Ink300)
+private val DotUp = ColorProvider(day = Moss600, night = Moss300)
+private val DotDown = ColorProvider(day = Ember600, night = Ember300)
+private val DotDrained = ColorProvider(day = Brass600, night = Brass300)
+private val DotUnknown = ColorProvider(day = PaperInkMuted, night = Ink300)
+
+private fun dotColor(state: MemberHealthState) =
+    when (state) {
+        MemberHealthState.UP -> DotUp
+        MemberHealthState.DOWN -> DotDown
+        MemberHealthState.DRAINED -> DotDrained
+        MemberHealthState.UNKNOWN -> DotUnknown
+    }
+
+@Composable
+private fun WidgetContent(
+    state: WidgetState?,
+    monitoringActive: Boolean,
+) {
+    val context = LocalContext.current
+    Column(
+        modifier =
+            GlanceModifier
+                .fillMaxSize()
+                .background(ImageProvider(R.drawable.widget_bg))
+                .padding(12.dp)
+                .clickable(actionStartActivity<MainActivity>()),
+    ) {
+        when {
+            state == null ->
+                Text(
+                    context.getString(R.string.widget_unpaired),
+                    style = TextStyle(color = TextMuted, fontSize = 13.sp),
+                )
+            state.members.isEmpty() ->
+                Text(
+                    context.getString(R.string.widget_no_members),
+                    style = TextStyle(color = TextMuted, fontSize = 13.sp),
+                )
+            state.members.size > BellhopWidget.MAX_MEMBER_ROWS -> {
+                val c = countsOf(state)
+                Text(
+                    context.getString(R.string.widget_counts, c.up, c.down, c.drained),
+                    style = TextStyle(color = TextPrimary, fontSize = 14.sp, fontWeight = FontWeight.Medium),
+                )
+            }
+            else ->
+                state.members.forEach { member ->
+                    Row(modifier = GlanceModifier.padding(vertical = 2.dp)) {
+                        Text("●", style = TextStyle(color = dotColor(member.healthState), fontSize = 13.sp))
+                        Spacer(GlanceModifier.width(6.dp))
+                        Text(member.name, style = TextStyle(color = TextPrimary, fontSize = 13.sp), maxLines = 1)
+                    }
+                }
+        }
+        if (state != null && LocalSize.current.height >= BellhopWidget.TALL.height) {
+            state.newestEvent?.let { event ->
+                Spacer(GlanceModifier.height(6.dp))
+                Text(event.message, style = TextStyle(color = TextMuted, fontSize = 11.sp), maxLines = 2)
+            }
+        }
+        Spacer(GlanceModifier.defaultWeight())
+        Row(modifier = GlanceModifier.fillMaxWidth()) {
+            if (state != null) {
+                val stamp = DateFormat.getTimeFormat(context).format(Date(state.updatedAt))
+                Text(
+                    context.getString(R.string.widget_as_of, stamp),
+                    style = TextStyle(color = TextMuted, fontSize = 11.sp),
+                )
+            }
+            Spacer(GlanceModifier.defaultWeight())
+            when {
+                state?.autosyncStale == true ->
+                    Text(
+                        context.getString(R.string.widget_stale),
+                        style = TextStyle(color = DotDrained, fontSize = 11.sp),
+                    )
+                !monitoringActive && state != null ->
+                    Text(
+                        context.getString(R.string.widget_monitoring_off),
+                        style = TextStyle(color = TextMuted, fontSize = 11.sp),
+                    )
+            }
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/work/FleetPollWorker.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/work/FleetPollWorker.kt
@@ -25,6 +25,7 @@ import com.hugalafutro.bellhop.data.diffAutoSync
 import com.hugalafutro.bellhop.data.diffFleet
 import com.hugalafutro.bellhop.data.widgetStateOf
 import com.hugalafutro.bellhop.notify.FleetNotifier
+import com.hugalafutro.bellhop.widget.BellhopWidget
 import kotlinx.coroutines.flow.first
 import java.util.concurrent.TimeUnit
 
@@ -166,17 +167,22 @@ class FleetPollWorker(
 ) : CoroutineWorker(appContext, params) {
     override suspend fun doWork(): Result {
         val context = applicationContext
-        return runBackstop(
-            monitorStore = MonitorStore.create(context),
-            linkStore = LinkStore.create(context),
-            widgetStore = WidgetStore.create(context),
-            client = FrontDeskClient(),
-            canNotify = FleetNotifier.canPost(context),
-            notify = { FleetNotifier.notify(context, it) },
-            // The push one-shot must not retry (see runBackstop): a backing-off
-            // one-shot would block later push wakes under the KEEP policy.
-            retryOnFailure = !inputData.getBoolean(KEY_ONESHOT, false),
-        )
+        val result =
+            runBackstop(
+                monitorStore = MonitorStore.create(context),
+                linkStore = LinkStore.create(context),
+                widgetStore = WidgetStore.create(context),
+                client = FrontDeskClient(),
+                canNotify = FleetNotifier.canPost(context),
+                notify = { FleetNotifier.notify(context, it) },
+                // The push one-shot must not retry (see runBackstop): a backing-off
+                // one-shot would block later push wakes under the KEEP policy.
+                retryOnFailure = !inputData.getBoolean(KEY_ONESHOT, false),
+            )
+        // Re-render after every run: cheap no-op with no widget placed, and a
+        // successful poll just wrote fresh WidgetStore state.
+        BellhopWidget.update(context)
+        return result
     }
 
     companion object {

--- a/android/app/src/main/res/drawable-night/widget_bg.xml
+++ b/android/app/src/main/res/drawable-night/widget_bg.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="#111823" />
+    <corners android:radius="16dp" />
+</shape>

--- a/android/app/src/main/res/drawable/widget_bg.xml
+++ b/android/app/src/main/res/drawable/widget_bg.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="#FAF6EF" />
+    <corners android:radius="16dp" />
+</shape>

--- a/android/app/src/main/res/values-cs/strings.xml
+++ b/android/app/src/main/res/values-cs/strings.xml
@@ -257,4 +257,15 @@
         <item quantity="many">před %d dne</item>
         <item quantity="other">před %d dny</item>
     </plurals>
+
+    <!-- Home-screen widget -->
+    <string name="widget_label">Stav flotily</string>
+    <string name="widget_unpaired">Otevřete Bellhop a spárujte</string>
+    <string name="widget_no_members">Zatím žádní členové</string>
+    <string name="widget_monitoring_off">Sledování vypnuto</string>
+    <!-- %1$s is a clock time, e.g. 14:32 -->
+    <string name="widget_as_of">k %1$s</string>
+    <string name="widget_stale">Synchronizace zastaralá</string>
+    <!-- Collapsed face for large fleets: up/down/drained counts -->
+    <string name="widget_counts">%1$d běží · %2$d mimo · %3$d odstaveno</string>
 </resources>

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -245,4 +245,15 @@
         <item quantity="one">vor %d Tag</item>
         <item quantity="other">vor %d Tagen</item>
     </plurals>
+
+    <!-- Home-screen widget -->
+    <string name="widget_label">Flottenstatus</string>
+    <string name="widget_unpaired">Bellhop öffnen zum Koppeln</string>
+    <string name="widget_no_members">Noch keine Mitglieder</string>
+    <string name="widget_monitoring_off">Überwachung aus</string>
+    <!-- %1$s is a clock time, e.g. 14:32 -->
+    <string name="widget_as_of">Stand %1$s</string>
+    <string name="widget_stale">Sync veraltet</string>
+    <!-- Collapsed face for large fleets: up/down/drained counts -->
+    <string name="widget_counts">%1$d aktiv · %2$d ausgefallen · %3$d stillgelegt</string>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -245,4 +245,15 @@
         <item quantity="one">hace %d día</item>
         <item quantity="other">hace %d días</item>
     </plurals>
+
+    <!-- Home-screen widget -->
+    <string name="widget_label">Estado de la flota</string>
+    <string name="widget_unpaired">Abre Bellhop para emparejar</string>
+    <string name="widget_no_members">Aún sin miembros</string>
+    <string name="widget_monitoring_off">Supervisión desactivada</string>
+    <!-- %1$s is a clock time, e.g. 14:32 -->
+    <string name="widget_as_of">a las %1$s</string>
+    <string name="widget_stale">Sincronización obsoleta</string>
+    <!-- Collapsed face for large fleets: up/down/drained counts -->
+    <string name="widget_counts">%1$d activos · %2$d caídos · %3$d drenados</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -245,4 +245,15 @@
         <item quantity="one">il y a %d jour</item>
         <item quantity="other">il y a %d jours</item>
     </plurals>
+
+    <!-- Home-screen widget -->
+    <string name="widget_label">État de la flotte</string>
+    <string name="widget_unpaired">Ouvrez Bellhop pour appairer</string>
+    <string name="widget_no_members">Aucun membre pour l\'instant</string>
+    <string name="widget_monitoring_off">Surveillance désactivée</string>
+    <!-- %1$s is a clock time, e.g. 14:32 -->
+    <string name="widget_as_of">à %1$s</string>
+    <string name="widget_stale">Synchro périmée</string>
+    <!-- Collapsed face for large fleets: up/down/drained counts -->
+    <string name="widget_counts">%1$d actifs · %2$d hors service · %3$d drainés</string>
 </resources>

--- a/android/app/src/main/res/values-ja/strings.xml
+++ b/android/app/src/main/res/values-ja/strings.xml
@@ -239,4 +239,15 @@
     <plurals name="time_day_ago">
         <item quantity="other">%d 日前</item>
     </plurals>
+
+    <!-- Home-screen widget -->
+    <string name="widget_label">フリートの状態</string>
+    <string name="widget_unpaired">Bellhop を開いてペアリング</string>
+    <string name="widget_no_members">メンバーはまだいません</string>
+    <string name="widget_monitoring_off">監視オフ</string>
+    <!-- %1$s is a clock time, e.g. 14:32 -->
+    <string name="widget_as_of">%1$s 時点</string>
+    <string name="widget_stale">同期が古い</string>
+    <!-- Collapsed face for large fleets: up/down/drained counts -->
+    <string name="widget_counts">稼働 %1$d · ダウン %2$d · ドレイン %3$d</string>
 </resources>

--- a/android/app/src/main/res/values-nl/strings.xml
+++ b/android/app/src/main/res/values-nl/strings.xml
@@ -245,4 +245,15 @@
         <item quantity="one">%d dag geleden</item>
         <item quantity="other">%d dagen geleden</item>
     </plurals>
+
+    <!-- Home-screen widget -->
+    <string name="widget_label">Vlootstatus</string>
+    <string name="widget_unpaired">Open Bellhop om te koppelen</string>
+    <string name="widget_no_members">Nog geen leden</string>
+    <string name="widget_monitoring_off">Bewaking uit</string>
+    <!-- %1$s is a clock time, e.g. 14:32 -->
+    <string name="widget_as_of">per %1$s</string>
+    <string name="widget_stale">Sync verouderd</string>
+    <!-- Collapsed face for large fleets: up/down/drained counts -->
+    <string name="widget_counts">%1$d actief · %2$d offline · %3$d gedraineerd</string>
 </resources>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -257,4 +257,15 @@
         <item quantity="many">%d dni temu</item>
         <item quantity="other">%d dnia temu</item>
     </plurals>
+
+    <!-- Home-screen widget -->
+    <string name="widget_label">Stan floty</string>
+    <string name="widget_unpaired">Otwórz Bellhop, aby sparować</string>
+    <string name="widget_no_members">Brak węzłów</string>
+    <string name="widget_monitoring_off">Monitorowanie wyłączone</string>
+    <!-- %1$s is a clock time, e.g. 14:32 -->
+    <string name="widget_as_of">stan na %1$s</string>
+    <string name="widget_stale">Synchronizacja nieaktualna</string>
+    <!-- Collapsed face for large fleets: up/down/drained counts -->
+    <string name="widget_counts">%1$d działa · %2$d nie działa · %3$d wygaszone</string>
 </resources>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -257,4 +257,15 @@
         <item quantity="many">%d дней назад</item>
         <item quantity="other">%d дня назад</item>
     </plurals>
+
+    <!-- Home-screen widget -->
+    <string name="widget_label">Состояние флота</string>
+    <string name="widget_unpaired">Откройте Bellhop для сопряжения</string>
+    <string name="widget_no_members">Пока нет узлов</string>
+    <string name="widget_monitoring_off">Мониторинг выключен</string>
+    <!-- %1$s is a clock time, e.g. 14:32 -->
+    <string name="widget_as_of">на %1$s</string>
+    <string name="widget_stale">Синхронизация устарела</string>
+    <!-- Collapsed face for large fleets: up/down/drained counts -->
+    <string name="widget_counts">%1$d работает · %2$d недоступно · %3$d выведено</string>
 </resources>

--- a/android/app/src/main/res/values-sk/strings.xml
+++ b/android/app/src/main/res/values-sk/strings.xml
@@ -257,4 +257,15 @@
         <item quantity="many">pred %d dňa</item>
         <item quantity="other">pred %d dňami</item>
     </plurals>
+
+    <!-- Home-screen widget -->
+    <string name="widget_label">Stav flotily</string>
+    <string name="widget_unpaired">Otvorte Bellhop a spárujte</string>
+    <string name="widget_no_members">Zatiaľ žiadni členovia</string>
+    <string name="widget_monitoring_off">Sledovanie vypnuté</string>
+    <!-- %1$s is a clock time, e.g. 14:32 -->
+    <string name="widget_as_of">k %1$s</string>
+    <string name="widget_stale">Synchronizácia zastaraná</string>
+    <!-- Collapsed face for large fleets: up/down/drained counts -->
+    <string name="widget_counts">%1$d beží · %2$d mimo · %3$d odstavené</string>
 </resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -239,4 +239,15 @@
     <plurals name="time_day_ago">
         <item quantity="other">%d 天前</item>
     </plurals>
+
+    <!-- Home-screen widget -->
+    <string name="widget_label">集群状态</string>
+    <string name="widget_unpaired">打开 Bellhop 进行配对</string>
+    <string name="widget_no_members">暂无成员</string>
+    <string name="widget_monitoring_off">监控已关闭</string>
+    <!-- %1$s is a clock time, e.g. 14:32 -->
+    <string name="widget_as_of">截至 %1$s</string>
+    <string name="widget_stale">同步已过期</string>
+    <!-- Collapsed face for large fleets: up/down/drained counts -->
+    <string name="widget_counts">%1$d 运行中 · %2$d 已宕机 · %3$d 已排空</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -249,4 +249,15 @@
     <string name="dashboard_unlink_retry">Try again</string>
     <string name="dashboard_unlink_force">Unlink anyway</string>
     <string name="common_cancel">Cancel</string>
+
+    <!-- Home-screen widget -->
+    <string name="widget_label">Fleet status</string>
+    <string name="widget_unpaired">Open Bellhop to pair</string>
+    <string name="widget_no_members">No members yet</string>
+    <string name="widget_monitoring_off">Monitoring off</string>
+    <!-- %1$s is a clock time, e.g. 14:32 -->
+    <string name="widget_as_of">as of %1$s</string>
+    <string name="widget_stale">Sync stale</string>
+    <!-- Collapsed face for large fleets: up/down/drained counts -->
+    <string name="widget_counts">%1$d up · %2$d down · %3$d drained</string>
 </resources>

--- a/android/app/src/main/res/xml/bellhop_widget_info.xml
+++ b/android/app/src/main/res/xml/bellhop_widget_info.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- updatePeriodMillis=0: NEVER auto-refresh. All refreshes come from
+     WidgetStore writers calling BellhopWidget.update, per the no-new-polling rule:
+     the widget renders persisted state only and never fetches on its own. -->
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:minWidth="180dp"
+    android:minHeight="110dp"
+    android:targetCellWidth="3"
+    android:targetCellHeight="2"
+    android:resizeMode="horizontal|vertical"
+    android:widgetCategory="home_screen"
+    android:updatePeriodMillis="0"
+    android:initialLayout="@layout/glance_default_loading_layout"
+    tools:targetApi="s" />

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -20,6 +20,9 @@ work = "2.9.1"
 # 3.1.0+ ship Kotlin 2.2/2.3 metadata the 2.1.0 compiler can't read. 3.0.10 has
 # the full PushService API we use and stdlib 2.0.21, which resolves cleanly here.
 unifiedpush = "3.0.10"
+# Last stable Glance; built against Compose runtime 1.7.x / pre-2.2 Kotlin
+# metadata, so it resolves cleanly under this project's Kotlin 2.1.0.
+glance = "1.1.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -47,6 +50,7 @@ zxing-android-embedded = { group = "com.journeyapps", name = "zxing-android-embe
 androidx-biometric = { group = "androidx.biometric", name = "biometric", version.ref = "biometric" }
 androidx-fragment = { group = "androidx.fragment", name = "fragment-ktx", version.ref = "fragment" }
 androidx-work-runtime = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "work" }
+androidx-glance-appwidget = { group = "androidx.glance", name = "glance-appwidget", version.ref = "glance" }
 unifiedpush-connector = { group = "org.unifiedpush.android", name = "connector", version.ref = "unifiedpush" }
 
 [plugins]


### PR DESCRIPTION
Slice 2 of the Bellhop home-screen widget (data layer merged in #512): the widget itself.

- `androidx.glance:glance-appwidget` pinned 1.1.1 (last stable; resolves cleanly under Kotlin 2.1.0 / Compose runtime 1.7.6, verified via dependency graph, no version drift).
- `widget/BellhopWidget.kt`: GlanceAppWidget rendering persisted WidgetStore state only. No network, no timers, `updatePeriodMillis=0` — every render is pushed by app code after a store write. Responsive two tiers (compact rows / tall adds newest-event line), per-member rows with health dots up to 5 members then up/down/drained counts, autosync-stale badge, monitoring-off hint, absolute-time "as of" stamp (relative text would need timed re-renders, refused by design). Body tap opens the app.
- Update triggers wired: worker doWork (periodic + push wakes), monitoring/push toggles, unlink clearing.
- 7 widget strings in base + all 10 locales, terminology matched to each locale's existing fleet/member/drained wording; day/night background drawables off the app palette.

Emulator-verified end to end (mock FD): placement, unpaired face, tap-to-open, pair, organic 15-min background poll wrote the store and re-rendered the widget — rows with correct dot colors (Up green / Down ember / Drained brass), newest-event line, "as of" stamp, Sync stale badge, in dark and light mode.

No new unit tests by design: the render is logic-free; the mapping/counts/collapse logic it draws on is pinned by the slice-1 suites.

Slice 3 (refresh button + foreground mirror) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)