### PR TITLE
Make the widget's overflow marker count the whole selection

### DIFF
--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/WidgetState.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/WidgetState.kt
@@ -96,8 +96,13 @@ private const val WIDGET_QUOTA_PILL_CHROME_DP = 9
  */
 private const val WIDGET_QUOTA_MAX_PER_ROW = 9
 
-/** badgeWidthDp estimates what one badge occupies, label plus pill chrome. */
-private fun badgeWidthDp(badge: WidgetQuotaBadge): Int =
+/**
+ * badgeWidthDp estimates what one badge occupies, label plus pill chrome.
+ * Internal rather than private so the packing tests measure rows with the same
+ * arithmetic the packer uses instead of restating the constants, which is how
+ * they came to check a marker reserve production had already outgrown.
+ */
+internal fun badgeWidthDp(badge: WidgetQuotaBadge): Int =
     badge.label.length * WIDGET_QUOTA_CHAR_DP + WIDGET_QUOTA_PILL_CHROME_DP
 
 /**
@@ -107,8 +112,11 @@ private fun badgeWidthDp(badge: WidgetQuotaBadge): Int =
  * width off the top and the row's badges split only what is left -- which is
  * why the row that carries it is fitted against a budget short by this much,
  * rather than against the full width.
+ *
+ * Internal for the same reason as [badgeWidthDp]: the tests assert against this
+ * number, so they must read it rather than repeat it.
  */
-private const val WIDGET_QUOTA_OVERFLOW_MARKER_DP = 28
+internal const val WIDGET_QUOTA_OVERFLOW_MARKER_DP = 28
 
 /**
  * quotaBadgeRows packs [badges] into the rows the widget renders, keeping the

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/WidgetState.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/WidgetState.kt
@@ -69,15 +69,6 @@ data class WidgetState(
 )
 
 /**
- * WIDGET_QUOTA_CAP is the most badges the widget renders. The strip wraps onto
- * several lines now ([quotaBadgeRows]), so this is no longer the old
- * one-line-holds-six limit that quietly hid the rest of an operator's
- * selection: it bounds how much of a small widget the strip may eat, and keeps
- * the row count inside the nested Column well under Glance's 10-children cap.
- */
-const val WIDGET_QUOTA_CAP = 12
-
-/**
  * WIDGET_QUOTA_MAX_ROWS caps the strip's height. Four rows of 9sp pills is
  * roughly a third of the smallest widget; past that the fleet rows the widget
  * exists for would be the ones squeezed out.
@@ -111,13 +102,13 @@ private fun badgeWidthDp(badge: WidgetQuotaBadge): Int =
 
 /**
  * WIDGET_QUOTA_OVERFLOW_MARKER_DP is what the trailing "+N" costs the row that
- * carries it: at most three characters ("+12", since [WIDGET_QUOTA_CAP] bounds
- * it) plus its gap. The marker is rendered *unweighted*, so it takes its width
- * off the top and the row's badges split only what is left -- which is why the
- * row that carries it is fitted against a budget short by this much, rather
- * than against the full width.
+ * carries it: four characters ("+999", far past any real fleet's provider
+ * count) plus its gap. The marker is rendered *unweighted*, so it takes its
+ * width off the top and the row's badges split only what is left -- which is
+ * why the row that carries it is fitted against a budget short by this much,
+ * rather than against the full width.
  */
