### PR TITLE
ci: make the weekly image scan reliable, self-healing and legible

### DIFF
--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -25,36 +25,20 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      # Pull the image ourselves, with retries, instead of letting Trivy fetch
-      # it from the registry: a single Docker Hub blip (`dial tcp ...: i/o
-      # timeout`) used to fail the whole job, and because this is the only
-      # workflow that uploads Trivy SARIF, the Security tab then showed the
-      # tool as failing for a week. Trivy resolves the image from the local
-      # docker daemon first, so both scans below reuse this one pull.
-      - name: Pull published images (with retries)
+      # Each image is pulled immediately before its own scan, and never in a
+      # shared step: a failed pull aborts the job, so batching both pulls up
+      # front would mean an unreachable Front Desk image costs us the app
+      # image's report too. That is the same "lost a week of scanning to a
+      # registry blip" failure this workflow is trying to stop having.
+      #
+      # We pull rather than letting Trivy fetch from the registry so a single
+      # Docker Hub blip (`dial tcp ...: i/o timeout`) gets retried instead of
+      # killing the run. Trivy resolves an image from the local docker daemon
+      # before the registry, so each scan reuses the pull above it.
+      - name: Pull published image (with retries)
         env:
-          IMAGES: >-
-            docker.io/hugalafutro/model-hotel:latest
-            docker.io/hugalafutro/model-hotel-frontdesk:latest
-        run: |
-          set -euo pipefail
-          for image in $IMAGES; do
-            pulled=false
-            for attempt in 1 2 3; do
-              if docker pull "$image"; then
-                pulled=true
-                break
-              fi
-              echo "::warning::docker pull $image failed (attempt $attempt/3)"
-              if [ "$attempt" -lt 3 ]; then
-                sleep $((attempt * 30))
-              fi
-            done
-            if [ "$pulled" = false ]; then
-              echo "::error::could not pull $image after 3 attempts"
-              exit 1
-            fi
-          done
+          IMAGE: docker.io/hugalafutro/model-hotel:latest
+        run: scripts/ci/pull-image-with-retries.sh "$IMAGE"
 
       # Full-picture report (all severities, unfixed included) for the GitHub
       # Security tab, so findings are tracked over time — deliberately broader
@@ -79,6 +63,11 @@ jobs:
       # The Front Desk control plane is published from the same release, so it
       # ages the same way and deserves the same weekly look. A distinct SARIF
       # category keeps its findings from overwriting the app image's.
+      - name: Pull published Front Desk image (with retries)
+        env:
+          IMAGE: docker.io/hugalafutro/model-hotel-frontdesk:latest
+        run: scripts/ci/pull-image-with-retries.sh "$IMAGE"
+
       - name: Scan published Front Desk image (SARIF report)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -33,6 +33,9 @@ jobs:
   scan:
     name: Trivy Scan (latest)
     runs-on: ubuntu-latest
