### PR TITLE
fix(quota): disabled providers vanish from the fleet quota export

### DIFF
--- a/internal/api/quota_fleet.go
+++ b/internal/api/quota_fleet.go
@@ -70,6 +70,17 @@ func (h *QuotaFleetHandler) ExportSnapshots(w http.ResponseWriter, r *http.Reque
 	idToName := make(map[uuid.UUID]string, len(provs))
 	idToType := make(map[uuid.UUID]string, len(provs))
 	for _, p := range provs {
+		if !p.Enabled {
+			// A disabled provider's snapshot is frozen (the poller skips it) and
+			// its badge must disappear everywhere a disable happens, not just on
+			// the dashboard: this export feeds Front Desk's /api/quota proxy, which
+			// is what the FD dashboard and Bellhop render. Dropping it here is also
+			// harmless for the member-to-member distribution the same wire serves:
+			// members skip disabled providers in their own polls, and quota advice
+			// is meaningless for a provider that is not routed. Config-sync keeps
+			// enabled state fleet-wide, so the primary's view is the fleet's view.
+			continue
+		}
 		idToName[p.ID] = p.Name
 		idToType[p.ID] = provider.DetectProviderType(p.BaseURL)
 	}
@@ -86,7 +97,7 @@ func (h *QuotaFleetHandler) ExportSnapshots(w http.ResponseWriter, r *http.Reque
 		}
 		name, ok := idToName[s.ProviderID]
 		if !ok {
-			continue // provider deleted since the snapshot was stored; skip it
+			continue // provider deleted or disabled since the snapshot was stored
 		}
 		wire = append(wire, QuotaSnapshotWire{
 			ProviderName: name,

--- a/internal/api/quota_fleet_test.go
+++ b/internal/api/quota_fleet_test.go
@@ -111,6 +111,77 @@ func TestQuotaFleetExportSnapshots(t *testing.T) {
 	}
 }
 
+// TestQuotaFleetExportSkipsDisabledProviders: a disabled provider's badge must
+// disappear everywhere a disable happens (dashboard, Front Desk, Bellhop). The
+// dashboard filters client-side; FD and Bellhop render whatever this export
+// serves, so the frozen snapshot of a disabled provider is dropped here and
+// comes back when the provider is re-enabled.
+func TestQuotaFleetExportSkipsDisabledProviders(t *testing.T) {
+	h := newTestHandler(t)
+	fleet := NewQuotaFleetHandler(h.quotaRepo, h.providerRepo)
+	ctx := context.Background()
+
+	prov, err := h.providerRepo.Create(ctx, provider.CreateProviderRequest{
+		Name:    "zai-export-toggle",
+		BaseURL: "https://api.z.ai/api/coding/paas/v4",
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("create provider: %v", err)
+	}
+	if err := h.quotaRepo.Upsert(ctx, quota.Snapshot{
+		ProviderID: prov.ID,
+		Kind:       "usage",
+		Payload:    json.RawMessage(`{"used":4}`),
+		HTTPStatus: 200,
+		Source:     "poll",
+	}); err != nil {
+		t.Fatalf("upsert snapshot: %v", err)
+	}
+
+	export := func(t *testing.T) []QuotaSnapshotWire {
+		t.Helper()
+		rr := httptest.NewRecorder()
+		fleet.ExportSnapshots(rr, httptest.NewRequest(http.MethodGet, "/config/quota-snapshots", http.NoBody))
+		if rr.Code != http.StatusOK {
+			t.Fatalf("want 200, got %d: %s", rr.Code, rr.Body.String())
+		}
+		var body struct {
+			Snapshots []QuotaSnapshotWire `json:"snapshots"`
+		}
+		if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		return body.Snapshots
+	}
+	has := func(snaps []QuotaSnapshotWire) bool {
+		for _, s := range snaps {
+			if s.ProviderName == prov.Name {
+				return true
+			}
+		}
+		return false
+	}
+	setEnabled := func(t *testing.T, enabled bool) {
+		t.Helper()
+		if _, err := h.providerRepo.Update(ctx, prov.ID,
+			provider.UpdateProviderRequest{Enabled: &enabled}, nil, nil, nil); err != nil {
+			t.Fatalf("set enabled=%v: %v", enabled, err)
+		}
+	}
+
+	if !has(export(t)) {
+		t.Fatal("enabled provider's snapshot missing from the export")
+	}
+	setEnabled(t, false)
+	if has(export(t)) {
+		t.Fatal("disabled provider's snapshot still exported; its badge would linger on FD and Bellhop")
+	}
+	setEnabled(t, true)
+	if !has(export(t)) {
+		t.Fatal("re-enabled provider's snapshot did not return to the export")
+	}
+}
+
 // TestQuotaFleetExportSkipsFailurePlaceholders: RecordFailure leaves a
 // placeholder row (http_status=0, no real payload, fresh fetched_at). It must
 // not be distributed, or a member would store it as source='fleet' and suppress


### PR DESCRIPTION
Completes the "disabled provider = no badges" rule (#663) across all three apps. The MH dashboard filters client-side, but Front Desk's `/api/quota` proxy and Bellhop both render the primary's quota-snapshot export verbatim, so a disabled provider's badge lingered there frozen at its last pre-disable numbers.

`ExportSnapshots` now drops disabled providers; their snapshots return the moment they are re-enabled. Harmless for the member-to-member snapshot distribution the same wire feeds: members already skip disabled providers in their own polls, quota advice is meaningless for a provider that is not routed, and config-sync keeps enabled state fleet-wide so the primary's view is the fleet's view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)