### PR TITLE
fix(sso): survive a transient DNS or dial failure during OIDC and GitHub login

### DIFF
--- a/internal/adminauth/github.go
+++ b/internal/adminauth/github.go
@@ -128,7 +128,7 @@ func NewGitHubHandler(
 		masterKey:     masterKey,
 		cookieSecure:  cookieSecure,
 		loginThrottle: totp.NewThrottle(5, time.Second, 5*time.Minute),
-		httpClient:    netguard.NewClient(githubHTTPTimeout),
+		httpClient:    netguard.NewClientWithRetry(githubHTTPTimeout),
 	}
 }
 

--- a/internal/adminauth/github.go
+++ b/internal/adminauth/github.go
@@ -96,7 +96,9 @@ type GitHubHandler struct {
 	// (token exchange, /user, /user/emails). Without it oauth2 falls back to
 	// http.DefaultClient; routing through netguard blocks metadata/link-local
 	// targets and keeps parity with the OIDC handler. github.com is public, so
-	// normal login is unaffected (netguard permits only what it must).
+	// normal login is unaffected (netguard permits only what it must). It also
+	// retries a request that failed before reaching GitHub so a momentary DNS or
+	// dial fault does not cost the user the whole login.
 	httpClient *http.Client
 
 	// cached holds the lazily-built oauth2 config for one config fingerprint,

--- a/internal/adminauth/github_test.go
+++ b/internal/adminauth/github_test.go
@@ -15,6 +15,7 @@ import (
 	"golang.org/x/oauth2"
 
 	"github.com/hugalafutro/model-hotel/internal/auth"
+	"github.com/hugalafutro/model-hotel/internal/netguard"
 	"github.com/hugalafutro/model-hotel/internal/webauthn"
 )
 
@@ -606,6 +607,11 @@ func TestNewGitHubHandler_UsesNetguardClient(t *testing.T) {
 	h := NewGitHubHandler(newFakeSettings(map[string]string{}), sessionMgr, mockIPLimiter{}, testMasterKey, "auto")
 	if h.httpClient == nil {
 		t.Fatal("GitHubHandler.httpClient must be an SSRF-guarded netguard client, got nil")
+	}
+	// GitHub SSO is the same kind of path as OIDC: a pre-connection failure
+	// after the user has already authenticated must not cost them the flow.
+	if _, ok := h.httpClient.Transport.(*netguard.RetryTransport); !ok {
+		t.Fatalf("httpClient.Transport = %T, want *netguard.RetryTransport", h.httpClient.Transport)
 	}
 	// Prove it is genuinely the netguard-guarded client, not merely non-nil: a
 	// plain http.Client would dial the link-local cloud-metadata address; the

--- a/internal/adminauth/oidc.go
+++ b/internal/adminauth/oidc.go
@@ -86,10 +86,12 @@ type OIDCHandler struct {
 	cookieSecure string
 
 	// httpClient is an SSRF-guarded client used for every outbound OIDC request
-	// (discovery, token exchange, UserInfo). Without it go-oidc/oauth2 fall back
-	// to http.DefaultClient, letting an admin-configured (or fleet-synced) issuer
-	// URL reach cloud-metadata/link-local addresses. It allows private/loopback
-	// so an internal IdP (e.g. Authelia on the docker network) still works.
+	// (discovery, token exchange, JWKS, UserInfo). Without it go-oidc/oauth2 fall
+	// back to http.DefaultClient, letting an admin-configured (or fleet-synced)
+	// issuer URL reach cloud-metadata/link-local addresses. It allows
+	// private/loopback so an internal IdP (e.g. Authelia on the docker network)
+	// still works, and retries a request that failed before reaching the IdP so a
+	// momentary DNS or dial fault does not cost the user the whole login.
 	httpClient *http.Client
 
 	// loginThrottle applies per-IP exponential backoff to the callback, mirroring
@@ -123,7 +125,7 @@ func NewOIDCHandler(
 		useCookieAuth: useCookieAuth,
 		cookieSecure:  cookieSecure,
 		loginThrottle: totp.NewThrottle(5, time.Second, 5*time.Minute),
-		httpClient:    netguard.NewClient(oidcHTTPTimeout),
+		httpClient:    netguard.NewClientWithRetry(oidcHTTPTimeout),
 	}
 }
 

--- a/internal/adminauth/oidc_test.go
+++ b/internal/adminauth/oidc_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/hugalafutro/model-hotel/internal/auth"
 	"github.com/hugalafutro/model-hotel/internal/authcookie"
+	"github.com/hugalafutro/model-hotel/internal/netguard"
 	"github.com/hugalafutro/model-hotel/internal/webauthn"
 )
 
@@ -1018,5 +1019,33 @@ func TestConsumeLoginStateSingleUseUnderRace(t *testing.T) {
 	// DELETE removed nothing, so the single-use guard must reject it.
 	if _, err := sm.ConsumeLoginState(context.Background(), id); err == nil {
 		t.Fatal("second consume should fail (record already claimed)")
+	}
+}
+
+// TestNewOIDCHandler_UsesRetryingNetguardClient guards the wiring behind the
+// 2026-08-04 prod incident: the token exchange runs after the user has already
+// round-tripped through the IdP, so a transient DNS failure there costs them the
+// entire flow, consent screen included. The client must retry a pre-connection
+// failure and must still refuse the link-local metadata address.
+func TestNewOIDCHandler_UsesRetryingNetguardClient(t *testing.T) {
+	sessionMgr := webauthn.NewSessionManager(newMemStore())
+	h := NewOIDCHandler(newFakeSettings(map[string]string{}), sessionMgr, mockIPLimiter{}, testMasterKey, false, "auto")
+	if h.httpClient == nil {
+		t.Fatal("OIDCHandler.httpClient must be a netguard client, got nil")
+	}
+	if _, ok := h.httpClient.Transport.(*netguard.RetryTransport); !ok {
+		t.Fatalf("httpClient.Transport = %T, want *netguard.RetryTransport", h.httpClient.Transport)
+	}
+	req, err := http.NewRequest(http.MethodGet, "http://169.254.169.254/latest/meta-data/", http.NoBody)
+	if err != nil {
+		t.Fatalf("build metadata request: %v", err)
+	}
+	resp, err := h.httpClient.Do(req)
+	if err == nil {
+		_ = resp.Body.Close()
+		t.Fatal("httpClient reached the link-local metadata address; expected a netguard dial block")
+	}
+	if !errors.Is(err, netguard.ErrBlockedAddress) {
+		t.Fatalf("want netguard.ErrBlockedAddress, got %v", err)
 	}
 }

--- a/internal/netguard/netguard.go
+++ b/internal/netguard/netguard.go
@@ -12,6 +12,7 @@
 package netguard
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -51,6 +52,11 @@ func BlockedIP(ip net.IP) bool {
 		ip.IsLinkLocalMulticast()
 }
 
+// ErrBlockedAddress is the dial guard's denial: the resolved address is one
+// netguard refuses to connect to. It is permanent, never transient, so a caller
+// must not retry it.
+var ErrBlockedAddress = errors.New("netguard: refusing to connect to blocked address")
+
 // dialControl is the net.Dialer.Control hook that rejects a connection whose
 // resolved address is a blocked IP. It runs after DNS resolution on the actual
 // dial target, so it also catches DNS rebinding (a hostname that resolves to a
@@ -62,7 +68,7 @@ func dialControl(_, address string, _ syscall.RawConn) error {
 		return err
 	}
 	if ip := net.ParseIP(host); ip != nil && BlockedIP(ip) {
-		return fmt.Errorf("netguard: refusing to connect to blocked address %s", host)
+		return fmt.Errorf("%w %s", ErrBlockedAddress, host)
 	}
 	return nil
 }

