### PR TITLE
feat: quota-pin NeuralWatt when energy and credits are both spent

### DIFF
--- a/internal/api/discovery.go
+++ b/internal/api/discovery.go
@@ -350,6 +350,9 @@ func (h *Handler) DiscoverProviderModels(w http.ResponseWriter, r *http.Request)
 		respondError(w, fmt.Sprintf("failed to update provider %s", prov.Name), err, http.StatusInternalServerError)
 		return
 	}
+	// Raw UPDATE bypasses the repository, so the read-through provider cache
+	// still holds the old last_discovered_at; evict this provider's entries.
+	provider.EvictProviderCacheByID(providerID)
 
 	response := map[string]any{
 		"discovered": len(models),
@@ -664,6 +667,10 @@ func (h *Handler) discoverAllProviders(ctx context.Context, recordMisses bool) (
 		if _, err := dbExec(h.dbPool.Pool(), provCtx,
 			`UPDATE providers SET last_discovered_at = $1 WHERE id = $2`, now, prov.ID); err != nil {
 			debuglog.Debug("discovery: failed to update last_discovered_at", "provider_id", prov.ID, "error", err)
+		} else {
+			// Raw UPDATE bypasses the repository; evict this provider's cache
+			// entries so read-through Get sees the new last_discovered_at.
+			provider.EvictProviderCacheByID(prov.ID)
 		}
 
 		provCancel()

--- a/internal/quota/normalize.go
+++ b/internal/quota/normalize.go
@@ -89,6 +89,8 @@ func Assess(providerType string, s Snapshot) Assessment {
 		return assessKimiCode(s.Payload)
 	case "minimax":
 		return assessMiniMax(s.Payload)
+	case "neuralwatt":
+		return assessNeuralwatt(s.Payload)
 	default:
 		return Assessment{}
 	}
@@ -146,6 +148,45 @@ func assessZaiCoding(payload json.RawMessage) Assessment {
 			continue
 		}
 		if t, ok := epochToTime(l.NextResetTime); ok {
+			e.add(t)
+		}
+	}
+	return e.result(time.Now())
+}
+
+// neuralwattQuotaPayload is the subset of NeuralWatt's account payload the
+// normalizer needs. Both decisive numbers are pointers for the same reason as
+// zaiCodingQuotaLimit.Remaining: a bare float64 cannot tell "field absent"
+// apart from an explicit 0, and treating an absent balance as spent would pin
+// a healthy provider shut.
+type neuralwattQuotaPayload struct {
+	Balance struct {
+		CreditsRemainingUSD *float64 `json:"credits_remaining_usd"`
+	} `json:"balance"`
+	Subscription struct {
+		KwhRemaining     *float64 `json:"kwh_remaining"`
+		CurrentPeriodEnd string   `json:"current_period_end"`
+	} `json:"subscription"`
+}
+
+// assessNeuralwatt handles NeuralWatt's balance model, which differs from the
+// window models above: spending the included monthly energy does not make the
+// provider refuse requests — it keeps serving in overage, debiting the credit
+// balance. Requests only start failing once BOTH the included energy and the
+// credits are affirmatively spent, and the only scheduled recovery from that
+// state is the billing period end, so that is the reset the pin targets (the
+// breaker's 24h pin ceiling re-pins toward it on each open, and an
+// off-schedule recovery — a top-up, a plan change — lifts the pin on the next
+// poll via the recovered path in buildQuotaAdvice).
+func assessNeuralwatt(payload json.RawMessage) Assessment {
+	var res neuralwattQuotaPayload
+	if err := json.Unmarshal(payload, &res); err != nil {
+		return Assessment{}
+	}
+	var e earliestReset
+	if res.Subscription.KwhRemaining != nil && *res.Subscription.KwhRemaining <= 0 &&
+		res.Balance.CreditsRemainingUSD != nil && *res.Balance.CreditsRemainingUSD <= 0 {
+		if t, ok := parseResetString(res.Subscription.CurrentPeriodEnd); ok {
 			e.add(t)
 		}
 	}

--- a/internal/quota/normalize_test.go
+++ b/internal/quota/normalize_test.go
@@ -315,6 +315,18 @@ func TestAssess_Neuralwatt_AbsentFieldsAreNotExhausted(t *testing.T) {
 	}
 }
 
