### PR TITLE
perf(hooks): scope every pre-push step to the surfaces that changed

### DIFF
--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -34,15 +34,40 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 # 'dockerhub-readme-not-needed' PR label).
 DEFAULT_BRANCH="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##')"
 DEFAULT_BRANCH="${DEFAULT_BRANCH:-master}"
-SYNC_BASE="$(git merge-base "origin/${DEFAULT_BRANCH}" HEAD 2>/dev/null || true)"
-
-# One diff for the whole hook. Every gate below tests against this, so a branch
-# only pays for the surfaces it actually touched. Empty when there is no
-# merge-base, in which case the gates fall back to running everything.
-CHANGED=""
-if [ -n "$SYNC_BASE" ]; then
-	CHANGED="$(git diff --name-only "$SYNC_BASE" HEAD)"
+# git feeds pre-push the refs actually being pushed on stdin, one line each:
+#   <local ref> <local sha> <remote ref> <remote sha>
+# Gate on THOSE, not on HEAD. `git push origin some-other-branch` and multi-ref
+# pushes never touch HEAD, so a gate reading HEAD would measure an unrelated
+# branch and skip checks the pushed commits actually need. Falls back to HEAD
+# when stdin is empty or a terminal, i.e. the hook was run by hand.
+PUSH_HEADS=()
+if [ ! -t 0 ]; then
+	while read -r _local_ref local_sha _remote_ref _remote_sha; do
+		[ -n "${local_sha:-}" ] || continue
+		# All-zero local sha means a branch deletion: nothing to check.
+		case "$local_sha" in
+		*[!0]*) PUSH_HEADS+=("$local_sha") ;;
+		esac
+	done
 fi
