### PR TITLE
fix(events): pluralise count in server-composed event messages

### DIFF
--- a/cmd/server/background.go
+++ b/cmd/server/background.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 	"github.com/hugalafutro/model-hotel/internal/events"
 	"github.com/hugalafutro/model-hotel/internal/settings"
+	"github.com/hugalafutro/model-hotel/internal/util"
 	"github.com/hugalafutro/model-hotel/internal/webauthn"
 )
 
@@ -276,7 +277,7 @@ func staleLogCleanupPass(pool *pgxpool.Pool, settingsRepo *settings.Repository, 
 		events.Publish(events.Event{
 			Type:     "logs.stale_cleanup",
 			Severity: "warning",
-			Message:  fmt.Sprintf("Marked %d stale requests as interrupted", tag.RowsAffected()),
+			Message:  fmt.Sprintf("Marked %d stale %s as interrupted", tag.RowsAffected(), util.Plural(int(tag.RowsAffected()), "request", "requests")),
 			Metadata: map[string]any{"count": tag.RowsAffected()},
 		})
 	} else if err != nil {

--- a/cmd/server/discovery.go
+++ b/cmd/server/discovery.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/provider"
 	"github.com/hugalafutro/model-hotel/internal/proxy"
 	"github.com/hugalafutro/model-hotel/internal/settings"
+	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
 type DiscoveryResult struct {
@@ -56,14 +57,14 @@ func publishDiscoveryEvent(source string, result DiscoveryResult) {
 		events.Publish(events.Event{
 			Type:     "discovery.complete",
 			Severity: "warning",
-			Message:  fmt.Sprintf("Discovery partially failed: %d/%d providers OK, %d models found", result.ProvidersScanned-result.ProvidersFailed, result.ProvidersScanned, result.ModelsDiscovered),
+			Message:  fmt.Sprintf("Discovery partially failed: %d/%d providers OK, %s found", result.ProvidersScanned-result.ProvidersFailed, result.ProvidersScanned, util.Count(result.ModelsDiscovered, "model", "models")),
 			Metadata: map[string]any{"source": source, "errors": result.Errors},
 		})
 	default:
 		events.Publish(events.Event{
 			Type:     "discovery.complete",
 			Severity: "success",
-			Message:  fmt.Sprintf("%s discovery complete: %d models across %d providers", source, result.ModelsDiscovered, result.ProvidersScanned),
+			Message:  fmt.Sprintf("%s discovery complete: %s across %s", source, util.Count(result.ModelsDiscovered, "model", "models"), util.Count(result.ProvidersScanned, "provider", "providers")),
 			Metadata: map[string]any{"source": source},
 		})
 	}
@@ -179,7 +180,7 @@ func scanProvider(ctx context.Context, deps discoveryDeps, discoverySvc *provide
 		events.Publish(events.Event{
 			Type:     "discovery.models_disabled",
 			Severity: "warning",
-			Message:  fmt.Sprintf("%d models no longer available at '%s' and were disabled", len(disabledRefs), p.Name),
+			Message:  fmt.Sprintf("%s no longer available at '%s' and %s disabled", util.Count(len(disabledRefs), "model", "models"), p.Name, util.Plural(len(disabledRefs), "was", "were")),
 			Metadata: map[string]any{"provider": p.Name, "count": len(disabledRefs)},
 		})
 	}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -96,7 +96,7 @@ func cleanupInterruptedRequests(pool *pgxpool.Pool, serverStartTime time.Time) {
 		events.Publish(events.Event{
 			Type:     "logs.stale_startup",
 			Severity: "warning",
-			Message:  fmt.Sprintf("Server restart interrupted %d pending requests", tag.RowsAffected()),
+			Message:  fmt.Sprintf("Server restart interrupted %d pending %s", tag.RowsAffected(), util.Plural(int(tag.RowsAffected()), "request", "requests")),
 			Metadata: map[string]any{"count": tag.RowsAffected()},
 		})
 	} else if err != nil {

--- a/internal/api/discovery.go
+++ b/internal/api/discovery.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/model"
 	"github.com/hugalafutro/model-hotel/internal/provider"
 	"github.com/hugalafutro/model-hotel/internal/quota"
+	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
 // newDiscoveryService creates a DiscoveryService. NewHandler overwrites this
@@ -148,7 +149,7 @@ func (h *Handler) DiscoverProviderModels(w http.ResponseWriter, r *http.Request)
 		Type:     "discovery.provider_fetched",
 		Severity: "success",
 		Source:   "discovery",
-		Message:  fmt.Sprintf("Fetched %d models from %s", len(models), prov.Name),
+		Message:  fmt.Sprintf("Fetched %s from %s", util.Count(len(models), "model", "models"), prov.Name),
 		Metadata: map[string]any{"provider": prov.Name, "count": len(models)},
 	})
 
@@ -450,7 +451,7 @@ func (h *Handler) discoverAllProviders(ctx context.Context, recordMisses bool) (
 			Type:     "discovery.provider_fetched",
 			Severity: "success",
 			Source:   "discovery",
-			Message:  fmt.Sprintf("Fetched %d models from %s", len(models), prov.Name),
+			Message:  fmt.Sprintf("Fetched %s from %s", util.Count(len(models), "model", "models"), prov.Name),
 			Metadata: map[string]any{"provider": prov.Name, "count": len(models)},
 		})
 

