### PR TITLE
fix(ci): unbreak the changed-surfaces gate for test-only PRs, and fix two flaky tests

### DIFF
--- a/.github/actions/changed-surfaces/action.yml
+++ b/.github/actions/changed-surfaces/action.yml
@@ -56,9 +56,16 @@ runs:
         BASE_REF: ${{ github.base_ref }}
         BEFORE_SHA: ${{ github.event.before }}
         HEAD_SHA: ${{ github.sha }}
-      # No `set -e`: every failure path is handled explicitly by run_everything,
-      # so this cannot die half-way and leave callers reading an empty (and
-      # therefore run-everything) output set by accident.
+      # `set -e` IS in effect and cannot be opted out of here: `shell: bash` runs
+      # this as `bash --noprofile --norc -e -o pipefail`, so -e arrives from the
+      # shell directive rather than from the script. The line below adds -u and
+      # is deliberately not `set +e` — failing on an unhandled error beats
+      # continuing with a half-built output set that callers would read as
+      # "nothing changed".
+      #
+      # What that costs: any command whose non-zero exit is EXPECTED has to say
+      # so. A bare `grep -v` that filters everything out exits 1 and killed this
+      # step for every test-only PR until it was guarded (see src= below).
       run: |
         set -uo pipefail
 
@@ -162,7 +169,20 @@ runs:
         # but the -q below can, so both use herestrings for the same reason as
         # match() above. An all-test-files diff filters to empty, which correctly
         # yields image=false.
-        src=$(grep -vE '(_test\.go|\.test\.tsx?|\.spec\.tsx?)$' <<< "$changed")
+        #
+        # The status has to be caught, and an unguarded assignment here made every
+        # test-only PR unmergeable: grep exits 1 when it prints nothing, `shell:
+        # bash` runs with -e (see the note above the run block), and the step died
+        # right after printing the changed files. Exit 1 is the expected
+        # all-tests-filtered case; anything higher is a real grep failure, where
+        # the honest answer is the same as any other undeterminable diff.
+        # ci.yml's publish-dev copy of this predicate already guards it with
+        # `|| true`; this is the same guard, told apart from a genuine error.
+        grep_status=0
+        src=$(grep -vE '(_test\.go|\.test\.tsx?|\.spec\.tsx?)$' <<< "$changed") || grep_status=$?
+        if [ "$grep_status" -gt 1 ]; then
+          run_everything "could not filter test files out of the diff"
+        fi
         if grep -qE '^(internal/|cmd/|web/|frontdesk/web/|Dockerfile|docker-entrypoint|\.dockerignore|go\.(mod|sum))' <<< "$src"; then
           image=true
         else

--- a/internal/proxy/models_test.go
+++ b/internal/proxy/models_test.go
@@ -2046,11 +2046,12 @@ func TestListModels_DisabledModelsFiltered(t *testing.T) {
 		t.Error("expected disabled-model to NOT be present")
 	}
 
-	// Verify it's the enabled model
-	m := data[0].(map[string]any)
-	if m["id"] != provider.NormalizeName(providerName)+"/enabled-model" {
-		t.Errorf("expected enabled-model, got %v", m["id"])
-	}
+	// Deliberately no assertion about data[0]. The listing is not scoped to this
+	// test's provider and the suite shares one Postgres, so which row lands first
+	// depends on what else has been inserted by the time this runs — the reason
+	// the count assertion above was already relaxed. The loop is the whole test:
+	// what filtering has to guarantee is that the enabled model is present and
+	// the disabled one is not, at any position.
 }
 
 // Test ListModels with failover groups

--- a/internal/proxy/safe_dialer_test.go
+++ b/internal/proxy/safe_dialer_test.go
@@ -467,49 +467,6 @@ func TestSafeDialer_DialByIPWithMockDNS(t *testing.T) {
 	}
 }
 
