### PR TITLE
fix(quota): Kimi exhaustion pin, breaker-open nudge, shared web quota helpers

### DIFF
--- a/.github/actions/changed-surfaces/action.yml
+++ b/.github/actions/changed-surfaces/action.yml
@@ -143,8 +143,11 @@ runs:
         # the SQL migrations and testdata too, and the Makefile drives the local
         # equivalents of these jobs.
         go=$(match '^(cmd|internal)/|\.go$|^go\.(mod|sum)$|^\.golangci\.ya?ml$|^Makefile$')
-        web=$(match '^web/')
-        fdweb=$(match '^frontdesk/web/')
+        # web-shared/ holds the quota parsing both SPAs import through their
+        # @quota-shared alias, and testdata/quota-contract/ the fixtures their
+        # suites read, so a change to either is a change to BOTH app surfaces.
+        web=$(match '^web/|^web-shared/|^testdata/quota-contract/')
+        fdweb=$(match '^frontdesk/web/|^web-shared/|^testdata/quota-contract/')
         workflows=$(match '^\.github/')
         # THIRD-PARTY-NOTICES.md is generated FROM these, so a hand-edit to the
         # committed file must be caught by regenerating it.
@@ -183,7 +186,7 @@ runs:
         if [ "$grep_status" -gt 1 ]; then
           run_everything "could not filter test files out of the diff"
         fi
-        if grep -qE '^(internal/|cmd/|web/|frontdesk/web/|Dockerfile|docker-entrypoint|\.dockerignore|go\.(mod|sum))' <<< "$src"; then
+        if grep -qE '^(internal/|cmd/|web/|web-shared/|frontdesk/web/|Dockerfile|docker-entrypoint|\.dockerignore|go\.(mod|sum))' <<< "$src"; then
           image=true
         else
           image=false

--- a/.github/actions/changed-surfaces/action.yml
+++ b/.github/actions/changed-surfaces/action.yml
@@ -159,7 +159,9 @@ runs:
         # to those scripts has to reach them even with no code change.
         covtools=$(match '^scripts/coverage/')
         python=$(match '\.py$')
-        android=$(match '^android/')
+        # Bellhop's quota tests read the same testdata/quota-contract/ fixtures
+        # the two SPAs do, so a fixture change is an android change too.
+        android=$(match '^android/|^testdata/quota-contract/')
         # Loose JS/TS outside the two app trees (build scripts, config).
         jsts=$(match '\.(m|c)?[jt]sx?$')
 

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -5,11 +5,13 @@ on:
     branches: [master]
     paths:
       - "android/**"
+      - "testdata/quota-contract/**"
       - ".github/workflows/android.yml"
   pull_request:
     branches: [master]
     paths:
       - "android/**"
+      - "testdata/quota-contract/**"
       - ".github/workflows/android.yml"
 
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -773,14 +773,15 @@ jobs:
           # (base == HEAD) legitimately means nothing new to publish.
           changed=$(git diff --name-only "$base" "$HEAD_SHA")
           # The :dev image carries the compiled Go binary (cmd/ + internal/) and
-          # the built+embedded frontend (web/, frontdesk/web/). Docs, screenshots,
+          # the built+embedded frontend (web/, frontdesk/web/, and the
+          # web-shared/ module both of them bundle). Docs, screenshots,
           # wiki, AGENTS.md, CI workflows, the Makefile, and test files cannot
           # affect it. Drop test files first (not compiled or bundled), then match
           # the image-affecting surface the Dockerfiles COPY wholesale. Kept broad
           # on purpose: a wasted build is cheap, a stale :dev is not — a genuinely
           # new top-level COPY source must be added here.
           src=$(printf '%s\n' "$changed" | grep -vE '(_test\.go|\.test\.tsx?|\.spec\.tsx?)$' || true)
-          code=$(printf '%s\n' "$src" | grep -E '^(internal/|cmd/|web/|frontdesk/web/|Dockerfile|docker-entrypoint|\.dockerignore|go\.mod|go\.sum)' || true)
+          code=$(printf '%s\n' "$src" | grep -E '^(internal/|cmd/|web/|web-shared/|frontdesk/web/|Dockerfile|docker-entrypoint|\.dockerignore|go\.mod|go\.sum)' || true)
           if [ -n "$code" ]; then
             echo "image-affecting changes since last published :dev ($base); building:"
             printf '%s\n' "$code"

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,10 @@ COPY web/package.json web/pnpm-lock.yaml web/pnpm-workspace.yaml ./
 RUN --mount=type=cache,target=/pnpm-store \
     pnpm install --frozen-lockfile --store-dir=/pnpm-store
 
+# The quota parsing helpers live outside the app tree and are pulled in through
+# the @quota-shared alias, so the build needs them beside it.
+COPY web-shared/ /app/web-shared/
+
 COPY web/ ./
 # build:docker skips `tsc -b` — type-checking is gated by the pre-push hook and
 # CI's full `pnpm run build`, so the image build stays off the typecheck path.

--- a/Dockerfile.frontdesk
+++ b/Dockerfile.frontdesk
@@ -17,6 +17,10 @@ COPY frontdesk/web/package.json frontdesk/web/pnpm-lock.yaml frontdesk/web/pnpm-
 RUN --mount=type=cache,target=/pnpm-store \
     pnpm install --frozen-lockfile --store-dir=/pnpm-store
 
+# The quota parsing helpers live outside the app tree and are pulled in through
+# the @quota-shared alias, so the build needs them beside it.
+COPY web-shared/ /app/web-shared/
+
 COPY frontdesk/web/ ./
 # build:docker skips `tsc -b` — type-checking is gated by the pre-push hook and
 # CI, so the image build stays off the typecheck path (same as the main image).

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -103,6 +103,19 @@ android {
                 // Print each test as it starts, not just failures, so a future
                 // wedge names its culprit in the CI log instead of going silent.
                 test.testLogging.events("started", "failed", "skipped")
+                // The cross-platform contract fixtures live at the repo root,
+                // one level above this Gradle root, and back the web, Front
+                // Desk and Bellhop suites alike. Passing the absolute path to
+                // the test JVM keeps them resolvable whichever directory
+                // Gradle was invoked from, and declaring the directory as a
+                // task input re-runs the tests when a fixture changes rather
+                // than reporting an up-to-date pass against the old figures.
+                val testdata = rootDir.parentFile.resolve("testdata")
+                test.systemProperty("modelhotel.testdata.dir", testdata.absolutePath)
+                test.inputs
+                    .dir(testdata)
+                    .withPropertyName("modelHotelTestdata")
+                    .withPathSensitivity(PathSensitivity.RELATIVE)
             }
         }
     }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/QuotaModels.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/QuotaModels.kt
@@ -244,6 +244,7 @@ data class KimiCodeMembership(
 @Serializable
 data class KimiCodeDetail(
     val limit: String = "",
+    val used: String = "",
     val remaining: String = "",
     val resetTime: String = "",
 )
@@ -700,12 +701,55 @@ private fun amountMeter(
     )
 }
 
-/** kimiUsedPercent computes used% from Kimi's wire-string limit/remaining pair. */
+/**
+ * parseKimiNumber reads one of Kimi's wire-string numbers, or null when the
+ * field carries no value.
+ *
+ * Absent, "" and whitespace are one case: Kimi's proto3 JSON omits a
+ * zero-valued field and the Go snapshot re-marshal writes "" for the omission,
+ * so both arrive here as null and what the omission means is the caller's to
+ * decide, field by field. Mirrors `parseKimiNumber` in web-shared/quota/kimi.ts.
+ */
+private fun parseKimiNumber(v: String?): Double? {
+    val trimmed = v?.trim().orEmpty()
+    if (trimmed.isEmpty()) return null
+    val n = trimmed.toDoubleOrNull() ?: return null
+    return if (n.isFinite()) n else null
+}
+
+/**
+ * resolveKimiRemaining is how many units of the window are still available.
+ *
+ * `remaining` wins when it carries a value. Otherwise the window is exhausted
+ * enough for Kimi to have dropped `remaining` and `used` carries the count, so
+ * remaining is limit minus used, floored at zero. An omitted `used` means zero
+ * used, hence the full limit. A `used` that is present but unreadable yields
+ * null: an unparseable window must not be turned into a number, ever.
+ */
+private fun resolveKimiRemaining(
+    limit: Double,
+    remainingStr: String?,
+    usedStr: String?,
+): Double? {
+    parseKimiNumber(remainingStr)?.let { return it }
+    parseKimiNumber(usedStr)?.let { return (limit - it).coerceAtLeast(0.0) }
+    return if (usedStr.isNullOrBlank()) limit else null
+}
+
+/**
+ * kimiUsedPercent computes used% for one Kimi window, clamped to [0, 100].
+ * Null means the window cannot be read (an unparseable limit, or a `used` that
+ * is present but not a number), which callers render as "-". A zero or
+ * negative limit meters as 0% rather than as no reading, matching
+ * `toKimiCodeWindow` in web-shared/quota/kimi.ts; the shared fixtures under
+ * testdata/quota-contract/kimi hold the two platforms to the same figures.
+ */
 private fun kimiUsedPercent(detail: KimiCodeDetail?): Double? {
-    val limit = detail?.limit?.toDoubleOrNull() ?: return null
-    val remaining = detail.remaining.toDoubleOrNull() ?: return null
-    if (limit == 0.0) return null
-    return (limit - remaining) / limit * 100.0
+    if (detail == null) return null
+    val limit = parseKimiNumber(detail.limit) ?: return null
+    val remaining = resolveKimiRemaining(limit, detail.remaining, detail.used) ?: return null
+    val raw = if (limit > 0.0) (limit - remaining) / limit * 100.0 else 0.0
+    return raw.coerceIn(0.0, 100.0)
 }
 
 /**

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/KimiQuotaContractTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/KimiQuotaContractTest.kt
@@ -1,0 +1,108 @@
+package com.hugalafutro.bellhop.data
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * Cross-platform drift net for Kimi Code quota parsing.
+ *
+ * The fixtures under `testdata/quota-contract/kimi/` are shared with the web
+ * dashboard and Front Desk suites, so every app that renders a stored Kimi
+ * snapshot derives the same numbers from it. Each fixture carries the raw
+ * `payload` Front Desk stores plus the `expected` percentages; a fixture whose
+ * expectation Bellhop cannot reproduce fails here rather than showing a
+ * different figure than the web badge for the same snapshot.
+ *
+ * Payloads go through [providerQuotaOf] and [quotaMeters], the production
+ * decode and metering path, so the test pins what the widget actually renders
+ * and not a parallel parser written for the test.
+ */
+class KimiQuotaContractTest {
+    @Serializable
+    private data class KimiContractExpected(
+        val fiveHourUsedPercent: Double,
+        val weeklyUsedPercent: Double,
+    )
+
+    @Serializable
+    private data class KimiContractFixture(
+        val payload: JsonElement,
+        val expected: KimiContractExpected,
+    )
+
+    // The fixture envelope only, never the payload: the payload is decoded by
+    // the app's own quota Json config inside providerQuotaOf.
+    private val fixtureJson = Json { ignoreUnknownKeys = true }
+
+    /**
+     * The shared fixture directory, handed to the test JVM by Gradle as
+     * `modelhotel.testdata.dir` so it resolves the same whether Gradle is
+     * invoked from `android/` or from the repo root.
+     */
+    private fun fixtureDir(): File {
+        val root =
+            System.getProperty("modelhotel.testdata.dir")
+                ?: error("modelhotel.testdata.dir is unset; app/build.gradle.kts sets it from the repo root")
+        return File(root, "quota-contract/kimi")
+    }
+
+    private fun fixtureFiles(): List<File> {
+        val dir = fixtureDir()
+        assertTrue("missing shared fixture directory ${dir.absolutePath}", dir.isDirectory)
+        return dir.listFiles { f: File -> f.isFile && f.name.endsWith(".json") }.orEmpty().sortedBy { it.name }
+    }
+
+    private fun meterPercent(
+        meters: List<QuotaMeter>,
+        kind: QuotaMeterKind,
+        label: String,
+    ): Double {
+        val meter = meters.find { it.kind == kind }
+        assertNotNull("$label: no $kind meter, so the badge would render \"-\"", meter)
+        return meter!!.usedPercent
+    }
+
+    @Test
+    fun sharedFixtureDirectoryIsPopulated() {
+        // Guards against a silently green run when the directory is gone or a
+        // path change leaves the glob matching nothing.
+        val files = fixtureFiles()
+        assertTrue("expected at least 3 Kimi contract fixtures, found ${files.size}", files.size >= 3)
+    }
+
+    @Test
+    fun everyFixtureYieldsTheExpectedPercentages() {
+        for (file in fixtureFiles()) {
+            val fixture = fixtureJson.decodeFromString<KimiContractFixture>(file.readText())
+            val wire =
+                QuotaWire(
+                    providerName = "kimi",
+                    type = "kimi-code",
+                    kind = "usage",
+                    payload = fixture.payload,
+                    httpStatus = 200,
+                    fetchedAt = "2026-08-07T00:00:00Z",
+                )
+            val meters = quotaMeters(providerQuotaOf(wire))
+
+            assertEquals(
+                "${file.name}: five-hour",
+                fixture.expected.fiveHourUsedPercent,
+                meterPercent(meters, QuotaMeterKind.FIVE_HOUR, file.name),
+                1e-9,
+            )
+            assertEquals(
+                "${file.name}: weekly",
+                fixture.expected.weeklyUsedPercent,
+                meterPercent(meters, QuotaMeterKind.WEEKLY, file.name),
+                1e-9,
+            )
+        }
+    }
+}

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/QuotaMetersTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/QuotaMetersTest.kt
@@ -130,6 +130,33 @@ class QuotaMetersTest {
     }
 
     @Test
