### PR TITLE
fix(security): validate URL settings on config-sync import (CWE-918)

### DIFF
--- a/internal/api/configsync.go
+++ b/internal/api/configsync.go
@@ -79,6 +79,14 @@ var errStaleSourceGen = errors.New("configsync: import source generation is olde
 // reported backdoor-wipe vector). Import maps it to a 400 refusal.
 var errWouldWipeProviders = errors.New("configsync: refusing to wipe every provider off a populated member")
 
+// errInvalidSyncedURL is returned by apply when a syncable url-typed setting in
+// the envelope fails the same netguard validation the interactive PUT
+// /api/settings handler enforces. Without it a compromised primary could push an
+// oidc_issuer_url the interactive endpoint rejects, which the gateway later
+// fetches during OIDC discovery / token exchange (reported SSRF bypass,
+// CWE-918). Import maps it to a 400 refusal.
+var errInvalidSyncedURL = errors.New("configsync: refusing to apply a setting with an invalid URL")
+
 // ConfigSyncHandler serves the member-side config export/import endpoints. It is
 // mounted inside the admin-authenticated /api group, so every call already
 // requires the admin token (or a session when TOTP is on): a caller able to

--- a/internal/api/configsync_apply.go
+++ b/internal/api/configsync_apply.go
@@ -170,6 +170,13 @@ func (h *ConfigSyncHandler) applySettingsTx(ctx context.Context, tx pgx.Tx, want
 		if !isSyncableSetting(k) {
 			continue // skip non-syncable / unknown keys silently
 		}
+		// Mirror the interactive PUT /api/settings URL validation: the config-sync
+		// path also writes url-typed settings (oidc_issuer_url, ...) that the server
+		// later fetches, so a compromised primary must not bypass netguard here
+		// (CWE-918). A legitimate primary already validated these on the way in.
+		if err := validateSyncedSettingURL(k, v); err != nil {
+			return nil, err
+		}
 		if err := h.settings.SetTx(ctx, tx, k, v); err != nil {
 			return nil, err
 		}
@@ -182,6 +189,29 @@ func (h *ConfigSyncHandler) applySettingsTx(ctx context.Context, tx pgx.Tx, want
 		return nil, err
 	}
 	return removedSettings, nil
+}
+
+// validateSyncedSettingURL applies the same netguard checks to a url-typed
+// setting that the interactive UpdateSettings handler enforces (settings.go),
+// so a config-sync import cannot write an oidc_issuer_url / apprise base URL the
+// interactive endpoint would reject (reported SSRF bypass, CWE-918). Non-URL and
+// unknown keys pass through untouched; the caller has already gated syncability.
+func validateSyncedSettingURL(key, value string) error {
+	rule, ok := allowedSettings[key]
+	if !ok {
+		return nil
+	}
+	switch rule.typeName {
+	case "url":
+		if err := netguard.ValidateURL(value); err != nil {
+			return fmt.Errorf("%w %q: %w", errInvalidSyncedURL, key, err)
+		}
+	case "url_public":
+		if err := netguard.ValidatePublicURL(value); err != nil {
+			return fmt.Errorf("%w %q: %w", errInvalidSyncedURL, key, err)
+		}
+	}
+	return nil
 }
 
 // postImportRefresh runs the best-effort post-commit steps of an import: the

--- a/internal/api/configsync_import.go
+++ b/internal/api/configsync_import.go
@@ -89,6 +89,14 @@ func (h *ConfigSyncHandler) Import(w http.ResponseWriter, r *http.Request) {
 		debuglog.Warn("configsync: refused provider-wiping import")
 		http.Error(w, "refusing to import a config that would delete every provider on this member", http.StatusBadRequest)
 		return
+	case errors.Is(err, errInvalidSyncedURL):
+		// A syncable url-typed setting failed the same netguard validation the
+		// interactive settings endpoint enforces (reported SSRF bypass, CWE-918).
+		// A legitimate primary never exports such a value, so a 400 surfaces the
+		// poisoned/corrupt envelope to Front Desk rather than silently applying it.
+		debuglog.Warn("configsync: refused import with invalid URL setting", "error", err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
 	case err != nil:
 		debuglog.Error("configsync: apply import", "error", err)
 		http.Error(w, "could not apply config", http.StatusInternalServerError)

--- a/internal/api/configsync_test.go
+++ b/internal/api/configsync_test.go
@@ -582,6 +582,82 @@ func TestConfigSync_RefusesUsersOnlyEnvelope(t *testing.T) {
 	}
 }
 
+// TestConfigSync_ImportRejectsPoisonedURLSetting reproduces the reported SSRF
+// bypass (CWE-918). The interactive PUT /api/settings validates url-typed
+// settings with netguard.ValidateURL, but the config-sync apply path wrote them
+// straight through SetTx. A compromised primary could push an oidc_issuer_url the
+// interactive endpoint would reject, and the gateway would later fetch it during
+// OIDC discovery / token exchange (leaking the client secret). The import must
+// refuse the whole envelope with a 400, and its transaction must roll back so no
+// provider or setting from the poisoned envelope survives.
+func TestConfigSync_ImportRejectsPoisonedURLSetting(t *testing.T) {
+	for _, tc := range []struct {
+		name, key, value string
+	}{
+		{"oidc issuer link-local", "oidc_issuer_url", "http://169.254.169.254/"},
+		{"oidc issuer bad scheme", "oidc_issuer_url", "ftp://evil.example/"},
+		{"oidc issuer missing host", "oidc_issuer_url", "http://"},
+		{"public base bad scheme", "oidc_public_base_url", "javascript:alert(1)"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cleanConfigTables(t)
+			r := newConfigSyncRouter(t, configSyncMasterKey)
+			seedProvider(t, "openai", "sk-secret", configSyncMasterKey)
+			env := doExport(t, r)
+			if env.Config.Settings == nil {
+				env.Config.Settings = map[string]string{}
+			}
+			env.Config.Settings[tc.key] = tc.value
+
+			cleanConfigTables(t) // fresh replica: the whole envelope must fail atomically
+			rec := doImport(t, r, env, "")
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("poisoned %s status = %d, want 400; body %s", tc.key, rec.Code, rec.Body.String())
+			}
+			if !bytes.Contains(rec.Body.Bytes(), []byte(tc.key)) {
+				t.Errorf("rejection body should name the setting %q, got %s", tc.key, rec.Body.String())
+			}
+
+			ctx := context.Background()
+			var providers, poisoned int
+			_ = apiTestDB.Pool().QueryRow(ctx, `SELECT count(*) FROM providers`).Scan(&providers)
+			if providers != 0 {
+				t.Errorf("refused import must roll back: providers = %d, want 0", providers)
+			}
+			_ = apiTestDB.Pool().QueryRow(ctx,
+				`SELECT count(*) FROM settings WHERE key = $1`, tc.key).Scan(&poisoned)
+			if poisoned != 0 {
+				t.Errorf("poisoned %s must not be written, count = %d", tc.key, poisoned)
+			}
+		})
+	}
+}
+
+// A valid url-typed setting must still sync: the CWE-918 guard rejects only
+// values the interactive endpoint would reject, never a legitimate primary's
+// already-validated URL (including the empty string that clears the setting).
+func TestConfigSync_ImportAcceptsValidURLSetting(t *testing.T) {
+	cleanConfigTables(t)
+	ctx := context.Background()
+	r := newConfigSyncRouter(t, configSyncMasterKey)
+	seedProvider(t, "openai", "sk-secret", configSyncMasterKey)
+	env := doExport(t, r)
+	if env.Config.Settings == nil {
+		env.Config.Settings = map[string]string{}
+	}
+	env.Config.Settings["oidc_issuer_url"] = "https://idp.example.com/"
+
+	cleanConfigTables(t)
+	rec := doImport(t, r, env, "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("valid URL import status = %d, body %s", rec.Code, rec.Body.String())
+	}
+	if got := settings.NewRepository(apiTestDB.Pool()).
+		GetWithDefault(ctx, "oidc_issuer_url", ""); got != "https://idp.example.com/" {
+		t.Fatalf("valid oidc_issuer_url = %q, want it applied", got)
+	}
+}
+
 // TestConfigSync_RefusesProviderWipeBackdoorInjection reproduces the reported
 // critical bypass (CWE-284) AND the one-line variant of it. The declarative
 // replace in apply() deletes every provider absent from the envelope, so an


