### PR TITLE
fix(i18n): pluralise count-based provider/failover toasts

### DIFF
--- a/tools/i18n-translate/allow-english.json
+++ b/tools/i18n-translate/allow-english.json
@@ -5235,9 +5235,6 @@
 	"providers.page_title_one": [
 		"it"
 	],
-	"providers.toast_refresh_success": [
-		"da"
-	],
 	"providers.type_anthropic": [
 		"af",
 		"ar",

--- a/web/src/i18n/locales/af.json
+++ b/web/src/i18n/locales/af.json
@@ -696,7 +696,6 @@
 		"sort_title_desc": "Gesorteer Z-A (klik om om te keer)",
 		"empty_no_match": "Geen verskaffers pas by die gekose filter nie.",
 		"empty_no_providers": "Geen verskaffers gekonfigureer nie. Voeg jou eerste verskaffer by om te begin.",
-		"toast_discovery_failed_all": "Ontdekking het vir alle verskaffers van {{failed}} misluk.",
 		"toast_discover_failed": "Ontdekking het misluk: {{message}}",
 		"toast_provider_added": "Verskaffer \"{{name}}\" bygevoeg",
 		"toast_provider_updated": "Verskaffer \"{{name}}\" is opgedateer",
@@ -704,7 +703,6 @@
 		"toast_delete_failed": "Het misluk om te verwyder: {{message}}",
 		"toast_add_failed": "Misluk om verskaffer by te voeg: {{message}}",
 		"toast_update_failed": "Het misluk om op te dateer: {{message}}",
-		"toast_refresh_success": "Opgedateerde {{count}} -kwootas/balansies",
 		"toast_refresh_warning": "Gerenoveerde {{refreshed}} -kotas ({{failed}} het misluk, {{skipped}} nie ondersteun nie)",
 		"toast_refresh_none": "Geen verskaffers met kwota-/saldo-ondersteuning gevind nie",
 		"toast_refresh_failed": "Kwota-opdaterings het misluk: {{message}}",
@@ -851,10 +849,15 @@
 			"retestDone": "{{provider}} hertoets",
 			"toggleSection": "Wissel {{provider}}-afdeling",
 			"failoverDisabled": "Failover-groepe gedeaktiveer",
-			"failoverDisabledReason": "{{count}} roeteerbare lid(lede) oor, benodig 2+"
+			"failoverDisabledReason_one": "{{count}} roeteerbare lid oor, benodig 2+",
+			"failoverDisabledReason_other": "{{count}} roeteerbare lede oor, benodig 2+"
 		},
 		"toast_quota_detected_minimax": "MiniMax-kwota opgespoor",
-		"type_minimax": "MiniMax"
+		"type_minimax": "MiniMax",
+		"toast_refresh_success_one": "Opgedateer {{count}} kwota/balans",
+		"toast_refresh_success_other": "Opgedateer {{count}} kwotas/balanse",
+		"toast_discovery_failed_all_one": "Ontdekking het vir die verskaffer misluk.",
+		"toast_discovery_failed_all_other": "Ontdekking het vir al {{count}} verskaffers misluk."
 	},
 	"models": {
 		"page_title_one": "Model",
@@ -991,7 +994,6 @@
 		"toast_bulk_toggle_failed": "Groepskakelaar het vir sommige groepe misluk",
 		"toast_provider_toggle_failed": "Groothandelsverskaffer-skakelaar het vir sommige groepe misluk",
 		"toast_sync_deleted": "hotel/{{model}} verwyder: {{reason}}{{providers}}",
-		"toast_sync_purged": "hotel/{{group}}: verwyder {{count}} verouderde inskrywing(e)",
 		"toast_sync_success": "Oorgangsgroepe gesinchroniseer",
 		"toast_sync_failed": "Misluk om te sinchroniseer: {{message}}",
 		"toast_update_failed": "Het misluk om op te dateer: {{message}}",
@@ -1037,8 +1039,11 @@
 		"provider_modal_description": "Deur 'n verskaffer te deaktiveer, word al sy modelle in elke failover-groep gedeaktiveer.",
 		"toast_provider_toggle_no_groups": "Geen failover-groepe gebruik verskaffer {{provider}}",
 		"last_sync_label": "Laaste sinchronisasie:",
-		"toast_sync_disabled": "hotel/{{group}} gedeaktiveer: {{count}} roeteerbare lid(lede) oor",
-		"toast_entry_min_two": "Ten minste 2 lede moet aktief bly."
+		"toast_entry_min_two": "Ten minste 2 lede moet aktief bly.",
+		"toast_sync_purged_one": "hotel/{{group}}: {{count}} verouderde inskrywing verwyder",
+		"toast_sync_purged_other": "hotel/{{group}}: {{count}} verouderde inskrywings verwyder",
+		"toast_sync_disabled_one": "hotel/{{group}} gedeaktiveer: {{count}} roeteerbare lid oor",
+		"toast_sync_disabled_other": "hotel/{{group}} gedeaktiveer: {{count}} roeteerbare lede oor"
 	},
 	"delete_confirm": {
 		"unsaved_changes": "Onbewaarde veranderinge"

--- a/web/src/i18n/locales/ar.json
+++ b/web/src/i18n/locales/ar.json
@@ -696,7 +696,6 @@
 		"sort_title_desc": "تم فرز Z-A (انقر لعكس ذلك)",
 		"empty_no_match": "لا يوجد موفري يتطابق مع الفلتر المحدد.",
 		"empty_no_providers": "لم يتم تكوين موفري الخدمة. أضف موفر الخدمة الأول للبدء.",
-		"toast_discovery_failed_all": "فشل اكتشاف جميع موفري {{failed}}",
 		"toast_discover_failed": "فشل الاكتشاف: {{message}}",
 		"toast_provider_added": "مزود \"{{name}}\" أضيف",
 		"toast_provider_updated": "تم تحديث موفر \"{{name}}\"",
@@ -704,7 +703,6 @@
 		"toast_delete_failed": "فشل الحذف: {{message}}",
 		"toast_add_failed": "فشل في إضافة المزود: {{message}}",
 		"toast_update_failed": "فشل التحديث: {{message}}",
-		"toast_refresh_success": "تحديث الحصص/الأرصدة {{count}}",
 		"toast_refresh_warning": "تحديث الحصص {{refreshed}} ( فشل{{failed}} ، {{skipped}} غير مدعوم)",
 		"toast_refresh_none": "لم يتم العثور على مزودين مع دعم الحصة/الرصيد",
 		"toast_refresh_failed": "فشل تحديث الحصص: {{message}}",
@@ -851,10 +849,15 @@
 			"retestDone": "تمت إعادة اختبار {{provider}}",
 			"toggleSection": "تبديل قسم {{provider}}",
 			"failoverDisabled": "تم تعطيل مجموعات التحويل التلقائي",
-			"failoverDisabledReason": "{{count}} عضو قابل للتوجيه متبقٍ، يلزم 2+"
+			"failoverDisabledReason_one": "{{count}} عضو قابل للتوجيه متبقٍ، يلزم 2+",
+			"failoverDisabledReason_other": "{{count}} أعضاء قابلون للتوجيه متبقّون، يلزم 2+"
 		},
 		"toast_quota_detected_minimax": "تم اكتشاف حصة MiniMax",
-		"type_minimax": "MiniMax"
+		"type_minimax": "MiniMax",
+		"toast_refresh_success_one": "تحديث الحصة/الرصيد {{count}}",
+		"toast_refresh_success_other": "تحديث الحصص/الأرصدة {{count}}",
+		"toast_discovery_failed_all_one": "فشل الاكتشاف للموفّر",
+		"toast_discovery_failed_all_other": "فشل اكتشاف جميع الموفّرين {{count}}"
 	},
 	"models": {
 		"page_title_one": "الموديل",
@@ -991,7 +994,6 @@
 		"toast_bulk_toggle_failed": "فشل تبديل الكتلة لبعض المجموعات",
 		"toast_provider_toggle_failed": "فشل تبديل موفر الجملة لبعض المجموعات",
 		"toast_sync_deleted": "الفندق/{{model}} حذف: {{reason}}{{providers}}",
-		"toast_sync_purged": "فندق/{{group}}: إزالة إدخال (إدخالات) أستاذية {{count}}",
 		"toast_sync_success": "مجموعات الفشل مزامنة",
 		"toast_sync_failed": "فشل في المزامنة: {{message}}",
 		"toast_update_failed": "فشل التحديث: {{message}}",
@@ -1037,8 +1039,11 @@
 		"provider_modal_description": "تعطيل موفر سيعطل جميع نماذجه في كل مجموعة فشل",
 		"toast_provider_toggle_no_groups": "لا يوجد فشل في المجموعات التي تستخدم موفر {{provider}}",
 		"last_sync_label": "آخر مزامنة:",
-		"toast_sync_disabled": "فندق/{{group}} معطل: {{count}} عضو قابل للتوجيه متبقٍ",
-		"toast_entry_min_two": "يجب أن يبقى عضوان على الأقل نشطين."
+		"toast_entry_min_two": "يجب أن يبقى عضوان على الأقل نشطين.",
+		"toast_sync_purged_one": "فندق/{{group}}: تمت إزالة {{count}} إدخال قديم",
+		"toast_sync_purged_other": "فندق/{{group}}: تمت إزالة {{count}} إدخالات قديمة",
+		"toast_sync_disabled_one": "فندق/{{group}} معطل: {{count}} عضو قابل للتوجيه متبقٍ",
+		"toast_sync_disabled_other": "فندق/{{group}} معطل: {{count}} أعضاء قابلون للتوجيه متبقّون"
 	},
 	"delete_confirm": {
 		"unsaved_changes": "التغييرات غير المحفوظة"

--- a/web/src/i18n/locales/ca.json
+++ b/web/src/i18n/locales/ca.json
@@ -696,7 +696,6 @@
 		"sort_title_desc": "Ordenat de Z a A (fes clic per invertir)",
 		"empty_no_match": "No hi ha cap proveïdor que coincideixi amb el filtre seleccionat.",
 		"empty_no_providers": "No s'ha configurat cap proveïdor. Afegeix el teu primer proveïdor per començar.",
-		"toast_discovery_failed_all": "El descobriment va fallar per a tots els proveïdors {{failed}}",
 		"toast_discover_failed": "El descobriment va fracassar: {{message}}",
 		"toast_provider_added": "S'ha afegit el proveïdor \"{{name}}\".",
 		"toast_provider_updated": "El proveïdor \"{{name}}\" s'ha actualitzat.",
@@ -704,7 +703,6 @@
 		"toast_delete_failed": "No s'ha pogut suprimir: {{message}}",
 		"toast_add_failed": "S'ha fallat l'addició del proveïdor: {{message}}",
 		"toast_update_failed": "S'ha fallat l'actualització: {{message}}",
-		"toast_refresh_success": "Quotes/saldos de {{count}} actualitzats",
 		"toast_refresh_warning": "Quotes de {{refreshed}} actualitzades ({{failed}} ha fallat, {{skipped}} no admès)",
 		"toast_refresh_none": "No s'han trobat proveïdors amb suport de quota/saldo.",
 		"toast_refresh_failed": "L'actualització de les quotes ha fallat: {{message}}",
@@ -851,10 +849,15 @@
 			"retestDone": "S'ha reprovat {{provider}}",
 			"toggleSection": "Mostra o amaga la secció {{provider}}",
 			"failoverDisabled": "Grups de fallada desactivats",
-			"failoverDisabledReason": "queden {{count}} membre(s) encaminable(s), calen 2+"
+			"failoverDisabledReason_one": "queda {{count}} membre encaminable, calen 2+",
+			"failoverDisabledReason_other": "queden {{count}} membres encaminables, calen 2+"
 		},
 		"toast_quota_detected_minimax": "Detectada quota de MiniMax",
-		"type_minimax": "MiniMax"
+		"type_minimax": "MiniMax",
+		"toast_refresh_success_one": "Quota/saldo de {{count}} actualitzat",
+		"toast_refresh_success_other": "Quotes/saldos de {{count}} actualitzats",
+		"toast_discovery_failed_all_one": "El descobriment ha fallat per al proveïdor",
+		"toast_discovery_failed_all_other": "El descobriment ha fallat per a tots els {{count}} proveïdors"
 	},
 	"models": {
 		"page_title_one": "Model",
@@ -991,7 +994,6 @@
 		"toast_bulk_toggle_failed": "L'activació massiva ha fallat per a alguns grups",
 		"toast_provider_toggle_failed": "L'interruptor de proveïdor massiu ha fallat per a alguns grups",
 		"toast_sync_deleted": "hotel/{{model}} eliminat: {{reason}}{{providers}}",
-		"toast_sync_purged": "hotel/{{group}}: eliminada la(s) entrada(s) caduca(s) de {{count}}",
 		"toast_sync_success": "Grups de fallada sincronitzats",
 		"toast_sync_failed": "Sincronització fallida: {{message}}",
 		"toast_update_failed": "S'ha fallat l'actualització: {{message}}",
@@ -1037,8 +1039,11 @@
 		"provider_modal_description": "Desactivar un proveïdor desactivarà tots els seus models en cada grup de conmutació per error.",
 		"toast_provider_toggle_no_groups": "Cap grup de fallada utilitza proveïdor. {{provider}}",
 		"last_sync_label": "Darrera sincronització:",
-		"toast_sync_disabled": "hotel/{{group}} desactivat: queden {{count}} membre(s) encaminable(s)",
-		"toast_entry_min_two": "Almenys 2 membres han de romandre actius."
+		"toast_entry_min_two": "Almenys 2 membres han de romandre actius.",
+		"toast_sync_purged_one": "hotel/{{group}}: eliminada {{count}} entrada caducada",
+		"toast_sync_purged_other": "hotel/{{group}}: eliminades {{count}} entrades caducades",
+		"toast_sync_disabled_one": "hotel/{{group}} desactivat: queda {{count}} membre encaminable",
+		"toast_sync_disabled_other": "hotel/{{group}} desactivat: queden {{count}} membres encaminables"
 	},
 	"delete_confirm": {
 		"unsaved_changes": "Canvis no desats"

--- a/web/src/i18n/locales/cs.json
+++ b/web/src/i18n/locales/cs.json
@@ -696,7 +696,6 @@
 		"sort_title_desc": "Seřazeno podle abecedy (kliknutím obrátíte pořadí)",
 		"empty_no_match": "Žádný poskytovatel neodpovídá zadaným kritériím.",
 		"empty_no_providers": "Není nakonfigurován žádný poskytovatel. Přidejte svého prvního poskytovatele a můžete začít.",
-		"toast_discovery_failed_all": "Vyhledávání selhalo u všech poskytovatelů {{failed}}",
 		"toast_discover_failed": "Vyhledávání selhalo: {{message}}",
 		"toast_provider_added": "Byl přidán poskytovatel „{{name}}“",
 		"toast_provider_updated": "Poskytovatel „{{name}}“ byl aktualizován",
@@ -704,7 +703,6 @@
 		"toast_delete_failed": "Odstranění selhalo: {{message}}",
 		"toast_add_failed": "Nepodařilo se přidat poskytovatele: {{message}}",
 		"toast_update_failed": "Aktualizace selhala: {{message}}",
-		"toast_refresh_success": "Aktualizované kvóty/zůstatky {{count}}",
 		"toast_refresh_warning": "Aktualizované kvóty {{refreshed}} ({{failed}} selhalo, {{skipped}} není podporováno)",
 		"toast_refresh_none": "Nebyli nalezeni žádní poskytovatelé s podporou kvót/zůstatků",
 		"toast_refresh_failed": "Obnovení kvót selhalo: {{message}}",
@@ -851,10 +849,15 @@
 			"retestDone": "{{provider}} otestováno znovu",
 			"toggleSection": "Přepnout sekci {{provider}}",
 			"failoverDisabled": "Failover skupiny deaktivovány",
-			"failoverDisabledReason": "zbývá {{count}} směrovatelných členů, potřeba 2+"
+			"failoverDisabledReason_one": "zbývá {{count}} směrovatelný člen, potřeba 2+",
+			"failoverDisabledReason_other": "zbývá {{count}} směrovatelných členů, potřeba 2+"
 		},
 		"toast_quota_detected_minimax": "Zjištěna kvóta MiniMax",
