### PR TITLE
fix(sidebar): scale nav and stats spacing on viewport height, not width

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -665,6 +665,21 @@ nav ul:has(> li > .sidebar-link) {
 	}
 }
 
+/* Wide but short (1080p and below): the sidebar column is height-constrained,
+   not width-constrained, so the width clamp above hands it its roomiest rows
+   exactly where the nav, the quota badges and the stats stop fitting. Shrink
+   the row padding on viewport height instead, between 1100px and 950px — a
+   1080p screen lands near the bottom of that ramp once browser chrome is off.
+   Scoped to >=1200px wide so it never loosens the narrow-viewport rule. */
+@media (min-width: 1200px) and (max-height: 1100px) {
+	.sidebar-link {
+		padding-block: clamp(0.2rem, 1.13vh - 7.55px, 0.5rem);
+	}
+	nav ul:has(> li > .sidebar-link) {
+		gap: 0;
+	}
+}
+
 .sidebar-link-active {
 	background-color: var(--accent-light);
 	color: var(--accent);
@@ -1298,6 +1313,19 @@ html[data-ui-style="clean-saas"].light .sidebar-quota-pill:hover {
 @media (min-width: 1536px) {
 	.sidebar-stats-content > * + * {
 		margin-top: 0.2rem;
+	}
+}
+
+/* Short viewports (1080p and below) tighten the stat rows: line spacing and
+   row gap scale down between 1100px and 950px of viewport height, font size
+   and colour stay put. Taller viewports keep the roomy spacing above. */
+@media (max-height: 1100px) {
+	.sidebar-stats-content {
+		line-height: clamp(14px, 1.67vh - 1.83px, 16.5px);
+	}
+
+	.sidebar-stats-content > * + * {
+		margin-top: clamp(1px, 1.47vh - 12.93px, 3.2px);
 	}
 }
 


### PR DESCRIPTION
## Problem

At 1080p the sidebar scrolls: the nav, the quota badges and the system-stats block don't fit in the column.

The cause is that every responsive rule on the sidebar keys on **width**, but the dimension that runs out at 1080p is **height**. At 1920 wide:

- `.sidebar-link` padding came from `clamp(0.3rem, 0.47vw - 0.25rem, 0.5rem)`, which resolves to 5.02px, near the top of the ramp.
- `.sidebar-stats-content > * + *` got its 3.2px row gap from a `@media (min-width: 1536px)` rule, so 1920 wide deliberately received the *loosest* stat spacing, on top of the inherited 1.5 line-height (16.5px rows).

Net effect: 1920x1080 gets the roomiest possible treatment exactly where vertical space is shortest. Measured at 1920x969 (1080p minus browser chrome), the nav content overflowed by 22px.

## Change

Two height-gated blocks in `web/src/index.css` that only ever tighten, ramping smoothly from 1100px down to 950px of viewport height:

```css
@media (max-height: 1100px) {
  .sidebar-stats-content         { line-height: clamp(14px, 1.67vh - 1.83px, 16.5px); }
  .sidebar-stats-content > * + * { margin-top:  clamp(1px, 1.47vh - 12.93px, 3.2px); }
}
@media (min-width: 1200px) and (max-height: 1100px) {
  .sidebar-link                    { padding-block: clamp(0.2rem, 1.13vh - 7.55px, 0.5rem); }
  nav ul:has(> li > .sidebar-link) { gap: 0; }
}
```

Only line spacing moves. Font sizes, colours, icon sizes and badge sizes are untouched. The nav block is scoped `min-width: 1200px` so it can never loosen the existing narrow-viewport rule at `max-width: 1199px`.

## Measured results

Dashboard against the dev stack, 7 quota badges wrapping to 4 rows:

| viewport height | nav overflow before → after | link padding | stats line-height | stats row gap |
|---|---|---|---|---|
| 1310 (1440p) | 0 → 0 | 5.02px *(unchanged)* | 16.5px *(unchanged)* | 3.2px *(unchanged)* |
| 1080 | 0 → 0 | 5.02 → 4.65px | 16.5 → 16.2px | 3.2 → 2.95px |
| 969 (1080p fullscreen) | **22px → 0**, 81px spare | 5.02 → 3.40px | 16.5 → 14.35px | 3.2 → 1.31px |
| 900 | 91px → 17px | 3.2px (floor) | 14px (floor) | 1px (floor) |

1440p and above is byte-identical to before, and the 1080-height row shows the boundary is a smooth ramp rather than a jump.

## Known limitation

At a 900px viewport height with 4 badge rows the nav still overflows by 17px, down from 91px. With 2-3 badge rows it clears. I stopped the ramp there rather than push nav padding below `0.2rem`, which is where the rows start looking squeezed against the 18px icons; the nav is `overflow-y-auto`, so that case degrades to scrolling rather than clipping.

## Verification

- Measured live in Chromium against the rebuilt dev stack at five viewport heights (numbers above), not estimated from the stylesheet.
- Confirmed all three `clamp()` expressions survive the Lightning CSS build intact (mixed `rem`/`vh`/`px` units are not constant-folded).
- `pnpm build` passes, Biome clean on `index.css`.
- `Layout.navigation` + `Layout.system-status` (146 tests) and `Layout.test.tsx` (32 tests) pass.
- Visually checked the rendered sidebar at 969px: all 12 nav rows, 4 badge rows, error shelf, footer and the full stats block fit with room to spare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)