### PR TITLE
fix(security): strip provider auth headers on cross-host redirects; allowlist dead Ollama key

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,22 @@
+# gitleaks configuration.
+#
+# We do not run gitleaks in CI (secret scanning here is Trivy on the built
+# image). This file exists solely to allowlist a known, dead credential that
+# external history-walking scanners keep flagging, so the noise does not
+# distract from real findings.
+
+[extend]
+useDefault = true
+
+[[allowlist]]
+description = """
+Dead Ollama Cloud API key committed to old history in
+plans/integrating-ollama-cloud.md (commit bb7bb913, 2026-04-22) and removed
+from the tree in 370186d7. The key is revoked/expired: it returns HTTP 401
+and is not present among the account's active keys, so there is nothing to
+abuse. History was deliberately not rewritten (force-pushing master to scrub
+a dead string is not worth breaking every clone, fork, and open PR).
+"""
+regexes = [
+  '''49071b69aefc4bbe9d78a3419b6e3d23\.os5ggixiHouArVW8RzqUkFWm''',
+]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -8,7 +8,7 @@
 [extend]
 useDefault = true
 
-[[allowlist]]
+[[allowlists]]
 description = """
 Dead Ollama Cloud API key committed to old history in
 plans/integrating-ollama-cloud.md (commit bb7bb913, 2026-04-22) and removed

--- a/internal/proxy/safe_dialer.go
+++ b/internal/proxy/safe_dialer.go
@@ -170,6 +170,16 @@ func (s *SafeDialer) CheckRedirect(req *http.Request, via []*http.Request) error
 		return fmt.Errorf("proxy: stopped after 10 redirects")
 	}
 	host := req.URL.Hostname()
+	// A redirect that leaves the original upstream host must not carry the
+	// provider's credentials with it. Go's http.Client strips the standard
+	// Authorization header across hosts, but forwards custom auth headers
+	// (x-api-key, x-goog-api-key) verbatim, which would leak the key to the
+	// redirect target. Strip all provider auth headers on any cross-host hop,
+	// before the allowlist/IP checks below, so it applies regardless of whether
+	// the target is allowed.
+	if len(via) > 0 && !strings.EqualFold(host, via[0].URL.Hostname()) {
+		util.StripProviderAuthHeaders(req)
+	}
 	// Allowlisted hosts bypass all checks.
 	if s.hosts[strings.ToLower(host)] {
 		return nil

--- a/internal/proxy/safe_dialer_test.go
+++ b/internal/proxy/safe_dialer_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hugalafutro/model-hotel/internal/ctxkeys"
 	"github.com/hugalafutro/model-hotel/internal/provider"
+	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
 func TestIsBlockedIP_LoopbackIPv4(t *testing.T) {
@@ -791,5 +792,88 @@ func TestDiscoveryService_NoProtectionWhenNil(t *testing.T) {
 	// Should be a normal connection error, NOT an SSRF block.
 	if strings.Contains(err.Error(), "refused connection to private/reserved IP") {
 		t.Errorf("expected normal connection error without SSRF protection, got SSRF block: %v", err)
+	}
+}
+
+// redirectReq builds a redirect target request with the provider auth headers
+// that Go's http.Client would have copied verbatim from the original request.
+func redirectReq(t *testing.T, providerType, target, apiKey string) *http.Request {
+	t.Helper()
+	orig, err := http.NewRequest(http.MethodPost, "https://provider.example/v1/messages", http.NoBody)
+	if err != nil {
+		t.Fatalf("build original request: %v", err)
+	}
+	util.SetProviderAuthHeaders(orig, providerType, apiKey)
+	redir, err := http.NewRequest(http.MethodPost, target, http.NoBody)
+	if err != nil {
+		t.Fatalf("build redirect request: %v", err)
+	}
+	// Mirror net/http: non-sensitive headers (including custom x-* auth
+	// headers) are copied onto the redirect request before CheckRedirect runs.
+	for k, vals := range orig.Header {
+		if strings.EqualFold(k, "Authorization") {
+			continue // Go strips Authorization cross-host on its own.
+		}
+		for _, v := range vals {
+			redir.Header.Add(k, v)
+		}
+	}
+	return redir
+}
+
+// TestCheckRedirect_StripsCustomAuthHeadersCrossHost is the regression test for
+// the provider-key leak: a cross-host redirect must not carry x-api-key /
+// x-goog-api-key to the redirect target.
+func TestCheckRedirect_StripsCustomAuthHeadersCrossHost(t *testing.T) {
+	// attacker.example resolves to a public IP, so CheckRedirect would otherwise
+	// allow the redirect and forward the credential.
+	sd := newSafeDialerWithResolver(nil, &mockResolver{
+		lookupFunc: func(ctx context.Context, host string) ([]net.IPAddr, error) {
+			return []net.IPAddr{{IP: net.ParseIP("93.184.216.34")}}, nil
+		},
+	}, nil)
+
+	cases := []struct {
+		name         string
+		providerType string
+		header       string
+	}{
+		{"anthropic", "anthropic", "x-api-key"},
+		{"vertex-express", "vertex-express", "x-goog-api-key"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := redirectReq(t, tc.providerType, "http://attacker.example/exfil", "super-secret-key")
+			if got := req.Header.Get(tc.header); got == "" {
+				t.Fatalf("precondition: %s should be set before redirect", tc.header)
+			}
+			orig, _ := http.NewRequest(http.MethodPost, "https://provider.example/v1/messages", http.NoBody)
+			if err := sd.CheckRedirect(req, []*http.Request{orig}); err != nil {
+				t.Fatalf("cross-host redirect to public host should be allowed: %v", err)
+			}
+			if got := req.Header.Get(tc.header); got != "" {
+				t.Fatalf("%s leaked to redirect target: %q", tc.header, got)
+			}
+		})
+	}
+}
+
+// TestCheckRedirect_PreservesAuthHeadersSameHost ensures the strip is scoped to
+// cross-host hops: a same-host redirect (e.g. a provider pointing at a longer
+// path on itself) keeps the credential so the redirected request still auths.
+func TestCheckRedirect_PreservesAuthHeadersSameHost(t *testing.T) {
+	sd := newSafeDialerWithResolver([]string{"provider.example"}, &mockResolver{
+		lookupFunc: func(ctx context.Context, host string) ([]net.IPAddr, error) {
+			return []net.IPAddr{{IP: net.ParseIP("93.184.216.34")}}, nil
+		},
+	}, nil)
+
+	req := redirectReq(t, "anthropic", "https://provider.example/v1/messages/next", "super-secret-key")
+	orig, _ := http.NewRequest(http.MethodPost, "https://provider.example/v1/messages", http.NoBody)
+	if err := sd.CheckRedirect(req, []*http.Request{orig}); err != nil {
+		t.Fatalf("same-host redirect should be allowed: %v", err)
+	}
+	if got := req.Header.Get("x-api-key"); got != "super-secret-key" {
+		t.Fatalf("x-api-key should survive a same-host redirect, got %q", got)
 	}
 }

--- a/internal/util/httputil.go
+++ b/internal/util/httputil.go
@@ -254,6 +254,27 @@ func SetProviderAuthHeaders(req *http.Request, providerType, apiKey string) {
 	}
 }
 
+// providerAuthHeaders lists every header SetProviderAuthHeaders may set. It is
+// the single source of truth for StripProviderAuthHeaders, so the two stay in
+// sync as provider auth schemes are added.
+var providerAuthHeaders = []string{
+	"Authorization",
+	"anthropic-version",
+	"x-api-key",
+	"x-goog-api-key",
+}
+
+// StripProviderAuthHeaders removes any provider authentication headers set by
+// SetProviderAuthHeaders from req. Go's http.Client strips the standard
+// Authorization header on cross-host redirects but forwards custom headers such
+// as x-api-key and x-goog-api-key verbatim, so this must be called explicitly to
+// keep a provider credential from leaking to a redirect target.
+func StripProviderAuthHeaders(req *http.Request) {
+	for _, h := range providerAuthHeaders {
+		req.Header.Del(h)
+	}
+}
+
 // OpenAIErrorType maps an HTTP status code to the corresponding OpenAI error type string.
 func OpenAIErrorType(code int) string {
 	switch {

--- a/internal/util/httputil_test.go
+++ b/internal/util/httputil_test.go
@@ -1195,3 +1195,25 @@ func TestSetProviderAuthHeaders(t *testing.T) {
 		})
 	}
 }
+
+func TestStripProviderAuthHeaders(t *testing.T) {
+	for _, providerType := range []string{"anthropic", "vertex-express", "openai"} {
+		t.Run(providerType, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/", http.NoBody)
+			SetProviderAuthHeaders(req, providerType, "super-secret-key")
+			// A non-auth header must survive the strip.
+			req.Header.Set("X-Request-Id", "keep-me")
+
+			StripProviderAuthHeaders(req)
+
+			for _, h := range []string{"Authorization", "anthropic-version", "x-api-key", "x-goog-api-key"} {
+				if got := req.Header.Get(h); got != "" {
+					t.Errorf("%s not stripped: %q", h, got)
+				}
+			}
+			if got := req.Header.Get("X-Request-Id"); got != "keep-me" {
+				t.Errorf("non-auth header should be preserved, got %q", got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Addresses two Strix findings from the 2026-07-18 batch. Investigated both against the current tree; one is a real code defect, the other a dead artifact handled with a scanner allowlist rather than a history rewrite.

## Commit 1 — dead Ollama key (`.gitleaks.toml` allowlist)
Strix flagged an Ollama Cloud API key recoverable from history (`bb7bb913`, `plans/integrating-ollama-cloud.md`). Verified it is **dead**: it returns HTTP 401 and is not among the account's active keys, identical to a random bogus key. The file was already removed from the tree in `370186d7`; the blob survives only in old history.

Rewriting history to scrub a revoked string is not worth force-pushing `master` and breaking every clone/fork/open-PR. Instead we allowlist the fingerprint so external history-walking scanners stop reporting it. (Our CI secret scanning is Trivy on the built image, which never sees this — so no `.trivyignore` entry is warranted.)

## Commit 2 — provider key leak via cross-host redirect (real fix)
The upstream proxy follows 3xx redirects via `SafeDialer.CheckRedirect`, which only rejected targets resolving to private/reserved IPs. Go's `http.Client` strips the standard `Authorization` header on cross-host redirects but forwards **custom** auth headers verbatim, so a provider returning a 302 to another host would leak the credential set by `SetProviderAuthHeaders`: `x-api-key` (Anthropic) and `x-goog-api-key` (Vertex Express).

`CheckRedirect` now strips all provider auth headers whenever a redirect leaves the original upstream host, before the allowlist/IP checks (so it applies even to allowlisted targets). Same-host redirects keep the credential so legitimate redirects still authenticate. `util.StripProviderAuthHeaders` sits next to `SetProviderAuthHeaders` as the single source of truth for the header set. Both upstream paths (primary `doUpstream` and the 400-auto-retry) share this `CheckRedirect`, so both are covered.

Precondition (per Strix): requires an upstream provider to issue the redirect (a compromised/malicious custom provider, or a legitimate provider with an open-redirect flaw) — a plain virtual-key holder cannot trigger it, since targets derive from operator-configured `BaseURL`.

### Tests
- `TestCheckRedirect_StripsCustomAuthHeadersCrossHost` (anthropic + vertex-express): the regression test — `x-api-key`/`x-goog-api-key` are stripped on a cross-host redirect to a public host.
- `TestCheckRedirect_PreservesAuthHeadersSameHost`: same-host redirect keeps the credential.

`go test ./internal/util/... ./internal/proxy/...` green; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)