### PR TITLE
feat(proxy): read a retirement out of error fields, not only out of prose

### DIFF
--- a/internal/proxy/upstream_classify.go
+++ b/internal/proxy/upstream_classify.go
@@ -339,6 +339,20 @@ var genericNotFoundTypes = map[string]bool{
 
 // structuredError is what a provider said about WHY it refused, in fields rather
 // than prose.
+//
+// The three fields must come from ONE object. That is the invariant this type
+// exists to carry, and it has been broken three separate ways while this was
+// being written: a message read from anywhere in the body, then from a different
+// level of the same document, then from a sibling object of the right one. Each
+// is the same mistake — a code or type is a claim about whatever its own object
+// is describing, and pairing it with a message from elsewhere invents a
+// statement no provider made. The identity check that bounds a generic
+// not-found type then reads the wrong text and retires a model nobody said
+// anything about.
+//
+// Both extractors enforce it and neither may relax it: the parse takes the error
+// object whole or the top level whole, and the scan works inside one delimited
+// region.
 type structuredError struct {
 	code    string
 	typ     string
@@ -347,14 +361,61 @@ type structuredError struct {
 
 // The scan fallback's patterns: a quoted string field by name, anchored on the
 // key so a value that merely looks like one cannot be picked up.
+//
+// The value may contain escaped quotes, which is not a nicety: providers quote
+// the model name inside the message they are already sending as JSON, so
+// `"message":"model \"gpt-4\" not found"` is an ordinary shape, and a pattern
+// that stopped at the first quote captured `model \` and lost the id. The escape
+// handling matches jsonObjectBody's, so the region walker and the field readers
+// agree about where a string ends.
 var (
-	scanCode    = regexp.MustCompile(`"code"\s*:\s*"([^"]*)"`)
-	scanType    = regexp.MustCompile(`"type"\s*:\s*"([^"]*)"`)
-	scanMessage = regexp.MustCompile(`"message"\s*:\s*"([^"]*)"`)
+	scanCode    = regexp.MustCompile(`"code"\s*:\s*"((?:[^"\\]|\\.)*)"`)
+	scanType    = regexp.MustCompile(`"type"\s*:\s*"((?:[^"\\]|\\.)*)"`)
+	scanMessage = regexp.MustCompile(`"message"\s*:\s*"((?:[^"\\]|\\.)*)"`)
 	// errorObjectStart finds where the error object opens, so the scan reads
 	// the fields belonging to it rather than the first ones in the document.
 	errorObjectStart = regexp.MustCompile(`"error"\s*:\s*\{`)
 )
+
+// jsonObjectBody returns the contents of the object whose opening brace ends at
+// start, up to its matching close brace, or to the end of the input when the
+// object never closes.
+//
+// The unclosed case is not an error path, it is the point: this only runs on a
+// body no parser would accept, which usually means SanitizeLogBody cut it
+// mid-object. A truncated object has no siblings after it, so running to the end
+// is exactly right there — and where the object DOES close, stopping at the brace
+// is what keeps a sibling's message from being read as this error's.
+//
+// Braces inside strings are skipped, because a provider message is free to
+// contain one ("expected { at position 4"), and a quote is only a delimiter when
+// it is not escaped. Anything more than that — numbers, nesting rules, escape
+// semantics beyond \" — belongs to the parser this function is the fallback for.
+func jsonObjectBody(body string, start int) string {
+	depth := 1
+	inString, escaped := false, false
+	for i := start; i < len(body); i++ {
+		c := body[i]
+		switch {
+		case escaped:
+			escaped = false
+		case c == '\\' && inString:
+			escaped = true
+		case c == '"':
+			inString = !inString
+		case inString:
+			// Braces inside a string are text, not structure.
+		case c == '{':
+			depth++
+		case c == '}':
+			depth--
+			if depth == 0 {
+				return body[start:i]
+			}
+		}
+	}
+	return body[start:]
+}
 
 // scanStructuredError extracts the three fields from a body no parser would
 // accept, scoped to the error object when one can be found.
@@ -378,7 +439,7 @@ func scanStructuredError(body string) structuredError {
 	// that do not travel together are not evidence about each other.
 	region := body
 	if at := errorObjectStart.FindStringIndex(body); at != nil {
-		region = body[at[1]:]
+		region = jsonObjectBody(body, at[1])
 	}
 	first := func(re *regexp.Regexp) string {
 		if m := re.FindStringSubmatch(region); m != nil {

--- a/internal/proxy/upstream_classify.go
+++ b/internal/proxy/upstream_classify.go
@@ -152,11 +152,15 @@ const minVersionSuffixDigits = 4
 // an id is never a suffix of another id's dated form, so nothing that ends in
 // letters ("-lite", "-32k") or in a decimal (".1") can reach this at all.
 func idEndAllowingVersion(body string, pos, end int) (int, bool) {
+	// The whole-identifier rule first and by name, because the extension below
+	// sits on top of it rather than instead of it.
+	if isWholeIDAt(body, pos, end) {
+		return end, true
+	}
+	// Only the tail may differ. A dirty START means the match is inside a longer
+	// id, which no suffix can rescue.
 	if pos != 0 && isModelIDChar(body[pos-1]) {
 		return 0, false
-	}
-	if end == len(body) || !isModelIDChar(body[end]) {
-		return end, true
 	}
 	suffix := versionSuffix.FindString(body[end:])
 	if suffix == "" {
@@ -283,12 +287,17 @@ func phraseIsAbout(body string, verbPos, verbEnd, lo, hi int, id string) bool {
 			return false
 		}
 		pos := off + at
-		end := pos + len(id)
-		if isWholeIDAt(body, pos, end) {
+		// The occurrence may be a dated snapshot of the id we asked for, and
+		// then it is the snapshot that has to clear the phrase: the gap below
+		// starts after the suffix, not after the alias. Prose carries this shape
+		// as readily as a JSON field does — "model `gpt-4-0613` does not exist"
+		// is the same claim as an error.message saying so — and reading only one
+		// of the two would leave the other silently unhandled.
+		if occEnd, ok := idEndAllowingVersion(body, pos, pos+len(id)); ok {
 			var gap string
 			switch {
-			case end <= verbPos:
-				gap = body[end:verbPos]
+			case occEnd <= verbPos:
+				gap = body[occEnd:verbPos]
 			case pos >= verbEnd:
 				gap = body[verbEnd:pos]
 			default:
@@ -336,13 +345,45 @@ type structuredError struct {
 	message string
 }
 
-// structuredFieldScan finds a quoted string field by name in a body that could
-// not be parsed. Deliberately anchored on the key so it cannot pick up a value
-// that merely looks like one.
-var structuredFieldScan = map[string]*regexp.Regexp{
-	"code":    regexp.MustCompile(`"code"\s*:\s*"([^"]*)"`),
-	"type":    regexp.MustCompile(`"type"\s*:\s*"([^"]*)"`),
-	"message": regexp.MustCompile(`"message"\s*:\s*"([^"]*)"`),
+// The scan fallback's patterns: a quoted string field by name, anchored on the
+// key so a value that merely looks like one cannot be picked up.
+var (
+	scanCode    = regexp.MustCompile(`"code"\s*:\s*"([^"]*)"`)
+	scanType    = regexp.MustCompile(`"type"\s*:\s*"([^"]*)"`)
+	scanMessage = regexp.MustCompile(`"message"\s*:\s*"([^"]*)"`)
+	// errorObjectStart finds where the error object opens, so the scan reads
+	// the fields belonging to it rather than the first ones in the document.
+	errorObjectStart = regexp.MustCompile(`"error"\s*:\s*\{`)
+)
+
+// scanStructuredError extracts the three fields from a body no parser would
+// accept, scoped to the error object when one can be found.
+//
+// The scoping is the whole point rather than tidiness. The payload this change
+// exists for opens `{"type":"error","error":{"type":"not_found_error",…}}`, so a
+// scan of the whole document finds the ENVELOPE's type first and reads "error" —
+// which is not a retirement signal, and shadows the one that is. A truncated
+// body is the normal case for a large error, so the fallback has to handle the
+// real shape rather than a tidier one.
+//
+// Falling back to the whole document when no error object is found keeps a
+// provider that reports its fields at the top level working; it is looser, and
+// what the callers do with the result is what bounds it.
+func scanStructuredError(body string) structuredError {
+	scoped := body
+	if at := errorObjectStart.FindStringIndex(body); at != nil {
+		scoped = body[at[1]:]
+	}
+	first := func(re *regexp.Regexp) string {
+		if m := re.FindStringSubmatch(scoped); m != nil {
+			return m[1]
+		}
+		if m := re.FindStringSubmatch(body); m != nil {
+			return m[1]
+		}
+		return ""
+	}
+	return structuredError{code: first(scanCode), typ: first(scanType), message: first(scanMessage)}
 }
 
 // parseStructuredError pulls the error code, type and message out of a body,
@@ -385,22 +426,7 @@ func parseStructuredError(body string) structuredError {
 		}
 	}
 
-	var found structuredError
-	for field, re := range structuredFieldScan {
-		m := re.FindStringSubmatch(body)
-		if m == nil {
-			continue
-		}
-		switch field {
-		case "code":
-			found.code = m[1]
-		case "type":
-			found.typ = m[1]
-		case "message":
-			found.message = m[1]
-		}
-	}
-	return found
+	return scanStructuredError(body)
 }
 
 func firstNonEmpty(a, b string) string {

--- a/internal/proxy/upstream_classify.go
+++ b/internal/proxy/upstream_classify.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"encoding/json"
 	"net/http"
 	"regexp"
 	"strconv"
@@ -115,6 +116,96 @@ func isWholeIDAt(body string, pos, end int) bool {
 	return startsClean && endsClean
 }
 
+// versionSuffix matches the tail a provider adds when it resolves an alias to a
+// dated snapshot: dash-separated runs of digits, at most three of them.
+//
+// The run count is bounded and the digits are counted separately (see
+// minVersionSuffixDigits) rather than being spelled `(-\d{4,}){1,3}`, because
+// a segmented date does not have four digits in every run: "-2024-04-09" is
+// "-2024", "-04", "-09". Requiring four per run rejected exactly that case.
+var versionSuffix = regexp.MustCompile(`^(-\d+){1,3}`)
+
+// minVersionSuffixDigits is what separates a date from a size or a variant
+// number, and it is the whole safety of the alias rule.
+//
+// "-20250514" and "-0613" and "-2024-04-09" are dates; "-70" (llama-3-70) and
+// "-32" are not, and neither is ".1" (gpt-4.1), which the pattern rejects on
+// shape before this is consulted. Four is the smallest threshold that admits a
+// bare year and excludes the two-digit variant numbers providers actually use.
+// It is the one number here I would expect to revisit, and it should be revisited
+// from a real payload rather than from speculation.
+const minVersionSuffixDigits = 4
+
+// idEndAllowingVersion reports where an occurrence of the requested id at
+// [pos, end) really ends, allowing the provider to have named a dated snapshot
+// of it, and whether that occurrence names the requested model at all.
+//
+// The problem it solves is asymmetric, which is why it is a separate predicate
+// from isWholeIDAt rather than a loosening of it. We ask for "claude-sonnet-4";
+// the provider resolves the alias and answers about "claude-sonnet-4-20250514".
+// Whole-identifier matching rejects that, correctly by its own rule, and that
+// same rejection is what stops an error about "gpt-4.1" from retiring "gpt-4".
+// So the boundary rule cannot be relaxed: what is added is one narrow shape on
+// top of it.
+//
+// The start must still be clean. Only the tail may differ, and only by digits:
+// an id is never a suffix of another id's dated form, so nothing that ends in
+// letters ("-lite", "-32k") or in a decimal (".1") can reach this at all.
+func idEndAllowingVersion(body string, pos, end int) (int, bool) {
+	if pos != 0 && isModelIDChar(body[pos-1]) {
+		return 0, false
+	}
+	if end == len(body) || !isModelIDChar(body[end]) {
+		return end, true
+	}
+	suffix := versionSuffix.FindString(body[end:])
+	if suffix == "" {
+		return 0, false
+	}
+	digits := 0
+	for i := range len(suffix) {
+		if suffix[i] >= '0' && suffix[i] <= '9' {
+			digits++
+		}
+	}
+	if digits < minVersionSuffixDigits {
+		return 0, false
+	}
+	extended := end + len(suffix)
+	// Whatever follows the snapshot must not continue the identifier:
+	// "gpt-4-0613-preview" is a variant of a snapshot, not the model we asked
+	// for.
+	if extended != len(body) && isModelIDChar(body[extended]) {
+		return 0, false
+	}
+	return extended, true
+}
+
+// namesModelAllowingVersion reports whether body names the requested model
+// anywhere in it, as a whole identifier or as a dated snapshot of one.
+//
+// No proximity, deliberately, and it is only used where proximity cannot apply:
+// a structured error puts the type in one JSON field and the id in another, so
+// there is no adjacency to measure. The callers that DO have prose to work with
+// keep using phraseIsAbout, which is stricter.
+func namesModelAllowingVersion(body, id string) bool {
+	if id == "" || body == "" {
+		return false
+	}
+	for off := 0; off+len(id) <= len(body); {
+		at := strings.Index(body[off:], id)
+		if at < 0 {
+			return false
+		}
+		pos := off + at
+		if _, ok := idEndAllowingVersion(body, pos, pos+len(id)); ok {
+			return true
+		}
+		off = pos + 1
+	}
+	return false
+}
+
 // maxAttributionGap bounds the text allowed between the model id and the phrase
 // that retires it. Real payloads put them adjacent or a few words apart ("The
 // model `gpt-4` has been deprecated and does not exist"); anything longer is a
@@ -214,6 +305,160 @@ func phraseIsAbout(body string, verbPos, verbEnd, lo, hi int, id string) bool {
 	return false
 }
 
+// modelScopedErrorCodes name the model in the field itself, so a body carrying
+// one is talking about the model the request asked for by construction.
+//
+// A deliberately small allowlist rather than a "model_*" pattern. A provider is
+// free to invent "model_overloaded" or "model_rate_limited", and those are
+// transient faults about a model that very much still exists — matching them by
+// prefix would retire it. The list grows from payloads observed in /api/logs,
+// which is the rule this whole change came from.
+var modelScopedErrorCodes = map[string]bool{
+	"model_not_found":     true,
+	"model_not_supported": true,
+}
+
+// genericNotFoundTypes say something is missing without saying what, so they
+// only count as a retirement alongside the requested model's own id.
+//
+// not_found_error is Anthropic's, forwarded verbatim by aggregators. It is used
+// for any absent entity — a conversation, a file, a batch — so on its own it is
+// far too weak to disable a model on.
+var genericNotFoundTypes = map[string]bool{
+	"not_found_error": true,
+}
+
+// structuredError is what a provider said about WHY it refused, in fields rather
+// than prose.
+type structuredError struct {
+	code    string
+	typ     string
+	message string
+}
+
+// structuredFieldScan finds a quoted string field by name in a body that could
+// not be parsed. Deliberately anchored on the key so it cannot pick up a value
+// that merely looks like one.
+var structuredFieldScan = map[string]*regexp.Regexp{
+	"code":    regexp.MustCompile(`"code"\s*:\s*"([^"]*)"`),
+	"type":    regexp.MustCompile(`"type"\s*:\s*"([^"]*)"`),
+	"message": regexp.MustCompile(`"message"\s*:\s*"([^"]*)"`),
+}
+
+// parseStructuredError pulls the error code, type and message out of a body,
+// and never fails: an absent field means no signal, which every caller treats as
+// "nothing established".
+//
+// Two passes, because the input cannot be trusted to be a document. The body
+// reaching the classifier has been through util.SanitizeLogBody, which truncates
+// at 10 000 bytes and will happily cut JSON mid-structure, and plenty of
+// providers answer with HTML or plain text. So the parse is tried first, for its
+// precision — it reads error.code and error.type from the error OBJECT, not from
+// anywhere the strings happen to appear — and a key scan is the fallback.
+//
+// The fallback is the looser of the two and is scoped by what the callers do
+// with it rather than by the scan itself: a code only counts if it is in a small
+// allowlist, and a type only counts alongside the model's own id. A stray
+// "type":"function" in an echoed tool definition matches neither.
+func parseStructuredError(body string) structuredError {
+	var envelope struct {
+		Error struct {
+			Code    any    `json:"code"`
+			Type    string `json:"type"`
+			Message string `json:"message"`
+		} `json:"error"`
+		Code    any    `json:"code"`
+		Type    string `json:"type"`
+		Message string `json:"message"`
+	}
+	if json.Unmarshal([]byte(body), &envelope) == nil {
+		// A code may be a string ("model_not_found") or a number; only the
+		// string form carries a name worth matching.
+		codeOf := func(v any) string {
+			s, _ := v.(string)
+			return s
+		}
+		return structuredError{
+			code:    firstNonEmpty(codeOf(envelope.Error.Code), codeOf(envelope.Code)),
+			typ:     firstNonEmpty(envelope.Error.Type, envelope.Type),
+			message: firstNonEmpty(envelope.Error.Message, envelope.Message),
+		}
+	}
+
+	var found structuredError
+	for field, re := range structuredFieldScan {
+		m := re.FindStringSubmatch(body)
+		if m == nil {
+			continue
+		}
+		switch field {
+		case "code":
+			found.code = m[1]
+		case "type":
+			found.typ = m[1]
+		case "message":
+			found.message = m[1]
+		}
+	}
+	return found
+}
+
+func firstNonEmpty(a, b string) string {
+	if a != "" {
+		return a
+	}
+	return b
+}
+
+// normalizeModelID reduces an upstream model id to the form the body is matched
+// against: lowercased, trimmed, and cut to the last path segment, because
+// providers report Google models with the "models/" prefix the id omits and the
+// distinctive part is the tail either way.
+func normalizeModelID(modelID string) string {
+	id := strings.ToLower(strings.TrimSpace(modelID))
+	if i := strings.LastIndex(id, "/"); i >= 0 && i+1 < len(id) {
+		id = id[i+1:]
+	}
+	return id
+}
+
+// structuredModelGone reports whether the body's ERROR FIELDS say the requested
+// model is gone, for the providers that answer with a code rather than a
+// sentence.
+//
+// It exists because prose matching cannot reach these payloads at all. Zen
+// forwards Anthropic's error verbatim, and the only retirement signal in it is
+// error.type; the model id lives in error.message. modelGoneAbout requires the
+// two to be adjacent with no clause break between them — a rule that is right
+// for prose and structurally impossible to satisfy across two JSON fields, which
+// are separated by the comma isClauseBreak treats as a boundary by design.
+//
+// Two tiers, and the difference between them is whether the field already names
+// its subject:
+//
+//   - A model-scoped code is about the model by construction. There is no prose
+//     to anchor to and none is wanted.
+//   - A generic not-found type could as easily be a missing conversation, so it
+//     needs the requested model named in the error's own message. Not merely
+//     somewhere in the body: a provider echoing the request back would name the
+//     model in it, and a not_found_error about something else entirely would
+//     then read as this model's retirement.
+//
+// An empty model id claims nothing, for the same reason modelGoneAbout claims
+// nothing: a retirement that cannot be attributed is not one this gateway will
+// assert.
+func structuredModelGone(body, modelID string) bool {
+	id := normalizeModelID(modelID)
+	if id == "" || body == "" {
+		return false
+	}
+	e := parseStructuredError(body)
+	if modelScopedErrorCodes[e.code] {
+		return true
+	}
+	return genericNotFoundTypes[e.typ] && namesModelAllowingVersion(e.message, id)
+}
+
 // modelGoneAbout reports whether the body is the provider asserting that THIS
 // model — the one the request asked for — is gone.
 //
@@ -229,14 +474,9 @@ func phraseIsAbout(body string, verbPos, verbEnd, lo, hi int, id string) bool {
 // be verified, so nothing is claimed: the caller gets the generic provider
 // error rather than a retirement it cannot substantiate.
 func modelGoneAbout(body, modelID string) bool {
-	id := strings.ToLower(strings.TrimSpace(modelID))
+	id := normalizeModelID(modelID)
 	if id == "" || body == "" {
 		return false
-	}
-	// Providers report Google models with the "models/" prefix the id omits, so
-	// compare on the last path segment; it is the distinctive part either way.
-	if i := strings.LastIndex(id, "/"); i >= 0 && i+1 < len(id) {
-		id = id[i+1:]
 	}
 
 	for _, verb := range modelGoneVerbs {
@@ -295,6 +535,20 @@ func modelGoneAbout(body, modelID string) bool {
 // response.
 func classifyUpstreamError(status int, body, modelID string) (ErrorKind, string) {
 	b := strings.ToLower(body)
+
+	// Model retired or never served by this provider, said in fields rather than
+	// in a sentence. Ahead of the prose path because it is the more specific
+	// claim: a provider that names a model-scoped code has already told us what
+	// its message can only imply.
+	//
+	// The capability veto deliberately does not apply here. It exists to stop
+	// "is not supported for this endpoint" reading as a retirement, which is a
+	// property of prose; a structured model_not_supported is the provider
+	// answering the question directly, and there is no qualifying clause to
+	// misread.
+	if structuredModelGone(b, modelID) {
+		return KindProviderModelGone, "the provider no longer serves this model"
+	}
 
 	// Model retired or never served by this provider. modelGoneAbout requires
 	// the requested model's own id beside the phrase AND that the phrase is not

--- a/internal/proxy/upstream_classify.go
+++ b/internal/proxy/upstream_classify.go
@@ -370,15 +370,18 @@ var (
 // provider that reports its fields at the top level working; it is looser, and
 // what the callers do with the result is what bounds it.
 func scanStructuredError(body string) structuredError {
-	scoped := body
+	// One region for all three fields, never a field-by-field fallback. Reading
+	// the type from inside the error object and the message from outside it
+	// pairs a real signal with an unrelated sentence, and the identity check
+	// that is meant to bound the type then answers about the wrong text: a body
+	// whose top-level message merely mentions the model would retire it. Fields
+	// that do not travel together are not evidence about each other.
+	region := body
 	if at := errorObjectStart.FindStringIndex(body); at != nil {
-		scoped = body[at[1]:]
+		region = body[at[1]:]
 	}
 	first := func(re *regexp.Regexp) string {
-		if m := re.FindStringSubmatch(scoped); m != nil {
-			return m[1]
-		}
-		if m := re.FindStringSubmatch(body); m != nil {
+		if m := re.FindStringSubmatch(region); m != nil {
 			return m[1]
 		}
 		return ""
@@ -419,21 +422,28 @@ func parseStructuredError(body string) structuredError {
 			s, _ := v.(string)
 			return s
 		}
+		nested := structuredError{
+			code:    codeOf(envelope.Error.Code),
+			typ:     envelope.Error.Type,
+			message: envelope.Error.Message,
+		}
+		// One level or the other, never a mixture, for the reason
+		// scanStructuredError gives: a type from the error object paired with a
+		// message from outside it is two unrelated statements, and the identity
+		// check that bounds the type would then be reading the wrong text. The
+		// error object wins whenever it said anything at all; a provider that
+		// reports at the top level still works because then it said nothing.
+		if nested != (structuredError{}) {
+			return nested
+		}
 		return structuredError{
-			code:    firstNonEmpty(codeOf(envelope.Error.Code), codeOf(envelope.Code)),
-			typ:     firstNonEmpty(envelope.Error.Type, envelope.Type),
-			message: firstNonEmpty(envelope.Error.Message, envelope.Message),
+			code:    codeOf(envelope.Code),
+			typ:     envelope.Type,
+			message: envelope.Message,
 		}
 	}
 
 	return scanStructuredError(body)
-}
-
-func firstNonEmpty(a, b string) string {
-	if a != "" {
-		return a
-	}
-	return b
 }
 
 // normalizeModelID reduces an upstream model id to the form the body is matched

--- a/internal/proxy/upstream_classify_test.go
+++ b/internal/proxy/upstream_classify_test.go
@@ -750,6 +750,33 @@ func TestClassifyUpstreamError_StructuredRetirementSignals(t *testing.T) {
 			want:      KindProviderError,
 		},
 		{
+			// The same hole through a different door: the error object supplies
+			// the type and says nothing else, and a top-level message mentions
+			// the model. Reading a field from each level pairs two unrelated
+			// statements, and the identity check meant to bound the type then
+			// answers about the wrong text.
+			name:      "a not-found type paired with a top-level message",
+			body:      `{"message":"please retry claude-sonnet-4 later","error":{"type":"not_found_error"}}`,
+			requested: "claude-sonnet-4",
+			want:      KindProviderError,
+		},
+		{
+			// And the truncated form of it, which takes the scan rather than
+			// the parse.
+			name:      "a truncated not-found type paired with a top-level message",
+			body:      `{"message":"claude-sonnet-4 was requested","error":{"type":"not_found_error"`,
+			requested: "claude-sonnet-4",
+			want:      KindProviderError,
+		},
+		{
+			// A provider that reports at the top level still works, because
+			// then the error object said nothing to prefer.
+			name:      "a top-level not-found type naming the model",
+			body:      `{"type":"not_found_error","message":"model: claude-sonnet-4-20250514"}`,
+			requested: "claude-sonnet-4",
+			want:      KindProviderModelGone,
+		},
+		{
 			name:      "an invalid-request type naming the model",
 			body:      `{"error":{"type":"invalid_request_error","message":"model: claude-sonnet-4-20250514 rejected"}}`,
 			requested: "claude-sonnet-4",

--- a/internal/proxy/upstream_classify_test.go
+++ b/internal/proxy/upstream_classify_test.go
@@ -798,15 +798,91 @@ func TestClassifyUpstreamError_StructuredRetirementSignals(t *testing.T) {
 // the signal is usually near the front while the truncation is at the end. The
 // key scan is looser than the parse, which is why what it finds only counts
 // against an allowlisted code or beside the model's own id.
+//
+// The fixture is the REAL captured body, envelope and all, because the envelope
+// is what makes this hard: `{"type":"error","error":{"type":"not_found_error"`
+// puts a decoy in front of the signal, and a scan of the whole document reads
+// the outer one and finds "error", which retires nothing. An earlier version of
+// this test dropped the outer field and passed against a scan that could not
+// handle the payload it was written for.
 func TestClassifyUpstreamError_TruncatedStructuredBodyStillClassifies(t *testing.T) {
 	t.Parallel()
 
-	// A complete error object followed by a cut-off tail: valid JSON never
-	// arrives, so json.Unmarshal fails and the scan is what is left.
-	body := `{"error":{"type":"not_found_error","message":"model: claude-sonnet-4-20250514"},"usage":{"input_tok`
-	if got, _ := classifyUpstreamError(404, body, "claude-sonnet-4"); got != KindProviderModelGone {
-		t.Errorf("kind = %q, want %q: the signal was in the part that survived truncation", got, KindProviderModelGone)
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "the captured body, cut mid-tail",
+			body: `{"type":"error","error":{"type":"not_found_error",` +
+				`"message":"error from provider (anthropic): model: claude-sonnet-4-20250514"},"request_id":"req_011Cda`,
+		},
+		{
+			name: "an error object with no envelope around it",
+			body: `{"error":{"type":"not_found_error","message":"model: claude-sonnet-4-20250514"},"usage":{"input_tok`,
+		},
 	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got, _ := classifyUpstreamError(404, tc.body, "claude-sonnet-4"); got != KindProviderModelGone {
+				t.Errorf("kind = %q, want %q: the signal was in the part that survived truncation", got, KindProviderModelGone)
+			}
+		})
+	}
+}
+
+// TestClassifyUpstreamError_ProseNamingADatedSnapshot pins that the alias rule
+// reaches the prose path too.
+//
+// A provider that resolves the alias and says so in a sentence is making the
+// same claim as one that says so in a JSON field, and identity is the thing that
+// was failing in both. Handling only the structured half would have left the
+// other silently unfixed, which is the shape of the bug this whole change came
+// from.
+//
+// The negatives are the ones that matter: extending an occurrence over a dated
+// tail must not extend it over anything else.
+func TestClassifyUpstreamError_ProseNamingADatedSnapshot(t *testing.T) {
+	t.Parallel()
+
+	runClassifyCases(t, []struct {
+		name      string
+		body      string
+		requested string
+		want      ErrorKind
+	}{
+		{
+			name:      "prose naming a dated snapshot of the requested alias",
+			body:      "the model `gpt-4-0613` does not exist",
+			requested: "gpt-4",
+			want:      KindProviderModelGone,
+		},
+		{
+			name:      "prose naming a segmented-date snapshot",
+			body:      "model gpt-4-turbo-2024-04-09 is no longer available",
+			requested: "gpt-4-turbo",
+			want:      KindProviderModelGone,
+		},
+		{
+			name:      "prose naming a sibling family member is still not us",
+			body:      "the model `gpt-4.1` does not exist",
+			requested: "gpt-4",
+			want:      KindProviderError,
+		},
+		{
+			name:      "prose naming a named variant is still not us",
+			body:      "the model `gemini-3-flash-lite` does not exist",
+			requested: "gemini-3-flash",
+			want:      KindProviderError,
+		},
+		{
+			name:      "prose naming a size variant is still not us",
+			body:      "the model `gpt-4-32k` does not exist",
+			requested: "gpt-4",
+			want:      KindProviderError,
+		},
+	})
 }
 
 // TestVersionSuffixIdentity is the table from the plan, and the negatives in it

--- a/internal/proxy/upstream_classify_test.go
+++ b/internal/proxy/upstream_classify_test.go
@@ -859,6 +859,77 @@ func TestClassifyUpstreamError_TruncatedStructuredBodyStillClassifies(t *testing
 	}
 }
 
+// TestScanStructuredError_ReadsOneObject pins the invariant structuredError
+// exists to carry: the three fields come from ONE object.
+//
+// It has been broken three ways while this was written — a message read from
+// anywhere in the body, then from another level of the same document, then from
+// a SIBLING of the right object — and each time the identity check that bounds a
+// generic not-found type ended up reading text no provider had attached to it.
+// These are the sibling cases, which only the scan can reach: the parse rejects
+// them by construction, and the scan is what runs on a truncated body, which is
+// the normal case for a large error.
+func TestScanStructuredError_ReadsOneObject(t *testing.T) {
+	t.Parallel()
+
+	runClassifyCases(t, []struct {
+		name      string
+		body      string
+		requested string
+		want      ErrorKind
+	}{
+		{
+			name:      "a sibling object's message is not this error's",
+			body:      `{"error":{"type":"not_found_error"},"hint":{"message":"try claude-sonnet-4 instead"}`,
+			requested: "claude-sonnet-4",
+			want:      KindProviderError,
+		},
+		{
+			name:      "nor is a later echo of the request",
+			body:      `{"error":{"type":"not_found_error"},"request":{"message":"claude-sonnet-4 hello"}`,
+			requested: "claude-sonnet-4",
+			want:      KindProviderError,
+		},
+		{
+			// The object closes, so the walker stops there even though the id
+			// appears afterwards.
+			name:      "a closed error object does not reach past its brace",
+			body:      `{"error":{"type":"not_found_error","message":"nothing \"here\""},"z":{"message":"claude-sonnet-4-20250514"}`,
+			requested: "claude-sonnet-4",
+			want:      KindProviderError,
+		},
+		{
+			// An object nested INSIDE the error object must not end the region
+			// early, or the fields after it are lost.
+			name:      "a nested object does not end the region",
+			body:      `{"error":{"details":{"foo":"bar"},"type":"not_found_error","message":"model: claude-sonnet-4-20250514"},"x":1`,
+			requested: "claude-sonnet-4",
+			want:      KindProviderModelGone,
+		},
+		{
+			// A brace inside a message is text, not structure. A CLOSING one is
+			// what proves it: counted as structure it ends the region mid-value,
+			// the message loses its closing quote, and the field reader finds
+			// nothing. An opening brace would not show this, since the region
+			// merely runs long and the right message is still the first one in
+			// it.
+			name:      "a closing brace inside a message is not a delimiter",
+			body:      `{"error":{"type":"not_found_error","message":"unexpected } in model claude-sonnet-4-20250514"},"y":{"message":"nope"}`,
+			requested: "claude-sonnet-4",
+			want:      KindProviderModelGone,
+		},
+		{
+			// Providers quote the model name inside a message that is itself
+			// JSON, so a field reader that stopped at the first quote lost the
+			// id it was looking for.
+			name:      "escaped quotes around the id still name it",
+			body:      `{"error":{"type":"not_found_error","message":"model \"claude-sonnet-4-20250514\" not found"},"z":{"message":"nope"}`,
+			requested: "claude-sonnet-4",
+			want:      KindProviderModelGone,
+		},
+	})
+}
+
 // TestClassifyUpstreamError_ProseNamingADatedSnapshot pins that the alias rule
 // reaches the prose path too.
 //

--- a/internal/proxy/upstream_classify_test.go
+++ b/internal/proxy/upstream_classify_test.go
@@ -671,3 +671,183 @@ func runClassifyCases(t *testing.T, tests []struct {
 		})
 	}
 }
+
+// TestClassifyUpstreamError_StructuredRetirementSignals covers the payload shape
+// that prose matching cannot reach at all: the retirement is a JSON field, and
+// the model id is in a different one.
+//
+// The captured body is from issue #595 — OpenCode Zen forwarding Anthropic's own
+// error verbatim for claude-sonnet-4, a model Zen lists and refuses. It accrued
+// no strike and was never retired, because modelGoneAbout requires the id
+// adjacent to a verb with no clause break between them, and here the two are
+// separated by the comma between two JSON fields.
+//
+// The negatives are the point of this test rather than the positives. Each of
+// them is a body that says something is missing, or names a model, or both, and
+// none of them is this model being retired.
+func TestClassifyUpstreamError_StructuredRetirementSignals(t *testing.T) {
+	t.Parallel()
+
+	// The exact body captured on dev, whitespace and all.
+	zenBody := `{"type":"error","error":{"type":"not_found_error",` +
+		`"message":"Error from provider (Anthropic): model: claude-sonnet-4-20250514"},` +
+		`"request_id":"req_011CdaLiCduCzdJHbasS6cWF"}`
+
+	tests := []struct {
+		name      string
+		body      string
+		requested string
+		want      ErrorKind
+	}{
+		{
+			name:      "the captured Zen body, asked for by its alias",
+			body:      zenBody,
+			requested: "claude-sonnet-4",
+			want:      KindProviderModelGone,
+		},
+		{
+			name:      "the same body, asked for by the snapshot it names",
+			body:      zenBody,
+			requested: "claude-sonnet-4-20250514",
+			want:      KindProviderModelGone,
+		},
+		{
+			// A model-scoped code names its own subject, so no identity check
+			// applies and none is wanted.
+			name:      "a model-scoped code needs no prose",
+			body:      `{"error":{"code":"model_not_found","message":"no such model"}}`,
+			requested: "hy3-preview",
+			want:      KindProviderModelGone,
+		},
+		{
+			name:      "a model-scoped code at the top level",
+			body:      `{"code":"model_not_supported","message":"unavailable"}`,
+			requested: "hy3-preview",
+			want:      KindProviderModelGone,
+		},
+
+		// --- negatives: something is missing, but not this model ---
+		{
+			// The whole reason not_found_error needs identity: it is used for
+			// any absent entity.
+			name:      "a not-found type naming a different model",
+			body:      `{"error":{"type":"not_found_error","message":"model: some-other-model-20250101"}}`,
+			requested: "claude-sonnet-4",
+			want:      KindProviderError,
+		},
+		{
+			name:      "a not-found type about something that is not a model",
+			body:      `{"error":{"type":"not_found_error","message":"conversation conv_0192 not found"}}`,
+			requested: "claude-sonnet-4",
+			want:      KindProviderError,
+		},
+		{
+			// The model is named, but in the request echo rather than in the
+			// error. Matching anywhere in the body would retire it.
+			name:      "a not-found type with the model named only outside the error",
+			body:      `{"model":"claude-sonnet-4","error":{"type":"not_found_error","message":"file file_01 not found"}}`,
+			requested: "claude-sonnet-4",
+			want:      KindProviderError,
+		},
+		{
+			name:      "an invalid-request type naming the model",
+			body:      `{"error":{"type":"invalid_request_error","message":"model: claude-sonnet-4-20250514 rejected"}}`,
+			requested: "claude-sonnet-4",
+			want:      KindProviderError,
+		},
+		{
+			name:      "a server-error type naming the model",
+			body:      `{"error":{"type":"server_error","message":"model: claude-sonnet-4-20250514 failed"}}`,
+			requested: "claude-sonnet-4",
+			want:      KindProviderError,
+		},
+		{
+			// Providers invent codes. An unknown model-ish one is a transient
+			// fault about a model that plainly still exists.
+			name:      "an unknown model-ish code is not an allowlisted one",
+			body:      `{"error":{"code":"model_overloaded","message":"try again"}}`,
+			requested: "claude-sonnet-4",
+			want:      KindProviderError,
+		},
+		{
+			// SanitizeLogBody truncates at 10 000 bytes and will cut JSON
+			// mid-structure. The parse must degrade to "no structured signal"
+			// rather than matching on a fragment.
+			name:      "a truncated body carrying the words but no parseable structure",
+			body:      `{"error":{"type":"not_found_erro`,
+			requested: "claude-sonnet-4",
+			want:      KindProviderError,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, _ := classifyUpstreamError(404, tc.body, tc.requested)
+			if got != tc.want {
+				t.Errorf("classifyUpstreamError(404, %q, %q) = %q, want %q", tc.body, tc.requested, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestClassifyUpstreamError_TruncatedStructuredBodyStillClassifies pins the
+// fallback the parse degrades to when SanitizeLogBody has cut the document.
+//
+// A truncated body is the normal case for a large error, not an exotic one, and
+// the signal is usually near the front while the truncation is at the end. The
+// key scan is looser than the parse, which is why what it finds only counts
+// against an allowlisted code or beside the model's own id.
+func TestClassifyUpstreamError_TruncatedStructuredBodyStillClassifies(t *testing.T) {
+	t.Parallel()
+
+	// A complete error object followed by a cut-off tail: valid JSON never
+	// arrives, so json.Unmarshal fails and the scan is what is left.
+	body := `{"error":{"type":"not_found_error","message":"model: claude-sonnet-4-20250514"},"usage":{"input_tok`
+	if got, _ := classifyUpstreamError(404, body, "claude-sonnet-4"); got != KindProviderModelGone {
+		t.Errorf("kind = %q, want %q: the signal was in the part that survived truncation", got, KindProviderModelGone)
+	}
+}
+
+// TestVersionSuffixIdentity is the table from the plan, and the negatives in it
+// are the regression that five rounds of review produced.
+//
+// Widening identity is the dangerous half of this change: every one of those
+// rounds was about a false retirement, and the whole-identifier rule is what
+// stops an error about gpt-4.1 from disabling gpt-4. The suffix rule is additive
+// to that rule rather than a relaxation of it, and any doubt resolves toward
+// rejecting.
+func TestVersionSuffixIdentity(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		requested string
+		body      string
+		want      bool
+	}{
+		{"dated snapshot", "claude-sonnet-4", "model: claude-sonnet-4-20250514", true},
+		{"short dated snapshot", "gpt-4", "model: gpt-4-0613", true},
+		{"segmented date", "gpt-4-turbo", "model: gpt-4-turbo-2024-04-09", true},
+		{"exact id", "gpt-4", "model: gpt-4", true},
+		{"id at the very end", "gpt-4", "gpt-4", true},
+
+		{"a sibling family member is not an alias", "gpt-4", "model: gpt-4.1", false},
+		{"a named variant is not a date", "gemini-3-flash", "model: gemini-3-flash-lite", false},
+		{"a size suffix is not a date", "gpt-4", "model: gpt-4-32k", false},
+		{"too few digits to be a date", "llama-3", "model: llama-3-70", false},
+		{"a shorter id is never an alias of a longer one", "gpt-4.1", "model: gpt-4", false},
+		{"a variant of a snapshot is not the model", "gpt-4", "model: gpt-4-0613-preview", false},
+		{"a longer id that merely starts the same", "gpt-4", "model: gpt-4o", false},
+		{"the id inside a longer word", "gpt-4", "not-gpt-4", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := namesModelAllowingVersion(tc.body, tc.requested); got != tc.want {
+				t.Errorf("namesModelAllowingVersion(%q, %q) = %v, want %v", tc.body, tc.requested, got, tc.want)
+			}
+		})
+	}
+}

--- a/wiki/Model-Discovery.md
+++ b/wiki/Model-Discovery.md
@@ -1010,13 +1010,24 @@ request before anything is written.
 
 How a retirement is reached:
 
-1. **Nomination.** A request that the provider refuses with retirement-shaped
-   prose counts one strike against that model. Three strikes nominate it, with no
-   successful request in between and no more than 30 minutes between one strike
-   and the next. That is a gap, not a deadline: refusals at 0, 29 and 58 minutes
-   are one streak of three, while a model refused once an hour never accumulates
-   one. Strikes are in-memory and per gateway instance: they are not persisted,
-   and each HA member reaches its own conclusion from its own traffic.
+1. **Nomination.** A request the provider refuses as a retirement counts one
+   strike against that model. Three strikes nominate it, with no successful
+   request in between and no more than 30 minutes between one strike and the
+   next. That is a gap, not a deadline: refusals at 0, 29 and 58 minutes are one
+   streak of three, while a model refused once an hour never accumulates one.
+   Strikes are in-memory and per gateway instance: they are not persisted, and
+   each HA member reaches its own conclusion from its own traffic.
+
+   A refusal is read two ways. In prose, the model's own id has to sit beside the
+   phrase that retires it, with no clause break between them, and a phrase that
+   only refuses one capability ("not supported for this endpoint") does not
+   count. In fields, a model-scoped error code (`model_not_found`,
+   `model_not_supported`) is a retirement on its own because it names its own
+   subject, and a generic `not_found_error` counts only when the error's message
+   also names the model. That name may be a dated snapshot, since providers
+   resolve an alias like `claude-sonnet-4` and answer about
+   `claude-sonnet-4-20250514`. Only dash-separated digit runs are accepted as
+   that kind of suffix, so `gpt-4.1` still cannot retire `gpt-4`.
 
    Strikes are counted per surface, and a refusal only counts on a surface the
    model is known to serve. Chat and embeddings keep separate counts, because the


### PR DESCRIPTION
Closes #595. Implements `plans/595-structured-retirement-signals.md`.

## The payload

`OpenCode Zen/claude-sonnet-4` — listed by Zen, refused by Zen — accrued no
retirement strike. Zen forwards Anthropic's error verbatim:

```json
{"type":"error","error":{"type":"not_found_error",
 "message":"Error from provider (Anthropic): model: claude-sonnet-4-20250514"},
 "request_id":"req_011CdaLiCduCzdJHbasS6cWF"}
```

Two independent reasons it classified as `provider_error`, and the second is the
harder one.

## 1. The signal is a field, not a sentence

Every entry in `modelGoneVerbs` is a phrase, and `modelGoneAbout` requires the
model id beside the phrase with no clause break between them. Here the type is in
`error.type` and the id is in `error.message`, separated by the comma that
`isClauseBreak` treats as a boundary **by design**. No amount of adding strings
to the verb list reaches this payload.

So error fields are now read directly, in two tiers that differ in whether the
field already names its subject:

- **A model-scoped code** (`model_not_found`, `model_not_supported`) is about the
  model by construction. No identity check applies and none is wanted. A small
  allowlist rather than a `model_*` pattern, because a provider is free to invent
  `model_overloaded` for a model that plainly still exists.
- **A generic `not_found_error`** could as easily be a missing conversation, so
  it counts only when the error's own **message** names the requested model. Not
  merely the body: a provider echoing the request back names the model in it, and
  a not-found about something else would then read as this model's retirement.

The capability veto stays on the prose path alone. It exists to stop "not
supported for this endpoint" reading as a retirement, which is a property of
sentences; a structured `model_not_supported` has no qualifying clause to misread.

## 2. The provider names a version-suffixed alias

We ask for `claude-sonnet-4`; the provider resolves the alias and answers about
`claude-sonnet-4-20250514`. Whole-identifier matching rejects that — and the same
rejection is what stops an error about `gpt-4.1` from retiring `gpt-4`.

**The boundary rule is not relaxed.** One narrow shape is added on top of it: an
occurrence may carry a version suffix of dash-separated digit runs totalling at
least four digits.

| Requested | Body names | Verdict |
|---|---|---|
| `claude-sonnet-4` | `claude-sonnet-4-20250514` | accept |
| `gpt-4` | `gpt-4-0613` | accept |
| `gpt-4-turbo` | `gpt-4-turbo-2024-04-09` | accept |
| `gpt-4` | `gpt-4.1` | **reject** |
| `gemini-3-flash` | `gemini-3-flash-lite` | **reject** |
| `gpt-4` | `gpt-4-32k` | **reject** |
| `llama-3` | `llama-3-70` | **reject** |
| `gpt-4` | `gpt-4-0613-preview` | **reject** |

Counting digits across the runs rather than per run is what makes the segmented
date work; the four-digit floor is what separates a date from a size or a variant
number.

**What the floor also admits, stated rather than left to be found.** It is a
shape rule, not a date parser, so a numeric suffix of four or more digits that is
*not* a date passes too: `gpt-4-32768` and `llama-3-8000` are read as snapshots of
`gpt-4` and `llama-3`. Real ids mostly spell variants with letters (`-32k`,
`-70b`), which reject, so this is narrow — and since #596 a wrong classifier
signal buys a probe rather than a retirement: a live `gpt-4` answers its probe and
is never disabled. The floor is the one number here worth revisiting, and it
should be revisited from a real payload rather than from speculation.

**The scan is positional.** When the parse fails, fields are read from the first
`"error": {` in the document, so an echoed request carrying its own error object
shadows the real one and the signal is missed (`provider_error` — the safe
direction). Fields are read from one level or the other and never mixed: a type
from inside the error object paired with a message from outside it is two
unrelated statements, and the identity check meant to bound the type would then
be reading the wrong text.

## Truncation

`SanitizeLogBody` caps at 10 000 bytes and will cut JSON mid-structure, so the
parse never fails: a document parse is tried first for its precision, and a key
scan is the fallback. What the looser one finds still only counts against an
allowlisted code or beside the model's own id.

## Testing

Every new test was run against the unfixed classifier first. Without the tiers the
captured body classifies as `provider_error`; without the suffix rule all three
dated-snapshot cases fail. The negative controls are the point rather than the
positives — `gpt-4` vs `gpt-4.1` is the regression five rounds of review on #593
produced, and it is asserted directly. The existing classifier cases are
unchanged.

## Relationship to #596

#596 made classifier precision an accuracy question rather than a correctness
one: a missed signal means no retirement, and a false one is thrown out by the
probe before anything is written. This is that accuracy work — fewer pointless
probes, and a genuinely dead model on Zen now reaching a probe at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
