### PR TITLE
fix: refresh on fleet./traefik./settings. SSE events (Bellhop dashboard + FD Members page)

### DIFF
--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModel.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModel.kt
@@ -857,15 +857,18 @@ class DashboardViewModel(
                 (current * 2).coerceAtMost(SSE_BACKOFF_MAX_MS)
             }
 
-        // triggersRefresh mirrors the Front Desk web dashboard: only membership,
-        // config, health, and version events change what a member card shows, so
-        // only those warrant a refetch. Other events (alerts, traefik notices) ride
+        // triggersRefresh mirrors the Front Desk web Members page: membership,
+        // config, health, and version events change what a member card shows, and
+        // fleet/traefik events move the server fleet-state summary the dashboard
+        // renders, so all of those warrant a refetch. Other events (alerts) ride
         // the same stream but the dashboard ignores them. internal so the filter can
         // be unit-tested directly without driving the whole stream.
         internal fun triggersRefresh(type: String): Boolean =
             type.startsWith("member.") ||
                 type.startsWith("config.") ||
                 type.startsWith("health.") ||
-                type.startsWith("version.")
+                type.startsWith("version.") ||
+                type.startsWith("fleet.") ||
+                type.startsWith("traefik.")
     }
 }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModel.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModel.kt
@@ -858,17 +858,20 @@ class DashboardViewModel(
             }
 
         // triggersRefresh mirrors the Front Desk web Members page: membership,
-        // config, health, and version events change what a member card shows, and
-        // fleet/traefik events move the server fleet-state summary the dashboard
-        // renders, so all of those warrant a refetch. Other events (alerts) ride
-        // the same stream but the dashboard ignores them. internal so the filter can
-        // be unit-tested directly without driving the whole stream.
+        // config, health, and version events change what a member card shows,
+        // fleet/traefik events move the server fleet-state summary, and
+        // settings events carry the auto-sync toggle and primary repoints,
+        // all state the dashboard renders, so each warrants a refetch. Device
+        // and backup events ride the same stream but nothing on the dashboard
+        // shows them. internal so the filter can be unit-tested directly
+        // without driving the whole stream.
         internal fun triggersRefresh(type: String): Boolean =
             type.startsWith("member.") ||
                 type.startsWith("config.") ||
                 type.startsWith("health.") ||
                 type.startsWith("version.") ||
                 type.startsWith("fleet.") ||
