### PR TITLE
feat(frontdesk,bellhop): center + fully collapse the quota strip, add widget badge alignment

### DIFF
--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/MainActivity.kt
@@ -44,6 +44,7 @@ import com.hugalafutro.bellhop.data.LockStore
 import com.hugalafutro.bellhop.data.LockTimeout
 import com.hugalafutro.bellhop.data.MonitorStore
 import com.hugalafutro.bellhop.data.PrefsStore
+import com.hugalafutro.bellhop.data.QuotaBadgeAlign
 import com.hugalafutro.bellhop.data.QuotaBadgeConfigStore
 import com.hugalafutro.bellhop.data.QuotaBarMode
 import com.hugalafutro.bellhop.data.TimeFormat
@@ -263,6 +264,9 @@ fun BellhopApp(
     val holdToCopy by prefsStore.holdToCopy.collectAsStateWithLifecycle(initialValue = true)
     val widgetGraphs by prefsStore.widgetGraphs.collectAsStateWithLifecycle(initialValue = false)
     val widgetQuota by prefsStore.widgetQuota.collectAsStateWithLifecycle(initialValue = true)
+    val widgetQuotaAlign by prefsStore.widgetQuotaAlign.collectAsStateWithLifecycle(
+        initialValue = QuotaBadgeAlign.LEFT,
+    )
     val quotaBarMode by prefsStore.quotaBarMode.collectAsStateWithLifecycle(initialValue = QuotaBarMode.REMAINING)
     val timeFormat by prefsStore.timeFormat.collectAsStateWithLifecycle(initialValue = TimeFormat.SYSTEM)
     val graphRangeMinutes by
@@ -617,6 +621,22 @@ fun BellhopApp(
                                 FleetPollWorker.runWidgetRefresh(context, supersedeInFlight = true)
                             }
                         },
+                        widgetQuotaAlign = widgetQuotaAlign,
+                        onSetWidgetQuotaAlign = {
+                            scope.launch {
+                                prefsStore.setWidgetQuotaAlign(it)
+                                // Deliberately BellhopWidget.update, not
+                                // FleetPollWorker.runWidgetRefresh like the two
+                                // toggles above: alignment changes nothing about
+                                // what gets fetched, only where the same badges
+                                // sit, so a network round trip would be waste.
+                                // The update call is still needed -- provideGlance
+                                // collects this flow, but only for a Glance session
+                                // that happens to be alive, and a widget on a home
+                                // screen nobody is looking at has none.
+                                BellhopWidget.update(context)
+                            }
+                        },
                         onUnlink = { runUnlink(state.fdUrl) },
                         onForceUnlink = { forceUnlink() },
                         requireOperatorAuth = { action -> requireOperatorAuth(action) },
