### PR TITLE
ci: sync Docker Hub README on DOCKERHUB.md change, not on release

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -158,33 +158,7 @@ jobs:
             --latest \
             --title "${{ steps.version.outputs.tag }}"
 
-      # Sync the Docker Hub repository README from the tracked, Hub-tailored
-      # copy (absolute URLs only — the GitHub README's relative links break on
-      # Docker Hub, so the two are deliberately separate documents; it lives
-      # at the repo root next to README.md so doc updates don't miss it). The
-      # file is uploaded verbatim; nothing is rewritten. Requires the
-      # DOCKERHUB_TOKEN PAT to have read/write/delete scope. Non-blocking: a
-      # failed README sync must never fail a release.
-      - name: Sync Docker Hub README
-        if: steps.version.outputs.skip_existing == 'false'
-        continue-on-error: true
-        uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5.0.0
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-          repository: ${{ env.DOCKERHUB_IMAGE }}
-          readme-filepath: ./DOCKERHUB.md
-
-      # Sync the Front Desk repo's Hub README from DOCKERHUB-frontdesk.md. Not
-      # gated on skip_existing: the Front Desk page is near-static and the sync
-      # is cheap, so we refresh it on every workflow run (including when the
-      # version tag already exists) to keep it current without needing a release.
-      # Non-blocking, same as the main README sync.
-      - name: Sync Docker Hub README (Front Desk)
-        continue-on-error: true
-        uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5.0.0
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-          repository: ${{ env.DOCKERHUB_FRONTDESK_IMAGE }}
-          readme-filepath: ./DOCKERHUB-frontdesk.md
+      # Docker Hub repository descriptions (DOCKERHUB.md / DOCKERHUB-frontdesk.md)
+      # are NOT synced here — they are decoupled from image builds and pushed by
+      # sync-dockerhub-readme.yml whenever the Hub copy changes on master. A
+      # README edit does not need a release to show up on Docker Hub.

--- a/.github/workflows/dockerhub-readme-guard.yml
+++ b/.github/workflows/dockerhub-readme-guard.yml
@@ -1,7 +1,8 @@
 name: Docker Hub README guard
 
 # DOCKERHUB.md is a deliberately separate, Hub-tailored copy of the README
-# (absolute URLs only) that docker-publish.yml uploads verbatim on release.
+# (absolute URLs only) that sync-dockerhub-readme.yml uploads verbatim whenever
+# it changes on master.
 # Nothing keeps it honest except a human remembering it exists - this check
 # fails any PR that touches README.md without touching DOCKERHUB.md, so the
 # decision ("update it" or "doesn't apply") happens while the diff is fresh.
@@ -43,7 +44,7 @@ jobs:
             echo "DOCKERHUB.md updated alongside README.md - OK."
             exit 0
           fi
-          echo "::error file=README.md::README.md changed but DOCKERHUB.md did not. Update DOCKERHUB.md (the Docker Hub copy, uploaded on release) or add the 'dockerhub-readme-not-needed' label if the change doesn't apply to Docker Hub."
+          echo "::error file=README.md::README.md changed but DOCKERHUB.md did not. Update DOCKERHUB.md (the Docker Hub copy, synced to Docker Hub when it changes on master) or add the 'dockerhub-readme-not-needed' label if the change doesn't apply to Docker Hub."
           exit 1
 
   length:
@@ -57,9 +58,9 @@ jobs:
           # Docker Hub truncates a repository's full description at 25,000
           # characters; a longer file is sliced mid-content (often mid-link),
           # silently breaking the rendered page. We never see it locally because
-          # docker-publish.yml uploads the file verbatim only on release. Guard
+          # sync-dockerhub-readme.yml uploads the file verbatim to Docker Hub. Guard
           # on both character count (Docker Hub's unit) and byte count, so neither
-          # interpretation can sneak a truncated readme into a release.
+          # interpretation can sneak a truncated readme onto Docker Hub.
           LIMIT=25000
           chars=$(python3 -c "import io; print(len(io.open('DOCKERHUB.md', encoding='utf-8').read()))")
           bytes=$(wc -c < DOCKERHUB.md)