-		"type_minimax": "MiniMax"
+		"type_minimax": "MiniMax",
+		"toast_refresh_success_one": "Aktualizována {{count}} kvóta/zůstatek",
+		"toast_refresh_success_other": "Aktualizovány {{count}} kvóty/zůstatky",
+		"toast_discovery_failed_all_one": "Vyhledávání selhalo u poskytovatele",
+		"toast_discovery_failed_all_other": "Vyhledávání selhalo u všech {{count}} poskytovatelů"
 	},
 	"models": {
 		"page_title_one": "Model",
@@ -991,7 +994,6 @@
 		"toast_bulk_toggle_failed": "U některých skupin se nepodařilo přepnout hromadně",
 		"toast_provider_toggle_failed": "U některých skupin se nepodařilo přepnout na hromadné nastavení",
 		"toast_sync_deleted": "hotel/{{model}} odstraněno: {{reason}}{{providers}}",
-		"toast_sync_purged": "hotel/{{group}}: odstraněny zastaralé záznamy {{count}}",
 		"toast_sync_success": "Failover skupiny synchronizovány",
 		"toast_sync_failed": "Synchronizace selhala: {{message}}",
 		"toast_update_failed": "Aktualizace selhala: {{message}}",
@@ -1037,8 +1039,11 @@
 		"provider_modal_description": "Zakázáním poskytovatele dojde k vypnutí všech modelů v každé skupině selhání",
 		"toast_provider_toggle_no_groups": "Není použito poskytovatele {{provider}}",
 		"last_sync_label": "Poslední synchronizace:",
-		"toast_sync_disabled": "hotel/{{group}} deaktivováno: zbývá {{count}} směrovatelných členů",
-		"toast_entry_min_two": "Aktivní musí zůstat alespoň 2 členové."
+		"toast_entry_min_two": "Aktivní musí zůstat alespoň 2 členové.",
+		"toast_sync_purged_one": "hotel/{{group}}: odstraněn {{count}} zastaralý záznam",
+		"toast_sync_purged_other": "hotel/{{group}}: odstraněno {{count}} zastaralých záznamů",
+		"toast_sync_disabled_one": "hotel/{{group}} deaktivováno: zbývá {{count}} směrovatelný člen",
+		"toast_sync_disabled_other": "hotel/{{group}} deaktivováno: zbývá {{count}} směrovatelných členů"
 	},
 	"delete_confirm": {
 		"unsaved_changes": "Neuložené změny"

--- a/web/src/i18n/locales/da.json
+++ b/web/src/i18n/locales/da.json
@@ -696,7 +696,6 @@
 		"sort_title_desc": "Sorteret Z-A (klik for at vende)",
 		"empty_no_match": "Ingen udbydere matcher det valgte filter.",
 		"empty_no_providers": "Ingen udbydere konfigureret. Tilføj din første udbyder for at komme i gang.",
-		"toast_discovery_failed_all": "Discovery mislykkedes for alle {{failed}} udbydere",
 		"toast_discover_failed": "Opdagelse mislykkedes: {{message}}",
 		"toast_provider_added": "Udbyder \"{{name}}\" tilføjet",
 		"toast_provider_updated": "Udbyder \"{{name}}\" opdateret",
@@ -704,7 +703,6 @@
 		"toast_delete_failed": "Mislykkedes at slette: {{message}}",
 		"toast_add_failed": "Kunne ikke tilføje udbyder: {{message}}",
 		"toast_update_failed": "Mislykkedes at opdatere: {{message}}",
-		"toast_refresh_success": "Refreshed {{count}} quotas/balances",
 		"toast_refresh_warning": "Refreshed {{refreshed}} quotas ({{failed}} mislykkedes, {{skipped}} uunderstøttet)",
 		"toast_refresh_none": "Ingen udbydere med kvote/saldounderstøttelse fundet",
 		"toast_refresh_failed": "Opdatering af kvoter mislykkedes: {{message}}",
@@ -851,10 +849,15 @@
 			"retestDone": "{{provider}} testet igen",
 			"toggleSection": "Skift {{provider}}-sektion",
 			"failoverDisabled": "Failover-grupper deaktiveret",
-			"failoverDisabledReason": "{{count}} rutebare medlem(mer) tilbage, kræver 2+"
+			"failoverDisabledReason_one": "{{count}} rutebart medlem tilbage, kræver 2+",
+			"failoverDisabledReason_other": "{{count}} rutebare medlemmer tilbage, kræver 2+"
 		},
 		"toast_quota_detected_minimax": "Opdaget kvote for MiniMax",
-		"type_minimax": "MiniMax"
+		"type_minimax": "MiniMax",
+		"toast_refresh_success_one": "Opdaterede {{count}} kvote/saldo",
+		"toast_refresh_success_other": "Opdaterede {{count}} kvoter/saldi",
+		"toast_discovery_failed_all_one": "Discovery mislykkedes for udbyderen",
+		"toast_discovery_failed_all_other": "Discovery mislykkedes for alle {{count}} udbydere"
 	},
 	"models": {
 		"page_title_one": "Model",
@@ -991,7 +994,6 @@
 		"toast_bulk_toggle_failed": "Masseskift mislykkedes for nogle grupper",
 		"toast_provider_toggle_failed": "Masse udbyder skifte mislykkedes for nogle grupper",
 		"toast_sync_deleted": "Hotel/{{model}} slettet: {{reason}}{{providers}}",
-		"toast_sync_purged": "hotel/{{group}}: fjernede {{count}} forsvundet indgang (ies)",
 		"toast_sync_success": "Mislykket grupper synkroniseret",
 		"toast_sync_failed": "Synkronisering mislykkedes: {{message}}",
 		"toast_update_failed": "Mislykkedes at opdatere: {{message}}",
@@ -1037,8 +1039,11 @@
 		"provider_modal_description": "Deaktivering af en udbyder vil deaktivere alle sine modeller i hver failover gruppe",
 		"toast_provider_toggle_no_groups": "Ingen mislykkede grupper bruger udbyder {{provider}}",
 		"last_sync_label": "Seneste synkronisering:",
-		"toast_sync_disabled": "hotel/{{group}} deaktiveret: {{count}} rutebare medlem(mer) tilbage",
-		"toast_entry_min_two": "Mindst 2 medlemmer skal forblive aktive."
+		"toast_entry_min_two": "Mindst 2 medlemmer skal forblive aktive.",
+		"toast_sync_purged_one": "hotel/{{group}}: fjernede {{count}} forældet indgang",
+		"toast_sync_purged_other": "hotel/{{group}}: fjernede {{count}} forældede indgange",
+		"toast_sync_disabled_one": "hotel/{{group}} deaktiveret: {{count}} rutebart medlem tilbage",
+		"toast_sync_disabled_other": "hotel/{{group}} deaktiveret: {{count}} rutebare medlemmer tilbage"
 	},
 	"delete_confirm": {
 		"unsaved_changes": "Ikke-Gemte Ændringer"

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -696,7 +696,6 @@
 		"sort_title_desc": "Z-A sortiert (zum Umkehren)",
 		"empty_no_match": "Keine Anbieter stimmen mit dem ausgewählten Filter überein.",
 		"empty_no_providers": "Keine Anbieter konfiguriert. Fügen Sie Ihren ersten Anbieter hinzu, um loszulegen.",
-		"toast_discovery_failed_all": "Discovery fehlgeschlagen für alle {{failed}} Anbieter",
 		"toast_discover_failed": "Entdeckung fehlgeschlagen: {{message}}",
 		"toast_provider_added": "Anbieter \"{{name}}\" hinzugefügt",
 		"toast_provider_updated": "Anbieter \"{{name}}\" aktualisiert",
@@ -704,7 +703,6 @@
 		"toast_delete_failed": "Fehler beim Löschen: {{message}}",
 		"toast_add_failed": "Fehler beim Hinzufügen des Providers: {{message}}",
 		"toast_update_failed": "Aktualisierung fehlgeschlagen: {{message}}",
-		"toast_refresh_success": "Aktualisierte {{count}} Quoten/Salden",
 		"toast_refresh_warning": "Aktualisierte {{refreshed}} Quoten ({{failed}} fehlgeschlagen, {{skipped}} nicht unterstützt)",
 		"toast_refresh_none": "Keine Anbieter mit Quota/Saldo Unterstützung gefunden",
 		"toast_refresh_failed": "Quota aktualisieren fehlgeschlagen: {{message}}",
@@ -851,10 +849,15 @@
 			"retestDone": "{{provider}} erneut getestet",
 			"toggleSection": "Abschnitt {{provider}} umschalten",
 			"failoverDisabled": "Failover-Gruppen deaktiviert",
-			"failoverDisabledReason": "{{count}} routbare(s) Mitglied(er) übrig, 2+ erforderlich"
+			"failoverDisabledReason_one": "{{count}} routbares Mitglied übrig, 2+ erforderlich",
+			"failoverDisabledReason_other": "{{count}} routbare Mitglieder übrig, 2+ erforderlich"
 		},
 		"toast_quota_detected_minimax": "MiniMax Quote erkannt",
-		"type_minimax": "MiniMax"
+		"type_minimax": "MiniMax",
+		"toast_refresh_success_one": "Aktualisierte {{count}} Quote/Saldo",
+		"toast_refresh_success_other": "Aktualisierte {{count}} Quoten/Salden",
+		"toast_discovery_failed_all_one": "Discovery fehlgeschlagen für den Anbieter",
+		"toast_discovery_failed_all_other": "Discovery fehlgeschlagen für alle {{count}} Anbieter"
 	},
 	"models": {
 		"page_title_one": "Modell",
@@ -991,7 +994,6 @@
 		"toast_bulk_toggle_failed": "Massenschalter für einige Gruppen fehlgeschlagen",
 		"toast_provider_toggle_failed": "Massenanbieter für einige Gruppen fehlgeschlagen",
 		"toast_sync_deleted": "hotel/{{model}} gelöscht: {{reason}}{{providers}}",
-		"toast_sync_purged": "hotel/{{group}}: entfernte {{count}} veraltete Einträge(n)",
 		"toast_sync_success": "Failover Gruppen synchronisiert",
 		"toast_sync_failed": "Fehler beim Synchronisieren: {{message}}",
 		"toast_update_failed": "Aktualisierung fehlgeschlagen: {{message}}",
@@ -1037,8 +1039,11 @@
 		"provider_modal_description": "Das Deaktivieren eines Anbieters wird alle seine Modelle in jeder Failover-Gruppe deaktivieren",
 		"toast_provider_toggle_no_groups": "Keine Failover-Gruppen verwenden den Anbieter {{provider}}",
 		"last_sync_label": "Letzter Sync:",
-		"toast_sync_disabled": "hotel/{{group}} deaktiviert: {{count}} routbare(s) Mitglied(er) übrig",
-		"toast_entry_min_two": "Mindestens 2 Mitglieder müssen aktiv bleiben."
+		"toast_entry_min_two": "Mindestens 2 Mitglieder müssen aktiv bleiben.",
+		"toast_sync_purged_one": "hotel/{{group}}: {{count}} veralteten Eintrag entfernt",
+		"toast_sync_purged_other": "hotel/{{group}}: {{count}} veraltete Einträge entfernt",
+		"toast_sync_disabled_one": "hotel/{{group}} deaktiviert: {{count}} routbares Mitglied übrig",
+		"toast_sync_disabled_other": "hotel/{{group}} deaktiviert: {{count}} routbare Mitglieder übrig"
 	},
 	"delete_confirm": {
 		"unsaved_changes": "Ungespeicherte Änderungen"

--- a/web/src/i18n/locales/el.json
+++ b/web/src/i18n/locales/el.json
@@ -696,7 +696,6 @@
 		"sort_title_desc": "Ταξινόμηση Z-A (κλικ για αντιστροφή)",
 		"empty_no_match": "Κανένας πάροχος δεν ταιριάζει με το επιλεγμένο φίλτρο.",
 		"empty_no_providers": "Δεν έχουν ρυθμιστεί πάροχοι. Προσθέστε τον πρώτο πάροχο σας για να ξεκινήσετε.",
-		"toast_discovery_failed_all": "Η αναζήτηση απέτυχε για όλους τους παρόχους του {{failed}}",
 		"toast_discover_failed": "Η αναζήτηση απέτυχε: {{message}}",
 		"toast_provider_added": "Πάροχος \"{{name}}\" προστέθηκε",
 		"toast_provider_updated": "Ο πάροχος \"{{name}}\" ενημερώθηκε",
@@ -704,7 +703,6 @@
 		"toast_delete_failed": "Δεν κατέστη δυνατή η διαγραφή: {{message}}",
 		"toast_add_failed": "Δεν κατέστη δυνατή η προσθήκη παρόχου: {{message}}",
 		"toast_update_failed": "Η ενημέρωση απέτυχε: {{message}}",
-		"toast_refresh_success": "Ενημέρωση των {{count}} ποσοστώσεων/υπολοίπων",
 		"toast_refresh_warning": "Ενημερώθηκαν οι ποσοστώσεις του {{refreshed}} (το{{failed}} απέτυχε, το {{skipped}} δεν υποστηρίζεται)",
 		"toast_refresh_none": "Δεν βρέθηκαν πάροχοι με υποστήριξη ποσόστωσης/υπολοίπου",
 		"toast_refresh_failed": "Η ανανέωση των ορίων απέτυχε: {{message}}",
@@ -851,10 +849,15 @@
 			"retestDone": "Έγινε επανέλεγχος του {{provider}}",
 			"toggleSection": "Εναλλαγή ενότητας {{provider}}",
 			"failoverDisabled": "Ομάδες ανακατεύθυνσης απενεργοποιημένες",
-			"failoverDisabledReason": "απομένουν {{count}} δρομολογήσιμα μέλη, απαιτούνται 2+"
+			"failoverDisabledReason_one": "απομένει {{count}} δρομολογήσιμο μέλος, απαιτούνται 2+",
+			"failoverDisabledReason_other": "απομένουν {{count}} δρομολογήσιμα μέλη, απαιτούνται 2+"
 		},
 		"toast_quota_detected_minimax": "Ανιχνεύθηκε ποσόστωση MiniMax",
