### PR TITLE
feat(auth): screen new passwords against Have I Been Pwned

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,14 @@ COOKIE_SECURE=always
 RATE_LIMIT_ENABLED=true
 RATE_LIMIT_IP_RPS=30
 RATE_LIMIT_IP_BURST=60
+# Breached-password check: screen new dashboard passwords against the Have I
+# Been Pwned range API using k-anonymity (only a 5-char SHA-1 prefix is sent;
+# the password never leaves the box). Fails open — an unreachable endpoint
+# never blocks a password change. Set PWNED_PASSWORD_API_URL to a self-hosted
+# mirror (e.g. http://hibp-api:8000) for offline/egress-restricted deployments;
+# see Configuration.md for a docker-compose example.
+PWNED_PASSWORD_CHECK_ENABLED=true
+PWNED_PASSWORD_API_URL=https://api.pwnedpasswords.com
 MAX_REQUEST_SIZE=52428800
 CORS_ORIGINS=http://localhost:5173,http://localhost:8081
 ALLOWED_PROVIDER_HOSTS=

--- a/Configuration.md
+++ b/Configuration.md
@@ -20,6 +20,8 @@ These are read once at startup and cannot be changed at runtime.
 | `ALLOWED_PROVIDER_HOSTS` | No | *(empty)* | Comma-separated list of additional allowed provider hosts. Built-in provider hosts (`api.openai.com`, `api.nano-gpt.com`, `api.z.ai`, `api.deepseek.com`, `api.anthropic.com`, `ollama.com`, `opencode.ai`, `api.x.ai`, `generativelanguage.googleapis.com`, `api.cohere.com`, `api.cohere.ai`, `openrouter.ai`) are **always** allowed regardless of this setting. Hosts listed here bypass URL-validation checks (loopback-address blocking and DNS-resolved loopback detection) so `localhost` can be added for local Ollama or testing. They do **not** bypass SafeDialer private-IP blocking at the TCP level (use `KNOWN_PROXIES` for that). |
 | `RATE_LIMIT_IP_RPS` | No | `30` | Per-IP requests per second (DoS safety net; always-on, not DB-configurable). |
 | `RATE_LIMIT_IP_BURST` | No | `60` | Per-IP burst size for DoS protection token bucket. |
