### PR TITLE
feat(models): bulk-delete endpoint to fix delete stampede

### DIFF
--- a/internal/api/models.go
+++ b/internal/api/models.go
@@ -294,7 +294,7 @@ type BulkDeleteRequest struct {
 // BulkDeleteResponse reports the outcome of a bulk delete. Deleted may be less
 // than Requested when some IDs no longer exist (idempotent, not an error).
 type BulkDeleteResponse struct {
-	Requested int   `json:"requested"`
+	Requested int64 `json:"requested"`
 	Deleted   int64 `json:"deleted"`
 }
 
@@ -342,12 +342,15 @@ func (h *Handler) BulkDeleteModels(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Resync failover groups since deleted models may leave auto-groups with too
-	// few candidates. Best-effort like single-model DeleteModel: log but don't
-	// fail the delete. WithoutCancel so it survives the request completing.
+	// Resync failover groups since the deleted models may leave groups with too
+	// few candidates. SyncForModel handles the auto-group for each affected base
+	// name (deduped, one resync per base instead of one per model); PruneModelUUID
+	// cleans up any custom groups that referenced the deleted UUIDs. Best-effort
+	// like single-model DeleteModel: log but don't fail the delete. WithoutCancel
+	// so it survives the request completing.
 	h.resyncFailoverAfterModelDelete(context.WithoutCancel(r.Context()), modelIDs, ids)
 
-	writeJSON(w, BulkDeleteResponse{Requested: len(ids), Deleted: deleted})
+	writeJSON(w, BulkDeleteResponse{Requested: int64(len(req.IDs)), Deleted: deleted})
 }
 
 // collectDistinctModelIDs returns the distinct provider model_id strings for the

--- a/internal/api/models.go
+++ b/internal/api/models.go
@@ -138,6 +138,7 @@ func (h *Handler) RegisterModels(r chi.Router) {
 		})
 		r.Group(func(r chi.Router) {
 			r.Use(requireAdmin)
+			r.Post("/bulk-delete", h.BulkDeleteModels)
 			r.Patch("/{id}", h.UpdateModel)
 			r.Delete("/{id}", h.DeleteModel)
 			r.Post("/{id}/test", h.TestModel)
@@ -278,6 +279,112 @@ func (h *Handler) DeleteModel(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// maxBulkDeleteIDs caps the number of models a single bulk-delete request may
+// remove, bounding the DELETE ... = ANY($1) parameter and the follow-up
+// failover resync work. Far above any realistic manual selection.
+const maxBulkDeleteIDs = 10000
+
+// BulkDeleteRequest is the JSON body for POST /api/models/bulk-delete.
+type BulkDeleteRequest struct {
+	IDs []string `json:"ids"`
+}
+
+// BulkDeleteResponse reports the outcome of a bulk delete. Deleted may be less
+// than Requested when some IDs no longer exist (idempotent, not an error).
+type BulkDeleteResponse struct {
+	Requested int   `json:"requested"`
+	Deleted   int64 `json:"deleted"`
+}
+
+// BulkDeleteModels removes many models in a single request and resyncs the
+// affected failover groups once at the end. The Models page uses it to clear a
+// large selection without firing one HTTP DELETE per model — a concurrent burst
+// that trips the admin IP rate limiter and surfaces spurious "N failed" toasts.
+func (h *Handler) BulkDeleteModels(w http.ResponseWriter, r *http.Request) {
+	var req BulkDeleteRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		respondBadRequest(w, "invalid request body", err)
+		return
+	}
+	if len(req.IDs) == 0 {
+		respondBadRequest(w, "ids must not be empty", nil)
+		return
+	}
+	if len(req.IDs) > maxBulkDeleteIDs {
+		respondBadRequest(w, fmt.Sprintf("too many ids (max %d)", maxBulkDeleteIDs), nil)
+		return
+	}
+
+	ids := make([]uuid.UUID, 0, len(req.IDs))
+	for _, s := range req.IDs {
+		id, err := uuid.Parse(s)
+		if err != nil {
+			respondBadRequest(w, "invalid model ID: "+s, err)
+			return
+		}
+		ids = append(ids, id)
+	}
+
+	// Capture the affected provider model_ids before deletion so we can resync
+	// the right failover auto-groups afterwards.
+	modelIDs, err := h.collectDistinctModelIDs(r.Context(), ids)
+	if err != nil {
+		respondError(w, "failed to look up models for bulk delete", err, http.StatusInternalServerError)
+		return
+	}
+
+	modelRepo := model.NewRepository(h.dbPool.Pool())
+	deleted, err := modelRepo.DeleteByIDs(r.Context(), ids)
+	if err != nil {
+		respondError(w, "failed to bulk delete models", err, http.StatusInternalServerError)
+		return
+	}
+
+	// Resync failover groups since deleted models may leave auto-groups with too
+	// few candidates. Best-effort like single-model DeleteModel: log but don't
+	// fail the delete. WithoutCancel so it survives the request completing.
+	h.resyncFailoverAfterModelDelete(context.WithoutCancel(r.Context()), modelIDs, ids)
+
+	writeJSON(w, BulkDeleteResponse{Requested: len(ids), Deleted: deleted})
+}
+
+// collectDistinctModelIDs returns the distinct provider model_id strings for the
+// given model UUIDs, used to decide which failover auto-groups to resync.
+func (h *Handler) collectDistinctModelIDs(ctx context.Context, ids []uuid.UUID) ([]string, error) {
+	rows, err := h.dbPool.Pool().Query(ctx, `SELECT DISTINCT model_id FROM models WHERE id = ANY($1)`, ids)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var modelIDs []string
+	for rows.Next() {
+		var mid string
+		if err := rows.Scan(&mid); err != nil {
+			return nil, err
+		}
+		modelIDs = append(modelIDs, mid)
+	}
+	return modelIDs, rows.Err()
+}
+
+// resyncFailoverAfterModelDelete resyncs the auto-group for each affected base
+// model once and prunes any custom groups that referenced the deleted UUIDs.
+// This mirrors the per-model cleanup in DeleteModel, batched for a bulk delete.
+func (h *Handler) resyncFailoverAfterModelDelete(ctx context.Context, modelIDs []string, deletedIDs []uuid.UUID) {
+	failoverRepo := failover.NewRepository(h.dbPool.Pool())
+	for _, mid := range modelIDs {
+		if _, err := failoverRepo.SyncForModel(ctx, mid); err != nil {
+			debuglog.Info("admin: failed to sync failover groups after bulk model delete", "model_id", mid, "error", err)
+		}
+	}
+	for _, id := range deletedIDs {
+		if err := failoverRepo.PruneModelUUID(ctx, id); err != nil {
+			debuglog.Info("admin: failed to prune stale failover entries after bulk model delete", "id", id, "error", err)
+		}
+	}
 }
 
 // TestModelResponse is the JSON response for model test requests.

--- a/internal/api/models_integration_test.go
+++ b/internal/api/models_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
@@ -17,6 +18,7 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/admin"
 	"github.com/hugalafutro/model-hotel/internal/config"
 	"github.com/hugalafutro/model-hotel/internal/db"
+	"github.com/hugalafutro/model-hotel/internal/failover"
 	"github.com/hugalafutro/model-hotel/internal/model"
 	"github.com/hugalafutro/model-hotel/internal/provider"
 	"github.com/hugalafutro/model-hotel/internal/settings"
@@ -599,6 +601,121 @@ func TestBulkDeleteModels_MalformedBody(t *testing.T) {
 
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("Expected 400 for malformed body, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestBulkDeleteModels_RequiresAdmin verifies the endpoint rejects a request
+// with no admin credentials.
+func TestBulkDeleteModels_RequiresAdmin(t *testing.T) {
+	_, r := newTestHandlerWithRouter(t)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/models/bulk-delete", strings.NewReader(`{"ids":["`+uuid.New().String()+`"]}`))
+	req.Header.Set("Content-Type", "application/json")
+	// deliberately no Authorization header
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized && rec.Code != http.StatusForbidden {
+		t.Errorf("Expected 401 or 403 without admin token, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestDeleteModel_RequiresAdmin verifies the single-model delete also rejects a
+// request with no admin credentials.
+func TestDeleteModel_RequiresAdmin(t *testing.T) {
+	_, r := newTestHandlerWithRouter(t)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete, "/models/"+uuid.New().String(), http.NoBody)
+	// deliberately no Authorization header
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized && rec.Code != http.StatusForbidden {
+		t.Errorf("Expected 401 or 403 without admin token, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestBulkDeleteModels_ResyncsFailoverGroup verifies the handler actually
+// resyncs failover after deleting: an auto-group formed from two same-named
+// models must be torn down once the bulk delete removes them (SyncForModel runs
+// synchronously inside the handler, so the state is settled by the response).
+func TestBulkDeleteModels_ResyncsFailoverGroup(t *testing.T) {
+	h, r := newTestHandlerWithRouter(t)
+	pool := h.Pool().Pool()
+	ctx := context.Background()
+
+	// Two enabled providers, one same-named enabled model each: SyncForModel
+	// groups them into an auto-created failover group.
+	base := "shared-bulk-" + uuid.New().String()[:8]
+	provA := bulkDeleteTestProvider(t, r)
+	provB := bulkDeleteTestProvider(t, r)
+	idA, idB := uuid.New(), uuid.New()
+	for _, m := range []struct {
+		id   uuid.UUID
+		prov string
+	}{{idA, provA}, {idB, provB}} {
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO models (id, provider_id, model_id, name, enabled) VALUES ($1, $2, $3, $4, true)`,
+			m.id, m.prov, base, "Shared"); err != nil {
+			t.Fatalf("insert model failed: %v", err)
+		}
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, "DELETE FROM model_failover_groups WHERE display_model = $1", base)
+	})
+
+	failoverRepo := failover.NewRepository(pool)
+	if _, err := failoverRepo.SyncForModel(ctx, base); err != nil {
+		t.Fatalf("SyncForModel setup failed: %v", err)
+	}
+	var groupsBefore int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM model_failover_groups WHERE display_model = $1`, base).Scan(&groupsBefore); err != nil {
+		t.Fatalf("count before failed: %v", err)
+	}
+	if groupsBefore == 0 {
+		t.Fatalf("expected an auto-group for %q before delete, found none", base)
+	}
+
+	// Bulk-delete both members: the handler's resync must remove the now-empty group.
+	body := fmt.Sprintf(`{"ids": [%q, %q]}`, idA, idB)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/models/bulk-delete", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-admin-token")
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var groupsAfter int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM model_failover_groups WHERE display_model = $1`, base).Scan(&groupsAfter); err != nil {
+		t.Fatalf("count after failed: %v", err)
+	}
+	if groupsAfter != 0 {
+		t.Errorf("expected auto-group for %q to be resynced away after delete, still %d present", base, groupsAfter)
+	}
+}
+
+// TestBulkDeleteModels_ResyncFailureDoesNotFail verifies the failover resync is
+// best-effort: even when the resync calls error (here, a cancelled context), the
+// helper swallows them and returns rather than propagating the failure.
+func TestBulkDeleteModels_ResyncFailureDoesNotFail(t *testing.T) {
+	h, _ := newTestHandlerWithRouter(t)
+
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel() // every DB call on this context now errors
+
+	done := make(chan struct{})
+	go func() {
+		// Must return despite SyncForModel and PruneModelUUID erroring.
+		h.resyncFailoverAfterModelDelete(cancelled, []string{"any-model"}, []uuid.UUID{uuid.New()})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("resyncFailoverAfterModelDelete did not return on resync failure")
 	}
 }
 

--- a/internal/api/models_integration_test.go
+++ b/internal/api/models_integration_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -441,6 +442,187 @@ func TestDeleteModel_Success(t *testing.T) {
 		if m.ID == modelID {
 			t.Errorf("Deleted model %s still appears in list", modelID)
 		}
+	}
+}
+
+// bulkDeleteTestProvider creates a provider and returns its ID for bulk-delete tests.
+func bulkDeleteTestProvider(t *testing.T, r chi.Router) string {
+	t.Helper()
+	providerData := fmt.Sprintf(`{"name": "test-provider-%s", "base_url": "https://api.openai.com", "api_key": "test-key"}`, uuid.New().String()[:8])
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/providers", strings.NewReader(providerData))
+	req.Header.Set("Authorization", "Bearer test-admin-token")
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("Failed to create provider: %d: %s", rec.Code, rec.Body.String())
+	}
+	var providerResp struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &providerResp); err != nil {
+		t.Fatalf("Failed to parse provider response: %v", err)
+	}
+	return providerResp.ID
+}
+
+// TestBulkDeleteModels_Success verifies BulkDeleteModels removes exactly the
+// requested models in one request, leaves the rest, and reports the counts.
+func TestBulkDeleteModels_Success(t *testing.T) {
+	h, r := newTestHandlerWithRouter(t)
+	providerID := bulkDeleteTestProvider(t, r)
+	pool := h.Pool().Pool()
+
+	// Insert three models; we will delete the first two.
+	ids := []string{uuid.New().String(), uuid.New().String(), uuid.New().String()}
+	for i, id := range ids {
+		_, err := pool.Exec(context.Background(),
+			`INSERT INTO models (id, provider_id, model_id, name, enabled) VALUES ($1, $2, $3, $4, $5)`,
+			id, providerID, fmt.Sprintf("model-%d", i), fmt.Sprintf("Model %d", i), true)
+		if err != nil {
+			t.Fatalf("Failed to insert model %d: %v", i, err)
+		}
+	}
+
+	body := fmt.Sprintf(`{"ids": [%q, %q]}`, ids[0], ids[1])
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/models/bulk-delete", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-admin-token")
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp BulkDeleteResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Failed to parse response: %v", err)
+	}
+	if resp.Requested != 2 || resp.Deleted != 2 {
+		t.Errorf("Expected requested=2 deleted=2, got requested=%d deleted=%d", resp.Requested, resp.Deleted)
+	}
+
+	// The first two are gone; the third survives.
+	for _, id := range []string{ids[0], ids[1]} {
+		var exists bool
+		if err := pool.QueryRow(context.Background(), `SELECT EXISTS(SELECT 1 FROM models WHERE id = $1)`, id).Scan(&exists); err != nil {
+			t.Fatalf("existence check failed: %v", err)
+		}
+		if exists {
+			t.Errorf("Model %s should have been deleted", id)
+		}
+	}
+	var survives bool
+	if err := pool.QueryRow(context.Background(), `SELECT EXISTS(SELECT 1 FROM models WHERE id = $1)`, ids[2]).Scan(&survives); err != nil {
+		t.Fatalf("existence check failed: %v", err)
+	}
+	if !survives {
+		t.Errorf("Model %s should NOT have been deleted", ids[2])
+	}
+}
+
+// TestBulkDeleteModels_Idempotent verifies that unknown IDs are counted as not
+// deleted rather than failing the request.
+func TestBulkDeleteModels_Idempotent(t *testing.T) {
+	h, r := newTestHandlerWithRouter(t)
+	providerID := bulkDeleteTestProvider(t, r)
+	pool := h.Pool().Pool()
+
+	realID := uuid.New().String()
+	_, err := pool.Exec(context.Background(),
+		`INSERT INTO models (id, provider_id, model_id, name, enabled) VALUES ($1, $2, $3, $4, $5)`,
+		realID, providerID, "real-model", "Real Model", true)
+	if err != nil {
+		t.Fatalf("Failed to insert model: %v", err)
+	}
+
+	// One real ID plus one that does not exist.
+	body := fmt.Sprintf(`{"ids": [%q, %q]}`, realID, uuid.New().String())
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/models/bulk-delete", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-admin-token")
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp BulkDeleteResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Failed to parse response: %v", err)
+	}
+	if resp.Requested != 2 || resp.Deleted != 1 {
+		t.Errorf("Expected requested=2 deleted=1, got requested=%d deleted=%d", resp.Requested, resp.Deleted)
+	}
+}
+
+// TestBulkDeleteModels_EmptyIDs verifies an empty ids array is rejected with 400.
+func TestBulkDeleteModels_EmptyIDs(t *testing.T) {
+	_, r := newTestHandlerWithRouter(t)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/models/bulk-delete", strings.NewReader(`{"ids": []}`))
+	req.Header.Set("Authorization", "Bearer test-admin-token")
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("Expected 400 for empty ids, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestBulkDeleteModels_InvalidUUID verifies a malformed ID is rejected with 400
+// and no models are deleted.
+func TestBulkDeleteModels_InvalidUUID(t *testing.T) {
+	_, r := newTestHandlerWithRouter(t)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/models/bulk-delete", strings.NewReader(`{"ids": ["not-a-uuid"]}`))
+	req.Header.Set("Authorization", "Bearer test-admin-token")
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("Expected 400 for invalid UUID, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestBulkDeleteModels_MalformedBody verifies an unparseable JSON body is 400.
+func TestBulkDeleteModels_MalformedBody(t *testing.T) {
+	_, r := newTestHandlerWithRouter(t)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/models/bulk-delete", strings.NewReader(`{"ids":`))
+	req.Header.Set("Authorization", "Bearer test-admin-token")
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("Expected 400 for malformed body, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestBulkDeleteModels_TooMany verifies requests over the cap are rejected 400.
+func TestBulkDeleteModels_TooMany(t *testing.T) {
+	_, r := newTestHandlerWithRouter(t)
+
+	ids := make([]string, maxBulkDeleteIDs+1)
+	for i := range ids {
+		ids[i] = uuid.New().String()
+	}
+	body, err := json.Marshal(BulkDeleteRequest{IDs: ids})
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/models/bulk-delete", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-admin-token")
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("Expected 400 for over-cap request, got %d: %s", rec.Code, rec.Body.String())
 	}
 }
 

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -436,6 +436,24 @@ func (r *Repository) DeleteByID(ctx context.Context, id uuid.UUID) error {
 	return nil
 }
 
+// DeleteByIDs removes multiple models in a single statement and returns the
+// number of rows actually deleted (IDs that no longer exist are silently
+// skipped, matching DeleteByID's idempotent semantics). It exists so the Models
+// page can clear a large selection in one request instead of firing one HTTP
+// DELETE per model — a burst that trips the admin IP rate limiter.
+func (r *Repository) DeleteByIDs(ctx context.Context, ids []uuid.UUID) (int64, error) {
+	if len(ids) == 0 {
+		return 0, nil
+	}
+	tag, err := r.pool.Exec(ctx, `DELETE FROM models WHERE id = ANY($1)`, ids)
+	if err != nil {
+		debuglog.Error("model: bulk delete failed", "count", len(ids), "error", err)
+		return 0, err
+	}
+	InvalidateModelCache()
+	return tag.RowsAffected(), nil
+}
+
 // UpdateModelRequest contains optional fields for updating a model.
 type UpdateModelRequest struct {
 	DisplayName           *string  `json:"display_name"`

--- a/internal/model/model_crud_test.go
+++ b/internal/model/model_crud_test.go
@@ -1185,6 +1185,79 @@ func TestDeleteByID_Success(t *testing.T) {
 	}
 }
 
+func TestDeleteByIDs_Success(t *testing.T) {
+	ctx := context.Background()
+	repo := NewRepository(testPool)
+
+	providerID := insertTestProvider(ctx, t, "test-delete-ids-success")
+	t.Cleanup(func() { cleanupProvider(ctx, t, providerID) })
+
+	ids := []uuid.UUID{uuid.New(), uuid.New(), uuid.New()}
+	for i, id := range ids {
+		_, err := testPool.Exec(ctx, `
+			INSERT INTO models (id, provider_id, model_id, name, created_at)
+			VALUES ($1, $2, $3, $4, now())
+		`, id, providerID, "delete-me-"+id.String()[:8], "Delete Me")
+		if err != nil {
+			t.Fatalf("insert %d failed: %v", i, err)
+		}
+	}
+
+	// Delete the first two; the third must survive.
+	deleted, err := repo.DeleteByIDs(ctx, ids[:2])
+	if err != nil {
+		t.Fatalf("DeleteByIDs failed: %v", err)
+	}
+	if deleted != 2 {
+		t.Errorf("expected 2 deleted, got %d", deleted)
+	}
+
+	var remaining int
+	if err := testPool.QueryRow(ctx, `SELECT count(*) FROM models WHERE id = ANY($1)`, ids).Scan(&remaining); err != nil {
+		t.Fatalf("count failed: %v", err)
+	}
+	if remaining != 1 {
+		t.Errorf("expected 1 remaining model, got %d", remaining)
+	}
+}
+
+func TestDeleteByIDs_Empty(t *testing.T) {
+	repo := NewRepository(testPool)
+	deleted, err := repo.DeleteByIDs(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("DeleteByIDs(nil) should not error: %v", err)
+	}
+	if deleted != 0 {
+		t.Errorf("expected 0 deleted for empty input, got %d", deleted)
+	}
+}
+
+func TestDeleteByIDs_Idempotent(t *testing.T) {
+	ctx := context.Background()
+	repo := NewRepository(testPool)
+
+	providerID := insertTestProvider(ctx, t, "test-delete-ids-idempotent")
+	t.Cleanup(func() { cleanupProvider(ctx, t, providerID) })
+
+	realID := uuid.New()
+	_, err := testPool.Exec(ctx, `
+		INSERT INTO models (id, provider_id, model_id, name, created_at)
+		VALUES ($1, $2, $3, $4, now())
+	`, realID, providerID, "real-model", "Real Model")
+	if err != nil {
+		t.Fatalf("insert failed: %v", err)
+	}
+
+	// One real ID plus one that does not exist: only the real one counts.
+	deleted, err := repo.DeleteByIDs(ctx, []uuid.UUID{realID, uuid.New()})
+	if err != nil {
+		t.Fatalf("DeleteByIDs failed: %v", err)
+	}
+	if deleted != 1 {
+		t.Errorf("expected 1 deleted, got %d", deleted)
+	}
+}
+
 func TestDeleteByID_CacheInvalidated(t *testing.T) {
 	ctx := context.Background()
 	repo := NewRepository(testPool)

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -486,6 +486,23 @@ export const api = {
 				throw new Error("Failed to delete model");
 			}
 		},
+		// Delete many models in one request. Deleting one HTTP DELETE per model
+		// stampedes the admin IP rate limiter, so bulk selections go through this
+		// single endpoint instead. deleted may be < requested when some IDs were
+		// already gone (idempotent).
+		bulkDelete: async (
+			ids: string[],
+		): Promise<{ requested: number; deleted: number }> => {
+			return fetchJSON<{ requested: number; deleted: number }>(
+				`${API_BASE}/api/models/bulk-delete`,
+				{
+					method: "POST",
+					headers: getAuthHeaders(),
+					body: JSON.stringify({ ids }),
+				},
+				"Failed to delete models",
+			);
+		},
 	},
 
 	logs: {

--- a/web/src/i18n/locales/af.json
+++ b/web/src/i18n/locales/af.json
@@ -784,9 +784,6 @@
 		"toast_delete_models_success_one": "Verwyder {{count}} geaktiveerde model",
 		"toast_delete_models_success_other": "Verwyder {{count}} -ongeskikte modelle",
 		"toast_delete_models_success": "Verwyder {{count}} -ongeskikte modelle",
-		"toast_delete_models_warning_one": "Verwyderde {{kept}} -model, {{failed}} het misluk",
-		"toast_delete_models_warning_other": "Verwyderde {{kept}} -modelle, {{failed}} het misluk",
-		"toast_delete_models_warning": "Verwyderde {{kept}} -modelle, {{failed}} het misluk",
 		"card_models_one": "{{count}} model",
 		"card_models_other": "{{count}} modelle",
 		"add": {
@@ -878,9 +875,6 @@
 		"detail_modal_title": "Modelbesonderhede",
 		"toast_delete_bulk_success_one": "Verwyder {{count}} geaktiveerde model",
 		"toast_delete_bulk_success_other": "Verwyder {{count}} -ongeskikte modelle",
-		"toast_delete_bulk_warning_one": "Verwyderde {{kept}} -model, {{failed}} het misluk",
-		"toast_delete_bulk_warning_other": "Verwyderde {{kept}} -modelle, {{failed}} het misluk",
-		"toast_delete_bulk_warning": "Verwyderde {{kept}} -model, {{failed}} het misluk",
 		"detail": {
 			"snippet": {
 				"curl": "cURL",

--- a/web/src/i18n/locales/ar.json
+++ b/web/src/i18n/locales/ar.json
@@ -784,9 +784,6 @@
 		"toast_delete_models_success_one": "تم تعطيل نموذج {{count}} المحذوف",
 		"toast_delete_models_success_other": "تم تعطيل نماذج {{count}} المحذوفة",
 		"toast_delete_models_success": "تم تعطيل نماذج {{count}} المحذوفة",
-		"toast_delete_models_warning_one": "نموذج {{kept}} المحذوف، {{failed}} فشل",
-		"toast_delete_models_warning_other": "النماذج المحذوفة {{kept}} ، فشل {{failed}}",
-		"toast_delete_models_warning": "النماذج المحذوفة {{kept}} ، فشل {{failed}}",
 		"card_models_one": "نموذج {{count}}",
 		"card_models_other": "نماذج {{count}}",
 		"add": {
@@ -878,9 +875,6 @@
 		"detail_modal_title": "تفاصيل النموذج",
 		"toast_delete_bulk_success_one": "تم تعطيل نموذج {{count}} المحذوف",
 		"toast_delete_bulk_success_other": "تم تعطيل نماذج {{count}} المحذوفة",
-		"toast_delete_bulk_warning_one": "نموذج {{kept}} المحذوف، {{failed}} فشل",
-		"toast_delete_bulk_warning_other": "النماذج المحذوفة {{kept}} ، فشل {{failed}}",
-		"toast_delete_bulk_warning": "نموذج {{kept}} المحذوف، {{failed}} فشل",
 		"detail": {
 			"snippet": {
 				"curl": "cURL",

--- a/web/src/i18n/locales/ca.json
+++ b/web/src/i18n/locales/ca.json
@@ -784,9 +784,6 @@
 		"toast_delete_models_success_one": "Suprimit {{count}} model desactivat",
 		"toast_delete_models_success_other": "Suprimit {{count}} models desactivats",
 		"toast_delete_models_success": "Suprimit {{count}} models desactivats",
-		"toast_delete_models_warning_one": "Suprimit {{kept}} model, {{failed}} fallat",
-		"toast_delete_models_warning_other": "Models {{kept}} eliminats, {{failed}} fallat",
-		"toast_delete_models_warning": "Models {{kept}} eliminats, {{failed}} fallat",
 		"card_models_one": "{{count}} model",
 		"card_models_other": "{{count}} models",
 		"add": {
@@ -878,9 +875,6 @@
 		"detail_modal_title": "Detalls del model",
 		"toast_delete_bulk_success_one": "Suprimit {{count}} model desactivat",
 		"toast_delete_bulk_success_other": "Suprimit {{count}} models desactivats",
-		"toast_delete_bulk_warning_one": "Suprimit {{kept}} model, {{failed}} fallat",
-		"toast_delete_bulk_warning_other": "Models {{kept}} eliminats, {{failed}} fallat",
-		"toast_delete_bulk_warning": "Suprimit {{kept}} model, {{failed}} fallat",
 		"detail": {
 			"snippet": {
 				"curl": "cURL",

--- a/web/src/i18n/locales/cs.json
+++ b/web/src/i18n/locales/cs.json
@@ -784,9 +784,6 @@
 		"toast_delete_models_success_one": "Odstraněný model {{count}} (deaktivován)",
 		"toast_delete_models_success_other": "Odstraněné modely s deaktivovaným {{count}}",
 		"toast_delete_models_success": "Odstraněné modely s deaktivovaným {{count}}",
-		"toast_delete_models_warning_one": "Model {{kept}} byl odstraněn, model {{failed}} selhal",
-		"toast_delete_models_warning_other": "Modely {{kept}} byly odstraněny, {{failed}} selhal",
-		"toast_delete_models_warning": "Modely {{kept}} byly odstraněny, {{failed}} selhal",
 		"card_models_one": "Model {{count}}",
 		"card_models_other": "Modely {{count}}",
 		"add": {
@@ -878,9 +875,6 @@
 		"detail_modal_title": "Podrobnosti o modelu",
 		"toast_delete_bulk_success_one": "Odstraněný model {{count}} (deaktivovaný)",
 		"toast_delete_bulk_success_other": "Odstraněné modely s deaktivovaným {{count}}",
-		"toast_delete_bulk_warning_one": "Model {{kept}} byl odstraněn, model {{failed}} selhal",
-		"toast_delete_bulk_warning_other": "Modely {{kept}} byly odstraněny, {{failed}} selhal",
-		"toast_delete_bulk_warning": "Model {{kept}} byl odstraněn, model {{failed}} selhal",
 		"detail": {
 			"snippet": {
 				"curl": "cURL",

--- a/web/src/i18n/locales/da.json
+++ b/web/src/i18n/locales/da.json
@@ -784,9 +784,6 @@
 		"toast_delete_models_success_one": "Slettede {{count}} deaktiveret model",
 		"toast_delete_models_success_other": "Slettede {{count}} deaktiverede modeller",
 		"toast_delete_models_success": "Slettede {{count}} deaktiverede modeller",
-		"toast_delete_models_warning_one": "Slettede {{kept}} model, {{failed}} mislykkedes",
-		"toast_delete_models_warning_other": "Slettede {{kept}} modeller, {{failed}} mislykkedes",
-		"toast_delete_models_warning": "Slettede {{kept}} modeller, {{failed}} mislykkedes",
 		"card_models_one": "{{count}} model",
 		"card_models_other": "{{count}} modeller",
 		"add": {
@@ -878,9 +875,6 @@
 		"detail_modal_title": "Model Detaljer",
 		"toast_delete_bulk_success_one": "Slettede {{count}} deaktiveret model",
 		"toast_delete_bulk_success_other": "Slettede {{count}} deaktiverede modeller",
-		"toast_delete_bulk_warning_one": "Slettede {{kept}} model, {{failed}} mislykkedes",
-		"toast_delete_bulk_warning_other": "Slettede {{kept}} modeller, {{failed}} mislykkedes",
-		"toast_delete_bulk_warning": "Slettede {{kept}} model, {{failed}} mislykkedes",
 		"detail": {
 			"snippet": {
 				"curl": "cURL",

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -784,9 +784,6 @@
 		"toast_delete_models_success_one": "Gelöschtes {{count}} deaktiviertes Modell",
 		"toast_delete_models_success_other": "Gelöschte {{count}} deaktivierte Modelle",
 		"toast_delete_models_success": "Gelöschte {{count}} deaktivierte Modelle",
-		"toast_delete_models_warning_one": "Löschte {{kept}} Modell, {{failed}} fehlgeschlagen",
-		"toast_delete_models_warning_other": "Gelöschte {{kept}} Modelle, {{failed}} fehlgeschlagen",
-		"toast_delete_models_warning": "Gelöschte {{kept}} Modelle, {{failed}} fehlgeschlagen",
 		"card_models_one": "{{count}} Modell",
 		"card_models_other": "{{count}} Modelle",
 		"add": {
@@ -878,9 +875,6 @@
 		"detail_modal_title": "Modelldetails",
 		"toast_delete_bulk_success_one": "Gelöschtes {{count}} deaktiviertes Modell",
 		"toast_delete_bulk_success_other": "Gelöschte {{count}} deaktivierte Modelle",
-		"toast_delete_bulk_warning_one": "Löschte {{kept}} Modell, {{failed}} fehlgeschlagen",
-		"toast_delete_bulk_warning_other": "Gelöschte {{kept}} Modelle, {{failed}} fehlgeschlagen",
-		"toast_delete_bulk_warning": "Löschte {{kept}} Modell, {{failed}} fehlgeschlagen",
 		"detail": {
 			"snippet": {
 				"curl": "cURL",

--- a/web/src/i18n/locales/el.json
+++ b/web/src/i18n/locales/el.json
@@ -784,9 +784,6 @@
 		"toast_delete_models_success_one": "Διαγραμμένο μοντέλο {{count}} απενεργοποιημένο",
 		"toast_delete_models_success_other": "Διαγραμμένα μοντέλα {{count}} απενεργοποιημένα",
 		"toast_delete_models_success": "Διαγραμμένα μοντέλα {{count}} απενεργοποιημένα",
-		"toast_delete_models_warning_one": "Το μοντέλο {{kept}} διαγράφηκε, {{failed}} απέτυχε",
-		"toast_delete_models_warning_other": "Διαγραφή {{kept}} μοντέλα, {{failed}} απέτυχε",
-		"toast_delete_models_warning": "Διαγραφή {{kept}} μοντέλα, {{failed}} απέτυχε",
 		"card_models_one": "{{count}} μοντέλο",
 		"card_models_other": "{{count}} μοντέλα",
 		"add": {
@@ -878,9 +875,6 @@
 		"detail_modal_title": "Λεπτομέρειες Μοντέλου",
 		"toast_delete_bulk_success_one": "Διαγραμμένο μοντέλο {{count}} απενεργοποιημένο",
 		"toast_delete_bulk_success_other": "Διαγραμμένα μοντέλα {{count}} απενεργοποιημένα",
-		"toast_delete_bulk_warning_one": "Το μοντέλο {{kept}} διαγράφηκε, {{failed}} απέτυχε",
-		"toast_delete_bulk_warning_other": "Διαγραφή {{kept}} μοντέλα, {{failed}} απέτυχε",
-		"toast_delete_bulk_warning": "Το μοντέλο {{kept}} διαγράφηκε, {{failed}} απέτυχε",
 		"detail": {
 			"snippet": {
 				"curl": "cURL",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -786,9 +786,6 @@
 		"toast_delete_models_success_one": "Deleted {{count}} disabled model",
 		"toast_delete_models_success_other": "Deleted {{count}} disabled models",
 		"toast_delete_models_success": "Deleted {{count}} disabled models",
-		"toast_delete_models_warning_one": "Deleted {{kept}} model, {{failed}} failed",
-		"toast_delete_models_warning_other": "Deleted {{kept}} models, {{failed}} failed",
-		"toast_delete_models_warning": "Deleted {{kept}} models, {{failed}} failed",
 		"card_models_one": "{{count}} model",
 		"card_models_other": "{{count}} models",
 		"add": {
@@ -878,9 +875,6 @@
 		"detail_modal_title": "Model Details",
 		"toast_delete_bulk_success_one": "Deleted {{count}} disabled model",
 		"toast_delete_bulk_success_other": "Deleted {{count}} disabled models",
-		"toast_delete_bulk_warning_one": "Deleted {{kept}} model, {{failed}} failed",
-		"toast_delete_bulk_warning_other": "Deleted {{kept}} models, {{failed}} failed",
-		"toast_delete_bulk_warning": "Deleted {{kept}} model, {{failed}} failed",
 		"detail": {
 			"snippet": {
 				"curl": "cURL",

--- a/web/src/i18n/locales/es.json
+++ b/web/src/i18n/locales/es.json
@@ -784,9 +784,6 @@
 		"toast_delete_models_success_one": "Eliminado modelo deshabilitado {{count}}",
 		"toast_delete_models_success_other": "Eliminados modelos {{count}} deshabilitados",
 		"toast_delete_models_success": "Eliminados modelos {{count}} deshabilitados",
-		"toast_delete_models_warning_one": "Modelo {{kept}} eliminado, {{failed}} falló",
-		"toast_delete_models_warning_other": "Modelos {{kept}} eliminados, {{failed}} falló",
-		"toast_delete_models_warning": "Modelos {{kept}} eliminados, {{failed}} falló",
 		"card_models_one": "Modelo {{count}}",
 		"card_models_other": "Modelos {{count}}",
 		"add": {
@@ -878,9 +875,6 @@
 		"detail_modal_title": "Detalles del Modelo",
 		"toast_delete_bulk_success_one": "Eliminado modelo deshabilitado {{count}}",
 		"toast_delete_bulk_success_other": "Eliminados modelos {{count}} deshabilitados",
-		"toast_delete_bulk_warning_one": "Modelo {{kept}} eliminado, {{failed}} falló",
-		"toast_delete_bulk_warning_other": "Modelos {{kept}} eliminados, {{failed}} falló",
-		"toast_delete_bulk_warning": "Modelo {{kept}} eliminado, {{failed}} falló",
 		"detail": {
 			"snippet": {
 				"curl": "cURL",

--- a/web/src/i18n/locales/fi.json
+++ b/web/src/i18n/locales/fi.json
@@ -784,9 +784,6 @@
 		"toast_delete_models_success_one": "Poistettu {{count}} pois käytöstä -malli",
 		"toast_delete_models_success_other": "Poistettu {{count}} käytöstä poistetut mallit",
 		"toast_delete_models_success": "Poistettu {{count}} käytöstä poistetut mallit",
-		"toast_delete_models_warning_one": "Poistettu {{kept}} malli, {{failed}} epäonnistui",
-		"toast_delete_models_warning_other": "Poistettu {{kept}} mallit, {{failed}} epäonnistui",
-		"toast_delete_models_warning": "Poistettu {{kept}} mallit, {{failed}} epäonnistui",
 		"card_models_one": "{{count}} mallia",
 		"card_models_other": "{{count}} mallia",
 		"add": {
@@ -878,9 +875,6 @@
 		"detail_modal_title": "Mallin Tiedot",
 		"toast_delete_bulk_success_one": "Poistettu {{count}} pois käytöstä -malli",
 		"toast_delete_bulk_success_other": "Poistettu {{count}} käytöstä poistetut mallit",
-		"toast_delete_bulk_warning_one": "Poistettu {{kept}} malli, {{failed}} epäonnistui",
-		"toast_delete_bulk_warning_other": "Poistettu {{kept}} mallit, {{failed}} epäonnistui",
-		"toast_delete_bulk_warning": "Poistettu {{kept}} malli, {{failed}} epäonnistui",
 		"detail": {
 			"snippet": {
 				"curl": "cURL",

--- a/web/src/i18n/locales/fr.json
+++ b/web/src/i18n/locales/fr.json
@@ -784,9 +784,6 @@
 		"toast_delete_models_success_one": "Modèle {{count}} supprimé désactivé",
 		"toast_delete_models_success_other": "Modèles {{count}} supprimés",
 		"toast_delete_models_success": "Modèles {{count}} supprimés",
-		"toast_delete_models_warning_one": "Le modèle {{kept}} supprimé, {{failed}} a échoué",
-		"toast_delete_models_warning_other": "Les modèles {{kept}} supprimés, {{failed}} a échoué",
-		"toast_delete_models_warning": "Les modèles {{kept}} supprimés, {{failed}} a échoué",
 		"card_models_one": "Modèle {{count}}",
 		"card_models_other": "Modèles {{count}}",
 		"add": {
@@ -878,9 +875,6 @@
 		"detail_modal_title": "Détails du modèle",
 		"toast_delete_bulk_success_one": "Modèle {{count}} supprimé désactivé",
 		"toast_delete_bulk_success_other": "Modèles {{count}} supprimés",
-		"toast_delete_bulk_warning_one": "Le modèle {{kept}} supprimé, {{failed}} a échoué",
-		"toast_delete_bulk_warning_other": "Les modèles {{kept}} supprimés, {{failed}} a échoué",
-		"toast_delete_bulk_warning": "Le modèle {{kept}} supprimé, {{failed}} a échoué",
 		"detail": {
 			"snippet": {
 				"curl": "cURL",

--- a/web/src/i18n/locales/he.json
+++ b/web/src/i18n/locales/he.json
@@ -784,9 +784,6 @@
 		"toast_delete_models_success_one": "נמחק {{count}} דגם מושבת",
 		"toast_delete_models_success_other": "נמחק {{count}} דוגמניות מושעות",
 		"toast_delete_models_success": "נמחק {{count}} דוגמניות מושעות",
-		"toast_delete_models_warning_one": "נמחק {{kept}} model, {{failed}} נכשל",
-		"toast_delete_models_warning_other": "נמחקו {{kept}} models, {{failed}} נכשל",
-		"toast_delete_models_warning": "נמחקו {{kept}} models, {{failed}} נכשל",
 		"card_models_one": "{{count}} דגם",
 		"card_models_other": "{{count}} דגמים",
 		"add": {
@@ -878,9 +875,6 @@
 		"detail_modal_title": "פרטי הדגם",
 		"toast_delete_bulk_success_one": "נמחק {{count}} דגם מושבת",
 		"toast_delete_bulk_success_other": "נמחק {{count}} דוגמניות מושעות",
-		"toast_delete_bulk_warning_one": "נמחק {{kept}} model, {{failed}} נכשל",
-		"toast_delete_bulk_warning_other": "נמחקו {{kept}} models, {{failed}} נכשל",
-		"toast_delete_bulk_warning": "נמחק {{kept}} model, {{failed}} נכשל",
 		"detail": {
 			"snippet": {
 				"curl": "cURL",

--- a/web/src/i18n/locales/hu.json
+++ b/web/src/i18n/locales/hu.json
@@ -784,9 +784,6 @@
 		"toast_delete_models_success_one": "Törölve {{count}} letiltott modell",
 		"toast_delete_models_success_other": "Törölve {{count}} letiltott modellek",
 		"toast_delete_models_success": "Törölve {{count}} letiltott modellek",
-		"toast_delete_models_warning_one": "Törölve: {{kept}} modell, {{failed}} sikertelen",
-		"toast_delete_models_warning_other": "Törölve: {{kept}} modellek, {{failed}} sikertelen",
-		"toast_delete_models_warning": "Törölve: {{kept}} modellek, {{failed}} sikertelen",
 		"card_models_one": "{{count}} modell",
 		"card_models_other": "{{count}} modellek",
 		"add": {
@@ -878,9 +875,6 @@
 		"detail_modal_title": "A modell részletei",
 		"toast_delete_bulk_success_one": "Törölve {{count}} letiltott modell",
 		"toast_delete_bulk_success_other": "Törölve {{count}} letiltott modellek",
-		"toast_delete_bulk_warning_one": "Törölve: {{kept}} modell, {{failed}} sikertelen",
-		"toast_delete_bulk_warning_other": "Törölve: {{kept}} modellek, {{failed}} sikertelen",
-		"toast_delete_bulk_warning": "Törölve: {{kept}} modell, {{failed}} sikertelen",
 		"detail": {
 			"snippet": {
 				"curl": "cURL",

--- a/web/src/i18n/locales/it.json
+++ b/web/src/i18n/locales/it.json
@@ -784,9 +784,6 @@
 		"toast_delete_models_success_one": "Eliminato {{count}} modello disabilitato",
 		"toast_delete_models_success_other": "Eliminati {{count}} modelli disabilitati",
 		"toast_delete_models_success": "Eliminati {{count}} modelli disabilitati",
-		"toast_delete_models_warning_one": "Eliminato il modello {{kept}} , {{failed}} fallito",
-		"toast_delete_models_warning_other": "Modelli {{kept}} eliminati, {{failed}} falliti",
-		"toast_delete_models_warning": "Modelli {{kept}} eliminati, {{failed}} falliti",
 		"card_models_one": "{{count}} modello",
 		"card_models_other": "{{count}} modelli",
 		"add": {
@@ -878,9 +875,6 @@
 		"detail_modal_title": "Dettagli Modello",
 		"toast_delete_bulk_success_one": "Eliminato {{count}} modello disabilitato",
 		"toast_delete_bulk_success_other": "Eliminati {{count}} modelli disabilitati",
-		"toast_delete_bulk_warning_one": "Eliminato il modello {{kept}} , {{failed}} fallito",
-		"toast_delete_bulk_warning_other": "Modelli {{kept}} eliminati, {{failed}} falliti",
-		"toast_delete_bulk_warning": "Eliminato il modello {{kept}} , {{failed}} fallito",
 		"detail": {
 			"snippet": {
 				"curl": "cURL",

--- a/web/src/i18n/locales/ja.json
+++ b/web/src/i18n/locales/ja.json
@@ -784,9 +784,6 @@
 		"toast_delete_models_success_one": "削除された {{count}} 無効化されたモデル",
 		"toast_delete_models_success_other": "削除された {{count}} 無効化されたモデル",
 		"toast_delete_models_success": "削除された {{count}} 無効化されたモデル",
-		"toast_delete_models_warning_one": "{{kept}} モデルを削除しました。 {{failed}} に失敗しました",
-		"toast_delete_models_warning_other": "{{kept}} モデルを削除しました。 {{failed}} に失敗しました",
-		"toast_delete_models_warning": "{{kept}} モデルを削除しました。 {{failed}} に失敗しました",
 		"card_models_one": "{{count}} モデル",
 		"card_models_other": "{{count}} モデル",
 		"add": {
@@ -878,9 +875,6 @@
 		"detail_modal_title": "モデルの詳細",
 		"toast_delete_bulk_success_one": "削除された {{count}} 無効化されたモデル",
 		"toast_delete_bulk_success_other": "削除された {{count}} 無効化されたモデル",
-		"toast_delete_bulk_warning_one": "{{kept}} モデルを削除しました。 {{failed}} に失敗しました",
-		"toast_delete_bulk_warning_other": "{{kept}} モデルを削除しました。 {{failed}} に失敗しました",
-		"toast_delete_bulk_warning": "{{kept}} モデルを削除しました。 {{failed}} に失敗しました",
 		"detail": {
 			"snippet": {
 				"curl": "cURL",

--- a/web/src/i18n/locales/ko.json
+++ b/web/src/i18n/locales/ko.json
@@ -784,9 +784,6 @@
 		"toast_delete_models_success_one": "삭제됨 {{count}} 비활성화된 모델",
 		"toast_delete_models_success_other": "삭제됨 {{count}} 사용 중지된 모델",
 		"toast_delete_models_success": "삭제됨 {{count}} 사용 중지된 모델",
-		"toast_delete_models_warning_one": "{{kept}} 모델 삭제됨, {{failed}} 실패",
-		"toast_delete_models_warning_other": "삭제됨 {{kept}} 모델, {{failed}} 실패",
-		"toast_delete_models_warning": "삭제됨 {{kept}} 모델, {{failed}} 실패",
 		"card_models_one": "{{count}} 모델",
 		"card_models_other": "{{count}} 모델",
 		"add": {
@@ -878,9 +875,6 @@
 		"detail_modal_title": "모델 상세 정보",
 		"toast_delete_bulk_success_one": "삭제됨 {{count}} 비활성화된 모델",
 		"toast_delete_bulk_success_other": "삭제됨 {{count}} 사용 중지된 모델",
-		"toast_delete_bulk_warning_one": "{{kept}} 모델 삭제됨, {{failed}} 실패",
-		"toast_delete_bulk_warning_other": "삭제됨 {{kept}} 모델, {{failed}} 실패",
-		"toast_delete_bulk_warning": "{{kept}} 모델 삭제됨, {{failed}} 실패",
 		"detail": {
 			"snippet": {
 				"curl": "cURL",

--- a/web/src/i18n/locales/nl.json
+++ b/web/src/i18n/locales/nl.json
@@ -784,9 +784,6 @@
 		"toast_delete_models_success_one": "Verwijderd {{count}} uitgeschakeld model",
 		"toast_delete_models_success_other": "Verwijderde {{count}} uitgeschakelde modellen",
 		"toast_delete_models_success": "Verwijderde {{count}} uitgeschakelde modellen",
-		"toast_delete_models_warning_one": "{{kept}} model verwijderd, {{failed}} mislukt",
-		"toast_delete_models_warning_other": "{{kept}} modellen verwijderd, {{failed}} is mislukt",
-		"toast_delete_models_warning": "{{kept}} modellen verwijderd, {{failed}} is mislukt",
 		"card_models_one": "{{count}} model",
 		"card_models_other": "{{count}} modellen",
 		"add": {
@@ -878,9 +875,6 @@
 		"detail_modal_title": "Model details",
 		"toast_delete_bulk_success_one": "Verwijderd {{count}} uitgeschakeld model",
 		"toast_delete_bulk_success_other": "Verwijderde {{count}} uitgeschakelde modellen",
-		"toast_delete_bulk_warning_one": "{{kept}} model verwijderd, {{failed}} mislukt",
-		"toast_delete_bulk_warning_other": "{{kept}} modellen verwijderd, {{failed}} is mislukt",
-		"toast_delete_bulk_warning": "{{kept}} model verwijderd, {{failed}} mislukt",
 		"detail": {
 			"snippet": {
 				"curl": "cURL",

--- a/web/src/i18n/locales/no.json
+++ b/web/src/i18n/locales/no.json
@@ -784,9 +784,6 @@
 		"toast_delete_models_success_one": "Slettet {{count}} deaktivert modell",
 		"toast_delete_models_success_other": "Slettet {{count}} deaktiverte modeller",
 		"toast_delete_models_success": "Slettet {{count}} deaktiverte modeller",
-		"toast_delete_models_warning_one": "Slettet {{kept}} modell, {{failed}} mislyktes",
-		"toast_delete_models_warning_other": "Slettet {{kept}} modeller, {{failed}} mislyktes",
-		"toast_delete_models_warning": "Slettet {{kept}} modeller, {{failed}} mislyktes",
 		"card_models_one": "{{count}} modell",
 		"card_models_other": "{{count}} modeller",
 		"add": {
@@ -878,9 +875,6 @@
 		"detail_modal_title": "Modell detaljer",
 		"toast_delete_bulk_success_one": "Slettet {{count}} deaktivert modell",
 		"toast_delete_bulk_success_other": "Slettet {{count}} deaktiverte modeller",
-		"toast_delete_bulk_warning_one": "Slettet {{kept}} modell, {{failed}} mislyktes",
-		"toast_delete_bulk_warning_other": "Slettet {{kept}} modeller, {{failed}} mislyktes",
-		"toast_delete_bulk_warning": "Slettet {{kept}} modell, {{failed}} mislyktes",
 		"detail": {
 			"snippet": {
 				"curl": "cURL",

--- a/web/src/i18n/locales/pl.json
+++ b/web/src/i18n/locales/pl.json
@@ -784,9 +784,6 @@
 		"toast_delete_models_success_one": "Usunięto model {{count}} wyłączony",
 		"toast_delete_models_success_other": "Usunięte modele {{count}} wyłączone",
 		"toast_delete_models_success": "Usunięte modele {{count}} wyłączone",
-		"toast_delete_models_warning_one": "Usunięto model {{kept}} , {{failed}} nie powiodło się",
-		"toast_delete_models_warning_other": "Usunięto modele {{kept}} , {{failed}} nie powiodło się",
-		"toast_delete_models_warning": "Usunięto modele {{kept}} , {{failed}} nie powiodło się",
 		"card_models_one": "Model {{count}}",
 		"card_models_other": "Modele {{count}}",
 		"add": {
@@ -878,9 +875,6 @@
 		"detail_modal_title": "Szczegóły modelu",
 		"toast_delete_bulk_success_one": "Usunięto model {{count}} wyłączony",
 		"toast_delete_bulk_success_other": "Usunięte modele {{count}} wyłączone",
-		"toast_delete_bulk_warning_one": "Usunięto model {{kept}} , {{failed}} nie powiodło się",
-		"toast_delete_bulk_warning_other": "Usunięto modele {{kept}} , {{failed}} nie powiodło się",
-		"toast_delete_bulk_warning": "Usunięto model {{kept}} , {{failed}} nie powiodło się",
 		"detail": {
 			"snippet": {
 				"curl": "cURL",

--- a/web/src/i18n/locales/pt.json
+++ b/web/src/i18n/locales/pt.json
@@ -784,9 +784,6 @@
 		"toast_delete_models_success_one": "{{count}} excluído desabilitado modelo",
 		"toast_delete_models_success_other": "Excluído modelos {{count}} desativados",
 		"toast_delete_models_success": "Excluído modelos {{count}} desativados",
-		"toast_delete_models_warning_one": "O modelo {{kept}} excluído, {{failed}} falhou",
-		"toast_delete_models_warning_other": "{{kept}} modelos excluídos, {{failed}} falhou",
-		"toast_delete_models_warning": "{{kept}} modelos excluídos, {{failed}} falhou",
 		"card_models_one": "Modelo {{count}}",
 		"card_models_other": "Modelos {{count}}",
 		"add": {
@@ -878,9 +875,6 @@
 		"detail_modal_title": "Detalhes do modelo",
 		"toast_delete_bulk_success_one": "{{count}} excluído desabilitado modelo",
 		"toast_delete_bulk_success_other": "Excluído modelos {{count}} desativados",
-		"toast_delete_bulk_warning_one": "O modelo {{kept}} excluído, {{failed}} falhou",
-		"toast_delete_bulk_warning_other": "{{kept}} modelos excluídos, {{failed}} falhou",
-		"toast_delete_bulk_warning": "O modelo {{kept}} excluído, {{failed}} falhou",
 		"detail": {
 			"snippet": {
 				"curl": "cURL",

--- a/web/src/i18n/locales/ro.json
+++ b/web/src/i18n/locales/ro.json
@@ -784,9 +784,6 @@
 		"toast_delete_models_success_one": "Model dezactivat de {{count}}",
 		"toast_delete_models_success_other": "{{count}} modele dezactivate",
 		"toast_delete_models_success": "{{count}} modele dezactivate",
-		"toast_delete_models_warning_one": "Modelul {{kept}} a fost șters, {{failed}} a eșuat",
-		"toast_delete_models_warning_other": "{{kept}} modele, {{failed}} a eșuat",
-		"toast_delete_models_warning": "{{kept}} modele, {{failed}} a eșuat",
 		"card_models_one": "{{count}} model",
 		"card_models_other": "{{count}} modele",
 		"add": {
@@ -878,9 +875,6 @@
 		"detail_modal_title": "Detalii model",
 		"toast_delete_bulk_success_one": "Model dezactivat de {{count}}",
 		"toast_delete_bulk_success_other": "{{count}} modele dezactivate",
-		"toast_delete_bulk_warning_one": "Modelul {{kept}} a fost șters, {{failed}} a eșuat",
-		"toast_delete_bulk_warning_other": "{{kept}} modele, {{failed}} a eșuat",
-		"toast_delete_bulk_warning": "Modelul {{kept}} a fost șters, {{failed}} a eșuat",
 		"detail": {
 			"snippet": {
 				"curl": "cURL",

--- a/web/src/i18n/locales/ru.json
+++ b/web/src/i18n/locales/ru.json
@@ -784,9 +784,6 @@
 		"toast_delete_models_success_one": "Модель отключена {{count}}",
 		"toast_delete_models_success_other": "Удаленные {{count}} модели отключены",
 		"toast_delete_models_success": "Удаленные {{count}} модели отключены",
-		"toast_delete_models_warning_one": "Удалена модель {{kept}} , {{failed}} не удалось",
-		"toast_delete_models_warning_other": "Удаленные {{kept}} модели, {{failed}} не удалось",
-		"toast_delete_models_warning": "Удаленные {{kept}} модели, {{failed}} не удалось",
 		"card_models_one": "Модель {{count}}",
 		"card_models_other": "Модели {{count}}",
 		"add": {
@@ -878,9 +875,6 @@
 		"detail_modal_title": "Детали модели",
 		"toast_delete_bulk_success_one": "Модель отключена {{count}}",
 		"toast_delete_bulk_success_other": "Удаленные {{count}} модели отключены",
-		"toast_delete_bulk_warning_one": "Удалена модель {{kept}} , {{failed}} не удалось",
-		"toast_delete_bulk_warning_other": "Удаленные {{kept}} модели, {{failed}} не удалось",
-		"toast_delete_bulk_warning": "Удалена модель {{kept}} , {{failed}} не удалось",
 		"detail": {
 			"snippet": {
 				"curl": "cURL",

--- a/web/src/i18n/locales/sk.json
+++ b/web/src/i18n/locales/sk.json
@@ -784,9 +784,6 @@
 		"toast_delete_models_success_one": "Odstránené {{count}} nefunkčný model",
 		"toast_delete_models_success_other": "Odstránené {{count}} nefunkčné modely",
 		"toast_delete_models_success": "Odstránené {{count}} nefunkčné modely",
-		"toast_delete_models_warning_one": "Odstránené {{kept}} model, {{failed}} neúspešné",
-		"toast_delete_models_warning_other": "Odstránené {{kept}} modely, {{failed}} neúspešné",
-		"toast_delete_models_warning": "Odstránené {{kept}} modely, {{failed}} neúspešné",
 		"card_models_one": "{{count}} model",
 		"card_models_other": "{{count}} modely",
 		"add": {
@@ -878,9 +875,6 @@
 		"detail_modal_title": "Podrobnosti o modeli",
 		"toast_delete_bulk_success_one": "Odstránené {{count}} nefunkčný model",
 		"toast_delete_bulk_success_other": "Odstránené {{count}} nefunkčné modely",
-		"toast_delete_bulk_warning_one": "Odstránené {{kept}} model, {{failed}} neúspešné",
-		"toast_delete_bulk_warning_other": "Odstránené {{kept}} modely, {{failed}} neúspešné",
-		"toast_delete_bulk_warning": "Odstránené {{kept}} model, {{failed}} neúspešné",
 		"detail": {
 			"snippet": {
 				"curl": "cURL",

--- a/web/src/i18n/locales/sr.json
+++ b/web/src/i18n/locales/sr.json
@@ -784,9 +784,6 @@
 		"toast_delete_models_success_one": "Избрисано {{count}} онемогућен модел",
 		"toast_delete_models_success_other": "Избрисано {{count}} онемогућени модели",
 		"toast_delete_models_success": "Избрисано {{count}} онемогућени модели",
-		"toast_delete_models_warning_one": "Избрисано {{kept}} модел, {{failed}} није успео",
-		"toast_delete_models_warning_other": "Избрисани модели {{kept}} , {{failed}} нису успели",
-		"toast_delete_models_warning": "Избрисани модели {{kept}} , {{failed}} нису успели",
 		"card_models_one": "{{count}} модел",
 		"card_models_other": "{{count}} модели",
 		"add": {
@@ -878,9 +875,6 @@
 		"detail_modal_title": "Детаљи модела",
 		"toast_delete_bulk_success_one": "Избрисано {{count}} онемогућен модел",
 		"toast_delete_bulk_success_other": "Избрисано {{count}} онемогућени модели",
-		"toast_delete_bulk_warning_one": "Избрисан {{kept}} модел, {{failed}} није успео",
-		"toast_delete_bulk_warning_other": "Избрисани модели {{kept}} , {{failed}} нису успели",
-		"toast_delete_bulk_warning": "Избрисано {{kept}} модел, {{failed}} није успео",
 		"detail": {
 			"snippet": {
 				"curl": "cURL",

--- a/web/src/i18n/locales/sv.json
+++ b/web/src/i18n/locales/sv.json
@@ -784,9 +784,6 @@
 		"toast_delete_models_success_one": "Raderad {{count}} inaktiverad modell",
 		"toast_delete_models_success_other": "Raderade {{count}} inaktiverade modeller",
 		"toast_delete_models_success": "Raderade {{count}} inaktiverade modeller",
-		"toast_delete_models_warning_one": "Raderad {{kept}} modell, {{failed}} misslyckades",
-		"toast_delete_models_warning_other": "Borttagna {{kept}} modeller, {{failed}} misslyckades",
-		"toast_delete_models_warning": "Borttagna {{kept}} modeller, {{failed}} misslyckades",
 		"card_models_one": "{{count}} modell",
 		"card_models_other": "{{count}} modeller",
 		"add": {
@@ -878,9 +875,6 @@
 		"detail_modal_title": "Modell Detaljer",
 		"toast_delete_bulk_success_one": "Raderad {{count}} inaktiverad modell",
 		"toast_delete_bulk_success_other": "Raderade {{count}} inaktiverade modeller",
-		"toast_delete_bulk_warning_one": "Raderad {{kept}} modell, {{failed}} misslyckades",
-		"toast_delete_bulk_warning_other": "Borttagna {{kept}} modeller, {{failed}} misslyckades",
-		"toast_delete_bulk_warning": "Raderad {{kept}} modell, {{failed}} misslyckades",
 		"detail": {
 			"snippet": {
 				"curl": "cURL",

--- a/web/src/i18n/locales/tr.json
+++ b/web/src/i18n/locales/tr.json
@@ -784,9 +784,6 @@
 		"toast_delete_models_success_one": "Silindi {{count}} devre dışı bırakılmış model",
 		"toast_delete_models_success_other": "Silindi {{count}} devre dışı bırakılmış modeller",
 		"toast_delete_models_success": "Silindi {{count}} devre dışı bırakılmış modeller",
-		"toast_delete_models_warning_one": "Silindi {{kept}} modeli, {{failed}} başarısız",
-		"toast_delete_models_warning_other": "Silindi {{kept}} modeller, {{failed}} başarısız",
-		"toast_delete_models_warning": "Silindi {{kept}} modeller, {{failed}} başarısız",
 		"card_models_one": "{{count}} model",
 		"card_models_other": "{{count}} modeller",
 		"add": {
@@ -878,9 +875,6 @@
 		"detail_modal_title": "Model Bilgileri",
 		"toast_delete_bulk_success_one": "Silindi {{count}} devre dışı bırakılmış model",
 		"toast_delete_bulk_success_other": "Silindi {{count}} devre dışı bırakılmış modeller",
-		"toast_delete_bulk_warning_one": "Silindi {{kept}} modeli, {{failed}} başarısız",
-		"toast_delete_bulk_warning_other": "Silindi {{kept}} modeller, {{failed}} başarısız",
-		"toast_delete_bulk_warning": "Silindi {{kept}} modeli, {{failed}} başarısız",
 		"detail": {
 			"snippet": {
 				"curl": "cURL",

--- a/web/src/i18n/locales/uk.json
+++ b/web/src/i18n/locales/uk.json
@@ -784,9 +784,6 @@
 		"toast_delete_models_success_one": "Видалено модель {{count}}",
 		"toast_delete_models_success_other": "Видалено {{count}} деактивованих моделей",
 		"toast_delete_models_success": "Видалено {{count}} деактивованих моделей",
-		"toast_delete_models_warning_one": "Видалено модель {{kept}} , {{failed}} не вдалося",
-		"toast_delete_models_warning_other": "Видалені {{kept}} моделі, {{failed}} не вдалося",
-		"toast_delete_models_warning": "Видалені {{kept}} моделі, {{failed}} не вдалося",
 		"card_models_one": "{{count}} модель",
 		"card_models_other": "Моделі {{count}}",
 		"add": {
@@ -878,9 +875,6 @@
 		"detail_modal_title": "Деталі моделі",
 		"toast_delete_bulk_success_one": "Видалено модель {{count}}",
 		"toast_delete_bulk_success_other": "Видалено {{count}} деактивованих моделей",
-		"toast_delete_bulk_warning_one": "Видалено модель {{kept}} , {{failed}} не вдалося",
-		"toast_delete_bulk_warning_other": "Видалені {{kept}} моделі, {{failed}} не вдалося",
-		"toast_delete_bulk_warning": "Видалено модель {{kept}} , {{failed}} не вдалося",
 		"detail": {
 			"snippet": {
 				"curl": "cURL",

--- a/web/src/i18n/locales/vi.json
+++ b/web/src/i18n/locales/vi.json
@@ -784,9 +784,6 @@
 		"toast_delete_models_success_one": "Đã xóa {{count}} mô hình đã bị vô hiệu hóa",
 		"toast_delete_models_success_other": "Đã xóa {{count}} các mẫu đã bị vô hiệu hóa",
 		"toast_delete_models_success": "Đã xóa {{count}} các mẫu đã bị vô hiệu hóa",
-		"toast_delete_models_warning_one": "Đã xóa mô hình {{kept}} , {{failed}} không thành công",
-		"toast_delete_models_warning_other": "Đã xóa {{kept}} các mẫu, {{failed}} không thành công",
-		"toast_delete_models_warning": "Đã xóa {{kept}} các mẫu, {{failed}} không thành công",
 		"card_models_one": "{{count}} mẫu",
 		"card_models_other": "{{count}} các mẫu",
 		"add": {
@@ -878,9 +875,6 @@
 		"detail_modal_title": "Chi tiết mẫu",
 		"toast_delete_bulk_success_one": "Đã xóa {{count}} mô hình đã bị vô hiệu hóa",
 		"toast_delete_bulk_success_other": "Đã xóa {{count}} các mẫu đã bị vô hiệu hóa",
-		"toast_delete_bulk_warning_one": "Đã xóa mô hình {{kept}} , {{failed}} không thành công",
-		"toast_delete_bulk_warning_other": "Đã xóa {{kept}} các mẫu, {{failed}} không thành công",
-		"toast_delete_bulk_warning": "Đã xóa mô hình {{kept}} , {{failed}} không thành công",
 		"detail": {
 			"snippet": {
 				"curl": "cURL",

--- a/web/src/i18n/locales/zh.json
+++ b/web/src/i18n/locales/zh.json
@@ -784,9 +784,6 @@
 		"toast_delete_models_success_one": "已删除 {{count}} 已停用该模型",
 		"toast_delete_models_success_other": "已删除 {{count}} 已停用的模型",
 		"toast_delete_models_success": "已删除 {{count}} 已停用的模型",
-		"toast_delete_models_warning_one": "已删除 {{kept}} 模型， {{failed}} 操作失败",
-		"toast_delete_models_warning_other": "已删除 {{kept}} models， {{failed}} 失败",
-		"toast_delete_models_warning": "已删除 {{kept}} models， {{failed}} 失败",
 		"card_models_one": "{{count}} 模型",
 		"card_models_other": "{{count}} 模型",
 		"add": {
@@ -878,9 +875,6 @@
 		"detail_modal_title": "模型详细信息",
 		"toast_delete_bulk_success_one": "已删除 {{count}} 已停用该模型",
 		"toast_delete_bulk_success_other": "已删除 {{count}} 已停用的模型",
-		"toast_delete_bulk_warning_one": "已删除 {{kept}} 模型， {{failed}} 操作失败",
-		"toast_delete_bulk_warning_other": "已删除 {{kept}} models， {{failed}} 失败",
-		"toast_delete_bulk_warning": "已删除 {{kept}} 模型， {{failed}} 操作失败",
 		"detail": {
 			"snippet": {
 				"curl": "cURL",

--- a/web/src/pages/Models.tsx
+++ b/web/src/pages/Models.tsx
@@ -125,28 +125,22 @@ export function Models() {
 
 	const handleDeleteDisabled = useCallback(
 		async (ids: string[]) => {
-			let failed = 0;
-			await Promise.all(
-				ids.map((id) =>
-					api.models.delete(id).catch(() => {
-						failed++;
-					}),
-				),
-			);
-			queryClient.invalidateQueries({ queryKey: ["models"] });
-			setModelRefreshTrigger((n) => n + 1);
-			if (failed === 0) {
+			try {
+				// One atomic request instead of one DELETE per model: a concurrent
+				// burst trips the admin IP rate limiter and reports spurious failures.
+				const { deleted } = await api.models.bulkDelete(ids);
+				queryClient.invalidateQueries({ queryKey: ["models"] });
+				setModelRefreshTrigger((n) => n + 1);
 				toast(
-					t("models.toast_delete_bulk_success", { count: ids.length }),
+					t("models.toast_delete_bulk_success", { count: deleted }),
 					"success",
 				);
-			} else {
+			} catch (err) {
+				queryClient.invalidateQueries({ queryKey: ["models"] });
+				setModelRefreshTrigger((n) => n + 1);
 				toast(
-					t("models.toast_delete_bulk_warning", {
-						kept: ids.length - failed,
-						failed,
-					}),
-					"warning",
+					t("models.toast_delete_failed", { message: (err as Error).message }),
+					"error",
 				);
 			}
 		},

--- a/web/src/pages/Models/__tests__/Models.test.tsx
+++ b/web/src/pages/Models/__tests__/Models.test.tsx
@@ -921,8 +921,8 @@ describe("Models", () => {
 
 			server.use(
 				...mockAllDefaults({ models }),
-				http.delete("/api/models/:id", () => {
-					return new HttpResponse(null, { status: 204 });
+				http.post("/api/models/bulk-delete", () => {
+					return HttpResponse.json({ requested: 2, deleted: 2 });
 				}),
 			);
 
@@ -952,7 +952,7 @@ describe("Models", () => {
 			});
 		});
 
-		it("shows warning toast when some deletes fail", async () => {
+		it("shows error toast when the bulk delete request fails", async () => {
 			const models = [
 				{ ...mockModel, id: "model-001", enabled: true },
 				{
@@ -969,15 +969,9 @@ describe("Models", () => {
 				},
 			];
 
-			let deleteCount = 0;
 			server.use(
 				...mockAllDefaults({ models }),
-				http.delete("/api/models/:id", () => {
-					deleteCount++;
-					// First delete succeeds, second fails
-					if (deleteCount === 1) {
-						return new HttpResponse(null, { status: 204 });
-					}
+				http.post("/api/models/bulk-delete", () => {
 					return HttpResponse.json(
 						{ error: "Database connection failed" },
 						{ status: 500 },
@@ -1001,11 +995,11 @@ describe("Models", () => {
 			// Click "Delete" in the confirm dialog
 			await user.click(screen.getByRole("button", { name: "Delete" }));
 
-			// Should show warning toast with partial failure message
+			// Should show error toast (the whole request failed atomically)
 			await waitFor(() => {
 				expect(
 					screen.getByRole("button", {
-						name: /Deleted 1 model, 1 failed/,
+						name: /Failed to delete/,
 					}),
 				).toBeInTheDocument();
 			});

--- a/web/src/pages/Providers.tsx
+++ b/web/src/pages/Providers.tsx
@@ -257,27 +257,22 @@ export function Providers() {
 
 	const handleDeleteDisabledModels = useCallback(
 		async (ids: string[]) => {
-			let failed = 0;
-			await Promise.all(
-				ids.map((id) =>
-					api.models.delete(id).catch(() => {
-						failed++;
-					}),
-				),
-			);
-			queryClient.invalidateQueries({ queryKey: ["models"] });
-			if (failed === 0) {
+			try {
+				// One atomic request instead of one DELETE per model: a concurrent
+				// burst trips the admin IP rate limiter and reports spurious failures.
+				const { deleted } = await api.models.bulkDelete(ids);
+				queryClient.invalidateQueries({ queryKey: ["models"] });
 				toast(
-					t("providers.toast_delete_models_success", { count: ids.length }),
+					t("providers.toast_delete_models_success", { count: deleted }),
 					"success",
 				);
-			} else {
+			} catch (err) {
+				queryClient.invalidateQueries({ queryKey: ["models"] });
 				toast(
-					t("providers.toast_delete_models_warning", {
-						kept: ids.length - failed,
-						failed,
+					t("providers.toast_delete_failed", {
+						message: (err as Error).message,
 					}),
-					"warning",
+					"error",
 				);
 			}
 		},

--- a/web/src/pages/__tests__/Providers.test.tsx
+++ b/web/src/pages/__tests__/Providers.test.tsx
@@ -1352,7 +1352,7 @@ describe("Providers", () => {
 				name: "Disabled Model 2",
 			};
 
-			let deleteCallCount = 0;
+			let bulkCallCount = 0;
 			const deletedIds: string[] = [];
 
 			server.use(
@@ -1366,10 +1366,14 @@ describe("Providers", () => {
 						disabledModel2,
 					]);
 				}),
-				http.delete("/api/models/:id", ({ params }) => {
-					deleteCallCount++;
-					deletedIds.push(params.id as string);
-					return new HttpResponse(null, { status: 204 });
+				http.post("/api/models/bulk-delete", async ({ request }) => {
+					bulkCallCount++;
+					const body = (await request.json()) as { ids: string[] };
+					deletedIds.push(...body.ids);
+					return HttpResponse.json({
+						requested: body.ids.length,
+						deleted: body.ids.length,
+					});
 				}),
 			);
 
@@ -1415,9 +1419,9 @@ describe("Providers", () => {
 			});
 			await user.click(confirmBtn);
 
-			// Verify all disabled models were deleted
+			// Verify all disabled models were deleted in a single bulk request
 			await waitFor(() => {
-				expect(deleteCallCount).toBe(2);
+				expect(bulkCallCount).toBe(1);
 				expect(deletedIds).toContain("model-002");
 				expect(deletedIds).toContain("model-003");
 				expect(
@@ -1426,7 +1430,7 @@ describe("Providers", () => {
 			});
 		});
 
-		it("shows warning toast when some deletions fail", async () => {
+		it("shows error toast when the bulk delete request fails", async () => {
 			const enabledModel = { ...mockModel, id: "model-001", enabled: true };
 			const disabledModel1 = {
 				...mockModel,
@@ -1459,15 +1463,11 @@ describe("Providers", () => {
 						disabledModel3,
 					]);
 				}),
-				http.delete("/api/models/:id", ({ params }) => {
-					// Fail deletion for model-003
-					if (params.id === "model-003") {
-						return HttpResponse.json(
-							{ error: "Failed to delete model" },
-							{ status: 500 },
-						);
-					}
-					return new HttpResponse(null, { status: 204 });
+				http.post("/api/models/bulk-delete", () => {
+					return HttpResponse.json(
+						{ error: "Failed to delete models" },
+						{ status: 500 },
+					);
 				}),
 			);
 
@@ -1513,11 +1513,9 @@ describe("Providers", () => {
 			});
 			await user.click(confirmBtn);
 
-			// Verify partial success toast (2 succeeded, 1 failed)
+			// Verify error toast (the whole request failed atomically)
 			await waitFor(() => {
-				expect(
-					screen.getByText(/Deleted 2 models?[, ]+1 failed/),
-				).toBeInTheDocument();
+				expect(screen.getByText(/Failed to delete/)).toBeInTheDocument();
 			});
 		});
 	});


### PR DESCRIPTION
## What

Adds `POST /api/models/bulk-delete` (`{ids:[...]}` → `{requested, deleted}`) and rewires both bulk-delete call sites to use it instead of firing one `DELETE /api/models/{id}` per model.

## Why

Investigating MH1's live logs after a "Deleted 94 model / 34 failed" toast: the Models page deleted a selection via `Promise.all`, so ~130 `DELETE` requests landed in the same ~400 ms burst. The admin IP rate limiter (`ipLimiter.Middleware`, 30 RPS / 60 burst — there to slow auth brute-forcing) rejected 34 of them with **429**. There were zero DB errors — the "failures" were throttling, and they cleared on reload once the burst was over. The `.catch(() => failed++)` couldn't distinguish a 429 from a real failure. The warning toast also mispluralized ("model" not "models") because it was rendered without a `count`.

`Providers.tsx` had the identical per-id stampede for its disabled-models modal; fixed here too.

## How

- **`internal/model/model.go`** — `DeleteByIDs`: one `DELETE ... WHERE id = ANY($1)`, returns rows affected.
- **`internal/api/models.go`** — `BulkDeleteModels` (admin-gated, cap 10000): validates IDs, deletes in one statement, then resyncs each affected failover auto-group **once** + prunes custom groups (was one resync per deleted model before). Idempotent: `deleted` may be `< requested` when some IDs were already gone.
- **Frontend** — `api.models.bulkDelete`; `Models.tsx` + `Providers.tsx` rewired to the single call. Success shows the real deleted count with correct pluralization; a failed request shows an error toast. The partial-failure/warning path is gone since the delete is atomic, so the now-orphaned `toast_delete_*_warning` i18n keys are removed from all locales.

## Tests

6 handler integration tests (success, idempotent, empty, invalid UUID, malformed body, over-cap) + 3 `DeleteByIDs` repo tests; updated the two obsolete partial-failure tests in `Models.test.tsx` / `Providers.test.tsx`. `make i18n-check`, `tsc`, Biome, and `golangci-lint` all clean.

## Notes (non-blocking, from review)

Three test gaps flagged by review are pre-existing and shared with single-model `DeleteModel`, so this branch neither introduces nor owes them: no resync-verification test, no `requireAdmin` rejection test, no "resync-failure-doesn't-fail-delete" test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)