### PR TITLE
fix(configsync): apply admin-grade SSRF guard to imported provider URLs

### DIFF
--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -351,7 +351,7 @@ func (h *Handler) registerAdminOnly(r chi.Router) {
 			// synced member's own scheduled sweep owns disabling.
 			_, _, _, _, err := h.discoverAllProviders(ctx, false)
 			return err
-		}).Register(r)
+		}, h.cfg.ValidateProviderURL).Register(r)
 
 	// HA fleet membership heartbeat (Phase 6). Front Desk POSTs /fleet/announce
 	// on its poll; the member records the contact as instance-local _fleet_*

--- a/internal/api/configsync.go
+++ b/internal/api/configsync.go
@@ -100,15 +100,26 @@ type ConfigSyncHandler struct {
 	// providers, so custom failover groups can resolve. Nil disables it (tests
 	// that seed models directly pass nil).
 	discoverAll func(context.Context) error
+	// validateProviderURL guards imported provider base_urls with the same SSRF
+	// check the interactive admin API applies on CreateProvider/UpdateProvider
+	// (config.ValidateProviderURL): resolve DNS and reject loopback, RFC
+	// 1918/ULA, link-local, CGNAT and cloud-metadata addresses (hosts in
+	// ALLOWED_PROVIDER_HOSTS are exempted). Keeps a compromised primary from
+	// persisting a base_url the admin API would refuse. Nil disables the check
+	// (tests that do not exercise it pass nil).
+	validateProviderURL func(string) error
 }
 
 // NewConfigSyncHandler builds the handler. masterKey is needed only to verify
 // (on import) that this member can decrypt the incoming provider keys; the
-// plaintext is never produced here.
+// plaintext is never produced here. validateProviderURL applies the admin API's
+// SSRF check to imported provider base_urls (see the field doc); production
+// passes config.ValidateProviderURL, tests may pass nil to skip it.
 func NewConfigSyncHandler(database *db.DB, settingsRepo SettingsStore, masterKey, appVersion string,
-	discoverAll func(context.Context) error) *ConfigSyncHandler {
+	discoverAll func(context.Context) error, validateProviderURL func(string) error) *ConfigSyncHandler {
 	return &ConfigSyncHandler{
-		db: database, settings: settingsRepo, masterKey: masterKey, appVersion: appVersion, discoverAll: discoverAll,
+		db: database, settings: settingsRepo, masterKey: masterKey, appVersion: appVersion,
+		discoverAll: discoverAll, validateProviderURL: validateProviderURL,
 	}
 }
 

--- a/internal/api/configsync_apply.go
+++ b/internal/api/configsync_apply.go
@@ -48,7 +48,7 @@ func (h *ConfigSyncHandler) apply(ctx context.Context, env ConfigEnvelope, sourc
 		return err
 	}
 
