### PR TITLE
feat(bellhop): widget populates on placement (no empty face until first poll)

### DIFF
--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/widget/BellhopWidget.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/widget/BellhopWidget.kt
@@ -3,6 +3,8 @@ package com.hugalafutro.bellhop.widget
 import android.content.Context
 import android.text.format.DateFormat
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -61,6 +63,18 @@ import java.util.Date
 /** BellhopWidgetReceiver is the manifest entry point; all logic is in [BellhopWidget]. */
 class BellhopWidgetReceiver : GlanceAppWidgetReceiver() {
     override val glanceAppWidget: GlanceAppWidget = BellhopWidget()
+
+    // Placing the first widget instance is a user action asking for fleet state
+    // now, so fire the same display-only one-shot as the refresh button rather
+    // than sitting on empty-or-stale until the next organic write (the periodic
+    // backstop's first run can be a full period away). Not polling: one fetch
+    // per placement, and the linked/token guards inside make it a no-op when
+    // unpaired. onEnabled fires on first placement only, not on boot, so a
+    // reboot still renders purely from persisted state.
+    override fun onEnabled(context: Context) {
+        super.onEnabled(context)
+        FleetPollWorker.runWidgetRefresh(context)
+    }
 }
 
 /**
@@ -77,11 +91,22 @@ class BellhopWidget : GlanceAppWidget() {
         context: Context,
         id: GlanceId,
     ) {
-        // Read once per render; updateAll() re-runs provideGlance, so writers
-        // control freshness and the composition itself stays static.
-        val state = WidgetStore.create(context).read()
-        val monitoringActive = MonitorStore.create(context).active.first()
-        provideContent { WidgetContent(state, monitoringActive) }
+        val widgetStore = WidgetStore.create(context)
+        val monitorStore = MonitorStore.create(context)
+        // Seed synchronously so the first frame shows real data, then keep
+        // collecting inside the composition: a Glance session outlives its
+        // first frame, and an update landing while it is alive (the placement
+        // refresh finishes seconds after placement) re-runs only the
+        // composition, not this function - a read captured out here would
+        // pin every recomposition to placement-time state. Collecting is not
+        // polling: the flow only emits when a writer commits.
+        val initialState = widgetStore.read()
+        val initialActive = monitorStore.active.first()
+        provideContent {
+            val state by widgetStore.state.collectAsState(initial = initialState)
+            val monitoringActive by monitorStore.active.collectAsState(initial = initialActive)
+            WidgetContent(state, monitoringActive)
+        }
     }
 
     companion object {


### PR DESCRIPTION
Follow-up to #512/#513/#514: placing the widget while the app is closed left it on the unpaired/stale face until the next organic write (worst case a full 15-min backstop period). Two changes:

- **Placement refresh**: `BellhopWidgetReceiver.onEnabled` fires the same display-only one-shot as the refresh button. Placement is a deliberate user action, so this stays inside the no-polling rule: one fetch per placement, no-op when unpaired, nothing on boot (onEnabled doesn't fire then).
- **Live-session render fix (real bug in the merged widget, exposed by the above)**: `provideGlance` captured the store read before `provideContent`, so a live Glance session (~45s idle window) recomposed with stale placement-time state and `updateAll` only surfaced fresh data after the session expired. Every earlier e2e happened minutes apart, masking it; the placement refresh lands 5s after first composition, inside the window. The composition now collects the store flow, seeded synchronously so the first frame stays instant. The flow only emits on writer commits, so no polling and no timed re-renders.

Emulator-verified end to end: fresh install → pair to mock FD → force-stop app → delete the widget store file → place widget → fleet rows + stamp render within seconds, without the app ever reopening. Gates green (ktlintCheck, testDebugUnitTest, lintDebug, assembleDebug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)