### PR TITLE
Security hardening: RULE blocklist, auth-invariant comments, GitHub SSO netguard

### DIFF
--- a/internal/adminauth/github.go
+++ b/internal/adminauth/github.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/auth"
 	"github.com/hugalafutro/model-hotel/internal/authcookie"
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
+	"github.com/hugalafutro/model-hotel/internal/netguard"
 	"github.com/hugalafutro/model-hotel/internal/totp"
 	"github.com/hugalafutro/model-hotel/internal/webauthn"
 )
@@ -38,6 +39,11 @@ const (
 // githubCallbackPath is the fixed redirect-URI path. The operator registers
 // <github_public_base_url><githubCallbackPath> as the OAuth App callback URL.
 const githubCallbackPath = "/api/auth/github/callback"
+
+// githubHTTPTimeout bounds each outbound GitHub request (token exchange, /user,
+// /user/emails). Mirrors oidcHTTPTimeout; the netguard client's own dialer also
+// enforces this as its dial/keepalive timeout.
+const githubHTTPTimeout = 15 * time.Second
 
 // githubAPIBaseURL is GitHub's REST API root. It is a package constant (GitHub
 // has no discovery document); the value is copied into each githubRuntime so
@@ -86,6 +92,13 @@ type GitHubHandler struct {
 	// the OIDC/TOTP login defense (5 failures, 1s doubling, capped at 5m).
 	loginThrottle *totp.Throttle
 
+	// httpClient is an SSRF-guarded client used for every outbound GitHub request
+	// (token exchange, /user, /user/emails). Without it oauth2 falls back to
+	// http.DefaultClient; routing through netguard blocks metadata/link-local
+	// targets and keeps parity with the OIDC handler. github.com is public, so
+	// normal login is unaffected (netguard permits only what it must).
+	httpClient *http.Client
+
 	// cached holds the lazily-built oauth2 config for one config fingerprint,
 	// rebuilt only when the fingerprint changes. Mirrors OIDCHandler; there is no
 	// network discovery to amortize here, but the cache keeps the allowlist parse
@@ -115,6 +128,7 @@ func NewGitHubHandler(
 		masterKey:     masterKey,
 		cookieSecure:  cookieSecure,
 		loginThrottle: totp.NewThrottle(5, time.Second, 5*time.Minute),
+		httpClient:    netguard.NewClient(githubHTTPTimeout),
 	}
 }
 
@@ -309,6 +323,11 @@ func (h *GitHubHandler) Callback(w http.ResponseWriter, r *http.Request) {
 		h.fail(w, r, throttleKey, "missing code", nil)
 		return
 	}
+
+	// Route the token exchange AND the derived API client (fetchUser /
+	// fetchVerifiedEmails, built by oauth2Config.Client below) through the
+	// SSRF-guarded transport. oauth2 reads the base client from this context key.
+	ctx = context.WithValue(ctx, oauth2.HTTPClient, h.httpClient)
 
 	// Exchange the code for an access token (no PKCE verifier: GitHub OAuth Apps
 	// don't support it; the confidential client secret authenticates this call).

--- a/internal/adminauth/github_test.go
+++ b/internal/adminauth/github_test.go
@@ -599,3 +599,12 @@ func TestGitHubCallbackDisabledClearsCookie(t *testing.T) {
 		t.Fatal("disabled-runtime callback must still clear the login-state cookie")
 	}
 }
+
+func TestNewGitHubHandler_UsesNetguardClient(t *testing.T) {
+	store := newMemStore()
+	sessionMgr := webauthn.NewSessionManager(store)
+	h := NewGitHubHandler(newFakeSettings(map[string]string{}), sessionMgr, mockIPLimiter{}, testMasterKey, "auto")
+	if h.httpClient == nil {
+		t.Fatal("GitHubHandler.httpClient must be an SSRF-guarded netguard client, got nil")
+	}
+}