+if [ "${#PUSH_HEADS[@]}" -eq 0 ]; then
+	PUSH_HEADS=("$(git rev-parse HEAD)")
+fi
+
+# One diff for the whole hook: the union of every ref being pushed, each measured
+# against its own merge-base with the default branch (the base..head model CI
+# uses). Every gate below tests against this, so a push only pays for the
+# surfaces it actually touched. SYNC_BASE stays empty when nothing has a
+# merge-base, in which case the gates fall back to running everything.
+SYNC_BASE=""
+CHANGED=""
+for _sha in "${PUSH_HEADS[@]}"; do
+	_base="$(git merge-base "origin/${DEFAULT_BRANCH}" "$_sha" 2>/dev/null || true)"
+	[ -n "$_base" ] || continue
+	[ -n "$SYNC_BASE" ] || SYNC_BASE="$_base"
+	CHANGED="$(printf '%s\n%s\n' "$CHANGED" "$(git diff --name-only "$_base" "$_sha" 2>/dev/null || true)")"
+done
+CHANGED="$(printf '%s\n' "$CHANGED" | grep -v '^[[:space:]]*$' || true)"
 # touched <regex> - true when a changed path matches, or when we have no diff to
 # go on (no merge-base), so an unknown state stays conservative and runs the check.
 touched() {
@@ -91,7 +116,9 @@ fi
 # Go lint, only when Go actually changed. golangci-lint already runs govet as one
 # of its enabled linters (.golangci.yml), so a separate `go vet` pass was doing
 # the same package-graph analysis twice for no extra signal; it is gone.
-if touched '\.go$|^go\.(mod|sum)$'; then
+# The linter's own config counts as a Go change: editing .golangci.yml can turn a
+# linter on and make previously-passing code fail, so it has to re-run.
+if touched '\.go$|^go\.(mod|sum)$|^\.golangci\.ya?ml$'; then
 	echo "pre-push: golangci-lint run ./cmd/... ./internal/... (includes govet)"
 	if ! golangci-lint run ./cmd/... ./internal/...; then
 		echo "pre-push: FAILED - golangci-lint" >&2

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -1,7 +1,16 @@
 #!/usr/bin/env bash
-# Pre-push: smoke test (~30s) plus a scoped diff-coverage gate. GitHub CI is
+# Pre-push: a scoped smoke test plus a scoped diff-coverage gate. GitHub CI is
 # still the real gatekeeper; this just catches the common failures before a
 # wasted CI cycle.
+#
+# EVERY step is gated on the surface it protects actually having changed, because
+# git opens the connection to the remote BEFORE running this hook and only writes
+# the pack afterwards. A hook that runs for minutes leaves that connection idle
+# for minutes, and a dropped connection kills the push with SIGPIPE (exit 141)
+# after all the work is done. Keeping the hook proportional to the diff is what
+# stops that, so do not add an ungated step here. If you are on a network that
+# drops idle connections anyway, push with:
+#   GIT_SSH_COMMAND="ssh -o ServerAliveInterval=15" git push
 #
 # Frontend checks use local pnpm when web/node_modules exists,
 # otherwise fall back to Docker.
@@ -26,8 +35,22 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 DEFAULT_BRANCH="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##')"
 DEFAULT_BRANCH="${DEFAULT_BRANCH:-master}"
 SYNC_BASE="$(git merge-base "origin/${DEFAULT_BRANCH}" HEAD 2>/dev/null || true)"
+
+# One diff for the whole hook. Every gate below tests against this, so a branch
+# only pays for the surfaces it actually touched. Empty when there is no
+# merge-base, in which case the gates fall back to running everything.
+CHANGED=""
 if [ -n "$SYNC_BASE" ]; then
 	CHANGED="$(git diff --name-only "$SYNC_BASE" HEAD)"
+fi
+# touched <regex> - true when a changed path matches, or when we have no diff to
+# go on (no merge-base), so an unknown state stays conservative and runs the check.
+touched() {
+	[ -z "$SYNC_BASE" ] && return 0
+	printf '%s\n' "$CHANGED" | grep -qE "$1"
+}
+
+if [ -n "$SYNC_BASE" ]; then
 	if printf '%s\n' "$CHANGED" | grep -qx "README.md" &&
 		! printf '%s\n' "$CHANGED" | grep -qx "DOCKERHUB.md"; then
 		if [ "${DOCKERHUB_README_NOT_NEEDED:-}" = "1" ]; then
@@ -65,21 +88,27 @@ if [ -f "$REPO_ROOT/DOCKERHUB.md" ]; then
 	fi
 fi
 
-echo "pre-push: go vet ./..."
-if ! go vet ./cmd/... ./internal/...; then
-	echo "pre-push: FAILED - go vet" >&2
-	exit 1
+# Go lint, only when Go actually changed. golangci-lint already runs govet as one
+# of its enabled linters (.golangci.yml), so a separate `go vet` pass was doing
+# the same package-graph analysis twice for no extra signal; it is gone.
+if touched '\.go$|^go\.(mod|sum)$'; then
+	echo "pre-push: golangci-lint run ./cmd/... ./internal/... (includes govet)"
+	if ! golangci-lint run ./cmd/... ./internal/...; then
+		echo "pre-push: FAILED - golangci-lint" >&2
+		exit 1
+	fi
+else
+	echo "pre-push: no Go changes, skipping golangci-lint"
 fi
 
-echo "pre-push: golangci-lint run ./..."
-if ! golangci-lint run ./cmd/... ./internal/...; then
-	echo "pre-push: FAILED - golangci-lint" >&2
-	exit 1
-fi
-
-# tsc -b runs here (not in the Docker image build) so type errors are caught
-# locally before push. It is incremental (tsbuildinfo), so it is cheap to repeat.
-if [ -d "$REPO_ROOT/web/node_modules" ]; then
+# Main-dashboard lint + typecheck, only when web/ changed. tsc -b runs here (not
+# in the Docker image build) so type errors are caught locally before push; it is
+# incremental (tsbuildinfo), so it is cheap to repeat.
+# This step only ever covered web/. frontdesk/web has never been linted by this
+# hook, so gating on ^web/ takes no protection away from a Front Desk branch.
+if ! touched '^web/'; then
+	echo "pre-push: no web/ changes, skipping pnpm lint + tsc -b"
+elif [ -d "$REPO_ROOT/web/node_modules" ]; then
 	echo "pre-push: pnpm lint + tsc -b (local)..."
 	if ! (cd "$REPO_ROOT/web" && pnpm run lint && pnpm exec tsc -b); then
 		echo "pre-push: FAILED - pnpm lint / tsc -b" >&2


### PR DESCRIPTION
The pre-push hook ran `go vet`, `golangci-lint` and the main-dashboard
`pnpm lint` + `tsc -b` on **every** push, whatever the diff contained. A
frontend-only branch paid for the whole Go package graph twice, and a Front Desk
branch paid for a lint of `web/` that covers none of its files.

## Why this is worse than just slow

`git push` opens the connection to the remote **before** running `pre-push`, and
only writes the pack afterwards. A hook that runs for minutes leaves that
connection idle for minutes. On a link that drops idle connections, the push then
dies with `SIGPIPE` (exit 141) *after every check has passed*, which looks like a
clean run that pushed nothing.

That happened three times in a row while pushing #559: full gate green, exit code
0, branch never on the remote. It only became visible by checking
`git ls-remote` rather than trusting the exit status. `ServerAliveInterval=15`
worked around it, but the real fix is not to hold the connection open that long.

## Changes

- Hoist one merge-base diff and add a `touched()` helper. Every gate uses it, and
  it returns true when there is no merge-base, so an unknown state still runs the
  check rather than silently skipping it.
- **Drop the separate `go vet` pass.** `.golangci.yml` already enables `govet`,
  so `golangci-lint` was repeating the same analysis over the same packages.
- **Gate `golangci-lint` on Go changes.**
- **Gate the `web/` lint + `tsc -b` on `web/` changes.** That step only ever
  covered `web/`, so this takes no protection away from a Front Desk branch.
- The diff-coverage gate was already scoped per surface and is unchanged.
- The header now records why every step must stay gated, so the next addition
  does not quietly reintroduce the idle-connection problem.

Nothing here weakens the actual gate: GitHub CI still runs the full suite, and a
branch that touches Go or `web/` still gets exactly the checks it did before.

## Measured

Pushing this branch (one changed file, `scripts/pre-push`):

```
pre-push: no Go changes, skipping golangci-lint
pre-push: no web/ changes, skipping pnpm lint + tsc -b
pre-push: diff-coverage gate - no measurable changed surfaces, skipping
pre-push: smoke ok (full CI runs on GitHub)
exit=0   elapsed=2s
```

2 seconds, against several minutes before. `bash -n` and `shellcheck -S warning`
are clean.

## Known remaining cost

A branch that touches even one line of `web/src/` still triggers the full
main-dashboard vitest coverage run. On #559 that was a six-line **comment** in
`web/src/hooks/useQuotaData.ts`. Skipping a surface whose changed lines are all
non-executable would need the gate to reason about which lines are executable
before it has coverage data, so it is left as a follow-up rather than guessed at
here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
