### PR TITLE
fix(frontdesk): 240s import deadline + stamp last-sync when verification proves a lost push landed

### DIFF
--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/FrontDeskClient.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/FrontDeskClient.kt
@@ -551,10 +551,12 @@ open class FrontDeskClient(
 
         // Generous ceiling for the synchronous fleet sync: per-member imports
         // run model discovery and Front Desk answers only after every member is
-        // done, so this must comfortably cover a few slow members. Front Desk
-        // also detaches the run from the connection, so even tripping this
-        // no longer aborts the sync — it only stops the phone waiting.
-        private const val SYNC_READ_TIMEOUT_SECONDS = 180L
+        // done. Front Desk allows each import up to 240s (memberSyncTimeout), so
+        // this covers one legitimately slow member plus overhead; a fleet of
+        // several slow members can outlive it. Front Desk detaches the run from
+        // the connection, so tripping this never aborts the sync — it only stops
+        // the phone waiting for the summary.
+        private const val SYNC_READ_TIMEOUT_SECONDS = 300L
 
         // eventQueryString renders an EventQuery as an encoded query string
         // ("" when every field is unset). Internal so the omission and encoding

--- a/internal/api/configsync_apply.go
+++ b/internal/api/configsync_apply.go
@@ -343,9 +343,10 @@ func validateSyncedRateLimits(subject string, rps *float64, burst, tpm *int) err
 func (h *ConfigSyncHandler) postImportRefresh(ctx context.Context, env ConfigEnvelope, removedSettings []string) applyOutcome {
 	var out applyOutcome
 	// The core config is committed, so the remaining work is not bound to the
-	// caller's request. Front Desk's import client gives up after 120s while
-	// discovery on a fresh member routinely runs longer, and inheriting that
-	// deadline starves the group build, which depends on discovery's output.
+	// caller's request. Front Desk's import client gives up after 240s
+	// (frontdesk.memberSyncTimeout) while discovery on a fresh member routinely
+	// runs longer, and inheriting that deadline starves the group build, which
+	// depends on discovery's output.
 	//
 	// Detached rather than given an aggregate deadline. A ceiling here would not
 	// bound discovery, which detaches each provider under its own 180s timeout and

--- a/internal/frontdesk/autosync.go
+++ b/internal/frontdesk/autosync.go
@@ -498,7 +498,7 @@ func (s *Server) measureMember(ctx, passCtx context.Context, m *Member, token, h
 			if err := s.store.SetMemberLastSync(ctx, m.ID, time.Now().UTC(), unconfirmedSyncReason); err != nil {
 				debuglog.Warn("frontdesk: stamp member last-sync on verified convergence", "member", m.Name, "error", err)
 			} else {
-				s.clearUnconfirmedPush(m.ID)
+				s.clearUnconfirmedPush(m.ID, hash)
 			}
 		}
 		s.poller.SetAutoSyncVerified(m.ID, time.Now().UTC())
@@ -625,13 +625,19 @@ func (s *Server) markUnconfirmedPush(memberID, hash string) {
 	s.unconfirmedSync[memberID] = hash
 }
 
-// clearUnconfirmedPush forgets a member's unconfirmed push once a sync stamp has
-// landed for it: either a later push was confirmed and stamped itself, or the
-// verification pass stamped on the hash match.
-func (s *Server) clearUnconfirmedPush(memberID string) {
+// clearUnconfirmedPush forgets a member's unconfirmed push of exactly this
+// config once a sync stamp has landed for it: either a later push of it was
+// confirmed and stamped itself, or the verification pass stamped on the hash
+// match. Compare-and-delete rather than delete: between the caller reading the
+// flag and stamping, a concurrent push (the wizard runs on its own goroutine)
+// can lose ITS answer and re-mark the member with a newer hash, and that entry
+// must survive to earn its own stamp.
+func (s *Server) clearUnconfirmedPush(memberID, hash string) {
 	s.syncIncompleteMu.Lock()
 	defer s.syncIncompleteMu.Unlock()
-	delete(s.unconfirmedSync, memberID)
+	if hash != "" && s.unconfirmedSync[memberID] == hash {
+		delete(s.unconfirmedSync, memberID)
+	}
 }
 
 // hasUnconfirmedPush reports whether this member has a lost-answer push of

--- a/internal/frontdesk/autosync.go
+++ b/internal/frontdesk/autosync.go
@@ -52,10 +52,18 @@ const (
 	// or repoints the primary.
 	autoSyncKickReason = "auto-sync was enabled"
 
+	// unconfirmedSyncReason is stamped when a pass measures a member holding the
+	// primary's exact hash after a push whose answer was lost (the relay deadline
+	// expired, or a proxy in between answered 5xx while the member was still
+	// importing). The hash match proves the push landed, so the last-sync marker
+	// the push itself could not stamp is stamped at verification time instead.
+	unconfirmedSyncReason = "verified holding the primary's config after an unconfirmed push"
+
 	// autoSyncKickTimeout caps the detached pass fired when auto-sync is enabled,
 	// so a stuck member cannot leak the goroutine. Generous: the pass imports into
-	// every drifted member in turn.
-	autoSyncKickTimeout = 5 * time.Minute
+	// every drifted member in turn, and each import may legitimately run up to
+	// memberSyncTimeout on a slow member, so the cap covers several of those.
+	autoSyncKickTimeout = 15 * time.Minute
 
 	// autoSyncStaleThreshold is how long the fleet may go unsynced, with auto-sync
 	// off, before Front Desk warns of possible drift. Long enough that a brief
@@ -405,13 +413,15 @@ func (s *Server) applyAutoSync(ctx context.Context, primary *Member, primaryToke
 		// of one roll-up below. gen lets the member's commit fence refuse this push if
 		// a newer generation already won the in-flight race (out.Stale, a benign
 		// supersede).
-		out := s.applyMemberConfig(passCtx, m, token, export, reason, false, gen)
-		if out.OK || out.Incomplete || out.TimedOut {
+		out := s.applyMemberConfig(passCtx, m, token, export, reason, false, gen, hash)
+		if out.OK || out.Incomplete || out.Unconfirmed {
 			// The member received the config, whether or not it built all of it and
 			// whether or not it answered in time. The stamp bounds the re-push and tells
 			// the next pass this member has had its chance, so a hash that still differs
-			// then is a failure to converge rather than a member nobody reached. A
-			// timed-out member is very likely still importing, so it counts too.
+			// then is a failure to converge rather than a member nobody reached. An
+			// unconfirmed push (timed out, or answered 5xx by a proxy mid-import)
+			// counts too: the member is very likely still importing, and re-pushing
+			// every tick would restart that import and its discovery each time.
 			//
 			// A push the member refused or never received is deliberately not stamped,
 			// so a transient failure retries next tick instead of waiting out the
@@ -479,6 +489,18 @@ func (s *Server) measureMember(ctx, passCtx context.Context, m *Member, token, h
 		// heartbeat. Only a hash match moves it, so it means "measured holding the
 		// primary's config", never "written to".
 		s.clearMemberIncomplete(ctx, m)
+		if s.hasUnconfirmedPush(m.ID, hash) {
+			// The member holds the primary's exact config, so the push whose answer
+			// was lost did land: record the sync its own stamp missed, at the moment
+			// it was proven rather than guessed. An idle converged fleet never gets
+			// here (no push, no flag), so the marker still means a real write. A
+			// failed stamp keeps the flag, and the next converged pass retries it.
+			if err := s.store.SetMemberLastSync(ctx, m.ID, time.Now().UTC(), unconfirmedSyncReason); err != nil {
+				debuglog.Warn("frontdesk: stamp member last-sync on verified convergence", "member", m.Name, "error", err)
+			} else {
+				s.clearUnconfirmedPush(m.ID)
+			}
+		}
 		s.poller.SetAutoSyncVerified(m.ID, time.Now().UTC())
 		return true, true
 	}
@@ -584,6 +606,44 @@ func (s *Server) recordSyncAttempt(memberID string, unapplied, partial, unapplie
 	st.lastPartial = partial
 	st.lastUnappliedModels = unappliedModels
 	s.syncIncomplete[memberID] = st
+}
+
+// markUnconfirmedPush remembers that a member's latest real config push, carrying
+// the primary config identified by hash, got no usable answer, so its last-sync
+// marker could not be stamped even though the import may have completed
+// member-side. A later pass that measures the member holding exactly that hash
+// stamps the marker then and clears this. An empty hash records nothing: the
+// caller had no hash for what it pushed (the wizard when the primary's hash was
+// unreadable), and a stamp that cannot be tied to the pushed config must not be
+// promised.
+func (s *Server) markUnconfirmedPush(memberID, hash string) {
+	if hash == "" {
+		return
+	}
+	s.syncIncompleteMu.Lock()
+	defer s.syncIncompleteMu.Unlock()
+	s.unconfirmedSync[memberID] = hash
+}
+
+// clearUnconfirmedPush forgets a member's unconfirmed push once a sync stamp has
+// landed for it: either a later push was confirmed and stamped itself, or the
+// verification pass stamped on the hash match.
+func (s *Server) clearUnconfirmedPush(memberID string) {
+	s.syncIncompleteMu.Lock()
+	defer s.syncIncompleteMu.Unlock()
+	delete(s.unconfirmedSync, memberID)
+}
+
+// hasUnconfirmedPush reports whether this member has a lost-answer push of
+// exactly this config behind it, still waiting for the stamp its lost answer
+// denied it. Bound to the hash so a push of an older config can never be
+// "proven" by convergence on a newer one, and a definite member-side failure
+// (nothing committed) can never be stamped just because the member later came to
+// hold the primary's config some other way.
+func (s *Server) hasUnconfirmedPush(memberID, hash string) bool {
+	s.syncIncompleteMu.Lock()
+	defer s.syncIncompleteMu.Unlock()
+	return hash != "" && s.unconfirmedSync[memberID] == hash
 }
 
 // hasBeenPushedSinceReset reports whether this member has received the config

--- a/internal/frontdesk/autosync_test.go
+++ b/internal/frontdesk/autosync_test.go
@@ -1000,7 +1000,9 @@ func TestAutoSync_IncompleteStampClearsUnconfirmedPush(t *testing.T) {
 	primary.versionHash = "hash-B"
 	replica := newStubAutoMember(t, "rtoken")
 	replica.dryDiff = driftDiff
-	replica.realImportCode = http.StatusBadGateway // lost answer, nothing adopted
+	// A 504 is a lost answer on its own; an instant 502 would be a plain failure
+	// now (see lostAnswer5xx).
+	replica.realImportCode = http.StatusGatewayTimeout // lost answer, nothing adopted
 
 	pm, _ := store.CreateMember(t.Context(), "primary", primary.srv.URL, "ptoken")
 	rm, _ := store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken")
@@ -1064,6 +1066,75 @@ func TestAutoSync_FailedVerifyStampKeepsFlag(t *testing.T) {
 	}
 	if !srv.hasUnconfirmedPush(rm.ID, "hash-B") {
 		t.Error("the flag was dropped on a failed stamp write; the next converged pass has nothing left to retry")
+	}
+}
+
+// TestAutoSync_InstantGatewayErrorRetriesNextTick: an instant 5xx is not a lost
+// answer. A proxy answers 502 immediately when its upstream is down (a member
+// that crashed mid-import looks like this), so nothing is importing behind such
+// an answer: the re-push must come on the next tick rather than sitting out
+// incompleteRetryInterval, and no unconfirmed push is remembered, so a member
+// that later converges through no write of Front Desk's is verified but never
+// stamped.
+func TestAutoSync_InstantGatewayErrorRetriesNextTick(t *testing.T) {
+	srv, store := newTestServer(t)
+	primary := newStubAutoMember(t, "ptoken")
+	primary.versionHash = "hash-B"
+	replica := newStubAutoMember(t, "rtoken")
+	replica.dryDiff = driftDiff
+	replica.realImportCode = http.StatusBadGateway // instant: the proxy's upstream is down
+
+	pm, _ := store.CreateMember(t.Context(), "primary", primary.srv.URL, "ptoken")
+	rm, _ := store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken")
+	enableAutoSync(t, store, pm.ID)
+	alignFleetVersions(t, srv, store, "dev")
+
+	srv.autoSyncOnce(t.Context(), "hash-B")
+	if got := replica.realSyncCount(); got != 1 {
+		t.Fatalf("real imports = %d, want 1", got)
+	}
+
+	// The push failed outright, so it must not be rate-limited: the next pass
+	// pushes again instead of waiting out incompleteRetryInterval.
+	srv.autoSyncOnce(t.Context(), "hash-B")
+	if got := replica.realSyncCount(); got != 2 {
+		t.Fatalf("real imports after the next tick = %d, want 2: an instant 5xx is a plain failure, not a maybe-landed import", got)
+	}
+
+	// The member comes to hold the primary's config through no write of Front
+	// Desk's (an operator restore, or the primary edited back): verified, but not
+	// stamped, because no unconfirmed push was remembered for it.
+	replica.setVersionHash("hash-B")
+	srv.autoSyncOnce(t.Context(), "hash-B")
+	got, err := store.GetMember(t.Context(), rm.ID)
+	if err != nil {
+		t.Fatalf("GetMember: %v", err)
+	}
+	if got.LastConfigSyncAt != nil {
+		t.Error("an instant-5xx push was stamped on convergence; the write was never confirmed and nothing was importing behind the answer")
+	}
+	if !memberVerified(srv, rm.ID) {
+		t.Error("the converged member was not verified in sync")
+	}
+}
+
+// TestClearUnconfirmedPushKeepsNewerHash: clearing is compare-and-delete. The
+// stamp paths check the flag, write the stamp, then clear; a concurrent push
+// (the wizard runs on its own goroutine) can lose ITS answer to newer config in
+// that window and re-mark the member. The stale clear must not drop the newer
+// entry, or that push would never be stamped on verification.
+func TestClearUnconfirmedPushKeepsNewerHash(t *testing.T) {
+	srv, _ := newTestServer(t)
+	srv.markUnconfirmedPush("m1", "hash-C")
+
+	srv.clearUnconfirmedPush("m1", "hash-B") // a stamp for an older push landing late
+	if !srv.hasUnconfirmedPush("m1", "hash-C") {
+		t.Fatal("a stale clear dropped a newer unconfirmed push; its verify stamp is lost")
+	}
+
+	srv.clearUnconfirmedPush("m1", "hash-C")
+	if srv.hasUnconfirmedPush("m1", "hash-C") {
+		t.Error("clearing the matching hash must drop the entry")
 	}
 }
 

--- a/internal/frontdesk/autosync_test.go
+++ b/internal/frontdesk/autosync_test.go
@@ -55,6 +55,11 @@ type stubAutoMember struct {
 	// the member claims about its own apply: an explicit "incomplete":false, or an
 	// older member's response that omits the field entirely.
 	realImportBody string
+	// realImportCode, when set, is the status the real import answers with even
+	// though the member applies the config anyway: what a reverse proxy answering
+	// 502/504 mid-import looks like from Front Desk, with the member finishing
+	// the apply behind it.
+	realImportCode int
 	gotBackup      bool
 	backups        int // how many backups this member was asked to take; must stay 0
 	dryRuns        int // how many dry-run imports this member was asked for
@@ -149,6 +154,11 @@ func newStubAutoMember(t *testing.T, token string) *stubAutoMember {
 			}
 			if sm.appliedHash != "" {
 				sm.versionHash = sm.appliedHash // the member now holds the primary's config
+			}
+			if sm.realImportCode != 0 {
+				// The apply above still happened; only the answer is lost.
+				w.WriteHeader(sm.realImportCode)
+				return
 			}
 			if sm.realImportBody != "" {
 				_, _ = w.Write([]byte(sm.realImportBody))
@@ -771,6 +781,289 @@ func TestAutoSyncSchemaBlockedMemberSkipped(t *testing.T) {
 	}
 	if memberVerified(srv, bm.ID) {
 		t.Error("a member that cannot take the config was recorded verified in sync")
+	}
+}
+
+// TestAutoSync_GatewayErroredPushStampsOnVerify: a push answered 5xx by a proxy
+// mid-import is not stamped (the write was never confirmed), but the import
+// completes member-side; the next pass measures the member holding the primary's
+// hash, which proves the push landed, and stamps last_config_sync_at then. A
+// converged pass after that must not stamp again: the marker still means a real
+// write, not a heartbeat.
+func TestAutoSync_GatewayErroredPushStampsOnVerify(t *testing.T) {
+	srv, store := newTestServer(t)
+	primary := newStubAutoMember(t, "ptoken")
+	primary.versionHash = "hash-B"
+	replica := newStubAutoMember(t, "rtoken")
+	replica.dryDiff = driftDiff
+	replica.appliedHash = "hash-B"                     // the import applies...
+	replica.realImportCode = http.StatusGatewayTimeout // ...but the answer is a proxy's 504
+
+	pm, _ := store.CreateMember(t.Context(), "primary", primary.srv.URL, "ptoken")
+	rm, _ := store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken")
+	enableAutoSync(t, store, pm.ID)
+	alignFleetVersions(t, srv, store, "dev")
+
+	srv.autoSyncOnce(t.Context(), "hash-B")
+
+	if got := replica.realSyncCount(); got != 1 {
+		t.Fatalf("real imports = %d, want 1", got)
+	}
+	got, err := store.GetMember(t.Context(), rm.ID)
+	if err != nil {
+		t.Fatalf("GetMember: %v", err)
+	}
+	if got.LastConfigSyncAt != nil {
+		t.Fatal("a push answered 504 was stamped as a sync; the write was never confirmed")
+	}
+
+	// The next pass measures the member serving hash-B: the lost push is proven
+	// landed, so the marker it missed is stamped now.
+	srv.autoSyncOnce(t.Context(), "hash-B")
+
+	got, err = store.GetMember(t.Context(), rm.ID)
+	if err != nil {
+		t.Fatalf("GetMember: %v", err)
+	}
+	if got.LastConfigSyncAt == nil {
+		t.Fatal("a verified member with an unconfirmed push behind it was not stamped")
+	}
+	if got.LastConfigSyncReason != unconfirmedSyncReason {
+		t.Errorf("reason = %q, want %q", got.LastConfigSyncReason, unconfirmedSyncReason)
+	}
+	if !memberVerified(srv, rm.ID) {
+		t.Error("the converged member was not verified in sync")
+	}
+
+	// The stamp is once per lost push, not per converged tick: overwrite the
+	// marker with a sentinel and prove a further converged pass leaves it alone.
+	if err := store.SetMemberLastSync(t.Context(), rm.ID, time.Now().UTC(), "sentinel"); err != nil {
+		t.Fatalf("SetMemberLastSync: %v", err)
+	}
+	srv.autoSyncOnce(t.Context(), "hash-B")
+	got, err = store.GetMember(t.Context(), rm.ID)
+	if err != nil {
+		t.Fatalf("GetMember: %v", err)
+	}
+	if got.LastConfigSyncReason != "sentinel" {
+		t.Errorf("reason = %q after a quiet converged pass, want the sentinel untouched: converged ticks must not stamp", got.LastConfigSyncReason)
+	}
+}
+
+// TestAutoSync_TimedOutPushStampsOnVerify: the same proof for the other lost
+// answer, Front Desk's own relay deadline expiring while the member is still
+// importing. The push is not stamped; the pass that measures the member holding
+// the primary's hash stamps it.
+func TestAutoSync_TimedOutPushStampsOnVerify(t *testing.T) {
+	srv, store := newTestServer(t)
+	primary := newStubAutoMember(t, "ptoken")
+	primary.versionHash = "hash-B"
+	replica := newStubAutoMember(t, "rtoken")
+	replica.dryDiff = driftDiff
+	replica.appliedHash = "hash-B"
+	replica.onImport = func(context.Context) bool {
+		time.Sleep(time.Second) // outlives the relay deadline below, then commits
+		return true
+	}
+	// Comfortably above the dry-run round-trip even on a loaded machine, and a
+	// quarter of the import sleep above, so the real import always times out.
+	srv.syncClient = newProbeClient(250 * time.Millisecond)
+
+	pm, _ := store.CreateMember(t.Context(), "primary", primary.srv.URL, "ptoken")
+	rm, _ := store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken")
+	enableAutoSync(t, store, pm.ID)
+	alignFleetVersions(t, srv, store, "dev")
+
+	srv.autoSyncOnce(t.Context(), "hash-B")
+
+	// realSyncCount waits on the stub's mutex, so this both proves the import
+	// committed after the client hung up and fences the next pass behind it.
+	if got := replica.realSyncCount(); got != 1 {
+		t.Fatalf("real imports = %d, want 1: the import commits after the deadline", got)
+	}
+	got, err := store.GetMember(t.Context(), rm.ID)
+	if err != nil {
+		t.Fatalf("GetMember: %v", err)
+	}
+	if got.LastConfigSyncAt != nil {
+		t.Fatal("a timed-out push was stamped as a sync; the write was never confirmed")
+	}
+
+	srv.autoSyncOnce(t.Context(), "hash-B")
+
+	got, err = store.GetMember(t.Context(), rm.ID)
+	if err != nil {
+		t.Fatalf("GetMember: %v", err)
+	}
+	if got.LastConfigSyncAt == nil {
+		t.Fatal("a verified member with a timed-out push behind it was not stamped")
+	}
+	if got.LastConfigSyncReason != unconfirmedSyncReason {
+		t.Errorf("reason = %q, want %q", got.LastConfigSyncReason, unconfirmedSyncReason)
+	}
+}
+
+// TestAutoSync_RefusedPushDoesNotStampOnVerify: a 4xx is a definite refusal, so
+// no unconfirmed push is remembered. A member that later converges anyway (the
+// primary edited back to what it already held) is verified but NOT stamped:
+// Front Desk never wrote to it.
+func TestAutoSync_RefusedPushDoesNotStampOnVerify(t *testing.T) {
+	srv, store := newTestServer(t)
+	primary := newStubAutoMember(t, "ptoken")
+	primary.versionHash = "hash-B"
+	replica := newStubAutoMember(t, "rtoken")
+	replica.dryDiff = driftDiff
+	replica.realImportCode = http.StatusUnauthorized // definite refusal, nothing applied
+
+	pm, _ := store.CreateMember(t.Context(), "primary", primary.srv.URL, "ptoken")
+	rm, _ := store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken")
+	enableAutoSync(t, store, pm.ID)
+	alignFleetVersions(t, srv, store, "dev")
+
+	srv.autoSyncOnce(t.Context(), "hash-B")
+
+	// The member ends up holding the primary's config through no write of Front
+	// Desk's (a revert on the primary looks like this).
+	replica.setVersionHash("hash-B")
+	srv.autoSyncOnce(t.Context(), "hash-B")
+
+	got, err := store.GetMember(t.Context(), rm.ID)
+	if err != nil {
+		t.Fatalf("GetMember: %v", err)
+	}
+	if got.LastConfigSyncAt != nil {
+		t.Error("a refused push was stamped on convergence; Front Desk never wrote to this member")
+	}
+	if !memberVerified(srv, rm.ID) {
+		t.Error("the converged member was not verified in sync")
+	}
+}
+
+// TestAutoSync_ConfirmedStampClearsUnconfirmedPush: a lost push followed by a
+// confirmed one must not leave the flag behind, or the converged pass after the
+// confirmed sync would overwrite its honest stamp (timestamp AND reason) with the
+// unconfirmed-push wording.
+func TestAutoSync_ConfirmedStampClearsUnconfirmedPush(t *testing.T) {
+	srv, store := newTestServer(t)
+	primary := newStubAutoMember(t, "ptoken")
+	primary.versionHash = "hash-B"
+	replica := newStubAutoMember(t, "rtoken")
+	replica.dryDiff = driftDiff
+	replica.realImportCode = http.StatusGatewayTimeout // lost answer, nothing adopted
+
+	pm, _ := store.CreateMember(t.Context(), "primary", primary.srv.URL, "ptoken")
+	rm, _ := store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken")
+	enableAutoSync(t, store, pm.ID)
+	alignFleetVersions(t, srv, store, "dev")
+
+	srv.autoSyncOnce(t.Context(), "hash-B") // lost push: flag set, no stamp
+
+	// The lost push is rate-limited like a timeout; drop the timer so the next
+	// pass may push again, as a primary edit would.
+	srv.resetIncompleteRetries()
+	replica.mu.Lock()
+	replica.realImportCode = 0
+	replica.mu.Unlock()
+	replica.setAppliedHash("hash-B")
+
+	srv.autoSyncOnce(t.Context(), "hash-B") // confirmed push: honest stamp, flag cleared
+
+	got, err := store.GetMember(t.Context(), rm.ID)
+	if err != nil {
+		t.Fatalf("GetMember: %v", err)
+	}
+	if got.LastConfigSyncReason != autoSyncReason {
+		t.Fatalf("reason = %q, want %q from the confirmed push", got.LastConfigSyncReason, autoSyncReason)
+	}
+
+	// The converged pass must leave the confirmed stamp alone: prove it with a
+	// sentinel it would overwrite if the flag had survived.
+	if err := store.SetMemberLastSync(t.Context(), rm.ID, time.Now().UTC(), "sentinel"); err != nil {
+		t.Fatalf("SetMemberLastSync: %v", err)
+	}
+	srv.autoSyncOnce(t.Context(), "hash-B")
+	got, err = store.GetMember(t.Context(), rm.ID)
+	if err != nil {
+		t.Fatalf("GetMember: %v", err)
+	}
+	if got.LastConfigSyncReason != "sentinel" {
+		t.Errorf("reason = %q, want the sentinel: a confirmed stamp must clear the unconfirmed-push flag", got.LastConfigSyncReason)
+	}
+}
+
+// TestAutoSync_IncompleteStampClearsUnconfirmedPush: the incomplete arm stamps
+// too (the member committed the config), so it must clear the flag for the same
+// reason as the OK arm.
+func TestAutoSync_IncompleteStampClearsUnconfirmedPush(t *testing.T) {
+	srv, store := newTestServer(t)
+	primary := newStubAutoMember(t, "ptoken")
+	primary.versionHash = "hash-B"
+	replica := newStubAutoMember(t, "rtoken")
+	replica.dryDiff = driftDiff
+	replica.realImportCode = http.StatusBadGateway // lost answer, nothing adopted
+
+	pm, _ := store.CreateMember(t.Context(), "primary", primary.srv.URL, "ptoken")
+	rm, _ := store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken")
+	enableAutoSync(t, store, pm.ID)
+	alignFleetVersions(t, srv, store, "dev")
+
+	srv.autoSyncOnce(t.Context(), "hash-B") // lost push: flag set
+
+	srv.resetIncompleteRetries()
+	replica.mu.Lock()
+	replica.realImportCode = 0
+	replica.incompleteImport = true // commits, but cannot build a group
+	replica.mu.Unlock()
+
+	srv.autoSyncOnce(t.Context(), "hash-B") // incomplete apply: stamps, must clear the flag
+
+	got, err := store.GetMember(t.Context(), rm.ID)
+	if err != nil {
+		t.Fatalf("GetMember: %v", err)
+	}
+	if got.LastConfigSyncAt == nil {
+		t.Fatal("an incomplete apply did not stamp; the member committed the config")
+	}
+
+	// The member later comes to hold the primary's config. With the flag cleared
+	// the converged pass must not restamp; overwrite with a sentinel to see.
+	if err := store.SetMemberLastSync(t.Context(), rm.ID, time.Now().UTC(), "sentinel"); err != nil {
+		t.Fatalf("SetMemberLastSync: %v", err)
+	}
+	replica.setVersionHash("hash-B")
+	srv.autoSyncOnce(t.Context(), "hash-B")
+	got, err = store.GetMember(t.Context(), rm.ID)
+	if err != nil {
+		t.Fatalf("GetMember: %v", err)
+	}
+	if got.LastConfigSyncReason != "sentinel" {
+		t.Errorf("reason = %q, want the sentinel: an incomplete apply's stamp must clear the unconfirmed-push flag", got.LastConfigSyncReason)
+	}
+}
+
+// TestAutoSync_FailedVerifyStampKeepsFlag: a converged measurement whose stamp
+// write fails must keep the flag, so the next converged pass retries the stamp
+// instead of losing it forever.
+func TestAutoSync_FailedVerifyStampKeepsFlag(t *testing.T) {
+	srv, store := newTestServer(t)
+	replica := newStubAutoMember(t, "rtoken")
+	replica.versionHash = "hash-B"
+	rm, _ := store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken")
+
+	srv.markUnconfirmedPush(rm.ID, "hash-B")
+	// Delete the row so the in-memory member still resolves for the hash read
+	// while SetMemberLastSync affects zero rows and errors (the same seam as
+	// TestConfigSyncStampFailureFailsResult).
+	if err := store.DeleteMember(t.Context(), rm.ID); err != nil {
+		t.Fatalf("delete member: %v", err)
+	}
+
+	converged, measured := srv.measureMember(t.Context(), t.Context(), rm, "rtoken", "hash-B")
+	if !converged || !measured {
+		t.Fatalf("converged=%v measured=%v, want both true", converged, measured)
+	}
+	if !srv.hasUnconfirmedPush(rm.ID, "hash-B") {
+		t.Error("the flag was dropped on a failed stamp write; the next converged pass has nothing left to retry")
 	}
 }
 
@@ -1580,7 +1873,7 @@ func TestAutoSync_IncompleteMemberIsNotConverged(t *testing.T) {
 		`"incomplete":true,"unapplied":["ds4flash","glm52"],"diff":{}}`
 	rm, _ := store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken")
 
-	res := srv.applyMemberConfig(t.Context(), rm, "rtoken", []byte(fleetExportWithKey), "test", false, 0)
+	res := srv.applyMemberConfig(t.Context(), rm, "rtoken", []byte(fleetExportWithKey), "test", false, 0, "")
 
 	if res.OK {
 		t.Fatal("OK = true, want false: the member did not fully apply the config")
@@ -1613,7 +1906,7 @@ func TestAutoSync_ResponseWithoutIncompleteFieldReadsAsApplied(t *testing.T) {
 	replica.importBody = `{"schema_version_ok":true,"master_key_ok":true,"applied":true,"diff":{}}`
 	rm, _ := store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken")
 
-	res := srv.applyMemberConfig(t.Context(), rm, "rtoken", []byte(fleetExportWithKey), "test", false, 0)
+	res := srv.applyMemberConfig(t.Context(), rm, "rtoken", []byte(fleetExportWithKey), "test", false, 0, "")
 
 	if !res.OK {
 		t.Fatalf("OK = false (%s), want true: an older member omits the field", res.Error)
@@ -1632,7 +1925,7 @@ func TestAutoSync_IncompleteWithEmptyUnappliedHasSensibleMessage(t *testing.T) {
 	replica.importBody = `{"schema_version_ok":true,"master_key_ok":true,"applied":true,"incomplete":true,"diff":{}}`
 	rm, _ := store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken")
 
-	res := srv.applyMemberConfig(t.Context(), rm, "rtoken", []byte(fleetExportWithKey), "test", false, 0)
+	res := srv.applyMemberConfig(t.Context(), rm, "rtoken", []byte(fleetExportWithKey), "test", false, 0, "")
 
 	if res.OK {
 		t.Fatal("OK = true, want false: the member did not fully apply the config")
@@ -2551,11 +2844,11 @@ func TestConfigSync_WizardStampsVerifiedOnItsOwnWrite(t *testing.T) {
 
 	// emitSuccessEvent true is the wizard's call; false is the auto-syncer's.
 	if res := srv.applyMemberConfig(t.Context(), wm, "wtoken", []byte(fleetExportWithKey),
-		manualSyncReason("the dashboard"), true, 0); !res.OK {
+		manualSyncReason("the dashboard"), true, 0, ""); !res.OK {
 		t.Fatalf("wizard sync OK = false (%s), want true", res.Error)
 	}
 	if res := srv.applyMemberConfig(t.Context(), am, "atoken", []byte(fleetExportWithKey),
-		autoSyncReason, false, 0); !res.OK {
+		autoSyncReason, false, 0, ""); !res.OK {
 		t.Fatalf("auto sync OK = false (%s), want true", res.Error)
 	}
 

--- a/internal/frontdesk/configsync.go
+++ b/internal/frontdesk/configsync.go
@@ -70,9 +70,10 @@ type syncResultItem struct {
 	TimedOut bool `json:"-"`
 	// Unconfirmed marks a push whose answer was lost in either of the two ways a
 	// still-running import looks like a failure from here: the deadline expired
-	// (TimedOut), or a 5xx came back, which a reverse proxy answers mid-import
-	// when the member outlives ITS deadline. The import may have landed, so the
-	// auto-sync loop rate-limits the re-push the same way it does a timeout
+	// (TimedOut), or a 5xx came back that can stand in front of a live import (a
+	// gateway timeout, or another 5xx after the call ran long enough for a proxy
+	// deadline to have cut it; see lostAnswer5xx). The import may have landed, so
+	// the auto-sync loop rate-limits the re-push the same way it does a timeout
 	// instead of restarting the member's import every tick. Not on the wire.
 	Unconfirmed bool `json:"-"`
 }
@@ -298,6 +299,9 @@ func (s *Server) recordFleetSyncRun(ctx context.Context, primary *Member, result
 // comparison. Failure events fire either way.
 func (s *Server) applyMemberConfig(ctx context.Context, m *Member, token string, export []byte, reason string, emitSuccessEvent bool, sourceGen int64, pushedHash string) syncResultItem {
 	res := syncResultItem{MemberID: m.ID, Name: m.Name}
+	// How long the push ran separates a 5xx that cut a live import from one the
+	// answerer had at hand (see lostAnswer5xx).
+	pushStart := time.Now()
 	out, status, err := s.pushMemberImport(ctx, m, token, export, false, sourceGen)
 	// Carried on the success path too: neither a group built short nor a disable
 	// the member has no model for is a failure to apply, so neither reaches the
@@ -323,14 +327,14 @@ func (s *Server) applyMemberConfig(ctx context.Context, m *Member, token string,
 		// The member answered, just with a status we cannot apply: surface it so a
 		// wrong stored token or a member-side error is not mislabeled "offline".
 		res.Error = fmt.Sprintf("this member rejected the request (HTTP %d)", status)
-		if status >= http.StatusInternalServerError {
-			// A 5xx is not proof the import failed: a reverse proxy between Front
+		if lostAnswer5xx(status, time.Since(pushStart)) {
+			// This 5xx is not proof the import failed: a reverse proxy between Front
 			// Desk and the member answers 502/504 when the import outlives its own
-			// read timeout, with the member still applying behind it. A 4xx is a
-			// definite refusal (auth, schema) and gets no such benefit. The hash
-			// binding covers the other 5xx source, the member's own import erroring
-			// before commit: nothing landed there, so it can only converge on this
-			// exact hash through an operator restoring precisely this config.
+			// read timeout, with the member still applying behind it. The hash
+			// binding covers the other slow 5xx source, the member's own import
+			// erroring before commit: nothing landed there, so it can only converge
+			// on this exact hash through an operator restoring precisely this config.
+			res.Error = fmt.Sprintf("this member's answer was lost (HTTP %d); it may still be applying", status)
 			res.Unconfirmed = true
 			s.markUnconfirmedPush(m.ID, pushedHash)
 		}
@@ -374,8 +378,9 @@ func (s *Server) applyMemberConfig(ctx context.Context, m *Member, token string,
 		if err := s.store.SetMemberLastSync(ctx, m.ID, time.Now().UTC(), reason); err != nil {
 			debuglog.Warn("frontdesk: stamp member last-sync", "member", m.Name, "error", err)
 		} else {
-			// This stamp supersedes any earlier push whose answer was lost.
-			s.clearUnconfirmedPush(m.ID)
+			// This stamp covers a lost-answer push of this same config; a concurrent
+			// push of newer config keeps its own flag (see clearUnconfirmedPush).
+			s.clearUnconfirmedPush(m.ID, pushedHash)
 		}
 		// This arm returns before the shared failure branch below, so without this an
 		// incomplete apply would leave no trace in the logs when alerting is off.
@@ -394,8 +399,9 @@ func (s *Server) applyMemberConfig(ctx context.Context, m *Member, token string,
 			res.OK = false
 			res.Error = "applied but could not record the sync stamp"
 		} else {
-			// This stamp supersedes any earlier push whose answer was lost.
-			s.clearUnconfirmedPush(m.ID)
+			// This stamp covers a lost-answer push of this same config; a concurrent
+			// push of newer config keeps its own flag (see clearUnconfirmedPush).
+			s.clearUnconfirmedPush(m.ID, pushedHash)
 		}
 	}
 
@@ -422,24 +428,28 @@ func (s *Server) applyMemberConfig(ctx context.Context, m *Member, token string,
 	} else {
 		recordConfigSync("err")
 		debuglog.Warn("frontdesk: config sync failed", "member", m.Name, "error", res.Error)
-		// A timed-out push is published at info, not warning. The type stays the same,
-		// because it is still the outcome of a push that did not converge the member
-		// and belongs in the same log, but alert dispatch derives its notification
-		// severity from the live event, and paging an operator at warning for a
-		// condition this very message describes as probably fine is noise. The caller
-		// agrees with the message: it stamps the push as received and rate-limits the
-		// re-push on exactly that reading. A member that is genuinely refusing, or
-		// unreachable, or mismatched, still warns.
+		// An unconfirmed push (timed out, or 5xx'd in a way that can stand in front
+		// of a live import) is published at info, not warning. The type stays the
+		// same, because it is still the outcome of a push that did not converge the
+		// member and belongs in the same log, but alert dispatch derives its
+		// notification severity from the live event, and paging an operator at
+		// warning for a condition this very message describes as probably fine is
+		// noise. The caller agrees with the message: it stamps the push as received
+		// and rate-limits the re-push on exactly that reading. A member that is
+		// genuinely refusing, or unreachable, or mismatched, still warns.
 		severity := "warning"
-		if res.TimedOut {
+		if res.Unconfirmed {
 			severity = "info"
 		}
 		s.emit(ctx, Event{
 			Type: "config.sync_failed", Severity: severity, Source: "frontdesk",
 			Message: syncFailureMessage(m.Name, res.Error, res.TimedOut), MemberID: m.ID,
-			// error carries the specific cause the message renders; timed_out is always
-			// present so a consumer reads one shape rather than testing for the key.
-			Metadata: map[string]any{"reason": reason, "error": res.Error, "timed_out": res.TimedOut},
+			// error carries the specific cause the message renders; timed_out and
+			// unconfirmed are always present so a consumer reads one shape rather than
+			// testing for the keys. unconfirmed is what separates a lost answer, which
+			// is rate-limited and may prove itself landed on a later verification pass,
+			// from a genuine rejection.
+			Metadata: map[string]any{"reason": reason, "error": res.Error, "timed_out": res.TimedOut, "unconfirmed": res.Unconfirmed},
 		})
 	}
 	return res
@@ -501,6 +511,33 @@ func isTimeout(err error) bool {
 		return true
 	}
 	return errors.Is(err, context.DeadlineExceeded)
+}
+
+// unconfirmed5xxFloor is how long a real import call must have run for a 5xx
+// other than 504 to be read as a proxy giving up on a live import rather than a
+// refusal the answerer already had at hand. A reverse proxy only 5xxes a live
+// import once its own read timeout expires, 30-60s at the low end, while a
+// connection-refused 502 (the member's process is down) or an immediate
+// member-side 500 answers within milliseconds.
+const unconfirmed5xxFloor = 10 * time.Second
+
+// lostAnswer5xx reports whether a 5xx answer to a real import may be standing
+// in front of an import that is still running member-side, making it a lost
+// answer rather than a refusal. A 4xx is a definite refusal (auth, schema) and
+// never qualifies.
+//
+// 504 qualifies on its own: a gateway timeout means an intermediary waited for
+// the member and gave up, however long that wait was configured to be. Any
+// other 5xx qualifies only after unconfirmed5xxFloor: an instant 502/500
+// cannot mean "still importing" — it is a proxy whose upstream is down, or a
+// member handler erroring on the spot — and treating it as maybe-landed would
+// rate-limit the re-push (see applyAutoSync) for a push that demonstrably did
+// nothing, where retrying next tick is right.
+func lostAnswer5xx(status int, elapsed time.Duration) bool {
+	if status == http.StatusGatewayTimeout {
+		return true
+	}
+	return status >= http.StatusInternalServerError && elapsed >= unconfirmed5xxFloor
 }
 
 // maxMemberConfigExportBody is the read limit for a member's config envelope. It

--- a/internal/frontdesk/configsync.go
+++ b/internal/frontdesk/configsync.go
@@ -68,6 +68,13 @@ type syncResultItem struct {
 	// like from here. Not on the wire: it only tells the auto-sync loop the member
 	// did receive the config, so the re-push is rate-limited.
 	TimedOut bool `json:"-"`
+	// Unconfirmed marks a push whose answer was lost in either of the two ways a
+	// still-running import looks like a failure from here: the deadline expired
+	// (TimedOut), or a 5xx came back, which a reverse proxy answers mid-import
+	// when the member outlives ITS deadline. The import may have landed, so the
+	// auto-sync loop rate-limits the re-push the same way it does a timeout
+	// instead of restarting the member's import every tick. Not on the wire.
+	Unconfirmed bool `json:"-"`
 }
 
 // memberImportResult mirrors internal/api.importResponse so Front Desk can read
@@ -175,6 +182,16 @@ func (s *Server) configSync(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// The primary's config hash keys any lost-answer push so a later verification
+	// pass can stamp it (see unconfirmedSync). Best-effort: with the hash
+	// unreadable the run proceeds and a lost answer simply stays unstamped, since
+	// a stamp that cannot be tied to the pushed config must not be promised.
+	pushedHash, err := s.fetchMemberConfigVersion(ctx, primary, primaryToken)
+	if err != nil {
+		debuglog.Debug("frontdesk: config sync: read primary config hash", "member", primary.Name, "error", err)
+		pushedHash = ""
+	}
+
 	primaryVer := s.poller.MemberVersion(primary.ID)
 	results := make([]syncResultItem, 0)
 	for _, m := range members {
@@ -201,7 +218,7 @@ func (s *Server) configSync(w http.ResponseWriter, r *http.Request) {
 			results = append(results, *item)
 			continue
 		}
-		results = append(results, s.applyMemberConfig(ctx, m, token, export, reason, true, gen))
+		results = append(results, s.applyMemberConfig(ctx, m, token, export, reason, true, gen, pushedHash))
 	}
 	s.recordFleetSyncRun(ctx, primary, results)
 	writeJSON(w, http.StatusOK, map[string]any{"primary_id": primary.ID, "results": results})
@@ -279,7 +296,7 @@ func (s *Server) recordFleetSyncRun(ctx context.Context, primary *Member, result
 // heartbeat moves with the write. The auto-syncer sets it false: it emits one
 // roll-up rather than toasting per member, and takes its heartbeat from its own hash
 // comparison. Failure events fire either way.
-func (s *Server) applyMemberConfig(ctx context.Context, m *Member, token string, export []byte, reason string, emitSuccessEvent bool, sourceGen int64) syncResultItem {
+func (s *Server) applyMemberConfig(ctx context.Context, m *Member, token string, export []byte, reason string, emitSuccessEvent bool, sourceGen int64, pushedHash string) syncResultItem {
 	res := syncResultItem{MemberID: m.ID, Name: m.Name}
 	out, status, err := s.pushMemberImport(ctx, m, token, export, false, sourceGen)
 	// Carried on the success path too: neither a group built short nor a disable
@@ -296,12 +313,27 @@ func (s *Server) applyMemberConfig(ctx context.Context, m *Member, token string,
 		// member-side discovery.
 		res.Error = "this member did not answer in time"
 		res.TimedOut = true
+		res.Unconfirmed = true
+		// No stamp lands below, but the import may still complete member-side; the
+		// pass that measures the member holding this exact config stamps it then.
+		s.markUnconfirmedPush(m.ID, pushedHash)
 	case err != nil && status == 0:
 		res.Error = "could not reach this member"
 	case err != nil:
 		// The member answered, just with a status we cannot apply: surface it so a
 		// wrong stored token or a member-side error is not mislabeled "offline".
 		res.Error = fmt.Sprintf("this member rejected the request (HTTP %d)", status)
+		if status >= http.StatusInternalServerError {
+			// A 5xx is not proof the import failed: a reverse proxy between Front
+			// Desk and the member answers 502/504 when the import outlives its own
+			// read timeout, with the member still applying behind it. A 4xx is a
+			// definite refusal (auth, schema) and gets no such benefit. The hash
+			// binding covers the other 5xx source, the member's own import erroring
+			// before commit: nothing landed there, so it can only converge on this
+			// exact hash through an operator restoring precisely this config.
+			res.Unconfirmed = true
+			s.markUnconfirmedPush(m.ID, pushedHash)
+		}
 	case !out.SchemaVersionOK:
 		// Schema is checked before MASTER_KEY: a 422 short-circuits before the
 		// canary, leaving master_key_ok an unevaluated false (see previewMemberConfig).
@@ -341,6 +373,9 @@ func (s *Server) applyMemberConfig(ctx context.Context, m *Member, token string,
 		// reported diverged either way.
 		if err := s.store.SetMemberLastSync(ctx, m.ID, time.Now().UTC(), reason); err != nil {
 			debuglog.Warn("frontdesk: stamp member last-sync", "member", m.Name, "error", err)
+		} else {
+			// This stamp supersedes any earlier push whose answer was lost.
+			s.clearUnconfirmedPush(m.ID)
 		}
 		// This arm returns before the shared failure branch below, so without this an
 		// incomplete apply would leave no trace in the logs when alerting is off.
@@ -358,6 +393,9 @@ func (s *Server) applyMemberConfig(ctx context.Context, m *Member, token string,
 			debuglog.Warn("frontdesk: stamp member last-sync", "member", m.Name, "error", err)
 			res.OK = false
 			res.Error = "applied but could not record the sync stamp"
+		} else {
+			// This stamp supersedes any earlier push whose answer was lost.
+			s.clearUnconfirmedPush(m.ID)
 		}
 	}
 

--- a/internal/frontdesk/configsync_test.go
+++ b/internal/frontdesk/configsync_test.go
@@ -485,7 +485,7 @@ func TestConfigSyncStampFailureFailsResult(t *testing.T) {
 	okBefore := configSyncCount(t, srv, "ok")
 	errBefore := configSyncCount(t, srv, "err")
 
-	res := srv.applyMemberConfig(t.Context(), rm, "rtoken", []byte(fleetExportWithKey), "test", true, 1)
+	res := srv.applyMemberConfig(t.Context(), rm, "rtoken", []byte(fleetExportWithKey), "test", true, 1, "")
 	if res.OK || res.Error == "" {
 		t.Fatalf("stamp failure must fail the result, got OK=%v err=%q", res.OK, res.Error)
 	}
@@ -719,7 +719,7 @@ func TestAutoSync_FailedModelReconcileDoesNotBlameFailoverGroups(t *testing.T) {
 		`"incomplete":true,"model_state_failed":true,"diff":{}}`
 	rm, _ := store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken")
 
-	res := srv.applyMemberConfig(t.Context(), rm, "rtoken", []byte(fleetExportWithKey), "test", false, 0)
+	res := srv.applyMemberConfig(t.Context(), rm, "rtoken", []byte(fleetExportWithKey), "test", false, 0, "")
 
 	if !res.Incomplete {
 		t.Fatal("Incomplete = false, want true")
@@ -745,7 +745,7 @@ func TestAutoSync_TimedOutPushIsNotPagedAsAFailure(t *testing.T) {
 		rm, _ := store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken")
 		srv.syncClient = newProbeClient(60 * time.Millisecond)
 
-		srv.applyMemberConfig(t.Context(), rm, "rtoken", []byte(fleetExportWithKey), "test", false, 0)
+		srv.applyMemberConfig(t.Context(), rm, "rtoken", []byte(fleetExportWithKey), "test", false, 0, "")
 
 		evs, _, err := store.ListEvents(t.Context(), EventFilter{Type: "config.sync_failed"})
 		if err != nil {
@@ -765,7 +765,7 @@ func TestAutoSync_TimedOutPushIsNotPagedAsAFailure(t *testing.T) {
 		replica.importCode = http.StatusInternalServerError
 		rm, _ := store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken")
 
-		srv.applyMemberConfig(t.Context(), rm, "rtoken", []byte(fleetExportWithKey), "test", false, 0)
+		srv.applyMemberConfig(t.Context(), rm, "rtoken", []byte(fleetExportWithKey), "test", false, 0, "")
 
 		evs, _, err := store.ListEvents(t.Context(), EventFilter{Type: "config.sync_failed"})
 		if err != nil {

--- a/internal/frontdesk/configsync_test.go
+++ b/internal/frontdesk/configsync_test.go
@@ -757,12 +757,42 @@ func TestAutoSync_TimedOutPushIsNotPagedAsAFailure(t *testing.T) {
 		if evs[0].Severity != "info" {
 			t.Errorf("severity = %q, want info: the member is very likely still importing", evs[0].Severity)
 		}
+		if evs[0].Metadata["unconfirmed"] != true {
+			t.Errorf("metadata unconfirmed = %v, want true: a timed-out push is a lost answer", evs[0].Metadata["unconfirmed"])
+		}
+	})
+
+	t.Run("a gateway timeout is info", func(t *testing.T) {
+		srv, store := newTestServer(t)
+		replica := newStubConfigMember(t, "rtoken")
+		replica.importCode = http.StatusGatewayTimeout // a proxy waited on the member and gave up
+		rm, _ := store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken")
+
+		srv.applyMemberConfig(t.Context(), rm, "rtoken", []byte(fleetExportWithKey), "test", false, 0, "")
+
+		evs, _, err := store.ListEvents(t.Context(), EventFilter{Type: "config.sync_failed"})
+		if err != nil {
+			t.Fatalf("ListEvents: %v", err)
+		}
+		if len(evs) != 1 {
+			t.Fatalf("config.sync_failed events = %d, want 1", len(evs))
+		}
+		if evs[0].Severity != "info" {
+			t.Errorf("severity = %q, want info: a proxy cut a live import, the member is very likely still applying", evs[0].Severity)
+		}
+		if evs[0].Metadata["timed_out"] != false || evs[0].Metadata["unconfirmed"] != true {
+			t.Errorf("metadata timed_out = %v, unconfirmed = %v; a consumer must be able to tell a lost answer from a rejection",
+				evs[0].Metadata["timed_out"], evs[0].Metadata["unconfirmed"])
+		}
+		if !strings.Contains(evs[0].Message, "may still be applying") {
+			t.Errorf("message = %q, want it to say the member may still be applying, not that it rejected the push", evs[0].Message)
+		}
 	})
 
 	t.Run("a refusal still warns", func(t *testing.T) {
 		srv, store := newTestServer(t)
 		replica := newStubConfigMember(t, "rtoken")
-		replica.importCode = http.StatusInternalServerError
+		replica.importCode = http.StatusInternalServerError // instant: an error the member had at hand
 		rm, _ := store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken")
 
 		srv.applyMemberConfig(t.Context(), rm, "rtoken", []byte(fleetExportWithKey), "test", false, 0, "")
@@ -774,5 +804,33 @@ func TestAutoSync_TimedOutPushIsNotPagedAsAFailure(t *testing.T) {
 		if len(evs) != 1 || evs[0].Severity != "warning" {
 			t.Errorf("events = %+v, want one at warning", evs)
 		}
+		if len(evs) == 1 && evs[0].Metadata["unconfirmed"] != false {
+			t.Errorf("metadata unconfirmed = %v, want false: an instant 500 is a plain failure", evs[0].Metadata["unconfirmed"])
+		}
 	})
+}
+
+// TestLostAnswer5xx pins the boundary between a 5xx that may be standing in
+// front of a live import (a lost answer: unconfirmed, rate-limited, stamped on
+// verification) and one that is a plain failure retried next tick.
+func TestLostAnswer5xx(t *testing.T) {
+	tests := []struct {
+		name    string
+		status  int
+		elapsed time.Duration
+		want    bool
+	}{
+		{"instant 502: the proxy's upstream is down", http.StatusBadGateway, 10 * time.Millisecond, false},
+		{"instant 500: the member erred on the spot", http.StatusInternalServerError, 10 * time.Millisecond, false},
+		{"slow 502: a proxy cut a live import", http.StatusBadGateway, unconfirmed5xxFloor, true},
+		{"504 is an intermediary's timeout whatever the clock says", http.StatusGatewayTimeout, 0, true},
+		{"4xx is a definite refusal however slow", http.StatusUnauthorized, time.Minute, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := lostAnswer5xx(tc.status, tc.elapsed); got != tc.want {
+				t.Errorf("lostAnswer5xx(%d, %v) = %v, want %v", tc.status, tc.elapsed, got, tc.want)
+			}
+		})
+	}
 }

--- a/internal/frontdesk/memberapi.go
+++ b/internal/frontdesk/memberapi.go
@@ -100,7 +100,11 @@ const memberReadTimeout = 15 * time.Second
 // import runs model discovery on the member (live upstream calls), which easily
 // exceeds the 4s probe timeout, so the import client is given a far more generous
 // deadline; it is still capped so a hung member cannot stall the sync forever.
-const memberSyncTimeout = 120 * time.Second
+// Sized at ~1.5x the slowest import measured on a production member (2m34s on a
+// storage-bound box importing a many-hundred-model fleet config); any reverse
+// proxy between Front Desk and a member needs a read timeout at least this long,
+// or the proxy fails the push while the member is still applying it.
+const memberSyncTimeout = 240 * time.Second
 
 // tokenProbe is the outcome of checking a member's admin token at add/edit time,
 // before the background poller would otherwise catch a mistake.

--- a/internal/frontdesk/server.go
+++ b/internal/frontdesk/server.go
@@ -89,6 +89,17 @@ type Server struct {
 	// incompleteState). In-memory and bounded by fleet size, like syncHeld.
 	syncIncompleteMu sync.Mutex
 	syncIncomplete   map[string]incompleteState
+	// unconfirmedSync maps a member to the primary config hash of its latest real
+	// push that got no usable answer (relay deadline expired, or a 5xx from the
+	// member or a proxy in front of it) and so was never stamped as a sync, even
+	// though the import may have completed member-side. The pass that later
+	// measures the member holding exactly that hash stamps the last-sync marker
+	// then (see measureMember); the hash binding is what keeps a member that
+	// converged by any other route (a definite-failure 500 followed by an operator
+	// fix, a primary that moved on) from being stamped for a push that never
+	// landed. Guarded by syncIncompleteMu; in-memory and bounded by fleet size,
+	// like syncIncomplete.
+	unconfirmedSync map[string]string
 	// backupStale tracks which members have no database backup from the last
 	// memberBackupStaleAfter, so backup.stale fires once on the transition in and
 	// backup.recovered once on the way out. In-memory and bounded by fleet size,
@@ -146,28 +157,29 @@ func NewServer(cfg ServerConfig) *Server {
 	}
 
 	s := &Server{
-		store:          cfg.Store,
-		poller:         cfg.Poller,
-		bus:            cfg.Bus,
-		adminMgr:       cfg.AdminMgr,
-		sessionMgr:     sessionMgr,
-		totpRepo:       totpRepo,
-		totpStatus:     newTotpEnabledCache(totpRepo),
-		probe:          newProbeClient(httpProbeTimeout),
-		readClient:     newProbeClient(memberReadTimeout),
-		syncClient:     newProbeClient(memberSyncTimeout),
-		backupClient:   newProbeClient(memberBackupTimeout),
-		lbPort:         lbPort,
-		version:        version,
-		masterKey:      cfg.MasterKey,
-		metricsToken:   strings.TrimSpace(cfg.MetricsToken), // whitespace-only is treated as unset, not a live bearer
-		pairing:        newPairingCodes(),
-		ipLimiter:      cfg.IPLimiter,
-		rearmCh:        make(chan struct{}),
-		syncHeld:       make(map[string]bool),
-		syncIncomplete: make(map[string]incompleteState),
-		backupStale:    make(map[string]bool),
-		startedAt:      time.Now(),
+		store:           cfg.Store,
+		poller:          cfg.Poller,
+		bus:             cfg.Bus,
+		adminMgr:        cfg.AdminMgr,
+		sessionMgr:      sessionMgr,
+		totpRepo:        totpRepo,
+		totpStatus:      newTotpEnabledCache(totpRepo),
+		probe:           newProbeClient(httpProbeTimeout),
+		readClient:      newProbeClient(memberReadTimeout),
+		syncClient:      newProbeClient(memberSyncTimeout),
+		backupClient:    newProbeClient(memberBackupTimeout),
+		lbPort:          lbPort,
+		version:         version,
+		masterKey:       cfg.MasterKey,
+		metricsToken:    strings.TrimSpace(cfg.MetricsToken), // whitespace-only is treated as unset, not a live bearer
+		pairing:         newPairingCodes(),
+		ipLimiter:       cfg.IPLimiter,
+		rearmCh:         make(chan struct{}),
+		syncHeld:        make(map[string]bool),
+		syncIncomplete:  make(map[string]incompleteState),
+		unconfirmedSync: make(map[string]string),
+		backupStale:     make(map[string]bool),
+		startedAt:       time.Now(),
 	}
 
 	// Bind the scrape-time member-fleet collector to this server's store and

--- a/internal/frontdesk/server.go
+++ b/internal/frontdesk/server.go
@@ -90,8 +90,8 @@ type Server struct {
 	syncIncompleteMu sync.Mutex
 	syncIncomplete   map[string]incompleteState
 	// unconfirmedSync maps a member to the primary config hash of its latest real
-	// push that got no usable answer (relay deadline expired, or a 5xx from the
-	// member or a proxy in front of it) and so was never stamped as a sync, even
+	// push that got no usable answer (relay deadline expired, or a 5xx that can
+	// stand in front of a live import; see lostAnswer5xx) and so was never stamped as a sync, even
 	// though the import may have completed member-side. The pass that later
 	// measures the member holding exactly that hash stamps the last-sync marker
 	// then (see measureMember); the hash binding is what keeps a member that

--- a/internal/frontdesk/server_members.go
+++ b/internal/frontdesk/server_members.go
@@ -272,10 +272,10 @@ func (s *Server) deleteMember(w http.ResponseWriter, r *http.Request) {
 }
 
 // forgetMemberState drops the in-memory per-member state Front Desk keeps outside
-// the store: the version-skew hold, the config divergence, and the backup
-// staleness flag. All three are read against the live member list, so this is
-// hygiene rather than correctness: a re-added member starts clean, and the maps do
-// not grow with every member ever removed.
+// the store: the version-skew hold, the config divergence, the unconfirmed-push
+// hash, and the backup staleness flag. All are read against the live member list,
+// so this is hygiene rather than correctness: a re-added member starts clean, and
+// the maps do not grow with every member ever removed.
 func (s *Server) forgetMemberState(id string) {
 	s.syncHeldMu.Lock()
 	delete(s.syncHeld, id)
@@ -283,6 +283,7 @@ func (s *Server) forgetMemberState(id string) {
 
 	s.syncIncompleteMu.Lock()
 	delete(s.syncIncomplete, id)
+	delete(s.unconfirmedSync, id)
 	s.syncIncompleteMu.Unlock()
 
 	s.backupStaleMu.Lock()

--- a/wiki/High-Availability.md
+++ b/wiki/High-Availability.md
@@ -410,6 +410,15 @@ server {
 }
 ```
 
+If the member URLs you register in Front Desk also sit behind reverse proxies
+(each member's own dashboard hostname), give those proxies a read timeout of at
+least 240s (`proxy_read_timeout 240s;` in nginx, which defaults to 60s). A
+config sync push runs model discovery on the member and can legitimately take
+minutes on a slow box; Front Desk itself waits up to 240s, and a proxy that
+gives up earlier answers 502/504 while the member is still applying. Front Desk
+recovers on its own (the next verification pass detects the member converged and
+stamps the sync), but every long import gets reported as a failed push first.
+
 Set `FRONTDESK_PUBLIC_ORIGIN=https://frontdesk.example.com` and
 `FRONTDESK_TRUSTED_PROXIES` to the proxy's address in `.env`.
 


### PR DESCRIPTION
## Incident

After a fleet rebuild plus a provider disable on the primary, MH4's config import ran 2m34s. The reverse proxy in front of it gave up at ~90s (504), Front Desk's own relay deadline would have given up at 120s, and the push was reported as failed while the member finished applying behind the gateway. The next verification tick then correctly showed **Verified in sync** while **Last Config Sync** stayed hours old, since the write was never confirmed.

## Changes

**Timeouts** (commit 1)
- `memberSyncTimeout` 120s -> 240s: 1.5x the slowest import measured in production. Any reverse proxy fronting a member URL needs a read timeout to match; documented in the HA wiki (nginx defaults to 60s, which reproduces the incident).
- Bellhop's synchronous-sync read ceiling 180s -> 300s so one legitimately slow member still returns synchronously.

**Stamp on verified convergence** (commit 2)
- A real push whose answer is lost (relay timeout, or a 5xx: what a proxy answers mid-import) is recorded in an in-memory map keyed by member and the **pushed config hash**. When a later pass measures the member holding exactly that hash, the hash match proves the push landed, and `last_config_sync_at` is stamped then with reason "verified holding the primary's config after an unconfirmed push".
- The #357 honesty rule is preserved: an idle converged fleet never stamps, a 4xx refusal never stamps, and the hash binding prevents stamping on coincidental convergence (a definite member-side 500 with nothing committed, or a primary that moved on).
- Lost-answer pushes now count as sync attempts: rate-limited like timeouts (no more full re-import every 15s tick against a slow member) and the member turns amber via the divergence alert instead of reading as a green fleet.
- `autoSyncKickTimeout` 5m -> 15m so the enable-time pass covers several imports at the new deadline; removed members drop the new map entry with the rest of their in-memory state.

## Review

Adversarially reviewed by a second model before opening; its findings (flag not bound to the pushed config, 5xx treated as definite failure for retry purposes but not for stamping, member-removal cleanup, two unpinned clears, a flaky-margin test) are all addressed in commit 2, with regression tests for each.

Known pre-existing follow-up, out of scope here: the enable-time kick pass and the ticker have no mutual exclusion, so a kick import and a ticker import can overlap on the same member; the commit fence keeps this safe but wasteful, and the longer deadlines widen the window.

## Testing

- `go test ./internal/frontdesk ./internal/api` green locally; the six new tests also pass `-count=4 -race`.
- Pre-push diff coverage: 90/90 changed lines (100%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)