### PR TITLE
fix(a11y): make a toast a message again, not one big button

### DIFF
--- a/web/src/components/__tests__/CopyablePill.test.tsx
+++ b/web/src/components/__tests__/CopyablePill.test.tsx
@@ -3,7 +3,13 @@ import { renderWithProviders } from "../../test/utils";
 import { CopyablePill } from "../CopyablePill";
 
 // Stub Lucide icons
-vi.mock("@/lib/icons", () => ({
+// Partial mock, spreading the real barrel. A bare object mock breaks any
+// component this test happens to render that reaches for a different icon —
+// the toast this file asserts on draws its own dismiss and copy controls, and a
+// missing export there throws out of React's render rather than failing an
+// assertion, which reads as an unrelated crash.
+vi.mock("@/lib/icons", async (importOriginal) => ({
+	...(await importOriginal<typeof import("@/lib/icons")>()),
 	Briefcase: ({ className }: { className?: string }) => (
 		<svg className={className} data-testid="stub-icon" />
 	),

--- a/web/src/context/ToastContext.tsx
+++ b/web/src/context/ToastContext.tsx
@@ -239,16 +239,57 @@ function ToastItem({
 		return () => clearTimeout(timerRef.current);
 	}, [timeout, startTimer]);
 
-	const handleMouseEnter = () => {
+	// Two independent things hold the clock: the pointer being over the toast,
+	// and focus being inside it. They overlap constantly — clicking Copy with a
+	// mouse both hovers and focuses — so the pause is refcounted rather than a
+	// single flag, and the arithmetic runs only on the transitions.
+	//
+	// Pausing has to be idempotent because startTimeRef is only reset when the
+	// timer restarts: subtracting the elapsed span a second time would zero the
+	// remaining time, and the toast would vanish the moment the pointer left
+	// with seconds still on the clock. Resuming has to check the other holder,
+	// or un-hovering would restart the clock under a keyboard user still
+	// focused on Dismiss — the exact thing the focus pause exists to prevent.
+	const hoverRef = useRef(false);
+	const focusRef = useRef(false);
+	const pausedRef = useRef(false);
+
+	const pause = () => {
+		if (pausedRef.current) return;
+		pausedRef.current = true;
 		setPaused(true);
 		clearTimeout(timerRef.current);
 		const elapsed = Date.now() - startTimeRef.current;
 		remainingRef.current = Math.max(0, remainingRef.current - elapsed);
 	};
 
-	const handleMouseLeave = () => {
+	const resume = () => {
+		if (!pausedRef.current || hoverRef.current || focusRef.current) return;
+		pausedRef.current = false;
 		setPaused(false);
 		startTimer(remainingRef.current);
+	};
+
+	const handleMouseEnter = () => {
+		hoverRef.current = true;
+		pause();
+	};
+
+	const handleMouseLeave = () => {
+		hoverRef.current = false;
+		resume();
+	};
+
+	const handleFocus = () => {
+		focusRef.current = true;
+		pause();
+	};
+
+	const handleBlur = (e: React.FocusEvent<HTMLLIElement>) => {
+		// A move between the toast's own buttons is not a departure.
+		if (e.currentTarget.contains(e.relatedTarget as Node | null)) return;
+		focusRef.current = false;
+		resume();
 	};
 
 	const strokeColors: Record<ToastType, string> = {
@@ -295,19 +336,16 @@ function ToastItem({
 			// Focus pauses the timer for the same reason hover does, and matters
 			// more: a keyboard user tabbing to Dismiss would otherwise have the
 			// button deleted out from under them mid-reach. Capture-phase because
-			// focus lands on the buttons inside, not on this element.
+			// focus lands on the buttons inside, not on this element. See the
+			// refcount above for why the two holders cannot share one flag.
 			//
-			// The relatedTarget check keeps a move between the toast's own buttons
-			// from restarting the clock. It is belt-and-braces rather than
+			// The relatedTarget check in handleBlur is belt-and-braces rather than
 			// load-bearing: blur and the following focus are adjacent, so the
-			// restart would be undone before the timer could advance. Kept because
-			// the alternative is a resume that only happens to be harmless.
-			onFocusCapture={handleMouseEnter}
-			onBlurCapture={(e: React.FocusEvent<HTMLLIElement>) => {
-				if (!e.currentTarget.contains(e.relatedTarget as Node | null)) {
-					handleMouseLeave();
-				}
-			}}
+			// resume it prevents would be undone before the timer could advance.
+			// Kept because the alternative is a resume that only happens to be
+			// harmless.
+			onFocusCapture={handleFocus}
+			onBlurCapture={handleBlur}
 			className={`relative flex items-start gap-2 px-4 py-2 rounded-(--radius-card) shadow-lg text-sm font-medium whitespace-pre-line break-words max-w-[min(28rem,90vw)] text-left ${bgColors[toast.type]} ${fading ? "opacity-0" : "opacity-100"}`}
 			style={{
 				overflow: "hidden",

--- a/web/src/context/ToastContext.tsx
+++ b/web/src/context/ToastContext.tsx
@@ -11,6 +11,7 @@ import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import { FuseOutline } from "../components/FuseOutline";
 import { useLocalStorage } from "../hooks/useLocalStorage";
+import { Copy, X } from "../lib/icons";
 
 export type ToastType = "success" | "error" | "info" | "warning";
 
@@ -152,8 +153,28 @@ export function ToastProvider({ children }: { children: ReactNode }) {
 			    modal card as a colored blob), and a filtered ancestor would also
 			    trap the fixed-position container. Same fix Modal uses. */}
 			{createPortal(
-				<div
-					className={`${containerClass} z-[70] flex flex-col ${alignClass} gap-2`}
+				// The live region is THIS container, not the individual toast, and it
+				// is mounted for the life of the app whether or not a toast exists.
+				// That is the part that makes announcements work: a live region has to
+				// be in the accessibility tree BEFORE its content changes, so marking
+				// up each toast as it appears announces nothing reliably. Before this
+				// the toasts were never announced at all — they were buttons that
+				// silently appeared, which a screen reader has no reason to read out.
+				//
+				// Polite rather than assertive, including for errors: a toast reports
+				// something that already happened, and interrupting whatever the user
+				// is reading to say so is worse than waiting for the next pause.
+				// aria-atomic="false" so adding a second toast announces only the new
+				// one instead of re-reading the whole stack.
+				//
+				// A real <ol>, so the stack is countable — "list, 3 items", steppable
+				// — rather than three unrelated blocks of text arriving from nowhere.
+				// It also lets each toast be an <li> instead of a div wearing a role
+				// attribute to look like one.
+				<ol
+					aria-live="polite"
+					aria-atomic="false"
+					className={`${containerClass} z-[70] m-0 flex list-none flex-col ${alignClass} gap-2 p-0`}
 				>
 					{toasts.map((t) => (
 						<ToastItem
@@ -164,7 +185,7 @@ export function ToastProvider({ children }: { children: ReactNode }) {
 							onDone={() => removeToast(t.id)}
 						/>
 					))}
-				</div>,
+				</ol>,
 				document.body,
 			)}
 		</ToastContext.Provider>
@@ -244,27 +265,50 @@ function ToastItem({
 		warning: "bg-amber-900/70 text-amber-200",
 	};
 
-	const handleClick = () => {
-		if (toast.type === "error") {
-			navigator.clipboard.writeText(toast.message).catch(() => {});
-		}
-		onDone();
+	const handleCopy = () => {
+		navigator.clipboard.writeText(toast.message).catch(() => {});
 	};
 
 	const { t } = useTranslation();
 
 	return (
-		<button
-			type="button"
+		// A toast is a message, not a control, so the body is a plain <li> in the
+		// live-region list above, and every action on it is its own real <button>.
+		//
+		// It used to be one big <button>: clicking anywhere dismissed it, and for
+		// errors also copied the message. That made the whole content model invalid
+		// the moment anything interactive went inside it — the reason the action
+		// slot below had to fake itself with role="button" on a <span>, which
+		// screen readers expose unreliably. It also put every visible toast in the
+		// tab order announced as "button" with the whole message as its name, and a
+		// stack of four toasts meant four tab stops in front of the page.
+		//
+		// The tradeoff, stated plainly: clicking the body no longer dismisses. The
+		// dismiss button is always there, errors get an explicit copy button
+		// instead of a hidden click-to-copy discoverable only through a tooltip,
+		// and the auto-dismiss timer is unchanged.
+		<li
 			data-testid="toast"
 			data-toast-type={toast.type}
-			onClick={handleClick}
 			onMouseEnter={handleMouseEnter}
 			onMouseLeave={handleMouseLeave}
-			{...(toast.type === "error"
-				? { title: t("context.toast.clickToCopyDismiss") }
-				: {})}
-			className={`relative px-4 py-2 rounded-(--radius-card) shadow-lg text-sm font-medium hover:brightness-125 whitespace-pre-line break-words max-w-[min(28rem,90vw)] text-left border-0 ${bgColors[toast.type]} ${fading ? "opacity-0" : "opacity-100"}`}
+			// Focus pauses the timer for the same reason hover does, and matters
+			// more: a keyboard user tabbing to Dismiss would otherwise have the
+			// button deleted out from under them mid-reach. Capture-phase because
+			// focus lands on the buttons inside, not on this element.
+			//
+			// The relatedTarget check keeps a move between the toast's own buttons
+			// from restarting the clock. It is belt-and-braces rather than
+			// load-bearing: blur and the following focus are adjacent, so the
+			// restart would be undone before the timer could advance. Kept because
+			// the alternative is a resume that only happens to be harmless.
+			onFocusCapture={handleMouseEnter}
+			onBlurCapture={(e: React.FocusEvent<HTMLLIElement>) => {
+				if (!e.currentTarget.contains(e.relatedTarget as Node | null)) {
+					handleMouseLeave();
+				}
+			}}
+			className={`relative flex items-start gap-2 px-4 py-2 rounded-(--radius-card) shadow-lg text-sm font-medium whitespace-pre-line break-words max-w-[min(28rem,90vw)] text-left ${bgColors[toast.type]} ${fading ? "opacity-0" : "opacity-100"}`}
 			style={{
 				overflow: "hidden",
 				transition: "opacity 300ms ease",
@@ -277,47 +321,56 @@ function ToastItem({
 					: undefined
 			}
 		>
-			{toast.message}
+			<span data-testid="toast-message" className="min-w-0 flex-1">
+				{toast.message}
+			</span>
 			{toast.action ? (
-				// KNOWN LIMITATION, not a solved problem. The toast body is itself a
-				// <button> (clicking it dismisses, and copies for errors), so this is
-				// an interactive descendant of an interactive element either way:
-				// role="button" + tabIndex is exactly as invalid per the HTML content
-				// model as a nested <button> would be, and screen readers expose it
-				// unreliably. The span merely avoids the parse-level button-in-button.
-				// The honest fix is to stop making the toast body a button, which is a
-				// change to every existing toast and out of scope here.
-				// biome-ignore lint/a11y/useSemanticElements: nesting a real <button> inside the toast <button> is invalid; this span is a knowingly imperfect stand-in, see the note above
-				<span
-					role="button"
-					tabIndex={0}
+				<button
+					type="button"
 					data-testid="toast-action"
-					onClick={(e) => {
-						e.stopPropagation();
+					onClick={() => {
 						toast.action?.onClick();
 						onDone();
 					}}
-					onKeyDown={(e) => {
-						if (e.key === "Enter" || e.key === " ") {
-							e.preventDefault();
-							e.stopPropagation();
-							toast.action?.onClick();
-							onDone();
-						}
-					}}
-					className="ui-btn ui-btn-ghost ui-btn-compact ml-2 inline-flex cursor-pointer items-center underline"
+					className="ui-btn ui-btn-ghost ui-btn-compact inline-flex shrink-0 items-center underline"
 				>
 					{toast.action.label}
-				</span>
+				</button>
 			) : null}
+			{toast.type === "error" ? (
+				// Copy does NOT dismiss. It used to, because it was the same click;
+				// separating them means an operator can copy a stack trace and still
+				// read the toast it came from.
+				<button
+					type="button"
+					data-testid="toast-copy"
+					onClick={handleCopy}
+					aria-label={t("common.copy")}
+					title={t("common.copy")}
+					className="ui-icon-btn shrink-0"
+				>
+					<Copy className="h-4 w-4" aria-hidden="true" />
+				</button>
+			) : null}
+			<button
+				type="button"
+				data-testid="toast-dismiss"
+				onClick={onDone}
+				aria-label={t("common.close")}
+				title={t("common.close")}
+				className="ui-icon-btn shrink-0"
+			>
+				<X className="h-4 w-4" aria-hidden="true" />
+			</button>
 			{fuse && (
 				<FuseOutline
+					data-testid="toast-fuse"
 					color={strokeColors[toast.type]}
 					durationMs={timeout}
 					paused={paused}
 				/>
 			)}
-		</button>
+		</li>
 	);
 }
 

--- a/web/src/context/__tests__/ToastContext.test.tsx
+++ b/web/src/context/__tests__/ToastContext.test.tsx
@@ -513,6 +513,64 @@ describe("ToastItem", () => {
 
 		vi.useRealTimers();
 	});
+
+	it("holds the timer while hover and focus overlap, and loses no time to either", () => {
+		vi.useFakeTimers();
+
+		const wrapper = ({ children }: { children: ReactNode }) => (
+			<ToastProvider>{children}</ToastProvider>
+		);
+
+		const { result } = renderHook(() => useToast(), { wrapper });
+
+		act(() => {
+			result.current.toast("Overlapping holds", "error");
+		});
+
+		const toastEl = screen.getByTestId("toast");
+		const copy = screen.getByTestId("toast-copy");
+
+		// Halfway: the pointer pauses. 2000ms of the 4000ms remain.
+		act(() => {
+			vi.advanceTimersByTime(2000);
+			fireEvent.mouseEnter(toastEl);
+		});
+
+		// Clicking Copy with a mouse focuses it while the pointer is still over
+		// the toast, so the clock is now held twice. Pausing again must not
+		// subtract the elapsed span a second time — that used to leave 0ms.
+		act(() => {
+			vi.advanceTimersByTime(100);
+			fireEvent.focus(copy);
+		});
+
+		// The pointer leaves, focus stays inside. The clock is still held, and
+		// the time it kept is the full 2000ms, not what a double subtraction
+		// left behind.
+		act(() => {
+			fireEvent.mouseLeave(toastEl);
+			vi.advanceTimersByTime(10000);
+		});
+
+		expect(screen.getByTestId("toast")).toHaveClass("opacity-100");
+
+		// Focus leaves too. Now the clock runs, and it runs for the 2000ms that
+		// were banked at the first pause.
+		act(() => {
+			fireEvent.blur(copy, { relatedTarget: document.body });
+			vi.advanceTimersByTime(1999);
+		});
+
+		expect(screen.getByTestId("toast")).toHaveClass("opacity-100");
+
+		act(() => {
+			vi.advanceTimersByTime(1);
+		});
+
+		expect(screen.getByTestId("toast")).toHaveClass("opacity-0");
+
+		vi.useRealTimers();
+	});
 });
 
 // Helper component for testing toast addition

--- a/web/src/context/__tests__/ToastContext.test.tsx
+++ b/web/src/context/__tests__/ToastContext.test.tsx
@@ -51,8 +51,7 @@ describe("ToastProvider / addToast", () => {
 			result.current.toast("Default type message");
 		});
 
-		const toast = screen.getByText("Default type message");
-		expect(toast).toHaveClass("bg-emerald-900/70");
+		expect(screen.getByTestId("toast")).toHaveClass("bg-emerald-900/70");
 	});
 
 	it("respects custom type ('error', 'info', 'warning')", () => {
@@ -64,13 +63,16 @@ describe("ToastProvider / addToast", () => {
 			result.current.toast("Warning message", "warning");
 		});
 
-		const errorToast = screen.getByText("Error message");
-		const infoToast = screen.getByText("Info message");
-		const warningToast = screen.getByText("Warning message");
+		// Keyed off data-toast-type rather than the message node: the message
+		// lives in its own span now, and the palette is on the toast root.
+		const byType = (type: string) =>
+			screen
+				.getAllByTestId("toast")
+				.find((el) => el.getAttribute("data-toast-type") === type);
 
-		expect(errorToast).toHaveClass("bg-red-900/70");
-		expect(infoToast).toHaveClass("bg-slate-700/80");
-		expect(warningToast).toHaveClass("bg-amber-900/70");
+		expect(byType("error")).toHaveClass("bg-red-900/70");
+		expect(byType("info")).toHaveClass("bg-slate-700/80");
+		expect(byType("warning")).toHaveClass("bg-amber-900/70");
 	});
 });
 
@@ -93,13 +95,9 @@ describe("removeToast", () => {
 
 		expect(screen.getByText("To be removed")).toBeInTheDocument();
 
-		// Get the toast ID and remove it
-		const toasts = screen.getAllByRole("button");
-		const firstToast = toasts[0];
-
-		// Click to trigger onDone (which calls removeToast)
+		// Dismissal is its own button now, not the toast body.
 		act(() => {
-			firstToast.click();
+			screen.getAllByTestId("toast-dismiss")[0].click();
 		});
 
 		expect(screen.queryByText("To be removed")).not.toBeInTheDocument();
@@ -238,7 +236,7 @@ describe("ToastItem", () => {
 		// Toast fades out (opacity-0) then relies on CSS transitionend to remove.
 		// jsdom doesn't fire real CSS transitions, so simulate the event.
 		const btn = screen.queryByText("Auto-dismiss toast");
-		const toastEl = btn?.closest("button") ?? null;
+		const toastEl = btn?.closest("[data-testid='toast']") ?? null;
 		if (toastEl) {
 			act(() => {
 				fireEvent.transitionEnd(toastEl, {
@@ -265,7 +263,10 @@ describe("ToastItem", () => {
 			result.current.toast("Fuse toast");
 		});
 
-		const svg = document.querySelector("svg[aria-hidden='true']");
+		// Addressed by test id, not by `svg[aria-hidden]`: the toast's own icons
+		// are decorative SVGs and are aria-hidden too, so that selector stopped
+		// identifying the fuse the moment the controls became real buttons.
+		const svg = screen.getByTestId("toast-fuse");
 		expect(svg).toBeInTheDocument();
 
 		const rect = svg?.querySelector("rect");
@@ -289,7 +290,7 @@ describe("ToastItem", () => {
 			result.current.toast("No-fuse toast");
 		});
 
-		expect(document.querySelector("svg[aria-hidden='true']")).toBeNull();
+		expect(screen.queryByTestId("toast-fuse")).toBeNull();
 	});
 
 	it("pauses timeout on mouseenter and resumes on mouseleave", () => {
@@ -305,7 +306,9 @@ describe("ToastItem", () => {
 			result.current.toast("Pause test");
 		});
 
-		const toastButton = screen.getByText("Pause test");
+		// The hover handlers live on the toast root. React's onMouseEnter does not
+		// bubble, so firing on the message span would silently no-op.
+		const toastEl = screen.getByTestId("toast");
 
 		// Advance halfway (2000ms of 4000ms)
 		act(() => {
@@ -313,13 +316,13 @@ describe("ToastItem", () => {
 		});
 
 		// Toast still present and not yet fading.
-		expect(toastButton).toHaveClass("opacity-100");
+		expect(toastEl).toHaveClass("opacity-100");
 
 		// Hover to pause. fireEvent.mouseEnter routes through React's synthetic
 		// onMouseEnter (a raw mouseenter dispatch does not), so this actually
 		// exercises the pause handler rather than silently no-opping.
 		act(() => {
-			fireEvent.mouseEnter(toastButton);
+			fireEvent.mouseEnter(toastEl);
 		});
 
 		// Advance past the original 4000ms total while paused: only 2000ms of the
@@ -329,11 +332,11 @@ describe("ToastItem", () => {
 			vi.advanceTimersByTime(2000);
 		});
 
-		expect(screen.getByText("Pause test")).toHaveClass("opacity-100");
+		expect(screen.getByTestId("toast")).toHaveClass("opacity-100");
 
 		// Unhover to resume the remaining time.
 		act(() => {
-			fireEvent.mouseLeave(toastButton);
+			fireEvent.mouseLeave(toastEl);
 		});
 
 		// Advance past remaining time — should now remove
@@ -342,22 +345,18 @@ describe("ToastItem", () => {
 		});
 
 		// jsdom doesn't fire real CSS transitions, simulate transitionend
-		const btn = screen.queryByText("Pause test");
-		const toastEl = btn?.closest("button") ?? null;
-		if (toastEl) {
-			act(() => {
-				fireEvent.transitionEnd(toastEl, {
-					propertyName: "opacity",
-				});
+		act(() => {
+			fireEvent.transitionEnd(toastEl, {
+				propertyName: "opacity",
 			});
-		}
+		});
 
 		expect(screen.queryByText("Pause test")).not.toBeInTheDocument();
 
 		vi.useRealTimers();
 	});
 
-	it("clicking an error toast calls navigator.clipboard.writeText then onDone", async () => {
+	it("the copy button copies the message and leaves the toast up", async () => {
 		// Mock clipboard API
 		const writeTextSpy = vi.fn().mockResolvedValue(undefined);
 		Object.assign(navigator, { clipboard: { writeText: writeTextSpy } });
@@ -372,19 +371,147 @@ describe("ToastItem", () => {
 			result.current.toast("Error to copy", "error");
 		});
 
-		const errorToast = screen.getByText("Error to copy");
-		expect(errorToast).toBeInTheDocument();
-
-		// Click the toast — this triggers clipboard write + onDone (immediate remove)
 		await act(async () => {
-			errorToast.click();
+			screen.getByTestId("toast-copy").click();
 		});
 
-		// Verify clipboard was called with the message
 		expect(writeTextSpy).toHaveBeenCalledWith("Error to copy");
 
-		// Toast should be removed after click
-		expect(screen.queryByText("Error to copy")).not.toBeInTheDocument();
+		// Copy used to dismiss, because it was the same click as the dismissal.
+		// Separating them is the point: the message stays readable after copying.
+		expect(screen.getByText("Error to copy")).toBeInTheDocument();
+	});
+
+	it("offers copy only on errors, and dismiss on every toast", () => {
+		const wrapper = ({ children }: { children: ReactNode }) => (
+			<ToastProvider>{children}</ToastProvider>
+		);
+
+		const { result } = renderHook(() => useToast(), { wrapper });
+
+		act(() => {
+			result.current.toast("Just information", "info");
+		});
+
+		expect(screen.queryByTestId("toast-copy")).toBeNull();
+		expect(screen.getByTestId("toast-dismiss")).toBeInTheDocument();
+	});
+
+	it("the dismiss button removes the toast", () => {
+		const wrapper = ({ children }: { children: ReactNode }) => (
+			<ToastProvider>{children}</ToastProvider>
+		);
+
+		const { result } = renderHook(() => useToast(), { wrapper });
+
+		act(() => {
+			result.current.toast("Dismiss me");
+		});
+
+		act(() => {
+			screen.getByTestId("toast-dismiss").click();
+		});
+
+		expect(screen.queryByText("Dismiss me")).not.toBeInTheDocument();
+	});
+
+	it("is a message, not a control: the body is not a button and holds no fake ones", () => {
+		const wrapper = ({ children }: { children: ReactNode }) => (
+			<ToastProvider>{children}</ToastProvider>
+		);
+
+		const { result } = renderHook(() => useToast(), { wrapper });
+
+		act(() => {
+			result.current.toast("Not a button", "error", {
+				label: "Undo",
+				onClick: () => {},
+			});
+		});
+
+		const toastEl = screen.getByTestId("toast");
+
+		// The regression this pins: the toast body used to be a <button>, which
+		// made every interactive child an invalid content model and forced the
+		// action slot to fake itself with role="button" on a <span>.
+		expect(toastEl.tagName).toBe("LI");
+		expect(toastEl.closest("button")).toBeNull();
+		expect(toastEl.querySelector("[role='button']")).toBeNull();
+		// The list is what makes the stack countable to a screen reader.
+		expect(toastEl.parentElement?.tagName).toBe("OL");
+
+		// And every control inside it is a real button.
+		for (const id of ["toast-action", "toast-copy", "toast-dismiss"]) {
+			expect(screen.getByTestId(id).tagName).toBe("BUTTON");
+		}
+	});
+
+	it("announces through a live region that outlives any single toast", () => {
+		const wrapper = ({ children }: { children: ReactNode }) => (
+			<ToastProvider>{children}</ToastProvider>
+		);
+
+		// The region has to exist BEFORE the first toast arrives, or nothing is
+		// announced. Asserting it while the stack is empty is the whole point.
+		const { result } = renderHook(() => useToast(), { wrapper });
+
+		const region = document.querySelector("[aria-live='polite']");
+		expect(region).toBeInTheDocument();
+		expect(region).toHaveAttribute("aria-atomic", "false");
+		expect(screen.queryByTestId("toast")).toBeNull();
+
+		act(() => {
+			result.current.toast("Announce me");
+		});
+
+		expect(region).toContainElement(screen.getByTestId("toast"));
+	});
+
+	it("focus pauses the auto-dismiss timer until focus leaves the toast", () => {
+		vi.useFakeTimers();
+
+		const wrapper = ({ children }: { children: ReactNode }) => (
+			<ToastProvider>{children}</ToastProvider>
+		);
+
+		const { result } = renderHook(() => useToast(), { wrapper });
+
+		act(() => {
+			result.current.toast("Keyboard reach", "error");
+		});
+
+		const copy = screen.getByTestId("toast-copy");
+		const dismiss = screen.getByTestId("toast-dismiss");
+
+		// Tab to Copy at the halfway mark.
+		act(() => {
+			vi.advanceTimersByTime(2000);
+			fireEvent.focus(copy);
+		});
+
+		// Move on to Dismiss. Blur and the following focus are adjacent, so no
+		// time passes between them and the timer cannot advance either way —
+		// this leg is here because it is the real keyboard path, not because it
+		// discriminates the relatedTarget guard in ToastContext (verified: that
+		// guard can be removed without failing this test; it prevents a
+		// redundant restart, which the timer never gets a chance to show).
+		act(() => {
+			fireEvent.blur(copy, { relatedTarget: dismiss });
+			fireEvent.focus(dismiss);
+			vi.advanceTimersByTime(4000);
+		});
+
+		expect(screen.getByTestId("toast")).toHaveClass("opacity-100");
+
+		// Focus leaves the toast entirely: the remaining 2000ms resumes.
+		act(() => {
+			fireEvent.blur(dismiss, { relatedTarget: document.body });
+			vi.advanceTimersByTime(2000);
+		});
+
+		expect(screen.getByTestId("toast")).toHaveClass("opacity-0");
+
+		vi.useRealTimers();
 	});
 });
 

--- a/web/src/i18n/locales/af.json
+++ b/web/src/i18n/locales/af.json
@@ -2835,11 +2835,6 @@
 			"fuchsia": "Fuchsia"
 		}
 	},
-	"context": {
-		"toast": {
-			"clickToCopyDismiss": "Klik om te kopieer en te verwyder"
-		}
-	},
 	"paramCompat": {
 		"anthropic": {
 			"topP": "top_p is verouderd op die huidige Anthropic-modelle; gebruik eerder top_k.",

--- a/web/src/i18n/locales/ar.json
+++ b/web/src/i18n/locales/ar.json
@@ -3079,11 +3079,6 @@
 			"fuchsia": "Fuchsia"
 		}
 	},
-	"context": {
-		"toast": {
-			"clickToCopyDismiss": "انقر لنسخ ورفض"
-		}
-	},
 	"paramCompat": {
 		"anthropic": {
 			"topP": "top_p مهمل في نماذج Anthropic الحالية؛ استخدم top_k بدلاً من ذلك",

--- a/web/src/i18n/locales/ca.json
+++ b/web/src/i18n/locales/ca.json
@@ -2896,11 +2896,6 @@
 			"fuchsia": "Fúcsia"
 		}
 	},
-	"context": {
-		"toast": {
-			"clickToCopyDismiss": "Feu clic per copiar i descartar"
-		}
-	},
 	"paramCompat": {
 		"anthropic": {
 			"topP": "top_p està obsolet en els models actuals d'Anthropic; utilitzeu top_k en el seu lloc.",

--- a/web/src/i18n/locales/cs.json
+++ b/web/src/i18n/locales/cs.json
@@ -2957,11 +2957,6 @@
 			"fuchsia": "Fuchsiová"
 		}
 	},
-	"context": {
-		"toast": {
-			"clickToCopyDismiss": "Kliknutím zkopírujete a zavřete"
-		}
-	},
 	"paramCompat": {
 		"anthropic": {
 			"topP": "Funkce top_p je u aktuálních modelů Anthropic zastaralá; místo ní použijte top_k",

--- a/web/src/i18n/locales/da.json
+++ b/web/src/i18n/locales/da.json
@@ -2835,11 +2835,6 @@
 			"fuchsia": "Fuchsia"
 		}
 	},
-	"context": {
-		"toast": {
-			"clickToCopyDismiss": "Klik for at kopiere og afvise"
-		}
-	},
 	"paramCompat": {
 		"anthropic": {
 			"topP": "top_p er forældet på nuværende Anthropic-modeller; brug i stedet top_k",

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -2835,11 +2835,6 @@
 			"fuchsia": "Fuchsia"
 		}
 	},
-	"context": {
-		"toast": {
-			"clickToCopyDismiss": "Zum Kopieren und Verwerfen klicken"
-		}
-	},
 	"paramCompat": {
 		"anthropic": {
 			"topP": "top_p ist bei aktuellen Anthropic-Modellen veraltet; stattdessen top_k verwenden",

--- a/web/src/i18n/locales/el.json
+++ b/web/src/i18n/locales/el.json
@@ -2835,11 +2835,6 @@
 			"fuchsia": "Fuchsia"
 		}
 	},
-	"context": {
-		"toast": {
-			"clickToCopyDismiss": "Κάντε κλικ για αντιγραφή και απόρριψη"
-		}
-	},
 	"paramCompat": {
 		"anthropic": {
 			"topP": "Το top_p έχει καταργηθεί στα τρέχοντα μοντέλα Anthropic· χρησιμοποιήστε top_k",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -2835,11 +2835,6 @@
 			"fuchsia": "Fuchsia"
 		}
 	},
-	"context": {
-		"toast": {
-			"clickToCopyDismiss": "Click to copy and dismiss"
-		}
-	},
 	"paramCompat": {
 		"anthropic": {
 			"topP": "top_p is deprecated on current Anthropic models; use top_k instead",

--- a/web/src/i18n/locales/es.json
+++ b/web/src/i18n/locales/es.json
@@ -2896,11 +2896,6 @@
 			"fuchsia": "Fuchsia"
 		}
 	},
-	"context": {
-		"toast": {
-			"clickToCopyDismiss": "Haga clic para copiar y descartar"
-		}
-	},
 	"paramCompat": {
 		"anthropic": {
 			"topP": "top_p está obsoleto en los modelos actuales de Anthropic; usa top_k en su lugar",

--- a/web/src/i18n/locales/fi.json
+++ b/web/src/i18n/locales/fi.json
@@ -2835,11 +2835,6 @@
 			"fuchsia": "Fuchsia"
 		}
 	},
-	"context": {
-		"toast": {
-			"clickToCopyDismiss": "Klikkaa kopioidaksesi ja hylätäksesi"
-		}
-	},
 	"paramCompat": {
 		"anthropic": {
 			"topP": "top_p on vanhentunut nykyisissä Anthropic-malleissa; käytä sen sijaan top_k",

--- a/web/src/i18n/locales/fr.json
+++ b/web/src/i18n/locales/fr.json
@@ -2896,11 +2896,6 @@
 			"fuchsia": "Fuchsia"
 		}
 	},
-	"context": {
-		"toast": {
-			"clickToCopyDismiss": "Cliquez pour copier et rejeter"
-		}
-	},
 	"paramCompat": {
 		"anthropic": {
 			"topP": "top_p est déprécié sur les modèles Anthropic actuels ; utilisez top_k à la place",

--- a/web/src/i18n/locales/he.json
+++ b/web/src/i18n/locales/he.json
@@ -2896,11 +2896,6 @@
 			"fuchsia": "פוקסיה"
 		}
 	},
-	"context": {
-		"toast": {
-			"clickToCopyDismiss": "לחץ כדי להעתיק ולסגור"
-		}
-	},
 	"paramCompat": {
 		"anthropic": {
 			"topP": "השימוש ב-top_p אינו מומלץ עוד במודלים הנוכחיים של Anthropic; יש להשתמש ב-top_k במקום זאת",

--- a/web/src/i18n/locales/hu.json
+++ b/web/src/i18n/locales/hu.json
@@ -2835,11 +2835,6 @@
 			"fuchsia": "Fukszia"
 		}
 	},
-	"context": {
-		"toast": {
-			"clickToCopyDismiss": "Kattintson a másoláshoz és az ablak bezárásához"
-		}
-	},
 	"paramCompat": {
 		"anthropic": {
 			"topP": "A top_p használata az aktuális Anthropic-modellekben már nem ajánlott; helyette a top_k-t használja",

--- a/web/src/i18n/locales/it.json
+++ b/web/src/i18n/locales/it.json
@@ -2896,11 +2896,6 @@
 			"fuchsia": "Fuchsia"
 		}
 	},
-	"context": {
-		"toast": {
-			"clickToCopyDismiss": "Clicca per copiare e chiudere"
-		}
-	},
 	"paramCompat": {
 		"anthropic": {
 			"topP": "top_p è deprecato sui modelli Anthropic attuali; usa invece top_k",

--- a/web/src/i18n/locales/ja.json
+++ b/web/src/i18n/locales/ja.json
@@ -2835,11 +2835,6 @@
 			"fuchsia": "Fuchsia"
 		}
 	},
-	"context": {
-		"toast": {
-			"clickToCopyDismiss": "クリックしてコピー&解除"
-		}
-	},
 	"paramCompat": {
 		"anthropic": {
 			"topP": "top_pは現在のAnthropicモデルでは非推奨です。代わりにtop_kを使用してください",

--- a/web/src/i18n/locales/ko.json
+++ b/web/src/i18n/locales/ko.json
@@ -2835,11 +2835,6 @@
 			"fuchsia": "푸시아"
 		}
 	},
-	"context": {
-		"toast": {
-			"clickToCopyDismiss": "클릭하여 복사하고 닫기"
-		}
-	},
 	"paramCompat": {
 		"anthropic": {
 			"topP": "현재 Anthropic 모델에서는 top_p가 더 이상 권장되지 않으므로, 대신 top_k를 사용하십시오.",

--- a/web/src/i18n/locales/nl.json
+++ b/web/src/i18n/locales/nl.json
@@ -2835,11 +2835,6 @@
 			"fuchsia": "Fuchsia"
 		}
 	},
-	"context": {
-		"toast": {
-			"clickToCopyDismiss": "Klik om te kopiëren en te sluiten"
-		}
-	},
 	"paramCompat": {
 		"anthropic": {
 			"topP": "top_p wordt niet meer ondersteund op de huidige Anthropic-modellen; gebruik in plaats daarvan top_k",

--- a/web/src/i18n/locales/no.json
+++ b/web/src/i18n/locales/no.json
@@ -2835,11 +2835,6 @@
 			"fuchsia": "Fuchsia"
 		}
 	},
-	"context": {
-		"toast": {
-			"clickToCopyDismiss": "Klikk for å kopiere og avvise"
-		}
-	},
 	"paramCompat": {
 		"anthropic": {
 			"topP": "top_p er utfaset på gjeldende Anthropic-modeller; bruk top_k i stedet",

--- a/web/src/i18n/locales/pl.json
+++ b/web/src/i18n/locales/pl.json
@@ -2957,11 +2957,6 @@
 			"fuchsia": "Fuchsia"
 		}
 	},
-	"context": {
-		"toast": {
-			"clickToCopyDismiss": "Kliknij, aby skopiować i odrzucić"
-		}
-	},
 	"paramCompat": {
 		"anthropic": {
 			"topP": "top_p jest przestarzały w aktualnych modelach Anthropic; użyj zamiast tego top_k",

--- a/web/src/i18n/locales/pt.json
+++ b/web/src/i18n/locales/pt.json
@@ -2896,11 +2896,6 @@
 			"fuchsia": "Fuchsia"
 		}
 	},
-	"context": {
-		"toast": {
-			"clickToCopyDismiss": "Clique para copiar e descartar"
-		}
-	},
 	"paramCompat": {
 		"anthropic": {
 			"topP": "top_p está obsoleto nos modelos atuais da Anthropic; use top_k",

--- a/web/src/i18n/locales/ro.json
+++ b/web/src/i18n/locales/ro.json
@@ -2896,11 +2896,6 @@
 			"fuchsia": "Fuchsia"
 		}
 	},
-	"context": {
-		"toast": {
-			"clickToCopyDismiss": "Faceți clic pentru a copia și a respinge"
-		}
-	},
 	"paramCompat": {
 		"anthropic": {
 			"topP": "top_p este învechit pe modelele Anthropic actuale; folosește în schimb top_k",

--- a/web/src/i18n/locales/ru.json
+++ b/web/src/i18n/locales/ru.json
@@ -2957,11 +2957,6 @@
 			"fuchsia": "Fuchsia"
 		}
 	},
-	"context": {
-		"toast": {
-			"clickToCopyDismiss": "Нажмите, чтобы скопировать и отклонить"
-		}
-	},
 	"paramCompat": {
 		"anthropic": {
 			"topP": "top_p устарел в текущих моделях Anthropic; используйте вместо него top_k",

--- a/web/src/i18n/locales/sk.json
+++ b/web/src/i18n/locales/sk.json
@@ -2957,11 +2957,6 @@
 			"fuchsia": "Fuchsiová"
 		}
 	},
-	"context": {
-		"toast": {
-			"clickToCopyDismiss": "Kliknutím skopírujete a zatvoríte"
-		}
-	},
 	"paramCompat": {
 		"anthropic": {
 			"topP": "Funkcia top_p je v súčasných modeloch Anthropic zastaraná; namiesto nej použite top_k",

--- a/web/src/i18n/locales/sr.json
+++ b/web/src/i18n/locales/sr.json
@@ -2896,11 +2896,6 @@
 			"fuchsia": "Фуксија"
 		}
 	},
-	"context": {
-		"toast": {
-			"clickToCopyDismiss": "Кликните да копирате и отклоните"
-		}
-	},
 	"paramCompat": {
 		"anthropic": {
 			"topP": "top_p је застарео на тренутним Anthropic моделима; уместо тога користите top_k",

--- a/web/src/i18n/locales/sv.json
+++ b/web/src/i18n/locales/sv.json
@@ -2835,11 +2835,6 @@
 			"fuchsia": "Fuchsia"
 		}
 	},
-	"context": {
-		"toast": {
-			"clickToCopyDismiss": "Klicka för att kopiera och avfärda"
-		}
-	},
 	"paramCompat": {
 		"anthropic": {
 			"topP": "top_p är föråldrad på nuvarande Anthropic-modeller; använd top_k istället",

--- a/web/src/i18n/locales/tr.json
+++ b/web/src/i18n/locales/tr.json
@@ -2835,11 +2835,6 @@
 			"fuchsia": "Fuşya"
 		}
 	},
-	"context": {
-		"toast": {
-			"clickToCopyDismiss": "Kopyalayıp kapatmak için tıklayın"
-		}
-	},
 	"paramCompat": {
 		"anthropic": {
 			"topP": "top_p, güncel Anthropic modellerinde artık kullanılmamaktadır; bunun yerine top_k'yi kullanın",

--- a/web/src/i18n/locales/uk.json
+++ b/web/src/i18n/locales/uk.json
@@ -2957,11 +2957,6 @@
 			"fuchsia": "Fuchsia"
 		}
 	},
-	"context": {
-		"toast": {
-			"clickToCopyDismiss": "Натисніть, щоб скопіювати і відхилити"
-		}
-	},
 	"paramCompat": {
 		"anthropic": {
 			"topP": "top_p застаріло в поточних моделях Anthropic; використовуйте top_k",

--- a/web/src/i18n/locales/vi.json
+++ b/web/src/i18n/locales/vi.json
@@ -2835,11 +2835,6 @@
 			"fuchsia": "Màu fuchsia"
 		}
 	},
-	"context": {
-		"toast": {
-			"clickToCopyDismiss": "Nhấp để sao chép và đóng"
-		}
-	},
 	"paramCompat": {
 		"anthropic": {
 			"topP": "top_p hiện đã không còn được khuyến nghị sử dụng trên các mô hình Anthropic hiện tại; hãy sử dụng top_k thay thế",

--- a/web/src/i18n/locales/zh.json
+++ b/web/src/i18n/locales/zh.json
@@ -2835,11 +2835,6 @@
 			"fuchsia": "Fuchsia"
 		}
 	},
-	"context": {
-		"toast": {
-			"clickToCopyDismiss": "单击以复制并取消"
-		}
-	},
 	"paramCompat": {
 		"anthropic": {
 			"topP": "top_p 在当前 Anthropic 模型上已弃用；请改用 top_k",

--- a/web/src/pages/Models/__tests__/Models.test.tsx
+++ b/web/src/pages/Models/__tests__/Models.test.tsx
@@ -966,12 +966,11 @@ describe("Models", () => {
 			// Click "Delete" in the confirm dialog
 			await user.click(screen.getByRole("button", { name: "Delete" }));
 
-			// Should show success toast
+			// Should show success toast. Matched on text, not on a button role: a
+			// toast is a message in a live region and is not itself a control.
 			await waitFor(() => {
 				expect(
-					screen.getByRole("button", {
-						name: /Deleted 2 disabled models/,
-					}),
+					screen.getByText(/Deleted 2 disabled models/),
 				).toBeInTheDocument();
 			});
 		});
@@ -1019,13 +1018,10 @@ describe("Models", () => {
 			// Click "Delete" in the confirm dialog
 			await user.click(screen.getByRole("button", { name: "Delete" }));
 
-			// Should show error toast (the whole request failed atomically)
+			// Should show error toast (the whole request failed atomically).
+			// Text, not button role: see the success case above.
 			await waitFor(() => {
-				expect(
-					screen.getByRole("button", {
-						name: /Failed to delete/,
-					}),
-				).toBeInTheDocument();
+				expect(screen.getByText(/Failed to delete/)).toBeInTheDocument();
 			});
 		});
 	});

--- a/web/src/pages/Settings/__tests__/TotpSettings.test.tsx
+++ b/web/src/pages/Settings/__tests__/TotpSettings.test.tsx
@@ -343,10 +343,9 @@ describe("TotpSettings", () => {
 		await user.click(verifyBtn);
 
 		// enrollVerifyMutation.onError fires a toast with failedToVerify text.
-		// Toast renders a <button> whose accessible name is the message.
-		expect(
-			await screen.findByRole("button", { name: /Invalid TOTP code/i }),
-		).toBeInTheDocument();
+		// Asserted as text: a toast is a message in a live region, not a control,
+		// so it has no button role and no accessible name of its own.
+		expect(await screen.findByText(/Invalid TOTP code/i)).toBeInTheDocument();
 	});
 
 	it("renders nothing sensitive in initial disabled state", async () => {


### PR DESCRIPTION
The toast body was one big `<button>`. Clicking anywhere dismissed it, and for errors also copied the message. Three things followed from that, and the visible one was the least important.

## What was wrong

**The content model was invalid.** Anything interactive inside an interactive element is invalid HTML, so the optional action slot could not hold a real `<button>`. It faked one with `role="button"` + `tabIndex` on a `<span>` — exactly as invalid, and unreliably exposed. The code said so and left it:

> The honest fix is to stop making the toast body a button, which is a change to every existing toast and out of scope here.

This is that fix.

**Every toast was a tab stop**, announced as "button" with the entire message as its accessible name. A stack of four toasts put four of them in front of the page.

**Nothing was ever announced.** A toast is a button that silently appears, and a screen reader has no reason to read one out. There was no live region anywhere — so the feature whose entire job is to tell you what happened told a screen reader user nothing at all. That is the part this actually fixes.

## What it is now

An `<ol aria-live="polite" aria-atomic="false">` mounted for the life of the app, holding one `<li>` per toast.

- **The region is the container, not the toast.** A live region has to predate its content or nothing is announced, so marking up each toast as it appears would announce nothing reliably.
- **Polite, even for errors.** A toast reports something that already happened; interrupting a reader mid-sentence to say so is worse than waiting for the next pause.
- **A real list**, so the stack is countable and steppable ("list, 3 items") rather than three unrelated blocks of text arriving from nowhere. Being an `<li>` is also what lets the element carry the hover/focus handlers without wearing a role attribute to look like something it is not — no lint suppression involved.
- **Every action is a real `<button>`**: the action slot, an explicit copy button on errors, and a dismiss button on all of them.

## The tradeoff, stated plainly

**Clicking the body no longer dismisses.** Dismiss is a button that is always present. The hidden click-to-copy on errors — whose only advertisement was a `title` tooltip — is now a labelled copy button that does **not** dismiss, so you can copy a stack trace and still read the toast it came from. The auto-dismiss timer is untouched.

Focus now pauses that timer the way hover does, and it matters more: a keyboard user reaching for Dismiss would otherwise have the button deleted mid-reach.

## Fallout worth naming

- **Three test files asserted on the toast by its button role**, one with the comment *"Toast renders a `<button>` whose accessible name is the message"*. They were pinning the defect. They now match on text.
- **`CopyablePill`'s icon mock was a bare object**, so it threw out of React's render the moment the toast reached for an icon it did not list. Converted to a partial mock over `importOriginal`, fixing the class of problem rather than this instance.
- **The fuse overlay is addressed by test id** instead of `svg[aria-hidden]`, which stopped identifying it once the toast grew decorative icons of its own.
- **`context.toast.clickToCopyDismiss`** described a gesture that no longer exists. Dropped from all 29 locales, which left the `context` block empty and removed. The two new labels reuse `common.copy` and `common.close`, already translated everywhere — **this adds no untranslated strings**.

## Verification

| check | result |
|---|---|
| web suite | 291 files, **5597 tests**, all passing |
| `tsc -b` | clean |
| biome + eslint | clean, **no suppressions added** — the one that was there is gone |
| `make i18n-check` | 28 locales in sync, every `t()` key resolves |

Mutations, each caught: dropping `aria-live` fails the live-region test; dropping `onFocusCapture` fails the focus-pause test.

One negative result reported rather than papered over: the `relatedTarget` guard on blur is **not** pinned by any test, and the test says so in a comment. Blur and the following focus are adjacent, so the redundant timer restart it prevents is never observable. The guard stays because the alternative is a resume that only happens to be harmless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