+    fun kimiUnreadableUsedDrawsNoBarForThatWindow() {
+        // `used` present but unreadable, and no `remaining` to fall back on:
+        // the window has no reading, and a bar drawn from a guess is worse
+        // than no bar. The weekly window beside it still reads, so the loss is
+        // confined to the window that stopped making sense.
+        val meters =
+            quotaMeters(
+                quotaOf(
+                    QuotaType.KIMI_CODE,
+                    QuotaData.KimiCode(
+                        limits =
+                            listOf(
+                                KimiCodeLimitEntry(
+                                    window = KimiCodeWindowSpec(duration = 300, timeUnit = "TIME_UNIT_MINUTE"),
+                                    detail = KimiCodeDetail(limit = "100", used = "abc"),
+                                ),
+                            ),
+                        usage = KimiCodeDetail(limit = "1000", remaining = "900"),
+                    ),
+                ),
+            )
+
+        assertEquals(listOf(QuotaMeterKind.WEEKLY), meters.map { it.kind })
+        assertEquals(10.0, meters.single().usedPercent, 0.001)
+    }
+
+    @Test
     fun miniMaxMetersOnlyModelsOnThePlan() {
         val meters =
             quotaMeters(

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/QuotaModelsTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/QuotaModelsTest.kt
@@ -366,6 +366,29 @@ class QuotaModelsTest {
     }
 
     @Test
+    fun kimiCodeUnreadableUsedRendersDashNotZero() {
+        // A `used` that is present but not a number is neither a count nor the
+        // omission that means zero, so the window has no reading and must
+        // render "-". Turning it into 0% would tell an operator their quota is
+        // untouched at the moment the payload stopped making sense. The weekly
+        // window still reads, so only the unreadable window goes dark.
+        val data =
+            QuotaData.KimiCode(
+                usage = KimiCodeDetail(limit = "200000", remaining = "150000"),
+                limits =
+                    listOf(
+                        KimiCodeLimitEntry(
+                            window = KimiCodeWindowSpec(duration = 300, timeUnit = "TIME_UNIT_MINUTE"),
+                            detail = KimiCodeDetail(limit = "100000", used = "abc"),
+                        ),
+                    ),
+            )
+        val wrapped = pq(data, QuotaType.KIMI_CODE)
+        assertEquals("-/25%", quotaBadgeLabel(wrapped, QuotaBarMode.USED))
+        assertEquals("-/75%", quotaBadgeLabel(wrapped, QuotaBarMode.REMAINING))
+    }
+
+    @Test
     fun miniMaxUsedAndRemainingPercentages() {
         val data =
             QuotaData.MiniMax(

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -200,6 +200,11 @@ func main() {
 	apiHandler.SetQuotaAdvisor(quotaAdvisor)
 	proxyHandler.CircuitBreaker().SetQuotaAdvisor(quotaAdvisor)
 
+	// A circuit that opens on a spent quota window needs the reading that pins
+	// its cooldown now, not on the next poll pass up to an interval away, so the
+	// open transition triggers a debounced single-provider poll.
+	proxyHandler.CircuitBreaker().SetOnOpen(apiHandler.NudgeQuotaPoll)
+
 	// Outbound alerting: a single consumer of the events bus that forwards
 	// operator-selected events to a stateless apprise-api container. Best-effort
 	// — a missing/failing apprise-api never affects request serving. Runs for the

--- a/frontdesk/web/src/api/types.ts
+++ b/frontdesk/web/src/api/types.ts
@@ -321,15 +321,7 @@ export interface TotpEnrollVerify {
 // QuotaSnapshot.payload, so the field names are the providers', not ours.
 
 /** The provider families that expose a quota or balance endpoint. */
-export type QuotaProviderType =
-	| "nanogpt"
-	| "zai-coding"
-	| "kimi-code"
-	| "minimax"
-	| "deepseek"
-	| "openrouter"
-	| "ollama-cloud"
-	| "neuralwatt";
+export type { QuotaProviderType } from "@quota-shared";
 
 /**
  * One provider's quota snapshot as proxied from the fleet primary.
@@ -413,52 +405,22 @@ export interface ZAICodingQuotaResponse {
 	};
 }
 
-export interface KimiCodeQuotaLimitEntry {
-	window?: { timeUnit?: string; duration?: number };
-	detail?: { limit?: string; remaining?: string; resetTime?: string };
-}
+// ── Kimi Code + MiniMax quota ───────────────────────────────────
+// Declared in web-shared/quota, which both Front Desk and the Model Hotel
+// dashboard parse these payloads with, and re-exported here so app code keeps
+// importing every API type from one place.
 
-export interface KimiCodeQuotaResponse {
-	user?: { membership?: { level?: string } };
-	usage?: { limit?: string; remaining?: string; resetTime?: string };
-	limits?: KimiCodeQuotaLimitEntry[];
-	// Kimi encodes numeric fields as JSON strings throughout, which is why
-	// toKimiCodeWindow parses with Number(). These two are no exception.
-	parallel?: { limit?: string };
-	totalQuota?: { limit?: string; remaining?: string };
-}
-
-/** Derived Kimi Code window. `percentage` is percent USED. */
-export interface KimiCodeQuotaWindow {
-	limit: number;
-	remaining: number;
-	resetTime: string;
-	percentage: number;
-}
-
-export interface MiniMaxModelRemains {
-	model_name: string;
-	start_time?: number;
-	end_time?: number;
-	remains_time: number;
-	weekly_remains_time: number;
-	current_interval_status: number;
-	current_interval_remaining_percent: number;
-	current_weekly_status: number;
-	current_weekly_remaining_percent: number;
-}
-
-export interface MiniMaxQuotaResponse {
-	model_remains: MiniMaxModelRemains[] | null;
-	base_resp: { status_code: number; status_msg: string };
-}
-
-/** Derived MiniMax window. `percentage` is percent USED. */
-export interface MiniMaxQuotaWindow {
-	percentage: number;
-	remainingPercent: number;
-	resetMs: number;
-}
+export type {
+	KimiCodeQuotaLimitEntry,
+	KimiCodeQuotaResponse,
+	KimiCodeQuotaUsageWindow,
+	KimiCodeQuotaWindow,
+	KimiCodeQuotaWindowSpec,
+	MiniMaxBaseResp,
+	MiniMaxModelRemains,
+	MiniMaxQuotaResponse,
+	MiniMaxQuotaWindow,
+} from "@quota-shared";
 
 export interface DeepSeekBalanceInfo {
 	currency: "CNY" | "USD";
@@ -502,9 +464,9 @@ export interface NeuralWattQuotaUsagePeriod {
  * NeuralWatt's quota body, as relayed by the fleet primary.
  *
  * Only `balance` is declared required, and only because the badge visibility
- * gate (utils/quota.ts isVisible) refuses to render a NeuralWatt badge at all
- * unless balance.credits_remaining_usd is present, so nothing downstream can be
- * reached without it. Every other block is optional on purpose: this is an
+ * gate (isNeuralWattQuotaVisible in web-shared/quota) refuses to render a
+ * NeuralWatt badge at all unless balance.credits_remaining_usd is present, so
+ * nothing downstream can be reached without it. Every other block is optional on purpose: this is an
  * upstream provider's JSON forwarded through another machine's export, not a
  * shape this build controls, and a fleet primary on a different version may
  * relay less than the current one does. Optional here is what makes the

--- a/frontdesk/web/src/components/QuotaBadge.tsx
+++ b/frontdesk/web/src/components/QuotaBadge.tsx
@@ -6,6 +6,7 @@ import type {
 	NeuralWattQuotaResponse,
 	OllamaCloudAccount,
 	OpenRouterBalance,
+	ZAICodingQuotaResponse,
 } from "../api/types";
 import { formatDollars, formatKwh, formatTokens } from "../utils/format";
 import {
@@ -94,7 +95,7 @@ function contentFor(
 			};
 		}
 		case "zai-coding": {
-			const u = payload as Parameters<typeof getZaiCodingFiveHourLimit>[0];
+			const u = payload as ZAICodingQuotaResponse;
 			return {
 				label: windowsLabel(
 					getZaiCodingFiveHourLimit(u)?.percentage,

--- a/frontdesk/web/src/components/quota/MiniMaxQuotaModal.tsx
+++ b/frontdesk/web/src/components/quota/MiniMaxQuotaModal.tsx
@@ -127,11 +127,11 @@ export function MiniMaxQuotaModal({
 	onClose,
 }: MiniMaxQuotaModalProps) {
 	const { t } = useTranslation();
-	// Unlike getMiniMaxGeneralEntry (utils/quota.ts), this does not gate on
+	// Unlike getMiniMaxGeneralEntry (web-shared/quota), this does not gate on
 	// base_resp.status_code === 0. That is safe, not an oversight: a non-zero
-	// status produces no visible badge (toBadgeModels/isVisible), so this modal
-	// is never opened for that payload in the first place. Model Hotel's
-	// equivalent modal makes the same simplification.
+	// status produces no visible badge (toBadgeModels/isQuotaPayloadVisible), so
+	// this modal is never opened for that payload in the first place. Model
+	// Hotel's equivalent modal makes the same simplification.
 	const entries = payload.model_remains ?? [];
 
 	return (

--- a/frontdesk/web/src/utils/__tests__/quotaContract.test.ts
+++ b/frontdesk/web/src/utils/__tests__/quotaContract.test.ts
@@ -1,0 +1,44 @@
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import type { KimiCodeQuotaResponse } from "../../api/types";
+import { getKimiCodeFiveHourLimit, getKimiCodeWeeklyLimit } from "../quota";
+
+// Cross-platform contract fixtures. The same files back the Model Hotel
+// dashboard suite and the Bellhop unit tests, so every app that renders a stored
+// Kimi snapshot derives the same numbers from it.
+const FIXTURE_DIR = path.resolve(
+	path.dirname(fileURLToPath(import.meta.url)),
+	"../../../../../testdata/quota-contract/kimi",
+);
+
+interface KimiContractFixture {
+	payload: KimiCodeQuotaResponse;
+	expected: { fiveHourUsedPercent: number; weeklyUsedPercent: number };
+}
+
+const fixtureFiles = readdirSync(FIXTURE_DIR)
+	.filter((f) => f.endsWith(".json"))
+	.sort();
+
+describe("Kimi Code quota contract fixtures", () => {
+	it("reads the shared fixture directory", () => {
+		expect(fixtureFiles.length).toBeGreaterThanOrEqual(3);
+	});
+
+	it.each(fixtureFiles)("%s yields the expected percentages", (file) => {
+		const fixture = JSON.parse(
+			readFileSync(path.join(FIXTURE_DIR, file), "utf8"),
+		) as KimiContractFixture;
+
+		expect(getKimiCodeFiveHourLimit(fixture.payload)?.percentage).toBeCloseTo(
+			fixture.expected.fiveHourUsedPercent,
+			10,
+		);
+		expect(getKimiCodeWeeklyLimit(fixture.payload)?.percentage).toBeCloseTo(
+			fixture.expected.weeklyUsedPercent,
+			10,
+		);
+	});
+});

--- a/frontdesk/web/src/utils/quota.ts
+++ b/frontdesk/web/src/utils/quota.ts
@@ -1,25 +1,25 @@
-import type {
-	DeepSeekBalance,
-	KimiCodeQuotaResponse,
-	KimiCodeQuotaWindow,
-	MiniMaxModelRemains,
-	MiniMaxQuotaResponse,
-	MiniMaxQuotaWindow,
-	NanoGPTUsage,
-	NeuralWattQuotaResponse,
-	OllamaCloudAccount,
-	OpenRouterBalance,
-	QuotaProviderType,
-	QuotaSnapshot,
-	ZAICodingQuotaLimit,
-	ZAICodingQuotaResponse,
-} from "../api/types";
+import { isQuotaPayloadVisible } from "@quota-shared";
+import type { QuotaProviderType, QuotaSnapshot } from "../api/types";
 
-// Quota domain logic, ported from the Model Hotel dashboard
-// (web/src/hooks/useQuotaData.ts) so both frontends derive the same numbers from
-// the same provider payloads. What is NOT ported: detectQuotaProviderType. The
-// member export stamps `type` on every snapshot, so Front Desk never sniffs a
-// base URL.
+// Front Desk's quota glue. The payload parsing itself lives in
+// web-shared/quota, which the Model Hotel dashboard reads the same payloads
+// with, so both frontends derive the same numbers for the same fleet. What
+// stays here is what only Front Desk needs: snapshot handling, badge models and
+// the pill's own presentation. The shared module deliberately carries no
+// equivalent of detectQuotaProviderType: the member export stamps `type` on
+// every snapshot, so Front Desk never sniffs a base URL.
+
+// The parsing helpers are re-exported because Front Desk components have always
+// reached them through this module.
+export {
+	getKimiCodeFiveHourLimit,
+	getKimiCodeWeeklyLimit,
+	getMiniMaxFiveHourLimit,
+	getMiniMaxGeneralEntry,
+	getMiniMaxWeeklyLimit,
+	getZaiCodingFiveHourLimit,
+	getZaiCodingWeeklyLimit,
+} from "@quota-shared";
 
 // ── Provider type ────────────────────────────────────────────────────────
 
@@ -32,7 +32,7 @@ const QUOTA_PROVIDER_TYPES = [
 	"openrouter",
 	"ollama-cloud",
 	"neuralwatt",
-] as const;
+] as const satisfies readonly QuotaProviderType[];
 
 const KNOWN_TYPES = new Set<string>(QUOTA_PROVIDER_TYPES);
 
@@ -116,166 +116,7 @@ export function barTone(percentUsed: number, mode: QuotaBarMode): QuotaBarTone {
 	return "danger";
 }
 
-// ── Z.ai Coding ──────────────────────────────────────────────────────────
-
-export function getZaiCodingFiveHourLimit(
-	data: ZAICodingQuotaResponse | undefined | null,
-): ZAICodingQuotaLimit | undefined {
-	return data?.data?.limits?.find(
-		(l) => l.type === "TOKENS_LIMIT" && l.unit === 3,
-	);
-}
-
-export function getZaiCodingWeeklyLimit(
-	data: ZAICodingQuotaResponse | undefined | null,
-): ZAICodingQuotaLimit | undefined {
-	return data?.data?.limits?.find(
-		(l) => l.type === "TOKENS_LIMIT" && l.unit === 6,
-	);
-}
-
-// ── Kimi Code ────────────────────────────────────────────────────────────
-// Kimi encodes limit and remaining as JSON strings, so parse with Number()
-// before computing. Percent used = (limit - remaining) / limit * 100.
-
-function toKimiCodeWindow(
-	limitStr: string | undefined,
-	remainingStr: string | undefined,
-	resetTime: string | undefined,
-): KimiCodeQuotaWindow | undefined {
-	if (limitStr == null || remainingStr == null) return undefined;
-	const limit = Number(limitStr);
-	const remaining = Number(remainingStr);
-	if (!Number.isFinite(limit) || !Number.isFinite(remaining)) return undefined;
-	const percentage = limit > 0 ? ((limit - remaining) / limit) * 100 : 0;
-	return { limit, remaining, resetTime: resetTime ?? "", percentage };
-}
-
-/** The rolling 300 minute (5 hour) window. */
-export function getKimiCodeFiveHourLimit(
-	data: KimiCodeQuotaResponse | undefined | null,
-): KimiCodeQuotaWindow | undefined {
-	const entry = data?.limits?.find(
-		(l) =>
-			l.window?.timeUnit === "TIME_UNIT_MINUTE" && l.window?.duration === 300,
-	);
-	if (!entry) return undefined;
-	return toKimiCodeWindow(
-		entry.detail?.limit,
-		entry.detail?.remaining,
-		entry.detail?.resetTime,
-	);
-}
-
-/** The weekly window, carried in the top-level `usage` block. */
-export function getKimiCodeWeeklyLimit(
-	data: KimiCodeQuotaResponse | undefined | null,
-): KimiCodeQuotaWindow | undefined {
-	const usage = data?.usage;
-	if (!usage) return undefined;
-	return toKimiCodeWindow(usage.limit, usage.remaining, usage.resetTime);
-}
-
-// ── MiniMax ──────────────────────────────────────────────────────────────
-// MiniMax reports REMAINING percentages per model class. The active class is the
-// first "general" entry with current_interval_status === 1. Used = 100 - remaining.
-
-/** First active "general" model-class entry, or undefined. */
-export function getMiniMaxGeneralEntry(
-	data: MiniMaxQuotaResponse | undefined | null,
-): MiniMaxModelRemains | undefined {
-	const entries =
-		data?.base_resp?.status_code === 0 ? data.model_remains : null;
-	if (!Array.isArray(entries)) return undefined;
-	return entries.find(
-		(m) => m.model_name === "general" && m.current_interval_status === 1,
-	);
-}
-
-function toMiniMaxWindow(
-	remainingPercent: number | undefined,
-	resetMs: number | undefined,
-): MiniMaxQuotaWindow | undefined {
-	if (remainingPercent == null || !Number.isFinite(remainingPercent))
-		return undefined;
-	return {
-		percentage: 100 - remainingPercent,
-		remainingPercent,
-		resetMs: resetMs ?? 0,
-	};
-}
-
-export function getMiniMaxFiveHourLimit(
-	data: MiniMaxQuotaResponse | undefined | null,
-): MiniMaxQuotaWindow | undefined {
-	const g = getMiniMaxGeneralEntry(data);
-	if (!g) return undefined;
-	return toMiniMaxWindow(g.current_interval_remaining_percent, g.remains_time);
-}
-
-export function getMiniMaxWeeklyLimit(
-	data: MiniMaxQuotaResponse | undefined | null,
-): MiniMaxQuotaWindow | undefined {
-	const g = getMiniMaxGeneralEntry(data);
-	if (!g) return undefined;
-	return toMiniMaxWindow(
-		g.current_weekly_remaining_percent,
-		g.weekly_remains_time,
-	);
-}
-
 // ── Badge models ─────────────────────────────────────────────────────────
-
-/** Subscription plans too low-tier to be worth a badge. */
-const NEURALWATT_EXCLUDED_PLANS = new Set(["free", "starter"]);
-
-/**
- * Whether a healthy payload has anything worth showing. Ported one-for-one from
- * the Model Hotel visibility booleans (web/src/hooks/useQuotaData.ts:644-690) so
- * both dashboards show the same set of badges for the same fleet.
- */
-function isVisible(type: QuotaProviderType, payload: object): boolean {
-	switch (type) {
-		case "nanogpt": {
-			const u = payload as NanoGPTUsage;
-			const cancelled =
-				u.providerStatus === "canceled" || u.providerStatus === "cancelled";
-			return (
-				!cancelled &&
-				u.weeklyInputTokens?.used != null &&
-				Boolean(u.limits?.weeklyInputTokens)
-			);
-		}
-		case "zai-coding": {
-			const u = payload as ZAICodingQuotaResponse;
-			return (
-				u.success === true &&
-				Boolean(getZaiCodingFiveHourLimit(u) || getZaiCodingWeeklyLimit(u))
-			);
-		}
-		case "kimi-code": {
-			const u = payload as KimiCodeQuotaResponse;
-			return Boolean(getKimiCodeFiveHourLimit(u) || getKimiCodeWeeklyLimit(u));
-		}
-		case "minimax":
-			return Boolean(getMiniMaxGeneralEntry(payload as MiniMaxQuotaResponse));
-		case "deepseek":
-			return (payload as DeepSeekBalance).is_available === true;
-		case "openrouter":
-			return (payload as OpenRouterBalance).credits_remaining != null;
-		case "ollama-cloud":
-			return (payload as OllamaCloudAccount).suspended_at?.valid !== true;
-		case "neuralwatt": {
-			const q = payload as NeuralWattQuotaResponse;
-			return (
-				q.balance?.credits_remaining_usd != null &&
-				!NEURALWATT_EXCLUDED_PLANS.has(
-					q.subscription?.plan?.toLowerCase() ?? "",
-				)
-			);
-		}
-	}
-}
 
 export interface QuotaBadgeModel {
 	/** Stable identity: `${type}:${provider_name}`. */
@@ -306,7 +147,7 @@ export function toBadgeModels(snapshots: QuotaSnapshot[]): QuotaBadgeModel[] {
 		if (!isQuotaProviderType(s.type)) continue;
 		const payload = payloadOf<object>(s);
 		const degraded = payload === null;
-		if (!degraded && !isVisible(s.type, payload)) continue;
+		if (!degraded && !isQuotaPayloadVisible(s.type, payload)) continue;
 		kept.push({
 			key: `${s.type}:${s.provider_name}`,
 			type: s.type,

--- a/frontdesk/web/tsconfig.app.json
+++ b/frontdesk/web/tsconfig.app.json
@@ -7,7 +7,10 @@
 		"module": "ESNext",
 		"skipLibCheck": true,
 		"moduleResolution": "bundler",
-		"paths": { "@/*": ["./src/*"] },
+		"paths": {
+			"@/*": ["./src/*"],
+			"@quota-shared": ["../../web-shared/quota/index.ts"]
+		},
 		"allowImportingTsExtensions": true,
 		"resolveJsonModule": true,
 		"isolatedModules": true,

--- a/frontdesk/web/vite.config.ts
+++ b/frontdesk/web/vite.config.ts
@@ -9,9 +9,18 @@ import { defineConfig } from "vite";
 export default defineConfig({
 	plugins: [react()],
 	resolve: {
-		alias: { "@": path.resolve(__dirname, "./src") },
+		alias: {
+			"@": path.resolve(__dirname, "./src"),
+			"@quota-shared": path.resolve(
+				__dirname,
+				"../../web-shared/quota/index.ts",
+			),
+		},
 	},
 	server: {
+		// The quota helpers live outside this project root, so the dev server has
+		// to be allowed to serve them alongside the app's own files.
+		fs: { allow: [__dirname, path.resolve(__dirname, "../../web-shared")] },
 		// `pnpm dev` proxies the API to a locally running frontdesk binary so the
 		// SPA and its REST/SSE backend share an origin during development.
 		proxy: {

--- a/frontdesk/web/vitest.config.ts
+++ b/frontdesk/web/vitest.config.ts
@@ -5,7 +5,13 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
 	plugins: [react()],
 	resolve: {
-		alias: { "@": path.resolve(__dirname, "./src") },
+		alias: {
+			"@": path.resolve(__dirname, "./src"),
+			"@quota-shared": path.resolve(
+				__dirname,
+				"../../web-shared/quota/index.ts",
+			),
+		},
 	},
 	test: {
 		globals: true,

--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -155,6 +155,12 @@ type Handler struct {
 	// process-wide state, even though only the poll goroutine touches it today.
 	quotaSchemaMu   sync.Mutex
 	quotaSchemaSeen map[uuid.UUID]quotaSchemaCandidate
+
+	// Debounce state for the breaker-open quota nudge: when each provider was
+	// last polled out of band. Guarded because a nudge arrives on whichever
+	// goroutine opened the circuit, so several can land at once.
+	quotaNudgeMu   sync.Mutex
+	quotaNudgeLast map[uuid.UUID]time.Time
 }
 
 // NewHandler creates a new admin API handler with the given dependencies.

--- a/internal/api/failover.go
+++ b/internal/api/failover.go
@@ -74,6 +74,13 @@ type CircuitBreakerQuotaPinner interface {
 	// switched off, so no refresh will ever report a recovery again. It must
 	// not change any circuit's state either.
 	ReleaseAllQuotaPins() int
+	// ApplyQuotaPins retargets the cooldown of every already-open circuit whose
+	// provider appears in advice, returning how many it retargeted. It only
+	// lengthens a wait: it must not change any circuit's state, must leave
+	// closed and half-open circuits alone, and must never shorten a pin already
+	// reaching further than the advice. Implementations may read advice only for
+	// the duration of the call.
+	ApplyQuotaPins(advice map[uuid.UUID]time.Time) int
 }
 
 // CircuitBreakerControl is the whole breaker surface the failover API needs.

--- a/internal/api/handler_failover_test.go
+++ b/internal/api/handler_failover_test.go
@@ -761,6 +761,10 @@ func (m *mockCircuitBreaker) ReleaseQuotaPins(map[uuid.UUID]struct{}) int { retu
 // reaches it, never an HTTP handler.
 func (m *mockCircuitBreaker) ReleaseAllQuotaPins() int { return 0 }
 
+// ApplyQuotaPins is a no-op for the same reason: only the quota refresh
+// retargets a pin, never an HTTP handler.
+func (m *mockCircuitBreaker) ApplyQuotaPins(map[uuid.UUID]time.Time) int { return 0 }
+
 func (m *mockCircuitBreaker) ResetAll() (cleared, recovered int) {
 	cleared = len(m.statuses)
 	for _, s := range m.statuses {

--- a/internal/api/metrics_test.go
+++ b/internal/api/metrics_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -34,6 +35,10 @@ func (f fakeBreakerReader) ReleaseQuotaPins(map[uuid.UUID]struct{}) int {
 }
 
 func (f fakeBreakerReader) ReleaseAllQuotaPins() int {
+	panic("metrics must never mutate quota pins")
+}
+
+func (f fakeBreakerReader) ApplyQuotaPins(map[uuid.UUID]time.Time) int {
 	panic("metrics must never mutate quota pins")
 }
 

--- a/internal/api/quota_snapshot.go
+++ b/internal/api/quota_snapshot.go
@@ -189,8 +189,11 @@ func (h *Handler) pollQuotaForProvider(ctx context.Context, disc *provider.Disco
 // already refusing traffic.
 const quotaNudgeDebounce = 60 * time.Second
 
-// quotaNudgeTimeout bounds a nudge end to end, matching the per-provider budget
-// the background poll pass uses.
+// quotaNudgeTimeout is the budget each stage of a nudge gets: the provider
+// lookup, the poll, and the advice refresh are bounded separately rather than
+// sharing one allowance, so a slow stage cannot starve the one after it. The
+// background pass needs no equivalent, since its refresh runs on the long-lived
+// loop context and the per-provider fetches are children that cannot exhaust it.
 const quotaNudgeTimeout = 30 * time.Second
 
 // NudgeQuotaPoll refreshes one provider's quota snapshot out of band and
@@ -227,9 +230,26 @@ func (h *Handler) NudgeQuotaPoll(providerID uuid.UUID) {
 	go func() {
 		pollCtx, pollCancel := context.WithTimeout(context.Background(), quotaNudgeTimeout)
 		defer pollCancel()
-		h.pollQuotaForProvider(pollCtx, disc, prov, kind)
-		h.RefreshQuotaAdvice(pollCtx)
+		h.runQuotaNudge(pollCtx, disc, prov, kind)
 	}()
+}
+
+// runQuotaNudge performs one nudge: the out-of-band poll under pollCtx, then
+// the advice refresh under a budget of its own.
+//
+// The two must not share one budget. A fetch that hangs to its deadline leaves
+// the refresh nothing to read with, and a refresh that cannot read fails closed
+// by clearing every provider's advice rather than only this one's. That turns a
+// single slow quota endpoint into a fleet-wide loss of pins until the next
+// background pass succeeds, and it would fire under precisely the conditions
+// this exists for: a provider that just failed enough requests to open a circuit
+// is a provider whose quota endpoint is plausibly hanging too.
+func (h *Handler) runQuotaNudge(pollCtx context.Context, disc *provider.DiscoveryService, prov *provider.Provider, kind string) {
+	h.pollQuotaForProvider(pollCtx, disc, prov, kind)
+
+	refreshCtx, cancel := context.WithTimeout(context.Background(), quotaNudgeTimeout)
+	defer cancel()
+	h.RefreshQuotaAdvice(refreshCtx)
 }
 
 // allowQuotaNudge reports whether a nudge for this provider is due, stamping it

--- a/internal/api/quota_snapshot.go
+++ b/internal/api/quota_snapshot.go
@@ -199,10 +199,9 @@ const quotaNudgeTimeout = 30 * time.Second
 // cycle away from the reading that would pin its cooldown to the real reset
 // time, and every probe it lets through until then is a guaranteed 429.
 //
-// The breaker stamps a pin when a circuit opens, so this reading governs the
-// circuit's next open transition rather than the cooldown already in force: the
-// pin lands on the first failed probe instead of however many probes fit in a
-// poll interval.
+// The refresh this ends with retargets circuits that are already open, so the
+// reading reaches the very circuit whose opening asked for it rather than only
+// governing the next one to open.
 //
 // The upstream call runs on its own goroutine under a fresh context, so it
 // never adds latency to whatever opened the circuit and never inherits that
@@ -297,6 +296,16 @@ func (h *Handler) RefreshQuotaAdvice(ctx context.Context) {
 	// cannot touch it.
 	advice, recovered := buildQuotaAdvice(snaps, typeByID, maxAge, time.Now())
 	advised := len(advice)
+
+	// Retarget the circuits that are already open before handing the map over:
+	// Replace takes ownership, so this is the last point at which advice may be
+	// read. The breaker only pins at the instant a circuit opens, so without
+	// this a reading that arrives even a second later reaches nothing until the
+	// circuit fails a probe and opens again — which is most of what the poll a
+	// breaker open triggers exists to prevent.
+	if h.circuitBreaker != nil {
+		h.circuitBreaker.ApplyQuotaPins(advice)
+	}
 
 	h.quotaAdvisor.Replace(advice)
 

--- a/internal/api/quota_snapshot.go
+++ b/internal/api/quota_snapshot.go
@@ -167,7 +167,12 @@ func (h *Handler) pollQuotaForProvider(ctx context.Context, disc *provider.Disco
 	_, payload, status, ferr := fetchQuotaSnapshot(provCtx, disc, prov, h.cfg.MasterKey)
 	if ferr != nil {
 		debuglog.Warn("quota: poll fetch failed", "provider", prov.Name, "error", ferr)
-		if rerr := h.quotaRepo.RecordFailure(provCtx, prov.ID, kind, ferr.Error()); rerr != nil {
+		// Its own context: a fetch that hung to its deadline is exactly the case
+		// worth recording, and provCtx is already expired by then, so writing the
+		// failure through it would drop the record for every timeout.
+		recCtx, recCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer recCancel()
+		if rerr := h.quotaRepo.RecordFailure(recCtx, prov.ID, kind, ferr.Error()); rerr != nil {
 			debuglog.Warn("quota: record failure failed", "provider", prov.Name, "error", rerr)
 		}
 		return

--- a/internal/api/quota_snapshot.go
+++ b/internal/api/quota_snapshot.go
@@ -149,26 +149,105 @@ func (h *Handler) PollQuotasOnce(ctx context.Context) {
 			}
 		}
 
-		provCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-		_, payload, status, ferr := fetchQuotaSnapshot(provCtx, disc, prov, h.cfg.MasterKey)
-		if ferr != nil {
-			debuglog.Warn("quota: poll fetch failed", "provider", prov.Name, "error", ferr)
-			if rerr := h.quotaRepo.RecordFailure(provCtx, prov.ID, kind, ferr.Error()); rerr != nil {
-				debuglog.Warn("quota: record failure failed", "provider", prov.Name, "error", rerr)
-			}
-		} else if uerr := h.quotaRepo.Upsert(provCtx, quota.Snapshot{
-			ProviderID: prov.ID,
-			Kind:       kind,
-			Payload:    payload,
-			HTTPStatus: status,
-			Source:     "poll",
-		}); uerr != nil {
-			debuglog.Warn("quota: poll upsert failed", "provider", prov.Name, "error", uerr)
-		}
-		cancel()
+		h.pollQuotaForProvider(ctx, disc, prov, kind)
 	}
 
 	h.RefreshQuotaAdvice(ctx)
+}
+
+// pollQuotaForProvider fetches and stores one provider's quota snapshot. The
+// fetch is bounded by its own timeout so a single slow upstream cannot stall
+// the caller, and a failure is recorded (via RecordFailure) without discarding
+// the last good snapshot. kind comes from the caller, which has already
+// established that this provider type exposes quota.
+func (h *Handler) pollQuotaForProvider(ctx context.Context, disc *provider.DiscoveryService, prov *provider.Provider, kind string) {
+	provCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	_, payload, status, ferr := fetchQuotaSnapshot(provCtx, disc, prov, h.cfg.MasterKey)
+	if ferr != nil {
+		debuglog.Warn("quota: poll fetch failed", "provider", prov.Name, "error", ferr)
+		if rerr := h.quotaRepo.RecordFailure(provCtx, prov.ID, kind, ferr.Error()); rerr != nil {
+			debuglog.Warn("quota: record failure failed", "provider", prov.Name, "error", rerr)
+		}
+		return
+	}
+	if uerr := h.quotaRepo.Upsert(provCtx, quota.Snapshot{
+		ProviderID: prov.ID,
+		Kind:       kind,
+		Payload:    payload,
+		HTTPStatus: status,
+		Source:     "poll",
+	}); uerr != nil {
+		debuglog.Warn("quota: poll upsert failed", "provider", prov.Name, "error", uerr)
+	}
+}
+
+// quotaNudgeDebounce is the minimum spacing between breaker-triggered polls of
+// one provider. A flapping circuit opens over and over, and every open would
+// otherwise become another upstream quota call against a provider that is
+// already refusing traffic.
+const quotaNudgeDebounce = 60 * time.Second
+
+// quotaNudgeTimeout bounds a nudge end to end, matching the per-provider budget
+// the background poll pass uses.
+const quotaNudgeTimeout = 30 * time.Second
+
+// NudgeQuotaPoll refreshes one provider's quota snapshot out of band and
+// rebuilds the advice from it. The background pass polls every few minutes, so
+// a circuit that opens because the provider's window is spent can be most of a
+// cycle away from the reading that would pin its cooldown to the real reset
+// time, and every probe it lets through until then is a guaranteed 429.
+//
+// The breaker stamps a pin when a circuit opens, so this reading governs the
+// circuit's next open transition rather than the cooldown already in force: the
+// pin lands on the first failed probe instead of however many probes fit in a
+// poll interval.
+//
+// The upstream call runs on its own goroutine under a fresh context, so it
+// never adds latency to whatever opened the circuit and never inherits that
+// caller's cancellation. Providers that serve no traffic or expose no quota
+// endpoint are rejected before any of that.
+func (h *Handler) NudgeQuotaPoll(providerID uuid.UUID) {
+	ctx, cancel := context.WithTimeout(context.Background(), quotaNudgeTimeout)
+	defer cancel()
+
+	prov, err := h.providerRepo.Get(ctx, providerID)
+	if err != nil || prov == nil || !prov.Enabled {
+		return
+	}
+	kind, ok := quotaKindFor(provider.DetectProviderType(prov.BaseURL))
+	if !ok {
+		return
+	}
+	if !h.allowQuotaNudge(providerID, time.Now()) {
+		return
+	}
+
+	disc := newDiscoveryService()
+	go func() {
+		pollCtx, pollCancel := context.WithTimeout(context.Background(), quotaNudgeTimeout)
+		defer pollCancel()
+		h.pollQuotaForProvider(pollCtx, disc, prov, kind)
+		h.RefreshQuotaAdvice(pollCtx)
+	}()
+}
+
+// allowQuotaNudge reports whether a nudge for this provider is due, stamping it
+// when it is. Deliberately in-memory: a restart re-arms every provider, which
+// costs one extra poll at worst.
+func (h *Handler) allowQuotaNudge(providerID uuid.UUID, now time.Time) bool {
+	h.quotaNudgeMu.Lock()
+	defer h.quotaNudgeMu.Unlock()
+
+	if last, ok := h.quotaNudgeLast[providerID]; ok && now.Sub(last) < quotaNudgeDebounce {
+		return false
+	}
+	if h.quotaNudgeLast == nil {
+		h.quotaNudgeLast = make(map[uuid.UUID]time.Time)
+	}
+	h.quotaNudgeLast[providerID] = now
+	return true
 }
 
 // RefreshQuotaAdvice rebuilds the in-memory quota advice from stored snapshots.

--- a/internal/api/quota_snapshot_test.go
+++ b/internal/api/quota_snapshot_test.go
@@ -1200,3 +1200,63 @@ func TestNudgeQuotaPoll_RetargetsAnAlreadyOpenCircuit(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 }
+
+// TestNudgeQuotaPoll_SpentPollBudgetDoesNotWipeAdvice pins the blast radius of a
+// hanging quota endpoint. The poll and the advice refresh must not share one
+// budget: a fetch that runs to its deadline leaves the refresh unable to read,
+// and a refresh that cannot read fails closed by clearing *every* provider's
+// advice, not just this one's. That would turn one slow endpoint into a
+// fleet-wide loss of pins until the next successful background pass, under
+// exactly the conditions the nudge exists for, since a provider that just failed
+// requests is a provider whose quota endpoint is plausibly hanging too.
+//
+// A cancelled context is what an exhausted poll budget leaves behind at the
+// moment the refresh would start, without the test waiting out the real budget.
+func TestNudgeQuotaPoll_SpentPollBudgetDoesNotWipeAdvice(t *testing.T) {
+	h := newTestHandler(t)
+	advisor := NewQuotaAdvisor()
+	h.SetQuotaAdvisor(advisor)
+	ctx := context.Background()
+
+	// Two exhausted providers, so the assertion can tell a wipe confined to the
+	// nudged provider apart from the fleet-wide one this guards against.
+	nudged := insertQuotaPollProvider(t, h.dbPool.Pool(), "zai-nudged", "https://api.z.ai/api/coding/paas/v4", true)
+	bystander := insertQuotaPollProvider(t, h.dbPool.Pool(), "zai-bystander", "https://gw.z.ai/api/coding/paas/v4", true)
+
+	resetsAt := time.Now().Add(4 * time.Hour)
+	for _, id := range []uuid.UUID{nudged, bystander} {
+		if err := h.quotaRepo.Upsert(ctx, quota.Snapshot{
+			ProviderID: id, Kind: "usage", Payload: exhaustedZaiCodingPayload(t, resetsAt),
+			HTTPStatus: 200, Source: "poll", FetchedAt: time.Now(),
+		}); err != nil {
+			t.Fatalf("seed snapshot: %v", err)
+		}
+	}
+
+	h.RefreshQuotaAdvice(ctx)
+	for _, c := range []struct {
+		name string
+		id   uuid.UUID
+	}{{"nudged", nudged}, {"bystander", bystander}} {
+		if _, ok := advisor.ResetsAt(c.id); !ok {
+			t.Fatalf("setup: %s provider must start out advised", c.name)
+		}
+	}
+
+	prov, err := h.providerRepo.Get(ctx, nudged)
+	if err != nil {
+		t.Fatalf("get provider: %v", err)
+	}
+
+	spent, cancel := context.WithCancel(ctx)
+	cancel()
+
+	h.runQuotaNudge(spent, exhaustedZaiCodingDiscovery(resetsAt), prov, "usage")
+
+	if _, ok := advisor.ResetsAt(bystander); !ok {
+		t.Error("a spent poll budget wiped advice for an unrelated provider: the refresh must not run on a context the poll could exhaust")
+	}
+	if _, ok := advisor.ResetsAt(nudged); !ok {
+		t.Error("a spent poll budget dropped the nudged provider's own advice, which its stored snapshot still supports")
+	}
+}

--- a/internal/api/quota_snapshot_test.go
+++ b/internal/api/quota_snapshot_test.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -997,4 +998,148 @@ func TestPollQuotasOnce_ProviderListFailureClearsQuotaAdvice(t *testing.T) {
 func TestClearQuotaAdvice_NilAdvisorNoop(t *testing.T) {
 	h := newTestHandler(t)
 	h.ClearQuotaAdvice(context.Background())
+}
+
+// ---------------------------------------------------------------------------
+// Breaker-open quota nudge
+// ---------------------------------------------------------------------------
+
+// waitForQuotaSnapshot returns the snapshot a nudge stores from its own
+// goroutine, failing once the deadline passes. The poll interval is a retry
+// cadence, not a synchronization point: the assertion is the snapshot existing.
+func waitForQuotaSnapshot(t *testing.T, h *Handler, id uuid.UUID, kind string) *quota.Snapshot {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		snap, err := h.quotaRepo.Get(context.Background(), id, kind)
+		if err != nil {
+			t.Fatalf("get snapshot: %v", err)
+		}
+		if snap != nil {
+			return snap
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for the nudge to store a snapshot")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// exhaustedZaiCodingDiscovery returns a discovery service whose zai-coding quota
+// endpoint reports a fully spent 5-hour window resetting at resetsAt. percentage
+// is set because the stored payload is a re-marshal of ZAICodingQuotaResponse,
+// whose non-pointer percentage field always serializes: the normalizer trusts a
+// percentage inside [0,100] over remaining, so a payload carrying only
+// remaining=0 would round-trip as percentage=0 and read as healthy.
+func exhaustedZaiCodingDiscovery(resetsAt time.Time) *provider.DiscoveryService {
+	body := `{"code":200,"success":true,"data":{"limits":[{"type":"TOKENS_LIMIT","unit":3,"remaining":0,"percentage":100,"nextResetTime":` +
+		strconv.FormatInt(resetsAt.UnixMilli(), 10) + `}]}}`
+	ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
+		Transport: &mockTransport{roundTripFunc: func(_ *http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body)), Header: make(http.Header)}, nil
+		}},
+	})
+	ds.SetRetryBaseDelay(time.Millisecond)
+	return ds
+}
+
+// TestNudgeQuotaPoll_DebouncesRepeatOpens verifies a flapping circuit cannot
+// turn into a poll storm against the provider it just gave up on. The discovery
+// service is built on the caller's goroutine before the poll is spawned, so the
+// factory count is a synchronous readout of how many nudges were admitted.
+func TestNudgeQuotaPoll_DebouncesRepeatOpens(t *testing.T) {
+	h := newTestHandler(t)
+	id := insertQuotaPollProvider(t, h.dbPool.Pool(), "nanogpt-nudge-debounce", "https://api.nano-gpt.com/v1", true)
+
+	var admitted atomic.Int64
+	orig := newDiscoveryService
+	defer func() { newDiscoveryService = orig }()
+	newDiscoveryService = func() *provider.DiscoveryService {
+		admitted.Add(1)
+		return nanoGPTPollDiscovery(7)
+	}
+
+	h.NudgeQuotaPoll(id)
+	waitForQuotaSnapshot(t, h, id, "usage")
+	if got := admitted.Load(); got != 1 {
+		t.Fatalf("first nudge: got %d polls, want 1", got)
+	}
+
+	h.NudgeQuotaPoll(id)
+	if got := admitted.Load(); got != 1 {
+		t.Fatalf("a second open inside the debounce window must not poll again, got %d polls", got)
+	}
+}
+
+// TestNudgeQuotaPoll_SkipsProvidersWithNothingToPoll verifies the two cases
+// where an open circuit says nothing about quota: the provider is switched off,
+// or its type exposes no quota endpoint at all.
+func TestNudgeQuotaPoll_SkipsProvidersWithNothingToPoll(t *testing.T) {
+	cases := []struct {
+		name    string
+		baseURL string
+		enabled bool
+		why     string
+	}{
+		{"disabled", "https://api.nano-gpt.com/v1", false, "a disabled provider serves no traffic and must not be called"},
+		{"no-quota-endpoint", "https://api.openai.com/v1", true, "this provider type exposes no quota endpoint"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			h := newTestHandler(t)
+			id := insertQuotaPollProvider(t, h.dbPool.Pool(), "nudge-"+c.name, c.baseURL, c.enabled)
+
+			var admitted atomic.Int64
+			orig := newDiscoveryService
+			defer func() { newDiscoveryService = orig }()
+			newDiscoveryService = func() *provider.DiscoveryService {
+				admitted.Add(1)
+				return nanoGPTPollDiscovery(1)
+			}
+
+			h.NudgeQuotaPoll(id)
+
+			if got := admitted.Load(); got != 0 {
+				t.Fatalf("got %d polls, want 0: %s", got, c.why)
+			}
+		})
+	}
+}
+
+// TestNudgeQuotaPoll_RetargetsAdviceFromFreshReading is the whole point of the
+// nudge: a circuit that opens on a spent quota window gets its cooldown pinned
+// from advice, and advice only exists once a snapshot has been read and
+// assessed. Polling alone is not enough, so this asserts the advisor carries the
+// provider's real reset deadline afterwards rather than only that a row landed.
+func TestNudgeQuotaPoll_RetargetsAdviceFromFreshReading(t *testing.T) {
+	h := newTestHandler(t)
+	advisor := NewQuotaAdvisor()
+	h.SetQuotaAdvisor(advisor)
+	id := insertQuotaPollProvider(t, h.dbPool.Pool(), "zai-nudge", "https://api.z.ai/api/coding/paas/v4", true)
+
+	resetsAt := time.Now().Add(4 * time.Hour)
+	orig := newDiscoveryService
+	defer func() { newDiscoveryService = orig }()
+	newDiscoveryService = func() *provider.DiscoveryService { return exhaustedZaiCodingDiscovery(resetsAt) }
+
+	h.NudgeQuotaPoll(id)
+
+	snap := waitForQuotaSnapshot(t, h, id, "usage")
+	if snap.Source != "poll" {
+		t.Fatalf("want source=poll, got %q", snap.Source)
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if at, ok := advisor.ResetsAt(id); ok {
+			if at.UnixMilli() != resetsAt.UnixMilli() {
+				t.Fatalf("advised reset %s, want %s", at, resetsAt)
+			}
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for the nudge to refresh quota advice")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 }

--- a/internal/api/quota_snapshot_test.go
+++ b/internal/api/quota_snapshot_test.go
@@ -508,6 +508,11 @@ func (p *pinReleaseRecorder) ReleaseAllQuotaPins() int {
 	return 0
 }
 
+// ApplyQuotaPins records nothing: these tests are about the release half of the
+// contract, and returning 0 keeps a refresh that retargets pins from disturbing
+// the release assertions.
+func (p *pinReleaseRecorder) ApplyQuotaPins(map[uuid.UUID]time.Time) int { return 0 }
+
 func (p *pinReleaseRecorder) recorded() []map[uuid.UUID]struct{} {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -1139,6 +1144,58 @@ func TestNudgeQuotaPoll_RetargetsAdviceFromFreshReading(t *testing.T) {
 		}
 		if time.Now().After(deadline) {
 			t.Fatal("timed out waiting for the nudge to refresh quota advice")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// TestNudgeQuotaPoll_RetargetsAnAlreadyOpenCircuit wires the feature end to end.
+// A circuit opens while nothing yet knows the provider's window is spent, so it
+// is pinned to nothing and holds an ordinary cooldown. The open transition
+// triggers the nudge, and the reading it fetches must move the retry instant on
+// that same circuit out to the real reset, rather than waiting for the circuit
+// to fail a probe and open a second time.
+func TestNudgeQuotaPoll_RetargetsAnAlreadyOpenCircuit(t *testing.T) {
+	h := newTestHandler(t)
+
+	// One advisor behind both sides, as main.go wires it.
+	advisor := NewQuotaAdvisor()
+	h.SetQuotaAdvisor(advisor)
+	cb := failover.NewCircuitBreaker(nil) // threshold 5, cooldown 60s
+	cb.SetQuotaAdvisor(advisor)
+	cb.SetOnOpen(h.NudgeQuotaPoll)
+	h.SetCircuitBreaker(cb)
+
+	id := insertQuotaPollProvider(t, h.dbPool.Pool(), "zai-repin", "https://api.z.ai/api/coding/paas/v4", true)
+
+	resetsAt := time.Now().Add(4 * time.Hour)
+	orig := newDiscoveryService
+	defer func() { newDiscoveryService = orig }()
+	newDiscoveryService = func() *provider.DiscoveryService { return exhaustedZaiCodingDiscovery(resetsAt) }
+
+	// The advisor is empty until the nudge refreshes it, so this open is
+	// necessarily unpinned and lands on the 60s default cooldown.
+	for i := 0; i < 5; i++ {
+		cb.RecordFailure(id, "zai-repin")
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		statuses := cb.Status()
+		if len(statuses) == 1 && statuses[0].QuotaPinned {
+			got := statuses[0].CooldownMs
+			minMs := (4*time.Hour - time.Minute).Milliseconds()
+			maxMs := (4 * time.Hour).Milliseconds() * 21 / 20
+			if got < minMs || got > maxMs {
+				t.Fatalf("got CooldownMs=%d, want the circuit retargeted to the ~4h quota reset (within [%d,%d])", got, minMs, maxMs)
+			}
+			if statuses[0].State != "open" {
+				t.Fatalf("got state %q, want the circuit still open: quota must never close a circuit", statuses[0].State)
+			}
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for the nudge to retarget the open circuit, last status %+v", statuses)
 		}
 		time.Sleep(10 * time.Millisecond)
 	}

--- a/internal/failover/circuitbreaker.go
+++ b/internal/failover/circuitbreaker.go
@@ -505,6 +505,9 @@ func (cb *CircuitBreaker) ApplyQuotaPins(advice map[uuid.UUID]time.Time) int {
 		return 0
 	}
 	base := cb.effectiveCooldown()
+	// Hoisted with base: both read settings, and a cold settings cache turns that
+	// into a DB round trip under cb.mu held for write.
+	maxPin := cb.quotaPinMax()
 
 	// Walk the advice rather than every circuit, for the same reason
 	// ReleaseQuotaPins walks the recovered set: it is the smaller side, and the
@@ -525,7 +528,7 @@ func (cb *CircuitBreaker) ApplyQuotaPins(advice map[uuid.UUID]time.Time) int {
 		// Ceiling first, so a clamped value is compared against the floors
 		// rather than smuggled past them: capping after those checks could
 		// shorten a pin that is already longer.
-		if maxPin := cb.quotaPinMax(); d > maxPin {
+		if d > maxPin {
 			d = maxPin
 		}
 		if d <= base || d <= c.cooldownOverride {

--- a/internal/failover/circuitbreaker.go
+++ b/internal/failover/circuitbreaker.go
@@ -474,6 +474,77 @@ func (cb *CircuitBreaker) ReleaseQuotaPins(recovered map[uuid.UUID]struct{}) int
 	return released
 }
 
+// ApplyQuotaPins retargets the cooldown of every already-open circuit whose
+// provider is now known to be exhausted, and reports how many it retargeted. It
+// is the counterpart to applyQuotaPin, which stamps a pin at the instant a
+// circuit opens and therefore only ever sees the advice that existed by then. A
+// reading that lands moments later (the poll a breaker open triggers) has to
+// reach the circuit that prompted it, or that circuit serves out an ordinary
+// cooldown and probes into a certain 429 before the pin finally applies on the
+// re-open.
+//
+// It only ever lengthens a wait, and only for circuits open right now:
+//
+//   - A closed circuit is serving traffic and has no cooldown to retarget.
+//   - A half-open circuit has a probe out or due, so HTTP is mid-verdict.
+//     logicalState decides that, which means an open circuit whose cooldown has
+//     already elapsed counts as half-open here too: it is owed a probe, and
+//     pushing it back into the dark would overturn a decision the breaker has
+//     already handed to the request path.
+//   - A pin already reaching further than the advice stands. Releasing needs
+//     affirmative proof the provider recovered, which is ReleaseQuotaPins' job;
+//     a nearer deadline arriving here is not that proof.
+//
+// advice is read, never retained: the caller may hand the same map to the
+// advisor afterwards.
+func (cb *CircuitBreaker) ApplyQuotaPins(advice map[uuid.UUID]time.Time) int {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	if len(advice) == 0 || !cb.quotaPinEnabled() {
+		return 0
+	}
+	base := cb.effectiveCooldown()
+
+	// Walk the advice rather than every circuit, for the same reason
+	// ReleaseQuotaPins walks the recovered set: it is the smaller side, and the
+	// circuits map is keyed by the provider's UUID string.
+	retargeted := 0
+	for providerID, resetsAt := range advice {
+		c, ok := cb.circuits[providerID.String()]
+		if !ok || cb.logicalState(c) != StateOpen {
+			continue
+		}
+		// Measured from openedAt, because that is what the enforced cooldown is
+		// measured from. applyQuotaPin computes this from time.Until(resetsAt)
+		// instead, which is the same number at the one instant it runs; here
+		// openedAt is already in the past, and a pin derived from "time until
+		// reset" would expire that much too early and probe before the window
+		// rolls over.
+		d := resetsAt.Sub(c.openedAt)
+		// Ceiling first, so a clamped value is compared against the floors
+		// rather than smuggled past them: capping after those checks could
+		// shorten a pin that is already longer.
+		if maxPin := cb.quotaPinMax(); d > maxPin {
+			d = maxPin
+		}
+		if d <= base || d <= c.cooldownOverride {
+			continue
+		}
+		if spread := int64(d / 20); spread > 0 {
+			d += time.Duration(rand.Int64N(spread + 1))
+		}
+		c.cooldownOverride = d
+		retargeted++
+		// The open transition already logged a cooldown_ms that is now wrong,
+		// and the corrected one can mean hours of darkness, so an operator gets
+		// the same Info-level line a release gets. Routing metadata only, never
+		// payload or credentials.
+		debuglog.Info("circuit-breaker: quota pin retargeted (fresh exhaustion reading)", "provider_id", providerID, "cooldown_ms", d.Milliseconds())
+	}
+	return retargeted
+}
+
 // ReleaseAllQuotaPins lifts the quota cooldown override from every circuit that
 // carries one, and reports how many it lifted.
 //

--- a/internal/failover/circuitbreaker.go
+++ b/internal/failover/circuitbreaker.go
@@ -96,6 +96,13 @@ type CircuitBreaker struct {
 	// cooldown of an already-open circuit. Nil disables quota pinning.
 	quota QuotaAdvisor
 
+	// onOpen is notified whenever a circuit transitions to Open. It exists so a
+	// consumer can refresh what it knows about the provider at the one moment
+	// that knowledge decides how long the circuit stays dark. A plain callback
+	// rather than a package dependency: the breaker must not know what the
+	// consumer does with the notification. Nil when nothing is wired.
+	onOpen func(providerID uuid.UUID)
+
 	// Threshold is the number of consecutive failures before opening.
 	Threshold int
 
@@ -132,6 +139,27 @@ func (cb *CircuitBreaker) SetQuotaAdvisor(a QuotaAdvisor) {
 	cb.mu.Lock()
 	defer cb.mu.Unlock()
 	cb.quota = a
+}
+
+// SetOnOpen installs the open-transition callback. Call during startup wiring,
+// before the breaker serves traffic. A nil callback disables the notification.
+func (cb *CircuitBreaker) SetOnOpen(fn func(providerID uuid.UUID)) {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+	cb.onOpen = fn
+}
+
+// notifyOpen fires the open-transition callback for a circuit that just went
+// open. The callback runs on its own goroutine, so it never executes under
+// cb.mu and never adds latency to the request that opened the circuit: this is
+// reached from RecordFailure on the proxy path, and a consumer is free to reach
+// the network. Must be called with cb.mu held.
+func (cb *CircuitBreaker) notifyOpen(providerID uuid.UUID) {
+	if cb.onOpen == nil {
+		return
+	}
+	fn := cb.onOpen
+	go fn(providerID)
 }
 
 func (cb *CircuitBreaker) getOrCreate(providerID string) *circuit {
@@ -217,6 +245,7 @@ func (cb *CircuitBreaker) RecordFailure(providerID uuid.UUID, providerName strin
 			// about that. Routing metadata only — never payload or credentials.
 			debuglog.Warn("circuit-breaker: provider state=closed→open", "provider", providerName, "provider_id", providerID, "consecutive_failures", c.consecutiveFails, "cooldown_ms", cb.effectiveCooldownFor(c).Milliseconds(), "quota_pinned", cb.quotaPinnedFor(c))
 			cb.publishEvent(providerID, providerName, "open", c)
+			cb.notifyOpen(providerID)
 		}
 	case StateHalfOpen:
 		c.state = StateOpen
@@ -225,6 +254,7 @@ func (cb *CircuitBreaker) RecordFailure(providerID uuid.UUID, providerName strin
 		cb.applyQuotaPin(providerID, c)
 		debuglog.Warn("circuit-breaker: provider state=half-open→open (probe failed)", "provider", providerName, "provider_id", providerID, "cooldown_ms", cb.effectiveCooldownFor(c).Milliseconds(), "quota_pinned", cb.quotaPinnedFor(c))
 		cb.publishEvent(providerID, providerName, "open", c)
+		cb.notifyOpen(providerID)
 	case StateOpen:
 		// Already open — no-op.
 	}

--- a/internal/failover/circuitbreaker_test.go
+++ b/internal/failover/circuitbreaker_test.go
@@ -1848,3 +1848,206 @@ func TestOnOpen_NoCallbackIsSafe(t *testing.T) {
 		t.Errorf("got state %v, want open", s)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Quota re-pin tests
+// ---------------------------------------------------------------------------
+
+// backdateOpen moves a circuit's open instant into the past, so a cooldown
+// computed from openedAt is distinguishable from one computed from now without
+// the test waiting out real time.
+func backdateOpen(t *testing.T, cb *CircuitBreaker, id uuid.UUID, by time.Duration) {
+	t.Helper()
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+	c, ok := cb.circuits[id.String()]
+	if !ok {
+		t.Fatalf("setup: no circuit tracked for %s", id)
+	}
+	c.openedAt = c.openedAt.Add(-by)
+}
+
+// overrideFor reads a circuit's stored quota override. Status reports the
+// cooldown actually governing the circuit, which hides the override whenever
+// pinning is switched off, so assertions about the override itself read it here.
+func overrideFor(t *testing.T, cb *CircuitBreaker, id uuid.UUID) time.Duration {
+	t.Helper()
+	cb.mu.RLock()
+	defer cb.mu.RUnlock()
+	c, ok := cb.circuits[id.String()]
+	if !ok {
+		t.Fatalf("no circuit tracked for %s", id)
+	}
+	return c.cooldownOverride
+}
+
+func onlyStatus(t *testing.T, cb *CircuitBreaker) ProviderStatus {
+	t.Helper()
+	statuses := cb.Status()
+	if len(statuses) != 1 {
+		t.Fatalf("got %d statuses, want 1", len(statuses))
+	}
+	return statuses[0]
+}
+
+// TestApplyQuotaPins_RetargetsOpenCircuit is the whole point of the re-pin: a
+// circuit that opened before the exhaustion was known carries an ordinary
+// cooldown, and the reading that arrives seconds later must move its retry
+// instant out to the real reset rather than waiting for the circuit to open a
+// second time.
+//
+// The circuit is backdated so the assertion can tell the two candidate
+// computations apart. The breaker enforces a cooldown measured from openedAt,
+// so a pin derived from "time until reset" expires early by however long the
+// circuit has already been open and probes before the window rolls over. The
+// backdate has to clear the 5% positive jitter to be decisive, hence two hours
+// against a six-hour reset, and the configured cooldown has to outlast the
+// backdate or the circuit would read as half-open and be skipped by design.
+func TestApplyQuotaPins_RetargetsOpenCircuit(t *testing.T) {
+	cb := newTestCB(1, 3*time.Hour)
+	id := uuid.New()
+
+	cb.RecordFailure(id, "test-provider") // opens unpinned: no advice existed yet
+	if got := overrideFor(t, cb, id); got != 0 {
+		t.Fatalf("setup: got override %v, want an unpinned circuit", got)
+	}
+	backdateOpen(t, cb, id, 2*time.Hour)
+
+	resetsAt := time.Now().Add(6 * time.Hour).Truncate(time.Second)
+	if got := cb.ApplyQuotaPins(map[uuid.UUID]time.Time{id: resetsAt}); got != 1 {
+		t.Fatalf("got %d circuits retargeted, want 1", got)
+	}
+
+	s := onlyStatus(t, cb)
+	if !s.QuotaPinned {
+		t.Error("a retargeted circuit must report quota_pinned")
+	}
+	next, err := time.Parse(time.RFC3339, s.NextRetryAt)
+	if err != nil {
+		t.Fatalf("parse next_retry_at %q: %v", s.NextRetryAt, err)
+	}
+	if next.Before(resetsAt) {
+		t.Errorf("next retry %s falls before the quota reset %s: the pin must be measured from openedAt, not from now", next, resetsAt)
+	}
+	// Positive-only jitter is capped at 5% of the pin, which spans openedAt to
+	// the reset, so the retry cannot land arbitrarily far past it either.
+	if latest := resetsAt.Add(8 * time.Hour / 20); next.After(latest) {
+		t.Errorf("next retry %s lands past %s, further than jitter allows", next, latest)
+	}
+}
+
+// TestApplyQuotaPins_LeavesNonOpenCircuitsAlone verifies the re-pin only touches
+// circuits that are actually holding traffic back. A closed circuit has no
+// cooldown to retarget, and a half-open one has a probe out or due, so HTTP is
+// mid-verdict: pushing it back into the dark would overturn a decision the
+// breaker has already handed to the request path.
+func TestApplyQuotaPins_LeavesNonOpenCircuitsAlone(t *testing.T) {
+	cases := []struct {
+		name  string
+		setup func(t *testing.T, cb *CircuitBreaker, id uuid.UUID)
+		why   string
+	}{
+		{
+			name: "closed",
+			setup: func(_ *testing.T, cb *CircuitBreaker, id uuid.UUID) {
+				cb.RecordFailure(id, "test-provider") // one short of the threshold
+			},
+			why: "a closed circuit is serving traffic and has no cooldown to retarget",
+		},
+		{
+			name: "half-open probe out",
+			setup: func(t *testing.T, cb *CircuitBreaker, id uuid.UUID) {
+				cb.RecordFailure(id, "test-provider")
+				cb.RecordFailure(id, "test-provider") // opens
+				backdateOpen(t, cb, id, time.Second)
+				cb.IsOpen(id, "test-provider") // cooldown elapsed: hands out a probe
+			},
+			why: "a probe is in flight and HTTP is about to decide",
+		},
+		{
+			name: "cooldown elapsed",
+			setup: func(t *testing.T, cb *CircuitBreaker, id uuid.UUID) {
+				cb.RecordFailure(id, "test-provider")
+				cb.RecordFailure(id, "test-provider") // opens
+				backdateOpen(t, cb, id, time.Second)  // probe due, reads as half-open
+			},
+			why: "the cooldown already elapsed, so the circuit is due a probe",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cb := newTestCB(2, 50*time.Millisecond)
+			id := uuid.New()
+			c.setup(t, cb, id)
+
+			got := cb.ApplyQuotaPins(map[uuid.UUID]time.Time{id: time.Now().Add(6 * time.Hour)})
+
+			if got != 0 {
+				t.Errorf("got %d circuits retargeted, want 0: %s", got, c.why)
+			}
+			if o := overrideFor(t, cb, id); o != 0 {
+				t.Errorf("got override %v, want none: %s", o, c.why)
+			}
+		})
+	}
+}
+
+// TestApplyQuotaPins_NeverShortensExistingPin verifies the re-pin only ever
+// lengthens a wait. Releasing a pin needs affirmative proof the provider
+// recovered, which is ReleaseQuotaPins' job; a shorter deadline arriving here
+// is not that proof.
+func TestApplyQuotaPins_NeverShortensExistingPin(t *testing.T) {
+	cb := newTestCB(1, 60*time.Second)
+	id := uuid.New()
+	cb.SetQuotaAdvisor(stubAdvisor{at: time.Now().Add(6 * time.Hour), ok: true})
+
+	cb.RecordFailure(id, "test-provider") // opens pinned to ~6h
+	before := overrideFor(t, cb, id)
+	if before == 0 {
+		t.Fatal("setup: expected the open transition to pin the circuit")
+	}
+
+	if got := cb.ApplyQuotaPins(map[uuid.UUID]time.Time{id: time.Now().Add(time.Hour)}); got != 0 {
+		t.Errorf("got %d circuits retargeted, want 0 for a nearer deadline", got)
+	}
+	if after := overrideFor(t, cb, id); after != before {
+		t.Errorf("got override %v, want the longer existing pin %v left alone", after, before)
+	}
+}
+
+// TestApplyQuotaPins_SkipsWhenPinDisabled verifies the operator kill switch
+// covers this path too. Status would hide the override anyway, so the stored
+// value is checked directly: a circuit must not carry a pin an operator has
+// switched off, or re-enabling would resurrect deadlines from a disabled span.
+func TestApplyQuotaPins_SkipsWhenPinDisabled(t *testing.T) {
+	disabled := false
+	cb := NewCircuitBreaker(&stubSettings{threshold: 1, cooldown: 60 * time.Second, pinEnabled: &disabled})
+	id := uuid.New()
+
+	cb.RecordFailure(id, "test-provider")
+
+	if got := cb.ApplyQuotaPins(map[uuid.UUID]time.Time{id: time.Now().Add(6 * time.Hour)}); got != 0 {
+		t.Errorf("got %d circuits retargeted, want 0 while quota pinning is disabled", got)
+	}
+	if o := overrideFor(t, cb, id); o != 0 {
+		t.Errorf("got override %v, want none while quota pinning is disabled", o)
+	}
+}
+
+// TestApplyQuotaPins_CeilingCapsRunawayDeadline verifies the re-pin obeys the
+// same ceiling the open-time pin does, so a nonsense deadline cannot bench a
+// provider indefinitely.
+func TestApplyQuotaPins_CeilingCapsRunawayDeadline(t *testing.T) {
+	cb := NewCircuitBreaker(&stubSettings{threshold: 1, cooldown: time.Second, pinMax: time.Hour})
+	id := uuid.New()
+
+	cb.RecordFailure(id, "test-provider")
+
+	if got := cb.ApplyQuotaPins(map[uuid.UUID]time.Time{id: time.Now().Add(500 * 24 * time.Hour)}); got != 1 {
+		t.Fatalf("got %d circuits retargeted, want 1", got)
+	}
+	ceiling := time.Hour
+	if o := overrideFor(t, cb, id); o > ceiling+ceiling/20 {
+		t.Errorf("got override %v, want capped near the settings max %v", o, ceiling)
+	}
+}

--- a/internal/failover/circuitbreaker_test.go
+++ b/internal/failover/circuitbreaker_test.go
@@ -2038,7 +2038,10 @@ func TestApplyQuotaPins_SkipsWhenPinDisabled(t *testing.T) {
 // same ceiling the open-time pin does, so a nonsense deadline cannot bench a
 // provider indefinitely.
 func TestApplyQuotaPins_CeilingCapsRunawayDeadline(t *testing.T) {
-	cb := NewCircuitBreaker(&stubSettings{threshold: 1, cooldown: time.Second, pinMax: time.Hour})
+	// A cooldown long enough that scheduling delay cannot age the circuit into
+	// half-open before ApplyQuotaPins reads it; still far below the 1h ceiling
+	// under test, so the pin is a genuine lengthening.
+	cb := NewCircuitBreaker(&stubSettings{threshold: 1, cooldown: 60 * time.Second, pinMax: time.Hour})
 	id := uuid.New()
 
 	cb.RecordFailure(id, "test-provider")

--- a/internal/failover/circuitbreaker_test.go
+++ b/internal/failover/circuitbreaker_test.go
@@ -1770,3 +1770,81 @@ func TestPublishEvent_UnpinnedOmitsNextRetryAt(t *testing.T) {
 		t.Fatalf("the old resets_at name must not linger alongside it, got %#v", v)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Open-transition callback tests
+// ---------------------------------------------------------------------------
+
+// waitForOnOpen returns the provider the open callback reported, or fails the
+// test if nothing arrives. The callback runs on its own goroutine, so a channel
+// with a deadline is the only sound way to observe it.
+func waitForOnOpen(t *testing.T, got <-chan uuid.UUID) uuid.UUID {
+	t.Helper()
+	select {
+	case id := <-got:
+		return id
+	case <-time.After(2 * time.Second):
+		t.Fatal("open transition did not invoke the open callback")
+		return uuid.Nil
+	}
+}
+
+// TestOnOpen_FiresOnClosedToOpen verifies the callback the quota nudge hangs
+// off: a circuit that opens on the ordinary failure-threshold path must report
+// which provider went dark, so a fresh quota reading can be fetched while the
+// pin still matters.
+func TestOnOpen_FiresOnClosedToOpen(t *testing.T) {
+	cb := newTestCB(2, 30*time.Second)
+	id := uuid.New()
+
+	got := make(chan uuid.UUID, 1)
+	cb.SetOnOpen(func(providerID uuid.UUID) { got <- providerID })
+
+	cb.RecordFailure(id, "test-provider")
+	cb.RecordFailure(id, "test-provider") // threshold reached → opens
+
+	if reported := waitForOnOpen(t, got); reported != id {
+		t.Errorf("callback got provider %s, want %s", reported, id)
+	}
+}
+
+// TestOnOpen_FiresOnHalfOpenToOpen covers the second open transition: a failed
+// half-open probe re-opens the circuit with a fresh cooldown, which is exactly
+// the cooldown a quota pin would retarget, so it must nudge too. The callback is
+// installed after the first open so only the re-open can feed the channel.
+func TestOnOpen_FiresOnHalfOpenToOpen(t *testing.T) {
+	cb := newTestCB(1, 0) // zero cooldown: the first IsOpen call hands out a probe
+	id := uuid.New()
+
+	cb.RecordFailure(id, "test-provider") // closed→open, no callback installed yet
+
+	got := make(chan uuid.UUID, 1)
+	cb.SetOnOpen(func(providerID uuid.UUID) { got <- providerID })
+
+	if cb.IsOpen(id, "test-provider") {
+		t.Fatal("setup: elapsed cooldown should hand out a half-open probe")
+	}
+	if s := cb.GetState(id); s != StateHalfOpen {
+		t.Fatalf("setup: got state %v, want half-open", s)
+	}
+
+	cb.RecordFailure(id, "test-provider") // probe fails → half-open→open
+
+	if reported := waitForOnOpen(t, got); reported != id {
+		t.Errorf("callback got provider %s, want %s", reported, id)
+	}
+}
+
+// TestOnOpen_NoCallbackIsSafe verifies a breaker with nothing wired still opens
+// normally. Every deployment that does not run the quota nudge is this case, and
+// an unguarded invocation would panic on the request path.
+func TestOnOpen_NoCallbackIsSafe(t *testing.T) {
+	cb := newTestCB(1, 30*time.Second)
+	id := uuid.New()
+
+	cb.RecordFailure(id, "test-provider")
+
+	if s := cb.GetState(id); s != StateOpen {
+		t.Errorf("got state %v, want open", s)
+	}
+}

--- a/internal/provider/discovery_kimi_test.go
+++ b/internal/provider/discovery_kimi_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -360,6 +361,66 @@ func TestGetKimiCodeQuota_DecodeError(t *testing.T) {
 	_, err = svc.GetKimiCodeQuota(context.Background(), provider, masterKey)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to decode response")
+}
+
+// kimiExhaustedUsagePayload is the real /usages response of an account that has
+// spent its 5-hour window (live-captured 2026-08-07). /usages is proto3 JSON and
+// omits zero-valued fields, so the spent window carries "used" and no
+// "remaining" at all.
+const kimiExhaustedUsagePayload = `{
+	"user": {"userId": "u-1", "region": "REGION_OVERSEA", "membership": {"level": "LEVEL_BASIC"}},
+	"limited": true,
+	"usage": {"limit": "100", "used": "23", "remaining": "77", "resetTime": "2026-08-09T12:10:02.008931Z"},
+	"limits": [{"window": {"duration": 300, "timeUnit": "TIME_UNIT_MINUTE"}, "detail": {"limit": "100", "used": "100", "resetTime": "2026-08-07T01:10:02.008931Z"}}],
+	"parallel": {"limit": "10"},
+	"totalQuota": {},
+	"subType": "TYPE_PURCHASE"
+}`
+
+// TestGetKimiCodeQuota_UsedSurvivesRoundTrip pins the passthrough the stored
+// quota snapshot depends on: the snapshot is a re-marshal of this struct, so a
+// field the struct does not model is dropped before the dashboards ever see it.
+// "used" is the only evidence of consumption an exhausted window carries.
+func TestGetKimiCodeQuota_UsedSurvivesRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	masterKey := "test-master-key-1234567890123456"
+	apiKey := "test-api-key"
+	kp, err := auth.Encrypt(apiKey, masterKey)
+	assert.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(kimiExhaustedUsagePayload))
+	}))
+	defer server.Close()
+
+	provider := &Provider{
+		ID:           uuid.New(),
+		Name:         "test-kimi-code",
+		BaseURL:      server.URL,
+		EncryptedKey: kp.Ciphertext,
+		KeyNonce:     kp.Nonce,
+		KeySalt:      kp.Salt,
+	}
+	svc := &DiscoveryService{httpClient: server.Client()}
+
+	quota, err := svc.GetKimiCodeQuota(context.Background(), provider, masterKey)
+	assert.NoError(t, err)
+	if assert.NotNil(t, quota) && assert.Len(t, quota.Limits, 1) {
+		assert.Equal(t, "100", quota.Limits[0].Detail.Used)
+		assert.Empty(t, quota.Limits[0].Detail.Remaining)
+	}
+	assert.Equal(t, "23", quota.Usage.Used)
+
+	stored, err := json.Marshal(quota)
+	assert.NoError(t, err)
+	var reread KimiCodeQuotaResponse
+	assert.NoError(t, json.Unmarshal(stored, &reread))
+	if assert.Len(t, reread.Limits, 1) {
+		assert.Equal(t, "100", reread.Limits[0].Detail.Used)
+	}
 }
 
 // TestDiscoverModels_KimiCodeDispatch exercises the kimi-code arm of the

--- a/internal/provider/discovery_types.go
+++ b/internal/provider/discovery_types.go
@@ -291,10 +291,15 @@ type ZAICodingQuotaResponse struct {
 	Success bool               `json:"success"`
 }
 
-// KimiCodeQuotaDetail is one limit/remaining/reset block in the Kimi Code
-// /usages response. Numeric fields arrive as JSON strings.
+// KimiCodeQuotaDetail is one limit/used/remaining/reset block in the Kimi Code
+// /usages response. Numeric fields arrive as JSON strings, and the response is
+// proto3 JSON: zero-valued fields are omitted, so a spent block carries only
+// used and a fresh one carries only remaining. Both are modelled because the
+// stored quota snapshot is a re-marshal of this struct and consumers need
+// whichever one the payload actually carried.
 type KimiCodeQuotaDetail struct {
 	Limit     string `json:"limit"`
+	Used      string `json:"used"`
 	Remaining string `json:"remaining"`
 	ResetTime string `json:"resetTime"`
 }

--- a/internal/provider/discovery_types.go
+++ b/internal/provider/discovery_types.go
@@ -325,8 +325,9 @@ type KimiCodeQuotaUser struct {
 	} `json:"membership"`
 }
 
-// KimiCodeQuotaResponse is the Kimi Code /usages payload, passed through to
-// the dashboard as-is.
+// KimiCodeQuotaResponse is the Kimi Code /usages payload. The stored snapshot is
+// a re-marshal of this struct, so only the fields modelled here reach the
+// dashboard and anything Kimi adds outside them is dropped.
 type KimiCodeQuotaResponse struct {
 	User     KimiCodeQuotaUser    `json:"user"`
 	Usage    KimiCodeQuotaDetail  `json:"usage"`

--- a/internal/quota/normalize.go
+++ b/internal/quota/normalize.go
@@ -199,19 +199,47 @@ func assessKimiCode(payload json.RawMessage) Assessment {
 		return Assessment{}
 	}
 	var e earliestReset
+	// The top-level usage block is the subscription cycle counter and carries
+	// its own reset. Spending it blocks the account just as a spent rolling
+	// window does, so it is judged by the same rule.
+	addKimiWindow(&e, res.Usage)
 	for _, l := range res.Limits {
-		// Kimi encodes limit/remaining as JSON strings. A value we cannot parse
-		// is never treated as exhausted: guessing here would pin a healthy
-		// provider, which the behaviour contract forbids.
-		remaining, err := strconv.ParseInt(strings.TrimSpace(l.Detail.Remaining), 10, 64)
-		if err != nil || remaining > 0 {
-			continue
-		}
-		if t, ok := parseResetString(l.Detail.ResetTime); ok {
-			e.add(t)
-		}
+		addKimiWindow(&e, l.Detail)
 	}
 	return e.result(time.Now())
+}
+
+// kimiRemaining reports how much of a Kimi window is left. Kimi's /usages is
+// proto3 JSON and omits zero-valued fields, so a spent window carries used and
+// no remaining while a fresh one carries remaining and no used. An explicit
+// remaining decides; otherwise limit minus used does, but only when both parse.
+// A window we cannot read either way reports not-ok and is never treated as
+// exhausted: guessing here would pin a healthy provider, which the behaviour
+// contract forbids.
+func kimiRemaining(d provider.KimiCodeQuotaDetail) (int64, bool) {
+	if remaining, err := strconv.ParseInt(strings.TrimSpace(d.Remaining), 10, 64); err == nil {
+		return remaining, true
+	}
+	limit, limitErr := strconv.ParseInt(strings.TrimSpace(d.Limit), 10, 64)
+	used, usedErr := strconv.ParseInt(strings.TrimSpace(d.Used), 10, 64)
+	if limitErr != nil || usedErr != nil {
+		return 0, false
+	}
+	if used >= limit {
+		return 0, true
+	}
+	return limit - used, true
+}
+
+// addKimiWindow records one Kimi quota block if it is spent.
+func addKimiWindow(e *earliestReset, d provider.KimiCodeQuotaDetail) {
+	remaining, ok := kimiRemaining(d)
+	if !ok || remaining > 0 {
+		return
+	}
+	if t, ok := parseResetString(d.ResetTime); ok {
+		e.add(t)
+	}
 }
 
 // minimaxModelRemain is the subset of a MiniMax model_remains entry the quota

--- a/internal/quota/normalize_test.go
+++ b/internal/quota/normalize_test.go
@@ -2,6 +2,7 @@ package quota
 
 import (
 	"encoding/json"
+	"fmt"
 	"strconv"
 	"strings"
 	"testing"
@@ -349,12 +350,11 @@ func TestAssess_Neuralwatt_PastPeriodEndIsNoPin(t *testing.T) {
 }
 
 // TestAssess_KimiCode_AbsentRemainingIsNotExhausted guards the same hole in the
-// Kimi parser. Kimi encodes remaining as a JSON string, so an absent key decodes
-// to "" and ParseInt rejects it — the parser is safe, but only because a string's
-// zero value happens to be unparseable rather than because absence is handled.
-// Pinning that behaviour here means a future switch to a numeric field (which is
-// exactly the kind of reshape the drift watch exists for) fails this test rather
-// than silently sidelining a healthy provider.
+// Kimi parser. A block that carries neither remaining nor used says nothing
+// about consumption, whatever its limit reads, so it must not pin. Pinning that
+// behaviour here means a future switch to a numeric field (which is exactly the
+// kind of reshape the drift watch exists for) fails this test rather than
+// silently sidelining a healthy provider.
 func TestAssess_KimiCode_AbsentRemainingIsNotExhausted(t *testing.T) {
 	payload, err := json.Marshal(map[string]any{
 		"limits": []map[string]any{{
@@ -544,6 +544,99 @@ func TestAssess_KimiCode_EpochStringResetTime(t *testing.T) {
 
 	if !got.Exhausted || got.ResetsAt.Unix() != reset {
 		t.Errorf("got Exhausted=%v ResetsAt=%d, want true/%d", got.Exhausted, got.ResetsAt.Unix(), reset)
+	}
+}
+
+// kimiEnvelope is the live Kimi Code /usages response (prod fetch 2026-08-07)
+// with the two blocks under test substituted in: the top-level cycle counter
+// and the rolling window's detail. Everything around them is the payload
+// verbatim, so a decode regression in the envelope surfaces here too.
+const kimiEnvelope = `{
+	"user": {"userId": "d9ebt1t22qd2lajpoiig", "region": "REGION_OVERSEA", "membership": {"level": "LEVEL_BASIC"}},
+	"limited": true,
+	"usage": %s,
+	"limits": [
+		{"window": {"duration": 300, "timeUnit": "TIME_UNIT_MINUTE"},
+		 "detail": %s}
+	],
+	"parallel": {"limit": "10"},
+	"totalQuota": {},
+	"subType": "TYPE_PURCHASE"
+}`
+
+// TestAssess_KimiCode_Proto3OmitsZeroValuedFields covers the shape Kimi
+// actually sends. /usages is proto3 JSON and drops zero-valued fields, so an
+// exhausted window carries used="100" and no remaining at all, while a fresh
+// window carries remaining and no used. Reading remaining alone therefore goes
+// blind at exactly the moment the pin exists for. Reset timestamps are relative
+// to now because a reset in the past never pins.
+func TestAssess_KimiCode_Proto3OmitsZeroValuedFields(t *testing.T) {
+	usageReset := time.Now().Add(48 * time.Hour).UTC().Format(time.RFC3339)
+	windowReset := time.Now().Add(90 * time.Minute).UTC().Format(time.RFC3339)
+	healthyUsage := fmt.Sprintf(`{"limit": "100", "used": "23", "remaining": "77", "resetTime": %q}`, usageReset)
+	healthyWindow := fmt.Sprintf(`{"limit": "100", "used": "23", "remaining": "77", "resetTime": %q}`, windowReset)
+
+	cases := []struct {
+		name          string
+		usage         string
+		detail        string
+		wantExhausted bool
+		wantReset     string
+	}{
+		{
+			name:          "spent window omits remaining and reports used",
+			usage:         healthyUsage,
+			detail:        fmt.Sprintf(`{"limit": "100", "used": "100", "resetTime": %q}`, windowReset),
+			wantExhausted: true,
+			wantReset:     windowReset,
+		},
+		{
+			name:   "healthy window reports remaining",
+			usage:  healthyUsage,
+			detail: healthyWindow,
+		},
+		{
+			name:   "untouched window omits used",
+			usage:  healthyUsage,
+			detail: fmt.Sprintf(`{"limit": "100", "remaining": "100", "resetTime": %q}`, windowReset),
+		},
+		{
+			name:   "neither remaining nor used parses",
+			usage:  healthyUsage,
+			detail: fmt.Sprintf(`{"limit": "100", "remaining": "", "used": "", "resetTime": %q}`, windowReset),
+		},
+		{
+			name:          "spent cycle counter pins while the window is healthy",
+			usage:         fmt.Sprintf(`{"limit": "100", "used": "100", "resetTime": %q}`, usageReset),
+			detail:        healthyWindow,
+			wantExhausted: true,
+			wantReset:     usageReset,
+		},
+		{
+			name:   "explicit remaining wins over the used derivation",
+			usage:  healthyUsage,
+			detail: fmt.Sprintf(`{"limit": "100", "used": "100", "remaining": "5", "resetTime": %q}`, windowReset),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			payload := fmt.Sprintf(kimiEnvelope, tc.usage, tc.detail)
+
+			got := Assess("kimi-code", Snapshot{Kind: "usage", Payload: json.RawMessage(payload)})
+
+			if !got.OK {
+				t.Fatalf("a well-formed payload must assess OK, got %+v", got)
+			}
+			if got.Exhausted != tc.wantExhausted {
+				t.Fatalf("got Exhausted=%v, want %v", got.Exhausted, tc.wantExhausted)
+			}
+			if !tc.wantExhausted {
+				return
+			}
+			if got.ResetsAt.Format(time.RFC3339) != tc.wantReset {
+				t.Errorf("got ResetsAt=%s, want %s", got.ResetsAt.Format(time.RFC3339), tc.wantReset)
+			}
+		})
 	}
 }
 

--- a/scripts/coverage/covlib.py
+++ b/scripts/coverage/covlib.py
@@ -1,4 +1,5 @@
 """Shared coverage parsing/exclusion helpers (stdlib only)."""
+import posixpath
 import re
 
 MODULE_PREFIX = "github.com/hugalafutro/model-hotel/"
@@ -138,7 +139,11 @@ def parse_lcov(text: str, root: str) -> dict:
     cur = None
     for line in text.splitlines():
         if line.startswith("SF:"):
-            rel = root + line[3:].strip()
+            # An app's report can name a file outside its own tree: web/'s suite
+            # covers web-shared/, which vitest records as `../web-shared/...`.
+            # Normalising folds that back onto the repo-relative path git reports,
+            # so those lines are matched rather than silently skipped.
+            rel = posixpath.normpath(root + line[3:].strip())
             cur = None if is_excluded(rel) else rel
         elif line.startswith("DA:") and cur is not None:
             ln, hits = line[3:].split(",", 1)

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -241,8 +241,10 @@ fi
 # Main-dashboard lint + typecheck, only when web/ changed. tsc -b runs here rather
 # than in the Docker image build, catching type errors before the push, and is
 # incremental (tsbuildinfo). Covers web/ only; frontdesk/web is not linted here.
-if ! touched '^web/'; then
-	echo "pre-push: no web/ changes, skipping pnpm lint + tsc -b"
+# web-shared/ counts as a web/ change: the dashboard imports it through the
+# @quota-shared alias, so its types are checked by web/'s tsc -b.
+if ! touched '^web/|^web-shared/'; then
+	echo "pre-push: no web/ or web-shared/ changes, skipping pnpm lint + tsc -b"
 elif [ -d "$REPO_ROOT/web/node_modules" ]; then
 	echo "pre-push: pnpm lint + tsc -b (local)..."
 	if ! (cd "$REPO_ROOT/web" && pnpm run lint && pnpm exec tsc -b); then
@@ -341,17 +343,21 @@ else
 		fi
 	fi
 
-	# web dashboard frontend.
-	if has_measurable_change '^web/src/.*\.tsx?$' '\.test\.tsx?$|/__tests__/|^web/src/test/'; then
-		if run_vitest_coverage web '^web/src/.*\.tsx?$'; then
+	# web dashboard frontend. web/ owns web-shared/ for coverage (its vitest
+	# config instruments it), so shared files are measured and gated here.
+	if has_measurable_change '^web/src/.*\.tsx?$|^web-shared/.*\.ts$' '\.test\.tsx?$|/__tests__/|^web/src/test/'; then
+		if run_vitest_coverage web '^web/src/.*\.tsx?$|^web-shared/.*\.ts$'; then
 			DC_ARGS+=(--lcov "web/=$REPO_ROOT/web/coverage/lcov.info")
 		else
 			exit 1
 		fi
 	fi
 
-	# Front Desk frontend.
-	if has_measurable_change '^frontdesk/web/src/.*\.tsx?$' '\.test\.tsx?$|/__tests__/|^frontdesk/web/src/test/'; then
+	# Front Desk frontend. A web-shared/ change runs this suite too - Front Desk
+	# imports the same modules through @quota-shared - but the scoping regex stays
+	# frontdesk-only: those lines are measured by web/'s report, and asking for
+	# them here would fail the instrumentation guard on every push.
+	if has_measurable_change '^frontdesk/web/src/.*\.tsx?$|^web-shared/.*\.ts$' '\.test\.tsx?$|/__tests__/|^frontdesk/web/src/test/'; then
 		if run_vitest_coverage frontdesk/web '^frontdesk/web/src/.*\.tsx?$'; then
 			DC_ARGS+=(--lcov "frontdesk/web/=$REPO_ROOT/frontdesk/web/coverage/lcov.info")
 		else

--- a/testdata/quota-contract/kimi/clamped.json
+++ b/testdata/quota-contract/kimi/clamped.json
@@ -1,0 +1,24 @@
+{
+	"payload": {
+		"usage": {
+			"limit": "100",
+			"remaining": "150",
+			"resetTime": "2026-08-09T12:10:02.008931Z"
+		},
+		"limits": [
+			{
+				"window": { "duration": 300, "timeUnit": "TIME_UNIT_MINUTE" },
+				"detail": {
+					"limit": "100",
+					"used": "150",
+					"resetTime": "2026-08-07T01:10:02.008931Z"
+				}
+			}
+		],
+		"parallel": { "limit": "10" }
+	},
+	"expected": {
+		"fiveHourUsedPercent": 100,
+		"weeklyUsedPercent": 0
+	}
+}

--- a/testdata/quota-contract/kimi/exhausted-empty-strings.json
+++ b/testdata/quota-contract/kimi/exhausted-empty-strings.json
@@ -1,0 +1,27 @@
+{
+	"payload": {
+		"usage": {
+			"limit": "100",
+			"used": "23",
+			"remaining": "77",
+			"resetTime": "2026-08-09T12:10:02.008931Z"
+		},
+		"limits": [
+			{
+				"window": { "duration": 300, "timeUnit": "TIME_UNIT_MINUTE" },
+				"detail": {
+					"limit": "100",
+					"used": "100",
+					"remaining": "",
+					"resetTime": "2026-08-07T01:10:02.008931Z"
+				}
+			}
+		],
+		"parallel": { "limit": "10" },
+		"totalQuota": {}
+	},
+	"expected": {
+		"fiveHourUsedPercent": 100,
+		"weeklyUsedPercent": 23
+	}
+}

--- a/testdata/quota-contract/kimi/exhausted.json
+++ b/testdata/quota-contract/kimi/exhausted.json
@@ -1,0 +1,33 @@
+{
+	"payload": {
+		"user": {
+			"userId": "d9ebt1t22qd2lajpoiig",
+			"region": "REGION_OVERSEA",
+			"membership": { "level": "LEVEL_BASIC" }
+		},
+		"limited": true,
+		"usage": {
+			"limit": "100",
+			"used": "23",
+			"remaining": "77",
+			"resetTime": "2026-08-09T12:10:02.008931Z"
+		},
+		"limits": [
+			{
+				"window": { "duration": 300, "timeUnit": "TIME_UNIT_MINUTE" },
+				"detail": {
+					"limit": "100",
+					"used": "100",
+					"resetTime": "2026-08-07T01:10:02.008931Z"
+				}
+			}
+		],
+		"parallel": { "limit": "10" },
+		"totalQuota": {},
+		"subType": "TYPE_PURCHASE"
+	},
+	"expected": {
+		"fiveHourUsedPercent": 100,
+		"weeklyUsedPercent": 23
+	}
+}

--- a/testdata/quota-contract/kimi/healthy.json
+++ b/testdata/quota-contract/kimi/healthy.json
@@ -1,0 +1,27 @@
+{
+	"payload": {
+		"user": { "membership": { "level": "LEVEL_BASIC" } },
+		"usage": {
+			"limit": "100",
+			"used": "23",
+			"remaining": "77",
+			"resetTime": "2026-08-09T12:10:02.008931Z"
+		},
+		"limits": [
+			{
+				"window": { "duration": 300, "timeUnit": "TIME_UNIT_MINUTE" },
+				"detail": {
+					"limit": "100",
+					"used": "40",
+					"remaining": "60",
+					"resetTime": "2026-08-07T01:10:02.008931Z"
+				}
+			}
+		],
+		"parallel": { "limit": "10" }
+	},
+	"expected": {
+		"fiveHourUsedPercent": 40,
+		"weeklyUsedPercent": 23
+	}
+}

--- a/testdata/quota-contract/kimi/omitted-fields.json
+++ b/testdata/quota-contract/kimi/omitted-fields.json
@@ -1,0 +1,24 @@
+{
+	"payload": {
+		"usage": {
+			"limit": "1000",
+			"used": "",
+			"remaining": "",
+			"resetTime": "2026-08-09T12:10:02.008931Z"
+		},
+		"limits": [
+			{
+				"window": { "duration": 300, "timeUnit": "TIME_UNIT_MINUTE" },
+				"detail": {
+					"limit": "100",
+					"resetTime": "2026-08-07T01:10:02.008931Z"
+				}
+			}
+		],
+		"parallel": { "limit": "10" }
+	},
+	"expected": {
+		"fiveHourUsedPercent": 0,
+		"weeklyUsedPercent": 0
+	}
+}

--- a/testdata/quota-contract/kimi/preburst.json
+++ b/testdata/quota-contract/kimi/preburst.json
@@ -1,0 +1,25 @@
+{
+	"payload": {
+		"usage": {
+			"limit": "1000",
+			"remaining": "1000",
+			"resetTime": "2026-08-09T12:10:02.008931Z"
+		},
+		"limits": [
+			{
+				"window": { "duration": 300, "timeUnit": "TIME_UNIT_MINUTE" },
+				"detail": {
+					"limit": "100",
+					"used": "",
+					"remaining": "100",
+					"resetTime": "2026-08-07T01:10:02.008931Z"
+				}
+			}
+		],
+		"parallel": { "limit": "10" }
+	},
+	"expected": {
+		"fiveHourUsedPercent": 0,
+		"weeklyUsedPercent": 0
+	}
+}

--- a/testdata/quota-contract/kimi/remaining-wins.json
+++ b/testdata/quota-contract/kimi/remaining-wins.json
@@ -1,0 +1,26 @@
+{
+	"payload": {
+		"usage": {
+			"limit": "100",
+			"used": "5",
+			"remaining": "45",
+			"resetTime": "2026-08-09T12:10:02.008931Z"
+		},
+		"limits": [
+			{
+				"window": { "duration": 300, "timeUnit": "TIME_UNIT_MINUTE" },
+				"detail": {
+					"limit": "100",
+					"used": "10",
+					"remaining": "70",
+					"resetTime": "2026-08-07T01:10:02.008931Z"
+				}
+			}
+		],
+		"parallel": { "limit": "10" }
+	},
+	"expected": {
+		"fiveHourUsedPercent": 30,
+		"weeklyUsedPercent": 55
+	}
+}

--- a/web-shared/quota/index.ts
+++ b/web-shared/quota/index.ts
@@ -1,0 +1,52 @@
+// Quota payload parsing shared by the Model Hotel dashboard (web/) and Front
+// Desk (frontdesk/web/). Pure TypeScript: no React, no i18next, no imports from
+// either app. Presentation (pill prefixes, brand colours, modals, reset labels)
+// stays in the app that renders it.
+//
+// Both apps reach this module through the `@quota-shared` alias, wired in their
+// tsconfig `paths`, vite and vitest configs.
+
+export {
+	getKimiCodeFiveHourLimit,
+	getKimiCodeWeeklyLimit,
+	toKimiCodeWindow,
+} from "./kimi";
+export {
+	getMiniMaxFiveHourLimit,
+	getMiniMaxGeneralEntry,
+	getMiniMaxWeeklyLimit,
+} from "./minimax";
+export type {
+	DeepSeekBalanceLike,
+	KimiCodeQuotaLimitEntry,
+	KimiCodeQuotaResponse,
+	KimiCodeQuotaUsageWindow,
+	KimiCodeQuotaWindow,
+	KimiCodeQuotaWindowSpec,
+	MiniMaxBaseResp,
+	MiniMaxModelRemains,
+	MiniMaxQuotaResponse,
+	MiniMaxQuotaWindow,
+	NanoGptUsageLike,
+	NeuralWattQuotaLike,
+	OllamaCloudAccountLike,
+	OpenRouterBalanceLike,
+	QuotaProviderType,
+	ZaiCodingLimitLike,
+	ZaiCodingResponseLike,
+} from "./types";
+export {
+	isDeepSeekQuotaVisible,
+	isKimiCodeQuotaVisible,
+	isMiniMaxQuotaVisible,
+	isNanoGptQuotaVisible,
+	isNeuralWattQuotaVisible,
+	isOllamaCloudQuotaVisible,
+	isOpenRouterQuotaVisible,
+	isQuotaPayloadVisible,
+	isZaiCodingQuotaVisible,
+} from "./visibility";
+export {
+	getZaiCodingFiveHourLimit,
+	getZaiCodingWeeklyLimit,
+} from "./zai";

--- a/web-shared/quota/kimi.ts
+++ b/web-shared/quota/kimi.ts
@@ -1,0 +1,98 @@
+import type { KimiCodeQuotaResponse, KimiCodeQuotaWindow } from "./types";
+
+/**
+ * A Kimi string-encoded number, or undefined when the field carries no value.
+ *
+ * Absent, "" and whitespace are one case: proto3 omits a zero-valued field and
+ * the Go snapshot re-marshal writes "" for the omission. Both come back as
+ * undefined here, and what the omission means is the caller's to decide, field
+ * by field.
+ */
+function parseKimiNumber(v: string | undefined): number | undefined {
+	if (v == null) return undefined;
+	const trimmed = v.trim();
+	if (trimmed === "") return undefined;
+	const n = Number(trimmed);
+	return Number.isFinite(n) ? n : undefined;
+}
+
+/** True when the field was omitted, which for Kimi means the value is zero. */
+function isOmitted(v: string | undefined): boolean {
+	return v == null || v.trim() === "";
+}
+
+/**
+ * How many units of the window are still available.
+ *
+ * `remaining` wins when it carries a value. Otherwise the window is exhausted
+ * enough for Kimi to have dropped `remaining`, and `used` carries the count, so
+ * remaining is limit minus used. An omitted `used` means zero used, hence the
+ * full limit. A `used` that is present but unreadable yields undefined: an
+ * unparseable window must not be turned into a number, ever.
+ */
+function resolveRemaining(
+	limit: number,
+	remainingStr: string | undefined,
+	usedStr: string | undefined,
+): number | undefined {
+	const remaining = parseKimiNumber(remainingStr);
+	if (remaining !== undefined) return remaining;
+
+	const used = parseKimiNumber(usedStr);
+	if (used !== undefined) return Math.max(0, limit - used);
+
+	return isOmitted(usedStr) ? limit : undefined;
+}
+
+/**
+ * Normalizes one Kimi window. Returns undefined when the limit is unreadable or
+ * the remaining count cannot be established, so callers render a "-" rather
+ * than a guess.
+ */
+export function toKimiCodeWindow(
+	limitStr: string | undefined,
+	remainingStr: string | undefined,
+	usedStr: string | undefined,
+	resetTime: string | undefined,
+): KimiCodeQuotaWindow | undefined {
+	const limit = parseKimiNumber(limitStr);
+	if (limit === undefined) return undefined;
+
+	const remaining = resolveRemaining(limit, remainingStr, usedStr);
+	if (remaining === undefined) return undefined;
+
+	const raw = limit > 0 ? ((limit - remaining) / limit) * 100 : 0;
+	const percentage = Math.min(100, Math.max(0, raw));
+	return { limit, remaining, resetTime: resetTime ?? "", percentage };
+}
+
+/** The rolling 300-minute (5-hour) window. */
+export function getKimiCodeFiveHourLimit(
+	data: KimiCodeQuotaResponse | undefined | null,
+): KimiCodeQuotaWindow | undefined {
+	const entry = data?.limits?.find(
+		(l) =>
+			l.window?.timeUnit === "TIME_UNIT_MINUTE" && l.window?.duration === 300,
+	);
+	if (!entry) return undefined;
+	return toKimiCodeWindow(
+		entry.detail?.limit,
+		entry.detail?.remaining,
+		entry.detail?.used,
+		entry.detail?.resetTime,
+	);
+}
+
+/** The weekly window, carried in the top-level `usage` block. */
+export function getKimiCodeWeeklyLimit(
+	data: KimiCodeQuotaResponse | undefined | null,
+): KimiCodeQuotaWindow | undefined {
+	const usage = data?.usage;
+	if (!usage) return undefined;
+	return toKimiCodeWindow(
+		usage.limit,
+		usage.remaining,
+		usage.used,
+		usage.resetTime,
+	);
+}

--- a/web-shared/quota/minimax.ts
+++ b/web-shared/quota/minimax.ts
@@ -1,0 +1,57 @@
+import type {
+	MiniMaxModelRemains,
+	MiniMaxQuotaResponse,
+	MiniMaxQuotaWindow,
+} from "./types";
+
+// MiniMax reports REMAINING percentages per model class. The active class is the
+// first "general" entry with current_interval_status === 1. Used = 100 minus
+// remaining. A non-zero base_resp.status_code (2062 "no active token plan", for
+// example) means there is nothing to show.
+
+/** First active "general" model-class entry, or undefined. */
+export function getMiniMaxGeneralEntry(
+	data: MiniMaxQuotaResponse | undefined | null,
+): MiniMaxModelRemains | undefined {
+	const entries =
+		data?.base_resp?.status_code === 0 ? data.model_remains : null;
+	if (!Array.isArray(entries)) return undefined;
+	return entries.find(
+		(m) => m.model_name === "general" && m.current_interval_status === 1,
+	);
+}
+
+function toMiniMaxWindow(
+	remainingPercent: number | undefined,
+	resetMs: number | undefined,
+): MiniMaxQuotaWindow | undefined {
+	if (remainingPercent == null || !Number.isFinite(remainingPercent)) {
+		return undefined;
+	}
+	return {
+		percentage: 100 - remainingPercent,
+		remainingPercent,
+		resetMs: resetMs ?? 0,
+	};
+}
+
+/** Rolling 5-hour window derived from the active general entry. */
+export function getMiniMaxFiveHourLimit(
+	data: MiniMaxQuotaResponse | undefined | null,
+): MiniMaxQuotaWindow | undefined {
+	const g = getMiniMaxGeneralEntry(data);
+	if (!g) return undefined;
+	return toMiniMaxWindow(g.current_interval_remaining_percent, g.remains_time);
+}
+
+/** Weekly window derived from the active general entry. */
+export function getMiniMaxWeeklyLimit(
+	data: MiniMaxQuotaResponse | undefined | null,
+): MiniMaxQuotaWindow | undefined {
+	const g = getMiniMaxGeneralEntry(data);
+	if (!g) return undefined;
+	return toMiniMaxWindow(
+		g.current_weekly_remaining_percent,
+		g.weekly_remains_time,
+	);
+}

--- a/web-shared/quota/types.ts
+++ b/web-shared/quota/types.ts
@@ -1,0 +1,150 @@
+// Payload and derived-window types for the provider quota endpoints.
+//
+// These declarations are the ones both frontends agree on. Where an app models
+// more of a payload than the helpers here read (the dashboard's fuller Z.ai
+// limit, for instance), the app keeps its own declaration and the helper takes a
+// structural view of it, so neither app has to widen or narrow the other.
+
+/** Provider families that expose a quota or balance endpoint. */
+export type QuotaProviderType =
+	| "nanogpt"
+	| "zai-coding"
+	| "kimi-code"
+	| "minimax"
+	| "deepseek"
+	| "openrouter"
+	| "ollama-cloud"
+	| "neuralwatt";
+
+// ── Kimi Code ────────────────────────────────────────────────────────────
+// Kimi's /usages body is proto3 JSON: numbers are string-encoded and a
+// zero-valued field is omitted entirely. The stored snapshot round-trips
+// through a Go struct, which materializes an omitted string as "", so absent
+// and "" are the same case everywhere below: the field is zero.
+
+/** One quota window as Kimi reports it. Every field is string-encoded. */
+export interface KimiCodeQuotaUsageWindow {
+	limit?: string;
+	remaining?: string;
+	used?: string;
+	resetTime?: string;
+}
+
+export interface KimiCodeQuotaWindowSpec {
+	duration?: number;
+	timeUnit?: string;
+}
+
+export interface KimiCodeQuotaLimitEntry {
+	window?: KimiCodeQuotaWindowSpec;
+	detail?: KimiCodeQuotaUsageWindow;
+}
+
+export interface KimiCodeQuotaResponse {
+	user?: {
+		userId?: string;
+		region?: string;
+		membership?: { level?: string };
+	};
+	/** Weekly window. */
+	usage?: KimiCodeQuotaUsageWindow;
+	/** Rolling windows; the 300-minute entry is the 5-hour window. */
+	limits?: KimiCodeQuotaLimitEntry[];
+	parallel?: { limit?: string };
+	totalQuota?: { limit?: string; remaining?: string };
+	authentication?: { method?: string; scope?: string };
+	subType?: string;
+}
+
+/**
+ * Normalized Kimi window. `percentage` is percent USED, clamped to [0, 100], so
+ * badge and modal code stays uniform across providers.
+ */
+export interface KimiCodeQuotaWindow {
+	limit: number;
+	remaining: number;
+	resetTime: string;
+	percentage: number;
+}
+
+// ── Z.ai Coding ──────────────────────────────────────────────────────────
+// Both apps model the limit entry with different depth, so the extractors are
+// generic over it: they select by `type`/`unit` and hand the caller's own entry
+// back untouched.
+
+/** The two fields the Z.ai window selectors read. */
+export interface ZaiCodingLimitLike {
+	type?: string;
+	unit?: number;
+}
+
+export interface ZaiCodingResponseLike<
+	L extends ZaiCodingLimitLike = ZaiCodingLimitLike,
+> {
+	success?: boolean;
+	data?: { limits?: L[] } | null;
+}
+
+// ── MiniMax ──────────────────────────────────────────────────────────────
+// MiniMax reports REMAINING percentages (0-100) per model class.
+
+export interface MiniMaxModelRemains {
+	model_name: string;
+	start_time?: number;
+	end_time?: number;
+	remains_time: number;
+	weekly_start_time?: number;
+	weekly_end_time?: number;
+	weekly_remains_time: number;
+	current_interval_status: number;
+	current_interval_remaining_percent: number;
+	current_weekly_status: number;
+	current_weekly_remaining_percent: number;
+}
+
+export interface MiniMaxBaseResp {
+	status_code: number;
+	status_msg: string;
+}
+
+export interface MiniMaxQuotaResponse {
+	model_remains: MiniMaxModelRemains[] | null;
+	base_resp: MiniMaxBaseResp;
+}
+
+/**
+ * Normalized MiniMax window. `percentage` is the USED percentage (100 minus
+ * remaining); `resetMs` is the millisecond duration until the window resets.
+ */
+export interface MiniMaxQuotaWindow {
+	percentage: number;
+	remainingPercent: number;
+	resetMs: number;
+}
+
+// ── Structural views for the balance-style providers ─────────────────────
+// These providers have no window math, only a visibility rule, so the shared
+// module reads just the fields that rule needs.
+
+export interface NanoGptUsageLike {
+	providerStatus?: string;
+	limits?: { weeklyInputTokens?: number | null } | null;
+	weeklyInputTokens?: { used?: number | null } | null;
+}
+
+export interface DeepSeekBalanceLike {
+	is_available?: boolean;
+}
+
+export interface OpenRouterBalanceLike {
+	credits_remaining?: number | null;
+}
+
+export interface OllamaCloudAccountLike {
+	suspended_at?: { valid?: boolean } | null;
+}
+
+export interface NeuralWattQuotaLike {
+	balance?: { credits_remaining_usd?: number | null } | null;
+	subscription?: { plan?: string } | null;
+}

--- a/web-shared/quota/visibility.ts
+++ b/web-shared/quota/visibility.ts
@@ -1,0 +1,95 @@
+import { getKimiCodeFiveHourLimit, getKimiCodeWeeklyLimit } from "./kimi";
+import { getMiniMaxGeneralEntry } from "./minimax";
+import type {
+	DeepSeekBalanceLike,
+	KimiCodeQuotaResponse,
+	MiniMaxQuotaResponse,
+	NanoGptUsageLike,
+	NeuralWattQuotaLike,
+	OllamaCloudAccountLike,
+	OpenRouterBalanceLike,
+	QuotaProviderType,
+	ZaiCodingResponseLike,
+} from "./types";
+import { getZaiCodingFiveHourLimit, getZaiCodingWeeklyLimit } from "./zai";
+
+// Whether a readable payload holds anything worth putting on a badge. Both
+// frontends gate on these, so the same fleet shows the same set of badges in
+// each. Whether the provider exists at all, and whether its fetch succeeded,
+// are the app's own questions and stay there.
+
+/** Subscription plans too low-tier to be worth a badge. */
+const NEURALWATT_EXCLUDED_PLANS = new Set(["free", "starter"]);
+
+export function isNanoGptQuotaVisible(u: NanoGptUsageLike): boolean {
+	const cancelled =
+		u.providerStatus === "canceled" || u.providerStatus === "cancelled";
+	return (
+		!cancelled &&
+		u.weeklyInputTokens?.used != null &&
+		Boolean(u.limits?.weeklyInputTokens)
+	);
+}
+
+export function isZaiCodingQuotaVisible(u: ZaiCodingResponseLike): boolean {
+	return (
+		u.success === true &&
+		Boolean(getZaiCodingFiveHourLimit(u) || getZaiCodingWeeklyLimit(u))
+	);
+}
+
+export function isKimiCodeQuotaVisible(u: KimiCodeQuotaResponse): boolean {
+	return Boolean(getKimiCodeFiveHourLimit(u) || getKimiCodeWeeklyLimit(u));
+}
+
+export function isMiniMaxQuotaVisible(u: MiniMaxQuotaResponse): boolean {
+	return Boolean(getMiniMaxGeneralEntry(u));
+}
+
+export function isDeepSeekQuotaVisible(b: DeepSeekBalanceLike): boolean {
+	return b.is_available === true;
+}
+
+export function isOpenRouterQuotaVisible(b: OpenRouterBalanceLike): boolean {
+	return b.credits_remaining != null;
+}
+
+export function isOllamaCloudQuotaVisible(a: OllamaCloudAccountLike): boolean {
+	return a.suspended_at?.valid !== true;
+}
+
+export function isNeuralWattQuotaVisible(q: NeuralWattQuotaLike): boolean {
+	return (
+		q.balance?.credits_remaining_usd != null &&
+		!NEURALWATT_EXCLUDED_PLANS.has(q.subscription?.plan?.toLowerCase() ?? "")
+	);
+}
+
+/**
+ * Visibility for a payload whose provider type is known only as a value, which
+ * is how Front Desk receives it: the fleet primary stamps the type on every
+ * snapshot rather than the SPA sniffing a base URL.
+ */
+export function isQuotaPayloadVisible(
+	type: QuotaProviderType,
+	payload: object,
+): boolean {
+	switch (type) {
+		case "nanogpt":
+			return isNanoGptQuotaVisible(payload as NanoGptUsageLike);
+		case "zai-coding":
+			return isZaiCodingQuotaVisible(payload as ZaiCodingResponseLike);
+		case "kimi-code":
+			return isKimiCodeQuotaVisible(payload as KimiCodeQuotaResponse);
+		case "minimax":
+			return isMiniMaxQuotaVisible(payload as MiniMaxQuotaResponse);
+		case "deepseek":
+			return isDeepSeekQuotaVisible(payload as DeepSeekBalanceLike);
+		case "openrouter":
+			return isOpenRouterQuotaVisible(payload as OpenRouterBalanceLike);
+		case "ollama-cloud":
+			return isOllamaCloudQuotaVisible(payload as OllamaCloudAccountLike);
+		case "neuralwatt":
+			return isNeuralWattQuotaVisible(payload as NeuralWattQuotaLike);
+	}
+}

--- a/web-shared/quota/zai.ts
+++ b/web-shared/quota/zai.ts
@@ -1,0 +1,22 @@
+import type { ZaiCodingLimitLike, ZaiCodingResponseLike } from "./types";
+
+// Z.ai reports one entry per window in `data.limits`, keyed by `type` plus a
+// `unit` code: 3 is the rolling 5-hour window, 6 the weekly one. The entry is
+// returned as the caller declared it, so an app that models more of the payload
+// keeps its own fields.
+
+export function getZaiCodingFiveHourLimit<L extends ZaiCodingLimitLike>(
+	data: ZaiCodingResponseLike<L> | undefined | null,
+): L | undefined {
+	return data?.data?.limits?.find(
+		(l) => l.type === "TOKENS_LIMIT" && l.unit === 3,
+	);
+}
+
+export function getZaiCodingWeeklyLimit<L extends ZaiCodingLimitLike>(
+	data: ZaiCodingResponseLike<L> | undefined | null,
+): L | undefined {
+	return data?.data?.limits?.find(
+		(l) => l.type === "TOKENS_LIMIT" && l.unit === 6,
+	);
+}

--- a/web/package.json
+++ b/web/package.json
@@ -10,7 +10,7 @@
 		"build:docker": "vite build",
 		"typecheck:tests": "tsc --noEmit -p tsconfig.test.json",
 		"lint": "eslint --no-warn-ignored ${@:-.}",
-		"format": "biome check",
+		"format": "biome check . ../web-shared",
 		"format:fix": "biome check --write",
 		"preview": "vite preview",
 		"test": "NODE_OPTIONS='--disable-warning=ExperimentalWarning --disable-warning=DEP0205' vitest run",

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -665,101 +665,22 @@ export interface ZAICodingQuotaResponse {
 	success: boolean;
 }
 
-// ── Kimi Code quota ────────────────────────────────────────────────────
-// Numeric fields arrive as JSON strings; parse with Number() before math.
+// ── Kimi Code + MiniMax quota ───────────────────────────────────
+// Declared in web-shared/quota, which both this dashboard and Front Desk parse
+// these payloads with, and re-exported here so app code keeps importing every
+// API type from one place.
 
-export interface KimiCodeQuotaMembership {
-	level?: string;
-}
-
-export interface KimiCodeQuotaUser {
-	userId?: string;
-	region?: string;
-	membership?: KimiCodeQuotaMembership;
-}
-
-/** A quota window: limit/remaining are string-encoded numbers, resetTime an ISO timestamp. */
-export interface KimiCodeQuotaUsageWindow {
-	limit: string;
-	remaining: string;
-	resetTime: string;
-}
-
-export interface KimiCodeQuotaWindowSpec {
-	duration: number;
-	timeUnit: string;
-}
-
-export interface KimiCodeQuotaLimitEntry {
-	window: KimiCodeQuotaWindowSpec;
-	detail: KimiCodeQuotaUsageWindow;
-}
-
-export interface KimiCodeQuotaResponse {
-	user?: KimiCodeQuotaUser;
-	/** Weekly window. */
-	usage?: KimiCodeQuotaUsageWindow;
-	/** Rolling windows; the 300-minute entry is the 5-hour window. */
-	limits?: KimiCodeQuotaLimitEntry[];
-	parallel?: { limit?: string };
-	totalQuota?: { limit?: string; remaining?: string };
-	authentication?: { method?: string; scope?: string };
-	subType?: string;
-}
-
-/**
- * Normalized quota window returned by the Kimi limit helpers. Mirrors the shape
- * the Z.ai helpers return (an object exposing `percentage`) so badge code stays
- * uniform across providers.
- */
-export interface KimiCodeQuotaWindow {
-	limit: number;
-	remaining: number;
-	resetTime: string;
-	percentage: number;
-}
-
-/**
- * MiniMax token-plan quota. Raw `/token_plan/remains` payload: one entry per
- * model class ("general", "video"). Percentages are already 0-100 numbers
- * (REMAINING, not used); `remains_time`/`weekly_remains_time` are millisecond
- * durations until the 5-hour / weekly window resets. `current_interval_status`
- * / `current_weekly_status` of 3 means the class is not in the active plan.
- */
-export interface MiniMaxModelRemains {
-	model_name: string;
-	start_time?: number;
-	end_time?: number;
-	remains_time: number;
-	weekly_start_time?: number;
-	weekly_end_time?: number;
-	weekly_remains_time: number;
-	current_interval_status: number;
-	current_interval_remaining_percent: number;
-	current_weekly_status: number;
-	current_weekly_remaining_percent: number;
-}
-
-export interface MiniMaxBaseResp {
-	status_code: number;
-	status_msg: string;
-}
-
-export interface MiniMaxQuotaResponse {
-	model_remains: MiniMaxModelRemains[] | null;
-	base_resp: MiniMaxBaseResp;
-}
-
-/**
- * Normalized MiniMax quota window returned by the helpers. `percentage` is the
- * USED percentage (100 − remaining) so badge/modal code stays uniform with the
- * other providers; `resetMs` is the millisecond duration until reset.
- */
-export interface MiniMaxQuotaWindow {
-	percentage: number;
-	remainingPercent: number;
-	resetMs: number;
-}
+export type {
+	KimiCodeQuotaLimitEntry,
+	KimiCodeQuotaResponse,
+	KimiCodeQuotaUsageWindow,
+	KimiCodeQuotaWindow,
+	KimiCodeQuotaWindowSpec,
+	MiniMaxBaseResp,
+	MiniMaxModelRemains,
+	MiniMaxQuotaResponse,
+	MiniMaxQuotaWindow,
+} from "@quota-shared";
 
 export interface NeuralWattQuotaBalance {
 	credits_remaining_usd: number;

--- a/web/src/hooks/__tests__/quotaContract.test.ts
+++ b/web/src/hooks/__tests__/quotaContract.test.ts
@@ -1,0 +1,47 @@
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import type { KimiCodeQuotaResponse } from "../../api/types";
+import {
+	getKimiCodeFiveHourLimit,
+	getKimiCodeWeeklyLimit,
+} from "../useQuotaData";
+
+// Cross-platform contract fixtures. The same files back the Front Desk suite and
+// the Bellhop unit tests, so every app that renders a stored Kimi snapshot
+// derives the same numbers from it.
+const FIXTURE_DIR = path.resolve(
+	path.dirname(fileURLToPath(import.meta.url)),
+	"../../../../testdata/quota-contract/kimi",
+);
+
+interface KimiContractFixture {
+	payload: KimiCodeQuotaResponse;
+	expected: { fiveHourUsedPercent: number; weeklyUsedPercent: number };
+}
+
+const fixtureFiles = readdirSync(FIXTURE_DIR)
+	.filter((f) => f.endsWith(".json"))
+	.sort();
+
+describe("Kimi Code quota contract fixtures", () => {
+	it("reads the shared fixture directory", () => {
+		expect(fixtureFiles.length).toBeGreaterThanOrEqual(3);
+	});
+
+	it.each(fixtureFiles)("%s yields the expected percentages", (file) => {
+		const fixture = JSON.parse(
+			readFileSync(path.join(FIXTURE_DIR, file), "utf8"),
+		) as KimiContractFixture;
+
+		expect(getKimiCodeFiveHourLimit(fixture.payload)?.percentage).toBeCloseTo(
+			fixture.expected.fiveHourUsedPercent,
+			10,
+		);
+		expect(getKimiCodeWeeklyLimit(fixture.payload)?.percentage).toBeCloseTo(
+			fixture.expected.weeklyUsedPercent,
+			10,
+		);
+	});
+});

--- a/web/src/hooks/__tests__/useQuotaData.test.tsx
+++ b/web/src/hooks/__tests__/useQuotaData.test.tsx
@@ -974,6 +974,75 @@ describe("useQuotaData", () => {
 			expect(win?.percentage).toBe(0);
 		});
 
+		// Kimi omits a zero-valued field and the stored snapshot materializes the
+		// omission as "", so both spellings mean the value is zero rather than
+		// unknown. `used` carries the count once `remaining` disappears.
+		const detailWindow = (detail: Record<string, string>) => ({
+			window: { duration: 300, timeUnit: "TIME_UNIT_MINUTE" },
+			detail,
+		});
+
+		it("derives remaining from used when remaining is omitted", () => {
+			const win = getKimiCodeFiveHourLimit({
+				limits: [detailWindow({ limit: "100", used: "100" })],
+			} as never);
+			expect(win?.remaining).toBe(0);
+			expect(win?.percentage).toBe(100);
+		});
+
+		it("treats an empty remaining exactly like an omitted one", () => {
+			const win = getKimiCodeFiveHourLimit({
+				limits: [detailWindow({ limit: "100", remaining: "", used: "75" })],
+			} as never);
+			expect(win?.remaining).toBe(25);
+			expect(win?.percentage).toBe(75);
+		});
+
+		it("prefers a reported remaining over the used derivation", () => {
+			const win = getKimiCodeFiveHourLimit({
+				limits: [detailWindow({ limit: "100", remaining: "5", used: "100" })],
+			} as never);
+			expect(win?.remaining).toBe(5);
+			expect(win?.percentage).toBe(95);
+		});
+
+		it("reads an omitted used as zero used, leaving the whole limit", () => {
+			const win = getKimiCodeFiveHourLimit({
+				limits: [detailWindow({ limit: "100" })],
+			} as never);
+			expect(win?.remaining).toBe(100);
+			expect(win?.percentage).toBe(0);
+		});
+
+		it("skips a window whose used is present but unreadable", () => {
+			expect(
+				getKimiCodeFiveHourLimit({
+					limits: [detailWindow({ limit: "100", used: "lots" })],
+				} as never),
+			).toBeUndefined();
+		});
+
+		it("clamps the percentage to the 0-100 range", () => {
+			expect(
+				getKimiCodeFiveHourLimit({
+					limits: [detailWindow({ limit: "100", used: "150" })],
+				} as never)?.percentage,
+			).toBe(100);
+			expect(
+				getKimiCodeFiveHourLimit({
+					limits: [detailWindow({ limit: "100", remaining: "150" })],
+				} as never)?.percentage,
+			).toBe(0);
+		});
+
+		it("derives the weekly window from used as well", () => {
+			const win = getKimiCodeWeeklyLimit({
+				usage: { limit: "1000", used: "250" },
+			} as never);
+			expect(win?.remaining).toBe(750);
+			expect(win?.percentage).toBe(25);
+		});
+
 		it("returns the weekly window from top-level usage", () => {
 			const data = {
 				usage: { limit: "1000", remaining: "250", resetTime: "reset-weekly" },

--- a/web/src/hooks/__tests__/useQuotaData.test.tsx
+++ b/web/src/hooks/__tests__/useQuotaData.test.tsx
@@ -951,7 +951,7 @@ describe("useQuotaData", () => {
 			expect(getKimiCodeFiveHourLimit(data)).toBeUndefined();
 		});
 
-		it("returns undefined when the window detail is missing limit/remaining", () => {
+		it("returns undefined when the window detail has no limit to read", () => {
 			const data = {
 				limits: [window300(undefined, undefined)],
 			} as never;

--- a/web/src/hooks/useQuotaData.ts
+++ b/web/src/hooks/useQuotaData.ts
@@ -1,3 +1,20 @@
+import type { QuotaProviderType } from "@quota-shared";
+import {
+	getKimiCodeFiveHourLimit,
+	getKimiCodeWeeklyLimit,
+	getMiniMaxFiveHourLimit,
+	getMiniMaxWeeklyLimit,
+	getZaiCodingFiveHourLimit,
+	getZaiCodingWeeklyLimit,
+	isDeepSeekQuotaVisible,
+	isKimiCodeQuotaVisible,
+	isMiniMaxQuotaVisible,
+	isNanoGptQuotaVisible,
+	isNeuralWattQuotaVisible,
+	isOllamaCloudQuotaVisible,
+	isOpenRouterQuotaVisible,
+	isZaiCodingQuotaVisible,
+} from "@quota-shared";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
@@ -6,7 +23,6 @@ import type {
 	DeepSeekBalance,
 	KimiCodeQuotaResponse,
 	KimiCodeQuotaWindow,
-	MiniMaxModelRemains,
 	MiniMaxQuotaResponse,
 	MiniMaxQuotaWindow,
 	NanoGPTUsage,
@@ -18,12 +34,23 @@ import type {
 	ZAICodingQuotaResponse,
 } from "../api/types";
 
+// The payload parsing behind these helpers lives in web-shared/quota so Front
+// Desk derives identical numbers from identical payloads. Re-exported here
+// because app code has always reached them through this hook module.
+export type { QuotaProviderType } from "@quota-shared";
+export {
+	getKimiCodeFiveHourLimit,
+	getKimiCodeWeeklyLimit,
+	getMiniMaxFiveHourLimit,
+	getMiniMaxGeneralEntry,
+	getMiniMaxWeeklyLimit,
+	getZaiCodingFiveHourLimit,
+	getZaiCodingWeeklyLimit,
+} from "@quota-shared";
+
 // ── Cache helpers (shared across consumers) ──────────────────────────────
 
 const CACHE_PREFIX = "model-hotel";
-
-/** Subscription plans that don't qualify for quota badge display (lowest/free tier). */
-const NEURALWATT_BADGE_EXCLUDED_PLANS = new Set(["free", "starter"]);
 
 export function getCachedData<T>(key: string): T | undefined {
 	try {
@@ -44,16 +71,9 @@ export function setCachedData<T>(key: string, data: T) {
 }
 
 // ── Provider type detection ──────────────────────────────────────────────
-
-export type QuotaProviderType =
-	| "nanogpt"
-	| "zai-coding"
-	| "kimi-code"
-	| "minimax"
-	| "deepseek"
-	| "openrouter"
-	| "ollama-cloud"
-	| "neuralwatt";
+// The type union is the shared one; sniffing a base URL for it is the
+// dashboard's own job, because only it holds provider records. Front Desk reads
+// the type the fleet primary stamps on each snapshot instead.
 
 function hostnameMatches(url: string, suffix: string, exact?: string): boolean {
 	try {
@@ -86,126 +106,6 @@ function findProviderId(
 ): string | undefined {
 	return providers?.find((p) => detectQuotaProviderType(p.base_url) === type)
 		?.id;
-}
-
-// NOTE: the limit helpers below, and the badge-visibility booleans further down,
-// are duplicated in Front Desk at frontdesk/web/src/utils/quota.ts. The two
-// frontends are separate pnpm projects with no shared package, so the copy is
-// deliberate -- but it means both dashboards only show the same numbers for the
-// same fleet as long as they stay in step. Change one, change the other.
-
-// ── Z.ai Coding limit helpers ───────────────────────────────────────────
-
-export function getZaiCodingFiveHourLimit(
-	data: ZAICodingQuotaResponse | undefined | null,
-): ZAICodingQuotaLimit | undefined {
-	return data?.data?.limits?.find(
-		(l) => l.type === "TOKENS_LIMIT" && l.unit === 3,
-	);
-}
-
-export function getZaiCodingWeeklyLimit(
-	data: ZAICodingQuotaResponse | undefined | null,
-): ZAICodingQuotaLimit | undefined {
-	return data?.data?.limits?.find(
-		(l) => l.type === "TOKENS_LIMIT" && l.unit === 6,
-	);
-}
-
-// ── Kimi Code limit helpers ─────────────────────────────────────────────
-// Kimi encodes limit/remaining as JSON strings; parse with Number() before
-// computing percentage. Percentage used = (limit - remaining) / limit * 100.
-
-function toKimiCodeWindow(
-	limitStr: string | undefined,
-	remainingStr: string | undefined,
-	resetTime: string | undefined,
-): KimiCodeQuotaWindow | undefined {
-	if (limitStr == null || remainingStr == null) return undefined;
-	const limit = Number(limitStr);
-	const remaining = Number(remainingStr);
-	if (!Number.isFinite(limit) || !Number.isFinite(remaining)) return undefined;
-	const percentage = limit > 0 ? ((limit - remaining) / limit) * 100 : 0;
-	return { limit, remaining, resetTime: resetTime ?? "", percentage };
-}
-
-/** The rolling 300-minute (5-hour) window. */
-export function getKimiCodeFiveHourLimit(
-	data: KimiCodeQuotaResponse | undefined | null,
-): KimiCodeQuotaWindow | undefined {
-	const entry = data?.limits?.find(
-		(l) =>
-			l.window?.timeUnit === "TIME_UNIT_MINUTE" && l.window?.duration === 300,
-	);
-	if (!entry) return undefined;
-	return toKimiCodeWindow(
-		entry.detail?.limit,
-		entry.detail?.remaining,
-		entry.detail?.resetTime,
-	);
-}
-
-/** The weekly window (top-level `usage`). */
-export function getKimiCodeWeeklyLimit(
-	data: KimiCodeQuotaResponse | undefined | null,
-): KimiCodeQuotaWindow | undefined {
-	const usage = data?.usage;
-	if (!usage) return undefined;
-	return toKimiCodeWindow(usage.limit, usage.remaining, usage.resetTime);
-}
-
-// ── MiniMax token-plan helpers ─────────────────────────────────────────────
-// MiniMax reports REMAINING percentages (0-100) per model class. The active
-// class is the first "general" entry with current_interval_status === 1. Used%
-// is 100 − remaining%. Badge/panel hide entirely when base_resp.status_code is
-// non-zero (e.g. 2062 "no active token plan"), model_remains is empty, or no
-// active general entry exists.
-
-/** First active "general" model-class entry, or undefined. */
-export function getMiniMaxGeneralEntry(
-	data: MiniMaxQuotaResponse | undefined | null,
-): MiniMaxModelRemains | undefined {
-	const entries =
-		data?.base_resp?.status_code === 0 ? data.model_remains : null;
-	if (!Array.isArray(entries)) return undefined;
-	return entries.find(
-		(m) => m.model_name === "general" && m.current_interval_status === 1,
-	);
-}
-
-function toMiniMaxWindow(
-	remainingPercent: number | undefined,
-	resetMs: number | undefined,
-): MiniMaxQuotaWindow | undefined {
-	if (remainingPercent == null || !Number.isFinite(remainingPercent)) {
-		return undefined;
-	}
-	return {
-		percentage: 100 - remainingPercent,
-		remainingPercent,
-		resetMs: resetMs ?? 0,
-	};
-}
-
-/** Rolling 5-hour window derived from the active general entry. */
-export function getMiniMaxFiveHourLimit(
-	data: MiniMaxQuotaResponse | undefined | null,
-): MiniMaxQuotaWindow | undefined {
-	const g = getMiniMaxGeneralEntry(data);
-	if (!g) return undefined;
-	return toMiniMaxWindow(g.current_interval_remaining_percent, g.remains_time);
-}
-
-/** Weekly window derived from the active general entry. */
-export function getMiniMaxWeeklyLimit(
-	data: MiniMaxQuotaResponse | undefined | null,
-): MiniMaxQuotaWindow | undefined {
-	const g = getMiniMaxGeneralEntry(data);
-	if (!g) return undefined;
-	return toMiniMaxWindow(
-		g.current_weekly_remaining_percent,
-		g.weekly_remains_time,
-	);
 }
 
 // ── Hook options ─────────────────────────────────────────────────────────
@@ -643,57 +543,48 @@ export function useQuotaData(
 	const nanoWeeklyUsed = nanogptUsage?.weeklyInputTokens?.used;
 	const nanoWeeklyLimit = nanogptUsage?.limits?.weeklyInputTokens;
 
-	const isNanoCancelled =
-		nanogptUsage?.providerStatus === "canceled" ||
-		nanogptUsage?.providerStatus === "cancelled";
-
+	// Badge visibility: the provider has to exist and its payload has to have
+	// arrived here, then the shared rule decides whether the payload is worth a
+	// badge. Front Desk gates on the same rule.
 	const showNanoBadge =
 		Boolean(nanogptProviderId) &&
-		Boolean(nanogptUsage) &&
-		!isNanoCancelled &&
-		nanoWeeklyUsed != null &&
-		Boolean(nanoWeeklyLimit);
+		nanogptUsage != null &&
+		isNanoGptQuotaVisible(nanogptUsage);
 
 	const showZaiCodingBadge =
 		Boolean(zaiCodingProviderId) &&
-		Boolean(zaiCodingUsage?.success) &&
-		Boolean(zaiCodingFiveHour || zaiCodingWeekly);
+		zaiCodingUsage != null &&
+		isZaiCodingQuotaVisible(zaiCodingUsage);
 
 	const showKimiCodeBadge =
 		Boolean(kimiCodeProviderId) &&
-		Boolean(kimiCodeUsage) &&
-		Boolean(kimiCodeFiveHour || kimiCodeWeekly);
+		kimiCodeUsage != null &&
+		isKimiCodeQuotaVisible(kimiCodeUsage);
 
 	const showMiniMaxBadge =
 		Boolean(minimaxProviderId) &&
-		Boolean(minimaxUsage) &&
-		Boolean(getMiniMaxGeneralEntry(minimaxUsage));
+		minimaxUsage != null &&
+		isMiniMaxQuotaVisible(minimaxUsage);
 
 	const showDsBadge =
 		Boolean(deepseekProviderId) &&
-		Boolean(deepseekBalance) &&
-		Boolean(deepseekBalance?.is_available);
+		deepseekBalance != null &&
+		isDeepSeekQuotaVisible(deepseekBalance);
 
 	const showOrBadge =
 		Boolean(openrouterProviderId) &&
-		Boolean(openrouterBalance) &&
-		openrouterBalance?.credits_remaining != null;
-
-	const isOllamaCloudSuspended =
-		ollamaCloudAccount?.suspended_at?.valid === true;
+		openrouterBalance != null &&
+		isOpenRouterQuotaVisible(openrouterBalance);
 
 	const showOllamaCloudBadge =
 		Boolean(ollamaCloudProviderId) &&
-		Boolean(ollamaCloudAccount) &&
-		!isOllamaCloudSuspended;
+		ollamaCloudAccount != null &&
+		isOllamaCloudQuotaVisible(ollamaCloudAccount);
 
 	const showNeuralwattBadge =
 		Boolean(neuralwattProviderId) &&
-		Boolean(neuralwattQuota) &&
-		neuralwattQuota?.balance?.credits_remaining_usd != null &&
-		!NEURALWATT_BADGE_EXCLUDED_PLANS.has(
-			neuralwattQuota?.subscription?.plan?.toLowerCase() ?? "",
-		);
+		neuralwattQuota != null &&
+		isNeuralWattQuotaVisible(neuralwattQuota);
 
 	const hasAnyProvider = Boolean(
 		nanogptProviderId ||

--- a/web/src/utils/__tests__/format.test.ts
+++ b/web/src/utils/__tests__/format.test.ts
@@ -361,6 +361,26 @@ describe("formatTimeUntil", () => {
 		expect(formatTimeUntil(Date.now())).toBe("now");
 	});
 
+	// Sub-hour resets are minutes, not "0 hours". Kimi's 5-hour window and the
+	// Z.ai ones routinely sit inside the last hour before a reset.
+	it("returns minutes for timestamps less than an hour away", () => {
+		expect(formatTimeUntil(Date.now() + 60 * 1000)).toBe("in 1 minute");
+		expect(formatTimeUntil(Date.now() + 30 * 60 * 1000)).toBe("in 30 minutes");
+		expect(formatTimeUntil(Date.now() + 59 * 60 * 1000)).toBe("in 59 minutes");
+	});
+
+	it("rounds a sub-minute gap up to one minute rather than zero", () => {
+		expect(formatTimeUntil(Date.now() + 1000)).toBe("in 1 minute");
+		expect(formatTimeUntil(Date.now() + 59 * 1000)).toBe("in 1 minute");
+	});
+
+	it("switches to hours at exactly one hour", () => {
+		// The hour strings come from i18next, which glues the number to its unit
+		// with a non-breaking space; the Intl minute strings above use a plain one.
+		expect(formatTimeUntil(Date.now() + 60 * 60 * 1000)).toBe("in 1\u00a0hour");
+		expect(formatTimeUntil(Date.now() + 61 * 60 * 1000)).toBe("in 1\u00a0hour");
+	});
+
 	// Each number is glued to its unit word with a non-breaking space ( )
 	// so a line wrap can't strand the digit from "day(s)"/"hour(s)".
 	it("returns hours for timestamps less than a day away", () => {

--- a/web/src/utils/format.ts
+++ b/web/src/utils/format.ts
@@ -144,6 +144,16 @@ export function formatTimeUntil(ts: number): string {
 	const diff = ts - now;
 	if (diff <= 0) return i18next.t("format.now");
 
+	// Under an hour is minutes, which Intl phrases for every locale we ship, so
+	// no catalog key is involved. Anything above zero rounds up to one minute
+	// rather than reading as a whole "0 hours" away.
+	if (diff < 1000 * 60 * 60) {
+		const minutes = Math.max(1, Math.floor(diff / 60000));
+		return new Intl.RelativeTimeFormat(i18next.language, {
+			numeric: "always",
+		}).format(minutes, "minute");
+	}
+
 	const hours = Math.floor(diff / (1000 * 60 * 60));
 	const days = Math.floor(hours / 24);
 	const remainingHours = hours % 24;

--- a/web/tsconfig.app.json
+++ b/web/tsconfig.app.json
@@ -7,7 +7,10 @@
 		"module": "ESNext",
 		"skipLibCheck": true,
 		"moduleResolution": "bundler",
-		"paths": { "@/*": ["./src/*"] },
+		"paths": {
+			"@/*": ["./src/*"],
+			"@quota-shared": ["../web-shared/quota/index.ts"]
+		},
 		"allowImportingTsExtensions": true,
 		"resolveJsonModule": true,
 		"isolatedModules": true,

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -26,7 +26,13 @@ export default defineConfig({
 	resolve: {
 		alias: {
 			"@": path.resolve(__dirname, "./src"),
+			"@quota-shared": path.resolve(__dirname, "../web-shared/quota/index.ts"),
 		},
+	},
+	server: {
+		// The quota helpers live outside this project root, so the dev server has
+		// to be allowed to serve them alongside the app's own files.
+		fs: { allow: [__dirname, path.resolve(__dirname, "../web-shared")] },
 	},
 	build: {
 		// The two chunks over Vite's default 500 kB warning line are both benign:

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
 	resolve: {
 		alias: {
 			"@": path.resolve(__dirname, "./src"),
+			"@quota-shared": path.resolve(__dirname, "../web-shared/quota/index.ts"),
 		},
 	},
 	test: {

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -21,7 +21,14 @@ export default defineConfig({
 		coverage: {
 			provider: "v8",
 			reporter: ["text", "html", "lcov", "json-summary"],
-			include: ["src/**/*.{ts,tsx}"],
+			// web-shared/ holds the quota parsing both SPAs import through
+			// @quota-shared, and web/ is its owning app for coverage. It sits
+			// outside this project's root, so it needs allowExternal plus a
+			// pattern that matches an ABSOLUTE path: vitest tests coverage.include
+			// against the resolved filename (picomatch, `contains: true`), where a
+			// `../`-relative glob can never match.
+			allowExternal: true,
+			include: ["src/**/*.{ts,tsx}", "**/web-shared/**/*.ts"],
 			exclude: [
 				"src/**/*.test.{ts,tsx}",
 				"src/**/__tests__/**",


### PR DESCRIPTION
Fixes the three quota defects found in the 2026-08-06 live triage, and consolidates the duplicated frontend quota parsing that let them hide.

## What

**Kimi quota pin can finally fire** — Kimi's `/usages` is proto3-JSON and omits zero-valued fields, so at exhaustion `remaining` disappears and only `used` is present. The assessor parsed only `remaining`, making exhaustion undetectable at exactly the moment the pin exists for. Now: `used` is modelled (it previously vanished in the snapshot re-marshal), remaining derives from `limit - used` when absent, and the top-level cycle counter is assessed too.

**Breaker-open quota nudge + immediate re-pin** — a circuit opening triggers a debounced (60s/provider) single-provider quota poll, and fresh exhaustion advice retargets the already-open circuit's cooldown via `ApplyQuotaPins` (lengthen-only, logically-open-only, measured from `openedAt` so a pin can never probe early). Poll, refresh, and lookup run on independent contexts so one hanging quota endpoint cannot wipe fleet-wide advice.

**One source of truth for web quota parsing** — `web-shared/quota/` now serves both the dashboard and Front Desk (~370 duplicated lines deleted). Kimi badges show 100% used at exhaustion by correct logic (previously two bugs canceling: the re-marshal materialized `""` and `Number("") === 0`), and sub-hour resets render "in 33 minutes" via `Intl.RelativeTimeFormat` instead of "Resets in 0 hours" — zero new i18n keys.

**Bellhop parity + cross-platform drift net** — the Kotlin port matches the TS semantics branch for branch, and both consume the 7 contract fixtures in `testdata/quota-contract/kimi/` (Bellhop through the production decode path; the fixture dir is a declared Gradle test input so fixture edits invalidate the task). CI runs the Android leg on fixture-only changes, and `web-shared/` is inside the lint/format/typecheck/diff-coverage gates locally and in CI.

## Deploy notes

- **Upgrade fleet members before or together with Front Desk.** A pre-upgrade member's snapshot (`remaining:""`, no `used`) renders on a new FD as 0% used — a green bar for an exhausted account — until that member re-polls post-upgrade.
- **Expect a one-time quota schema-drift alert per Kimi provider** (new `used` key paths). That is the drift watch working; it self-rebaselines after two agreeing polls.

## Not in scope (parked, non-blocking)

- `web-shared/quota/index.ts` barrel forces a full-suite pre-push fallback when touched (fail-safe; one-line `covlib` exclude as follow-up).
- A Go-vs-fixtures contract test needs the fixtures to carry relative-offset resets first (absolute timestamps go stale; a past reset never pins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)