-private const val WIDGET_QUOTA_OVERFLOW_MARKER_DP = 22
+private const val WIDGET_QUOTA_OVERFLOW_MARKER_DP = 28
 
 /**
  * quotaBadgeRows packs [badges] into the rows the widget renders, keeping the
@@ -209,9 +200,16 @@ fun quotaBadgeOverflow(
 /**
  * widgetQuotaOf resolves [quota] against [config] the same way the main-page
  * badge list does ([orderedVisible]: hidden/unavailable names dropped, order
- * preserved), then trims to [WIDGET_QUOTA_CAP] and precomputes each badge's
- * short [WidgetQuotaBadge.label] via [quotaBadgeLabel] (in [mode]'s polarity)
- * so the widget's render stays pure-string. The label leads with
+ * preserved) and precomputes each badge's short [WidgetQuotaBadge.label] via
+ * [quotaBadgeLabel] (in [mode]'s polarity) so the widget's render stays
+ * pure-string.
+ *
+ * It carries the operator's WHOLE selection, uncapped. Trimming it here to a
+ * fixed count would make [quotaBadgeOverflow] -- which measures what the strip
+ * showed against what it was given -- report a shortfall short by whatever this
+ * had already discarded, so a "+3" could stand for eleven missing badges. How
+ * many actually fit is [quotaBadgeRows]' business, and depends on the widget's
+ * width, which nothing upstream of the render knows. The label leads with
  * [quotaShortCode] because a widget badge showing only a number says nothing
  * about whose number it is, and the dashboard's full provider name would eat
  * the row at this size.
@@ -222,7 +220,6 @@ fun widgetQuotaOf(
     mode: QuotaBarMode,
 ): List<WidgetQuotaBadge> =
     orderedVisible(config, quota)
-        .take(WIDGET_QUOTA_CAP)
         .map {
             WidgetQuotaBadge(
                 providerName = it.providerName,

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/settings/QuotaBadgesConfigScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/settings/QuotaBadgesConfigScreen.kt
@@ -39,7 +39,6 @@ import com.hugalafutro.bellhop.data.QuotaBadgeConfig
 import com.hugalafutro.bellhop.data.QuotaBadgeConfigStore
 import com.hugalafutro.bellhop.data.QuotaBarMode
 import com.hugalafutro.bellhop.data.QuotaSurface
-import com.hugalafutro.bellhop.data.WIDGET_QUOTA_CAP
 import com.hugalafutro.bellhop.ui.common.FilterPill
 import com.hugalafutro.bellhop.ui.common.ReorderableColumn
 import com.hugalafutro.bellhop.ui.common.bellhopSwitchColors
@@ -132,18 +131,6 @@ fun QuotaBadgesConfigScreen(
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.padding(top = 8.dp).testTag("quota-config-count"),
-                )
-            }
-            // The widget wraps its badges onto several lines, so a selection that
-            // fits needs no commentary at all -- a cap line reads as a limit being
-            // enforced even when nothing is being dropped. Speak up only when the
-            // selection genuinely outruns WIDGET_QUOTA_CAP.
-            if (surface == QuotaSurface.WIDGET && visibleCount > WIDGET_QUOTA_CAP) {
-                Text(
-                    text = stringResource(R.string.quota_config_widget_cap, WIDGET_QUOTA_CAP),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(top = 4.dp).testTag("quota-config-widget-cap"),
                 )
             }
 

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/widget/BellhopWidget.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/widget/BellhopWidget.kt
@@ -457,9 +457,9 @@ private fun WidgetContent(
                 // header + 5 rows + quota Column + weight spacer + event Column
                 // + footer = 10, no headroom. The quota strip is ONE child
                 // whatever its badge count (its rows are children of its own
-                // nested Column), so raising WIDGET_QUOTA_CAP is free here -
-                // but adding any new top-level SECTION will silently drop a
-                // child; free a slot (nest a singleton) before doing so.
+                // nested Column), so a bigger selection is free here - but
+                // adding any new top-level SECTION will silently drop a child;
+                // free a slot (nest a singleton) before doing so.
                 state.members.forEach { member ->
                     // The gap rides an outer Box because Glance padding is a
                     // view's *inner* padding: put it on the card itself and the
@@ -509,8 +509,8 @@ private fun WidgetContent(
                     }
                 }
         }
-        // One badge per configured provider, pre-ordered/filtered/capped by the
-        // poll layer (WIDGET_QUOTA_CAP) and packed into lines by quotaBadgeRows
+        // One badge per configured provider, pre-ordered and filtered by the
+        // poll layer and packed into lines by quotaBadgeRows
         // -- Glance has no wrapping layout, so the rows are explicit. The whole
         // strip is ONE child of the Column above (the badge rows are children
         // of this nested Column, which has its own 10-child budget that

--- a/android/app/src/main/res/values-cs/strings.xml
+++ b/android/app/src/main/res/values-cs/strings.xml
@@ -322,7 +322,6 @@
     <string name="quota_config_mode_remaining">Zbývající</string>
     <string name="quota_config_mode_used">Využité</string>
     <string name="quota_config_empty">Zatím nejsou vidět žádní poskytovatelé s kvótou.</string>
-    <string name="quota_config_widget_cap">Na widget se vejde jen prvních %1$d</string>
     <string name="quota_config_selected">Zobrazeno %1$d z %2$d</string>
     <string name="quota_config_reorder">Přesunout %1$s</string>
 </resources>

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -310,7 +310,6 @@
     <string name="quota_config_mode_remaining">Verbleibend</string>
     <string name="quota_config_mode_used">Verbraucht</string>
     <string name="quota_config_empty">Noch keine kontingentfähigen Anbieter gesehen.</string>
-    <string name="quota_config_widget_cap">Nur die ersten %1$d passen auf das Widget</string>
     <string name="quota_config_selected">%1$d von %2$d angezeigt</string>
     <string name="quota_config_reorder">%1$s neu anordnen</string>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -310,7 +310,6 @@
     <string name="quota_config_mode_remaining">Restante</string>
     <string name="quota_config_mode_used">Usado</string>
     <string name="quota_config_empty">Aún no se han detectado proveedores con cuota.</string>
-    <string name="quota_config_widget_cap">Solo los primeros %1$d caben en el widget</string>
     <string name="quota_config_selected">%1$d de %2$d mostrados</string>
     <string name="quota_config_reorder">Reordenar %1$s</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -310,7 +310,6 @@
     <string name="quota_config_mode_remaining">Restant</string>
     <string name="quota_config_mode_used">Utilisé</string>
     <string name="quota_config_empty">Aucun fournisseur compatible avec les quotas pour l\'instant.</string>
-    <string name="quota_config_widget_cap">Seuls les %1$d premiers tiennent sur le widget</string>
     <string name="quota_config_selected">%1$d sur %2$d affichés</string>
     <string name="quota_config_reorder">Réorganiser %1$s</string>
 </resources>

--- a/android/app/src/main/res/values-ja/strings.xml
+++ b/android/app/src/main/res/values-ja/strings.xml
@@ -304,7 +304,6 @@
     <string name="quota_config_mode_remaining">残量</string>
     <string name="quota_config_mode_used">使用量</string>
     <string name="quota_config_empty">クォータに対応するプロバイダーはまだありません。</string>
-    <string name="quota_config_widget_cap">ウィジェットに収まるのは先頭の %1$d 件のみです</string>
     <string name="quota_config_selected">%2$d 件中 %1$d 件を表示</string>
     <string name="quota_config_reorder">%1$s を並べ替え</string>
 </resources>

--- a/android/app/src/main/res/values-nl/strings.xml
+++ b/android/app/src/main/res/values-nl/strings.xml
@@ -310,7 +310,6 @@
     <string name="quota_config_mode_remaining">Resterend</string>
     <string name="quota_config_mode_used">Gebruikt</string>
     <string name="quota_config_empty">Nog geen providers met quota gezien.</string>
-    <string name="quota_config_widget_cap">Alleen de eerste %1$d passen op de widget</string>
     <string name="quota_config_selected">%1$d van %2$d getoond</string>
     <string name="quota_config_reorder">%1$s herschikken</string>
 </resources>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -322,7 +322,6 @@
     <string name="quota_config_mode_remaining">Pozostałe</string>
     <string name="quota_config_mode_used">Wykorzystane</string>
     <string name="quota_config_empty">Nie znaleziono jeszcze dostawców obsługujących limity.</string>
-    <string name="quota_config_widget_cap">Na widżecie zmieści się tylko pierwszych %1$d</string>
     <string name="quota_config_selected">Pokazano %1$d z %2$d</string>
     <string name="quota_config_reorder">Zmień kolejność: %1$s</string>
 </resources>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -322,7 +322,6 @@
     <string name="quota_config_mode_remaining">Осталось</string>
     <string name="quota_config_mode_used">Использовано</string>
     <string name="quota_config_empty">Провайдеры с поддержкой квот пока не найдены.</string>
-    <string name="quota_config_widget_cap">В виджет помещаются только первые %1$d</string>
     <string name="quota_config_selected">Показано %1$d из %2$d</string>
     <string name="quota_config_reorder">Переместить %1$s</string>
 </resources>

--- a/android/app/src/main/res/values-sk/strings.xml
+++ b/android/app/src/main/res/values-sk/strings.xml
@@ -322,7 +322,6 @@
     <string name="quota_config_mode_remaining">Zostávajúce</string>
     <string name="quota_config_mode_used">Využité</string>
     <string name="quota_config_empty">Zatiaľ nie sú vidieť žiadni poskytovatelia s kvótou.</string>
-    <string name="quota_config_widget_cap">Na widget sa zmestí len prvých %1$d</string>
     <string name="quota_config_selected">Zobrazené %1$d z %2$d</string>
     <string name="quota_config_reorder">Presunúť %1$s</string>
 </resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -304,7 +304,6 @@
     <string name="quota_config_mode_remaining">剩余</string>
     <string name="quota_config_mode_used">已用</string>
     <string name="quota_config_empty">尚未发现支持配额的服务商。</string>
-    <string name="quota_config_widget_cap">小组件仅能显示前 %1$d 项</string>
     <string name="quota_config_selected">已显示 %2$d 项中的 %1$d 项</string>
     <string name="quota_config_reorder">重新排序 %1$s</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -314,7 +314,6 @@
     <string name="quota_config_mode_remaining">Remaining</string>
     <string name="quota_config_mode_used">Used</string>
     <string name="quota_config_empty">No quota-capable providers seen yet.</string>
-    <string name="quota_config_widget_cap">Only the first %1$d fit on the widget</string>
     <string name="quota_config_selected">%1$d of %2$d shown</string>
     <string name="quota_config_reorder">Reorder %1$s</string>
 </resources>

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/WidgetStateTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/WidgetStateTest.kt
@@ -201,7 +201,7 @@ class WidgetStateTest {
             )
         listOf(120, 156, 240, 320, 480).forEach { budget ->
             quotaBadgeRows(badges, budget).forEach { row ->
-                val widest = row.maxOf { it.label.length * 6 + 9 }
+                val widest = row.maxOf { badgeWidthDp(it) }
                 assertTrue(
                     "row of ${row.size} at ${budget}dp gives ${budget / row.size}dp to a ${widest}dp badge",
                     row.size == 1 || budget / row.size >= widest,
@@ -251,23 +251,41 @@ class WidgetStateTest {
     fun quotaBadgeRowsLeaveTheOverflowMarkerItsWidth() {
         // The "+N" is rendered unweighted, so it takes its width off the top and
         // the row's badges split only the remainder. A last row fitted against
-        // the full width would therefore hand each badge less than was checked
-        // and clip the labels; the marker's width has to come out first.
-        val marker = 22
+        // the full width would hand each badge less than was checked and clip the
+        // labels, so the marker's width has to come out first.
+        //
+        // 170dp is the width that makes this bind rather than merely hold: a
+        // 12-character label is ~81dp, two of them fit 170dp on their own
+        // (162dp), and only the marker's reserve pushes them over. Widths where
+        // the row already held one badge, or had slack to spare, pass whether
+        // the reserve is applied or not -- an earlier version of this test used
+        // only those and went green against a deliberately reverted fix.
         val badges = (1..12).map { badge("P$it", "NANO 1.9M/3M") }
 
-        listOf(120, 156, 240, 320).forEach { budget ->
+        listOf(120, 156, 170, 240).forEach { budget ->
             val rows = quotaBadgeRows(badges, budget)
-            val overflow = quotaBadgeOverflow(badges, rows)
-            if (overflow == 0) return@forEach
+            if (quotaBadgeOverflow(badges, rows) == 0) return@forEach
             val last = rows.last()
-            val widest = last.maxOf { it.label.length * 6 + 9 }
+            val widest = last.maxOf { badgeWidthDp(it) }
+            val share = (budget - WIDGET_QUOTA_OVERFLOW_MARKER_DP) / last.size
             assertTrue(
-                "last row of ${last.size} at ${budget}dp leaves ${(budget - marker) / last.size}dp " +
-                    "per badge for a ${widest}dp label",
-                last.size == 1 || (budget - marker) / last.size >= widest,
+                "last row of ${last.size} at ${budget}dp leaves ${share}dp per badge for a ${widest}dp label",
+                last.size == 1 || share >= widest,
             )
         }
+    }
+
+    @Test
+    fun theMarkerReserveActuallyTrimsTheLastRow() {
+        // Guards the assertion above from going vacuous: at 170dp the packer
+        // fills the last row with two badges and only the marker's reserve takes
+        // one back, so this pins that the reserve is doing something. Remove the
+        // reserve and this fails; the invariant test fails with it.
+        val badges = (1..12).map { badge("P$it", "NANO 1.9M/3M") }
+        val rows = quotaBadgeRows(badges, budgetDp = 170)
+
+        assertEquals(1, rows.last().size)
+        assertEquals(2, rows.first().size)
     }
 
     @Test

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/WidgetStateTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/WidgetStateTest.kt
@@ -131,9 +131,9 @@ class WidgetStateTest {
     }
 
     @Test
-    fun widgetQuotaRespectsOrderVisibilityAndCap() {
+    fun widgetQuotaRespectsOrderAndVisibilityAndKeepsTheWholeSelection() {
         val quotas =
-            (1..WIDGET_QUOTA_CAP + 3).map {
+            (1..15).map {
                 ProviderQuota(
                     providerName = "P$it",
                     type = QuotaType.OPENROUTER,
@@ -144,8 +144,12 @@ class WidgetStateTest {
             }
         val cfg = QuotaBadgeConfig(order = quotas.map { it.providerName }, hidden = setOf("P2"))
         val badges = widgetQuotaOf(quotas, cfg, QuotaBarMode.REMAINING)
-        assertEquals(WIDGET_QUOTA_CAP, badges.size)
-        assertFalse(badges.any { it.providerName == "P2" }) // hidden dropped before the cap
+
+        // Everything the operator selected, uncapped: how many fit is decided at
+        // render time by width, and pre-trimming here would make the widget's
+        // "+N" understate what is missing.
+        assertEquals(14, badges.size)
+        assertFalse(badges.any { it.providerName == "P2" })
     }
 
     @Test
@@ -274,6 +278,34 @@ class WidgetStateTest {
         val rows = quotaBadgeRows(badges, budgetDp = 156)
 
         assertEquals(badges.size, rows.sumOf { it.size } + quotaBadgeOverflow(badges, rows))
+    }
+
+    @Test
+    fun overflowCountsEveryBadgeTheStripLeftOut() {
+        // The marker has to speak for the whole selection. When the badge list
+        // was pre-trimmed before it reached the strip, this arithmetic held
+        // against the trimmed list and the "+N" understated the shortfall.
+        val quotas =
+            (1..15).map {
+                ProviderQuota(
+                    providerName = "P$it",
+                    type = QuotaType.OPENROUTER,
+                    data = QuotaData.OpenRouter(limitReset = "k", limit = 10.0, creditsRemaining = 1.0),
+                    fetchedAt = "t",
+                    available = true,
+                )
+            }
+        val badges =
+            widgetQuotaOf(
+                quotas,
+                QuotaBadgeConfig(order = quotas.map { it.providerName }, hidden = emptySet()),
+                QuotaBarMode.REMAINING,
+            )
+        val rows = quotaBadgeRows(badges, budgetDp = 156)
+
+        assertEquals(15, badges.size)
+        assertEquals(15 - rows.sumOf { it.size }, quotaBadgeOverflow(badges, rows))
+        assertTrue("a 15-badge selection cannot fit a narrow strip", quotaBadgeOverflow(badges, rows) > 0)
     }
 
     @Test

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/settings/QuotaBadgesConfigScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/settings/QuotaBadgesConfigScreenTest.kt
@@ -9,7 +9,6 @@ import com.hugalafutro.bellhop.data.PrefsStore
 import com.hugalafutro.bellhop.data.QuotaBadgeConfigStore
 import com.hugalafutro.bellhop.data.QuotaBarMode
 import com.hugalafutro.bellhop.data.QuotaSurface
-import com.hugalafutro.bellhop.data.WIDGET_QUOTA_CAP
 import com.hugalafutro.bellhop.ui.theme.BellhopTheme
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
@@ -91,48 +90,6 @@ class QuotaBadgesConfigScreenTest {
 
         val visible = runBlocking { configStore.config(QuotaSurface.WIDGET).first().hidden }
         assertTrue("NG" !in visible)
-    }
-
-    @Test
-    fun widgetTabStaysQuietWhenTheSelectionFits() {
-        // The widget wraps badges onto several lines, so a selection under the
-        // cap is shown in full and the cap note would only be noise.
-        val configStore = newConfigStore()
-        runBlocking { configStore.reconcile(QuotaSurface.WIDGET, listOf("OR", "NG")) }
-
-        composeTestRule.setContent {
-            BellhopTheme {
-                QuotaBadgesConfigScreen(configStore = configStore, prefsStore = newPrefsStore(), onBack = {})
-            }
-        }
-
-        composeTestRule.onNodeWithTag("quota-config-tab-widget").performClick()
-        composeTestRule.waitForIdle()
-
-        composeTestRule.onNodeWithTag("quota-config-widget-cap").assertDoesNotExist()
-    }
-
-    @Test
-    fun widgetTabWarnsWhenTheSelectionOutrunsTheCap() {
-        val configStore = newConfigStore()
-        val names = (1..WIDGET_QUOTA_CAP + 1).map { "P$it" }
-        runBlocking {
-            configStore.reconcile(QuotaSurface.WIDGET, names)
-            // WIDGET is opt-in, so reconcile leaves new names hidden; tick them
-            // all on to get past the cap.
-            names.forEach { configStore.setVisible(QuotaSurface.WIDGET, it, true) }
-        }
-
-        composeTestRule.setContent {
-            BellhopTheme {
-                QuotaBadgesConfigScreen(configStore = configStore, prefsStore = newPrefsStore(), onBack = {})
-            }
-        }
-
-        composeTestRule.onNodeWithTag("quota-config-tab-widget").performClick()
-        composeTestRule.waitForIdle()
-
-        composeTestRule.onNodeWithTag("quota-config-widget-cap").assertIsDisplayed()
     }
 
     @Test


### PR DESCRIPTION
Follow-up to #555, which added the widget's "+N" overflow marker.

## The bug

The marker measured what the strip rendered against a badge list that had already been
trimmed to twelve by `WIDGET_QUOTA_CAP` upstream in `widgetQuotaOf`. Select fifteen
badges, see four on a narrow widget, and it read `+8` when eleven were missing. The
marker's whole job is to say what isn't there, and it was under-reporting by however much
the earlier cap had quietly removed.

## The fix

Drop that cap rather than teach the marker to compensate for it.

`WIDGET_QUOTA_CAP` predates the strip wrapping onto several lines, and both jobs its
comment claims are now done by `WIDGET_QUOTA_MAX_ROWS`: the row cap is what bounds how
much of the widget the strip may eat, and what keeps the nested Column's children well
under Glance's ten. What remained was a second, invisible truncation sitting in front of
the one that reports itself. `widgetQuotaOf` now carries the operator's whole selection
and `quotaBadgeRows` decides what fits, which is the only place that can — it is the only
one that knows the widget's width.

The configurator's "Only the first 12 fit on the widget" note goes with it, in all eleven
locales. It was already saying something untrue: how many fit depends on the widget's
width and its labels' lengths, so on a narrow widget the real number is nearer four, and
on a wide one it can exceed twelve. The widget's own `+N` answers that question where the
answer is actually knowable.

## Verification

486 unit tests, ktlint and Android Lint green. `make i18n-check` confirms all eleven
locales stayed in parity through the string removal — that gate covers Android as of
#555, and this is the first change it has checked.

Two tests carry the fix: `overflowCountsEveryBadgeTheStripLeftOut` drives a fifteen-badge
selection through `widgetQuotaOf` into `quotaBadgeRows` and asserts the marker's count
equals the real shortfall, and `widgetQuotaRespectsOrderAndVisibilityAndKeepsTheWholeSelection`
pins that nothing is trimmed before the strip sees it. The two configurator tests that
asserted the removed note are gone with it.

Not verified on a device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
