### PR TITLE
fix(discrepancies): re-read the Models badge after every discovery write

### DIFF
--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -40,6 +40,7 @@ import {
 import { useGitHubVersion } from "../hooks/useGitHubVersion";
 import { useIdleLogout } from "../hooks/useIdleLogout";
 import { useReadOnly } from "../hooks/useReadOnly";
+import { useRefreshDiscoveryBadge } from "../hooks/useRefreshDiscoveryBadge";
 import i18next, { LANGUAGE_STORAGE_KEY } from "../i18n";
 import { useDiscoveryRetest } from "../pages/Providers/useDiscoveryRetest";
 import { CollapsibleToggle, useCollapsible } from "./CollapsibleToggle";
@@ -756,6 +757,13 @@ export function Layout({ children }: LayoutProps) {
 	const { toast } = useToast();
 	const readOnly = useReadOnly();
 
+	// Requirement 5 keeps the ?review=1 stamp off the 60s timer; the `exact: true`
+	// inside this hook is what keeps it off a click. See useRefreshDiscoveryBadge.
+	//
+	// Retests do NOT call it from here: useDiscoveryRetest owns that, so a retest
+	// run from the Providers page refreshes the badge too.
+	const refreshBadge = useRefreshDiscoveryBadge();
+
 	// The retest response's own diff is deliberately discarded. It describes what
 	// THAT run changed, which is empty when the model is still missing, and
 	// reading that emptiness as "fixed" is the original defect. Truth comes from
@@ -928,9 +936,15 @@ export function Layout({ children }: LayoutProps) {
 					}),
 					"error",
 				);
+			} finally {
+				// `finally`, not the success path: a request that rejects can still
+				// have landed — the response is what was lost — and the rows correctly
+				// stay actionable either way. Re-reading the badge is how it learns
+				// which of the two happened.
+				refreshBadge();
 			}
 		},
-		[dismissClaim, refresh, toast, t],
+		[dismissClaim, refresh, refreshBadge, toast, t],
 	);
 
 	const onDismissEverything = useCallback(
@@ -952,6 +966,12 @@ export function Layout({ children }: LayoutProps) {
 				dismissClaim(b.providerID, new Set(r.value.dismissed));
 			});
 			await refresh();
+			// After the batches, not per batch: one invalidation covers every
+			// provider's worth of dismissals. Unconditional even when nothing was
+			// confirmed, because a batch that rejects can still have landed — the
+			// response is what was lost — and the badge is better re-read than
+			// inferred from a count the client only partly knows.
+			refreshBadge();
 			if (dismissed === 0) {
 				toast(t("providers.discrepancies.dismissEverythingFailed"), "error");
 				return;
@@ -966,7 +986,7 @@ export function Layout({ children }: LayoutProps) {
 				dismissed < total ? "warning" : "success",
 			);
 		},
-		[dismissClaim, refresh, toast, t],
+		[dismissClaim, refresh, refreshBadge, toast, t],
 	);
 
 	const onDismiss = useCallback(
@@ -1011,28 +1031,13 @@ export function Layout({ children }: LayoutProps) {
 					}),
 					"error",
 				);
+			} finally {
+				// See onDismissAll: a rejected request can still have landed.
+				refreshBadge();
 			}
 		},
-		[dismissClaim, refresh, toast, t],
+		[dismissClaim, refresh, refreshBadge, toast, t],
 	);
-
-	// `exact: true` on BOTH invalidations below, and it is not optional.
-	//
-	// TanStack Query matches query keys by PREFIX, and the modal's key is
-	// ["discovery-status", "modal", n] — a prefix child of the poll's
-	// ["discovery-status"]. A non-exact invalidation therefore also refetches the
-	// modal's query whenever the modal is open, and that query calls
-	// api.discovery.status(TRUE), which stamps the server's last-reviewed marker.
-	// The refetch itself is inert (`seeded` is already true, so the snapshot does
-	// not change) but the stamp is not: it moves the "since your last visit"
-	// baseline to now, zeroing every flap_since_review for the next visit.
-	// Requirement 5 keeps that write off the timer; this keeps it off a click.
-	const refreshBadge = useCallback(() => {
-		queryClient.invalidateQueries({
-			queryKey: ["discovery-status"],
-			exact: true,
-		});
-	}, [queryClient]);
 
 	// Expanding the journal is what marks it read; the destructive ack-on-open is
 	// gone, so nothing clears the dot until the operator actually looks.