-	if err := upsertProviders(ctx, tx, env.Config.Providers); err != nil {
+	if err := upsertProviders(ctx, tx, env.Config.Providers, h.validateProviderURL); err != nil {
 		return err
 	}
 	// Declarative replace: drop providers absent from the primary. This cascades
@@ -317,14 +317,20 @@ func (h *ConfigSyncHandler) syncableSettingsToDelete(ctx context.Context, q quer
 	return toDelete, nil
 }
 
-func upsertProviders(ctx context.Context, tx pgx.Tx, providers []ExportProvider) error {
+func upsertProviders(ctx context.Context, tx pgx.Tx, providers []ExportProvider, validateURL func(string) error) error {
 	for _, p := range providers {
 		// Defense in depth on the import path: a compromised primary must not be
-		// able to write a provider base_url that points at a link-local/metadata
-		// address. The runtime proxy SafeDialer still blocks it at dial time, but
-		// rejecting it here keeps the poisoned value out of the database entirely.
-		if err := netguard.ValidateURL(p.BaseURL); err != nil {
-			return fmt.Errorf("provider %q has an invalid base_url: %w", p.Name, err)
+		// able to write a provider base_url that the interactive admin API would
+		// reject. validateURL is the same guard CreateProvider/UpdateProvider use
+		// (config.ValidateProviderURL): it resolves DNS and blocks loopback, RFC
+		// 1918/ULA, link-local, CGNAT and cloud-metadata addresses (hosts in
+		// ALLOWED_PROVIDER_HOSTS are exempted). The runtime proxy SafeDialer also
+		// blocks these at dial time, but rejecting here keeps the poisoned value
+		// out of the database entirely. Nil validateURL disables the check (tests).
+		if validateURL != nil {
+			if err := validateURL(p.BaseURL); err != nil {
+				return fmt.Errorf("provider %q has an invalid base_url: %w", p.Name, err)
+			}
 		}
 		_, err := tx.Exec(ctx, `
 			INSERT INTO providers (name, base_url, encrypted_key, key_nonce, key_salt, masked_key, enabled, autodiscovery_enabled, updated_at)

--- a/internal/api/configsync_test.go
+++ b/internal/api/configsync_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/hugalafutro/model-hotel/internal/auth"
+	"github.com/hugalafutro/model-hotel/internal/config"
 	"github.com/hugalafutro/model-hotel/internal/settings"
 )
 
@@ -32,7 +33,7 @@ func newConfigSyncRouter(t *testing.T, masterKey string) chi.Router {
 // import (the real wiring runs discoverAllProviders).
 func newConfigSyncRouterWithDiscovery(t *testing.T, masterKey string, discoverAll func(context.Context) error) chi.Router {
 	t.Helper()
-	h := NewConfigSyncHandler(apiTestDB, settings.NewRepository(apiTestDB.Pool()), masterKey, "v-test", discoverAll)
+	h := NewConfigSyncHandler(apiTestDB, settings.NewRepository(apiTestDB.Pool()), masterKey, "v-test", discoverAll, nil)
 	r := chi.NewRouter()
 	h.Register(r)
 	return r
@@ -805,7 +806,7 @@ func TestConfigSync_ImportDBError(t *testing.T) {
 // handling is covered without a broken database.
 func TestConfigSync_HelperDBErrors(t *testing.T) {
 	pool := apiTestDB.Pool()
-	h := NewConfigSyncHandler(apiTestDB, settings.NewRepository(pool), configSyncMasterKey, "v-test", nil)
+	h := NewConfigSyncHandler(apiTestDB, settings.NewRepository(pool), configSyncMasterKey, "v-test", nil, nil)
 	cctx := cancelledCtx()
 	env := ConfigEnvelope{
 		SchemaVersion: configSchemaVersion,
@@ -851,7 +852,7 @@ func TestConfigSync_ApplyHelperDBErrors(t *testing.T) {
 	cleanConfigTables(t)
 	ctx := context.Background()
 	pool := apiTestDB.Pool()
-	h := NewConfigSyncHandler(apiTestDB, settings.NewRepository(pool), configSyncMasterKey, "v-test", nil)
+	h := NewConfigSyncHandler(apiTestDB, settings.NewRepository(pool), configSyncMasterKey, "v-test", nil, nil)
 
 	deadTx := func() pgx.Tx {
 		tx, err := pool.Begin(ctx)
@@ -903,6 +904,53 @@ func TestConfigSync_ApplyHelperDBErrors(t *testing.T) {
 	// syncable key still triggers the failing delete.
 	if _, err := h.applySettingsTx(ctx, roTx, map[string]string{"not_a_syncable_key": "x"}); err == nil {
 		t.Error("applySettingsTx should error when DeleteKeysTx fails on a read-only tx")
+	}
+}
+
+// TestUpsertProviders_ProviderURLGuard proves the config-sync import path
+// applies the same SSRF guard as the interactive admin API (config.
+// ValidateProviderURL) rather than the weaker netguard.ValidateURL: a base_url
+// resolving to a private/reserved address is refused (kept out of the database),
+// while a public one still imports. Literal IPs are used so the guard's DNS
+// resolution is deterministic and never touches the network.
+func TestUpsertProviders_ProviderURLGuard(t *testing.T) {
+	cleanConfigTables(t)
+	ctx := context.Background()
+	pool := apiTestDB.Pool()
+	validate := (&config.Config{}).ValidateProviderURL
+
+	// Reject: a private-IP base_url the admin API would refuse must not be
+	// persisted. Validation fails before any INSERT, so an empty-key provider
+	// is fine here.
+	rejTx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	err = upsertProviders(ctx, rejTx, []ExportProvider{
+		{Name: "ssrf-probe", BaseURL: "http://10.0.0.5/v1"},
+	}, validate)
+	_ = rejTx.Rollback(ctx)
+	if err == nil {
+		t.Fatal("upsertProviders should reject a private-IP base_url on import")
+	}
+
+	// Accept: a public-IP base_url still imports through the same guard, so the
+	// stricter check does not over-block legitimate fleet providers.
+	kp, err := auth.Encrypt("sk-ok", configSyncMasterKey)
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	okTx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	defer func() { _ = okTx.Rollback(ctx) }()
+	err = upsertProviders(ctx, okTx, []ExportProvider{{
+		Name: "public", BaseURL: "http://8.8.8.8/v1", Enabled: true,
+		EncryptedKey: kp.Ciphertext, KeyNonce: kp.Nonce, KeySalt: kp.Salt,
+	}}, validate)
+	if err != nil {
+		t.Fatalf("upsertProviders should accept a public base_url: %v", err)
 	}
 }
 

--- a/internal/api/fleet_test.go
+++ b/internal/api/fleet_test.go
@@ -470,7 +470,7 @@ func TestConfigSyncApplyStampsFleetMarker(t *testing.T) {
 	cleanConfigTables(t)
 	ctx := context.Background()
 	sr := settings.NewRepository(apiTestDB.Pool())
-	h := NewConfigSyncHandler(apiTestDB, sr, "", "v-test", nil)
+	h := NewConfigSyncHandler(apiTestDB, sr, "", "v-test", nil, nil)
 
 	// Instance-local fleet key (must survive) + a syncable key the envelope omits
 	// (must be deleted by the declarative replace).


### PR DESCRIPTION
## Summary

Closes Strix **vuln-0001** (2026-07-20, CWE-918 SSRF, defense-in-depth gap).

The config-sync import path (`upsertProviders`) validated provider `base_url`s with `netguard.ValidateURL`, which only rejects literal link-local/metadata IPs and never resolves DNS. The interactive admin API (`CreateProvider`/`UpdateProvider`) uses the stricter `config.ValidateProviderURL`, which resolves DNS and blocks loopback, RFC 1918/ULA, link-local, CGNAT and cloud-metadata addresses.

A compromised fleet primary (or admin) could therefore persist a provider `base_url` via `POST /api/config-sync/import` pointing at an internal/private address that the admin API would reject — e.g. `http://10.0.0.5/v1`.

This is a follow-up to #520, which added the import-path guard but wired in the weaker validator.

## Fix

- Thread the **same** guard the admin API uses (`config.ValidateProviderURL`) into `ConfigSyncHandler` as an injected callback, mirroring the existing `discoverAll` pattern. Both entry points now enforce identical SSRF validation.
- The settings URL path (`validateSyncedSettingURL`: OIDC issuer, apprise) intentionally **stays** on `netguard` — those legitimately point at internal hosts. Only provider `base_url` is upgraded.
- Fleet deployments with internal LLM URLs are unaffected: `ALLOWED_PROVIDER_HOSTS` exempts them exactly as it does for the admin API.

## Tests

- New `TestUpsertProviders_ProviderURLGuard` (deterministic, literal IPs — no network): rejects `http://10.0.0.5/v1`, accepts `http://8.8.8.8/v1`.
- Existing config-sync + fleet suite unchanged and green (their base_urls are non-resolving/known hosts).
- `go build`, `go vet`, `golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)