### PR TITLE
feat: fleet quota distribution via Front Desk (phase 2)

### DIFF
--- a/cmd/frontdesk/main.go
+++ b/cmd/frontdesk/main.go
@@ -142,6 +142,7 @@ func main() {
 
 	go poller.Run(ctx)
 	go srv.RunAutoSync(ctx)
+	go srv.RunQuotaDistribute(ctx)
 	go srv.RunFleetState(ctx)
 	go srv.RunAlerts(ctx)
 

--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -361,6 +361,11 @@ func (h *Handler) registerAdminOnly(r chi.Router) {
 			return err
 		}, h.cfg.ValidateProviderURL).Register(r)
 
+	// Fleet quota snapshot export/receive (quota poller Phase 2). Same
+	// fleet-authed router as config-sync; snapshots carry no key material, so
+	// unlike config import there is no MASTER_KEY canary.
+	NewQuotaFleetHandler(h.quotaRepo, h.providerRepo).Register(r)
+
 	// HA fleet membership heartbeat (Phase 6). Front Desk POSTs /fleet/announce
 	// on its poll; the member records the contact as instance-local _fleet_*
 	// settings and surfaces fleet state on its system payload. Inherits this

--- a/internal/api/quota_fleet.go
+++ b/internal/api/quota_fleet.go
@@ -1,0 +1,78 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+
+	"github.com/hugalafutro/model-hotel/internal/quota"
+)
+
+// QuotaSnapshotWire is a quota snapshot keyed by provider NAME (not UUID) so a
+// receiving member maps it onto its own provider IDs, matching the name-keyed
+// contract config-sync already uses.
+type QuotaSnapshotWire struct {
+	ProviderName string          `json:"provider_name"`
+	Kind         string          `json:"kind"`
+	Payload      json.RawMessage `json:"payload"`
+	HTTPStatus   int             `json:"http_status"`
+	FetchedAt    time.Time       `json:"fetched_at"`
+}
+
+// QuotaFleetHandler serves and receives fleet quota snapshots. It mounts on the
+// same fleet-authed router as config-sync (see ConfigSyncHandler.Register), so
+// it inherits that router's fleet auth. Quota snapshots carry no key material,
+// so unlike config import there is no MASTER_KEY canary.
+type QuotaFleetHandler struct {
+	quotaRepo    *quota.Repository
+	providerRepo ProviderStore
+}
+
+// NewQuotaFleetHandler builds a QuotaFleetHandler.
+func NewQuotaFleetHandler(quotaRepo *quota.Repository, providerRepo ProviderStore) *QuotaFleetHandler {
+	return &QuotaFleetHandler{quotaRepo: quotaRepo, providerRepo: providerRepo}
+}
+
+// Register mounts the fleet quota routes on the given (fleet-authed) router.
+func (h *QuotaFleetHandler) Register(r chi.Router) {
+	r.Get("/config/quota-snapshots", h.ExportSnapshots)
+}
+
+// ExportSnapshots serves this node's quota snapshots keyed by provider name so a
+// consumer maps them onto its own provider IDs.
+func (h *QuotaFleetHandler) ExportSnapshots(w http.ResponseWriter, r *http.Request) {
+	snaps, err := h.quotaRepo.List(r.Context())
+	if err != nil {
+		respondError(w, "failed to list quota snapshots", err, http.StatusInternalServerError)
+		return
+	}
+	provs, err := h.providerRepo.List(r.Context())
+	if err != nil {
+		respondError(w, "failed to list providers", err, http.StatusInternalServerError)
+		return
+	}
+
+	idToName := make(map[uuid.UUID]string, len(provs))
+	for _, p := range provs {
+		idToName[p.ID] = p.Name
+	}
+
+	wire := make([]QuotaSnapshotWire, 0, len(snaps))
+	for _, s := range snaps {
+		name, ok := idToName[s.ProviderID]
+		if !ok {
+			continue // provider deleted since the snapshot was stored; skip it
+		}
+		wire = append(wire, QuotaSnapshotWire{
+			ProviderName: name,
+			Kind:         s.Kind,
+			Payload:      s.Payload,
+			HTTPStatus:   s.HTTPStatus,
+			FetchedAt:    s.FetchedAt,
+		})
+	}
+	writeJSON(w, map[string]any{"snapshots": wire})
+}

