### PR TITLE
test(backup): cover restore in-flight button state deterministically

### DIFF
--- a/web/src/pages/Settings/__tests__/DatabaseBackupSettings.test.tsx
+++ b/web/src/pages/Settings/__tests__/DatabaseBackupSettings.test.tsx
@@ -842,7 +842,57 @@ describe("DatabaseBackupSettings", () => {
 		expect(clickSpy).toHaveBeenCalled();
 	});
 
-	// TODO: test button disabled/text state during restore — flaky due to modal timing
+	it("disables the upload button and shows 'Restoring…' while a restore is in flight", async () => {
+		const user = userEvent.setup();
+
+		// Hold the restore request open with a gate we release explicitly, so the
+		// in-flight state is stable to assert instead of racing the response.
+		let releaseRestore: () => void = () => {};
+		const restoreGate = new Promise<void>((resolve) => {
+			releaseRestore = resolve;
+		});
+		server.use(
+			http.post("/api/backups/restore", async () => {
+				await restoreGate;
+				return HttpResponse.json({ success: true });
+			}),
+		);
+
+		renderWithProviders(
+			<DatabaseBackupSettings collapsed={false} onToggle={onToggle} />,
+		);
+
+		// Capture the upload/restore button now: in flight both it and the modal's
+		// confirm button read "Restoring…", so hold a ref to assert the right one.
+		const uploadButton = await screen.findByRole("button", {
+			name: /upload & restore/i,
+		});
+
+		// The confirm modal opens on file selection, not on the button click.
+		const fileInput = screen.getByLabelText("Select backup file to restore");
+		await user.upload(
+			fileInput,
+			new File(["dump"], "backup.dump", { type: "application/octet-stream" }),
+		);
+		const tokenInput = await screen.findByLabelText("Confirm with admin token");
+		await user.type(tokenInput, "test-admin-token");
+		await user.click(screen.getByRole("button", { name: /restore database/i }));
+
+		// In flight: the upload button is disabled and relabeled "Restoring…".
+		await waitFor(() => {
+			expect(uploadButton).toBeDisabled();
+			expect(uploadButton).toHaveTextContent("Restoring…");
+		});
+
+		// Releasing the request lets the restore complete and drops the in-flight state.
+		releaseRestore();
+		await waitFor(() => {
+			expect(
+				screen.getByText("Database restored. The server is restarting…"),
+			).toBeInTheDocument();
+		});
+		expect(uploadButton).not.toBeDisabled();
+	});
 
 	it("formats KB correctly (1536 bytes → 1.5 KB)", async () => {
 		server.use(


### PR DESCRIPTION
## What

Replaces the `TODO: test button disabled/text state during restore — flaky due to modal timing` placeholder in `DatabaseBackupSettings.test.tsx` with a real, deterministic test.

## Why

It was the one genuine deferred item left after the skip purge (#526). The original attempt was flaky because it raced the restore response and the confirm-modal lifecycle — the restore resolved (or the modal closed) before the assertion could observe the in-flight state.

## How

- Holds `POST /api/backups/restore` open with an explicit gate promise, so the in-flight state is stable to assert instead of racing the response.
- Captures the "Upload & Restore" button by reference before starting — in flight both it and the modal's confirm button read "Restoring…", so a ref disambiguates.
- Asserts the button is `disabled` and relabeled "Restoring…" while the request is pending, then releases the gate and asserts the restore completes ("Database restored…") and the button re-enables.
- Uses real timers; the post-success poll returns on its first immediate `200` from the default `GET /api/backups` mock, so no dangling timer.

## Tests

Passes 5/5 on repeat. Full `DatabaseBackupSettings.test.tsx` file green (66 tests); `tsc` and Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)