### PR TITLE
fix(frontdesk): close version-skew holds with config.sync_recovered; Bellhop de-duplicated event lines

### DIFF
--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/EventLabels.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/EventLabels.kt
@@ -39,3 +39,57 @@ internal fun eventTypeLabel(type: String): String =
         "settings.changed" -> stringResource(R.string.event_settings_changed)
         else -> type
     }
+
+/**
+ * withoutMemberName drops the member's own name out of a Front Desk event
+ * message on surfaces that already show that name directly above the line --
+ * the dashboard card's recent-event pill and the member's own log -- so
+ * "MH2 is healthy" reads as "is healthy" and a longer message has more room
+ * before it truncates. A feed that mixes members keeps the full message: there
+ * the name is the only thing saying which member the line is about.
+ *
+ * Messages are composed server-side in English, so two shapes cover them: the
+ * name leading the sentence, and a " to <name>" sync target inside it. Anything
+ * else, and anything that would strip down to nothing, is returned as it is.
+ */
+internal fun withoutMemberName(
+    message: String,
+    memberName: String,
+): String {
+    if (message.isBlank() || memberName.isBlank()) return message
+    val stripped =
+        stripLeadingName(message, memberName)
+            ?: stripSyncTarget(message, memberName)
+            ?: return message
+    return stripped.ifBlank { message }
+}
+
+/**
+ * NAME_BOUNDARY are the characters that may follow the name for it to count as
+ * a whole word, which keeps "MH2" from matching inside "MH20".
+ */
+private const val NAME_BOUNDARY = " :,"
+
+/** stripLeadingName removes a leading name plus its separator, or null if the message doesn't open with the name. */
+private fun stripLeadingName(
+    message: String,
+    name: String,
+): String? {
+    if (!message.startsWith(name)) return null
+    val rest = message.substring(name.length)
+    if (rest.isNotEmpty() && rest.first() !in NAME_BOUNDARY) return null
+    return rest.trimStart(' ').trimStart(':', ',', '-').trim()
+}
+
+/** stripSyncTarget removes a " to <name>" target from inside the message, or null if there isn't one. */
+private fun stripSyncTarget(
+    message: String,
+    name: String,
+): String? {
+    val target = " to $name"
+    val at = message.indexOf(target)
+    if (at < 0) return null
+    val after = at + target.length
+    if (after < message.length && message[after] !in NAME_BOUNDARY) return null
+    return (message.substring(0, at) + message.substring(after)).trim()
+}

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
@@ -85,6 +85,7 @@ import com.hugalafutro.bellhop.ui.common.healthColor
 import com.hugalafutro.bellhop.ui.common.healthLabel
 import com.hugalafutro.bellhop.ui.common.relativeAgo
 import com.hugalafutro.bellhop.ui.common.severityColors