-// TestSafeDialer_DialByIPPublicHostWithDNS tests the dial-by-IP path with a real
-// public hostname. This test may be skipped if DNS resolution fails in the test environment.
-func TestSafeDialer_DialByIPPublicHostWithDNS(t *testing.T) {
-	t.Parallel()
-
-	// First check if DNS resolution works
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	ips, err := net.DefaultResolver.LookupIPAddr(ctx, "example.com")
-	if err != nil {
-		t.Fatalf("DNS resolution failed, skipping test: %v", err)
-	}
-
-	// Check if any resolved IP is non-blocked
-	hasNonBlocked := false
-	for _, ip := range ips {
-		if !isBlockedIP(ip.IP) {
-			hasNonBlocked = true
-			break
-		}
-	}
-	if !hasNonBlocked {
-		t.Fatal("all resolved IPs are blocked, skipping test")
-	}
-
-	// Now test the actual dial-by-IP path
-	sd := NewSafeDialer(nil, nil)
-	ctx2, cancel2 := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel2()
-
-	// Dial example.com - DNS should resolve to public IPs, then dial by IP
-	// The connection may fail (timeout, connection refused, etc.) but the
-	// dial-by-IP path should be exercised
-	_, err = sd.DialContext(ctx2, "tcp", "example.com:80")
-
-	// We don't care if the connection succeeds or fails
-	// We just care that it's NOT a blocked-IP error
-	if err != nil && strings.Contains(err.Error(), "refused connection to private/reserved IP") {
-		t.Errorf("public host should not be blocked, got: %v", err)
-	}
-}
-
 // TestNewSafeDialerWithResolver_UppercaseAllowedHosts covers lines 47-49
 // (strings.ToLower in the allowedHosts loop of newSafeDialerWithResolver).
 func TestNewSafeDialerWithResolver_UppercaseAllowedHosts(t *testing.T) {


### PR DESCRIPTION
Three fixes, and the first one is why the other two could not have merged on their own.

## 1. The changed-surfaces gate rejected any test-only PR

`Changed Surfaces` and `CodeQL Surfaces` are required checks, and **both failed on any diff that touched only test files** — so such a PR could never merge. This PR started as exactly that and went red.

One unguarded assignment in `.github/actions/changed-surfaces/action.yml`:

```bash
src=$(grep -vE '(_test\.go|\.test\.tsx?|\.spec\.tsx?)$' <<< "$changed")
```

`grep -v` exits 1 when it prints nothing, which is precisely what this filter does on an all-test diff, and the step runs under `set -e` — so it died right after printing the changed files, before computing a single surface.

The comment above the run block asserted the opposite (*"No `set -e`"*), and that is where the reasoning went wrong: `-e` is not set by the script, it arrives from `shell: bash`, which GitHub expands to `bash --noprofile --norc -e -o pipefail`. The job log confirms it. The same predicate in `ci.yml`'s publish-dev job already carries `|| true`, so the hazard was known in one copy and not the other.

Guarded rather than copied, so a real grep failure stays distinct from an empty result: exit 1 means every path was a test file (`src` empty, `image=false`, what the existing comment always intended), anything higher falls through to `run_everything`.

Verified under the real flags: the old line exits 1 on a two-test-file diff, the new one reaches the end with `image=false`, and a mixed diff still yields `image=true`.

## 2. `TestListModels_DisabledModelsFiltered`

Asserted that `data[0]` was its own enabled model. The listing is not scoped to this test's provider and the suite shares one Postgres, so first place belongs to whichever provider another test inserted most recently. The test had already conceded this one assertion earlier — the count check above it carries the comment *"exact count is fragile in parallel test suite"* — then reintroduced the assumption positionally.

Reproducible on master:

```
go test ./internal/proxy/ -count=2 -shuffle=1   # and 2, and 3
--- FAIL: TestListModels_DisabledModelsFiltered
    models_test.go:2052: expected enabled-model, got allowed-prov-f39fe30d/ap-model-b17fe086
```

The presence/absence loop above it is the whole test and is untouched.

## 3. `TestSafeDialer_DialByIPPublicHostWithDNS`

Resolved `example.com` over real DNS and `t.Fatalf`'d when the lookup timed out, which it does under parallel load. Its own comment says the test *"may be skipped"* on DNS failure, but skipping is banned here (#526), so it failed instead.

Deleted rather than repaired: `TestSafeDialer_DialByIPWithMockDNS` twenty lines above already drives the same resolve → check → dial-by-IP path to the same assertion through the injected resolver seam. `NewSafeDialer` stays covered by a dozen other tests.

## After

`go test ./internal/proxy/ -count=2 -shuffle=on` passes three runs in a row, 2502 tests each. Full backend suite green (6481).

🤖 Generated with [Claude Code](https://claude.com/claude-code)