+    outputs:
+      app_gate: ${{ steps.gate_app.outcome }}
+      frontdesk_gate: ${{ steps.gate_frontdesk.outcome }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -152,3 +155,180 @@ jobs:
         run: |
           # shellcheck disable=SC2086 # deliberate split: one argument per outcome
           scripts/ci/summarise-scan-outcomes.sh $OUTCOMES
+
+  # When the scan finds something fixable, try the cheap fix before asking a
+  # human for anything: rebuild the SAME released source, which picks up current
+  # Alpine security patches via the Dockerfile's apk upgrade.
+  #
+  # This deliberately rebuilds the release TAG, not master. Rebuilding master
+  # would quietly put unreleased code behind :latest. The consequence is that a
+  # rebuild only clears OS-level CVEs: anything coming from go.mod needs a code
+  # change that exists only on master, so it cannot fix itself and the report job
+  # says so instead of pretending otherwise.
+  refresh:
+    name: Rebuild ${{ matrix.image }} from the current release
+    needs: scan
+    if: >-
+      always() && (needs.scan.outputs.app_gate == 'failure'
+      || needs.scan.outputs.frontdesk_gate == 'failure')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: model-hotel
+            dockerfile: Dockerfile
+            smoke: true
+          - image: model-hotel-frontdesk
+            dockerfile: Dockerfile.frontdesk
+            smoke: false
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: modelhotel
+          POSTGRES_PASSWORD: changeme
+          POSTGRES_DB: modelhotel
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      # :latest always tracks the newest release, so that tag is the source the
+      # published image was built from.
+      - name: Resolve the released tag behind :latest
+        id: release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          tag=$(gh release view --json tagName --jq .tagName)
+          echo "tag=$tag" >>"$GITHUB_OUTPUT"
+          echo "sha=$(git rev-list -n1 "$tag")" >>"$GITHUB_OUTPUT"
+          echo "Rebuilding from $tag"
+
+      - name: Check out the released tag
+        run: git checkout --detach "${{ steps.release.outputs.tag }}"
+
+      - name: Rebuild the image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          load: true
+          tags: ${{ matrix.image }}:rebuild-candidate
+          build-args: |
+            VERSION=${{ steps.release.outputs.tag }}
+            COMMIT=${{ steps.release.outputs.sha }}
+          platforms: linux/amd64
+          provenance: false
+          # No cache: a cached apk upgrade layer is precisely what would make
+          # this rebuild a no-op and waste the whole exercise.
+          no-cache: true
+
+      - name: Does the rebuild clear the findings?
+        id: rescan
+        continue-on-error: true
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: image
+          image-ref: ${{ matrix.image }}:rebuild-candidate
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: 1
+          timeout: 15m
+
+      # Nothing else in this repo smoke-tests an image before publishing; the
+      # release path relies on the full suite passing before the build. A
+      # rebuild runs none of that, so this is the only thing standing between a
+      # broken base-image update and everyone who pulls :latest.
+      - name: Smoke test the rebuilt image
+        id: smoke
+        if: matrix.smoke && steps.rescan.outcome == 'success'
+        continue-on-error: true
+        env:
+          IMAGE: ${{ matrix.image }}:rebuild-candidate
+        run: scripts/ci/smoke-test-image.sh "$IMAGE"
+
+      - name: Publish the rebuilt image as :latest
+        id: publish
+        if: >-
+          steps.rescan.outcome == 'success'
+          && (matrix.smoke != true || steps.smoke.outcome == 'success')
+        env:
+          IMAGE: ${{ matrix.image }}
+          TARGET: ${{ secrets.DOCKERHUB_USERNAME }}/${{ matrix.image }}:latest
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          echo "$DOCKERHUB_TOKEN" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+          docker tag "$IMAGE:rebuild-candidate" "$TARGET"
+          docker push "$TARGET"
+          echo "Republished $TARGET"
+
+      - name: Record what happened
+        if: always()
+        env:
+          IMAGE: ${{ matrix.image }}
+          TAG: ${{ steps.release.outputs.tag }}
+          RESCAN: ${{ steps.rescan.outcome }}
+          SMOKE: ${{ steps.smoke.outcome }}
+          PUBLISH: ${{ steps.publish.outcome }}
+        run: |
+          set -euo pipefail
+          mkdir -p refresh-status
+          {
+            echo "image=$IMAGE"
+            echo "tag=$TAG"
+            echo "rebuild_clean=$RESCAN"
+            echo "smoke=$SMOKE"
+            echo "published=$PUBLISH"
+          } >"refresh-status/$IMAGE.txt"
+
+      - name: Upload status
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: refresh-status-${{ matrix.image }}
+          path: refresh-status/
+
+  # One issue, reused, that says what it wants from you. The weekly scan's only
+  # previous output was a failure email, and an email that says "network error"
+  # on the one week that mattered is how a real finding went unnoticed.
+  report:
+    name: Report scan result
+    needs: [scan, refresh]
+    if: always() && needs.scan.result != 'cancelled'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Download refresh status
+        if: needs.refresh.result != 'skipped'
+        continue-on-error: true
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: refresh-status-*
+          merge-multiple: true
+          path: refresh-status
+
+      - name: Compose and file the report
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APP_GATE: ${{ needs.scan.outputs.app_gate }}
+          FRONTDESK_GATE: ${{ needs.scan.outputs.frontdesk_gate }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: scripts/ci/compose-scan-report.sh

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -25,6 +25,27 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # Pull the image ourselves, with retries, instead of letting Trivy fetch
+      # it from the registry: a single Docker Hub blip (`dial tcp ...: i/o
+      # timeout`) used to fail the whole job, and because this is the only
+      # workflow that uploads Trivy SARIF, the Security tab then showed the
+      # tool as failing for a week. Trivy resolves the image from the local
+      # docker daemon first, so both scans below reuse this one pull.
+      - name: Pull published image (with retries)
+        env:
+          IMAGE: docker.io/hugalafutro/model-hotel:latest
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            if docker pull "$IMAGE"; then
+              exit 0
+            fi
+            echo "::warning::docker pull $IMAGE failed (attempt $attempt/3)"
+            sleep $((attempt * 30))
+          done
+          echo "::error::could not pull $IMAGE after 3 attempts"
+          exit 1
+
       # Full-picture report (all severities, unfixed included) for the GitHub
       # Security tab, so findings are tracked over time — deliberately broader
       # than the gate below, which only fails on what is actionable.
@@ -35,6 +56,9 @@ jobs:
           image-ref: docker.io/hugalafutro/model-hotel:latest
           format: sarif
           output: trivy-image.sarif
+          # Well above Trivy's 5m default: the image is already local, but the
+          # vulnerability DB download still goes over the network.
+          timeout: 15m
 
       - name: Upload SARIF to GitHub Security tab
         uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
@@ -51,3 +75,4 @@ jobs:
           severity: CRITICAL,HIGH
           ignore-unfixed: true
           exit-code: 1
+          timeout: 15m

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -1,4 +1,4 @@
-# Weekly vulnerability scan of the published image.
+# Weekly vulnerability scan of the published images (app + Front Desk).
 #
 # The CI gate only runs when a PR is open, but CVEs land in already-published
 # images (this is exactly how the OpenSSL 3.5.6 flags appeared on Docker Hub:
@@ -31,20 +31,30 @@ jobs:
       # workflow that uploads Trivy SARIF, the Security tab then showed the
       # tool as failing for a week. Trivy resolves the image from the local
       # docker daemon first, so both scans below reuse this one pull.
-      - name: Pull published image (with retries)
+      - name: Pull published images (with retries)
         env:
-          IMAGE: docker.io/hugalafutro/model-hotel:latest
+          IMAGES: >-
+            docker.io/hugalafutro/model-hotel:latest
+            docker.io/hugalafutro/model-hotel-frontdesk:latest
         run: |
           set -euo pipefail
-          for attempt in 1 2 3; do
-            if docker pull "$IMAGE"; then
-              exit 0
+          for image in $IMAGES; do
+            pulled=false
+            for attempt in 1 2 3; do
+              if docker pull "$image"; then
+                pulled=true
+                break
+              fi
+              echo "::warning::docker pull $image failed (attempt $attempt/3)"
+              if [ "$attempt" -lt 3 ]; then
+                sleep $((attempt * 30))
+              fi
+            done
+            if [ "$pulled" = false ]; then
+              echo "::error::could not pull $image after 3 attempts"
+              exit 1
             fi
-            echo "::warning::docker pull $IMAGE failed (attempt $attempt/3)"
-            sleep $((attempt * 30))
           done
-          echo "::error::could not pull $IMAGE after 3 attempts"
-          exit 1
 
       # Full-picture report (all severities, unfixed included) for the GitHub
       # Security tab, so findings are tracked over time — deliberately broader
@@ -66,12 +76,43 @@ jobs:
           sarif_file: trivy-image.sarif
           category: published-image
 
+      # The Front Desk control plane is published from the same release, so it
+      # ages the same way and deserves the same weekly look. A distinct SARIF
+      # category keeps its findings from overwriting the app image's.
+      - name: Scan published Front Desk image (SARIF report)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: image
+          image-ref: docker.io/hugalafutro/model-hotel-frontdesk:latest
+          format: sarif
+          output: trivy-frontdesk-image.sarif
+          timeout: 15m
+
+      - name: Upload Front Desk SARIF to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        with:
+          sarif_file: trivy-frontdesk-image.sarif
+          category: published-frontdesk-image
+
+      # Gates run last, after both SARIF uploads: a failing gate must never cost
+      # us the Security tab record of why it failed.
+      #
       # Same actionable-only policy as the CI gate: fixable HIGH/CRITICAL only.
       - name: Scan published image for fixable HIGH/CRITICAL vulnerabilities
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: image
           image-ref: docker.io/hugalafutro/model-hotel:latest
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: 1
+          timeout: 15m
+
+      - name: Scan published Front Desk image for fixable HIGH/CRITICAL vulnerabilities
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: image
+          image-ref: docker.io/hugalafutro/model-hotel-frontdesk:latest
           severity: CRITICAL,HIGH
           ignore-unfixed: true
           exit-code: 1

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -7,6 +7,13 @@
 # Alpine patches — so it doubles as the signal to cut a patch release. It also
 # catches the publish workflow's GHA layer cache serving a stale apk upgrade
 # layer.
+#
+# Every step below is independent on purpose. This job is the only thing that
+# uploads Trivy SARIF, so one image being briefly unreachable must never cost
+# us the other image's report or gate: each step records its own outcome, and
+# the summary at the end fails the job while naming what actually broke. A red
+# run whose cause you have to go dig for is how this workflow already lost a
+# week of scan coverage to a transient Docker Hub timeout.
 name: Scan Published Image
 
 on:
@@ -18,6 +25,10 @@ permissions:
   contents: read
   security-events: write
 
+env:
+  APP_IMAGE: docker.io/hugalafutro/model-hotel:latest
+  FRONTDESK_IMAGE: docker.io/hugalafutro/model-hotel-frontdesk:latest
+
 jobs:
   scan:
     name: Trivy Scan (latest)
@@ -25,29 +36,26 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      # Each image is pulled immediately before its own scan, and never in a
-      # shared step: a failed pull aborts the job, so batching both pulls up
-      # front would mean an unreachable Front Desk image costs us the app
-      # image's report too. That is the same "lost a week of scanning to a
-      # registry blip" failure this workflow is trying to stop having.
-      #
       # We pull rather than letting Trivy fetch from the registry so a single
       # Docker Hub blip (`dial tcp ...: i/o timeout`) gets retried instead of
       # killing the run. Trivy resolves an image from the local docker daemon
       # before the registry, so each scan reuses the pull above it.
       - name: Pull published image (with retries)
-        env:
-          IMAGE: docker.io/hugalafutro/model-hotel:latest
-        run: scripts/ci/pull-image-with-retries.sh "$IMAGE"
+        id: pull_app
+        continue-on-error: true
+        run: scripts/ci/pull-image-with-retries.sh "$APP_IMAGE"
 
       # Full-picture report (all severities, unfixed included) for the GitHub
       # Security tab, so findings are tracked over time — deliberately broader
       # than the gate below, which only fails on what is actionable.
       - name: Scan published image (SARIF report)
+        id: scan_app
+        if: steps.pull_app.outcome == 'success'
+        continue-on-error: true
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: image
-          image-ref: docker.io/hugalafutro/model-hotel:latest
+          image-ref: ${{ env.APP_IMAGE }}
           format: sarif
           output: trivy-image.sarif
           # Well above Trivy's 5m default: the image is already local, but the
@@ -55,6 +63,9 @@ jobs:
           timeout: 15m
 
       - name: Upload SARIF to GitHub Security tab
+        id: upload_app
+        if: steps.scan_app.outcome == 'success'
+        continue-on-error: true
         uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           sarif_file: trivy-image.sarif
@@ -64,45 +75,80 @@ jobs:
       # ages the same way and deserves the same weekly look. A distinct SARIF
       # category keeps its findings from overwriting the app image's.
       - name: Pull published Front Desk image (with retries)
-        env:
-          IMAGE: docker.io/hugalafutro/model-hotel-frontdesk:latest
-        run: scripts/ci/pull-image-with-retries.sh "$IMAGE"
+        id: pull_frontdesk
+        continue-on-error: true
+        run: scripts/ci/pull-image-with-retries.sh "$FRONTDESK_IMAGE"
 
       - name: Scan published Front Desk image (SARIF report)
+        id: scan_frontdesk
+        if: steps.pull_frontdesk.outcome == 'success'
+        continue-on-error: true
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: image
-          image-ref: docker.io/hugalafutro/model-hotel-frontdesk:latest
+          image-ref: ${{ env.FRONTDESK_IMAGE }}
           format: sarif
           output: trivy-frontdesk-image.sarif
           timeout: 15m
 
       - name: Upload Front Desk SARIF to GitHub Security tab
+        id: upload_frontdesk
+        if: steps.scan_frontdesk.outcome == 'success'
+        continue-on-error: true
         uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           sarif_file: trivy-frontdesk-image.sarif
           category: published-frontdesk-image
 
-      # Gates run last, after both SARIF uploads: a failing gate must never cost
-      # us the Security tab record of why it failed.
+      # Gates run after both uploads, so a gate failure never costs us the
+      # Security tab record of why it failed, and each gate is tied only to its
+      # own image's pull: an unreachable Front Desk image must not let an
+      # actionable app-image vulnerability through unremarked.
       #
       # Same actionable-only policy as the CI gate: fixable HIGH/CRITICAL only.
       - name: Scan published image for fixable HIGH/CRITICAL vulnerabilities
+        id: gate_app
+        if: steps.pull_app.outcome == 'success'
+        continue-on-error: true
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: image
-          image-ref: docker.io/hugalafutro/model-hotel:latest
+          image-ref: ${{ env.APP_IMAGE }}
           severity: CRITICAL,HIGH
           ignore-unfixed: true
           exit-code: 1
           timeout: 15m
 
       - name: Scan published Front Desk image for fixable HIGH/CRITICAL vulnerabilities
+        id: gate_frontdesk
+        if: steps.pull_frontdesk.outcome == 'success'
+        continue-on-error: true
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: image
-          image-ref: docker.io/hugalafutro/model-hotel-frontdesk:latest
+          image-ref: ${{ env.FRONTDESK_IMAGE }}
           severity: CRITICAL,HIGH
           ignore-unfixed: true
           exit-code: 1
           timeout: 15m
+
+      # Single place that decides red or green. Every step above is
+      # continue-on-error so none of them can abort the others, which means the
+      # job's own status would be green no matter what happened; this step is
+      # what makes it honest, and it names the failing step so the run does not
+      # need archaeology to interpret.
+      - name: Summarise scan outcomes
+        if: always()
+        env:
+          OUTCOMES: >-
+            pull_app=${{ steps.pull_app.outcome }}
+            scan_app=${{ steps.scan_app.outcome }}
+            upload_app=${{ steps.upload_app.outcome }}
+            gate_app=${{ steps.gate_app.outcome }}
+            pull_frontdesk=${{ steps.pull_frontdesk.outcome }}
+            scan_frontdesk=${{ steps.scan_frontdesk.outcome }}
+            upload_frontdesk=${{ steps.upload_frontdesk.outcome }}
+            gate_frontdesk=${{ steps.gate_frontdesk.outcome }}
+        run: |
+          # shellcheck disable=SC2086 # deliberate split: one argument per outcome
+          scripts/ci/summarise-scan-outcomes.sh $OUTCOMES

--- a/scripts/ci/compose-scan-report.sh
+++ b/scripts/ci/compose-scan-report.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+#
+# Turn the weekly scan + rebuild results into the tracking issue's body, then
+# file it via report-image-scan-issue.sh.
+#
+# The point of the wording here is to answer "what do you want from me" without
+# a log dig. A rebuild can only clear OS-level CVEs, because it rebuilds the
+# released tag; anything left after a successful rebuild comes from go.mod and
+# needs a patch release cut from master. Saying which of the two you are looking
+# at is the whole value of this report.
+set -euo pipefail
+
+APP_GATE=${APP_GATE:-}
+FRONTDESK_GATE=${FRONTDESK_GATE:-}
+RUN_URL=${RUN_URL:-}
+STATUS_DIR=${STATUS_DIR:-refresh-status}
+
+body=$(mktemp)
+trap 'rm -f "$body"' EXIT
+
+# read_status <image> <field> - pull one field out of a refresh status file.
+read_status() {
+  local file="$STATUS_DIR/$1.txt"
+  [ -f "$file" ] || return 1
+  sed -n "s/^$2=//p" "$file" | head -1
+}
+
+vulnerable=false
+needs_release=false
+republished=false
+
+{
+  echo "The weekly scan of the published images found fixable HIGH/CRITICAL vulnerabilities."
+  echo
+  echo "| image | scan | rebuild clears it | republished |"
+  echo "|---|---|---|---|"
+} >"$body"
+
+for entry in "model-hotel:$APP_GATE" "model-hotel-frontdesk:$FRONTDESK_GATE"; do
+  image=${entry%%:*}
+  gate=${entry#*:}
+
+  case "$gate" in
+  failure) vulnerable=true; scan_cell="fixable HIGH/CRITICAL" ;;
+  success) scan_cell="clean" ;;
+  *) scan_cell="not scanned ($gate)" ;;
+  esac
+
+  rebuild=$(read_status "$image" rebuild_clean || echo "not attempted")
+  published=$(read_status "$image" published || echo "not attempted")
+
+  case "$rebuild" in
+  success) rebuild_cell="yes" ;;
+  failure)
+    rebuild_cell="no, still vulnerable"
+    if [ "$gate" = failure ]; then
+      needs_release=true
+    fi
+    ;;
+  *) rebuild_cell="$rebuild" ;;
+  esac
+
+  case "$published" in
+  success)
+    published_cell="yes, :latest refreshed"
+    republished=true
+    ;;
+  failure) published_cell="push failed" ;;
+  skipped) published_cell="no" ;;
+  *) published_cell="$published" ;;
+  esac
+
+  echo "| \`$image\` | $scan_cell | $rebuild_cell | $published_cell |" >>"$body"
+done
+
+{
+  echo
+  if [ "$needs_release" = true ]; then
+    echo "### This one needs you"
+    echo
+    echo "Rebuilding the released tag did **not** clear the findings, which means they come from"
+    echo "a Go dependency rather than an Alpine package. A rebuild cannot fix that: the fix has to"
+    echo "be in \`go.mod\`, and only a patch release cut from \`master\` will put it in the published"
+    echo "image. Check whether \`master\` already carries the bump before doing anything else."
+  elif [ "$republished" = true ]; then
+    echo "### Handled automatically"
+    echo
+    echo "A rebuild of the released tag cleared the findings and \`:latest\` has been refreshed."
+    echo "No release is needed. This issue is here as a record and will close on the next clean scan."
+  else
+    # Never claim a rebuild happened just because one was not reported as
+    # failed: the refresh job can be skipped or die before publishing, and an
+    # issue that says ":latest was refreshed" when it was not is worse than no
+    # issue at all.
+    echo "### Needs a look"
+    echo
+    echo "The scan found fixable vulnerabilities, but the rebuild did not get as far as"
+    echo "republishing \`:latest\`, so nothing has been fixed automatically. Check the run below"
+    echo "to see whether the rebuild failed or never started."
+  fi
+  echo
+  if [ -n "$RUN_URL" ]; then
+    echo "[Full scan run]($RUN_URL)"
+  fi
+} >>"$body"
+
+if [ "$vulnerable" != true ]; then
+  echo "No fixable findings; closing any open tracking issue."
+  scripts/ci/report-image-scan-issue.sh clean "Published images: fixable vulnerabilities found"
+  exit 0
+fi
+
+title="Published images: fixable vulnerabilities found"
+if [ "$needs_release" = true ]; then
+  title="Published images need a patch release"
+fi
+
+cat "$body"
+scripts/ci/report-image-scan-issue.sh vulnerable "$title" "$body"