### PR DESCRIPTION
## What

Closes the config-sync URL-validation bypass Strix flagged as **vuln-0001** (CWE-918, MEDIUM/4.7).

The interactive `PUT /api/settings` handler validates url-typed settings with `netguard.ValidateURL` (`settings.go:241-248`), but the config-sync apply path (`applySettingsTx`) wrote values straight through `SetTx` with no value validation. A compromised Front Desk primary (or any admin) could push an `oidc_issuer_url` the interactive endpoint would reject via `POST /api/config/import`.

Because the gateway server-fetches the OIDC issuer during discovery + token exchange, and the runtime netguard dial guard only blocks link-local/metadata IPs (private IPs are allowed by design for internal IdPs), a poisoned private-IP issuer (`http://10.0.0.5/`) would be reachable — capturing the OIDC **client secret** on the token exchange. Malformed values also break OIDC login on affected members (DoS).

## Fix

- `applySettingsTx` now validates each syncable url-typed setting before `SetTx`, reusing the existing `allowedSettings` type rules: `netguard.ValidateURL` for `"url"`, `netguard.ValidatePublicURL` for `"url_public"`.
- A failure returns the new `errInvalidSyncedURL` sentinel; `Import` maps it to a **400** (fail-closed inside the import transaction, so the whole poisoned envelope rolls back).
- A legitimate primary already validated these on the way in, so a valid sync is never rejected (empty string still clears the setting).

## Tests

- `TestConfigSync_ImportRejectsPoisonedURLSetting` — table of poisoned values (link-local, bad scheme, missing host, `url_public` bad scheme); asserts 400, body names the setting, and the transaction rolls back (no provider/setting persisted).
- `TestConfigSync_ImportAcceptsValidURLSetting` — a valid `oidc_issuer_url` still applies.

`golangci-lint` clean; full config-sync + settings suites green locally.

> Note: per the team's plan, **deploy waits until the current in-flight work is merged** — this PR is up for review now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)