-		"type_minimax": "MiniMax"
+		"type_minimax": "MiniMax",
+		"toast_refresh_success_one": "Ενημέρωση {{count}} ποσόστωσης/υπολοίπου",
+		"toast_refresh_success_other": "Ενημέρωση {{count}} ποσοστώσεων/υπολοίπων",
+		"toast_discovery_failed_all_one": "Η αναζήτηση απέτυχε για τον πάροχο",
+		"toast_discovery_failed_all_other": "Η αναζήτηση απέτυχε για όλους τους {{count}} παρόχους"
 	},
 	"models": {
 		"page_title_one": "Μοντέλο",
@@ -991,7 +994,6 @@
 		"toast_bulk_toggle_failed": "Η μαζική εναλλαγή απέτυχε για ορισμένες ομάδες",
 		"toast_provider_toggle_failed": "Η εναλλαγή μαζικής παροχής απέτυχε για ορισμένες ομάδες",
 		"toast_sync_deleted": "hotel/{{model}} διαγράφηκε: {{reason}}{{providers}}",
-		"toast_sync_purged": "hotel/{{group}}: αφαιρέθηκε {{count}} stale entry(ies)",
 		"toast_sync_success": "Οι ομάδες απέτυχαν συγχρονίστηκαν",
 		"toast_sync_failed": "Αποτυχία συγχρονισμού: {{message}}",
 		"toast_update_failed": "Η ενημέρωση απέτυχε: {{message}}",
@@ -1037,8 +1039,11 @@
 		"provider_modal_description": "Η απενεργοποίηση ενός παρόχου θα απενεργοποιήσει όλα τα μοντέλα του σε κάθε ομάδα αποτυχίας",
 		"toast_provider_toggle_no_groups": "Δεν υπάρχουν ομάδες αποτυχίας χρήσης παρόχου {{provider}}",
 		"last_sync_label": "Τελευταίος συγχρονισμός:",
-		"toast_sync_disabled": "hotel/{{group}} απενεργοποιήθηκε: απομένουν {{count}} δρομολογήσιμα μέλη",
-		"toast_entry_min_two": "Τουλάχιστον 2 μέλη πρέπει να παραμείνουν ενεργά."
+		"toast_entry_min_two": "Τουλάχιστον 2 μέλη πρέπει να παραμείνουν ενεργά.",
+		"toast_sync_purged_one": "hotel/{{group}}: αφαιρέθηκε {{count}} παλαιά καταχώριση",
+		"toast_sync_purged_other": "hotel/{{group}}: αφαιρέθηκαν {{count}} παλαιές καταχωρίσεις",
+		"toast_sync_disabled_one": "hotel/{{group}} απενεργοποιήθηκε: απομένει {{count}} δρομολογήσιμο μέλος",
+		"toast_sync_disabled_other": "hotel/{{group}} απενεργοποιήθηκε: απομένουν {{count}} δρομολογήσιμα μέλη"
 	},
 	"delete_confirm": {
 		"unsaved_changes": "Μη Αποθηκευμένες Αλλαγές"

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -696,7 +696,6 @@
 		"sort_title_desc": "Sorted Z-A (click to reverse)",
 		"empty_no_match": "No providers match the selected filter.",
 		"empty_no_providers": "No providers configured. Add your first provider to get started.",
-		"toast_discovery_failed_all": "Discovery failed for all {{failed}} providers",
 		"toast_discover_failed": "Discovery failed: {{message}}",
 		"toast_provider_added": "Provider \"{{name}}\" added",
 		"toast_provider_updated": "Provider \"{{name}}\" updated",
@@ -704,7 +703,6 @@
 		"toast_delete_failed": "Failed to delete: {{message}}",
 		"toast_add_failed": "Failed to add provider: {{message}}",
 		"toast_update_failed": "Failed to update: {{message}}",
-		"toast_refresh_success": "Refreshed {{count}} quotas/balances",
 		"toast_refresh_warning": "Refreshed {{refreshed}} quotas ({{failed}} failed, {{skipped}} unsupported)",
 		"toast_refresh_none": "No providers with quota/balance support found",
 		"toast_refresh_failed": "Refresh quotas failed: {{message}}",
@@ -853,8 +851,13 @@
 			"retestDone": "Retested {{provider}}",
 			"toggleSection": "Toggle {{provider}} section",
 			"failoverDisabled": "Failover groups disabled",
-			"failoverDisabledReason": "{{count}} routable member(s) left, need 2+"
-		}
+			"failoverDisabledReason_one": "{{count}} routable member left, need 2+",
+			"failoverDisabledReason_other": "{{count}} routable members left, need 2+"
+		},
+		"toast_refresh_success_one": "Refreshed {{count}} quota/balance",
+		"toast_refresh_success_other": "Refreshed {{count}} quotas/balances",
+		"toast_discovery_failed_all_one": "Discovery failed for the provider",
+		"toast_discovery_failed_all_other": "Discovery failed for all {{count}} providers"
 	},
 	"models": {
 		"page_title_one": "Model",
@@ -992,7 +995,6 @@
 		"toast_bulk_toggle_failed": "Bulk toggle failed for some groups",
 		"toast_provider_toggle_failed": "Bulk provider toggle failed for some groups",
 		"toast_sync_deleted": "hotel/{{model}} deleted: {{reason}}{{providers}}",
-		"toast_sync_purged": "hotel/{{group}}: removed {{count}} stale entry(ies)",
 		"toast_sync_success": "Failover groups synced",
 		"toast_sync_failed": "Failed to sync: {{message}}",
 		"toast_update_failed": "Failed to update: {{message}}",
@@ -1037,8 +1039,11 @@
 		"provider_modal_title": "Manage Provider Status",
 		"provider_modal_description": "Disabling a provider will disable all its models in every failover group",
 		"toast_provider_toggle_no_groups": "No failover groups use provider {{provider}}",
-		"toast_sync_disabled": "hotel/{{group}} disabled: {{count}} routable member(s) left",
-		"toast_entry_min_two": "At least 2 members must stay active."
+		"toast_entry_min_two": "At least 2 members must stay active.",
+		"toast_sync_purged_one": "hotel/{{group}}: removed {{count}} stale entry",
+		"toast_sync_purged_other": "hotel/{{group}}: removed {{count}} stale entries",
+		"toast_sync_disabled_one": "hotel/{{group}} disabled: {{count}} routable member left",
+		"toast_sync_disabled_other": "hotel/{{group}} disabled: {{count}} routable members left"
 	},
 	"delete_confirm": {
 		"unsaved_changes": "Unsaved Changes"

--- a/web/src/i18n/locales/es.json
+++ b/web/src/i18n/locales/es.json
@@ -696,7 +696,6 @@
 		"sort_title_desc": "Z-A ordenada (haga clic para revertir)",
 		"empty_no_match": "Ningún proveedor coincide con el filtro seleccionado.",
 		"empty_no_providers": "No hay proveedores configurados. Añade tu primer proveedor para empezar.",
-		"toast_discovery_failed_all": "El descubrimiento falló para todos los proveedores {{failed}}",
 		"toast_discover_failed": "Descubrimiento fallido: {{message}}",
 		"toast_provider_added": "Proveedor \"{{name}}\" añadido",
 		"toast_provider_updated": "Proveedor \"{{name}}\" actualizado",
@@ -704,7 +703,6 @@
 		"toast_delete_failed": "Error al eliminar: {{message}}",
 		"toast_add_failed": "No se pudo agregar el proveedor: {{message}}",
 		"toast_update_failed": "Error al actualizar: {{message}}",
-		"toast_refresh_success": "Actualización de {{count}} cuotas/saldos",
 		"toast_refresh_warning": "Cuotas {{refreshed}} actualizadas ({{failed}} fallaron, {{skipped}} no soportados)",
 		"toast_refresh_none": "No se encontró ningún proveedor con soporte de quota/balance",
 		"toast_refresh_failed": "Error al actualizar cuotas: {{message}}",
@@ -851,10 +849,15 @@
 			"retestDone": "Se ha vuelto a probar {{provider}}",
 			"toggleSection": "Mostrar u ocultar la sección {{provider}}",
 			"failoverDisabled": "Grupos de conmutación por error desactivados",
-			"failoverDisabledReason": "quedan {{count}} miembro(s) enrutable(s), se necesitan 2+"
+			"failoverDisabledReason_one": "queda {{count}} miembro enrutable, se necesitan 2+",
+			"failoverDisabledReason_other": "quedan {{count}} miembros enrutables, se necesitan 2+"
 		},
 		"toast_quota_detected_minimax": "Cuota de MiniMax detectada",
-		"type_minimax": "MiniMax"
+		"type_minimax": "MiniMax",
+		"toast_refresh_success_one": "Actualización de {{count}} cuota/saldo",
+		"toast_refresh_success_other": "Actualización de {{count}} cuotas/saldos",
+		"toast_discovery_failed_all_one": "El descubrimiento falló para el proveedor",
+		"toast_discovery_failed_all_other": "El descubrimiento falló para todos los {{count}} proveedores"
 	},
 	"models": {
 		"page_title_one": "Modelo",
@@ -991,7 +994,6 @@
 		"toast_bulk_toggle_failed": "Fallo al alternar masivo para algunos grupos",
 		"toast_provider_toggle_failed": "Error al alternar proveedores masivos para algunos grupos",
 		"toast_sync_deleted": "hotel/{{model}} eliminado: {{reason}}{{providers}}",
-		"toast_sync_purged": "hotel/{{group}}: se ha eliminado la entrada antigua de {{count}}",
 		"toast_sync_success": "Grupos de fallo sincronizados",
 		"toast_sync_failed": "Error al sincronizar: {{message}}",
 		"toast_update_failed": "Error al actualizar: {{message}}",
@@ -1037,8 +1039,11 @@
 		"provider_modal_description": "Deshabilitar un proveedor desactivará todos sus modelos en cada grupo de tolerancia contra fallos",
 		"toast_provider_toggle_no_groups": "Ningún grupo de tolerancia contra fallos utiliza el proveedor {{provider}}",
 		"last_sync_label": "Última sincronización:",
-		"toast_sync_disabled": "hotel/{{group}} desactivado: quedan {{count}} miembro(s) enrutable(s)",
-		"toast_entry_min_two": "Al menos 2 miembros deben permanecer activos."
+		"toast_entry_min_two": "Al menos 2 miembros deben permanecer activos.",
+		"toast_sync_purged_one": "hotel/{{group}}: se ha eliminado {{count}} entrada antigua",
+		"toast_sync_purged_other": "hotel/{{group}}: se han eliminado {{count}} entradas antiguas",
+		"toast_sync_disabled_one": "hotel/{{group}} desactivado: queda {{count}} miembro enrutable",
+		"toast_sync_disabled_other": "hotel/{{group}} desactivado: quedan {{count}} miembros enrutables"
 	},
 	"delete_confirm": {
 		"unsaved_changes": "Cambios sin guardar"

--- a/web/src/i18n/locales/fi.json
+++ b/web/src/i18n/locales/fi.json
@@ -696,7 +696,6 @@
 		"sort_title_desc": "Lajiteltu Z-A (klikkaa peruuttaaksesi)",
 		"empty_no_match": "Yksikään tarjoaja ei vastaa valittua suodatinta.",
 		"empty_no_providers": "Yhtään palveluntarjoajaa ei määritetty. Lisää ensimmäinen palveluntarjoajasi aloittaaksesi.",
-		"toast_discovery_failed_all": "Löytäminen epäonnistui kaikille {{failed}} palveluntarjoajille",
 		"toast_discover_failed": "Löytäminen epäonnistui: {{message}}",
 		"toast_provider_added": "Tarjoaja \"{{name}}\" lisätty",
 		"toast_provider_updated": "Tarjoaja \"{{name}}\" päivitetty",
@@ -704,7 +703,6 @@
 		"toast_delete_failed": "Poistaminen epäonnistui: {{message}}",
 		"toast_add_failed": "Tarjoajan lisääminen epäonnistui: {{message}}",
 		"toast_update_failed": "Päivitys epäonnistui: {{message}}",
-		"toast_refresh_success": "Päivitetyt {{count}} kiintiötä/saldoa",
 		"toast_refresh_warning": " {{refreshed}} -kiintiöt on päivitetty ({{failed}} -kiintiöiden päivitys epäonnistui, {{skipped}} -kiintiöitä ei tueta)",
 		"toast_refresh_none": "Yhtään palveluntarjoajaa, joilla on kiintiö-/saldotukea",
 		"toast_refresh_failed": "Kiintiöiden päivitys epäonnistui: {{message}}",
@@ -851,10 +849,15 @@
 			"retestDone": "{{provider}} testattu uudelleen",
 			"toggleSection": "Näytä tai piilota osio {{provider}}",
 			"failoverDisabled": "Vikasietoryhmät poistettu käytöstä",
-			"failoverDisabledReason": "{{count}} reititettävää jäsentä jäljellä, tarvitaan 2+"
+			"failoverDisabledReason_one": "{{count}} reititettävä jäsen jäljellä, tarvitaan 2+",
+			"failoverDisabledReason_other": "{{count}} reititettävää jäsentä jäljellä, tarvitaan 2+"
 		},
 		"toast_quota_detected_minimax": "MiniMax-kiintiö havaittu",
-		"type_minimax": "MiniMax"
+		"type_minimax": "MiniMax",
+		"toast_refresh_success_one": "Päivitetty {{count}} kiintiö/saldo",
+		"toast_refresh_success_other": "Päivitetty {{count}} kiintiötä/saldoa",
+		"toast_discovery_failed_all_one": "Löytäminen epäonnistui palveluntarjoajalle",
+		"toast_discovery_failed_all_other": "Löytäminen epäonnistui kaikille {{count}} palveluntarjoajalle"
 	},
 	"models": {
 		"page_title_one": "Malli",
@@ -991,7 +994,6 @@
 		"toast_bulk_toggle_failed": "Bulk vaihto epäonnistui joillekin ryhmille",
 		"toast_provider_toggle_failed": "Bulk tarjoajan vaihtaminen epäonnistui joillekin ryhmille",
 		"toast_sync_deleted": "hotelli/{{model}} poistettu: {{reason}}{{providers}}",
-		"toast_sync_purged": "hotelli/{{group}}: poistettu {{count}} vanhentuneet merkinnät",
 		"toast_sync_success": "Epäonnistumisryhmien synkronointi",
 		"toast_sync_failed": "Synkronointia ei voitu suorittaa: {{message}}",
 		"toast_update_failed": "Päivitys epäonnistui: {{message}}",
@@ -1037,8 +1039,11 @@
 		"provider_modal_description": "Tarjoajan poistaminen käytöstä poistaa kaikki sen mallit käytöstä jokaisessa epäonnistumisryhmässä",
 		"toast_provider_toggle_no_groups": "Ei epäonnistumisryhmiä käytä tarjoajaa {{provider}}",
 		"last_sync_label": "Viimeisin synkronointi:",
-		"toast_sync_disabled": "hotelli/{{group}} poistettu käytöstä: {{count}} reititettävää jäsentä jäljellä",
-		"toast_entry_min_two": "Vähintään 2 jäsentä on pysyttävä aktiivisena."
+		"toast_entry_min_two": "Vähintään 2 jäsentä on pysyttävä aktiivisena.",
+		"toast_sync_purged_one": "hotelli/{{group}}: poistettu {{count}} vanhentunut merkintä",
+		"toast_sync_purged_other": "hotelli/{{group}}: poistettu {{count}} vanhentunutta merkintää",
+		"toast_sync_disabled_one": "hotelli/{{group}} poistettu käytöstä: {{count}} reititettävä jäsen jäljellä",
+		"toast_sync_disabled_other": "hotelli/{{group}} poistettu käytöstä: {{count}} reititettävää jäsentä jäljellä"
 	},
 	"delete_confirm": {
 		"unsaved_changes": "Tallentamattomat Muutokset"

--- a/web/src/i18n/locales/fr.json
+++ b/web/src/i18n/locales/fr.json
@@ -696,7 +696,6 @@
 		"sort_title_desc": "Trié Z-A (cliquez pour inverser)",
 		"empty_no_match": "Aucun fournisseur ne correspond au filtre sélectionné.",
 		"empty_no_providers": "Aucun fournisseur configuré. Ajoutez votre premier fournisseur pour commencer.",
-		"toast_discovery_failed_all": "La découverte a échoué pour tous les fournisseurs {{failed}}",
 		"toast_discover_failed": "Échec de la découverte : {{message}}",
 		"toast_provider_added": "Ajout du fournisseur «{{name}}»",
 		"toast_provider_updated": "Fournisseur \"{{name}}\" mis à jour",
@@ -704,7 +703,6 @@
 		"toast_delete_failed": "Échec de la suppression : {{message}}",
 		"toast_add_failed": "Impossible d'ajouter le fournisseur : {{message}}",
 		"toast_update_failed": "Échec de la mise à jour : {{message}}",
-		"toast_refresh_success": "Quota/Soldes {{count}} actualisés",
 		"toast_refresh_warning": "Mise à jour des quotas {{refreshed}} ({{failed}} échoué, {{skipped}} non pris en charge)",
 		"toast_refresh_none": "Aucun fournisseur avec le support du quota/solde trouvé",
 		"toast_refresh_failed": "Échec de l'actualisation des quotas : {{message}}",
@@ -851,10 +849,15 @@
 			"retestDone": "{{provider}} retesté",
 			"toggleSection": "Afficher ou masquer la section {{provider}}",
 			"failoverDisabled": "Groupes de basculement désactivés",
-			"failoverDisabledReason": "{{count}} membre(s) routable(s) restant(s), 2+ requis"
+			"failoverDisabledReason_one": "{{count}} membre routable restant, 2+ requis",
+			"failoverDisabledReason_other": "{{count}} membres routables restants, 2+ requis"
 		},
 		"toast_quota_detected_minimax": "Quota MiniMax détecté",
-		"type_minimax": "MiniMax"
+		"type_minimax": "MiniMax",
+		"toast_refresh_success_one": "Quota/Solde {{count}} actualisé",
+		"toast_refresh_success_other": "Quotas/Soldes {{count}} actualisés",
+		"toast_discovery_failed_all_one": "La découverte a échoué pour le fournisseur",
+		"toast_discovery_failed_all_other": "La découverte a échoué pour tous les {{count}} fournisseurs"
 	},
 	"models": {
 		"page_title_one": "Modèle",
@@ -991,7 +994,6 @@
 		"toast_bulk_toggle_failed": "Échec de l'activation en bloc pour certains groupes",
 		"toast_provider_toggle_failed": "Échec du basculement du fournisseur de masse pour certains groupes",
 		"toast_sync_deleted": "hotel/{{model}} supprimé: {{reason}}{{providers}}",
-		"toast_sync_purged": "hôtel/{{group}}: suppression de l'adresse {{count}} (entrée(s) obsolète(s))",
 		"toast_sync_success": "Groupes de basculement synchronisés",
 		"toast_sync_failed": "Échec de la synchronisation : {{message}}",
 		"toast_update_failed": "Échec de la mise à jour : {{message}}",
@@ -1037,8 +1039,11 @@
 		"provider_modal_description": "Désactiver un fournisseur désactivera tous ses modèles dans chaque groupe de basculement",
 		"toast_provider_toggle_no_groups": "Aucun groupe de basculement n'utilise le fournisseur {{provider}}",
 		"last_sync_label": "Dernière synchronisation :",
-		"toast_sync_disabled": "hôtel/{{group}} désactivé : {{count}} membre(s) routable(s) restant(s)",
-		"toast_entry_min_two": "Au moins 2 membres doivent rester actifs."
+		"toast_entry_min_two": "Au moins 2 membres doivent rester actifs.",
+		"toast_sync_purged_one": "hôtel/{{group}} : {{count}} entrée obsolète supprimée",
+		"toast_sync_purged_other": "hôtel/{{group}} : {{count}} entrées obsolètes supprimées",
+		"toast_sync_disabled_one": "hôtel/{{group}} désactivé : {{count}} membre routable restant",
+		"toast_sync_disabled_other": "hôtel/{{group}} désactivé : {{count}} membres routables restants"
 	},
 	"delete_confirm": {
 		"unsaved_changes": "Modifications non enregistrées"

--- a/web/src/i18n/locales/he.json
+++ b/web/src/i18n/locales/he.json
@@ -696,7 +696,6 @@
 		"sort_title_desc": "מסודר לפי Z-A (לחץ כדי להפוך את הסדר)",
 		"empty_no_match": "אין ספקים העונים על הקריטריונים שנבחרו.",
 		"empty_no_providers": "לא הוגדרו ספקים. הוסף את הספק הראשון שלך כדי להתחיל.",
-		"toast_discovery_failed_all": "לא נמצא אף ספק בכתובת {{failed}}",
 		"toast_discover_failed": "החיפוש נכשל: {{message}}",
 		"toast_provider_added": "הספק \"{{name}}\" נוסף",
 		"toast_provider_updated": "הספק \"{{name}}\" עודכן",
@@ -704,7 +703,6 @@
 		"toast_delete_failed": "לא הצליח למחוק: {{message}}",
 		"toast_add_failed": "לא הצליח להוסיף ספק: {{message}}",
 		"toast_update_failed": "לא הצליח לעדכן: {{message}}",
-		"toast_refresh_success": "עודכן {{count}} מכסות/יתרות",
 		"toast_refresh_warning": "מכסות ה- {{refreshed}} עודכנו ({{failed}} נכשל, {{skipped}} אינו נתמך)",
 		"toast_refresh_none": "לא נמצאו ספקים התומכים במכסות/יתרות",
 		"toast_refresh_failed": "לא ניתן לרענן את מכסות: {{message}}",
@@ -851,10 +849,15 @@
 			"retestDone": "{{provider}} נבדק מחדש",
 			"toggleSection": "החלף את מקטע {{provider}}",
 			"failoverDisabled": "קבוצות מעבר למקרה כשל הושבתו",
-			"failoverDisabledReason": "נותרו {{count}} חברים הניתנים לניתוב, נדרשים 2+"
+			"failoverDisabledReason_one": "נותר {{count}} חבר הניתן לניתוב, נדרשים 2+",
+			"failoverDisabledReason_other": "נותרו {{count}} חברים הניתנים לניתוב, נדרשים 2+"
 		},
 		"toast_quota_detected_minimax": "זוהתה מכסת MiniMax",