--- a/web/src/components/Modal.tsx
+++ b/web/src/components/Modal.tsx
@@ -30,6 +30,16 @@ interface ModalProps {
 
 const FADE_DURATION = 200;
 
+/**
+ * Every mounted Modal's dialog node, in mount order, so a document-level
+ * Escape can be given to the topmost one only.
+ *
+ * Module scope rather than context: modals portal to <body> from anywhere in
+ * the tree, including from siblings that share no provider, and nesting is
+ * decided by what is on screen rather than by who rendered whom.
+ */
+const openDialogs: HTMLElement[] = [];
+
 export const Modal = forwardRef<ModalHandle, ModalProps>(function Modal(
 	{
 		title,
@@ -102,12 +112,41 @@ export const Modal = forwardRef<ModalHandle, ModalProps>(function Modal(
 		[onClose],
 	);
 
-	const handleKeyDown = useCallback(
-		(e: React.KeyboardEvent) => {
-			if (e.key === "Escape") handleClose();
-		},
-		[handleClose],
-	);
+	// Read by the document listener below, which must not re-register when
+	// `onClose` changes identity: re-registering re-pushes this dialog onto
+	// `openDialogs`, and a parent that outranks its own child swallows the
+	// Escape meant to close the child.
+	const closeRef = useRef(handleClose);
+	useEffect(() => {
+		closeRef.current = handleClose;
+	}, [handleClose]);
+
+	// Escape is handled on the DOCUMENT, not on the dialog node.
+	//
+	// A control that unmounts while focused — dismissing the row whose button
+	// you just clicked — hands focus back to <body>, which is outside this
+	// subtree. A dialog-scoped handler never sees the key from there, so the
+	// modal silently stops closing on Escape for the rest of its life.
+	//
+	// Topmost only, so a nested confirm closes before the dialog that opened it.
+	// Mount order is the stacking order: modals portal to <body> in the order
+	// they open, and the one opened last is the one drawn on top.
+	useEffect(() => {
+		const el = dialogRef.current;
+		if (!el) return;
+		openDialogs.push(el);
+		const onKeyDown = (e: KeyboardEvent) => {
+			if (e.key !== "Escape") return;
+			if (openDialogs[openDialogs.length - 1] !== el) return;
+			closeRef.current();
+		};
+		document.addEventListener("keydown", onKeyDown);
+		return () => {
+			document.removeEventListener("keydown", onKeyDown);
+			const i = openDialogs.indexOf(el);
+			if (i !== -1) openDialogs.splice(i, 1);
+		};
+	}, []);
 
 	useImperativeHandle(ref, () => ({ close: handleClose }), [handleClose]);
 
@@ -127,7 +166,6 @@ export const Modal = forwardRef<ModalHandle, ModalProps>(function Modal(
 				opacity,
 				transition: `opacity ${FADE_DURATION}ms ease`,
 			}}
-			onKeyDown={handleKeyDown}
 			onTransitionEnd={handleTransitionEnd}
 		>
 			<button

--- a/web/src/components/__tests__/Layout.navigation.test.tsx
+++ b/web/src/components/__tests__/Layout.navigation.test.tsx
@@ -1641,6 +1641,30 @@ describe("Layout", () => {
 			await expectBadgeAfterClose("1");
 		});
 
+		it("still closes on Escape after a dismissal has unmounted the focused button", async () => {
+			// The row's Dismiss button holds focus when it is clicked, and
+			// dismissing unmounts it, so the browser hands focus back to <body>.
+			// A key pressed from there does not originate inside the dialog, which
+			// is why Escape is handled on the document: scoped to the dialog node
+			// it went unheard and the modal could no longer be closed by keyboard.
+			const dismissed = serveDismissable([["p1", "One", ["a", "b"]]]);
+			const { user } = renderWithProviders(<Layout>{mockChildren}</Layout>);
+
+			await user.click(await screen.findByTestId("discovery-status-badge"));
+			await openFirstBucket(user);
+			await user.click(
+				(await screen.findAllByTestId("discrepancy-dismiss"))[0],
+			);
+			await waitFor(() => expect(dismissed.size).toBe(1));
+
+			// Dispatched on the body rather than the dialog: addressing the dialog
+			// would sidestep the very thing that broke.
+			fireEvent.keyDown(document.body, { key: "Escape" });
+			await waitFor(() =>
+				expect(screen.queryByTestId("discrepancy-modal")).toBeNull(),
+			);
+		});
+
 		it("re-reads the badge after a dismissal that reports failure", async () => {
 			// A rejected request does not prove the write did not land: the server can
 			// commit and the response be lost. The row correctly stays actionable and

--- a/web/src/components/__tests__/Layout.navigation.test.tsx
+++ b/web/src/components/__tests__/Layout.navigation.test.tsx
@@ -1541,6 +1541,248 @@ describe("Layout", () => {
 			await waitFor(() => expect(bodies).toHaveLength(2));
 			expect(bodies.flatMap((b) => b.model_ids).sort()).toEqual(["a", "b"]);
 		});
+
+		/**
+		 * A status endpoint whose `claim_count` actually falls as models are
+		 * dismissed, the way listClaimRows does (it filters on
+		 * discovery_dismissed_at IS NULL).
+		 *
+		 * A fixed payload cannot test the badge at all: the number it shows would
+		 * be right by accident whether or not anything re-read it.
+		 */
+		function serveDismissable(providers: [string, string, string[]][]) {
+			const dismissed = new Set<string>();
+			server.use(
+				http.get("/api/discovery/status", () => {
+					const live = providers
+						.map(([id, name, models]) =>
+							providerClaims(
+								id,
+								name,
+								models.filter((m) => !dismissed.has(m)).map(claim),
+							),
+						)
+						.filter((p) => p.gone.length > 0);
+					return HttpResponse.json(
+						status({
+							claim_count: live.reduce((n, p) => n + p.gone.length, 0),
+							claims: live,
+						}),
+					);
+				}),
+				http.post("/api/discovery/dismiss", async ({ request }) => {
+					const body = (await request.json()) as { model_ids: string[] };
+					for (const m of body.model_ids) dismissed.add(m);
+					return HttpResponse.json({
+						dismissed: body.model_ids,
+						updated: body.model_ids.length,
+					});
+				}),
+			);
+			return dismissed;
+		}
+
+		/**
+		 * Escape, not the close button: that control is labelled with a translated
+		 * string and this suite stays locale-independent.
+		 *
+		 * Addressed through the modal's own testid rather than by role, because a
+		 * ConfirmDialog is a SIBLING dialog and lingers through its fade-out.
+		 */
+		async function closeDiscrepancyModal() {
+			const dialog = screen
+				.getByTestId("discrepancy-modal")
+				.closest('[role="dialog"]') as HTMLElement;
+			fireEvent.keyDown(dialog, { key: "Escape" });
+			await waitFor(() =>
+				expect(screen.queryByTestId("discrepancy-modal")).toBeNull(),
+			);
+		}
+
+		/**
+		 * The badge is hidden while the modal is open, so what it says is only
+		 * observable after a close — which is exactly where the operator reads it,
+		 * and exactly where it used to lie.
+		 *
+		 * `null` means the badge is gone entirely. Every caller below asserts a
+		 * value the STALE poll response would not produce, so none of them can pass
+		 * on a badge that was never re-read.
+		 */
+		async function expectBadgeAfterClose(text: string | null) {
+			await closeDiscrepancyModal();
+			await waitFor(() => {
+				const badge = screen.queryByTestId("discovery-status-badge");
+				if (text === null) expect(badge).toBeNull();
+				else expect(badge).toHaveTextContent(text);
+			});
+		}
+
+		it("re-reads the badge after a single dismissal", async () => {
+			// The modal's own refresh writes to the modal's snapshot alone: a
+			// different query key, fetched straight through the api client. Nothing
+			// it does reaches the nav badge, which otherwise keeps showing whatever
+			// the 60s poll last saw.
+			const dismissed = serveDismissable([["p1", "One", ["a", "b"]]]);
+			const { user } = renderWithProviders(<Layout>{mockChildren}</Layout>);
+
+			expect(
+				await screen.findByTestId("discovery-status-badge"),
+			).toHaveTextContent("2");
+			await user.click(screen.getByTestId("discovery-status-badge"));
+			await openFirstBucket(user);
+			await user.click(
+				screen
+					.getAllByTestId("discrepancy-claim")
+					.find((el) => el.getAttribute("data-model-id") === "a")
+					?.querySelector('[data-testid="discrepancy-dismiss"]') as HTMLElement,
+			);
+			await waitFor(() => expect(dismissed.size).toBe(1));
+
+			await expectBadgeAfterClose("1");
+		});
+
+		it("re-reads the badge after a dismissal that reports failure", async () => {
+			// A rejected request does not prove the write did not land: the server can
+			// commit and the response be lost. The row correctly stays actionable and
+			// the toast reports the failure, but the badge must not keep asserting a
+			// count it can no longer back.
+			let dismissed = false;
+			server.use(
+				http.get("/api/discovery/status", () => {
+					const gone = dismissed ? [] : [claim("a")];
+					return HttpResponse.json(
+						status({
+							claim_count: gone.length,
+							claims: gone.length ? [providerClaims("p1", "One", gone)] : [],
+						}),
+					);
+				}),
+				http.post("/api/discovery/dismiss", () => {
+					dismissed = true;
+					return HttpResponse.json({ error: "boom" }, { status: 500 });
+				}),
+			);
+			const { user } = renderWithProviders(<Layout>{mockChildren}</Layout>);
+
+			await user.click(await screen.findByTestId("discovery-status-badge"));
+			await openFirstBucket(user);
+			await user.click(await screen.findByTestId("discrepancy-dismiss"));
+			await waitFor(() =>
+				expect(
+					screen
+						.getAllByTestId("toast")
+						.some((el) => el.getAttribute("data-toast-type") === "error"),
+				).toBe(true),
+			);
+
+			await expectBadgeAfterClose(null);
+		});
+
+		it("re-reads the badge after a provider-wide dismiss", async () => {
+			const dismissed = serveDismissable([
+				["p1", "One", ["a", "b"]],
+				["p2", "Two", ["c"]],
+			]);
+			const { user } = renderWithProviders(<Layout>{mockChildren}</Layout>);
+
+			await user.click(await screen.findByTestId("discovery-status-badge"));
+			await user.click(
+				(await screen.findAllByTestId("discrepancy-dismiss-all"))[0],
+			);
+			await user.click(
+				await screen.findByTestId("discrepancy-dismiss-all-confirm"),
+			);
+			// ConfirmDialog confirms through the modal's fade-out, so the request is
+			// a timer away from the click, not a microtask.
+			await waitFor(() => expect(dismissed.size).toBe(2));
+
+			// The other provider's claim survives, so this pins a re-read rather than
+			// a badge that merely happens to be empty.
+			await expectBadgeAfterClose("1");
+		});
+
+		it("clears the badge when a modal-wide dismiss empties it", async () => {
+			// The reported sequence: dismiss everything, close, and find the badge
+			// still lit with a count for claims the server no longer has.
+			const dismissed = serveDismissable([
+				["p1", "One", ["a"]],
+				["p2", "Two", ["b"]],
+			]);
+			const { user } = renderWithProviders(<Layout>{mockChildren}</Layout>);
+
+			await user.click(await screen.findByTestId("discovery-status-badge"));
+			await user.click(
+				await screen.findByTestId("discrepancy-dismiss-everything"),
+			);
+			await user.click(
+				await screen.findByTestId("discrepancy-dismiss-everything-confirm"),
+			);
+			await waitFor(() => expect(dismissed.size).toBe(2));
+
+			await expectBadgeAfterClose(null);
+		});
+
+		it("re-reads the badge after a single provider retest", async () => {
+			// A retest clears a claim by changing what the server reports, which
+			// leaves the badge exactly as stale as a dismissal does.
+			const gone = new Set(["a", "b"]);
+			server.use(
+				http.get("/api/discovery/status", () => {
+					const rows = [...gone].map(claim);
+					return HttpResponse.json(
+						status({
+							claim_count: rows.length,
+							claims: rows.length ? [providerClaims("p1", "One", rows)] : [],
+						}),
+					);
+				}),
+				http.post("/api/providers/:id/discover", () => {
+					gone.delete("a");
+					return HttpResponse.json({ discovered: 1, diff: {} });
+				}),
+			);
+			const { user } = renderWithProviders(<Layout>{mockChildren}</Layout>);
+
+			await user.click(await screen.findByTestId("discovery-status-badge"));
+			await user.click(await screen.findByTestId("discrepancy-retest"));
+			await waitFor(() => expect(gone.has("a")).toBe(false));
+
+			await expectBadgeAfterClose("1");
+		});
+
+		it("re-reads the badge once a Retest all walk has finished", async () => {
+			// The walk silences the per-provider refresh and reports once at the end,
+			// so the badge has to be re-read there or not at all.
+			const gone = new Map([
+				["p1", "a"],
+				["p2", "b"],
+			]);
+			server.use(
+				http.get("/api/discovery/status", () => {
+					const live = [...gone].map(([id, model]) =>
+						providerClaims(id, id === "p1" ? "One" : "Two", [claim(model)]),
+					);
+					return HttpResponse.json(
+						status({ claim_count: live.length, claims: live }),
+					);
+				}),
+				http.post("/api/providers/:id/discover", ({ params }) => {
+					gone.delete(String(params.id));
+					return HttpResponse.json({ discovered: 1, diff: {} });
+				}),
+			);
+			const { user } = renderWithProviders(<Layout>{mockChildren}</Layout>);
+
+			await user.click(await screen.findByTestId("discovery-status-badge"));
+			await user.click(await screen.findByTestId("discrepancy-retest-all"));
+			await waitFor(() =>
+				expect(screen.queryByTestId("discrepancy-retest-progress")).toBeNull(),
+			);
+			expect(gone.size).toBe(0);
+
+			await expectBadgeAfterClose(null);
+		});
+
 		it("treats updated: 0 as a failed dismissal", async () => {
 			// The endpoint 200s with a short `updated` and only 404s when nothing at
 			// all matched, so HTTP status alone would report a phantom success.

--- a/web/src/components/__tests__/Modal.test.tsx
+++ b/web/src/components/__tests__/Modal.test.tsx
@@ -87,6 +87,58 @@ describe("Modal", () => {
 		await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
 	});
 
+	it("closes on Escape pressed from outside the dialog subtree", async () => {
+		// The regression this guards: a control that unmounts while focused hands
+		// focus back to <body>, so the key event no longer originates inside the
+		// dialog. With the handler scoped to the dialog node the modal simply
+		// stopped closing on Escape from that point on.
+		render(<Modal onClose={onClose}>Content</Modal>);
+		act(() => {
+			fireEvent.keyDown(document.body, { key: "Escape" });
+		});
+		await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+	});
+
+	it("gives Escape to the topmost dialog only", async () => {
+		// A nested confirm must close before the dialog that opened it. With a
+		// document-level listener every open modal hears the key, so the stack
+		// order is what decides, and only the last-opened one may act.
+		const onCloseOuter = vi.fn();
+		const onCloseInner = vi.fn();
+		render(
+			<>
+				<Modal onClose={onCloseOuter}>Outer</Modal>
+				<Modal onClose={onCloseInner}>Inner</Modal>
+			</>,
+		);
+		act(() => {
+			fireEvent.keyDown(document.body, { key: "Escape" });
+		});
+		await waitFor(() => expect(onCloseInner).toHaveBeenCalledTimes(1));
+		expect(onCloseOuter).not.toHaveBeenCalled();
+	});
+
+	it("hands Escape back to the opener once the nested dialog unmounts", async () => {
+		// The stack has to shrink on unmount, or the outer dialog stays deaf to
+		// Escape for the rest of its life.
+		const onCloseOuter = vi.fn();
+		function Nested({ showInner }: { showInner: boolean }) {
+			return (
+				<>
+					<Modal onClose={onCloseOuter}>Outer</Modal>
+					{showInner && <Modal onClose={vi.fn()}>Inner</Modal>}
+				</>
+			);
+		}
+		const { rerender } = render(<Nested showInner={true} />);
+		rerender(<Nested showInner={false} />);
+
+		act(() => {
+			fireEvent.keyDown(document.body, { key: "Escape" });
+		});
+		await waitFor(() => expect(onCloseOuter).toHaveBeenCalledTimes(1));
+	});
+
 	it("closes on the opacity transition end and cancels the fallback timer", () => {
 		vi.useFakeTimers();
 		try {

--- a/web/src/hooks/useDisableModel.ts
+++ b/web/src/hooks/useDisableModel.ts
@@ -32,11 +32,19 @@ export function useDisableModel(enabledModels: Model[]) {
 				t("hooks.useDisableModel.success", { model: modelIdentifier }),
 				"success",
 			);
-			queryClient.invalidateQueries({ queryKey: ["models"] });
-			queryClient.invalidateQueries({ queryKey: ["providers"] });
 		},
 		onError: (err: Error) => {
 			toast(t("hooks.useDisableModel.error", { error: err.message }), "error");
+		},
+		// No badge refresh, unlike the other model writes: this only ever acts on
+		// a model taken from `enabledModels`, and an enabled model is either
+		// absent from the claim set or Suspect, which the badge does not count.
+		// Disabling it moves it from uncounted to absent, so claim_count cannot
+		// change. UpdateModel does not resync failover either, so no group claim
+		// can move behind it.
+		onSettled: () => {
+			queryClient.invalidateQueries({ queryKey: ["models"] });
+			queryClient.invalidateQueries({ queryKey: ["providers"] });
 		},
 	});
 }

--- a/web/src/hooks/useRefreshDiscoveryBadge.ts
+++ b/web/src/hooks/useRefreshDiscoveryBadge.ts
@@ -1,0 +1,40 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
+
+/**
+ * Re-reads the Models nav badge (`claim_count` + `informational_unseen`).
+ *
+ * Every path that changes what /api/discovery/status would report has to call
+ * this, wherever it lives. The badge is a 60s poll on its own query key, and
+ * nothing else feeds it: the discrepancy modal's `refresh()` writes to the
+ * modal's snapshot alone, and the Providers page's discover/delete mutations
+ * invalidate models and providers. A dismissal, a retest or a rediscover
+ * therefore leaves the badge showing a count the server no longer agrees with,
+ * for up to another 60s. Dismissing everything and closing the modal onto a
+ * badge that still reads 7 is the symptom.
+ *
+ * `exact: true`, and it is not optional. TanStack Query matches query keys by
+ * PREFIX, and the modal's key is ["discovery-status", "modal", n] — a prefix
+ * child of the poll's ["discovery-status"]. A non-exact invalidation therefore
+ * also refetches the modal's query whenever the modal is open, and that query
+ * calls api.discovery.status(TRUE), which stamps the server's last-reviewed
+ * marker. The refetch itself is inert (`seeded` is already true, so the
+ * snapshot does not change) but the stamp is not: it moves the "since your last
+ * visit" baseline to now, zeroing every flap_since_review for the next visit.
+ *
+ * Deliberately an invalidation rather than a `setQueryData` seeded from the
+ * modal's own refresh, even though that payload is byte-identical and would
+ * save a round trip: `refresh()` returns its response even when a newer refresh
+ * has superseded it (it drops the stale one instead of applying it), so seeding
+ * from the return value can write a payload already known to be out of date
+ * into the badge. One small GET per operator click is the cheaper mistake.
+ */
+export function useRefreshDiscoveryBadge() {
+	const queryClient = useQueryClient();
+	return useCallback(() => {
+		queryClient.invalidateQueries({
+			queryKey: ["discovery-status"],
+			exact: true,
+		});
+	}, [queryClient]);
+}

--- a/web/src/hooks/useRefreshDiscoveryBadge.ts
+++ b/web/src/hooks/useRefreshDiscoveryBadge.ts
@@ -5,13 +5,11 @@ import { useCallback } from "react";
  * Re-reads the Models nav badge (`claim_count` + `informational_unseen`).
  *
  * Every path that changes what /api/discovery/status would report has to call
- * this, wherever it lives. The badge is a 60s poll on its own query key, and
- * nothing else feeds it: the discrepancy modal's `refresh()` writes to the
- * modal's snapshot alone, and the Providers page's discover/delete mutations
- * invalidate models and providers. A dismissal, a retest or a rediscover
- * therefore leaves the badge showing a count the server no longer agrees with,
- * for up to another 60s. Dismissing everything and closing the modal onto a
- * badge that still reads 7 is the symptom.
+ * this, wherever it lives. Nothing else feeds the badge: it is a 60s poll on
+ * its own query key, the discrepancy modal's `refresh()` writes to the modal's
+ * snapshot alone, and the models/providers invalidations around it reach
+ * neither. A path that skips this leaves the badge on a stale count until the
+ * poll comes round.
  *
  * `exact: true`, and it is not optional. TanStack Query matches query keys by
  * PREFIX, and the modal's key is ["discovery-status", "modal", n] — a prefix
@@ -22,10 +20,9 @@ import { useCallback } from "react";
  * snapshot does not change) but the stamp is not: it moves the "since your last
  * visit" baseline to now, zeroing every flap_since_review for the next visit.
  *
- * Deliberately an invalidation rather than a `setQueryData` seeded from the
- * modal's own refresh, even though that payload is byte-identical and would
- * save a round trip: `refresh()` returns its response even when a newer refresh
- * has superseded it (it drops the stale one instead of applying it), so seeding
+ * An invalidation rather than a `setQueryData` seeded from the modal's own
+ * refresh: `refresh()` returns its response even when a newer refresh has
+ * superseded it (it drops the stale one instead of applying it), so seeding
  * from the return value can write a payload already known to be out of date
  * into the badge. One small GET per operator click is the cheaper mistake.
  */

--- a/web/src/pages/FailoverGroups.tsx
+++ b/web/src/pages/FailoverGroups.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
 	CheckSquare,
@@ -20,6 +20,7 @@ import { Spinner } from "../components/Spinner";
 import { useToast } from "../context/ToastContext";
 import { useManaged } from "../hooks/useManaged";
 import { useReadOnly } from "../hooks/useReadOnly";
+import { useRefreshDiscoveryBadge } from "../hooks/useRefreshDiscoveryBadge";
 import { countLabel, formatTimestamp } from "../utils/format";
 import { CreateGroupModal } from "./FailoverGroups/CreateGroupModal";
 import { FailoverGroupCard } from "./FailoverGroups/FailoverGroupCard";
@@ -31,6 +32,16 @@ export function FailoverGroups() {
 	const readOnly = useReadOnly();
 	const managed = useManaged();
 	const queryClient = useQueryClient();
+	const refreshBadge = useRefreshDiscoveryBadge();
+
+	// Group state and the Models nav badge move together: an auto-disabled group
+	// IS a counted claim (see useRefreshDiscoveryBadge), so re-enabling or
+	// deleting one changes claim_count. Paired here rather than at each site so
+	// the next path that re-reads groups cannot forget the badge.
+	const refreshGroups = useCallback(() => {
+		queryClient.invalidateQueries({ queryKey: ["failover-groups"] });
+		refreshBadge();
+	}, [queryClient, refreshBadge]);
 
 	const [showCreateModal, setShowCreateModal] = useState(false);
 	const [editGroup, setEditGroup] = useState<FailoverGroup | null>(null);
@@ -205,7 +216,7 @@ export function FailoverGroups() {
 
 		try {
 			await Promise.all(promises);
-			queryClient.invalidateQueries({ queryKey: ["failover-groups"] });
+			refreshGroups();
 			setSelectedGroupIds(new Set());
 			toast(
 				t("failover.toast_bulk_toggle_success", {
@@ -215,7 +226,7 @@ export function FailoverGroups() {
 				"success",
 			);
 		} catch {
-			queryClient.invalidateQueries({ queryKey: ["failover-groups"] });
+			refreshGroups();
 			toast(t("failover.toast_bulk_toggle_failed"), "error");
 		}
 	};
@@ -255,7 +266,7 @@ export function FailoverGroups() {
 
 		try {
 			await Promise.all(promises);
-			queryClient.invalidateQueries({ queryKey: ["failover-groups"] });
+			refreshGroups();
 			toast(
 				t("failover.toast_provider_toggle_success", {
 					action: enabled ? t("common.enabled") : t("common.disabled"),
@@ -265,7 +276,7 @@ export function FailoverGroups() {
 				"success",
 			);
 		} catch {
-			queryClient.invalidateQueries({ queryKey: ["failover-groups"] });
+			refreshGroups();
 			toast(t("failover.toast_provider_toggle_failed"), "error");
 		}
 	};
@@ -312,7 +323,7 @@ export function FailoverGroups() {
 		try {
 			await Promise.all(promises);
 			// Re-fetch groups; disabledProviders is derived from the result.
-			queryClient.invalidateQueries({ queryKey: ["failover-groups"] });
+			refreshGroups();
 			toast(
 				t("failover.toast_provider_toggle_success", {
 					action: enabled ? t("common.enabled") : t("common.disabled"),
@@ -322,7 +333,7 @@ export function FailoverGroups() {
 				"success",
 			);
 		} catch {
-			queryClient.invalidateQueries({ queryKey: ["failover-groups"] });
+			refreshGroups();
 			toast(t("failover.toast_provider_toggle_failed"), "error");
 		} finally {
 			setIsProviderToggling(false);
@@ -342,7 +353,6 @@ export function FailoverGroups() {
 	const syncMutation = useMutation({
 		mutationFn: () => api.failoverGroups.sync(),
 		onSuccess: (data) => {
-			queryClient.invalidateQueries({ queryKey: ["failover-groups"] });
 			if (data.deleted_groups && data.deleted_groups.length > 0) {
 				for (const g of data.deleted_groups) {
 					const provs =
@@ -392,6 +402,12 @@ export function FailoverGroups() {
 		onError: (err: Error) => {
 			toast(t("failover.toast_sync_failed", { message: err.message }), "error");
 		},
+		// Sync applies partially by design: it reports the groups it deleted,
+		// purged and disabled, so a run that errors after any of that has still
+		// changed what the list and the badge should say.
+		onSettled: () => {
+			refreshGroups();
+		},
 	});
 
 	const updateMutation = useMutation({
@@ -402,21 +418,22 @@ export function FailoverGroups() {
 			id: string;
 			data: Parameters<typeof api.failoverGroups.update>[1];
 		}) => api.failoverGroups.update(id, data),
-		onSuccess: () => {
-			queryClient.invalidateQueries({ queryKey: ["failover-groups"] });
-		},
 		onError: (err: Error) => {
 			toast(
 				t("failover.toast_update_failed", { message: err.message }),
 				"error",
 			);
 		},
+		// `onSettled`, matching the bulk handlers above, which re-read from both
+		// their try and their catch: a rejected write can still have landed.
+		onSettled: () => {
+			refreshGroups();
+		},
 	});
 
 	const deleteMutation = useMutation({
 		mutationFn: (id: string) => api.failoverGroups.delete(id),
 		onSuccess: () => {
-			queryClient.invalidateQueries({ queryKey: ["failover-groups"] });
 			toast(t("failover.toast_delete_success"), "success");
 		},
 		onError: (err: Error) => {
@@ -424,6 +441,10 @@ export function FailoverGroups() {
 				t("failover.toast_delete_failed", { message: err.message }),
 				"error",
 			);
+		},
+		// See updateMutation: a rejected DELETE can still have landed.
+		onSettled: () => {
+			refreshGroups();
 		},
 	});
 
@@ -537,7 +558,7 @@ export function FailoverGroups() {
 		);
 		const succeeded = results.filter((r) => r.status === "fulfilled").length;
 		const failed = results.length - succeeded;
-		queryClient.invalidateQueries({ queryKey: ["failover-groups"] });
+		refreshGroups();
 		if (failed === 0) {
 			toast(
 				t("failover.toast_bulk_delete_success", { count: succeeded }),

--- a/web/src/pages/FailoverGroups/CreateGroupModal.tsx
+++ b/web/src/pages/FailoverGroups/CreateGroupModal.tsx
@@ -8,6 +8,7 @@ import { Modal } from "../../components/Modal";
 import type { ModelItem } from "../../components/ModelPicker";
 import { ModelPicker } from "../../components/ModelPicker";
 import { useToast } from "../../context/ToastContext";
+import { useRefreshDiscoveryBadge } from "../../hooks/useRefreshDiscoveryBadge";
 import { isNaEntry, naReasonKey } from "../../utils/failoverEntry";
 import { proxyModelID } from "../../utils/model";
 import {
@@ -31,6 +32,10 @@ export function CreateGroupModal({
 	const { t } = useTranslation();
 	const { toast } = useToast();
 	const queryClient = useQueryClient();
+	// Editing or deleting a group moves the group claims the Models nav badge
+	// counts, and Retry N/A re-enables models, which reclassifies theirs. See
+	// useRefreshDiscoveryBadge.
+	const refreshBadge = useRefreshDiscoveryBadge();
 	const isEdit = !!group;
 
 	const [displayModel, setDisplayModel] = useState(group?.display_model ?? "");
@@ -108,7 +113,6 @@ export function CreateGroupModal({
 			entry_ids: string[];
 		}) => api.failoverGroups.create(data),
 		onSuccess: () => {
-			queryClient.invalidateQueries({ queryKey: ["failover-groups"] });
 			toast(t("failover.toast_created"), "success");
 			onCreated?.();
 		},
@@ -131,6 +135,15 @@ export function CreateGroupModal({
 				);
 			}
 		},
+		// A create that lands but loses its response leaves the list a group
+		// short; see the sibling mutations below. The badge is refreshed with it
+		// rather than reasoned about: a new group is enabled, so it is not itself
+		// a claim, but that is a property of the backend's rules, not of this
+		// call site.
+		onSettled: () => {
+			queryClient.invalidateQueries({ queryKey: ["failover-groups"] });
+			refreshBadge();
+		},
 	});
 
 	const updateMutation = useMutation({
@@ -139,7 +152,6 @@ export function CreateGroupModal({
 			body: Parameters<typeof api.failoverGroups.update>[1];
 		}) => api.failoverGroups.update(data.id, data.body),
 		onSuccess: () => {
-			queryClient.invalidateQueries({ queryKey: ["failover-groups"] });
 			toast(t("failover.toast_updated"), "success");
 			onUpdated?.();
 		},
@@ -155,6 +167,12 @@ export function CreateGroupModal({
 					"error",
 				);
 			}
+		},
+		onSettled: () => {
+			// A rejected write can still have landed, so the group list and the
+			// badge are re-read together.
+			queryClient.invalidateQueries({ queryKey: ["failover-groups"] });
+			refreshBadge();
 		},
 	});
 
@@ -180,7 +198,6 @@ export function CreateGroupModal({
 	const deleteGroupMutation = useMutation({
 		mutationFn: (id: string) => api.failoverGroups.delete(id),
 		onSuccess: () => {
-			queryClient.invalidateQueries({ queryKey: ["failover-groups"] });
 			toast(t("failover.toast_delete_success"), "success");
 			onUpdated?.();
 		},
@@ -189,6 +206,11 @@ export function CreateGroupModal({
 				t("failover.toast_delete_failed", { message: err.message }),
 				"error",
 			);
+		},
+		onSettled: () => {
+			// See updateMutation: a rejected DELETE can still have landed.
+			queryClient.invalidateQueries({ queryKey: ["failover-groups"] });
+			refreshBadge();
 		},
 	});
 
@@ -244,6 +266,9 @@ export function CreateGroupModal({
 		queryClient.invalidateQueries({ queryKey: ["failover-groups"] });
 		queryClient.invalidateQueries({ queryKey: ["failover-candidates"] });
 		queryClient.invalidateQueries({ queryKey: ["models"] });
+		// Re-enabling a member reclassifies its claim: a Gone model becomes
+		// Suspect, which the badge does not count.
+		refreshBadge();
 
 		const byProvider = new Map<
 			string,

--- a/web/src/pages/FailoverGroups/CreateGroupModal.tsx
+++ b/web/src/pages/FailoverGroups/CreateGroupModal.tsx
@@ -315,7 +315,7 @@ export function CreateGroupModal({
 		});
 	};
 
-	const handleSubmit = (e: React.FormEvent) => {
+	const handleSubmit = (e: React.SubmitEvent) => {
 		e.preventDefault();
 
 		const entryUuids = selectedProxyIDs

--- a/web/src/pages/FailoverGroups/__tests__/CreateGroupModal.test.tsx
+++ b/web/src/pages/FailoverGroups/__tests__/CreateGroupModal.test.tsx
@@ -454,7 +454,7 @@ describe("CreateGroupModal", () => {
 	describe("form validation", () => {
 		it("shows error toast when display model name is empty (JS guard)", async () => {
 			// Bypass HTML5 required validation by submitting the form directly
-			renderWithProviders(
+			const { user } = renderWithProviders(
 				<CreateGroupModal
 					candidates={mockCandidates}
 					onClose={mockOnClose}
@@ -463,8 +463,8 @@ describe("CreateGroupModal", () => {
 			);
 
 			// Select 2 models but leave display model name empty
-			await screen.getByText("Gemma 3 4B").click();
-			await screen.getByText("Gemma 3").click();
+			await user.click(screen.getByText("Gemma 3 4B"));
+			await user.click(screen.getByText("Gemma 3"));
 
 			// Submit form directly (bypasses browser required check)
 			const form = screen

--- a/web/src/pages/FailoverGroups/__tests__/CreateGroupModal.test.tsx
+++ b/web/src/pages/FailoverGroups/__tests__/CreateGroupModal.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, screen, waitFor } from "@testing-library/react";
 import { HttpResponse, http } from "msw";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { CandidateModel, FailoverGroup } from "../../../api/types";
+import { Layout } from "../../../components/Layout";
 import { server } from "../../../test/mocks/server";
 import { renderWithProviders } from "../../../test/utils";
 import { CreateGroupModal } from "../CreateGroupModal";
@@ -1306,6 +1307,62 @@ describe("CreateGroupModal", () => {
 			expect(screen.getByText("Re-enabled")).toBeInTheDocument();
 			expect(tested).toBe("uuid-na");
 			expect(patched).toBe("uuid-na");
+		});
+
+		it("re-reads the Models nav badge after Retry N/A re-enables a member", async () => {
+			// Re-enabling reclassifies that member's claim rather than removing it:
+			// buildProviderClaims puts an enabled model in Suspect, and Suspect does
+			// not count towards the badge. The badge is a 60s poll in Layout that
+			// this modal's ["models"] invalidation never reached.
+			let reenabled = false;
+			server.use(
+				http.post("/api/models/:id/test", () =>
+					HttpResponse.json({
+						success: true,
+						streaming: false,
+						ttft_ms: 1,
+						duration_ms: 1,
+						response: "hi",
+					}),
+				),
+				http.patch("/api/models/:id", () => {
+					reenabled = true;
+					return HttpResponse.json({});
+				}),
+				http.get("/api/discovery/status", () =>
+					HttpResponse.json({
+						claims: [],
+						group_claims: [],
+						informational: [],
+						claim_count: reenabled ? 1 : 2,
+						informational_unseen: 0,
+					}),
+				),
+			);
+
+			const { user } = renderWithProviders(
+				<Layout>
+					<CreateGroupModal
+						candidates={mockCandidates}
+						group={groupWithNa}
+						onClose={mockOnClose}
+						onUpdated={mockOnUpdated}
+					/>
+				</Layout>,
+			);
+
+			expect(
+				await screen.findByTestId("discovery-status-badge"),
+			).toHaveTextContent("2");
+
+			await user.click(screen.getByRole("button", { name: "Retry N/A" }));
+			await waitFor(() => expect(reenabled).toBe(true));
+
+			await waitFor(() =>
+				expect(screen.getByTestId("discovery-status-badge")).toHaveTextContent(
+					"1",
+				),
+			);
 		});
 
 		it("Retry N/A keeps a member out of Re-enabled when the write fails", async () => {

--- a/web/src/pages/Models.tsx
+++ b/web/src/pages/Models.tsx
@@ -10,6 +10,7 @@ import { PageHeader } from "../components/PageHeader";
 import { VirtualModelTable } from "../components/VirtualModelTable";
 import { useToast } from "../context/ToastContext";
 import { useLocalStorage } from "../hooks/useLocalStorage";
+import { useRefreshDiscoveryBadge } from "../hooks/useRefreshDiscoveryBadge";
 import { countLabel } from "../utils/format";
 import { ModelDetailModal } from "./Models/ModelDetailModal";
 
@@ -17,6 +18,10 @@ export function Models() {
 	const { toast } = useToast();
 	const { t } = useTranslation();
 	const queryClient = useQueryClient();
+	// Discovering and deleting both move the claim set behind the Models nav
+	// badge, and the badge is a 60s poll that nothing here otherwise touches.
+	// See useRefreshDiscoveryBadge.
+	const refreshBadge = useRefreshDiscoveryBadge();
 	const [detailModel, setDetailModel] = useState<Model | null>(null);
 	const [providerFilter, setProviderFilter] = useState("");
 	const [modelRefreshTrigger, setModelRefreshTrigger] = useState(0);
@@ -40,11 +45,18 @@ export function Models() {
 	const toggleMutation = useMutation({
 		mutationFn: ({ id, enabled }: { id: string; enabled: boolean }) =>
 			api.models.update(id, { enabled }),
-		onSuccess: () => {
-			queryClient.invalidateQueries({ queryKey: ["models"] });
-		},
 		onError: (err: Error) => {
 			toast(t("models.toast_update_failed", { message: err.message }), "error");
+		},
+		onSettled: () => {
+			// Toggling reclassifies the claim: enabling a Gone model makes it
+			// Suspect, and Suspect does not count towards the badge, while
+			// disabling it by hand drops it from the claim set outright.
+			//
+			// Table and badge re-read together, so a rejected PATCH that landed
+			// cannot leave one showing a state the other contradicts.
+			queryClient.invalidateQueries({ queryKey: ["models"] });
+			refreshBadge();
 		},
 	});
 
@@ -98,13 +110,19 @@ export function Models() {
 
 	const handleDiscover = useCallback(
 		async (providerId: string) => {
-			const result = await api.providers.discover(providerId);
-			queryClient.invalidateQueries({ queryKey: ["models"] });
-			queryClient.invalidateQueries({ queryKey: ["providers"] });
-			setModelRefreshTrigger((n) => n + 1);
-			return result;
+			try {
+				return await api.providers.discover(providerId);
+			} finally {
+				// `finally`, like useDiscoveryRetest: a discovery run that errors
+				// partway has still upserted whatever it reached, so table and badge
+				// are re-read either way. The rejection still reaches the caller.
+				queryClient.invalidateQueries({ queryKey: ["models"] });
+				queryClient.invalidateQueries({ queryKey: ["providers"] });
+				setModelRefreshTrigger((n) => n + 1);
+				refreshBadge();
+			}
 		},
-		[queryClient],
+		[queryClient, refreshBadge],
 	);
 
 	const handleTest = useCallback(async (id: string) => {
@@ -114,12 +132,19 @@ export function Models() {
 	const deleteMutation = useMutation({
 		mutationFn: (id: string) => api.models.delete(id),
 		onSuccess: () => {
-			queryClient.invalidateQueries({ queryKey: ["models"] });
-			setModelRefreshTrigger((n) => n + 1);
 			toast(t("models.toast_deleted"), "success");
 		},
 		onError: (err: Error) => {
 			toast(t("models.toast_delete_failed", { message: err.message }), "error");
+		},
+		onSettled: () => {
+			// A deleted model takes its claim with it, and a rejected DELETE can
+			// still have landed — the response is what was lost. Table and badge
+			// re-read together so neither can outlive the other's version of
+			// what exists.
+			queryClient.invalidateQueries({ queryKey: ["models"] });
+			setModelRefreshTrigger((n) => n + 1);
+			refreshBadge();
 		},
 	});
 
@@ -130,13 +155,17 @@ export function Models() {
 				// burst trips the admin IP rate limiter and reports spurious failures.
 				const { deleted } = await api.models.bulkDelete(ids);
 				queryClient.invalidateQueries({ queryKey: ["models"] });
+				refreshBadge();
 				setModelRefreshTrigger((n) => n + 1);
 				toast(
 					t("models.toast_delete_bulk_success", { count: deleted }),
 					"success",
 				);
 			} catch (err) {
+				// The bulk delete is one request, but a failure does not prove nothing
+				// was deleted, so both paths re-read what the server now has.
 				queryClient.invalidateQueries({ queryKey: ["models"] });
+				refreshBadge();
 				setModelRefreshTrigger((n) => n + 1);
 				toast(
 					t("models.toast_delete_failed", { message: (err as Error).message }),
@@ -144,7 +173,7 @@ export function Models() {
 				);
 			}
 		},
-		[queryClient, toast, t],
+		[queryClient, refreshBadge, toast, t],
 	);
 
 	if (isLoading && viewMode === "paginate") {

--- a/web/src/pages/Providers.tsx
+++ b/web/src/pages/Providers.tsx
@@ -135,9 +135,6 @@ export function Providers() {
 			return api.providers.discoverAll();
 		},
 		onSuccess: (data) => {
-			queryClient.invalidateQueries({ queryKey: ["providers"] });
-			queryClient.invalidateQueries({ queryKey: ["models"] });
-			refreshBadge();
 			setDiscoverAllCurrentId(null);
 			if (data.failed > 0 && data.succeeded === 0) {
 				toast(
@@ -164,6 +161,14 @@ export function Providers() {
 				"error",
 			);
 			setDiscoverAllCurrentId(null);
+		},
+		onSettled: () => {
+			// `onSettled`, like useDiscoveryRetest: a sweep that errors partway has
+			// still upserted whatever it reached, so the catalogue and the claim
+			// set can both move without a success.
+			queryClient.invalidateQueries({ queryKey: ["providers"] });
+			queryClient.invalidateQueries({ queryKey: ["models"] });
+			refreshBadge();
 		},
 	});
 
@@ -205,9 +210,6 @@ export function Providers() {
 			return api.providers.discover(id);
 		},
 		onSuccess: (data, id) => {
-			queryClient.invalidateQueries({ queryKey: ["providers"] });
-			queryClient.invalidateQueries({ queryKey: ["models"] });
-			refreshBadge();
 			const providerName = providers?.find((p) => p.id === id)?.name ?? id;
 			setDiscoverySummary([{ providerName, diff: data.diff, providerId: id }]);
 		},
@@ -219,6 +221,12 @@ export function Providers() {
 		},
 		onSettled: () => {
 			setDiscoveringId(null);
+			// See discoverAllMutation: a discovery run that errors partway has
+			// still upserted whatever it reached, so the lists are re-read here
+			// too and not only when the run reports success.
+			queryClient.invalidateQueries({ queryKey: ["providers"] });
+			queryClient.invalidateQueries({ queryKey: ["models"] });
+			refreshBadge();
 		},
 	});
 
@@ -241,6 +249,21 @@ export function Providers() {
 	const deleteMutation = useMutation({
 		mutationFn: (id: string) => api.providers.delete(id),
 		onSuccess: () => {
+			toast(t("providers.toast_provider_deleted"), "success");
+		},
+		onError: (err: Error) => {
+			toast(
+				t("providers.toast_delete_failed", { message: err.message }),
+				"error",
+			);
+		},
+		// Every re-read together, on settle rather than on success. A rejected
+		// DELETE can still have landed — the response is what was lost — and
+		// re-reading only the badge would leave the card, its models and its
+		// failover groups on screen asserting a provider that no longer exists.
+		// A genuine failure costs a refetch of what is already displayed.
+		onSettled: () => {
+			setDeleteProvider(null);
 			queryClient.invalidateQueries({ queryKey: ["providers"] });
 			queryClient.invalidateQueries({ queryKey: ["models"] });
 			queryClient.invalidateQueries({ queryKey: ["nanogpt-usage"] });
@@ -250,18 +273,7 @@ export function Providers() {
 			queryClient.invalidateQueries({ queryKey: ["deepseek-balance"] });
 			queryClient.invalidateQueries({ queryKey: ["openrouter-balance"] });
 			queryClient.invalidateQueries({ queryKey: ["failover-groups"] });
-			// A deleted provider takes its models, and therefore its claims, with it.
 			refreshBadge();
-			toast(t("providers.toast_provider_deleted"), "success");
-		},
-		onError: (err: Error) => {
-			toast(
-				t("providers.toast_delete_failed", { message: err.message }),
-				"error",
-			);
-		},
-		onSettled: () => {
-			setDeleteProvider(null);
 		},
 	});
 

--- a/web/src/pages/Providers.tsx
+++ b/web/src/pages/Providers.tsx
@@ -26,6 +26,7 @@ import { useToast } from "../context/ToastContext";
 import { useManaged } from "../hooks/useManaged";
 import { useQuotaData } from "../hooks/useQuotaData";
 import { useReadOnly } from "../hooks/useReadOnly";
+import { useRefreshDiscoveryBadge } from "../hooks/useRefreshDiscoveryBadge";
 import { countLabel } from "../utils/format";
 import { ModelDetailModal } from "./Models/ModelDetailModal";
 import { AddProviderModal } from "./Providers/AddProviderModal";
@@ -43,6 +44,10 @@ import { useDiscoveryRetest } from "./Providers/useDiscoveryRetest";
 
 export function Providers() {
 	const queryClient = useQueryClient();
+	// Discovery and provider deletion both move the claim set the Models nav
+	// badge counts, and the badge is a 60s poll that nothing here otherwise
+	// touches. See useRefreshDiscoveryBadge.
+	const refreshBadge = useRefreshDiscoveryBadge();
 	const { toast } = useToast();
 	const { t } = useTranslation();
 	const readOnly = useReadOnly();
@@ -132,6 +137,7 @@ export function Providers() {
 		onSuccess: (data) => {
 			queryClient.invalidateQueries({ queryKey: ["providers"] });
 			queryClient.invalidateQueries({ queryKey: ["models"] });
+			refreshBadge();
 			setDiscoverAllCurrentId(null);
 			if (data.failed > 0 && data.succeeded === 0) {
 				toast(
@@ -201,6 +207,7 @@ export function Providers() {
 		onSuccess: (data, id) => {
 			queryClient.invalidateQueries({ queryKey: ["providers"] });
 			queryClient.invalidateQueries({ queryKey: ["models"] });
+			refreshBadge();
 			const providerName = providers?.find((p) => p.id === id)?.name ?? id;
 			setDiscoverySummary([{ providerName, diff: data.diff, providerId: id }]);
 		},
@@ -243,6 +250,8 @@ export function Providers() {
 			queryClient.invalidateQueries({ queryKey: ["deepseek-balance"] });
 			queryClient.invalidateQueries({ queryKey: ["openrouter-balance"] });
 			queryClient.invalidateQueries({ queryKey: ["failover-groups"] });
+			// A deleted provider takes its models, and therefore its claims, with it.
+			refreshBadge();
 			toast(t("providers.toast_provider_deleted"), "success");
 		},
 		onError: (err: Error) => {
@@ -263,12 +272,16 @@ export function Providers() {
 				// burst trips the admin IP rate limiter and reports spurious failures.
 				const { deleted } = await api.models.bulkDelete(ids);
 				queryClient.invalidateQueries({ queryKey: ["models"] });
+				refreshBadge();
 				toast(
 					t("providers.toast_delete_models_success", { count: deleted }),
 					"success",
 				);
 			} catch (err) {
+				// The bulk delete is one request, but a failure does not prove nothing
+				// was deleted, so both paths re-read what the server now has.
 				queryClient.invalidateQueries({ queryKey: ["models"] });
+				refreshBadge();
 				toast(
 					t("providers.toast_delete_failed", {
 						message: (err as Error).message,
@@ -277,7 +290,7 @@ export function Providers() {
 				);
 			}
 		},
-		[queryClient, toast, t],
+		[queryClient, refreshBadge, toast, t],
 	);
 
 	const typeOptions = useMemo(() => {

--- a/web/src/pages/Providers/AddProviderModal.tsx
+++ b/web/src/pages/Providers/AddProviderModal.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { type FormEvent, useState } from "react";
+import { type SubmitEvent, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Eye, EyeOff } from "@/lib/icons";
 import { api } from "../../api/client";
@@ -212,7 +212,7 @@ export function AddProviderModal({
 		}));
 	};
 
-	const handleSubmit = (e: FormEvent) => {
+	const handleSubmit = (e: SubmitEvent) => {
 		e.preventDefault();
 		setError(null);
 		createMutation.mutate({

--- a/web/src/pages/Providers/AddProviderModal.tsx
+++ b/web/src/pages/Providers/AddProviderModal.tsx
@@ -6,6 +6,7 @@ import { api } from "../../api/client";
 import type { Provider } from "../../api/types";
 import { FilterDropdown } from "../../components/FilterDropdown";
 import { Modal } from "../../components/Modal";
+import { useRefreshDiscoveryBadge } from "../../hooks/useRefreshDiscoveryBadge";
 import {
 	baseUrls,
 	getProviderType,
@@ -49,6 +50,7 @@ export function AddProviderModal({
 	providers,
 }: AddProviderModalProps) {
 	const queryClient = useQueryClient();
+	const refreshBadge = useRefreshDiscoveryBadge();
 	const { t } = useTranslation();
 	const [formData, setFormData] = useState<{
 		name: string;
@@ -86,8 +88,6 @@ export function AddProviderModal({
 			if (shouldDiscover) {
 				try {
 					const result = await api.providers.discover(newProvider.id);
-					queryClient.invalidateQueries({ queryKey: ["models"] });
-					queryClient.invalidateQueries({ queryKey: ["providers"] });
 					onToast(
 						t("providers.add.discoveredModels", { count: result.discovered }),
 						"success",
@@ -100,6 +100,15 @@ export function AddProviderModal({
 						}),
 						"warning",
 					);
+				} finally {
+					// The new provider owns no claims of its own, but the scan re-syncs
+					// failover, and an auto-disabled group IS a counted claim: fresh
+					// members can lift one back over the routable floor and retire its
+					// claim. Re-read here rather than only on success, since a scan that
+					// errors partway has still upserted whatever it reached.
+					queryClient.invalidateQueries({ queryKey: ["models"] });
+					queryClient.invalidateQueries({ queryKey: ["providers"] });
+					refreshBadge();
 				}
 			}
 

--- a/web/src/pages/Providers/EditProviderModal.tsx
+++ b/web/src/pages/Providers/EditProviderModal.tsx
@@ -87,7 +87,7 @@ export function EditProviderModal({
 		}
 	};
 
-	const handleSubmit = (e: React.FormEvent) => {
+	const handleSubmit = (e: React.SubmitEvent) => {
 		e.preventDefault();
 		setError(null);
 		const payload: {

--- a/web/src/pages/Providers/EditProviderModal.tsx
+++ b/web/src/pages/Providers/EditProviderModal.tsx
@@ -7,6 +7,7 @@ import type { Provider } from "../../api/types";
 import { ConfirmDialog } from "../../components/ConfirmDialog";
 import { Modal } from "../../components/Modal";
 import { Toggle } from "../../components/Toggle";
+import { useRefreshDiscoveryBadge } from "../../hooks/useRefreshDiscoveryBadge";
 import { isKnownProviderUrl } from "./constants";
 
 export function EditProviderModal({
@@ -19,6 +20,10 @@ export function EditProviderModal({
 	onToast: (msg: string, type: "success" | "error" | "info") => void;
 }) {
 	const queryClient = useQueryClient();
+	// Claims are read per enabled provider, so switching one off takes every
+	// claim it owns out of the Models nav badge (and back on restores them).
+	// See useRefreshDiscoveryBadge.
+	const refreshBadge = useRefreshDiscoveryBadge();
 	const { t } = useTranslation();
 	const [formData, setFormData] = useState({
 		name: provider.name,
@@ -40,7 +45,6 @@ export function EditProviderModal({
 			autodiscovery_enabled?: boolean;
 		}) => api.providers.update(provider.id, data),
 		onSuccess: (updated: Provider) => {
-			queryClient.invalidateQueries({ queryKey: ["providers"] });
 			onToast(
 				t("providers.toast_provider_updated", { name: updated.name }),
 				"success",
@@ -53,6 +57,13 @@ export function EditProviderModal({
 				t("providers.toast_update_failed", { message: err.message }),
 				"error",
 			);
+		},
+		onSettled: () => {
+			// A rejected write can still have landed, so the provider list and the
+			// badge are both re-read rather than inferred from a response that
+			// never arrived.
+			queryClient.invalidateQueries({ queryKey: ["providers"] });
+			refreshBadge();
 		},
 	});
 

--- a/web/src/pages/Providers/__tests__/AddProviderModal.test.tsx
+++ b/web/src/pages/Providers/__tests__/AddProviderModal.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, screen, waitFor } from "@testing-library/react";
 import { HttpResponse, http } from "msw";
+import { Layout } from "../../../components/Layout";
 import { server } from "../../../test/mocks/server";
 import { renderWithProviders } from "../../../test/utils";
 import { AddProviderModal } from "../AddProviderModal";
@@ -654,6 +655,80 @@ describe("AddProviderModal", () => {
 	});
 
 	describe("auto-discovery", () => {
+		it("re-reads the Models nav badge after the discovery that follows a create", async () => {
+			// The new provider owns no claims of its own, but the scan re-syncs
+			// failover, and an auto-disabled group IS a counted claim: fresh members
+			// can lift one back over the routable floor. The badge is a 60s poll in
+			// Layout that this modal's ["providers"]/["models"] invalidations never
+			// reached, hence the real Layout here.
+			//
+			// The discovery is made to FAIL, because the re-read must not depend on
+			// it succeeding: a scan that errors partway has still upserted whatever
+			// it reached.
+			let scanned = false;
+			server.use(
+				http.post("/api/providers", () =>
+					HttpResponse.json(
+						{
+							id: "provider-new",
+							name: "New Provider",
+							base_url: "https://api.example.com/v1",
+							masked_key: "sk_test_••••••••",
+							enabled: true,
+							last_discovered_at: null,
+							last_used_at: null,
+							created_at: new Date().toISOString(),
+							updated_at: new Date().toISOString(),
+							model_count: 0,
+							total_tokens: 0,
+						},
+						{ status: 201 },
+					),
+				),
+				http.post("/api/providers/:id/discover", () => {
+					scanned = true;
+					return HttpResponse.json({ error: "upstream died" }, { status: 500 });
+				}),
+				http.get("/api/discovery/status", () =>
+					HttpResponse.json({
+						claims: [],
+						group_claims: [],
+						informational: [],
+						claim_count: scanned ? 1 : 3,
+						informational_unseen: 0,
+					}),
+				),
+			);
+
+			const { user } = renderWithProviders(
+				<Layout>
+					<AddProviderModal
+						{...defaultProps}
+						settings={{ discovery_on_provider_create: "true" }}
+					/>
+				</Layout>,
+			);
+
+			expect(
+				await screen.findByTestId("discovery-status-badge"),
+			).toHaveTextContent("3");
+
+			await user.type(screen.getByLabelText("Name"), "Test Provider");
+			await user.type(
+				screen.getByLabelText("Base URL"),
+				"https://api.test.com/v1",
+			);
+			await user.type(screen.getByLabelText("API Key"), "sk-test-key");
+			await user.click(screen.getByRole("button", { name: "Add Provider" }));
+			await waitFor(() => expect(scanned).toBe(true));
+
+			await waitFor(() =>
+				expect(screen.getByTestId("discovery-status-badge")).toHaveTextContent(
+					"1",
+				),
+			);
+		});
+
 		it("triggers auto-discovery after successful creation when enabled", async () => {
 			server.use(
 				http.post("/api/providers", async ({ request }) => {

--- a/web/src/pages/Providers/__tests__/EditProviderModal.test.tsx
+++ b/web/src/pages/Providers/__tests__/EditProviderModal.test.tsx
@@ -1,6 +1,7 @@
 import { screen, waitFor } from "@testing-library/react";
 import { HttpResponse, http } from "msw";
 import type { Provider } from "../../../api/types";
+import { Layout } from "../../../components/Layout";
 import { server } from "../../../test/mocks/server";
 import { renderWithProviders } from "../../../test/utils";
 import { EditProviderModal } from "../EditProviderModal";
@@ -597,6 +598,49 @@ describe("EditProviderModal", () => {
 			expect(apiKeyInput).toHaveAttribute(
 				"placeholder",
 				"Leave blank to keep current key",
+			);
+		});
+	});
+
+	describe("Models nav badge", () => {
+		it("re-reads the badge when the provider is switched off", async () => {
+			// listClaimRows joins on `p.enabled = true`, so switching a provider off
+			// takes every claim it owns out of claim_count at once (and back on
+			// restores them). The badge is a 60s poll in Layout that this modal's
+			// ["providers"] invalidation never reaches, hence the real Layout here.
+			let disabled = false;
+			server.use(
+				http.get("/api/discovery/status", () =>
+					HttpResponse.json({
+						claims: [],
+						group_claims: [],
+						informational: [],
+						claim_count: disabled ? 0 : 3,
+						informational_unseen: 0,
+					}),
+				),
+				http.put("/api/providers/:id", () => {
+					disabled = true;
+					return HttpResponse.json({ ...mockProvider, enabled: false });
+				}),
+			);
+
+			const { user } = renderWithProviders(
+				<Layout>
+					<EditProviderModal {...defaultProps} />
+				</Layout>,
+			);
+
+			expect(
+				await screen.findByTestId("discovery-status-badge"),
+			).toHaveTextContent("3");
+
+			await user.click(screen.getByLabelText("Provider enabled"));
+			await user.click(screen.getByRole("button", { name: "Save Changes" }));
+			await waitFor(() => expect(disabled).toBe(true));
+
+			await waitFor(() =>
+				expect(screen.queryByTestId("discovery-status-badge")).toBeNull(),
 			);
 		});
 	});

--- a/web/src/pages/Providers/__tests__/useDiscoveryRetest.test.tsx
+++ b/web/src/pages/Providers/__tests__/useDiscoveryRetest.test.tsx
@@ -1,6 +1,10 @@
+import { useQuery } from "@tanstack/react-query";
 import { act, renderHook, screen, waitFor } from "@testing-library/react";
+import { HttpResponse, http } from "msw";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { api } from "../../../api/client";
 import type { DiscoveryDiff } from "../../../api/types";
+import { server } from "../../../test/mocks/server";
 import { AllProviders } from "../../../test/utils";
 import type { DiscoverySummaryEntry } from "../DiscoverySummaryModal";
 import { useDiscoveryRetest } from "../useDiscoveryRetest";
@@ -96,6 +100,52 @@ describe("useDiscoveryRetest", () => {
 		// clear too — otherwise every Retest button stays disabled for the rest
 		// of the session after one bad entry.
 		await waitFor(() => expect(result.current.isAnyRetesting).toBe(false));
+	});
+
+	it("does not re-read the badge for an entry that never left the browser", async () => {
+		// onSettled runs for a local rejection too, so the badge refresh has to be
+		// guarded: nothing can have changed server-side when no request was sent.
+		// Observed through a mounted ["discovery-status"] query, because an
+		// invalidation with nothing listening is not observable at all.
+		let statusReads = 0;
+		server.use(
+			http.get("/api/discovery/status", () => {
+				statusReads++;
+				return HttpResponse.json({
+					claims: [],
+					group_claims: [],
+					informational: [],
+					claim_count: 0,
+					informational_unseen: 0,
+				});
+			}),
+		);
+
+		function BadgeProbe() {
+			useQuery({
+				queryKey: ["discovery-status"],
+				queryFn: () => api.discovery.status(false),
+			});
+			return null;
+		}
+
+		const { result } = renderHook(() => useDiscoveryRetest(vi.fn()), {
+			wrapper: ({ children }) => (
+				<AllProviders>
+					<BadgeProbe />
+					{children}
+				</AllProviders>
+			),
+		});
+		await waitFor(() => expect(statusReads).toBe(1));
+
+		act(() => {
+			result.current.onRetest({ providerName: "NoId" });
+		});
+		await waitFor(() => expect(result.current.isAnyRetesting).toBe(false));
+
+		// A real retest re-reads; this one must not, so the count stays put.
+		expect(statusReads).toBe(1);
 	});
 
 	it("reports a global in-flight flag and ignores a second onRetest while one is running", async () => {

--- a/web/src/pages/Providers/useDiscoveryRetest.ts
+++ b/web/src/pages/Providers/useDiscoveryRetest.ts
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import { api } from "../../api/client";
 import type { DiscoveryDiff } from "../../api/types";
 import { useToast } from "../../context/ToastContext";
+import { useRefreshDiscoveryBadge } from "../../hooks/useRefreshDiscoveryBadge";
 import type { DiscoverySummaryEntry } from "./DiscoverySummaryModal";
 
 /** Stable key for a summary entry, matching the modal's entryKeyOf. */
@@ -21,6 +22,7 @@ export function useDiscoveryRetest(
 	patchEntry: (key: string, diff: DiscoveryDiff) => void,
 ) {
 	const queryClient = useQueryClient();
+	const refreshBadge = useRefreshDiscoveryBadge();
 	const { toast } = useToast();
 	const { t } = useTranslation();
 	const [retestingKey, setRetestingKey] = useState<string | undefined>(
@@ -72,6 +74,13 @@ export function useDiscoveryRetest(
 		},
 		onSettled: () => {
 			setRetestingKey(undefined);
+			// Here rather than in onSuccess, unlike the two invalidations above: a
+			// discovery run that errors partway has still upserted whatever it got
+			// to before failing, so the claim set can move without a success.
+			//
+			// And here rather than in the callers, so a retest refreshes the badge
+			// from the Providers page as well as from the discrepancy modal.
+			refreshBadge();
 		},
 	});
 

--- a/web/src/pages/Providers/useDiscoveryRetest.ts
+++ b/web/src/pages/Providers/useDiscoveryRetest.ts
@@ -54,8 +54,6 @@ export function useDiscoveryRetest(
 			setRetestingKey(keyOf(entry));
 		},
 		onSuccess: (data, { entry, silent }) => {
-			queryClient.invalidateQueries({ queryKey: ["providers"] });
-			queryClient.invalidateQueries({ queryKey: ["models"] });
 			patchEntry(keyOf(entry), data.diff);
 			if (silent) return;
 			toast(
@@ -72,14 +70,19 @@ export function useDiscoveryRetest(
 				"error",
 			);
 		},
-		onSettled: () => {
+		onSettled: (_data, _err, { entry }) => {
 			setRetestingKey(undefined);
-			// Here rather than in onSuccess, unlike the two invalidations above: a
-			// discovery run that errors partway has still upserted whatever it got
-			// to before failing, so the claim set can move without a success.
+			// Skipped when the guard above rejected locally: that request never
+			// left the browser, so nothing can have changed.
+			if (!entry.providerId) return;
+			// Here rather than in onSuccess: a discovery run that errors partway
+			// has still upserted whatever it got to before failing, so the
+			// catalogue and the claim set can both move without a success.
 			//
 			// And here rather than in the callers, so a retest refreshes the badge
 			// from the Providers page as well as from the discrepancy modal.
+			queryClient.invalidateQueries({ queryKey: ["providers"] });
+			queryClient.invalidateQueries({ queryKey: ["models"] });
 			refreshBadge();
 		},
 	});

--- a/web/src/pages/Settings/DiscoverySettings.tsx
+++ b/web/src/pages/Settings/DiscoverySettings.tsx
@@ -10,6 +10,7 @@ import { SettingsSlider } from "../../components/SettingsSlider";
 import { Spinner } from "../../components/Spinner";
 import { Toggle } from "../../components/Toggle";
 import { useToast } from "../../context/ToastContext";
+import { useRefreshDiscoveryBadge } from "../../hooks/useRefreshDiscoveryBadge";
 import { goDurationToHours, hoursToGoDuration } from "../../utils/duration";
 import { formatDateTimeShort } from "../../utils/format";
 import { useSettingsMutations } from "./useSettingsMutations";
@@ -30,6 +31,10 @@ export function DiscoverySettings({
 	const { t } = useTranslation();
 	const { toast } = useToast();
 	const queryClient = useQueryClient();
+	// "Discover all" moves the claim set behind the Models nav badge, and the
+	// badge is a 60s poll that nothing here otherwise touches. See
+	// useRefreshDiscoveryBadge.
+	const refreshBadge = useRefreshDiscoveryBadge();
 
 	const { settings, updateMutation, resetSettingMutation, isResetting } =
 		useSettingsMutations();
@@ -61,8 +66,6 @@ export function DiscoverySettings({
 	const discoverAllMutation = useMutation({
 		mutationFn: () => api.providers.discoverAll(),
 		onSuccess: () => {
-			queryClient.invalidateQueries({ queryKey: ["providers"] });
-			queryClient.invalidateQueries({ queryKey: ["models"] });
 			toast(t("settings.discovery.discoverAllComplete"), "success");
 		},
 		onError: (err: Error) => {
@@ -70,6 +73,14 @@ export function DiscoverySettings({
 				t("settings.discovery.discoverAllFailed", { message: err.message }),
 				"error",
 			);
+		},
+		onSettled: () => {
+			// `onSettled`, like useDiscoveryRetest: a sweep that errors partway has
+			// still upserted whatever it reached, so the catalogue counts above and
+			// the claim set can both move without a success.
+			queryClient.invalidateQueries({ queryKey: ["providers"] });
+			queryClient.invalidateQueries({ queryKey: ["models"] });
+			refreshBadge();
 		},
 	});
 

--- a/web/src/pages/Settings/__tests__/DiscoverySettings.test.tsx
+++ b/web/src/pages/Settings/__tests__/DiscoverySettings.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { HttpResponse, http } from "msw";
+import { Layout } from "../../../components/Layout";
 import { server } from "../../../test/mocks/server";
 import { renderWithProviders } from "../../../test/utils";
 import { DiscoverySettings } from "../DiscoverySettings";
@@ -461,6 +462,60 @@ describe("DiscoverySettings", () => {
 			await waitFor(() => {
 				expect(screen.getByText("Discovery complete")).toBeInTheDocument();
 			});
+		});
+
+		/**
+		 * The Models nav badge lives in Layout, on its own 60s poll on
+		 * ["discovery-status"]; the ["providers"] and ["models"] invalidations
+		 * this section fires never reach it. Mounted inside the real Layout so
+		 * the assertion is about the real badge, against a `claim_count` that
+		 * actually falls once the sweep lands.
+		 */
+		it("re-reads the Models nav badge after a sweep", async () => {
+			let swept = false;
+			server.use(
+				http.get("/api/discovery/status", () =>
+					HttpResponse.json({
+						claims: [],
+						group_claims: [],
+						informational: [],
+						claim_count: swept ? 1 : 4,
+						informational_unseen: 0,
+					}),
+				),
+				http.post("/api/providers/discover-all", () => {
+					swept = true;
+					return HttpResponse.json({
+						succeeded: 2,
+						failed: 0,
+						discovered: 10,
+						results: [],
+					});
+				}),
+			);
+
+			renderWithProviders(
+				<Layout>
+					<DiscoverySettings collapsed={false} onToggle={() => {}} />
+				</Layout>,
+			);
+
+			expect(
+				await screen.findByTestId("discovery-status-badge"),
+			).toHaveTextContent("4");
+
+			await userEvent
+				.setup()
+				.click(screen.getByRole("button", { name: /discover all models/i }));
+			await waitFor(() => expect(swept).toBe(true));
+
+			// A count the stale poll response would not produce, and not zero: a
+			// surviving claim pins a re-read rather than an empty badge.
+			await waitFor(() =>
+				expect(screen.getByTestId("discovery-status-badge")).toHaveTextContent(
+					"1",
+				),
+			);
 		});
 	});
 });

--- a/web/src/pages/VirtualKeys/CreateKeyModal.tsx
+++ b/web/src/pages/VirtualKeys/CreateKeyModal.tsx
@@ -150,7 +150,7 @@ export function CreateKeyModal({
 		},
 	});
 
-	const handleSubmit = (e: React.FormEvent) => {
+	const handleSubmit = (e: React.SubmitEvent) => {
 		e.preventDefault();
 		if (!name.trim()) return;
 		setProviderError("");

--- a/web/src/pages/__tests__/FailoverGroups.delete.test.tsx
+++ b/web/src/pages/__tests__/FailoverGroups.delete.test.tsx
@@ -658,10 +658,9 @@ describe("FailoverGroups", () => {
 				http.get("/api/failover-groups/candidates", () =>
 					HttpResponse.json([]),
 				),
-				http.delete("/api/failover-groups/:id", () => {
-					return deletePromise.then(
-						() => new HttpResponse(null, { status: 204 }),
-					);
+				http.delete("/api/failover-groups/:id", async () => {
+					await deletePromise;
+					return new HttpResponse(null, { status: 204 });
 				}),
 			);
 

--- a/web/src/pages/__tests__/FailoverGroups.delete.test.tsx
+++ b/web/src/pages/__tests__/FailoverGroups.delete.test.tsx
@@ -1,6 +1,7 @@
 import { screen, waitFor, within } from "@testing-library/react";
 import { HttpResponse, http } from "msw";
 import { beforeEach, describe, expect, it } from "vitest";
+import { Layout } from "../../components/Layout";
 import { mockFailoverGroup } from "../../test/mocks/data";
 import { server } from "../../test/mocks/server";
 import { renderWithProviders } from "../../test/utils";
@@ -742,6 +743,120 @@ describe("FailoverGroups", () => {
 			// The confirmBulkDelete function should early return when bulkDeleteIds is null/empty
 			// This is tested implicitly by the absence of any API calls or toasts
 			// when no groups are selected
+		});
+	});
+
+	/**
+	 * An auto-disabled group IS a counted claim: listGroupClaims selects
+	 * `group_enabled = false AND auto_disabled_at IS NOT NULL`, and
+	 * GetDiscoveryStatus adds those to claim_count alongside the model claims.
+	 * So deleting or re-enabling one moves the Models nav badge, which lives in
+	 * Layout on its own 60s poll that this page's ["failover-groups"]
+	 * invalidation never reached.
+	 */
+	describe("Models nav badge", () => {
+		const status = (claim_count: number) => ({
+			claims: [],
+			group_claims: [],
+			informational: [],
+			claim_count,
+			informational_unseen: 0,
+		});
+
+		const groupWithEntries = {
+			...mockFailoverGroup,
+			entries: [
+				{
+					provider_name: "Test Provider",
+					model_id: "test-model",
+					enabled: true,
+					model_uuid: "model-001",
+				},
+			],
+		};
+
+		it("re-reads the badge after a group is deleted", async () => {
+			let deleted = false;
+			server.use(
+				http.get("/api/failover-groups", () =>
+					HttpResponse.json({
+						groups: deleted ? [] : [groupWithEntries],
+						last_synced_at: null,
+					}),
+				),
+				http.get("/api/discovery/status", () =>
+					HttpResponse.json(status(deleted ? 1 : 2)),
+				),
+				http.delete("/api/failover-groups/:id", () => {
+					deleted = true;
+					return HttpResponse.json({});
+				}),
+			);
+
+			const { user } = renderWithProviders(
+				<Layout>
+					<FailoverGroups />
+				</Layout>,
+			);
+
+			expect(
+				await screen.findByTestId("discovery-status-badge"),
+			).toHaveTextContent("2");
+
+			await user.click(
+				(await screen.findAllByRole("button", { name: "Delete" }))[0],
+			);
+			await user.click(getModalDeleteButton());
+			await waitFor(() => expect(deleted).toBe(true));
+
+			// A model claim survives, so this pins a re-read rather than a badge
+			// that merely happens to be empty.
+			await waitFor(() =>
+				expect(screen.getByTestId("discovery-status-badge")).toHaveTextContent(
+					"1",
+				),
+			);
+		});
+
+		it("re-reads the badge after a group delete that reports failure", async () => {
+			// A rejected DELETE does not prove the row survived, and the bulk
+			// handlers on this page already re-read from their catch.
+			let deleted = false;
+			server.use(
+				http.get("/api/failover-groups", () =>
+					HttpResponse.json({
+						groups: [groupWithEntries],
+						last_synced_at: null,
+					}),
+				),
+				http.get("/api/discovery/status", () =>
+					HttpResponse.json(status(deleted ? 0 : 1)),
+				),
+				http.delete("/api/failover-groups/:id", () => {
+					deleted = true;
+					return HttpResponse.json({ error: "boom" }, { status: 500 });
+				}),
+			);
+
+			const { user } = renderWithProviders(
+				<Layout>
+					<FailoverGroups />
+				</Layout>,
+			);
+
+			expect(
+				await screen.findByTestId("discovery-status-badge"),
+			).toHaveTextContent("1");
+
+			await user.click(
+				(await screen.findAllByRole("button", { name: "Delete" }))[0],
+			);
+			await user.click(getModalDeleteButton());
+			await waitFor(() => expect(deleted).toBe(true));
+
+			await waitFor(() =>
+				expect(screen.queryByTestId("discovery-status-badge")).toBeNull(),
+			);
 		});
 	});
 });

--- a/web/src/pages/__tests__/Models.test.tsx
+++ b/web/src/pages/__tests__/Models.test.tsx
@@ -2,6 +2,7 @@ import { screen, waitFor, within } from "@testing-library/react";
 import { HttpResponse, http } from "msw";
 import { beforeEach, describe, expect, it } from "vitest";
 import type { Model } from "../../api/types";
+import { Layout } from "../../components/Layout";
 import { mockModel, mockProvider } from "../../test/mocks/data";
 import { server } from "../../test/mocks/server";
 import { renderWithProviders } from "../../test/utils";
@@ -972,6 +973,263 @@ describe("Models", () => {
 
 			// Should still render models without provider data
 			expect(screen.getByText("Test Model")).toBeInTheDocument();
+		});
+	});
+
+	/**
+	 * The Models nav badge lives in Layout, on its own 60s poll on
+	 * ["discovery-status"]: this page's `["models"]` invalidations never reach
+	 * it. So these mount the page inside the real Layout and read the real badge
+	 * rather than a probe query, and each serves a `claim_count` that actually
+	 * falls once the write lands — a fixed payload would be right by accident
+	 * whether or not anything re-read it.
+	 */
+	describe("Models nav badge", () => {
+		const status = (claim_count: number) => ({
+			claims: [],
+			group_claims: [],
+			informational: [],
+			claim_count,
+			informational_unseen: 0,
+		});
+
+		const disabledModel = {
+			...mockModel,
+			id: "model-002",
+			model_id: "test-model-v2",
+			name: "Retired Model",
+			display_name: "Retired Model v2",
+			enabled: false,
+		};
+
+		function renderInLayout() {
+			return renderWithProviders(
+				<Layout>
+					<Models />
+				</Layout>,
+			);
+		}
+
+		/** Opens the detail modal for the enabled mock model. */
+		async function openDetailModal(
+			user: ReturnType<typeof renderWithProviders>["user"],
+		) {
+			await user.click(
+				(await screen.findByText("Test Model")).closest("tr") as HTMLElement,
+			);
+			return screen.findByRole("dialog");
+		}
+
+		it("re-reads the badge after a model is deleted", async () => {
+			// Deleting a gone model is one way to resolve its claim, and it is done
+			// from this page with the badge in view.
+			let deleted = false;
+			server.use(
+				http.get("/api/models", () =>
+					HttpResponse.json(deleted ? [] : [mockModel]),
+				),
+				http.get("/api/providers", () => HttpResponse.json([mockProvider])),
+				http.get("/api/discovery/status", () =>
+					HttpResponse.json(status(deleted ? 0 : 1)),
+				),
+				http.delete("/api/models/:id", () => {
+					deleted = true;
+					return new HttpResponse(null, { status: 204 });
+				}),
+			);
+
+			const { user } = renderInLayout();
+			expect(
+				await screen.findByTestId("discovery-status-badge"),
+			).toHaveTextContent("1");
+
+			const modal = await openDetailModal(user);
+			await user.click(within(modal).getByRole("button", { name: "Delete" }));
+			await user.click(
+				within(modal).getByRole("button", { name: "Confirm delete" }),
+			);
+			await waitFor(() => expect(deleted).toBe(true));
+
+			// Gone entirely, which the stale poll response would never produce.
+			await waitFor(() =>
+				expect(screen.queryByTestId("discovery-status-badge")).toBeNull(),
+			);
+		});
+
+		it("clears the table row too when a delete reports failure", async () => {
+			// Re-reading only the badge would leave the page contradicting itself:
+			// the count drops to reflect a model that is gone while its row sits
+			// there claiming it still exists. Both re-read on settle.
+			let deleted = false;
+			server.use(
+				http.get("/api/models", () =>
+					HttpResponse.json(deleted ? [] : [mockModel]),
+				),
+				http.get("/api/providers", () => HttpResponse.json([mockProvider])),
+				http.get("/api/discovery/status", () =>
+					HttpResponse.json(status(deleted ? 0 : 1)),
+				),
+				http.delete("/api/models/:id", () => {
+					deleted = true;
+					return HttpResponse.json({ error: "boom" }, { status: 500 });
+				}),
+			);
+
+			const { user } = renderInLayout();
+			expect(
+				await screen.findByTestId("discovery-status-badge"),
+			).toHaveTextContent("1");
+
+			const modal = await openDetailModal(user);
+			await user.click(within(modal).getByRole("button", { name: "Delete" }));
+			await user.click(
+				within(modal).getByRole("button", { name: "Confirm delete" }),
+			);
+			await screen.findByText(/Failed to delete/);
+
+			await waitFor(() => expect(screen.queryByText("Test Model")).toBeNull());
+			expect(screen.queryByTestId("discovery-status-badge")).toBeNull();
+		});
+
+		it("re-reads the badge after the disabled models are bulk deleted", async () => {
+			let deleted = false;
+			server.use(
+				http.get("/api/models", () =>
+					HttpResponse.json(deleted ? [mockModel] : [mockModel, disabledModel]),
+				),
+				http.get("/api/providers", () => HttpResponse.json([mockProvider])),
+				http.get("/api/discovery/status", () =>
+					HttpResponse.json(status(deleted ? 1 : 2)),
+				),
+				http.post("/api/models/bulk-delete", () => {
+					deleted = true;
+					return HttpResponse.json({ requested: 1, deleted: 1 });
+				}),
+			);
+
+			const { user } = renderInLayout();
+			expect(
+				await screen.findByTestId("discovery-status-badge"),
+			).toHaveTextContent("2");
+
+			await user.click(await screen.findByText("Delete 1 disabled"));
+			// ConfirmDialog confirms through the modal's fade-out, so the request is
+			// a timer away from the click, not a microtask.
+			await user.click(within(screen.getByRole("dialog")).getByText("Delete"));
+			await waitFor(() => expect(deleted).toBe(true));
+
+			// The enabled model's claim survives, so this pins a re-read rather than
+			// a badge that merely happens to be empty.
+			await waitFor(() =>
+				expect(screen.getByTestId("discovery-status-badge")).toHaveTextContent(
+					"1",
+				),
+			);
+		});
+
+		it("re-reads the badge after a model is toggled", async () => {
+			// Toggling reclassifies rather than removes: buildProviderClaims puts an
+			// enabled model in Suspect, and Suspect is not counted, so re-enabling a
+			// Gone model drops claim_count without deleting anything.
+			let enabled = false;
+			server.use(
+				http.get("/api/models", () =>
+					HttpResponse.json([{ ...mockModel, enabled }]),
+				),
+				http.get("/api/providers", () => HttpResponse.json([mockProvider])),
+				http.get("/api/discovery/status", () =>
+					HttpResponse.json(status(enabled ? 1 : 2)),
+				),
+				http.patch("/api/models/:id", () => {
+					enabled = true;
+					return HttpResponse.json({ ...mockModel, enabled: true });
+				}),
+			);
+
+			const { user } = renderInLayout();
+			expect(
+				await screen.findByTestId("discovery-status-badge"),
+			).toHaveTextContent("2");
+
+			const modal = await openDetailModal(user);
+			await user.click(
+				within(modal).getByRole("button", { name: /Enabled|Disabled/i }),
+			);
+			await waitFor(() => expect(enabled).toBe(true));
+
+			await waitFor(() =>
+				expect(screen.getByTestId("discovery-status-badge")).toHaveTextContent(
+					"1",
+				),
+			);
+		});
+
+		it("re-reads the badge after a bulk delete that reports failure", async () => {
+			// A rejected request does not prove the write did not land: the server
+			// can commit and the response be lost. The toast reports the failure,
+			// but the badge must not keep asserting a count it can no longer back.
+			let deleted = false;
+			server.use(
+				http.get("/api/models", () =>
+					HttpResponse.json(deleted ? [mockModel] : [mockModel, disabledModel]),
+				),
+				http.get("/api/providers", () => HttpResponse.json([mockProvider])),
+				http.get("/api/discovery/status", () =>
+					HttpResponse.json(status(deleted ? 1 : 2)),
+				),
+				http.post("/api/models/bulk-delete", () => {
+					deleted = true;
+					return HttpResponse.json({ error: "boom" }, { status: 500 });
+				}),
+			);
+
+			const { user } = renderInLayout();
+			expect(
+				await screen.findByTestId("discovery-status-badge"),
+			).toHaveTextContent("2");
+
+			await user.click(await screen.findByText("Delete 1 disabled"));
+			await user.click(within(screen.getByRole("dialog")).getByText("Delete"));
+			await screen.findByText(/Failed to delete/);
+
+			await waitFor(() =>
+				expect(screen.getByTestId("discovery-status-badge")).toHaveTextContent(
+					"1",
+				),
+			);
+		});
+
+		it("re-reads the badge after a discover run from the detail modal", async () => {
+			// A discover run can clear a claim by finding the model listed again, or
+			// raise one by confirming it missing. Either way the badge is as stale
+			// as it is after a dismissal.
+			let discovered = false;
+			server.use(
+				http.get("/api/models", () => HttpResponse.json([mockModel])),
+				http.get("/api/providers", () => HttpResponse.json([mockProvider])),
+				http.get("/api/discovery/status", () =>
+					HttpResponse.json(status(discovered ? 0 : 3)),
+				),
+				http.post("/api/providers/:id/discover", () => {
+					discovered = true;
+					return HttpResponse.json({ discovered: 1, diff: {} });
+				}),
+			);
+
+			const { user } = renderInLayout();
+			expect(
+				await screen.findByTestId("discovery-status-badge"),
+			).toHaveTextContent("3");
+
+			const modal = await openDetailModal(user);
+			await user.click(
+				within(modal).getByRole("button", { name: "Update info" }),
+			);
+			await waitFor(() => expect(discovered).toBe(true));
+
+			await waitFor(() =>
+				expect(screen.queryByTestId("discovery-status-badge")).toBeNull(),
+			);
 		});
 	});
 });

--- a/web/src/pages/__tests__/Providers.test.tsx
+++ b/web/src/pages/__tests__/Providers.test.tsx
@@ -1,6 +1,7 @@
 import { screen, waitFor, within } from "@testing-library/react";
 import { HttpResponse, http } from "msw";
 import { beforeEach, describe, expect, it } from "vitest";
+import { Layout } from "../../components/Layout";
 import { mockModel, mockProvider } from "../../test/mocks/data";
 import { server } from "../../test/mocks/server";
 import { renderWithProviders } from "../../test/utils";
@@ -1517,6 +1518,169 @@ describe("Providers", () => {
 			await waitFor(() => {
 				expect(screen.getByText(/Failed to delete/)).toBeInTheDocument();
 			});
+		});
+	});
+
+	/**
+	 * The Models nav badge lives in Layout, on its own 60s poll on
+	 * ["discovery-status"]: this page's ["providers"] and ["models"]
+	 * invalidations never reach it. So these mount the page inside the real
+	 * Layout and read the real badge, against a `claim_count` that actually
+	 * moves once the write lands.
+	 *
+	 * Every one drives a path that REPORTS FAILURE, because that is what the
+	 * onSettled placement buys: a request that rejects can still have landed,
+	 * and a discovery run that errors partway has still upserted whatever it
+	 * reached.
+	 */
+	describe("Models nav badge", () => {
+		const status = (claim_count: number) => ({
+			claims: [],
+			group_claims: [],
+			informational: [],
+			claim_count,
+			informational_unseen: 0,
+		});
+
+		function renderInLayout() {
+			return renderWithProviders(
+				<Layout>
+					<Providers />
+				</Layout>,
+			);
+		}
+
+		it("re-reads the badge after a failed single-provider discover", async () => {
+			let scanned = false;
+			server.use(
+				http.get("/api/providers", () => HttpResponse.json([mockProvider])),
+				http.get("/api/discovery/status", () =>
+					HttpResponse.json(status(scanned ? 1 : 3)),
+				),
+				http.post("/api/providers/:id/discover", () => {
+					// Errored partway, after upserting part of what it found.
+					scanned = true;
+					return HttpResponse.json({ error: "upstream died" }, { status: 500 });
+				}),
+			);
+
+			const { user } = renderInLayout();
+			expect(
+				await screen.findByTestId("discovery-status-badge"),
+			).toHaveTextContent("3");
+
+			await user.click(
+				await screen.findByRole("button", { name: "Discover Models" }),
+			);
+			await waitFor(() => expect(scanned).toBe(true));
+
+			await waitFor(() =>
+				expect(screen.getByTestId("discovery-status-badge")).toHaveTextContent(
+					"1",
+				),
+			);
+		});
+
+		it("re-reads the badge after a failed discover-all sweep", async () => {
+			let swept = false;
+			server.use(
+				http.get("/api/providers", () => HttpResponse.json([mockProvider])),
+				http.get("/api/discovery/status", () =>
+					HttpResponse.json(status(swept ? 2 : 5)),
+				),
+				http.post("/api/providers/discover-all", () => {
+					swept = true;
+					return HttpResponse.json({ error: "upstream died" }, { status: 500 });
+				}),
+			);
+
+			const { user } = renderInLayout();
+			expect(
+				await screen.findByTestId("discovery-status-badge"),
+			).toHaveTextContent("5");
+
+			await user.click(
+				await screen.findByRole("button", { name: "Discover All Models" }),
+			);
+			await waitFor(() => expect(swept).toBe(true));
+
+			await waitFor(() =>
+				expect(screen.getByTestId("discovery-status-badge")).toHaveTextContent(
+					"2",
+				),
+			);
+		});
+
+		it("re-reads the badge after a provider delete that reports failure", async () => {
+			// The provider is gone and its claims with it; only the response was
+			// lost. The toast reports the failure, but the badge must not keep
+			// asserting a count it can no longer back.
+			let deleted = false;
+			server.use(
+				http.get("/api/providers", () => HttpResponse.json([mockProvider])),
+				http.get("/api/discovery/status", () =>
+					HttpResponse.json(status(deleted ? 0 : 2)),
+				),
+				http.delete("/api/providers/:id", () => {
+					deleted = true;
+					return HttpResponse.json({ error: "boom" }, { status: 500 });
+				}),
+			);
+
+			const { user } = renderInLayout();
+			expect(
+				await screen.findByTestId("discovery-status-badge"),
+			).toHaveTextContent("2");
+
+			await user.click(await screen.findByRole("button", { name: "Delete" }));
+			await user.click(
+				within(await screen.findByRole("dialog")).getByRole("button", {
+					name: "Delete",
+				}),
+			);
+			await waitFor(() => expect(deleted).toBe(true));
+
+			await waitFor(() =>
+				expect(screen.queryByTestId("discovery-status-badge")).toBeNull(),
+			);
+		});
+
+		it("clears the provider card too, not just the badge", async () => {
+			// Re-reading only the badge would leave the page contradicting itself:
+			// the sidebar count drops to reflect a provider that is gone while its
+			// card sits there claiming it still exists. Both re-read on settle.
+			let deleted = false;
+			server.use(
+				http.get("/api/providers", () =>
+					HttpResponse.json(deleted ? [] : [mockProvider]),
+				),
+				http.get("/api/discovery/status", () =>
+					HttpResponse.json(status(deleted ? 0 : 2)),
+				),
+				http.delete("/api/providers/:id", () => {
+					deleted = true;
+					return HttpResponse.json({ error: "boom" }, { status: 500 });
+				}),
+			);
+
+			const { user } = renderInLayout();
+			expect(
+				await screen.findByTestId("discovery-status-badge"),
+			).toHaveTextContent("2");
+			expect(await screen.findByText("Test Provider")).toBeInTheDocument();
+
+			await user.click(await screen.findByRole("button", { name: "Delete" }));
+			await user.click(
+				within(await screen.findByRole("dialog")).getByRole("button", {
+					name: "Delete",
+				}),
+			);
+			await waitFor(() => expect(deleted).toBe(true));
+
+			await waitFor(() =>
+				expect(screen.queryByText("Test Provider")).toBeNull(),
+			);
+			expect(screen.queryByTestId("discovery-status-badge")).toBeNull();
 		});
 	});
 });


### PR DESCRIPTION
## What

The Models nav badge is a 60s poll on its own query key, and nothing that changes the claim set touched it. Dismissing every claim and closing the modal left the badge asserting a count the server no longer had, until the next poll landed. Confirmed against prod MH1's access log:

```
14:50:25.346-.359  POST /api/discovery/dismiss  x7  (all 200)   <- "Dismiss all"
14:50:25.393       GET  /api/discovery/status  3472 bytes       <- modal's own refresh
   ... 11s gap, no requests ...                                 <- modal closed, badge still lit
14:50:36.620       GET  /api/discovery/status  3472 bytes       <- reopened (?review=1)
14:50:36.672       POST /api/discovery/changes/ack             <- journal expanded
14:50:36.703       GET  /api/discovery/status  86 bytes         <- badge finally cleared
```

## How

A shared `useRefreshDiscoveryBadge()` owns the invalidation, so the `exact: true` that keeps the modal's `?review=1` query (and its server-side last-reviewed stamp) off a click is stated once instead of at every call site.

**Every surface that can move `claim_count` now calls it**, which took three passes to get complete:

| Surface | What moves the count |
|---|---|
| Discrepancy modal | all three dismiss paths |
| `useDiscoveryRetest` | so a retest refreshes the badge from the Providers page too |
| Providers page | discover, discover-all, provider delete, disabled-model bulk delete |
| Models page | discover, single delete, bulk delete, **and the enable/disable toggle** |
| Settings | the second "Discover all" |
| EditProviderModal | `listClaimRows` joins on `p.enabled`, so switching a provider off takes every claim it owns |
| FailoverGroups + CreateGroupModal | an auto-disabled group IS a counted claim, so re-enable / delete / sync all move it |
| AddProviderModal | the scan after a create re-syncs failover, and fresh members can lift a group back over the routable floor |

Two subtleties worth reading the comments for:

- **Toggling reclassifies rather than removes.** `buildProviderClaims` puts an enabled model in Suspect, and Suspect is not counted, so enabling a Gone model drops the count without deleting anything.
- **`useDisableModel` is deliberately excluded.** It only ever acts on a model from `enabledModels`, and an enabled model is either absent from the claim set or Suspect, so `claim_count` cannot move. `UpdateModel` does no failover resync either. Recorded in the file so it is not "fixed" later.

**Refreshes moved from `onSuccess` to `onSettled`, and the lists move with the badge.** A rejected write can still have landed (the response is what was lost), and a discovery run that errors partway has still upserted whatever it reached. Re-reading only the badge would leave the page contradicting itself: the count dropping for a provider whose card is still on screen.

Seeding the badge from `refresh()`'s return value instead would save a round trip but is unsound: that value is returned even when a newer refresh has superseded it, so it can write a known-stale count into the badge. Rationale is recorded in the hook.

## Also: Escape stopped closing modals

Found while verifying the above in a real browser. Escape was handled on the dialog node, so it only saw keys originating inside that subtree. Dismissing a claim unmounts the button that had focus, focus falls to `<body>`, and the modal goes permanently deaf to Escape. Reproduced live: `document.activeElement = <BODY>`, Escape does nothing.

Now handled on the document, which does not depend on focus semantics. Restoring focus would also have fixed Tab order, but browsers disagree about whether removing a focused element fires `focusout`, so that fix would work in some and not others. A module-level stack keeps nesting correct: only the topmost dialog reacts, so a nested confirm closes before its opener. Affects every modal in the app.

## Tests

**20 new tests.** The badge ones mount each page inside the real `<Layout>` and read the real badge, against a status endpoint whose `claim_count` actually falls as writes land: a fixed payload would be right by accident whether or not anything re-read it. Several drive paths that **report failure**, since that is what the `onSettled` placement buys.

Every one was verified to fail with the fix removed, and only those (neutralising `useRefreshDiscoveryBadge` fails the 9 badge tests and nothing else; removing the `providerId` guard fails only the guard test; reverting `Modal.tsx` fails only the 4 Escape tests).

Full frontend suite green (294 files / 5657 tests), `tsc -b` and `pnpm lint` clean.

## Verified live

Rebuilt the dev container and drove it with a real browser against 114 real claims. The discriminator is **time**: the poll is 60s and a reload restarts it, so a change within 10s can only be an invalidation.

| Check | Result |
|---|---|
| Dismiss a claim, close the modal, read the badge | 110 → 109 in **5ms** |
| Enable a Gone model from the Models page | 109 → 108 in **209ms** |
| Badge agrees with `/api/discovery/status` | both 108 |
| Disable a provider drops its counted claims | 108 → 100 → 108 |
| Escape after a dismissal | closes (was: nothing) |

That fourth row is a better check than it looks: xAI owns 9 claim rows but only **8** are counted, the 9th being Stale, and the count dropped by exactly 8.

Dev was restored to exactly its prior state afterwards (`claim_count` back to 114).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
