### PR TITLE
perf(pre-push): scope the Go coverage run to the packages you changed

### DIFF
--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -223,11 +223,51 @@ else
 	# Go: any non-test .go under internal/ (cmd/ and tools/ are excluded from coverage).
 	if has_measurable_change '^internal/.*\.go$' '_test\.go$'; then
 		if (exec 3<>/dev/tcp/localhost/5433) 2>/dev/null; then
-			echo "pre-push: coverage - go test ./internal/... (Postgres :5433 up)"
+			# Only the packages whose files changed, not ./internal/... . `go test
+			# -coverprofile` attributes coverage solely to the package under test
+			# unless -coverpkg widens it, which we do not use: a profile built from
+			# one package contains that package's statements and nothing else. So
+			# for a gate that measures CHANGED LINES, a dependent package's tests
+			# contribute exactly nothing to the number, and running them is pure
+			# cost. Verified by measuring internal/{proxy,quota,failover,model}
+			# inside the full tree and in isolation: 94.9/99.3/95.6/95.5% either
+			# way, identical.
+			#
+			# This matters because internal/api costs ~190s of the ~196s a full run
+			# takes, and it sits downstream of 24 of the 33 internal packages.
+			# Go's test cache already spares you when nothing it compiles against
+			# actually changed (adding an unused function is stripped by the
+			# linker, leaving the test binary byte-identical and the cached result
+			# valid), but any REAL change to one of those 24 re-runs it in full.
+			# Editing an error string in internal/db is enough. Now you pay for
+			# internal/api only when you change internal/api. Falls back to the
+			# whole tree when there is no diff to scope by, the same conservative
+			# default touched() uses.
+			GO_PKGS=""
+			if [ -n "$SYNC_BASE" ]; then
+				# The diff lists deleted paths too, and a package whose last file
+				# was removed no longer exists on disk. `go test ./internal/gone`
+				# is a hard error, so an unrelated deletion would block the push
+				# for a reason that has nothing to do with coverage. Keep only
+				# directories that are still there.
+				while read -r _dir; do
+					[ -n "$_dir" ] || continue
+					[ -d "$REPO_ROOT/$_dir" ] || continue
+					GO_PKGS="$GO_PKGS ./$_dir"
+				done < <(printf '%s\n' "$CHANGED_FILES" |
+					grep -E '^internal/.*\.go$' |
+					grep -vE '_test\.go$' |
+					xargs -d '\n' -r -n1 dirname |
+					sort -u)
+				GO_PKGS="${GO_PKGS# }"
+			fi
+			[ -n "$GO_PKGS" ] || GO_PKGS="./internal/..."
+			echo "pre-push: coverage - go test ${GO_PKGS} (Postgres :5433 up)"
 			# -timeout is per package: internal/api alone runs for minutes against
 			# a real Postgres, and at 5m it started tripping the clock in CI with
 			# nothing actually hung. Same headroom as .github/workflows/ci.yml.
-			if go test -timeout 10m -coverprofile="$COV_DIR/go.out" -covermode=atomic ./internal/...; then
+			# shellcheck disable=SC2086 # deliberate split: one argument per package
+			if go test -timeout 10m -coverprofile="$COV_DIR/go.out" -covermode=atomic $GO_PKGS; then
 				DC_ARGS+=(--go "$COV_DIR/go.out")
 			else
 				echo "pre-push: FAILED - go test (coverage run)" >&2

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -110,7 +110,11 @@ has_measurable_change() {
 	[ -z "$files" ] && return 1
 	[ -z "$SYNC_BASE" ] && return 0
 	local diff
-	diff="$(printf '%s\n' "$files" | xargs -d '\n' -r git diff -U0 "$SYNC_BASE...HEAD" -- 2>/dev/null)" || return 0
+	# NUL-delimited rather than `xargs -d '\n'`: -d is a GNU extension BSD xargs
+	# rejects, so on macOS this errored, hit the `|| return 0` below and ran the
+	# suite unconditionally. -r is not needed (files is non-empty by the guard
+	# above) and is itself GNU-only.
+	diff="$(printf '%s\n' "$files" | tr '\n' '\0' | xargs -0 git diff -U0 "$SYNC_BASE...HEAD" -- 2>/dev/null)" || return 0
 	printf '%s\n' "$diff" |
 		grep -E '^[+-]' |
 		grep -vE '^(\+\+\+|---)' |
@@ -254,10 +258,15 @@ else
 					[ -n "$_dir" ] || continue
 					[ -d "$REPO_ROOT/$_dir" ] || continue
 					GO_PKGS="$GO_PKGS ./$_dir"
+				# sed rather than `xargs -n1 dirname`: -d is a GNU extension that
+				# BSD xargs rejects outright, so on macOS this would print an
+				# option error, leave GO_PKGS empty and quietly fall back to the
+				# full suite -- the exact cost this block exists to avoid. Every
+				# path here matched ^internal/.*\.go$ so it always has a slash.
 				done < <(printf '%s\n' "$CHANGED_FILES" |
 					grep -E '^internal/.*\.go$' |
 					grep -vE '_test\.go$' |
-					xargs -d '\n' -r -n1 dirname |
+					sed 's#/[^/]*$##' |
 					sort -u)
 				GO_PKGS="${GO_PKGS# }"
 			fi


### PR DESCRIPTION
## The number

Same commit, same gate, same verdict, measured end to end by feeding the hook the ref line git feeds it:

| | time | what it ran |
|---|---|---|
| before | **198s** | `go test ./internal/...` |
| after | **35s** | `go test ./internal/db ./internal/quota` |

The test change was deliberately realistic: an error string edited inside a function that is actually called in `internal/db`, plus a leaf change in `internal/quota`. Almost the entire 198s was `internal/api`, a package the change never went near.

## Why the whole tree was never needed

`go test -coverprofile` credits coverage **only to the package under test** unless `-coverpkg` widens it, and this repo does not use it. A profile built from one package contains that package's statements and nothing else. Since the gate measures *changed lines*, a dependent package's tests contribute exactly nothing to the number `diff_coverage.py` computes.

Verified rather than assumed, by measuring the same packages both inside the full tree and alone:

| package | in `./internal/...` | alone |
|---|---|---|
| `internal/proxy` | 94.9% | 94.9% |
| `internal/quota` | 99.3% | 99.3% |
| `internal/failover` | 95.6% | 95.6% |
| `internal/model` | 95.5% | 95.5% |

Identical. This is a strictly cheaper way to compute the same answer, not a softer gate. During testing it still failed correctly on an uncovered changed line, with the same message as before.

## A false start worth recording

This looked unnecessary at first. Probing by adding an unused function to a package showed dependents staying cached, suggesting Go's cache already handled it. That probe was broken: an unused function is stripped by the linker, so the test binary comes out byte-identical and the cached result is legitimately still valid. It was measuring dead code being deleted.

A real change behaves differently. `internal/api` sits downstream of 24 of the 33 `internal/` packages, and editing an error string in `internal/db` is enough to re-run all ~190s of it. The cache helps, but not for the changes you actually make.

## Edge case closed

The diff lists deleted paths too, and a package whose last file was removed no longer exists on disk. `go test ./internal/gone` is a hard error, so an unrelated deletion would have blocked the push for a reason with nothing to do with coverage. Only directories still present are passed.

Falls back to the whole tree when there is no merge-base to scope by, matching the existing conservative default in `touched()`. CI is unchanged and still enforces coverage against the real ref.

🤖 Generated with [Claude Code](https://claude.com/claude-code)