### PR TITLE
fix(deps): bump brace-expansion to 5.0.7 (CVE-2026-13149)

### DIFF
--- a/frontdesk/web/pnpm-lock.yaml
+++ b/frontdesk/web/pnpm-lock.yaml
@@ -836,8 +836,8 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
   browserslist@4.28.4:
@@ -2632,7 +2632,7 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -3123,7 +3123,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   ms@2.1.3: {}
 


### PR DESCRIPTION
Resolves Dependabot alert #14 (GHSA-3jxr-9vmj-r5cp / CVE-2026-13149, high severity).

## What
`brace-expansion` had exponential-time — O(2ⁿ) — behavior in the number of consecutive non-expanding `{}` groups. A ~90-byte input can stall the calling thread for minutes. Patched in 5.0.7.

## Change
Lockfile-only patch bump 5.0.6 → 5.0.7 in `frontdesk/web/pnpm-lock.yaml`. It's a **dev-scope transitive** dependency (pulled in via `minimatch@10.2.5`), so no runtime/app-facing impact. Stays within minimatch's accepted range.

Verified with a frozen `--frozen-lockfile` install — lockfile resolves cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)