-		"type_minimax": "MiniMax"
+		"type_minimax": "MiniMax",
+		"toast_refresh_success_one": "עודכנה {{count}} מכסה/יתרה",
+		"toast_refresh_success_other": "עודכנו {{count}} מכסות/יתרות",
+		"toast_discovery_failed_all_one": "הגילוי נכשל עבור הספק",
+		"toast_discovery_failed_all_other": "הגילוי נכשל עבור כל {{count}} הספקים"
 	},
 	"models": {
 		"page_title_one": "מודל",
@@ -991,7 +994,6 @@
 		"toast_bulk_toggle_failed": "הפעלת/כיבוי המוני נכשל עבור חלק מהקבוצות",
 		"toast_provider_toggle_failed": "הפעלת/כיבוי האפשרות 'ספק בכמות גדולה' נכשלה עבור קבוצות מסוימות",
 		"toast_sync_deleted": "מלון/{{model}} נמחק: {{reason}}{{providers}}",
-		"toast_sync_purged": "מלון/{{group}}: הוסרו {{count}} רשומות מיושנות",
 		"toast_sync_success": "קבוצות מעבר לגיבוי מסונכרנות",
 		"toast_sync_failed": "לא הצליח לסנכרן: {{message}}",
 		"toast_update_failed": "לא הצליח לעדכן: {{message}}",
@@ -1037,8 +1039,11 @@
 		"provider_modal_description": "השבתת ספק תשבית את כל הדגמים שלו בכל קבוצת מעבר לגיבוי",
 		"toast_provider_toggle_no_groups": "אף קבוצת מעבר לגיבוי אינה משתמשת בספק {{provider}}",
 		"last_sync_label": "הסנכרון האחרון:",
-		"toast_sync_disabled": "מלון/{{group}} מושבת: נותרו {{count}} חברים הניתנים לניתוב",
-		"toast_entry_min_two": "לפחות 2 חברים חייבים להישאר פעילים."
+		"toast_entry_min_two": "לפחות 2 חברים חייבים להישאר פעילים.",
+		"toast_sync_purged_one": "מלון/{{group}}: הוסרה {{count}} רשומה מיושנת",
+		"toast_sync_purged_other": "מלון/{{group}}: הוסרו {{count}} רשומות מיושנות",
+		"toast_sync_disabled_one": "מלון/{{group}} מושבת: נותר {{count}} חבר הניתן לניתוב",
+		"toast_sync_disabled_other": "מלון/{{group}} מושבת: נותרו {{count}} חברים הניתנים לניתוב"
 	},
 	"delete_confirm": {
 		"unsaved_changes": "שינויים שלא נשמרו"

--- a/web/src/i18n/locales/hu.json
+++ b/web/src/i18n/locales/hu.json
@@ -696,7 +696,6 @@
 		"sort_title_desc": "Z–A sorrendben (kattintson a sorrend megfordításához)",
 		"empty_no_match": "A kiválasztott szűrőnek nem felel meg egyetlen szolgáltató sem.",
 		"empty_no_providers": "Nincs beállított szolgáltató. Az induláshoz adja hozzá az első szolgáltatót.",
-		"toast_discovery_failed_all": "A felfedezés sikertelen volt az összes {{failed}} szolgáltató esetében",
 		"toast_discover_failed": "A felfedezés sikertelen volt: {{message}}",
 		"toast_provider_added": "Hozzáadva a „{{name}}” szolgáltató",
 		"toast_provider_updated": "A „{{name}}” szolgáltató frissítve",
@@ -704,7 +703,6 @@
 		"toast_delete_failed": "A törlés nem sikerült: {{message}}",
 		"toast_add_failed": "A szolgáltató hozzáadása nem sikerült: {{message}}",
 		"toast_update_failed": "A frissítés nem sikerült: {{message}}",
-		"toast_refresh_success": "Frissítve: {{count}} kvóták/egyenlegek",
 		"toast_refresh_warning": "A {{refreshed}} kvóták frissítése (a{{failed}} frissítése sikertelen, a {{skipped}} nem támogatott)",
 		"toast_refresh_none": "Nem találtam olyan szolgáltatót, amely támogatná a kvótát/egyenleget",
 		"toast_refresh_failed": "A kvóták frissítése sikertelen volt: {{message}}",
@@ -851,10 +849,15 @@
 			"retestDone": "{{provider}} újratesztelve",
 			"toggleSection": "{{provider}} szakasz be- és kikapcsolása",
 			"failoverDisabled": "Letiltott failover csoportok",
-			"failoverDisabledReason": "{{count}} útválasztható tag maradt, 2+ szükséges"
+			"failoverDisabledReason_one": "{{count}} útválasztható tag maradt, 2+ szükséges",
+			"failoverDisabledReason_other": "{{count}} útválasztható tag maradt, 2+ szükséges"
 		},
 		"toast_quota_detected_minimax": "MiniMax kvóta észlelve",
-		"type_minimax": "MiniMax"
+		"type_minimax": "MiniMax",
+		"toast_refresh_success_one": "Frissítve: {{count}} kvóta/egyenleg",
+		"toast_refresh_success_other": "Frissítve: {{count}} kvóta/egyenleg",
+		"toast_discovery_failed_all_one": "A felfedezés sikertelen volt a szolgáltatónál",
+		"toast_discovery_failed_all_other": "A felfedezés sikertelen volt mind a(z) {{count}} szolgáltatónál"
 	},
 	"models": {
 		"page_title_one": "Modell",
@@ -991,7 +994,6 @@
 		"toast_bulk_toggle_failed": "Néhány csoportnál nem sikerült a tömeges átkapcsolás",
 		"toast_provider_toggle_failed": "Egyes csoportoknál nem sikerült a tömeges szolgáltatókapcsolás",
 		"toast_sync_deleted": "szálloda/{{model}} törölve: {{reason}}{{providers}}",
-		"toast_sync_purged": "szálloda/{{group}}: eltávolítva {{count}} elavult bejegyzés(ek)",
 		"toast_sync_success": "A feladatátvételi csoportok szinkronizálva",
 		"toast_sync_failed": "A szinkronizálás nem sikerült: {{message}}",
 		"toast_update_failed": "A frissítés nem sikerült: {{message}}",
@@ -1037,8 +1039,11 @@
 		"provider_modal_description": "Egy szolgáltató letiltása minden failover-csoportban letiltja az összes modelljét",
 		"toast_provider_toggle_no_groups": "Egyetlen átállási csoport sem használja a szolgáltatót {{provider}}",
 		"last_sync_label": "Utolsó szinkronizálás:",
-		"toast_sync_disabled": "szálloda/{{group}} letiltva: {{count}} útválasztható tag maradt",
-		"toast_entry_min_two": "Legalább 2 tagnak aktívnak kell maradnia."
+		"toast_entry_min_two": "Legalább 2 tagnak aktívnak kell maradnia.",
+		"toast_sync_purged_one": "szálloda/{{group}}: {{count}} elavult bejegyzés eltávolítva",
+		"toast_sync_purged_other": "szálloda/{{group}}: {{count}} elavult bejegyzés eltávolítva",
+		"toast_sync_disabled_one": "szálloda/{{group}} letiltva: {{count}} útválasztható tag maradt",
+		"toast_sync_disabled_other": "szálloda/{{group}} letiltva: {{count}} útválasztható tag maradt"
 	},
 	"delete_confirm": {
 		"unsaved_changes": "Még nem mentett módosítások"

--- a/web/src/i18n/locales/it.json
+++ b/web/src/i18n/locales/it.json
@@ -696,7 +696,6 @@
 		"sort_title_desc": "Z-A ordinata (clicca per invertire)",
 		"empty_no_match": "Nessun provider corrisponde al filtro selezionato.",
 		"empty_no_providers": "Nessun provider configurato. Aggiungi il tuo primo provider per iniziare.",
-		"toast_discovery_failed_all": "Scoperta fallita per tutti i provider {{failed}}",
 		"toast_discover_failed": "Scoperta non riuscita: {{message}}",
 		"toast_provider_added": "Provider \"{{name}}\" aggiunto",
 		"toast_provider_updated": "Provider \"{{name}}\" aggiornato",
@@ -704,7 +703,6 @@
 		"toast_delete_failed": "Impossibile eliminare: {{message}}",
 		"toast_add_failed": "Impossibile aggiungere il provider: {{message}}",
 		"toast_update_failed": "Aggiornamento non riuscito: {{message}}",
-		"toast_refresh_success": "Aggiornato {{count}} quote/saldi",
 		"toast_refresh_warning": "Quote aggiornate {{refreshed}} ({{failed}} fallito, {{skipped}} non supportato)",
 		"toast_refresh_none": "Nessun provider con supporto quota/saldo trovato",
 		"toast_refresh_failed": "Aggiornamento quote non riuscito: {{message}}",
@@ -851,10 +849,15 @@
 			"retestDone": "{{provider}} ritestato",
 			"toggleSection": "Mostra o nascondi la sezione {{provider}}",
 			"failoverDisabled": "Gruppi di failover disabilitati",
-			"failoverDisabledReason": "{{count}} membro/i instradabile/i rimasto/i, ne servono 2+"
+			"failoverDisabledReason_one": "{{count}} membro instradabile rimasto, ne servono 2+",
+			"failoverDisabledReason_other": "{{count}} membri instradabili rimasti, ne servono 2+"
 		},
 		"toast_quota_detected_minimax": "Rilevata quota MiniMax",
-		"type_minimax": "MiniMax"
+		"type_minimax": "MiniMax",
+		"toast_refresh_success_one": "Aggiornata {{count}} quota/saldo",
+		"toast_refresh_success_other": "Aggiornate {{count}} quote/saldi",
+		"toast_discovery_failed_all_one": "Rilevamento non riuscito per il provider",
+		"toast_discovery_failed_all_other": "Rilevamento non riuscito per tutti i {{count}} provider"
 	},
 	"models": {
 		"page_title_one": "Modello",
@@ -991,7 +994,6 @@
 		"toast_bulk_toggle_failed": "Interruttore di massa fallito per alcuni gruppi",
 		"toast_provider_toggle_failed": "Attiva/disattiva provider Bulk per alcuni gruppi",
 		"toast_sync_deleted": "hotel/{{model}} eliminato: {{reason}}{{providers}}",
-		"toast_sync_purged": "hotel/{{group}}: rimosso {{count}} stale entry(ies)",
 		"toast_sync_success": "Gruppi di failover sincronizzati",
 		"toast_sync_failed": "Sincronizzazione non riuscita: {{message}}",
 		"toast_update_failed": "Aggiornamento non riuscito: {{message}}",
@@ -1037,8 +1039,11 @@
 		"provider_modal_description": "Disabilitare un provider disabiliterà tutti i suoi modelli in ogni gruppo di failover",
 		"toast_provider_toggle_no_groups": "Nessun gruppo di failover usa il provider {{provider}}",
 		"last_sync_label": "Ultima sincronizzazione:",
-		"toast_sync_disabled": "hotel/{{group}} disabilitato: {{count}} membro/i instradabile/i rimasto/i",
-		"toast_entry_min_two": "Almeno 2 membri devono rimanere attivi."
+		"toast_entry_min_two": "Almeno 2 membri devono rimanere attivi.",
+		"toast_sync_purged_one": "hotel/{{group}}: rimossa {{count}} voce obsoleta",
+		"toast_sync_purged_other": "hotel/{{group}}: rimosse {{count}} voci obsolete",
+		"toast_sync_disabled_one": "hotel/{{group}} disabilitato: {{count}} membro instradabile rimasto",
+		"toast_sync_disabled_other": "hotel/{{group}} disabilitato: {{count}} membri instradabili rimasti"
 	},
 	"delete_confirm": {
 		"unsaved_changes": "Modifiche Non Salvate"

--- a/web/src/i18n/locales/ja.json
+++ b/web/src/i18n/locales/ja.json
@@ -696,7 +696,6 @@
 		"sort_title_desc": "Z-Aを並べ替えました（クリックすると元に戻します）",
 		"empty_no_match": "選択したフィルタに一致するプロバイダがありません。",
 		"empty_no_providers": "プロバイダが設定されていません。最初のプロバイダを追加して開始します。",
-		"toast_discovery_failed_all": "すべての {{failed}} プロバイダーの検出に失敗しました",
 		"toast_discover_failed": "ディスカバリーに失敗しました: {{message}}",
 		"toast_provider_added": "プロバイダー \"{{name}}\" が追加されました",
 		"toast_provider_updated": "プロバイダー \"{{name}}\" が更新されました",
@@ -704,7 +703,6 @@
 		"toast_delete_failed": "{{message}} の削除に失敗しました",
 		"toast_add_failed": "プロバイダの追加に失敗しました: {{message}}",
 		"toast_update_failed": "更新に失敗しました: {{message}}",
-		"toast_refresh_success": "更新された {{count}} クォータ/残高",
 		"toast_refresh_warning": " {{refreshed}} クォータを更新しました ({{failed}} 失敗しました, {{skipped}} サポートされていません)",
 		"toast_refresh_none": "クォータ/残高サポートを持つプロバイダが見つかりません",
 		"toast_refresh_failed": "クォータの更新に失敗しました: {{message}}",
@@ -851,10 +849,15 @@
 			"retestDone": "{{provider}} を再テストしました",
 			"toggleSection": "{{provider}} セクションの表示切り替え",
 			"failoverDisabled": "フェイルオーバーグループが無効化されました",
-			"failoverDisabledReason": "ルーティング可能なメンバーが {{count}} 個、2個以上必要"
+			"failoverDisabledReason_one": "ルーティング可能なメンバーが残り {{count}} 個、2個以上必要",
+			"failoverDisabledReason_other": "ルーティング可能なメンバーが残り {{count}} 個、2個以上必要"
 		},
 		"toast_quota_detected_minimax": "MiniMax のクオータを検出しました",