--- a/internal/netguard/netguard_test.go
+++ b/internal/netguard/netguard_test.go
@@ -1,6 +1,7 @@
 package netguard
 
 import (
+	"errors"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -132,6 +133,25 @@ func TestValidateURL(t *testing.T) {
 		if (err != nil) != tc.wantErr {
 			t.Errorf("ValidateURL(%q) err=%v, wantErr=%v", tc.url, err, tc.wantErr)
 		}
+	}
+}
+
+// TestDialControlErrorIsSentinel pins the blocked-address denial to a sentinel
+// error. RetryTransport relies on it to tell a permanent security refusal apart
+// from a transient dial fault, which it would otherwise retry pointlessly.
+func TestDialControlErrorIsSentinel(t *testing.T) {
+	client := NewClient(2 * time.Second)
+	req, err := http.NewRequest(http.MethodGet, "http://169.254.169.254/latest/meta-data/", http.NoBody)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	resp, err := client.Do(req)
+	if err == nil {
+		_ = resp.Body.Close()
+		t.Fatal("dial to the link-local metadata address succeeded; expected a netguard block")
+	}
+	if !errors.Is(err, ErrBlockedAddress) {
+		t.Fatalf("dial guard error must wrap ErrBlockedAddress, got %v", err)
 	}
 }
 

--- a/internal/netguard/retry.go
+++ b/internal/netguard/retry.go
@@ -91,10 +91,11 @@ func preConnectionFailure(err error) bool {
 }
 
 // replayable reports whether the request body can be produced a second time.
-// A nil body always can; otherwise it takes GetBody, which http.NewRequest sets
-// for the in-memory body types the oauth2 and oidc packages use.
+// A nil body and http.NoBody are both trivially reproducible; otherwise it
+// takes GetBody, which http.NewRequest sets for the in-memory body types the
+// oauth2 and oidc packages use.
 func replayable(req *http.Request) bool {
-	return req.Body == nil || req.GetBody != nil
+	return req.Body == nil || req.Body == http.NoBody || req.GetBody != nil
 }
 
 // replayRequest clones req with a freshly opened body, because the previous

--- a/internal/netguard/retry.go
+++ b/internal/netguard/retry.go
@@ -1,0 +1,124 @@
+package netguard
+
+import (
+	"errors"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/hugalafutro/model-hotel/internal/debuglog"
+)
+
+// retryAttempts is how many times a login-path request is issued in total: the
+// original plus one retry. Every attempt shares the client's single overall
+// timeout, so after a resolver that took seconds to fail there is rarely budget
+// left for a third.
+const retryAttempts = 2
+
+// retryDelay spaces the retry far enough to clear a momentary resolver failure
+// without noticeably lengthening a login the user is already waiting on.
+const retryDelay = 250 * time.Millisecond
+
+// RetryTransport re-issues a request that failed before any byte reached the
+// server: a DNS resolution failure or a dial failure. Both mean the server never
+// saw the request, so re-issuing is safe for any method, including the
+// non-idempotent OIDC token POST.
+//
+// Nothing past connection setup is retried. Once a connection exists a failure
+// may mean the server processed the request and only the response was lost, and
+// replaying a single-use authorization code in that state would turn a transient
+// error into a hard invalid_grant.
+//
+// Base must be non-nil.
+type RetryTransport struct {
+	Base     http.RoundTripper
+	Attempts int
+	Delay    time.Duration
+}
+
+// RoundTrip implements http.RoundTripper. It returns the underlying error
+// unchanged on the last attempt, for an error that is not a pre-connection
+// failure, and for a body that cannot be rewound.
+func (t *RetryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	for attempt := 1; ; attempt++ {
+		attemptReq := req
+		if attempt > 1 {
+			replay, err := replayRequest(req)
+			if err != nil {
+				return nil, err
+			}
+			attemptReq = replay
+		}
+
+		resp, err := t.Base.RoundTrip(attemptReq)
+		if err == nil {
+			return resp, nil
+		}
+		if attempt >= t.Attempts || !preConnectionFailure(err) || !replayable(req) {
+			return nil, err
+		}
+
+		// Worth a WARN even when the retry succeeds: it is the only signal that
+		// the resolver is flaking. The error text carries the host and resolver,
+		// never a credential, which live in the request body.
+		debuglog.Warn("netguard: retrying request after pre-connection failure",
+			"method", req.Method, "host", req.URL.Host, "attempt", attempt, "error", err)
+
+		select {
+		case <-req.Context().Done():
+			// Surface the transport failure rather than the context error: it is
+			// the cause an operator needs, and http.Client reports its own
+			// timeout separately.
+			return nil, err
+		case <-time.After(t.Delay):
+		}
+	}
+}
+
+// preConnectionFailure reports whether err occurred before the request could
+// reach the server, which is what makes re-issuing it safe.
+func preConnectionFailure(err error) bool {
+	// A blocked address is a permanent security denial, not a transient fault.
+	if errors.Is(err, ErrBlockedAddress) {
+		return false
+	}
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return true
+	}
+	var opErr *net.OpError
+	return errors.As(err, &opErr) && opErr.Op == "dial"
+}
+
+// replayable reports whether the request body can be produced a second time.
+// A nil body always can; otherwise it takes GetBody, which http.NewRequest sets
+// for the in-memory body types the oauth2 and oidc packages use.
+func replayable(req *http.Request) bool {
+	return req.Body == nil || req.GetBody != nil
+}
+
+// replayRequest clones req with a freshly opened body, because the previous
+// RoundTrip has already consumed and closed the original.
+func replayRequest(req *http.Request) (*http.Request, error) {
+	clone := req.Clone(req.Context())
+	if req.GetBody == nil {
+		return clone, nil
+	}
+	body, err := req.GetBody()
+	if err != nil {
+		return nil, err
+	}
+	clone.Body = body
+	return clone, nil
+}
+
+// NewClientWithRetry builds a NewClient that also re-issues a request which
+// failed before reaching the server. Login paths use it: a momentary resolver
+// failure on the token exchange would otherwise throw the user back to the login
+// screen with the whole IdP round trip, consent screen included, to repeat.
+// Fire-and-forget senders keep NewClient.
+func NewClientWithRetry(timeout time.Duration) *http.Client {
+	c := NewClient(timeout)
+	c.Transport = &RetryTransport{Base: c.Transport, Attempts: retryAttempts, Delay: retryDelay}
+	return c
+}

