### PR TITLE
feat(bellhop): widget visual polish (header, row cards, event pill + stamp)

### DIFF
--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/widget/BellhopWidget.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/widget/BellhopWidget.kt
@@ -27,6 +27,7 @@ import androidx.glance.appwidget.provideContent
 import androidx.glance.appwidget.updateAll
 import androidx.glance.background
 import androidx.glance.color.ColorProvider
+import androidx.glance.layout.Alignment
 import androidx.glance.layout.Column
 import androidx.glance.layout.Row
 import androidx.glance.layout.Spacer
@@ -41,6 +42,8 @@ import androidx.glance.text.Text
 import androidx.glance.text.TextStyle
 import com.hugalafutro.bellhop.MainActivity
 import com.hugalafutro.bellhop.R
+import com.hugalafutro.bellhop.data.LinkState
+import com.hugalafutro.bellhop.data.LinkStore
 import com.hugalafutro.bellhop.data.MemberHealthState
 import com.hugalafutro.bellhop.data.MonitorStore
 import com.hugalafutro.bellhop.data.WidgetState
@@ -58,6 +61,8 @@ import com.hugalafutro.bellhop.ui.theme.PaperInk
 import com.hugalafutro.bellhop.ui.theme.PaperInkMuted
 import com.hugalafutro.bellhop.work.FleetPollWorker
 import kotlinx.coroutines.flow.first
+import java.time.Instant
+import java.time.ZoneId
 import java.util.Date
 
 /** BellhopWidgetReceiver is the manifest entry point; all logic is in [BellhopWidget]. */