-		"type_minimax": "MiniMax"
+		"type_minimax": "MiniMax",
+		"toast_refresh_success_one": "{{count}} 件のクォータ/残高を更新しました",
+		"toast_refresh_success_other": "{{count}} 件のクォータ/残高を更新しました",
+		"toast_discovery_failed_all_one": "プロバイダーの検出に失敗しました",
+		"toast_discovery_failed_all_other": "すべての {{count}} プロバイダーの検出に失敗しました"
 	},
 	"models": {
 		"page_title_one": "モデル",
@@ -991,7 +994,6 @@
 		"toast_bulk_toggle_failed": "いくつかのグループの一括切り替えに失敗しました",
 		"toast_provider_toggle_failed": "一部のグループの一括プロバイダの切り替えに失敗しました",
 		"toast_sync_deleted": "ホテル/{{model}} 削除: {{reason}}{{providers}}",
-		"toast_sync_purged": "hotel/{{group}}: {{count}} 古いエントリを削除しました",
 		"toast_sync_success": "フェイルオーバーグループが同期されました",
 		"toast_sync_failed": "同期に失敗しました: {{message}}",
 		"toast_update_failed": "更新に失敗しました: {{message}}",
@@ -1037,8 +1039,11 @@
 		"provider_modal_description": "プロバイダを無効にすると、フェイルオーバーグループのすべてのモデルが無効になります",
 		"toast_provider_toggle_no_groups": "フェイルオーバーグループでプロバイダ {{provider}}を使用しません",
 		"last_sync_label": "前回の同期:",
-		"toast_sync_disabled": "hotel/{{group}} を無効化しました: ルーティング可能なメンバーが {{count}} 個",
-		"toast_entry_min_two": "少なくとも2つのメンバーをアクティブのままにする必要があります。"
+		"toast_entry_min_two": "少なくとも2つのメンバーをアクティブのままにする必要があります。",
+		"toast_sync_purged_one": "hotel/{{group}}: 古いエントリを {{count}} 件削除しました",
+		"toast_sync_purged_other": "hotel/{{group}}: 古いエントリを {{count}} 件削除しました",
+		"toast_sync_disabled_one": "hotel/{{group}} を無効化しました: ルーティング可能なメンバーが残り {{count}} 個",
+		"toast_sync_disabled_other": "hotel/{{group}} を無効化しました: ルーティング可能なメンバーが残り {{count}} 個"
 	},
 	"delete_confirm": {
 		"unsaved_changes": "保存されていない変更"

--- a/web/src/i18n/locales/ko.json
+++ b/web/src/i18n/locales/ko.json
@@ -696,7 +696,6 @@
 		"sort_title_desc": "Z-A 순서 (클릭하면 순서 반전)",
 		"empty_no_match": "선택한 필터에 해당하는 제공자가 없습니다.",
 		"empty_no_providers": "설정된 공급자가 없습니다. 시작하려면 첫 번째 공급자를 추가하세요.",
-		"toast_discovery_failed_all": "모든 {{failed}} 제공자에 대해 검색에 실패했습니다",
 		"toast_discover_failed": "탐색에 실패했습니다: {{message}}",
 		"toast_provider_added": "제공자 \"{{name}}\"가 추가되었습니다",
 		"toast_provider_updated": "제공자 \"{{name}}\"가 업데이트되었습니다",
@@ -704,7 +703,6 @@
 		"toast_delete_failed": "삭제에 실패했습니다: {{message}}",
 		"toast_add_failed": "프로바이더 추가에 실패했습니다: {{message}}",
 		"toast_update_failed": "업데이트에 실패했습니다: {{message}}",
-		"toast_refresh_success": "{{count}} 의 할당량/잔액 업데이트",
 		"toast_refresh_warning": " {{refreshed}} 할당량 갱신 ({{failed}} 실패, {{skipped}} 미지원)",
 		"toast_refresh_none": "할당량/잔액 기능을 지원하는 제공자가 없습니다.",
 		"toast_refresh_failed": "할당량 갱신에 실패했습니다: {{message}}",
@@ -851,10 +849,15 @@
 			"retestDone": "{{provider}} 다시 테스트함",
 			"toggleSection": "{{provider}} 섹션 전환",
 			"failoverDisabled": "페일오버 그룹 비활성화됨",
-			"failoverDisabledReason": "라우팅 가능한 멤버 {{count}}개 남음, 2개 이상 필요"
+			"failoverDisabledReason_one": "라우팅 가능한 멤버 {{count}}개 남음, 2개 이상 필요",
+			"failoverDisabledReason_other": "라우팅 가능한 멤버 {{count}}개 남음, 2개 이상 필요"
 		},
 		"toast_quota_detected_minimax": "MiniMax 할당량 감지됨",
-		"type_minimax": "MiniMax"
+		"type_minimax": "MiniMax",
+		"toast_refresh_success_one": "{{count}}개의 할당량/잔액 업데이트",
+		"toast_refresh_success_other": "{{count}}개의 할당량/잔액 업데이트",
+		"toast_discovery_failed_all_one": "공급자 검색에 실패했습니다",
+		"toast_discovery_failed_all_other": "모든 {{count}}개 공급자 검색에 실패했습니다"
 	},
 	"models": {
 		"page_title_one": "모델",
@@ -991,7 +994,6 @@
 		"toast_bulk_toggle_failed": "일부 그룹에서 일괄 토글이 실패했습니다",
 		"toast_provider_toggle_failed": "일부 그룹에서 대량 제공자 토글이 실패했습니다",
 		"toast_sync_deleted": "호텔/{{model}} 삭제됨: {{reason}}{{providers}}",
-		"toast_sync_purged": "호텔/{{group}}: 삭제됨 {{count}} 오래된 게시물",
 		"toast_sync_success": "페일오버 그룹 동기화됨",
 		"toast_sync_failed": "동기화 실패: {{message}}",
 		"toast_update_failed": "업데이트에 실패했습니다: {{message}}",
@@ -1037,8 +1039,11 @@
 		"provider_modal_description": "프로바이더를 비활성화하면 모든 페일오버 그룹에서 해당 프로바이더의 모든 모델이 비활성화됩니다.",
 		"toast_provider_toggle_no_groups": "이 공급자를 사용하는 장애 조치 그룹이 없습니다 {{provider}}",
 		"last_sync_label": "마지막 동기화:",
-		"toast_sync_disabled": "호텔/{{group}} 비활성화됨: 라우팅 가능한 멤버 {{count}}개 남음",
-		"toast_entry_min_two": "최소 2개의 구성원이 활성 상태를 유지해야 합니다."
+		"toast_entry_min_two": "최소 2개의 구성원이 활성 상태를 유지해야 합니다.",
+		"toast_sync_purged_one": "호텔/{{group}}: 오래된 항목 {{count}}개 삭제됨",
+		"toast_sync_purged_other": "호텔/{{group}}: 오래된 항목 {{count}}개 삭제됨",
+		"toast_sync_disabled_one": "호텔/{{group}} 비활성화됨: 라우팅 가능한 멤버 {{count}}개 남음",
+		"toast_sync_disabled_other": "호텔/{{group}} 비활성화됨: 라우팅 가능한 멤버 {{count}}개 남음"
 	},
 	"delete_confirm": {
 		"unsaved_changes": "저장되지 않은 변경 사항"

--- a/web/src/i18n/locales/nl.json
+++ b/web/src/i18n/locales/nl.json
@@ -696,7 +696,6 @@
 		"sort_title_desc": "Gesorteerd op Z-A (klik om terug te keren)",
 		"empty_no_match": "Geen enkele provider komt overeen met het geselecteerde filter.",
 		"empty_no_providers": "Geen aanbieders geconfigureerd. Voeg je eerste provider toe om te beginnen.",
-		"toast_discovery_failed_all": "Ontdekken mislukt voor alle {{failed}} providers",
 		"toast_discover_failed": "Ontdekking mislukt: {{message}}",
 		"toast_provider_added": "Provider \"{{name}}\" toegevoegd",
 		"toast_provider_updated": "Provider \"{{name}}\" bijgewerkt",
@@ -704,7 +703,6 @@
 		"toast_delete_failed": "Verwijderen mislukt: {{message}}",
 		"toast_add_failed": "Leverancier toevoegen mislukt: {{message}}",
 		"toast_update_failed": "Bijwerken mislukt: {{message}}",
-		"toast_refresh_success": "Vernieuwde {{count}} quota/saldi",
 		"toast_refresh_warning": "Vernieuwde {{refreshed}} quota ({{failed}} mislukt, {{skipped}} niet ondersteund)",
 		"toast_refresh_none": "Geen aanbieders met quota/saldo ondersteuning gevonden",
 		"toast_refresh_failed": "quota's vernieuwen mislukt: {{message}}",
@@ -851,10 +849,15 @@
 			"retestDone": "{{provider}} opnieuw getest",
 			"toggleSection": "Sectie {{provider}} in-/uitklappen",
 			"failoverDisabled": "Failover-groepen uitgeschakeld",
-			"failoverDisabledReason": "{{count}} routeerbaar lid/leden over, 2+ vereist"
+			"failoverDisabledReason_one": "{{count}} routeerbaar lid over, 2+ vereist",
+			"failoverDisabledReason_other": "{{count}} routeerbare leden over, 2+ vereist"
 		},
 		"toast_quota_detected_minimax": "MiniMax quotum gedetecteerd",
-		"type_minimax": "MiniMax"
+		"type_minimax": "MiniMax",
+		"toast_refresh_success_one": "{{count}} quota/saldo vernieuwd",
+		"toast_refresh_success_other": "{{count}} quota/saldi vernieuwd",
+		"toast_discovery_failed_all_one": "Ontdekken mislukt voor de provider",
+		"toast_discovery_failed_all_other": "Ontdekken mislukt voor alle {{count}} providers"
 	},
 	"models": {
 		"page_title_one": "Model",
@@ -991,7 +994,6 @@
 		"toast_bulk_toggle_failed": "Bulkschakelaar voor sommige groepen mislukt",
 		"toast_provider_toggle_failed": "Bulk provider wisselen mislukt voor sommige groepen",
 		"toast_sync_deleted": "hotel/{{model}} verwijderd: {{reason}}{{providers}}",
-		"toast_sync_purged": "hotel/{{group}}: verwijderde {{count}} verouderde post(ën)",
 		"toast_sync_success": "Failover groepen gesynchroniseerd",
 		"toast_sync_failed": "Synchroniseren mislukt: {{message}}",
 		"toast_update_failed": "Bijwerken mislukt: {{message}}",
@@ -1037,8 +1039,11 @@
 		"provider_modal_description": "Het uitschakelen van een provider zal al zijn modellen in elke mislukte groep uitschakelen",
 		"toast_provider_toggle_no_groups": "Geen failover groepen gebruiken provider {{provider}}",
 		"last_sync_label": "Laatste synchronisatie:",
-		"toast_sync_disabled": "hotel/{{group}} uitgeschakeld: {{count}} routeerbaar lid/leden over",
-		"toast_entry_min_two": "Er moeten minstens 2 leden actief blijven."
+		"toast_entry_min_two": "Er moeten minstens 2 leden actief blijven.",
+		"toast_sync_purged_one": "hotel/{{group}}: {{count}} verouderde vermelding verwijderd",
+		"toast_sync_purged_other": "hotel/{{group}}: {{count}} verouderde vermeldingen verwijderd",
+		"toast_sync_disabled_one": "hotel/{{group}} uitgeschakeld: {{count}} routeerbaar lid over",
+		"toast_sync_disabled_other": "hotel/{{group}} uitgeschakeld: {{count}} routeerbare leden over"
 	},
 	"delete_confirm": {
 		"unsaved_changes": "Niet-opgeslagen wijzigingen"

--- a/web/src/i18n/locales/no.json
+++ b/web/src/i18n/locales/no.json
@@ -696,7 +696,6 @@
 		"sort_title_desc": "Sortert Z-A (klikk for å reversere)",
 		"empty_no_match": "Ingen leverandører stemmer med det valgte filteret.",
 		"empty_no_providers": "Ingen leverandører konfigurert. Legg til din første leverandør for å starte.",
-		"toast_discovery_failed_all": "Funnet mislyktes for alle {{failed}} leverandører",
 		"toast_discover_failed": "Funnene mislyktes: {{message}}",
 		"toast_provider_added": "Søkeleverandør \"{{name}}\" lagt til",
 		"toast_provider_updated": "Leverandør \"{{name}}\" oppdatert",
@@ -704,7 +703,6 @@
 		"toast_delete_failed": "Kan ikke slette: {{message}}",
 		"toast_add_failed": "Kan ikke legge til leverandør: {{message}}",
 		"toast_update_failed": "Kan ikke oppdatere: {{message}}",
-		"toast_refresh_success": "Oppdatert {{count}} sitat/saldoer",
 		"toast_refresh_warning": "Oppdaterte {{refreshed}} kvoter ({{failed}} mislyktes, {{skipped}} ikke støttet)",
 		"toast_refresh_none": "Ingen leverandører med kvote/saldostøtte funnet",
 		"toast_refresh_failed": "Oppdateringskvoter mislyktes: {{message}}",
@@ -851,10 +849,15 @@
 			"retestDone": "{{provider}} testet på nytt",
 			"toggleSection": "Veksle {{provider}}-seksjon",
 			"failoverDisabled": "Failover-grupper deaktivert",
-			"failoverDisabledReason": "{{count}} rutbare medlem(mer) igjen, krever 2+"
+			"failoverDisabledReason_one": "{{count}} rutbart medlem igjen, krever 2+",
+			"failoverDisabledReason_other": "{{count}} rutbare medlemmer igjen, krever 2+"
 		},
 		"toast_quota_detected_minimax": "MiniMax-kvote oppdaget",
-		"type_minimax": "MiniMax"
+		"type_minimax": "MiniMax",
+		"toast_refresh_success_one": "Oppdaterte {{count}} kvote/saldo",
+		"toast_refresh_success_other": "Oppdaterte {{count}} kvoter/saldoer",
+		"toast_discovery_failed_all_one": "Oppdagelse mislyktes for leverandøren",
+		"toast_discovery_failed_all_other": "Oppdagelse mislyktes for alle {{count}} leverandører"
 	},
 	"models": {
 		"page_title_one": "Modell",
@@ -991,7 +994,6 @@
 		"toast_bulk_toggle_failed": "Masseveksling mislyktes for noen grupper",
 		"toast_provider_toggle_failed": "Masseleverandørvekselveksling mislyktes for noen grupper",
 		"toast_sync_deleted": "hotell/{{model}} slettet: {{reason}}{{providers}}",
-		"toast_sync_purged": "hotell/{{group}}: fjernet fra {{count}} hovedenheter",
 		"toast_sync_success": "Feil over grupper synkronisert",
 		"toast_sync_failed": "Kan ikke synkronisere: {{message}}",
 		"toast_update_failed": "Kan ikke oppdatere: {{message}}",
@@ -1037,8 +1039,11 @@
 		"provider_modal_description": "Deaktivering av en leverandør vil deaktivere alle modellene i hver feilovergruppe",
 		"toast_provider_toggle_no_groups": "Ingen mislykket gruppe bruk {{provider}}",
 		"last_sync_label": "Sist synkronisert:",
-		"toast_sync_disabled": "hotell/{{group}} deaktivert: {{count}} rutbare medlem(mer) igjen",
-		"toast_entry_min_two": "Minst 2 medlemmer må forbli aktive."
+		"toast_entry_min_two": "Minst 2 medlemmer må forbli aktive.",
+		"toast_sync_purged_one": "hotell/{{group}}: fjernet {{count}} utdatert oppføring",
+		"toast_sync_purged_other": "hotell/{{group}}: fjernet {{count}} utdaterte oppføringer",
+		"toast_sync_disabled_one": "hotell/{{group}} deaktivert: {{count}} rutbart medlem igjen",
+		"toast_sync_disabled_other": "hotell/{{group}} deaktivert: {{count}} rutbare medlemmer igjen"
 	},
 	"delete_confirm": {
 		"unsaved_changes": "Ulagrede endringer"

--- a/web/src/i18n/locales/pl.json
+++ b/web/src/i18n/locales/pl.json
@@ -696,7 +696,6 @@
 		"sort_title_desc": "Sortowane Z-A (kliknij, aby cofnąć)",
 		"empty_no_match": "Żaden dostawca nie pasuje do wybranego filtra.",
 		"empty_no_providers": "Brak skonfigurowanych dostawców. Dodaj swojego pierwszego dostawcę, aby rozpocząć.",
-		"toast_discovery_failed_all": "Odkrycie nie powiodło się dla wszystkich dostawców {{failed}}",
 		"toast_discover_failed": "Odkrycie nie powiodło się: {{message}}",
 		"toast_provider_added": "Dodano dostawcę \"{{name}}\"",
 		"toast_provider_updated": "Dostawca \"{{name}}\" zaktualizowany",
@@ -704,7 +703,6 @@
 		"toast_delete_failed": "Nie udało się usunąć: {{message}}",
 		"toast_add_failed": "Nie udało się dodać dostawcy: {{message}}",
 		"toast_update_failed": "Nie udało się zaktualizować: {{message}}",
-		"toast_refresh_success": "Odświeżono kwotę/salda {{count}}",
 		"toast_refresh_warning": "Odświeżone kontyngenty {{refreshed}} ({{failed}} nie powiodło się, {{skipped}} nieobsługiwane)",
 		"toast_refresh_none": "Nie znaleziono dostawców obsługujących kwotę/saldo",
 		"toast_refresh_failed": "Nie udało się odświeżyć kontyngentów: {{message}}",
@@ -851,10 +849,15 @@
 			"retestDone": "Ponownie przetestowano {{provider}}",
 			"toggleSection": "Przełącz sekcję {{provider}}",
 			"failoverDisabled": "Grupy przełączania awaryjnego wyłączone",
-			"failoverDisabledReason": "pozostało {{count}} członków z routingiem, potrzeba 2+"
+			"failoverDisabledReason_one": "pozostał {{count}} członek z routingiem, potrzeba 2+",
+			"failoverDisabledReason_other": "pozostało {{count}} członków z routingiem, potrzeba 2+"
 		},
 		"toast_quota_detected_minimax": "Wykryto limit MiniMax",