+func TestAssess_Neuralwatt_UnparseablePayloadIsNotOK(t *testing.T) {
+	// A payload that does not decode must report OK=false so the caller falls
+	// back to the default cooldown, never a guessed pin.
+	got := Assess("neuralwatt", Snapshot{Kind: "usage", Payload: []byte(`{"subscription": "not-an-object"}`)})
+	if got.OK {
+		t.Error("an undecodable payload must not assess OK")
+	}
+	if got.Exhausted {
+		t.Error("an undecodable payload must never read as exhausted")
+	}
+}
+
 func TestAssess_Neuralwatt_PastPeriodEndIsNoPin(t *testing.T) {
 	// A stale snapshot whose period already rolled over must not pin: the
 	// window it describes is gone.

--- a/internal/quota/normalize_test.go
+++ b/internal/quota/normalize_test.go
@@ -225,6 +225,117 @@ func TestAssess_ZaiCoding_NonsensePercentageFallsBackToRemaining(t *testing.T) {
 	}
 }
 
+// NeuralWatt is a balance model, not a window model: exhausting the included
+// monthly energy does not make it refuse requests — it keeps serving in
+// overage, debiting the credit balance. Only when BOTH the included energy and
+// the credits are affirmatively spent do requests actually start failing, and
+// the only scheduled recovery is the billing period end. The tests below pin
+// that two-sided rule.
+func TestAssess_Neuralwatt_EnergyAndCreditsSpentPinsToPeriodEnd(t *testing.T) {
+	periodEnd := time.Now().Add(20 * 24 * time.Hour).Truncate(time.Second)
+	payload, err := json.Marshal(map[string]any{
+		"balance":      map[string]any{"credits_remaining_usd": 0},
+		"subscription": map[string]any{"status": "active", "kwh_remaining": 0, "in_overage": true, "current_period_end": periodEnd.Format(time.RFC3339)},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	got := Assess("neuralwatt", Snapshot{Kind: "usage", Payload: payload})
+
+	if !got.OK || !got.Exhausted {
+		t.Fatalf("got OK=%v Exhausted=%v, want both true", got.OK, got.Exhausted)
+	}
+	if !got.ResetsAt.Equal(periodEnd.UTC()) {
+		t.Errorf("got ResetsAt=%v, want period end %v", got.ResetsAt, periodEnd.UTC())
+	}
+}
+
+func TestAssess_Neuralwatt_CreditsRemainingIsNotExhausted(t *testing.T) {
+	// Included energy spent but credits cover overage: the provider keeps
+	// serving, so pinning here would sideline a working provider.
+	payload, err := json.Marshal(map[string]any{
+		"balance":      map[string]any{"credits_remaining_usd": 28.9},
+		"subscription": map[string]any{"status": "active", "kwh_remaining": 0, "current_period_end": time.Now().Add(time.Hour).Format(time.RFC3339)},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	got := Assess("neuralwatt", Snapshot{Kind: "usage", Payload: payload})
+
+	if !got.OK {
+		t.Fatal("a well-formed payload must assess OK")
+	}
+	if got.Exhausted {
+		t.Error("credits remaining must not read as exhausted: overage keeps serving")
+	}
+}
+
+func TestAssess_Neuralwatt_EnergyRemainingIsNotExhausted(t *testing.T) {
+	payload, err := json.Marshal(map[string]any{
+		"balance":      map[string]any{"credits_remaining_usd": 0},
+		"subscription": map[string]any{"status": "active", "kwh_remaining": 1.92, "current_period_end": time.Now().Add(time.Hour).Format(time.RFC3339)},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	got := Assess("neuralwatt", Snapshot{Kind: "usage", Payload: payload})
+
+	if !got.OK {
+		t.Fatal("a well-formed payload must assess OK")
+	}
+	if got.Exhausted {
+		t.Error("included energy remaining must not read as exhausted")
+	}
+}
+
+// TestAssess_Neuralwatt_AbsentFieldsAreNotExhausted: the same absent-vs-zero
+// contract every parser in this file honors. A payload missing either decisive
+// field (free tier, older API shape) must fail open, never pin.
+func TestAssess_Neuralwatt_AbsentFieldsAreNotExhausted(t *testing.T) {
+	cases := []map[string]any{
+		{"subscription": map[string]any{"status": "active", "kwh_remaining": 0, "current_period_end": time.Now().Add(time.Hour).Format(time.RFC3339)}},
+		{"balance": map[string]any{"credits_remaining_usd": 0}},
+		{},
+	}
+	for i, c := range cases {
+		payload, err := json.Marshal(c)
+		if err != nil {
+			t.Fatalf("case %d marshal: %v", i, err)
+		}
+		got := Assess("neuralwatt", Snapshot{Kind: "usage", Payload: payload})
+		if !got.OK {
+			t.Fatalf("case %d: a well-formed payload must assess OK", i)
+		}
+		if got.Exhausted {
+			t.Errorf("case %d: absent decisive fields must never read as exhausted", i)
+		}
+	}
+}
+
+func TestAssess_Neuralwatt_PastPeriodEndIsNoPin(t *testing.T) {
+	// A stale snapshot whose period already rolled over must not pin: the
+	// window it describes is gone.
+	payload, err := json.Marshal(map[string]any{
+		"balance":      map[string]any{"credits_remaining_usd": 0},
+		"subscription": map[string]any{"status": "active", "kwh_remaining": 0, "current_period_end": time.Now().Add(-time.Hour).Format(time.RFC3339)},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	got := Assess("neuralwatt", Snapshot{Kind: "usage", Payload: payload})
+
+	if !got.OK {
+		t.Fatal("a well-formed payload must assess OK")
+	}
+	if got.Exhausted {
+		t.Error("a period that already ended must not pin")
+	}
+}
+
 // TestAssess_KimiCode_AbsentRemainingIsNotExhausted guards the same hole in the
 // Kimi parser. Kimi encodes remaining as a JSON string, so an absent key decodes
 // to "" and ParseInt rejects it — the parser is safe, but only because a string's


### PR DESCRIPTION
Follow-up to #635, from the same incident review.

## NeuralWatt quota pin (`internal/quota/normalize.go`)

NeuralWatt is a balance model, not a window model: spending the included monthly energy does not make it refuse requests — it keeps serving in overage (account-page toggle permitting), debiting the credit balance. Requests only start failing once **both** the included kWh and the credit balance are affirmatively spent, and the only scheduled recovery from that state is the billing period end.

`assessNeuralwatt` now pins toward `subscription.current_period_end` in exactly that state: `kwh_remaining <= 0` **and** `credits_remaining_usd <= 0`, both fields explicitly present (pointers — an absent field never reads as spent, matching every other parser's fail-open contract). Either resource remaining fails open; an undecodable payload reports OK=false and the breaker keeps its default cooldown. The overage on/off account toggle needs no special handling: we act on what the JSON reports, and every non-pinned state degrades to the ordinary 5-minute breaker cycle.

No plumbing changes: the snapshot poller already stores `neuralwatt` payloads and calls `Assess` with that type — it just returned "cannot interpret" until now. The breaker's 24h pin ceiling re-pins toward the period end on each open, and the advisor's affirmative-recovery path lifts a pin within one poll cycle of any off-schedule revival (top-up, plan change).

## Drive-by: discovery cache staleness unmasked by #635 (`internal/api/discovery.go`)

Both discovery paths write `last_discovered_at` with raw SQL, bypassing the repository, and never invalidated the provider cache. This was masked while `TouchLastUsed` flushed the entire cache on every proxied request; after #635 narrowed that to a per-ID eviction, the single-provider GET could serve a stale `last_discovered_at` for up to the 5-minute TTL. Both raw-update sites now evict the affected provider's cache entries. (Found by the second-opinion review of #635, verified against the read-through paths.)

Tests: 6 new NeuralWatt assessment tests (TDD, exhausted/credits-remain/energy-remain/absent-fields/past-period/unparseable); discovery covered by the existing handler suite. 70 quota tests pass, golangci-lint clean, pre-push diff-coverage gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)