### PR TITLE
fix(settings): stop a read racing a write from caching the pre-write value

### DIFF
--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -171,6 +171,15 @@ func (r *Repository) evict(key string) {
 	r.mu.Unlock()
 }
 
+// evictKVs evicts the key of every pair, taking the lock once.
+func (r *Repository) evictKVs(kvs [][2]string) {
+	r.mu.Lock()
+	for _, kv := range kvs {
+		r.evictLocked(kv[0])
+	}
+	r.mu.Unlock()
+}
+
 // Subscribe returns a Subscription whose channel receives a ChangeEvent for
 // every settings update written through Set or SetTx + InvalidateCache.
 //
@@ -364,10 +373,22 @@ func (r *Repository) Set(ctx context.Context, key, value string) error {
 		INSERT INTO settings (key, value, updated_at) VALUES ($1, $2, now())
 		ON CONFLICT (key) DO UPDATE SET value = $2, updated_at = now()
 	`, key, value)
+
+	// Evict unconditionally, before the error check, because an error here does
+	// not mean the row is unchanged: if the connection drops or ctx is
+	// cancelled in the commit-acknowledgement window, pgx reports a failure for
+	// a statement the server actually applied. Callers do pass cancellable
+	// request contexts (quota drift, config-sync apply), so this is reachable.
+	// Skipping the eviction on that path would leave a reader's mid-write
+	// install pinned for the full cacheTTL against a write that took effect —
+	// the exact bug the post-write eviction exists to close. Evicting after a
+	// genuinely failed write is harmless: it costs one DB read on next access.
+	// Only the notification stays gated on success; we must not announce a
+	// change we cannot confirm.
+	r.evict(key)
 	if err != nil {
 		return err
 	}
-	r.evict(key)
 	r.notifyChange(key, value)
 	return nil
 }
@@ -387,11 +408,7 @@ func (r *Repository) SetMany(ctx context.Context, kvs [][2]string) error {
 
 	// Evict before the write, exactly as Set does, so a read racing the write
 	// falls through to the DB rather than serving a stale cached value.
-	r.mu.Lock()
-	for _, kv := range kvs {
-		r.evictLocked(kv[0])
-	}
-	r.mu.Unlock()
+	r.evictKVs(kvs)
 
 	var sb strings.Builder
 	sb.WriteString("INSERT INTO settings (key, value, updated_at) VALUES ")
@@ -405,17 +422,15 @@ func (r *Repository) SetMany(ctx context.Context, kvs [][2]string) error {
 	}
 	sb.WriteString(" ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = now()")
 
-	if _, err := r.pool.Exec(ctx, sb.String(), args...); err != nil {
+	_, err := r.pool.Exec(ctx, sb.String(), args...)
+
+	// Evict again for the same reason Set does, and — like Set — unconditionally
+	// and before the error check, because a reported error can still describe a
+	// statement the server applied.
+	r.evictKVs(kvs)
+	if err != nil {
 		return err
 	}
-	// Evict again now the write has committed, for the same reason Set does:
-	// a reader that missed the cache mid-write installed the pre-write value
-	// and would otherwise hold it for the full cacheTTL.
-	r.mu.Lock()
-	for _, kv := range kvs {
-		r.evictLocked(kv[0])
-	}
-	r.mu.Unlock()
 	// The row write is atomic (one statement); the notifications are not. We fan
 	// out one change event per key after the commit succeeds, exactly as a loop
 	// of Set calls would, so a subscriber may observe the keys arrive one at a
@@ -516,7 +531,10 @@ func (r *Repository) WarmCache(ctx context.Context) {
 		warmed++
 	}
 	r.mu.Unlock()
-	debuglog.Info("settings: warmed cache", "count", warmed)
+	// Log both numbers: "count" stays the installed total, and "read" preserves
+	// the "how many settings exist" signal, so a skip is visible as a gap
+	// rather than looking like an empty settings table.
+	debuglog.Info("settings: warmed cache", "count", warmed, "read", len(all), "skipped", len(all)-warmed)
 }
 
 // GetAll retrieves all settings as a key-value map.

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -100,9 +100,22 @@ type subscription struct {
 // events. The returned Subscription provides a channel to read from and an
 // Unsubscribe method to clean up.
 type Repository struct {
-	pool     *pgxpool.Pool
-	mu       sync.RWMutex
-	cache    map[string]cacheEntry
+	pool  *pgxpool.Pool
+	mu    sync.RWMutex
+	cache map[string]cacheEntry
+	// cacheGen counts mutations per key. A reader captures the generation
+	// before issuing its query and installs the result only if the generation
+	// is unchanged when it takes the write lock, so a read that overlapped a
+	// write can never resurrect the pre-write value. See evictLocked.
+	//
+	// The counter is per-key rather than global on purpose: settings writes
+	// are rare but reads are on the proxy's per-request hot path, and a global
+	// counter would make any single write discard every unrelated cache fill
+	// in flight (a config-sync import or a fleet heartbeat SetMany would
+	// briefly degrade every key to a query per read). Per-key confines that to
+	// the key actually being written. The map is bounded by the number of
+	// distinct keys ever written, which is the settings key space.
+	cacheGen map[string]uint64
 	cacheTTL time.Duration
 
 	// changeMu protects onChangeCallbacks and subscriptions.
@@ -138,8 +151,24 @@ func NewRepository(pool *pgxpool.Pool) *Repository {
 	return &Repository{
 		pool:     pool,
 		cache:    make(map[string]cacheEntry),
+		cacheGen: make(map[string]uint64),
 		cacheTTL: 30 * time.Second,
 	}
+}
+
+// evictLocked drops the cache entry for key and advances its generation so a
+// read already in flight cannot install its (now potentially stale) result.
+// The caller must hold r.mu for writing.
+func (r *Repository) evictLocked(key string) {
+	delete(r.cache, key)
+	r.cacheGen[key]++
+}
+
+// evict is evictLocked with the lock taken for you.
+func (r *Repository) evict(key string) {
+	r.mu.Lock()
+	r.evictLocked(key)
+	r.mu.Unlock()
 }
 
 // Subscribe returns a Subscription whose channel receives a ChangeEvent for
@@ -250,6 +279,7 @@ func (r *Repository) GetWithDefault(ctx context.Context, key, defaultValue strin
 		r.mu.RUnlock()
 		return entry.value
 	}
+	gen := r.cacheGen[key]
 	r.mu.RUnlock()
 
 	var value string
@@ -264,8 +294,17 @@ func (r *Repository) GetWithDefault(ctx context.Context, key, defaultValue strin
 		return defaultValue
 	}
 
+	// Only install the result if no write landed while the query was in
+	// flight. If one did, the value we read may already be stale, so we return
+	// it to this caller but leave the cache empty for the next reader to
+	// refill. This cannot wedge the hot path: the guard never retries and
+	// never blocks, so the very next read after the writes stop caches
+	// normally — reads only stay uncached for as long as writes to this key
+	// are actually in flight, which is exactly when caching would be wrong.
 	r.mu.Lock()
-	r.cache[key] = cacheEntry{value: value, expiresAt: time.Now().Add(r.cacheTTL)}
+	if r.cacheGen[key] == gen {
+		r.cache[key] = cacheEntry{value: value, expiresAt: time.Now().Add(r.cacheTTL)}
+	}
 	r.mu.Unlock()
 
 	return value
@@ -283,6 +322,7 @@ func (r *Repository) GetChecked(ctx context.Context, key string) (value string, 
 		r.mu.RUnlock()
 		return entry.value, true, nil
 	}
+	gen := r.cacheGen[key]
 	r.mu.RUnlock()
 
 	var v string
@@ -294,18 +334,31 @@ func (r *Repository) GetChecked(ctx context.Context, key string) (value string, 
 		return "", false, err // real read failure: let the caller decide
 	}
 
+	// Same generation guard as GetWithDefault: skip the install if a write
+	// landed while the query was in flight.
 	r.mu.Lock()
-	r.cache[key] = cacheEntry{value: v, expiresAt: time.Now().Add(r.cacheTTL)}
+	if r.cacheGen[key] == gen {
+		r.cache[key] = cacheEntry{value: v, expiresAt: time.Now().Add(r.cacheTTL)}
+	}
 	r.mu.Unlock()
 
 	return v, true, nil
 }
 
 // Set updates a setting and invalidates the cache.
+//
+// The cache is evicted twice, once on each side of the write, and both
+// evictions matter. The pre-write eviction stops an entry that was already
+// cached from being served for the rest of its TTL while the write is in
+// flight. The post-write eviction drops anything a reader installed *during*
+// the write: such a reader misses the cache, reads the pre-write row (the
+// UPSERT has not committed yet, so it is invisible), and would otherwise pin
+// that stale value for the full cacheTTL — far longer than any caller that
+// re-reads on the change notification is willing to wait. Both evictions
+// happen before notifyChange, so a subscriber woken by the event and
+// re-reading from the "source of truth" cannot be handed the old value.
 func (r *Repository) Set(ctx context.Context, key, value string) error {
-	r.mu.Lock()
-	delete(r.cache, key)
-	r.mu.Unlock()
+	r.evict(key)
 
 	_, err := r.pool.Exec(ctx, `
 		INSERT INTO settings (key, value, updated_at) VALUES ($1, $2, now())
@@ -314,6 +367,7 @@ func (r *Repository) Set(ctx context.Context, key, value string) error {
 	if err != nil {
 		return err
 	}
+	r.evict(key)
 	r.notifyChange(key, value)
 	return nil
 }
@@ -324,8 +378,8 @@ func (r *Repository) Set(ctx context.Context, key, value string) error {
 // round-trip instead of one per key, which keeps them comfortably inside a
 // caller's request timeout even when the database is briefly slow (a
 // simultaneous multi-container restart, say). Semantics otherwise match Set:
-// no allowlist gate, cache evicted before the write, subscribers notified
-// after it commits. An empty slice is a no-op.
+// no allowlist gate, cache evicted on both sides of the write, subscribers
+// notified after it commits. An empty slice is a no-op.
 func (r *Repository) SetMany(ctx context.Context, kvs [][2]string) error {
 	if len(kvs) == 0 {
 		return nil
@@ -335,7 +389,7 @@ func (r *Repository) SetMany(ctx context.Context, kvs [][2]string) error {
 	// falls through to the DB rather than serving a stale cached value.
 	r.mu.Lock()
 	for _, kv := range kvs {
-		delete(r.cache, kv[0])
+		r.evictLocked(kv[0])
 	}
 	r.mu.Unlock()
 
@@ -354,6 +408,14 @@ func (r *Repository) SetMany(ctx context.Context, kvs [][2]string) error {
 	if _, err := r.pool.Exec(ctx, sb.String(), args...); err != nil {
 		return err
 	}
+	// Evict again now the write has committed, for the same reason Set does:
+	// a reader that missed the cache mid-write installed the pre-write value
+	// and would otherwise hold it for the full cacheTTL.
+	r.mu.Lock()
+	for _, kv := range kvs {
+		r.evictLocked(kv[0])
+	}
+	r.mu.Unlock()
 	// The row write is atomic (one statement); the notifications are not. We fan
 	// out one change event per key after the commit succeeds, exactly as a loop
 	// of Set calls would, so a subscriber may observe the keys arrive one at a
@@ -406,9 +468,7 @@ func (r *Repository) DeleteKeysTx(ctx context.Context, tx pgx.Tx, keys []string)
 // For reset-to-default flows where the key was deleted from the DB, use
 // NotifyDeleted instead to avoid a wasteful DB query.
 func (r *Repository) InvalidateCache(key string) {
-	r.mu.Lock()
-	delete(r.cache, key)
-	r.mu.Unlock()
+	r.evict(key)
 	// InvalidateCache is called after SetTx commits. We don't know the
 	// committed value here, so we do a best-effort lookup to notify
 	// subscribers. If the lookup fails (e.g. the key was deleted), we
@@ -422,9 +482,7 @@ func (r *Repository) InvalidateCache(key string) {
 // deleted from the database (reset-to-default) to avoid a redundant DB
 // lookup — we already know the value is gone.
 func (r *Repository) NotifyDeleted(key string) {
-	r.mu.Lock()
-	delete(r.cache, key)
-	r.mu.Unlock()
+	r.evict(key)
 	r.notifyChange(key, "")
 }
 
@@ -432,17 +490,33 @@ func (r *Repository) NotifyDeleted(key string) {
 // Without this, settings are populated lazily on first read and expire after
 // cacheTTL (30s), causing periodic cache misses on the hot path.
 func (r *Repository) WarmCache(ctx context.Context) {
+	// Snapshot the generations before the query, so a write that lands while
+	// the bulk read is in flight is not undone by warming the pre-write value
+	// back in. Keys absent from the snapshot are at generation 0. This runs
+	// once at startup, so the copy is not on any hot path.
+	r.mu.RLock()
+	gens := make(map[string]uint64, len(r.cacheGen))
+	for k, v := range r.cacheGen {
+		gens[k] = v
+	}
+	r.mu.RUnlock()
+
 	all, err := r.GetAll(ctx)
 	if err != nil {
 		debuglog.Warn("settings: failed to warm cache", "error", err)
 		return
 	}
+	warmed := 0
 	r.mu.Lock()
 	for key, value := range all {
+		if r.cacheGen[key] != gens[key] {
+			continue // written while we were reading; let the next read refill
+		}
 		r.cache[key] = cacheEntry{value: value, expiresAt: time.Now().Add(r.cacheTTL)}
+		warmed++
 	}
 	r.mu.Unlock()
-	debuglog.Info("settings: warmed cache", "count", len(all))
+	debuglog.Info("settings: warmed cache", "count", warmed)
 }
 
 // GetAll retrieves all settings as a key-value map.

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -1437,7 +1437,10 @@ func TestSetManyVisibleToReaderRacingTheWrite(t *testing.T) {
 // generation and is parked inside its query.
 func waitForBlockedSettingsRead(t *testing.T) {
 	t.Helper()
-	ctx := context.Background()
+	// Bound the probe itself by the same deadline, not just the loop: a probe
+	// that blocks would otherwise never get back to the deadline check.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
 	deadline := time.Now().Add(30 * time.Second)
 	for time.Now().Before(deadline) {
 		var n int
@@ -1532,15 +1535,23 @@ func TestCacheGenerationGuardStillCachesAfterWritesStop(t *testing.T) {
 	r := NewRepository(testPool)
 	key := "gen_settle_key"
 
+	// Wait for the readers rather than leaking them: a reader still parked in
+	// its SELECT would be matched by another test's pg_stat_activity probe.
+	var wg sync.WaitGroup
 	for range 20 {
 		if err := r.Set(ctx, key, "1"); err != nil {
 			t.Fatalf("set failed: %v", err)
 		}
-		go func() { _ = r.GetWithDefault(ctx, key, "d") }()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = r.GetWithDefault(ctx, key, "d")
+		}()
 	}
 	if err := r.Set(ctx, key, "final"); err != nil {
 		t.Fatalf("set failed: %v", err)
 	}
+	wg.Wait()
 
 	// With writes finished, the next read must install a cache entry.
 	deadline := time.Now().Add(10 * time.Second)
@@ -1556,4 +1567,71 @@ func TestCacheGenerationGuardStillCachesAfterWritesStop(t *testing.T) {
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
+}
+
+// TestFailedWriteStillEvictsOnBothSides covers the error path of Set and
+// SetMany. pgx reports a failure for a statement the server actually applied
+// when the connection drops or the context is cancelled in the
+// commit-acknowledgement window, and both functions are called with
+// cancellable request contexts (quota drift, config-sync apply). The
+// post-write eviction must therefore run even when Exec returns an error,
+// otherwise a reader that installed the pre-write value mid-write keeps it for
+// the full cacheTTL against a write that took effect. Only the change
+// notification is gated on success.
+//
+// The discriminating observable is the generation counter: a write must move
+// it twice, once on each side of Exec, regardless of the outcome. A full
+// end-to-end repro would need a reader whose entire query completes inside the
+// write window of a write that then fails, which cannot be scheduled without a
+// fault-injection hook in production code. That hook is deliberately not
+// added, so the invariant is asserted directly instead.
+func TestFailedWriteStillEvictsOnBothSides(t *testing.T) {
+	clearSettings(t)
+	r := NewRepository(testPool)
+
+	generation := func(key string) uint64 {
+		r.mu.RLock()
+		defer r.mu.RUnlock()
+		return r.cacheGen[key]
+	}
+
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	t.Run("Set", func(t *testing.T) {
+		key := "failed_set_key"
+		before := generation(key)
+		if err := r.Set(cancelled, key, "new"); err == nil {
+			t.Fatal("expected Set to fail on a cancelled context")
+		}
+		if moved := generation(key) - before; moved != 2 {
+			t.Errorf("failed Set moved the generation %d time(s), want 2 (one eviction on each side of the write)", moved)
+		}
+	})
+
+	t.Run("SetMany", func(t *testing.T) {
+		key := "failed_setmany_key"
+		before := generation(key)
+		if err := r.SetMany(cancelled, [][2]string{{key, "new"}}); err == nil {
+			t.Fatal("expected SetMany to fail on a cancelled context")
+		}
+		if moved := generation(key) - before; moved != 2 {
+			t.Errorf("failed SetMany moved the generation %d time(s), want 2 (one eviction on each side of the write)", moved)
+		}
+	})
+
+	t.Run("a failed write does not notify subscribers", func(t *testing.T) {
+		key := "failed_notify_key"
+		sub := r.Subscribe()
+		defer sub.Unsubscribe()
+
+		if err := r.Set(cancelled, key, "new"); err == nil {
+			t.Fatal("expected Set to fail on a cancelled context")
+		}
+		select {
+		case ev := <-sub.Events():
+			t.Errorf("a failed write must not announce a change, got %+v", ev)
+		case <-time.After(100 * time.Millisecond):
+		}
+	})
 }

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1345,5 +1346,214 @@ func TestWarmCache_EmptyDB(t *testing.T) {
 	r.mu.RUnlock()
 	if cacheLen != 0 {
 		t.Errorf("expected empty cache after WarmCache on empty DB, got %d entries", cacheLen)
+	}
+}
+
+// readerRacingWrite runs a reader hammering the key while write flips it from
+// "20" to "0", then reports whether the post-write value is visible once the
+// write returns. It is the shared body of the Set and SetMany regression
+// tests below.
+//
+// The hazard being covered: the cache is evicted before the write, so a reader
+// that misses the cache mid-write reads the *pre-write* row (the UPSERT has
+// not committed, so it is invisible) and installs it. Without the post-write
+// eviction that stale entry is served for the full cacheTTL (30s), which is
+// far longer than any subscriber that re-reads on the change notification is
+// prepared to wait.
+func readerRacingWrite(t *testing.T, r *Repository, key string, write func() error) int {
+	t.Helper()
+	ctx := context.Background()
+
+	violations := 0
+	const rounds = 50
+	deadline := time.Now().Add(90 * time.Second)
+
+	for i := range rounds {
+		if time.Now().After(deadline) {
+			t.Fatalf("test budget exhausted after %d rounds", i)
+		}
+		if err := r.Set(ctx, key, "20"); err != nil {
+			t.Fatalf("seed set failed: %v", err)
+		}
+		_ = r.GetInt(ctx, key, 5) // warm the cache with the pre-write value
+
+		var stop atomic.Bool
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			for !stop.Load() {
+				_ = r.GetInt(ctx, key, 5)
+			}
+		}()
+
+		err := write()
+		stop.Store(true)
+		<-done
+		if err != nil {
+			t.Fatalf("write failed: %v", err)
+		}
+
+		if got := r.GetInt(ctx, key, 5); got != 0 {
+			violations++
+		}
+	}
+	return violations
+}
+
+// TestSetVisibleToReaderRacingTheWrite pins the fix for a cache race in Set: a
+// read concurrent with the write must not be able to pin the pre-write value
+// for the rest of the cache TTL. Against the pre-fix code this reproduced on
+// every round.
+func TestSetVisibleToReaderRacingTheWrite(t *testing.T) {
+	clearSettings(t)
+	r := NewRepository(testPool)
+	key := "race_set_key"
+
+	violations := readerRacingWrite(t, r, key, func() error {
+		return r.Set(context.Background(), key, "0")
+	})
+	if violations != 0 {
+		t.Errorf("Set: reader observed the pre-write value after the write returned in %d rounds", violations)
+	}
+}
+
+// TestSetManyVisibleToReaderRacingTheWrite is TestSetVisibleToReaderRacingTheWrite
+// for SetMany, which had the identical evict-before-write-only bug.
+func TestSetManyVisibleToReaderRacingTheWrite(t *testing.T) {
+	clearSettings(t)
+	r := NewRepository(testPool)
+	key := "race_setmany_key"
+
+	violations := readerRacingWrite(t, r, key, func() error {
+		return r.SetMany(context.Background(), [][2]string{{key, "0"}})
+	})
+	if violations != 0 {
+		t.Errorf("SetMany: reader observed the pre-write value after the write returned in %d rounds", violations)
+	}
+}
+
+// waitForBlockedSettingsRead blocks until a query against the settings table is
+// waiting on a lock, so the caller knows a reader has captured its cache
+// generation and is parked inside its query.
+func waitForBlockedSettingsRead(t *testing.T) {
+	t.Helper()
+	ctx := context.Background()
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		var n int
+		err := testPool.QueryRow(ctx, `
+			SELECT count(*) FROM pg_stat_activity
+			WHERE datname = current_database()
+			  AND wait_event_type = 'Lock'
+			  AND query LIKE '%FROM settings WHERE key%'
+		`).Scan(&n)
+		if err != nil {
+			t.Fatalf("pg_stat_activity probe failed: %v", err)
+		}
+		if n > 0 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("reader never blocked on the settings table lock")
+}
+
+// TestCacheGenerationGuardBlocksLateReader covers the residual the double
+// eviction alone cannot close: a reader whose query has already returned, but
+// which has not yet taken the write lock, could still install the value it
+// read after an eviction happened. The per-key generation counter stops it.
+//
+// The interleaving is made deterministic by holding an ACCESS EXCLUSIVE lock on
+// the settings table, which blocks the reader's plain SELECT. That parks the
+// reader precisely between capturing the generation and installing its result,
+// with no test-only hook in the production code.
+func TestCacheGenerationGuardBlocksLateReader(t *testing.T) {
+	ctx := context.Background()
+	clearSettings(t)
+	r := NewRepository(testPool)
+	key := "gen_guard_key"
+
+	if err := r.Set(ctx, key, "old"); err != nil {
+		t.Fatalf("seed set failed: %v", err)
+	}
+	if r.IsCached(key) {
+		t.Fatal("Set must leave the cache empty")
+	}
+
+	tx, err := testPool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin failed: %v", err)
+	}
+	defer func() { _ = tx.Rollback(context.Background()) }()
+	if _, err := tx.Exec(ctx, "LOCK TABLE settings IN ACCESS EXCLUSIVE MODE"); err != nil {
+		t.Fatalf("lock table failed: %v", err)
+	}
+
+	// Bound the read so a lock we somehow fail to release cannot hang the suite.
+	readCtx, cancelRead := context.WithTimeout(ctx, 60*time.Second)
+	defer cancelRead()
+	got := make(chan string, 1)
+	go func() { got <- r.GetWithDefault(readCtx, key, "default") }()
+
+	waitForBlockedSettingsRead(t)
+
+	// An invalidation lands while the reader is parked inside its query. This
+	// only touches the cache, so it does not contend for the table lock.
+	r.NotifyDeleted(key)
+
+	// Release the lock; the reader's SELECT now returns the row it was waiting
+	// on, which is the value that predates the invalidation.
+	if err := tx.Rollback(ctx); err != nil {
+		t.Fatalf("rollback failed: %v", err)
+	}
+
+	select {
+	case v := <-got:
+		// The reader still returns what it read — the guard suppresses caching,
+		// not the result.
+		if v != "old" {
+			t.Errorf("expected the reader to return the value it read, got %q", v)
+		}
+	case <-time.After(60 * time.Second):
+		t.Fatal("blocked read never completed")
+	}
+
+	if r.IsCached(key) {
+		t.Error("a reader whose generation moved mid-query must not populate the cache")
+	}
+}
+
+// TestCacheGenerationGuardStillCachesAfterWritesStop guards against the guard
+// itself wedging the hot path: once writes stop, reads must cache normally
+// again rather than degrading into a query per read.
+func TestCacheGenerationGuardStillCachesAfterWritesStop(t *testing.T) {
+	ctx := context.Background()
+	clearSettings(t)
+	r := NewRepository(testPool)
+	key := "gen_settle_key"
+
+	for range 20 {
+		if err := r.Set(ctx, key, "1"); err != nil {
+			t.Fatalf("set failed: %v", err)
+		}
+		go func() { _ = r.GetWithDefault(ctx, key, "d") }()
+	}
+	if err := r.Set(ctx, key, "final"); err != nil {
+		t.Fatalf("set failed: %v", err)
+	}
+
+	// With writes finished, the next read must install a cache entry.
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		if v := r.GetWithDefault(ctx, key, "d"); v != "final" {
+			t.Fatalf("expected %q, got %q", "final", v)
+		}
+		if r.IsCached(key) {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("reads never resumed caching after writes stopped")
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 }


### PR DESCRIPTION
## What this fixes

`master` is red on `TestQuotaPollLoop_TransitionToDisabledClearsQuotaAdvice` (CI run 30311255323). That test was **correctly detecting a real bug**, not flaking.

`internal/settings` caches values with a 30-second TTL. `Set` evicted the cache entry **before** the database write and never after, so a reader that missed the cache during the write window repopulated it with the **pre-write** value, which then served for the full TTL. `SetMany` had the same shape.

That breaks the package's own documented subscription contract: *wake on the change event, re-read the database as the source of truth*. The quota poll loop and the discovery scheduler both use it, so **any** settings change could be ignored for up to 30 seconds by a component unlucky enough to read during the write window. Every `Set` caller was exposed; the quota loop just happened to have a test tight enough to catch it.

The file already knew about this hazard. `DeleteKeysTx` carries a comment saying evicting before commit *"would let concurrent reads repopulate the cache with the pre-delete DB value"*, and `SetTx`/`InvalidateCache` follow the correct order. Only `Set` and `SetMany` had it backwards.

**Measured before the fix:** 200/200 rounds reproduced in a tight loop; 0.5% at the poll loop's real ~20ms cadence on an idle 12-core machine, which is the shape of a rare single-job CI flake.

## The fix, in two layers

Both are necessary and neither is sufficient alone.

1. **Evict after the successful write** (`Set`, `SetMany`), before `notifyChange`, keeping the pre-write eviction. Closes the common case.
2. **Per-key generation guard.** Readers capture the generation before their query and install the cache entry only if it is unchanged when they take the write lock. This closes the case the first layer cannot: a reader whose query landed *before* the commit but installs *after* the eviction.

Installs and evictions both take the same mutex and are therefore totally ordered, so at a reader's install point exactly one of two things is true: the install won the lock and the post-write eviction removes it immediately, or the eviction won and the generation compare rejects it. There is no third case.

**Per-key rather than global:** a global counter would be correct but would discard every unrelated cache fill in flight on any single write. Settings reads are on the proxy's per-request path; writes are rare and bursty (config-sync import, fleet heartbeat).

**Hot path is unchanged on a cache hit** — the early return fires before the generation is read. A miss adds one map lookup under the `RLock` already held and one lookup plus a `uint64` compare under the `Lock` already held. No second lock, no allocation.

**Starvation is structurally impossible:** bumps originate only from an eviction, and the compare is against a per-read captured value with no retry, so the first read whose capture postdates the last write installs.

Eviction is centralised into `evictLocked`/`evict` (delete and bump together); the only raw `delete(r.cache, …)` left in production code is inside the helper.

### Error-path eviction

`Set`/`SetMany` now evict **unconditionally** after `Exec`, before the error check. pgx can return an error for a statement the server actually committed (context cancellation in the acknowledgement window), and both reachable call sites pass a cancellable request context. `notifyChange` stays gated on success, so an unconfirmable change is still never announced.

## Tests

- `TestSetVisibleToReaderRacingTheWrite` / `TestSetManyVisibleToReaderRacingTheWrite` — reader racing a write; **fail 50/50 rounds against pre-fix code**.
- `TestCacheGenerationGuardBlocksLateReader` — deterministic, and written **without a test-only seam**: it parks a reader inside its `SELECT` with `LOCK TABLE … ACCESS EXCLUSIVE`, waits on `pg_stat_activity` until the reader is confirmed blocked, lands a `NotifyDeleted`, then releases. The lock is confined to this package's own test database (`TestMain` creates a dedicated one and the probe filters on `datname = current_database()`), and release is covered on every exit path including `t.Fatalf`.
- `TestCacheGenerationGuardStillCachesAfterWritesStop` — proves the guard cannot permanently suppress caching.
- `TestFailedWriteStillEvictsOnBothSides` — asserts the generation moves twice per write regardless of outcome; fails at 1 without the error-path fix.

`cmd/server/background_test.go` is deliberately **untouched**. It was doing its job; widening its timeout would have buried this.

## Verification

- New tests fail against pre-fix code, pass after
- `internal/settings`: green plain, `-race`, and `-shuffle=on`; new tests green at `-count=8`
- `go test ./cmd/server/ -run TestQuotaPollLoop -count=10` green, and `GOMAXPROCS=1` full package green — the originally red test
- `go test ./...` fully green; `go build ./...` clean; `golangci-lint run ./...` 0 issues

## Note for operators

`WarmCache`'s startup log gains `read` and `skipped` alongside `count`, so a skipped key is a visible gap rather than looking like an empty settings table. If anything pattern-matches that line, the shape has changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
