### PR TITLE
feat: httpOnly cookie auth for the dashboard (session tokens out of localStorage)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -248,7 +248,7 @@ func main() {
 	// the same CreateAuthToken, so no downstream gate changes. Config lives in
 	// settings (rebuilt lazily on change), so it is always constructed; the
 	// public status/start/callback endpoints no-op until oidc_enabled is set.
-	oidcHandler := adminauth.NewOIDCHandler(settingsRepo, sessionMgr, ipLimiter, cfg.MasterKey)
+	oidcHandler := adminauth.NewOIDCHandler(settingsRepo, sessionMgr, ipLimiter, cfg.MasterKey, true, cfg.CookieSecure)
 	oidcHandler.SetUserResolver(userRepo)
 
 	// GitHub SSO is a fourth admin-login front-end, alongside OIDC/passkey/TOTP.

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -273,7 +273,7 @@ func main() {
 		if err != nil {
 			debuglog.Fatal("startup: failed to initialize WebAuthn relying party", "error", err)
 		}
-		webauthnHandler = adminauth.NewWebAuthnHandler(webauthnRepo, rp, sessionMgr, adminMgr, ipLimiter, cfg.DemoReadOnly, apiHandler.TotpEnabled)
+		webauthnHandler = adminauth.NewWebAuthnHandler(webauthnRepo, rp, sessionMgr, adminMgr, ipLimiter, cfg.DemoReadOnly, apiHandler.TotpEnabled, true, cfg.CookieSecure)
 
 		debuglog.Info("webauthn: passkey authentication enabled", "rp_id", cfg.WebAuthnRPID)
 	}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -241,7 +241,7 @@ func main() {
 	// IsEnabled state wired into the Handler (AuthMiddleware gate).
 	totpRepo := totp.NewRepository(database.Pool(), cfg.MasterKey)
 	apiHandler.SetTotpStatus(totpRepo)
-	totpHandler := adminauth.NewTotpHandler(totpRepo, adminMgr, sessionMgr, ipLimiter, cfg.DemoReadOnly, apiHandler.TotpEnabled, apiHandler.RefreshTotpEnabled, cfg.CookieSecure)
+	totpHandler := adminauth.NewTotpHandler(totpRepo, adminMgr, sessionMgr, ipLimiter, cfg.DemoReadOnly, apiHandler.TotpEnabled, apiHandler.RefreshTotpEnabled, cfg.CookieSecure, true)
 
 	// OIDC single sign-on. A third front-end to the same session token minted by
 	// passkey/TOTP login: after the IdP confirms an allowlisted identity it calls

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -223,7 +223,7 @@ func main() {
 	userTotpFactory := func(id uuid.UUID) *totp.Repository {
 		return totp.NewRepositoryWithStore(totp.NewUserPostgresStore(database.Pool(), id), cfg.MasterKey)
 	}
-	userLoginHandler := adminauth.NewUserLoginHandler(userRepo, sessionMgr, ipLimiter, userTotpFactory)
+	userLoginHandler := adminauth.NewUserLoginHandler(userRepo, sessionMgr, ipLimiter, userTotpFactory, cfg.CookieSecure)
 	apiHandler.SetUserTotp(userTotpFactory)
 
 	// Audit trail of admin actions: middleware-recorded mutating requests on

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -256,7 +256,7 @@ func main() {
 	// that confirms an allowlisted *verified* email via the REST API and then
 	// mints the same CreateAuthToken session. Always constructed; the public
 	// endpoints no-op until github_sso_enabled is set.
-	githubHandler := adminauth.NewGitHubHandler(settingsRepo, sessionMgr, ipLimiter, cfg.MasterKey)
+	githubHandler := adminauth.NewGitHubHandler(settingsRepo, sessionMgr, ipLimiter, cfg.MasterKey, cfg.CookieSecure)
 	githubHandler.SetUserResolver(userRepo)
 
 	if cfg.WebAuthnRPID != "" {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -241,7 +241,7 @@ func main() {
 	// IsEnabled state wired into the Handler (AuthMiddleware gate).
 	totpRepo := totp.NewRepository(database.Pool(), cfg.MasterKey)
 	apiHandler.SetTotpStatus(totpRepo)
-	totpHandler := adminauth.NewTotpHandler(totpRepo, adminMgr, sessionMgr, ipLimiter, cfg.DemoReadOnly, apiHandler.TotpEnabled, apiHandler.RefreshTotpEnabled)
+	totpHandler := adminauth.NewTotpHandler(totpRepo, adminMgr, sessionMgr, ipLimiter, cfg.DemoReadOnly, apiHandler.TotpEnabled, apiHandler.RefreshTotpEnabled, cfg.CookieSecure)
 
 	// OIDC single sign-on. A third front-end to the same session token minted by
 	// passkey/TOTP login: after the IdP confirms an allowlisted identity it calls

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -327,6 +327,16 @@ func main() {
 			githubHandler.Register(r)
 		})
 
+		// Admin-token bootstrap exchange (POST /api/auth/admin-exchange) — a
+		// dashboard-only login front-end that trades a valid raw admin token for
+		// an HttpOnly session cookie so the browser never stores the raw token.
+		// Unauthenticated (the exchange IS the login), same posture as the other
+		// login groups; the per-IP limiter above still throttles brute-force.
+		r.Group(func(r chi.Router) {
+			r.Use(middleware.Timeout(60 * time.Second))
+			apiHandler.RegisterAuthExchange(r)
+		})
+
 		r.Group(func(r chi.Router) {
 			r.Use(middleware.Timeout(60 * time.Second))
 			apiHandler.Register(r)

--- a/internal/adminauth/github.go
+++ b/internal/adminauth/github.go
@@ -19,6 +19,7 @@ import (
 	githuboauth "golang.org/x/oauth2/github"
 
 	"github.com/hugalafutro/model-hotel/internal/auth"
+	"github.com/hugalafutro/model-hotel/internal/authcookie"
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 	"github.com/hugalafutro/model-hotel/internal/totp"
 	"github.com/hugalafutro/model-hotel/internal/webauthn"
@@ -74,11 +75,12 @@ type GitHubSettings interface {
 // ID token, and the state parameter + single-use login-state record + the
 // confidential client secret carry the CSRF/replay defense.
 type GitHubHandler struct {
-	settings   GitHubSettings
-	sessionMgr *webauthn.SessionManager
-	ipLimiter  IPLimiterMiddleware
-	masterKey  string
-	users      SSOUserResolver // nil = no user email binding (admin allowlist only)
+	settings     GitHubSettings
+	sessionMgr   *webauthn.SessionManager
+	ipLimiter    IPLimiterMiddleware
+	masterKey    string
+	cookieSecure string          // authcookie.Secure mode ("auto"/"always"/"never")
+	users        SSOUserResolver // nil = no user email binding (admin allowlist only)
 
 	// loginThrottle applies per-IP exponential backoff to the callback, mirroring
 	// the OIDC/TOTP login defense (5 failures, 1s doubling, capped at 5m).
@@ -95,17 +97,23 @@ type GitHubHandler struct {
 
 // NewGitHubHandler constructs a GitHubHandler. masterKey decrypts the stored
 // client secret (encrypted at rest like provider keys and the OIDC secret).
+// GitHub is a dashboard-only login front-end (Front Desk does not use it), so
+// the successful callback always delivers the session via the HttpOnly
+// mh_session cookie; cookieSecure is the authcookie.Secure mode passed through
+// from config.
 func NewGitHubHandler(
 	settings GitHubSettings,
 	sessionMgr *webauthn.SessionManager,
 	ipLimiter IPLimiterMiddleware,
 	masterKey string,
+	cookieSecure string,
 ) *GitHubHandler {
 	return &GitHubHandler{
 		settings:      settings,
 		sessionMgr:    sessionMgr,
 		ipLimiter:     ipLimiter,
 		masterKey:     masterKey,
+		cookieSecure:  cookieSecure,
 		loginThrottle: totp.NewThrottle(5, time.Second, 5*time.Minute),
 	}
 }
@@ -375,17 +383,22 @@ func (h *GitHubHandler) Callback(w http.ResponseWriter, r *http.Request) {
 	debuglog.Info("github: login success",
 		"email_masked", maskEmail(matched), "gh_id", user.ID, "gh_login", user.Login)
 
-	// Deliver the token in the URL *fragment* (shared with OIDC): the SPA reads it
-	// on mount, stores it, and scrubs the URL. The fragment is never sent to the
-	// server on the follow-up request (no Referer leak, nothing in our own request
-	// logs). It does appear in this 302's Location response header, so operators
-	// should redact `Location` on /api/auth/github/callback in their access logs.
+	// Deliver the session via the HttpOnly mh_session cookie and redirect to a
+	// clean "/": GitHub is dashboard-only (Front Desk does not use this handler),
+	// so there is no legacy fragment-token surface to preserve here. The token
+	// never appears in the URL or this 302's Location response header.
 	//
-	// The `oidc_token`/`oidc_error` fragment keys are the generic SSO hand-off
-	// slot the SPA already consumes, not an OIDC-specific channel. If a third SSO
-	// provider is ever added, rename these to a neutral `sso_*` across the handlers
-	// and the SPA's consume helpers in lockstep.
-	http.Redirect(w, r, "/#oidc_token="+url.QueryEscape(sessionToken), http.StatusFound)
+	// The `oidc_error` fragment key (used by redirectError below) is the generic
+	// SSO hand-off slot the SPA already consumes for failures, not an
+	// OIDC-specific channel. If a third SSO provider is ever added, rename it to
+	// a neutral `sso_error` across the handlers and the SPA's consume helpers in
+	// lockstep.
+	if err := authcookie.SetSession(w, sessionToken, authcookie.Secure(r, h.cookieSecure), webauthn.AuthTokenTTL); err != nil {
+		debuglog.Error("github: set session cookie failed", "error", err)
+		h.redirectError(w, r, "session_error")
+		return
+	}
+	http.Redirect(w, r, "/", http.StatusFound)
 }
 
 // fetchUser GETs {apiBase}/user and decodes the id + login.

--- a/internal/adminauth/github.go
+++ b/internal/adminauth/github.go
@@ -242,9 +242,9 @@ type githubEmail struct {
 // Callback completes the flow: it validates the login-state record (single use)
 // and state, exchanges the code for an access token, fetches the GitHub identity
 // and verified emails over the REST API, enforces the verified-email allowlist,
-// and on success mints a normal session token and redirects to the SPA with the
-// token in the URL fragment (never sent back to the server, so it can't be
-// logged). All denials redirect with a generic error code.
+// and on success mints a session token, delivers it in the HttpOnly mh_session
+// cookie, and redirects to a clean SPA URL (no token in the URL). All denials
+// redirect with a generic error code.
 func (h *GitHubHandler) Callback(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 

--- a/internal/adminauth/github_test.go
+++ b/internal/adminauth/github_test.go
@@ -124,7 +124,7 @@ func newGitHubTestHandler(t *testing.T, m *githubMock, allowed string) (*GitHubH
 		githubAllowedEmailsKey: allowed,
 		githubPublicBaseURLKey: "https://mh.example.test",
 	})
-	h := NewGitHubHandler(fs, sessionMgr, mockIPLimiter{}, testMasterKey)
+	h := NewGitHubHandler(fs, sessionMgr, mockIPLimiter{}, testMasterKey, "auto")
 
 	// Build once, then redirect the cached runtime at the mock server.
 	rt, err := h.runtime(context.Background())
@@ -168,9 +168,10 @@ func runGitHubStart(t *testing.T, h *GitHubHandler) (*url.URL, *http.Cookie) {
 	return loc, cookie
 }
 
-// runGitHubCallback drives GET /callback and returns the fragment of the redirect
-// Location (the part after '#').
-func runGitHubCallback(t *testing.T, h *GitHubHandler, cookie *http.Cookie, query url.Values) string {
+// runGitHubCallbackRec drives GET /callback and returns the raw response
+// recorder, so callers can inspect the Location header and any Set-Cookie
+// headers (the fragment-only runGitHubCallback below cannot see cookies).
+func runGitHubCallbackRec(t *testing.T, h *GitHubHandler, cookie *http.Cookie, query url.Values) *httptest.ResponseRecorder {
 	t.Helper()
 	req := httptest.NewRequest(http.MethodGet, "/api/auth/github/callback?"+query.Encode(), http.NoBody)
 	if cookie != nil {
@@ -178,19 +179,27 @@ func runGitHubCallback(t *testing.T, h *GitHubHandler, cookie *http.Cookie, quer
 	}
 	rec := httptest.NewRecorder()
 	h.Callback(rec, req)
-	res := rec.Result()
-	defer res.Body.Close()
-	if res.StatusCode != http.StatusFound {
-		t.Fatalf("Callback status = %d, want 302 (body=%s)", res.StatusCode, rec.Body.String())
+	if rec.Result().StatusCode != http.StatusFound {
+		t.Fatalf("Callback status = %d, want 302 (body=%s)", rec.Result().StatusCode, rec.Body.String())
 	}
-	loc := res.Header.Get("Location")
+	return rec
+}
+
+// runGitHubCallback drives GET /callback and returns the fragment of the redirect
+// Location (the part after '#'). Used by the rejection-path tests, which still
+// deliver errors via the "oidc_error" fragment.
+func runGitHubCallback(t *testing.T, h *GitHubHandler, cookie *http.Cookie, query url.Values) string {
+	t.Helper()
+	rec := runGitHubCallbackRec(t, h, cookie, query)
+	loc := rec.Result().Header.Get("Location")
 	if _, after, ok := strings.Cut(loc, "#"); ok {
 		return after
 	}
 	return ""
 }
 
-// successToken drives start+callback and asserts a session token came back.
+// successToken drives start+callback and asserts the session came back on the
+// HttpOnly mh_session cookie, with a clean "/" redirect carrying no token.
 func successToken(t *testing.T, h *GitHubHandler, sessionMgr *webauthn.SessionManager) {
 	t.Helper()
 	loc, cookie := runGitHubStart(t, h)
@@ -198,18 +207,27 @@ func successToken(t *testing.T, h *GitHubHandler, sessionMgr *webauthn.SessionMa
 	if state == "" {
 		t.Fatalf("auth URL missing state: %s", loc.String())
 	}
-	frag := runGitHubCallback(t, h, cookie, url.Values{"state": {state}, "code": {"auth-code"}})
-	const prefix = "oidc_token="
-	if !strings.HasPrefix(frag, prefix) {
-		t.Fatalf("expected token fragment, got %q", frag)
+	rec := runGitHubCallbackRec(t, h, cookie, url.Values{"state": {state}, "code": {"auth-code"}})
+	location := rec.Result().Header.Get("Location")
+	if location != "/" {
+		t.Fatalf("expected a clean redirect to \"/\", got %q", location)
 	}
-	token, err := url.QueryUnescape(strings.TrimPrefix(frag, prefix))
-	if err != nil {
-		t.Fatalf("unescape token: %v", err)
+	if strings.Contains(location, "oidc_token") || strings.Contains(location, "access_token") {
+		t.Fatalf("Location must not carry the session token, got %q", location)
 	}
+	token := sessionCookie(t, rec)
 	if !sessionMgr.Validate(context.Background(), token) {
 		t.Fatal("minted session token failed Validate")
 	}
+}
+
+// TestGitHubCallback_SetsCookie_RedirectsClean pins the dashboard cookie-auth
+// contract end to end: a successful callback sets the HttpOnly mh_session
+// cookie and redirects to a clean "/" with no token in the Location header.
+func TestGitHubCallback_SetsCookie_RedirectsClean(t *testing.T) {
+	m := newGitHubMock(t)
+	h, _, sessionMgr := newGitHubTestHandler(t, m, "admin@example.com")
+	successToken(t, h, sessionMgr)
 }
 
 func TestGitHubStatus(t *testing.T) {
@@ -250,7 +268,7 @@ func TestGitHubStatus(t *testing.T) {
 			githubPublicBaseURLKey: "https://mh.example.test",
 		})
 		fs.set(tc.key, tc.val)
-		h := NewGitHubHandler(fs, nil, mockIPLimiter{}, testMasterKey)
+		h := NewGitHubHandler(fs, nil, mockIPLimiter{}, testMasterKey, "auto")
 		rec := httptest.NewRecorder()
 		h.Status(rec, httptest.NewRequest(http.MethodGet, "/api/auth/github/status", http.NoBody))
 		var resp githubStatusResponse
@@ -469,7 +487,7 @@ func TestGitHubCreateAuthTokenError(t *testing.T) {
 		githubAllowedEmailsKey: "admin@example.com",
 		githubPublicBaseURLKey: "https://mh.example.test",
 	})
-	h := NewGitHubHandler(fs, sessionMgr, mockIPLimiter{}, testMasterKey)
+	h := NewGitHubHandler(fs, sessionMgr, mockIPLimiter{}, testMasterKey, "auto")
 	rt, err := h.runtime(context.Background())
 	if err != nil || rt == nil || !rt.enabled {
 		t.Fatalf("runtime: %v", err)

--- a/internal/adminauth/middleware.go
+++ b/internal/adminauth/middleware.go
@@ -3,6 +3,7 @@ package adminauth
 import (
 	"net/http"
 
+	"github.com/hugalafutro/model-hotel/internal/authcookie"
 	"github.com/hugalafutro/model-hotel/internal/util"
 	"github.com/hugalafutro/model-hotel/internal/webauthn"
 )
@@ -32,6 +33,25 @@ func RequireAdminOrSession(
 	next http.Handler,
 ) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Cookie path (browser). The session token rides an HttpOnly cookie
+		// instead of an Authorization header. This branch is additive and keeps
+		// the same admin-only gate: it admits only the admin session
+		// (UserID == "admin"). A valid but non-admin (UUID) session cookie, or
+		// an absent/expired cookie, falls through to the header logic below so
+		// header (admin-token / bearer) callers stay unaffected. On unsafe
+		// methods a matching CSRF header is also required.
+		if tok, ok := authcookie.SessionToken(r); ok && sessionMgr != nil {
+			if userID, ok := sessionMgr.TokenUser(r.Context(), tok); ok && string(userID) == "admin" {
+				if !authcookie.IsSafeMethod(r.Method) && !authcookie.ValidCSRF(r) {
+					http.Error(w, "CSRF token missing or invalid", http.StatusForbidden)
+					return
+				}
+				next.ServeHTTP(w, r)
+				return
+			}
+			// Non-admin or invalid cookie session: fall through to header logic.
+		}
+
 		token, ok := util.ParseBearerToken(r)
 		if !ok {
 			http.Error(w, "Authorization header required (Bearer token)", http.StatusUnauthorized)

--- a/internal/adminauth/oidc.go
+++ b/internal/adminauth/oidc.go
@@ -254,9 +254,10 @@ func (h *OIDCHandler) Start(w http.ResponseWriter, r *http.Request) {
 // Callback completes the flow: it validates the login-state record (single use),
 // state, PKCE, and the IdP error param; exchanges the code; verifies the ID
 // token (iss/aud/exp/signature via go-oidc, plus nonce here); enforces the
-// verified-email allowlist; and on success mints a normal session token and
-// redirects to the SPA with the token in the URL fragment (never sent back to
-// the server, so it can't be logged). All denials redirect with an error code.
+// verified-email allowlist; and on success mints a session token, then either
+// delivers it in the HttpOnly mh_session cookie and redirects to a clean SPA URL
+// (dashboard, useCookieAuth) or, for legacy Front Desk callers, redirects with
+// the token in the URL fragment. All denials redirect with an error code.
 func (h *OIDCHandler) Callback(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 

--- a/internal/adminauth/oidc.go
+++ b/internal/adminauth/oidc.go
@@ -21,6 +21,7 @@ import (
 	"golang.org/x/oauth2"
 
 	"github.com/hugalafutro/model-hotel/internal/auth"
+	"github.com/hugalafutro/model-hotel/internal/authcookie"
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 	"github.com/hugalafutro/model-hotel/internal/netguard"
 	"github.com/hugalafutro/model-hotel/internal/totp"
@@ -76,6 +77,14 @@ type OIDCHandler struct {
 	masterKey  string
 	users      SSOUserResolver // nil = no user email binding (admin allowlist only)
 
+	// useCookieAuth delivers the session over the dashboard HttpOnly cookie and
+	// a clean redirect; Front Desk leaves it false to keep the legacy
+	// token-in-URL-fragment contract byte-for-byte.
+	useCookieAuth bool
+	// cookieSecure ("auto"/"always"/"never") resolves the cookie Secure
+	// attribute; only consulted when useCookieAuth is true.
+	cookieSecure string
+
 	// httpClient is an SSRF-guarded client used for every outbound OIDC request
 	// (discovery, token exchange, UserInfo). Without it go-oidc/oauth2 fall back
 	// to http.DefaultClient, letting an admin-configured (or fleet-synced) issuer
@@ -103,12 +112,16 @@ func NewOIDCHandler(
 	sessionMgr *webauthn.SessionManager,
 	ipLimiter IPLimiterMiddleware,
 	masterKey string,
+	useCookieAuth bool,
+	cookieSecure string,
 ) *OIDCHandler {
 	return &OIDCHandler{
 		settings:      settings,
 		sessionMgr:    sessionMgr,
 		ipLimiter:     ipLimiter,
 		masterKey:     masterKey,
+		useCookieAuth: useCookieAuth,
+		cookieSecure:  cookieSecure,
 		loginThrottle: totp.NewThrottle(5, time.Second, 5*time.Minute),
 		httpClient:    netguard.NewClient(oidcHTTPTimeout),
 	}
@@ -405,12 +418,25 @@ func (h *OIDCHandler) Callback(w http.ResponseWriter, r *http.Request) {
 	debuglog.Info("oidc: login success",
 		"email_masked", maskEmail(email), "sub", idToken.Subject, "iss", idToken.Issuer)
 
-	// Deliver the token in the URL *fragment*: the SPA reads it on mount, stores
-	// it, and scrubs the URL. The fragment is never sent to the server on the
-	// follow-up request (no Referer leak, nothing in our own request logs). It
-	// does, however, appear in this 302's Location response header, so a proxy
-	// that logs response headers would capture it -- operators should redact
-	// `Location` on /api/auth/oidc/callback in their access logs (see README).
+	if h.useCookieAuth {
+		if err := authcookie.SetSession(w, sessionToken, authcookie.Secure(r, h.cookieSecure), webauthn.AuthTokenTTL); err != nil {
+			debuglog.Error("oidc: set session cookie failed", "error", err)
+			h.redirectError(w, r, "session_error")
+			return
+		}
+		// Clean redirect: the session rides the HttpOnly cookie, so the token
+		// never appears in the URL or this 302's Location response header.
+		http.Redirect(w, r, "/", http.StatusFound)
+		return
+	}
+
+	// Legacy Front Desk delivery: put the token in the URL *fragment*. The SPA
+	// reads it on mount, stores it, and scrubs the URL. The fragment is never
+	// sent to the server on the follow-up request (no Referer leak, nothing in
+	// our own request logs). It does, however, appear in this 302's Location
+	// response header, so a proxy that logs response headers would capture it --
+	// operators should redact `Location` on /api/auth/oidc/callback in their
+	// access logs (see README).
 	http.Redirect(w, r, "/#oidc_token="+url.QueryEscape(sessionToken), http.StatusFound)
 }
 

--- a/internal/adminauth/oidc_test.go
+++ b/internal/adminauth/oidc_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/hugalafutro/model-hotel/internal/auth"
+	"github.com/hugalafutro/model-hotel/internal/authcookie"
 	"github.com/hugalafutro/model-hotel/internal/webauthn"
 )
 
@@ -301,6 +302,15 @@ const oidcTestClientID = "model-hotel-test"
 
 func newOIDCTestHandler(t *testing.T, idp *mockIDP, allowed string) (*OIDCHandler, *fakeSettings, *webauthn.SessionManager) {
 	t.Helper()
+	// Default to legacy mode (token-in-fragment) so the existing round-trip and
+	// rejection tests exercise the Front Desk contract unchanged.
+	return newOIDCTestHandlerMode(t, idp, allowed, false, "auto")
+}
+
+// newOIDCTestHandlerMode builds a handler with an explicit cookie-auth mode so
+// tests can cover both the dashboard (cookie) and Front Desk (legacy) surfaces.
+func newOIDCTestHandlerMode(t *testing.T, idp *mockIDP, allowed string, useCookieAuth bool, cookieSecure string) (*OIDCHandler, *fakeSettings, *webauthn.SessionManager) {
+	t.Helper()
 	store := newMemStore()
 	sessionMgr := webauthn.NewSessionManager(store)
 	enc, err := auth.EncryptString("client-secret-value", testMasterKey)
@@ -315,7 +325,7 @@ func newOIDCTestHandler(t *testing.T, idp *mockIDP, allowed string) (*OIDCHandle
 		OIDCAllowedEmailsKey: allowed,
 		OIDCPublicBaseURLKey: "https://mh.example.test",
 	})
-	h := NewOIDCHandler(fs, sessionMgr, mockIPLimiter{}, testMasterKey)
+	h := NewOIDCHandler(fs, sessionMgr, mockIPLimiter{}, testMasterKey, useCookieAuth, cookieSecure)
 	return h, fs, sessionMgr
 }
 
@@ -428,6 +438,73 @@ func TestOIDCLoginRoundTrip(t *testing.T) {
 	}
 	if !sessionMgr.Validate(context.Background(), token) {
 		t.Fatal("minted session token failed Validate")
+	}
+}
+
+// TestOIDCCallback_SetsCookie_RedirectsClean covers the dashboard (cookie) mode:
+// the callback sets the HttpOnly mh_session cookie and redirects to a clean "/"
+// with no token exposed in the Location URL or fragment.
+func TestOIDCCallback_SetsCookie_RedirectsClean(t *testing.T) {
+	idp := newMockIDP(t, oidcTestClientID)
+	h, _, sessionMgr := newOIDCTestHandlerMode(t, idp, "admin@example.com", true, "always")
+
+	loc, cookie := runStart(t, h)
+	state := loc.Query().Get("state")
+	idp.configure(loc.Query().Get("nonce"), "admin@example.com", true)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/auth/oidc/callback?"+url.Values{"state": {state}, "code": {"auth-code"}}.Encode(),
+		http.NoBody)
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	h.Callback(rec, req)
+
+	res := rec.Result()
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusFound {
+		t.Fatalf("Callback status = %d, want 302 (body=%s)", res.StatusCode, rec.Body.String())
+	}
+	// The session rides the HttpOnly cookie, so the token must not appear in the
+	// Location header (query or fragment).
+	location := res.Header.Get("Location")
+	if strings.Contains(location, "oidc_token") || strings.Contains(location, "access_token") {
+		t.Fatalf("Location must not carry the session token, got %q", location)
+	}
+	if location != "/" {
+		t.Fatalf("expected a clean redirect to \"/\", got %q", location)
+	}
+	token := sessionCookie(t, rec)
+	if !sessionMgr.Validate(context.Background(), token) {
+		t.Fatal("session cookie token failed Validate")
+	}
+}
+
+// TestOIDCCallback_LegacyMode_NoCookie pins the Front Desk contract: legacy mode
+// keeps the token in the URL fragment and sets no session cookie.
+func TestOIDCCallback_LegacyMode_NoCookie(t *testing.T) {
+	idp := newMockIDP(t, oidcTestClientID)
+	h, _, _ := newOIDCTestHandler(t, idp, "admin@example.com") // legacy default
+
+	loc, cookie := runStart(t, h)
+	state := loc.Query().Get("state")
+	idp.configure(loc.Query().Get("nonce"), "admin@example.com", true)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/auth/oidc/callback?"+url.Values{"state": {state}, "code": {"auth-code"}}.Encode(),
+		http.NoBody)
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	h.Callback(rec, req)
+
+	res := rec.Result()
+	defer res.Body.Close()
+	if !strings.Contains(res.Header.Get("Location"), "oidc_token=") {
+		t.Fatalf("legacy mode must keep the token in the fragment, got %q", res.Header.Get("Location"))
+	}
+	for _, c := range res.Cookies() {
+		if c.Name == authcookie.SessionCookie {
+			t.Fatalf("legacy mode must not set a session cookie, got %+v", c)
+		}
 	}
 }
 
@@ -622,7 +699,7 @@ func TestOIDCCallbackThrottle(t *testing.T) {
 // TestOIDCCallbackDisabled covers the Callback early-out when SSO is off.
 func TestOIDCCallbackDisabled(t *testing.T) {
 	sm := webauthn.NewSessionManager(newMemStore())
-	h := NewOIDCHandler(newFakeSettings(map[string]string{OIDCEnabledKey: "false"}), sm, mockIPLimiter{}, testMasterKey)
+	h := NewOIDCHandler(newFakeSettings(map[string]string{OIDCEnabledKey: "false"}), sm, mockIPLimiter{}, testMasterKey, false, "auto")
 	frag := runCallback(t, h, nil, url.Values{"state": {"x"}, "code": {"c"}})
 	if !strings.HasPrefix(frag, "oidc_error=") {
 		t.Fatalf("disabled callback should redirect with an error, got %q", frag)
@@ -665,7 +742,7 @@ func TestOIDCCallbackCreateAuthTokenError(t *testing.T) {
 		OIDCClientSecretKey:  enc,
 		OIDCAllowedEmailsKey: "admin@example.com",
 		OIDCPublicBaseURLKey: "https://h.example",
-	}), sm, mockIPLimiter{}, testMasterKey)
+	}), sm, mockIPLimiter{}, testMasterKey, false, "auto")
 
 	loc, cookie := runStart(t, h) // CreateLoginState -> CreateSession #1 (ok)
 	state := loc.Query().Get("state")
@@ -689,7 +766,7 @@ func TestOIDCDiscoverySSRFBlocked(t *testing.T) {
 			OIDCClientIDKey:      oidcTestClientID,
 			OIDCAllowedEmailsKey: "admin@example.com",
 			OIDCPublicBaseURLKey: "https://h.example",
-		}), webauthn.NewSessionManager(newMemStore()), mockIPLimiter{}, testMasterKey)
+		}), webauthn.NewSessionManager(newMemStore()), mockIPLimiter{}, testMasterKey, false, "auto")
 
 		_, err := h.runtime(context.Background())
 		if err == nil {
@@ -797,7 +874,7 @@ func TestOIDCRegisterRoutes(t *testing.T) {
 func TestOIDCStartErrors(t *testing.T) {
 	newH := func(masterKey string, kv map[string]string) *OIDCHandler {
 		sm := webauthn.NewSessionManager(newMemStore())
-		return NewOIDCHandler(newFakeSettings(kv), sm, mockIPLimiter{}, masterKey)
+		return NewOIDCHandler(newFakeSettings(kv), sm, mockIPLimiter{}, masterKey, false, "auto")
 	}
 	call := func(h *OIDCHandler) int {
 		req := httptest.NewRequest(http.MethodGet, "/api/auth/oidc/start", http.NoBody)
@@ -891,7 +968,7 @@ func TestOIDCStartErrors(t *testing.T) {
 			OIDCClientSecretKey:  enc,
 			OIDCAllowedEmailsKey: "admin@example.com",
 			OIDCPublicBaseURLKey: "https://h.example",
-		}), sm, mockIPLimiter{}, testMasterKey)
+		}), sm, mockIPLimiter{}, testMasterKey, false, "auto")
 		if got := call(h); got != http.StatusInternalServerError {
 			t.Fatalf("status = %d, want 500", got)
 		}

--- a/internal/adminauth/ssobinding_test.go
+++ b/internal/adminauth/ssobinding_test.go
@@ -238,8 +238,8 @@ func TestGitHubUserEmailBinding(t *testing.T) {
 
 	loc, cookie := runGitHubStart(t, h)
 	state := loc.Query().Get("state")
-	frag := runGitHubCallback(t, h, cookie, url.Values{"state": {state}, "code": {"auth-code"}})
-	token := oidcTokenFromFragment(t, frag)
+	rec := runGitHubCallbackRec(t, h, cookie, url.Values{"state": {state}, "code": {"auth-code"}})
+	token := sessionCookie(t, rec)
 	handle, ok := sessionMgr.TokenUser(context.Background(), token)
 	if !ok {
 		t.Fatal("bound-user token failed validation")

--- a/internal/adminauth/totp.go
+++ b/internal/adminauth/totp.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
+	"github.com/hugalafutro/model-hotel/internal/authcookie"
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 	"github.com/hugalafutro/model-hotel/internal/totp"
 	"github.com/hugalafutro/model-hotel/internal/webauthn"
@@ -29,6 +30,9 @@ type TotpHandler struct {
 	totpEnabled        func() bool           // shared cached state (Handler.TotpEnabled)
 	refreshTotpEnabled func(context.Context) // refresh cache after mutations (Handler.RefreshTotpEnabled)
 	loginThrottle      *totp.Throttle        // per-IP exponential backoff on failed /totp/login
+	// cookieSecure ("auto"/"always"/"never") resolves the Secure attribute on
+	// the session cookie so plain-http LAN deployments still work.
+	cookieSecure string
 	// confirmed_at cache for /totp/status. The stamp is set once at enrollment
 	// and never changes until disable/re-enroll, so a polled status endpoint can
 	// serve it from memory instead of reading the DB on every call. Read lock-free
@@ -51,6 +55,7 @@ func NewTotpHandler(
 	demoReadOnly bool,
 	totpEnabled func() bool,
 	refreshTotpEnabled func(context.Context),
+	cookieSecure string,
 ) *TotpHandler {
 	return &TotpHandler{
 		totpRepo:           totpRepo,
@@ -60,6 +65,7 @@ func NewTotpHandler(
 		demoReadOnly:       demoReadOnly,
 		totpEnabled:        totpEnabled,
 		refreshTotpEnabled: refreshTotpEnabled,
+		cookieSecure:       cookieSecure,
 		// After maxFailures failed logins from one IP, back off exponentially
 		// (1s doubling, capped at 5m), self-clearing and reset on success.
 		loginThrottle: totp.NewThrottle(5, time.Second, 5*time.Minute),
@@ -251,12 +257,15 @@ func (h *TotpHandler) EnrollVerify(w http.ResponseWriter, r *http.Request) {
 	// endpoint + a valid TOTP code), so a session is warranted. Best effort:
 	// the recovery codes are the critical payload and are returned even if the
 	// mint fails (the admin can re-login manually).
-	resp := map[string]any{"recovery_codes": codes}
+	resp := map[string]any{"recovery_codes": codes, "success": true}
 	if h.sessionMgr != nil {
 		if tok, err := h.sessionMgr.CreateAuthToken(r.Context(), []byte("admin"), nil); err != nil {
 			debuglog.Error("totp: failed to mint post-enroll session token; admin must re-login", "error", err)
-		} else {
-			resp["token"] = tok
+		} else if err := authcookie.SetSession(w, tok, authcookie.Secure(r, h.cookieSecure), webauthn.AuthTokenTTL); err != nil {
+			// Best effort like the mint above: the recovery codes are the
+			// critical payload and are still returned even if the cookie
+			// write fails (the admin can re-login manually).
+			debuglog.Error("totp: set session cookie failed", "error", err)
 		}
 	}
 	writeJSON(w, resp)
@@ -354,5 +363,13 @@ func (h *TotpHandler) Login(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	h.loginThrottle.RecordSuccess(throttleKey)
-	writeJSON(w, map[string]string{"token": sessionToken})
+	// Hand the session to the browser as an HttpOnly cookie rather than in the
+	// body: JS never touches it, and the cookie MaxAge is bound to the same
+	// webauthn.AuthTokenTTL as the server-side session so the two cannot drift.
+	if err := authcookie.SetSession(w, sessionToken, authcookie.Secure(r, h.cookieSecure), webauthn.AuthTokenTTL); err != nil {
+		debuglog.Error("totp: set session cookie failed", "error", err)
+		http.Error(w, "failed to create session", http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, map[string]any{"success": true})
 }

--- a/internal/adminauth/totp.go
+++ b/internal/adminauth/totp.go
@@ -33,6 +33,13 @@ type TotpHandler struct {
 	// cookieSecure ("auto"/"always"/"never") resolves the Secure attribute on
 	// the session cookie so plain-http LAN deployments still work.
 	cookieSecure string
+	// useCookieAuth selects the session-delivery mode at both mint sites
+	// (EnrollVerify, Login). true (the dashboard): mint sets an HttpOnly
+	// mh_session cookie and the body carries no token. false (Front Desk):
+	// legacy behavior preserved byte-for-byte from before the httpOnly-cookie
+	// migration, since the Front Desk web client keeps its bearer token in
+	// localStorage rather than a cookie.
+	useCookieAuth bool
 	// confirmed_at cache for /totp/status. The stamp is set once at enrollment
 	// and never changes until disable/re-enroll, so a polled status endpoint can
 	// serve it from memory instead of reading the DB on every call. Read lock-free
@@ -56,6 +63,7 @@ func NewTotpHandler(
 	totpEnabled func() bool,
 	refreshTotpEnabled func(context.Context),
 	cookieSecure string,
+	useCookieAuth bool,
 ) *TotpHandler {
 	return &TotpHandler{
 		totpRepo:           totpRepo,
@@ -66,6 +74,7 @@ func NewTotpHandler(
 		totpEnabled:        totpEnabled,
 		refreshTotpEnabled: refreshTotpEnabled,
 		cookieSecure:       cookieSecure,
+		useCookieAuth:      useCookieAuth,
 		// After maxFailures failed logins from one IP, back off exponentially
 		// (1s doubling, capped at 5m), self-clearing and reset on success.
 		loginThrottle: totp.NewThrottle(5, time.Second, 5*time.Minute),
@@ -257,15 +266,30 @@ func (h *TotpHandler) EnrollVerify(w http.ResponseWriter, r *http.Request) {
 	// endpoint + a valid TOTP code), so a session is warranted. Best effort:
 	// the recovery codes are the critical payload and are returned even if the
 	// mint fails (the admin can re-login manually).
-	resp := map[string]any{"recovery_codes": codes, "success": true}
+	if h.useCookieAuth {
+		resp := map[string]any{"recovery_codes": codes, "success": true}
+		if h.sessionMgr != nil {
+			if tok, err := h.sessionMgr.CreateAuthToken(r.Context(), []byte("admin"), nil); err != nil {
+				debuglog.Error("totp: failed to mint post-enroll session token; admin must re-login", "error", err)
+			} else if err := authcookie.SetSession(w, tok, authcookie.Secure(r, h.cookieSecure), webauthn.AuthTokenTTL); err != nil {
+				// Best effort like the mint above: the recovery codes are the
+				// critical payload and are still returned even if the cookie
+				// write fails (the admin can re-login manually).
+				debuglog.Error("totp: set session cookie failed", "error", err)
+			}
+		}
+		writeJSON(w, resp)
+		return
+	}
+	// Legacy path (Front Desk): return the session token in the body exactly
+	// as before the httpOnly-cookie migration. Front Desk's web client keeps
+	// its bearer token in localStorage rather than reading a cookie.
+	resp := map[string]any{"recovery_codes": codes}
 	if h.sessionMgr != nil {
 		if tok, err := h.sessionMgr.CreateAuthToken(r.Context(), []byte("admin"), nil); err != nil {
 			debuglog.Error("totp: failed to mint post-enroll session token; admin must re-login", "error", err)
-		} else if err := authcookie.SetSession(w, tok, authcookie.Secure(r, h.cookieSecure), webauthn.AuthTokenTTL); err != nil {
-			// Best effort like the mint above: the recovery codes are the
-			// critical payload and are still returned even if the cookie
-			// write fails (the admin can re-login manually).
-			debuglog.Error("totp: set session cookie failed", "error", err)
+		} else {
+			resp["token"] = tok
 		}
 	}
 	writeJSON(w, resp)
@@ -363,6 +387,14 @@ func (h *TotpHandler) Login(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	h.loginThrottle.RecordSuccess(throttleKey)
+	if !h.useCookieAuth {
+		// Legacy path (Front Desk): return the session token in the body
+		// exactly as before the httpOnly-cookie migration. Front Desk's web
+		// client keeps its bearer token in localStorage rather than reading
+		// a cookie.
+		writeJSON(w, map[string]string{"token": sessionToken})
+		return
+	}
 	// Hand the session to the browser as an HttpOnly cookie rather than in the
 	// body: JS never touches it, and the cookie MaxAge is bound to the same
 	// webauthn.AuthTokenTTL as the server-side session so the two cannot drift.

--- a/internal/adminauth/totp_test.go
+++ b/internal/adminauth/totp_test.go
@@ -52,7 +52,7 @@ func newTotpTestHandler(t *testing.T) (*totpEnabledShim, *TotpHandler) {
 	// Clean up TOTP state after the test too.
 	t.Cleanup(func() { truncateTOTPTables(t) })
 
-	th := NewTotpHandler(totpRepo, adminMgr, sessionMgr, mockIPLimiter{}, false, shim.TotpEnabled, shim.RefreshTotpEnabled)
+	th := NewTotpHandler(totpRepo, adminMgr, sessionMgr, mockIPLimiter{}, false, shim.TotpEnabled, shim.RefreshTotpEnabled, "auto")
 	return shim, th
 }
 
@@ -389,7 +389,7 @@ func TestTotpEnrollStart_DemoReadOnly(t *testing.T) {
 	adminMgr := &mockAdminAuth{validateFn: func(token string) bool { return token == "admin-token" }}
 	wrepo := webauthn.NewRepository(apiTestDB.Pool())
 	sessionMgr := webauthn.NewSessionManager(wrepo)
-	th := NewTotpHandler(totpRepo, adminMgr, sessionMgr, mockIPLimiter{}, true, func() bool { return false }, func(context.Context) {})
+	th := NewTotpHandler(totpRepo, adminMgr, sessionMgr, mockIPLimiter{}, true, func() bool { return false }, func(context.Context) {}, "auto")
 
 	req := httptest.NewRequest(http.MethodPost, "/totp/enroll/start", http.NoBody)
 	req.Header.Set("Authorization", "Bearer admin-token")
@@ -472,7 +472,7 @@ func TestTotpEnrollVerify_HappyPath(t *testing.T) {
 	}
 	var verifyResp struct {
 		RecoveryCodes []string `json:"recovery_codes"`
-		Token         string   `json:"token"`
+		Success       bool     `json:"success"`
 	}
 	if err := json.Unmarshal(vw.Body.Bytes(), &verifyResp); err != nil {
 		t.Fatalf("decode: %v", err)
@@ -480,10 +480,54 @@ func TestTotpEnrollVerify_HappyPath(t *testing.T) {
 	if len(verifyResp.RecoveryCodes) != 10 {
 		t.Errorf("expected 10 recovery codes, got %d", len(verifyResp.RecoveryCodes))
 	}
+	if !verifyResp.Success {
+		t.Error("expected success=true in the enroll/verify response")
+	}
 	// Enabling 2FA invalidates the raw admin token, so enroll/verify mints a
-	// session token (kept by the UI) to avoid logging the admin out.
-	if verifyResp.Token == "" {
-		t.Error("expected a session token in the enroll/verify response")
+	// session (kept by the UI as an HttpOnly cookie) to avoid logging the
+	// admin out.
+	if _, ok := th.sessionMgr.TokenUser(context.Background(), sessionCookie(t, vw)); !ok {
+		t.Error("cookie token does not validate against the session manager")
+	}
+}
+
+// TestTotpEnrollVerify_SetsSessionCookie_NoTokenInBody pins the cookie-auth
+// contract for the post-enroll mint: recovery codes travel in the body (the
+// UI must display them once), but the session token never does.
+func TestTotpEnrollVerify_SetsSessionCookie_NoTokenInBody(t *testing.T) {
+	_, th := newTotpTestHandler(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/totp/enroll/start", http.NoBody)
+	req.Header.Set("Authorization", "Bearer admin-token")
+	w := httptest.NewRecorder()
+	serveTotpRouter(th).ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("enroll/start: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var startResp map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &startResp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	code := validCode(t, startResp["secret"])
+	vreq := httptest.NewRequest(http.MethodPost, "/totp/enroll/verify",
+		bytes.NewReader([]byte(`{"code":"`+code+`"}`)))
+	vreq.Header.Set("Authorization", "Bearer admin-token")
+	vreq.Header.Set("Content-Type", "application/json")
+	vw := httptest.NewRecorder()
+	serveTotpRouter(th).ServeHTTP(vw, vreq)
+
+	if vw.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", vw.Code, vw.Body.String())
+	}
+	if bytes.Contains(vw.Body.Bytes(), []byte(`"token"`)) {
+		t.Errorf("token leaked into body: %s", vw.Body.String())
+	}
+	if !bytes.Contains(vw.Body.Bytes(), []byte(`"success":true`)) {
+		t.Errorf("expected success:true in body: %s", vw.Body.String())
+	}
+	if _, ok := th.sessionMgr.TokenUser(context.Background(), sessionCookie(t, vw)); !ok {
+		t.Error("cookie token does not validate against the session manager")
 	}
 }
 
@@ -552,7 +596,6 @@ func doEnrollVerify(t *testing.T, th *TotpHandler) (string, []string) {
 	}
 	var verifyResp struct {
 		RecoveryCodes []string `json:"recovery_codes"`
-		Token         string   `json:"token"`
 	}
 	if err := json.Unmarshal(vw.Body.Bytes(), &verifyResp); err != nil {
 		t.Fatalf("decode: %v", err)
@@ -562,6 +605,7 @@ func doEnrollVerify(t *testing.T, th *TotpHandler) (string, []string) {
 
 // sessionTokenAfterEnroll logs in via /totp/login to obtain a session token
 // for the post-EnrollVerify state (where raw admin is rejected by the gate).
+// The session travels in the HttpOnly mh_session cookie, not the body.
 func sessionTokenAfterEnroll(t *testing.T, th *TotpHandler, secret string) string {
 	t.Helper()
 	code := validCode(t, secret)
@@ -573,11 +617,7 @@ func sessionTokenAfterEnroll(t *testing.T, th *TotpHandler, secret string) strin
 	if w.Code != http.StatusOK {
 		t.Fatalf("totp/login: expected 200, got %d: %s", w.Code, w.Body.String())
 	}
-	var resp map[string]string
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
-	return resp["token"]
+	return sessionCookie(t, w)
 }
 
 func TestTotpDisable_WithTotpCode(t *testing.T) {
@@ -666,14 +706,7 @@ func TestTotpLogin_HappyPath(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
-	var resp map[string]string
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
-	sessionToken := resp["token"]
-	if sessionToken == "" {
-		t.Fatal("expected non-empty session token")
-	}
+	sessionToken := sessionCookie(t, w)
 
 	// Assert the session token passes AuthMiddleware on a protected route.
 	mw := h.AuthMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -708,24 +741,46 @@ func TestTotpLogin_RecoveryCode(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
-	var resp map[string]string
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
-	if resp["token"] == "" {
-		t.Error("expected non-empty session token")
-	}
+	sessionToken := sessionCookie(t, w)
 
 	// session token must pass AuthMiddleware.
 	mw := h.AuthMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	protectedReq := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
-	protectedReq.Header.Set("Authorization", "Bearer "+resp["token"])
+	protectedReq.Header.Set("Authorization", "Bearer "+sessionToken)
 	pw := httptest.NewRecorder()
 	mw.ServeHTTP(pw, protectedReq)
 	if pw.Code != http.StatusOK {
 		t.Errorf("recovery-code session token should pass AuthMiddleware, got %d", pw.Code)
+	}
+}
+
+// TestTotpLogin_SetsSessionCookie_NoTokenInBody pins the cookie-auth contract:
+// a successful TOTP login sets an HttpOnly mh_session cookie and the body
+// carries only {"success":true}, never the raw token.
+func TestTotpLogin_SetsSessionCookie_NoTokenInBody(t *testing.T) {
+	h, th := newTotpTestHandler(t)
+	secret, _ := doEnrollVerify(t, th)
+	if !h.TotpEnabled() {
+		t.Fatal("expected TOTP enabled after enroll/verify")
+	}
+
+	code := validCode(t, secret)
+	body := []byte(`{"token":"admin-token","code":"` + code + `"}`)
+	req := httptest.NewRequest(http.MethodPost, "/totp/login", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	serveTotpRouter(th).ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if !bytes.Contains(w.Body.Bytes(), []byte(`"success"`)) || bytes.Contains(w.Body.Bytes(), []byte(`"token"`)) {
+		t.Errorf("body must be success-only with no token: %s", w.Body.String())
+	}
+	if _, ok := th.sessionMgr.TokenUser(context.Background(), sessionCookie(t, w)); !ok {
+		t.Error("cookie token does not validate against the session manager")
 	}
 }
 
@@ -805,7 +860,7 @@ func TestTotpAdminOrSessionAuth_TotpOn_RejectsRawToken(t *testing.T) {
 	sessionMgr := webauthn.NewSessionManager(wrepo)
 	adminMgr := &mockAdminAuth{validateFn: func(token string) bool { return token == "admin-token" }}
 
-	th := NewTotpHandler(totpRepo, adminMgr, sessionMgr, mockIPLimiter{}, false, func() bool { return true }, func(context.Context) {})
+	th := NewTotpHandler(totpRepo, adminMgr, sessionMgr, mockIPLimiter{}, false, func() bool { return true }, func(context.Context) {}, "auto")
 
 	// Raw admin token: with TOTP on, enroll/start must 401.
 	req := httptest.NewRequest(http.MethodPost, "/totp/enroll/start", http.NoBody)

--- a/internal/adminauth/totp_test.go
+++ b/internal/adminauth/totp_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	otptotp "github.com/pquerna/otp/totp"
 
+	"github.com/hugalafutro/model-hotel/internal/authcookie"
 	totpsvc "github.com/hugalafutro/model-hotel/internal/totp"
 	"github.com/hugalafutro/model-hotel/internal/webauthn"
 )
@@ -52,7 +53,28 @@ func newTotpTestHandler(t *testing.T) (*totpEnabledShim, *TotpHandler) {
 	// Clean up TOTP state after the test too.
 	t.Cleanup(func() { truncateTOTPTables(t) })
 
-	th := NewTotpHandler(totpRepo, adminMgr, sessionMgr, mockIPLimiter{}, false, shim.TotpEnabled, shim.RefreshTotpEnabled, "auto")
+	th := NewTotpHandler(totpRepo, adminMgr, sessionMgr, mockIPLimiter{}, false, shim.TotpEnabled, shim.RefreshTotpEnabled, "auto", true)
+	return shim, th
+}
+
+// newTotpTestHandlerLegacy is newTotpTestHandler with useCookieAuth=false,
+// pinning the Front Desk contract: session tokens travel in the JSON body,
+// never as an mh_session cookie.
+func newTotpTestHandlerLegacy(t *testing.T) (*totpEnabledShim, *TotpHandler) {
+	t.Helper()
+	truncateTOTPTables(t)
+
+	totpRepo := totpsvc.NewRepository(apiTestDB.Pool(), testMasterKey)
+	adminMgr := &mockAdminAuth{validateFn: func(token string) bool { return token == "admin-token" }}
+	wrepo := webauthn.NewRepository(apiTestDB.Pool())
+	sessionMgr := webauthn.NewSessionManager(wrepo)
+
+	shim := &totpEnabledShim{repo: totpRepo, adminMgr: adminMgr, sessionMgr: sessionMgr}
+	shim.totpEnabled.Store(false)
+
+	t.Cleanup(func() { truncateTOTPTables(t) })
+
+	th := NewTotpHandler(totpRepo, adminMgr, sessionMgr, mockIPLimiter{}, false, shim.TotpEnabled, shim.RefreshTotpEnabled, "auto", false)
 	return shim, th
 }
 
@@ -389,7 +411,7 @@ func TestTotpEnrollStart_DemoReadOnly(t *testing.T) {
 	adminMgr := &mockAdminAuth{validateFn: func(token string) bool { return token == "admin-token" }}
 	wrepo := webauthn.NewRepository(apiTestDB.Pool())
 	sessionMgr := webauthn.NewSessionManager(wrepo)
-	th := NewTotpHandler(totpRepo, adminMgr, sessionMgr, mockIPLimiter{}, true, func() bool { return false }, func(context.Context) {}, "auto")
+	th := NewTotpHandler(totpRepo, adminMgr, sessionMgr, mockIPLimiter{}, true, func() bool { return false }, func(context.Context) {}, "auto", true)
 
 	req := httptest.NewRequest(http.MethodPost, "/totp/enroll/start", http.NoBody)
 	req.Header.Set("Authorization", "Bearer admin-token")
@@ -528,6 +550,62 @@ func TestTotpEnrollVerify_SetsSessionCookie_NoTokenInBody(t *testing.T) {
 	}
 	if _, ok := th.sessionMgr.TokenUser(context.Background(), sessionCookie(t, vw)); !ok {
 		t.Error("cookie token does not validate against the session manager")
+	}
+}
+
+// TestTotpEnrollVerify_LegacyMode_ReturnsTokenInBody_NoCookie pins the Front
+// Desk contract: with useCookieAuth=false the post-enroll session token
+// travels in the JSON body alongside recovery_codes, exactly as before the
+// httpOnly-cookie migration, and no mh_session cookie is ever set.
+func TestTotpEnrollVerify_LegacyMode_ReturnsTokenInBody_NoCookie(t *testing.T) {
+	_, th := newTotpTestHandlerLegacy(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/totp/enroll/start", http.NoBody)
+	req.Header.Set("Authorization", "Bearer admin-token")
+	w := httptest.NewRecorder()
+	serveTotpRouter(th).ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("enroll/start: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var startResp map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &startResp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	code := validCode(t, startResp["secret"])
+	vreq := httptest.NewRequest(http.MethodPost, "/totp/enroll/verify",
+		bytes.NewReader([]byte(`{"code":"`+code+`"}`)))
+	vreq.Header.Set("Authorization", "Bearer admin-token")
+	vreq.Header.Set("Content-Type", "application/json")
+	vw := httptest.NewRecorder()
+	serveTotpRouter(th).ServeHTTP(vw, vreq)
+
+	if vw.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", vw.Code, vw.Body.String())
+	}
+	var verifyResp struct {
+		RecoveryCodes []string `json:"recovery_codes"`
+		Token         string   `json:"token"`
+	}
+	if err := json.Unmarshal(vw.Body.Bytes(), &verifyResp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if verifyResp.Token == "" {
+		t.Errorf("expected token in legacy body, got: %s", vw.Body.String())
+	}
+	if len(verifyResp.RecoveryCodes) == 0 {
+		t.Errorf("expected recovery_codes in legacy body, got: %s", vw.Body.String())
+	}
+	if bytes.Contains(vw.Body.Bytes(), []byte(`"success"`)) {
+		t.Errorf("legacy body must not carry success flag: %s", vw.Body.String())
+	}
+	for _, c := range vw.Result().Cookies() {
+		if c.Name == authcookie.SessionCookie {
+			t.Errorf("legacy mode must not set an mh_session cookie, got %+v", c)
+		}
+	}
+	if _, ok := th.sessionMgr.TokenUser(context.Background(), verifyResp.Token); !ok {
+		t.Error("legacy body token does not validate against the session manager")
 	}
 }
 
@@ -784,6 +862,49 @@ func TestTotpLogin_SetsSessionCookie_NoTokenInBody(t *testing.T) {
 	}
 }
 
+// TestTotpLogin_LegacyMode_ReturnsTokenInBody_NoCookie pins the Front Desk
+// contract: with useCookieAuth=false a successful TOTP login returns the
+// session token in the JSON body exactly as before the httpOnly-cookie
+// migration, and no mh_session cookie is ever set.
+func TestTotpLogin_LegacyMode_ReturnsTokenInBody_NoCookie(t *testing.T) {
+	h, th := newTotpTestHandlerLegacy(t)
+	secret, _ := doEnrollVerify(t, th)
+	if !h.TotpEnabled() {
+		t.Fatal("expected TOTP enabled after enroll/verify")
+	}
+
+	code := validCode(t, secret)
+	body := []byte(`{"token":"admin-token","code":"` + code + `"}`)
+	req := httptest.NewRequest(http.MethodPost, "/totp/login", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	serveTotpRouter(th).ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Token string `json:"token"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Token == "" {
+		t.Errorf("expected token in legacy body, got: %s", w.Body.String())
+	}
+	if bytes.Contains(w.Body.Bytes(), []byte(`"success"`)) {
+		t.Errorf("legacy body must not carry success flag: %s", w.Body.String())
+	}
+	for _, c := range w.Result().Cookies() {
+		if c.Name == authcookie.SessionCookie {
+			t.Errorf("legacy mode must not set an mh_session cookie, got %+v", c)
+		}
+	}
+	if _, ok := th.sessionMgr.TokenUser(context.Background(), resp.Token); !ok {
+		t.Error("legacy body token does not validate against the session manager")
+	}
+}
+
 func TestTotpLogin_BadToken(t *testing.T) {
 	_, th := newTotpTestHandler(t)
 	secret, _ := doEnrollVerify(t, th)
@@ -860,7 +981,7 @@ func TestTotpAdminOrSessionAuth_TotpOn_RejectsRawToken(t *testing.T) {
 	sessionMgr := webauthn.NewSessionManager(wrepo)
 	adminMgr := &mockAdminAuth{validateFn: func(token string) bool { return token == "admin-token" }}
 
-	th := NewTotpHandler(totpRepo, adminMgr, sessionMgr, mockIPLimiter{}, false, func() bool { return true }, func(context.Context) {}, "auto")
+	th := NewTotpHandler(totpRepo, adminMgr, sessionMgr, mockIPLimiter{}, false, func() bool { return true }, func(context.Context) {}, "auto", true)
 
 	// Raw admin token: with TOTP on, enroll/start must 401.
 	req := httptest.NewRequest(http.MethodPost, "/totp/enroll/start", http.NoBody)

--- a/internal/adminauth/userlogin.go
+++ b/internal/adminauth/userlogin.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 
+	"github.com/hugalafutro/model-hotel/internal/authcookie"
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 	"github.com/hugalafutro/model-hotel/internal/totp"
 	"github.com/hugalafutro/model-hotel/internal/user"
@@ -42,6 +43,9 @@ type UserLoginHandler struct {
 	sessionMgr *webauthn.SessionManager
 	ipLimiter  IPLimiterMiddleware
 	userTotp   UserTotpFactory
+	// cookieSecure ("auto"/"always"/"never") resolves the Secure attribute on
+	// the session cookie so plain-http LAN deployments still work.
+	cookieSecure string
 	// Per-IP exponential backoff on failed logins, same knobs as /totp/login.
 	throttle *totp.Throttle
 	// Per-username backoff so a brute force distributed across source IPs is
@@ -52,12 +56,13 @@ type UserLoginHandler struct {
 
 // NewUserLoginHandler constructs the password-login front-end. userTotp may
 // be nil (no second factor is ever required then).
-func NewUserLoginHandler(users UserLoginStore, sessionMgr *webauthn.SessionManager, ipLimiter IPLimiterMiddleware, userTotp UserTotpFactory) *UserLoginHandler {
+func NewUserLoginHandler(users UserLoginStore, sessionMgr *webauthn.SessionManager, ipLimiter IPLimiterMiddleware, userTotp UserTotpFactory, cookieSecure string) *UserLoginHandler {
 	return &UserLoginHandler{
 		users:        users,
 		sessionMgr:   sessionMgr,
 		ipLimiter:    ipLimiter,
 		userTotp:     userTotp,
+		cookieSecure: cookieSecure,
 		throttle:     totp.NewThrottle(5, time.Second, 5*time.Minute),
 		userThrottle: totp.NewThrottle(5, time.Second, 5*time.Minute),
 	}
@@ -174,7 +179,15 @@ func (h *UserLoginHandler) Login(w http.ResponseWriter, r *http.Request) {
 	if err := h.users.TouchLastLogin(r.Context(), u.ID); err != nil {
 		debuglog.Warn("userlogin: failed to record last login", "error", err)
 	}
-	writeJSON(w, map[string]string{"token": token})
+	// Hand the session to the browser as an HttpOnly cookie rather than in the
+	// body: JS never touches it, and the cookie MaxAge is bound to the same
+	// webauthn.AuthTokenTTL as the server-side session so the two cannot drift.
+	if err := authcookie.SetSession(w, token, authcookie.Secure(r, h.cookieSecure), webauthn.AuthTokenTTL); err != nil {
+		debuglog.Error("userlogin: set session cookie failed", "error", err)
+		http.Error(w, "failed to create session", http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, map[string]any{"success": true})
 }
 
 // checkSecondFactor enforces per-user TOTP after the password has verified.

--- a/internal/adminauth/userlogin_test.go
+++ b/internal/adminauth/userlogin_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 
+	"github.com/hugalafutro/model-hotel/internal/authcookie"
 	totpsvc "github.com/hugalafutro/model-hotel/internal/totp"
 	"github.com/hugalafutro/model-hotel/internal/user"
 	"github.com/hugalafutro/model-hotel/internal/webauthn"
@@ -55,7 +56,7 @@ func newLoginFixture(t *testing.T, users ...*user.User) (*UserLoginHandler, *fak
 		store.byUsername[u.Username] = u
 	}
 	sm := webauthn.NewSessionManager(newMemStore())
-	h := NewUserLoginHandler(store, sm, mockIPLimiter{}, nil)
+	h := NewUserLoginHandler(store, sm, mockIPLimiter{}, nil, "auto")
 	r := chi.NewRouter()
 	h.Register(r)
 	return h, store, sm, r
@@ -86,6 +87,22 @@ func doLogin(t *testing.T, r chi.Router, body string) *httptest.ResponseRecorder
 	return w
 }
 
+// sessionCookie returns the value of the HttpOnly mh_session cookie set on the
+// response, failing the test if it is absent, empty, or not HttpOnly.
+func sessionCookie(t *testing.T, w *httptest.ResponseRecorder) string {
+	t.Helper()
+	for _, c := range w.Result().Cookies() {
+		if c.Name == authcookie.SessionCookie {
+			if !c.HttpOnly || c.Value == "" {
+				t.Fatalf("session cookie must be HttpOnly and non-empty, got %+v", c)
+			}
+			return c.Value
+		}
+	}
+	t.Fatalf("no %s cookie set: %+v", authcookie.SessionCookie, w.Result().Cookies())
+	return ""
+}
+
 func TestUserLogin_Success(t *testing.T) {
 	u := testUser(t, "alice", "correct-horse", true)
 	_, store, sm, r := newLoginFixture(t, u)
@@ -94,11 +111,11 @@ func TestUserLogin_Success(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
 	}
-	var resp map[string]string
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("bad body: %v", err)
+	// The session travels in the HttpOnly cookie, never the response body.
+	if bytes.Contains(w.Body.Bytes(), []byte("token")) {
+		t.Errorf("token leaked into body: %s", w.Body.String())
 	}
-	handle, ok := sm.TokenUser(context.Background(), resp["token"])
+	handle, ok := sm.TokenUser(context.Background(), sessionCookie(t, w))
 	if !ok {
 		t.Fatal("minted token does not validate")
 	}
@@ -107,6 +124,25 @@ func TestUserLogin_Success(t *testing.T) {
 	}
 	if len(store.touched) != 1 || store.touched[0] != u.ID {
 		t.Errorf("TouchLastLogin not recorded: %v", store.touched)
+	}
+}
+
+// TestUserLogin_SetsSessionCookie_NoTokenInBody pins the cookie-auth contract:
+// a successful login sets an HttpOnly mh_session cookie and the body carries
+// only {"success":true}, never the raw token.
+func TestUserLogin_SetsSessionCookie_NoTokenInBody(t *testing.T) {
+	u := testUser(t, "alice", "correct-horse", true)
+	_, _, sm, r := newLoginFixture(t, u)
+
+	w := doLogin(t, r, `{"username":"alice","password":"correct-horse"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("login = %d, want 200 (%s)", w.Code, w.Body.String())
+	}
+	if !bytes.Contains(w.Body.Bytes(), []byte(`"success"`)) || bytes.Contains(w.Body.Bytes(), []byte(`"token"`)) {
+		t.Errorf("body must be success-only with no token: %s", w.Body.String())
+	}
+	if _, ok := sm.TokenUser(context.Background(), sessionCookie(t, w)); !ok {
+		t.Error("cookie token does not validate against the session manager")
 	}
 }
 
@@ -219,7 +255,7 @@ func TestUserLogin_LookupErrorIs500(t *testing.T) {
 	// error, distinct from bad credentials: it must surface as 500, not 401.
 	store := &fakeUserStore{byUsername: map[string]*user.User{}, hasEnabled: true, getErr: errors.New("db down")}
 	sm := webauthn.NewSessionManager(newMemStore())
-	h := NewUserLoginHandler(store, sm, mockIPLimiter{}, nil)
+	h := NewUserLoginHandler(store, sm, mockIPLimiter{}, nil, "auto")
 	r := chi.NewRouter()
 	h.Register(r)
 
@@ -248,7 +284,7 @@ func TestUserLogin_TouchLastLoginFailureStillSucceeds(t *testing.T) {
 	u := testUser(t, "alice", "correct-horse", true)
 	store := &fakeUserStore{byUsername: map[string]*user.User{"alice": u}, hasEnabled: true, touchErr: errors.New("write failed")}
 	sm := webauthn.NewSessionManager(newMemStore())
-	h := NewUserLoginHandler(store, sm, mockIPLimiter{}, nil)
+	h := NewUserLoginHandler(store, sm, mockIPLimiter{}, nil, "auto")
 	r := chi.NewRouter()
 	h.Register(r)
 
@@ -454,7 +490,7 @@ func newTotpLoginFixture(t *testing.T, u *user.User) (*fakeTotpStore, string, ch
 		t.Fatalf("Enable: %v", err)
 	}
 	sm := webauthn.NewSessionManager(newMemStore())
-	h := NewUserLoginHandler(store, sm, mockIPLimiter{}, func(uuid.UUID) *totpsvc.Repository { return repo })
+	h := NewUserLoginHandler(store, sm, mockIPLimiter{}, func(uuid.UUID) *totpsvc.Repository { return repo }, "auto")
 	r := chi.NewRouter()
 	h.Register(r)
 	return fake, secret, r
@@ -495,12 +531,9 @@ func TestUserLogin_TotpValidCode(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
 	}
-	var resp map[string]string
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("bad body: %v", err)
-	}
-	if resp["token"] == "" {
-		t.Error("no session token in response")
+	// A code-gated login also delivers its session via the HttpOnly cookie.
+	if sessionCookie(t, w) == "" {
+		t.Error("no session cookie after valid TOTP login")
 	}
 }
 
@@ -564,7 +597,7 @@ func TestUserLogin_TotpWiredButNotEnabled(t *testing.T) {
 	fake := &fakeTotpStore{recovery: map[string]bool{}} // never enrolled/enabled
 	repo := totpsvc.NewRepositoryWithStore(fake, testMasterKey)
 	sm := webauthn.NewSessionManager(newMemStore())
-	h := NewUserLoginHandler(store, sm, mockIPLimiter{}, func(uuid.UUID) *totpsvc.Repository { return repo })
+	h := NewUserLoginHandler(store, sm, mockIPLimiter{}, func(uuid.UUID) *totpsvc.Repository { return repo }, "auto")
 	r := chi.NewRouter()
 	h.Register(r)
 
@@ -634,7 +667,7 @@ func TestUserLogin_TotpPostgresStoreRoundTrip(t *testing.T) {
 
 	store := &fakeUserStore{byUsername: map[string]*user.User{u.Username: u}, hasEnabled: true}
 	sm := webauthn.NewSessionManager(newMemStore())
-	h := NewUserLoginHandler(store, sm, mockIPLimiter{}, factory)
+	h := NewUserLoginHandler(store, sm, mockIPLimiter{}, factory, "auto")
 	r := chi.NewRouter()
 	h.Register(r)
 

--- a/internal/adminauth/webauthn.go
+++ b/internal/adminauth/webauthn.go
@@ -14,6 +14,7 @@ import (
 	webauthnx "github.com/go-webauthn/webauthn/webauthn"
 	"github.com/google/uuid"
 
+	"github.com/hugalafutro/model-hotel/internal/authcookie"
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 	"github.com/hugalafutro/model-hotel/internal/events"
 	"github.com/hugalafutro/model-hotel/internal/util"
@@ -33,6 +34,13 @@ type WebAuthnHandler struct {
 	ipLimiter    IPLimiterMiddleware
 	demoReadOnly bool
 	totpEnabled  func() bool
+	// useCookieAuth mints the dashboard HttpOnly session cookie on passkey
+	// login and clears it on logout. Front Desk leaves this false so its
+	// legacy token-in-body login and header-only logout stay byte-for-byte.
+	useCookieAuth bool
+	// cookieSecure ("auto"/"always"/"never") resolves the cookie Secure
+	// attribute; only consulted when useCookieAuth is true.
+	cookieSecure string
 }
 
 // NewWebAuthnHandler creates a new WebAuthn handler with the given dependencies.
@@ -44,15 +52,19 @@ func NewWebAuthnHandler(
 	ipLimiter IPLimiterMiddleware,
 	demoReadOnly bool,
 	totpEnabled func() bool,
+	useCookieAuth bool,
+	cookieSecure string,
 ) *WebAuthnHandler {
 	return &WebAuthnHandler{
-		webauthnRepo: webauthnRepo,
-		relyingParty: relyingParty,
-		sessionMgr:   sessionMgr,
-		adminMgr:     adminMgr,
-		ipLimiter:    ipLimiter,
-		demoReadOnly: demoReadOnly,
-		totpEnabled:  totpEnabled,
+		webauthnRepo:  webauthnRepo,
+		relyingParty:  relyingParty,
+		sessionMgr:    sessionMgr,
+		adminMgr:      adminMgr,
+		ipLimiter:     ipLimiter,
+		demoReadOnly:  demoReadOnly,
+		totpEnabled:   totpEnabled,
+		useCookieAuth: useCookieAuth,
+		cookieSecure:  cookieSecure,
 	}
 }
 
@@ -405,6 +417,23 @@ func (h *WebAuthnHandler) LoginFinish(w http.ResponseWriter, r *http.Request) {
 	}
 
 	debuglog.Info("webauthn: passkey login successful")
+	h.respondLoginSuccess(w, r, token)
+}
+
+// respondLoginSuccess writes the minted auth token to the response. In cookie
+// mode (main dashboard) it sets the HttpOnly session cookie and returns
+// {"success": true}; otherwise (Front Desk legacy) it returns the token in the
+// body so the pre-cookie contract stays byte-for-byte.
+func (h *WebAuthnHandler) respondLoginSuccess(w http.ResponseWriter, r *http.Request, token string) {
+	if h.useCookieAuth {
+		if err := authcookie.SetSession(w, token, authcookie.Secure(r, h.cookieSecure), webauthn.AuthTokenTTL); err != nil {
+			debuglog.Error("webauthn: set session cookie failed", "error", err)
+			http.Error(w, "failed to create session", http.StatusInternalServerError)
+			return
+		}
+		writeJSON(w, map[string]any{"success": true})
+		return
+	}
 	writeJSON(w, map[string]any{
 		"token": token,
 	})
@@ -413,13 +442,25 @@ func (h *WebAuthnHandler) LoginFinish(w http.ResponseWriter, r *http.Request) {
 // Logout revokes a WebAuthn session token.
 // POST /webauthn/logout (admin or session auth required)
 func (h *WebAuthnHandler) Logout(w http.ResponseWriter, r *http.Request) {
-	token, ok := util.ParseBearerToken(r)
+	// Read the token cookie-first (main dashboard) with a bearer-header
+	// fallback (Front Desk legacy), so both auth surfaces can log out.
+	token, ok := authcookie.SessionToken(r)
+	if !ok {
+		token, ok = util.ParseBearerToken(r)
+	}
 	if !ok {
 		http.Error(w, "Authorization header required", http.StatusUnauthorized)
 		return
 	}
 
 	h.sessionMgr.RevokeAuthToken(r.Context(), token)
+
+	// Clear the session cookies only in cookie mode. Front Desk leaves this
+	// off so its logout response emits no Set-Cookie header and stays
+	// byte-identical to the legacy contract.
+	if h.useCookieAuth {
+		authcookie.ClearSession(w, authcookie.Secure(r, h.cookieSecure))
+	}
 
 	writeJSON(w, map[string]any{
 		"success": true,

--- a/internal/adminauth/webauthn_test.go
+++ b/internal/adminauth/webauthn_test.go
@@ -14,6 +14,7 @@ import (
 	webauthnx "github.com/go-webauthn/webauthn/webauthn"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/hugalafutro/model-hotel/internal/authcookie"
 	"github.com/hugalafutro/model-hotel/internal/webauthn"
 )
 
@@ -193,6 +194,106 @@ func TestAdminOrSessionAuth_SessionToken(t *testing.T) {
 
 	if w.Code != http.StatusOK {
 		t.Errorf("expected status %d, got %d; body: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+}
+
+// newCookieSessionEnv builds a repo-backed SessionManager wired through
+// adminOrSessionAuth and mints a session token for the given user handle.
+// It returns the wrapped handler and the minted token. The admin token is
+// never valid here, so only the cookie/session paths can admit a request.
+func newCookieSessionEnv(t *testing.T, userID []byte) (http.Handler, string) {
+	t.Helper()
+	if apiTestDBURL == "" {
+		t.Fatal("test database not available")
+	}
+	pool, err := pgxpool.New(context.Background(), apiTestDBURL)
+	if err != nil {
+		t.Fatal("test database not available")
+	}
+	t.Cleanup(pool.Close)
+
+	repo := webauthn.NewRepository(pool)
+	sessionMgr := webauthn.NewSessionManager(repo)
+	adminMgr := &mockAdminAuth{validateFn: func(string) bool { return false }}
+	h := newTestWebAuthnHandler(repo, nil, sessionMgr, adminMgr)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	wrapped := h.adminOrSessionAuth(handler)
+
+	token, err := sessionMgr.CreateAuthToken(context.Background(), userID, nil)
+	if err != nil {
+		t.Fatalf("failed to create session token: %v", err)
+	}
+	return wrapped, token
+}
+
+// TestAdminOrSession_Cookie_AdminGet_Works verifies an admin session ridden on
+// the mh_session cookie admits a safe GET (no CSRF header required).
+func TestAdminOrSession_Cookie_AdminGet_Works(t *testing.T) {
+	wrapped, token := newCookieSessionEnv(t, []byte("admin"))
+
+	req := httptest.NewRequest(http.MethodGet, "/test", http.NoBody)
+	req.AddCookie(&http.Cookie{Name: authcookie.SessionCookie, Value: token})
+	w := httptest.NewRecorder()
+
+	wrapped.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d; body: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+}
+
+// TestAdminOrSession_Cookie_Post_RequiresCSRF verifies an admin cookie session
+// on an unsafe method is rejected with 403 when the CSRF header is absent.
+func TestAdminOrSession_Cookie_Post_RequiresCSRF(t *testing.T) {
+	wrapped, token := newCookieSessionEnv(t, []byte("admin"))
+
+	req := httptest.NewRequest(http.MethodPost, "/test", http.NoBody)
+	req.AddCookie(&http.Cookie{Name: authcookie.SessionCookie, Value: token})
+	w := httptest.NewRecorder()
+
+	wrapped.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected status %d (CSRF required), got %d; body: %s", http.StatusForbidden, w.Code, w.Body.String())
+	}
+}
+
+// TestAdminOrSession_Cookie_Post_WithCSRF verifies an admin cookie session on
+// an unsafe method passes when the CSRF cookie and header match.
+func TestAdminOrSession_Cookie_Post_WithCSRF(t *testing.T) {
+	wrapped, token := newCookieSessionEnv(t, []byte("admin"))
+
+	req := httptest.NewRequest(http.MethodPost, "/test", http.NoBody)
+	req.AddCookie(&http.Cookie{Name: authcookie.SessionCookie, Value: token})
+	req.AddCookie(&http.Cookie{Name: authcookie.CSRFCookie, Value: "csrf-tok"})
+	req.Header.Set(authcookie.CSRFHeader, "csrf-tok")
+	w := httptest.NewRecorder()
+
+	wrapped.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status %d (matching CSRF), got %d; body: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+}
+
+// TestAdminOrSession_Cookie_UserSessionRejected verifies the admin-only gate:
+// a valid but non-admin (UUID) session cookie must NOT reach next. With no
+// bearer header and no admin cookie identity, it falls through to the header
+// logic and is rejected with 401.
+func TestAdminOrSession_Cookie_UserSessionRejected(t *testing.T) {
+	wrapped, token := newCookieSessionEnv(t, []byte("11111111-1111-1111-1111-111111111111"))
+
+	req := httptest.NewRequest(http.MethodGet, "/test", http.NoBody)
+	req.AddCookie(&http.Cookie{Name: authcookie.SessionCookie, Value: token})
+	w := httptest.NewRecorder()
+
+	wrapped.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected status %d (non-admin session rejected), got %d; body: %s", http.StatusUnauthorized, w.Code, w.Body.String())
 	}
 }
 

--- a/internal/adminauth/webauthn_test.go
+++ b/internal/adminauth/webauthn_test.go
@@ -342,6 +342,160 @@ func TestWebAuthnHandler_Logout_WithValidToken(t *testing.T) {
 	}
 }
 
+// TestWebAuthnLoginFinish_SetsSessionCookie verifies that in cookie mode the
+// passkey login success response sets the HttpOnly session cookie carrying the
+// minted token and returns {"success": true} with no token in the body.
+func TestWebAuthnLoginFinish_SetsSessionCookie(t *testing.T) {
+	h := newTestWebAuthnHandler(nil, nil, nil, nil)
+	h.useCookieAuth = true
+	h.cookieSecure = "never"
+
+	req := httptest.NewRequest(http.MethodPost, "/webauthn/login/finish", http.NoBody)
+	w := httptest.NewRecorder()
+
+	h.respondLoginSuccess(w, req, "session-token-123")
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d; body: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+	if got := sessionCookie(t, w); got != "session-token-123" {
+		t.Errorf("session cookie value = %q, want %q", got, "session-token-123")
+	}
+	var resp map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode body: %v", err)
+	}
+	if _, ok := resp["token"]; ok {
+		t.Errorf("cookie-mode response must not include token in body: %v", resp)
+	}
+	if resp["success"] != true {
+		t.Errorf("expected success:true, got %v", resp)
+	}
+}
+
+// TestWebAuthnLoginFinish_LegacyReturnsToken verifies that with cookie auth
+// disabled (Front Desk) the login response carries the token in the body and
+// sets no session cookie, preserving the legacy contract byte-for-byte.
+func TestWebAuthnLoginFinish_LegacyReturnsToken(t *testing.T) {
+	h := newTestWebAuthnHandler(nil, nil, nil, nil)
+	// useCookieAuth defaults to false (Front Desk legacy).
+
+	req := httptest.NewRequest(http.MethodPost, "/webauthn/login/finish", http.NoBody)
+	w := httptest.NewRecorder()
+
+	h.respondLoginSuccess(w, req, "legacy-token")
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, w.Code)
+	}
+	var resp map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode body: %v", err)
+	}
+	if resp["token"] != "legacy-token" {
+		t.Errorf("expected token in body, got %v", resp)
+	}
+	for _, c := range w.Result().Cookies() {
+		if c.Name == authcookie.SessionCookie {
+			t.Errorf("legacy mode must not set session cookie, got %+v", c)
+		}
+	}
+}
+
+// TestWebAuthnHandler_Logout_CookieMode_ClearsCookie verifies that in cookie
+// mode logout revokes the token read from the session cookie and emits an
+// expiring session cookie (MaxAge < 0).
+func TestWebAuthnHandler_Logout_CookieMode_ClearsCookie(t *testing.T) {
+	dbURL := apiTestDBURL
+	if dbURL == "" {
+		t.Fatal("test database not available")
+	}
+	pool, err := pgxpool.New(context.Background(), dbURL)
+	if err != nil {
+		t.Fatal("test database not available")
+	}
+	defer pool.Close()
+
+	repo := webauthn.NewRepository(pool)
+	sessionMgr := webauthn.NewSessionManager(repo)
+	adminMgr := &mockAdminAuth{validateFn: func(string) bool { return false }}
+	h := newTestWebAuthnHandler(repo, nil, sessionMgr, adminMgr)
+	h.useCookieAuth = true
+	h.cookieSecure = "never"
+
+	token, err := sessionMgr.CreateAuthToken(context.Background(), []byte("admin"), nil)
+	if err != nil {
+		t.Fatalf("failed to create session token: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/webauthn/logout", http.NoBody)
+	req.AddCookie(&http.Cookie{Name: authcookie.SessionCookie, Value: token})
+	w := httptest.NewRecorder()
+
+	h.Logout(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d; body: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+	if sessionMgr.Validate(context.Background(), token) {
+		t.Error("token should be invalid after cookie-mode logout")
+	}
+	var cleared *http.Cookie
+	for _, c := range w.Result().Cookies() {
+		if c.Name == authcookie.SessionCookie {
+			cleared = c
+		}
+	}
+	if cleared == nil {
+		t.Fatalf("expected expiring %s cookie, got %+v", authcookie.SessionCookie, w.Result().Cookies())
+	}
+	if cleared.MaxAge >= 0 {
+		t.Errorf("expected session cookie MaxAge < 0, got %d", cleared.MaxAge)
+	}
+}
+
+// TestWebAuthnHandler_Logout_LegacyMode_NoSetCookie verifies the Front Desk
+// legacy logout path: it revokes the bearer token and emits no Set-Cookie
+// header so the response stays byte-identical to the pre-cookie contract.
+func TestWebAuthnHandler_Logout_LegacyMode_NoSetCookie(t *testing.T) {
+	dbURL := apiTestDBURL
+	if dbURL == "" {
+		t.Fatal("test database not available")
+	}
+	pool, err := pgxpool.New(context.Background(), dbURL)
+	if err != nil {
+		t.Fatal("test database not available")
+	}
+	defer pool.Close()
+
+	repo := webauthn.NewRepository(pool)
+	sessionMgr := webauthn.NewSessionManager(repo)
+	adminMgr := &mockAdminAuth{validateFn: func(string) bool { return false }}
+	h := newTestWebAuthnHandler(repo, nil, sessionMgr, adminMgr)
+	// useCookieAuth defaults to false (Front Desk legacy).
+
+	token, err := sessionMgr.CreateAuthToken(context.Background(), []byte("admin"), nil)
+	if err != nil {
+		t.Fatalf("failed to create session token: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/webauthn/logout", http.NoBody)
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+
+	h.Logout(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d; body: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+	if sessionMgr.Validate(context.Background(), token) {
+		t.Error("token should be invalid after logout")
+	}
+	if sc := w.Header().Values("Set-Cookie"); len(sc) != 0 {
+		t.Errorf("legacy logout must not emit Set-Cookie, got %v", sc)
+	}
+}
+
 // TestListCredentials_Success tests listing credentials with valid auth
 func TestListCredentials_Success(t *testing.T) {
 	dbURL := apiTestDBURL
@@ -384,7 +538,7 @@ func TestListCredentials_Success(t *testing.T) {
 
 // TestWebAuthnHandler_NewWebAuthnHandler_NilParams tests the constructor with nil params
 func TestWebAuthnHandler_NewWebAuthnHandler_NilParams(t *testing.T) {
-	h := NewWebAuthnHandler(nil, nil, nil, nil, nil, false, nil)
+	h := NewWebAuthnHandler(nil, nil, nil, nil, nil, false, nil, false, "")
 	if h == nil {
 		t.Fatal("expected non-nil handler")
 	}
@@ -409,7 +563,7 @@ func TestWebAuthnHandler_NewWebAuthnHandler_NilParams(t *testing.T) {
 func TestWebAuthnHandler_NewWebAuthnHandler_NonNilParams(t *testing.T) {
 	adminMgr := &mockAdminAuth{validateFn: func(token string) bool { return true }}
 	limiter := mockIPLimiter{}
-	h := NewWebAuthnHandler(nil, nil, nil, adminMgr, limiter, false, nil)
+	h := NewWebAuthnHandler(nil, nil, nil, adminMgr, limiter, false, nil, false, "")
 	if h == nil {
 		t.Fatal("expected non-nil handler")
 	}

--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -96,6 +96,10 @@ type WebAuthnSessionManager interface {
 	// multi-user password logins).
 	TokenUser(ctx context.Context, token string) ([]byte, bool)
 	RevokeAuthToken(ctx context.Context, token string) bool
+	// CreateAuthToken mints a new session token for the given user handle. The
+	// admin-token exchange trades a valid admin token for a session cookie via
+	// this method (userID is []byte("admin") for the legacy admin login).
+	CreateAuthToken(ctx context.Context, userID, credentialID []byte) (string, error)
 }
 
 // Handler manages admin API operations for providers, models, and virtual keys.

--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/hugalafutro/model-hotel/internal/audit"
 	"github.com/hugalafutro/model-hotel/internal/auth"
+	"github.com/hugalafutro/model-hotel/internal/authcookie"
 	"github.com/hugalafutro/model-hotel/internal/config"
 	"github.com/hugalafutro/model-hotel/internal/db"
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
@@ -365,6 +366,25 @@ func (h *Handler) registerAdminOnly(r chi.Router) {
 // If the admin token is invalid, the session-based token is tried as a fallback.
 func (h *Handler) AuthMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Cookie path (browser). The session token rides an HttpOnly cookie;
+		// unsafe methods must also present a matching CSRF header. This branch
+		// is additive: an invalid/expired cookie falls through to the header
+		// logic below, and header (admin-token / bearer) callers are unaffected.
+		if tok, ok := authcookie.SessionToken(r); ok && h.webauthnSessionMgr != nil {
+			if sessionUserID, ok := h.webauthnSessionMgr.TokenUser(r.Context(), tok); ok {
+				if id, ok := h.resolveIdentity(r.Context(), sessionUserID); ok {
+					if !authcookie.IsSafeMethod(r.Method) && !authcookie.ValidCSRF(r) {
+						debuglog.Warn("auth: CSRF check failed", "remote_addr", r.RemoteAddr, "path", r.URL.Path)
+						http.Error(w, "CSRF token missing or invalid", http.StatusForbidden)
+						return
+					}
+					next.ServeHTTP(w, r.WithContext(user.WithIdentity(r.Context(), id)))
+					return
+				}
+			}
+			// Invalid/expired cookie: fall through to header logic.
+		}
+
 		token, ok := util.ParseBearerToken(r)
 		if !ok {
 			// Warn (not Error) with the remote address — never the token — so

--- a/internal/api/admin_test.go
+++ b/internal/api/admin_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/hugalafutro/model-hotel/internal/admin"
+	"github.com/hugalafutro/model-hotel/internal/authcookie"
 	"github.com/hugalafutro/model-hotel/internal/config"
 	"github.com/hugalafutro/model-hotel/internal/db"
 	"github.com/hugalafutro/model-hotel/internal/provider"
@@ -849,6 +850,97 @@ func TestAuthMiddleware_WebAuthnSessionFallbackFails(t *testing.T) {
 
 	if rec.Code != http.StatusUnauthorized {
 		t.Errorf("expected status %d when both admin and webAuthn fail, got %d", http.StatusUnauthorized, rec.Code)
+	}
+}
+
+// --- Cookie/CSRF AuthMiddleware tests ---
+
+// TestAuthMiddleware_SessionCookie_Get_Works verifies a browser session
+// carried on the HttpOnly cookie authenticates a safe (GET) request without
+// any Authorization header.
+func TestAuthMiddleware_SessionCookie_Get_Works(t *testing.T) {
+	mockAuth := &mockAdminAuth{validateFn: func(string) bool { return false }}
+	h := testHandler(nil, nil, nil, mockAuth, nil)
+	h.webauthnSessionMgr = &mockWebAuthnSessionMgr{
+		validateFn: func(_ context.Context, token string) bool { return token == "valid-session" },
+	}
+	handler := h.AuthMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/system", http.NoBody)
+	req.AddCookie(&http.Cookie{Name: authcookie.SessionCookie, Value: "valid-session"})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET with session cookie = %d, want 200 (body %s)", rec.Code, rec.Body.String())
+	}
+}
+
+// TestAuthMiddleware_SessionCookie_Post_RequiresCSRF verifies that a cookie-authenticated
+// unsafe method (POST) is rejected with 403 when no matching CSRF header is present.
+func TestAuthMiddleware_SessionCookie_Post_RequiresCSRF(t *testing.T) {
+	mockAuth := &mockAdminAuth{validateFn: func(string) bool { return false }}
+	h := testHandler(nil, nil, nil, mockAuth, nil)
+	h.webauthnSessionMgr = &mockWebAuthnSessionMgr{
+		validateFn: func(_ context.Context, token string) bool { return token == "valid-session" },
+	}
+	handler := h.AuthMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/providers", http.NoBody)
+	req.AddCookie(&http.Cookie{Name: authcookie.SessionCookie, Value: "valid-session"})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("POST cookie without CSRF = %d, want 403", rec.Code)
+	}
+}
+
+// TestAuthMiddleware_SessionCookie_Post_WithCSRF_Works verifies that a cookie-authenticated
+// POST succeeds when the CSRF header matches the CSRF cookie (double-submit).
+func TestAuthMiddleware_SessionCookie_Post_WithCSRF_Works(t *testing.T) {
+	mockAuth := &mockAdminAuth{validateFn: func(string) bool { return false }}
+	h := testHandler(nil, nil, nil, mockAuth, nil)
+	h.webauthnSessionMgr = &mockWebAuthnSessionMgr{
+		validateFn: func(_ context.Context, token string) bool { return token == "valid-session" },
+	}
+	handler := h.AuthMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/providers", http.NoBody)
+	req.AddCookie(&http.Cookie{Name: authcookie.SessionCookie, Value: "valid-session"})
+	req.AddCookie(&http.Cookie{Name: authcookie.CSRFCookie, Value: "csrf-xyz"})
+	req.Header.Set(authcookie.CSRFHeader, "csrf-xyz")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("POST cookie with CSRF = %d, want 200", rec.Code)
+	}
+}
+
+// TestAuthMiddleware_AdminTokenHeader_StillWorks_NoCSRF verifies that the
+// existing admin-token bearer path (TOTP off) is untouched by the cookie
+// branch: a header POST needs no CSRF token.
+func TestAuthMiddleware_AdminTokenHeader_StillWorks_NoCSRF(t *testing.T) {
+	mockAuth := &mockAdminAuth{validateFn: func(token string) bool { return token == "valid-token" }}
+	h := testHandler(nil, nil, nil, mockAuth, nil)
+	handler := h.AuthMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/providers", http.NoBody)
+	req.Header.Set("Authorization", "Bearer valid-token")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("admin-token header POST = %d, want 200 (CSRF-exempt)", rec.Code)
 	}
 }
 

--- a/internal/api/admin_token_exchange.go
+++ b/internal/api/admin_token_exchange.go
@@ -1,0 +1,73 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/hugalafutro/model-hotel/internal/authcookie"
+	"github.com/hugalafutro/model-hotel/internal/webauthn"
+)
+
+// adminTokenExchangeRequest is the JSON body of POST /api/auth/admin-exchange.
+type adminTokenExchangeRequest struct {
+	AdminToken string `json:"admin_token"`
+}
+
+// AdminTokenExchange trades a raw global admin token for an HttpOnly session
+// cookie so the dashboard never has to keep the raw admin token in the browser.
+// It is a login front-end (the exchange IS the login) and therefore lives in
+// the auth-exempt route group. When TOTP 2FA is enabled the admin token alone
+// is not a sufficient credential, so this refuses to mint a session and directs
+// callers to the /api/totp/login flow instead.
+func (h *Handler) AdminTokenExchange(w http.ResponseWriter, r *http.Request) {
+	var req adminTokenExchangeRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.AdminToken == "" {
+		respondBadRequest(w, "invalid request body", err)
+		return
+	}
+
+	// With 2FA on, the admin token is only a first factor; minting a full
+	// session from it here would bypass TOTP. Check before validating so a
+	// valid admin token still cannot short-circuit the second factor.
+	if h.TotpEnabled() {
+		respondBadRequest(w, "use TOTP login", nil)
+		return
+	}
+
+	// SetWebAuthnSessionManager is wired unconditionally in production, but guard
+	// defensively so a misconfigured build fails closed rather than panicking.
+	if h.webauthnSessionMgr == nil {
+		http.Error(w, "session manager unavailable", http.StatusInternalServerError)
+		return
+	}
+
+	// Validate before minting so an invalid admin token never yields a session.
+	if !h.adminMgr.Validate(req.AdminToken) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	tok, err := h.webauthnSessionMgr.CreateAuthToken(r.Context(), []byte("admin"), nil)
+	if err != nil {
+		http.Error(w, "failed to create session", http.StatusInternalServerError)
+		return
+	}
+	if err := authcookie.SetSession(w, tok, authcookie.Secure(r, h.cfg.CookieSecure), webauthn.AuthTokenTTL); err != nil {
+		http.Error(w, "failed to set session cookie", http.StatusInternalServerError)
+		return
+	}
+
+	// Never echo the admin token nor the freshly minted session token; the
+	// session travels only in the HttpOnly cookie set above.
+	writeJSON(w, map[string]bool{"success": true})
+}
+
+// RegisterAuthExchange mounts the admin-token exchange endpoint. It must be
+// registered in the auth-exempt group next to the other login routes because
+// the exchange runs before any session exists. Mounted under /api, this
+// resolves to POST /api/auth/admin-exchange.
+func (h *Handler) RegisterAuthExchange(r chi.Router) {
+	r.Post("/auth/admin-exchange", h.AdminTokenExchange)
+}

--- a/internal/api/admin_token_exchange.go
+++ b/internal/api/admin_token_exchange.go
@@ -64,10 +64,13 @@ func (h *Handler) AdminTokenExchange(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, map[string]bool{"success": true})
 }
 
-// RegisterAuthExchange mounts the admin-token exchange endpoint. It must be
-// registered in the auth-exempt group next to the other login routes because
-// the exchange runs before any session exists. Mounted under /api, this
-// resolves to POST /api/auth/admin-exchange.
+// RegisterAuthExchange mounts the admin-token exchange endpoint and the
+// always-available logout endpoint. Both must be registered in the
+// auth-exempt group: the exchange runs before any session exists, and
+// logout must work even for an already-expired or otherwise invalid
+// session. Mounted under /api, this resolves to POST /api/auth/admin-exchange
+// and POST /api/auth/logout.
 func (h *Handler) RegisterAuthExchange(r chi.Router) {
 	r.Post("/auth/admin-exchange", h.AdminTokenExchange)
+	r.Post("/auth/logout", h.AuthLogout)
 }

--- a/internal/api/admin_token_exchange_test.go
+++ b/internal/api/admin_token_exchange_test.go
@@ -2,10 +2,13 @@ package api
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/go-chi/chi/v5"
 
 	"github.com/hugalafutro/model-hotel/internal/authcookie"
 )
@@ -93,6 +96,72 @@ func TestAdminTokenExchange_MalformedBody_400(t *testing.T) {
 
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("malformed body = %d, want 400", rec.Code)
+	}
+}
+
+func TestAdminTokenExchange_NoSessionManager_500(t *testing.T) {
+	// Build a handler without SetWebAuthnSessionManager: a misconfigured build
+	// must fail closed with 500 rather than panicking on a nil session manager.
+	h := testHandler(nil, nil, nil, &mockAdminAuth{
+		validateFn: func(tok string) bool { return tok == exchangeAdminToken },
+	}, nil)
+
+	rec := httptest.NewRecorder()
+	body := `{"admin_token":"` + exchangeAdminToken + `"}`
+	h.AdminTokenExchange(rec, httptest.NewRequest(http.MethodPost, "/api/auth/admin-exchange", strings.NewReader(body)))
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("no session manager = %d, want 500 (%s)", rec.Code, rec.Body.String())
+	}
+	if cookieByName(rec, authcookie.SessionCookie) != nil {
+		t.Error("no session cookie should be set when the session manager is unavailable")
+	}
+}
+
+func TestAdminTokenExchange_CreateAuthTokenError_500(t *testing.T) {
+	h := testHandler(nil, nil, nil, &mockAdminAuth{
+		validateFn: func(tok string) bool { return tok == exchangeAdminToken },
+	}, nil)
+	h.SetWebAuthnSessionManager(&mockWebAuthnSessionMgr{
+		createFn: func(_ context.Context, _, _ []byte) (string, error) {
+			return "", errors.New("session store unavailable")
+		},
+	})
+
+	rec := httptest.NewRecorder()
+	body := `{"admin_token":"` + exchangeAdminToken + `"}`
+	h.AdminTokenExchange(rec, httptest.NewRequest(http.MethodPost, "/api/auth/admin-exchange", strings.NewReader(body)))
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("CreateAuthToken error = %d, want 500 (%s)", rec.Code, rec.Body.String())
+	}
+	if cookieByName(rec, authcookie.SessionCookie) != nil {
+		t.Error("no session cookie should be set when CreateAuthToken fails")
+	}
+}
+
+func TestRegisterAuthExchange_MountsRoutes(t *testing.T) {
+	h := testHandler(nil, nil, nil, &mockAdminAuth{
+		validateFn: func(tok string) bool { return tok == exchangeAdminToken },
+	}, nil)
+	h.SetWebAuthnSessionManager(&mockWebAuthnSessionMgr{
+		createFn: func(_ context.Context, _, _ []byte) (string, error) { return "admin-sess", nil },
+	})
+
+	r := chi.NewRouter()
+	h.RegisterAuthExchange(r)
+
+	rec := httptest.NewRecorder()
+	body := `{"admin_token":"` + exchangeAdminToken + `"}`
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/auth/admin-exchange", strings.NewReader(body)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("POST /auth/admin-exchange = %d, want 200 (%s)", rec.Code, rec.Body.String())
+	}
+
+	rec2 := httptest.NewRecorder()
+	r.ServeHTTP(rec2, httptest.NewRequest(http.MethodPost, "/auth/logout", http.NoBody))
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("POST /auth/logout = %d, want 200 (%s)", rec2.Code, rec2.Body.String())
 	}
 }
 

--- a/internal/api/admin_token_exchange_test.go
+++ b/internal/api/admin_token_exchange_test.go
@@ -1,0 +1,116 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/hugalafutro/model-hotel/internal/authcookie"
+)
+
+const exchangeAdminToken = "test-admin-token"
+
+// exchangeHandler builds a mock-backed Handler for the admin-token exchange
+// endpoint: the admin authenticator accepts exchangeAdminToken, and the session
+// manager mints a deterministic token so tests never touch a real session store.
+func exchangeHandler(t *testing.T) *Handler {
+	t.Helper()
+	h := testHandler(nil, nil, nil, &mockAdminAuth{
+		validateFn: func(tok string) bool { return tok == exchangeAdminToken },
+	}, nil)
+	h.SetWebAuthnSessionManager(&mockWebAuthnSessionMgr{
+		createFn: func(_ context.Context, _, _ []byte) (string, error) { return "admin-sess", nil },
+	})
+	return h
+}
+
+// cookieByName returns the response cookie with the given name, or nil.
+func cookieByName(rec *httptest.ResponseRecorder, name string) *http.Cookie {
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == name {
+			return c
+		}
+	}
+	return nil
+}
+
+func TestAdminTokenExchange_ValidToken_SetsCookie(t *testing.T) {
+	h := exchangeHandler(t)
+	rec := httptest.NewRecorder()
+	body := `{"admin_token":"` + exchangeAdminToken + `"}`
+	h.AdminTokenExchange(rec, httptest.NewRequest(http.MethodPost, "/api/auth/admin-exchange", strings.NewReader(body)))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("exchange = %d, want 200 (%s)", rec.Code, rec.Body.String())
+	}
+	c := cookieByName(rec, authcookie.SessionCookie)
+	if c == nil {
+		t.Fatalf("expected %s cookie", authcookie.SessionCookie)
+	}
+	if !c.HttpOnly {
+		t.Error("session cookie must be HttpOnly")
+	}
+	if c.Value != "admin-sess" {
+		t.Errorf("cookie value = %q, want minted session token", c.Value)
+	}
+	if strings.Contains(rec.Body.String(), "token") {
+		t.Errorf("body must not echo any token, got %q", rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "success") {
+		t.Errorf("body should report success, got %q", rec.Body.String())
+	}
+}
+
+func TestAdminTokenExchange_BadToken_401(t *testing.T) {
+	h := exchangeHandler(t)
+	rec := httptest.NewRecorder()
+	h.AdminTokenExchange(rec, httptest.NewRequest(http.MethodPost, "/api/auth/admin-exchange", strings.NewReader(`{"admin_token":"nope"}`)))
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("bad token = %d, want 401", rec.Code)
+	}
+	if cookieByName(rec, authcookie.SessionCookie) != nil {
+		t.Error("no session cookie should be set for a bad token")
+	}
+}
+
+func TestAdminTokenExchange_EmptyToken_400(t *testing.T) {
+	h := exchangeHandler(t)
+	rec := httptest.NewRecorder()
+	h.AdminTokenExchange(rec, httptest.NewRequest(http.MethodPost, "/api/auth/admin-exchange", strings.NewReader(`{"admin_token":""}`)))
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("empty token = %d, want 400", rec.Code)
+	}
+}
+
+func TestAdminTokenExchange_MalformedBody_400(t *testing.T) {
+	h := exchangeHandler(t)
+	rec := httptest.NewRecorder()
+	h.AdminTokenExchange(rec, httptest.NewRequest(http.MethodPost, "/api/auth/admin-exchange", strings.NewReader(`{not-json`)))
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("malformed body = %d, want 400", rec.Code)
+	}
+}
+
+func TestAdminTokenExchange_TotpEnabled_400(t *testing.T) {
+	h := exchangeHandler(t)
+	// With 2FA on the admin token alone is not sufficient; callers must use the
+	// TOTP login flow, so the exchange refuses to mint a session.
+	h.SetTotpStatus(&stubTotpStatus{enabled: true})
+	h.totpEnabled.Store(true)
+
+	rec := httptest.NewRecorder()
+	body := `{"admin_token":"` + exchangeAdminToken + `"}`
+	h.AdminTokenExchange(rec, httptest.NewRequest(http.MethodPost, "/api/auth/admin-exchange", strings.NewReader(body)))
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("totp enabled = %d, want 400", rec.Code)
+	}
+	if cookieByName(rec, authcookie.SessionCookie) != nil {
+		t.Error("no session cookie should be set when TOTP is enabled")
+	}
+}

--- a/internal/api/auth_logout.go
+++ b/internal/api/auth_logout.go
@@ -1,0 +1,27 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/hugalafutro/model-hotel/internal/authcookie"
+	"github.com/hugalafutro/model-hotel/internal/util"
+)
+
+// AuthLogout revokes the caller's session (if any) and clears the auth cookies.
+// Always mounted, unlike the passkey-gated /webauthn/logout, so the dashboard
+// can log out regardless of whether WebAuthn is configured. Safe unauthenticated:
+// it only revokes the token the caller presents and clears the caller's own cookies.
+func (h *Handler) AuthLogout(w http.ResponseWriter, r *http.Request) {
+	tok, ok := authcookie.SessionToken(r)
+	if !ok {
+		tok, ok = util.ParseBearerToken(r)
+	}
+
+	if ok && h.webauthnSessionMgr != nil {
+		h.webauthnSessionMgr.RevokeAuthToken(r.Context(), tok)
+	}
+
+	authcookie.ClearSession(w, authcookie.Secure(r, h.cfg.CookieSecure))
+
+	writeJSON(w, map[string]bool{"success": true})
+}

--- a/internal/api/auth_logout_test.go
+++ b/internal/api/auth_logout_test.go
@@ -1,0 +1,111 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hugalafutro/model-hotel/internal/authcookie"
+)
+
+// logoutHandler builds a mock-backed Handler for the always-available logout
+// endpoint, tracking whether and with what token RevokeAuthToken was called.
+func logoutHandler(t *testing.T, revoked *string, revokeCalled *bool) *Handler {
+	t.Helper()
+	h := testHandler(nil, nil, nil, nil, nil)
+	h.SetWebAuthnSessionManager(&mockWebAuthnSessionMgr{
+		revokeFn: func(_ context.Context, token string) bool {
+			if revokeCalled != nil {
+				*revokeCalled = true
+			}
+			if revoked != nil {
+				*revoked = token
+			}
+			return true
+		},
+	})
+	return h
+}
+
+func TestAuthLogout_CookieToken_ClearsCookieAndRevokes(t *testing.T) {
+	var revokedTok string
+	var called bool
+	h := logoutHandler(t, &revokedTok, &called)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/logout", http.NoBody)
+	req.AddCookie(&http.Cookie{Name: authcookie.SessionCookie, Value: "cookie-tok"})
+	rec := httptest.NewRecorder()
+
+	h.AuthLogout(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("logout = %d, want 200 (%s)", rec.Code, rec.Body.String())
+	}
+	if !called {
+		t.Fatal("expected RevokeAuthToken to be called")
+	}
+	if revokedTok != "cookie-tok" {
+		t.Errorf("revoked token = %q, want %q", revokedTok, "cookie-tok")
+	}
+	c := cookieByName(rec, authcookie.SessionCookie)
+	if c == nil {
+		t.Fatal("expected an mh_session cookie to be set (cleared)")
+	}
+	if c.MaxAge >= 0 {
+		t.Errorf("session cookie MaxAge = %d, want negative (expiring)", c.MaxAge)
+	}
+}
+
+func TestAuthLogout_BearerToken_ClearsCookieAndRevokes(t *testing.T) {
+	var revokedTok string
+	var called bool
+	h := logoutHandler(t, &revokedTok, &called)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/logout", http.NoBody)
+	req.Header.Set("Authorization", "Bearer bearer-tok")
+	rec := httptest.NewRecorder()
+
+	h.AuthLogout(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("logout = %d, want 200 (%s)", rec.Code, rec.Body.String())
+	}
+	if !called {
+		t.Fatal("expected RevokeAuthToken to be called")
+	}
+	if revokedTok != "bearer-tok" {
+		t.Errorf("revoked token = %q, want %q", revokedTok, "bearer-tok")
+	}
+	c := cookieByName(rec, authcookie.SessionCookie)
+	if c == nil {
+		t.Fatal("expected an mh_session cookie to be set (cleared)")
+	}
+	if c.MaxAge >= 0 {
+		t.Errorf("session cookie MaxAge = %d, want negative (expiring)", c.MaxAge)
+	}
+}
+
+func TestAuthLogout_NoToken_StillClearsCookieIdempotently(t *testing.T) {
+	var called bool
+	h := logoutHandler(t, nil, &called)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/logout", http.NoBody)
+	rec := httptest.NewRecorder()
+
+	h.AuthLogout(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("logout = %d, want 200 (%s)", rec.Code, rec.Body.String())
+	}
+	if called {
+		t.Error("RevokeAuthToken should not be called when no token is presented")
+	}
+	c := cookieByName(rec, authcookie.SessionCookie)
+	if c == nil {
+		t.Fatal("expected an mh_session cookie clear even with no token (idempotent)")
+	}
+	if c.MaxAge >= 0 {
+		t.Errorf("session cookie MaxAge = %d, want negative (expiring)", c.MaxAge)
+	}
+}

--- a/internal/api/webauthn_session_test.go
+++ b/internal/api/webauthn_session_test.go
@@ -13,6 +13,16 @@ import (
 type mockWebAuthnSessionMgr struct {
 	validateFn func(ctx context.Context, token string) bool
 	revokeFn   func(ctx context.Context, token string) bool
+	createFn   func(ctx context.Context, userID, credentialID []byte) (string, error)
+}
+
+// CreateAuthToken mints a session token, deferring to createFn when set so
+// tests can return a deterministic token (or an error) without a session store.
+func (m *mockWebAuthnSessionMgr) CreateAuthToken(ctx context.Context, userID, credentialID []byte) (string, error) {
+	if m.createFn != nil {
+		return m.createFn(ctx, userID, credentialID)
+	}
+	return "mock-session-token", nil
 }
 
 func (m *mockWebAuthnSessionMgr) Validate(ctx context.Context, token string) bool {

--- a/internal/authcookie/authcookie.go
+++ b/internal/authcookie/authcookie.go
@@ -1,0 +1,109 @@
+// Package authcookie carries dashboard session auth over hardened cookies:
+// an HttpOnly session cookie the browser cannot read, plus a readable CSRF
+// cookie echoed back in a header for stateless double-submit verification.
+package authcookie
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Cookie and header names used to carry dashboard session auth.
+const (
+	SessionCookie = "mh_session"
+	CSRFCookie    = "mh_csrf"
+	CSRFHeader    = "X-CSRF-Token"
+)
+
+// SetSession writes the session cookie (HttpOnly) and a fresh CSRF cookie
+// (readable) with SameSite=Strict. secure toggles the Secure attribute so
+// plain-http LAN deployments still work; callers decide via Secure().
+func SetSession(w http.ResponseWriter, token string, secure bool, maxAge time.Duration) error {
+	csrf, err := randomToken()
+	if err != nil {
+		return err
+	}
+	age := int(maxAge.Seconds())
+	http.SetCookie(w, &http.Cookie{ //nolint:gosec // Secure/HttpOnly/SameSite are all set below via caller-controlled args, not omitted
+		Name: SessionCookie, Value: token, Path: "/",
+		HttpOnly: true, Secure: secure, SameSite: http.SameSiteStrictMode, MaxAge: age,
+	})
+	http.SetCookie(w, &http.Cookie{ //nolint:gosec // CSRF cookie is intentionally readable (HttpOnly: false) for double-submit; Secure/SameSite still set
+		Name: CSRFCookie, Value: csrf, Path: "/",
+		HttpOnly: false, Secure: secure, SameSite: http.SameSiteStrictMode, MaxAge: age,
+	})
+	return nil
+}
+
+// ClearSession expires both cookies.
+func ClearSession(w http.ResponseWriter, secure bool) {
+	for _, name := range []string{SessionCookie, CSRFCookie} {
+		http.SetCookie(w, &http.Cookie{ //nolint:gosec // Secure/HttpOnly/SameSite are all set below via caller-controlled args, not omitted
+			Name: name, Value: "", Path: "/",
+			HttpOnly: name == SessionCookie, Secure: secure,
+			SameSite: http.SameSiteStrictMode, MaxAge: -1,
+		})
+	}
+}
+
+// SessionToken returns the session token from the cookie, if present.
+func SessionToken(r *http.Request) (string, bool) {
+	c, err := r.Cookie(SessionCookie)
+	if err != nil || c.Value == "" {
+		return "", false
+	}
+	return c.Value, true
+}
+
+// ValidCSRF reports whether the request carries a CSRF header equal to its
+// CSRF cookie (constant-time). Callers apply this only to unsafe methods on
+// cookie-authenticated requests.
+func ValidCSRF(r *http.Request) bool {
+	c, err := r.Cookie(CSRFCookie)
+	if err != nil || c.Value == "" {
+		return false
+	}
+	h := r.Header.Get(CSRFHeader)
+	if h == "" {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(c.Value), []byte(h)) == 1
+}
+
+// IsSafeMethod reports whether the HTTP method is non-mutating (CSRF-exempt).
+func IsSafeMethod(method string) bool {
+	switch method {
+	case http.MethodGet, http.MethodHead, http.MethodOptions:
+		return true
+	default:
+		return false
+	}
+}
+
+// Secure resolves the cookie Secure attribute. mode is "always", "never", or
+// "auto" (default): auto is on for TLS or X-Forwarded-Proto=https.
+func Secure(r *http.Request, mode string) bool {
+	switch mode {
+	case "always":
+		return true
+	case "never":
+		return false
+	default:
+		if r.TLS != nil {
+			return true
+		}
+		return strings.EqualFold(r.Header.Get("X-Forwarded-Proto"), "https")
+	}
+}
+
+func randomToken() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}

--- a/internal/authcookie/authcookie_test.go
+++ b/internal/authcookie/authcookie_test.go
@@ -1,0 +1,83 @@
+package authcookie
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestSetSession_SetsHardenedCookies(t *testing.T) {
+	rec := httptest.NewRecorder()
+	if err := SetSession(rec, "sess-abc", true, time.Hour); err != nil {
+		t.Fatalf("SetSession: %v", err)
+	}
+	cookies := rec.Result().Cookies()
+	var sess, csrf *http.Cookie
+	for _, c := range cookies {
+		switch c.Name {
+		case SessionCookie:
+			sess = c
+		case CSRFCookie:
+			csrf = c
+		}
+	}
+	if sess == nil || csrf == nil {
+		t.Fatalf("expected both %s and %s cookies, got %+v", SessionCookie, CSRFCookie, cookies)
+	}
+	if !sess.HttpOnly {
+		t.Error("session cookie must be HttpOnly")
+	}
+	if csrf.HttpOnly {
+		t.Error("csrf cookie must be readable (not HttpOnly)")
+	}
+	if sess.SameSite != http.SameSiteStrictMode || csrf.SameSite != http.SameSiteStrictMode {
+		t.Error("both cookies must be SameSite=Strict")
+	}
+	if !sess.Secure || !csrf.Secure {
+		t.Error("secure=true must set Secure on both cookies")
+	}
+	if sess.Value != "sess-abc" {
+		t.Errorf("session value = %q, want sess-abc", sess.Value)
+	}
+	if csrf.Value == "" {
+		t.Error("csrf cookie must carry a generated value")
+	}
+}
+
+func TestValidCSRF_HeaderMatchesCookie(t *testing.T) {
+	r := httptest.NewRequest(http.MethodPost, "/api/x", http.NoBody)
+	r.AddCookie(&http.Cookie{Name: CSRFCookie, Value: "tok123"})
+	r.Header.Set(CSRFHeader, "tok123")
+	if !ValidCSRF(r) {
+		t.Error("matching header and cookie should be valid")
+	}
+	r2 := httptest.NewRequest(http.MethodPost, "/api/x", http.NoBody)
+	r2.AddCookie(&http.Cookie{Name: CSRFCookie, Value: "tok123"})
+	r2.Header.Set(CSRFHeader, "wrong")
+	if ValidCSRF(r2) {
+		t.Error("mismatched header should be invalid")
+	}
+	r3 := httptest.NewRequest(http.MethodPost, "/api/x", http.NoBody)
+	r3.AddCookie(&http.Cookie{Name: CSRFCookie, Value: "tok123"})
+	if ValidCSRF(r3) {
+		t.Error("missing header should be invalid")
+	}
+}
+
+func TestSecure_Modes(t *testing.T) {
+	httpReq := httptest.NewRequest(http.MethodGet, "http://x/api", http.NoBody)
+	tlsReq := httptest.NewRequest(http.MethodGet, "https://x/api", http.NoBody)
+	fwd := httptest.NewRequest(http.MethodGet, "http://x/api", http.NoBody)
+	fwd.Header.Set("X-Forwarded-Proto", "https")
+
+	if Secure(httpReq, "always") != true || Secure(tlsReq, "never") != false {
+		t.Error("explicit modes must win")
+	}
+	if Secure(httpReq, "auto") != false {
+		t.Error("auto over plain http must be false")
+	}
+	if Secure(tlsReq, "auto") != true || Secure(fwd, "auto") != true {
+		t.Error("auto must detect TLS and X-Forwarded-Proto=https")
+	}
+}

--- a/internal/authcookie/authcookie_test.go
+++ b/internal/authcookie/authcookie_test.go
@@ -65,6 +65,88 @@ func TestValidCSRF_HeaderMatchesCookie(t *testing.T) {
 	}
 }
 
+func TestClearSession_ExpiresBothCookies(t *testing.T) {
+	rec := httptest.NewRecorder()
+	ClearSession(rec, true)
+
+	cookies := rec.Result().Cookies()
+	var sess, csrf *http.Cookie
+	for _, c := range cookies {
+		switch c.Name {
+		case SessionCookie:
+			sess = c
+		case CSRFCookie:
+			csrf = c
+		}
+	}
+	if sess == nil || csrf == nil {
+		t.Fatalf("expected both %s and %s cookies, got %+v", SessionCookie, CSRFCookie, cookies)
+	}
+	if sess.MaxAge != -1 || csrf.MaxAge != -1 {
+		t.Errorf("both cookies must expire with MaxAge -1, got session=%d csrf=%d", sess.MaxAge, csrf.MaxAge)
+	}
+	if !sess.HttpOnly {
+		t.Error("session cookie must stay HttpOnly on clear")
+	}
+	if csrf.HttpOnly {
+		t.Error("csrf cookie must stay readable (not HttpOnly) on clear")
+	}
+	if sess.SameSite != http.SameSiteStrictMode || csrf.SameSite != http.SameSiteStrictMode {
+		t.Error("both cleared cookies must stay SameSite=Strict")
+	}
+	if !sess.Secure || !csrf.Secure {
+		t.Error("secure=true must set Secure on both cleared cookies")
+	}
+}
+
+func TestClearSession_SecureFalse(t *testing.T) {
+	rec := httptest.NewRecorder()
+	ClearSession(rec, false)
+
+	for _, c := range rec.Result().Cookies() {
+		if c.Secure {
+			t.Errorf("secure=false must not set Secure on %s", c.Name)
+		}
+	}
+}
+
+func TestSessionToken(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/api/x", http.NoBody)
+	r.AddCookie(&http.Cookie{Name: SessionCookie, Value: "sess-xyz"})
+	tok, ok := SessionToken(r)
+	if !ok || tok != "sess-xyz" {
+		t.Errorf("SessionToken() = (%q, %v), want (sess-xyz, true)", tok, ok)
+	}
+
+	r2 := httptest.NewRequest(http.MethodGet, "/api/x", http.NoBody)
+	tok2, ok2 := SessionToken(r2)
+	if ok2 || tok2 != "" {
+		t.Errorf("SessionToken() with no cookie = (%q, %v), want (\"\", false)", tok2, ok2)
+	}
+
+	r3 := httptest.NewRequest(http.MethodGet, "/api/x", http.NoBody)
+	r3.AddCookie(&http.Cookie{Name: SessionCookie, Value: ""})
+	tok3, ok3 := SessionToken(r3)
+	if ok3 || tok3 != "" {
+		t.Errorf("SessionToken() with empty cookie value = (%q, %v), want (\"\", false)", tok3, ok3)
+	}
+}
+
+func TestIsSafeMethod(t *testing.T) {
+	safe := []string{http.MethodGet, http.MethodHead, http.MethodOptions}
+	for _, m := range safe {
+		if !IsSafeMethod(m) {
+			t.Errorf("IsSafeMethod(%q) = false, want true", m)
+		}
+	}
+	unsafe := []string{http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete}
+	for _, m := range unsafe {
+		if IsSafeMethod(m) {
+			t.Errorf("IsSafeMethod(%q) = true, want false", m)
+		}
+	}
+}
+
 func TestSecure_Modes(t *testing.T) {
 	httpReq := httptest.NewRequest(http.MethodGet, "http://x/api", http.NoBody)
 	tlsReq := httptest.NewRequest(http.MethodGet, "https://x/api", http.NoBody)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -46,6 +46,11 @@ type Config struct {
 	TrustedProxies       []*net.IPNet
 	KnownProxies         []*net.IPNet
 
+	// CookieSecure controls the Secure attribute on dashboard auth cookies.
+	// "auto" (default) sets Secure based on the request scheme, "always"
+	// forces Secure on, and "never" forces Secure off (for local HTTP dev).
+	CookieSecure string
+
 	// WebAuthn/FIDO2 configuration. When WEBAUTHN_RP_ID is set, passkey
 	// login is enabled; otherwise the feature is completely disabled.
 	WebAuthnRPID          string
@@ -148,6 +153,8 @@ func Load() (*Config, error) {
 		WebAuthnRPID:          getEnv("WEBAUTHN_RP_ID"),
 		WebAuthnRPDisplayName: getEnvWithDefault("WEBAUTHN_RP_DISPLAY_NAME", "Model Hotel"),
 		WebAuthnRPOrigins:     parseCORSOrigins(getEnv("WEBAUTHN_RP_ORIGINS")),
+
+		CookieSecure: normalizeCookieSecure(getEnv("COOKIE_SECURE")),
 	}
 
 	// If DATABASE_URL is not set, construct it from POSTGRES_* components.
@@ -427,6 +434,19 @@ func getEnvWithDefault(key, defaultValue string) string {
 		return value
 	}
 	return defaultValue
+}
+
+// normalizeCookieSecure validates COOKIE_SECURE against its allowed values
+// ("always", "never"), defaulting to "auto" for unset or unrecognized input.
+func normalizeCookieSecure(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "always":
+		return "always"
+	case "never":
+		return "never"
+	default:
+		return "auto"
+	}
 }
 
 func getBoolEnvWithDefault(key string, defaultValue bool) bool {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1608,4 +1608,24 @@ func TestCookieSecure_DefaultsToAuto(t *testing.T) {
 	if cfg2.CookieSecure != "always" {
 		t.Errorf("CookieSecure = %q, want always", cfg2.CookieSecure)
 	}
+
+	t.Setenv("COOKIE_SECURE", "never")
+	cfg2b, err := Load()
+	if err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+	if cfg2b.CookieSecure != "never" {
+		t.Errorf("CookieSecure = %q, want never", cfg2b.CookieSecure)
+	}
+
+	// An unrecognized value falls back to the "auto" default rather than
+	// propagating garbage into the Secure() cookie attribute decision.
+	t.Setenv("COOKIE_SECURE", "bogus")
+	cfg3, err := Load()
+	if err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+	if cfg3.CookieSecure != "auto" {
+		t.Errorf("CookieSecure = %q, want auto for unrecognized value", cfg3.CookieSecure)
+	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1584,3 +1584,28 @@ func TestLoadTrustedProxies_InvalidCIDRGraceful(t *testing.T) {
 		t.Error("Second valid CIDR should contain 192.168.1.1")
 	}
 }
+
+// TestCookieSecure_DefaultsToAuto tests that COOKIE_SECURE defaults to "auto"
+// when unset, and that a valid explicit value ("always") is honored.
+func TestCookieSecure_DefaultsToAuto(t *testing.T) {
+	t.Setenv("DATABASE_URL", "postgres://user:pass@localhost/test")
+	t.Setenv("MASTER_KEY", "test-master-key")
+	t.Setenv("COOKIE_SECURE", "")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+	if cfg.CookieSecure != "auto" {
+		t.Errorf("CookieSecure = %q, want auto", cfg.CookieSecure)
+	}
+
+	t.Setenv("COOKIE_SECURE", "always")
+	cfg2, err := Load()
+	if err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+	if cfg2.CookieSecure != "always" {
+		t.Errorf("CookieSecure = %q, want always", cfg2.CookieSecure)
+	}
+}

--- a/internal/frontdesk/server.go
+++ b/internal/frontdesk/server.go
@@ -164,12 +164,14 @@ func NewServer(cfg ServerConfig) *Server {
 	)
 	// NOTE: Front Desk's own web client (frontdesk/web) still consumes the
 	// TOTP login/enroll-verify session token from the JSON body (bearer
-	// auth), not the HttpOnly cookie the main dashboard now reads. "auto"
-	// keeps the cookie Secure attribute sane for both http and https
-	// deployments; it is otherwise unused here until Front Desk's frontend
-	// is migrated to cookie auth in a follow-up.
+	// auth), not the HttpOnly cookie the main dashboard reads. useCookieAuth
+	// is false here so the legacy token-in-body shape is preserved
+	// byte-for-byte until Front Desk's frontend migrates to cookie auth in a
+	// follow-up. "auto" still keeps the cookie Secure attribute sane in case
+	// that migration lands, but is otherwise unused while useCookieAuth is
+	// false.
 	totpHandler := adminauth.NewTotpHandler(
-		totpRepo, cfg.AdminMgr, sessionMgr, cfg.IPLimiter, false, s.totpStatus.Enabled, s.totpStatus.Refresh, "auto",
+		totpRepo, cfg.AdminMgr, sessionMgr, cfg.IPLimiter, false, s.totpStatus.Enabled, s.totpStatus.Refresh, "auto", false,
 	)
 	// OIDC SSO: a fourth admin-login path. The shared adminauth handler is reused
 	// as-is; newOIDCSettings adapts Front Desk's typed settings row to its key/value

--- a/internal/frontdesk/server.go
+++ b/internal/frontdesk/server.go
@@ -162,8 +162,14 @@ func NewServer(cfg ServerConfig) *Server {
 	webauthnHandler := adminauth.NewWebAuthnHandler(
 		webAuthnStore, cfg.RelyingParty, sessionMgr, cfg.AdminMgr, cfg.IPLimiter, false, s.totpStatus.Enabled,
 	)
+	// NOTE: Front Desk's own web client (frontdesk/web) still consumes the
+	// TOTP login/enroll-verify session token from the JSON body (bearer
+	// auth), not the HttpOnly cookie the main dashboard now reads. "auto"
+	// keeps the cookie Secure attribute sane for both http and https
+	// deployments; it is otherwise unused here until Front Desk's frontend
+	// is migrated to cookie auth in a follow-up.
 	totpHandler := adminauth.NewTotpHandler(
-		totpRepo, cfg.AdminMgr, sessionMgr, cfg.IPLimiter, false, s.totpStatus.Enabled, s.totpStatus.Refresh,
+		totpRepo, cfg.AdminMgr, sessionMgr, cfg.IPLimiter, false, s.totpStatus.Enabled, s.totpStatus.Refresh, "auto",
 	)
 	// OIDC SSO: a fourth admin-login path. The shared adminauth handler is reused
 	// as-is; newOIDCSettings adapts Front Desk's typed settings row to its key/value

--- a/internal/frontdesk/server.go
+++ b/internal/frontdesk/server.go
@@ -176,7 +176,7 @@ func NewServer(cfg ServerConfig) *Server {
 	// OIDC SSO: a fourth admin-login path. The shared adminauth handler is reused
 	// as-is; newOIDCSettings adapts Front Desk's typed settings row to its key/value
 	// contract, and the config secret rides the same MasterKey encryption as above.
-	oidcHandler := adminauth.NewOIDCHandler(newOIDCSettings(cfg.Store), sessionMgr, cfg.IPLimiter, cfg.MasterKey)
+	oidcHandler := adminauth.NewOIDCHandler(newOIDCSettings(cfg.Store), sessionMgr, cfg.IPLimiter, cfg.MasterKey, false, "auto")
 
 	s.router = s.buildRouter(webauthnHandler, totpHandler, oidcHandler, cfg.UI)
 	return s

--- a/internal/frontdesk/server.go
+++ b/internal/frontdesk/server.go
@@ -160,7 +160,7 @@ func NewServer(cfg ServerConfig) *Server {
 	)
 
 	webauthnHandler := adminauth.NewWebAuthnHandler(
-		webAuthnStore, cfg.RelyingParty, sessionMgr, cfg.AdminMgr, cfg.IPLimiter, false, s.totpStatus.Enabled,
+		webAuthnStore, cfg.RelyingParty, sessionMgr, cfg.AdminMgr, cfg.IPLimiter, false, s.totpStatus.Enabled, false, "auto",
 	)
 	// NOTE: Front Desk's own web client (frontdesk/web) still consumes the
 	// TOTP login/enroll-verify session token from the JSON body (bearer

--- a/internal/webauthn/session.go
+++ b/internal/webauthn/session.go
@@ -15,6 +15,11 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 )
 
+// AuthTokenTTL is the lifetime of a minted auth-token session, shared by the
+// server-side session expiry and the session cookie MaxAge so the two cannot
+// drift apart. All login front-ends that mint sessions use this single value.
+const AuthTokenTTL = 30 * 24 * time.Hour
+
 // errInvalidLoginState is returned by ConsumeLoginState when the record is
 // missing, of the wrong type, or expired. Kept unexported and opaque so callers
 // can't distinguish the cases (no oracle for a probing attacker).
@@ -125,7 +130,7 @@ func (m *SessionManager) CreateAuthToken(ctx context.Context, userID, credential
 		UserID:       userID,
 		TokenHash:    &tokenHash,
 		CredentialID: credentialID,
-		ExpiresAt:    time.Now().Add(30 * 24 * time.Hour),
+		ExpiresAt:    time.Now().Add(AuthTokenTTL),
 	}
 
 	if err := m.store.CreateSession(ctx, session); err != nil {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,7 +3,7 @@ import { lazy, Suspense, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Navigate, Route, Routes } from "react-router-dom";
 import { Eye, EyeOff, Fingerprint, GithubLogo, LogIn } from "@/lib/icons";
-import { api, setAdminToken } from "./api/client";
+import { api, isAuthenticated } from "./api/client";
 import { CopyablePill } from "./components/CopyablePill";
 import { Layout } from "./components/Layout";
 import { Logo } from "./components/Logo";
@@ -16,7 +16,7 @@ import { SidebarModeProvider } from "./context/SidebarModeContext";
 import { StorageProvider } from "./context/StorageContext";
 import { ThemeProvider } from "./context/ThemeContext";
 import { ToastProvider } from "./context/ToastContext";
-import { consumeOidcError, consumeOidcToken } from "./utils/oidc";
+import { consumeOidcError } from "./utils/oidc";
 import { canUsePasskeyLogin, loginWithPasskey } from "./utils/webauthn";
 
 const Dashboard = lazy(() =>
@@ -121,13 +121,12 @@ function LoginScreen() {
 		setUserLoading(true);
 		setError(null);
 		try {
-			const res = await api.auth.login(
+			await api.auth.login(
 				name,
 				userPassword,
 				userTotpNeeded ? userTotpCode.trim() : undefined,
 			);
-			localStorage.setItem("adminToken", res.token);
-			setAdminToken(res.token);
+			// The server set the session cookie pair; reload boots into the app.
 			window.location.reload();
 		} catch (err) {
 			const status =
@@ -206,21 +205,15 @@ function LoginScreen() {
 					setLoading(false);
 					return;
 				}
-				const res = await api.totp.login(value, code);
-				localStorage.setItem("adminToken", res.token);
-				setAdminToken(res.token);
+				// The server sets the session cookie pair; reload boots into the app.
+				await api.totp.login(value, code);
 				window.location.reload();
 				return;
 			}
-			const res = await fetch("/api/system", {
-				headers: { Authorization: `Bearer ${value}` },
-			});
-			if (!res.ok) {
-				setError(t("layout.auth.invalidToken"));
-				return;
-			}
-			localStorage.setItem("adminToken", value);
-			setAdminToken(value);
+			// Exchange the raw admin token for a session cookie pair. A 400 means the
+			// admin account actually has TOTP enabled, so flip into the TOTP step
+			// instead of failing outright.
+			await api.auth.adminExchange(value);
 			window.location.reload();
 		} catch (err) {
 			// Duck-type the status (ApiError carries it) so this is robust to the
@@ -229,14 +222,20 @@ function LoginScreen() {
 				err && typeof err === "object" && "status" in err
 					? (err as { status?: number }).status
 					: undefined;
-			if (totpEnabled && status === 429) {
-				setError(t("layout.auth.totpThrottled"));
-			} else {
+			if (totpEnabled) {
 				setError(
-					totpEnabled
-						? t("layout.auth.totpFailed")
-						: t("layout.auth.connectionFailed"),
+					status === 429
+						? t("layout.auth.totpThrottled")
+						: t("layout.auth.totpFailed"),
 				);
+			} else if (status === 400) {
+				// The admin account has TOTP enabled; reveal the code field.
+				setTotpEnabled(true);
+				setError(t("layout.auth.totpCodeRequired"));
+			} else if (status === 401) {
+				setError(t("layout.auth.invalidToken"));
+			} else {
+				setError(t("layout.auth.connectionFailed"));
 			}
 		} finally {
 			setLoading(false);
@@ -247,10 +246,9 @@ function LoginScreen() {
 		setPasskeyLoading(true);
 		setError(null);
 		try {
-			const sessionToken = await loginWithPasskey();
-			if (sessionToken) {
-				localStorage.setItem("adminToken", sessionToken);
-				setAdminToken(sessionToken);
+			const ok = await loginWithPasskey();
+			if (ok) {
+				// The server set the session cookie pair; reload boots into the app.
 				window.location.reload();
 			}
 		} catch {
@@ -586,15 +584,10 @@ function PageSuspense({ children }: { children: React.ReactNode }) {
 }
 
 function AppContent() {
-	// An SSO callback hands the session token back in the URL fragment. Consume
-	// it before reading the stored token so the app boots logged in.
-	consumeOidcToken();
-	const token = localStorage.getItem("adminToken");
-	if (token) {
-		setAdminToken(token);
-	}
-
-	if (!token) {
+	// Auth is derived from the session cookie pair (set by the server on every
+	// login path, including a clean SSO redirect). No token juggling: presence of
+	// the readable CSRF cookie is the "logged in" signal.
+	if (!isAuthenticated()) {
 		return <LoginScreen />;
 	}
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -88,8 +88,9 @@ function LoginScreen() {
 	const ssoProvider = oidcStatus?.display_name ?? "";
 
 	// GitHub SSO is independent of OIDC: an operator may run either, both, or
-	// neither. It shares the same callback hand-off (token/error in the URL
-	// fragment), so consumeOidcToken/consumeOidcError below cover it too.
+	// neither. It shares the same callback hand-off (error in the URL fragment;
+	// the session cookie is set by the clean redirect), so consumeOidcError
+	// below covers it too.
 	const { data: githubStatus } = useQuery({
 		queryKey: ["github-status"],
 		queryFn: () => api.github.status(),

--- a/web/src/__tests__/App.test.tsx
+++ b/web/src/__tests__/App.test.tsx
@@ -193,6 +193,31 @@ describe("LoginScreen", () => {
 		});
 	});
 
+	it("reveals the TOTP field when the admin account has 2FA enabled (400)", async () => {
+		// A 400 on the admin-token exchange means the account has TOTP enabled;
+		// the admin token alone is not a sufficient credential, so the UI must
+		// flip into the TOTP step rather than reporting a hard failure.
+		vi.mocked(api.auth.adminExchange).mockRejectedValue(
+			Object.assign(new Error("400 Bad Request"), { status: 400 }),
+		);
+
+		const user = userEvent.setup();
+		renderWithProviders(<App />);
+
+		const input = screen.getByLabelText("Admin Token");
+		await user.type(input, "test-admin-token");
+
+		const signInButton = screen.getByRole("button", { name: "Sign In" });
+		await user.click(signInButton);
+
+		await waitFor(() => {
+			expect(
+				screen.getByText("Please enter your TOTP code"),
+			).toBeInTheDocument();
+		});
+		expect(screen.getByLabelText("TOTP code")).toBeInTheDocument();
+	});
+
 	it("shows error when server is unreachable", async () => {
 		vi.mocked(api.auth.adminExchange).mockRejectedValue(
 			new TypeError("Failed to fetch"),

--- a/web/src/__tests__/App.test.tsx
+++ b/web/src/__tests__/App.test.tsx
@@ -1,19 +1,28 @@
 import { act, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { HttpResponse, http } from "msw";
 import { lazy, Suspense } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import App from "../App";
-import { api, setAdminToken } from "../api/client";
+import { api } from "../api/client";
 import { mockAllDefaults } from "../test/helpers";
 import { server } from "../test/mocks/server";
 import { renderWithProviders } from "../test/utils";
 
+// The dashboard is authenticated purely from the readable mh_csrf cookie now.
+// Drive login state by setting/clearing that cookie in tests.
+function clearAuthCookie() {
+	document.cookie = "mh_csrf=; path=/; max-age=0";
+}
+
 vi.mock("../api/client", () => ({
-	setAdminToken: vi.fn(),
-	getAdminToken: vi.fn(() => localStorage.getItem("adminToken")),
 	API_BASE: "",
+	// Cookie-derived auth signal so AppContent gates on it, mirroring production.
+	isAuthenticated: vi.fn(() => /mh_csrf=[^;\s]/.test(document.cookie)),
 	api: {
+		auth: {
+			// Admin-token bootstrap for non-TOTP login.
+			adminExchange: vi.fn().mockResolvedValue({ success: true }),
+		},
 		settings: {
 			get: vi.fn().mockResolvedValue({ app_version: "v0.0.0-test" }),
 		},
@@ -38,7 +47,9 @@ vi.mock("../api/client", () => ({
 describe("LoginScreen", () => {
 	beforeEach(() => {
 		localStorage.clear();
+		clearAuthCookie(); // logged-out: no session cookie -> LoginScreen renders
 		vi.clearAllMocks();
+		vi.mocked(api.auth.adminExchange).mockResolvedValue({ success: true });
 	});
 
 	it("renders logo, token input, and sign-in button", () => {
@@ -95,24 +106,20 @@ describe("LoginScreen", () => {
 		expect(input).toHaveAttribute("type", "password");
 	});
 
-	it("calls setAdminToken and reloads on successful submit", async () => {
+	it("exchanges the admin token and reloads on successful submit", async () => {
 		const user = userEvent.setup();
 		renderWithProviders(<App />);
 
 		const input = screen.getByLabelText("Admin Token");
 		await user.type(input, "test-admin-token");
 
-		const reloadSpy = vi.spyOn(window, "location", "get");
-
 		const signInButton = screen.getByRole("button", { name: "Sign In" });
 		await user.click(signInButton);
 
+		// The server sets the session cookie pair; the client just POSTs the token.
 		await waitFor(() => {
-			expect(setAdminToken).toHaveBeenCalledWith("test-admin-token");
-			expect(localStorage.getItem("adminToken")).toBe("test-admin-token");
+			expect(api.auth.adminExchange).toHaveBeenCalledWith("test-admin-token");
 		});
-
-		reloadSpy.mockRestore();
 	});
 
 	it("shows the demo token as a copyable pill, not a second login button", async () => {
@@ -126,7 +133,7 @@ describe("LoginScreen", () => {
 		// The old one-click "log in to the demo" button is gone (the pill copies),
 		// and nothing logs in just by rendering the box.
 		expect(within(box).queryByRole("button", { name: /log in/i })).toBeNull();
-		expect(setAdminToken).not.toHaveBeenCalled();
+		expect(api.auth.adminExchange).not.toHaveBeenCalled();
 	});
 
 	it("does not show the demo token box when no demo token is present", async () => {
@@ -148,8 +155,7 @@ describe("LoginScreen", () => {
 		await user.type(input, "test-admin-token{enter}");
 
 		await waitFor(() => {
-			expect(setAdminToken).toHaveBeenCalledWith("test-admin-token");
-			expect(localStorage.getItem("adminToken")).toBe("test-admin-token");
+			expect(api.auth.adminExchange).toHaveBeenCalledWith("test-admin-token");
 		});
 	});
 
@@ -164,16 +170,13 @@ describe("LoginScreen", () => {
 		await user.click(signInButton);
 
 		await waitFor(() => {
-			expect(setAdminToken).toHaveBeenCalledWith("test-admin-token");
-			expect(localStorage.getItem("adminToken")).toBe("test-admin-token");
+			expect(api.auth.adminExchange).toHaveBeenCalledWith("test-admin-token");
 		});
 	});
 
 	it("shows error when token is invalid (401)", async () => {
-		server.use(
-			http.get("/api/system", () =>
-				HttpResponse.json({ error: "Unauthorized" }, { status: 401 }),
-			),
+		vi.mocked(api.auth.adminExchange).mockRejectedValue(
+			Object.assign(new Error("401 Unauthorized"), { status: 401 }),
 		);
 
 		const user = userEvent.setup();
@@ -188,14 +191,12 @@ describe("LoginScreen", () => {
 		await waitFor(() => {
 			expect(screen.getByText("Invalid admin token")).toBeInTheDocument();
 		});
-
-		// Should NOT have saved the token
-		expect(localStorage.getItem("adminToken")).toBeNull();
-		expect(setAdminToken).not.toHaveBeenCalled();
 	});
 
 	it("shows error when server is unreachable", async () => {
-		server.use(http.get("/api/system", () => HttpResponse.error()));
+		vi.mocked(api.auth.adminExchange).mockRejectedValue(
+			new TypeError("Failed to fetch"),
+		);
 
 		const user = userEvent.setup();
 		renderWithProviders(<App />);
@@ -211,18 +212,11 @@ describe("LoginScreen", () => {
 				screen.getByText("Failed to connect to server"),
 			).toBeInTheDocument();
 		});
-
-		expect(localStorage.getItem("adminToken")).toBeNull();
 	});
 
 	it("disables sign-in button while validating", async () => {
-		// Use a delayed response to catch the loading state
-		server.use(
-			http.get("/api/system", async () => {
-				await new Promise((r) => setTimeout(r, 500));
-				return HttpResponse.json({});
-			}),
-		);
+		// Never-resolving exchange keeps the button in its loading state.
+		vi.mocked(api.auth.adminExchange).mockReturnValue(new Promise(() => {}));
 
 		const user = userEvent.setup();
 		renderWithProviders(<App />);
@@ -238,11 +232,9 @@ describe("LoginScreen", () => {
 	});
 
 	it("clears previous error on new submit attempt", async () => {
-		// First attempt: invalid token
-		server.use(
-			http.get("/api/system", () =>
-				HttpResponse.json({ error: "Unauthorized" }, { status: 401 }),
-			),
+		// First attempt: invalid token.
+		vi.mocked(api.auth.adminExchange).mockRejectedValueOnce(
+			Object.assign(new Error("401 Unauthorized"), { status: 401 }),
 		);
 
 		const user = userEvent.setup();
@@ -258,10 +250,7 @@ describe("LoginScreen", () => {
 			expect(screen.getByText("Invalid admin token")).toBeInTheDocument();
 		});
 
-		// Override handler to accept any token now
-		server.use(http.get("/api/system", () => HttpResponse.json({})));
-
-		// Clear input and type a valid token
+		// Second attempt succeeds (default mock resolves).
 		await user.clear(input);
 		await user.type(input, "valid-token");
 		await user.click(signInButton);
@@ -274,13 +263,11 @@ describe("LoginScreen", () => {
 
 	it("does not submit on Enter while already validating", async () => {
 		let callCount = 0;
-		server.use(
-			http.get("/api/system", async () => {
-				callCount++;
-				await new Promise((r) => setTimeout(r, 500));
-				return HttpResponse.json({});
-			}),
-		);
+		vi.mocked(api.auth.adminExchange).mockImplementation(async () => {
+			callCount++;
+			await new Promise((r) => setTimeout(r, 500));
+			return { success: true };
+		});
 
 		const user = userEvent.setup();
 		renderWithProviders(<App />);
@@ -303,18 +290,19 @@ describe("LoginScreen", () => {
 describe("AppContent", () => {
 	beforeEach(() => {
 		localStorage.clear();
+		clearAuthCookie();
 		vi.clearAllMocks();
 	});
 
-	it("renders LoginScreen when no token in localStorage", () => {
+	it("renders LoginScreen when no session cookie is present", () => {
 		renderWithProviders(<App />);
 
 		expect(screen.getByLabelText("Admin Token")).toBeInTheDocument();
 		expect(screen.getByRole("button", { name: "Sign In" })).toBeInTheDocument();
 	});
 
-	it("renders Layout with routes when token present", async () => {
-		localStorage.setItem("adminToken", "existing-token");
+	it("renders Layout with routes when session cookie present", async () => {
+		document.cookie = "mh_csrf=existing-token; path=/";
 
 		renderWithProviders(<App />);
 
@@ -332,18 +320,8 @@ describe("AppContent", () => {
 		await act(async () => {});
 	});
 
-	it("calls setAdminToken with token from localStorage on mount", async () => {
-		localStorage.setItem("adminToken", "stored-token");
-
-		renderWithProviders(<App />);
-
-		expect(setAdminToken).toHaveBeenCalledWith("stored-token");
-
-		await act(async () => {});
-	});
-
-	it("navigates to dashboard by default when token present", async () => {
-		localStorage.setItem("adminToken", "test-token");
+	it("navigates to dashboard by default when session cookie present", async () => {
+		document.cookie = "mh_csrf=test-token; path=/";
 
 		renderWithProviders(<App />);
 
@@ -359,6 +337,7 @@ describe("AppContent", () => {
 describe("App providers", () => {
 	beforeEach(() => {
 		localStorage.clear();
+		clearAuthCookie();
 	});
 
 	it("wraps AppContent in all required providers", () => {
@@ -448,13 +427,14 @@ describe("PageSuspense pattern (Suspense with spinner fallback)", () => {
 describe("Route navigation", () => {
 	beforeEach(() => {
 		localStorage.clear();
+		clearAuthCookie();
 		vi.clearAllMocks();
 		server.resetHandlers();
 		server.use(...mockAllDefaults());
 	});
 
 	it("navigates to Logs page", async () => {
-		localStorage.setItem("adminToken", "test-token");
+		document.cookie = "mh_csrf=test-token; path=/";
 		renderWithProviders(<App />);
 
 		const logsLink = screen.getByRole("link", { name: /Requests/ });
@@ -468,7 +448,7 @@ describe("Route navigation", () => {
 	});
 
 	it("navigates to Settings page", async () => {
-		localStorage.setItem("adminToken", "test-token");
+		document.cookie = "mh_csrf=test-token; path=/";
 		renderWithProviders(<App />);
 
 		const settingsLink = screen.getByRole("link", { name: "Settings" });
@@ -482,7 +462,7 @@ describe("Route navigation", () => {
 	});
 
 	it("navigates to Virtual Keys page", async () => {
-		localStorage.setItem("adminToken", "test-token");
+		document.cookie = "mh_csrf=test-token; path=/";
 		renderWithProviders(<App />);
 
 		const virtualKeysLink = screen.getByRole("link", { name: "Virtual Keys" });
@@ -496,7 +476,7 @@ describe("Route navigation", () => {
 	});
 
 	it("navigates to Chat page", async () => {
-		localStorage.setItem("adminToken", "test-token");
+		document.cookie = "mh_csrf=test-token; path=/";
 		renderWithProviders(<App />);
 
 		const chatLink = screen.getByRole("link", { name: /Chat/ });
@@ -510,7 +490,7 @@ describe("Route navigation", () => {
 	});
 
 	it("navigates to Arena page", async () => {
-		localStorage.setItem("adminToken", "test-token");
+		document.cookie = "mh_csrf=test-token; path=/";
 		renderWithProviders(<App />);
 
 		const arenaLink = screen.getByRole("link", { name: /Arena/ });
@@ -524,7 +504,7 @@ describe("Route navigation", () => {
 	});
 
 	it("navigates to Dashboard page", async () => {
-		localStorage.setItem("adminToken", "test-token");
+		document.cookie = "mh_csrf=test-token; path=/";
 		renderWithProviders(<App />);
 
 		// Navigate away first (to Settings), since Dashboard is the default route
@@ -553,7 +533,7 @@ describe("Route navigation", () => {
 	});
 
 	it("navigates to Providers page", async () => {
-		localStorage.setItem("adminToken", "test-token");
+		document.cookie = "mh_csrf=test-token; path=/";
 		renderWithProviders(<App />);
 
 		const providersLink = screen.getByRole("link", { name: "Providers" });
@@ -572,7 +552,7 @@ describe("Route navigation", () => {
 	});
 
 	it("navigates to Models page", async () => {
-		localStorage.setItem("adminToken", "test-token");
+		document.cookie = "mh_csrf=test-token; path=/";
 		renderWithProviders(<App />);
 
 		const modelsLink = screen.getByRole("link", { name: "Models" });
@@ -586,7 +566,7 @@ describe("Route navigation", () => {
 	});
 
 	it("navigates to Failover Groups page", async () => {
-		localStorage.setItem("adminToken", "test-token");
+		document.cookie = "mh_csrf=test-token; path=/";
 		renderWithProviders(<App />);
 
 		const failoverLink = screen.getByRole("link", { name: "Failover" });

--- a/web/src/__tests__/LoginScreen.loading.test.tsx
+++ b/web/src/__tests__/LoginScreen.loading.test.tsx
@@ -8,8 +8,7 @@ import { renderWithProviders } from "../test/utils";
 // Mirror LoginScreen.usertotp.test.tsx's client mock; both totp and auth
 // blocks are present so either login path can be driven per-test.
 vi.mock("../api/client", () => ({
-	setAdminToken: vi.fn(),
-	getAdminToken: vi.fn(() => localStorage.getItem("adminToken")),
+	isAuthenticated: vi.fn(() => /mh_csrf=[^;\s]/.test(document.cookie)),
 	API_BASE: "",
 	api: {
 		settings: {
@@ -51,6 +50,7 @@ vi.mock("../utils/webauthn", () => ({
 describe("LoginScreen loading indicators", () => {
 	beforeEach(() => {
 		localStorage.clear();
+		document.cookie = "mh_csrf=; path=/; max-age=0"; // logged out -> LoginScreen
 		vi.clearAllMocks();
 		server.resetHandlers();
 	});

--- a/web/src/__tests__/LoginScreen.totp.test.tsx
+++ b/web/src/__tests__/LoginScreen.totp.test.tsx
@@ -2,17 +2,18 @@ import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import App from "../App";
-import { setAdminToken } from "../api/client";
 import { server } from "../test/mocks/server";
 import { renderWithProviders } from "../test/utils";
 
 // Mirror App.test.tsx's client mock, adding the totp block so the LoginScreen
-// status probe + login flow can be driven per-test.
+// status probe + login flow can be driven per-test. Auth is cookie-derived.
 vi.mock("../api/client", () => ({
-	setAdminToken: vi.fn(),
-	getAdminToken: vi.fn(() => localStorage.getItem("adminToken")),
+	isAuthenticated: vi.fn(() => /mh_csrf=[^;\s]/.test(document.cookie)),
 	API_BASE: "",
 	api: {
+		auth: {
+			adminExchange: vi.fn().mockResolvedValue({ success: true }),
+		},
 		settings: {
 			get: vi.fn().mockResolvedValue({ app_version: "v0.0.0-test" }),
 		},
@@ -44,6 +45,7 @@ vi.mock("../api/client", () => ({
 describe("LoginScreen TOTP step", () => {
 	beforeEach(() => {
 		localStorage.clear();
+		document.cookie = "mh_csrf=; path=/; max-age=0"; // logged out -> LoginScreen
 		vi.clearAllMocks();
 		server.resetHandlers();
 		// Default: status disabled. Tests that need enabled override via
@@ -71,7 +73,7 @@ describe("LoginScreen TOTP step", () => {
 		expect(screen.queryByLabelText("TOTP code")).not.toBeInTheDocument();
 	});
 
-	it("submits token+code to totp.login and stores the session token", async () => {
+	it("submits token+code to totp.login on the TOTP step", async () => {
 		const { api } = await import("../api/client");
 		vi.mocked(api.totp.status).mockResolvedValue({ enabled: true });
 		vi.mocked(api.totp.login).mockResolvedValue({
@@ -80,8 +82,8 @@ describe("LoginScreen TOTP step", () => {
 
 		const user = userEvent.setup();
 		// jsdom's window.location.reload is a no-op for navigation (setup.ts
-		// suppresses the "Not implemented" warning, exactly as App.test.tsx
-		// does). We assert on the api call + localStorage + setAdminToken.
+		// suppresses the "Not implemented" warning). The server sets the session
+		// cookie pair; we assert only that the api call fired.
 
 		renderWithProviders(<App />);
 
@@ -97,10 +99,6 @@ describe("LoginScreen TOTP step", () => {
 		await waitFor(() => {
 			expect(api.totp.login).toHaveBeenCalledWith("raw-admin-token", "654321");
 		});
-
-		// The SESSION token (not the raw admin token) is persisted.
-		expect(localStorage.getItem("adminToken")).toBe("ses_sessionTokenValue123");
-		expect(setAdminToken).toHaveBeenCalledWith("ses_sessionTokenValue123");
 	});
 
 	it("shows generic totpFailed error on login failure", async () => {
@@ -126,9 +124,6 @@ describe("LoginScreen TOTP step", () => {
 		expect(
 			await screen.findByText("Invalid admin token or TOTP code"),
 		).toBeInTheDocument();
-		// Raw token was NOT persisted on failure.
-		expect(localStorage.getItem("adminToken")).toBeNull();
-		expect(setAdminToken).not.toHaveBeenCalled();
 	});
 
 	it("shows the throttled message on a 429 login response", async () => {
@@ -157,8 +152,6 @@ describe("LoginScreen TOTP step", () => {
 				"Too many attempts. Please wait a moment and try again.",
 			),
 		).toBeInTheDocument();
-		expect(localStorage.getItem("adminToken")).toBeNull();
-		expect(setAdminToken).not.toHaveBeenCalled();
 	});
 
 	it("shows the SSO button only when oidc status is enabled", async () => {

--- a/web/src/__tests__/LoginScreen.usertotp.test.tsx
+++ b/web/src/__tests__/LoginScreen.usertotp.test.tsx
@@ -2,15 +2,14 @@ import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import App from "../App";
-import { setAdminToken } from "../api/client";
 import { server } from "../test/mocks/server";
 import { renderWithProviders } from "../test/utils";
 
 // Mirror LoginScreen.totp.test.tsx's client mock, adding the auth block so the
-// username/password form renders and its TOTP second step can be driven.
+// username/password form renders and its TOTP second step can be driven. Auth
+// is cookie-derived.
 vi.mock("../api/client", () => ({
-	setAdminToken: vi.fn(),
-	getAdminToken: vi.fn(() => localStorage.getItem("adminToken")),
+	isAuthenticated: vi.fn(() => /mh_csrf=[^;\s]/.test(document.cookie)),
 	API_BASE: "",
 	api: {
 		settings: {
@@ -52,6 +51,7 @@ const totpRequiredError = () =>
 describe("LoginScreen user TOTP step", () => {
 	beforeEach(() => {
 		localStorage.clear();
+		document.cookie = "mh_csrf=; path=/; max-age=0"; // logged out -> LoginScreen
 		vi.clearAllMocks();
 		server.resetHandlers();
 	});
@@ -79,12 +79,9 @@ describe("LoginScreen user TOTP step", () => {
 			"correct-horse",
 			undefined,
 		);
-		// Nothing was persisted yet.
-		expect(localStorage.getItem("adminToken")).toBeNull();
-		expect(setAdminToken).not.toHaveBeenCalled();
 	});
 
-	it("resubmits with the code and stores the session token", async () => {
+	it("resubmits with the code and logs in", async () => {
 		const { api } = await import("../api/client");
 		vi.mocked(api.auth.login)
 			.mockRejectedValueOnce(totpRequiredError())
@@ -105,8 +102,6 @@ describe("LoginScreen user TOTP step", () => {
 				"123456",
 			);
 		});
-		expect(localStorage.getItem("adminToken")).toBe("ses_userSessionToken");
-		expect(setAdminToken).toHaveBeenCalledWith("ses_userSessionToken");
 	});
 
 	it("shows the code error on a wrong code, not the generic login failure", async () => {
@@ -130,7 +125,6 @@ describe("LoginScreen user TOTP step", () => {
 		expect(
 			await screen.findByText("Invalid TOTP or recovery code"),
 		).toBeInTheDocument();
-		expect(localStorage.getItem("adminToken")).toBeNull();
 	});
 
 	it("accepts a full recovery code in the user code field", async () => {

--- a/web/src/api/__tests__/client.appLogs.test.ts
+++ b/web/src/api/__tests__/client.appLogs.test.ts
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { api, setAdminToken } from "../client";
+import { api } from "../client";
 
 describe("api.appLogs", () => {
 	beforeEach(() => {
-		setAdminToken("test-token");
+		document.cookie = "mh_csrf=test-csrf; path=/";
 		vi.restoreAllMocks();
 	});
 
@@ -27,7 +27,6 @@ describe("api.appLogs", () => {
 				"/api/logs/app",
 				expect.objectContaining({
 					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
 						"Content-Type": "application/json",
 					}),
 				}),
@@ -53,7 +52,6 @@ describe("api.appLogs", () => {
 				"/api/logs/app?limit=50&after=abc123",
 				expect.objectContaining({
 					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
 						"Content-Type": "application/json",
 					}),
 				}),
@@ -84,7 +82,6 @@ describe("api.appLogs", () => {
 				expect.objectContaining({
 					method: "DELETE",
 					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
 						"Content-Type": "application/json",
 					}),
 				}),
@@ -121,7 +118,6 @@ describe("api.appLogs", () => {
 				"/api/logs/app?history=true",
 				expect.objectContaining({
 					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
 						"Content-Type": "application/json",
 					}),
 				}),
@@ -155,7 +151,6 @@ describe("api.appLogs", () => {
 				expect.stringContaining("/api/logs/app?history=true&"),
 				expect.objectContaining({
 					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
 						"Content-Type": "application/json",
 					}),
 				}),
@@ -193,7 +188,6 @@ describe("api.appLogs", () => {
 				expect.stringContaining("/api/logs/app/cursor?"),
 				expect.objectContaining({
 					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
 						"Content-Type": "application/json",
 					}),
 				}),

--- a/web/src/api/__tests__/client.auth.test.ts
+++ b/web/src/api/__tests__/client.auth.test.ts
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { api, setAdminToken } from "../client";
+import { api } from "../client";
 
 describe("api.demoLogin", () => {
 	beforeEach(() => {
-		setAdminToken("test-token");
+		document.cookie = "mh_csrf=test-csrf; path=/";
 		vi.restoreAllMocks();
 	});
 
@@ -15,7 +15,9 @@ describe("api.demoLogin", () => {
 		const result = await api.demoLogin.get();
 
 		expect(result).toEqual({ token: "demo-abc" });
-		expect(globalThis.fetch).toHaveBeenCalledWith("/api/demo-login", undefined);
+		expect(globalThis.fetch).toHaveBeenCalledWith("/api/demo-login", {
+			credentials: "same-origin",
+		});
 	});
 
 	it("throws on error response", async () => {
@@ -30,7 +32,7 @@ describe("api.demoLogin", () => {
 
 describe("api.totp.login", () => {
 	beforeEach(() => {
-		setAdminToken("test-token");
+		document.cookie = "mh_csrf=test-csrf; path=/";
 		vi.restoreAllMocks();
 	});
 

--- a/web/src/api/__tests__/client.backups.test.ts
+++ b/web/src/api/__tests__/client.backups.test.ts
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { api, setAdminToken } from "../client";
+import { api } from "../client";
 
 describe("api.backups", () => {
 	beforeEach(() => {
-		setAdminToken("test-token");
+		document.cookie = "mh_csrf=test-csrf; path=/";
 		vi.restoreAllMocks();
 	});
 
@@ -23,9 +23,7 @@ describe("api.backups", () => {
 			expect(globalThis.fetch).toHaveBeenCalledWith(
 				"/api/backups",
 				expect.objectContaining({
-					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
-					}),
+					headers: expect.objectContaining({}),
 				}),
 			);
 		});
@@ -59,9 +57,7 @@ describe("api.backups", () => {
 				"/api/backups",
 				expect.objectContaining({
 					method: "POST",
-					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
-					}),
+					headers: expect.objectContaining({}),
 				}),
 			);
 		});
@@ -105,9 +101,7 @@ describe("api.backups", () => {
 				"/api/backups/backup-2024-01-01.sql",
 				expect.objectContaining({
 					method: "DELETE",
-					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
-					}),
+					headers: expect.objectContaining({}),
 				}),
 			);
 		});
@@ -146,7 +140,6 @@ describe("api.backups", () => {
 				type: "application/sql",
 			});
 			const adminToken = "restore-token-123";
-			localStorage.setItem("adminToken", adminToken);
 
 			const mockResponse = { migration_count: 5, known_count: 10 };
 			const fetchSpy = vi
@@ -165,9 +158,10 @@ describe("api.backups", () => {
 
 			const options = callArgs[1] as RequestInit;
 			expect(options.method).toBe("POST");
-			expect(options.headers).toEqual({
-				Authorization: `Bearer ${adminToken}`,
-			});
+			expect(options.credentials).toBe("same-origin");
+			// Session rides in the cookie; the CSRF header (from the mh_csrf cookie
+			// seeded in setup.ts) authorizes the write. No bearer token.
+			expect(options.headers).toEqual({ "X-CSRF-Token": "test-csrf" });
 			expect(options.body).toBeInstanceOf(FormData);
 
 			const formData = options.body as FormData;
@@ -175,10 +169,8 @@ describe("api.backups", () => {
 			expect(formData.get("admin_token")).toBe(adminToken);
 		});
 
-		it("uses localStorage token for Authorization", async () => {
+		it("sends the CSRF header from the cookie, never a bearer token", async () => {
 			const mockFile = new File(["content"], "test.sql");
-			const storedToken = "stored-restore-token";
-			localStorage.setItem("adminToken", storedToken);
 
 			vi.spyOn(globalThis, "fetch").mockImplementation(
 				async () =>
@@ -187,23 +179,20 @@ describe("api.backups", () => {
 					}),
 			);
 
-			await api.backups.restore(mockFile, storedToken);
+			await api.backups.restore(mockFile, "confirm-token");
 
 			expect(globalThis.fetch).toHaveBeenCalledWith(
 				"/api/backups/restore",
 				expect.objectContaining({
-					headers: {
-						Authorization: `Bearer ${storedToken}`,
-					},
+					credentials: "same-origin",
+					headers: { "X-CSRF-Token": "test-csrf" },
 				}),
 			);
 		});
 
-		it("uses localStorage token for Authorization, not the parameter", async () => {
+		it("passes the admin_token parameter through the FormData body", async () => {
 			const mockFile = new File(["content"], "test.sql");
-			const localStorageToken = "local-storage-token";
 			const paramToken = "param-token";
-			localStorage.setItem("adminToken", localStorageToken);
 
 			const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(
 				async () =>
@@ -214,13 +203,8 @@ describe("api.backups", () => {
 
 			await api.backups.restore(mockFile, paramToken);
 
-			// Authorization header uses localStorage, not the parameter
+			// The admin_token confirmation travels in the form body, not a header.
 			const options = fetchSpy.mock.calls[0][1] as RequestInit;
-			expect(options.headers).toEqual({
-				Authorization: `Bearer ${localStorageToken}`,
-			});
-
-			// FormData admin_token uses the parameter
 			const formData = options.body as FormData;
 			expect(formData.get("admin_token")).toBe(paramToken);
 		});

--- a/web/src/api/__tests__/client.chat.test.ts
+++ b/web/src/api/__tests__/client.chat.test.ts
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { api, setAdminToken } from "../client";
+import { api } from "../client";
 
 describe("api.chat", () => {
 	beforeEach(() => {
-		setAdminToken("test-token");
+		document.cookie = "mh_csrf=test-csrf; path=/";
 		vi.restoreAllMocks();
 	});
 
@@ -29,7 +29,6 @@ describe("api.chat", () => {
 				expect.objectContaining({
 					method: "POST",
 					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
 						"Content-Type": "application/json",
 					}),
 					body: JSON.stringify(chatBody),
@@ -62,9 +61,7 @@ describe("api.chat", () => {
 				"/api/chat/chat",
 				expect.objectContaining({
 					method: "POST",
-					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
-					}),
+					headers: expect.objectContaining({}),
 					body: JSON.stringify(chatBody),
 				}),
 			);
@@ -111,9 +108,7 @@ describe("api.chat", () => {
 				"/api/chat/arena",
 				expect.objectContaining({
 					method: "POST",
-					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
-					}),
+					headers: expect.objectContaining({}),
 					body: JSON.stringify(chatBody),
 				}),
 			);

--- a/web/src/api/__tests__/client.cookieAuth.test.ts
+++ b/web/src/api/__tests__/client.cookieAuth.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	api,
+	clearAuth,
+	getAuthHeaders,
+	getCsrfToken,
+	isAuthenticated,
+} from "../client";
+
+// Clear every cookie so each test starts from a known auth state.
+function clearAllCookies() {
+	for (const part of document.cookie.split(";")) {
+		const name = part.split("=")[0]?.trim();
+		if (name) document.cookie = `${name}=; path=/; max-age=0`;
+	}
+}
+
+describe("client cookie auth", () => {
+	beforeEach(() => {
+		clearAllCookies();
+		vi.restoreAllMocks();
+	});
+
+	it("reads the CSRF token from the mh_csrf cookie", () => {
+		document.cookie = "mh_csrf=csrf-abc; path=/";
+		expect(getCsrfToken()).toBe("csrf-abc");
+		expect(isAuthenticated()).toBe(true);
+	});
+
+	it("reports unauthenticated when the mh_csrf cookie is absent", () => {
+		expect(getCsrfToken()).toBeNull();
+		expect(isAuthenticated()).toBe(false);
+	});
+
+	it("clearAuth expires the mh_csrf cookie", () => {
+		document.cookie = "mh_csrf=csrf-abc; path=/";
+		expect(isAuthenticated()).toBe(true);
+		clearAuth();
+		expect(getCsrfToken()).toBeNull();
+		expect(isAuthenticated()).toBe(false);
+	});
+
+	it("getAuthHeaders carries the CSRF token, never an Authorization bearer", () => {
+		document.cookie = "mh_csrf=csrf-abc; path=/";
+		const headers = getAuthHeaders();
+		expect(headers["X-CSRF-Token"]).toBe("csrf-abc");
+		expect(headers["Content-Type"]).toBe("application/json");
+		expect(headers.Authorization).toBeUndefined();
+	});
+
+	it("sends X-CSRF-Token on mutating requests and same-origin credentials, never a bearer token", async () => {
+		document.cookie = "mh_csrf=csrf-abc; path=/";
+		const seen: Array<{ method: string; init?: RequestInit }> = [];
+		vi.spyOn(globalThis, "fetch").mockImplementation((async (
+			_url: string,
+			init?: RequestInit,
+		) => {
+			seen.push({ method: init?.method ?? "GET", init });
+			return new Response("{}", { status: 200 });
+		}) as typeof fetch);
+
+		await api.providers.list(); // GET
+		await api.providers.create({
+			name: "x",
+			base_url: "https://api.example.com",
+			api_key: "sk-1",
+		}); // POST
+
+		const get = seen.find((s) => s.method === "GET");
+		const post = seen.find((s) => s.method === "POST");
+		expect(get?.init?.credentials).toBe("same-origin");
+		expect(post?.init?.credentials).toBe("same-origin");
+		const getHeaders = new Headers(get?.init?.headers);
+		const postHeaders = new Headers(post?.init?.headers);
+		expect(getHeaders.get("Authorization")).toBeNull();
+		expect(postHeaders.get("Authorization")).toBeNull();
+		expect(postHeaders.get("X-CSRF-Token")).toBe("csrf-abc");
+	});
+});

--- a/web/src/api/__tests__/client.cookieAuth.test.ts
+++ b/web/src/api/__tests__/client.cookieAuth.test.ts
@@ -75,5 +75,8 @@ describe("client cookie auth", () => {
 		expect(getHeaders.get("Authorization")).toBeNull();
 		expect(postHeaders.get("Authorization")).toBeNull();
 		expect(postHeaders.get("X-CSRF-Token")).toBe("csrf-abc");
+		// The CSRF token guards mutating requests only; a read-only GET must not
+		// carry it even though getAuthHeaders() (shared with POST callers) sets it.
+		expect(getHeaders.get("X-CSRF-Token")).toBeNull();
 	});
 });

--- a/web/src/api/__tests__/client.cookieAuth.test.ts
+++ b/web/src/api/__tests__/client.cookieAuth.test.ts
@@ -1,7 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+	ApiError,
 	api,
 	clearAuth,
+	fetchJSONWithServerNow,
 	getAuthHeaders,
 	getCsrfToken,
 	isAuthenticated,
@@ -78,5 +80,61 @@ describe("client cookie auth", () => {
 		// The CSRF token guards mutating requests only; a read-only GET must not
 		// carry it even though getAuthHeaders() (shared with POST callers) sets it.
 		expect(getHeaders.get("X-CSRF-Token")).toBeNull();
+	});
+
+	it("strips X-CSRF-Token from a GET request whose headers are a Headers instance", async () => {
+		const seen: Array<{ init?: RequestInit }> = [];
+		vi.spyOn(globalThis, "fetch").mockImplementation((async (
+			_url: string,
+			init?: RequestInit,
+		) => {
+			seen.push({ init });
+			return new Response("{}", { status: 200 });
+		}) as typeof fetch);
+
+		await fetchJSONWithServerNow("/api/x", {
+			headers: new Headers({ "X-CSRF-Token": "csrf-abc" }),
+		});
+
+		const headers = seen[0]?.init?.headers as Headers;
+		expect(headers).toBeInstanceOf(Headers);
+		expect(headers.get("X-CSRF-Token")).toBeNull();
+	});
+
+	it("strips X-CSRF-Token from a GET request whose headers are an array of tuples", async () => {
+		const seen: Array<{ init?: RequestInit }> = [];
+		vi.spyOn(globalThis, "fetch").mockImplementation((async (
+			_url: string,
+			init?: RequestInit,
+		) => {
+			seen.push({ init });
+			return new Response("{}", { status: 200 });
+		}) as typeof fetch);
+
+		await fetchJSONWithServerNow("/api/x", {
+			method: "HEAD",
+			headers: [
+				["X-CSRF-Token", "csrf-abc"],
+				["Accept", "application/json"],
+			],
+		});
+
+		const headers = seen[0]?.init?.headers as Array<[string, string]>;
+		expect(headers).toEqual([["Accept", "application/json"]]);
+	});
+
+	it("clears the auth cookie and throws an ApiError with status 401 on an expired session", async () => {
+		document.cookie = "mh_csrf=csrf-abc; path=/";
+		expect(isAuthenticated()).toBe(true);
+		vi.spyOn(globalThis, "fetch").mockImplementation(
+			async () => new Response("unauthorized", { status: 401 }),
+		);
+
+		await expect(api.providers.list()).rejects.toThrow(ApiError);
+		expect(isAuthenticated()).toBe(false);
+
+		document.cookie = "mh_csrf=csrf-abc; path=/";
+		await expect(api.providers.list()).rejects.toMatchObject({ status: 401 });
+		expect(isAuthenticated()).toBe(false);
 	});
 });

--- a/web/src/api/__tests__/client.failoverGroups.test.ts
+++ b/web/src/api/__tests__/client.failoverGroups.test.ts
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { api, setAdminToken } from "../client";
+import { api } from "../client";
 
 describe("api.failoverGroups", () => {
 	beforeEach(() => {
-		setAdminToken("test-token");
+		document.cookie = "mh_csrf=test-csrf; path=/";
 		vi.restoreAllMocks();
 	});
 
@@ -23,9 +23,7 @@ describe("api.failoverGroups", () => {
 			expect(globalThis.fetch).toHaveBeenCalledWith(
 				"/api/failover-groups",
 				expect.objectContaining({
-					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
-					}),
+					headers: expect.objectContaining({}),
 				}),
 			);
 		});
@@ -58,9 +56,7 @@ describe("api.failoverGroups", () => {
 			expect(globalThis.fetch).toHaveBeenCalledWith(
 				"/api/failover-groups/1",
 				expect.objectContaining({
-					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
-					}),
+					headers: expect.objectContaining({}),
 				}),
 			);
 		});
@@ -96,9 +92,7 @@ describe("api.failoverGroups", () => {
 				"/api/failover-groups",
 				expect.objectContaining({
 					method: "POST",
-					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
-					}),
+					headers: expect.objectContaining({}),
 					body: JSON.stringify(createData),
 				}),
 			);
@@ -143,9 +137,7 @@ describe("api.failoverGroups", () => {
 				"/api/failover-groups/1",
 				expect.objectContaining({
 					method: "PUT",
-					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
-					}),
+					headers: expect.objectContaining({}),
 					body: JSON.stringify(updateData),
 				}),
 			);
@@ -177,9 +169,7 @@ describe("api.failoverGroups", () => {
 				"/api/failover-groups/1",
 				expect.objectContaining({
 					method: "DELETE",
-					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
-					}),
+					headers: expect.objectContaining({}),
 				}),
 			);
 		});
@@ -209,9 +199,7 @@ describe("api.failoverGroups", () => {
 				"/api/failover-groups/sync",
 				expect.objectContaining({
 					method: "POST",
-					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
-					}),
+					headers: expect.objectContaining({}),
 				}),
 			);
 		});
@@ -243,9 +231,7 @@ describe("api.failoverGroups", () => {
 			expect(globalThis.fetch).toHaveBeenCalledWith(
 				"/api/failover-groups/candidates",
 				expect.objectContaining({
-					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
-					}),
+					headers: expect.objectContaining({}),
 				}),
 			);
 		});

--- a/web/src/api/__tests__/client.logs.test.ts
+++ b/web/src/api/__tests__/client.logs.test.ts
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { api, setAdminToken } from "../client";
+import { api } from "../client";
 
 describe("api.logs", () => {
 	beforeEach(() => {
-		setAdminToken("test-token");
+		document.cookie = "mh_csrf=test-csrf; path=/";
 		vi.restoreAllMocks();
 	});
 
@@ -20,7 +20,6 @@ describe("api.logs", () => {
 				"/api/logs",
 				expect.objectContaining({
 					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
 						"Content-Type": "application/json",
 					}),
 				}),
@@ -49,7 +48,6 @@ describe("api.logs", () => {
 				expect.stringContaining("/api/logs?"),
 				expect.objectContaining({
 					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
 						"Content-Type": "application/json",
 					}),
 				}),
@@ -78,7 +76,6 @@ describe("api.logs", () => {
 				expect.objectContaining({
 					method: "DELETE",
 					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
 						"Content-Type": "application/json",
 					}),
 					body: JSON.stringify({ older_than: "2024-01-01" }),
@@ -119,7 +116,6 @@ describe("api.logs", () => {
 				expect.stringContaining("/api/logs/cursor?"),
 				expect.objectContaining({
 					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
 						"Content-Type": "application/json",
 					}),
 				}),
@@ -175,9 +171,7 @@ describe("api.logs", () => {
 			expect(globalThis.fetch).toHaveBeenCalledWith(
 				"/api/logs/log-123",
 				expect.objectContaining({
-					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
-					}),
+					headers: expect.objectContaining({}),
 				}),
 			);
 		});

--- a/web/src/api/__tests__/client.models.test.ts
+++ b/web/src/api/__tests__/client.models.test.ts
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { api, setAdminToken } from "../client";
+import { api } from "../client";
 
 describe("api.models", () => {
 	beforeEach(() => {
-		setAdminToken("test-token");
+		document.cookie = "mh_csrf=test-csrf; path=/";
 		vi.restoreAllMocks();
 	});
 
@@ -20,7 +20,6 @@ describe("api.models", () => {
 				"/api/models",
 				expect.objectContaining({
 					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
 						"Content-Type": "application/json",
 					}),
 				}),
@@ -39,7 +38,6 @@ describe("api.models", () => {
 				"/api/models?provider_id=provider-123",
 				expect.objectContaining({
 					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
 						"Content-Type": "application/json",
 					}),
 				}),
@@ -77,7 +75,6 @@ describe("api.models", () => {
 				expect.stringContaining("/api/models/cursor?"),
 				expect.objectContaining({
 					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
 						"Content-Type": "application/json",
 					}),
 				}),
@@ -135,7 +132,6 @@ describe("api.models", () => {
 				expect.objectContaining({
 					method: "PATCH",
 					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
 						"Content-Type": "application/json",
 					}),
 					body: JSON.stringify(data),
@@ -173,7 +169,6 @@ describe("api.models", () => {
 				expect.objectContaining({
 					method: "POST",
 					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
 						"Content-Type": "application/json",
 					}),
 				}),
@@ -202,7 +197,6 @@ describe("api.models", () => {
 				expect.objectContaining({
 					method: "DELETE",
 					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
 						"Content-Type": "application/json",
 					}),
 				}),

--- a/web/src/api/__tests__/client.providers.test.ts
+++ b/web/src/api/__tests__/client.providers.test.ts
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { api, setAdminToken } from "../client";
+import { api } from "../client";
 
 describe("api.providers", () => {
 	beforeEach(() => {
-		setAdminToken("test-token");
+		document.cookie = "mh_csrf=test-csrf; path=/";
 		vi.restoreAllMocks();
 	});
 
@@ -20,7 +20,6 @@ describe("api.providers", () => {
 				"/api/providers",
 				expect.objectContaining({
 					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
 						"Content-Type": "application/json",
 					}),
 				}),
@@ -56,7 +55,6 @@ describe("api.providers", () => {
 				expect.objectContaining({
 					method: "POST",
 					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
 						"Content-Type": "application/json",
 					}),
 					body: JSON.stringify(data),
@@ -90,7 +88,6 @@ describe("api.providers", () => {
 				expect.objectContaining({
 					method: "DELETE",
 					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
 						"Content-Type": "application/json",
 					}),
 				}),
@@ -122,7 +119,6 @@ describe("api.providers", () => {
 				expect.objectContaining({
 					method: "PUT",
 					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
 						"Content-Type": "application/json",
 					}),
 					body: JSON.stringify(data),
@@ -154,7 +150,6 @@ describe("api.providers", () => {
 				expect.objectContaining({
 					method: "POST",
 					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
 						"Content-Type": "application/json",
 					}),
 				}),
@@ -193,7 +188,6 @@ describe("api.providers", () => {
 				expect.objectContaining({
 					method: "POST",
 					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
 						"Content-Type": "application/json",
 					}),
 				}),
@@ -231,7 +225,6 @@ describe("api.providers", () => {
 				expect.objectContaining({
 					method: "POST",
 					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
 						"Content-Type": "application/json",
 					}),
 				}),
@@ -261,7 +254,6 @@ describe("api.providers", () => {
 				"/api/providers/123/usage",
 				expect.objectContaining({
 					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
 						"Content-Type": "application/json",
 					}),
 				}),
@@ -291,7 +283,6 @@ describe("api.providers", () => {
 				"/api/providers/123/balance",
 				expect.objectContaining({
 					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
 						"Content-Type": "application/json",
 					}),
 				}),
@@ -321,7 +312,6 @@ describe("api.providers", () => {
 				"/api/providers/123/usage",
 				expect.objectContaining({
 					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
 						"Content-Type": "application/json",
 					}),
 				}),
@@ -351,7 +341,6 @@ describe("api.providers", () => {
 				"/api/providers/123/account",
 				expect.objectContaining({
 					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
 						"Content-Type": "application/json",
 					}),
 				}),
@@ -381,9 +370,7 @@ describe("api.providers", () => {
 			expect(globalThis.fetch).toHaveBeenCalledWith(
 				"/api/providers/123/usage",
 				expect.objectContaining({
-					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
-					}),
+					headers: expect.objectContaining({}),
 				}),
 			);
 		});

--- a/web/src/api/__tests__/client.settings.test.ts
+++ b/web/src/api/__tests__/client.settings.test.ts
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { api, setAdminToken } from "../client";
+import { api } from "../client";
 
 describe("api.settings", () => {
 	beforeEach(() => {
-		setAdminToken("test-token");
+		document.cookie = "mh_csrf=test-csrf; path=/";
 		vi.restoreAllMocks();
 	});
 
@@ -20,9 +20,7 @@ describe("api.settings", () => {
 			expect(globalThis.fetch).toHaveBeenCalledWith(
 				"/api/settings",
 				expect.objectContaining({
-					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
-					}),
+					headers: expect.objectContaining({}),
 				}),
 			);
 		});
@@ -53,7 +51,6 @@ describe("api.settings", () => {
 				expect.objectContaining({
 					method: "PUT",
 					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
 						"Content-Type": "application/json",
 					}),
 					body: JSON.stringify(newSettings),
@@ -92,9 +89,7 @@ describe("api.settings", () => {
 					body: JSON.stringify({
 						keys: ["log_retention", "stale_request_timeout"],
 					}),
-					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
-					}),
+					headers: expect.objectContaining({}),
 				}),
 			);
 		});

--- a/web/src/api/__tests__/client.stats.test.ts
+++ b/web/src/api/__tests__/client.stats.test.ts
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { api, setAdminToken } from "../client";
+import { api } from "../client";
 
 describe("api.stats", () => {
 	beforeEach(() => {
-		setAdminToken("test-token");
+		document.cookie = "mh_csrf=test-csrf; path=/";
 		vi.restoreAllMocks();
 	});
 
@@ -20,9 +20,7 @@ describe("api.stats", () => {
 			expect(globalThis.fetch).toHaveBeenCalledWith(
 				"/api/stats",
 				expect.objectContaining({
-					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
-					}),
+					headers: expect.objectContaining({}),
 				}),
 			);
 		});
@@ -69,9 +67,7 @@ describe("api.stats", () => {
 			expect(globalThis.fetch).toHaveBeenCalledWith(
 				"/api/stats/timeseries",
 				expect.objectContaining({
-					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
-					}),
+					headers: expect.objectContaining({}),
 				}),
 			);
 		});
@@ -113,9 +109,7 @@ describe("api.stats", () => {
 			expect(globalThis.fetch).toHaveBeenCalledWith(
 				"/api/stats/provider-distribution",
 				expect.objectContaining({
-					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
-					}),
+					headers: expect.objectContaining({}),
 				}),
 			);
 		});

--- a/web/src/api/__tests__/client.system.test.ts
+++ b/web/src/api/__tests__/client.system.test.ts
@@ -1,9 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { api, setAdminToken } from "../client";
+import { api } from "../client";
 
 describe("api.system", () => {
 	beforeEach(() => {
-		setAdminToken("test-token");
+		document.cookie = "mh_csrf=test-csrf; path=/";
 		vi.restoreAllMocks();
 		vi.useFakeTimers();
 		vi.setSystemTime(new Date("2024-01-15T10:30:00Z"));
@@ -35,9 +35,7 @@ describe("api.system", () => {
 		expect(globalThis.fetch).toHaveBeenCalledWith(
 			`/api/system?since=${expectedSince}`,
 			expect.objectContaining({
-				headers: expect.objectContaining({
-					Authorization: "Bearer test-token",
-				}),
+				headers: expect.objectContaining({}),
 			}),
 		);
 	});

--- a/web/src/api/__tests__/client.utils.test.ts
+++ b/web/src/api/__tests__/client.utils.test.ts
@@ -2,9 +2,10 @@ import { beforeEach, describe, expect, it } from "vitest";
 import {
 	buildQueryString,
 	buildUrl,
-	getAdminToken,
+	clearAuth,
 	getAuthHeaders,
-	setAdminToken,
+	getCsrfToken,
+	isAuthenticated,
 } from "../client";
 
 describe("buildQueryString", () => {
@@ -96,118 +97,62 @@ describe("buildUrl", () => {
 	});
 });
 
-describe("setAdminToken", () => {
-	beforeEach(() => {
-		localStorage.clear();
-		// Reset in-memory token by setting empty string
-		setAdminToken("");
+function clearCsrfCookie() {
+	document.cookie = "mh_csrf=; path=/; max-age=0";
+}
+
+describe("getCsrfToken / isAuthenticated", () => {
+	beforeEach(clearCsrfCookie);
+
+	it("reads the CSRF token from the mh_csrf cookie", () => {
+		document.cookie = "mh_csrf=my-test-csrf; path=/";
+		expect(getCsrfToken()).toBe("my-test-csrf");
+		expect(isAuthenticated()).toBe(true);
 	});
 
-	it("stores token in memory", () => {
-		setAdminToken("my-test-token");
-		expect(getAdminToken()).toBe("my-test-token");
+	it("reports unauthenticated with no cookie", () => {
+		expect(getCsrfToken()).toBeNull();
+		expect(isAuthenticated()).toBe(false);
 	});
 
-	it("overwrites previous token", () => {
-		setAdminToken("first-token");
-		setAdminToken("second-token");
-		expect(getAdminToken()).toBe("second-token");
+	it("decodes URL-encoded cookie values", () => {
+		document.cookie = "mh_csrf=a%2Bb; path=/";
+		expect(getCsrfToken()).toBe("a+b");
 	});
 });
 
-describe("getAdminToken", () => {
-	beforeEach(() => {
-		localStorage.clear();
-		setAdminToken("");
-	});
+describe("clearAuth", () => {
+	beforeEach(clearCsrfCookie);
 
-	it("returns empty string when token set to empty", () => {
-		setAdminToken("");
-		expect(getAdminToken()).toBe("");
-	});
-
-	it("returns token after setAdminToken", () => {
-		setAdminToken("stored-token");
-		expect(getAdminToken()).toBe("stored-token");
-	});
-
-	it("returns in-memory value only (no localStorage fallback)", () => {
-		// getAdminToken() returns only in-memory value
-		// localStorage fallback is only in getAuthHeaders()
-		localStorage.setItem("adminToken", "localStorage-token");
-		setAdminToken("");
-		expect(getAdminToken()).toBe("");
-	});
-
-	it("prefers memory over localStorage", () => {
-		localStorage.setItem("adminToken", "storage-token");
-		setAdminToken("memory-token");
-		expect(getAdminToken()).toBe("memory-token");
+	it("expires the mh_csrf cookie so isAuthenticated flips false", () => {
+		document.cookie = "mh_csrf=stored-csrf; path=/";
+		expect(isAuthenticated()).toBe(true);
+		clearAuth();
+		expect(getCsrfToken()).toBeNull();
+		expect(isAuthenticated()).toBe(false);
 	});
 });
 
 describe("getAuthHeaders", () => {
-	beforeEach(() => {
-		localStorage.clear();
-		setAdminToken("");
-	});
+	beforeEach(clearCsrfCookie);
 
-	it("throws error when no token set in memory or localStorage", () => {
-		setAdminToken("");
-		expect(() => getAuthHeaders()).toThrow("Admin token not set");
-	});
-
-	it("returns Authorization header with Bearer token when set", () => {
-		setAdminToken("test-token");
+	it("returns Content-Type plus the CSRF header, never a bearer token", () => {
+		document.cookie = "mh_csrf=test-csrf; path=/";
 		expect(getAuthHeaders()).toEqual({
-			Authorization: "Bearer test-token",
 			"Content-Type": "application/json",
+			"X-CSRF-Token": "test-csrf",
 		});
 	});
 
-	it("uses localStorage token when memory not set", () => {
-		setAdminToken("");
-		localStorage.setItem("adminToken", "storage-token");
-		expect(getAuthHeaders()).toEqual({
-			Authorization: "Bearer storage-token",
-			"Content-Type": "application/json",
-		});
+	it("omits the CSRF header when logged out", () => {
+		expect(getAuthHeaders()).toEqual({ "Content-Type": "application/json" });
+		expect(getAuthHeaders().Authorization).toBeUndefined();
 	});
 
-	it("prefers memory over localStorage", () => {
-		localStorage.setItem("adminToken", "storage-token");
-		setAdminToken("memory-token");
-		expect(getAuthHeaders()).toEqual({
-			Authorization: "Bearer memory-token",
-			"Content-Type": "application/json",
-		});
-	});
-
-	it("includes Content-Type header", () => {
-		setAdminToken("token");
-		const headers = getAuthHeaders();
-		expect(headers["Content-Type"]).toBe("application/json");
-	});
-});
-
-describe("Integration: setAdminToken + getAuthHeaders", () => {
-	beforeEach(() => {
-		localStorage.clear();
-		setAdminToken("");
-	});
-
-	it("setAdminToken then getAuthHeaders returns correct header", () => {
-		setAdminToken("integration-test-token");
-		const headers = getAuthHeaders();
-		expect(headers.Authorization).toBe("Bearer integration-test-token");
-		expect(headers["Content-Type"]).toBe("application/json");
-	});
-
-	it("works with complex token values", () => {
-		const complexToken =
+	it("works with complex CSRF token values", () => {
+		const complex =
 			"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0";
-		setAdminToken(complexToken);
-		const headers = getAuthHeaders();
-		expect(headers.Authorization).toBe(`Bearer ${complexToken}`);
+		document.cookie = `mh_csrf=${complex}; path=/`;
+		expect(getAuthHeaders()["X-CSRF-Token"]).toBe(complex);
 	});
 });

--- a/web/src/api/__tests__/client.version.test.ts
+++ b/web/src/api/__tests__/client.version.test.ts
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { api, setAdminToken } from "../client";
+import { api } from "../client";
 
 describe("api.version", () => {
 	beforeEach(() => {
-		setAdminToken("test-token");
+		document.cookie = "mh_csrf=test-csrf; path=/";
 		vi.restoreAllMocks();
 	});
 
@@ -20,9 +20,7 @@ describe("api.version", () => {
 			expect(globalThis.fetch).toHaveBeenCalledWith(
 				"/api/version/latest",
 				expect.objectContaining({
-					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
-					}),
+					headers: expect.objectContaining({}),
 				}),
 			);
 		});
@@ -42,9 +40,7 @@ describe("api.version", () => {
 			expect(globalThis.fetch).toHaveBeenCalledWith(
 				"/api/version/latest",
 				expect.objectContaining({
-					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
-					}),
+					headers: expect.objectContaining({}),
 					cache: "no-cache",
 					signal: expect.any(AbortSignal),
 				}),

--- a/web/src/api/__tests__/client.virtualKeys.test.ts
+++ b/web/src/api/__tests__/client.virtualKeys.test.ts
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { api, setAdminToken } from "../client";
+import { api } from "../client";
 
 describe("api.virtualKeys", () => {
 	beforeEach(() => {
-		setAdminToken("test-token");
+		document.cookie = "mh_csrf=test-csrf; path=/";
 		vi.restoreAllMocks();
 	});
 
@@ -23,9 +23,7 @@ describe("api.virtualKeys", () => {
 			expect(globalThis.fetch).toHaveBeenCalledWith(
 				"/api/virtual-keys",
 				expect.objectContaining({
-					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
-					}),
+					headers: expect.objectContaining({}),
 				}),
 			);
 		});
@@ -68,9 +66,7 @@ describe("api.virtualKeys", () => {
 				"/api/virtual-keys",
 				expect.objectContaining({
 					method: "POST",
-					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
-					}),
+					headers: expect.objectContaining({}),
 					body: JSON.stringify(requestBody),
 				}),
 			);
@@ -121,9 +117,7 @@ describe("api.virtualKeys", () => {
 			expect(globalThis.fetch).toHaveBeenCalledWith(
 				"/api/virtual-keys/1",
 				expect.objectContaining({
-					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
-					}),
+					headers: expect.objectContaining({}),
 				}),
 			);
 		});
@@ -157,9 +151,7 @@ describe("api.virtualKeys", () => {
 				"/api/virtual-keys/1",
 				expect.objectContaining({
 					method: "PUT",
-					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
-					}),
+					headers: expect.objectContaining({}),
 					body: JSON.stringify(updateData),
 				}),
 			);
@@ -188,9 +180,7 @@ describe("api.virtualKeys", () => {
 				"/api/virtual-keys/1",
 				expect.objectContaining({
 					method: "DELETE",
-					headers: expect.objectContaining({
-						Authorization: "Bearer test-token",
-					}),
+					headers: expect.objectContaining({}),
 				}),
 			);
 		});

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -147,13 +147,9 @@ export function buildUrl(
 
 // ── API ─────────────────────────────────────────────────────────────
 
-// Admin token is stored in memory (preferred) with localStorage as a
-// persistence fallback so sessions survive page reloads. This is an explicit
-// trade-off: the dashboard is same-origin and admin-only, so XSS is the only
-// practical attack vector. httpOnly cookies would eliminate the XSS risk but
-// require CSRF protection, which adds complexity for a single-user admin
-// panel serving an embedded SPA. If you deploy this behind a public-facing
-// domain with untrusted users, consider switching to httpOnly cookies.
+// The admin token is held in memory and mirrored to localStorage so a session
+// survives a page reload. getAuthHeaders() reads the in-memory value first and
+// falls back to the persisted copy.
 let adminToken: string | null = null;
 
 export function setAdminToken(token: string) {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -83,7 +83,26 @@ async function fetchOK(
 	// Same-origin credentials so the httpOnly session cookie rides along on every
 	// dashboard call. (Same-origin is the fetch default, but we set it explicitly
 	// so the intent is obvious and survives any future default change.)
-	const response = await fetch(url, { credentials: "same-origin", ...options });
+	const init: RequestInit = { credentials: "same-origin", ...options };
+	// The CSRF token only guards state-changing requests. getAuthHeaders() is
+	// shared by GET and mutating callers, so strip X-CSRF-Token here for safe
+	// methods (GET/HEAD) rather than leaking the token on read-only calls. The
+	// original header shape is preserved (plain object stays a plain object).
+	const method = (init.method ?? "GET").toUpperCase();
+	if ((method === "GET" || method === "HEAD") && init.headers) {
+		if (init.headers instanceof Headers) {
+			init.headers.delete("X-CSRF-Token");
+		} else if (Array.isArray(init.headers)) {
+			init.headers = init.headers.filter(
+				([key]) => key.toLowerCase() !== "x-csrf-token",
+			);
+		} else {
+			const rest = { ...(init.headers as Record<string, string>) };
+			delete rest["X-CSRF-Token"];
+			init.headers = rest;
+		}
+	}
+	const response = await fetch(url, init);
 	if (!response.ok) {
 		// A 401 means the session cookie is gone or invalid. Drop the client-side
 		// auth signal so isAuthenticated() flips false; the surfaced ApiError lets
@@ -1269,16 +1288,6 @@ export const api = {
 				"Failed to rename passkey",
 			);
 		},
-		logout: async (): Promise<void> => {
-			await fetchOK(
-				`${API_BASE}/api/webauthn/logout`,
-				{
-					method: "POST",
-					headers: getAuthHeaders(),
-				},
-				"Failed to logout",
-			);
-		},
 	},
 	totp: {
 		status: async (): Promise<TotpStatus> =>
@@ -1373,6 +1382,20 @@ export const api = {
 				},
 				"Login failed",
 			),
+		// Always-mounted logout: revokes whatever session the caller presents
+		// (passkey OR TOTP session token) and clears both auth cookies
+		// server-side. Works with or without passkeys configured, unlike the
+		// passkey-gated /webauthn/logout.
+		logout: async (): Promise<void> => {
+			await fetchOK(
+				`${API_BASE}/api/auth/logout`,
+				{
+					method: "POST",
+					headers: getAuthHeaders(),
+				},
+				"Failed to logout",
+			);
+		},
 		me: async (): Promise<Me> =>
 			fetchJSON<Me>(`${API_BASE}/api/auth/me`, {
 				headers: getAuthHeaders(),

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -80,8 +80,16 @@ async function fetchOK(
 	options?: RequestInit,
 	errorPrefix = "Request failed",
 ): Promise<Response> {
-	const response = await fetch(url, options);
+	// Same-origin credentials so the httpOnly session cookie rides along on every
+	// dashboard call. (Same-origin is the fetch default, but we set it explicitly
+	// so the intent is obvious and survives any future default change.)
+	const response = await fetch(url, { credentials: "same-origin", ...options });
 	if (!response.ok) {
+		// A 401 means the session cookie is gone or invalid. Drop the client-side
+		// auth signal so isAuthenticated() flips false; the surfaced ApiError lets
+		// callers show a session-expired state (the SSE stream forces the reload
+		// to the login screen).
+		if (response.status === 401) clearAuth();
 		const text = await response.text();
 		throw new ApiError(
 			`${errorPrefix}: ${response.status} ${text}`,
@@ -147,28 +155,45 @@ export function buildUrl(
 
 // ── API ─────────────────────────────────────────────────────────────
 
-// The admin token is held in memory and mirrored to localStorage so a session
-// survives a page reload. getAuthHeaders() reads the in-memory value first and
-// falls back to the persisted copy.
-let adminToken: string | null = null;
+// Cookie-session auth. The session rides in an httpOnly `mh_session` cookie the
+// browser attaches automatically on same-origin requests; JS cannot read it. A
+// companion readable `mh_csrf` cookie is the client-visible "is logged in"
+// signal and is echoed back in the X-CSRF-Token header on mutating requests so
+// the server can reject cross-site writes. No bearer token is ever stored or
+// sent.
 
-export function setAdminToken(token: string) {
-	adminToken = token;
+/** getCsrfToken reads the readable `mh_csrf` cookie, or null when absent. */
+export function getCsrfToken(): string | null {
+	const m = document.cookie.match(/(?:^|;\s*)mh_csrf=([^;]+)/);
+	return m ? decodeURIComponent(m[1]) : null;
 }
 
-export function getAdminToken(): string | null {
-	return adminToken;
+/** isAuthenticated reports whether the dashboard session cookie pair is present,
+ * derived from the readable CSRF cookie (the httpOnly session cookie can't be
+ * observed from JS). */
+export function isAuthenticated(): boolean {
+	return getCsrfToken() !== null;
 }
 
+/** clearAuth expires the readable CSRF cookie so isAuthenticated() flips false.
+ * The httpOnly session cookie is cleared server-side on logout / on a 401; this
+ * drops the client-visible auth signal immediately. */
+export function clearAuth(): void {
+	document.cookie = "mh_csrf=; path=/; max-age=0";
+}
+
+/** getAuthHeaders returns the headers for an authenticated mutating request:
+ * a JSON content type plus the CSRF token echoed from the readable cookie. It
+ * never throws and never sends an Authorization bearer; the session travels in
+ * the cookie. Safe (GET) requests may reuse it harmlessly — the server only
+ * validates the CSRF header on mutating methods. */
 export function getAuthHeaders(): Record<string, string> {
-	const token = adminToken || localStorage.getItem("adminToken");
-	if (!token) {
-		throw new Error("Admin token not set");
-	}
-	return {
-		Authorization: `Bearer ${token}`,
+	const headers: Record<string, string> = {
 		"Content-Type": "application/json",
 	};
+	const csrf = getCsrfToken();
+	if (csrf) headers["X-CSRF-Token"] = csrf;
+	return headers;
 }
 
 export const api = {
@@ -1126,13 +1151,13 @@ export const api = {
 			formData.append("admin_token", adminToken);
 
 			// Must not set Content-Type: the browser needs to auto-set
-			// multipart/form-data with the correct boundary for FormData.
-			const token = localStorage.getItem("adminToken") || "";
+			// multipart/form-data with the correct boundary for FormData. The
+			// session rides in the cookie; the CSRF token authorizes this write.
+			const csrf = getCsrfToken();
 			const response = await fetch(`${API_BASE}/api/backups/restore`, {
 				method: "POST",
-				headers: {
-					Authorization: `Bearer ${token}`,
-				},
+				credentials: "same-origin",
+				headers: csrf ? { "X-CSRF-Token": csrf } : {},
 				body: formData,
 			});
 			if (!response.ok) {
@@ -1332,6 +1357,19 @@ export const api = {
 					body: JSON.stringify(
 						code ? { username, password, code } : { username, password },
 					),
+				},
+				"Login failed",
+			),
+		// Admin-token bootstrap: exchanges the env admin token for a session
+		// cookie pair. Returns 400 when the admin account has TOTP enabled (the
+		// caller must use the TOTP login flow instead), 401 on a bad token.
+		adminExchange: async (adminToken: string): Promise<{ success: boolean }> =>
+			fetchJSON<{ success: boolean }>(
+				`${API_BASE}/api/auth/admin-exchange`,
+				{
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ admin_token: adminToken }),
 				},
 				"Login failed",
 			),

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -26,7 +26,7 @@ import {
 	Swords,
 	Users as UsersIcon,
 } from "@/lib/icons";
-import { api, setAdminToken } from "../api/client";
+import { api, clearAuth } from "../api/client";
 import { useIdentity } from "../context/IdentityContext";
 import { useSidebarMode } from "../context/SidebarModeContext";
 import { useTheme } from "../context/ThemeContext";
@@ -919,15 +919,11 @@ export function Layout({ children }: LayoutProps) {
 		} catch {
 			// Server-side logout failure is non-fatal.
 		}
-		// Tear down the auth state before the reload. Order matters: clear the
-		// in-memory token (the primary source getAuthHeaders() reads) AND the
-		// localStorage fallback, then cancel any in-flight queries. Without
-		// clearing the in-memory token, queries that refetch in the gap before the
-		// reload would still send the now-revoked token, producing a burst of
-		// 401s server-side (and pointless work client-side). With it cleared,
-		// getAuthHeaders() throws locally and those refetches never hit the wire.
-		setAdminToken("");
-		localStorage.removeItem("adminToken");
+		// The logout call cleared the session cookies server-side. Drop the
+		// client-visible auth signal so isAuthenticated() flips false, cancel any
+		// in-flight queries so they don't race the reload, then reload into the
+		// login screen.
+		clearAuth();
 		queryClient.cancelQueries();
 		window.location.reload();
 	};

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -909,20 +909,21 @@ export function Layout({ children }: LayoutProps) {
 
 	const handleLogout = async () => {
 		try {
-			// Best-effort server-side session revoke. The endpoint revokes whatever
-			// session matches the bearer (passkey OR TOTP session token), so it must
-			// run for every session type, not only when passkeys are configured. A
-			// raw admin token with no server session is a harmless no-op; a route
-			// that isn't mounted 404s into the catch below. This matters for idle
-			// auto-logout: a TOTP-only admin's session must die server-side too.
-			await api.webauthn.logout();
+			// Best-effort server-side session revoke via the always-mounted
+			// endpoint. It revokes whatever session the caller presents (passkey OR
+			// TOTP session token) and clears both auth cookies, so it must run for
+			// every session type and works whether or not passkeys are configured. A
+			// raw admin token with no server session is a harmless no-op. This
+			// matters for idle auto-logout: a TOTP-only admin's session must die
+			// server-side too.
+			await api.auth.logout();
 		} catch {
 			// Server-side logout failure is non-fatal.
 		}
-		// The logout call cleared the session cookies server-side. Drop the
-		// client-visible auth signal so isAuthenticated() flips false, cancel any
-		// in-flight queries so they don't race the reload, then reload into the
-		// login screen.
+		// The logout call revoked the session and cleared the httpOnly session
+		// cookie server-side. Drop the client-visible auth signal so
+		// isAuthenticated() flips false, cancel any in-flight queries so they don't
+		// race the reload, then reload into the login screen.
 		clearAuth();
 		queryClient.cancelQueries();
 		window.location.reload();

--- a/web/src/components/__tests__/Layout.identity.test.tsx
+++ b/web/src/components/__tests__/Layout.identity.test.tsx
@@ -1,7 +1,6 @@
 import { screen } from "@testing-library/react";
 import { HttpResponse, http } from "msw";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { setAdminToken } from "../../api/client";
 import { IdentityProvider } from "../../context/IdentityContext";
 import { server } from "../../test/mocks/server";
 import { renderWithProviders } from "../../test/utils";
@@ -16,7 +15,7 @@ describe("Layout — logged-in identity", () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks();
-		setAdminToken("test-admin-token");
+		document.cookie = "mh_csrf=test-csrf; path=/";
 	});
 
 	it("labels the logout button with the user's display name", async () => {

--- a/web/src/components/__tests__/Layout.navigation.test.tsx
+++ b/web/src/components/__tests__/Layout.navigation.test.tsx
@@ -867,13 +867,13 @@ describe("Layout", () => {
 		});
 	});
 
-	describe("Logout with WebAuthn", () => {
-		it("calls webauthn.logout when WebAuthn is available", async () => {
+	describe("Logout", () => {
+		it("revokes the session via the always-mounted logout endpoint", async () => {
 			const user = userEvent.setup();
 			vi.spyOn(webauthnUtils, "isWebAuthnAvailable").mockResolvedValue(true);
 			let logoutCalled = false;
 			server.use(
-				http.post("/api/webauthn/logout", () => {
+				http.post("/api/auth/logout", () => {
 					logoutCalled = true;
 					return HttpResponse.json({ success: true });
 				}),
@@ -909,7 +909,7 @@ describe("Layout", () => {
 			vi.spyOn(webauthnUtils, "isWebAuthnAvailable").mockResolvedValue(true);
 			document.cookie = "mh_csrf=test-csrf; path=/";
 			server.use(
-				http.post("/api/webauthn/logout", () =>
+				http.post("/api/auth/logout", () =>
 					HttpResponse.json({ success: true }),
 				),
 			);

--- a/web/src/components/__tests__/Layout.navigation.test.tsx
+++ b/web/src/components/__tests__/Layout.navigation.test.tsx
@@ -2,7 +2,6 @@ import { act, fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { HttpResponse, http } from "msw";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { getAdminToken, setAdminToken } from "../../api/client";
 import { server } from "../../test/mocks/server";
 import { renderWithProviders } from "../../test/utils";
 import * as webauthnUtils from "../../utils/webauthn";
@@ -13,10 +12,10 @@ describe("Layout", () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks();
-		// The admin token is module-global state (seeded once in setup.ts). The
-		// logout tests now clear it (the in-memory token, not just localStorage),
-		// so re-seed before every test to keep the suite order-independent.
-		setAdminToken("test-admin-token");
+		// Auth is the readable mh_csrf cookie (seeded once in setup.ts). The logout
+		// tests clear it, so re-seed before every test to keep the suite
+		// order-independent.
+		document.cookie = "mh_csrf=test-csrf; path=/";
 	});
 
 	describe("Sidebar Navigation", () => {
@@ -266,8 +265,7 @@ describe("Layout", () => {
 
 		it("performs logout on confirmation", async () => {
 			const user = userEvent.setup();
-			const originalStorage = localStorage.getItem("adminToken");
-			localStorage.setItem("adminToken", "test-token");
+			document.cookie = "mh_csrf=test-csrf; path=/";
 
 			renderWithProviders(<Layout>{mockChildren}</Layout>);
 
@@ -288,12 +286,8 @@ describe("Layout", () => {
 			}
 
 			await waitFor(() => {
-				expect(localStorage.getItem("adminToken")).toBeNull();
+				expect(document.cookie).not.toContain("mh_csrf=");
 			});
-
-			if (originalStorage) {
-				localStorage.setItem("adminToken", originalStorage);
-			}
 		});
 	});
 
@@ -474,8 +468,7 @@ describe("Layout", () => {
 
 		it("handles logout confirmation flow", async () => {
 			const user = userEvent.setup();
-			const originalStorage = localStorage.getItem("adminToken");
-			localStorage.setItem("adminToken", "test-token");
+			document.cookie = "mh_csrf=test-csrf; path=/";
 
 			renderWithProviders(<Layout>{mockChildren}</Layout>, {
 				initialEntries: ["/dashboard"],
@@ -500,12 +493,8 @@ describe("Layout", () => {
 			}
 
 			await waitFor(() => {
-				expect(localStorage.getItem("adminToken")).toBeNull();
+				expect(document.cookie).not.toContain("mh_csrf=");
 			});
-
-			if (originalStorage) {
-				localStorage.setItem("adminToken", originalStorage);
-			}
 		});
 
 		it("cancels logout confirmation", async () => {
@@ -889,7 +878,7 @@ describe("Layout", () => {
 					return HttpResponse.json({ success: true });
 				}),
 			);
-			localStorage.setItem("adminToken", "test-token");
+			document.cookie = "mh_csrf=test-csrf; path=/";
 
 			renderWithProviders(<Layout>{mockChildren}</Layout>);
 
@@ -908,21 +897,17 @@ describe("Layout", () => {
 
 			await waitFor(() => {
 				expect(logoutCalled).toBe(true);
-				expect(localStorage.getItem("adminToken")).toBeNull();
+				expect(document.cookie).not.toContain("mh_csrf=");
 			});
-
-			localStorage.removeItem("adminToken");
 		});
 
-		// Regression: logout must clear the IN-MEMORY token, not just localStorage.
-		// getAuthHeaders() reads the in-memory token first, so leaving it set let
-		// queries refetch with the just-revoked token in the gap before the reload,
+		// Regression: logout must clear the client auth signal so queries don't
+		// refetch with a just-revoked session in the gap before the reload,
 		// producing a burst of 401s server-side.
-		it("clears the in-memory admin token on logout", async () => {
+		it("clears the session cookie on logout", async () => {
 			const user = userEvent.setup();
 			vi.spyOn(webauthnUtils, "isWebAuthnAvailable").mockResolvedValue(true);
-			setAdminToken("test-token");
-			localStorage.setItem("adminToken", "test-token");
+			document.cookie = "mh_csrf=test-csrf; path=/";
 			server.use(
 				http.post("/api/webauthn/logout", () =>
 					HttpResponse.json({ success: true }),
@@ -943,11 +928,8 @@ describe("Layout", () => {
 			}
 
 			await waitFor(() => {
-				expect(getAdminToken()).toBe("");
-				expect(localStorage.getItem("adminToken")).toBeNull();
+				expect(document.cookie).not.toContain("mh_csrf=");
 			});
-
-			localStorage.removeItem("adminToken");
 		});
 	});
 });

--- a/web/src/components/__tests__/VirtualAppLogTable.test.tsx
+++ b/web/src/components/__tests__/VirtualAppLogTable.test.tsx
@@ -47,7 +47,7 @@ const defaultProps = {
 describe("VirtualAppLogTable", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
-		localStorage.setItem("adminToken", "test-token");
+		document.cookie = "mh_csrf=test-csrf; path=/";
 	});
 
 	// ==================== Empty State Tests ====================

--- a/web/src/components/__tests__/VirtualLogTable.scroll.test.tsx
+++ b/web/src/components/__tests__/VirtualLogTable.scroll.test.tsx
@@ -77,7 +77,7 @@ const defaultProps = {
 describe("VirtualLogTable", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
-		localStorage.setItem("adminToken", "test-token");
+		document.cookie = "mh_csrf=test-csrf; path=/";
 		mockGetVirtualItems.mockReturnValue([]);
 		mockGetTotalSize.mockReturnValue(0);
 		mockMeasureElement.mockImplementation(() => {});

--- a/web/src/components/__tests__/VirtualLogTable.test.tsx
+++ b/web/src/components/__tests__/VirtualLogTable.test.tsx
@@ -86,7 +86,7 @@ const defaultProps = {
 describe("VirtualLogTable", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
-		localStorage.setItem("adminToken", "test-token");
+		document.cookie = "mh_csrf=test-csrf; path=/";
 		mockGetVirtualItems.mockReturnValue([]);
 		mockGetTotalSize.mockReturnValue(0);
 		mockMeasureElement.mockImplementation(() => {});

--- a/web/src/components/__tests__/VirtualModelTable.test.tsx
+++ b/web/src/components/__tests__/VirtualModelTable.test.tsx
@@ -32,7 +32,11 @@ vi.mock("../../api/client", () => ({
 			cursor: vi.fn(),
 		},
 	},
-	getAdminToken: vi.fn(() => "test-admin-token"),
+	// EventProvider (mounted by renderWithProviders) reads the cookie-derived
+	// auth signal; the fetch helpers ride along for any component network calls.
+	isAuthenticated: vi.fn(() => true),
+	clearAuth: vi.fn(),
+	getAuthHeaders: vi.fn(() => ({ "Content-Type": "application/json" })),
 	API_BASE: "",
 }));
 
@@ -105,7 +109,7 @@ function setupWithEntries(
 
 describe("VirtualModelTable", () => {
 	beforeEach(() => {
-		localStorage.setItem("adminToken", "test-token");
+		document.cookie = "mh_csrf=test-csrf; path=/";
 		mockGetVirtualItems.mockReturnValue([]);
 		mockGetTotalSize.mockReturnValue(0);
 		mockMeasureElement.mockImplementation(() => {});

--- a/web/src/context/EventContext.tsx
+++ b/web/src/context/EventContext.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode, useEffect, useRef } from "react";
-import { API_BASE, getAdminToken } from "../api/client";
+import { API_BASE, clearAuth, isAuthenticated } from "../api/client";
 import { readSSEStream } from "../utils/sse";
 import { useToast } from "./ToastContext";
 
@@ -20,7 +20,7 @@ export function EventProvider({ children }: { children: ReactNode }) {
 	const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
 	useEffect(() => {
-		if (!getAdminToken()) return;
+		if (!isAuthenticated()) return;
 
 		// Set once the effect's cleanup has run so any in-flight fetch that
 		// settles afterwards won't schedule a fresh reconnect.
@@ -28,25 +28,24 @@ export function EventProvider({ children }: { children: ReactNode }) {
 
 		const connect = () => {
 			if (connectingRef.current) return;
-			// Re-read the token on every (re)connect so a token rotated mid-session
-			// (e.g. enabling TOTP 2FA swaps the raw admin token for a session token)
-			// is used instead of the stale one captured when the effect mounted.
-			const token = getAdminToken();
-			if (!token) return;
+			// Re-check auth on every (re)connect so a session dropped mid-run stops
+			// us from reconnecting in a loop. The session cookie attaches
+			// automatically on this same-origin request.
+			if (!isAuthenticated()) return;
 			connectingRef.current = true;
 			const ac = new AbortController();
 			abortRef.current = ac;
 			let authFailed = false;
 
 			fetch(`${API_BASE}/api/events`, {
-				headers: { Authorization: `Bearer ${token}` },
+				credentials: "same-origin",
 				signal: ac.signal,
 			})
 				.then((response) => {
 					if (!response.ok) {
 						if (response.status === 401) {
 							authFailed = true;
-							localStorage.removeItem("adminToken");
+							clearAuth();
 							window.location.reload();
 							return;
 						}

--- a/web/src/context/__tests__/EventContext.test.tsx
+++ b/web/src/context/__tests__/EventContext.test.tsx
@@ -34,7 +34,7 @@ describe("EventContext", () => {
 		expect(getByTestId("child")).toBeInTheDocument();
 	});
 
-	it("EventProvider works with admin token set (from setup.ts which calls setAdminToken)", () => {
+	it("EventProvider works with the session cookie set (seeded in setup.ts)", () => {
 		const TestChild = () => <div data-testid="child">Test Child</div>;
 
 		const { getByTestId } = renderWithEventProvider(<TestChild />);
@@ -48,16 +48,21 @@ describe("SSE connection and event handling", () => {
 		server.resetHandlers();
 		vi.clearAllMocks();
 		vi.useRealTimers();
+		// Re-seed the session cookie so the next test starts authenticated (the
+		// 401 test clears it via clearAuth()).
+		document.cookie = "mh_csrf=test-csrf; path=/";
 	});
 
-	it("connects to /api/events on mount", async () => {
+	it("connects to /api/events on mount with the session cookie", async () => {
 		let fetchCalled = false;
 		let authHeader: string | undefined;
+		let cookieHeader: string | undefined;
 
 		server.use(
 			http.get("/api/events", ({ request }) => {
 				fetchCalled = true;
 				authHeader = request.headers.get("Authorization") ?? undefined;
+				cookieHeader = request.headers.get("Cookie") ?? undefined;
 				const stream = createSSEStream([], { doneSentinel: null });
 				return new HttpResponse(stream, {
 					status: 200,
@@ -76,7 +81,8 @@ describe("SSE connection and event handling", () => {
 			expect(fetchCalled).toBe(true);
 		});
 
-		expect(authHeader).toBe("Bearer test-admin-token");
+		expect(authHeader).toBeUndefined();
+		expect(cookieHeader).toContain("mh_csrf=");
 	});
 
 	it("dispatches server-event CustomEvent for each SSE chunk", async () => {
@@ -413,9 +419,9 @@ describe("SSE connection and event handling", () => {
 		);
 	});
 
-	it("clears token and reloads on 401 response", async () => {
-		// Pre-set the adminToken in localStorage so we can verify removal
-		localStorage.setItem("adminToken", "will-be-removed");
+	it("clears the session and reloads on 401 response", async () => {
+		// The session cookie is present (seeded in setup); a 401 must clear it.
+		expect(document.cookie).toContain("mh_csrf=");
 
 		const reloadMock = vi.fn();
 		vi.stubGlobal("location", {
@@ -436,15 +442,13 @@ describe("SSE connection and event handling", () => {
 			expect(reloadMock).toHaveBeenCalled();
 		});
 
-		expect(localStorage.getItem("adminToken")).toBeNull();
+		// clearAuth() expired the readable CSRF cookie.
+		expect(document.cookie).not.toContain("mh_csrf=");
 
 		vi.unstubAllGlobals();
 	});
 
 	it("reconnects with backoff on non-401 error", async () => {
-		// Pre-set the adminToken to verify it's NOT removed on non-401 errors
-		localStorage.setItem("adminToken", "should-remain");
-
 		const reloadMock = vi.fn();
 		vi.stubGlobal("location", {
 			...window.location,
@@ -476,8 +480,8 @@ describe("SSE connection and event handling", () => {
 
 		// Verify reload was NOT called
 		expect(reloadMock).not.toHaveBeenCalled();
-		// Verify adminToken was NOT removed
-		expect(localStorage.getItem("adminToken")).toBe("should-remain");
+		// The session cookie is NOT cleared on non-401 errors.
+		expect(document.cookie).toContain("mh_csrf=");
 
 		vi.unstubAllGlobals();
 	});

--- a/web/src/pages/Security/__tests__/Security.test.tsx
+++ b/web/src/pages/Security/__tests__/Security.test.tsx
@@ -1,7 +1,6 @@
 import { screen, waitFor } from "@testing-library/react";
 import { HttpResponse, http } from "msw";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { setAdminToken } from "../../../api/client";
 import type { UserTotpStatus } from "../../../api/types";
 import { server } from "../../../test/mocks/server";
 import { renderWithProviders } from "../../../test/utils";
@@ -349,15 +348,16 @@ describe("Security page edge handlers", () => {
 			await waitFor(() => expect(reload).toHaveBeenCalled(), {
 				timeout: 15000,
 			});
-			expect(localStorage.getItem("adminToken")).toBeNull();
+			// The teardown clears the client auth signal (mh_csrf cookie).
+			expect(document.cookie).not.toContain("mh_csrf=");
 		} finally {
 			Object.defineProperty(window, "location", {
 				value: original,
 				configurable: true,
 			});
-			// The teardown cleared the file-wide test token; put it back for
+			// The teardown cleared the file-wide session cookie; put it back for
 			// whatever runs after this test.
-			setAdminToken("test-admin-token");
+			document.cookie = "mh_csrf=test-csrf; path=/";
 		}
 	});
 

--- a/web/src/pages/Security/index.tsx
+++ b/web/src/pages/Security/index.tsx
@@ -3,7 +3,7 @@ import QRCode from "qrcode";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Check, Copy, Download, ShieldCheck, X } from "@/lib/icons";
-import { ApiError, api, setAdminToken } from "../../api/client";
+import { ApiError, api, clearAuth } from "../../api/client";
 import { CopyButton } from "../../components/CopyButton";
 import { PageHeader } from "../../components/PageHeader";
 import { useToast } from "../../context/ToastContext";
@@ -158,8 +158,7 @@ export function Security() {
 			// logout button does and land on the login screen.
 			toast(t("security.password.success"), "success");
 			setTimeout(() => {
-				setAdminToken("");
-				localStorage.removeItem("adminToken");
+				clearAuth();
 				queryClient.cancelQueries();
 				window.location.reload();
 			}, 1500);

--- a/web/src/pages/Settings/TotpSettings.tsx
+++ b/web/src/pages/Settings/TotpSettings.tsx
@@ -3,7 +3,7 @@ import QRCode from "qrcode";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Check, Copy, Download, X } from "@/lib/icons";
-import { api, setAdminToken } from "../../api/client";
+import { api } from "../../api/client";
 import { CopyButton } from "../../components/CopyButton";
 import { useToast } from "../../context/ToastContext";
 import { formatDate } from "../../utils/format";
@@ -76,12 +76,9 @@ export function TotpPanel() {
 		mutationFn: (code: string) => api.totp.enrollVerify(code),
 		onSuccess: (data) => {
 			// Enabling 2FA invalidates the raw admin token the browser was using;
-			// the server returns a session token so we stay logged in instead of the
-			// dashboard suddenly going "API offline". Install it before any refetch.
-			if (data.token) {
-				localStorage.setItem("adminToken", data.token);
-				setAdminToken(data.token);
-			}
+			// the server rotates the session cookie pair in the response so we stay
+			// logged in instead of the dashboard suddenly going "API offline". No
+			// client-side token juggling is needed.
 			setRecoveryCodes(data.recovery_codes);
 			setShowRecovery(true);
 			setEnrollUri("");

--- a/web/src/pages/Settings/__tests__/AlertsSettings.test.tsx
+++ b/web/src/pages/Settings/__tests__/AlertsSettings.test.tsx
@@ -8,7 +8,7 @@ import { AlertsSettings } from "../AlertsSettings";
 function mockSettings(values: Record<string, string>) {
 	server.use(
 		http.get("/api/settings", ({ request }) => {
-			if (!request.headers.get("Authorization")?.startsWith("Bearer ")) {
+			if (!request.headers.get("Cookie")?.includes("mh_csrf=")) {
 				return HttpResponse.json({ error: "Unauthorized" }, { status: 401 });
 			}
 			return HttpResponse.json(values);

--- a/web/src/pages/Settings/__tests__/CircuitBreakerSettings.test.tsx
+++ b/web/src/pages/Settings/__tests__/CircuitBreakerSettings.test.tsx
@@ -232,7 +232,7 @@ describe("CircuitBreakerSettings", () => {
 				},
 			}),
 			http.put("/api/settings", async ({ request }) => {
-				if (!request.headers.get("Authorization")?.startsWith("Bearer ")) {
+				if (!request.headers.get("Cookie")?.includes("mh_csrf=")) {
 					return HttpResponse.json({ error: "Unauthorized" }, { status: 401 });
 				}
 				const body = await request.json();
@@ -278,7 +278,7 @@ describe("CircuitBreakerSettings", () => {
 				},
 			}),
 			http.put("/api/settings", async ({ request }) => {
-				if (!request.headers.get("Authorization")?.startsWith("Bearer ")) {
+				if (!request.headers.get("Cookie")?.includes("mh_csrf=")) {
 					return HttpResponse.json({ error: "Unauthorized" }, { status: 401 });
 				}
 				const body = await request.json();
@@ -320,7 +320,7 @@ describe("CircuitBreakerSettings", () => {
 				},
 			}),
 			http.put("/api/settings", async ({ request }) => {
-				if (!request.headers.get("Authorization")?.startsWith("Bearer ")) {
+				if (!request.headers.get("Cookie")?.includes("mh_csrf=")) {
 					return HttpResponse.json({ error: "Unauthorized" }, { status: 401 });
 				}
 				return HttpResponse.json({ ok: true });
@@ -418,7 +418,7 @@ describe("CircuitBreakerSettings", () => {
 		server.use(
 			...mockSettings({ body: { circuit_breaker_enabled: "true" } }),
 			http.put("/api/settings", async ({ request }) => {
-				if (!request.headers.get("Authorization")?.startsWith("Bearer ")) {
+				if (!request.headers.get("Cookie")?.includes("mh_csrf=")) {
 					return HttpResponse.json({ error: "Unauthorized" }, { status: 401 });
 				}
 				capturedPayload = (await request.json()) as Record<string, string>;
@@ -448,7 +448,7 @@ describe("CircuitBreakerSettings", () => {
 		server.use(
 			...mockSettings({ body: {} }),
 			http.put("/api/settings", async ({ request }) => {
-				if (!request.headers.get("Authorization")?.startsWith("Bearer ")) {
+				if (!request.headers.get("Cookie")?.includes("mh_csrf=")) {
 					return HttpResponse.json({ error: "Unauthorized" }, { status: 401 });
 				}
 				capturedPayload = (await request.json()) as Record<string, string>;
@@ -502,7 +502,7 @@ describe("CircuitBreakerSettings", () => {
 		server.use(
 			...mockSettings({ body: { circuit_breaker_enabled: "false" } }),
 			http.put("/api/settings", async ({ request }) => {
-				if (!request.headers.get("Authorization")?.startsWith("Bearer ")) {
+				if (!request.headers.get("Cookie")?.includes("mh_csrf=")) {
 					return HttpResponse.json({ error: "Unauthorized" }, { status: 401 });
 				}
 				capturedPayload = (await request.json()) as Record<string, string>;
@@ -574,7 +574,7 @@ describe("CircuitBreakerSettings", () => {
 			server.use(
 				...mockSettings({ body: {} }),
 				http.put("/api/settings", async ({ request }) => {
-					if (!request.headers.get("Authorization")?.startsWith("Bearer ")) {
+					if (!request.headers.get("Cookie")?.includes("mh_csrf=")) {
 						return HttpResponse.json(
 							{ error: "Unauthorized" },
 							{ status: 401 },
@@ -608,7 +608,7 @@ describe("CircuitBreakerSettings", () => {
 					body: { hedging_enabled: "true", hedge_delay: "4s" },
 				}),
 				http.put("/api/settings", async ({ request }) => {
-					if (!request.headers.get("Authorization")?.startsWith("Bearer ")) {
+					if (!request.headers.get("Cookie")?.includes("mh_csrf=")) {
 						return HttpResponse.json(
 							{ error: "Unauthorized" },
 							{ status: 401 },

--- a/web/src/pages/Settings/__tests__/DiscoverySettings.test.tsx
+++ b/web/src/pages/Settings/__tests__/DiscoverySettings.test.tsx
@@ -30,7 +30,7 @@ describe("DiscoverySettings", () => {
 	it("displays default values when settings are empty", async () => {
 		server.use(
 			http.get("/api/settings", ({ request }) => {
-				if (!request.headers.get("Authorization")?.startsWith("Bearer ")) {
+				if (!request.headers.get("Cookie")?.includes("mh_csrf=")) {
 					return HttpResponse.json({ error: "Unauthorized" }, { status: 401 });
 				}
 				return HttpResponse.json({});
@@ -49,7 +49,7 @@ describe("DiscoverySettings", () => {
 	it("shows success toast on mutation success", async () => {
 		server.use(
 			http.put("/api/settings", async ({ request }) => {
-				if (!request.headers.get("Authorization")?.startsWith("Bearer ")) {
+				if (!request.headers.get("Cookie")?.includes("mh_csrf=")) {
 					return HttpResponse.json({ error: "Unauthorized" }, { status: 401 });
 				}
 				return HttpResponse.json({ ok: true });
@@ -106,7 +106,7 @@ describe("DiscoverySettings", () => {
 	it("shows description with disable note when interval is 0", async () => {
 		server.use(
 			http.get("/api/settings", ({ request }) => {
-				if (!request.headers.get("Authorization")?.startsWith("Bearer ")) {
+				if (!request.headers.get("Cookie")?.includes("mh_csrf=")) {
 					return HttpResponse.json({ error: "Unauthorized" }, { status: 401 });
 				}
 				return HttpResponse.json({
@@ -146,7 +146,7 @@ describe("DiscoverySettings", () => {
 
 		server.use(
 			http.get("/api/settings", ({ request }) => {
-				if (!request.headers.get("Authorization")?.startsWith("Bearer ")) {
+				if (!request.headers.get("Cookie")?.includes("mh_csrf=")) {
 					return HttpResponse.json({ error: "Unauthorized" }, { status: 401 });
 				}
 				return HttpResponse.json({
@@ -154,7 +154,7 @@ describe("DiscoverySettings", () => {
 				});
 			}),
 			http.put("/api/settings", async ({ request }) => {
-				if (!request.headers.get("Authorization")?.startsWith("Bearer ")) {
+				if (!request.headers.get("Cookie")?.includes("mh_csrf=")) {
 					return HttpResponse.json({ error: "Unauthorized" }, { status: 401 });
 				}
 				capturedPayload = (await request.json()) as Record<string, string>;
@@ -193,7 +193,7 @@ describe("DiscoverySettings", () => {
 
 		server.use(
 			http.get("/api/settings", ({ request }) => {
-				if (!request.headers.get("Authorization")?.startsWith("Bearer ")) {
+				if (!request.headers.get("Cookie")?.includes("mh_csrf=")) {
 					return HttpResponse.json({ error: "Unauthorized" }, { status: 401 });
 				}
 				return HttpResponse.json({
@@ -201,7 +201,7 @@ describe("DiscoverySettings", () => {
 				});
 			}),
 			http.put("/api/settings", async ({ request }) => {
-				if (!request.headers.get("Authorization")?.startsWith("Bearer ")) {
+				if (!request.headers.get("Cookie")?.includes("mh_csrf=")) {
 					return HttpResponse.json({ error: "Unauthorized" }, { status: 401 });
 				}
 				capturedPayload = (await request.json()) as Record<string, string>;
@@ -290,7 +290,7 @@ describe("DiscoverySettings", () => {
 
 		server.use(
 			http.get("/api/settings", ({ request }) => {
-				if (!request.headers.get("Authorization")?.startsWith("Bearer ")) {
+				if (!request.headers.get("Cookie")?.includes("mh_csrf=")) {
 					return HttpResponse.json({ error: "Unauthorized" }, { status: 401 });
 				}
 				return HttpResponse.json({

--- a/web/src/pages/Settings/__tests__/GithubSettings.test.tsx
+++ b/web/src/pages/Settings/__tests__/GithubSettings.test.tsx
@@ -9,7 +9,7 @@ import { GithubPanel } from "../GithubSettings";
 function mockSettings(values: Record<string, string>) {
 	server.use(
 		http.get("/api/settings", ({ request }) => {
-			if (!request.headers.get("Authorization")?.startsWith("Bearer ")) {
+			if (!request.headers.get("Cookie")?.includes("mh_csrf=")) {
 				return HttpResponse.json({ error: "Unauthorized" }, { status: 401 });
 			}
 			return HttpResponse.json(values);

--- a/web/src/pages/Settings/__tests__/OidcSettings.test.tsx
+++ b/web/src/pages/Settings/__tests__/OidcSettings.test.tsx
@@ -9,7 +9,7 @@ import { OidcPanel } from "../OidcSettings";
 function mockSettings(values: Record<string, string>) {
 	server.use(
 		http.get("/api/settings", ({ request }) => {
-			if (!request.headers.get("Authorization")?.startsWith("Bearer ")) {
+			if (!request.headers.get("Cookie")?.includes("mh_csrf=")) {
 				return HttpResponse.json({ error: "Unauthorized" }, { status: 401 });
 			}
 			return HttpResponse.json(values);

--- a/web/src/pages/Settings/__tests__/ProxySettings.test.tsx
+++ b/web/src/pages/Settings/__tests__/ProxySettings.test.tsx
@@ -28,7 +28,7 @@ describe("ProxySettings", () => {
 	it("displays default values when settings are empty", async () => {
 		server.use(
 			http.get("/api/settings", ({ request }) => {
-				if (!request.headers.get("Authorization")?.startsWith("Bearer ")) {
+				if (!request.headers.get("Cookie")?.includes("mh_csrf=")) {
 					return HttpResponse.json({ error: "Unauthorized" }, { status: 401 });
 				}
 				return HttpResponse.json({});
@@ -57,7 +57,7 @@ describe("ProxySettings", () => {
 	it("displays values from settings API", async () => {
 		server.use(
 			http.get("/api/settings", ({ request }) => {
-				if (!request.headers.get("Authorization")?.startsWith("Bearer ")) {
+				if (!request.headers.get("Cookie")?.includes("mh_csrf=")) {
 					return HttpResponse.json({ error: "Unauthorized" }, { status: 401 });
 				}
 				return HttpResponse.json({
@@ -91,7 +91,7 @@ describe("ProxySettings", () => {
 
 		server.use(
 			http.put("/api/settings", async ({ request }) => {
-				if (!request.headers.get("Authorization")?.startsWith("Bearer ")) {
+				if (!request.headers.get("Cookie")?.includes("mh_csrf=")) {
 					return HttpResponse.json({ error: "Unauthorized" }, { status: 401 });
 				}
 				const body = await request.json();
@@ -133,7 +133,7 @@ describe("ProxySettings", () => {
 
 		server.use(
 			http.put("/api/settings", async ({ request }) => {
-				if (!request.headers.get("Authorization")?.startsWith("Bearer ")) {
+				if (!request.headers.get("Cookie")?.includes("mh_csrf=")) {
 					return HttpResponse.json({ error: "Unauthorized" }, { status: 401 });
 				}
 				const body = await request.json();
@@ -173,7 +173,7 @@ describe("ProxySettings", () => {
 	it("shows success toast on mutation success", async () => {
 		server.use(
 			http.put("/api/settings", async ({ request }) => {
-				if (!request.headers.get("Authorization")?.startsWith("Bearer ")) {
+				if (!request.headers.get("Cookie")?.includes("mh_csrf=")) {
 					return HttpResponse.json({ error: "Unauthorized" }, { status: 401 });
 				}
 				return HttpResponse.json({ ok: true });
@@ -262,7 +262,7 @@ describe("ProxySettings", () => {
 	it("invalidates settings query after successful mutation", async () => {
 		server.use(
 			http.put("/api/settings", async ({ request }) => {
-				if (!request.headers.get("Authorization")?.startsWith("Bearer ")) {
+				if (!request.headers.get("Cookie")?.includes("mh_csrf=")) {
 					return HttpResponse.json({ error: "Unauthorized" }, { status: 401 });
 				}
 				return HttpResponse.json({ ok: true });
@@ -380,7 +380,7 @@ describe("ProxySettings", () => {
 
 		server.use(
 			http.put("/api/settings", async ({ request }) => {
-				if (!request.headers.get("Authorization")?.startsWith("Bearer ")) {
+				if (!request.headers.get("Cookie")?.includes("mh_csrf=")) {
 					return HttpResponse.json({ error: "Unauthorized" }, { status: 401 });
 				}
 				capturedPayload = (await request.json()) as Record<string, string>;
@@ -415,7 +415,7 @@ describe("ProxySettings", () => {
 
 		server.use(
 			http.put("/api/settings", async ({ request }) => {
-				if (!request.headers.get("Authorization")?.startsWith("Bearer ")) {
+				if (!request.headers.get("Cookie")?.includes("mh_csrf=")) {
 					return HttpResponse.json({ error: "Unauthorized" }, { status: 401 });
 				}
 				capturedPayload = (await request.json()) as Record<string, string>;

--- a/web/src/pages/Settings/__tests__/RateLimitSettings.test.tsx
+++ b/web/src/pages/Settings/__tests__/RateLimitSettings.test.tsx
@@ -466,7 +466,7 @@ describe("RateLimitSettings", () => {
 					});
 				}),
 				http.put("/api/settings", async ({ request }) => {
-					if (!request.headers.get("Authorization")?.startsWith("Bearer ")) {
+					if (!request.headers.get("Cookie")?.includes("mh_csrf=")) {
 						return HttpResponse.json(
 							{ error: "Unauthorized" },
 							{ status: 401 },
@@ -509,7 +509,7 @@ describe("RateLimitSettings", () => {
 					});
 				}),
 				http.put("/api/settings", async ({ request }) => {
-					if (!request.headers.get("Authorization")?.startsWith("Bearer ")) {
+					if (!request.headers.get("Cookie")?.includes("mh_csrf=")) {
 						return HttpResponse.json(
 							{ error: "Unauthorized" },
 							{ status: 401 },

--- a/web/src/pages/Settings/__tests__/TotpSettings.test.tsx
+++ b/web/src/pages/Settings/__tests__/TotpSettings.test.tsx
@@ -161,7 +161,7 @@ describe("TotpSettings", () => {
 		clickSpy.mockRestore();
 	});
 
-	it("installs the session token from enroll/verify to stay logged in", async () => {
+	it("stays logged in after enroll/verify without client-side token juggling", async () => {
 		mockStatus(false);
 		server.use(
 			http.post("/api/totp/enroll/start", () =>
@@ -193,8 +193,9 @@ describe("TotpSettings", () => {
 		await waitFor(() => {
 			expect(screen.getByText(RECOVERY_CODES[0])).toBeInTheDocument();
 		});
-		// The minted session token is installed so the dashboard stays authed.
-		expect(localStorage.getItem("adminToken")).toBe("sess-tok-123");
+		// The server rotates the session cookie pair in the response; the client
+		// does not stash any token in localStorage.
+		expect(localStorage.getItem("adminToken")).toBeNull();
 	});
 
 	it("clears recovery codes after I have saved them", async () => {

--- a/web/src/pages/__tests__/Arena.flow.test.tsx
+++ b/web/src/pages/__tests__/Arena.flow.test.tsx
@@ -29,7 +29,7 @@ describe("Arena", () => {
 			server.use(
 				http.get("/api/models", ({ request }) => {
 					modelsApiCalled = true;
-					expect(request.headers.get("Authorization")).toMatch(/Bearer /);
+					expect(request.headers.get("Cookie")).toContain("mh_csrf=");
 					return HttpResponse.json([mockModel]);
 				}),
 				http.get("/api/providers", () => HttpResponse.json([mockProvider])),
@@ -49,7 +49,7 @@ describe("Arena", () => {
 			server.use(
 				http.get("/api/models", ({ request }) => {
 					modelsApiCalled = true;
-					expect(request.headers.get("Authorization")).toMatch(/Bearer /);
+					expect(request.headers.get("Cookie")).toContain("mh_csrf=");
 					return HttpResponse.json([mockModel]);
 				}),
 				http.get("/api/providers", () => HttpResponse.json([mockProvider])),

--- a/web/src/pages/__tests__/Dashboard.test.tsx
+++ b/web/src/pages/__tests__/Dashboard.test.tsx
@@ -598,7 +598,7 @@ describe("Dashboard", () => {
 			server.use(
 				http.get("/api/stats", ({ request }) => {
 					apiCalled = true;
-					expect(request.headers.get("Authorization")).toMatch(/Bearer /);
+					expect(request.headers.get("Cookie")).toContain("mh_csrf=");
 					return HttpResponse.json(mockStats);
 				}),
 			);
@@ -615,7 +615,7 @@ describe("Dashboard", () => {
 			server.use(
 				http.get("/api/models", ({ request }) => {
 					apiCalled = true;
-					expect(request.headers.get("Authorization")).toMatch(/Bearer /);
+					expect(request.headers.get("Cookie")).toContain("mh_csrf=");
 					return HttpResponse.json([mockModel]);
 				}),
 			);
@@ -632,7 +632,7 @@ describe("Dashboard", () => {
 			server.use(
 				http.get("/api/providers", ({ request }) => {
 					apiCalled = true;
-					expect(request.headers.get("Authorization")).toMatch(/Bearer /);
+					expect(request.headers.get("Cookie")).toContain("mh_csrf=");
 					return HttpResponse.json([mockProvider]);
 				}),
 			);

--- a/web/src/pages/__tests__/Logs.updates-api.test.tsx
+++ b/web/src/pages/__tests__/Logs.updates-api.test.tsx
@@ -123,7 +123,7 @@ describe("Logs", () => {
 			server.use(
 				http.get("/api/logs", ({ request }) => {
 					apiCalled = true;
-					expect(request.headers.get("Authorization")).toMatch(/Bearer /);
+					expect(request.headers.get("Cookie")).toContain("mh_csrf=");
 					return HttpResponse.json({
 						entries: [],
 						total: 0,

--- a/web/src/test/infrastructure.test.tsx
+++ b/web/src/test/infrastructure.test.tsx
@@ -40,9 +40,7 @@ describe("Test infrastructure", () => {
 			}),
 		);
 
-		const response = await fetch("/api/providers", {
-			headers: { Authorization: "Bearer test-admin-token" },
-		});
+		const response = await fetch("/api/providers");
 		const data = await response.json();
 
 		expect(data).toHaveLength(1);
@@ -56,9 +54,7 @@ describe("Test infrastructure", () => {
 			}),
 		);
 
-		const response = await fetch("/api/providers", {
-			headers: { Authorization: "Bearer test-admin-token" },
-		});
+		const response = await fetch("/api/providers");
 		const data = await response.json();
 		expect(data).toHaveLength(0);
 	});

--- a/web/src/test/mocks/handlers.ts
+++ b/web/src/test/mocks/handlers.ts
@@ -18,10 +18,12 @@ import {
 	mockVirtualKey,
 } from "./data";
 
-// Helper to check for valid auth header
+// Helper to check for a valid dashboard session. Cookie-session auth: the
+// session rides in the (httpOnly, in prod) mh_session cookie and a readable
+// mh_csrf cookie. Tests seed mh_csrf via document.cookie, which same-origin
+// fetch forwards to MSW as the Cookie header, so we gate on its presence.
 function hasValidAuth(request: Request): boolean {
-	const auth = request.headers.get("Authorization");
-	return auth?.startsWith("Bearer ") ?? false;
+	return request.headers.get("Cookie")?.includes("mh_csrf=") ?? false;
 }
 
 // Factory function to create fresh mock data arrays for each test.

--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -12,7 +12,6 @@ import "../i18n";
 // unchanged, so this only tolerates scheduling jitter, it does not hide failures.
 configure({ asyncUtilTimeout: 5000 });
 
-import { setAdminToken } from "../api/client";
 import { resetStore } from "./mocks/handlers";
 import { server } from "./mocks/server";
 
@@ -165,12 +164,21 @@ if (
 beforeAll(() => {
 	_suppressJsdomNotImplemented();
 	server.listen({ onUnhandledRequest: "warn" });
-	setAdminToken("test-admin-token");
+	// Cookie-session auth: seed the readable CSRF cookie so isAuthenticated()
+	// reports logged-in and same-origin requests carry the session cookie to the
+	// MSW handlers (which gate on mh_csrf). httpOnly cookies can't be set from JS,
+	// so the readable half stands in for the session in tests.
+	document.cookie = "mh_csrf=test-csrf; path=/";
 });
 
 afterEach(() => {
 	server.resetHandlers();
 	resetStore();
+	// Re-seed the session cookie between tests. A 401 response clears it (the api
+	// client's clearAuth on 401), and tests that exercise logged-out flows clear
+	// it in their own beforeEach; re-seeding here keeps the default state
+	// "logged in" and makes the suite order-independent.
+	document.cookie = "mh_csrf=test-csrf; path=/";
 });
 
 afterAll(() => {

--- a/web/src/utils/__tests__/oidc.test.ts
+++ b/web/src/utils/__tests__/oidc.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { consumeOidcError, consumeOidcToken } from "../oidc";
+import { consumeOidcError } from "../oidc";
 
 function setHash(h: string) {
 	window.location.hash = h;
@@ -8,38 +8,6 @@ function setHash(h: string) {
 function resetUrl() {
 	window.history.replaceState(null, "", "/");
 }
-
-describe("consumeOidcToken", () => {
-	beforeEach(() => {
-		localStorage.clear();
-		resetUrl();
-	});
-
-	it("returns false when there is no token fragment", () => {
-		expect(consumeOidcToken()).toBe(false);
-		expect(localStorage.getItem("adminToken")).toBeNull();
-	});
-
-	it("stores the decoded token and scrubs the fragment", () => {
-		setHash("#oidc_token=sk-abc%20123");
-		expect(consumeOidcToken()).toBe(true);
-		expect(localStorage.getItem("adminToken")).toBe("sk-abc 123");
-		expect(window.location.hash).toBe("");
-	});
-
-	it("does not crash on a malformed fragment and scrubs it", () => {
-		setHash("#oidc_token=%");
-		expect(consumeOidcToken()).toBe(false);
-		expect(localStorage.getItem("adminToken")).toBeNull();
-		expect(window.location.hash).toBe("");
-	});
-
-	it("returns false for an empty token", () => {
-		setHash("#oidc_token=");
-		expect(consumeOidcToken()).toBe(false);
-		expect(localStorage.getItem("adminToken")).toBeNull();
-	});
-});
 
 describe("consumeOidcError", () => {
 	beforeEach(() => {

--- a/web/src/utils/__tests__/webauthn.test.ts
+++ b/web/src/utils/__tests__/webauthn.test.ts
@@ -234,7 +234,7 @@ describe("webauthn utils", () => {
 			userVerification: "preferred",
 		} as PublicKeyCredentialRequestOptionsJSON;
 
-		it("successfully logs in with passkey and returns token", async () => {
+		it("successfully logs in with passkey and returns true", async () => {
 			server.use(
 				http.post("/api/webauthn/login/start", () =>
 					HttpResponse.json({
@@ -242,8 +242,9 @@ describe("webauthn utils", () => {
 						options: mockOptions,
 					}),
 				),
+				// The server sets the session cookie pair; the body carries no token.
 				http.post("/api/webauthn/login/finish", () =>
-					HttpResponse.json({ token: "mock-token-123" }),
+					HttpResponse.json({ success: true }),
 				),
 			);
 			vi.spyOn(simplewebauthn, "startAuthentication").mockResolvedValue({
@@ -259,10 +260,10 @@ describe("webauthn utils", () => {
 				clientExtensionResults: {},
 			});
 			const result = await webauthn.loginWithPasskey();
-			expect(result).toBe("mock-token-123");
+			expect(result).toBe(true);
 		});
 
-		it("returns null when user cancels (NotAllowedError)", async () => {
+		it("returns false when user cancels (NotAllowedError)", async () => {
 			server.use(
 				http.post("/api/webauthn/login/start", () =>
 					HttpResponse.json({
@@ -275,7 +276,7 @@ describe("webauthn utils", () => {
 				new MockDOMError("User cancelled", "NotAllowedError"),
 			);
 			const result = await webauthn.loginWithPasskey();
-			expect(result).toBe(null);
+			expect(result).toBe(false);
 		});
 
 		it("throws on other errors", async () => {

--- a/web/src/utils/oidc.ts
+++ b/web/src/utils/oidc.ts
@@ -1,11 +1,8 @@
-// Helpers for the OIDC SSO callback hand-off. The backend callback redirects the
-// browser to the SPA with the result in the URL *fragment* (never the query
-// string), so the session token is not sent back to the server on the follow-up
-// request (no Referer leak, nothing in request logs). It does still appear in the
-// callback's 302 Location response header, so operators should redact Location on
-// /api/auth/oidc/callback in proxy access logs.
+// Helpers for the OIDC SSO callback hand-off. On success the backend callback
+// sets the session cookie pair and redirects to a clean `/` (no token in the URL
+// at all), so the app boots logged in purely from the cookie. On failure it
+// redirects to `/#oidc_error=<code>`; consumeOidcError turns that into a message.
 
-const TOKEN_PREFIX = "#oidc_token=";
 const ERROR_PREFIX = "#oidc_error=";
 
 /** scrubHash removes the fragment without adding a history entry. */
@@ -25,22 +22,6 @@ function safeDecode(s: string): string {
 	} catch {
 		return "";
 	}
-}
-
-/**
- * consumeOidcToken stores an SSO session token delivered in the URL fragment
- * (the same `adminToken` slot the other login paths use) and scrubs the
- * fragment. Returns true when a token was consumed. Call this synchronously
- * before the app reads the stored token so an SSO redirect boots logged in.
- */
-export function consumeOidcToken(): boolean {
-	const hash = window.location.hash;
-	if (!hash.startsWith(TOKEN_PREFIX)) return false;
-	const token = safeDecode(hash.slice(TOKEN_PREFIX.length));
-	scrubHash();
-	if (!token) return false;
-	localStorage.setItem("adminToken", token);
-	return true;
 }
 
 /**

--- a/web/src/utils/webauthn.ts
+++ b/web/src/utils/webauthn.ts
@@ -58,17 +58,21 @@ export async function registerPasskey(): Promise<boolean> {
 	}
 }
 
-export async function loginWithPasskey(): Promise<string | null> {
+// loginWithPasskey drives a passkey assertion and returns true on success. The
+// server sets the session cookie pair on loginFinish, so there is no token to
+// hand back; reaching the end without throwing means we are logged in. Returns
+// false when the user dismisses the browser prompt (NotAllowedError).
+export async function loginWithPasskey(): Promise<boolean> {
 	try {
 		const { session_id, options } = await api.webauthn.loginStart();
 		const credential = await startAuthentication({
 			optionsJSON: options as unknown as PublicKeyCredentialRequestOptionsJSON,
 		});
-		const { token } = await api.webauthn.loginFinish(session_id, credential);
-		return token;
+		await api.webauthn.loginFinish(session_id, credential);
+		return true;
 	} catch (err) {
 		if (err instanceof Error && err.name === "NotAllowedError") {
-			return null;
+			return false;
 		}
 		throw err;
 	}


### PR DESCRIPTION
## Summary

Migrates the **dashboard** (`web/`) session auth from localStorage bearer tokens to **httpOnly session cookies + double-submit CSRF**. Because the app is multi-user, per-user session tokens sitting in `localStorage` were exfiltratable by any XSS (including stored XSS rendered in another user's dashboard) — cross-user, replayable off-device. `httpOnly` makes the session token unreadable to JS, closing that path (defense in depth on top of the existing CSP/escaping).

Follows the design + plan in `plans/2026-07-20-httponly-cookie-auth-migration-*.md` (gitignored). Grew out of the Strix-flagged `client.ts` comment that recommended exactly this switch.

## What changed

- **`internal/authcookie`** (new) — single source for the `mh_session` (HttpOnly) + `mh_csrf` (readable) cookies, `SameSite=Strict`, conditional `Secure` via new `COOKIE_SECURE=auto|always|never`, constant-time CSRF compare, `Secure`/safe-method helpers.
- **Middlewares** (`AuthMiddleware`, `RequireAdminOrSession`) — additive: read the session token from `mh_session` first and enforce CSRF on cookie-authenticated unsafe methods; the existing `Authorization: Bearer` header path is left **verbatim**. The admin-only privilege gate (CWE-863) is preserved.
- **Mint paths** — password, TOTP, WebAuthn, OIDC, GitHub now deliver via cookie; OIDC/GitHub redirect to a clean `/` (token removed from the URL). New `POST /api/auth/admin-exchange` bootstrap (admin-token paste → cookie) and always-mounted `POST /api/auth/logout` (revoke + clear).
- **Frontend** — `client.ts` cookie transport + `X-CSRF-Token` on mutations, `isAuthenticated()` from the `mh_csrf` cookie, `401 → login`; login/logout/SSO flows de-tokenized; SSE `Authorization` header dropped.

## Front Desk preserved (design decision)

TOTP, WebAuthn, and OIDC handlers are **shared** with Front Desk (which uses bearer/localStorage). They branch on a `useCookieAuth` flag: the dashboard passes `true`, Front Desk passes `false` and keeps its legacy token-in-body / fragment-redirect / no-Set-Cookie-on-logout behavior. **`frontdesk/` has zero changes.** The `/v1` virtual-key proxy and the admin token's machine-to-machine header use are untouched.

## Verification

- `go build ./...`, `golangci-lint run ./...` clean; **full api suite green** (174s) + authcookie/config/adminauth/webauthn suites.
- Frontend **5422 tests pass**, `tsc -b` + ESLint + Biome clean.
- **Live container smoke** (rebuilt image): M2M header auth 200; admin-exchange sets HttpOnly `mh_session` (30d) + `mh_csrf`; cookie auth 200; CSRF 403-without / 400-with; logout clears the cookie.
- Whole-branch review: all cross-cutting invariants confirmed (no token in JS/localStorage/URL, CSRF coherent, FD byte-identical, M2M/`/v1` untouched, no lockout path).

## Notes for reviewers

- Two known **non-blocking Minors**: `TestCookieSecure` doesn't assert the unknown-value→`auto` branch (logic is a correct 3-way switch); the `/api/auth/admin-exchange` 401 path has no dedicated warn-log (the `/api` per-IP limiter still counts attempts).
- **Browser SSO E2E** (live OIDC/GitHub) was not exercised here (needs configured providers) — worth a manual pass in a real deployment.
- Rollout is a hard cut: after upgrade, users re-log-in once. Sessions are per-instance (no fleet-sync interaction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)