--- a/scripts/ci/compose-scan-report.sh
+++ b/scripts/ci/compose-scan-report.sh
@@ -28,6 +28,7 @@ read_status() {
 vulnerable=false
 needs_release=false
 republished=false
+unverified=false
 
 {
   echo "The weekly scan of the published images found fixable HIGH/CRITICAL vulnerabilities."
@@ -41,9 +42,18 @@ for entry in "model-hotel:$APP_GATE" "model-hotel-frontdesk:$FRONTDESK_GATE"; do
   gate=${entry#*:}
 
   case "$gate" in
-  failure) vulnerable=true; scan_cell="fixable HIGH/CRITICAL" ;;
+  failure)
+    vulnerable=true
+    scan_cell="fixable HIGH/CRITICAL"
+    ;;
   success) scan_cell="clean" ;;
-  *) scan_cell="not scanned ($gate)" ;;
+  # Any other outcome means this image was never actually scanned, most often
+  # because its pull failed. That is not evidence of anything, least of all of
+  # being clean.
+  *)
+    unverified=true
+    scan_cell="not scanned ($gate)"
+    ;;
   esac
 
   rebuild=$(read_status "$image" rebuild_clean || echo "not attempted")
@@ -105,6 +115,16 @@ done
 } >>"$body"
 
 if [ "$vulnerable" != true ]; then
