### PR TITLE
fix(hooks): stop the diff-coverage gate skipping itself on large diffs

### DIFF
--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -82,9 +82,13 @@ if [ "${#PUSH_HEADS[@]}" -eq 1 ] && [ "${PUSH_HEADS[0]}" = "$(git rev-parse HEAD
 fi
 # touched <regex> - true when a changed path matches, or when we have no diff to
 # go on (no merge-base), so an unknown state stays conservative and runs the check.
+#
+# `grep -c >/dev/null` rather than `grep -q`, for the reason spelled out on
+# has_measurable_change: -q exits on the first match, and under `set -o pipefail`
+# the SIGPIPE it deals the writer becomes the pipeline's status. See there.
 touched() {
 	[ -z "$SYNC_BASE" ] && return 0
-	printf '%s\n' "$CHANGED" | grep -qE "$1"
+	printf '%s\n' "$CHANGED" | grep -cE "$1" >/dev/null
 }
 
 # has_measurable_change <include-regex> <exclude-regex> - true when a changed file
@@ -104,6 +108,23 @@ touched() {
 # a line with `*`); anything unrecognised counts as code; and if the diff cannot be
 # computed at all we return true so the suite still runs. CI enforces coverage
 # against the real ref regardless.
+#
+# The final grep counts instead of using -q, and that is load-bearing under this
+# script's `set -o pipefail`. `grep -q` exits the moment it matches; the `sed` and
+# `grep` upstream of it then take SIGPIPE and die with 141, and pipefail makes 141
+# the status of the whole pipeline — which is this function's return value. So a
+# diff WITH measurable lines reported "none", and did it only once the diff grew
+# past the 64 KiB pipe buffer (below that the writers finish before the reader
+# closes and nothing is signalled).
+#
+# That inverted the gate exactly where it matters: small changes were measured,
+# large ones skipped, and "no measurable lines" was indistinguishable from "plenty".
+# A 123 KB Go diff on the retirement branch skipped the gate and shipped a file at
+# 0% changed-line coverage, which CI's aggregate threshold then hid.
+#
+# -c reads its input to the end, so nothing upstream is ever signalled, and the
+# exit status is still 0-on-match / 1-on-none. The count itself is unwanted, hence
+# the redirect. The cost is reading the diff in full: ~120 KB, once, per push.
 has_measurable_change() {
 	local files
 	files="$(printf '%s\n' "$CHANGED_FILES" | grep -E "$1" | grep -vE "$2" || true)"
@@ -119,7 +140,7 @@ has_measurable_change() {
 		grep -E '^[+-]' |
 		grep -vE '^(\+\+\+|---)' |
 		sed -E 's/^[+-][[:space:]]*//' |
-		grep -qvE '^$|^//'
+		grep -cvE '^$|^//' >/dev/null
 }
 
 # run_vitest_coverage <app-subdir> <source-file-regex> - build lcov for one
@@ -180,8 +201,12 @@ run_vitest_coverage() {
 }
 
 if [ -n "$SYNC_BASE" ]; then
-	if printf '%s\n' "$CHANGED" | grep -qx "README.md" &&
-		! printf '%s\n' "$CHANGED" | grep -qx "DOCKERHUB.md"; then
+	# -c over -q on both, for the pipefail reason argued on has_measurable_change.
+	# A file list only exceeds the pipe buffer on a very wide change (a locale
+	# sweep, a mass rename), so this one is latent rather than firing — but it is
+	# the same construct, and the way it fails is to wave the guard through.
+	if printf '%s\n' "$CHANGED" | grep -cx "README.md" >/dev/null &&
+		! printf '%s\n' "$CHANGED" | grep -cx "DOCKERHUB.md" >/dev/null; then
 		if [ "${DOCKERHUB_README_NOT_NEEDED:-}" = "1" ]; then
 			echo "pre-push: README.md changed without DOCKERHUB.md - acknowledged (DOCKERHUB_README_NOT_NEEDED=1)"
 			echo "  -> CI uses a LABEL, not this env var: add the 'dockerhub-readme-not-needed'" >&2


### PR DESCRIPTION
The pre-push diff-coverage gate has been silently skipping itself on exactly the
changes it exists for. Found while investigating why PR #596's push printed
`no measurable changed surfaces, skipping` for a 12-file Go diff.

## Root cause

`has_measurable_change` ends in a `grep -q` pipeline:

```sh
printf '%s\n' "$diff" | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' \
  | sed -E 's/^[+-][[:space:]]*//' | grep -qvE '^$|^//'
```

`grep -q` exits on the **first** match. The `sed` and `grep` upstream then take
SIGPIPE and die with 141, and the script runs under `set -euo pipefail` (line
23), so 141 becomes the pipeline's status — and that pipeline is the function's
return value. `if has_measurable_change ...` reads false.

Those are the `sed: couldn't write 75 items to stdout: Broken pipe` lines that
show up in push output.

## Why it is inverted

A writer only gets EPIPE if it writes *after* the reader closes, so a diff that
fits the 64 KiB pipe buffer is fully written before `grep -q` exits:

| Situation | Should be | Was |
|---|---|---|
| Big diff, lots of code | run gate | **skipped** (141) |
| Small diff, some code | run gate | runs (0) |
| Only comments / blank lines | skip gate | skips (1) ✓ |

Small changes measured, large ones skipped — and "nothing to measure" was
indistinguishable from "plenty to measure", because both surface as non-zero.

## Measured on the branch that exposed it

```
merge-base diff:            12 Go files, 123,086 bytes  (pipe buffer: 65,536)
measurable changed lines:   643
pipeline with    pipefail:  exit=141   -> "skip the gate"
pipeline without pipefail:  exit=0     -> "measurable"
```

That push shipped `internal/anthropic/native.go` at **0.0% (0/8)** changed-line
coverage. CI's aggregate 94.4% was over threshold, so it rode through; the local
gate is what would have caught it per-file.

## Fix

`grep -c >/dev/null` instead of `grep -q`. `-c` reads its input to the end, so
nothing upstream is ever signalled, and the exit status is unchanged (0 on match,
1 on none). Cost is reading the diff in full — ~120 KB, once, per push.

Verified both directions with `pipefail` on:

```
real 123 KB diff  -> exit=0   (measurable, gate runs)
comments-only     -> exit=1   (nothing to measure, correctly skipped)
```

The same construct is fixed in `touched` and the DOCKERHUB.md guard. Both feed on
file lists, which only exceed the buffer on a very wide change (a locale sweep, a
mass rename), so they were latent — but the way they fail is to wave the guard
through.

## Not affected

CI's Coverage Diff Gate does not share this code and has been enforcing
throughout, so nothing merged uncovered. This restores the local gate, which is
the fast feedback loop, not the safety net.

## Not included

There is no test harness for the shell hooks (only `scripts/coverage/*.py` have
unit tests, run by CI's "Coverage script self-tests"). Adding one for a single
function felt disproportionate; the mechanism is documented in the function's
comment instead. Happy to wire one up if you'd rather have it pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)