### PR TITLE
fix: logout CSRF, backup download race, and SSE re-authentication

### DIFF
--- a/frontdesk/web/pnpm-lock.yaml
+++ b/frontdesk/web/pnpm-lock.yaml
@@ -837,9 +837,9 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   browserslist@4.28.4:
     resolution: {integrity: sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==}
@@ -2633,7 +2633,7 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -3124,7 +3124,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.9
 
   ms@2.1.3: {}
 

--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -408,65 +408,87 @@ func (h *Handler) registerAdminOnly(r chi.Router) {
 	NewFleetHandler(h.settingsRepo).Register(r)
 }
 
+// resolveCredentials authenticates the request and returns the caller's
+// identity. cookieAuth reports that the identity came from the session cookie,
+// the only ambient-credential path and therefore the only one needing a CSRF
+// check; the caller applies that check because only it can answer with a 403.
+//
+// Shared by AuthMiddleware and by the long-lived SSE stream, which re-runs it
+// mid-connection so a revoked session or changed grants take effect without
+// waiting for the client to disconnect. Purely a lookup: it writes nothing and
+// has no side effects, so it is safe to call repeatedly.
+func (h *Handler) resolveCredentials(r *http.Request) (id *user.Identity, cookieAuth, ok bool) {
+	// Cookie path (browser). The session token rides an HttpOnly cookie. This
+	// branch is additive: an invalid/expired cookie falls through to the header
+	// logic below, and header (admin-token / bearer) callers are unaffected.
+	if tok, found := authcookie.SessionToken(r); found && h.webauthnSessionMgr != nil {
+		if sessionUserID, valid := h.webauthnSessionMgr.TokenUser(r.Context(), tok); valid {
+			if id, resolved := h.resolveIdentity(r.Context(), sessionUserID); resolved {
+				return id, true, true
+			}
+		}
+		// Invalid/expired cookie: fall through to header logic.
+	}
+
+	token, found := util.ParseBearerToken(r)
+	if !found {
+		return nil, false, false
+	}
+
+	// Fast path: admin token (in-memory hash comparison) -- only when TOTP
+	// 2FA is disabled. With TOTP enabled, the raw admin token is a first
+	// factor only and must be exchanged for a session token via POST
+	// /api/totp/login; a bare admin token bearer is rejected so the second
+	// factor cannot be bypassed.
+	if !h.TotpEnabled() && h.adminMgr.Validate(token) {
+		return user.AdminIdentity(), false, true
+	}
+
+	// Fallback: session token (DB-backed SHA-256 hash lookup). The session's
+	// user handle resolves to an identity: legacy admin sessions stay admin,
+	// UUID handles must match an enabled users row (disabled/deleted users
+	// are rejected here even if their token has not been revoked yet).
+	if h.webauthnSessionMgr != nil {
+		if sessionUserID, valid := h.webauthnSessionMgr.TokenUser(r.Context(), token); valid {
+			if id, resolved := h.resolveIdentity(r.Context(), sessionUserID); resolved {
+				return id, false, true
+			}
+		}
+	}
+
+	return nil, false, false
+}
+
 // AuthMiddleware validates admin token or webAuthn session token authentication.
 // Admin token has priority (fast in-memory hash comparison).
 // If the admin token is invalid, the session-based token is tried as a fallback.
 func (h *Handler) AuthMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Cookie path (browser). The session token rides an HttpOnly cookie;