@@ -93,6 +98,9 @@ class BellhopWidget : GlanceAppWidget() {
     ) {
         val widgetStore = WidgetStore.create(context)
         val monitorStore = MonitorStore.create(context)
+        // The header names the linked Front Desk. Read once per session: it
+        // only changes across link/unlink, and unlink tears the session down.
+        val fdName = (LinkStore.create(context).state.first() as? LinkState.Linked)?.fdName.orEmpty()
         // Seed synchronously so the first frame shows real data, then keep
         // collecting inside the composition: a Glance session outlives its
         // first frame, and an update landing while it is alive (the placement
@@ -105,7 +113,7 @@ class BellhopWidget : GlanceAppWidget() {
         provideContent {
             val state by widgetStore.state.collectAsState(initial = initialState)
             val monitoringActive by monitorStore.active.collectAsState(initial = initialActive)
-            WidgetContent(state, monitoringActive)
+            WidgetContent(state, monitoringActive, fdName)
         }
     }
 
@@ -142,6 +150,7 @@ class WidgetRefreshAction : ActionCallback {
 
 // Day/night pairs off the app palette (ui/theme/Color.kt); Glance can't read
 // MaterialTheme, so the pairing is repeated here with the same named colors.
+private val BrandAccent = ColorProvider(day = Brass600, night = Brass300)
 private val TextPrimary = ColorProvider(day = PaperInk, night = Ink100)
 private val TextMuted = ColorProvider(day = PaperInkMuted, night = Ink300)
 private val DotUp = ColorProvider(day = Moss600, night = Moss300)
@@ -157,10 +166,45 @@ private fun dotColor(state: MemberHealthState) =
         MemberHealthState.UNKNOWN -> DotUnknown
     }
 
+/** stateLabel is the row chip's short localized status word. */
+private fun stateLabel(
+    context: Context,
+    state: MemberHealthState,
+): String =
+    context.getString(
+        when (state) {
+            MemberHealthState.UP -> R.string.widget_state_up
+            MemberHealthState.DOWN -> R.string.widget_state_down
+            MemberHealthState.DRAINED -> R.string.widget_state_drained
+            MemberHealthState.UNKNOWN -> R.string.widget_state_unknown
+        },
+    )
+
+/**
+ * eventStamp dates the newest-event pill: clock time when the event is from
+ * today, a short date otherwise, so a day-old event can't masquerade as fresh.
+ * Absolute like the "as of" stamp (relative text would need timed re-renders).
+ * Empty when the wire timestamp doesn't parse; the pill just omits the stamp.
+ */
+private fun eventStamp(
+    context: Context,
+    createdAt: String,
+): String {
+    val instant = runCatching { Instant.parse(createdAt) }.getOrNull() ?: return ""
+    val zone = ZoneId.systemDefault()
+    val asDate = Date(instant.toEpochMilli())
+    return if (instant.atZone(zone).toLocalDate() == Instant.now().atZone(zone).toLocalDate()) {
+        DateFormat.getTimeFormat(context).format(asDate)
+    } else {
+        DateFormat.getDateFormat(context).format(asDate)
+    }
+}
+
 @Composable
 private fun WidgetContent(
     state: WidgetState?,
     monitoringActive: Boolean,
+    fdName: String,
 ) {
     val context = LocalContext.current
     Column(
@@ -171,6 +215,53 @@ private fun WidgetContent(
                 .padding(12.dp)
                 .clickable(actionStartActivity<MainActivity>()),
     ) {
+        if (state != null) {
+            // Header carries the always-present chrome: FD name on the left,
+            // freshness stamp + refresh on the right. Living up here means the
+            // row cards and event pill can never push them off the bottom.
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = GlanceModifier.fillMaxWidth().padding(bottom = 6.dp),
+            ) {
+                Image(
+                    ImageProvider(R.drawable.ic_stat_bellhop),
+                    null,
+                    GlanceModifier.size(14.dp),
+                    colorFilter = ColorFilter.tint(BrandAccent),
+                )
+                Spacer(GlanceModifier.width(6.dp))
+                Text(
+                    fdName,
+                    style = TextStyle(color = TextMuted, fontSize = 11.sp, fontWeight = FontWeight.Medium),
+                    maxLines = 1,
+                    modifier = GlanceModifier.defaultWeight(),
+                )
+                Spacer(GlanceModifier.width(8.dp))
+                // Overall fleet badge: up/total ratio, locale-neutral, colored
+                // by the worst state present (all up wins green, any down wins
+                // ember, drained/unknown mixes read brass).
+                if (state.members.isNotEmpty()) {
+                    val c = countsOf(state)
+                    val badgeColor =
+                        when {
+                            c.down > 0 -> DotDown
+                            c.up == state.members.size -> DotUp
+                            else -> DotDrained
+                        }
+                    Row(
+                        modifier =
+                            GlanceModifier.background(
+                                ImageProvider(R.drawable.widget_pill_bg),
+                            ).padding(horizontal = 7.dp, vertical = 2.dp),
+                    ) {
+                        Text(
+                            "${c.up}/${state.members.size}",
+                            style = TextStyle(color = badgeColor, fontSize = 10.sp, fontWeight = FontWeight.Bold),
+                        )
+                    }
+                }
+            }
+        }
         when {
             state == null ->
                 Text(
@@ -184,24 +275,80 @@ private fun WidgetContent(
                 )
             state.members.size > BellhopWidget.MAX_MEMBER_ROWS -> {
                 val c = countsOf(state)
-                Text(
-                    context.getString(R.string.widget_counts, c.up, c.down, c.drained),
-                    style = TextStyle(color = TextPrimary, fontSize = 14.sp, fontWeight = FontWeight.Medium),
-                )
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier =
+                        GlanceModifier
+                            .fillMaxWidth()
+                            .background(ImageProvider(R.drawable.widget_row_bg))
+                            .padding(horizontal = 10.dp, vertical = 7.dp),
+                ) {
+                    Text(
+                        context.getString(R.string.widget_counts, c.up, c.down, c.drained),
+                        style = TextStyle(color = TextPrimary, fontSize = 13.sp, fontWeight = FontWeight.Medium),
+                    )
+                }
             }
             else ->
+                // Row gaps ride as outer padding, not Spacer children: a Glance
+                // Column translates to a RemoteViews container capped at 10
+                // children, and per-row Spacers blew past it on a 3-member
+                // fleet (the children beyond the cap are silently dropped -
+                // the footer was the casualty). Worst case now: header + 5
+                // rows + pill + weight spacer + footer = 9.
                 state.members.forEach { member ->
-                    Row(modifier = GlanceModifier.padding(vertical = 2.dp)) {
-                        Text("●", style = TextStyle(color = dotColor(member.healthState), fontSize = 13.sp))
-                        Spacer(GlanceModifier.width(6.dp))
-                        Text(member.name, style = TextStyle(color = TextPrimary, fontSize = 13.sp), maxLines = 1)
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier =
+                            GlanceModifier
+                                .fillMaxWidth()
+                                .padding(bottom = 3.dp)
+                                .background(ImageProvider(R.drawable.widget_row_bg))
+                                .padding(horizontal = 10.dp, vertical = 5.dp),
+                    ) {
+                        Image(
+                            ImageProvider(R.drawable.widget_dot),
+                            null,
+                            GlanceModifier.size(9.dp),
+                            colorFilter = ColorFilter.tint(dotColor(member.healthState)),
+                        )
+                        Spacer(GlanceModifier.width(8.dp))
+                        Text(
+                            member.name,
+                            style = TextStyle(color = TextPrimary, fontSize = 13.sp, fontWeight = FontWeight.Medium),
+                            maxLines = 1,
+                            modifier = GlanceModifier.defaultWeight(),
+                        )
+                        Spacer(GlanceModifier.width(8.dp))
+                        Text(
+                            stateLabel(context, member.healthState),
+                            style = TextStyle(color = dotColor(member.healthState), fontSize = 11.sp),
+                        )
                     }
                 }
         }
         if (state != null && LocalSize.current.height >= BellhopWidget.TALL.height) {
             state.newestEvent?.let { event ->
-                Spacer(GlanceModifier.height(6.dp))
-                Text(event.message, style = TextStyle(color = TextMuted, fontSize = 11.sp), maxLines = 2)
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier =
+                        GlanceModifier
+                            .padding(top = 2.dp)
+                            .background(ImageProvider(R.drawable.widget_pill_bg))
+                            .padding(horizontal = 10.dp, vertical = 4.dp),
+                ) {
+                    Text(
+                        event.message,
+                        style = TextStyle(color = TextMuted, fontSize = 11.sp),
+                        maxLines = 1,
+                        modifier = GlanceModifier.defaultWeight(),
+                    )
+                    Spacer(GlanceModifier.width(6.dp))
+                    Text(
+                        eventStamp(context, event.createdAt),
+                        style = TextStyle(color = TextMuted, fontSize = 10.sp),
+                    )
+                }
             }
         }
         Spacer(GlanceModifier.defaultWeight())

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/widget/BellhopWidget.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/widget/BellhopWidget.kt
@@ -327,31 +327,42 @@ private fun WidgetContent(
                     }
                 }
         }