-                type.startsWith("traefik.")
+                type.startsWith("traefik.") ||
+                type.startsWith("settings.")
     }
 }

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModelTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModelTest.kt
@@ -791,14 +791,16 @@ class DashboardViewModelTest {
 
     @Test
     fun triggersRefreshOnlyForRenderedEventFamilies() {
-        // Only membership/config/health/version events change a member card; alerts
-        // and traefik notices ride the same stream but must not trigger a refetch.
+        // Membership/config/health/version events change a member card, and
+        // fleet/traefik events move the fleet-state summary; alerts ride the same
+        // stream but must not trigger a refetch.
         assertTrue(DashboardViewModel.triggersRefresh("member.added"))
         assertTrue(DashboardViewModel.triggersRefresh("config.auto_synced"))
         assertTrue(DashboardViewModel.triggersRefresh("health.down"))
         assertTrue(DashboardViewModel.triggersRefresh("version.fetch_failed"))
+        assertTrue(DashboardViewModel.triggersRefresh("fleet.state_changed"))
+        assertTrue(DashboardViewModel.triggersRefresh("traefik.stale"))
         assertFalse(DashboardViewModel.triggersRefresh("alert.fired"))
-        assertFalse(DashboardViewModel.triggersRefresh("traefik.stale"))
     }
 
     @Test

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModelTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardViewModelTest.kt
@@ -791,16 +791,20 @@ class DashboardViewModelTest {
 
     @Test
     fun triggersRefreshOnlyForRenderedEventFamilies() {
-        // Membership/config/health/version events change a member card, and
-        // fleet/traefik events move the fleet-state summary; alerts ride the same
-        // stream but must not trigger a refetch.
+        // Membership/config/health/version events change a member card,
+        // fleet/traefik events move the fleet-state summary, and settings
+        // events carry the auto-sync toggle and primary repoints; device and
+        // backup events (real types the stream does carry) show nowhere on the
+        // dashboard and must not trigger a refetch.
         assertTrue(DashboardViewModel.triggersRefresh("member.added"))
         assertTrue(DashboardViewModel.triggersRefresh("config.auto_synced"))
         assertTrue(DashboardViewModel.triggersRefresh("health.down"))
         assertTrue(DashboardViewModel.triggersRefresh("version.fetch_failed"))
         assertTrue(DashboardViewModel.triggersRefresh("fleet.state_changed"))
         assertTrue(DashboardViewModel.triggersRefresh("traefik.stale"))
-        assertFalse(DashboardViewModel.triggersRefresh("alert.fired"))
+        assertTrue(DashboardViewModel.triggersRefresh("settings.changed"))
+        assertFalse(DashboardViewModel.triggersRefresh("device.paired"))
+        assertFalse(DashboardViewModel.triggersRefresh("backup.pruned"))
     }
 
     @Test

--- a/frontdesk/web/src/pages/MembersPage.tsx
+++ b/frontdesk/web/src/pages/MembersPage.tsx
@@ -81,10 +81,12 @@ export function MembersPage() {
 	}, []);
 	const primaryId = autoSync?.primary_id || null;
 	// useMembers owns the page's single SSE subscription; piggyback on it to
-	// refresh the auto-sync status when membership, a sync, health, or a fleet /
-	// Traefik signal changes, rather than opening a second stream to /api/sse.
-	// The health/fleet/traefik events are what move the fleet-state badge, so the
-	// filter is wider here than the membership-only refresh the primary needed.
+	// refresh the auto-sync status when membership, a sync, health, a fleet /
+	// Traefik signal, or a settings change lands, rather than opening a second
+	// stream to /api/sse. The health/fleet/traefik events are what move the
+	// fleet-state badge, and settings.changed is the only event emitted when
+	// auto-sync is toggled or the primary is repointed, so the filter is wider
+	// here than the membership-only refresh the primary needed.
 	const { members, loading, error, refetch, lastUpdatedAt } = useMembers(
 		useCallback(
 			(e) => {
@@ -93,7 +95,8 @@ export function MembersPage() {
 					e.type.startsWith("config.") ||
 					e.type.startsWith("health.") ||
 					e.type.startsWith("fleet.") ||
-					e.type.startsWith("traefik.")
+					e.type.startsWith("traefik.") ||
+					e.type.startsWith("settings.")
 				) {
 					refreshPrimary();
 				}

--- a/frontdesk/web/src/pages/__tests__/MembersPage.test.tsx
+++ b/frontdesk/web/src/pages/__tests__/MembersPage.test.tsx
@@ -418,6 +418,39 @@ describe("MembersPage", () => {
 		expect(await screen.findByText("hotel-2")).toBeInTheDocument();
 	});
 
+	it("live-refreshes the primary badge when a settings event arrives", async () => {
+		// Repointing the primary (or toggling auto-sync) emits only
+		// settings.changed, so the event filter must refresh the auto-sync
+		// status on it or the badge stays stale until the next unrelated event.
+		let autosyncCalls = 0;
+		server.use(
+			http.get("/api/members", () =>
+				HttpResponse.json([member({ id: "1", name: "hotel-1" })]),
+			),
+			http.get("/api/fleet/autosync", () => {
+				autosyncCalls += 1;
+				return HttpResponse.json(
+					autosyncCalls === 1
+						? { enabled: false, primary_id: "" }
+						: { enabled: true, primary_id: "1" },
+				);
+			}),
+			sseEmitting([
+				{
+					id: "e1",
+					type: "settings.changed",
+					severity: "info",
+					source: "frontdesk",
+					message: "auto-sync settings updated",
+					created_at: "",
+				},
+			]),
+		);
+		renderPage();
+		await screen.findByText("hotel-1");
+		expect(await screen.findByTestId("primary-badge")).toBeInTheDocument();
+	});
+
 	it("shows the error state when the list cannot be loaded", async () => {
 		server.use(
 			http.get("/api/members", () => new HttpResponse("boom", { status: 500 })),


### PR DESCRIPTION
## Summary
The Bellhop dashboard renders the server fleet-state verdict (the "All up / Degraded / Faulty" summary line), but `triggersRefresh` only refetched on `member.` / `config.` / `health.` / `version.` SSE events. A fleet-state transition with no companion event in those families (autosync going stale, Traefik config-poll staleness, a sync hold appearing) reached the phone only via the fallback poll, up to 60s later while the SSE stream is healthy.

This widens the filter to also match `fleet.` and `traefik.` events, the same families the Front Desk web Members page watches, so the summary flips within seconds of the server emitting the transition.

Review of this PR surfaced two more instances of the same staleness class, fixed here as well:

- `settings.changed` is the only event emitted when auto-sync is toggled or the primary is repointed. Both the Bellhop dashboard and the FD web Members page render that state (auto-sync toggle, primary badge) yet excluded `settings.` from their refresh filters, so a cross-device change stayed stale for up to the 60s poll. Both filters now match the `settings.` prefix.
- The filter test's negative case asserted on `alert.fired`, an event type the FD backend never emits (there is no `alert.*` family; alerts fire on the cataloged event types themselves). The families the stream really carries that both filters ignore are `device.` and `backup.`, and the tests now assert on those.

## Changes
- `DashboardViewModel.triggersRefresh` now matches `fleet.`, `traefik.`, and `settings.` prefixes; comment updated to describe the current filter and the genuinely ignored families.
- FD web `MembersPage` SSE filter gains the same `settings.` match, so `refreshPrimary` reloads the primary badge and fleet-state badge when the settings change lands.
- `triggersRefreshOnlyForRenderedEventFamilies` asserts `fleet.state_changed`, `traefik.stale`, and `settings.changed` trigger a refetch while real ignored types (`device.paired`, `backup.pruned`) do not.
- New FD web test: a `settings.changed` frame on the mocked SSE stream makes the primary badge appear without waiting for a poll.

## Testing
- `./gradlew :app:testDebugUnitTest --tests ...DashboardViewModelTest` passes (full class, exit 0); `:app:ktlintCheck` clean.
- `pnpm vitest run src/pages/__tests__/MembersPage.test.tsx` in `frontdesk/web` passes 24/24; `tsc -b`, test typecheck, Biome, and ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
