### PR TITLE
fix(logs): attribute keyless chat rows to their owner

### DIFF
--- a/internal/api/chatusercontext.go
+++ b/internal/api/chatusercontext.go
@@ -46,9 +46,12 @@ import (
 //   - UserAllowedProvidersKey — read by resolveCandidates
 //     (internal/proxy/proxy_request.go) via effectiveAllowedProviders.
 //   - VirtualKeyOwnerIDKey — the shared "user:<uuid>" bucket identity for both
-//     rate limiters, and the owner stamped on the request lifecycle SSE events
-//     (newPendingRequestLog), which is what scopes a non-admin's live log feed
-//     (eventOwnedBy in events.go).
+//     rate limiters, and the owner stamped by newPendingRequestLog on the
+//     request lifecycle SSE events (which is what scopes a non-admin's live log
+//     feed, eventOwnedBy in events.go) and, because this surface has no key to
+//     resolve an owner through, on request_logs.owner_user_id itself, which is
+//     what puts chat traffic in the caller's own REST logs and stats
+//     (migration 067).
 //   - UserRateLimitRPSKey / UserRateLimitBurstKey — read by
 //     ratelimit.Limiter.Middleware, which RegisterAdminChat already mounts.
 //   - UserRateLimitTPMKey — read by ratelimit.TPMLimiter.UserMiddleware, mounted

--- a/internal/api/logs.go
+++ b/internal/api/logs.go
@@ -97,12 +97,14 @@ func (h *Handler) GetLog(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
 	defer cancel()
 
-	// Non-admins can only fetch rows from keys they own; a non-owned id scans
-	// zero rows and answers 404 below, so ownership is not an existence oracle.
+	// Non-admins can only fetch their own rows; a non-owned id scans zero rows
+	// and answers 404 below, so ownership is not an existence oracle. Same
+	// two-shape disjunction as appendLogFilters — see the comment there.
 	ownerPredicate := ""
 	ownerArgs := []any{id}
 	if scope := ownerScopeFromIdentity(r); scope != "" {
-		ownerPredicate = " AND rl.virtual_key_id IN (SELECT vko.id FROM virtual_keys vko WHERE vko.owner_user_id = $2)"
+		ownerPredicate = " AND (rl.virtual_key_id IN (SELECT vko.id FROM virtual_keys vko WHERE vko.owner_user_id = $2)" +
+			" OR (rl.virtual_key_id IS NULL AND rl.owner_user_id = $2))"
 		ownerArgs = append(ownerArgs, scope)
 	}
 
@@ -427,12 +429,18 @@ func scanLogEntry(rows pgx.Rows) (LogEntry, error) {
 // the guard, so an invalid negative status_code is uniformly ignored — a
 // behaviour-neutral fix since status codes are always >= 0).
 func appendLogFilters(query string, args []any, argIndex int, modelID, providerID, statusCodeStr, fromDate, toDate, endpointType, ownerUserID string) (string, []any, int) {
-	// Owner scope first: for non-admins this is mandatory row-level security
-	// (only traffic from keys they own; rows without a virtual_key_id - admin
-	// chat, arena - are invisible by construction), for admins an optional
-	// dashboard filter.
+	// Owner scope first: for non-admins this is mandatory row-level security,
+	// for admins an optional dashboard filter. The two branches cover the two
+	// disjoint row shapes. A KEYED row resolves through the key's CURRENT owner,
+	// so reassigning a key moves its whole history with it. A KEYLESS row
+	// (dashboard chat/arena, which have no key to join through) carries the
+	// owner stamped at request time in request_logs.owner_user_id, written only
+	// for that shape; see migration 067. Rows predating that column stay NULL on
+	// both sides and remain admin-only.
 	if ownerUserID != "" {
-		query += " AND rl.virtual_key_id IN (SELECT vko.id FROM virtual_keys vko WHERE vko.owner_user_id = $" + util.IntToStr(argIndex) + ")"
+		ph := util.IntToStr(argIndex)
+		query += " AND (rl.virtual_key_id IN (SELECT vko.id FROM virtual_keys vko WHERE vko.owner_user_id = $" + ph + ")" +
+			" OR (rl.virtual_key_id IS NULL AND rl.owner_user_id = $" + ph + "))"
 		args = append(args, ownerUserID)
 		argIndex++
 	}

--- a/internal/api/logs_ownerscope_test.go
+++ b/internal/api/logs_ownerscope_test.go
@@ -13,13 +13,17 @@ import (
 )
 
 // logScopeFixture is the harness state for the owner-scope tests: two
-// log-granted users, one owned virtual key each, and four request_logs rows
-// (two for alice, one for bob, one with no virtual key at all).
+// log-granted users, one owned virtual key each, and six request_logs rows
+// covering both attribution shapes — two keyed rows for alice and one for bob
+// (owner resolved through the key), one keyless dashboard-chat row for each of
+// them (owner stamped on the row, migration 067), and one keyless row with no
+// owner at all, which stays admin-only.
 type logScopeFixture struct {
-	router               chi.Router
-	aliceToken, bobToken string
-	aliceID, bobID       string
-	aliceLogID, bobLogID string
+	router                       chi.Router
+	aliceToken, bobToken         string
+	aliceID, bobID               string
+	aliceLogID, bobLogID         string
+	aliceChatLogID, bobChatLogID string
 }
 
 func setupLogScopeTest(t *testing.T) logScopeFixture {
@@ -50,20 +54,27 @@ func setupLogScopeTest(t *testing.T) logScopeFixture {
 	aliceKey := mkKey("alice-key", fx.aliceID)
 	bobKey := mkKey("bob-key", fx.bobID)
 
-	insert := func(vkID any, vkName, model string) string {
+	// Mirrors what insertRequestLogAsync writes: a keyed row carries no
+	// owner_user_id (it resolves through the key), a keyless row carries the
+	// request-time owner and no key.
+	insert := func(vkID any, vkName, model string, ownerID any) string {
 		var id string
 		err := pool.QueryRow(context.Background(),
-			`INSERT INTO request_logs (model_id, status_code, virtual_key_id, virtual_key_name, created_at)
-			 VALUES ($1, 200, $2, $3, NOW()) RETURNING id`, model, vkID, vkName).Scan(&id)
+			`INSERT INTO request_logs (model_id, status_code, virtual_key_id, virtual_key_name, owner_user_id, created_at)
+			 VALUES ($1, 200, $2, $3, $4, NOW()) RETURNING id`, model, vkID, vkName, ownerID).Scan(&id)
 		if err != nil {
 			t.Fatalf("insert log: %v", err)
 		}
 		return id
 	}
-	fx.aliceLogID = insert(aliceKey, "alice-key", "alice-model-1")
-	insert(aliceKey, "alice-key", "alice-model-2")
-	fx.bobLogID = insert(bobKey, "bob-key", "bob-model")
-	insert(nil, "", "unkeyed-model") // admin chat / arena style row
+	fx.aliceLogID = insert(aliceKey, "alice-key", "alice-model-1", nil)
+	insert(aliceKey, "alice-key", "alice-model-2", nil)
+	fx.bobLogID = insert(bobKey, "bob-key", "bob-model", nil)
+	// Dashboard chat / arena rows: no virtual key, owner stamped at request time.
+	fx.aliceChatLogID = insert(nil, "", "alice-chat-model", fx.aliceID)
+	fx.bobChatLogID = insert(nil, "", "bob-chat-model", fx.bobID)
+	// Pre-067 keyless row: no key and no owner, so it stays admin-only.
+	insert(nil, "", "unattributed-model", nil)
 
 	return fx
 }
@@ -86,35 +97,131 @@ func listLogEntries(t *testing.T, router chi.Router, path, token string) []LogEn
 func TestLogs_OwnerScope_NonAdminSeesOnlyOwnTraffic(t *testing.T) {
 	fx := setupLogScopeTest(t)
 
+	// Alice owns two keyed rows plus one keyless chat row; bob one of each. The
+	// unattributed keyless row belongs to neither.
+	want := map[string]map[string]bool{
+		fx.aliceToken: {"alice-model-1": true, "alice-model-2": true, "alice-chat-model": true},
+		fx.bobToken:   {"bob-model": true, "bob-chat-model": true},
+	}
 	for _, path := range []string{"/logs?per_page=50", "/logs/cursor?limit=50"} {
-		entries := listLogEntries(t, fx.router, path, fx.aliceToken)
-		if len(entries) != 2 {
-			t.Fatalf("%s as alice: %d entries, want 2", path, len(entries))
-		}
-		for _, e := range entries {
-			if e.VirtualKeyName != "alice-key" {
-				t.Errorf("%s leaked foreign row: %+v", path, e)
+		for token, models := range want {
+			entries := listLogEntries(t, fx.router, path, token)
+			if len(entries) != len(models) {
+				t.Fatalf("%s: %d entries, want %d", path, len(entries), len(models))
+			}
+			for _, e := range entries {
+				if !models[e.ModelID] {
+					t.Errorf("%s leaked foreign row: %+v", path, e)
+				}
 			}
 		}
-		if got := listLogEntries(t, fx.router, path, fx.bobToken); len(got) != 1 {
-			t.Fatalf("%s as bob: %d entries, want 1", path, len(got))
+	}
+}
+
+// TestLogs_OwnerScope_ChatRowsVisibleToTheirOwner is the gap this column
+// closes: dashboard chat has no virtual key, so before request_logs.owner_user_id
+// existed a non-admin's own chat traffic could not satisfy the key-join
+// predicate and was invisible to them in the REST logs and stats.
+func TestLogs_OwnerScope_ChatRowsVisibleToTheirOwner(t *testing.T) {
+	fx := setupLogScopeTest(t)
+
+	hasModel := func(entries []LogEntry, model string) bool {
+		for _, e := range entries {
+			if e.ModelID == model {
+				return true
+			}
 		}
+		return false
+	}
+
+	for _, path := range []string{"/logs?per_page=50", "/logs/cursor?limit=50"} {
+		alice := listLogEntries(t, fx.router, path, fx.aliceToken)
+		if !hasModel(alice, "alice-chat-model") {
+			t.Errorf("%s: alice cannot see her own chat row", path)
+		}
+		if hasModel(alice, "bob-chat-model") {
+			t.Errorf("%s: alice sees bob's chat row", path)
+		}
+		if hasModel(alice, "unattributed-model") {
+			t.Errorf("%s: alice sees an ownerless keyless row", path)
+		}
+	}
+
+	// The single-row fetch applies the same disjunction.
+	if w := doJSON(t, fx.router, http.MethodGet, "/logs/"+fx.aliceChatLogID, fx.aliceToken, ""); w.Code != http.StatusOK {
+		t.Errorf("own chat row: %d %s", w.Code, w.Body.String())
+	}
+	if w := doJSON(t, fx.router, http.MethodGet, "/logs/"+fx.bobChatLogID, fx.aliceToken, ""); w.Code != http.StatusNotFound {
+		t.Errorf("foreign chat row: %d, want 404", w.Code)
+	}
+}
+
+// TestLogs_OwnerScope_KeyReassignmentMovesHistory guards the half of the
+// predicate that did NOT change. Keyed rows resolve through the key's CURRENT
+// owner, so reassigning a key hands its whole log history to the new owner.
+// Widening the predicate to a disjunction must not have turned that into
+// request-time attribution, and must not have widened what either user sees.
+func TestLogs_OwnerScope_KeyReassignmentMovesHistory(t *testing.T) {
+	fx := setupLogScopeTest(t)
+
+	keys := listLogEntries(t, fx.router, "/logs/cursor?limit=50", fx.aliceToken)
+	if len(keys) != 3 {
+		t.Fatalf("alice before reassignment: %d entries, want 3", len(keys))
+	}
+
+	// Find alice's key and hand it to bob.
+	w := doJSON(t, fx.router, http.MethodGet, "/virtual-keys", envAdminToken, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("list keys: %d %s", w.Code, w.Body.String())
+	}
+	var listed []struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &listed); err != nil {
+		t.Fatalf("decode keys: %v", err)
+	}
+	aliceKeyID := ""
+	for _, k := range listed {
+		if k.Name == "alice-key" {
+			aliceKeyID = k.ID
+		}
+	}
+	if aliceKeyID == "" {
+		t.Fatalf("alice-key not found in %+v", listed)
+	}
+	w = doJSON(t, fx.router, http.MethodPut, "/virtual-keys/"+aliceKeyID, envAdminToken,
+		fmt.Sprintf(`{"name":"alice-key","owner_user_id":%q}`, fx.bobID))
+	if w.Code != http.StatusOK {
+		t.Fatalf("reassign key: %d %s", w.Code, w.Body.String())
+	}
+	globalLogsCache.clear()
+
+	// Alice keeps only her keyless chat row; the two keyed rows followed the key.
+	after := listLogEntries(t, fx.router, "/logs/cursor?limit=50", fx.aliceToken)
+	if len(after) != 1 || after[0].ModelID != "alice-chat-model" {
+		t.Fatalf("alice after reassignment: %+v, want only alice-chat-model", after)
+	}
+	if got := listLogEntries(t, fx.router, "/logs/cursor?limit=50", fx.bobToken); len(got) != 4 {
+		t.Fatalf("bob after reassignment: %d entries, want 4", len(got))
 	}
 }
 
 func TestLogs_OwnerScope_AdminSeesAllAndCanFilter(t *testing.T) {
 	fx := setupLogScopeTest(t)
 
-	if got := listLogEntries(t, fx.router, "/logs/cursor?limit=50", envAdminToken); len(got) != 4 {
-		t.Fatalf("admin unfiltered: %d entries, want 4", len(got))
+	if got := listLogEntries(t, fx.router, "/logs/cursor?limit=50", envAdminToken); len(got) != 6 {
+		t.Fatalf("admin unfiltered: %d entries, want 6", len(got))
 	}
+	// The admin owner filter uses the same disjunction, so it picks up alice's
+	// keyed rows and her chat row.
 	filtered := listLogEntries(t, fx.router, "/logs/cursor?limit=50&owner_user_id="+fx.aliceID, envAdminToken)
-	if len(filtered) != 2 {
-		t.Fatalf("admin owner filter: %d entries, want 2", len(filtered))
+	if len(filtered) != 3 {
+		t.Fatalf("admin owner filter: %d entries, want 3", len(filtered))
 	}
 	// A malformed owner filter is ignored, like the other lenient filters.
-	if got := listLogEntries(t, fx.router, "/logs/cursor?limit=50&owner_user_id=nonsense", envAdminToken); len(got) != 4 {
-		t.Fatalf("admin bogus owner filter: %d entries, want 4", len(got))
+	if got := listLogEntries(t, fx.router, "/logs/cursor?limit=50&owner_user_id=nonsense", envAdminToken); len(got) != 6 {
+		t.Fatalf("admin bogus owner filter: %d entries, want 6", len(got))
 	}
 }
 
@@ -139,11 +246,11 @@ func TestLogs_OwnerScope_CacheDoesNotLeakAcrossIdentities(t *testing.T) {
 	// Prime the offset-list cache as admin, then request the byte-identical
 	// query as a scoped user: the cache key carries the owner scope, so alice
 	// must not be served the admin's 4-row page.
-	if got := listLogEntries(t, fx.router, "/logs?per_page=50", envAdminToken); len(got) != 4 {
-		t.Fatalf("admin prime: %d entries, want 4", len(got))
+	if got := listLogEntries(t, fx.router, "/logs?per_page=50", envAdminToken); len(got) != 6 {
+		t.Fatalf("admin prime: %d entries, want 6", len(got))
 	}
-	if got := listLogEntries(t, fx.router, "/logs?per_page=50", fx.aliceToken); len(got) != 2 {
-		t.Fatalf("alice after admin prime: %d entries, want 2 (cache leak?)", len(got))
+	if got := listLogEntries(t, fx.router, "/logs?per_page=50", fx.aliceToken); len(got) != 3 {
+		t.Fatalf("alice after admin prime: %d entries, want 3 (cache leak?)", len(got))
 	}
 }
 
@@ -162,11 +269,11 @@ func TestStats_OwnerScope(t *testing.T) {
 		return s
 	}
 
-	// Alice sees only her own two requests; the by-key breakdown never names
-	// a foreign key.
+	// Alice sees her two keyed requests plus her own chat request; the by-key
+	// breakdown never names a foreign key.
 	s := getStats("/stats?period=7d", fx.aliceToken)
-	if s.TotalRequestsLast7d != 2 {
-		t.Errorf("alice total7d = %d, want 2", s.TotalRequestsLast7d)
+	if s.TotalRequestsLast7d != 3 {
+		t.Errorf("alice total7d = %d, want 3", s.TotalRequestsLast7d)
 	}
 	if _, leaked := s.ByVirtualKey["bob-key"]; leaked {
 		t.Error("alice by_virtual_key leaked bob-key")
@@ -175,12 +282,12 @@ func TestStats_OwnerScope(t *testing.T) {
 		t.Errorf("alice by_virtual_key[alice-key] = %d, want 2", s.ByVirtualKey["alice-key"])
 	}
 
-	// Admin is unscoped (4 rows incl. the unkeyed one) and can filter.
-	if s := getStats("/stats?period=7d", envAdminToken); s.TotalRequestsLast7d != 4 {
-		t.Errorf("admin total7d = %d, want 4", s.TotalRequestsLast7d)
+	// Admin is unscoped (6 rows incl. the ownerless keyless one) and can filter.
+	if s := getStats("/stats?period=7d", envAdminToken); s.TotalRequestsLast7d != 6 {
+		t.Errorf("admin total7d = %d, want 6", s.TotalRequestsLast7d)
 	}
-	if s := getStats("/stats?period=7d&owner_user_id="+fx.bobID, envAdminToken); s.TotalRequestsLast7d != 1 {
-		t.Errorf("admin owner-filtered total7d = %d, want 1", s.TotalRequestsLast7d)
+	if s := getStats("/stats?period=7d&owner_user_id="+fx.bobID, envAdminToken); s.TotalRequestsLast7d != 2 {
+		t.Errorf("admin owner-filtered total7d = %d, want 2", s.TotalRequestsLast7d)
 	}
 }
 
@@ -203,14 +310,14 @@ func TestStats_TimeSeries_OwnerScope(t *testing.T) {
 		return total
 	}
 
-	if got := sumCounts(fx.aliceToken, "/stats/timeseries"); got != 2 {
-		t.Errorf("alice timeseries total = %d, want 2", got)
+	if got := sumCounts(fx.aliceToken, "/stats/timeseries"); got != 3 {
+		t.Errorf("alice timeseries total = %d, want 3", got)
 	}
-	if got := sumCounts(envAdminToken, "/stats/timeseries"); got != 4 {
-		t.Errorf("admin timeseries total = %d, want 4", got)
+	if got := sumCounts(envAdminToken, "/stats/timeseries"); got != 6 {
+		t.Errorf("admin timeseries total = %d, want 6", got)
 	}
-	if got := sumCounts(envAdminToken, "/stats/timeseries?owner_user_id="+fx.aliceID); got != 2 {
-		t.Errorf("admin filtered timeseries total = %d, want 2", got)
+	if got := sumCounts(envAdminToken, "/stats/timeseries?owner_user_id="+fx.aliceID); got != 3 {
+		t.Errorf("admin filtered timeseries total = %d, want 3", got)
 	}
 
 	// The provider-distribution path applies the same scope (fixture rows have

--- a/internal/api/stats.go
+++ b/internal/api/stats.go
@@ -153,8 +153,12 @@ func vkScope(excludeDeleted bool) (join, filter string) {
 	return "", ""
 }
 
-// ownerFilterFragment returns a WHERE fragment restricting rows to virtual
-// keys owned by ownerID, or "" when unscoped (empty ownerID). The id is inlined
+// ownerFilterFragment returns a WHERE fragment restricting rows to traffic
+// belonging to ownerID, or "" when unscoped (empty ownerID). It matches the two
+// disjoint row shapes the same way appendLogFilters does: keyed rows through the
+// key's CURRENT owner (so reassigning a key moves its history), keyless rows
+// (dashboard chat/arena) through the request-time owner_user_id stamped on the
+// row itself; see migration 067. The id is inlined
 // as a literal because threading an extra bind arg through every stats query
 // would touch a dozen call sites, so this is the one place that must guarantee
 // the value can never carry SQL. Today the only caller feeds logOwnerScope,
@@ -172,7 +176,8 @@ func ownerFilterFragment(ownerID string) string {
 	if err != nil {
 		return " AND 1=0"
 	}
-	return " AND rl.virtual_key_id IN (SELECT vko.id FROM virtual_keys vko WHERE vko.owner_user_id = '" + u.String() + "')"
+	return " AND (rl.virtual_key_id IN (SELECT vko.id FROM virtual_keys vko WHERE vko.owner_user_id = '" + u.String() + "')" +
+		" OR (rl.virtual_key_id IS NULL AND rl.owner_user_id = '" + u.String() + "'))"
 }
 
 // metricValueSelect returns the aggregate column expression (aliased "val") for

--- a/internal/ctxkeys/keys.go
+++ b/internal/ctxkeys/keys.go
@@ -78,7 +78,9 @@ const VirtualKeyAllowedProvidersKey contextKey = "virtual_key_allowed_providers"
 // rate-limit middlewares derive the shared "user:<uuid>" bucket key from it so
 // one user's traffic aggregates across every surface and key they use, and the
 // proxy stamps it on request lifecycle SSE events so a non-admin's live log
-// feed can be scoped to their own activity.
+// feed can be scoped to their own activity. On surfaces with no virtual key it
+// is also persisted to request_logs.owner_user_id, the only owner a keyless row
+// can have (migration 067).
 //
 // Written by the same two middlewares as UserAllowedProvidersKey below: the
 // proxy's ProxyKeyMiddleware (from the virtual key's OWNER, absent when the key

--- a/internal/db/migrations/067_request_log_owner.sql
+++ b/internal/db/migrations/067_request_log_owner.sql
@@ -1,0 +1,35 @@
+-- Owner attribution for request_logs rows that have no virtual key.
+--
+-- Non-admin log and stats views scope rows by joining request_logs.virtual_key_id
+-- to virtual_keys.owner_user_id. Dashboard chat (/api/chat/chat, /arena,
+-- /completions) authenticates a session rather than a key, so those rows insert
+-- with virtual_key_id NULL and can never satisfy that join: a non-admin saw
+-- their own /v1 traffic but none of their own chat activity.
+--
+-- This column is written ONLY for keyless rows (internal/proxy/logging.go
+-- insertRequestLogAsync stores it when virtual_key_id would be NULL, and leaves
+-- it NULL otherwise). Keyed traffic deliberately keeps resolving through the
+-- key's CURRENT owner, because reassigning a key is meant to move its whole log
+-- history with it; a denormalized column would instead freeze ownership at
+-- request time. Those are different semantics, so the scope predicates became a
+-- disjunction over the two disjoint row shapes rather than switching everything
+-- to the column. A chat row has no key to reassign, so request-time attribution
+-- is the only meaning available for it and the two can never disagree.
+--
+-- ON DELETE SET NULL matches virtual_keys.owner_user_id (migration 051):
+-- deleting an account orphans its history rather than deleting it, and an
+-- orphaned row falls back to admin-only visibility.
+--
+-- No backfill: rows written before this column predate any stored owner and
+-- there is nothing reliable to recover one from, so they stay NULL and stay
+-- admin-only, which is where they have always been.
+ALTER TABLE request_logs ADD COLUMN IF NOT EXISTS
+    owner_user_id UUID REFERENCES users(id) ON DELETE SET NULL;
+
+-- Partial, mirroring idx_virtual_keys_owner (051): only the keyless minority of
+-- rows ever carries a value, so indexing the NULLs would be pure overhead on
+-- the busiest table in the schema. Note request_logs.virtual_key_id itself is
+-- deliberately unindexed, so the other half of the scope disjunction is not
+-- index-backed either.
+CREATE INDEX IF NOT EXISTS idx_request_logs_owner
+    ON request_logs (owner_user_id) WHERE owner_user_id IS NOT NULL;

--- a/internal/proxy/logging.go
+++ b/internal/proxy/logging.go
@@ -56,6 +56,7 @@ func (h *Handler) insertRequestLogAsync(logEntry *requestLogData) {
 	streaming := logEntry.streaming
 	virtualKeyName := logEntry.virtualKeyName
 	virtualKeyID := logEntry.virtualKeyID
+	ownerUserID := logEntry.ownerUserID
 	failoverAttempt := logEntry.failoverAttempt
 	state := logEntry.state
 	endpointType := logEntry.endpointType
@@ -78,10 +79,19 @@ func (h *Handler) insertRequestLogAsync(logEntry *requestLogData) {
 		if virtualKeyID != "" {
 			vkID = virtualKeyID
 		}
+		// owner_user_id is stored ONLY for keyless rows (dashboard chat/arena,
+		// which authenticate a session instead of a virtual key). A keyed row
+		// leaves it NULL and keeps resolving through the key's CURRENT owner, so
+		// reassigning a key still moves its whole log history; see migration 067
+		// for why the two row shapes are attributed differently.
+		var ownerID any
+		if vkID == nil && ownerUserID != "" {
+			ownerID = ownerUserID
+		}
 		_, err := h.dbPool.Exec(ctx, `
-			INSERT INTO request_logs (id, model_id, request_hash, streaming, virtual_key_name, virtual_key_id, failover_attempt, state, endpoint_type)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
-			id, modelID, requestHash, streaming, virtualKeyName, vkID, failoverAttempt, state, endpointType,
+			INSERT INTO request_logs (id, model_id, request_hash, streaming, virtual_key_name, virtual_key_id, failover_attempt, state, endpoint_type, owner_user_id)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+			id, modelID, requestHash, streaming, virtualKeyName, vkID, failoverAttempt, state, endpointType, ownerID,
 		)
 		if err != nil {
 			debuglog.Error("proxy: failed to insert initial request log", "request_id", id, "error", err)

--- a/internal/proxy/logging_test.go
+++ b/internal/proxy/logging_test.go
@@ -151,6 +151,68 @@ func TestInsertRequestLogAsync_EmptyVirtualKeyID(t *testing.T) {
 	// No panic = pass
 }
 
+// TestInsertRequestLogAsync_OwnerStoredOnlyForKeylessRows pins the attribution
+// split introduced by migration 067: a keyless row (dashboard chat/arena) is the
+// only shape that stores the request-time owner, because it has no virtual key
+// to resolve one through. A keyed row must leave the column NULL so its owner
+// keeps being read from the key's CURRENT owner and reassigning the key still
+// moves its whole log history.
+func TestInsertRequestLogAsync_OwnerStoredOnlyForKeylessRows(t *testing.T) {
+	h := newIntegrationHandler()
+	pool := testDB.Pool()
+	ctx := context.Background()
+
+	var ownerID string
+	err := pool.QueryRow(ctx,
+		`INSERT INTO users (username, password_hash) VALUES ($1, 'x') RETURNING id::text`,
+		"log-owner-"+uuid.NewString(),
+	).Scan(&ownerID)
+	if err != nil {
+		t.Fatalf("create owner user: %v", err)
+	}
+
+	storedOwner := func(logEntry *requestLogData) *string {
+		h.insertRequestLogAsync(logEntry)
+		h.WaitForInsert(logEntry)
+		var got *string
+		if err := pool.QueryRow(ctx,
+			`SELECT owner_user_id::text FROM request_logs WHERE id = $1`, logEntry.id,
+		).Scan(&got); err != nil {
+			t.Fatalf("read back row %s: %v", logEntry.id, err)
+		}
+		return got
+	}
+
+	keyless := storedOwner(&requestLogData{
+		modelID:     uuid.NewString(),
+		ownerUserID: ownerID,
+		state:       "pending",
+	})
+	if keyless == nil || *keyless != ownerID {
+		t.Errorf("keyless row owner_user_id = %v, want %q", keyless, ownerID)
+	}
+
+	keyed := storedOwner(&requestLogData{
+		modelID:        uuid.NewString(),
+		virtualKeyName: "some-key",
+		virtualKeyID:   uuid.NewString(),
+		ownerUserID:    ownerID,
+		state:          "pending",
+	})
+	if keyed != nil {
+		t.Errorf("keyed row owner_user_id = %q, want NULL", *keyed)
+	}
+
+	// No owner in context at all (env admin token, unowned key): still NULL.
+	anonymous := storedOwner(&requestLogData{
+		modelID: uuid.NewString(),
+		state:   "pending",
+	})
+	if anonymous != nil {
+		t.Errorf("unattributed row owner_user_id = %q, want NULL", *anonymous)
+	}
+}
+
 func TestInsertRequestLogAsync_ContextCanceled(t *testing.T) {
 	h := newIntegrationHandler()
 

--- a/internal/proxy/proxy_request.go
+++ b/internal/proxy/proxy_request.go
@@ -136,7 +136,9 @@ func (h *Handler) newPendingRequestLog(r *http.Request, endpointType, modelID st
 		vkHash, _ = v.(string)
 	}
 	// The owning user's UUID (empty for unowned keys) scopes the SSE request
-	// events to that user, matching the owner-scoping the logs REST API applies.
+	// events to that user, and is persisted on the log row itself when there is
+	// no virtual key to resolve an owner through (dashboard chat/arena), which is
+	// what lets the owner-scoped logs REST API see those rows at all.
 	var ownerUserID string
 	if v := r.Context().Value(ctxkeys.VirtualKeyOwnerIDKey); v != nil {
 		ownerUserID, _ = v.(string)

--- a/internal/proxy/types.go
+++ b/internal/proxy/types.go
@@ -128,9 +128,13 @@ type requestLogData struct {
 	streaming                 bool
 	virtualKeyName            string
 	virtualKeyID              string
-	ownerUserID               string // owning dashboard user's UUID; "" for unowned keys (admin-only visibility)
-	errorMessage              string
-	errorKind                 ErrorKind // machine-readable classification; "" = unclassified (NULL in DB)
+	// ownerUserID is the owning dashboard user's UUID; "" for unowned keys
+	// (admin-only visibility). Persisted to request_logs.owner_user_id only when
+	// there is no virtual key (migration 067); keyed rows resolve their owner
+	// through the key instead.
+	ownerUserID  string
+	errorMessage string
+	errorKind    ErrorKind // machine-readable classification; "" = unclassified (NULL in DB)
 	// upstreamKind is what the PROVIDER said, kept apart from errorKind because
 	// errorKind records how the request ended and later causes overwrite earlier
 	// ones. A client that hangs up on receiving an in-stream error turns the


### PR DESCRIPTION
## What

Dashboard chat requests never appeared in the owner-scoped logs or stats views. A non-admin could see their `/v1` traffic but not their own chat activity.

The non-admin scope predicate joins through the virtual key:

```sql
AND rl.virtual_key_id IN (SELECT vko.id FROM virtual_keys vko WHERE vko.owner_user_id = $n)
```

Admin-chat rows insert with `virtual_key_id` NULL, because that surface has no virtual key. No amount of request context can satisfy a predicate that requires one.

## How

Migration 067 adds `request_logs.owner_user_id`, populated **only for keyless rows**. Keyed rows keep it NULL and keep resolving through the existing subquery. The three predicates become a disjunction:

```sql
AND (rl.virtual_key_id IN (SELECT ... WHERE vko.owner_user_id = $n)
     OR (rl.virtual_key_id IS NULL AND rl.owner_user_id = $n))
```

## Why it is scoped that way

Keyed traffic resolves through the key's **current** owner, so reassigning a key moves its whole log history to the new owner. A denormalized column would freeze ownership at request time. Those are different semantics, and switching keyed traffic to the column would change what non-admins see for traffic unrelated to this fix.

Chat rows have no key to reassign, so request-time attribution is the only meaning available for them, and the two readings cannot disagree.

Historical chat rows are not backfilled. They predate the column and there is no reliable owner to recover, so they stay NULL and remain admin-only, which is where they have always been.

## Index

`request_logs.virtual_key_id` has no index at all, so there was nothing to mirror. The new column follows `idx_virtual_keys_owner` instead: partial, `WHERE owner_user_id IS NOT NULL`, which suits a column only keyless rows ever populate. The migration comment records that the other half of the disjunction is not index-backed.

## Verification

Go 6534 tests across 33 packages, `golangci-lint` 0 issues, build clean.

Vacuity proven both directions: reverting the insert gate fails the proxy test with `keyless row owner_user_id = <nil>`, and reverting the three predicates fails 7 of 8 API tests.

Driven live on a rebuilt dev stack with three users and four keys: each non-admin sees their own key traffic plus their own chat, arena and completions rows; alice and bob have zero row overlap; the admin sees everything. The key-reassignment regression test confirms keyed history still follows the current owner.

Also corrects five comments that described this owner id as SSE-only, including one asserting keyless rows are "invisible by construction" — true when written, made false by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)