### PR TITLE
ci: analyse only the CodeQL languages the change touches

### DIFF
--- a/.github/actions/changed-surfaces/action.yml
+++ b/.github/actions/changed-surfaces/action.yml
@@ -1,0 +1,227 @@
+name: Changed surfaces
+description: >-
+  Classify which parts of the tree a push or PR touches, so callers can skip work
+  that cannot be affected by it. Requires the repo already checked out with
+  fetch-depth 0.
+
+# A composite action rather than a reusable workflow on purpose: `uses:` at job
+# level renames the check run to "<caller job> / <called job>", and
+# "Changed Surfaces" is a REQUIRED context. A composite action runs as steps
+# inside the caller's job, so the job keeps its name.
+
+outputs:
+  go:
+    description: Go sources, module files, migrations or the lint config changed
+    value: ${{ steps.filter.outputs.go }}
+  web:
+    description: web/ (the dashboard frontend) changed
+    value: ${{ steps.filter.outputs.web }}
+  fdweb:
+    description: frontdesk/web/ changed
+    value: ${{ steps.filter.outputs.fdweb }}
+  workflows:
+    description: .github/ changed
+    value: ${{ steps.filter.outputs.workflows }}
+  deps:
+    description: dependency manifests, the notices generator, or the notices file changed
+    value: ${{ steps.filter.outputs.deps }}
+  i18n:
+    description: anything the offline locale gate reads changed
+    value: ${{ steps.filter.outputs.i18n }}
+  image:
+    description: something the Docker images actually carry changed
+    value: ${{ steps.filter.outputs.image }}
+  measurable:
+    description: a surface with coverage data changed
+    value: ${{ steps.filter.outputs.measurable }}
+  all_coverage:
+    description: >-
+      run every coverage suite regardless of surface (a master push that changes
+      anything measurable, because the badge aggregates all three)
+    value: ${{ steps.filter.outputs.all_coverage }}
+  codeql_langs:
+    description: >-
+      JSON matrix include list for codeql.yml, holding only the languages this
+      change can have affected. Never empty.
+    value: ${{ steps.filter.outputs.codeql_langs }}
+
+runs:
+  using: composite
+  steps:
+    - name: Detect changed surfaces
+      id: filter
+      shell: bash
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+        BASE_REF: ${{ github.base_ref }}
+        BEFORE_SHA: ${{ github.event.before }}
+        HEAD_SHA: ${{ github.sha }}
+      # No `set -e`: every failure path is handled explicitly by run_everything,
+      # so this cannot die half-way and leave callers reading an empty (and
+      # therefore run-everything) output set by accident.
+      run: |
+        set -uo pipefail
+
+        # Every language codeql.yml knows how to analyse, with its build mode.
+        ALL_LANGS='[{"language":"actions","build-mode":"none"},{"language":"go","build-mode":"autobuild"},{"language":"javascript-typescript","build-mode":"none"},{"language":"python","build-mode":"none"},{"language":"java-kotlin","build-mode":"manual"}]'
+
+        # "I cannot establish the diff" -> run the whole suite. Also the
+        # workflow_dispatch answer: a manual run is an explicit "test it all".
+        run_everything() {
+          echo "running everything: $1"
+          for k in go web fdweb workflows deps i18n image python android measurable all_coverage; do
+            echo "$k=true" >> "$GITHUB_OUTPUT"
+          done
+          echo "codeql_langs=$ALL_LANGS" >> "$GITHUB_OUTPUT"
+          {
+            echo "### Changed surfaces"
+            echo
+            echo "Running **everything**: $1"
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit 0
+        }
+
+        case "$EVENT_NAME" in
+          pull_request)
+            git fetch --no-tags --quiet origin "$BASE_REF" \
+              || run_everything "could not fetch base ref $BASE_REF"
+            # Three-dot: compare against the merge base, so commits that landed
+            # on master since the branch started are not counted as this PR's
+            # changes.
+            changed=$(git diff --name-only "origin/${BASE_REF}...HEAD") \
+              || run_everything "diff against origin/$BASE_REF failed"
+            ;;
+          push)
+            # A brand-new branch (or a force push) reports an all-zero or absent
+            # before-SHA; there is no previous state to diff.
+            if [ -z "$BEFORE_SHA" ] || [ "$BEFORE_SHA" = "0000000000000000000000000000000000000000" ]; then
+              run_everything "push carried no usable before-SHA"
+            fi
+            git cat-file -e "${BEFORE_SHA}^{commit}" 2>/dev/null \
+              || run_everything "before-SHA $BEFORE_SHA is not in this clone"
+            changed=$(git diff --name-only "$BEFORE_SHA" "$HEAD_SHA") \
+              || run_everything "diff $BEFORE_SHA..$HEAD_SHA failed"
+            ;;
+          *)
+            run_everything "$EVENT_NAME is an explicit request to run"
+            ;;
+        esac
+
+        if [ -z "$changed" ]; then
+          run_everything "the diff is empty"
+        fi
+
+        echo "changed files:"
+        printf '%s\n' "$changed"
+
+        match() {
+          if printf '%s\n' "$changed" | grep -qE "$1"; then echo true; else echo false; fi
+        }
+
+        any() {
+          for v in "$@"; do
+            if [ "$v" = true ]; then echo true; return; fi
+          done
+          echo false
+        }
+
+        # Go build/test/lint surface. Kept broad: `internal/` and `cmd/` carry
+        # the SQL migrations and testdata too, and the Makefile drives the local
+        # equivalents of these jobs.
+        go=$(match '^(cmd|internal)/|\.go$|^go\.(mod|sum)$|^\.golangci\.ya?ml$|^Makefile$')
+        web=$(match '^web/')
+        fdweb=$(match '^frontdesk/web/')
+        workflows=$(match '^\.github/')
+        # THIRD-PARTY-NOTICES.md is generated FROM these, so a hand-edit to the
+        # committed file must be caught by regenerating it.
+        deps=$(match '^go\.(mod|sum)$|^web/(package\.json|pnpm-lock\.yaml|pnpm-workspace\.yaml)$|^tools/gen-notices/|^THIRD-PARTY-NOTICES\.md$')
+        # The locale gate reads both apps' sources, not just their catalogs: it
+        # verifies every literal t("...") key resolves in en.json.
+        i18n=$(match '^web/|^frontdesk/web/|^tools/i18n-translate/|^Makefile$')
+        # The coverage jobs run the coverage scripts' own self-tests, so a change
+        # to those scripts has to reach them even with no code change.
+        covtools=$(match '^scripts/coverage/')
+        python=$(match '\.py$')
+        android=$(match '^android/')
+        # Loose JS/TS outside the two app trees (build scripts, config).
+        jsts=$(match '\.(m|c)?[jt]sx?$')
+
+        # The images carry the compiled Go binary plus both built frontends. Test
+        # files are neither compiled nor bundled, so drop them before matching the
+        # surface the Dockerfiles COPY. publish-dev keeps its own independent copy
+        # of this predicate because it diffs against the last PUBLISHED image, not
+        # against this push's parent.
+        src=$(printf '%s\n' "$changed" | grep -vE '(_test\.go|\.test\.tsx?|\.spec\.tsx?)$')
+        if printf '%s\n' "$src" | grep -qE '^(internal/|cmd/|web/|frontdesk/web/|Dockerfile|docker-entrypoint|\.dockerignore|go\.(mod|sum))'; then
+          image=true
+        else
+          image=false
+        fi
+
+        measurable=$(any "$go" "$web" "$fdweb" "$covtools")
+
+        # The master coverage badge is one number aggregated from all three
+        # suites, so it can only be recomputed when all three have reported. On a
+        # push that changes any measurable surface we therefore run the full trio;
+        # on a docs-only push we run none of them and the badge correctly stays
+        # where it is. PRs gate each suite independently - they feed the diff
+        # gate, which is per-file.
+        if [ "$EVENT_NAME" = push ] && [ "$measurable" = true ]; then
+          all_coverage=true
+        else
+          all_coverage=false
+        fi
+
+        # CodeQL analyses only the languages this change can have affected.
+        # `actions` is UNCONDITIONAL and that is deliberate: the required "CodeQL"
+        # context is posted by the code-scanning app once an analysis is uploaded,
+        # so a run that analysed nothing at all risks a context that never
+        # reports and blocks the PR forever. It is also the cheapest leg.
+        langs='{"language":"actions","build-mode":"none"}'
+        if [ "$go" = true ]; then
+          langs="$langs,{\"language\":\"go\",\"build-mode\":\"autobuild\"}"
+        fi
+        if [ "$web" = true ] || [ "$fdweb" = true ] || [ "$jsts" = true ]; then
+          langs="$langs,{\"language\":\"javascript-typescript\",\"build-mode\":\"none\"}"
+        fi
+        if [ "$python" = true ]; then
+          langs="$langs,{\"language\":\"python\",\"build-mode\":\"none\"}"
+        fi
+        if [ "$android" = true ]; then
+          langs="$langs,{\"language\":\"java-kotlin\",\"build-mode\":\"manual\"}"
+        fi
+        codeql_langs="[$langs]"
+
+        {
+          echo "go=$go"
+          echo "web=$web"
+          echo "fdweb=$fdweb"
+          echo "workflows=$workflows"
+          echo "deps=$deps"
+          echo "i18n=$i18n"
+          echo "image=$image"
+          echo "python=$python"
+          echo "android=$android"
+          echo "measurable=$measurable"
+          echo "all_coverage=$all_coverage"
+          echo "codeql_langs=$codeql_langs"
+        } | tee -a "$GITHUB_OUTPUT"
+
+        {
+          echo "### Changed surfaces"
+          echo
+          echo "| surface | changed |"
+          echo "| --- | --- |"
+          echo "| Go | $go |"
+          echo "| web/ | $web |"
+          echo "| frontdesk/web/ | $fdweb |"
+          echo "| workflows | $workflows |"
+          echo "| dependencies | $deps |"
+          echo "| i18n | $i18n |"
+          echo "| image | $image |"
+          echo "| Python | $python |"
+          echo "| android/ | $android |"
+          echo "| coverage-measurable | $measurable |"
+          echo
+          echo "CodeQL languages: \`$codeql_langs\`"
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/actions/changed-surfaces/action.yml
+++ b/.github/actions/changed-surfaces/action.yml
@@ -114,8 +114,15 @@ runs:
         echo "changed files:"
         printf '%s\n' "$changed"
 
+        # Herestring, NEVER `printf ... | grep -q`. Under `pipefail`, grep -q
+        # exits the moment it matches and closes the pipe; on a diff bigger than
+        # the 64KB pipe buffer the still-writing producer takes SIGPIPE, the
+        # pipeline reports 141, and an EARLY match comes back as `false`. That
+        # fails closed - a changed surface reported as unchanged - which is the
+        # one direction this gate must never fail in. Measured threshold: around
+        # 1,500 to 2,000 changed paths.
         match() {
-          if printf '%s\n' "$changed" | grep -qE "$1"; then echo true; else echo false; fi
+          if grep -qE "$1" <<< "$changed"; then echo true; else echo false; fi
         }
 
         any() {
@@ -151,8 +158,12 @@ runs:
         # surface the Dockerfiles COPY. publish-dev keeps its own independent copy
         # of this predicate because it diffs against the last PUBLISHED image, not
         # against this push's parent.
-        src=$(printf '%s\n' "$changed" | grep -vE '(_test\.go|\.test\.tsx?|\.spec\.tsx?)$')
-        if printf '%s\n' "$src" | grep -qE '^(internal/|cmd/|web/|frontdesk/web/|Dockerfile|docker-entrypoint|\.dockerignore|go\.(mod|sum))'; then
+        # `grep -v` consumes all of its input so it cannot SIGPIPE its producer,
+        # but the -q below can, so both use herestrings for the same reason as
+        # match() above. An all-test-files diff filters to empty, which correctly
+        # yields image=false.
+        src=$(grep -vE '(_test\.go|\.test\.tsx?|\.spec\.tsx?)$' <<< "$changed")
+        if grep -qE '^(internal/|cmd/|web/|frontdesk/web/|Dockerfile|docker-entrypoint|\.dockerignore|go\.(mod|sum))' <<< "$src"; then
           image=true
         else
           image=false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,11 +34,12 @@ jobs:
   # protection. See GitHub's "Troubleshooting required status checks".
   #
   # Fail-OPEN on purpose. Every gate below tests `!= 'false'`, so an output this
-  # job never wrote (empty string) runs the job anyway, and the script below
+  # job never wrote (empty string) runs the job anyway, and the action it calls
   # answers "I don't know" with run-everything rather than a silent skip. The
   # failure mode of a bug here must be a wasted run, never an untested merge —
   # a skipped required check counts as passing, so a gate that guesses "unchanged"
-  # would wave work through.
+  # would wave work through. This job is itself a REQUIRED check, so a gate that
+  # dies blocks the PR instead of skipping (= passing) everything below it.
   changes:
     name: Changed Surfaces
     runs-on: ubuntu-latest
@@ -57,148 +58,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Detect changed surfaces
-        id: filter
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          BASE_REF: ${{ github.base_ref }}
-          BEFORE_SHA: ${{ github.event.before }}
-          HEAD_SHA: ${{ github.sha }}
-        # No `set -e`: every failure path is handled explicitly by
-        # run_everything, so the job cannot die half-way and leave the gates
-        # reading an empty (and therefore run-everything) output set by accident.
-        run: |
-          set -uo pipefail
-
-          # "I cannot establish the diff" -> run the whole suite. Also the
-          # workflow_dispatch answer: a manual run is an explicit "test it all".
-          run_everything() {
-            echo "running everything: $1"
-            for k in go web fdweb workflows deps i18n image measurable all_coverage; do
-              echo "$k=true" >> "$GITHUB_OUTPUT"
-            done
-            {
-              echo "### Changed surfaces"
-              echo
-              echo "Running **everything**: $1"
-            } >> "$GITHUB_STEP_SUMMARY"
-            exit 0
-          }
-
-          case "$EVENT_NAME" in
-            pull_request)
-              git fetch --no-tags --quiet origin "$BASE_REF" \
-                || run_everything "could not fetch base ref $BASE_REF"
-              # Three-dot: compare against the merge base, so commits that
-              # landed on master since the branch started are not counted as
-              # this PR's changes.
-              changed=$(git diff --name-only "origin/${BASE_REF}...HEAD") \
-                || run_everything "diff against origin/$BASE_REF failed"
-              ;;
-            push)
-              # A brand-new branch (or a force push) reports an all-zero or
-              # absent before-SHA; there is no previous state to diff.
-              if [ -z "$BEFORE_SHA" ] || [ "$BEFORE_SHA" = "0000000000000000000000000000000000000000" ]; then
-                run_everything "push carried no usable before-SHA"
-              fi
-              git cat-file -e "${BEFORE_SHA}^{commit}" 2>/dev/null \
-                || run_everything "before-SHA $BEFORE_SHA is not in this clone"
-              changed=$(git diff --name-only "$BEFORE_SHA" "$HEAD_SHA") \
-                || run_everything "diff $BEFORE_SHA..$HEAD_SHA failed"
-              ;;
-            *)
-              run_everything "$EVENT_NAME is an explicit request to run"
-              ;;
-          esac
-
-          if [ -z "$changed" ]; then
-            run_everything "the diff is empty"
-          fi
-
-          echo "changed files:"
-          printf '%s\n' "$changed"
-
-          match() {
-            if printf '%s\n' "$changed" | grep -qE "$1"; then echo true; else echo false; fi
-          }
-
-          any() {
-            for v in "$@"; do
-              if [ "$v" = true ]; then echo true; return; fi
-            done
-            echo false
-          }
-
-          # Go build/test/lint surface. Kept broad: `internal/` and `cmd/` carry
-          # the SQL migrations and testdata too, and the Makefile drives the
-          # local equivalents of these jobs.
-          go=$(match '^(cmd|internal)/|\.go$|^go\.(mod|sum)$|^\.golangci\.ya?ml$|^Makefile$')
-          web=$(match '^web/')
-          fdweb=$(match '^frontdesk/web/')
-          workflows=$(match '^\.github/')
-          # THIRD-PARTY-NOTICES.md is generated FROM these, so a hand-edit to the
-          # committed file must be caught by regenerating it.
-          deps=$(match '^go\.(mod|sum)$|^web/(package\.json|pnpm-lock\.yaml|pnpm-workspace\.yaml)$|^tools/gen-notices/|^THIRD-PARTY-NOTICES\.md$')
-          # The locale gate reads both apps' sources, not just their catalogs: it
-          # verifies every literal t("...") key resolves in en.json.
-          i18n=$(match '^web/|^frontdesk/web/|^tools/i18n-translate/|^Makefile$')
-          # The coverage jobs run the coverage scripts' own self-tests, so a
-          # change to those scripts has to reach them even with no code change.
-          covtools=$(match '^scripts/coverage/')
-
-          # The :dev image carries the compiled Go binary plus both built
-          # frontends. Test files are neither compiled nor bundled, so drop them
-          # before matching the surface the Dockerfiles COPY. Same predicate as
-          # publish-dev's own gate below, which keeps its independent copy
-          # because it diffs against the last PUBLISHED image, not against this
-          # push's parent.
-          src=$(printf '%s\n' "$changed" | grep -vE '(_test\.go|\.test\.tsx?|\.spec\.tsx?)$')
-          if printf '%s\n' "$src" | grep -qE '^(internal/|cmd/|web/|frontdesk/web/|Dockerfile|docker-entrypoint|\.dockerignore|go\.(mod|sum))'; then
-            image=true
-          else
-            image=false
-          fi
-
-          measurable=$(any "$go" "$web" "$fdweb" "$covtools")
-
-          # The master coverage badge is one number aggregated from all three
-          # suites, so it can only be recomputed when all three have reported.
-          # On a push that changes any measurable surface we therefore run the
-          # full trio; on a docs-only push we run none of them and the badge
-          # correctly stays where it is. PRs gate each suite independently -
-          # they feed the diff gate, which is per-file.
-          if [ "$EVENT_NAME" = push ] && [ "$measurable" = true ]; then
-            all_coverage=true
-          else
-            all_coverage=false
-          fi
-
-          {
-            echo "go=$go"
-            echo "web=$web"
-            echo "fdweb=$fdweb"
-            echo "workflows=$workflows"
-            echo "deps=$deps"
-            echo "i18n=$i18n"
-            echo "image=$image"
-            echo "measurable=$measurable"
-            echo "all_coverage=$all_coverage"
-          } | tee -a "$GITHUB_OUTPUT"
-
-          {
-            echo "### Changed surfaces"
-            echo
-            echo "| surface | changed |"
-            echo "| --- | --- |"
-            echo "| Go | $go |"
-            echo "| web/ | $web |"
-            echo "| frontdesk/web/ | $fdweb |"
-            echo "| workflows | $workflows |"
-            echo "| dependencies | $deps |"
-            echo "| i18n | $i18n |"
-            echo "| image | $image |"
-            echo "| coverage-measurable | $measurable |"
-          } >> "$GITHUB_STEP_SUMMARY"
+      # Shared with codeql.yml. A composite action, not a reusable workflow:
+      # `uses:` at job level would rename this check to "<caller> / <called>",
+      # and "Changed Surfaces" is a required context.
+      - id: filter
+        uses: ./.github/actions/changed-surfaces
 
   go-test:
     name: Go Test

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,8 +19,33 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # Analysing all five languages on every change meant a full no-daemon Gradle
+  # build of Bellhop, a Go autobuild, and a JS/TS extraction on pushes containing
+  # none of those languages: 481 runner-seconds for a docs-only PR. This job
+  # builds the matrix from what actually changed, sharing ci.yml's gate via the
+  # composite action so the two cannot drift.
+  #
+  # Unlike ci.yml this gate does NOT gate the job, it shrinks the matrix. The
+  # per-language `Analyze (...)` checks are not required contexts, so there is no
+  # skipped-leg hazard; what matters is that `actions` is always in the list, so
+  # SOME analysis is always uploaded and the required "CodeQL" context (posted by
+  # the code-scanning app, not by a job here) always reports.
+  changes:
+    name: CodeQL Surfaces
+    runs-on: ubuntu-latest
+    outputs:
+      langs: ${{ steps.filter.outputs.codeql_langs }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - id: filter
+        uses: ./.github/actions/changed-surfaces
+
   analyze:
     name: Analyze (${{ matrix.language }})
+    needs: changes
     runs-on: ubuntu-latest
     permissions:
       security-events: write
@@ -30,19 +55,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - language: actions
-            build-mode: none
-          - language: go
-            build-mode: autobuild
-          - language: javascript-typescript
-            build-mode: none
-          - language: python
-            build-mode: none
-          # Pure-Kotlin (Bellhop) cannot be extracted with build-mode: none;
-          # it needs a real Gradle build (build-mode: manual).
-          - language: java-kotlin
-            build-mode: manual
+        # Pure-Kotlin (Bellhop) cannot be extracted with build-mode: none; it
+        # needs a real Gradle build (build-mode: manual). The build modes are
+        # paired with their languages inside the action.
+        include: ${{ fromJSON(needs.changes.outputs.langs) }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 


### PR DESCRIPTION
Follow-up to #589, which scoped `ci.yml` but deliberately left CodeQL alone.

CodeQL analyses all five languages on every push and PR: a full no-daemon Gradle build of Bellhop, a
Go autobuild, and a JS/TS extraction on changes that contain none of those languages. Measured on
\#589, whose diff was one workflow file and one PNG:

| leg | duration |
| --- | --- |
| `Analyze (java-kotlin)` | 170s |
| `Analyze (go)` | 127s |
| `Analyze (javascript-typescript)` | 103s |
| `Analyze (python)` | 45s |
| `Analyze (actions)` | 36s |

481 runner-seconds, of which only the last leg had anything to look at.

## How it works

The matrix is now built from what actually changed:

```yaml
strategy:
  matrix:
    include: ${{ fromJSON(needs.changes.outputs.langs) }}
```

Unlike `ci.yml` this gates the **matrix**, not the job. That difference is deliberate: #589 had to
gate `frontend-test` per step because its shard contexts are separately required and [a matrix job
skipped at job level is never expanded](https://github.com/actions/runner/issues/952). The
per-language `Analyze (...)` checks here are *not* required contexts, so shrinking the matrix is
free of that hazard and also saves the runner spin-up.

`actions` is unconditionally in the list, and that is the load-bearing part. The required `CodeQL`
context is posted by the code-scanning app once an analysis is uploaded, not by any job in this
workflow, so a run that analysed nothing at all risks a context that never reports and blocks the PR
forever. It is also the cheapest leg. `schedule` and `workflow_dispatch` fall through to
run-everything, so the weekly full scan stays a full scan.

## Shared detection

The gate script moves into the composite action `.github/actions/changed-surfaces`, used by both
workflows, so the two cannot drift.

Composite action and **not** a reusable workflow: `uses:` at job level renames the check run to
`<caller job> / <called job>`, and `Changed Surfaces` became a required context after #589 merged.
A composite action runs as steps inside the caller's job, so the job keeps its name. `ci.yml`'s job
keeps its name, its outputs and every gate unchanged; only the body of one step moved out.

## Verification

`actionlint` clean. The action's script was extracted from the YAML and run against real commit
ranges and synthetic file lists. Surface flags are byte-identical to the merged version for both the
README-only commit `ef85bbad` and the #587 merge, so nothing about `ci.yml`'s behaviour moved.

Language selection:

| change | languages analysed |
| --- | --- |
| `docs/screenshots/*.png`, `.github/workflows/*` | `actions` |
| `internal/api/x.go` | `actions`, `go` |
| `web/src/**` or `frontdesk/web/**` or a loose `.ts` | `actions`, `javascript-typescript` |
| `scripts/coverage/*.py` | `actions`, `python` |
| `android/**` | `actions`, `java-kotlin` |
| `go.mod` + `android/**` + `*.py` together | `actions`, `go`, `python`, `java-kotlin` |
| unresolvable diff, `schedule`, `workflow_dispatch` | all five |

**This PR is its own test**, the same way #589 was: it touches only `.github/`, so it should analyse
`actions` alone and the required `CodeQL` context should still report. If it does not, it shows up
here rather than on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
