### PR TITLE
fix: Z.ai quota false-pin (trust percentage) + hedged-probe last_used_at

### DIFF
--- a/internal/provider/cache.go
+++ b/internal/provider/cache.go
@@ -92,6 +92,20 @@ func IsCachedByName(name string) bool {
 	return ok && !time.Now().After(entry.expiresAt)
 }
 
+// EvictProviderCacheByID removes one provider's entries from all three key
+// maps, leaving the rest of the cache intact. For single-row metadata writes
+// (e.g. TouchLastUsed) this keeps read-through Get/GetByIDs honest without the
+// cost of a full flush on a hot path.
+func EvictProviderCacheByID(id uuid.UUID) {
+	providerCacheMu.Lock()
+	if entry, ok := providerByIDCache[id]; ok {
+		delete(providerByNameCache, entry.provider.Name)
+		delete(providerByNormalNameCache, NormalizeName(entry.provider.Name))
+	}
+	delete(providerByIDCache, id)
+	providerCacheMu.Unlock()
+}
+
 // InvalidateProviderCache clears all provider cache entries.
 func InvalidateProviderCache() {
 	providerCacheMu.Lock()

--- a/internal/provider/cache_test.go
+++ b/internal/provider/cache_test.go
@@ -32,6 +32,40 @@ func TestIsCachedByID_Cached(t *testing.T) {
 	}
 }
 
+func TestEvictProviderCacheByID_RemovesOnlyThatProvider(t *testing.T) {
+	InvalidateProviderCache()
+	evicted := uuid.New()
+	kept := uuid.New()
+	WarmProviderCache([]*Provider{
+		{ID: evicted, Name: "evicted-provider"},
+		{ID: kept, Name: "kept-provider"},
+	})
+
+	EvictProviderCacheByID(evicted)
+
+	if IsCachedByID(evicted) {
+		t.Error("evicted provider must miss by ID")
+	}
+	if IsCachedByName("evicted-provider") || IsCachedByName(NormalizeName("evicted-provider")) {
+		t.Error("evicted provider must miss by name and normalized name")
+	}
+	if !IsCachedByID(kept) || !IsCachedByName("kept-provider") {
+		t.Error("eviction must not disturb other providers' entries")
+	}
+}
+
+func TestEvictProviderCacheByID_UnknownIDIsNoop(t *testing.T) {
+	InvalidateProviderCache()
+	id := uuid.New()
+	WarmProviderCache([]*Provider{{ID: id, Name: "survivor"}})
+
+	EvictProviderCacheByID(uuid.New())
+
+	if !IsCachedByID(id) {
+		t.Error("evicting an unknown ID must leave existing entries intact")
+	}
+}
+
 func TestIsCachedByID_Miss(t *testing.T) {
 	InvalidateProviderCache()
 	WarmProviderCache([]*Provider{{ID: uuid.New(), Name: "test-provider"}})

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -397,6 +397,9 @@ func (r *Repository) TouchLastUsed(ctx context.Context, id uuid.UUID) error {
 		debuglog.Error("provider: touch last_used failed", "id", id, "error", err)
 		return err
 	}
-	InvalidateProviderCache()
+	// A single-row metadata write only invalidates that provider's own cache
+	// entries: a full flush here would empty the routing cache on every
+	// attempt/probe, and hedged streaming touches every launched candidate.
+	EvictProviderCacheByID(id)
 	return nil
 }

