### PR TITLE
perf(pre-push): seed vitest selection from the changed files, not the raw diff

### DIFF
--- a/scripts/coverage/select_related.py
+++ b/scripts/coverage/select_related.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Print the changed files worth seeding `vitest related` test selection with.
+
+The pre-push hook's scoped vitest run picks its tests from the changed files.
+Seeding that selection with a file that compiles to no runtime JavaScript is
+worse than useless: such a file can never be measured by coverage, and the one
+this repo actually has - web/src/api/types.ts, the typed boundary to the
+backend - is imported by nearly every module, so leaving it in the seed list
+degenerated the scoped run into 183 of 190 test files (6m29s, the entire
+pre-push wait).
+
+Dropping those files here cannot weaken the gate: assert_instrumented.py
+exempts exactly the same files from its "every changed file was measured"
+check (same covlib.emits_no_runtime_code call), so a file dropped from
+selection is never one whose absence from the report the guard would flag.
+Everything else - including changed test files, which select themselves - is
+kept, and any under-selection still trips the guard's full-suite rerun.
+"""
+import argparse
+import sys
+
+import covlib
+
+
+def selectable(paths: list) -> list:
+    """The subset of paths that could ever appear in a coverage report."""
+    return [p for p in paths if not covlib.emits_no_runtime_code(p)]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("files", nargs="*", help="changed files, repo-relative")
+    args = ap.parse_args()
+
+    for path in selectable(args.files):
+        print(path)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/coverage/test_select_related.py
+++ b/scripts/coverage/test_select_related.py
@@ -1,0 +1,52 @@
+import os
+import shutil
+import tempfile
+import unittest
+
+import select_related
+
+
+class TestSelectable(unittest.TestCase):
+    """Pins the seed-list filter for the pre-push `vitest related` run.
+
+    The only thing dropped is a file that compiles to no runtime code - the
+    same exemption assert_instrumented.py grants, so a dropped file is never
+    one whose absence from the report would trip the full-suite fallback.
+    Everything ambiguous stays selected: an over-full seed list only costs
+    test time, an over-trimmed one skips tests silently.
+    """
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp)
+
+    def _write(self, name, src):
+        path = os.path.join(self.tmp, name)
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write(src)
+        return path
+
+    def test_drops_types_only_hub_keeps_runtime_source(self):
+        types_only = self._write(
+            "types.ts", "export interface Claim { model_id: string }\n"
+        )
+        runtime = self._write("client.ts", "export const api = fetch;\n")
+        self.assertEqual(
+            select_related.selectable([types_only, runtime]), [runtime]
+        )
+
+    def test_keeps_changed_test_files(self):
+        # A changed test selects itself under `vitest related`; its top-level
+        # describe() call reads as runtime code, so it must survive the filter.
+        test = self._write("foo.test.tsx", "describe('foo', () => {});\n")
+        self.assertEqual(select_related.selectable([test]), [test])
+
+    def test_keeps_unreadable_paths(self):
+        # A path that cannot be read answers "emits" (covlib returns False),
+        # staying in the seed list - the direction that runs more tests.
+        gone = os.path.join(self.tmp, "absent.ts")
+        self.assertEqual(select_related.selectable([gone]), [gone])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -134,44 +134,78 @@ has_measurable_change() {
 	gate_status "$status" "has_measurable_change($1)"
 }
 
-# run_vitest_coverage <app-subdir> <source-file-regex> - build lcov for one
-# frontend, preferring the tests vitest believes the change affects (~4x faster).
-#
-# The scoped run is not trusted on its own: vitest's affected-test detection misses
-# real dependents, and diff_coverage.py skips any changed file it has no coverage
-# for, reporting PASS when that leaves nothing to measure. assert_instrumented.py
-# checks every changed file was measured, and the full suite reruns when it was not.
-# Worst case costs both runs; the gate stays honest.
-run_vitest_coverage() {
-	local app=$1 include=$2
-	local dir="$REPO_ROOT/$app" lcov="$REPO_ROOT/$app/coverage/lcov.info"
-	local changed_files=""
-	# Keep only files that still exist. A deleted path can never appear in an lcov
-	# report, so it would read as unmeasured and rerun the full suite for nothing.
-	# Its lines are gone from HEAD, so they are not in the gated changed-line set.
+# existing_changed <regex> - the changed files matching regex that still exist
+# on disk, one per line. A deleted path can never appear in an lcov report, so
+# it would read as unmeasured and rerun the full suite for nothing; its lines
+# are gone from HEAD, so they are not in the gated changed-line set either.
+existing_changed() {
 	while read -r _file; do
 		[ -n "$_file" ] || continue
 		[ -f "$REPO_ROOT/$_file" ] || continue
-		changed_files="$changed_files$_file
-"
-	done < <(printf '%s\n' "$CHANGED_FILES" | grep -E "$include" || true)
+		printf '%s\n' "$_file"
+	done < <(printf '%s\n' "$CHANGED_FILES" | grep -E "$1" || true)
+}
 
-	if [ -n "$SYNC_BASE" ] && [ -n "$changed_files" ]; then
-		echo "pre-push: coverage - $app vitest (tests affected by this branch)"
-		# --passWithNoTests: "nothing affected" is a legitimate outcome, not a
-		# failure. The guard below still decides whether that result is usable.
-		if ! (cd "$dir" && env -u NODE_ENV pnpm exec vitest run --changed "$SYNC_BASE" --passWithNoTests --coverage --coverage.reporter=lcov); then
-			echo "pre-push: FAILED - $app vitest (affected tests)" >&2
-			return 1
+# run_vitest_coverage <app-subdir> <report-file-regex> [<seed-file-regex>] -
+# build lcov for one frontend, running only the tests vitest can tie to the
+# changed files.
+#
+# <report-file-regex> names the changed files this app's report must measure.
+# <seed-file-regex> (default: the report regex) names the files test selection
+# seeds from and may be broader: Front Desk seeds on web-shared/ too, whose
+# lines are measured by web/'s report.
+#
+# Selection is `vitest related <changed files>` rather than `--changed <base>`.
+# --changed seeds from every file in the raw diff, so a types-only hub like
+# web/src/api/types.ts - imported by every page, erased at compile time, exempt
+# from the instrumentation guard - turned "affected" into a near-full suite
+# (183 of 190 test files, 6m29s) while contributing nothing measurable.
+# select_related.py drops exactly the files that guard exempts, so the two
+# stay one filter, and a seed list that comes back empty means no changed file
+# can appear in any report: the truthful lcov is an empty one, and the guard
+# below still vets that conclusion file by file.
+#
+# The scoped run is not trusted on its own: vitest's import graph misses real
+# dependents, and diff_coverage.py skips any changed file it has no coverage
+# for, reporting PASS when that leaves nothing to measure. assert_instrumented.py
+# checks every changed file was measured, and the full suite reruns when it was
+# not. Worst case costs both runs; the gate stays honest.
+run_vitest_coverage() {
+	local app=$1 report_include=$2 seed_include=${3:-$2}
+	local dir="$REPO_ROOT/$app" lcov="$REPO_ROOT/$app/coverage/lcov.info"
+	local report_files seed_files
+	report_files="$(existing_changed "$report_include")"
+
+	if [ -n "$SYNC_BASE" ]; then
+		# Unquoted expansions on purpose, here and below: one argument per
+		# file. A path containing whitespace splits into names that match
+		# nothing, which under-selects or reads as unmeasured and falls back
+		# to the full suite - the safe direction.
+		# shellcheck disable=SC2046
+		seed_files="$(python3 "$REPO_ROOT/scripts/coverage/select_related.py" $(existing_changed "$seed_include"))"
+		if [ -n "$seed_files" ]; then
+			echo "pre-push: coverage - $app vitest (tests related to the changed files)"
+			# Absolute paths: vitest resolves the seeds against its own CWD,
+			# and web/'s seeds can live outside web/ (web-shared/).
+			local seed_abs
+			seed_abs="$(printf '%s\n' "$seed_files" | sed "s#^#$REPO_ROOT/#")"
+			# --passWithNoTests: "nothing related" is a legitimate outcome, not
+			# a failure. The guard below still decides whether it is usable.
+			# shellcheck disable=SC2086
+			if ! (cd "$dir" && env -u NODE_ENV pnpm exec vitest related --run $seed_abs --passWithNoTests --coverage --coverage.reporter=lcov); then
+				echo "pre-push: FAILED - $app vitest (related tests)" >&2
+				return 1
+			fi
+		else
+			echo "pre-push: coverage - $app vitest skipped (changed files emit no runtime code)"
+			mkdir -p "${lcov%/*}"
+			: >"$lcov"
 		fi
-		# Unquoted on purpose: one argument per changed file. A path containing
-		# whitespace splits into names that match nothing, which reads as
-		# unmeasured and falls back to the full suite - the safe direction.
 		# shellcheck disable=SC2086
-		if python3 "$REPO_ROOT/scripts/coverage/assert_instrumented.py" --lcov "$lcov" --root "$app/" $changed_files; then
+		if python3 "$REPO_ROOT/scripts/coverage/assert_instrumented.py" --lcov "$lcov" --root "$app/" $report_files; then
 			return 0
 		fi
-		echo "pre-push: affected-test run left changed files unmeasured; rerunning the full $app suite" >&2
+		echo "pre-push: related-test run left changed files unmeasured; rerunning the full $app suite" >&2
 	fi
 
 	echo "pre-push: coverage - $app vitest (full suite)"
@@ -354,11 +388,13 @@ else
 	fi
 
 	# Front Desk frontend. A web-shared/ change runs this suite too - Front Desk
-	# imports the same modules through @quota-shared - but the scoping regex stays
+	# imports the same modules through @quota-shared - but the report regex stays
 	# frontdesk-only: those lines are measured by web/'s report, and asking for
-	# them here would fail the instrumentation guard on every push.
+	# them here would fail the instrumentation guard on every push. The broader
+	# seed regex still hands them to test selection, so a web-shared change runs
+	# the Front Desk tests that import it rather than the whole suite.
 	if has_measurable_change '^frontdesk/web/src/.*\.tsx?$|^web-shared/.*\.ts$' '\.test\.tsx?$|/__tests__/|^frontdesk/web/src/test/'; then
-		if run_vitest_coverage frontdesk/web '^frontdesk/web/src/.*\.tsx?$'; then
+		if run_vitest_coverage frontdesk/web '^frontdesk/web/src/.*\.tsx?$' '^frontdesk/web/src/.*\.tsx?$|^web-shared/.*\.ts$'; then
 			DC_ARGS+=(--lcov "frontdesk/web/=$REPO_ROOT/frontdesk/web/coverage/lcov.info")
 		else
 			exit 1

--- a/web/package.json
+++ b/web/package.json
@@ -9,7 +9,7 @@
 		"build": "tsc -b && vite build",
 		"build:docker": "vite build",
 		"typecheck:tests": "tsc --noEmit -p tsconfig.test.json",
-		"lint": "eslint --no-warn-ignored ${@:-.}",
+		"lint": "eslint --cache --cache-location node_modules/.cache/eslint/ --cache-strategy content --no-warn-ignored ${@:-.}",
 		"format": "biome check . ../web-shared",
 		"format:fix": "biome check --write",
 		"preview": "vite preview",


### PR DESCRIPTION
## What

The pre-push hook's scoped vitest coverage run selected tests with `vitest run --changed <base>`, which seeds selection from every file in the raw diff. A types-only hub like `web/src/api/types.ts` - imported by every page, erased at compile time, and already exempt from the instrumentation guard - degenerated "affected" into 183 of 190 test files (6m29s), the entire pre-push wait, while contributing nothing measurable.

- `run_vitest_coverage` now selects with `vitest related --run <changed files>` (absolute paths, so seeds outside the app root like `web-shared/` resolve). Seeds are filtered by the new `scripts/coverage/select_related.py`, which drops only `covlib.emits_no_runtime_code` files - the exact set `assert_instrumented.py` exempts - so selection and the honesty guard remain one filter by construction. An empty seed list writes a truthful empty lcov, still vetted file by file by the guard.
- The function takes separate **report** and **seed** regexes: Front Desk seeds on `web-shared/` too, so a web-shared change runs the FD tests that import it instead of the full FD suite (which #644 had made the unconditional cost of that case), while its report scope stays frontdesk-only.
- eslint gets `--cache --cache-strategy content` (cache in `node_modules/.cache/eslint/`) - the lint step was a fixed 34s per push; warm runs take seconds. No effect in CI (cold, ephemeral).

No gate is weakened: the `assert_instrumented.py` full-suite fallback on under-selection is unchanged, and CI enforces everything against the real ref regardless.

## Measured (hook run against real pushed refs)

| push | before | after |
|---|---|---|
| web + web-shared change | ~8min | 1m43s (30 web + 9 FD test files) |
| `types.ts`-only change | ~7min | 7s (vitest skipped, honestly) |

## Tests

- `scripts/coverage/test_select_related.py` pins the seed filter (types-only dropped; runtime source, changed test files, and unreadable paths kept - the direction that runs more tests). All 27 coverage-script unittests pass.
- End-to-end: hook exercised by hand with pushed-ref stdin on scratch commits covering the related-run path (both apps), the empty-seed path, and the diff gate; instrumentation guard passed in all cases with no fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)