--- a/internal/netguard/retry.go
+++ b/internal/netguard/retry.go
@@ -38,8 +38,8 @@ const retryDelay = 250 * time.Millisecond
 // authorization code in that state would turn a transient error into a hard
 // invalid_grant.
 //
-// Base must be non-nil. Attempts below 2 issues the request exactly once, which
-// makes the zero value a passthrough.
+// Base must be non-nil. An Attempts below 2 issues the request exactly once,
+// which makes the zero value a passthrough.
 type RetryTransport struct {
 	Base     http.RoundTripper
 	Attempts int

--- a/internal/netguard/retry.go
+++ b/internal/netguard/retry.go
@@ -1,6 +1,7 @@
 package netguard
 
 import (
+	"context"
 	"errors"
 	"net"
 	"net/http"
@@ -21,9 +22,10 @@ const retryAttempts = 2
 // without noticeably lengthening a login the user is already waiting on.
 const retryDelay = 250 * time.Millisecond
 
-// RetryTransport re-issues a request whose error is a DNS resolution or dial
-// failure. Normally that means nothing ever left this process, so re-issuing is
-// safe for any method, including the non-idempotent OIDC token POST.
+// RetryTransport re-issues a request whose error is a transient DNS resolution
+// or dial failure, including the dial of an egress proxy. Normally that means
+// nothing ever left this process, so re-issuing is safe for any method,
+// including the non-idempotent OIDC token POST.
 //
 // One shape is not purely pre-connection: net/http re-issues a request itself
 // when a reused connection dies, and if the follow-up dial then fails, that dial
@@ -46,10 +48,12 @@ type RetryTransport struct {
 	Delay    time.Duration
 }
 
-// RoundTrip implements http.RoundTripper. It returns the underlying error
-// unchanged on the last attempt, for an error that is not a pre-connection
-// failure, and for a body that cannot be rewound.
+// RoundTrip implements http.RoundTripper. It returns the transport error on the
+// last attempt, for an error that is not a pre-connection failure, and for a
+// body that cannot be rewound. When a later attempt dies on the client's own
+// deadline, the first attempt's error is returned instead: it names the cause.
 func (t *RetryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	var firstErr error
 	for attempt := 1; ; attempt++ {
 		attemptReq := req
 		if attempt > 1 {
@@ -64,8 +68,11 @@ func (t *RetryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		if err == nil {
 			return resp, nil
 		}
+		if firstErr == nil {
+			firstErr = err
+		}
 		if attempt >= t.Attempts || !preConnectionFailure(err) || !replayable(req) {
-			return nil, err
+			return nil, diagnosableError(firstErr, err)
 		}
 
 		// Worth a WARN even when the retry succeeds: it is the only signal that
@@ -79,7 +86,7 @@ func (t *RetryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 			// Surface the transport failure rather than the context error: it is
 			// the cause an operator needs, and http.Client reports its own
 			// timeout separately.
-			return nil, err
+			return nil, diagnosableError(firstErr, err)
 		case <-time.After(t.Delay):
 		}
 	}
@@ -94,19 +101,57 @@ func (t *RetryTransport) CloseIdleConnections() {
 	}
 }
 
-// preConnectionFailure reports whether err is a DNS or dial failure. See
-// RetryTransport for why re-issuing on those is safe.
+// preConnectionFailure reports whether err is a transient DNS or dial failure.
+// See RetryTransport for why re-issuing on those is safe.
 func preConnectionFailure(err error) bool {
 	// A blocked address is a permanent security denial, not a transient fault.
+	// errors.Is unwraps the whole chain, so this still wins when the denial
+	// arrives inside a proxy's connect error.
 	if errors.Is(err, ErrBlockedAddress) {
 		return false
 	}
 	var dnsErr *net.DNSError
 	if errors.As(err, &dnsErr) {
-		return true
+		// NXDOMAIN is the resolver's definitive answer that the host does not
+		// exist, typically a typo'd issuer or a decommissioned IdP domain. A
+		// second lookup buys the same answer plus the delay, and two WARN lines
+		// where one clear failure is what an operator wants.
+		return !dnsErr.IsNotFound
 	}
+	return dialFailure(err)
+}
+
+// dialFailure reports whether any error in err's chain is a failed connection
+// attempt. errors.As binds only the outermost match, and net/http wraps every
+// dial error as an outer OpError{Op: "proxyconnect"} once HTTP(S)_PROXY is set,
+// so inspecting one value would miss every dial failure behind an egress proxy.
+// Both shapes stop short of the origin server, so both are safe to re-issue.
+func dialFailure(err error) bool {
 	var opErr *net.OpError
-	return errors.As(err, &opErr) && opErr.Op == "dial"
+	for errors.As(err, &opErr) {
+		if opErr.Op == "dial" || opErr.Op == "proxyconnect" {
+			return true
+		}
+		err = opErr.Err
+	}
+	return false
+}
+
+// diagnosableError picks which attempt's error to surface. A retry issued near
+// the end of the client's timeout can fail on the deadline alone, reporting a
+// generic context error in place of the transport cause the first attempt named,
+// so that first error wins whenever it is the more specific of the two.
+func diagnosableError(first, last error) error {
+	if contextError(last) && !contextError(first) {
+		return first
+	}
+	return last
+}
+
+// contextError reports whether err is the request context expiring or being
+// cancelled, which says only that time ran out, never why.
+func contextError(err error) bool {
+	return errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled)
 }
 
 // replayable reports whether the request body can be produced a second time.

--- a/internal/netguard/retry.go
+++ b/internal/netguard/retry.go
@@ -12,24 +12,34 @@ import (
 // retryAttempts is how many times a login-path request is issued in total: the
 // original plus one retry. Every attempt shares the client's single overall
 // timeout, so after a resolver that took seconds to fail there is rarely budget
-// left for a third.
+// left for a third. The retry is best-effort within that budget: a failure that
+// takes the whole timeout to surface leaves no room for it, so this rescues a
+// fast pre-connection failure and not a slow one.
 const retryAttempts = 2
 
 // retryDelay spaces the retry far enough to clear a momentary resolver failure
 // without noticeably lengthening a login the user is already waiting on.
 const retryDelay = 250 * time.Millisecond
 
-// RetryTransport re-issues a request that failed before any byte reached the
-// server: a DNS resolution failure or a dial failure. Both mean the server never
-// saw the request, so re-issuing is safe for any method, including the
-// non-idempotent OIDC token POST.
+// RetryTransport re-issues a request whose error is a DNS resolution or dial
+// failure. Normally that means nothing ever left this process, so re-issuing is
+// safe for any method, including the non-idempotent OIDC token POST.
 //
-// Nothing past connection setup is retried. Once a connection exists a failure
-// may mean the server processed the request and only the response was lost, and
-// replaying a single-use authorization code in that state would turn a transient
-// error into a hard invalid_grant.
+// One shape is not purely pre-connection: net/http re-issues a request itself
+// when a reused connection dies, and if the follow-up dial then fails, that dial
+// error surfaces here even though an earlier attempt was already written to a
+// server. The stdlib only re-issues a request it has deemed replayable (GET,
+// HEAD, OPTIONS, TRACE, or one carrying an Idempotency-Key), so those are
+// idempotent by HTTP semantics and one more issue changes nothing. A
+// non-idempotent POST never reaches that path.
 //
-// Base must be non-nil.
+// Any other error is returned untouched. Once a connection carries the request,
+// a lost response may mean the server processed it, and replaying a single-use
+// authorization code in that state would turn a transient error into a hard
+// invalid_grant.
+//
+// Base must be non-nil. Attempts below 2 issues the request exactly once, which
+// makes the zero value a passthrough.
 type RetryTransport struct {
 	Base     http.RoundTripper
 	Attempts int
@@ -75,8 +85,17 @@ func (t *RetryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 }
 
-// preConnectionFailure reports whether err occurred before the request could
-// reach the server, which is what makes re-issuing it safe.
+// CloseIdleConnections keeps (*http.Client).CloseIdleConnections working: the
+// client type-asserts its transport for this method, so a wrapper that omits it
+// turns the call into a silent no-op. Bases without it are left alone.
+func (t *RetryTransport) CloseIdleConnections() {
+	if c, ok := t.Base.(interface{ CloseIdleConnections() }); ok {
+		c.CloseIdleConnections()
+	}
+}
+
+// preConnectionFailure reports whether err is a DNS or dial failure. See
+// RetryTransport for why re-issuing on those is safe.
 func preConnectionFailure(err error) bool {
 	// A blocked address is a permanent security denial, not a transient fault.
 	if errors.Is(err, ErrBlockedAddress) {

--- a/internal/netguard/retry_test.go
+++ b/internal/netguard/retry_test.go
@@ -110,20 +110,18 @@ func TestRetryTransport_RetriesDialFailure(t *testing.T) {
 	}
 }
 
-// TestRetryTransport_RetriesBodylessRequest covers a GET with no body: replay
-// takes the req.GetBody == nil branch in replayRequest rather than reopening a
-// body that never existed.
-func TestRetryTransport_RetriesBodylessRequest(t *testing.T) {
+// TestRetryTransport_RetriesNoBodyRequest covers a GET built the idiomatic
+// way, with http.NoBody: net/http leaves req.Body non-nil (http.NoBody) and
+// req.GetBody nil for this case, so it exercises both the req.Body ==
+// http.NoBody clause in replayable and the req.GetBody == nil branch in
+// replayRequest.
+func TestRetryTransport_RetriesNoBodyRequest(t *testing.T) {
 	stub := &stubTransport{results: []stubResult{
 		{err: dnsFailure()},
 		{resp: okResponse()},
 	}}
 	rt := &RetryTransport{Base: stub, Attempts: 2, Delay: time.Millisecond}
-	// A literal nil body (not http.NoBody) is deliberate: it leaves req.GetBody
-	// nil while req.Body is also nil, which is what exercises replayRequest's
-	// req.GetBody == nil branch. http.NoBody would leave req.Body non-nil with
-	// req.GetBody nil, which replayable() correctly treats as unreplayable.
-	req, err := http.NewRequest(http.MethodGet, "https://idp.example.test/jwks", nil) //nolint:gocritic // see comment above: nil body is required to hit the replay branch under test
+	req, err := http.NewRequest(http.MethodGet, "https://idp.example.test/jwks", http.NoBody)
 	if err != nil {
 		t.Fatalf("build request: %v", err)
 	}

--- a/internal/netguard/retry_test.go
+++ b/internal/netguard/retry_test.go
@@ -136,6 +136,37 @@ func TestRetryTransport_RetriesNoBodyRequest(t *testing.T) {
 	}
 }
 
+// TestRetryTransport_RetriesNilBodyRequest covers the shape go-oidc sends for
+// three of the four OIDC hops: discovery, JWKS and UserInfo are built with
+// http.NewRequest and a literal nil body, which leaves both req.Body and
+// req.GetBody nil. That is the req.Body == nil clause in replayable, a different
+// clause from the http.NoBody one GitHub's helpers exercise.
+func TestRetryTransport_RetriesNilBodyRequest(t *testing.T) {
+	stub := &stubTransport{results: []stubResult{
+		{err: dnsFailure()},
+		{resp: okResponse()},
+	}}
+	rt := &RetryTransport{Base: stub, Attempts: 2, Delay: time.Millisecond}
+	//nolint:gocritic // httpNoBody: go-oidc passes a literal nil body, and the
+	// point of this test is that exact request shape.
+	req, err := http.NewRequest(http.MethodGet, "https://idp.example.test/.well-known/openid-configuration", nil)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	if req.Body != nil || req.GetBody != nil {
+		t.Fatalf("Body = %v, GetBody set = %t; want both nil so the nil-body clause is what is under test", req.Body, req.GetBody != nil)
+	}
+
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip = %v, want success on the retry", err)
+	}
+	_ = resp.Body.Close()
+	if stub.calls != 2 {
+		t.Fatalf("calls = %d, want 2: a nil-body request is replayable", stub.calls)
+	}
+}
+
 // TestRetryTransport_SucceedsWithoutRetry keeps the common path honest: a
 // working request is issued exactly once.
 func TestRetryTransport_SucceedsWithoutRetry(t *testing.T) {
@@ -257,6 +288,42 @@ func TestRetryTransport_StopsOnCancelledContext(t *testing.T) {
 	}
 	if stub.calls != 1 {
 		t.Fatalf("calls = %d, want 1", stub.calls)
+	}
+}
+
+// closeIdleBase is a base transport that also implements the CloseIdleConnections
+// interface http.Client looks for, and records that it was reached.
+type closeIdleBase struct {
+	stubTransport
+	closed int
+}
+
+func (c *closeIdleBase) CloseIdleConnections() { c.closed++ }
+
+// TestRetryTransport_CloseIdleConnectionsReachesBase: http.Client type-asserts
+// its transport for CloseIdleConnections, so without the passthrough the wrapper
+// would silently turn every caller's close into a no-op.
+func TestRetryTransport_CloseIdleConnectionsReachesBase(t *testing.T) {
+	base := &closeIdleBase{}
+	client := &http.Client{Transport: &RetryTransport{Base: base, Attempts: 2, Delay: time.Millisecond}}
+
+	client.CloseIdleConnections()
+
+	if base.closed != 1 {
+		t.Fatalf("base CloseIdleConnections calls = %d, want 1", base.closed)
+	}
+}
+
+// TestRetryTransport_CloseIdleConnectionsIgnoresBaseWithout: a base that does not
+// implement the interface makes the call a no-op, not a panic.
+func TestRetryTransport_CloseIdleConnectionsIgnoresBaseWithout(t *testing.T) {
+	base := &stubTransport{}
+	rt := &RetryTransport{Base: base, Attempts: 2, Delay: time.Millisecond}
+
+	rt.CloseIdleConnections()
+
+	if base.calls != 0 {
+		t.Fatalf("calls = %d, want 0: closing idle connections must not issue a request", base.calls)
 	}
 }
 

--- a/internal/netguard/retry_test.go
+++ b/internal/netguard/retry_test.go
@@ -1,0 +1,284 @@
+package netguard
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+// stubTransport returns a scripted result per call and records the request body
+// it saw each time, so a test can prove the body was replayed intact.
+type stubTransport struct {
+	results []stubResult
+	calls   int
+	bodies  []string
+}
+
+type stubResult struct {
+	resp *http.Response
+	err  error
+}
+
+func (s *stubTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	body := ""
+	if req.Body != nil {
+		b, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		_ = req.Body.Close()
+		body = string(b)
+	}
+	s.bodies = append(s.bodies, body)
+	i := s.calls
+	s.calls++
+	if i >= len(s.results) {
+		return nil, fmt.Errorf("stub: unexpected call %d", i+1)
+	}
+	return s.results[i].resp, s.results[i].err
+}
+
+func okResponse() *http.Response {
+	return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("ok"))}
+}
+
+// dnsFailure mirrors the shape net/http surfaces for the prod incident:
+// "dial tcp: lookup auth.zmrd.uk on 127.0.0.11:53: server misbehaving".
+func dnsFailure() error {
+	return &net.OpError{
+		Op:  "dial",
+		Net: "tcp",
+		Err: &net.DNSError{Err: "server misbehaving", Name: "auth.example.test", Server: "127.0.0.11:53"},
+	}
+}
+
+func postRequest(t *testing.T, body string) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, "https://idp.example.test/token", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	return req
+}
+
+// TestRetryTransport_RetriesDNSFailure is the prod incident: the token POST dies
+// on DNS before reaching the IdP, and the retry has to carry the same body.
+func TestRetryTransport_RetriesDNSFailure(t *testing.T) {
+	stub := &stubTransport{results: []stubResult{
+		{err: dnsFailure()},
+		{resp: okResponse()},
+	}}
+	rt := &RetryTransport{Base: stub, Attempts: 2, Delay: time.Millisecond}
+
+	resp, err := rt.RoundTrip(postRequest(t, "grant_type=authorization_code&code=abc"))
+	if err != nil {
+		t.Fatalf("RoundTrip = %v, want success on the retry", err)
+	}
+	_ = resp.Body.Close()
+	if stub.calls != 2 {
+		t.Fatalf("calls = %d, want 2", stub.calls)
+	}
+	for i, got := range stub.bodies {
+		if got != "grant_type=authorization_code&code=abc" {
+			t.Fatalf("attempt %d body = %q, want the original body replayed", i+1, got)
+		}
+	}
+}
+
+// TestRetryTransport_RetriesDialFailure covers a dial that fails for a reason
+// other than DNS (refused, unreachable): still nothing reached the server.
+func TestRetryTransport_RetriesDialFailure(t *testing.T) {
+	stub := &stubTransport{results: []stubResult{
+		{err: &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("connection refused")}},
+		{resp: okResponse()},
+	}}
+	rt := &RetryTransport{Base: stub, Attempts: 2, Delay: time.Millisecond}
+
+	resp, err := rt.RoundTrip(postRequest(t, "x=1"))
+	if err != nil {
+		t.Fatalf("RoundTrip = %v, want success on the retry", err)
+	}
+	_ = resp.Body.Close()
+	if stub.calls != 2 {
+		t.Fatalf("calls = %d, want 2", stub.calls)
+	}
+}
+
+// TestRetryTransport_RetriesBodylessRequest covers a GET with no body: replay
+// takes the req.GetBody == nil branch in replayRequest rather than reopening a
+// body that never existed.
+func TestRetryTransport_RetriesBodylessRequest(t *testing.T) {
+	stub := &stubTransport{results: []stubResult{
+		{err: dnsFailure()},
+		{resp: okResponse()},
+	}}
+	rt := &RetryTransport{Base: stub, Attempts: 2, Delay: time.Millisecond}
+	// A literal nil body (not http.NoBody) is deliberate: it leaves req.GetBody
+	// nil while req.Body is also nil, which is what exercises replayRequest's
+	// req.GetBody == nil branch. http.NoBody would leave req.Body non-nil with
+	// req.GetBody nil, which replayable() correctly treats as unreplayable.
+	req, err := http.NewRequest(http.MethodGet, "https://idp.example.test/jwks", nil) //nolint:gocritic // see comment above: nil body is required to hit the replay branch under test
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip = %v, want success on the retry", err)
+	}
+	_ = resp.Body.Close()
+	if stub.calls != 2 {
+		t.Fatalf("calls = %d, want 2", stub.calls)
+	}
+}
+
+// TestRetryTransport_SucceedsWithoutRetry keeps the common path honest: a
+// working request is issued exactly once.
+func TestRetryTransport_SucceedsWithoutRetry(t *testing.T) {
+	stub := &stubTransport{results: []stubResult{{resp: okResponse()}}}
+	rt := &RetryTransport{Base: stub, Attempts: 2, Delay: time.Millisecond}
+
+	resp, err := rt.RoundTrip(postRequest(t, "x=1"))
+	if err != nil {
+		t.Fatalf("RoundTrip = %v, want success", err)
+	}
+	_ = resp.Body.Close()
+	if stub.calls != 1 {
+		t.Fatalf("calls = %d, want 1", stub.calls)
+	}
+}
+
+// TestRetryTransport_DoesNotRetryAfterConnect is the safety property: once a
+// connection exists, the server may have consumed the single-use authorization
+// code, so a lost response must never be replayed.
+func TestRetryTransport_DoesNotRetryAfterConnect(t *testing.T) {
+	stub := &stubTransport{results: []stubResult{
+		{err: &net.OpError{Op: "read", Net: "tcp", Err: io.ErrUnexpectedEOF}},
+	}}
+	rt := &RetryTransport{Base: stub, Attempts: 2, Delay: time.Millisecond}
+
+	if _, err := rt.RoundTrip(postRequest(t, "x=1")); err == nil {
+		t.Fatal("RoundTrip = nil error, want the read failure surfaced")
+	}
+	if stub.calls != 1 {
+		t.Fatalf("calls = %d, want 1: a post-connection failure must not be replayed", stub.calls)
+	}
+}
+
+// TestRetryTransport_DoesNotRetryBlockedAddress: an SSRF denial is permanent,
+// so retrying it only doubles the delay before the same refusal.
+func TestRetryTransport_DoesNotRetryBlockedAddress(t *testing.T) {
+	stub := &stubTransport{results: []stubResult{
+		{err: &net.OpError{Op: "dial", Net: "tcp", Err: fmt.Errorf("%w %s", ErrBlockedAddress, "169.254.169.254")}},
+	}}
+	rt := &RetryTransport{Base: stub, Attempts: 2, Delay: time.Millisecond}
+
+	_, err := rt.RoundTrip(postRequest(t, "x=1"))
+	if !errors.Is(err, ErrBlockedAddress) {
+		t.Fatalf("RoundTrip = %v, want ErrBlockedAddress", err)
+	}
+	if stub.calls != 1 {
+		t.Fatalf("calls = %d, want 1: a security denial must not be retried", stub.calls)
+	}
+}
+
+// TestRetryTransport_DoesNotRetryUnrewindableBody: without GetBody the body is
+// already drained, so a second attempt would send a truncated request.
+func TestRetryTransport_DoesNotRetryUnrewindableBody(t *testing.T) {
+	stub := &stubTransport{results: []stubResult{{err: dnsFailure()}}}
+	rt := &RetryTransport{Base: stub, Attempts: 2, Delay: time.Millisecond}
+	req := postRequest(t, "x=1")
+	req.GetBody = nil
+
+	if _, err := rt.RoundTrip(req); err == nil {
+		t.Fatal("RoundTrip = nil error, want the dial failure surfaced")
+	}
+	if stub.calls != 1 {
+		t.Fatalf("calls = %d, want 1: an unrewindable body must not be replayed", stub.calls)
+	}
+}
+
+// TestRetryTransport_SurfacesGetBodyError: if the body cannot be reopened the
+// caller gets that reason rather than a silent second attempt.
+func TestRetryTransport_SurfacesGetBodyError(t *testing.T) {
+	stub := &stubTransport{results: []stubResult{{err: dnsFailure()}}}
+	rt := &RetryTransport{Base: stub, Attempts: 2, Delay: time.Millisecond}
+	req := postRequest(t, "x=1")
+	rewindErr := errors.New("body source is gone")
+	req.GetBody = func() (io.ReadCloser, error) { return nil, rewindErr }
+
+	_, err := rt.RoundTrip(req)
+	if !errors.Is(err, rewindErr) {
+		t.Fatalf("RoundTrip = %v, want the GetBody error", err)
+	}
+	if stub.calls != 1 {
+		t.Fatalf("calls = %d, want 1", stub.calls)
+	}
+}
+
+// TestRetryTransport_ReturnsLastErrorWhenAttemptsExhausted: a resolver that is
+// still sick fails the same way it does today, no worse.
+func TestRetryTransport_ReturnsLastErrorWhenAttemptsExhausted(t *testing.T) {
+	stub := &stubTransport{results: []stubResult{
+		{err: dnsFailure()},
+		{err: dnsFailure()},
+	}}
+	rt := &RetryTransport{Base: stub, Attempts: 2, Delay: time.Millisecond}
+
+	_, err := rt.RoundTrip(postRequest(t, "x=1"))
+	var dnsErr *net.DNSError
+	if !errors.As(err, &dnsErr) {
+		t.Fatalf("RoundTrip = %v, want the DNS failure surfaced", err)
+	}
+	if stub.calls != 2 {
+		t.Fatalf("calls = %d, want 2", stub.calls)
+	}
+}
+
+// TestRetryTransport_StopsOnCancelledContext: the backoff must not outlive the
+// request's own deadline.
+func TestRetryTransport_StopsOnCancelledContext(t *testing.T) {
+	stub := &stubTransport{results: []stubResult{{err: dnsFailure()}}}
+	rt := &RetryTransport{Base: stub, Attempts: 2, Delay: 30 * time.Second}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	req := postRequest(t, "x=1").WithContext(ctx)
+
+	start := time.Now()
+	if _, err := rt.RoundTrip(req); err == nil {
+		t.Fatal("RoundTrip = nil error, want the dial failure surfaced")
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("RoundTrip waited %v; a cancelled context must abandon the backoff", elapsed)
+	}
+	if stub.calls != 1 {
+		t.Fatalf("calls = %d, want 1", stub.calls)
+	}
+}
+
+// TestNewClientWithRetry_StillBlocksMetadata proves the wrapper did not defeat
+// the SSRF guard it wraps.
+func TestNewClientWithRetry_StillBlocksMetadata(t *testing.T) {
+	client := NewClientWithRetry(2 * time.Second)
+	if _, ok := client.Transport.(*RetryTransport); !ok {
+		t.Fatalf("Transport = %T, want *RetryTransport", client.Transport)
+	}
+	req, err := http.NewRequest(http.MethodGet, "http://169.254.169.254/latest/meta-data/", http.NoBody)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	resp, err := client.Do(req)
+	if err == nil {
+		_ = resp.Body.Close()
+		t.Fatal("retrying client reached the link-local metadata address")
+	}
+	if !errors.Is(err, ErrBlockedAddress) {
+		t.Fatalf("want ErrBlockedAddress, got %v", err)
+	}
+}

--- a/internal/netguard/retry_test.go
+++ b/internal/netguard/retry_test.go
@@ -110,6 +110,131 @@ func TestRetryTransport_RetriesDialFailure(t *testing.T) {
 	}
 }
 