-		"type_minimax": "MiniMax"
+		"type_minimax": "MiniMax",
+		"toast_refresh_success_one": "Odświeżono {{count}} kwotę/saldo",
+		"toast_refresh_success_other": "Odświeżono {{count}} kwot/sald",
+		"toast_discovery_failed_all_one": "Wykrywanie nie powiodło się dla dostawcy",
+		"toast_discovery_failed_all_other": "Wykrywanie nie powiodło się dla wszystkich {{count}} dostawców"
 	},
 	"models": {
 		"page_title_one": "Model",
@@ -991,7 +994,6 @@
 		"toast_bulk_toggle_failed": "Przełączanie masowe nie powiodło się dla niektórych grup",
 		"toast_provider_toggle_failed": "Przełączenie grupowego dostawcy nie powiodło się dla niektórych grup",
 		"toast_sync_deleted": "hotel/{{model}} usunięto: {{reason}}{{providers}}",
-		"toast_sync_purged": "hotel/{{group}}: usunięto przestarzałe wpis(y) {{count}}",
 		"toast_sync_success": "Grupy niepowodzeń zsynchronizowane",
 		"toast_sync_failed": "Synchronizacja nie powiodła się: {{message}}",
 		"toast_update_failed": "Nie udało się zaktualizować: {{message}}",
@@ -1037,8 +1039,11 @@
 		"provider_modal_description": "Wyłączenie dostawcy wyłączy wszystkie jego modele w każdej grupie awaryjnej",
 		"toast_provider_toggle_no_groups": "Żadne grupy awaryjne nie używają dostawcy {{provider}}",
 		"last_sync_label": "Ostatnia synchronizacja:",
-		"toast_sync_disabled": "hotel/{{group}} wyłączono: pozostało {{count}} członków z routingiem",
-		"toast_entry_min_two": "Co najmniej 2 członków musi pozostać aktywnych."
+		"toast_entry_min_two": "Co najmniej 2 członków musi pozostać aktywnych.",
+		"toast_sync_purged_one": "hotel/{{group}}: usunięto {{count}} przestarzały wpis",
+		"toast_sync_purged_other": "hotel/{{group}}: usunięto {{count}} przestarzałych wpisów",
+		"toast_sync_disabled_one": "hotel/{{group}} wyłączono: pozostał {{count}} członek z routingiem",
+		"toast_sync_disabled_other": "hotel/{{group}} wyłączono: pozostało {{count}} członków z routingiem"
 	},
 	"delete_confirm": {
 		"unsaved_changes": "Niezapisane zmiany"

--- a/web/src/i18n/locales/pt.json
+++ b/web/src/i18n/locales/pt.json
@@ -696,7 +696,6 @@
 		"sort_title_desc": "Ordenado Z-A (clique para reverter)",
 		"empty_no_match": "Nenhum provedor corresponde ao filtro selecionado.",
 		"empty_no_providers": "Nenhum provedor configurado. Adicione seu primeiro provedor para começar.",
-		"toast_discovery_failed_all": "A descoberta falhou para todos os provedores {{failed}}",
 		"toast_discover_failed": "A descoberta falhou: {{message}}",
 		"toast_provider_added": "Provedor \"{{name}}\" adicionado",
 		"toast_provider_updated": "Provedor \"{{name}}\" atualizado",
@@ -704,7 +703,6 @@
 		"toast_delete_failed": "Falha ao excluir: {{message}}",
 		"toast_add_failed": "Falha ao adicionar provedor: {{message}}",
 		"toast_update_failed": "Falha ao atualizar: {{message}}",
-		"toast_refresh_success": "Atualizado entre aspas/saldos {{count}}",
 		"toast_refresh_warning": "Cotas {{refreshed}} atualizadas ({{failed}} falhou, {{skipped}} não suportado)",
 		"toast_refresh_none": "Nenhum provedor com suporte de quota/saldo encontrado",
 		"toast_refresh_failed": "Falha ao atualizar cotas: {{message}}",
@@ -851,10 +849,15 @@
 			"retestDone": "{{provider}} testado novamente",
 			"toggleSection": "Alternar a seção {{provider}}",
 			"failoverDisabled": "Grupos de failover desativados",
-			"failoverDisabledReason": "{{count}} membro(s) roteável(is) restante(s), são necessários 2+"
+			"failoverDisabledReason_one": "{{count}} membro roteável restante, são necessários 2+",
+			"failoverDisabledReason_other": "{{count}} membros roteáveis restantes, são necessários 2+"
 		},
 		"toast_quota_detected_minimax": "Cota MiniMax detectada",
-		"type_minimax": "MiniMax"
+		"type_minimax": "MiniMax",
+		"toast_refresh_success_one": "Atualizada {{count}} cota/saldo",
+		"toast_refresh_success_other": "Atualizadas {{count}} cotas/saldos",
+		"toast_discovery_failed_all_one": "A descoberta falhou para o provedor",
+		"toast_discovery_failed_all_other": "A descoberta falhou para todos os {{count}} provedores"
 	},
 	"models": {
 		"page_title_one": "Modelo",
@@ -991,7 +994,6 @@
 		"toast_bulk_toggle_failed": "Falha ao alternar em massa para alguns grupos",
 		"toast_provider_toggle_failed": "Falha ao alternar provedor de massa para alguns grupos",
 		"toast_sync_deleted": "hotel/{{model}} excluído: {{reason}}{{providers}}",
-		"toast_sync_purged": "hotel/{{group}}: removeu entrada obsoleta {{count}}",
 		"toast_sync_success": "Grupos falhados sincronizados",
 		"toast_sync_failed": "Falha ao sincronizar: {{message}}",
 		"toast_update_failed": "Falha ao atualizar: {{message}}",
@@ -1037,8 +1039,11 @@
 		"provider_modal_description": "Desabilitar um provedor desativará todos os seus modelos em cada grupo de falhas",
 		"toast_provider_toggle_no_groups": "Nenhum grupo de falha usa o provedor {{provider}}",
 		"last_sync_label": "Última sincronização:",
-		"toast_sync_disabled": "hotel/{{group}} desativado: {{count}} membro(s) roteável(is) restante(s)",
-		"toast_entry_min_two": "Pelo menos 2 membros têm de permanecer ativos."
+		"toast_entry_min_two": "Pelo menos 2 membros têm de permanecer ativos.",
+		"toast_sync_purged_one": "hotel/{{group}}: removida {{count}} entrada obsoleta",
+		"toast_sync_purged_other": "hotel/{{group}}: removidas {{count}} entradas obsoletas",
+		"toast_sync_disabled_one": "hotel/{{group}} desativado: {{count}} membro roteável restante",
+		"toast_sync_disabled_other": "hotel/{{group}} desativado: {{count}} membros roteáveis restantes"
 	},
 	"delete_confirm": {
 		"unsaved_changes": "Alterações Não Salvas"

--- a/web/src/i18n/locales/ro.json
+++ b/web/src/i18n/locales/ro.json
@@ -696,7 +696,6 @@
 		"sort_title_desc": "Z-A sortat (click pentru a inversa)",
 		"empty_no_match": "Niciun furnizor nu se potrivește cu filtrul selectat.",
 		"empty_no_providers": "Niciun furnizor configurat. Adăugați primul dvs. furnizor pentru a începe.",
-		"toast_discovery_failed_all": "Descoperirea a eșuat pentru toți furnizorii {{failed}}",
 		"toast_discover_failed": "Descoperire eșuată: {{message}}",
 		"toast_provider_added": "Furnizor \"{{name}}\" adăugat",
 		"toast_provider_updated": "Furnizor \"{{name}}\" actualizat",
@@ -704,7 +703,6 @@
 		"toast_delete_failed": "Ștergerea nu a reușit: {{message}}",
 		"toast_add_failed": "Nu s-a reușit adăugarea furnizorului: {{message}}",
 		"toast_update_failed": "Actualizarea nu a reușit: {{message}}",
-		"toast_refresh_success": "Actualizat {{count}} cote/solduri",
 		"toast_refresh_warning": "Reîmprospătat {{refreshed}} cote ({{failed}} a eșuat, {{skipped}} nesuportat)",
 		"toast_refresh_none": "Niciun furnizor cu suport pentru cotă/echilibru găsit",
 		"toast_refresh_failed": "Reîmprospătarea cotelor a eșuat: {{message}}",
@@ -851,10 +849,15 @@
 			"retestDone": "{{provider}} a fost retestat",
 			"toggleSection": "Comută secțiunea {{provider}}",
 			"failoverDisabled": "Grupuri de failover dezactivate",
-			"failoverDisabledReason": "au rămas {{count}} membri rutabili, sunt necesari 2+"
+			"failoverDisabledReason_one": "a rămas {{count}} membru rutabil, sunt necesari 2+",
+			"failoverDisabledReason_other": "au rămas {{count}} membri rutabili, sunt necesari 2+"
 		},
 		"toast_quota_detected_minimax": "Cotă MiniMax detectată",
-		"type_minimax": "MiniMax"
+		"type_minimax": "MiniMax",
+		"toast_refresh_success_one": "Actualizat {{count}} cotă/sold",
+		"toast_refresh_success_other": "Actualizat {{count}} cote/solduri",
+		"toast_discovery_failed_all_one": "Descoperirea a eșuat pentru furnizor",
+		"toast_discovery_failed_all_other": "Descoperirea a eșuat pentru toți cei {{count}} furnizori"
 	},
 	"models": {
 		"page_title_one": "Model",
@@ -991,7 +994,6 @@
 		"toast_bulk_toggle_failed": "Comutarea în bloc a eșuat pentru unele grupuri",
 		"toast_provider_toggle_failed": "Comutarea furnizorului în bloc a eșuat pentru unele grupuri",
 		"toast_sync_deleted": "hotel/{{model}} șters: {{reason}}{{providers}}",
-		"toast_sync_purged": "hotel/{{group}}: a eliminat {{count}} intrare veche",
 		"toast_sync_success": "Grupuri eșuate sincronizate",
 		"toast_sync_failed": "Nu s-a putut sincroniza: {{message}}",
 		"toast_update_failed": "Actualizarea nu a reușit: {{message}}",
@@ -1037,8 +1039,11 @@
 		"provider_modal_description": "Dezactivarea unui furnizor va dezactiva toate modelele sale în fiecare grup de eșec",
 		"toast_provider_toggle_no_groups": "Niciun grup eșuat utilizați furnizorul {{provider}}",
 		"last_sync_label": "Ultima sincronizare:",
-		"toast_sync_disabled": "hotel/{{group}} dezactivat: au rămas {{count}} membri rutabili",
-		"toast_entry_min_two": "Cel puțin 2 membri trebuie să rămână activi."
+		"toast_entry_min_two": "Cel puțin 2 membri trebuie să rămână activi.",
+		"toast_sync_purged_one": "hotel/{{group}}: a eliminat {{count}} intrare veche",
+		"toast_sync_purged_other": "hotel/{{group}}: a eliminat {{count}} intrări vechi",
+		"toast_sync_disabled_one": "hotel/{{group}} dezactivat: a rămas {{count}} membru rutabil",
+		"toast_sync_disabled_other": "hotel/{{group}} dezactivat: au rămas {{count}} membri rutabili"
 	},
 	"delete_confirm": {
 		"unsaved_changes": "Modificări nesalvate"

--- a/web/src/i18n/locales/ru.json
+++ b/web/src/i18n/locales/ru.json
@@ -696,7 +696,6 @@
 		"sort_title_desc": "Сортировка Z-A (нажмите, чтобы вернуться)",
 		"empty_no_match": "Ни один провайдер не соответствует выбранному фильтру.",
 		"empty_no_providers": "Провайдеры не настроены. Добавьте вашего первого провайдера для начала.",
-		"toast_discovery_failed_all": "Не удалось обнаружить для всех {{failed}} провайдеров",
 		"toast_discover_failed": "Обнаружение не удалось: {{message}}",
 		"toast_provider_added": "Поставщик \"{{name}}\" добавлен",
 		"toast_provider_updated": "Поставщик \"{{name}}\" обновлен",
@@ -704,7 +703,6 @@
 		"toast_delete_failed": "Не удалось удалить: {{message}}",
 		"toast_add_failed": "Не удалось добавить провайдера: {{message}}",
 		"toast_update_failed": "Не удалось обновить: {{message}}",
-		"toast_refresh_success": "Обновлены {{count}} квоты/балансы",
 		"toast_refresh_warning": "Обновленные квот {{refreshed}} ({{failed}} не удалось, {{skipped}} не поддерживается)",
 		"toast_refresh_none": "Не найдено ни одного провайдера с поддержкой квоты/баланса",
 		"toast_refresh_failed": "Обновить квоты не удалось: {{message}}",
@@ -851,10 +849,15 @@
 			"retestDone": "{{provider}} повторно проверен",
 			"toggleSection": "Переключить раздел {{provider}}",
 			"failoverDisabled": "Группы отказоустойчивости отключены",
-			"failoverDisabledReason": "осталось {{count}} маршрутизируемых участников, нужно 2+"
+			"failoverDisabledReason_one": "остался {{count}} маршрутизируемый участник, нужно 2+",
+			"failoverDisabledReason_other": "осталось {{count}} маршрутизируемых участников, нужно 2+"
 		},
 		"toast_quota_detected_minimax": "Обнаружена квота MiniMax",
-		"type_minimax": "MiniMax"
+		"type_minimax": "MiniMax",
+		"toast_refresh_success_one": "Обновлена {{count}} квота/баланс",
+		"toast_refresh_success_other": "Обновлены {{count}} квоты/балансы",
+		"toast_discovery_failed_all_one": "Не удалось выполнить обнаружение для провайдера",
+		"toast_discovery_failed_all_other": "Не удалось выполнить обнаружение для всех {{count}} провайдеров"
 	},
 	"models": {
 		"page_title_one": "Модель",
@@ -991,7 +994,6 @@
 		"toast_bulk_toggle_failed": "Массовое переключение не удалось для некоторых групп",
 		"toast_provider_toggle_failed": "Для некоторых групп не удалось переключить поставщик маски",
 		"toast_sync_deleted": "гостиница /{{model}} удалено: {{reason}}{{providers}}",
-		"toast_sync_purged": "гостиница/{{group}}: удалена запись (записи) {{count}}",
 		"toast_sync_success": "Группы резервирования синхронизированы",
 		"toast_sync_failed": "Не удалось синхронизировать: {{message}}",
 		"toast_update_failed": "Не удалось обновить: {{message}}",
@@ -1037,8 +1039,11 @@
 		"provider_modal_description": "Отключение провайдера отключит все его модели в каждой группе отказов",
 		"toast_provider_toggle_no_groups": "Нет групп отказов использовать провайдера {{provider}}",
 		"last_sync_label": "Последняя синхронизация:",
-		"toast_sync_disabled": "гостиница/{{group}} отключено: осталось {{count}} маршрутизируемых участников",
-		"toast_entry_min_two": "Как минимум 2 участника должны оставаться активными."
+		"toast_entry_min_two": "Как минимум 2 участника должны оставаться активными.",
+		"toast_sync_purged_one": "гостиница/{{group}}: удалена {{count}} устаревшая запись",
+		"toast_sync_purged_other": "гостиница/{{group}}: удалено {{count}} устаревших записей",
+		"toast_sync_disabled_one": "гостиница/{{group}} отключено: остался {{count}} маршрутизируемый участник",
+		"toast_sync_disabled_other": "гостиница/{{group}} отключено: осталось {{count}} маршрутизируемых участников"
 	},
 	"delete_confirm": {
 		"unsaved_changes": "Несохраненные изменения"

--- a/web/src/i18n/locales/sk.json
+++ b/web/src/i18n/locales/sk.json
@@ -696,7 +696,6 @@
 		"sort_title_desc": "Zoradené podľa abecedy (kliknutím obrátite poradie)",
 		"empty_no_match": "Žiadny poskytovateľ nezodpovedá zvoleným kritériám.",
 		"empty_no_providers": "Nie sú nakonfigurovaní žiadni poskytovatelia. Pridajte svojho prvého poskytovateľa a môžete začať.",
-		"toast_discovery_failed_all": "Zistenie sa nepodarilo pre všetkých poskytovateľov služby {{failed}}",
 		"toast_discover_failed": "Objav sa nepodaril: {{message}}",
 		"toast_provider_added": "Bol pridaný poskytovateľ „{{name}}“",
 		"toast_provider_updated": "Poskytovateľ „{{name}}“ aktualizoval",
@@ -704,7 +703,6 @@
 		"toast_delete_failed": "Odstránenie sa nepodarilo: {{message}}",
 		"toast_add_failed": "Nepodarilo sa pridať poskytovateľa: {{message}}",
 		"toast_update_failed": "Aktualizácia sa nepodarila: {{message}}",
-		"toast_refresh_success": "Aktualizované {{count}} kvóty/zostatky",
 		"toast_refresh_warning": "Aktualizované kvóty pre doménu {{refreshed}} ({{failed}} sa nepodarilo aktualizovať, doména {{skipped}} nie je podporovaná)",
 		"toast_refresh_none": "Nenašli sa žiadni poskytovatelia s podporou kvót/zostatkov",
 		"toast_refresh_failed": "Obnovenie kvót sa nepodarilo: {{message}}",
@@ -851,10 +849,15 @@
 			"retestDone": "{{provider}} znova otestované",
 			"toggleSection": "Prepnúť sekciu {{provider}}",
 			"failoverDisabled": "Skupiny pre prevzatie pri výpadku deaktivované",
-			"failoverDisabledReason": "zostáva {{count}} smerovateľných členov, potrebné 2+"
+			"failoverDisabledReason_one": "zostáva {{count}} smerovateľný člen, potrebné 2+",
+			"failoverDisabledReason_other": "zostáva {{count}} smerovateľných členov, potrebné 2+"
 		},
 		"toast_quota_detected_minimax": "Zistená kvóta MiniMax",