+  # Closing requires a clean result for EVERY image, not merely the absence of a
+  # failing one. An image whose pull died reports its gate as "skipped", and
+  # treating that as clean would close an issue about confirmed HIGH/CRITICAL
+  # vulnerabilities on the strength of never having looked. The run is already
+  # red in that case, so leaving the issue open costs nothing and assuming
+  # recovery costs everything.
+  if [ "$unverified" = true ]; then
+    echo "Not every image was scanned; leaving any open tracking issue alone."
+    exit 0
+  fi
   echo "No fixable findings; closing any open tracking issue."
   scripts/ci/report-image-scan-issue.sh clean "Published images: fixable vulnerabilities found"
   exit 0

--- a/scripts/ci/pull-image-with-retries.sh
+++ b/scripts/ci/pull-image-with-retries.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# Pull a container image, retrying on transient registry failures.
+#
+# Used by .github/workflows/image-scan.yml, which scans already-published
+# images. Trivy's own registry fetch has no retry and a 5m default timeout, so
+# one Docker Hub blip (`dial tcp ...: i/o timeout`) fails the whole scheduled
+# run: no SARIF is uploaded, and the Security tab shows Trivy red until the
+# next weekly run. Pulling here instead means a blip costs a retry, not a week
+# of scan coverage. Trivy resolves an image from the local docker daemon before
+# reaching for the registry, so the scan steps reuse what this pulls.
+set -euo pipefail
+
+readonly ATTEMPTS=3
+
+image=${1:-}
+if [ -z "$image" ]; then
+  echo "::error::usage: $0 <image-ref>"
+  exit 2
+fi
+
+for attempt in $(seq 1 "$ATTEMPTS"); do
+  if docker pull "$image"; then
+    exit 0
+  fi
+  echo "::warning::docker pull $image failed (attempt $attempt/$ATTEMPTS)"
+  # No sleep after the final attempt: nothing follows it but the failure.
+  if [ "$attempt" -lt "$ATTEMPTS" ]; then
+    sleep $((attempt * 30))
+  fi
+done
+
+echo "::error::could not pull $image after $ATTEMPTS attempts"
+exit 1

