### PR TITLE
feat(bellhop): widget refresh + foreground mirror (interactions slice)

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -7,7 +7,11 @@ to that FD; it never holds a member Model Hotel token. The full design lives in
 
 Current status: in active use. Pairing (QR/code), the live dashboard and member
 detail, background monitoring, push notifications, operator actions, an app lock,
-alerts, an event log, a settings screen, and full internationalisation have shipped.
+alerts, an event log, a settings screen, full internationalisation, and a
+home-screen widget have shipped. The widget renders persisted fleet state only:
+its updates piggyback on fetches the app already makes (background poll, push
+wakes, foreground refresh) plus a manual refresh button; it never polls on its
+own, so it adds no battery cost.
 
 ## Stack
 

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
@@ -521,6 +521,7 @@ fun BellhopApp() {
                         state = state,
                         client = client,
                         linkStore = linkStore,
+                        widgetStore = widgetStore,
                         lockStore = lockStore,
                         lockConfig = lockConfig,
                         lockAvailable = lockAvailable,
@@ -568,6 +569,7 @@ private fun LinkedContent(
     state: LinkState.Linked,
     client: FrontDeskClient,
     linkStore: LinkStore,
+    widgetStore: WidgetStore,
     lockStore: LockStore,
     lockConfig: LockConfig,
     lockAvailable: Boolean,
@@ -633,7 +635,14 @@ private fun LinkedContent(
     val dashVm: DashboardViewModel =
         viewModel(
             key = "dashboard-${state.fdUrl}|${state.deviceId}",
-            factory = DashboardViewModel.Factory(client, linkStore, state.fdUrl),
+            factory =
+                DashboardViewModel.Factory(
+                    client,
+                    linkStore,
+                    state.fdUrl,
+                    widgetStore,
+                    onWidgetWritten = { BellhopWidget.update(monitorContext.applicationContext) },
+                ),
         )
     val ui by dashVm.state.collectAsStateWithLifecycle()
     // Feed the Settings graph-range pref into the dashboard VM; a change

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModel.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModel.kt
@@ -13,6 +13,8 @@ import com.hugalafutro.bellhop.data.LinkStore
 import com.hugalafutro.bellhop.data.MemberTraffic
 import com.hugalafutro.bellhop.data.PrefsStore
 import com.hugalafutro.bellhop.data.SseMessage
+import com.hugalafutro.bellhop.data.WidgetStore
+import com.hugalafutro.bellhop.data.widgetStateOf
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
@@ -95,6 +97,10 @@ class DashboardViewModel(
     private val client: FrontDeskClient,
     private val linkStore: LinkStore,
     private val fdUrl: String,
+    private val widgetStore: WidgetStore,
+    // Called after a refresh writes a changed widget state, so the caller can
+    // trigger a Glance re-render (default no-op keeps unit tests off the widget).
+    private val onWidgetWritten: suspend () -> Unit = {},
     private val pollIntervalMs: Long = POLL_INTERVAL_MS,
     private val sseHealthyPollIntervalMs: Long = SSE_HEALTHY_POLL_INTERVAL_MS,
     private val trafficPollMs: Long = TRAFFIC_POLL_MS,
@@ -397,6 +403,11 @@ class DashboardViewModel(
             _state.update { it.copy(loading = false, revoked = true) }
             return
         }
+        // Widget write fence, captured before the fetch (same pattern as the
+        // background poll): an unlink mid-refresh stamps a fresh generation, so
+        // this refresh's late display write is dropped instead of resurrecting the
+        // old fleet (see WidgetStore).
+        val widgetGeneration = widgetStore.generation()
         when (val result = client.members(fdUrl, token)) {
             is FetchResult.Success -> {
                 val autoSync = client.autoSync(fdUrl, token) as? FetchResult.Success
@@ -477,6 +488,17 @@ class DashboardViewModel(
                     )
                 }
                 trafficFetchedAt.keys.retainAll(liveIds)
+                // Mirror this refresh into the home-screen widget so it rides the
+                // existing fetch (the no-new-polling rule) instead of ever fetching
+                // itself. Fenced by the generation captured before the fetch; the
+                // autosync flag falls back to the stored value when its read failed
+                // so a transient miss doesn't flip the widget's badge. Only a real
+                // change (saveIfChanged returns true) triggers a Glance re-render,
+                // so the dashboard's fast poll cadence doesn't re-render every tick.
+                val autosyncStale = autoSync?.data?.stale ?: widgetStore.read()?.autosyncStale ?: false
+                if (widgetStore.saveIfChanged(widgetStateOf(result.data, autosyncStale, now()), widgetGeneration)) {
+                    onWidgetWritten()
+                }
             }
             FetchResult.Unauthorized ->
                 _state.update { it.copy(loading = false, revoked = true) }
@@ -543,9 +565,12 @@ class DashboardViewModel(
         private val client: FrontDeskClient,
         private val linkStore: LinkStore,
         private val fdUrl: String,
+        private val widgetStore: WidgetStore,
+        private val onWidgetWritten: suspend () -> Unit = {},
     ) : ViewModelProvider.Factory {
         @Suppress("UNCHECKED_CAST")
-        override fun <T : ViewModel> create(modelClass: Class<T>): T = DashboardViewModel(client, linkStore, fdUrl) as T
+        override fun <T : ViewModel> create(modelClass: Class<T>): T =
+            DashboardViewModel(client, linkStore, fdUrl, widgetStore, onWidgetWritten) as T
     }
 
     companion object {

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/widget/BellhopWidget.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/widget/BellhopWidget.kt
@@ -8,14 +8,18 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.glance.GlanceId
 import androidx.glance.GlanceModifier
+import androidx.glance.Image
 import androidx.glance.ImageProvider
 import androidx.glance.LocalContext
 import androidx.glance.LocalSize
+import androidx.glance.action.ActionParameters
 import androidx.glance.action.actionStartActivity
 import androidx.glance.action.clickable
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.GlanceAppWidgetReceiver
 import androidx.glance.appwidget.SizeMode
+import androidx.glance.appwidget.action.ActionCallback
+import androidx.glance.appwidget.action.actionRunCallback
 import androidx.glance.appwidget.provideContent
 import androidx.glance.appwidget.updateAll
 import androidx.glance.background
@@ -27,6 +31,7 @@ import androidx.glance.layout.fillMaxSize
 import androidx.glance.layout.fillMaxWidth
 import androidx.glance.layout.height
 import androidx.glance.layout.padding
+import androidx.glance.layout.size
 import androidx.glance.layout.width
 import androidx.glance.text.FontWeight
 import androidx.glance.text.Text
@@ -48,6 +53,7 @@ import com.hugalafutro.bellhop.ui.theme.Moss300
 import com.hugalafutro.bellhop.ui.theme.Moss600
 import com.hugalafutro.bellhop.ui.theme.PaperInk
 import com.hugalafutro.bellhop.ui.theme.PaperInkMuted
+import com.hugalafutro.bellhop.work.FleetPollWorker
 import kotlinx.coroutines.flow.first
 import java.util.Date
 
@@ -89,6 +95,22 @@ class BellhopWidget : GlanceAppWidget() {
         suspend fun update(context: Context) {
             BellhopWidget().updateAll(context)
         }
+    }
+}
+
+/**
+ * WidgetRefreshAction hands the tap off to WorkManager and returns; the
+ * poll's own completion re-renders the widget via [FleetPollWorker]'s update
+ * call, so the action itself stays instant and the widget never blocks on
+ * the network.
+ */
+class WidgetRefreshAction : ActionCallback {
+    override suspend fun onAction(
+        context: Context,
+        glanceId: GlanceId,
+        parameters: ActionParameters,
+    ) {
+        FleetPollWorker.runWidgetRefresh(context)
     }
 }
 
@@ -177,6 +199,14 @@ private fun WidgetContent(
                         context.getString(R.string.widget_monitoring_off),
                         style = TextStyle(color = TextMuted, fontSize = 11.sp),
                     )
+            }
+            if (state != null) {
+                Spacer(GlanceModifier.width(8.dp))
+                Image(
+                    ImageProvider(R.drawable.ic_widget_refresh),
+                    context.getString(R.string.widget_refresh),
+                    GlanceModifier.size(18.dp).clickable(actionRunCallback<WidgetRefreshAction>()),
+                )
             }
         }
     }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/widget/BellhopWidget.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/widget/BellhopWidget.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.glance.ColorFilter
 import androidx.glance.GlanceId
 import androidx.glance.GlanceModifier
 import androidx.glance.Image
@@ -206,6 +207,9 @@ private fun WidgetContent(
                     ImageProvider(R.drawable.ic_widget_refresh),
                     context.getString(R.string.widget_refresh),
                     GlanceModifier.size(18.dp).clickable(actionRunCallback<WidgetRefreshAction>()),
+                    // The vector's fill is opaque black; tint to the footer's muted
+                    // pair or the icon vanishes on the night background.
+                    colorFilter = ColorFilter.tint(TextMuted),
                 )
             }
         }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/work/FleetPollWorker.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/work/FleetPollWorker.kt