-		"type_minimax": "MiniMax"
+		"type_minimax": "MiniMax",
+		"toast_refresh_success_one": "Aktualizovaná {{count}} kvóta/zostatok",
+		"toast_refresh_success_other": "Aktualizované {{count}} kvóty/zostatky",
+		"toast_discovery_failed_all_one": "Zisťovanie zlyhalo pre poskytovateľa",
+		"toast_discovery_failed_all_other": "Zisťovanie zlyhalo pre všetkých {{count}} poskytovateľov"
 	},
 	"models": {
 		"page_title_one": "Model",
@@ -991,7 +994,6 @@
 		"toast_bulk_toggle_failed": "U niektorých skupín sa nepodarilo zapnúť hromadné prepínanie",
 		"toast_provider_toggle_failed": "U niektorých skupín sa nepodarilo prepnúť režim hromadného poskytovateľa",
 		"toast_sync_deleted": "hotel/{{model}} vymazané: {{reason}}{{providers}}",
-		"toast_sync_purged": "hotel/{{group}}: odstránené {{count}} neaktuálne záznamy",
 		"toast_sync_success": "Skupiny pre prevzatie pri výpadku sú synchronizované",
 		"toast_sync_failed": "Synchronizácia sa nepodarila: {{message}}",
 		"toast_update_failed": "Aktualizácia sa nepodarila: {{message}}",
@@ -1037,8 +1039,11 @@
 		"provider_modal_description": "Deaktiváciou poskytovateľa sa deaktivujú všetky jeho modely vo všetkých skupinách pre prevzatie pri výpadku",
 		"toast_provider_toggle_no_groups": "Žiadna skupina pre prechod na záložný systém nepoužíva poskytovateľa {{provider}}",
 		"last_sync_label": "Posledná synchronizácia:",
-		"toast_sync_disabled": "hotel/{{group}} deaktivované: zostáva {{count}} smerovateľných členov",
-		"toast_entry_min_two": "Aktívni musia zostať aspoň 2 členovia."
+		"toast_entry_min_two": "Aktívni musia zostať aspoň 2 členovia.",
+		"toast_sync_purged_one": "hotel/{{group}}: odstránený {{count}} neaktuálny záznam",
+		"toast_sync_purged_other": "hotel/{{group}}: odstránené {{count}} neaktuálne záznamy",
+		"toast_sync_disabled_one": "hotel/{{group}} deaktivované: zostáva {{count}} smerovateľný člen",
+		"toast_sync_disabled_other": "hotel/{{group}} deaktivované: zostáva {{count}} smerovateľných členov"
 	},
 	"delete_confirm": {
 		"unsaved_changes": "Neuložené zmeny"

--- a/web/src/i18n/locales/sr.json
+++ b/web/src/i18n/locales/sr.json
@@ -696,7 +696,6 @@
 		"sort_title_desc": "Сортирано Z-A (кликните за обрнуто)",
 		"empty_no_match": "Нема пружалаца услуга који одговарају изабраном филтеру.",
 		"empty_no_providers": "Није конфигурисан ниједан провајдер. Додајте свог првог провајдера да бисте започели.",
-		"toast_discovery_failed_all": "Откривање није успело за све пружаоце услуге {{failed}}",
 		"toast_discover_failed": "Откриће је пропало: {{message}}",
 		"toast_provider_added": "Добављен провајдер \"{{name}}\"",
 		"toast_provider_updated": "Провајдер \"{{name}}\" је ажуриран",
@@ -704,7 +703,6 @@
 		"toast_delete_failed": "Није успело да се обрише: {{message}}",
 		"toast_add_failed": "Није успело да се дода провајдер: {{message}}",
 		"toast_update_failed": "Ажурирање није успело: {{message}}",
-		"toast_refresh_success": "Ажуриране квоте/стања {{count}}",
 		"toast_refresh_warning": "Обновиле су се квоте за {{refreshed}} ({{failed}} није успео, {{skipped}} није подржан)",
 		"toast_refresh_none": "Није пронађен ниједан провајдер са подршком за квоту/стање",
 		"toast_refresh_failed": "Обнове квота су неуспеле: {{message}}",
@@ -851,10 +849,15 @@
 			"retestDone": "{{provider}} поново тестиран",
 			"toggleSection": "Прикажи/сакриј одељак {{provider}}",
 			"failoverDisabled": "Фејловер групе су онемогућене",
-			"failoverDisabledReason": "преостало {{count}} чланова који се могу рутирати, потребно 2+"
+			"failoverDisabledReason_one": "преостао {{count}} члан који се може рутирати, потребно 2+",
+			"failoverDisabledReason_other": "преостало {{count}} чланова који се могу рутирати, потребно 2+"
 		},
 		"toast_quota_detected_minimax": "MiniMax квота откривена",
-		"type_minimax": "MiniMax"
+		"type_minimax": "MiniMax",
+		"toast_refresh_success_one": "Ажурирана {{count}} квота/стање",
+		"toast_refresh_success_other": "Ажуриране {{count}} квоте/стања",
+		"toast_discovery_failed_all_one": "Откривање није успело за добављача",
+		"toast_discovery_failed_all_other": "Откривање није успело за све {{count}} добављача"
 	},
 	"models": {
 		"page_title_one": "Модел",
@@ -991,7 +994,6 @@
 		"toast_bulk_toggle_failed": "Масовно пребацивање није успело за неке групе",
 		"toast_provider_toggle_failed": "Прекинуто пребацивање добављача за неке групе",
 		"toast_sync_deleted": "хотел/{{model}} избрисано: {{reason}}{{providers}}",
-		"toast_sync_purged": "хотел/{{group}}: уклоњене застареле уносе са {{count}}",
 		"toast_sync_success": "Синкронизоване групе за преузимање",
 		"toast_sync_failed": "Синхронизација није успела: {{message}}",
 		"toast_update_failed": "Ажурирање није успело: {{message}}",
@@ -1037,8 +1039,11 @@
 		"provider_modal_description": "Онемогућавање провајдера онемогућиће све његове моделе у свакој групи за преузимање.",
 		"toast_provider_toggle_no_groups": "Ниједна група за преузимање не користи провајдера {{provider}}",
 		"last_sync_label": "Последња синхронизација:",
-		"toast_sync_disabled": "хотел/{{group}} онемогућено: преостало {{count}} чланова који се могу рутирати",
-		"toast_entry_min_two": "Најмање 2 члана морају остати активна."
+		"toast_entry_min_two": "Најмање 2 члана морају остати активна.",
+		"toast_sync_purged_one": "хотел/{{group}}: уклоњен {{count}} застарели унос",
+		"toast_sync_purged_other": "хотел/{{group}}: уклоњено {{count}} застарелих уноса",
+		"toast_sync_disabled_one": "хотел/{{group}} онемогућено: преостао {{count}} члан који се може рутирати",
+		"toast_sync_disabled_other": "хотел/{{group}} онемогућено: преостало {{count}} чланова који се могу рутирати"
 	},
 	"delete_confirm": {
 		"unsaved_changes": "Несачуване измене"

--- a/web/src/i18n/locales/sv.json
+++ b/web/src/i18n/locales/sv.json
@@ -696,7 +696,6 @@
 		"sort_title_desc": "Sorterade Z-A (klicka för att återställa)",
 		"empty_no_match": "Inga leverantörer matchar det valda filtret.",
 		"empty_no_providers": "Inga leverantörer konfigurerade. Lägg till din första leverantör för att komma igång.",
-		"toast_discovery_failed_all": "Upptäckten misslyckades för alla {{failed}} leverantörer",
 		"toast_discover_failed": "Upptäckten misslyckades: {{message}}",
 		"toast_provider_added": "Leverantör \"{{name}}\" tillagd",
 		"toast_provider_updated": "Leverantör \"{{name}}\" uppdaterad",
@@ -704,7 +703,6 @@
 		"toast_delete_failed": "Misslyckades att radera: {{message}}",
 		"toast_add_failed": "Kunde inte lägga till leverantör: {{message}}",
 		"toast_update_failed": "Det gick inte att uppdatera: {{message}}",
-		"toast_refresh_success": "Uppdaterade {{count}} kvoter/saldon",
 		"toast_refresh_warning": "Uppdaterad {{refreshed}} quotas ({{failed}} misslyckades, {{skipped}} stöds inte)",
 		"toast_refresh_none": "Inga leverantörer med kvot/balanssupport hittades",
 		"toast_refresh_failed": "Uppdateringskvoter misslyckades: {{message}}",
@@ -851,10 +849,15 @@
 			"retestDone": "{{provider}} testad igen",
 			"toggleSection": "Växla {{provider}}-sektion",
 			"failoverDisabled": "Failover-grupper inaktiverade",
-			"failoverDisabledReason": "{{count}} dirigerbar(a) medlem(mar) kvar, behöver 2+"
+			"failoverDisabledReason_one": "{{count}} dirigerbar medlem kvar, behöver 2+",
+			"failoverDisabledReason_other": "{{count}} dirigerbara medlemmar kvar, behöver 2+"
 		},
 		"toast_quota_detected_minimax": "MiniMax-kvot upptäckt",
-		"type_minimax": "MiniMax"
+		"type_minimax": "MiniMax",
+		"toast_refresh_success_one": "Uppdaterade {{count}} kvot/saldo",
+		"toast_refresh_success_other": "Uppdaterade {{count}} kvoter/saldon",
+		"toast_discovery_failed_all_one": "Upptäckten misslyckades för leverantören",
+		"toast_discovery_failed_all_other": "Upptäckten misslyckades för alla {{count}} leverantörer"
 	},
 	"models": {
 		"page_title_one": "Modell",
@@ -991,7 +994,6 @@
 		"toast_bulk_toggle_failed": "Bulkväxling misslyckades för vissa grupper",
 		"toast_provider_toggle_failed": "Bulk provider toggle misslyckades för vissa grupper",
 		"toast_sync_deleted": "hotel/{{model}} borttaget: {{reason}}{{providers}}",
-		"toast_sync_purged": "hotel/{{group}}: tog bort {{count}} gamla poster",
 		"toast_sync_success": "Misslyckade grupper synkroniserade",
 		"toast_sync_failed": "Det gick inte att synkronisera: {{message}}",
 		"toast_update_failed": "Det gick inte att uppdatera: {{message}}",
@@ -1037,8 +1039,11 @@
 		"provider_modal_description": "Inaktivera en leverantör kommer att inaktivera alla dess modeller i varje felöversättningsgrupp",
 		"toast_provider_toggle_no_groups": "Inga övergångsgrupper använder leverantören {{provider}}",
 		"last_sync_label": "Senaste synkronisering:",
-		"toast_sync_disabled": "hotel/{{group}} inaktiverad: {{count}} dirigerbar(a) medlem(mar) kvar",
-		"toast_entry_min_two": "Minst 2 medlemmar måste förbli aktiva."
+		"toast_entry_min_two": "Minst 2 medlemmar måste förbli aktiva.",
+		"toast_sync_purged_one": "hotel/{{group}}: tog bort {{count}} gammal post",
+		"toast_sync_purged_other": "hotel/{{group}}: tog bort {{count}} gamla poster",
+		"toast_sync_disabled_one": "hotel/{{group}} inaktiverad: {{count}} dirigerbar medlem kvar",
+		"toast_sync_disabled_other": "hotel/{{group}} inaktiverad: {{count}} dirigerbara medlemmar kvar"
 	},
 	"delete_confirm": {
 		"unsaved_changes": "Osparade ändringar"

--- a/web/src/i18n/locales/tr.json
+++ b/web/src/i18n/locales/tr.json
@@ -696,7 +696,6 @@
 		"sort_title_desc": "Z-A sırasına göre (tersine çevirmek için tıklayın)",
 		"empty_no_match": "Seçilen filtreye uyan sağlayıcı bulunamadı.",
 		"empty_no_providers": "Yapılandırılmış sağlayıcı yok. Başlamak için ilk sağlayıcınızı ekleyin.",
-		"toast_discovery_failed_all": "{{failed}} 'daki tüm sağlayıcılar için keşif işlemi başarısız oldu",
 		"toast_discover_failed": "Keşif başarısız oldu: {{message}}",
 		"toast_provider_added": "\"{{name}}\" sağlayıcısı eklendi",
 		"toast_provider_updated": "\"{{name}}\" sağlayıcısı güncellendi",
@@ -704,7 +703,6 @@
 		"toast_delete_failed": "Silme işlemi başarısız: {{message}}",
 		"toast_add_failed": "Sağlayıcı eklenemedi: {{message}}",
 		"toast_update_failed": "Güncelleme başarısız: {{message}}",
-		"toast_refresh_success": "Güncellenen {{count}} kota/bakiye bilgileri",
 		"toast_refresh_warning": " {{refreshed}} kota değerleri güncellendi ({{failed}} başarısız, {{skipped}} desteklenmiyor)",
 		"toast_refresh_none": "Kota/bakiye desteği sunan sağlayıcı bulunamadı",
 		"toast_refresh_failed": "Kota yenileme işlemi başarısız oldu: {{message}}",
@@ -851,10 +849,15 @@
 			"retestDone": "{{provider}} yeniden test edildi",
 			"toggleSection": "{{provider}} bölümünü aç/kapat",
 			"failoverDisabled": "Yedekleme grupları devre dışı bırakıldı",
-			"failoverDisabledReason": "{{count}} yönlendirilebilir üye kaldı, 2+ gerekli"
+			"failoverDisabledReason_one": "{{count}} yönlendirilebilir üye kaldı, 2+ gerekli",
+			"failoverDisabledReason_other": "{{count}} yönlendirilebilir üye kaldı, 2+ gerekli"
 		},
 		"toast_quota_detected_minimax": "MiniMax kotası tespit edildi",