--- a/.github/workflows/sync-dockerhub-readme.yml
+++ b/.github/workflows/sync-dockerhub-readme.yml
@@ -1,0 +1,48 @@
+# Push the Docker Hub repository descriptions from their tracked, Hub-tailored
+# copies whenever those copies change on master (or on demand). This is
+# deliberately decoupled from image builds: a README edit reaches Docker Hub as
+# soon as it lands on master, without waiting for a version release. DOCKERHUB.md
+# and DOCKERHUB-frontdesk.md use absolute URLs only (the GitHub READMEs' relative
+# links break on Docker Hub, so they are separate documents kept at the repo root
+# next to README.md). Each file is uploaded verbatim; nothing is rewritten.
+name: Sync Docker Hub README
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - DOCKERHUB.md
+      - DOCKERHUB-frontdesk.md
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  DOCKERHUB_IMAGE: ${{ secrets.DOCKERHUB_USERNAME }}/model-hotel
+  DOCKERHUB_FRONTDESK_IMAGE: ${{ secrets.DOCKERHUB_USERNAME }}/model-hotel-frontdesk
+
+jobs:
+  sync:
+    name: Push Hub descriptions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      # Requires the DOCKERHUB_TOKEN PAT to have read/write scope. Failures are
+      # visible (not swallowed) so a silently stale Hub page can't recur.
+      - name: Sync Docker Hub README (server)
+        uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5.0.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: ${{ env.DOCKERHUB_IMAGE }}
+          readme-filepath: ./DOCKERHUB.md
+
+      - name: Sync Docker Hub README (Front Desk)
+        uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5.0.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: ${{ env.DOCKERHUB_FRONTDESK_IMAGE }}
+          readme-filepath: ./DOCKERHUB-frontdesk.md

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -17,8 +17,9 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 
 # README/DOCKERHUB.md sync guard - mirrors .github/workflows/dockerhub-readme-guard.yml
 # so the "you touched README.md, touch DOCKERHUB.md too" decision happens here
-# instead of after a wasted CI cycle. DOCKERHUB.md is the Hub-tailored copy uploaded
-# on release. Diff this branch against its merge-base with the default branch (same
+# instead of after a wasted CI cycle. DOCKERHUB.md is the Hub-tailored copy synced
+# to Docker Hub whenever it changes on master (sync-dockerhub-readme.yml). Diff this
+# branch against its merge-base with the default branch (same
 # base..head model the CI uses). Set DOCKERHUB_README_NOT_NEEDED=1 to acknowledge a
 # README change that genuinely doesn't apply to Docker Hub (local stand-in for the
 # 'dockerhub-readme-not-needed' PR label).
@@ -46,7 +47,7 @@ fi
 # DOCKERHUB.md length guard - mirrors the 'length' job in dockerhub-readme-guard.yml.
 # Docker Hub truncates a repository description at 25,000 characters (sliced
 # mid-content, often mid-link), and we never see it locally because the file is
-# uploaded verbatim only on release. Guard on chars (Docker Hub's unit) AND bytes
+# uploaded verbatim to Docker Hub. Guard on chars (Docker Hub's unit) AND bytes
 # here so an over-length edit fails before the push, not after a wasted CI cycle.
 DOCKERHUB_LIMIT=25000
 if [ -f "$REPO_ROOT/DOCKERHUB.md" ]; then
@@ -59,7 +60,7 @@ if [ -f "$REPO_ROOT/DOCKERHUB.md" ]; then
 	DH_BYTES="$(wc -c <"$REPO_ROOT/DOCKERHUB.md" | tr -d '[:space:]')"
 	if [ "$DH_CHARS" -gt "$DOCKERHUB_LIMIT" ] || [ "$DH_BYTES" -gt "$DOCKERHUB_LIMIT" ]; then
 		echo "pre-push: FAILED - DOCKERHUB.md is ${DH_CHARS} chars / ${DH_BYTES} bytes, over Docker Hub's ${DOCKERHUB_LIMIT}-char limit." >&2
-		echo "  Trim DOCKERHUB.md below ${DOCKERHUB_LIMIT} (it ships to Docker Hub on release and truncates mid-content)." >&2
+		echo "  Trim DOCKERHUB.md below ${DOCKERHUB_LIMIT} (it ships to Docker Hub verbatim and truncates mid-content)." >&2
 		exit 1
 	fi
 fi


### PR DESCRIPTION
## What

The Docker Hub repository description upload lived inside `docker-publish.yml` as a step gated on `skip_existing == 'false'`, so it only ran when a **new `.version` tag** was released. A `DOCKERHUB.md` edit merged to master without a version bump never reached Docker Hub, leaving the live page stale — it kept showing the old codecov badge long after that badge had been replaced in the repo.

## Change

- New `.github/workflows/sync-dockerhub-readme.yml`: pushes both Hub descriptions (`DOCKERHUB.md`, `DOCKERHUB-frontdesk.md`) on any push to `master` that touches them, plus `workflow_dispatch` for a manual refresh. Decoupled from image builds — a README edit reaches Docker Hub as soon as it lands on master.
- `docker-publish.yml`: removed the two `peter-evans/dockerhub-description` steps; the image workflow now only builds/pushes images and cuts the release.
- Sync failures are no longer swallowed with `continue-on-error`, so a broken sync is visible instead of silently stale.
- Updated the now-inaccurate "uploaded on release" comments in `dockerhub-readme-guard.yml` and `scripts/pre-push`.

This is the flow as intended: change README → guard reminds you to mirror into DOCKERHUB.md (or bypass via the env var / label if it doesn't apply) → merged DOCKERHUB.md change syncs to Docker Hub on master.

## Notes

- The currently-live stale page was already fixed out-of-band by pushing the current `DOCKERHUB.md` to the Hub API; this PR prevents recurrence.
- `actionlint` clean; `bash -n scripts/pre-push` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)