+// proxyConnectFailure mirrors the shape net/http surfaces when HTTP(S)_PROXY is
+// set and the proxy itself cannot be dialled: dialConn wraps the dial OpError in
+// an outer OpError with Op "proxyconnect".
+func proxyConnectFailure(inner error) error {
+	return &net.OpError{Op: "proxyconnect", Net: "tcp", Err: inner}
+}
+
+// TestRetryTransport_RetriesProxyConnectFailure: with an egress proxy in front
+// of the IdP, a failed dial reaches the transport under a proxyconnect wrapper.
+// Nothing reached the origin, so it retries like any other dial failure.
+func TestRetryTransport_RetriesProxyConnectFailure(t *testing.T) {
+	stub := &stubTransport{results: []stubResult{
+		{err: proxyConnectFailure(&net.OpError{Op: "dial", Net: "tcp", Err: errors.New("connection refused")})},
+		{resp: okResponse()},
+	}}
+	rt := &RetryTransport{Base: stub, Attempts: 2, Delay: time.Millisecond}
+
+	resp, err := rt.RoundTrip(postRequest(t, "x=1"))
+	if err != nil {
+		t.Fatalf("RoundTrip = %v, want success on the retry", err)
+	}
+	_ = resp.Body.Close()
+	if stub.calls != 2 {
+		t.Fatalf("calls = %d, want 2: a proxy dial failure never reached the origin", stub.calls)
+	}
+}
+
+// TestRetryTransport_RetriesProxyTLSFailure: with an https:// egress proxy, a
+// TLS handshake failure against the proxy is wrapped as proxyconnect around an
+// error that is not itself a dial OpError. The CONNECT never went out, so the
+// origin never saw the request and re-issuing is safe.
+func TestRetryTransport_RetriesProxyTLSFailure(t *testing.T) {
+	stub := &stubTransport{results: []stubResult{
+		{err: proxyConnectFailure(errors.New("tls: failed to verify certificate"))},
+		{resp: okResponse()},
+	}}
+	rt := &RetryTransport{Base: stub, Attempts: 2, Delay: time.Millisecond}
+
+	resp, err := rt.RoundTrip(postRequest(t, "x=1"))
+	if err != nil {
+		t.Fatalf("RoundTrip = %v, want success on the retry", err)
+	}
+	_ = resp.Body.Close()
+	if stub.calls != 2 {
+		t.Fatalf("calls = %d, want 2: the proxy handshake failed before any CONNECT", stub.calls)
+	}
+}
+
+// TestRetryTransport_DoesNotRetryBlockedAddressBehindProxy: the SSRF denial is
+// still permanent when it arrives nested inside a proxyconnect wrapper.
+func TestRetryTransport_DoesNotRetryBlockedAddressBehindProxy(t *testing.T) {
+	blocked := &net.OpError{Op: "dial", Net: "tcp", Err: fmt.Errorf("%w %s", ErrBlockedAddress, "169.254.169.254")}
+	stub := &stubTransport{results: []stubResult{{err: proxyConnectFailure(blocked)}}}
+	rt := &RetryTransport{Base: stub, Attempts: 2, Delay: time.Millisecond}
+
+	_, err := rt.RoundTrip(postRequest(t, "x=1"))
+	if !errors.Is(err, ErrBlockedAddress) {
+		t.Fatalf("RoundTrip = %v, want ErrBlockedAddress", err)
+	}
+	if stub.calls != 1 {
+		t.Fatalf("calls = %d, want 1: a security denial must not be retried", stub.calls)
+	}
+}
+
+// TestRetryTransport_DoesNotRetryNonExistentHost: NXDOMAIN is the resolver's
+// definitive answer, so a typo'd issuer host fails once and clearly.
+func TestRetryTransport_DoesNotRetryNonExistentHost(t *testing.T) {
+	notFound := &net.OpError{
+		Op:  "dial",
+		Net: "tcp",
+		Err: &net.DNSError{Err: "no such host", Name: "typo.example.test", IsNotFound: true},
+	}
+	stub := &stubTransport{results: []stubResult{{err: notFound}}}
+	rt := &RetryTransport{Base: stub, Attempts: 2, Delay: time.Millisecond}
+
+	_, err := rt.RoundTrip(postRequest(t, "x=1"))
+	var dnsErr *net.DNSError
+	if !errors.As(err, &dnsErr) {
+		t.Fatalf("RoundTrip = %v, want the DNS failure surfaced", err)
+	}
+	if stub.calls != 1 {
+		t.Fatalf("calls = %d, want 1: a host that does not exist must not be retried", stub.calls)
+	}
+}
+
+// TestRetryTransport_PrefersTransportErrorOverContextDeadline: a retry issued
+// with little budget left can die on the client timeout alone. The operator
+// needs the resolver failure that started it, not a bare deadline.
+func TestRetryTransport_PrefersTransportErrorOverContextDeadline(t *testing.T) {
+	stub := &stubTransport{results: []stubResult{
+		{err: dnsFailure()},
+		{err: context.DeadlineExceeded},
+	}}
+	rt := &RetryTransport{Base: stub, Attempts: 2, Delay: time.Millisecond}
+
+	_, err := rt.RoundTrip(postRequest(t, "x=1"))
+	var dnsErr *net.DNSError
+	if !errors.As(err, &dnsErr) {
+		t.Fatalf("RoundTrip = %v, want the first attempt's DNS failure, not the deadline", err)
+	}
+	if stub.calls != 2 {
+		t.Fatalf("calls = %d, want 2", stub.calls)
+	}
+}
+
+// TestRetryTransport_ReturnsContextErrorWhenFirstIsAlsoContext: a dial that
+// times out on the request context is itself a context error, so there is no
+// more specific cause to preserve and the last error stands.
+func TestRetryTransport_ReturnsContextErrorWhenFirstIsAlsoContext(t *testing.T) {
+	lastErr := fmt.Errorf("second attempt: %w", context.DeadlineExceeded)
+	stub := &stubTransport{results: []stubResult{
+		{err: &net.OpError{Op: "dial", Net: "tcp", Err: context.DeadlineExceeded}},
+		{err: lastErr},
+	}}
+	rt := &RetryTransport{Base: stub, Attempts: 2, Delay: time.Millisecond}
+
+	_, err := rt.RoundTrip(postRequest(t, "x=1"))
+	if !errors.Is(err, lastErr) {
+		t.Fatalf("RoundTrip = %v, want the last attempt's error", err)
+	}
+	if stub.calls != 2 {
+		t.Fatalf("calls = %d, want 2", stub.calls)
+	}
+}
+
 // TestRetryTransport_RetriesNoBodyRequest covers a GET built the idiomatic
 // way, with http.NoBody: net/http leaves req.Body non-nil (http.NoBody) and
 // req.GetBody nil for this case, so it exercises both the req.Body ==
