### PR TITLE
fix(configsync): order the virtual-key export by a column that syncs

### DIFF
--- a/internal/api/configsync_export.go
+++ b/internal/api/configsync_export.go
@@ -46,10 +46,11 @@ func (h *ConfigSyncHandler) Version(w http.ResponseWriter, r *http.Request) {
 	// Marshal only the Config payload. Every list is ordered by a column a unique
 	// index makes total, so no two rows tie and fall back to physical row order:
 	// providers by name, failover groups by display_model, users by username,
-	// virtual keys by (created_at, key_hash), disabled models by (provider,
-	// model_id). encoding/json key-sorts the settings map. The bytes are therefore
-	// deterministic for an unchanged config, and two members holding the same config
-	// hash identically.
+	// virtual keys by key_hash, disabled models by (provider, model_id).
+	// encoding/json key-sorts the settings map. Every ordering column also rides in
+	// the payload itself, never an instance-local one like created_at, so the bytes
+	// are deterministic for an unchanged config and two members holding the same
+	// config hash identically.
 	payload, err := json.Marshal(env.Config)
 	if err != nil {
 		debuglog.Error("configsync: marshal config for version", "error", err)
@@ -412,18 +413,21 @@ func exportProviders(ctx context.Context, q querier) ([]ExportProvider, error) {
 	return out, rows.Err()
 }
 
-// exportVirtualKeys lists every virtual key by (created_at, key_hash). The
-// tiebreaker is load-bearing: an import writes every key in one transaction, so a
-// whole fleet's keys share a created_at, and without a second ordering column tied
-// rows come back in physical row order. A row rewrite on either side would then
-// reorder byte-identical config and change its hash, which Front Desk reads as a
-// member that has not converged. key_hash is unique, so the order is total.
+// exportVirtualKeys lists every virtual key by key_hash, the one ordering
+// column that is both unique (so no row ever ties and falls back to physical row
+// order) and part of the synced payload itself. Ordering by anything
+// instance-local breaks fleet convergence: created_at, for example, never rides
+// in the envelope, and an import writes every key in one transaction, so a
+// member's keys all share one created_at while the primary's keep their distinct
+// history. The same keys would then serialize in different orders on the two
+// instances, their config hashes would never match, and Front Desk would re-sync
+// the member forever.
 func exportVirtualKeys(ctx context.Context, q querier, idToName map[string]string) ([]ExportVK, error) {
 	rows, err := q.Query(ctx, `
 		SELECT vk.name, vk.key_hash, vk.key_preview, vk.rate_limit_rps, vk.rate_limit_burst, vk.rate_limit_tpm,
 		       vk.allowed_providers, vk.strip_reasoning, u.username
 		FROM virtual_keys vk LEFT JOIN users u ON u.id = vk.owner_user_id
-		ORDER BY vk.created_at, vk.key_hash`)
+		ORDER BY vk.key_hash`)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/api/configsync_test.go
+++ b/internal/api/configsync_test.go
@@ -134,20 +134,18 @@ func TestConfigSync_VersionStableAndChanges(t *testing.T) {
 }
 
 // TestConfigSync_ExportOrdersTiedVirtualKeysDeterministically pins the ordering
-// guarantee the config hash rests on. An import writes every virtual key in one
-// transaction, so a whole fleet's keys share a created_at; ordering by created_at
-// alone leaves tied rows in physical row order, which any row rewrite can change.
-// Byte-identical config would then hash differently, and Front Desk reads a hash
-// that differs as a member that has not converged. key_hash is unique, so it makes
-// the order total.
+// guarantee the config hash rests on: virtual keys export in key_hash order,
+// whatever their physical row order, and a row rewrite that changes no exported
+// field moves neither the order nor the hash. Front Desk reads a hash that
+// differs as a member that has not converged, so any physical-order leak here
+// re-syncs a converged member.
 func TestConfigSync_ExportOrdersTiedVirtualKeysDeterministically(t *testing.T) {
 	cleanConfigTables(t)
 	ctx := context.Background()
 	r := newConfigSyncRouter(t, configSyncMasterKey)
 
 	// Seeded in reverse key_hash order, sharing one created_at, so physical row
-	// order is the opposite of the order the export must produce. Only the
-	// tiebreaker can turn one into the other.
+	// order is the opposite of the order the export must produce.
 	for _, h := range []string{"hash-c", "hash-b", "hash-a"} {
 		if _, err := apiTestDB.Pool().Exec(ctx, `
 			INSERT INTO virtual_keys (name, key_hash, key_preview, created_at)
@@ -168,7 +166,7 @@ func TestConfigSync_ExportOrdersTiedVirtualKeysDeterministically(t *testing.T) {
 
 	want := []string{"hash-a", "hash-b", "hash-c"}
 	if got := exportedHashes(); !slices.Equal(got, want) {
-		t.Fatalf("tied virtual keys exported as %v, want %v (key_hash breaks the created_at tie)", got, want)
+		t.Fatalf("virtual keys exported as %v, want %v (key_hash order, not physical row order)", got, want)
 	}
 	before := doVersion(t, r)
 
@@ -185,6 +183,44 @@ func TestConfigSync_ExportOrdersTiedVirtualKeysDeterministically(t *testing.T) {
 	}
 	if after := doVersion(t, r); after != before {
 		t.Error("the config hash moved after a row rewrite that changed no exported field")
+	}
+}
+
+// TestConfigSync_ImportedMemberHashesLikeThePrimary pins the cross-instance
+// convergence guarantee: a member that imports the primary's envelope must
+// report the primary's config-version hash, or Front Desk re-syncs it forever.
+// The primary's virtual keys carry distinct created_at values in an order that
+// disagrees with key_hash order, while an import writes every key in one
+// transaction (one shared created_at) — so any created_at-dependent export
+// ordering makes the two instances serialize the same config differently and
+// never hash-converge.
+func TestConfigSync_ImportedMemberHashesLikeThePrimary(t *testing.T) {
+	cleanConfigTables(t)
+	ctx := context.Background()
+	r := newConfigSyncRouter(t, configSyncMasterKey)
+
+	// Chronological order c, b, a: the reverse of key_hash order.
+	for i, h := range []string{"hash-c", "hash-b", "hash-a"} {
+		if _, err := apiTestDB.Pool().Exec(ctx, `
+			INSERT INTO virtual_keys (name, key_hash, key_preview, created_at)
+			VALUES ($1, $2, 'mh-***', TIMESTAMPTZ '2026-08-04 12:00:00+00' + make_interval(mins => $3))`,
+			"vk-"+h, h, i); err != nil {
+			t.Fatalf("seed vk %s: %v", h, err)
+		}
+	}
+
+	env := doExport(t, r)
+	primaryHash := doVersion(t, r)
+
+	// Fresh member: wipe, import the primary's envelope, and measure what Front
+	// Desk's next auto-sync pass would.
+	cleanConfigTables(t)
+	rec := doImport(t, r, env, "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("import status = %d, body %s", rec.Code, rec.Body.String())
+	}
+	if memberHash := doVersion(t, r); memberHash != primaryHash {
+		t.Errorf("imported member hashes %q, primary hashes %q: the fleet can never verify in sync", memberHash, primaryHash)
 	}
 }
 


### PR DESCRIPTION
## Why the fleet never showed "Verified in sync"

Front Desk's convergence criterion is a hash comparison: a member is verified only when its `/api/config/version` sha256 equals the primary's. That hash is computed over each instance's own serialized export, so identical logical config must serialize into identical bytes on every instance.

Virtual keys were exported `ORDER BY (created_at, key_hash)` — but `created_at` never rides in the envelope, and the member-side import writes every key in one transaction, so all of a member's keys share one `created_at` and serialize in pure `key_hash` order. The primary's keys keep their distinct creation history, and on the prod fleet that chronological order differs from hash order. Same config, two byte orders, two hashes: no member could ever verify, and auto-sync re-pushed every member each retry interval forever (`config.sync_incomplete`: "applied the config but does not match the primary's config", with an empty diff and nothing unapplied).

## Fix

Order the export by `key_hash` alone. It is unique (the order is total, no physical-row-order fallback) and part of the synced payload itself (every instance agrees on it). Invariant now stated at both comment sites: an export ordering column must itself ride in the synced payload — anything instance-local breaks fleet hash convergence.

## Tests

- New `TestConfigSync_ImportedMemberHashesLikeThePrimary`: exports a primary whose key creation order disagrees with hash order, imports the envelope into a wiped member, and requires both version hashes equal. Red before the fix, green after.
- `TestConfigSync_ExportOrdersTiedVirtualKeysDeterministically` retargeted to the surviving guarantee (key_hash order, immune to physical row rewrites).
- Full `internal/api` suite (2051 tests) green, golangci-lint clean, diff coverage 100%.

## Deploy note

Both the primary and the members compute the hash, so **all MH instances need the new build** for hashes to meet. Front Desk itself is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)