### PR TITLE
fix(ratelimit): close TPM admission TOCTOU race with atomic reservation

### DIFF
--- a/internal/ratelimit/tpm_limiter.go
+++ b/internal/ratelimit/tpm_limiter.go
@@ -28,10 +28,14 @@ const defaultTPM = 0
 // upstream provider is never throttled.
 //
 // Because a request's token cost is unknown until it completes, enforcement is
-// admit-on-past-consumption / debit-on-completion: admission checks the current
-// budget (Allow), and the actual token total is debited afterwards (Debit). A
-// key can therefore overshoot by ~one in-flight request's worth of tokens; this
-// is the standard, accepted behaviour for token rate limiting.
+// admit-on-past-consumption / debit-on-completion: admission reserves one
+// placeholder token (Allow / ReserveN, which also closes the concurrent
+// admission race), and the actual token total is debited afterwards (Debit) on
+// top of that reservation. Each admitted request thus costs its real total plus
+// one placeholder token; the reservation is not reconciled against the debit,
+// so it is a small restrictive surcharge, negligible at realistic budgets. A
+// key can still overshoot by up to its in-flight requests' worth of tokens
+// (bounded by the RPS burst), the standard behaviour for token rate limiting.
 //
 // Like Limiter, the budget lives in-process and is NOT consistent across
 // replicas behind a load balancer (effective limit is ~N× configured with N
