### PR TITLE
chore(web): silence noDocumentCookie where it does not apply

### DIFF
--- a/web/biome.json
+++ b/web/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.5.3/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
 	"vcs": {
 		"enabled": true,
 		"clientKind": "git",
@@ -39,5 +39,17 @@
 				"organizeImports": "on"
 			}
 		}
-	}
+	},
+	"overrides": [
+		{
+			"includes": ["**/__tests__/**", "src/test/**"],
+			"linter": {
+				"rules": {
+					"suspicious": {
+						"noDocumentCookie": "off"
+					}
+				}
+			}
+		}
+	]
 }

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -197,8 +197,16 @@ export function isAuthenticated(): boolean {
 
 /** clearAuth expires the readable CSRF cookie so isAuthenticated() flips false.
  * The httpOnly session cookie is cleared server-side on logout / on a 401; this
- * drops the client-visible auth signal immediately. */
+ * drops the client-visible auth signal immediately.
+ *
+ * The write stays on document.cookie rather than the Cookie Store API that
+ * noDocumentCookie suggests: cookieStore.delete() is async and unavailable in
+ * Safari and Firefox, and every caller either reloads the page (Layout logout,
+ * the SSE 401 path) or throws right after this returns, so a promise-based
+ * delete could lose the race and leave the stale signal readable on the next
+ * page load. */
 export function clearAuth(): void {
+	// biome-ignore lint/suspicious/noDocumentCookie: must be synchronous; see the doc comment above.
 	document.cookie = "mh_csrf=; path=/; max-age=0";
 }
 


### PR DESCRIPTION
Follow-up to #576. Biome 2.5.5 added `lint/suspicious/noDocumentCookie`, which fires
**57 times** in `web/`. None of them are defects, and the rule's suggested remedy does
not fit either site, so this scopes the rule rather than rewriting working code.

**56 are tests** seeding or clearing the readable `mh_csrf` cookie under jsdom. jsdom
implements no Cookie Store API at all, so there is nothing to migrate them to. The rule
is turned off for `**/__tests__/**` and `src/test/**`.

**1 is production** - `clearAuth()` in `web/src/api/client.ts`, which is deliberate.
`cookieStore.delete()` is async and unavailable in Safari and Firefox, and every caller
either reloads the page (`Layout` logout, the SSE 401 path in `EventContext`) or throws
immediately after `clearAuth()` returns, so a promise-based delete could lose the race
and leave the stale auth signal readable on the next page load. It carries a single
suppression, with the reasoning in the function's doc comment.

Worth recording for the next person who writes one of these: the suppression has to be a
**single** comment line. A `biome-ignore` followed by further `//` lines attaches to the
next comment instead of the statement, and Biome reports `Suppression comment has no
effect`.

Also bumps the `biome.json` `$schema` to 2.5.5 to match the version #576 installed.

## Verification

- `biome check` - clean, **0 warnings** (was 57)
- `pnpm run lint` - clean
- `tsc -b` - clean
- `pnpm run test` - 5481 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