+        Spacer(GlanceModifier.defaultWeight())
+        // Pinned above the footer rather than under the member rows, so a small
+        // fleet doesn't render the event box glued on like an n+1th member.
         if (state != null && LocalSize.current.height >= BellhopWidget.TALL.height) {
             state.newestEvent?.let { event ->
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
+                Column(
                     modifier =
                         GlanceModifier
-                            .padding(top = 2.dp)
-                            .background(ImageProvider(R.drawable.widget_pill_bg))
-                            .padding(horizontal = 10.dp, vertical = 4.dp),
+                            .fillMaxWidth()
+                            .padding(bottom = 6.dp)
+                            .background(ImageProvider(R.drawable.widget_event_bg))
+                            .padding(horizontal = 8.dp, vertical = 4.dp),
                 ) {
                     Text(
-                        event.message,
-                        style = TextStyle(color = TextMuted, fontSize = 11.sp),
-                        maxLines = 1,
-                        modifier = GlanceModifier.defaultWeight(),
+                        context.getString(R.string.widget_event_header),
+                        style = TextStyle(color = TextMuted, fontSize = 9.sp, fontWeight = FontWeight.Medium),
                     )
-                    Spacer(GlanceModifier.width(6.dp))
-                    Text(
-                        eventStamp(context, event.createdAt),
-                        style = TextStyle(color = TextMuted, fontSize = 10.sp),
-                    )
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = GlanceModifier.fillMaxWidth(),
+                    ) {
+                        Text(
+                            event.message,
+                            style = TextStyle(color = TextPrimary, fontSize = 11.sp),
+                            maxLines = 1,
+                            modifier = GlanceModifier.defaultWeight(),
+                        )
+                        Spacer(GlanceModifier.width(6.dp))
+                        Text(
+                            eventStamp(context, event.createdAt),
+                            style = TextStyle(color = TextMuted, fontSize = 9.sp),
+                        )
+                    }
                 }
             }
         }
