### PR TITLE
feat(frontdesk): re-check credentials on the SSE heartbeat

### DIFF
--- a/internal/adminauth/middleware.go
+++ b/internal/adminauth/middleware.go
@@ -34,48 +34,96 @@ func RequireAdminOrSession(
 	next http.Handler,
 ) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Cookie path (browser). The session token rides an HttpOnly cookie
-		// instead of an Authorization header, named by the caller's jar so
-		// the dashboard and Front Desk never read each other's cookie when
-		// they share a hostname. It admits only the admin session (UserID
-		// == "admin"). A valid but non-admin (UUID) session cookie, or an
-		// absent/expired cookie, falls through to the header logic below so
-		// header (admin-token / bearer) callers stay unaffected. On unsafe
-		// methods a matching CSRF header is also required.
-		if tok, ok := jar.SessionToken(r); ok && sessionMgr != nil {
-			if userID, ok := sessionMgr.TokenUser(r.Context(), tok); ok && string(userID) == "admin" {
-				if !authcookie.IsSafeMethod(r.Method) && !jar.ValidCSRF(r) {
-					http.Error(w, "CSRF token missing or invalid", http.StatusForbidden)
-					return
-				}
-				next.ServeHTTP(w, r)
+		if validAdminCookie(r, sessionMgr, jar) {
+			if !authcookie.IsSafeMethod(r.Method) && !jar.ValidCSRF(r) {
+				http.Error(w, "CSRF token missing or invalid", http.StatusForbidden)
 				return
 			}
-			// Non-admin or invalid cookie session: fall through to header logic.
+			next.ServeHTTP(w, r)
+			return
 		}
 
+		// A caller with no bearer at all is told what is missing; a caller
+		// carrying one that does not resolve is told it was rejected. The two
+		// messages stay distinct, so the bearer branch is asked separately
+		// rather than folded into one boolean.
 		token, ok := util.ParseBearerToken(r)
 		if !ok {
 			http.Error(w, "Authorization header required (Bearer token)", http.StatusUnauthorized)
 			return
 		}
 
-		if (totpEnabled == nil || !totpEnabled()) && adminMgr.Validate(token) {
+		if validAdminBearer(r, token, adminMgr, sessionMgr, totpEnabled) {
 			next.ServeHTTP(w, r)
 			return
 		}
 
-		if sessionMgr != nil {
-			// Admin-only gate: resolve the session's identity and admit only the
-			// admin session (UserID == "admin"). A UUID-carrying multi-user/SSO
-			// user session must NOT pass, or a regular user could enroll admin
-			// TOTP or register an admin passkey and escalate to full admin.
-			if userID, ok := sessionMgr.TokenUser(r.Context(), token); ok && string(userID) == "admin" {
-				next.ServeHTTP(w, r)
-				return
-			}
-		}
-
 		http.Error(w, "Invalid admin token or session token", http.StatusUnauthorized)
 	})
+}
+
+// ValidAdminOrSession reports whether r carries a credential RequireAdminOrSession
+// would admit: an admin session token (cookie or bearer), or the raw admin token
+// while TOTP is disabled. CSRF is not checked here; it is an unsafe-method concern
+// the middleware owns.
+//
+// It exists for long-lived connections that outlive the middleware: an SSE stream
+// is gated once at connect, so the handler re-asks this question on its heartbeat
+// to bound how long a revoked credential keeps a stream alive.
+func ValidAdminOrSession(
+	r *http.Request,
+	adminMgr AdminAuthenticator,
+	sessionMgr *webauthn.SessionManager,
+	totpEnabled func() bool,
+	jar authcookie.Jar,
+) bool {
+	if validAdminCookie(r, sessionMgr, jar) {
+		return true
+	}
+	token, ok := util.ParseBearerToken(r)
+	if !ok {
+		return false
+	}
+	return validAdminBearer(r, token, adminMgr, sessionMgr, totpEnabled)
+}
+
+// validAdminCookie reports whether r carries an admin session on the jar's
+// session cookie. The session token rides an HttpOnly cookie instead of an
+// Authorization header, named by the caller's jar so the dashboard and Front
+// Desk never read each other's cookie when they share a hostname. Only the
+// admin session (UserID == "admin") qualifies: a valid but non-admin (UUID)
+// session cookie, or an absent/expired cookie, reports false so callers fall
+// through to the header path and header (admin-token / bearer) callers stay
+// unaffected.
+func validAdminCookie(r *http.Request, sessionMgr *webauthn.SessionManager, jar authcookie.Jar) bool {
+	tok, ok := jar.SessionToken(r)
+	if !ok || sessionMgr == nil {
+		return false
+	}
+	userID, ok := sessionMgr.TokenUser(r.Context(), tok)
+	return ok && string(userID) == "admin"
+}
+
+// validAdminBearer reports whether the bearer token parsed from r is admissible:
+// the raw admin token with TOTP off, or an admin session token.
+//
+// The admin-only gate resolves the session's identity and admits only the admin
+// session (UserID == "admin"). A UUID-carrying multi-user/SSO user session must
+// NOT pass, or a regular user could enroll admin TOTP or register an admin
+// passkey and escalate to full admin.
+func validAdminBearer(
+	r *http.Request,
+	token string,
+	adminMgr AdminAuthenticator,
+	sessionMgr *webauthn.SessionManager,
+	totpEnabled func() bool,
+) bool {
+	if (totpEnabled == nil || !totpEnabled()) && adminMgr.Validate(token) {
+		return true
+	}
+	if sessionMgr == nil {
+		return false
+	}
+	userID, ok := sessionMgr.TokenUser(r.Context(), token)
+	return ok && string(userID) == "admin"
 }

