### PR TITLE
feat(metrics): count pre-retirement probe verdicts

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -52,6 +52,11 @@ var (
 		Name: "modelhotel_responses_reroute_total",
 		Help: "Attempts routed via the OpenAI Responses API instead of chat completions, by provider, model, and mode (learned = healed from a live 400, preemptive = cache-driven).",
 	}, []string{"provider", "model", "mode"})
+
+	retirementProbesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "modelhotel_retirement_probes_total",
+		Help: "Pre-retirement probes by provider, model, and verdict. refused = the provider refused the model by name, so a retirement was attempted (it can still be called off, so this is not a count of retirements; use the model.auto_disabled_gone event for those). served = the model answered and the retirement was called off. inconclusive = nothing was established and the retirement was postponed. model is the provider-side model id, not the name a client asked for.",
+	}, []string{"provider", "model", "verdict"})
 )
 
 func init() {
@@ -62,6 +67,7 @@ func init() {
 		tokensTotal,
 		failoverAttemptsTotal,
 		responsesRerouteTotal,
+		retirementProbesTotal,
 		collectors.NewGoCollector(),
 		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
 	)
@@ -114,6 +120,38 @@ func Record(o Observation) {
 // when the cached requirement redirected the attempt up front.
 func RecordResponsesReroute(provider, model, mode string) {
 	responsesRerouteTotal.WithLabelValues(labelOrUnknown(provider), labelOrUnknown(model), mode).Inc()
+}
+
+// RecordRetirementProbe counts one completed pre-retirement probe. verdict is
+// the probe's own name for what it established ("refused", "served",
+// "inconclusive"); the caller owns that vocabulary, because the verdict type
+// lives in the proxy and this package must stay importable by it.
+//
+// One series per (provider, model, verdict), and only for models the gateway
+// actually probed: a probe is rate-limited to one per model per cooldown, and
+// only a model drawing repeated gone-classified refusals is ever nominated. The
+// bound is the catalog, and in practice a small fraction of it.
+//
+// The model label is the PROVIDER-SIDE id, which is not the label space
+// requestsTotal uses: that one carries the name the client asked for, so a model
+// reached through a failover group is counted there as "hotel/<group>" (and a
+// validation failure as "unresolved") while it appears here under its real id.
+// The two counters therefore do not join on model, which is worth knowing before
+// writing a PromQL query that expects them to.
+//
+// Counting VERDICTS rather than retirements is deliberate. A retirement is
+// visible in the model row and in the model.auto_disabled_gone event; what
+// neither records is the probe that did NOT retire anything — a "served" is the
+// classifier having nominated a live model, and a run of "inconclusive" is the
+// gateway paying for an answer it is not getting. Those two are the reason this
+// metric exists, and they leave no other trace than a log line.
+//
+// A refused verdict is not the same thing as a completed retirement: the write
+// that follows can still be superseded by a success, refused by the repository,
+// or reverted. Alert on the ratio between verdicts, not on refused as a
+// retirement count.
+func RecordRetirementProbe(provider, model, verdict string) {
+	retirementProbesTotal.WithLabelValues(labelOrUnknown(provider), labelOrUnknown(model), verdict).Inc()
 }
 
 // Handler returns the HTTP handler that serves the metrics in Prometheus text

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -132,12 +132,14 @@ func RecordResponsesReroute(provider, model, mode string) {
 // only a model drawing repeated gone-classified refusals is ever nominated. The
 // bound is the catalog, and in practice a small fraction of it.
 //
-// The model label is the PROVIDER-SIDE id, which is not the label space
-// requestsTotal uses: that one carries the name the client asked for, so a model
-// reached through a failover group is counted there as "hotel/<group>" (and a
-// validation failure as "unresolved") while it appears here under its real id.
-// The two counters therefore do not join on model, which is worth knowing before
-// writing a PromQL query that expects them to.
+// The model label is the PROVIDER-SIDE id, while requestsTotal carries the name
+// the CLIENT asked for. For direct "provider/model" traffic those are the same
+// string — resolution matched the model row on that exact id, and the request
+// log keeps the post-slash part — so the two counters join. They diverge on
+// exactly two shapes: a request routed through a failover group is "hotel/<group>"
+// on requestsTotal and the real id here, and a validation failure is collapsed
+// there to "unresolved". A PromQL join is therefore sound but silently
+// incomplete, missing precisely the group-routed traffic.
 //
 // Counting VERDICTS rather than retirements is deliberate. A retirement is
 // visible in the model row and in the model.auto_disabled_gone event; what

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -109,6 +109,34 @@ func TestRecordResponsesReroute(t *testing.T) {
 	}
 }
 
+// TestRecordRetirementProbe verifies the pre-retirement probe counter keeps the
+// three verdicts as separate series, which is the whole point of the metric: the
+// operator question is the RATIO between them, so a refused that could not be
+// told from a served would answer nothing.
+func TestRecordRetirementProbe(t *testing.T) {
+	const prov = "test-prov-retirement"
+	RecordRetirementProbe(prov, "gemini-2.0-flash", "refused")
+	RecordRetirementProbe(prov, "gemini-2.0-flash", "inconclusive")
+	RecordRetirementProbe(prov, "gemini-2.0-flash", "inconclusive")
+	RecordRetirementProbe(prov, "claude-sonnet-4", "served")
+	// An empty provider still has to produce a usable series rather than a
+	// blank label, exactly as the request counter does.
+	RecordRetirementProbe("", "orphan-model", "inconclusive")
+
+	out := scrape(t)
+	wantSubstrings := []string{
+		`modelhotel_retirement_probes_total{model="gemini-2.0-flash",provider="test-prov-retirement",verdict="refused"} 1`,
+		`modelhotel_retirement_probes_total{model="gemini-2.0-flash",provider="test-prov-retirement",verdict="inconclusive"} 2`,
+		`modelhotel_retirement_probes_total{model="claude-sonnet-4",provider="test-prov-retirement",verdict="served"} 1`,
+		`modelhotel_retirement_probes_total{model="orphan-model",provider="unknown",verdict="inconclusive"} 1`,
+	}
+	for _, w := range wantSubstrings {
+		if !strings.Contains(out, w) {
+			t.Errorf("scrape output missing %q", w)
+		}
+	}
+}
+
 func TestBreakerCollector(t *testing.T) {
 	RegisterBreakerCollector(func() []BreakerState {
 		return []BreakerState{

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,12 +1,33 @@
 package metrics
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 )
+
+// labelSeq numbers the label values below so each test invocation gets its own
+// series.
+//
+// The registry is process-wide and counters only accumulate, so every exact-count
+// assertion in this file is a claim about how many times its test has ever run.
+// With fixed labels `go test -count=2` failed all of them, which matters because
+// re-running under -count is how a flake is hunted here: the whole package looked
+// broken the moment anyone did it.
+//
+// A counter rather than a random suffix, because it keeps a failed assertion
+// readable and cannot collide. It is shared across tests, so the numbers a given
+// test sees are not contiguous; nothing depends on that.
+var labelSeq atomic.Uint64
+
+func uniqueLabel(prefix string) string {
+	return prefix + "-" + strconv.FormatUint(labelSeq.Add(1), 10)
+}
 
 func scrape(t *testing.T) string {
 	t.Helper()
@@ -36,10 +57,14 @@ func TestStatusClass(t *testing.T) {
 // (so the assertions are isolated from any other test's counters) and verifies
 // the exposition output parses and carries every expected series.
 func TestRecordEmitsMetrics(t *testing.T) {
-	const prov = "test-prov-emit"
+	prov := uniqueLabel("test-prov-emit")
+	// The model label has to be unique too: the failover counter is keyed by
+	// model alone, so a shared id would accumulate across runs even under a
+	// fresh provider.
+	mdl := uniqueLabel("llama-3")
 	Record(Observation{
 		Provider:         prov,
-		Model:            "llama-3",
+		Model:            mdl,
 		StatusCode:       200,
 		DurationSeconds:  0.5,
 		Streaming:        true,
@@ -52,13 +77,13 @@ func TestRecordEmitsMetrics(t *testing.T) {
 
 	out := scrape(t)
 	wantSubstrings := []string{
-		`modelhotel_requests_total{error_kind="",model="llama-3",provider="test-prov-emit",status_class="2xx"} 1`,
-		`modelhotel_request_duration_seconds_bucket{model="llama-3",provider="test-prov-emit",`,
-		`modelhotel_ttft_seconds_bucket{model="llama-3",provider="test-prov-emit",`,
-		`modelhotel_tokens_total{kind="completion",model="llama-3",provider="test-prov-emit"} 20`,
-		`modelhotel_tokens_total{kind="prompt",model="llama-3",provider="test-prov-emit"} 10`,
-		`modelhotel_tokens_total{kind="reasoning",model="llama-3",provider="test-prov-emit"} 5`,
-		`modelhotel_failover_attempts_total{model="llama-3"} 1`,
+		fmt.Sprintf(`modelhotel_requests_total{error_kind="",model=%q,provider=%q,status_class="2xx"} 1`, mdl, prov),
+		fmt.Sprintf(`modelhotel_request_duration_seconds_bucket{model=%q,provider=%q,`, mdl, prov),
+		fmt.Sprintf(`modelhotel_ttft_seconds_bucket{model=%q,provider=%q,`, mdl, prov),
+		fmt.Sprintf(`modelhotel_tokens_total{kind="completion",model=%q,provider=%q} 20`, mdl, prov),
+		fmt.Sprintf(`modelhotel_tokens_total{kind="prompt",model=%q,provider=%q} 10`, mdl, prov),
+		fmt.Sprintf(`modelhotel_tokens_total{kind="reasoning",model=%q,provider=%q} 5`, mdl, prov),
+		fmt.Sprintf(`modelhotel_failover_attempts_total{model=%q} 1`, mdl),
 		`go_goroutines`, // Go runtime collector is registered
 	}
 	for _, w := range wantSubstrings {
@@ -71,7 +96,7 @@ func TestRecordEmitsMetrics(t *testing.T) {
 // TestRecordSkipsZeroTokensAndNonStreamingTTFT verifies we don't emit token or
 // TTFT series for values that don't apply.
 func TestRecordSkipsZeroTokensAndNonStreamingTTFT(t *testing.T) {
-	const prov = "test-prov-skip"
+	prov := uniqueLabel("test-prov-skip")
 	Record(Observation{
 		Provider:        prov,
 		Model:           "m",
@@ -82,10 +107,10 @@ func TestRecordSkipsZeroTokensAndNonStreamingTTFT(t *testing.T) {
 		TTFTSeconds:     0.3, // ignored because not streaming
 	})
 	out := scrape(t)
-	if strings.Contains(out, `provider="test-prov-skip"`) && strings.Contains(out, `modelhotel_ttft_seconds_bucket{model="m",provider="test-prov-skip"`) {
+	if strings.Contains(out, fmt.Sprintf(`modelhotel_ttft_seconds_bucket{model="m",provider=%q`, prov)) {
 		t.Error("ttft must not be recorded for a non-streaming request")
 	}
-	if !strings.Contains(out, `modelhotel_requests_total{error_kind="provider_error",model="m",provider="test-prov-skip",status_class="5xx"} 1`) {
+	if !strings.Contains(out, fmt.Sprintf(`modelhotel_requests_total{error_kind="provider_error",model="m",provider=%q,status_class="5xx"} 1`, prov)) {
 		t.Errorf("missing 5xx provider_error series:\n%s", out)
 	}
 }
@@ -93,14 +118,14 @@ func TestRecordSkipsZeroTokensAndNonStreamingTTFT(t *testing.T) {
 // TestRecordResponsesReroute verifies the OpenAI Responses re-route counter
 // tracks learned and preemptive attempts as separate series.
 func TestRecordResponsesReroute(t *testing.T) {
-	const prov = "test-prov-responses"
+	prov := uniqueLabel("test-prov-responses")
 	RecordResponsesReroute(prov, "gpt-5.6-sol", "learned")
 	RecordResponsesReroute(prov, "gpt-5.6-sol", "preemptive")
 	RecordResponsesReroute(prov, "gpt-5.6-sol", "preemptive")
 	out := scrape(t)
 	wantSubstrings := []string{
-		`modelhotel_responses_reroute_total{mode="learned",model="gpt-5.6-sol",provider="test-prov-responses"} 1`,
-		`modelhotel_responses_reroute_total{mode="preemptive",model="gpt-5.6-sol",provider="test-prov-responses"} 2`,
+		fmt.Sprintf(`modelhotel_responses_reroute_total{mode="learned",model="gpt-5.6-sol",provider=%q} 1`, prov),
+		fmt.Sprintf(`modelhotel_responses_reroute_total{mode="preemptive",model="gpt-5.6-sol",provider=%q} 2`, prov),
 	}
 	for _, w := range wantSubstrings {
 		if !strings.Contains(out, w) {
@@ -114,21 +139,24 @@ func TestRecordResponsesReroute(t *testing.T) {
 // operator question is the RATIO between them, so a refused that could not be
 // told from a served would answer nothing.
 func TestRecordRetirementProbe(t *testing.T) {
-	const prov = "test-prov-retirement"
+	prov := uniqueLabel("test-prov-retirement")
 	RecordRetirementProbe(prov, "gemini-2.0-flash", "refused")
 	RecordRetirementProbe(prov, "gemini-2.0-flash", "inconclusive")
 	RecordRetirementProbe(prov, "gemini-2.0-flash", "inconclusive")
 	RecordRetirementProbe(prov, "claude-sonnet-4", "served")
 	// An empty provider still has to produce a usable series rather than a
-	// blank label, exactly as the request counter does.
-	RecordRetirementProbe("", "orphan-model", "inconclusive")
+	// blank label, exactly as the request counter does. The model carries the
+	// run's own suffix because the provider label — the usual isolator — is the
+	// very thing under test here.
+	orphan := uniqueLabel("orphan-model")
+	RecordRetirementProbe("", orphan, "inconclusive")
 
 	out := scrape(t)
 	wantSubstrings := []string{
-		`modelhotel_retirement_probes_total{model="gemini-2.0-flash",provider="test-prov-retirement",verdict="refused"} 1`,
-		`modelhotel_retirement_probes_total{model="gemini-2.0-flash",provider="test-prov-retirement",verdict="inconclusive"} 2`,
-		`modelhotel_retirement_probes_total{model="claude-sonnet-4",provider="test-prov-retirement",verdict="served"} 1`,
-		`modelhotel_retirement_probes_total{model="orphan-model",provider="unknown",verdict="inconclusive"} 1`,
+		fmt.Sprintf(`modelhotel_retirement_probes_total{model="gemini-2.0-flash",provider=%q,verdict="refused"} 1`, prov),
+		fmt.Sprintf(`modelhotel_retirement_probes_total{model="gemini-2.0-flash",provider=%q,verdict="inconclusive"} 2`, prov),
+		fmt.Sprintf(`modelhotel_retirement_probes_total{model="claude-sonnet-4",provider=%q,verdict="served"} 1`, prov),
+		fmt.Sprintf(`modelhotel_retirement_probes_total{model=%q,provider="unknown",verdict="inconclusive"} 1`, orphan),
 	}
 	for _, w := range wantSubstrings {
 		if !strings.Contains(out, w) {

--- a/internal/proxy/model_gone.go
+++ b/internal/proxy/model_gone.go
@@ -958,7 +958,9 @@ func (h *Handler) probeForRetirement(candidate modelCandidate, endpointType stri
 	// build, a missing transport, or the circuit opening in the window after
 	// noteModelGone's own check. Those are rarer than the network cases and
 	// indistinguishable from them here, which is why neither this metric nor the
-	// wiki describes inconclusive as a spend figure.
+	// wiki describes inconclusive as a spend figure. It is inexact in the other
+	// direction too: a panic inside probeModel is caught by the goroutine's
+	// recover, so a request that WAS sent can end up counted as nothing at all.
 	metrics.RecordRetirementProbe(candidate.provider.Name, candidate.model.ModelID, verdict.String())
 	return verdict
 }

--- a/internal/proxy/model_gone.go
+++ b/internal/proxy/model_gone.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 	"github.com/hugalafutro/model-hotel/internal/events"
 	"github.com/hugalafutro/model-hotel/internal/failover"
+	"github.com/hugalafutro/model-hotel/internal/metrics"
 	"github.com/hugalafutro/model-hotel/internal/model"
 )
 
@@ -934,7 +935,32 @@ func (h *Handler) probeForRetirement(candidate modelCandidate, endpointType stri
 
 	pctx, pcancel := context.WithTimeout(context.Background(), goneProbeTimeout)
 	defer pcancel()
-	return h.probeModel(pctx, candidate, endpointType)
+	verdict := h.probeModel(pctx, candidate, endpointType)
+
+	// The metric is recorded HERE rather than at probeModel's many exits or at
+	// the caller's switch, because this is the one function every production
+	// probe passes through exactly once and it holds the verdict whole. The
+	// switch in noteModelGone would need four call sites and would miss the
+	// default arm's meaning; probeModel would need one per early return.
+	//
+	// Above the nil guard there is deliberately nothing to count: that return
+	// has no provider or model to label, and it is defensive rather than
+	// reachable — noteModelGone checks both before spawning the goroutine.
+	//
+	// What is counted is one ADJUDICATION ATTEMPT: a nomination that got past
+	// every gate in noteModelGone and spent the model's five-minute claim. The
+	// postponements before that point — a busy semaphore, an open circuit, a
+	// cooldown still running — cost nothing and are deliberately not counted.
+	//
+	// Not the same as "an upstream request was sent", and the difference is the
+	// inconclusive bucket's. probeModel returns inconclusive from a few paths
+	// that bail before the request leaves the process: a request that would not
+	// build, a missing transport, or the circuit opening in the window after
+	// noteModelGone's own check. Those are rarer than the network cases and
+	// indistinguishable from them here, which is why neither this metric nor the
+	// wiki describes inconclusive as a spend figure.
+	metrics.RecordRetirementProbe(candidate.provider.Name, candidate.model.ModelID, verdict.String())
+	return verdict
 }
 
 // acquireProbeSlot takes one of the provider's goneProbeMaxConcurrent probe

--- a/internal/proxy/model_probe_test.go
+++ b/internal/proxy/model_probe_test.go
@@ -823,6 +823,22 @@ func TestProbeModel_DialectAnswerIsBounded(t *testing.T) {
 	}
 }
 
+// probeModelIDSeq numbers the model ids used in the metric assertions below, so
+// each invocation of a test gets series of its own on the process-wide registry.
+//
+// Deliberately NOT a uuid, and the reason is a production behaviour worth
+// knowing about: judgeProbeFailure classifies the body through
+// util.SanitizeLogBody, which redacts anything uuid-shaped. A uuid-suffixed
+// model id is therefore erased from the refusal that names it, the classifier
+// finds nothing to attribute the gone-phrase to, and a refused probe reads as
+// inconclusive. That is real behaviour for any provider whose model ids look
+// like uuids; here it would just make the test lie.
+var probeModelIDSeq atomic.Uint64
+
+func uniqueProbeModelID(prefix string) string {
+	return prefix + "-" + strconv.FormatUint(probeModelIDSeq.Add(1), 10)
+}
+
 // scrapeMetrics renders the process's Prometheus exposition through the real
 // handler, which is the only read path the metrics package offers and the same
 // one an operator's scrape takes.
@@ -847,40 +863,47 @@ func scrapeMetrics(t *testing.T) string {
 // through the real exposition handler rather than the counter variable, so the
 // series name and its labels are pinned as the public contract they are.
 //
-// The model ids are unique per case, which is what keeps the assertions exact
-// while the package's tests run in parallel against one process-wide registry.
+// The exact count of 1 is the assertion worth having — it is what would catch a
+// probe recorded twice — and holding it requires a model id that is unique per
+// INVOCATION, not merely per case. The registry is process-wide and counters
+// only ever accumulate, so a fixed id pins a value that is right on the first
+// run and wrong on every one after it: `go test -count=2` failed all three
+// subtests before probeModelIDSeq existed.
 func TestProbeForRetirement_RecordsItsVerdict(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name    string
-		modelID string
-		status  int
-		body    string
-		want    probeVerdict
+		name   string
+		status int
+		// Taken as a function because the refusal has to name the very model
+		// the probe asked for, and that id is not known until the subtest
+		// builds its own.
+		body func(modelID string) string
+		want probeVerdict
 	}{
 		{
-			name:    "refused",
-			modelID: "verdict-metric-refused-1",
-			status:  http.StatusNotFound,
-			body:    goneRefusalBody("verdict-metric-refused-1"),
-			want:    probeRefused,
+			name:   "refused",
+			status: http.StatusNotFound,
+			body:   goneRefusalBody,
+			want:   probeRefused,
 		},
 		{
-			name:    "served",
-			modelID: "verdict-metric-served-1",
-			status:  http.StatusOK,
-			body:    `{"choices":[{"message":{"role":"assistant","content":"Hi"}}]}`,
-			want:    probeServed,
+			name:   "served",
+			status: http.StatusOK,
+			body: func(string) string {
+				return `{"choices":[{"message":{"role":"assistant","content":"Hi"}}]}`
+			},
+			want: probeServed,
 		},
 		{
 			// A 500 is a provider fault rather than a statement about the
 			// model, so it establishes nothing and must be counted as such.
-			name:    "inconclusive",
-			modelID: "verdict-metric-inconclusive-1",
-			status:  http.StatusInternalServerError,
-			body:    `{"error":{"message":"internal error"}}`,
-			want:    probeInconclusive,
+			name:   "inconclusive",
+			status: http.StatusInternalServerError,
+			body: func(string) string {
+				return `{"error":{"message":"internal error"}}`
+			},
+			want: probeInconclusive,
 		},
 	}
 
@@ -888,9 +911,10 @@ func TestProbeForRetirement_RecordsItsVerdict(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			srv, _ := probeServer(t, tc.status, tc.body)
+			modelID := uniqueProbeModelID("verdict-metric-" + tc.name)
+			srv, _ := probeServer(t, tc.status, tc.body(modelID))
 			h := newProbeHandler(t)
-			candidate := probeCandidateFor(srv.URL, tc.modelID)
+			candidate := probeCandidateFor(srv.URL, modelID)
 
 			if got := h.probeForRetirement(candidate, endpointTypeChat); got != tc.want {
 				t.Fatalf("verdict = %s, want %s", got, tc.want)
@@ -898,7 +922,7 @@ func TestProbeForRetirement_RecordsItsVerdict(t *testing.T) {
 
 			want := fmt.Sprintf(
 				`modelhotel_retirement_probes_total{model=%q,provider="Probe Provider",verdict=%q} 1`,
-				tc.modelID, tc.want.String(),
+				modelID, tc.want.String(),
 			)
 			if out := scrapeMetrics(t); !strings.Contains(out, want) {
 				t.Errorf("metrics scrape missing %q", want)

--- a/internal/proxy/model_probe_test.go
+++ b/internal/proxy/model_probe_test.go
@@ -946,6 +946,13 @@ func TestProbeForRetirement_UnprobeableCandidateRecordsNothing(t *testing.T) {
 	// Scoped to this metric's own lines. Other counters run their empty labels
 	// through the same labelOrUnknown fallback, so an unqualified search for
 	// provider="unknown" would answer for the whole exposition.
+	//
+	// Still a claim about the whole PROCESS, not just this call: the registry is
+	// shared, so a future test that probes with a blank provider name would fail
+	// HERE rather than where it was written (and, being parallel, would do so
+	// only when it happened to record before this scrape). Nothing in the package
+	// does that today. If one ever needs to, give it its own registry rather than
+	// loosening this.
 	for _, line := range strings.Split(scrapeMetrics(t), "\n") {
 		if !strings.HasPrefix(line, "modelhotel_retirement_probes_total{") {
 			continue

--- a/internal/proxy/model_probe_test.go
+++ b/internal/proxy/model_probe_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/hugalafutro/model-hotel/internal/failover"
+	"github.com/hugalafutro/model-hotel/internal/metrics"
 	"github.com/hugalafutro/model-hotel/internal/model"
 	"github.com/hugalafutro/model-hotel/internal/paramrewrite"
 	"github.com/hugalafutro/model-hotel/internal/provider"
@@ -819,5 +820,114 @@ func TestProbeModel_DialectAnswerIsBounded(t *testing.T) {
 	}
 	if n := written.Load(); n >= flood {
 		t.Fatalf("the provider sent all %d bytes, so nothing bounded the read; the cap is %d", n, goneProbeMaxBody)
+	}
+}
+
+// scrapeMetrics renders the process's Prometheus exposition through the real
+// handler, which is the only read path the metrics package offers and the same
+// one an operator's scrape takes.
+func scrapeMetrics(t *testing.T) string {
+	t.Helper()
+	rr := httptest.NewRecorder()
+	metrics.Handler().ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/metrics", http.NoBody))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("metrics scrape returned status %d", rr.Code)
+	}
+	return rr.Body.String()
+}
+
+// TestProbeForRetirement_RecordsItsVerdict pins that a probe accounts for
+// itself. The counter is the only place an operator can see a probe that did
+// NOT retire anything: a served verdict means the classifier nominated a live
+// model, and neither that nor an inconclusive run leaves any trace but a log
+// line.
+//
+// It drives probeForRetirement rather than probeModel because that is where the
+// recording lives and where production enters, and it reads the count back
+// through the real exposition handler rather than the counter variable, so the
+// series name and its labels are pinned as the public contract they are.
+//
+// The model ids are unique per case, which is what keeps the assertions exact
+// while the package's tests run in parallel against one process-wide registry.
+func TestProbeForRetirement_RecordsItsVerdict(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		modelID string
+		status  int
+		body    string
+		want    probeVerdict
+	}{
+		{
+			name:    "refused",
+			modelID: "verdict-metric-refused-1",
+			status:  http.StatusNotFound,
+			body:    goneRefusalBody("verdict-metric-refused-1"),
+			want:    probeRefused,
+		},
+		{
+			name:    "served",
+			modelID: "verdict-metric-served-1",
+			status:  http.StatusOK,
+			body:    `{"choices":[{"message":{"role":"assistant","content":"Hi"}}]}`,
+			want:    probeServed,
+		},
+		{
+			// A 500 is a provider fault rather than a statement about the
+			// model, so it establishes nothing and must be counted as such.
+			name:    "inconclusive",
+			modelID: "verdict-metric-inconclusive-1",
+			status:  http.StatusInternalServerError,
+			body:    `{"error":{"message":"internal error"}}`,
+			want:    probeInconclusive,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv, _ := probeServer(t, tc.status, tc.body)
+			h := newProbeHandler(t)
+			candidate := probeCandidateFor(srv.URL, tc.modelID)
+
+			if got := h.probeForRetirement(candidate, endpointTypeChat); got != tc.want {
+				t.Fatalf("verdict = %s, want %s", got, tc.want)
+			}
+
+			want := fmt.Sprintf(
+				`modelhotel_retirement_probes_total{model=%q,provider="Probe Provider",verdict=%q} 1`,
+				tc.modelID, tc.want.String(),
+			)
+			if out := scrapeMetrics(t); !strings.Contains(out, want) {
+				t.Errorf("metrics scrape missing %q", want)
+			}
+		})
+	}
+}
+
+// TestProbeForRetirement_UnprobeableCandidateRecordsNothing guards the seam's
+// one deliberate omission: the nil-candidate return has no provider or model to
+// label, so it must not manufacture an "unknown" series. Every probe the
+// gateway actually spends a request on has both.
+func TestProbeForRetirement_UnprobeableCandidateRecordsNothing(t *testing.T) {
+	t.Parallel()
+
+	h := newProbeHandler(t)
+	if got := h.probeForRetirement(modelCandidate{}, endpointTypeChat); got != probeInconclusive {
+		t.Fatalf("verdict = %s, want inconclusive", got)
+	}
+
+	// Scoped to this metric's own lines. Other counters run their empty labels
+	// through the same labelOrUnknown fallback, so an unqualified search for
+	// provider="unknown" would answer for the whole exposition.
+	for _, line := range strings.Split(scrapeMetrics(t), "\n") {
+		if !strings.HasPrefix(line, "modelhotel_retirement_probes_total{") {
+			continue
+		}
+		if strings.Contains(line, `provider="unknown"`) || strings.Contains(line, `model="unknown"`) {
+			t.Errorf("a candidate with nothing to label recorded a series: %s", line)
+		}
 	}
 }

--- a/wiki/Model-Discovery.md
+++ b/wiki/Model-Discovery.md
@@ -1097,6 +1097,31 @@ Two consequences worth knowing about before you upgrade:
   that cannot be reached on the surface the probe asks, shows up as itself rather
   than as ordinary noise. Nothing is retired on the strength of it; the run ends
   as soon as the model answers.
+
+  Every finished probe is also counted, so the cost and the classifier's accuracy
+  can be watched without reading logs:
+
+  ```
+  modelhotel_retirement_probes_total{provider,model,verdict}
+  ```
+
+  `verdict` is `refused`, `served` or `inconclusive`. The interesting figure is
+  the ratio rather than any single series: a rising `served` count means the
+  classifier keeps nominating models that are alive, and a rising `inconclusive`
+  count means those nominations are not being settled, so the model keeps its
+  strikes and comes back every cooldown. Most inconclusive verdicts cost an
+  upstream request, but not all of them do (a request that cannot be built for
+  that provider, for instance, is counted without anything being sent), so read
+  the series as unanswered questions rather than as a spend figure.
+
+  Two things it does not say. `refused` counts verdicts, not completed
+  retirements: the write that follows can still be called off by a late success
+  or refused by the database, so count retirements with the
+  `model.auto_disabled_gone` event instead. And `model` here is the provider-side
+  model id, whereas `modelhotel_requests_total` carries the name the client
+  asked for, so a model routed through a failover group appears as
+  `hotel/<group>` in one and under its real id in the other. The two do not join
+  on `model`.
 - **Some endpoint families are never auto-retired from traffic.** Only chat,
   messages and embeddings models can be verified cheaply and safely. Image, TTS,
   STT and rerank models are never auto-retired at all, because a chat probe

--- a/wiki/Model-Discovery.md
+++ b/wiki/Model-Discovery.md
@@ -1118,10 +1118,12 @@ Two consequences worth knowing about before you upgrade:
   retirements: the write that follows can still be called off by a late success
   or refused by the database, so count retirements with the
   `model.auto_disabled_gone` event instead. And `model` here is the provider-side
-  model id, whereas `modelhotel_requests_total` carries the name the client
-  asked for, so a model routed through a failover group appears as
-  `hotel/<group>` in one and under its real id in the other. The two do not join
-  on `model`.
+  model id, whereas `modelhotel_requests_total` carries the name the client asked
+  for. For ordinary `provider/model` traffic those are the same string and the two
+  metrics join cleanly. They part company on requests routed through a failover
+  group, which `modelhotel_requests_total` labels `hotel/<group>` while this
+  counter uses the real model id, so a join covers direct traffic and silently
+  drops the group-routed kind.
 - **Some endpoint families are never auto-retired from traffic.** Only chat,
   messages and embeddings models can be verified cheaply and safely. Image, TTS,
   STT and rerank models are never auto-retired at all, because a chat probe

--- a/wiki/Model-Discovery.md
+++ b/wiki/Model-Discovery.md
@@ -1123,7 +1123,9 @@ Two consequences worth knowing about before you upgrade:
   metrics join cleanly. They part company on requests routed through a failover
   group, which `modelhotel_requests_total` labels `hotel/<group>` while this
   counter uses the real model id, so a join covers direct traffic and silently
-  drops the group-routed kind.
+  drops the group-routed kind. (Validation failures are labelled `unresolved`
+  there and are the other place the two label spaces differ, but they never
+  reached a provider, so there is no probe for them to have joined to.)
 - **Some endpoint families are never auto-retired from traffic.** Only chat,
   messages and embeddings models can be verified cheaply and safely. Image, TTS,
   STT and rerank models are never auto-retired at all, because a chat probe


### PR DESCRIPTION
Adds a Prometheus counter for the pre-retirement probe, closing the observability follow-up left open by #596.

```
modelhotel_retirement_probes_total{provider, model, verdict}
```

`verdict` is `refused` / `served` / `inconclusive`, taken from `probeVerdict.String()` so the label vocabulary cannot drift from the type.

## Why

A retirement already leaves three traces: the row, the `model.auto_disabled_gone` event, and a warning line. A probe that retires **nothing** left only a debug line, and those are the two cases worth watching:

- **`served`** means the classifier nominated a live model, which is the exact mistake the probe was added to catch. A rising count means the prose patterns are drifting.
- **`inconclusive`** means the nomination is never settled: the model keeps its strikes and comes back every cooldown.

## Where it records

One seam: `probeForRetirement`, the only function every production probe passes through exactly once, holding the verdict whole. It sits below the nil guard, so the defensive early return cannot manufacture an `unknown/unknown` series for a request that was never made.

## What it deliberately does not claim

Stated in the `Help` string, the function doc and the wiki:

- `refused` is **not** a retirement count. The write after it can still be called off by a late success, refused by the repository, or reverted. Count retirements with the `model.auto_disabled_gone` event.
- `inconclusive` is **not** a spend figure. A few paths return it before the request leaves the process, and a panic mid-probe records nothing at all.
- It joins `modelhotel_requests_total` on `model` for direct `provider/model` traffic, but not for `hotel/<group>` routing, where that counter labels the group instead of the model.

## Cardinality

Bounded by the catalog and in practice far below it: only a model drawing repeated gone-classified refusals is nominated, and a nomination is rate-limited to one probe per model per five minutes however hard a client retries.

## Testing

- New tests in both packages, reading the count back through the real exposition handler so the series name and labels are pinned as the public contract they are.
- Proved by mutation: deleting the record call, recording on the nil path, collapsing the verdict label, swapping the provider/model args and recording twice each fail the suite.
- Also made the metrics package's exposition assertions survive `go test -count=N` — they asserted exact counts against a process-wide registry, so two pre-existing tests already failed on master under `-count=2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)