--- a/scripts/ci/report-image-scan-issue.sh
+++ b/scripts/ci/report-image-scan-issue.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# Open, update or close the tracking issue for the weekly published-image scan.
+#
+# The weekly scan's only previous output was a failure email, which is how a
+# real finding sat unnoticed: the one run that mattered had failed on a network
+# error, and an email saying "network error" reads exactly like noise you learn
+# to ignore. An issue has a lifecycle, sits where work is tracked, and says what
+# it wants from you. It is deliberately ONE issue, reused: a new issue every
+# Monday would train the same reflex the email did.
+#
+# Usage:
+#   report-image-scan-issue.sh vulnerable <title> <body-file>
+#   report-image-scan-issue.sh clean      <title>
+#
+# Requires gh authenticated with issues:write (GH_TOKEN in CI).
+set -euo pipefail
+
+readonly LABEL="published-image-scan"
+
+state=${1:-}
+title=${2:-}
+body_file=${3:-}
+
+if [ -z "$state" ] || [ -z "$title" ]; then
+  echo "::error::usage: $0 <vulnerable|clean> <title> [body-file]"
+  exit 2
+fi
+
+# Reuse the existing open issue if there is one. --limit 1 with the label is
+# enough: this script is the only thing that creates them.
+existing=$(gh issue list --label "$LABEL" --state open --limit 1 --json number --jq '.[0].number // empty')
+
+case "$state" in
+vulnerable)
+  if [ -z "$body_file" ] || [ ! -f "$body_file" ]; then
+    echo "::error::vulnerable requires a readable body file"
+    exit 2
+  fi
+  if [ -n "$existing" ]; then
+    echo "Updating issue #$existing"
+    # Rewrite the body so the issue always shows the CURRENT state rather than
+    # forcing a reader to scroll to the newest comment, and comment so the issue
+    # still surfaces in notifications.
+    gh issue edit "$existing" --title "$title" --body-file "$body_file"
+    gh issue comment "$existing" --body-file "$body_file"
+  else
+    echo "Opening a new issue"
+    gh issue create --label "$LABEL" --title "$title" --body-file "$body_file"
+  fi
+  ;;
+clean)
+  if [ -z "$existing" ]; then
+    echo "Nothing to close: no open $LABEL issue."
+    exit 0
+  fi
+  echo "Closing issue #$existing"
+  gh issue comment "$existing" --body "The published images are clean of fixable HIGH/CRITICAL vulnerabilities as of this run. Closing automatically; the weekly scan will reopen a fresh issue if that changes."
+  gh issue close "$existing"
+  ;;
+*)
+  echo "::error::unknown state '$state' (expected vulnerable or clean)"
+  exit 2
+  ;;
+esac