--- a/internal/proxy/hedging.go
+++ b/internal/proxy/hedging.go
@@ -211,8 +211,9 @@ func (h *Handler) runHedgedStreaming(w http.ResponseWriter, r *http.Request, st 
 func (h *Handler) probeStreamingCandidate(ctx context.Context, st *requestState, candidate modelCandidate, attempt int, ttftTimeout, stallTimeout time.Duration) hedgeResult {
 	res := hedgeResult{idx: attempt}
 
-	// Same stamp beginAttempt makes at attempt start: a probe is a real request
-	// to this provider whether or not it wins the race.
+	// Same stamp beginAttempt makes at attempt start, before the request is
+	// built: launching an attempt against this provider counts as use, whether
+	// or not the probe wins the race or even reaches the wire.
 	h.touchProviderLastUsed(candidate.provider.ID)
 
 	var dialMs float64

--- a/internal/proxy/hedging.go
+++ b/internal/proxy/hedging.go
@@ -211,6 +211,10 @@ func (h *Handler) runHedgedStreaming(w http.ResponseWriter, r *http.Request, st 
 func (h *Handler) probeStreamingCandidate(ctx context.Context, st *requestState, candidate modelCandidate, attempt int, ttftTimeout, stallTimeout time.Duration) hedgeResult {
 	res := hedgeResult{idx: attempt}
 
+	// Same stamp beginAttempt makes at attempt start: a probe is a real request
+	// to this provider whether or not it wins the race.
+	h.touchProviderLastUsed(candidate.provider.ID)
+
 	var dialMs float64
 	proxyReq, _, _, err := h.buildCandidateRequest(ctx, st, candidate)
 	if err != nil {

--- a/internal/proxy/hedging_test.go
+++ b/internal/proxy/hedging_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/hugalafutro/model-hotel/internal/auth"
 	"github.com/hugalafutro/model-hotel/internal/model"
 	"github.com/hugalafutro/model-hotel/internal/provider"
 )
@@ -518,6 +519,63 @@ func probeStateForServer(serverURL string) (*requestState, modelCandidate) {
 		apiKey:   "sk-test",
 	}
 	return st, cand
+}
+
+// TestProbeStreamingCandidate_TouchesProviderLastUsed pins parity with the
+// sequential path (beginAttempt): launching a hedged probe stamps the
+// provider's last_used_at, so the dashboard's "last used" column stays
+// truthful when streaming traffic goes through the hedged path.
+func TestProbeStreamingCandidate_TouchesProviderLastUsed(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandler(h)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"}}]}\n\ndata: [DONE]\n\n")
+	}))
+	defer srv.Close()
+
+	kp, err := auth.Encrypt("sk-probe-touch", h.cfg.MasterKey)
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	prov, err := h.providerRepo.Create(context.Background(), provider.CreateProviderRequest{
+		Name:    "probe-touch-provider",
+		BaseURL: srv.URL,
+		APIKey:  "sk-probe-touch",
+	}, kp.Ciphertext, kp.Nonce, kp.Salt)
+	if err != nil {
+		t.Fatalf("create provider: %v", err)
+	}
+	defer func() { _ = h.providerRepo.Delete(context.Background(), prov.ID) }()
+
+	st, cand := probeStateForServer(srv.URL)
+	cand.provider = prov
+
+	res := h.probeStreamingCandidate(context.Background(), st, cand, 0, 5*time.Second, 30*time.Second)
+	if !res.won {
+		t.Fatalf("expected a win, got reqErr=%+v", res.reqErr)
+	}
+	if res.resp != nil {
+		_ = res.resp.Body.Close()
+	}
+
+	// The touch is fire-and-forget on its own goroutine; poll briefly.
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		got, err := h.providerRepo.GetByIDs(context.Background(), []uuid.UUID{prov.ID})
+		if err != nil {
+			t.Fatalf("get provider: %v", err)
+		}
+		if p := got[prov.ID]; p != nil && p.LastUsedAt != nil {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("hedged probe never stamped the provider's last_used_at")
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
 }
 
 // TestProbeStreamingCandidate covers the real begin+probe path (no client write):