+| `PWNED_PASSWORD_CHECK_ENABLED` | No | `true` | Screen new dashboard passwords against the Have I Been Pwned range API (k-anonymity: only a 5-char SHA-1 prefix is sent, the password never leaves the box). Hard kill-switch: when `false`, no breach check ever runs and the `pwned_password_check_enabled` DB toggle has no effect. The check **fails open** — an unreachable endpoint never blocks a password change. |
+| `PWNED_PASSWORD_API_URL` | No | `https://api.pwnedpasswords.com` | Base URL of the breach range API. Point it at a self-hosted mirror (e.g. `http://hibp-api:8000`) for offline or egress-restricted deployments. The request path is `<base>/range/<prefix>`. See [Breached-password screening](#breached-password-screening). |
 | `DATABASE_MAX_CONNS` | No | `25` | Maximum database connection pool size. |
 | `DATABASE_MIN_CONNS` | No | `5` | Minimum database connection pool size. |
 | `MODELSDEV_ENABLED` | No | `true` | Enable models.dev enrichment for auto-discovering model metadata (pricing, context window, capabilities). |
@@ -64,6 +66,7 @@ These settings are stored in the `settings` table and can be changed at runtime 
 | `circuit_breaker_threshold` | `5` | Number of consecutive failures before the circuit breaker opens (1-100). |
 | `circuit_breaker_cooldown` | `1m0s` | Duration the circuit breaker stays open before allowing a half-open retry (e.g. `30s`, `1m0s`, `5m0s`). |
 | `rate_limit_ip_enabled` | `true` | Runtime toggle for per-IP rate limiting. Overridden by the `RATE_LIMIT_ENABLED` env var. |
+| `pwned_password_check_enabled` | `true` | Runtime toggle for breached-password screening. Overridden by the `PWNED_PASSWORD_CHECK_ENABLED` env var: if the env var is `false`, this setting has no effect. Lets an operator turn the check off without a redeploy. |
 | `rate_limit_ip_rps` | `30` | Per-IP requests per second. |
 | `rate_limit_ip_burst` | `60` | Per-IP burst size for the token bucket. |
 | `rate_limit_max_wait_ms` | `200` | Maximum time (ms) a rate-limited request waits for a token before returning 429 (0-10000). |
@@ -104,6 +107,50 @@ When a request is rate-limited, the response includes:
 - `X-RateLimit-Limit: <rate>`: The refill rate
 - `X-RateLimit-Remaining: <tokens>`: Remaining tokens in the bucket
 - `X-RateLimit-Burst: <burst>`: The burst capacity
+
+### Breached-password screening
+
+When `PWNED_PASSWORD_CHECK_ENABLED` is `true` (the default) and the runtime `pwned_password_check_enabled` toggle is on, every new dashboard password — set at user creation, admin reset, or self-service change — is checked against the [Have I Been Pwned](https://haveibeenpwned.com/Passwords) Pwned Passwords corpus before it is accepted. If the password appears in a known breach, the change is rejected with a message telling the user to pick a different one.
+
+The lookup uses **k-anonymity**: the password is hashed with SHA-1, only the first 5 hex characters of the hash are sent to the range API, and the full password never leaves the box. The API returns every suffix sharing that prefix along with a breach count, and Model Hotel matches the remaining suffix locally.
+
+The check is **fail-open**: if the range endpoint is unreachable, times out, or errors, the password change is allowed rather than blocked. It only ever adds a rejection, never a lock-out. The length minimum (8 characters) is enforced first and short-circuits the lookup.
+
+#### Self-hosted / offline mirror
+
+For air-gapped or egress-restricted deployments, point `PWNED_PASSWORD_API_URL` at a local mirror that speaks the same `GET /range/{prefix}` contract. [IncogniPwn](https://github.com/millaguie/incognipwn) serves the full Pwned Passwords corpus (~80 GB) from a downloader + API pair. Add it to your `docker-compose.yml`:
+
+```yaml
+services:
+  hibp-downloader:
+    # One-shot: downloads the Pwned Passwords corpus into the shared volume.
+    # Re-run periodically to refresh. Expect ~80 GB and a long first run.
+    image: ghcr.io/millaguie/incognipwn-downloader:latest
+    volumes:
+      - hibp-data:/data
+    restart: "no"
+
+  hibp-api:
+    # Serves GET /range/{prefix} on port 8000 from the downloaded corpus.
+    image: ghcr.io/millaguie/incognipwn-api:latest
+    volumes:
+      - hibp-data:/data
+    expose:
+      - "8000"
+    restart: unless-stopped
+
+  app:
+    # ... your existing Model Hotel service ...
+    environment:
+      PWNED_PASSWORD_API_URL: http://hibp-api:8000
+    depends_on:
+      - hibp-api
+
+volumes:
+  hibp-data:
+```
+
+The mirror only needs to be reachable from the `app` container — do not expose it publicly. Because the check fails open, Model Hotel keeps accepting password changes even while the downloader is still populating the corpus.
 
 ## Frontend Settings
 

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -67,7 +67,7 @@ The web UI embeds the JetBrains Mono, Onest, and Schibsted Grotesk typefaces, an
 | [golang.org/x/time](https://golang.org/x/time) | v0.15.0 | Go | BSD-3-Clause |
 | [google.golang.org/genproto/googleapis/api](https://google.golang.org/genproto/googleapis/api) | v0.0.0-20260526163538-3dc84a4a5aaa | Go | Apache-2.0 |
 | [google.golang.org/genproto/googleapis/rpc](https://google.golang.org/genproto/googleapis/rpc) | v0.0.0-20260526163538-3dc84a4a5aaa | Go | Apache-2.0 |
-| [google.golang.org/grpc](https://google.golang.org/grpc) | v1.81.1 | Go | Apache-2.0 |
+| [google.golang.org/grpc](https://google.golang.org/grpc) | v1.82.1 | Go | Apache-2.0 |
 | [google.golang.org/protobuf](https://google.golang.org/protobuf) | v1.36.11 | Go | BSD-3-Clause |
 | [@babel/runtime](https://babel.dev/docs/en/next/babel-runtime) | 7.29.7 | npm | MIT |
 | [@dnd-kit/accessibility](https://github.com/clauderic/dnd-kit#readme) | 3.1.1 | npm | MIT |
@@ -3577,7 +3577,7 @@ SOFTWARE.
 
 copyright notice that is included in or attached to the work
 
-Applies to: `google.golang.org/grpc@v1.81.1`
+Applies to: `google.golang.org/grpc@v1.82.1`
 
 ```
 Apache License

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -39,6 +39,7 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/otelexport"
 	"github.com/hugalafutro/model-hotel/internal/provider"
 	"github.com/hugalafutro/model-hotel/internal/proxy"
+	"github.com/hugalafutro/model-hotel/internal/pwned"
 	"github.com/hugalafutro/model-hotel/internal/ratelimit"
 	"github.com/hugalafutro/model-hotel/internal/settings"
 	"github.com/hugalafutro/model-hotel/internal/totp"
@@ -217,6 +218,13 @@ func main() {
 	// doubles as the session revoker for disable/delete/password-reset.
 	userRepo := user.NewRepository(database.Pool())
 	apiHandler.SetUserAuth(userRepo, webauthnRepo)
+	// Breached-password check: new dashboard passwords are screened against the
+	// Have I Been Pwned range API (k-anonymity — only a 5-char SHA-1 prefix ever
+	// leaves the process) unless disabled via the env kill-switch or DB toggle.
+	// It fails open, so an unreachable endpoint never blocks a password change;
+	// PWNED_PASSWORD_API_URL can point at a self-hosted mirror for offline or
+	// egress-restricted deployments.
+	apiHandler.SetPwnedChecker(pwned.New(cfg.PwnedPasswordAPIURL, nil))
 	// Per-user TOTP second factor: the factory binds the shared crypto/policy
 	// repository to one user's rows (user_totp tables), so login enforcement
 	// and the self-service endpoints reuse the admin TOTP machinery verbatim.

--- a/go.mod
+++ b/go.mod
@@ -69,7 +69,7 @@ require (
 	golang.org/x/net v0.56.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
-	google.golang.org/grpc v1.81.1 // indirect
+	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	modernc.org/libc v1.74.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -182,8 +182,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:q4lMZS6kskjT5HvCPrnnypcDPVJqT/f4nfxmkE7gryY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa h1:mZHHdPZl0dbGHCflZgAq/Q468DWVFcU2whhB2KAo8fk=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.81.1 h1:VnnIIZ88UzOOKLukQi+ImGz8O1Wdp8nAGGnvOfEIWQQ=
-google.golang.org/grpc v1.81.1/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
+google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
+google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -103,6 +103,13 @@ type WebAuthnSessionManager interface {
 	CreateAuthToken(ctx context.Context, userID, credentialID []byte) (string, error)
 }
 
+// PwnedChecker reports whether a password appears in a known breach corpus.
+// Satisfied by *pwned.Checker in production and by a stub in tests; nil when
+// the feature is not wired.
+type PwnedChecker interface {
+	Breached(ctx context.Context, password string) (bool, int, error)
+}
+
 // Handler manages admin API operations for providers, models, and virtual keys.
 type Handler struct {
 	cfg                    *config.Config
@@ -130,6 +137,7 @@ type Handler struct {
 	totpStatus             TotpStatus        // nil when TOTP feature not wired -> TotpEnabled() returns false (today's behavior)
 	totpEnabled            atomic.Bool       // cached IsEnabled result; refreshed by enroll-verify/disable handlers after DB mutations
 	quotaRepo              *quota.Repository // read-through store for polled provider quota snapshots
+	pwnedChecker           PwnedChecker      // nil until SetPwnedChecker (breached-password check on create/reset/change)
 }
 
 // NewHandler creates a new admin API handler with the given dependencies.
@@ -164,6 +172,13 @@ func NewHandler(cfg *config.Config, providerRepo ProviderStore, database *db.DB,
 // Pool returns the database connection pool.
 func (h *Handler) Pool() *db.DB {
 	return h.dbPool
+}
+
+// SetPwnedChecker wires the breached-password checker used by the user
+// create/reset/change flows. Leaving it unset disables the check regardless of
+// config (the check is skipped, never blocking).
+func (h *Handler) SetPwnedChecker(c PwnedChecker) {
+	h.pwnedChecker = c
 }
 
 // SetWebAuthnSessionManager sets the optional webAuthn session manager for

--- a/internal/api/admin_test.go
+++ b/internal/api/admin_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/provider"
 	"github.com/hugalafutro/model-hotel/internal/settings"
 	totpsvc "github.com/hugalafutro/model-hotel/internal/totp"
+	"github.com/hugalafutro/model-hotel/internal/user"
 	"github.com/hugalafutro/model-hotel/internal/virtualkey"
 	"github.com/hugalafutro/model-hotel/internal/webauthn"
 )
@@ -246,6 +247,11 @@ func testHandler(provStore *mockProviderStore, vkStore *mockVirtualKeyStore, set
 func newChiRequest(method, path string, body io.Reader) (*http.Request, *httptest.ResponseRecorder) {
 	req := httptest.NewRequest(method, path, body)
 	req.Header.Set("Content-Type", "application/json")
+	// The admin auth middleware injects an identity on every authenticated
+	// request (AdminIdentity for the admin token). These handler tests call the
+	// handlers directly, so carry the same admin identity to mirror production;
+	// authorization predicates like canTouchKey fail closed on a nil identity.
+	req = req.WithContext(user.WithIdentity(req.Context(), user.AdminIdentity()))
 	return req, httptest.NewRecorder()
 }
 

--- a/internal/api/handler_settings_test.go
+++ b/internal/api/handler_settings_test.go
@@ -254,6 +254,42 @@ func TestUpdateSettings_TimeoutDurations(t *testing.T) {
 	}
 }
 
+// Test that pwned_password_check_enabled round-trips through the settings API.
+// It is the runtime toggle read by passwordpolicy.go; without an allowlist entry
+// the write silently 400s and the "disable without a redeploy" promise breaks
+// (AGENTS.md: one save/retrieve test per allowedSettings key).
+func TestUpdateSettings_PwnedPasswordToggle(t *testing.T) {
+	_, r := newTestHandlerWithRouter(t)
+
+	body := `{"pwned_password_check_enabled": "false"}`
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("PUT", "/settings", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-admin-token")
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/settings", http.NoBody)
+	req.Header.Set("Authorization", "Bearer test-admin-token")
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var response map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("Failed to parse response: %v", err)
+	}
+	if response["pwned_password_check_enabled"] != "false" {
+		t.Errorf("Expected pwned_password_check_enabled='false', got %q", response["pwned_password_check_enabled"])
+	}
+}
+
 // Test that hedging_enabled and hedge_delay round-trip through the settings API
 // (AGENTS.md: one save/retrieve test per allowedSettings key).
 func TestUpdateSettings_Hedging(t *testing.T) {

--- a/internal/api/passwordpolicy.go
+++ b/internal/api/passwordpolicy.go
@@ -1,0 +1,68 @@
+package api
+
+import (
+	"context"
+	"errors"
+
+	"github.com/hugalafutro/model-hotel/internal/debuglog"
+)
+
+// settingKeyPwnedPasswordCheck is the DB-backed runtime toggle for the
+// breached-password check. Absent (the default) reads as enabled, so the
+// feature is on out of the box; an operator can turn it off without a
+// redeploy. The env kill-switch (PWNED_PASSWORD_CHECK_ENABLED=false) is
+// evaluated first and cannot be overridden back on from the DB.
+const settingKeyPwnedPasswordCheck = "pwned_password_check_enabled"
+
+// Password-policy rejection reasons, surfaced to the client as the 400 body
+// text. They are stable strings the dashboard maps to localized copy, so
+// changing their wording is a frontend-visible contract change.
+var (
+	errPasswordTooShort = errors.New("password must be at least 8 characters")
+	errPasswordBreached = errors.New("this password has appeared in a known data breach; choose a different one")
+)
+
+// validateNewPassword enforces the password policy for the admin-driven
+// create/reset flows: a minimum length, then (when enabled) a Have I Been
+// Pwned breach check. It returns errPasswordTooShort or errPasswordBreached on
+// a policy failure so callers can respondBadRequest(w, err.Error(), nil), nil
+// on success, and — deliberately — nil on any breach-check infrastructure
+// failure (fail open). ChangeOwnPassword does not use this helper: it runs the
+// breach check only after verifying the current password (see there).
+func (h *Handler) validateNewPassword(ctx context.Context, password string) error {
+	if len(password) < minPasswordLen {
+		return errPasswordTooShort
+	}
+	if h.passwordBreached(ctx, password) {
+		return errPasswordBreached
+	}
+	return nil
+}
+
+// passwordBreached reports whether the breach check is enabled AND positively
+// identifies the password as breached. Every other outcome returns false:
+// feature disabled by the env kill-switch or the DB toggle, checker not wired,
+// or the range endpoint erroring/timing out. That fail-open stance means a HIBP
+// outage or an offline/air-gapped deployment can never lock an operator out of
+// setting a password.
+func (h *Handler) passwordBreached(ctx context.Context, password string) bool {
+	if h.pwnedChecker == nil || h.cfg == nil || !h.cfg.PwnedPasswordCheckEnabled {
+		return false
+	}
+	if h.settingsRepo != nil && !h.settingsRepo.GetBool(ctx, settingKeyPwnedPasswordCheck, true) {
+		return false
+	}
+	breached, count, err := h.pwnedChecker.Breached(ctx, password)
+	if err != nil {
+		// Fail open: never block a password change because the breach service is
+		// unreachable. No password material is logged.
+		debuglog.Warn("password-policy: breach check failed, allowing password", "error", err)
+		return false
+	}
+	if breached {
+		// count is the corpus breach frequency, not password material, so it is
+		// safe to log and gives operators a sense of how common the reject was.
+		debuglog.Info("password-policy: rejected a breached password", "breach_count", count)
+	}
+	return breached
+}

--- a/internal/api/passwordpolicy_test.go
+++ b/internal/api/passwordpolicy_test.go
@@ -1,0 +1,108 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/hugalafutro/model-hotel/internal/config"
+)
+
+// stubPwnedChecker is a hand-driven PwnedChecker for policy tests.
+type stubPwnedChecker struct {
+	breached bool
+	count    int
+	err      error
+	calls    int
+}
+
+func (s *stubPwnedChecker) Breached(_ context.Context, _ string) (bool, int, error) {
+	s.calls++
+	return s.breached, s.count, s.err
+}
+
+const (
+	shortPassword = "1234567"            // 7 chars, below minPasswordLen
+	longPassword  = "longenoughpassword" // >= minPasswordLen
+)
+
+func enabledCfg() *config.Config {
+	return &config.Config{PwnedPasswordCheckEnabled: true}
+}
+
+func TestValidateNewPassword_TooShortSkipsBreachCheck(t *testing.T) {
+	chk := &stubPwnedChecker{breached: true}
+	h := &Handler{cfg: enabledCfg(), pwnedChecker: chk, settingsRepo: &mockSettingsStore{}}
+
+	if err := h.validateNewPassword(context.Background(), shortPassword); !errors.Is(err, errPasswordTooShort) {
+		t.Fatalf("got %v, want errPasswordTooShort", err)
+	}
+	if chk.calls != 0 {
+		t.Fatalf("breach check ran for a too-short password (%d calls); length should short-circuit", chk.calls)
+	}
+}
+
+func TestValidateNewPassword_RejectsBreached(t *testing.T) {
+	chk := &stubPwnedChecker{breached: true, count: 5}
+	h := &Handler{cfg: enabledCfg(), pwnedChecker: chk, settingsRepo: &mockSettingsStore{}}
+
+	if err := h.validateNewPassword(context.Background(), longPassword); !errors.Is(err, errPasswordBreached) {
+		t.Fatalf("got %v, want errPasswordBreached", err)
+	}
+}
+
+func TestValidateNewPassword_AllowsClean(t *testing.T) {
+	chk := &stubPwnedChecker{breached: false}
+	h := &Handler{cfg: enabledCfg(), pwnedChecker: chk, settingsRepo: &mockSettingsStore{}}
+
+	if err := h.validateNewPassword(context.Background(), longPassword); err != nil {
+		t.Fatalf("got %v, want nil for a clean password", err)
+	}
+	if chk.calls != 1 {
+		t.Fatalf("breach check ran %d times, want exactly 1", chk.calls)
+	}
+}
+
+func TestValidateNewPassword_FailsOpenOnCheckerError(t *testing.T) {
+	chk := &stubPwnedChecker{err: errors.New("range endpoint unreachable")}
+	h := &Handler{cfg: enabledCfg(), pwnedChecker: chk, settingsRepo: &mockSettingsStore{}}
+
+	if err := h.validateNewPassword(context.Background(), longPassword); err != nil {
+		t.Fatalf("got %v, want nil (fail open) when the breach service errors", err)
+	}
+}
+
+func TestValidateNewPassword_EnvKillSwitchSkipsCheck(t *testing.T) {
+	chk := &stubPwnedChecker{breached: true}
+	h := &Handler{cfg: &config.Config{PwnedPasswordCheckEnabled: false}, pwnedChecker: chk, settingsRepo: &mockSettingsStore{}}
+
+	if err := h.validateNewPassword(context.Background(), longPassword); err != nil {
+		t.Fatalf("got %v, want nil when disabled via env", err)
+	}
+	if chk.calls != 0 {
+		t.Fatalf("breach check ran (%d calls) despite the env kill-switch", chk.calls)
+	}
+}
+
+func TestValidateNewPassword_DBToggleOffSkipsCheck(t *testing.T) {
+	chk := &stubPwnedChecker{breached: true}
+	settings := &mockSettingsStore{getBoolFn: func(_ context.Context, key string, _ bool) bool {
+		return key != settingKeyPwnedPasswordCheck
+	}}
+	h := &Handler{cfg: enabledCfg(), pwnedChecker: chk, settingsRepo: settings}
+
+	if err := h.validateNewPassword(context.Background(), longPassword); err != nil {
+		t.Fatalf("got %v, want nil when disabled via the DB toggle", err)
+	}
+	if chk.calls != 0 {
+		t.Fatalf("breach check ran (%d calls) despite the DB toggle being off", chk.calls)
+	}
+}
+
+func TestValidateNewPassword_UnwiredCheckerAllows(t *testing.T) {
+	h := &Handler{cfg: enabledCfg(), settingsRepo: &mockSettingsStore{}}
+
+	if err := h.validateNewPassword(context.Background(), longPassword); err != nil {
+		t.Fatalf("got %v, want nil when no checker is wired", err)
+	}
+}

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -171,6 +171,7 @@ var allowedSettings = map[string]struct {
 	"alert_apprise_targets":        {typeName: "string"},                // secret: encrypted at rest, masked on read
 	"alert_events":                 {typeName: "string"},                // CSV of enabled event Types (the picker)
 	"session_idle_timeout_minutes": {typeName: "int", min: 0, max: 240}, // dashboard auto-logout window in minutes; 0 = disabled
+	"pwned_password_check_enabled": {typeName: "string"},                // bool as string; breached-password screening runtime toggle
 	"oidc_enabled":                 {typeName: "string"},                // bool as string
 	"oidc_issuer_url":              {typeName: "url"},                   // OIDC discovery base URL (SSRF-validated)
 	"oidc_client_id":               {typeName: "string"},                // OAuth client id

--- a/internal/api/userpassword.go
+++ b/internal/api/userpassword.go
@@ -66,6 +66,13 @@ func (h *Handler) ChangeOwnPassword(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "current password is incorrect", http.StatusUnauthorized)
 		return
 	}
+	// Breach-check the new password only after the current one is verified, so
+	// the outbound lookup is driven by this authenticated action rather than an
+	// unauthenticated probe, and a throttled caller cannot spam it.
+	if h.passwordBreached(r.Context(), req.NewPassword) {
+		respondBadRequest(w, errPasswordBreached.Error(), nil)
+		return
+	}
 	hash, err := user.HashPassword(req.NewPassword)
 	if err != nil {
 		respondError(w, "failed to hash password", err, http.StatusInternalServerError)

--- a/internal/api/users.go
+++ b/internal/api/users.go
@@ -161,8 +161,8 @@ func (h *Handler) CreateUser(w http.ResponseWriter, r *http.Request) {
 	if err := validateRateLimits(req.RateLimitRPS, req.RateLimitBurst, req.RateLimitTPM, w); err != nil {
 		return
 	}
-	if len(req.Password) < minPasswordLen {
-		respondBadRequest(w, "password must be at least 8 characters", nil)
+	if err := h.validateNewPassword(r.Context(), req.Password); err != nil {
+		respondBadRequest(w, err.Error(), nil)
 		return
 	}
 	hash, err := user.HashPassword(req.Password)
@@ -249,8 +249,8 @@ func (h *Handler) SetUserPassword(w http.ResponseWriter, r *http.Request) {
 		respondBadRequest(w, "invalid request body", err)
 		return
 	}
-	if len(req.Password) < minPasswordLen {
-		respondBadRequest(w, "password must be at least 8 characters", nil)
+	if err := h.validateNewPassword(r.Context(), req.Password); err != nil {
+		respondBadRequest(w, err.Error(), nil)
 		return
 	}
 	hash, err := user.HashPassword(req.Password)

--- a/internal/api/users_test.go
+++ b/internal/api/users_test.go
@@ -71,6 +71,50 @@ func createUserViaAPI(t *testing.T, r chi.Router, username, password, role strin
 	return resp.ID
 }
 
+// TestCreateUser_BreachCheckAndToggle exercises breached-password screening end
+// to end through the admin create-user path: a wired checker rejects a breached
+// password with 400, and flipping the pwned_password_check_enabled runtime
+// toggle off (through the settings API a real operator uses) lets the same
+// password through. The unit tests in passwordpolicy_test.go cover
+// validateNewPassword directly; this asserts the full request path plus the DB
+// toggle, which no unit test can reach.
+func TestCreateUser_BreachCheckAndToggle(t *testing.T) {
+	h, r := newTestHandlerWithRouter(t)
+
+	pool := h.Pool().Pool()
+	if _, err := pool.Exec(context.Background(), `TRUNCATE users, webauthn_sessions CASCADE`); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	userRepo := user.NewRepository(pool)
+	webauthnRepo := webauthn.NewRepository(pool)
+	h.SetWebAuthnSessionManager(webauthn.NewSessionManager(webauthnRepo))
+	h.SetUserAuth(userRepo, webauthnRepo)
+
+	h.cfg.PwnedPasswordCheckEnabled = true
+	h.SetPwnedChecker(&stubPwnedChecker{breached: true, count: 42})
+
+	body := `{"username":"breachy","password":"password123","role":"user","grants":["chat"]}`
+
+	// A breached password is refused at create time.
+	w := doJSON(t, r, http.MethodPost, "/users", envAdminToken, body)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("breached create: %d, want 400; body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "data breach") {
+		t.Errorf("body %q missing the breach message", w.Body.String())
+	}
+
+	// Turn the runtime toggle off through the settings API; the same password
+	// now goes through, proving the DB toggle reaches passwordBreached live.
+	if tw := doJSON(t, r, http.MethodPut, "/settings", envAdminToken, `{"pwned_password_check_enabled":"false"}`); tw.Code != http.StatusOK {
+		t.Fatalf("toggle off: %d, body=%s", tw.Code, tw.Body.String())
+	}
+	w = doJSON(t, r, http.MethodPost, "/users", envAdminToken, body)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create after toggle off: %d, want 201; body=%s", w.Code, w.Body.String())
+	}
+}
+
 func TestUsersAPI_AdminCRUD(t *testing.T) {
 	r, _, _ := setupUsersTest(t)
 

--- a/internal/api/virtualkeys.go
+++ b/internal/api/virtualkeys.go
@@ -155,8 +155,16 @@ func resolveWriteOwner(id *user.Identity, requested *string) (*uuid.UUID, error)
 // always, non-admins only for keys they own. Deny reads as 404 so the key
 // listing and the detail routes tell a consistent story (no existence
 // oracle for other users' keys).
+//
+// A nil identity fails closed. The routes that call this already reject nil
+// callers upstream (behind requireGrant/requireAdmin), so treating nil as an
+// allow was never reachable — but an authorization predicate should be safe by
+// construction, not by every caller remembering to pre-check.
 func canTouchKey(id *user.Identity, vk *virtualkey.VirtualKey) bool {
-	if id == nil || id.IsAdmin() {
+	if id == nil {
+		return false
+	}
+	if id.IsAdmin() {
 		return true
 	}
 	return id.UserID != nil && vk.OwnerUserID != nil && *vk.OwnerUserID == *id.UserID

--- a/internal/api/virtualkeys_authz_test.go
+++ b/internal/api/virtualkeys_authz_test.go
@@ -1,0 +1,42 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/hugalafutro/model-hotel/internal/user"
+	"github.com/hugalafutro/model-hotel/internal/virtualkey"
+)
+
+func TestCanTouchKey(t *testing.T) {
+	owner := uuid.New()
+	other := uuid.New()
+	ownedKey := &virtualkey.VirtualKey{OwnerUserID: &owner}
+	unownedKey := &virtualkey.VirtualKey{}
+
+	admin := &user.Identity{Role: user.RoleAdmin}
+	ownerUser := &user.Identity{Role: user.RoleUser, UserID: &owner}
+	otherUser := &user.Identity{Role: user.RoleUser, UserID: &other}
+
+	tests := []struct {
+		name string
+		id   *user.Identity
+		vk   *virtualkey.VirtualKey
+		want bool
+	}{
+		{"nil identity fails closed", nil, ownedKey, false},
+		{"admin may touch any key", admin, ownedKey, true},
+		{"admin may touch an unowned key", admin, unownedKey, true},
+		{"owner may touch own key", ownerUser, ownedKey, true},
+		{"non-owner may not touch another's key", otherUser, ownedKey, false},
+		{"user may not touch an unowned key", ownerUser, unownedKey, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := canTouchKey(tt.id, tt.vk); got != tt.want {
+				t.Fatalf("canTouchKey() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -54,6 +54,15 @@ type Config struct {
 	// browser secure context, so "always" still works in local HTTP dev.
 	CookieSecure string
 
+	// Breached-password checking. When enabled (the default), new dashboard
+	// passwords are checked against the Have I Been Pwned Pwned Passwords range
+	// API using k-anonymity (only a 5-char SHA-1 prefix is sent). The check
+	// fails open, so an unreachable endpoint never blocks a password change.
+	// PwnedPasswordAPIURL points the check at a self-hosted mirror instead of
+	// the public service for offline or egress-restricted deployments.
+	PwnedPasswordCheckEnabled bool
+	PwnedPasswordAPIURL       string
+
 	// WebAuthn/FIDO2 configuration. When WEBAUTHN_RP_ID is set, passkey
 	// login is enabled; otherwise the feature is completely disabled.
 	WebAuthnRPID          string
@@ -153,6 +162,9 @@ func Load() (*Config, error) {
 		TrustedProxies:       LoadTrustedProxies(),
 		KnownProxies:         LoadKnownProxies(),
 
+		PwnedPasswordCheckEnabled: getBoolEnvWithDefault("PWNED_PASSWORD_CHECK_ENABLED", true),
+		PwnedPasswordAPIURL:       getEnvWithDefault("PWNED_PASSWORD_API_URL", "https://api.pwnedpasswords.com"),
+
 		WebAuthnRPID:          getEnv("WEBAUTHN_RP_ID"),
 		WebAuthnRPDisplayName: getEnvWithDefault("WEBAUTHN_RP_DISPLAY_NAME", "Model Hotel"),
 		WebAuthnRPOrigins:     parseCORSOrigins(getEnv("WEBAUTHN_RP_ORIGINS")),
@@ -238,6 +250,7 @@ func (c *Config) String() string {
 		{"HTTP Providers", fmt.Sprintf("%t", c.AllowHTTPProviders)},
 		{"Allow Embed", fmt.Sprintf("%t", c.AllowEmbed)},
 		{"Rate Limiting", fmt.Sprintf("%t", c.RateLimitEnabled)},
+		{"Breached-PW Check", fmt.Sprintf("%t", c.PwnedPasswordCheckEnabled)},
 		{"Max Request Size", formatBytes(c.MaxRequestSize)},
 		{"Debug Log", fmt.Sprintf("%t", c.DebugLog)},
 		{"Log Format", logFormat},

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -353,6 +353,46 @@ func TestLoad_SuccessWithDefaults(t *testing.T) {
 	}
 }
 
+func TestLoad_PwnedPasswordDefaults(t *testing.T) {
+	os.Setenv("DATABASE_URL", "postgres://user:pass@localhost/test")
+	os.Setenv("MASTER_KEY", "test-master-key-12345")
+	defer os.Unsetenv("DATABASE_URL")
+	defer os.Unsetenv("MASTER_KEY")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+	if !cfg.PwnedPasswordCheckEnabled {
+		t.Error("expected PwnedPasswordCheckEnabled to default to true")
+	}
+	if cfg.PwnedPasswordAPIURL != "https://api.pwnedpasswords.com" {
+		t.Errorf("expected default PwnedPasswordAPIURL, got %q", cfg.PwnedPasswordAPIURL)
+	}
+}
+
+func TestLoad_PwnedPasswordOverrides(t *testing.T) {
+	os.Setenv("DATABASE_URL", "postgres://user:pass@localhost/test")
+	os.Setenv("MASTER_KEY", "test-master-key-12345")
+	os.Setenv("PWNED_PASSWORD_CHECK_ENABLED", "false")
+	os.Setenv("PWNED_PASSWORD_API_URL", "http://hibp-api:8000")
+	defer os.Unsetenv("DATABASE_URL")
+	defer os.Unsetenv("MASTER_KEY")
+	defer os.Unsetenv("PWNED_PASSWORD_CHECK_ENABLED")
+	defer os.Unsetenv("PWNED_PASSWORD_API_URL")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+	if cfg.PwnedPasswordCheckEnabled {
+		t.Error("expected PwnedPasswordCheckEnabled to be false via env")
+	}
+	if cfg.PwnedPasswordAPIURL != "http://hibp-api:8000" {
+		t.Errorf("expected self-hosted PwnedPasswordAPIURL, got %q", cfg.PwnedPasswordAPIURL)
+	}
+}
+
 func TestLoad_CustomPort(t *testing.T) {
 	os.Setenv("DATABASE_URL", "postgres://user:pass@localhost/test")
 	os.Setenv("MASTER_KEY", "test-master-key-12345")

--- a/internal/pwned/pwned.go
+++ b/internal/pwned/pwned.go
@@ -1,0 +1,91 @@
+// Package pwned checks passwords against the Have I Been Pwned "Pwned
+// Passwords" range API using the k-anonymity model: only the first five hex
+// characters of the password's SHA-1 hash ever leave the process, and the
+// endpoint returns every stored suffix sharing that prefix for the caller to
+// match locally. The plaintext password and its full hash are never
+// transmitted. The endpoint is a fixed, operator-configured URL (default
+// api.pwnedpasswords.com, overridable for a self-hosted mirror), so there is
+// no user-controlled URL and therefore no SSRF surface.
+package pwned
+
+import (
+	"bufio"
+	"context"
+	"crypto/sha1" //nolint:gosec // SHA-1 is the HIBP range-API wire contract, not used as a security primitive
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// maxRangeBody caps how much of a range response we read. A prefix returns on
+// the order of a thousand 40-byte lines; 4 MiB is comfortably above that while
+// bounding memory if a mirror misbehaves.
+const maxRangeBody = 4 << 20
+
+// Checker queries a HIBP-compatible Pwned Passwords range endpoint.
+type Checker struct {
+	baseURL string
+	client  *http.Client
+}
+
+// New returns a Checker for the given base URL (e.g.
+// "https://api.pwnedpasswords.com" or a self-hosted mirror). A nil client is
+// replaced with one carrying a short timeout so a slow or unreachable endpoint
+// cannot stall a password change; callers treat any error as "allow" (fail
+// open), so the timeout bounds worst-case latency rather than blocking users.
+func New(baseURL string, client *http.Client) *Checker {
+	if client == nil {
+		client = &http.Client{Timeout: 5 * time.Second}
+	}
+	return &Checker{
+		baseURL: strings.TrimRight(strings.TrimSpace(baseURL), "/"),
+		client:  client,
+	}
+}
+
+// Breached reports whether password appears in the breach corpus and, if so,
+// how many times. It sends only the 5-character SHA-1 prefix and matches the
+// returned suffixes locally. Any transport error or non-200 status is returned
+// to the caller, which decides how to fail (the callers in this project fail
+// open). Padding decoys (count 0) never count as a match.
+func (c *Checker) Breached(ctx context.Context, password string) (bool, int, error) {
+	sum := sha1.Sum([]byte(password)) //nolint:gosec // see package doc: wire contract, not a security primitive
+	hash := strings.ToUpper(hex.EncodeToString(sum[:]))
+	prefix, suffix := hash[:5], hash[5:]
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/range/"+prefix, http.NoBody)
+	if err != nil {
+		return false, 0, err
+	}
+	// Add-Padding pads the response with decoy suffixes (count 0) so the number
+	// of returned lines cannot leak how many real matches a prefix has. Honored
+	// by HIBP and compatible mirrors; harmlessly ignored otherwise.
+	req.Header.Set("Add-Padding", "true")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return false, 0, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return false, 0, fmt.Errorf("pwned: range endpoint returned status %d", resp.StatusCode)
+	}
+
+	sc := bufio.NewScanner(io.LimitReader(resp.Body, maxRangeBody))
+	for sc.Scan() {
+		sfx, cnt, ok := strings.Cut(sc.Text(), ":")
+		if !ok || !strings.EqualFold(strings.TrimSpace(sfx), suffix) {
+			continue
+		}
+		count, _ := strconv.Atoi(strings.TrimSpace(cnt))
+		return count > 0, count, nil
+	}
+	if err := sc.Err(); err != nil {
+		return false, 0, err
+	}
+	return false, 0, nil
+}

--- a/internal/pwned/pwned.go
+++ b/internal/pwned/pwned.go
@@ -53,7 +53,11 @@ func New(baseURL string, client *http.Client) *Checker {
 // to the caller, which decides how to fail (the callers in this project fail
 // open). Padding decoys (count 0) never count as a match.
 func (c *Checker) Breached(ctx context.Context, password string) (bool, int, error) {
-	sum := sha1.Sum([]byte(password)) //nolint:gosec // see package doc: wire contract, not a security primitive
+	// SHA-1 is the HIBP range API's wire contract for k-anonymity, not password
+	// storage: only the 5-char prefix below is ever sent and the password is
+	// never persisted as this hash. The gosec/CodeQL weak-hash warnings key on
+	// the word "password" reaching sha1 and cannot see that distinction.
+	sum := sha1.Sum([]byte(password)) //nolint:gosec // codeql[go/weak-sensitive-data-hashing] -- HIBP k-anonymity wire contract, not a security primitive
 	hash := strings.ToUpper(hex.EncodeToString(sum[:]))
 	prefix, suffix := hash[:5], hash[5:]
 

--- a/internal/pwned/pwned_test.go
+++ b/internal/pwned/pwned_test.go
@@ -1,0 +1,131 @@
+package pwned
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// sha1("password") = 5BAA61E4C9B93F3F0682250B6CF8331B7EE68FD8
+const (
+	pwPassword      = "password"
+	pwPasswordPfx   = "5BAA6"
+	pwPasswordSfx   = "1E4C9B93F3F0682250B6CF8331B7EE68FD8"
+	pwNeverBreached = "correct horse battery staple !@#$ 2026"
+)
+
+// rangeServer stands in for the HIBP range API. It records the last request it
+// saw and returns the supplied body verbatim for any /range/{prefix} path.
+func rangeServer(t *testing.T, body string) (*httptest.Server, *http.Request) {
+	t.Helper()
+	var last http.Request
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		last = *r
+		if !strings.HasPrefix(r.URL.Path, "/range/") {
+			http.Error(w, "bad path", http.StatusNotFound)
+			return
+		}
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &last
+}
+
+func TestBreached_Match(t *testing.T) {
+	body := fmt.Sprintf("00000000000000000000000000000000000:3\r\n%s:42\r\nFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF:1\r\n", pwPasswordSfx)
+	srv, last := rangeServer(t, body)
+	c := New(srv.URL, srv.Client())
+
+	breached, count, err := c.Breached(context.Background(), pwPassword)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !breached || count != 42 {
+		t.Fatalf("got breached=%v count=%d, want true/42", breached, count)
+	}
+	// Only the 5-char prefix must ever be sent to the endpoint.
+	if want := "/range/" + pwPasswordPfx; last.URL.Path != want {
+		t.Fatalf("request path = %q, want %q (only the prefix, never the suffix)", last.URL.Path, want)
+	}
+	if last.Header.Get("Add-Padding") != "true" {
+		t.Fatalf("Add-Padding header = %q, want \"true\"", last.Header.Get("Add-Padding"))
+	}
+}
+
+func TestBreached_MatchIsCaseInsensitive(t *testing.T) {
+	// HIBP returns uppercase suffixes; accept a lowercased mirror too.
+	body := strings.ToLower(pwPasswordSfx) + ":7\n"
+	srv, _ := rangeServer(t, body)
+	c := New(srv.URL, srv.Client())
+
+	breached, count, err := c.Breached(context.Background(), pwPassword)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !breached || count != 7 {
+		t.Fatalf("got breached=%v count=%d, want true/7", breached, count)
+	}
+}
+
+func TestBreached_NoMatch(t *testing.T) {
+	body := "00000000000000000000000000000000000:3\nFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF:1\n"
+	srv, _ := rangeServer(t, body)
+	c := New(srv.URL, srv.Client())
+
+	breached, count, err := c.Breached(context.Background(), pwNeverBreached)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if breached || count != 0 {
+		t.Fatalf("got breached=%v count=%d, want false/0", breached, count)
+	}
+}
+
+func TestBreached_PaddingDecoyIgnored(t *testing.T) {
+	// Add-Padding decoys carry a count of 0; a suffix that matches a decoy must
+	// still read as not-breached.
+	body := pwPasswordSfx + ":0\n"
+	srv, _ := rangeServer(t, body)
+	c := New(srv.URL, srv.Client())
+
+	breached, _, err := c.Breached(context.Background(), pwPassword)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if breached {
+		t.Fatal("a decoy suffix (count 0) must not count as breached")
+	}
+}
+
+func TestBreached_Non200IsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+	c := New(srv.URL, srv.Client())
+
+	if _, _, err := c.Breached(context.Background(), pwPassword); err == nil {
+		t.Fatal("expected an error for a non-200 response so the caller can fail open")
+	}
+}
+
+func TestBreached_TransportErrorIsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	url := srv.URL
+	srv.Close() // nothing is listening now
+
+	c := New(url, srv.Client())
+	if _, _, err := c.Breached(context.Background(), pwPassword); err == nil {
+		t.Fatal("expected a transport error when the endpoint is unreachable")
+	}
+}
+
+func TestNew_TrimsTrailingSlash(t *testing.T) {
+	c := New(" https://example.test/ ", nil)
+	if c.baseURL != "https://example.test" {
+		t.Fatalf("baseURL = %q, want trimmed", c.baseURL)
+	}
+}

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -54,6 +54,7 @@ var AllowedSettings = map[string]bool{
 	"alert_apprise_targets":        true,
 	"alert_events":                 true,
 	"session_idle_timeout_minutes": true,
+	"pwned_password_check_enabled": true,
 	"oidc_enabled":                 true,
 	"oidc_issuer_url":              true,
 	"oidc_client_id":               true,

--- a/wiki/Configuration.md
+++ b/wiki/Configuration.md
@@ -36,6 +36,8 @@ Environment variables are read once at server startup and cannot be changed at r
 | `RATE_LIMIT_ENABLED` | bool | `true` | **Hard kill-switch** for rate limiting. When `false`, the rate-limiting middleware is always mounted but becomes a complete pass-through (no buckets allocated, no headers, no 429 responses). Cannot be overridden at runtime. |
 | `RATE_LIMIT_IP_RPS` | float | `30` | Per-IP requests per second for the token bucket rate limiter. Clamped to 0–10000. |
 | `RATE_LIMIT_IP_BURST` | int | `60` | Per-IP maximum burst size for the token bucket. Clamped to 1–10000. |
+| `PWNED_PASSWORD_CHECK_ENABLED` | bool | `true` | Screen new dashboard passwords against the Have I Been Pwned range API using k-anonymity (only a 5-char SHA-1 prefix is sent; the password never leaves the box). **Hard kill-switch**: when `false`, no breach check runs and the `pwned_password_check_enabled` DB toggle has no effect. The check **fails open** — an unreachable endpoint never blocks a password change. |
+| `PWNED_PASSWORD_API_URL` | string | `https://api.pwnedpasswords.com` | Base URL of the breach range API. Point at a self-hosted mirror (e.g. `http://hibp-api:8000`) for offline/egress-restricted deployments. Request path is `<base>/range/<prefix>`. See [Breached-password screening](#breached-password-screening). |
 | `MAX_REQUEST_SIZE` | int | `52428800` | Maximum request body size in bytes. Clamped to 1KB–100MB. Default is 50 MB, sized for multipart audio uploads to `/v1/audio/transcriptions` (OpenAI's audio file limit is 25 MB). |
 | `CORS_ORIGINS` | string (comma-separated) | `http://localhost:5173,http://localhost:8081` | Comma-separated list of allowed CORS origins. Must include the scheme (e.g. `http://`). Wildcard `*` is explicitly rejected (incompatible with credentials=true). |
 | `ALLOWED_PROVIDER_HOSTS` | string (comma-separated) | (empty) | Comma-separated list of additional allowed provider hosts. Built-in provider hosts are **always** allowed regardless of this setting. Hosts listed here bypass loopback blocking, so `localhost` can be added for local Ollama. E.g. `localhost,api.example.com` |
@@ -123,6 +125,7 @@ These settings are stored in the `settings` table and can be changed at runtime 
 | `rate_limit_ip_enabled` | bool string | `true` | Runtime toggle for per-IP rate limiting. Only effective when `RATE_LIMIT_ENABLED=true`. | `true`, `false` |
 | `rate_limit_ip_rps` | float | `30` | Per-IP requests per second. Set to `0` for unlimited per-IP rate. | 0–10000 |
 | `rate_limit_ip_burst` | int | `60` | Per-IP burst size for token bucket. | 1–10000 |
+| `pwned_password_check_enabled` | bool string | `true` | Runtime toggle for breached-password screening. **Overridden by `PWNED_PASSWORD_CHECK_ENABLED` env var** - if env var is `false`, this setting has no effect. Lets an operator turn the check off without a redeploy. | `true`, `false` |
 | `rate_limit_rps` | float | `10` | Per-virtual-key requests per second. Set to `0` to disable per-key rate limiting (makes every bucket unlimited). | 0–10000 |
 | `rate_limit_burst` | int | `20` | Maximum burst bucket size per virtual key. | 1–10000 |
 | `rate_limit_tpm` | int | `0` | Global default tokens-per-minute cap for keys without a per-key `rate_limit_tpm`. `0` = no cap. No Settings-UI control (API-only). | 0–100000000 |
@@ -146,6 +149,50 @@ To avoid this, either:
 - set `ttft_timeout` below the proxy's read timeout, so Model Hotel's own probe fires first and fails over to the next provider while the connection is still alive.
 
 A request cut off this way is logged as a `provider_timeout` (502) whose message names the likely reverse-proxy cause, and the stalling provider's circuit breaker records the failure, so repeated stalls open the breaker and subsequent requests skip that provider.
+
+### Breached-password screening
+
+When `PWNED_PASSWORD_CHECK_ENABLED` is `true` (the default) and the runtime `pwned_password_check_enabled` toggle is on, every new dashboard password — set at user creation, admin reset, or self-service change — is checked against the [Have I Been Pwned](https://haveibeenpwned.com/Passwords) Pwned Passwords corpus before it is accepted. If the password appears in a known breach, the change is rejected and the user is asked to pick a different one.
+
+The lookup uses **k-anonymity**: the password is hashed with SHA-1, only the first 5 hex characters of the hash are sent to the range API, and the full password never leaves the box. The API returns every suffix sharing that prefix along with a breach count, and Model Hotel matches the remaining suffix locally.
+
+The check is **fail-open**: if the range endpoint is unreachable, times out, or errors, the password change is allowed rather than blocked - it only ever adds a rejection, never a lock-out. The 8-character length minimum is enforced first and short-circuits the lookup.
+
+#### Self-hosted / offline mirror
+
+For air-gapped or egress-restricted deployments, point `PWNED_PASSWORD_API_URL` at a local mirror that speaks the same `GET /range/{prefix}` contract. [IncogniPwn](https://github.com/millaguie/incognipwn) serves the full Pwned Passwords corpus (~80 GB) from a downloader + API pair. Add it to your `docker-compose.yml`:
+
+```yaml
+services:
+  hibp-downloader:
+    # One-shot: downloads the Pwned Passwords corpus into the shared volume.
+    # Re-run periodically to refresh. Expect ~80 GB and a long first run.
+    image: ghcr.io/millaguie/incognipwn-downloader:latest
+    volumes:
+      - hibp-data:/data
+    restart: "no"
+
+  hibp-api:
+    # Serves GET /range/{prefix} on port 8000 from the downloaded corpus.
+    image: ghcr.io/millaguie/incognipwn-api:latest
+    volumes:
+      - hibp-data:/data
+    expose:
+      - "8000"
+    restart: unless-stopped
+
+  app:
+    # ... your existing Model Hotel service ...
+    environment:
+      PWNED_PASSWORD_API_URL: http://hibp-api:8000
+    depends_on:
+      - hibp-api
+
+volumes:
+  hibp-data:
+```
+
+The mirror only needs to be reachable from the `app` container — do not expose it publicly. Because the check fails open, Model Hotel keeps accepting password changes even while the downloader is still populating the corpus.
 
 ### Reset to Defaults
 


### PR DESCRIPTION
## What

Screens new dashboard passwords against the [Have I Been Pwned](https://haveibeenpwned.com/Passwords) Pwned Passwords range API. Applies to all three password-setting paths: user creation, admin reset, and self-service change.

- **k-anonymity**: only the first 5 hex chars of the SHA-1 hash are sent; the password never leaves the process. `Add-Padding: true` is set on the request.
- **On by default**, two off-switches:
  - `PWNED_PASSWORD_CHECK_ENABLED=false` env kill-switch (hard override; requires redeploy)
  - `pwned_password_check_enabled` runtime settings toggle (no redeploy; overridden by the env var when that is false)
- **Fails open**: an unreachable/erroring endpoint never blocks a password change — it only ever adds a rejection, never a lock-out.
- **Self-hostable**: `PWNED_PASSWORD_API_URL` points the check at a mirror speaking the same `GET /range/{prefix}` contract. Docs include an [IncogniPwn](https://github.com/millaguie/incognipwn) docker-compose example for air-gapped / egress-restricted deployments.

## Security hardening (`canTouchKey`)

The virtual-key authorization predicate no longer treats an absent identity as admin. The old `id == nil || id.IsAdmin()` allowed a nil identity through; the auth middleware always injects an identity (`AdminIdentity()` for the admin token), so this was unreachable in production, but the predicate now fails closed by construction rather than relying on every caller to pre-check.

## Tests

- `internal/pwned`: unit tests for the range client (prefix-only path, `Add-Padding` header, case-insensitive suffix match, padding decoys ignored, non-200 and transport errors surface).
- `passwordpolicy_test.go`: `validateNewPassword` unit matrix (length short-circuit, breach reject, clean allow, fail-open, env kill-switch, DB toggle, unwired checker).
- `virtualkeys_authz_test.go`: `canTouchKey` table incl. nil-fails-closed.
- `handler_settings_test.go`: `pwned_password_check_enabled` save/retrieve round-trip (AGENTS.md: one per allowlist key).
- `users_test.go`: **integration test** exercising the full create-user request path — breached password → 400, then flip the runtime toggle off via the settings API → same password → 201.

Full backend suite green (`internal/api`: 1797 passed), `golangci-lint run ./...` clean.

## Follow-ups (not in this PR)

- Frontend PR: i18n the breach rejection string across 11 locales + a Security-settings toggle UI writing `pwned_password_check_enabled`. The error string is English-only here (matches the existing `errPasswordTooShort` pattern).
- Optional: a SHA-1 prefix cache in `internal/pwned` (only matters for scripted bulk user creation against the public endpoint; the self-hosted mirror already mitigates it).