-		"type_minimax": "MiniMax"
+		"type_minimax": "MiniMax",
+		"toast_refresh_success_one": "{{count}} kota/bakiye güncellendi",
+		"toast_refresh_success_other": "{{count}} kota/bakiye güncellendi",
+		"toast_discovery_failed_all_one": "Sağlayıcı için keşif başarısız oldu",
+		"toast_discovery_failed_all_other": "Tüm {{count}} sağlayıcı için keşif başarısız oldu"
 	},
 	"models": {
 		"page_title_one": "Model",
@@ -991,7 +994,6 @@
 		"toast_bulk_toggle_failed": "Bazı gruplarda toplu geçiş işlemi başarısız oldu",
 		"toast_provider_toggle_failed": "Bazı gruplar için toplu sağlayıcı geçişi başarısız oldu",
 		"toast_sync_deleted": "otel/{{model}} silindi: {{reason}}{{providers}}",
-		"toast_sync_purged": "otel/{{group}}: kaldırıldı {{count}} eski giriş(ler)",
 		"toast_sync_success": "Yedekleme grupları senkronize edildi",
 		"toast_sync_failed": "Senkronizasyon başarısız: {{message}}",
 		"toast_update_failed": "Güncelleme başarısız: {{message}}",
@@ -1037,8 +1039,11 @@
 		"provider_modal_description": "Bir sağlayıcının devre dışı bırakılması, tüm yedekleme gruplarındaki tüm modellerini devre dışı bırakır",
 		"toast_provider_toggle_no_groups": "Hiçbir yük devretme grubu bu sağlayıcıyı kullanmıyor {{provider}}",
 		"last_sync_label": "Son senkronizasyon:",
-		"toast_sync_disabled": "otel/{{group}} devre dışı: {{count}} yönlendirilebilir üye kaldı",
-		"toast_entry_min_two": "En az 2 üye etkin kalmalıdır."
+		"toast_entry_min_two": "En az 2 üye etkin kalmalıdır.",
+		"toast_sync_purged_one": "otel/{{group}}: {{count}} eski giriş kaldırıldı",
+		"toast_sync_purged_other": "otel/{{group}}: {{count}} eski giriş kaldırıldı",
+		"toast_sync_disabled_one": "otel/{{group}} devre dışı: {{count}} yönlendirilebilir üye kaldı",
+		"toast_sync_disabled_other": "otel/{{group}} devre dışı: {{count}} yönlendirilebilir üye kaldı"
 	},
 	"delete_confirm": {
 		"unsaved_changes": "Kaydedilmemiş Değişiklikler"

--- a/web/src/i18n/locales/uk.json
+++ b/web/src/i18n/locales/uk.json
@@ -696,7 +696,6 @@
 		"sort_title_desc": "Сортовано Z-A (натисніть, щоб повернути)",
 		"empty_no_match": "Немає провайдерів, які відповідають вибраному фільтру.",
 		"empty_no_providers": "Не налаштовано жодного постачальника. Додайте свого першого постачальника, щоб розпочати роботу.",
-		"toast_discovery_failed_all": "Помилка відкриття для всіх провайдерів {{failed}}",
 		"toast_discover_failed": "Не вдалося відкриття: {{message}}",
 		"toast_provider_added": "Додано постачальника «{{name}}»",
 		"toast_provider_updated": "Постачальник \"{{name}}\" оновлено",
@@ -704,7 +703,6 @@
 		"toast_delete_failed": "Не вдалося видалити: {{message}}",
 		"toast_add_failed": "Не вдалося додати постачальника: {{message}}",
 		"toast_update_failed": "Оновлення не вдалося: {{message}}",
-		"toast_refresh_success": "Оновлено квоту та баланси {{count}}",
 		"toast_refresh_warning": "Оновлено квоти {{refreshed}} ({{failed}} не вдалося, {{skipped}} не підтримується)",
 		"toast_refresh_none": "Жодного постачальника з квота/балансовою підтримкою не знайдено",
 		"toast_refresh_failed": "Помилка оновлення квот: {{message}}",
@@ -851,10 +849,15 @@
 			"retestDone": "{{provider}} повторно перевірено",
 			"toggleSection": "Перемкнути розділ {{provider}}",
 			"failoverDisabled": "Групи відмовостійкості вимкнено",
-			"failoverDisabledReason": "залишилося {{count}} маршрутизованих учасників, потрібно 2+"
+			"failoverDisabledReason_one": "залишився {{count}} маршрутизований учасник, потрібно 2+",
+			"failoverDisabledReason_other": "залишилося {{count}} маршрутизованих учасників, потрібно 2+"
 		},
 		"toast_quota_detected_minimax": "MiniMax виявлена квота",
-		"type_minimax": "MiniMax"
+		"type_minimax": "MiniMax",
+		"toast_refresh_success_one": "Оновлено {{count}} квоту/баланс",
+		"toast_refresh_success_other": "Оновлено {{count}} квоти/баланси",
+		"toast_discovery_failed_all_one": "Помилка виявлення для постачальника",
+		"toast_discovery_failed_all_other": "Помилка виявлення для всіх {{count}} постачальників"
 	},
 	"models": {
 		"page_title_one": "Модель",
@@ -991,7 +994,6 @@
 		"toast_bulk_toggle_failed": "Помилка перемикання для деяких груп",
 		"toast_provider_toggle_failed": "Перемикання провайдера маси не вдалося для деяких груп",
 		"toast_sync_deleted": "готель/{{model}} видалено: {{reason}}{{providers}}",
-		"toast_sync_purged": "hotel/{{group}}: видалено {{count}} застарілі записи (ies)",
 		"toast_sync_success": "Групи відмовостійкості синхронізовано",
 		"toast_sync_failed": "Не вдалося синхронізувати: {{message}}",
 		"toast_update_failed": "Оновлення не вдалося: {{message}}",
@@ -1037,8 +1039,11 @@
 		"provider_modal_description": "Вимкнення постачальника вимкне всі її моделі у кожній її групі з відмовою",
 		"toast_provider_toggle_no_groups": "Немає групи відмови використовувати провайдера {{provider}}",
 		"last_sync_label": "Остання синхронізація:",
-		"toast_sync_disabled": "hotel/{{group}} вимкнено: залишилося {{count}} маршрутизованих учасників",
-		"toast_entry_min_two": "Щонайменше 2 учасники мають залишатися активними."
+		"toast_entry_min_two": "Щонайменше 2 учасники мають залишатися активними.",
+		"toast_sync_purged_one": "hotel/{{group}}: видалено {{count}} застарілий запис",
+		"toast_sync_purged_other": "hotel/{{group}}: видалено {{count}} застарілих записів",
+		"toast_sync_disabled_one": "hotel/{{group}} вимкнено: залишився {{count}} маршрутизований учасник",
+		"toast_sync_disabled_other": "hotel/{{group}} вимкнено: залишилося {{count}} маршрутизованих учасників"
 	},
 	"delete_confirm": {
 		"unsaved_changes": "Незбережені зміни"

--- a/web/src/i18n/locales/vi.json
+++ b/web/src/i18n/locales/vi.json
@@ -696,7 +696,6 @@
 		"sort_title_desc": "Sắp xếp theo thứ tự Z-A (nhấp để đảo ngược)",
 		"empty_no_match": "Không có nhà cung cấp nào phù hợp với bộ lọc đã chọn.",
 		"empty_no_providers": "Chưa có nhà cung cấp nào được thiết lập. Hãy thêm nhà cung cấp đầu tiên của bạn để bắt đầu.",
-		"toast_discovery_failed_all": "Không tìm thấy bất kỳ nhà cung cấp nào tại địa chỉ {{failed}}",
 		"toast_discover_failed": "Không tìm thấy: {{message}}",
 		"toast_provider_added": "Nhà cung cấp \"{{name}}\" đã được thêm vào",
 		"toast_provider_updated": "Nhà cung cấp \"{{name}}\" đã được cập nhật",
@@ -704,7 +703,6 @@
 		"toast_delete_failed": "Không thể xóa: {{message}}",
 		"toast_add_failed": "Không thể thêm nhà cung cấp: {{message}}",
 		"toast_update_failed": "Không thể cập nhật: {{message}}",
-		"toast_refresh_success": "Cập nhật {{count}} hạn mức/số dư",
 		"toast_refresh_warning": "Đã cập nhật hạn ngạch của {{refreshed}} ({{failed}} không thành công, {{skipped}} không được hỗ trợ)",
 		"toast_refresh_none": "Không tìm thấy nhà cung cấp nào hỗ trợ hạn mức/số dư",
 		"toast_refresh_failed": "Không thể làm mới hạn mức: {{message}}",
@@ -851,10 +849,15 @@
 			"retestDone": "Đã kiểm tra lại {{provider}}",
 			"toggleSection": "Bật/tắt phần {{provider}}",
 			"failoverDisabled": "Các nhóm dự phòng đã bị vô hiệu hóa",
-			"failoverDisabledReason": "còn {{count}} thành viên có thể định tuyến, cần 2+"
+			"failoverDisabledReason_one": "còn {{count}} thành viên có thể định tuyến, cần 2+",
+			"failoverDisabledReason_other": "còn {{count}} thành viên có thể định tuyến, cần 2+"
 		},
 		"toast_quota_detected_minimax": "Đã phát hiện hạn ngạch MiniMax",
-		"type_minimax": "MiniMax"
+		"type_minimax": "MiniMax",
+		"toast_refresh_success_one": "Đã cập nhật {{count}} hạn mức/số dư",
+		"toast_refresh_success_other": "Đã cập nhật {{count}} hạn mức/số dư",
+		"toast_discovery_failed_all_one": "Khám phá không thành công cho nhà cung cấp",
+		"toast_discovery_failed_all_other": "Khám phá không thành công cho tất cả {{count}} nhà cung cấp"
 	},
 	"models": {
 		"page_title_one": "Mô hình",
@@ -991,7 +994,6 @@
 		"toast_bulk_toggle_failed": "Chức năng chuyển đổi hàng loạt không thành công đối với một số nhóm",
 		"toast_provider_toggle_failed": "Chức năng chuyển đổi nhà cung cấp số lượng lớn không hoạt động đối với một số nhóm",
 		"toast_sync_deleted": "khách sạn/{{model}} đã xóa: {{reason}}{{providers}}",
-		"toast_sync_purged": "khách sạn/{{group}}: đã xóa {{count}} các mục đã hết hạn",
 		"toast_sync_success": "Các nhóm chuyển đổi dự phòng đã được đồng bộ hóa",
 		"toast_sync_failed": "Không đồng bộ hóa thành công: {{message}}",
 		"toast_update_failed": "Không thể cập nhật: {{message}}",
@@ -1037,8 +1039,11 @@
 		"provider_modal_description": "Việc vô hiệu hóa một nhà cung cấp sẽ vô hiệu hóa tất cả các mô hình của nhà cung cấp đó trong mọi nhóm chuyển đổi dự phòng",
 		"toast_provider_toggle_no_groups": "Không có nhóm chuyển đổi dự phòng nào sử dụng nhà cung cấp {{provider}}",
 		"last_sync_label": "Lần đồng bộ hóa gần nhất:",
-		"toast_sync_disabled": "khách sạn/{{group}} đã bị vô hiệu hóa: còn {{count}} thành viên có thể định tuyến",
-		"toast_entry_min_two": "Ít nhất 2 thành viên phải luôn hoạt động."
+		"toast_entry_min_two": "Ít nhất 2 thành viên phải luôn hoạt động.",
+		"toast_sync_purged_one": "khách sạn/{{group}}: đã xóa {{count}} mục đã hết hạn",
+		"toast_sync_purged_other": "khách sạn/{{group}}: đã xóa {{count}} mục đã hết hạn",
+		"toast_sync_disabled_one": "khách sạn/{{group}} đã bị vô hiệu hóa: còn {{count}} thành viên có thể định tuyến",
+		"toast_sync_disabled_other": "khách sạn/{{group}} đã bị vô hiệu hóa: còn {{count}} thành viên có thể định tuyến"
 	},
 	"delete_confirm": {
 		"unsaved_changes": "Các thay đổi chưa được lưu"

--- a/web/src/i18n/locales/zh.json
+++ b/web/src/i18n/locales/zh.json
@@ -696,7 +696,6 @@
 		"sort_title_desc": "排序 Z-A (点击还原)",
 		"empty_no_match": "没有匹配所选过滤器的提供者。",
 		"empty_no_providers": "未配置提供商。添加您的第一个提供商以开始操作。",
-		"toast_discovery_failed_all": "无法发现所有 {{failed}} 提供商",
 		"toast_discover_failed": "发现失败： {{message}}",
 		"toast_provider_added": "已添加服务提供商“{{name}}”",
 		"toast_provider_updated": "提供商“{{name}}”已更新",
@@ -704,7 +703,6 @@
 		"toast_delete_failed": "删除失败： {{message}}",
 		"toast_add_failed": "添加提供程序失败： {{message}}",
 		"toast_update_failed": "更新失败： {{message}}",
-		"toast_refresh_success": "已刷新 {{count}} 配额/余额",
 		"toast_refresh_warning": "已刷新 {{refreshed}} 配额（{{failed}} 操作失败， {{skipped}} 不支持）",
 		"toast_refresh_none": "没有找到配额/平衡支持的提供商",
 		"toast_refresh_failed": "刷新配额失败： {{message}}",
@@ -851,10 +849,15 @@
 			"retestDone": "已重新测试 {{provider}}",
 			"toggleSection": "切换 {{provider}} 部分",
 			"failoverDisabled": "故障转移组已停用",
-			"failoverDisabledReason": "剩余 {{count}} 个可路由成员，需要 2 个以上"
+			"failoverDisabledReason_one": "剩余 {{count}} 个可路由成员，需要 2 个以上",
+			"failoverDisabledReason_other": "剩余 {{count}} 个可路由成员，需要 2 个以上"
 		},
 		"toast_quota_detected_minimax": "检测到 MiniMax 配额",
-		"type_minimax": "MiniMax"
+		"type_minimax": "MiniMax",
+		"toast_refresh_success_one": "已刷新 {{count}} 个配额/余额",
+		"toast_refresh_success_other": "已刷新 {{count}} 个配额/余额",
+		"toast_discovery_failed_all_one": "无法发现该提供商",
+		"toast_discovery_failed_all_other": "无法发现所有 {{count}} 个提供商"
 	},
 	"models": {
 		"page_title_one": "模型",
@@ -991,7 +994,6 @@
 		"toast_bulk_toggle_failed": "批量切换某些组失败",
 		"toast_provider_toggle_failed": "批量提供商切换某些组失败",
 		"toast_sync_deleted": "酒店/{{model}} 已删除： {{reason}}{{providers}}",
-		"toast_sync_purged": "酒店/{{group}}：已删除 {{count}} 过期条目",
 		"toast_sync_success": "失败的组同步",
 		"toast_sync_failed": "同步失败： {{message}}",
 		"toast_update_failed": "更新失败： {{message}}",
@@ -1037,8 +1039,11 @@
 		"provider_modal_description": "禁用一个提供商将在每个失败组禁用其所有模型",
 		"toast_provider_toggle_no_groups": "没有故障转移组使用该提供程序 {{provider}}",
 		"last_sync_label": "最后同步时间：",
-		"toast_sync_disabled": "酒店/{{group}} 已停用：剩余 {{count}} 个可路由成员",
-		"toast_entry_min_two": "至少 2 个成员必须保持活动状态。"
+		"toast_entry_min_two": "至少 2 个成员必须保持活动状态。",
+		"toast_sync_purged_one": "酒店/{{group}}：已删除 {{count}} 个过期条目",
+		"toast_sync_purged_other": "酒店/{{group}}：已删除 {{count}} 个过期条目",
+		"toast_sync_disabled_one": "酒店/{{group}} 已停用：剩余 {{count}} 个可路由成员",
+		"toast_sync_disabled_other": "酒店/{{group}} 已停用：剩余 {{count}} 个可路由成员"
 	},
 	"delete_confirm": {
 		"unsaved_changes": "未保存的更改"

--- a/web/src/pages/Providers.tsx
+++ b/web/src/pages/Providers.tsx
@@ -135,7 +135,7 @@ export function Providers() {
 			setDiscoverAllCurrentId(null);
 			if (data.failed > 0 && data.succeeded === 0) {
 				toast(
-					t("providers.toast_discovery_failed_all", { failed: data.failed }),
+					t("providers.toast_discovery_failed_all", { count: data.failed }),
 					"error",
 				);
 			}

--- a/web/src/pages/__tests__/FailoverGroups.details.test.tsx
+++ b/web/src/pages/__tests__/FailoverGroups.details.test.tsx
@@ -288,7 +288,7 @@ describe("FailoverGroups", () => {
 
 			await waitFor(() => {
 				expect(
-					screen.getByText("hotel/claude-3: removed 2 stale entry(ies)"),
+					screen.getByText("hotel/claude-3: removed 2 stale entries"),
 				).toBeInTheDocument();
 			});
 		});
@@ -330,9 +330,7 @@ describe("FailoverGroups", () => {
 
 			await waitFor(() => {
 				expect(
-					screen.getByText(
-						"hotel/claude-3 disabled: 1 routable member(s) left",
-					),
+					screen.getByText("hotel/claude-3 disabled: 1 routable member left"),
 				).toBeInTheDocument();
 			});
 		});


### PR DESCRIPTION
## What

Follow-up to #542 (backend). Five frontend toasts hardcoded a plural noun or dodged it with `(s)`/`(ies)`, so a count of 1 rendered awkwardly:

- `Refreshed 1 quotas/balances`
- `Discovery failed for all 1 providers`
- `1 routable member(s) left, need 2+`
- `hotel/X: removed 1 stale entry(ies)`
- `hotel/X disabled: 1 routable member(s) left`

## Change

Converted each to i18next `_one`/`_other` plural keys across `en.json` and all 28 other web locales (hand-translated, following the repo's `_one`/`_other`-only convention; CJK/Turkish/Hungarian get identical forms):

- `providers.toast_refresh_success`
- `providers.toast_discovery_failed_all` — also switched `{{failed}}` → `{{count}}` (i18next plural keys off `count`, so it never pluralised before) and updated the call site in `Providers.tsx`
- `providers.discoverySummary.failoverDisabledReason`
- `failover.toast_sync_purged`
- `failover.toast_sync_disabled`

Drops the now-stale `allow-english` entry for `toast_refresh_success` (`da` is now translated).

## Verification

- `make i18n-check` — green (28 web + 10 FD locales in sync, placeholder parity OK)
- `pnpm exec tsc -b` — clean
- ESLint — clean
- 60 affected component tests (Providers, FailoverGroups) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)