--- a/scripts/ci/report-image-scan-issue.sh
+++ b/scripts/ci/report-image-scan-issue.sh
@@ -27,6 +27,14 @@ if [ -z "$state" ] || [ -z "$title" ]; then
   exit 2
 fi
 
+# gh refuses to create an issue with a label the repo does not have, which would
+# break the first real run and nothing after it. --force makes this idempotent.
+ensure_label() {
+  gh label create "$LABEL" --force \
+    --color B60205 \
+    --description "Weekly scan of the published Docker images" >/dev/null
+}
+
 # Reuse the existing open issue if there is one. --limit 1 with the label is
 # enough: this script is the only thing that creates them.
 existing=$(gh issue list --label "$LABEL" --state open --limit 1 --json number --jq '.[0].number // empty')
@@ -46,6 +54,7 @@ vulnerable)
     gh issue comment "$existing" --body-file "$body_file"
   else
     echo "Opening a new issue"
+    ensure_label
     gh issue create --label "$LABEL" --title "$title" --body-file "$body_file"
   fi
   ;;

--- a/scripts/ci/smoke-test-image.sh
+++ b/scripts/ci/smoke-test-image.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# Prove a rebuilt image actually boots and serves before it replaces :latest.
+#
+# The normal release path never smoke-tests the image: it relies on the full
+# test suite passing before the build, which is sound because the build is the
+# last step. An automated rebuild runs none of that suite, and it changes the
+# base OS packages underneath the same application code, so this is the only
+# thing between a bad Alpine update and everyone who pulls :latest. It is
+# deliberately shallow: boot, serve /health, exit. Anything deeper belongs in
+# the test suite, not in a Monday-morning rebuild.
+#
+# Expects a Postgres reachable on localhost:5432 (the workflow's service
+# container) and uses host networking so the container can see it.
+#
+# Usage: smoke-test-image.sh <image-ref>
+set -euo pipefail
+
+readonly HEALTH_URL="http://localhost:8080/health"
+readonly BOOT_TIMEOUT=90
+
+image=${1:-}
+if [ -z "$image" ]; then
+  echo "::error::usage: $0 <image-ref>"
+  exit 2
+fi
+
+container=""
+# shellcheck disable=SC2329 # invoked indirectly via trap
+cleanup() {
+  if [ -n "$container" ]; then
+    echo "--- container logs ---"
+    docker logs "$container" 2>&1 | tail -40 || true
+    docker rm -f "$container" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+echo "Starting $image"
+container=$(docker run -d --network host \
+  -e MASTER_KEY=smoke-test-master-key-not-a-real-secret-000 \
+  -e POSTGRES_USER=modelhotel \
+  -e POSTGRES_PASSWORD=changeme \
+  -e POSTGRES_HOST=localhost \
+  -e POSTGRES_DB=modelhotel \
+  -e DATA_DIR=/data \
+  "$image")
+
+deadline=$((SECONDS + BOOT_TIMEOUT))
+while [ "$SECONDS" -lt "$deadline" ]; do
+  # A dead container will never become healthy, so stop waiting on it rather
+  # than burning the full timeout.
+  if [ "$(docker inspect -f '{{.State.Running}}' "$container" 2>/dev/null)" != "true" ]; then
+    echo "::error::container exited before serving $HEALTH_URL"
+    exit 1
+  fi
+  if curl -fsS --max-time 5 "$HEALTH_URL" >/dev/null 2>&1; then
+    echo "Healthy: $image answered $HEALTH_URL"
+    exit 0
+  fi
+  sleep 3
+done
+
+echo "::error::$image did not answer $HEALTH_URL within ${BOOT_TIMEOUT}s"
+exit 1

--- a/scripts/ci/summarise-scan-outcomes.sh
+++ b/scripts/ci/summarise-scan-outcomes.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# Decide whether the weekly image scan passed, and say why if it did not.
+#
+# Every step in .github/workflows/image-scan.yml is continue-on-error, so that
+# one unreachable image cannot abort the other image's scan, upload or gate.
+# The cost of that is the job status no longer reflects reality on its own, so
+# this script is the single place that turns per-step outcomes back into a red
+# or green run. It also names the failing step, because the failure mode that
+# started all this was a red icon whose cause took a log dig to find.
+#
+# Usage: summarise-scan-outcomes.sh name=outcome [name=outcome ...]
+# where outcome is a GitHub steps.<id>.outcome: success, failure, skipped,
+# cancelled, or empty when the step never ran.
+set -euo pipefail
+
+if [ "$#" -eq 0 ]; then
+  echo "::error::usage: $0 name=outcome [name=outcome ...]"
+  exit 2
+fi
+
+failed=()
+skipped=()
+unknown=()
+
+echo "Weekly image scan outcomes:"
+for pair in "$@"; do
+  name=${pair%%=*}
+  outcome=${pair#*=}
+  printf '  %-20s %s\n' "$name" "${outcome:-<empty>}"
+  case "$outcome" in
+  success) ;;
+  skipped) skipped+=("$name") ;;
+  # An empty outcome means the workflow referenced a step id that does not
+  # exist, so a gate we believe is running is in fact absent. Treating it as
+  # "skipped" would let a typo silently retire a gate and still report green.
+  '') unknown+=("$name") ;;
+  *) failed+=("$name") ;;
+  esac
+done
+
+if [ "${#unknown[@]}" -gt 0 ]; then
+  echo "::error::no outcome reported for: ${unknown[*]} (step id renamed or misspelled in image-scan.yml)"
+  exit 1
+fi
+
+# A skipped step is never a failure on its own: it means the step it depends on
+# already failed, and that dependency is reported below in its own right.
+if [ "${#skipped[@]}" -gt 0 ]; then
+  echo "::notice::skipped (upstream step failed): ${skipped[*]}"
+fi
+
+if [ "${#failed[@]}" -gt 0 ]; then
+  echo "::error::weekly image scan failed: ${failed[*]}"
+  exit 1
+fi
+
+echo "All image scans passed."


