### PR TITLE
fix(frontdesk): emit fleet-state transitions correctly across restarts

### DIFF
--- a/internal/frontdesk/autosync.go
+++ b/internal/frontdesk/autosync.go
@@ -146,7 +146,11 @@ func (s *Server) autoSyncOnce(ctx context.Context, prev string) string {
 		return ""
 	}
 	if !cfg.Enabled || cfg.PrimaryID == "" {
-		return "" // disabled or no primary designated: nothing to do
+		// Disabled or no primary designated: nothing to do, but that IS this
+		// tick's verdict — no holds can exist, so the fleet state's sync inputs
+		// count as observed (fleetInputsWarm).
+		s.autoSyncEvaluated.Store(true)
+		return ""
 	}
 
 	primary, primaryToken, hash, ok := s.primaryConfigHash(ctx, cfg)
@@ -222,6 +226,9 @@ func (s *Server) primaryConfigHash(ctx context.Context, cfg AutoSyncConfig) (pri
 // it does not.
 func (s *Server) convergeFleet(ctx context.Context, primary *Member, primaryToken, hash, reason string, gen int64) {
 	applied := s.applyAutoSync(ctx, primary, primaryToken, hash, reason, gen)
+	// The pass has judged every member, so the version-skew hold and
+	// incomplete-apply sets now reflect observations, not a cold start.
+	s.autoSyncEvaluated.Store(true)
 	if applied > 0 {
 		noun := "members"
 		if applied == 1 {

--- a/internal/frontdesk/autosync_test.go
+++ b/internal/frontdesk/autosync_test.go
@@ -2222,7 +2222,7 @@ func TestAutoSync_ConvergedFleetDoesNotFlap(t *testing.T) {
 		if len(f.srv.heldSnapshot()) != 0 {
 			t.Fatalf("tick %d: heldSnapshot = %v, want empty", i, f.srv.heldSnapshot())
 		}
-		state, reasons, err := f.srv.fleetStateNow(t.Context())
+		state, reasons, _, err := f.srv.fleetStateNow(t.Context())
 		if err != nil {
 			t.Fatalf("tick %d: fleetStateNow: %v", i, err)
 		}
@@ -2331,7 +2331,7 @@ func TestAutoSync_DriftThatDoesNotCorrectIsFlagged(t *testing.T) {
 	if n := countEventsOfType(t, f.store, "config.sync_incomplete"); n != 1 {
 		t.Errorf("config.sync_incomplete events = %d, want 1 for the drifted member", n)
 	}
-	state, reasons, err := f.srv.fleetStateNow(t.Context())
+	state, reasons, _, err := f.srv.fleetStateNow(t.Context())
 	if err != nil {
 		t.Fatalf("fleetStateNow: %v", err)
 	}

--- a/internal/frontdesk/fleetstate.go
+++ b/internal/frontdesk/fleetstate.go
@@ -247,15 +247,42 @@ func (s *Server) checkFleetState(ctx context.Context) {
 	}
 	s.fleetStateMu.Lock()
 	prev := s.fleetStatePrev
+	s.fleetStateMu.Unlock()
 	if prev == "" {
-		prev = FleetOK
+		// First tick of this process: seed the edge detector from the newest
+		// persisted transition instead of assuming ok, so a restart while the
+		// fleet is (or was last reported) degraded still emits the recovery and
+		// never re-emits a degradation the previous process already reported.
+		prev = s.lastEmittedFleetState(ctx)
 	}
+	s.fleetStateMu.Lock()
 	changed := cur != prev
 	s.fleetStatePrev = cur
 	s.fleetStateMu.Unlock()
 	if changed {
 		s.emit(ctx, fleetStateEvent(prev, cur, reasons))
 	}
+}
+
+// lastEmittedFleetState returns the target state of the newest persisted
+// fleet.state_changed event, defaulting to ok when no event exists yet or the
+// row cannot be read back. Only the in-memory edge detector needs this; the
+// state itself is always recomputed from live inputs.
+func (s *Server) lastEmittedFleetState(ctx context.Context) FleetState {
+	evs, _, err := s.store.ListEvents(ctx, EventFilter{Type: "fleet.state_changed", Limit: 1})
+	if err != nil {
+		debuglog.Warn("frontdesk: seed fleet state from events", "error", err)
+		return FleetOK
+	}
+	if len(evs) == 0 {
+		return FleetOK
+	}
+	to, _ := evs[0].Metadata["to"].(string)
+	switch st := FleetState(to); st {
+	case FleetOK, FleetDegraded, FleetFaulty:
+		return st
+	}
+	return FleetOK
 }
 
 // fleetStateEvent shapes the edge-triggered transition event. The message is

--- a/internal/frontdesk/fleetstate.go
+++ b/internal/frontdesk/fleetstate.go
@@ -188,24 +188,58 @@ func (s *Server) heldSnapshot() map[string]bool {
 	return out
 }
 
-// fleetStateNow gathers the live inputs and computes the current fleet state.
-// The background loop uses this self-contained form; autoSyncStatusNow reuses
-// reads it has already made by calling fleetStateFrom directly.
-func (s *Server) fleetStateNow(ctx context.Context) (FleetState, []string, error) {
+// fleetStateNow gathers the live inputs and computes the current fleet state,
+// plus whether those inputs are warm (fleetInputsWarm). The background loop
+// uses this self-contained form; autoSyncStatusNow reuses reads it has already
+// made by calling fleetStateFrom directly.
+func (s *Server) fleetStateNow(ctx context.Context) (FleetState, []string, bool, error) {
 	members, err := s.store.ListMembers(ctx)
 	if err != nil {
-		return "", nil, err
+		return "", nil, false, err
 	}
 	cfg, err := s.store.GetAutoSync(ctx)
 	if err != nil {
-		return "", nil, err
+		return "", nil, false, err
 	}
 	syncState, haveSync, err := s.store.GetFleetSyncState(ctx)
 	if err != nil {
-		return "", nil, err
+		return "", nil, false, err
 	}
 	state, reasons := s.fleetStateFrom(ctx, members, cfg, syncState.LastRunAt, haveSync)
-	return state, reasons, nil
+	return state, reasons, s.fleetInputsWarm(ctx, members), nil
+}
+
+// fleetInputsWarm reports whether every in-memory input computeFleetState
+// reads has produced at least one real observation this process: each member's
+// health is a confirmed verdict (the cold poller map means "never probed", not
+// "up"), the auto-sync loop has judged the fleet once (only such a pass
+// rebuilds the version-skew hold and incomplete-apply sets), and the Traefik
+// config-poll watchdog has either seen a poll or outwaited its own staleness
+// window (ConfigPollWarm). Until all three hold, a computed improvement over
+// the seeded state is indistinguishable from ignorance, and checkFleetState
+// sits on it. Store-backed inputs (drain state, autosync staleness) survive a
+// restart and need no warm-up.
+func (s *Server) fleetInputsWarm(ctx context.Context, members []*Member) bool {
+	statuses := s.poller.Snapshot()
+	for _, m := range members {
+		if !statuses[m.ID].Health.Known {
+			return false
+		}
+	}
+	return s.autoSyncEvaluated.Load() && s.poller.ConfigPollWarm(ctx, s.startedAt)
+}
+
+// fleetStateSeverity orders the states for the warm-up gate: emitting a
+// transition to a lower severity requires warm inputs, a higher one never
+// waits (it is always backed by a positive observation).
+func fleetStateSeverity(st FleetState) int {
+	switch st {
+	case FleetFaulty:
+		return 2
+	case FleetDegraded:
+		return 1
+	}
+	return 0
 }
 
 // fleetStateFrom assembles the per-member facts from already-read store data
@@ -239,23 +273,36 @@ func (s *Server) fleetStateFrom(ctx context.Context, members []*Member, cfg Auto
 
 // checkFleetState computes the state and emits fleet.state_changed exactly on
 // transitions. Split from RunFleetState so tests drive ticks directly.
+//
+// The edge detector seeds from the newest persisted transition instead of
+// assuming ok, so a restart continues where the previous process left off. And
+// while the inputs are cold (fleetInputsWarm false), a computed drop in
+// severity is held back without advancing the detector: a fresh poller that
+// has confirmed nothing computes ok out of ignorance, and emitting that would
+// send a false all-clear (fleet.state_changed alerts by default). Increases in
+// severity always emit — a down or held verdict is a positive observation.
 func (s *Server) checkFleetState(ctx context.Context) {
-	cur, reasons, err := s.fleetStateNow(ctx)
+	cur, reasons, warm, err := s.fleetStateNow(ctx)
 	if err != nil {
 		debuglog.Warn("frontdesk: compute fleet state", "error", err)
 		return
 	}
 	s.fleetStateMu.Lock()
-	prev := s.fleetStatePrev
-	s.fleetStateMu.Unlock()
-	if prev == "" {
-		// First tick of this process: seed the edge detector from the newest
-		// persisted transition instead of assuming ok, so a restart while the
-		// fleet is (or was last reported) degraded still emits the recovery and
-		// never re-emits a degradation the previous process already reported.
-		prev = s.lastEmittedFleetState(ctx)
+	if s.fleetStatePrev == "" {
+		// Seed outside the lock (a store read), then re-check: a concurrent
+		// caller may have seeded meanwhile.
+		s.fleetStateMu.Unlock()
+		seed := s.lastEmittedFleetState(ctx)
+		s.fleetStateMu.Lock()
+		if s.fleetStatePrev == "" {
+			s.fleetStatePrev = seed
+		}
 	}
-	s.fleetStateMu.Lock()
+	prev := s.fleetStatePrev
+	if !warm && fleetStateSeverity(cur) < fleetStateSeverity(prev) {
+		s.fleetStateMu.Unlock()
+		return
+	}
 	changed := cur != prev
 	s.fleetStatePrev = cur
 	s.fleetStateMu.Unlock()
@@ -267,7 +314,9 @@ func (s *Server) checkFleetState(ctx context.Context) {
 // lastEmittedFleetState returns the target state of the newest persisted
 // fleet.state_changed event, defaulting to ok when no event exists yet or the
 // row cannot be read back. Only the in-memory edge detector needs this; the
-// state itself is always recomputed from live inputs.
+// state itself is always recomputed from live inputs. Anyone wiring event
+// pruning (PruneEvents currently has no production caller): deleting the
+// newest fleet.state_changed row demotes a restart to the old ok assumption.
 func (s *Server) lastEmittedFleetState(ctx context.Context) FleetState {
 	evs, _, err := s.store.ListEvents(ctx, EventFilter{Type: "fleet.state_changed", Limit: 1})
 	if err != nil {

--- a/internal/frontdesk/fleetstate_test.go
+++ b/internal/frontdesk/fleetstate_test.go
@@ -322,6 +322,145 @@ func TestCheckFleetStateEmitsDrainTransitions(t *testing.T) {
 	}
 }
 
+// simulateFleetStateRestart clears the in-memory edge detector exactly as a
+// process restart does: fleetStatePrev is the only fleet-state input that does
+// not survive a Front Desk restart (member facts, holds and events are all
+// store- or poller-backed).
+func simulateFleetStateRestart(s *Server) {
+	s.fleetStateMu.Lock()
+	s.fleetStatePrev = ""
+	s.fleetStateMu.Unlock()
+}
+
+// TestCheckFleetStateSeedsPrevAcrossRestart_EmitsMissedRecovery pins the seed:
+// when the fleet recovers while no tick observes it (the process is down) and
+// Front Desk then restarts, the first tick must still emit degraded -> ok,
+// seeded from the newest persisted fleet.state_changed event rather than
+// assuming the process started with a healthy fleet.
+func TestCheckFleetStateSeedsPrevAcrossRestart_EmitsMissedRecovery(t *testing.T) {
+	srv, store := newTestServer(t)
+	ctx := context.Background()
+
+	m1, err := store.CreateMember(ctx, "hotel-1", "https://h1.example", "tok1")
+	if err != nil {
+		t.Fatalf("create m1: %v", err)
+	}
+	m2, err := store.CreateMember(ctx, "hotel-2", "https://h2.example", "tok2")
+	if err != nil {
+		t.Fatalf("create m2: %v", err)
+	}
+	setHealth(srv, m1.ID, true)
+	setHealth(srv, m2.ID, true)
+	srv.checkFleetState(ctx)
+
+	// One member confirmed down -> the ok-to-degraded transition is persisted.
+	setHealth(srv, m1.ID, false)
+	srv.checkFleetState(ctx)
+	if evs := fleetStateEvents(ctx, t, srv); len(evs) != 1 {
+		t.Fatalf("after member down: %d events, want 1", len(evs))
+	}
+
+	// The member recovers while Front Desk is down, then the process restarts.
+	setHealth(srv, m1.ID, true)
+	simulateFleetStateRestart(srv)
+	srv.checkFleetState(ctx)
+
+	evs := fleetStateEvents(ctx, t, srv)
+	if len(evs) != 2 {
+		t.Fatalf("first tick after restart: %d events, want 2 (recovery must not be swallowed)", len(evs))
+	}
+	if got := evs[0].Metadata["to"]; got != "ok" {
+		t.Errorf(`recovery metadata["to"] = %v, want "ok"`, got)
+	}
+	if got := evs[0].Metadata["from"]; got != "degraded" {
+		t.Errorf(`recovery metadata["from"] = %v, want "degraded"`, got)
+	}
+	if evs[0].Severity != "success" {
+		t.Errorf("recovery severity = %q, want success", evs[0].Severity)
+	}
+}
+
+// TestCheckFleetStateSeedsPrevAcrossRestart_NoDuplicateDegradation is the
+// mirror case: restarting while the fleet is still degraded must not re-emit
+// the ok -> degraded transition the previous process already reported.
+func TestCheckFleetStateSeedsPrevAcrossRestart_NoDuplicateDegradation(t *testing.T) {
+	srv, store := newTestServer(t)
+	ctx := context.Background()
+
+	m1, err := store.CreateMember(ctx, "hotel-1", "https://h1.example", "tok1")
+	if err != nil {
+		t.Fatalf("create m1: %v", err)
+	}
+	m2, err := store.CreateMember(ctx, "hotel-2", "https://h2.example", "tok2")
+	if err != nil {
+		t.Fatalf("create m2: %v", err)
+	}
+	setHealth(srv, m1.ID, true)
+	setHealth(srv, m2.ID, false)
+	srv.checkFleetState(ctx)
+	if evs := fleetStateEvents(ctx, t, srv); len(evs) != 1 {
+		t.Fatalf("after member down: %d events, want 1", len(evs))
+	}
+
+	// Restart with the member still down: the state is unchanged, so the first
+	// tick must stay silent.
+	simulateFleetStateRestart(srv)
+	srv.checkFleetState(ctx)
+	if evs := fleetStateEvents(ctx, t, srv); len(evs) != 1 {
+		t.Fatalf("first tick after restart re-emitted: %d events, want 1", len(evs))
+	}
+}
+
+// TestCheckFleetStateSeedsPrevAcrossRestart_UnknownStateFallsBackToOK guards
+// the seed against a fleet.state_changed row whose metadata carries no valid
+// state (a corrupted or future-format row): it falls back to ok, so the first
+// transition after restart reads from=ok rather than echoing the garbage.
+func TestCheckFleetStateSeedsPrevAcrossRestart_UnknownStateFallsBackToOK(t *testing.T) {
+	srv, store := newTestServer(t)
+	ctx := context.Background()
+
+	m1, err := store.CreateMember(ctx, "hotel-1", "https://h1.example", "tok1")
+	if err != nil {
+		t.Fatalf("create m1: %v", err)
+	}
+	m2, err := store.CreateMember(ctx, "hotel-2", "https://h2.example", "tok2")
+	if err != nil {
+		t.Fatalf("create m2: %v", err)
+	}
+	setHealth(srv, m1.ID, false)
+	setHealth(srv, m2.ID, true)
+	srv.emit(ctx, Event{
+		Type: "fleet.state_changed", Severity: "success", Source: "frontdesk",
+		Message:  "bogus row",
+		Metadata: map[string]any{"to": "banana"},
+	})
+
+	srv.checkFleetState(ctx)
+	evs := fleetStateEvents(ctx, t, srv)
+	if len(evs) != 2 {
+		t.Fatalf("after first tick: %d events, want 2 (bogus row plus the new transition)", len(evs))
+	}
+	if got := evs[0].Metadata["from"]; got != "ok" {
+		t.Errorf(`metadata["from"] = %v, want "ok"`, got)
+	}
+	if got := evs[0].Metadata["to"]; got != "degraded" {
+		t.Errorf(`metadata["to"] = %v, want "degraded"`, got)
+	}
+}
+
+// TestLastEmittedFleetState_StoreErrorFallsBackToOK pins the fail-safe: when
+// the events table cannot be read back the seed reports ok, the same posture a
+// first boot has, rather than blocking the tick or inventing a state.
+func TestLastEmittedFleetState_StoreErrorFallsBackToOK(t *testing.T) {
+	srv, store := newTestServer(t)
+	if err := store.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+	if got := srv.lastEmittedFleetState(context.Background()); got != FleetOK {
+		t.Fatalf("lastEmittedFleetState on a closed store = %q, want ok", got)
+	}
+}
+
 // TestCheckFleetStateEmitsIncompleteTransition drives the diverged set through
 // the live path: the auto-sync loop's own bookkeeping (markMemberIncomplete)
 // feeds fleetStateFrom, so the badge turns amber for as long as the member does

--- a/internal/frontdesk/fleetstate_test.go
+++ b/internal/frontdesk/fleetstate_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"slices"
 	"testing"
+	"time"
 )
 
 func TestComputeFleetState(t *testing.T) {
@@ -167,8 +168,10 @@ func TestCheckFleetStateEmitsOnTransitions(t *testing.T) {
 	}
 	setHealth(srv, m1.ID, true)
 	setHealth(srv, m2.ID, true)
+	warmFleetInputs(ctx, srv)
 
-	// Baseline ok: the empty-prev is treated as ok, so no transition, no event.
+	// Baseline ok: with no persisted transition the seed is ok, so no
+	// transition, no event.
 	srv.checkFleetState(ctx)
 	if evs := fleetStateEvents(ctx, t, srv); len(evs) != 0 {
 		t.Fatalf("baseline emitted %d fleet.state_changed events, want 0", len(evs))
@@ -322,21 +325,45 @@ func TestCheckFleetStateEmitsDrainTransitions(t *testing.T) {
 	}
 }
 
-// simulateFleetStateRestart clears the in-memory edge detector exactly as a
-// process restart does: fleetStatePrev is the only fleet-state input that does
-// not survive a Front Desk restart (member facts, holds and events are all
-// store- or poller-backed).
+// simulateFleetStateRestart resets every piece of in-memory fleet-state input
+// exactly as a process restart does: the edge detector's previous state, the
+// poller's health verdicts and fail counters, the version-skew hold set and
+// the incomplete-apply set all start empty in a fresh process. Only the store
+// (members, events, autosync config) survives.
 func simulateFleetStateRestart(s *Server) {
 	s.fleetStateMu.Lock()
 	s.fleetStatePrev = ""
 	s.fleetStateMu.Unlock()
+	s.poller.mu.Lock()
+	s.poller.statuses = make(map[string]MemberStatus)
+	s.poller.healthFailures = make(map[string]int)
+	s.poller.lastConfigPollAt = time.Time{}
+	s.poller.mu.Unlock()
+	s.syncHeldMu.Lock()
+	s.syncHeld = make(map[string]bool)
+	s.syncHeldMu.Unlock()
+	s.syncIncompleteMu.Lock()
+	s.syncIncomplete = make(map[string]incompleteState)
+	s.syncIncompleteMu.Unlock()
+	s.autoSyncEvaluated.Store(false)
+	s.startedAt = time.Now()
+}
+
+// warmFleetInputs gives every non-health cold-start input a first real
+// observation, the way a running process acquires them within its first
+// ticks: one auto-sync evaluation (rebuilding the hold set) and one Traefik
+// config poll. Health verdicts stay whatever setHealth installed.
+func warmFleetInputs(ctx context.Context, s *Server) {
+	s.autoSyncOnce(ctx, "")
+	s.poller.RecordConfigPoll()
 }
 
 // TestCheckFleetStateSeedsPrevAcrossRestart_EmitsMissedRecovery pins the seed:
 // when the fleet recovers while no tick observes it (the process is down) and
-// Front Desk then restarts, the first tick must still emit degraded -> ok,
-// seeded from the newest persisted fleet.state_changed event rather than
-// assuming the process started with a healthy fleet.
+// Front Desk then restarts, the recovery is still emitted, seeded from the
+// newest persisted fleet.state_changed event rather than assuming the process
+// started with a healthy fleet. It must only be emitted once the inputs are
+// warm: the cold first tick computes ok out of ignorance, not evidence.
 func TestCheckFleetStateSeedsPrevAcrossRestart_EmitsMissedRecovery(t *testing.T) {
 	srv, store := newTestServer(t)
 	ctx := context.Background()
@@ -361,13 +388,24 @@ func TestCheckFleetStateSeedsPrevAcrossRestart_EmitsMissedRecovery(t *testing.T)
 	}
 
 	// The member recovers while Front Desk is down, then the process restarts.
+	// The cold tick must sit on the seeded degraded state: nothing has been
+	// probed yet, so the computed ok is not evidence of recovery.
 	setHealth(srv, m1.ID, true)
 	simulateFleetStateRestart(srv)
+	srv.checkFleetState(ctx)
+	if evs := fleetStateEvents(ctx, t, srv); len(evs) != 1 {
+		t.Fatalf("cold tick after restart: %d events, want 1 (no recovery before the inputs are warm)", len(evs))
+	}
+
+	// Once every input has a real observation, the recovery is emitted.
+	setHealth(srv, m1.ID, true)
+	setHealth(srv, m2.ID, true)
+	warmFleetInputs(ctx, srv)
 	srv.checkFleetState(ctx)
 
 	evs := fleetStateEvents(ctx, t, srv)
 	if len(evs) != 2 {
-		t.Fatalf("first tick after restart: %d events, want 2 (recovery must not be swallowed)", len(evs))
+		t.Fatalf("warm tick after restart: %d events, want 2 (recovery must not be swallowed)", len(evs))
 	}
 	if got := evs[0].Metadata["to"]; got != "ok" {
 		t.Errorf(`recovery metadata["to"] = %v, want "ok"`, got)
@@ -381,8 +419,11 @@ func TestCheckFleetStateSeedsPrevAcrossRestart_EmitsMissedRecovery(t *testing.T)
 }
 
 // TestCheckFleetStateSeedsPrevAcrossRestart_NoDuplicateDegradation is the
-// mirror case: restarting while the fleet is still degraded must not re-emit
-// the ok -> degraded transition the previous process already reported.
+// mirror case: restarting while the fleet is still degraded must emit nothing
+// at all — no false degraded-to-ok while the poller has not confirmed anything
+// (fleet.state_changed alerts by default, so that would page an operator with
+// an all-clear mid-incident), and no repeat of the ok-to-degraded the previous
+// process already reported once the down verdict is confirmed again.
 func TestCheckFleetStateSeedsPrevAcrossRestart_NoDuplicateDegradation(t *testing.T) {
 	srv, store := newTestServer(t)
 	ctx := context.Background()
@@ -402,12 +443,52 @@ func TestCheckFleetStateSeedsPrevAcrossRestart_NoDuplicateDegradation(t *testing
 		t.Fatalf("after member down: %d events, want 1", len(evs))
 	}
 
-	// Restart with the member still down: the state is unchanged, so the first
-	// tick must stay silent.
+	// Restart with the member still down. The cold tick computes ok because the
+	// fresh poller has confirmed nothing: that must not surface as a recovery.
 	simulateFleetStateRestart(srv)
 	srv.checkFleetState(ctx)
 	if evs := fleetStateEvents(ctx, t, srv); len(evs) != 1 {
-		t.Fatalf("first tick after restart re-emitted: %d events, want 1", len(evs))
+		t.Fatalf("cold tick after restart emitted: %d events, want 1", len(evs))
+	}
+
+	// The poller re-confirms the member down and the other inputs warm up: the
+	// state matches the seed, so there is still nothing to say.
+	setHealth(srv, m1.ID, true)
+	setHealth(srv, m2.ID, false)
+	warmFleetInputs(ctx, srv)
+	srv.checkFleetState(ctx)
+	if evs := fleetStateEvents(ctx, t, srv); len(evs) != 1 {
+		t.Fatalf("warm tick after restart re-emitted: %d events, want 1", len(evs))
+	}
+}
+
+// TestCheckFleetStateColdDegradationStillEmits pins the gate's asymmetry: a
+// degradation is always backed by a confirmed observation (a down verdict only
+// exists once the poller crossed its fail threshold), so it must be emitted
+// even while other inputs are still cold. Only improvements wait for warmth.
+func TestCheckFleetStateColdDegradationStillEmits(t *testing.T) {
+	srv, store := newTestServer(t)
+	ctx := context.Background()
+
+	m1, err := store.CreateMember(ctx, "hotel-1", "https://h1.example", "tok1")
+	if err != nil {
+		t.Fatalf("create m1: %v", err)
+	}
+	if _, err := store.CreateMember(ctx, "hotel-2", "https://h2.example", "tok2"); err != nil {
+		t.Fatalf("create m2: %v", err)
+	}
+
+	// m1 is confirmed down while m2 has never been probed, auto-sync has not
+	// evaluated and Traefik has not polled: as cold as a first tick gets.
+	setHealth(srv, m1.ID, false)
+	srv.checkFleetState(ctx)
+
+	evs := fleetStateEvents(ctx, t, srv)
+	if len(evs) != 1 {
+		t.Fatalf("cold degradation: %d events, want 1 (degradations must not wait for warm-up)", len(evs))
+	}
+	if got := evs[0].Metadata["to"]; got != "degraded" {
+		t.Errorf(`metadata["to"] = %v, want "degraded"`, got)
 	}
 }
 
@@ -415,6 +496,8 @@ func TestCheckFleetStateSeedsPrevAcrossRestart_NoDuplicateDegradation(t *testing
 // the seed against a fleet.state_changed row whose metadata carries no valid
 // state (a corrupted or future-format row): it falls back to ok, so the first
 // transition after restart reads from=ok rather than echoing the garbage.
+// This pins the fallback value only (the unseeded detector also assumed ok),
+// so it holds on any implementation that ignores the bogus row.
 func TestCheckFleetStateSeedsPrevAcrossRestart_UnknownStateFallsBackToOK(t *testing.T) {
 	srv, store := newTestServer(t)
 	ctx := context.Background()
@@ -445,6 +528,116 @@ func TestCheckFleetStateSeedsPrevAcrossRestart_UnknownStateFallsBackToOK(t *test
 	}
 	if got := evs[0].Metadata["to"]; got != "degraded" {
 		t.Errorf(`metadata["to"] = %v, want "degraded"`, got)
+	}
+}
+
+// TestCheckFleetStateWarmupBounded pins the gate's escape hatch: when Traefik
+// never fetches the config (so that input can never arm), the warm-up must
+// still open once a full staleness window has passed since process start.
+// Suppressing a recovery is a grace period, never a deadlock.
+func TestCheckFleetStateWarmupBounded(t *testing.T) {
+	srv, store := newTestServer(t)
+	ctx := context.Background()
+
+	m1, err := store.CreateMember(ctx, "hotel-1", "https://h1.example", "tok1")
+	if err != nil {
+		t.Fatalf("create m1: %v", err)
+	}
+	// The previous process left the fleet reported degraded.
+	srv.emit(ctx, fleetStateEvent(FleetDegraded, FleetDegraded, []string{reasonMemberDown}))
+
+	// This process: health confirmed, auto-sync evaluated, but not a single
+	// Traefik poll — and a start time a full staleness window in the past.
+	setHealth(srv, m1.ID, true)
+	srv.autoSyncOnce(ctx, "")
+	srv.startedAt = time.Now().Add(-time.Hour)
+	srv.checkFleetState(ctx)
+
+	evs := fleetStateEvents(ctx, t, srv)
+	if len(evs) != 2 {
+		t.Fatalf("tick past the grace window: %d events, want 2 (recovery must not be held forever)", len(evs))
+	}
+	if got := evs[0].Metadata["to"]; got != "ok" {
+		t.Errorf(`metadata["to"] = %v, want "ok"`, got)
+	}
+}
+
+// TestLastEmittedFleetState_UsesNewestRow pins the seed's load-bearing
+// ordering assumption: with several persisted transitions, the newest row is
+// the one that seeds. Driven through real ticks so the rows are exactly what
+// production persists; the fleet comes to rest at faulty, which also
+// exercises that arm of the seed's state switch.
+func TestLastEmittedFleetState_UsesNewestRow(t *testing.T) {
+	srv, store := newTestServer(t)
+	ctx := context.Background()
+
+	m1, err := store.CreateMember(ctx, "hotel-1", "https://h1.example", "tok1")
+	if err != nil {
+		t.Fatalf("create m1: %v", err)
+	}
+	m2, err := store.CreateMember(ctx, "hotel-2", "https://h2.example", "tok2")
+	if err != nil {
+		t.Fatalf("create m2: %v", err)
+	}
+	warmFleetInputs(ctx, srv)
+
+	// ok -> degraded, then degraded -> faulty: two persisted transitions.
+	setHealth(srv, m1.ID, false)
+	setHealth(srv, m2.ID, true)
+	srv.checkFleetState(ctx)
+	setHealth(srv, m2.ID, false)
+	srv.checkFleetState(ctx)
+	if evs := fleetStateEvents(ctx, t, srv); len(evs) != 2 {
+		t.Fatalf("setup persisted %d events, want 2", len(evs))
+	}
+
+	if got := srv.lastEmittedFleetState(ctx); got != FleetFaulty {
+		t.Fatalf("lastEmittedFleetState = %q, want faulty (the newest row)", got)
+	}
+}
+
+// TestCheckFleetStateSeedsOncePerProcess pins that the seed is a first-tick
+// affair: once the detector holds a state, a fleet.state_changed row landing
+// out of band must not re-seed it and fake a transition.
+func TestCheckFleetStateSeedsOncePerProcess(t *testing.T) {
+	srv, store := newTestServer(t)
+	ctx := context.Background()
+
+	m1, err := store.CreateMember(ctx, "hotel-1", "https://h1.example", "tok1")
+	if err != nil {
+		t.Fatalf("create m1: %v", err)
+	}
+	setHealth(srv, m1.ID, true)
+	warmFleetInputs(ctx, srv)
+	srv.checkFleetState(ctx)
+
+	// A bogus faulty row lands after the detector is seeded. If a later tick
+	// re-read the store it would see prev=faulty, cur=ok and emit a recovery.
+	srv.emit(ctx, fleetStateEvent(FleetOK, FleetFaulty, []string{reasonAllMembersDown}))
+	srv.checkFleetState(ctx)
+
+	evs := fleetStateEvents(ctx, t, srv)
+	if len(evs) != 1 {
+		t.Fatalf("tick after out-of-band row: %d events, want 1 (the injected row only)", len(evs))
+	}
+}
+
+// TestCheckFleetStateStoreErrorLeavesDetectorUntouched pins the error path: a
+// tick that cannot read the store computes nothing, emits nothing and leaves
+// the edge detector unseeded, so the next healthy tick starts from scratch.
+func TestCheckFleetStateStoreErrorLeavesDetectorUntouched(t *testing.T) {
+	srv, store := newTestServer(t)
+	if err := store.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+
+	srv.checkFleetState(context.Background())
+
+	srv.fleetStateMu.Lock()
+	prev := srv.fleetStatePrev
+	srv.fleetStateMu.Unlock()
+	if prev != "" {
+		t.Fatalf("fleetStatePrev = %q after a failed tick, want unseeded", prev)
 	}
 }
 
@@ -479,6 +672,7 @@ func TestCheckFleetStateEmitsIncompleteTransition(t *testing.T) {
 	}
 	setHealth(srv, m1.ID, true)
 	setHealth(srv, m2.ID, true)
+	warmFleetInputs(ctx, srv)
 
 	srv.checkFleetState(ctx)
 	if evs := fleetStateEvents(ctx, t, srv); len(evs) != 0 {

--- a/internal/frontdesk/poller.go
+++ b/internal/frontdesk/poller.go
@@ -817,6 +817,19 @@ func (p *Poller) ConfigPollStale(ctx context.Context) bool {
 	return !last.IsZero() && p.now().Sub(last) > threshold
 }
 
+// ConfigPollWarm reports whether the Traefik staleness input has produced a
+// real observation this process: either Traefik has fetched the config at
+// least once, or a full staleness window has elapsed since `since` (process
+// start) without a fetch — at which point the silence is itself the
+// steady-state observation ConfigPollStale will keep reporting. Used by
+// fleetInputsWarm to keep a cold start from reading as a recovery.
+func (p *Poller) ConfigPollWarm(ctx context.Context, since time.Time) bool {
+	p.mu.RLock()
+	armed := !p.lastConfigPollAt.IsZero()
+	p.mu.RUnlock()
+	return armed || p.now().Sub(since) > secs(p.settings(ctx).TraefikStaleSecs, 30)
+}
+
 // checkAutoSyncStale emits a single warning when auto-sync is off and the fleet
 // has not been synced within autoSyncStaleThreshold (see autoSyncStale for the
 // exact rule). Like checkConfigStaleness it de-dups on an in-memory flag so it

--- a/internal/frontdesk/server.go
+++ b/internal/frontdesk/server.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -99,10 +100,21 @@ type Server struct {
 	// which seeds it from the newest persisted fleet.state_changed event
 	// (lastEmittedFleetState), so a restart continues the event chain instead of
 	// assuming ok: a recovery that happened while the process was down is still
-	// emitted, and a degradation the previous process reported is not repeated.
+	// emitted (once the inputs are warm, see fleetInputsWarm), and a degradation
+	// the previous process reported is not repeated.
 	fleetStateMu   sync.Mutex
 	fleetStatePrev FleetState
-	router         http.Handler
+	// autoSyncEvaluated flips once the auto-sync loop has judged the fleet this
+	// process: either a convergence pass ran (rebuilding the version-skew hold
+	// and incomplete-apply sets) or a tick found auto-sync disabled, in which
+	// case those sets stay deliberately empty. Until then their emptiness means
+	// "not looked yet", not "no holds", and fleetInputsWarm reports cold.
+	autoSyncEvaluated atomic.Bool
+	// startedAt anchors fleetInputsWarm's Traefik grace: with no config poll
+	// recorded yet, the staleness input only counts as observed once a full
+	// staleness window has passed since this process started.
+	startedAt time.Time
+	router    http.Handler
 	// bgWG tracks detached background goroutines (e.g. the auto-sync kick) so
 	// callers can drain them on shutdown. Without it, a kick fired by an enable
 	// keeps writing to the store after a caller (or a test) has moved on, which
@@ -155,6 +167,7 @@ func NewServer(cfg ServerConfig) *Server {
 		syncHeld:       make(map[string]bool),
 		syncIncomplete: make(map[string]incompleteState),
 		backupStale:    make(map[string]bool),
+		startedAt:      time.Now(),
 	}
 
 	// Bind the scrape-time member-fleet collector to this server's store and

--- a/internal/frontdesk/server.go
+++ b/internal/frontdesk/server.go
@@ -95,10 +95,11 @@ type Server struct {
 	backupStaleMu sync.Mutex
 	backupStale   map[string]bool
 	// fleetStatePrev is the last state checkFleetState saw, guarding the
-	// edge-triggered fleet.state_changed emission. Empty until the first check
-	// (treated as ok, so a fleet that starts unhealthy alerts once on startup).
-	// This mirrors checkAutoSyncStale, which re-alerts on a stale start, not
-	// checkConfigStaleness, which stays quiet until it has armed.
+	// edge-triggered fleet.state_changed emission. Empty until the first check,
+	// which seeds it from the newest persisted fleet.state_changed event
+	// (lastEmittedFleetState), so a restart continues the event chain instead of
+	// assuming ok: a recovery that happened while the process was down is still
+	// emitted, and a degradation the previous process reported is not repeated.
 	fleetStateMu   sync.Mutex
 	fleetStatePrev FleetState
 	router         http.Handler

--- a/internal/frontdesk/store_events.go
+++ b/internal/frontdesk/store_events.go
@@ -58,7 +58,9 @@ func (s *Store) ListEvents(ctx context.Context, f EventFilter) ([]Event, int, er
 	}
 
 	//nolint:gosec // `where` is built only from fixed clause strings; all values are bound parameters.
-	query := `SELECT id, type, severity, source, message, metadata, member_id, created_at FROM events` + where + ` ORDER BY created_at DESC`
+	// id DESC keeps the order deterministic when two events share a timestamp,
+	// like NewestEventPerMember; lastEmittedFleetState leans on "newest first".
+	query := `SELECT id, type, severity, source, message, metadata, member_id, created_at FROM events` + where + ` ORDER BY created_at DESC, id DESC`
 	if f.Limit > 0 {
 		query += fmt.Sprintf(" LIMIT %d OFFSET %d", f.Limit, max(f.Offset, 0))
 	}


### PR DESCRIPTION
## What

An FD restart used to reset the fleet-state edge detector to an assumed `ok`, which swallowed recovery events and duplicated degradations. Observed in prod 2026-08-06: the rolling rebuild ended with FD itself, and the fleet's `degraded -> ok` recovery (docker-pc dip at 10:25Z) was never emitted.

Two commits, because the naive fix failed adversarial review:

1. **`dd7c644` seeds the detector** on the first tick from the newest persisted `fleet.state_changed` event (`metadata.to`), falling back to `ok` on no rows, unreadable rows, or unknown state strings.
2. **`cac2e3d` gates emissions on warmed inputs.** The seed alone was wrong: every degradation input except drain state and autosync staleness lives in memory (poller health verdicts need `health_fail_threshold` consecutive polls, holds are only rebuilt by an auto-sync pass, the Traefik watchdog starts unarmed), so a fresh process computes `ok` out of ignorance. A restart mid-incident would have emitted a false `degraded -> ok` success event — alerted via Apprise by default — then re-emitted the degradation. Now a transition to a *lower* severity waits until every member's health is a confirmed verdict, the auto-sync loop has judged the fleet once, and the Traefik poll has been seen or its staleness window has elapsed since start (bounded grace, no deadlock). Transitions to *higher* severity emit immediately: they only arise from positive observations.

Net behavior: the event chain survives restarts (`from` always equals the previous event's `to`), recoveries that happened while FD was down are emitted once inputs warm (~15-30s), and nothing is emitted twice.

## Notes

- First deploy will retroactively emit the missed 2026-08-06 recovery: the newest stored transition is still `ok -> degraded`, so the first warm tick emits `degraded -> ok`.
- `ListEvents` gains an `id DESC` tiebreak (matches `NewestEventPerMember`) since the seed leans on newest-first.
- The chain invariant is best-effort under `emit` failures (insert errors are logged and swallowed, as before), and `PruneEvents` — currently unwired — would demote a restart to the old `ok` assumption if it ever deletes the newest transition row; both noted in comments.
- Known pre-existing gap, untouched: the Traefik staleness detector is blind until Traefik's first poll, so a restart during a Traefik outage still cannot re-detect `traefik_config_stale` on its own.

## Testing

- TDD throughout; the restart simulation resets all process state (poller verdicts, fail counters, holds, incomplete sets), not just the detector — the first version cleared only the detector and hid the false-recovery bug.
- New pins: missed-recovery emission, no false recovery on cold ticks, no duplicate degradation, cold degradations still emit, seed-once-per-process, newest-row seeding (incl. the faulty arm), unknown-state and store-error fallbacks, bounded grace window.
- `go test ./internal/...`: 6814 passed across 33 packages; `golangci-lint`: 0 issues; changed lines covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)