### PR TITLE
perf(pre-push): run only the affected frontend tests, with a safety net

### DIFF
--- a/scripts/coverage/assert_instrumented.py
+++ b/scripts/coverage/assert_instrumented.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Fail when a changed source file is missing from an lcov report.
+
+Guards the pre-push hook's scoped vitest run. Running only the tests vitest
+believes are affected by a change is roughly 4x faster (281s -> 68s on this
+repo), but vitest's affected-test detection is not reliable: changing
+web/src/components/CapBadge.tsx did not run ModelTable.test.tsx, even though
+ModelTable.test.tsx imports ModelTable, which imports CapBadge.
+
+On its own that would only make the gate stricter. The danger is the
+interaction with diff_coverage.py, which skips any changed file it has no
+coverage data for (`path not in cov: continue`). A changed file whose tests
+vitest missed is never loaded, so it never appears in the report, so it is
+skipped, so the gate reports PASS on a completely untested change.
+
+This script closes that hole: if any changed, non-excluded source file is
+absent from the report, the caller must rerun the full suite rather than trust
+the scoped one. Exclusions come from covlib so they cannot drift from what
+diff_coverage.py itself ignores.
+"""
+import argparse
+import sys
+
+import covlib
+
+
+def missing_files(lcov_text: str, root: str, changed: list) -> list:
+    """Changed files that diff_coverage would silently skip."""
+    cov = covlib.parse_lcov(lcov_text, root)
+    # is_excluded mirrors diff_coverage's own filter: a file it would ignore
+    # anyway is not evidence that the scoped run was incomplete.
+    return [f for f in changed if not covlib.is_excluded(f) and f not in cov]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--lcov", required=True, help="path to lcov.info")
+    ap.add_argument("--root", required=True, help="repo-relative prefix, e.g. web/")
+    ap.add_argument("files", nargs="*", help="changed files, repo-relative")
+    args = ap.parse_args()
+
+    if not args.files:
+        return 0
+
+    try:
+        with open(args.lcov, encoding="utf-8") as fh:
+            text = fh.read()
+    except OSError as exc:
+        # No report at all means nothing can be verified. Treat as incomplete
+        # so the caller falls back rather than trusting an absent file.
+        print(f"assert_instrumented: cannot read {args.lcov}: {exc}", file=sys.stderr)
+        return 1
+
+    missing = missing_files(text, args.root, args.files)
+    if missing:
+        print("assert_instrumented: no coverage recorded for:", file=sys.stderr)
+        for path in missing:
+            print(f"  {path}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -140,8 +140,18 @@ has_measurable_change() {
 run_vitest_coverage() {
 	local app=$1 include=$2
 	local dir="$REPO_ROOT/$app" lcov="$REPO_ROOT/$app/coverage/lcov.info"
-	local changed_files
-	changed_files="$(printf '%s\n' "$CHANGED_FILES" | grep -E "$include" || true)"
+	local changed_files=""
+	# Keep only files that still exist. The diff lists deleted paths too, and a
+	# deleted file can never appear in an lcov report, so passing it to the guard
+	# would report "unmeasured" every time and rerun the full suite for nothing.
+	# diff_coverage has nothing to measure in it either: its lines are gone from
+	# HEAD, so they are never part of the changed-line set being gated.
+	while read -r _file; do
+		[ -n "$_file" ] || continue
+		[ -f "$REPO_ROOT/$_file" ] || continue
+		changed_files="$changed_files$_file
+"
+	done < <(printf '%s\n' "$CHANGED_FILES" | grep -E "$include" || true)
 
 	if [ -n "$SYNC_BASE" ] && [ -n "$changed_files" ]; then
 		echo "pre-push: coverage - $app vitest (tests affected by this branch)"

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -122,6 +122,53 @@ has_measurable_change() {
 		grep -qvE '^$|^//'
 }
 
+# run_vitest_coverage <app-subdir> <source-file-regex> - build lcov for one
+# frontend, preferring the tests vitest believes the change affects.
+#
+# The scoped run is ~4x faster (281s -> 68s for web/ on this repo, 936 of 5481
+# tests). It is NOT trusted on its own, because vitest's affected-test detection
+# misses real dependents: changing web/src/components/CapBadge.tsx did not run
+# ModelTable.test.tsx, despite ModelTable.test.tsx importing ModelTable, which
+# imports CapBadge.
+#
+# That matters because diff_coverage.py SKIPS any changed file it has no
+# coverage for, and reports PASS when that leaves nothing to measure. A file
+# whose tests vitest missed is never loaded, so it never appears in the report,
+# so the gate would wave through a completely untested change. assert_instrumented.py
+# therefore checks every changed file actually got measured, and we rerun the
+# full suite when it did not. Worst case costs both runs; the gate stays honest.
+run_vitest_coverage() {
+	local app=$1 include=$2
+	local dir="$REPO_ROOT/$app" lcov="$REPO_ROOT/$app/coverage/lcov.info"
+	local changed_files
+	changed_files="$(printf '%s\n' "$CHANGED_FILES" | grep -E "$include" || true)"
+
+	if [ -n "$SYNC_BASE" ] && [ -n "$changed_files" ]; then
+		echo "pre-push: coverage - $app vitest (tests affected by this branch)"
+		# --passWithNoTests: "nothing affected" is a legitimate outcome, not a
+		# failure. The guard below still decides whether that result is usable.
+		if ! (cd "$dir" && env -u NODE_ENV pnpm exec vitest run --changed "$SYNC_BASE" --passWithNoTests --coverage --coverage.reporter=lcov); then
+			echo "pre-push: FAILED - $app vitest (affected tests)" >&2
+			return 1
+		fi
+		# Unquoted on purpose: one argument per changed file. A path containing
+		# whitespace splits into names that match nothing, which reads as
+		# unmeasured and falls back to the full suite - the safe direction.
+		# shellcheck disable=SC2086
+		if python3 "$REPO_ROOT/scripts/coverage/assert_instrumented.py" --lcov "$lcov" --root "$app/" $changed_files; then
+			return 0
+		fi
+		echo "pre-push: affected-test run left changed files unmeasured; rerunning the full $app suite" >&2
+	fi
+
+	echo "pre-push: coverage - $app vitest (full suite)"
+	if ! (cd "$dir" && env -u NODE_ENV pnpm exec vitest run --coverage --coverage.reporter=lcov); then
+		echo "pre-push: FAILED - $app vitest (coverage run)" >&2
+		return 1
+	fi
+	return 0
+}
+
 if [ -n "$SYNC_BASE" ]; then
 	if printf '%s\n' "$CHANGED" | grep -qx "README.md" &&
 		! printf '%s\n' "$CHANGED" | grep -qx "DOCKERHUB.md"; then
@@ -289,22 +336,18 @@ else
 
 	# web dashboard frontend.
 	if has_measurable_change '^web/src/.*\.tsx?$' '\.test\.tsx?$|/__tests__/|^web/src/test/'; then
-		echo "pre-push: coverage - web vitest"
-		if (cd "$REPO_ROOT/web" && env -u NODE_ENV pnpm exec vitest run --coverage --coverage.reporter=lcov); then
+		if run_vitest_coverage web '^web/src/.*\.tsx?$'; then
 			DC_ARGS+=(--lcov "web/=$REPO_ROOT/web/coverage/lcov.info")
 		else
-			echo "pre-push: FAILED - web vitest (coverage run)" >&2
 			exit 1
 		fi
 	fi
 
 	# Front Desk frontend.
 	if has_measurable_change '^frontdesk/web/src/.*\.tsx?$' '\.test\.tsx?$|/__tests__/|^frontdesk/web/src/test/'; then
-		echo "pre-push: coverage - frontdesk/web vitest"
-		if (cd "$REPO_ROOT/frontdesk/web" && env -u NODE_ENV pnpm exec vitest run --coverage --coverage.reporter=lcov); then
+		if run_vitest_coverage frontdesk/web '^frontdesk/web/src/.*\.tsx?$'; then
 			DC_ARGS+=(--lcov "frontdesk/web/=$REPO_ROOT/frontdesk/web/coverage/lcov.info")
 		else
-			echo "pre-push: FAILED - frontdesk/web vitest (coverage run)" >&2
 			exit 1
 		fi
 	fi


### PR DESCRIPTION
Follow-up to #580, which handled the Go half. This is the other half.

## The numbers

| scenario | time |
|---|---|
| full web suite (baseline) | **281s** (5481 tests) |
| leaf component changed | **97s** |
| component with no test of its own, 5 importers | **66s** (936 tests) |
| fallback engaged | 393s |

## Why this needed a guard, unlike the Go version

#580 was safe by construction: Go credits coverage to the package under test, so scoping provably cannot change the number. Vitest offers no such guarantee, and I caught it being wrong.

Changing `web/src/components/CapBadge.tsx` did **not** run `ModelTable.test.tsx`, despite a real static chain: `ModelTable.test.tsx:7` imports `ModelTable`, which imports `CapBadge` at line 11.

On its own that only makes the gate stricter. The danger is the interaction with `scripts/coverage/diff_coverage.py:22`:

```python
if covlib.is_excluded(path) or path not in cov:
    continue
```

A changed file **absent** from coverage is silently skipped, and when that empties the set the gate prints `no coverable changed lines - PASS`. So a file whose tests vitest missed is never loaded, never appears in the report, gets skipped, and the gate waves through a completely untested change while showing green.

## The safety net

`scripts/coverage/assert_instrumented.py` asserts every changed, non-excluded source file actually got measured. It reuses `covlib.is_excluded`, so its notion of "ignorable" cannot drift from what `diff_coverage.py` itself skips. If anything is missing, the hook says so and reruns the full suite:

```
pre-push: coverage - web vitest (tests affected by this branch)
pre-push: affected-test run left changed files unmeasured; rerunning the full web suite
pre-push: coverage - web vitest (full suite)
   100.0%     1/1     web/src/components/Badge.tsx
```

Worst case pays both runs. The gate never reports on coverage it does not have.

Both frontends now share one implementation instead of two near-identical blocks.

## Verification

End to end, driving the hook with the ref line git actually feeds it:

- leaf component: 97s, no fallback
- `Badge.tsx`, no test of its own but five importers: 66s, its changed line measured 1/1 = 100%, no fallback
- fallback forced: announced the rerun, completed the full suite, gate still evaluated correctly

Guard checked against real lcov files for: the report that measured the file (pass), the `ModelTable` miss (fail, correctly), excluded paths `main.tsx` / tests / `.d.ts` / `src/test/` (pass, no needless fallback), an unreadable report (fail closed), and an empty file list (pass).

## Honest note on frequency

My one counterexample made vitest look worse than it is. In the `Badge.tsx` case it correctly found the indirect tests for a component with no test of its own. So the fallback should be rare and most pushes should get the speedup; the guard exists for a failure mode I demonstrated rather than one I merely feared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)