--- a/internal/adminauth/middleware_test.go
+++ b/internal/adminauth/middleware_test.go
@@ -46,31 +46,39 @@ func TestValidAdminOrSession(t *testing.T) {
 		want   bool
 	}{
 		{
-			name:  "admin cookie",
-			build: func(r *http.Request) { r.AddCookie(&http.Cookie{Name: "fd_session", Value: adminTok}) },
-			mgr:   mgr,
-			want:  true,
+			name: "admin cookie",
+			build: func(r *http.Request) {
+				r.AddCookie(&http.Cookie{Name: authcookie.FrontDesk.SessionCookie, Value: adminTok})
+			},
+			mgr:  mgr,
+			want: true,
 		},
 		{
 			name:   "admin cookie on an unsafe method without CSRF",
 			method: http.MethodPost,
-			build:  func(r *http.Request) { r.AddCookie(&http.Cookie{Name: "fd_session", Value: adminTok}) },
-			mgr:    mgr,
+			build: func(r *http.Request) {
+				r.AddCookie(&http.Cookie{Name: authcookie.FrontDesk.SessionCookie, Value: adminTok})
+			},
+			mgr: mgr,
 			// CSRF belongs to the middleware: the credential itself is valid, which
 			// is all a re-check on an already-open stream asks about.
 			want: true,
 		},
 		{
-			name:  "user cookie session",
-			build: func(r *http.Request) { r.AddCookie(&http.Cookie{Name: "fd_session", Value: userTok}) },
-			mgr:   mgr,
-			want:  false,
+			name: "user cookie session",
+			build: func(r *http.Request) {
+				r.AddCookie(&http.Cookie{Name: authcookie.FrontDesk.SessionCookie, Value: userTok})
+			},
+			mgr:  mgr,
+			want: false,
 		},
 		{
-			name:  "admin cookie under the other app's jar name",
-			build: func(r *http.Request) { r.AddCookie(&http.Cookie{Name: "mh_session", Value: adminTok}) },
-			mgr:   mgr,
-			want:  false,
+			name: "admin cookie under the other app's jar name",
+			build: func(r *http.Request) {
+				r.AddCookie(&http.Cookie{Name: authcookie.Dashboard.SessionCookie, Value: adminTok})
+			},
+			mgr:  mgr,
+			want: false,
 		},
 		{
 			name:  "raw admin token, TOTP off",
@@ -117,10 +125,12 @@ func TestValidAdminOrSession(t *testing.T) {
 			want:  true,
 		},
 		{
-			name:  "session cookie with no session manager",
-			build: func(r *http.Request) { r.AddCookie(&http.Cookie{Name: "fd_session", Value: adminTok}) },
-			mgr:   nil,
-			want:  false,
+			name: "session cookie with no session manager",
+			build: func(r *http.Request) {
+				r.AddCookie(&http.Cookie{Name: authcookie.FrontDesk.SessionCookie, Value: adminTok})
+			},
+			mgr:  nil,
+			want: false,
 		},
 		{
 			name:  "unknown bearer with no session manager",

--- a/internal/adminauth/middleware_test.go
+++ b/internal/adminauth/middleware_test.go
@@ -1,0 +1,147 @@
+package adminauth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hugalafutro/model-hotel/internal/authcookie"
+	"github.com/hugalafutro/model-hotel/internal/webauthn"
+)
+
+// ValidAdminOrSession is the admission half of RequireAdminOrSession, exported
+// for long-lived connections (the Front Desk SSE stream) that re-ask the
+// question after the middleware has run. The middleware suite covers the
+// admission cases it can express as a status code; these cover the rest: the
+// predicate answers on a request the middleware would have rejected for CSRF,
+// and it works with no session manager at all.
+
+// newValidAdminSession returns a session manager holding one admin session and
+// one regular-user session, both DB-free.
+func newValidAdminSession(t *testing.T) (mgr *webauthn.SessionManager, adminTok, userTok string) {
+	t.Helper()
+	mgr = webauthn.NewSessionManager(newMemStore())
+	var err error
+	if adminTok, err = mgr.CreateAuthToken(context.Background(), []byte("admin"), nil); err != nil {
+		t.Fatalf("CreateAuthToken(admin): %v", err)
+	}
+	if userTok, err = mgr.CreateAuthToken(context.Background(), []byte("6f1d0f26-0f77-4a0a-9a1e-2b6b1f8f0f11"), nil); err != nil {
+		t.Fatalf("CreateAuthToken(user): %v", err)
+	}
+	return mgr, adminTok, userTok
+}
+
+func TestValidAdminOrSession(t *testing.T) {
+	mgr, adminTok, userTok := newValidAdminSession(t)
+	adminOnly := &mockAdminAuth{validateFn: func(token string) bool { return token == "raw-admin" }}
+	totpOn := func() bool { return true }
+
+	tests := []struct {
+		name   string
+		method string
+		build  func(r *http.Request)
+		mgr    *webauthn.SessionManager
+		totp   func() bool
+		want   bool
+	}{
+		{
+			name:  "admin cookie",
+			build: func(r *http.Request) { r.AddCookie(&http.Cookie{Name: "fd_session", Value: adminTok}) },
+			mgr:   mgr,
+			want:  true,
+		},
+		{
+			name:   "admin cookie on an unsafe method without CSRF",
+			method: http.MethodPost,
+			build:  func(r *http.Request) { r.AddCookie(&http.Cookie{Name: "fd_session", Value: adminTok}) },
+			mgr:    mgr,
+			// CSRF belongs to the middleware: the credential itself is valid, which
+			// is all a re-check on an already-open stream asks about.
+			want: true,
+		},
+		{
+			name:  "user cookie session",
+			build: func(r *http.Request) { r.AddCookie(&http.Cookie{Name: "fd_session", Value: userTok}) },
+			mgr:   mgr,
+			want:  false,
+		},
+		{
+			name:  "admin cookie under the other app's jar name",
+			build: func(r *http.Request) { r.AddCookie(&http.Cookie{Name: "mh_session", Value: adminTok}) },
+			mgr:   mgr,
+			want:  false,
+		},
+		{
+			name:  "raw admin token, TOTP off",
+			build: func(r *http.Request) { r.Header.Set("Authorization", "Bearer raw-admin") },
+			mgr:   mgr,
+			want:  true,
+		},
+		{
+			name:  "raw admin token, TOTP on",
+			build: func(r *http.Request) { r.Header.Set("Authorization", "Bearer raw-admin") },
+			mgr:   mgr,
+			totp:  totpOn,
+			want:  false,
+		},
+		{
+			name:  "admin session as a bearer",
+			build: func(r *http.Request) { r.Header.Set("Authorization", "Bearer "+adminTok) },
+			mgr:   mgr,
+			totp:  totpOn,
+			want:  true,
+		},
+		{
+			name:  "user session as a bearer",
+			build: func(r *http.Request) { r.Header.Set("Authorization", "Bearer "+userTok) },
+			mgr:   mgr,
+			want:  false,
+		},
+		{
+			name:  "unknown bearer",
+			build: func(r *http.Request) { r.Header.Set("Authorization", "Bearer nope") },
+			mgr:   mgr,
+			want:  false,
+		},
+		{
+			name:  "no credential at all",
+			build: func(*http.Request) {},
+			mgr:   mgr,
+			want:  false,
+		},
+		{
+			name:  "raw admin token with no session manager",
+			build: func(r *http.Request) { r.Header.Set("Authorization", "Bearer raw-admin") },
+			mgr:   nil,
+			want:  true,
+		},
+		{
+			name:  "session cookie with no session manager",
+			build: func(r *http.Request) { r.AddCookie(&http.Cookie{Name: "fd_session", Value: adminTok}) },
+			mgr:   nil,
+			want:  false,
+		},
+		{
+			name:  "unknown bearer with no session manager",
+			build: func(r *http.Request) { r.Header.Set("Authorization", "Bearer nope") },
+			mgr:   nil,
+			want:  false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			method := tc.method
+			if method == "" {
+				method = http.MethodGet
+			}
+			r := httptest.NewRequest(method, "/api/sse", http.NoBody)
+			tc.build(r)
+			got := ValidAdminOrSession(r, adminOnly, tc.mgr, tc.totp, authcookie.FrontDesk)
+			if got != tc.want {
+				t.Errorf("ValidAdminOrSession = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/api/events_reauth_test.go
+++ b/internal/api/events_reauth_test.go
@@ -31,6 +31,14 @@ func (m *revocableSessionMgr) revoke() {
 	m.revoked = true
 }
 
+// setRevoked flips validity in both directions, for staging a failed re-check
+// that heals on the next tick.
+func (m *revocableSessionMgr) setRevoked(revoked bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.revoked = revoked
+}
+
 func (m *revocableSessionMgr) CreateAuthToken(_ context.Context, _, _ []byte) (string, error) {
 	return "stream-token", nil
 }
@@ -231,6 +239,57 @@ func TestStreamEvents_RefreshesGrantsMidStream(t *testing.T) {
 	if strings.Contains(delivered, "request.completed") {
 		t.Errorf("stream kept delivering request events after the logs grant was revoked: %q", delivered)
 	}
+
+	cancel()
+	<-done
+}
+
+// A passing re-check resets the consecutive-failure count, so failures have to
+// be consecutive to close a stream. The third phase is the assertion that
+// matters: it is the stream's second failed check overall but the first since a
+// passing one, so the stream must survive it. A counter that only ever climbed
+// would drop a caller whose credential blipped twice over an afternoon.
+func TestStreamEvents_PassingRecheckResetsFailureCount(t *testing.T) {
+	mgr := &revocableSessionMgr{}
+	h := testHandler(nil, nil, nil, nil, nil)
+	h.SetWebAuthnSessionManager(mgr)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	rec := newSyncRecorder()
+	done := make(chan struct{})
+	go func() {
+		// Wide enough that flipping the session in reaction to one heartbeat
+		// comfortably lands before the next re-check.
+		h.streamEvents(rec, streamRequest(ctx), 200*time.Millisecond)
+		close(done)
+	}()
+	<-rec.flushed
+
+	// beat waits for the nth heartbeat and asserts the stream is still open.
+	beat := func(n int, why string) {
+		t.Helper()
+		if !waitFor(t, func() bool { return strings.Count(rec.String(), ": heartbeat") >= n }) {
+			t.Fatalf("heartbeat %d never arrived (%s): %q", n, why, rec.String())
+		}
+		select {
+		case <-done:
+			t.Fatalf("stream closed %s", why)
+		default:
+		}
+	}
+
+	beat(1, "while the session was valid")
+
+	mgr.setRevoked(true)
+	beat(2, "on the first failed re-check")
+
+	mgr.setRevoked(false)
+	beat(3, "after the credential recovered")
+
+	mgr.setRevoked(true)
+	beat(4, "on a failure the passing re-check should have reset the counter for")
 
 	cancel()
 	<-done

--- a/internal/frontdesk/coverage_test.go
+++ b/internal/frontdesk/coverage_test.go
@@ -10,8 +10,6 @@ import (
 	"testing"
 	"testing/fstest"
 	"time"
-
-	"github.com/hugalafutro/model-hotel/internal/events"
 )
 
 // TestPollerRunTicksAndStops exercises Run + tickLoop and one tick of every poll
@@ -263,8 +261,11 @@ func TestHandleTraefikConfig(t *testing.T) {
 	}
 }
 
-// TestSSEStreamsAndStops covers the SSE handler: it sets up the stream, delivers
-// a published event, and returns when the request context is cancelled.
+// TestSSEStreamsAndStops covers the routed /api/sse path end to end: the auth
+// gate admits the admin bearer, the handler answers with event-stream headers,
+// and it returns when the client hangs up. The streaming behaviour behind it
+// (keep-alives, credential re-checks, event frames) is covered against the
+// handler directly in sse_reauth_test.go.
 func TestSSEStreamsAndStops(t *testing.T) {
 	srv, _ := newTestServer(t)
 
@@ -278,18 +279,15 @@ func TestSSEStreamsAndStops(t *testing.T) {
 		srv.ServeHTTP(rec, req)
 		close(done)
 	}()
-
-	// Give the handler time to subscribe, then publish an event so the data
-	// branch runs, then cancel so the handler exits via ctx.Done().
-	time.Sleep(40 * time.Millisecond)
-	srv.bus.Publish(events.Event{Type: "member.added", Severity: "info", Source: "test", Message: "hi"})
-	time.Sleep(40 * time.Millisecond)
 	cancel()
 
 	select {
 	case <-done:
-	case <-time.After(2 * time.Second):
+	case <-time.After(5 * time.Second):
 		t.Fatal("sse did not return after context cancel")
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
 	}
 	if ct := rec.Header().Get("Content-Type"); ct != "text/event-stream" {
 		t.Errorf("content-type = %q, want text/event-stream", ct)

--- a/internal/frontdesk/server_status.go
+++ b/internal/frontdesk/server_status.go
@@ -114,17 +114,22 @@ func (s *Server) sse(w http.ResponseWriter, r *http.Request) {
 // revalidate re-runs the connect-time admission of requireAuth: a device token
 // that still resolves to a non-revoked device, otherwise the admin-or-session
 // gate. last_seen_at is deliberately not re-stamped; it records requests the
-// device made, not a heartbeat this server drives. A store error other than
-// ErrNotFound counts as a failed check, which the failure tolerance absorbs.
+// device made, not a heartbeat this server drives.
+//
+// A device-lookup failure falls through to the admin/session gate, exactly as
+// requireAuth does: that gate never reads paired_devices, so a broken or
+// unavailable table cannot close an admin-bearer stream. A device token then
+// fails the gate and the tick counts as a failed check, which the tolerance
+// absorbs when the failure was a one-off blip. The error is logged only while
+// the request is live; a client hanging up races the tick and is not a fault.
 func (s *Server) revalidate(r *http.Request) bool {
 	if token, ok := util.ParseBearerToken(r); ok {
 		_, err := s.store.DeviceByTokenHash(r.Context(), hashDeviceToken(token))
 		if err == nil {
 			return true
 		}
-		if !errors.Is(err, ErrNotFound) {
+		if !errors.Is(err, ErrNotFound) && r.Context().Err() == nil {
 			debuglog.Error("frontdesk: sse device token re-check", "error", err)
-			return false
 		}
 	}
 	return adminauth.ValidAdminOrSession(r, s.adminMgr, s.sessionMgr, s.totpStatus.Enabled, authcookie.FrontDesk)

--- a/internal/frontdesk/server_status.go
+++ b/internal/frontdesk/server_status.go
@@ -108,7 +108,7 @@ const sseReauthFailuresBeforeClose = 2
 // Desk SSE has no per-subscriber filtering (every authenticated caller sees the
 // whole bus), so there is no identity to refresh.
 func (s *Server) sse(w http.ResponseWriter, r *http.Request) {
-	s.stream(w, r, sseHeartbeat)
+	s.streamEvents(w, r, sseHeartbeat)
 }
 
 // revalidate re-runs the connect-time admission of requireAuth: a device token
@@ -161,10 +161,10 @@ func (s *Server) reauthLoop(r *http.Request, every time.Duration, out chan<- boo
 	}
 }
 
-// stream is sse with the heartbeat cadence supplied by the caller, so the
+// streamEvents is sse with the heartbeat cadence supplied by the caller, so the
 // keep-alive/re-auth tick can be driven without waiting out the production
 // interval.
-func (s *Server) stream(w http.ResponseWriter, r *http.Request, heartbeatEvery time.Duration) {
+func (s *Server) streamEvents(w http.ResponseWriter, r *http.Request, heartbeatEvery time.Duration) {
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		http.Error(w, "streaming unsupported", http.StatusInternalServerError)

--- a/internal/frontdesk/server_status.go
+++ b/internal/frontdesk/server_status.go
@@ -3,11 +3,14 @@ package frontdesk
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"maps"
 	"net/http"
 	"sync/atomic"
 	"time"
 
+	"github.com/hugalafutro/model-hotel/internal/adminauth"
+	"github.com/hugalafutro/model-hotel/internal/authcookie"
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 	"github.com/hugalafutro/model-hotel/internal/events"
 	"github.com/hugalafutro/model-hotel/internal/otelexport"
@@ -78,10 +81,85 @@ func (s *Server) getObservability(w http.ResponseWriter, _ *http.Request) {
 	})
 }
 
-// sseHeartbeat keeps idle SSE connections alive through proxies.
+// sseHeartbeat keeps idle SSE connections alive through proxies, and is
+// therefore also how often the caller's credentials are re-checked.
 const sseHeartbeat = 25 * time.Second
 
+// sseReauthFailuresBeforeClose is how many consecutive failed credential
+// re-checks close a stream, bounding authorization staleness at
+// sseHeartbeat * this.
+//
+// Tolerance rather than fail-fast because revalidate cannot distinguish "this
+// device was unpaired" from "the store could not be asked": both surface as a
+// plain false. A revoked credential fails every check and is dropped on the
+// second, while a transient store failure (a locked SQLite file, a restart mid
+// query) recovers on the next tick. Failing on the first miss would turn a brief
+// blip into a forced logout, since the SPA's SSE reconnect treats a 401 as
+// "session gone" and sends the operator back to the login screen.
+const sseReauthFailuresBeforeClose = 2
+
+// sse streams control-plane events to the dashboard and to paired devices.
+//
+// The caller's credentials are re-checked on every heartbeat rather than pinned
+// at connect. requireAuth only runs once, so a stream opened before a device was
+// unpaired or a session revoked would otherwise keep delivering events for as
+// long as the client held the socket open - unbounded, since the heartbeat keeps
+// it alive. Unlike the main server's stream this re-check is validity-only: Front
+// Desk SSE has no per-subscriber filtering (every authenticated caller sees the
+// whole bus), so there is no identity to refresh.
 func (s *Server) sse(w http.ResponseWriter, r *http.Request) {
+	s.stream(w, r, sseHeartbeat)
+}
+
+// revalidate re-runs the connect-time admission of requireAuth: a device token
+// that still resolves to a non-revoked device, otherwise the admin-or-session
+// gate. last_seen_at is deliberately not re-stamped; it records requests the
+// device made, not a heartbeat this server drives. A store error other than
+// ErrNotFound counts as a failed check, which the failure tolerance absorbs.
+func (s *Server) revalidate(r *http.Request) bool {
+	if token, ok := util.ParseBearerToken(r); ok {
+		_, err := s.store.DeviceByTokenHash(r.Context(), hashDeviceToken(token))
+		if err == nil {
+			return true
+		}
+		if !errors.Is(err, ErrNotFound) {
+			debuglog.Error("frontdesk: sse device token re-check", "error", err)
+			return false
+		}
+	}
+	return adminauth.ValidAdminOrSession(r, s.adminMgr, s.sessionMgr, s.totpStatus.Enabled, authcookie.FrontDesk)
+}
+
+// reauthLoop re-checks the caller's credentials on every tick and reports the
+// verdict on out. Exits when the request context is cancelled.
+//
+// Runs off the read loop deliberately. revalidate makes a store round-trip, and
+// the event bus drops events for any subscriber that is not draining its channel
+// (internal/events/bus.go), so doing this inline would trade a slow credential
+// lookup for lost live events on a busy control plane.
+func (s *Server) reauthLoop(r *http.Request, every time.Duration, out chan<- bool) {
+	ticker := time.NewTicker(every)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-ticker.C:
+			valid := s.revalidate(r)
+			select {
+			case out <- valid:
+			case <-r.Context().Done():
+				return
+			}
+		}
+	}
+}
+
+// stream is sse with the heartbeat cadence supplied by the caller, so the
+// keep-alive/re-auth tick can be driven without waiting out the production
+// interval.
+func (s *Server) stream(w http.ResponseWriter, r *http.Request, heartbeatEvery time.Duration) {
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
@@ -96,14 +174,28 @@ func (s *Server) sse(w http.ResponseWriter, r *http.Request) {
 	ch := s.bus.Subscribe()
 	defer s.bus.Unsubscribe(ch)
 
-	ticker := time.NewTicker(sseHeartbeat)
-	defer ticker.Stop()
+	// Buffered so a re-auth verdict never parks its goroutine while this loop is
+	// busy writing an event; the loop drains it on the next pass.
+	reauth := make(chan bool, 1)
+	go s.reauthLoop(r, heartbeatEvery, reauth)
 
+	failures := 0
 	for {
 		select {
 		case <-r.Context().Done():
 			return
-		case <-ticker.C:
+		case valid := <-reauth:
+			// A re-auth verdict doubles as the keep-alive tick.
+			if valid {
+				failures = 0
+			} else {
+				failures++
+				if failures >= sseReauthFailuresBeforeClose {
+					debuglog.Info("frontdesk: sse stream closed, credentials no longer valid",
+						"remote_addr", r.RemoteAddr, "consecutive_failures", failures)
+					return
+				}
+			}
 			if _, err := w.Write([]byte(": keep-alive\n\n")); err != nil {
 				return
 			}

--- a/internal/frontdesk/sse_reauth_test.go
+++ b/internal/frontdesk/sse_reauth_test.go
@@ -102,16 +102,17 @@ func assertOpen(t *testing.T, done <-chan struct{}, why string) {
 func startStream(t *testing.T, srv *Server, req *http.Request) (*sseRecorder, chan struct{}) {
 	t.Helper()
 	rec := newSSERecorder()
-	return rec, startStreamWith(t, srv, req, rec)
+	return rec, startStreamWith(t, srv, req, rec, sseTick)
 }
 
-// startStreamWith is startStream against a recorder the test has configured.
-func startStreamWith(t *testing.T, srv *Server, req *http.Request, rec *sseRecorder) chan struct{} {
+// startStreamWith is startStream against a recorder and a cadence the test has
+// chosen, for the cases that need a configured writer or a wider tick.
+func startStreamWith(t *testing.T, srv *Server, req *http.Request, rec *sseRecorder, every time.Duration) chan struct{} {
 	t.Helper()
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		srv.stream(rec, req, sseTick)
+		srv.stream(rec, req, every)
 	}()
 	return done
 }
@@ -249,13 +250,17 @@ func TestSSESingleFailureDoesNotClose(t *testing.T) {
 // survives. TOTP is flipped on to make the raw admin token stop resolving (with
 // TOTP enabled it is a first factor only) and back off to heal it, which is the
 // in-memory equivalent of a store blip clearing on the next tick.
+//
+// The healing flip has to land before the tick after the one it reacts to, so
+// this is the one test that runs at a wider cadence than the rest.
 func TestSSEFailedCheckRecovers(t *testing.T) {
 	srv, _ := newTestServer(t)
 
 	req, cancel := sseRequest(t)
 	req.Header.Set("Authorization", "Bearer "+testFrontdeskToken)
 
-	rec, done := startStream(t, srv, req)
+	rec := newSSERecorder()
+	done := startStreamWith(t, srv, req, rec, 500*time.Millisecond)
 	awaitWrite(t, rec, "keep-alive on a live admin token")
 
 	srv.totpStatus.val.Store(true)
@@ -272,23 +277,50 @@ func TestSSEFailedCheckRecovers(t *testing.T) {
 }
 
 // A device-token lookup that errors for a reason other than "no such device"
-// counts as a failed check rather than falling through to the admin gate, so a
-// broken store closes streams instead of silently widening admission.
-func TestSSEStoreErrorCountsAsFailure(t *testing.T) {
-	srv, store := newTestServer(t)
-	token, _ := pairDevice(t, srv, RoleMonitor, "phone")
+// falls through to the admin/session gate, exactly as requireAuth does. An admin
+// bearer never depended on paired_devices, so a broken table must not close its
+// stream; a device token has nothing else to fall back on, so its stream closes
+// once the tolerance is used up.
+func TestSSEDeviceStoreErrorFallsThroughToTheAdminGate(t *testing.T) {
+	t.Run("admin bearer survives", func(t *testing.T) {
+		srv, store := newTestServer(t)
 
-	req, cancel := sseRequest(t)
-	defer cancel()
-	req.Header.Set("Authorization", "Bearer "+token)
+		req, cancel := sseRequest(t)
+		req.Header.Set("Authorization", "Bearer "+testFrontdeskToken)
 
-	// Closing the store makes every DeviceByTokenHash return a driver error.
-	if err := store.Close(); err != nil {
-		t.Fatalf("store.Close: %v", err)
-	}
+		// Closing the store makes every DeviceByTokenHash return a driver error.
+		if err := store.Close(); err != nil {
+			t.Fatalf("store.Close: %v", err)
+		}
 
-	_, done := startStream(t, srv, req)
-	awaitClosed(t, done, "with a store that errors on every re-check")
+		rec, done := startStream(t, srv, req)
+		for range 3 {
+			awaitWrite(t, rec, "keep-alive")
+			assertOpen(t, done, "on an admin bearer while the device table was unreadable")
+		}
+
+		cancel()
+		awaitClosed(t, done, "after the client hung up")
+	})
+
+	t.Run("device token closes", func(t *testing.T) {
+		srv, store := newTestServer(t)
+		token, _ := pairDevice(t, srv, RoleMonitor, "phone")
+
+		req, cancel := sseRequest(t)
+		defer cancel()
+		req.Header.Set("Authorization", "Bearer "+token)
+
+		if err := store.Close(); err != nil {
+			t.Fatalf("store.Close: %v", err)
+		}
+
+		rec, done := startStream(t, srv, req)
+		awaitClosed(t, done, "on a device token the store could no longer confirm")
+		if got := strings.Count(rec.String(), ": keep-alive"); got != 1 {
+			t.Errorf("keep-alives = %d, want exactly 1 (the first failure is tolerated, the second closes)", got)
+		}
+	})
 }
 
 // Bus events still reach the stream alongside the re-auth tick.
@@ -330,7 +362,7 @@ func TestSSEStopsWhenTheClientIsGone(t *testing.T) {
 
 		rec := newSSERecorder()
 		rec.failOn = func(string) bool { return true }
-		done := startStreamWith(t, srv, req, rec)
+		done := startStreamWith(t, srv, req, rec, sseTick)
 		awaitClosed(t, done, "after the keep-alive write failed")
 	})
 
@@ -342,7 +374,7 @@ func TestSSEStopsWhenTheClientIsGone(t *testing.T) {
 
 		rec := newSSERecorder()
 		rec.failOn = func(frame string) bool { return strings.HasPrefix(frame, "data: ") }
-		done := startStreamWith(t, srv, req, rec)
+		done := startStreamWith(t, srv, req, rec, sseTick)
 		awaitWrite(t, rec, "keep-alive")
 		srv.bus.Publish(events.Event{Type: "member.state_changed", Severity: "info", Source: "frontdesk"})
 		awaitClosed(t, done, "after the event write failed")

--- a/internal/frontdesk/sse_reauth_test.go
+++ b/internal/frontdesk/sse_reauth_test.go
@@ -112,7 +112,7 @@ func startStreamWith(t *testing.T, srv *Server, req *http.Request, rec *sseRecor
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		srv.stream(rec, req, every)
+		srv.streamEvents(rec, req, every)
 	}()
 	return done
 }
@@ -251,7 +251,11 @@ func TestSSESingleFailureDoesNotClose(t *testing.T) {
 // TOTP enabled it is a first factor only) and back off to heal it, which is the
 // in-memory equivalent of a store blip clearing on the next tick.
 //
-// The healing flip has to land before the tick after the one it reacts to, so
+// The last flip is what pins the reset: it is the second failure of the stream
+// but the first since the passing check, so the stream must live through it. A
+// counter that only ever climbed would close here.
+//
+// Each healing flip has to land before the tick after the one it reacts to, so
 // this is the one test that runs at a wider cadence than the rest.
 func TestSSEFailedCheckRecovers(t *testing.T) {
 	srv, _ := newTestServer(t)
@@ -269,8 +273,11 @@ func TestSSEFailedCheckRecovers(t *testing.T) {
 
 	srv.totpStatus.val.Store(false)
 	awaitWrite(t, rec, "keep-alive after the credential recovered")
-	awaitWrite(t, rec, "further keep-alive proving the counter reset")
-	assertOpen(t, done, "after the failure counter was reset by a passing re-check")
+	assertOpen(t, done, "after a passing re-check followed the failure")
+
+	srv.totpStatus.val.Store(true)
+	awaitWrite(t, rec, "keep-alive after the second isolated failure")
+	assertOpen(t, done, "on a failure the passing re-check should have reset the counter for")
 
 	cancel()
 	awaitClosed(t, done, "after the client hung up")
@@ -415,7 +422,7 @@ func TestSSERejectsNonFlushingWriter(t *testing.T) {
 	req, cancel := sseRequest(t)
 	defer cancel()
 	rec := &nonFlushingWriter{hdr: http.Header{}}
-	srv.stream(rec, req, sseTick)
+	srv.streamEvents(rec, req, sseTick)
 
 	if rec.status != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500", rec.status)

--- a/internal/frontdesk/sse_reauth_test.go
+++ b/internal/frontdesk/sse_reauth_test.go
@@ -1,0 +1,401 @@
+package frontdesk
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/hugalafutro/model-hotel/internal/authcookie"
+	"github.com/hugalafutro/model-hotel/internal/events"
+)
+
+// The SSE stream re-checks the caller's credentials on every heartbeat, so a
+// credential revoked after connect stops the stream instead of living as long
+// as the socket. These tests drive the handler's unexported cadence variant at
+// a millisecond-scale tick and assert on observable writes and handler return,
+// never on a sleep sized to the cadence.
+
+// sseTick is the cadence the tests drive the heartbeat at. Long enough that a
+// test reacting to one keep-alive comfortably wins the race against the next
+// tick, short enough that a whole test runs in well under a second.
+const sseTick = 100 * time.Millisecond
+
+// sseRecorder is a ResponseWriter whose body can be read while the handler is
+// still writing, and which signals every write, so a test can react to a
+// keep-alive the moment it lands.
+type sseRecorder struct {
+	mu     sync.Mutex
+	hdr    http.Header
+	body   strings.Builder
+	writes chan struct{}
+	// failOn, set before the stream starts, stands in for a client that hung up:
+	// the frames it selects fail to write.
+	failOn func(frame string) bool
+}
+
+func newSSERecorder() *sseRecorder {
+	return &sseRecorder{hdr: http.Header{}, writes: make(chan struct{}, 64)}
+}
+
+func (s *sseRecorder) Header() http.Header { return s.hdr }
+func (s *sseRecorder) WriteHeader(int)     {}
+func (s *sseRecorder) Flush()              {}
+
+func (s *sseRecorder) Write(p []byte) (int, error) {
+	if s.failOn != nil && s.failOn(string(p)) {
+		return 0, syscall.EPIPE
+	}
+	s.mu.Lock()
+	n, err := s.body.Write(p)
+	s.mu.Unlock()
+	select {
+	case s.writes <- struct{}{}:
+	default:
+	}
+	return n, err
+}
+
+func (s *sseRecorder) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.body.String()
+}
+
+// awaitWrite blocks until the handler writes to the stream, failing the test if
+// nothing arrives within a deadline far longer than the tick.
+func awaitWrite(t *testing.T, rec *sseRecorder, what string) {
+	t.Helper()
+	select {
+	case <-rec.writes:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("no %s arrived: body=%q", what, rec.String())
+	}
+}
+
+// awaitClosed blocks until the handler returns, failing the test otherwise.
+func awaitClosed(t *testing.T, done <-chan struct{}, why string) {
+	t.Helper()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("stream stayed open %s", why)
+	}
+}
+
+// assertOpen fails if the handler has already returned.
+func assertOpen(t *testing.T, done <-chan struct{}, why string) {
+	t.Helper()
+	select {
+	case <-done:
+		t.Fatalf("stream closed %s", why)
+	default:
+	}
+}
+
+// startStream runs the SSE handler in the background at the test cadence and
+// returns the live recorder plus a channel closed when the handler returns.
+func startStream(t *testing.T, srv *Server, req *http.Request) (*sseRecorder, chan struct{}) {
+	t.Helper()
+	rec := newSSERecorder()
+	return rec, startStreamWith(t, srv, req, rec)
+}
+
+// startStreamWith is startStream against a recorder the test has configured.
+func startStreamWith(t *testing.T, srv *Server, req *http.Request, rec *sseRecorder) chan struct{} {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		srv.stream(rec, req, sseTick)
+	}()
+	return done
+}
+
+// sseRequest builds a GET /api/sse request on a context the test controls.
+func sseRequest(t *testing.T) (*http.Request, context.CancelFunc) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	return httptest.NewRequestWithContext(ctx, http.MethodGet, "/api/sse", http.NoBody), cancel
+}
+
+// A device unpaired while its stream is open must lose the stream: the next
+// re-checks fail and the handler returns.
+func TestSSEClosesAfterDeviceRevoked(t *testing.T) {
+	srv, store := newTestServer(t)
+	token, id := pairDevice(t, srv, RoleMonitor, "phone")
+
+	req, cancel := sseRequest(t)
+	defer cancel()
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	rec, done := startStream(t, srv, req)
+	awaitWrite(t, rec, "keep-alive on a live device token")
+
+	if err := store.RevokePairedDevice(context.Background(), id); err != nil {
+		t.Fatalf("RevokePairedDevice: %v", err)
+	}
+	awaitClosed(t, done, "after the device was unpaired")
+
+	if body := rec.String(); !strings.Contains(body, ": keep-alive") {
+		t.Errorf("expected keep-alives before revocation, got %q", body)
+	}
+}
+
+// A session revoked while its stream is open must lose the stream too, whether
+// the token rode a cookie or the Authorization header.
+func TestSSEClosesAfterSessionRevoked(t *testing.T) {
+	for _, carrier := range []string{"cookie", "bearer"} {
+		t.Run(carrier, func(t *testing.T) {
+			srv, _ := newTestServer(t)
+			ctx := context.Background()
+			token, err := srv.SessionManager().CreateAuthToken(ctx, []byte("admin"), nil)
+			if err != nil {
+				t.Fatalf("CreateAuthToken: %v", err)
+			}
+
+			req, cancel := sseRequest(t)
+			defer cancel()
+			if carrier == "cookie" {
+				req.AddCookie(&http.Cookie{Name: authcookie.FrontDesk.SessionCookie, Value: token})
+			} else {
+				req.Header.Set("Authorization", "Bearer "+token)
+			}
+
+			rec, done := startStream(t, srv, req)
+			awaitWrite(t, rec, "keep-alive on a live session")
+
+			if !srv.SessionManager().RevokeAuthToken(ctx, token) {
+				t.Fatal("RevokeAuthToken did not find the session")
+			}
+			awaitClosed(t, done, "after its session was revoked")
+		})
+	}
+}
+
+// A credential that stays valid must keep its stream: many re-checks in a row
+// pass, the failure counter never builds, and only the client hanging up (the
+// request context) ends the stream.
+func TestSSEValidCredentialStaysConnected(t *testing.T) {
+	srv, _ := newTestServer(t)
+
+	req, cancel := sseRequest(t)
+	req.Header.Set("Authorization", "Bearer "+testFrontdeskToken)
+
+	rec, done := startStream(t, srv, req)
+	for range 3 {
+		awaitWrite(t, rec, "keep-alive")
+		assertOpen(t, done, "while its admin token was still valid")
+	}
+
+	cancel()
+	awaitClosed(t, done, "after the client hung up")
+
+	if got := strings.Count(rec.String(), ": keep-alive"); got < 3 {
+		t.Errorf("keep-alives = %d, want at least 3 on a long-lived valid stream", got)
+	}
+}
+
+// The re-check must not stamp last_seen_at: that column records requests the
+// device made, and a heartbeat this server drives would make an idle phone look
+// permanently active in the Paired devices list.
+func TestSSEReauthDoesNotStampDeviceLastSeen(t *testing.T) {
+	srv, store := newTestServer(t)
+	token, _ := pairDevice(t, srv, RoleMonitor, "phone")
+
+	req, cancel := sseRequest(t)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	rec, done := startStream(t, srv, req)
+	awaitWrite(t, rec, "keep-alive")
+	awaitWrite(t, rec, "second keep-alive")
+	cancel()
+	awaitClosed(t, done, "after the client hung up")
+
+	devices, err := store.ListPairedDevices(context.Background())
+	if err != nil || len(devices) != 1 {
+		t.Fatalf("ListPairedDevices = %v, %v", devices, err)
+	}
+	if devices[0].LastSeenAt != nil {
+		t.Errorf("re-auth stamped last_seen_at = %v, want it untouched", devices[0].LastSeenAt)
+	}
+}
+
+// One failed re-check must not close the stream: the tolerance is there so a
+// transient store failure does not log the operator out. A stream whose
+// credential never resolves therefore writes exactly one keep-alive (failure 1)
+// and closes on the second failure.
+func TestSSESingleFailureDoesNotClose(t *testing.T) {
+	srv, _ := newTestServer(t)
+
+	// No bearer and no cookie: every re-check fails, from the first tick.
+	req, cancel := sseRequest(t)
+	defer cancel()
+
+	rec, done := startStream(t, srv, req)
+	awaitClosed(t, done, "on a credential that never resolved")
+
+	if got := strings.Count(rec.String(), ": keep-alive"); got != 1 {
+		t.Errorf("keep-alives = %d, want exactly 1 (the first failure is tolerated, the second closes)", got)
+	}
+}
+
+// A failed re-check followed by a passing one resets the counter, so the stream
+// survives. TOTP is flipped on to make the raw admin token stop resolving (with
+// TOTP enabled it is a first factor only) and back off to heal it, which is the
+// in-memory equivalent of a store blip clearing on the next tick.
+func TestSSEFailedCheckRecovers(t *testing.T) {
+	srv, _ := newTestServer(t)
+
+	req, cancel := sseRequest(t)
+	req.Header.Set("Authorization", "Bearer "+testFrontdeskToken)
+
+	rec, done := startStream(t, srv, req)
+	awaitWrite(t, rec, "keep-alive on a live admin token")
+
+	srv.totpStatus.val.Store(true)
+	awaitWrite(t, rec, "keep-alive after the tolerated failure")
+	assertOpen(t, done, "on a single failed re-check")
+
+	srv.totpStatus.val.Store(false)
+	awaitWrite(t, rec, "keep-alive after the credential recovered")
+	awaitWrite(t, rec, "further keep-alive proving the counter reset")
+	assertOpen(t, done, "after the failure counter was reset by a passing re-check")
+
+	cancel()
+	awaitClosed(t, done, "after the client hung up")
+}
+
+// A device-token lookup that errors for a reason other than "no such device"
+// counts as a failed check rather than falling through to the admin gate, so a
+// broken store closes streams instead of silently widening admission.
+func TestSSEStoreErrorCountsAsFailure(t *testing.T) {
+	srv, store := newTestServer(t)
+	token, _ := pairDevice(t, srv, RoleMonitor, "phone")
+
+	req, cancel := sseRequest(t)
+	defer cancel()
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	// Closing the store makes every DeviceByTokenHash return a driver error.
+	if err := store.Close(); err != nil {
+		t.Fatalf("store.Close: %v", err)
+	}
+
+	_, done := startStream(t, srv, req)
+	awaitClosed(t, done, "with a store that errors on every re-check")
+}
+
+// Bus events still reach the stream alongside the re-auth tick.
+func TestSSEDeliversBusEvents(t *testing.T) {
+	srv, _ := newTestServer(t)
+
+	req, cancel := sseRequest(t)
+	req.Header.Set("Authorization", "Bearer "+testFrontdeskToken)
+
+	rec, done := startStream(t, srv, req)
+	// The first keep-alive proves the handler is subscribed; the bus drops
+	// events published before that.
+	awaitWrite(t, rec, "keep-alive")
+	srv.bus.Publish(events.Event{Type: "member.state_changed", Severity: "info", Source: "frontdesk"})
+
+	deadline := time.Now().Add(5 * time.Second)
+	for !strings.Contains(rec.String(), "member.state_changed") {
+		if time.Now().After(deadline) {
+			t.Fatalf("event never reached the stream: %q", rec.String())
+		}
+		select {
+		case <-rec.writes:
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+
+	cancel()
+	awaitClosed(t, done, "after the client hung up")
+}
+
+// A client that hangs up mid-write ends the stream rather than looping on a
+// dead socket, on both the keep-alive and the event frame.
+func TestSSEStopsWhenTheClientIsGone(t *testing.T) {
+	t.Run("keep-alive", func(t *testing.T) {
+		srv, _ := newTestServer(t)
+		req, cancel := sseRequest(t)
+		defer cancel()
+		req.Header.Set("Authorization", "Bearer "+testFrontdeskToken)
+
+		rec := newSSERecorder()
+		rec.failOn = func(string) bool { return true }
+		done := startStreamWith(t, srv, req, rec)
+		awaitClosed(t, done, "after the keep-alive write failed")
+	})
+
+	t.Run("event", func(t *testing.T) {
+		srv, _ := newTestServer(t)
+		req, cancel := sseRequest(t)
+		defer cancel()
+		req.Header.Set("Authorization", "Bearer "+testFrontdeskToken)
+
+		rec := newSSERecorder()
+		rec.failOn = func(frame string) bool { return strings.HasPrefix(frame, "data: ") }
+		done := startStreamWith(t, srv, req, rec)
+		awaitWrite(t, rec, "keep-alive")
+		srv.bus.Publish(events.Event{Type: "member.state_changed", Severity: "info", Source: "frontdesk"})
+		awaitClosed(t, done, "after the event write failed")
+	})
+}
+
+// An event that cannot be encoded is skipped, not fatal: the stream keeps
+// running for the events that follow.
+func TestSSESkipsUnencodableEvent(t *testing.T) {
+	srv, _ := newTestServer(t)
+
+	req, cancel := sseRequest(t)
+	req.Header.Set("Authorization", "Bearer "+testFrontdeskToken)
+
+	rec, done := startStream(t, srv, req)
+	awaitWrite(t, rec, "keep-alive")
+
+	// A func value in the metadata makes json.Marshal fail on this event only.
+	srv.bus.Publish(events.Event{
+		Type: "member.state_changed", Severity: "info", Source: "frontdesk",
+		Metadata: map[string]any{"unencodable": func() {}},
+	})
+	awaitWrite(t, rec, "keep-alive after the unencodable event")
+	assertOpen(t, done, "on an event it could not encode")
+	if body := rec.String(); strings.Contains(body, "data: ") {
+		t.Errorf("unencodable event was written anyway: %q", body)
+	}
+
+	cancel()
+	awaitClosed(t, done, "after the client hung up")
+}
+
+// The non-streaming path stays a 500: a ResponseWriter that cannot flush cannot
+// carry an event stream.
+func TestSSERejectsNonFlushingWriter(t *testing.T) {
+	srv, _ := newTestServer(t)
+
+	req, cancel := sseRequest(t)
+	defer cancel()
+	rec := &nonFlushingWriter{hdr: http.Header{}}
+	srv.stream(rec, req, sseTick)
+
+	if rec.status != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", rec.status)
+	}
+}
+
+// nonFlushingWriter is a ResponseWriter without http.Flusher.
+type nonFlushingWriter struct {
+	hdr    http.Header
+	status int
+}
+
+func (w *nonFlushingWriter) Header() http.Header         { return w.hdr }
+func (w *nonFlushingWriter) WriteHeader(code int)        { w.status = code }
+func (w *nonFlushingWriter) Write(p []byte) (int, error) { return len(p), nil }


### PR DESCRIPTION
## Summary

The Front Desk SSE endpoint authenticated only at connect time: a revoked paired-device token or admin session holding the stream open kept receiving fleet events for as long as the client held the socket. The main server already re-checks credentials on its SSE heartbeat (internal/api/events.go); this PR brings the Front Desk stream to parity.

- `(*Server).streamEvents` re-validates the caller's credential on every 25s heartbeat tick and closes the stream after 2 consecutive failures. The tolerance mirrors the main server's rationale: a revoked credential fails every check and drops on the second, while a transient store blip recovers on the next tick instead of forcing a dashboard logout.
- The re-check mirrors `requireAuth` exactly, including the error handling: bearer resolved against `paired_devices` first; on a non-ErrNotFound store error it falls through to the admin gate (which never reads that table), so a device-table outage cannot close admin streams. Device tokens then fail the predicate and the tolerance treats a blip as recoverable.
- `adminauth.ValidAdminOrSession` is extracted from `RequireAdminOrSession` so the SSE re-check and the middleware share one admission definition. The refactor is behavior-preserving: both distinct 401 messages remain, CSRF stays a middleware concern, and the existing adminauth suite passes unmodified.
- Review found the main server's `failures = 0` reset was not pinned by any test either; both servers now have mutation-verified fail-pass-fail tests (deleting the reset makes them fail).

No frontend changes: `useSSE` already treats the reconnect 401 as session-gone and routes to login.

## Test plan

- 12 new Front Desk SSE tests (revocation for device tokens and sessions, cookie and bearer carriers, single-failure tolerance, recovery, store-error fall-through both halves, keep-alive cadence), all write-reactive rather than sleep-based; green under `-race -count=3`.
- New `TestValidAdminOrSession` table covering the predicate, including the one case the middleware suite cannot express (valid admin cookie on POST without CSRF).
- `TestStreamEvents_PassingRecheckResetsFailureCount` on the main server closes the same pre-existing gap.
- Pre-push gates green: golangci-lint 0 issues, frontdesk + adminauth suites, diff coverage 97.3% (threshold 90%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)