-        Spacer(GlanceModifier.defaultWeight())
         Row(modifier = GlanceModifier.fillMaxWidth()) {
             if (state != null) {
                 val stamp = DateFormat.getTimeFormat(context).format(Date(state.updatedAt))

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/widget/BellhopWidget.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/widget/BellhopWidget.kt
@@ -3,6 +3,8 @@ package com.hugalafutro.bellhop.widget
 import android.content.Context
 import android.text.format.DateFormat
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -61,6 +63,18 @@ import java.util.Date
 /** BellhopWidgetReceiver is the manifest entry point; all logic is in [BellhopWidget]. */
 class BellhopWidgetReceiver : GlanceAppWidgetReceiver() {
     override val glanceAppWidget: GlanceAppWidget = BellhopWidget()
+
+    // Placing the first widget instance is a user action asking for fleet state
+    // now, so fire the same display-only one-shot as the refresh button rather
+    // than sitting on empty-or-stale until the next organic write (the periodic
+    // backstop's first run can be a full period away). Not polling: one fetch
+    // per placement, and the linked/token guards inside make it a no-op when
+    // unpaired. onEnabled fires on first placement only, not on boot, so a
+    // reboot still renders purely from persisted state.
+    override fun onEnabled(context: Context) {
+        super.onEnabled(context)
+        FleetPollWorker.runWidgetRefresh(context)
+    }
 }
 
 /**
@@ -77,11 +91,22 @@ class BellhopWidget : GlanceAppWidget() {
         context: Context,
         id: GlanceId,
     ) {
-        // Read once per render; updateAll() re-runs provideGlance, so writers
-        // control freshness and the composition itself stays static.
-        val state = WidgetStore.create(context).read()
-        val monitoringActive = MonitorStore.create(context).active.first()
-        provideContent { WidgetContent(state, monitoringActive) }
+        val widgetStore = WidgetStore.create(context)
+        val monitorStore = MonitorStore.create(context)
+        // Seed synchronously so the first frame shows real data, then keep
+        // collecting inside the composition: a Glance session outlives its
+        // first frame, and an update landing while it is alive (the placement
+        // refresh finishes seconds after placement) re-runs only the
+        // composition, not this function - a read captured out here would
+        // pin every recomposition to placement-time state. Collecting is not
+        // polling: the flow only emits when a writer commits.
+        val initialState = widgetStore.read()
+        val initialActive = monitorStore.active.first()
+        provideContent {
+            val state by widgetStore.state.collectAsState(initial = initialState)
+            val monitoringActive by monitorStore.active.collectAsState(initial = initialActive)
+            WidgetContent(state, monitoringActive)
+        }
     }
 
     companion object {

--- a/android/app/src/main/res/drawable-night/widget_event_bg.xml
+++ b/android/app/src/main/res/drawable-night/widget_event_bg.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Latest-event box, night: Ink700. -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="#273344" />
+    <corners android:radius="8dp" />
+</shape>

--- a/android/app/src/main/res/drawable-night/widget_pill_bg.xml
+++ b/android/app/src/main/res/drawable-night/widget_pill_bg.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Newest-event pill, night: Ink700. -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="#273344" />
+    <corners android:radius="99dp" />
+</shape>

--- a/android/app/src/main/res/drawable-night/widget_row_bg.xml
+++ b/android/app/src/main/res/drawable-night/widget_row_bg.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Member row card, night: Ink800 on the Ink900 widget background. -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="#1A2331" />
+    <corners android:radius="10dp" />
+</shape>

--- a/android/app/src/main/res/drawable/widget_dot.xml
+++ b/android/app/src/main/res/drawable/widget_dot.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Health dot: white oval tinted per state at the use site. A drawable rather
+     than a text glyph so the dot is crisp and identically sized everywhere. -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="oval">
+    <solid android:color="#FFFFFFFF" />
+</shape>

--- a/android/app/src/main/res/drawable/widget_event_bg.xml
+++ b/android/app/src/main/res/drawable/widget_event_bg.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Latest-event box, day: Paper200 with a tighter radius than the member
+     cards so it reads as a footnote panel, not an n+1th member row. -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="#E5DCCB" />
+    <corners android:radius="8dp" />
+</shape>

--- a/android/app/src/main/res/drawable/widget_pill_bg.xml
+++ b/android/app/src/main/res/drawable/widget_pill_bg.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Newest-event pill, day: Paper200, fully rounded like the app's event chips. -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="#E5DCCB" />
+    <corners android:radius="99dp" />
+</shape>

--- a/android/app/src/main/res/drawable/widget_row_bg.xml
+++ b/android/app/src/main/res/drawable/widget_row_bg.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Member row card, day: Paper100 on the Paper50 widget background. -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="#F2ECE0" />
+    <corners android:radius="10dp" />
+</shape>

--- a/android/app/src/main/res/values-cs/strings.xml
+++ b/android/app/src/main/res/values-cs/strings.xml
@@ -273,4 +273,5 @@
     <string name="widget_state_down">Mimo provoz</string>
     <string name="widget_state_drained">Odstaveno</string>
     <string name="widget_state_unknown">Neznámé</string>
+    <string name="widget_event_header">Poslední událost flotily</string>
 </resources>

--- a/android/app/src/main/res/values-cs/strings.xml
+++ b/android/app/src/main/res/values-cs/strings.xml
@@ -269,4 +269,8 @@
     <!-- Collapsed face for large fleets: up/down/drained counts -->
     <string name="widget_counts">%1$d běží · %2$d mimo · %3$d odstaveno</string>
     <string name="widget_refresh">Obnovit</string>
+    <string name="widget_state_up">Běží</string>
+    <string name="widget_state_down">Mimo provoz</string>
+    <string name="widget_state_drained">Odstaveno</string>
+    <string name="widget_state_unknown">Neznámé</string>
 </resources>

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -257,4 +257,8 @@
     <!-- Collapsed face for large fleets: up/down/drained counts -->
     <string name="widget_counts">%1$d aktiv · %2$d ausgefallen · %3$d stillgelegt</string>
     <string name="widget_refresh">Aktualisieren</string>
+    <string name="widget_state_up">Aktiv</string>
+    <string name="widget_state_down">Ausgefallen</string>
+    <string name="widget_state_drained">Stillgelegt</string>
+    <string name="widget_state_unknown">Unbekannt</string>
 </resources>

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -261,4 +261,5 @@
     <string name="widget_state_down">Ausgefallen</string>
     <string name="widget_state_drained">Stillgelegt</string>
     <string name="widget_state_unknown">Unbekannt</string>
+    <string name="widget_event_header">Letztes Flottenereignis</string>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -257,4 +257,8 @@
     <!-- Collapsed face for large fleets: up/down/drained counts -->
     <string name="widget_counts">%1$d activos · %2$d caídos · %3$d drenados</string>
     <string name="widget_refresh">Actualizar</string>
+    <string name="widget_state_up">Activo</string>
+    <string name="widget_state_down">Caído</string>
+    <string name="widget_state_drained">Drenado</string>
+    <string name="widget_state_unknown">Desconocido</string>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -261,4 +261,5 @@
     <string name="widget_state_down">Caído</string>
     <string name="widget_state_drained">Drenado</string>
     <string name="widget_state_unknown">Desconocido</string>
+    <string name="widget_event_header">Último evento de la flota</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -257,4 +257,8 @@
     <!-- Collapsed face for large fleets: up/down/drained counts -->
     <string name="widget_counts">%1$d actifs · %2$d hors service · %3$d drainés</string>
     <string name="widget_refresh">Actualiser</string>
+    <string name="widget_state_up">Actif</string>
+    <string name="widget_state_down">Hors service</string>
+    <string name="widget_state_drained">Drainé</string>
+    <string name="widget_state_unknown">Inconnu</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -261,4 +261,5 @@
     <string name="widget_state_down">Hors service</string>
     <string name="widget_state_drained">Drainé</string>
     <string name="widget_state_unknown">Inconnu</string>
+    <string name="widget_event_header">Dernier événement de la flotte</string>
 </resources>

--- a/android/app/src/main/res/values-ja/strings.xml
+++ b/android/app/src/main/res/values-ja/strings.xml
@@ -255,4 +255,5 @@
     <string name="widget_state_down">ダウン</string>
     <string name="widget_state_drained">ドレイン済み</string>
     <string name="widget_state_unknown">不明</string>
+    <string name="widget_event_header">最新のフリートイベント</string>
 </resources>

--- a/android/app/src/main/res/values-ja/strings.xml
+++ b/android/app/src/main/res/values-ja/strings.xml
@@ -251,4 +251,8 @@
     <!-- Collapsed face for large fleets: up/down/drained counts -->
     <string name="widget_counts">稼働 %1$d · ダウン %2$d · ドレイン %3$d</string>
     <string name="widget_refresh">更新</string>
+    <string name="widget_state_up">稼働中</string>
+    <string name="widget_state_down">ダウン</string>
+    <string name="widget_state_drained">ドレイン済み</string>
+    <string name="widget_state_unknown">不明</string>
 </resources>

--- a/android/app/src/main/res/values-nl/strings.xml
+++ b/android/app/src/main/res/values-nl/strings.xml
@@ -257,4 +257,8 @@
     <!-- Collapsed face for large fleets: up/down/drained counts -->
     <string name="widget_counts">%1$d actief · %2$d offline · %3$d gedraineerd</string>
     <string name="widget_refresh">Vernieuwen</string>
+    <string name="widget_state_up">Actief</string>
+    <string name="widget_state_down">Offline</string>
+    <string name="widget_state_drained">Gedraineerd</string>
+    <string name="widget_state_unknown">Onbekend</string>
 </resources>

--- a/android/app/src/main/res/values-nl/strings.xml
+++ b/android/app/src/main/res/values-nl/strings.xml
@@ -261,4 +261,5 @@
     <string name="widget_state_down">Offline</string>
     <string name="widget_state_drained">Gedraineerd</string>
     <string name="widget_state_unknown">Onbekend</string>
+    <string name="widget_event_header">Laatste vlootgebeurtenis</string>
 </resources>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -269,4 +269,8 @@
     <!-- Collapsed face for large fleets: up/down/drained counts -->
     <string name="widget_counts">%1$d działa · %2$d nie działa · %3$d wygaszone</string>
     <string name="widget_refresh">Odśwież</string>
+    <string name="widget_state_up">Działa</string>
+    <string name="widget_state_down">Nie działa</string>
+    <string name="widget_state_drained">Wygaszony</string>
+    <string name="widget_state_unknown">Nieznany</string>
 </resources>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -273,4 +273,5 @@
     <string name="widget_state_down">Nie działa</string>
     <string name="widget_state_drained">Wygaszony</string>
     <string name="widget_state_unknown">Nieznany</string>
+    <string name="widget_event_header">Ostatnie zdarzenie floty</string>
 </resources>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -273,4 +273,5 @@
     <string name="widget_state_down">Недоступен</string>
     <string name="widget_state_drained">Выведен</string>
     <string name="widget_state_unknown">Неизвестно</string>
+    <string name="widget_event_header">Последнее событие флота</string>
 </resources>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -269,4 +269,8 @@
     <!-- Collapsed face for large fleets: up/down/drained counts -->
     <string name="widget_counts">%1$d работает · %2$d недоступно · %3$d выведено</string>
     <string name="widget_refresh">Обновить</string>
+    <string name="widget_state_up">Работает</string>
+    <string name="widget_state_down">Недоступен</string>
+    <string name="widget_state_drained">Выведен</string>
+    <string name="widget_state_unknown">Неизвестно</string>
 </resources>

--- a/android/app/src/main/res/values-sk/strings.xml
+++ b/android/app/src/main/res/values-sk/strings.xml
@@ -269,4 +269,8 @@
     <!-- Collapsed face for large fleets: up/down/drained counts -->
     <string name="widget_counts">%1$d beží · %2$d mimo · %3$d odstavené</string>
     <string name="widget_refresh">Obnoviť</string>
+    <string name="widget_state_up">Beží</string>
+    <string name="widget_state_down">Mimo prevádzky</string>
+    <string name="widget_state_drained">Odstavené</string>
+    <string name="widget_state_unknown">Neznáme</string>
 </resources>

--- a/android/app/src/main/res/values-sk/strings.xml
+++ b/android/app/src/main/res/values-sk/strings.xml
@@ -273,4 +273,5 @@
     <string name="widget_state_down">Mimo prevádzky</string>
     <string name="widget_state_drained">Odstavené</string>
     <string name="widget_state_unknown">Neznáme</string>
+    <string name="widget_event_header">Posledná udalosť flotily</string>
 </resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -251,4 +251,8 @@
     <!-- Collapsed face for large fleets: up/down/drained counts -->
     <string name="widget_counts">%1$d 运行中 · %2$d 已宕机 · %3$d 已排空</string>
     <string name="widget_refresh">刷新</string>
+    <string name="widget_state_up">运行中</string>
+    <string name="widget_state_down">已宕机</string>
+    <string name="widget_state_drained">已排空</string>
+    <string name="widget_state_unknown">未知</string>
 </resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -255,4 +255,5 @@
     <string name="widget_state_down">已宕机</string>
     <string name="widget_state_drained">已排空</string>
     <string name="widget_state_unknown">未知</string>
+    <string name="widget_event_header">最新集群事件</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -265,4 +265,5 @@
     <string name="widget_state_down">Down</string>
     <string name="widget_state_drained">Drained</string>
     <string name="widget_state_unknown">Unknown</string>
+    <string name="widget_event_header">Latest fleet event</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -261,4 +261,8 @@
     <!-- Collapsed face for large fleets: up/down/drained counts -->
     <string name="widget_counts">%1$d up · %2$d down · %3$d drained</string>
     <string name="widget_refresh">Refresh</string>
+    <string name="widget_state_up">Up</string>
+    <string name="widget_state_down">Down</string>
+    <string name="widget_state_drained">Drained</string>
+    <string name="widget_state_unknown">Unknown</string>
 </resources>


### PR DESCRIPTION
Restyle of the widget face (follow-up to #512-#515, on top of #515's branch):

- Header: brass bell + linked Front Desk name, and an up/total fleet badge top right (locale-neutral "2/3", green all-up / ember any-down / brass otherwise).
- Member rows become cards: rounded day/night surfaces, drawable dots (crisp + tinted, replacing the text glyph), member name + short localized status word colored by state (4 new strings x 11 locale files, terminology matched per locale).
- Newest event renders as a pill with its own absolute timestamp (clock time if today, short date otherwise) so a day-old event can't masquerade as fresh.
- Footer ("as of" + stale/monitoring hint + refresh) kept at the bottom, tightened.

Gotcha found and encoded in a comment: a Glance Column maps to a RemoteViews container capped at 10 children, and overflow is silently dropped (the footer vanished once the row cards + spacers exceeded the cap). Inter-row gaps are outer padding on the cards now; worst case is 9 children at the 5-row max.

Emulator-verified in dark and light. Gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)