### PR TITLE
feat(proxy): verify a model with a real request before retiring it

### DIFF
--- a/internal/anthropic/native.go
+++ b/internal/anthropic/native.go
@@ -44,6 +44,23 @@ func ParseResponseUsage(body []byte) (inputTokens, outputTokens int) {
 	return resp.Usage.InputTokens, resp.Usage.OutputTokens
 }
 
+// ResponseCarriesContent reports whether a non-streaming Messages response holds
+// any content block. A 200 with an empty content array is a status rather than
+// an answer, and the proxy's model-retirement path needs the difference: an
+// empty completion must not count as the model answering.
+//
+// The blocks are left undecoded — a block of any type is the model producing
+// something, and their vocabulary is Anthropic's to extend.
+func ResponseCarriesContent(body []byte) bool {
+	var resp struct {
+		Content []json.RawMessage `json:"content"`
+	}
+	if json.Unmarshal(body, &resp) != nil {
+		return false
+	}
+	return len(resp.Content) > 0
+}
+
 // StreamEvent is the decoded summary of a single Anthropic stream event,
 // produced by InspectStreamEvent for the native passthrough path. It carries
 // everything that path needs from one parse: the event Type (so the terminal

--- a/internal/anthropic/native_test.go
+++ b/internal/anthropic/native_test.go
@@ -44,6 +44,38 @@ func TestParseResponseUsage(t *testing.T) {
 	}
 }
 
+// ResponseCarriesContent decides whether a native 200 counts as the model
+// answering, which is what clears its gone-strike streak in the proxy. The
+// distinction that matters is a nonempty body carrying an empty content array:
+// an aggregator in front of a retired model returns exactly that between its
+// refusals, and crediting it would stop the streak ever reaching three
+// consecutive strikes.
+func TestResponseCarriesContent(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{"text block", `{"id":"m","type":"message","content":[{"type":"text","text":"hi"}]}`, true},
+		// Any block type is the model producing something; the vocabulary is
+		// Anthropic's to extend, so the blocks are deliberately not decoded.
+		{"tool_use block", `{"id":"m","type":"message","content":[{"type":"tool_use","id":"toolu_1","name":"f"}]}`, true},
+		{"unknown block type still counts", `{"id":"m","type":"message","content":[{"type":"something_new"}]}`, true},
+		{"empty content array", `{"id":"m","type":"message","content":[]}`, false},
+		{"content absent", `{"id":"m","type":"message","usage":{"output_tokens":3}}`, false},
+		{"content null", `{"id":"m","type":"message","content":null}`, false},
+		{"not json", `not json`, false},
+		{"empty body", ``, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ResponseCarriesContent([]byte(tt.body)); got != tt.want {
+				t.Errorf("ResponseCarriesContent(%s) = %v, want %v", tt.body, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestStreamTranslator_ToolWithoutID_AndIdempotentFinish(t *testing.T) {
 	tr := NewStreamTranslator("msg_t", "m")
 	// A tool-call fragment with no id forces id synthesis; arguments stream as

--- a/internal/api/discovery_diff.go
+++ b/internal/api/discovery_diff.go
@@ -145,18 +145,19 @@ type DiscoveryDiff struct {
 	FailoverDisabledGroups []failover.DisabledGroupInfo `json:"failover_disabled_groups,omitempty"`
 }
 
-// ModelSnapshot captures a model's pre-scan state — enabled flags plus the
-// pricing/context fields compared to detect metadata changes. The type is
+// ModelSnapshot captures a model's pre-scan state — whether it was routable,
+// plus the pricing/context fields compared to detect metadata changes. Why it
+// carries no disabled_manually or auto_retired_at: what the scan did about
+// either is read off the row Upsert returned, not re-derived here. The type is
 // exported so the scheduled discovery loop (package main) can hold the snapshot
 // returned by SnapshotProviderModels and pass it to BuildDiscoveryDiff; its
 // fields stay package-private.
 type ModelSnapshot struct {
-	enabled          bool
-	disabledManually bool
-	inputPrice       *float64
-	inputPriceCache  *float64
-	outputPrice      *float64
-	contextLength    *int
+	enabled         bool
+	inputPrice      *float64
+	inputPriceCache *float64
+	outputPrice     *float64
+	contextLength   *int
 }
 
 // SnapshotProviderModels maps model_id to its pre-scan state for one provider.
@@ -168,22 +169,30 @@ func SnapshotProviderModels(ctx context.Context, repo *model.Repository, provide
 	snap := make(map[string]ModelSnapshot, len(existing))
 	for _, m := range existing {
 		snap[m.ModelID] = ModelSnapshot{
-			enabled:          m.Enabled,
-			disabledManually: m.DisabledManually,
-			inputPrice:       m.InputPricePerMillion,
-			inputPriceCache:  m.InputPricePerMillionCacheHit,
-			outputPrice:      m.OutputPricePerMillion,
-			contextLength:    m.ContextLength,
+			enabled:         m.Enabled,
+			inputPrice:      m.InputPricePerMillion,
+			inputPriceCache: m.InputPricePerMillionCacheHit,
+			outputPrice:     m.OutputPricePerMillion,
+			contextLength:   m.ContextLength,
 		}
 	}
 	return snap, nil
 }
 
 // BuildDiscoveryDiff classifies one provider scan against its before-snapshot:
-// upserted models absent from the snapshot are new; snapshot models that were
-// discovery-disabled (not manually — Upsert never re-enables those) count as
-// reappeared; an unchanged-membership model whose pricing/context fields moved
-// is an update; disabledRefs are the models this scan just disabled.
+// upserted models absent from the snapshot are new; a snapshot model the scan
+// actually brought back counts as reappeared; an unchanged-membership model
+// whose pricing/context fields moved is an update; disabledRefs are the models
+// this scan just disabled.
+//
+// The re-enable is read off the row Upsert returned rather than re-derived from
+// the conditions Upsert applies. Those conditions have grown — a model the
+// operator disabled by hand stays off, and so does one the proxy retired from
+// traffic (auto_retired_at, migration 063) — and a copy of them here drifted
+// from the SQL and reported a revival that never happened. An auto-retired model
+// is the case that made it permanent rather than occasional: it never left the
+// listing, so it is sighted on every single scan, and every scan claimed to have
+// re-enabled it while the write correctly declined to.
 func BuildDiscoveryDiff(snapshot map[string]ModelSnapshot, upserted []*model.Model, disabledRefs []model.DisabledModelRef) *DiscoveryDiff {
 	diff := &DiscoveryDiff{}
 	for _, m := range upserted {
@@ -191,13 +200,15 @@ func BuildDiscoveryDiff(snapshot map[string]ModelSnapshot, upserted []*model.Mod
 		switch {
 		case !ok:
 			diff.Added = append(diff.Added, ModelChange{ModelID: m.ModelID, Reason: changeReasonNewModel})
-		case !prev.enabled && !prev.disabledManually:
+		case !m.Enabled:
+			// Still off after the sighting, so the sighting changed nothing worth
+			// reporting. Metadata-change detection is skipped for the same reason
+			// it is skipped for any disabled model: a hidden model's price and
+			// context churn must not raise the discovery-changes badge. (It is
+			// still upserted, so the values stay current for whenever it comes
+			// back.)
+		case !prev.enabled:
 			diff.Reenabled = append(diff.Reenabled, ModelChange{ModelID: m.ModelID, Reason: changeReasonReappeared})
-		case prev.disabledManually:
-			// The user has manually disabled this model, so skip metadata-change
-			// detection: a hidden model's price/context churn should not raise the
-			// discovery-changes badge. (It is still upserted so the value stays
-			// current if the user re-enables it.)
 		default:
 			if changes := diffModelFields(prev, m); len(changes) > 0 {
 				diff.Updated = append(diff.Updated, ModelUpdate{ModelID: m.ModelID, Changes: changes})

--- a/internal/api/discovery_diff_test.go
+++ b/internal/api/discovery_diff_test.go
@@ -38,17 +38,29 @@ func TestBuildDiscoveryDiff(t *testing.T) {
 		{
 			name: "reappeared model (discovery-disabled before)",
 			snapshot: map[string]ModelSnapshot{
-				"model-back": {enabled: false, disabledManually: false},
+				"model-back": {enabled: false},
 			},
 			upserted:      models("model-back"),
 			wantReenabled: []string{"model-back"},
 		},
 		{
-			name: "manually disabled model stays excluded",
+			// A sighting Upsert declined to act on. Both causes land here and
+			// neither is distinguishable from a discovery-disabled model in the
+			// snapshot alone — enabled=false either way — which is the whole
+			// reason the classification reads the returned row instead:
+			//
+			//   - the operator disabled it by hand (disabled_manually)
+			//   - the proxy retired it from traffic (auto_retired_at, 063)
+			//
+			// The second is why this must be right rather than merely tidy: a
+			// retired model never leaves the listing, so it is sighted on EVERY
+			// scan, and classifying it from the snapshot reported a revival that
+			// never happened forever, keeping the discovery-changes badge lit.
+			name: "a sighting that did not re-enable is not a change",
 			snapshot: map[string]ModelSnapshot{
-				"model-manual": {enabled: false, disabledManually: true},
+				"model-still-off": {enabled: false},
 			},
-			upserted: models("model-manual"),
+			upserted: disabledModels("model-still-off"),
 		},
 		{
 			name: "already enabled model is no change",
@@ -69,7 +81,7 @@ func TestBuildDiscoveryDiff(t *testing.T) {
 			name: "mixed scan",
 			snapshot: map[string]ModelSnapshot{
 				"model-kept": {enabled: true},
-				"model-back": {enabled: false, disabledManually: false},
+				"model-back": {enabled: false},
 				"model-gone": {enabled: true},
 			},
 			upserted: models("model-kept", "model-back", "model-new"),
@@ -107,13 +119,29 @@ func TestBuildDiscoveryDiff(t *testing.T) {
 	}
 }
 
-// models builds bare *model.Model values carrying only a ModelID, for the
+// models builds the rows Upsert returns for a routable sighting, for the
 // membership-classification cases (no pricing/context fields, so no metadata
 // updates are detected).
+//
+// Enabled is set because these stand in for what Upsert RETURNS, not for what
+// discovery sent it: the classification reads the post-write state off that row.
+// Leaving it at the zero value would describe a model the write left disabled.
 func models(ids ...string) []*model.Model {
 	out := make([]*model.Model, len(ids))
 	for i, id := range ids {
-		out[i] = &model.Model{ModelID: id}
+		out[i] = &model.Model{ModelID: id, Enabled: true}
+	}
+	return out
+}
+
+// disabledModels builds the rows Upsert returns for a sighting it declined to
+// re-enable: a model the operator disabled by hand, or one the proxy retired
+// from traffic (auto_retired_at). Both are still upserted on every scan, and
+// both come back with enabled=false.
+func disabledModels(ids ...string) []*model.Model {
+	out := make([]*model.Model, len(ids))
+	for i, id := range ids {
+		out[i] = &model.Model{ModelID: id, Enabled: false}
 	}
 	return out
 }
@@ -133,7 +161,7 @@ func TestBuildDiscoveryDiff_MetadataChanges(t *testing.T) {
 			name: "live input price changed",
 			prev: ModelSnapshot{enabled: true, inputPrice: new(float64(1))},
 			model: &model.Model{
-				ModelID: "m", InputPricePerMillion: new(float64(2)),
+				ModelID: "m", Enabled: true, InputPricePerMillion: new(float64(2)),
 				LiveMeta: model.LiveMetaFields{InputPrice: true},
 			},
 			wantChanges: []FieldChange{
@@ -147,7 +175,7 @@ func TestBuildDiscoveryDiff_MetadataChanges(t *testing.T) {
 			// flood the modal with phantom price flips.
 			name:        "non-live value change is not reported",
 			prev:        ModelSnapshot{enabled: true, inputPrice: new(float64(1))},
-			model:       &model.Model{ModelID: "m", InputPricePerMillion: new(float64(2))},
+			model:       &model.Model{ModelID: "m", Enabled: true, InputPricePerMillion: new(float64(2))},
 			wantChanges: nil,
 		},
 		{
@@ -155,7 +183,7 @@ func TestBuildDiscoveryDiff_MetadataChanges(t *testing.T) {
 			// Upsert fills the gap, so it is a genuine new value.
 			name:  "context length set from unset (non-live fill)",
 			prev:  ModelSnapshot{enabled: true},
-			model: &model.Model{ModelID: "m", ContextLength: new(8192)},
+			model: &model.Model{ModelID: "m", Enabled: true, ContextLength: new(8192)},
 			wantChanges: []FieldChange{
 				{Field: changeFieldContextLength, Old: nil, New: new(float64(8192))},
 			},
@@ -165,13 +193,13 @@ func TestBuildDiscoveryDiff_MetadataChanges(t *testing.T) {
 			// preserves the stored value, so the diff stays quiet.
 			name:        "scan omits a value — preserved, not reported",
 			prev:        ModelSnapshot{enabled: true, outputPrice: new(float64(5))},
-			model:       &model.Model{ModelID: "m"},
+			model:       &model.Model{ModelID: "m", Enabled: true},
 			wantChanges: nil,
 		},
 		{
 			name:  "value gained from unset",
 			prev:  ModelSnapshot{enabled: true},
-			model: &model.Model{ModelID: "m", OutputPricePerMillion: new(float64(3))},
+			model: &model.Model{ModelID: "m", Enabled: true, OutputPricePerMillion: new(float64(3))},
 			wantChanges: []FieldChange{
 				{Field: changeFieldOutputPrice, Old: nil, New: new(float64(3))},
 			},
@@ -185,6 +213,7 @@ func TestBuildDiscoveryDiff_MetadataChanges(t *testing.T) {
 			},
 			model: &model.Model{
 				ModelID:                      "m",
+				Enabled:                      true,
 				InputPricePerMillionCacheHit: new(0.25),
 				ContextLength:                new(262144),
 				LiveMeta:                     model.LiveMetaFields{InputPriceCache: true, ContextLength: true},
@@ -199,7 +228,7 @@ func TestBuildDiscoveryDiff_MetadataChanges(t *testing.T) {
 			// alone produces no update.
 			name: "max output tokens change is ignored",
 			prev: ModelSnapshot{enabled: true},
-			model: &model.Model{ModelID: "m", MaxOutputTokens: new(8192),
+			model: &model.Model{ModelID: "m", Enabled: true, MaxOutputTokens: new(8192),
 				LiveMeta: model.LiveMetaFields{MaxOutputTokens: true}},
 			wantChanges: nil,
 		},
@@ -208,7 +237,7 @@ func TestBuildDiscoveryDiff_MetadataChanges(t *testing.T) {
 			// even for a live field.
 			name: "context length unit difference is ignored",
 			prev: ModelSnapshot{enabled: true, contextLength: new(262144)},
-			model: &model.Model{ModelID: "m", ContextLength: new(262000),
+			model: &model.Model{ModelID: "m", Enabled: true, ContextLength: new(262000),
 				LiveMeta: model.LiveMetaFields{ContextLength: true}},
 			wantChanges: nil,
 		},
@@ -217,7 +246,7 @@ func TestBuildDiscoveryDiff_MetadataChanges(t *testing.T) {
 			// past tolerance.
 			name: "real live context length jump is reported",
 			prev: ModelSnapshot{enabled: true, contextLength: new(200000)},
-			model: &model.Model{ModelID: "m", ContextLength: new(256000),
+			model: &model.Model{ModelID: "m", Enabled: true, ContextLength: new(256000),
 				LiveMeta: model.LiveMetaFields{ContextLength: true}},
 			wantChanges: []FieldChange{
 				{Field: changeFieldContextLength, Old: new(float64(200000)), New: new(float64(256000))},
@@ -227,30 +256,30 @@ func TestBuildDiscoveryDiff_MetadataChanges(t *testing.T) {
 			// Float32 storage jitter on a live price must not register.
 			name: "price float32 jitter is ignored",
 			prev: ModelSnapshot{enabled: true, inputPrice: new(float64(float32(0.28)))},
-			model: &model.Model{ModelID: "m", InputPricePerMillion: new(0.28),
+			model: &model.Model{ModelID: "m", Enabled: true, InputPricePerMillion: new(0.28),
 				LiveMeta: model.LiveMetaFields{InputPrice: true}},
 			wantChanges: nil,
 		},
 		{
 			name: "unchanged live values produce no update",
 			prev: ModelSnapshot{enabled: true, inputPrice: new(float64(1)), contextLength: new(8192)},
-			model: &model.Model{ModelID: "m", InputPricePerMillion: new(float64(1)), ContextLength: new(8192),
+			model: &model.Model{ModelID: "m", Enabled: true, InputPricePerMillion: new(float64(1)), ContextLength: new(8192),
 				LiveMeta: model.LiveMetaFields{InputPrice: true, ContextLength: true}},
 			wantChanges: nil,
 		},
 		{
 			name:        "both unset is not a change",
 			prev:        ModelSnapshot{enabled: true},
-			model:       &model.Model{ModelID: "m"},
+			model:       &model.Model{ModelID: "m", Enabled: true},
 			wantChanges: nil,
 		},
 		{
 			// A model the user has manually disabled is skipped entirely: even a
 			// genuine live price change on a hidden model must not raise the badge.
 			name: "manually disabled model is not reported",
-			prev: ModelSnapshot{enabled: false, disabledManually: true, inputPrice: new(float64(1))},
+			prev: ModelSnapshot{enabled: false, inputPrice: new(float64(1))},
 			model: &model.Model{
-				ModelID: "m", InputPricePerMillion: new(float64(2)),
+				ModelID: "m", Enabled: false, InputPricePerMillion: new(float64(2)),
 				LiveMeta: model.LiveMetaFields{InputPrice: true},
 			},
 			wantChanges: nil,
@@ -289,11 +318,11 @@ func TestBuildDiscoveryDiff_NewAndReenabledSkipMetadata(t *testing.T) {
 	// A brand-new or reappearing model is classified by membership only; its
 	// field values are not also diffed (no snapshot baseline to compare).
 	snapshot := map[string]ModelSnapshot{
-		"back": {enabled: false, disabledManually: false, inputPrice: new(float64(1))},
+		"back": {enabled: false, inputPrice: new(float64(1))},
 	}
 	upserted := []*model.Model{
-		{ModelID: "new", InputPricePerMillion: new(float64(9))},
-		{ModelID: "back", InputPricePerMillion: new(float64(2))},
+		{ModelID: "new", Enabled: true, InputPricePerMillion: new(float64(9))},
+		{ModelID: "back", Enabled: true, InputPricePerMillion: new(float64(2))},
 	}
 	diff := BuildDiscoveryDiff(snapshot, upserted, nil)
 

--- a/internal/proxy/anthropic_native.go
+++ b/internal/proxy/anthropic_native.go
@@ -79,12 +79,13 @@ func (h *Handler) handleNativeNonStreaming(w http.ResponseWriter, r *http.Reques
 	logData.tokensCompletion = outputTokens
 	logData.failoverAttempt = attempt
 	logData.state = "completed"
-	// The same signal the OpenAI-shaped path records, at the same bar the
-	// pass-through commit points use: bytes arrived from the provider. It is
-	// what clears the model's gone-strike streak (see attemptCandidate), and it
-	// is deliberately not a parse of Anthropic's content array — a body this
-	// path forwards verbatim is not one it should be judging the shape of.
-	logData.deliveredContent = len(body) > 0
+	// What clears the model's gone-strike streak (see attemptCandidate), so the
+	// bar is content and not bytes: `200 {"content":[]}` is what an aggregator in
+	// front of a retired model returns between its refusals, and crediting it
+	// would stop the streak ever reaching three consecutive strikes. Tokens
+	// corroborate, for a provider that answers without reporting usage. Same
+	// judgement the OpenAI-shaped path makes with chatAnswerCarriesContent.
+	logData.deliveredContent = outputTokens > 0 || anthropic.ResponseCarriesContent(body)
 	h.updateRequestLog(logData, updateLogOption{skipWaitForInsert: true})
 
 	if st.vkHash != "" {

--- a/internal/proxy/anthropic_native.go
+++ b/internal/proxy/anthropic_native.go
@@ -79,6 +79,12 @@ func (h *Handler) handleNativeNonStreaming(w http.ResponseWriter, r *http.Reques
 	logData.tokensCompletion = outputTokens
 	logData.failoverAttempt = attempt
 	logData.state = "completed"
+	// The same signal the OpenAI-shaped path records, at the same bar the
+	// pass-through commit points use: bytes arrived from the provider. It is
+	// what clears the model's gone-strike streak (see attemptCandidate), and it
+	// is deliberately not a parse of Anthropic's content array — a body this
+	// path forwards verbatim is not one it should be judging the shape of.
+	logData.deliveredContent = len(body) > 0
 	h.updateRequestLog(logData, updateLogOption{skipWaitForInsert: true})
 
 	if st.vkHash != "" {

--- a/internal/proxy/anthropic_native_test.go
+++ b/internal/proxy/anthropic_native_test.go
@@ -90,6 +90,64 @@ func TestHandleNativeNonStreaming(t *testing.T) {
 	}
 }
 
+// deliveredContent is what clears a model's gone-strike streak, so a native 200
+// is judged on content and not on bytes. `200 {"content":[]}` is what an
+// aggregator in front of a retired model returns between its refusals, and
+// crediting it would stop a streak ever reaching three CONSECUTIVE strikes — the
+// model would then never be nominated and never probed.
+func TestHandleNativeNonStreaming_JudgesContentNotBytes(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{"content block", `{"id":"m","type":"message","content":[{"type":"text","text":"hi"}],"usage":{"input_tokens":9,"output_tokens":3}}`, true},
+		// No block came back but the provider reported output: a model that
+		// spent its whole budget on reasoning still answered.
+		{"tokens without a block", `{"id":"m","type":"message","content":[],"usage":{"input_tokens":9,"output_tokens":3}}`, true},
+		{"empty message", `{"id":"m","type":"message","content":[],"usage":{"input_tokens":9,"output_tokens":0}}`, false},
+		// Nonempty bytes carrying nothing at all, which the byte-counting
+		// version credited as the model answering.
+		{"not a message", `{}`, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newIntegrationHandler()
+			t.Cleanup(func() { stopUnitHandler(h) })
+
+			resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(tc.body)), Header: make(http.Header)}
+			rec := httptest.NewRecorder()
+			native := true
+			aw := newAnthropicResponseWriter(rec, "msg_j", "m")
+			aw.bindNativeFlag(&native)
+			req := httptest.NewRequest("POST", "/v1/messages", http.NoBody)
+			logData := &requestLogData{
+				id:             uuid.New().String(),
+				modelID:        "claude-x",
+				virtualKeyName: "test-key",
+				virtualKeyID:   "00000000-0000-0000-0000-000000000001",
+				state:          "streaming",
+			}
+			st := &requestState{startTime: time.Now(), logData: logData}
+
+			if got := h.handleNativeNonStreaming(aw, req, st, resp, 1, 10.0); got != outcomeServed {
+				t.Fatalf("outcome = %v, want outcomeServed", got)
+			}
+			aw.Finalize()
+
+			if logData.deliveredContent != tc.want {
+				t.Errorf("deliveredContent = %v, want %v", logData.deliveredContent, tc.want)
+			}
+			// The body still reaches the client verbatim whatever the verdict:
+			// this judgement is about the retirement streak, not about what is
+			// forwarded.
+			if rec.Body.String() != tc.body {
+				t.Errorf("body = %s, want %s", rec.Body.String(), tc.body)
+			}
+		})
+	}
+}
+
 // errorReadCloser fails on Read, simulating an upstream body that drops
 // mid-transfer after a 200 header.
 type errorReadCloser struct{}

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -67,12 +67,8 @@ type Handler struct {
 	// goneProbeSlots bounds how many pre-retirement probes may be in flight
 	// against one provider at once, keyed by provider UUID. Value: a
 	// chan struct{} of goneProbeMaxConcurrent capacity, used as a non-blocking
-	// semaphore (see acquireProbeSlot).
-	//
-	// Per gateway instance rather than per process, exactly like goneStrikes
-	// beside it: the cap describes what THIS gateway is willing to aim at a
-	// provider, and each HA member reaches its own conclusions from its own
-	// traffic.
+	// semaphore (see acquireProbeSlot). Per gateway instance, like goneStrikes
+	// beside it: the cap describes what THIS gateway will aim at a provider.
 	goneProbeSlots sync.Map
 	// responsesRequiredCache remembers models whose upstream 400'd
 	// tools+reasoning over chat-completions and demanded /v1/responses (OpenAI

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -64,6 +64,16 @@ type Handler struct {
 	// refusals in one streak may be, and the tombstone a success uses to stand
 	// down a disable that has been decided but not yet written.
 	goneStrikes sync.Map
+	// goneProbeSlots bounds how many pre-retirement probes may be in flight
+	// against one provider at once, keyed by provider UUID. Value: a
+	// chan struct{} of goneProbeMaxConcurrent capacity, used as a non-blocking
+	// semaphore (see acquireProbeSlot).
+	//
+	// Per gateway instance rather than per process, exactly like goneStrikes
+	// beside it: the cap describes what THIS gateway is willing to aim at a
+	// provider, and each HA member reaches its own conclusions from its own
+	// traffic.
+	goneProbeSlots sync.Map
 	// responsesRequiredCache remembers models whose upstream 400'd
 	// tools+reasoning over chat-completions and demanded /v1/responses (OpenAI
 	// gpt-5.4+/gpt-5.6 families), keyed by "providerType:modelID". Once a model

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -53,13 +53,16 @@ type Handler struct {
 	// "providerType:modelID". Value: map[string]string of old->new param names.
 	paramRenameCache sync.Map
 	// goneStrikes counts consecutive KindProviderModelGone responses per model
-	// UUID, so a model the provider has retired is disabled after
-	// goneStrikeThreshold refusals. Deliberately in-memory and per-instance;
-	// see noteModelGone for why it is not persisted.
+	// UUID, so a model the provider has retired is probed and then disabled
+	// after goneStrikeThreshold refusals. Deliberately in-memory and
+	// per-instance; see noteModelGone for why it is not persisted.
 	//
-	// Value: *atomic.Int64, not a plain int. A retired model is precisely the
-	// one taking concurrent refusals, so the increment has to be atomic or
-	// racing strikes overwrite each other and the streak never lands.
+	// Value: *goneStreak, not a plain int. A retired model is precisely the one
+	// taking concurrent refusals, so the increment has to be atomic or racing
+	// strikes overwrite each other and the streak never lands. The struct also
+	// carries the time of the last strike, which bounds how far apart the
+	// refusals in one streak may be, and the tombstone a success uses to stand
+	// down a disable that has been decided but not yet written.
 	goneStrikes sync.Map
 	// responsesRequiredCache remembers models whose upstream 400'd
 	// tools+reasoning over chat-completions and demanded /v1/responses (OpenAI

--- a/internal/proxy/hedging.go
+++ b/internal/proxy/hedging.go
@@ -245,7 +245,20 @@ func (h *Handler) probeStreamingCandidate(ctx context.Context, st *requestState,
 		// Any non-200 drops this candidate. The orchestrator owns the terminal
 		// write if every candidate fails; drain so the connection can be reused,
 		// keeping only as much as the two readers below can use.
-		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, failoverErrorClassifyCap))
+		//
+		// The two readers want different amounts, so the cap follows the status.
+		// classifyUpstreamError never sees past SanitizeLogBody's 10 000 bytes,
+		// which is what failoverErrorClassifyCap is sized against; but a 400 is
+		// also handed to learnResponsesRequirement, which json.Unmarshals it, and
+		// a document cut short does not parse at all. Capping a 400 at 16 KiB
+		// would silently stop teaching the /v1/responses requirement, and the
+		// sequential path that learns the same thing reads unbounded — the two
+		// must not disagree about the same learner.
+		readCap := int64(failoverErrorClassifyCap)
+		if resp.StatusCode == http.StatusBadRequest {
+			readCap = responsesLearnBodyCap
+		}
+		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, readCap))
 		_, _ = io.Copy(io.Discard, resp.Body)
 		_ = resp.Body.Close()
 		if resp.StatusCode == http.StatusBadRequest {

--- a/internal/proxy/hedging.go
+++ b/internal/proxy/hedging.go
@@ -91,6 +91,15 @@ func (h *Handler) runHedgedStreaming(w http.ResponseWriter, r *http.Request, st 
 		// probe a private throwaway logData so they never overlap. (A plain
 		// *st.logData copy is impossible: requestLogData embeds a sync.WaitGroup.
 		// The orchestrator keeps using the real st for all terminal logging.)
+		//
+		// Constraint on future edits: this throwaway must never reach
+		// noteStreamOutcome. It carries no endpointType, and an empty endpoint
+		// family switches auto-retirement off silently — noteModelGone's family
+		// gate rejects it BEFORE recording a strike, and says so only at Debug, so
+		// hedged streams would quietly stop retiring dead models with nothing in
+		// the logs to show for it. serveHedgeWinner deliberately re-binds logData
+		// to the real, ingest-stamped st.logData before it judges the model; keep
+		// it that way.
 		snap.logData = &requestLogData{modelID: st.logData.modelID, providerName: candidates[idx].provider.Name}
 		go func() {
 			results <- probeOne(ctx, &snap, candidates[idx], idx, ttftTimeout, stallTimeout)

--- a/internal/proxy/hedging.go
+++ b/internal/proxy/hedging.go
@@ -93,21 +93,19 @@ func (h *Handler) runHedgedStreaming(w http.ResponseWriter, r *http.Request, st 
 		// *st.logData copy is impossible: requestLogData embeds a sync.WaitGroup.
 		// The orchestrator keeps using the real st for all terminal logging.)
 		//
-		// endpointType is copied across and is load-bearing, not decoration: a
-		// losing candidate's refusal is classified against this throwaway (see
+		// endpointType is load-bearing, not decoration: a losing candidate's
+		// refusal is classified against this throwaway (see
 		// probeStreamingCandidate), and an empty endpoint family switches
 		// auto-retirement off SILENTLY — noteModelGone's family gate rejects it
-		// before recording a strike and says so only at Debug, so hedged streams
-		// would quietly stop retiring dead models with nothing in the logs to
-		// show for it. It is safe to copy where the rest is not: ingest stamps it
-		// once and nothing writes it afterwards, so it cannot race
-		// serveHedgeWinner the way providerName and the timings would.
+		// before recording a strike and says so only at Debug. It is safe to copy
+		// where the rest is not, because ingest stamps it once and nothing writes
+		// it afterwards, so it cannot race serveHedgeWinner the way providerName
+		// and the timings would.
 		//
-		// Constraint on future edits: this throwaway must still never reach
+		// Constraint on future edits: this throwaway must never reach
 		// noteStreamOutcome, which judges a finished stream from fields the probe
 		// never fills in (upstreamKind, the content flag). serveHedgeWinner
-		// deliberately re-binds logData to the real st.logData before it judges
-		// the model; keep it that way.
+		// re-binds logData to the real st.logData before judging the model.
 		snap.logData = &requestLogData{modelID: st.logData.modelID, providerName: candidates[idx].provider.Name, endpointType: st.logData.endpointType}
 		go func() {
 			results <- probeOne(ctx, &snap, candidates[idx], idx, ttftTimeout, stallTimeout)
@@ -246,14 +244,11 @@ func (h *Handler) probeStreamingCandidate(ctx context.Context, st *requestState,
 		// write if every candidate fails; drain so the connection can be reused,
 		// keeping only as much as the two readers below can use.
 		//
-		// The two readers want different amounts, so the cap follows the status.
-		// classifyUpstreamError never sees past SanitizeLogBody's 10 000 bytes,
-		// which is what failoverErrorClassifyCap is sized against; but a 400 is
-		// also handed to learnResponsesRequirement, which json.Unmarshals it, and
-		// a document cut short does not parse at all. Capping a 400 at 16 KiB
-		// would silently stop teaching the /v1/responses requirement, and the
-		// sequential path that learns the same thing reads unbounded — the two
-		// must not disagree about the same learner.
+		// The cap follows the status because the two readers want different
+		// amounts. classifyUpstreamError never sees past SanitizeLogBody's 10 000
+		// bytes, which failoverErrorClassifyCap is sized against; but a 400 also
+		// goes to learnResponsesRequirement, which json.Unmarshals it, and a
+		// document cut short does not parse at all.
 		readCap := int64(failoverErrorClassifyCap)
 		if resp.StatusCode == http.StatusBadRequest {
 			readCap = responsesLearnBodyCap
@@ -268,13 +263,11 @@ func (h *Handler) probeStreamingCandidate(ctx context.Context, st *requestState,
 			// subsequent request — hedged or sequential — routes preemptively.
 			h.learnResponsesRequirement(st, candidate, providerType, errBody)
 		}
-		// The third and last place a retired model's refusal was being thrown
-		// away. A hedged race drops every candidate but the winner here, so
-		// without this a dead model in a hedged group accrued strikes only on
-		// the runs it happened to win — which is to say almost never, since a
-		// model answering 404 loses the TTFT contest to anything that works.
-		// Same classification the sequential and pass-through loops do, on a
-		// body that is being discarded either way.
+		// A hedged race drops every candidate but the winner here, so without
+		// this a dead model in a hedged group accrued strikes only on the runs it
+		// happened to win — almost never, since a model answering 404 loses the
+		// TTFT contest to anything that works. Same classification the sequential
+		// and pass-through loops do, on a body being discarded either way.
 		if kind, _ := classifyUpstreamError(resp.StatusCode, util.SanitizeLogBody(string(errBody), 10000), candidate.model.ModelID); kind == KindProviderModelGone {
 			h.noteModelGone(candidate, st.logData.endpointType)
 		}

--- a/internal/proxy/hedging.go
+++ b/internal/proxy/hedging.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/gemini"
 	"github.com/hugalafutro/model-hotel/internal/openairesponses"
 	"github.com/hugalafutro/model-hotel/internal/provider"
+	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
 // hedgeResult is the outcome of probing one candidate in a hedged streaming race.
@@ -92,15 +93,22 @@ func (h *Handler) runHedgedStreaming(w http.ResponseWriter, r *http.Request, st 
 		// *st.logData copy is impossible: requestLogData embeds a sync.WaitGroup.
 		// The orchestrator keeps using the real st for all terminal logging.)
 		//
-		// Constraint on future edits: this throwaway must never reach
-		// noteStreamOutcome. It carries no endpointType, and an empty endpoint
-		// family switches auto-retirement off silently — noteModelGone's family
-		// gate rejects it BEFORE recording a strike, and says so only at Debug, so
-		// hedged streams would quietly stop retiring dead models with nothing in
-		// the logs to show for it. serveHedgeWinner deliberately re-binds logData
-		// to the real, ingest-stamped st.logData before it judges the model; keep
-		// it that way.
-		snap.logData = &requestLogData{modelID: st.logData.modelID, providerName: candidates[idx].provider.Name}
+		// endpointType is copied across and is load-bearing, not decoration: a
+		// losing candidate's refusal is classified against this throwaway (see
+		// probeStreamingCandidate), and an empty endpoint family switches
+		// auto-retirement off SILENTLY — noteModelGone's family gate rejects it
+		// before recording a strike and says so only at Debug, so hedged streams
+		// would quietly stop retiring dead models with nothing in the logs to
+		// show for it. It is safe to copy where the rest is not: ingest stamps it
+		// once and nothing writes it afterwards, so it cannot race
+		// serveHedgeWinner the way providerName and the timings would.
+		//
+		// Constraint on future edits: this throwaway must still never reach
+		// noteStreamOutcome, which judges a finished stream from fields the probe
+		// never fills in (upstreamKind, the content flag). serveHedgeWinner
+		// deliberately re-binds logData to the real st.logData before it judges
+		// the model; keep it that way.
+		snap.logData = &requestLogData{modelID: st.logData.modelID, providerName: candidates[idx].provider.Name, endpointType: st.logData.endpointType}
 		go func() {
 			results <- probeOne(ctx, &snap, candidates[idx], idx, ttftTimeout, stallTimeout)
 		}()
@@ -235,8 +243,10 @@ func (h *Handler) probeStreamingCandidate(ctx context.Context, st *requestState,
 
 	if resp.StatusCode != http.StatusOK {
 		// Any non-200 drops this candidate. The orchestrator owns the terminal
-		// write if every candidate fails; drain so the connection can be reused.
-		errBody, _ := io.ReadAll(resp.Body)
+		// write if every candidate fails; drain so the connection can be reused,
+		// keeping only as much as the two readers below can use.
+		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, failoverErrorClassifyCap))
+		_, _ = io.Copy(io.Discard, resp.Body)
 		_ = resp.Body.Close()
 		if resp.StatusCode == http.StatusBadRequest {
 			// A hedged probe cannot retry in-race (a second upstream round-trip
@@ -244,6 +254,16 @@ func (h *Handler) probeStreamingCandidate(ctx context.Context, st *requestState,
 			// still LEARN the /v1/responses requirement from the 400 so every
 			// subsequent request — hedged or sequential — routes preemptively.
 			h.learnResponsesRequirement(st, candidate, providerType, errBody)
+		}
+		// The third and last place a retired model's refusal was being thrown
+		// away. A hedged race drops every candidate but the winner here, so
+		// without this a dead model in a hedged group accrued strikes only on
+		// the runs it happened to win — which is to say almost never, since a
+		// model answering 404 loses the TTFT contest to anything that works.
+		// Same classification the sequential and pass-through loops do, on a
+		// body that is being discarded either way.
+		if kind, _ := classifyUpstreamError(resp.StatusCode, util.SanitizeLogBody(string(errBody), 10000), candidate.model.ModelID); kind == KindProviderModelGone {
+			h.noteModelGone(candidate, st.logData.endpointType)
 		}
 		res.reqErr = reqError{Kind: KindProviderError, Attempt: attempt, Provider: candidate.provider.Name, Detail: fmt.Sprintf("HTTP %d", resp.StatusCode)}
 		return res

--- a/internal/proxy/hedging_test.go
+++ b/internal/proxy/hedging_test.go
@@ -350,6 +350,66 @@ func TestRunHedgedStreaming_RealProbesConcurrent(t *testing.T) {
 	}
 }
 
+// TestRunHedgedStreaming_LosingCandidateStrikesTheRightFamily pins the one field
+// the orchestrator has to copy into each probe's throwaway logData.
+//
+// The probes cannot share the real logData (serveHedgeWinner writes the winner's
+// identity onto it), so each gets a private one carrying only what the probe
+// path reads. A losing candidate's refusal is now classified against that
+// throwaway, and noteModelGone's family gate rejects an empty endpointType
+// BEFORE recording a strike, at Debug and nowhere else. Drop the copy and hedged
+// streaming silently stops retiring dead models with nothing in the logs to show
+// for it, which is the failure this test exists to make loud.
+func TestRunHedgedStreaming_LosingCandidateStrikesTheRightFamily(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandler(h)
+
+	refused := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = io.WriteString(w, goneRefusalBody("gemini-2.0-flash"))
+	}))
+	defer refused.Close()
+	winner := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"x\"}}]}\n\ndata: [DONE]\n\n")
+	}))
+	defer winner.Close()
+
+	st, logData := newHedgeState(25 * time.Millisecond)
+	// What ingest stamps on every real request, and what the throwaway has to
+	// carry through to the probe.
+	logData.endpointType = endpointTypeChat
+	st.reqModel = "orig-model"
+	st.bodyBytes = []byte(`{"model":"orig-model","messages":[{"role":"user","content":"hi"}],"stream":true}`)
+
+	dead := &model.Model{ID: uuid.New(), ModelID: "gemini-2.0-flash"}
+	cands := []modelCandidate{
+		{model: dead, provider: &provider.Provider{ID: uuid.New(), Name: "retired", BaseURL: refused.URL}},
+		{model: &model.Model{ID: uuid.New(), ModelID: "m1"}, provider: &provider.Provider{ID: uuid.New(), Name: "healthy", BaseURL: winner.URL}},
+	}
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)
+	h.runHedgedStreaming(w, req, st, cands, h.probeStreamingCandidate)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected the healthy member to win, got %d", w.Code)
+	}
+	raw, ok := h.goneStrikes.Load(dead.ID)
+	if !ok {
+		t.Fatal("the refused candidate accrued no strike, so a hedged group can never retire a dead model")
+	}
+	streak, ok := raw.(*goneStreak)
+	if !ok {
+		t.Fatalf("unexpected streak type %T", raw)
+	}
+	if n := streak.count(); n != 1 {
+		t.Errorf("streak = %d, want exactly 1 strike for one refusal", n)
+	}
+}
+
 // closeTrackingBody is an io.ReadCloser that records whether Close was called.
 type closeTrackingBody struct {
 	closed bool
@@ -522,6 +582,44 @@ func TestProbeStreamingCandidate(t *testing.T) {
 		}
 		if res.resp != nil {
 			_ = res.resp.Body.Close()
+		}
+	})
+
+	t.Run("a refused model still strikes", func(t *testing.T) {
+		// The third and last path that drops a candidate's error body. A hedged
+		// race discards every loser here, so a dead model in a hedged group only
+		// ever accrued strikes on the runs it happened to WIN — and a model
+		// answering 404 loses the first-token race to anything that works. Delete
+		// this and traffic-driven retirement is silently off for every streaming
+		// failover group whenever hedging is enabled.
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = io.WriteString(w, goneRefusalBody("gemini-2.0-flash"))
+		}))
+		defer srv.Close()
+
+		st, cand := probeStateForServer(srv.URL)
+		// What the orchestrator's throwaway logData carries. An empty endpoint
+		// family drops the strike before it is recorded, which is the failure
+		// this subtest would otherwise sail past.
+		st.logData.endpointType = endpointTypeChat
+		cand.model = &model.Model{ID: uuid.New(), ModelID: "gemini-2.0-flash"}
+
+		res := h.probeStreamingCandidate(context.Background(), st, cand, 0, 5*time.Second, 30*time.Second)
+		if res.won {
+			t.Fatal("a 404 must not win")
+		}
+		raw, ok := h.goneStrikes.Load(cand.model.ID)
+		if !ok {
+			t.Fatal("a losing candidate's refusal accrued no strike")
+		}
+		streak, ok := raw.(*goneStreak)
+		if !ok {
+			t.Fatalf("unexpected streak type %T", raw)
+		}
+		if n := streak.count(); n != 1 {
+			t.Errorf("streak = %d, want exactly 1 strike for one refusal", n)
 		}
 	})
 

--- a/internal/proxy/hedging_test.go
+++ b/internal/proxy/hedging_test.go
@@ -397,7 +397,7 @@ func TestRunHedgedStreaming_LosingCandidateStrikesTheRightFamily(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected the healthy member to win, got %d", w.Code)
 	}
-	raw, ok := h.goneStrikes.Load(dead.ID)
+	raw, ok := h.goneStrikes.Load(goneStreakKey{model: dead.ID, endpoint: probeChatEndpoint})
 	if !ok {
 		t.Fatal("the refused candidate accrued no strike, so a hedged group can never retire a dead model")
 	}
@@ -610,7 +610,7 @@ func TestProbeStreamingCandidate(t *testing.T) {
 		if res.won {
 			t.Fatal("a 404 must not win")
 		}
-		raw, ok := h.goneStrikes.Load(cand.model.ID)
+		raw, ok := h.goneStrikes.Load(goneStreakKey{model: cand.model.ID, endpoint: probeChatEndpoint})
 		if !ok {
 			t.Fatal("a losing candidate's refusal accrued no strike")
 		}

--- a/internal/proxy/minimax.go
+++ b/internal/proxy/minimax.go
@@ -39,19 +39,17 @@ type miniMaxRestoredBody struct {
 // miniMaxEnvelopePossible reports whether a 200 with this content type could
 // carry a base_resp envelope, and so whether it is worth reading any of it.
 //
-// A deny-list rather than a "must say json" allow-list, and the difference is
-// the point. The types below cannot contain an envelope and must not be read:
-// SSE carries none by protocol, and the multimodal pass-through routes audio,
-// image and octet-stream answers through this function, where buffering to look
-// for a field the content type says is not there would defeat the streaming that
-// path exists to do. But a missing, empty or text/plain content type says
-// nothing about the body, and MiniMax or an intermediary returning the envelope
-// under one of those is exactly the empty-200-forwarded-as-success bug this
-// function was written to fix — an allow-list would quietly restore it.
+// A deny-list rather than a "must say json" allow-list. The types below cannot
+// contain an envelope and must not be read: SSE carries none by protocol, and
+// the multimodal pass-through routes audio, image and octet-stream answers
+// through here, where buffering to look for a field the content type says is not
+// there would defeat the streaming that path exists to do. A missing, empty or
+// text/plain content type says nothing about the body, and an intermediary
+// returning the envelope under one of those is the empty-200-forwarded-as-success
+// bug this function exists to fix — an allow-list would quietly restore it.
 //
-// Reading a little of an unlabelled body is cheap now in a way it was not: the
-// read is bounded and prepended back, so the worst case is 64 KiB held for the
-// length of one envelope check.
+// Reading a little of an unlabelled body is cheap because the read is bounded
+// and prepended back: the worst case is 64 KiB held for one envelope check.
 func miniMaxEnvelopePossible(contentType string) bool {
 	ct := strings.ToLower(strings.TrimSpace(contentType))
 	switch {
@@ -87,34 +85,30 @@ func remapMiniMaxBusinessError(providerType, providerName string, resp *http.Res
 	}
 
 	// Bounded, because an envelope is a sentence and a JSON response is not
-	// necessarily one. MiniMax returns base64 audio inside JSON and the image
+	// necessarily one: MiniMax returns base64 audio inside JSON and the image
 	// endpoints can answer with megabytes of b64_json, so reading to the end
 	// would hold all of it in memory and make TTFB wait for the last upstream
 	// byte — on a path that otherwise caps its buffering at
 	// passthroughJSONBufferCap and streams the remainder.
 	//
-	// One byte past the cap, so "the whole body is in hand" is something this
-	// can know rather than assume.
+	// One byte past the cap, so "the whole body is in hand" is something this can
+	// know rather than assume.
 	head, err := io.ReadAll(io.LimitReader(resp.Body, miniMaxEnvelopeCap+1))
 	if err != nil || len(head) > miniMaxEnvelopeCap {
 		// Either the body is bigger than any envelope, or it failed mid-read.
 		// Both are handed back as a stream: the bytes already taken, then
 		// whatever the connection does next.
 		//
-		// Prepending rather than replacing is what fixes the read error the old
-		// shape swallowed. It discarded the error and handed downstream the
-		// partial body as a complete answer — a truncated 200, which the
-		// pass-through path would then also count as the model having answered.
-		// Here the failure is still in the stream, so it surfaces where the
-		// handlers have always dealt with it.
+		// Prepending rather than replacing is what keeps a read error in the
+		// stream. Discarding it would hand downstream a partial body as a
+		// complete answer — a truncated 200, which the pass-through path would
+		// then count as the model having answered.
 		rest := resp.Body
 		resp.Body = miniMaxRestoredBody{Reader: io.MultiReader(bytes.NewReader(head), rest), Closer: rest}
 		return resp
 	}
 
-	// The whole body fits, so it is buffered and the upstream one is closed —
-	// which is what this function has always done, and all it ever needed to do
-	// for the chat path that has JSON answers of ordinary size.
+	// The whole body fits, so it is buffered and the upstream one is closed.
 	body := head
 	_ = resp.Body.Close()
 	resp.Body = io.NopCloser(bytes.NewReader(body))

--- a/internal/proxy/minimax.go
+++ b/internal/proxy/minimax.go
@@ -23,6 +23,19 @@ var miniMaxStatusToHTTP = map[int]int{
 	1004: http.StatusUnauthorized,
 }
 
+// miniMaxEnvelopeCap bounds how much of a 200 body is read looking for the
+// base_resp envelope. The envelope is a status code and a message; a body that
+// has not produced one in 64 KiB is an answer rather than a refusal, and is left
+// to stream.
+const miniMaxEnvelopeCap = 64 << 10
+
+// miniMaxRestoredBody is the body handed back after the envelope check: the
+// bytes already read, then the rest of the upstream stream, closing the real one.
+type miniMaxRestoredBody struct {
+	io.Reader
+	io.Closer
+}
+
 // remapMiniMaxBusinessError converts a MiniMax "HTTP 200 base_resp error"
 // response into one carrying the equivalent HTTP status, so the failover,
 // circuit-breaker, and error-forwarding paths — all keyed on status codes — see
@@ -41,15 +54,47 @@ func remapMiniMaxBusinessError(providerType, providerName string, resp *http.Res
 		return resp
 	}
 	// Streaming responses carry no base_resp envelope; never consume their body.
-	if strings.Contains(resp.Header.Get("Content-Type"), "text/event-stream") {
+	// Neither does anything that is not JSON — this function reads bodies, and
+	// the multimodal pass-through routes audio and image responses through it.
+	// Buffering an audio/mpeg answer to look for a field its content type says
+	// cannot be there would defeat the streaming that path exists to do.
+	contentType := resp.Header.Get("Content-Type")
+	if strings.Contains(contentType, "text/event-stream") || !strings.Contains(contentType, "json") {
 		return resp
 	}
-	body, err := io.ReadAll(resp.Body)
+
+	// Bounded, because an envelope is a sentence and a JSON response is not
+	// necessarily one. MiniMax returns base64 audio inside JSON and the image
+	// endpoints can answer with megabytes of b64_json, so reading to the end
+	// would hold all of it in memory and make TTFB wait for the last upstream
+	// byte — on a path that otherwise caps its buffering at
+	// passthroughJSONBufferCap and streams the remainder.
+	//
+	// One byte past the cap, so "the whole body is in hand" is something this
+	// can know rather than assume.
+	head, err := io.ReadAll(io.LimitReader(resp.Body, miniMaxEnvelopeCap+1))
+	if err != nil || len(head) > miniMaxEnvelopeCap {
+		// Either the body is bigger than any envelope, or it failed mid-read.
+		// Both are handed back as a stream: the bytes already taken, then
+		// whatever the connection does next.
+		//
+		// Prepending rather than replacing is what fixes the read error the old
+		// shape swallowed. It discarded the error and handed downstream the
+		// partial body as a complete answer — a truncated 200, which the
+		// pass-through path would then also count as the model having answered.
+		// Here the failure is still in the stream, so it surfaces where the
+		// handlers have always dealt with it.
+		rest := resp.Body
+		resp.Body = miniMaxRestoredBody{Reader: io.MultiReader(bytes.NewReader(head), rest), Closer: rest}
+		return resp
+	}
+
+	// The whole body fits, so it is buffered and the upstream one is closed —
+	// which is what this function has always done, and all it ever needed to do
+	// for the chat path that has JSON answers of ordinary size.
+	body := head
 	_ = resp.Body.Close()
 	resp.Body = io.NopCloser(bytes.NewReader(body))
-	if err != nil {
-		return resp
-	}
 	var envelope struct {
 		BaseResp *struct {
 			StatusCode int    `json:"status_code"`

--- a/internal/proxy/minimax.go
+++ b/internal/proxy/minimax.go
@@ -36,6 +36,35 @@ type miniMaxRestoredBody struct {
 	io.Closer
 }
 
+// miniMaxEnvelopePossible reports whether a 200 with this content type could
+// carry a base_resp envelope, and so whether it is worth reading any of it.
+//
+// A deny-list rather than a "must say json" allow-list, and the difference is
+// the point. The types below cannot contain an envelope and must not be read:
+// SSE carries none by protocol, and the multimodal pass-through routes audio,
+// image and octet-stream answers through this function, where buffering to look
+// for a field the content type says is not there would defeat the streaming that
+// path exists to do. But a missing, empty or text/plain content type says
+// nothing about the body, and MiniMax or an intermediary returning the envelope
+// under one of those is exactly the empty-200-forwarded-as-success bug this
+// function was written to fix — an allow-list would quietly restore it.
+//
+// Reading a little of an unlabelled body is cheap now in a way it was not: the
+// read is bounded and prepended back, so the worst case is 64 KiB held for the
+// length of one envelope check.
+func miniMaxEnvelopePossible(contentType string) bool {
+	ct := strings.ToLower(strings.TrimSpace(contentType))
+	switch {
+	case strings.Contains(ct, "text/event-stream"),
+		strings.HasPrefix(ct, "audio/"),
+		strings.HasPrefix(ct, "image/"),
+		strings.HasPrefix(ct, "video/"),
+		strings.HasPrefix(ct, "application/octet-stream"):
+		return false
+	}
+	return true
+}
+
 // remapMiniMaxBusinessError converts a MiniMax "HTTP 200 base_resp error"
 // response into one carrying the equivalent HTTP status, so the failover,
 // circuit-breaker, and error-forwarding paths — all keyed on status codes — see
@@ -53,13 +82,7 @@ func remapMiniMaxBusinessError(providerType, providerName string, resp *http.Res
 	if resp == nil || providerType != "minimax" || resp.StatusCode != http.StatusOK {
 		return resp
 	}
-	// Streaming responses carry no base_resp envelope; never consume their body.
-	// Neither does anything that is not JSON — this function reads bodies, and
-	// the multimodal pass-through routes audio and image responses through it.
-	// Buffering an audio/mpeg answer to look for a field its content type says
-	// cannot be there would defeat the streaming that path exists to do.
-	contentType := resp.Header.Get("Content-Type")
-	if strings.Contains(contentType, "text/event-stream") || !strings.Contains(contentType, "json") {
+	if !miniMaxEnvelopePossible(resp.Header.Get("Content-Type")) {
 		return resp
 	}
 

--- a/internal/proxy/minimax_test.go
+++ b/internal/proxy/minimax_test.go
@@ -147,15 +147,15 @@ func TestRemapMiniMaxBusinessError_InvalidJSONPassthrough(t *testing.T) {
 	}
 }
 
-// 7. A non-JSON 200 is left alone and its body is never read.
+// 7. A binary or streamed 200 is left alone and its body is never read.
 //
 // This function is on the multimodal pass-through path as well as the chat one,
 // where a 200 can be an audio stream or a multi-megabyte image payload. Reading
 // one to look for a field its content type says cannot be there would buffer in
 // full what that path exists to stream, and make TTFB wait for the last upstream
 // byte.
-func TestRemapMiniMaxBusinessError_NonJSONUntouched(t *testing.T) {
-	for _, contentType := range []string{"audio/mpeg", "application/octet-stream", ""} {
+func TestRemapMiniMaxBusinessError_BinaryUntouched(t *testing.T) {
+	for _, contentType := range []string{"audio/mpeg", "image/png", "video/mp4", "application/octet-stream", "AUDIO/MPEG"} {
 		resp, rr := minimaxTestResp(http.StatusOK, contentType,
 			`{"base_resp":{"status_code":1008,"status_msg":"insufficient balance"}}`)
 		out := remapMiniMaxBusinessError("minimax", "mm", resp)
@@ -164,6 +164,23 @@ func TestRemapMiniMaxBusinessError_NonJSONUntouched(t *testing.T) {
 		}
 		if rr.read {
 			t.Errorf("content type %q: body was consumed", contentType)
+		}
+	}
+}
+
+// 7b. An envelope that arrives without a JSON content type is still remapped.
+//
+// The bound above is a deny-list on purpose. Skipping everything that does not
+// say "json" would also skip a missing, empty or text/plain content type — and a
+// base_resp arriving under one of those is exactly the empty-200-forwarded-as-a-
+// success this function exists to prevent. An unlabelled body says nothing about
+// itself, and reading a bounded prefix of one is cheap.
+func TestRemapMiniMaxBusinessError_UnlabelledEnvelopeStillRemapped(t *testing.T) {
+	for _, contentType := range []string{"", "text/plain", "application/json; charset=utf-8"} {
+		resp, _ := minimaxTestResp(http.StatusOK, contentType,
+			`{"base_resp":{"status_code":1008,"status_msg":"insufficient balance"}}`)
+		if got := remapMiniMaxBusinessError("minimax", "mm", resp).StatusCode; got != http.StatusTooManyRequests {
+			t.Errorf("content type %q: status = %d, want 429", contentType, got)
 		}
 	}
 }

--- a/internal/proxy/minimax_test.go
+++ b/internal/proxy/minimax_test.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -143,6 +144,90 @@ func TestRemapMiniMaxBusinessError_InvalidJSONPassthrough(t *testing.T) {
 	}
 	if string(body) != "not json" {
 		t.Errorf("body altered: %s", body)
+	}
+}
+
+// 7. A non-JSON 200 is left alone and its body is never read.
+//
+// This function is on the multimodal pass-through path as well as the chat one,
+// where a 200 can be an audio stream or a multi-megabyte image payload. Reading
+// one to look for a field its content type says cannot be there would buffer in
+// full what that path exists to stream, and make TTFB wait for the last upstream
+// byte.
+func TestRemapMiniMaxBusinessError_NonJSONUntouched(t *testing.T) {
+	for _, contentType := range []string{"audio/mpeg", "application/octet-stream", ""} {
+		resp, rr := minimaxTestResp(http.StatusOK, contentType,
+			`{"base_resp":{"status_code":1008,"status_msg":"insufficient balance"}}`)
+		out := remapMiniMaxBusinessError("minimax", "mm", resp)
+		if out.StatusCode != http.StatusOK {
+			t.Errorf("content type %q: status = %d, want 200 (untouched)", contentType, out.StatusCode)
+		}
+		if rr.read {
+			t.Errorf("content type %q: body was consumed", contentType)
+		}
+	}
+}
+
+// 8. A JSON body past the envelope cap streams through whole.
+//
+// MiniMax answers with base64 audio inside JSON and the image endpoints can
+// return megabytes of b64_json, so "it is JSON" is not "it is small". What must
+// not happen is the two failure modes the unbounded read had: holding all of it
+// in memory, and — since the bytes were replaced rather than prepended —
+// delivering a truncated body as a complete answer.
+func TestRemapMiniMaxBusinessError_OversizedJSONStreamsThrough(t *testing.T) {
+	payload := `{"data":[{"b64_json":"` + strings.Repeat("A", 2*miniMaxEnvelopeCap) + `"}]}`
+	resp, _ := minimaxTestResp(http.StatusOK, "application/json", payload)
+	out := remapMiniMaxBusinessError("minimax", "mm", resp)
+	if out.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", out.StatusCode)
+	}
+	body, err := io.ReadAll(out.Body)
+	if err != nil {
+		t.Fatalf("read restored body: %v", err)
+	}
+	if string(body) != payload {
+		t.Fatalf("body altered: read %d bytes, want %d", len(body), len(payload))
+	}
+}
+
+// failAfterReader delivers a prefix and then fails, standing in for a connection
+// that dies mid-body.
+type failAfterReader struct {
+	head io.Reader
+	err  error
+}
+
+func (f *failAfterReader) Read(p []byte) (int, error) {
+	n, err := f.head.Read(p)
+	if err == io.EOF {
+		return n, f.err
+	}
+	return n, err
+}
+
+func (f *failAfterReader) Close() error { return nil }
+
+// 9. A body that dies mid-read still dies downstream.
+//
+// The old shape read the body, ignored the error and handed back whatever it
+// had, so a truncated response was forwarded as a complete 200 — and on the
+// pass-through path that also credited the model as having answered. Restoring
+// the remaining stream rather than replacing it keeps the failure where the
+// handlers can see it.
+func TestRemapMiniMaxBusinessError_MidBodyFailureSurfaces(t *testing.T) {
+	wantErr := io.ErrUnexpectedEOF
+	h := make(http.Header)
+	h.Set("Content-Type", "application/json")
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     h,
+		Body:       &failAfterReader{head: strings.NewReader(`{"data":[`), err: wantErr},
+	}
+
+	out := remapMiniMaxBusinessError("minimax", "mm", resp)
+	if _, err := io.ReadAll(out.Body); !errors.Is(err, wantErr) {
+		t.Fatalf("downstream read error = %v, want %v: a truncated body must not read as a complete one", err, wantErr)
 	}
 }
 

--- a/internal/proxy/model_gone.go
+++ b/internal/proxy/model_gone.go
@@ -198,6 +198,31 @@ type goneStreakKey struct {
 // declares image alone is an images-endpoint model whatever it can be coaxed
 // into. See canonicalModalityRank in internal/provider for the full vocabulary
 // these are drawn from.
+// modalityAdmitsBothProbeSurfaces reports whether the catalog says this model
+// serves chat AND embeddings.
+//
+// Such a model is not auto-retired at all, and the reason is the mismatch
+// between what the evidence is about and what the action does. Strikes, probes
+// and successes are all per surface, because a provider can retire one surface
+// of a model and keep serving the other — but AutoRetireIfConfirmed disables the
+// model ROW, so a chat retirement would take the working embeddings surface with
+// it. That is a false positive of exactly the kind this whole path exists to
+// stop writing, and no probe can catch it: the probe is right, the model really
+// is gone on chat, and the disable is simply broader than the finding.
+//
+// Retiring per surface is the honest fix and the schema does not offer it: one
+// row is one model, enabled or not. So this takes the same trade as every other
+// case where the verdict cannot justify the action — image, TTS, STT and rerank
+// models are not auto-retired either — and leaves the model enabled until
+// discovery drops it or an operator disables it by hand.
+//
+// It costs almost nothing: it needs a provider serving one model id on both
+// surfaces, which is rare, and the undeclared case is unaffected because an
+// empty modality list already rules the embeddings surface out.
+func modalityAdmitsBothProbeSurfaces(m *model.Model) bool {
+	return !modalityRulesOutSurface(m, probeChatEndpoint) && !modalityRulesOutSurface(m, probeEmbeddingsEndpoint)
+}
+
 func modalityRulesOutSurface(m *model.Model, probeEndpoint string) bool {
 	out := declaredModalities(m.OutputModalities)
 	if probeEndpoint == probeEmbeddingsEndpoint {
@@ -524,6 +549,16 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 		return
 	}
 
+	// The third gate, and the one that is about the ACTION rather than the
+	// evidence. Everything above decides which surface a refusal is about; the
+	// disable it can lead to is model-wide, and for a model that serves both
+	// probeable surfaces those two are not the same scope. See
+	// modalityAdmitsBothProbeSurfaces.
+	if modalityAdmitsBothProbeSurfaces(m) {
+		debuglog.Debug("proxy: ignoring a gone-classified refusal on a model that serves both probeable surfaces, which one disable cannot separate", "model", m.ModelID, "provider", candidate.provider.Name, "endpoint", endpointType, "output_modalities", m.OutputModalities)
+		return
+	}
+
 	// The counter must be incremented atomically, not read-modify-written. A
 	// dead model is exactly the one that gets hammered concurrently — clients
 	// retry it, and a failover group can try it on several requests at once — so
@@ -753,8 +788,13 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 			return
 		case probeInconclusive:
 			// Nothing was established: a 429, a 5xx, an entitlement failure, a
-			// connection that never landed, an expired deadline, or no probe
-			// slot free. Postpone.
+			// connection that never landed, or an expired deadline. Postpone.
+			//
+			// Deliberately NOT the postponements that happen before this
+			// goroutine exists — a busy provider semaphore, an open circuit, a
+			// cooldown still running. Those return on the request path without
+			// producing a verdict at all, and each says so on its own Debug line;
+			// looking for them here is looking in the wrong place.
 			//
 			// The count is left exactly where it is, and neither half of that is
 			// incidental. Postponing means postponing: the strikes were real

--- a/internal/proxy/model_gone.go
+++ b/internal/proxy/model_gone.go
@@ -134,7 +134,25 @@ func (s *goneStreak) count() int64 {
 }
 
 // noteModelGone records one strike against a model the provider refused as
-// retired, and disables it once the streak reaches goneStrikeThreshold.
+// retired, and once the streak reaches goneStrikeThreshold asks the provider
+// directly before disabling anything.
+//
+// The classifier nominates, the probe adjudicates. Every strike here was read
+// out of provider prose by classifyUpstreamError, and prose drifts: a phrasing
+// that means "retired" today is a phrasing some provider will use for something
+// else tomorrow, and the disable was being written on that reading alone. The
+// threshold is now the bar for spending one upstream request on the question
+// rather than the verdict itself, and the model is retired only when a real
+// request to it is refused as well.
+//
+// The probe can only ever PREVENT a disable. It never causes one that three
+// strikes had not already earned, so widening it cannot make the gateway retire
+// more than it did before.
+//
+// The whole candidate is taken rather than the model plus a provider name
+// because the probe needs a provider to talk to: its base URL, its dialect and
+// the already-decrypted key. A name was enough to log with and is not enough to
+// verify anything.
 //
 // Strikes are in-memory and deliberately not persisted. They are a heuristic
 // over recent traffic, not an audit trail: losing them on restart just means a
@@ -143,8 +161,36 @@ func (s *goneStreak) count() int64 {
 // therefore reaches its own conclusion from its own traffic, which is the safer
 // direction — nothing fans a disable out across the fleet on one member's
 // evidence.
-func (h *Handler) noteModelGone(m *model.Model, providerName string) {
-	if m == nil || m.ID == uuid.Nil {
+func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
+	m := candidate.model
+	// A nil provider now stops the retirement outright instead of being papered
+	// over. Under the old signature it could not: providerName was a string, so
+	// a candidate with no provider still counted strikes and still disabled the
+	// model. There is nothing to probe without one, and an unprobeable
+	// retirement is exactly what this change exists to stop writing.
+	if m == nil || m.ID == uuid.Nil || candidate.provider == nil {
+		return
+	}
+
+	// The family gate, and it runs BEFORE the strike is recorded.
+	//
+	// Only chat and embeddings can be probed cheaply (see
+	// probeEndpointForFamily). A chat probe against an image, TTS, STT or rerank
+	// model fails for reasons that have nothing to do with retirement, and that
+	// failure would read as confirmation of it — the verification would
+	// manufacture the very answer it was added to check. Falling back to
+	// classifier-only for those families is not the alternative it looks like
+	// either: it would leave the guessing this change removes running
+	// unsupervised in the corner where it is least observed.
+	//
+	// Gating before the strike rather than after is what keeps the counter
+	// honest. A streak that can never fire is not evidence, so recording it
+	// would only manufacture the appearance of some; and a model that takes
+	// chat traffic and image traffic must not have its chat streak — the one
+	// that CAN retire it — topped up by image refusals nothing will ever
+	// adjudicate.
+	if _, ok := probeEndpointForFamily(endpointType); !ok {
+		debuglog.Info("proxy: provider reports model gone on an endpoint family that cannot be probed, so it is never auto-retired", "model", m.ModelID, "provider", candidate.provider.Name, "endpoint", endpointType)
 		return
 	}
 
@@ -166,7 +212,7 @@ func (h *Handler) noteModelGone(m *model.Model, providerName string) {
 	strikes := streak.strike(time.Now())
 
 	if strikes < goneStrikeThreshold {
-		debuglog.Info("proxy: provider reports model gone", "model", m.ModelID, "provider", providerName, "strikes", strikes, "threshold", goneStrikeThreshold)
+		debuglog.Info("proxy: provider reports model gone", "model", m.ModelID, "provider", candidate.provider.Name, "strikes", strikes, "threshold", goneStrikeThreshold)
 		return
 	}
 	// Exactly one caller sees the threshold value, so a burst of concurrent
@@ -177,15 +223,17 @@ func (h *Handler) noteModelGone(m *model.Model, providerName string) {
 	// model — 50 concurrent retries, say — would disable it once every three
 	// strikes and publish an alert each time. Leaving the count above the
 	// threshold makes every later refusal a no-op. noteModelServed clears it if
-	// the model ever answers again, and the failure path below clears it so a
-	// disable that could not be written is retried rather than lost.
+	// the model ever answers again, and the two paths below that reach no
+	// conclusion — a probe that established nothing, a disable that could not be
+	// written — clear it so the attempt is retried rather than lost.
 	if strikes > goneStrikeThreshold {
 		return
 	}
 
-	// Threshold reached. Disable out of band: this runs on the request path and
-	// must not add latency to the error response the caller is already getting.
-	modelID, modelName, provider := m.ID, m.ModelID, providerName
+	// Threshold reached. Probe and disable out of band: this runs on the request
+	// path and must not add latency to the error response the caller is already
+	// getting — least of all an upstream round trip to a third party.
+	modelID, modelName, provider := m.ID, m.ModelID, candidate.provider.Name
 
 	go func() {
 		// The decision was made before this goroutine was scheduled, and the
@@ -199,6 +247,72 @@ func (h *Handler) noteModelGone(m *model.Model, providerName string) {
 		if streak.cancelled.Load() {
 			debuglog.Info("proxy: skipping auto-disable, model answered while the disable was queued", "model", modelName, "provider", provider)
 			return
+		}
+
+		// Ask the provider itself. The three strikes decided this model was
+		// worth one upstream request; what retires it is the answer to that
+		// request.
+		//
+		// Placed after the cancelled check above and before the write below, and
+		// both halves of that are deliberate. After, because a success that
+		// landed while the disable was queued has already settled the question,
+		// and paying for a probe to re-establish it would spend an upstream call
+		// on an answer already in hand. Before, because the whole point is that
+		// the write is not made on the classifier's reading alone.
+		//
+		// The deadline is created here rather than inside probeModel so the
+		// production budget stays at the call site that owns the decision. It is
+		// generous — a cold model can take tens of seconds to answer, and a
+		// probe that times out on a slow but living model would postpone the
+		// retirement rather than confirm it, which is the safe direction but
+		// still a wasted call. Nothing on the request path is waiting on it.
+		pctx, pcancel := context.WithTimeout(context.Background(), goneProbeTimeout)
+		verdict := h.probeModel(pctx, candidate, endpointType)
+		pcancel()
+
+		switch verdict {
+		case probeServed:
+			// The model refused real traffic three times and then answered a
+			// direct request. Warn rather than Info: whatever is going on —
+			// drifted classifier patterns, a provider returning retirement prose
+			// for a transient fault, traffic that carries something the probe
+			// does not — an operator should see it, because it is the case in
+			// which the old code would have retired a working model.
+			//
+			// noteModelServed is the existing machinery for "this model works":
+			// it stands down any queued disable and clears the streak, so the
+			// model needs three FRESH refusals before it is reconsidered. That
+			// is the backoff, and it is why no durable "never retire this model"
+			// store is being added — a model that is genuinely dead simply earns
+			// the strikes again, and one that is alive keeps clearing them.
+			debuglog.Warn("proxy: not auto-disabling, the model answered a direct probe after being reported gone", "model", modelName, "provider", provider, "endpoint", endpointType, "strikes", goneStrikeThreshold)
+			h.noteModelServed(m)
+			return
+		case probeInconclusive:
+			// Nothing was established: a 429, a 5xx, an entitlement failure, a
+			// connection that never landed, an expired deadline. Postpone.
+			//
+			// The model is deliberately NOT credited with a success.
+			// noteModelServed is not called, so no in-flight disable is stood
+			// down and no cancelled flag is set — the model has not proved
+			// anything, and treating "we could not tell" as "it works" would let
+			// a provider outage clear the streaks of everything behind it.
+			//
+			// Dropping the count is a retry mechanism, not a verdict. Without it
+			// the streak stays parked at the threshold, where the strikes >
+			// goneStrikeThreshold check above makes every later refusal a no-op,
+			// and a genuinely dead model whose first probe happened to hit a 429
+			// would stay enabled forever. This is the same reasoning, and the
+			// same call, as the failed-write path a few lines below —
+			// CompareAndDelete on identity included, so a stale goroutine cannot
+			// throw away a newer streak on its way out.
+			h.goneStrikes.CompareAndDelete(modelID, streak)
+			debuglog.Info("proxy: postponing auto-disable, the retirement probe established nothing", "model", modelName, "provider", provider, "endpoint", endpointType)
+			return
+		case probeRefused:
+			// The provider refused the model by name to a request the gateway
+			// made itself. That is the fourth independent piece of evidence and
+			// the one the disable is actually written on; fall through.
 		}
 
 		// Staged, not written outright. confirm runs with the row already
@@ -412,7 +526,12 @@ func streamProducedOutput(logData *requestLogData) bool {
 func (h *Handler) noteStreamOutcome(logData *requestLogData, candidate modelCandidate) {
 	switch verdictForStream(logData.errorKind, logData.upstreamKind, streamProducedOutput(logData)) {
 	case verdictGone:
-		h.noteModelGone(candidate.model, candidate.provider.Name)
+		// The endpoint family comes off the log entry rather than being assumed:
+		// it is what decides whether this refusal can be adjudicated at all, and
+		// a stream reaching here can have started at /v1/chat/completions or at
+		// /v1/messages. newPendingRequestLog stamps it at ingest, so it is set on
+		// every path that can reach this.
+		h.noteModelGone(candidate, logData.endpointType)
 	case verdictServed:
 		h.noteModelServed(candidate.model)
 	case verdictInconclusive:

--- a/internal/proxy/model_gone.go
+++ b/internal/proxy/model_gone.go
@@ -947,10 +947,16 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 		// so it is undone instead.
 		//
 		// Serialising would close it, and is not available here.
-		// noteModelServed runs on the request path BEFORE a non-streaming
-		// response is written to the client (see proxy_failover.go), so holding
-		// a lock across the write would put client latency behind a database
-		// write belonging to an unrelated request's error path.
+		// noteModelServed runs on the request path (see proxy_failover.go), so
+		// holding a lock across the write would put client latency behind a
+		// database write belonging to an unrelated request's error path.
+		//
+		// It runs AFTER the non-streaming response is written now, not before:
+		// the clear is judged on what the handler decoded rather than on the 200
+		// that preceded it. That widens this window slightly — the cancel signal
+		// lands later, so AutoRetireIfConfirmed has more room to commit before a
+		// success is observed — which changes nothing here, because the window
+		// this comment is about is the one the revert below exists for.
 		//
 		// The disabled state IS briefly visible on this path, which is what the
 		// staging above exists to avoid. Accepted, because the alternative is
@@ -1079,6 +1085,17 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 // and a probe that times out on a slow but living model postpones the
 // retirement rather than confirming it, which is the safe direction but still a
 // wasted call. Nothing on the request path is waiting on any of it.
+//
+// The context is Background and not tied to server shutdown, which is what the
+// detachment costs and is worth stating rather than leaving to be discovered.
+// The retirement's worst case is now this probe plus up to three ten-second
+// writes, so a nomination that lands just before shutdown can spend one upstream
+// request and then find a closing pool. What that produces is a failed write on
+// a path that already treats a failed write as "change nothing and retry": the
+// streak keeps its strikes, nothing is disabled, and the next process re-earns
+// the decision from its own traffic. Closing it properly means a handler-scoped
+// parent context, which is a lifecycle this Handler does not have and is not
+// worth inventing for one background probe.
 func (h *Handler) probeForRetirement(candidate modelCandidate, endpointType string) probeVerdict {
 	// Before anything is dereferenced, and that is the point of it being here.
 	// probeModel makes the same check, but the fields this function touches on

--- a/internal/proxy/model_gone.go
+++ b/internal/proxy/model_gone.go
@@ -21,111 +21,100 @@ import (
 // model must draw, with no successful request in between, before the gateway
 // PROBES it.
 //
-// It is no longer the retirement bar. What disables a model is probeModel
-// refusing it on a request the gateway makes itself (see noteModelGone); the
-// strikes decide only that the question is worth one upstream call. Reading
-// this as the retirement bar is the mistake to avoid: three strikes on their
-// own now disable nothing.
+// It is NOT the retirement bar. What disables a model is probeModel refusing it
+// on a request the gateway makes itself (see noteModelGone); the strikes decide
+// only that the question is worth one upstream call.
 //
 // Why traffic and not discovery: a provider listing is not a promise. Google
 // kept gemini-2.0-flash in /models for two months after shutting it down,
-// OpenCode Zen lists claude-sonnet-4 and refuses it, OpenCode Go lists
-// hy3-preview and refuses it. RecordMissingModels can only act when a model
-// leaves the listing, so none of those were ever going to be caught by
-// discovery. The only source that knows a model is dead is a real request to
-// it, which is exactly what classifyUpstreamError labels.
+// OpenCode Zen lists claude-sonnet-4 and refuses it. RecordMissingModels can
+// only act when a model leaves the listing, so none of those were going to be
+// caught by discovery. The only source that knows a model is dead is a real
+// request to it, which is what classifyUpstreamError labels.
 //
-// Three rather than the discovery sweep's two: a scan is a deliberate, spaced
-// observation, whereas requests can arrive in a burst during a provider
-// incident. Requiring three consecutive refusals with no success in between
-// keeps a brief upstream wobble that happens to match a gone-pattern from
-// spending a probe on a live model — and, before the probe existed, from
-// retiring one outright. The probe has since taken over the second job, which
-// is why three is now a cost control rather than the last line of defence, and
-// why it has not been raised: a wrong nomination costs one cheap request, and
-// the probe throws it out.
+// Three rather than the discovery sweep's two, because requests can arrive in a
+// burst during a provider incident while a scan is a deliberate, spaced
+// observation. It is a cost control rather than the last line of defence: a
+// wrong nomination costs one cheap request, and the probe throws it out.
 const goneStrikeThreshold = 3
 
 // goneStrikeWindow is how long a strike stays part of the streak it belongs to.
 //
-// "Three consecutive refusals" was counting refusals with no bound on how far
-// apart they were, so two strikes from a provider incident this morning and one
-// this afternoon retired a model on evidence that had nothing to do with each
-// other. Worse, the older strikes are exactly the ones an operator may already
-// have acted on — they enable the model, and a count they cannot see finishes
-// and turns it off again.
-//
 // A strike arriving after this long starts the streak over rather than adding to
-// it, so a retirement is always drawn from one run of recent traffic.
+// it, so a retirement is always drawn from one run of recent traffic. Without
+// it, two strikes from this morning's incident plus one this afternoon retired a
+// model on unrelated evidence — including evidence an operator may already have
+// acted on by re-enabling it.
 //
 // It bounds the GAP between consecutive strikes, not the span of the streak.
 // Refusals at 0, 29 and 58 minutes are one streak of three, because neither gap
-// exceeds the window; the count only restarts when a strike arrives more than
-// this long after the one before it. Written out because "three strikes within
-// 30 minutes" is the natural way to say it and is not what the code does.
+// exceeds the window. Written out because "three strikes within 30 minutes" is
+// the natural way to say it and is not what the code does.
 //
-// Thirty minutes is chosen against real traffic rather than as a round number:
-// each refusal only has to arrive within half an hour of the last one, which a
-// gateway with any load does easily, while a model refused once an hour never
-// accumulates a streak at all. That second case is deliberate — a model too idle
-// to fail twice in half an hour is also too idle for its staying enabled to cost
-// anything, and traffic-driven retirement should not be guessing from sparse
-// evidence.
+// A model refused once an hour therefore never accumulates a streak, which is
+// deliberate: one too idle to fail twice in half an hour is also too idle for
+// staying enabled to cost anything.
 const goneStrikeWindow = 30 * time.Minute
 
 // goneProbeCooldown is the shortest interval between two probes of the same
 // model, and it is what makes an inconclusive probe a postponement rather than a
 // standing invitation to keep asking.
 //
-// The case it exists for is the one the design names: a provider rate limiting
-// the gateway. Real traffic draws the retirement prose, the probe draws a 429,
-// nothing is established. Without a cooldown the streak had to be dropped so a
-// later refusal could re-probe, and the steady state became one extra upstream
-// request per three refusals — forever, with no bound. A client retrying a dead
-// model at 10 req/s produced roughly three probes a second at a provider that
-// was already shedding load, and the probe deliberately bypasses both the rate
-// limiter and the circuit breaker, so nothing else was going to slow it down.
-// Before the probe existed, strike three disabled the model and the traffic
-// stopped; the cooldown is what restores that bound.
+// The case it exists for is a provider rate limiting the gateway: real traffic
+// draws the retirement prose, the probe draws a 429, nothing is established.
+// Unbounded, a client retrying a dead model at 10 req/s produced roughly three
+// probes a second at a provider already shedding load — and the probe
+// deliberately bypasses both the rate limiter and the circuit breaker, so
+// nothing else was going to slow it down.
 //
 // The floor is goneProbeTimeout (30s) and it is not a soft one: claimProbe
 // claims at SPAWN time, so the claim doubles as the "a probe is already in
-// flight" guard, and a cooldown shorter than the probe's own deadline would let
-// a second probe be claimed while the first was still waiting on the provider.
-// Five minutes clears it by an order of magnitude and caps the cost at 12
-// probes per model per hour in the worst case — a model under constant refusal
-// whose probe never establishes anything — against the roughly 1,200 an hour
-// the uncapped version allowed for the same traffic.
+// flight" guard, and a shorter cooldown would let a second probe be claimed
+// while the first was still waiting on the provider. Five minutes clears that by
+// an order of magnitude and caps the worst case at 12 probes per model per hour.
 //
 // It bounds one model. goneProbeMaxConcurrent bounds the burst across models.
 const goneProbeCooldown = 5 * time.Minute
+
+// goneProbeInconclusiveWarnAfter is how many probes in a row may establish
+// nothing before the postponement is reported at Warn instead of Info.
+//
+// Nothing bounds how long a streak can sit unadjudicable. A provider that rate
+// limits the gateway, or one whose model cannot be reached on the surface the
+// probe asks (an endpointTypeMessages candidate is probed over the
+// OpenAI-compatible surface — see newProbeState), postpones every time: the
+// model keeps its strikes and spends one upstream request per cooldown for as
+// long as traffic keeps refusing it. Before the probe existed that model was
+// disabled and the traffic stopped.
+//
+// The direction is safe and the rate is bounded, but the cost is real and at
+// Info it was indistinguishable from an ordinary single postponement. Three in a
+// row is roughly fifteen minutes of paying for an answer that is not coming.
+//
+// It warns on every inconclusive probe past the threshold rather than only on
+// the crossing, because the line is what the cost looks like: one per model per
+// goneProbeCooldown, exactly the rate of the requests being spent. The run ends
+// with the evidence it belonged to — see clearLocked.
+const goneProbeInconclusiveWarnAfter = 3
 
 // goneProbeMaxConcurrent bounds how many retirement probes may be in flight
 // against one provider at a time.
 //
 // The cooldown above bounds one model, and one model was never the shape of the
-// problem: a provider event that nominates 200 models nominates them all within
-// the same few seconds, and every nomination that reached the threshold spawned
-// its own goroutine holding a connection to the SAME host for up to
-// goneProbeTimeout. Two hundred simultaneous verification requests at a
-// provider already misbehaving is the gateway adding to an incident it is
-// supposed to be diagnosing — and each HA member does it independently.
+// problem: a provider event nominates 200 models within the same few seconds,
+// each spawning its own goroutine holding a connection to the SAME host for up
+// to goneProbeTimeout. That is the gateway adding to an incident it is supposed
+// to be diagnosing, and each HA member does it independently.
 //
 // Per provider rather than one counter for the whole gateway, because the harm
-// is per host. A cap on the total cannot tell 200 probes at one struggling
-// provider from 200 spread over 200 healthy ones, so it either throttles the
-// case that is fine or fails to throttle the case that is not. Keyed by
-// provider it throttles exactly the burst that lands on one host, and a second
-// provider's retirements are not postponed by the first provider's incident.
+// is per host: a total cap cannot tell 200 probes at one struggling provider
+// from 200 spread over 200 healthy ones.
 //
-// Four slots, following the argon2 semaphore in internal/user: enough that an
-// ordinary trickle of retirements never queues, small enough that the worst case
-// is a handful of extra connections. The acquire is non-blocking on purpose: a
-// probe that cannot get a slot drops out rather than waiting, and costs nothing
-// on the way — the slot is taken before the model's claim is spent, so the next
-// refusal retries immediately (see noteModelGone). Blocking would hold
-// goroutines and slots for work whose whole justification is that it is not
-// urgent.
+// Four slots, following the argon2 semaphore in internal/user. The acquire is
+// non-blocking: a probe that cannot get a slot drops out rather than waiting and
+// costs nothing on the way, since the slot is taken before the model's claim is
+// spent (see noteModelGone). Blocking would hold goroutines for work whose whole
+// justification is that it is not urgent.
 const goneProbeMaxConcurrent = 4
 
 // goneWriteTimeout bounds each out-of-band write the auto-disable makes.
@@ -133,12 +122,9 @@ const goneProbeMaxConcurrent = 4
 // Each write gets its OWN deadline rather than sharing one across the sequence.
 // They run one after another, so a shared budget lets a slow first write starve
 // everything after it: a disable that took the full ten seconds but succeeded
-// would leave group revalidation to fail instantly with a deadline that was
-// already spent — exactly when the database is under the load that made the
-// disable slow, and exactly when an undersized group most needs resizing.
-//
-// The work is already detached from the request path, so nothing is waiting on
-// the total. Bounding each step is what keeps every step able to do its job.
+// would leave group revalidation to fail instantly with a spent deadline —
+// exactly when an undersized group most needs resizing. Nothing on the request
+// path is waiting on the total.
 const goneWriteTimeout = 10 * time.Second
 
 // goneStreakKey identifies a streak: one model, on one upstream surface.
@@ -156,48 +142,37 @@ type goneStreakKey struct {
 // modalityRulesOutSurface reports whether a gone-classified refusal that arrived
 // on this upstream surface may count against the model at all.
 //
-// The two surfaces answer to different burdens of proof, and the asymmetry is
-// the point rather than an inconsistency. What is at stake is the same in both
-// cases — the disable is model-wide, so a strike drawn on the wrong surface can
-// take a working model out of routing everywhere — but the cost of guessing is
-// not.
-//
-// The embeddings surface requires POSITIVE evidence: the catalog has to say this
-// model produces embeddings. Nothing filters a request by modality on the way
-// in, so `POST /v1/embeddings` naming a chat model is forwarded to the
-// provider's embeddings endpoint, and a provider that answers "gpt-4o is not
+// Nothing filters a request by modality on the way in, so `POST /v1/embeddings`
+// naming a chat model is forwarded, and a provider answering "gpt-4o is not
 // supported for embeddings" has named the model beside a gone-phrase. The probe
 // cannot rescue it: it asks on the surface the strikes arrived on, so it
-// reproduces the misuse and confirms. Being wrong here retires a live chat model
-// gateway-wide; being cautious only means an embeddings model whose catalog
-// entry declares nothing is never auto-retired — the same trade
-// probeEndpointForFamily already takes for rerank, and it matters because
-// liveModelStub writes "[]" for every model no catalog covers.
+// reproduces the misuse and confirms.
 //
-// The chat surface keeps the opposite default, because there the two costs
-// invert. Chat is what most models are and what most refusals arrive on, so
-// demanding a declared modality would switch traffic-driven retirement off for
-// every uncatalogued model at once — silently, and precisely where it does the
-// most work. So a silent catalog is allowed to strike on chat, and a catalog
-// that positively describes something a chat completion cannot be about is not.
+// The two surfaces answer to different burdens of proof, because the cost of
+// guessing is not symmetric:
 //
-// "Something a chat completion cannot be about" is read from both arrays,
-// because either one can settle it and neither can on its own. An image model
-// declares output ["image"] and a TTS model ["audio"]; a speech-to-text model
-// declares output ["text"] like any chat model and gives itself away on the
-// INPUT side with ["audio"]. All four are reachable: nothing filters a request
-// by modality on the way in, so POST /v1/chat/completions naming flux-1.1-pro is
-// forwarded, and a provider answering "Model 'flux-1.1-pro' is not supported for
-// chat completions" has named the model beside a gone-phrase. Three of those and
-// the probe re-sends the same misuse, draws the same refusal, and retires a
-// working image model on every surface including the one it serves.
+//   - Embeddings requires POSITIVE evidence — the catalog has to say this model
+//     produces embeddings. Being wrong retires a live chat model gateway-wide;
+//     being cautious only means an embeddings model whose catalog declares
+//     nothing is never auto-retired, the same trade probeEndpointForFamily takes
+//     for rerank. It matters because liveModelStub writes "[]" for every model no
+//     catalog covers.
+//   - Chat keeps the opposite default. Chat is what most models are and what
+//     most refusals arrive on, so demanding a declared modality would switch
+//     traffic-driven retirement off for every uncatalogued model at once. A
+//     silent catalog may strike; one that positively describes something a chat
+//     completion cannot be about may not.
 //
-// Text and code are the whole allow-list, and it is deliberately not the
-// vocabulary of things a chat completion can CARRY. A chat model that also emits
-// images declares ["text","image"] and is admitted by the text; a model that
-// declares image alone is an images-endpoint model whatever it can be coaxed
-// into. See canonicalModalityRank in internal/provider for the full vocabulary
-// these are drawn from.
+// The chat test reads both arrays because either can settle it and neither can
+// alone: an image model declares output ["image"] and a TTS model ["audio"],
+// while a speech-to-text model declares output ["text"] like any chat model and
+// gives itself away on the INPUT side with ["audio"].
+//
+// Text and code are the whole allow-list, and deliberately not the vocabulary of
+// things a chat completion can CARRY: a chat model that also emits images
+// declares ["text","image"] and is admitted by the text, while one declaring
+// image alone is an images-endpoint model whatever it can be coaxed into. See
+// canonicalModalityRank in internal/provider for the full vocabulary.
 func modalityRulesOutSurface(m *model.Model, probeEndpoint string) bool {
 	out := declaredModalities(m.OutputModalities)
 	if probeEndpoint == probeEmbeddingsEndpoint {
@@ -210,24 +185,21 @@ func modalityRulesOutSurface(m *model.Model, probeEndpoint string) bool {
 // modalityAdmitsBothProbeSurfaces reports whether the catalog says this model
 // serves chat AND embeddings.
 //
-// Such a model is not auto-retired at all, and the reason is the mismatch
-// between what the evidence is about and what the action does. Strikes, probes
-// and successes are all per surface, because a provider can retire one surface
-// of a model and keep serving the other — but AutoRetireIfConfirmed disables the
-// model ROW, so a chat retirement would take the working embeddings surface with
-// it. That is a false positive of exactly the kind this whole path exists to
-// stop writing, and no probe can catch it: the probe is right, the model really
-// is gone on chat, and the disable is simply broader than the finding.
+// Such a model is not auto-retired at all, because of the mismatch between what
+// the evidence is about and what the action does. Strikes, probes and successes
+// are per surface, but AutoRetireIfConfirmed disables the model ROW, so a chat
+// retirement would take the working embeddings surface with it. No probe can
+// catch that: the probe is right, the model really is gone on chat, and the
+// disable is simply broader than the finding.
 //
-// Retiring per surface is the honest fix and the schema does not offer it: one
-// row is one model, enabled or not. So this takes the same trade as every other
-// case where the verdict cannot justify the action — image, TTS, STT and rerank
-// models are not auto-retired either — and leaves the model enabled until
-// discovery drops it or an operator disables it by hand.
+// Retiring per surface is the honest fix and the schema does not offer it — one
+// row is one model, enabled or not — so this takes the same trade as image, TTS,
+// STT and rerank and leaves the model enabled until discovery drops it or an
+// operator disables it by hand.
 //
 // It costs almost nothing: it needs a provider serving one model id on both
-// surfaces, which is rare, and the undeclared case is unaffected because an
-// empty modality list already rules the embeddings surface out.
+// surfaces, which is rare, and an empty modality list already rules the
+// embeddings surface out.
 func modalityAdmitsBothProbeSurfaces(m *model.Model) bool {
 	return !modalityRulesOutSurface(m, probeChatEndpoint) && !modalityRulesOutSurface(m, probeEmbeddingsEndpoint)
 }
@@ -258,44 +230,30 @@ func admitsChatModalities(list []string) bool {
 // goneStreak is one model's consecutive-refusal count plus a tombstone for the
 // window between deciding to disable and the write landing.
 //
-// n must be atomic because a retired model is precisely the one taking
-// concurrent refusals; a read-modify-write would lose increments and the streak
-// would never reach the threshold.
-//
-// cancelled exists because the disable is detached. Between the threshold being
-// reached and the database write completing — as long as the database takes —
-// the model can answer a request and prove it is alive. noteModelServed sets
-// this so the queued write can stand down instead of retiring a model whose
-// evidence has already been superseded.
-//
-// It is read twice, and both reads are needed. Before the write it prevents a
-// disable that is now known to be wrong; after the write it catches a success
-// that landed while the write was in flight, which the first read is by
-// definition too early to see. The second case cannot be prevented, only
-// undone, so noteModelGone reverts rather than skips there.
-//
-// The count, the time of the last strike and the next time a probe may be spent
-// are guarded by mu rather than being separate atomics. Atomics cannot express
-// any of the three: deciding whether the window has lapsed and then applying the
-// decision is one operation, and splitting it loses strikes. A reset racing two
-// increments stores 1 after both have added, erasing them, so a model refused
-// three times ends the burst on a count of one and never reaches the threshold.
-// nextProbeAt is the same shape of decision — read the deadline, decide, stamp
+// The counters are guarded by mu rather than being separate atomics, because
+// none of the three decisions can be expressed atomically: deciding whether the
+// strike window has lapsed and then applying the decision is one operation, and
+// splitting it loses strikes (a reset racing two increments stores 1 after both
+// have added). nextProbeAt is the same shape — read the deadline, decide, stamp
 // the new one — and splitting it would let two callers past the same expired
-// deadline and issue two probes where the whole point is to issue one.
+// deadline and issue two probes where the point is to issue one. The lock is
+// held for a comparison and an addition on a per-model struct that is contended
+// only while that model is failing.
 //
-// The lock is held for a comparison and an addition, on a per-model struct that
-// is only contended while that one model is failing, so it costs nothing worth
-// measuring.
-//
-// cancelled stays atomic because it is read by the detached disable goroutine
-// while the request path may be writing it, and it is independent of the three
-// above.
+// cancelled is a tombstone for the window between deciding to disable and the
+// write landing, during which the model can answer a request and prove it is
+// alive. It stays atomic because the detached disable goroutine reads it while
+// the request path may be writing it. It is read twice and both reads are
+// needed: before the write to prevent a disable now known to be wrong, and after
+// it to catch a success that landed while the write was in flight — which the
+// first read is by definition too early to see, and which can only be undone
+// rather than prevented.
 type goneStreak struct {
-	mu          sync.Mutex
-	n           int64
-	lastStrike  time.Time
-	nextProbeAt time.Time
+	mu           sync.Mutex
+	n            int64
+	lastStrike   time.Time
+	nextProbeAt  time.Time
+	inconclusive int
 
 	cancelled atomic.Bool
 }
@@ -321,44 +279,33 @@ func (s *goneStreak) strike(now time.Time) int64 {
 // claimProbe reports whether this caller may spend an upstream request on the
 // model, and takes the right to do so if it may.
 //
-// It is one operation and not two, which is what makes it serve both of its
-// jobs. Claiming at spawn time rather than crediting at completion means a
-// second caller arriving while the first probe is still in flight finds the
-// stamp already set and drops out, so this is also the "a probe is already in
-// flight" guard — hence goneProbeCooldown's floor being the probe's own
-// deadline rather than a matter of taste.
-//
-// The two jobs it replaced:
-//
-//   - "exactly one caller sees the threshold value", which the old
-//     strikes == goneStrikeThreshold test did. A burst of concurrent refusals
-//     still issues a single probe, but now because everyone after the first is
-//     inside the cooldown rather than because their count happened to overshoot.
-//   - the retry, which the inconclusive path used to get by deleting the streak.
-//     A parked streak is re-probed by the next refusal past the cooldown, so
-//     postponing no longer has to throw the evidence away to stay reachable.
+// It is one operation and not two, which is what makes it serve both jobs.
+// Claiming at spawn time rather than crediting at completion means a second
+// caller arriving while the first probe is still in flight finds the stamp
+// already set and drops out, so this is also the "a probe is already in flight"
+// guard — hence goneProbeCooldown's floor being the probe's own deadline. A
+// burst of concurrent refusals therefore issues a single probe, and a parked
+// streak stays re-probeable by the next refusal past the cooldown, so postponing
+// does not have to throw the evidence away to stay reachable.
 //
 // A zero stamp admits the first caller, which is what a model that has never
 // been probed should get.
 //
-// The evidence has to still be standing, which is the other half of the same
-// critical section and not a formality. The caller strikes and then claims, and
-// those are two lock acquisitions: a success can land in between, clear the
-// count and set the tombstone, and the claim would otherwise proceed on strikes
-// that no longer exist — spending an upstream request, and reporting a strike
-// count the streak does not hold. Reading the count here is what makes "the
-// success is older than the strikes" true rather than merely usual.
+// The count check is the other half of the same critical section and not a
+// formality. The caller strikes and then claims, and those are two lock
+// acquisitions: a success can land in between, clear the count and set the
+// tombstone, and the claim would otherwise spend an upstream request on strikes
+// that no longer exist.
 //
-// Granting a claim also clears the cancelled tombstone, and that is what makes
-// a streak reusable rather than something to be thrown away. The flag means "a
-// success landed after the disable now in flight was decided", so it belongs to
-// one decision; a claim starts the next one, and the count check above is what
-// guarantees the strikes it starts on are newer than any success that set the
-// flag. Leaving it set would make the disable this claim spawns stand down at
-// its own pre-write check, and the model would never be retired again on this
-// streak. Nothing can be racing an earlier probe either: a claim cannot be
-// granted while one is alive, because goneProbeCooldown is five minutes and the
-// whole goroutine lives at most goneProbeTimeout plus one write.
+// Granting a claim also clears the tombstone, which is what makes a streak
+// reusable. The flag means "a success landed after the disable now in flight was
+// decided", so it belongs to one decision; a claim starts the next one, and the
+// count check guarantees the strikes it starts on are newer than any success
+// that set the flag. Leaving it set would make the disable this claim spawns
+// stand down at its own pre-write check, and the model would never be retired
+// again on this streak. Nothing can be racing an earlier probe: goneProbeCooldown
+// is five minutes and the whole goroutine lives at most goneProbeTimeout plus
+// one write.
 func (s *goneStreak) claimProbe(now time.Time) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -376,27 +323,21 @@ func (s *goneStreak) claimProbe(now time.Time) bool {
 // canClaimProbe answers the same question as claimProbe without taking anything.
 //
 // It is not a substitute for the claim and cannot be: two callers can both read
-// true and only one of them may proceed, which is what claimProbe's single
-// critical section decides. It exists so the cheap, per-model reason to stop can
-// be checked before the shared, per-provider one — a refusal inside its cooldown
-// then never touches the semaphore at all.
+// true and only one may proceed. It exists so the cheap, per-model reason to
+// stop is checked before the shared, per-provider one, which is what keeps the
+// semaphore counting adjudications rather than refusals — without it, a retry
+// storm across models that are all inside their cooldowns holds all four slots
+// for the microseconds each take-and-release costs, denying a genuine probe to
+// the one model whose cooldown HAS expired.
 //
-// That ordering is what keeps the semaphore counting adjudications rather than
-// refusals. Without it, a retry storm across models that are all inside their
-// cooldowns can hold all four slots for the microseconds each take-and-release
-// costs, and the one model whose cooldown HAS expired is denied a genuine probe
-// by traffic that was never going to spend one.
-// It mirrors both of claimProbe's conditions, including the count. Reading only
-// the stamp would let a refusal whose evidence a success had already cleared
-// walk past the cheap check and go take a provider slot, to be turned away by
-// the claim a moment later — which is the shape of waste this read exists to
-// stop.
-// The reason is returned alongside the answer because the caller logs it, and
-// the two are not the same event: a cooldown is a deliberate wait, while a count
-// below the threshold means a success cleared the evidence between the strike
-// and this read. Reporting the first for the second told an operator a model was
-// waiting out five minutes when its streak had in fact gone back to zero — the
-// distinction the line exists to make.
+// It mirrors both of claimProbe's conditions, including the count: reading only
+// the stamp would let a refusal whose evidence a success had already cleared go
+// take a provider slot, to be turned away by the claim a moment later.
+//
+// The reason is returned because the caller logs it and the two cases are not
+// the same event: a cooldown is a deliberate wait, while a count below the
+// threshold means a success cleared the evidence between the strike and this
+// read.
 func (s *goneStreak) canClaimProbe(now time.Time) (ok bool, reason string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -413,32 +354,29 @@ func (s *goneStreak) canClaimProbe(now time.Time) (ok bool, reason string) {
 // cooldown it has earned. It is what "clear the streak" means everywhere in
 // this file; nothing removes the entry.
 //
-// Deleting was the obvious spelling and it silently discarded the rate bound.
-// nextProbeAt lives on the streak, so dropping the entry drops the stamp, and
-// the next refusal builds a fresh zero-valued streak whose claimProbe admits
-// immediately. Every reason a streak used to be deleted is a reason it is
-// likely to be rebuilt at once: a probe that answered while traffic keeps
-// drawing retirement prose, a real request that succeeded between refusals, a
-// disable that failed to write. Each of those turned into three fresh refusals
-// buying another upstream call, forever, which is precisely the loop
-// goneProbeCooldown exists to close.
+// Deleting the entry would silently discard the rate bound: nextProbeAt lives on
+// the streak, so the next refusal would build a fresh zero-valued one whose
+// claimProbe admits immediately. Every reason a streak is cleared is a reason it
+// may be rebuilt at once — a probe that answered while traffic keeps drawing
+// retirement prose, a success between refusals, a disable that failed to write —
+// so each would turn into three fresh refusals buying another upstream call,
+// forever.
 //
-// Parking gives both halves of the bound instead. The count is reset, so the
-// model needs three FRESH refusals before it is reconsidered, and the stamp
-// survives, so the reconsideration also waits out the cooldown.
+// Parking keeps both halves of the bound: the count is reset, so the model needs
+// three FRESH refusals, and the stamp survives, so the reconsideration also
+// waits out the cooldown.
 //
-// Mutating the streak in place rather than reaching into h.goneStrikes by model
-// id is what makes every caller identity-scoped for free: sync.Map holds the
-// pointer, so a park lands on the map entry while this is still the live streak
-// and touches nothing once it is not.
+// Mutating in place rather than reaching into h.goneStrikes by model id makes
+// every caller identity-scoped for free: sync.Map holds the pointer, so a park
+// lands on the map entry while this is still the live streak.
 //
-// The tombstone is deliberately not touched here: a success has to set it (see
-// noteModelServed) and a claim has to clear it (see claimProbe), and both of
-// those are decisions about a disable rather than about the evidence.
+// The tombstone is deliberately not touched: a success sets it (noteModelServed)
+// and a claim clears it (claimProbe), and both are decisions about a disable
+// rather than about the evidence.
 //
 // Nothing is ever deleted, so the map holds one small struct per model that has
-// ever drawn a gone-classified refusal. That is bounded by the catalog and is
-// the point: a model's probe cooldown has to outlive the streak that earned it.
+// ever drawn a gone-classified refusal — bounded by the catalog, and the point:
+// a model's probe cooldown has to outlive the streak that earned it.
 func (s *goneStreak) park() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -448,27 +386,19 @@ func (s *goneStreak) park() {
 // supersede is park plus the tombstone: the model answered, so a disable that
 // has been decided stands down and the evidence behind it is cleared.
 //
-// One critical section, and that is the whole reason this is not two calls at
-// the call site. The disable goroutine reads the tombstone without the lock and
-// then asks for the count, so the two updates have to be indivisible from its
-// point of view: seeing cancelled set while the count still shows the strikes
-// that caused this retirement reads as "the model is refusing again", and the
-// revert is skipped — leaving a model that has just answered disabled, with the
-// count parked at zero immediately afterwards so nothing ever triggers a revert
-// again. An operator would have to re-enable it by hand, which is the exact
-// outcome the cancellation exists to prevent.
-//
-// Storing inside the lock is what closes it: once a reader observes the
-// tombstone the writer is still holding mu, so the count it goes on to ask for
-// cannot be read until this has finished zeroing it.
+// One critical section, which is why this is not two calls at the call site. The
+// disable goroutine reads the tombstone without the lock and then asks for the
+// count, so the two updates have to be indivisible from its point of view:
+// seeing cancelled set while the count still shows the strikes that caused this
+// retirement reads as "the model is refusing again", the revert is skipped, and
+// the count is parked at zero immediately afterwards so nothing triggers one
+// again — leaving a model that has just answered disabled until an operator
+// re-enables it by hand. Storing inside the lock closes that: once a reader
+// observes the tombstone the writer still holds mu.
 //
 // It reports whether it changed anything, for the caller's log line rather than
-// for control flow. A streak already at zero with the tombstone already set has
-// been superseded by an earlier success and there is nothing left to stand down
-// — which is the steady state for any model that drew one refusal and then went
-// on serving, since nothing removes entries. The early return is deliberately
-// that narrow: a count of zero with no tombstone can still belong to a disable
-// this success has to cancel.
+// for control flow. The early return is deliberately narrow — a count of zero
+// with no tombstone can still belong to a disable this success has to cancel.
 func (s *goneStreak) supersede() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -481,9 +411,24 @@ func (s *goneStreak) supersede() bool {
 }
 
 // clearLocked resets the evidence. Callers hold mu.
+//
+// The inconclusive run goes with it: it counts probes that could not answer a
+// question, so clearing the question ends the run. Every caller is the model
+// answering — a success, or a probe that got content out of it — which is the
+// outcome the run was waiting for.
 func (s *goneStreak) clearLocked() {
 	s.n = 0
 	s.lastStrike = time.Time{}
+	s.inconclusive = 0
+}
+
+// noteInconclusiveProbe records a probe that established nothing and reports how
+// many in a row this streak has now taken. See goneProbeInconclusiveWarnAfter.
+func (s *goneStreak) noteInconclusiveProbe() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.inconclusive++
+	return s.inconclusive
 }
 
 // count reports the current streak length.
@@ -499,35 +444,28 @@ func (s *goneStreak) count() int64 {
 //
 // The classifier nominates, the probe adjudicates. Every strike here was read
 // out of provider prose by classifyUpstreamError, and prose drifts: a phrasing
-// that means "retired" today is a phrasing some provider will use for something
-// else tomorrow, and the disable was being written on that reading alone. The
-// threshold is now the bar for spending one upstream request on the question
-// rather than the verdict itself, and the model is retired only when a real
-// request to it is refused as well.
+// that means "retired" today is one some provider will use for something else
+// tomorrow. The threshold is the bar for spending one upstream request on the
+// question, not the verdict itself.
 //
 // The probe can only ever PREVENT a disable. It never causes one that three
-// strikes had not already earned, so widening it cannot make the gateway retire
-// more than it did before.
+// strikes had not already earned.
 //
 // The whole candidate is taken rather than the model plus a provider name
 // because the probe needs a provider to talk to: its base URL, its dialect and
-// the already-decrypted key. A name was enough to log with and is not enough to
-// verify anything.
+// the already-decrypted key.
 //
 // Strikes are in-memory and deliberately not persisted. They are a heuristic
-// over recent traffic, not an audit trail: losing them on restart just means a
-// genuinely dead model re-earns them on the next few requests, while keeping
-// the hot path free of a database write per failed request. Each HA member
-// therefore reaches its own conclusion from its own traffic, which is the safer
-// direction — nothing fans a disable out across the fleet on one member's
-// evidence.
+// over recent traffic, not an audit trail: losing them on restart means a
+// genuinely dead model re-earns them on the next few requests, while the hot
+// path stays free of a database write per failed request. Each HA member reaches
+// its own conclusion from its own traffic, so nothing fans a disable out across
+// the fleet on one member's evidence.
 func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 	m := candidate.model
-	// A nil provider now stops the retirement outright instead of being papered
-	// over. Under the old signature it could not: providerName was a string, so
-	// a candidate with no provider still counted strikes and still disabled the
-	// model. There is nothing to probe without one, and an unprobeable
-	// retirement is exactly what this change exists to stop writing.
+	// A nil provider stops the retirement outright: there is nothing to probe
+	// without one, and an unprobeable retirement is what this path exists to stop
+	// writing.
 	if m == nil || m.ID == uuid.Nil || candidate.provider == nil {
 		return
 	}
@@ -537,27 +475,18 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 	// Only chat and embeddings can be probed cheaply (see
 	// probeEndpointForFamily). A chat probe against an image, TTS, STT or rerank
 	// model fails for reasons that have nothing to do with retirement, and that
-	// failure would read as confirmation of it — the verification would
-	// manufacture the very answer it was added to check. Falling back to
-	// classifier-only for those families is not the alternative it looks like
-	// either: it would leave the guessing this change removes running
-	// unsupervised in the corner where it is least observed.
+	// failure would read as confirmation of it. Falling back to classifier-only
+	// for those families would leave the guessing running unsupervised where it
+	// is least observed.
 	//
-	// Gating before the strike rather than after is what keeps the counter
-	// honest. A streak that can never fire is not evidence, so recording it
-	// would only manufacture the appearance of some; and a model that takes
-	// chat traffic and image traffic must not have its chat streak — the one
-	// that CAN retire it — topped up by image refusals nothing will ever
-	// adjudicate.
+	// Before the strike rather than after, because a streak that can never fire
+	// is not evidence, and a model taking both chat and image traffic must not
+	// have its chat streak — the one that CAN retire it — topped up by image
+	// refusals nothing will ever adjudicate.
 	//
-	// Debug rather than Info, and that is a consequence of returning before the
-	// strike rather than a preference. Nothing throttles this line: no counter
-	// is kept, so there is no threshold to cross and nothing ever goes quiet. A
-	// genuinely retired image or TTS model used to log twice, reach the
-	// threshold, be disabled and stop; it now logs once per refused request for
-	// as long as traffic keeps arriving, precisely BECAUSE it is never retired
-	// to make it stop. At Info that is an unbounded line in every operator's log
-	// for a condition that is by design permanent.
+	// Debug rather than Info because nothing throttles this line: the model is
+	// never retired to make it stop, so it fires once per refused request for as
+	// long as traffic keeps arriving.
 	probeEndpoint, ok := probeEndpointForFamily(endpointType)
 	if !ok {
 		debuglog.Debug("proxy: provider reports model gone on an endpoint family that cannot be probed, so it is never auto-retired", "model", m.ModelID, "provider", candidate.provider.Name, "endpoint", endpointType)
@@ -566,13 +495,11 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 
 	// The second gate: the refusal has to be about a surface this model is FOR.
 	//
-	// This is the same argument as the family gate above, applied to the one
-	// direction that gate cannot see. Chat and embeddings are both probeable, so
-	// the mismatch is between the model and the surface rather than between the
-	// surface and the probe — and the probe cannot catch it, because it asks on
-	// the surface the strikes arrived on and would reproduce the misuse
-	// faithfully. What each surface demands of the catalog, and why the two
-	// differ, is argued in modalityRulesOutSurface.
+	// Chat and embeddings are both probeable, so here the mismatch is between the
+	// model and the surface rather than between the surface and the probe — and
+	// the probe cannot catch it, because it asks on the surface the strikes
+	// arrived on and would reproduce the misuse faithfully. What each surface
+	// demands of the catalog is argued in modalityRulesOutSurface.
 	if modalityRulesOutSurface(m, probeEndpoint) {
 		debuglog.Debug("proxy: ignoring a gone-classified refusal on a surface this model is not known to serve", "model", m.ModelID, "provider", candidate.provider.Name, "endpoint", endpointType, "input_modalities", m.InputModalities, "output_modalities", m.OutputModalities)
 		return
@@ -588,24 +515,19 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 		return
 	}
 
-	// The counter must be incremented atomically, not read-modify-written. A
-	// dead model is exactly the one that gets hammered concurrently — clients
+	// A dead model is exactly the one that gets hammered concurrently — clients
 	// retry it, and a failover group can try it on several requests at once — so
-	// a lost update here is not theoretical: two refusals racing would both read
-	// the same value and store the same increment, the streak would stall below
-	// the threshold, and the model would stay routable indefinitely.
-	//
-	// sync.Map holds a per-model *goneStreak rather than a plain int, so
+	// a lost update is not theoretical: two racing refusals would store the same
+	// increment, the streak would stall below the threshold, and the model would
+	// stay routable indefinitely. sync.Map holds a per-model *goneStreak, so
 	// LoadOrStore only races on creating it (harmless, the winner's is used by
-	// everyone) and the increment itself is atomic.
+	// everyone) and the increment itself is guarded.
 	//
-	// Keyed by model AND probe surface, not by model alone. The two are separate
-	// questions — a model can be served on one surface and refused on another —
-	// and the probe is sent to the surface the strikes came from, so pooling them
-	// let two chat refusals plus one embeddings refusal buy an embeddings probe.
-	// Keyed this way, every streak names one surface, and what the probe asks is
-	// always what the strikes were about. Chat and messages share a key by
-	// design: they resolve to the same probe endpoint, so they are the same
+	// Keyed by model AND probe surface, not by model alone: a model can be served
+	// on one surface and refused on another, and the probe is sent to the surface
+	// the strikes came from, so pooling them let two chat refusals plus one
+	// embeddings refusal buy an embeddings probe. Chat and messages share a key
+	// by design — they resolve to the same probe endpoint, so they are one
 	// question asked through two front doors.
 	raw, _ := h.goneStrikes.LoadOrStore(goneStreakKey{model: m.ID, endpoint: probeEndpoint}, &goneStreak{})
 	streak, ok := raw.(*goneStreak)
@@ -621,99 +543,61 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 	}
 
 	// At or above the threshold every refusal asks for a probe, and the streak's
-	// own cooldown decides which one gets it. The old shape tested for the
-	// threshold value exactly, so only the caller that saw a count of three ever
-	// proceeded; claimProbe now does that job and two more besides.
+	// own cooldown decides which one gets it. A burst issues ONE probe — fifty
+	// concurrent retries all ask, one wins the claim, the rest drop out inside
+	// the cooldown — and a parked streak stays reachable, so a single refusal
+	// after the cooldown re-probes a streak still sitting at three. Postponing
+	// therefore costs no evidence and the retry costs no extra strikes.
 	//
-	// What each version buys:
+	// The counter is deliberately NOT cleared on the way to a disable: clearing
+	// it would let a burst against a dead model re-enter the threshold every
+	// three strikes. Exactly two things clear it and both are the model
+	// answering: noteModelServed, and the served-probe branch below. A disable
+	// that could not be written clears nothing, so the next refusal past the
+	// cooldown retries it. A retirement that did land needs no guard either — the
+	// model is disabled, so no traffic reaches it, and a straggler finds
+	// AutoRetireIfConfirmed refusing to write over an already-retired row.
 	//
-	//   - A burst still issues ONE probe. Fifty concurrent retries all reach
-	//     here, all ask, one wins the claim and the other forty-nine drop out
-	//     inside the cooldown. Same outcome as the equality test, on a rule that
-	//     survives the count moving on.
-	//   - A parked streak stays reachable. The equality test made every refusal
-	//     past the threshold a permanent no-op, which is why the inconclusive
-	//     path below had to DELETE the streak to be retried at all — and
-	//     deleting it is what left the probe rate unbounded. With the claim
-	//     gating instead, a single refusal after the cooldown re-probes a streak
-	//     that is still sitting at three, so postponing costs no evidence and
-	//     the retry costs no extra strikes.
-	//   - The rate is bounded. See goneProbeCooldown.
+	// The provider's slot is taken BEFORE the model's claim. Both are
+	// non-blocking, but only one is spent: the claim stamps a five-minute
+	// cooldown, while a refused slot costs nothing. Taking the claim first meant
+	// a model that lost the race for a slot had already burnt its cooldown for
+	// zero upstream work — so a provider incident nominating two hundred models
+	// would adjudicate four and push the rest out a full cooldown each,
+	// converging in hours rather than in the time four slots take to turn over.
+	// The refused caller leaves the streak untouched and the next refusal retries
+	// immediately, which is safe because the semaphore is itself the rate bound
+	// in that window.
 	//
-	// The counter is still deliberately NOT cleared on the way to a disable.
-	// Clearing it would let the next refusal start a fresh count from zero, so a
-	// burst against a dead model would re-enter the threshold every three
-	// strikes. Exactly two things clear it, and both are the model answering:
-	// noteModelServed, when a request to it succeeds, and the served-probe branch
-	// below, when the probe gets content out of it. A disable that could not be
-	// written clears nothing at all — the streak stays as it is and the next
-	// refusal past the cooldown retries it. A retirement that did land does not
-	// need the guard either: the model is disabled, so no traffic reaches it to
-	// strike it again, and a straggler that arrives past the cooldown finds
-	// AutoRetireIfConfirmed refusing to write over an already-retired row, which
-	// reports as an uncommitted attempt and publishes no second alert.
-	// The provider's slot is taken BEFORE the model's claim, and the order is the
-	// whole point. Both are non-blocking, but only one of them is spent: the
-	// claim stamps a five-minute cooldown on the model, while a refused slot
-	// costs nothing at all.
-	//
-	// Taking the claim first meant a model that lost the race for a slot had
-	// already burnt its cooldown for zero upstream work — and that is exactly the
-	// event goneProbeMaxConcurrent exists for. A provider incident nominating two
-	// hundred models adjudicates four of them and pushes every other one out a
-	// full cooldown, so a batch that should converge in the time it takes the
-	// four slots to turn over (a probe is ≤30s) instead converges at four models
-	// per five minutes. Hours rather than minutes, with the gateway idle in
-	// between.
-	//
-	// This way the refused caller leaves the streak untouched and the next
-	// refusal tries again immediately, which is safe because the semaphore is
-	// itself the rate bound in that window: no upstream request can be spent
-	// without a slot, whatever the retry rate.
-	//
-	// The cooldown is still read FIRST, without taking anything, so a refusal
-	// that could not have probed anyway never reaches the semaphore. Otherwise
-	// the shared, per-provider resource ends up counting refusals rather than
-	// adjudications: a retry storm across models that are all inside their
-	// cooldowns can hold the four slots for the moment each take-and-release
-	// costs, and deny them to the one model whose cooldown has actually expired.
-	// The read cannot replace the claim — two callers can both see true and only
-	// one may proceed — which is why claimProbe still decides below.
+	// The cooldown is read FIRST, without taking anything, so a refusal that
+	// could not have probed anyway never reaches the semaphore. See
+	// canClaimProbe, which also explains why that read cannot replace the claim.
 	if claimable, reason := streak.canClaimProbe(now); !claimable {
-		// The only postponement on this path that used to be silent, and the one
-		// an operator is most likely to be looking at: it is the steady state
-		// for every refusal against a model already at the threshold. Without a
-		// line here, strikes 1 and 2 log at Info and then five minutes go quiet,
-		// with nothing to distinguish waiting out the cooldown from a strike
-		// dropped by one of the gates above.
+		// The steady state for every refusal against a model already at the
+		// threshold. Without a line here, strikes 1 and 2 log at Info and then
+		// five minutes go quiet, with nothing to distinguish waiting out the
+		// cooldown from a strike dropped by one of the gates above.
 		//
-		// Debug for the same reason as the semaphore line below: nothing
-		// throttles it, and a client retry loop against a dead model reaches it
-		// on every request.
+		// Debug because nothing throttles it: a client retry loop against a dead
+		// model reaches it on every request.
 		debuglog.Debug("proxy: postponing auto-disable, "+reason, "model", m.ModelID, "provider", candidate.provider.Name, "endpoint", endpointType, "strikes", streak.count(), "retry_after", goneProbeCooldown.String())
 		return
 	}
 
-	// And the breaker is read before the claim for the same reason the cooldown
-	// is: a claim must only ever be spent on a probe that can actually leave the
-	// process. probeModel asks this too, but it asks from inside the goroutine,
-	// by which point the five minutes are already gone — so a model whose third
-	// strike landed in the gap between the provider's last answer and its circuit
-	// opening bought nothing with them.
+	// The breaker is read before the claim for the same reason the cooldown is: a
+	// claim must only be spent on a probe that can actually leave the process.
+	// probeModel asks this too, but from inside the goroutine, by which point the
+	// five minutes are already gone.
 	//
-	// The window is narrow rather than open-ended, and worth naming so the check
-	// is not read as more than it is: resolveCandidates skips providers whose
-	// circuit is open, so while it stays open nothing is routed to them, no
-	// refusal is classified and no strike is recorded. Only nominations already
-	// at the threshold when the circuit opened are affected, and each is delayed
-	// once.
+	// The window is narrow: resolveCandidates skips providers whose circuit is
+	// open, so while it stays open nothing is routed to them and no strike is
+	// recorded. Only nominations already at the threshold when the circuit opened
+	// are affected, and each is delayed once.
 	//
-	// GetState rather than IsOpen, exactly as probeModel does: IsOpen is the
-	// routing gate and performs the Open->HalfOpen transition, which would spend
-	// the provider's one half-open trial slot on a request the operator never
-	// made. GetState derives the same logical state under a read lock and touches
-	// nothing. The check inside probeModel stays where it is — it is that
-	// function's own contract, and it is what any future caller gets.
+	// GetState rather than IsOpen, exactly as probeModel does — IsOpen is the
+	// routing gate and would spend the provider's one half-open trial slot on a
+	// request the operator never made. The check inside probeModel stays where it
+	// is: it is that function's own contract.
 	if h.circuitBreaker != nil && h.circuitBreaker.GetState(candidate.provider.ID) == failover.StateOpen {
 		debuglog.Debug("proxy: postponing auto-disable, the provider's circuit is open", "model", m.ModelID, "provider", candidate.provider.Name, "endpoint", endpointType)
 		return
@@ -721,13 +605,11 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 
 	release, ok := h.acquireProbeSlot(candidate.provider.ID)
 	if !ok {
-		// Debug, for the same reason the family gate above is: nothing throttles
-		// this line. Since the slot is taken before the claim is spent, every
-		// refusal past the cooldown reaches it, and the case it reports is a
-		// provider-wide nomination event under a client's retry loop — thousands
-		// of lines a second describing a condition an operator can already see in
-		// the probes that ARE going out. The postponement itself costs nothing
-		// and is retried by the next refusal.
+		// Debug because nothing throttles this line: the slot is taken before the
+		// claim is spent, so every refusal past the cooldown reaches it, and the
+		// case it reports is a provider-wide nomination event under a client's
+		// retry loop. The postponement costs nothing and is retried by the next
+		// refusal.
 		debuglog.Debug("proxy: postponing auto-disable, too many retirement probes are already in flight for this provider", "model", m.ModelID, "provider", candidate.provider.Name, "endpoint", endpointType, "limit", goneProbeMaxConcurrent)
 		return
 	}
@@ -744,21 +626,18 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 	modelID, modelName, provider := m.ID, m.ModelID, candidate.provider.Name
 
 	// announceRetirement is everything a disable owes the rest of the system once
-	// the row is actually off, and it is one function because the goroutine below
-	// has four exits that leave it off and only one that does not.
+	// the row is actually off, in one function because the goroutine below has
+	// four exits that leave it off and only one that does not.
 	//
-	// The revalidation is unconditional among those four. Disabling a member does
+	// The revalidation is unconditional among those four: disabling a member does
 	// not resize the custom failover groups it belongs to, so a group can be left
-	// enabled while it no longer has two routable members. Discovery already
-	// revalidates after it disables a model (see discovery_diff.go); this path has
-	// to do the same or an undersized group stays enabled until some unrelated
-	// scan happens to fix it. Best-effort: a failure here must not undo the
-	// disable.
+	// enabled with fewer than two routable members until some unrelated scan
+	// notices. Discovery already revalidates after its own disables (see
+	// discovery_diff.go). Best-effort — a failure here must not undo the disable.
 	//
-	// The alert is not, which is why it is a parameter rather than assumed. It
-	// asserts that THIS model is retired, so it is published only where the
-	// goroutine still knows that to be true — not where the row has moved on
-	// under someone else, and not where the retirement was successfully undone.
+	// The alert is a parameter rather than assumed because it asserts that THIS
+	// model is retired, so it is published only where that is still known to be
+	// true.
 	announceRetirement := func(publish bool) {
 		if h.failoverRepo != nil {
 			vctx, vcancel := context.WithTimeout(context.Background(), goneWriteTimeout)
@@ -796,13 +675,12 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 		defer release()
 
 		// Every other detached goroutine in this package recovers
-		// (touchProviderLastUsed, the log writer, the usage recorder) and this
-		// one now has far more reason to. It used to call repository methods and
-		// nothing else; it now makes an upstream request and runs bytes a
-		// provider chose through the dialect translators, so a panic anywhere in
-		// json, the transport or a translator would take the whole gateway down
-		// over one model's retirement. Recovering leaves the model enabled, which
-		// is the direction every unproven case on this path already takes.
+		// (touchProviderLastUsed, the log writer, the usage recorder), and this
+		// one makes an upstream request and runs bytes a provider chose through
+		// the dialect translators — so a panic in json, the transport or a
+		// translator would take the whole gateway down over one model's
+		// retirement. Recovering leaves the model enabled, which is the direction
+		// every unproven case on this path takes.
 		defer func() {
 			if r := recover(); r != nil {
 				debuglog.Error("proxy: panic while auto-disabling a retired model", "model", modelName, "provider", provider, "error", r)
@@ -822,52 +700,37 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 			return
 		}
 
-		// Ask the provider itself. The three strikes decided this model was
-		// worth one upstream request; what retires it is the answer to that
-		// request.
+		// Ask the provider itself. The strikes decided this model was worth one
+		// upstream request; what retires it is the answer.
 		//
-		// Placed after the cancelled check above and before the write below, and
-		// both halves of that are deliberate. After, because a success that
-		// landed while the disable was queued has already settled the question,
-		// and paying for a probe to re-establish it would spend an upstream call
-		// on an answer already in hand. Before, because the whole point is that
-		// the write is not made on the classifier's reading alone.
-		//
-		// The deadline lives in probeForRetirement, which is still this file
-		// rather than probeModel: the production budget stays with the decision
-		// that owns it, and probeModel stays a helper that issues one request and
-		// reports what came back.
+		// After the cancelled check because a success that landed while the
+		// disable was queued has already settled the question, and before the
+		// write because the whole point is that the write is not made on the
+		// classifier's reading alone.
 		verdict := h.probeForRetirement(candidate, endpointType)
 		// The upstream request is over, so the provider's slot goes back now
 		// rather than at the end of the write. Holding it across
 		// AutoRetireIfConfirmed and the revalidation would tie a cap on
-		// CONNECTIONS to how fast the database is, and halve what four slots can
-		// adjudicate during exactly the provider event they exist for.
+		// CONNECTIONS to how fast the database is.
 		release()
 
 		switch verdict {
 		case probeServed:
-			// The model refused real traffic three times and then answered a
-			// direct request. Warn rather than Info: whatever is going on —
-			// drifted classifier patterns, a provider returning retirement prose
-			// for a transient fault, traffic that carries something the probe
-			// does not — an operator should see it, because it is the case in
-			// which the old code would have retired a working model.
+			// The model refused real traffic and then answered a direct request.
+			// Warn rather than Info: whatever is going on — drifted classifier
+			// patterns, a provider returning retirement prose for a transient
+			// fault, traffic carrying something the probe does not — an operator
+			// should see it, because it is the case in which the classifier alone
+			// would have retired a working model.
 			//
-			// The park is the backoff, and it is why no durable "never retire
-			// this model" store is being added: the count is reset, so the model
-			// needs three FRESH refusals before it is reconsidered, and one that
-			// is genuinely dead simply earns them again while one that is alive
-			// keeps clearing them.
+			// The park is the backoff, and why no durable "never retire this
+			// model" store is needed: the count is reset, so a genuinely dead
+			// model simply earns three FRESH refusals again while a live one keeps
+			// clearing them.
 			//
-			// The streak is parked directly rather than through noteModelServed,
-			// which does the same to the count and additionally sets the
-			// tombstone. There is nothing here for the tombstone to stand down:
-			// the only disable this streak can have queued is this goroutine,
-			// which is about to return.
-			// The count that claimed the probe, for the reason the disable line
-			// below gives: under claimProbe the number that bought it is not
-			// always three.
+			// Parked directly rather than through noteModelServed because there is
+			// nothing here for the tombstone to stand down: the only disable this
+			// streak can have queued is this goroutine, which is about to return.
 			debuglog.Warn("proxy: not auto-disabling, the model answered a direct probe after being reported gone", "model", modelName, "provider", provider, "endpoint", endpointType, "strikes", strikes, "retry_after", goneProbeCooldown.String())
 			streak.park()
 			return
@@ -875,33 +738,27 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 			// Nothing was established: a 429, a 5xx, an entitlement failure, a
 			// connection that never landed, or an expired deadline. Postpone.
 			//
-			// Deliberately NOT the postponements that happen before this
-			// goroutine exists — a busy provider semaphore, an open circuit, a
-			// cooldown still running. Those return on the request path without
-			// producing a verdict at all, and each says so on its own Debug line;
-			// looking for them here is looking in the wrong place.
+			// The count is left exactly where it is. The strikes were real
+			// evidence and nothing has contradicted them, so an unanswered
+			// question must not cost the model its whole case; the next refusal
+			// past goneProbeCooldown re-probes the parked streak.
 			//
-			// The count is left exactly where it is, and neither half of that is
-			// incidental. Postponing means postponing: the strikes were real
-			// evidence and nothing has contradicted them, so throwing them away
-			// would make an unanswered question cost the model its whole case.
+			// The model is NOT credited with a success either. noteModelServed is
+			// not called, so no in-flight disable stands down and no cancelled
+			// flag is set: treating "we could not tell" as "it works" would let a
+			// provider outage clear the streaks of everything behind it.
 			//
-			// This used to delete the streak, for a reason that no longer holds.
-			// Under the old strikes == goneStrikeThreshold gate a parked streak
-			// was unreachable — every later refusal was a no-op — so deleting it
-			// was the only way a model whose first probe hit a 429 could ever be
-			// retired. The cost was that three fresh refusals then bought another
-			// probe, and another, with nothing bounding the rate at a provider
-			// that was already rate limiting us. claimProbe replaces that: the
-			// streak stays parked and the next refusal past goneProbeCooldown
-			// re-probes it, so the retirement stays reachable at one probe per
-			// cooldown instead of one per three refusals.
-			//
-			// The model is still deliberately NOT credited with a success.
-			// noteModelServed is not called, so no in-flight disable is stood
-			// down and no cancelled flag is set — the model has not proved
-			// anything, and treating "we could not tell" as "it works" would let
-			// a provider outage clear the streaks of everything behind it.
+			// Only verdicts are reported here. The postponements that happen
+			// before this goroutine exists — a busy semaphore, an open circuit, a
+			// cooldown still running — never produce one, and log on their own
+			// lines on the request path.
+			if run := streak.noteInconclusiveProbe(); run >= goneProbeInconclusiveWarnAfter {
+				// A model that cannot be adjudicated is costing an upstream
+				// request per cooldown indefinitely. See
+				// goneProbeInconclusiveWarnAfter.
+				debuglog.Warn("proxy: auto-disable postponed repeatedly, the retirement probe keeps establishing nothing", "model", modelName, "provider", provider, "endpoint", endpointType, "strikes", streak.count(), "inconclusive_probes", run, "retry_after", goneProbeCooldown.String())
+				return
+			}
 			debuglog.Info("proxy: postponing auto-disable, the retirement probe established nothing", "model", modelName, "provider", provider, "endpoint", endpointType, "strikes", streak.count(), "retry_after", goneProbeCooldown.String())
 			return
 		case probeRefused:
@@ -910,14 +767,10 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 			// the one the disable is actually written on; fall through.
 		default:
 			// Unreachable while probeVerdict has three values, and present
-			// because the cost of the two outcomes is not symmetric. Go does not
-			// check switch exhaustiveness and no linter here does either, so a
-			// fourth verdict added later would silently fall out of this switch
-			// and into the write below — the one direction the probe is not
-			// allowed to take, since it may only ever PREVENT a disable. Failing
-			// closed means a new verdict postpones until someone decides
-			// otherwise, which is the same answer this file gives to every other
-			// case it cannot substantiate.
+			// because Go does not check switch exhaustiveness and no linter here
+			// does either: a fourth verdict added later would fall through into
+			// the write below, the one direction the probe is not allowed to
+			// take. Failing closed postpones until someone decides otherwise.
 			debuglog.Warn("proxy: postponing auto-disable, unrecognised retirement probe verdict", "model", modelName, "provider", provider, "endpoint", endpointType, "verdict", verdict.String())
 			return
 		}
@@ -938,16 +791,10 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 			debuglog.Error("proxy: failed to auto-disable retired model", "model", modelName, "provider", provider, "error", err, "retry_after", goneProbeCooldown.String())
 			// Nothing is touched, and that is the retry. The streak keeps its
 			// count and its stamp, so the next refusal past goneProbeCooldown
-			// claims a probe and the disable is attempted again.
-			//
-			// This used to delete the streak, for the same reason the
-			// inconclusive path did and with the same cost. Under the old
-			// strikes == goneStrikeThreshold gate a parked count was
-			// unreachable, so dropping it was the only way a model whose write
-			// failed could ever be retired; claimProbe made it reachable, and
-			// deleting also threw away the cooldown — which turned a database
-			// outage into three fresh refusals buying another upstream probe,
-			// on repeat, for every model refusing traffic at the time.
+			// claims a probe and the disable is attempted again. Dropping the
+			// streak instead would throw away the cooldown with it, turning a
+			// database outage into three fresh refusals buying another upstream
+			// probe on repeat, for every model refusing traffic at the time.
 			return
 		}
 
@@ -962,56 +809,38 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 		}
 
 		// One window is left, and it is the only one staging cannot close: a
-		// success that lands after confirm has already returned, while the
-		// commit is on its way to the database. That write cannot be recalled,
-		// so it is undone instead.
+		// success that lands after confirm has returned, while the commit is on
+		// its way to the database. That write cannot be recalled, so it is undone
+		// instead.
 		//
-		// Serialising would close it, and is not available here.
-		// noteModelServed runs on the request path (see proxy_failover.go), so
-		// holding a lock across the write would put client latency behind a
-		// database write belonging to an unrelated request's error path.
+		// Serialising would close it and is not available here: noteModelServed
+		// runs on the request path (see proxy_failover.go), so holding a lock
+		// across the write would put client latency behind a database write
+		// belonging to an unrelated request's error path.
 		//
-		// It runs AFTER the non-streaming response is written now, not before:
-		// the clear is judged on what the handler decoded rather than on the 200
-		// that preceded it. That widens this window slightly — the cancel signal
-		// lands later, so AutoRetireIfConfirmed has more room to commit before a
-		// success is observed — which changes nothing here, because the window
-		// this comment is about is the one the revert below exists for.
-		//
-		// The disabled state IS briefly visible on this path, which is what the
-		// staging above exists to avoid. Accepted, because the alternative is
-		// worse: leaving the model disabled when it has just proved it works.
-		// The window is now one commit rather than a whole check-write-check
-		// cycle, and the model ends up correct either way.
+		// The disabled state IS briefly visible here, which is what the staging
+		// above exists to avoid. Accepted, because the alternative is leaving the
+		// model disabled when it has just proved it works, and the window is one
+		// commit rather than a whole check-write-check cycle.
 		if streak.cancelled.Load() {
 			// The success that cancelled this retirement can itself be out of
 			// date: it cleared the count, and refusals arriving since can have
 			// rebuilt it past the threshold inside this same write window.
-			// Reverting on the strength of the older success would re-enable a
-			// model that current evidence says is gone, and the rebuilt streak
-			// would stand down at its own claim when it found the model already
-			// retired — by this very write.
+			// Reverting on the older success would re-enable a model that current
+			// evidence says is gone, and the rebuilt streak would stand down at
+			// its own claim on finding the model already retired — by this write.
+			// So the revert defers to what the model is saying NOW.
 			//
-			// So the revert defers to whatever the model is saying NOW rather
-			// than to the success that scheduled it. The count is read off this
-			// streak directly: nothing removes an entry from h.goneStrikes, so a
-			// lookup by model id could only ever return the same struct, and
-			// supersede's single critical section is what guarantees the count
-			// read here is the one that belongs to the tombstone read above.
-			// Three of the four ways out of here leave the model DISABLED, and
-			// each of them still owes the retirement its follow-through. The
-			// revalidation is the load-bearing half: a disabled member does not
-			// resize the custom groups it belongs to, so skipping it leaves a
-			// group enabled with fewer than two routable members until some
-			// unrelated scan happens to notice — which is the whole reason the
-			// call exists. Only a revert that actually landed is exempt, because
-			// then nothing happened as far as anyone outside this goroutine is
-			// concerned.
+			// The count is read off this streak directly: nothing removes an entry
+			// from h.goneStrikes, and supersede's single critical section is what
+			// guarantees the count read here belongs to the tombstone read above.
 			//
-			// The alert is judged separately, because it asserts something
-			// stronger than the revalidation does. It says this model is retired,
-			// so it is published only where that is known to be true: the two
-			// arms below where the row is still exactly as this write left it.
+			// Three of the four ways out leave the model DISABLED and each still
+			// owes the retirement its revalidation; only a revert that landed is
+			// exempt, because then nothing happened as far as anyone outside this
+			// goroutine is concerned. The alert is judged separately because it
+			// asserts something stronger: it is published only on the arms where
+			// the row is still exactly as this write left it.
 			if streak.count() >= goneStrikeThreshold {
 				debuglog.Info("proxy: not reverting the auto-disable, the model is refusing again", "model", modelName, "provider", provider)
 				announceRetirement(true)
@@ -1053,36 +882,20 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 			return
 		}
 
-		// The verdict is stamped on the line and in the event, and it is the
-		// point of the line rather than decoration. Before the probe existed
-		// this log and this alert were written on three classifier readings of
-		// provider prose; they now mean something materially different, and they
-		// said exactly the same words. An operator upgrading could not tell a
-		// verified retirement from an unverified one in their own logs, and the
-		// refused verdict is both the common outcome and the only one that costs
-		// an upstream call AND writes to the database. The design asked for this
-		// directly: the probe is a call the operator did not make, so it should
-		// be logged as what it is.
+		// The verdict is stamped on the line and in the event so a verified
+		// retirement can be told from an unverified one: the words were identical
+		// before the probe existed, and the probe is a call the operator did not
+		// make. The endpoint family rides along because it decides which surface
+		// was asked and whether the model was eligible for auto-retirement at all.
 		//
-		// The endpoint family rides along for the same reason. It decides which
-		// surface was asked and whether the model was eligible for auto-
-		// retirement at all, so a retirement that cannot be traced back to a
-		// family cannot be argued with.
-		//
-		// The strike count is the streak's own, not goneStrikeThreshold. The
-		// constant was accurate while a retirement could only be triggered by the
-		// caller that saw exactly three; claimProbe replaced that gate, so this
-		// write can equally stand on a streak sitting at fifty under a retry
-		// loop, or on a single refusal that re-claimed a streak parked since the
-		// last cooldown. Reporting the constant would tell every operator the
-		// same story about a decision that was reached differently.
+		// The strike count is the streak's own, not goneStrikeThreshold: under
+		// claimProbe this write can stand on a streak sitting at fifty under a
+		// retry loop, or on a single refusal that re-claimed a parked streak.
 		//
 		// It is the count this refusal SAW, captured before the probe rather than
-		// read back here. Nothing clears the counter on the retire path, and this
-		// point is up to a probe timeout and a database write later, so reading it
-		// now would report a number inflated by every refusal that arrived while
-		// the decision was being made — which is the opposite of "how was this
-		// decision reached".
+		// read back here — this point is up to a probe timeout and a database
+		// write later, so reading it now would report a number inflated by every
+		// refusal that arrived while the decision was being made.
 		debuglog.Warn("proxy: auto-disabled retired model", "model", modelName, "provider", provider, "strikes", strikes, "endpoint", endpointType, "probe_verdict", probeRefused.String())
 		announceRetirement(true)
 	}()
@@ -1091,39 +904,30 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 // probeForRetirement runs the pre-retirement probe under the production
 // deadline and reports what it found.
 //
-// It is a separate function because the deadline belongs here and not inside
-// probeModel: the number the operator's cost depends on stays beside the
-// decision that spends it rather than buried in a helper, and a test can still
-// drive the real probe with a deadline measured in milliseconds.
+// Separate from probeModel because the deadline belongs beside the decision that
+// spends it rather than buried in a helper, and a test can then drive the real
+// probe with a deadline measured in milliseconds.
 //
-// The per-provider slot is NOT taken here. It is taken by the caller before the
+// The per-provider slot is NOT taken here. The caller takes it before the
 // model's claim is spent, because a refused slot must cost nothing — see
-// noteModelGone for what taking them in the other order did to a provider-wide
-// nomination event.
+// noteModelGone.
 //
-// The deadline is generous. A cold model can take tens of seconds to answer,
-// and a probe that times out on a slow but living model postpones the
-// retirement rather than confirming it, which is the safe direction but still a
-// wasted call. Nothing on the request path is waiting on any of it.
+// The deadline is generous: a cold model can take tens of seconds, and a probe
+// that times out on a slow but living model postpones rather than confirms.
+// Nothing on the request path is waiting on any of it.
 //
 // The context is Background and not tied to server shutdown, which is what the
-// detachment costs and is worth stating rather than leaving to be discovered.
-// The retirement's worst case is now this probe plus up to three ten-second
-// writes, so a nomination that lands just before shutdown can spend one upstream
-// request and then find a closing pool. What that produces is a failed write on
-// a path that already treats a failed write as "change nothing and retry": the
-// streak keeps its strikes, nothing is disabled, and the next process re-earns
-// the decision from its own traffic. Closing it properly means a handler-scoped
-// parent context, which is a lifecycle this Handler does not have and is not
-// worth inventing for one background probe.
+// detachment costs. A nomination landing just before shutdown can spend one
+// upstream request and then find a closing pool, which produces a failed write
+// on a path that already treats one as "change nothing and retry". Closing that
+// properly means a handler-scoped parent context, a lifecycle this Handler does
+// not have.
 func (h *Handler) probeForRetirement(candidate modelCandidate, endpointType string) probeVerdict {
-	// Before anything is dereferenced, and that is the point of it being here.
-	// probeModel makes the same check, but the fields this function touches on
-	// the way there would already have panicked, so the guard downstream was
-	// promising a postponement it could never deliver. A panic here is caught by
-	// the disable goroutine's recover and reported as a panic, which is the
-	// wrong answer to "is this model still served": nothing was established, and
-	// nothing being established is what probeInconclusive means.
+	// Before anything is dereferenced. probeModel makes the same check, but the
+	// fields this function touches on the way there would already have panicked,
+	// so the guard downstream was promising a postponement it could not deliver.
+	// A panic is the wrong answer to "is this model still served": nothing was
+	// established, which is what probeInconclusive means.
 	if candidate.model == nil || candidate.provider == nil {
 		return probeInconclusive
 	}
@@ -1136,27 +940,20 @@ func (h *Handler) probeForRetirement(candidate modelCandidate, endpointType stri
 // acquireProbeSlot takes one of the provider's goneProbeMaxConcurrent probe
 // slots without waiting, returning the release for it.
 //
-// The release is idempotent, because the caller has two of them: an explicit one
+// The release is idempotent because the caller has two of them: an explicit one
 // the moment the upstream request is done, so the slot is not held across a
 // database write, and a deferred one covering the paths that never reach it.
 // Without sync.OnceFunc the second call would drain a slot belonging to somebody
-// else's probe, which is the kind of bug that only shows up under the burst the
-// semaphore exists for.
+// else's probe.
 //
-// Load is tried first and LoadOrStore only on a miss, so the common case — a
-// provider whose semaphore already exists, which is every probe after the
-// first for that provider — does not allocate and immediately discard a
-// channel it will never use. The allocation only happens on a genuine miss,
-// and the per-provider semaphore is still created on first use through
-// LoadOrStore there, so a race on that miss only duplicates the channel that
-// loses, and the winner's is the one everyone counts against — the same
-// pattern, and the same reasoning, as the per-model streaks in goneStrikes.
+// Load is tried first and LoadOrStore only on a miss, so the common case does
+// not allocate a channel it will never use. A race on that miss only duplicates
+// the channel that loses — the same pattern as the per-model streaks in
+// goneStrikes.
 //
-// Entries are never removed, and that is a bounded leak by construction rather
-// than an oversight: the key space is the operator's configured providers, a
-// number in the tens, and each entry is one small channel. Reclaiming them would
-// need to prove no probe is in flight for that provider first, which is more
-// machinery and more ways to be wrong than the bytes are worth.
+// Entries are never removed: the key space is the operator's configured
+// providers, a number in the tens, each one small channel. Reclaiming them would
+// need to prove no probe is in flight for that provider first.
 func (h *Handler) acquireProbeSlot(providerID uuid.UUID) (release func(), ok bool) {
 	raw, loaded := h.goneProbeSlots.Load(providerID)
 	if !loaded {
@@ -1165,11 +962,9 @@ func (h *Handler) acquireProbeSlot(providerID uuid.UUID) (release func(), ok boo
 	sem, isChan := raw.(chan struct{})
 	if !isChan {
 		// Unreachable by construction: this function is the only writer of the
-		// map and only ever stores a chan struct{}. It is logged rather than
-		// left silent because the caller cannot tell this apart from a full
-		// semaphore, and reports the postponement as probe throttling — which
-		// would send an operator looking at a concurrency cap that has nothing
-		// to do with it.
+		// map and only ever stores a chan struct{}. Logged rather than left
+		// silent because the caller cannot tell it apart from a full semaphore
+		// and would report the postponement as probe throttling.
 		debuglog.Error("proxy: retirement probe slot map holds an unexpected value, so no slot can be taken", "provider_id", providerID, "type", fmt.Sprintf("%T", raw))
 		return nil, false
 	}
@@ -1261,12 +1056,10 @@ func producedOutput(logData *requestLogData) bool {
 // the hedged path previously returned without recording any verdict at all, so
 // a model retired mid-stream stayed routable whenever hedging was enabled.
 func (h *Handler) noteStreamOutcome(logData *requestLogData, candidate modelCandidate) {
-	// The guard belongs here, not in producedOutput. That function checks
-	// for nil too and is tested for it, but this expression dereferences logData
-	// to build its arguments, and Go evaluates all of them before the call — so
-	// on this path the helper's guard could never run and a nil would panic
-	// before reaching it. Same shape as probeForRetirement's: a check downstream
-	// of the dereference promises something it cannot deliver.
+	// The guard belongs here, not in producedOutput. That function checks for nil
+	// too, but this expression dereferences logData to build its arguments and Go
+	// evaluates all of them before the call, so the helper's guard could never
+	// run. Same shape as probeForRetirement's.
 	if logData == nil {
 		return
 	}
@@ -1295,45 +1088,31 @@ func (h *Handler) noteStreamOutcome(logData *requestLogData, candidate modelCand
 //
 // It also cancels a disable that has been decided but not yet written, which is
 // why it goes through supersede rather than setting the flag and parking
-// separately: a queued disable reads both, and has to see them change together.
+// separately: a queued disable reads both and has to see them change together.
 //
 // The entry is parked, not dropped, and the difference is the probe cooldown.
 // Deleting it took nextProbeAt with it, so a success between refusals reset the
-// rate bound — and a model that refuses some request shapes while serving
-// others produces exactly that interleaving. Three refusals then bought a probe,
-// a success wiped the stamp, three more refusals bought another, indefinitely.
-// A success clears what the model is accused of; it does not buy the gateway
-// another free upstream call. See park.
+// rate bound — and a model that refuses some request shapes while serving others
+// produces exactly that interleaving. A success clears what the model is accused
+// of; it does not buy the gateway another free upstream call. See park.
 //
-// The success clears ONE surface: the one it arrived on. It used to clear all of
-// them, on the argument that a success is evidence about the model and that
-// clearing can only ever prevent a retirement — but that argument, taken
-// seriously, also justifies never retiring anything, and it undoes on the
-// clearing side exactly the split the strike side was given.
+// The success clears ONE surface: the one it arrived on. Clearing globally
+// answered two separate questions as one — a provider that had retired a model's
+// chat surface while still serving its embeddings would have every embeddings
+// success wipe the chat streak, so the dead surface could never accumulate three
+// consecutive strikes and would never be adjudicated at all. Tightening it is
+// safe because what retires a model is the PROBE, and the probe asks on the same
+// surface.
 //
-// The split exists because a model can be served on one surface and refused on
-// another, and the two are separate questions. Clearing globally answered them
-// as one: a provider that had retired a model's chat surface while still serving
-// its embeddings would have every embeddings success wipe the chat streak, so
-// the dead surface could never accumulate three consecutive strikes and would
-// never be adjudicated at all — the case this feature exists to catch.
+// A family that cannot be probed clears nothing, following the strike side: an
+// image or TTS response is not evidence about the chat surface any more than an
+// image refusal is. It is also why this takes an endpointType rather than
+// deriving one — every caller has the family that ingest stamped.
 //
-// Tightening it is safe for the reason the whole branch is built on: what
-// retires a model is the PROBE, and the probe asks on the same surface. A chat
-// streak that survives an embeddings success still has to be refused by a real
-// request to /chat/completions before anything is written.
-//
-// A family that cannot be probed clears nothing, which is the same rule the
-// strike side follows: an image or TTS response is not evidence about the chat
-// surface any more than an image refusal is. It is also why this takes an
-// endpointType rather than deriving anything: every caller (a chat 200, a
-// pass-through 2xx, a finished stream) has the family that ingest stamped.
-//
-// supersede reports whether it changed anything, and the log line is conditional
-// on that. Since nothing removes entries, a model that drew one refusal at 09:00
-// keeps its parked streak for the life of the process, and an unconditional line
-// would then claim to have "cleared gone-strikes" on every successful request to
-// that model from then on — a log that describes work nobody did.
+// The log line is conditional on supersede having changed something. Nothing
+// removes entries, so a model that drew one refusal at 09:00 keeps its parked
+// streak for the life of the process, and an unconditional line would claim to
+// have "cleared gone-strikes" on every successful request from then on.
 func (h *Handler) noteModelServed(m *model.Model, endpointType string) {
 	if m == nil || m.ID == uuid.Nil {
 		return

--- a/internal/proxy/model_gone.go
+++ b/internal/proxy/model_gone.go
@@ -668,10 +668,14 @@ func (h *Handler) probeForRetirement(candidate modelCandidate, endpointType stri
 // acquireProbeSlot takes one of the provider's goneProbeMaxConcurrent probe
 // slots without waiting, returning the release for it.
 //
-// The per-provider semaphore is created on first use through LoadOrStore, so a
-// race only duplicates the channel that loses, and the winner's is the one
-// everyone counts against — the same pattern, and the same reasoning, as the
-// per-model streaks in goneStrikes.
+// Load is tried first and LoadOrStore only on a miss, so the common case — a
+// provider whose semaphore already exists, which is every probe after the
+// first for that provider — does not allocate and immediately discard a
+// channel it will never use. The allocation only happens on a genuine miss,
+// and the per-provider semaphore is still created on first use through
+// LoadOrStore there, so a race on that miss only duplicates the channel that
+// loses, and the winner's is the one everyone counts against — the same
+// pattern, and the same reasoning, as the per-model streaks in goneStrikes.
 //
 // Entries are never removed, and that is a bounded leak by construction rather
 // than an oversight: the key space is the operator's configured providers, a
@@ -679,7 +683,10 @@ func (h *Handler) probeForRetirement(candidate modelCandidate, endpointType stri
 // need to prove no probe is in flight for that provider first, which is more
 // machinery and more ways to be wrong than the bytes are worth.
 func (h *Handler) acquireProbeSlot(providerID uuid.UUID) (release func(), ok bool) {
-	raw, _ := h.goneProbeSlots.LoadOrStore(providerID, make(chan struct{}, goneProbeMaxConcurrent))
+	raw, loaded := h.goneProbeSlots.Load(providerID)
+	if !loaded {
+		raw, _ = h.goneProbeSlots.LoadOrStore(providerID, make(chan struct{}, goneProbeMaxConcurrent))
+	}
 	sem, isChan := raw.(chan struct{})
 	if !isChan {
 		return nil, false

--- a/internal/proxy/model_gone.go
+++ b/internal/proxy/model_gone.go
@@ -565,7 +565,7 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 	// faithfully. What each surface demands of the catalog, and why the two
 	// differ, is argued in modalityRulesOutSurface.
 	if modalityRulesOutSurface(m, probeEndpoint) {
-		debuglog.Debug("proxy: ignoring a gone-classified refusal on a surface this model is not known to serve", "model", m.ModelID, "provider", candidate.provider.Name, "endpoint", endpointType, "output_modalities", m.OutputModalities)
+		debuglog.Debug("proxy: ignoring a gone-classified refusal on a surface this model is not known to serve", "model", m.ModelID, "provider", candidate.provider.Name, "endpoint", endpointType, "input_modalities", m.InputModalities, "output_modalities", m.OutputModalities)
 		return
 	}
 
@@ -575,7 +575,7 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 	// probeable surfaces those two are not the same scope. See
 	// modalityAdmitsBothProbeSurfaces.
 	if modalityAdmitsBothProbeSurfaces(m) {
-		debuglog.Debug("proxy: ignoring a gone-classified refusal on a model that serves both probeable surfaces, which one disable cannot separate", "model", m.ModelID, "provider", candidate.provider.Name, "endpoint", endpointType, "output_modalities", m.OutputModalities)
+		debuglog.Debug("proxy: ignoring a gone-classified refusal on a model that serves both probeable surfaces, which one disable cannot separate", "model", m.ModelID, "provider", candidate.provider.Name, "endpoint", endpointType, "input_modalities", m.InputModalities, "output_modalities", m.OutputModalities)
 		return
 	}
 
@@ -671,6 +671,17 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 	// The read cannot replace the claim — two callers can both see true and only
 	// one may proceed — which is why claimProbe still decides below.
 	if !streak.canClaimProbe(now) {
+		// The only postponement on this path that used to be silent, and the one
+		// an operator is most likely to be looking at: it is the steady state
+		// for every refusal against a model already at the threshold. Without a
+		// line here, strikes 1 and 2 log at Info and then five minutes go quiet,
+		// with nothing to distinguish waiting out the cooldown from a strike
+		// dropped by one of the gates above.
+		//
+		// Debug for the same reason as the semaphore line below: nothing
+		// throttles it, and a client retry loop against a dead model reaches it
+		// on every request.
+		debuglog.Debug("proxy: postponing auto-disable, the model is inside its probe cooldown", "model", m.ModelID, "provider", candidate.provider.Name, "endpoint", endpointType, "strikes", strikes, "retry_after", goneProbeCooldown.String())
 		return
 	}
 

--- a/internal/proxy/model_gone.go
+++ b/internal/proxy/model_gone.go
@@ -55,11 +55,17 @@ const goneStrikeThreshold = 3
 // A strike arriving after this long starts the streak over rather than adding to
 // it, so a retirement is always drawn from one run of recent traffic.
 //
+// It bounds the GAP between consecutive strikes, not the span of the streak.
+// Refusals at 0, 29 and 58 minutes are one streak of three, because neither gap
+// exceeds the window; the count only restarts when a strike arrives more than
+// this long after the one before it. Written out because "three strikes within
+// 30 minutes" is the natural way to say it and is not what the code does.
+//
 // Thirty minutes is chosen against real traffic rather than as a round number:
-// three requests to the same model have to fall inside it, which a gateway with
-// any load does easily, while a model receiving one request an hour will never
-// accumulate a streak. That second case is deliberate — a model too idle to fail
-// three times in half an hour is also too idle for its staying enabled to cost
+// each refusal only has to arrive within half an hour of the last one, which a
+// gateway with any load does easily, while a model refused once an hour never
+// accumulates a streak at all. That second case is deliberate — a model too idle
+// to fail twice in half an hour is also too idle for its staying enabled to cost
 // anything, and traffic-driven retirement should not be guessing from sparse
 // evidence.
 const goneStrikeWindow = 30 * time.Minute
@@ -425,11 +431,13 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 	// The counter is still deliberately NOT cleared on the way to a disable.
 	// Clearing it would let the next refusal start a fresh count from zero, so a
 	// burst against a dead model would re-enter the threshold every three
-	// strikes. Only two paths clear it now: noteModelServed, when the model
-	// proves it is alive, and a disable that could not be WRITTEN, so the
-	// attempt is retried rather than lost. A retirement that did land does not
-	// need the guard — the model is disabled, so no traffic reaches it to strike
-	// it again, and a straggler that arrives past the cooldown finds
+	// strikes. Exactly two things clear it, and both are the model answering:
+	// noteModelServed, when a request to it succeeds, and the served-probe branch
+	// below, when the probe gets content out of it. A disable that could not be
+	// written clears nothing at all — the streak stays as it is and the next
+	// refusal past the cooldown retries it. A retirement that did land does not
+	// need the guard either: the model is disabled, so no traffic reaches it to
+	// strike it again, and a straggler that arrives past the cooldown finds
 	// AutoRetireIfConfirmed refusing to write over an already-retired row, which
 	// reports as an uncommitted attempt and publishes no second alert.
 	if !streak.claimProbe(now) {
@@ -506,7 +514,11 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 			// tombstone. There is nothing here for the tombstone to stand down:
 			// the only disable this streak can have queued is this goroutine,
 			// which is about to return.
-			debuglog.Warn("proxy: not auto-disabling, the model answered a direct probe after being reported gone", "model", modelName, "provider", provider, "endpoint", endpointType, "strikes", goneStrikeThreshold, "retry_after", goneProbeCooldown.String())
+			// The streak's own count, for the reason the disable line below gives:
+			// under claimProbe the number that bought this probe is not always
+			// three. Read before the park, so it is the count that nominated the
+			// model rather than the zero it is about to become.
+			debuglog.Warn("proxy: not auto-disabling, the model answered a direct probe after being reported gone", "model", modelName, "provider", provider, "endpoint", endpointType, "strikes", streak.count(), "retry_after", goneProbeCooldown.String())
 			streak.park()
 			return
 		case probeInconclusive:
@@ -672,7 +684,16 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 		// surface was asked and whether the model was eligible for auto-
 		// retirement at all, so a retirement that cannot be traced back to a
 		// family cannot be argued with.
-		debuglog.Warn("proxy: auto-disabled retired model", "model", modelName, "provider", provider, "strikes", goneStrikeThreshold, "endpoint", endpointType, "probe_verdict", probeRefused.String())
+		//
+		// The strike count is the streak's own, not goneStrikeThreshold. The
+		// constant was accurate while a retirement could only be triggered by the
+		// caller that saw exactly three; claimProbe replaced that gate, so this
+		// write can equally stand on a streak sitting at fifty under a retry
+		// loop, or on a single refusal that re-claimed a streak parked since the
+		// last cooldown. Reporting the constant would tell every operator the
+		// same story about a decision that was reached differently.
+		strikes := streak.count()
+		debuglog.Warn("proxy: auto-disabled retired model", "model", modelName, "provider", provider, "strikes", strikes, "endpoint", endpointType, "probe_verdict", probeRefused.String())
 
 		// Disabling a member does not resize the custom failover groups it
 		// belongs to, so a group can be left enabled while it no longer has two
@@ -697,7 +718,7 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 				"model_id":      modelName,
 				"model_uuid":    modelID.String(),
 				"provider_name": provider,
-				"strikes":       goneStrikeThreshold,
+				"strikes":       strikes,
 				"reason":        string(KindProviderModelGone),
 				"probe_verdict": probeRefused.String(),
 				"endpoint_type": endpointType,

--- a/internal/proxy/model_gone.go
+++ b/internal/proxy/model_gone.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 	"github.com/hugalafutro/model-hotel/internal/events"
+	"github.com/hugalafutro/model-hotel/internal/failover"
 	"github.com/hugalafutro/model-hotel/internal/model"
 )
 
@@ -119,11 +120,12 @@ const goneProbeCooldown = 5 * time.Minute
 //
 // Four slots, following the argon2 semaphore in internal/user: enough that an
 // ordinary trickle of retirements never queues, small enough that the worst case
-// is a handful of extra connections. The acquire is non-blocking on purpose (see
-// probeForRetirement): a probe that cannot get a slot postpones rather than
-// waiting, because the streak's nextProbeAt is already stamped and the retry
-// arrives on its own after the cooldown. Blocking would hold goroutines and
-// slots for work whose whole justification is that it is not urgent.
+// is a handful of extra connections. The acquire is non-blocking on purpose: a
+// probe that cannot get a slot drops out rather than waiting, and costs nothing
+// on the way — the slot is taken before the model's claim is spent, so the next
+// refusal retries immediately (see noteModelGone). Blocking would hold
+// goroutines and slots for work whose whole justification is that it is not
+// urgent.
 const goneProbeMaxConcurrent = 4
 
 // goneWriteTimeout bounds each out-of-band write the auto-disable makes.
@@ -616,6 +618,32 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 	if !streak.canClaimProbe(now) {
 		return
 	}
+
+	// And the breaker is read before the claim for the same reason the cooldown
+	// is: a claim must only ever be spent on a probe that can actually leave the
+	// process. probeModel asks this too, but it asks from inside the goroutine,
+	// by which point the five minutes are already gone — so a model whose third
+	// strike landed in the gap between the provider's last answer and its circuit
+	// opening bought nothing with them.
+	//
+	// The window is narrow rather than open-ended, and worth naming so the check
+	// is not read as more than it is: resolveCandidates skips providers whose
+	// circuit is open, so while it stays open nothing is routed to them, no
+	// refusal is classified and no strike is recorded. Only nominations already
+	// at the threshold when the circuit opened are affected, and each is delayed
+	// once.
+	//
+	// GetState rather than IsOpen, exactly as probeModel does: IsOpen is the
+	// routing gate and performs the Open->HalfOpen transition, which would spend
+	// the provider's one half-open trial slot on a request the operator never
+	// made. GetState derives the same logical state under a read lock and touches
+	// nothing. The check inside probeModel stays where it is — it is that
+	// function's own contract, and it is what any future caller gets.
+	if h.circuitBreaker != nil && h.circuitBreaker.GetState(candidate.provider.ID) == failover.StateOpen {
+		debuglog.Debug("proxy: postponing auto-disable, the provider's circuit is open", "model", m.ModelID, "provider", candidate.provider.Name, "endpoint", endpointType)
+		return
+	}
+
 	release, ok := h.acquireProbeSlot(candidate.provider.ID)
 	if !ok {
 		// Debug, for the same reason the family gate above is: nothing throttles

--- a/internal/proxy/model_gone.go
+++ b/internal/proxy/model_gone.go
@@ -2,7 +2,9 @@ package proxy
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -136,6 +138,58 @@ const goneProbeMaxConcurrent = 4
 // The work is already detached from the request path, so nothing is waiting on
 // the total. Bounding each step is what keeps every step able to do its job.
 const goneWriteTimeout = 10 * time.Second
+
+// goneStreakKey identifies a streak: one model, on one upstream surface.
+//
+// The surface is the PROBE endpoint (see probeEndpointForFamily), not the
+// endpoint family, so chat and messages share a streak while embeddings keeps
+// its own. That is the right grain because it is exactly what the probe can ask:
+// two front doors onto the same question are one question, and a different door
+// onto a different question is a different streak.
+type goneStreakKey struct {
+	model    uuid.UUID
+	endpoint string
+}
+
+// goneProbeSurfaces is every endpoint a streak can be keyed on.
+//
+// It has to agree with probeEndpointForFamily's returns, and
+// TestProbeEndpointForFamily_SurfacesAreCovered fails if a new probeable family
+// introduces a surface that is missing here. The one caller that needs it is
+// noteModelServed, which has a model and no family: a success clears the model's
+// streaks on every surface, so it enumerates them rather than scanning the map.
+var goneProbeSurfaces = [...]string{probeChatEndpoint, probeEmbeddingsEndpoint}
+
+// modalityContradictsSurface reports whether the model's own catalog metadata
+// says it is not for this upstream surface.
+//
+// Positive evidence of a mismatch only. An empty, unparseable or unrecognised
+// modality list is not a contradiction: rows predating the modality columns and
+// providers that report nothing must keep the retirement they have today, and
+// the alternative — treating "we cannot tell" as "do not retire" — would switch
+// auto-retirement off silently for whole catalogs. What it catches is the case
+// the catalog is explicit about: a text model refused on /embeddings, or an
+// embedding-only model refused on /chat/completions.
+//
+// Reading output modalities rather than input: discovery classifies an
+// embeddings model by what it PRODUCES (["embedding"]), which is the only field
+// that separates it from a chat model taking the same text input.
+func modalityContradictsSurface(m *model.Model, probeEndpoint string) bool {
+	if m.OutputModalities == "" || m.OutputModalities == "[]" {
+		return false
+	}
+	var out []string
+	if json.Unmarshal([]byte(m.OutputModalities), &out) != nil || len(out) == 0 {
+		return false
+	}
+	embeds := slices.Contains(out, "embedding")
+	if probeEndpoint == probeEmbeddingsEndpoint {
+		return !embeds
+	}
+	// The chat surface: only an embedding-ONLY model contradicts it. A model
+	// that produces embeddings alongside text is not evidence of anything.
+	return embeds && len(out) == 1
+}
 
 // goneStreak is one model's consecutive-refusal count plus a tombstone for the
 // window between deciding to disable and the write landing.
@@ -295,11 +349,23 @@ func (s *goneStreak) park() {
 // Storing inside the lock is what closes it: once a reader observes the
 // tombstone the writer is still holding mu, so the count it goes on to ask for
 // cannot be read until this has finished zeroing it.
-func (s *goneStreak) supersede() {
+//
+// It reports whether it changed anything, for the caller's log line rather than
+// for control flow. A streak already at zero with the tombstone already set has
+// been superseded by an earlier success and there is nothing left to stand down
+// — which is the steady state for any model that drew one refusal and then went
+// on serving, since nothing removes entries. The early return is deliberately
+// that narrow: a count of zero with no tombstone can still belong to a disable
+// this success has to cancel.
+func (s *goneStreak) supersede() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if s.n == 0 && s.cancelled.Load() {
+		return false
+	}
 	s.cancelled.Store(true)
 	s.clearLocked()
+	return true
 }
 
 // clearLocked resets the evidence. Callers hold mu.
@@ -380,8 +446,32 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 	// as long as traffic keeps arriving, precisely BECAUSE it is never retired
 	// to make it stop. At Info that is an unbounded line in every operator's log
 	// for a condition that is by design permanent.
-	if _, ok := probeEndpointForFamily(endpointType); !ok {
+	probeEndpoint, ok := probeEndpointForFamily(endpointType)
+	if !ok {
 		debuglog.Debug("proxy: provider reports model gone on an endpoint family that cannot be probed, so it is never auto-retired", "model", m.ModelID, "provider", candidate.provider.Name, "endpoint", endpointType)
+		return
+	}
+
+	// The second gate: the refusal has to be about a surface this model is FOR.
+	//
+	// Nothing filters a request by modality on the way in. `POST /v1/embeddings`
+	// with a chat model's name is forwarded to the provider's embeddings
+	// endpoint, and a provider that answers "gpt-4o is not supported for
+	// embeddings" has named the model beside a gone-phrase, which
+	// classifyUpstreamError reads as a retirement. Three of those from one
+	// misconfigured client used to nominate the model, and the probe could not
+	// save it: the probe asks on the family the strikes arrived on, so it
+	// reproduces the misuse faithfully, draws the same refusal and confirms a
+	// retirement of a model that serves chat perfectly. The disable is
+	// model-wide, so a surface-specific refusal would take the model out of
+	// routing everywhere.
+	//
+	// This is the same argument as the family gate above, applied to the one
+	// direction that gate cannot see: chat and embeddings are both probeable, so
+	// the mismatch is between the model and the surface rather than between the
+	// surface and the probe.
+	if modalityContradictsSurface(m, probeEndpoint) {
+		debuglog.Debug("proxy: ignoring a gone-classified refusal on a surface this model is not for", "model", m.ModelID, "provider", candidate.provider.Name, "endpoint", endpointType, "output_modalities", m.OutputModalities)
 		return
 	}
 
@@ -395,7 +485,16 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 	// sync.Map holds a per-model *goneStreak rather than a plain int, so
 	// LoadOrStore only races on creating it (harmless, the winner's is used by
 	// everyone) and the increment itself is atomic.
-	raw, _ := h.goneStrikes.LoadOrStore(m.ID, &goneStreak{})
+	//
+	// Keyed by model AND probe surface, not by model alone. The two are separate
+	// questions — a model can be served on one surface and refused on another —
+	// and the probe is sent to the surface the strikes came from, so pooling them
+	// let two chat refusals plus one embeddings refusal buy an embeddings probe.
+	// Keyed this way, every streak names one surface, and what the probe asks is
+	// always what the strikes were about. Chat and messages share a key by
+	// design: they resolve to the same probe endpoint, so they are the same
+	// question asked through two front doors.
+	raw, _ := h.goneStrikes.LoadOrStore(goneStreakKey{model: m.ID, endpoint: probeEndpoint}, &goneStreak{})
 	streak, ok := raw.(*goneStreak)
 	if !ok {
 		return
@@ -919,18 +1018,35 @@ func (h *Handler) noteStreamOutcome(logData *requestLogData, candidate modelCand
 // a success wiped the stamp, three more refusals bought another, indefinitely.
 // A success clears what the model is accused of; it does not buy the gateway
 // another free upstream call. See park.
+//
+// Every surface, because a success is evidence about the MODEL. The caller has a
+// model and no endpoint family (a streaming verdict, a pass-through 2xx and a
+// chat 200 all arrive here the same way), and enumerating the two probe surfaces
+// is cheaper and more predictable than scanning the map for a model's keys. It
+// is also the answer that was wanted before the streaks were split: clearing a
+// streak can only ever PREVENT a retirement, so being generous across surfaces
+// costs nothing, while a strike is gated tightly in both directions.
+//
+// supersede reports whether it changed anything, and the log line is conditional
+// on that. Since nothing removes entries, a model that drew one refusal at 09:00
+// keeps its parked streak for the life of the process, and an unconditional line
+// would then claim to have "cleared gone-strikes" on every successful request to
+// that model from then on — a log that describes work nobody did.
 func (h *Handler) noteModelServed(m *model.Model) {
 	if m == nil || m.ID == uuid.Nil {
 		return
 	}
-	raw, ok := h.goneStrikes.Load(m.ID)
-	if !ok {
-		return
+	for _, endpoint := range goneProbeSurfaces {
+		raw, ok := h.goneStrikes.Load(goneStreakKey{model: m.ID, endpoint: endpoint})
+		if !ok {
+			continue
+		}
+		streak, ok := raw.(*goneStreak)
+		if !ok {
+			continue
+		}
+		if streak.supersede() {
+			debuglog.Debug("proxy: model answered again, cleared gone-strikes", "model", m.ModelID, "endpoint", endpoint)
+		}
 	}
-	streak, ok := raw.(*goneStreak)
-	if !ok {
-		return
-	}
-	streak.supersede()
-	debuglog.Debug("proxy: model answered again, cleared gone-strikes", "model", m.ModelID)
 }

--- a/internal/proxy/model_gone.go
+++ b/internal/proxy/model_gone.go
@@ -64,6 +64,60 @@ const goneStrikeThreshold = 3
 // evidence.
 const goneStrikeWindow = 30 * time.Minute
 
+// goneProbeCooldown is the shortest interval between two probes of the same
+// model, and it is what makes an inconclusive probe a postponement rather than a
+// standing invitation to keep asking.
+//
+// The case it exists for is the one the design names: a provider rate limiting
+// the gateway. Real traffic draws the retirement prose, the probe draws a 429,
+// nothing is established. Without a cooldown the streak had to be dropped so a
+// later refusal could re-probe, and the steady state became one extra upstream
+// request per three refusals — forever, with no bound. A client retrying a dead
+// model at 10 req/s produced roughly three probes a second at a provider that
+// was already shedding load, and the probe deliberately bypasses both the rate
+// limiter and the circuit breaker, so nothing else was going to slow it down.
+// Before the probe existed, strike three disabled the model and the traffic
+// stopped; the cooldown is what restores that bound.
+//
+// The floor is goneProbeTimeout (30s) and it is not a soft one: claimProbe
+// claims at SPAWN time, so the claim doubles as the "a probe is already in
+// flight" guard, and a cooldown shorter than the probe's own deadline would let
+// a second probe be claimed while the first was still waiting on the provider.
+// Five minutes clears it by an order of magnitude and caps the cost at 12
+// probes per model per hour in the worst case — a model under constant refusal
+// whose probe never establishes anything — against the roughly 1,200 an hour
+// the uncapped version allowed for the same traffic.
+//
+// It bounds one model. goneProbeMaxConcurrent bounds the burst across models.
+const goneProbeCooldown = 5 * time.Minute
+
+// goneProbeMaxConcurrent bounds how many retirement probes may be in flight
+// against one provider at a time.
+//
+// The cooldown above bounds one model, and one model was never the shape of the
+// problem: a provider event that nominates 200 models nominates them all within
+// the same few seconds, and every nomination that reached the threshold spawned
+// its own goroutine holding a connection to the SAME host for up to
+// goneProbeTimeout. Two hundred simultaneous verification requests at a
+// provider already misbehaving is the gateway adding to an incident it is
+// supposed to be diagnosing — and each HA member does it independently.
+//
+// Per provider rather than one counter for the whole gateway, because the harm
+// is per host. A cap on the total cannot tell 200 probes at one struggling
+// provider from 200 spread over 200 healthy ones, so it either throttles the
+// case that is fine or fails to throttle the case that is not. Keyed by
+// provider it throttles exactly the burst that lands on one host, and a second
+// provider's retirements are not postponed by the first provider's incident.
+//
+// Four slots, following the argon2 semaphore in internal/user: enough that an
+// ordinary trickle of retirements never queues, small enough that the worst case
+// is a handful of extra connections. The acquire is non-blocking on purpose (see
+// probeForRetirement): a probe that cannot get a slot postpones rather than
+// waiting, because the streak's nextProbeAt is already stamped and the retry
+// arrives on its own after the cooldown. Blocking would hold goroutines and
+// slots for work whose whole justification is that it is not urgent.
+const goneProbeMaxConcurrent = 4
+
 // goneWriteTimeout bounds each out-of-band write the auto-disable makes.
 //
 // Each write gets its OWN deadline rather than sharing one across the sequence.
@@ -96,24 +150,28 @@ const goneWriteTimeout = 10 * time.Second
 // definition too early to see. The second case cannot be prevented, only
 // undone, so noteModelGone reverts rather than skips there.
 //
-// The count and the time of the last strike are guarded by mu rather than being
-// separate atomics. Two atomics cannot express this: deciding whether the window
-// has lapsed and then applying the decision is one operation, and splitting it
-// loses strikes. A reset racing two increments stores 1 after both have added,
-// erasing them, so a model refused three times ends the burst on a count of one
-// and never reaches the threshold.
+// The count, the time of the last strike and the next time a probe may be spent
+// are guarded by mu rather than being separate atomics. Atomics cannot express
+// any of the three: deciding whether the window has lapsed and then applying the
+// decision is one operation, and splitting it loses strikes. A reset racing two
+// increments stores 1 after both have added, erasing them, so a model refused
+// three times ends the burst on a count of one and never reaches the threshold.
+// nextProbeAt is the same shape of decision — read the deadline, decide, stamp
+// the new one — and splitting it would let two callers past the same expired
+// deadline and issue two probes where the whole point is to issue one.
 //
 // The lock is held for a comparison and an addition, on a per-model struct that
 // is only contended while that one model is failing, so it costs nothing worth
 // measuring.
 //
 // cancelled stays atomic because it is read by the detached disable goroutine
-// while the request path may be writing it, and it is independent of the pair
+// while the request path may be writing it, and it is independent of the three
 // above.
 type goneStreak struct {
-	mu         sync.Mutex
-	n          int64
-	lastStrike time.Time
+	mu          sync.Mutex
+	n           int64
+	lastStrike  time.Time
+	nextProbeAt time.Time
 
 	cancelled atomic.Bool
 }
@@ -134,6 +192,38 @@ func (s *goneStreak) strike(now time.Time) int64 {
 	}
 	s.lastStrike = now
 	return s.n
+}
+
+// claimProbe reports whether this caller may spend an upstream request on the
+// model, and takes the right to do so if it may.
+//
+// It is one operation and not two, which is what makes it serve both of its
+// jobs. Claiming at spawn time rather than crediting at completion means a
+// second caller arriving while the first probe is still in flight finds the
+// stamp already set and drops out, so this is also the "a probe is already in
+// flight" guard — hence goneProbeCooldown's floor being the probe's own
+// deadline rather than a matter of taste.
+//
+// The two jobs it replaced:
+//
+//   - "exactly one caller sees the threshold value", which the old
+//     strikes == goneStrikeThreshold test did. A burst of concurrent refusals
+//     still issues a single probe, but now because everyone after the first is
+//     inside the cooldown rather than because their count happened to overshoot.
+//   - the retry, which the inconclusive path used to get by deleting the streak.
+//     A parked streak is re-probed by the next refusal past the cooldown, so
+//     postponing no longer has to throw the evidence away to stay reachable.
+//
+// The zero value admits the first caller, which is what a model that has never
+// been probed should get.
+func (s *goneStreak) claimProbe(now time.Time) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.nextProbeAt.IsZero() && now.Before(s.nextProbeAt) {
+		return false
+	}
+	s.nextProbeAt = now.Add(goneProbeCooldown)
+	return true
 }
 
 // count reports the current streak length.
@@ -228,24 +318,45 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 	if !ok {
 		return
 	}
-	strikes := streak.strike(time.Now())
+	now := time.Now()
+	strikes := streak.strike(now)
 
 	if strikes < goneStrikeThreshold {
 		debuglog.Info("proxy: provider reports model gone", "model", m.ModelID, "provider", candidate.provider.Name, "strikes", strikes, "threshold", goneStrikeThreshold)
 		return
 	}
-	// Exactly one caller sees the threshold value, so a burst of concurrent
-	// refusals still issues a single disable; everyone past it drops out here.
+
+	// At or above the threshold every refusal asks for a probe, and the streak's
+	// own cooldown decides which one gets it. The old shape tested for the
+	// threshold value exactly, so only the caller that saw a count of three ever
+	// proceeded; claimProbe now does that job and two more besides.
 	//
-	// The counter is deliberately NOT cleared here. Clearing it would let the
-	// next refusal start a fresh count from zero, so a burst against a dead
-	// model — 50 concurrent retries, say — would disable it once every three
-	// strikes and publish an alert each time. Leaving the count above the
-	// threshold makes every later refusal a no-op. noteModelServed clears it if
-	// the model ever answers again, and the two paths below that reach no
-	// conclusion — a probe that established nothing, a disable that could not be
-	// written — clear it so the attempt is retried rather than lost.
-	if strikes > goneStrikeThreshold {
+	// What each version buys:
+	//
+	//   - A burst still issues ONE probe. Fifty concurrent retries all reach
+	//     here, all ask, one wins the claim and the other forty-nine drop out
+	//     inside the cooldown. Same outcome as the equality test, on a rule that
+	//     survives the count moving on.
+	//   - A parked streak stays reachable. The equality test made every refusal
+	//     past the threshold a permanent no-op, which is why the inconclusive
+	//     path below had to DELETE the streak to be retried at all — and
+	//     deleting it is what left the probe rate unbounded. With the claim
+	//     gating instead, a single refusal after the cooldown re-probes a streak
+	//     that is still sitting at three, so postponing costs no evidence and
+	//     the retry costs no extra strikes.
+	//   - The rate is bounded. See goneProbeCooldown.
+	//
+	// The counter is still deliberately NOT cleared on the way to a disable.
+	// Clearing it would let the next refusal start a fresh count from zero, so a
+	// burst against a dead model would re-enter the threshold every three
+	// strikes. Only two paths clear it now: noteModelServed, when the model
+	// proves it is alive, and a disable that could not be WRITTEN, so the
+	// attempt is retried rather than lost. A retirement that did land does not
+	// need the guard — the model is disabled, so no traffic reaches it to strike
+	// it again, and a straggler that arrives past the cooldown finds
+	// AutoRetireIfConfirmed refusing to write over an already-retired row, which
+	// reports as an uncommitted attempt and publishes no second alert.
+	if !streak.claimProbe(now) {
 		return
 	}
 
@@ -279,15 +390,11 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 		// on an answer already in hand. Before, because the whole point is that
 		// the write is not made on the classifier's reading alone.
 		//
-		// The deadline is created here rather than inside probeModel so the
-		// production budget stays at the call site that owns the decision. It is
-		// generous — a cold model can take tens of seconds to answer, and a
-		// probe that times out on a slow but living model would postpone the
-		// retirement rather than confirm it, which is the safe direction but
-		// still a wasted call. Nothing on the request path is waiting on it.
-		pctx, pcancel := context.WithTimeout(context.Background(), goneProbeTimeout)
-		verdict := h.probeModel(pctx, candidate, endpointType)
-		pcancel()
+		// The deadline and the concurrency cap live in probeForRetirement, which
+		// is still this file rather than probeModel: the production budget stays
+		// with the decision that owns it, and probeModel stays a helper that
+		// issues one request and reports what came back.
+		verdict := h.probeForRetirement(candidate, endpointType)
 
 		switch verdict {
 		case probeServed:
@@ -304,29 +411,57 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 			// is the backoff, and it is why no durable "never retire this model"
 			// store is being added — a model that is genuinely dead simply earns
 			// the strikes again, and one that is alive keeps clearing them.
+			//
+			// noteModelServed is called unconditionally, and that is the one
+			// place on this path where a stale goroutine can act on a streak
+			// that is not the one it was started for. This probe can have begun
+			// up to goneProbeTimeout ago; in the meantime a success could have
+			// dropped its streak and fresh refusals built another, and
+			// noteModelServed cancels and deletes whatever it finds under the
+			// model id. The revert path below guards exactly this hazard
+			// explicitly (it re-reads the streak and stands down if the model is
+			// refusing again), and the asymmetry is deliberate rather than an
+			// omission.
+			//
+			// Why this one does not need the guard: it fails safe and it heals.
+			// The probe just had CONTENT out of the model, which is stronger and
+			// more recent evidence than any classifier strike sitting in that
+			// newer streak — the revert path is defending a database write made
+			// on older evidence, and this path is defending nothing, because it
+			// writes nothing. Cancelling a newer in-flight disable postpones a
+			// retirement; it cannot cause one. And the streak is deleted rather
+			// than parked, so refusals that are still real rebuild it from zero
+			// and reach the threshold again on their own.
 			debuglog.Warn("proxy: not auto-disabling, the model answered a direct probe after being reported gone", "model", modelName, "provider", provider, "endpoint", endpointType, "strikes", goneStrikeThreshold)
 			h.noteModelServed(m)
 			return
 		case probeInconclusive:
 			// Nothing was established: a 429, a 5xx, an entitlement failure, a
-			// connection that never landed, an expired deadline. Postpone.
+			// connection that never landed, an expired deadline, or no probe
+			// slot free. Postpone.
 			//
-			// The model is deliberately NOT credited with a success.
+			// The count is left exactly where it is, and neither half of that is
+			// incidental. Postponing means postponing: the strikes were real
+			// evidence and nothing has contradicted them, so throwing them away
+			// would make an unanswered question cost the model its whole case.
+			//
+			// This used to delete the streak, for a reason that no longer holds.
+			// Under the old strikes == goneStrikeThreshold gate a parked streak
+			// was unreachable — every later refusal was a no-op — so deleting it
+			// was the only way a model whose first probe hit a 429 could ever be
+			// retired. The cost was that three fresh refusals then bought another
+			// probe, and another, with nothing bounding the rate at a provider
+			// that was already rate limiting us. claimProbe replaces that: the
+			// streak stays parked and the next refusal past goneProbeCooldown
+			// re-probes it, so the retirement stays reachable at one probe per
+			// cooldown instead of one per three refusals.
+			//
+			// The model is still deliberately NOT credited with a success.
 			// noteModelServed is not called, so no in-flight disable is stood
 			// down and no cancelled flag is set — the model has not proved
 			// anything, and treating "we could not tell" as "it works" would let
 			// a provider outage clear the streaks of everything behind it.
-			//
-			// Dropping the count is a retry mechanism, not a verdict. Without it
-			// the streak stays parked at the threshold, where the strikes >
-			// goneStrikeThreshold check above makes every later refusal a no-op,
-			// and a genuinely dead model whose first probe happened to hit a 429
-			// would stay enabled forever. This is the same reasoning, and the
-			// same call, as the failed-write path a few lines below —
-			// CompareAndDelete on identity included, so a stale goroutine cannot
-			// throw away a newer streak on its way out.
-			h.goneStrikes.CompareAndDelete(modelID, streak)
-			debuglog.Info("proxy: postponing auto-disable, the retirement probe established nothing", "model", modelName, "provider", provider, "endpoint", endpointType)
+			debuglog.Info("proxy: postponing auto-disable, the retirement probe established nothing", "model", modelName, "provider", provider, "endpoint", endpointType, "strikes", streak.count(), "retry_after", goneProbeCooldown.String())
 			return
 		case probeRefused:
 			// The provider refused the model by name to a request the gateway
@@ -446,7 +581,22 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 			return
 		}
 
-		debuglog.Warn("proxy: auto-disabled retired model", "model", modelName, "provider", provider, "strikes", goneStrikeThreshold)
+		// The verdict is stamped on the line and in the event, and it is the
+		// point of the line rather than decoration. Before the probe existed
+		// this log and this alert were written on three classifier readings of
+		// provider prose; they now mean something materially different, and they
+		// said exactly the same words. An operator upgrading could not tell a
+		// verified retirement from an unverified one in their own logs, and the
+		// refused verdict is both the common outcome and the only one that costs
+		// an upstream call AND writes to the database. The design asked for this
+		// directly: the probe is a call the operator did not make, so it should
+		// be logged as what it is.
+		//
+		// The endpoint family rides along for the same reason. It decides which
+		// surface was asked and whether the model was eligible for auto-
+		// retirement at all, so a retirement that cannot be traced back to a
+		// family cannot be argued with.
+		debuglog.Warn("proxy: auto-disabled retired model", "model", modelName, "provider", provider, "strikes", goneStrikeThreshold, "endpoint", endpointType, "probe_verdict", probeRefused.String())
 
 		// Disabling a member does not resize the custom failover groups it
 		// belongs to, so a group can be left enabled while it no longer has two
@@ -473,9 +623,73 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 				"provider_name": provider,
 				"strikes":       goneStrikeThreshold,
 				"reason":        string(KindProviderModelGone),
+				"probe_verdict": probeRefused.String(),
+				"endpoint_type": endpointType,
 			},
 		})
 	}()
+}
+
+// probeForRetirement runs the pre-retirement probe under the per-provider
+// concurrency cap and the production deadline, and reports what it found.
+//
+// It is a separate function because two budgets belong here and neither belongs
+// inside probeModel: the deadline, so the number the operator's cost depends on
+// stays beside the decision that spends it rather than buried in a helper (and
+// so a test can drive the real probe with a deadline measured in milliseconds),
+// and the semaphore, which is about how many retirements may be adjudicated at
+// once and says nothing about how one request is made.
+//
+// A slot that is not free returns probeInconclusive, which is the honest answer
+// and not a fallback: no request was sent, so nothing was established, and the
+// caller's postpone branch is exactly the right handling. The acquire does not
+// block. The streak's nextProbeAt was stamped before this goroutine was
+// spawned, so the model is already scheduled to be re-probed after the cooldown
+// — waiting here would hold a goroutine open to arrive at the same answer
+// later, during the same burst that made slots scarce.
+//
+// The deadline is generous. A cold model can take tens of seconds to answer,
+// and a probe that times out on a slow but living model postpones the
+// retirement rather than confirming it, which is the safe direction but still a
+// wasted call. Nothing on the request path is waiting on any of it.
+func (h *Handler) probeForRetirement(candidate modelCandidate, endpointType string) probeVerdict {
+	release, ok := h.acquireProbeSlot(candidate.provider.ID)
+	if !ok {
+		debuglog.Info("proxy: postponing auto-disable, too many retirement probes are already in flight for this provider", "model", candidate.model.ModelID, "provider", candidate.provider.Name, "endpoint", endpointType, "limit", goneProbeMaxConcurrent, "retry_after", goneProbeCooldown.String())
+		return probeInconclusive
+	}
+	defer release()
+
+	pctx, pcancel := context.WithTimeout(context.Background(), goneProbeTimeout)
+	defer pcancel()
+	return h.probeModel(pctx, candidate, endpointType)
+}
+
+// acquireProbeSlot takes one of the provider's goneProbeMaxConcurrent probe
+// slots without waiting, returning the release for it.
+//
+// The per-provider semaphore is created on first use through LoadOrStore, so a
+// race only duplicates the channel that loses, and the winner's is the one
+// everyone counts against — the same pattern, and the same reasoning, as the
+// per-model streaks in goneStrikes.
+//
+// Entries are never removed, and that is a bounded leak by construction rather
+// than an oversight: the key space is the operator's configured providers, a
+// number in the tens, and each entry is one small channel. Reclaiming them would
+// need to prove no probe is in flight for that provider first, which is more
+// machinery and more ways to be wrong than the bytes are worth.
+func (h *Handler) acquireProbeSlot(providerID uuid.UUID) (release func(), ok bool) {
+	raw, _ := h.goneProbeSlots.LoadOrStore(providerID, make(chan struct{}, goneProbeMaxConcurrent))
+	sem, isChan := raw.(chan struct{})
+	if !isChan {
+		return nil, false
+	}
+	select {
+	case sem <- struct{}{}:
+		return func() { <-sem }, true
+	default:
+		return nil, false
+	}
 }
 
 // streamVerdict is what a finished stream says about whether the model still

--- a/internal/proxy/model_gone.go
+++ b/internal/proxy/model_gone.go
@@ -226,6 +226,46 @@ func (s *goneStreak) claimProbe(now time.Time) bool {
 	return true
 }
 
+// parkServed records that a direct probe got content out of the model: the
+// count goes, the cooldown stays.
+//
+// It exists because "clear the streak" and "delete the streak" are the same
+// thing everywhere else in this file and must not be here. noteModelServed —
+// the request path's version, which this deliberately does not call — drops the
+// whole entry, and nextProbeAt goes with it. A model whose real traffic keeps
+// drawing retirement prose while a minimal probe keeps succeeding would then
+// rebuild three strikes against a fresh zero-valued streak, whose claimProbe
+// admits immediately, and probe again: one probe per three refusals, forever.
+// That is the unbounded rate goneProbeCooldown was added to close, reopened by
+// the one verdict that is expected to repeat, since a probe that disagrees with
+// the traffic is precisely the case this whole feature exists to catch.
+//
+// So the count is reset — the model needs three FRESH refusals before it is
+// reconsidered, which is the backoff the served path always meant — and the
+// stamp is kept, so the reconsideration also waits out the cooldown. Both must
+// hold before another upstream request is spent.
+//
+// Mutating this streak in place rather than reaching into h.goneStrikes by
+// model id is what makes it identity-scoped for free: sync.Map holds the
+// pointer, so a park lands on the map entry when this is still the live streak
+// and touches nothing when it is not. That matters for a probe goroutine that
+// began up to goneProbeTimeout ago — a success may have dropped its streak and
+// fresh refusals built another, and this evidence is not about that one.
+//
+// cancelled is cleared for the same reason the count is: what stays behind must
+// be a streak that can still work. A parked entry carrying a stale tombstone
+// would fail its next disable's pre-write check and silently never retire the
+// model again. Nothing can be racing it — claimProbe admits one probe per
+// cooldown and the whole goroutine lives well inside that — so this is the
+// last writer.
+func (s *goneStreak) parkServed() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.n = 0
+	s.lastStrike = time.Time{}
+	s.cancelled.Store(false)
+}
+
 // count reports the current streak length.
 func (s *goneStreak) count() int64 {
 	s.mu.Lock()
@@ -366,6 +406,20 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 	modelID, modelName, provider := m.ID, m.ModelID, candidate.provider.Name
 
 	go func() {
+		// Every other detached goroutine in this package recovers
+		// (touchProviderLastUsed, the log writer, the usage recorder) and this
+		// one now has far more reason to. It used to call repository methods and
+		// nothing else; it now makes an upstream request and runs bytes a
+		// provider chose through the dialect translators, so a panic anywhere in
+		// json, the transport or a translator would take the whole gateway down
+		// over one model's retirement. Recovering leaves the model enabled, which
+		// is the direction every unproven case on this path already takes.
+		defer func() {
+			if r := recover(); r != nil {
+				debuglog.Error("proxy: panic while auto-disabling a retired model", "model", modelName, "provider", provider, "error", r)
+			}
+		}()
+
 		// The decision was made before this goroutine was scheduled, and the
 		// write below can take as long as the database does. If the model
 		// answered a request in the meantime it has proved it is alive, and
@@ -405,35 +459,20 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 			// does not — an operator should see it, because it is the case in
 			// which the old code would have retired a working model.
 			//
-			// noteModelServed is the existing machinery for "this model works":
-			// it stands down any queued disable and clears the streak, so the
-			// model needs three FRESH refusals before it is reconsidered. That
-			// is the backoff, and it is why no durable "never retire this model"
-			// store is being added — a model that is genuinely dead simply earns
-			// the strikes again, and one that is alive keeps clearing them.
+			// parkServed is the backoff, and it is why no durable "never retire
+			// this model" store is being added: the count is reset, so the model
+			// needs three FRESH refusals before it is reconsidered, and one that
+			// is genuinely dead simply earns them again while one that is alive
+			// keeps clearing them.
 			//
-			// noteModelServed is called unconditionally, and that is the one
-			// place on this path where a stale goroutine can act on a streak
-			// that is not the one it was started for. This probe can have begun
-			// up to goneProbeTimeout ago; in the meantime a success could have
-			// dropped its streak and fresh refusals built another, and
-			// noteModelServed cancels and deletes whatever it finds under the
-			// model id. The revert path below guards exactly this hazard
-			// explicitly (it re-reads the streak and stands down if the model is
-			// refusing again), and the asymmetry is deliberate rather than an
-			// omission.
-			//
-			// Why this one does not need the guard: it fails safe and it heals.
-			// The probe just had CONTENT out of the model, which is stronger and
-			// more recent evidence than any classifier strike sitting in that
-			// newer streak — the revert path is defending a database write made
-			// on older evidence, and this path is defending nothing, because it
-			// writes nothing. Cancelling a newer in-flight disable postpones a
-			// retirement; it cannot cause one. And the streak is deleted rather
-			// than parked, so refusals that are still real rebuild it from zero
-			// and reach the threshold again on their own.
-			debuglog.Warn("proxy: not auto-disabling, the model answered a direct probe after being reported gone", "model", modelName, "provider", provider, "endpoint", endpointType, "strikes", goneStrikeThreshold)
-			h.noteModelServed(m)
+			// Deliberately not noteModelServed, which is the request path's
+			// version of the same idea. That one deletes the whole streak, and
+			// the probe cooldown is part of the streak — see parkServed for what
+			// deleting it costs. Its other job, standing down a queued disable,
+			// has nothing to do here either: the only disable this streak can
+			// have queued is this goroutine, which is about to return.
+			debuglog.Warn("proxy: not auto-disabling, the model answered a direct probe after being reported gone", "model", modelName, "provider", provider, "endpoint", endpointType, "strikes", goneStrikeThreshold, "retry_after", goneProbeCooldown.String())
+			streak.parkServed()
 			return
 		case probeInconclusive:
 			// Nothing was established: a 429, a 5xx, an entitlement failure, a

--- a/internal/proxy/model_gone.go
+++ b/internal/proxy/model_gone.go
@@ -334,6 +334,25 @@ func (s *goneStreak) claimProbe(now time.Time) bool {
 	return true
 }
 
+// canClaimProbe answers the same question as claimProbe without taking anything.
+//
+// It is not a substitute for the claim and cannot be: two callers can both read
+// true and only one of them may proceed, which is what claimProbe's single
+// critical section decides. It exists so the cheap, per-model reason to stop can
+// be checked before the shared, per-provider one — a refusal inside its cooldown
+// then never touches the semaphore at all.
+//
+// That ordering is what keeps the semaphore counting adjudications rather than
+// refusals. Without it, a retry storm across models that are all inside their
+// cooldowns can hold all four slots for the microseconds each take-and-release
+// costs, and the one model whose cooldown HAS expired is denied a genuine probe
+// by traffic that was never going to spend one.
+func (s *goneStreak) canClaimProbe(now time.Time) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.nextProbeAt.IsZero() || !now.Before(s.nextProbeAt)
+}
+
 // park clears the evidence a streak has accumulated and keeps the probe
 // cooldown it has earned. It is what "clear the streak" means everywhere in
 // this file; nothing removes the entry.
@@ -585,12 +604,33 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 	// refusal tries again immediately, which is safe because the semaphore is
 	// itself the rate bound in that window: no upstream request can be spent
 	// without a slot, whatever the retry rate.
+	//
+	// The cooldown is still read FIRST, without taking anything, so a refusal
+	// that could not have probed anyway never reaches the semaphore. Otherwise
+	// the shared, per-provider resource ends up counting refusals rather than
+	// adjudications: a retry storm across models that are all inside their
+	// cooldowns can hold the four slots for the moment each take-and-release
+	// costs, and deny them to the one model whose cooldown has actually expired.
+	// The read cannot replace the claim — two callers can both see true and only
+	// one may proceed — which is why claimProbe still decides below.
+	if !streak.canClaimProbe(now) {
+		return
+	}
 	release, ok := h.acquireProbeSlot(candidate.provider.ID)
 	if !ok {
-		debuglog.Info("proxy: postponing auto-disable, too many retirement probes are already in flight for this provider", "model", m.ModelID, "provider", candidate.provider.Name, "endpoint", endpointType, "limit", goneProbeMaxConcurrent)
+		// Debug, for the same reason the family gate above is: nothing throttles
+		// this line. Since the slot is taken before the claim is spent, every
+		// refusal past the cooldown reaches it, and the case it reports is a
+		// provider-wide nomination event under a client's retry loop — thousands
+		// of lines a second describing a condition an operator can already see in
+		// the probes that ARE going out. The postponement itself costs nothing
+		// and is retried by the next refusal.
+		debuglog.Debug("proxy: postponing auto-disable, too many retirement probes are already in flight for this provider", "model", m.ModelID, "provider", candidate.provider.Name, "endpoint", endpointType, "limit", goneProbeMaxConcurrent)
 		return
 	}
 	if !streak.claimProbe(now) {
+		// Another refusal won the claim between the read above and here. It owns
+		// the probe; this one gives the slot back and drops out.
 		release()
 		return
 	}
@@ -1054,6 +1094,15 @@ func streamProducedOutput(logData *requestLogData) bool {
 // the hedged path previously returned without recording any verdict at all, so
 // a model retired mid-stream stayed routable whenever hedging was enabled.
 func (h *Handler) noteStreamOutcome(logData *requestLogData, candidate modelCandidate) {
+	// The guard belongs here, not in streamProducedOutput. That function checks
+	// for nil too and is tested for it, but this expression dereferences logData
+	// to build its arguments, and Go evaluates all of them before the call — so
+	// on this path the helper's guard could never run and a nil would panic
+	// before reaching it. Same shape as probeForRetirement's: a check downstream
+	// of the dereference promises something it cannot deliver.
+	if logData == nil {
+		return
+	}
 	switch verdictForStream(logData.errorKind, logData.upstreamKind, streamProducedOutput(logData)) {
 	case verdictGone:
 		// The endpoint family comes off the log entry rather than being assumed:

--- a/internal/proxy/model_gone.go
+++ b/internal/proxy/model_gone.go
@@ -729,6 +729,18 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 // retirement rather than confirming it, which is the safe direction but still a
 // wasted call. Nothing on the request path is waiting on any of it.
 func (h *Handler) probeForRetirement(candidate modelCandidate, endpointType string) probeVerdict {
+	// Before anything is dereferenced, and that is the point of it being here.
+	// probeModel makes the same check, but every field this function touches on
+	// the way there — the provider's id for the semaphore, the model's id for
+	// the log line — would already have panicked, so the guard downstream was
+	// promising a postponement it could never deliver. A panic here is caught by
+	// the disable goroutine's recover and reported as a panic, which is the
+	// wrong answer to "is this model still served": nothing was established, and
+	// nothing being established is what probeInconclusive means.
+	if candidate.model == nil || candidate.provider == nil {
+		return probeInconclusive
+	}
+
 	release, ok := h.acquireProbeSlot(candidate.provider.ID)
 	if !ok {
 		debuglog.Info("proxy: postponing auto-disable, too many retirement probes are already in flight for this provider", "model", candidate.model.ModelID, "provider", candidate.provider.Name, "endpoint", endpointType, "limit", goneProbeMaxConcurrent, "retry_after", goneProbeCooldown.String())

--- a/internal/proxy/model_gone.go
+++ b/internal/proxy/model_gone.go
@@ -216,6 +216,16 @@ func (s *goneStreak) strike(now time.Time) int64 {
 //
 // The zero value admits the first caller, which is what a model that has never
 // been probed should get.
+//
+// Granting a claim also clears the cancelled tombstone, and that is what makes
+// a streak reusable rather than something to be thrown away. The flag means "a
+// success landed after the disable now in flight was decided", so it belongs to
+// one decision; a claim starts the next one, on three fresh strikes that the
+// success itself is older than. Leaving it set would make the disable this claim
+// spawns stand down at its own pre-write check, and the model would never be
+// retired again on this streak. Nothing can be racing it: a claim cannot be
+// granted while an earlier probe is alive, because goneProbeCooldown is five
+// minutes and the whole goroutine lives at most goneProbeTimeout plus one write.
 func (s *goneStreak) claimProbe(now time.Time) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -223,47 +233,45 @@ func (s *goneStreak) claimProbe(now time.Time) bool {
 		return false
 	}
 	s.nextProbeAt = now.Add(goneProbeCooldown)
+	s.cancelled.Store(false)
 	return true
 }
 
-// parkServed records that a direct probe got content out of the model: the
-// count goes, the cooldown stays.
+// park clears the evidence a streak has accumulated and keeps the probe
+// cooldown it has earned. It is what "clear the streak" means everywhere in
+// this file; nothing removes the entry.
 //
-// It exists because "clear the streak" and "delete the streak" are the same
-// thing everywhere else in this file and must not be here. noteModelServed —
-// the request path's version, which this deliberately does not call — drops the
-// whole entry, and nextProbeAt goes with it. A model whose real traffic keeps
-// drawing retirement prose while a minimal probe keeps succeeding would then
-// rebuild three strikes against a fresh zero-valued streak, whose claimProbe
-// admits immediately, and probe again: one probe per three refusals, forever.
-// That is the unbounded rate goneProbeCooldown was added to close, reopened by
-// the one verdict that is expected to repeat, since a probe that disagrees with
-// the traffic is precisely the case this whole feature exists to catch.
+// Deleting was the obvious spelling and it silently discarded the rate bound.
+// nextProbeAt lives on the streak, so dropping the entry drops the stamp, and
+// the next refusal builds a fresh zero-valued streak whose claimProbe admits
+// immediately. Every reason a streak used to be deleted is a reason it is
+// likely to be rebuilt at once: a probe that answered while traffic keeps
+// drawing retirement prose, a real request that succeeded between refusals, a
+// disable that failed to write. Each of those turned into three fresh refusals
+// buying another upstream call, forever, which is precisely the loop
+// goneProbeCooldown exists to close.
 //
-// So the count is reset — the model needs three FRESH refusals before it is
-// reconsidered, which is the backoff the served path always meant — and the
-// stamp is kept, so the reconsideration also waits out the cooldown. Both must
-// hold before another upstream request is spent.
+// Parking gives both halves of the bound instead. The count is reset, so the
+// model needs three FRESH refusals before it is reconsidered, and the stamp
+// survives, so the reconsideration also waits out the cooldown.
 //
-// Mutating this streak in place rather than reaching into h.goneStrikes by
-// model id is what makes it identity-scoped for free: sync.Map holds the
-// pointer, so a park lands on the map entry when this is still the live streak
-// and touches nothing when it is not. That matters for a probe goroutine that
-// began up to goneProbeTimeout ago — a success may have dropped its streak and
-// fresh refusals built another, and this evidence is not about that one.
+// Mutating the streak in place rather than reaching into h.goneStrikes by model
+// id is what makes every caller identity-scoped for free: sync.Map holds the
+// pointer, so a park lands on the map entry while this is still the live streak
+// and touches nothing once it is not.
 //
-// cancelled is cleared for the same reason the count is: what stays behind must
-// be a streak that can still work. A parked entry carrying a stale tombstone
-// would fail its next disable's pre-write check and silently never retire the
-// model again. Nothing can be racing it — claimProbe admits one probe per
-// cooldown and the whole goroutine lives well inside that — so this is the
-// last writer.
-func (s *goneStreak) parkServed() {
+// The tombstone is deliberately not touched here: a success has to set it (see
+// noteModelServed) and a claim has to clear it (see claimProbe), and both of
+// those are decisions about a disable rather than about the evidence.
+//
+// Nothing is ever deleted, so the map holds one small struct per model that has
+// ever drawn a gone-classified refusal. That is bounded by the catalog and is
+// the point: a model's probe cooldown has to outlive the streak that earned it.
+func (s *goneStreak) park() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.n = 0
 	s.lastStrike = time.Time{}
-	s.cancelled.Store(false)
 }
 
 // count reports the current streak length.
@@ -459,20 +467,19 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 			// does not — an operator should see it, because it is the case in
 			// which the old code would have retired a working model.
 			//
-			// parkServed is the backoff, and it is why no durable "never retire
+			// The park is the backoff, and it is why no durable "never retire
 			// this model" store is being added: the count is reset, so the model
 			// needs three FRESH refusals before it is reconsidered, and one that
 			// is genuinely dead simply earns them again while one that is alive
 			// keeps clearing them.
 			//
-			// Deliberately not noteModelServed, which is the request path's
-			// version of the same idea. That one deletes the whole streak, and
-			// the probe cooldown is part of the streak — see parkServed for what
-			// deleting it costs. Its other job, standing down a queued disable,
-			// has nothing to do here either: the only disable this streak can
-			// have queued is this goroutine, which is about to return.
+			// The streak is parked directly rather than through noteModelServed,
+			// which does the same to the count and additionally sets the
+			// tombstone. There is nothing here for the tombstone to stand down:
+			// the only disable this streak can have queued is this goroutine,
+			// which is about to return.
 			debuglog.Warn("proxy: not auto-disabling, the model answered a direct probe after being reported gone", "model", modelName, "provider", provider, "endpoint", endpointType, "strikes", goneStrikeThreshold, "retry_after", goneProbeCooldown.String())
-			streak.parkServed()
+			streak.park()
 			return
 		case probeInconclusive:
 			// Nothing was established: a 429, a 5xx, an entitlement failure, a
@@ -533,19 +540,19 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 		})
 		cancel()
 		if err != nil {
-			debuglog.Error("proxy: failed to auto-disable retired model", "model", modelName, "provider", provider, "error", err)
-			// Clear the streak so the next refusals can rebuild it and try
-			// again. Without this a transient database error would leave the
-			// count parked above the threshold and the model enabled forever.
+			debuglog.Error("proxy: failed to auto-disable retired model", "model", modelName, "provider", provider, "error", err, "retry_after", goneProbeCooldown.String())
+			// Nothing is touched, and that is the retry. The streak keeps its
+			// count and its stamp, so the next refusal past goneProbeCooldown
+			// claims a probe and the disable is attempted again.
 			//
-			// Conditional on identity, because this goroutine may be stale. It
-			// can sit in the write while a success clears the streak it was
-			// started for and later refusals build a NEW one; deleting by model
-			// id would then throw away that newer count on its way out, and the
-			// model would keep restarting from zero instead of reaching the
-			// threshold. Only the streak this attempt actually belongs to may
-			// be retired by it.
-			h.goneStrikes.CompareAndDelete(modelID, streak)
+			// This used to delete the streak, for the same reason the
+			// inconclusive path did and with the same cost. Under the old
+			// strikes == goneStrikeThreshold gate a parked count was
+			// unreachable, so dropping it was the only way a model whose write
+			// failed could ever be retired; claimProbe made it reachable, and
+			// deleting also threw away the cooldown — which turned a database
+			// outage into three fresh refusals buying another upstream probe,
+			// on repeat, for every model refusing traffic at the time.
 			return
 		}
 
@@ -832,14 +839,24 @@ func (h *Handler) noteStreamOutcome(logData *requestLogData, candidate modelCand
 
 // noteModelServed clears any accumulated gone-strikes after the model answers.
 // The strike streak must be consecutive, so one success is enough to reset it.
-// The map lookup is deliberately the only work done for a healthy model: nothing
-// is written, and nothing touches the database.
+//
+// It runs on the request path, so what it costs there is part of the design: a
+// model that has never been refused misses the map entirely, and one that has
+// pays a miss plus an uncontended mutex on a request that is already waiting on
+// an upstream call. Nothing is written and nothing touches the database.
 //
 // It also cancels a disable that has been decided but not yet written. The
-// ordering matters: mark the streak cancelled FIRST, then drop it from the map.
-// A queued disable holds a pointer to the streak, not the map entry, so marking
-// before deleting is what makes the flag visible to it — deleting first would
-// leave the goroutine holding an orphan it can never be told about.
+// ordering matters: mark the streak cancelled FIRST, then clear the count. A
+// queued disable holds a pointer to the streak, so setting the flag before
+// standing the evidence down is what makes it visible to that goroutine.
+//
+// The entry is parked, not dropped, and the difference is the probe cooldown.
+// Deleting it took nextProbeAt with it, so a success between refusals reset the
+// rate bound — and a model that refuses some request shapes while serving
+// others produces exactly that interleaving. Three refusals then bought a probe,
+// a success wiped the stamp, three more refusals bought another, indefinitely.
+// A success clears what the model is accused of; it does not buy the gateway
+// another free upstream call. See park.
 func (h *Handler) noteModelServed(m *model.Model) {
 	if m == nil || m.ID == uuid.Nil {
 		return
@@ -853,9 +870,6 @@ func (h *Handler) noteModelServed(m *model.Model) {
 		return
 	}
 	streak.cancelled.Store(true)
-	// Also conditional on identity: between the load above and here the streak
-	// can be dropped by a failing disable and a fresh one started by new
-	// refusals, and this success is not evidence about that later streak.
-	h.goneStrikes.CompareAndDelete(m.ID, streak)
+	streak.park()
 	debuglog.Debug("proxy: model answered again, cleared gone-strikes", "model", m.ModelID)
 }

--- a/internal/proxy/model_gone.go
+++ b/internal/proxy/model_gone.go
@@ -723,6 +723,51 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 	// getting — least of all an upstream round trip to a third party.
 	modelID, modelName, provider := m.ID, m.ModelID, candidate.provider.Name
 
+	// announceRetirement is everything a disable owes the rest of the system once
+	// the row is actually off, and it is one function because the goroutine below
+	// has four exits that leave it off and only one that does not.
+	//
+	// The revalidation is unconditional among those four. Disabling a member does
+	// not resize the custom failover groups it belongs to, so a group can be left
+	// enabled while it no longer has two routable members. Discovery already
+	// revalidates after it disables a model (see discovery_diff.go); this path has
+	// to do the same or an undersized group stays enabled until some unrelated
+	// scan happens to fix it. Best-effort: a failure here must not undo the
+	// disable.
+	//
+	// The alert is not, which is why it is a parameter rather than assumed. It
+	// asserts that THIS model is retired, so it is published only where the
+	// goroutine still knows that to be true — not where the row has moved on
+	// under someone else, and not where the retirement was successfully undone.
+	announceRetirement := func(publish bool) {
+		if h.failoverRepo != nil {
+			vctx, vcancel := context.WithTimeout(context.Background(), goneWriteTimeout)
+			_, verr := h.failoverRepo.RevalidateCustomGroups(vctx)
+			vcancel()
+			if verr != nil {
+				debuglog.Error("proxy: custom-group revalidation after auto-disable failed", "model", modelName, "error", verr)
+			}
+		}
+		if !publish {
+			return
+		}
+		events.Publish(events.Event{
+			Type:     "model.auto_disabled_gone",
+			Severity: "warning",
+			Source:   "proxy",
+			Message:  fmt.Sprintf("Disabled %s: %s reports it is no longer served", modelName, provider),
+			Metadata: map[string]any{
+				"model_id":      modelName,
+				"model_uuid":    modelID.String(),
+				"provider_name": provider,
+				"strikes":       strikes,
+				"reason":        string(KindProviderModelGone),
+				"probe_verdict": probeRefused.String(),
+				"endpoint_type": endpointType,
+			},
+		})
+	}
+
 	go func() {
 		// The slot belongs to the upstream request, not to the whole retirement.
 		// It is released explicitly the moment the probe returns, below; this is
@@ -927,8 +972,23 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 			// lookup by model id could only ever return the same struct, and
 			// supersede's single critical section is what guarantees the count
 			// read here is the one that belongs to the tombstone read above.
+			// Three of the four ways out of here leave the model DISABLED, and
+			// each of them still owes the retirement its follow-through. The
+			// revalidation is the load-bearing half: a disabled member does not
+			// resize the custom groups it belongs to, so skipping it leaves a
+			// group enabled with fewer than two routable members until some
+			// unrelated scan happens to notice — which is the whole reason the
+			// call exists. Only a revert that actually landed is exempt, because
+			// then nothing happened as far as anyone outside this goroutine is
+			// concerned.
+			//
+			// The alert is judged separately, because it asserts something
+			// stronger than the revalidation does. It says this model is retired,
+			// so it is published only where that is known to be true: the two
+			// arms below where the row is still exactly as this write left it.
 			if streak.count() >= goneStrikeThreshold {
 				debuglog.Info("proxy: not reverting the auto-disable, the model is refusing again", "model", modelName, "provider", provider)
+				announceRetirement(true)
 				return
 			}
 
@@ -943,13 +1003,21 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 			switch {
 			case rerr != nil:
 				// Nothing safe is left to try. Log loudly: the model is
-				// disabled and the gateway believes it should not be.
+				// disabled and the gateway believes it should not be. The
+				// retirement is still announced, because it is what happened —
+				// an operator reading only the error line would have a model
+				// disabled by this path with no event to match it to.
 				debuglog.Error("proxy: model answered while its auto-disable was in flight, and re-enabling it failed", "model", modelName, "provider", provider, "error", rerr)
+				announceRetirement(true)
 				return
 			case !reverted:
 				// Someone else owns the row's state now. Leaving it alone is
-				// the whole point of the condition.
+				// the whole point of the condition — and it is also why this
+				// one revalidates without alerting: the groups have to be
+				// re-checked whatever the row ended up as, but this goroutine
+				// no longer knows what to claim about it.
 				debuglog.Info("proxy: auto-disable was superseded before it could be reverted", "model", modelName, "provider", provider)
+				announceRetirement(false)
 				return
 			}
 			debuglog.Info("proxy: reverted auto-disable, model answered while the write was in flight", "model", modelName, "provider", provider)
@@ -990,36 +1058,7 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 		// the decision was being made — which is the opposite of "how was this
 		// decision reached".
 		debuglog.Warn("proxy: auto-disabled retired model", "model", modelName, "provider", provider, "strikes", strikes, "endpoint", endpointType, "probe_verdict", probeRefused.String())
-
-		// Disabling a member does not resize the custom failover groups it
-		// belongs to, so a group can be left enabled while it no longer has two
-		// routable members. Discovery already revalidates after it disables a
-		// model (see discovery_diff.go); this path has to do the same or an
-		// undersized group stays enabled until some unrelated scan happens to
-		// fix it. Best-effort: a failure here must not undo the disable.
-		if h.failoverRepo != nil {
-			vctx, vcancel := context.WithTimeout(context.Background(), goneWriteTimeout)
-			_, verr := h.failoverRepo.RevalidateCustomGroups(vctx)
-			vcancel()
-			if verr != nil {
-				debuglog.Error("proxy: custom-group revalidation after auto-disable failed", "model", modelName, "error", verr)
-			}
-		}
-		events.Publish(events.Event{
-			Type:     "model.auto_disabled_gone",
-			Severity: "warning",
-			Source:   "proxy",
-			Message:  fmt.Sprintf("Disabled %s: %s reports it is no longer served", modelName, provider),
-			Metadata: map[string]any{
-				"model_id":      modelName,
-				"model_uuid":    modelID.String(),
-				"provider_name": provider,
-				"strikes":       strikes,
-				"reason":        string(KindProviderModelGone),
-				"probe_verdict": probeRefused.String(),
-				"endpoint_type": endpointType,
-			},
-		})
+		announceRetirement(true)
 	}()
 }
 
@@ -1154,8 +1193,11 @@ func verdictForStream(kind, upstreamKind ErrorKind, producedOutput bool) streamV
 	}
 }
 
-// streamProducedOutput reports whether a finished stream actually delivered
-// content.
+// producedOutput reports whether a response actually delivered content.
+//
+// Used by the stream verdict and by the non-streaming chat path, which ask the
+// same question of the same fields: a 200 is a status, and what clears a
+// retirement streak has to be an answer.
 //
 // deliveredContent is the authoritative signal, set where the content itself is
 // observed. The other two are corroboration and neither can be relied on alone:
@@ -1170,7 +1212,7 @@ func verdictForStream(kind, upstreamKind ErrorKind, producedOutput bool) streamV
 // evidence rather than absence of an error: a stream can open, emit nothing and
 // end without recording anything, and crediting that would clear a retirement
 // streak on the strength of an empty response.
-func streamProducedOutput(logData *requestLogData) bool {
+func producedOutput(logData *requestLogData) bool {
 	if logData == nil {
 		return false
 	}
@@ -1182,7 +1224,7 @@ func streamProducedOutput(logData *requestLogData) bool {
 // the hedged path previously returned without recording any verdict at all, so
 // a model retired mid-stream stayed routable whenever hedging was enabled.
 func (h *Handler) noteStreamOutcome(logData *requestLogData, candidate modelCandidate) {
-	// The guard belongs here, not in streamProducedOutput. That function checks
+	// The guard belongs here, not in producedOutput. That function checks
 	// for nil too and is tested for it, but this expression dereferences logData
 	// to build its arguments, and Go evaluates all of them before the call — so
 	// on this path the helper's guard could never run and a nil would panic
@@ -1191,7 +1233,7 @@ func (h *Handler) noteStreamOutcome(logData *requestLogData, candidate modelCand
 	if logData == nil {
 		return
 	}
-	switch verdictForStream(logData.errorKind, logData.upstreamKind, streamProducedOutput(logData)) {
+	switch verdictForStream(logData.errorKind, logData.upstreamKind, producedOutput(logData)) {
 	case verdictGone:
 		// The endpoint family comes off the log entry rather than being assumed:
 		// it is what decides whether this refusal can be adjudicated at all, and

--- a/internal/proxy/model_gone.go
+++ b/internal/proxy/model_gone.go
@@ -391,13 +391,22 @@ func (s *goneStreak) claimProbe(now time.Time) bool {
 // walk past the cheap check and go take a provider slot, to be turned away by
 // the claim a moment later — which is the shape of waste this read exists to
 // stop.
-func (s *goneStreak) canClaimProbe(now time.Time) bool {
+// The reason is returned alongside the answer because the caller logs it, and
+// the two are not the same event: a cooldown is a deliberate wait, while a count
+// below the threshold means a success cleared the evidence between the strike
+// and this read. Reporting the first for the second told an operator a model was
+// waiting out five minutes when its streak had in fact gone back to zero — the
+// distinction the line exists to make.
+func (s *goneStreak) canClaimProbe(now time.Time) (ok bool, reason string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.n < goneStrikeThreshold {
-		return false
+		return false, "the strikes were cleared while this refusal was being recorded"
 	}
-	return s.nextProbeAt.IsZero() || !now.Before(s.nextProbeAt)
+	if !s.nextProbeAt.IsZero() && now.Before(s.nextProbeAt) {
+		return false, "the model is inside its probe cooldown"
+	}
+	return true, ""
 }
 
 // park clears the evidence a streak has accumulated and keeps the probe
@@ -670,7 +679,7 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 	// costs, and deny them to the one model whose cooldown has actually expired.
 	// The read cannot replace the claim — two callers can both see true and only
 	// one may proceed — which is why claimProbe still decides below.
-	if !streak.canClaimProbe(now) {
+	if claimable, reason := streak.canClaimProbe(now); !claimable {
 		// The only postponement on this path that used to be silent, and the one
 		// an operator is most likely to be looking at: it is the steady state
 		// for every refusal against a model already at the threshold. Without a
@@ -681,7 +690,7 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 		// Debug for the same reason as the semaphore line below: nothing
 		// throttles it, and a client retry loop against a dead model reaches it
 		// on every request.
-		debuglog.Debug("proxy: postponing auto-disable, the model is inside its probe cooldown", "model", m.ModelID, "provider", candidate.provider.Name, "endpoint", endpointType, "strikes", strikes, "retry_after", goneProbeCooldown.String())
+		debuglog.Debug("proxy: postponing auto-disable, "+reason, "model", m.ModelID, "provider", candidate.provider.Name, "endpoint", endpointType, "strikes", streak.count(), "retry_after", goneProbeCooldown.String())
 		return
 	}
 

--- a/internal/proxy/model_gone.go
+++ b/internal/proxy/model_gone.go
@@ -160,34 +160,49 @@ type goneStreakKey struct {
 // streaks on every surface, so it enumerates them rather than scanning the map.
 var goneProbeSurfaces = [...]string{probeChatEndpoint, probeEmbeddingsEndpoint}
 
-// modalityContradictsSurface reports whether the model's own catalog metadata
-// says it is not for this upstream surface.
+// modalityRulesOutSurface reports whether a gone-classified refusal that arrived
+// on this upstream surface may count against the model at all.
 //
-// Positive evidence of a mismatch only. An empty, unparseable or unrecognised
-// modality list is not a contradiction: rows predating the modality columns and
-// providers that report nothing must keep the retirement they have today, and
-// the alternative — treating "we cannot tell" as "do not retire" — would switch
-// auto-retirement off silently for whole catalogs. What it catches is the case
-// the catalog is explicit about: a text model refused on /embeddings, or an
-// embedding-only model refused on /chat/completions.
+// The two surfaces answer to different burdens of proof, and the asymmetry is
+// the point rather than an inconsistency. What is at stake is the same in both
+// cases — the disable is model-wide, so a strike drawn on the wrong surface can
+// take a working model out of routing everywhere — but the cost of guessing is
+// not.
+//
+// The embeddings surface requires POSITIVE evidence: the catalog has to say this
+// model produces embeddings. Nothing filters a request by modality on the way
+// in, so `POST /v1/embeddings` naming a chat model is forwarded to the
+// provider's embeddings endpoint, and a provider that answers "gpt-4o is not
+// supported for embeddings" has named the model beside a gone-phrase. The probe
+// cannot rescue it: it asks on the surface the strikes arrived on, so it
+// reproduces the misuse and confirms. Being wrong here retires a live chat model
+// gateway-wide; being cautious only means an embeddings model whose catalog
+// entry declares nothing is never auto-retired — the same trade
+// probeEndpointForFamily already takes for rerank, and it matters because
+// liveModelStub writes "[]" for every model no catalog covers.
+//
+// The chat surface keeps the opposite default, because there the two costs
+// invert. Chat is what most models are and what most refusals arrive on, so
+// demanding a declared modality would switch traffic-driven retirement off for
+// every uncatalogued model at once — silently, and precisely where it does the
+// most work. Only a positively embedding-ONLY model rules the chat surface out.
 //
 // Reading output modalities rather than input: discovery classifies an
 // embeddings model by what it PRODUCES (["embedding"]), which is the only field
 // that separates it from a chat model taking the same text input.
-func modalityContradictsSurface(m *model.Model, probeEndpoint string) bool {
-	if m.OutputModalities == "" || m.OutputModalities == "[]" {
-		return false
-	}
+func modalityRulesOutSurface(m *model.Model, probeEndpoint string) bool {
 	var out []string
-	if json.Unmarshal([]byte(m.OutputModalities), &out) != nil || len(out) == 0 {
-		return false
+	if m.OutputModalities != "" && m.OutputModalities != "[]" {
+		if json.Unmarshal([]byte(m.OutputModalities), &out) != nil {
+			out = nil
+		}
 	}
 	embeds := slices.Contains(out, "embedding")
 	if probeEndpoint == probeEmbeddingsEndpoint {
 		return !embeds
 	}
-	// The chat surface: only an embedding-ONLY model contradicts it. A model
-	// that produces embeddings alongside text is not evidence of anything.
+	// A model that produces embeddings alongside text says nothing against the
+	// chat surface; only an embedding-only one does.
 	return embeds && len(out) == 1
 }
 
@@ -454,24 +469,15 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 
 	// The second gate: the refusal has to be about a surface this model is FOR.
 	//
-	// Nothing filters a request by modality on the way in. `POST /v1/embeddings`
-	// with a chat model's name is forwarded to the provider's embeddings
-	// endpoint, and a provider that answers "gpt-4o is not supported for
-	// embeddings" has named the model beside a gone-phrase, which
-	// classifyUpstreamError reads as a retirement. Three of those from one
-	// misconfigured client used to nominate the model, and the probe could not
-	// save it: the probe asks on the family the strikes arrived on, so it
-	// reproduces the misuse faithfully, draws the same refusal and confirms a
-	// retirement of a model that serves chat perfectly. The disable is
-	// model-wide, so a surface-specific refusal would take the model out of
-	// routing everywhere.
-	//
 	// This is the same argument as the family gate above, applied to the one
-	// direction that gate cannot see: chat and embeddings are both probeable, so
+	// direction that gate cannot see. Chat and embeddings are both probeable, so
 	// the mismatch is between the model and the surface rather than between the
-	// surface and the probe.
-	if modalityContradictsSurface(m, probeEndpoint) {
-		debuglog.Debug("proxy: ignoring a gone-classified refusal on a surface this model is not for", "model", m.ModelID, "provider", candidate.provider.Name, "endpoint", endpointType, "output_modalities", m.OutputModalities)
+	// surface and the probe — and the probe cannot catch it, because it asks on
+	// the surface the strikes arrived on and would reproduce the misuse
+	// faithfully. What each surface demands of the catalog, and why the two
+	// differ, is argued in modalityRulesOutSurface.
+	if modalityRulesOutSurface(m, probeEndpoint) {
+		debuglog.Debug("proxy: ignoring a gone-classified refusal on a surface this model is not known to serve", "model", m.ModelID, "provider", candidate.provider.Name, "endpoint", endpointType, "output_modalities", m.OutputModalities)
 		return
 	}
 
@@ -613,11 +619,10 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 			// tombstone. There is nothing here for the tombstone to stand down:
 			// the only disable this streak can have queued is this goroutine,
 			// which is about to return.
-			// The streak's own count, for the reason the disable line below gives:
-			// under claimProbe the number that bought this probe is not always
-			// three. Read before the park, so it is the count that nominated the
-			// model rather than the zero it is about to become.
-			debuglog.Warn("proxy: not auto-disabling, the model answered a direct probe after being reported gone", "model", modelName, "provider", provider, "endpoint", endpointType, "strikes", streak.count(), "retry_after", goneProbeCooldown.String())
+			// The count that claimed the probe, for the reason the disable line
+			// below gives: under claimProbe the number that bought it is not
+			// always three.
+			debuglog.Warn("proxy: not auto-disabling, the model answered a direct probe after being reported gone", "model", modelName, "provider", provider, "endpoint", endpointType, "strikes", strikes, "retry_after", goneProbeCooldown.String())
 			streak.park()
 			return
 		case probeInconclusive:
@@ -791,7 +796,13 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 		// loop, or on a single refusal that re-claimed a streak parked since the
 		// last cooldown. Reporting the constant would tell every operator the
 		// same story about a decision that was reached differently.
-		strikes := streak.count()
+		//
+		// It is the count this refusal SAW, captured before the probe rather than
+		// read back here. Nothing clears the counter on the retire path, and this
+		// point is up to a probe timeout and a database write later, so reading it
+		// now would report a number inflated by every refusal that arrived while
+		// the decision was being made — which is the opposite of "how was this
+		// decision reached".
 		debuglog.Warn("proxy: auto-disabled retired model", "model", modelName, "provider", provider, "strikes", strikes, "endpoint", endpointType, "probe_verdict", probeRefused.String())
 
 		// Disabling a member does not resize the custom failover groups it

--- a/internal/proxy/model_gone.go
+++ b/internal/proxy/model_gone.go
@@ -16,7 +16,13 @@ import (
 
 // goneStrikeThreshold is how many consecutive KindProviderModelGone responses a
 // model must draw, with no successful request in between, before the gateway
-// disables it.
+// PROBES it.
+//
+// It is no longer the retirement bar. What disables a model is probeModel
+// refusing it on a request the gateway makes itself (see noteModelGone); the
+// strikes decide only that the question is worth one upstream call. Reading
+// this as the retirement bar is the mistake to avoid: three strikes on their
+// own now disable nothing.
 //
 // Why traffic and not discovery: a provider listing is not a promise. Google
 // kept gemini-2.0-flash in /models for two months after shutting it down,
@@ -24,13 +30,17 @@ import (
 // hy3-preview and refuses it. RecordMissingModels can only act when a model
 // leaves the listing, so none of those were ever going to be caught by
 // discovery. The only source that knows a model is dead is a real request to
-// it, which is exactly what classifyUpstreamError now labels.
+// it, which is exactly what classifyUpstreamError labels.
 //
 // Three rather than the discovery sweep's two: a scan is a deliberate, spaced
 // observation, whereas requests can arrive in a burst during a provider
 // incident. Requiring three consecutive refusals with no success in between
 // keeps a brief upstream wobble that happens to match a gone-pattern from
-// retiring a live model.
+// spending a probe on a live model — and, before the probe existed, from
+// retiring one outright. The probe has since taken over the second job, which
+// is why three is now a cost control rather than the last line of defence, and
+// why it has not been raised: a wrong nomination costs one cheap request, and
+// the probe throws it out.
 const goneStrikeThreshold = 3
 
 // goneStrikeWindow is how long a strike stays part of the streak it belongs to.
@@ -189,8 +199,17 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 	// chat traffic and image traffic must not have its chat streak — the one
 	// that CAN retire it — topped up by image refusals nothing will ever
 	// adjudicate.
+	//
+	// Debug rather than Info, and that is a consequence of returning before the
+	// strike rather than a preference. Nothing throttles this line: no counter
+	// is kept, so there is no threshold to cross and nothing ever goes quiet. A
+	// genuinely retired image or TTS model used to log twice, reach the
+	// threshold, be disabled and stop; it now logs once per refused request for
+	// as long as traffic keeps arriving, precisely BECAUSE it is never retired
+	// to make it stop. At Info that is an unbounded line in every operator's log
+	// for a condition that is by design permanent.
 	if _, ok := probeEndpointForFamily(endpointType); !ok {
-		debuglog.Info("proxy: provider reports model gone on an endpoint family that cannot be probed, so it is never auto-retired", "model", m.ModelID, "provider", candidate.provider.Name, "endpoint", endpointType)
+		debuglog.Debug("proxy: provider reports model gone on an endpoint family that cannot be probed, so it is never auto-retired", "model", m.ModelID, "provider", candidate.provider.Name, "endpoint", endpointType)
 		return
 	}
 
@@ -313,6 +332,18 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 			// The provider refused the model by name to a request the gateway
 			// made itself. That is the fourth independent piece of evidence and
 			// the one the disable is actually written on; fall through.
+		default:
+			// Unreachable while probeVerdict has three values, and present
+			// because the cost of the two outcomes is not symmetric. Go does not
+			// check switch exhaustiveness and no linter here does either, so a
+			// fourth verdict added later would silently fall out of this switch
+			// and into the write below — the one direction the probe is not
+			// allowed to take, since it may only ever PREVENT a disable. Failing
+			// closed means a new verdict postpones until someone decides
+			// otherwise, which is the same answer this file gives to every other
+			// case it cannot substantiate.
+			debuglog.Warn("proxy: postponing auto-disable, unrecognised retirement probe verdict", "model", modelName, "provider", provider, "endpoint", endpointType, "verdict", verdict.String())
+			return
 		}
 
 		// Staged, not written outright. confirm runs with the row already

--- a/internal/proxy/model_gone.go
+++ b/internal/proxy/model_gone.go
@@ -198,6 +198,15 @@ type goneStreakKey struct {
 // declares image alone is an images-endpoint model whatever it can be coaxed
 // into. See canonicalModalityRank in internal/provider for the full vocabulary
 // these are drawn from.
+func modalityRulesOutSurface(m *model.Model, probeEndpoint string) bool {
+	out := declaredModalities(m.OutputModalities)
+	if probeEndpoint == probeEmbeddingsEndpoint {
+		// Positive evidence, so an undeclared list rules the surface out.
+		return !slices.Contains(out, "embedding")
+	}
+	return !admitsChatModalities(out) || !admitsChatModalities(declaredModalities(m.InputModalities))
+}
+
 // modalityAdmitsBothProbeSurfaces reports whether the catalog says this model
 // serves chat AND embeddings.
 //
@@ -221,15 +230,6 @@ type goneStreakKey struct {
 // empty modality list already rules the embeddings surface out.
 func modalityAdmitsBothProbeSurfaces(m *model.Model) bool {
 	return !modalityRulesOutSurface(m, probeChatEndpoint) && !modalityRulesOutSurface(m, probeEmbeddingsEndpoint)
-}
-
-func modalityRulesOutSurface(m *model.Model, probeEndpoint string) bool {
-	out := declaredModalities(m.OutputModalities)
-	if probeEndpoint == probeEmbeddingsEndpoint {
-		// Positive evidence, so an undeclared list rules the surface out.
-		return !slices.Contains(out, "embedding")
-	}
-	return !admitsChatModalities(out) || !admitsChatModalities(declaredModalities(m.InputModalities))
 }
 
 // declaredModalities parses one of the model's modality columns, returning nil
@@ -338,21 +338,33 @@ func (s *goneStreak) strike(now time.Time) int64 {
 //     A parked streak is re-probed by the next refusal past the cooldown, so
 //     postponing no longer has to throw the evidence away to stay reachable.
 //
-// The zero value admits the first caller, which is what a model that has never
+// A zero stamp admits the first caller, which is what a model that has never
 // been probed should get.
+//
+// The evidence has to still be standing, which is the other half of the same
+// critical section and not a formality. The caller strikes and then claims, and
+// those are two lock acquisitions: a success can land in between, clear the
+// count and set the tombstone, and the claim would otherwise proceed on strikes
+// that no longer exist — spending an upstream request, and reporting a strike
+// count the streak does not hold. Reading the count here is what makes "the
+// success is older than the strikes" true rather than merely usual.
 //
 // Granting a claim also clears the cancelled tombstone, and that is what makes
 // a streak reusable rather than something to be thrown away. The flag means "a
 // success landed after the disable now in flight was decided", so it belongs to
-// one decision; a claim starts the next one, on three fresh strikes that the
-// success itself is older than. Leaving it set would make the disable this claim
-// spawns stand down at its own pre-write check, and the model would never be
-// retired again on this streak. Nothing can be racing it: a claim cannot be
-// granted while an earlier probe is alive, because goneProbeCooldown is five
-// minutes and the whole goroutine lives at most goneProbeTimeout plus one write.
+// one decision; a claim starts the next one, and the count check above is what
+// guarantees the strikes it starts on are newer than any success that set the
+// flag. Leaving it set would make the disable this claim spawns stand down at
+// its own pre-write check, and the model would never be retired again on this
+// streak. Nothing can be racing an earlier probe either: a claim cannot be
+// granted while one is alive, because goneProbeCooldown is five minutes and the
+// whole goroutine lives at most goneProbeTimeout plus one write.
 func (s *goneStreak) claimProbe(now time.Time) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if s.n < goneStrikeThreshold {
+		return false
+	}
 	if !s.nextProbeAt.IsZero() && now.Before(s.nextProbeAt) {
 		return false
 	}
@@ -374,9 +386,17 @@ func (s *goneStreak) claimProbe(now time.Time) bool {
 // cooldowns can hold all four slots for the microseconds each take-and-release
 // costs, and the one model whose cooldown HAS expired is denied a genuine probe
 // by traffic that was never going to spend one.
+// It mirrors both of claimProbe's conditions, including the count. Reading only
+// the stamp would let a refusal whose evidence a success had already cleared
+// walk past the cheap check and go take a provider slot, to be turned away by
+// the claim a moment later — which is the shape of waste this read exists to
+// stop.
 func (s *goneStreak) canClaimProbe(now time.Time) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if s.n < goneStrikeThreshold {
+		return false
+	}
 	return s.nextProbeAt.IsZero() || !now.Before(s.nextProbeAt)
 }
 

--- a/internal/proxy/model_gone.go
+++ b/internal/proxy/model_gone.go
@@ -151,15 +151,6 @@ type goneStreakKey struct {
 	endpoint string
 }
 
-// goneProbeSurfaces is every endpoint a streak can be keyed on.
-//
-// It has to agree with probeEndpointForFamily's returns, and
-// TestProbeEndpointForFamily_SurfacesAreCovered fails if a new probeable family
-// introduces a surface that is missing here. The one caller that needs it is
-// noteModelServed, which has a model and no family: a success clears the model's
-// streaks on every surface, so it enumerates them rather than scanning the map.
-var goneProbeSurfaces = [...]string{probeChatEndpoint, probeEmbeddingsEndpoint}
-
 // modalityRulesOutSurface reports whether a gone-classified refusal that arrived
 // on this upstream surface may count against the model at all.
 //
@@ -908,6 +899,13 @@ func (h *Handler) acquireProbeSlot(providerID uuid.UUID) (release func(), ok boo
 	}
 	sem, isChan := raw.(chan struct{})
 	if !isChan {
+		// Unreachable by construction: this function is the only writer of the
+		// map and only ever stores a chan struct{}. It is logged rather than
+		// left silent because the caller cannot tell this apart from a full
+		// semaphore, and reports the postponement as probe throttling — which
+		// would send an operator looking at a concurrency cap that has nothing
+		// to do with it.
+		debuglog.Error("proxy: retirement probe slot map holds an unexpected value, so no slot can be taken", "provider_id", providerID, "type", fmt.Sprintf("%T", raw))
 		return nil, false
 	}
 	select {
@@ -1004,7 +1002,7 @@ func (h *Handler) noteStreamOutcome(logData *requestLogData, candidate modelCand
 		// every path that can reach this.
 		h.noteModelGone(candidate, logData.endpointType)
 	case verdictServed:
-		h.noteModelServed(candidate.model)
+		h.noteModelServed(candidate.model, logData.endpointType)
 	case verdictInconclusive:
 		// Deliberately nothing: see verdictForStream.
 	}
@@ -1030,34 +1028,52 @@ func (h *Handler) noteStreamOutcome(logData *requestLogData, candidate modelCand
 // A success clears what the model is accused of; it does not buy the gateway
 // another free upstream call. See park.
 //
-// Every surface, because a success is evidence about the MODEL. The caller has a
-// model and no endpoint family (a streaming verdict, a pass-through 2xx and a
-// chat 200 all arrive here the same way), and enumerating the two probe surfaces
-// is cheaper and more predictable than scanning the map for a model's keys. It
-// is also the answer that was wanted before the streaks were split: clearing a
-// streak can only ever PREVENT a retirement, so being generous across surfaces
-// costs nothing, while a strike is gated tightly in both directions.
+// The success clears ONE surface: the one it arrived on. It used to clear all of
+// them, on the argument that a success is evidence about the model and that
+// clearing can only ever prevent a retirement — but that argument, taken
+// seriously, also justifies never retiring anything, and it undoes on the
+// clearing side exactly the split the strike side was given.
+//
+// The split exists because a model can be served on one surface and refused on
+// another, and the two are separate questions. Clearing globally answered them
+// as one: a provider that had retired a model's chat surface while still serving
+// its embeddings would have every embeddings success wipe the chat streak, so
+// the dead surface could never accumulate three consecutive strikes and would
+// never be adjudicated at all — the case this feature exists to catch.
+//
+// Tightening it is safe for the reason the whole branch is built on: what
+// retires a model is the PROBE, and the probe asks on the same surface. A chat
+// streak that survives an embeddings success still has to be refused by a real
+// request to /chat/completions before anything is written.
+//
+// A family that cannot be probed clears nothing, which is the same rule the
+// strike side follows: an image or TTS response is not evidence about the chat
+// surface any more than an image refusal is. It is also why this takes an
+// endpointType rather than deriving anything: every caller (a chat 200, a
+// pass-through 2xx, a finished stream) has the family that ingest stamped.
 //
 // supersede reports whether it changed anything, and the log line is conditional
 // on that. Since nothing removes entries, a model that drew one refusal at 09:00
 // keeps its parked streak for the life of the process, and an unconditional line
 // would then claim to have "cleared gone-strikes" on every successful request to
 // that model from then on — a log that describes work nobody did.
-func (h *Handler) noteModelServed(m *model.Model) {
+func (h *Handler) noteModelServed(m *model.Model, endpointType string) {
 	if m == nil || m.ID == uuid.Nil {
 		return
 	}
-	for _, endpoint := range goneProbeSurfaces {
-		raw, ok := h.goneStrikes.Load(goneStreakKey{model: m.ID, endpoint: endpoint})
-		if !ok {
-			continue
-		}
-		streak, ok := raw.(*goneStreak)
-		if !ok {
-			continue
-		}
-		if streak.supersede() {
-			debuglog.Debug("proxy: model answered again, cleared gone-strikes", "model", m.ModelID, "endpoint", endpoint)
-		}
+	endpoint, ok := probeEndpointForFamily(endpointType)
+	if !ok {
+		return
+	}
+	raw, ok := h.goneStrikes.Load(goneStreakKey{model: m.ID, endpoint: endpoint})
+	if !ok {
+		return
+	}
+	streak, ok := raw.(*goneStreak)
+	if !ok {
+		return
+	}
+	if streak.supersede() {
+		debuglog.Debug("proxy: model answered again, cleared gone-strikes", "model", m.ModelID, "endpoint", endpoint)
 	}
 }

--- a/internal/proxy/model_gone.go
+++ b/internal/proxy/model_gone.go
@@ -270,6 +270,34 @@ func (s *goneStreak) claimProbe(now time.Time) bool {
 func (s *goneStreak) park() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	s.clearLocked()
+}
+
+// supersede is park plus the tombstone: the model answered, so a disable that
+// has been decided stands down and the evidence behind it is cleared.
+//
+// One critical section, and that is the whole reason this is not two calls at
+// the call site. The disable goroutine reads the tombstone without the lock and
+// then asks for the count, so the two updates have to be indivisible from its
+// point of view: seeing cancelled set while the count still shows the strikes
+// that caused this retirement reads as "the model is refusing again", and the
+// revert is skipped — leaving a model that has just answered disabled, with the
+// count parked at zero immediately afterwards so nothing ever triggers a revert
+// again. An operator would have to re-enable it by hand, which is the exact
+// outcome the cancellation exists to prevent.
+//
+// Storing inside the lock is what closes it: once a reader observes the
+// tombstone the writer is still holding mu, so the count it goes on to ask for
+// cannot be read until this has finished zeroing it.
+func (s *goneStreak) supersede() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cancelled.Store(true)
+	s.clearLocked()
+}
+
+// clearLocked resets the evidence. Callers hold mu.
+func (s *goneStreak) clearLocked() {
 	s.n = 0
 	s.lastStrike = time.Time{}
 }
@@ -584,20 +612,22 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 		// cycle, and the model ends up correct either way.
 		if streak.cancelled.Load() {
 			// The success that cancelled this retirement can itself be out of
-			// date. Its streak was dropped, new refusals can have built another
-			// one, and that replacement stands down when it finds the model
-			// already retired — by this very write. Reverting on the strength of
-			// the older success would then re-enable a model that current
-			// evidence says is gone, and the fresh streak, parked above the
-			// threshold, would never disable it again.
+			// date: it cleared the count, and refusals arriving since can have
+			// rebuilt it past the threshold inside this same write window.
+			// Reverting on the strength of the older success would re-enable a
+			// model that current evidence says is gone, and the rebuilt streak
+			// would stand down at its own claim when it found the model already
+			// retired — by this very write.
 			//
 			// So the revert defers to whatever the model is saying NOW rather
-			// than to the success that scheduled it.
-			if fresh, ok := h.goneStrikes.Load(modelID); ok {
-				if s, ok := fresh.(*goneStreak); ok && s.count() >= goneStrikeThreshold {
-					debuglog.Info("proxy: not reverting the auto-disable, the model is refusing again", "model", modelName, "provider", provider)
-					return
-				}
+			// than to the success that scheduled it. The count is read off this
+			// streak directly: nothing removes an entry from h.goneStrikes, so a
+			// lookup by model id could only ever return the same struct, and
+			// supersede's single critical section is what guarantees the count
+			// read here is the one that belongs to the tombstone read above.
+			if streak.count() >= goneStrikeThreshold {
+				debuglog.Info("proxy: not reverting the auto-disable, the model is refusing again", "model", modelName, "provider", provider)
+				return
 			}
 
 			rctx, rcancel := context.WithTimeout(context.Background(), goneWriteTimeout)
@@ -845,10 +875,9 @@ func (h *Handler) noteStreamOutcome(logData *requestLogData, candidate modelCand
 // pays a miss plus an uncontended mutex on a request that is already waiting on
 // an upstream call. Nothing is written and nothing touches the database.
 //
-// It also cancels a disable that has been decided but not yet written. The
-// ordering matters: mark the streak cancelled FIRST, then clear the count. A
-// queued disable holds a pointer to the streak, so setting the flag before
-// standing the evidence down is what makes it visible to that goroutine.
+// It also cancels a disable that has been decided but not yet written, which is
+// why it goes through supersede rather than setting the flag and parking
+// separately: a queued disable reads both, and has to see them change together.
 //
 // The entry is parked, not dropped, and the difference is the probe cooldown.
 // Deleting it took nextProbeAt with it, so a success between refusals reset the
@@ -869,7 +898,6 @@ func (h *Handler) noteModelServed(m *model.Model) {
 	if !ok {
 		return
 	}
-	streak.cancelled.Store(true)
-	streak.park()
+	streak.supersede()
 	debuglog.Debug("proxy: model answered again, cleared gone-strikes", "model", m.ModelID)
 }

--- a/internal/proxy/model_gone.go
+++ b/internal/proxy/model_gone.go
@@ -176,25 +176,56 @@ type goneStreakKey struct {
 // invert. Chat is what most models are and what most refusals arrive on, so
 // demanding a declared modality would switch traffic-driven retirement off for
 // every uncatalogued model at once — silently, and precisely where it does the
-// most work. Only a positively embedding-ONLY model rules the chat surface out.
+// most work. So a silent catalog is allowed to strike on chat, and a catalog
+// that positively describes something a chat completion cannot be about is not.
 //
-// Reading output modalities rather than input: discovery classifies an
-// embeddings model by what it PRODUCES (["embedding"]), which is the only field
-// that separates it from a chat model taking the same text input.
+// "Something a chat completion cannot be about" is read from both arrays,
+// because either one can settle it and neither can on its own. An image model
+// declares output ["image"] and a TTS model ["audio"]; a speech-to-text model
+// declares output ["text"] like any chat model and gives itself away on the
+// INPUT side with ["audio"]. All four are reachable: nothing filters a request
+// by modality on the way in, so POST /v1/chat/completions naming flux-1.1-pro is
+// forwarded, and a provider answering "Model 'flux-1.1-pro' is not supported for
+// chat completions" has named the model beside a gone-phrase. Three of those and
+// the probe re-sends the same misuse, draws the same refusal, and retires a
+// working image model on every surface including the one it serves.
+//
+// Text and code are the whole allow-list, and it is deliberately not the
+// vocabulary of things a chat completion can CARRY. A chat model that also emits
+// images declares ["text","image"] and is admitted by the text; a model that
+// declares image alone is an images-endpoint model whatever it can be coaxed
+// into. See canonicalModalityRank in internal/provider for the full vocabulary
+// these are drawn from.
 func modalityRulesOutSurface(m *model.Model, probeEndpoint string) bool {
-	var out []string
-	if m.OutputModalities != "" && m.OutputModalities != "[]" {
-		if json.Unmarshal([]byte(m.OutputModalities), &out) != nil {
-			out = nil
-		}
-	}
-	embeds := slices.Contains(out, "embedding")
+	out := declaredModalities(m.OutputModalities)
 	if probeEndpoint == probeEmbeddingsEndpoint {
-		return !embeds
+		// Positive evidence, so an undeclared list rules the surface out.
+		return !slices.Contains(out, "embedding")
 	}
-	// A model that produces embeddings alongside text says nothing against the
-	// chat surface; only an embedding-only one does.
-	return embeds && len(out) == 1
+	return !admitsChatModalities(out) || !admitsChatModalities(declaredModalities(m.InputModalities))
+}
+
+// declaredModalities parses one of the model's modality columns, returning nil
+// for anything it cannot read as a list. Callers treat nil as "the catalog says
+// nothing", which is not the same as "the catalog says no".
+func declaredModalities(raw string) []string {
+	if raw == "" || raw == "[]" {
+		return nil
+	}
+	var list []string
+	if json.Unmarshal([]byte(raw), &list) != nil {
+		return nil
+	}
+	return list
+}
+
+// admitsChatModalities reports whether a declared modality list leaves room for
+// a chat completion. An empty list does: nothing declared is not evidence.
+func admitsChatModalities(list []string) bool {
+	if len(list) == 0 {
+		return true
+	}
+	return slices.Contains(list, "text") || slices.Contains(list, "code")
 }
 
 // goneStreak is one model's consecutive-refusal count plus a tombstone for the
@@ -536,7 +567,31 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 	// strike it again, and a straggler that arrives past the cooldown finds
 	// AutoRetireIfConfirmed refusing to write over an already-retired row, which
 	// reports as an uncommitted attempt and publishes no second alert.
+	// The provider's slot is taken BEFORE the model's claim, and the order is the
+	// whole point. Both are non-blocking, but only one of them is spent: the
+	// claim stamps a five-minute cooldown on the model, while a refused slot
+	// costs nothing at all.
+	//
+	// Taking the claim first meant a model that lost the race for a slot had
+	// already burnt its cooldown for zero upstream work — and that is exactly the
+	// event goneProbeMaxConcurrent exists for. A provider incident nominating two
+	// hundred models adjudicates four of them and pushes every other one out a
+	// full cooldown, so a batch that should converge in the time it takes the
+	// four slots to turn over (a probe is ≤30s) instead converges at four models
+	// per five minutes. Hours rather than minutes, with the gateway idle in
+	// between.
+	//
+	// This way the refused caller leaves the streak untouched and the next
+	// refusal tries again immediately, which is safe because the semaphore is
+	// itself the rate bound in that window: no upstream request can be spent
+	// without a slot, whatever the retry rate.
+	release, ok := h.acquireProbeSlot(candidate.provider.ID)
+	if !ok {
+		debuglog.Info("proxy: postponing auto-disable, too many retirement probes are already in flight for this provider", "model", m.ModelID, "provider", candidate.provider.Name, "endpoint", endpointType, "limit", goneProbeMaxConcurrent)
+		return
+	}
 	if !streak.claimProbe(now) {
+		release()
 		return
 	}
 
@@ -546,6 +601,12 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 	modelID, modelName, provider := m.ID, m.ModelID, candidate.provider.Name
 
 	go func() {
+		// The slot belongs to the upstream request, not to the whole retirement.
+		// It is released explicitly the moment the probe returns, below; this is
+		// the net for the paths that never get there — the cancelled check, and
+		// a panic. release is idempotent, so both firing is fine.
+		defer release()
+
 		// Every other detached goroutine in this package recovers
 		// (touchProviderLastUsed, the log writer, the usage recorder) and this
 		// one now has far more reason to. It used to call repository methods and
@@ -584,11 +645,17 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 		// on an answer already in hand. Before, because the whole point is that
 		// the write is not made on the classifier's reading alone.
 		//
-		// The deadline and the concurrency cap live in probeForRetirement, which
-		// is still this file rather than probeModel: the production budget stays
-		// with the decision that owns it, and probeModel stays a helper that
-		// issues one request and reports what came back.
+		// The deadline lives in probeForRetirement, which is still this file
+		// rather than probeModel: the production budget stays with the decision
+		// that owns it, and probeModel stays a helper that issues one request and
+		// reports what came back.
 		verdict := h.probeForRetirement(candidate, endpointType)
+		// The upstream request is over, so the provider's slot goes back now
+		// rather than at the end of the write. Holding it across
+		// AutoRetireIfConfirmed and the revalidation would tie a cap on
+		// CONNECTIONS to how fast the database is, and halve what four slots can
+		// adjudicate during exactly the provider event they exist for.
+		release()
 
 		switch verdict {
 		case probeServed:
@@ -828,23 +895,18 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 	}()
 }
 
-// probeForRetirement runs the pre-retirement probe under the per-provider
-// concurrency cap and the production deadline, and reports what it found.
+// probeForRetirement runs the pre-retirement probe under the production
+// deadline and reports what it found.
 //
-// It is a separate function because two budgets belong here and neither belongs
-// inside probeModel: the deadline, so the number the operator's cost depends on
-// stays beside the decision that spends it rather than buried in a helper (and
-// so a test can drive the real probe with a deadline measured in milliseconds),
-// and the semaphore, which is about how many retirements may be adjudicated at
-// once and says nothing about how one request is made.
+// It is a separate function because the deadline belongs here and not inside
+// probeModel: the number the operator's cost depends on stays beside the
+// decision that spends it rather than buried in a helper, and a test can still
+// drive the real probe with a deadline measured in milliseconds.
 //
-// A slot that is not free returns probeInconclusive, which is the honest answer
-// and not a fallback: no request was sent, so nothing was established, and the
-// caller's postpone branch is exactly the right handling. The acquire does not
-// block. The streak's nextProbeAt was stamped before this goroutine was
-// spawned, so the model is already scheduled to be re-probed after the cooldown
-// — waiting here would hold a goroutine open to arrive at the same answer
-// later, during the same burst that made slots scarce.
+// The per-provider slot is NOT taken here. It is taken by the caller before the
+// model's claim is spent, because a refused slot must cost nothing — see
+// noteModelGone for what taking them in the other order did to a provider-wide
+// nomination event.
 //
 // The deadline is generous. A cold model can take tens of seconds to answer,
 // and a probe that times out on a slow but living model postpones the
@@ -852,9 +914,8 @@ func (h *Handler) noteModelGone(candidate modelCandidate, endpointType string) {
 // wasted call. Nothing on the request path is waiting on any of it.
 func (h *Handler) probeForRetirement(candidate modelCandidate, endpointType string) probeVerdict {
 	// Before anything is dereferenced, and that is the point of it being here.
-	// probeModel makes the same check, but every field this function touches on
-	// the way there — the provider's id for the semaphore, the model's id for
-	// the log line — would already have panicked, so the guard downstream was
+	// probeModel makes the same check, but the fields this function touches on
+	// the way there would already have panicked, so the guard downstream was
 	// promising a postponement it could never deliver. A panic here is caught by
 	// the disable goroutine's recover and reported as a panic, which is the
 	// wrong answer to "is this model still served": nothing was established, and
@@ -863,13 +924,6 @@ func (h *Handler) probeForRetirement(candidate modelCandidate, endpointType stri
 		return probeInconclusive
 	}
 
-	release, ok := h.acquireProbeSlot(candidate.provider.ID)
-	if !ok {
-		debuglog.Info("proxy: postponing auto-disable, too many retirement probes are already in flight for this provider", "model", candidate.model.ModelID, "provider", candidate.provider.Name, "endpoint", endpointType, "limit", goneProbeMaxConcurrent, "retry_after", goneProbeCooldown.String())
-		return probeInconclusive
-	}
-	defer release()
-
 	pctx, pcancel := context.WithTimeout(context.Background(), goneProbeTimeout)
 	defer pcancel()
 	return h.probeModel(pctx, candidate, endpointType)
@@ -877,6 +931,13 @@ func (h *Handler) probeForRetirement(candidate modelCandidate, endpointType stri
 
 // acquireProbeSlot takes one of the provider's goneProbeMaxConcurrent probe
 // slots without waiting, returning the release for it.
+//
+// The release is idempotent, because the caller has two of them: an explicit one
+// the moment the upstream request is done, so the slot is not held across a
+// database write, and a deferred one covering the paths that never reach it.
+// Without sync.OnceFunc the second call would drain a slot belonging to somebody
+// else's probe, which is the kind of bug that only shows up under the burst the
+// semaphore exists for.
 //
 // Load is tried first and LoadOrStore only on a miss, so the common case — a
 // provider whose semaphore already exists, which is every probe after the
@@ -910,7 +971,7 @@ func (h *Handler) acquireProbeSlot(providerID uuid.UUID) (release func(), ok boo
 	}
 	select {
 	case sem <- struct{}{}:
-		return func() { <-sem }, true
+		return sync.OnceFunc(func() { <-sem }), true
 	default:
 		return nil, false
 	}

--- a/internal/proxy/model_gone_test.go
+++ b/internal/proxy/model_gone_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -68,6 +69,24 @@ func goneStreakFor(t *testing.T, h *Handler, id uuid.UUID) *goneStreak {
 		t.Fatal("unexpected streak type")
 	}
 	return streak
+}
+
+// waitForStreakCount blocks until the model's streak holds want strikes, for the
+// paths that reset the count in place instead of dropping the entry. The reset
+// happens on the detached goroutine, so reading the count straight after the
+// refusals that triggered it races the reset rather than observing it.
+func waitForStreakCount(t *testing.T, h *Handler, id uuid.UUID, want int64) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if raw, ok := h.goneStrikes.Load(id); ok {
+			if s, ok := raw.(*goneStreak); ok && s.count() == want {
+				return
+			}
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("the streak never settled at %d strikes", want)
 }
 
 // expireProbeCooldown ages the model's probe claim so the next refusal may spend
@@ -1299,13 +1318,122 @@ func TestNoteModelGone_AnsweredProbePreventsTheDisable(t *testing.T) {
 	if calls := waitForDisable(t, repo); len(calls) != 0 {
 		t.Fatalf("a model that answered a direct probe must not be retired, got %+v", calls)
 	}
-	// The streak is dropped by the served branch (through noteModelServed), so
-	// the model needs three FRESH refusals before it is reconsidered.
-	waitForStreakCleared(t, h, m.ID)
+	// The count is reset by the served branch, so the model needs three FRESH
+	// refusals before it is reconsidered. The entry itself stays — it is what
+	// carries the probe cooldown, which the test below is about.
+	waitForStreakCount(t, h, m.ID, 0)
 	// And the outcome came from asking rather than from nothing happening.
 	if paths := script.requestedPaths(); len(paths) != 1 || paths[0] != probeChatEndpoint {
 		t.Fatalf("expected exactly one probe on %s, got %v", probeChatEndpoint, paths)
 	}
+}
+
+// TestNoteModelGone_APanicWhileDisablingDoesNotKillTheGateway pins the
+// recover() on the detached goroutine.
+//
+// That goroutine used to call repository methods and nothing else. It now makes
+// an upstream request and runs bytes a provider chose through json and the
+// dialect translators, and an unrecovered panic on any goroutine takes the whole
+// process down — so one model's retirement would be able to kill a gateway that
+// is serving everything else fine. Every other detached goroutine in this
+// package already recovers.
+//
+// The failure mode is why this test looks the way it does: without the recover,
+// the panic is not a failed assertion, it is the test binary dying, and the
+// second half below never runs at all. What is asserted is that the gateway
+// carried on and retired the next model normally.
+func TestNoteModelGone_APanicWhileDisablingDoesNotKillTheGateway(t *testing.T) {
+	t.Parallel()
+
+	// Panic once, on the first retirement only, so the second one exercises a
+	// gateway that is still working rather than a mock that stopped panicking.
+	var panicked atomic.Bool
+	repo := &mockModelRepo{afterConfirm: func() {
+		if panicked.CompareAndSwap(false, true) {
+			panic("a provider answer blew up mid-retirement")
+		}
+	}}
+	h := newGoneHandler(t, repo)
+
+	doomed := &model.Model{ID: uuid.New(), ModelID: "claude-sonnet-4"}
+	doomedCand := goneCandidateFor(t, doomed, "OpenCode Zen")
+	for range goneStrikeThreshold {
+		h.noteModelGone(doomedCand, endpointTypeChat)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for !panicked.Load() && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if !panicked.Load() {
+		t.Fatal("the retirement never reached the write, so nothing was proved about surviving one")
+	}
+
+	// The gateway is still here, and still retiring models.
+	next := &model.Model{ID: uuid.New(), ModelID: "gemini-2.0-flash"}
+	nextCand := goneCandidateFor(t, next, "Google AI Studio (Gemini)")
+	for range goneStrikeThreshold {
+		h.noteModelGone(nextCand, endpointTypeChat)
+	}
+
+	calls := waitForDisable(t, repo)
+	if len(calls) != 1 || calls[0].id != next.ID || !calls[0].committed {
+		t.Fatalf("the retirement after the panic must land normally, got %+v", calls)
+	}
+}
+
+// TestNoteModelGone_AnsweredProbeKeepsTheCooldown pins the bound on the one
+// verdict that is expected to REPEAT.
+//
+// A model whose real traffic keeps drawing retirement prose while a minimal
+// probe keeps answering is not an edge case: it is the disagreement the whole
+// feature exists to catch, and it does not resolve itself. Three refusals, a
+// probe, a served verdict, and the traffic goes straight back to refusing. If
+// the served branch drops the whole streak the way a real success does, the
+// cooldown goes with it, the rebuilt streak starts from a zero-valued one that
+// admits immediately, and the gateway probes once per three refusals for as long
+// as the disagreement lasts — roughly three upstream requests a second under a
+// client retry loop, at a provider that is already answering everything with an
+// error.
+//
+// Delete this test and that regression is invisible: every other served-probe
+// assertion still passes, because the model is still not retired.
+func TestNoteModelGone_AnsweredProbeKeepsTheCooldown(t *testing.T) {
+	t.Parallel()
+
+	repo := &mockModelRepo{}
+	h := newGoneHandler(t, repo)
+	m := &model.Model{ID: uuid.New(), ModelID: "gpt-5.6-sol"}
+	srv, script := newGoneScriptedServer(t, http.StatusOK, goneServedAnswer)
+	cand := goneCandidateAt(m, "OpenAI", srv.URL)
+
+	for range goneStrikeThreshold {
+		h.noteModelGone(cand, endpointTypeChat)
+	}
+	// Wait for the probe to have happened, then for the served branch to have
+	// finished with the streak. Without both, "no second probe" and "the first
+	// probe has not landed yet" are the same observation.
+	waitForProbes(t, script, 1)
+	waitForStreakCount(t, h, m.ID, 0)
+
+	// The traffic goes back to refusing, which is what a real disagreement looks
+	// like. The count is allowed to climb again — that is the backoff working —
+	// but not one of these may buy an upstream request inside the cooldown.
+	for range 10 * goneStrikeThreshold {
+		h.noteModelGone(cand, endpointTypeChat)
+	}
+	if calls := waitForDisable(t, repo); len(calls) != 0 {
+		t.Fatalf("a model that answered a direct probe must not be retired, got %+v", calls)
+	}
+	if paths := script.requestedPaths(); len(paths) != 1 {
+		t.Fatalf("refusals inside the cooldown must cost no further upstream requests, got %v", paths)
+	}
+
+	// And it is a delay rather than a lockout: once the cooldown lapses the model
+	// is reconsidered on the strikes it has rebuilt since.
+	expireProbeCooldown(t, h, m.ID)
+	h.noteModelGone(cand, endpointTypeChat)
+	waitForProbes(t, script, 2)
 }
 
 // TestNoteModelGone_RefusedProbeStillDisables is the paired control for the test

--- a/internal/proxy/model_gone_test.go
+++ b/internal/proxy/model_gone_test.go
@@ -1606,6 +1606,50 @@ func TestProbeForRetirement_NilCandidatePostponesInsteadOfPanicking(t *testing.T
 	}
 }
 
+// TestGoneStreak_ASuccessBetweenTheStrikeAndTheClaimWins pins the window between
+// the two lock acquisitions noteModelGone makes.
+//
+// A refusal strikes and then claims, and a success can land in between: it
+// clears the count and sets the tombstone, and the claim would then proceed on
+// strikes that no longer exist — spending an upstream request, wiping the
+// tombstone that success set, and reporting a strike count the streak does not
+// hold. The claim reads the count for exactly this reason, which is what makes
+// the comment's "a claim starts the next decision, on strikes the success is
+// older than" true rather than merely usual.
+func TestGoneStreak_ASuccessBetweenTheStrikeAndTheClaimWins(t *testing.T) {
+	t.Parallel()
+
+	s := &goneStreak{}
+	now := time.Now()
+	for range goneStrikeThreshold {
+		s.strike(now)
+	}
+
+	// The success lands after the last strike and before the claim.
+	s.supersede()
+
+	if s.canClaimProbe(now) {
+		t.Error("the cheap read admitted a claim on evidence a success had already cleared")
+	}
+	if s.claimProbe(now) {
+		t.Fatal("claimed a probe on evidence a success had already cleared")
+	}
+	if !s.cancelled.Load() {
+		t.Fatal("the claim wiped the tombstone the success set, so the queued disable would not stand down")
+	}
+
+	// Fresh refusals rebuild the case, and then the claim is real again.
+	for range goneStrikeThreshold {
+		s.strike(now)
+	}
+	if !s.claimProbe(now) {
+		t.Fatal("three fresh strikes must buy a claim")
+	}
+	if s.cancelled.Load() {
+		t.Error("a claim on strikes newer than the success must clear the tombstone")
+	}
+}
+
 // TestGoneStreak_CanClaimProbeDoesNotTakeTheClaim pins the read that lets the
 // cheap per-model reason to stop be checked before the shared per-provider one.
 //
@@ -1619,9 +1663,14 @@ func TestGoneStreak_CanClaimProbeDoesNotTakeTheClaim(t *testing.T) {
 
 	s := &goneStreak{}
 	now := time.Now()
+	// A claim needs evidence as well as an expired cooldown, so the streak has
+	// to be at the threshold before either can be asked about.
+	for range goneStrikeThreshold {
+		s.strike(now)
+	}
 
 	if !s.canClaimProbe(now) {
-		t.Fatal("a streak that has never been probed must admit a claim")
+		t.Fatal("a streak at the threshold that has never been probed must admit a claim")
 	}
 	if !s.canClaimProbe(now) {
 		t.Fatal("asking twice was refused, so the read spent the claim it was asking about")
@@ -1697,9 +1746,13 @@ func TestGoneStreak_SupersedeReportsWhetherItChangedAnything(t *testing.T) {
 	// tombstone can still belong to a disable this success has to stand down,
 	// which is the state a claim leaves behind.
 	claimed := &goneStreak{}
-	if !claimed.claimProbe(time.Now()) {
-		t.Fatal("a fresh streak must admit the first claim")
+	for range goneStrikeThreshold {
+		claimed.strike(time.Now())
 	}
+	if !claimed.claimProbe(time.Now()) {
+		t.Fatal("a streak at the threshold must admit the first claim")
+	}
+	claimed.park()
 	if !claimed.supersede() {
 		t.Fatal("a success against a claimed streak must still set the tombstone")
 	}

--- a/internal/proxy/model_gone_test.go
+++ b/internal/proxy/model_gone_test.go
@@ -73,6 +73,16 @@ func waitForStreakCount(t *testing.T, h *Handler, id uuid.UUID, endpoint string,
 	t.Fatalf("the streak never settled at %d strikes", want)
 }
 
+// probeClaimAt reports when the model's streak will next admit a probe. The zero
+// time means no claim has been spent on this surface.
+func probeClaimAt(t *testing.T, h *Handler, id uuid.UUID, endpoint string) time.Time {
+	t.Helper()
+	streak := goneStreakFor(t, h, id, endpoint)
+	streak.mu.Lock()
+	defer streak.mu.Unlock()
+	return streak.nextProbeAt
+}
+
 // expireProbeCooldown ages the model's probe claim so the next refusal may spend
 // a probe, standing in for goneProbeCooldown having elapsed.
 //
@@ -1927,11 +1937,18 @@ func TestNoteModelGone_ExhaustedProbeSlotsPostponeWithoutAsking(t *testing.T) {
 	if n := goneStreakFor(t, h, m.ID, probeChatEndpoint).count(); n != goneStrikeThreshold {
 		t.Fatalf("the strikes must survive so the retry is reachable, got a streak of %d", n)
 	}
+	// And the model's own claim was not spent on it. A refused slot costs
+	// nothing: no upstream request was made, so there is nothing for the
+	// five-minute cooldown to be bounding. Charging it anyway is what turned a
+	// provider-wide nomination event into four models per cooldown — the very
+	// burst the semaphore exists for, converging in hours instead of minutes.
+	if next := probeClaimAt(t, h, m.ID, probeChatEndpoint); !next.IsZero() {
+		t.Fatalf("a refused slot burnt the probe cooldown until %s", next)
+	}
 
-	// A slot frees up and the cooldown lapses: the retirement lands on the
-	// evidence that was already there.
+	// A slot frees up: the very next refusal probes, with no cooldown to wait
+	// out, and the retirement lands on the evidence that was already there.
 	<-full
-	expireProbeCooldown(t, h, m.ID, probeChatEndpoint)
 	h.noteModelGone(cand, endpointTypeChat)
 
 	calls := waitForDisable(t, repo)
@@ -1964,6 +1981,7 @@ func TestNoteModelGone_ASurfaceTheModelIsNotForNeverStrikes(t *testing.T) {
 
 	cases := []struct {
 		name             string
+		inputModalities  string
 		outputModalities string
 		endpointType     string
 		endpoint         string
@@ -1971,27 +1989,47 @@ func TestNoteModelGone_ASurfaceTheModelIsNotForNeverStrikes(t *testing.T) {
 	}{
 		// A chat model sent to the embeddings surface: the refusal is about the
 		// misuse, not about the model.
-		{"text model on embeddings", `["text"]`, endpointTypeEmbeddings, probeEmbeddingsEndpoint, false},
+		{"text model on embeddings", `["text"]`, `["text"]`, endpointTypeEmbeddings, probeEmbeddingsEndpoint, false},
 		// And the mirror image, which is just as wrong.
-		{"embedding model on chat", `["embedding"]`, endpointTypeChat, probeChatEndpoint, false},
+		{"embedding model on chat", `["text"]`, `["embedding"]`, endpointTypeChat, probeChatEndpoint, false},
+		// Every other non-chat class is the same mistake with a different noun,
+		// and all of them are reachable: nothing filters a request by modality on
+		// the way in, and a provider that answers "Model 'flux-1.1-pro' is not
+		// supported for chat completions" has named the model beside a
+		// gone-phrase.
+		{"image model on chat", `["text"]`, `["image"]`, endpointTypeChat, probeChatEndpoint, false},
+		{"video model on chat", `["text"]`, `["video"]`, endpointTypeChat, probeChatEndpoint, false},
+		{"tts model on chat", `["text"]`, `["audio"]`, endpointTypeChat, probeChatEndpoint, false},
+		{"rerank model on chat", `["text"]`, `["rerank"]`, endpointTypeChat, probeChatEndpoint, false},
+		// Speech-to-text produces text like any chat model and gives itself away
+		// on the input side, which is why both arrays are read.
+		{"stt model on chat", `["audio"]`, `["text"]`, endpointTypeChat, probeChatEndpoint, false},
 		// The same refusals on the surfaces the models are for.
-		{"text model on chat", `["text"]`, endpointTypeChat, probeChatEndpoint, true},
-		{"embedding model on embeddings", `["embedding"]`, endpointTypeEmbeddings, probeEmbeddingsEndpoint, true},
+		{"text model on chat", `["text"]`, `["text"]`, endpointTypeChat, probeChatEndpoint, true},
+		{"embedding model on embeddings", `["text"]`, `["embedding"]`, endpointTypeEmbeddings, probeEmbeddingsEndpoint, true},
+		// A chat model that also emits images is a chat model; the text admits
+		// it, and so does a vision model's image INPUT.
+		{"image-emitting chat model", `["text"]`, `["text","image"]`, endpointTypeChat, probeChatEndpoint, true},
+		{"vision chat model", `["text","image"]`, `["text"]`, endpointTypeChat, probeChatEndpoint, true},
+		{"code model on chat", `["text"]`, `["code"]`, endpointTypeChat, probeChatEndpoint, true},
 		// A model that produces both is not evidence against either surface.
-		{"multimodal on chat", `["text","embedding"]`, endpointTypeChat, probeChatEndpoint, true},
-		{"multimodal on embeddings", `["text","embedding"]`, endpointTypeEmbeddings, probeEmbeddingsEndpoint, true},
+		{"multimodal on chat", `["text"]`, `["text","embedding"]`, endpointTypeChat, probeChatEndpoint, true},
+		{"multimodal on embeddings", `["text"]`, `["text","embedding"]`, endpointTypeEmbeddings, probeEmbeddingsEndpoint, true},
 		// The two surfaces answer to different burdens of proof when the catalog
 		// says nothing, and this is where that shows. liveModelStub writes "[]"
 		// for every model no catalog covers, so failing open on embeddings would
 		// leave the whole misuse case reachable for exactly those rows; failing
 		// closed on chat would switch traffic-driven retirement off for them
 		// altogether.
-		{"unknown modality on embeddings", "", endpointTypeEmbeddings, probeEmbeddingsEndpoint, false},
-		{"empty modality on embeddings", "[]", endpointTypeEmbeddings, probeEmbeddingsEndpoint, false},
-		{"unparseable modality on embeddings", `{"not":"a list"}`, endpointTypeEmbeddings, probeEmbeddingsEndpoint, false},
-		{"unknown modality on chat", "", endpointTypeChat, probeChatEndpoint, true},
-		{"empty modality on chat", "[]", endpointTypeChat, probeChatEndpoint, true},
-		{"unparseable modality on chat", `{"not":"a list"}`, endpointTypeChat, probeChatEndpoint, true},
+		{"unknown modality on embeddings", "", "", endpointTypeEmbeddings, probeEmbeddingsEndpoint, false},
+		{"empty modality on embeddings", "[]", "[]", endpointTypeEmbeddings, probeEmbeddingsEndpoint, false},
+		{"unparseable modality on embeddings", `{"not":"a list"}`, `{"not":"a list"}`, endpointTypeEmbeddings, probeEmbeddingsEndpoint, false},
+		{"unknown modality on chat", "", "", endpointTypeChat, probeChatEndpoint, true},
+		{"empty modality on chat", "[]", "[]", endpointTypeChat, probeChatEndpoint, true},
+		{"unparseable modality on chat", `{"not":"a list"}`, `{"not":"a list"}`, endpointTypeChat, probeChatEndpoint, true},
+		// A declared output with an undeclared input is still admitted: an
+		// unreadable array is not evidence, and only evidence rules a surface out.
+		{"text out, unknown in, on chat", "", `["text"]`, endpointTypeChat, probeChatEndpoint, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1999,7 +2037,7 @@ func TestNoteModelGone_ASurfaceTheModelIsNotForNeverStrikes(t *testing.T) {
 
 			repo := &mockModelRepo{}
 			h := newGoneHandler(t, repo)
-			m := &model.Model{ID: uuid.New(), ModelID: "gpt-4o", OutputModalities: tc.outputModalities}
+			m := &model.Model{ID: uuid.New(), ModelID: "gpt-4o", InputModalities: tc.inputModalities, OutputModalities: tc.outputModalities}
 			cand := goneCandidateFor(t, m, "OpenAI")
 
 			h.noteModelGone(cand, tc.endpointType)

--- a/internal/proxy/model_gone_test.go
+++ b/internal/proxy/model_gone_test.go
@@ -1488,14 +1488,18 @@ func TestAttemptCandidate_ATranslationFailureKeepsTheStreak(t *testing.T) {
 }
 
 // TestNoteModelGone_TheRetirementEventReportsTheRealStrikeCount pins that the
-// number an operator reads is the number that happened.
+// number an operator reads is the number the decision was made on.
 //
-// Both the log line and the alert reported goneStrikeThreshold, which was
-// accurate while a retirement could only be triggered by the caller that saw
-// exactly three. claimProbe replaced that gate: the write can equally stand on a
-// streak sitting at thirteen under a client's retry loop, or on a single refusal
-// that re-claimed a streak parked since the last cooldown. A constant would tell
-// every operator the same story about decisions that were reached differently.
+// Both the log line and the alert used to report goneStrikeThreshold, which was
+// accurate only while a retirement could be triggered by the caller that saw
+// exactly three. claimProbe replaced that gate, so a write can equally stand on
+// a single refusal that re-claimed a streak parked since the last cooldown, or
+// on a streak already past the threshold.
+//
+// The sequence below produces three different plausible answers, which is the
+// point of its shape: the constant would say 3, a count read back after the
+// probe and the write would say 14, and the count the claiming refusal actually
+// saw is 4. Only the last one answers "how was this decision reached".
 func TestNoteModelGone_TheRetirementEventReportsTheRealStrikeCount(t *testing.T) {
 	// Not parallel: it subscribes to the process-wide event bus.
 	const extraRefusals = 10
@@ -1506,7 +1510,10 @@ func TestNoteModelGone_TheRetirementEventReportsTheRealStrikeCount(t *testing.T)
 	}
 	h := newGoneHandler(t, repo)
 	m := &model.Model{ID: uuid.New(), ModelID: "gemini-2.0-flash"}
-	cand := goneCandidateFor(t, m, "Google AI Studio (Gemini)")
+	// Rate limited first, so the first probe establishes nothing and parks the
+	// streak at the threshold instead of retiring on it.
+	srv, script := newGoneScriptedServer(t, http.StatusTooManyRequests, goneRateLimitedAnswer)
+	cand := goneCandidateAt(m, "Google AI Studio (Gemini)", srv.URL)
 
 	ch := events.Subscribe()
 	defer events.Unsubscribe(ch)
@@ -1514,6 +1521,15 @@ func TestNoteModelGone_TheRetirementEventReportsTheRealStrikeCount(t *testing.T)
 	for range goneStrikeThreshold {
 		h.noteModelGone(cand, endpointTypeChat)
 	}
+	waitForProbes(t, script, 1)
+
+	// The incident passes and the model turns out to be genuinely gone. One
+	// refusal now claims the probe, and the count it sees is one past the
+	// threshold — a number no constant could produce.
+	script.answer(http.StatusNotFound, goneRefusalBody(m.ModelID))
+	expireProbeCooldown(t, h, m.ID, probeChatEndpoint)
+	h.noteModelGone(cand, endpointTypeChat)
+
 	select {
 	case <-repo.setEnabledEntered:
 	case <-time.After(2 * time.Second):
@@ -1521,15 +1537,14 @@ func TestNoteModelGone_TheRetirementEventReportsTheRealStrikeCount(t *testing.T)
 	}
 
 	// The client keeps retrying the dead model while the write is held open.
-	// None of these buys a probe (the cooldown is running), but every one of
-	// them is a strike, so the streak is well past the threshold by the time the
-	// retirement is announced.
+	// None of these buys a probe (the cooldown is running again) and none of
+	// them was part of the decision, but every one is a strike.
 	for range extraRefusals {
 		h.noteModelGone(cand, endpointTypeChat)
 	}
 	close(repo.setEnabledGate)
 
-	want := int64(goneStrikeThreshold + extraRefusals)
+	want := int64(goneStrikeThreshold + 1)
 	deadline := time.After(2 * time.Second)
 	for {
 		select {
@@ -1965,10 +1980,19 @@ func TestNoteModelGone_ASurfaceTheModelIsNotForNeverStrikes(t *testing.T) {
 		{"embedding model on embeddings", `["embedding"]`, endpointTypeEmbeddings, probeEmbeddingsEndpoint, true},
 		// A model that produces both is not evidence against either surface.
 		{"multimodal on chat", `["text","embedding"]`, endpointTypeChat, probeChatEndpoint, true},
-		// No metadata is not evidence either: rows predating the modality
-		// columns must keep the retirement they have today.
-		{"unknown modality on embeddings", "", endpointTypeEmbeddings, probeEmbeddingsEndpoint, true},
+		{"multimodal on embeddings", `["text","embedding"]`, endpointTypeEmbeddings, probeEmbeddingsEndpoint, true},
+		// The two surfaces answer to different burdens of proof when the catalog
+		// says nothing, and this is where that shows. liveModelStub writes "[]"
+		// for every model no catalog covers, so failing open on embeddings would
+		// leave the whole misuse case reachable for exactly those rows; failing
+		// closed on chat would switch traffic-driven retirement off for them
+		// altogether.
+		{"unknown modality on embeddings", "", endpointTypeEmbeddings, probeEmbeddingsEndpoint, false},
+		{"empty modality on embeddings", "[]", endpointTypeEmbeddings, probeEmbeddingsEndpoint, false},
+		{"unparseable modality on embeddings", `{"not":"a list"}`, endpointTypeEmbeddings, probeEmbeddingsEndpoint, false},
+		{"unknown modality on chat", "", endpointTypeChat, probeChatEndpoint, true},
 		{"empty modality on chat", "[]", endpointTypeChat, probeChatEndpoint, true},
+		{"unparseable modality on chat", `{"not":"a list"}`, endpointTypeChat, probeChatEndpoint, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -2008,9 +2032,9 @@ func TestNoteModelGone_SurfacesDoNotPoolTheirStrikes(t *testing.T) {
 
 	repo := &mockModelRepo{}
 	h := newGoneHandler(t, repo)
-	// No declared modality, so neither surface is contradicted and the split is
-	// the only thing keeping the two counters apart.
-	m := &model.Model{ID: uuid.New(), ModelID: "gpt-5.6-sol"}
+	// A model the catalog says produces both, so neither surface is ruled out
+	// and the split is the only thing keeping the two counters apart.
+	m := &model.Model{ID: uuid.New(), ModelID: "gpt-5.6-sol", OutputModalities: `["text","embedding"]`}
 	srv, script := newGoneScriptedServer(t, http.StatusNotFound, goneRefusalBody("gpt-5.6-sol"))
 	cand := goneCandidateAt(m, "OpenAI", srv.URL)
 
@@ -2051,7 +2075,7 @@ func TestNoteModelServed_ClearsEverySurface(t *testing.T) {
 
 	repo := &mockModelRepo{}
 	h := newGoneHandler(t, repo)
-	m := &model.Model{ID: uuid.New(), ModelID: "gpt-5.6-sol"}
+	m := &model.Model{ID: uuid.New(), ModelID: "gpt-5.6-sol", OutputModalities: `["text","embedding"]`}
 	cand := goneCandidateFor(t, m, "OpenAI")
 
 	h.noteModelGone(cand, endpointTypeChat)
@@ -2098,7 +2122,9 @@ func TestNoteModelGone_EmbeddingsAreProbedOnTheirOwnEndpoint(t *testing.T) {
 
 	repo := &mockModelRepo{}
 	h := newGoneHandler(t, repo)
-	m := &model.Model{ID: uuid.New(), ModelID: "text-embedding-3-small"}
+	// An embeddings model as the catalog describes one: a refusal on
+	// /embeddings only counts against a model that says it produces embeddings.
+	m := &model.Model{ID: uuid.New(), ModelID: "text-embedding-3-small", OutputModalities: `["embedding"]`}
 	srv, script := newGoneScriptedServer(t, http.StatusNotFound, goneRefusalBody("text-embedding-3-small"))
 	cand := goneCandidateAt(m, "OpenAI", srv.URL)
 

--- a/internal/proxy/model_gone_test.go
+++ b/internal/proxy/model_gone_test.go
@@ -422,7 +422,12 @@ func TestNoteModelGone_CapabilityRefusalsNeverDisable(t *testing.T) {
 	repo := &mockModelRepo{}
 	h := newGoneHandler(t, repo)
 	m := &model.Model{ID: uuid.New(), ModelID: "gpt-5.6-sol"}
-	cand := goneCandidateFor(t, m, "OpenAI")
+	// Deliberately NOT goneCandidateFor: the classifier never returns
+	// KindProviderModelGone for these bodies, so noteModelGone is never reached
+	// and no probe is ever sent. A listener here would be dead weight, and worse,
+	// it would read as though the provider had a say in the outcome. What this
+	// test pins is that the classifier alone declines to nominate the model.
+	cand := modelCandidate{model: m, provider: &provider.Provider{ID: uuid.New(), Name: "OpenAI"}}
 
 	// Well past the threshold, cycling through every refusal shape.
 	for i := range goneStrikeThreshold * 3 {

--- a/internal/proxy/model_gone_test.go
+++ b/internal/proxy/model_gone_test.go
@@ -431,11 +431,11 @@ func TestVerdictForStream(t *testing.T) {
 	}
 }
 
-// TestStreamProducedOutput covers the two independent signals that a stream
+// TestProducedOutput covers the two independent signals that a stream
 // actually delivered content. Neither is reliable alone: completion tokens are
 // absent when a provider omits the usage chunk, TTFT is zero when the probe is
 // disabled.
-func TestStreamProducedOutput(t *testing.T) {
+func TestProducedOutput(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -459,8 +459,8 @@ func TestStreamProducedOutput(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			if got := streamProducedOutput(tc.log); got != tc.want {
-				t.Errorf("streamProducedOutput() = %v, want %v", got, tc.want)
+			if got := producedOutput(tc.log); got != tc.want {
+				t.Errorf("producedOutput() = %v, want %v", got, tc.want)
 			}
 		})
 	}
@@ -1497,6 +1497,113 @@ func TestAttemptCandidate_ATranslationFailureKeepsTheStreak(t *testing.T) {
 	}
 }
 
+// TestAttemptCandidate_AnEmptyCompletionKeepsTheStreak pins that the
+// non-streaming chat path judges the answer rather than the status.
+//
+// `200 {"choices":[]}` decodes, is forwarded to the client as a normal
+// completion, and is exactly what an aggregator in front of a retired model can
+// return between its gone-shaped 404s. Crediting it resets the count, so the
+// three refusals never land consecutively and the model is never nominated,
+// probed or retired. Every other path on this branch already draws this line.
+func TestAttemptCandidate_AnEmptyCompletionKeepsTheStreak(t *testing.T) {
+	cases := []struct {
+		name       string
+		answer     string
+		wantStreak int64
+	}{
+		{"empty completion", `{"id":"x","object":"chat.completion","choices":[]}`, 1},
+		// The control, without which this test would also pass against a path
+		// that had simply stopped clearing streaks altogether.
+		{"real completion", `{"id":"x","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"hi"}}],"usage":{"completion_tokens":1}}`, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newIntegrationHandler()
+			defer stopUnitHandler(h)
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, tc.answer)
+			}))
+			defer srv.Close()
+
+			m := &model.Model{ID: uuid.New(), ModelID: "gpt-5.6-sol", InputModalities: `["text"]`, OutputModalities: `["text"]`}
+			cand := goneCandidateAt(m, "OpenAI", srv.URL)
+
+			// One real refusal, so there is a streak for the 200 to clear.
+			h.noteModelGone(cand, endpointTypeChat)
+			streak := goneStreakFor(t, h, m.ID, probeChatEndpoint)
+
+			st := &requestState{
+				startTime:       time.Now(),
+				reqModel:        "gpt-5.6-sol",
+				bodyBytes:       []byte(`{"model":"gpt-5.6-sol","messages":[{"role":"user","content":"hi"}]}`),
+				failoverTimeout: 30 * time.Second,
+				logData:         &requestLogData{modelID: "gpt-5.6-sol", endpointType: endpointTypeChat},
+			}
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)
+
+			if got := h.attemptCandidate(w, r, st, cand, 0, 1); got != outcomeServed {
+				t.Fatalf("outcome = %v, want served", got)
+			}
+			if n := streak.count(); n != tc.wantStreak {
+				t.Fatalf("streak = %d, want %d", n, tc.wantStreak)
+			}
+		})
+	}
+}
+
+// TestNoteModelGone_ARetirementThatStandsIsStillAnnounced pins that a disable
+// which stuck gets its follow-through.
+//
+// Once AutoRetireIfConfirmed commits, the row is off. Three of the four ways out
+// of the post-commit cancelled branch leave it off — no revert attempted, a
+// revert that errored, a revert the row had moved past — and all three used to
+// return before the custom-group revalidation and the alert. The revalidation is
+// the load-bearing half: a disabled member does not resize the groups it belongs
+// to, so skipping it leaves a group enabled with fewer than two routable members
+// until an unrelated scan notices.
+//
+// The arm driven here is the one where the model is refusing again, which is
+// also the one where the retirement is most clearly real.
+func TestNoteModelGone_ARetirementThatStandsIsStillAnnounced(t *testing.T) {
+	// Not parallel: it subscribes to the process-wide event bus.
+	repo := &mockModelRepo{}
+	h := newGoneHandler(t, repo)
+	m := &model.Model{ID: uuid.New(), ModelID: "gemini-2.0-flash"}
+	cand := goneCandidateFor(t, m, "Google AI Studio (Gemini)")
+
+	// A success lands inside the commit window and fresh refusals rebuild the
+	// case behind it, so the revert stands down and the model stays retired.
+	repo.afterConfirm = func() {
+		h.noteModelServed(m, endpointTypeChat)
+		for range goneStrikeThreshold {
+			h.noteModelGone(cand, endpointTypeChat)
+		}
+	}
+
+	ch := events.Subscribe()
+	defer events.Unsubscribe(ch)
+
+	for range goneStrikeThreshold {
+		h.noteModelGone(cand, endpointTypeChat)
+	}
+
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case ev := <-ch:
+			if ev.Type != "model.auto_disabled_gone" || ev.Metadata["model_uuid"] != m.ID.String() {
+				continue
+			}
+			return
+		case <-deadline:
+			t.Fatal("a retirement that was never reverted was never announced")
+		}
+	}
+}
+
 // TestNoteModelGone_TheRetirementEventReportsTheRealStrikeCount pins that the
 // number an operator reads is the number the decision was made on.
 //
@@ -1698,7 +1805,7 @@ func TestGoneStreak_CanClaimProbeDoesNotTakeTheClaim(t *testing.T) {
 }
 
 // TestNoteStreamOutcome_NilLogDataIsIgnored pins a guard that has to live at the
-// dereference. streamProducedOutput checks for nil as well, but noteStreamOutcome
+// dereference. producedOutput checks for nil as well, but noteStreamOutcome
 // builds its arguments from logData in the same expression that calls it, and Go
 // evaluates all of them first — so on this path the helper's check could never
 // run and a nil would panic before reaching it.

--- a/internal/proxy/model_gone_test.go
+++ b/internal/proxy/model_gone_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"runtime"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -42,9 +43,9 @@ func waitForDisable(t *testing.T, repo *mockModelRepo) []setEnabledCall {
 // goneStreakFor returns the model's live streak, failing the test if there is
 // none. The streak is what the postponement paths now leave behind, so several
 // tests below assert on it directly rather than on the absence of a write.
-func goneStreakFor(t *testing.T, h *Handler, id uuid.UUID) *goneStreak {
+func goneStreakFor(t *testing.T, h *Handler, id uuid.UUID, endpoint string) *goneStreak {
 	t.Helper()
-	raw, ok := h.goneStrikes.Load(id)
+	raw, ok := h.goneStrikes.Load(goneStreakKey{model: id, endpoint: endpoint})
 	if !ok {
 		t.Fatal("the model has no streak")
 	}
@@ -59,11 +60,11 @@ func goneStreakFor(t *testing.T, h *Handler, id uuid.UUID) *goneStreak {
 // paths that reset the count in place instead of dropping the entry. The reset
 // happens on the detached goroutine, so reading the count straight after the
 // refusals that triggered it races the reset rather than observing it.
-func waitForStreakCount(t *testing.T, h *Handler, id uuid.UUID, want int64) {
+func waitForStreakCount(t *testing.T, h *Handler, id uuid.UUID, endpoint string, want int64) {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		if raw, ok := h.goneStrikes.Load(id); ok {
+		if raw, ok := h.goneStrikes.Load(goneStreakKey{model: id, endpoint: endpoint}); ok {
 			if s, ok := raw.(*goneStreak); ok && s.count() == want {
 				return
 			}
@@ -80,9 +81,9 @@ func waitForStreakCount(t *testing.T, h *Handler, id uuid.UUID, want int64) {
 // lastStrike. The alternative — a knob, an injected clock, a var instead of a
 // const — would put a seam in production code that exists only for tests, and
 // the wait it replaces is five minutes.
-func expireProbeCooldown(t *testing.T, h *Handler, id uuid.UUID) {
+func expireProbeCooldown(t *testing.T, h *Handler, id uuid.UUID, endpoint string) {
 	t.Helper()
-	streak := goneStreakFor(t, h, id)
+	streak := goneStreakFor(t, h, id, endpoint)
 	streak.mu.Lock()
 	streak.nextProbeAt = time.Now().Add(-time.Second)
 	streak.mu.Unlock()
@@ -700,7 +701,7 @@ func TestNoteModelGone_FailedDisableIsRetried(t *testing.T) {
 
 	// Once it lapses, the parked evidence is still there and one refusal is
 	// enough to try the write again.
-	expireProbeCooldown(t, h, m.ID)
+	expireProbeCooldown(t, h, m.ID, probeChatEndpoint)
 	h.noteModelGone(cand, endpointTypeChat)
 
 	deadline := time.Now().Add(2 * time.Second)
@@ -896,7 +897,7 @@ func TestNoteModelGone_StaleFailedDisableKeepsTheEvidence(t *testing.T) {
 	}
 	watch := time.Now().Add(300 * time.Millisecond)
 	for time.Now().Before(watch) {
-		if n := goneStreakFor(t, h, m.ID).count(); n != goneStrikeThreshold-1 {
+		if n := goneStreakFor(t, h, m.ID, probeChatEndpoint).count(); n != goneStrikeThreshold-1 {
 			t.Fatalf("the stale failed disable took the newer evidence with it: streak = %d", n)
 		}
 		time.Sleep(5 * time.Millisecond)
@@ -905,7 +906,7 @@ func TestNoteModelGone_StaleFailedDisableKeepsTheEvidence(t *testing.T) {
 	// One more refusal completes the rebuilt streak. The cooldown from the first
 	// claim is still running, so this is also the point at which the retry
 	// becomes reachable rather than immediate.
-	expireProbeCooldown(t, h, m.ID)
+	expireProbeCooldown(t, h, m.ID, probeChatEndpoint)
 	h.noteModelGone(cand, endpointTypeChat)
 
 	deadline = time.Now().Add(2 * time.Second)
@@ -986,7 +987,7 @@ func TestNoteModelGone_StaleStrikesDoNotAccumulate(t *testing.T) {
 	}
 
 	// Age them past the window, as if the incident were hours ago.
-	raw, ok := h.goneStrikes.Load(m.ID)
+	raw, ok := h.goneStrikes.Load(goneStreakKey{model: m.ID, endpoint: probeChatEndpoint})
 	if !ok {
 		t.Fatal("the strikes did not start a streak")
 	}
@@ -1319,7 +1320,7 @@ func TestNoteModelGone_AnsweredProbePreventsTheDisable(t *testing.T) {
 	// The count is reset by the served branch, so the model needs three FRESH
 	// refusals before it is reconsidered. The entry itself stays — it is what
 	// carries the probe cooldown, which the test below is about.
-	waitForStreakCount(t, h, m.ID, 0)
+	waitForStreakCount(t, h, m.ID, probeChatEndpoint, 0)
 	// And the outcome came from asking rather than from nothing happening.
 	if paths := script.requestedPaths(); len(paths) != 1 || paths[0] != probeChatEndpoint {
 		t.Fatalf("expected exactly one probe on %s, got %v", probeChatEndpoint, paths)
@@ -1412,7 +1413,7 @@ func TestNoteModelGone_AnsweredProbeKeepsTheCooldown(t *testing.T) {
 	// finished with the streak. Without both, "no second probe" and "the first
 	// probe has not landed yet" are the same observation.
 	waitForProbes(t, script, 1)
-	waitForStreakCount(t, h, m.ID, 0)
+	waitForStreakCount(t, h, m.ID, probeChatEndpoint, 0)
 
 	// The traffic goes back to refusing, which is what a real disagreement looks
 	// like. The count is allowed to climb again — that is the backoff working —
@@ -1429,7 +1430,7 @@ func TestNoteModelGone_AnsweredProbeKeepsTheCooldown(t *testing.T) {
 
 	// And it is a delay rather than a lockout: once the cooldown lapses the model
 	// is reconsidered on the strikes it has rebuilt since.
-	expireProbeCooldown(t, h, m.ID)
+	expireProbeCooldown(t, h, m.ID, probeChatEndpoint)
 	h.noteModelGone(cand, endpointTypeChat)
 	waitForProbes(t, script, 2)
 }
@@ -1461,7 +1462,7 @@ func TestAttemptCandidate_ATranslationFailureKeepsTheStreak(t *testing.T) {
 
 	// One real refusal, so there is a streak for the 200 to wrongly clear.
 	h.noteModelGone(cand, endpointTypeChat)
-	streak := goneStreakFor(t, h, m.ID)
+	streak := goneStreakFor(t, h, m.ID, probeChatEndpoint)
 	if n := streak.count(); n != 1 {
 		t.Fatalf("streak = %d, want 1 before the attempt", n)
 	}
@@ -1580,6 +1581,44 @@ func TestProbeForRetirement_NilCandidatePostponesInsteadOfPanicking(t *testing.T
 	}
 }
 
+// TestGoneStreak_SupersedeReportsWhetherItChangedAnything pins the report the
+// log line depends on.
+//
+// Nothing removes a streak any more, which is what keeps the probe cooldown. The
+// consequence is that a model which drew a single refusal at 09:00 carries a
+// parked streak for the life of the process, and every successful request to it
+// from then on reaches supersede with nothing left to do. An unconditional line
+// would claim to have "cleared gone-strikes" on every one of them.
+func TestGoneStreak_SupersedeReportsWhetherItChangedAnything(t *testing.T) {
+	t.Parallel()
+
+	s := &goneStreak{}
+	s.strike(time.Now())
+	if !s.supersede() {
+		t.Fatal("the first success had a strike to clear and said it did nothing")
+	}
+	if s.supersede() {
+		t.Fatal("a second success on an already-superseded streak did no work but reported that it had")
+	}
+
+	// A fresh refusal makes it real work again.
+	s.strike(time.Now())
+	if !s.supersede() {
+		t.Fatal("a success after a new strike had evidence to clear")
+	}
+
+	// And the early return is deliberately narrow: an empty count with no
+	// tombstone can still belong to a disable this success has to stand down,
+	// which is the state a claim leaves behind.
+	claimed := &goneStreak{}
+	if !claimed.claimProbe(time.Now()) {
+		t.Fatal("a fresh streak must admit the first claim")
+	}
+	if !claimed.supersede() {
+		t.Fatal("a success against a claimed streak must still set the tombstone")
+	}
+}
+
 // TestGoneStreak_SupersedeIsAtomicToAReader pins the one ordering the revert
 // path depends on and cannot check for itself.
 //
@@ -1661,7 +1700,7 @@ func TestNoteModelGone_ASuccessDoesNotResetTheProbeCooldown(t *testing.T) {
 		h.noteModelGone(cand, endpointTypeChat)
 	}
 	waitForProbes(t, script, 1)
-	waitForStreakCount(t, h, m.ID, 0)
+	waitForStreakCount(t, h, m.ID, probeChatEndpoint, 0)
 
 	// An ordinary request to the same model succeeds, exactly as the request
 	// path reports it.
@@ -1680,7 +1719,7 @@ func TestNoteModelGone_ASuccessDoesNotResetTheProbeCooldown(t *testing.T) {
 	}
 
 	// Still a delay rather than a lockout.
-	expireProbeCooldown(t, h, m.ID)
+	expireProbeCooldown(t, h, m.ID, probeChatEndpoint)
 	h.noteModelGone(cand, endpointTypeChat)
 	waitForProbes(t, script, 2)
 }
@@ -1753,14 +1792,14 @@ func TestNoteModelGone_RateLimitedProbePostponesThenRetires(t *testing.T) {
 	// rate unbounded: three fresh refusals bought another probe, forever, at a
 	// provider that was already rate limiting us. The claim is what gates the
 	// retry now, so the strikes stay where they are.
-	if n := goneStreakFor(t, h, m.ID).count(); n != goneStrikeThreshold {
+	if n := goneStreakFor(t, h, m.ID, probeChatEndpoint).count(); n != goneStrikeThreshold {
 		t.Fatalf("a postponed retirement must keep the strikes it was built on, got a streak of %d", n)
 	}
 
 	// The incident passes and the model turns out to be genuinely gone. One
 	// refusal is now enough, precisely because the earlier strikes survived.
 	script.answer(http.StatusNotFound, goneRefusalBody(m.ModelID))
-	expireProbeCooldown(t, h, m.ID)
+	expireProbeCooldown(t, h, m.ID, probeChatEndpoint)
 	h.noteModelGone(cand, endpointTypeChat)
 
 	calls := waitForDisable(t, repo)
@@ -1818,7 +1857,7 @@ func TestNoteModelGone_ProbeCooldownBoundsTheProbeRate(t *testing.T) {
 	// The bound is a delay, not a lockout: once the cooldown lapses the next
 	// refusal probes again.
 	script.answer(http.StatusNotFound, goneRefusalBody(m.ModelID))
-	expireProbeCooldown(t, h, m.ID)
+	expireProbeCooldown(t, h, m.ID, probeChatEndpoint)
 	h.noteModelGone(cand, endpointTypeChat)
 
 	if calls := waitForDisable(t, repo); len(calls) != 1 {
@@ -1871,14 +1910,14 @@ func TestNoteModelGone_ExhaustedProbeSlotsPostponeWithoutAsking(t *testing.T) {
 	if paths := script.requestedPaths(); len(paths) != 0 {
 		t.Fatalf("no slot was free, so no upstream request may be spent, got %v", paths)
 	}
-	if n := goneStreakFor(t, h, m.ID).count(); n != goneStrikeThreshold {
+	if n := goneStreakFor(t, h, m.ID, probeChatEndpoint).count(); n != goneStrikeThreshold {
 		t.Fatalf("the strikes must survive so the retry is reachable, got a streak of %d", n)
 	}
 
 	// A slot frees up and the cooldown lapses: the retirement lands on the
 	// evidence that was already there.
 	<-full
-	expireProbeCooldown(t, h, m.ID)
+	expireProbeCooldown(t, h, m.ID, probeChatEndpoint)
 	h.noteModelGone(cand, endpointTypeChat)
 
 	calls := waitForDisable(t, repo)
@@ -1890,6 +1929,158 @@ func TestNoteModelGone_ExhaustedProbeSlotsPostponeWithoutAsking(t *testing.T) {
 	}
 	if paths := waitForProbes(t, script, 1); len(paths) != 1 {
 		t.Errorf("expected exactly one probe, got %v", paths)
+	}
+}
+
+// TestNoteModelGone_ASurfaceTheModelIsNotForNeverStrikes pins the second gate.
+//
+// Nothing filters a request by modality on the way in: `POST /v1/embeddings`
+// naming a chat model is forwarded to the provider's embeddings endpoint, and a
+// provider that answers "gpt-4o is not supported for embeddings" has named the
+// model beside a gone-phrase, which the classifier reads as a retirement. The
+// probe cannot save the model from that, because it asks on the family the
+// strikes arrived on: it reproduces the misuse, draws the same refusal, and
+// confirms a retirement of a model that serves chat perfectly. And the disable
+// is model-wide, so one misconfigured client would take it out of routing
+// everywhere.
+//
+// The control case is the same model, same refusal, on the surface it IS for.
+func TestNoteModelGone_ASurfaceTheModelIsNotForNeverStrikes(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name             string
+		outputModalities string
+		endpointType     string
+		endpoint         string
+		wantStrike       bool
+	}{
+		// A chat model sent to the embeddings surface: the refusal is about the
+		// misuse, not about the model.
+		{"text model on embeddings", `["text"]`, endpointTypeEmbeddings, probeEmbeddingsEndpoint, false},
+		// And the mirror image, which is just as wrong.
+		{"embedding model on chat", `["embedding"]`, endpointTypeChat, probeChatEndpoint, false},
+		// The same refusals on the surfaces the models are for.
+		{"text model on chat", `["text"]`, endpointTypeChat, probeChatEndpoint, true},
+		{"embedding model on embeddings", `["embedding"]`, endpointTypeEmbeddings, probeEmbeddingsEndpoint, true},
+		// A model that produces both is not evidence against either surface.
+		{"multimodal on chat", `["text","embedding"]`, endpointTypeChat, probeChatEndpoint, true},
+		// No metadata is not evidence either: rows predating the modality
+		// columns must keep the retirement they have today.
+		{"unknown modality on embeddings", "", endpointTypeEmbeddings, probeEmbeddingsEndpoint, true},
+		{"empty modality on chat", "[]", endpointTypeChat, probeChatEndpoint, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			repo := &mockModelRepo{}
+			h := newGoneHandler(t, repo)
+			m := &model.Model{ID: uuid.New(), ModelID: "gpt-4o", OutputModalities: tc.outputModalities}
+			cand := goneCandidateFor(t, m, "OpenAI")
+
+			h.noteModelGone(cand, tc.endpointType)
+
+			raw, ok := h.goneStrikes.Load(goneStreakKey{model: m.ID, endpoint: tc.endpoint})
+			if ok != tc.wantStrike {
+				t.Fatalf("streak recorded = %v, want %v", ok, tc.wantStrike)
+			}
+			if !tc.wantStrike {
+				return
+			}
+			if streak, isStreak := raw.(*goneStreak); !isStreak || streak.count() != 1 {
+				t.Fatalf("expected exactly one strike, got %+v", raw)
+			}
+		})
+	}
+}
+
+// TestNoteModelGone_SurfacesDoNotPoolTheirStrikes pins that a streak is about
+// one surface.
+//
+// The streak used to be keyed by model UUID alone while the probe endpoint came
+// from whichever refusal crossed the threshold, so two chat refusals plus one
+// embeddings refusal bought an EMBEDDINGS probe — a question nobody had
+// accumulated evidence for. Keyed per surface, each counter means one thing and
+// the probe always asks what the strikes were about.
+func TestNoteModelGone_SurfacesDoNotPoolTheirStrikes(t *testing.T) {
+	t.Parallel()
+
+	repo := &mockModelRepo{}
+	h := newGoneHandler(t, repo)
+	// No declared modality, so neither surface is contradicted and the split is
+	// the only thing keeping the two counters apart.
+	m := &model.Model{ID: uuid.New(), ModelID: "gpt-5.6-sol"}
+	srv, script := newGoneScriptedServer(t, http.StatusNotFound, goneRefusalBody("gpt-5.6-sol"))
+	cand := goneCandidateAt(m, "OpenAI", srv.URL)
+
+	// Two on chat, two on embeddings: four refusals, and neither surface has
+	// reached the threshold.
+	for range goneStrikeThreshold - 1 {
+		h.noteModelGone(cand, endpointTypeChat)
+		h.noteModelGone(cand, endpointTypeEmbeddings)
+	}
+	if calls := waitForDisable(t, repo); len(calls) != 0 {
+		t.Fatalf("no surface reached the threshold, so nothing may be probed or retired, got %+v", calls)
+	}
+	if paths := script.requestedPaths(); len(paths) != 0 {
+		t.Fatalf("pooled strikes bought a probe, got %v", paths)
+	}
+	if n := goneStreakFor(t, h, m.ID, probeChatEndpoint).count(); n != goneStrikeThreshold-1 {
+		t.Errorf("chat streak = %d, want %d", n, goneStrikeThreshold-1)
+	}
+	if n := goneStreakFor(t, h, m.ID, probeEmbeddingsEndpoint).count(); n != goneStrikeThreshold-1 {
+		t.Errorf("embeddings streak = %d, want %d", n, goneStrikeThreshold-1)
+	}
+
+	// The third chat refusal completes the CHAT streak, so the probe goes to
+	// the chat surface.
+	h.noteModelGone(cand, endpointTypeChat)
+	if paths := waitForProbes(t, script, 1); len(paths) != 1 || paths[0] != probeChatEndpoint {
+		t.Fatalf("expected one probe on %s, got %v", probeChatEndpoint, paths)
+	}
+}
+
+// TestNoteModelServed_ClearsEverySurface pins the other side of the split: a
+// success is evidence about the MODEL, and the caller has no family to pass.
+// If a chat 200 only cleared the chat streak, an embeddings streak would keep
+// its strikes across an arbitrary amount of healthy traffic and eventually
+// spend a probe on a model that has been answering all along.
+func TestNoteModelServed_ClearsEverySurface(t *testing.T) {
+	t.Parallel()
+
+	repo := &mockModelRepo{}
+	h := newGoneHandler(t, repo)
+	m := &model.Model{ID: uuid.New(), ModelID: "gpt-5.6-sol"}
+	cand := goneCandidateFor(t, m, "OpenAI")
+
+	h.noteModelGone(cand, endpointTypeChat)
+	h.noteModelGone(cand, endpointTypeEmbeddings)
+
+	h.noteModelServed(m)
+
+	for _, endpoint := range goneProbeSurfaces {
+		if n := goneStreakFor(t, h, m.ID, endpoint).count(); n != 0 {
+			t.Errorf("%s streak = %d, want 0 after the model answered", endpoint, n)
+		}
+	}
+}
+
+// TestProbeEndpointForFamily_SurfacesAreCovered is the guard on goneProbeSurfaces
+// drifting from probeEndpointForFamily. noteModelServed enumerates that list to
+// clear a model's streaks, so a new probeable family whose endpoint is missing
+// from it would accumulate strikes no success could ever clear.
+func TestProbeEndpointForFamily_SurfacesAreCovered(t *testing.T) {
+	t.Parallel()
+
+	for _, family := range []string{endpointTypeChat, endpointTypeMessages, endpointTypeEmbeddings, endpointTypeImage, endpointTypeTTS, endpointTypeSTT, endpointTypeRerank, ""} {
+		endpoint, ok := probeEndpointForFamily(family)
+		if !ok {
+			continue
+		}
+		if !slices.Contains(goneProbeSurfaces[:], endpoint) {
+			t.Errorf("family %q probes %q, which goneProbeSurfaces does not list", family, endpoint)
+		}
 	}
 }
 
@@ -1972,8 +2163,12 @@ func TestNoteModelGone_UnprobeableFamiliesAreNeverRetired(t *testing.T) {
 		for range goneStrikeThreshold + 3 {
 			h.noteModelGone(cand, f.endpointType)
 		}
-		if _, ok := h.goneStrikes.Load(m.ID); ok {
-			t.Errorf("%s: a family that can never be adjudicated must not record a streak", f.name)
+		// Every surface a streak can be keyed on, so this cannot pass by
+		// looking under a key nothing would have written.
+		for _, endpoint := range goneProbeSurfaces {
+			if _, ok := h.goneStrikes.Load(goneStreakKey{model: m.ID, endpoint: endpoint}); ok {
+				t.Errorf("%s: a family that can never be adjudicated must not record a streak (%s)", f.name, endpoint)
+			}
 		}
 	}
 

--- a/internal/proxy/model_gone_test.go
+++ b/internal/proxy/model_gone_test.go
@@ -42,8 +42,8 @@ func waitForDisable(t *testing.T, repo *mockModelRepo) []setEnabledCall {
 }
 
 // goneStreakFor returns the model's live streak, failing the test if there is
-// none. The streak is what the postponement paths now leave behind, so several
-// tests below assert on it directly rather than on the absence of a write.
+// none. The postponement paths leave a streak behind rather than a write, so
+// several tests below assert on it directly.
 func goneStreakFor(t *testing.T, h *Handler, id uuid.UUID, endpoint string) *goneStreak {
 	t.Helper()
 	raw, ok := h.goneStrikes.Load(goneStreakKey{model: id, endpoint: endpoint})
@@ -86,18 +86,36 @@ func probeClaimAt(t *testing.T, h *Handler, id uuid.UUID, endpoint string) time.
 }
 
 // expireProbeCooldown ages the model's probe claim so the next refusal may spend
-// a probe, standing in for goneProbeCooldown having elapsed.
-//
-// Driven through the streak's own field, exactly as the staleness test drives
-// lastStrike. The alternative — a knob, an injected clock, a var instead of a
-// const — would put a seam in production code that exists only for tests, and
-// the wait it replaces is five minutes.
+// a probe, standing in for goneProbeCooldown having elapsed. Driven through the
+// streak's own field, as the staleness test drives lastStrike: a knob or an
+// injected clock would put a seam in production code that exists only for tests.
 func expireProbeCooldown(t *testing.T, h *Handler, id uuid.UUID, endpoint string) {
 	t.Helper()
 	streak := goneStreakFor(t, h, id, endpoint)
 	streak.mu.Lock()
 	streak.nextProbeAt = time.Now().Add(-time.Second)
 	streak.mu.Unlock()
+}
+
+// waitForInconclusiveRun blocks until the model's streak reports want probes in
+// a row that established nothing. The verdict is applied on the detached probe
+// goroutine, so reading the run straight after the refusal that triggered it
+// races the update.
+func waitForInconclusiveRun(t *testing.T, h *Handler, id uuid.UUID, endpoint string, want int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	var got int
+	for time.Now().Before(deadline) {
+		streak := goneStreakFor(t, h, id, endpoint)
+		streak.mu.Lock()
+		got = streak.inconclusive
+		streak.mu.Unlock()
+		if got == want {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("inconclusive run settled at %d, want %d", got, want)
 }
 
 // waitForProbes blocks until the fake provider has been asked n times, so a
@@ -119,15 +137,13 @@ func waitForProbes(t *testing.T, script *goneScriptedServer, n int) []string {
 
 // goneRefusalServer starts a fake provider that refuses modelID as retired on
 // every request: a 404 naming the model beside a phrase from modelGoneVerbs,
-// which is precisely what classifyUpstreamError reads as KindProviderModelGone.
+// which classifyUpstreamError reads as KindProviderModelGone.
 //
-// It exists because the probe now adjudicates every retirement. The tests below
-// are about what the disable machinery does once the evidence is in — the
-// threshold, the two cancellation windows, the rollback, the streak-identity
-// rules — and every one of them was written expecting the disable to be
-// written. Giving the probe nothing to reach would turn each of them into an
-// assertion about an unreachable provider instead, so the fixture reproduces
-// the evidence rather than standing in for it.
+// The tests below are about what the disable machinery does once the evidence is
+// in — the threshold, the two cancellation windows, the rollback, the
+// streak-identity rules — and the probe adjudicates every retirement, so giving
+// it nothing to reach would turn each of them into an assertion about an
+// unreachable provider instead.
 func goneRefusalServer(t *testing.T, modelID string) *httptest.Server {
 	t.Helper()
 	body := goneRefusalBody(modelID)
@@ -161,13 +177,11 @@ const goneRateLimitedAnswer = `{"error":{"message":"Rate limit reached for reque
 // goneScriptedServer is a fake provider whose answer a test can change while the
 // test is running, and which records every path it was asked for.
 //
-// Both halves are needed and neither is served by the fixtures already here.
-// goneRefusalServer only ever refuses, and the postponement test has to switch a
-// live candidate from a 429 to a refusal without moving it to a second base URL
-// — the candidate is built once and carries the URL. probeServer (model_probe_test.go)
-// keeps only the LAST path, whereas the family tests assert over every path:
-// "never asked on /chat/completions" and "never asked at all" are claims about
-// all of them.
+// Neither half is served by the fixtures already here: goneRefusalServer only
+// ever refuses, and the candidate is built once and carries its base URL, so a
+// postponement test cannot switch to a second server. probeServer
+// (model_probe_test.go) keeps only the LAST path, whereas the family tests
+// assert over all of them.
 type goneScriptedServer struct {
 	mu     sync.Mutex
 	status int
@@ -349,13 +363,9 @@ func TestNoteModelGone_ResetsAfterDisable(t *testing.T) {
 // TestNoteModelGone_NilSafe: the failover drain path passes its candidate
 // straight through, so a malformed one must not panic the proxy.
 //
-// The nil provider is the case the widened signature adds. It used to be
-// unreachable — the old parameter was a provider NAME, and a missing one was
-// just an empty string in a log line — so a candidate with no provider counted
-// strikes and disabled the model like any other. It cannot now: the disable is
-// adjudicated by a real request, there is nobody to send it to, and the
-// retirement stops rather than being written on evidence that can never be
-// checked.
+// A candidate with no provider must stop the retirement outright rather than
+// counting strikes: the disable is adjudicated by a real request, and there is
+// nobody to send it to.
 func TestNoteModelGone_NilSafe(t *testing.T) {
 	t.Parallel()
 
@@ -527,9 +537,9 @@ func TestNoteModelGone_FailedStreamsDoNotResetStreak(t *testing.T) {
 
 	for range goneStrikeThreshold {
 		h.noteModelGone(cand, endpointTypeChat)
-		// A transient stream failure lands between strikes. Under the old
-		// "anything not gone is a success" rule this cleared the streak and the
-		// model could never be retired.
+		// A transient stream failure lands between strikes. Under an "anything
+		// not gone is a success" rule this would clear the streak and the model
+		// could never be retired.
 		if v := verdictForStream(KindProviderError, KindProviderError, true); v == verdictServed {
 			h.noteModelServed(m, endpointTypeChat)
 		}
@@ -1341,12 +1351,10 @@ func TestNoteModelGone_AnsweredProbePreventsTheDisable(t *testing.T) {
 // TestNoteModelGone_APanicWhileDisablingDoesNotKillTheGateway pins the
 // recover() on the detached goroutine.
 //
-// That goroutine used to call repository methods and nothing else. It now makes
-// an upstream request and runs bytes a provider chose through json and the
-// dialect translators, and an unrecovered panic on any goroutine takes the whole
-// process down — so one model's retirement would be able to kill a gateway that
-// is serving everything else fine. Every other detached goroutine in this
-// package already recovers.
+// It makes an upstream request and runs bytes a provider chose through json and
+// the dialect translators, and an unrecovered panic on any goroutine takes the
+// whole process down — so one model's retirement could kill a gateway serving
+// everything else fine. Every other detached goroutine in this package recovers.
 //
 // The failure mode is why this test looks the way it does: without the recover,
 // the panic is not a failed assertion, it is the test binary dying, and the
@@ -1608,11 +1616,10 @@ func TestNoteModelGone_ARetirementThatStandsIsStillAnnounced(t *testing.T) {
 // TestNoteModelGone_TheRetirementEventReportsTheRealStrikeCount pins that the
 // number an operator reads is the number the decision was made on.
 //
-// Both the log line and the alert used to report goneStrikeThreshold, which was
-// accurate only while a retirement could be triggered by the caller that saw
-// exactly three. claimProbe replaced that gate, so a write can equally stand on
-// a single refusal that re-claimed a streak parked since the last cooldown, or
-// on a streak already past the threshold.
+// Reporting goneStrikeThreshold would be accurate only if a retirement could
+// only be triggered by the caller that saw exactly three. Under claimProbe a
+// write can equally stand on a single refusal that re-claimed a streak parked
+// since the last cooldown, or on a streak already past the threshold.
 //
 // The sequence below produces three different plausible answers, which is the
 // point of its shape: the constant would say 3, a count read back after the
@@ -2038,11 +2045,10 @@ func TestNoteModelGone_RateLimitedProbePostponesThenRetires(t *testing.T) {
 		t.Fatalf("a rate-limited probe proved nothing, so nothing may be retired on it, got %+v", calls)
 	}
 
-	// The postponement KEEPS the evidence. Dropping the streak was how the
-	// retirement used to stay reachable, and it was also what left the probe
-	// rate unbounded: three fresh refusals bought another probe, forever, at a
-	// provider that was already rate limiting us. The claim is what gates the
-	// retry now, so the strikes stay where they are.
+	// The postponement KEEPS the evidence. Dropping the streak to stay reachable
+	// would leave the probe rate unbounded — three fresh refusals buying another
+	// probe, forever, at a provider already rate limiting us — so the claim gates
+	// the retry instead and the strikes stay where they are.
 	if n := goneStreakFor(t, h, m.ID, probeChatEndpoint).count(); n != goneStrikeThreshold {
 		t.Fatalf("a postponed retirement must keep the strikes it was built on, got a streak of %d", n)
 	}
@@ -2075,6 +2081,46 @@ func TestNoteModelGone_RateLimitedProbePostponesThenRetires(t *testing.T) {
 // limiter and the circuit breaker, so nothing else would slow it down. Deleting
 // this test loses the only thing standing between a provider incident and the
 // gateway hammering the provider that is having it.
+// A model whose probe can never answer keeps its strikes and keeps spending one
+// upstream request per cooldown, indefinitely — a provider rate limiting the
+// gateway, or a model that cannot be reached on the surface the probe asks. The
+// run counter is what escalates that from Info to Warn, so it has to survive
+// repeated postponements and end when the question is finally settled.
+func TestNoteModelGone_UnadjudicableModelIsEscalated(t *testing.T) {
+	t.Parallel()
+
+	repo := &mockModelRepo{}
+	h := newGoneHandler(t, repo)
+	m := &model.Model{ID: uuid.New(), ModelID: "claude-sonnet-4"}
+	srv, script := newGoneScriptedServer(t, http.StatusTooManyRequests, goneRateLimitedAnswer)
+	cand := goneCandidateAt(m, "OpenCode Zen", srv.URL)
+
+	for range goneStrikeThreshold {
+		h.noteModelGone(cand, endpointTypeChat)
+	}
+	waitForProbes(t, script, 1)
+	waitForInconclusiveRun(t, h, m.ID, probeChatEndpoint, 1)
+
+	// Each further refusal past the cooldown buys another probe that answers
+	// nothing, and the run counts them rather than resetting with each verdict.
+	for probes := 2; probes <= goneProbeInconclusiveWarnAfter; probes++ {
+		expireProbeCooldown(t, h, m.ID, probeChatEndpoint)
+		h.noteModelGone(cand, endpointTypeChat)
+		waitForProbes(t, script, probes)
+		waitForInconclusiveRun(t, h, m.ID, probeChatEndpoint, probes)
+	}
+
+	// The model answers, which is the outcome the run was waiting for. Nothing
+	// is disabled and the run ends with the evidence it belonged to.
+	script.answer(http.StatusOK, goneServedAnswer)
+	expireProbeCooldown(t, h, m.ID, probeChatEndpoint)
+	h.noteModelGone(cand, endpointTypeChat)
+	waitForInconclusiveRun(t, h, m.ID, probeChatEndpoint, 0)
+	if calls := repo.disableCalls(); len(calls) != 0 {
+		t.Fatalf("a model that answered its probe must not be retired, got %+v", calls)
+	}
+}
+
 func TestNoteModelGone_ProbeCooldownBoundsTheProbeRate(t *testing.T) {
 	t.Parallel()
 

--- a/internal/proxy/model_gone_test.go
+++ b/internal/proxy/model_gone_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/hugalafutro/model-hotel/internal/events"
+	"github.com/hugalafutro/model-hotel/internal/failover"
 	"github.com/hugalafutro/model-hotel/internal/model"
 	"github.com/hugalafutro/model-hotel/internal/provider"
 )
@@ -2022,6 +2023,63 @@ func TestNoteModelGone_ExhaustedProbeSlotsPostponeWithoutAsking(t *testing.T) {
 	if paths := waitForProbes(t, script, 1); len(paths) != 1 {
 		t.Errorf("expected exactly one probe, got %v", paths)
 	}
+}
+
+// TestNoteModelGone_AnOpenCircuitCostsNoClaim pins that the cooldown is only
+// spent on a probe that can actually leave the process.
+//
+// probeModel asks the breaker too, but it asks from inside the detached
+// goroutine — by which point the five minutes are gone. A model whose third
+// strike landed in the gap between its provider's last answer and its circuit
+// opening would buy nothing with them and wait out the full cooldown before it
+// could be adjudicated, once the provider came back.
+//
+// The strikes must survive either way: an open circuit says something about the
+// provider and nothing about the model.
+func TestNoteModelGone_AnOpenCircuitCostsNoClaim(t *testing.T) {
+	t.Parallel()
+
+	repo := &mockModelRepo{}
+	h := newGoneHandler(t, repo)
+	h.circuitBreaker = failover.NewCircuitBreaker(nil)
+	m := &model.Model{ID: uuid.New(), ModelID: "claude-sonnet-4"}
+	srv, script := newGoneScriptedServer(t, http.StatusNotFound, goneRefusalBody("claude-sonnet-4"))
+	cand := goneCandidateAt(m, "OpenCode Zen", srv.URL)
+
+	// Driven through the breaker's own API rather than by reaching into its
+	// state: this check has to agree with what the routing path sees, and the
+	// threshold is the breaker's to define.
+	for range h.circuitBreaker.Threshold {
+		h.circuitBreaker.RecordFailure(cand.provider.ID, cand.provider.Name)
+	}
+	if state := h.circuitBreaker.GetState(cand.provider.ID); state != failover.StateOpen {
+		t.Fatalf("fixture: the circuit did not open, state = %v", state)
+	}
+
+	// The provider WOULD refuse this model, so a probe that went out would
+	// retire it.
+	for range goneStrikeThreshold {
+		h.noteModelGone(cand, endpointTypeChat)
+	}
+
+	if calls := waitForDisable(t, repo); len(calls) != 0 {
+		t.Fatalf("nothing may be retired on a probe that was never sent, got %+v", calls)
+	}
+	if paths := script.requestedPaths(); len(paths) != 0 {
+		t.Fatalf("a sidelined provider must not be asked, got %v", paths)
+	}
+	if next := probeClaimAt(t, h, m.ID, probeChatEndpoint); !next.IsZero() {
+		t.Fatalf("the claim was spent on a probe that never left the process, cooldown until %s", next)
+	}
+	if n := goneStreakFor(t, h, m.ID, probeChatEndpoint).count(); n != goneStrikeThreshold {
+		t.Fatalf("the strikes must survive: an open circuit is evidence about the provider, got %d", n)
+	}
+	// Between them, those two assertions are the whole property: the evidence is
+	// intact and nothing stands between it and the next refusal, so the
+	// retirement is adjudicated as soon as the provider is routable again rather
+	// than a cooldown later. The recovery itself is not driven here because the
+	// breaker only leaves the open state through its own cooldown, which is the
+	// breaker's business and not this path's.
 }
 
 // TestNoteModelGone_ASurfaceTheModelIsNotForNeverStrikes pins the second gate.

--- a/internal/proxy/model_gone_test.go
+++ b/internal/proxy/model_gone_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -1430,6 +1431,63 @@ func TestNoteModelGone_AnsweredProbeKeepsTheCooldown(t *testing.T) {
 	expireProbeCooldown(t, h, m.ID)
 	h.noteModelGone(cand, endpointTypeChat)
 	waitForProbes(t, script, 2)
+}
+
+// TestGoneStreak_SupersedeIsAtomicToAReader pins the one ordering the revert
+// path depends on and cannot check for itself.
+//
+// The disable goroutine reads the tombstone without the lock and then asks for
+// the count, and it treats "cancelled, but the strikes are still standing" as
+// "the model is refusing again" and skips the revert. If a success sets the flag
+// before it clears the count, that reader can land in the gap and see the very
+// strikes that caused the retirement it is holding — so a model that has just
+// answered stays disabled, the count is parked at zero a moment later, and
+// nothing ever triggers a revert again. An operator has to re-enable it by hand,
+// which is the outcome the whole cancellation exists to prevent.
+//
+// Driven directly against the streak, and by holding its lock rather than by
+// racing it. The real window is one mutex acquire, so a test that merely raced
+// would pass against the broken ordering almost every time — a test that cannot
+// fail pins nothing. Holding mu is what any concurrent strike or claim does
+// anyway, and it makes the question exact: while the count CANNOT be cleared,
+// the tombstone must not be visible either.
+func TestGoneStreak_SupersedeIsAtomicToAReader(t *testing.T) {
+	t.Parallel()
+
+	s := &goneStreak{}
+	now := time.Now()
+	for range goneStrikeThreshold {
+		s.strike(now)
+	}
+
+	s.mu.Lock()
+	started := make(chan struct{})
+	go func() {
+		close(started)
+		s.supersede()
+	}()
+	<-started
+	// Long enough that a supersede setting the tombstone outside the lock would
+	// have done it by now. The fixed one cannot do it at any wait, so the
+	// assertion below has no flaky direction.
+	time.Sleep(50 * time.Millisecond)
+	visible := s.cancelled.Load()
+	s.mu.Unlock()
+	if visible {
+		t.Fatal("the tombstone became visible while the strikes it stands down were still on the streak: a reader landing here skips the revert and leaves a model that just answered disabled")
+	}
+
+	// And once it can run, both halves land together.
+	deadline := time.Now().Add(2 * time.Second)
+	for !s.cancelled.Load() && time.Now().Before(deadline) {
+		runtime.Gosched()
+	}
+	if !s.cancelled.Load() {
+		t.Fatal("the success never stood the disable down")
+	}
+	if n := s.count(); n != 0 {
+		t.Fatalf("streak = %d, want the evidence cleared alongside the tombstone", n)
+	}
 }
 
 // TestNoteModelGone_ASuccessDoesNotResetTheProbeCooldown closes the other door

--- a/internal/proxy/model_gone_test.go
+++ b/internal/proxy/model_gone_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"runtime"
-	"slices"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -277,7 +276,7 @@ func TestNoteModelServed_ResetsStreak(t *testing.T) {
 		for i := 1; i < goneStrikeThreshold; i++ {
 			h.noteModelGone(cand, endpointTypeChat)
 		}
-		h.noteModelServed(m)
+		h.noteModelServed(m, endpointTypeChat)
 	}
 
 	if calls := repo.disableCalls(); len(calls) != 0 {
@@ -298,7 +297,7 @@ func TestNoteModelGone_StrikesArePerModel(t *testing.T) {
 
 	for range goneStrikeThreshold {
 		h.noteModelGone(deadCand, endpointTypeChat)
-		h.noteModelServed(alive)
+		h.noteModelServed(alive, endpointTypeChat)
 	}
 
 	calls := waitForDisable(t, repo)
@@ -363,8 +362,8 @@ func TestNoteModelGone_NilSafe(t *testing.T) {
 		h.noteModelGone(noID, endpointTypeChat)
 		h.noteModelGone(noProvider, endpointTypeChat)
 	}
-	h.noteModelServed(nil)
-	h.noteModelServed(&model.Model{ModelID: "no-uuid"})
+	h.noteModelServed(nil, endpointTypeChat)
+	h.noteModelServed(&model.Model{ModelID: "no-uuid"}, endpointTypeChat)
 
 	if calls := repo.disableCalls(); len(calls) != 0 {
 		t.Errorf("expected no disable calls, got %d", len(calls))
@@ -520,7 +519,7 @@ func TestNoteModelGone_FailedStreamsDoNotResetStreak(t *testing.T) {
 		// "anything not gone is a success" rule this cleared the streak and the
 		// model could never be retired.
 		if v := verdictForStream(KindProviderError, KindProviderError, true); v == verdictServed {
-			h.noteModelServed(m)
+			h.noteModelServed(m, endpointTypeChat)
 		}
 	}
 
@@ -747,7 +746,7 @@ func TestNoteModelGone_SuccessCancelsAQueuedDisable(t *testing.T) {
 	}
 
 	// The model answers before the write is released.
-	h.noteModelServed(m)
+	h.noteModelServed(m, endpointTypeChat)
 	close(repo.setEnabledGate)
 
 	// Give the goroutine room to run to completion either way.
@@ -797,7 +796,7 @@ func TestNoteModelGone_SuccessDuringTheWriteIsAbandoned(t *testing.T) {
 	}
 
 	// The model answers while the disable is staged.
-	h.noteModelServed(m)
+	h.noteModelServed(m, endpointTypeChat)
 	close(repo.setEnabledGate)
 
 	// Let the goroutine run to completion, then assert on what was durable.
@@ -821,7 +820,7 @@ func TestNoteModelGone_SuccessAfterConfirmIsRolledBack(t *testing.T) {
 	h := newGoneHandler(t, repo)
 	m := &model.Model{ID: uuid.New(), ModelID: "gemini-2.0-flash"}
 	cand := goneCandidateFor(t, m, "Google AI Studio (Gemini)")
-	repo.afterConfirm = func() { h.noteModelServed(m) }
+	repo.afterConfirm = func() { h.noteModelServed(m, endpointTypeChat) }
 
 	for range goneStrikeThreshold {
 		h.noteModelGone(cand, endpointTypeChat)
@@ -881,7 +880,7 @@ func TestNoteModelGone_StaleFailedDisableKeepsTheEvidence(t *testing.T) {
 	// While it is held open: the model answers, which cancels that write and
 	// clears the count, and then refuses again — evidence that belongs to the
 	// next decision, not to the one now unwinding.
-	h.noteModelServed(m)
+	h.noteModelServed(m, endpointTypeChat)
 	for range goneStrikeThreshold - 1 {
 		h.noteModelGone(cand, endpointTypeChat)
 	}
@@ -935,7 +934,7 @@ func TestNoteModelGone_FailedRollbackStopsThere(t *testing.T) {
 	h := newGoneHandler(t, repo)
 	m := &model.Model{ID: uuid.New(), ModelID: "gemini-2.0-flash"}
 	cand := goneCandidateFor(t, m, "Google AI Studio (Gemini)")
-	repo.afterConfirm = func() { h.noteModelServed(m) }
+	repo.afterConfirm = func() { h.noteModelServed(m, endpointTypeChat) }
 
 	for range goneStrikeThreshold {
 		h.noteModelGone(cand, endpointTypeChat)
@@ -1090,7 +1089,7 @@ func TestNoteModelGone_FreshEvidenceBeatsAStaleRevert(t *testing.T) {
 	var once sync.Once
 	repo.afterConfirm = func() {
 		once.Do(func() {
-			h.noteModelServed(m)
+			h.noteModelServed(m, endpointTypeChat)
 			for range goneStrikeThreshold {
 				h.noteModelGone(cand, endpointTypeChat)
 			}
@@ -1124,7 +1123,7 @@ func TestNoteModelGone_SupersededRevertStandsDown(t *testing.T) {
 	h := newGoneHandler(t, repo)
 	m := &model.Model{ID: uuid.New(), ModelID: "gemini-2.0-flash"}
 	cand := goneCandidateFor(t, m, "Google AI Studio (Gemini)")
-	repo.afterConfirm = func() { h.noteModelServed(m) }
+	repo.afterConfirm = func() { h.noteModelServed(m, endpointTypeChat) }
 
 	for range goneStrikeThreshold {
 		h.noteModelGone(cand, endpointTypeChat)
@@ -1217,7 +1216,7 @@ func TestNoteModelGone_EachWriteGetsAFreshDeadline(t *testing.T) {
 	cand := goneCandidateFor(t, m, "Google AI Studio (Gemini)")
 	// The success has to land AFTER confirm for a rollback to happen at all;
 	// landing earlier abandons the write and there is no second one to measure.
-	repo.afterConfirm = func() { h.noteModelServed(m) }
+	repo.afterConfirm = func() { h.noteModelServed(m, endpointTypeChat) }
 
 	for range goneStrikeThreshold {
 		h.noteModelGone(cand, endpointTypeChat)
@@ -1719,7 +1718,7 @@ func TestNoteModelGone_ASuccessDoesNotResetTheProbeCooldown(t *testing.T) {
 
 	// An ordinary request to the same model succeeds, exactly as the request
 	// path reports it.
-	h.noteModelServed(m)
+	h.noteModelServed(m, endpointTypeChat)
 
 	// And the traffic that does not succeed carries on refusing. None of it may
 	// buy an upstream request while the cooldown is running.
@@ -2065,12 +2064,19 @@ func TestNoteModelGone_SurfacesDoNotPoolTheirStrikes(t *testing.T) {
 	}
 }
 
-// TestNoteModelServed_ClearsEverySurface pins the other side of the split: a
-// success is evidence about the MODEL, and the caller has no family to pass.
-// If a chat 200 only cleared the chat streak, an embeddings streak would keep
-// its strikes across an arbitrary amount of healthy traffic and eventually
-// spend a probe on a model that has been answering all along.
-func TestNoteModelServed_ClearsEverySurface(t *testing.T) {
+// TestNoteModelServed_ClearsOnlyItsOwnSurface pins the other side of the split.
+//
+// A streak is about one surface because a model can be served on one and refused
+// on another. Clearing every surface on any success answered both questions as
+// one, and the direction it failed in is the one that matters: a provider that
+// has retired a model's chat surface while still serving its embeddings would
+// have every embeddings success wipe the chat streak, so the dead surface could
+// never reach three consecutive strikes and would never be adjudicated at all.
+//
+// Narrowing it cannot retire anything wrongly, which is why it is safe to do:
+// the surviving streak still has to be refused by a real PROBE to that same
+// surface before a disable is written.
+func TestNoteModelServed_ClearsOnlyItsOwnSurface(t *testing.T) {
 	t.Parallel()
 
 	repo := &mockModelRepo{}
@@ -2081,29 +2087,44 @@ func TestNoteModelServed_ClearsEverySurface(t *testing.T) {
 	h.noteModelGone(cand, endpointTypeChat)
 	h.noteModelGone(cand, endpointTypeEmbeddings)
 
-	h.noteModelServed(m)
+	// An embeddings request succeeds. It says nothing about the chat surface.
+	h.noteModelServed(m, endpointTypeEmbeddings)
 
-	for _, endpoint := range goneProbeSurfaces {
-		if n := goneStreakFor(t, h, m.ID, endpoint).count(); n != 0 {
-			t.Errorf("%s streak = %d, want 0 after the model answered", endpoint, n)
-		}
+	if n := goneStreakFor(t, h, m.ID, probeEmbeddingsEndpoint).count(); n != 0 {
+		t.Errorf("embeddings streak = %d, want 0 after an embeddings success", n)
+	}
+	if n := goneStreakFor(t, h, m.ID, probeChatEndpoint).count(); n != 1 {
+		t.Errorf("chat streak = %d, want the strike kept: an embeddings success is not evidence about chat", n)
+	}
+
+	// And the mirror: /v1/messages resolves to the chat surface, so a success
+	// there clears the streak a /v1/chat/completions refusal built.
+	h.noteModelServed(m, endpointTypeMessages)
+	if n := goneStreakFor(t, h, m.ID, probeChatEndpoint).count(); n != 0 {
+		t.Errorf("chat streak = %d, want 0 after a success on the same surface", n)
 	}
 }
 
-// TestProbeEndpointForFamily_SurfacesAreCovered is the guard on goneProbeSurfaces
-// drifting from probeEndpointForFamily. noteModelServed enumerates that list to
-// clear a model's streaks, so a new probeable family whose endpoint is missing
-// from it would accumulate strikes no success could ever clear.
-func TestProbeEndpointForFamily_SurfacesAreCovered(t *testing.T) {
+// TestNoteModelServed_AnUnprobeableFamilyClearsNothing pins the rule the strike
+// side already follows, applied to the success side: a family that cannot be
+// adjudicated does not get to speak about one that can. An image or TTS response
+// says no more about the chat surface than an image refusal does, and crediting
+// it would let traffic on an unprobeable surface hold a genuinely dead chat
+// surface open indefinitely.
+func TestNoteModelServed_AnUnprobeableFamilyClearsNothing(t *testing.T) {
 	t.Parallel()
 
-	for _, family := range []string{endpointTypeChat, endpointTypeMessages, endpointTypeEmbeddings, endpointTypeImage, endpointTypeTTS, endpointTypeSTT, endpointTypeRerank, ""} {
-		endpoint, ok := probeEndpointForFamily(family)
-		if !ok {
-			continue
-		}
-		if !slices.Contains(goneProbeSurfaces[:], endpoint) {
-			t.Errorf("family %q probes %q, which goneProbeSurfaces does not list", family, endpoint)
+	repo := &mockModelRepo{}
+	h := newGoneHandler(t, repo)
+	m := &model.Model{ID: uuid.New(), ModelID: "gemini-2.5-flash-image"}
+	cand := goneCandidateFor(t, m, "Google AI Studio (Gemini)")
+
+	h.noteModelGone(cand, endpointTypeChat)
+
+	for _, family := range []string{endpointTypeImage, endpointTypeTTS, endpointTypeSTT, endpointTypeRerank, ""} {
+		h.noteModelServed(m, family)
+		if n := goneStreakFor(t, h, m.ID, probeChatEndpoint).count(); n != 1 {
+			t.Fatalf("a %q success cleared the chat streak (now %d)", family, n)
 		}
 	}
 }
@@ -2191,7 +2212,7 @@ func TestNoteModelGone_UnprobeableFamiliesAreNeverRetired(t *testing.T) {
 		}
 		// Every surface a streak can be keyed on, so this cannot pass by
 		// looking under a key nothing would have written.
-		for _, endpoint := range goneProbeSurfaces {
+		for _, endpoint := range []string{probeChatEndpoint, probeEmbeddingsEndpoint} {
 			if _, ok := h.goneStrikes.Load(goneStreakKey{model: m.ID, endpoint: endpoint}); ok {
 				t.Errorf("%s: a family that can never be adjudicated must not record a streak (%s)", f.name, endpoint)
 			}

--- a/internal/proxy/model_gone_test.go
+++ b/internal/proxy/model_gone_test.go
@@ -2131,9 +2131,12 @@ func TestNoteModelGone_ASurfaceTheModelIsNotForNeverStrikes(t *testing.T) {
 		{"image-emitting chat model", `["text"]`, `["text","image"]`, endpointTypeChat, probeChatEndpoint, true},
 		{"vision chat model", `["text","image"]`, `["text"]`, endpointTypeChat, probeChatEndpoint, true},
 		{"code model on chat", `["text"]`, `["code"]`, endpointTypeChat, probeChatEndpoint, true},
-		// A model that produces both is not evidence against either surface.
-		{"multimodal on chat", `["text"]`, `["text","embedding"]`, endpointTypeChat, probeChatEndpoint, true},
-		{"multimodal on embeddings", `["text"]`, `["text","embedding"]`, endpointTypeEmbeddings, probeEmbeddingsEndpoint, true},
+		// A model that serves BOTH probeable surfaces strikes on neither, and
+		// that is the third gate rather than this one: the refusal is about one
+		// surface and the disable it could lead to is about the row, which for
+		// this model is two surfaces. See modalityAdmitsBothProbeSurfaces.
+		{"serves both surfaces, refused on chat", `["text"]`, `["text","embedding"]`, endpointTypeChat, probeChatEndpoint, false},
+		{"serves both surfaces, refused on embeddings", `["text"]`, `["text","embedding"]`, endpointTypeEmbeddings, probeEmbeddingsEndpoint, false},
 		// The two surfaces answer to different burdens of proof when the catalog
 		// says nothing, and this is where that shows. liveModelStub writes "[]"
 		// for every model no catalog covers, so failing open on embeddings would
@@ -2175,49 +2178,46 @@ func TestNoteModelGone_ASurfaceTheModelIsNotForNeverStrikes(t *testing.T) {
 	}
 }
 
-// TestNoteModelGone_SurfacesDoNotPoolTheirStrikes pins that a streak is about
-// one surface.
+// TestNoteModelGone_AModelServingBothSurfacesIsNeverRetired pins the gate that
+// is about the ACTION rather than the evidence.
 //
-// The streak used to be keyed by model UUID alone while the probe endpoint came
-// from whichever refusal crossed the threshold, so two chat refusals plus one
-// embeddings refusal bought an EMBEDDINGS probe — a question nobody had
-// accumulated evidence for. Keyed per surface, each counter means one thing and
-// the probe always asks what the strikes were about.
-func TestNoteModelGone_SurfacesDoNotPoolTheirStrikes(t *testing.T) {
+// Strikes, probes and successes are per surface, because a provider can retire
+// one surface of a model and keep serving the other. The disable is not: it
+// turns the model ROW off. For a model the catalog says serves chat AND
+// embeddings those two scopes disagree, and no probe can catch it — the probe is
+// right, the model really is gone on that surface, and the disable is simply
+// broader than the finding. So nothing is written at all, and the model stays
+// enabled until discovery drops it or an operator does.
+//
+// The refusals here would otherwise retire it: the fixture refuses by name, and
+// the same sequence against a chat-only model disables it (see
+// TestNoteModelGone_DisablesAfterThreshold).
+func TestNoteModelGone_AModelServingBothSurfacesIsNeverRetired(t *testing.T) {
 	t.Parallel()
 
 	repo := &mockModelRepo{}
 	h := newGoneHandler(t, repo)
-	// A model the catalog says produces both, so neither surface is ruled out
-	// and the split is the only thing keeping the two counters apart.
-	m := &model.Model{ID: uuid.New(), ModelID: "gpt-5.6-sol", OutputModalities: `["text","embedding"]`}
+	m := &model.Model{ID: uuid.New(), ModelID: "gpt-5.6-sol", InputModalities: `["text"]`, OutputModalities: `["text","embedding"]`}
 	srv, script := newGoneScriptedServer(t, http.StatusNotFound, goneRefusalBody("gpt-5.6-sol"))
 	cand := goneCandidateAt(m, "OpenAI", srv.URL)
 
-	// Two on chat, two on embeddings: four refusals, and neither surface has
-	// reached the threshold.
-	for range goneStrikeThreshold - 1 {
+	// Well past the threshold on both surfaces: the gate is unconditional, not
+	// a delay.
+	for range goneStrikeThreshold + 3 {
 		h.noteModelGone(cand, endpointTypeChat)
 		h.noteModelGone(cand, endpointTypeEmbeddings)
 	}
+
 	if calls := waitForDisable(t, repo); len(calls) != 0 {
-		t.Fatalf("no surface reached the threshold, so nothing may be probed or retired, got %+v", calls)
+		t.Fatalf("a disable cannot separate the surfaces, so it must not be written, got %+v", calls)
 	}
 	if paths := script.requestedPaths(); len(paths) != 0 {
-		t.Fatalf("pooled strikes bought a probe, got %v", paths)
+		t.Fatalf("a refusal that can never be acted on must not spend an upstream request, got %v", paths)
 	}
-	if n := goneStreakFor(t, h, m.ID, probeChatEndpoint).count(); n != goneStrikeThreshold-1 {
-		t.Errorf("chat streak = %d, want %d", n, goneStrikeThreshold-1)
-	}
-	if n := goneStreakFor(t, h, m.ID, probeEmbeddingsEndpoint).count(); n != goneStrikeThreshold-1 {
-		t.Errorf("embeddings streak = %d, want %d", n, goneStrikeThreshold-1)
-	}
-
-	// The third chat refusal completes the CHAT streak, so the probe goes to
-	// the chat surface.
-	h.noteModelGone(cand, endpointTypeChat)
-	if paths := waitForProbes(t, script, 1); len(paths) != 1 || paths[0] != probeChatEndpoint {
-		t.Fatalf("expected one probe on %s, got %v", probeChatEndpoint, paths)
+	for _, endpoint := range []string{probeChatEndpoint, probeEmbeddingsEndpoint} {
+		if _, ok := h.goneStrikes.Load(goneStreakKey{model: m.ID, endpoint: endpoint}); ok {
+			t.Errorf("a streak that can never fire is not evidence, and one was recorded on %s", endpoint)
+		}
 	}
 }
 
@@ -2238,20 +2238,26 @@ func TestNoteModelServed_ClearsOnlyItsOwnSurface(t *testing.T) {
 
 	repo := &mockModelRepo{}
 	h := newGoneHandler(t, repo)
-	m := &model.Model{ID: uuid.New(), ModelID: "gpt-5.6-sol", OutputModalities: `["text","embedding"]`}
+	// A chat model. Nothing filters a request by modality on the way in, so it
+	// can still be sent to /v1/embeddings and can still be served there — the
+	// refusals that arrive on that surface are ignored, but a SUCCESS on it is
+	// what this test is about.
+	m := &model.Model{ID: uuid.New(), ModelID: "gpt-5.6-sol", InputModalities: `["text"]`, OutputModalities: `["text"]`}
 	cand := goneCandidateFor(t, m, "OpenAI")
 
 	h.noteModelGone(cand, endpointTypeChat)
-	h.noteModelGone(cand, endpointTypeEmbeddings)
 
-	// An embeddings request succeeds. It says nothing about the chat surface.
+	// An embeddings request to the same model succeeds. It says nothing about
+	// the chat surface, which is the one accused.
 	h.noteModelServed(m, endpointTypeEmbeddings)
-
-	if n := goneStreakFor(t, h, m.ID, probeEmbeddingsEndpoint).count(); n != 0 {
-		t.Errorf("embeddings streak = %d, want 0 after an embeddings success", n)
-	}
 	if n := goneStreakFor(t, h, m.ID, probeChatEndpoint).count(); n != 1 {
 		t.Errorf("chat streak = %d, want the strike kept: an embeddings success is not evidence about chat", n)
+	}
+
+	// Nor does traffic on a surface that is never auto-retired.
+	h.noteModelServed(m, endpointTypeImage)
+	if n := goneStreakFor(t, h, m.ID, probeChatEndpoint).count(); n != 1 {
+		t.Errorf("chat streak = %d, want the strike kept after an image success", n)
 	}
 
 	// And the mirror: /v1/messages resolves to the chat surface, so a success

--- a/internal/proxy/model_gone_test.go
+++ b/internal/proxy/model_gone_test.go
@@ -54,6 +54,54 @@ func waitForStreakCleared(t *testing.T, h *Handler, id uuid.UUID) {
 	t.Fatal("the streak was never cleared")
 }
 
+// goneStreakFor returns the model's live streak, failing the test if there is
+// none. The streak is what the postponement paths now leave behind, so several
+// tests below assert on it directly rather than on the absence of a write.
+func goneStreakFor(t *testing.T, h *Handler, id uuid.UUID) *goneStreak {
+	t.Helper()
+	raw, ok := h.goneStrikes.Load(id)
+	if !ok {
+		t.Fatal("the model has no streak")
+	}
+	streak, ok := raw.(*goneStreak)
+	if !ok {
+		t.Fatal("unexpected streak type")
+	}
+	return streak
+}
+
+// expireProbeCooldown ages the model's probe claim so the next refusal may spend
+// a probe, standing in for goneProbeCooldown having elapsed.
+//
+// Driven through the streak's own field, exactly as the staleness test drives
+// lastStrike. The alternative — a knob, an injected clock, a var instead of a
+// const — would put a seam in production code that exists only for tests, and
+// the wait it replaces is five minutes.
+func expireProbeCooldown(t *testing.T, h *Handler, id uuid.UUID) {
+	t.Helper()
+	streak := goneStreakFor(t, h, id)
+	streak.mu.Lock()
+	streak.nextProbeAt = time.Now().Add(-time.Second)
+	streak.mu.Unlock()
+}
+
+// waitForProbes blocks until the fake provider has been asked n times, so a
+// test can assert on what a probe did rather than on how long it took. Without
+// it, "no second probe was sent" and "the second probe has not been sent yet"
+// are the same observation.
+func waitForProbes(t *testing.T, script *goneScriptedServer, n int) []string {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if paths := script.requestedPaths(); len(paths) >= n {
+			return paths
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("expected %d probe(s), got %v", n, script.requestedPaths())
+	return nil
+}
+
 // goneRefusalServer starts a fake provider that refuses modelID as retired on
 // every request: a 404 naming the model beside a phrase from modelGoneVerbs,
 // which is precisely what classifyUpstreamError reads as KindProviderModelGone.
@@ -1322,16 +1370,21 @@ func TestNoteModelGone_RateLimitedProbePostponesThenRetires(t *testing.T) {
 	if calls := waitForDisable(t, repo); len(calls) != 0 {
 		t.Fatalf("a rate-limited probe proved nothing, so nothing may be retired on it, got %+v", calls)
 	}
-	// The postponement drops the streak so later refusals can rebuild it. Without
-	// this the count stays parked at the threshold and the second round below is
-	// swallowed entirely.
-	waitForStreakCleared(t, h, m.ID)
 
-	// The incident passes and the model turns out to be genuinely gone.
-	script.answer(http.StatusNotFound, goneRefusalBody(m.ModelID))
-	for range goneStrikeThreshold {
-		h.noteModelGone(cand, endpointTypeChat)
+	// The postponement KEEPS the evidence. Dropping the streak was how the
+	// retirement used to stay reachable, and it was also what left the probe
+	// rate unbounded: three fresh refusals bought another probe, forever, at a
+	// provider that was already rate limiting us. The claim is what gates the
+	// retry now, so the strikes stay where they are.
+	if n := goneStreakFor(t, h, m.ID).count(); n != goneStrikeThreshold {
+		t.Fatalf("a postponed retirement must keep the strikes it was built on, got a streak of %d", n)
 	}
+
+	// The incident passes and the model turns out to be genuinely gone. One
+	// refusal is now enough, precisely because the earlier strikes survived.
+	script.answer(http.StatusNotFound, goneRefusalBody(m.ModelID))
+	expireProbeCooldown(t, h, m.ID)
+	h.noteModelGone(cand, endpointTypeChat)
 
 	calls := waitForDisable(t, repo)
 	if len(calls) != 1 {
@@ -1341,7 +1394,125 @@ func TestNoteModelGone_RateLimitedProbePostponesThenRetires(t *testing.T) {
 		t.Errorf("expected a committed disable, got %+v", calls[0])
 	}
 	if paths := script.requestedPaths(); len(paths) != 2 {
-		t.Errorf("expected one probe per completed streak, got %v", paths)
+		t.Errorf("expected one probe per claim, got %v", paths)
+	}
+}
+
+// TestNoteModelGone_ProbeCooldownBoundsTheProbeRate pins the bound itself.
+//
+// The postponement above must not become an invitation to keep asking. A dead
+// model under a client's retry loop draws gone-classified refusals as fast as
+// the client sends them, and every one of them arrives at a streak already
+// sitting on the threshold. Without the cooldown each one is a fresh chance to
+// spend an upstream request — and the probe deliberately bypasses both the rate
+// limiter and the circuit breaker, so nothing else would slow it down. Deleting
+// this test loses the only thing standing between a provider incident and the
+// gateway hammering the provider that is having it.
+func TestNoteModelGone_ProbeCooldownBoundsTheProbeRate(t *testing.T) {
+	t.Parallel()
+
+	repo := &mockModelRepo{}
+	h := newGoneHandler(t, repo)
+	m := &model.Model{ID: uuid.New(), ModelID: "claude-sonnet-4"}
+	srv, script := newGoneScriptedServer(t, http.StatusTooManyRequests, goneRateLimitedAnswer)
+	cand := goneCandidateAt(m, "OpenCode Zen", srv.URL)
+
+	for range goneStrikeThreshold {
+		h.noteModelGone(cand, endpointTypeChat)
+	}
+	// Wait for the first probe rather than assuming it: "no second probe" and
+	// "no probe yet" would otherwise be indistinguishable, and the test would
+	// pass against code that never probed at all.
+	waitForProbes(t, script, 1)
+
+	// A client retrying the dead model. Every one of these lands on a streak
+	// that is already at the threshold, and not one of them may buy a probe.
+	for range 10 * goneStrikeThreshold {
+		h.noteModelGone(cand, endpointTypeChat)
+	}
+
+	if calls := waitForDisable(t, repo); len(calls) != 0 {
+		t.Fatalf("nothing established anything, so nothing may be retired, got %+v", calls)
+	}
+	if paths := script.requestedPaths(); len(paths) != 1 {
+		t.Fatalf("30 refusals inside the cooldown must cost exactly one upstream request, got %v", paths)
+	}
+
+	// The bound is a delay, not a lockout: once the cooldown lapses the next
+	// refusal probes again.
+	script.answer(http.StatusNotFound, goneRefusalBody(m.ModelID))
+	expireProbeCooldown(t, h, m.ID)
+	h.noteModelGone(cand, endpointTypeChat)
+
+	if calls := waitForDisable(t, repo); len(calls) != 1 {
+		t.Fatalf("the cooldown must expire, got %+v", calls)
+	}
+	if paths := waitForProbes(t, script, 2); len(paths) != 2 {
+		t.Errorf("expected exactly one probe per claim, got %v", paths)
+	}
+}
+
+// TestNoteModelGone_ExhaustedProbeSlotsPostponeWithoutAsking pins the other
+// bound: the one across models rather than across time.
+//
+// A provider event nominates its whole catalog at once, and each nomination that
+// reaches the threshold runs on its own detached goroutine. Without a cap they
+// all open a connection to the same host simultaneously, each holding it for up
+// to goneProbeTimeout, so the gateway's diagnosis of an incident becomes part of
+// the incident. What the cap must NOT do is convert a missing slot into a
+// retirement: no request was sent, so nothing was established, and the honest
+// outcome is the same postponement every other unproven case gets.
+func TestNoteModelGone_ExhaustedProbeSlotsPostponeWithoutAsking(t *testing.T) {
+	t.Parallel()
+
+	repo := &mockModelRepo{}
+	h := newGoneHandler(t, repo)
+	m := &model.Model{ID: uuid.New(), ModelID: "claude-sonnet-4"}
+	srv, script := newGoneScriptedServer(t, http.StatusNotFound, goneRefusalBody("claude-sonnet-4"))
+	cand := goneCandidateAt(m, "OpenCode Zen", srv.URL)
+
+	// Every slot for this provider taken, as a burst of concurrent retirements
+	// against the same host leaves them. Seeding the map is how the test gets
+	// there without spawning goneProbeMaxConcurrent real probes and hoping they
+	// overlap; the slots are per provider, so this constrains nothing outside
+	// this test.
+	full := make(chan struct{}, goneProbeMaxConcurrent)
+	for range goneProbeMaxConcurrent {
+		full <- struct{}{}
+	}
+	h.goneProbeSlots.Store(cand.provider.ID, full)
+
+	// The provider WOULD refuse this model, so a probe that went out would
+	// retire it. Nothing may be retired on a probe that never went out.
+	for range goneStrikeThreshold {
+		h.noteModelGone(cand, endpointTypeChat)
+	}
+
+	if calls := waitForDisable(t, repo); len(calls) != 0 {
+		t.Fatalf("a probe that was never sent established nothing, so nothing may be retired, got %+v", calls)
+	}
+	if paths := script.requestedPaths(); len(paths) != 0 {
+		t.Fatalf("no slot was free, so no upstream request may be spent, got %v", paths)
+	}
+	if n := goneStreakFor(t, h, m.ID).count(); n != goneStrikeThreshold {
+		t.Fatalf("the strikes must survive so the retry is reachable, got a streak of %d", n)
+	}
+
+	// A slot frees up and the cooldown lapses: the retirement lands on the
+	// evidence that was already there.
+	<-full
+	expireProbeCooldown(t, h, m.ID)
+	h.noteModelGone(cand, endpointTypeChat)
+
+	calls := waitForDisable(t, repo)
+	if len(calls) != 1 {
+		t.Fatalf("a retirement postponed for want of a slot must still be reachable, got %+v", calls)
+	}
+	if calls[0].enabled || !calls[0].committed {
+		t.Errorf("expected a committed disable, got %+v", calls[0])
+	}
+	if paths := waitForProbes(t, script, 1); len(paths) != 1 {
+		t.Errorf("expected exactly one probe, got %v", paths)
 	}
 }
 
@@ -1443,10 +1614,15 @@ func TestNoteModelGone_UnprobeableFamiliesAreNeverRetired(t *testing.T) {
 //
 // A model can be reported retired mid-stream, and that report arrives through
 // noteStreamOutcome rather than through the non-streaming error path. If the
-// gone verdict did not forward to the retirement machinery — or forwarded a
-// family other than the one the log entry carries — a model that only ever fails
-// on streaming requests would stay routable forever, which is most of the
-// gateway's traffic.
+// gone verdict did not forward to the retirement machinery, a model that only
+// ever fails on streaming requests would stay routable forever, which is most
+// of the gateway's traffic.
+//
+// It does not claim to catch a forwarded family that differs from the one on
+// the log entry, and deliberately does not try. noteStreamOutcome is reachable
+// only from dispatchStreaming and serveHedgeWinner, both chat/messages
+// surfaces, so a row driving any other family would pin an input the production
+// code cannot produce.
 //
 // The probe assertion is what makes this about the verdict reaching the PROBE:
 // a disable that landed without an upstream request would be the unverified

--- a/internal/proxy/model_gone_test.go
+++ b/internal/proxy/model_gone_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"runtime"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -1735,8 +1736,10 @@ func TestGoneStreak_ASuccessBetweenTheStrikeAndTheClaimWins(t *testing.T) {
 	// The success lands after the last strike and before the claim.
 	s.supersede()
 
-	if s.canClaimProbe(now) {
+	if ok, reason := s.canClaimProbe(now); ok {
 		t.Error("the cheap read admitted a claim on evidence a success had already cleared")
+	} else if !strings.Contains(reason, "cleared") {
+		t.Errorf("reason = %q, want the cleared-strikes reason rather than the cooldown one", reason)
 	}
 	if s.claimProbe(now) {
 		t.Fatal("claimed a probe on evidence a success had already cleared")
@@ -1776,10 +1779,10 @@ func TestGoneStreak_CanClaimProbeDoesNotTakeTheClaim(t *testing.T) {
 		s.strike(now)
 	}
 
-	if !s.canClaimProbe(now) {
+	if ok, _ := s.canClaimProbe(now); !ok {
 		t.Fatal("a streak at the threshold that has never been probed must admit a claim")
 	}
-	if !s.canClaimProbe(now) {
+	if ok, _ := s.canClaimProbe(now); !ok {
 		t.Fatal("asking twice was refused, so the read spent the claim it was asking about")
 	}
 	if !s.claimProbe(now) {
@@ -1787,8 +1790,10 @@ func TestGoneStreak_CanClaimProbeDoesNotTakeTheClaim(t *testing.T) {
 	}
 
 	// And now both must see the cooldown.
-	if s.canClaimProbe(now) {
+	if ok, reason := s.canClaimProbe(now); ok {
 		t.Fatal("the read did not see the claim that was just taken")
+	} else if !strings.Contains(reason, "cooldown") {
+		t.Errorf("reason = %q, want the cooldown reason", reason)
 	}
 	if s.claimProbe(now) {
 		t.Fatal("claimProbe granted a second claim inside the cooldown")
@@ -1796,7 +1801,7 @@ func TestGoneStreak_CanClaimProbeDoesNotTakeTheClaim(t *testing.T) {
 
 	// They agree on the far side of it too.
 	lapsed := now.Add(goneProbeCooldown)
-	if !s.canClaimProbe(lapsed) {
+	if ok, _ := s.canClaimProbe(lapsed); !ok {
 		t.Fatal("the read must admit a claim once the cooldown has lapsed")
 	}
 	if !s.claimProbe(lapsed) {

--- a/internal/proxy/model_gone_test.go
+++ b/internal/proxy/model_gone_test.go
@@ -67,7 +67,7 @@ func waitForStreakCleared(t *testing.T, h *Handler, id uuid.UUID) {
 // the evidence rather than standing in for it.
 func goneRefusalServer(t *testing.T, modelID string) *httptest.Server {
 	t.Helper()
-	body := fmt.Sprintf("{\"error\":{\"message\":\"The model `%s` does not exist\"}}", modelID)
+	body := goneRefusalBody(modelID)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNotFound)
@@ -77,15 +77,90 @@ func goneRefusalServer(t *testing.T, modelID string) *httptest.Server {
 	return srv
 }
 
+// goneRefusalBody is the retirement refusal itself, split out from the server so
+// a test that needs its own server can still produce the one body
+// classifyUpstreamError reads as KindProviderModelGone. The model id has to look
+// like one (looksLikeAModelID wants a digit or a hyphen) or the classifier will
+// not attribute the phrase to it.
+func goneRefusalBody(modelID string) string {
+	return fmt.Sprintf("{\"error\":{\"message\":\"The model `%s` does not exist\"}}", modelID)
+}
+
+// goneServedAnswer is a real completion: a 200 carrying visible content, which
+// is what probeDeliveredContent requires before it will call a probe served.
+// Deliberately not an empty 200 — that is inconclusive, not a success.
+const goneServedAnswer = `{"id":"chatcmpl-probe","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"hi"},"finish_reason":"stop"}],"usage":{"completion_tokens":1}}`
+
+// goneRateLimitedAnswer is the provider incident the postponement exists for: a
+// 429 says nothing whatever about whether the model still exists.
+const goneRateLimitedAnswer = `{"error":{"message":"Rate limit reached for requests","type":"requests"}}`
+
+// goneScriptedServer is a fake provider whose answer a test can change while the
+// test is running, and which records every path it was asked for.
+//
+// Both halves are needed and neither is served by the fixtures already here.
+// goneRefusalServer only ever refuses, and the postponement test has to switch a
+// live candidate from a 429 to a refusal without moving it to a second base URL
+// — the candidate is built once and carries the URL. probeServer (model_probe_test.go)
+// keeps only the LAST path, whereas the family tests assert over every path:
+// "never asked on /chat/completions" and "never asked at all" are claims about
+// all of them.
+type goneScriptedServer struct {
+	mu     sync.Mutex
+	status int
+	body   string
+	paths  []string
+}
+
+// answer replaces what the server returns from the next request onwards.
+func (s *goneScriptedServer) answer(status int, body string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.status, s.body = status, body
+}
+
+// requestedPaths returns a copy of every path the server was asked for, in
+// order. Copied under the lock: the probe runs on a detached goroutine, so the
+// server's handler may be appending while a test reads.
+func (s *goneScriptedServer) requestedPaths() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.paths...)
+}
+
+// newGoneScriptedServer starts the fake provider with its opening answer.
+func newGoneScriptedServer(t *testing.T, status int, body string) (*httptest.Server, *goneScriptedServer) {
+	t.Helper()
+	script := &goneScriptedServer{status: status, body: body}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		script.mu.Lock()
+		status, body := script.status, script.body
+		script.paths = append(script.paths, r.URL.Path)
+		script.mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = io.WriteString(w, body)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, script
+}
+
 // goneCandidateFor builds the candidate the retirement path actually carries,
 // pointed at a provider that refuses this model. It is the whole candidate and
 // not just the model because the probe needs a base URL, a provider name and a
 // decrypted key to ask anything at all.
 func goneCandidateFor(t *testing.T, m *model.Model, providerName string) modelCandidate {
 	t.Helper()
+	return goneCandidateAt(m, providerName, goneRefusalServer(t, m.ModelID).URL)
+}
+
+// goneCandidateAt is the same candidate pointed at a base URL the test chose,
+// for the cases whose whole subject is what the provider answers.
+func goneCandidateAt(m *model.Model, providerName, baseURL string) modelCandidate {
 	return modelCandidate{
 		model:    m,
-		provider: &provider.Provider{ID: uuid.New(), Name: providerName, BaseURL: goneRefusalServer(t, m.ModelID).URL},
+		provider: &provider.Provider{ID: uuid.New(), Name: providerName, BaseURL: baseURL},
 		apiKey:   goneAPIKey,
 	}
 }
@@ -1138,5 +1213,268 @@ func TestNoteModelGone_QueuedDisableStillLandsWithoutASuccess(t *testing.T) {
 	}
 	if calls[0].enabled {
 		t.Error("model must be disabled, not enabled")
+	}
+}
+
+// TestNoteModelGone_AnsweredProbePreventsTheDisable is the whole point of
+// verifying before retiring: three refusals read out of provider prose are a
+// nomination, not a verdict, and a model that answers a request the gateway
+// makes itself is not retired however the classifier read the traffic.
+//
+// Delete this and a drifted gone-pattern — a phrasing some provider starts using
+// for a transient fault — takes a working model out of routing after three
+// requests, which is exactly what the old code did.
+func TestNoteModelGone_AnsweredProbePreventsTheDisable(t *testing.T) {
+	t.Parallel()
+
+	// Guard on the fixture rather than trusting it. A served verdict and an
+	// inconclusive one are indistinguishable from outside — neither writes
+	// anything and both drop the streak — so a body that failed to parse would
+	// let every assertion below pass without the served branch ever running.
+	if !probeDeliveredContent(endpointTypeChat, []byte(goneServedAnswer)) {
+		t.Fatal("the fixture answer does not read as served, so this test would pass on an inconclusive probe")
+	}
+
+	repo := &mockModelRepo{}
+	h := newGoneHandler(t, repo)
+	m := &model.Model{ID: uuid.New(), ModelID: "gpt-5.6-sol"}
+	srv, script := newGoneScriptedServer(t, http.StatusOK, goneServedAnswer)
+	cand := goneCandidateAt(m, "OpenAI", srv.URL)
+
+	for range goneStrikeThreshold {
+		h.noteModelGone(cand, endpointTypeChat)
+	}
+
+	// disableCalls records every attempt, committed or not, and RevertAutoRetire
+	// records into the same list — so an empty list is the full claim: nothing
+	// was written, and nothing had to be undone.
+	if calls := waitForDisable(t, repo); len(calls) != 0 {
+		t.Fatalf("a model that answered a direct probe must not be retired, got %+v", calls)
+	}
+	// The streak is dropped by the served branch (through noteModelServed), so
+	// the model needs three FRESH refusals before it is reconsidered.
+	waitForStreakCleared(t, h, m.ID)
+	// And the outcome came from asking rather than from nothing happening.
+	if paths := script.requestedPaths(); len(paths) != 1 || paths[0] != probeChatEndpoint {
+		t.Fatalf("expected exactly one probe on %s, got %v", probeChatEndpoint, paths)
+	}
+}
+
+// TestNoteModelGone_RefusedProbeStillDisables is the paired control for the test
+// above: identical strikes, identical code path, the provider's answer the only
+// difference, and the opposite outcome.
+//
+// Together they pin that the retirement is written on what the probe found and
+// not on the strike count. This is the half that keeps the verification from
+// quietly disarming the feature — the probe may only ever PREVENT a disable,
+// never weaken one that three refusals and a refused probe have earned.
+func TestNoteModelGone_RefusedProbeStillDisables(t *testing.T) {
+	t.Parallel()
+
+	repo := &mockModelRepo{}
+	h := newGoneHandler(t, repo)
+	m := &model.Model{ID: uuid.New(), ModelID: "gpt-5.6-sol"}
+	srv, script := newGoneScriptedServer(t, http.StatusNotFound, goneRefusalBody("gpt-5.6-sol"))
+	cand := goneCandidateAt(m, "OpenAI", srv.URL)
+
+	for range goneStrikeThreshold {
+		h.noteModelGone(cand, endpointTypeChat)
+	}
+
+	calls := waitForDisable(t, repo)
+	if len(calls) != 1 {
+		t.Fatalf("a probe that refused the model must still retire it, got %+v", calls)
+	}
+	if calls[0].id != m.ID || calls[0].enabled || !calls[0].committed {
+		t.Errorf("expected a committed disable of %s, got %+v", m.ID, calls[0])
+	}
+	if paths := script.requestedPaths(); len(paths) != 1 || paths[0] != probeChatEndpoint {
+		t.Fatalf("expected exactly one probe on %s, got %v", probeChatEndpoint, paths)
+	}
+}
+
+// TestNoteModelGone_RateLimitedProbePostponesThenRetires pins the postponement
+// and its exit in one sequence.
+//
+// A 429 is the provider incident case: it establishes nothing about whether the
+// model exists, so retiring on it would turn one bad afternoon at a provider
+// into a mass retirement of its whole catalog. But postponing must not become
+// permanent either — a model that is genuinely dead has to be retirable once the
+// incident passes. Deleting this test loses one or the other: either the
+// gateway retires models it never verified, or the inconclusive branch parks the
+// streak above the threshold where every later refusal is a no-op and the dead
+// model stays enabled forever.
+func TestNoteModelGone_RateLimitedProbePostponesThenRetires(t *testing.T) {
+	t.Parallel()
+
+	repo := &mockModelRepo{}
+	h := newGoneHandler(t, repo)
+	m := &model.Model{ID: uuid.New(), ModelID: "claude-sonnet-4"}
+	// One server that changes its answer, not two servers: the candidate is built
+	// once and carries the base URL, so the provider has to be the same host
+	// before and after the incident.
+	srv, script := newGoneScriptedServer(t, http.StatusTooManyRequests, goneRateLimitedAnswer)
+	cand := goneCandidateAt(m, "OpenCode Zen", srv.URL)
+
+	for range goneStrikeThreshold {
+		h.noteModelGone(cand, endpointTypeChat)
+	}
+	if calls := waitForDisable(t, repo); len(calls) != 0 {
+		t.Fatalf("a rate-limited probe proved nothing, so nothing may be retired on it, got %+v", calls)
+	}
+	// The postponement drops the streak so later refusals can rebuild it. Without
+	// this the count stays parked at the threshold and the second round below is
+	// swallowed entirely.
+	waitForStreakCleared(t, h, m.ID)
+
+	// The incident passes and the model turns out to be genuinely gone.
+	script.answer(http.StatusNotFound, goneRefusalBody(m.ModelID))
+	for range goneStrikeThreshold {
+		h.noteModelGone(cand, endpointTypeChat)
+	}
+
+	calls := waitForDisable(t, repo)
+	if len(calls) != 1 {
+		t.Fatalf("a postponed retirement must still be reachable once the provider answers again, got %+v", calls)
+	}
+	if calls[0].enabled || !calls[0].committed {
+		t.Errorf("expected a committed disable, got %+v", calls[0])
+	}
+	if paths := script.requestedPaths(); len(paths) != 2 {
+		t.Errorf("expected one probe per completed streak, got %v", paths)
+	}
+}
+
+// TestNoteModelGone_EmbeddingsAreProbedOnTheirOwnEndpoint pins that the probe
+// asks the question on the surface the model actually serves.
+//
+// An embeddings model has no /chat/completions, so a chat probe against one
+// fails for a reason that has nothing to do with retirement — and that failure
+// reads as confirmation of the retirement it was supposed to adjudicate. The
+// verification would then manufacture exactly the wrong answer, and every
+// embeddings model that drew three classifier strikes would be retired
+// unverified.
+func TestNoteModelGone_EmbeddingsAreProbedOnTheirOwnEndpoint(t *testing.T) {
+	t.Parallel()
+
+	repo := &mockModelRepo{}
+	h := newGoneHandler(t, repo)
+	m := &model.Model{ID: uuid.New(), ModelID: "text-embedding-3-small"}
+	srv, script := newGoneScriptedServer(t, http.StatusNotFound, goneRefusalBody("text-embedding-3-small"))
+	cand := goneCandidateAt(m, "OpenAI", srv.URL)
+
+	for range goneStrikeThreshold {
+		h.noteModelGone(cand, endpointTypeEmbeddings)
+	}
+
+	if calls := waitForDisable(t, repo); len(calls) != 1 {
+		t.Fatalf("an embeddings model refused by its own endpoint must still be retired, got %+v", calls)
+	}
+
+	paths := script.requestedPaths()
+	if len(paths) != 1 || paths[0] != probeEmbeddingsEndpoint {
+		t.Fatalf("expected exactly one probe on %s, got %v", probeEmbeddingsEndpoint, paths)
+	}
+	for _, p := range paths {
+		if p == probeChatEndpoint {
+			t.Errorf("an embeddings model was probed on the chat endpoint (%s), which fails for reasons unrelated to retirement", p)
+		}
+	}
+}
+
+// TestNoteModelGone_UnprobeableFamiliesAreNeverRetired pins the family gate, and
+// pins it before the strike rather than after.
+//
+// Image, speech and transcription models cannot be probed cheaply or safely: the
+// call costs real money and real seconds, and a chat probe against one fails for
+// reasons unrelated to retirement. Where the answer cannot be substantiated the
+// correct outcome is to never auto-retire the family at all — falling back to
+// the classifier alone would leave the guessing running unsupervised precisely
+// where it is least observed.
+//
+// The streak assertion is the other half. A counter that can never fire is not
+// evidence, and recording one would both manufacture the appearance of some and
+// let image refusals top up a chat streak that CAN retire the model.
+func TestNoteModelGone_UnprobeableFamiliesAreNeverRetired(t *testing.T) {
+	t.Parallel()
+
+	repo := &mockModelRepo{}
+	h := newGoneHandler(t, repo)
+
+	families := []struct {
+		name         string
+		endpointType string
+		modelID      string
+	}{
+		{"image", endpointTypeImage, "dall-e-3"},
+		{"speech", endpointTypeTTS, "tts-1-hd"},
+		// An entry whose family was never stamped is unprobeable for the same
+		// reason as the two above: nothing can be established about it.
+		{"unstamped", "", "gpt-5.6-sol"},
+	}
+
+	scripts := make([]*goneScriptedServer, len(families))
+	for i, f := range families {
+		m := &model.Model{ID: uuid.New(), ModelID: f.modelID}
+		srv, script := newGoneScriptedServer(t, http.StatusNotFound, goneRefusalBody(f.modelID))
+		scripts[i] = script
+		cand := goneCandidateAt(m, "OpenAI", srv.URL)
+
+		// Well past the threshold: the gate is unconditional, not a delay.
+		for range goneStrikeThreshold + 3 {
+			h.noteModelGone(cand, f.endpointType)
+		}
+		if _, ok := h.goneStrikes.Load(m.ID); ok {
+			t.Errorf("%s: a family that can never be adjudicated must not record a streak", f.name)
+		}
+	}
+
+	if calls := waitForDisable(t, repo); len(calls) != 0 {
+		t.Fatalf("an unprobeable family must never be auto-retired, got %+v", calls)
+	}
+	for i, script := range scripts {
+		if paths := script.requestedPaths(); len(paths) != 0 {
+			t.Errorf("%s: an unprobeable family must not spend an upstream request, got %v", families[i].name, paths)
+		}
+	}
+}
+
+// TestNoteStreamOutcome_GoneVerdictReachesTheProbe covers the third call site.
+//
+// A model can be reported retired mid-stream, and that report arrives through
+// noteStreamOutcome rather than through the non-streaming error path. If the
+// gone verdict did not forward to the retirement machinery — or forwarded a
+// family other than the one the log entry carries — a model that only ever fails
+// on streaming requests would stay routable forever, which is most of the
+// gateway's traffic.
+//
+// The probe assertion is what makes this about the verdict reaching the PROBE:
+// a disable that landed without an upstream request would be the unverified
+// retirement this whole change removes.
+func TestNoteStreamOutcome_GoneVerdictReachesTheProbe(t *testing.T) {
+	t.Parallel()
+
+	repo := &mockModelRepo{}
+	h := newGoneHandler(t, repo)
+	m := &model.Model{ID: uuid.New(), ModelID: "gemini-2.0-flash"}
+	srv, script := newGoneScriptedServer(t, http.StatusNotFound, goneRefusalBody("gemini-2.0-flash"))
+	cand := goneCandidateAt(m, "Google AI Studio (Gemini)", srv.URL)
+
+	for range goneStrikeThreshold {
+		// upstreamKind is what the provider said, which is the only thing that can
+		// establish a retirement; the endpoint family is stamped at ingest exactly
+		// as newPendingRequestLog leaves it.
+		h.noteStreamOutcome(&requestLogData{endpointType: endpointTypeChat, upstreamKind: KindProviderModelGone}, cand)
+	}
+
+	calls := waitForDisable(t, repo)
+	if len(calls) != 1 {
+		t.Fatalf("a model reported retired mid-stream must be retired like any other, got %+v", calls)
+	}
+	if calls[0].id != m.ID || calls[0].enabled || !calls[0].committed {
+		t.Errorf("expected a committed disable of %s, got %+v", m.ID, calls[0])
+	}
+	if paths := script.requestedPaths(); len(paths) != 1 || paths[0] != probeChatEndpoint {
+		t.Fatalf("the stream verdict must be adjudicated by a probe on %s, got %v", probeChatEndpoint, paths)
 	}
 }

--- a/internal/proxy/model_gone_test.go
+++ b/internal/proxy/model_gone_test.go
@@ -2,6 +2,10 @@ package proxy
 
 import (
 	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"sync"
 	"testing"
 	"time"
@@ -11,6 +15,11 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/model"
 	"github.com/hugalafutro/model-hotel/internal/provider"
 )
+
+// goneAPIKey is the decrypted credential the fixture candidates carry. The
+// probe authenticates exactly like real traffic, so a candidate without one is
+// not the candidate production hands to noteModelGone.
+const goneAPIKey = "sk-gone-fixture-key"
 
 // waitForDisable polls the mock for a recorded SetEnabled call, since
 // noteModelGone disables on a detached goroutine so the request path is not
@@ -45,8 +54,50 @@ func waitForStreakCleared(t *testing.T, h *Handler, id uuid.UUID) {
 	t.Fatal("the streak was never cleared")
 }
 
-func newGoneHandler(repo *mockModelRepo) *Handler {
-	return &Handler{modelRepo: repo}
+// goneRefusalServer starts a fake provider that refuses modelID as retired on
+// every request: a 404 naming the model beside a phrase from modelGoneVerbs,
+// which is precisely what classifyUpstreamError reads as KindProviderModelGone.
+//
+// It exists because the probe now adjudicates every retirement. The tests below
+// are about what the disable machinery does once the evidence is in — the
+// threshold, the two cancellation windows, the rollback, the streak-identity
+// rules — and every one of them was written expecting the disable to be
+// written. Giving the probe nothing to reach would turn each of them into an
+// assertion about an unreachable provider instead, so the fixture reproduces
+// the evidence rather than standing in for it.
+func goneRefusalServer(t *testing.T, modelID string) *httptest.Server {
+	t.Helper()
+	body := fmt.Sprintf("{\"error\":{\"message\":\"The model `%s` does not exist\"}}", modelID)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = io.WriteString(w, body)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// goneCandidateFor builds the candidate the retirement path actually carries,
+// pointed at a provider that refuses this model. It is the whole candidate and
+// not just the model because the probe needs a base URL, a provider name and a
+// decrypted key to ask anything at all.
+func goneCandidateFor(t *testing.T, m *model.Model, providerName string) modelCandidate {
+	t.Helper()
+	return modelCandidate{
+		model:    m,
+		provider: &provider.Provider{ID: uuid.New(), Name: providerName, BaseURL: goneRefusalServer(t, m.ModelID).URL},
+		apiKey:   goneAPIKey,
+	}
+}
+
+// newGoneHandler builds a Handler carrying a real shared upstream transport,
+// which is what production has and what the pre-retirement probe now goes out
+// over.
+func newGoneHandler(t *testing.T, repo *mockModelRepo) *Handler {
+	t.Helper()
+	tr := &http.Transport{}
+	t.Cleanup(tr.CloseIdleConnections)
+	return &Handler{modelRepo: repo, upstreamTransport: tr}
 }
 
 // TestNoteModelGone_DisablesAfterThreshold covers the whole point of the
@@ -57,18 +108,19 @@ func TestNoteModelGone_DisablesAfterThreshold(t *testing.T) {
 	t.Parallel()
 
 	repo := &mockModelRepo{}
-	h := newGoneHandler(repo)
+	h := newGoneHandler(t, repo)
 	m := &model.Model{ID: uuid.New(), ModelID: "gemini-2.0-flash"}
+	cand := goneCandidateFor(t, m, "Google AI Studio (Gemini)")
 
 	// Below the threshold nothing is touched.
 	for i := 1; i < goneStrikeThreshold; i++ {
-		h.noteModelGone(m, "Google AI Studio (Gemini)")
+		h.noteModelGone(cand, endpointTypeChat)
 		if calls := repo.disableCalls(); len(calls) != 0 {
 			t.Fatalf("disabled after %d strike(s), threshold is %d", i, goneStrikeThreshold)
 		}
 	}
 
-	h.noteModelGone(m, "Google AI Studio (Gemini)")
+	h.noteModelGone(cand, endpointTypeChat)
 
 	calls := waitForDisable(t, repo)
 	if len(calls) != 1 {
@@ -89,13 +141,14 @@ func TestNoteModelServed_ResetsStreak(t *testing.T) {
 	t.Parallel()
 
 	repo := &mockModelRepo{}
-	h := newGoneHandler(repo)
+	h := newGoneHandler(t, repo)
 	m := &model.Model{ID: uuid.New(), ModelID: "glm-5.2"}
+	cand := goneCandidateFor(t, m, "OpenCode Zen")
 
 	for range goneStrikeThreshold * 3 {
 		// One short of the threshold, then a success, forever.
 		for i := 1; i < goneStrikeThreshold; i++ {
-			h.noteModelGone(m, "OpenCode Zen")
+			h.noteModelGone(cand, endpointTypeChat)
 		}
 		h.noteModelServed(m)
 	}
@@ -111,12 +164,13 @@ func TestNoteModelGone_StrikesArePerModel(t *testing.T) {
 	t.Parallel()
 
 	repo := &mockModelRepo{}
-	h := newGoneHandler(repo)
+	h := newGoneHandler(t, repo)
 	dead := &model.Model{ID: uuid.New(), ModelID: "claude-sonnet-4"}
 	alive := &model.Model{ID: uuid.New(), ModelID: "claude-sonnet-5"}
+	deadCand := goneCandidateFor(t, dead, "OpenCode Zen")
 
 	for range goneStrikeThreshold {
-		h.noteModelGone(dead, "OpenCode Zen")
+		h.noteModelGone(deadCand, endpointTypeChat)
 		h.noteModelServed(alive)
 	}
 
@@ -135,34 +189,53 @@ func TestNoteModelGone_ResetsAfterDisable(t *testing.T) {
 	t.Parallel()
 
 	repo := &mockModelRepo{}
-	h := newGoneHandler(repo)
+	h := newGoneHandler(t, repo)
 	m := &model.Model{ID: uuid.New(), ModelID: "hy3-preview"}
+	cand := goneCandidateFor(t, m, "OpenCode Go")
 
 	for range goneStrikeThreshold {
-		h.noteModelGone(m, "OpenCode Go")
+		h.noteModelGone(cand, endpointTypeChat)
 	}
 	if calls := waitForDisable(t, repo); len(calls) != 1 {
 		t.Fatalf("expected one disable, got %d", len(calls))
 	}
 
 	// Two more refusals must not reach the threshold again on their own.
-	h.noteModelGone(m, "OpenCode Go")
-	h.noteModelGone(m, "OpenCode Go")
+	h.noteModelGone(cand, endpointTypeChat)
+	h.noteModelGone(cand, endpointTypeChat)
 	if calls := repo.disableCalls(); len(calls) != 1 {
 		t.Errorf("expected still one disable, got %d", len(calls))
 	}
 }
 
-// TestNoteModelGone_NilSafe: the failover drain path passes candidate.model
-// straight through, so a malformed candidate must not panic the proxy.
+// TestNoteModelGone_NilSafe: the failover drain path passes its candidate
+// straight through, so a malformed one must not panic the proxy.
+//
+// The nil provider is the case the widened signature adds. It used to be
+// unreachable — the old parameter was a provider NAME, and a missing one was
+// just an empty string in a log line — so a candidate with no provider counted
+// strikes and disabled the model like any other. It cannot now: the disable is
+// adjudicated by a real request, there is nobody to send it to, and the
+// retirement stops rather than being written on evidence that can never be
+// checked.
 func TestNoteModelGone_NilSafe(t *testing.T) {
 	t.Parallel()
 
 	repo := &mockModelRepo{}
-	h := newGoneHandler(repo)
+	h := newGoneHandler(t, repo)
 
-	h.noteModelGone(nil, "Somewhere")
-	h.noteModelGone(&model.Model{ModelID: "no-uuid"}, "Somewhere")
+	somewhere := &provider.Provider{ID: uuid.New(), Name: "Somewhere"}
+	noModel := modelCandidate{}
+	noID := modelCandidate{model: &model.Model{ModelID: "no-uuid"}, provider: somewhere}
+	// A real, stable model id with nothing to send a probe to. Stable on
+	// purpose: a fresh uuid per iteration could never accumulate, so the loop
+	// would prove nothing about the guard it is here to exercise.
+	noProvider := modelCandidate{model: &model.Model{ID: uuid.New(), ModelID: "no-provider"}}
+	for range goneStrikeThreshold {
+		h.noteModelGone(noModel, endpointTypeChat)
+		h.noteModelGone(noID, endpointTypeChat)
+		h.noteModelGone(noProvider, endpointTypeChat)
+	}
 	h.noteModelServed(nil)
 	h.noteModelServed(&model.Model{ModelID: "no-uuid"})
 
@@ -263,14 +336,16 @@ func TestNoteStreamOutcome_EmptyStreamDoesNotClearStreak(t *testing.T) {
 	t.Parallel()
 
 	repo := &mockModelRepo{}
-	h := newGoneHandler(repo)
+	h := newGoneHandler(t, repo)
 	m := &model.Model{ID: uuid.New(), ModelID: "gemini-2.0-flash"}
-	candidate := modelCandidate{model: m, provider: &provider.Provider{Name: "Google AI Studio (Gemini)"}}
+	cand := goneCandidateFor(t, m, "Google AI Studio (Gemini)")
 
 	for range goneStrikeThreshold {
-		h.noteModelGone(m, "Google AI Studio (Gemini)")
-		// An empty, error-free stream lands between strikes.
-		h.noteStreamOutcome(&requestLogData{}, candidate)
+		h.noteModelGone(cand, endpointTypeChat)
+		// An empty, error-free stream lands between strikes. The log entry
+		// carries its endpoint family exactly as ingest stamps it, since that is
+		// what noteStreamOutcome forwards on a gone verdict.
+		h.noteStreamOutcome(&requestLogData{endpointType: endpointTypeChat}, cand)
 	}
 
 	if calls := waitForDisable(t, repo); len(calls) != 1 {
@@ -284,15 +359,15 @@ func TestNoteStreamOutcome_RealSuccessClears(t *testing.T) {
 	t.Parallel()
 
 	repo := &mockModelRepo{}
-	h := newGoneHandler(repo)
+	h := newGoneHandler(t, repo)
 	m := &model.Model{ID: uuid.New(), ModelID: "glm-5.2"}
-	candidate := modelCandidate{model: m, provider: &provider.Provider{Name: "OpenCode Zen"}}
+	cand := goneCandidateFor(t, m, "OpenCode Zen")
 
 	for range goneStrikeThreshold * 3 {
 		for i := 1; i < goneStrikeThreshold; i++ {
-			h.noteModelGone(m, "OpenCode Zen")
+			h.noteModelGone(cand, endpointTypeChat)
 		}
-		h.noteStreamOutcome(&requestLogData{tokensCompletion: 5, ttftMs: 30}, candidate)
+		h.noteStreamOutcome(&requestLogData{endpointType: endpointTypeChat, tokensCompletion: 5, ttftMs: 30}, cand)
 	}
 
 	if calls := repo.disableCalls(); len(calls) != 0 {
@@ -308,11 +383,12 @@ func TestNoteModelGone_FailedStreamsDoNotResetStreak(t *testing.T) {
 	t.Parallel()
 
 	repo := &mockModelRepo{}
-	h := newGoneHandler(repo)
+	h := newGoneHandler(t, repo)
 	m := &model.Model{ID: uuid.New(), ModelID: "gemini-2.0-flash"}
+	cand := goneCandidateFor(t, m, "Google AI Studio (Gemini)")
 
 	for range goneStrikeThreshold {
-		h.noteModelGone(m, "Google AI Studio (Gemini)")
+		h.noteModelGone(cand, endpointTypeChat)
 		// A transient stream failure lands between strikes. Under the old
 		// "anything not gone is a success" rule this cleared the streak and the
 		// model could never be retired.
@@ -344,14 +420,15 @@ func TestNoteModelGone_CapabilityRefusalsNeverDisable(t *testing.T) {
 	}
 
 	repo := &mockModelRepo{}
-	h := newGoneHandler(repo)
+	h := newGoneHandler(t, repo)
 	m := &model.Model{ID: uuid.New(), ModelID: "gpt-5.6-sol"}
+	cand := goneCandidateFor(t, m, "OpenAI")
 
 	// Well past the threshold, cycling through every refusal shape.
 	for i := range goneStrikeThreshold * 3 {
 		body := refusals[i%len(refusals)]
 		if kind, _ := classifyUpstreamError(400, body, "gpt-5.6-sol"); kind == KindProviderModelGone {
-			h.noteModelGone(m, "OpenAI")
+			h.noteModelGone(cand, endpointTypeChat)
 		}
 	}
 
@@ -366,13 +443,14 @@ func TestNoteModelGone_RealRetirementStillDisables(t *testing.T) {
 	t.Parallel()
 
 	repo := &mockModelRepo{}
-	h := newGoneHandler(repo)
+	h := newGoneHandler(t, repo)
 	m := &model.Model{ID: uuid.New(), ModelID: "gemini-2.0-flash"}
+	cand := goneCandidateFor(t, m, "Google AI Studio (Gemini)")
 	body := `{"error":{"code":404,"message":"This model models/gemini-2.0-flash is no longer available. Please update your code to use a newer model."}}`
 
 	for range goneStrikeThreshold {
 		if kind, _ := classifyUpstreamError(404, body, "gemini-2.0-flash"); kind == KindProviderModelGone {
-			h.noteModelGone(m, "Google AI Studio (Gemini)")
+			h.noteModelGone(cand, endpointTypeChat)
 		}
 	}
 
@@ -395,8 +473,9 @@ func TestNoteModelGone_ConcurrentStrikesAreNotLost(t *testing.T) {
 	t.Parallel()
 
 	repo := &mockModelRepo{}
-	h := newGoneHandler(repo)
+	h := newGoneHandler(t, repo)
 	m := &model.Model{ID: uuid.New(), ModelID: "gemini-2.0-flash"}
+	cand := goneCandidateFor(t, m, "Google AI Studio (Gemini)")
 
 	var wg sync.WaitGroup
 	start := make(chan struct{})
@@ -405,7 +484,7 @@ func TestNoteModelGone_ConcurrentStrikesAreNotLost(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			<-start // maximise overlap
-			h.noteModelGone(m, "Google AI Studio (Gemini)")
+			h.noteModelGone(cand, endpointTypeChat)
 		}()
 	}
 	close(start)
@@ -427,8 +506,9 @@ func TestNoteModelGone_ConcurrentBurstDisablesOnce(t *testing.T) {
 	t.Parallel()
 
 	repo := &mockModelRepo{}
-	h := newGoneHandler(repo)
+	h := newGoneHandler(t, repo)
 	m := &model.Model{ID: uuid.New(), ModelID: "claude-sonnet-4"}
+	cand := goneCandidateFor(t, m, "OpenCode Zen")
 
 	var wg sync.WaitGroup
 	start := make(chan struct{})
@@ -437,7 +517,7 @@ func TestNoteModelGone_ConcurrentBurstDisablesOnce(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			<-start
-			h.noteModelGone(m, "OpenCode Zen")
+			h.noteModelGone(cand, endpointTypeChat)
 		}()
 	}
 	close(start)
@@ -458,11 +538,12 @@ func TestNoteModelGone_FailedDisableIsRetried(t *testing.T) {
 	t.Parallel()
 
 	repo := &mockModelRepo{setEnabledErr: errors.New("database unavailable")}
-	h := newGoneHandler(repo)
+	h := newGoneHandler(t, repo)
 	m := &model.Model{ID: uuid.New(), ModelID: "gemini-2.0-flash"}
+	cand := goneCandidateFor(t, m, "Google AI Studio (Gemini)")
 
 	for range goneStrikeThreshold {
-		h.noteModelGone(m, "Google AI Studio (Gemini)")
+		h.noteModelGone(cand, endpointTypeChat)
 	}
 	if calls := waitForDisable(t, repo); len(calls) != 1 {
 		t.Fatalf("expected the first (failing) attempt, got %d", len(calls))
@@ -472,7 +553,7 @@ func TestNoteModelGone_FailedDisableIsRetried(t *testing.T) {
 	// The streak was cleared by the failure, so a fresh run of refusals must
 	// reach the threshold and try again rather than being swallowed.
 	for range goneStrikeThreshold {
-		h.noteModelGone(m, "Google AI Studio (Gemini)")
+		h.noteModelGone(cand, endpointTypeChat)
 	}
 
 	deadline := time.Now().Add(2 * time.Second)
@@ -508,12 +589,13 @@ func TestNoteModelGone_SuccessCancelsAQueuedDisable(t *testing.T) {
 		setEnabledGate:    make(chan struct{}),
 		setEnabledEntered: make(chan struct{}),
 	}
-	h := newGoneHandler(repo)
+	h := newGoneHandler(t, repo)
 	m := &model.Model{ID: uuid.New(), ModelID: "gemini-2.0-flash"}
+	cand := goneCandidateFor(t, m, "Google AI Studio (Gemini)")
 
 	// Reach the threshold: the disable goroutine is now queued.
 	for range goneStrikeThreshold {
-		h.noteModelGone(m, "Google AI Studio (Gemini)")
+		h.noteModelGone(cand, endpointTypeChat)
 	}
 
 	// The model answers before the write is released.
@@ -549,11 +631,12 @@ func TestNoteModelGone_SuccessDuringTheWriteIsAbandoned(t *testing.T) {
 		setEnabledGate:    make(chan struct{}),
 		setEnabledEntered: make(chan struct{}),
 	}
-	h := newGoneHandler(repo)
+	h := newGoneHandler(t, repo)
 	m := &model.Model{ID: uuid.New(), ModelID: "gemini-2.0-flash"}
+	cand := goneCandidateFor(t, m, "Google AI Studio (Gemini)")
 
 	for range goneStrikeThreshold {
-		h.noteModelGone(m, "Google AI Studio (Gemini)")
+		h.noteModelGone(cand, endpointTypeChat)
 	}
 
 	// Wait for the write to be genuinely in flight — past the pre-check and
@@ -587,12 +670,13 @@ func TestNoteModelGone_SuccessAfterConfirmIsRolledBack(t *testing.T) {
 	t.Parallel()
 
 	repo := &mockModelRepo{}
-	h := newGoneHandler(repo)
+	h := newGoneHandler(t, repo)
 	m := &model.Model{ID: uuid.New(), ModelID: "gemini-2.0-flash"}
+	cand := goneCandidateFor(t, m, "Google AI Studio (Gemini)")
 	repo.afterConfirm = func() { h.noteModelServed(m) }
 
 	for range goneStrikeThreshold {
-		h.noteModelGone(m, "Google AI Studio (Gemini)")
+		h.noteModelGone(cand, endpointTypeChat)
 	}
 
 	deadline := time.Now().Add(2 * time.Second)
@@ -628,12 +712,13 @@ func TestNoteModelGone_StaleFailedDisableKeepsANewerStreak(t *testing.T) {
 		setEnabledGate:    make(chan struct{}),
 		setEnabledEntered: make(chan struct{}),
 	}
-	h := newGoneHandler(repo)
+	h := newGoneHandler(t, repo)
 	m := &model.Model{ID: uuid.New(), ModelID: "gemini-2.0-flash"}
+	cand := goneCandidateFor(t, m, "Google AI Studio (Gemini)")
 
 	// Reach the threshold and let the (failing) write start.
 	for range goneStrikeThreshold {
-		h.noteModelGone(m, "Google AI Studio (Gemini)")
+		h.noteModelGone(cand, endpointTypeChat)
 	}
 	select {
 	case <-repo.setEnabledEntered:
@@ -645,7 +730,7 @@ func TestNoteModelGone_StaleFailedDisableKeepsANewerStreak(t *testing.T) {
 	// refuses again, building a new one one strike short of the threshold.
 	h.noteModelServed(m)
 	for range goneStrikeThreshold - 1 {
-		h.noteModelGone(m, "Google AI Studio (Gemini)")
+		h.noteModelGone(cand, endpointTypeChat)
 	}
 	newer, ok := h.goneStrikes.Load(m.ID)
 	if !ok {
@@ -676,7 +761,7 @@ func TestNoteModelGone_StaleFailedDisableKeepsANewerStreak(t *testing.T) {
 	// One more refusal now completes the newer streak, so a second disable must
 	// be attempted. If the stale cleanup had erased it, this would be strike one
 	// of three and nothing would happen.
-	h.noteModelGone(m, "Google AI Studio (Gemini)")
+	h.noteModelGone(cand, endpointTypeChat)
 
 	deadline = time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
@@ -701,12 +786,13 @@ func TestNoteModelGone_FailedRollbackStopsThere(t *testing.T) {
 	t.Parallel()
 
 	repo := &mockModelRepo{reEnableErr: errors.New("database unavailable")}
-	h := newGoneHandler(repo)
+	h := newGoneHandler(t, repo)
 	m := &model.Model{ID: uuid.New(), ModelID: "gemini-2.0-flash"}
+	cand := goneCandidateFor(t, m, "Google AI Studio (Gemini)")
 	repo.afterConfirm = func() { h.noteModelServed(m) }
 
 	for range goneStrikeThreshold {
-		h.noteModelGone(m, "Google AI Studio (Gemini)")
+		h.noteModelGone(cand, endpointTypeChat)
 	}
 
 	deadline := time.Now().Add(2 * time.Second)
@@ -745,12 +831,13 @@ func TestNoteModelGone_StaleStrikesDoNotAccumulate(t *testing.T) {
 	t.Parallel()
 
 	repo := &mockModelRepo{}
-	h := newGoneHandler(repo)
+	h := newGoneHandler(t, repo)
 	m := &model.Model{ID: uuid.New(), ModelID: "gemini-2.0-flash"}
+	cand := goneCandidateFor(t, m, "Google AI Studio (Gemini)")
 
 	// Two refusals, one short of the threshold.
 	for range goneStrikeThreshold - 1 {
-		h.noteModelGone(m, "Google AI Studio (Gemini)")
+		h.noteModelGone(cand, endpointTypeChat)
 	}
 
 	// Age them past the window, as if the incident were hours ago.
@@ -767,7 +854,7 @@ func TestNoteModelGone_StaleStrikesDoNotAccumulate(t *testing.T) {
 	streak.mu.Unlock()
 
 	// The next refusal begins a new streak instead of completing the old one.
-	h.noteModelGone(m, "Google AI Studio (Gemini)")
+	h.noteModelGone(cand, endpointTypeChat)
 	if n := streak.count(); n != 1 {
 		t.Errorf("a strike after the window must start over, got a streak of %d", n)
 	}
@@ -780,7 +867,7 @@ func TestNoteModelGone_StaleStrikesDoNotAccumulate(t *testing.T) {
 	// Fresh traffic still retires it: the window bounds the evidence, it does
 	// not disarm the feature.
 	for range goneStrikeThreshold - 1 {
-		h.noteModelGone(m, "Google AI Studio (Gemini)")
+		h.noteModelGone(cand, endpointTypeChat)
 	}
 	if calls := waitForDisable(t, repo); len(calls) != 1 {
 		t.Fatalf("three recent refusals must still retire, got %+v", calls)
@@ -845,8 +932,9 @@ func TestNoteModelGone_FreshEvidenceBeatsAStaleRevert(t *testing.T) {
 	t.Parallel()
 
 	repo := &mockModelRepo{}
-	h := newGoneHandler(repo)
+	h := newGoneHandler(t, repo)
 	m := &model.Model{ID: uuid.New(), ModelID: "gemini-2.0-flash"}
+	cand := goneCandidateFor(t, m, "Google AI Studio (Gemini)")
 
 	// The success lands after confirm, so the retirement commits and an undo is
 	// scheduled. Before it runs, the model refuses again and reaches a fresh
@@ -858,13 +946,13 @@ func TestNoteModelGone_FreshEvidenceBeatsAStaleRevert(t *testing.T) {
 		once.Do(func() {
 			h.noteModelServed(m)
 			for range goneStrikeThreshold {
-				h.noteModelGone(m, "Google AI Studio (Gemini)")
+				h.noteModelGone(cand, endpointTypeChat)
 			}
 		})
 	}
 
 	for range goneStrikeThreshold {
-		h.noteModelGone(m, "Google AI Studio (Gemini)")
+		h.noteModelGone(cand, endpointTypeChat)
 	}
 
 	time.Sleep(200 * time.Millisecond)
@@ -887,12 +975,13 @@ func TestNoteModelGone_SupersededRevertStandsDown(t *testing.T) {
 	t.Parallel()
 
 	repo := &mockModelRepo{revertSuperseded: true}
-	h := newGoneHandler(repo)
+	h := newGoneHandler(t, repo)
 	m := &model.Model{ID: uuid.New(), ModelID: "gemini-2.0-flash"}
+	cand := goneCandidateFor(t, m, "Google AI Studio (Gemini)")
 	repo.afterConfirm = func() { h.noteModelServed(m) }
 
 	for range goneStrikeThreshold {
-		h.noteModelGone(m, "Google AI Studio (Gemini)")
+		h.noteModelGone(cand, endpointTypeChat)
 	}
 
 	deadline := time.Now().Add(2 * time.Second)
@@ -925,20 +1014,20 @@ func TestNoteStreamOutcome_InconclusiveTouchesNeitherCounter(t *testing.T) {
 	t.Parallel()
 
 	repo := &mockModelRepo{}
-	h := newGoneHandler(repo)
+	h := newGoneHandler(t, repo)
 	m := &model.Model{ID: uuid.New(), ModelID: "gemini-2.0-flash"}
-	candidate := modelCandidate{model: m, provider: &provider.Provider{Name: "Google AI Studio (Gemini)"}}
+	cand := goneCandidateFor(t, m, "Google AI Studio (Gemini)")
 
 	// One short of the threshold, so a stray strike would disable and a stray
 	// clear would be visible as a restart.
 	for range goneStrikeThreshold - 1 {
-		h.noteModelGone(m, "Google AI Studio (Gemini)")
+		h.noteModelGone(cand, endpointTypeChat)
 	}
 
 	// A timeout, a client disconnect and a transient provider failure: none of
 	// them is evidence about whether the model still exists.
 	for _, kind := range []ErrorKind{KindProviderTimeout, KindClientDisconnect, KindProviderError} {
-		h.noteStreamOutcome(&requestLogData{errorKind: kind}, candidate)
+		h.noteStreamOutcome(&requestLogData{endpointType: endpointTypeChat, errorKind: kind}, cand)
 	}
 
 	if calls := repo.disableCalls(); len(calls) != 0 {
@@ -946,7 +1035,7 @@ func TestNoteStreamOutcome_InconclusiveTouchesNeitherCounter(t *testing.T) {
 	}
 
 	// The streak survived intact, so the next real refusal completes it.
-	h.noteModelGone(m, "Google AI Studio (Gemini)")
+	h.noteModelGone(cand, endpointTypeChat)
 	if calls := waitForDisable(t, repo); len(calls) != 1 {
 		t.Fatalf("an inconclusive stream cleared the streak: expected the disable, got %+v", calls)
 	}
@@ -977,14 +1066,15 @@ func TestNoteModelGone_EachWriteGetsAFreshDeadline(t *testing.T) {
 		setEnabledGate:    make(chan struct{}),
 		setEnabledEntered: make(chan struct{}),
 	}
-	h := newGoneHandler(repo)
+	h := newGoneHandler(t, repo)
 	m := &model.Model{ID: uuid.New(), ModelID: "gemini-2.0-flash"}
+	cand := goneCandidateFor(t, m, "Google AI Studio (Gemini)")
 	// The success has to land AFTER confirm for a rollback to happen at all;
 	// landing earlier abandons the write and there is no second one to measure.
 	repo.afterConfirm = func() { h.noteModelServed(m) }
 
 	for range goneStrikeThreshold {
-		h.noteModelGone(m, "Google AI Studio (Gemini)")
+		h.noteModelGone(cand, endpointTypeChat)
 	}
 
 	select {
@@ -1026,11 +1116,12 @@ func TestNoteModelGone_QueuedDisableStillLandsWithoutASuccess(t *testing.T) {
 		setEnabledGate:    make(chan struct{}),
 		setEnabledEntered: make(chan struct{}),
 	}
-	h := newGoneHandler(repo)
+	h := newGoneHandler(t, repo)
 	m := &model.Model{ID: uuid.New(), ModelID: "gemini-2.0-flash"}
+	cand := goneCandidateFor(t, m, "Google AI Studio (Gemini)")
 
 	for range goneStrikeThreshold {
-		h.noteModelGone(m, "Google AI Studio (Gemini)")
+		h.noteModelGone(cand, endpointTypeChat)
 	}
 
 	// No success this time; release the slow write.

--- a/internal/proxy/model_gone_test.go
+++ b/internal/proxy/model_gone_test.go
@@ -1433,6 +1433,38 @@ func TestNoteModelGone_AnsweredProbeKeepsTheCooldown(t *testing.T) {
 	waitForProbes(t, script, 2)
 }
 
+// TestProbeForRetirement_NilCandidatePostponesInsteadOfPanicking pins that the
+// guard is where the dereferences are.
+//
+// probeModel checks the same two fields, but every field probeForRetirement
+// touches on the way there — the provider's id for the semaphore, the model's id
+// for the postpone log — would already have panicked, so the downstream guard
+// was promising an outcome it could never deliver. The panic is caught by the
+// disable goroutine's recover and reported as a panic, which is the wrong answer
+// to "is this model still served": nothing was established, and that is what
+// probeInconclusive means.
+func TestProbeForRetirement_NilCandidatePostponesInsteadOfPanicking(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{}
+	cases := []struct {
+		name      string
+		candidate modelCandidate
+	}{
+		{"no provider", modelCandidate{model: &model.Model{ID: uuid.New(), ModelID: "gemini-2.0-flash"}}},
+		{"no model", modelCandidate{provider: &provider.Provider{ID: uuid.New(), Name: "Google AI Studio (Gemini)"}}},
+		{"neither", modelCandidate{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := h.probeForRetirement(tc.candidate, endpointTypeChat); got != probeInconclusive {
+				t.Fatalf("verdict = %s, want inconclusive", got)
+			}
+		})
+	}
+}
+
 // TestGoneStreak_SupersedeIsAtomicToAReader pins the one ordering the revert
 // path depends on and cannot check for itself.
 //

--- a/internal/proxy/model_gone_test.go
+++ b/internal/proxy/model_gone_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/hugalafutro/model-hotel/internal/events"
 	"github.com/hugalafutro/model-hotel/internal/model"
 	"github.com/hugalafutro/model-hotel/internal/provider"
 )
@@ -1431,6 +1432,120 @@ func TestNoteModelGone_AnsweredProbeKeepsTheCooldown(t *testing.T) {
 	expireProbeCooldown(t, h, m.ID)
 	h.noteModelGone(cand, endpointTypeChat)
 	waitForProbes(t, script, 2)
+}
+
+// TestAttemptCandidate_ATranslationFailureKeepsTheStreak pins where the chat
+// path is allowed to call a 200 a success.
+//
+// A vertex-express candidate answers in Gemini's wire format, and a 200 whose
+// body is not a Gemini answer is a provider fault: the attempt FAILS OVER to the
+// next candidate. Crediting the model on the 200 headers cleared the streak of a
+// model the gateway was in the act of giving up on, so a dead model behind a
+// provider that 200s garbage could never accumulate three consecutive strikes.
+func TestAttemptCandidate_ATranslationFailureKeepsTheStreak(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandler(h)
+
+	// A 200 that is not a Gemini answer, so translateGeminiResponseBody fails.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `<html>502 Bad Gateway</html>`)
+	}))
+	defer srv.Close()
+	h.upstreamTransport = dialToTestServer(t, srv)
+
+	m := &model.Model{ID: uuid.New(), ModelID: "gemini-2.0-flash"}
+	// The hostname decides the dialect, which is why the transport above dials
+	// the test server regardless of it.
+	cand := goneCandidateAt(m, "Vertex Express", "http://us-central1-aiplatform.googleapis.com/v1")
+
+	// One real refusal, so there is a streak for the 200 to wrongly clear.
+	h.noteModelGone(cand, endpointTypeChat)
+	streak := goneStreakFor(t, h, m.ID)
+	if n := streak.count(); n != 1 {
+		t.Fatalf("streak = %d, want 1 before the attempt", n)
+	}
+
+	st := &requestState{
+		startTime:       time.Now(),
+		reqModel:        "gemini-2.0-flash",
+		bodyBytes:       []byte(`{"model":"gemini-2.0-flash","messages":[{"role":"user","content":"hi"}]}`),
+		failoverTimeout: 30 * time.Second,
+		logData:         &requestLogData{modelID: "gemini-2.0-flash", endpointType: endpointTypeChat},
+	}
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)
+
+	// Two candidates, so a failover is available and the attempt is free to
+	// reject this one.
+	if got := h.attemptCandidate(w, r, st, cand, 0, 2); got != outcomeFailover {
+		t.Fatalf("outcome = %v, want a failover on an untranslatable 200", got)
+	}
+	if n := streak.count(); n != 1 {
+		t.Fatalf("streak = %d, want the strike kept: an attempt that failed over did not serve the model", n)
+	}
+}
+
+// TestNoteModelGone_TheRetirementEventReportsTheRealStrikeCount pins that the
+// number an operator reads is the number that happened.
+//
+// Both the log line and the alert reported goneStrikeThreshold, which was
+// accurate while a retirement could only be triggered by the caller that saw
+// exactly three. claimProbe replaced that gate: the write can equally stand on a
+// streak sitting at thirteen under a client's retry loop, or on a single refusal
+// that re-claimed a streak parked since the last cooldown. A constant would tell
+// every operator the same story about decisions that were reached differently.
+func TestNoteModelGone_TheRetirementEventReportsTheRealStrikeCount(t *testing.T) {
+	// Not parallel: it subscribes to the process-wide event bus.
+	const extraRefusals = 10
+
+	repo := &mockModelRepo{
+		setEnabledGate:    make(chan struct{}),
+		setEnabledEntered: make(chan struct{}),
+	}
+	h := newGoneHandler(t, repo)
+	m := &model.Model{ID: uuid.New(), ModelID: "gemini-2.0-flash"}
+	cand := goneCandidateFor(t, m, "Google AI Studio (Gemini)")
+
+	ch := events.Subscribe()
+	defer events.Unsubscribe(ch)
+
+	for range goneStrikeThreshold {
+		h.noteModelGone(cand, endpointTypeChat)
+	}
+	select {
+	case <-repo.setEnabledEntered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the disable write never started")
+	}
+
+	// The client keeps retrying the dead model while the write is held open.
+	// None of these buys a probe (the cooldown is running), but every one of
+	// them is a strike, so the streak is well past the threshold by the time the
+	// retirement is announced.
+	for range extraRefusals {
+		h.noteModelGone(cand, endpointTypeChat)
+	}
+	close(repo.setEnabledGate)
+
+	want := int64(goneStrikeThreshold + extraRefusals)
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case ev := <-ch:
+			// The bus fans out to every subscriber, so other tests' events
+			// interleave; filter to this model's retirement.
+			if ev.Type != "model.auto_disabled_gone" || ev.Metadata["model_uuid"] != m.ID.String() {
+				continue
+			}
+			if got := ev.Metadata["strikes"]; got != want {
+				t.Fatalf("event reported strikes = %v (%T), want %d", got, got, want)
+			}
+			return
+		case <-deadline:
+			t.Fatal("the retirement was never announced")
+		}
+	}
 }
 
 // TestProbeForRetirement_NilCandidatePostponesInsteadOfPanicking pins that the

--- a/internal/proxy/model_gone_test.go
+++ b/internal/proxy/model_gone_test.go
@@ -37,24 +37,6 @@ func waitForDisable(t *testing.T, repo *mockModelRepo) []setEnabledCall {
 	return repo.disableCalls()
 }
 
-// waitForStreakCleared blocks until the disable goroutine has finished dropping
-// the model's streak. Observing the SetEnabled call is not enough: the call is
-// recorded inside the mock, while the streak is cleared only after it returns,
-// so a test that starts a second round on the call alone can strike the OLD
-// streak — pushing it past the threshold, where every strike is a no-op — and
-// then watch the first goroutine delete the evidence.
-func waitForStreakCleared(t *testing.T, h *Handler, id uuid.UUID) {
-	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if _, ok := h.goneStrikes.Load(id); !ok {
-			return
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
-	t.Fatal("the streak was never cleared")
-}
-
 // goneStreakFor returns the model's live streak, failing the test if there is
 // none. The streak is what the postponement paths now leave behind, so several
 // tests below assert on it directly rather than on the absence of a write.
@@ -676,18 +658,24 @@ func TestNoteModelGone_ConcurrentBurstDisablesOnce(t *testing.T) {
 	}
 }
 
-// TestNoteModelGone_FailedDisableIsRetried pins the failure path of the
-// no-clear-on-success rule. Leaving the count above the threshold is what stops
-// a burst re-disabling and re-alerting, but a disable that never landed must not
-// be parked there forever, or a transient database error would leave a dead
-// model enabled permanently.
+// TestNoteModelGone_FailedDisableIsRetried pins both halves of what a write
+// that never landed must do.
+//
+// It must be retried: a transient database error may not leave a dead model
+// enabled forever. And the retry must respect the same bound as everything else
+// on this path — the failure says nothing about the provider, so it is no reason
+// to spend another upstream request now. The old shape deleted the streak to
+// make the retry reachable, which cost the cooldown with it and turned a
+// database outage into three fresh refusals buying another probe, on repeat, for
+// every model refusing traffic at the time.
 func TestNoteModelGone_FailedDisableIsRetried(t *testing.T) {
 	t.Parallel()
 
 	repo := &mockModelRepo{setEnabledErr: errors.New("database unavailable")}
 	h := newGoneHandler(t, repo)
 	m := &model.Model{ID: uuid.New(), ModelID: "gemini-2.0-flash"}
-	cand := goneCandidateFor(t, m, "Google AI Studio (Gemini)")
+	srv, script := newGoneScriptedServer(t, http.StatusNotFound, goneRefusalBody("gemini-2.0-flash"))
+	cand := goneCandidateAt(m, "Google AI Studio (Gemini)", srv.URL)
 
 	for range goneStrikeThreshold {
 		h.noteModelGone(cand, endpointTypeChat)
@@ -695,13 +683,23 @@ func TestNoteModelGone_FailedDisableIsRetried(t *testing.T) {
 	if calls := waitForDisable(t, repo); len(calls) != 1 {
 		t.Fatalf("expected the first (failing) attempt, got %d", len(calls))
 	}
-	waitForStreakCleared(t, h, m.ID)
 
-	// The streak was cleared by the failure, so a fresh run of refusals must
-	// reach the threshold and try again rather than being swallowed.
-	for range goneStrikeThreshold {
+	// Refusals inside the cooldown cost nothing: no second probe, no second
+	// write attempt.
+	for range 10 * goneStrikeThreshold {
 		h.noteModelGone(cand, endpointTypeChat)
 	}
+	if paths := script.requestedPaths(); len(paths) != 1 {
+		t.Fatalf("a failed write is not a reason to re-probe the provider, got %v", paths)
+	}
+	if calls := repo.disableCalls(); len(calls) != 1 {
+		t.Fatalf("expected no retry inside the cooldown, got %+v", calls)
+	}
+
+	// Once it lapses, the parked evidence is still there and one refusal is
+	// enough to try the write again.
+	expireProbeCooldown(t, h, m.ID)
+	h.noteModelGone(cand, endpointTypeChat)
 
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
@@ -842,16 +840,20 @@ func TestNoteModelGone_SuccessAfterConfirmIsRolledBack(t *testing.T) {
 	t.Fatalf("expected the committed disable to be rolled back, got %+v", repo.committedCalls())
 }
 
-// TestNoteModelGone_StaleFailedDisableKeepsANewerStreak pins that a disable
-// goroutine may only retire the streak it was actually started for.
+// TestNoteModelGone_StaleFailedDisableKeepsTheEvidence pins what a disable
+// goroutine may do to a streak that has moved on underneath it, and what the
+// next claim owes the disable it spawns.
 //
 // The sequence is reachable because the write is detached: the goroutine can
-// still be inside SetEnabled when the model answers (clearing its streak) and
-// later refusals build a fresh one. If its cleanup then deleted by model id, it
-// would erase that newer count on its way out — and a model refusing every
-// request would restart from zero each time a disable failed, staying enabled
-// exactly when it is most clearly dead.
-func TestNoteModelGone_StaleFailedDisableKeepsANewerStreak(t *testing.T) {
+// still be inside SetEnabled when the model answers — standing its write down
+// and clearing the count — and fresh refusals then start rebuilding. Two things
+// must survive that. The unwinding goroutine must not erase the evidence
+// accumulated after it (a model refusing every request would otherwise restart
+// from zero each time a disable failed, staying enabled exactly when it is most
+// clearly dead), and the tombstone that success left behind must not outlive the
+// decision it belonged to, or the next disable stands down at its own pre-write
+// check and the model is never retired again.
+func TestNoteModelGone_StaleFailedDisableKeepsTheEvidence(t *testing.T) {
 	t.Parallel()
 
 	repo := &mockModelRepo{
@@ -873,22 +875,18 @@ func TestNoteModelGone_StaleFailedDisableKeepsANewerStreak(t *testing.T) {
 		t.Fatal("the disable write never started")
 	}
 
-	// While it is held open: the model answers, dropping that streak, and then
-	// refuses again, building a new one one strike short of the threshold.
+	// While it is held open: the model answers, which cancels that write and
+	// clears the count, and then refuses again — evidence that belongs to the
+	// next decision, not to the one now unwinding.
 	h.noteModelServed(m)
 	for range goneStrikeThreshold - 1 {
 		h.noteModelGone(cand, endpointTypeChat)
 	}
-	newer, ok := h.goneStrikes.Load(m.ID)
-	if !ok {
-		t.Fatal("the later refusals did not start a new streak")
-	}
 
-	// Release the stale write, then hold the newer streak under observation.
-	// Asserting on identity rather than on the disable count is what makes this
-	// deterministic: an unconditional delete erases the entry within
-	// microseconds of the write returning, whereas counting disables would race
-	// the cleanup against the strike below and could pass either way.
+	// Release the stale write and watch what it does on its way out. Asserting
+	// on the count rather than on a later disable is what makes this
+	// deterministic: a cleanup that erases evidence does so within microseconds
+	// of the write returning, whereas counting disables would race it.
 	close(repo.setEnabledGate)
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) && len(repo.disableCalls()) < 1 {
@@ -896,18 +894,16 @@ func TestNoteModelGone_StaleFailedDisableKeepsANewerStreak(t *testing.T) {
 	}
 	watch := time.Now().Add(300 * time.Millisecond)
 	for time.Now().Before(watch) {
-		switch current, ok := h.goneStrikes.Load(m.ID); {
-		case !ok:
-			t.Fatal("the stale failed disable deleted the newer streak")
-		case current != newer:
-			t.Fatal("the newer streak was replaced while the stale disable unwound")
+		if n := goneStreakFor(t, h, m.ID).count(); n != goneStrikeThreshold-1 {
+			t.Fatalf("the stale failed disable took the newer evidence with it: streak = %d", n)
 		}
 		time.Sleep(5 * time.Millisecond)
 	}
 
-	// One more refusal now completes the newer streak, so a second disable must
-	// be attempted. If the stale cleanup had erased it, this would be strike one
-	// of three and nothing would happen.
+	// One more refusal completes the rebuilt streak. The cooldown from the first
+	// claim is still running, so this is also the point at which the retry
+	// becomes reachable rather than immediate.
+	expireProbeCooldown(t, h, m.ID)
 	h.noteModelGone(cand, endpointTypeChat)
 
 	deadline = time.Now().Add(2 * time.Second)
@@ -917,7 +913,7 @@ func TestNoteModelGone_StaleFailedDisableKeepsANewerStreak(t *testing.T) {
 		}
 		time.Sleep(5 * time.Millisecond)
 	}
-	t.Fatalf("a stale failed disable erased the newer streak: only %d disable attempts", len(repo.disableCalls()))
+	t.Fatalf("the rebuilt streak never reached a second disable: only %d attempts", len(repo.disableCalls()))
 }
 
 // TestNoteModelGone_FailedRollbackStopsThere pins the worst case on the
@@ -1431,6 +1427,54 @@ func TestNoteModelGone_AnsweredProbeKeepsTheCooldown(t *testing.T) {
 
 	// And it is a delay rather than a lockout: once the cooldown lapses the model
 	// is reconsidered on the strikes it has rebuilt since.
+	expireProbeCooldown(t, h, m.ID)
+	h.noteModelGone(cand, endpointTypeChat)
+	waitForProbes(t, script, 2)
+}
+
+// TestNoteModelGone_ASuccessDoesNotResetTheProbeCooldown closes the other door
+// into the same unbounded loop.
+//
+// Clearing the count on a served probe was only half the bound, because a real
+// request succeeding clears it too — and that is the MIXED case, which is at
+// least as likely as the pure one: a provider that refuses one request shape
+// with retirement prose while serving another produces both signals from the
+// same client traffic. If the success drops the whole streak, the probe cooldown
+// goes with it, and three more refusals buy another upstream call immediately.
+// A success clears what the model is accused of; it does not buy the gateway a
+// free probe.
+func TestNoteModelGone_ASuccessDoesNotResetTheProbeCooldown(t *testing.T) {
+	t.Parallel()
+
+	repo := &mockModelRepo{}
+	h := newGoneHandler(t, repo)
+	m := &model.Model{ID: uuid.New(), ModelID: "gpt-5.6-sol"}
+	srv, script := newGoneScriptedServer(t, http.StatusOK, goneServedAnswer)
+	cand := goneCandidateAt(m, "OpenAI", srv.URL)
+
+	for range goneStrikeThreshold {
+		h.noteModelGone(cand, endpointTypeChat)
+	}
+	waitForProbes(t, script, 1)
+	waitForStreakCount(t, h, m.ID, 0)
+
+	// An ordinary request to the same model succeeds, exactly as the request
+	// path reports it.
+	h.noteModelServed(m)
+
+	// And the traffic that does not succeed carries on refusing. None of it may
+	// buy an upstream request while the cooldown is running.
+	for range 10 * goneStrikeThreshold {
+		h.noteModelGone(cand, endpointTypeChat)
+	}
+	if calls := waitForDisable(t, repo); len(calls) != 0 {
+		t.Fatalf("a model that answered must not be retired, got %+v", calls)
+	}
+	if paths := script.requestedPaths(); len(paths) != 1 {
+		t.Fatalf("a success must not reset the probe cooldown, got %v", paths)
+	}
+
+	// Still a delay rather than a lockout.
 	expireProbeCooldown(t, h, m.ID)
 	h.noteModelGone(cand, endpointTypeChat)
 	waitForProbes(t, script, 2)

--- a/internal/proxy/model_gone_test.go
+++ b/internal/proxy/model_gone_test.go
@@ -1605,6 +1605,67 @@ func TestProbeForRetirement_NilCandidatePostponesInsteadOfPanicking(t *testing.T
 	}
 }
 
+// TestGoneStreak_CanClaimProbeDoesNotTakeTheClaim pins the read that lets the
+// cheap per-model reason to stop be checked before the shared per-provider one.
+//
+// It has to agree with claimProbe and it has to take nothing. If it stamped, a
+// refusal that only asked whether a probe was possible would extend the cooldown
+// it was asking about; if it disagreed, a model would either be denied a probe
+// it had earned or reach the semaphore on every refusal, which is what put the
+// per-provider slots in the path of traffic that was never going to spend one.
+func TestGoneStreak_CanClaimProbeDoesNotTakeTheClaim(t *testing.T) {
+	t.Parallel()
+
+	s := &goneStreak{}
+	now := time.Now()
+
+	if !s.canClaimProbe(now) {
+		t.Fatal("a streak that has never been probed must admit a claim")
+	}
+	if !s.canClaimProbe(now) {
+		t.Fatal("asking twice was refused, so the read spent the claim it was asking about")
+	}
+	if !s.claimProbe(now) {
+		t.Fatal("the real claim must still be available after the read")
+	}
+
+	// And now both must see the cooldown.
+	if s.canClaimProbe(now) {
+		t.Fatal("the read did not see the claim that was just taken")
+	}
+	if s.claimProbe(now) {
+		t.Fatal("claimProbe granted a second claim inside the cooldown")
+	}
+
+	// They agree on the far side of it too.
+	lapsed := now.Add(goneProbeCooldown)
+	if !s.canClaimProbe(lapsed) {
+		t.Fatal("the read must admit a claim once the cooldown has lapsed")
+	}
+	if !s.claimProbe(lapsed) {
+		t.Fatal("claimProbe must grant one once the cooldown has lapsed")
+	}
+}
+
+// TestNoteStreamOutcome_NilLogDataIsIgnored pins a guard that has to live at the
+// dereference. streamProducedOutput checks for nil as well, but noteStreamOutcome
+// builds its arguments from logData in the same expression that calls it, and Go
+// evaluates all of them first — so on this path the helper's check could never
+// run and a nil would panic before reaching it.
+func TestNoteStreamOutcome_NilLogDataIsIgnored(t *testing.T) {
+	t.Parallel()
+
+	repo := &mockModelRepo{}
+	h := newGoneHandler(t, repo)
+	m := &model.Model{ID: uuid.New(), ModelID: "gemini-2.0-flash"}
+
+	h.noteStreamOutcome(nil, goneCandidateFor(t, m, "Google AI Studio (Gemini)"))
+
+	if calls := repo.disableCalls(); len(calls) != 0 {
+		t.Fatalf("a stream with no log entry establishes nothing, got %+v", calls)
+	}
+}
+
 // TestGoneStreak_SupersedeReportsWhetherItChangedAnything pins the report the
 // log line depends on.
 //

--- a/internal/proxy/model_probe.go
+++ b/internal/proxy/model_probe.go
@@ -589,6 +589,18 @@ func probeDeliveredContent(endpointType string, body []byte) bool {
 		if s, ok := choice.Message.Content.(string); ok && s != "" {
 			return true
 		}
+		// Content is `any` because a provider may answer with content PARTS
+		// rather than a string. Judging only the string shape would call such a
+		// model empty: the probe would return inconclusive on a model that is
+		// demonstrably alive, the streak would never be parked, and every fresh
+		// refusal past the cooldown would buy another upstream request for as
+		// long as the disagreement lasted. Non-empty is the whole test — the
+		// parts are the model's output whatever their shape, and reaching into
+		// them to find a non-empty text field would be judging providers' part
+		// vocabularies from here.
+		if parts, ok := choice.Message.Content.([]any); ok && len(parts) > 0 {
+			return true
+		}
 		if choice.Message.ReasoningContent != "" || choice.Message.Reasoning != "" {
 			return true
 		}

--- a/internal/proxy/model_probe.go
+++ b/internal/proxy/model_probe.go
@@ -31,18 +31,27 @@ const goneProbeMaxTokens = 64
 
 // goneProbeMaxBody bounds how much of a probe answer is read into memory.
 //
-// The expected body is a couple of hundred bytes — one refusal, or one 64-token
-// completion. The read happens on the detached disable goroutine with no client
-// backpressure behind it, so nothing downstream would notice a provider (or
-// something impersonating one) streaming megabytes into it. 64 KiB is orders of
-// magnitude above any real answer and orders of magnitude below anything that
-// matters to the process.
+// The read happens on the detached disable goroutine with no client backpressure
+// behind it, so nothing downstream would notice a provider (or something
+// impersonating one) streaming megabytes into it. probeModel applies this to
+// resp.Body itself rather than at each read site, because the reads are not all
+// in this file: remapMiniMaxBusinessError and both dialect translators consume
+// the body whole, and a cap that only covered the two judgement functions would
+// have left every MiniMax, vertex-express and Responses probe unbounded.
 //
-// Truncation is safe by construction on both judgement paths: a cut-off body
-// either fails to parse, or parses into something the judgement reads as
-// unproven, and both postpone. See judgeProbeFailure for the one case where
-// that had to be reasoned about rather than assumed.
-const goneProbeMaxBody = 64 << 10
+// A megabyte rather than the couple of hundred bytes a chat refusal or a
+// 64-token completion actually needs, because the embeddings family shares the
+// constant: a 3072-dimension embedding serialised at full float precision runs
+// past 60 KiB, so a tighter cap would truncate legitimate answers from exactly
+// the models this probe is supposed to adjudicate. Still orders of magnitude
+// below anything that matters to the process, at one probe per model per
+// goneProbeCooldown.
+//
+// The value is not load-bearing for correctness in either direction, which is
+// the point of judgeProbeFailure's explicit length check: a truncated body
+// postpones because it was measured to be truncated, not because 1 MiB happens
+// to sit above the classifier's own 10 000-character window.
+const goneProbeMaxBody = 1 << 20
 
 // goneProbeTimeout bounds the pre-retirement probe. It runs on the detached
 // disable goroutine, so nothing on the request path is waiting on it.
@@ -145,6 +154,18 @@ func probeEndpointForFamily(endpointType string) (endpoint string, ok bool) {
 	default:
 		return "", false
 	}
+}
+
+// cappedBody is a response body bounded by goneProbeMaxBody whose Close still
+// closes the transport's own body underneath.
+//
+// The Closer half is the point. Wrapping in an io.NopCloser would leave nothing
+// holding the real body, and every reader downstream — including the two in
+// other packages — would then be reading through a cap while the connection it
+// belongs to leaked.
+type cappedBody struct {
+	io.Reader
+	io.Closer
 }
 
 // probeChatRequest is the minimal chat body the probe sends. It reuses the
@@ -364,12 +385,34 @@ func (h *Handler) probeModel(ctx context.Context, candidate modelCandidate, endp
 		debuglog.Debug("proxy: retirement probe did not reach the provider", "endpoint", endpointType, "provider", candidate.provider.Name, "model", candidate.model.ModelID, "verdict", probeInconclusive.String(), "error", err)
 		return probeInconclusive
 	}
+	// The cap goes on the body here, once, and everything past this line reads
+	// through it. Applying it at the read sites instead would have missed three
+	// of them: remapMiniMaxBusinessError and both dialect translators call
+	// io.ReadAll(resp.Body) inside packages that know nothing about this budget,
+	// so a MiniMax, vertex-express or Responses candidate answering a 200 with a
+	// multi-gigabyte body would have been read into memory in full.
+	//
+	// rawBody is held separately because resp.Body is replaced here and replaced
+	// again by remapMiniMaxBusinessError, and the drain below has to read the
+	// transport's own body rather than whichever wrapper is in the field by then.
+	// The close can stay on the field precisely because cappedBody passes Close
+	// through — see cappedBody for why the obvious io.NopCloser cannot.
+	//
+	// One byte past the cap, so a truncated body can be recognised as truncated:
+	// io.ReadAll reports no error when a LimitReader runs out, so length is the
+	// only signal there is (see judgeProbeFailure).
+	rawBody := resp.Body
+	resp.Body = cappedBody{Reader: io.LimitReader(rawBody, goneProbeMaxBody+1), Closer: rawBody}
 	defer func() {
 		// Drain before closing so the transport can reuse the connection, and
 		// drain no more than the judgement was willing to read. A body past
 		// goneProbeMaxBody costs the connection its reuse and nothing else,
 		// which is the cheaper of the two ways to be wrong here.
-		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, goneProbeMaxBody))
+		_, _ = io.Copy(io.Discard, io.LimitReader(rawBody, goneProbeMaxBody))
+		// Whatever is in the field: the cap above on every path, or the
+		// NopCloser remapMiniMaxBusinessError leaves behind — and that path has
+		// already closed the cap, and through it the transport's own body. The
+		// real body is closed exactly once either way.
 		_ = resp.Body.Close()
 	}()
 
@@ -392,14 +435,29 @@ func (h *Handler) probeModel(ctx context.Context, candidate modelCandidate, endp
 // no status-code shortcut around the classifier here — a bare "404 means gone"
 // would retire every model behind a misconfigured base URL.
 func judgeProbeFailure(resp *http.Response, candidate modelCandidate, endpointType string) probeVerdict {
-	body, err := io.ReadAll(io.LimitReader(resp.Body, goneProbeMaxBody))
-	if err != nil {
-		// The one place in this file where a discarded read error could RETIRE
-		// a model: a truncated body whose surviving prefix happens to name the
-		// model beside a gone-phrase classifies exactly like a real refusal.
+	// One byte past the cap on purpose. This is the one place in this file where
+	// a body we did not receive in full could RETIRE a model: a surviving prefix
+	// that happens to name the model beside a gone-phrase classifies exactly like
+	// a real refusal, and the classifier only ever sees the first 10 000
+	// characters, so it cannot tell that the rest went missing.
+	//
+	// Reading exactly goneProbeMaxBody could not tell either. io.ReadAll returns
+	// a nil error when a LimitReader is exhausted — that is not a read failure,
+	// it is the reader ending — so the err branch below catches genuine transport
+	// failures and never catches truncation. The extra byte is what turns "we hit
+	// the cap" into something observable, and probeModel sizes its own wrapper to
+	// let it through.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, goneProbeMaxBody+1))
+	switch {
+	case err != nil:
 		// A body we could not finish reading is not the provider saying
 		// anything, so it postpones like every other unproven case.
 		debuglog.Debug("proxy: retirement probe could not read the provider's answer", "endpoint", endpointType, "provider", candidate.provider.Name, "model", candidate.model.ModelID, "status", resp.StatusCode, "verdict", probeInconclusive.String(), "error", err)
+		return probeInconclusive
+	case len(body) > goneProbeMaxBody:
+		// Over the cap: what is in hand is a prefix of an answer whose real
+		// content is unknown. Postpone rather than classify it.
+		debuglog.Debug("proxy: retirement probe answer exceeded the read cap", "endpoint", endpointType, "provider", candidate.provider.Name, "model", candidate.model.ModelID, "status", resp.StatusCode, "verdict", probeInconclusive.String(), "max_bytes", goneProbeMaxBody)
 		return probeInconclusive
 	}
 	kind, _ := classifyUpstreamError(resp.StatusCode, util.SanitizeLogBody(string(body), 10000), candidate.model.ModelID)
@@ -431,15 +489,16 @@ func judgeProbeSuccess(resp *http.Response, st *requestState, candidate modelCan
 		return probeInconclusive
 	}
 
-	// The read error IS discarded here, and deliberately, which is the opposite
-	// of the care judgeProbeFailure takes over the same call. The asymmetry is
-	// in what a truncated body can produce, not in how much attention the two
+	// Both the read error and the cap are ignored here, which is the opposite of
+	// the care judgeProbeFailure takes over the same call. The asymmetry is in
+	// what an incomplete body can produce, not in how much attention the two
 	// paths deserve. There, a surviving prefix naming the model beside a
-	// gone-phrase classifies as a refusal and RETIRES; here, the worst a partial
-	// body can do is fail to parse (probeDeliveredContent returns false, and the
-	// probe postpones) or carry content, which can only ever PREVENT a disable.
-	// Neither outcome can retire a model, so a separate branch for the error
-	// would postpone exactly where the code already postpones.
+	// gone-phrase would classify as a refusal and RETIRE, so it has to be
+	// detected; here, the worst a partial body can do is fail to parse
+	// (probeDeliveredContent returns false, and the probe postpones) or carry
+	// content, which can only ever PREVENT a disable. Neither outcome can retire
+	// a model, so the branches would postpone exactly where the code already
+	// postpones.
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, goneProbeMaxBody))
 	verdict := probeInconclusive
 	if probeDeliveredContent(endpointType, body) {

--- a/internal/proxy/model_probe.go
+++ b/internal/proxy/model_probe.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
+	"github.com/hugalafutro/model-hotel/internal/failover"
 	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
@@ -15,7 +17,32 @@ import (
 // reasoning model spends a 1-token budget on thinking, returns an empty
 // completion, and some providers wrap that in a 400 — a manufactured false
 // failure that cost half a day during the July catalog audit.
+//
+// Best-effort, and knowingly so. The probe goes through the real egress builder
+// (see newProbeState), whose step 6 strips params this provider+model has
+// LEARNED the upstream rejects. A model that once answered 400 for max_tokens
+// outright therefore gets probed with no cap at all and answers at whatever
+// length it likes. That is the right trade rather than a gap to close: the
+// alternative is a bespoke body that keeps the cap by skipping the rewrite, and
+// a probe that is easier to satisfy than the requests it adjudicates is worse
+// than no probe. The cost is bounded anyway — one uncapped completion per
+// retirement decision, at goneProbeCooldown apiece.
 const goneProbeMaxTokens = 64
+
+// goneProbeMaxBody bounds how much of a probe answer is read into memory.
+//
+// The expected body is a couple of hundred bytes — one refusal, or one 64-token
+// completion. The read happens on the detached disable goroutine with no client
+// backpressure behind it, so nothing downstream would notice a provider (or
+// something impersonating one) streaming megabytes into it. 64 KiB is orders of
+// magnitude above any real answer and orders of magnitude below anything that
+// matters to the process.
+//
+// Truncation is safe by construction on both judgement paths: a cut-off body
+// either fails to parse, or parses into something the judgement reads as
+// unproven, and both postpone. See judgeProbeFailure for the one case where
+// that had to be reasoned about rather than assumed.
+const goneProbeMaxBody = 64 << 10
 
 // goneProbeTimeout bounds the pre-retirement probe. It runs on the detached
 // disable goroutine, so nothing on the request path is waiting on it.
@@ -57,14 +84,24 @@ const (
 // rather than the value itself: debuglog's arguments are evaluated eagerly, so
 // an explicit conversion keeps the rendered name independent of whether the
 // Debug scope happens to be enabled.
+//
+// probeInconclusive has its own case and the default renders the number, which
+// is the opposite of the obvious arrangement and is the point. noteModelGone's
+// default arm exists specifically to surface a verdict nobody has handled, and
+// it logs this string; folding unknown values into "inconclusive" meant the one
+// diagnostic designed to name the unknown value was guaranteed to misname it,
+// and a fourth verdict would have been indistinguishable in the logs from the
+// zero value it is not.
 func (v probeVerdict) String() string {
 	switch v {
+	case probeInconclusive:
+		return "inconclusive"
 	case probeRefused:
 		return "refused"
 	case probeServed:
 		return "served"
 	default:
-		return "inconclusive"
+		return "unknown(" + strconv.Itoa(int(v)) + ")"
 	}
 }
 
@@ -79,6 +116,18 @@ func (v probeVerdict) String() string {
 // adjudicate — the probe would manufacture exactly the wrong answer. Image,
 // speech and transcription probes also cost real money and real seconds per
 // call, which a background verification must not spend.
+//
+// Rerank is excluded on a different and weaker ground, recorded here so nobody
+// reads it as belonging to the sentence above. A /rerank call with one document
+// is about as cheap as the embeddings call this function already allows, so the
+// cost argument does not apply to it. It is excluded because a rerank probe
+// would need its own request body, its own answer shape and its own "did the
+// model actually produce something" judgement, none of which exist yet and none
+// of which anything has asked for — and shipping an unexercised third judgement
+// path is a worse trade than the consequence, which is that rerank models are
+// never auto-retired and simply stay enabled until an operator disables one.
+// This is a deliberately conservative choice and the cheap one to reverse:
+// adding the family here plus a body and a content check is all it takes.
 //
 // So where a family cannot be probed cheaply, the correct outcome is to not
 // auto-retire that family at all. The alternative — falling back to trusting
@@ -122,6 +171,24 @@ type probeEmbeddingsRequest struct {
 // because a bespoke request builder would be able to succeed where real traffic
 // fails and a probe that is easier to satisfy than the requests it adjudicates
 // is worse than no probe at all.
+//
+// One divergence from that, named rather than left to be discovered. anthropicIn
+// and anthropicRawBody are NOT set, so an endpointTypeMessages candidate on an
+// anthropic-type provider is probed with an OpenAI chat body at
+// {base}/v1/chat/completions, whereas the traffic that nominated it went out
+// natively at /v1/messages (see anthropic_native.go). Setting them is not
+// available here: anthropicRawBody is the CLIENT's /v1/messages body, and a
+// probe has no client, so the native path would have to be handed a body this
+// function invented — which is the bespoke request the paragraph above rules
+// out, on the one dialect where it is easiest to get subtly wrong.
+//
+// It is acceptable because of which way the difference can fail. Anthropic's
+// compat layer serves the same model catalog, so a live model answers on both
+// surfaces and a retired one is refused by name on both. If the compat layer
+// itself is the problem — not enabled, differently gated, differently shaped —
+// the probe draws an error that is not a retirement, classifies as such, and
+// returns probeInconclusive. The retirement is postponed, never manufactured,
+// which is the direction every unproven case in this file already takes.
 //
 // endpointPath is deliberately left empty for the chat families even though
 // probeEndpointForFamily names "/chat/completions". Empty IS chat to the
@@ -220,6 +287,30 @@ func (h *Handler) probeModel(ctx context.Context, candidate modelCandidate, endp
 		return probeInconclusive
 	}
 
+	// Skipping the breaker's ACCOUNTING is argued at length above. Skipping its
+	// CHECK would be a separate decision and is not one this makes: if the
+	// gateway has already sidelined this provider, a probe to it is a
+	// guaranteed-wasted call to a host nothing else is being sent to, and its
+	// answer would be inconclusive anyway. So the breaker is consulted, and
+	// consulted through the one entry point that records nothing.
+	//
+	// GetState rather than IsOpen, and the difference is the whole reason this
+	// check is safe to make. IsOpen is the routing gate: it takes a write lock
+	// and performs the Open→HalfOpen transition, which spends the provider's
+	// one half-open trial slot on a request the operator did not make and would
+	// let a verification decide a provider's fate. GetState takes a read lock
+	// and derives the same logical state without touching the circuit, so an
+	// open circuit past its cooldown already reads as half-open here — which is
+	// exactly the semantics wanted: postpone only while the breaker is actually
+	// holding traffic back, proceed the moment it is ready to be probed again.
+	//
+	// A nil breaker means nobody has an opinion, which is not a reason to
+	// postpone.
+	if h.circuitBreaker != nil && h.circuitBreaker.GetState(candidate.provider.ID) == failover.StateOpen {
+		debuglog.Debug("proxy: retirement probe skipped, the provider's circuit is open", "endpoint", endpointType, "provider", candidate.provider.Name, "model", candidate.model.ModelID, "verdict", probeInconclusive.String())
+		return probeInconclusive
+	}
+
 	st := newProbeState(candidate, endpointType, endpoint)
 
 	req, providerType, _, err := h.buildCandidateRequest(ctx, st, candidate)
@@ -257,8 +348,11 @@ func (h *Handler) probeModel(ctx context.Context, candidate modelCandidate, endp
 		return probeInconclusive
 	}
 	defer func() {
-		// Drain before closing so the transport can reuse the connection.
-		_, _ = io.Copy(io.Discard, resp.Body)
+		// Drain before closing so the transport can reuse the connection, and
+		// drain no more than the judgement was willing to read. A body past
+		// goneProbeMaxBody costs the connection its reuse and nothing else,
+		// which is the cheaper of the two ways to be wrong here.
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, goneProbeMaxBody))
 		_ = resp.Body.Close()
 	}()
 
@@ -281,7 +375,7 @@ func (h *Handler) probeModel(ctx context.Context, candidate modelCandidate, endp
 // no status-code shortcut around the classifier here — a bare "404 means gone"
 // would retire every model behind a misconfigured base URL.
 func judgeProbeFailure(resp *http.Response, candidate modelCandidate, endpointType string) probeVerdict {
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, goneProbeMaxBody))
 	if err != nil {
 		// The one place in this file where a discarded read error could RETIRE
 		// a model: a truncated body whose surviving prefix happens to name the
@@ -320,7 +414,16 @@ func judgeProbeSuccess(resp *http.Response, st *requestState, candidate modelCan
 		return probeInconclusive
 	}
 
-	body, _ := io.ReadAll(resp.Body)
+	// The read error IS discarded here, and deliberately, which is the opposite
+	// of the care judgeProbeFailure takes over the same call. The asymmetry is
+	// in what a truncated body can produce, not in how much attention the two
+	// paths deserve. There, a surviving prefix naming the model beside a
+	// gone-phrase classifies as a refusal and RETIRES; here, the worst a partial
+	// body can do is fail to parse (probeDeliveredContent returns false, and the
+	// probe postpones) or carry content, which can only ever PREVENT a disable.
+	// Neither outcome can retire a model, so a separate branch for the error
+	// would postpone exactly where the code already postpones.
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, goneProbeMaxBody))
 	verdict := probeInconclusive
 	if probeDeliveredContent(endpointType, body) {
 		verdict = probeServed

--- a/internal/proxy/model_probe.go
+++ b/internal/proxy/model_probe.go
@@ -505,7 +505,7 @@ func judgeProbeFailure(resp *http.Response, candidate modelCandidate, endpointTy
 //
 // A 200 that carries nothing is NOT a success. A stream can open, emit nothing
 // and end cleanly, and crediting that is the same bug an earlier review round
-// caught on the streaming path (see streamProducedOutput in model_gone.go).
+// caught on the streaming path (see producedOutput in model_gone.go).
 // It is not a refusal either — the provider did not say the model is gone — so
 // an empty answer postpones like every other unproven case.
 func judgeProbeSuccess(resp *http.Response, st *requestState, candidate modelCandidate, endpointType string) probeVerdict {
@@ -611,6 +611,19 @@ func probeDeliveredContent(endpointType string, body []byte) bool {
 	if json.Unmarshal(body, &out) != nil {
 		return false
 	}
+	return chatAnswerCarriesContent(out)
+}
+
+// chatAnswerCarriesContent reports whether a decoded chat completion carries
+// something the model produced.
+//
+// Shared with the non-streaming request path, which asks the same question of
+// the same shape for the same reason: a 200 that carries nothing is not the
+// model answering, and crediting one would let a provider intermittently
+// returning an empty completion reset a retired model's strike count forever.
+// One judgement rather than two, so the probe and the traffic cannot drift into
+// disagreeing about what an answer is.
+func chatAnswerCarriesContent(out ChatCompletionResponse) bool {
 	for _, choice := range out.Choices {
 		if s, ok := choice.Message.Content.(string); ok && s != "" {
 			return true

--- a/internal/proxy/model_probe.go
+++ b/internal/proxy/model_probe.go
@@ -1,0 +1,371 @@
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/hugalafutro/model-hotel/internal/debuglog"
+	"github.com/hugalafutro/model-hotel/internal/util"
+)
+
+// goneProbeMaxTokens is the probe's output budget. Deliberately not 1: a
+// reasoning model spends a 1-token budget on thinking, returns an empty
+// completion, and some providers wrap that in a 400 — a manufactured false
+// failure that cost half a day during the July catalog audit.
+const goneProbeMaxTokens = 64
+
+// goneProbeTimeout bounds the pre-retirement probe. It runs on the detached
+// disable goroutine, so nothing on the request path is waiting on it.
+//
+// probeModel does NOT apply this itself. Taking the context from the caller is
+// what lets a test drive the real code with a deadline measured in
+// milliseconds, and it keeps the production budget at the single call site that
+// owns the decision rather than buried in the helper.
+const goneProbeTimeout = 30 * time.Second
+
+// The two upstream surfaces a retirement probe is allowed to touch. Both are
+// the OpenAI-compatible spelling; the egress builder re-routes them per
+// provider dialect, which is the whole reason the probe goes through it.
+const (
+	probeChatEndpoint       = "/chat/completions"
+	probeEmbeddingsEndpoint = "/embeddings"
+)
+
+// probeVerdict is what a real request to the model proves about whether the
+// provider still serves it.
+//
+// Three-way, and the zero value is the one that matters: every path that cannot
+// establish anything — an unprobeable family, a request that would not build, a
+// connection that never landed, a deadline, a body that will not parse — lands
+// on probeInconclusive, and the caller postpones the retirement on it. Nothing
+// is claimed from evidence that was never gathered.
+type probeVerdict int
+
+const (
+	// probeInconclusive: the probe proved nothing. Postpone.
+	probeInconclusive probeVerdict = iota
+	// probeRefused: the provider refused the model by name. Retire.
+	probeRefused
+	// probeServed: the model answered with content. Do not retire.
+	probeServed
+)
+
+// String names the verdict for logs. The call sites pass the result of this
+// rather than the value itself: debuglog's arguments are evaluated eagerly, so
+// an explicit conversion keeps the rendered name independent of whether the
+// Debug scope happens to be enabled.
+func (v probeVerdict) String() string {
+	switch v {
+	case probeRefused:
+		return "refused"
+	case probeServed:
+		return "served"
+	default:
+		return "inconclusive"
+	}
+}
+
+// probeEndpointForFamily reports which upstream endpoint can cheaply prove
+// whether a model of this endpoint family is still served, and whether one
+// exists at all.
+//
+// Only chat and embeddings qualify, and the exclusions are the point rather
+// than an omission. A chat probe against an image, TTS or STT model fails for
+// reasons that have nothing to do with the model being retired, and that
+// failure would read as confirmation of the retirement it was supposed to
+// adjudicate — the probe would manufacture exactly the wrong answer. Image,
+// speech and transcription probes also cost real money and real seconds per
+// call, which a background verification must not spend.
+//
+// So where a family cannot be probed cheaply, the correct outcome is to not
+// auto-retire that family at all. The alternative — falling back to trusting
+// the prose classifier — would leave the retirement running unsupervised
+// precisely in the corner where it is least observed and least often right.
+//
+// The empty string and any unknown family are unprobeable for the same reason:
+// nothing can be substantiated about them, so nothing is claimed.
+func probeEndpointForFamily(endpointType string) (endpoint string, ok bool) {
+	switch endpointType {
+	case endpointTypeChat, endpointTypeMessages:
+		return probeChatEndpoint, true
+	case endpointTypeEmbeddings:
+		return probeEmbeddingsEndpoint, true
+	default:
+		return "", false
+	}
+}
+
+// probeChatRequest is the minimal chat body the probe sends. It reuses the
+// package's Message so the shape cannot drift from what the rest of the proxy
+// considers a chat message.
+type probeChatRequest struct {
+	Model     string    `json:"model"`
+	Messages  []Message `json:"messages"`
+	MaxTokens int       `json:"max_tokens"`
+}
+
+// probeEmbeddingsRequest is the minimal embeddings body the probe sends.
+type probeEmbeddingsRequest struct {
+	Model string `json:"model"`
+	Input string `json:"input"`
+}
+
+// newProbeState builds the synthetic requestState the probe hands to the real
+// egress builder.
+//
+// The state is synthetic but the path is not. Everything the builder derives
+// from it — provider-type detection, the target-URL rules, the OpenAI-Responses
+// and vertex-express Gemini dialect re-routes, the param rewrite — has to run,
+// because a bespoke request builder would be able to succeed where real traffic
+// fails and a probe that is easier to satisfy than the requests it adjudicates
+// is worse than no probe at all.
+//
+// endpointPath is deliberately left empty for the chat families even though
+// probeEndpointForFamily names "/chat/completions". Empty IS chat to the
+// builder (it defaults to exactly that path), while a non-empty endpointPath is
+// how the pipeline says "this is one of the multimodal endpoints" — and both
+// dialect re-routes refuse to fire when it is set. Spelling the default out
+// would therefore switch off the re-routes this function exists to go through,
+// and a vertex-express candidate would be probed with an OpenAI body against a
+// path Google does not serve.
+//
+// The marshal errors are discarded rather than propagated, and that is a
+// statement about the inputs rather than a shortcut: both payloads are fixed
+// structs of strings and ints, so encoding/json has no failure to report here.
+// Threading an error nothing can produce would add a branch no test could ever
+// reach.
+func newProbeState(candidate modelCandidate, endpointType, endpoint string) *requestState {
+	modelID := candidate.model.ModelID
+	st := &requestState{
+		reqModel: modelID,
+		logData: &requestLogData{
+			modelID:      modelID,
+			endpointType: endpointType,
+		},
+	}
+
+	if endpoint == probeEmbeddingsEndpoint {
+		body, _ := json.Marshal(probeEmbeddingsRequest{Model: modelID, Input: "hi"})
+		st.endpointPath = endpoint
+		// The multimodal endpoints own their body rewrite through
+		// makeUpstreamBody (see multimodal.go); the probe does the same, so the
+		// id in the body is the one the builder resolved rather than the one
+		// this function happened to be handed.
+		st.makeUpstreamBody = func(resolvedModelID string) ([]byte, string, error) {
+			resolved, _ := json.Marshal(probeEmbeddingsRequest{Model: resolvedModelID, Input: "hi"})
+			return resolved, "application/json", nil
+		}
+		// bodyBytes is set to the same payload even though makeUpstreamBody
+		// supersedes it: several things downstream of the builder read the
+		// request body, and none of them should be looking at an empty one.
+		st.bodyBytes = body
+		return st
+	}
+
+	body, _ := json.Marshal(probeChatRequest{
+		Model:     modelID,
+		Messages:  []Message{{Role: "user", Content: "hi"}},
+		MaxTokens: goneProbeMaxTokens,
+	})
+	st.bodyBytes = body
+	return st
+}
+
+// probeModel asks the provider directly whether it still serves this model.
+//
+// It exists because the retirement verdict was being drawn from provider prose,
+// and prose drifts. classifyUpstreamError reads the words a provider chose on
+// the day it wrote them; this reads what the provider actually does when asked
+// for the model. The probe is the adjudicator, the classifier is only what
+// nominates a model for adjudication.
+//
+// It is an upstream call the operator did not make, so it is deliberately NOT
+// run through doUpstream: no circuit-breaker outcome, no request log, no
+// metering, no rate-limit accounting. Charging a provider's breaker for a
+// verification request would let the verification itself take a healthy
+// provider out of routing, and metering it would bill an operator for traffic
+// they never sent.
+//
+// The caller owns the deadline (see goneProbeTimeout) and the decision; this
+// returns evidence only.
+func (h *Handler) probeModel(ctx context.Context, candidate modelCandidate, endpointType string) probeVerdict {
+	endpoint, ok := probeEndpointForFamily(endpointType)
+	if !ok {
+		// Defensive: the caller is expected to gate on the family before
+		// spending a request. Reaching here means it did not, and the honest
+		// answer is still that nothing was established.
+		return probeInconclusive
+	}
+	if candidate.model == nil || candidate.provider == nil {
+		return probeInconclusive
+	}
+
+	st := newProbeState(candidate, endpointType, endpoint)
+
+	req, providerType, _, err := h.buildCandidateRequest(ctx, st, candidate)
+	if err != nil {
+		debuglog.Debug("proxy: retirement probe could not build its request", "endpoint", endpointType, "provider", candidate.provider.Name, "model", candidate.model.ModelID, "error", err)
+		return probeInconclusive
+	}
+
+	// The shared upstream transport, with the same redirect guard real traffic
+	// gets: a provider that redirects must not be able to walk this request's
+	// credential to another host just because it arrived off the request path.
+	//
+	// The nil check is load-bearing, not defensive tidiness. upstreamTransport
+	// is a concrete *http.Transport, so assigning a nil one into the
+	// RoundTripper field produces a non-nil interface holding a nil pointer:
+	// net/http does not fall back to DefaultTransport, it panics inside
+	// RoundTrip — on the detached disable goroutine, where a panic takes the
+	// process down.
+	client := &http.Client{}
+	if h.upstreamTransport != nil {
+		client.Transport = h.upstreamTransport
+	}
+	if h.safeDialer != nil {
+		client.CheckRedirect = h.safeDialer.CheckRedirect
+	}
+
+	//nolint:gosec // provider URL is admin-configured, not arbitrary user input
+	resp, err := client.Do(req)
+	if err != nil {
+		// A connection that never landed, a DNS failure or an expired deadline
+		// says nothing about the model. This is the branch that keeps a network
+		// problem on the gateway's side from retiring a provider's whole
+		// catalog.
+		debuglog.Debug("proxy: retirement probe did not reach the provider", "endpoint", endpointType, "provider", candidate.provider.Name, "model", candidate.model.ModelID, "verdict", probeInconclusive.String(), "error", err)
+		return probeInconclusive
+	}
+	defer func() {
+		// Drain before closing so the transport can reuse the connection.
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+
+	// MiniMax reports refusals inside a 200 envelope, so the status has to be
+	// normalised before it is judged — exactly as attemptCandidate does.
+	resp = remapMiniMaxBusinessError(providerType, candidate.provider.Name, resp)
+
+	if resp.StatusCode != http.StatusOK {
+		return judgeProbeFailure(resp, candidate, endpointType)
+	}
+	return judgeProbeSuccess(resp, st, candidate, endpointType)
+}
+
+// judgeProbeFailure turns a non-200 probe response into a verdict.
+//
+// Only the classifier's retirement verdict retires. Everything else postpones,
+// and that single line is what keeps a provider incident from becoming a mass
+// retirement: 429s, 402s, quota and entitlement failures, bad-request verdicts
+// and every 5xx are things that happen to models that are alive. Deliberately
+// no status-code shortcut around the classifier here — a bare "404 means gone"
+// would retire every model behind a misconfigured base URL.
+func judgeProbeFailure(resp *http.Response, candidate modelCandidate, endpointType string) probeVerdict {
+	body, _ := io.ReadAll(resp.Body)
+	kind, _ := classifyUpstreamError(resp.StatusCode, util.SanitizeLogBody(string(body), 10000), candidate.model.ModelID)
+
+	verdict := probeInconclusive
+	if kind == KindProviderModelGone {
+		verdict = probeRefused
+	}
+	// Never the body, never the key: this is a provider response and the
+	// no-content rule applies to it exactly as it does on the request path.
+	debuglog.Debug("proxy: retirement probe refused", "endpoint", endpointType, "provider", candidate.provider.Name, "model", candidate.model.ModelID, "status", resp.StatusCode, "error_kind", string(kind), "verdict", verdict.String())
+	return verdict
+}
+
+// judgeProbeSuccess turns a 200 probe response into a verdict.
+//
+// A 200 that carries nothing is NOT a success. A stream can open, emit nothing
+// and end cleanly, and crediting that is the same bug an earlier review round
+// caught on the streaming path (see streamProducedOutput in model_gone.go).
+// It is not a refusal either — the provider did not say the model is gone — so
+// an empty answer postpones like every other unproven case.
+func judgeProbeSuccess(resp *http.Response, st *requestState, candidate modelCandidate, endpointType string) probeVerdict {
+	// The dialect re-routes answer in their own wire format. Translate first,
+	// for the same reason attemptCandidate does: everything downstream judges
+	// the chat-completions shape. An answer that cannot be translated is not a
+	// refusal, so it postpones like every other unreadable result.
+	if err := translateProbeDialect(resp, st); err != nil {
+		debuglog.Debug("proxy: retirement probe could not read the provider's dialect", "endpoint", endpointType, "provider", candidate.provider.Name, "model", candidate.model.ModelID, "error", err)
+		return probeInconclusive
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	verdict := probeInconclusive
+	if probeDeliveredContent(endpointType, body) {
+		verdict = probeServed
+	}
+	debuglog.Debug("proxy: retirement probe answered", "endpoint", endpointType, "provider", candidate.provider.Name, "model", candidate.model.ModelID, "status", resp.StatusCode, "verdict", verdict.String())
+	return verdict
+}
+
+// translateProbeDialect converts a dialect answer back to the
+// chat-completions shape the judgement below understands, mirroring what
+// attemptCandidate does on the served path. Which flag is set was decided by
+// buildCandidateRequest, so this stays correct as the re-route rules move.
+//
+// Only the non-streaming translators are reachable: the probe never asks for a
+// stream, so there is no adapter to install.
+//
+// The Responses case cannot fire as the probe body stands — that re-route also
+// requires tools in the request, and the probe sends none — but it is kept
+// rather than dropped, because the flag is set by buildCandidateRequest and not
+// by anything here. If the re-route rules widen, a probe that skipped the
+// translation would read a Responses object as an empty chat completion and
+// postpone every retirement for those models forever, silently.
+func translateProbeDialect(resp *http.Response, st *requestState) error {
+	switch {
+	case st.responsesAttempt:
+		return translateResponsesResponseBody(resp, st.reqModel)
+	case st.geminiAttempt:
+		return translateGeminiResponseBody(resp, st.reqModel)
+	default:
+		return nil
+	}
+}
+
+// probeDeliveredContent reports whether a 200 probe response actually carried
+// something the model produced.
+//
+// The chat side accepts visible content, reasoning content and tool calls
+// because all three are the model working, and falls back to the reported
+// completion tokens because a reasoning model can legitimately spend the whole
+// budget thinking and return an empty visible answer. Without that fallback the
+// probe would call a working reasoning model empty and postpone forever.
+//
+// A body that will not parse returns false, which postpones rather than
+// retires: an unreadable answer is not the provider saying the model is gone.
+func probeDeliveredContent(endpointType string, body []byte) bool {
+	if endpointType == endpointTypeEmbeddings {
+		var out struct {
+			Data []struct {
+				Embedding []float64 `json:"embedding"`
+			} `json:"data"`
+		}
+		if json.Unmarshal(body, &out) != nil {
+			return false
+		}
+		return len(out.Data) > 0 && len(out.Data[0].Embedding) > 0
+	}
+
+	var out ChatCompletionResponse
+	if json.Unmarshal(body, &out) != nil {
+		return false
+	}
+	for _, choice := range out.Choices {
+		if s, ok := choice.Message.Content.(string); ok && s != "" {
+			return true
+		}
+		if choice.Message.ReasoningContent != "" || choice.Message.Reasoning != "" {
+			return true
+		}
+		if len(choice.Message.ToolCalls) > 0 {
+			return true
+		}
+	}
+	return out.Usage.CompletionTokens > 0
+}

--- a/internal/proxy/model_probe.go
+++ b/internal/proxy/model_probe.go
@@ -366,16 +366,22 @@ func (h *Handler) probeModel(ctx context.Context, candidate modelCandidate, endp
 	// gets: a provider that redirects must not be able to walk this request's
 	// credential to another host just because it arrived off the request path.
 	//
-	// The nil check is load-bearing, not defensive tidiness. upstreamTransport
-	// is a concrete *http.Transport, so assigning a nil one into the
-	// RoundTripper field produces a non-nil interface holding a nil pointer:
-	// net/http does not fall back to DefaultTransport, it panics inside
-	// RoundTrip — on the detached disable goroutine, where a panic takes the
-	// process down.
-	client := &http.Client{}
-	if h.upstreamTransport != nil {
-		client.Transport = h.upstreamTransport
+	// No transport, no probe. The nil check has to exist — upstreamTransport is a
+	// concrete *http.Transport, so assigning a nil one into the RoundTripper
+	// field produces a non-nil interface holding a nil pointer, and net/http does
+	// not fall back to DefaultTransport, it panics inside RoundTrip, on the
+	// detached disable goroutine — but leaving the field unset instead is not the
+	// harmless half of that choice. An unset Transport IS http.DefaultTransport,
+	// which carries no DialContext, so the SafeDialer's guard against a provider
+	// URL resolving into the gateway's own network would be silently absent for
+	// exactly the request nobody is watching. Every other outbound site in this
+	// package assigns the shared transport unconditionally; a probe that cannot
+	// have it postpones, which costs nothing in a process that always sets it.
+	if h.upstreamTransport == nil {
+		debuglog.Debug("proxy: retirement probe has no upstream transport to make a guarded request with", "endpoint", endpointType, "provider", candidate.provider.Name, "model", candidate.model.ModelID, "verdict", probeInconclusive.String())
+		return probeInconclusive
 	}
+	client := &http.Client{Transport: h.upstreamTransport}
 	if h.safeDialer != nil {
 		client.CheckRedirect = h.safeDialer.CheckRedirect
 	}

--- a/internal/proxy/model_probe.go
+++ b/internal/proxy/model_probe.go
@@ -17,50 +17,41 @@ import (
 // goneProbeMaxTokens is the probe's output budget. Deliberately not 1: a
 // reasoning model spends a 1-token budget on thinking, returns an empty
 // completion, and some providers wrap that in a 400 — a manufactured false
-// failure that cost half a day during the July catalog audit.
+// failure.
 //
 // Best-effort, and knowingly so. The probe goes through the real egress builder
-// (see newProbeState), whose step 6 strips params this provider+model has
-// LEARNED the upstream rejects. A model that once answered 400 for max_tokens
-// outright therefore gets probed with no cap at all and answers at whatever
-// length it likes. That is the right trade rather than a gap to close: the
-// alternative is a bespoke body that keeps the cap by skipping the rewrite, and
-// a probe that is easier to satisfy than the requests it adjudicates is worse
-// than no probe. The cost is bounded anyway — one uncapped completion per
+// (see newProbeState), which strips params this provider+model has LEARNED the
+// upstream rejects, so a model that once answered 400 for max_tokens is probed
+// with no cap at all. Keeping the cap would mean a bespoke body that skips the
+// rewrite, and a probe that is easier to satisfy than the requests it
+// adjudicates is worse than no probe. The cost is one uncapped completion per
 // retirement decision, at goneProbeCooldown apiece.
 const goneProbeMaxTokens = 64
 
 // goneProbeMaxBody bounds how much of a probe answer is read into memory.
 //
-// The read happens on the detached disable goroutine with no client backpressure
-// behind it, so nothing downstream would notice a provider (or something
-// impersonating one) streaming megabytes into it. probeModel applies this to
-// resp.Body itself rather than at each read site, because the reads are not all
-// in this file: remapMiniMaxBusinessError and both dialect translators consume
-// the body whole, and a cap that only covered the two judgement functions would
-// have left every MiniMax, vertex-express and Responses probe unbounded.
+// Applied to resp.Body itself rather than at each read site: remapMiniMaxBusinessError
+// and both dialect translators consume the body whole from other packages, so a
+// cap that only covered the judgement functions would leave every MiniMax,
+// vertex-express and Responses probe unbounded. The read happens on a detached
+// goroutine with no client backpressure behind it.
 //
-// A megabyte rather than the couple of hundred bytes a chat refusal or a
-// 64-token completion actually needs, because the embeddings family shares the
-// constant: a 3072-dimension embedding serialised at full float precision runs
-// past 60 KiB, so a tighter cap would truncate legitimate answers from exactly
-// the models this probe is supposed to adjudicate. Still orders of magnitude
-// below anything that matters to the process, at one probe per model per
-// goneProbeCooldown.
+// A megabyte rather than the few hundred bytes a refusal needs, because the
+// embeddings family shares the constant: a 3072-dimension embedding at full
+// float precision runs past 60 KiB, so a tighter cap would truncate legitimate
+// answers from exactly the models being adjudicated.
 //
 // The value is not load-bearing for correctness in either direction, which is
-// the point of judgeProbeFailure's explicit length check: a truncated body
-// postpones because it was measured to be truncated, not because 1 MiB happens
-// to sit above the classifier's own 10 000-character window.
+// what judgeProbeFailure's explicit length check is for: a truncated body
+// postpones because it was measured to be truncated.
 const goneProbeMaxBody = 1 << 20
 
 // goneProbeTimeout bounds the pre-retirement probe. It runs on the detached
 // disable goroutine, so nothing on the request path is waiting on it.
 //
-// probeModel does NOT apply this itself. Taking the context from the caller is
-// what lets a test drive the real code with a deadline measured in
-// milliseconds, and it keeps the production budget at the single call site that
-// owns the decision rather than buried in the helper.
+// probeModel does NOT apply this itself. Taking the context from the caller lets
+// a test drive the real code with a millisecond deadline, and keeps the
+// production budget at the call site that owns the decision.
 const goneProbeTimeout = 30 * time.Second
 
 // The two upstream surfaces a retirement probe is allowed to touch. Both are
@@ -77,8 +68,7 @@ const (
 // Three-way, and the zero value is the one that matters: every path that cannot
 // establish anything — an unprobeable family, a request that would not build, a
 // connection that never landed, a deadline, a body that will not parse — lands
-// on probeInconclusive, and the caller postpones the retirement on it. Nothing
-// is claimed from evidence that was never gathered.
+// on probeInconclusive, and the caller postpones the retirement on it.
 type probeVerdict int
 
 const (
@@ -90,18 +80,13 @@ const (
 	probeServed
 )
 
-// String names the verdict for logs. The call sites pass the result of this
-// rather than the value itself: debuglog's arguments are evaluated eagerly, so
-// an explicit conversion keeps the rendered name independent of whether the
-// Debug scope happens to be enabled.
+// String names the verdict for logs. Call sites pass the result of this rather
+// than the value: debuglog's arguments are evaluated eagerly, so an explicit
+// conversion keeps the rendered name independent of whether Debug is enabled.
 //
-// probeInconclusive has its own case and the default renders the number, which
-// is the opposite of the obvious arrangement and is the point. noteModelGone's
-// default arm exists specifically to surface a verdict nobody has handled, and
-// it logs this string; folding unknown values into "inconclusive" meant the one
-// diagnostic designed to name the unknown value was guaranteed to misname it,
-// and a fourth verdict would have been indistinguishable in the logs from the
-// zero value it is not.
+// The default renders the number rather than folding into "inconclusive",
+// because noteModelGone's default arm exists to surface a verdict nobody has
+// handled and logs this string.
 func (v probeVerdict) String() string {
 	switch v {
 	case probeInconclusive:
@@ -119,30 +104,22 @@ func (v probeVerdict) String() string {
 // whether a model of this endpoint family is still served, and whether one
 // exists at all.
 //
-// Only chat and embeddings qualify, and the exclusions are the point rather
-// than an omission. A chat probe against an image, TTS or STT model fails for
-// reasons that have nothing to do with the model being retired, and that
-// failure would read as confirmation of the retirement it was supposed to
-// adjudicate — the probe would manufacture exactly the wrong answer. Image,
-// speech and transcription probes also cost real money and real seconds per
-// call, which a background verification must not spend.
+// Only chat and embeddings qualify, and the exclusions are the point. A chat
+// probe against an image, TTS or STT model fails for reasons that have nothing
+// to do with retirement, and that failure would read as confirmation of the
+// retirement it was supposed to adjudicate. Those probes also cost real money
+// and real seconds per call.
 //
-// Rerank is excluded on a different and weaker ground, recorded here so nobody
-// reads it as belonging to the sentence above. A /rerank call with one document
-// is about as cheap as the embeddings call this function already allows, so the
-// cost argument does not apply to it. It is excluded because a rerank probe
-// would need its own request body, its own answer shape and its own "did the
-// model actually produce something" judgement, none of which exist yet and none
-// of which anything has asked for — and shipping an unexercised third judgement
-// path is a worse trade than the consequence, which is that rerank models are
-// never auto-retired and simply stay enabled until an operator disables one.
-// This is a deliberately conservative choice and the cheap one to reverse:
-// adding the family here plus a body and a content check is all it takes.
+// Rerank is excluded on weaker grounds: a /rerank call with one document is as
+// cheap as an embeddings call, but it would need its own request body, answer
+// shape and content judgement, and shipping an unexercised third judgement path
+// is a worse trade than leaving rerank models enabled until an operator disables
+// one. Cheap to reverse: add the family here plus a body and a content check.
 //
-// So where a family cannot be probed cheaply, the correct outcome is to not
-// auto-retire that family at all. The alternative — falling back to trusting
-// the prose classifier — would leave the retirement running unsupervised
-// precisely in the corner where it is least observed and least often right.
+// Where a family cannot be probed cheaply, the correct outcome is to not
+// auto-retire that family at all. Falling back to the prose classifier would
+// leave the retirement running unsupervised precisely where it is least
+// observed.
 //
 // The empty string and any unknown family are unprobeable for the same reason:
 // nothing can be substantiated about them, so nothing is claimed.
@@ -160,10 +137,9 @@ func probeEndpointForFamily(endpointType string) (endpoint string, ok bool) {
 // cappedBody is a response body bounded by goneProbeMaxBody whose Close still
 // closes the transport's own body underneath.
 //
-// The Closer half is the point. Wrapping in an io.NopCloser would leave nothing
-// holding the real body, and every reader downstream — including the two in
-// other packages — would then be reading through a cap while the connection it
-// belongs to leaked.
+// The Closer half is the point: an io.NopCloser would leave nothing holding the
+// real body, and every reader downstream — including the two in other packages —
+// would read through a cap while the connection leaked.
 type cappedBody struct {
 	io.Reader
 	io.Closer
@@ -187,60 +163,37 @@ type probeEmbeddingsRequest struct {
 // newProbeState builds the synthetic requestState the probe hands to the real
 // egress builder.
 //
-// The state is synthetic but the path is not. Everything the builder derives
-// from it — provider-type detection, the target-URL rules, the OpenAI-Responses
-// and vertex-express Gemini dialect re-routes, the param rewrite — has to run,
-// because a bespoke request builder would be able to succeed where real traffic
-// fails and a probe that is easier to satisfy than the requests it adjudicates
-// is worse than no probe at all.
+// The state is synthetic but the path is not. Provider-type detection, the
+// target-URL rules, the Responses and vertex-express Gemini re-routes and the
+// param rewrite all have to run, because a bespoke request builder could succeed
+// where real traffic fails.
 //
-// One divergence from that, named rather than left to be discovered. anthropicIn
-// and anthropicRawBody are NOT set, so an endpointTypeMessages candidate on an
-// anthropic-type provider is probed with an OpenAI chat body at
-// {base}/v1/chat/completions, whereas the traffic that nominated it went out
-// natively at /v1/messages (see anthropic_native.go). Setting them is not
-// available here: anthropicRawBody is the CLIENT's /v1/messages body, and a
-// probe has no client, so the native path would have to be handed a body this
-// function invented — which is the bespoke request the paragraph above rules
-// out, on the one dialect where it is easiest to get subtly wrong.
+// Three fields are load-bearing by their absence:
 //
-// It is acceptable because of which way the difference can fail. Anthropic's
-// compat layer serves the same model catalog, so a live model answers on both
-// surfaces and a retired one is refused by name on both. If the compat layer
-// itself is the problem — not enabled, differently gated, differently shaped —
-// the probe draws an error that is not a retirement, classifies as such, and
-// returns probeInconclusive. The retirement is postponed, never manufactured,
-// which is the direction every unproven case in this file already takes.
+//   - anthropicIn/anthropicRawBody are NOT set, so an endpointTypeMessages
+//     candidate on an anthropic provider is probed with an OpenAI chat body at
+//     {base}/v1/chat/completions rather than natively at /v1/messages.
+//     anthropicRawBody is the CLIENT's Messages body and a probe has no client,
+//     so the native path would have to be handed an invented one. Anthropic's
+//     compat layer serves the same catalog, so a live model answers on both
+//     surfaces and a retired one is refused by name on both; if the compat layer
+//     itself is the problem the probe draws an error that is not a retirement and
+//     returns probeInconclusive.
+//   - endpointPath is left empty for the chat families even though
+//     probeEndpointForFamily names "/chat/completions". Empty IS chat to the
+//     builder, while a non-empty endpointPath means "this is a multimodal
+//     endpoint" and both dialect re-routes refuse to fire when it is set.
+//   - reqModel is left empty. It is the model the CLIENT asked for, and the
+//     builder's rewrite gate is `st.reqModel != candidate.model.ModelID || ...`
+//     (proxy_failover.go), so naming the upstream model here closes every
+//     disjunct and paramrewrite.BuildUpstreamBody never runs. The probe would
+//     then skip the learned renames real traffic gets — an OpenAI reasoning model
+//     that has learned max_tokens -> max_completion_tokens would be probed with
+//     the very parameter it rejects and answer 400 forever.
 //
-// endpointPath is deliberately left empty for the chat families even though
-// probeEndpointForFamily names "/chat/completions". Empty IS chat to the
-// builder (it defaults to exactly that path), while a non-empty endpointPath is
-// how the pipeline says "this is one of the multimodal endpoints" — and both
-// dialect re-routes refuse to fire when it is set. Spelling the default out
-// would therefore switch off the re-routes this function exists to go through,
-// and a vertex-express candidate would be probed with an OpenAI body against a
-// path Google does not serve.
-//
-// reqModel is deliberately left EMPTY, and that is load-bearing for the same
-// reason. It is the model the CLIENT asked for, and a probe has no client, so
-// there is no alias to record — but the builder's rewrite gate is
-// `st.reqModel != candidate.model.ModelID || ...` (proxy_failover.go), so
-// naming the upstream model here closes every disjunct and
-// paramrewrite.BuildUpstreamBody never runs. The probe would then skip the
-// learned renames and strips that real traffic to the same candidate gets:
-// an OpenAI reasoning model that has learned max_tokens -> max_completion_tokens
-// would be probed with the very parameter it rejects, answer 400, classify as
-// not-a-retirement and return inconclusive forever. That is the exact inversion
-// this function exists to prevent — the probe failing where real traffic
-// succeeds — and it would land on the reasoning family the 64-token budget was
-// chosen for. Empty opens the gate honestly, and BuildUpstreamBody then writes
-// the resolved id into the body itself.
-//
-// The marshal errors are discarded rather than propagated, and that is a
-// statement about the inputs rather than a shortcut: both payloads are fixed
-// structs of strings and ints, so encoding/json has no failure to report here.
-// Threading an error nothing can produce would add a branch no test could ever
-// reach.
+// The marshal errors are discarded because both payloads are fixed structs of
+// strings and ints: encoding/json has no failure to report, and threading an
+// error nothing can produce would add a branch no test could reach.
 func newProbeState(candidate modelCandidate, endpointType, endpoint string) *requestState {
 	modelID := candidate.model.ModelID
 	st := &requestState{
@@ -258,15 +211,14 @@ func newProbeState(candidate modelCandidate, endpointType, endpoint string) *req
 		st.endpointPath = endpoint
 		// The multimodal endpoints own their body rewrite through
 		// makeUpstreamBody (see multimodal.go); the probe does the same, so the
-		// id in the body is the one the builder resolved rather than the one
-		// this function happened to be handed.
+		// id in the body is the one the builder resolved.
 		st.makeUpstreamBody = func(resolvedModelID string) ([]byte, string, error) {
 			resolved, _ := json.Marshal(probeEmbeddingsRequest{Model: resolvedModelID, Input: "hi"})
 			return resolved, "application/json", nil
 		}
-		// bodyBytes is set to the same payload even though makeUpstreamBody
-		// supersedes it: several things downstream of the builder read the
-		// request body, and none of them should be looking at an empty one.
+		// Set to the same payload even though makeUpstreamBody supersedes it:
+		// several things downstream of the builder read the request body, and
+		// none of them should be looking at an empty one.
 		st.bodyBytes = body
 		return st
 	}
@@ -282,74 +234,54 @@ func newProbeState(candidate modelCandidate, endpointType, endpoint string) *req
 
 // probeModel asks the provider directly whether it still serves this model.
 //
-// It exists because the retirement verdict was being drawn from provider prose,
-// and prose drifts. classifyUpstreamError reads the words a provider chose on
-// the day it wrote them; this reads what the provider actually does when asked
-// for the model. The probe is the adjudicator, the classifier is only what
-// nominates a model for adjudication.
+// classifyUpstreamError reads the words a provider chose on the day it wrote
+// them; this reads what the provider actually does when asked for the model. The
+// probe is the adjudicator, the classifier only nominates.
 //
 // It is an upstream call the operator did not make, so it is deliberately NOT
 // run through doUpstream: no circuit-breaker outcome, no request log, no
 // metering, no rate-limit accounting. Charging a provider's breaker for a
-// verification request would let the verification itself take a healthy
-// provider out of routing, and metering it would bill an operator for traffic
-// they never sent.
+// verification would let the verification take a healthy provider out of
+// routing, and metering it would bill an operator for traffic they never sent.
 //
 // The caller owns the deadline (see goneProbeTimeout) and the decision; this
 // returns evidence only.
 func (h *Handler) probeModel(ctx context.Context, candidate modelCandidate, endpointType string) probeVerdict {
 	endpoint, ok := probeEndpointForFamily(endpointType)
 	if !ok {
-		// Defensive: the caller is expected to gate on the family before
-		// spending a request. Reaching here means it did not, and the honest
-		// answer is still that nothing was established.
+		// Defensive: the caller gates on the family before spending a request.
+		// Reaching here means it did not, and the honest answer is still that
+		// nothing was established.
 		return probeInconclusive
 	}
-	// Kept although probeForRetirement now checks first, because this function
-	// takes a candidate and dereferences it and must be able to say so on its
-	// own terms rather than by the grace of its only production caller. It is
-	// reachable and exercised: the tests drive probeModel directly, which is
-	// also how any future caller would.
+	// Kept although probeForRetirement checks first, because this function takes
+	// a candidate and dereferences it. The tests drive probeModel directly, which
+	// is also how any future caller would.
 	if candidate.model == nil || candidate.provider == nil {
 		return probeInconclusive
 	}
 
-	// Skipping the breaker's ACCOUNTING is argued at length above. Skipping its
-	// CHECK would be a separate decision and is not one this makes: if the
-	// gateway has already sidelined this provider, a probe to it is a
-	// guaranteed-wasted call to a host nothing else is being sent to, and its
-	// answer would be inconclusive anyway. So the breaker is consulted, and
-	// consulted through the one entry point that records nothing.
+	// Skipping the breaker's ACCOUNTING is argued above; skipping its CHECK is a
+	// separate decision and not one this makes. If the gateway has already
+	// sidelined this provider, a probe to it is a guaranteed-wasted call whose
+	// answer would be inconclusive anyway.
 	//
-	// GetState rather than IsOpen, and the difference is the whole reason this
-	// check is safe to make. IsOpen is the routing gate: it takes a write lock
-	// and performs the Open→HalfOpen transition, which spends the provider's
-	// one half-open trial slot on a request the operator did not make and would
-	// let a verification decide a provider's fate. GetState takes a read lock
-	// and derives the same logical state without touching the circuit, so an
-	// open circuit past its cooldown already reads as half-open here — which is
-	// exactly the semantics wanted: postpone only while the breaker is actually
-	// holding traffic back, proceed the moment it is ready to be probed again.
+	// GetState rather than IsOpen, and the difference is what makes the check
+	// safe. IsOpen is the routing gate: it takes a write lock and performs the
+	// Open->HalfOpen transition, spending the provider's one half-open trial slot
+	// on a request the operator did not make. GetState takes a read lock and
+	// derives the same logical state without touching the circuit, so an open
+	// circuit past its cooldown already reads as half-open here. A nil breaker
+	// means nobody has an opinion, which is not a reason to postpone.
 	//
-	// A nil breaker means nobody has an opinion, which is not a reason to
-	// postpone.
-	//
-	// This gate is on the breaker alone, unlike every other breaker consultation
-	// in the proxy (resolve.go's cbEnabled, the record sites' st.circuitBreakerEnabled),
-	// which also checks the circuit_breaker_enabled setting before consulting the
-	// breaker at all. That is a known asymmetry, not an oversight: reading the
-	// setting here means calling h.settingsRepo.GetBool, and h.settingsRepo is nil
-	// on the path every probe unit test in this file exercises (newProbeHandler
-	// builds a bare *Handler with no settings repository, deliberately, so these
-	// tests do not need a database). Wiring a live settings repository through
-	// that fixture to read one flag is a cost this check does not justify, because
-	// the failure mode of skipping it is bounded and always in the safe direction:
-	// an operator who disables the breaker after a provider's circuit has already
-	// opened sees that provider's probes deferred until the breaker's own cooldown
-	// clears rather than immediately, and a deferred probe can only leave a model
-	// enabled longer, never retire it early or wrongly. If a later change threads a
-	// testable settings source through this path for some other reason, honoring
-	// the setting here becomes free and should be done then.
+	// Unlike every other breaker consultation in the proxy this gate does not
+	// also check the circuit_breaker_enabled setting, because reading it means
+	// calling h.settingsRepo.GetBool and h.settingsRepo is nil on the path the
+	// probe unit tests exercise. The failure mode is bounded and safe: an
+	// operator who disables the breaker after a circuit has opened sees that
+	// provider's probes deferred until the breaker's own cooldown clears, and a
+	// deferred probe can only leave a model enabled longer. If a later change
+	// threads a testable settings source through here, honor the setting then.
 	if h.circuitBreaker != nil && h.circuitBreaker.GetState(candidate.provider.ID) == failover.StateOpen {
 		debuglog.Debug("proxy: retirement probe skipped, the provider's circuit is open", "endpoint", endpointType, "provider", candidate.provider.Name, "model", candidate.model.ModelID, "verdict", probeInconclusive.String())
 		return probeInconclusive
@@ -367,17 +299,13 @@ func (h *Handler) probeModel(ctx context.Context, candidate modelCandidate, endp
 	// gets: a provider that redirects must not be able to walk this request's
 	// credential to another host just because it arrived off the request path.
 	//
-	// No transport, no probe. The nil check has to exist — upstreamTransport is a
-	// concrete *http.Transport, so assigning a nil one into the RoundTripper
-	// field produces a non-nil interface holding a nil pointer, and net/http does
-	// not fall back to DefaultTransport, it panics inside RoundTrip, on the
-	// detached disable goroutine — but leaving the field unset instead is not the
-	// harmless half of that choice. An unset Transport IS http.DefaultTransport,
-	// which carries no DialContext, so the SafeDialer's guard against a provider
-	// URL resolving into the gateway's own network would be silently absent for
-	// exactly the request nobody is watching. Every other outbound site in this
-	// package assigns the shared transport unconditionally; a probe that cannot
-	// have it postpones, which costs nothing in a process that always sets it.
+	// The nil check has to exist — upstreamTransport is a concrete
+	// *http.Transport, so assigning a nil one produces a non-nil interface
+	// holding a nil pointer and net/http panics inside RoundTrip — and leaving
+	// the field unset instead is not the harmless alternative: an unset Transport
+	// IS http.DefaultTransport, which carries no DialContext, so the SafeDialer's
+	// guard against a provider URL resolving into the gateway's own network would
+	// be silently absent for exactly the request nobody is watching.
 	if h.upstreamTransport == nil {
 		debuglog.Debug("proxy: retirement probe has no upstream transport to make a guarded request with", "endpoint", endpointType, "provider", candidate.provider.Name, "model", candidate.model.ModelID, "verdict", probeInconclusive.String())
 		return probeInconclusive
@@ -391,24 +319,17 @@ func (h *Handler) probeModel(ctx context.Context, candidate modelCandidate, endp
 	resp, err := client.Do(req)
 	if err != nil {
 		// A connection that never landed, a DNS failure or an expired deadline
-		// says nothing about the model. This is the branch that keeps a network
-		// problem on the gateway's side from retiring a provider's whole
-		// catalog.
+		// says nothing about the model. This branch is what keeps a network
+		// problem on the gateway's side from retiring a provider's whole catalog.
 		debuglog.Debug("proxy: retirement probe did not reach the provider", "endpoint", endpointType, "provider", candidate.provider.Name, "model", candidate.model.ModelID, "verdict", probeInconclusive.String(), "error", err)
 		return probeInconclusive
 	}
 	// The cap goes on the body here, once, and everything past this line reads
-	// through it. Applying it at the read sites instead would have missed three
-	// of them: remapMiniMaxBusinessError and both dialect translators call
-	// io.ReadAll(resp.Body) inside packages that know nothing about this budget,
-	// so a MiniMax, vertex-express or Responses candidate answering a 200 with a
-	// multi-gigabyte body would have been read into memory in full.
-	//
-	// rawBody is held separately because resp.Body is replaced here and replaced
-	// again by remapMiniMaxBusinessError, and the drain below has to read the
-	// transport's own body rather than whichever wrapper is in the field by then.
-	// The close can stay on the field precisely because cappedBody passes Close
-	// through — see cappedBody for why the obvious io.NopCloser cannot.
+	// through it. rawBody is held separately because resp.Body is replaced here
+	// and replaced again by remapMiniMaxBusinessError, and the drain below has to
+	// read the transport's own body rather than whichever wrapper is in the field
+	// by then. The close can stay on the field because cappedBody passes Close
+	// through.
 	//
 	// One byte past the cap, so a truncated body can be recognised as truncated:
 	// io.ReadAll reports no error when a LimitReader runs out, so length is the
@@ -418,30 +339,23 @@ func (h *Handler) probeModel(ctx context.Context, candidate modelCandidate, endp
 	defer func() {
 		// Drain before closing so the transport can reuse the connection, and
 		// drain no more than the judgement was willing to read. A body past
-		// goneProbeMaxBody costs the connection its reuse and nothing else,
-		// which is the cheaper of the two ways to be wrong here.
+		// goneProbeMaxBody costs the connection its reuse and nothing else.
 		//
-		// "No more than the judgement read" bounds this copy, not the total: the
-		// judgement has already taken its own goneProbeMaxBody out of rawBody, so
-		// a large answer is pulled off the socket twice over. What the constant
-		// promises is memory, and that still holds — what is retained is the
-		// judgement's read, while this streams to io.Discard through one 32 KiB
-		// buffer. Bytes off a socket on a detached goroutine, four at a time per
-		// provider, are not the resource being bounded.
+		// This bounds the copy, not the total: the judgement has already taken
+		// its own goneProbeMaxBody, so a large answer is pulled off the socket
+		// twice. What the constant promises is memory, and that still holds —
+		// this streams to io.Discard through one 32 KiB buffer.
 		//
-		// It is a plain-path drain and knowingly a no-op elsewhere: MiniMax and
-		// both dialect translators read the body to EOF and CLOSE it themselves,
-		// so on those candidates this copy reads an already-closed body and
-		// discards the error. Nothing is lost by that. A body those paths could
+		// Knowingly a no-op on some paths: MiniMax and both dialect translators
+		// read the body to EOF and CLOSE it themselves, so there this copy reads
+		// an already-closed body and discards the error. A body those paths could
 		// finish was already drained by them, and one they could not finish is
-		// past the cap, where the connection is forfeit either way. The branch it
-		// would take to skip the copy would cost more to read than the copy costs
-		// to run.
+		// past the cap, where the connection is forfeit either way.
 		_, _ = io.Copy(io.Discard, io.LimitReader(rawBody, goneProbeMaxBody))
-		// Whatever is in the field: the cap above on every path, or the
-		// NopCloser remapMiniMaxBusinessError leaves behind — and that path has
-		// already closed the cap, and through it the transport's own body. The
-		// real body is closed exactly once either way.
+		// Whatever is in the field: the cap above on every path, or the NopCloser
+		// remapMiniMaxBusinessError leaves behind — and that path has already
+		// closed the cap, and through it the transport's own body. The real body
+		// is closed exactly once either way.
 		_ = resp.Body.Close()
 	}()
 
@@ -461,21 +375,17 @@ func (h *Handler) probeModel(ctx context.Context, candidate modelCandidate, endp
 // and that single line is what keeps a provider incident from becoming a mass
 // retirement: 429s, 402s, quota and entitlement failures, bad-request verdicts
 // and every 5xx are things that happen to models that are alive. Deliberately
-// no status-code shortcut around the classifier here — a bare "404 means gone"
-// would retire every model behind a misconfigured base URL.
+// no status-code shortcut around the classifier — a bare "404 means gone" would
+// retire every model behind a misconfigured base URL.
 func judgeProbeFailure(resp *http.Response, candidate modelCandidate, endpointType string) probeVerdict {
 	// One byte past the cap on purpose. This is the one place in this file where
 	// a body we did not receive in full could RETIRE a model: a surviving prefix
-	// that happens to name the model beside a gone-phrase classifies exactly like
-	// a real refusal, and the classifier only ever sees the first 10 000
-	// characters, so it cannot tell that the rest went missing.
+	// that names the model beside a gone-phrase classifies exactly like a real
+	// refusal, and the classifier only sees the first 10 000 characters.
 	//
-	// Reading exactly goneProbeMaxBody could not tell either. io.ReadAll returns
-	// a nil error when a LimitReader is exhausted — that is not a read failure,
-	// it is the reader ending — so the err branch below catches genuine transport
-	// failures and never catches truncation. The extra byte is what turns "we hit
-	// the cap" into something observable, and probeModel sizes its own wrapper to
-	// let it through.
+	// Reading exactly goneProbeMaxBody could not tell either: io.ReadAll returns
+	// a nil error when a LimitReader is exhausted, so the err branch below catches
+	// genuine transport failures and never catches truncation.
 	body, err := io.ReadAll(io.LimitReader(resp.Body, goneProbeMaxBody+1))
 	switch {
 	case err != nil:
@@ -503,31 +413,25 @@ func judgeProbeFailure(resp *http.Response, candidate modelCandidate, endpointTy
 
 // judgeProbeSuccess turns a 200 probe response into a verdict.
 //
-// A 200 that carries nothing is NOT a success. A stream can open, emit nothing
-// and end cleanly, and crediting that is the same bug an earlier review round
-// caught on the streaming path (see producedOutput in model_gone.go).
-// It is not a refusal either — the provider did not say the model is gone — so
-// an empty answer postpones like every other unproven case.
+// A 200 that carries nothing is NOT a success: a stream can open, emit nothing
+// and end cleanly. It is not a refusal either — the provider did not say the
+// model is gone — so an empty answer postpones like every other unproven case.
 func judgeProbeSuccess(resp *http.Response, st *requestState, candidate modelCandidate, endpointType string) probeVerdict {
-	// The dialect re-routes answer in their own wire format. Translate first,
-	// for the same reason attemptCandidate does: everything downstream judges
-	// the chat-completions shape. An answer that cannot be translated is not a
-	// refusal, so it postpones like every other unreadable result.
+	// The dialect re-routes answer in their own wire format. Translate first, for
+	// the same reason attemptCandidate does: everything downstream judges the
+	// chat-completions shape. An answer that cannot be translated is not a
+	// refusal, so it postpones.
 	if err := translateProbeDialect(resp, st, candidate.model.ModelID); err != nil {
 		debuglog.Debug("proxy: retirement probe could not read the provider's dialect", "endpoint", endpointType, "provider", candidate.provider.Name, "model", candidate.model.ModelID, "error", err)
 		return probeInconclusive
 	}
 
-	// Both the read error and the cap are ignored here, which is the opposite of
-	// the care judgeProbeFailure takes over the same call. The asymmetry is in
-	// what an incomplete body can produce, not in how much attention the two
-	// paths deserve. There, a surviving prefix naming the model beside a
-	// gone-phrase would classify as a refusal and RETIRE, so it has to be
-	// detected; here, the worst a partial body can do is fail to parse
-	// (probeDeliveredContent returns false, and the probe postpones) or carry
-	// content, which can only ever PREVENT a disable. Neither outcome can retire
-	// a model, so the branches would postpone exactly where the code already
-	// postpones.
+	// Both the read error and the cap are ignored here, unlike in
+	// judgeProbeFailure, because of what an incomplete body can produce. There, a
+	// surviving prefix naming the model beside a gone-phrase would RETIRE, so it
+	// has to be detected; here the worst a partial body can do is fail to parse
+	// (probeDeliveredContent returns false and the probe postpones) or carry
+	// content, which can only PREVENT a disable.
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, goneProbeMaxBody))
 	verdict := probeInconclusive
 	if probeDeliveredContent(endpointType, body) {
@@ -537,25 +441,21 @@ func judgeProbeSuccess(resp *http.Response, st *requestState, candidate modelCan
 	return verdict
 }
 
-// translateProbeDialect converts a dialect answer back to the
-// chat-completions shape the judgement below understands, mirroring what
-// attemptCandidate does on the served path. Which flag is set was decided by
-// buildCandidateRequest, so this stays correct as the re-route rules move.
+// translateProbeDialect converts a dialect answer back to the chat-completions
+// shape the judgement understands, mirroring what attemptCandidate does on the
+// served path. Which flag is set was decided by buildCandidateRequest, so this
+// stays correct as the re-route rules move.
 //
 // Only the non-streaming translators are reachable: the probe never asks for a
-// stream, so there is no adapter to install.
-//
-// The Responses case cannot fire as the probe body stands — that re-route also
-// requires tools in the request, and the probe sends none — but it is kept
-// rather than dropped, because the flag is set by buildCandidateRequest and not
-// by anything here. If the re-route rules widen, a probe that skipped the
-// translation would read a Responses object as an empty chat completion and
-// postpone every retirement for those models forever, silently.
+// stream. The Responses case cannot fire as the probe body stands — that
+// re-route also requires tools in the request — but it is kept because the flag
+// is set by buildCandidateRequest and not by anything here. If the re-route rules
+// widen, a probe that skipped the translation would read a Responses object as
+// an empty chat completion and postpone those retirements forever, silently.
 func translateProbeDialect(resp *http.Response, st *requestState, modelID string) error {
-	// The upstream model id, NOT st.reqModel: the served path passes the name
-	// the client asked for, and a probe has no client (st.reqModel is empty by
-	// design, see newProbeState). The synthesized response is named after the
-	// model actually asked for, which is the only name this request ever had.
+	// The upstream model id, NOT st.reqModel: the served path passes the name the
+	// client asked for, and a probe has no client (st.reqModel is empty by design,
+	// see newProbeState).
 	switch {
 	case st.responsesAttempt:
 		return translateResponsesResponseBody(resp, modelID)
@@ -569,29 +469,19 @@ func translateProbeDialect(resp *http.Response, st *requestState, modelID string
 // probeDeliveredContent reports whether a 200 probe response actually carried
 // something the model produced.
 //
-// The chat side accepts visible content, reasoning content and tool calls
-// because all three are the model working, and falls back to the reported
-// completion tokens because a reasoning model can legitimately spend the whole
-// budget thinking and return an empty visible answer. Without that fallback the
-// probe would call a working reasoning model empty and postpone forever.
-//
-// A body that will not parse returns false, which postpones rather than
-// retires: an unreadable answer is not the provider saying the model is gone.
+// A body that will not parse returns false, which postpones rather than retires:
+// an unreadable answer is not the provider saying the model is gone.
 func probeDeliveredContent(endpointType string, body []byte) bool {
 	if endpointType == endpointTypeEmbeddings {
 		// The vector is left undecoded on purpose. Typing it as []float64 made
 		// the whole document fail to parse when a provider answered with
 		// base64-encoded embeddings — a JSON string where the struct wanted an
-		// array — so a live embeddings model came back inconclusive, its streak
-		// was never parked, and every refusal past the cooldown bought another
-		// upstream request indefinitely. It is the same shape of mistake the
-		// chat side made by accepting only a string content.
+		// array — so a live embeddings model came back inconclusive forever.
 		//
 		// Raw and non-empty is still a real bar: an absent vector, a null, an
 		// empty array and an empty string are all "the provider answered with
-		// nothing", which is not evidence the model is served. What it stops
-		// doing is judging the ENCODING, which is the provider's choice and says
-		// nothing about whether the model exists.
+		// nothing". What it stops doing is judging the ENCODING, which is the
+		// provider's choice and says nothing about whether the model exists.
 		var out struct {
 			Data []struct {
 				Embedding json.RawMessage `json:"embedding"`
@@ -614,10 +504,8 @@ func probeDeliveredContent(endpointType string, body []byte) bool {
 // null, an array with no elements, or a string with no characters.
 //
 // Structural rather than a comparison against the spellings encoding/json
-// happens to emit. `[]` and `[ ]` are the same empty array, and a provider whose
-// encoder pads is not a provider whose model answered — the exact-string version
-// of this read `[ ]` as content and reported a served model on an answer that
-// carried none, which is the one thing the check exists to reject.
+// happens to emit. `[]` and `[ ]` are the same empty array, and the
+// exact-string version of this read `[ ]` as content.
 func jsonValueIsEmpty(raw json.RawMessage) bool {
 	v := bytes.TrimSpace(raw)
 	if len(v) == 0 || bytes.Equal(v, []byte("null")) {
@@ -636,22 +524,21 @@ func jsonValueIsEmpty(raw json.RawMessage) bool {
 // the same shape for the same reason: a 200 that carries nothing is not the
 // model answering, and crediting one would let a provider intermittently
 // returning an empty completion reset a retired model's strike count forever.
-// One judgement rather than two, so the probe and the traffic cannot drift into
-// disagreeing about what an answer is.
+// One judgement rather than two, so the probe and the traffic cannot drift.
+//
+// The completion-token fallback is what admits a reasoning model that
+// legitimately spends the whole budget thinking and returns an empty visible
+// answer.
 func chatAnswerCarriesContent(out ChatCompletionResponse) bool {
 	for _, choice := range out.Choices {
 		if s, ok := choice.Message.Content.(string); ok && s != "" {
 			return true
 		}
 		// Content is `any` because a provider may answer with content PARTS
-		// rather than a string. Judging only the string shape would call such a
-		// model empty: the probe would return inconclusive on a model that is
-		// demonstrably alive, the streak would never be parked, and every fresh
-		// refusal past the cooldown would buy another upstream request for as
-		// long as the disagreement lasted. Non-empty is the whole test — the
-		// parts are the model's output whatever their shape, and reaching into
-		// them to find a non-empty text field would be judging providers' part
-		// vocabularies from here.
+		// rather than a string. Non-empty is the whole test — the parts are the
+		// model's output whatever their shape, and reaching into them to find a
+		// non-empty text field would be judging providers' part vocabularies from
+		// here.
 		if parts, ok := choice.Message.Content.([]any); ok && len(parts) > 0 {
 			return true
 		}

--- a/internal/proxy/model_probe.go
+++ b/internal/proxy/model_probe.go
@@ -600,11 +600,7 @@ func probeDeliveredContent(endpointType string, body []byte) bool {
 		if json.Unmarshal(body, &out) != nil || len(out.Data) == 0 {
 			return false
 		}
-		switch string(bytes.TrimSpace(out.Data[0].Embedding)) {
-		case "", "null", "[]", `""`:
-			return false
-		}
-		return true
+		return !jsonValueIsEmpty(out.Data[0].Embedding)
 	}
 
 	var out ChatCompletionResponse
@@ -612,6 +608,25 @@ func probeDeliveredContent(endpointType string, body []byte) bool {
 		return false
 	}
 	return chatAnswerCarriesContent(out)
+}
+
+// jsonValueIsEmpty reports whether a raw JSON value carries nothing: absent,
+// null, an array with no elements, or a string with no characters.
+//
+// Structural rather than a comparison against the spellings encoding/json
+// happens to emit. `[]` and `[ ]` are the same empty array, and a provider whose
+// encoder pads is not a provider whose model answered — the exact-string version
+// of this read `[ ]` as content and reported a served model on an answer that
+// carried none, which is the one thing the check exists to reject.
+func jsonValueIsEmpty(raw json.RawMessage) bool {
+	v := bytes.TrimSpace(raw)
+	if len(v) == 0 || bytes.Equal(v, []byte("null")) {
+		return true
+	}
+	if len(v) >= 2 && (v[0] == '[' && v[len(v)-1] == ']' || v[0] == '"' && v[len(v)-1] == '"') {
+		return len(bytes.TrimSpace(v[1:len(v)-1])) == 0
+	}
+	return false
 }
 
 // chatAnswerCarriesContent reports whether a decoded chat completion carries

--- a/internal/proxy/model_probe.go
+++ b/internal/proxy/model_probe.go
@@ -304,6 +304,11 @@ func (h *Handler) probeModel(ctx context.Context, candidate modelCandidate, endp
 		// answer is still that nothing was established.
 		return probeInconclusive
 	}
+	// Kept although probeForRetirement now checks first, because this function
+	// takes a candidate and dereferences it and must be able to say so on its
+	// own terms rather than by the grace of its only production caller. It is
+	// reachable and exercised: the tests drive probeModel directly, which is
+	// also how any future caller would.
 	if candidate.model == nil || candidate.provider == nil {
 		return probeInconclusive
 	}

--- a/internal/proxy/model_probe.go
+++ b/internal/proxy/model_probe.go
@@ -132,6 +132,21 @@ type probeEmbeddingsRequest struct {
 // and a vertex-express candidate would be probed with an OpenAI body against a
 // path Google does not serve.
 //
+// reqModel is deliberately left EMPTY, and that is load-bearing for the same
+// reason. It is the model the CLIENT asked for, and a probe has no client, so
+// there is no alias to record — but the builder's rewrite gate is
+// `st.reqModel != candidate.model.ModelID || ...` (proxy_failover.go), so
+// naming the upstream model here closes every disjunct and
+// paramrewrite.BuildUpstreamBody never runs. The probe would then skip the
+// learned renames and strips that real traffic to the same candidate gets:
+// an OpenAI reasoning model that has learned max_tokens -> max_completion_tokens
+// would be probed with the very parameter it rejects, answer 400, classify as
+// not-a-retirement and return inconclusive forever. That is the exact inversion
+// this function exists to prevent — the probe failing where real traffic
+// succeeds — and it would land on the reasoning family the 64-token budget was
+// chosen for. Empty opens the gate honestly, and BuildUpstreamBody then writes
+// the resolved id into the body itself.
+//
 // The marshal errors are discarded rather than propagated, and that is a
 // statement about the inputs rather than a shortcut: both payloads are fixed
 // structs of strings and ints, so encoding/json has no failure to report here.
@@ -140,9 +155,11 @@ type probeEmbeddingsRequest struct {
 func newProbeState(candidate modelCandidate, endpointType, endpoint string) *requestState {
 	modelID := candidate.model.ModelID
 	st := &requestState{
-		reqModel: modelID,
 		logData: &requestLogData{
-			modelID:      modelID,
+			modelID: modelID,
+			// The builder logs the provider on its rewrite-check line; without
+			// this every probe would report an empty one.
+			providerName: candidate.provider.Name,
 			endpointType: endpointType,
 		},
 	}
@@ -264,7 +281,16 @@ func (h *Handler) probeModel(ctx context.Context, candidate modelCandidate, endp
 // no status-code shortcut around the classifier here — a bare "404 means gone"
 // would retire every model behind a misconfigured base URL.
 func judgeProbeFailure(resp *http.Response, candidate modelCandidate, endpointType string) probeVerdict {
-	body, _ := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		// The one place in this file where a discarded read error could RETIRE
+		// a model: a truncated body whose surviving prefix happens to name the
+		// model beside a gone-phrase classifies exactly like a real refusal.
+		// A body we could not finish reading is not the provider saying
+		// anything, so it postpones like every other unproven case.
+		debuglog.Debug("proxy: retirement probe could not read the provider's answer", "endpoint", endpointType, "provider", candidate.provider.Name, "model", candidate.model.ModelID, "status", resp.StatusCode, "verdict", probeInconclusive.String(), "error", err)
+		return probeInconclusive
+	}
 	kind, _ := classifyUpstreamError(resp.StatusCode, util.SanitizeLogBody(string(body), 10000), candidate.model.ModelID)
 
 	verdict := probeInconclusive
@@ -273,7 +299,7 @@ func judgeProbeFailure(resp *http.Response, candidate modelCandidate, endpointTy
 	}
 	// Never the body, never the key: this is a provider response and the
 	// no-content rule applies to it exactly as it does on the request path.
-	debuglog.Debug("proxy: retirement probe refused", "endpoint", endpointType, "provider", candidate.provider.Name, "model", candidate.model.ModelID, "status", resp.StatusCode, "error_kind", string(kind), "verdict", verdict.String())
+	debuglog.Debug("proxy: retirement probe drew an error status", "endpoint", endpointType, "provider", candidate.provider.Name, "model", candidate.model.ModelID, "status", resp.StatusCode, "error_kind", string(kind), "verdict", verdict.String())
 	return verdict
 }
 
@@ -289,7 +315,7 @@ func judgeProbeSuccess(resp *http.Response, st *requestState, candidate modelCan
 	// for the same reason attemptCandidate does: everything downstream judges
 	// the chat-completions shape. An answer that cannot be translated is not a
 	// refusal, so it postpones like every other unreadable result.
-	if err := translateProbeDialect(resp, st); err != nil {
+	if err := translateProbeDialect(resp, st, candidate.model.ModelID); err != nil {
 		debuglog.Debug("proxy: retirement probe could not read the provider's dialect", "endpoint", endpointType, "provider", candidate.provider.Name, "model", candidate.model.ModelID, "error", err)
 		return probeInconclusive
 	}
@@ -317,12 +343,16 @@ func judgeProbeSuccess(resp *http.Response, st *requestState, candidate modelCan
 // by anything here. If the re-route rules widen, a probe that skipped the
 // translation would read a Responses object as an empty chat completion and
 // postpone every retirement for those models forever, silently.
-func translateProbeDialect(resp *http.Response, st *requestState) error {
+func translateProbeDialect(resp *http.Response, st *requestState, modelID string) error {
+	// The upstream model id, NOT st.reqModel: the served path passes the name
+	// the client asked for, and a probe has no client (st.reqModel is empty by
+	// design, see newProbeState). The synthesized response is named after the
+	// model actually asked for, which is the only name this request ever had.
 	switch {
 	case st.responsesAttempt:
-		return translateResponsesResponseBody(resp, st.reqModel)
+		return translateResponsesResponseBody(resp, modelID)
 	case st.geminiAttempt:
-		return translateGeminiResponseBody(resp, st.reqModel)
+		return translateGeminiResponseBody(resp, modelID)
 	default:
 		return nil
 	}

--- a/internal/proxy/model_probe.go
+++ b/internal/proxy/model_probe.go
@@ -408,6 +408,15 @@ func (h *Handler) probeModel(ctx context.Context, candidate modelCandidate, endp
 		// drain no more than the judgement was willing to read. A body past
 		// goneProbeMaxBody costs the connection its reuse and nothing else,
 		// which is the cheaper of the two ways to be wrong here.
+		//
+		// It is a plain-path drain and knowingly a no-op elsewhere: MiniMax and
+		// both dialect translators read the body to EOF and CLOSE it themselves,
+		// so on those candidates this copy reads an already-closed body and
+		// discards the error. Nothing is lost by that. A body those paths could
+		// finish was already drained by them, and one they could not finish is
+		// past the cap, where the connection is forfeit either way. The branch it
+		// would take to skip the copy would cost more to read than the copy costs
+		// to run.
 		_, _ = io.Copy(io.Discard, io.LimitReader(rawBody, goneProbeMaxBody))
 		// Whatever is in the field: the cap above on every path, or the
 		// NopCloser remapMiniMaxBusinessError leaves behind — and that path has

--- a/internal/proxy/model_probe.go
+++ b/internal/proxy/model_probe.go
@@ -421,6 +421,14 @@ func (h *Handler) probeModel(ctx context.Context, candidate modelCandidate, endp
 		// goneProbeMaxBody costs the connection its reuse and nothing else,
 		// which is the cheaper of the two ways to be wrong here.
 		//
+		// "No more than the judgement read" bounds this copy, not the total: the
+		// judgement has already taken its own goneProbeMaxBody out of rawBody, so
+		// a large answer is pulled off the socket twice over. What the constant
+		// promises is memory, and that still holds — what is retained is the
+		// judgement's read, while this streams to io.Discard through one 32 KiB
+		// buffer. Bytes off a socket on a detached goroutine, four at a time per
+		// provider, are not the resource being bounded.
+		//
 		// It is a plain-path drain and knowingly a no-op elsewhere: MiniMax and
 		// both dialect translators read the body to EOF and CLOSE it themselves,
 		// so on those candidates this copy reads an already-closed body and

--- a/internal/proxy/model_probe.go
+++ b/internal/proxy/model_probe.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"io"
@@ -570,15 +571,32 @@ func translateProbeDialect(resp *http.Response, st *requestState, modelID string
 // retires: an unreadable answer is not the provider saying the model is gone.
 func probeDeliveredContent(endpointType string, body []byte) bool {
 	if endpointType == endpointTypeEmbeddings {
+		// The vector is left undecoded on purpose. Typing it as []float64 made
+		// the whole document fail to parse when a provider answered with
+		// base64-encoded embeddings — a JSON string where the struct wanted an
+		// array — so a live embeddings model came back inconclusive, its streak
+		// was never parked, and every refusal past the cooldown bought another
+		// upstream request indefinitely. It is the same shape of mistake the
+		// chat side made by accepting only a string content.
+		//
+		// Raw and non-empty is still a real bar: an absent vector, a null, an
+		// empty array and an empty string are all "the provider answered with
+		// nothing", which is not evidence the model is served. What it stops
+		// doing is judging the ENCODING, which is the provider's choice and says
+		// nothing about whether the model exists.
 		var out struct {
 			Data []struct {
-				Embedding []float64 `json:"embedding"`
+				Embedding json.RawMessage `json:"embedding"`
 			} `json:"data"`
 		}
-		if json.Unmarshal(body, &out) != nil {
+		if json.Unmarshal(body, &out) != nil || len(out.Data) == 0 {
 			return false
 		}
-		return len(out.Data) > 0 && len(out.Data[0].Embedding) > 0
+		switch string(bytes.TrimSpace(out.Data[0].Embedding)) {
+		case "", "null", "[]", `""`:
+			return false
+		}
+		return true
 	}
 
 	var out ChatCompletionResponse

--- a/internal/proxy/model_probe.go
+++ b/internal/proxy/model_probe.go
@@ -306,6 +306,23 @@ func (h *Handler) probeModel(ctx context.Context, candidate modelCandidate, endp
 	//
 	// A nil breaker means nobody has an opinion, which is not a reason to
 	// postpone.
+	//
+	// This gate is on the breaker alone, unlike every other breaker consultation
+	// in the proxy (resolve.go's cbEnabled, the record sites' st.circuitBreakerEnabled),
+	// which also checks the circuit_breaker_enabled setting before consulting the
+	// breaker at all. That is a known asymmetry, not an oversight: reading the
+	// setting here means calling h.settingsRepo.GetBool, and h.settingsRepo is nil
+	// on the path every probe unit test in this file exercises (newProbeHandler
+	// builds a bare *Handler with no settings repository, deliberately, so these
+	// tests do not need a database). Wiring a live settings repository through
+	// that fixture to read one flag is a cost this check does not justify, because
+	// the failure mode of skipping it is bounded and always in the safe direction:
+	// an operator who disables the breaker after a provider's circuit has already
+	// opened sees that provider's probes deferred until the breaker's own cooldown
+	// clears rather than immediately, and a deferred probe can only leave a model
+	// enabled longer, never retire it early or wrongly. If a later change threads a
+	// testable settings source through this path for some other reason, honoring
+	// the setting here becomes free and should be done then.
 	if h.circuitBreaker != nil && h.circuitBreaker.GetState(candidate.provider.ID) == failover.StateOpen {
 		debuglog.Debug("proxy: retirement probe skipped, the provider's circuit is open", "endpoint", endpointType, "provider", candidate.provider.Name, "model", candidate.model.ModelID, "verdict", probeInconclusive.String())
 		return probeInconclusive

--- a/internal/proxy/model_probe_test.go
+++ b/internal/proxy/model_probe_test.go
@@ -497,6 +497,13 @@ func TestProbeDeliveredContent(t *testing.T) {
 		{"reasoning field only", endpointTypeChat, `{"choices":[{"message":{"content":"","reasoning":"thinking"}}]}`, true},
 		{"tool calls only", endpointTypeChat, `{"choices":[{"message":{"content":"","tool_calls":[{"id":"c1","type":"function","function":{"name":"f","arguments":"{}"}}]}}]}`, true},
 		{"completion tokens only", endpointTypeChat, `{"choices":[],"usage":{"completion_tokens":7}}`, true},
+		// Content is `any` on the wire: a provider may answer with content parts
+		// instead of a string. Judging only the string shape calls such a model
+		// empty, and the probe then returns inconclusive on a model that is
+		// demonstrably alive — the streak is never parked, and every fresh
+		// refusal past the cooldown buys another upstream request indefinitely.
+		{"content parts", endpointTypeChat, `{"choices":[{"message":{"content":[{"type":"text","text":"Hi"}]}}]}`, true},
+		{"empty content parts", endpointTypeChat, `{"choices":[{"message":{"content":[]}}]}`, false},
 		{"nothing at all", endpointTypeChat, `{"choices":[]}`, false},
 		{"unparseable", endpointTypeChat, `<html>502 Bad Gateway</html>`, false},
 		{"embedding vector", endpointTypeEmbeddings, `{"data":[{"embedding":[0.5]}]}`, true},

--- a/internal/proxy/model_probe_test.go
+++ b/internal/proxy/model_probe_test.go
@@ -1,0 +1,490 @@
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/hugalafutro/model-hotel/internal/model"
+	"github.com/hugalafutro/model-hotel/internal/provider"
+)
+
+// probeAPIKey is the credential the fake provider expects to see. The probe
+// runs off the request path, so nothing else would notice if it stopped
+// authenticating; the served test asserts the header explicitly for that
+// reason.
+const probeAPIKey = "sk-probe-fixture-key"
+
+// capturedProbe records what the fake provider was actually asked for. Guarded
+// because the handler runs on the server's goroutine.
+type capturedProbe struct {
+	mu     sync.Mutex
+	path   string
+	auth   string
+	body   []byte
+	called int
+}
+
+func (c *capturedProbe) record(r *http.Request) {
+	body, _ := io.ReadAll(r.Body)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.path = r.URL.Path
+	c.auth = r.Header.Get("Authorization")
+	c.body = body
+	c.called++
+}
+
+func (c *capturedProbe) snapshot() (path, auth string, body []byte, called int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.path, c.auth, c.body, c.called
+}
+
+// probeServer starts a fake provider that answers every request with the given
+// status and body, recording what it was asked for.
+func probeServer(t *testing.T, status int, body string) (*httptest.Server, *capturedProbe) {
+	t.Helper()
+	rec := &capturedProbe{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec.record(r)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = io.WriteString(w, body)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, rec
+}
+
+// probeCandidateFor builds a candidate pointed at the fake provider. It carries
+// a decrypted key exactly as the real one does, so the probe needs no database.
+func probeCandidateFor(baseURL, modelID string) modelCandidate {
+	return modelCandidate{
+		model:    &model.Model{ID: uuid.New(), ModelID: modelID},
+		provider: &provider.Provider{ID: uuid.New(), Name: "Probe Provider", BaseURL: baseURL},
+		apiKey:   probeAPIKey,
+	}
+}
+
+// runProbe drives the real helper under the production budget. Deliberately
+// goneProbeTimeout rather than a number picked for the tests: probeModel takes
+// its deadline from the caller, so a case that only passes with more (or less)
+// time than the retirement path actually grants would be pinning something the
+// gateway never does.
+func runProbe(t *testing.T, h *Handler, candidate modelCandidate, endpointType string) probeVerdict {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), goneProbeTimeout)
+	defer cancel()
+	return h.probeModel(ctx, candidate, endpointType)
+}
+
+// TestProbeModel_ServedAnswerIsNotARetirement is the case the whole feature
+// turns on: a model that answers must never be retired, whatever the classifier
+// made of the three refusals that nominated it.
+//
+// It also pins that the probe went out over the REAL egress path rather than
+// some easier bespoke request — same endpoint, same auth header, same resolved
+// model id, and the documented output budget. A probe that is cheaper to
+// satisfy than real traffic would clear models that real traffic cannot reach.
+func TestProbeModel_ServedAnswerIsNotARetirement(t *testing.T) {
+	t.Parallel()
+
+	srv, rec := probeServer(t, http.StatusOK, `{"choices":[{"message":{"role":"assistant","content":"Hi"}}]}`)
+	h := &Handler{}
+	candidate := probeCandidateFor(srv.URL, "gemini-2.0-flash")
+
+	if got := runProbe(t, h, candidate, endpointTypeChat); got != probeServed {
+		t.Fatalf("verdict = %s, want served", got)
+	}
+
+	path, auth, body, called := rec.snapshot()
+	if called != 1 {
+		t.Fatalf("provider was called %d times, want exactly 1", called)
+	}
+	if path != "/chat/completions" {
+		t.Errorf("probe hit %q, want /chat/completions", path)
+	}
+	if auth != "Bearer "+probeAPIKey {
+		t.Errorf("authorization header = %q, want the provider's key", auth)
+	}
+
+	var sent struct {
+		Model     string `json:"model"`
+		MaxTokens int    `json:"max_tokens"`
+		Messages  []struct {
+			Role string `json:"role"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(body, &sent); err != nil {
+		t.Fatalf("probe body is not JSON: %v", err)
+	}
+	if sent.Model != "gemini-2.0-flash" {
+		t.Errorf("probe asked for %q, want the candidate's upstream model id", sent.Model)
+	}
+	if sent.MaxTokens != goneProbeMaxTokens {
+		t.Errorf("max_tokens = %d, want %d", sent.MaxTokens, goneProbeMaxTokens)
+	}
+	if len(sent.Messages) != 1 || sent.Messages[0].Role != "user" {
+		t.Errorf("probe body carried %+v, want a single user message", sent.Messages)
+	}
+}
+
+// TestProbeModel_ReasoningModelServedOnUsageAlone covers the model that spends
+// its whole budget thinking and returns no visible text. Judging on content
+// alone would call that empty and postpone every retirement decision for the
+// entire reasoning family forever.
+func TestProbeModel_ReasoningModelServedOnUsageAlone(t *testing.T) {
+	t.Parallel()
+
+	srv, _ := probeServer(t, http.StatusOK, `{"choices":[{"message":{"role":"assistant","content":""}}],"usage":{"completion_tokens":12}}`)
+	h := &Handler{}
+
+	if got := runProbe(t, h, probeCandidateFor(srv.URL, "gpt-5.6-sol"), endpointTypeChat); got != probeServed {
+		t.Fatalf("verdict = %s, want served", got)
+	}
+}
+
+// TestProbeModel_EmptyAnswerPostpones pins the half of the judgement an earlier
+// review round caught on the streaming path: a 200 that carries nothing is not
+// a success. It is not a refusal either, so it must postpone rather than
+// retire — the model gets asked again next time.
+func TestProbeModel_EmptyAnswerPostpones(t *testing.T) {
+	t.Parallel()
+
+	srv, _ := probeServer(t, http.StatusOK, `{"choices":[{"message":{"role":"assistant","content":""}}]}`)
+	h := &Handler{}
+
+	if got := runProbe(t, h, probeCandidateFor(srv.URL, "glm-5.2"), endpointTypeChat); got != probeInconclusive {
+		t.Fatalf("verdict = %s, want inconclusive", got)
+	}
+}
+
+// TestProbeModel_RefusalByNameRetires is the other half: the provider naming
+// this model and saying it does not exist is the one thing that may retire it.
+func TestProbeModel_RefusalByNameRetires(t *testing.T) {
+	t.Parallel()
+
+	srv, _ := probeServer(t, http.StatusNotFound, "{\"error\":{\"message\":\"The model `gemini-2.0-flash` does not exist\"}}")
+	h := &Handler{}
+
+	if got := runProbe(t, h, probeCandidateFor(srv.URL, "gemini-2.0-flash"), endpointTypeChat); got != probeRefused {
+		t.Fatalf("verdict = %s, want refused", got)
+	}
+}
+
+// TestProbeModel_RateLimitPostpones is the line that keeps a provider incident
+// from becoming a mass retirement. A 429 is a live model the gateway may not
+// have right now.
+func TestProbeModel_RateLimitPostpones(t *testing.T) {
+	t.Parallel()
+
+	srv, _ := probeServer(t, http.StatusTooManyRequests, `{"error":{"message":"Rate limit reached for gemini-2.0-flash"}}`)
+	h := &Handler{}
+
+	if got := runProbe(t, h, probeCandidateFor(srv.URL, "gemini-2.0-flash"), endpointTypeChat); got != probeInconclusive {
+		t.Fatalf("verdict = %s, want inconclusive", got)
+	}
+}
+
+// TestProbeModel_EntitlementFailurePostpones pins that "you cannot pay for this
+// model" is never "this model is gone". Both shapes the classifier recognises
+// as an entitlement failure must leave the model enabled: an operator topping
+// up their account must not find their catalog retired behind them.
+func TestProbeModel_EntitlementFailurePostpones(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		status int
+		body   string
+	}{
+		{"payment required", http.StatusPaymentRequired, `{"error":{"message":"quota exhausted"}}`},
+		{"insufficient balance inside a 429", http.StatusTooManyRequests, `{"error":{"code":1113,"message":"Insufficient balance or no resource package. Please recharge."}}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			srv, _ := probeServer(t, tc.status, tc.body)
+			h := &Handler{}
+			if got := runProbe(t, h, probeCandidateFor(srv.URL, "glm-4.6"), endpointTypeChat); got != probeInconclusive {
+				t.Fatalf("verdict = %s, want inconclusive", got)
+			}
+		})
+	}
+}
+
+// TestProbeModel_UnreachableProviderPostpones covers the failure mode that
+// would be most destructive: a network problem on the gateway's own side must
+// not read as every model being gone.
+func TestProbeModel_UnreachableProviderPostpones(t *testing.T) {
+	t.Parallel()
+
+	// A privileged port on loopback: binding it needs root, so no test server
+	// can ever be listening there and the connection is refused immediately.
+	// Deliberately not "start a server and close it" — that releases the port
+	// back to the ephemeral range, where the OS can hand it straight to another
+	// parallel test's server and this probe would then reach a live listener.
+	h := &Handler{}
+	if got := runProbe(t, h, probeCandidateFor("http://127.0.0.1:1", "gemini-2.0-flash"), endpointTypeChat); got != probeInconclusive {
+		t.Fatalf("verdict = %s, want inconclusive", got)
+	}
+}
+
+// TestProbeModel_DeadlinePostpones pins that the probe's own budget expiring is
+// evidence about the budget, not about the model.
+func TestProbeModel_DeadlinePostpones(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-time.After(2 * time.Second):
+		case <-r.Context().Done():
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	h := &Handler{}
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	if got := h.probeModel(ctx, probeCandidateFor(srv.URL, "gemini-2.0-flash"), endpointTypeChat); got != probeInconclusive {
+		t.Fatalf("verdict = %s, want inconclusive", got)
+	}
+}
+
+// TestProbeModel_EmbeddingsProbeUsesItsOwnEndpoint pins that an embeddings
+// model is asked something an embeddings model can answer. Probing it with a
+// chat body would fail for reasons that have nothing to do with retirement, and
+// that failure would read as confirmation of the retirement.
+func TestProbeModel_EmbeddingsProbeUsesItsOwnEndpoint(t *testing.T) {
+	t.Parallel()
+
+	srv, rec := probeServer(t, http.StatusOK, `{"data":[{"embedding":[0.1,0.2,0.3]}]}`)
+	h := &Handler{}
+
+	if got := runProbe(t, h, probeCandidateFor(srv.URL, "text-embedding-3-small"), endpointTypeEmbeddings); got != probeServed {
+		t.Fatalf("verdict = %s, want served", got)
+	}
+
+	path, _, body, _ := rec.snapshot()
+	if path != "/embeddings" {
+		t.Fatalf("probe hit %q, want /embeddings", path)
+	}
+
+	var sent struct {
+		Model string `json:"model"`
+		Input string `json:"input"`
+	}
+	if err := json.Unmarshal(body, &sent); err != nil {
+		t.Fatalf("probe body is not JSON: %v", err)
+	}
+	if sent.Input == "" {
+		t.Errorf("embeddings probe body carried no input: %s", body)
+	}
+	if sent.Model != "text-embedding-3-small" {
+		t.Errorf("probe asked for %q, want the candidate's upstream model id", sent.Model)
+	}
+}
+
+// TestProbeEndpointForFamily pins which families may be auto-retired at all.
+// The unprobeable ones are refused deliberately: image, TTS and STT probes cost
+// real money and would fail for reasons unrelated to retirement, and an unknown
+// family is something nothing can be substantiated about.
+func TestProbeEndpointForFamily(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		family   string
+		endpoint string
+		ok       bool
+	}{
+		{endpointTypeChat, "/chat/completions", true},
+		{endpointTypeMessages, "/chat/completions", true},
+		{endpointTypeEmbeddings, "/embeddings", true},
+		{endpointTypeRerank, "", false},
+		{endpointTypeImage, "", false},
+		{endpointTypeTTS, "", false},
+		{endpointTypeSTT, "", false},
+		{"", "", false},
+		{"something-new", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.family, func(t *testing.T) {
+			t.Parallel()
+			endpoint, ok := probeEndpointForFamily(tc.family)
+			if ok != tc.ok {
+				t.Fatalf("ok = %v, want %v", ok, tc.ok)
+			}
+			if endpoint != tc.endpoint {
+				t.Errorf("endpoint = %q, want %q", endpoint, tc.endpoint)
+			}
+		})
+	}
+}
+
+// TestProbeModel_UnprobeableFamilyCostsNoRequest is the defensive half of the
+// gate. The caller is expected to check the family first; if it does not, the
+// probe must still refuse to send anything — an image model asked for a chat
+// completion would answer with a failure that looks exactly like a retirement.
+func TestProbeModel_UnprobeableFamilyCostsNoRequest(t *testing.T) {
+	t.Parallel()
+
+	srv, rec := probeServer(t, http.StatusOK, `{"choices":[{"message":{"content":"Hi"}}]}`)
+	h := &Handler{}
+
+	if got := runProbe(t, h, probeCandidateFor(srv.URL, "dall-e-3"), endpointTypeImage); got != probeInconclusive {
+		t.Fatalf("verdict = %s, want inconclusive", got)
+	}
+	if _, _, _, called := rec.snapshot(); called != 0 {
+		t.Fatalf("provider was called %d times, want none", called)
+	}
+}
+
+// TestProbeModel_NilCandidateIsInconclusive pins that a malformed candidate
+// postpones instead of panicking on the detached disable goroutine, where a
+// panic would take the process down.
+func TestProbeModel_NilCandidateIsInconclusive(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{}
+	if got := runProbe(t, h, modelCandidate{}, endpointTypeChat); got != probeInconclusive {
+		t.Fatalf("verdict = %s, want inconclusive", got)
+	}
+}
+
+// TestProbeDeliveredContent pins what counts as the model having worked. Each
+// case is a real provider shape: reasoning-only answers, tool calls with no
+// prose, and bodies that do not parse at all.
+func TestProbeDeliveredContent(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		family string
+		body   string
+		flowed bool
+	}{
+		{"visible content", endpointTypeChat, `{"choices":[{"message":{"content":"Hi"}}]}`, true},
+		{"reasoning content only", endpointTypeChat, `{"choices":[{"message":{"content":"","reasoning_content":"thinking"}}]}`, true},
+		{"reasoning field only", endpointTypeChat, `{"choices":[{"message":{"content":"","reasoning":"thinking"}}]}`, true},
+		{"tool calls only", endpointTypeChat, `{"choices":[{"message":{"content":"","tool_calls":[{"id":"c1","type":"function","function":{"name":"f","arguments":"{}"}}]}}]}`, true},
+		{"completion tokens only", endpointTypeChat, `{"choices":[],"usage":{"completion_tokens":7}}`, true},
+		{"nothing at all", endpointTypeChat, `{"choices":[]}`, false},
+		{"unparseable", endpointTypeChat, `<html>502 Bad Gateway</html>`, false},
+		{"embedding vector", endpointTypeEmbeddings, `{"data":[{"embedding":[0.5]}]}`, true},
+		{"empty embedding vector", endpointTypeEmbeddings, `{"data":[{"embedding":[]}]}`, false},
+		{"no embedding data", endpointTypeEmbeddings, `{"data":[]}`, false},
+		{"unparseable embeddings", endpointTypeEmbeddings, `<html>502 Bad Gateway</html>`, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := probeDeliveredContent(tc.family, []byte(tc.body)); got != tc.flowed {
+				t.Fatalf("probeDeliveredContent = %v, want %v", got, tc.flowed)
+			}
+		})
+	}
+}
+
+// dialToTestServer builds an upstream transport that sends every connection to
+// the given test server regardless of the hostname in the URL. Nothing about
+// the probe is faked: it is the production *http.Transport field, carrying a
+// DialContext, which is how the real one reaches providers too. The hostname
+// still has to be Google's, because that is what DetectProviderType reads to
+// decide a candidate is vertex-express.
+func dialToTestServer(srv *httptest.Server) *http.Transport {
+	return &http.Transport{
+		DialContext: func(ctx context.Context, network, _ string) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, network, srv.Listener.Addr().String())
+		},
+	}
+}
+
+// TestProbeModel_VertexExpressProbeSpeaksGemini is why the probe goes through
+// the real egress builder instead of assembling its own request. A
+// vertex-express candidate is served the native generateContent route, so an
+// OpenAI-shaped chat probe would hit a path Google does not serve and come back
+// with a failure that says nothing about the model — and gemini-2.0-flash, the
+// model this whole feature was built for, is exactly that kind of candidate.
+func TestProbeModel_VertexExpressProbeSpeaksGemini(t *testing.T) {
+	t.Parallel()
+
+	srv, rec := probeServer(t, http.StatusOK, `{"candidates":[{"content":{"role":"model","parts":[{"text":"Hi"}]},"finishReason":"STOP"}]}`)
+	h := &Handler{upstreamTransport: dialToTestServer(srv)}
+	candidate := probeCandidateFor("http://us-central1-aiplatform.googleapis.com/v1", "gemini-2.0-flash")
+
+	if got := runProbe(t, h, candidate, endpointTypeChat); got != probeServed {
+		t.Fatalf("verdict = %s, want served", got)
+	}
+
+	path, _, _, called := rec.snapshot()
+	if called != 1 {
+		t.Fatalf("provider was called %d times, want exactly 1", called)
+	}
+	if path != "/v1/publishers/google/models/gemini-2.0-flash:generateContent" {
+		t.Errorf("probe hit %q, want the native generateContent route", path)
+	}
+}
+
+// TestProbeModel_UntranslatableDialectAnswerPostpones pins the other half of
+// that re-route: a 200 whose body cannot be read as the dialect it claims to
+// speak proves nothing, so it must postpone rather than count as a refusal.
+func TestProbeModel_UntranslatableDialectAnswerPostpones(t *testing.T) {
+	t.Parallel()
+
+	srv, _ := probeServer(t, http.StatusOK, `<html>502 Bad Gateway</html>`)
+	h := &Handler{upstreamTransport: dialToTestServer(srv)}
+	candidate := probeCandidateFor("http://us-central1-aiplatform.googleapis.com/v1", "gemini-2.0-flash")
+
+	if got := runProbe(t, h, candidate, endpointTypeChat); got != probeInconclusive {
+		t.Fatalf("verdict = %s, want inconclusive", got)
+	}
+}
+
+// TestProbeModel_UnbuildableRequestPostpones covers a provider whose base URL
+// cannot form a valid target URL. The gateway's own misconfiguration must not
+// be charged to the model: a request that never left is not evidence of
+// anything.
+func TestProbeModel_UnbuildableRequestPostpones(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{}
+	// A newline is rejected by net/url, so the request cannot be constructed.
+	candidate := probeCandidateFor("http://127.0.0.1:1/v1\n", "gemini-2.0-flash")
+
+	if got := runProbe(t, h, candidate, endpointTypeChat); got != probeInconclusive {
+		t.Fatalf("verdict = %s, want inconclusive", got)
+	}
+}
+
+// TestProbeModel_RedirectGuardAppliesToTheProbe pins that running off the
+// request path does not drop the SSRF defenses real traffic gets. A provider
+// that answers the probe with a redirect must not be able to walk the
+// decrypted key to another host, and the refused hop must postpone rather than
+// retire.
+func TestProbeModel_RedirectGuardAppliesToTheProbe(t *testing.T) {
+	t.Parallel()
+
+	target, targetRec := probeServer(t, http.StatusOK, `{"choices":[{"message":{"content":"Hi"}}]}`)
+
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+"/chat/completions", http.StatusTemporaryRedirect)
+	}))
+	t.Cleanup(redirector.Close)
+
+	h := &Handler{safeDialer: NewSafeDialer(nil, nil)}
+	if got := runProbe(t, h, probeCandidateFor(redirector.URL, "gemini-2.0-flash"), endpointTypeChat); got != probeInconclusive {
+		t.Fatalf("verdict = %s, want inconclusive", got)
+	}
+	if _, _, _, called := targetRec.snapshot(); called != 0 {
+		t.Fatalf("the redirect target was called %d times, want none", called)
+	}
+}

--- a/internal/proxy/model_probe_test.go
+++ b/internal/proxy/model_probe_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/hugalafutro/model-hotel/internal/failover"
 	"github.com/hugalafutro/model-hotel/internal/model"
 	"github.com/hugalafutro/model-hotel/internal/paramrewrite"
 	"github.com/hugalafutro/model-hotel/internal/provider"
@@ -342,6 +343,75 @@ func TestProbeEndpointForFamily(t *testing.T) {
 			}
 			if endpoint != tc.endpoint {
 				t.Errorf("endpoint = %q, want %q", endpoint, tc.endpoint)
+			}
+		})
+	}
+}
+
+// TestProbeModel_OpenCircuitCostsNoRequest pins that the probe asks the breaker
+// before it asks the provider.
+//
+// The probe skips the breaker's ACCOUNTING deliberately: charging a provider's
+// circuit for a verification the operator did not request would let the
+// verification itself take a healthy provider out of routing. Skipping the
+// CHECK is a different thing entirely, and it was never argued — a probe to a
+// provider the gateway has already sidelined is a guaranteed-wasted call to a
+// host nothing else is being sent to, and its answer postpones anyway. The
+// fixture refuses the model by name, so a probe that went out would RETIRE it;
+// the whole assertion is that no request is made and the retirement postpones.
+func TestProbeModel_OpenCircuitCostsNoRequest(t *testing.T) {
+	t.Parallel()
+
+	srv, rec := probeServer(t, http.StatusNotFound, `{"error":{"message":"The model `+"`claude-sonnet-4`"+` does not exist"}}`)
+	h := newProbeHandler(t)
+	h.circuitBreaker = failover.NewCircuitBreaker(nil)
+	cand := probeCandidateFor(srv.URL, "claude-sonnet-4")
+
+	// Driven through the breaker's own API rather than by reaching into its
+	// state: the check has to agree with what the routing path would see, and
+	// the threshold is the breaker's to define.
+	for range h.circuitBreaker.Threshold {
+		h.circuitBreaker.RecordFailure(cand.provider.ID, cand.provider.Name)
+	}
+	if state := h.circuitBreaker.GetState(cand.provider.ID); state != failover.StateOpen {
+		t.Fatalf("fixture: the circuit did not open, state = %v", state)
+	}
+
+	if got := runProbe(t, h, cand, endpointTypeChat); got != probeInconclusive {
+		t.Errorf("a probe to a sidelined provider must establish nothing, got %v", got)
+	}
+	if _, _, _, called := rec.snapshot(); called != 0 {
+		t.Errorf("a sidelined provider must not be asked, got %d request(s)", called)
+	}
+}
+
+// TestProbeVerdictString pins that an unhandled verdict is named as one.
+//
+// noteModelGone's default arm exists specifically to surface a verdict nobody
+// wrote a case for, and it fails the retirement closed and logs this string.
+// While String's default returned "inconclusive", the one diagnostic designed
+// to name the unknown value was guaranteed to misname it as the zero value it
+// is not — so a fourth verdict silently postponing every retirement for a whole
+// class of models would have read, in the logs, exactly like an ordinary
+// unproven probe. The unknown case is the only reason this test exists; the
+// three named ones are here so a renumbering cannot quietly shuffle them.
+func TestProbeVerdictString(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		verdict probeVerdict
+		want    string
+	}{
+		{probeInconclusive, "inconclusive"},
+		{probeRefused, "refused"},
+		{probeServed, "served"},
+		{probeVerdict(7), "unknown(7)"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.want, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.verdict.String(); got != tc.want {
+				t.Errorf("String() = %q, want %q", got, tc.want)
 			}
 		})
 	}

--- a/internal/proxy/model_probe_test.go
+++ b/internal/proxy/model_probe_test.go
@@ -507,7 +507,16 @@ func TestProbeDeliveredContent(t *testing.T) {
 		{"nothing at all", endpointTypeChat, `{"choices":[]}`, false},
 		{"unparseable", endpointTypeChat, `<html>502 Bad Gateway</html>`, false},
 		{"embedding vector", endpointTypeEmbeddings, `{"data":[{"embedding":[0.5]}]}`, true},
+		// A provider may answer with the vector base64-encoded, which is a JSON
+		// string rather than an array. Decoding it as []float64 made the whole
+		// document fail to parse, so a live embeddings model came back
+		// inconclusive, its streak was never parked, and every refusal past the
+		// cooldown bought another upstream request indefinitely.
+		{"base64 embedding", endpointTypeEmbeddings, `{"data":[{"embedding":"eNqLZoAAAA=="}]}`, true},
 		{"empty embedding vector", endpointTypeEmbeddings, `{"data":[{"embedding":[]}]}`, false},
+		{"empty base64 embedding", endpointTypeEmbeddings, `{"data":[{"embedding":""}]}`, false},
+		{"null embedding", endpointTypeEmbeddings, `{"data":[{"embedding":null}]}`, false},
+		{"embedding key absent", endpointTypeEmbeddings, `{"data":[{}]}`, false},
 		{"no embedding data", endpointTypeEmbeddings, `{"data":[]}`, false},
 		{"unparseable embeddings", endpointTypeEmbeddings, `<html>502 Bad Gateway</html>`, false},
 	}

--- a/internal/proxy/model_probe_test.go
+++ b/internal/proxy/model_probe_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -14,6 +15,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/hugalafutro/model-hotel/internal/model"
+	"github.com/hugalafutro/model-hotel/internal/paramrewrite"
 	"github.com/hugalafutro/model-hotel/internal/provider"
 )
 
@@ -74,6 +76,17 @@ func probeCandidateFor(baseURL, modelID string) modelCandidate {
 	}
 }
 
+// newProbeHandler builds a Handler carrying a real shared upstream transport,
+// which is what production has. Most cases use it so the probe is exercised
+// over the same egress machinery real traffic uses rather than over the nil
+// fallback.
+func newProbeHandler(t *testing.T) *Handler {
+	t.Helper()
+	tr := &http.Transport{}
+	t.Cleanup(tr.CloseIdleConnections)
+	return &Handler{upstreamTransport: tr}
+}
+
 // runProbe drives the real helper under the production budget. Deliberately
 // goneProbeTimeout rather than a number picked for the tests: probeModel takes
 // its deadline from the caller, so a case that only passes with more (or less)
@@ -98,7 +111,7 @@ func TestProbeModel_ServedAnswerIsNotARetirement(t *testing.T) {
 	t.Parallel()
 
 	srv, rec := probeServer(t, http.StatusOK, `{"choices":[{"message":{"role":"assistant","content":"Hi"}}]}`)
-	h := &Handler{}
+	h := newProbeHandler(t)
 	candidate := probeCandidateFor(srv.URL, "gemini-2.0-flash")
 
 	if got := runProbe(t, h, candidate, endpointTypeChat); got != probeServed {
@@ -145,7 +158,7 @@ func TestProbeModel_ReasoningModelServedOnUsageAlone(t *testing.T) {
 	t.Parallel()
 
 	srv, _ := probeServer(t, http.StatusOK, `{"choices":[{"message":{"role":"assistant","content":""}}],"usage":{"completion_tokens":12}}`)
-	h := &Handler{}
+	h := newProbeHandler(t)
 
 	if got := runProbe(t, h, probeCandidateFor(srv.URL, "gpt-5.6-sol"), endpointTypeChat); got != probeServed {
 		t.Fatalf("verdict = %s, want served", got)
@@ -160,6 +173,10 @@ func TestProbeModel_EmptyAnswerPostpones(t *testing.T) {
 	t.Parallel()
 
 	srv, _ := probeServer(t, http.StatusOK, `{"choices":[{"message":{"role":"assistant","content":""}}]}`)
+	// Deliberately the ONLY case left on a nil upstreamTransport: it
+	// completes a real round trip, so it pins that the nil guard falls back
+	// to DefaultTransport instead of panicking on a nil *http.Transport
+	// wrapped in a non-nil RoundTripper interface.
 	h := &Handler{}
 
 	if got := runProbe(t, h, probeCandidateFor(srv.URL, "glm-5.2"), endpointTypeChat); got != probeInconclusive {
@@ -173,7 +190,7 @@ func TestProbeModel_RefusalByNameRetires(t *testing.T) {
 	t.Parallel()
 
 	srv, _ := probeServer(t, http.StatusNotFound, "{\"error\":{\"message\":\"The model `gemini-2.0-flash` does not exist\"}}")
-	h := &Handler{}
+	h := newProbeHandler(t)
 
 	if got := runProbe(t, h, probeCandidateFor(srv.URL, "gemini-2.0-flash"), endpointTypeChat); got != probeRefused {
 		t.Fatalf("verdict = %s, want refused", got)
@@ -187,7 +204,7 @@ func TestProbeModel_RateLimitPostpones(t *testing.T) {
 	t.Parallel()
 
 	srv, _ := probeServer(t, http.StatusTooManyRequests, `{"error":{"message":"Rate limit reached for gemini-2.0-flash"}}`)
-	h := &Handler{}
+	h := newProbeHandler(t)
 
 	if got := runProbe(t, h, probeCandidateFor(srv.URL, "gemini-2.0-flash"), endpointTypeChat); got != probeInconclusive {
 		t.Fatalf("verdict = %s, want inconclusive", got)
@@ -213,7 +230,7 @@ func TestProbeModel_EntitlementFailurePostpones(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			srv, _ := probeServer(t, tc.status, tc.body)
-			h := &Handler{}
+			h := newProbeHandler(t)
 			if got := runProbe(t, h, probeCandidateFor(srv.URL, "glm-4.6"), endpointTypeChat); got != probeInconclusive {
 				t.Fatalf("verdict = %s, want inconclusive", got)
 			}
@@ -251,7 +268,7 @@ func TestProbeModel_DeadlinePostpones(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	h := &Handler{}
+	h := newProbeHandler(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
 	defer cancel()
 
@@ -268,7 +285,7 @@ func TestProbeModel_EmbeddingsProbeUsesItsOwnEndpoint(t *testing.T) {
 	t.Parallel()
 
 	srv, rec := probeServer(t, http.StatusOK, `{"data":[{"embedding":[0.1,0.2,0.3]}]}`)
-	h := &Handler{}
+	h := newProbeHandler(t)
 
 	if got := runProbe(t, h, probeCandidateFor(srv.URL, "text-embedding-3-small"), endpointTypeEmbeddings); got != probeServed {
 		t.Fatalf("verdict = %s, want served", got)
@@ -400,12 +417,15 @@ func TestProbeDeliveredContent(t *testing.T) {
 // DialContext, which is how the real one reaches providers too. The hostname
 // still has to be Google's, because that is what DetectProviderType reads to
 // decide a candidate is vertex-express.
-func dialToTestServer(srv *httptest.Server) *http.Transport {
-	return &http.Transport{
+func dialToTestServer(t *testing.T, srv *httptest.Server) *http.Transport {
+	t.Helper()
+	tr := &http.Transport{
 		DialContext: func(ctx context.Context, network, _ string) (net.Conn, error) {
 			return (&net.Dialer{}).DialContext(ctx, network, srv.Listener.Addr().String())
 		},
 	}
+	t.Cleanup(tr.CloseIdleConnections)
+	return tr
 }
 
 // TestProbeModel_VertexExpressProbeSpeaksGemini is why the probe goes through
@@ -418,7 +438,7 @@ func TestProbeModel_VertexExpressProbeSpeaksGemini(t *testing.T) {
 	t.Parallel()
 
 	srv, rec := probeServer(t, http.StatusOK, `{"candidates":[{"content":{"role":"model","parts":[{"text":"Hi"}]},"finishReason":"STOP"}]}`)
-	h := &Handler{upstreamTransport: dialToTestServer(srv)}
+	h := &Handler{upstreamTransport: dialToTestServer(t, srv)}
 	candidate := probeCandidateFor("http://us-central1-aiplatform.googleapis.com/v1", "gemini-2.0-flash")
 
 	if got := runProbe(t, h, candidate, endpointTypeChat); got != probeServed {
@@ -441,7 +461,7 @@ func TestProbeModel_UntranslatableDialectAnswerPostpones(t *testing.T) {
 	t.Parallel()
 
 	srv, _ := probeServer(t, http.StatusOK, `<html>502 Bad Gateway</html>`)
-	h := &Handler{upstreamTransport: dialToTestServer(srv)}
+	h := &Handler{upstreamTransport: dialToTestServer(t, srv)}
 	candidate := probeCandidateFor("http://us-central1-aiplatform.googleapis.com/v1", "gemini-2.0-flash")
 
 	if got := runProbe(t, h, candidate, endpointTypeChat); got != probeInconclusive {
@@ -480,11 +500,85 @@ func TestProbeModel_RedirectGuardAppliesToTheProbe(t *testing.T) {
 	}))
 	t.Cleanup(redirector.Close)
 
-	h := &Handler{safeDialer: NewSafeDialer(nil, nil)}
+	h := newProbeHandler(t)
+	h.safeDialer = NewSafeDialer(nil, nil)
 	if got := runProbe(t, h, probeCandidateFor(redirector.URL, "gemini-2.0-flash"), endpointTypeChat); got != probeInconclusive {
 		t.Fatalf("verdict = %s, want inconclusive", got)
 	}
 	if _, _, _, called := targetRec.snapshot(); called != 0 {
 		t.Fatalf("the redirect target was called %d times, want none", called)
+	}
+}
+
+// TestProbeModel_LearnedParamRenameIsApplied is the invariant that justifies
+// going through buildCandidateRequest at all: the probe must not be able to
+// fail where real traffic succeeds.
+//
+// OpenAI's reasoning models reject max_tokens and demand
+// max_completion_tokens, which the gateway learns from a 400 and caches. Real
+// traffic to such a model always carries that rename, because every request
+// goes through paramrewrite.BuildUpstreamBody. A probe that skipped it would
+// send the exact parameter the model rejects, collect a 400, classify it as
+// not-a-retirement and postpone forever — permanently unable to CLEAR the
+// reasoning family the 64-token budget was chosen for.
+func TestProbeModel_LearnedParamRenameIsApplied(t *testing.T) {
+	t.Parallel()
+
+	srv, rec := probeServer(t, http.StatusOK, `{"choices":[{"message":{"content":"Hi"}}]}`)
+	h := newProbeHandler(t)
+	// Seeded through the production writer, keyed exactly as
+	// BuildUpstreamBody keys it: "<provider type>:<resolved model id>". An
+	// httptest URL detects as the openai provider type.
+	paramrewrite.MergeLearnedParamCache(&h.paramRenameCache, "openai:gpt-5.6-sol", map[string]string{
+		"max_tokens": "max_completion_tokens",
+	})
+
+	if got := runProbe(t, h, probeCandidateFor(srv.URL, "gpt-5.6-sol"), endpointTypeChat); got != probeServed {
+		t.Fatalf("verdict = %s, want served", got)
+	}
+
+	_, _, body, _ := rec.snapshot()
+	var sent map[string]any
+	if err := json.Unmarshal(body, &sent); err != nil {
+		t.Fatalf("probe body is not JSON: %v", err)
+	}
+	if _, stillThere := sent["max_tokens"]; stillThere {
+		t.Errorf("probe sent max_tokens, which this model rejects: %s", body)
+	}
+	budget, renamed := sent["max_completion_tokens"]
+	if !renamed {
+		t.Fatalf("probe body carried no max_completion_tokens: %s", body)
+	}
+	if budget != float64(goneProbeMaxTokens) {
+		t.Errorf("renamed budget = %v, want %d", budget, goneProbeMaxTokens)
+	}
+	if sent["model"] != "gpt-5.6-sol" {
+		t.Errorf("probe asked for %v, want the candidate's upstream model id", sent["model"])
+	}
+}
+
+// TestProbeModel_TruncatedRefusalPostpones pins the one place a discarded read
+// error could RETIRE a model. The provider declares more body than it delivers
+// and the connection dies mid-answer; the surviving prefix happens to name the
+// model beside a gone-phrase, so classifying it would read exactly like a real
+// refusal. A body that could not be read to the end is not the provider saying
+// anything.
+func TestProbeModel_TruncatedRefusalPostpones(t *testing.T) {
+	t.Parallel()
+
+	refusal := "{\"error\":{\"message\":\"The model `gemini-2.0-flash` does not exist\"}}"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// Promise far more than is written, then return: the server closes the
+		// connection and the client's read fails with an unexpected EOF.
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Length", strconv.Itoa(len(refusal)*4))
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = io.WriteString(w, refusal)
+	}))
+	t.Cleanup(srv.Close)
+
+	h := newProbeHandler(t)
+	if got := runProbe(t, h, probeCandidateFor(srv.URL, "gemini-2.0-flash"), endpointTypeChat); got != probeInconclusive {
+		t.Fatalf("verdict = %s, want inconclusive", got)
 	}
 }

--- a/internal/proxy/model_probe_test.go
+++ b/internal/proxy/model_probe_test.go
@@ -515,6 +515,12 @@ func TestProbeDeliveredContent(t *testing.T) {
 		{"base64 embedding", endpointTypeEmbeddings, `{"data":[{"embedding":"eNqLZoAAAA=="}]}`, true},
 		{"empty embedding vector", endpointTypeEmbeddings, `{"data":[{"embedding":[]}]}`, false},
 		{"empty base64 embedding", endpointTypeEmbeddings, `{"data":[{"embedding":""}]}`, false},
+		// Emptiness is judged structurally, not against the spellings
+		// encoding/json happens to emit: a provider whose encoder pads still
+		// answered with nothing.
+		{"padded empty vector", endpointTypeEmbeddings, `{"data":[{"embedding":[ ]}]}`, false},
+		{"newline-padded empty vector", endpointTypeEmbeddings, "{\"data\":[{\"embedding\":[\n]}]}", false},
+		{"padded empty base64", endpointTypeEmbeddings, `{"data":[{"embedding":"  "}]}`, false},
 		{"null embedding", endpointTypeEmbeddings, `{"data":[{"embedding":null}]}`, false},
 		{"embedding key absent", endpointTypeEmbeddings, `{"data":[{}]}`, false},
 		{"no embedding data", endpointTypeEmbeddings, `{"data":[]}`, false},

--- a/internal/proxy/model_probe_test.go
+++ b/internal/proxy/model_probe_test.go
@@ -178,14 +178,39 @@ func TestProbeModel_EmptyAnswerPostpones(t *testing.T) {
 	t.Parallel()
 
 	srv, _ := probeServer(t, http.StatusOK, `{"choices":[{"message":{"role":"assistant","content":""}}]}`)
-	// Deliberately the ONLY case left on a nil upstreamTransport: it
-	// completes a real round trip, so it pins that the nil guard falls back
-	// to DefaultTransport instead of panicking on a nil *http.Transport
-	// wrapped in a non-nil RoundTripper interface.
+	h := newProbeHandler(t)
+
+	if got := runProbe(t, h, probeCandidateFor(srv.URL, "glm-5.2"), endpointTypeChat); got != probeInconclusive {
+		t.Fatalf("verdict = %s, want inconclusive", got)
+	}
+}
+
+// TestProbeModel_NoTransportPostpones pins that the probe refuses to fall back
+// to net/http's default client.
+//
+// The nil check cannot go away — upstreamTransport is a concrete
+// *http.Transport, so assigning a nil one panics inside RoundTrip rather than
+// falling back — but leaving Transport unset is not a safe way to satisfy it: an
+// unset Transport is http.DefaultTransport, which has no DialContext, so the
+// SafeDialer's guard against a provider URL that resolves into the gateway's own
+// network would be silently gone for the one request nobody is watching. The
+// probe postpones instead, which is what it does with every other question it
+// cannot answer safely.
+//
+// The fake provider records every call, so this asserts the request was never
+// sent rather than merely that the verdict came out inconclusive — which it
+// would either way.
+func TestProbeModel_NoTransportPostpones(t *testing.T) {
+	t.Parallel()
+
+	srv, rec := probeServer(t, http.StatusOK, `{"choices":[{"message":{"content":"Hi"}}]}`)
 	h := &Handler{}
 
 	if got := runProbe(t, h, probeCandidateFor(srv.URL, "glm-5.2"), endpointTypeChat); got != probeInconclusive {
 		t.Fatalf("verdict = %s, want inconclusive", got)
+	}
+	if _, _, _, called := rec.snapshot(); called != 0 {
+		t.Fatalf("the provider was called %d times over an unguarded transport", called)
 	}
 }
 
@@ -254,7 +279,11 @@ func TestProbeModel_UnreachableProviderPostpones(t *testing.T) {
 	// Deliberately not "start a server and close it" — that releases the port
 	// back to the ephemeral range, where the OS can hand it straight to another
 	// parallel test's server and this probe would then reach a live listener.
-	h := &Handler{}
+	//
+	// A real transport, so the refused connection is what produces the verdict.
+	// On a bare Handler the probe now postpones before it dials at all, and this
+	// test would pass without a packet being sent.
+	h := newProbeHandler(t)
 	if got := runProbe(t, h, probeCandidateFor("http://127.0.0.1:1", "gemini-2.0-flash"), endpointTypeChat); got != probeInconclusive {
 		t.Fatalf("verdict = %s, want inconclusive", got)
 	}

--- a/internal/proxy/model_probe_test.go
+++ b/internal/proxy/model_probe_test.go
@@ -1,14 +1,18 @@
 package proxy
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -650,5 +654,119 @@ func TestProbeModel_TruncatedRefusalPostpones(t *testing.T) {
 	h := newProbeHandler(t)
 	if got := runProbe(t, h, probeCandidateFor(srv.URL, "gemini-2.0-flash"), endpointTypeChat); got != probeInconclusive {
 		t.Fatalf("verdict = %s, want inconclusive", got)
+	}
+}
+
+// paddedRefusal builds a retirement refusal of roughly size bytes: the
+// gone-phrase first, so the classifier sees it inside its own 10 000-character
+// window whatever the total length, then filler.
+//
+// The point is a body whose CLASSIFICATION is identical at every size, so a
+// verdict that changes with the size changed because of the size.
+func paddedRefusal(modelID string, size int) string {
+	head := fmt.Sprintf("{\"error\":{\"message\":\"The model `%s` does not exist\",\"detail\":\"", modelID)
+	const tail = "\"}}"
+	if pad := size - len(head) - len(tail); pad > 0 {
+		return head + strings.Repeat("a", pad) + tail
+	}
+	return head + tail
+}
+
+// TestProbeModel_OversizedRefusalPostpones pins the read cap as a real guard
+// rather than a comment.
+//
+// io.ReadAll returns a NIL error when a LimitReader is exhausted, so a body cut
+// off at goneProbeMaxBody arrives looking exactly like a body that ended: no
+// error, and a prefix that still names the model beside a gone-phrase, because
+// the classifier only ever reads the first 10 000 characters and the phrase is
+// at the front. The model gets RETIRED on an answer the gateway never received
+// in full — the one direction a probe is never allowed to take.
+//
+// The under-cap half is the control. Without it the test would also pass if the
+// probe simply stopped retiring anything on a large body, or on any body at all.
+func TestProbeModel_OversizedRefusalPostpones(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		size int
+		want probeVerdict
+	}{
+		// Comfortably inside the cap: an ordinary refusal, read whole, retires.
+		{"within the cap", goneProbeMaxBody - (8 << 10), probeRefused},
+		// Past it: the same words, but what arrived is a prefix of an answer
+		// whose real content nobody knows.
+		{"past the cap", goneProbeMaxBody + (8 << 10), probeInconclusive},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv, _ := probeServer(t, http.StatusNotFound, paddedRefusal("claude-sonnet-4", tc.size))
+			h := newProbeHandler(t)
+			if got := runProbe(t, h, probeCandidateFor(srv.URL, "claude-sonnet-4"), endpointTypeChat); got != tc.want {
+				t.Fatalf("verdict = %s, want %s", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestProbeModel_DialectAnswerIsBounded pins that the cap covers the reads this
+// file does not make.
+//
+// goneProbeMaxBody is applied to resp.Body once, in probeModel, and that is the
+// only reason it binds at all: remapMiniMaxBusinessError and both dialect
+// translators live in other files and read the body WHOLE, with io.ReadAll and
+// no budget of their own. Capping at the two judgement functions instead would
+// have left every MiniMax, vertex-express and OpenAI-Responses candidate
+// unbounded — and this all happens on the detached disable goroutine, with no
+// client backpressure behind it, so a provider (or something impersonating one)
+// answering 200 with a multi-gigabyte body would be read into memory in full
+// with nothing to notice.
+//
+// The assertion is on the bytes the provider managed to send, because that is
+// the only observable: the verdict is inconclusive either way, since a truncated
+// Gemini answer does not parse and neither does a complete one made of filler.
+func TestProbeModel_DialectAnswerIsBounded(t *testing.T) {
+	t.Parallel()
+
+	// Eight times the cap. The probe reads at most the cap plus its own drain of
+	// the same size, so the margin is wide enough that neither socket buffering
+	// nor the drain can be mistaken for the translator having read it all.
+	const flood = 8 * goneProbeMaxBody
+	var written atomic.Int64
+	done := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		defer close(done)
+		w.Header().Set("Content-Type", "application/json")
+		// Bounded so the handler always terminates: once the probe closes the
+		// body these writes fail, and if they somehow do not, the loop still ends
+		// rather than hanging the test's server shutdown.
+		chunk := bytes.Repeat([]byte("a"), 32<<10)
+		for written.Load() < flood {
+			n, err := w.Write(chunk)
+			written.Add(int64(n))
+			if err != nil {
+				return
+			}
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	// A vertex-express candidate, so the answer goes through
+	// translateGeminiResponseBody rather than through this file's own reads.
+	h := &Handler{upstreamTransport: dialToTestServer(t, srv)}
+	candidate := probeCandidateFor("http://us-central1-aiplatform.googleapis.com/v1", "gemini-2.0-flash")
+
+	if got := runProbe(t, h, candidate, endpointTypeChat); got != probeInconclusive {
+		t.Fatalf("verdict = %s, want inconclusive", got)
+	}
+	select {
+	case <-done:
+	case <-time.After(goneProbeTimeout):
+		t.Fatal("the provider never stopped writing, so the probe never stopped reading")
+	}
+	if n := written.Load(); n >= flood {
+		t.Fatalf("the provider sent all %d bytes, so nothing bounded the read; the cap is %d", n, goneProbeMaxBody)
 	}
 }

--- a/internal/proxy/multimodal.go
+++ b/internal/proxy/multimodal.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/hugalafutro/model-hotel/internal/ctxkeys"
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
+	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
 // Multimodal proxy endpoints: OpenAI-compatible pass-through for embeddings,
@@ -368,8 +369,30 @@ func (h *Handler) attemptPassthroughCandidate(w http.ResponseWriter, r *http.Req
 	if isFailoverEligible {
 		h.recordBreakerOutcome(st, candidate, resp.StatusCode, true)
 		if hasMoreCandidates {
-			_, _ = io.ReadAll(resp.Body)
+			// The body is discarded anyway, so classify it on the way out —
+			// exactly what attemptCandidate does for chat, and for the same
+			// reason: a retired model usually answers 404, which is
+			// failover-eligible, so without this the "model gone" signal is lost
+			// precisely when there is another candidate to fall back to. Only the
+			// LAST candidate in a group reached forwardUpstreamError and struck,
+			// which meant an embeddings model sitting anywhere else in a
+			// multi-candidate group accrued no strikes at all.
+			//
+			// It costs nothing that was not already being spent: the same read,
+			// the same discard, one classifier call on a body the request path
+			// has already given up on.
+			//
+			// Bounded rather than read whole, unlike the chat path. These are the
+			// multimodal endpoints, where a body can be a multi-megabyte image
+			// payload; the classifier only ever sees the first 10 000 characters
+			// of it, so anything past the cap is drained straight to Discard
+			// instead of being held in memory to be thrown away.
+			drained, _ := io.ReadAll(io.LimitReader(resp.Body, passthroughErrorClassifyCap))
+			_, _ = io.Copy(io.Discard, resp.Body)
 			_ = resp.Body.Close()
+			if kind, _ := classifyUpstreamError(resp.StatusCode, util.SanitizeLogBody(string(drained), 10000), candidate.model.ModelID); kind == KindProviderModelGone {
+				h.noteModelGone(candidate, logData.endpointType)
+			}
 			st.setReqErr(reqError{Kind: KindProviderError, Attempt: attempt, Provider: candidate.provider.Name, Detail: fmt.Sprintf("HTTP %d", resp.StatusCode)})
 			debuglog.Info("proxy: failover triggered", "endpoint", logData.endpointType, "attempt", attempt+1, "provider", candidate.provider.Name, "provider_id", candidate.provider.ID, "status", resp.StatusCode)
 			logData.failoverAttempt = attempt
@@ -395,6 +418,13 @@ func (h *Handler) attemptPassthroughCandidate(w http.ResponseWriter, r *http.Req
 	h.servePassthroughResponse(w, r, st, candidate, resp, attempt, responseHeaderMs)
 	return outcomeServed
 }
+
+// passthroughErrorClassifyCap bounds how much of a discarded failover error body
+// is held in memory long enough to be classified. classifyUpstreamError never
+// sees more than util.SanitizeLogBody's own 10 000 characters, so reading
+// further would retain bytes nothing can read — and on these endpoints the body
+// behind an error status can be an image payload rather than a sentence.
+const passthroughErrorClassifyCap = 16 << 10
 
 // passthroughJSONBufferCap bounds how much of a JSON pass-through response is
 // buffered for token-usage extraction. Bodies beyond the cap (e.g. multi-image

--- a/internal/proxy/multimodal.go
+++ b/internal/proxy/multimodal.go
@@ -511,7 +511,15 @@ func (h *Handler) servePassthroughResponse(w http.ResponseWriter, r *http.Reques
 		contentType = "application/octet-stream"
 	}
 	isSSE := strings.HasPrefix(contentType, "text/event-stream")
-	isJSON := !isSSE && strings.Contains(contentType, "json")
+	// An embeddings answer is JSON by definition, so it takes the buffered
+	// branch whatever an aggregator or CDN in front of the provider labelled it.
+	// Letting the content type decide sent an unlabelled one to the streamed
+	// twin, which commits on the first byte and cannot judge what it never
+	// holds — so `{"data":[]}` is eleven bytes and clears the streak, routing
+	// around the check passthroughAnswered exists to make. Embeddings is the
+	// only pass-through family that can be auto-retired, which is why it is the
+	// only one this says anything about.
+	isJSON := !isSSE && (strings.Contains(contentType, "json") || st.logData.endpointType == endpointTypeEmbeddings)
 
 	if isJSON {
 		h.serveBufferedJSONPassthrough(w, st, candidate, resp, contentType, attempt, responseHeaderMs)

--- a/internal/proxy/multimodal.go
+++ b/internal/proxy/multimodal.go
@@ -409,27 +409,12 @@ func (h *Handler) attemptPassthroughCandidate(w http.ResponseWriter, r *http.Req
 		return h.forwardUpstreamError(w, st, candidate, resp, attempt, hasMoreCandidates, responseHeaderMs)
 	}
 
-	// The provider served the model, so any gone-strike streak it had is stale.
-	// This is the success half of the signal the failover branch above records,
-	// and without it "three CONSECUTIVE refusals" was not true on this path:
-	// embeddings is the one pass-through family that can be auto-retired, and its
-	// strikes only ever expired with goneStrikeWindow. Three refusals scattered
-	// across half an hour of otherwise healthy traffic reached the threshold and
-	// spent a probe, where the chat path would have cleared the count on the first
-	// success in between.
-	//
-	// Unconditional on the family, unlike the strike. A strike has to be gated
-	// because it cannot be adjudicated for an image or TTS model, but a 2xx from
-	// any surface is evidence the provider still serves the model, and clearing a
-	// streak can only ever PREVENT a retirement. Nothing is at risk from being
-	// generous here, and a model taking both chat and embeddings traffic gets the
-	// same answer from either.
-	h.noteModelServed(candidate.model)
-
 	// Breaker success for 2xx is recorded inside servePassthroughResponse at
-	// the commit point (headers for buffered JSON, first body byte for
+	// the commit point (the buffered read for JSON, the first body byte for
 	// SSE/binary), so a provider that returns 200 and then stalls or dies
-	// before producing any data still accrues breaker failures.
+	// before producing any data still accrues breaker failures. The
+	// gone-strike streak is cleared at those same two points and for the same
+	// reason: 200 headers are a promise, not evidence.
 	debuglog.Debug("proxy: upstream responded OK, dispatching passthrough", "endpoint", logData.endpointType, "model", logData.modelID, "provider", logData.providerName, "status", resp.StatusCode, "content_type", resp.Header.Get("Content-Type"))
 	h.servePassthroughResponse(w, r, st, candidate, resp, attempt, responseHeaderMs)
 	return outcomeServed
@@ -506,6 +491,31 @@ func (h *Handler) serveBufferedJSONPassthrough(w http.ResponseWriter, st *reques
 	if st.circuitBreakerEnabled {
 		h.circuitBreaker.RecordSuccess(candidate.provider.ID, candidate.provider.Name)
 	}
+	// The commit point is also where the model has proved it is alive, so this
+	// is where its gone-strike streak stops being current. It is the success
+	// half of the signal the failover loop records, and without it "three
+	// CONSECUTIVE refusals" is not true on this path: embeddings is the one
+	// pass-through family that can be auto-retired, and its strikes would
+	// otherwise only expire with goneStrikeWindow, so three refusals scattered
+	// across half an hour of otherwise healthy traffic would reach the threshold
+	// and spend a probe.
+	//
+	// Here rather than on the 200 headers, and NOT beside the breaker call by
+	// coincidence. The read above is what distinguishes a provider that served
+	// the model from one that promised to: a body that died mid-read is the
+	// failure branch, and clearing the streak there would let a model that never
+	// actually answers stay out of reach of a retirement forever.
+	//
+	// Not gated on circuitBreakerEnabled either, unlike its neighbour. The
+	// breaker is an operator's routing choice; whether a model still exists is
+	// not, and turning the breaker off must not silently stop strikes being
+	// cleared.
+	//
+	// Unconditional on the family, unlike the strike. A strike has to be gated
+	// because it cannot be adjudicated for an image or TTS model, but a served
+	// body from any surface is evidence the provider still serves the model, and
+	// clearing a streak can only ever PREVENT a retirement.
+	h.noteModelServed(candidate.model)
 	copyPassthroughHeaders(w, resp, contentType)
 
 	if len(body) > passthroughJSONBufferCap {
@@ -563,6 +573,11 @@ func (h *Handler) serveStreamedPassthrough(w http.ResponseWriter, r *http.Reques
 	if st.circuitBreakerEnabled {
 		h.circuitBreaker.RecordSuccess(candidate.provider.ID, candidate.provider.Name)
 	}
+	// The streamed commit point, matching the buffered one: a first byte out of
+	// the provider is where a 200 stops being a promise. See the twin call in
+	// serveBufferedJSONPassthrough for why it is here, ungated by the breaker
+	// setting, and ungated by the endpoint family.
+	h.noteModelServed(candidate.model)
 
 	copyPassthroughHeaders(w, resp, contentType)
 	if isSSE {

--- a/internal/proxy/multimodal.go
+++ b/internal/proxy/multimodal.go
@@ -364,14 +364,10 @@ func (h *Handler) attemptPassthroughCandidate(w http.ResponseWriter, r *http.Req
 
 	// MiniMax reports business errors (rate limit, exhausted plan balance, auth
 	// failures) inside an HTTP 200 envelope, so the status has to be normalised
-	// before anything is judged from it — exactly as attemptCandidate,
-	// probeStreamingCandidate and probeModel all do.
-	//
-	// This loop was the one that did not, and until the retirement work that only
-	// cost a spurious breaker success. It costs more now: the 2xx branch below
-	// clears the model's gone-strike streak, so a refusal wrapped in a 200 was
-	// being recorded as the model answering and resetting the consecutive count
-	// that a retirement depends on.
+	// before anything is judged from it — as attemptCandidate,
+	// probeStreamingCandidate and probeModel all do. This loop was the one that
+	// did not, and the 2xx branch below now clears the model's gone-strike
+	// streak, so a refusal wrapped in a 200 was recorded as the model answering.
 	resp = remapMiniMaxBusinessError(providerType, candidate.provider.Name, resp)
 
 	responseHeaderMs := float64(time.Since(st.startTime).Microseconds()) / 1000.0
@@ -381,23 +377,17 @@ func (h *Handler) attemptPassthroughCandidate(w http.ResponseWriter, r *http.Req
 	if isFailoverEligible {
 		h.recordBreakerOutcome(st, candidate, resp.StatusCode, true)
 		if hasMoreCandidates {
-			// The body is discarded anyway, so classify it on the way out —
-			// exactly what attemptCandidate does for chat, and for the same
-			// reason: a retired model usually answers 404, which is
-			// failover-eligible, so without this the "model gone" signal is lost
-			// precisely when there is another candidate to fall back to. Only the
-			// LAST candidate in a group reached forwardUpstreamError and struck,
-			// which meant an embeddings model sitting anywhere else in a
-			// multi-candidate group accrued no strikes at all.
-			//
-			// It costs nothing that was not already being spent: the same read,
-			// the same discard, one classifier call on a body the request path
-			// has already given up on.
+			// The body is discarded anyway, so classify it on the way out — what
+			// attemptCandidate does for chat, and for the same reason: a retired
+			// model usually answers 404, which is failover-eligible, so without
+			// this the "model gone" signal is lost precisely when there is another
+			// candidate to fall back to. Only the LAST candidate in a group
+			// reached forwardUpstreamError and struck, so an embeddings model
+			// anywhere else in a multi-candidate group accrued no strikes at all.
 			//
 			// Bounded, and the cap matters more here than on the chat path that
-			// shares it: these are the multimodal endpoints, where the body
-			// behind an error status can be an image payload rather than a
-			// sentence.
+			// shares it: these are the multimodal endpoints, where the body behind
+			// an error status can be an image payload rather than a sentence.
 			drained, _ := io.ReadAll(io.LimitReader(resp.Body, failoverErrorClassifyCap))
 			_, _ = io.Copy(io.Discard, resp.Body)
 			_ = resp.Body.Close()
@@ -437,19 +427,15 @@ func (h *Handler) attemptPassthroughCandidate(w http.ResponseWriter, r *http.Req
 //
 // Embeddings is judged on content, by the same function the probe uses. It is
 // the only pass-through family that can be auto-retired, so it is the only one
-// where getting this wrong has a consequence — and the package plainly does know
-// what an embeddings answer looks like, since probeDeliveredContent implements
-// exactly this check and extractPassthroughUsage parses the same document a line
-// later. A provider alternating gone-shaped 404s with 200 {"data":[]} would
-// otherwise reset the count on every empty answer and the model would never be
-// nominated, which is the failure chatAnswerCarriesContent closes on the chat
-// path.
+// where getting this wrong has a consequence: a provider alternating gone-shaped
+// 404s with 200 {"data":[]} would otherwise reset the count on every empty
+// answer and the model would never be nominated. Same failure
+// chatAnswerCarriesContent closes on the chat path.
 //
-// Everything else is judged on bytes, and deliberately: this path forwards image
-// and audio answers verbatim and has no business parsing them. It costs nothing
-// to be generous there, because noteModelServed clears the streak for the
-// surface the response arrived on, and those surfaces have no streak to clear —
-// they are never auto-retired in the first place.
+// Everything else is judged on bytes, deliberately: this path forwards image and
+// audio answers verbatim and has no business parsing them. Being generous there
+// costs nothing, because noteModelServed clears the streak for the surface the
+// response arrived on and those surfaces have no streak to clear.
 func passthroughAnswered(endpointType string, body []byte) bool {
 	if len(body) == 0 {
 		return false
@@ -458,10 +444,8 @@ func passthroughAnswered(endpointType string, body []byte) bool {
 	// passthroughJSONBufferCap+1 bytes and streams the remainder. Truncated JSON
 	// never parses, so handing it to the content check below would report that a
 	// provider which just produced megabytes had answered with nothing — and a
-	// batch embeddings call clears 8 MiB at around 140 inputs of 3072
-	// dimensions, which is ordinary document-indexing traffic. The success side
-	// of the streak would be permanently dead on that workload: three refusals
-	// would nominate a live model and spend a probe on it, over and over.
+	// batch embeddings call clears 8 MiB at around 140 inputs of 3072 dimensions,
+	// which is ordinary document-indexing traffic.
 	if len(body) > passthroughJSONBufferCap {
 		return true
 	}
@@ -511,14 +495,13 @@ func (h *Handler) servePassthroughResponse(w http.ResponseWriter, r *http.Reques
 		contentType = "application/octet-stream"
 	}
 	isSSE := strings.HasPrefix(contentType, "text/event-stream")
-	// An embeddings answer is JSON by definition, so it takes the buffered
-	// branch whatever an aggregator or CDN in front of the provider labelled it.
-	// Letting the content type decide sent an unlabelled one to the streamed
-	// twin, which commits on the first byte and cannot judge what it never
-	// holds — so `{"data":[]}` is eleven bytes and clears the streak, routing
-	// around the check passthroughAnswered exists to make. Embeddings is the
-	// only pass-through family that can be auto-retired, which is why it is the
-	// only one this says anything about.
+	// An embeddings answer is JSON by definition, so it takes the buffered branch
+	// whatever an aggregator or CDN in front of the provider labelled it. Letting
+	// the content type decide sent an unlabelled one to the streamed twin, which
+	// commits on the first byte and cannot judge what it never holds — so
+	// `{"data":[]}` is eleven bytes and clears the streak, routing around the
+	// check passthroughAnswered exists to make. Embeddings is the only
+	// pass-through family that can be auto-retired, hence the only one named.
 	isJSON := !isSSE && (strings.Contains(contentType, "json") || st.logData.endpointType == endpointTypeEmbeddings)
 
 	if isJSON {
@@ -550,41 +533,25 @@ func (h *Handler) serveBufferedJSONPassthrough(w http.ResponseWriter, st *reques
 	if st.circuitBreakerEnabled {
 		h.circuitBreaker.RecordSuccess(candidate.provider.ID, candidate.provider.Name)
 	}
-	// The commit point is also where the model has proved it is alive, so this
-	// is where its gone-strike streak stops being current. It is the success
-	// half of the signal the failover loop records, and without it "three
-	// CONSECUTIVE refusals" is not true on this path: embeddings is the one
-	// pass-through family that can be auto-retired, and its strikes would
-	// otherwise only expire with goneStrikeWindow, so three refusals scattered
-	// across half an hour of otherwise healthy traffic would reach the threshold
-	// and spend a probe.
+	// The commit point is where the model has proved it is alive, so it is where
+	// its gone-strike streak stops being current. Without it "three CONSECUTIVE
+	// refusals" is not true on this path: embeddings strikes would only expire
+	// with goneStrikeWindow, so three refusals scattered across half an hour of
+	// otherwise healthy traffic would reach the threshold and spend a probe.
 	//
-	// Here rather than on the 200 headers, and NOT beside the breaker call by
-	// coincidence. The read above is what distinguishes a provider that served
-	// the model from one that promised to: a body that died mid-read is the
-	// failure branch, and clearing the streak there would let a model that never
-	// actually answers stay out of reach of a retirement forever.
+	// Here rather than on the 200 headers, because the read above is what
+	// distinguishes a provider that served the model from one that promised to: a
+	// body that died mid-read is the failure branch, and clearing the streak
+	// there would put a model that never actually answers out of reach of a
+	// retirement forever.
 	//
-	// Not gated on circuitBreakerEnabled either, unlike its neighbour. The
-	// breaker is an operator's routing choice; whether a model still exists is
-	// not, and turning the breaker off must not silently stop strikes being
-	// cleared.
+	// Not gated on circuitBreakerEnabled, unlike its neighbour: the breaker is an
+	// operator's routing choice, and whether a model still exists is not.
 	//
-	// Family-gated on the way in, exactly as the strike is: noteModelServed
-	// resolves the endpoint family to a probe surface and clears that one streak,
-	// so an embeddings 200 says nothing about the chat surface and an image or
-	// TTS 200 says nothing about either. A response is evidence about the
-	// question it answers, and the retirement question is per surface.
-	//
-	// Gated on bytes having arrived, exactly as the streamed twin gates on its
-	// first byte. A 200 with an empty body reads as a successful read here, and
-	// crediting it would let a provider (or a CDN in front of one) that
-	// intermittently answers 200 with nothing reset the count between genuine
-	// refusals, so a retired model would never reach three CONSECUTIVE strikes
-	// and would never be nominated at all.
-	//
-	// And judged by the same rule the probe uses, for the one family this can
-	// matter to. See passthroughAnswered.
+	// Family-gated inside noteModelServed, exactly as the strike is, so an
+	// embeddings 200 says nothing about the chat surface and an image or TTS 200
+	// says nothing about either. And gated on bytes having arrived, judged by the
+	// same rule the probe uses — see passthroughAnswered.
 	if passthroughAnswered(logData.endpointType, body) {
 		h.noteModelServed(candidate.model, logData.endpointType)
 	}
@@ -647,17 +614,13 @@ func (h *Handler) serveStreamedPassthrough(w http.ResponseWriter, r *http.Reques
 	}
 	// The streamed commit point, matching the buffered one: a first byte out of
 	// the provider is where a 200 stops being a promise. See the twin call in
-	// serveBufferedJSONPassthrough for why it is here, ungated by the breaker
-	// setting, and gated by the endpoint family inside noteModelServed.
+	// serveBufferedJSONPassthrough.
 	//
-	// Gated on a byte having actually arrived, which the breaker call above is
-	// deliberately not. They are answering different questions. A 204 that
-	// carries nothing is a legitimate HTTP success and the provider is plainly
-	// alive, so it belongs in the breaker's ledger; but it says nothing whatever
-	// about whether this MODEL is still served, and "a response that carried
-	// nothing is not evidence" is the same rule judgeProbeSuccess applies to the
-	// probe's own 200s. Clearing a streak on it would credit the model with an
-	// answer nobody received.
+	// Gated on a byte having arrived, which the breaker call above deliberately
+	// is not: they answer different questions. A 204 carrying nothing is a
+	// legitimate HTTP success and the provider is plainly alive, so it belongs in
+	// the breaker's ledger, but it says nothing about whether this MODEL is still
+	// served — the same rule judgeProbeSuccess applies to the probe's own 200s.
 	if n > 0 {
 		h.noteModelServed(candidate.model, logData.endpointType)
 	}

--- a/internal/proxy/multimodal.go
+++ b/internal/proxy/multimodal.go
@@ -577,7 +577,18 @@ func (h *Handler) serveStreamedPassthrough(w http.ResponseWriter, r *http.Reques
 	// the provider is where a 200 stops being a promise. See the twin call in
 	// serveBufferedJSONPassthrough for why it is here, ungated by the breaker
 	// setting, and ungated by the endpoint family.
-	h.noteModelServed(candidate.model)
+	//
+	// Gated on a byte having actually arrived, which the breaker call above is
+	// deliberately not. They are answering different questions. A 204 that
+	// carries nothing is a legitimate HTTP success and the provider is plainly
+	// alive, so it belongs in the breaker's ledger; but it says nothing whatever
+	// about whether this MODEL is still served, and "a response that carried
+	// nothing is not evidence" is the same rule judgeProbeSuccess applies to the
+	// probe's own 200s. Clearing a streak on it would credit the model with an
+	// answer nobody received.
+	if n > 0 {
+		h.noteModelServed(candidate.model)
+	}
 
 	copyPassthroughHeaders(w, resp, contentType)
 	if isSSE {

--- a/internal/proxy/multimodal.go
+++ b/internal/proxy/multimodal.go
@@ -511,10 +511,11 @@ func (h *Handler) serveBufferedJSONPassthrough(w http.ResponseWriter, st *reques
 	// not, and turning the breaker off must not silently stop strikes being
 	// cleared.
 	//
-	// Unconditional on the family, unlike the strike. A strike has to be gated
-	// because it cannot be adjudicated for an image or TTS model, but a served
-	// body from any surface is evidence the provider still serves the model, and
-	// clearing a streak can only ever PREVENT a retirement.
+	// Family-gated on the way in, exactly as the strike is: noteModelServed
+	// resolves the endpoint family to a probe surface and clears that one streak,
+	// so an embeddings 200 says nothing about the chat surface and an image or
+	// TTS 200 says nothing about either. A response is evidence about the
+	// question it answers, and the retirement question is per surface.
 	//
 	// Gated on bytes having arrived, exactly as the streamed twin gates on its
 	// first byte. A 200 with an empty body reads as a successful read here, and
@@ -591,7 +592,7 @@ func (h *Handler) serveStreamedPassthrough(w http.ResponseWriter, r *http.Reques
 	// The streamed commit point, matching the buffered one: a first byte out of
 	// the provider is where a 200 stops being a promise. See the twin call in
 	// serveBufferedJSONPassthrough for why it is here, ungated by the breaker
-	// setting, and ungated by the endpoint family.
+	// setting, and gated by the endpoint family inside noteModelServed.
 	//
 	// Gated on a byte having actually arrived, which the breaker call above is
 	// deliberately not. They are answering different questions. A 204 that

--- a/internal/proxy/multimodal.go
+++ b/internal/proxy/multimodal.go
@@ -515,7 +515,22 @@ func (h *Handler) serveBufferedJSONPassthrough(w http.ResponseWriter, st *reques
 	// because it cannot be adjudicated for an image or TTS model, but a served
 	// body from any surface is evidence the provider still serves the model, and
 	// clearing a streak can only ever PREVENT a retirement.
-	h.noteModelServed(candidate.model)
+	//
+	// Gated on bytes having arrived, exactly as the streamed twin gates on its
+	// first byte. A 200 with an empty body reads as a successful read here, and
+	// crediting it would let a provider (or a CDN in front of one) that
+	// intermittently answers 200 with nothing reset the count between genuine
+	// refusals, so a retired model would never reach three CONSECUTIVE strikes
+	// and would never be nominated at all.
+	//
+	// Bytes and not content, which is where this stops. The pass-through path
+	// forwards every family verbatim and does not know the shape of an
+	// embeddings, image or audio answer; judging one here would mean teaching it
+	// response schemas it deliberately does not have. "The provider sent
+	// something" is the same bar its neighbour applies.
+	if len(body) > 0 {
+		h.noteModelServed(candidate.model)
+	}
 	copyPassthroughHeaders(w, resp, contentType)
 
 	if len(body) > passthroughJSONBufferCap {

--- a/internal/proxy/multimodal.go
+++ b/internal/proxy/multimodal.go
@@ -432,6 +432,34 @@ func (h *Handler) attemptPassthroughCandidate(w http.ResponseWriter, r *http.Req
 	return outcomeServed
 }
 
+// passthroughAnswered reports whether a buffered pass-through response is the
+// model answering, for the purpose of clearing its gone-strike streak.
+//
+// Embeddings is judged on content, by the same function the probe uses. It is
+// the only pass-through family that can be auto-retired, so it is the only one
+// where getting this wrong has a consequence — and the package plainly does know
+// what an embeddings answer looks like, since probeDeliveredContent implements
+// exactly this check and extractPassthroughUsage parses the same document a line
+// later. A provider alternating gone-shaped 404s with 200 {"data":[]} would
+// otherwise reset the count on every empty answer and the model would never be
+// nominated, which is the failure chatAnswerCarriesContent closes on the chat
+// path.
+//
+// Everything else is judged on bytes, and deliberately: this path forwards image
+// and audio answers verbatim and has no business parsing them. It costs nothing
+// to be generous there, because noteModelServed clears the streak for the
+// surface the response arrived on, and those surfaces have no streak to clear —
+// they are never auto-retired in the first place.
+func passthroughAnswered(endpointType string, body []byte) bool {
+	if len(body) == 0 {
+		return false
+	}
+	if endpointType == endpointTypeEmbeddings {
+		return probeDeliveredContent(endpointTypeEmbeddings, body)
+	}
+	return true
+}
+
 // passthroughJSONBufferCap bounds how much of a JSON pass-through response is
 // buffered for token-usage extraction. Bodies beyond the cap (e.g. multi-image
 // b64_json payloads) are streamed through unbuffered with usage skipped,
@@ -536,12 +564,9 @@ func (h *Handler) serveBufferedJSONPassthrough(w http.ResponseWriter, st *reques
 	// refusals, so a retired model would never reach three CONSECUTIVE strikes
 	// and would never be nominated at all.
 	//
-	// Bytes and not content, which is where this stops. The pass-through path
-	// forwards every family verbatim and does not know the shape of an
-	// embeddings, image or audio answer; judging one here would mean teaching it
-	// response schemas it deliberately does not have. "The provider sent
-	// something" is the same bar its neighbour applies.
-	if len(body) > 0 {
+	// And judged by the same rule the probe uses, for the one family this can
+	// matter to. See passthroughAnswered.
+	if passthroughAnswered(logData.endpointType, body) {
 		h.noteModelServed(candidate.model, logData.endpointType)
 	}
 	copyPassthroughHeaders(w, resp, contentType)

--- a/internal/proxy/multimodal.go
+++ b/internal/proxy/multimodal.go
@@ -409,6 +409,23 @@ func (h *Handler) attemptPassthroughCandidate(w http.ResponseWriter, r *http.Req
 		return h.forwardUpstreamError(w, st, candidate, resp, attempt, hasMoreCandidates, responseHeaderMs)
 	}
 
+	// The provider served the model, so any gone-strike streak it had is stale.
+	// This is the success half of the signal the failover branch above records,
+	// and without it "three CONSECUTIVE refusals" was not true on this path:
+	// embeddings is the one pass-through family that can be auto-retired, and its
+	// strikes only ever expired with goneStrikeWindow. Three refusals scattered
+	// across half an hour of otherwise healthy traffic reached the threshold and
+	// spent a probe, where the chat path would have cleared the count on the first
+	// success in between.
+	//
+	// Unconditional on the family, unlike the strike. A strike has to be gated
+	// because it cannot be adjudicated for an image or TTS model, but a 2xx from
+	// any surface is evidence the provider still serves the model, and clearing a
+	// streak can only ever PREVENT a retirement. Nothing is at risk from being
+	// generous here, and a model taking both chat and embeddings traffic gets the
+	// same answer from either.
+	h.noteModelServed(candidate.model)
+
 	// Breaker success for 2xx is recorded inside servePassthroughResponse at
 	// the commit point (headers for buffered JSON, first body byte for
 	// SSE/binary), so a provider that returns 200 and then stalls or dies

--- a/internal/proxy/multimodal.go
+++ b/internal/proxy/multimodal.go
@@ -454,6 +454,17 @@ func passthroughAnswered(endpointType string, body []byte) bool {
 	if len(body) == 0 {
 		return false
 	}
+	// Past the buffer cap, body is a PREFIX: the caller read
+	// passthroughJSONBufferCap+1 bytes and streams the remainder. Truncated JSON
+	// never parses, so handing it to the content check below would report that a
+	// provider which just produced megabytes had answered with nothing — and a
+	// batch embeddings call clears 8 MiB at around 140 inputs of 3072
+	// dimensions, which is ordinary document-indexing traffic. The success side
+	// of the streak would be permanently dead on that workload: three refusals
+	// would nominate a live model and spend a probe on it, over and over.
+	if len(body) > passthroughJSONBufferCap {
+		return true
+	}
 	if endpointType == endpointTypeEmbeddings {
 		return probeDeliveredContent(endpointTypeEmbeddings, body)
 	}

--- a/internal/proxy/multimodal.go
+++ b/internal/proxy/multimodal.go
@@ -357,10 +357,22 @@ func (h *Handler) attemptPassthroughCandidate(w http.ResponseWriter, r *http.Req
 	defer failoverCancel()
 	failoverCtx = context.WithValue(failoverCtx, ctxkeys.CancelOriginKey, "failover_timeout")
 
-	resp, _, _, ok := h.beginAttempt(failoverCtx, st, candidate, attempt, totalCandidates, &dialMs)
+	resp, providerType, _, ok := h.beginAttempt(failoverCtx, st, candidate, attempt, totalCandidates, &dialMs)
 	if !ok {
 		return outcomeFailover
 	}
+
+	// MiniMax reports business errors (rate limit, exhausted plan balance, auth
+	// failures) inside an HTTP 200 envelope, so the status has to be normalised
+	// before anything is judged from it — exactly as attemptCandidate,
+	// probeStreamingCandidate and probeModel all do.
+	//
+	// This loop was the one that did not, and until the retirement work that only
+	// cost a spurious breaker success. It costs more now: the 2xx branch below
+	// clears the model's gone-strike streak, so a refusal wrapped in a 200 was
+	// being recorded as the model answering and resetting the consecutive count
+	// that a retirement depends on.
+	resp = remapMiniMaxBusinessError(providerType, candidate.provider.Name, resp)
 
 	responseHeaderMs := float64(time.Since(st.startTime).Microseconds()) / 1000.0
 	hasMoreCandidates := attempt < totalCandidates-1

--- a/internal/proxy/multimodal.go
+++ b/internal/proxy/multimodal.go
@@ -529,7 +529,7 @@ func (h *Handler) serveBufferedJSONPassthrough(w http.ResponseWriter, st *reques
 	// response schemas it deliberately does not have. "The provider sent
 	// something" is the same bar its neighbour applies.
 	if len(body) > 0 {
-		h.noteModelServed(candidate.model)
+		h.noteModelServed(candidate.model, logData.endpointType)
 	}
 	copyPassthroughHeaders(w, resp, contentType)
 
@@ -602,7 +602,7 @@ func (h *Handler) serveStreamedPassthrough(w http.ResponseWriter, r *http.Reques
 	// probe's own 200s. Clearing a streak on it would credit the model with an
 	// answer nobody received.
 	if n > 0 {
-		h.noteModelServed(candidate.model)
+		h.noteModelServed(candidate.model, logData.endpointType)
 	}
 
 	copyPassthroughHeaders(w, resp, contentType)

--- a/internal/proxy/multimodal.go
+++ b/internal/proxy/multimodal.go
@@ -382,12 +382,11 @@ func (h *Handler) attemptPassthroughCandidate(w http.ResponseWriter, r *http.Req
 			// the same discard, one classifier call on a body the request path
 			// has already given up on.
 			//
-			// Bounded rather than read whole, unlike the chat path. These are the
-			// multimodal endpoints, where a body can be a multi-megabyte image
-			// payload; the classifier only ever sees the first 10 000 characters
-			// of it, so anything past the cap is drained straight to Discard
-			// instead of being held in memory to be thrown away.
-			drained, _ := io.ReadAll(io.LimitReader(resp.Body, passthroughErrorClassifyCap))
+			// Bounded, and the cap matters more here than on the chat path that
+			// shares it: these are the multimodal endpoints, where the body
+			// behind an error status can be an image payload rather than a
+			// sentence.
+			drained, _ := io.ReadAll(io.LimitReader(resp.Body, failoverErrorClassifyCap))
 			_, _ = io.Copy(io.Discard, resp.Body)
 			_ = resp.Body.Close()
 			if kind, _ := classifyUpstreamError(resp.StatusCode, util.SanitizeLogBody(string(drained), 10000), candidate.model.ModelID); kind == KindProviderModelGone {
@@ -418,13 +417,6 @@ func (h *Handler) attemptPassthroughCandidate(w http.ResponseWriter, r *http.Req
 	h.servePassthroughResponse(w, r, st, candidate, resp, attempt, responseHeaderMs)
 	return outcomeServed
 }
-
-// passthroughErrorClassifyCap bounds how much of a discarded failover error body
-// is held in memory long enough to be classified. classifyUpstreamError never
-// sees more than util.SanitizeLogBody's own 10 000 characters, so reading
-// further would retain bytes nothing can read — and on these endpoints the body
-// behind an error status can be an image payload rather than a sentence.
-const passthroughErrorClassifyCap = 16 << 10
 
 // passthroughJSONBufferCap bounds how much of a JSON pass-through response is
 // buffered for token-usage extraction. Bodies beyond the cap (e.g. multi-image

--- a/internal/proxy/multimodal_passthrough_test.go
+++ b/internal/proxy/multimodal_passthrough_test.go
@@ -500,6 +500,58 @@ func TestEmbeddings_ResponsesThatCarryNothingKeepTheGoneStrikes(t *testing.T) {
 	}
 }
 
+// TestAttemptPassthroughCandidate_AMiniMaxRefusalInsideA200KeepsTheStreak pins
+// that the pass-through loop normalises MiniMax's 200-wrapped errors like every
+// other attempt path does.
+//
+// MiniMax reports rate limits, an exhausted plan balance and auth failures
+// inside an HTTP 200 envelope. attemptCandidate, probeStreamingCandidate and
+// probeModel all remap them before judging anything; this loop did not, and
+// until the retirement work that only cost a spurious breaker success. Now the
+// 2xx branch clears the model's gone-strike streak, so a refusal wrapped in a
+// 200 was recorded as the model answering and reset the consecutive count a
+// retirement depends on.
+func TestAttemptPassthroughCandidate_AMiniMaxRefusalInsideA200KeepsTheStreak(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandler(h)
+
+	// A 200 whose envelope says rate-limited, which remaps to 429.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"base_resp":{"status_code":1002,"status_msg":"rate limit exceeded"}}`)
+	}))
+	defer srv.Close()
+	// The hostname decides the provider dialect, so the transport dials the test
+	// server regardless of it. Plain http, because that dial hands back a TCP
+	// connection to an httptest server that speaks no TLS.
+	h.upstreamTransport = dialToTestServer(t, srv)
+
+	m := &model.Model{ID: uuid.New(), ModelID: "MiniMax-Text-01", InputModalities: `["text"]`, OutputModalities: `["embedding"]`}
+	cand := goneCandidateAt(m, "MiniMax", "http://api.minimax.io/v1")
+
+	// One real refusal, so there is a streak for the 200 to clear.
+	h.noteModelGone(cand, endpointTypeEmbeddings)
+	streak := goneStreakFor(t, h, m.ID, probeEmbeddingsEndpoint)
+
+	st := &requestState{
+		startTime:       time.Now(),
+		reqModel:        "MiniMax-Text-01",
+		endpointPath:    "/embeddings",
+		bodyBytes:       []byte(`{"model":"MiniMax-Text-01","input":"hi"}`),
+		failoverTimeout: 30 * time.Second,
+		logData:         &requestLogData{modelID: "MiniMax-Text-01", endpointType: endpointTypeEmbeddings},
+	}
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/v1/embeddings", http.NoBody)
+
+	if got := h.attemptPassthroughCandidate(w, r, st, cand, 0, 1); got != outcomeFatal {
+		t.Fatalf("outcome = %v, want a terminal error for a remapped 429", got)
+	}
+	if n := streak.count(); n != 1 {
+		t.Fatalf("streak = %d, want the strike kept: a refusal inside a 200 is not the model answering", n)
+	}
+}
+
 func TestEmbeddings_UpstreamErrorReturnsOpenAIError(t *testing.T) {
 	env := newMultimodalEnv(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/proxy/multimodal_passthrough_test.go
+++ b/internal/proxy/multimodal_passthrough_test.go
@@ -437,6 +437,62 @@ func TestEmbeddings_ADeadBodyDoesNotClearTheGoneStrikes(t *testing.T) {
 	}
 }
 
+// TestEmbeddings_AnEmptyResponseDoesNotClearTheGoneStrikes is the streamed
+// commit point's version of the question the test above asks of the buffered
+// one: a 2xx that carried no bytes is not the model answering.
+//
+// A 204 is a legitimate HTTP success and belongs in the breaker's ledger — the
+// provider is plainly alive. It says nothing whatever about whether this MODEL
+// is still served, which is the same distinction judgeProbeSuccess draws for the
+// probe's own 200s. Clearing the streak on it credits the model with an answer
+// nobody received.
+func TestEmbeddings_AnEmptyResponseDoesNotClearTheGoneStrikes(t *testing.T) {
+	var goneModelName atomic.Value
+	var refuse atomic.Bool
+	refuse.Store(true)
+	env := newMultimodalEnv(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if refuse.Load() {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			name, _ := goneModelName.Load().(string)
+			_, _ = fmt.Fprintf(w, "{\"error\":{\"message\":\"The model `%s` does not exist\"}}", name)
+			return
+		}
+		// No content type and no body: the pass-through takes its streamed
+		// branch and finds nothing to commit on.
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	goneModelName.Store(env.modelName)
+
+	body := fmt.Sprintf(`{"model":"%s/%s","input":"hi"}`, env.providerName, env.modelName)
+	embed := func() int {
+		req := env.request("/v1/embeddings", "application/json", strings.NewReader(body))
+		w := httptest.NewRecorder()
+		env.handler.Embeddings(w, req)
+		return w.Code
+	}
+
+	if code := embed(); code != http.StatusNotFound {
+		t.Fatalf("status = %d, want the provider's 404", code)
+	}
+	raw, ok := env.handler.goneStrikes.Load(env.modelUUID)
+	if !ok {
+		t.Fatal("the refusal accrued no strike")
+	}
+	streak, ok := raw.(*goneStreak)
+	if !ok {
+		t.Fatalf("unexpected streak type %T", raw)
+	}
+
+	refuse.Store(false)
+	if code := embed(); code != http.StatusNoContent {
+		t.Fatalf("status = %d, want the provider's 204 forwarded", code)
+	}
+	if n := streak.count(); n != 1 {
+		t.Fatalf("streak = %d, want the strike kept: a response that carried nothing is not evidence about the model", n)
+	}
+}
+
 func TestEmbeddings_UpstreamErrorReturnsOpenAIError(t *testing.T) {
 	env := newMultimodalEnv(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/proxy/multimodal_passthrough_test.go
+++ b/internal/proxy/multimodal_passthrough_test.go
@@ -442,6 +442,19 @@ func TestEmbeddings_ResponsesThatCarryNothingKeepTheGoneStrikes(t *testing.T) {
 			wantStatus: http.StatusOK,
 		},
 		{
+			// A well-formed embeddings response carrying no embedding. The
+			// probe already refuses to credit this shape; the traffic path has
+			// to agree, or an aggregator alternating gone-shaped 404s with an
+			// empty 200 resets the count on every other request and the model is
+			// never nominated.
+			name: "empty embeddings payload",
+			answer: func(_ *testing.T, w http.ResponseWriter) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, `{"object":"list","data":[]}`)
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
 			// A 204 is a legitimate HTTP success and belongs in the breaker's
 			// ledger, because the provider is plainly alive. It still says
 			// nothing about whether this MODEL is served.

--- a/internal/proxy/multimodal_passthrough_test.go
+++ b/internal/proxy/multimodal_passthrough_test.go
@@ -237,6 +237,75 @@ func TestEmbeddings_FailoverToNextProvider(t *testing.T) {
 	}
 }
 
+// TestEmbeddings_FailoverStillRecordsTheGoneSignal pins that failing over does
+// not throw the retirement evidence away.
+//
+// A retired model usually answers 404, which is failover-eligible, so the branch
+// that hands the request to the next candidate is the branch a dead model's
+// refusals actually take. It drained the body and moved on without classifying
+// it, which meant a model sitting anywhere but LAST in a failover group accrued
+// no strikes at all: only the final candidate reaches forwardUpstreamError,
+// where the strike is recorded. attemptCandidate has classified on the way out
+// for chat since the feature was written; the pass-through loop is the same
+// request path for embeddings, which is now an auto-retirable family.
+//
+// Delete this and traffic-driven retirement quietly stops working for exactly
+// the models that have somewhere to fail over to.
+func TestEmbeddings_FailoverStillRecordsTheGoneSignal(t *testing.T) {
+	// The upstream handler needs the model's generated name to refuse it BY
+	// NAME: classifyUpstreamError only reads a gone-phrase as a retirement when
+	// the body names the model the request asked for.
+	var goneModelName atomic.Value
+	envGone := newMultimodalEnv(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		name, _ := goneModelName.Load().(string)
+		_, _ = fmt.Fprintf(w, "{\"error\":{\"message\":\"The model `%s` does not exist\"}}", name)
+	}))
+	goneModelName.Store(envGone.modelName)
+
+	goodUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"object":"list","data":[{"object":"embedding","embedding":[0.1],"index":0}]}`)
+	}))
+	t.Cleanup(goodUpstream.Close)
+	_, _, goodModelUUID, _ := createMultimodalProvider(t, goodUpstream.URL)
+
+	groupName := envGone.modelName
+	failoverRepo := failover.NewRepository(testDB.Pool())
+	if _, err := failoverRepo.UpsertWithConfig(context.Background(), groupName,
+		[]uuid.UUID{envGone.modelUUID, goodModelUUID},
+		map[string]bool{envGone.modelUUID.String(): true, goodModelUUID.String(): true},
+		nil, nil, nil, nil); err != nil {
+		t.Fatalf("failed to create failover group: %v", err)
+	}
+
+	body := fmt.Sprintf(`{"model":"hotel/%s","input":"hi"}`, groupName)
+	req := envGone.request("/v1/embeddings", "application/json", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	envGone.handler.Embeddings(w, req)
+
+	// The client is served by the second candidate, exactly as before: recording
+	// the signal must not change what the request returns.
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 after failover (body: %s)", w.Code, w.Body.String())
+	}
+
+	// The strike itself is recorded synchronously — only the disable is detached
+	// — so this is the state the request left behind, not a race.
+	raw, ok := envGone.handler.goneStrikes.Load(envGone.modelUUID)
+	if !ok {
+		t.Fatal("the refused model accrued no strike, so it can never be auto-retired from a failover group")
+	}
+	streak, ok := raw.(*goneStreak)
+	if !ok {
+		t.Fatalf("unexpected streak type %T", raw)
+	}
+	if n := streak.count(); n != 1 {
+		t.Errorf("streak = %d, want exactly 1 strike for one refusal", n)
+	}
+}
+
 func TestEmbeddings_UpstreamErrorReturnsOpenAIError(t *testing.T) {
 	env := newMultimodalEnv(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/proxy/multimodal_passthrough_test.go
+++ b/internal/proxy/multimodal_passthrough_test.go
@@ -387,128 +387,116 @@ func TestEmbeddings_ASuccessClearsTheGoneStrikes(t *testing.T) {
 	}
 }
 
-// TestEmbeddings_ADeadBodyDoesNotClearTheGoneStrikes is the other half of the
-// test above: which 200 counts.
+// TestEmbeddings_ResponsesThatCarryNothingKeepTheGoneStrikes is the other half
+// of the test above: which 2xx counts as the model answering.
 //
-// 200 headers are a promise. The provider can send them and then die before a
-// byte of body arrives, which this file already treats as a provider FAILURE
-// everywhere else — the breaker records one, and the client gets a 502. Clearing
-// the streak on the headers would let a model that never actually answers keep
-// resetting its own count between refusals, so it would never reach three
-// consecutive strikes, never be probed, and never be retired: exactly the state
-// the strike machinery exists to escape.
-func TestEmbeddings_ADeadBodyDoesNotClearTheGoneStrikes(t *testing.T) {
-	var goneModelName atomic.Value
-	var refuse atomic.Bool
-	refuse.Store(true)
-	env := newMultimodalEnvWith(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		if refuse.Load() {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusNotFound)
-			name, _ := goneModelName.Load().(string)
-			_, _ = fmt.Fprintf(w, "{\"error\":{\"message\":\"The model `%s` does not exist\"}}", name)
-			return
-		}
-		// 200 headers, a promise of 1000 bytes, and then the connection dies
-		// nine bytes in.
-		hj, ok := w.(http.Hijacker)
-		if !ok {
-			t.Error("test server does not support hijacking")
-			return
-		}
-		conn, buf, err := hj.Hijack()
-		if err != nil {
-			t.Errorf("hijack: %v", err)
-			return
-		}
-		_, _ = buf.WriteString("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 1000\r\n\r\n{\"object\":")
-		_ = buf.Flush()
-		_ = conn.Close()
-	}), `["embedding"]`)
-	goneModelName.Store(env.modelName)
-
-	body := fmt.Sprintf(`{"model":"%s/%s","input":"hi"}`, env.providerName, env.modelName)
-	embed := func() int {
-		req := env.request("/v1/embeddings", "application/json", strings.NewReader(body))
-		w := httptest.NewRecorder()
-		env.handler.Embeddings(w, req)
-		return w.Code
-	}
-
-	if code := embed(); code != http.StatusNotFound {
-		t.Fatalf("status = %d, want the provider's 404", code)
-	}
-	raw, ok := env.handler.goneStrikes.Load(goneStreakKey{model: env.modelUUID, endpoint: probeEmbeddingsEndpoint})
-	if !ok {
-		t.Fatal("the refusal accrued no strike")
-	}
-	streak, ok := raw.(*goneStreak)
-	if !ok {
-		t.Fatalf("unexpected streak type %T", raw)
-	}
-
-	refuse.Store(false)
-	if code := embed(); code != http.StatusBadGateway {
-		t.Fatalf("status = %d, want 502 for a body that died mid-read", code)
-	}
-	if n := streak.count(); n != 1 {
-		t.Fatalf("streak = %d, want the strike kept: a 200 that produced no body is not the model answering", n)
-	}
-}
-
-// TestEmbeddings_AnEmptyResponseDoesNotClearTheGoneStrikes is the streamed
-// commit point's version of the question the test above asks of the buffered
-// one: a 2xx that carried no bytes is not the model answering.
+// A status is a promise; bytes are the evidence. All three cases below are
+// responses the pass-through path is perfectly happy with and none of them
+// carried an answer, so none may reset a strike count. Crediting any of them
+// would let a provider — or a CDN in front of one — that intermittently returns
+// an empty success keep a retired model from ever reaching three CONSECUTIVE
+// strikes: it would never be nominated, never probed, and never retired, which
+// is exactly the state the strike machinery exists to escape.
 //
-// A 204 is a legitimate HTTP success and belongs in the breaker's ledger — the
-// provider is plainly alive. It says nothing whatever about whether this MODEL
-// is still served, which is the same distinction judgeProbeSuccess draws for the
-// probe's own 200s. Clearing the streak on it credits the model with an answer
-// nobody received.
-func TestEmbeddings_AnEmptyResponseDoesNotClearTheGoneStrikes(t *testing.T) {
-	var goneModelName atomic.Value
-	var refuse atomic.Bool
-	refuse.Store(true)
-	env := newMultimodalEnvWith(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		if refuse.Load() {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusNotFound)
-			name, _ := goneModelName.Load().(string)
-			_, _ = fmt.Fprintf(w, "{\"error\":{\"message\":\"The model `%s` does not exist\"}}", name)
-			return
-		}
-		// No content type and no body: the pass-through takes its streamed
-		// branch and finds nothing to commit on.
-		w.WriteHeader(http.StatusNoContent)
-	}), `["embedding"]`)
-	goneModelName.Store(env.modelName)
+// The three cover both commit points. The first two take the buffered JSON
+// branch (a body that dies mid-read, and a clean 200 that carries nothing), the
+// third takes the streamed branch, and the point of running them together is
+// that the two branches must answer the same way.
+func TestEmbeddings_ResponsesThatCarryNothingKeepTheGoneStrikes(t *testing.T) {
+	cases := []struct {
+		name       string
+		answer     func(t *testing.T, w http.ResponseWriter)
+		wantStatus int
+	}{
+		{
+			// 200 headers, a promise of 1000 bytes, and then the connection
+			// dies nine bytes in. The breaker already records this as a
+			// provider failure and the client gets a 502.
+			name: "body dies mid-read",
+			answer: func(t *testing.T, w http.ResponseWriter) {
+				hj, ok := w.(http.Hijacker)
+				if !ok {
+					t.Error("test server does not support hijacking")
+					return
+				}
+				conn, buf, err := hj.Hijack()
+				if err != nil {
+					t.Errorf("hijack: %v", err)
+					return
+				}
+				_, _ = buf.WriteString("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 1000\r\n\r\n{\"object\":")
+				_ = buf.Flush()
+				_ = conn.Close()
+			},
+			wantStatus: http.StatusBadGateway,
+		},
+		{
+			// A clean, complete, entirely contentless 200. The read succeeds,
+			// which is what makes this the easiest of the three to credit by
+			// accident.
+			name: "empty json 200",
+			answer: func(_ *testing.T, w http.ResponseWriter) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			// A 204 is a legitimate HTTP success and belongs in the breaker's
+			// ledger, because the provider is plainly alive. It still says
+			// nothing about whether this MODEL is served.
+			name: "204 no content",
+			answer: func(_ *testing.T, w http.ResponseWriter) {
+				w.WriteHeader(http.StatusNoContent)
+			},
+			wantStatus: http.StatusNoContent,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var goneModelName atomic.Value
+			var refuse atomic.Bool
+			refuse.Store(true)
+			env := newMultimodalEnvWith(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				if refuse.Load() {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusNotFound)
+					name, _ := goneModelName.Load().(string)
+					_, _ = fmt.Fprintf(w, "{\"error\":{\"message\":\"The model `%s` does not exist\"}}", name)
+					return
+				}
+				tc.answer(t, w)
+			}), `["embedding"]`)
+			goneModelName.Store(env.modelName)
 
-	body := fmt.Sprintf(`{"model":"%s/%s","input":"hi"}`, env.providerName, env.modelName)
-	embed := func() int {
-		req := env.request("/v1/embeddings", "application/json", strings.NewReader(body))
-		w := httptest.NewRecorder()
-		env.handler.Embeddings(w, req)
-		return w.Code
-	}
+			body := fmt.Sprintf(`{"model":"%s/%s","input":"hi"}`, env.providerName, env.modelName)
+			embed := func() int {
+				req := env.request("/v1/embeddings", "application/json", strings.NewReader(body))
+				w := httptest.NewRecorder()
+				env.handler.Embeddings(w, req)
+				return w.Code
+			}
 
-	if code := embed(); code != http.StatusNotFound {
-		t.Fatalf("status = %d, want the provider's 404", code)
-	}
-	raw, ok := env.handler.goneStrikes.Load(goneStreakKey{model: env.modelUUID, endpoint: probeEmbeddingsEndpoint})
-	if !ok {
-		t.Fatal("the refusal accrued no strike")
-	}
-	streak, ok := raw.(*goneStreak)
-	if !ok {
-		t.Fatalf("unexpected streak type %T", raw)
-	}
+			if code := embed(); code != http.StatusNotFound {
+				t.Fatalf("status = %d, want the provider's 404", code)
+			}
+			raw, ok := env.handler.goneStrikes.Load(goneStreakKey{model: env.modelUUID, endpoint: probeEmbeddingsEndpoint})
+			if !ok {
+				t.Fatal("the refusal accrued no strike")
+			}
+			streak, ok := raw.(*goneStreak)
+			if !ok {
+				t.Fatalf("unexpected streak type %T", raw)
+			}
 
-	refuse.Store(false)
-	if code := embed(); code != http.StatusNoContent {
-		t.Fatalf("status = %d, want the provider's 204 forwarded", code)
-	}
-	if n := streak.count(); n != 1 {
-		t.Fatalf("streak = %d, want the strike kept: a response that carried nothing is not evidence about the model", n)
+			refuse.Store(false)
+			if code := embed(); code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d", code, tc.wantStatus)
+			}
+			if n := streak.count(); n != 1 {
+				t.Fatalf("streak = %d, want the strike kept: a response that carried nothing is not the model answering", n)
+			}
+		})
 	}
 }
 

--- a/internal/proxy/multimodal_passthrough_test.go
+++ b/internal/proxy/multimodal_passthrough_test.go
@@ -306,6 +306,68 @@ func TestEmbeddings_FailoverStillRecordsTheGoneSignal(t *testing.T) {
 	}
 }
 
+// TestEmbeddings_ASuccessClearsTheGoneStrikes pins the success half of
+// traffic-driven retirement on the pass-through path.
+//
+// The strike is only half a signal. What makes three strikes mean anything is
+// that they have to be CONSECUTIVE: a success in between resets the count, so a
+// retirement is drawn from a run of failures rather than from three unrelated
+// ones. The chat loop has always done that; the pass-through loop recorded
+// strikes and never cleared them, so for embeddings — the one pass-through
+// family that can be auto-retired — nothing but the 30-minute window bounded
+// them. A model serving thousands of requests an hour that drew three scattered
+// 404s in half an hour reached the threshold and spent a probe on a model that
+// was demonstrably working the whole time.
+func TestEmbeddings_ASuccessClearsTheGoneStrikes(t *testing.T) {
+	var goneModelName atomic.Value
+	var refuse atomic.Bool
+	refuse.Store(true)
+	env := newMultimodalEnv(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if refuse.Load() {
+			w.WriteHeader(http.StatusNotFound)
+			name, _ := goneModelName.Load().(string)
+			_, _ = fmt.Fprintf(w, "{\"error\":{\"message\":\"The model `%s` does not exist\"}}", name)
+			return
+		}
+		_, _ = io.WriteString(w, `{"object":"list","data":[{"object":"embedding","embedding":[0.1],"index":0}]}`)
+	}))
+	goneModelName.Store(env.modelName)
+
+	body := fmt.Sprintf(`{"model":"%s/%s","input":"hi"}`, env.providerName, env.modelName)
+	embed := func() int {
+		req := env.request("/v1/embeddings", "application/json", strings.NewReader(body))
+		w := httptest.NewRecorder()
+		env.handler.Embeddings(w, req)
+		return w.Code
+	}
+
+	if code := embed(); code != http.StatusNotFound {
+		t.Fatalf("status = %d, want the provider's 404", code)
+	}
+	raw, ok := env.handler.goneStrikes.Load(env.modelUUID)
+	if !ok {
+		t.Fatal("the refusal accrued no strike")
+	}
+	streak, ok := raw.(*goneStreak)
+	if !ok {
+		t.Fatalf("unexpected streak type %T", raw)
+	}
+	if n := streak.count(); n != 1 {
+		t.Fatalf("streak = %d, want 1 after one refusal", n)
+	}
+
+	// The same model now answers. That is the evidence a strike is measured
+	// against, and it must reset the count.
+	refuse.Store(false)
+	if code := embed(); code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", code)
+	}
+	if n := streak.count(); n != 0 {
+		t.Fatalf("streak = %d, want 0 after the model answered", n)
+	}
+}
+
 func TestEmbeddings_UpstreamErrorReturnsOpenAIError(t *testing.T) {
 	env := newMultimodalEnv(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/proxy/multimodal_passthrough_test.go
+++ b/internal/proxy/multimodal_passthrough_test.go
@@ -293,7 +293,7 @@ func TestEmbeddings_FailoverStillRecordsTheGoneSignal(t *testing.T) {
 
 	// The strike itself is recorded synchronously — only the disable is detached
 	// — so this is the state the request left behind, not a race.
-	raw, ok := envGone.handler.goneStrikes.Load(envGone.modelUUID)
+	raw, ok := envGone.handler.goneStrikes.Load(goneStreakKey{model: envGone.modelUUID, endpoint: probeEmbeddingsEndpoint})
 	if !ok {
 		t.Fatal("the refused model accrued no strike, so it can never be auto-retired from a failover group")
 	}
@@ -345,7 +345,7 @@ func TestEmbeddings_ASuccessClearsTheGoneStrikes(t *testing.T) {
 	if code := embed(); code != http.StatusNotFound {
 		t.Fatalf("status = %d, want the provider's 404", code)
 	}
-	raw, ok := env.handler.goneStrikes.Load(env.modelUUID)
+	raw, ok := env.handler.goneStrikes.Load(goneStreakKey{model: env.modelUUID, endpoint: probeEmbeddingsEndpoint})
 	if !ok {
 		t.Fatal("the refusal accrued no strike")
 	}
@@ -419,7 +419,7 @@ func TestEmbeddings_ADeadBodyDoesNotClearTheGoneStrikes(t *testing.T) {
 	if code := embed(); code != http.StatusNotFound {
 		t.Fatalf("status = %d, want the provider's 404", code)
 	}
-	raw, ok := env.handler.goneStrikes.Load(env.modelUUID)
+	raw, ok := env.handler.goneStrikes.Load(goneStreakKey{model: env.modelUUID, endpoint: probeEmbeddingsEndpoint})
 	if !ok {
 		t.Fatal("the refusal accrued no strike")
 	}
@@ -475,7 +475,7 @@ func TestEmbeddings_AnEmptyResponseDoesNotClearTheGoneStrikes(t *testing.T) {
 	if code := embed(); code != http.StatusNotFound {
 		t.Fatalf("status = %d, want the provider's 404", code)
 	}
-	raw, ok := env.handler.goneStrikes.Load(env.modelUUID)
+	raw, ok := env.handler.goneStrikes.Load(goneStreakKey{model: env.modelUUID, endpoint: probeEmbeddingsEndpoint})
 	if !ok {
 		t.Fatal("the refusal accrued no strike")
 	}

--- a/internal/proxy/multimodal_passthrough_test.go
+++ b/internal/proxy/multimodal_passthrough_test.go
@@ -368,6 +368,75 @@ func TestEmbeddings_ASuccessClearsTheGoneStrikes(t *testing.T) {
 	}
 }
 
+// TestEmbeddings_ADeadBodyDoesNotClearTheGoneStrikes is the other half of the
+// test above: which 200 counts.
+//
+// 200 headers are a promise. The provider can send them and then die before a
+// byte of body arrives, which this file already treats as a provider FAILURE
+// everywhere else — the breaker records one, and the client gets a 502. Clearing
+// the streak on the headers would let a model that never actually answers keep
+// resetting its own count between refusals, so it would never reach three
+// consecutive strikes, never be probed, and never be retired: exactly the state
+// the strike machinery exists to escape.
+func TestEmbeddings_ADeadBodyDoesNotClearTheGoneStrikes(t *testing.T) {
+	var goneModelName atomic.Value
+	var refuse atomic.Bool
+	refuse.Store(true)
+	env := newMultimodalEnv(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if refuse.Load() {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			name, _ := goneModelName.Load().(string)
+			_, _ = fmt.Fprintf(w, "{\"error\":{\"message\":\"The model `%s` does not exist\"}}", name)
+			return
+		}
+		// 200 headers, a promise of 1000 bytes, and then the connection dies
+		// nine bytes in.
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			t.Error("test server does not support hijacking")
+			return
+		}
+		conn, buf, err := hj.Hijack()
+		if err != nil {
+			t.Errorf("hijack: %v", err)
+			return
+		}
+		_, _ = buf.WriteString("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 1000\r\n\r\n{\"object\":")
+		_ = buf.Flush()
+		_ = conn.Close()
+	}))
+	goneModelName.Store(env.modelName)
+
+	body := fmt.Sprintf(`{"model":"%s/%s","input":"hi"}`, env.providerName, env.modelName)
+	embed := func() int {
+		req := env.request("/v1/embeddings", "application/json", strings.NewReader(body))
+		w := httptest.NewRecorder()
+		env.handler.Embeddings(w, req)
+		return w.Code
+	}
+
+	if code := embed(); code != http.StatusNotFound {
+		t.Fatalf("status = %d, want the provider's 404", code)
+	}
+	raw, ok := env.handler.goneStrikes.Load(env.modelUUID)
+	if !ok {
+		t.Fatal("the refusal accrued no strike")
+	}
+	streak, ok := raw.(*goneStreak)
+	if !ok {
+		t.Fatalf("unexpected streak type %T", raw)
+	}
+
+	refuse.Store(false)
+	if code := embed(); code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502 for a body that died mid-read", code)
+	}
+	if n := streak.count(); n != 1 {
+		t.Fatalf("streak = %d, want the strike kept: a 200 that produced no body is not the model answering", n)
+	}
+}
+
 func TestEmbeddings_UpstreamErrorReturnsOpenAIError(t *testing.T) {
 	env := newMultimodalEnv(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/proxy/multimodal_passthrough_test.go
+++ b/internal/proxy/multimodal_passthrough_test.go
@@ -455,6 +455,20 @@ func TestEmbeddings_ResponsesThatCarryNothingKeepTheGoneStrikes(t *testing.T) {
 			wantStatus: http.StatusOK,
 		},
 		{
+			// The same empty payload, unlabelled. Which twin runs was decided by
+			// the content type alone, so an aggregator or CDN that drops the
+			// header sent an embeddings answer to the streamed path — which
+			// commits on the first byte and cannot judge what it never holds, so
+			// eleven bytes cleared the streak through the one door that skips
+			// passthroughAnswered.
+			name: "empty embeddings payload, unlabelled",
+			answer: func(_ *testing.T, w http.ResponseWriter) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = io.WriteString(w, `{"object":"list","data":[]}`)
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
 			// A 204 is a legitimate HTTP success and belongs in the breaker's
 			// ledger, because the provider is plainly alive. It still says
 			// nothing about whether this MODEL is served.

--- a/internal/proxy/multimodal_passthrough_test.go
+++ b/internal/proxy/multimodal_passthrough_test.go
@@ -565,6 +565,64 @@ func TestAttemptPassthroughCandidate_AMiniMaxRefusalInsideA200KeepsTheStreak(t *
 	}
 }
 
+// TestEmbeddings_AnOversizedAnswerStillClearsTheGoneStrikes pins the one case
+// where the buffered pass-through must NOT ask what the body contains.
+//
+// Past passthroughJSONBufferCap the buffered body is a prefix and the remainder
+// is streamed, so a content check would be parsing truncated JSON — which never
+// parses, so a provider that had just produced megabytes would read as having
+// answered with nothing. A batch embeddings call clears 8 MiB at around 140
+// inputs of 3072 dimensions, which is ordinary document-indexing traffic: the
+// success side of the streak would be permanently dead on that workload, and a
+// live model would be nominated and probed over and over.
+func TestEmbeddings_AnOversizedAnswerStillClearsTheGoneStrikes(t *testing.T) {
+	var goneModelName atomic.Value
+	var refuse atomic.Bool
+	refuse.Store(true)
+	// A real embeddings answer, past the buffer cap.
+	oversized := `{"object":"list","data":[{"object":"embedding","index":0,"embedding":[` +
+		strings.Repeat("0.1,", (passthroughJSONBufferCap/4)+16) + `0.2]}]}`
+	env := newMultimodalEnvWith(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if refuse.Load() {
+			w.WriteHeader(http.StatusNotFound)
+			name, _ := goneModelName.Load().(string)
+			_, _ = fmt.Fprintf(w, "{\"error\":{\"message\":\"The model `%s` does not exist\"}}", name)
+			return
+		}
+		_, _ = io.WriteString(w, oversized)
+	}), `["embedding"]`)
+	goneModelName.Store(env.modelName)
+
+	body := fmt.Sprintf(`{"model":"%s/%s","input":"hi"}`, env.providerName, env.modelName)
+	embed := func() int {
+		req := env.request("/v1/embeddings", "application/json", strings.NewReader(body))
+		w := httptest.NewRecorder()
+		env.handler.Embeddings(w, req)
+		return w.Code
+	}
+
+	if code := embed(); code != http.StatusNotFound {
+		t.Fatalf("status = %d, want the provider's 404", code)
+	}
+	raw, ok := env.handler.goneStrikes.Load(goneStreakKey{model: env.modelUUID, endpoint: probeEmbeddingsEndpoint})
+	if !ok {
+		t.Fatal("the refusal accrued no strike")
+	}
+	streak, ok := raw.(*goneStreak)
+	if !ok {
+		t.Fatalf("unexpected streak type %T", raw)
+	}
+
+	refuse.Store(false)
+	if code := embed(); code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", code)
+	}
+	if n := streak.count(); n != 0 {
+		t.Fatalf("streak = %d, want 0: a provider that produced %d bytes answered", n, len(oversized))
+	}
+}
+
 func TestEmbeddings_UpstreamErrorReturnsOpenAIError(t *testing.T) {
 	env := newMultimodalEnv(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/proxy/multimodal_passthrough_test.go
+++ b/internal/proxy/multimodal_passthrough_test.go
@@ -42,6 +42,18 @@ type multimodalTestEnv struct {
 // upstream handler: provider + model + virtual key + canonical proxy Handler.
 func newMultimodalEnv(t *testing.T, upstreamHandler http.Handler) *multimodalTestEnv {
 	t.Helper()
+	return newMultimodalEnvWith(t, upstreamHandler, "[]")
+}
+
+// newMultimodalEnvWith is the same environment with the model's declared output
+// modalities under the test's control.
+//
+// It exists because a gone-classified refusal on /embeddings only counts against
+// a model the catalog says produces embeddings (see modalityRulesOutSurface), so
+// a test about embeddings retirement has to describe an embeddings model rather
+// than the "[]" every uncatalogued row carries.
+func newMultimodalEnvWith(t *testing.T, upstreamHandler http.Handler, outputModalities string) *multimodalTestEnv {
+	t.Helper()
 	pool := testDB.Pool()
 	settingsRepo := settings.NewRepository(pool)
 	failoverRepo := failover.NewRepository(pool)
@@ -54,7 +66,7 @@ func newMultimodalEnv(t *testing.T, upstreamHandler http.Handler) *multimodalTes
 	upstream := httptest.NewServer(upstreamHandler)
 	t.Cleanup(upstream.Close)
 
-	providerName, providerID, modelUUID, modelName := createMultimodalProvider(t, upstream.URL)
+	providerName, providerID, modelUUID, modelName := createMultimodalProviderWith(t, upstream.URL, outputModalities)
 
 	virtualKeyName := "mm-key-" + uuid.New().String()[:8]
 	keyHash := virtualkey.Hash(virtualKeyName)
@@ -78,6 +90,13 @@ func newMultimodalEnv(t *testing.T, upstreamHandler http.Handler) *multimodalTes
 // createMultimodalProvider registers a provider pointing at baseURL and one
 // enabled model under it. Returns the generated names/IDs.
 func createMultimodalProvider(t *testing.T, baseURL string) (providerName string, providerID, modelUUID uuid.UUID, modelName string) {
+	t.Helper()
+	return createMultimodalProviderWith(t, baseURL, "[]")
+}
+
+// createMultimodalProviderWith is the same, with the model's declared output
+// modalities under the caller's control.
+func createMultimodalProviderWith(t *testing.T, baseURL, outputModalities string) (providerName string, providerID, modelUUID uuid.UUID, modelName string) {
 	t.Helper()
 	pool := testDB.Pool()
 	providerRepo := provider.NewRepository(pool)
@@ -108,7 +127,7 @@ func createMultimodalProvider(t *testing.T, baseURL string) (providerName string
 		Capabilities:     "{}",
 		Params:           "{}",
 		InputModalities:  "[]",
-		OutputModalities: "[]",
+		OutputModalities: outputModalities,
 		Enabled:          true,
 		ProviderName:     providerName,
 		ProviderEnabled:  true,
@@ -256,12 +275,12 @@ func TestEmbeddings_FailoverStillRecordsTheGoneSignal(t *testing.T) {
 	// NAME: classifyUpstreamError only reads a gone-phrase as a retirement when
 	// the body names the model the request asked for.
 	var goneModelName atomic.Value
-	envGone := newMultimodalEnv(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	envGone := newMultimodalEnvWith(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNotFound)
 		name, _ := goneModelName.Load().(string)
 		_, _ = fmt.Fprintf(w, "{\"error\":{\"message\":\"The model `%s` does not exist\"}}", name)
-	}))
+	}), `["embedding"]`)
 	goneModelName.Store(envGone.modelName)
 
 	goodUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -322,7 +341,7 @@ func TestEmbeddings_ASuccessClearsTheGoneStrikes(t *testing.T) {
 	var goneModelName atomic.Value
 	var refuse atomic.Bool
 	refuse.Store(true)
-	env := newMultimodalEnv(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	env := newMultimodalEnvWith(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		if refuse.Load() {
 			w.WriteHeader(http.StatusNotFound)
@@ -331,7 +350,7 @@ func TestEmbeddings_ASuccessClearsTheGoneStrikes(t *testing.T) {
 			return
 		}
 		_, _ = io.WriteString(w, `{"object":"list","data":[{"object":"embedding","embedding":[0.1],"index":0}]}`)
-	}))
+	}), `["embedding"]`)
 	goneModelName.Store(env.modelName)
 
 	body := fmt.Sprintf(`{"model":"%s/%s","input":"hi"}`, env.providerName, env.modelName)
@@ -382,7 +401,7 @@ func TestEmbeddings_ADeadBodyDoesNotClearTheGoneStrikes(t *testing.T) {
 	var goneModelName atomic.Value
 	var refuse atomic.Bool
 	refuse.Store(true)
-	env := newMultimodalEnv(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	env := newMultimodalEnvWith(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		if refuse.Load() {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusNotFound)
@@ -405,7 +424,7 @@ func TestEmbeddings_ADeadBodyDoesNotClearTheGoneStrikes(t *testing.T) {
 		_, _ = buf.WriteString("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 1000\r\n\r\n{\"object\":")
 		_ = buf.Flush()
 		_ = conn.Close()
-	}))
+	}), `["embedding"]`)
 	goneModelName.Store(env.modelName)
 
 	body := fmt.Sprintf(`{"model":"%s/%s","input":"hi"}`, env.providerName, env.modelName)
@@ -450,7 +469,7 @@ func TestEmbeddings_AnEmptyResponseDoesNotClearTheGoneStrikes(t *testing.T) {
 	var goneModelName atomic.Value
 	var refuse atomic.Bool
 	refuse.Store(true)
-	env := newMultimodalEnv(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	env := newMultimodalEnvWith(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		if refuse.Load() {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusNotFound)
@@ -461,7 +480,7 @@ func TestEmbeddings_AnEmptyResponseDoesNotClearTheGoneStrikes(t *testing.T) {
 		// No content type and no body: the pass-through takes its streamed
 		// branch and finds nothing to commit on.
 		w.WriteHeader(http.StatusNoContent)
-	}))
+	}), `["embedding"]`)
 	goneModelName.Store(env.modelName)
 
 	body := fmt.Sprintf(`{"model":"%s/%s","input":"hi"}`, env.providerName, env.modelName)

--- a/internal/proxy/openai_responses_test.go
+++ b/internal/proxy/openai_responses_test.go
@@ -245,6 +245,22 @@ func TestProbeStreamingCandidate_LearnsResponsesRequirement(t *testing.T) {
 	if _, learned := h.responsesRequiredCache.Load("openai:" + cand.model.ModelID); learned {
 		t.Error("generic 400 must not be learned as a responses requirement")
 	}
+
+	// The hedged path reads a bounded prefix of an error body, because it also
+	// hands it to the classifier and the classifier's window is small. This
+	// learner is the reader that needs the WHOLE document: RequiresResponsesAPI
+	// json.Unmarshals it, and a body cut off mid-JSON does not parse at all, so
+	// a cap sized for the classifier would silently stop teaching the
+	// requirement — and the sequential path that learns the same thing reads
+	// unbounded, so the two would disagree about the same fact.
+	padded := fmt.Sprintf(`{"error":{"message":"Function tools with reasoning_effort are not supported in the Chat Completions API for this model. Please use the /v1/responses endpoint, or set reasoning_effort to 'none'."},"padding":"%s"}`, strings.Repeat("a", 4*failoverErrorClassifyCap))
+	res, cand = run(t, "gpt-hedge-oversized", padded)
+	if res.won {
+		t.Error("400 probe must fail the candidate")
+	}
+	if _, learned := h.responsesRequiredCache.Load("openai:" + cand.model.ModelID); !learned {
+		t.Errorf("a %d-byte 400 was truncated past parsing, so the responses requirement was never learned", len(padded))
+	}
 }
 
 // End-to-end through the real ChatCompletions pipeline (plan §11 in

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -487,6 +487,12 @@ func (h *Handler) handleNonStreamingResponse(w http.ResponseWriter, r *http.Requ
 		logData.tokensPromptCacheHit, logData.tokensPromptCacheMiss = extractCacheTokens(chatResp.Usage)
 		logData.failoverAttempt = attempt
 		logData.state = "completed"
+		// Whether the model actually answered, judged where the decoded body is
+		// in hand. The failover loop clears the model's gone-strike streak on it
+		// (see attemptCandidate): a 200 is a status, and a decodable-but-empty
+		// completion is one an aggregator in front of a retired model can return
+		// all day, resetting the count so the model is never nominated.
+		logData.deliveredContent = chatAnswerCarriesContent(chatResp)
 		// Fire-and-forget: skip WaitForInsert to avoid blocking TTFB.
 		// The async INSERT is very likely complete by now; if not, the
 		// UPDATE simply affects 0 rows (harmless, logged as warning).

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -487,11 +487,11 @@ func (h *Handler) handleNonStreamingResponse(w http.ResponseWriter, r *http.Requ
 		logData.tokensPromptCacheHit, logData.tokensPromptCacheMiss = extractCacheTokens(chatResp.Usage)
 		logData.failoverAttempt = attempt
 		logData.state = "completed"
-		// Whether the model actually answered, judged where the decoded body is
-		// in hand. The failover loop clears the model's gone-strike streak on it
-		// (see attemptCandidate): a 200 is a status, and a decodable-but-empty
-		// completion is one an aggregator in front of a retired model can return
-		// all day, resetting the count so the model is never nominated.
+		// Whether the model actually answered, judged where the decoded body is in
+		// hand. The failover loop clears the gone-strike streak on it (see
+		// attemptCandidate): a 200 is a status, and a decodable-but-empty
+		// completion is what an aggregator in front of a retired model returns,
+		// resetting the count so the model is never nominated.
 		logData.deliveredContent = chatAnswerCarriesContent(chatResp)
 		// Fire-and-forget: skip WaitForInsert to avoid blocking TTFB.
 		// The async INSERT is very likely complete by now; if not, the

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -212,14 +212,6 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 		return h.forwardUpstreamError(w, st, candidate, resp, attempt, hasMoreCandidates, responseHeaderMs)
 	}
 
-	// A non-streaming 200 means the model answered, so any gone-strike streak it
-	// had accumulated is stale. Streaming cannot be judged yet: the provider can
-	// send 200 headers and only then report the model gone in an SSE error, so
-	// that verdict is deferred to dispatchStreaming once the stream has ended.
-	if !st.isStreaming {
-		h.noteModelServed(candidate.model)
-	}
-
 	debuglog.Debug("proxy: upstream responded OK, dispatching to handler", "stream", st.isStreaming, "native_anthropic", st.anthropicNativeAttempt, "responses_api", st.responsesAttempt, "model", logData.modelID, "provider", logData.providerName, "provider_id", candidate.provider.ID, "status", resp.StatusCode)
 	if st.responsesAttempt {
 		// Translate the /v1/responses answer back to the chat-completions
@@ -248,6 +240,31 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 			return outcomeFailover
 		}
 	}
+	// A non-streaming 200 that survived the dialect translation above means the
+	// model answered, so any gone-strike streak it had accumulated is stale.
+	// Streaming cannot be judged yet: the provider can send 200 headers and only
+	// then report the model gone in an SSE error, so that verdict is deferred to
+	// dispatchStreaming once the stream has ended.
+	//
+	// After the two translations rather than on the 200, and that is the whole
+	// point of where it sits. Either of them reads the body, fails, and sends the
+	// attempt to FAILOVER — a provider that answered 200 with something that is
+	// not a Responses object or not a Gemini answer has not served the model, and
+	// crediting it there cleared the streak of a model the gateway was in the act
+	// of giving up on.
+	//
+	// It is still ahead of the non-streaming handler's own decode, which is the
+	// last place a plain 200 can turn out to be empty. That is deliberate rather
+	// than overlooked: this path records its breaker outcome from the status too
+	// (see recordBreakerOutcome above), no failover follows the decode, and the
+	// only cost of being wrong is a cleared streak on a response the client got a
+	// 502 for — the direction that leaves a model enabled. Threading a served
+	// signal back out of handleNonStreamingResponse and its native twin would buy
+	// precision this path does not otherwise keep.
+	if !st.isStreaming {
+		h.noteModelServed(candidate.model)
+	}
+
 	if st.isStreaming {
 		return h.dispatchStreaming(w, r, st, candidate, resp, attempt, responseHeaderMs, streamCancelOrigin)
 	}

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -690,7 +690,21 @@ func (h *Handler) doUpstream(ctx context.Context, req *http.Request, st *request
 // returns outcomeFatal.
 func (h *Handler) forwardUpstreamError(w http.ResponseWriter, st *requestState, candidate modelCandidate, resp *http.Response, attempt int, hasMoreCandidates bool, responseHeaderMs float64) candidateOutcome {
 	logData := st.logData
-	body, _ := io.ReadAll(resp.Body)
+	// How much of the body is worth holding depends on what happens to it below,
+	// which hasMoreCandidates already decides. Forwarded, it is read whole:
+	// truncating a body on its way to the client would hand them invalid JSON
+	// where the provider sent something complete. Discarded, it is read under the
+	// same cap as the two drain sites, because all that is left to take from it
+	// is a classification and the first 10 000 bytes of request log — and on the
+	// multimodal endpoints the body behind an error status can be an image
+	// payload rather than a sentence.
+	var body []byte
+	if hasMoreCandidates {
+		body, _ = io.ReadAll(resp.Body)
+	} else {
+		body, _ = io.ReadAll(io.LimitReader(resp.Body, failoverErrorClassifyCap))
+		_, _ = io.Copy(io.Discard, resp.Body)
+	}
 	_ = resp.Body.Close()
 	errMsg := util.SanitizeLogBody(string(body), 10000)
 	// Classify for the request log and metrics only — routing is unaffected,

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -24,6 +24,21 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
+// failoverErrorClassifyCap bounds how much of a discarded failover error body is
+// held in memory long enough to be classified.
+//
+// The body is on its way to being thrown away: the client is served by the next
+// candidate, and the only thing still wanted from it is whether the provider
+// said the model is retired. classifyUpstreamError never sees more than
+// util.SanitizeLogBody's own 10 000 characters, so everything above this cap is
+// read and discarded rather than retained.
+//
+// Shared by the chat loop and the multimodal pass-through loop, which run the
+// same drain-and-classify block. Sixteen kibibytes is comfortably above any
+// error message and well below the multi-megabyte bodies the image endpoints can
+// answer with.
+const failoverErrorClassifyCap = 16 << 10
+
 // paramRetryResult is the outcome of the 400 param-stripping auto-retry
 // (retryWithStrippedParams). It tells the failover loop how to proceed:
 //   - resp: the response to continue handling with — the retry's response on a
@@ -164,7 +179,14 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 	debuglog.Debug("proxy: failover decision", "status", resp.StatusCode, "is_failover_eligible", isFailoverEligible, "has_more_candidates", hasMoreCandidates, "should_failover_now", shouldFailoverNow, "attempt", attempt+1)
 
 	if shouldFailoverNow {
-		drained, _ := io.ReadAll(resp.Body)
+		// Read only what can be classified, then drain the rest straight to
+		// Discard so the connection stays reusable without the body being held
+		// in memory. The classifier never sees past util.SanitizeLogBody's own
+		// 10 000 characters, so everything above the cap was being retained to
+		// be thrown away — once per concurrent failing request, on the request
+		// path, at whatever size the provider chose to send.
+		drained, _ := io.ReadAll(io.LimitReader(resp.Body, failoverErrorClassifyCap))
+		_, _ = io.Copy(io.Discard, resp.Body)
 		_ = resp.Body.Close()
 		// The body is being discarded anyway, so classify it on the way out.
 		// A retired model usually answers 404, which is failover-eligible, so

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -170,8 +170,15 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 		// A retired model usually answers 404, which is failover-eligible, so
 		// without this the "model gone" signal would be lost precisely when
 		// there is another candidate to fall back to.
+		//
+		// The whole candidate goes through, not just the model: the retirement
+		// is adjudicated by a real request to this provider, so it needs the
+		// provider and the decrypted key that are already in hand here. The
+		// endpoint family comes off the log entry, which ingest stamped from the
+		// surface the request arrived on, and decides whether the refusal can be
+		// adjudicated at all.
 		if kind, _ := classifyUpstreamError(resp.StatusCode, util.SanitizeLogBody(string(drained), 10000), candidate.model.ModelID); kind == KindProviderModelGone {
-			h.noteModelGone(candidate.model, candidate.provider.Name)
+			h.noteModelGone(candidate, logData.endpointType)
 		}
 		st.setReqErr(reqError{Kind: KindProviderError, Attempt: attempt, Provider: candidate.provider.Name, Detail: fmt.Sprintf("HTTP %d", resp.StatusCode)})
 		debuglog.Info("proxy: failover triggered", "attempt", attempt+1, "provider", candidate.provider.Name, "provider_id", candidate.provider.ID, "status", resp.StatusCode)
@@ -641,7 +648,10 @@ func (h *Handler) forwardUpstreamError(w http.ResponseWriter, st *requestState, 
 	// hasMoreCandidates was already decided from the status code.
 	kind, reason := classifyUpstreamError(resp.StatusCode, errMsg, candidate.model.ModelID)
 	if kind == KindProviderModelGone {
-		h.noteModelGone(candidate.model, candidate.provider.Name)
+		// Same as the drain path above: the candidate carries what the
+		// pre-retirement probe needs, and logData.endpointType is the family
+		// that decides whether this model can be adjudicated at all.
+		h.noteModelGone(candidate, logData.endpointType)
 	}
 	debuglog.Warn("proxy: upstream non-200", "status", resp.StatusCode, "error_kind", kind, "model", logData.modelID, "provider", logData.providerName, "provider_id", candidate.provider.ID)
 	debuglog.Debug("proxy: upstream error response", "status", resp.StatusCode, "model", logData.modelID, "provider", logData.providerName, "provider_id", candidate.provider.ID, "body_length", len(body), "attempt", attempt+1)

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -272,7 +272,7 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 	// signal back out of handleNonStreamingResponse and its native twin would buy
 	// precision this path does not otherwise keep.
 	if !st.isStreaming {
-		h.noteModelServed(candidate.model)
+		h.noteModelServed(candidate.model, logData.endpointType)
 	}
 
 	if st.isStreaming {

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -27,11 +27,11 @@ import (
 // failoverErrorClassifyCap bounds how much of a discarded failover error body is
 // held in memory long enough to be classified.
 //
-// The body is on its way to being thrown away: the client is served by the next
-// candidate, and the only thing still wanted from it is whether the provider
-// said the model is retired. classifyUpstreamError never sees more than
-// util.SanitizeLogBody's own 10 000 characters, so everything above this cap is
-// read and discarded rather than retained.
+// The client is served by the next candidate, and the only thing still wanted
+// from the body is whether the provider said the model is retired.
+// classifyUpstreamError never sees more than util.SanitizeLogBody's own 10 000
+// characters, so everything above this cap is read and discarded rather than
+// retained.
 //
 // Shared by the chat loop and the multimodal pass-through loop, which run the
 // same drain-and-classify block. Sixteen kibibytes is comfortably above any
@@ -44,9 +44,7 @@ const failoverErrorClassifyCap = 16 << 10
 // openairesponses.RequiresResponsesAPI json.Unmarshals the whole error document,
 // so the classifier's window is the wrong size for it: a body cut off mid-JSON
 // does not parse, and the /v1/responses requirement would silently stop being
-// learned. A megabyte is far past any real 400 (they are sentences) and still
-// bounded, which is more than the sequential path that learns the same thing
-// gives itself.
+// learned. A megabyte is far past any real 400 and still bounded.
 const responsesLearnBodyCap = 1 << 20
 
 // paramRetryResult is the outcome of the 400 param-stripping auto-retry
@@ -190,11 +188,10 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 
 	if shouldFailoverNow {
 		// Read only what can be classified, then drain the rest straight to
-		// Discard so the connection stays reusable without the body being held
-		// in memory. The classifier never sees past util.SanitizeLogBody's own
-		// 10 000 characters, so everything above the cap was being retained to
-		// be thrown away — once per concurrent failing request, on the request
-		// path, at whatever size the provider chose to send.
+		// Discard so the connection stays reusable without the body being held in
+		// memory. Everything above the cap was being retained to be thrown away —
+		// once per concurrent failing request, on the request path, at whatever
+		// size the provider chose to send.
 		drained, _ := io.ReadAll(io.LimitReader(resp.Body, failoverErrorClassifyCap))
 		_, _ = io.Copy(io.Discard, resp.Body)
 		_ = resp.Body.Close()
@@ -203,12 +200,11 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 		// without this the "model gone" signal would be lost precisely when
 		// there is another candidate to fall back to.
 		//
-		// The whole candidate goes through, not just the model: the retirement
-		// is adjudicated by a real request to this provider, so it needs the
-		// provider and the decrypted key that are already in hand here. The
-		// endpoint family comes off the log entry, which ingest stamped from the
-		// surface the request arrived on, and decides whether the refusal can be
-		// adjudicated at all.
+		// The whole candidate goes through, not just the model: the retirement is
+		// adjudicated by a real request to this provider, so it needs the provider
+		// and the decrypted key already in hand here. The endpoint family comes
+		// off the log entry and decides whether the refusal can be adjudicated at
+		// all.
 		if kind, _ := classifyUpstreamError(resp.StatusCode, util.SanitizeLogBody(string(drained), 10000), candidate.model.ModelID); kind == KindProviderModelGone {
 			h.noteModelGone(candidate, logData.endpointType)
 		}
@@ -257,22 +253,21 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 		return h.dispatchStreaming(w, r, st, candidate, resp, attempt, responseHeaderMs, streamCancelOrigin)
 	}
 
-	// A non-streaming answer clears any gone-strike streak the model had — and
-	// it is judged AFTER the handler, on what the handler decoded, rather than
-	// on the 200 that preceded it.
+	// A non-streaming answer clears any gone-strike streak the model had, judged
+	// AFTER the handler on what the handler decoded rather than on the 200 that
+	// preceded it. Both halves of that placement are load-bearing:
 	//
-	// Both halves of that placement are load-bearing. It is below the dialect
-	// translations because either of them reads the body, fails, and sends the
-	// attempt to FAILOVER: a provider that answered 200 with something that is
-	// not a Responses object or not a Gemini answer has not served the model,
-	// and crediting it there cleared the streak of a model the gateway was in
-	// the act of giving up on. And it is below the handler because a status is
-	// not an answer: `200 {"choices":[]}` decodes, is forwarded to the client as
-	// a normal completion, and is exactly what an aggregator in front of a
-	// retired model can return between its gone-shaped 404s — resetting the
-	// count so the three never land consecutively and the model is never
-	// nominated. Every other path on this branch already draws that line;
-	// producedOutput is where it is drawn.
+	//   - Below the dialect translations, because either of them can read the
+	//     body, fail, and send the attempt to FAILOVER. A provider that answered
+	//     200 with something that is not a Responses object or a Gemini answer has
+	//     not served the model.
+	//   - Below the handler, because a status is not an answer. `200
+	//     {"choices":[]}` decodes and is forwarded as a normal completion, and is
+	//     what an aggregator in front of a retired model returns between its
+	//     gone-shaped 404s — resetting the count so three never land
+	//     consecutively and the model is never nominated.
+	//
+	// producedOutput is where that line is drawn.
 	if st.anthropicNativeAttempt {
 		outcome := h.handleNativeNonStreaming(w, r, st, resp, attempt, responseHeaderMs)
 		if producedOutput(logData) {
@@ -693,12 +688,10 @@ func (h *Handler) forwardUpstreamError(w http.ResponseWriter, st *requestState, 
 	logData := st.logData
 	// How much of the body is worth holding depends on what happens to it below,
 	// which hasMoreCandidates already decides. Forwarded, it is read whole:
-	// truncating a body on its way to the client would hand them invalid JSON
-	// where the provider sent something complete. Discarded, it is read under the
-	// same cap as the two drain sites, because all that is left to take from it
-	// is a classification and the first 10 000 bytes of request log — and on the
-	// multimodal endpoints the body behind an error status can be an image
-	// payload rather than a sentence.
+	// truncating on the way to the client would hand them invalid JSON where the
+	// provider sent something complete. Discarded, it is read under the same cap
+	// as the two drain sites, since all that is left to take from it is a
+	// classification and the first 10 000 bytes of request log.
 	var body []byte
 	if hasMoreCandidates {
 		body, _ = io.ReadAll(resp.Body)

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -39,6 +39,16 @@ import (
 // answer with.
 const failoverErrorClassifyCap = 16 << 10
 
+// responsesLearnBodyCap bounds a 400 that has to be parsed rather than scanned.
+//
+// openairesponses.RequiresResponsesAPI json.Unmarshals the whole error document,
+// so the classifier's window is the wrong size for it: a body cut off mid-JSON
+// does not parse, and the /v1/responses requirement would silently stop being
+// learned. A megabyte is far past any real 400 (they are sentences) and still
+// bounded, which is more than the sequential path that learns the same thing
+// gives itself.
+const responsesLearnBodyCap = 1 << 20
+
 // paramRetryResult is the outcome of the 400 param-stripping auto-retry
 // (retryWithStrippedParams). It tells the failover loop how to proceed:
 //   - resp: the response to continue handling with — the retry's response on a

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -250,40 +250,41 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 			return outcomeFailover
 		}
 	}
-	// A non-streaming 200 that survived the dialect translation above means the
-	// model answered, so any gone-strike streak it had accumulated is stale.
-	// Streaming cannot be judged yet: the provider can send 200 headers and only
-	// then report the model gone in an SSE error, so that verdict is deferred to
-	// dispatchStreaming once the stream has ended.
-	//
-	// After the two translations rather than on the 200, and that is the whole
-	// point of where it sits. Either of them reads the body, fails, and sends the
-	// attempt to FAILOVER — a provider that answered 200 with something that is
-	// not a Responses object or not a Gemini answer has not served the model, and
-	// crediting it there cleared the streak of a model the gateway was in the act
-	// of giving up on.
-	//
-	// It is still ahead of the non-streaming handler's own decode, which is the
-	// last place a plain 200 can turn out to be empty. That is deliberate rather
-	// than overlooked: this path records its breaker outcome from the status too
-	// (see recordBreakerOutcome above), no failover follows the decode, and the
-	// only cost of being wrong is a cleared streak on a response the client got a
-	// 502 for — the direction that leaves a model enabled. Threading a served
-	// signal back out of handleNonStreamingResponse and its native twin would buy
-	// precision this path does not otherwise keep.
-	if !st.isStreaming {
-		h.noteModelServed(candidate.model, logData.endpointType)
-	}
-
 	if st.isStreaming {
+		// Streaming cannot be judged yet: the provider can send 200 headers and
+		// only then report the model gone in an SSE error, so that verdict is
+		// deferred to dispatchStreaming once the stream has ended.
 		return h.dispatchStreaming(w, r, st, candidate, resp, attempt, responseHeaderMs, streamCancelOrigin)
 	}
 
+	// A non-streaming answer clears any gone-strike streak the model had — and
+	// it is judged AFTER the handler, on what the handler decoded, rather than
+	// on the 200 that preceded it.
+	//
+	// Both halves of that placement are load-bearing. It is below the dialect
+	// translations because either of them reads the body, fails, and sends the
+	// attempt to FAILOVER: a provider that answered 200 with something that is
+	// not a Responses object or not a Gemini answer has not served the model,
+	// and crediting it there cleared the streak of a model the gateway was in
+	// the act of giving up on. And it is below the handler because a status is
+	// not an answer: `200 {"choices":[]}` decodes, is forwarded to the client as
+	// a normal completion, and is exactly what an aggregator in front of a
+	// retired model can return between its gone-shaped 404s — resetting the
+	// count so the three never land consecutively and the model is never
+	// nominated. Every other path on this branch already draws that line;
+	// producedOutput is where it is drawn.
 	if st.anthropicNativeAttempt {
-		return h.handleNativeNonStreaming(w, r, st, resp, attempt, responseHeaderMs)
+		outcome := h.handleNativeNonStreaming(w, r, st, resp, attempt, responseHeaderMs)
+		if producedOutput(logData) {
+			h.noteModelServed(candidate.model, logData.endpointType)
+		}
+		return outcome
 	}
 
 	h.handleNonStreamingResponse(w, r, logData, resp, st.startTime, st.proxyOverhead, st.parseMs, st.timings.failoverLookupMs, st.timings.modelLookupMs, st.timings.providerLookupMs, st.timings.keyDecryptMs, st.timings.dialMs, st.timings.settingsReadMs, responseHeaderMs, st.vkHash, attempt)
+	if producedOutput(logData) {
+		h.noteModelServed(candidate.model, logData.endpointType)
+	}
 	return outcomeServed
 }
 

--- a/internal/proxy/stream_error_sanitize_test.go
+++ b/internal/proxy/stream_error_sanitize_test.go
@@ -67,6 +67,41 @@ func TestDeriveStreamError_SanitizesProviderMessage(t *testing.T) {
 	// If the retirement verdict were read from errorKind, the client would be
 	// suppressing the evidence by reacting to it, and a retired model would stay
 	// routable for as long as clients kept disconnecting on its errors.
+	t.Run("a failover request is classified by the upstream id, not the alias", func(t *testing.T) {
+		t.Parallel()
+
+		// What a hotel/ request's log entry actually holds: modelID is the
+		// client-facing alias, and the committed candidate's real id is in
+		// resolvedModelID (beginAttempt sets it only on the failover path).
+		st := &streamState{lastErrMsg: "Model claude-sonnet-4 is no longer available"}
+		logData := &requestLogData{statusCode: 404, modelID: "hotel/claude", resolvedModelID: "claude-sonnet-4"}
+
+		deriveStreamError(st, nil, streamOptions{}, logData)
+
+		// Classified against "hotel/claude", modelGoneAbout trims to the last
+		// path segment and looks for "claude" inside "claude-sonnet-4", does not
+		// find a whole-id match, and the retirement signal is lost — for the one
+		// routing mode this feature exists for.
+		if logData.upstreamKind != KindProviderModelGone {
+			t.Errorf("upstreamKind = %q, want %q: a model retired mid-stream inside a failover group must still strike", logData.upstreamKind, KindProviderModelGone)
+		}
+	})
+
+	t.Run("a direct request still classifies by its own id", func(t *testing.T) {
+		t.Parallel()
+
+		// resolvedModelID is empty off the failover path, so the fallback is
+		// what keeps every non-failover stream classifying as it always did.
+		st := &streamState{lastErrMsg: "Model gemini-2.0-flash is no longer available"}
+		logData := &requestLogData{statusCode: 404, modelID: "gemini-2.0-flash"}
+
+		deriveStreamError(st, nil, streamOptions{}, logData)
+
+		if logData.upstreamKind != KindProviderModelGone {
+			t.Errorf("upstreamKind = %q, want %q", logData.upstreamKind, KindProviderModelGone)
+		}
+	})
+
 	t.Run("a client hangup does not erase the provider's retirement verdict", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/proxy/stream_finalize.go
+++ b/internal/proxy/stream_finalize.go
@@ -185,30 +185,6 @@ func (h *Handler) finalizeStream(st *streamState, sink *streamSink, scanErr erro
 // was derived so far, and finally a stall overrides the raw IO error produced
 // by the watchdog's body.Close(). The missing-[DONE] diagnosis is NOT handled
 // here — it may write to the client, so it stays in finalizeStream.
-// upstreamModelID is the id the PROVIDER knows this request by, which is not
-// always the one the client asked for.
-//
-// modelID is the client's spelling: for a failover request it is the literal
-// "hotel/<group>", and resolvedModelID is where the committed candidate's real
-// id lands (beginAttempt sets it only on that path, which is why the fallback is
-// not a convenience). Handing the alias to classifyUpstreamError meant its
-// gone-phrase test looked for "claude" — modelGoneAbout trims to the last path
-// segment — inside "Model claude-sonnet-4 is no longer available", and did not
-// find it. Mid-stream retirement therefore could not fire for the one routing
-// mode this whole feature exists for: a model retired inside a failover group
-// recorded no strike, was never nominated, and was never probed.
-//
-// Every classification site added by the retirement work passes
-// candidate.model.ModelID directly. This one has no candidate in hand — it runs
-// at stream teardown, off the log entry — so it reads the same fact from where
-// the log entry keeps it.
-func upstreamModelID(logData *requestLogData) string {
-	if logData.resolvedModelID != "" {
-		return logData.resolvedModelID
-	}
-	return logData.modelID
-}
-
 func deriveStreamError(st *streamState, scanErr error, opts streamOptions, logData *requestLogData) string {
 	errMsg := st.lastErrMsg
 	if errMsg != "" {
@@ -277,4 +253,28 @@ func deriveStreamError(st *streamState, scanErr error, opts streamOptions, logDa
 		debuglog.Warn("proxy: stream stall detected", "model", logData.modelID, "provider", logData.providerName, "stall_timeout", effectiveStall, "base_timeout", opts.streamStallTimeout, "chunks", st.chunkCount)
 	}
 	return errMsg
+}
+
+// upstreamModelID is the id the PROVIDER knows this request by, which is not
+// always the one the client asked for.
+//
+// modelID is the client's spelling: for a failover request it is the literal
+// "hotel/<group>", and resolvedModelID is where the committed candidate's real
+// id lands (beginAttempt sets it only on that path, which is why the fallback is
+// not a convenience). Handing the alias to classifyUpstreamError meant its
+// gone-phrase test looked for "claude" — modelGoneAbout trims to the last path
+// segment — inside "Model claude-sonnet-4 is no longer available", and did not
+// find it. Mid-stream retirement therefore could not fire for the one routing
+// mode this whole feature exists for: a model retired inside a failover group
+// recorded no strike, was never nominated, and was never probed.
+//
+// Every classification site added by the retirement work passes
+// candidate.model.ModelID directly. This one has no candidate in hand — it runs
+// at stream teardown, off the log entry — so it reads the same fact from where
+// the log entry keeps it.
+func upstreamModelID(logData *requestLogData) string {
+	if logData.resolvedModelID != "" {
+		return logData.resolvedModelID
+	}
+	return logData.modelID
 }

--- a/internal/proxy/stream_finalize.go
+++ b/internal/proxy/stream_finalize.go
@@ -185,6 +185,30 @@ func (h *Handler) finalizeStream(st *streamState, sink *streamSink, scanErr erro
 // was derived so far, and finally a stall overrides the raw IO error produced
 // by the watchdog's body.Close(). The missing-[DONE] diagnosis is NOT handled
 // here — it may write to the client, so it stays in finalizeStream.
+// upstreamModelID is the id the PROVIDER knows this request by, which is not
+// always the one the client asked for.
+//
+// modelID is the client's spelling: for a failover request it is the literal
+// "hotel/<group>", and resolvedModelID is where the committed candidate's real
+// id lands (beginAttempt sets it only on that path, which is why the fallback is
+// not a convenience). Handing the alias to classifyUpstreamError meant its
+// gone-phrase test looked for "claude" — modelGoneAbout trims to the last path
+// segment — inside "Model claude-sonnet-4 is no longer available", and did not
+// find it. Mid-stream retirement therefore could not fire for the one routing
+// mode this whole feature exists for: a model retired inside a failover group
+// recorded no strike, was never nominated, and was never probed.
+//
+// Every classification site added by the retirement work passes
+// candidate.model.ModelID directly. This one has no candidate in hand — it runs
+// at stream teardown, off the log entry — so it reads the same fact from where
+// the log entry keeps it.
+func upstreamModelID(logData *requestLogData) string {
+	if logData.resolvedModelID != "" {
+		return logData.resolvedModelID
+	}
+	return logData.modelID
+}
+
 func deriveStreamError(st *streamState, scanErr error, opts streamOptions, logData *requestLogData) string {
 	errMsg := st.lastErrMsg
 	if errMsg != "" {
@@ -194,7 +218,7 @@ func deriveStreamError(st *streamState, scanErr error, opts streamOptions, logDa
 		// intact — a provider is free to echo the request back inside an error,
 		// and an unbounded provider string must not land in the log either way.
 		errMsg = util.SanitizeLogBody(errMsg, 10000)
-		logData.errorKind, _ = classifyUpstreamError(logData.statusCode, errMsg, logData.modelID)
+		logData.errorKind, _ = classifyUpstreamError(logData.statusCode, errMsg, upstreamModelID(logData))
 		// Kept separately as well, because everything below can overwrite
 		// errorKind with a later cause. A client that receives this error chunk
 		// and hangs up — which is exactly what a client does on seeing an error

--- a/internal/proxy/stream_finalize.go
+++ b/internal/proxy/stream_finalize.go
@@ -264,14 +264,12 @@ func deriveStreamError(st *streamState, scanErr error, opts streamOptions, logDa
 // not a convenience). Handing the alias to classifyUpstreamError meant its
 // gone-phrase test looked for "claude" — modelGoneAbout trims to the last path
 // segment — inside "Model claude-sonnet-4 is no longer available", and did not
-// find it. Mid-stream retirement therefore could not fire for the one routing
-// mode this whole feature exists for: a model retired inside a failover group
-// recorded no strike, was never nominated, and was never probed.
+// find it, so a model retired inside a failover group recorded no strike and was
+// never probed.
 //
-// Every classification site added by the retirement work passes
-// candidate.model.ModelID directly. This one has no candidate in hand — it runs
-// at stream teardown, off the log entry — so it reads the same fact from where
-// the log entry keeps it.
+// Every other classification site passes candidate.model.ModelID directly. This
+// one runs at stream teardown with no candidate in hand, so it reads the same
+// fact off the log entry.
 func upstreamModelID(logData *requestLogData) string {
 	if logData.resolvedModelID != "" {
 		return logData.resolvedModelID

--- a/wiki/Model-Discovery.md
+++ b/wiki/Model-Discovery.md
@@ -1011,10 +1011,12 @@ request before anything is written.
 How a retirement is reached:
 
 1. **Nomination.** A request that the provider refuses with retirement-shaped
-   prose counts one strike against that model. Three strikes within 30 minutes,
-   with no successful request in between, nominate it. Strikes are in-memory and
-   per gateway instance: they are not persisted, and each HA member reaches its
-   own conclusion from its own traffic.
+   prose counts one strike against that model. Three strikes nominate it, with no
+   successful request in between and no more than 30 minutes between one strike
+   and the next. That is a gap, not a deadline: refusals at 0, 29 and 58 minutes
+   are one streak of three, while a model refused once an hour never accumulates
+   one. Strikes are in-memory and per gateway instance: they are not persisted,
+   and each HA member reaches its own conclusion from its own traffic.
 2. **Adjudication.** At the threshold the gateway sends a real, minimal request
    to the model itself (a 64-token chat completion, or a one-input embedding),
    off the request path. Content coming back means the model works: the strike

--- a/wiki/Model-Discovery.md
+++ b/wiki/Model-Discovery.md
@@ -1033,9 +1033,13 @@ How a retirement is reached:
    the model produces embeddings and nothing else. Chat is what most models are
    and where most refusals arrive, so requiring a declared modality there would
    switch traffic-driven retirement off for every uncatalogued model at once,
-   while guessing wrong on embeddings retires a working chat model everywhere. A
-   success clears every surface, because it is evidence about the model rather
-   than about one endpoint.
+   while guessing wrong on embeddings retires a working chat model everywhere.
+
+   A success clears the surface it arrived on and only that one, for the same
+   reason the counts are separate: a provider can retire a model's chat surface
+   while still serving its embeddings, and a global clear would let the healthy
+   surface hold the dead one open forever. Traffic on a surface that is never
+   auto-retired (images, speech, rerank) clears nothing at all.
 2. **Adjudication.** At the threshold the gateway sends a real, minimal request
    to the model itself (a 64-token chat completion, or a one-input embedding),
    off the request path. Content coming back means the model works: the strike

--- a/wiki/Model-Discovery.md
+++ b/wiki/Model-Discovery.md
@@ -998,6 +998,62 @@ In summary:
 - **Auto-disabled** models (removed from the provider API) have `disabled_manually = false` and are re-enabled if they reappear.
 - **Manually disabled** models have `disabled_manually = true` and stay disabled even if the model reappears in the provider API.
 
+### Traffic-driven retirement: verified before it is written
+
+Discovery can only act when a model leaves a provider's listing. Some providers
+keep serving a listing entry for a model they have already shut down (Google
+kept `gemini-2.0-flash` listed for two months after retirement, OpenCode Zen
+lists `claude-sonnet-4` and refuses it), so the only thing that knows such a
+model is dead is a real request to it. The proxy therefore also retires models
+from traffic, and every one of those retirements is verified with an upstream
+request before anything is written.
+
+How a retirement is reached:
+
+1. **Nomination.** A request that the provider refuses with retirement-shaped
+   prose counts one strike against that model. Three strikes within 30 minutes,
+   with no successful request in between, nominate it. Strikes are in-memory and
+   per gateway instance: they are not persisted, and each HA member reaches its
+   own conclusion from its own traffic.
+2. **Adjudication.** At the threshold the gateway sends a real, minimal request
+   to the model itself (a 64-token chat completion, or a one-input embedding),
+   off the request path. Content coming back means the model works: the streak
+   is cleared, nothing is disabled, and a warning is logged because a model that
+   refuses real traffic and answers a probe is worth a look. The provider
+   refusing the model by name is what writes the disable. Anything else (a 429,
+   a 5xx, an entitlement failure, a timeout, an unreadable answer) establishes
+   nothing and postpones.
+3. **The write.** A confirmed retirement sets `enabled = false` and stamps
+   `auto_retired_at`, revalidates the custom failover groups the model belonged
+   to, and publishes a `model.auto_disabled_gone` event.
+
+Two consequences worth knowing about before you upgrade:
+
+- **Every retirement decision costs one upstream request.** It is a call you did
+  not make, so it is logged as one: the `proxy: auto-disabled retired model`
+  line and the `model.auto_disabled_gone` event both carry `probe_verdict` and
+  the endpoint family. A retirement without `probe_verdict: refused` did not
+  come from this path. The rate is bounded on two axes: a model is probed at
+  most once every 5 minutes however hard it is being retried, and at most 4
+  probes are in flight against any one provider at a time. Probes deliberately
+  skip rate limiting and circuit-breaker accounting (a verification must not be
+  able to sideline a healthy provider), but they do respect an already-open
+  circuit and postpone instead of calling a provider the gateway has sidelined.
+- **Some endpoint families are never auto-retired from traffic.** Only chat,
+  messages and embeddings models can be verified cheaply and safely. Image, TTS,
+  STT and rerank models are never auto-retired at all, because a chat probe
+  against one fails for reasons that have nothing to do with retirement and that
+  failure would read as confirmation. Retiring them without verification is the
+  guessing this design exists to remove, so a retired image or TTS model stays
+  enabled until discovery drops it from the listing or you disable it by hand.
+  Refusals on those families are logged at debug level and no strikes are kept.
+
+A model retired this way is distinct from both a manual disable and a discovery
+disable (see migration `063`): re-appearing in a listing does not revive it,
+because the provider was refusing it while still listing it. Enabling it by hand
+clears the stamp, and if the model really is gone it re-earns its strikes, is
+re-probed and is retired again with a fresh alert.
+
 ### Manual Enable/Disable (API)
 
 Users can manually enable or disable a model via:

--- a/wiki/Model-Discovery.md
+++ b/wiki/Model-Discovery.md
@@ -1017,6 +1017,18 @@ How a retirement is reached:
    are one streak of three, while a model refused once an hour never accumulates
    one. Strikes are in-memory and per gateway instance: they are not persisted,
    and each HA member reaches its own conclusion from its own traffic.
+
+   Strikes are counted per surface, and a refusal only counts on a surface the
+   model is for. Chat and embeddings keep separate counts, because the probe asks
+   on the surface the strikes came from and the two are different questions. A
+   refusal that contradicts the model's own catalog modality is ignored outright:
+   sending a chat model to `/v1/embeddings` draws a capability error that names
+   the model, which reads exactly like a retirement, and a misconfigured client
+   must not be able to disable a model that serves chat perfectly. A model whose
+   catalog entry declares no modality is not second-guessed, so nothing is
+   switched off for entries that predate the modality columns. A success clears
+   every surface, because it is evidence about the model rather than about one
+   endpoint.
 2. **Adjudication.** At the threshold the gateway sends a real, minimal request
    to the model itself (a 64-token chat completion, or a one-input embedding),
    off the request path. Content coming back means the model works: the strike

--- a/wiki/Model-Discovery.md
+++ b/wiki/Model-Discovery.md
@@ -1078,6 +1078,14 @@ Two consequences worth knowing about before you upgrade:
   skip rate limiting and circuit-breaker accounting (a verification must not be
   able to sideline a healthy provider), but they do respect an already-open
   circuit and postpone instead of calling a provider the gateway has sidelined.
+
+  A model whose probe can never answer keeps its strikes and keeps paying that
+  cost. After three postponements in a row the line escalates from info to
+  warning (`proxy: auto-disable postponed repeatedly`, carrying
+  `inconclusive_probes`), so a provider that rate limits the gateway, or a model
+  that cannot be reached on the surface the probe asks, shows up as itself rather
+  than as ordinary noise. Nothing is retired on the strength of it; the run ends
+  as soon as the model answers.
 - **Some endpoint families are never auto-retired from traffic.** Only chat,
   messages and embeddings models can be verified cheaply and safely. Image, TTS,
   STT and rerank models are never auto-retired at all, because a chat probe

--- a/wiki/Model-Discovery.md
+++ b/wiki/Model-Discovery.md
@@ -1017,9 +1017,12 @@ How a retirement is reached:
    own conclusion from its own traffic.
 2. **Adjudication.** At the threshold the gateway sends a real, minimal request
    to the model itself (a 64-token chat completion, or a one-input embedding),
-   off the request path. Content coming back means the model works: the streak
-   is cleared, nothing is disabled, and a warning is logged because a model that
-   refuses real traffic and answers a probe is worth a look. The provider
+   off the request path. Content coming back means the model works: the strike
+   count is cleared, nothing is disabled, and a warning is logged because a model
+   that refuses real traffic and answers a probe is worth a look. Such a model
+   needs three fresh strikes AND the probe cooldown below before it is asked
+   again, which matters because a provider whose prose disagrees with its own
+   behaviour keeps producing this outcome. The provider
    refusing the model by name is what writes the disable. Anything else (a 429,
    a 5xx, an entitlement failure, a timeout, an unreadable answer) establishes
    nothing and postpones.

--- a/wiki/Model-Discovery.md
+++ b/wiki/Model-Discovery.md
@@ -1019,16 +1019,23 @@ How a retirement is reached:
    and each HA member reaches its own conclusion from its own traffic.
 
    Strikes are counted per surface, and a refusal only counts on a surface the
-   model is for. Chat and embeddings keep separate counts, because the probe asks
-   on the surface the strikes came from and the two are different questions. A
-   refusal that contradicts the model's own catalog modality is ignored outright:
-   sending a chat model to `/v1/embeddings` draws a capability error that names
-   the model, which reads exactly like a retirement, and a misconfigured client
-   must not be able to disable a model that serves chat perfectly. A model whose
-   catalog entry declares no modality is not second-guessed, so nothing is
-   switched off for entries that predate the modality columns. A success clears
-   every surface, because it is evidence about the model rather than about one
-   endpoint.
+   model is known to serve. Chat and embeddings keep separate counts, because the
+   probe asks on the surface the strikes came from and the two are different
+   questions. Sending a chat model to `/v1/embeddings` draws a capability error
+   that names the model, which reads exactly like a retirement, and a
+   misconfigured client must not be able to disable a model that serves chat
+   perfectly.
+
+   The two surfaces treat a silent catalog differently, on purpose. A refusal on
+   `/v1/embeddings` only counts when the model's `output_modalities` say it
+   produces embeddings, so an embeddings model whose catalog entry declares
+   nothing is never auto-retired. A refusal on chat counts unless the entry says
+   the model produces embeddings and nothing else. Chat is what most models are
+   and where most refusals arrive, so requiring a declared modality there would
+   switch traffic-driven retirement off for every uncatalogued model at once,
+   while guessing wrong on embeddings retires a working chat model everywhere. A
+   success clears every surface, because it is evidence about the model rather
+   than about one endpoint.
 2. **Adjudication.** At the threshold the gateway sends a real, minimal request
    to the model itself (a 64-token chat completion, or a one-input embedding),
    off the request path. Content coming back means the model works: the strike

--- a/wiki/Model-Discovery.md
+++ b/wiki/Model-Discovery.md
@@ -1056,14 +1056,16 @@ disable (see migration `063`): re-appearing in a listing does not revive it,
 because the provider was refusing it while still listing it. Enabling it by hand
 clears the stamp, and if the model really is gone it is retired again with a
 fresh alert, always behind a fresh probe. What differs is how it gets there.
-Strikes are kept in memory (see above), so if the streak was dropped (the
-gateway restarted, 30 minutes passed with no further refusal, or the previous
-disable attempt failed to write and reset the count) the model re-earns its
-three strikes before the next probe. If the streak is still parked at the
-threshold in the same running process, with no successful request in between,
-the first refusal past the probe cooldown claims a probe directly instead of
-re-earning three strikes. Either way, nothing is retired without a probe
-confirming it first.
+Strikes are kept in memory (see above), so if the count was cleared (the gateway
+restarted, 30 minutes passed with no further refusal, or a request to the model
+succeeded) the model re-earns its three strikes before the next probe. If the
+count is still parked at the threshold in the same running process, with no
+successful request in between, the first refusal past the probe cooldown claims
+a probe directly instead of re-earning three strikes; that is also how a disable
+that failed to write is retried. Either way, nothing is retired without a probe
+confirming it first, and the probe cooldown applies to every one of those
+routes. A success resets what the model is accused of, not the rate at which the
+gateway may ask the provider about it.
 
 ### Manual Enable/Disable (API)
 

--- a/wiki/Model-Discovery.md
+++ b/wiki/Model-Discovery.md
@@ -1051,8 +1051,16 @@ Two consequences worth knowing about before you upgrade:
 A model retired this way is distinct from both a manual disable and a discovery
 disable (see migration `063`): re-appearing in a listing does not revive it,
 because the provider was refusing it while still listing it. Enabling it by hand
-clears the stamp, and if the model really is gone it re-earns its strikes, is
-re-probed and is retired again with a fresh alert.
+clears the stamp, and if the model really is gone it is retired again with a
+fresh alert, always behind a fresh probe. What differs is how it gets there.
+Strikes are kept in memory (see above), so if the streak was dropped (the
+gateway restarted, 30 minutes passed with no further refusal, or the previous
+disable attempt failed to write and reset the count) the model re-earns its
+three strikes before the next probe. If the streak is still parked at the
+threshold in the same running process, with no successful request in between,
+the first refusal past the probe cooldown claims a probe directly instead of
+re-earning three strikes. Either way, nothing is retired without a probe
+confirming it first.
 
 ### Manual Enable/Disable (API)
 

--- a/wiki/Model-Discovery.md
+++ b/wiki/Model-Discovery.md
@@ -1043,6 +1043,14 @@ How a retirement is reached:
    while still serving its embeddings, and a global clear would let the healthy
    surface hold the dead one open forever. Traffic on a surface that is never
    auto-retired (images, speech, rerank) clears nothing at all.
+
+   A model the catalog says serves BOTH chat and embeddings is never
+   auto-retired. Disabling turns off the model row, so it cannot express "gone on
+   chat, still serving embeddings", and no probe can catch that: the probe would
+   be right about the surface it asked, and the disable simply broader than what
+   was found. Such a model stays enabled until discovery drops it or you disable
+   it by hand. It needs a provider serving one model id on both surfaces, which
+   is rare.
 2. **Adjudication.** At the threshold the gateway sends a real, minimal request
    to the model itself (a 64-token chat completion, or a one-input embedding),
    off the request path. Content coming back means the model works: the strike

--- a/wiki/Model-Discovery.md
+++ b/wiki/Model-Discovery.md
@@ -1029,11 +1029,14 @@ How a retirement is reached:
    The two surfaces treat a silent catalog differently, on purpose. A refusal on
    `/v1/embeddings` only counts when the model's `output_modalities` say it
    produces embeddings, so an embeddings model whose catalog entry declares
-   nothing is never auto-retired. A refusal on chat counts unless the entry says
-   the model produces embeddings and nothing else. Chat is what most models are
-   and where most refusals arrive, so requiring a declared modality there would
-   switch traffic-driven retirement off for every uncatalogued model at once,
-   while guessing wrong on embeddings retires a working chat model everywhere.
+   nothing is never auto-retired. A refusal on chat counts unless the entry
+   positively describes something a chat completion cannot be about: an image,
+   video, audio, embedding or rerank output, or an input that admits no text
+   (a speech-to-text model produces text like any chat model and gives itself
+   away on the input side). Chat is what most models are and where most refusals
+   arrive, so requiring a declared modality there would switch traffic-driven
+   retirement off for every uncatalogued model at once, while guessing wrong on
+   embeddings retires a working chat model everywhere.
 
    A success clears the surface it arrived on and only that one, for the same
    reason the counts are separate: a provider can retire a model's chat surface


### PR DESCRIPTION
Implements `plans/595-verify-before-retiring.md`.

Refs #595, and deliberately does not close it. That issue reports two classifier
gaps against a real OpenCode Zen payload — a retirement signal arriving as a
structured `type: not_found_error` field rather than prose, and a provider naming
the version-suffixed alias `claude-sonnet-4-20250514` where we asked for
`claude-sonnet-4`. Neither is fixed here: `upstream_classify.go` is not in this
diff, so `OpenCode Zen/claude-sonnet-4` still accrues no strike and is still
never retired.

What changes is what those gaps cost. With a real request adjudicating, a missed
signal means no retirement, which is the safe direction and the status quo, and a
wrong signal is thrown out before anything is written. The two matching rules
become an accuracy improvement — fewer pointless probes, faster retirement of
genuinely dead models — rather than a correctness fix.

## What changes

Traffic-driven retirement used to disable a model on the strength of provider
prose: three responses that `classifyUpstreamError` read as "this model is gone"
and the row was turned off. Provider wording drifts, so the classifier can never
be complete, and the failures are asymmetric — a missed retirement costs a bad
request, a false one costs availability.

The classifier now **nominates** and a real request **adjudicates**. At the
threshold, before anything is written, the gateway sends one minimal request to
the model itself and lets the answer decide:

- **content came back** → clear the count, disable nothing, log it (a model that
  refuses real traffic and answers a probe is worth an operator's attention)
- **refused again** → a fourth independent piece of evidence; disable as before
- **anything else** → postpone; neither disable nor clear

The probe goes through the real egress builder, so it speaks each provider's
dialect and gets the same learned param rewrites real traffic gets. A probe that
is easier to satisfy than the requests it adjudicates would be worse than no
probe.

## What it costs

One upstream call per retirement decision, bounded on three axes: a model is
probed at most once per 5 minutes however hard it is being retried, at most 4
probes are in flight per provider, and an open circuit or a family that cannot be
probed cheaply means no probe at all. Families that cannot be verified (image,
TTS, STT, rerank) are no longer auto-retired — falling back to the classifier
there would leave the guessing running where it is least observed.

## Notable decisions

- **Strikes are per surface**, keyed by (model, probe endpoint), so a chat
  refusal and an embeddings refusal are separate questions and the probe always
  asks what the strikes were about. A success clears the surface it arrived on.
- **A refusal only counts on a surface the model is known to serve.** Nothing
  filters requests by modality on the way in, so a chat model sent to
  `/v1/embeddings` draws a capability refusal that names it — which reads exactly
  like a retirement, and which the probe would faithfully reproduce.
- **A model serving both probeable surfaces is never auto-retired**, because the
  disable turns off the row and cannot express "gone on chat, still serving
  embeddings".
- **Nothing is credited on a status.** Every path clears a streak on evidence
  that content actually flowed, never on a 200.

## Review

20 rounds, ~50 findings, each fix mutation-proven: the production behaviour was
broken, the test observed to fail with a message naming the real problem, and the
code restored. Several rounds found defects in the fixes of the round before,
which is recorded in the commit messages rather than smoothed over.

Also documents the behaviour in `wiki/Model-Discovery.md` under "Traffic-driven
retirement: verified before it is written".

## Follow-ups (deliberately not here)

Recorded in the plan file: a Prometheus counter for probe verdicts (a new metric
name is a public contract), and probing rerank (cheap enough, but it would need
its own body and answer-shape judgement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