@@ -254,9 +379,10 @@ func TestRetryTransport_SurfacesGetBodyError(t *testing.T) {
 // TestRetryTransport_ReturnsLastErrorWhenAttemptsExhausted: a resolver that is
 // still sick fails the same way it does today, no worse.
 func TestRetryTransport_ReturnsLastErrorWhenAttemptsExhausted(t *testing.T) {
+	lastErr := dnsFailure()
 	stub := &stubTransport{results: []stubResult{
 		{err: dnsFailure()},
-		{err: dnsFailure()},
+		{err: lastErr},
 	}}
 	rt := &RetryTransport{Base: stub, Attempts: 2, Delay: time.Millisecond}
 
@@ -264,6 +390,11 @@ func TestRetryTransport_ReturnsLastErrorWhenAttemptsExhausted(t *testing.T) {
 	var dnsErr *net.DNSError
 	if !errors.As(err, &dnsErr) {
 		t.Fatalf("RoundTrip = %v, want the DNS failure surfaced", err)
+	}
+	// The most recent failure, not the first: substituting the first attempt's
+	// error is reserved for a last attempt that only reports a deadline.
+	if !errors.Is(err, lastErr) {
+		t.Fatalf("RoundTrip = %v, want the last attempt's error", err)
 	}
 	if stub.calls != 2 {
 		t.Fatalf("calls = %d, want 2", stub.calls)

--- a/web/src/utils/logBadgeUtils.test.ts
+++ b/web/src/utils/logBadgeUtils.test.ts
@@ -177,6 +177,14 @@ describe("getSourceBadgeClasses", () => {
 		expect(result).toContain("text-orange-400");
 	});
 
+	it("returns a bold red for netguard, distinct from modelsdev", () => {
+		const result = getSourceBadgeClasses("netguard");
+		expect(result).toContain("bg-red-500/30");
+		expect(result).toContain("text-red-200");
+		// Must not collide with the muted rose used for `modelsdev`.
+		expect(result).not.toBe(getSourceBadgeClasses("modelsdev"));
+	});
+
 	it("returns rose classes for modelsdev", () => {
 		const result = getSourceBadgeClasses("modelsdev");
 		expect(result).toContain("bg-rose-900/30");

--- a/web/src/utils/logBadgeUtils.ts
+++ b/web/src/utils/logBadgeUtils.ts
@@ -64,6 +64,11 @@ export const getSourceBadgeClasses = (source: string) => {
 			// brighter teal than the muted `resolve` teal so the two stay
 			// distinguishable in the source column, mirroring the HA pattern above.
 			return "bg-teal-500/30 text-teal-200";
+		case "netguard":
+			// Outbound network guard: SSRF refusals and pre-connection retries. A
+			// bold red for the guard, kept clear of the muted rose `modelsdev` uses
+			// so the two never read as the same badge.
+			return "bg-red-500/30 text-red-200";
 		case "modelsdev":
 			return "bg-rose-900/30 text-rose-400";
 		case "applogs":

--- a/wiki/Request-Logging.md
+++ b/wiki/Request-Logging.md
@@ -276,7 +276,8 @@ case-insensitively). The canonical scopes are:
 
 `proxy`, `resolve`, `discovery`, `failover`, `provider`, `settings`, `backup`,
 `webauthn`, `stats`, `system`, `db`, `admin`, `applogs`, `events`, `ratelimit`,
-`keycache`, `docker`, `auth`, `model`, `virtual-keys`, `version`, `api`.
+`keycache`, `docker`, `auth`, `model`, `virtual-keys`, `version`, `api`,
+`netguard`.
 
 Both variables are startup-only (env vars, set via `.env` / compose). See
 [[Configuration]] for the full table.


### PR DESCRIPTION
## The incident

On 2026-08-04 a Front Desk SSO login failed after the user had already authenticated and consented at Authelia. The callback's token exchange never left the container:

```
level=WARN msg="oidc: callback failed" reason="code exchange failed"
error="Post \"https://auth.zmrd.uk/api/oidc/token\": dial tcp:
       lookup auth.zmrd.uk on 127.0.0.11:53: server misbehaving"
```

Authelia logged no token request, confirming nothing reached it. The same hostname resolved fine 8 seconds earlier (discovery) and 12 seconds later (the successful retry). Resolution took ~9 seconds to fail, then the user was returned to the login screen with the whole IdP round trip, consent screen included, to repeat.

No resolver is 100% reliable, so the login path has to tolerate a blip.

## The change

`RetryTransport` wraps the SSRF-guarded `netguard` client and re-issues a request only when it failed **before any byte reached the origin server**. Wrapping the transport rather than each call site means one line at each handler constructor covers all four OIDC hops (discovery, token exchange, JWKS fetch, UserInfo) plus GitHub SSO, with no edits inside the handler methods.

- `internal/netguard/netguard.go` - the dial guard's denial becomes the `ErrBlockedAddress` sentinel, rendered message unchanged
- `internal/netguard/retry.go` (new) - `RetryTransport`, the predicate, body replay, `NewClientWithRetry`
- `internal/adminauth/{oidc,github}.go` - both SSO constructors adopt it

`internal/alert/dispatcher.go` deliberately keeps plain `NewClient`. That is scope discipline, not a safety argument: a pre-connection retry cannot duplicate a notification any more than it can duplicate a token exchange. Alerts simply are not the reported failure.

## Why re-issuing a non-idempotent POST is safe

A DNS or dial failure means the server never saw the request. Anything at or after the origin connection is never retried, because a lost response may mean the server already consumed the single-use authorization code, which would turn a transient error into a hard `invalid_grant`.

One shape is not purely pre-connection: `net/http` re-issues a request itself when a reused connection dies, and a follow-up dial failure surfaces here even though an earlier attempt was written. The stdlib gates that on `Request.isReplayable` (GET/HEAD/OPTIONS/TRACE, or an `Idempotency-Key`), so those are idempotent by HTTP semantics and the OIDC token POST can never reach that path. This is stated in the type doc rather than left implicit.

Also not retried: a blocked address (a permanent SSRF denial, checked first so the dial branch cannot shadow it), NXDOMAIN (a definitive "host does not exist", typically a typo'd issuer), and any request whose body cannot be reproduced.

## Verification

**Live, against a rebuilt dev container** driving real OIDC discovery, with resolution broken inside the container:

| Scenario | Result | Duration | Reading |
|---|---|---|---|
| Refused dial | 503 | 254ms | 250ms retry delay + two dials, retried once |
| Blocked address | 503 | 4.6ms | no delay, single attempt, correctly not retried |
| Healthy | 302 | 29ms | single successful attempt |

```
level=WARNING netguard: retrying request after pre-connection failure
  method=GET host=auth.zmrd.uk attempt=1 error=dial tcp 127.0.0.1:443: connect: connection refused
```

Exactly one warning per request, so exactly two attempts, never more.

**Unit tests** script the exact `server misbehaving` error from the incident and assert both attempts plus intact body replay. Every guard is mutation-verified: deleting it fails a named test.

The in-call rescue (attempt 1 fails, attempt 2 succeeds) is proven at the unit level only. Landing a repair inside the 250ms window on a live stack needs timing that the runtime cache makes impractical.

## Review history worth knowing about

Two bugs were found late and are instructive, because both are cases where a test passes for a reason other than the one it names and coverage tooling cannot see the difference:

1. **`replayable` excluded `http.NoBody`.** An idiomatic bodyless GET silently opted out of the retry, and this repo's own `gocritic` rule pushes authors toward exactly that spelling. The predicate now matches the stdlib's own `Request.isReplayable` clause for clause.
2. **`errors.As` binds the outermost match.** With `HTTP(S)_PROXY` set, which `netguard.NewClient` deliberately supports, Go wraps dial errors as `OpError{Op:"proxyconnect", Err: OpError{Op:"dial"}}`, so the predicate read the wrapper and returned false. Dial failures behind an egress proxy were never retried. DNS failures masked it because `*net.DNSError` unwraps all the way down. `dialFailure` now walks the chain.

Both landed with tests that fail when the fix is reverted.

## Also included

`netguard` was a brand-new log scope emitting nothing before this branch. It is now in the canonical scope list in the wiki and has a dashboard badge, so the new WARN does not render unlabeled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