--- a/internal/adminauth/github_test.go
+++ b/internal/adminauth/github_test.go
@@ -607,4 +607,72 @@ func TestNewGitHubHandler_UsesNetguardClient(t *testing.T) {
 	if h.httpClient == nil {
 		t.Fatal("GitHubHandler.httpClient must be an SSRF-guarded netguard client, got nil")
 	}
+	// Prove it is genuinely the netguard-guarded client, not merely non-nil: a
+	// plain http.Client would dial the link-local cloud-metadata address; the
+	// netguard client refuses it at the dial Control hook (169.254.0.0/16).
+	req, err := http.NewRequest(http.MethodGet, "http://169.254.169.254/latest/meta-data/", http.NoBody)
+	if err != nil {
+		t.Fatalf("build metadata request: %v", err)
+	}
+	resp, err := h.httpClient.Do(req)
+	if err == nil {
+		_ = resp.Body.Close()
+		t.Fatal("httpClient reached the link-local metadata address; expected a netguard dial block")
+	}
+}
+
+// recordingTransport records the request paths that pass through it, then
+// delegates to inner. It proves Callback routes its OAuth traffic through
+// GitHubHandler.httpClient rather than http.DefaultClient: if the ctx injection
+// in Callback is dropped, oauth2 uses http.DefaultClient, this transport is
+// never exercised, and the routing assertion fails.
+type recordingTransport struct {
+	inner http.RoundTripper
+	mu    sync.Mutex
+	paths []string
+}
+
+func (rt *recordingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt.mu.Lock()
+	rt.paths = append(rt.paths, req.URL.Path)
+	rt.mu.Unlock()
+	return rt.inner.RoundTrip(req)
+}
+
+func (rt *recordingTransport) saw(path string) bool {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	for _, p := range rt.paths {
+		if p == path {
+			return true
+		}
+	}
+	return false
+}
+
+func (rt *recordingTransport) recorded() []string {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	return append([]string(nil), rt.paths...)
+}
+
+// TestGitHubCallback_RoutesOAuthThroughHandlerClient guards the SSRF routing:
+// the token exchange and the GitHub identity calls must travel through
+// h.httpClient (the netguard-guarded client), not http.DefaultClient. Removing
+// the oauth2.HTTPClient ctx injection in Callback makes this fail.
+func TestGitHubCallback_RoutesOAuthThroughHandlerClient(t *testing.T) {
+	m := newGitHubMock(t)
+	h, _, sessionMgr := newGitHubTestHandler(t, m, "admin@example.com")
+
+	rec := &recordingTransport{inner: http.DefaultTransport}
+	h.httpClient = &http.Client{Transport: rec}
+
+	successToken(t, h, sessionMgr)
+
+	if !rec.saw("/login/oauth/access_token") {
+		t.Fatalf("token exchange did not route through h.httpClient; recorded paths: %v", rec.recorded())
+	}
+	if !rec.saw("/user") || !rec.saw("/user/emails") {
+		t.Fatalf("identity calls did not route through h.httpClient; recorded paths: %v", rec.recorded())
+	}
 }

--- a/internal/adminauth/github_test.go
+++ b/internal/adminauth/github_test.go
@@ -619,6 +619,13 @@ func TestNewGitHubHandler_UsesNetguardClient(t *testing.T) {
 		_ = resp.Body.Close()
 		t.Fatal("httpClient reached the link-local metadata address; expected a netguard dial block")
 	}
+	// Assert the SPECIFIC netguard block, not merely any error: a timeout, a
+	// refused connection, or a proxy failure would otherwise let this pass even
+	// after the dial guard is removed. netguard's dialControl returns
+	// "netguard: refusing to connect to blocked address <host>".
+	if !strings.Contains(err.Error(), "netguard: refusing to connect to blocked address") {
+		t.Fatalf("expected a netguard blocked-address dial error, got: %v", err)
+	}
 }
 
 // recordingTransport records the request paths that pass through it, then

