### PR TITLE
fix(docs): replace the dead golangci-lint badge with CodeQL

### DIFF
--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -6,7 +6,7 @@
 
 **Multi-Provider AI Gateway**
 
-![Github CI](https://github.com/hugalafutro/model-hotel/actions/workflows/ci.yml/badge.svg) [![golangci-lint](https://github.com/hugalafutro/model-hotel/actions/workflows/lint.yml/badge.svg)](https://github.com/hugalafutro/model-hotel/actions/workflows/lint.yml) ![Go Version](https://img.shields.io/github/go-mod/go-version/hugalafutro/model-hotel) ![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?logo=typescript&logoColor=white) ![React](https://img.shields.io/badge/React-61DAFB?logo=react&logoColor=black) ![PostgreSQL](https://img.shields.io/badge/PostgreSQL-4169E1?logo=postgresql&logoColor=white)  ![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/hugalafutro/model-hotel/badges/coverage.json) ![GitHub Repo stars](https://img.shields.io/github/stars/hugalafutro/model-hotel)
+![Github CI](https://github.com/hugalafutro/model-hotel/actions/workflows/ci.yml/badge.svg) [![CodeQL](https://github.com/hugalafutro/model-hotel/actions/workflows/codeql.yml/badge.svg)](https://github.com/hugalafutro/model-hotel/actions/workflows/codeql.yml) ![Go Version](https://img.shields.io/github/go-mod/go-version/hugalafutro/model-hotel) ![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?logo=typescript&logoColor=white) ![React](https://img.shields.io/badge/React-61DAFB?logo=react&logoColor=black) ![PostgreSQL](https://img.shields.io/badge/PostgreSQL-4169E1?logo=postgresql&logoColor=white)  ![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/hugalafutro/model-hotel/badges/coverage.json) ![GitHub Repo stars](https://img.shields.io/github/stars/hugalafutro/model-hotel)
 
 
 > **AI-Assisted Project Disclaimer:**

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
  <a href="https://hub.docker.com/r/hugalafutro/model-hotel"><img src="https://img.shields.io/docker/pulls/hugalafutro/model-hotel.svg" alt="Docker Pulls"></a>
  <br>
  <a href="https://github.com/hugalafutro/model-hotel/actions/workflows/ci.yml"><img src="https://github.com/hugalafutro/model-hotel/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
- <a href="https://github.com/hugalafutro/model-hotel/actions/workflows/lint.yml"><img src="https://github.com/hugalafutro/model-hotel/actions/workflows/lint.yml/badge.svg" alt="golangci-lint"></a>
+ <a href="https://github.com/hugalafutro/model-hotel/actions/workflows/codeql.yml"><img src="https://github.com/hugalafutro/model-hotel/actions/workflows/codeql.yml/badge.svg" alt="CodeQL"></a>
  <a href="https://github.com/hugalafutro/model-hotel/actions/workflows/ci.yml"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/hugalafutro/model-hotel/badges/coverage.json" alt="Coverage"></a>
  <img src="https://img.shields.io/github/stars/hugalafutro/model-hotel" alt="GitHub Stars">
  <br>


### PR DESCRIPTION
#589 removed `lint.yml` as a duplicate of `ci.yml`'s `Go Lint` job, but two badges pointed at it, so
both went dead. Verified:

```
actions/workflows/lint.yml/badge.svg   -> 404
actions/workflows/ci.yml/badge.svg     -> 200 passing
actions/workflows/codeql.yml/badge.svg -> 200 passing
```

GitHub has no per-job badge, so a standalone golangci-lint badge needs a workflow that does nothing
but lint, which is precisely the duplicate run #589 removed. Linting is not unreported: `Go Lint` is
a job in CI and a lint failure fails the run, so the CI badge already covers it.

Rather than leave the row one badge shorter, the slot now carries CodeQL, which had no badge and
reports something the CI badge does not. Mirrored into `DOCKERHUB.md`, as the readme guard requires.

Also a live check of the new gating: this PR touches only `README.md` and `DOCKERHUB.md`, so it
should run no suites at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