@@ -153,6 +153,39 @@ suspend fun runBackstop(
 }
 
 /**
+ * refreshWidgetOnly is the widget refresh button's poll: fetch and persist the
+ * DISPLAY state, and nothing else. Deliberately not [runBackstop]: this work runs
+ * even when monitoring is off and notifications are blocked (it renders, it does
+ * not page), it never notifies the user (they are looking at the widget), and it
+ * never touches the alert baseline, so a member found down here still alerts on
+ * the next backstop poll. It always ends in success: a user-initiated one-shot
+ * must not hold the unique-work slot in a retry backoff, and the stale stamp
+ * already tells the truth about a failed refresh.
+ */
+suspend fun refreshWidgetOnly(
+    linkStore: LinkStore,
+    widgetStore: WidgetStore,
+    client: FrontDeskClient,
+    now: () -> Long = System::currentTimeMillis,
+): Result {
+    val link = linkStore.state.first()
+    if (link !is LinkState.Linked) return Result.success()
+    val token = linkStore.token() ?: return Result.success()
+    // Write fence captured before the fetch (same pattern as pollFleet): an
+    // unlink mid-refresh stamps a fresh generation and this write is dropped.
+    val generation = widgetStore.generation()
+    val result = client.members(link.fdUrl, token)
+    if (result is FetchResult.Success) {
+        val stale =
+            (client.autoSync(link.fdUrl, token) as? FetchResult.Success)?.data?.stale
+                ?: widgetStore.read()?.autosyncStale
+                ?: false
+        widgetStore.saveIfChanged(widgetStateOf(result.data, stale, now()), generation)
+    }
+    return Result.success()
+}
+
+/**
  * FleetPollWorker is the Layer-2 background backstop (plan section 5.2): a periodic
  * poll that, while Bellhop is backgrounded or killed, diffs fleet health against
  * the last poll and posts a local notification on a member going down or
@@ -167,6 +200,19 @@ class FleetPollWorker(
 ) : CoroutineWorker(appContext, params) {
     override suspend fun doWork(): Result {
         val context = applicationContext
+        // The widget refresh tap is a display-only one-shot: no monitor guards, no
+        // notify, no alert baseline. It still re-renders the widget afterwards, the
+        // same as a backstop run does below.
+        if (inputData.getBoolean(KEY_WIDGET, false)) {
+            val result =
+                refreshWidgetOnly(
+                    LinkStore.create(context),
+                    WidgetStore.create(context),
+                    FrontDeskClient(),
+                )
+            BellhopWidget.update(context)
+            return result
+        }
         val result =
             runBackstop(
                 monitorStore = MonitorStore.create(context),
@@ -188,7 +234,9 @@ class FleetPollWorker(
     companion object {
         private const val UNIQUE_NAME = "fleet-poll"
         private const val ONESHOT_NAME = "fleet-poll-now"
+        private const val WIDGET_NAME = "widget-refresh"
         private const val KEY_ONESHOT = "oneshot"
+        private const val KEY_WIDGET = "widget"
 
         // The 15-minute WorkManager floor is the shortest periodic interval Android
         // allows; the backstop is explicitly not real-time (plan section 5.2).
@@ -244,6 +292,28 @@ class FleetPollWorker(
         }
 
         /**
+         * runWidgetRefresh enqueues the widget refresh button's one-shot. KEEP
+         * coalesces tap-spam onto one in-flight poll; expedited with a non-expedited
+         * fallback, the same as [runNow]. A distinct unique name from the push wake
+         * so a widget tap can't coalesce away a pending push poll (or vice versa).
+         */
+        fun runWidgetRefresh(context: Context) {
+            val request =
+                OneTimeWorkRequestBuilder<FleetPollWorker>()
+                    .setConstraints(
+                        Constraints
+                            .Builder()
+                            .setRequiredNetworkType(NetworkType.CONNECTED)
+                            .build(),
+                    ).setInputData(workDataOf(KEY_WIDGET to true))
+                    .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+                    .build()
+            WorkManager
+                .getInstance(context)
+                .enqueueUniqueWork(WIDGET_NAME, ExistingWorkPolicy.KEEP, request)
+        }
+
+        /**
          * cancel stops ONLY the periodic poll, used when Layer-2 monitoring is
          * turned off. It deliberately leaves the push one-shot alone: push-only mode
          * (Layer 2 off, Layer 3 on) is supported, so cancelling a queued or running
@@ -264,6 +334,7 @@ class FleetPollWorker(
             val wm = WorkManager.getInstance(context)
             wm.cancelUniqueWork(UNIQUE_NAME)
             wm.cancelUniqueWork(ONESHOT_NAME)
+            wm.cancelUniqueWork(WIDGET_NAME)
         }
     }
 }

--- a/android/app/src/main/res/drawable/ic_widget_refresh.xml
+++ b/android/app/src/main/res/drawable/ic_widget_refresh.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M17.65,6.35C16.2,4.9 14.21,4 12,4c-4.42,0 -7.99,3.58 -7.99,8s3.57,8 7.99,8c3.73,0 6.84,-2.55 7.73,-6h-2.08c-0.82,2.33 -3.04,4 -5.65,4 -3.31,0 -6,-2.69 -6,-6s2.69,-6 6,-6c1.66,0 3.14,0.69 4.22,1.78L13,11h7V4l-2.35,2.35z" />
+</vector>

--- a/android/app/src/main/res/values-cs/strings.xml
+++ b/android/app/src/main/res/values-cs/strings.xml
@@ -268,4 +268,5 @@
     <string name="widget_stale">Synchronizace zastaralá</string>
     <!-- Collapsed face for large fleets: up/down/drained counts -->
     <string name="widget_counts">%1$d běží · %2$d mimo · %3$d odstaveno</string>
+    <string name="widget_refresh">Obnovit</string>
 </resources>

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -256,4 +256,5 @@
     <string name="widget_stale">Sync veraltet</string>
     <!-- Collapsed face for large fleets: up/down/drained counts -->
     <string name="widget_counts">%1$d aktiv · %2$d ausgefallen · %3$d stillgelegt</string>
+    <string name="widget_refresh">Aktualisieren</string>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -256,4 +256,5 @@
     <string name="widget_stale">Sincronización obsoleta</string>
     <!-- Collapsed face for large fleets: up/down/drained counts -->
     <string name="widget_counts">%1$d activos · %2$d caídos · %3$d drenados</string>
+    <string name="widget_refresh">Actualizar</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -256,4 +256,5 @@
     <string name="widget_stale">Synchro périmée</string>
     <!-- Collapsed face for large fleets: up/down/drained counts -->
     <string name="widget_counts">%1$d actifs · %2$d hors service · %3$d drainés</string>
+    <string name="widget_refresh">Actualiser</string>
 </resources>

--- a/android/app/src/main/res/values-ja/strings.xml
+++ b/android/app/src/main/res/values-ja/strings.xml
@@ -250,4 +250,5 @@
     <string name="widget_stale">同期が古い</string>
     <!-- Collapsed face for large fleets: up/down/drained counts -->
     <string name="widget_counts">稼働 %1$d · ダウン %2$d · ドレイン %3$d</string>
+    <string name="widget_refresh">更新</string>
 </resources>

--- a/android/app/src/main/res/values-nl/strings.xml
+++ b/android/app/src/main/res/values-nl/strings.xml
@@ -256,4 +256,5 @@
     <string name="widget_stale">Sync verouderd</string>
     <!-- Collapsed face for large fleets: up/down/drained counts -->
     <string name="widget_counts">%1$d actief · %2$d offline · %3$d gedraineerd</string>
+    <string name="widget_refresh">Vernieuwen</string>
 </resources>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -268,4 +268,5 @@
     <string name="widget_stale">Synchronizacja nieaktualna</string>
     <!-- Collapsed face for large fleets: up/down/drained counts -->
     <string name="widget_counts">%1$d działa · %2$d nie działa · %3$d wygaszone</string>
+    <string name="widget_refresh">Odśwież</string>
 </resources>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -268,4 +268,5 @@
     <string name="widget_stale">Синхронизация устарела</string>
     <!-- Collapsed face for large fleets: up/down/drained counts -->
     <string name="widget_counts">%1$d работает · %2$d недоступно · %3$d выведено</string>
+    <string name="widget_refresh">Обновить</string>
 </resources>

--- a/android/app/src/main/res/values-sk/strings.xml
+++ b/android/app/src/main/res/values-sk/strings.xml
@@ -268,4 +268,5 @@
     <string name="widget_stale">Synchronizácia zastaraná</string>
     <!-- Collapsed face for large fleets: up/down/drained counts -->
     <string name="widget_counts">%1$d beží · %2$d mimo · %3$d odstavené</string>
+    <string name="widget_refresh">Obnoviť</string>
 </resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -250,4 +250,5 @@
     <string name="widget_stale">同步已过期</string>
     <!-- Collapsed face for large fleets: up/down/drained counts -->
     <string name="widget_counts">%1$d 运行中 · %2$d 已宕机 · %3$d 已排空</string>
+    <string name="widget_refresh">刷新</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -260,4 +260,5 @@
     <string name="widget_stale">Sync stale</string>
     <!-- Collapsed face for large fleets: up/down/drained counts -->
     <string name="widget_counts">%1$d up · %2$d down · %3$d drained</string>
+    <string name="widget_refresh">Refresh</string>
 </resources>

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModelTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModelTest.kt
@@ -17,6 +17,7 @@ import com.hugalafutro.bellhop.data.MemberStatus
 import com.hugalafutro.bellhop.data.MemberTraffic
 import com.hugalafutro.bellhop.data.PairedDevice
 import com.hugalafutro.bellhop.data.SseMessage
+import com.hugalafutro.bellhop.data.WidgetStore
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.awaitCancellation
@@ -190,6 +191,49 @@ class DashboardViewModelTest {
             status = MemberStatus(health = HealthStatus(known = true, healthy = true, latencyMs = 5)),
         )
 
+    // Builds a DashboardViewModel with the widget wiring defaulted, so the existing
+    // tests read exactly as their old direct construction did: the widget mirror
+    // lands in a throwaway in-memory store and signals nothing. Tests that assert on
+    // the widget pass their own store and onWidgetWritten.
+    private suspend fun viewModel(
+        client: FrontDeskClient = FakeFleetClient(FetchResult.Success(listOf(member))),
+        linkStore: LinkStore? = null,
+        fdUrl: String = "http://fd:1",
+        widgetStore: WidgetStore = WidgetStore(InMemoryPreferencesDataStore()),
+        onWidgetWritten: suspend () -> Unit = {},
+        pollIntervalMs: Long = DashboardViewModel.POLL_INTERVAL_MS,
+        sseHealthyPollIntervalMs: Long = DashboardViewModel.SSE_HEALTHY_POLL_INTERVAL_MS,
+        trafficPollMs: Long = DashboardViewModel.TRAFFIC_POLL_MS,
+        now: () -> Long = System::currentTimeMillis,
+    ): DashboardViewModel =
+        DashboardViewModel(
+            client,
+            linkStore ?: linkedStore(),
+            fdUrl,
+            widgetStore,
+            onWidgetWritten,
+            pollIntervalMs,
+            sseHealthyPollIntervalMs,
+            trafficPollMs,
+            now,
+        )
+
+    @Test
+    fun refreshWritesWidgetStateAndSignalsOnChange() =
+        runBlocking {
+            val widget = WidgetStore(InMemoryPreferencesDataStore())
+            var signals = 0
+            val vm = viewModel(widgetStore = widget, onWidgetWritten = { signals++ })
+
+            vm.refreshOnce()
+            assertEquals(1, signals)
+            assertEquals("hotel-1", widget.read()?.members?.single()?.name)
+
+            // The same data again inside the stamp window: no write, no re-render signal.
+            vm.refreshOnce()
+            assertEquals(1, signals)
+        }
+
     @Test
     fun refreshPopulatesMembersAndPrimaryWithStoredToken() =
         runBlocking {
@@ -198,7 +242,7 @@ class DashboardViewModelTest {
                     membersResult = FetchResult.Success(listOf(member)),
                     autoSyncResult = FetchResult.Success(AutoSyncConfig(enabled = true, primaryId = "m1")),
                 )
-            val vm = DashboardViewModel(client, linkedStore(), "http://fd:1")
+            val vm = viewModel(client, linkedStore(), "http://fd:1")
 
             vm.refreshOnce()
 
@@ -231,7 +275,7 @@ class DashboardViewModelTest {
                         ),
                     "m2" to listOf(FdEvent(id = "e2", memberId = "m2", message = "only m2")),
                 )
-            val vm = DashboardViewModel(client, linkedStore(), "http://fd:1")
+            val vm = viewModel(client, linkedStore(), "http://fd:1")
 
             vm.refreshOnce()
 
@@ -250,7 +294,7 @@ class DashboardViewModelTest {
                     autoSyncResult = FetchResult.Success(AutoSyncConfig(enabled = true, primaryId = "m1")),
                 )
             // No per-member events configured, so the map stays empty (no pill).
-            val vm = DashboardViewModel(client, linkedStore(), "http://fd:1")
+            val vm = viewModel(client, linkedStore(), "http://fd:1")
 
             vm.refreshOnce()
 
@@ -274,7 +318,7 @@ class DashboardViewModelTest {
                     membersResult = FetchResult.Success(listOf(m1, m2)),
                     autoSyncResult = FetchResult.Success(AutoSyncConfig(enabled = true, primaryId = "m1")),
                 )
-            val vm = DashboardViewModel(client, linkedStore(), "http://fd:1")
+            val vm = viewModel(client, linkedStore(), "http://fd:1")
 
             vm.refreshOnce()
 
@@ -295,7 +339,7 @@ class DashboardViewModelTest {
                     autoSyncResult = FetchResult.Success(AutoSyncConfig(enabled = true, primaryId = "m1")),
                 )
             client.eventsByMember = mapOf("m1" to listOf(FdEvent(id = "e1", memberId = "m1", message = "fetched m1")))
-            val vm = DashboardViewModel(client, linkedStore(), "http://fd:1")
+            val vm = viewModel(client, linkedStore(), "http://fd:1")
 
             vm.refreshOnce()
 
@@ -314,7 +358,7 @@ class DashboardViewModelTest {
         runBlocking {
             val client = autoSyncClient(enabled = true)
             client.setAutoSyncResult = ActionResult.Success(AutoSyncConfig(enabled = false, primaryId = "m1"))
-            val vm = DashboardViewModel(client, linkedStore(), "http://fd:1")
+            val vm = viewModel(client, linkedStore(), "http://fd:1")
             vm.refreshOnce()
             assertTrue(vm.state.value.autoSyncEnabled)
 
@@ -338,7 +382,7 @@ class DashboardViewModelTest {
         runBlocking {
             val client = autoSyncClient(enabled = true)
             client.setAutoSyncResult = ActionResult.Success(AutoSyncConfig(enabled = false, primaryId = "m1"))
-            val vm = DashboardViewModel(client, linkedStore(), "http://fd:1")
+            val vm = viewModel(client, linkedStore(), "http://fd:1")
             vm.refreshOnce()
 
             vm.setAutoSync(false)
@@ -359,7 +403,7 @@ class DashboardViewModelTest {
         runBlocking {
             val client = autoSyncClient()
             client.setAutoSyncResult = ActionResult.Forbidden
-            val vm = DashboardViewModel(client, linkedStore(), "http://fd:1")
+            val vm = viewModel(client, linkedStore(), "http://fd:1")
             vm.refreshOnce()
 
             vm.setAutoSync(false)
@@ -372,7 +416,7 @@ class DashboardViewModelTest {
         runBlocking {
             val client = autoSyncClient()
             client.setAutoSyncResult = ActionResult.Unauthorized
-            val vm = DashboardViewModel(client, linkedStore(), "http://fd:1")
+            val vm = viewModel(client, linkedStore(), "http://fd:1")
             vm.refreshOnce()
 
             vm.setAutoSync(false)
@@ -385,7 +429,7 @@ class DashboardViewModelTest {
         runBlocking {
             val client = autoSyncClient()
             client.setAutoSyncResult = ActionResult.Failure("boom")
-            val vm = DashboardViewModel(client, linkedStore(), "http://fd:1")
+            val vm = viewModel(client, linkedStore(), "http://fd:1")
             vm.refreshOnce()
 
             vm.setAutoSync(false)
@@ -404,7 +448,7 @@ class DashboardViewModelTest {
                     membersResult = FetchResult.Success(listOf(member)),
                     autoSyncResult = FetchResult.Success(AutoSyncConfig(enabled = false, primaryId = "")),
                 )
-            val vm = DashboardViewModel(client, linkedStore(), "http://fd:1")
+            val vm = viewModel(client, linkedStore(), "http://fd:1")
             vm.refreshOnce()
 
             vm.setAutoSync(true)
@@ -415,7 +459,7 @@ class DashboardViewModelTest {
     fun failedRefreshKeepsStaleMembersAndRecovers() =
         runBlocking {
             val client = FakeFleetClient(FetchResult.Success(listOf(member)))
-            val vm = DashboardViewModel(client, linkedStore(), "http://fd:1")
+            val vm = viewModel(client, linkedStore(), "http://fd:1")
             vm.refreshOnce()
 
             // Stale beats blank: the last good list stays, the error surfaces.
@@ -446,7 +490,7 @@ class DashboardViewModelTest {
                             ),
                         ),
                 )
-            val vm = DashboardViewModel(client, linkedStore(), "http://fd:1")
+            val vm = viewModel(client, linkedStore(), "http://fd:1")
 
             vm.refreshOnce()
 
@@ -471,7 +515,7 @@ class DashboardViewModelTest {
                             ),
                         ),
                 )
-            val vm = DashboardViewModel(client, linkedStore(), "http://fd:1")
+            val vm = viewModel(client, linkedStore(), "http://fd:1")
             vm.refreshOnce()
             assertEquals("degraded", vm.state.value.fleetState)
 
@@ -499,7 +543,7 @@ class DashboardViewModelTest {
                             MemberTraffic(memberId = "m1", reachable = true, totalRequests = 5),
                         ),
                 )
-            val vm = DashboardViewModel(client, linkedStore(), "http://fd:1")
+            val vm = viewModel(client, linkedStore(), "http://fd:1")
             val job = launch { vm.state.collect {} }
             withTimeout(5_000) { vm.state.first { it.members.size == 2 } }
 
@@ -520,7 +564,7 @@ class DashboardViewModelTest {
             val client = FakeFleetClient(FetchResult.Success(listOf(member)))
             client.trafficResults =
                 mapOf("m1" to FetchResult.Success(MemberTraffic(memberId = "m1", reachable = true)))
-            val vm = DashboardViewModel(client, linkedStore(), "http://fd:1", trafficPollMs = 40)
+            val vm = viewModel(client, linkedStore(), "http://fd:1", trafficPollMs = 40)
             val job = launch { vm.state.collect {} }
             vm.setVisibleMembers(listOf("m1"))
             // The periodic fetch ticks while the dashboard is shown.
@@ -551,7 +595,7 @@ class DashboardViewModelTest {
                 mapOf("m1" to FetchResult.Success(MemberTraffic(memberId = "m1", reachable = true)))
             // A long poll keeps the periodic tick out of the window so only the
             // range change could move the count.
-            val vm = DashboardViewModel(client, linkedStore(), "http://fd:1", trafficPollMs = 10_000)
+            val vm = viewModel(client, linkedStore(), "http://fd:1", trafficPollMs = 10_000)
             val job = launch { vm.state.collect {} }
             vm.setVisibleMembers(listOf("m1"))
             withTimeout(5_000) { while (client.trafficFetched.isEmpty()) delay(20) }
@@ -573,7 +617,7 @@ class DashboardViewModelTest {
             val client = FakeFleetClient(FetchResult.Success(listOf(member)))
             client.trafficResults =
                 mapOf("m1" to FetchResult.Success(MemberTraffic(memberId = "m1", reachable = true)))
-            val vm = DashboardViewModel(client, linkedStore(), "http://fd:1")
+            val vm = viewModel(client, linkedStore(), "http://fd:1")
             val job = launch { vm.state.collect {} }
             withTimeout(5_000) { vm.state.first { it.members.size == 1 } }
 
@@ -597,7 +641,7 @@ class DashboardViewModelTest {
                 mapOf("m1" to FetchResult.Success(MemberTraffic(memberId = "m1", reachable = true)))
             // Park the initial default-window fetch so it stays in flight.
             client.firstTrafficGate = CompletableDeferred()
-            val vm = DashboardViewModel(client, linkedStore(), "http://fd:1")
+            val vm = viewModel(client, linkedStore(), "http://fd:1")
             val job = launch { vm.state.collect {} }
             withTimeout(5_000) { vm.state.first { it.members.size == 1 } }
 
@@ -618,7 +662,7 @@ class DashboardViewModelTest {
     @Test
     fun unauthorizedFlagsRevoked() =
         runBlocking {
-            val vm = DashboardViewModel(FakeFleetClient(FetchResult.Unauthorized), linkedStore(), "http://fd:1")
+            val vm = viewModel(FakeFleetClient(FetchResult.Unauthorized), linkedStore(), "http://fd:1")
             vm.refreshOnce()
             assertTrue(vm.state.value.revoked)
             assertFalse(vm.state.value.loading)
@@ -634,7 +678,7 @@ class DashboardViewModelTest {
                 FakeFleetClient(membersResult = FetchResult.Success(listOf(member))).apply {
                     eventsResult = FetchResult.Unauthorized
                 }
-            val vm = DashboardViewModel(client, linkedStore(), "http://fd:1")
+            val vm = viewModel(client, linkedStore(), "http://fd:1")
             vm.refreshOnce()
             assertTrue(vm.state.value.revoked)
             assertFalse(vm.state.value.loading)
@@ -646,7 +690,7 @@ class DashboardViewModelTest {
             // Linked metadata without a readable token (e.g. lost Keystore key):
             // no request can succeed, so don't make one.
             val client = FakeFleetClient(FetchResult.Success(listOf(member)))
-            val vm = DashboardViewModel(client, newLinkStore(), "http://fd:1")
+            val vm = viewModel(client, newLinkStore(), "http://fd:1")
             vm.refreshOnce()
             assertTrue(vm.state.value.revoked)
             assertNull(client.lastToken)
@@ -661,7 +705,7 @@ class DashboardViewModelTest {
                     membersResult = FetchResult.Success(listOf(member)),
                     autoSyncResult = FetchResult.Failure("nope"),
                 )
-            val vm = DashboardViewModel(client, linkedStore(), "http://fd:1")
+            val vm = viewModel(client, linkedStore(), "http://fd:1")
             vm.refreshOnce()
             val s = vm.state.value
             assertEquals(listOf(member), s.members)
@@ -675,7 +719,7 @@ class DashboardViewModelTest {
             // The poll loop is gated on collectors; the first collector must
             // trigger a refresh on its own, with no manual refreshOnce call.
             val client = FakeFleetClient(FetchResult.Success(listOf(member)))
-            val vm = DashboardViewModel(client, linkedStore(), "http://fd:1")
+            val vm = viewModel(client, linkedStore(), "http://fd:1")
 
             val s = withTimeout(5_000) { vm.state.first { !it.loading } }
             assertEquals(listOf(member), s.members)
@@ -688,7 +732,7 @@ class DashboardViewModelTest {
             // through without waiting for the slow fallback poll.
             val events = MutableSharedFlow<SseMessage>(extraBufferCapacity = 8)
             val client = FakeFleetClient(FetchResult.Success(emptyList()), sseFlow = events)
-            val vm = DashboardViewModel(client, linkedStore(), "http://fd:1")
+            val vm = viewModel(client, linkedStore(), "http://fd:1")
 
             val job = launch { vm.state.collect {} }
             withTimeout(5_000) { vm.state.first { !it.loading } }
@@ -722,7 +766,7 @@ class DashboardViewModelTest {
             // A stream that completes at once models a dropped connection; the loop
             // must back off and reconnect (subscribe again), not give up after one.
             val client = FakeFleetClient(FetchResult.Success(listOf(member)), sseFlow = flowOf())
-            val vm = DashboardViewModel(client, linkedStore(), "http://fd:1")
+            val vm = viewModel(client, linkedStore(), "http://fd:1")
 
             val job = launch { vm.state.collect {} }
             withTimeout(5_000) {
@@ -743,7 +787,7 @@ class DashboardViewModelTest {
             withTimeout(30_000) {
                 val events = MutableSharedFlow<SseMessage>(extraBufferCapacity = 8)
                 val client = FakeFleetClient(FetchResult.Unauthorized, sseFlow = events)
-                val vm = DashboardViewModel(client, linkedStore(), "http://fd:1")
+                val vm = viewModel(client, linkedStore(), "http://fd:1")
 
                 val job = launch { vm.state.collect {} }
                 withTimeout(5_000) { vm.state.first { it.revoked } }
@@ -775,7 +819,7 @@ class DashboardViewModelTest {
                     FetchResult.Success(listOf(member)),
                     sseFlow = flowOf(SseMessage.Unauthorized),
                 )
-            val vm = DashboardViewModel(client, linkedStore(), "http://fd:1")
+            val vm = viewModel(client, linkedStore(), "http://fd:1")
 
             val job = launch { vm.state.collect {} }
             // revoked here is reached only through streamLoop (the poll succeeds), so
@@ -817,7 +861,7 @@ class DashboardViewModelTest {
             val events = MutableSharedFlow<SseMessage>(extraBufferCapacity = 8)
             val client = FakeFleetClient(FetchResult.Success(listOf(member)), sseFlow = events)
             val vm =
-                DashboardViewModel(
+                viewModel(
                     client,
                     linkedStore(),
                     "http://fd:1",
@@ -849,7 +893,7 @@ class DashboardViewModelTest {
             val events = MutableSharedFlow<SseMessage>(extraBufferCapacity = 8)
             val client = FakeFleetClient(FetchResult.Success(listOf(member)), sseFlow = events)
             val vm =
-                DashboardViewModel(
+                viewModel(
                     client,
                     linkedStore(),
                     "http://fd:1",

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/work/WidgetRefreshTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/work/WidgetRefreshTest.kt
@@ -1,0 +1,169 @@
+package com.hugalafutro.bellhop.work
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.work.ListenableWorker.Result
+import com.hugalafutro.bellhop.data.FrontDeskClient
+import com.hugalafutro.bellhop.data.LinkStore
+import com.hugalafutro.bellhop.data.PairedDevice
+import com.hugalafutro.bellhop.data.TokenCipher
+import com.hugalafutro.bellhop.data.WidgetMember
+import com.hugalafutro.bellhop.data.WidgetState
+import com.hugalafutro.bellhop.data.WidgetStore
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.runBlocking
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+/**
+ * refreshWidgetOnly is the widget refresh button's display-only poll, so these
+ * tests pin the three properties that separate it from [runBackstop]: it works
+ * with monitoring fully off (its whole reason to exist), it can never touch the
+ * alert baseline (it takes no MonitorStore, so this holds by construction), and
+ * it always ends in success — a user-initiated one-shot must not hold the retry
+ * backoff slot, and the stale stamp already tells the truth about a failed
+ * refresh. Fetch/persist wiring mirrors [FleetPollTest]; the linked-store seeding
+ * mirrors [FleetBackstopTest].
+ */
+class WidgetRefreshTest {
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    private lateinit var server: MockWebServer
+    private val client = FrontDeskClient()
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    // A fake cipher round-trips the token so LinkStore persists without an
+    // AndroidKeyStore provider (Robolectric has none), same as FleetBackstopTest.
+    private val passThrough =
+        object : TokenCipher {
+            override fun encrypt(plaintext: String) = plaintext
+
+            override fun decrypt(stored: String) = stored
+        }
+
+    private fun preferences(name: String): DataStore<Preferences> {
+        val scope = CoroutineScope(Dispatchers.IO + Job())
+        return PreferenceDataStoreFactory.create(scope = scope) {
+            File(tmp.newFolder(), "$name.preferences_pb")
+        }
+    }
+
+    private fun newWidgetStore(): WidgetStore = WidgetStore(preferences("widget"))
+
+    private fun unlinkedLinkStore(): LinkStore = LinkStore(preferences("link"), passThrough)
+
+    private suspend fun linkedLinkStore(): LinkStore =
+        LinkStore(preferences("link"), passThrough).also {
+            it.save(
+                fdUrl = server.url("/").toString(),
+                fdName = "Home Front Desk",
+                token = "tok-1",
+                device = PairedDevice(id = "dev-1", label = "Pixel 8", role = "operator"),
+            )
+        }
+
+    private fun memberBody(healthy: Boolean): String =
+        """[{"id":"m1","name":"hotel-1","state":"active",""" +
+            """"status":{"health":{"known":true,"healthy":$healthy}}}]"""
+
+    // A successful refresh fetches members then auto-sync, so enqueue both.
+    private fun enqueuePoll(
+        healthy: Boolean,
+        stale: Boolean = false,
+    ) {
+        server.enqueue(MockResponse().setBody(memberBody(healthy)))
+        server.enqueue(MockResponse().setBody("""{"enabled":true,"primary_id":"m1","stale":$stale}"""))
+    }
+
+    @Test
+    fun refreshWritesWidgetState() =
+        runBlocking {
+            // Monitoring fully OFF: refresh must still work (that is its point).
+            // Baseline safety is by construction: refreshWidgetOnly does not even
+            // take a MonitorStore, so it CANNOT touch the alert baseline.
+            val widget = newWidgetStore()
+            enqueuePoll(healthy = true)
+
+            val result = refreshWidgetOnly(linkedLinkStore(), widget, client, now = { 42L })
+
+            assertEquals(Result.success(), result)
+            assertEquals(listOf(WidgetMember("hotel-1", "UP")), widget.read()?.members)
+            assertEquals(42L, widget.read()?.updatedAt)
+        }
+
+    @Test
+    fun refreshWhileUnlinkedIsANoOp() =
+        runBlocking {
+            val widget = newWidgetStore()
+
+            val result = refreshWidgetOnly(unlinkedLinkStore(), widget, client, now = { 42L })
+
+            assertEquals(Result.success(), result)
+            assertNull(widget.read())
+            assertEquals(0, server.requestCount)
+        }
+
+    @Test
+    fun failedRefreshKeepsStaleStateAndSucceeds() =
+        runBlocking {
+            val widget = newWidgetStore()
+            // Seed a previous fetch's state; a failed refresh must keep showing it
+            // (a wiped store would read null, so the surviving seed proves "kept").
+            widget.saveIfChanged(
+                WidgetState(members = listOf(WidgetMember("hotel-1", "UP")), updatedAt = 7L),
+                widget.generation(),
+            )
+            server.enqueue(MockResponse().setResponseCode(500).setBody("nope"))
+
+            val result = refreshWidgetOnly(linkedLinkStore(), widget, client, now = { 42L })
+
+            // User-initiated one-shot never retries; stale beats blank.
+            assertEquals(Result.success(), result)
+            assertEquals(7L, widget.read()?.updatedAt)
+        }
+
+    @Test
+    fun autoSyncFailureKeepsLastKnownStaleFlag() =
+        runBlocking {
+            val widget = newWidgetStore()
+            // Seed a stale flag; a failed auto-sync read must fall back to it rather
+            // than clear it out from under the display.
+            widget.saveIfChanged(
+                WidgetState(
+                    autosyncStale = true,
+                    members = listOf(WidgetMember("hotel-1", "UP")),
+                    updatedAt = 7L,
+                ),
+                widget.generation(),
+            )
+            server.enqueue(MockResponse().setBody(memberBody(healthy = true)))
+            server.enqueue(MockResponse().setResponseCode(500).setBody("nope"))
+
+            val result = refreshWidgetOnly(linkedLinkStore(), widget, client, now = { 42L })
+
+            assertEquals(Result.success(), result)
+            assertEquals(true, widget.read()?.autosyncStale)
+        }
+}