--- a/internal/quota/normalize.go
+++ b/internal/quota/normalize.go
@@ -101,10 +101,11 @@ func Assess(providerType string, s Snapshot) Assessment {
 // apart from an explicit 0, and treating an absent remaining as a spent window
 // would pin a healthy provider shut. Same reasoning as minimaxModelRemain below.
 type zaiCodingQuotaLimit struct {
-	Type          string `json:"type"`
-	Unit          int    `json:"unit"`
-	Remaining     *int64 `json:"remaining"`
-	NextResetTime int64  `json:"nextResetTime"`
+	Type          string   `json:"type"`
+	Unit          int      `json:"unit"`
+	Remaining     *int64   `json:"remaining"`
+	Percentage    *float64 `json:"percentage"`
+	NextResetTime int64    `json:"nextResetTime"`
 }
 
 type zaiCodingQuotaPayload struct {
@@ -125,9 +126,20 @@ func assessZaiCoding(payload json.RawMessage) Assessment {
 		if l.Type != "TOKENS_LIMIT" || (l.Unit != 3 && l.Unit != 6) {
 			continue
 		}
-		// A missing remaining decodes to nil, never to 0, so it can never be
-		// misread as exhausted; only a value the provider actually sent counts.
-		if l.Remaining == nil || *l.Remaining > 0 {
+		// Z.ai's remaining cannot be trusted on its own: the live API sends an
+		// explicit remaining: 0 on windows that are only partially used, while
+		// percentage (percent of the window consumed) tracks the account page
+		// exactly. A sane percentage therefore decides; remaining decides only
+		// when the payload carries no usable percentage, and a missing field
+		// decodes to nil, never to 0, so absence is never read as exhausted.
+		exhausted := false
+		switch {
+		case l.Percentage != nil && *l.Percentage >= 0:
+			exhausted = *l.Percentage >= 100
+		case l.Remaining != nil && *l.Remaining <= 0:
+			exhausted = true
+		}
+		if !exhausted {
 			continue
 		}
 		if t, ok := epochToTime(l.NextResetTime); ok {

--- a/internal/quota/normalize.go
+++ b/internal/quota/normalize.go
@@ -129,12 +129,15 @@ func assessZaiCoding(payload json.RawMessage) Assessment {
 		// Z.ai's remaining cannot be trusted on its own: the live API sends an
 		// explicit remaining: 0 on windows that are only partially used, while
 		// percentage (percent of the window consumed) tracks the account page
-		// exactly. A sane percentage therefore decides; remaining decides only
-		// when the payload carries no usable percentage, and a missing field
-		// decodes to nil, never to 0, so absence is never read as exhausted.
+		// exactly. A sane percentage — within [0, 100], the same definition
+		// addMiniMaxWindow uses — therefore decides; anything outside that
+		// range is nonsense, not a signal, and falls back to the remaining
+		// rule (where Z.ai's ever-present remaining: 0 still reads a genuine
+		// overage as exhausted). A missing field decodes to nil, never to 0,
+		// so absence is never read as exhausted.
 		exhausted := false
 		switch {
-		case l.Percentage != nil && *l.Percentage >= 0:
+		case l.Percentage != nil && *l.Percentage >= 0 && *l.Percentage <= 100:
 			exhausted = *l.Percentage >= 100
 		case l.Remaining != nil && *l.Remaining <= 0:
 			exhausted = true

--- a/internal/quota/normalize_test.go
+++ b/internal/quota/normalize_test.go
@@ -202,23 +202,26 @@ func TestAssess_ZaiCoding_PercentageAt100IsExhausted(t *testing.T) {
 }
 
 // TestAssess_ZaiCoding_NonsensePercentageFallsBackToRemaining: a percentage
-// outside [0, ...) is not a signal, so the remaining rule decides as it did
-// before the field existed.
+// outside [0, 100] is not a signal, so the remaining rule decides as it did
+// before the field existed. For an over-100 overage reading that fallback
+// still pins, because Z.ai always sends remaining: 0 alongside it.
 func TestAssess_ZaiCoding_NonsensePercentageFallsBackToRemaining(t *testing.T) {
-	reset := time.Now().Add(2 * time.Hour).UnixMilli()
-	payload, err := json.Marshal(map[string]any{
-		"data": map[string]any{"limits": []map[string]any{
-			{"type": "TOKENS_LIMIT", "unit": 3, "remaining": 0, "percentage": -7, "nextResetTime": reset},
-		}},
-	})
-	if err != nil {
-		t.Fatalf("marshal: %v", err)
-	}
+	for _, pct := range []float64{-7, 150} {
+		reset := time.Now().Add(2 * time.Hour).UnixMilli()
+		payload, err := json.Marshal(map[string]any{
+			"data": map[string]any{"limits": []map[string]any{
+				{"type": "TOKENS_LIMIT", "unit": 3, "remaining": 0, "percentage": pct, "nextResetTime": reset},
+			}},
+		})
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
 
-	got := Assess("zai-coding", Snapshot{Kind: "usage", Payload: payload})
+		got := Assess("zai-coding", Snapshot{Kind: "usage", Payload: payload})
 
-	if !got.OK || !got.Exhausted {
-		t.Fatalf("got OK=%v Exhausted=%v, want remaining=0 to decide when percentage is nonsense", got.OK, got.Exhausted)
+		if !got.OK || !got.Exhausted {
+			t.Fatalf("percentage=%v: got OK=%v Exhausted=%v, want remaining=0 to decide when percentage is out of range", pct, got.OK, got.Exhausted)
+		}
 	}
 }
 

--- a/internal/quota/normalize_test.go
+++ b/internal/quota/normalize_test.go
@@ -153,6 +153,75 @@ func TestAssess_ZaiCoding_ExplicitZeroRemainingIsExhausted(t *testing.T) {
 	}
 }
 
+// TestAssess_ZaiCoding_PercentageBelow100OverridesZeroRemaining pins the shape
+// the live API actually sends: remaining is a constant 0 even on a window that
+// is only partially used, while percentage (percent consumed) matches the
+// account page. A parser that believes remaining=0 here pins a healthy
+// provider shut for the rest of its window.
+func TestAssess_ZaiCoding_PercentageBelow100OverridesZeroRemaining(t *testing.T) {
+	payload, err := json.Marshal(map[string]any{
+		"data": map[string]any{"limits": []map[string]any{
+			{"type": "TOKENS_LIMIT", "unit": 3, "remaining": 0, "percentage": 63, "nextResetTime": time.Now().Add(4 * time.Hour).UnixMilli()},
+			{"type": "TOKENS_LIMIT", "unit": 6, "remaining": 0, "percentage": 48, "nextResetTime": time.Now().Add(72 * time.Hour).UnixMilli()},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	got := Assess("zai-coding", Snapshot{Kind: "usage", Payload: payload})
+
+	if !got.OK {
+		t.Fatal("a well-formed payload must assess OK")
+	}
+	if got.Exhausted {
+		t.Error("percentage<100 must not be exhausted, whatever remaining says")
+	}
+}
+
+func TestAssess_ZaiCoding_PercentageAt100IsExhausted(t *testing.T) {
+	reset := time.Now().Add(3 * time.Hour).UnixMilli()
+	payload, err := json.Marshal(map[string]any{
+		"data": map[string]any{"limits": []map[string]any{
+			{"type": "TOKENS_LIMIT", "unit": 3, "remaining": 0, "percentage": 100, "nextResetTime": reset},
+			{"type": "TOKENS_LIMIT", "unit": 6, "remaining": 0, "percentage": 48, "nextResetTime": time.Now().Add(72 * time.Hour).UnixMilli()},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	got := Assess("zai-coding", Snapshot{Kind: "usage", Payload: payload})
+
+	if !got.OK || !got.Exhausted {
+		t.Fatalf("got OK=%v Exhausted=%v, want a 100%% window to read as exhausted", got.OK, got.Exhausted)
+	}
+	if got.ResetsAt.UnixMilli() != reset {
+		t.Errorf("got ResetsAt=%d, want the spent window's reset %d, not the healthy one's", got.ResetsAt.UnixMilli(), reset)
+	}
+}
+
+// TestAssess_ZaiCoding_NonsensePercentageFallsBackToRemaining: a percentage
+// outside [0, ...) is not a signal, so the remaining rule decides as it did
+// before the field existed.
+func TestAssess_ZaiCoding_NonsensePercentageFallsBackToRemaining(t *testing.T) {
+	reset := time.Now().Add(2 * time.Hour).UnixMilli()
+	payload, err := json.Marshal(map[string]any{
+		"data": map[string]any{"limits": []map[string]any{
+			{"type": "TOKENS_LIMIT", "unit": 3, "remaining": 0, "percentage": -7, "nextResetTime": reset},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	got := Assess("zai-coding", Snapshot{Kind: "usage", Payload: payload})
+
+	if !got.OK || !got.Exhausted {
+		t.Fatalf("got OK=%v Exhausted=%v, want remaining=0 to decide when percentage is nonsense", got.OK, got.Exhausted)
+	}
+}
+
 // TestAssess_KimiCode_AbsentRemainingIsNotExhausted guards the same hole in the
 // Kimi parser. Kimi encodes remaining as a JSON string, so an absent key decodes
 // to "" and ParseInt rejects it — the parser is safe, but only because a string's


### PR DESCRIPTION
Two production-observed fixes from tonight's hedging rollout (2026-08-06):

## 1. Z.ai quota advisor false-pins the breaker (`internal/quota/normalize.go`)

Z.ai's `/usage` payload sends a literal `remaining: 0` on token windows that are only **partially used**, while `percentage` (percent consumed) tracks the account page exactly (verified live: `remaining=0, percentage=63` with the account page showing 63% of the 5h window used). The quota advisor read `remaining`, so when Z.ai's circuit opened after two transient failures at 03:46 UK, the cooldown was pinned to the 5-hour window reset: a **4-hour lockout of a provider with 37% of its window left**.

Fix: a sane `percentage` decides exhaustion (`>= 100`); `remaining == 0` is believed only when the payload carries no usable percentage. Kimi/MiniMax assessments untouched. New tests pin the exact live payload shape that caused the incident.

Workaround until deployed: `POST /api/failover-groups/circuit-breaker/{providerID}/reset`.

## 2. Hedged probes never stamp provider `last_used_at` (`internal/proxy/hedging.go`)

`beginAttempt` (sequential path) touches the provider's last-used timestamp at attempt start; the hedged path's `probeStreamingCandidate` did not. With hedging enabled, no streaming request updates it — observed in prod as a provider serving a request every few seconds while the dashboard showed "last used 2 days ago". One-line parity fix + integration test (red before, green after).

Both packages: 1370 tests pass, golangci-lint clean, diff coverage 11/11 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review notes (second-opinion Opus review: approve, 4 minors — all addressed in the third commit)

- Percentage sanity is now the same `[0, 100]` definition `addMiniMaxWindow` uses; out-of-range readings fall back to the `remaining` rule.
- `TouchLastUsed` now evicts only that provider's cache entries instead of flushing the whole provider cache per touch (hedging touches every launched candidate).
- Caveat: the *exhausted* side of the percentage rule (`>= 100`) is verified against Z.ai's documented consumed-percent semantics but not against a live fully-spent window (we'd have to burn the plan to 100% to observe one). If Z.ai saturates the field below 100, the fallback still pins via `remaining: 0`, i.e. behavior degrades to exactly the pre-fix rule, never worse.
