### PR TITLE
fix(ratelimit): expire a future fleet-divisor stamp; harden pnpm resolution

### DIFF
--- a/frontdesk/web/pnpm-workspace.yaml
+++ b/frontdesk/web/pnpm-workspace.yaml
@@ -10,6 +10,16 @@ packages: []
 # install/update/add; --frozen-lockfile CI installs are unaffected. pnpm >= 10.16.
 minimumReleaseAge: 1440
 
+# Supply-chain trust gates mirrored from web/pnpm-workspace.yaml (see there for
+# the rationale): reject a version that drops supply-chain trust rank relative to
+# the package's own history (the fingerprint of a stolen maintainer token), and
+# reject subdependencies resolved from git refs, tarball URLs or local paths
+# instead of a registry. Both gate fresh resolution only, so --frozen-lockfile CI
+# installs are unaffected. Verified against the pinned pnpm 10.33.
+trustPolicy: no-downgrade
+trustPolicyIgnoreAfter: 129600
+blockExoticSubdeps: true
+
 # Transitive build/lint-time dep pins mirrored from web/pnpm-workspace.yaml so
 # the same Dependabot advisories stay closed here. Remove each once a direct
 # dependency requires the patched range on its own.

--- a/internal/ratelimit/fleet_share.go
+++ b/internal/ratelimit/fleet_share.go
@@ -43,13 +43,25 @@ const fleetDivisorTTL = 24 * time.Hour
 // member is standalone, has been pulled from the fleet, or is under a control
 // plane too old to send the count — so the divisor reverts to 1 rather than
 // under-serve on a frozen fraction of the configured capacity.
