### PR TITLE
fix(deps): patch Front Desk's transitive undici and close the Dependabot blind spot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,16 @@ updates:
       npm-deps:
         patterns: ["*"]
 
+  # Front Desk's UI is its own pnpm workspace root, so it needs its own entry;
+  # the /web one does not reach it.
+  - package-ecosystem: "npm"
+    directory: "/frontdesk/web"
+    schedule:
+      interval: "weekly"
+    groups:
+      frontdesk-npm-deps:
+        patterns: ["*"]
+
   - package-ecosystem: "docker"
     directory: "/"
     schedule:

--- a/frontdesk/web/pnpm-lock.yaml
+++ b/frontdesk/web/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   '@babel/core': ^7.29.6
   undici@6: ^6.27.0
-  undici@7: ^7.28.0
+  undici@7: ^7.29.0
   postcss: ^8.5.18
 
 importers:
@@ -1729,8 +1729,8 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   until-async@3.0.2:
@@ -3011,7 +3011,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.28.0
+      undici: 7.29.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -3438,7 +3438,7 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   until-async@3.0.2: {}
 

--- a/frontdesk/web/pnpm-workspace.yaml
+++ b/frontdesk/web/pnpm-workspace.yaml
@@ -16,7 +16,9 @@ minimumReleaseAge: 1440
 overrides:
   "@babel/core": "^7.29.6"
   "undici@6": "^6.27.0"
-  "undici@7": "^7.28.0"
+  # Transitive via jsdom. 7.29.0 patches the cache-directive, retry-interceptor,
+  # cookie-attribute and blob-type advisories that hit every 7.x below it.
+  "undici@7": "^7.29.0"
   # Transitive via vite. Fixes GHSA-r28c-9q8g-f849 (path traversal in postcss's
   # sourceMappingURL auto-loading, arbitrary .map disclosure); 8.5.15 was the
   # resolved version and anything <= 8.5.17 is vulnerable. web/ needs no

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   '@babel/core': ^7.29.6
   undici@6: ^6.27.0
-  undici@7: ^7.28.0
+  undici@7: ^7.29.0
 
 importers:
 

--- a/web/pnpm-workspace.yaml
+++ b/web/pnpm-workspace.yaml
@@ -22,4 +22,4 @@ overrides:
   # SOCKS5 cross-origin routing, and keep-alive response-queue poisoning.
   # Remove each line once a direct dependency requires the patched range itself.
   "undici@6": "^6.27.0"
-  "undici@7": "^7.28.0"
+  "undici@7": "^7.29.0"


### PR DESCRIPTION
Closes all five open Dependabot alerts (#29, #27, #26, #23, #21). They are the same package: `undici` 7.28.0 in `frontdesk/web`, transitive via jsdom, all patched in 7.29.0.

## Why only Front Desk was affected

`web/` escaped these on its own: the jsdom 29 -> 30 bump in #623 moved it to undici **8.9.0**, outside the vulnerable `>= 7.0.0, < 7.29.0` range.

Front Desk's UI is deliberately its own pnpm workspace root, and `.github/dependabot.yml` only had an npm entry for `/web` — which does not reach it. So `frontdesk/web` has never had a dependency PR: its `jsdom ^29.1.1` stayed put and kept resolving undici 7.28.0. The alerts are the visible end of that gap.

## Changes

- `frontdesk/web/pnpm-workspace.yaml`: `undici@7` override floor `^7.28.0` -> `^7.29.0`, with a note on what 7.29.0 patches. Lockfile now resolves 7.29.0.
- `web/pnpm-workspace.yaml`: same floor raise. The override is currently inert there (the tree is on undici 8), but the two files document themselves as mirrored, so they stay mirrored. Its lockfile diff is the one `settings.overrides` line.
- `.github/dependabot.yml`: new weekly npm entry for `/frontdesk/web`, grouped as `frontdesk-npm-deps` so it arrives as one PR, matching the `/web` shape. This is the part that stops the gap recurring.

## Verification (local)

- `frontdesk/web`: `pnpm install --frozen-lockfile` clean (CI's install mode), `vitest run` 440 passed / 0 failed, `pnpm build` (tsc -b + vite build) ok, `pnpm lint` clean, `pnpm typecheck:tests` clean.
- `web`: `pnpm install --frozen-lockfile` clean, resolved package set unchanged.
- `make notices` regenerates identically, so `THIRD-PARTY-NOTICES.md` needs no update: it does not scan `frontdesk/web`, and `web/`'s resolved versions did not move.
- `.github/dependabot.yml` parses as YAML.

Expect a `frontdesk-npm-deps` PR on the next Dependabot run, likely a jsdom 29 -> 30 bump among others, which is the durable fix for the undici 7 line here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