-		// unsafe methods must also present a matching CSRF header. This branch
-		// is additive: an invalid/expired cookie falls through to the header
-		// logic below, and header (admin-token / bearer) callers are unaffected.
-		if tok, ok := authcookie.SessionToken(r); ok && h.webauthnSessionMgr != nil {
-			if sessionUserID, ok := h.webauthnSessionMgr.TokenUser(r.Context(), tok); ok {
-				if id, ok := h.resolveIdentity(r.Context(), sessionUserID); ok {
-					if !authcookie.IsSafeMethod(r.Method) && !authcookie.ValidCSRF(r) {
-						debuglog.Warn("auth: CSRF check failed", "remote_addr", r.RemoteAddr, "path", r.URL.Path)
-						http.Error(w, "CSRF token missing or invalid", http.StatusForbidden)
-						return
-					}
-					next.ServeHTTP(w, r.WithContext(user.WithIdentity(r.Context(), id)))
-					return
-				}
-			}
-			// Invalid/expired cookie: fall through to header logic.
-		}
-
-		token, ok := util.ParseBearerToken(r)
+		id, cookieAuth, ok := h.resolveCredentials(r)
 		if !ok {
 			// Warn (not Error) with the remote address — never the token — so
 			// repeated admin-auth failures are visible for abuse detection
 			// without polluting the operator-actionable Error stream.
-			debuglog.Warn("auth: admin request missing bearer token", "remote_addr", r.RemoteAddr, "path", r.URL.Path)
-			http.Error(w, "Authorization header required (Bearer token)", http.StatusUnauthorized)
-			return
-		}
-
-		// Fast path: admin token (in-memory hash comparison) -- only when TOTP
-		// 2FA is disabled. With TOTP enabled, the raw admin token is a first
-		// factor only and must be exchanged for a session token via POST
-		// /api/totp/login; a bare admin token bearer is rejected so the second
-		// factor cannot be bypassed.
-		if !h.TotpEnabled() && h.adminMgr.Validate(token) {
-			next.ServeHTTP(w, r.WithContext(user.WithIdentity(r.Context(), user.AdminIdentity())))
-			return
-		}
-
-		// Fallback: session token (DB-backed SHA-256 hash lookup). The session's
-		// user handle resolves to an identity: legacy admin sessions stay admin,
-		// UUID handles must match an enabled users row (disabled/deleted users
-		// are rejected here even if their token has not been revoked yet).
-		if h.webauthnSessionMgr != nil {
-			if sessionUserID, ok := h.webauthnSessionMgr.TokenUser(r.Context(), token); ok {
-				if id, ok := h.resolveIdentity(r.Context(), sessionUserID); ok {
-					next.ServeHTTP(w, r.WithContext(user.WithIdentity(r.Context(), id)))
-					return
-				}
+			if _, hasBearer := util.ParseBearerToken(r); !hasBearer {
+				debuglog.Warn("auth: admin request missing bearer token", "remote_addr", r.RemoteAddr, "path", r.URL.Path)
+				http.Error(w, "Authorization header required (Bearer token)", http.StatusUnauthorized)
+				return
 			}
+			debuglog.Warn("auth: admin request with invalid token", "remote_addr", r.RemoteAddr, "path", r.URL.Path)
+			http.Error(w, "Invalid admin token", http.StatusUnauthorized)
+			return
 		}
 
-		debuglog.Warn("auth: admin request with invalid token", "remote_addr", r.RemoteAddr, "path", r.URL.Path)
-		http.Error(w, "Invalid admin token", http.StatusUnauthorized)
+		// Cookie-authenticated unsafe methods must also present a matching CSRF
+		// header. Bearer callers are exempt: an explicit header is not a
+		// credential the browser attaches on its own.
+		if cookieAuth && !authcookie.IsSafeMethod(r.Method) && !authcookie.ValidCSRF(r) {
+			debuglog.Warn("auth: CSRF check failed", "remote_addr", r.RemoteAddr, "path", r.URL.Path)
+			http.Error(w, "CSRF token missing or invalid", http.StatusForbidden)
+			return
+		}
+
+		next.ServeHTTP(w, r.WithContext(user.WithIdentity(r.Context(), id)))
 	})
 }
 