--- a/internal/api/backup_migrations_test.go
+++ b/internal/api/backup_migrations_test.go
@@ -434,7 +434,7 @@ func TestCheckDangerousObjects_AllTypes(t *testing.T) {
 		"FUNCTION", "AGGREGATE", "TRIGGER", "EXTENSION", "PROCEDURE",
 		"OPERATOR", "CAST", "COLLATION", "CONVERSION", "DOMAIN",
 		"EVENT TRIGGER", "FOREIGN DATA", "FOREIGN TABLE", "MATERIALIZED VIEW",
-		"SERVER", "TYPE",
+		"SERVER", "TYPE", "RULE",
 	}
 
 	for _, objType := range dangerousTypes {

--- a/internal/api/backup_restore.go
+++ b/internal/api/backup_restore.go
@@ -50,6 +50,7 @@ var dangerousObjectTypes = map[string]bool{
 	"FOREIGN DATA":      true,
 	"FOREIGN TABLE":     true,
 	"MATERIALIZED VIEW": true,
+	"RULE":              true,
 	"SERVER":            true,
 	"TYPE":              true,
 }

--- a/internal/api/managedwrite.go
+++ b/internal/api/managedwrite.go
@@ -76,6 +76,13 @@ func managedBlocksSyncableSettings(ctx context.Context, fs fleetSettings, keys [
 // (providers, virtual keys, custom failover group CRUD, user accounts): every
 // request that reaches it is treated as such a write, so it does no method or
 // path inspection.
+//
+// SECURITY INVARIANT: this is a fleet-ROLE policy gate layered on TOP of the
+// upstream auth middleware (requireGrant/requireAdmin), NOT the authorization
+// control itself. It answers "may this instance accept synced-entity writes at
+// all", not "is this caller authenticated/authorized". Removing or reordering it
+// does not reopen authz (that stays with the upstream middleware) — but it does
+// reopen fleet split-brain writes on a managed member, so keep it mounted.
 func managedWriteGuard(fs fleetSettings) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/virtualkeys.go
+++ b/internal/api/virtualkeys.go
@@ -132,11 +132,16 @@ func (h *Handler) ownerUsername(ctx context.Context, ownerID *uuid.UUID) *string
 	return &u.Username
 }
 
-// resolveWriteOwner decides the owner a create/update writes. Non-admins
-// always write their own id: they can neither assign keys to others nor
-// orphan their own. Admins get what they asked for (requested, which may be
-// nil to unassign); a caller without a users row (the env-token admin)
-// behaves like any admin.
+// resolveWriteOwner decides the owner a create/update writes. Non-admins always
+// write their own id: the request-body owner_user_id (the `requested` argument)
+// is deliberately IGNORED for them, so a non-admin can neither assign a key to
+// another owner nor orphan their own. Admins get what they asked for (requested,
+// which may be nil to unassign); a caller without a users row (the env-token
+// admin) behaves like any admin.
+//
+// SECURITY INVARIANT: never honor `requested` for a non-admin caller — doing so
+// is a privilege-escalation / key-reassignment vector. Any refactor that starts
+// threading the body value through for non-admins is a bug.
 func resolveWriteOwner(id *user.Identity, requested *string) (*uuid.UUID, error) {
 	if id != nil && !id.IsAdmin() {
 		return id.UserID, nil


### PR DESCRIPTION
Defense-in-depth hardening from a Strix pentest triage. Each recommendation was verified against the actual code; only the genuinely useful, low-risk ones are here. No behavior change for valid inputs.

## Changes

- **`fix(backup)`** — add `RULE` to the backup restore TOC dangerous-object blocklist (`dangerousObjectTypes`). `CREATE RULE` rewrites queries, so it belongs alongside `TRIGGER`/`FUNCTION`. Test extended to cover it.
- **`docs(api)`** — pin two security invariants in comments so a future refactor can't silently break them: `resolveWriteOwner` (the request-body `owner_user_id` is discarded for non-admins) and `managedWriteGuard` (a fleet-role policy gate layered on top of the upstream auth middleware, not the authz control itself). Comments only.
- **`fix(github-sso)`** — route GitHub SSO's OAuth token exchange and GitHub REST calls through the SSRF-guarded `netguard` client, mirroring the OIDC handler (`context.WithValue(ctx, oauth2.HTTPClient, ...)` before the exchange, so both `Exchange` and the derived `Client` are guarded). netguard permits loopback/private and blocks metadata/link-local, so normal login and internal deployments are unaffected.
- **`test(github-sso)`** — regression guard for the routing above: a recording-transport test asserts the token exchange and identity calls actually travel through the guarded client (removing the ctx injection makes it fail), plus the field test now proves the client refuses the cloud-metadata address at dial time rather than only asserting non-nil.

## Rejected recommendations (verified, deliberately not done)

- **pwned-checker through netguard** — would break self-hosted HIBP mirrors on private networks; the URL is operator-configured, no SSRF surface.
- **SRI on `web/index.html`** — false positive; the flagged line is a `dns-prefetch` hint, not a CDN resource load.
- **Docker non-root** — already implemented; both images drop privileges via `su-exec` in the entrypoint (Trivy DS-0002 only sees the missing static `USER` directive).
- **canDecryptSample across all providers** and **parameterizing the stats.go UUID fragment** — marginal; existing code is a MASTER_KEY canary with transactional import, and the UUID fragment is already fail-closed + `uuid.Parse`-validated with a documented tradeoff.

## Verification

- `go build ./...` clean; `go vet ./internal/adminauth/...` clean; `golangci-lint` clean on touched packages.
- `internal/adminauth` suite green; new `RULE` blocklist test fails-then-passes; the routing regression test was proven to fail when the ctx injection is removed and pass after restore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