+//
+// A timestamp in the future counts as untrustworthy, not as fresh: time.Since
+// returns a negative duration for it, which can never exceed the TTL, so a
+// future stamp would pin the divisor forever and defeat the self-expiry this
+// whole check exists to provide. The stamp is written member-locally from
+// time.Now (internal/api/fleet.go), so the only ways to get one are a backwards
+// clock jump or a direct settings write; both are cases where expiring is the
+// honest answer. The next announce writes a sane stamp and restores division.
 func fleetDivisor(ctx context.Context, s SettingsReader) int {
 	n := s.GetInt(ctx, settingsKeyFleetActiveMembers, 1)
 	if n <= 1 {
 		return 1
 	}
 	at := s.GetInt(ctx, settingsKeyFleetActiveMembersAt, 0)
-	if at == 0 || time.Since(time.Unix(int64(at), 0)) > fleetDivisorTTL {
+	if at == 0 {
+		return 1
+	}
+	// Negative age == future stamp; both ends of the range are untrustworthy.
+	if age := time.Since(time.Unix(int64(at), 0)); age < 0 || age > fleetDivisorTTL {
 		return 1
 	}
 	return n

--- a/internal/ratelimit/fleet_share_test.go
+++ b/internal/ratelimit/fleet_share_test.go
@@ -90,3 +90,29 @@ func TestFleetDivisor_StaleReverts(t *testing.T) {
 		t.Errorf("no-timestamp divisor = %d, want reverted 1", got)
 	}
 }
+
+func TestFleetDivisor_FutureStampReverts(t *testing.T) {
+	ctx := context.Background()
+
+	// A refresh stamp in the future makes time.Since negative, which can never
+	// exceed the TTL — so without an explicit guard the divisor would be pinned
+	// forever and the self-expiry would silently never fire. Treat it as stale.
+	s := newStubSettings()
+	setFleetActive(s, 3)
+	s.set(settingsKeyFleetActiveMembersAt, strconv.FormatInt(time.Now().Add(fleetDivisorTTL*10).Unix(), 10))
+	if got := fleetDivisor(ctx, s); got != 1 {
+		t.Errorf("future-stamp divisor = %d, want reverted 1", got)
+	}
+
+	// Even a stamp only slightly ahead (a backwards clock jump) expires rather
+	// than pinning: the next announce rewrites it from the local clock.
+	s.set(settingsKeyFleetActiveMembersAt, strconv.FormatInt(time.Now().Add(time.Hour).Unix(), 10))
+	if got := fleetDivisor(ctx, s); got != 1 {
+		t.Errorf("near-future-stamp divisor = %d, want reverted 1", got)
+	}
+
+	// And the shared TPM path inherits it: no division on an untrustworthy stamp.
+	if got := fleetShareTPM(ctx, s, 900); got != 900 {
+		t.Errorf("future-stamp shared tpm = %d, want undivided 900", got)
+	}
+}

--- a/web/pnpm-workspace.yaml
+++ b/web/pnpm-workspace.yaml
@@ -10,6 +10,32 @@ packages: []
 # exact lockfile versions and are unaffected. pnpm >= 10.16.
 minimumReleaseAge: 1440
 
+# Refuse a version whose supply-chain trust rank is lower than the ranks already
+# seen for that package (trusted-publisher > provenance attestation > neither).
+# That drop is the signature of a stolen maintainer token publishing outside the
+# package's normal CI: the release still looks like a routine bump, but arrives
+# without the attestation every prior release carried. Like the cooldown above it
+# only gates fresh resolution, so --frozen-lockfile CI installs are unaffected.
+# Verified against the pinned pnpm 10.33 (packageManager in package.json).
+trustPolicy: no-downgrade
+
+# Enforce that trust check only on releases younger than 90 days (129600 min).
+# The check is by publish date, not semver, so unscoped it also condemns the
+# pre-provenance long tail: a from-scratch resolve fails on semver@6.3.1 (2023,
+# transitive under @babel/core) purely because a later-published sibling carries
+# an attestation it predates. That is archaeology, not an incident. A real
+# takeover ships a *new* version, which is exactly what this window still
+# covers, and minimumReleaseAge above already holds the first 24h of it.
+trustPolicyIgnoreAfter: 129600
+
+# Refuse subdependencies resolved from anywhere but a registry (git refs, bare
+# tarball URLs, local paths). Direct dependencies here are all registry packages,
+# so an exotic spec appearing at depth > 0 means some transitive maintainer
+# started pulling code from a URL nobody in this repo reviewed. Checked only on
+# fresh resolution; entries replayed from the lockfile are skipped. Verified
+# against the pinned pnpm 10.33.
+blockExoticSubdeps: true
+
 # Force the transitive @babel/core (pulled in by eslint-plugin-react-hooks,
 # build/lint-time only) to a patched release. Fixes Dependabot advisory
 # GHSA-4x5r-pxfx-6jf8; 7.29.0 is the vulnerable pin. Remove once a direct


### PR DESCRIPTION
Two findings from a scanner batch that survived verification against the actual code. The other two in the batch were rejected (see below) and are not touched here.

## 1. Fleet divisor never expired on a future timestamp

`fleetDivisor` treated a future `_fleet_active_members_at` as permanently fresh. `time.Since` returns a *negative* duration for a future stamp, and a negative duration can never exceed `fleetDivisorTTL`, so the staleness check silently never fired and the divisor stayed pinned at whatever count was stored. That defeats the entire point of the timestamp, which exists so a persisted count stops throttling once the control plane stops managing this member.

The stamp is written member-locally from `time.Now()` (`internal/api/fleet.go:319`), so the only ways to get a future value are a backwards clock jump or a direct settings write. In both cases expiring is the honest answer, and the next announce writes a sane stamp and restores division.

Guard is now `age < 0 || age > fleetDivisorTTL`.

I deliberately did **not** take the other half of that report (allowlist-gating `settings.Set()` the way `SetTx()` does). The `_fleet_*` keys go through `Set` on purpose; gating it would break fleet announce.

## 2. pnpm supply-chain gates

Added to both `web/` and `frontdesk/web/`, alongside the existing `minimumReleaseAge` cooldown:

- **`trustPolicy: no-downgrade`** rejects a version whose supply-chain trust rank drops below what that package's own history already showed (trusted-publisher > provenance attestation > neither). That drop is the fingerprint of a stolen maintainer token publishing outside the package's normal CI: the release looks like a routine bump but arrives without the attestation every prior release carried.
- **`blockExoticSubdeps: true`** rejects subdependencies resolved from git refs, bare tarball URLs or local paths instead of a registry. Every direct dependency here is a registry package, so an exotic spec appearing at depth > 0 means some transitive maintainer started pulling code from a URL nobody in this repo reviewed.

**`trustPolicyIgnoreAfter: 129600`** (90 days) is the part worth reviewing. A bare `trustPolicy: no-downgrade` **breaks fresh resolution**: the check is by publish date, not semver, so it also condemns the pre-provenance long tail. A from-scratch resolve of `web/` dies with `ERR_PNPM_TRUST_DOWNGRADE` on `semver@6.3.1` (2023, transitive under `@babel/core`) purely for predating an attestation a later-published sibling carries. That is archaeology, not an incident. Scoping the check to recent releases keeps it aimed at where takeovers actually land, and `minimumReleaseAge` already holds the first 24h of that window.

Both gates apply to fresh resolution only. `--frozen-lockfile` skips resolution entirely, so CI installs are unaffected and no lockfile changes here.

## Verification

- `go test ./internal/ratelimit/...` — 137 pass. Pre-push diff coverage gate: **100% (4/4 lines)**.
- New `TestFleetDivisor_FutureStampReverts` was mutation-tested: reverting the `age < 0` guard fails all three assertions (divisor 3 instead of 1, shared TPM 300 instead of 900).
- `golangci-lint run ./cmd/... ./internal/...` — 0 issues.
- pnpm gates verified by *actually resolving from scratch* in a scratch copy (`rm pnpm-lock.yaml && pnpm install --lockfile-only`), for both workspaces, since a `--frozen-lockfile` install proves nothing about them. That is how the `semver@6.3.1` failure above was found.

## Rejected from the same batch, for the record

- **Reordering the TOTP check after token validation in `/api/auth/admin-exchange`** — reported as a TOTP-status oracle. It is not one: `GET /api/totp/status` is mounted outside the authed group (`internal/adminauth/totp.go:90`) and returns `{"enabled":true}` unauthenticated *by design*, because the login UI polls it to decide whether to show the TOTP field. Worse, the proposed reorder would turn the exchange into an admin-token **validity oracle** queryable without the second factor, which is strictly worse than today's short-circuit. The current ordering is deliberate and commented in both handler copies.
- **Moving `DOCKERHUB_IMAGE` from workflow-level to job-level `env:`** — the interpolated `DOCKERHUB_USERNAME` is published in `DOCKERHUB.md` (`hugalafutro/model-hotel:latest`) in this public repo, so it is not a secret. Both workflows also have exactly one job, so the move changes exposure by nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)