### PR TITLE
fix(hooks): do not report diff coverage for a ref that is not HEAD

### DIFF
--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -68,6 +68,18 @@ for _sha in "${PUSH_HEADS[@]}"; do
 	CHANGED="$(printf '%s\n%s\n' "$CHANGED" "$(git diff --name-only "$_base" "$_sha" 2>/dev/null || true)")"
 done
 CHANGED="$(printf '%s\n' "$CHANGED" | grep -v '^[[:space:]]*$' || true)"
+
+# Is the push exactly HEAD? The lint gates above only need the changed PATHS, which
+# the union covers. The coverage gate is different: it runs the suites against the
+# WORKING TREE and diff_coverage.py maps that coverage onto `base...HEAD`, so its
+# number only describes the push when the pushed ref IS HEAD. On a non-HEAD or
+# multi-ref push it would measure code that was never checked out, and with several
+# refs it would keep only the first merge-base, silently reporting on the wrong
+# range. Skipping beats a confident wrong answer; CI enforces coverage regardless.
+PUSH_IS_HEAD="no"
+if [ "${#PUSH_HEADS[@]}" -eq 1 ] && [ "${PUSH_HEADS[0]}" = "$(git rev-parse HEAD)" ]; then
+	PUSH_IS_HEAD="yes"
+fi
 # touched <regex> - true when a changed path matches, or when we have no diff to
 # go on (no merge-base), so an unknown state stays conservative and runs the check.
 touched() {
@@ -166,8 +178,13 @@ elif [ -z "$SYNC_BASE" ]; then
 	echo "pre-push: diff-coverage gate skipped (no merge-base with origin/${DEFAULT_BRANCH})" >&2
 elif ! command -v python3 >/dev/null 2>&1; then
 	echo "pre-push: diff-coverage gate skipped (python3 not found)" >&2
+elif [ "$PUSH_IS_HEAD" != "yes" ]; then
+	echo "pre-push: diff-coverage gate skipped (pushing a ref that is not HEAD)." >&2
+	echo "  Coverage here is measured from the working tree and mapped onto base...HEAD," >&2
+	echo "  so for another ref it would report a confident number about code that was" >&2
+	echo "  never checked out. CI enforces the same gate against the real ref." >&2
 else
-	CHANGED_FILES="$(git diff --name-only "$SYNC_BASE" HEAD)"
+	CHANGED_FILES="$CHANGED"
 	COV_DIR="$(mktemp -d)"
 	trap 'rm -rf "$COV_DIR"' EXIT
 	DC_ARGS=()


### PR DESCRIPTION
Follow-up to #560, which scoped the pre-push steps but left the coverage gate
reading the wrong ref. **This was a P1 on #560 that I merged without resolving**,
so it is fixed here rather than left on master.

## The bug

#560 made the lint gates read the refs git actually feeds `pre-push` on stdin,
but the coverage gate kept its own `git diff --name-only "$SYNC_BASE" HEAD`, and
`scripts/coverage/diff_coverage.py` hardcodes `{base}...HEAD`. `SYNC_BASE` also
keeps only the **first** pushed ref's merge-base. So on a non-HEAD or multi-ref
push the gate compared the wrong range and printed a confident coverage number
describing code that was never checked out.

## Why skip rather than plumb a `--diff-head` through

The coverage data is produced by running the suites against the **working tree**.
For a ref that is not checked out there is no correct number available, only a
wrongly-labelled one, so passing the pushed sha into `diff_coverage.py` would
move the error rather than remove it. CI runs the same gate against the real ref.

## Changes

- Add `PUSH_IS_HEAD`: exactly one pushed sha, equal to `HEAD`.
- Skip the coverage gate otherwise, printing why.
- Use the already-computed union `CHANGED` for the surface list, dropping the
  second `HEAD`-based diff.

The lint gates are unaffected. They only need the changed *paths*, which the
union over pushed refs already provides.

## Verified

`bash -n` and `shellcheck -S warning` clean, plus the hook run with stubbed tools
against both directions:

- pushing `HEAD` -> coverage gate evaluates normally
- pushing a non-HEAD ref -> `diff-coverage gate skipped (pushing a ref that is not HEAD)`, while the lint gates still run against that ref's diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)