--- a/internal/frontdesk/poller.go
+++ b/internal/frontdesk/poller.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 	"github.com/hugalafutro/model-hotel/internal/events"
+	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
 // This file holds the background pollers: a per-member /health probe (status +
@@ -351,7 +352,7 @@ func (p *Poller) applyHealth(ctx context.Context, m *Member, hs HealthStatus) {
 			"member", m.Name, "consecutive_failures", fails, "error", hs.Error)
 		p.recordEvent(ctx, Event{
 			Type: "health.down", Severity: "error", Source: "frontdesk-poller",
-			Message: fmt.Sprintf("%s is unreachable after %d checks", m.Name, fails), MemberID: m.ID,
+			Message: fmt.Sprintf("%s is unreachable after %d %s", m.Name, fails, util.Plural(fails, "check", "checks")), MemberID: m.ID,
 			Metadata: map[string]any{"error": hs.Error, "consecutive_failures": fails},
 		})
 	}

--- a/internal/util/plural.go
+++ b/internal/util/plural.go
@@ -1,0 +1,19 @@
+package util
+
+import "fmt"
+
+// Plural picks the singular or plural word for a count. It exists so
+// user-facing messages read "1 model" / "2 models" instead of the
+// unpluralised "1 models".
+func Plural(n int, singular, plural string) string {
+	if n == 1 {
+		return singular
+	}
+	return plural
+}
+
+// Count renders a count with its correctly pluralised noun, e.g.
+// Count(1, "model", "models") == "1 model".
+func Count(n int, singular, plural string) string {
+	return fmt.Sprintf("%d %s", n, Plural(n, singular, plural))
+}

--- a/internal/util/plural_test.go
+++ b/internal/util/plural_test.go
@@ -1,0 +1,36 @@
+package util
+
+import "testing"
+
+func TestPlural(t *testing.T) {
+	cases := []struct {
+		n    int
+		want string
+	}{
+		{0, "models"},
+		{1, "model"},
+		{2, "models"},
+		{-1, "models"},
+	}
+	for _, c := range cases {
+		if got := Plural(c.n, "model", "models"); got != c.want {
+			t.Errorf("Plural(%d) = %q, want %q", c.n, got, c.want)
+		}
+	}
+}
+
+func TestCount(t *testing.T) {
+	cases := []struct {
+		n    int
+		want string
+	}{
+		{0, "0 models"},
+		{1, "1 model"},
+		{5, "5 models"},
+	}
+	for _, c := range cases {
+		if got := Count(c.n, "model", "models"); got != c.want {
+			t.Errorf("Count(%d) = %q, want %q", c.n, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## What

Backend event/toast messages built with `fmt.Sprintf` hardcoded plural nouns, so a count of 1 rendered awkwardly:

- `1 models no longer available at 'X' and were disabled`
- `Marked 1 stale requests as interrupted`
- `Fetched 1 models from X`
- `X is unreachable after 1 checks`

These are server-composed (English-only, not i18n), so they had no pluralization at all.

## Change

- New `internal/util/plural.go` — `Plural(n, singular, plural)` and `Count(n, singular, plural)` helpers, with unit tests.
- Applied to every count-driven event message whose value can legitimately be 1:
  - `cmd/server/discovery.go` (models disabled / models found / models across providers — also `were`→`was`)
  - `cmd/server/background.go`, `cmd/server/main.go` (stale/pending requests)
  - `internal/api/discovery.go` (Fetched N models)
  - `internal/frontdesk/poller.go` (unreachable after N checks — threshold is operator-settable to 1)

Left as-is: ratio forms (`%d/%d`) and fixed-threshold counts that are always ≥2 (`poller.go` version-fetch at threshold 3, bulk-removal streak at multiples of 3).

## Follow-up

The frontend i18n toasts (`toast_refresh_success`, `toast_discovery_failed_all`, `toast_sync_purged`, `toast_sync_disabled`, `failoverDisabledReason`) still dodge pluralization with `(s)`/`(ies)` or a bare `{{count}}`. Fixing those needs `_one`/`_other` keys across all 11 locale files and will land as a separate PR after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)