@@ -113,9 +117,35 @@ func (l *TPMLimiter) Middleware(enabled bool) func(http.Handler) http.Handler {
 			userKey, userTPM := userTPMFromCtx(r.Context())
 			userTPM = fleetShareTPM(r.Context(), l.settings, userTPM)
 			l.setAssoc(keyHash, userKey)
+			// The owner token is reserved (not committed) here and only kept
+			// once every later gate passes. A request that clears this stage
+			// but is then rejected by the per-key gate cancels the reservation,
+			// so a rejected request never burns an owner token (Debit only runs
+			// for admitted requests). Without this a single over-cap key would
+			// drain the shared owner budget and 429 the owner's other keys.
+			//
+			// The reservation and its cancellation are pinned to a single `now`
+			// on purpose: an immediately actionable reservation (Delay 0) has
+			// timeToAct == now, and CancelAt only restores tokens when
+			// timeToAct is not before the cancel time. Using time.Now() again
+			// at cancel would make timeToAct earlier than it, turning Cancel
+			// into a no-op and defeating the whole point.
+			now := time.Now()
+			var userRes *rate.Reservation
 			if userKey != "" {
 				userEntry := l.getEntry(userKey, userTPM)
-				if userEntry.limiter.Tokens() < 1 {
+				// ReserveN takes one admission token under the limiter's mutex,
+				// so concurrent requests can't all pass the same non-mutating
+				// peek and blow the budget. Unlike Allow() the reservation is
+				// cancellable; !OK() || DelayFrom(now) > 0 is the exact
+				// equivalent of Allow() returning false (no token available
+				// right now). The reserved token is a placeholder that is not
+				// reconciled: Debit later charges the full total on top of it,
+				// a ~1-token restrictive surcharge, negligible at realistic
+				// budgets.
+				userRes = userEntry.limiter.ReserveN(now, 1)
+				if !userRes.OK() || userRes.DelayFrom(now) > 0 {
+					userRes.CancelAt(now)
 					w.Header().Set("Retry-After", strconv.Itoa(tpmRetryAfter(userEntry.limiter)))
 					util.WriteOpenAIError(w, "user token rate limit exceeded", http.StatusTooManyRequests)
 					return
@@ -129,7 +159,19 @@ func (l *TPMLimiter) Middleware(enabled bool) func(http.Handler) http.Handler {
 			}
 
 			entry := l.getEntry(keyHash, tpm)
-			if entry.limiter.Tokens() < 1 {
+			// Allow() atomically reserves one admission token under the
+			// limiter's mutex; concurrent requests cannot all pass the same
+			// non-mutating peek. The reserved token is a placeholder that is
+			// not reconciled: Debit later charges the full total on top of it,
+			// a ~1-token restrictive surcharge, negligible at realistic budgets.
+			if !entry.limiter.Allow() {
+				// This request cleared the owner stage but fails here, so return
+				// its held owner token. Leaving it committed would let sustained
+				// per-key rejections drain the shared owner budget even though
+				// none of those requests ever run (Debit is never called).
+				if userRes != nil {
+					userRes.CancelAt(now)
+				}
 				w.Header().Set("Retry-After", strconv.Itoa(tpmRetryAfter(entry.limiter)))
 				util.WriteOpenAIError(w, "token rate limit exceeded", http.StatusTooManyRequests)
 				return
@@ -140,13 +182,16 @@ func (l *TPMLimiter) Middleware(enabled bool) func(http.Handler) http.Handler {
 }
 
 // Allow reports whether a request may be admitted for keyHash under the given
-// per-minute token budget. tpm <= 0 means no cap (always allowed). Exposed for
-// testing and reuse; the Middleware performs the same check inline.
+// per-minute token budget, and atomically reserves one admission token when it
+// returns true. tpm <= 0 means no cap (always allowed, no reservation). The
+// reservation is what makes admission race-free: concurrent callers cannot all
+// pass the same non-mutating peek. Exposed for testing and reuse; the
+// Middleware performs the same reserving check inline.
 func (l *TPMLimiter) Allow(keyHash string, tpm int) bool {
 	if tpm <= 0 {
 		return true
 	}
-	return l.getEntry(keyHash, tpm).limiter.Tokens() >= 1
+	return l.getEntry(keyHash, tpm).limiter.Allow()
 }
 
 // Debit removes the actual token total from a key's budget after a request

--- a/internal/ratelimit/tpm_limiter.go
+++ b/internal/ratelimit/tpm_limiter.go
@@ -35,7 +35,8 @@ const defaultTPM = 0
 // one placeholder token; the reservation is not reconciled against the debit,
 // so it is a small restrictive surcharge, negligible at realistic budgets. A
 // key can still overshoot by up to its in-flight requests' worth of tokens
-// (bounded by the RPS burst), the standard behaviour for token rate limiting.
+// (bounded in practice by the separate RPS limiter's burst), the standard
+// behaviour for token rate limiting.
 //
 // Like Limiter, the budget lives in-process and is NOT consistent across
 // replicas behind a load balancer (effective limit is ~N× configured with N

--- a/internal/ratelimit/tpm_limiter_test.go
+++ b/internal/ratelimit/tpm_limiter_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -389,6 +391,48 @@ func TestTPMMiddleware_UserAggregateBudget(t *testing.T) {
 	}
 }
 
+// TestTPMMiddleware_RejectedPerKeyDoesNotDrainOwnerBucket guards against an
+// owner-budget leak. When a request clears the user-aggregate stage but is
+// then rejected by the per-key gate, the owner token it reserved must be
+// returned. Otherwise sustained rejections on one over-cap key would drain
+// the shared owner budget and 429 the owner's other keys, even though those
+// rejected requests never run and so never call Debit.
+func TestTPMMiddleware_RejectedPerKeyDoesNotDrainOwnerBucket(t *testing.T) {
+	l, s := newTestTPMLimiter(t)
+	// Global default of 1 makes the per-key cap 1, so the per-key gate is the
+	// bottleneck. The owner budget (userTPM) is larger.
+	s.set(settingsKeyTPM, "1")
+	userTPM := 5
+	h := l.Middleware(true)(okHandler())
+
+	// First request on key-a consumes its sole per-key token and one owner
+	// token, and passes.
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, ownedTPMReq("key-a", "uid-1", userTPM))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("first request should pass, got %d", rec.Code)
+	}
+
+	// Hammer key-a past its per-key budget. Each request clears the owner
+	// stage then fails the per-key gate. If the owner token were committed on
+	// rejection, this loop would exhaust the shared owner budget.
+	for i := 0; i < userTPM+3; i++ {
+		rec = httptest.NewRecorder()
+		h.ServeHTTP(rec, ownedTPMReq("key-a", "uid-1", userTPM))
+		if rec.Code != http.StatusTooManyRequests {
+			t.Fatalf("over-cap key-a request %d should be 429, got %d", i, rec.Code)
+		}
+	}
+
+	// Sibling key-b (same owner, its own per-key bucket) must still pass:
+	// key-a's rejections must not have drained the shared owner budget.
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, ownedTPMReq("key-b", "uid-1", userTPM))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("sibling key-b should still pass (owner budget intact), got %d", rec.Code)
+	}
+}
+
 // TestTPMLimiter_DebitDebitsOwnerBucket verifies the dual debit: the key's own
 // bucket (when capped) and the owner's aggregate bucket both drop.
 func TestTPMLimiter_DebitDebitsOwnerBucket(t *testing.T) {
@@ -469,6 +513,55 @@ func TestEffectiveTPM_FleetDivisor(t *testing.T) {
 
 	if got := l.effectiveTPM(context.Background()); got != 200 {
 		t.Errorf("effectiveTPM = %d, want 200", got)
+	}
+}
+
+// TestTPMMiddleware_ConcurrentAdmissionReservesTokens guards the admission
+// TOCTOU race: admission must atomically reserve a token, not merely peek at the
+// available count. Under the old non-mutating Tokens() peek, many concurrent
+// requests all observed tokens available before any of them reserved one, so far
+// more than the per-minute burst passed and the budget was blown. okHandler
+// returns immediately and never calls Debit, so nothing but the 1-token
+// admission reservation can throttle: with a burst of tpm, at most tpm requests
+// (plus a negligible sub-millisecond refill) may be admitted no matter how many
+// fire at once.
+func TestTPMMiddleware_ConcurrentAdmissionReservesTokens(t *testing.T) {
+	l, _ := newTestTPMLimiter(t)
+	tpm := 50 // burst == tpm == 50
+	h := l.Middleware(true)(okHandler())
+
+	const N = 200
+	var admitted, rejected int64
+	var wg sync.WaitGroup
+	wg.Add(N)
+	for range N {
+		go func() {
+			defer wg.Done()
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, tpmReq("k", &tpm))
+			switch rec.Code {
+			case http.StatusOK:
+				atomic.AddInt64(&admitted, 1)
+			case http.StatusTooManyRequests:
+				atomic.AddInt64(&rejected, 1)
+			default:
+				t.Errorf("unexpected status %d", rec.Code)
+			}
+		}()
+	}
+	wg.Wait()
+
+	// The sub-millisecond run refills ~0 tokens, so admissions must stay within
+	// the burst. The +2 slack absorbs any tiny refill without letting the old
+	// peek-based regression (which would admit ~all N) slip through.
+	if admitted > int64(tpm+2) {
+		t.Fatalf("admitted %d of %d concurrent requests, want <= %d: admission did not reserve tokens atomically", admitted, N, tpm+2)
+	}
+	if admitted < 1 {
+		t.Fatalf("admitted %d requests, want at least 1", admitted)
+	}
+	if admitted+rejected != N {
+		t.Fatalf("accounting mismatch: admitted=%d rejected=%d, want sum %d", admitted, rejected, N)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes a confirmed TOCTOU race in the per-key **tokens-per-minute (TPM) rate limiter** found in a white-box security assessment. Admission gated on `rate.Limiter.Tokens()`, a non-mutating peek: concurrent requests all observed a positive budget and passed without reserving, so a valid virtual key could overshoot its configured TPM cap by up to an RPS burst of in-flight requests. The RPS limiter was unaffected (it already uses `Reserve()`).

## Changes

- **Atomic admission.** Replace the three `Tokens()` peeks (user-aggregate stage, per-key stage, exported `Allow`) with `rate.Limiter.Allow()` / `ReserveN()`, which check-and-reserve one token under the limiter's mutex, closing the race.
- **No owner-bucket leak.** The user-aggregate stage takes a *cancellable* `ReserveN(now, 1)` instead of committing unconditionally. A request that clears the owner gate but is rejected by the per-key gate cancels the reservation via `CancelAt(now)`, so per-key rejections no longer drain the shared owner budget and 429 the owner's other keys. Reserve and cancel are pinned to a single `now`: a plain `Cancel()` (fresh clock) is a no-op on a Delay-0 reservation because `CancelAt` bails once `timeToAct` is before the cancel time.

## Accepted behaviour

Each admitted request now carries a **one-token placeholder surcharge** on top of `Debit`'s real total. It errs *restrictive* (never permits bypass) and is negligible at realistic budgets; documented in the code comments.

## Tests

- `TestTPMMiddleware_ConcurrentAdmissionReservesTokens` — 200 concurrent requests admit at most the burst (fails against the old peek).
- `TestTPMMiddleware_RejectedPerKeyDoesNotDrainOwnerBucket` — a sibling key stays admissible after another key's per-key rejections.

Package suite green (127 tests), race-clean at `-count=5`, `golangci-lint` clean.

## Review

Implemented and independently reviewed across models (Opus + Sonnet). Verdict APPROVE-WITH-NITS; the one comment nit (scoping the overshoot bound to the separate RPS limiter) is addressed in the second commit. No correctness or security defects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)