### PR DESCRIPTION
## Why

The weekly `Scan Published Image` run on 2026-07-27 ([30256795690](https://github.com/hugalafutro/model-hotel/actions/runs/30256795690)) died on a Docker Hub blip:

```
FATAL ... unable to find the specified image "docker.io/hugalafutro/model-hotel:latest"
  * remote error: Get "https://index.docker.io/v2/": dial tcp 98.87.64.57:443: i/o timeout
```

It sat for exactly 5 minutes (Trivy's default image timeout) and gave up before producing any SARIF. This is the only workflow that uploads Trivy results, so the Security tab showed the tool red with no scan for a week.

Then the re-run found the failure had been masking something real:

```
app/server (gobinary)  google.golang.org/grpc  GHSA-hrxh-6v49-42gf  HIGH  fixed
  v1.81.1 -> 1.82.1
```

So the week the alarm was mute was the week it mattered. Three separate weaknesses combined: the scan was fragile, its output was a failure email that reads like noise, and nothing acted on the result.

## What

**Reliable.** Each image is pulled by `scripts/ci/pull-image-with-retries.sh` (3 attempts, 30s/60s backoff) immediately before its own scan, and every Trivy step gets `timeout: 15m`. Trivy resolves from the local docker daemon before the registry, so the scans reuse the pull.

**Independent.** Every step is `continue-on-error` with its own id, and each scan, upload and gate keys off *its own* image's pull. One unreachable image can no longer cost the other its report or its gate. Since that leaves the job status unable to reflect reality, `scripts/ci/summarise-scan-outcomes.sh` is the single place that decides red or green and names the failing steps.

**Self-healing where it can be.** When the scan finds something fixable, `refresh` rebuilds the released tag (picking up current Alpine patches via the Dockerfile's `apk upgrade`), smoke tests that the image still boots and serves `/health`, and republishes `:latest` only if both hold. It rebuilds the **tag, not master**, so `:latest` never gains unreleased code.

**Legible.** `report` files one reused issue that says which situation you are in: fixed automatically, or needs a patch release cut from master because the fix lives in `go.mod`. It closes itself on the next clean scan.

**Front Desk added.** `model-hotel-frontdesk:latest` is published from the same release but was never scanned after publication. It now gets the same treatment under its own SARIF category.

## The honest limitation

A rebuild only clears **OS-level** CVEs. Today's grpc finding came from `go.mod`, and that fix exists only on master (`f19d0036`, Jul 22), not in the v0.9.90 tag `:latest` was built from. Rebuilding the tag reproduces v1.81.1 forever. The workflow does not pretend otherwise: it detects exactly this case and says a patch release is needed instead of silently doing nothing.

Nothing else in this repo smoke tests an image before publishing (the release path relies on the suite passing before the build). An automated rebuild runs none of that, which is why the smoke test exists and why the push is gated on it.

## Verification

- `actionlint` and `shellcheck` clean on the workflow and all four scripts.
- Retry script exercised against a stubbed `docker`: exhausts 3 attempts and fails, recovers mid-retry, fails per-image without a false pass, rejects a missing argument.
- Outcome summariser exercised across all-success (0), Front Desk pull dies while the app has a real vuln (1), app pull dies while Front Desk scans fully (1), total Docker Hub outage (1), no args (2).
- Report composer exercised against a stubbed `gh` for: rebuild clears it, rebuild does not clear it (today's real situation), everything clean, and refresh never ran.

Two bugs found by that testing rather than in review: an empty step outcome (a renamed or misspelled step id) was passing green, which would silently retire a gate; and the report claimed `:latest` had been refreshed in cases where the refresh never ran.

🤖 Generated with [Claude Code](https://claude.com/claude-code)