+import com.hugalafutro.bellhop.ui.common.withoutMemberName
 import com.hugalafutro.bellhop.ui.theme.BellhopTheme
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -827,7 +828,9 @@ private fun MemberCard(
                                     .background(evAccent),
                         )
                         Text(
-                            text = ev.message.ifBlank { ev.type },
+                            // The card header already names the member, so the
+                            // message drops its copy of the name.
+                            text = withoutMemberName(ev.message, member.name).ifBlank { ev.type },
                             style = MaterialTheme.typography.bodySmall,
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis,

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreen.kt
@@ -75,6 +75,7 @@ import com.hugalafutro.bellhop.ui.common.eventTypeLabel
 import com.hugalafutro.bellhop.ui.common.healthColor
 import com.hugalafutro.bellhop.ui.common.loadMoreSentinel
 import com.hugalafutro.bellhop.ui.common.relativeAgo
+import com.hugalafutro.bellhop.ui.common.withoutMemberName
 import com.hugalafutro.bellhop.ui.events.eventClipboardText
 import com.hugalafutro.bellhop.ui.events.formatEventTime
 import com.hugalafutro.bellhop.ui.theme.BellhopTheme
@@ -261,6 +262,10 @@ fun MemberDetailScreen(
                             itemsIndexed(ui.events) { index, event ->
                                 MemberEventRow(
                                     event = event,
+                                    // Only this member's own events lose the name --
+                                    // the screen is headed by it. An event about
+                                    // someone else keeps its message whole.
+                                    memberName = member.name.takeIf { event.memberId == member.id }.orEmpty(),
                                     onCopy = if (holdToCopy) ({ onCopyEvent(event) }) else null,
                                 )
                                 if (index < ui.events.lastIndex) {
@@ -858,6 +863,9 @@ private fun trafficAxisLabels(
 private fun MemberEventRow(
     event: FdEvent,
     modifier: Modifier = Modifier,
+    // The member this log belongs to, stripped out of the message so the screen's
+    // own heading doesn't repeat inside every line. Blank leaves it in.
+    memberName: String = "",
     // Long-press to copy, or null when hold-to-copy is off (the row is inert).
     onCopy: (() -> Unit)? = null,
 ) {
@@ -890,7 +898,7 @@ private fun MemberEventRow(
             )
         }
         Text(
-            text = event.message,
+            text = withoutMemberName(event.message, memberName),
             style = MaterialTheme.typography.bodyMedium,
             maxLines = 2,
             overflow = TextOverflow.Ellipsis,

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/common/EventLabelsTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/common/EventLabelsTest.kt
@@ -1,0 +1,75 @@
+package com.hugalafutro.bellhop.ui.common
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * withoutMemberName is what keeps a member-scoped line from saying the member's
+ * name twice. These pin the two shapes Front Desk composes -- the name leading
+ * the sentence and a " to <name>" sync target -- and, just as importantly, the
+ * cases it must leave alone: another member's name, a name that is only part of
+ * a longer word, and a message that is nothing but the name.
+ */
+class EventLabelsTest {
+    @Test
+    fun `a leading name and its separator are dropped`() {
+        assertEquals("is healthy", withoutMemberName("MH docker-vm is healthy", "MH docker-vm"))
+        assertEquals("now holds the primary's config", withoutMemberName("MH2: now holds the primary's config", "MH2"))
+        assertEquals("sync failed", withoutMemberName("MH2, sync failed", "MH2"))
+        assertEquals("sync failed", withoutMemberName("MH2 - sync failed", "MH2"))
+    }
+
+    @Test
+    fun `the remainder keeps its own capitalisation`() {
+        // The line reads as a continuation of the name in the header above it, so
+        // a lowercase verb is the wanted output, not a re-capitalised sentence.
+        assertEquals("is healthy", withoutMemberName("MH2 is healthy", "MH2"))
+        assertEquals("Traefik is stale", withoutMemberName("MH2: Traefik is stale", "MH2"))
+    }
+
+    @Test
+    fun `a sync target is removed from the middle of the message`() {
+        assertEquals(
+            "Held sync: its app version differs from the primary's",
+            withoutMemberName("Held sync to MH2: its app version differs from the primary's", "MH2"),
+        )
+        assertEquals(
+            "Resumed sync: its app version matches the primary's again",
+            withoutMemberName("Resumed sync to MH2: its app version matches the primary's again", "MH2"),
+        )
+        assertEquals("Pushed config", withoutMemberName("Pushed config to MH2", "MH2"))
+    }
+
+    @Test
+    fun `a name elsewhere in the sentence stays`() {
+        // Only a leading name and a sync target are ours to strip: anywhere else
+        // the name is carrying meaning the sentence needs.
+        assertEquals("Primary moved from MH2", withoutMemberName("Primary moved from MH2", "MH2"))
+        assertEquals("Compared MH2 against the primary", withoutMemberName("Compared MH2 against the primary", "MH2"))
+    }
+
+    @Test
+    fun `a name that is only part of a longer word stays`() {
+        assertEquals("MH20 is healthy", withoutMemberName("MH20 is healthy", "MH2"))
+        assertEquals("Held sync to MH20: it lags", withoutMemberName("Held sync to MH20: it lags", "MH2"))
+    }
+
+    @Test
+    fun `another member's name is left alone`() {
+        assertEquals("MH2 is healthy", withoutMemberName("MH2 is healthy", "MH1"))
+    }
+
+    @Test
+    fun `a message that is nothing but the name survives`() {
+        // Stripping would leave an empty line, which says less than the name does.
+        assertEquals("MH2", withoutMemberName("MH2", "MH2"))
+        assertEquals("MH2:", withoutMemberName("MH2:", "MH2"))
+    }
+
+    @Test
+    fun `a blank name or message changes nothing`() {
+        assertEquals("MH2 is healthy", withoutMemberName("MH2 is healthy", ""))
+        assertEquals("MH2 is healthy", withoutMemberName("MH2 is healthy", "   "))
+        assertEquals("", withoutMemberName("", "MH2"))
+    }
+}

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreenTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performSemanticsAction
 import androidx.compose.ui.test.performTouchInput
@@ -135,6 +136,29 @@ class DashboardScreenTest {
         pill.assertIsDisplayed()
         pill.performClick()
         assertEquals("m1", opened)
+    }
+
+    @Test
+    fun recentEventPillDropsTheMembersOwnName() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                DashboardScreen(
+                    link = link,
+                    ui =
+                        DashboardUiState(
+                            loading = false,
+                            members = allUp,
+                            recentEvents =
+                                mapOf("m1" to FdEvent(id = "e1", severity = "success", message = "alpha is healthy")),
+                        ),
+                )
+            }
+        }
+        // The card header already says "alpha", so the pill under it doesn't. The
+        // message is server-composed English rather than app copy, so asserting on
+        // it here ties the test to Front Desk's wording, not to a translation.
+        composeTestRule.onNodeWithText("is healthy").assertIsDisplayed()
+        composeTestRule.onNodeWithText("alpha is healthy").assertDoesNotExist()
     }
 
     @Test

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreenTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollToIndex
 import androidx.compose.ui.test.performScrollToNode
@@ -173,6 +174,49 @@ class MemberDetailScreenTest {
         assertTrue(
             composeTestRule.onAllNodesWithTag("member-event-row").fetchSemanticsNodes().isNotEmpty(),
         )
+    }
+
+    @Test
+    fun eventRowsDropThisMembersOwnNameButKeepAnotherMembers() {
+        composeTestRule.setContent {
+            BellhopTheme {
+                MemberDetailScreen(
+                    member = member,
+                    isPrimary = false,
+                    onBack = {},
+                    ui =
+                        MemberDetailUiState(
+                            loading = false,
+                            traffic = reachableTraffic,
+                            events =
+                                listOf(
+                                    FdEvent(
+                                        id = "e1",
+                                        severity = "success",
+                                        message = "alpha is healthy",
+                                        memberId = "m1",
+                                    ),
+                                    FdEvent(
+                                        id = "e2",
+                                        severity = "warn",
+                                        message = "beta is unreachable",
+                                        memberId = "m2",
+                                    ),
+                                ),
+                        ),
+                )
+            }
+        }
+        composeTestRule
+            .onNodeWithTag("member-detail-list")
+            .performScrollToNode(hasTestTag("member-event-row"))
+        // The screen is headed by "alpha", so its own line doesn't repeat it. The
+        // line about another member keeps the name it needs to be readable. Both
+        // messages are server-composed English, not app copy, so asserting on them
+        // doesn't tie the test to a translation.
+        composeTestRule.onNodeWithText("is healthy").assertIsDisplayed()
+        composeTestRule.onNodeWithText("alpha is healthy").assertDoesNotExist()
+        composeTestRule.onNodeWithText("beta is unreachable").assertIsDisplayed()
     }
 
     @Test

--- a/frontdesk/web/src/i18n/locales/cs.json
+++ b/frontdesk/web/src/i18n/locales/cs.json
@@ -69,7 +69,6 @@
 		"colTraefik": "Traefik",
 		"colVersion": "Verze",
 		"colLastSync": "Poslední synchronizace konfigurace",
-		"colUpdated": "Aktualizováno",
 		"lastSyncNever": "Nikdy",
 		"lastSyncPrimary": "n/a",
 		"lastSyncPrimaryTip": "Tento člen je zdrojem konfigurace.",

--- a/frontdesk/web/src/i18n/locales/de.json
+++ b/frontdesk/web/src/i18n/locales/de.json
@@ -69,7 +69,6 @@
 		"colTraefik": "Traefik",
 		"colVersion": "Version",
 		"colLastSync": "Letzter Config-Sync",
-		"colUpdated": "Aktualisiert",
 		"lastSyncNever": "Nie",
 		"lastSyncPrimary": "n/a",
 		"lastSyncPrimaryTip": "Dieses Mitglied ist die Quelle der Konfiguration.",

--- a/frontdesk/web/src/i18n/locales/en.json
+++ b/frontdesk/web/src/i18n/locales/en.json
@@ -69,7 +69,6 @@
 		"colTraefik": "Traefik",
 		"colVersion": "Version",
 		"colLastSync": "Last Config Sync",
-		"colUpdated": "Updated",
 		"lastSyncNever": "Never",
 		"lastSyncPrimary": "n/a",
 		"lastSyncPrimaryTip": "This member is the source of config.",

--- a/frontdesk/web/src/i18n/locales/es.json
+++ b/frontdesk/web/src/i18n/locales/es.json
@@ -69,7 +69,6 @@
 		"colTraefik": "Traefik",
 		"colVersion": "Versión",
 		"colLastSync": "Última sinc. de config",
-		"colUpdated": "Actualizado",
 		"lastSyncNever": "Nunca",
 		"lastSyncPrimary": "n/a",
 		"lastSyncPrimaryTip": "Este miembro es el origen de la configuración.",

--- a/frontdesk/web/src/i18n/locales/fr.json
+++ b/frontdesk/web/src/i18n/locales/fr.json
@@ -69,7 +69,6 @@
 		"colTraefik": "Traefik",
 		"colVersion": "Version",
 		"colLastSync": "Dernière synchro de config",
-		"colUpdated": "Mis à jour",
 		"lastSyncNever": "Jamais",
 		"lastSyncPrimary": "n/a",
 		"lastSyncPrimaryTip": "Ce membre est la source de la configuration.",

--- a/frontdesk/web/src/i18n/locales/ja.json
+++ b/frontdesk/web/src/i18n/locales/ja.json
@@ -69,7 +69,6 @@
 		"colTraefik": "Traefik",
 		"colVersion": "バージョン",
 		"colLastSync": "最終設定同期",
-		"colUpdated": "更新",
 		"lastSyncNever": "なし",
 		"lastSyncPrimary": "n/a",
 		"lastSyncPrimaryTip": "このメンバーが設定の来源です。",

--- a/frontdesk/web/src/i18n/locales/nl.json
+++ b/frontdesk/web/src/i18n/locales/nl.json
@@ -69,7 +69,6 @@
 		"colTraefik": "Traefik",
 		"colVersion": "Versie",
 		"colLastSync": "Laatste config-sync",
-		"colUpdated": "Bijgewerkt",
 		"lastSyncNever": "Nooit",
 		"lastSyncPrimary": "n/a",
 		"lastSyncPrimaryTip": "Deze member is de bron van de configuratie.",

--- a/frontdesk/web/src/i18n/locales/pl.json
+++ b/frontdesk/web/src/i18n/locales/pl.json
@@ -69,7 +69,6 @@
 		"colTraefik": "Traefik",
 		"colVersion": "Wersja",
 		"colLastSync": "Ostatnia synchronizacja konfiguracji",
-		"colUpdated": "Aktualizacja",
 		"lastSyncNever": "Nigdy",
 		"lastSyncPrimary": "n/a",
 		"lastSyncPrimaryTip": "Ten członek jest źródłem konfiguracji.",

--- a/frontdesk/web/src/i18n/locales/ru.json
+++ b/frontdesk/web/src/i18n/locales/ru.json
@@ -69,7 +69,6 @@
 		"colTraefik": "Traefik",
 		"colVersion": "Версия",
 		"colLastSync": "Последняя синхронизация",
-		"colUpdated": "Обновлено",
 		"lastSyncNever": "Никогда",
 		"lastSyncPrimary": "n/a",
 		"lastSyncPrimaryTip": "Этот узел является источником конфигурации.",

--- a/frontdesk/web/src/i18n/locales/sk.json
+++ b/frontdesk/web/src/i18n/locales/sk.json
@@ -69,7 +69,6 @@
 		"colTraefik": "Traefik",
 		"colVersion": "Verzia",
 		"colLastSync": "Posledná synchronizácia konfigurácie",
-		"colUpdated": "Aktualizované",
 		"lastSyncNever": "Nikdy",
 		"lastSyncPrimary": "n/a",
 		"lastSyncPrimaryTip": "Tento člen je zdrojom konfigurácie.",

--- a/frontdesk/web/src/i18n/locales/zh.json
+++ b/frontdesk/web/src/i18n/locales/zh.json
@@ -69,7 +69,6 @@
 		"colTraefik": "Traefik",
 		"colVersion": "版本",
 		"colLastSync": "上次配置同步",
-		"colUpdated": "更新时间",
 		"lastSyncNever": "从未",
 		"lastSyncPrimary": "n/a",
 		"lastSyncPrimaryTip": "此成员是配置的来源。",

--- a/frontdesk/web/src/pages/MembersPage.tsx
+++ b/frontdesk/web/src/pages/MembersPage.tsx
@@ -193,7 +193,6 @@ export function MembersPage() {
 								<th>{t("members.colVerified")}</th>
 								<th>{t("members.colLastSync")}</th>
 								<th>{t("members.colState")}</th>
-								<th>{t("members.colUpdated")}</th>
 								<th />
 							</tr>
 						</thead>
@@ -426,7 +425,6 @@ function MemberRow({
 					</span>
 				)}
 			</td>
-			<td className="fd-faint">{formatRelative(m.updated_at)}</td>
 			<td>
 				<div className="fd-row" style={{ justifyContent: "flex-end" }}>
 					{m.state === "active" ? (

--- a/internal/frontdesk/autosync.go
+++ b/internal/frontdesk/autosync.go
@@ -580,20 +580,23 @@ func (s *Server) heldPerLog(ctx context.Context, memberID string) bool {
 	if done {
 		return false
 	}
-	held, _, err := s.store.ListEvents(ctx, EventFilter{MemberID: memberID, Type: "config.sync_held", Limit: 1})
-	if err != nil {
-		debuglog.Warn("frontdesk: auto-sync: read persisted hold state", "member", memberID, "error", err)
-		return false
-	}
-	recovered, _, err := s.store.ListEvents(ctx, EventFilter{MemberID: memberID, Type: "config.sync_recovered", Limit: 1})
-	if err != nil {
-		debuglog.Warn("frontdesk: auto-sync: read persisted hold state", "member", memberID, "error", err)
-		return false
+	var newest [2]time.Time // when the newest sync_held / sync_recovered was emitted
+	var have [2]bool
+	for i, typ := range []string{"config.sync_held", "config.sync_recovered"} {
+		evs, _, err := s.store.ListEvents(ctx, EventFilter{MemberID: memberID, Type: typ, Limit: 1})
+		if err != nil {
+			debuglog.Warn("frontdesk: auto-sync: read persisted hold state", "member", memberID, "error", err)
+			return false
+		}
+		if len(evs) > 0 {
+			have[i] = true
+			newest[i] = evs[0].CreatedAt
+		}
 	}
 	s.syncHeldMu.Lock()
 	s.holdLogChecked[memberID] = true
 	s.syncHeldMu.Unlock()
-	return len(held) > 0 && (len(recovered) == 0 || recovered[0].CreatedAt.Before(held[0].CreatedAt))
+	return have[0] && (!have[1] || newest[1].Before(newest[0]))
 }
 
 // incompleteState is what Front Desk remembers about a member it has given the

--- a/internal/frontdesk/autosync.go
+++ b/internal/frontdesk/autosync.go
@@ -352,7 +352,7 @@ func (s *Server) applyAutoSync(ctx context.Context, primary *Member, primaryToke
 			s.holdMemberForSkew(ctx, m, primaryVer, memberVer)
 			continue
 		}
-		s.clearSyncHold(m.ID)
+		s.closeSyncHold(ctx, m)
 		converged, measured := s.measureMember(ctx, passCtx, m, token, hash)
 		if converged {
 			continue
@@ -527,6 +527,12 @@ func (s *Server) holdMemberForSkew(ctx context.Context, m *Member, primaryVer, m
 	if already {
 		return
 	}
+	if s.heldPerLog(ctx, m.ID) {
+		// The previous process already announced this hold and it never closed:
+		// the member is continuing a hold, not entering one, so re-emitting
+		// config.sync_held would duplicate the alert after every restart.
+		return
+	}
 	debuglog.Debug("frontdesk: auto-sync: holding member for version skew",
 		"member", m.Name, "primary_version", primaryVer, "member_version", memberVer)
 	s.emit(ctx, Event{
@@ -537,12 +543,57 @@ func (s *Server) holdMemberForSkew(ctx context.Context, m *Member, primaryVer, m
 	})
 }
 
-// clearSyncHold forgets a member's held-for-skew state so a future divergence
-// re-emits config.sync_held. Called whenever the member is not skewed on a pass.
-func (s *Server) clearSyncHold(memberID string) {
+// closeSyncHold forgets a member's held-for-skew state so a future divergence
+// re-emits config.sync_held, and emits config.sync_recovered once on the
+// transition out. Without the closing event, config.sync_held stays the
+// member's newest event indefinitely, and every consumer that leads with it
+// (Bellhop's member pill, the events feed) keeps telling a "held" story about a
+// member the live status shows verified in sync. Called whenever the member is
+// not skewed on a pass; a member that was never held emits nothing. The
+// persisted log is consulted too (heldPerLog), so a hold announced before a
+// restart — syncHeld itself is in-memory — is also closed out.
+func (s *Server) closeSyncHold(ctx context.Context, m *Member) {
 	s.syncHeldMu.Lock()
-	delete(s.syncHeld, memberID)
+	was := s.syncHeld[m.ID]
+	delete(s.syncHeld, m.ID)
 	s.syncHeldMu.Unlock()
+	if !was && !s.heldPerLog(ctx, m.ID) {
+		return
+	}
+	s.emit(ctx, Event{
+		Type: "config.sync_recovered", Severity: "success", Source: "frontdesk",
+		Message:  fmt.Sprintf("Resumed sync to %s: its app version matches the primary's again", m.Name),
+		MemberID: m.ID,
+	})
+}
+
+// heldPerLog reports whether the event log left this member inside an open
+// hold: a config.sync_held with no config.sync_recovered after it. The
+// in-memory syncHeld map is authoritative from the moment a pass touches the
+// member, so the log is read at most once per member per process (a read error
+// is not memoised and retries on the next pass). A tie on timestamps counts as
+// closed, so an ambiguous log never produces a spurious event.
+func (s *Server) heldPerLog(ctx context.Context, memberID string) bool {
+	s.syncHeldMu.Lock()
+	done := s.holdLogChecked[memberID]
+	s.syncHeldMu.Unlock()
+	if done {
+		return false
+	}
+	held, _, err := s.store.ListEvents(ctx, EventFilter{MemberID: memberID, Type: "config.sync_held", Limit: 1})
+	if err != nil {
+		debuglog.Warn("frontdesk: auto-sync: read persisted hold state", "member", memberID, "error", err)
+		return false
+	}
+	recovered, _, err := s.store.ListEvents(ctx, EventFilter{MemberID: memberID, Type: "config.sync_recovered", Limit: 1})
+	if err != nil {
+		debuglog.Warn("frontdesk: auto-sync: read persisted hold state", "member", memberID, "error", err)
+		return false
+	}
+	s.syncHeldMu.Lock()
+	s.holdLogChecked[memberID] = true
+	s.syncHeldMu.Unlock()
+	return len(held) > 0 && (len(recovered) == 0 || recovered[0].CreatedAt.Before(held[0].CreatedAt))
 }
 
 // incompleteState is what Front Desk remembers about a member it has given the
@@ -744,8 +795,7 @@ func (s *Server) markMemberUnmeasured(ctx context.Context, m *Member) {
 // LAN hostname and port should not start reaching a notification provider as a
 // side effect of this check. The unredacted error still goes to the local log.
 func unreadableCause(err error) string {
-	var uerr *url.Error
-	if errors.As(err, &uerr) {
+	if _, ok := errors.AsType[*url.Error](err); ok {
 		if isTimeout(err) {
 			return "the member did not answer in time"
 		}

--- a/internal/frontdesk/autosync.go
+++ b/internal/frontdesk/autosync.go
@@ -325,7 +325,7 @@ func (s *Server) applyAutoSync(ctx context.Context, primary *Member, primaryToke
 			// member's promotion must still close here: no other pass will ever
 			// reach it, and an unclosed config.sync_held would stay the new
 			// primary's newest event forever.
-			s.closeSyncHold(ctx, m)
+			s.closeSyncHold(ctx, m, fmt.Sprintf("%s is no longer held for sync: it is now the primary", m.Name))
 			continue
 		}
 		if stale() {
@@ -347,7 +347,13 @@ func (s *Server) applyAutoSync(ctx context.Context, primary *Member, primaryToke
 		memberVer := s.poller.MemberVersion(m.ID)
 		skewed := versionSkew(primaryVer, memberVer)
 		if !skewed {
-			s.closeSyncHold(ctx, m)
+			// "Resumed" is only claimed when a token exists to resume with; for a
+			// tokenless member the versions realigned but sync stays impossible.
+			message := fmt.Sprintf("%s is no longer held for sync: its app version matches the primary's again", m.Name)
+			if m.HasToken {
+				message = fmt.Sprintf("Resumed sync to %s: its app version matches the primary's again", m.Name)
+			}
+			s.closeSyncHold(ctx, m, message)
 		}
 		if !m.HasToken {
 			// Cannot be authenticated to, so it can be measured in neither direction.
@@ -567,7 +573,13 @@ func (s *Server) holdMemberForSkew(ctx context.Context, m *Member, primaryVer, m
 // from before its promotion; a member that was never held emits nothing. The
 // persisted log is consulted too (heldPerLog), so a hold announced before a
 // restart — syncHeld itself is in-memory — is also closed out.
-func (s *Server) closeSyncHold(ctx context.Context, m *Member) {
+//
+// message is the operator-facing reason the hold is over, supplied by the call
+// site because only it knows which story is true: sync resuming, versions
+// realigning on a member sync cannot reach, or the member's promotion. It must
+// keep to one of the two shapes Bellhop's name-stripper knows (the member name
+// leading the sentence, or a " to <name>" target).
+func (s *Server) closeSyncHold(ctx context.Context, m *Member, message string) {
 	s.syncHeldMu.Lock()
 	was := s.syncHeld[m.ID]
 	delete(s.syncHeld, m.ID)
@@ -575,19 +587,26 @@ func (s *Server) closeSyncHold(ctx context.Context, m *Member) {
 	if !was && !s.heldPerLog(ctx, m) {
 		return
 	}
-	if !s.emitPersisted(ctx, Event{
+	ev := Event{
 		Type: "config.sync_recovered", Severity: "success", Source: "frontdesk",
-		Message:  fmt.Sprintf("Resumed sync to %s: its app version matches the primary's again", m.Name),
-		MemberID: m.ID,
-	}) {
-		// The closing event never reached the log, which therefore still ends
-		// with the member held. Drop the memoised log verdict so the next pass
-		// re-reads the log, finds the hold still open, and retries the event.
-		// The in-memory hold stays cleared: the fleet state is already right.
+		Message: message, MemberID: m.ID,
+	}
+	// Inserted and published by hand rather than through emit: the publish must
+	// wait for the insert. On a failed insert the log still ends with the member
+	// held, so the memoised log verdict is dropped and the next pass re-reads
+	// the log, finds the hold still open, and retries — and holding the bus
+	// publish back with it keeps SSE consumers and the alert dispatcher at one
+	// event per close instead of one per retry. The in-memory hold stays
+	// cleared either way: the fleet state is already right.
+	stored, err := s.store.InsertEvent(ctx, ev)
+	if err != nil {
+		debuglog.Warn("frontdesk: persist event", "type", ev.Type, "error", err)
 		s.syncHeldMu.Lock()
 		delete(s.holdLogChecked, m.ID)
 		s.syncHeldMu.Unlock()
+		return
 	}
+	s.bus.Publish(busEvent(stored))
 }
 
 // heldPerLog reports whether the event log left this member inside an open

--- a/internal/frontdesk/autosync.go
+++ b/internal/frontdesk/autosync.go
@@ -321,13 +321,33 @@ func (s *Server) applyAutoSync(ctx context.Context, primary *Member, primaryToke
 	primaryVer := s.poller.MemberVersion(primary.ID)
 	for _, m := range members {
 		if m.ID == primary.ID {
-			continue // the source is never written to
+			// The source is never written to, but a hold announced before this
+			// member's promotion must still close here: no other pass will ever
+			// reach it, and an unclosed config.sync_held would stay the new
+			// primary's newest event forever.
+			s.closeSyncHold(ctx, m)
+			continue
 		}
 		if stale() {
 			// A rearm/repoint landed mid-pass: stop before importing the stale export
 			// into any further member, and leave the rest to the rearm's own pass.
 			debuglog.Debug("frontdesk: auto-sync: aborting stale pass after rearm", "synced", applied)
 			break
+		}
+		// Version gate: never push onto a member running a different app version. An
+		// older primary's export omits settings the newer member legitimately has, and
+		// the member-side converge-delete would drop them. Fails closed on an unknown
+		// version, and is re-evaluated every pass, so it resumes automatically.
+		//
+		// Decided before the token guards, because the verdict comes from the poller,
+		// not the token: a held member whose token was cleared must still close its
+		// hold once versions realign, or the "held" story outlives the skew. Entering
+		// a hold stays behind the guards: sync to a tokenless member is not held, it
+		// is impossible, and holds on unsyncable members would be noise.
+		memberVer := s.poller.MemberVersion(m.ID)
+		skewed := versionSkew(primaryVer, memberVer)
+		if !skewed {
+			s.closeSyncHold(ctx, m)
 		}
 		if !m.HasToken {
 			// Cannot be authenticated to, so it can be measured in neither direction.
@@ -343,16 +363,10 @@ func (s *Server) applyAutoSync(ctx context.Context, primary *Member, primaryToke
 			debuglog.Debug("frontdesk: auto-sync: member token unavailable, will retry", "member", m.Name, "loaded", ok, "error", err)
 			continue
 		}
-		// Version gate: never push onto a member running a different app version. An
-		// older primary's export omits settings the newer member legitimately has, and
-		// the member-side converge-delete would drop them. Fails closed on an unknown
-		// version, and is re-evaluated every pass, so it resumes automatically.
-		memberVer := s.poller.MemberVersion(m.ID)
-		if versionSkew(primaryVer, memberVer) {
+		if skewed {
 			s.holdMemberForSkew(ctx, m, primaryVer, memberVer)
 			continue
 		}
-		s.closeSyncHold(ctx, m)
 		converged, measured := s.measureMember(ctx, passCtx, m, token, hash)
 		if converged {
 			continue
@@ -527,7 +541,7 @@ func (s *Server) holdMemberForSkew(ctx context.Context, m *Member, primaryVer, m
 	if already {
 		return
 	}
-	if s.heldPerLog(ctx, m.ID) {
+	if s.heldPerLog(ctx, m) {
 		// The previous process already announced this hold and it never closed:
 		// the member is continuing a hold, not entering one, so re-emitting
 		// config.sync_held would duplicate the alert after every restart.
@@ -549,7 +563,8 @@ func (s *Server) holdMemberForSkew(ctx context.Context, m *Member, primaryVer, m
 // member's newest event indefinitely, and every consumer that leads with it
 // (Bellhop's member pill, the events feed) keeps telling a "held" story about a
 // member the live status shows verified in sync. Called whenever the member is
-// not skewed on a pass; a member that was never held emits nothing. The
+// not skewed on a pass, and for the primary itself, which may carry a hold
+// from before its promotion; a member that was never held emits nothing. The
 // persisted log is consulted too (heldPerLog), so a hold announced before a
 // restart — syncHeld itself is in-memory — is also closed out.
 func (s *Server) closeSyncHold(ctx context.Context, m *Member) {
@@ -557,46 +572,47 @@ func (s *Server) closeSyncHold(ctx context.Context, m *Member) {
 	was := s.syncHeld[m.ID]
 	delete(s.syncHeld, m.ID)
 	s.syncHeldMu.Unlock()
-	if !was && !s.heldPerLog(ctx, m.ID) {
+	if !was && !s.heldPerLog(ctx, m) {
 		return
 	}
-	s.emit(ctx, Event{
+	if !s.emitPersisted(ctx, Event{
 		Type: "config.sync_recovered", Severity: "success", Source: "frontdesk",
 		Message:  fmt.Sprintf("Resumed sync to %s: its app version matches the primary's again", m.Name),
 		MemberID: m.ID,
-	})
+	}) {
+		// The closing event never reached the log, which therefore still ends
+		// with the member held. Drop the memoised log verdict so the next pass
+		// re-reads the log, finds the hold still open, and retries the event.
+		// The in-memory hold stays cleared: the fleet state is already right.
+		s.syncHeldMu.Lock()
+		delete(s.holdLogChecked, m.ID)
+		s.syncHeldMu.Unlock()
+	}
 }
 
 // heldPerLog reports whether the event log left this member inside an open
-// hold: a config.sync_held with no config.sync_recovered after it. The
-// in-memory syncHeld map is authoritative from the moment a pass touches the
-// member, so the log is read at most once per member per process (a read error
-// is not memoised and retries on the next pass). A tie on timestamps counts as
-// closed, so an ambiguous log never produces a spurious event.
-func (s *Server) heldPerLog(ctx context.Context, memberID string) bool {
+// hold: a config.sync_held with no config.sync_recovered after it, decided by
+// one newest-of-the-two-types read under the store's deterministic tie-break.
+// The in-memory syncHeld map is authoritative from the moment a pass touches
+// the member, so the log is read at most once per member per process (a read
+// error is not memoised and retries on the next pass, and closeSyncHold drops
+// the memo again when its closing event fails to persist).
+func (s *Server) heldPerLog(ctx context.Context, m *Member) bool {
 	s.syncHeldMu.Lock()
-	done := s.holdLogChecked[memberID]
+	done := s.holdLogChecked[m.ID]
 	s.syncHeldMu.Unlock()
 	if done {
 		return false
 	}
-	var newest [2]time.Time // when the newest sync_held / sync_recovered was emitted
-	var have [2]bool
-	for i, typ := range []string{"config.sync_held", "config.sync_recovered"} {
-		evs, _, err := s.store.ListEvents(ctx, EventFilter{MemberID: memberID, Type: typ, Limit: 1})
-		if err != nil {
-			debuglog.Warn("frontdesk: auto-sync: read persisted hold state", "member", memberID, "error", err)
-			return false
-		}
-		if len(evs) > 0 {
-			have[i] = true
-			newest[i] = evs[0].CreatedAt
-		}
+	newest, found, err := s.store.NewestEventOfTypes(ctx, m.ID, "config.sync_held", "config.sync_recovered")
+	if err != nil {
+		debuglog.Warn("frontdesk: auto-sync: read persisted hold state", "member", m.Name, "error", err)
+		return false
 	}
 	s.syncHeldMu.Lock()
-	s.holdLogChecked[memberID] = true
+	s.holdLogChecked[m.ID] = true
 	s.syncHeldMu.Unlock()
-	return have[0] && (!have[1] || newest[1].Before(newest[0]))
+	return found && newest.Type == "config.sync_held"
 }
 
 // incompleteState is what Front Desk remembers about a member it has given the

--- a/internal/frontdesk/autosync_test.go
+++ b/internal/frontdesk/autosync_test.go
@@ -1984,6 +1984,26 @@ func TestAutoSync_ClosesHoldAcrossRestart(t *testing.T) {
 	}
 }
 
+// TestAutoSync_HoldLogReadErrorIsNotMemoised: a store error while reconciling
+// the persisted hold state reads as "not held" for that pass but is not
+// remembered as resolved, so the next pass retries the read instead of
+// treating a transient DB failure as a clean log.
+func TestAutoSync_HoldLogReadErrorIsNotMemoised(t *testing.T) {
+	srv, store := newTestServer(t)
+	if err := store.db.Close(); err != nil {
+		t.Fatalf("close store db: %v", err)
+	}
+	if srv.heldPerLog(t.Context(), "m1") {
+		t.Error("heldPerLog = true on a store read error, want false")
+	}
+	srv.syncHeldMu.Lock()
+	checked := srv.holdLogChecked["m1"]
+	srv.syncHeldMu.Unlock()
+	if checked {
+		t.Error("a failed log read was memoised as checked; it must retry on the next pass")
+	}
+}
+
 // TestAutoSync_StillHeldAfterRestartDoesNotRealert: a restart that comes back
 // up with the member still skewed is continuing a hold the previous process
 // already announced, not entering a new one, so config.sync_held is not

--- a/internal/frontdesk/autosync_test.go
+++ b/internal/frontdesk/autosync_test.go
@@ -2074,17 +2074,25 @@ func TestAutoSync_PromotedPrimaryClosesItsHold(t *testing.T) {
 	if len(evs) != 1 || evs[0].MemberID != rm.ID {
 		t.Fatalf("config.sync_recovered after promotion = %d events, want exactly 1 for the promoted member", len(evs))
 	}
+	// The message must tell the promotion story: sync was not "resumed" to a
+	// member that is now the source and is never synced to.
+	if !strings.Contains(evs[0].Message, "it is now the primary") {
+		t.Errorf("promoted-primary recovered message = %q, want the promotion wording", evs[0].Message)
+	}
 	if replica.didRealSync() {
 		t.Error("the promoted primary was pushed to; the source is never written to")
 	}
 }
 
 // TestAutoSync_TokenlessMemberStillClosesItsHold: a held member whose admin
-// token is cleared is skipped for measuring and pushing, but once its versions
-// realign its hold must still close. The version verdict comes from the poller,
-// not the sync token, so Front Desk knows the skew is over and must say so
-// rather than leave config.sync_held dangling against a member the versions
-// say is fine.
+// token is cleared is skipped for measuring and pushing, but once the versions
+// realign its hold must still close. The version verdict comes from the
+// poller, not the sync token, so Front Desk knows the skew is over and must
+// say so rather than leave config.sync_held dangling against a member the
+// versions say is fine. The realignment is the primary's version moving onto
+// the member's, because that is the direction reachable in production: the
+// poller skips a tokenless member, so its own polled version stays frozen at
+// the last read taken while it had a token.
 func TestAutoSync_TokenlessMemberStillClosesItsHold(t *testing.T) {
 	srv, store := newTestServer(t)
 	primary := newStubAutoMember(t, "ptoken")
@@ -2099,11 +2107,12 @@ func TestAutoSync_TokenlessMemberStillClosesItsHold(t *testing.T) {
 	setMemberVersion(srv, rm.ID, "v0.9.0")
 	srv.forceAutoSyncNow(t.Context()) // announces the hold on the replica
 
-	// The member's token is cleared while held, then its versions realign.
+	// The member's token is cleared while held, then the operator rolls the
+	// primary back onto the member's (frozen) version.
 	if err := store.SetMemberToken(t.Context(), rm.ID, ""); err != nil {
 		t.Fatalf("SetMemberToken: %v", err)
 	}
-	setMemberVersion(srv, rm.ID, "v1.0.0")
+	setMemberVersion(srv, pm.ID, "v0.9.0")
 	srv.forceAutoSyncNow(t.Context())
 
 	evs, _, err := store.ListEvents(t.Context(), EventFilter{Type: "config.sync_recovered"})
@@ -2112,6 +2121,11 @@ func TestAutoSync_TokenlessMemberStillClosesItsHold(t *testing.T) {
 	}
 	if len(evs) != 1 || evs[0].MemberID != rm.ID {
 		t.Fatalf("config.sync_recovered for the tokenless member = %d events, want exactly 1", len(evs))
+	}
+	// The message must not claim sync resumed: without a token there is
+	// nothing to resume with, only a skew that ended.
+	if strings.Contains(evs[0].Message, "Resumed sync") {
+		t.Errorf("tokenless recovered message = %q, want no resumed-sync claim", evs[0].Message)
 	}
 	if replica.didRealSync() {
 		t.Error("a tokenless member was pushed to")
@@ -2135,7 +2149,7 @@ func TestAutoSync_FailedRecoveredEmitIsNotMemoisedAsClosed(t *testing.T) {
 	if err := store.db.Close(); err != nil {
 		t.Fatalf("close store db: %v", err)
 	}
-	srv.closeSyncHold(t.Context(), m)
+	srv.closeSyncHold(t.Context(), m, "m1 is no longer held for sync: its app version matches the primary's again")
 
 	srv.syncHeldMu.Lock()
 	checked := srv.holdLogChecked[m.ID]

--- a/internal/frontdesk/autosync_test.go
+++ b/internal/frontdesk/autosync_test.go
@@ -1993,7 +1993,7 @@ func TestAutoSync_HoldLogReadErrorIsNotMemoised(t *testing.T) {
 	if err := store.db.Close(); err != nil {
 		t.Fatalf("close store db: %v", err)
 	}
-	if srv.heldPerLog(t.Context(), "m1") {
+	if srv.heldPerLog(t.Context(), &Member{ID: "m1", Name: "m1"}) {
 		t.Error("heldPerLog = true on a store read error, want false")
 	}
 	srv.syncHeldMu.Lock()
@@ -2041,6 +2041,111 @@ func TestAutoSync_StillHeldAfterRestartDoesNotRealert(t *testing.T) {
 	srv.forceAutoSyncNow(t.Context())
 	if n := countEventsOfType(t, store, "config.sync_recovered"); n != 1 {
 		t.Errorf("config.sync_recovered once the continued hold cleared = %d, want 1", n)
+	}
+}
+
+// TestAutoSync_PromotedPrimaryClosesItsHold: a held member the operator
+// upgrades and promotes to primary is skipped as the sync source from then on,
+// but the hold it carried must still close. Without that, config.sync_held
+// stays the new primary's newest event forever: no pass would ever emit
+// config.sync_recovered for the one member every pass skips.
+func TestAutoSync_PromotedPrimaryClosesItsHold(t *testing.T) {
+	srv, store := newTestServer(t)
+	primary := newStubAutoMember(t, "ptoken")
+	primary.versionHash = "hash-B"
+	replica := newStubAutoMember(t, "rtoken")
+	replica.dryDiff = driftDiff
+
+	pm, _ := store.CreateMember(t.Context(), "primary", primary.srv.URL, "ptoken")
+	rm, _ := store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken")
+	enableAutoSync(t, store, pm.ID)
+	setMemberVersion(srv, pm.ID, "v1.0.0")
+	setMemberVersion(srv, rm.ID, "v0.9.0")
+	srv.forceAutoSyncNow(t.Context()) // announces the hold on the replica
+
+	// The operator promotes the held member to primary and the next pass runs.
+	enableAutoSync(t, store, rm.ID)
+	srv.forceAutoSyncNow(t.Context())
+
+	evs, _, err := store.ListEvents(t.Context(), EventFilter{Type: "config.sync_recovered"})
+	if err != nil {
+		t.Fatalf("ListEvents: %v", err)
+	}
+	if len(evs) != 1 || evs[0].MemberID != rm.ID {
+		t.Fatalf("config.sync_recovered after promotion = %d events, want exactly 1 for the promoted member", len(evs))
+	}
+	if replica.didRealSync() {
+		t.Error("the promoted primary was pushed to; the source is never written to")
+	}
+}
+
+// TestAutoSync_TokenlessMemberStillClosesItsHold: a held member whose admin
+// token is cleared is skipped for measuring and pushing, but once its versions
+// realign its hold must still close. The version verdict comes from the poller,
+// not the sync token, so Front Desk knows the skew is over and must say so
+// rather than leave config.sync_held dangling against a member the versions
+// say is fine.
+func TestAutoSync_TokenlessMemberStillClosesItsHold(t *testing.T) {
+	srv, store := newTestServer(t)
+	primary := newStubAutoMember(t, "ptoken")
+	primary.versionHash = "hash-B"
+	replica := newStubAutoMember(t, "rtoken")
+	replica.dryDiff = driftDiff
+
+	pm, _ := store.CreateMember(t.Context(), "primary", primary.srv.URL, "ptoken")
+	rm, _ := store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken")
+	enableAutoSync(t, store, pm.ID)
+	setMemberVersion(srv, pm.ID, "v1.0.0")
+	setMemberVersion(srv, rm.ID, "v0.9.0")
+	srv.forceAutoSyncNow(t.Context()) // announces the hold on the replica
+
+	// The member's token is cleared while held, then its versions realign.
+	if err := store.SetMemberToken(t.Context(), rm.ID, ""); err != nil {
+		t.Fatalf("SetMemberToken: %v", err)
+	}
+	setMemberVersion(srv, rm.ID, "v1.0.0")
+	srv.forceAutoSyncNow(t.Context())
+
+	evs, _, err := store.ListEvents(t.Context(), EventFilter{Type: "config.sync_recovered"})
+	if err != nil {
+		t.Fatalf("ListEvents: %v", err)
+	}
+	if len(evs) != 1 || evs[0].MemberID != rm.ID {
+		t.Fatalf("config.sync_recovered for the tokenless member = %d events, want exactly 1", len(evs))
+	}
+	if replica.didRealSync() {
+		t.Error("a tokenless member was pushed to")
+	}
+}
+
+// TestAutoSync_FailedRecoveredEmitIsNotMemoisedAsClosed: when the
+// config.sync_recovered insert fails, the persisted log still ends with the
+// member held, so the memoised log verdict must be dropped: the next pass then
+// re-reads the log, finds the hold still open, and retries the event (the same
+// path TestAutoSync_ClosesHoldAcrossRestart proves emits). The in-memory hold
+// stays cleared either way; the fleet state is already right.
+func TestAutoSync_FailedRecoveredEmitIsNotMemoisedAsClosed(t *testing.T) {
+	srv, store := newTestServer(t)
+	m := &Member{ID: "m1", Name: "m1"}
+	srv.syncHeldMu.Lock()
+	srv.syncHeld[m.ID] = true
+	srv.holdLogChecked[m.ID] = true
+	srv.syncHeldMu.Unlock()
+
+	if err := store.db.Close(); err != nil {
+		t.Fatalf("close store db: %v", err)
+	}
+	srv.closeSyncHold(t.Context(), m)
+
+	srv.syncHeldMu.Lock()
+	checked := srv.holdLogChecked[m.ID]
+	held := srv.syncHeld[m.ID]
+	srv.syncHeldMu.Unlock()
+	if checked {
+		t.Error("a failed config.sync_recovered persist stayed memoised as closed; the next pass must re-read the log and retry")
+	}
+	if held {
+		t.Error("the in-memory hold must stay cleared even when the closing event fails to persist")
 	}
 }
 

--- a/internal/frontdesk/autosync_test.go
+++ b/internal/frontdesk/autosync_test.go
@@ -1898,6 +1898,132 @@ func TestAutoSyncHoldsVersionSkew(t *testing.T) {
 	}
 }
 
+// TestAutoSync_EmitsRecoveredWhenHoldClears: leaving the held-for-skew state
+// emits config.sync_recovered exactly once, so config.sync_held is never a
+// member's last word once its versions realign (consumers that lead with the
+// newest per-member event — Bellhop's member pill, the events feed — would
+// otherwise show "held" forever against a live status of verified in sync).
+func TestAutoSync_EmitsRecoveredWhenHoldClears(t *testing.T) {
+	srv, store := newTestServer(t)
+	primary := newStubAutoMember(t, "ptoken")
+	primary.versionHash = "hash-B"
+	replica := newStubAutoMember(t, "rtoken")
+	replica.dryDiff = driftDiff
+
+	pm, _ := store.CreateMember(t.Context(), "primary", primary.srv.URL, "ptoken")
+	rm, _ := store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken")
+	enableAutoSync(t, store, pm.ID)
+	setMemberVersion(srv, pm.ID, "v1.0.0")
+	setMemberVersion(srv, rm.ID, "v0.9.0")
+
+	srv.forceAutoSyncNow(t.Context())
+	if n := countEventsOfType(t, store, "config.sync_recovered"); n != 0 {
+		t.Fatalf("config.sync_recovered events while still held = %d, want 0", n)
+	}
+
+	// Versions align: the same pass that resumes syncing closes the hold.
+	setMemberVersion(srv, rm.ID, "v1.0.0")
+	srv.forceAutoSyncNow(t.Context())
+	evs, _, err := store.ListEvents(t.Context(), EventFilter{Type: "config.sync_recovered"})
+	if err != nil {
+		t.Fatalf("ListEvents: %v", err)
+	}
+	if len(evs) != 1 {
+		t.Fatalf("config.sync_recovered events = %d, want exactly 1 on the transition out of held", len(evs))
+	}
+	if evs[0].MemberID != rm.ID {
+		t.Errorf("recovered event member = %q, want %q", evs[0].MemberID, rm.ID)
+	}
+
+	// Edge-triggered: further aligned passes stay quiet.
+	srv.forceAutoSyncNow(t.Context())
+	if n := countEventsOfType(t, store, "config.sync_recovered"); n != 1 {
+		t.Errorf("config.sync_recovered events after another aligned pass = %d, want still 1", n)
+	}
+}
+
+// TestAutoSync_ClosesHoldAcrossRestart: the hold set is in-memory, so a restart
+// forgets a hold config.sync_held already announced. The first pass that finds
+// the member's versions aligned must still emit config.sync_recovered, seeded
+// from the persisted event log, or the warning dangles as the member's newest
+// event forever.
+func TestAutoSync_ClosesHoldAcrossRestart(t *testing.T) {
+	srv, store := newTestServer(t)
+	primary := newStubAutoMember(t, "ptoken")
+	primary.versionHash = "hash-B"
+	replica := newStubAutoMember(t, "rtoken")
+	replica.dryDiff = driftDiff
+
+	pm, _ := store.CreateMember(t.Context(), "primary", primary.srv.URL, "ptoken")
+	rm, _ := store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken")
+	enableAutoSync(t, store, pm.ID)
+	setMemberVersion(srv, pm.ID, "v1.0.0")
+	setMemberVersion(srv, rm.ID, "v0.9.0")
+	srv.forceAutoSyncNow(t.Context()) // announces the hold
+
+	// Simulate a restart: the in-memory hold state is gone, the event log is not.
+	srv.syncHeldMu.Lock()
+	srv.syncHeld = make(map[string]bool)
+	srv.holdLogChecked = make(map[string]bool)
+	srv.syncHeldMu.Unlock()
+
+	setMemberVersion(srv, rm.ID, "v1.0.0")
+	srv.forceAutoSyncNow(t.Context())
+	evs, _, err := store.ListEvents(t.Context(), EventFilter{Type: "config.sync_recovered"})
+	if err != nil {
+		t.Fatalf("ListEvents: %v", err)
+	}
+	if len(evs) != 1 || evs[0].MemberID != rm.ID {
+		t.Fatalf("config.sync_recovered after restart = %d events, want exactly 1 for the held member", len(evs))
+	}
+
+	// The log verdict is consumed: later aligned passes emit nothing more.
+	srv.forceAutoSyncNow(t.Context())
+	if n := countEventsOfType(t, store, "config.sync_recovered"); n != 1 {
+		t.Errorf("config.sync_recovered events after another aligned pass = %d, want still 1", n)
+	}
+}
+
+// TestAutoSync_StillHeldAfterRestartDoesNotRealert: a restart that comes back
+// up with the member still skewed is continuing a hold the previous process
+// already announced, not entering a new one, so config.sync_held is not
+// duplicated after every restart.
+func TestAutoSync_StillHeldAfterRestartDoesNotRealert(t *testing.T) {
+	srv, store := newTestServer(t)
+	primary := newStubAutoMember(t, "ptoken")
+	primary.versionHash = "hash-B"
+	replica := newStubAutoMember(t, "rtoken")
+	replica.dryDiff = driftDiff
+
+	pm, _ := store.CreateMember(t.Context(), "primary", primary.srv.URL, "ptoken")
+	rm, _ := store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken")
+	enableAutoSync(t, store, pm.ID)
+	setMemberVersion(srv, pm.ID, "v1.0.0")
+	setMemberVersion(srv, rm.ID, "v0.9.0")
+	srv.forceAutoSyncNow(t.Context()) // announces the hold
+
+	// Simulate a restart with the member still skewed.
+	srv.syncHeldMu.Lock()
+	srv.syncHeld = make(map[string]bool)
+	srv.holdLogChecked = make(map[string]bool)
+	srv.syncHeldMu.Unlock()
+
+	srv.forceAutoSyncNow(t.Context())
+	if n := countEventsOfType(t, store, "config.sync_held"); n != 1 {
+		t.Errorf("config.sync_held events after restart while still skewed = %d, want still 1", n)
+	}
+	if n := countEventsOfType(t, store, "config.sync_recovered"); n != 0 {
+		t.Errorf("config.sync_recovered events while still skewed = %d, want 0", n)
+	}
+
+	// And the continued hold still closes normally once versions align.
+	setMemberVersion(srv, rm.ID, "v1.0.0")
+	srv.forceAutoSyncNow(t.Context())
+	if n := countEventsOfType(t, store, "config.sync_recovered"); n != 1 {
+		t.Errorf("config.sync_recovered once the continued hold cleared = %d, want 1", n)
+	}
+}
+
 // TestAutoSync_VersionSkewedMemberIsHeldEvenWhenItsConfigMatches pins where the
 // hash check sits: after the version gate, not before it. A member running a
 // different app version is held even when it already holds this exact config, so

--- a/internal/frontdesk/server.go
+++ b/internal/frontdesk/server.go
@@ -83,11 +83,18 @@ type Server struct {
 	rearmMu sync.Mutex
 	rearmCh chan struct{}
 	// syncHeld tracks which members autosync is currently holding for version
-	// skew, so config.sync_held fires once on the transition into held rather than
-	// every pass (mirrors the poller's versionFailures edge-trigger). In-memory and
-	// bounded by fleet size; a restart re-emits at most once per still-held member.
+	// skew, so config.sync_held fires once on the transition into held and
+	// config.sync_recovered once on the way out rather than every pass (mirrors
+	// the poller's versionFailures edge-trigger). In-memory and bounded by fleet
+	// size; a restart reconciles against the event log (heldPerLog) so a hold the
+	// previous process announced is still closed out, and a still-held member is
+	// not re-alerted.
 	syncHeldMu sync.Mutex
 	syncHeld   map[string]bool
+	// holdLogChecked marks members whose persisted hold state this process has
+	// already reconciled, so heldPerLog reads the event log at most once per
+	// member. Guarded by syncHeldMu; in-memory and bounded by fleet size.
+	holdLogChecked map[string]bool
 	// syncIncomplete tracks which members took a config and when, and which of them
 	// still do not serve the primary's hash. Drives the once-per-transition
 	// config.sync_incomplete event and the rate-limited re-push (see
@@ -191,6 +198,7 @@ func NewServer(cfg ServerConfig) *Server {
 		ipLimiter:       cfg.IPLimiter,
 		rearmCh:         make(chan struct{}),
 		syncHeld:        make(map[string]bool),
+		holdLogChecked:  make(map[string]bool),
 		syncIncomplete:  make(map[string]incompleteState),
 		unconfirmedSync: make(map[string]string),
 		backupStale:     make(map[string]bool),

--- a/internal/frontdesk/server_members.go
+++ b/internal/frontdesk/server_members.go
@@ -279,6 +279,7 @@ func (s *Server) deleteMember(w http.ResponseWriter, r *http.Request) {
 func (s *Server) forgetMemberState(id string) {
 	s.syncHeldMu.Lock()
 	delete(s.syncHeld, id)
+	delete(s.holdLogChecked, id)
 	s.syncHeldMu.Unlock()
 
 	s.syncIncompleteMu.Lock()

--- a/internal/frontdesk/server_status.go
+++ b/internal/frontdesk/server_status.go
@@ -171,23 +171,16 @@ func (c *totpEnabledCache) Refresh(ctx context.Context) {
 	c.val.Store(enabled)
 }
 
-// emit persists a control-plane event and publishes it on the SSE bus.
+// emit persists a control-plane event and publishes it on the SSE bus. The
+// publish is best-effort on a failed insert; closeSyncHold, whose correctness
+// leans on the persisted log, inserts and publishes by hand instead.
 func (s *Server) emit(ctx context.Context, e Event) {
-	s.emitPersisted(ctx, e)
-}
-
-// emitPersisted is emit, reporting whether the event reached the store. The
-// bus publish happens either way; a caller whose correctness leans on the
-// persisted log (closeSyncHold's restart reconciliation) retries on false,
-// where emit's callers treat persistence as best-effort.
-func (s *Server) emitPersisted(ctx context.Context, e Event) bool {
 	stored, err := s.store.InsertEvent(ctx, e)
 	if err != nil {
 		debuglog.Warn("frontdesk: persist event", "type", e.Type, "error", err)
 		stored = e
 	}
 	s.bus.Publish(busEvent(stored))
-	return err == nil
 }
 
 // busEvent maps a stored Front Desk Event to a bus event. When the event concerns

--- a/internal/frontdesk/server_status.go
+++ b/internal/frontdesk/server_status.go
@@ -173,12 +173,21 @@ func (c *totpEnabledCache) Refresh(ctx context.Context) {
 
 // emit persists a control-plane event and publishes it on the SSE bus.
 func (s *Server) emit(ctx context.Context, e Event) {
+	s.emitPersisted(ctx, e)
+}
+
+// emitPersisted is emit, reporting whether the event reached the store. The
+// bus publish happens either way; a caller whose correctness leans on the
+// persisted log (closeSyncHold's restart reconciliation) retries on false,
+// where emit's callers treat persistence as best-effort.
+func (s *Server) emitPersisted(ctx context.Context, e Event) bool {
 	stored, err := s.store.InsertEvent(ctx, e)
 	if err != nil {
 		debuglog.Warn("frontdesk: persist event", "type", e.Type, "error", err)
 		stored = e
 	}
 	s.bus.Publish(busEvent(stored))
+	return err == nil
 }
 
 // busEvent maps a stored Front Desk Event to a bus event. When the event concerns

--- a/internal/frontdesk/store_events.go
+++ b/internal/frontdesk/store_events.go
@@ -112,6 +112,40 @@ func (s *Store) NewestEventPerMember(ctx context.Context) (map[string]Event, err
 	return out, rows.Err()
 }
 
+// NewestEventOfTypes returns the member's most recent event among the given
+// types, in one indexed read: no pagination count, and one query rather than
+// one per type, so a caller ranking two types (heldPerLog's sync_held vs
+// sync_recovered) inherits the store's deterministic id tie-break instead of
+// comparing timestamps across separate reads. found is false when the member
+// has no event of any given type.
+func (s *Store) NewestEventOfTypes(ctx context.Context, memberID string, types ...string) (ev Event, found bool, err error) {
+	if len(types) == 0 {
+		return Event{}, false, nil
+	}
+	args := make([]any, 0, len(types)+1)
+	args = append(args, memberID)
+	for _, t := range types {
+		args = append(args, t)
+	}
+	//nolint:gosec // the placeholder list is derived from len(types) alone; all values are bound parameters.
+	query := `SELECT id, type, severity, source, message, metadata, member_id, created_at FROM events
+		WHERE member_id = ? AND type IN (` + strings.TrimSuffix(strings.Repeat("?,", len(types)), ",") + `)
+		ORDER BY created_at DESC, id DESC LIMIT 1`
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return Event{}, false, fmt.Errorf("frontdesk: newest event of types: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	if !rows.Next() {
+		return Event{}, false, rows.Err()
+	}
+	ev, err = scanEvent(rows)
+	if err != nil {
+		return Event{}, false, err
+	}
+	return ev, true, nil
+}
+
 // PruneEvents deletes events older than retentionDays and returns the count
 // removed.
 func (s *Store) PruneEvents(ctx context.Context, retentionDays int) (int64, error) {

--- a/internal/frontdesk/store_test.go
+++ b/internal/frontdesk/store_test.go
@@ -412,6 +412,38 @@ func TestNewestEventPerMember(t *testing.T) {
 	}
 }
 
+func TestNewestEventOfTypes(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	a, _ := s.CreateMember(ctx, "a", "http://a:8081", "")
+	b, _ := s.CreateMember(ctx, "b", "http://b:8081", "")
+
+	base := time.Now().UTC()
+	_, _ = s.InsertEvent(ctx, Event{Type: "config.sync_held", Severity: "warning", Source: "frontdesk", Message: "held", MemberID: a.ID, CreatedAt: base})
+	_, _ = s.InsertEvent(ctx, Event{Type: "config.sync_recovered", Severity: "success", Source: "frontdesk", Message: "recovered", MemberID: a.ID, CreatedAt: base.Add(time.Minute)})
+	// Newer events of other types, and other members' events, must not shadow the pick.
+	_, _ = s.InsertEvent(ctx, Event{Type: "health.up", Severity: "success", Source: "poller", Message: "up", MemberID: a.ID, CreatedAt: base.Add(2 * time.Minute)})
+	_, _ = s.InsertEvent(ctx, Event{Type: "config.sync_held", Severity: "warning", Source: "frontdesk", Message: "held", MemberID: b.ID, CreatedAt: base.Add(3 * time.Minute)})
+
+	ev, found, err := s.NewestEventOfTypes(ctx, a.ID, "config.sync_held", "config.sync_recovered")
+	if err != nil {
+		t.Fatalf("NewestEventOfTypes: %v", err)
+	}
+	if !found || ev.Type != "config.sync_recovered" {
+		t.Errorf("newest of the two types = (%q, %v), want config.sync_recovered", ev.Type, found)
+	}
+
+	// A member with no event of the given types reports found=false, whatever
+	// else its log holds.
+	if _, found, err := s.NewestEventOfTypes(ctx, a.ID, "config.auto_synced"); err != nil || found {
+		t.Errorf("no event of type: found=%v err=%v, want found=false", found, err)
+	}
+	if _, found, err := s.NewestEventOfTypes(ctx, a.ID); err != nil || found {
+		t.Errorf("no types given: found=%v err=%v, want found=false", found, err)
+	}
+}
+
 func TestEventsPagination(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()

--- a/internal/frontdesk/store_test.go
+++ b/internal/frontdesk/store_test.go
@@ -416,15 +416,27 @@ func TestNewestEventOfTypes(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()
 
-	a, _ := s.CreateMember(ctx, "a", "http://a:8081", "")
-	b, _ := s.CreateMember(ctx, "b", "http://b:8081", "")
+	a, err := s.CreateMember(ctx, "a", "http://a:8081", "")
+	if err != nil {
+		t.Fatalf("CreateMember a: %v", err)
+	}
+	b, err := s.CreateMember(ctx, "b", "http://b:8081", "")
+	if err != nil {
+		t.Fatalf("CreateMember b: %v", err)
+	}
+	insert := func(e Event) {
+		t.Helper()
+		if _, err := s.InsertEvent(ctx, e); err != nil {
+			t.Fatalf("InsertEvent %s: %v", e.Type, err)
+		}
+	}
 
 	base := time.Now().UTC()
-	_, _ = s.InsertEvent(ctx, Event{Type: "config.sync_held", Severity: "warning", Source: "frontdesk", Message: "held", MemberID: a.ID, CreatedAt: base})
-	_, _ = s.InsertEvent(ctx, Event{Type: "config.sync_recovered", Severity: "success", Source: "frontdesk", Message: "recovered", MemberID: a.ID, CreatedAt: base.Add(time.Minute)})
+	insert(Event{Type: "config.sync_held", Severity: "warning", Source: "frontdesk", Message: "held", MemberID: a.ID, CreatedAt: base})
+	insert(Event{Type: "config.sync_recovered", Severity: "success", Source: "frontdesk", Message: "recovered", MemberID: a.ID, CreatedAt: base.Add(time.Minute)})
 	// Newer events of other types, and other members' events, must not shadow the pick.
-	_, _ = s.InsertEvent(ctx, Event{Type: "health.up", Severity: "success", Source: "poller", Message: "up", MemberID: a.ID, CreatedAt: base.Add(2 * time.Minute)})
-	_, _ = s.InsertEvent(ctx, Event{Type: "config.sync_held", Severity: "warning", Source: "frontdesk", Message: "held", MemberID: b.ID, CreatedAt: base.Add(3 * time.Minute)})
+	insert(Event{Type: "health.up", Severity: "success", Source: "poller", Message: "up", MemberID: a.ID, CreatedAt: base.Add(2 * time.Minute)})
+	insert(Event{Type: "config.sync_held", Severity: "warning", Source: "frontdesk", Message: "held", MemberID: b.ID, CreatedAt: base.Add(3 * time.Minute)})
 
 	ev, found, err := s.NewestEventOfTypes(ctx, a.ID, "config.sync_held", "config.sync_recovered")
 	if err != nil {
@@ -432,6 +444,19 @@ func TestNewestEventOfTypes(t *testing.T) {
 	}
 	if !found || ev.Type != "config.sync_recovered" {
 		t.Errorf("newest of the two types = (%q, %v), want config.sync_recovered", ev.Type, found)
+	}
+
+	// Equal timestamps resolve by id DESC, the same tie-break ListEvents and
+	// NewestEventPerMember serve, so a caller ranking two types agrees with the
+	// surfaces that render the same rows. Explicit ids pin the winner.
+	insert(Event{ID: "id-a", Type: "config.sync_recovered", Severity: "success", Source: "frontdesk", Message: "recovered", MemberID: b.ID, CreatedAt: base.Add(4 * time.Minute)})
+	insert(Event{ID: "id-z", Type: "config.sync_held", Severity: "warning", Source: "frontdesk", Message: "held", MemberID: b.ID, CreatedAt: base.Add(4 * time.Minute)})
+	ev, found, err = s.NewestEventOfTypes(ctx, b.ID, "config.sync_held", "config.sync_recovered")
+	if err != nil {
+		t.Fatalf("NewestEventOfTypes (tie): %v", err)
+	}
+	if !found || ev.ID != "id-z" {
+		t.Errorf("timestamp tie pick = (%q, %v), want id-z (id DESC tie-break)", ev.ID, found)
 	}
 
 	// A member with no event of the given types reports found=false, whatever


### PR DESCRIPTION
## What

Three commits, two concerns:

**1. `config.sync_held` now gets a closing event (+ Members page cleanup)**

`config.sync_held` fired on the transition into a version-skew hold, but clearing the hold emitted nothing, so the warning stayed a member's newest event indefinitely: Bellhop's card pill kept saying "Held sync 2h ago" about a member Front Desk itself showed verified in sync. Leaving the held state now emits `config.sync_recovered` ("Resumed sync to X: its app version matches the primary's again") once on the transition out.

The hold set is in-memory, so a restart used to strand an announced hold with no way to ever close it (the likely origin of the stuck pill). `heldPerLog` reconciles against the persisted event log — newest `sync_held` vs newest `sync_recovered`, read at most once per member per process, read errors retried — so a hold announced before a restart still closes on the first aligned pass, and a member that comes back still skewed no longer re-emits a duplicate `sync_held`. Existing consumers (Bellhop pill via `NewestEventPerMember`, events feed, Apprise) need zero changes since `config.sync_recovered` is already in the catalog and all locales; fleet-state semantics are untouched.

Also drops the Members page **Updated** column: it rendered the FD registration row's `updated_at` (touched only by add/rename/token/drain-activate), which read as config freshness next to Verified and Last Sync while measuring something unrelated and administrative. The API field stays.

**2. Bellhop: member-scoped event lines no longer repeat the member's name**

The dashboard card said the name twice ("MH docker-vm" / "MH docker-vm is healthy"). A new `withoutMemberName` helper strips the member's own name — leading ("is healthy") and " to <name>" sync targets ("Held sync: its app version differs...") — on the card pill and the member detail log, with a whole-word boundary so "MH2" never matches inside "MH20" and a fall-back to the original message if stripping would empty it. The global events feed and the widget keep full messages: there the name identifies the member.

## Tests

- 4 new Go tests: recovered emitted exactly once on hold clear, hold closed across a simulated restart, no duplicate `sync_held` after restart while still skewed, store read error not memoised. Full `internal/frontdesk` suite green (464), golangci-lint clean, diff-coverage gate passing.
- FD web: MembersPage 24/24, `tsc -b`, `make i18n-check` (colUpdated removed from all 11 locales).
- Bellhop: 8 unit tests for the helper + screen tests for both surfaces (mutation-checked: reverting the call sites fails exactly those tests). `make android-test` green — 539 tests, ktlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)