@@ -674,6 +694,8 @@ private fun LinkedContent(
     onToggleWidgetGraphs: (Boolean) -> Unit,
     widgetQuota: Boolean,
     onToggleWidgetQuota: (Boolean) -> Unit,
+    widgetQuotaAlign: QuotaBadgeAlign,
+    onSetWidgetQuotaAlign: (QuotaBadgeAlign) -> Unit,
     onUnlink: () -> Unit,
     onForceUnlink: () -> Unit,
     requireOperatorAuth: (() -> Unit) -> Unit,
@@ -876,6 +898,8 @@ private fun LinkedContent(
                 onToggleWidgetGraphs = onToggleWidgetGraphs,
                 widgetQuota = widgetQuota,
                 onToggleWidgetQuota = onToggleWidgetQuota,
+                widgetQuotaAlign = widgetQuotaAlign,
+                onSetWidgetQuotaAlign = onSetWidgetQuotaAlign,
                 timeFormat = timeFormat,
                 onSetTimeFormat = onSetTimeFormat,
                 alertCounts = alertCounts,

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/PrefsStore.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/PrefsStore.kt
@@ -79,6 +79,24 @@ class PrefsStore(
     }
 
     /**
+     * widgetQuotaAlign emits where the widget's quota badge rows sit across its
+     * width; defaults to [QuotaBadgeAlign.LEFT], which is what the widget did
+     * before this preference existed. Purely a rendering choice: unlike
+     * [widgetQuota] it changes nothing about what the background poll reads.
+     * A stored value this build doesn't recognize falls back to the default
+     * rather than throwing, same stance as [quotaBarMode].
+     */
+    val widgetQuotaAlign: Flow<QuotaBadgeAlign> =
+        dataStore.data.map {
+            val stored = it[WIDGET_QUOTA_ALIGN] ?: return@map QuotaBadgeAlign.LEFT
+            runCatching { QuotaBadgeAlign.valueOf(stored) }.getOrDefault(QuotaBadgeAlign.LEFT)
+        }
+
+    suspend fun setWidgetQuotaAlign(align: QuotaBadgeAlign) {
+        dataStore.edit { it[WIDGET_QUOTA_ALIGN] = align.name }
+    }
+
+    /**
      * quotaBarMode emits which polarity ([QuotaBarMode.REMAINING] or
      * [QuotaBarMode.USED]) quota badges show for METERED types; defaults to
      * REMAINING, matching the web dashboard's default. A stored value this
@@ -120,6 +138,7 @@ class PrefsStore(
         private val WIDGET_GRAPHS = booleanPreferencesKey("widget_graphs")
         private val WIDGET_QUOTA = booleanPreferencesKey("widget_quota")
         private val QUOTA_BAR_MODE = stringPreferencesKey("quota_bar_mode")
+        private val WIDGET_QUOTA_ALIGN = stringPreferencesKey("widget_quota_align")
         private val TIME_FORMAT = stringPreferencesKey("time_format")
 
         /** Default traffic-graph lookback: the last hour. */

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/QuotaModels.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/QuotaModels.kt
@@ -429,6 +429,12 @@ private fun decodeQuotaPayload(
 enum class QuotaBarMode { REMAINING, USED }
 
 /**
+ * QuotaBadgeAlign is where the home-screen widget's badge rows sit across the
+ * widget's width. Widget-only: the phone dashboard strip has no such choice.
+ */
+enum class QuotaBadgeAlign { LEFT, CENTER, RIGHT }
+
+/**
  * quotaBadgeLabel formats [pq] into the short text a badge shows, in the
  * polarity [mode] selects for METERED types. Unavailable or payload-less
  * quotas (see [ProviderQuota.available]) render as "-", mirroring the web

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/FleetUi.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/FleetUi.kt
@@ -15,6 +15,8 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -131,7 +133,15 @@ internal fun FilterPill(
         contentColor = content.copy(alpha = stateAlpha),
         shape = MaterialTheme.shapes.small,
         border = if (selected) null else BorderStroke(1.dp, borderColor.copy(alpha = stateAlpha)),
-        modifier = modifier.testTag(tag),
+        // Selection has to reach the semantics tree, not just the palette above.
+        // Surface's own clickable publishes "is a button, is enabled" and nothing
+        // about which button is the active one, so before this a screen-reader
+        // user heard five identical buttons in every picker built on this pill
+        // (clock, graph range, severity, surface tabs, badge alignment) with no
+        // way to tell which was in effect -- the state was carried entirely by
+        // fill colour. It also makes assertIsSelected() meaningful in tests,
+        // which previously had nothing to read.
+        modifier = modifier.testTag(tag).semantics { this.selected = selected },
     ) {
         Text(
             text = text,

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreen.kt
@@ -410,6 +410,7 @@ fun SettingsScreen(
                             tag = "settings-widget-align-${option.name}",
                             modifier = Modifier.weight(1f),
                             borderColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                            enabled = widgetQuota,
                         )
                     }
                 }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreen.kt
@@ -54,6 +54,7 @@ import com.hugalafutro.bellhop.data.LinkState
 import com.hugalafutro.bellhop.data.LockConfig
 import com.hugalafutro.bellhop.data.LockTimeout
 import com.hugalafutro.bellhop.data.PrefsStore
+import com.hugalafutro.bellhop.data.QuotaBadgeAlign
 import com.hugalafutro.bellhop.data.TimeFormat
 import com.hugalafutro.bellhop.ui.alerts.ALERT_SEVERITIES
 import com.hugalafutro.bellhop.ui.common.BellhopSwitch
@@ -113,6 +114,10 @@ fun SettingsScreen(
     // strip before there was a switch for it.
     widgetQuota: Boolean = true,
     onToggleWidgetQuota: (Boolean) -> Unit = {},
+    // Defaults to LEFT like the preference itself: that is what the widget did
+    // before the picker existed.
+    widgetQuotaAlign: QuotaBadgeAlign = QuotaBadgeAlign.LEFT,
+    onSetWidgetQuotaAlign: (QuotaBadgeAlign) -> Unit = {},
     timeFormat: TimeFormat = TimeFormat.SYSTEM,
     onSetTimeFormat: (TimeFormat) -> Unit = {},
     // Enabled-alert counts per severity (error/warning/info/success), sourced from
@@ -381,6 +386,33 @@ fun SettingsScreen(
                     onCheckedChange = onToggleWidgetQuota,
                     tag = "settings-widget-quota-toggle",
                 )
+                // Not a WidgetToggleRow: alignment is a three-way choice, and
+                // unlike the two switches above it changes nothing about what the
+                // background poll reads -- only where the same badges sit.
+                Text(
+                    text = stringResource(R.string.settings_widget_align_title),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                Text(
+                    text = stringResource(R.string.settings_widget_align_subtitle),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    QuotaBadgeAlign.entries.forEach { option ->
+                        FilterPill(
+                            text = stringResource(alignLabel(option)),
+                            selected = option == widgetQuotaAlign,
+                            onClick = { onSetWidgetQuotaAlign(option) },
+                            tag = "settings-widget-align-${option.name}",
+                            modifier = Modifier.weight(1f),
+                            borderColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
             }
 
             // Clock: which face every wall-clock time in the app is drawn on.
@@ -793,6 +825,14 @@ private fun timeFormatLabel(format: TimeFormat): Int =
         TimeFormat.SYSTEM -> R.string.settings_time_format_system
         TimeFormat.H24 -> R.string.settings_time_format_24h
         TimeFormat.H12 -> R.string.settings_time_format_12h
+    }
+
+/** alignLabel maps a widget badge alignment to its picker label. */
+private fun alignLabel(align: QuotaBadgeAlign): Int =
+    when (align) {
+        QuotaBadgeAlign.LEFT -> R.string.settings_widget_align_left
+        QuotaBadgeAlign.CENTER -> R.string.settings_widget_align_center
+        QuotaBadgeAlign.RIGHT -> R.string.settings_widget_align_right
     }
 
 /**

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/widget/BellhopWidget.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/widget/BellhopWidget.kt
@@ -279,6 +279,10 @@ private fun quotaBadgeColor(type: QuotaType) = quotaBrand(type).let { ColorProvi
  * rows are laid out with. A function rather than an inline `when` so the mapping
  * is testable: the widget's render is only covered on-device, and a transposed
  * arm here would quietly send RIGHT to the left edge.
+ *
+ * LEFT/RIGHT are absolute labels mapped to Start/End, which Glance resolves
+ * against layout direction -- that only lines up while every shipped locale is
+ * LTR. Adding an RTL locale means revisiting either this mapping or the copy.
  */
 internal fun quotaRowAlignment(align: QuotaBadgeAlign): Alignment.Horizontal =
     when (align) {

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/widget/BellhopWidget.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/widget/BellhopWidget.kt
@@ -53,6 +53,7 @@ import com.hugalafutro.bellhop.data.LinkStore
 import com.hugalafutro.bellhop.data.MemberHealthState
 import com.hugalafutro.bellhop.data.MonitorStore
 import com.hugalafutro.bellhop.data.PrefsStore
+import com.hugalafutro.bellhop.data.QuotaBadgeAlign
 import com.hugalafutro.bellhop.data.QuotaType
 import com.hugalafutro.bellhop.data.TRAFFIC_BUCKETS
 import com.hugalafutro.bellhop.data.TimeFormat
@@ -143,14 +144,16 @@ class BellhopWidget : GlanceAppWidget() {
         val initialActive = monitorStore.active.first()
         val initialGraphs = prefsStore.widgetGraphs.first()
         val initialQuota = prefsStore.widgetQuota.first()
+        val initialQuotaAlign = prefsStore.widgetQuotaAlign.first()
         val initialTimeFormat = prefsStore.timeFormat.first()
         provideContent {
             val state by widgetStore.state.collectAsState(initial = initialState)
             val monitoringActive by monitorStore.active.collectAsState(initial = initialActive)
             val graphs by prefsStore.widgetGraphs.collectAsState(initial = initialGraphs)
             val quotaStrip by prefsStore.widgetQuota.collectAsState(initial = initialQuota)
+            val quotaAlign by prefsStore.widgetQuotaAlign.collectAsState(initial = initialQuotaAlign)
             val timeFormat by prefsStore.timeFormat.collectAsState(initial = initialTimeFormat)
-            WidgetContent(state, monitoringActive, fdName, graphs, quotaStrip, timeFormat)
+            WidgetContent(state, monitoringActive, fdName, graphs, quotaStrip, quotaAlign, timeFormat)
         }
     }
 
@@ -270,6 +273,19 @@ private val DotUnknown = ColorProvider(day = PaperInkMuted, night = Ink300)
 // rather than the app palette; quotaBrand is the shared source (ui/theme),
 // so the widget pill and the dashboard chip can never drift apart.
 private fun quotaBadgeColor(type: QuotaType) = quotaBrand(type).let { ColorProvider(day = it.day, night = it.night) }
+
+/**
+ * quotaRowAlignment maps the stored preference to the Glance alignment the badge
+ * rows are laid out with. A function rather than an inline `when` so the mapping
+ * is testable: the widget's render is only covered on-device, and a transposed
+ * arm here would quietly send RIGHT to the left edge.
+ */
+internal fun quotaRowAlignment(align: QuotaBadgeAlign): Alignment.Horizontal =
+    when (align) {
+        QuotaBadgeAlign.LEFT -> Alignment.Start
+        QuotaBadgeAlign.CENTER -> Alignment.CenterHorizontally
+        QuotaBadgeAlign.RIGHT -> Alignment.End
+    }
 
 private fun dotColor(state: MemberHealthState) =
     when (state) {
@@ -410,6 +426,7 @@ private fun WidgetContent(
     fdName: String,
     graphs: Boolean,
     quotaStrip: Boolean,
+    quotaAlign: QuotaBadgeAlign,
     timeFormat: TimeFormat,
 ) {
     val context = LocalContext.current
@@ -577,6 +594,11 @@ private fun WidgetContent(
                 val overflow = quotaBadgeOverflow(state.quota, rows)
                 rows.forEachIndexed { index, row ->
                     Row(
+                        // Where the strip sits across the widget. This can only
+                        // do anything because the badges below take no weight --
+                        // each pill is its own label's width, so the row has real
+                        // slack to distribute.
+                        horizontalAlignment = quotaRowAlignment(quotaAlign),
                         verticalAlignment = Alignment.CenterVertically,
                         modifier = GlanceModifier.fillMaxWidth().padding(bottom = 1.dp),
                     ) {

--- a/android/app/src/main/res/values-cs/strings.xml
+++ b/android/app/src/main/res/values-cs/strings.xml
@@ -286,6 +286,11 @@
     <string name="settings_widget_graphs_subtitle">Překryjí každého člena požadavky za poslední hodinu. Čerstvé sloupce stojí jeden požadavek na člena navíc při každé kontrole na pozadí.</string>
     <string name="settings_widget_quota_title">Odznaky kvót</string>
     <string name="settings_widget_quota_subtitle">Zobrazovat na widgetu pás kvót poskytovatelů. Vypnutí zároveň odebere čtení kvót z každé kontroly na pozadí.</string>
+    <string name="settings_widget_align_title">Zarovnání odznaků</string>
+    <string name="settings_widget_align_subtitle">Kde odznaky kvót sedí napříč šířkou widgetu.</string>
+    <string name="settings_widget_align_left">Vlevo</string>
+    <string name="settings_widget_align_center">Na střed</string>
+    <string name="settings_widget_align_right">Vpravo</string>
 
     <string name="settings_quota_badges_title">Odznaky kvót</string>
     <string name="settings_quota_badges_subtitle">Vyberte, které odznaky kvót poskytovatelů se zobrazí na dashboardu a ve widgetu, přeuspořádejte je a zvolte využité nebo zbývající.</string>

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -274,6 +274,11 @@
     <string name="settings_widget_graphs_subtitle">Zeigen je Mitglied die Anfragen der letzten Stunde. Frische Balken kosten pro Hintergrundprüfung eine zusätzliche Anfrage je Mitglied.</string>
     <string name="settings_widget_quota_title">Kontingent-Badges</string>
     <string name="settings_widget_quota_subtitle">Die Kontingent-Leiste der Anbieter im Widget anzeigen. Aus spart außerdem die Kontingentabfrage bei jeder Hintergrundprüfung.</string>
+    <string name="settings_widget_align_title">Badge-Ausrichtung</string>
+    <string name="settings_widget_align_subtitle">Wo die Kontingent-Badges über die Breite des Widgets sitzen.</string>
+    <string name="settings_widget_align_left">Links</string>
+    <string name="settings_widget_align_center">Mittig</string>
+    <string name="settings_widget_align_right">Rechts</string>
 
     <string name="settings_quota_badges_title">Kontingent-Badges</string>
     <string name="settings_quota_badges_subtitle">Wähle aus, welche Kontingent-Badges der Anbieter im Dashboard und im Widget angezeigt werden, ordne sie neu an und wähle verbraucht oder verbleibend.</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -274,6 +274,11 @@
     <string name="settings_widget_graphs_subtitle">Muestran sobre cada miembro sus solicitudes de la última hora. Mantenerlas al día cuesta una solicitud extra por miembro en cada comprobación en segundo plano.</string>
     <string name="settings_widget_quota_title">Insignias de cuota</string>
     <string name="settings_widget_quota_subtitle">Mostrar en el widget la tira de cuotas de los proveedores. Al desactivarla también se omite la lectura de cuotas en cada comprobación en segundo plano.</string>
+    <string name="settings_widget_align_title">Alineación de las insignias</string>
+    <string name="settings_widget_align_subtitle">Dónde se sitúan las insignias de cuota a lo ancho del widget.</string>
+    <string name="settings_widget_align_left">Izquierda</string>
+    <string name="settings_widget_align_center">Centro</string>
+    <string name="settings_widget_align_right">Derecha</string>
 
     <string name="settings_quota_badges_title">Insignias de cuota</string>
     <string name="settings_quota_badges_subtitle">Elige qué insignias de cuota de proveedor se muestran en el dashboard y en el widget, reordénalas y elige usado o restante.</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -274,6 +274,11 @@
     <string name="settings_widget_graphs_subtitle">Superposent à chaque membre ses requêtes de la dernière heure. Leur fraîcheur coûte une requête de plus par membre à chaque vérification en arrière-plan.</string>
     <string name="settings_widget_quota_title">Badges de quota</string>
     <string name="settings_widget_quota_subtitle">Afficher la bande de quotas des fournisseurs sur le widget. Désactivé, la lecture des quotas disparaît aussi de chaque vérification en arrière-plan.</string>
+    <string name="settings_widget_align_title">Alignement des badges</string>
+    <string name="settings_widget_align_subtitle">Où les badges de quota se placent sur la largeur du widget.</string>
+    <string name="settings_widget_align_left">Gauche</string>
+    <string name="settings_widget_align_center">Centre</string>
+    <string name="settings_widget_align_right">Droite</string>
 
     <string name="settings_quota_badges_title">Badges de quota</string>
     <string name="settings_quota_badges_subtitle">Choisissez les badges de quota des fournisseurs affichés sur le tableau de bord et le widget, réorganisez-les, et choisissez utilisé ou restant.</string>

--- a/android/app/src/main/res/values-ja/strings.xml
+++ b/android/app/src/main/res/values-ja/strings.xml
@@ -268,6 +268,11 @@
     <string name="settings_widget_graphs_subtitle">各メンバーに直近1時間のリクエストを重ねて表示します。バックグラウンド確認ごとにメンバーあたり1リクエスト増えます。</string>
     <string name="settings_widget_quota_title">クォータバッジ</string>
     <string name="settings_widget_quota_subtitle">ウィジェットにプロバイダーのクォータ帯を表示します。オフにすると、バックグラウンド確認ごとのクォータ取得もなくなります。</string>
+    <string name="settings_widget_align_title">バッジの配置</string>
+    <string name="settings_widget_align_subtitle">ウィジェットの幅に対してクォータバッジを置く位置です。</string>
+    <string name="settings_widget_align_left">左</string>
+    <string name="settings_widget_align_center">中央</string>
+    <string name="settings_widget_align_right">右</string>
 
     <string name="settings_quota_badges_title">クォータバッジ</string>
     <string name="settings_quota_badges_subtitle">ダッシュボードとウィジェットに表示するプロバイダーのクォータバッジを選び、並べ替えて、使用量か残量かを選択します。</string>

--- a/android/app/src/main/res/values-nl/strings.xml
+++ b/android/app/src/main/res/values-nl/strings.xml
@@ -274,6 +274,11 @@
     <string name="settings_widget_graphs_subtitle">Tonen per lid de verzoeken van het afgelopen uur. Verse balken kosten één extra verzoek per lid bij elke achtergrondcontrole.</string>
     <string name="settings_widget_quota_title">Quotabadges</string>
     <string name="settings_widget_quota_subtitle">Toon de quotastrook van de providers op de widget. Uit laat ook de quota-uitlezing bij elke achtergrondcontrole vervallen.</string>
+    <string name="settings_widget_align_title">Uitlijning van badges</string>
+    <string name="settings_widget_align_subtitle">Waar de quotabadges over de breedte van de widget staan.</string>
+    <string name="settings_widget_align_left">Links</string>
+    <string name="settings_widget_align_center">Midden</string>
+    <string name="settings_widget_align_right">Rechts</string>
 
     <string name="settings_quota_badges_title">Quotabadges</string>
     <string name="settings_quota_badges_subtitle">Kies welke quotabadges van providers worden getoond op het dashboard en de widget, herschik ze en kies gebruikt of resterend.</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -286,6 +286,11 @@
     <string name="settings_widget_graphs_subtitle">Nakładają na każdy węzeł żądania z ostatniej godziny. Świeże słupki kosztują jedno dodatkowe żądanie na węzeł przy każdym sprawdzeniu w tle.</string>
     <string name="settings_widget_quota_title">Odznaki limitów</string>
     <string name="settings_widget_quota_subtitle">Pokazuj na widżecie pasek limitów dostawców. Wyłączenie usuwa też odczyt limitów z każdego sprawdzenia w tle.</string>
+    <string name="settings_widget_align_title">Wyrównanie odznak</string>
+    <string name="settings_widget_align_subtitle">Gdzie odznaki limitów znajdują się na szerokości widżetu.</string>
+    <string name="settings_widget_align_left">Do lewej</string>
+    <string name="settings_widget_align_center">Do środka</string>
+    <string name="settings_widget_align_right">Do prawej</string>
 
     <string name="settings_quota_badges_title">Odznaki limitów</string>
     <string name="settings_quota_badges_subtitle">Wybierz, które odznaki limitów dostawców są widoczne na dashboardzie i w widżecie, zmień ich kolejność i wybierz wykorzystane lub pozostałe.</string>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -286,6 +286,11 @@
     <string name="settings_widget_graphs_subtitle">Показывают по каждому узлу запросы за последний час. Свежие столбцы стоят один дополнительный запрос на узел при каждой фоновой проверке.</string>
     <string name="settings_widget_quota_title">Значки квот</string>
     <string name="settings_widget_quota_subtitle">Показывать на виджете полосу квот провайдеров. Если выключено, запрос квот исчезает и из каждой фоновой проверки.</string>
+    <string name="settings_widget_align_title">Выравнивание значков</string>
+    <string name="settings_widget_align_subtitle">Где значки квот располагаются по ширине виджета.</string>
+    <string name="settings_widget_align_left">Слева</string>
+    <string name="settings_widget_align_center">По центру</string>
+    <string name="settings_widget_align_right">Справа</string>
 
     <string name="settings_quota_badges_title">Значки квот</string>
     <string name="settings_quota_badges_subtitle">Выберите, какие значки квот поставщиков показывать на дашборде и в виджете, измените их порядок и выберите использовано или осталось.</string>

--- a/android/app/src/main/res/values-sk/strings.xml
+++ b/android/app/src/main/res/values-sk/strings.xml
@@ -286,6 +286,11 @@
     <string name="settings_widget_graphs_subtitle">Prekryjú každého člena požiadavkami za poslednú hodinu. Čerstvé stĺpce stoja jednu požiadavku na člena navyše pri každej kontrole na pozadí.</string>
     <string name="settings_widget_quota_title">Odznaky kvót</string>
     <string name="settings_widget_quota_subtitle">Zobrazovať na widgete pás kvót poskytovateľov. Vypnutie zároveň odoberie čítanie kvót z každej kontroly na pozadí.</string>
+    <string name="settings_widget_align_title">Zarovnanie odznakov</string>
+    <string name="settings_widget_align_subtitle">Kde odznaky kvót sedia naprieč šírkou widgetu.</string>
+    <string name="settings_widget_align_left">Vľavo</string>
+    <string name="settings_widget_align_center">Na stred</string>
+    <string name="settings_widget_align_right">Vpravo</string>
 
     <string name="settings_quota_badges_title">Odznaky kvót</string>
     <string name="settings_quota_badges_subtitle">Vyberte, ktoré odznaky kvót poskytovateľov sa zobrazia na dashboarde a vo widgete, usporiadajte ich a zvoľte využité alebo zostávajúce.</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -268,6 +268,11 @@
     <string name="settings_widget_graphs_subtitle">在每个成员上叠加最近一小时的请求。保持更新会使每次后台检查对每个成员多发送一个请求。</string>
     <string name="settings_widget_quota_title">配额徽章</string>
     <string name="settings_widget_quota_subtitle">在小组件上显示各提供商的配额条。关闭后，每次后台检查也不再读取配额。</string>
+    <string name="settings_widget_align_title">徽章对齐</string>
+    <string name="settings_widget_align_subtitle">配额徽章在小组件宽度方向上的位置。</string>
+    <string name="settings_widget_align_left">左对齐</string>
+    <string name="settings_widget_align_center">居中</string>
+    <string name="settings_widget_align_right">右对齐</string>
 
     <string name="settings_quota_badges_title">配额徽章</string>
     <string name="settings_quota_badges_subtitle">选择在仪表盘和小组件上显示哪些服务商的配额徽章，调整顺序，并选择已用量或剩余量。</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -279,6 +279,11 @@
     <string name="settings_widget_graphs_subtitle">Overlay each member with its last hour of requests. Fresh bars cost one extra request per member on each background check.</string>
     <string name="settings_widget_quota_title">Quota badges</string>
     <string name="settings_widget_quota_subtitle">Carry the provider quota strip on the widget. Off also drops the quota read from each background check.</string>
+    <string name="settings_widget_align_title">Badge alignment</string>
+    <string name="settings_widget_align_subtitle">Where the quota badges sit across the width of the widget.</string>
+    <string name="settings_widget_align_left">Left</string>
+    <string name="settings_widget_align_center">Center</string>
+    <string name="settings_widget_align_right">Right</string>
 
     <string name="settings_quota_badges_title">Quota badges</string>
     <string name="settings_quota_badges_subtitle">Choose which provider quota badges show on the dashboard and the widget, reorder them, and pick used or remaining.</string>

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/PrefsStoreTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/PrefsStoreTest.kt
@@ -90,4 +90,37 @@ class PrefsStoreTest {
 
             assertEquals(QuotaBarMode.REMAINING, PrefsStore(dataStore).quotaBarMode.first())
         }
+
+    @Test
+    fun widgetQuotaAlignDefaultsToLeft() =
+        runBlocking {
+            // LEFT is exactly what the widget did before this preference existed,
+            // so an upgrading user must see no change until they choose otherwise.
+            assertEquals(QuotaBadgeAlign.LEFT, newStore().widgetQuotaAlign.first())
+        }
+
+    @Test
+    fun widgetQuotaAlignRoundTripsThroughSet() =
+        runBlocking {
+            val store = newStore()
+            store.setWidgetQuotaAlign(QuotaBadgeAlign.CENTER)
+            assertEquals(QuotaBadgeAlign.CENTER, store.widgetQuotaAlign.first())
+
+            store.setWidgetQuotaAlign(QuotaBadgeAlign.RIGHT)
+            assertEquals(QuotaBadgeAlign.RIGHT, store.widgetQuotaAlign.first())
+
+            store.setWidgetQuotaAlign(QuotaBadgeAlign.LEFT)
+            assertEquals(QuotaBadgeAlign.LEFT, store.widgetQuotaAlign.first())
+        }
+
+    @Test
+    fun unrecognizedStoredWidgetQuotaAlignDegradesToDefault() =
+        runBlocking {
+            val dataStore = InMemoryPreferencesDataStore()
+            // A value written by a future build with an alignment this build does
+            // not know: must fall back to the default, not throw.
+            dataStore.edit { it[stringPreferencesKey("widget_quota_align")] = "DIAGONAL" }
+
+            assertEquals(QuotaBadgeAlign.LEFT, PrefsStore(dataStore).widgetQuotaAlign.first())
+        }
 }

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreenTest.kt
@@ -408,7 +408,11 @@ class SettingsScreenTest {
         var picked: QuotaBadgeAlign? = null
         content(widgetQuota = false, onSetWidgetQuotaAlign = { picked = it })
 
-        composeTestRule.onNodeWithTag("settings-widget-align-LEFT").performScrollTo().assertIsDisplayed().assertIsNotEnabled()
+        composeTestRule
+            .onNodeWithTag("settings-widget-align-LEFT")
+            .performScrollTo()
+            .assertIsDisplayed()
+            .assertIsNotEnabled()
         composeTestRule.onNodeWithTag("settings-widget-align-CENTER").performScrollTo().assertIsNotEnabled()
         composeTestRule.onNodeWithTag("settings-widget-align-RIGHT").performScrollTo().assertIsNotEnabled()
 

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreenTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.performScrollTo
 import com.hugalafutro.bellhop.data.LinkState
 import com.hugalafutro.bellhop.data.LockConfig
 import com.hugalafutro.bellhop.data.LockTimeout
+import com.hugalafutro.bellhop.data.QuotaBadgeAlign
 import com.hugalafutro.bellhop.data.TimeFormat
 import com.hugalafutro.bellhop.ui.theme.BellhopTheme
 import org.junit.Assert.assertEquals
@@ -61,6 +62,8 @@ class SettingsScreenTest {
         onToggleWidgetGraphs: (Boolean) -> Unit = {},
         widgetQuota: Boolean = true,
         onToggleWidgetQuota: (Boolean) -> Unit = {},
+        widgetQuotaAlign: QuotaBadgeAlign = QuotaBadgeAlign.LEFT,
+        onSetWidgetQuotaAlign: (QuotaBadgeAlign) -> Unit = {},
         timeFormat: TimeFormat = TimeFormat.SYSTEM,
         onSetTimeFormat: (TimeFormat) -> Unit = {},
         batteryUnrestricted: Boolean = true,
@@ -104,6 +107,8 @@ class SettingsScreenTest {
                     onToggleWidgetGraphs = onToggleWidgetGraphs,
                     widgetQuota = widgetQuota,
                     onToggleWidgetQuota = onToggleWidgetQuota,
+                    widgetQuotaAlign = widgetQuotaAlign,
+                    onSetWidgetQuotaAlign = onSetWidgetQuotaAlign,
                     timeFormat = timeFormat,
                     onSetTimeFormat = onSetTimeFormat,
                     alertCounts = alertCounts,
@@ -371,5 +376,25 @@ class SettingsScreenTest {
         composeTestRule.onNodeWithTag("settings-unlink-force").performClick()
         assertTrue(dismissed)
         assertTrue(forced == 1)
+    }
+
+    @Test
+    fun widgetAlignmentPickerOffersAllThreeChoices() {
+        content()
+        composeTestRule.onNodeWithTag("settings-widget-align-LEFT").performScrollTo().assertIsDisplayed()
+        composeTestRule.onNodeWithTag("settings-widget-align-CENTER").performScrollTo().assertIsDisplayed()
+        composeTestRule.onNodeWithTag("settings-widget-align-RIGHT").performScrollTo().assertIsDisplayed()
+    }
+
+    @Test
+    fun pickingWidgetAlignmentFiresCallback() {
+        var picked: QuotaBadgeAlign? = null
+        content(widgetQuotaAlign = QuotaBadgeAlign.LEFT, onSetWidgetQuotaAlign = { picked = it })
+
+        composeTestRule.onNodeWithTag("settings-widget-align-CENTER").performScrollTo().performClick()
+        assertEquals(QuotaBadgeAlign.CENTER, picked)
+
+        composeTestRule.onNodeWithTag("settings-widget-align-RIGHT").performScrollTo().performClick()
+        assertEquals(QuotaBadgeAlign.RIGHT, picked)
     }
 }

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreenTest.kt
@@ -2,6 +2,8 @@ package com.hugalafutro.bellhop.ui.settings
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.assertIsNotSelected
+import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
@@ -397,6 +399,19 @@ class SettingsScreenTest {
 
         composeTestRule.onNodeWithTag("settings-widget-align-RIGHT").performScrollTo().performClick()
         assertEquals(QuotaBadgeAlign.RIGHT, picked)
+    }
+
+    @Test
+    fun widgetAlignmentPickerMarksTheActiveChoiceSelected() {
+        // Selection reaches the semantics tree, not just the fill colour, so a
+        // screen reader can say which alignment is in effect. Asserting the two
+        // unselected pills as well pins the mapping: a pill that reported itself
+        // selected unconditionally would satisfy the first assertion alone.
+        content(widgetQuotaAlign = QuotaBadgeAlign.CENTER)
+
+        composeTestRule.onNodeWithTag("settings-widget-align-CENTER").performScrollTo().assertIsSelected()
+        composeTestRule.onNodeWithTag("settings-widget-align-LEFT").assertIsNotSelected()
+        composeTestRule.onNodeWithTag("settings-widget-align-RIGHT").assertIsNotSelected()
     }
 
     @Test

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreenTest.kt
@@ -1,6 +1,7 @@
 package com.hugalafutro.bellhop.ui.settings
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
@@ -396,5 +397,23 @@ class SettingsScreenTest {
 
         composeTestRule.onNodeWithTag("settings-widget-align-RIGHT").performScrollTo().performClick()
         assertEquals(QuotaBadgeAlign.RIGHT, picked)
+    }
+
+    @Test
+    fun widgetAlignmentPickerInertWhenQuotaStripOff() {
+        // BellhopWidget gates the whole badge strip on widgetQuota, so with the
+        // switch off the alignment choice has nothing left to arrange. The
+        // pills stay visible (the set still says what it offers) but faded and
+        // untappable, same as the WIDGET tab on the quota config screen.
+        var picked: QuotaBadgeAlign? = null
+        content(widgetQuota = false, onSetWidgetQuotaAlign = { picked = it })
+
+        composeTestRule.onNodeWithTag("settings-widget-align-LEFT").performScrollTo().assertIsDisplayed().assertIsNotEnabled()
+        composeTestRule.onNodeWithTag("settings-widget-align-CENTER").performScrollTo().assertIsNotEnabled()
+        composeTestRule.onNodeWithTag("settings-widget-align-RIGHT").performScrollTo().assertIsNotEnabled()
+
+        composeTestRule.onNodeWithTag("settings-widget-align-CENTER").performClick()
+        composeTestRule.waitForIdle()
+        assertNull(picked)
     }
 }

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/widget/BellhopWidgetTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/widget/BellhopWidgetTest.kt
@@ -3,7 +3,9 @@ package com.hugalafutro.bellhop.widget
 import android.app.Application
 import androidx.glance.GlanceId
 import androidx.glance.action.actionParametersOf
+import androidx.glance.layout.Alignment
 import com.hugalafutro.bellhop.MainActivity
+import com.hugalafutro.bellhop.data.QuotaBadgeAlign
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -61,4 +63,15 @@ class BellhopWidgetTest {
 
             assertNull(ShadowToast.getTextOfLatestToast())
         }
+
+    @Test
+    fun alignmentPreferenceMapsToTheMatchingGlanceAlignment() {
+        // The render itself is an on-device smoke test (see this class' header:
+        // Glance composables cannot be driven by createComposeRule), so the one
+        // thing worth pinning here is the mapping, where a transposition would
+        // silently send RIGHT to the left edge.
+        assertEquals(Alignment.Start, quotaRowAlignment(QuotaBadgeAlign.LEFT))
+        assertEquals(Alignment.CenterHorizontally, quotaRowAlignment(QuotaBadgeAlign.CENTER))
+        assertEquals(Alignment.End, quotaRowAlignment(QuotaBadgeAlign.RIGHT))
+    }
 }

--- a/frontdesk/web/src/components/QuotaStrip.tsx
+++ b/frontdesk/web/src/components/QuotaStrip.tsx
@@ -147,10 +147,24 @@ export function QuotaStrip() {
 	if (models.length === 0) return null;
 
 	return (
-		<div className="fd-quota-strip" data-testid="quota-strip">
+		<div
+			// Collapsed, the strip is nothing but its unroll caret. The label and
+			// the stale note come out of the tree rather than being hidden in CSS,
+			// so a screen reader does not announce a QUOTA heading over a strip
+			// showing nothing.
+			className={`fd-quota-strip${collapsed ? " fd-quota-strip-collapsed" : ""}`}
+			data-testid="quota-strip"
+		>
 			<div className="fd-quota-strip-head">
-				<span className="fd-quota-strip-label">{t("quota.title")}</span>
-				{stale && (
+				{!collapsed && (
+					<span
+						className="fd-quota-strip-label"
+						data-testid="quota-strip-label"
+					>
+						{t("quota.title")}
+					</span>
+				)}
+				{!collapsed && stale && (
 					<span
 						className="fd-quota-stale"
 						data-testid="quota-stale"

--- a/frontdesk/web/src/components/__tests__/QuotaStrip.test.tsx
+++ b/frontdesk/web/src/components/__tests__/QuotaStrip.test.tsx
@@ -664,6 +664,72 @@ describe("QuotaStrip", () => {
 		// The cooldown outcome returns before calling the endpoint again.
 		expect(posted).toBe(1);
 	});
+
+	it("collapses to nothing but the caret", async () => {
+		localStorage.setItem("fdQuotaCollapsed", "true");
+		server.use(
+			http.get("/api/quota", () => HttpResponse.json({ quota: [nano] })),
+		);
+		renderStrip();
+		await waitFor(() =>
+			expect(screen.getByTestId("quota-strip")).toBeInTheDocument(),
+		);
+		// The caret is the whole collapsed strip: no label, and the modifier
+		// class that strips the band, the rule and the padding is on.
+		expect(screen.queryByTestId("quota-strip-label")).toBeNull();
+		expect(screen.getByTestId("quota-strip")).toHaveClass(
+			"fd-quota-strip-collapsed",
+		);
+		expect(screen.getByTestId("quota-collapse")).toBeInTheDocument();
+	});
+
+	it("keeps the label and the full band while expanded", async () => {
+		server.use(
+			http.get("/api/quota", () => HttpResponse.json({ quota: [nano] })),
+		);
+		renderStrip();
+		await waitFor(() =>
+			expect(screen.getByTestId("quota-strip-label")).toBeInTheDocument(),
+		);
+		expect(screen.getByTestId("quota-strip")).not.toHaveClass(
+			"fd-quota-strip-collapsed",
+		);
+	});
+
+	it("hides the stale marker once collapsed", async () => {
+		// Stale is `error && snapshots.length > 0`, so it needs one good read
+		// followed by a failed one; the refresh path is how the existing suite
+		// produces it. Collapsing must take the marker with the badges: polling
+		// stops while collapsed, so a freshness stamp there describes data the
+		// strip is no longer refreshing.
+		let getCalls = 0;
+		server.use(
+			http.get("/api/quota", () => {
+				getCalls++;
+				return getCalls === 1
+					? HttpResponse.json({ quota: [nano] })
+					: HttpResponse.json({ error: "x" }, { status: 502 });
+			}),
+			http.post("/api/quota/refresh", () =>
+				HttpResponse.json({
+					results: [],
+					refreshed: 1,
+					failed: 0,
+					skipped: 0,
+				}),
+			),
+		);
+		renderStrip();
+		await waitFor(() =>
+			expect(screen.getByTestId("quota-refresh")).toBeInTheDocument(),
+		);
+		await userEvent.click(screen.getByTestId("quota-refresh"));
+		await waitFor(() =>
+			expect(screen.getByTestId("quota-stale")).toBeInTheDocument(),
+		);
+		await userEvent.click(screen.getByTestId("quota-collapse"));
+		expect(screen.queryByTestId("quota-stale")).toBeNull();
+	});
 });
 
 // M-4 regression: a provider dropping out of a LATER, genuinely loaded poll

--- a/frontdesk/web/src/index.css
+++ b/frontdesk/web/src/index.css
@@ -970,5 +970,12 @@ h3 {
 .fd-quota-badges {
 	display: flex;
 	flex-wrap: wrap;
+	/* Centered rather than left-hugging: the strip spans the page, so a fleet
+	   with two or three quota providers otherwise left a long empty run to the
+	   right. The container already wraps, so each wrapped line centers on its
+	   own, which is what a fleet with more providers than fit one line wants.
+	   Only the main axis: every .fd-quota-pill is the same height, so
+	   align-items would be a declaration nothing depends on. */
+	justify-content: center;
 	gap: 0.35rem;
 }

--- a/frontdesk/web/src/index.css
+++ b/frontdesk/web/src/index.css
@@ -979,3 +979,19 @@ h3 {
 	justify-content: center;
 	gap: 0.35rem;
 }
+
+/* Collapsed, the strip is nothing but its unroll caret: no band, no rule, no
+   label, so the page reads exactly as it did before quota badges existed.
+   .fd-header directly above already carries this background and its own
+   border-bottom, so keeping either here painted a second, empty header. The
+   horizontal padding is the one thing retained, so the caret lines up with the
+   header's right edge instead of sitting flush against the viewport.
+   The root's `gap` is deliberately left alone: collapsed, the strip has exactly
+   one child (the badges are gated on !collapsed and the modal cannot be open,
+   since toggleCollapsed nulls openKey on the way in), so overriding it would be
+   a dead declaration. */
+.fd-quota-strip-collapsed {
+	padding: 0 1.25rem;
+	border-bottom: none;
+	background: none;
+}


### PR DESCRIPTION
Three presentation changes to how quota badges sit on their surfaces.

## Front Desk

**Badges are centered.** The strip spans the page, so a fleet with two or three quota
providers left a long empty run to the right. One declaration on `.fd-quota-badges`; the
container already wraps, so each wrapped line centers on its own.

**Collapsing the strip now actually collapses it.** Previously the collapsed strip kept its
padding, bottom border, elevated background and "QUOTA" label, and since `.fd-header` above
carries the same background and its own rule, it read as a second empty header band.
Collapsed now renders as nothing but the unroll caret, so the page looks as it did before
quota badges existed.

The label and stale note are removed from the tree rather than hidden in CSS, so a screen
reader does not announce a QUOTA heading over a strip showing nothing. Hiding the stale note
is consistent with what collapse already meant: `useQuota(collapsed)` stops polling, so a
freshness stamp there describes data the strip is no longer refreshing.

The strip root stays mounted and keeps its `data-testid` (pre-existing tests depend on the
element being present while collapsed), the caret keeps `aria-expanded` and its existing
labels, and the `models.length === 0` early return is untouched, so a fleet reporting no
quota at all still renders nothing rather than a bare caret. No new i18n keys.

## Bellhop

New left/center/right alignment preference for the home-screen widget's quota badge strip,
picked from Settings -> Home-screen widget, translated into all 11 locales.

- `QuotaBadgeAlign` beside `QuotaBarMode`; `PrefsStore.widgetQuotaAlign` defaults to `LEFT`
  and degrades to `LEFT` on an unrecognised stored value, matching the `quotaBarMode` idiom,
  so an upgrading user sees no change.
- `horizontalAlignment` on the badge rows via `quotaRowAlignment`. This only does anything
  because the badge children take no `defaultWeight()` -- each pill is its own label's width,
  which is the slack there is to distribute. Packing, the row cap and the `+N` overflow
  marker are untouched, and the marker stays a child of the same `Row`, so it travels with
  the badges under all three settings.
- The settings write calls `BellhopWidget.update(context)`, **not**
  `FleetPollWorker.runWidgetRefresh(...)` like the two toggles directly above it. Those
  change what the background poll fetches; alignment changes no data at all. The `update`
  call is still required: `provideGlance` only collects the flow for a live Glance session,
  and a widget on a home screen nobody is looking at has none.
- The picker is disabled when the "Quota badges" switch is off, matching how the quota
  badges config screen already treats its widget tab -- otherwise each tap wrote storage and
  poked the widget for no visible effect.

## Verification

Front Desk: 433/433 vitest, `tsc -b` + `typecheck:tests` + lint clean. `QuotaStrip.tsx` at
95.65% statements, with every line this branch changed covered.

Bellhop: 523/523 unit tests, `lintDebug` clean (so the `MissingTranslation` gate passed
across all 11 locales).

The Bellhop half was verified on the emulator against a real placed widget whose strip wraps
to two rows: Left leaves the second row at the left edge, Center centers both rows, Right
pushes both flush right. The widget's "as of" stamp did not move across those switches,
confirming the re-render happens without a network fetch and reaches a widget with no live
Glance session.

Two changes deliberately ship without tests, and both are documented in the plan: the CSS
rule (jsdom does not load `index.css` under vitest, so any assertion would be vacuous) and
the `MainActivity` wiring (making it unit-testable would require a test-only seam in
production code).

## Known follow-up, not in this PR

`FilterPill` signals selection through colour only, with no `Modifier.selectable` and no
`semantics { selected = ... }`. So TalkBack cannot announce which option is active in any of
the five pickers built on it (clock, graph range, severity, surface tabs, and now alignment),
and "the selected pill renders as selected" is untestable. Fixing it means touching the
shared component, so it is left out here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
