### PR TITLE
fix(proxy): stop punctuation and vendor prefixes reading as rival model ids

### DIFF
--- a/internal/proxy/upstream_classify.go
+++ b/internal/proxy/upstream_classify.go
@@ -232,22 +232,39 @@ func isClauseBreak(b byte) bool {
 // looksLikeAModelID reports whether s contains a token shaped like a model id.
 // Digits and hyphens are the tell: "gpt-4", "retired-model" and "llama3" all
 // qualify, while ordinary words and vendor prefixes like "openai/" do not.
+//
+// A token also has to carry a letter or a digit, which is what stops PUNCTUATION
+// being read as an identifier. Without it a lone "-" qualified on the dash
+// alone, so the dash in "unknown model - gpt-4o-mini" counted as a competing id
+// sitting between the phrase and its subject, gapBindsPhrase refused to bind,
+// and a plainly-worded refusal never classified. Providers punctuate that way
+// (an em-dash, a bulleted list, an arrow), and each spelling silently switched
+// retirement off for that provider.
+//
+// The direction matters: this makes fewer gaps look like they hold a competing
+// id, so it can only make MORE bodies classify as gone. It is kept to the one
+// case that cannot be an identifier under any reading — a run with no
+// alphanumeric character in it at all. A gap holding a real second id still has
+// letters or digits in it and still blocks attribution, which is the whole job
+// of this check.
 func looksLikeAModelID(s string) bool {
-	tokenHasDigit, tokenHasDash := false, false
+	tokenHasDigit, tokenHasDash, tokenHasAlnum := false, false, false
 	for i := 0; i <= len(s); i++ {
 		if i < len(s) && (isModelIDChar(s[i]) || s[i] == '/') {
 			switch {
 			case s[i] >= '0' && s[i] <= '9':
-				tokenHasDigit = true
+				tokenHasDigit, tokenHasAlnum = true, true
 			case s[i] == '-':
 				tokenHasDash = true
+			case s[i] >= 'a' && s[i] <= 'z', s[i] >= 'A' && s[i] <= 'Z':
+				tokenHasAlnum = true
 			}
 			continue
 		}
-		if tokenHasDigit || tokenHasDash {
+		if tokenHasAlnum && (tokenHasDigit || tokenHasDash) {
 			return true
 		}
-		tokenHasDigit, tokenHasDash = false, false
+		tokenHasDigit, tokenHasDash, tokenHasAlnum = false, false, false
 	}
 	return false
 }

--- a/internal/proxy/upstream_classify.go
+++ b/internal/proxy/upstream_classify.go
@@ -230,8 +230,9 @@ func isClauseBreak(b byte) bool {
 }
 
 // looksLikeAModelID reports whether s contains a token shaped like a model id.
-// Digits and hyphens are the tell: "gpt-4", "retired-model" and "llama3" all
-// qualify, while ordinary words and vendor prefixes like "openai/" do not.
+// A digit is the tell on its own; a hyphen is one only alongside a letter. So
+// "gpt-4", "llama3" and "retired-model" all qualify, while ordinary words and
+// vendor prefixes like "openai/" do not.
 //
 // A token also has to carry a letter or a digit, which is what stops PUNCTUATION
 // being read as an identifier. Without it a lone "-" qualified on the dash
@@ -290,6 +291,30 @@ func gapBindsPhrase(gap string) bool {
 	return !looksLikeAModelID(gap)
 }
 
+// isVendorSegmentChar reports whether b can appear in a vendor namespace.
+//
+// Deliberately NARROWER than isModelIDChar. The walk in vendorPrefixStart
+// removes text from the gap gapBindsPhrase inspects, so every character it is
+// willing to cross is a character that can hide a clause break or a competing
+// id. isModelIDChar also admits '.', ':' and '@', which is how a model names a
+// tag or a snapshot ("llama3:8b") but never how a registry names a publisher:
+// every slashed id in the catalogue has a vendor segment inside [A-Za-z0-9_-].
+//
+// '.' is the one that must not be crossed, because it is also an isClauseBreak
+// character. Crossing it would let the walk step over a clause boundary and hand
+// gapBindsPhrase a gap the boundary had already been removed from — silently
+// undoing the rule it exists to enforce.
+func isVendorSegmentChar(b byte) bool {
+	switch {
+	case b >= 'a' && b <= 'z', b >= 'A' && b <= 'Z', b >= '0' && b <= '9':
+		return true
+	case b == '-', b == '_':
+		return true
+	default:
+		return false
+	}
+}
+
 // vendorPrefixStart walks back from an id occurrence over the vendor prefix
 // attached to it, returning where the whole identifier starts.
 //
@@ -299,6 +324,12 @@ func gapBindsPhrase(gap string) bool {
 // is the shape registries use, and walking further would swallow a preceding
 // word that merely ended in a slash.
 //
+// The walk is bounded twice over, because both bounds protect the same thing:
+// what it crosses, it deletes from the gap. One segment, and only characters a
+// publisher name can contain (see isVendorSegmentChar) — so a rival id butted
+// against the vendor by a period or a colon stays in the gap and still blocks,
+// exactly as it does when a space separates them.
+//
 // It returns pos unchanged when there is no prefix, so callers can use it
 // unconditionally.
 func vendorPrefixStart(body string, pos int) int {
@@ -306,7 +337,7 @@ func vendorPrefixStart(body string, pos int) int {
 		return pos
 	}
 	start := pos - 1
-	for start > 0 && isModelIDChar(body[start-1]) {
+	for start > 0 && isVendorSegmentChar(body[start-1]) {
 		start--
 	}
 	// A slash with nothing identifier-shaped in front of it is punctuation

--- a/internal/proxy/upstream_classify.go
+++ b/internal/proxy/upstream_classify.go
@@ -290,6 +290,33 @@ func gapBindsPhrase(gap string) bool {
 	return !looksLikeAModelID(gap)
 }
 
+// vendorPrefixStart walks back from an id occurrence over the vendor prefix
+// attached to it, returning where the whole identifier starts.
+//
+// "openai/gpt-4o" is one identifier, and the search term is only ever its tail
+// (see normalizeModelID), so every caller matching inside the body has to be
+// able to find the head again. Only ONE prefix segment is taken: publisher/model
+// is the shape registries use, and walking further would swallow a preceding
+// word that merely ended in a slash.
+//
+// It returns pos unchanged when there is no prefix, so callers can use it
+// unconditionally.
+func vendorPrefixStart(body string, pos int) int {
+	if pos == 0 || body[pos-1] != '/' {
+		return pos
+	}
+	start := pos - 1
+	for start > 0 && isModelIDChar(body[start-1]) {
+		start--
+	}
+	// A slash with nothing identifier-shaped in front of it is punctuation
+	// ("try: /models"), not a vendor prefix.
+	if start == pos-1 {
+		return pos
+	}
+	return start
+}
+
 // phraseIsAbout reports whether the phrase occupying [verbPos, verbEnd) is the
 // provider talking about id, searching the surrounding window for an occurrence
 // bound tightly enough to be its subject or object.
@@ -311,12 +338,25 @@ func phraseIsAbout(body string, verbPos, verbEnd, lo, hi int, id string) bool {
 		// is the same claim as an error.message saying so — and reading only one
 		// of the two would leave the other silently unhandled.
 		if occEnd, ok := idEndAllowingVersion(body, pos, pos+len(id)); ok {
+			// The vendor prefix in front of the occurrence belongs to THIS id,
+			// so the gap has to start before it. modelGoneAbout searches for the
+			// normalized id, which is the part after the last slash, while the
+			// body carries the id whole — so "model not found: ai21/jamba-1.7"
+			// matched at "jamba-1.7" and left "ai21/" sitting in the gap, where
+			// looksLikeAModelID read it as a RIVAL id and refused to bind.
+			//
+			// It only bit prefixes carrying a digit or a hyphen, which is why it
+			// looked arbitrary: openai/ and google/ classified while ai21/,
+			// meta-llama/, LLM360/ and aion-labs/ did not. Measured against the
+			// dev catalogue, 125 of 1141 model ids could not be retired by either
+			// phrase-first refusal shape.
+			idStart := vendorPrefixStart(body, pos)
 			var gap string
 			switch {
 			case occEnd <= verbPos:
 				gap = body[occEnd:verbPos]
-			case pos >= verbEnd:
-				gap = body[verbEnd:pos]
+			case idStart >= verbEnd:
+				gap = body[verbEnd:idStart]
 			default:
 				// Overlapping the phrase itself; treat as bound.
 				return true

--- a/internal/proxy/upstream_classify_test.go
+++ b/internal/proxy/upstream_classify_test.go
@@ -1080,3 +1080,100 @@ func TestClassifyUpstreamError_ModelNamedAfterThePhrase(t *testing.T) {
 		})
 	}
 }
+
+// TestClassifyUpstreamError_PunctuationDoesNotBlockAttribution pins the fix for
+// a false negative that switched retirement off for whole providers.
+//
+// gapBindsPhrase refuses to bind when a COMPETING model id sits between the
+// phrase and its subject, and looksLikeAModelID took a bare "-" for one, on the
+// strength of the hyphen alone. So every provider that punctuates a refusal
+// ("unknown model - gpt-4o-mini", an arrow, an em dash, a bullet) had that
+// refusal read as provider_error. It failed safe, which is why it went unnoticed:
+// nothing was retired, the strikes simply never accumulated.
+//
+// The guard cases are the other half and matter more than the fix, because the
+// change can only make MORE bodies classify as gone: a gap holding a real second
+// id must still block, in both word orders.
+func TestClassifyUpstreamError_PunctuationDoesNotBlockAttribution(t *testing.T) {
+	t.Parallel()
+
+	const modelID = "gpt-4o-mini"
+
+	cases := []struct {
+		name string
+		body string
+		want ErrorKind
+	}{
+		{
+			name: "hyphen between phrase and id",
+			body: `{"error":{"message":"unknown model - gpt-4o-mini"}}`,
+			want: KindProviderModelGone,
+		},
+		{
+			name: "arrow between phrase and id",
+			body: `{"error":{"message":"model not found -> gpt-4o-mini"}}`,
+			want: KindProviderModelGone,
+		},
+		{
+			name: "em dash between phrase and id",
+			body: `{"error":{"message":"unknown model — gpt-4o-mini"}}`,
+			want: KindProviderModelGone,
+		},
+		{
+			name: "id before the phrase, hyphen after it",
+			body: `{"error":{"message":"gpt-4o-mini - does not exist"}}`,
+			want: KindProviderModelGone,
+		},
+		{
+			// The guard: a real id in the gap is still a competing subject, and
+			// binding here would retire the model named in the OTHER clause.
+			name: "competing id in the gap still blocks, id last",
+			body: `{"error":{"message":"does not exist for other-model-7 gpt-4o-mini"}}`,
+			want: KindProviderError,
+		},
+		{
+			name: "competing id in the gap still blocks, id first",
+			body: `{"error":{"message":"healthy-model was routed but retired-x9 does not exist"}}`,
+			want: KindProviderError,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got, _ := classifyUpstreamError(404, tc.body, modelID); got != tc.want {
+				t.Errorf("classify(%s) = %s, want %s", tc.body, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestLooksLikeAModelID_RequiresAnAlphanumeric pins the rule directly, because
+// the classifier cases above can only reach it through a gap and would not
+// distinguish "punctuation is not an id" from "the gap was short enough".
+func TestLooksLikeAModelID_RequiresAnAlphanumeric(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]bool{
+		// Punctuation alone is never an identifier, whatever it is made of.
+		" - ":  false,
+		" -- ": false,
+		" -> ": false,
+		"-":    false,
+		" ":    false,
+		"":     false,
+		// The tell still has to be there: a plain word is not an id.
+		" model ": false,
+		// Unchanged: a letter or digit plus the digit-or-dash tell.
+		"gpt-4":         true,
+		"llama3":        true,
+		"retired-model": true,
+		" 4 ":           true,
+	}
+
+	for in, want := range cases {
+		if got := looksLikeAModelID(in); got != want {
+			t.Errorf("looksLikeAModelID(%q) = %v, want %v", in, got, want)
+		}
+	}
+}

--- a/internal/proxy/upstream_classify_test.go
+++ b/internal/proxy/upstream_classify_test.go
@@ -1177,3 +1177,113 @@ func TestLooksLikeAModelID_RequiresAnAlphanumeric(t *testing.T) {
 		}
 	}
 }
+
+// TestClassifyUpstreamError_VendorPrefixIsNotARivalID pins the fix for a false
+// negative that hid behind the vendor prefix.
+//
+// modelGoneAbout searches for the NORMALIZED id — the part after the last slash
+// — while the body carries the id whole. So "model not found: ai21/jamba-1.7"
+// matched at "jamba-1.7" and left "ai21/" sitting in the gap between the phrase
+// and its subject, where looksLikeAModelID read it as a rival id and refused to
+// bind.
+//
+// It only bit prefixes carrying a digit or a hyphen, which is what made it look
+// arbitrary rather than systematic: openai/ and google/ classified, ai21/,
+// meta-llama/, LLM360/ and aion-labs/ did not. Swept against the dev catalogue,
+// 125 of 1141 real model ids could not be retired by either phrase-first refusal
+// shape, and nothing complained because the failure is silent: no attribution,
+// no strike, no retirement.
+func TestClassifyUpstreamError_VendorPrefixIsNotARivalID(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		modelID string
+		body    string
+		want    ErrorKind
+	}{
+		{
+			name:    "digit in the vendor prefix",
+			modelID: "ai21/jamba-large-1.7",
+			body:    `{"error":{"message":"model not found: ai21/jamba-large-1.7"}}`,
+			want:    KindProviderModelGone,
+		},
+		{
+			name:    "hyphen in the vendor prefix",
+			modelID: "meta-llama/llama-3-8b",
+			body:    `{"error":{"message":"unknown model - meta-llama/llama-3-8b"}}`,
+			want:    KindProviderModelGone,
+		},
+		{
+			name:    "uppercase and digits in the vendor prefix",
+			modelID: "LLM360/K2-Think",
+			body:    `{"error":{"message":"model not found: LLM360/K2-Think"}}`,
+			want:    KindProviderModelGone,
+		},
+		{
+			// The control: this shape always worked, because "openai" carries
+			// neither of the tells looksLikeAModelID looks for.
+			name:    "plain vendor prefix still classifies",
+			modelID: "openai/gpt-4o",
+			body:    `{"error":{"message":"model not found: openai/gpt-4o"}}`,
+			want:    KindProviderModelGone,
+		},
+		{
+			// The guard that matters: only the prefix ATTACHED to this id is
+			// absorbed. A genuine second id in the gap is still a rival subject.
+			name:    "rival id before the vendor prefix still blocks",
+			modelID: "ai21/jamba-large-1.7",
+			body:    `{"error":{"message":"model not found for other-model-3 ai21/jamba-large-1.7"}}`,
+			want:    KindProviderError,
+		},
+		{
+			// A different vendor's model being retired says nothing about ours.
+			name:    "another vendor's model is not ours",
+			modelID: "ai21/jamba-large-1.7",
+			body:    `{"error":{"message":"model not found: other-vendor/some-model-9"}}`,
+			want:    KindProviderError,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got, _ := classifyUpstreamError(404, tc.body, tc.modelID); got != tc.want {
+				t.Errorf("classify(%s) for %s = %s, want %s", tc.body, tc.modelID, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestVendorPrefixStart pins the walk directly, including the two ways it must
+// decline: no slash at all, and a slash that is punctuation rather than the end
+// of a vendor segment.
+func TestVendorPrefixStart(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		body string
+		pos  int
+		want int
+	}{
+		{name: "no prefix", body: "gpt-4o", pos: 0, want: 0},
+		{name: "vendor prefix absorbed", body: "ai21/jamba", pos: 5, want: 0},
+		{name: "prefix mid-body", body: "x: ai21/jamba", pos: 8, want: 3},
+		// Only one segment: a preceding word that happens to end in a slash is
+		// not part of the identifier.
+		{name: "one segment only", body: "see docs/ai21/jamba", pos: 14, want: 9},
+		// A bare slash is punctuation, not a vendor.
+		{name: "bare slash is punctuation", body: "try /jamba", pos: 5, want: 5},
+		{name: "slash at body start", body: "/jamba", pos: 1, want: 1},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := vendorPrefixStart(tc.body, tc.pos); got != tc.want {
+				t.Errorf("vendorPrefixStart(%q, %d) = %d, want %d", tc.body, tc.pos, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/proxy/upstream_classify_test.go
+++ b/internal/proxy/upstream_classify_test.go
@@ -1237,11 +1237,52 @@ func TestClassifyUpstreamError_VendorPrefixIsNotARivalID(t *testing.T) {
 			want:    KindProviderError,
 		},
 		{
-			// A different vendor's model being retired says nothing about ours.
-			name:    "another vendor's model is not ours",
+			// The same guard, with the rival butted against the vendor instead
+			// of spaced off it. The walk crosses characters, and every character
+			// it crosses is one gapBindsPhrase never gets to see — so it may not
+			// cross a period, which is a CLAUSE BREAK. Absorbing this whole run
+			// as "the vendor" would delete both the boundary and the rival id
+			// from the gap and bind to the wrong subject.
+			name:    "rival joined to the vendor by a period still blocks",
+			modelID: "ai21/jamba-large-1.7",
+			body:    `{"error":{"message":"model not found for other-model-3.ai21/jamba-large-1.7"}}`,
+			want:    KindProviderError,
+		},
+		{
+			// Same, for a separator that is not a clause break. A colon belongs
+			// to a model TAG ("llama3:8b"), never to a publisher, so the walk
+			// stops there too and the rival stays in the gap.
+			name:    "rival joined to the vendor by a colon still blocks",
+			modelID: "ai21/jamba-large-1.7",
+			body:    `{"error":{"message":"model not found for other-model-3:ai21/jamba-large-1.7"}}`,
+			want:    KindProviderError,
+		},
+		{
+			// A model id absent from the body cannot be attributed at all: the
+			// occurrence search fails before any gap is measured. Kept as the
+			// floor, NOT as evidence about vendors — the case that actually
+			// exercises the vendor comparison is the one below it.
+			name:    "a model we did not ask for is not ours",
 			modelID: "ai21/jamba-large-1.7",
 			body:    `{"error":{"message":"model not found: other-vendor/some-model-9"}}`,
 			want:    KindProviderError,
+		},
+		{
+			// ACCEPTED, and pinned here so that changing it has to be deliberate:
+			// normalizeModelID reduces the request to its tail, so a refusal
+			// naming a DIFFERENT vendor's copy of the same model classifies as
+			// ours. Providers echo the bare name as readily as the prefixed one,
+			// and this needs a provider to name a model the caller never asked
+			// for. It is not new here — "azure/gpt-4o" already bound for a
+			// request for "openai/gpt-4o", because a vendor with no digit and no
+			// hyphen never looked like a rival id. Absorbing the prefix only
+			// removes the accident that made ai21/ and meta-llama/ behave
+			// differently from openai/. A classification still only nominates:
+			// the probe that follows asks the live model.
+			name:    "another vendor's copy of the same model still classifies",
+			modelID: "ai21/jamba-large-1.7",
+			body:    `{"error":{"message":"model not found: other-vendor/jamba-large-1.7"}}`,
+			want:    KindProviderModelGone,
 		},
 	}
 
@@ -1268,6 +1309,7 @@ func TestVendorPrefixStart(t *testing.T) {
 		want int
 	}{
 		{name: "no prefix", body: "gpt-4o", pos: 0, want: 0},
+		{name: "no slash before the match", body: "gpt-4o", pos: 4, want: 4},
 		{name: "vendor prefix absorbed", body: "ai21/jamba", pos: 5, want: 0},
 		{name: "prefix mid-body", body: "x: ai21/jamba", pos: 8, want: 3},
 		// Only one segment: a preceding word that happens to end in a slash is
@@ -1276,6 +1318,16 @@ func TestVendorPrefixStart(t *testing.T) {
 		// A bare slash is punctuation, not a vendor.
 		{name: "bare slash is punctuation", body: "try /jamba", pos: 5, want: 5},
 		{name: "slash at body start", body: "/jamba", pos: 1, want: 1},
+		// The walk stops at anything a publisher name cannot contain, so a
+		// preceding id butted straight against the vendor is not swallowed.
+		// A period matters most: it is a clause break, and crossing it would
+		// hide the boundary from gapBindsPhrase.
+		{name: "period stops the walk", body: "other-model-3.ai21/jamba", pos: 19, want: 14},
+		{name: "colon stops the walk", body: "x:ai21/jamba", pos: 7, want: 2},
+		{name: "at-sign stops the walk", body: "x@ai21/jamba", pos: 7, want: 2},
+		// An underscore IS a publisher character, so it is crossed: registries
+		// name organisations that way and there is no id boundary there.
+		{name: "underscore is part of the vendor", body: "meta_llama/x", pos: 11, want: 0},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Two false negatives in the same rule, the second measured against the real catalogue: **125 of the 1141 model ids in the dev database could not be retired at all** by the two most common refusal shapes.

## The rule they both broke

`gapBindsPhrase` refuses to bind a retirement phrase to a model id when a **competing** id sits between them. That rule earns its keep — it is what stops `healthy-model was routed, but retired-model does not exist` from retiring the healthy one. Both bugs are things that are not rival ids being counted as rival ids.

## 1. A bare hyphen

`looksLikeAModelID` accepted `-` as an identifier on the strength of the hyphen alone, so the punctuation separating a phrase from its own subject was read as a rival subject standing between them. `unknown model - gpt-4o-mini` came back `provider_error`, as did an arrow, an em dash, or a bullet.

A token now has to carry a letter or a digit too. The digit-or-dash tell is untouched, so `gpt-4`, `llama3` and `retired-model` read exactly as before.

## 2. A vendor prefix

`modelGoneAbout` searches for the **normalized** id (the part after the last slash) while the body carries the id whole. So `model not found: ai21/jamba-large-1.7` matched at `jamba-large-1.7` and left `ai21/` in the gap — where it read as a rival id.

The prefix in front of an occurrence *is* that occurrence, so the gap has to start before it. `vendorPrefixStart` takes exactly one segment: `publisher/model` is the shape registries use, and a slash with nothing identifier-shaped before it is punctuation (`try: /models`), which is left alone.

**Why it looked arbitrary rather than systematic:** only prefixes carrying a digit or a hyphen tripped it. `openai/` and `google/` classified fine while `ai21/`, `meta-llama/`, `LLM360/` and `aion-labs/` did not, so any spot check on the usual suspects came back clean.

## Measurement

Every model id in the dev catalogue through seven real refusal shapes, plus three that must **not** classify:

| | before | after |
|---|---|---|
| false negatives (should retire, did not) | **250** of 7,987 | **0** |
| false positives (must not retire, did) | 0 of 3,423 | **0** |

Both failures were silent by construction: no attribution means no strike, no probe, no retirement, and nothing in the logs to say a refusal was ignored.

## The direction worth reviewing

Both changes make *fewer* things look like rival ids, so both can only make **more** bodies classify as gone — the direction that retires things. The guards are half the new cases:

| body | requested | verdict |
|---|---|---|
| `model not found for other-model-3 ai21/jamba-large-1.7` | `ai21/jamba-large-1.7` | `provider_error` (rival blocks) |
| `model not found: other-vendor/some-model-9` | `ai21/jamba-large-1.7` | `provider_error` (not ours) |
| `healthy-model was routed but retired-x9 does not exist` | `gpt-4o-mini` | `provider_error` (rival blocks) |

It also stays safe for the reason the feature is safe: a classification only **nominates**, and a live model answers the probe that follows.

## Testing

Five mutations, each caught, by four different tests:

- revert the alphanumeric requirement → new punctuation cases fail
- drop the digit-or-dash tell → new cases fail **plus** two existing attribution tests
- measure the gap from the match instead of the prefix → vendor-prefix cases fail
- absorb every segment instead of one → `vendorPrefixStart` cases fail
- absorb without requiring a slash → punctuation cases fail

Full backend suite green.

## Not changed

Because normalization drops the vendor, a refusal naming `vendorB/shared-model` matches a request for `vendorA/shared-model`. That is deliberate — providers echo the bare name as readily as the prefixed one — and it needs a provider to name a model the caller never asked for. Flagged rather than fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review follow-up (dd96834)

`vendorPrefixStart` was bounded once, by segment, and that was one bound short. It walked back over `isModelIDChar`, which also admits `.`, `:` and `@` — characters a model *tag* carries (`llama3:8b`) but a publisher name never does. So a rival id butted straight against the vendor was absorbed as part of it, and only the separator decided whether the guard held:

| body (requested `ai21/jamba-large-1.7`) | before | after |
|---|---|---|
| `model not found for other-model-3 ai21/jamba-large-1.7` | `provider_error` | `provider_error` |
| `model not found for other-model-3.ai21/jamba-large-1.7` | `provider_model_gone` | `provider_error` |
| `model not found for other-model-3:ai21/jamba-large-1.7` | `provider_model_gone` | `provider_error` |

The period is the one that had to stop it, because it is also an `isClauseBreak` character. What the walk crosses, it deletes from the gap `gapBindsPhrase` inspects — so crossing a period stepped over a clause boundary and then handed the gap check a gap that boundary had already been removed from, undoing the rule `gapBindsPhrase` exists to enforce, in the direction that retires things.

`isVendorSegmentChar` is deliberately narrower than `isModelIDChar`: `[A-Za-z0-9_-]`, what a registry allows in an organisation name. Every slashed id in the dev catalogue sits inside that set (**0 of 659** outside it), so no real prefix loses its head. `_` stays, because it is a genuine publisher character and there is no id boundary there to protect.

**The cross-vendor case is now pinned rather than described.** `model not found: other-vendor/jamba-large-1.7` still classifies a request for `ai21/jamba-large-1.7` as gone — deliberate, and not new: `azure/gpt-4o` already bound for a request for `openai/gpt-4o`, because a vendor carrying neither a digit nor a hyphen never looked like a rival id. Absorbing the prefix only removed the accident that made `ai21/` behave differently from `openai/`. The old `other-vendor/some-model-9` case is relabelled: that id is absent from the body, so the occurrence search fails before any gap is measured, and it was reading as evidence about vendors while pinning nothing.

Two more mutations, each caught: walking with `isModelIDChar` fails the three separator cases in `TestVendorPrefixStart` plus both new classifier guards; dropping `_` from `isVendorSegmentChar` fails the underscore case. Diff coverage 41/41 lines.