### PR DESCRIPTION
Slice 3 of the Bellhop home-screen widget (#512 data layer, #513 UI), completing the feature.

- **Refresh button on the widget**: `WidgetRefreshAction` enqueues a one-shot of `FleetPollWorker` (unique name `widget-refresh`, KEEP, expedited w/ fallback). The poll is DISPLAY-ONLY: `refreshWidgetOnly` takes no MonitorStore at all, so it cannot touch the alert baseline; it never notifies (a member found down here still alerts on the next backstop poll) and always ends in success so tap-spam can't wedge the KEEP slot in retry backoff. Works with monitoring off and notifications blocked — that is its point. Icon tinted with the day/night muted pair (reviewer catch: opaque black vanished on the night background).
- **Foreground mirror**: the dashboard's `refreshOnce` now writes the widget store at the end of a successful refresh, so the widget is current the moment you leave the app. `saveIfChanged` gates the Glance re-render signal (content-equal writes inside the 5-min stamp window are skipped), and the store's generation fence (captured before the members fetch, same as the worker paths) drops the write if an unlink cleared the store mid-refresh.
- `cancelAll` (unlink teardown) also cancels the widget one-shot; the per-layer `cancel()` is deliberately untouched.
- `widget_refresh` string in base + all 10 locales; README feature line.

Tests: 4-case `WidgetRefreshTest` (works monitoring-off; unlinked no-op; failure keeps seeded state + no retry; auto-sync failure keeps last stale flag — the seed/fallback assertions genuinely discriminate), dashboard mirror test (one write + one signal, then a content-equal no-op). Full gates green.

Emulator e2e (mock FD): refresh tap with monitoring OFF ran exactly one worker SUCCESS, advanced the stamp, and posted zero notifications before/after; flipping a member down + refresh turned its row red (still zero notifications — display-only proven); the foreground mirror updated the widget from a dashboard refresh alone; unlink revoked on FD and instantly rendered the unpaired face.

Whole-branch review: all feature invariants verified (no polling anywhere, alert path byte-untouched, generation fence on every writer, distinct work names).

🤖 Generated with [Claude Code](https://claude.com/claude-code)