### PR TITLE
feat(bellhop): per-provider quota badges on the dashboard and widget

### DIFF
--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
@@ -45,6 +45,7 @@ import com.hugalafutro.bellhop.data.LockTimeout
 import com.hugalafutro.bellhop.data.MonitorStore
 import com.hugalafutro.bellhop.data.PrefsStore
 import com.hugalafutro.bellhop.data.QuotaBadgeConfigStore
+import com.hugalafutro.bellhop.data.QuotaBarMode
 import com.hugalafutro.bellhop.data.WidgetStore
 import com.hugalafutro.bellhop.data.shouldLock
 import com.hugalafutro.bellhop.data.shouldLockOnEntry
@@ -222,6 +223,7 @@ fun BellhopApp() {
     val pushEndpoint by monitorStore.endpoint.collectAsStateWithLifecycle(initialValue = null)
     val holdToCopy by prefsStore.holdToCopy.collectAsStateWithLifecycle(initialValue = true)
     val widgetGraphs by prefsStore.widgetGraphs.collectAsStateWithLifecycle(initialValue = false)
+    val quotaBarMode by prefsStore.quotaBarMode.collectAsStateWithLifecycle(initialValue = QuotaBarMode.REMAINING)
     val graphRangeMinutes by
         prefsStore.graphRangeMinutes.collectAsStateWithLifecycle(
             initialValue = PrefsStore.DEFAULT_GRAPH_RANGE_MINUTES,
@@ -545,6 +547,7 @@ fun BellhopApp() {
                         onTogglePush = { togglePush(it) },
                         onToggleHoldToCopy = { scope.launch { prefsStore.setHoldToCopy(it) } },
                         graphRangeMinutes = graphRangeMinutes,
+                        quotaBarMode = quotaBarMode,
                         onSetGraphRange = { scope.launch { prefsStore.setGraphRangeMinutes(it) } },
                         widgetGraphs = widgetGraphs,
                         onToggleWidgetGraphs = {
@@ -602,6 +605,7 @@ private fun LinkedContent(
     onTogglePush: (Boolean) -> Unit,
     onToggleHoldToCopy: (Boolean) -> Unit,
     graphRangeMinutes: Int,
+    quotaBarMode: QuotaBarMode,
     onSetGraphRange: (Int) -> Unit,
     widgetGraphs: Boolean,
     onToggleWidgetGraphs: (Boolean) -> Unit,
@@ -833,6 +837,8 @@ private fun LinkedContent(
             onSetAutoSync = { enabled -> requireOperatorAuth { dashVm.setAutoSync(enabled) } },
             onDismissAutoSyncError = { dashVm.dismissAutoSyncError() },
             onVisibleMembers = dashVm::setVisibleMembers,
+            quotaBarMode = quotaBarMode,
+            onRefreshQuota = { dashVm.refreshQuota() },
             holdToCopy = holdToCopy,
             lockEnabled = lockConfig.enabled,
             onLock = onLock,

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
@@ -63,6 +63,7 @@ import com.hugalafutro.bellhop.ui.member.MemberDetailScreen
 import com.hugalafutro.bellhop.ui.member.MemberDetailViewModel
 import com.hugalafutro.bellhop.ui.pairing.PairingScreen
 import com.hugalafutro.bellhop.ui.pairing.PairingViewModel
+import com.hugalafutro.bellhop.ui.settings.QuotaBadgesConfigScreen
 import com.hugalafutro.bellhop.ui.settings.SettingsScreen
 import com.hugalafutro.bellhop.ui.theme.BellhopTheme
 import com.hugalafutro.bellhop.widget.ACTION_OPEN_QUOTA
@@ -741,6 +742,10 @@ private fun LinkedContent(
     var showSettings by rememberSaveable(state.fdUrl, state.deviceId) {
         mutableStateOf(false)
     }
+    // Whether the quota-badge configurator is open (reached from Settings).
+    var showQuotaConfig by rememberSaveable(state.fdUrl, state.deviceId) {
+        mutableStateOf(false)
+    }
     val selected = ui.members.find { it.id == selectedMemberId }
     // The member left the fleet while its detail was open: drop the
     // selection (once the list has actually loaded) so the detail
@@ -755,8 +760,8 @@ private fun LinkedContent(
     // (member detail, events, alerts, settings) is on top: those charts aren't
     // visible, so fetching them just wakes the radio. The list stays warm via the
     // health poll and SSE, and the fan-out resumes the moment the dashboard shows.
-    LaunchedEffect(showEvents, showAlerts, showSettings, selectedMemberId) {
-        dashVm.setCovered(showEvents || showAlerts || showSettings || selectedMemberId != null)
+    LaunchedEffect(showEvents, showAlerts, showSettings, showQuotaConfig, selectedMemberId) {
+        dashVm.setCovered(showEvents || showAlerts || showSettings || showQuotaConfig || selectedMemberId != null)
     }
 
     if (showEvents) {
@@ -795,6 +800,15 @@ private fun LinkedContent(
             onToggleEvent = { type, enabled -> requireOperatorAuth { alertsVm.toggleEvent(type, enabled) } },
             onDismissActionError = { alertsVm.dismissActionError() },
         )
+    } else if (showQuotaConfig) {
+        BackHandler { showQuotaConfig = false }
+        val quotaConfigStore = remember(monitorContext) { QuotaBadgeConfigStore.create(monitorContext) }
+        val quotaPrefsStore = remember(monitorContext) { PrefsStore.create(monitorContext) }
+        QuotaBadgesConfigScreen(
+            configStore = quotaConfigStore,
+            prefsStore = quotaPrefsStore,
+            onBack = { showQuotaConfig = false },
+        )
     } else if (showSettings) {
         BackHandler { showSettings = false }
         // Collecting the hoisted alerts VM here subscribes it, so its selection is
@@ -820,6 +834,7 @@ private fun LinkedContent(
             onToggleMonitor = onToggleMonitor,
             onTogglePush = onTogglePush,
             onAlertsClick = { showAlerts = true },
+            onQuotaBadgesClick = { showQuotaConfig = true },
             onUnlink = onUnlink,
             unlinking = unlinking,
             unlinkFailed = unlinkFailed,

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
@@ -44,6 +44,7 @@ import com.hugalafutro.bellhop.data.LockStore
 import com.hugalafutro.bellhop.data.LockTimeout
 import com.hugalafutro.bellhop.data.MonitorStore
 import com.hugalafutro.bellhop.data.PrefsStore
+import com.hugalafutro.bellhop.data.QuotaBadgeConfigStore
 import com.hugalafutro.bellhop.data.WidgetStore
 import com.hugalafutro.bellhop.data.shouldLock
 import com.hugalafutro.bellhop.data.shouldLockOnEntry
@@ -659,6 +660,8 @@ private fun LinkedContent(
                     // the VM outlives recompositions, so a captured Boolean
                     // would freeze the toggle at creation time.
                     widgetGraphs = { PrefsStore.create(monitorContext).widgetGraphs.first() },
+                    configStore = QuotaBadgeConfigStore.create(monitorContext),
+                    barMode = { PrefsStore.create(monitorContext).quotaBarMode.first() },
                 ),
         )
     val ui by dashVm.state.collectAsStateWithLifecycle()

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
@@ -65,7 +65,9 @@ import com.hugalafutro.bellhop.ui.pairing.PairingScreen
 import com.hugalafutro.bellhop.ui.pairing.PairingViewModel
 import com.hugalafutro.bellhop.ui.settings.SettingsScreen
 import com.hugalafutro.bellhop.ui.theme.BellhopTheme
+import com.hugalafutro.bellhop.widget.ACTION_OPEN_QUOTA
 import com.hugalafutro.bellhop.widget.BellhopWidget
+import com.hugalafutro.bellhop.widget.EXTRA_BADGE_PROVIDER_NAME
 import com.hugalafutro.bellhop.work.FleetPollWorker
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -84,6 +86,12 @@ private const val OPERATOR_AUTH_WINDOW_MS = 60_000L
 // FragmentActivity (not plain ComponentActivity) because BiometricPrompt hosts
 // its sheet on a FragmentManager; Compose still drives the whole UI.
 class MainActivity : FragmentActivity() {
+    // A widget quota-badge tap launches here carrying the provider name; held as
+    // Compose state so onNewIntent (app already running) recomposes, and so the
+    // target rides the app-lock gate -- BellhopApp only forwards it to the linked
+    // UI once unlocked (see consumePendingQuotaTarget).
+    private var pendingQuotaBadge by mutableStateOf<String?>(null)
+
     // Apply the in-app language override before any resource resolves. A change
     // from the Settings picker persists the tag and recreates the activity, which
     // re-enters here in the new locale.
@@ -96,14 +104,38 @@ class MainActivity : FragmentActivity() {
         // Register the background-backstop notification channels up front so a
         // poll that fires while the app is dead has channels to post into.
         FleetNotifier.ensureChannels(this)
+        pendingQuotaBadge = quotaBadgeFromIntent(intent)
         enableEdgeToEdge()
         setContent {
             BellhopTheme {
-                BellhopApp()
+                BellhopApp(
+                    deepLinkBadge = pendingQuotaBadge,
+                    onDeepLinkConsumed = { pendingQuotaBadge = null },
+                )
             }
         }
     }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        quotaBadgeFromIntent(intent)?.let { pendingQuotaBadge = it }
+    }
 }
+
+// quotaBadgeFromIntent pulls the widget deep-link's provider-name extra, but
+// only from an OPEN_QUOTA action, so an ordinary launch never opens a sheet.
+private fun quotaBadgeFromIntent(intent: Intent?): String? =
+    if (intent?.action == ACTION_OPEN_QUOTA) intent.getStringExtra(EXTRA_BADGE_PROVIDER_NAME) else null
+
+// consumePendingQuotaTarget gates the widget deep-link on the app lock: the
+// target opens the detail sheet only once [unlocked], otherwise it stays
+// pending. Returns (targetToOpen, stillPending). Pure, so the gate is
+// unit-testable without the Compose/biometric stack.
+fun consumePendingQuotaTarget(
+    pending: String?,
+    unlocked: Boolean,
+): Pair<String?, String?> = if (pending != null && unlocked) pending to null else null to pending
 
 // appLockAuthenticators is the authenticator set the app lock prompts with. The
 // STRONG|DEVICE_CREDENTIAL combination isn't supported below API 30, so fall back
@@ -203,7 +235,10 @@ private fun FragmentActivity.promptAppUnlock(
  * linked, an enabled app lock covers the fleet UI until the user authenticates.
  */
 @Composable
-fun BellhopApp() {
+fun BellhopApp(
+    deepLinkBadge: String? = null,
+    onDeepLinkConsumed: () -> Unit = {},
+) {
     val context = LocalContext.current
     val activity = context as? FragmentActivity
     val linkStore = remember { LinkStore.create(context) }
@@ -548,6 +583,9 @@ fun BellhopApp() {
                         onToggleHoldToCopy = { scope.launch { prefsStore.setHoldToCopy(it) } },
                         graphRangeMinutes = graphRangeMinutes,
                         quotaBarMode = quotaBarMode,
+                        deepLinkBadge =
+                            consumePendingQuotaTarget(deepLinkBadge, unlocked = lockEvaluated && !locked).first,
+                        onDeepLinkConsumed = onDeepLinkConsumed,
                         onSetGraphRange = { scope.launch { prefsStore.setGraphRangeMinutes(it) } },
                         widgetGraphs = widgetGraphs,
                         onToggleWidgetGraphs = {
@@ -606,6 +644,8 @@ private fun LinkedContent(
     onToggleHoldToCopy: (Boolean) -> Unit,
     graphRangeMinutes: Int,
     quotaBarMode: QuotaBarMode,
+    deepLinkBadge: String? = null,
+    onDeepLinkConsumed: () -> Unit = {},
     onSetGraphRange: (Int) -> Unit,
     widgetGraphs: Boolean,
     onToggleWidgetGraphs: (Boolean) -> Unit,
@@ -839,6 +879,8 @@ private fun LinkedContent(
             onVisibleMembers = dashVm::setVisibleMembers,
             quotaBarMode = quotaBarMode,
             onRefreshQuota = { dashVm.refreshQuota() },
+            deepLinkBadge = deepLinkBadge,
+            onDeepLinkConsumed = onDeepLinkConsumed,
             holdToCopy = holdToCopy,
             lockEnabled = lockConfig.enabled,
             onLock = onLock,

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/FrontDeskClient.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/FrontDeskClient.kt
@@ -227,6 +227,22 @@ open class FrontDeskClient(
     ): FetchResult<AutoSyncConfig> = get(fdUrl, "/api/fleet/autosync", token)
 
     /**
+     * quota fetches Front Desk's cached quota/balance readings for every
+     * quota-capable provider via GET /api/quota. Monitor tier, like
+     * [members]. The wire envelope is `{"quota": [...]}`; callers get the
+     * unwrapped list, each entry decoded through [providerQuotaOf].
+     */
+    open suspend fun quota(
+        fdUrl: String,
+        token: String,
+    ): FetchResult<List<ProviderQuota>> =
+        when (val r = get<QuotaEnvelope>(fdUrl, "/api/quota", token)) {
+            is FetchResult.Success -> FetchResult.Success(r.data.quota.map(::providerQuotaOf))
+            FetchResult.Unauthorized -> FetchResult.Unauthorized
+            is FetchResult.Failure -> r
+        }
+
+    /**
      * alertStatus reports whether Front Desk's outbound notifier is reachable
      * and delivering. Monitor tier, like [members]; the Alerts screen renders it
      * as a delivery-health pill.
@@ -324,6 +340,18 @@ open class FrontDeskClient(
         enabled: Boolean,
         primaryId: String,
     ): ActionResult<AutoSyncConfig> = put(fdUrl, "/api/fleet/autosync", token, AutoSyncRequest(enabled, primaryId))
+
+    /**
+     * refreshQuota tells Front Desk to re-poll every quota-capable provider
+     * now, rather than waiting for its own background cadence, via POST
+     * /api/quota/refresh. Monitor tier, like [quota]: any paired device may
+     * trigger it, not just operators. The request body is empty (`{}`);
+     * Front Desk already knows which providers are quota-capable.
+     */
+    open suspend fun refreshQuota(
+        fdUrl: String,
+        token: String,
+    ): ActionResult<QuotaRefreshResult> = post(fdUrl, "/api/quota/refresh", token, emptyMap<String, String>())
 
     /**
      * streamEvents subscribes to GET {fdUrl}/api/sse and emits each frame as an

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/FrontDeskClient.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/FrontDeskClient.kt
@@ -231,13 +231,25 @@ open class FrontDeskClient(
      * quota-capable provider via GET /api/quota. Monitor tier, like
      * [members]. The wire envelope is `{"quota": [...]}`; callers get the
      * unwrapped list, each entry decoded through [providerQuotaOf].
+     *
+     * [QuotaType.UNKNOWN] entries are dropped here rather than passed on: a
+     * type this build has no payload shape for can never render a value, so
+     * showing it would mean a permanent "-" badge (and a config row for a
+     * badge that never says anything). This is what a Front Desk reporting a
+     * ninth provider type to an older Bellhop looks like, and what a fleet
+     * mid-upgrade looks like while the primary member's export still predates
+     * the `type` field. Known types whose fetch failed keep their badge and
+     * render "-", mirroring the web dashboard.
      */
     open suspend fun quota(
         fdUrl: String,
         token: String,
     ): FetchResult<List<ProviderQuota>> =
         when (val r = get<QuotaEnvelope>(fdUrl, "/api/quota", token)) {
-            is FetchResult.Success -> FetchResult.Success(r.data.quota.map(::providerQuotaOf))
+            is FetchResult.Success ->
+                FetchResult.Success(
+                    r.data.quota.map(::providerQuotaOf).filter { it.type != QuotaType.UNKNOWN },
+                )
             FetchResult.Unauthorized -> FetchResult.Unauthorized
             is FetchResult.Failure -> r
         }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/PrefsStore.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/PrefsStore.kt
@@ -6,6 +6,7 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -60,12 +61,31 @@ class PrefsStore(
         dataStore.edit { it[WIDGET_GRAPHS] = enabled }
     }
 
+    /**
+     * quotaBarMode emits which polarity ([QuotaBarMode.REMAINING] or
+     * [QuotaBarMode.USED]) quota badges show for METERED types; defaults to
+     * REMAINING, matching the web dashboard's default. A stored value this
+     * build doesn't recognize (e.g. from a future build's new mode) falls
+     * back to the default rather than throwing -- same stance as
+     * [WidgetMember.healthState] on an unknown persisted enum name.
+     */
+    val quotaBarMode: Flow<QuotaBarMode> =
+        dataStore.data.map {
+            val stored = it[QUOTA_BAR_MODE] ?: return@map QuotaBarMode.REMAINING
+            runCatching { QuotaBarMode.valueOf(stored) }.getOrDefault(QuotaBarMode.REMAINING)
+        }
+
+    suspend fun setQuotaBarMode(mode: QuotaBarMode) {
+        dataStore.edit { it[QUOTA_BAR_MODE] = mode.name }
+    }
+
     companion object {
         fun create(context: Context): PrefsStore = PrefsStore(context.applicationContext.prefsDataStore)
 
         private val HOLD_TO_COPY = booleanPreferencesKey("hold_to_copy")
         private val GRAPH_RANGE_MINUTES = intPreferencesKey("graph_range_minutes")
         private val WIDGET_GRAPHS = booleanPreferencesKey("widget_graphs")
+        private val QUOTA_BAR_MODE = stringPreferencesKey("quota_bar_mode")
 
         /** Default traffic-graph lookback: the last hour. */
         const val DEFAULT_GRAPH_RANGE_MINUTES = 60

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/QuotaBadgeConfigStore.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/QuotaBadgeConfigStore.kt
@@ -124,8 +124,15 @@ class QuotaBadgeConfigStore(
     ) {
         val key = keyFor(surface)
         dataStore.edit { prefs ->
-            val prev = prefs[key]?.let(::decode) ?: QuotaBadgeConfig()
-            prefs[key] = json.encodeToString(transform(prev))
+            val stored = prefs[key]?.let(::decode)
+            val next = transform(stored ?: QuotaBadgeConfig())
+            // reconcile runs on every successful quota fetch (foreground poll
+            // and background worker) and yields the same config whenever no new
+            // provider appeared, so leave the stored value alone rather than
+            // re-encoding it each time. A missing or undecodable value is still
+            // written, so a corrupt record heals on the next edit.
+            if (stored != null && next == stored) return@edit
+            prefs[key] = json.encodeToString(next)
         }
     }
 

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/QuotaBadgeConfigStore.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/QuotaBadgeConfigStore.kt
@@ -1,0 +1,148 @@
+package com.hugalafutro.bellhop.data
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+/** QuotaSurface identifies which UI surface a badge order/visibility config belongs to. */
+enum class QuotaSurface { MAIN, WIDGET }
+
+/**
+ * QuotaBadgeConfig is the persisted per-surface badge layout: [order] is the
+ * user's chosen provider ordering and [hidden] is the set of names toggled
+ * off. Both are keyed by provider **name** -- the export's own identity on
+ * the wire -- never by type or UUID (see global-constraints badge-identity
+ * note).
+ */
+@Serializable
+data class QuotaBadgeConfig(
+    val order: List<String> = emptyList(),
+    val hidden: Set<String> = emptySet(),
+)
+
+/**
+ * reconcileConfig folds a fresh [available] list of provider names into
+ * [prev]: names not yet in [QuotaBadgeConfig.order] are appended -- visible
+ * by default on [QuotaSurface.MAIN], hidden by default on
+ * [QuotaSurface.WIDGET] (the home-screen widget is opt-in per badge, MAIN is
+ * opt-out). Names already known but no longer in [available] are retained
+ * verbatim -- a vanished provider keeps its order slot and hidden state so
+ * it reappears in the same place if Front Desk starts reporting it again.
+ * Nothing is ever dropped from [QuotaBadgeConfig.order] or [hidden] here.
+ */
+fun reconcileConfig(
+    prev: QuotaBadgeConfig,
+    available: List<String>,
+    surface: QuotaSurface,
+): QuotaBadgeConfig {
+    val known = prev.order.toSet()
+    val newlySeen = available.filter { it !in known }
+    if (newlySeen.isEmpty()) return prev
+    val hidden =
+        when (surface) {
+            QuotaSurface.MAIN -> prev.hidden
+            QuotaSurface.WIDGET -> prev.hidden + newlySeen
+        }
+    return prev.copy(order = prev.order + newlySeen, hidden = hidden)
+}
+
+/**
+ * orderedVisible resolves [config] against the currently [available] quotas
+ * for rendering: hidden names and names not currently available are
+ * dropped, the remainder follows [QuotaBadgeConfig.order], and any available
+ * name not yet in the order (a provider [reconcileConfig] hasn't folded in
+ * yet) is appended in [available]'s arrival order rather than silently
+ * dropped.
+ */
+fun orderedVisible(
+    config: QuotaBadgeConfig,
+    available: List<ProviderQuota>,
+): List<ProviderQuota> {
+    val orderIndex = config.order.withIndex().associate { (i, name) -> name to i }
+    return available
+        .filter { it.providerName !in config.hidden }
+        .sortedBy { orderIndex[it.providerName] ?: Int.MAX_VALUE }
+}
+
+// Separate DataStore file from the fleet/lock/widget records: this is a
+// rendering preference with its own lifecycle, grown as new providers are
+// discovered and never cleared on unlink.
+private val Context.quotaBadgeDataStore: DataStore<Preferences> by
+    preferencesDataStore(name = "bellhop_quota_badges")
+
+/**
+ * QuotaBadgeConfigStore persists a [QuotaBadgeConfig] per [QuotaSurface],
+ * one preference key each so MAIN and WIDGET layouts evolve independently.
+ */
+class QuotaBadgeConfigStore(
+    private val dataStore: DataStore<Preferences>,
+    private val json: Json = Json { ignoreUnknownKeys = true },
+) {
+    /** config emits the persisted layout for [surface], defaulting to empty. */
+    fun config(surface: QuotaSurface): Flow<QuotaBadgeConfig> =
+        dataStore.data.map { prefs -> prefs[keyFor(surface)]?.let(::decode) ?: QuotaBadgeConfig() }
+
+    /** reconcile folds [available] provider names into [surface]'s stored config via [reconcileConfig]. */
+    suspend fun reconcile(
+        surface: QuotaSurface,
+        available: List<String>,
+    ) {
+        edit(surface) { prev -> reconcileConfig(prev, available, surface) }
+    }
+
+    /** setOrder overwrites [surface]'s badge ordering, leaving [QuotaBadgeConfig.hidden] untouched. */
+    suspend fun setOrder(
+        surface: QuotaSurface,
+        order: List<String>,
+    ) {
+        edit(surface) { prev -> prev.copy(order = order) }
+    }
+
+    /** setVisible toggles one provider name's hidden state for [surface]. */
+    suspend fun setVisible(
+        surface: QuotaSurface,
+        name: String,
+        visible: Boolean,
+    ) {
+        edit(surface) { prev ->
+            prev.copy(hidden = if (visible) prev.hidden - name else prev.hidden + name)
+        }
+    }
+
+    private suspend fun edit(
+        surface: QuotaSurface,
+        transform: (QuotaBadgeConfig) -> QuotaBadgeConfig,
+    ) {
+        val key = keyFor(surface)
+        dataStore.edit { prefs ->
+            val prev = prefs[key]?.let(::decode) ?: QuotaBadgeConfig()
+            prefs[key] = json.encodeToString(transform(prev))
+        }
+    }
+
+    private fun decode(stored: String): QuotaBadgeConfig? =
+        runCatching { json.decodeFromString<QuotaBadgeConfig>(stored) }.getOrNull()
+
+    private fun keyFor(surface: QuotaSurface): Preferences.Key<String> =
+        when (surface) {
+            QuotaSurface.MAIN -> MAIN_KEY
+            QuotaSurface.WIDGET -> WIDGET_KEY
+        }
+
+    companion object {
+        fun create(context: Context): QuotaBadgeConfigStore =
+            QuotaBadgeConfigStore(context.applicationContext.quotaBadgeDataStore)
+
+        private val MAIN_KEY = stringPreferencesKey("quota_badges_main")
+        private val WIDGET_KEY = stringPreferencesKey("quota_badges_widget")
+    }
+}

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/QuotaModels.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/QuotaModels.kt
@@ -419,33 +419,50 @@ private fun decodeQuotaPayload(
 // formatted with a fixed Locale so the widget reads the same on every device.
 
 /**
- * quotaBadgeLabel formats [pq] into the short text a badge shows. Unavailable
- * or payload-less quotas (see [ProviderQuota.available]) render as "-",
- * mirroring the web badge's fallback when its balance hook has no data yet.
+ * QuotaBarMode selects which polarity [quotaBadgeLabel] shows for METERED
+ * (percentage/fraction) quota types -- REMAINING or USED -- mirroring the web
+ * dashboard's `QuotaBarMode` (web/src/components/QuotaBadge.tsx), whose
+ * default is also "remaining". BALANCE/credit types (OpenRouter, DeepSeek,
+ * OllamaCloud, NeuralWatt) render the same figure regardless of [mode]: there
+ * is no "used" polarity for an account balance or plan name.
  */
-fun quotaBadgeLabel(pq: ProviderQuota): String {
+enum class QuotaBarMode { REMAINING, USED }
+
+/**
+ * quotaBadgeLabel formats [pq] into the short text a badge shows, in the
+ * polarity [mode] selects for METERED types. Unavailable or payload-less
+ * quotas (see [ProviderQuota.available]) render as "-", mirroring the web
+ * badge's fallback when its balance hook has no data yet.
+ */
+fun quotaBadgeLabel(
+    pq: ProviderQuota,
+    mode: QuotaBarMode,
+): String {
     val data = pq.data
     if (!pq.available || data == null) return "-"
     return when (data) {
-        is QuotaData.NanoGpt ->
-            "${formatTokenCount(data.weeklyInputTokens?.used)}/${formatTokenCount(data.limits.weeklyInputTokens)}"
+        is QuotaData.NanoGpt -> nanoGptBadgeLabel(data, mode)
         is QuotaData.ZaiCoding -> {
             val fiveHour = data.data.limits.find { it.type == "TOKENS_LIMIT" && it.unit == 3 }
             val weekly = data.data.limits.find { it.type == "TOKENS_LIMIT" && it.unit == 6 }
-            "${formatPercent(fiveHour?.percentage)}/${formatPercent(weekly?.percentage)}"
+            val fiveHourPct = applyBarMode(fiveHour?.percentage, mode)
+            val weeklyPct = applyBarMode(weekly?.percentage, mode)
+            "${formatPercent(fiveHourPct)}/${formatPercent(weeklyPct)}"
         }
         is QuotaData.KimiCode -> {
             val fiveHour =
                 data.limits
                     .find { it.window.timeUnit == "TIME_UNIT_MINUTE" && it.window.duration == 300 }
                     ?.detail
-            "${formatPercent(kimiUsedPercent(fiveHour))}/${formatPercent(kimiUsedPercent(data.usage))}"
+            val fiveHourUsed = applyBarMode(kimiUsedPercent(fiveHour), mode)
+            val weeklyUsed = applyBarMode(kimiUsedPercent(data.usage), mode)
+            "${formatPercent(fiveHourUsed)}/${formatPercent(weeklyUsed)}"
         }
         is QuotaData.MiniMax -> {
             val general = data.modelRemains.find { it.modelName == "general" && it.currentIntervalStatus == 1 }
-            val fiveHour = general?.let { 100.0 - it.currentIntervalRemainingPercent }
-            val weekly = general?.let { 100.0 - it.currentWeeklyRemainingPercent }
-            "${formatPercent(fiveHour)}/${formatPercent(weekly)}"
+            val fiveHourUsed = general?.let { 100.0 - it.currentIntervalRemainingPercent }
+            val weeklyUsed = general?.let { 100.0 - it.currentWeeklyRemainingPercent }
+            "${formatPercent(applyBarMode(fiveHourUsed, mode))}/${formatPercent(applyBarMode(weeklyUsed, mode))}"
         }
         is QuotaData.DeepSeek -> {
             val usd = data.balanceInfos.find { it.currency == "USD" }?.totalBalance
@@ -471,6 +488,39 @@ private fun kimiUsedPercent(detail: KimiCodeDetail?): Double? {
     val remaining = detail.remaining.toDoubleOrNull() ?: return null
     if (limit == 0.0) return null
     return (limit - remaining) / limit * 100.0
+}
+
+/**
+ * nanoGptBadgeLabel renders NanoGPT's weekly-token fraction. USED (the prior,
+ * only behavior) shows used/limit; REMAINING shows (limit - used)/limit,
+ * floored at zero, mirroring web's `nanoBadgeContent`.
+ */
+private fun nanoGptBadgeLabel(
+    data: QuotaData.NanoGpt,
+    mode: QuotaBarMode,
+): String {
+    val used = data.weeklyInputTokens?.used
+    val limit = data.limits.weeklyInputTokens
+    val numerator =
+        if (mode == QuotaBarMode.REMAINING) {
+            if (used != null && limit != null) (limit - used).coerceAtLeast(0) else null
+        } else {
+            used
+        }
+    return "${formatTokenCount(numerator)}/${formatTokenCount(limit)}"
+}
+
+/**
+ * applyBarMode converts a used% value into the polarity [mode] wants: USED
+ * passes it through unchanged (the prior, only behavior); REMAINING returns
+ * 100 minus it. Null (no data) propagates through either polarity.
+ */
+private fun applyBarMode(
+    usedPercent: Double?,
+    mode: QuotaBarMode,
+): Double? {
+    if (usedPercent == null) return null
+    return if (mode == QuotaBarMode.USED) usedPercent else 100.0 - usedPercent
 }
 
 private fun formatPercent(pct: Double?): String = if (pct == null) "-" else "${pct.roundToInt()}%"

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/QuotaModels.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/QuotaModels.kt
@@ -74,6 +74,20 @@ data class QuotaEnvelope(
     val quota: List<QuotaWire> = emptyList(),
 )
 
+/**
+ * QuotaRefreshResult is the POST /api/quota/refresh response: how many
+ * cached entries Front Desk re-polled just now, split by outcome. Bellhop
+ * surfaces this as a one-shot confirmation of the manual refresh; the
+ * badges themselves repaint from the next [QuotaEnvelope] read, not from
+ * this tally directly.
+ */
+@Serializable
+data class QuotaRefreshResult(
+    val refreshed: Int = 0,
+    val failed: Int = 0,
+    val skipped: Int = 0,
+)
+
 // ── Per-type payload shapes ─────────────────────────────────────────────
 
 /**

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/QuotaModels.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/QuotaModels.kt
@@ -6,6 +6,8 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.decodeFromJsonElement
+import java.util.Locale
+import kotlin.math.roundToInt
 
 // Wire models for GET /api/quota (internal/frontdesk, monitor tier -- any
 // paired device may read/refresh). The envelope is one entry per
@@ -405,4 +407,92 @@ private fun decodeQuotaPayload(
             QuotaType.UNKNOWN -> null
         }
     }.getOrNull()
+}
+
+// ── Badge label formatting ──────────────────────────────────────────────
+// Shared between the widget (this file feeds WidgetState.widgetQuotaOf) and
+// the future main-page badge composable (D2), so the two surfaces never
+// drift on what a badge says. Shapes mirror web/src/components/QuotaBadge.tsx
+// (used-fraction / used-percent / dollars / plan name / kWh) -- data/shape
+// parity, not a code port. These are numeric or symbol fragments (not
+// natural-language copy), so no Android string resources apply, and they are
+// formatted with a fixed Locale so the widget reads the same on every device.
+
+/**
+ * quotaBadgeLabel formats [pq] into the short text a badge shows. Unavailable
+ * or payload-less quotas (see [ProviderQuota.available]) render as "-",
+ * mirroring the web badge's fallback when its balance hook has no data yet.
+ */
+fun quotaBadgeLabel(pq: ProviderQuota): String {
+    val data = pq.data
+    if (!pq.available || data == null) return "-"
+    return when (data) {
+        is QuotaData.NanoGpt ->
+            "${formatTokenCount(data.weeklyInputTokens?.used)}/${formatTokenCount(data.limits.weeklyInputTokens)}"
+        is QuotaData.ZaiCoding -> {
+            val fiveHour = data.data.limits.find { it.type == "TOKENS_LIMIT" && it.unit == 3 }
+            val weekly = data.data.limits.find { it.type == "TOKENS_LIMIT" && it.unit == 6 }
+            "${formatPercent(fiveHour?.percentage)}/${formatPercent(weekly?.percentage)}"
+        }
+        is QuotaData.KimiCode -> {
+            val fiveHour =
+                data.limits
+                    .find { it.window.timeUnit == "TIME_UNIT_MINUTE" && it.window.duration == 300 }
+                    ?.detail
+            "${formatPercent(kimiUsedPercent(fiveHour))}/${formatPercent(kimiUsedPercent(data.usage))}"
+        }
+        is QuotaData.MiniMax -> {
+            val general = data.modelRemains.find { it.modelName == "general" && it.currentIntervalStatus == 1 }
+            val fiveHour = general?.let { 100.0 - it.currentIntervalRemainingPercent }
+            val weekly = general?.let { 100.0 - it.currentWeeklyRemainingPercent }
+            "${formatPercent(fiveHour)}/${formatPercent(weekly)}"
+        }
+        is QuotaData.DeepSeek -> {
+            val usd = data.balanceInfos.find { it.currency == "USD" }?.totalBalance
+            if (usd.isNullOrBlank()) "-" else "$$usd"
+        }
+        is QuotaData.OpenRouter -> "$${formatDollarAmount(data.creditsRemaining)}"
+        is QuotaData.OllamaCloud -> data.plan.ifBlank { "-" }
+        is QuotaData.NeuralWatt -> {
+            val used = data.subscription.kwhUsed
+            val included = data.subscription.kwhIncluded
+            if (included > 0) {
+                "${formatKwhAmount(used)}/${formatKwhAmount(included)} kWh"
+            } else {
+                "${formatKwhAmount(used)} kWh"
+            }
+        }
+    }
+}
+
+/** kimiUsedPercent computes used% from Kimi's wire-string limit/remaining pair. */
+private fun kimiUsedPercent(detail: KimiCodeDetail?): Double? {
+    val limit = detail?.limit?.toDoubleOrNull() ?: return null
+    val remaining = detail.remaining.toDoubleOrNull() ?: return null
+    if (limit == 0.0) return null
+    return (limit - remaining) / limit * 100.0
+}
+
+private fun formatPercent(pct: Double?): String = if (pct == null) "-" else "${pct.roundToInt()}%"
+
+private fun formatDollarAmount(v: Double): String = String.format(Locale.US, "%.2f", v)
+
+private fun formatKwhAmount(v: Double): String = trimTrailingZero(v)
+
+/** formatTokenCount mirrors formatCompact from web/src/utils/format.ts: K/M/B suffixes, one decimal. */
+private fun formatTokenCount(n: Long?): String {
+    if (n == null) return "-"
+    if (n == 0L) return "0"
+    val abs = kotlin.math.abs(n)
+    return when {
+        abs >= 1_000_000_000L -> "${trimTrailingZero(n / 1_000_000_000.0)}B"
+        abs >= 1_000_000L -> "${trimTrailingZero(n / 1_000_000.0)}M"
+        abs >= 1_000L -> "${trimTrailingZero(n / 1_000.0)}K"
+        else -> n.toString()
+    }
+}
+
+private fun trimTrailingZero(v: Double): String {
+    val s = String.format(Locale.US, "%.1f", v)
+    return if (s.endsWith(".0")) s.dropLast(2) else s
 }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/QuotaModels.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/QuotaModels.kt
@@ -1,0 +1,394 @@
+package com.hugalafutro.bellhop.data
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.decodeFromJsonElement
+
+// Wire models for GET /api/quota (internal/frontdesk, monitor tier -- any
+// paired device may read/refresh). The envelope is one entry per
+// quota-supporting provider Front Desk has cached; `type` selects which
+// per-provider payload shape to decode and which badge to render -- `kind`
+// (usage|balance|account) is bookkeeping only, never a badge selector. Each
+// [QuotaData] variant mirrors the matching Go struct in internal/provider/
+// (discovery_types.go, openrouter_types.go, ollama_cloud_types.go) but only
+// carries the fields the dashboard (web/src/components/QuotaBadge.tsx +
+// web/src/components/modals/*QuotaModal.tsx) actually displays.
+
+/**
+ * QuotaType is the badge/payload-shape selector: FD's `type` field, not
+ * `kind`. [fromWire] degrades any string it doesn't recognize to [UNKNOWN]
+ * rather than throwing, so a Front Desk that has grown a ninth provider never
+ * crashes an older Bellhop -- the badge for it simply doesn't render.
+ */
+enum class QuotaType {
+    NANOGPT,
+    ZAI_CODING,
+    KIMI_CODE,
+    MINIMAX,
+    DEEPSEEK,
+    OPENROUTER,
+    OLLAMA_CLOUD,
+    NEURALWATT,
+    UNKNOWN,
+    ;
+
+    companion object {
+        fun fromWire(wire: String): QuotaType =
+            when (wire) {
+                "nanogpt" -> NANOGPT
+                "zai-coding" -> ZAI_CODING
+                "kimi-code" -> KIMI_CODE
+                "minimax" -> MINIMAX
+                "deepseek" -> DEEPSEEK
+                "openrouter" -> OPENROUTER
+                "ollama-cloud" -> OLLAMA_CLOUD
+                "neuralwatt" -> NEURALWATT
+                else -> UNKNOWN
+            }
+    }
+}
+
+/**
+ * QuotaWire is one raw entry of the GET /api/quota envelope, before payload
+ * decoding. [payload] is left as a [JsonElement] (rather than a concrete
+ * type) because its shape depends on [type]; it is null both when Front Desk
+ * has no cached payload yet and when the upstream fetch failed
+ * ([httpStatus] != 200).
+ */
+@Serializable
+data class QuotaWire(
+    @SerialName("provider_name") val providerName: String = "",
+    val type: String = "",
+    val kind: String = "",
+    val payload: JsonElement? = null,
+    @SerialName("http_status") val httpStatus: Int = 0,
+    @SerialName("fetched_at") val fetchedAt: String = "",
+)
+
+/** QuotaEnvelope is the GET /api/quota top-level response: `{"quota": [...]}`. */
+@Serializable
+data class QuotaEnvelope(
+    val quota: List<QuotaWire> = emptyList(),
+)
+
+// ── Per-type payload shapes ─────────────────────────────────────────────
+
+/**
+ * QuotaData is the decoded, per-type payload -- one variant per [QuotaType]
+ * (excluding [QuotaType.UNKNOWN], which never has a payload variant). Each
+ * variant models only the fields the dashboard badge or detail modal renders,
+ * not the full upstream response.
+ */
+sealed interface QuotaData {
+    /** Mirrors internal/provider/discovery_types.go NanoGPTUsageResponse. */
+    @Serializable
+    data class NanoGpt(
+        val active: Boolean = false,
+        val provider: String = "",
+        val providerStatus: String = "",
+        val allowOverage: Boolean = false,
+        val cancelAtPeriodEnd: Boolean = false,
+        val limits: NanoGptLimits = NanoGptLimits(),
+        val period: NanoGptPeriod = NanoGptPeriod(),
+        val weeklyInputTokens: NanoGptTokenInfo? = null,
+        val dailyInputTokens: NanoGptTokenInfo? = null,
+        val dailyImages: NanoGptTokenInfo? = null,
+    ) : QuotaData
+
+    /** Mirrors internal/provider/discovery_types.go ZAICodingQuotaResponse. */
+    @Serializable
+    data class ZaiCoding(
+        val data: ZaiCodingQuotaBody = ZaiCodingQuotaBody(),
+        val success: Boolean = false,
+    ) : QuotaData
+
+    /** Mirrors internal/provider/discovery_types.go KimiCodeQuotaResponse. */
+    @Serializable
+    data class KimiCode(
+        val user: KimiCodeUser = KimiCodeUser(),
+        val usage: KimiCodeDetail = KimiCodeDetail(),
+        val limits: List<KimiCodeLimitEntry> = emptyList(),
+        val parallel: KimiCodeParallel = KimiCodeParallel(),
+        val totalQuota: KimiCodeDetail = KimiCodeDetail(),
+    ) : QuotaData
+
+    /** Mirrors internal/provider/discovery_types.go MiniMaxQuotaResponse. */
+    @Serializable
+    data class MiniMax(
+        @SerialName("model_remains") val modelRemains: List<MiniMaxModelRemain> = emptyList(),
+        @SerialName("base_resp") val baseResp: MiniMaxBaseResp = MiniMaxBaseResp(),
+    ) : QuotaData
+
+    /** Mirrors internal/provider/discovery_types.go DeepSeekBalanceResponse. */
+    @Serializable
+    data class DeepSeek(
+        @SerialName("is_available") val isAvailable: Boolean = false,
+        @SerialName("balance_infos") val balanceInfos: List<DeepSeekBalanceInfo> = emptyList(),
+    ) : QuotaData
+
+    /** Mirrors internal/provider/openrouter_types.go OpenRouterBalance. */
+    @Serializable
+    data class OpenRouter(
+        val limit: Double? = null,
+        @SerialName("limit_reset") val limitReset: String = "",
+        @SerialName("limit_remaining") val limitRemaining: Double? = null,
+        val usage: Double = 0.0,
+        @SerialName("usage_daily") val usageDaily: Double = 0.0,
+        @SerialName("usage_weekly") val usageWeekly: Double = 0.0,
+        @SerialName("usage_monthly") val usageMonthly: Double = 0.0,
+        @SerialName("credits_total") val creditsTotal: Double = 0.0,
+        @SerialName("credits_used") val creditsUsed: Double = 0.0,
+        @SerialName("credits_remaining") val creditsRemaining: Double = 0.0,
+        @SerialName("is_free_tier") val isFreeTier: Boolean = false,
+    ) : QuotaData
+
+    /** Mirrors internal/provider/ollama_cloud_types.go OllamaCloudAccount. */
+    @Serializable
+    data class OllamaCloud(
+        val plan: String = "",
+        @SerialName("subscription_period_end")
+        val subscriptionPeriodEnd: OllamaCloudNullableTime = OllamaCloudNullableTime(),
+        @SerialName("suspended_at")
+        val suspendedAt: OllamaCloudNullableTime = OllamaCloudNullableTime(),
+    ) : QuotaData
+
+    /** Mirrors internal/provider/discovery_types.go NeuralWattQuotaResponse. */
+    @Serializable
+    data class NeuralWatt(
+        val balance: NeuralWattBalance = NeuralWattBalance(),
+        val usage: NeuralWattUsage = NeuralWattUsage(),
+        val limits: NeuralWattLimits = NeuralWattLimits(),
+        val subscription: NeuralWattSubscription = NeuralWattSubscription(),
+        val key: NeuralWattKey = NeuralWattKey(),
+    ) : QuotaData
+}
+
+// ── NanoGPT support types ───────────────────────────────────────────────
+// NanoGPT's JSON keys are already camelCase (no @SerialName needed).
+
+@Serializable
+data class NanoGptLimits(
+    val weeklyInputTokens: Long? = null,
+    val dailyInputTokens: Long? = null,
+    val dailyImages: Long? = null,
+)
+
+@Serializable
+data class NanoGptPeriod(
+    val currentPeriodEnd: String = "",
+)
+
+@Serializable
+data class NanoGptTokenInfo(
+    val used: Long = 0,
+    val remaining: Long = 0,
+    val percentUsed: Double = 0.0,
+    val resetAt: Long = 0,
+)
+
+// ── Z.ai Coding support types ───────────────────────────────────────────
+
+@Serializable
+data class ZaiCodingQuotaBody(
+    val limits: List<ZaiCodingLimit> = emptyList(),
+    val level: String = "",
+)
+
+@Serializable
+data class ZaiCodingLimit(
+    val type: String = "",
+    val unit: Int = 0,
+    val percentage: Double = 0.0,
+    val nextResetTime: Long = 0,
+    val usageDetails: List<ZaiCodingUsageDetail> = emptyList(),
+)
+
+@Serializable
+data class ZaiCodingUsageDetail(
+    val modelCode: String = "",
+    val usage: Long = 0,
+)
+
+// ── Kimi Code support types ─────────────────────────────────────────────
+// Kimi's numeric limit/remaining fields arrive as JSON strings on the wire.
+
+@Serializable
+data class KimiCodeUser(
+    val membership: KimiCodeMembership = KimiCodeMembership(),
+)
+
+@Serializable
+data class KimiCodeMembership(
+    val level: String = "",
+)
+
+@Serializable
+data class KimiCodeDetail(
+    val limit: String = "",
+    val remaining: String = "",
+    val resetTime: String = "",
+)
+
+@Serializable
+data class KimiCodeWindowSpec(
+    val duration: Int = 0,
+    val timeUnit: String = "",
+)
+
+@Serializable
+data class KimiCodeLimitEntry(
+    val window: KimiCodeWindowSpec = KimiCodeWindowSpec(),
+    val detail: KimiCodeDetail = KimiCodeDetail(),
+)
+
+@Serializable
+data class KimiCodeParallel(
+    val limit: String = "",
+)
+
+// ── MiniMax support types ───────────────────────────────────────────────
+
+@Serializable
+data class MiniMaxModelRemain(
+    @SerialName("model_name") val modelName: String = "",
+    @SerialName("start_time") val startTime: Long = 0,
+    @SerialName("end_time") val endTime: Long = 0,
+    @SerialName("remains_time") val remainsTime: Long = 0,
+    @SerialName("weekly_remains_time") val weeklyRemainsTime: Long = 0,
+    @SerialName("current_interval_status") val currentIntervalStatus: Int = 0,
+    @SerialName("current_interval_remaining_percent") val currentIntervalRemainingPercent: Double = 0.0,
+    @SerialName("current_weekly_status") val currentWeeklyStatus: Int = 0,
+    @SerialName("current_weekly_remaining_percent") val currentWeeklyRemainingPercent: Double = 0.0,
+)
+
+@Serializable
+data class MiniMaxBaseResp(
+    @SerialName("status_code") val statusCode: Int = 0,
+)
+
+// ── DeepSeek support types ──────────────────────────────────────────────
+
+@Serializable
+data class DeepSeekBalanceInfo(
+    val currency: String = "",
+    @SerialName("total_balance") val totalBalance: String = "",
+)
+
+// ── Ollama Cloud support types ──────────────────────────────────────────
+
+@Serializable
+data class OllamaCloudNullableTime(
+    val time: String = "",
+    val valid: Boolean = false,
+)
+
+// ── NeuralWatt support types ────────────────────────────────────────────
+
+@Serializable
+data class NeuralWattBalance(
+    @SerialName("credits_remaining_usd") val creditsRemainingUsd: Double = 0.0,
+    @SerialName("total_credits_usd") val totalCreditsUsd: Double = 0.0,
+    @SerialName("credits_used_usd") val creditsUsedUsd: Double = 0.0,
+    @SerialName("accounting_method") val accountingMethod: String = "",
+)
+
+@Serializable
+data class NeuralWattUsagePeriod(
+    @SerialName("cost_usd") val costUsd: Double = 0.0,
+    val requests: Long = 0,
+    val tokens: Long = 0,
+    @SerialName("energy_kwh") val energyKwh: Double = 0.0,
+)
+
+@Serializable
+data class NeuralWattUsage(
+    val lifetime: NeuralWattUsagePeriod = NeuralWattUsagePeriod(),
+    @SerialName("current_month") val currentMonth: NeuralWattUsagePeriod = NeuralWattUsagePeriod(),
+)
+
+@Serializable
+data class NeuralWattLimits(
+    @SerialName("overage_limit_usd") val overageLimitUsd: Double? = null,
+    @SerialName("rate_limit_tier") val rateLimitTier: String = "",
+)
+
+@Serializable
+data class NeuralWattSubscription(
+    val plan: String = "",
+    val status: String = "",
+    @SerialName("billing_interval") val billingInterval: String = "",
+    @SerialName("current_period_start") val currentPeriodStart: String = "",
+    @SerialName("current_period_end") val currentPeriodEnd: String = "",
+    @SerialName("auto_renew") val autoRenew: Boolean = false,
+    @SerialName("kwh_included") val kwhIncluded: Double = 0.0,
+    @SerialName("kwh_used") val kwhUsed: Double = 0.0,
+    @SerialName("kwh_remaining") val kwhRemaining: Double = 0.0,
+    @SerialName("in_overage") val inOverage: Boolean = false,
+)
+
+@Serializable
+data class NeuralWattKey(
+    val allowance: Double? = null,
+)
+
+// ── Parsing ──────────────────────────────────────────────────────────────
+
+/**
+ * ProviderQuota is the parsed, display-ready form of one [QuotaWire] entry.
+ * [available] is true only when Front Desk's own fetch succeeded
+ * (http_status == 200) *and* the payload decoded into the shape [type]
+ * expects; badge code should gate on [available], not on [data] alone.
+ */
+data class ProviderQuota(
+    val providerName: String,
+    val type: QuotaType,
+    val data: QuotaData?,
+    val fetchedAt: String,
+    val available: Boolean,
+)
+
+private val quotaPayloadJson = Json { ignoreUnknownKeys = true }
+
+/**
+ * providerQuotaOf maps one [QuotaWire] entry to a [ProviderQuota], decoding
+ * [QuotaWire.payload] into the variant matching [QuotaWire.type]. Mirrors
+ * [FleetSnapshot.stateOf]'s tolerant stance: a missing payload, a non-200
+ * [QuotaWire.httpStatus], an unrecognized [QuotaWire.type], or a payload that
+ * doesn't decode into the expected shape all degrade to `data = null,
+ * available = false` -- this must never throw on a foreign or malformed
+ * payload from a newer Front Desk.
+ */
+fun providerQuotaOf(wire: QuotaWire): ProviderQuota {
+    val type = QuotaType.fromWire(wire.type)
+    val data = decodeQuotaPayload(type, wire.payload)
+    return ProviderQuota(
+        providerName = wire.providerName,
+        type = type,
+        data = data,
+        fetchedAt = wire.fetchedAt,
+        available = wire.httpStatus == 200 && data != null,
+    )
+}
+
+private fun decodeQuotaPayload(
+    type: QuotaType,
+    payload: JsonElement?,
+): QuotaData? {
+    if (payload == null || payload is JsonNull) return null
+    return runCatching {
+        when (type) {
+            QuotaType.NANOGPT -> quotaPayloadJson.decodeFromJsonElement<QuotaData.NanoGpt>(payload)
+            QuotaType.ZAI_CODING -> quotaPayloadJson.decodeFromJsonElement<QuotaData.ZaiCoding>(payload)
+            QuotaType.KIMI_CODE -> quotaPayloadJson.decodeFromJsonElement<QuotaData.KimiCode>(payload)
+            QuotaType.MINIMAX -> quotaPayloadJson.decodeFromJsonElement<QuotaData.MiniMax>(payload)
+            QuotaType.DEEPSEEK -> quotaPayloadJson.decodeFromJsonElement<QuotaData.DeepSeek>(payload)
+            QuotaType.OPENROUTER -> quotaPayloadJson.decodeFromJsonElement<QuotaData.OpenRouter>(payload)
+            QuotaType.OLLAMA_CLOUD -> quotaPayloadJson.decodeFromJsonElement<QuotaData.OllamaCloud>(payload)
+            QuotaType.NEURALWATT -> quotaPayloadJson.decodeFromJsonElement<QuotaData.NeuralWatt>(payload)
+            QuotaType.UNKNOWN -> null
+        }
+    }.getOrNull()
+}

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/WidgetState.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/WidgetState.kt
@@ -45,7 +45,11 @@ data class WidgetQuotaBadge(
     val providerName: String,
     val type: String,
     val label: String,
-)
+) {
+    /** Decoded [type], UNKNOWN for a name this build doesn't know (see the class note). */
+    val quotaType: QuotaType
+        get() = runCatching { QuotaType.valueOf(type) }.getOrDefault(QuotaType.UNKNOWN)
+}
 
 /**
  * WidgetState is the widget's whole persisted render model. It is written only
@@ -64,8 +68,56 @@ data class WidgetState(
     val quota: List<WidgetQuotaBadge> = emptyList(),
 )
 
-/** WIDGET_QUOTA_CAP is headroom under Glance's 10-child cap, shared with member rows; tuned with the render in C3. */
-const val WIDGET_QUOTA_CAP = 6
+/**
+ * WIDGET_QUOTA_CAP is the most badges the widget renders. The strip wraps onto
+ * several lines now ([quotaBadgeRows]), so this is no longer the old
+ * one-line-holds-six limit that quietly hid the rest of an operator's
+ * selection: it bounds how much of a small widget the strip may eat, and keeps
+ * the row count inside the nested Column well under Glance's 10-children cap.
+ */
+const val WIDGET_QUOTA_CAP = 12
+
+/**
+ * WIDGET_QUOTA_MAX_ROWS caps the strip's height. Four rows of 9sp pills is
+ * roughly a third of the COMPACT widget; past that the fleet rows the widget
+ * exists for would be the ones squeezed out.
+ */
+const val WIDGET_QUOTA_MAX_ROWS = 4
+
+// Row packing budget. Glance cannot measure text or wrap a Row, and under
+// SizeMode.Responsive LocalSize reports the breakpoint (180dp wide), not the
+// real widget, so rows are packed against the narrowest width the widget can
+// be resized to: 180dp minus the root Column's 12dp side padding. Badges are
+// digits and percent signs at 9sp; 6dp per character is a deliberate
+// over-estimate (a clipped badge is worse than a short row) and the chrome
+// term is the pill's 12dp horizontal padding plus its 4dp end gap.
+private const val WIDGET_QUOTA_ROW_BUDGET_DP = 156
+private const val WIDGET_QUOTA_CHAR_DP = 6
+private const val WIDGET_QUOTA_PILL_CHROME_DP = 16
+
+/**
+ * quotaBadgeRows packs [badges] into the rows the widget renders, keeping the
+ * given order and fitting as many per row as [WIDGET_QUOTA_ROW_BUDGET_DP]
+ * allows (always at least one, so a badge wider than the whole row still gets
+ * its own line rather than disappearing). Rows past [WIDGET_QUOTA_MAX_ROWS] are
+ * dropped -- [widgetQuotaOf] has already capped the input, so this only bites
+ * when every label is unusually long.
+ */
+fun quotaBadgeRows(badges: List<WidgetQuotaBadge>): List<List<WidgetQuotaBadge>> {
+    val rows = mutableListOf<MutableList<WidgetQuotaBadge>>()
+    var used = 0
+    badges.forEach { badge ->
+        val width = badge.label.length * WIDGET_QUOTA_CHAR_DP + WIDGET_QUOTA_PILL_CHROME_DP
+        if (rows.isEmpty() || used + width > WIDGET_QUOTA_ROW_BUDGET_DP) {
+            rows += mutableListOf(badge)
+            used = width
+        } else {
+            rows.last() += badge
+            used += width
+        }
+    }
+    return rows.take(WIDGET_QUOTA_MAX_ROWS)
+}
 
 /**
  * widgetQuotaOf resolves [quota] against [config] the same way the main-page

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/WidgetState.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/WidgetState.kt
@@ -71,12 +71,13 @@ const val WIDGET_QUOTA_CAP = 6
  * widgetQuotaOf resolves [quota] against [config] the same way the main-page
  * badge list does ([orderedVisible]: hidden/unavailable names dropped, order
  * preserved), then trims to [WIDGET_QUOTA_CAP] and precomputes each badge's
- * short [WidgetQuotaBadge.label] via [quotaBadgeLabel] so the widget's render
- * stays pure-string.
+ * short [WidgetQuotaBadge.label] via [quotaBadgeLabel] (in [mode]'s polarity)
+ * so the widget's render stays pure-string.
  */
 fun widgetQuotaOf(
     quota: List<ProviderQuota>,
     config: QuotaBadgeConfig,
+    mode: QuotaBarMode,
 ): List<WidgetQuotaBadge> =
     orderedVisible(config, quota)
         .take(WIDGET_QUOTA_CAP)
@@ -84,7 +85,7 @@ fun widgetQuotaOf(
             WidgetQuotaBadge(
                 providerName = it.providerName,
                 type = it.type.name,
-                label = quotaBadgeLabel(it),
+                label = quotaBadgeLabel(it, mode),
             )
         }
 

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/WidgetState.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/WidgetState.kt
@@ -33,6 +33,21 @@ data class WidgetEvent(
 )
 
 /**
+ * WidgetQuotaBadge is one quota badge on the widget: the provider identity
+ * ([providerName], the wire's own key -- never type or UUID, see
+ * global-constraints badge-identity note) plus [type] (kept as the enum's
+ * wire name so a future build's new type degrades gracefully, same stance as
+ * [WidgetMember.state]) and a precomputed [label] so the Glance render stays
+ * a pure string (no [ProviderQuota]/formatting logic in the render path).
+ */
+@Serializable
+data class WidgetQuotaBadge(
+    val providerName: String,
+    val type: String,
+    val label: String,
+)
+
+/**
  * WidgetState is the widget's whole persisted render model. It is written only
  * by code paths that already fetched the fleet (background poll, foreground
  * refresh, widget refresh tap) so the widget itself never needs the network;
@@ -44,7 +59,34 @@ data class WidgetState(
     val autosyncStale: Boolean = false,
     val newestEvent: WidgetEvent? = null,
     val updatedAt: Long = 0L,
+    // Defaulted so widget state persisted before quota badges existed still
+    // decodes.
+    val quota: List<WidgetQuotaBadge> = emptyList(),
 )
+
+/** WIDGET_QUOTA_CAP is headroom under Glance's 10-child cap, shared with member rows; tuned with the render in C3. */
+const val WIDGET_QUOTA_CAP = 6
+
+/**
+ * widgetQuotaOf resolves [quota] against [config] the same way the main-page
+ * badge list does ([orderedVisible]: hidden/unavailable names dropped, order
+ * preserved), then trims to [WIDGET_QUOTA_CAP] and precomputes each badge's
+ * short [WidgetQuotaBadge.label] via [quotaBadgeLabel] so the widget's render
+ * stays pure-string.
+ */
+fun widgetQuotaOf(
+    quota: List<ProviderQuota>,
+    config: QuotaBadgeConfig,
+): List<WidgetQuotaBadge> =
+    orderedVisible(config, quota)
+        .take(WIDGET_QUOTA_CAP)
+        .map {
+            WidgetQuotaBadge(
+                providerName = it.providerName,
+                type = it.type.name,
+                label = quotaBadgeLabel(it),
+            )
+        }
 
 /** TRAFFIC_BUCKETS is the widget's bar-graph window: one hour of 5-minute buckets. */
 const val TRAFFIC_BUCKETS = 12
@@ -78,6 +120,7 @@ fun widgetStateOf(
     autosyncStale: Boolean,
     now: Long,
     traffic: Map<String, List<Int>> = emptyMap(),
+    quota: List<WidgetQuotaBadge> = emptyList(),
 ): WidgetState =
     WidgetState(
         members =
@@ -98,4 +141,9 @@ fun widgetStateOf(
                 .maxByOrNull { it.createdAt }
                 ?.let { WidgetEvent(it.message, it.createdAt) },
         updatedAt = now,
+        // Writers already computed the badge list via widgetQuotaOf (needs the
+        // fetched ProviderQuota list plus the surface's QuotaBadgeConfig,
+        // neither of which this function otherwise touches); threaded through
+        // verbatim.
+        quota = quota,
     )

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/ReorderableList.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/ReorderableList.kt
@@ -1,0 +1,117 @@
+package com.hugalafutro.bellhop.ui.common
+
+import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+
+/**
+ * Returns a new list with the item at [from] moved to [to], leaving all
+ * other items in their relative order. Pure and side-effect free so it can
+ * be unit tested without Compose.
+ *
+ * Out-of-range [from] is a no-op (returns [list] unchanged). Out-of-range
+ * [to] is clamped into `0..list.lastIndex`. `from == to` is a no-op.
+ */
+fun <T> moveItem(
+    list: List<T>,
+    from: Int,
+    to: Int,
+): List<T> {
+    if (list.isEmpty() || from !in list.indices) return list
+    val target = to.coerceIn(0, list.lastIndex)
+    if (from == target) return list
+    val mutable = list.toMutableList()
+    val item = mutable.removeAt(from)
+    mutable.add(target, item)
+    return mutable
+}
+
+/**
+ * A minimal, hand-rolled drag-to-reorder [LazyColumn] for short string lists
+ * (no drag-and-drop library dependency; see task brief). Long-pressing an
+ * item and dragging it up/down live-shifts that row; [onMove] is invoked
+ * once with the final `(from, to)` on release, so the caller owns the
+ * source of truth and is expected to persist the reordered list.
+ *
+ * Row heights are assumed roughly uniform (the common case for short
+ * configurator lists like provider name order) since the drop target is
+ * derived from accumulated drag distance divided by the first measured row
+ * height.
+ */
+@Composable
+fun ReorderableColumn(
+    items: List<String>,
+    onMove: (from: Int, to: Int) -> Unit,
+    modifier: Modifier = Modifier,
+    key: (String) -> Any = { it },
+    lazyListState: LazyListState = rememberLazyListState(),
+    itemContent: @Composable (String) -> Unit,
+) {
+    var draggedIndex by remember { mutableStateOf<Int?>(null) }
+    var dragOffsetY by remember { mutableStateOf(0f) }
+    var rowHeightPx by remember { mutableIntStateOf(0) }
+
+    LazyColumn(modifier = modifier.testTag("reorderable-column"), state = lazyListState) {
+        itemsIndexed(items, key = { _, item -> key(item) }) { index, item ->
+            val isDragged = draggedIndex == index
+            Surface(
+                tonalElevation = if (isDragged) 4.dp else 0.dp,
+                modifier =
+                    Modifier
+                        .testTag("reorderable-row-$index")
+                        .graphicsLayer {
+                            translationY = if (isDragged) dragOffsetY else 0f
+                        }
+                        .onGloballyPositioned { coordinates ->
+                            if (rowHeightPx == 0) rowHeightPx = coordinates.size.height
+                        }
+                        .pointerInput(items, index) {
+                            detectDragGesturesAfterLongPress(
+                                onDragStart = {
+                                    draggedIndex = index
+                                    dragOffsetY = 0f
+                                },
+                                onDragCancel = {
+                                    draggedIndex = null
+                                    dragOffsetY = 0f
+                                },
+                                onDragEnd = {
+                                    val startIndex = draggedIndex
+                                    if (startIndex != null && rowHeightPx > 0) {
+                                        val rowsMoved = (dragOffsetY / rowHeightPx).toInt()
+                                        val targetIndex =
+                                            (startIndex + rowsMoved)
+                                                .coerceIn(0, items.lastIndex)
+                                        if (targetIndex != startIndex) {
+                                            onMove(startIndex, targetIndex)
+                                        }
+                                    }
+                                    draggedIndex = null
+                                    dragOffsetY = 0f
+                                },
+                            ) { change, dragAmount ->
+                                change.consume()
+                                dragOffsetY += dragAmount.y
+                            }
+                        },
+            ) {
+                itemContent(item)
+            }
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
@@ -146,7 +146,7 @@ fun DashboardScreen(
         }
     }
     selectedQuotaBadge?.let { name ->
-        ui.quota.firstOrNull { it.providerName == name }?.let { pq ->
+        ui.quotaByName[name]?.let { pq ->
             QuotaDetailSheet(pq = pq, mode = quotaBarMode, onDismiss = { selectedQuotaBadge = null })
         }
     }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
@@ -224,7 +224,10 @@ fun DashboardScreen(
 
             if (ui.quota.isNotEmpty()) {
                 Row(
-                    verticalAlignment = Alignment.CenterVertically,
+                    // Top, not centre: the badge strip wraps onto as many lines
+                    // as the selection needs, and a centred refresh button ends
+                    // up floating halfway down a tall strip with nothing beside it.
+                    verticalAlignment = Alignment.Top,
                     modifier = Modifier.fillMaxWidth(),
                 ) {
                     QuotaBadgeRow(

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
@@ -70,6 +71,7 @@ import com.hugalafutro.bellhop.data.HealthStatus
 import com.hugalafutro.bellhop.data.LinkState
 import com.hugalafutro.bellhop.data.MemberStatus
 import com.hugalafutro.bellhop.data.MemberTraffic
+import com.hugalafutro.bellhop.data.QuotaBarMode
 import com.hugalafutro.bellhop.ui.common.ConfirmOpenUrlDialog
 import com.hugalafutro.bellhop.ui.common.LockFab
 import com.hugalafutro.bellhop.ui.common.Pill
@@ -107,6 +109,8 @@ fun DashboardScreen(
     onSetAutoSync: (Boolean) -> Unit = {},
     onDismissAutoSyncError: () -> Unit = {},
     onVisibleMembers: (List<String>) -> Unit = {},
+    quotaBarMode: QuotaBarMode = QuotaBarMode.REMAINING,
+    onRefreshQuota: () -> Unit = {},
     // When true, a long-press on a member card copies it to the clipboard (tap
     // still opens the member). Off leaves the card tap-only (Settings > Hold to copy).
     holdToCopy: Boolean = false,
@@ -127,6 +131,14 @@ fun DashboardScreen(
     var urlDialogFor by remember { mutableStateOf<FleetMember?>(null) }
     urlDialogFor?.let { member ->
         ConfirmOpenUrlDialog(url = member.url, onDismiss = { urlDialogFor = null })
+    }
+
+    // Which quota badge's detail sheet is open, if any (keyed by provider name).
+    var selectedQuotaBadge by remember { mutableStateOf<String?>(null) }
+    selectedQuotaBadge?.let { name ->
+        ui.quota.firstOrNull { it.providerName == name }?.let { pq ->
+            QuotaDetailSheet(pq = pq, mode = quotaBarMode, onDismiss = { selectedQuotaBadge = null })
+        }
     }
 
     // Build footer: tapping it confirms before leaving for GitHub. Stamped builds
@@ -199,6 +211,37 @@ fun DashboardScreen(
                 }
             }
             Spacer(modifier = Modifier.height(12.dp))
+
+            if (ui.quota.isNotEmpty()) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    QuotaBadgeRow(
+                        quota = ui.quota,
+                        mode = quotaBarMode,
+                        onBadgeClick = { selectedQuotaBadge = it },
+                        modifier = Modifier.weight(1f),
+                    )
+                    IconButton(
+                        onClick = onRefreshQuota,
+                        modifier = Modifier.testTag("quota-refresh"),
+                    ) {
+                        if (ui.refreshingQuota) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(20.dp),
+                                strokeWidth = 2.dp,
+                            )
+                        } else {
+                            Icon(
+                                imageVector = Icons.Filled.Refresh,
+                                contentDescription = stringResource(R.string.quota_refresh),
+                            )
+                        }
+                    }
+                }
+                Spacer(modifier = Modifier.height(12.dp))
+            }
 
             if (ui.revoked) {
                 StatusBanner(

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
@@ -111,6 +111,8 @@ fun DashboardScreen(
     onVisibleMembers: (List<String>) -> Unit = {},
     quotaBarMode: QuotaBarMode = QuotaBarMode.REMAINING,
     onRefreshQuota: () -> Unit = {},
+    deepLinkBadge: String? = null,
+    onDeepLinkConsumed: () -> Unit = {},
     // When true, a long-press on a member card copies it to the clipboard (tap
     // still opens the member). Off leaves the card tap-only (Settings > Hold to copy).
     holdToCopy: Boolean = false,
@@ -135,6 +137,14 @@ fun DashboardScreen(
 
     // Which quota badge's detail sheet is open, if any (keyed by provider name).
     var selectedQuotaBadge by remember { mutableStateOf<String?>(null) }
+    // A widget deep-link (already past the app lock, since this UI only composes
+    // once unlocked) opens that badge's detail sheet, then clears the pending target.
+    LaunchedEffect(deepLinkBadge) {
+        if (deepLinkBadge != null) {
+            selectedQuotaBadge = deepLinkBadge
+            onDeepLinkConsumed()
+        }
+    }
     selectedQuotaBadge?.let { name ->
         ui.quota.firstOrNull { it.providerName == name }?.let { pq ->
             QuotaDetailSheet(pq = pq, mode = quotaBarMode, onDismiss = { selectedQuotaBadge = null })

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
@@ -266,6 +266,16 @@ fun DashboardScreen(
                     text = stringResource(R.string.dashboard_refresh_failed, ui.error),
                     tag = "dashboard-error",
                 )
+            } else if (ui.quotaRefreshError != null) {
+                // Ranked below the two above because it is the narrower failure:
+                // a dead token or an unreadable fleet outranks quota readings
+                // Front Desk could not re-poll. Shown at all because the badge
+                // row keeps its last-good values, so the tap would otherwise be
+                // indistinguishable from a refresh that found no change.
+                StatusBanner(
+                    text = stringResource(R.string.dashboard_refresh_failed, ui.quotaRefreshError),
+                    tag = "quota-refresh-error",
+                )
             }
 
             // Pause/resume auto-sync: an operator lever, shown only once a primary

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModel.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModel.kt
@@ -12,8 +12,15 @@ import com.hugalafutro.bellhop.data.FrontDeskClient
 import com.hugalafutro.bellhop.data.LinkStore
 import com.hugalafutro.bellhop.data.MemberTraffic
 import com.hugalafutro.bellhop.data.PrefsStore
+import com.hugalafutro.bellhop.data.ProviderQuota
+import com.hugalafutro.bellhop.data.QuotaBadgeConfigStore
+import com.hugalafutro.bellhop.data.QuotaBarMode
+import com.hugalafutro.bellhop.data.QuotaSurface
 import com.hugalafutro.bellhop.data.SseMessage
+import com.hugalafutro.bellhop.data.WidgetQuotaBadge
 import com.hugalafutro.bellhop.data.WidgetStore
+import com.hugalafutro.bellhop.data.orderedVisible
+import com.hugalafutro.bellhop.data.widgetQuotaOf
 import com.hugalafutro.bellhop.data.widgetStateOf
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
@@ -26,6 +33,7 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -62,6 +70,15 @@ data class DashboardUiState(
     val revoked: Boolean = false,
     // Pause/resume operator action state (same shape as the member-detail card).
     val autoSync: AutoSyncAction = AutoSyncAction(),
+    // MAIN-surface quota badges, already ordered/filtered through
+    // [QuotaBadgeConfigStore] + [orderedVisible] -- the composable renders this
+    // list verbatim, no further config logic in the render path. A failed
+    // quota read keeps the last-good list (stale beats blank), same stance as
+    // [members].
+    val quota: List<ProviderQuota> = emptyList(),
+    // Whether a manual [DashboardViewModel.refreshQuota] call is in flight, so
+    // the badge row can show a spinner and the trigger can debounce a double-tap.
+    val refreshingQuota: Boolean = false,
 )
 
 /**
@@ -105,6 +122,13 @@ class DashboardViewModel(
     // rather than a store so unit tests stay store-free; when false the mirror
     // writes no traffic, matching what the background writers persist.
     private val widgetGraphs: suspend () -> Boolean = { false },
+    // Persists per-surface (MAIN/WIDGET) badge order + hidden set; reconciled
+    // whenever a fresh quota read comes in so newly-seen providers get folded
+    // in.
+    private val configStore: QuotaBadgeConfigStore,
+    // Which polarity (remaining/used) METERED quota badges render, from
+    // Settings. A supplier, like [widgetGraphs], so unit tests stay store-free.
+    private val barMode: suspend () -> QuotaBarMode = { QuotaBarMode.REMAINING },
     private val pollIntervalMs: Long = POLL_INTERVAL_MS,
     private val sseHealthyPollIntervalMs: Long = SSE_HEALTHY_POLL_INTERVAL_MS,
     private val trafficPollMs: Long = TRAFFIC_POLL_MS,
@@ -415,6 +439,12 @@ class DashboardViewModel(
         when (val result = client.members(fdUrl, token)) {
             is FetchResult.Success -> {
                 val autoSync = client.autoSync(fdUrl, token) as? FetchResult.Success
+                // One quota read feeds both surfaces this refresh needs: the
+                // MAIN-ordered list for the dashboard's own badge row, and the
+                // WIDGET-ordered list threaded into this refresh's widget mirror
+                // below (omitting it there used to blank the widget's badges on
+                // every foreground poll tick).
+                val quotaFetch = fetchQuota(token)
                 val liveIds = result.data.mapTo(HashSet()) { it.id }
                 // Each card's pill shows that member's newest event. Front Desk
                 // attaches it inline on the members read (newestEvent), so the common
@@ -477,6 +507,9 @@ class DashboardViewModel(
                         recentEvents = it.recentEvents.filterKeys { id -> id in liveIds } + recentMap,
                         error = null,
                         revoked = false,
+                        // Stale beats blank: a failed quota read keeps the last-good
+                        // list rather than blanking the badge row.
+                        quota = quotaFetch.first ?: it.quota,
                         // Reconcile the pause/resume control: drop the optimistic hint
                         // once it's resolved. Either a live read shows the toggle
                         // caught up (so a change made elsewhere isn't masked by it), or
@@ -510,7 +543,13 @@ class DashboardViewModel(
                         emptyMap()
                     }
                 if (widgetStore.saveIfChanged(
-                        widgetStateOf(result.data, autosyncStale, now(), widgetTraffic),
+                        // quotaFetch.second is already the WIDGET-ordered/capped
+                        // badge list (or, on a failed quota read, the store's
+                        // last-good one) -- the fix for the widget-blanking bug:
+                        // this trailing arg used to be omitted, so every dashboard
+                        // foreground poll tick defaulted it to emptyList() and wiped
+                        // whatever the background poll had written.
+                        widgetStateOf(result.data, autosyncStale, now(), widgetTraffic, quotaFetch.second),
                         widgetGeneration,
                     )
                 ) {
@@ -521,6 +560,73 @@ class DashboardViewModel(
                 _state.update { it.copy(loading = false, revoked = true) }
             is FetchResult.Failure ->
                 _state.update { it.copy(loading = false, error = result.message) }
+        }
+    }
+
+    /**
+     * fetchQuota fetches Front Desk's quota/balance readings once and derives
+     * both surfaces' badge lists off that single read (mirrors the shape of
+     * [com.hugalafutro.bellhop.work.pollFleet]'s quota handling): the
+     * MAIN-ordered list ready for [DashboardUiState.quota], and the
+     * WIDGET-ordered, capped, pre-labeled list ready for [widgetStateOf]'s
+     * trailing quota arg. Both surfaces' [QuotaBadgeConfigStore] entries are
+     * reconciled against the fresh provider names so newly-seen providers get
+     * folded in exactly once per refresh. A failed read returns a null MAIN
+     * list (caller keeps its own last-good one, stale beats blank) and falls
+     * back to the widget store's own last-good badges for the WIDGET side.
+     */
+    private suspend fun fetchQuota(token: String): Pair<List<ProviderQuota>?, List<WidgetQuotaBadge>> =
+        when (val q = client.quota(fdUrl, token)) {
+            is FetchResult.Success -> {
+                val names = q.data.map { it.providerName }
+                configStore.reconcile(QuotaSurface.MAIN, names)
+                configStore.reconcile(QuotaSurface.WIDGET, names)
+                val main = orderedVisible(configStore.config(QuotaSurface.MAIN).first(), q.data)
+                val widget = widgetQuotaOf(q.data, configStore.config(QuotaSurface.WIDGET).first(), barMode())
+                main to widget
+            }
+            else -> null to widgetStore.read()?.quota.orEmpty()
+        }
+
+    /**
+     * refreshQuota is the badge row's manual refresh: tells Front Desk to
+     * re-poll every quota-capable provider right now (POST /api/quota/refresh,
+     * monitor tier -- any paired device may trigger it), then re-reads via
+     * [refreshOnce] so the badges repaint from the fresh [com.hugalafutro.bellhop.data.QuotaEnvelope],
+     * not from the refresh call's own tally. Guarded like the other action
+     * methods against a concurrent tap; [DashboardUiState.refreshingQuota]
+     * flips back off in the `finally` so a request that throws still clears
+     * the spinner.
+     */
+    fun refreshQuota() {
+        if (_state.value.refreshingQuota) return
+        viewModelScope.launch {
+            _state.update { it.copy(refreshingQuota = true) }
+            try {
+                val token = linkStore.token()
+                if (token == null) {
+                    _state.update { it.copy(revoked = true) }
+                    return@launch
+                }
+                when (client.refreshQuota(fdUrl, token)) {
+                    ActionResult.Unauthorized ->
+                        _state.update { it.copy(revoked = true) }
+                    // Quota refresh is monitor tier -- any paired device may
+                    // trigger it -- so Forbidden should never happen; treat it
+                    // as a no-op rather than an error if a stricter Front Desk
+                    // ever returns it, same stance the brief calls for.
+                    ActionResult.Forbidden -> Unit
+                    is ActionResult.Success -> Unit
+                    is ActionResult.Failure -> Unit
+                }
+                // Re-read regardless of the refresh call's own outcome: a
+                // Forbidden/Failure still re-reads (a no-op re-read of the
+                // existing cache is harmless), and a Success's badges only
+                // land via this same re-read path, never off the tally.
+                refreshOnce()
+            } finally {
+                _state.update { it.copy(refreshingQuota = false) }
+            }
         }
     }
 
@@ -585,10 +691,21 @@ class DashboardViewModel(
         private val widgetStore: WidgetStore,
         private val onWidgetWritten: suspend () -> Unit = {},
         private val widgetGraphs: suspend () -> Boolean = { false },
+        private val configStore: QuotaBadgeConfigStore,
+        private val barMode: suspend () -> QuotaBarMode = { QuotaBarMode.REMAINING },
     ) : ViewModelProvider.Factory {
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>): T =
-            DashboardViewModel(client, linkStore, fdUrl, widgetStore, onWidgetWritten, widgetGraphs) as T
+            DashboardViewModel(
+                client,
+                linkStore,
+                fdUrl,
+                widgetStore,
+                onWidgetWritten,
+                widgetGraphs,
+                configStore,
+                barMode,
+            ) as T
     }
 
     companion object {

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModel.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModel.kt
@@ -76,6 +76,11 @@ data class DashboardUiState(
     // quota read keeps the last-good list (stale beats blank), same stance as
     // [members].
     val quota: List<ProviderQuota> = emptyList(),
+    // The full unfiltered quota set keyed by provider name, for resolving a
+    // tapped badge's detail sheet regardless of surface visibility: a widget
+    // deep-link can name a provider hidden on the dashboard, which is absent
+    // from [quota] (the MAIN-filtered row) but present here. Stale-kept too.
+    val quotaByName: Map<String, ProviderQuota> = emptyMap(),
     // Whether a manual [DashboardViewModel.refreshQuota] call is in flight, so
     // the badge row can show a spinner and the trigger can debounce a double-tap.
     val refreshingQuota: Boolean = false,
@@ -509,7 +514,8 @@ class DashboardViewModel(
                         revoked = false,
                         // Stale beats blank: a failed quota read keeps the last-good
                         // list rather than blanking the badge row.
-                        quota = quotaFetch.first ?: it.quota,
+                        quota = quotaFetch.main ?: it.quota,
+                        quotaByName = quotaFetch.all?.associateBy { pq -> pq.providerName } ?: it.quotaByName,
                         // Reconcile the pause/resume control: drop the optimistic hint
                         // once it's resolved. Either a live read shows the toggle
                         // caught up (so a change made elsewhere isn't masked by it), or
@@ -549,7 +555,7 @@ class DashboardViewModel(
                         // this trailing arg used to be omitted, so every dashboard
                         // foreground poll tick defaulted it to emptyList() and wiped
                         // whatever the background poll had written.
-                        widgetStateOf(result.data, autosyncStale, now(), widgetTraffic, quotaFetch.second),
+                        widgetStateOf(result.data, autosyncStale, now(), widgetTraffic, quotaFetch.widget),
                         widgetGeneration,
                     )
                 ) {
@@ -564,6 +570,18 @@ class DashboardViewModel(
     }
 
     /**
+     * QuotaFetch carries one quota read's three derivations: the MAIN-ordered
+     * dashboard row, the WIDGET-ordered/capped widget badges, and the full
+     * unfiltered set (for resolving any tapped badge, including a widget-only
+     * one). main/all are null on a failed read so the caller keeps last-good.
+     */
+    private data class QuotaFetch(
+        val main: List<ProviderQuota>?,
+        val widget: List<WidgetQuotaBadge>,
+        val all: List<ProviderQuota>?,
+    )
+
+    /**
      * fetchQuota fetches Front Desk's quota/balance readings once and derives
      * both surfaces' badge lists off that single read (mirrors the shape of
      * [com.hugalafutro.bellhop.work.pollFleet]'s quota handling): the
@@ -575,7 +593,8 @@ class DashboardViewModel(
      * list (caller keeps its own last-good one, stale beats blank) and falls
      * back to the widget store's own last-good badges for the WIDGET side.
      */
-    private suspend fun fetchQuota(token: String): Pair<List<ProviderQuota>?, List<WidgetQuotaBadge>> =
+
+    private suspend fun fetchQuota(token: String): QuotaFetch =
         when (val q = client.quota(fdUrl, token)) {
             is FetchResult.Success -> {
                 val names = q.data.map { it.providerName }
@@ -583,9 +602,9 @@ class DashboardViewModel(
                 configStore.reconcile(QuotaSurface.WIDGET, names)
                 val main = orderedVisible(configStore.config(QuotaSurface.MAIN).first(), q.data)
                 val widget = widgetQuotaOf(q.data, configStore.config(QuotaSurface.WIDGET).first(), barMode())
-                main to widget
+                QuotaFetch(main = main, widget = widget, all = q.data)
             }
-            else -> null to widgetStore.read()?.quota.orEmpty()
+            else -> QuotaFetch(main = null, widget = widgetStore.read()?.quota.orEmpty(), all = null)
         }
 
     /**

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModel.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModel.kt
@@ -84,6 +84,14 @@ data class DashboardUiState(
     // Whether a manual [DashboardViewModel.refreshQuota] call is in flight, so
     // the badge row can show a spinner and the trigger can debounce a double-tap.
     val refreshingQuota: Boolean = false,
+    // Why the last manual quota refresh failed (Front Desk answers 502 when it
+    // can't reach the primary member), or null when the last one ran. Kept apart
+    // from [error], which the members read owns and clears on its next success:
+    // the badge row repaints from the last-good readings either way, so without
+    // its own slot the failure would be wiped by the next poll tick and the tap
+    // would have looked exactly like a refresh that found no change. Cleared by
+    // the next successful quota read, so it can't outlive the problem.
+    val quotaRefreshError: String? = null,
 )
 
 /**
@@ -516,6 +524,9 @@ class DashboardViewModel(
                         // list rather than blanking the badge row.
                         quota = quotaFetch.main ?: it.quota,
                         quotaByName = quotaFetch.all?.associateBy { pq -> pq.providerName } ?: it.quotaByName,
+                        // A quota read that got through retires the stale
+                        // refresh-failed banner; a failing one leaves it up.
+                        quotaRefreshError = if (quotaFetch.main != null) null else it.quotaRefreshError,
                         // Reconcile the pause/resume control: drop the optimistic hint
                         // once it's resolved. Either a live read shows the toggle
                         // caught up (so a change made elsewhere isn't masked by it), or
@@ -615,34 +626,50 @@ class DashboardViewModel(
      * not from the refresh call's own tally. Guarded like the other action
      * methods against a concurrent tap; [DashboardUiState.refreshingQuota]
      * flips back off in the `finally` so a request that throws still clears
-     * the spinner.
+     * the spinner. A refresh Front Desk could not run (it answers 502 when the
+     * primary member is unreachable) lands in [DashboardUiState.quotaRefreshError]
+     * so the tap never passes for a successful one.
      */
     fun refreshQuota() {
         if (_state.value.refreshingQuota) return
         viewModelScope.launch {
-            _state.update { it.copy(refreshingQuota = true) }
+            // This tap's own outcome replaces the previous one's, so an old
+            // banner can't linger over a refresh that has since gone through.
+            _state.update { it.copy(refreshingQuota = true, quotaRefreshError = null) }
             try {
                 val token = linkStore.token()
                 if (token == null) {
                     _state.update { it.copy(revoked = true) }
                     return@launch
                 }
-                when (client.refreshQuota(fdUrl, token)) {
-                    ActionResult.Unauthorized ->
-                        _state.update { it.copy(revoked = true) }
-                    // Quota refresh is monitor tier -- any paired device may
-                    // trigger it -- so Forbidden should never happen; treat it
-                    // as a no-op rather than an error if a stricter Front Desk
-                    // ever returns it, same stance the brief calls for.
-                    ActionResult.Forbidden -> Unit
-                    is ActionResult.Success -> Unit
-                    is ActionResult.Failure -> Unit
-                }
+                val failure =
+                    when (val result = client.refreshQuota(fdUrl, token)) {
+                        ActionResult.Unauthorized -> {
+                            _state.update { it.copy(revoked = true) }
+                            null
+                        }
+                        // Quota refresh is monitor tier -- any paired device may
+                        // trigger it -- so Forbidden should never happen; treat it
+                        // as a no-op rather than an error if a stricter Front Desk
+                        // ever returns it, same stance the brief calls for.
+                        ActionResult.Forbidden -> null
+                        is ActionResult.Success -> null
+                        // Carried out of the `when` instead of being shown here:
+                        // the re-read below retires the banner whenever the quota
+                        // read gets through, which would wipe it immediately.
+                        is ActionResult.Failure -> result.message
+                    }
                 // Re-read regardless of the refresh call's own outcome: a
                 // Forbidden/Failure still re-reads (a no-op re-read of the
                 // existing cache is harmless), and a Success's badges only
                 // land via this same re-read path, never off the tally.
                 refreshOnce()
+                // Said out loud even when that re-read succeeded: Front Desk
+                // never ran the re-poll, so the badges are older than the tap
+                // implies.
+                if (failure != null) {
+                    _state.update { it.copy(quotaRefreshError = failure) }
+                }
             } finally {
                 _state.update { it.copy(refreshingQuota = false) }
             }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/QuotaBadges.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/QuotaBadges.kt
@@ -1,14 +1,15 @@
 package com.hugalafutro.bellhop.ui.dashboard
 
-import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
@@ -18,6 +19,7 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
@@ -27,21 +29,24 @@ import com.hugalafutro.bellhop.data.ProviderQuota
 import com.hugalafutro.bellhop.data.QuotaBarMode
 import com.hugalafutro.bellhop.data.QuotaData
 import com.hugalafutro.bellhop.data.quotaBadgeLabel
+import com.hugalafutro.bellhop.ui.theme.quotaBrandColor
 import java.util.Locale
 import kotlin.math.roundToInt
 
 /**
  * QuotaBadgeRow is the dashboard's quota-badge strip: one tappable chip per
  * [quota] entry, showing the same short label [quotaBadgeLabel] computes for
- * the widget, so the two surfaces never drift on what a badge says. Scrolls
- * horizontally rather than wrapping, so a long provider list stays a single
- * line above the member list. Renders nothing when [quota] is empty (no
+ * the widget, so the two surfaces never drift on what a badge says. Wraps onto
+ * as many lines as the selection needs rather than scrolling: everything the
+ * operator ticked in the configurator has to be visible without a gesture that
+ * nothing on screen advertises. Renders nothing when [quota] is empty (no
  * quota-capable providers configured) instead of an empty strip. A dead-key
  * entry ([ProviderQuota.available] == false) still renders and is still
  * tappable -- [onBadgeClick] carries [ProviderQuota.providerName] either
  * way -- because the detail sheet is what explains *why* it's unavailable;
  * swallowing the tap would strand the user looking at a bare "-".
  */
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun QuotaBadgeRow(
     quota: List<ProviderQuota>,
@@ -50,9 +55,13 @@ fun QuotaBadgeRow(
     modifier: Modifier = Modifier,
 ) {
     if (quota.isEmpty()) return
-    Row(
-        modifier = modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
+    FlowRow(
+        modifier = modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.spacedBy(8.dp),
+        // Tighter than the horizontal gap on purpose: each chip is a clickable
+        // Surface, so Material already reserves a 48dp touch target around it
+        // and a matching 8dp here reads as a hole between the lines.
+        verticalArrangement = Arrangement.spacedBy(2.dp),
     ) {
         quota.forEach { pq ->
             QuotaBadgeChip(pq = pq, mode = mode, onClick = { onBadgeClick(pq.providerName) })
@@ -63,9 +72,13 @@ fun QuotaBadgeRow(
 /**
  * QuotaBadgeChip is one badge: the provider's own name (badge identity is
  * always the wire's provider *name*, never its type or a list index -- see
- * global-constraints) plus [quotaBadgeLabel]'s short value. Availability
- * only changes the chip's tint (dimmed, matching a disabled-looking control)
- * -- it stays a live tap target either way.
+ * global-constraints) plus [quotaBadgeLabel]'s short value. The chip wears its
+ * provider's brand colour ([quotaBrandColor]) in the Model Hotel dashboard's
+ * own proportions -- tinted fill, brand text, brand outline -- so a strip of
+ * badges is scannable by colour rather than eight identical pills. An
+ * unavailable badge drops to the scheme's neutrals (matching a disabled-looking
+ * control) but stays a live tap target either way: the detail sheet is what
+ * explains the "-".
  */
 @Composable
 private fun QuotaBadgeChip(
@@ -74,14 +87,23 @@ private fun QuotaBadgeChip(
     onClick: () -> Unit,
 ) {
     val available = pq.available
-    val bg = if (available) MaterialTheme.colorScheme.secondaryContainer else MaterialTheme.colorScheme.surfaceVariant
-    val fg =
-        if (available) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurfaceVariant
+    // Read the scheme rather than isSystemInDarkTheme(): BellhopTheme takes
+    // darkTheme as a parameter, so the system flag can disagree with what is
+    // actually rendering (previews, tests, a future in-app theme switch).
+    val dark = MaterialTheme.colorScheme.surface.luminance() < 0.5f
+    val brand = quotaBrandColor(pq.type, dark)
+    // Alphas mirror the web pill (web/src/index.css .sidebar-quota-pill):
+    // 15% fill, 40% border, full-strength text.
+    val bg = if (available) brand.copy(alpha = 0.15f) else MaterialTheme.colorScheme.surfaceVariant
+    val fg = if (available) brand else MaterialTheme.colorScheme.onSurfaceVariant
+    val border =
+        if (available) brand.copy(alpha = 0.4f) else MaterialTheme.colorScheme.outline
     Surface(
         onClick = onClick,
         shape = MaterialTheme.shapes.large,
         color = bg,
         contentColor = fg,
+        border = BorderStroke(1.dp, border),
         modifier = Modifier.testTag("quota-badge-${pq.providerName}"),
     ) {
         Row(

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/QuotaBadges.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/QuotaBadges.kt
@@ -1,0 +1,293 @@
+package com.hugalafutro.bellhop.ui.dashboard
+
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.hugalafutro.bellhop.R
+import com.hugalafutro.bellhop.data.ProviderQuota
+import com.hugalafutro.bellhop.data.QuotaBarMode
+import com.hugalafutro.bellhop.data.QuotaData
+import com.hugalafutro.bellhop.data.quotaBadgeLabel
+import java.util.Locale
+
+/**
+ * QuotaBadgeRow is the dashboard's quota-badge strip: one tappable chip per
+ * [quota] entry, showing the same short label [quotaBadgeLabel] computes for
+ * the widget, so the two surfaces never drift on what a badge says. Scrolls
+ * horizontally rather than wrapping, so a long provider list stays a single
+ * line above the member list. Renders nothing when [quota] is empty (no
+ * quota-capable providers configured) instead of an empty strip. A dead-key
+ * entry ([ProviderQuota.available] == false) still renders and is still
+ * tappable -- [onBadgeClick] carries [ProviderQuota.providerName] either
+ * way -- because the detail sheet is what explains *why* it's unavailable;
+ * swallowing the tap would strand the user looking at a bare "-".
+ */
+@Composable
+fun QuotaBadgeRow(
+    quota: List<ProviderQuota>,
+    mode: QuotaBarMode,
+    onBadgeClick: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (quota.isEmpty()) return
+    Row(
+        modifier = modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        quota.forEach { pq ->
+            QuotaBadgeChip(pq = pq, mode = mode, onClick = { onBadgeClick(pq.providerName) })
+        }
+    }
+}
+
+/**
+ * QuotaBadgeChip is one badge: the provider's own name (badge identity is
+ * always the wire's provider *name*, never its type or a list index -- see
+ * global-constraints) plus [quotaBadgeLabel]'s short value. Availability
+ * only changes the chip's tint (dimmed, matching a disabled-looking control)
+ * -- it stays a live tap target either way.
+ */
+@Composable
+private fun QuotaBadgeChip(
+    pq: ProviderQuota,
+    mode: QuotaBarMode,
+    onClick: () -> Unit,
+) {
+    val available = pq.available
+    val bg = if (available) MaterialTheme.colorScheme.secondaryContainer else MaterialTheme.colorScheme.surfaceVariant
+    val fg =
+        if (available) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurfaceVariant
+    Surface(
+        onClick = onClick,
+        shape = MaterialTheme.shapes.large,
+        color = bg,
+        contentColor = fg,
+        modifier = Modifier.testTag("quota-badge-${pq.providerName}"),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),
+        ) {
+            Text(
+                text = pq.providerName,
+                style = MaterialTheme.typography.labelSmall,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                text = quotaBadgeLabel(pq, mode),
+                style = MaterialTheme.typography.labelMedium,
+            )
+        }
+    }
+}
+
+/**
+ * QuotaDetailSheet is the badge's tap target: [pq]'s full name, the same
+ * headline [quotaBadgeLabel] the chip shows (so the sheet never contradicts
+ * the badge that opened it), and a handful of per-type supporting rows --
+ * data/shape parity with the web dashboard's quota/balance modals
+ * (web/src/components/QuotaBadge.tsx + the web quota/balance modals), not a
+ * line-for-line port. An unavailable/payload-less quota ([ProviderQuota.data]
+ * null or [ProviderQuota.available] false) collapses to a short "unavailable"
+ * line instead of the supporting rows, mirroring the badge's own "-"
+ * fallback.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun QuotaDetailSheet(
+    pq: ProviderQuota,
+    mode: QuotaBarMode,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState()
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        modifier = Modifier.testTag("quota-detail-sheet"),
+    ) {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp)
+                    .padding(bottom = 24.dp),
+        ) {
+            Text(text = pq.providerName, style = MaterialTheme.typography.titleLarge)
+            Spacer(modifier = Modifier.height(8.dp))
+            val data = pq.data
+            if (!pq.available || data == null) {
+                Text(
+                    text = stringResource(R.string.quota_unavailable),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.testTag("quota-detail-unavailable"),
+                )
+            } else {
+                Text(
+                    text = quotaBadgeLabel(pq, mode),
+                    style = MaterialTheme.typography.headlineSmall,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+                QuotaDetailRows(data)
+            }
+        }
+    }
+}
+
+/** QuotaDetailRow is one label/value line in the detail sheet. */
+@Composable
+private fun QuotaDetailRow(
+    label: String,
+    value: String,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(text = value, style = MaterialTheme.typography.bodyMedium)
+    }
+}
+
+/**
+ * QuotaDetailRows dispatches on [data]'s variant to the per-type rows below.
+ * Each shows only the handful of fields the matching web modal (or, for the
+ * two types with no dedicated modal -- DeepSeek, Ollama Cloud -- the badge's
+ * own tooltip) actually surfaces; the headline above already carries the
+ * fraction/amount every type's badge shows, so these add context rather than
+ * repeating it.
+ */
+@Composable
+private fun QuotaDetailRows(data: QuotaData) {
+    val yes = stringResource(R.string.quota_yes)
+    val no = stringResource(R.string.quota_no)
+    when (data) {
+        is QuotaData.NanoGpt -> {
+            QuotaDetailRow(
+                stringResource(R.string.quota_field_status),
+                stringResource(if (data.active) R.string.quota_status_active else R.string.quota_status_inactive),
+            )
+            if (data.period.currentPeriodEnd.isNotBlank()) {
+                QuotaDetailRow(
+                    stringResource(R.string.quota_field_period_end),
+                    isoDatePart(data.period.currentPeriodEnd),
+                )
+            }
+            QuotaDetailRow(stringResource(R.string.quota_field_allow_overage), if (data.allowOverage) yes else no)
+        }
+        is QuotaData.ZaiCoding -> {
+            if (data.data.level.isNotBlank()) {
+                QuotaDetailRow(stringResource(R.string.quota_field_plan), data.data.level)
+            }
+        }
+        is QuotaData.KimiCode -> {
+            val level = data.user.membership.level
+            if (level.isNotBlank()) {
+                QuotaDetailRow(stringResource(R.string.quota_field_membership), level)
+            }
+            val parallel = data.parallel.limit
+            if (parallel.isNotBlank()) {
+                QuotaDetailRow(stringResource(R.string.quota_field_parallel_limit), parallel)
+            }
+            val total = data.totalQuota
+            if (total.remaining.isNotBlank() || total.limit.isNotBlank()) {
+                QuotaDetailRow(
+                    stringResource(R.string.quota_field_total_quota),
+                    "${total.remaining.ifBlank { "-" }}/${total.limit.ifBlank { "-" }}",
+                )
+            }
+        }
+        is QuotaData.MiniMax -> {
+            val general = data.modelRemains.find { it.modelName == "general" }
+            general?.let {
+                QuotaDetailRow(
+                    stringResource(R.string.quota_field_status),
+                    stringResource(
+                        if (it.currentIntervalStatus == 3) {
+                            R.string.quota_status_not_in_plan
+                        } else {
+                            R.string.quota_status_in_plan
+                        },
+                    ),
+                )
+            }
+        }
+        // DeepSeek has no dedicated web modal -- only the badge tooltip, which
+        // is exactly the headline above -- so no supporting rows.
+        is QuotaData.DeepSeek -> Unit
+        is QuotaData.OpenRouter -> {
+            if (data.creditsTotal > 0) {
+                QuotaDetailRow(stringResource(R.string.quota_field_credits_total), usd(data.creditsTotal))
+            }
+            QuotaDetailRow(stringResource(R.string.quota_field_credits_used), usd(data.creditsUsed))
+            QuotaDetailRow(stringResource(R.string.quota_field_usage_today), usd(data.usageDaily))
+            QuotaDetailRow(stringResource(R.string.quota_field_usage_month), usd(data.usageMonthly))
+            QuotaDetailRow(stringResource(R.string.quota_field_free_tier), if (data.isFreeTier) yes else no)
+        }
+        is QuotaData.OllamaCloud -> {
+            if (data.subscriptionPeriodEnd.valid) {
+                QuotaDetailRow(
+                    stringResource(R.string.quota_field_subscription_end),
+                    isoDatePart(data.subscriptionPeriodEnd.time),
+                )
+            }
+            if (data.suspendedAt.valid) {
+                QuotaDetailRow(stringResource(R.string.quota_field_suspended), isoDatePart(data.suspendedAt.time))
+            }
+        }
+        is QuotaData.NeuralWatt -> {
+            QuotaDetailRow(
+                stringResource(R.string.quota_field_balance_remaining),
+                usd(data.balance.creditsRemainingUsd),
+            )
+            if (data.balance.totalCreditsUsd > 0) {
+                QuotaDetailRow(stringResource(R.string.quota_field_balance_total), usd(data.balance.totalCreditsUsd))
+            }
+            if (data.subscription.plan.isNotBlank()) {
+                QuotaDetailRow(stringResource(R.string.quota_field_plan), data.subscription.plan)
+            }
+            if (data.subscription.status.isNotBlank()) {
+                QuotaDetailRow(stringResource(R.string.quota_field_status), data.subscription.status)
+            }
+        }
+    }
+}
+
+/** isoDatePart trims an RFC3339 timestamp to its date portion; a value that
+ * isn't RFC3339-shaped (no "T") is returned as-is rather than dropped, so a
+ * foreign format still shows something instead of going blank. */
+private fun isoDatePart(iso: String): String {
+    val t = iso.indexOf('T')
+    return if (t > 0) iso.substring(0, t) else iso
+}
+
+/** usd formats a dollar amount with a fixed Locale, mirroring
+ * [com.hugalafutro.bellhop.data]'s widget-facing formatters, so the sheet
+ * reads the same on every device regardless of the user's locale. */
+private fun usd(v: Double): String = "$" + String.format(Locale.US, "%.2f", v)

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/QuotaBadges.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/QuotaBadges.kt
@@ -28,6 +28,7 @@ import com.hugalafutro.bellhop.data.QuotaBarMode
 import com.hugalafutro.bellhop.data.QuotaData
 import com.hugalafutro.bellhop.data.quotaBadgeLabel
 import java.util.Locale
+import kotlin.math.roundToInt
 
 /**
  * QuotaBadgeRow is the dashboard's quota-badge strip: one tappable chip per
@@ -200,10 +201,29 @@ private fun QuotaDetailRows(data: QuotaData) {
                 )
             }
             QuotaDetailRow(stringResource(R.string.quota_field_allow_overage), if (data.allowOverage) yes else no)
+            data.dailyInputTokens?.let { info ->
+                QuotaDetailRow(
+                    stringResource(R.string.quota_field_daily_input_tokens),
+                    "${tokenAmount(info.used)}/${tokenAmount(data.limits.dailyInputTokens)}",
+                )
+            }
+            data.dailyImages?.let { info ->
+                QuotaDetailRow(
+                    stringResource(R.string.quota_field_daily_images),
+                    "${tokenAmount(info.used)}/${tokenAmount(data.limits.dailyImages)}",
+                )
+            }
         }
         is QuotaData.ZaiCoding -> {
             if (data.data.level.isNotBlank()) {
                 QuotaDetailRow(stringResource(R.string.quota_field_plan), data.data.level)
+            }
+            val mcpLimit = data.data.limits.find { it.type == "TIME_LIMIT" && it.unit == 5 }
+            mcpLimit?.let {
+                QuotaDetailRow(
+                    stringResource(R.string.quota_field_mcp_quota),
+                    "${it.percentage.roundToInt()}%",
+                )
             }
         }
         is QuotaData.KimiCode -> {
@@ -224,12 +244,11 @@ private fun QuotaDetailRows(data: QuotaData) {
             }
         }
         is QuotaData.MiniMax -> {
-            val general = data.modelRemains.find { it.modelName == "general" }
-            general?.let {
+            data.modelRemains.forEach { entry ->
                 QuotaDetailRow(
-                    stringResource(R.string.quota_field_status),
+                    entry.modelName,
                     stringResource(
-                        if (it.currentIntervalStatus == 3) {
+                        if (entry.currentIntervalStatus == 3) {
                             R.string.quota_status_not_in_plan
                         } else {
                             R.string.quota_status_in_plan
@@ -291,3 +310,8 @@ private fun isoDatePart(iso: String): String {
  * [com.hugalafutro.bellhop.data]'s widget-facing formatters, so the sheet
  * reads the same on every device regardless of the user's locale. */
 private fun usd(v: Double): String = "$" + String.format(Locale.US, "%.2f", v)
+
+/** tokenAmount formats a token/image count with locale-aware digit grouping;
+ * a null limit (no cap set) renders as "∞", mirroring the web modal's
+ * fallback for an unset per-period limit. */
+private fun tokenAmount(n: Long?): String = if (n == null) "∞" else String.format(Locale.US, "%,d", n)

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/settings/QuotaBadgesConfigScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/settings/QuotaBadgesConfigScreen.kt
@@ -1,0 +1,266 @@
+package com.hugalafutro.bellhop.ui.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Card
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.hugalafutro.bellhop.R
+import com.hugalafutro.bellhop.data.PrefsStore
+import com.hugalafutro.bellhop.data.QuotaBadgeConfig
+import com.hugalafutro.bellhop.data.QuotaBadgeConfigStore
+import com.hugalafutro.bellhop.data.QuotaBarMode
+import com.hugalafutro.bellhop.data.QuotaSurface
+import com.hugalafutro.bellhop.data.WIDGET_QUOTA_CAP
+import com.hugalafutro.bellhop.ui.common.FilterPill
+import com.hugalafutro.bellhop.ui.common.ReorderableColumn
+import com.hugalafutro.bellhop.ui.common.bellhopSwitchColors
+import com.hugalafutro.bellhop.ui.common.moveItem
+import com.hugalafutro.bellhop.ui.theme.BellhopTheme
+import kotlinx.coroutines.launch
+
+/**
+ * QuotaBadgesConfigScreen lets the user reorder and hide quota badges
+ * independently for the two surfaces that render them -- the dashboard strip
+ * and the home-screen widget -- plus one global remaining/used mode that
+ * governs the label both surfaces show for METERED providers
+ * ([PrefsStore.quotaBarMode], NOT per-surface: see the task's ADDENDUM).
+ *
+ * Unlike the other settings screens, this one owns its store writes
+ * directly rather than routing through a ViewModel + callbacks: [configStore]
+ * and [prefsStore] are read live via `collectAsState` and every mutation
+ * (`setOrder`, `setVisible`, `setQuotaBarMode`) is fired from a
+ * [rememberCoroutineScope] launch, since there is no other state here that
+ * needs a ViewModel's lifecycle-scoped coordination.
+ *
+ * Each [QuotaSurface] tab shows its own [QuotaBadgeConfig.order] as a
+ * [ReorderableColumn] of rows, each with a visibility [Switch] bound to
+ * [QuotaBadgeConfig.hidden]. Badge identity is always the provider **name**
+ * (see global-constraints) -- never type or index. An empty order (no
+ * quota-capable providers reconciled into this surface yet) renders a short
+ * empty-state line instead of an empty list.
+ */
+@Composable
+fun QuotaBadgesConfigScreen(
+    configStore: QuotaBadgeConfigStore,
+    prefsStore: PrefsStore,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val scope = rememberCoroutineScope()
+    var surface by remember { mutableStateOf(QuotaSurface.MAIN) }
+
+    // configStore.config(surface) builds a fresh Flow wrapper each call, so it's
+    // remembered per-surface -- otherwise an unrelated recomposition would swap
+    // the collected Flow's identity and force collectAsState to resubscribe.
+    val configFlow = remember(configStore, surface) { configStore.config(surface) }
+    val config by configFlow.collectAsState(initial = QuotaBadgeConfig())
+    val mode by prefsStore.quotaBarMode.collectAsState(initial = QuotaBarMode.REMAINING)
+
+    Scaffold(modifier = modifier.fillMaxSize()) { innerPadding ->
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding)
+                    .padding(horizontal = 16.dp),
+        ) {
+            Spacer(modifier = Modifier.height(8.dp))
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
+            ) {
+                IconButton(onClick = onBack, modifier = Modifier.testTag("quota-config-back")) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = stringResource(R.string.quota_config_back),
+                    )
+                }
+                Text(
+                    text = stringResource(R.string.quota_config_title),
+                    style = MaterialTheme.typography.titleLarge,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.weight(1f).testTag("quota-config-title"),
+                )
+            }
+
+            ModeToggleRow(
+                mode = mode,
+                onSelect = { selected -> scope.launch { prefsStore.setQuotaBarMode(selected) } },
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            SurfaceTabsRow(surface = surface, onSelect = { surface = it })
+
+            if (surface == QuotaSurface.WIDGET) {
+                val visibleCount = config.order.count { it !in config.hidden }
+                Text(
+                    text = stringResource(R.string.quota_config_widget_cap, visibleCount, WIDGET_QUOTA_CAP),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(top = 8.dp).testTag("quota-config-widget-cap"),
+                )
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            if (config.order.isEmpty()) {
+                Text(
+                    text = stringResource(R.string.quota_config_empty),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(top = 8.dp).testTag("quota-config-empty"),
+                )
+            } else {
+                ReorderableColumn(
+                    items = config.order,
+                    onMove = { from, to ->
+                        scope.launch { configStore.setOrder(surface, moveItem(config.order, from, to)) }
+                    },
+                    modifier = Modifier.fillMaxWidth().weight(1f),
+                ) { name ->
+                    BadgeRow(
+                        name = name,
+                        visible = name !in config.hidden,
+                        onVisibleChange = { checked ->
+                            scope.launch { configStore.setVisible(surface, name, checked) }
+                        },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ModeToggleRow(
+    mode: QuotaBarMode,
+    onSelect: (QuotaBarMode) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Card(modifier = modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text(
+                text = stringResource(R.string.quota_config_mode_title),
+                style = MaterialTheme.typography.titleMedium,
+            )
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                modifier = Modifier.fillMaxWidth().testTag("quota-mode-toggle"),
+            ) {
+                FilterPill(
+                    text = stringResource(R.string.quota_config_mode_remaining),
+                    selected = mode == QuotaBarMode.REMAINING,
+                    onClick = { onSelect(QuotaBarMode.REMAINING) },
+                    tag = "quota-mode-remaining",
+                    modifier = Modifier.weight(1f),
+                    borderColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                FilterPill(
+                    text = stringResource(R.string.quota_config_mode_used),
+                    selected = mode == QuotaBarMode.USED,
+                    onClick = { onSelect(QuotaBarMode.USED) },
+                    tag = "quota-mode-used",
+                    modifier = Modifier.weight(1f),
+                    borderColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SurfaceTabsRow(
+    surface: QuotaSurface,
+    onSelect: (QuotaSurface) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        FilterPill(
+            text = stringResource(R.string.quota_config_tab_main),
+            selected = surface == QuotaSurface.MAIN,
+            onClick = { onSelect(QuotaSurface.MAIN) },
+            tag = "quota-config-tab-main",
+            modifier = Modifier.weight(1f),
+        )
+        FilterPill(
+            text = stringResource(R.string.quota_config_tab_widget),
+            selected = surface == QuotaSurface.WIDGET,
+            onClick = { onSelect(QuotaSurface.WIDGET) },
+            tag = "quota-config-tab-widget",
+            modifier = Modifier.weight(1f),
+        )
+    }
+}
+
+@Composable
+private fun BadgeRow(
+    name: String,
+    visible: Boolean,
+    onVisibleChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Card(modifier = modifier.fillMaxWidth().padding(vertical = 4.dp).testTag("quota-config-row-$name")) {
+        Row(
+            modifier = Modifier.padding(14.dp).fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            Text(
+                text = name,
+                style = MaterialTheme.typography.bodyMedium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f),
+            )
+            Switch(
+                checked = visible,
+                onCheckedChange = onVisibleChange,
+                colors = bellhopSwitchColors(),
+                modifier = Modifier.testTag("quota-config-visible-$name"),
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun QuotaBadgesConfigScreenPreview() {
+    BellhopTheme {
+        // Preview only: real usage always passes live stores.
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text("Quota badges preview needs live stores")
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/settings/QuotaBadgesConfigScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/settings/QuotaBadgesConfigScreen.kt
@@ -120,10 +120,14 @@ fun QuotaBadgesConfigScreen(
 
             SurfaceTabsRow(surface = surface, onSelect = { surface = it })
 
-            if (surface == QuotaSurface.WIDGET) {
-                val visibleCount = config.order.count { it !in config.hidden }
+            // The widget wraps its badges onto several lines, so a selection that
+            // fits needs no commentary at all -- the old "N of 6" line read as a
+            // limit being enforced even when nothing was being dropped. Speak up
+            // only when the selection genuinely outruns WIDGET_QUOTA_CAP.
+            val visibleCount = config.order.count { it !in config.hidden }
+            if (surface == QuotaSurface.WIDGET && visibleCount > WIDGET_QUOTA_CAP) {
                 Text(
-                    text = stringResource(R.string.quota_config_widget_cap, visibleCount, WIDGET_QUOTA_CAP),
+                    text = stringResource(R.string.quota_config_widget_cap, WIDGET_QUOTA_CAP),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.padding(top = 8.dp).testTag("quota-config-widget-cap"),

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreen.kt
@@ -87,6 +87,7 @@ fun SettingsScreen(
     onToggleMonitor: (Boolean) -> Unit,
     onTogglePush: (Boolean) -> Unit,
     onAlertsClick: () -> Unit,
+    onQuotaBadgesClick: () -> Unit,
     onUnlink: () -> Unit,
     modifier: Modifier = Modifier,
     notificationsBlocked: Boolean = false,
@@ -680,6 +681,35 @@ fun SettingsScreen(
             // only appears when a member is down). The severity badges tally what
             // Front Desk currently alerts on; the brass chevron marks the tap as a
             // jump to the Alerts screen (where an operator can flip them).
+            Card(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .clickable(onClick = onQuotaBadgesClick)
+                        .testTag("settings-quota-badges"),
+            ) {
+                Row(
+                    modifier = Modifier.padding(16.dp).fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                        Text(
+                            text = stringResource(R.string.settings_quota_badges_title),
+                            style = MaterialTheme.typography.titleMedium,
+                        )
+                        Text(
+                            text = stringResource(R.string.settings_quota_badges_subtitle),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                    NavChevron(
+                        contentDescription = stringResource(R.string.settings_quota_badges_title),
+                        tag = "nav-chevron-quota",
+                    )
+                }
+            }
             Card(modifier = Modifier.fillMaxWidth().clickable(onClick = onAlertsClick).testTag("settings-alerts")) {
                 Row(
                     modifier = Modifier.padding(16.dp).fillMaxWidth(),
@@ -869,6 +899,7 @@ private fun SettingsScreenPreview() {
             onToggleMonitor = {},
             onTogglePush = {},
             onAlertsClick = {},
+            onQuotaBadgesClick = {},
             onUnlink = {},
         )
     }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreen.kt
@@ -318,9 +318,18 @@ fun SettingsScreen(
 
             // Copy gesture: whether a tap or a long-press copies a log/member cell.
             // Hold (the default) guards against stray copies while scrolling a list.
+            //
+            // The 12dp arrangement on this row and the switch rows below it is
+            // load-bearing: the label Column takes every pixel the switch leaves,
+            // so without a gap a subtitle that fills its line ends up touching
+            // the toggle. Same 12dp the nav cards further down put between their
+            // text and chevron.
             Card(modifier = Modifier.fillMaxWidth()) {
                 Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                    Row(verticalAlignment = Alignment.CenterVertically) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
                         Column(modifier = Modifier.weight(1f)) {
                             Text(
                                 text = stringResource(R.string.settings_hold_copy_title),
@@ -351,7 +360,10 @@ fun SettingsScreen(
             // background check; the widget itself still never polls.
             Card(modifier = Modifier.fillMaxWidth()) {
                 Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                    Row(verticalAlignment = Alignment.CenterVertically) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
                         Column(modifier = Modifier.weight(1f)) {
                             Text(
                                 text = stringResource(R.string.settings_widget_title),
@@ -416,7 +428,10 @@ fun SettingsScreen(
             // App lock: on/off plus the idle window it measures from foreground exit.
             Card(modifier = Modifier.fillMaxWidth()) {
                 Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                    Row(verticalAlignment = Alignment.CenterVertically) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
                         Column(modifier = Modifier.weight(1f)) {
                             Text(
                                 text = stringResource(R.string.settings_lock_title),
@@ -487,7 +502,10 @@ fun SettingsScreen(
             // for the notification permission.
             Card(modifier = Modifier.fillMaxWidth()) {
                 Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                    Row(verticalAlignment = Alignment.CenterVertically) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
                         Column(modifier = Modifier.weight(1f)) {
                             Text(
                                 text = stringResource(R.string.settings_monitor_title),
@@ -538,7 +556,10 @@ fun SettingsScreen(
             // (on API 33+) prompts for the notification permission.
             Card(modifier = Modifier.fillMaxWidth()) {
                 Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                    Row(verticalAlignment = Alignment.CenterVertically) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
                         Column(modifier = Modifier.weight(1f)) {
                             Text(
                                 text = stringResource(R.string.settings_push_title),
@@ -710,6 +731,9 @@ fun SettingsScreen(
                     )
                 }
             }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
             Card(modifier = Modifier.fillMaxWidth().clickable(onClick = onAlertsClick).testTag("settings-alerts")) {
                 Row(
                     modifier = Modifier.padding(16.dp).fillMaxWidth(),

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/theme/QuotaBrand.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/theme/QuotaBrand.kt
@@ -1,0 +1,57 @@
+package com.hugalafutro.bellhop.ui.theme
+
+import androidx.compose.ui.graphics.Color
+import com.hugalafutro.bellhop.data.QuotaType
+
+/*
+ * Provider brand colours for quota badges, so a strip of badges reads as
+ * eight providers rather than eight identical pills. Values are lifted from
+ * the Model Hotel dashboard's sidebar quota pills
+ * (web/src/utils/providerBrands.ts + the .sidebar-quota-pill-* rules in
+ * web/src/index.css), including the web's own light-mode overrides: the near
+ * black brands (Z.ai, Kimi, Ollama Cloud) would vanish on the night scheme,
+ * so they lighten to the same grey the web uses there. Deliberately outside
+ * Color.kt: those are Bellhop's scheme roles, these are third-party brands
+ * that must not drift toward the palette.
+ */
+
+/** QuotaBrand is one provider's badge colour in each scheme (day = paper, night = ink). */
+data class QuotaBrand(
+    val day: Color,
+    val night: Color,
+)
+
+private val BrandNanoGpt = QuotaBrand(day = Color(0xFF0EA5B0), night = Color(0xFF0EA5B0))
+private val BrandMiniMax = QuotaBrand(day = Color(0xFFF23F5B), night = Color(0xFFF23F5B))
+private val BrandDeepSeek = QuotaBrand(day = Color(0xFF4D6BFE), night = Color(0xFF4D6BFE))
+private val BrandOpenRouter = QuotaBrand(day = Color(0xFF6366F1), night = Color(0xFF6366F1))
+private val BrandNeuralWatt = QuotaBrand(day = Color(0xFFAC4324), night = Color(0xFFAC4324))
+private val BrandZaiCoding = QuotaBrand(day = Color(0xFF2D2D2D), night = Color(0xFFC8C8C8))
+private val BrandKimiCode = QuotaBrand(day = Color(0xFF2D2D2D), night = Color(0xFFC8C8C8))
+private val BrandOllamaCloud = QuotaBrand(day = Color(0xFF3D3D3D), night = Color(0xFFC8C8C8))
+
+// UNKNOWN never reaches a badge (FrontDeskClient.quota drops unknown types
+// before they render), but the map is total so a future type added upstream
+// falls back to the scheme's own muted neutrals instead of failing to compile
+// or picking someone else's brand.
+private val BrandUnknown = QuotaBrand(day = PaperInkMuted, night = Ink300)
+
+/** quotaBrand returns [type]'s badge colours; see the file note for provenance. */
+fun quotaBrand(type: QuotaType): QuotaBrand =
+    when (type) {
+        QuotaType.NANOGPT -> BrandNanoGpt
+        QuotaType.ZAI_CODING -> BrandZaiCoding
+        QuotaType.KIMI_CODE -> BrandKimiCode
+        QuotaType.MINIMAX -> BrandMiniMax
+        QuotaType.DEEPSEEK -> BrandDeepSeek
+        QuotaType.OPENROUTER -> BrandOpenRouter
+        QuotaType.OLLAMA_CLOUD -> BrandOllamaCloud
+        QuotaType.NEURALWATT -> BrandNeuralWatt
+        QuotaType.UNKNOWN -> BrandUnknown
+    }
+
+/** quotaBrandColor picks [type]'s colour for the active scheme. */
+fun quotaBrandColor(
+    type: QuotaType,
+    dark: Boolean,
+): Color = quotaBrand(type).let { if (dark) it.night else it.day }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/widget/BellhopWidget.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/widget/BellhopWidget.kt
@@ -373,8 +373,12 @@ private fun WidgetContent(
                 // Column translates to a RemoteViews container capped at 10
                 // children, and per-row Spacers blew past it on a 3-member
                 // fleet (the children beyond the cap are silently dropped -
-                // the footer was the casualty). Worst case now: header + 5
-                // rows + pill + weight spacer + footer = 9.
+                // the footer was the casualty). Worst case now sits AT the cap:
+                // header + 5 rows + quota Row + weight spacer + event Column +
+                // footer = 10, no headroom. The quota Row holds all badges as
+                // ONE child (not one-per-badge), so raising WIDGET_QUOTA_CAP is
+                // free here - but adding any new top-level SECTION will silently
+                // drop a child; free a slot (nest a singleton) before doing so.
                 state.members.forEach { member ->
                     Box(
                         contentAlignment = Alignment.BottomStart,

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/widget/BellhopWidget.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/widget/BellhopWidget.kt
@@ -49,10 +49,12 @@ import com.hugalafutro.bellhop.data.LinkStore
 import com.hugalafutro.bellhop.data.MemberHealthState
 import com.hugalafutro.bellhop.data.MonitorStore
 import com.hugalafutro.bellhop.data.PrefsStore
+import com.hugalafutro.bellhop.data.QuotaType
 import com.hugalafutro.bellhop.data.TRAFFIC_BUCKETS
 import com.hugalafutro.bellhop.data.WidgetState
 import com.hugalafutro.bellhop.data.WidgetStore
 import com.hugalafutro.bellhop.data.countsOf
+import com.hugalafutro.bellhop.data.quotaBadgeRows
 import com.hugalafutro.bellhop.ui.theme.Brass300
 import com.hugalafutro.bellhop.ui.theme.Brass600
 import com.hugalafutro.bellhop.ui.theme.Ember300
@@ -65,6 +67,7 @@ import com.hugalafutro.bellhop.ui.theme.PaperInk
 import com.hugalafutro.bellhop.ui.theme.PaperInkMuted
 import com.hugalafutro.bellhop.ui.theme.SteelContainerDark
 import com.hugalafutro.bellhop.ui.theme.SteelContainerLight
+import com.hugalafutro.bellhop.ui.theme.quotaBrand
 import com.hugalafutro.bellhop.work.FleetPollWorker
 import kotlinx.coroutines.flow.first
 import java.time.Instant
@@ -200,6 +203,11 @@ private val DotUp = ColorProvider(day = Moss600, night = Moss300)
 private val DotDown = ColorProvider(day = Ember600, night = Ember300)
 private val DotDrained = ColorProvider(day = Brass600, night = Brass300)
 private val DotUnknown = ColorProvider(day = PaperInkMuted, night = Ink300)
+
+// Quota badges are the one place the widget shows third-party brand colors
+// rather than the app palette; quotaBrand is the shared source (ui/theme),
+// so the widget pill and the dashboard chip can never drift apart.
+private fun quotaBadgeColor(type: QuotaType) = quotaBrand(type).let { ColorProvider(day = it.day, night = it.night) }
 
 private fun dotColor(state: MemberHealthState) =
     when (state) {
@@ -374,11 +382,12 @@ private fun WidgetContent(
                 // children, and per-row Spacers blew past it on a 3-member
                 // fleet (the children beyond the cap are silently dropped -
                 // the footer was the casualty). Worst case now sits AT the cap:
-                // header + 5 rows + quota Row + weight spacer + event Column +
-                // footer = 10, no headroom. The quota Row holds all badges as
-                // ONE child (not one-per-badge), so raising WIDGET_QUOTA_CAP is
-                // free here - but adding any new top-level SECTION will silently
-                // drop a child; free a slot (nest a singleton) before doing so.
+                // header + 5 rows + quota Column + weight spacer + event Column
+                // + footer = 10, no headroom. The quota strip is ONE child
+                // whatever its badge count (its rows are children of its own
+                // nested Column), so raising WIDGET_QUOTA_CAP is free here -
+                // but adding any new top-level SECTION will silently drop a
+                // child; free a slot (nest a singleton) before doing so.
                 state.members.forEach { member ->
                     Box(
                         contentAlignment = Alignment.BottomStart,
@@ -423,28 +432,48 @@ private fun WidgetContent(
                 }
         }
         // One badge per configured provider, pre-ordered/filtered/capped by the
-        // poll layer (WIDGET_QUOTA_CAP). A single Row is one Glance child no
-        // matter how many badges it holds, keeping this section cheap against
-        // the 10-child cap the member rows above already have to mind.
+        // poll layer (WIDGET_QUOTA_CAP) and packed into lines by quotaBadgeRows
+        // -- Glance has no wrapping layout, so the rows are explicit. The whole
+        // strip is ONE child of the Column above (the badge rows are children
+        // of this nested Column, which has its own 10-child budget that
+        // WIDGET_QUOTA_MAX_ROWS keeps it well inside), so it stays cheap
+        // against the 10-child cap the member rows already have to mind.
         if (state != null && state.quota.isNotEmpty()) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = GlanceModifier.fillMaxWidth().padding(top = 4.dp),
-            ) {
-                state.quota.forEach { badge ->
-                    Box(
-                        modifier =
-                            GlanceModifier
-                                .padding(end = 4.dp)
-                                .background(ImageProvider(R.drawable.widget_pill_bg))
-                                .padding(horizontal = 6.dp, vertical = 2.dp)
-                                .clickable(actionStartActivityIntent(quotaBadgeIntent(context, badge.providerName))),
+            Column(modifier = GlanceModifier.fillMaxWidth().padding(top = 4.dp)) {
+                quotaBadgeRows(state.quota).forEach { row ->
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = GlanceModifier.fillMaxWidth().padding(bottom = 2.dp),
                     ) {
-                        Text(
-                            badge.label,
-                            style = TextStyle(color = TextMuted, fontSize = 9.sp, fontWeight = FontWeight.Medium),
-                            maxLines = 1,
-                        )
+                        row.forEach { badge ->
+                            Box(
+                                modifier =
+                                    GlanceModifier
+                                        .padding(end = 4.dp)
+                                        .background(ImageProvider(R.drawable.widget_pill_bg))
+                                        .padding(horizontal = 6.dp, vertical = 2.dp)
+                                        .clickable(
+                                            actionStartActivityIntent(
+                                                quotaBadgeIntent(context, badge.providerName),
+                                            ),
+                                        ),
+                            ) {
+                                Text(
+                                    badge.label,
+                                    style =
+                                        TextStyle(
+                                            // Provider brand colour, same source as the
+                                            // dashboard chips and the Model Hotel sidebar
+                                            // pills, so a strip of badges is scannable
+                                            // instead of eight identical pills.
+                                            color = quotaBadgeColor(badge.quotaType),
+                                            fontSize = 9.sp,
+                                            fontWeight = FontWeight.Medium,
+                                        ),
+                                    maxLines = 1,
+                                )
+                            }
+                        }
                     }
                 }
             }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/widget/BellhopWidget.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/widget/BellhopWidget.kt
@@ -1,6 +1,7 @@
 package com.hugalafutro.bellhop.widget
 
 import android.content.Context
+import android.content.Intent
 import android.text.format.DateFormat
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -69,6 +70,7 @@ import kotlinx.coroutines.flow.first
 import java.time.Instant
 import java.time.ZoneId
 import java.util.Date
+import androidx.glance.appwidget.action.actionStartActivity as actionStartActivityIntent
 
 /** BellhopWidgetReceiver is the manifest entry point; all logic is in [BellhopWidget]. */
 class BellhopWidgetReceiver : GlanceAppWidgetReceiver() {
@@ -155,6 +157,35 @@ class WidgetRefreshAction : ActionCallback {
         FleetPollWorker.runWidgetRefresh(context)
     }
 }
+
+// Deep-link contract for a quota badge tap (Task D4 owns the MainActivity
+// side: intent-filter + extra read). Top-level and public so both sides of
+// the contract share the literal instead of duplicating strings.
+const val ACTION_OPEN_QUOTA = "com.hugalafutro.bellhop.OPEN_QUOTA"
+const val EXTRA_BADGE_PROVIDER_NAME = "badge_provider_name"
+
+/**
+ * quotaBadgeIntent builds the explicit intent a quota badge tap fires: same
+ * destination and launch flags as the widget's default open-app tap
+ * (`actionStartActivity<MainActivity>()` below), plus the deep-link
+ * action/extra above so MainActivity can route straight to that provider's
+ * quota sheet. Extracted as a plain function (no Glance/Composable types) so
+ * it is unit-testable without a composition.
+ *
+ * Rendered via the aliased `actionStartActivityIntent` (`androidx.glance.
+ * appwidget.action.actionStartActivity(Intent, ...)`): the core-module
+ * `actionStartActivity` imported above only targets a ComponentName/Class
+ * and can't carry this Intent's custom action + extra.
+ */
+fun quotaBadgeIntent(
+    context: Context,
+    providerName: String,
+): Intent =
+    Intent(context, MainActivity::class.java).apply {
+        action = ACTION_OPEN_QUOTA
+        putExtra(EXTRA_BADGE_PROVIDER_NAME, providerName)
+        flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+    }
 
 // Day/night pairs off the app palette (ui/theme/Color.kt); Glance can't read
 // MaterialTheme, so the pairing is repeated here with the same named colors.
@@ -386,6 +417,33 @@ private fun WidgetContent(
                         }
                     }
                 }
+        }
+        // One badge per configured provider, pre-ordered/filtered/capped by the
+        // poll layer (WIDGET_QUOTA_CAP). A single Row is one Glance child no
+        // matter how many badges it holds, keeping this section cheap against
+        // the 10-child cap the member rows above already have to mind.
+        if (state != null && state.quota.isNotEmpty()) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = GlanceModifier.fillMaxWidth().padding(top = 4.dp),
+            ) {
+                state.quota.forEach { badge ->
+                    Box(
+                        modifier =
+                            GlanceModifier
+                                .padding(end = 4.dp)
+                                .background(ImageProvider(R.drawable.widget_pill_bg))
+                                .padding(horizontal = 6.dp, vertical = 2.dp)
+                                .clickable(actionStartActivityIntent(quotaBadgeIntent(context, badge.providerName))),
+                    ) {
+                        Text(
+                            badge.label,
+                            style = TextStyle(color = TextMuted, fontSize = 9.sp, fontWeight = FontWeight.Medium),
+                            maxLines = 1,
+                        )
+                    }
+                }
+            }
         }
         Spacer(GlanceModifier.defaultWeight())
         // Pinned above the footer rather than under the member rows, so a small

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/work/FleetPollWorker.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/work/FleetPollWorker.kt
@@ -22,9 +22,13 @@ import com.hugalafutro.bellhop.data.LinkState
 import com.hugalafutro.bellhop.data.LinkStore
 import com.hugalafutro.bellhop.data.MonitorStore
 import com.hugalafutro.bellhop.data.PrefsStore
+import com.hugalafutro.bellhop.data.QuotaBadgeConfigStore
+import com.hugalafutro.bellhop.data.QuotaBarMode
+import com.hugalafutro.bellhop.data.QuotaSurface
 import com.hugalafutro.bellhop.data.WidgetStore
 import com.hugalafutro.bellhop.data.diffAutoSync
 import com.hugalafutro.bellhop.data.diffFleet
+import com.hugalafutro.bellhop.data.widgetQuotaOf
 import com.hugalafutro.bellhop.data.widgetStateOf
 import com.hugalafutro.bellhop.notify.FleetNotifier
 import com.hugalafutro.bellhop.widget.BellhopWidget
@@ -90,7 +94,9 @@ suspend fun pollFleet(
     token: String,
     monitorStore: MonitorStore,
     widgetStore: WidgetStore,
+    configStore: QuotaBadgeConfigStore,
     includeTraffic: Boolean = false,
+    barMode: QuotaBarMode = QuotaBarMode.REMAINING,
     now: () -> Long = System::currentTimeMillis,
 ): PollResult {
     // Capture the session epoch before the fetch: if an unlink + re-enable churns
@@ -114,6 +120,17 @@ suspend fun pollFleet(
                     is FetchResult.Success -> autoSync.data.stale
                     else -> previous?.autosyncStale ?: false
                 }
+            // Fetch the fleet's quota once per poll (piggyback on this fetch, no
+            // extra polling cycle) and fold the widget-visible subset into the
+            // render model. Stale-beats-blank: a failed read keeps the last-good.
+            val quotaBadges =
+                when (val q = client.quota(fdUrl, token)) {
+                    is FetchResult.Success -> {
+                        configStore.reconcile(QuotaSurface.WIDGET, q.data.map { it.providerName })
+                        widgetQuotaOf(q.data, configStore.config(QuotaSurface.WIDGET).first(), barMode)
+                    }
+                    else -> widgetStore.read()?.quota.orEmpty()
+                }
             val alerts = diffFleet(previous, result.data) + listOfNotNull(diffAutoSync(previous, stale))
             monitorStore.saveSnapshot(FleetSnapshot.of(result.data, stale), epoch)
             // This poll already holds everything the home-screen widget renders;
@@ -129,7 +146,7 @@ suspend fun pollFleet(
                 } else {
                     emptyMap()
                 }
-            widgetStore.saveIfChanged(widgetStateOf(result.data, stale, now(), traffic), widgetGeneration)
+            widgetStore.saveIfChanged(widgetStateOf(result.data, stale, now(), traffic, quotaBadges), widgetGeneration)
             PollResult.Changed(alerts)
         }
         FetchResult.Unauthorized -> PollResult.Unauthorized
@@ -150,10 +167,12 @@ suspend fun runBackstop(
     linkStore: LinkStore,
     widgetStore: WidgetStore,
     client: FrontDeskClient,
+    configStore: QuotaBadgeConfigStore,
     canNotify: Boolean,
     notify: (FleetAlert) -> Unit,
     retryOnFailure: Boolean = true,
     includeTraffic: Boolean = false,
+    barMode: QuotaBarMode = QuotaBarMode.REMAINING,
 ): Result {
     // Neither layer active: nothing to do. A stale periodic run can outlive the
     // Layer-2 toggle, and a push-triggered one-shot can land just after Layer 3
@@ -171,7 +190,19 @@ suspend fun runBackstop(
     // foreground UI surfaces the revoke; the backstop just stops quietly.
     val token = linkStore.token() ?: return Result.success()
 
-    return when (val result = pollFleet(client, link.fdUrl, token, monitorStore, widgetStore, includeTraffic)) {
+    return when (
+        val result =
+            pollFleet(
+                client,
+                link.fdUrl,
+                token,
+                monitorStore,
+                widgetStore,
+                configStore,
+                includeTraffic = includeTraffic,
+                barMode = barMode,
+            )
+    ) {
         is PollResult.Changed -> {
             result.alerts.forEach(notify)
             Result.success()
@@ -203,7 +234,9 @@ suspend fun refreshWidgetOnly(
     linkStore: LinkStore,
     widgetStore: WidgetStore,
     client: FrontDeskClient,
+    configStore: QuotaBadgeConfigStore,
     includeTraffic: Boolean = false,
+    barMode: QuotaBarMode = QuotaBarMode.REMAINING,
     now: () -> Long = System::currentTimeMillis,
 ): Result {
     val link = linkStore.state.first()
@@ -218,13 +251,21 @@ suspend fun refreshWidgetOnly(
             (client.autoSync(link.fdUrl, token) as? FetchResult.Success)?.data?.stale
                 ?: widgetStore.read()?.autosyncStale
                 ?: false
+        val quotaBadges =
+            when (val q = client.quota(link.fdUrl, token)) {
+                is FetchResult.Success -> {
+                    configStore.reconcile(QuotaSurface.WIDGET, q.data.map { it.providerName })
+                    widgetQuotaOf(q.data, configStore.config(QuotaSurface.WIDGET).first(), barMode)
+                }
+                else -> widgetStore.read()?.quota.orEmpty()
+            }
         val traffic =
             if (includeTraffic) {
                 widgetTraffic(client, link.fdUrl, token, result.data, widgetStore)
             } else {
                 emptyMap()
             }
-        widgetStore.saveIfChanged(widgetStateOf(result.data, stale, now(), traffic), generation)
+        widgetStore.saveIfChanged(widgetStateOf(result.data, stale, now(), traffic, quotaBadges), generation)
     }
     return Result.success()
 }
@@ -246,7 +287,10 @@ class FleetPollWorker(
         val context = applicationContext
         // Opt-in widget traffic bars (Settings): both paths pass it through so
         // the bars stay as fresh as the health rows they overlay.
-        val includeTraffic = PrefsStore.create(context).widgetGraphs.first()
+        val prefs = PrefsStore.create(context)
+        val includeTraffic = prefs.widgetGraphs.first()
+        val barMode = prefs.quotaBarMode.first()
+        val configStore = QuotaBadgeConfigStore.create(context)
         // The widget refresh tap is a display-only one-shot: no monitor guards, no
         // notify, no alert baseline. It still re-renders the widget afterwards, the
         // same as a backstop run does below.
@@ -256,7 +300,9 @@ class FleetPollWorker(
                     LinkStore.create(context),
                     WidgetStore.create(context),
                     FrontDeskClient(),
+                    configStore,
                     includeTraffic,
+                    barMode,
                 )
             BellhopWidget.update(context)
             return result
@@ -267,12 +313,14 @@ class FleetPollWorker(
                 linkStore = LinkStore.create(context),
                 widgetStore = WidgetStore.create(context),
                 client = FrontDeskClient(),
+                configStore = configStore,
                 canNotify = FleetNotifier.canPost(context),
                 notify = { FleetNotifier.notify(context, it) },
                 // The push one-shot must not retry (see runBackstop): a backing-off
                 // one-shot would block later push wakes under the KEEP policy.
                 retryOnFailure = !inputData.getBoolean(KEY_ONESHOT, false),
                 includeTraffic = includeTraffic,
+                barMode = barMode,
             )
         // Re-render after every run: cheap no-op with no widget placed, and a
         // successful poll just wrote fresh WidgetStore state.

--- a/android/app/src/main/res/values-cs/strings.xml
+++ b/android/app/src/main/res/values-cs/strings.xml
@@ -276,4 +276,47 @@
     <string name="widget_event_header">Poslední událost flotily</string>
     <string name="settings_widget_title">Widget na ploše</string>
     <string name="settings_widget_graphs_subtitle">Grafy provozu: překryjí každého člena požadavky za poslední hodinu. Čerstvé sloupce stojí jeden požadavek na člena navíc při každé kontrole na pozadí.</string>
+
+    <string name="settings_quota_badges_title">Odznaky kvót</string>
+    <string name="settings_quota_badges_subtitle">Vyberte, které odznaky kvót poskytovatelů se zobrazí na dashboardu a ve widgetu, přeuspořádejte je a zvolte využité nebo zbývající.</string>
+
+    <!-- Quota badge detail sheet -->
+    <string name="quota_refresh">Obnovit kvóty</string>
+    <string name="quota_unavailable">Data o kvótě nejsou dostupná</string>
+    <string name="quota_yes">Ano</string>
+    <string name="quota_no">Ne</string>
+    <string name="quota_status_active">Aktivní</string>
+    <string name="quota_status_inactive">Neaktivní</string>
+    <string name="quota_status_in_plan">V plánu</string>
+    <string name="quota_status_not_in_plan">Mimo plán</string>
+    <string name="quota_field_status">Stav</string>
+    <string name="quota_field_plan">Plán</string>
+    <string name="quota_field_membership">Členství</string>
+    <string name="quota_field_period_end">Konec období</string>
+    <string name="quota_field_subscription_end">Konec předplatného</string>
+    <string name="quota_field_suspended">Pozastaveno</string>
+    <string name="quota_field_allow_overage">Povolit překročení</string>
+    <string name="quota_field_free_tier">Bezplatná úroveň</string>
+    <string name="quota_field_parallel_limit">Limit souběžných požadavků</string>
+    <string name="quota_field_total_quota">Celková kvóta</string>
+    <string name="quota_field_credits_total">Kredity celkem</string>
+    <string name="quota_field_credits_used">Využité kredity</string>
+    <string name="quota_field_usage_today">Využití dnes</string>
+    <string name="quota_field_usage_month">Využití tento měsíc</string>
+    <string name="quota_field_balance_remaining">Zbývající zůstatek</string>
+    <string name="quota_field_balance_total">Celkové kredity</string>
+    <string name="quota_field_daily_input_tokens">Denní vstupní tokeny</string>
+    <string name="quota_field_daily_images">Denní obrázky</string>
+    <string name="quota_field_mcp_quota">Kvóta MCP</string>
+
+    <!-- Quota badge configurator (dashboard + widget surfaces) -->
+    <string name="quota_config_title">Odznaky kvót</string>
+    <string name="quota_config_back">Zpět</string>
+    <string name="quota_config_tab_main">Dashboard</string>
+    <string name="quota_config_tab_widget">Widget</string>
+    <string name="quota_config_mode_title">Styl odznaku</string>
+    <string name="quota_config_mode_remaining">Zbývající</string>
+    <string name="quota_config_mode_used">Využité</string>
+    <string name="quota_config_empty">Zatím nejsou vidět žádní poskytovatelé s kvótou.</string>
+    <string name="quota_config_widget_cap">%1$d z %2$d zobrazeno na widgetu</string>
 </resources>

--- a/android/app/src/main/res/values-cs/strings.xml
+++ b/android/app/src/main/res/values-cs/strings.xml
@@ -318,5 +318,5 @@
     <string name="quota_config_mode_remaining">Zbývající</string>
     <string name="quota_config_mode_used">Využité</string>
     <string name="quota_config_empty">Zatím nejsou vidět žádní poskytovatelé s kvótou.</string>
-    <string name="quota_config_widget_cap">%1$d z %2$d zobrazeno na widgetu</string>
+    <string name="quota_config_widget_cap">Na widget se vejde jen prvních %1$d</string>
 </resources>

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -264,4 +264,47 @@
     <string name="widget_event_header">Letztes Flottenereignis</string>
     <string name="settings_widget_title">Startbildschirm-Widget</string>
     <string name="settings_widget_graphs_subtitle">Verkehrsgraphen: zeigen je Mitglied die Anfragen der letzten Stunde. Frische Balken kosten pro Hintergrundprüfung eine zusätzliche Anfrage je Mitglied.</string>
+
+    <string name="settings_quota_badges_title">Kontingent-Badges</string>
+    <string name="settings_quota_badges_subtitle">Wähle aus, welche Kontingent-Badges der Anbieter im Dashboard und im Widget angezeigt werden, ordne sie neu an und wähle verbraucht oder verbleibend.</string>
+
+    <!-- Quota badge detail sheet -->
+    <string name="quota_refresh">Kontingente aktualisieren</string>
+    <string name="quota_unavailable">Kontingentdaten nicht verfügbar</string>
+    <string name="quota_yes">Ja</string>
+    <string name="quota_no">Nein</string>
+    <string name="quota_status_active">Aktiv</string>
+    <string name="quota_status_inactive">Inaktiv</string>
+    <string name="quota_status_in_plan">Im Tarif enthalten</string>
+    <string name="quota_status_not_in_plan">Nicht im Tarif enthalten</string>
+    <string name="quota_field_status">Status</string>
+    <string name="quota_field_plan">Tarif</string>
+    <string name="quota_field_membership">Mitgliedschaft</string>
+    <string name="quota_field_period_end">Zeitraum endet</string>
+    <string name="quota_field_subscription_end">Abo endet</string>
+    <string name="quota_field_suspended">Gesperrt</string>
+    <string name="quota_field_allow_overage">Überschreitung erlauben</string>
+    <string name="quota_field_free_tier">Kostenlose Stufe</string>
+    <string name="quota_field_parallel_limit">Parallel-Limit</string>
+    <string name="quota_field_total_quota">Gesamtkontingent</string>
+    <string name="quota_field_credits_total">Guthaben gesamt</string>
+    <string name="quota_field_credits_used">Guthaben verbraucht</string>
+    <string name="quota_field_usage_today">Nutzung heute</string>
+    <string name="quota_field_usage_month">Nutzung diesen Monat</string>
+    <string name="quota_field_balance_remaining">Verbleibendes Guthaben</string>
+    <string name="quota_field_balance_total">Guthaben insgesamt</string>
+    <string name="quota_field_daily_input_tokens">Tägliche Eingabe-Tokens</string>
+    <string name="quota_field_daily_images">Tägliche Bilder</string>
+    <string name="quota_field_mcp_quota">MCP-Kontingent</string>
+
+    <!-- Quota badge configurator (dashboard + widget surfaces) -->
+    <string name="quota_config_title">Kontingent-Badges</string>
+    <string name="quota_config_back">Zurück</string>
+    <string name="quota_config_tab_main">Dashboard</string>
+    <string name="quota_config_tab_widget">Widget</string>
+    <string name="quota_config_mode_title">Badge-Stil</string>
+    <string name="quota_config_mode_remaining">Verbleibend</string>
+    <string name="quota_config_mode_used">Verbraucht</string>
+    <string name="quota_config_empty">Noch keine kontingentfähigen Anbieter gesehen.</string>
+    <string name="quota_config_widget_cap">%1$d von %2$d im Widget angezeigt</string>
 </resources>

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -306,5 +306,5 @@
     <string name="quota_config_mode_remaining">Verbleibend</string>
     <string name="quota_config_mode_used">Verbraucht</string>
     <string name="quota_config_empty">Noch keine kontingentfähigen Anbieter gesehen.</string>
-    <string name="quota_config_widget_cap">%1$d von %2$d im Widget angezeigt</string>
+    <string name="quota_config_widget_cap">Nur die ersten %1$d passen auf das Widget</string>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -264,4 +264,47 @@
     <string name="widget_event_header">Último evento de la flota</string>
     <string name="settings_widget_title">Widget de pantalla de inicio</string>
     <string name="settings_widget_graphs_subtitle">Gráficas de tráfico: muestran sobre cada miembro sus solicitudes de la última hora. Mantenerlas al día cuesta una solicitud extra por miembro en cada comprobación en segundo plano.</string>
+
+    <string name="settings_quota_badges_title">Insignias de cuota</string>
+    <string name="settings_quota_badges_subtitle">Elige qué insignias de cuota de proveedor se muestran en el dashboard y en el widget, reordénalas y elige usado o restante.</string>
+
+    <!-- Quota badge detail sheet -->
+    <string name="quota_refresh">Actualizar cuotas</string>
+    <string name="quota_unavailable">Datos de cuota no disponibles</string>
+    <string name="quota_yes">Sí</string>
+    <string name="quota_no">No</string>
+    <string name="quota_status_active">Activo</string>
+    <string name="quota_status_inactive">Inactivo</string>
+    <string name="quota_status_in_plan">En el plan</string>
+    <string name="quota_status_not_in_plan">Fuera del plan</string>
+    <string name="quota_field_status">Estado</string>
+    <string name="quota_field_plan">Plan</string>
+    <string name="quota_field_membership">Membresía</string>
+    <string name="quota_field_period_end">Fin del periodo</string>
+    <string name="quota_field_subscription_end">Fin de la suscripción</string>
+    <string name="quota_field_suspended">Suspendido</string>
+    <string name="quota_field_allow_overage">Permitir exceso</string>
+    <string name="quota_field_free_tier">Nivel gratuito</string>
+    <string name="quota_field_parallel_limit">Límite paralelo</string>
+    <string name="quota_field_total_quota">Cuota total</string>
+    <string name="quota_field_credits_total">Total de créditos</string>
+    <string name="quota_field_credits_used">Créditos usados</string>
+    <string name="quota_field_usage_today">Uso de hoy</string>
+    <string name="quota_field_usage_month">Uso de este mes</string>
+    <string name="quota_field_balance_remaining">Saldo restante</string>
+    <string name="quota_field_balance_total">Créditos totales</string>
+    <string name="quota_field_daily_input_tokens">Tokens de entrada diarios</string>
+    <string name="quota_field_daily_images">Imágenes diarias</string>
+    <string name="quota_field_mcp_quota">Cuota de MCP</string>
+
+    <!-- Quota badge configurator (dashboard + widget surfaces) -->
+    <string name="quota_config_title">Insignias de cuota</string>
+    <string name="quota_config_back">Atrás</string>
+    <string name="quota_config_tab_main">Panel</string>
+    <string name="quota_config_tab_widget">Widget</string>
+    <string name="quota_config_mode_title">Estilo de insignia</string>
+    <string name="quota_config_mode_remaining">Restante</string>
+    <string name="quota_config_mode_used">Usado</string>
+    <string name="quota_config_empty">Aún no se han detectado proveedores con cuota.</string>
+    <string name="quota_config_widget_cap">%1$d de %2$d mostrados en el widget</string>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -306,5 +306,5 @@
     <string name="quota_config_mode_remaining">Restante</string>
     <string name="quota_config_mode_used">Usado</string>
     <string name="quota_config_empty">Aún no se han detectado proveedores con cuota.</string>
-    <string name="quota_config_widget_cap">%1$d de %2$d mostrados en el widget</string>
+    <string name="quota_config_widget_cap">Solo los primeros %1$d caben en el widget</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -264,4 +264,47 @@
     <string name="widget_event_header">Dernier événement de la flotte</string>
     <string name="settings_widget_title">Widget d\'écran d\'accueil</string>
     <string name="settings_widget_graphs_subtitle">Graphiques de trafic : superposent à chaque membre ses requêtes de la dernière heure. Leur fraîcheur coûte une requête de plus par membre à chaque vérification en arrière-plan.</string>
+
+    <string name="settings_quota_badges_title">Badges de quota</string>
+    <string name="settings_quota_badges_subtitle">Choisissez les badges de quota des fournisseurs affichés sur le tableau de bord et le widget, réorganisez-les, et choisissez utilisé ou restant.</string>
+
+    <!-- Quota badge detail sheet -->
+    <string name="quota_refresh">Actualiser les quotas</string>
+    <string name="quota_unavailable">Données de quota indisponibles</string>
+    <string name="quota_yes">Oui</string>
+    <string name="quota_no">Non</string>
+    <string name="quota_status_active">Actif</string>
+    <string name="quota_status_inactive">Inactif</string>
+    <string name="quota_status_in_plan">Dans le forfait</string>
+    <string name="quota_status_not_in_plan">Hors forfait</string>
+    <string name="quota_field_status">Statut</string>
+    <string name="quota_field_plan">Forfait</string>
+    <string name="quota_field_membership">Adhésion</string>
+    <string name="quota_field_period_end">Fin de période</string>
+    <string name="quota_field_subscription_end">Fin d\'abonnement</string>
+    <string name="quota_field_suspended">Suspendu</string>
+    <string name="quota_field_allow_overage">Autoriser le dépassement</string>
+    <string name="quota_field_free_tier">Palier gratuit</string>
+    <string name="quota_field_parallel_limit">Limite parallèle</string>
+    <string name="quota_field_total_quota">Quota total</string>
+    <string name="quota_field_credits_total">Total des crédits</string>
+    <string name="quota_field_credits_used">Crédits utilisés</string>
+    <string name="quota_field_usage_today">Utilisation aujourd\'hui</string>
+    <string name="quota_field_usage_month">Utilisation ce mois-ci</string>
+    <string name="quota_field_balance_remaining">Solde restant</string>
+    <string name="quota_field_balance_total">Crédits totaux</string>
+    <string name="quota_field_daily_input_tokens">Jetons d\'entrée quotidiens</string>
+    <string name="quota_field_daily_images">Images quotidiennes</string>
+    <string name="quota_field_mcp_quota">Quota MCP</string>
+
+    <!-- Quota badge configurator (dashboard + widget surfaces) -->
+    <string name="quota_config_title">Badges de quota</string>
+    <string name="quota_config_back">Retour</string>
+    <string name="quota_config_tab_main">Tableau de bord</string>
+    <string name="quota_config_tab_widget">Widget</string>
+    <string name="quota_config_mode_title">Style de badge</string>
+    <string name="quota_config_mode_remaining">Restant</string>
+    <string name="quota_config_mode_used">Utilisé</string>
+    <string name="quota_config_empty">Aucun fournisseur compatible avec les quotas pour l\'instant.</string>
+    <string name="quota_config_widget_cap">%1$d sur %2$d affichés sur le widget</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -306,5 +306,5 @@
     <string name="quota_config_mode_remaining">Restant</string>
     <string name="quota_config_mode_used">Utilisé</string>
     <string name="quota_config_empty">Aucun fournisseur compatible avec les quotas pour l\'instant.</string>
-    <string name="quota_config_widget_cap">%1$d sur %2$d affichés sur le widget</string>
+    <string name="quota_config_widget_cap">Seuls les %1$d premiers tiennent sur le widget</string>
 </resources>

--- a/android/app/src/main/res/values-ja/strings.xml
+++ b/android/app/src/main/res/values-ja/strings.xml
@@ -300,5 +300,5 @@
     <string name="quota_config_mode_remaining">残量</string>
     <string name="quota_config_mode_used">使用量</string>
     <string name="quota_config_empty">クォータに対応するプロバイダーはまだありません。</string>
-    <string name="quota_config_widget_cap">ウィジェットに %2$d 件中 %1$d 件を表示</string>
+    <string name="quota_config_widget_cap">ウィジェットに収まるのは先頭の %1$d 件のみです</string>
 </resources>

--- a/android/app/src/main/res/values-ja/strings.xml
+++ b/android/app/src/main/res/values-ja/strings.xml
@@ -258,4 +258,47 @@
     <string name="widget_event_header">最新のフリートイベント</string>
     <string name="settings_widget_title">ホーム画面ウィジェット</string>
     <string name="settings_widget_graphs_subtitle">トラフィックグラフ: 各メンバーに直近1時間のリクエストを重ねて表示します。バックグラウンド確認ごとにメンバーあたり1リクエスト増えます。</string>
+
+    <string name="settings_quota_badges_title">クォータバッジ</string>
+    <string name="settings_quota_badges_subtitle">ダッシュボードとウィジェットに表示するプロバイダーのクォータバッジを選び、並べ替えて、使用量か残量かを選択します。</string>
+
+    <!-- Quota badge detail sheet -->
+    <string name="quota_refresh">クォータを更新</string>
+    <string name="quota_unavailable">クォータデータを利用できません</string>
+    <string name="quota_yes">はい</string>
+    <string name="quota_no">いいえ</string>
+    <string name="quota_status_active">有効</string>
+    <string name="quota_status_inactive">無効</string>
+    <string name="quota_status_in_plan">プランに含まれる</string>
+    <string name="quota_status_not_in_plan">プランに含まれない</string>
+    <string name="quota_field_status">ステータス</string>
+    <string name="quota_field_plan">プラン</string>
+    <string name="quota_field_membership">メンバーシップ</string>
+    <string name="quota_field_period_end">期間終了</string>
+    <string name="quota_field_subscription_end">サブスクリプション終了</string>
+    <string name="quota_field_suspended">停止中</string>
+    <string name="quota_field_allow_overage">超過を許可</string>
+    <string name="quota_field_free_tier">無料ティア</string>
+    <string name="quota_field_parallel_limit">並列実行数の上限</string>
+    <string name="quota_field_total_quota">合計クォータ</string>
+    <string name="quota_field_credits_total">クレジット合計</string>
+    <string name="quota_field_credits_used">使用済みクレジット</string>
+    <string name="quota_field_usage_today">本日の使用量</string>
+    <string name="quota_field_usage_month">今月の使用量</string>
+    <string name="quota_field_balance_remaining">残高</string>
+    <string name="quota_field_balance_total">クレジット総額</string>
+    <string name="quota_field_daily_input_tokens">1日あたりの入力トークン</string>
+    <string name="quota_field_daily_images">1日あたりの画像数</string>
+    <string name="quota_field_mcp_quota">MCP クォータ</string>
+
+    <!-- Quota badge configurator (dashboard + widget surfaces) -->
+    <string name="quota_config_title">クォータバッジ</string>
+    <string name="quota_config_back">戻る</string>
+    <string name="quota_config_tab_main">ダッシュボード</string>
+    <string name="quota_config_tab_widget">ウィジェット</string>
+    <string name="quota_config_mode_title">バッジのスタイル</string>
+    <string name="quota_config_mode_remaining">残量</string>
+    <string name="quota_config_mode_used">使用量</string>
+    <string name="quota_config_empty">クォータに対応するプロバイダーはまだありません。</string>
+    <string name="quota_config_widget_cap">ウィジェットに %2$d 件中 %1$d 件を表示</string>
 </resources>

--- a/android/app/src/main/res/values-nl/strings.xml
+++ b/android/app/src/main/res/values-nl/strings.xml
@@ -264,4 +264,47 @@
     <string name="widget_event_header">Laatste vlootgebeurtenis</string>
     <string name="settings_widget_title">Startscherm-widget</string>
     <string name="settings_widget_graphs_subtitle">Verkeersgrafieken: tonen per lid de verzoeken van het afgelopen uur. Verse balken kosten één extra verzoek per lid bij elke achtergrondcontrole.</string>
+
+    <string name="settings_quota_badges_title">Quotabadges</string>
+    <string name="settings_quota_badges_subtitle">Kies welke quotabadges van providers worden getoond op het dashboard en de widget, herschik ze en kies gebruikt of resterend.</string>
+
+    <!-- Quota badge detail sheet -->
+    <string name="quota_refresh">Quota\'s vernieuwen</string>
+    <string name="quota_unavailable">Quotagegevens niet beschikbaar</string>
+    <string name="quota_yes">Ja</string>
+    <string name="quota_no">Nee</string>
+    <string name="quota_status_active">Actief</string>
+    <string name="quota_status_inactive">Inactief</string>
+    <string name="quota_status_in_plan">In abonnement</string>
+    <string name="quota_status_not_in_plan">Niet in abonnement</string>
+    <string name="quota_field_status">Status</string>
+    <string name="quota_field_plan">Abonnement</string>
+    <string name="quota_field_membership">Lidmaatschap</string>
+    <string name="quota_field_period_end">Periode eindigt</string>
+    <string name="quota_field_subscription_end">Abonnement eindigt</string>
+    <string name="quota_field_suspended">Opgeschort</string>
+    <string name="quota_field_allow_overage">Overschrijding toestaan</string>
+    <string name="quota_field_free_tier">Gratis niveau</string>
+    <string name="quota_field_parallel_limit">Parallellimiet</string>
+    <string name="quota_field_total_quota">Totaalquota</string>
+    <string name="quota_field_credits_total">Credits totaal</string>
+    <string name="quota_field_credits_used">Credits gebruikt</string>
+    <string name="quota_field_usage_today">Gebruik vandaag</string>
+    <string name="quota_field_usage_month">Gebruik deze maand</string>
+    <string name="quota_field_balance_remaining">Resterend saldo</string>
+    <string name="quota_field_balance_total">Totaal credits</string>
+    <string name="quota_field_daily_input_tokens">Dagelijkse invoertokens</string>
+    <string name="quota_field_daily_images">Dagelijkse afbeeldingen</string>
+    <string name="quota_field_mcp_quota">MCP-quota</string>
+
+    <!-- Quota badge configurator (dashboard + widget surfaces) -->
+    <string name="quota_config_title">Quotabadges</string>
+    <string name="quota_config_back">Terug</string>
+    <string name="quota_config_tab_main">Dashboard</string>
+    <string name="quota_config_tab_widget">Widget</string>
+    <string name="quota_config_mode_title">Badgestijl</string>
+    <string name="quota_config_mode_remaining">Resterend</string>
+    <string name="quota_config_mode_used">Gebruikt</string>
+    <string name="quota_config_empty">Nog geen providers met quota gezien.</string>
+    <string name="quota_config_widget_cap">%1$d van %2$d getoond op de widget</string>
 </resources>

--- a/android/app/src/main/res/values-nl/strings.xml
+++ b/android/app/src/main/res/values-nl/strings.xml
@@ -306,5 +306,5 @@
     <string name="quota_config_mode_remaining">Resterend</string>
     <string name="quota_config_mode_used">Gebruikt</string>
     <string name="quota_config_empty">Nog geen providers met quota gezien.</string>
-    <string name="quota_config_widget_cap">%1$d van %2$d getoond op de widget</string>
+    <string name="quota_config_widget_cap">Alleen de eerste %1$d passen op de widget</string>
 </resources>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -318,5 +318,5 @@
     <string name="quota_config_mode_remaining">Pozostałe</string>
     <string name="quota_config_mode_used">Wykorzystane</string>
     <string name="quota_config_empty">Nie znaleziono jeszcze dostawców obsługujących limity.</string>
-    <string name="quota_config_widget_cap">%1$d z %2$d widocznych w widżecie</string>
+    <string name="quota_config_widget_cap">Na widżecie zmieści się tylko pierwszych %1$d</string>
 </resources>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -276,4 +276,47 @@
     <string name="widget_event_header">Ostatnie zdarzenie floty</string>
     <string name="settings_widget_title">Widżet ekranu głównego</string>
     <string name="settings_widget_graphs_subtitle">Wykresy ruchu: nakładają na każdy węzeł żądania z ostatniej godziny. Świeże słupki kosztują jedno dodatkowe żądanie na węzeł przy każdym sprawdzeniu w tle.</string>
+
+    <string name="settings_quota_badges_title">Odznaki limitów</string>
+    <string name="settings_quota_badges_subtitle">Wybierz, które odznaki limitów dostawców są widoczne na dashboardzie i w widżecie, zmień ich kolejność i wybierz wykorzystane lub pozostałe.</string>
+
+    <!-- Quota badge detail sheet -->
+    <string name="quota_refresh">Odśwież limity</string>
+    <string name="quota_unavailable">Dane limitu niedostępne</string>
+    <string name="quota_yes">Tak</string>
+    <string name="quota_no">Nie</string>
+    <string name="quota_status_active">Aktywny</string>
+    <string name="quota_status_inactive">Nieaktywny</string>
+    <string name="quota_status_in_plan">W planie</string>
+    <string name="quota_status_not_in_plan">Poza planem</string>
+    <string name="quota_field_status">Status</string>
+    <string name="quota_field_plan">Plan</string>
+    <string name="quota_field_membership">Członkostwo</string>
+    <string name="quota_field_period_end">Koniec okresu</string>
+    <string name="quota_field_subscription_end">Koniec subskrypcji</string>
+    <string name="quota_field_suspended">Zawieszony</string>
+    <string name="quota_field_allow_overage">Zezwól na przekroczenie</string>
+    <string name="quota_field_free_tier">Poziom darmowy</string>
+    <string name="quota_field_parallel_limit">Limit równoległy</string>
+    <string name="quota_field_total_quota">Łączny limit</string>
+    <string name="quota_field_credits_total">Kredyty łącznie</string>
+    <string name="quota_field_credits_used">Wykorzystane kredyty</string>
+    <string name="quota_field_usage_today">Zużycie dzisiaj</string>
+    <string name="quota_field_usage_month">Zużycie w tym miesiącu</string>
+    <string name="quota_field_balance_remaining">Pozostałe saldo</string>
+    <string name="quota_field_balance_total">Łączne kredyty</string>
+    <string name="quota_field_daily_input_tokens">Dzienne tokeny wejściowe</string>
+    <string name="quota_field_daily_images">Dzienne obrazy</string>
+    <string name="quota_field_mcp_quota">Limit MCP</string>
+
+    <!-- Quota badge configurator (dashboard + widget surfaces) -->
+    <string name="quota_config_title">Odznaki limitów</string>
+    <string name="quota_config_back">Wstecz</string>
+    <string name="quota_config_tab_main">Dashboard</string>
+    <string name="quota_config_tab_widget">Widżet</string>
+    <string name="quota_config_mode_title">Styl odznaki</string>
+    <string name="quota_config_mode_remaining">Pozostałe</string>
+    <string name="quota_config_mode_used">Wykorzystane</string>
+    <string name="quota_config_empty">Nie znaleziono jeszcze dostawców obsługujących limity.</string>
+    <string name="quota_config_widget_cap">%1$d z %2$d widocznych w widżecie</string>
 </resources>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -276,4 +276,47 @@
     <string name="widget_event_header">Последнее событие флота</string>
     <string name="settings_widget_title">Виджет главного экрана</string>
     <string name="settings_widget_graphs_subtitle">Графики трафика: показывают по каждому узлу запросы за последний час. Свежие столбцы стоят один дополнительный запрос на узел при каждой фоновой проверке.</string>
+
+    <string name="settings_quota_badges_title">Значки квот</string>
+    <string name="settings_quota_badges_subtitle">Выберите, какие значки квот поставщиков показывать на дашборде и в виджете, измените их порядок и выберите использовано или осталось.</string>
+
+    <!-- Quota badge detail sheet -->
+    <string name="quota_refresh">Обновить квоты</string>
+    <string name="quota_unavailable">Данные о квоте недоступны</string>
+    <string name="quota_yes">Да</string>
+    <string name="quota_no">Нет</string>
+    <string name="quota_status_active">Активно</string>
+    <string name="quota_status_inactive">Неактивно</string>
+    <string name="quota_status_in_plan">В плане</string>
+    <string name="quota_status_not_in_plan">Вне плана</string>
+    <string name="quota_field_status">Статус</string>
+    <string name="quota_field_plan">План</string>
+    <string name="quota_field_membership">Членство</string>
+    <string name="quota_field_period_end">Окончание периода</string>
+    <string name="quota_field_subscription_end">Окончание подписки</string>
+    <string name="quota_field_suspended">Приостановлено</string>
+    <string name="quota_field_allow_overage">Разрешить превышение</string>
+    <string name="quota_field_free_tier">Бесплатный уровень</string>
+    <string name="quota_field_parallel_limit">Лимит параллельных запросов</string>
+    <string name="quota_field_total_quota">Общая квота</string>
+    <string name="quota_field_credits_total">Кредиты всего</string>
+    <string name="quota_field_credits_used">Использовано кредитов</string>
+    <string name="quota_field_usage_today">Использование сегодня</string>
+    <string name="quota_field_usage_month">Использование в этом месяце</string>
+    <string name="quota_field_balance_remaining">Остаток баланса</string>
+    <string name="quota_field_balance_total">Всего кредитов</string>
+    <string name="quota_field_daily_input_tokens">Дневные входные токены</string>
+    <string name="quota_field_daily_images">Дневные изображения</string>
+    <string name="quota_field_mcp_quota">Квота MCP</string>
+
+    <!-- Quota badge configurator (dashboard + widget surfaces) -->
+    <string name="quota_config_title">Значки квот</string>
+    <string name="quota_config_back">Назад</string>
+    <string name="quota_config_tab_main">Дашборд</string>
+    <string name="quota_config_tab_widget">Виджет</string>
+    <string name="quota_config_mode_title">Стиль значка</string>
+    <string name="quota_config_mode_remaining">Осталось</string>
+    <string name="quota_config_mode_used">Использовано</string>
+    <string name="quota_config_empty">Провайдеры с поддержкой квот пока не найдены.</string>
+    <string name="quota_config_widget_cap">%1$d из %2$d показано в виджете</string>
 </resources>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -318,5 +318,5 @@
     <string name="quota_config_mode_remaining">Осталось</string>
     <string name="quota_config_mode_used">Использовано</string>
     <string name="quota_config_empty">Провайдеры с поддержкой квот пока не найдены.</string>
-    <string name="quota_config_widget_cap">%1$d из %2$d показано в виджете</string>
+    <string name="quota_config_widget_cap">В виджет помещаются только первые %1$d</string>
 </resources>

--- a/android/app/src/main/res/values-sk/strings.xml
+++ b/android/app/src/main/res/values-sk/strings.xml
@@ -276,4 +276,47 @@
     <string name="widget_event_header">Posledná udalosť flotily</string>
     <string name="settings_widget_title">Widget na ploche</string>
     <string name="settings_widget_graphs_subtitle">Grafy prevádzky: prekryjú každého člena požiadavkami za poslednú hodinu. Čerstvé stĺpce stoja jednu požiadavku na člena navyše pri každej kontrole na pozadí.</string>
+
+    <string name="settings_quota_badges_title">Odznaky kvót</string>
+    <string name="settings_quota_badges_subtitle">Vyberte, ktoré odznaky kvót poskytovateľov sa zobrazia na dashboarde a vo widgete, usporiadajte ich a zvoľte využité alebo zostávajúce.</string>
+
+    <!-- Quota badge detail sheet -->
+    <string name="quota_refresh">Obnoviť kvóty</string>
+    <string name="quota_unavailable">Údaje o kvóte nie sú dostupné</string>
+    <string name="quota_yes">Áno</string>
+    <string name="quota_no">Nie</string>
+    <string name="quota_status_active">Aktívne</string>
+    <string name="quota_status_inactive">Neaktívne</string>
+    <string name="quota_status_in_plan">V pláne</string>
+    <string name="quota_status_not_in_plan">Mimo plánu</string>
+    <string name="quota_field_status">Stav</string>
+    <string name="quota_field_plan">Plán</string>
+    <string name="quota_field_membership">Členstvo</string>
+    <string name="quota_field_period_end">Koniec obdobia</string>
+    <string name="quota_field_subscription_end">Koniec predplatného</string>
+    <string name="quota_field_suspended">Pozastavené</string>
+    <string name="quota_field_allow_overage">Povoliť prekročenie</string>
+    <string name="quota_field_free_tier">Bezplatná úroveň</string>
+    <string name="quota_field_parallel_limit">Limit súbežných požiadaviek</string>
+    <string name="quota_field_total_quota">Celková kvóta</string>
+    <string name="quota_field_credits_total">Kredity spolu</string>
+    <string name="quota_field_credits_used">Využité kredity</string>
+    <string name="quota_field_usage_today">Využitie dnes</string>
+    <string name="quota_field_usage_month">Využitie tento mesiac</string>
+    <string name="quota_field_balance_remaining">Zostávajúci zostatok</string>
+    <string name="quota_field_balance_total">Celkové kredity</string>
+    <string name="quota_field_daily_input_tokens">Denné vstupné tokeny</string>
+    <string name="quota_field_daily_images">Denné obrázky</string>
+    <string name="quota_field_mcp_quota">Kvóta MCP</string>
+
+    <!-- Quota badge configurator (dashboard + widget surfaces) -->
+    <string name="quota_config_title">Odznaky kvót</string>
+    <string name="quota_config_back">Späť</string>
+    <string name="quota_config_tab_main">Dashboard</string>
+    <string name="quota_config_tab_widget">Widget</string>
+    <string name="quota_config_mode_title">Štýl odznaku</string>
+    <string name="quota_config_mode_remaining">Zostávajúce</string>
+    <string name="quota_config_mode_used">Využité</string>
+    <string name="quota_config_empty">Zatiaľ nie sú vidieť žiadni poskytovatelia s kvótou.</string>
+    <string name="quota_config_widget_cap">%1$d z %2$d zobrazených na widgete</string>
 </resources>

--- a/android/app/src/main/res/values-sk/strings.xml
+++ b/android/app/src/main/res/values-sk/strings.xml
@@ -318,5 +318,5 @@
     <string name="quota_config_mode_remaining">Zostávajúce</string>
     <string name="quota_config_mode_used">Využité</string>
     <string name="quota_config_empty">Zatiaľ nie sú vidieť žiadni poskytovatelia s kvótou.</string>
-    <string name="quota_config_widget_cap">%1$d z %2$d zobrazených na widgete</string>
+    <string name="quota_config_widget_cap">Na widget sa zmestí len prvých %1$d</string>
 </resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -300,5 +300,5 @@
     <string name="quota_config_mode_remaining">剩余</string>
     <string name="quota_config_mode_used">已用</string>
     <string name="quota_config_empty">尚未发现支持配额的服务商。</string>
-    <string name="quota_config_widget_cap">小组件中已显示 %2$d 项中的 %1$d 项</string>
+    <string name="quota_config_widget_cap">小组件仅能显示前 %1$d 项</string>
 </resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -258,4 +258,47 @@
     <string name="widget_event_header">最新集群事件</string>
     <string name="settings_widget_title">主屏幕小组件</string>
     <string name="settings_widget_graphs_subtitle">流量图：在每个成员上叠加最近一小时的请求。保持更新会使每次后台检查对每个成员多发送一个请求。</string>
+
+    <string name="settings_quota_badges_title">配额徽章</string>
+    <string name="settings_quota_badges_subtitle">选择在仪表盘和小组件上显示哪些服务商的配额徽章，调整顺序，并选择已用量或剩余量。</string>
+
+    <!-- Quota badge detail sheet -->
+    <string name="quota_refresh">刷新配额</string>
+    <string name="quota_unavailable">配额数据不可用</string>
+    <string name="quota_yes">是</string>
+    <string name="quota_no">否</string>
+    <string name="quota_status_active">已启用</string>
+    <string name="quota_status_inactive">未启用</string>
+    <string name="quota_status_in_plan">套餐内</string>
+    <string name="quota_status_not_in_plan">套餐外</string>
+    <string name="quota_field_status">状态</string>
+    <string name="quota_field_plan">套餐</string>
+    <string name="quota_field_membership">会员资格</string>
+    <string name="quota_field_period_end">周期结束</string>
+    <string name="quota_field_subscription_end">订阅结束</string>
+    <string name="quota_field_suspended">已暂停</string>
+    <string name="quota_field_allow_overage">允许超额</string>
+    <string name="quota_field_free_tier">免费层级</string>
+    <string name="quota_field_parallel_limit">并发限制</string>
+    <string name="quota_field_total_quota">总配额</string>
+    <string name="quota_field_credits_total">积分总额</string>
+    <string name="quota_field_credits_used">已用积分</string>
+    <string name="quota_field_usage_today">今日用量</string>
+    <string name="quota_field_usage_month">本月用量</string>
+    <string name="quota_field_balance_remaining">剩余余额</string>
+    <string name="quota_field_balance_total">总积分</string>
+    <string name="quota_field_daily_input_tokens">每日输入 token 数</string>
+    <string name="quota_field_daily_images">每日图片数</string>
+    <string name="quota_field_mcp_quota">MCP 配额</string>
+
+    <!-- Quota badge configurator (dashboard + widget surfaces) -->
+    <string name="quota_config_title">配额徽章</string>
+    <string name="quota_config_back">返回</string>
+    <string name="quota_config_tab_main">仪表盘</string>
+    <string name="quota_config_tab_widget">小组件</string>
+    <string name="quota_config_mode_title">徽章样式</string>
+    <string name="quota_config_mode_remaining">剩余</string>
+    <string name="quota_config_mode_used">已用</string>
+    <string name="quota_config_empty">尚未发现支持配额的服务商。</string>
+    <string name="quota_config_widget_cap">小组件中已显示 %2$d 项中的 %1$d 项</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -294,4 +294,7 @@
     <string name="quota_field_usage_month">Usage this month</string>
     <string name="quota_field_balance_remaining">Balance remaining</string>
     <string name="quota_field_balance_total">Total credits</string>
+    <string name="quota_field_daily_input_tokens">Daily input tokens</string>
+    <string name="quota_field_daily_images">Daily images</string>
+    <string name="quota_field_mcp_quota">MCP quota</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -268,4 +268,30 @@
     <string name="widget_event_header">Latest fleet event</string>
     <string name="settings_widget_title">Home-screen widget</string>
     <string name="settings_widget_graphs_subtitle">Traffic graphs: overlay each member with its last hour of requests. Fresh bars cost one extra request per member on each background check.</string>
+
+    <!-- Quota badge detail sheet -->
+    <string name="quota_refresh">Refresh quotas</string>
+    <string name="quota_unavailable">Quota data unavailable</string>
+    <string name="quota_yes">Yes</string>
+    <string name="quota_no">No</string>
+    <string name="quota_status_active">Active</string>
+    <string name="quota_status_inactive">Inactive</string>
+    <string name="quota_status_in_plan">In plan</string>
+    <string name="quota_status_not_in_plan">Not in plan</string>
+    <string name="quota_field_status">Status</string>
+    <string name="quota_field_plan">Plan</string>
+    <string name="quota_field_membership">Membership</string>
+    <string name="quota_field_period_end">Period ends</string>
+    <string name="quota_field_subscription_end">Subscription ends</string>
+    <string name="quota_field_suspended">Suspended</string>
+    <string name="quota_field_allow_overage">Allow overage</string>
+    <string name="quota_field_free_tier">Free tier</string>
+    <string name="quota_field_parallel_limit">Parallel limit</string>
+    <string name="quota_field_total_quota">Total quota</string>
+    <string name="quota_field_credits_total">Credits total</string>
+    <string name="quota_field_credits_used">Credits used</string>
+    <string name="quota_field_usage_today">Usage today</string>
+    <string name="quota_field_usage_month">Usage this month</string>
+    <string name="quota_field_balance_remaining">Balance remaining</string>
+    <string name="quota_field_balance_total">Total credits</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -310,5 +310,5 @@
     <string name="quota_config_mode_remaining">Remaining</string>
     <string name="quota_config_mode_used">Used</string>
     <string name="quota_config_empty">No quota-capable providers seen yet.</string>
-    <string name="quota_config_widget_cap">%1$d of %2$d shown on the widget</string>
+    <string name="quota_config_widget_cap">Only the first %1$d fit on the widget</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -297,4 +297,15 @@
     <string name="quota_field_daily_input_tokens">Daily input tokens</string>
     <string name="quota_field_daily_images">Daily images</string>
     <string name="quota_field_mcp_quota">MCP quota</string>
+
+    <!-- Quota badge configurator (dashboard + widget surfaces) -->
+    <string name="quota_config_title">Quota badges</string>
+    <string name="quota_config_back">Back</string>
+    <string name="quota_config_tab_main">Dashboard</string>
+    <string name="quota_config_tab_widget">Widget</string>
+    <string name="quota_config_mode_title">Badge style</string>
+    <string name="quota_config_mode_remaining">Remaining</string>
+    <string name="quota_config_mode_used">Used</string>
+    <string name="quota_config_empty">No quota-capable providers seen yet.</string>
+    <string name="quota_config_widget_cap">%1$d of %2$d shown on the widget</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -269,6 +269,9 @@
     <string name="settings_widget_title">Home-screen widget</string>
     <string name="settings_widget_graphs_subtitle">Traffic graphs: overlay each member with its last hour of requests. Fresh bars cost one extra request per member on each background check.</string>
 
+    <string name="settings_quota_badges_title">Quota badges</string>
+    <string name="settings_quota_badges_subtitle">Choose which provider quota badges show on the dashboard and the widget, reorder them, and pick used or remaining.</string>
+
     <!-- Quota badge detail sheet -->
     <string name="quota_refresh">Refresh quotas</string>
     <string name="quota_unavailable">Quota data unavailable</string>

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/QuotaDeepLinkTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/QuotaDeepLinkTest.kt
@@ -1,0 +1,28 @@
+package com.hugalafutro.bellhop
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * The widget quota deep-link must ride the app lock: [consumePendingQuotaTarget]
+ * only surfaces the target once the app is unlocked, so a locked device holds it
+ * pending instead of flashing a detail sheet over the lock screen.
+ */
+class QuotaDeepLinkTest {
+    @Test
+    fun heldWhileLocked() {
+        // Locked: nothing opens, the target stays pending.
+        assertEquals(null to "openrouter", consumePendingQuotaTarget("openrouter", unlocked = false))
+    }
+
+    @Test
+    fun openedAfterUnlock() {
+        // Unlocked: the target is consumed into the sheet and cleared.
+        assertEquals("openrouter" to null, consumePendingQuotaTarget("openrouter", unlocked = true))
+    }
+
+    @Test
+    fun nothingPendingIsNoOp() {
+        assertEquals(null to null, consumePendingQuotaTarget(null, unlocked = true))
+    }
+}

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/FrontDeskClientTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/FrontDeskClientTest.kt
@@ -411,6 +411,32 @@ class FrontDeskClientTest {
         }
 
     @Test
+    fun quotaDropsUnknownTypesAndKeepsKnownFailedFetches() =
+        runBlocking {
+            server.enqueue(
+                MockResponse().setBody(
+                    """{"quota":[""" +
+                        """{"provider_name":"Ninth","type":"brand-new","kind":"usage",""" +
+                        """"payload":{"whatever":1},"http_status":200,"fetched_at":"t"},""" +
+                        // A member still on a build whose export predates `type`.
+                        """{"provider_name":"Typeless","kind":"usage",""" +
+                        """"payload":{"credits_remaining":1.0},"http_status":200,"fetched_at":"t"},""" +
+                        """{"provider_name":"OR","type":"openrouter","kind":"usage",""" +
+                        """"payload":null,"http_status":500,"fetched_at":"t"}]}""",
+                ),
+            )
+
+            val result = client.quota(server.url("/").toString(), "tok-1")
+
+            assertTrue(result is FetchResult.Success)
+            result as FetchResult.Success
+            val quota = result.data.single()
+            assertEquals("OR", quota.providerName)
+            assertEquals(QuotaType.OPENROUTER, quota.type)
+            assertFalse(quota.available)
+        }
+
+    @Test
     fun quotaMapsUnauthorizedToItsOwnArm() =
         runBlocking {
             server.enqueue(

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/FrontDeskClientTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/FrontDeskClientTest.kt
@@ -386,6 +386,75 @@ class FrontDeskClientTest {
         }
 
     @Test
+    fun quotaMapsEnvelopeToProviderQuotas() =
+        runBlocking {
+            server.enqueue(
+                MockResponse().setBody(
+                    """{"quota":[{"provider_name":"OR","type":"openrouter","kind":"usage",""" +
+                        """"payload":{"label":"k","limit":10.0,"usage":2.5},"http_status":200,"fetched_at":"t"}]}""",
+                ),
+            )
+
+            val result = client.quota(server.url("/").toString(), "tok-1")
+
+            assertTrue(result is FetchResult.Success)
+            result as FetchResult.Success
+            val quota = result.data.single()
+            assertEquals("OR", quota.providerName)
+            assertEquals(QuotaType.OPENROUTER, quota.type)
+            assertTrue(quota.available)
+
+            val request = server.takeRequest()
+            assertEquals("GET", request.method)
+            assertEquals("/api/quota", request.path)
+            assertEquals("Bearer tok-1", request.getHeader("Authorization"))
+        }
+
+    @Test
+    fun quotaMapsUnauthorizedToItsOwnArm() =
+        runBlocking {
+            server.enqueue(
+                MockResponse().setResponseCode(401).setBody(
+                    """{"error":{"code":"unauthorized","message":"bad token"}}""",
+                ),
+            )
+            val result = client.quota(server.url("/").toString(), "dead")
+            assertEquals(FetchResult.Unauthorized, result)
+        }
+
+    @Test
+    fun refreshQuotaPostsEmptyBodyAndParsesTally() =
+        runBlocking {
+            server.enqueue(MockResponse().setBody("""{"refreshed":2,"failed":0,"skipped":1}"""))
+
+            val result = client.refreshQuota(server.url("/").toString(), "tok-1")
+
+            assertTrue(result is ActionResult.Success)
+            val data = (result as ActionResult.Success).data
+            assertEquals(2, data.refreshed)
+            assertEquals(0, data.failed)
+            assertEquals(1, data.skipped)
+
+            val request = server.takeRequest()
+            assertEquals("POST", request.method)
+            assertEquals("/api/quota/refresh", request.path)
+            assertEquals("Bearer tok-1", request.getHeader("Authorization"))
+            assertEquals("{}", request.body.readUtf8())
+        }
+
+    @Test
+    fun refreshQuotaMapsUnauthorizedToItsOwnArm() =
+        runBlocking {
+            server.enqueue(
+                MockResponse().setResponseCode(401).setBody(
+                    """{"error":{"code":"unauthorized","message":"bad token"}}""",
+                ),
+            )
+            val result = client.refreshQuota(server.url("/").toString(), "dead")
+            assertEquals(ActionResult.Unauthorized, result)
+        }
+
+    @Test
     fun unlinkMalformedUrlIsFalseNotThrow() =
         runBlocking {
             assertFalse(client.unlink("not a url", "tok"))

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/FrontDeskClientTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/FrontDeskClientTest.kt
@@ -449,6 +449,27 @@ class FrontDeskClientTest {
         }
 
     @Test
+    fun quotaMapsBadGatewayToFailureNotAnEmptyList() =
+        runBlocking {
+            // Front Desk answers 502 when it cannot reach the primary member, and
+            // its error envelope still carries a (empty) quota key, so the body
+            // decodes cleanly into a zero-entry list. Only the status keeps this
+            // off the Success arm -- and it must, or every consumer would read a
+            // "successful" empty list and blank its badges instead of keeping the
+            // last-good ones.
+            server.enqueue(
+                MockResponse().setResponseCode(502).setBody(
+                    """{"error":{"code":"primary_unreachable","message":"primary unreachable"},"quota":[]}""",
+                ),
+            )
+
+            val result = client.quota(server.url("/").toString(), "tok-1")
+
+            assertTrue(result is FetchResult.Failure)
+            assertEquals("primary unreachable", (result as FetchResult.Failure).message)
+        }
+
+    @Test
     fun refreshQuotaPostsEmptyBodyAndParsesTally() =
         runBlocking {
             server.enqueue(MockResponse().setBody("""{"refreshed":2,"failed":0,"skipped":1}"""))
@@ -478,6 +499,25 @@ class FrontDeskClientTest {
             )
             val result = client.refreshQuota(server.url("/").toString(), "dead")
             assertEquals(ActionResult.Unauthorized, result)
+        }
+
+    @Test
+    fun refreshQuotaMapsBadGatewayToFailureCarryingTheReason() =
+        runBlocking {
+            // A re-poll Front Desk could not run (primary unreachable) must reach
+            // the caller as a failure with Front Desk's own reason attached, so
+            // the dashboard can say the refresh failed rather than let the tap
+            // pass for a successful one.
+            server.enqueue(
+                MockResponse().setResponseCode(502).setBody(
+                    """{"error":{"code":"primary_unreachable","message":"primary unreachable"}}""",
+                ),
+            )
+
+            val result = client.refreshQuota(server.url("/").toString(), "tok-1")
+
+            assertTrue(result is ActionResult.Failure)
+            assertEquals("primary unreachable", (result as ActionResult.Failure).message)
         }
 
     @Test

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/PrefsStoreTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/PrefsStoreTest.kt
@@ -1,0 +1,45 @@
+package com.hugalafutro.bellhop.data
+
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * PrefsStore is device-local UI taste, not link metadata; these tests pin the
+ * DataStore round-trip and the unknown-value degrade stance shared with
+ * [WidgetMember.healthState].
+ */
+class PrefsStoreTest {
+    private fun newStore(): PrefsStore = PrefsStore(InMemoryPreferencesDataStore())
+
+    @Test
+    fun quotaBarModeDefaultsToRemaining() =
+        runBlocking {
+            assertEquals(QuotaBarMode.REMAINING, newStore().quotaBarMode.first())
+        }
+
+    @Test
+    fun quotaBarModeRoundTripsThroughSet() =
+        runBlocking {
+            val store = newStore()
+            store.setQuotaBarMode(QuotaBarMode.USED)
+            assertEquals(QuotaBarMode.USED, store.quotaBarMode.first())
+
+            store.setQuotaBarMode(QuotaBarMode.REMAINING)
+            assertEquals(QuotaBarMode.REMAINING, store.quotaBarMode.first())
+        }
+
+    @Test
+    fun unrecognizedStoredValueDegradesToDefault() =
+        runBlocking {
+            val dataStore = InMemoryPreferencesDataStore()
+            // Simulate a value written by a future build with a mode this build
+            // doesn't know: must fall back to the default, not throw.
+            dataStore.edit { it[stringPreferencesKey("quota_bar_mode")] = "SOME_FUTURE_MODE" }
+
+            assertEquals(QuotaBarMode.REMAINING, PrefsStore(dataStore).quotaBarMode.first())
+        }
+}

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/QuotaBadgeConfigStoreTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/QuotaBadgeConfigStoreTest.kt
@@ -1,5 +1,7 @@
 package com.hugalafutro.bellhop.data
 
+import androidx.datastore.preferences.core.mutablePreferencesOf
+import androidx.datastore.preferences.core.stringPreferencesKey
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
@@ -127,6 +129,35 @@ class QuotaBadgeConfigStoreTest {
 
             store.setVisible(QuotaSurface.MAIN, "OR", visible = true)
             assertFalse("OR" in store.config(QuotaSurface.MAIN).first().hidden)
+        }
+
+    @Test
+    fun reconcileLeavesTheStoredRecordAloneWhenNothingIsNew() =
+        runBlocking {
+            // reconcile runs on every quota fetch, so the common case is a no-op.
+            // The seeded record carries a field this build doesn't know: a
+            // re-encode would silently drop it, so its survival is the proof
+            // that nothing was rewritten.
+            val key = stringPreferencesKey("quota_badges_main")
+            val seeded = """{"order":["OR"],"hidden":[],"fieldFromALaterBuild":1}"""
+            val data = InMemoryPreferencesDataStore(mutablePreferencesOf(key to seeded))
+
+            QuotaBadgeConfigStore(data).reconcile(QuotaSurface.MAIN, listOf("OR"))
+
+            assertEquals(seeded, data.data.first()[key])
+        }
+
+    @Test
+    fun reconcileStillWritesWhenAProviderIsNew() =
+        runBlocking {
+            val key = stringPreferencesKey("quota_badges_main")
+            val seeded = """{"order":["OR"],"hidden":[]}"""
+            val data = InMemoryPreferencesDataStore(mutablePreferencesOf(key to seeded))
+            val store = QuotaBadgeConfigStore(data)
+
+            store.reconcile(QuotaSurface.MAIN, listOf("OR", "NG"))
+
+            assertEquals(listOf("OR", "NG"), store.config(QuotaSurface.MAIN).first().order)
         }
 
     private fun quota(name: String): ProviderQuota =

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/QuotaBadgeConfigStoreTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/QuotaBadgeConfigStoreTest.kt
@@ -1,0 +1,140 @@
+package com.hugalafutro.bellhop.data
+
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class QuotaBadgeConfigStoreTest {
+    // ── reconcileConfig (pure) ──────────────────────────────────────────
+
+    @Test
+    fun newMainBadgeDefaultsVisibleWidgetHidden() {
+        val start = QuotaBadgeConfig(order = emptyList(), hidden = emptySet())
+
+        val main = reconcileConfig(start, listOf("OR"), QuotaSurface.MAIN)
+        assertEquals(listOf("OR"), main.order)
+        assertFalse("OR" in main.hidden)
+
+        val widget = reconcileConfig(start, listOf("OR"), QuotaSurface.WIDGET)
+        assertEquals(listOf("OR"), widget.order)
+        assertTrue("OR" in widget.hidden)
+    }
+
+    @Test
+    fun vanishedNameRetainsSlotAndVisibility() {
+        val prev = QuotaBadgeConfig(order = listOf("OR", "NG"), hidden = setOf("NG"))
+        val after = reconcileConfig(prev, available = listOf("OR"), QuotaSurface.MAIN)
+        // NG is no longer reported but keeps its order slot and hidden state.
+        assertEquals(listOf("OR", "NG"), after.order)
+        assertTrue("NG" in after.hidden)
+    }
+
+    @Test
+    fun reconcileAppendsOnlyNewlySeenNames() {
+        val prev = QuotaBadgeConfig(order = listOf("OR"), hidden = emptySet())
+        val after = reconcileConfig(prev, available = listOf("OR", "NG"), QuotaSurface.MAIN)
+        assertEquals(listOf("OR", "NG"), after.order)
+        assertFalse("NG" in after.hidden)
+    }
+
+    @Test
+    fun reconcileNoOpWhenNothingNew() {
+        val prev = QuotaBadgeConfig(order = listOf("OR"), hidden = setOf("OR"))
+        val after = reconcileConfig(prev, available = listOf("OR"), QuotaSurface.MAIN)
+        assertEquals(prev, after)
+    }
+
+    // ── orderedVisible (pure) ────────────────────────────────────────────
+
+    @Test
+    fun orderedVisibleFiltersHiddenAndUnavailable() {
+        val config = QuotaBadgeConfig(order = listOf("OR", "NG"), hidden = setOf("NG"))
+        val available = listOf(quota("OR"), quota("NG"))
+        val visible = orderedVisible(config, available)
+        assertEquals(listOf("OR"), visible.map { it.providerName })
+    }
+
+    @Test
+    fun orderedVisibleDropsNamesNotCurrentlyAvailable() {
+        // NG has an order slot but isn't in the current fleet snapshot.
+        val config = QuotaBadgeConfig(order = listOf("OR", "NG"), hidden = emptySet())
+        val available = listOf(quota("OR"))
+        val visible = orderedVisible(config, available)
+        assertEquals(listOf("OR"), visible.map { it.providerName })
+    }
+
+    @Test
+    fun orderedVisibleFollowsConfigOrder() {
+        val config = QuotaBadgeConfig(order = listOf("NG", "OR"), hidden = emptySet())
+        val available = listOf(quota("OR"), quota("NG"))
+        val visible = orderedVisible(config, available)
+        assertEquals(listOf("NG", "OR"), visible.map { it.providerName })
+    }
+
+    @Test
+    fun orderedVisibleAppendsUnknownNamesInArrivalOrder() {
+        val config = QuotaBadgeConfig(order = listOf("OR"), hidden = emptySet())
+        val available = listOf(quota("OR"), quota("NG"), quota("DS"))
+        val visible = orderedVisible(config, available)
+        assertEquals(listOf("OR", "NG", "DS"), visible.map { it.providerName })
+    }
+
+    // ── QuotaBadgeConfigStore (DataStore round-trip) ─────────────────────
+
+    private fun newStore(): QuotaBadgeConfigStore = QuotaBadgeConfigStore(InMemoryPreferencesDataStore())
+
+    @Test
+    fun emptyStoreReadsDefaultConfig() =
+        runBlocking {
+            assertEquals(QuotaBadgeConfig(), newStore().config(QuotaSurface.MAIN).first())
+        }
+
+    @Test
+    fun reconcilePersistsIndependentlyPerSurface() =
+        runBlocking {
+            val store = newStore()
+            store.reconcile(QuotaSurface.MAIN, listOf("OR"))
+            store.reconcile(QuotaSurface.WIDGET, listOf("NG"))
+
+            val main = store.config(QuotaSurface.MAIN).first()
+            val widget = store.config(QuotaSurface.WIDGET).first()
+            assertEquals(listOf("OR"), main.order)
+            assertFalse("OR" in main.hidden)
+            assertEquals(listOf("NG"), widget.order)
+            assertTrue("NG" in widget.hidden)
+        }
+
+    @Test
+    fun setOrderPersists() =
+        runBlocking {
+            val store = newStore()
+            store.reconcile(QuotaSurface.MAIN, listOf("OR", "NG"))
+            store.setOrder(QuotaSurface.MAIN, listOf("NG", "OR"))
+            assertEquals(listOf("NG", "OR"), store.config(QuotaSurface.MAIN).first().order)
+        }
+
+    @Test
+    fun setVisibleTogglesHidden() =
+        runBlocking {
+            val store = newStore()
+            store.reconcile(QuotaSurface.MAIN, listOf("OR"))
+
+            store.setVisible(QuotaSurface.MAIN, "OR", visible = false)
+            assertTrue("OR" in store.config(QuotaSurface.MAIN).first().hidden)
+
+            store.setVisible(QuotaSurface.MAIN, "OR", visible = true)
+            assertFalse("OR" in store.config(QuotaSurface.MAIN).first().hidden)
+        }
+
+    private fun quota(name: String): ProviderQuota =
+        ProviderQuota(
+            providerName = name,
+            type = QuotaType.OPENROUTER,
+            data = null,
+            fetchedAt = "",
+            available = true,
+        )
+}

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/QuotaModelsTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/QuotaModelsTest.kt
@@ -268,4 +268,164 @@ class QuotaModelsTest {
         known.forEach { (wire, expected) -> assertEquals(expected, QuotaType.fromWire(wire)) }
         assertEquals(QuotaType.UNKNOWN, QuotaType.fromWire("garbage"))
     }
+
+    // ── quotaBadgeLabel ──────────────────────────────────────────────────
+    // METERED types (NanoGPT, Z.ai Coding, Kimi Code, MiniMax) flip polarity
+    // with mode; BALANCE/credit types (DeepSeek, OpenRouter, Ollama Cloud,
+    // NeuralWatt) render the same figure in either mode.
+
+    private fun pq(
+        data: QuotaData?,
+        type: QuotaType = QuotaType.UNKNOWN,
+        available: Boolean = true,
+    ): ProviderQuota =
+        ProviderQuota(providerName = "P", type = type, data = data, fetchedAt = "t", available = available)
+
+    @Test
+    fun unavailableOrPayloadlessRendersDash() {
+        val unavailable = pq(QuotaData.OpenRouter(creditsRemaining = 4.0), QuotaType.OPENROUTER, available = false)
+        assertEquals("-", quotaBadgeLabel(unavailable, QuotaBarMode.REMAINING))
+
+        val noPayload = pq(null, QuotaType.OPENROUTER, available = true)
+        assertEquals("-", quotaBadgeLabel(noPayload, QuotaBarMode.REMAINING))
+    }
+
+    @Test
+    fun nanoGptUsedModeShowsUsedOverLimit() {
+        val data =
+            QuotaData.NanoGpt(
+                limits = NanoGptLimits(weeklyInputTokens = 1_000_000L),
+                weeklyInputTokens = NanoGptTokenInfo(used = 250_000L, remaining = 750_000L),
+            )
+        assertEquals("250K/1M", quotaBadgeLabel(pq(data, QuotaType.NANOGPT), QuotaBarMode.USED))
+    }
+
+    @Test
+    fun nanoGptRemainingModeShowsRemainingOverLimit() {
+        val data =
+            QuotaData.NanoGpt(
+                limits = NanoGptLimits(weeklyInputTokens = 1_000_000L),
+                weeklyInputTokens = NanoGptTokenInfo(used = 250_000L, remaining = 750_000L),
+            )
+        assertEquals("750K/1M", quotaBadgeLabel(pq(data, QuotaType.NANOGPT), QuotaBarMode.REMAINING))
+    }
+
+    @Test
+    fun nanoGptRemainingFloorsAtZeroWhenUsedExceedsLimit() {
+        // Overage is allowed upstream; the badge must never show a negative fraction.
+        val data =
+            QuotaData.NanoGpt(
+                limits = NanoGptLimits(weeklyInputTokens = 1_000L),
+                weeklyInputTokens = NanoGptTokenInfo(used = 1_500L, remaining = 0L),
+            )
+        assertEquals("0/1K", quotaBadgeLabel(pq(data, QuotaType.NANOGPT), QuotaBarMode.REMAINING))
+    }
+
+    @Test
+    fun nanoGptMissingUsageRendersDashNumerator() {
+        val data = QuotaData.NanoGpt(limits = NanoGptLimits(weeklyInputTokens = 1_000_000L), weeklyInputTokens = null)
+        assertEquals("-/1M", quotaBadgeLabel(pq(data, QuotaType.NANOGPT), QuotaBarMode.USED))
+        assertEquals("-/1M", quotaBadgeLabel(pq(data, QuotaType.NANOGPT), QuotaBarMode.REMAINING))
+    }
+
+    @Test
+    fun zaiCodingUsedAndRemainingPercentages() {
+        val data =
+            QuotaData.ZaiCoding(
+                success = true,
+                data =
+                    ZaiCodingQuotaBody(
+                        limits =
+                            listOf(
+                                ZaiCodingLimit(type = "TOKENS_LIMIT", unit = 3, percentage = 30.0),
+                                ZaiCodingLimit(type = "TOKENS_LIMIT", unit = 6, percentage = 70.0),
+                            ),
+                    ),
+            )
+        val wrapped = pq(data, QuotaType.ZAI_CODING)
+        assertEquals("30%/70%", quotaBadgeLabel(wrapped, QuotaBarMode.USED))
+        assertEquals("70%/30%", quotaBadgeLabel(wrapped, QuotaBarMode.REMAINING))
+    }
+
+    @Test
+    fun kimiCodeUsedAndRemainingPercentages() {
+        val data =
+            QuotaData.KimiCode(
+                usage = KimiCodeDetail(limit = "200000", remaining = "150000"),
+                limits =
+                    listOf(
+                        KimiCodeLimitEntry(
+                            window = KimiCodeWindowSpec(duration = 300, timeUnit = "TIME_UNIT_MINUTE"),
+                            detail = KimiCodeDetail(limit = "100000", remaining = "60000"),
+                        ),
+                    ),
+            )
+        val wrapped = pq(data, QuotaType.KIMI_CODE)
+        assertEquals("40%/25%", quotaBadgeLabel(wrapped, QuotaBarMode.USED))
+        assertEquals("60%/75%", quotaBadgeLabel(wrapped, QuotaBarMode.REMAINING))
+    }
+
+    @Test
+    fun miniMaxUsedAndRemainingPercentages() {
+        val data =
+            QuotaData.MiniMax(
+                modelRemains =
+                    listOf(
+                        MiniMaxModelRemain(
+                            modelName = "general",
+                            currentIntervalStatus = 1,
+                            currentIntervalRemainingPercent = 65.0,
+                            currentWeeklyStatus = 1,
+                            currentWeeklyRemainingPercent = 80.0,
+                        ),
+                    ),
+            )
+        val wrapped = pq(data, QuotaType.MINIMAX)
+        assertEquals("35%/20%", quotaBadgeLabel(wrapped, QuotaBarMode.USED))
+        assertEquals("65%/80%", quotaBadgeLabel(wrapped, QuotaBarMode.REMAINING))
+    }
+
+    @Test
+    fun deepSeekBalanceUnaffectedByMode() {
+        val data =
+            QuotaData.DeepSeek(
+                isAvailable = true,
+                balanceInfos = listOf(DeepSeekBalanceInfo(currency = "USD", totalBalance = "12.34")),
+            )
+        val wrapped = pq(data, QuotaType.DEEPSEEK)
+        assertEquals("$12.34", quotaBadgeLabel(wrapped, QuotaBarMode.USED))
+        assertEquals("$12.34", quotaBadgeLabel(wrapped, QuotaBarMode.REMAINING))
+    }
+
+    @Test
+    fun openRouterBalanceUnaffectedByMode() {
+        val data = QuotaData.OpenRouter(creditsRemaining = 4.0)
+        val wrapped = pq(data, QuotaType.OPENROUTER)
+        assertEquals("$4.00", quotaBadgeLabel(wrapped, QuotaBarMode.USED))
+        assertEquals("$4.00", quotaBadgeLabel(wrapped, QuotaBarMode.REMAINING))
+    }
+
+    @Test
+    fun ollamaCloudPlanUnaffectedByMode() {
+        val data = QuotaData.OllamaCloud(plan = "pro")
+        val wrapped = pq(data, QuotaType.OLLAMA_CLOUD)
+        assertEquals("pro", quotaBadgeLabel(wrapped, QuotaBarMode.USED))
+        assertEquals("pro", quotaBadgeLabel(wrapped, QuotaBarMode.REMAINING))
+    }
+
+    @Test
+    fun neuralWattUnaffectedByModeWithIncludedAllowance() {
+        val data = QuotaData.NeuralWatt(subscription = NeuralWattSubscription(kwhUsed = 20.0, kwhIncluded = 50.0))
+        val wrapped = pq(data, QuotaType.NEURALWATT)
+        assertEquals("20/50 kWh", quotaBadgeLabel(wrapped, QuotaBarMode.USED))
+        assertEquals("20/50 kWh", quotaBadgeLabel(wrapped, QuotaBarMode.REMAINING))
+    }
+
+    @Test
+    fun neuralWattWithoutIncludedAllowanceShowsUsedOnly() {
+        val data = QuotaData.NeuralWatt(subscription = NeuralWattSubscription(kwhUsed = 20.0, kwhIncluded = 0.0))
+        val wrapped = pq(data, QuotaType.NEURALWATT)
+        assertEquals("20 kWh", quotaBadgeLabel(wrapped, QuotaBarMode.USED))
+        assertEquals("20 kWh", quotaBadgeLabel(wrapped, QuotaBarMode.REMAINING))
+    }
 }

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/QuotaModelsTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/QuotaModelsTest.kt
@@ -1,0 +1,147 @@
+package com.hugalafutro.bellhop.data
+
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the FD `/api/quota` wire shape and per-type payload parsing: `type`
+ * selects the badge/payload variant (never `kind`, which is just
+ * usage|balance|account bookkeeping), and a non-200 status or an unparseable
+ * payload degrades to `data = null, available = false` rather than throwing —
+ * mirroring [FleetSnapshot.stateOf]'s tolerant stance on bad/foreign data.
+ */
+class QuotaModelsTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun parsesOpenRouterPayloadOnSuccess() {
+        val body =
+            """
+            {"quota":[{"provider_name":"OR","type":"openrouter","kind":"usage",
+            "payload":{"label":"k","limit":10.0,"usage":2.5},"http_status":200,"fetched_at":"2026-07-24T00:00:00Z"}]}
+            """.trimIndent()
+        val env = json.decodeFromString<QuotaEnvelope>(body)
+        val pq = providerQuotaOf(env.quota.single())
+
+        assertEquals("OR", pq.providerName)
+        assertEquals(QuotaType.OPENROUTER, pq.type)
+        assertEquals("2026-07-24T00:00:00Z", pq.fetchedAt)
+        assertTrue(pq.available)
+        val data = pq.data as QuotaData.OpenRouter
+        assertEquals(2.5, data.usage, 0.0)
+        assertEquals(10.0, data.limit)
+    }
+
+    @Test
+    fun nonSuccessStatusDegradesToUnavailableNullData() {
+        val body =
+            """
+            {"quota":[{"provider_name":"OR","type":"openrouter","kind":"usage",
+            "payload":null,"http_status":424,"fetched_at":"2026-07-24T00:00:00Z"}]}
+            """.trimIndent()
+        val env = json.decodeFromString<QuotaEnvelope>(body)
+        val pq = providerQuotaOf(env.quota.single())
+
+        assertEquals(QuotaType.OPENROUTER, pq.type)
+        assertFalse(pq.available)
+        assertNull(pq.data)
+    }
+
+    @Test
+    fun unrecognizedWireTypeMapsToUnknown() {
+        val wire =
+            QuotaWire(
+                providerName = "brand-new",
+                type = "some-future-provider",
+                kind = "usage",
+                payload = null,
+                httpStatus = 200,
+                fetchedAt = "2026-07-24T00:00:00Z",
+            )
+        val pq = providerQuotaOf(wire)
+
+        assertEquals(QuotaType.UNKNOWN, pq.type)
+        assertFalse(pq.available)
+        assertNull(pq.data)
+    }
+
+    @Test
+    fun unparseablePayloadDegradesRatherThanThrowing() {
+        // http_status is 200 (a "success" per FD) but the payload doesn't decode
+        // into the expected shape for this type -- must not throw.
+        val body =
+            """
+            {"quota":[{"provider_name":"OR","type":"openrouter","kind":"usage",
+            "payload":{"usage":"not-a-number"},"http_status":200,"fetched_at":"2026-07-24T00:00:00Z"}]}
+            """.trimIndent()
+        val env = json.decodeFromString<QuotaEnvelope>(body)
+        val pq = providerQuotaOf(env.quota.single())
+
+        assertFalse(pq.available)
+        assertNull(pq.data)
+    }
+
+    @Test
+    fun parsesDeepSeekBalancePayload() {
+        val body =
+            """
+            {"quota":[{"provider_name":"DS","type":"deepseek","kind":"balance",
+            "payload":{"is_available":true,"balance_infos":[{"currency":"USD","total_balance":"12.34","granted_balance":"0","topped_up_balance":"12.34"}]},
+            "http_status":200,"fetched_at":"2026-07-24T00:00:00Z"}]}
+            """.trimIndent()
+        val env = json.decodeFromString<QuotaEnvelope>(body)
+        val pq = providerQuotaOf(env.quota.single())
+
+        assertEquals(QuotaType.DEEPSEEK, pq.type)
+        assertTrue(pq.available)
+        val data = pq.data as QuotaData.DeepSeek
+        assertTrue(data.isAvailable)
+        assertEquals("USD", data.balanceInfos.single().currency)
+        assertEquals("12.34", data.balanceInfos.single().totalBalance)
+    }
+
+    @Test
+    fun parsesNanoGptUsagePayloadWithCamelCaseKeys() {
+        val body =
+            """
+            {"quota":[{"provider_name":"NG","type":"nanogpt","kind":"usage",
+            "payload":{"active":true,"provider":"nanogpt","providerStatus":"active",
+            "allowOverage":false,"cancelAtPeriodEnd":false,
+            "limits":{"weeklyInputTokens":1000000,"dailyInputTokens":null,"dailyImages":null},
+            "period":{"currentPeriodEnd":"2026-08-01T00:00:00Z"},
+            "weeklyInputTokens":{"used":250000,"remaining":750000,"percentUsed":25.0,"resetAt":1234567890}},
+            "http_status":200,"fetched_at":"2026-07-24T00:00:00Z"}]}
+            """.trimIndent()
+        val env = json.decodeFromString<QuotaEnvelope>(body)
+        val pq = providerQuotaOf(env.quota.single())
+
+        assertEquals(QuotaType.NANOGPT, pq.type)
+        assertTrue(pq.available)
+        val data = pq.data as QuotaData.NanoGpt
+        assertTrue(data.active)
+        assertEquals(1_000_000L, data.limits.weeklyInputTokens)
+        assertEquals(250_000L, data.weeklyInputTokens?.used)
+        assertNull(data.limits.dailyImages)
+    }
+
+    @Test
+    fun fromWireCoversAllEightKnownTypes() {
+        val known =
+            mapOf(
+                "nanogpt" to QuotaType.NANOGPT,
+                "zai-coding" to QuotaType.ZAI_CODING,
+                "kimi-code" to QuotaType.KIMI_CODE,
+                "minimax" to QuotaType.MINIMAX,
+                "deepseek" to QuotaType.DEEPSEEK,
+                "openrouter" to QuotaType.OPENROUTER,
+                "ollama-cloud" to QuotaType.OLLAMA_CLOUD,
+                "neuralwatt" to QuotaType.NEURALWATT,
+            )
+        known.forEach { (wire, expected) -> assertEquals(expected, QuotaType.fromWire(wire)) }
+        assertEquals(QuotaType.UNKNOWN, QuotaType.fromWire("garbage"))
+    }
+}

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/QuotaModelsTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/QuotaModelsTest.kt
@@ -129,6 +129,130 @@ class QuotaModelsTest {
     }
 
     @Test
+    fun parsesZaiCodingQuotaPayload() {
+        val body =
+            """
+            {"quota":[{"provider_name":"ZAI","type":"zai-coding","kind":"usage",
+            "payload":{"code":0,"msg":"ok","success":true,"data":{"level":"pro","limits":[
+            {"type":"TOKENS_LIMIT","unit":3,"number":100,"usage":10,"currentValue":90,"remaining":90,
+            "percentage":10.0,"nextResetTime":1234567890,"usageDetails":[{"modelCode":"glm-4.6","usage":10}]}]}},
+            "http_status":200,"fetched_at":"2026-07-24T00:00:00Z"}]}
+            """.trimIndent()
+        val env = json.decodeFromString<QuotaEnvelope>(body)
+        val pq = providerQuotaOf(env.quota.single())
+
+        assertEquals(QuotaType.ZAI_CODING, pq.type)
+        assertTrue(pq.available)
+        val data = pq.data as QuotaData.ZaiCoding
+        assertTrue(data.success)
+        assertEquals("pro", data.data.level)
+        assertEquals(10.0, data.data.limits.single().percentage, 0.0)
+        assertEquals(1234567890L, data.data.limits.single().nextResetTime)
+    }
+
+    @Test
+    fun parsesKimiCodeQuotaPayload() {
+        val body =
+            """
+            {"quota":[{"provider_name":"KIMI","type":"kimi-code","kind":"usage",
+            "payload":{"user":{"membership":{"level":"pro"}},
+            "usage":{"limit":"1000000","remaining":"500000","resetTime":"2026-07-25T00:00:00Z"},
+            "limits":[{"window":{"duration":300,"timeUnit":"TIME_UNIT_MINUTE"},
+            "detail":{"limit":"100000","remaining":"40000","resetTime":"2026-07-24T05:00:00Z"}}],
+            "parallel":{"limit":"5"},
+            "totalQuota":{"limit":"2000000","remaining":"900000","resetTime":"2026-08-01T00:00:00Z"}},
+            "http_status":200,"fetched_at":"2026-07-24T00:00:00Z"}]}
+            """.trimIndent()
+        val env = json.decodeFromString<QuotaEnvelope>(body)
+        val pq = providerQuotaOf(env.quota.single())
+
+        assertEquals(QuotaType.KIMI_CODE, pq.type)
+        assertTrue(pq.available)
+        val data = pq.data as QuotaData.KimiCode
+        assertEquals("pro", data.user.membership.level)
+        assertEquals(300, data.limits.single().window.duration)
+        assertEquals("40000", data.limits.single().detail.remaining)
+        assertEquals("900000", data.totalQuota.remaining)
+    }
+
+    @Test
+    fun parsesMiniMaxQuotaPayloadWithSnakeCaseKeys() {
+        val body =
+            """
+            {"quota":[{"provider_name":"MM","type":"minimax","kind":"usage",
+            "payload":{"model_remains":[{"model_name":"general","start_time":1000,"end_time":19000000,
+            "remains_time":18000000,"weekly_remains_time":600000000,"current_interval_status":1,
+            "current_interval_remaining_percent":72.5,"current_weekly_status":1,
+            "current_weekly_remaining_percent":88.0}],"base_resp":{"status_code":0,"status_msg":"ok"}},
+            "http_status":200,"fetched_at":"2026-07-24T00:00:00Z"}]}
+            """.trimIndent()
+        val env = json.decodeFromString<QuotaEnvelope>(body)
+        val pq = providerQuotaOf(env.quota.single())
+
+        assertEquals(QuotaType.MINIMAX, pq.type)
+        assertTrue(pq.available)
+        val data = pq.data as QuotaData.MiniMax
+        val entry = data.modelRemains.single()
+        assertEquals("general", entry.modelName)
+        assertEquals(72.5, entry.currentIntervalRemainingPercent, 0.0)
+        assertEquals(88.0, entry.currentWeeklyRemainingPercent, 0.0)
+        assertEquals(0, data.baseResp.statusCode)
+    }
+
+    @Test
+    fun parsesNeuralWattQuotaPayloadWithSnakeCaseKeys() {
+        val body =
+            """
+            {"quota":[{"provider_name":"NW","type":"neuralwatt","kind":"account",
+            "payload":{"snapshot_at":"2026-07-24T00:00:00Z",
+            "balance":{"credits_remaining_usd":42.5,"total_credits_usd":100.0,"credits_used_usd":57.5,
+            "accounting_method":"prepaid"},
+            "usage":{"lifetime":{"cost_usd":500.0,"requests":1000,"tokens":2000000,"energy_kwh":12.5},
+            "current_month":{"cost_usd":10.0,"requests":20,"tokens":40000,"energy_kwh":0.5}},
+            "limits":{"overage_limit_usd":25.0,"rate_limit_tier":"standard"},
+            "subscription":{"plan":"pro","status":"active","billing_interval":"monthly",
+            "current_period_start":"2026-07-01T00:00:00Z","current_period_end":"2026-08-01T00:00:00Z",
+            "auto_renew":true,"kwh_included":50.0,"kwh_used":20.0,"kwh_remaining":30.0,"in_overage":false},
+            "key":{"name":"prod","allowance":100.0}},
+            "http_status":200,"fetched_at":"2026-07-24T00:00:00Z"}]}
+            """.trimIndent()
+        val env = json.decodeFromString<QuotaEnvelope>(body)
+        val pq = providerQuotaOf(env.quota.single())
+
+        assertEquals(QuotaType.NEURALWATT, pq.type)
+        assertTrue(pq.available)
+        val data = pq.data as QuotaData.NeuralWatt
+        assertEquals(42.5, data.balance.creditsRemainingUsd, 0.0)
+        assertEquals(20.0, data.subscription.kwhUsed, 0.0)
+        assertEquals(100.0, data.key.allowance)
+    }
+
+    @Test
+    fun parsesOllamaCloudPayloadWithSnakeCaseKeys() {
+        val body =
+            """
+            {"quota":[{"provider_name":"OC","type":"ollama-cloud","kind":"account",
+            "payload":{"id":"acc_1","email":"a@b.com","name":"A","plan":"pro",
+            "customer_id":{"string":"cus_1","valid":true},
+            "subscription_id":{"string":"sub_1","valid":true},
+            "subscription_period_start":{"time":"2026-07-01T00:00:00Z","valid":true},
+            "subscription_period_end":{"time":"2026-08-01T00:00:00Z","valid":true},
+            "suspended_at":{"time":"","valid":false}},
+            "http_status":200,"fetched_at":"2026-07-24T00:00:00Z"}]}
+            """.trimIndent()
+        val env = json.decodeFromString<QuotaEnvelope>(body)
+        val pq = providerQuotaOf(env.quota.single())
+
+        assertEquals(QuotaType.OLLAMA_CLOUD, pq.type)
+        assertTrue(pq.available)
+        val data = pq.data as QuotaData.OllamaCloud
+        assertEquals("pro", data.plan)
+        assertEquals("2026-08-01T00:00:00Z", data.subscriptionPeriodEnd.time)
+        assertTrue(data.subscriptionPeriodEnd.valid)
+        assertFalse(data.suspendedAt.valid)
+    }
+
+    @Test
     fun fromWireCoversAllEightKnownTypes() {
         val known =
             mapOf(

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/WidgetStateTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/WidgetStateTest.kt
@@ -132,7 +132,7 @@ class WidgetStateTest {
     @Test
     fun widgetQuotaRespectsOrderVisibilityAndCap() {
         val quotas =
-            (1..8).map {
+            (1..WIDGET_QUOTA_CAP + 3).map {
                 ProviderQuota(
                     providerName = "P$it",
                     type = QuotaType.OPENROUTER,
@@ -146,6 +146,40 @@ class WidgetStateTest {
         assertEquals(WIDGET_QUOTA_CAP, badges.size)
         assertFalse(badges.any { it.providerName == "P2" }) // hidden dropped before the cap
     }
+
+    @Test
+    fun quotaBadgeRowsPacksToTheRowBudget() {
+        // Short labels share a line; a long one starts the next.
+        val badges =
+            listOf(
+                badge("A", "$1"),
+                badge("B", "$2"),
+                badge("C", "$3"),
+                badge("D", "999.9M/999.9M"),
+            )
+        val rows = quotaBadgeRows(badges)
+        assertEquals(listOf(listOf("A", "B", "C"), listOf("D")), rows.map { row -> row.map { it.providerName } })
+    }
+
+    @Test
+    fun quotaBadgeRowsGivesAnOversizedBadgeItsOwnRow() {
+        val rows = quotaBadgeRows(listOf(badge("wide", "x".repeat(80)), badge("next", "$1")))
+        assertEquals(listOf(listOf("wide"), listOf("next")), rows.map { row -> row.map { it.providerName } })
+    }
+
+    @Test
+    fun quotaBadgeRowsStopsAtTheRowCap() {
+        // One badge per row (each fills the budget on its own), so the row cap
+        // is what bounds the strip's height.
+        val rows = quotaBadgeRows((1..WIDGET_QUOTA_MAX_ROWS + 2).map { badge("P$it", "x".repeat(40)) })
+        assertEquals(WIDGET_QUOTA_MAX_ROWS, rows.size)
+        assertEquals("P1", rows.first().single().providerName)
+    }
+
+    private fun badge(
+        name: String,
+        label: String,
+    ) = WidgetQuotaBadge(providerName = name, type = QuotaType.OPENROUTER.name, label = label)
 
     @Test
     fun widgetQuotaThreadsModeIntoLabel() {

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/WidgetStateTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/WidgetStateTest.kt
@@ -1,6 +1,7 @@
 package com.hugalafutro.bellhop.data
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Test
 
@@ -126,5 +127,23 @@ class WidgetStateTest {
                 traffic = mapOf("m1" to (1..15).toList()),
             )
         assertEquals((4..15).toList(), state.members.single().traffic)
+    }
+
+    @Test
+    fun widgetQuotaRespectsOrderVisibilityAndCap() {
+        val quotas =
+            (1..8).map {
+                ProviderQuota(
+                    providerName = "P$it",
+                    type = QuotaType.OPENROUTER,
+                    data = QuotaData.OpenRouter(limitReset = "k", limit = 10.0, creditsRemaining = it.toDouble()),
+                    fetchedAt = "t",
+                    available = true,
+                )
+            }
+        val cfg = QuotaBadgeConfig(order = quotas.map { it.providerName }, hidden = setOf("P2"))
+        val badges = widgetQuotaOf(quotas, cfg)
+        assertEquals(WIDGET_QUOTA_CAP, badges.size)
+        assertFalse(badges.any { it.providerName == "P2" }) // hidden dropped before the cap
     }
 }

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/WidgetStateTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/WidgetStateTest.kt
@@ -142,8 +142,25 @@ class WidgetStateTest {
                 )
             }
         val cfg = QuotaBadgeConfig(order = quotas.map { it.providerName }, hidden = setOf("P2"))
-        val badges = widgetQuotaOf(quotas, cfg)
+        val badges = widgetQuotaOf(quotas, cfg, QuotaBarMode.REMAINING)
         assertEquals(WIDGET_QUOTA_CAP, badges.size)
         assertFalse(badges.any { it.providerName == "P2" }) // hidden dropped before the cap
+    }
+
+    @Test
+    fun widgetQuotaThreadsModeIntoLabel() {
+        val quota =
+            ProviderQuota(
+                providerName = "OR",
+                type = QuotaType.OPENROUTER,
+                data = QuotaData.OpenRouter(limitReset = "k", limit = 10.0, creditsRemaining = 4.0),
+                fetchedAt = "t",
+                available = true,
+            )
+        val cfg = QuotaBadgeConfig(order = listOf("OR"), hidden = emptySet())
+        val remaining = widgetQuotaOf(listOf(quota), cfg, QuotaBarMode.REMAINING)
+        val used = widgetQuotaOf(listOf(quota), cfg, QuotaBarMode.USED)
+        // OpenRouter is a BALANCE type: mode doesn't change the figure.
+        assertEquals(remaining.single().label, used.single().label)
     }
 }

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/common/ReorderableListTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/common/ReorderableListTest.kt
@@ -1,0 +1,40 @@
+package com.hugalafutro.bellhop.ui.common
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ReorderableListTest {
+    @Test
+    fun `moves item down`() {
+        assertEquals(listOf("B", "C", "A"), moveItem(listOf("A", "B", "C"), from = 0, to = 2))
+    }
+
+    @Test
+    fun `moves item up`() {
+        assertEquals(listOf("C", "A", "B"), moveItem(listOf("A", "B", "C"), from = 2, to = 0))
+    }
+
+    @Test
+    fun `same index is a no-op`() {
+        assertEquals(listOf("A", "B", "C"), moveItem(listOf("A", "B", "C"), from = 1, to = 1))
+    }
+
+    @Test
+    fun `out-of-range from is a no-op`() {
+        val list = listOf("A", "B", "C")
+        assertEquals(list, moveItem(list, from = -1, to = 1))
+        assertEquals(list, moveItem(list, from = 3, to = 1))
+    }
+
+    @Test
+    fun `out-of-range to is clamped`() {
+        assertEquals(listOf("B", "C", "A"), moveItem(listOf("A", "B", "C"), from = 0, to = 99))
+        assertEquals(listOf("C", "A", "B"), moveItem(listOf("A", "B", "C"), from = 2, to = -99))
+    }
+
+    @Test
+    fun `empty list is a no-op`() {
+        val empty: List<String> = emptyList()
+        assertEquals(empty, moveItem(empty, from = 0, to = 1))
+    }
+}

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreenTest.kt
@@ -466,4 +466,42 @@ class DashboardScreenTest {
         }
         composeTestRule.onNodeWithTag("dashboard-revoked").assertIsDisplayed()
     }
+
+    @Test
+    fun failedQuotaRefreshShowsItsOwnBanner() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                DashboardScreen(
+                    link = link,
+                    ui =
+                        DashboardUiState(
+                            loading = false,
+                            members = allUp,
+                            quotaRefreshError = "primary unreachable",
+                        ),
+                )
+            }
+        }
+        composeTestRule.onNodeWithTag("quota-refresh-error").assertIsDisplayed()
+    }
+
+    @Test
+    fun fleetReadFailureOutranksTheQuotaRefreshBanner() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                DashboardScreen(
+                    link = link,
+                    ui =
+                        DashboardUiState(
+                            loading = false,
+                            members = allUp,
+                            error = "front desk unreachable",
+                            quotaRefreshError = "primary unreachable",
+                        ),
+                )
+            }
+        }
+        composeTestRule.onNodeWithTag("dashboard-error").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("quota-refresh-error").assertDoesNotExist()
+    }
 }

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModelTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModelTest.kt
@@ -1040,6 +1040,30 @@ class DashboardViewModelTest {
         }
 
     @Test
+    fun quotaByNameKeepsMainHiddenProviderForWidgetDeepLink() =
+        runBlocking {
+            val config = QuotaBadgeConfigStore(InMemoryPreferencesDataStore())
+            // "b" is a known dashboard badge the user hid on the dashboard (MAIN)
+            // while keeping it on the widget -- per-surface visibility is
+            // independent. It must drop out of the dashboard row yet stay
+            // resolvable by name, so a widget deep-link for "b" still opens its
+            // sheet instead of dead-ending (whole-branch review finding).
+            config.setOrder(QuotaSurface.MAIN, listOf("a", "b"))
+            config.setVisible(QuotaSurface.MAIN, "b", false)
+            val client = FakeFleetClient(FetchResult.Success(listOf(member)))
+            client.quotaResult = FetchResult.Success(listOf(quota("a"), quota("b")))
+            val vm = viewModel(client, configStore = config)
+
+            vm.refreshOnce()
+
+            // Dashboard row excludes the hidden "b"...
+            assertEquals(listOf("a"), vm.state.value.quota.map { it.providerName })
+            // ...but the deep-link resolver still carries it.
+            assertEquals("b", vm.state.value.quotaByName["b"]?.providerName)
+            assertEquals(setOf("a", "b"), vm.state.value.quotaByName.keys)
+        }
+
+    @Test
     fun dashboardDrivenWidgetWriteDoesNotBlankExistingQuotaOnFailedRead() =
         runBlocking {
             val widget = WidgetStore(InMemoryPreferencesDataStore())

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModelTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModelTest.kt
@@ -16,7 +16,15 @@ import com.hugalafutro.bellhop.data.LinkStore
 import com.hugalafutro.bellhop.data.MemberStatus
 import com.hugalafutro.bellhop.data.MemberTraffic
 import com.hugalafutro.bellhop.data.PairedDevice
+import com.hugalafutro.bellhop.data.ProviderQuota
+import com.hugalafutro.bellhop.data.QuotaBadgeConfigStore
+import com.hugalafutro.bellhop.data.QuotaBarMode
+import com.hugalafutro.bellhop.data.QuotaRefreshResult
+import com.hugalafutro.bellhop.data.QuotaSurface
+import com.hugalafutro.bellhop.data.QuotaType
 import com.hugalafutro.bellhop.data.SseMessage
+import com.hugalafutro.bellhop.data.WidgetQuotaBadge
+import com.hugalafutro.bellhop.data.WidgetState
 import com.hugalafutro.bellhop.data.WidgetStore
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
@@ -150,6 +158,31 @@ private class FakeFleetClient(
         streamCalls.incrementAndGet()
         return sseFlow
     }
+
+    // Quota badges: canned read plus a call counter so a test can prove
+    // refreshQuota() re-reads (not just fires the refresh POST) and a failed
+    // read leaves the previous list alone.
+    var quotaResult: FetchResult<List<ProviderQuota>> = FetchResult.Success(emptyList())
+    val quotaCalls = AtomicInteger(0)
+
+    override suspend fun quota(
+        fdUrl: String,
+        token: String,
+    ): FetchResult<List<ProviderQuota>> {
+        quotaCalls.incrementAndGet()
+        return quotaResult
+    }
+
+    var refreshQuotaResult: ActionResult<QuotaRefreshResult> = ActionResult.Success(QuotaRefreshResult())
+    val refreshQuotaCalls = AtomicInteger(0)
+
+    override suspend fun refreshQuota(
+        fdUrl: String,
+        token: String,
+    ): ActionResult<QuotaRefreshResult> {
+        refreshQuotaCalls.incrementAndGet()
+        return refreshQuotaResult
+    }
 }
 
 @RunWith(RobolectricTestRunner::class)
@@ -202,6 +235,8 @@ class DashboardViewModelTest {
         widgetStore: WidgetStore = WidgetStore(InMemoryPreferencesDataStore()),
         onWidgetWritten: suspend () -> Unit = {},
         widgetGraphs: suspend () -> Boolean = { false },
+        configStore: QuotaBadgeConfigStore = QuotaBadgeConfigStore(InMemoryPreferencesDataStore()),
+        barMode: suspend () -> QuotaBarMode = { QuotaBarMode.REMAINING },
         pollIntervalMs: Long = DashboardViewModel.POLL_INTERVAL_MS,
         sseHealthyPollIntervalMs: Long = DashboardViewModel.SSE_HEALTHY_POLL_INTERVAL_MS,
         trafficPollMs: Long = DashboardViewModel.TRAFFIC_POLL_MS,
@@ -214,6 +249,8 @@ class DashboardViewModelTest {
             widgetStore,
             onWidgetWritten,
             widgetGraphs,
+            configStore,
+            barMode,
             pollIntervalMs,
             sseHealthyPollIntervalMs,
             trafficPollMs,
@@ -920,5 +957,106 @@ class DashboardViewModelTest {
             withTimeout(5_000) { while (client.memberCalls.get() == afterInitial) delay(20) }
             assertTrue(client.memberCalls.get() > afterInitial)
             job.cancel()
+        }
+
+    private fun quota(
+        name: String,
+        type: QuotaType = QuotaType.OPENROUTER,
+    ) = ProviderQuota(providerName = name, type = type, data = null, fetchedAt = "t", available = true)
+
+    @Test
+    fun refreshExposesMainOrderedVisibleQuota() =
+        runBlocking {
+            val client = FakeFleetClient(FetchResult.Success(listOf(member)))
+            client.quotaResult = FetchResult.Success(listOf(quota("a"), quota("b"), quota("c")))
+            val config = QuotaBadgeConfigStore(InMemoryPreferencesDataStore())
+            // "b" ordered first, "c" hidden: the state's quota list must reflect
+            // both, not the fetch's own arrival order.
+            config.setOrder(QuotaSurface.MAIN, listOf("b", "a"))
+            config.setVisible(QuotaSurface.MAIN, "c", visible = false)
+            val vm = viewModel(client, configStore = config)
+
+            vm.refreshOnce()
+
+            assertEquals(listOf("b", "a"), vm.state.value.quota.map { it.providerName })
+        }
+
+    @Test
+    fun failedQuotaReadKeepsPreviousList() =
+        runBlocking {
+            val client = FakeFleetClient(FetchResult.Success(listOf(member)))
+            client.quotaResult = FetchResult.Success(listOf(quota("a")))
+            val vm = viewModel(client)
+
+            vm.refreshOnce()
+            assertEquals(listOf("a"), vm.state.value.quota.map { it.providerName })
+
+            // A transient quota read failure must not blank the already-good list.
+            client.quotaResult = FetchResult.Failure("nope")
+            vm.refreshOnce()
+            assertEquals(listOf("a"), vm.state.value.quota.map { it.providerName })
+        }
+
+    @Test
+    fun refreshQuotaTriggersRefreshThenReReadsAndClearsFlag() =
+        runBlocking {
+            val client = FakeFleetClient(FetchResult.Success(listOf(member)))
+            client.quotaResult = FetchResult.Success(listOf(quota("a")))
+            val vm = viewModel(client)
+            vm.refreshOnce()
+            assertEquals(listOf("a"), vm.state.value.quota.map { it.providerName })
+
+            // The manual refresh's re-read must see fresh data, not the stale
+            // snapshot from before the POST /api/quota/refresh call.
+            client.quotaResult = FetchResult.Success(listOf(quota("a"), quota("b")))
+
+            vm.refreshQuota()
+            withTimeout(5_000) { vm.state.first { !it.refreshingQuota && it.quota.size == 2 } }
+
+            assertEquals(1, client.refreshQuotaCalls.get())
+            assertEquals(listOf("a", "b"), vm.state.value.quota.map { it.providerName })
+            assertFalse(vm.state.value.refreshingQuota)
+        }
+
+    @Test
+    fun refreshWritesWidgetQuotaBadges() =
+        runBlocking {
+            val widget = WidgetStore(InMemoryPreferencesDataStore())
+            val config = QuotaBadgeConfigStore(InMemoryPreferencesDataStore())
+            // A widget badge is opt-in (new names default hidden on WIDGET), so
+            // pre-place it in the order to keep it visible through reconcile --
+            // same setup as FleetPollTest.successfulPollWritesVisibleWidgetQuota.
+            config.setOrder(QuotaSurface.WIDGET, listOf("a"))
+            val client = FakeFleetClient(FetchResult.Success(listOf(member)))
+            client.quotaResult = FetchResult.Success(listOf(quota("a")))
+            val vm = viewModel(client, widgetStore = widget, configStore = config)
+
+            vm.refreshOnce()
+
+            // This is the widget-blanking fix: the dashboard's own refresh must
+            // thread the fetched quota through to the widget's render model,
+            // not fall back to widgetStateOf's emptyList() default.
+            assertEquals(listOf("a"), widget.read()?.quota?.map { it.providerName })
+        }
+
+    @Test
+    fun dashboardDrivenWidgetWriteDoesNotBlankExistingQuotaOnFailedRead() =
+        runBlocking {
+            val widget = WidgetStore(InMemoryPreferencesDataStore())
+            val prior = listOf(WidgetQuotaBadge("a", "OPENROUTER", "\$7.50"))
+            widget.saveIfChanged(
+                WidgetState(members = emptyList(), updatedAt = 1L, quota = prior),
+                widget.generation(),
+            )
+            val client = FakeFleetClient(FetchResult.Success(listOf(member)))
+            client.quotaResult = FetchResult.Failure("nope")
+            val vm = viewModel(client, widgetStore = widget)
+
+            vm.refreshOnce()
+
+            // Stale beats blank: a failed quota read during a dashboard-driven
+            // refresh must keep the widget's last-good badges, same stance as the
+            // background poll (FleetPollTest.quotaReadFailureKeepsPreviousWidgetBadges).
+            assertEquals(prior, widget.read()?.quota)
         }
 }

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModelTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModelTest.kt
@@ -995,6 +995,42 @@ class DashboardViewModelTest {
             client.quotaResult = FetchResult.Failure("nope")
             vm.refreshOnce()
             assertEquals(listOf("a"), vm.state.value.quota.map { it.providerName })
+            // The deep-link resolver is kept alongside the row: a widget badge
+            // tapped while the quota read is failing must still find its entry
+            // instead of opening onto nothing.
+            assertEquals(setOf("a"), vm.state.value.quotaByName.keys)
+        }
+
+    @Test
+    fun failedQuotaRefreshSurfacesTheFailureInsteadOfPassingForSuccess() =
+        runBlocking {
+            val client = FakeFleetClient(FetchResult.Success(listOf(member)))
+            client.quotaResult = FetchResult.Success(listOf(quota("a")))
+            val vm = viewModel(client)
+            vm.refreshOnce()
+            assertEquals(listOf("a"), vm.state.value.quota.map { it.providerName })
+
+            // Front Desk can't reach the primary, so both the re-poll and the
+            // read behind it fail. The row keeps its last-good badge either way,
+            // which is exactly why the failure has to be said out loud: otherwise
+            // the tap looks identical to a refresh that found no change.
+            client.refreshQuotaResult = ActionResult.Failure("primary unreachable")
+            client.quotaResult = FetchResult.Failure("primary unreachable")
+
+            vm.refreshQuota()
+            val settled = withTimeout(5_000) { vm.state.first { !it.refreshingQuota } }
+
+            assertEquals("primary unreachable", settled.quotaRefreshError)
+            assertEquals(listOf("a"), settled.quota.map { it.providerName })
+            // The members read is fine, so its own banner slot stays empty: the
+            // two failures are surfaced separately.
+            assertNull(settled.error)
+
+            // Front Desk comes back: the first read that gets through retires the
+            // banner, so it can never outlive the problem it reported.
+            client.quotaResult = FetchResult.Success(listOf(quota("a")))
+            vm.refreshOnce()
+            assertNull(vm.state.value.quotaRefreshError)
         }
 
     @Test

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/QuotaBadgesTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/QuotaBadgesTest.kt
@@ -1,0 +1,149 @@
+package com.hugalafutro.bellhop.ui.dashboard
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.hugalafutro.bellhop.data.ProviderQuota
+import com.hugalafutro.bellhop.data.QuotaBarMode
+import com.hugalafutro.bellhop.data.QuotaData
+import com.hugalafutro.bellhop.data.QuotaType
+import com.hugalafutro.bellhop.ui.theme.BellhopTheme
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * QuotaBadgeRow / QuotaDetailSheet: badge identity is the provider *name*
+ * (never type or index, per global-constraints), so every assertion here is
+ * keyed off [ProviderQuota.providerName]. Asserts on testTag, not translated
+ * copy -- English strings never break these. Covers the brief's data/shape
+ * parity contract: an available provider's badge shows its computed label,
+ * a dead-key (available == false) one shows "-", and a tap -- on either --
+ * fires the click callback with the provider's name.
+ */
+@RunWith(RobolectricTestRunner::class)
+class QuotaBadgesTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val available =
+        ProviderQuota(
+            providerName = "openrouter-main",
+            type = QuotaType.OPENROUTER,
+            data = QuotaData.OpenRouter(creditsRemaining = 12.5),
+            fetchedAt = "2026-07-24T00:00:00Z",
+            available = true,
+        )
+
+    private val deadKey =
+        ProviderQuota(
+            providerName = "nanogpt-broken",
+            type = QuotaType.NANOGPT,
+            data = null,
+            fetchedAt = "",
+            available = false,
+        )
+
+    @Test
+    fun showsOneBadgePerProvider() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                QuotaBadgeRow(quota = listOf(available, deadKey), mode = QuotaBarMode.REMAINING, onBadgeClick = {})
+            }
+        }
+        composeTestRule.onNodeWithTag("quota-badge-openrouter-main").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("quota-badge-nanogpt-broken").assertIsDisplayed()
+    }
+
+    @Test
+    fun deadKeyBadgeRendersDash() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                QuotaBadgeRow(quota = listOf(deadKey), mode = QuotaBarMode.REMAINING, onBadgeClick = {})
+            }
+        }
+        composeTestRule.onNodeWithTag("quota-badge-nanogpt-broken").assertTextContains("-", substring = true)
+    }
+
+    @Test
+    fun availableBadgeShowsComputedLabel() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                QuotaBadgeRow(quota = listOf(available), mode = QuotaBarMode.REMAINING, onBadgeClick = {})
+            }
+        }
+        // quotaBadgeLabel formats OpenRouter as "$<creditsRemaining, 2dp>".
+        composeTestRule.onNodeWithTag("quota-badge-openrouter-main").assertTextContains("$12.50", substring = true)
+    }
+
+    @Test
+    fun tappingAvailableBadgeFiresCallbackWithProviderName() {
+        var clicked: String? = null
+        composeTestRule.setContent {
+            BellhopTheme {
+                QuotaBadgeRow(
+                    quota = listOf(available, deadKey),
+                    mode = QuotaBarMode.REMAINING,
+                    onBadgeClick = { clicked = it },
+                )
+            }
+        }
+        composeTestRule.onNodeWithTag("quota-badge-openrouter-main").performClick()
+        assertEquals("openrouter-main", clicked)
+    }
+
+    // A dead-key badge stays tappable: the detail sheet is what explains
+    // *why* it's unavailable, so swallowing the tap would strand the user
+    // looking at a "-" with no way to find out more.
+    @Test
+    fun tappingDeadKeyBadgeAlsoFiresCallback() {
+        var clicked: String? = null
+        composeTestRule.setContent {
+            BellhopTheme {
+                QuotaBadgeRow(
+                    quota = listOf(available, deadKey),
+                    mode = QuotaBarMode.REMAINING,
+                    onBadgeClick = { clicked = it },
+                )
+            }
+        }
+        composeTestRule.onNodeWithTag("quota-badge-nanogpt-broken").performClick()
+        assertEquals("nanogpt-broken", clicked)
+    }
+
+    @Test
+    fun emptyQuotaRendersNoBadges() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                QuotaBadgeRow(quota = emptyList(), mode = QuotaBarMode.REMAINING, onBadgeClick = {})
+            }
+        }
+        composeTestRule.onNodeWithTag("quota-badge-openrouter-main").assertDoesNotExist()
+    }
+
+    @Test
+    fun detailSheetShowsUnavailableLineForDeadKey() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                QuotaDetailSheet(pq = deadKey, mode = QuotaBarMode.REMAINING, onDismiss = {})
+            }
+        }
+        composeTestRule.onNodeWithTag("quota-detail-sheet").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("quota-detail-unavailable").assertIsDisplayed()
+    }
+
+    @Test
+    fun detailSheetShowsComputedLabelForAvailableProvider() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                QuotaDetailSheet(pq = available, mode = QuotaBarMode.REMAINING, onDismiss = {})
+            }
+        }
+        composeTestRule.onNodeWithText("$12.50", substring = true).assertIsDisplayed()
+    }
+}

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/settings/QuotaBadgesConfigScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/settings/QuotaBadgesConfigScreenTest.kt
@@ -1,0 +1,153 @@
+package com.hugalafutro.bellhop.ui.settings
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import com.hugalafutro.bellhop.data.InMemoryPreferencesDataStore
+import com.hugalafutro.bellhop.data.PrefsStore
+import com.hugalafutro.bellhop.data.QuotaBadgeConfigStore
+import com.hugalafutro.bellhop.data.QuotaBarMode
+import com.hugalafutro.bellhop.data.QuotaSurface
+import com.hugalafutro.bellhop.ui.theme.BellhopTheme
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * QuotaBadgesConfigScreen owns its store writes directly (no ViewModel), so
+ * these tests drive real in-memory-backed [QuotaBadgeConfigStore] /
+ * [PrefsStore] instances and assert on the store's resulting state after a
+ * tap, not on a callback capture. Assertions are all by test tag or store
+ * enum value, never translated text (see global-constraints).
+ */
+@RunWith(RobolectricTestRunner::class)
+class QuotaBadgesConfigScreenTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private fun newConfigStore(): QuotaBadgeConfigStore = QuotaBadgeConfigStore(InMemoryPreferencesDataStore())
+
+    private fun newPrefsStore(): PrefsStore = PrefsStore(InMemoryPreferencesDataStore())
+
+    @Test
+    fun bothSurfaceTabsAreDisplayed() {
+        val configStore = newConfigStore()
+        composeTestRule.setContent {
+            BellhopTheme {
+                QuotaBadgesConfigScreen(configStore = configStore, prefsStore = newPrefsStore(), onBack = {})
+            }
+        }
+        composeTestRule.onNodeWithTag("quota-config-tab-main").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("quota-config-tab-widget").assertIsDisplayed()
+    }
+
+    @Test
+    fun togglingRowSwitchHidesBadgeInStore() {
+        val configStore = newConfigStore()
+        runBlocking { configStore.reconcile(QuotaSurface.MAIN, listOf("OR", "NG")) }
+
+        composeTestRule.setContent {
+            BellhopTheme {
+                QuotaBadgesConfigScreen(configStore = configStore, prefsStore = newPrefsStore(), onBack = {})
+            }
+        }
+
+        // MAIN is the default tab and OR starts visible (unhidden) by default.
+        composeTestRule.onNodeWithTag("quota-config-visible-OR").performClick()
+        composeTestRule.waitForIdle()
+
+        val hidden = runBlocking { configStore.config(QuotaSurface.MAIN).first().hidden }
+        assertTrue("OR" in hidden)
+    }
+
+    @Test
+    fun switchingToWidgetTabShowsWidgetConfig() {
+        val configStore = newConfigStore()
+        runBlocking {
+            configStore.reconcile(QuotaSurface.MAIN, listOf("OR"))
+            configStore.reconcile(QuotaSurface.WIDGET, listOf("NG"))
+        }
+
+        composeTestRule.setContent {
+            BellhopTheme {
+                QuotaBadgesConfigScreen(configStore = configStore, prefsStore = newPrefsStore(), onBack = {})
+            }
+        }
+
+        composeTestRule.onNodeWithTag("quota-config-tab-widget").performClick()
+        composeTestRule.waitForIdle()
+
+        // WIDGET reconciled with one name, newly-seen names default hidden on
+        // that surface, so the row toggling it back on lands in the store.
+        composeTestRule.onNodeWithTag("quota-config-visible-NG").performClick()
+        composeTestRule.waitForIdle()
+
+        val visible = runBlocking { configStore.config(QuotaSurface.WIDGET).first().hidden }
+        assertTrue("NG" !in visible)
+    }
+
+    @Test
+    fun widgetTabShowsCapHeadroomText() {
+        val configStore = newConfigStore()
+        runBlocking { configStore.reconcile(QuotaSurface.WIDGET, listOf("OR", "NG")) }
+
+        composeTestRule.setContent {
+            BellhopTheme {
+                QuotaBadgesConfigScreen(configStore = configStore, prefsStore = newPrefsStore(), onBack = {})
+            }
+        }
+
+        composeTestRule.onNodeWithTag("quota-config-tab-widget").performClick()
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithTag("quota-config-widget-cap").assertIsDisplayed()
+    }
+
+    @Test
+    fun emptyOrderShowsEmptyState() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                QuotaBadgesConfigScreen(configStore = newConfigStore(), prefsStore = newPrefsStore(), onBack = {})
+            }
+        }
+        composeTestRule.onNodeWithTag("quota-config-empty").assertIsDisplayed()
+    }
+
+    @Test
+    fun modeToggleFiresSetQuotaBarMode() {
+        val prefsStore = newPrefsStore()
+        composeTestRule.setContent {
+            BellhopTheme {
+                QuotaBadgesConfigScreen(configStore = newConfigStore(), prefsStore = prefsStore, onBack = {})
+            }
+        }
+
+        composeTestRule.onNodeWithTag("quota-mode-toggle").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("quota-mode-used").performClick()
+        composeTestRule.waitForIdle()
+
+        assertEquals(QuotaBarMode.USED, runBlocking { prefsStore.quotaBarMode.first() })
+    }
+
+    @Test
+    fun backArrowFiresCallback() {
+        var backs = 0
+        composeTestRule.setContent {
+            BellhopTheme {
+                QuotaBadgesConfigScreen(
+                    configStore = newConfigStore(),
+                    prefsStore = newPrefsStore(),
+                    onBack = { backs++ },
+                )
+            }
+        }
+        composeTestRule.onNodeWithTag("quota-config-back").performClick()
+        assertEquals(1, backs)
+    }
+}

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/settings/QuotaBadgesConfigScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/settings/QuotaBadgesConfigScreenTest.kt
@@ -9,6 +9,7 @@ import com.hugalafutro.bellhop.data.PrefsStore
 import com.hugalafutro.bellhop.data.QuotaBadgeConfigStore
 import com.hugalafutro.bellhop.data.QuotaBarMode
 import com.hugalafutro.bellhop.data.QuotaSurface
+import com.hugalafutro.bellhop.data.WIDGET_QUOTA_CAP
 import com.hugalafutro.bellhop.ui.theme.BellhopTheme
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
@@ -93,9 +94,34 @@ class QuotaBadgesConfigScreenTest {
     }
 
     @Test
-    fun widgetTabShowsCapHeadroomText() {
+    fun widgetTabStaysQuietWhenTheSelectionFits() {
+        // The widget wraps badges onto several lines, so a selection under the
+        // cap is shown in full and the cap note would only be noise.
         val configStore = newConfigStore()
         runBlocking { configStore.reconcile(QuotaSurface.WIDGET, listOf("OR", "NG")) }
+
+        composeTestRule.setContent {
+            BellhopTheme {
+                QuotaBadgesConfigScreen(configStore = configStore, prefsStore = newPrefsStore(), onBack = {})
+            }
+        }
+
+        composeTestRule.onNodeWithTag("quota-config-tab-widget").performClick()
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithTag("quota-config-widget-cap").assertDoesNotExist()
+    }
+
+    @Test
+    fun widgetTabWarnsWhenTheSelectionOutrunsTheCap() {
+        val configStore = newConfigStore()
+        val names = (1..WIDGET_QUOTA_CAP + 1).map { "P$it" }
+        runBlocking {
+            configStore.reconcile(QuotaSurface.WIDGET, names)
+            // WIDGET is opt-in, so reconcile leaves new names hidden; tick them
+            // all on to get past the cap.
+            names.forEach { configStore.setVisible(QuotaSurface.WIDGET, it, true) }
+        }
 
         composeTestRule.setContent {
             BellhopTheme {

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreenTest.kt
@@ -58,6 +58,7 @@ class SettingsScreenTest {
         batteryUnrestricted: Boolean = true,
         onRequestBatteryExemption: () -> Unit = {},
         onAlertsClick: () -> Unit = {},
+        onQuotaBadgesClick: () -> Unit = {},
         onUnlink: () -> Unit = {},
         onForceUnlink: () -> Unit = {},
         onDismissUnlinkError: () -> Unit = {},
@@ -82,6 +83,7 @@ class SettingsScreenTest {
                     onToggleMonitor = onToggleMonitor,
                     onTogglePush = onTogglePush,
                     onAlertsClick = onAlertsClick,
+                    onQuotaBadgesClick = onQuotaBadgesClick,
                     onUnlink = onUnlink,
                     unlinkFailed = unlinkFailed,
                     onDismissUnlinkError = onDismissUnlinkError,
@@ -266,6 +268,14 @@ class SettingsScreenTest {
         var opened = 0
         content(onAlertsClick = { opened++ })
         composeTestRule.onNodeWithTag("settings-alerts").performScrollTo().performClick()
+        assertTrue(opened == 1)
+    }
+
+    @Test
+    fun quotaBadgesRowFiresCallback() {
+        var opened = 0
+        content(onQuotaBadgesClick = { opened++ })
+        composeTestRule.onNodeWithTag("settings-quota-badges").performScrollTo().performClick()
         assertTrue(opened == 1)
     }
 

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/widget/BellhopWidgetTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/widget/BellhopWidgetTest.kt
@@ -1,0 +1,31 @@
+package com.hugalafutro.bellhop.widget
+
+import android.app.Application
+import com.hugalafutro.bellhop.MainActivity
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+/**
+ * quotaBadgeIntent is the only piece of the quota-badge tap that is plain
+ * enough to unit test: it's a pure function over a Context, with no Glance
+ * composition involved. The render itself is covered by an on-device smoke
+ * test, not here.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class BellhopWidgetTest {
+    private val app: Application = RuntimeEnvironment.getApplication()
+
+    @Test
+    fun quotaBadgeIntentTargetsMainActivityWithDeepLinkExtras() {
+        val intent = quotaBadgeIntent(app, "or-1")
+
+        assertEquals(ACTION_OPEN_QUOTA, intent.action)
+        assertEquals("or-1", intent.getStringExtra(EXTRA_BADGE_PROVIDER_NAME))
+        assertEquals(MainActivity::class.java.name, intent.component?.className)
+    }
+}

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/work/FleetBackstopTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/work/FleetBackstopTest.kt
@@ -109,6 +109,8 @@ class FleetBackstopTest {
     private fun enqueuePoll(healthy: Boolean) {
         server.enqueue(MockResponse().setBody(memberBody(healthy)))
         server.enqueue(MockResponse().setBody("""{"enabled":true,"primary_id":"m1","stale":false}"""))
+        // Every successful poll now also fetches quota (empty here).
+        server.enqueue(MockResponse().setBody("""{"quota":[]}"""))
     }
 
     private suspend fun run(

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/work/FleetBackstopTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/work/FleetBackstopTest.kt
@@ -12,6 +12,7 @@ import com.hugalafutro.bellhop.data.MemberHealthState
 import com.hugalafutro.bellhop.data.MemberTransition
 import com.hugalafutro.bellhop.data.MonitorStore
 import com.hugalafutro.bellhop.data.PairedDevice
+import com.hugalafutro.bellhop.data.QuotaBadgeConfigStore
 import com.hugalafutro.bellhop.data.TokenCipher
 import com.hugalafutro.bellhop.data.WidgetStore
 import kotlinx.coroutines.CoroutineScope
@@ -83,6 +84,8 @@ class FleetBackstopTest {
 
     private fun widgetStore(): WidgetStore = WidgetStore(preferences("widget"))
 
+    private fun newConfigStore(): QuotaBadgeConfigStore = QuotaBadgeConfigStore(preferences("quota-config"))
+
     private fun linkStore(cipher: TokenCipher): LinkStore = LinkStore(preferences("link"), cipher)
 
     private suspend fun linkedTo(
@@ -113,9 +116,17 @@ class FleetBackstopTest {
         link: LinkStore,
         canNotify: Boolean = true,
     ): Result =
-        runBackstop(monitor, link, widgetStore = widgetStore(), client = client, canNotify = canNotify, notify = {
-            fired += it
-        })
+        runBackstop(
+            monitor,
+            link,
+            widgetStore = widgetStore(),
+            client = client,
+            configStore = newConfigStore(),
+            canNotify = canNotify,
+            notify = {
+                fired += it
+            },
+        )
 
     @Test
     fun disabledMonitoringSucceedsWithoutPolling() =
@@ -247,6 +258,7 @@ class FleetBackstopTest {
                     linkedTo(server.url("/").toString()),
                     widgetStore = widgetStore(),
                     client = client,
+                    configStore = newConfigStore(),
                     canNotify = true,
                     notify = { fired += it },
                     retryOnFailure = false,

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/work/FleetPollTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/work/FleetPollTest.kt
@@ -374,4 +374,29 @@ class FleetPollTest {
             // Stale beats blank: a failed quota read keeps the last-good badges.
             assertEquals(prior, widget.read()?.quota)
         }
+
+    @Test
+    fun badGatewayQuotaReadKeepsPreviousWidgetBadges() =
+        runBlocking {
+            val store = newStore()
+            store.setEnabled(true)
+            val widget = newWidgetStore()
+            val prior = listOf(WidgetQuotaBadge("or-1", "OPENROUTER", "\$7.50"))
+            widget.saveIfChanged(
+                WidgetState(members = listOf(WidgetMember("hotel-1", "UP", id = "m1")), quota = prior),
+                widget.generation(),
+            )
+            server.enqueue(MockResponse().setBody(memberBody(healthy = true)))
+            server.enqueue(MockResponse().setBody(autoSyncBody(false)))
+            // Front Desk's 502 for an unreachable primary, body and all: the
+            // envelope parses into a zero-entry list, so this is the case where
+            // ignoring the status would silently blank the widget's badges rather
+            // than fail loudly. Separate from the 500 case above precisely because
+            // the body is well-formed.
+            server.enqueue(MockResponse().setResponseCode(502).setBody("""{"quota":[]}"""))
+
+            poll(store, widget, newConfigStore())
+
+            assertEquals(prior, widget.read()?.quota)
+        }
 }

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/work/FleetPollTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/work/FleetPollTest.kt
@@ -9,7 +9,10 @@ import com.hugalafutro.bellhop.data.FrontDeskClient
 import com.hugalafutro.bellhop.data.MemberHealthState
 import com.hugalafutro.bellhop.data.MemberTransition
 import com.hugalafutro.bellhop.data.MonitorStore
+import com.hugalafutro.bellhop.data.QuotaBadgeConfigStore
+import com.hugalafutro.bellhop.data.QuotaSurface
 import com.hugalafutro.bellhop.data.WidgetMember
+import com.hugalafutro.bellhop.data.WidgetQuotaBadge
 import com.hugalafutro.bellhop.data.WidgetState
 import com.hugalafutro.bellhop.data.WidgetStore
 import kotlinx.coroutines.CoroutineScope
@@ -83,12 +86,29 @@ class FleetPollTest {
     ) {
         server.enqueue(MockResponse().setBody(memberBody(healthy)))
         server.enqueue(MockResponse().setBody(autoSyncBody(stale)))
+        // Every successful poll now also fetches quota; empty by default so tests
+        // that don't exercise badges keep their enqueue counts simple.
+        server.enqueue(MockResponse().setBody("""{"quota":[]}"""))
     }
+
+    private fun newConfigStore(): QuotaBadgeConfigStore {
+        val scope = CoroutineScope(Dispatchers.IO + Job())
+        val ds: DataStore<Preferences> =
+            PreferenceDataStoreFactory.create(scope = scope) {
+                File(tmp.newFolder(), "quota-config.preferences_pb")
+            }
+        return QuotaBadgeConfigStore(ds)
+    }
+
+    private fun quotaBody(): String =
+        """{"quota":[{"provider_name":"or-1","type":"openrouter","kind":"usage",""" +
+            """"payload":{"label":"k","limit":10.0,"usage":2.5},"http_status":200,"fetched_at":"t"}]}"""
 
     private suspend fun poll(
         store: MonitorStore,
         widget: WidgetStore = newWidgetStore(),
-    ): PollResult = pollFleet(client, server.url("/").toString(), "tok-1", store, widget, now = { 42L })
+        config: QuotaBadgeConfigStore = newConfigStore(),
+    ): PollResult = pollFleet(client, server.url("/").toString(), "tok-1", store, widget, config, now = { 42L })
 
     @Test
     fun firstPollSavesBaselineWithNoTransitions() =
@@ -150,6 +170,7 @@ class FleetPollTest {
             )
             server.enqueue(MockResponse().setBody(memberBody(healthy = false)))
             server.enqueue(MockResponse().setResponseCode(500).setBody("nope"))
+            server.enqueue(MockResponse().setBody("""{"quota":[]}"""))
 
             val result = poll(store)
 
@@ -241,11 +262,24 @@ class FleetPollTest {
                 ),
             )
 
-            pollFleet(client, server.url("/").toString(), "tok-1", store, widget, includeTraffic = true, now = { 42L })
+            pollFleet(
+                client,
+                server.url(
+                    "/",
+                ).toString(),
+                "tok-1",
+                store,
+                widget,
+                newConfigStore(),
+                includeTraffic = true,
+                now = {
+                    42L
+                },
+            )
 
             assertEquals(listOf(1, 5), widget.read()?.members?.single()?.traffic)
-            // members + autosync + one traffic call for the one member.
-            assertEquals(3, server.requestCount)
+            // members + autosync + quota + one traffic call for the one member.
+            assertEquals(4, server.requestCount)
         }
 
     @Test
@@ -260,7 +294,7 @@ class FleetPollTest {
 
             assertEquals(emptyList<Int>(), widget.read()?.members?.single()?.traffic)
             // The exact request count the battery baseline was measured against.
-            assertEquals(2, server.requestCount)
+            assertEquals(3, server.requestCount)
         }
 
     @Test
@@ -279,10 +313,65 @@ class FleetPollTest {
             enqueuePoll(healthy = true)
             server.enqueue(MockResponse().setResponseCode(500).setBody("nope"))
 
-            pollFleet(client, server.url("/").toString(), "tok-1", store, widget, includeTraffic = true, now = { 42L })
+            pollFleet(
+                client,
+                server.url(
+                    "/",
+                ).toString(),
+                "tok-1",
+                store,
+                widget,
+                newConfigStore(),
+                includeTraffic = true,
+                now = {
+                    42L
+                },
+            )
 
             // A failed series read keeps the member's previous bars: stale beats
             // blank, and a blip must not blank the whole hour.
             assertEquals(listOf(7, 8), widget.read()?.members?.single()?.traffic)
+        }
+
+    @Test
+    fun successfulPollWritesVisibleWidgetQuota() =
+        runBlocking {
+            val store = newStore()
+            store.setEnabled(true)
+            val widget = newWidgetStore()
+            val config = newConfigStore()
+            // A widget badge is opt-in (new names default hidden on WIDGET), so
+            // pre-place it in the order to keep it visible through reconcile.
+            config.setOrder(QuotaSurface.WIDGET, listOf("or-1"))
+            server.enqueue(MockResponse().setBody(memberBody(healthy = true)))
+            server.enqueue(MockResponse().setBody(autoSyncBody(false)))
+            server.enqueue(MockResponse().setBody(quotaBody()))
+
+            poll(store, widget, config)
+
+            val badges = widget.read()?.quota
+            assertEquals(1, badges?.size)
+            assertEquals("or-1", badges?.single()?.providerName)
+        }
+
+    @Test
+    fun quotaReadFailureKeepsPreviousWidgetBadges() =
+        runBlocking {
+            val store = newStore()
+            store.setEnabled(true)
+            val widget = newWidgetStore()
+            val prior = listOf(WidgetQuotaBadge("or-1", "OPENROUTER", "\$7.50"))
+            widget.saveIfChanged(
+                WidgetState(members = listOf(WidgetMember("hotel-1", "UP", id = "m1")), quota = prior),
+                widget.generation(),
+            )
+            server.enqueue(MockResponse().setBody(memberBody(healthy = true)))
+            server.enqueue(MockResponse().setBody(autoSyncBody(false)))
+            server.enqueue(MockResponse().setResponseCode(500).setBody("nope"))
+
+            poll(store, widget, newConfigStore())
+
+            // Stale beats blank: a failed quota read keeps the last-good badges.
+            assertEquals(prior, widget.read()?.quota)
         }
 }

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/work/WidgetRefreshTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/work/WidgetRefreshTest.kt
@@ -7,6 +7,7 @@ import androidx.work.ListenableWorker.Result
 import com.hugalafutro.bellhop.data.FrontDeskClient
 import com.hugalafutro.bellhop.data.LinkStore
 import com.hugalafutro.bellhop.data.PairedDevice
+import com.hugalafutro.bellhop.data.QuotaBadgeConfigStore
 import com.hugalafutro.bellhop.data.TokenCipher
 import com.hugalafutro.bellhop.data.WidgetMember
 import com.hugalafutro.bellhop.data.WidgetState
@@ -72,6 +73,8 @@ class WidgetRefreshTest {
 
     private fun newWidgetStore(): WidgetStore = WidgetStore(preferences("widget"))
 
+    private fun newConfigStore(): QuotaBadgeConfigStore = QuotaBadgeConfigStore(preferences("quota-config"))
+
     private fun unlinkedLinkStore(): LinkStore = LinkStore(preferences("link"), passThrough)
 
     private suspend fun linkedLinkStore(): LinkStore =
@@ -106,7 +109,7 @@ class WidgetRefreshTest {
             val widget = newWidgetStore()
             enqueuePoll(healthy = true)
 
-            val result = refreshWidgetOnly(linkedLinkStore(), widget, client, now = { 42L })
+            val result = refreshWidgetOnly(linkedLinkStore(), widget, client, newConfigStore(), now = { 42L })
 
             assertEquals(Result.success(), result)
             assertEquals(listOf(WidgetMember("hotel-1", "UP", id = "m1")), widget.read()?.members)
@@ -118,7 +121,7 @@ class WidgetRefreshTest {
         runBlocking {
             val widget = newWidgetStore()
 
-            val result = refreshWidgetOnly(unlinkedLinkStore(), widget, client, now = { 42L })
+            val result = refreshWidgetOnly(unlinkedLinkStore(), widget, client, newConfigStore(), now = { 42L })
 
             assertEquals(Result.success(), result)
             assertNull(widget.read())
@@ -137,7 +140,7 @@ class WidgetRefreshTest {
             )
             server.enqueue(MockResponse().setResponseCode(500).setBody("nope"))
 
-            val result = refreshWidgetOnly(linkedLinkStore(), widget, client, now = { 42L })
+            val result = refreshWidgetOnly(linkedLinkStore(), widget, client, newConfigStore(), now = { 42L })
 
             // User-initiated one-shot never retries; stale beats blank.
             assertEquals(Result.success(), result)
@@ -161,7 +164,7 @@ class WidgetRefreshTest {
             server.enqueue(MockResponse().setBody(memberBody(healthy = true)))
             server.enqueue(MockResponse().setResponseCode(500).setBody("nope"))
 
-            val result = refreshWidgetOnly(linkedLinkStore(), widget, client, now = { 42L })
+            val result = refreshWidgetOnly(linkedLinkStore(), widget, client, newConfigStore(), now = { 42L })
 
             assertEquals(Result.success(), result)
             assertEquals(true, widget.read()?.autosyncStale)

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/work/WidgetRefreshTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/work/WidgetRefreshTest.kt
@@ -98,6 +98,8 @@ class WidgetRefreshTest {
     ) {
         server.enqueue(MockResponse().setBody(memberBody(healthy)))
         server.enqueue(MockResponse().setBody("""{"enabled":true,"primary_id":"m1","stale":$stale}"""))
+        // Every successful poll now also fetches quota (empty here).
+        server.enqueue(MockResponse().setBody("""{"quota":[]}"""))
     }
 
     @Test
@@ -163,6 +165,7 @@ class WidgetRefreshTest {
             )
             server.enqueue(MockResponse().setBody(memberBody(healthy = true)))
             server.enqueue(MockResponse().setResponseCode(500).setBody("nope"))
+            server.enqueue(MockResponse().setBody("""{"quota":[]}"""))
 
             val result = refreshWidgetOnly(linkedLinkStore(), widget, client, newConfigStore(), now = { 42L })
 

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/work/WidgetRefreshTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/work/WidgetRefreshTest.kt
@@ -10,6 +10,7 @@ import com.hugalafutro.bellhop.data.PairedDevice
 import com.hugalafutro.bellhop.data.QuotaBadgeConfigStore
 import com.hugalafutro.bellhop.data.TokenCipher
 import com.hugalafutro.bellhop.data.WidgetMember
+import com.hugalafutro.bellhop.data.WidgetQuotaBadge
 import com.hugalafutro.bellhop.data.WidgetState
 import com.hugalafutro.bellhop.data.WidgetStore
 import kotlinx.coroutines.CoroutineScope
@@ -171,5 +172,28 @@ class WidgetRefreshTest {
 
             assertEquals(Result.success(), result)
             assertEquals(true, widget.read()?.autosyncStale)
+        }
+
+    @Test
+    fun badGatewayQuotaReadKeepsLastGoodBadges() =
+        runBlocking {
+            val widget = newWidgetStore()
+            val prior = listOf(WidgetQuotaBadge("or-1", "OPENROUTER", "\$7.50"))
+            widget.saveIfChanged(
+                WidgetState(members = listOf(WidgetMember("hotel-1", "UP", id = "m1")), quota = prior),
+                widget.generation(),
+            )
+            server.enqueue(MockResponse().setBody(memberBody(healthy = true)))
+            server.enqueue(MockResponse().setBody("""{"enabled":true,"primary_id":"m1","stale":false}"""))
+            // Front Desk's 502 for an unreachable primary. The envelope decodes
+            // into a zero-entry list, so the refresh button is the third surface
+            // that must reject it on status alone rather than write empty badges
+            // over the ones the widget is already showing.
+            server.enqueue(MockResponse().setResponseCode(502).setBody("""{"quota":[]}"""))
+
+            val result = refreshWidgetOnly(linkedLinkStore(), widget, client, newConfigStore(), now = { 42L })
+
+            assertEquals(Result.success(), result)
+            assertEquals(prior, widget.read()?.quota)
         }
 }

--- a/internal/api/quota_fleet.go
+++ b/internal/api/quota_fleet.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 
+	"github.com/hugalafutro/model-hotel/internal/provider"
 	"github.com/hugalafutro/model-hotel/internal/quota"
 )
 
@@ -16,6 +17,7 @@ import (
 // contract config-sync already uses.
 type QuotaSnapshotWire struct {
 	ProviderName string          `json:"provider_name"`
+	Type         string          `json:"type"` // provider type from DetectProviderType(base_url); chooses the badge
 	Kind         string          `json:"kind"`
 	Payload      json.RawMessage `json:"payload"`
 	HTTPStatus   int             `json:"http_status"`
@@ -57,8 +59,10 @@ func (h *QuotaFleetHandler) ExportSnapshots(w http.ResponseWriter, r *http.Reque
 	}
 
 	idToName := make(map[uuid.UUID]string, len(provs))
+	idToType := make(map[uuid.UUID]string, len(provs))
 	for _, p := range provs {
 		idToName[p.ID] = p.Name
+		idToType[p.ID] = provider.DetectProviderType(p.BaseURL)
 	}
 
 	wire := make([]QuotaSnapshotWire, 0, len(snaps))
@@ -77,6 +81,7 @@ func (h *QuotaFleetHandler) ExportSnapshots(w http.ResponseWriter, r *http.Reque
 		}
 		wire = append(wire, QuotaSnapshotWire{
 			ProviderName: name,
+			Type:         idToType[s.ProviderID],
 			Kind:         s.Kind,
 			Payload:      s.Payload,
 			HTTPStatus:   s.HTTPStatus,

--- a/internal/api/quota_fleet_test.go
+++ b/internal/api/quota_fleet_test.go
@@ -23,6 +23,51 @@ func cancelledRequest(method, target, body string) *http.Request {
 	return httptest.NewRequest(method, target, strings.NewReader(body)).WithContext(ctx)
 }
 
+// TestExportSnapshots_IncludesProviderType: the wire snapshot carries the
+// provider's detected type (not just its stored kind), so a consumer (Front
+// Desk, Bellhop) can pick the right badge without re-deriving it.
+func TestExportSnapshots_IncludesProviderType(t *testing.T) {
+	h := newTestHandler(t)
+	fleet := NewQuotaFleetHandler(h.quotaRepo, h.providerRepo)
+
+	prov, err := h.providerRepo.Create(context.Background(), provider.CreateProviderRequest{
+		Name:    "openrouter-export",
+		BaseURL: "https://openrouter.ai/api/v1",
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("create provider: %v", err)
+	}
+	if err := h.quotaRepo.Upsert(context.Background(), quota.Snapshot{
+		ProviderID: prov.ID,
+		Kind:       "usage",
+		Payload:    json.RawMessage(`{"used":4}`),
+		HTTPStatus: 200,
+		Source:     "poll",
+	}); err != nil {
+		t.Fatalf("upsert snapshot: %v", err)
+	}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/config/quota-snapshots", http.NoBody)
+	fleet.ExportSnapshots(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var body struct {
+		Snapshots []QuotaSnapshotWire `json:"snapshots"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Snapshots) != 1 {
+		t.Fatalf("want 1 snapshot, got %+v", body.Snapshots)
+	}
+	if body.Snapshots[0].Type != "openrouter" {
+		t.Fatalf("want type=openrouter, got %+v", body.Snapshots[0])
+	}
+}
+
 func TestQuotaFleetExportSnapshots(t *testing.T) {
 	h := newTestHandler(t)
 	fleet := NewQuotaFleetHandler(h.quotaRepo, h.providerRepo)

--- a/internal/frontdesk/quota.go
+++ b/internal/frontdesk/quota.go
@@ -2,7 +2,6 @@ package frontdesk
 
 import (
 	"encoding/json"
-	"errors"
 	"net/http"
 )
 
@@ -31,8 +30,8 @@ func writeQuotaUnreachable(w http.ResponseWriter, msg string) {
 // quotaPrimary resolves the member both quota handlers proxy to. When it returns
 // ok=false it has already written the response, so the caller just returns:
 // either a 200 carrying none (the caller's "nothing to report" payload) for the
-// two steady states that legitimately have no primary to ask, or an error status
-// for every failure to reach one that does exist.
+// one steady state with no primary to ask -- none designated -- or an error
+// status for every failure to reach a primary that is designated.
 func (s *Server) quotaPrimary(w http.ResponseWriter, r *http.Request, none any) (*Member, string, bool) {
 	cfg, err := s.store.GetAutoSync(r.Context())
 	if err != nil {
@@ -50,17 +49,15 @@ func (s *Server) quotaPrimary(w http.ResponseWriter, r *http.Request, none any) 
 		return nil, "", false
 	}
 	primary, token, err := s.memberTokenOrErr(r.Context(), cfg.PrimaryID)
-	switch {
-	case errors.Is(err, ErrNotFound):
-		// The designated member row is gone (deleted while still designated):
-		// the same steady state as none designated.
-		writeJSON(w, http.StatusOK, none)
-		return nil, "", false
-	case err != nil:
-		// The primary exists but is unusable to us: no stored admin token
-		// (ErrValidation), an undecryptable one, or a store failure. We could
-		// not ask, which is not the same as "nothing to report".
-		writeQuotaUnreachable(w, "could not authenticate to the fleet primary")
+	if err != nil {
+		// A designated primary we cannot use: no stored admin token
+		// (ErrValidation), an undecryptable one, a store failure, or no member
+		// row at all (ErrNotFound). The dangling-id case is an anomaly rather
+		// than a steady state -- DeleteMemberIfNotPrimary refuses to remove the
+		// designated primary, and DeleteMember clears the pointer -- so it means
+		// a cleanup failed, not that the fleet stopped having a primary. Either
+		// way we could not ask, which is not the same as "nothing to report".
+		writeQuotaUnreachable(w, "could not reach the fleet primary")
 		return nil, "", false
 	}
 	return primary, token, true

--- a/internal/frontdesk/quota.go
+++ b/internal/frontdesk/quota.go
@@ -2,6 +2,7 @@ package frontdesk
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 )
 
@@ -17,34 +18,80 @@ type quotaWire struct {
 	FetchedAt    string          `json:"fetched_at"`
 }
 
+// writeQuotaUnreachable answers a quota proxy request that could not be served
+// because Front Desk failed to get an answer out of a primary that does exist.
+// It must never be an empty 200: Bellhop keeps its last-good badges only when a
+// read fails, and an empty 200 is indistinguishable from a fleet that genuinely
+// has no quota-capable providers, so degrading a transient failure into one
+// silently wipes the badges off the dashboard and the home-screen widget.
+func writeQuotaUnreachable(w http.ResponseWriter, msg string) {
+	writeJSON(w, http.StatusBadGateway, map[string]string{"error": msg})
+}
+
+// quotaPrimary resolves the member both quota handlers proxy to. When it returns
+// ok=false it has already written the response, so the caller just returns:
+// either a 200 carrying none (the caller's "nothing to report" payload) for the
+// two steady states that legitimately have no primary to ask, or an error status
+// for every failure to reach one that does exist.
+func (s *Server) quotaPrimary(w http.ResponseWriter, r *http.Request, none any) (*Member, string, bool) {
+	cfg, err := s.store.GetAutoSync(r.Context())
+	if err != nil {
+		// Front Desk's own store is unreadable. That is our failure, not the
+		// primary's, so it maps to 500 rather than 502 -- but it is still an
+		// error, because answering "no quota" here would wipe the device's
+		// badges over a transient local hiccup.
+		writeError(w, err)
+		return nil, "", false
+	}
+	if cfg.PrimaryID == "" {
+		// Standalone / not set up yet: there is no one to ask, and there never
+		// was. A steady state, so an empty payload is the truthful answer.
+		writeJSON(w, http.StatusOK, none)
+		return nil, "", false
+	}
+	primary, token, err := s.memberTokenOrErr(r.Context(), cfg.PrimaryID)
+	switch {
+	case errors.Is(err, ErrNotFound):
+		// The designated member row is gone (deleted while still designated):
+		// the same steady state as none designated.
+		writeJSON(w, http.StatusOK, none)
+		return nil, "", false
+	case err != nil:
+		// The primary exists but is unusable to us: no stored admin token
+		// (ErrValidation), an undecryptable one, or a store failure. We could
+		// not ask, which is not the same as "nothing to report".
+		writeQuotaUnreachable(w, "could not authenticate to the fleet primary")
+		return nil, "", false
+	}
+	return primary, token, true
+}
+
 // handleQuota proxies the designated primary member's quota snapshot export to a
 // paired device (monitor tier). It mirrors DistributeQuotaOnce's read side: the
-// primary is the source of truth, Front Desk keeps no copy. No primary designated
-// (standalone / not set up) or an unreachable primary yields an empty set, and the
-// device shows its last-good (stale-beats-blank on the Android side).
+// primary is the source of truth, Front Desk keeps no copy. With no primary to
+// ask the answer is an empty set; a primary that cannot be reached, does not
+// answer 200, or answers something undecodable is a 502, which leaves the device
+// on its last-good badges (stale beats blank on the Android side).
 func (s *Server) handleQuota(w http.ResponseWriter, r *http.Request) {
 	empty := map[string]any{"quota": []quotaWire{}}
 
-	cfg, err := s.store.GetAutoSync(r.Context())
-	if err != nil || cfg.PrimaryID == "" {
-		writeJSON(w, http.StatusOK, empty)
-		return
-	}
-	primary, token, err := s.memberTokenOrErr(r.Context(), cfg.PrimaryID)
-	if err != nil {
-		writeJSON(w, http.StatusOK, empty)
+	primary, token, ok := s.quotaPrimary(w, r, empty)
+	if !ok {
 		return
 	}
 	status, body, err := s.callMember(r.Context(), http.MethodGet, primary.URL, memberQuotaSnapshotsPath, token, nil)
 	if err != nil || status != http.StatusOK {
-		writeJSON(w, http.StatusOK, empty)
+		writeQuotaUnreachable(w, "could not read the primary's quota snapshots")
 		return
 	}
 	var parsed struct {
 		Snapshots []quotaWire `json:"snapshots"`
 	}
 	if err := json.Unmarshal(body, &parsed); err != nil {
-		writeJSON(w, http.StatusOK, empty)
+		// A 200 that isn't the export shape (a proxy's error page, say) means we
+		// still don't know the primary's quota, so it fails like an unreachable
+		// primary rather than reading as "no snapshots".
+		writeQuotaUnreachable(w, "could not decode the primary's quota snapshots")
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"quota": parsed.Snapshots})
@@ -58,27 +105,23 @@ const memberRefreshQuotasPath = "/api/providers/refresh-quotas"
 // handleQuotaRefresh forces the designated primary member to re-poll its
 // quota-capable providers' upstream endpoints (the pull-to-refresh path),
 // mirroring handleQuota's read side but as a write-through proxy. It is
-// monitor-tier: any paired device may trigger a refresh. No primary
-// designated or an unreachable primary yields a 200 no-op.
+// monitor-tier: any paired device may trigger a refresh. It splits outcomes the
+// same way: no primary to ask is a 200 no-op, a primary that could not be asked
+// is a 502 so the device can say the refresh failed instead of showing a
+// successful refresh that changed nothing.
 func (s *Server) handleQuotaRefresh(w http.ResponseWriter, r *http.Request) {
 	// The success path writes the member's body verbatim ({results, refreshed,
 	// failed, skipped}); the no-op carries the same keys with an empty result
 	// list so both paths answer this route with one shape.
 	noop := map[string]any{"results": []any{}, "refreshed": 0, "failed": 0, "skipped": 0}
 
-	cfg, err := s.store.GetAutoSync(r.Context())
-	if err != nil || cfg.PrimaryID == "" {
-		writeJSON(w, http.StatusOK, noop)
-		return
-	}
-	primary, token, err := s.memberTokenOrErr(r.Context(), cfg.PrimaryID)
-	if err != nil {
-		writeJSON(w, http.StatusOK, noop)
+	primary, token, ok := s.quotaPrimary(w, r, noop)
+	if !ok {
 		return
 	}
 	status, body, err := s.callMember(r.Context(), http.MethodPost, primary.URL, memberRefreshQuotasPath, token, nil)
 	if err != nil || status != http.StatusOK {
-		writeJSON(w, http.StatusOK, noop)
+		writeQuotaUnreachable(w, "the primary could not refresh its quotas")
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/frontdesk/quota.go
+++ b/internal/frontdesk/quota.go
@@ -49,3 +49,36 @@ func (s *Server) handleQuota(w http.ResponseWriter, r *http.Request) {
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"quota": parsed.Snapshots})
 }
+
+// memberRefreshQuotasPath is the primary member's manual quota-refresh route
+// (internal/api Handler.RefreshAllQuotas), which re-polls quota-capable
+// providers' upstream endpoints synchronously.
+const memberRefreshQuotasPath = "/api/providers/refresh-quotas"
+
+// handleQuotaRefresh forces the designated primary member to re-poll its
+// quota-capable providers' upstream endpoints (the pull-to-refresh path),
+// mirroring handleQuota's read side but as a write-through proxy. It is
+// monitor-tier: any paired device may trigger a refresh. No primary
+// designated or an unreachable primary yields a 200 no-op.
+func (s *Server) handleQuotaRefresh(w http.ResponseWriter, r *http.Request) {
+	noop := map[string]any{"refreshed": 0, "failed": 0, "skipped": 0}
+
+	cfg, err := s.store.GetAutoSync(r.Context())
+	if err != nil || cfg.PrimaryID == "" {
+		writeJSON(w, http.StatusOK, noop)
+		return
+	}
+	primary, token, err := s.memberTokenOrErr(r.Context(), cfg.PrimaryID)
+	if err != nil {
+		writeJSON(w, http.StatusOK, noop)
+		return
+	}
+	status, body, err := s.callMember(r.Context(), http.MethodPost, primary.URL, memberRefreshQuotasPath, token, nil)
+	if err != nil || status != http.StatusOK {
+		writeJSON(w, http.StatusOK, noop)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(body)
+}

--- a/internal/frontdesk/quota.go
+++ b/internal/frontdesk/quota.go
@@ -61,7 +61,10 @@ const memberRefreshQuotasPath = "/api/providers/refresh-quotas"
 // monitor-tier: any paired device may trigger a refresh. No primary
 // designated or an unreachable primary yields a 200 no-op.
 func (s *Server) handleQuotaRefresh(w http.ResponseWriter, r *http.Request) {
-	noop := map[string]any{"refreshed": 0, "failed": 0, "skipped": 0}
+	// The success path writes the member's body verbatim ({results, refreshed,
+	// failed, skipped}); the no-op carries the same keys with an empty result
+	// list so both paths answer this route with one shape.
+	noop := map[string]any{"results": []any{}, "refreshed": 0, "failed": 0, "skipped": 0}
 
 	cfg, err := s.store.GetAutoSync(r.Context())
 	if err != nil || cfg.PrimaryID == "" {

--- a/internal/frontdesk/quota.go
+++ b/internal/frontdesk/quota.go
@@ -104,10 +104,13 @@ func (s *Server) handleQuota(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if snapshots == nil {
-		// The key was present but null. That still answers the question -- the
-		// primary has nothing to report -- so it stays a 200, normalised to a
-		// list rather than reaching the device as "quota": null.
-		snapshots = []quotaWire{}
+		// Present but null. No member sends that -- ExportSnapshots has built a
+		// non-nil slice since the endpoint existed, so an empty export is [] --
+		// which puts null in the same class as a missing key: something other
+		// than an export answered, and reading it as "no providers" is exactly
+		// the wipe this decode path exists to prevent.
+		writeQuotaUnreachable(w, "the primary's quota snapshots were missing from its export")
+		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"quota": snapshots})
 }

--- a/internal/frontdesk/quota.go
+++ b/internal/frontdesk/quota.go
@@ -1,0 +1,51 @@
+package frontdesk
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// quotaWire is one provider's quota snapshot as proxied to Bellhop. It mirrors
+// the member export (internal/api QuotaSnapshotWire) but is defined locally so the
+// control-plane package does not depend on the data-plane api package.
+type quotaWire struct {
+	ProviderName string          `json:"provider_name"`
+	Type         string          `json:"type"`
+	Kind         string          `json:"kind"`
+	Payload      json.RawMessage `json:"payload"`
+	HTTPStatus   int             `json:"http_status"`
+	FetchedAt    string          `json:"fetched_at"`
+}
+
+// handleQuota proxies the designated primary member's quota snapshot export to a
+// paired device (monitor tier). It mirrors DistributeQuotaOnce's read side: the
+// primary is the source of truth, Front Desk keeps no copy. No primary designated
+// (standalone / not set up) or an unreachable primary yields an empty set, and the
+// device shows its last-good (stale-beats-blank on the Android side).
+func (s *Server) handleQuota(w http.ResponseWriter, r *http.Request) {
+	empty := map[string]any{"quota": []quotaWire{}}
+
+	cfg, err := s.store.GetAutoSync(r.Context())
+	if err != nil || cfg.PrimaryID == "" {
+		writeJSON(w, http.StatusOK, empty)
+		return
+	}
+	primary, token, err := s.memberTokenOrErr(r.Context(), cfg.PrimaryID)
+	if err != nil {
+		writeJSON(w, http.StatusOK, empty)
+		return
+	}
+	status, body, err := s.callMember(r.Context(), http.MethodGet, primary.URL, memberQuotaSnapshotsPath, token, nil)
+	if err != nil || status != http.StatusOK {
+		writeJSON(w, http.StatusOK, empty)
+		return
+	}
+	var parsed struct {
+		Snapshots []quotaWire `json:"snapshots"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		writeJSON(w, http.StatusOK, empty)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"quota": parsed.Snapshots})
+}

--- a/internal/frontdesk/quota.go
+++ b/internal/frontdesk/quota.go
@@ -67,8 +67,9 @@ func (s *Server) quotaPrimary(w http.ResponseWriter, r *http.Request, none any) 
 // paired device (monitor tier). It mirrors DistributeQuotaOnce's read side: the
 // primary is the source of truth, Front Desk keeps no copy. With no primary to
 // ask the answer is an empty set; a primary that cannot be reached, does not
-// answer 200, or answers something undecodable is a 502, which leaves the device
-// on its last-good badges (stale beats blank on the Android side).
+// answer 200, or answers something that isn't the export shape is a 502, which
+// leaves the device on its last-good badges (stale beats blank on the Android
+// side).
 func (s *Server) handleQuota(w http.ResponseWriter, r *http.Request) {
 	empty := map[string]any{"quota": []quotaWire{}}
 
@@ -81,17 +82,34 @@ func (s *Server) handleQuota(w http.ResponseWriter, r *http.Request) {
 		writeQuotaUnreachable(w, "could not read the primary's quota snapshots")
 		return
 	}
-	var parsed struct {
-		Snapshots []quotaWire `json:"snapshots"`
-	}
+	// Decoded key-first rather than straight into a struct so a 200 that simply
+	// lacks the snapshots key -- an unrelated JSON object from a proxy or a
+	// captive portal -- fails instead of silently reading as a nil slice, i.e.
+	// as an authoritative "this fleet has no quota-capable providers". A primary
+	// that really has none sends the key with an empty list (ExportSnapshots
+	// builds a non-nil slice), so the truthful empty answer still gets through.
+	var parsed map[string]json.RawMessage
 	if err := json.Unmarshal(body, &parsed); err != nil {
-		// A 200 that isn't the export shape (a proxy's error page, say) means we
-		// still don't know the primary's quota, so it fails like an unreachable
-		// primary rather than reading as "no snapshots".
 		writeQuotaUnreachable(w, "could not decode the primary's quota snapshots")
 		return
 	}
-	writeJSON(w, http.StatusOK, map[string]any{"quota": parsed.Snapshots})
+	raw, ok := parsed["snapshots"]
+	if !ok {
+		writeQuotaUnreachable(w, "the primary's quota snapshots were missing from its export")
+		return
+	}
+	var snapshots []quotaWire
+	if err := json.Unmarshal(raw, &snapshots); err != nil {
+		writeQuotaUnreachable(w, "could not decode the primary's quota snapshots")
+		return
+	}
+	if snapshots == nil {
+		// The key was present but null. That still answers the question -- the
+		// primary has nothing to report -- so it stays a 200, normalised to a
+		// list rather than reaching the device as "quota": null.
+		snapshots = []quotaWire{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"quota": snapshots})
 }
 
 // memberRefreshQuotasPath is the primary member's manual quota-refresh route

--- a/internal/frontdesk/quota_test.go
+++ b/internal/frontdesk/quota_test.go
@@ -86,5 +86,5 @@ func TestHandleQuotaRefresh_NoPrimaryReturnsNoOp(t *testing.T) {
 	rr := httptest.NewRecorder()
 	s.handleQuotaRefresh(rr, httptest.NewRequest(http.MethodPost, "/api/quota/refresh", http.NoBody))
 	require.Equal(t, http.StatusOK, rr.Code)
-	require.JSONEq(t, `{"refreshed":0,"failed":0,"skipped":0}`, rr.Body.String())
+	require.JSONEq(t, `{"results":[],"refreshed":0,"failed":0,"skipped":0}`, rr.Body.String())
 }

--- a/internal/frontdesk/quota_test.go
+++ b/internal/frontdesk/quota_test.go
@@ -65,3 +65,26 @@ func TestHandleQuota_NoPrimaryReturnsEmpty(t *testing.T) {
 	require.Equal(t, http.StatusOK, rr.Code)
 	require.JSONEq(t, `{"quota":[]}`, rr.Body.String())
 }
+
+func TestHandleQuotaRefresh_ProxiesPrimary(t *testing.T) {
+	member := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/api/providers/refresh-quotas", r.URL.Path)
+		writeJSON(w, http.StatusOK, map[string]any{"refreshed": 2, "failed": 0, "skipped": 1})
+	}))
+	defer member.Close()
+	s := newTestServerWithPrimary(t, member.URL)
+
+	rr := httptest.NewRecorder()
+	s.handleQuotaRefresh(rr, httptest.NewRequest(http.MethodPost, "/api/quota/refresh", http.NoBody))
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Body.String(), `"refreshed":2`)
+}
+
+func TestHandleQuotaRefresh_NoPrimaryReturnsNoOp(t *testing.T) {
+	s := newTestServerNoPrimary(t)
+	rr := httptest.NewRecorder()
+	s.handleQuotaRefresh(rr, httptest.NewRequest(http.MethodPost, "/api/quota/refresh", http.NoBody))
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.JSONEq(t, `{"refreshed":0,"failed":0,"skipped":0}`, rr.Body.String())
+}

--- a/internal/frontdesk/quota_test.go
+++ b/internal/frontdesk/quota_test.go
@@ -66,6 +66,60 @@ func TestHandleQuota_NoPrimaryReturnsEmpty(t *testing.T) {
 	require.JSONEq(t, `{"quota":[]}`, rr.Body.String())
 }
 
+// newTestServerWithMissingPrimary designates a primary ID no member row
+// matches, the state left behind when a designated member is deleted.
+func newTestServerWithMissingPrimary(t *testing.T) *Server {
+	t.Helper()
+	srv, store := newTestServer(t)
+	if err := store.SetAutoSync(t.Context(), true, "gone"); err != nil {
+		t.Fatalf("SetAutoSync: %v", err)
+	}
+	return srv
+}
+
+// newTestServerWithFailingPrimary points the primary at a member that answers
+// every request with a 500.
+func newTestServerWithFailingPrimary(t *testing.T) *Server {
+	t.Helper()
+	member := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	t.Cleanup(member.Close)
+	return newTestServerWithPrimary(t, member.URL)
+}
+
+func TestHandleQuota_MissingPrimaryMemberReturnsEmpty(t *testing.T) {
+	s := newTestServerWithMissingPrimary(t)
+	rr := httptest.NewRecorder()
+	s.handleQuota(rr, httptest.NewRequest(http.MethodGet, "/api/quota", http.NoBody))
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.JSONEq(t, `{"quota":[]}`, rr.Body.String())
+}
+
+func TestHandleQuota_UnhappyPrimaryReturnsEmpty(t *testing.T) {
+	s := newTestServerWithFailingPrimary(t)
+	rr := httptest.NewRecorder()
+	s.handleQuota(rr, httptest.NewRequest(http.MethodGet, "/api/quota", http.NoBody))
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.JSONEq(t, `{"quota":[]}`, rr.Body.String())
+}
+
+func TestHandleQuota_UndecodableExportReturnsEmpty(t *testing.T) {
+	// A 200 whose body isn't the export shape (a proxy's error page, say)
+	// must read as "no snapshots", not propagate to the device.
+	member := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("not json"))
+	}))
+	defer member.Close()
+
+	s := newTestServerWithPrimary(t, member.URL)
+	rr := httptest.NewRecorder()
+	s.handleQuota(rr, httptest.NewRequest(http.MethodGet, "/api/quota", http.NoBody))
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.JSONEq(t, `{"quota":[]}`, rr.Body.String())
+}
+
 func TestHandleQuotaRefresh_ProxiesPrimary(t *testing.T) {
 	member := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, http.MethodPost, r.Method)
@@ -83,6 +137,24 @@ func TestHandleQuotaRefresh_ProxiesPrimary(t *testing.T) {
 
 func TestHandleQuotaRefresh_NoPrimaryReturnsNoOp(t *testing.T) {
 	s := newTestServerNoPrimary(t)
+	rr := httptest.NewRecorder()
+	s.handleQuotaRefresh(rr, httptest.NewRequest(http.MethodPost, "/api/quota/refresh", http.NoBody))
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.JSONEq(t, `{"results":[],"refreshed":0,"failed":0,"skipped":0}`, rr.Body.String())
+}
+
+func TestHandleQuotaRefresh_MissingPrimaryMemberReturnsNoOp(t *testing.T) {
+	s := newTestServerWithMissingPrimary(t)
+	rr := httptest.NewRecorder()
+	s.handleQuotaRefresh(rr, httptest.NewRequest(http.MethodPost, "/api/quota/refresh", http.NoBody))
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.JSONEq(t, `{"results":[],"refreshed":0,"failed":0,"skipped":0}`, rr.Body.String())
+}
+
+func TestHandleQuotaRefresh_UnhappyPrimaryReturnsNoOp(t *testing.T) {
+	// The refresh is best-effort: a member that can't re-poll leaves the
+	// device on its last-good snapshot rather than surfacing an error.
+	s := newTestServerWithFailingPrimary(t)
 	rr := httptest.NewRecorder()
 	s.handleQuotaRefresh(rr, httptest.NewRequest(http.MethodPost, "/api/quota/refresh", http.NoBody))
 	require.Equal(t, http.StatusOK, rr.Code)

--- a/internal/frontdesk/quota_test.go
+++ b/internal/frontdesk/quota_test.go
@@ -178,6 +178,53 @@ func TestHandleQuota_UndecodableExportReturnsBadGateway(t *testing.T) {
 	require.Contains(t, rr.Body.String(), `"error"`)
 }
 
+// newTestServerWithPrimaryBody points the primary at a member that answers the
+// export path 200 with the given body, for the shapes that decode as JSON but
+// aren't the export.
+func newTestServerWithPrimaryBody(t *testing.T, body string) *Server {
+	t.Helper()
+	member := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(member.Close)
+	return newTestServerWithPrimary(t, member.URL)
+}
+
+func TestHandleQuota_ExportWithoutSnapshotsKeyReturnsBadGateway(t *testing.T) {
+	// Valid JSON that simply isn't the export -- a proxy's own 200, say. It
+	// would decode into a nil slice and pass for "this fleet has no quota
+	// providers", which is the reading that wipes the device's badges.
+	s := newTestServerWithPrimaryBody(t, `{"detail":"upstream ok"}`)
+	rr := httptest.NewRecorder()
+	s.handleQuota(rr, httptest.NewRequest(http.MethodGet, "/api/quota", http.NoBody))
+	require.Equal(t, http.StatusBadGateway, rr.Code)
+	require.Contains(t, rr.Body.String(), `"error"`)
+}
+
+func TestHandleQuota_ExportWithUnreadableSnapshotsReturnsBadGateway(t *testing.T) {
+	// The key is there but holds something that isn't a snapshot list.
+	s := newTestServerWithPrimaryBody(t, `{"snapshots":"soon"}`)
+	rr := httptest.NewRecorder()
+	s.handleQuota(rr, httptest.NewRequest(http.MethodGet, "/api/quota", http.NoBody))
+	require.Equal(t, http.StatusBadGateway, rr.Code)
+	require.Contains(t, rr.Body.String(), `"error"`)
+}
+
+func TestHandleQuota_EmptyExportIsAnAnswer(t *testing.T) {
+	// The other side of the same coin: a primary that really has no
+	// quota-capable providers sends the key with an empty list, and that is a
+	// truthful empty answer rather than a failure. Null passes too, so a member
+	// that ever marshals the field that way isn't read as broken.
+	for _, body := range []string{`{"snapshots":[]}`, `{"snapshots":null}`} {
+		s := newTestServerWithPrimaryBody(t, body)
+		rr := httptest.NewRecorder()
+		s.handleQuota(rr, httptest.NewRequest(http.MethodGet, "/api/quota", http.NoBody))
+		require.Equal(t, http.StatusOK, rr.Code, body)
+		require.JSONEq(t, `{"quota":[]}`, rr.Body.String(), body)
+	}
+}
+
 func TestHandleQuotaRefresh_ProxiesPrimary(t *testing.T) {
 	member := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, http.MethodPost, r.Method)

--- a/internal/frontdesk/quota_test.go
+++ b/internal/frontdesk/quota_test.go
@@ -213,16 +213,23 @@ func TestHandleQuota_ExportWithUnreadableSnapshotsReturnsBadGateway(t *testing.T
 
 func TestHandleQuota_EmptyExportIsAnAnswer(t *testing.T) {
 	// The other side of the same coin: a primary that really has no
-	// quota-capable providers sends the key with an empty list, and that is a
-	// truthful empty answer rather than a failure. Null passes too, so a member
-	// that ever marshals the field that way isn't read as broken.
-	for _, body := range []string{`{"snapshots":[]}`, `{"snapshots":null}`} {
-		s := newTestServerWithPrimaryBody(t, body)
-		rr := httptest.NewRecorder()
-		s.handleQuota(rr, httptest.NewRequest(http.MethodGet, "/api/quota", http.NoBody))
-		require.Equal(t, http.StatusOK, rr.Code, body)
-		require.JSONEq(t, `{"quota":[]}`, rr.Body.String(), body)
-	}
+	// quota-capable providers sends the key with an empty list, which is a
+	// truthful empty answer rather than a failure.
+	s := newTestServerWithPrimaryBody(t, `{"snapshots":[]}`)
+	rr := httptest.NewRecorder()
+	s.handleQuota(rr, httptest.NewRequest(http.MethodGet, "/api/quota", http.NoBody))
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.JSONEq(t, `{"quota":[]}`, rr.Body.String())
+}
+
+func TestHandleQuota_NullSnapshotsReturnsBadGateway(t *testing.T) {
+	// An export has sent [] for empty since the endpoint existed, so null is
+	// not an empty export -- it is something else answering 200.
+	s := newTestServerWithPrimaryBody(t, `{"snapshots":null}`)
+	rr := httptest.NewRecorder()
+	s.handleQuota(rr, httptest.NewRequest(http.MethodGet, "/api/quota", http.NoBody))
+	require.Equal(t, http.StatusBadGateway, rr.Code)
+	require.Contains(t, rr.Body.String(), `"error"`)
 }
 
 func TestHandleQuotaRefresh_ProxiesPrimary(t *testing.T) {

--- a/internal/frontdesk/quota_test.go
+++ b/internal/frontdesk/quota_test.go
@@ -67,7 +67,9 @@ func TestHandleQuota_NoPrimaryReturnsEmpty(t *testing.T) {
 }
 
 // newTestServerWithMissingPrimary designates a primary ID no member row
-// matches, the state left behind when a designated member is deleted.
+// matches. Unreachable through the API -- DeleteMemberIfNotPrimary refuses to
+// remove the designated primary and DeleteMember clears the pointer -- so it
+// stands in for a cleanup that failed partway.
 func newTestServerWithMissingPrimary(t *testing.T) *Server {
 	t.Helper()
 	srv, store := newTestServer(t)
@@ -119,14 +121,15 @@ func newTestServerWithBrokenStore(t *testing.T) *Server {
 	return srv
 }
 
-func TestHandleQuota_MissingPrimaryMemberReturnsEmpty(t *testing.T) {
-	// A designated member that was deleted is a steady state, not a transient
-	// failure: there is nobody left to ask, so an empty set is truthful.
+func TestHandleQuota_MissingPrimaryMemberReturnsBadGateway(t *testing.T) {
+	// A designated id with no member row means a cleanup failed, not that the
+	// fleet stopped having a primary, so its quota is unknown rather than
+	// absent and the device keeps its badges.
 	s := newTestServerWithMissingPrimary(t)
 	rr := httptest.NewRecorder()
 	s.handleQuota(rr, httptest.NewRequest(http.MethodGet, "/api/quota", http.NoBody))
-	require.Equal(t, http.StatusOK, rr.Code)
-	require.JSONEq(t, `{"quota":[]}`, rr.Body.String())
+	require.Equal(t, http.StatusBadGateway, rr.Code)
+	require.Contains(t, rr.Body.String(), `"error"`)
 }
 
 func TestHandleQuota_TokenlessPrimaryReturnsBadGateway(t *testing.T) {
@@ -198,13 +201,14 @@ func TestHandleQuotaRefresh_NoPrimaryReturnsNoOp(t *testing.T) {
 	require.JSONEq(t, `{"results":[],"refreshed":0,"failed":0,"skipped":0}`, rr.Body.String())
 }
 
-func TestHandleQuotaRefresh_MissingPrimaryMemberReturnsNoOp(t *testing.T) {
-	// Deleted designated member: nobody to refresh, so the no-op is honest.
+func TestHandleQuotaRefresh_MissingPrimaryMemberReturnsBadGateway(t *testing.T) {
+	// A designated id with no member row is a failed cleanup, so the refresh
+	// could not run and must not answer like one that ran and found nothing.
 	s := newTestServerWithMissingPrimary(t)
 	rr := httptest.NewRecorder()
 	s.handleQuotaRefresh(rr, httptest.NewRequest(http.MethodPost, "/api/quota/refresh", http.NoBody))
-	require.Equal(t, http.StatusOK, rr.Code)
-	require.JSONEq(t, `{"results":[],"refreshed":0,"failed":0,"skipped":0}`, rr.Body.String())
+	require.Equal(t, http.StatusBadGateway, rr.Code)
+	require.Contains(t, rr.Body.String(), `"error"`)
 }
 
 func TestHandleQuotaRefresh_TokenlessPrimaryReturnsBadGateway(t *testing.T) {

--- a/internal/frontdesk/quota_test.go
+++ b/internal/frontdesk/quota_test.go
@@ -88,7 +88,40 @@ func newTestServerWithFailingPrimary(t *testing.T) *Server {
 	return newTestServerWithPrimary(t, member.URL)
 }
 
+// newTestServerWithTokenlessPrimary designates a member Front Desk holds no
+// admin token for, so memberTokenOrErr fails with ErrValidation: the primary
+// exists, we just cannot authenticate to it.
+func newTestServerWithTokenlessPrimary(t *testing.T) *Server {
+	t.Helper()
+	srv, store := newTestServer(t)
+	pm, err := store.CreateMember(t.Context(), "primary", "http://127.0.0.1:9", "")
+	if err != nil {
+		t.Fatalf("CreateMember: %v", err)
+	}
+	if err := store.SetAutoSync(t.Context(), true, pm.ID); err != nil {
+		t.Fatalf("SetAutoSync: %v", err)
+	}
+	return srv
+}
+
+// newTestServerWithBrokenStore designates a primary and then closes the store
+// underneath the Server, so the primary lookup fails the way an unreadable
+// database file would.
+func newTestServerWithBrokenStore(t *testing.T) *Server {
+	t.Helper()
+	srv, store := newTestServer(t)
+	if err := store.SetAutoSync(t.Context(), true, "primary"); err != nil {
+		t.Fatalf("SetAutoSync: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	return srv
+}
+
 func TestHandleQuota_MissingPrimaryMemberReturnsEmpty(t *testing.T) {
+	// A designated member that was deleted is a steady state, not a transient
+	// failure: there is nobody left to ask, so an empty set is truthful.
 	s := newTestServerWithMissingPrimary(t)
 	rr := httptest.NewRecorder()
 	s.handleQuota(rr, httptest.NewRequest(http.MethodGet, "/api/quota", http.NoBody))
@@ -96,17 +129,39 @@ func TestHandleQuota_MissingPrimaryMemberReturnsEmpty(t *testing.T) {
 	require.JSONEq(t, `{"quota":[]}`, rr.Body.String())
 }
 
-func TestHandleQuota_UnhappyPrimaryReturnsEmpty(t *testing.T) {
+func TestHandleQuota_TokenlessPrimaryReturnsBadGateway(t *testing.T) {
+	// The primary exists but Front Desk stores no admin token for it, so its
+	// quota is unknown rather than absent.
+	s := newTestServerWithTokenlessPrimary(t)
+	rr := httptest.NewRecorder()
+	s.handleQuota(rr, httptest.NewRequest(http.MethodGet, "/api/quota", http.NoBody))
+	require.Equal(t, http.StatusBadGateway, rr.Code)
+	require.Contains(t, rr.Body.String(), `"error"`)
+}
+
+func TestHandleQuota_StoreFailureReturnsError(t *testing.T) {
+	// Front Desk's own store is unreadable: our failure, still not an answer.
+	s := newTestServerWithBrokenStore(t)
+	rr := httptest.NewRecorder()
+	s.handleQuota(rr, httptest.NewRequest(http.MethodGet, "/api/quota", http.NoBody))
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+}
+
+func TestHandleQuota_UnhappyPrimaryReturnsBadGateway(t *testing.T) {
+	// A primary that answers 500 leaves its quota unknown. Answering an empty
+	// 200 here would read on the device as "this fleet has no quota providers"
+	// and wipe the last-good badges, so the read has to fail loudly.
 	s := newTestServerWithFailingPrimary(t)
 	rr := httptest.NewRecorder()
 	s.handleQuota(rr, httptest.NewRequest(http.MethodGet, "/api/quota", http.NoBody))
-	require.Equal(t, http.StatusOK, rr.Code)
-	require.JSONEq(t, `{"quota":[]}`, rr.Body.String())
+	require.Equal(t, http.StatusBadGateway, rr.Code)
+	require.Contains(t, rr.Body.String(), `"error"`)
 }
 
-func TestHandleQuota_UndecodableExportReturnsEmpty(t *testing.T) {
-	// A 200 whose body isn't the export shape (a proxy's error page, say)
-	// must read as "no snapshots", not propagate to the device.
+func TestHandleQuota_UndecodableExportReturnsBadGateway(t *testing.T) {
+	// A 200 whose body isn't the export shape (a proxy's error page, say) tells
+	// us nothing about the primary's quota, so it fails like an unreachable
+	// primary instead of reading as "no snapshots".
 	member := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte("not json"))
@@ -116,8 +171,8 @@ func TestHandleQuota_UndecodableExportReturnsEmpty(t *testing.T) {
 	s := newTestServerWithPrimary(t, member.URL)
 	rr := httptest.NewRecorder()
 	s.handleQuota(rr, httptest.NewRequest(http.MethodGet, "/api/quota", http.NoBody))
-	require.Equal(t, http.StatusOK, rr.Code)
-	require.JSONEq(t, `{"quota":[]}`, rr.Body.String())
+	require.Equal(t, http.StatusBadGateway, rr.Code)
+	require.Contains(t, rr.Body.String(), `"error"`)
 }
 
 func TestHandleQuotaRefresh_ProxiesPrimary(t *testing.T) {
@@ -144,6 +199,7 @@ func TestHandleQuotaRefresh_NoPrimaryReturnsNoOp(t *testing.T) {
 }
 
 func TestHandleQuotaRefresh_MissingPrimaryMemberReturnsNoOp(t *testing.T) {
+	// Deleted designated member: nobody to refresh, so the no-op is honest.
 	s := newTestServerWithMissingPrimary(t)
 	rr := httptest.NewRecorder()
 	s.handleQuotaRefresh(rr, httptest.NewRequest(http.MethodPost, "/api/quota/refresh", http.NoBody))
@@ -151,12 +207,27 @@ func TestHandleQuotaRefresh_MissingPrimaryMemberReturnsNoOp(t *testing.T) {
 	require.JSONEq(t, `{"results":[],"refreshed":0,"failed":0,"skipped":0}`, rr.Body.String())
 }
 
-func TestHandleQuotaRefresh_UnhappyPrimaryReturnsNoOp(t *testing.T) {
-	// The refresh is best-effort: a member that can't re-poll leaves the
-	// device on its last-good snapshot rather than surfacing an error.
+func TestHandleQuotaRefresh_TokenlessPrimaryReturnsBadGateway(t *testing.T) {
+	s := newTestServerWithTokenlessPrimary(t)
+	rr := httptest.NewRecorder()
+	s.handleQuotaRefresh(rr, httptest.NewRequest(http.MethodPost, "/api/quota/refresh", http.NoBody))
+	require.Equal(t, http.StatusBadGateway, rr.Code)
+	require.Contains(t, rr.Body.String(), `"error"`)
+}
+
+func TestHandleQuotaRefresh_StoreFailureReturnsError(t *testing.T) {
+	s := newTestServerWithBrokenStore(t)
+	rr := httptest.NewRecorder()
+	s.handleQuotaRefresh(rr, httptest.NewRequest(http.MethodPost, "/api/quota/refresh", http.NoBody))
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+}
+
+func TestHandleQuotaRefresh_UnhappyPrimaryReturnsBadGateway(t *testing.T) {
+	// A primary that can't re-poll must not answer like a refresh that ran and
+	// found nothing: the device has to be able to tell the operator it failed.
 	s := newTestServerWithFailingPrimary(t)
 	rr := httptest.NewRecorder()
 	s.handleQuotaRefresh(rr, httptest.NewRequest(http.MethodPost, "/api/quota/refresh", http.NoBody))
-	require.Equal(t, http.StatusOK, rr.Code)
-	require.JSONEq(t, `{"results":[],"refreshed":0,"failed":0,"skipped":0}`, rr.Body.String())
+	require.Equal(t, http.StatusBadGateway, rr.Code)
+	require.Contains(t, rr.Body.String(), `"error"`)
 }

--- a/internal/frontdesk/quota_test.go
+++ b/internal/frontdesk/quota_test.go
@@ -1,0 +1,67 @@
+package frontdesk
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// newTestServerWithPrimary builds a Server whose Store has one member
+// designated as the fleet primary, pointed at memberURL with a fixed token,
+// mirroring the primary+token fixture pattern used by DistributeQuotaOnce's
+// tests (quota_distribute_test.go).
+func newTestServerWithPrimary(t *testing.T, memberURL string) *Server {
+	t.Helper()
+	srv, store := newTestServer(t)
+	pm, err := store.CreateMember(t.Context(), "primary", memberURL, "ptoken")
+	if err != nil {
+		t.Fatalf("CreateMember: %v", err)
+	}
+	if err := store.SetAutoSync(t.Context(), true, pm.ID); err != nil {
+		t.Fatalf("SetAutoSync: %v", err)
+	}
+	return srv
+}
+
+// newTestServerNoPrimary builds a Server whose Store has no designated
+// primary (standalone / not set up).
+func newTestServerNoPrimary(t *testing.T) *Server {
+	t.Helper()
+	srv, _ := newTestServer(t)
+	return srv
+}
+
+func TestHandleQuota_ProxiesPrimaryExport(t *testing.T) {
+	// A member httptest server that answers the export path with one snapshot.
+	member := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/config/quota-snapshots", r.URL.Path)
+		writeJSON(w, http.StatusOK, map[string]any{"snapshots": []map[string]any{
+			{"provider_name": "OR", "type": "openrouter", "kind": "usage",
+				"payload": json.RawMessage(`{"usage":1.5}`), "http_status": 200},
+		}})
+	}))
+	defer member.Close()
+
+	s := newTestServerWithPrimary(t, member.URL) // store: one member = primary, token set
+	rr := httptest.NewRecorder()
+	s.handleQuota(rr, httptest.NewRequest(http.MethodGet, "/api/quota", http.NoBody))
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	var body struct {
+		Quota []map[string]any `json:"quota"`
+	}
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&body))
+	require.Len(t, body.Quota, 1)
+	require.Equal(t, "openrouter", body.Quota[0]["type"])
+}
+
+func TestHandleQuota_NoPrimaryReturnsEmpty(t *testing.T) {
+	s := newTestServerNoPrimary(t)
+	rr := httptest.NewRecorder()
+	s.handleQuota(rr, httptest.NewRequest(http.MethodGet, "/api/quota", http.NoBody))
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.JSONEq(t, `{"quota":[]}`, rr.Body.String())
+}

--- a/internal/frontdesk/server.go
+++ b/internal/frontdesk/server.go
@@ -267,6 +267,7 @@ func (s *Server) buildRouter(wa *adminauth.WebAuthnHandler, tp *adminauth.TotpHa
 			r.Use(s.requireAuth)
 			r.Get("/members", s.listMembers)
 			r.Get("/quota", s.handleQuota)
+			r.Post("/quota/refresh", s.handleQuotaRefresh)
 			r.Get("/members/{id}/traffic", s.memberTraffic)
 			r.Get("/version", s.getVersion)
 			r.Get("/observability", s.getObservability)

--- a/internal/frontdesk/server.go
+++ b/internal/frontdesk/server.go
@@ -266,6 +266,7 @@ func (s *Server) buildRouter(wa *adminauth.WebAuthnHandler, tp *adminauth.TotpHa
 		r.Group(func(r chi.Router) {
 			r.Use(s.requireAuth)
 			r.Get("/members", s.listMembers)
+			r.Get("/quota", s.handleQuota)
 			r.Get("/members/{id}/traffic", s.memberTraffic)
 			r.Get("/version", s.getVersion)
 			r.Get("/observability", s.getObservability)


### PR DESCRIPTION
Bellhop shows per-provider quota badges on the dashboard and the home-screen widget, fed by the primary member's quota snapshots through Front Desk.

## Data path

Front Desk gains two proxy routes; it stores no quota of its own, the primary member stays the source of truth.

- `GET /api/quota` proxies the primary's snapshot export. An empty set means one thing only: no primary is designated. Anything that stops Front Desk getting an answer out of a primary that is designated answers 502 instead, so the device can tell "no quota" from "couldn't read quota" and holds its last-good badges in the second case (stale beats blank).
- `POST /api/quota/refresh` forces the primary to re-poll its providers' upstream endpoints, backing pull-to-refresh. Monitor tier: any paired device may trigger it. It splits its outcomes the same way, so a refresh that never ran can say so rather than passing for one that found no change.
- The fleet snapshot export now carries each provider's quota type, so the device can pick the right parser without guessing from the payload.

## Android

- Wire model with per-type payload parsing (NanoGPT, Z.ai, MiniMax, Kimi, Ollama Cloud, DeepSeek, OpenRouter, NeuralWatt), and unknown types are dropped rather than rendered as a permanently blank badge.
- Dashboard badge strip that wraps onto as many rows as the selection needs, each badge opening a per-type detail sheet.
- Widget badges with the same brand colours, packed into explicit rows (Glance has no wrapping layout) inside one nested Column, so the strip stays a single child of the 10-child RemoteViews budget. Tapping one deep-links to its detail sheet behind the app lock.
- A configurator under Settings with independent Dashboard and Widget layouts: hand-rolled reorderable list, per-badge visibility, and a used/remaining style toggle. The widget surface is opt-in per badge, the dashboard opt-out.
- Pull-to-refresh on the badge row reports a refresh Front Desk could not run, in its own banner slot so the next poll tick doesn't wipe it. A failed read keeps the last-good badges on the dashboard, the widget, and the background poll alike.
- Badges take their provider's brand colour, matching the Model Hotel web dashboard (15% fill, 40% border, brand text), with the near-black brands lightened on dark.
- All new strings are hand-translated across the 11 locales.

Drive-by while in the file: 12dp between label and switch on the settings rows, where the text was touching the toggle.

## Verification

- `make android-test`: 466 tests, 0 failures, ktlint clean. `make android-lint` clean.
- `go test ./internal/frontdesk/... ./internal/api/...` green, `golangci-lint` clean.
- Exercised on the emulator against a Front Desk carrying real provider data: all 8 badges visible and wrapped on both surfaces, brand colours correct, deep links land on the right sheet.

Note for deployment: both Front Desk and the primary member need builds carrying these commits before the badges have anything to show.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