--- a/internal/api/quota_fleet.go
+++ b/internal/api/quota_fleet.go
@@ -63,6 +63,14 @@ func (h *QuotaFleetHandler) ExportSnapshots(w http.ResponseWriter, r *http.Reque
 
 	wire := make([]QuotaSnapshotWire, 0, len(snaps))
 	for _, s := range snaps {
+		if s.HTTPStatus == 0 {
+			// Failure placeholder from RecordFailure (no successful fetch yet): it
+			// carries no real payload but a fresh fetched_at. Distributing it as
+			// source='fleet' would suppress a member's own (potentially successful)
+			// poll, so it is never worse than standalone only if we drop it here. A
+			// real fetch always has a non-zero HTTP status (200/204/424, ...).
+			continue
+		}
 		name, ok := idToName[s.ProviderID]
 		if !ok {
 			continue // provider deleted since the snapshot was stored; skip it

--- a/internal/api/quota_fleet.go
+++ b/internal/api/quota_fleet.go
@@ -39,6 +39,7 @@ func NewQuotaFleetHandler(quotaRepo *quota.Repository, providerRepo ProviderStor
 // Register mounts the fleet quota routes on the given (fleet-authed) router.
 func (h *QuotaFleetHandler) Register(r chi.Router) {
 	r.Get("/config/quota-snapshots", h.ExportSnapshots)
+	r.Post("/config/quota-snapshots", h.ReceiveSnapshots)
 }
 
 // ExportSnapshots serves this node's quota snapshots keyed by provider name so a
@@ -75,4 +76,55 @@ func (h *QuotaFleetHandler) ExportSnapshots(w http.ResponseWriter, r *http.Reque
 		})
 	}
 	writeJSON(w, map[string]any{"snapshots": wire})
+}
+
+// ReceiveSnapshots stores fleet-distributed snapshots, mapping each by provider
+// name onto this member's own provider IDs and writing with UpsertIfNewer so an
+// older fleet write never clobbers a fresher local (e.g. manual) snapshot. A
+// name with no local provider is skipped. Written with source='fleet'.
+func (h *QuotaFleetHandler) ReceiveSnapshots(w http.ResponseWriter, r *http.Request) {
+	var in struct {
+		Snapshots []QuotaSnapshotWire `json:"snapshots"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+		http.Error(w, "invalid body", http.StatusBadRequest)
+		return
+	}
+
+	provs, err := h.providerRepo.List(r.Context())
+	if err != nil {
+		respondError(w, "failed to list providers", err, http.StatusInternalServerError)
+		return
+	}
+	nameToID := make(map[string]uuid.UUID, len(provs))
+	for _, p := range provs {
+		nameToID[p.Name] = p.ID
+	}
+
+	applied, skipped := 0, 0
+	for _, s := range in.Snapshots {
+		pid, ok := nameToID[s.ProviderName]
+		if !ok {
+			skipped++ // provider not present on this member
+			continue
+		}
+		wrote, err := h.quotaRepo.UpsertIfNewer(r.Context(), quota.Snapshot{
+			ProviderID: pid,
+			Kind:       s.Kind,
+			Payload:    s.Payload,
+			HTTPStatus: s.HTTPStatus,
+			Source:     "fleet",
+			FetchedAt:  s.FetchedAt,
+		})
+		if err != nil {
+			respondError(w, "failed to store snapshot", err, http.StatusInternalServerError)
+			return
+		}
+		if wrote {
+			applied++
+		} else {
+			skipped++
+		}
+	}
+	writeJSON(w, map[string]any{"applied": applied, "skipped": skipped})
 }

--- a/internal/api/quota_fleet_test.go
+++ b/internal/api/quota_fleet_test.go
@@ -9,9 +9,19 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-chi/chi/v5"
+
 	"github.com/hugalafutro/model-hotel/internal/provider"
 	"github.com/hugalafutro/model-hotel/internal/quota"
 )
+
+// cancelledRequest builds a request whose context is already cancelled, so the
+// first DB call the handler makes fails, exercising the store-error branches.
+func cancelledRequest(method, target, body string) *http.Request {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	return httptest.NewRequest(method, target, strings.NewReader(body)).WithContext(ctx)
+}
 
 func TestQuotaFleetExportSnapshots(t *testing.T) {
 	h := newTestHandler(t)
@@ -185,5 +195,91 @@ func TestQuotaFleetReceiveSnapshots_SkipsOlder(t *testing.T) {
 	}
 	if err := json.Unmarshal(snap.Payload, &got); err != nil || got.Used != 99 {
 		t.Fatalf("expected the newer manual payload used=99 to survive, got %s (err %v)", snap.Payload, err)
+	}
+}
+
+// TestQuotaFleetRegisterMountsRoutes: Register wires the export/receive routes on
+// the given router so both respond.
+func TestQuotaFleetRegisterMountsRoutes(t *testing.T) {
+	h := newTestHandler(t)
+	r := chi.NewRouter()
+	NewQuotaFleetHandler(h.quotaRepo, h.providerRepo).Register(r)
+
+	for _, tc := range []struct {
+		method, body string
+	}{
+		{http.MethodGet, ""},
+		{http.MethodPost, `{"snapshots":[]}`},
+	} {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(tc.method, "/config/quota-snapshots", strings.NewReader(tc.body))
+		r.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("%s: want 200, got %d: %s", tc.method, rr.Code, rr.Body.String())
+		}
+	}
+}
+
+// TestQuotaFleetExportListError: a store failure listing snapshots surfaces a 500.
+func TestQuotaFleetExportListError(t *testing.T) {
+	h := newTestHandler(t)
+	fleet := NewQuotaFleetHandler(h.quotaRepo, h.providerRepo)
+
+	rr := httptest.NewRecorder()
+	fleet.ExportSnapshots(rr, cancelledRequest(http.MethodGet, "/config/quota-snapshots", ""))
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("want 500 on store error, got %d", rr.Code)
+	}
+}
+
+// TestQuotaFleetReceiveInvalidBody: a malformed request body is a 400.
+func TestQuotaFleetReceiveInvalidBody(t *testing.T) {
+	h := newTestHandler(t)
+	fleet := NewQuotaFleetHandler(h.quotaRepo, h.providerRepo)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/config/quota-snapshots", strings.NewReader("not json"))
+	fleet.ReceiveSnapshots(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("want 400 on bad body, got %d", rr.Code)
+	}
+}
+
+// TestQuotaFleetReceiveProviderListError: a store failure listing providers (the
+// body decodes fine first) surfaces a 500.
+func TestQuotaFleetReceiveProviderListError(t *testing.T) {
+	h := newTestHandler(t)
+	fleet := NewQuotaFleetHandler(h.quotaRepo, h.providerRepo)
+
+	rr := httptest.NewRecorder()
+	fleet.ReceiveSnapshots(rr, cancelledRequest(http.MethodPost, "/config/quota-snapshots", `{"snapshots":[]}`))
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("want 500 on store error, got %d", rr.Code)
+	}
+}
+
+// TestQuotaFleetReceiveSkipsUnknownProvider: a snapshot for a provider name not
+// present on this member is skipped, not applied.
+func TestQuotaFleetReceiveSkipsUnknownProvider(t *testing.T) {
+	h := newTestHandler(t)
+	fleet := NewQuotaFleetHandler(h.quotaRepo, h.providerRepo)
+
+	body := `{"snapshots":[{"provider_name":"does-not-exist-here","kind":"usage","payload":{"used":1},"http_status":200,"fetched_at":"` + time.Now().UTC().Format(time.RFC3339) + `"}]}`
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/config/quota-snapshots", strings.NewReader(body))
+	fleet.ReceiveSnapshots(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var out struct {
+		Applied int `json:"applied"`
+		Skipped int `json:"skipped"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out.Applied != 0 || out.Skipped != 1 {
+		t.Fatalf("unknown provider must be skipped, got applied=%d skipped=%d", out.Applied, out.Skipped)
 	}
 }

--- a/internal/api/quota_fleet_test.go
+++ b/internal/api/quota_fleet_test.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/hugalafutro/model-hotel/internal/provider"
 	"github.com/hugalafutro/model-hotel/internal/quota"
@@ -50,5 +52,84 @@ func TestQuotaFleetExportSnapshots(t *testing.T) {
 	}
 	if body.Snapshots[0].ProviderName != prov.Name || body.Snapshots[0].Kind != "usage" {
 		t.Fatalf("unexpected export: %+v", body.Snapshots[0])
+	}
+}
+
+func TestQuotaFleetReceiveSnapshots_UpsertsAsFleet(t *testing.T) {
+	h := newTestHandler(t)
+	fleet := NewQuotaFleetHandler(h.quotaRepo, h.providerRepo)
+
+	prov, err := h.providerRepo.Create(context.Background(), provider.CreateProviderRequest{
+		Name:    "nano-recv",
+		BaseURL: "https://api.nano-gpt.com",
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("create provider: %v", err)
+	}
+
+	body := `{"snapshots":[{"provider_name":"` + prov.Name + `","kind":"usage","payload":{"used":8},"http_status":200,"fetched_at":"` + time.Now().UTC().Format(time.RFC3339) + `"}]}`
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/config/quota-snapshots", strings.NewReader(body))
+	fleet.ReceiveSnapshots(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	snap, _ := h.quotaRepo.Get(context.Background(), prov.ID, "usage")
+	if snap == nil || snap.Source != "fleet" {
+		t.Fatalf("receive should upsert a fleet snapshot, got %+v", snap)
+	}
+	// JSONB re-serializes (adds a space after ':'), so compare by value.
+	var got struct {
+		Used int `json:"used"`
+	}
+	if err := json.Unmarshal(snap.Payload, &got); err != nil || got.Used != 8 {
+		t.Fatalf("expected used=8 fleet payload, got %s (err %v)", snap.Payload, err)
+	}
+}
+
+func TestQuotaFleetReceiveSnapshots_SkipsOlder(t *testing.T) {
+	h := newTestHandler(t)
+	fleet := NewQuotaFleetHandler(h.quotaRepo, h.providerRepo)
+
+	prov, err := h.providerRepo.Create(context.Background(), provider.CreateProviderRequest{
+		Name:    "nano-recv-older",
+		BaseURL: "https://api.nano-gpt.com",
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("create provider: %v", err)
+	}
+
+	// A newer local manual snapshot must survive an older incoming fleet write.
+	if err := h.quotaRepo.Upsert(context.Background(), quota.Snapshot{
+		ProviderID: prov.ID,
+		Kind:       "usage",
+		Payload:    json.RawMessage(`{"used":99}`),
+		HTTPStatus: 200,
+		Source:     "manual",
+		FetchedAt:  time.Now(),
+	}); err != nil {
+		t.Fatalf("seed manual snapshot: %v", err)
+	}
+
+	old := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+	body := `{"snapshots":[{"provider_name":"` + prov.Name + `","kind":"usage","payload":{"used":1},"http_status":200,"fetched_at":"` + old + `"}]}`
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/config/quota-snapshots", strings.NewReader(body))
+	fleet.ReceiveSnapshots(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	snap, _ := h.quotaRepo.Get(context.Background(), prov.ID, "usage")
+	if snap == nil || snap.Source != "manual" {
+		t.Fatalf("older fleet write must not clobber newer manual, got %+v", snap)
+	}
+	// JSONB re-serializes (adds a space after ':'), so compare by value.
+	var got struct {
+		Used int `json:"used"`
+	}
+	if err := json.Unmarshal(snap.Payload, &got); err != nil || got.Used != 99 {
+		t.Fatalf("expected the newer manual payload used=99 to survive, got %s (err %v)", snap.Payload, err)
 	}
 }

--- a/internal/api/quota_fleet_test.go
+++ b/internal/api/quota_fleet_test.go
@@ -1,0 +1,54 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hugalafutro/model-hotel/internal/provider"
+	"github.com/hugalafutro/model-hotel/internal/quota"
+)
+
+func TestQuotaFleetExportSnapshots(t *testing.T) {
+	h := newTestHandler(t)
+	fleet := NewQuotaFleetHandler(h.quotaRepo, h.providerRepo)
+
+	prov, err := h.providerRepo.Create(context.Background(), provider.CreateProviderRequest{
+		Name:    "nano-export",
+		BaseURL: "https://api.nano-gpt.com",
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("create provider: %v", err)
+	}
+	if err := h.quotaRepo.Upsert(context.Background(), quota.Snapshot{
+		ProviderID: prov.ID,
+		Kind:       "usage",
+		Payload:    json.RawMessage(`{"used":4}`),
+		HTTPStatus: 200,
+		Source:     "poll",
+	}); err != nil {
+		t.Fatalf("upsert snapshot: %v", err)
+	}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/config/quota-snapshots", http.NoBody)
+	fleet.ExportSnapshots(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var body struct {
+		Snapshots []QuotaSnapshotWire `json:"snapshots"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Snapshots) != 1 {
+		t.Fatalf("want 1 snapshot, got %d: %+v", len(body.Snapshots), body.Snapshots)
+	}
+	if body.Snapshots[0].ProviderName != prov.Name || body.Snapshots[0].Kind != "usage" {
+		t.Fatalf("unexpected export: %+v", body.Snapshots[0])
+	}
+}

--- a/internal/api/quota_fleet_test.go
+++ b/internal/api/quota_fleet_test.go
@@ -55,6 +55,60 @@ func TestQuotaFleetExportSnapshots(t *testing.T) {
 	}
 }
 
+// TestQuotaFleetExportSkipsFailurePlaceholders: RecordFailure leaves a
+// placeholder row (http_status=0, no real payload, fresh fetched_at). It must
+// not be distributed, or a member would store it as source='fleet' and suppress
+// its own (potentially successful) poll while that empty row looks fresh.
+func TestQuotaFleetExportSkipsFailurePlaceholders(t *testing.T) {
+	h := newTestHandler(t)
+	fleet := NewQuotaFleetHandler(h.quotaRepo, h.providerRepo)
+
+	failed, err := h.providerRepo.Create(context.Background(), provider.CreateProviderRequest{
+		Name:    "failed-only",
+		BaseURL: "https://api.nano-gpt.com",
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("create failed provider: %v", err)
+	}
+	if err := h.quotaRepo.RecordFailure(context.Background(), failed.ID, "usage", "boom"); err != nil {
+		t.Fatalf("record failure: %v", err)
+	}
+
+	okProv, err := h.providerRepo.Create(context.Background(), provider.CreateProviderRequest{
+		Name:    "ok-provider",
+		BaseURL: "https://api.nano-gpt.com",
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("create ok provider: %v", err)
+	}
+	if err := h.quotaRepo.Upsert(context.Background(), quota.Snapshot{
+		ProviderID: okProv.ID,
+		Kind:       "usage",
+		Payload:    json.RawMessage(`{"used":4}`),
+		HTTPStatus: 200,
+		Source:     "poll",
+	}); err != nil {
+		t.Fatalf("upsert ok snapshot: %v", err)
+	}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/config/quota-snapshots", http.NoBody)
+	fleet.ExportSnapshots(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var body struct {
+		Snapshots []QuotaSnapshotWire `json:"snapshots"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Snapshots) != 1 || body.Snapshots[0].ProviderName != okProv.Name {
+		t.Fatalf("only the successful snapshot should export, got %+v", body.Snapshots)
+	}
+}
+
 func TestQuotaFleetReceiveSnapshots_UpsertsAsFleet(t *testing.T) {
 	h := newTestHandler(t)
 	fleet := NewQuotaFleetHandler(h.quotaRepo, h.providerRepo)

--- a/internal/api/quota_snapshot.go
+++ b/internal/api/quota_snapshot.go
@@ -126,11 +126,24 @@ func (h *Handler) PollQuotasOnce(ctx context.Context) {
 		if !prov.Enabled {
 			continue
 		}
-		if _, ok := quotaKindFor(provider.DetectProviderType(prov.BaseURL)); !ok {
+		kind, ok := quotaKindFor(provider.DetectProviderType(prov.BaseURL))
+		if !ok {
 			continue
 		}
+
+		// Fleet dedup: if Front Desk recently distributed a snapshot for this
+		// provider, skip the upstream call. The primary (and any node FD is not
+		// feeding) has no recent fleet snapshot and still self-polls, so quota is
+		// never worse than standalone.
+		interval := time.Duration(h.settingsRepo.GetInt(ctx, "quota_refresh_interval_min", 5)) * time.Minute
+		if interval > 0 {
+			if snap, _ := h.quotaRepo.Get(ctx, prov.ID, kind); snap != nil && snap.Source == "fleet" && time.Since(snap.FetchedAt) < interval {
+				continue
+			}
+		}
+
 		provCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-		kind, payload, status, ferr := fetchQuotaSnapshot(provCtx, disc, prov, h.cfg.MasterKey)
+		_, payload, status, ferr := fetchQuotaSnapshot(provCtx, disc, prov, h.cfg.MasterKey)
 		if ferr != nil {
 			debuglog.Warn("quota: poll fetch failed", "provider", prov.Name, "error", ferr)
 			if rerr := h.quotaRepo.RecordFailure(provCtx, prov.ID, kind, ferr.Error()); rerr != nil {

--- a/internal/api/quota_snapshot_test.go
+++ b/internal/api/quota_snapshot_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/hugalafutro/model-hotel/internal/provider"
+	"github.com/hugalafutro/model-hotel/internal/quota"
 )
 
 func TestQuotaKindFor(t *testing.T) {
@@ -160,6 +161,67 @@ func nanoGPTPollDiscovery(used int64) *provider.DiscoveryService {
 
 // TestPollQuotasOnce_UpsertsEnabledProviders verifies the poll pass fetches an
 // enabled quota-capable provider and stores a fresh source="poll" snapshot.
+// TestPollQuotasOnce_SuppressesWhenRecentFleetSnapshot verifies a member fed by
+// Front Desk does not also hit upstream while a recent fleet snapshot exists.
+func TestPollQuotasOnce_SuppressesWhenRecentFleetSnapshot(t *testing.T) {
+	h := newTestHandler(t)
+	id := insertQuotaPollProvider(t, h.dbPool.Pool(), "nanogpt-fleet-recent", "https://api.nano-gpt.com/v1", true)
+
+	// A recent fleet-distributed snapshot already exists.
+	if err := h.quotaRepo.Upsert(context.Background(), quota.Snapshot{
+		ProviderID: id, Kind: "usage", Payload: json.RawMessage(`{"used":1}`), HTTPStatus: 200, Source: "fleet", FetchedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("seed fleet snapshot: %v", err)
+	}
+
+	called := false
+	orig := newDiscoveryService
+	defer func() { newDiscoveryService = orig }()
+	newDiscoveryService = func() *provider.DiscoveryService {
+		return provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
+			Transport: &mockTransport{roundTripFunc: func(_ *http.Request) (*http.Response, error) {
+				called = true
+				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("{}")), Header: make(http.Header)}, nil
+			}},
+		})
+	}
+
+	h.PollQuotasOnce(context.Background())
+
+	if called {
+		t.Fatal("poll must not hit upstream while a recent fleet snapshot exists")
+	}
+	snap, _ := h.quotaRepo.Get(context.Background(), id, "usage")
+	if snap == nil || snap.Source != "fleet" {
+		t.Fatalf("the fleet snapshot should remain untouched, got %+v", snap)
+	}
+}
+
+// TestPollQuotasOnce_PollsWhenFleetSnapshotStale verifies a stale fleet snapshot
+// does not suppress the self-poll, so quota is never worse than standalone.
+func TestPollQuotasOnce_PollsWhenFleetSnapshotStale(t *testing.T) {
+	h := newTestHandler(t)
+	id := insertQuotaPollProvider(t, h.dbPool.Pool(), "nanogpt-fleet-stale", "https://api.nano-gpt.com/v1", true)
+
+	// A stale fleet snapshot (older than the poll interval) must not suppress.
+	if err := h.quotaRepo.Upsert(context.Background(), quota.Snapshot{
+		ProviderID: id, Kind: "usage", Payload: json.RawMessage(`{"used":1}`), HTTPStatus: 200, Source: "fleet", FetchedAt: time.Now().Add(-2 * time.Hour),
+	}); err != nil {
+		t.Fatalf("seed stale fleet snapshot: %v", err)
+	}
+
+	orig := newDiscoveryService
+	defer func() { newDiscoveryService = orig }()
+	newDiscoveryService = func() *provider.DiscoveryService { return nanoGPTPollDiscovery(2) }
+
+	h.PollQuotasOnce(context.Background())
+
+	snap, _ := h.quotaRepo.Get(context.Background(), id, "usage")
+	if snap == nil || snap.Source != "poll" {
+		t.Fatalf("stale fleet snapshot should fall back to self-poll, got %+v", snap)
+	}
+}
+
 func TestPollQuotasOnce_UpsertsEnabledProviders(t *testing.T) {
 	h := newTestHandler(t)
 	id := insertQuotaPollProvider(t, h.dbPool.Pool(), "nanogpt-poll", "https://api.nano-gpt.com/v1", true)

--- a/internal/frontdesk/quota_distribute.go
+++ b/internal/frontdesk/quota_distribute.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"net/http"
+	"time"
 
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 )
@@ -12,6 +13,31 @@ import (
 // mounted on the same fleet-authed router as config export/import (see
 // internal/api QuotaFleetHandler.Register), so it lives under /api/config.
 const memberQuotaSnapshotsPath = "/api/config/quota-snapshots"
+
+// quotaDistributeInterval is how often Front Desk redistributes the primary's
+// quota snapshots to the fleet. It is kept well under the member's quota-poll
+// interval (default 5 min) so a member Front Desk feeds always has a fresh fleet
+// snapshot and stays suppressed rather than falling back to its own upstream
+// poll. Redundant passes are cheap: the member applies with skip-if-newer, so an
+// unchanged snapshot is a no-op write. It is a var so tests can drive a tick.
+var quotaDistributeInterval = 60 * time.Second
+
+// RunQuotaDistribute runs the quota-distribution pass on a fixed tick until ctx
+// is cancelled. It is started once at startup, alongside RunAutoSync, and
+// mirrors that loop: a Front-Desk-owned ticker driving a best-effort,
+// error-free pass over the fleet.
+func (s *Server) RunQuotaDistribute(ctx context.Context) {
+	ticker := time.NewTicker(quotaDistributeInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.DistributeQuotaOnce(ctx)
+		}
+	}
+}
 
 // DistributeQuotaOnce fetches the designated primary's quota snapshots and posts
 // them to every other member, so members do not each poll the same upstream

--- a/internal/frontdesk/quota_distribute.go
+++ b/internal/frontdesk/quota_distribute.go
@@ -1,0 +1,71 @@
+package frontdesk
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+
+	"github.com/hugalafutro/model-hotel/internal/debuglog"
+)
+
+// memberQuotaSnapshotsPath is the fleet quota endpoint on each member. It is
+// mounted on the same fleet-authed router as config export/import (see
+// internal/api QuotaFleetHandler.Register), so it lives under /api/config.
+const memberQuotaSnapshotsPath = "/api/config/quota-snapshots"
+
+// DistributeQuotaOnce fetches the designated primary's quota snapshots and posts
+// them to every other member, so members do not each poll the same upstream
+// account. It mirrors the FD-orchestrated config-sync path (autoSyncOnce): the
+// primary is the read source, Front Desk only relays the snapshots (they carry
+// no key material), and members apply them with skip-if-newer so an older fleet
+// write never clobbers a fresher local one.
+//
+// Best-effort and error-free: the primary or any member being unreachable is
+// logged at debug and skipped, and those members fall back to their own
+// self-poll. It is a no-op when no primary is designated (standalone or a fleet
+// that has not been set up yet), which is what the receiving member's suppression
+// relies on: a node Front Desk is not feeding has no recent fleet snapshot and
+// keeps self-polling.
+func (s *Server) DistributeQuotaOnce(ctx context.Context) {
+	cfg, err := s.store.GetAutoSync(ctx)
+	if err != nil {
+		debuglog.Warn("frontdesk: quota distribute: read auto-sync config", "error", err)
+		return
+	}
+	if cfg.PrimaryID == "" {
+		return // no primary designated: nothing to distribute from
+	}
+
+	primary, primaryToken, err := s.memberTokenOrErr(ctx, cfg.PrimaryID)
+	if err != nil {
+		// The designated primary was removed or lost its token; retry next tick.
+		debuglog.Debug("frontdesk: quota distribute: primary unavailable", "error", err)
+		return
+	}
+	status, body, err := s.callMember(ctx, http.MethodGet, primary.URL, memberQuotaSnapshotsPath, primaryToken, nil)
+	if err != nil || status != http.StatusOK {
+		debuglog.Debug("frontdesk: quota distribute: fetch primary snapshots",
+			"member", primary.Name, "status", status, "error", err)
+		return
+	}
+
+	members, err := s.store.ListMembers(ctx)
+	if err != nil {
+		debuglog.Warn("frontdesk: quota distribute: list members", "error", err)
+		return
+	}
+	for _, m := range members {
+		if m.ID == cfg.PrimaryID {
+			continue // the primary is the source, not a destination
+		}
+		_, token, err := s.memberTokenOrErr(ctx, m.ID)
+		if err != nil {
+			debuglog.Debug("frontdesk: quota distribute: member token", "member", m.Name, "error", err)
+			continue
+		}
+		if status, _, err := s.callMember(ctx, http.MethodPost, m.URL, memberQuotaSnapshotsPath, token, bytes.NewReader(body)); err != nil || status != http.StatusOK {
+			debuglog.Debug("frontdesk: quota distribute: push to member",
+				"member", m.Name, "status", status, "error", err)
+		}
+	}
+}

--- a/internal/frontdesk/quota_distribute_test.go
+++ b/internal/frontdesk/quota_distribute_test.go
@@ -19,12 +19,14 @@ type stubQuotaMember struct {
 	srv        *httptest.Server
 	token      string
 	exportBody string
+	getCode    int // status for the export GET (default 200)
+	postCode   int // status for the receive POST (default 200)
 	posted     [][]byte
 }
 
 func newStubQuotaMember(t *testing.T, token, exportBody string) *stubQuotaMember {
 	t.Helper()
-	sm := &stubQuotaMember{token: token, exportBody: exportBody}
+	sm := &stubQuotaMember{token: token, exportBody: exportBody, getCode: http.StatusOK, postCode: http.StatusOK}
 	sm.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") != "Bearer "+sm.token {
 			w.WriteHeader(http.StatusUnauthorized)
@@ -34,8 +36,16 @@ func newStubQuotaMember(t *testing.T, token, exportBody string) *stubQuotaMember
 		defer sm.mu.Unlock()
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/api/config/quota-snapshots":
+			if sm.getCode != http.StatusOK {
+				w.WriteHeader(sm.getCode)
+				return
+			}
 			_, _ = w.Write([]byte(sm.exportBody))
 		case r.Method == http.MethodPost && r.URL.Path == "/api/config/quota-snapshots":
+			if sm.postCode != http.StatusOK {
+				w.WriteHeader(sm.postCode)
+				return
+			}
 			b, _ := io.ReadAll(r.Body)
 			sm.posted = append(sm.posted, b)
 			_, _ = w.Write([]byte(`{"applied":1,"skipped":0}`))
@@ -83,6 +93,85 @@ func TestDistributeQuotaOnce(t *testing.T) {
 func TestDistributeQuotaOnce_NoPrimaryIsNoop(t *testing.T) {
 	srv, _ := newTestServer(t)
 	srv.DistributeQuotaOnce(t.Context()) // must not panic or call anything
+}
+
+// TestDistributeQuotaOnce_GetAutoSyncError: a store read failure is logged and
+// the pass is a no-op (does not panic).
+func TestDistributeQuotaOnce_GetAutoSyncError(t *testing.T) {
+	srv, store := newTestServer(t)
+	if err := store.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+	srv.DistributeQuotaOnce(t.Context()) // GetAutoSync errors on the closed store
+}
+
+// TestDistributeQuotaOnce_PrimaryUnavailable: a designated primary that no longer
+// exists (removed, or lost its token) aborts the pass, so no member is written.
+func TestDistributeQuotaOnce_PrimaryUnavailable(t *testing.T) {
+	srv, store := newTestServer(t)
+	member := newStubQuotaMember(t, "rtoken", "")
+	_, _ = store.CreateMember(t.Context(), "replica", member.srv.URL, "rtoken")
+	// Point the primary at an id with no member row.
+	if err := store.SetAutoSync(t.Context(), true, "00000000-0000-0000-0000-000000000000"); err != nil {
+		t.Fatalf("SetAutoSync: %v", err)
+	}
+
+	srv.DistributeQuotaOnce(t.Context())
+
+	if n := len(member.postedBodies()); n != 0 {
+		t.Fatalf("no distribution expected when the primary is unavailable, got %d posts", n)
+	}
+}
+
+// TestDistributeQuotaOnce_PrimaryFetchFails: a primary that answers the export
+// with a non-200 aborts the pass, so no member is written.
+func TestDistributeQuotaOnce_PrimaryFetchFails(t *testing.T) {
+	srv, store := newTestServer(t)
+	primary := newStubQuotaMember(t, "ptoken", "")
+	primary.getCode = http.StatusInternalServerError
+	member := newStubQuotaMember(t, "rtoken", "")
+
+	pm, _ := store.CreateMember(t.Context(), "primary", primary.srv.URL, "ptoken")
+	_, _ = store.CreateMember(t.Context(), "replica", member.srv.URL, "rtoken")
+	if err := store.SetAutoSync(t.Context(), true, pm.ID); err != nil {
+		t.Fatalf("SetAutoSync: %v", err)
+	}
+
+	srv.DistributeQuotaOnce(t.Context())
+
+	if n := len(member.postedBodies()); n != 0 {
+		t.Fatalf("no distribution expected when the primary export fails, got %d posts", n)
+	}
+}
+
+// TestDistributeQuotaOnce_SkipsBadMembersDeliversRest: a tokenless member and a
+// member that rejects the push are each logged and skipped without aborting the
+// pass, so a healthy member still receives the snapshot.
+func TestDistributeQuotaOnce_SkipsBadMembersDeliversRest(t *testing.T) {
+	srv, store := newTestServer(t)
+	exportBody := `{"snapshots":[{"provider_name":"nano","kind":"usage","payload":{"used":5},"http_status":200,"fetched_at":"2026-07-21T00:00:00Z"}]}`
+	primary := newStubQuotaMember(t, "ptoken", exportBody)
+	rejecting := newStubQuotaMember(t, "btoken", "")
+	rejecting.postCode = http.StatusInternalServerError
+	good := newStubQuotaMember(t, "gtoken", "")
+
+	pm, _ := store.CreateMember(t.Context(), "primary", primary.srv.URL, "ptoken")
+	_, _ = store.CreateMember(t.Context(), "rejecting", rejecting.srv.URL, "btoken")
+	// A tokenless member: memberTokenOrErr fails, so it is skipped.
+	_, _ = store.CreateMember(t.Context(), "tokenless", "https://tokenless.example", "")
+	_, _ = store.CreateMember(t.Context(), "good", good.srv.URL, "gtoken")
+	if err := store.SetAutoSync(t.Context(), true, pm.ID); err != nil {
+		t.Fatalf("SetAutoSync: %v", err)
+	}
+
+	srv.DistributeQuotaOnce(t.Context())
+
+	if got := good.postedBodies(); len(got) != 1 || !strings.Contains(string(got[0]), `"used":5`) {
+		t.Fatalf("healthy member should still receive the snapshot, got %v", got)
+	}
+	if n := len(rejecting.postedBodies()); n != 0 {
+		t.Fatalf("rejecting member records nothing (500 before capture), got %d", n)
+	}
 }
 
 // TestRunQuotaDistributeDistributesOnTick: the loop distributes on its tick.

--- a/internal/frontdesk/quota_distribute_test.go
+++ b/internal/frontdesk/quota_distribute_test.go
@@ -1,12 +1,14 @@
 package frontdesk
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 )
 
 // stubQuotaMember plays a member for the quota-distribution loop: it serves the
@@ -81,4 +83,52 @@ func TestDistributeQuotaOnce(t *testing.T) {
 func TestDistributeQuotaOnce_NoPrimaryIsNoop(t *testing.T) {
 	srv, _ := newTestServer(t)
 	srv.DistributeQuotaOnce(t.Context()) // must not panic or call anything
+}
+
+// TestRunQuotaDistributeDistributesOnTick: the loop distributes on its tick.
+func TestRunQuotaDistributeDistributesOnTick(t *testing.T) {
+	old := quotaDistributeInterval
+	quotaDistributeInterval = 10 * time.Millisecond
+	t.Cleanup(func() { quotaDistributeInterval = old })
+
+	srv, store := newTestServer(t)
+	exportBody := `{"snapshots":[{"provider_name":"nano","kind":"usage","payload":{"used":5},"http_status":200,"fetched_at":"2026-07-21T00:00:00Z"}]}`
+	primary := newStubQuotaMember(t, "ptoken", exportBody)
+	replica := newStubQuotaMember(t, "rtoken", "")
+	pm, _ := store.CreateMember(t.Context(), "primary", primary.srv.URL, "ptoken")
+	_, _ = store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken")
+	if err := store.SetAutoSync(t.Context(), true, pm.ID); err != nil {
+		t.Fatalf("SetAutoSync: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go srv.RunQuotaDistribute(ctx)
+
+	deadline := time.After(2 * time.Second)
+	for {
+		if len(replica.postedBodies()) > 0 {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatal("no distribution within deadline")
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+}
+
+// TestRunQuotaDistributeStopsOnContextCancel: the loop returns promptly when its
+// context is cancelled.
+func TestRunQuotaDistributeStopsOnContextCancel(t *testing.T) {
+	srv, _ := newTestServer(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	done := make(chan struct{})
+	go func() { srv.RunQuotaDistribute(ctx); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("RunQuotaDistribute did not return after context cancel")
+	}
 }

--- a/internal/frontdesk/quota_distribute_test.go
+++ b/internal/frontdesk/quota_distribute_test.go
@@ -1,0 +1,84 @@
+package frontdesk
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// stubQuotaMember plays a member for the quota-distribution loop: it serves the
+// fleet quota export (GET) and records the fleet quota pushes it receives (POST),
+// both fleet-authed by a bearer token, mirroring the real member endpoints.
+type stubQuotaMember struct {
+	mu         sync.Mutex
+	srv        *httptest.Server
+	token      string
+	exportBody string
+	posted     [][]byte
+}
+
+func newStubQuotaMember(t *testing.T, token, exportBody string) *stubQuotaMember {
+	t.Helper()
+	sm := &stubQuotaMember{token: token, exportBody: exportBody}
+	sm.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer "+sm.token {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		sm.mu.Lock()
+		defer sm.mu.Unlock()
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/config/quota-snapshots":
+			_, _ = w.Write([]byte(sm.exportBody))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/config/quota-snapshots":
+			b, _ := io.ReadAll(r.Body)
+			sm.posted = append(sm.posted, b)
+			_, _ = w.Write([]byte(`{"applied":1,"skipped":0}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(sm.srv.Close)
+	return sm
+}
+
+func (sm *stubQuotaMember) postedBodies() [][]byte {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	return append([][]byte(nil), sm.posted...)
+}
+
+// TestDistributeQuotaOnce: Front Desk fetches the designated primary's quota
+// snapshots and posts them to every other member, never back to the primary.
+func TestDistributeQuotaOnce(t *testing.T) {
+	srv, store := newTestServer(t)
+	exportBody := `{"snapshots":[{"provider_name":"nano","kind":"usage","payload":{"used":5},"http_status":200,"fetched_at":"2026-07-21T00:00:00Z"}]}`
+	primary := newStubQuotaMember(t, "ptoken", exportBody)
+	replica := newStubQuotaMember(t, "rtoken", "")
+
+	pm, _ := store.CreateMember(t.Context(), "primary", primary.srv.URL, "ptoken")
+	_, _ = store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken")
+	if err := store.SetAutoSync(t.Context(), true, pm.ID); err != nil {
+		t.Fatalf("SetAutoSync: %v", err)
+	}
+
+	srv.DistributeQuotaOnce(t.Context())
+
+	got := replica.postedBodies()
+	if len(got) != 1 || !strings.Contains(string(got[0]), `"used":5`) {
+		t.Fatalf("member should receive the primary snapshot, got %v", got)
+	}
+	if n := len(primary.postedBodies()); n != 0 {
+		t.Fatalf("primary is the source, not a destination; got %d posts", n)
+	}
+}
+
+// TestDistributeQuotaOnce_NoPrimaryIsNoop: with no designated primary the pass
+// is a no-op and touches nothing.
+func TestDistributeQuotaOnce_NoPrimaryIsNoop(t *testing.T) {
+	srv, _ := newTestServer(t)
+	srv.DistributeQuotaOnce(t.Context()) // must not panic or call anything
+}

--- a/internal/quota/repository.go
+++ b/internal/quota/repository.go
@@ -89,3 +89,55 @@ func (r *Repository) RecordFailure(ctx context.Context, providerID uuid.UUID, ki
 		providerID, kind, errMsg, now)
 	return err
 }
+
+// List returns every stored snapshot. The fleet export endpoint reads this on
+// the primary so Front Desk can distribute the primary's snapshots to members.
+func (r *Repository) List(ctx context.Context) ([]Snapshot, error) {
+	rows, err := r.pool.Query(ctx, `
+		SELECT provider_id, kind, payload, http_status, fetched_at, source, last_error, last_attempt_at
+		FROM provider_quota_snapshots`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []Snapshot
+	for rows.Next() {
+		var s Snapshot
+		var lastErr *string
+		if err := rows.Scan(&s.ProviderID, &s.Kind, &s.Payload, &s.HTTPStatus, &s.FetchedAt, &s.Source, &lastErr, &s.LastAttemptAt); err != nil {
+			return nil, err
+		}
+		if lastErr != nil {
+			s.LastError = *lastErr
+		}
+		out = append(out, s)
+	}
+	return out, rows.Err()
+}
+
+// UpsertIfNewer writes only when there is no existing row or the incoming
+// fetched_at is strictly newer, so an older fleet write never clobbers a
+// member's fresher manual refresh. Returns whether the write applied.
+func (r *Repository) UpsertIfNewer(ctx context.Context, s Snapshot) (bool, error) {
+	if s.FetchedAt.IsZero() {
+		s.FetchedAt = time.Now()
+	}
+	tag, err := r.pool.Exec(ctx, `
+		INSERT INTO provider_quota_snapshots
+			(provider_id, kind, payload, http_status, fetched_at, source, last_error, last_attempt_at)
+		VALUES ($1, $2, $3, $4, $5, $6, NULL, $5)
+		ON CONFLICT (provider_id, kind) DO UPDATE SET
+			payload         = EXCLUDED.payload,
+			http_status     = EXCLUDED.http_status,
+			fetched_at      = EXCLUDED.fetched_at,
+			source          = EXCLUDED.source,
+			last_error      = NULL,
+			last_attempt_at = EXCLUDED.fetched_at
+		WHERE provider_quota_snapshots.fetched_at < EXCLUDED.fetched_at`,
+		s.ProviderID, s.Kind, s.Payload, s.HTTPStatus, s.FetchedAt, s.Source)
+	if err != nil {
+		return false, err
+	}
+	return tag.RowsAffected() > 0, nil
+}

--- a/internal/quota/repository_test.go
+++ b/internal/quota/repository_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -129,5 +130,62 @@ func TestRecordFailureKeepsPayload(t *testing.T) {
 	got, _ := repo.Get(ctx, provID, "usage")
 	if got == nil || !jsonEqual(t, got.Payload, json.RawMessage(`{"used":5}`)) || got.LastError != "boom" {
 		t.Fatalf("failure should keep payload and set last_error: %+v", got)
+	}
+}
+
+func TestUpsertIfNewer(t *testing.T) {
+	ctx := context.Background()
+	repo := quota.NewRepository(testPool)
+
+	provID := insertTestProvider(ctx, t, "test-quota-upsert-if-newer")
+	t.Cleanup(func() { cleanupProvider(ctx, t, provID) })
+
+	older := time.Now().Add(-10 * time.Minute)
+	newer := time.Now()
+
+	// First write always applies.
+	applied, err := repo.UpsertIfNewer(ctx, quota.Snapshot{ProviderID: provID, Kind: "usage", Payload: json.RawMessage(`{"v":1}`), HTTPStatus: 200, Source: "fleet", FetchedAt: newer})
+	if err != nil || !applied {
+		t.Fatalf("first write should apply: applied=%v err=%v", applied, err)
+	}
+
+	// An older incoming write is skipped so it cannot clobber a fresher local one.
+	applied, err = repo.UpsertIfNewer(ctx, quota.Snapshot{ProviderID: provID, Kind: "usage", Payload: json.RawMessage(`{"v":2}`), HTTPStatus: 200, Source: "fleet", FetchedAt: older})
+	if err != nil || applied {
+		t.Fatalf("older write should be skipped: applied=%v err=%v", applied, err)
+	}
+
+	got, _ := repo.Get(ctx, provID, "usage")
+	if got == nil || !jsonEqual(t, got.Payload, json.RawMessage(`{"v":1}`)) {
+		t.Fatalf("older write must not clobber newer payload, got %+v", got)
+	}
+}
+
+func TestList(t *testing.T) {
+	ctx := context.Background()
+	repo := quota.NewRepository(testPool)
+
+	provID := insertTestProvider(ctx, t, "test-quota-list")
+	t.Cleanup(func() { cleanupProvider(ctx, t, provID) })
+
+	if err := repo.Upsert(ctx, quota.Snapshot{ProviderID: provID, Kind: "usage", Payload: json.RawMessage(`{}`), HTTPStatus: 200, Source: "poll"}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	all, err := repo.List(ctx)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	// The test DB is shared across quota tests, so assert our row is present
+	// rather than an exact count.
+	found := false
+	for _, s := range all {
+		if s.ProviderID == provID && s.Kind == "usage" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("list did not contain the inserted snapshot (got %d rows)", len(all))
 	}
 }

--- a/internal/quota/repository_test.go
+++ b/internal/quota/repository_test.go
@@ -62,6 +62,89 @@ func cleanupProvider(ctx context.Context, t *testing.T, providerID uuid.UUID) {
 	_, _ = testPool.Exec(ctx, `DELETE FROM providers WHERE id = $1`, providerID)
 }
 
+// TestListPopulatesLastError: a failed refresh leaves a row whose last_error is
+// carried through List (the export reader relies on the field being populated).
+func TestListPopulatesLastError(t *testing.T) {
+	ctx := context.Background()
+	repo := quota.NewRepository(testPool)
+	id := insertTestProvider(ctx, t, "list-lasterr")
+	defer cleanupProvider(ctx, t, id)
+
+	if err := repo.RecordFailure(ctx, id, "usage", "boom"); err != nil {
+		t.Fatalf("record failure: %v", err)
+	}
+	snaps, err := repo.List(ctx)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	var found bool
+	for _, s := range snaps {
+		if s.ProviderID == id && s.Kind == "usage" {
+			found = true
+			if s.LastError != "boom" {
+				t.Fatalf("last_error = %q, want boom", s.LastError)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("failure placeholder row not returned by List")
+	}
+}
+
+// TestUpsertIfNewerDefaultsFetchedAt: an incoming snapshot with a zero FetchedAt
+// is stamped now and applied against an empty row.
+func TestUpsertIfNewerDefaultsFetchedAt(t *testing.T) {
+	ctx := context.Background()
+	repo := quota.NewRepository(testPool)
+	id := insertTestProvider(ctx, t, "upsertnewer-default")
+	defer cleanupProvider(ctx, t, id)
+
+	wrote, err := repo.UpsertIfNewer(ctx, quota.Snapshot{
+		ProviderID: id,
+		Kind:       "usage",
+		Payload:    json.RawMessage(`{"used":1}`),
+		HTTPStatus: 200,
+		Source:     "fleet",
+		// FetchedAt left zero on purpose.
+	})
+	if err != nil {
+		t.Fatalf("upsert if newer: %v", err)
+	}
+	if !wrote {
+		t.Fatal("first write should apply")
+	}
+	got, err := repo.Get(ctx, id, "usage")
+	if err != nil || got == nil {
+		t.Fatalf("get: %v (snap %v)", err, got)
+	}
+	if got.FetchedAt.IsZero() {
+		t.Fatal("fetched_at should have been defaulted to now")
+	}
+}
+
+// TestRepositoryContextCancelledErrors: each query surfaces the DB error (rather
+// than panicking or masking it) when the context is already cancelled.
+func TestRepositoryContextCancelledErrors(t *testing.T) {
+	repo := quota.NewRepository(testPool)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := repo.Get(ctx, uuid.New(), "usage"); err == nil {
+		t.Error("Get: want error on cancelled context")
+	}
+	if _, err := repo.List(ctx); err == nil {
+		t.Error("List: want error on cancelled context")
+	}
+	if _, err := repo.UpsertIfNewer(ctx, quota.Snapshot{
+		ProviderID: uuid.New(),
+		Kind:       "usage",
+		Payload:    json.RawMessage(`{}`),
+		FetchedAt:  time.Now(),
+	}); err == nil {
+		t.Error("UpsertIfNewer: want error on cancelled context")
+	}
+}
+
 // jsonEqual compares two JSON payloads by value rather than by raw bytes:
 // Postgres JSONB re-serializes on write/read (e.g. adds a space after ':'),
 // so a raw byte/string comparison against the literal we inserted is not


### PR DESCRIPTION
Phase 2 of the quota poller: Front Desk distributes the designated primary's quota snapshots to the rest of the fleet, so members do not each poll the same upstream account. Builds on phase 1 (self-polling + read-through snapshot store).

## What it does
- **Primary self-polls** (phase 1 `PollQuotasOnce`, unchanged).
- **FD fetches + distributes**: `DistributeQuotaOnce` reads the designated primary's `GET /api/config/quota-snapshots` and POSTs it to every other member. Driven by `RunQuotaDistribute`, a Front-Desk-owned ticker started alongside `RunAutoSync`.
- **Member receive**: snapshots are name-keyed, mapped onto each member's own provider IDs, and written with `UpsertIfNewer` (`source='fleet'`) so an older fleet write never clobbers a fresher local one.
- **Self-poll suppression + fallback**: a member with a fresh fleet snapshot skips the upstream call; a member FD is not feeding still self-polls, so quota is never worse than standalone.
- **FD never holds keys**: it relays snapshots (which carry no key material), never provider credentials.

## Design note
`DistributeQuotaOnce` is a `*Server` method (it needs `callMember`/`memberTokenOrErr`, and `Server` owns the poller, not vice versa), so it is driven by its own ticker mirroring how config-sync auto-sync is actually driven — not by the poller loop slice or a `Settings` field. Cadence is a constant kept under the member quota-poll interval so fed members stay suppressed; no FD schema change.

## Verification
- `go test ./...` green (5794 tests), `golangci-lint run ./...` clean, `-race` clean.
- Live 3-node fleet (Front Desk + 2 model-hotel nodes): primary self-polls (`source='poll'`); member receives `source='fleet'` snapshots with the primary's exact `fetched_at`; member self-polls only providers lacking a fresh fleet snapshot; snapshots survive a member restart with no manual refresh; skip-if-newer preserves a newer local snapshot against an older fleet push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)