--- a/internal/api/auth_logout.go
+++ b/internal/api/auth_logout.go
@@ -11,6 +11,19 @@ import (
 // Always mounted, unlike the passkey-gated /webauthn/logout, so the dashboard
 // can log out regardless of whether WebAuthn is configured. Safe unauthenticated:
 // it only revokes the token the caller presents and clears the caller's own cookies.
+//
+// Credential-gated against forced-logout CSRF. A cross-site POST cannot carry
+// either auth cookie (both are SameSite=Strict) nor an Authorization header, so
+// it arrives here bare; emitting Set-Cookie deletions unconditionally would let
+// any third-party page log the victim out. Requests with no credential at all
+// therefore get a success answer with no cookie headers - there is nothing to
+// log out. Same-site logout is unaffected, including an already-revoked or
+// otherwise invalid session, because the cookies still ride along.
+//
+// Deliberately not gated on the CSRF double-submit header instead: SameSite
+// strips the CSRF cookie from a cross-site request too, so the server cannot
+// tell "no session" from "cross-site", and requiring the header would break
+// bearer-token callers that never have one.
 func (h *Handler) AuthLogout(w http.ResponseWriter, r *http.Request) {
 	tok, ok := authcookie.SessionToken(r)
 	if !ok {
@@ -21,7 +34,16 @@ func (h *Handler) AuthLogout(w http.ResponseWriter, r *http.Request) {
 		h.webauthnSessionMgr.RevokeAuthToken(r.Context(), tok)
 	}
 
-	authcookie.ClearSession(w, authcookie.Secure(r, h.cfg.CookieSecure))
+	// A stray CSRF cookie with no session still counts as the caller's own
+	// state, so clear on either cookie rather than only on a full session.
+	// Non-empty, matching SessionToken's treatment of the session cookie: a
+	// bare "mh_csrf=" carries no state and must not stand in for a credential.
+	csrf, err := r.Cookie(authcookie.CSRFCookie)
+	csrfPresent := err == nil && csrf.Value != ""
+
+	if ok || csrfPresent {
+		authcookie.ClearSession(w, authcookie.Secure(r, h.cfg.CookieSecure))
+	}
 
 	writeJSON(w, map[string]bool{"success": true})
 }

--- a/internal/api/auth_logout_test.go
+++ b/internal/api/auth_logout_test.go
@@ -86,7 +86,11 @@ func TestAuthLogout_BearerToken_ClearsCookieAndRevokes(t *testing.T) {
 	}
 }
 
-func TestAuthLogout_NoToken_StillClearsCookieIdempotently(t *testing.T) {
+// A bare POST is what a forced-logout CSRF looks like from the server's side:
+// SameSite=Strict keeps both auth cookies off a cross-site request, so there is
+// no credential to act on. Answering 200 without any Set-Cookie leaves the
+// victim's cookie jar untouched.
+func TestAuthLogout_NoCredentials_DoesNotClearCookies(t *testing.T) {
 	var called bool
 	h := logoutHandler(t, nil, &called)
 
@@ -101,9 +105,32 @@ func TestAuthLogout_NoToken_StillClearsCookieIdempotently(t *testing.T) {
 	if called {
 		t.Error("RevokeAuthToken should not be called when no token is presented")
 	}
+	if got := rec.Result().Header.Values("Set-Cookie"); len(got) != 0 {
+		t.Errorf("Set-Cookie = %v, want none (a credential-less request must not expire the caller's cookies)", got)
+	}
+}
+
+// A CSRF cookie without a session is leftover same-site state (only a same-site
+// request can present it at all), so logout still clears it.
+func TestAuthLogout_CSRFCookieOnly_ClearsCookies(t *testing.T) {
+	var called bool
+	h := logoutHandler(t, nil, &called)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/logout", http.NoBody)
+	req.AddCookie(&http.Cookie{Name: authcookie.CSRFCookie, Value: "csrf-tok"})
+	rec := httptest.NewRecorder()
+
+	h.AuthLogout(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("logout = %d, want 200 (%s)", rec.Code, rec.Body.String())
+	}
+	if called {
+		t.Error("RevokeAuthToken should not be called when no session token is presented")
+	}
 	c := cookieByName(rec, authcookie.SessionCookie)
 	if c == nil {
-		t.Fatal("expected an mh_session cookie clear even with no token (idempotent)")
+		t.Fatal("expected an mh_session cookie clear alongside the stray CSRF cookie")
 	}
 	if c.MaxAge >= 0 {
 		t.Errorf("session cookie MaxAge = %d, want negative (expiring)", c.MaxAge)

--- a/internal/api/backup.go
+++ b/internal/api/backup.go
@@ -211,6 +211,16 @@ func (h *BackupHandler) validateBackupFilename(filename string) string {
 }
 
 // DownloadBackup serves a backup file for download.
+//
+// Opens the file up front and serves from that handle rather than stat-ing the
+// path and letting http.ServeFile reopen it. A stat-then-open pair races the
+// delete and retention-prune paths: the file can vanish between the two checks
+// and the client gets a truncated or failed transfer. Holding an open
+// descriptor removes the window - an unlink during the transfer leaves this
+// handle readable until it is closed. Deliberately does NOT take backupMu:
+// downloads are long-lived, and the create/restore/prune paths TryLock and give
+// up when busy, so a slow client would silently cancel scheduled backups for
+// the length of its transfer.
 func (h *BackupHandler) DownloadBackup(w http.ResponseWriter, r *http.Request) {
 	filename := chi.URLParam(r, "filename")
 
@@ -220,8 +230,23 @@ func (h *BackupHandler) DownloadBackup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if _, err := os.Stat(absPath); os.IsNotExist(err) {
+	//nolint:gosec // G304: absPath is validated above - a bare .dump basename resolved under backupDir
+	f, err := os.Open(absPath)
+	if os.IsNotExist(err) {
 		http.Error(w, "backup not found", http.StatusNotFound)
+		return
+	} else if err != nil {
+		respondError(w, fmt.Sprintf("failed to open backup %q", filename), err, http.StatusInternalServerError)
+		return
+	}
+	defer func() { _ = f.Close() }()
+
+	// ServeContent needs a size and modtime for Content-Length and conditional
+	// requests; take them from the open handle so they describe the bytes about
+	// to be sent rather than whatever the path points at now.
+	info, err := f.Stat()
+	if err != nil {
+		respondError(w, fmt.Sprintf("failed to stat backup %q", filename), err, http.StatusInternalServerError)
 		return
 	}
 
@@ -229,7 +254,7 @@ func (h *BackupHandler) DownloadBackup(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename=%q`, filename))
 	w.Header().Set("Content-Type", "application/octet-stream")
-	http.ServeFile(w, r, absPath)
+	http.ServeContent(w, r, filename, info.ModTime(), f)
 }
 
 // buildDumpCommand creates a pg_dump command with the password stripped from

--- a/internal/api/backup_test.go
+++ b/internal/api/backup_test.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -9,7 +11,9 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 )
@@ -113,6 +117,81 @@ func TestBackupHandler_DownloadBackup(t *testing.T) {
 	if cd := w.Header().Get("Content-Disposition"); cd != `attachment; filename="backup_test.dump"` {
 		t.Errorf("expected Content-Disposition header, got %q", cd)
 	}
+}
+
+// blockingWriter stalls the response body write until release is closed, so a
+// test can inspect handler state mid-transfer.
+type blockingWriter struct {
+	hdr      http.Header
+	started  chan struct{}
+	release  chan struct{}
+	once     sync.Once
+	body     bytes.Buffer
+	code     int
+	codeOnce sync.Once
+}
+
+func newBlockingWriter() *blockingWriter {
+	return &blockingWriter{
+		hdr:     http.Header{},
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+		code:    http.StatusOK,
+	}
+}
+
+func (b *blockingWriter) Header() http.Header { return b.hdr }
+
+func (b *blockingWriter) WriteHeader(code int) {
+	b.codeOnce.Do(func() { b.code = code })
+}
+
+func (b *blockingWriter) Write(p []byte) (int, error) {
+	b.once.Do(func() { close(b.started) })
+	<-b.release
+	return b.body.Write(p)
+}
+
+// A download must not hold backupMu. The create, restore and retention-prune
+// paths all TryLock and abandon their run when the lock is taken, so a download
+// that held it would silently cancel scheduled backups for as long as a slow
+// client took to pull the file down.
+func TestBackupHandler_DownloadBackup_DoesNotHoldBackupMutex(t *testing.T) {
+	dir := t.TempDir()
+	h := NewBackupHandler("postgres://invalid:invalid@127.0.0.1:1/nonexistent", dir, &mockAdminAuth{}, nil)
+
+	//nolint:gosec // test-only: permissive perms acceptable
+	if err := os.WriteFile(filepath.Join(dir, "backup_test.dump"), []byte("payload"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest("GET", "/backup_test.dump", http.NoBody)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("filename", "backup_test.dump")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	w := newBlockingWriter()
+	done := make(chan struct{})
+	go func() {
+		h.DownloadBackup(w, req)
+		close(done)
+	}()
+
+	select {
+	case <-w.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("download never began writing")
+	}
+
+	if !h.backupMu.TryLock() {
+		close(w.release)
+		<-done
+		t.Fatal("backupMu is held during a download; a slow client would block scheduled backups")
+	}
+	h.backupMu.Unlock()
+
+	close(w.release)
+	<-done
 }
 
 func TestBackupHandler_DownloadBackup_NotFound(t *testing.T) {

--- a/internal/api/events.go
+++ b/internal/api/events.go
@@ -7,10 +7,28 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hugalafutro/model-hotel/internal/debuglog"
 	"github.com/hugalafutro/model-hotel/internal/events"
 	"github.com/hugalafutro/model-hotel/internal/user"
 	"github.com/hugalafutro/model-hotel/internal/util"
 )
+
+// sseHeartbeatInterval is how often an idle SSE stream emits a keepalive
+// comment, and therefore also how often the caller's credentials are re-checked.
+const sseHeartbeatInterval = 30 * time.Second
+
+// sseReauthFailuresBeforeClose is how many consecutive failed credential
+// re-checks close a stream, bounding authorization staleness at
+// sseHeartbeatInterval * this.
+//
+// Tolerance rather than fail-fast because resolveCredentials cannot distinguish
+// "this session was revoked" from "the store could not be asked": both surface
+// as a plain false. A revoked session fails every check and is dropped on the
+// second, while a transient store failure (Postgres restart, pool exhaustion)
+// recovers on the next tick. Failing on the first miss would turn a brief
+// outage into a fleet-wide forced logout, since the dashboard's SSE reconnect
+// treats a 401 as "session gone" and reloads to the login screen.
+const sseReauthFailuresBeforeClose = 2
 
 // eventVisible decides whether one bus event may be forwarded to the caller.
 // The bus itself is identity-blind, so the SSE handler filters per subscriber:
@@ -49,7 +67,54 @@ func eventOwnedBy(id *user.Identity, ev events.Event) bool {
 }
 
 // StreamEvents handles server-sent events for real-time dashboard updates.
+//
+// The caller's identity is re-checked on every heartbeat rather than pinned at
+// connect. AuthMiddleware only runs once, so a stream opened before a session
+// was revoked, or before a user was disabled or had a grant taken away, would
+// otherwise keep delivering events under its connect-time permissions for as
+// long as the client held the socket open - unbounded, since the heartbeat
+// keeps it alive. Re-resolving costs one session lookup per stream per
+// heartbeat interval; once the credential stops resolving the stream closes and
+// the client's normal SSE reconnect then fails at the middleware.
 func (h *Handler) StreamEvents(w http.ResponseWriter, r *http.Request) {
+	h.streamEvents(w, r, sseHeartbeatInterval)
+}
+
+// reauthLoop re-resolves the caller's credentials on every tick and reports the
+// result on out: the refreshed identity, or nil when the credentials did not
+// resolve. Exits when the request context is cancelled.
+//
+// Runs off the read loop deliberately. resolveCredentials makes a session-store
+// round-trip (plus a users lookup for a UUID handle), and the event bus drops
+// events for any subscriber that is not draining its channel
+// (internal/events/bus.go), so doing this inline would trade a slow credential
+// lookup for lost live log rows on a busy gateway.
+func (h *Handler) reauthLoop(r *http.Request, every time.Duration, out chan<- *user.Identity) {
+	ticker := time.NewTicker(every)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-ticker.C:
+			id, _, ok := h.resolveCredentials(r)
+			if !ok {
+				id = nil
+			}
+			select {
+			case out <- id:
+			case <-r.Context().Done():
+				return
+			}
+		}
+	}
+}
+
+// streamEvents is StreamEvents with the heartbeat cadence supplied by the
+// caller, so the keepalive/re-auth tick can be driven without waiting out the
+// production interval.
+func (h *Handler) streamEvents(w http.ResponseWriter, r *http.Request, heartbeatEvery time.Duration) {
 	identity := user.IdentityFrom(r.Context())
 	flusher, ok := w.(http.Flusher)
 	if !ok {
@@ -69,9 +134,12 @@ func (h *Handler) StreamEvents(w http.ResponseWriter, r *http.Request) {
 	ch := events.DefaultBus.Subscribe()
 	defer events.DefaultBus.Unsubscribe(ch)
 
-	heartbeat := time.NewTicker(30 * time.Second)
-	defer heartbeat.Stop()
+	// Buffered so a re-auth result never parks its goroutine while this loop is
+	// busy writing an event; the loop drains it on the next pass.
+	reauth := make(chan *user.Identity, 1)
+	go h.reauthLoop(r, heartbeatEvery, reauth)
 
+	failures := 0
 	for {
 		select {
 		case <-r.Context().Done():
@@ -86,7 +154,21 @@ func (h *Handler) StreamEvents(w http.ResponseWriter, r *http.Request) {
 			}
 			_, _ = fmt.Fprintf(w, "data: %s\n\n", data)
 			flusher.Flush()
-		case <-heartbeat.C:
+		case id := <-reauth:
+			// A re-auth result doubles as the keepalive tick. nil means the
+			// credentials did not resolve; a live one refreshes the identity, so
+			// a user who lost a grant stops seeing what it no longer covers.
+			if id == nil {
+				failures++
+				if failures >= sseReauthFailuresBeforeClose {
+					debuglog.Info("events: stream closed, credentials no longer valid",
+						"remote_addr", r.RemoteAddr, "consecutive_failures", failures)
+					return
+				}
+			} else {
+				failures = 0
+				identity = id
+			}
 			_, _ = fmt.Fprint(w, ": heartbeat\n\n")
 			flusher.Flush()
 		}

--- a/internal/api/events_reauth_test.go
+++ b/internal/api/events_reauth_test.go
@@ -1,0 +1,278 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/hugalafutro/model-hotel/internal/authcookie"
+	"github.com/hugalafutro/model-hotel/internal/events"
+	"github.com/hugalafutro/model-hotel/internal/user"
+)
+
+// revocableSessionMgr is a session manager whose tokens stop resolving once
+// revoke() is called, standing in for an operator revoking a session (or
+// disabling the user behind it) while a stream is open.
+type revocableSessionMgr struct {
+	mu      sync.Mutex
+	revoked bool
+}
+
+func (m *revocableSessionMgr) revoke() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.revoked = true
+}
+
+func (m *revocableSessionMgr) CreateAuthToken(_ context.Context, _, _ []byte) (string, error) {
+	return "stream-token", nil
+}
+
+func (m *revocableSessionMgr) Validate(_ context.Context, _ string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return !m.revoked
+}
+
+func (m *revocableSessionMgr) TokenUser(ctx context.Context, token string) ([]byte, bool) {
+	if m.Validate(ctx, token) {
+		return []byte("admin"), true
+	}
+	return nil, false
+}
+
+func (m *revocableSessionMgr) RevokeAuthToken(_ context.Context, _ string) bool { return true }
+
+// streamRequest builds a cookie-authenticated SSE request carrying an admin
+// identity, as AuthMiddleware would have left it at connect time.
+func streamRequest(ctx context.Context) *http.Request {
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/events", http.NoBody)
+	req.AddCookie(&http.Cookie{Name: authcookie.SessionCookie, Value: "stream-token"})
+	return req.WithContext(user.WithIdentity(req.Context(), user.AdminIdentity()))
+}
+
+// A session revoked after the stream opened must not keep the stream alive:
+// the next heartbeat re-checks the credential and closes the connection.
+func TestStreamEvents_ClosesWhenSessionRevokedMidStream(t *testing.T) {
+	mgr := &revocableSessionMgr{}
+	h := testHandler(nil, nil, nil, nil, nil)
+	h.SetWebAuthnSessionManager(mgr)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	rec := httptest.NewRecorder()
+	done := make(chan struct{})
+	go func() {
+		h.streamEvents(rec, streamRequest(ctx), 10*time.Millisecond)
+		close(done)
+	}()
+
+	// Let a few heartbeats land while the session is still good, proving the
+	// re-check does not close a valid stream.
+	time.Sleep(60 * time.Millisecond)
+	select {
+	case <-done:
+		t.Fatal("stream closed while the session was still valid")
+	default:
+	}
+
+	mgr.revoke()
+
+	select {
+	case <-done:
+	case <-ctx.Done():
+		t.Fatal("stream stayed open after its session was revoked")
+	}
+
+	if body := rec.Body.String(); !strings.Contains(body, ": heartbeat") {
+		t.Errorf("expected at least one heartbeat before revocation, got: %q", body)
+	}
+}
+
+// syncRecorder is a ResponseWriter whose body can be read while the handler is
+// still writing, so a test can assert on a live stream rather than only after
+// it closes.
+type syncRecorder struct {
+	mu      sync.Mutex
+	hdr     http.Header
+	body    strings.Builder
+	flushed chan struct{}
+	once    sync.Once
+}
+
+func newSyncRecorder() *syncRecorder {
+	return &syncRecorder{hdr: http.Header{}, flushed: make(chan struct{})}
+}
+
+func (s *syncRecorder) Header() http.Header { return s.hdr }
+func (s *syncRecorder) WriteHeader(_ int)   {}
+func (s *syncRecorder) Flush()              { s.once.Do(func() { close(s.flushed) }) }
+
+func (s *syncRecorder) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.body.Write(p)
+}
+
+func (s *syncRecorder) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.body.String()
+}
+
+// uuidSessionMgr resolves its token to a fixed users-table handle, the shape a
+// multi-user (non-admin) session carries.
+type uuidSessionMgr struct{ id uuid.UUID }
+
+func (m *uuidSessionMgr) CreateAuthToken(_ context.Context, _, _ []byte) (string, error) {
+	return "stream-token", nil
+}
+func (m *uuidSessionMgr) Validate(_ context.Context, _ string) bool { return true }
+func (m *uuidSessionMgr) TokenUser(_ context.Context, _ string) ([]byte, bool) {
+	return []byte(m.id.String()), true
+}
+func (m *uuidSessionMgr) RevokeAuthToken(_ context.Context, _ string) bool { return true }
+
+// mutableUserStore serves one user whose grants a test can change mid-stream,
+// standing in for an operator editing the account while a stream is open.
+type mutableUserStore struct {
+	mu sync.Mutex
+	u  *user.User
+}
+
+func (s *mutableUserStore) setGrants(g []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.u.Grants = g
+}
+
+func (s *mutableUserStore) Get(_ context.Context, id uuid.UUID) (*user.User, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if id != s.u.ID {
+		return nil, errors.New("user not found")
+	}
+	clone := *s.u
+	clone.Grants = append([]string(nil), s.u.Grants...)
+	return &clone, nil
+}
+
+func (s *mutableUserStore) List(context.Context) ([]*user.User, error) { return nil, nil }
+func (s *mutableUserStore) Create(context.Context, string, string, *string, string, user.Role, []string, user.Limits, *[]string) (*user.User, error) {
+	return nil, nil
+}
+func (s *mutableUserStore) Update(context.Context, uuid.UUID, string, string, *string, user.Role, []string, bool, user.Limits, *[]string) (*user.User, error) {
+	return nil, nil
+}
+func (s *mutableUserStore) SetPassword(context.Context, uuid.UUID, string) error { return nil }
+func (s *mutableUserStore) Delete(context.Context, uuid.UUID) error              { return nil }
+
+// Stripping a grant from a user who already holds an open stream must take
+// effect on that stream: the re-check refreshes the identity, so request events
+// the user can no longer read over REST stop arriving over SSE too. Without the
+// identity refresh the stream keeps delivering under its connect-time grants
+// for as long as the client holds the socket.
+func TestStreamEvents_RefreshesGrantsMidStream(t *testing.T) {
+	uid := uuid.New()
+	store := &mutableUserStore{u: &user.User{
+		ID: uid, Username: "streamer", Role: user.RoleUser,
+		Grants: []string{string(user.GrantLogs)}, Enabled: true,
+	}}
+
+	h := testHandler(nil, nil, nil, nil, nil)
+	h.SetWebAuthnSessionManager(&uuidSessionMgr{id: uid})
+	h.SetUserAuth(store, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/events", http.NoBody)
+	req.AddCookie(&http.Cookie{Name: authcookie.SessionCookie, Value: "stream-token"})
+	req = req.WithContext(user.WithIdentity(req.Context(),
+		&user.Identity{Role: user.RoleUser, Grants: []string{string(user.GrantLogs)}, UserID: &uid}))
+
+	rec := newSyncRecorder()
+	done := make(chan struct{})
+	go func() {
+		h.streamEvents(rec, req, 20*time.Millisecond)
+		close(done)
+	}()
+	<-rec.flushed
+
+	// The event is owned by this user, so the logs grant makes it visible.
+	owned := events.Event{
+		Type: "request.completed", Severity: "info", Source: "proxy",
+		Metadata: map[string]any{"owner_user_id": uid.String()},
+	}
+
+	events.Publish(owned)
+	if !waitFor(t, func() bool { return strings.Contains(rec.String(), "request.completed") }) {
+		t.Fatalf("event never reached the stream while the grant was held: %q", rec.String())
+	}
+
+	// Operator strips the logs grant; the next re-check must pick it up.
+	store.setGrants(nil)
+	baseline := len(rec.String())
+	if !waitFor(t, func() bool { return strings.Count(rec.String(), ": heartbeat") >= 2 }) {
+		t.Fatal("no re-check happened after the grant was stripped")
+	}
+
+	events.Publish(owned)
+	time.Sleep(100 * time.Millisecond)
+	delivered := rec.String()[baseline:]
+	if strings.Contains(delivered, "request.completed") {
+		t.Errorf("stream kept delivering request events after the logs grant was revoked: %q", delivered)
+	}
+
+	cancel()
+	<-done
+}
+
+// waitFor polls cond until it holds or a generous deadline passes, so the
+// timing-sensitive stream assertions do not depend on a fixed sleep.
+func waitFor(t *testing.T, cond func() bool) bool {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return false
+}
+
+// A bearer-authenticated stream is re-checked on the same tick. The admin token
+// is validated in memory, so a stream on a still-valid token stays open.
+func TestStreamEvents_ValidBearerStreamSurvivesHeartbeats(t *testing.T) {
+	h := testHandler(nil, nil, nil, &mockAdminAuth{
+		validateFn: func(token string) bool { return token == "test-admin-token" },
+	}, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	defer cancel()
+
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/events", http.NoBody)
+	req.Header.Set("Authorization", "Bearer test-admin-token")
+	req = req.WithContext(user.WithIdentity(req.Context(), user.AdminIdentity()))
+
+	rec := httptest.NewRecorder()
+	h.streamEvents(rec, req, 10*time.Millisecond)
+
+	// The handler only returns when the context expires, never earlier, so a
+	// heartbeat re-check never rejected the still-valid admin token.
+	if ctx.Err() == nil {
+		t.Fatal("stream closed before its context expired, so a valid bearer token was rejected")
+	}
+	if body := rec.Body.String(); !strings.Contains(body, ": heartbeat") {
+		t.Errorf("expected heartbeats on a long-lived valid stream, got: %q", body)
+	}
+}


### PR DESCRIPTION
Works through a batch of security recommendations. Three were real and are fixed here; one was rejected after checking the premise, and one turned out to already be handled.

## Fixed

**Forced-logout CSRF on the main server.** `POST /api/auth/logout` sits in the auth-exempt group (logout has to work for an already-invalid session) and emitted `Set-Cookie` deletions unconditionally, so any third-party page could log a victim out with a bare cross-site POST. The clear is now gated on the caller presenting a credential; both cookies are `SameSite=Strict`, so a cross-site request arrives bare and gets a 200 that touches nothing.

Note this is *not* fixed by adding the CSRF header check, which is what the recommendation asked for. SameSite strips the CSRF cookie from a cross-site request too, so the server cannot tell "no session" from "cross-site", and requiring the header would break bearer-token callers that never have one.

**Backup download race.** `DownloadBackup` stat-ed the path then handed it to `http.ServeFile`, which reopens it; a delete or prune in between truncates the transfer. It now opens once and serves from that descriptor.

Also not fixed the way it was suggested. Taking `backupMu` would be a regression: create, restore and prune all `TryLock` and abandon their run when the lock is held, so one slow download would silently cancel scheduled backups for the length of its transfer. There is a test that blocks the response mid-write and asserts the mutex is free.

**SSE streams never re-authenticated.** `AuthMiddleware` runs once per connection, so a stream opened before a revocation kept its connect-time permissions for as long as the client held the socket, and the heartbeat keeps that socket alive indefinitely. Credentials are now re-checked on each heartbeat, which also refreshes grants.

Two things worth a look in review:

- The re-check runs in its own goroutine feeding a buffered channel rather than inline in the select loop. It makes a session-store round-trip, and the bus drops events for subscribers that are not draining, so inline would trade a slow lookup for lost live log rows.
- It takes two consecutive failures to close. `resolveCredentials` cannot distinguish "revoked" from "the store could not be asked", so failing on the first miss would turn a brief Postgres outage into a fleet-wide bounce to the login screen. Staleness is bounded at 60s instead of 30s, which seemed the right trade.

**brace-expansion bump in `frontdesk/web`.** Real advisory (GHSA-mh99-v99m-4gvg / CVE-2026-14257, uncatchable OOM in `expand()`), reached via `eslint > minimatch`, so lint-time only. `web/` was already patched. Lockfile only.

## Rejected

**Adding a `USER` directive to the Dockerfiles.** The stated justification was Trivy DS-0002 noise, but all six Trivy invocations across `ci.yml` and `image-scan.yml` are `scan-type: image`; this repo never runs `scan-type: config`, which is what emits DS-0002. There is no scanner noise to remove.

Meanwhile the entrypoint genuinely needs root: it chowns the bind-mounted `/data` and `/data/backups`, and creates an in-container group matching the host Docker socket's GID. `USER appuser` breaks both, and moving that work to an init step trades a working `docker compose up` for nothing.

## Already handled

**Front Desk logout.** The recommendation claimed it was CSRF-exempt too. It is not: `POST /api/logout` is registered inside the `requireAuth` group, which falls through to `adminauth.RequireAdminOrSession`, whose cookie branch enforces the double-submit check on every unsafe method. It also never emits `Set-Cookie`, so the vector does not exist there. No change.

## Verification

- 2577 tests pass across `api`, `authcookie`, `adminauth`, `frontdesk`, `events`; `-race` clean on the SSE and logout tests.
- `golangci-lint run ./...` clean. Pre-push diff-coverage gate: 92.4%.
- The grant-refresh path is mutation-verified: replacing `identity = id` with `_ = id` fails `TestStreamEvents_RefreshesGrantsMidStream`.

One honest gap: I wrote a concurrent-delete test for the backup fix, checked it against the pre-fix code, found it passed there too, and deleted it. The race window sits between `os.Stat` and `ServeFile`'s internal open with no hook to synchronize on, so that specific race is not unit-provable without a production seam. The fix is right; the mutex test is the part that actually guards a decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
