### PR TITLE
ci: GHCR as a full mirror (:dev + CVE rebuilds), scan from GHCR, prune both registries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -658,9 +658,11 @@ jobs:
           ignore-unfixed: true
           exit-code: 1
 
-  # Publish a rolling :dev image to Docker Hub on every master commit, so a
-  # second "staging" instance can track master by pointing its compose image:
-  # line at <DOCKERHUB_USERNAME>/model-hotel:dev (vs :latest for prod).
+  # Publish a rolling :dev image to GHCR and Docker Hub on every master commit,
+  # so a second "staging" instance can track master by pointing its compose
+  # image: line at ghcr.io/hugalafutro/model-hotel:dev (vs :latest for prod).
+  # Both registries get the same digest, same as the release publish, so either
+  # is a drop-in for the other.
   #
   # This is a dedicated job (not a step in docker-build) so it can `needs:` the
   # full required gate set: a master commit that fails Go tests, lint, vet,
@@ -711,7 +713,11 @@ jobs:
       # to the commit it just pushed, so the change-gate can diff future pushes
       # against what is actually live on :dev (self-healing a stranded change).
       contents: write
+      # packages write: the :dev push to GHCR uses GITHUB_TOKEN.
+      packages: write
     env:
+      GHCR_IMAGE: ghcr.io/${{ github.repository }}
+      GHCR_FRONTDESK_IMAGE: ghcr.io/${{ github.repository }}-frontdesk
       DOCKERHUB_IMAGE: ${{ secrets.DOCKERHUB_USERNAME }}/model-hotel
       DOCKERHUB_FRONTDESK_IMAGE: ${{ secrets.DOCKERHUB_USERNAME }}/model-hotel-frontdesk
     steps:
@@ -791,6 +797,14 @@ jobs:
             printf '%s\n' "$changed"
             echo "skip=true" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Log in to GHCR
+        if: steps.changes.outputs.skip == 'false'
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to Docker Hub
         if: steps.changes.outputs.skip == 'false'
@@ -882,10 +896,19 @@ jobs:
             echo "pushed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          docker tag model-hotel:dev-candidate "${DOCKERHUB_IMAGE}:dev"
-          docker push "${DOCKERHUB_IMAGE}:dev"
-          docker tag model-hotel-frontdesk:dev-candidate "${DOCKERHUB_FRONTDESK_IMAGE}:dev"
-          docker push "${DOCKERHUB_FRONTDESK_IMAGE}:dev"
+          # Same local image tagged for both registries, so :dev has one digest
+          # everywhere. GHCR first: it is what the staging fleet pulls, so if
+          # Docker Hub is having a moment the tag that matters still moves.
+          for target in \
+            "${GHCR_IMAGE}:dev" "${DOCKERHUB_IMAGE}:dev"; do
+            docker tag model-hotel:dev-candidate "$target"
+            docker push "$target"
+          done
+          for target in \
+            "${GHCR_FRONTDESK_IMAGE}:dev" "${DOCKERHUB_FRONTDESK_IMAGE}:dev"; do
+            docker tag model-hotel-frontdesk:dev-candidate "$target"
+            docker push "$target"
+          done
           echo "pushed=true" >> "$GITHUB_OUTPUT"
 
       # Move the dev-published marker to the commit we just published so the next

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -672,8 +672,9 @@ jobs:
   # master HEAD has already moved past this commit, so a slow older run can't
   # overwrite :dev with a stale image after a newer commit already published it.
   # The image carries no VERSION build-arg, so it self-reports version "dev".
-  # :dev is a moving tag the prune workflow leaves untouched (it only prunes
-  # vX.Y.Z releases and orphaned sha- tags).
+  # `dev` is a protected moving tag in the prune workflow, so the live :dev
+  # image always survives a prune; superseded :dev digests become untagged
+  # GHCR versions and are reclaimed by it (Docker Hub drops them on overwrite).
   publish-dev:
     name: Publish :dev image
     runs-on: ubuntu-latest

--- a/.github/workflows/dockerhub-prune.yml
+++ b/.github/workflows/dockerhub-prune.yml
@@ -1,13 +1,19 @@
-name: Prune Docker Hub Tags
+name: Prune Registry Tags
 
-# Keeps the Docker Hub repositories tidy after a release. Both the server image
-# (model-hotel) and the Front Desk control-plane image (model-hotel-frontdesk)
-# are released together under the same tag scheme, so both are pruned here with
-# identical retention. Retains the newest KEEP version tags (X.Y.Z) plus every
-# protected moving tag (latest, X.Y), and deletes older releases. Each release
-# pushes an X.Y.Z tag *and* a sha- tag at the same image digest, so a sha- tag
-# is pruned only when no retained tag still points at its digest — this drops a
-# release's sha- tag together with the release, without parsing commit SHAs.
+# Keeps both registries tidy after a release. The server image (model-hotel)
+# and the Front Desk control-plane image (model-hotel-frontdesk) are released
+# together under the same tag scheme to Docker Hub and GHCR, so all four
+# repositories are pruned here with identical retention. Retains the newest
+# KEEP version tags (X.Y.Z) plus every protected moving tag (latest, dev, X.Y),
+# and deletes older releases. Each release pushes an X.Y.Z tag *and* a sha- tag
+# at the same image digest, so a sha- tag is pruned only when no retained tag
+# still points at its digest — this drops a release's sha- tag together with
+# the release, without parsing commit SHAs.
+#
+# Docker Hub is pruned inline below (tag-level API). GHCR is pruned by
+# scripts/ci/prune-ghcr-versions.sh (version-level API, where a version is one
+# digest carrying all its tags, and untagged versions such as superseded :dev
+# digests are removed too, minus the children of retained multi-arch indexes).
 #
 # Runs automatically after "Publish Docker Image" succeeds. The manual
 # (workflow_dispatch) trigger defaults to dry_run=true: it lists what *would*
@@ -37,6 +43,9 @@ on:
 
 permissions:
   contents: read
+  # packages write: deleting GHCR versions with GITHUB_TOKEN. The packages were
+  # published by this repository's workflows, which grants it admin on them.
+  packages: write
 
 env:
   KEEP: ${{ github.event.inputs.keep || '20' }}
@@ -50,7 +59,21 @@ jobs:
     # On the automatic trigger, only run when the publish actually succeeded.
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Prune GHCR versions
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+          scripts/ci/prune-ghcr-versions.sh "$OWNER" model-hotel "$KEEP" "$DRY_RUN"
+          scripts/ci/prune-ghcr-versions.sh "$OWNER" model-hotel-frontdesk "$KEEP" "$DRY_RUN"
+
+      # Runs even if the GHCR prune failed: the two registries are independent
+      # and a refusal on one must not leave the other unpruned.
       - name: Prune Docker Hub tags
+        if: ${{ !cancelled() }}
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -106,7 +129,7 @@ jobs:
             # Docker Hub release tags carry no v prefix (docker/metadata-action
             # type=semver strips it; only the git tag is vX.Y.Z), so accept both.
             def isVersion: test("^v?[0-9]+\\.[0-9]+\\.[0-9]+$");
-            def isProtected: (. == "latest") or test("^[0-9]+\\.[0-9]+$");
+            def isProtected: (. == "latest") or (. == "dev") or test("^[0-9]+\\.[0-9]+$");
             def isSha: startswith("sha-");
 
             # every digest a tag references (top-level + per-image), nulls dropped.

--- a/.github/workflows/dockerhub-prune.yml
+++ b/.github/workflows/dockerhub-prune.yml
@@ -61,17 +61,24 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Prune GHCR versions
+      # One step per package, and the later steps run even if an earlier one
+      # failed: the registries and packages are independent, and a refusal on
+      # one must not leave the others unpruned. GHCR_PRUNE_TOKEN is an optional
+      # PAT (delete:packages) for the case where GITHUB_TOKEN turns out not to
+      # hold delete rights on a package; the script aborts on the first 403.
+      - name: Prune GHCR versions (model-hotel)
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GHCR_PRUNE_TOKEN || secrets.GITHUB_TOKEN }}
           OWNER: ${{ github.repository_owner }}
-        run: |
-          set -euo pipefail
-          scripts/ci/prune-ghcr-versions.sh "$OWNER" model-hotel "$KEEP" "$DRY_RUN"
-          scripts/ci/prune-ghcr-versions.sh "$OWNER" model-hotel-frontdesk "$KEEP" "$DRY_RUN"
+        run: scripts/ci/prune-ghcr-versions.sh "$OWNER" model-hotel "$KEEP" "$DRY_RUN"
 
-      # Runs even if the GHCR prune failed: the two registries are independent
-      # and a refusal on one must not leave the other unpruned.
+      - name: Prune GHCR versions (model-hotel-frontdesk)
+        if: ${{ !cancelled() }}
+        env:
+          GH_TOKEN: ${{ secrets.GHCR_PRUNE_TOKEN || secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+        run: scripts/ci/prune-ghcr-versions.sh "$OWNER" model-hotel-frontdesk "$KEEP" "$DRY_RUN"
+
       - name: Prune Docker Hub tags
         if: ${{ !cancelled() }}
         env:

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -1,8 +1,8 @@
 # Weekly vulnerability scan of the published images (app + Front Desk).
 #
 # The CI gate only runs when a PR is open, but CVEs land in already-published
-# images (this is exactly how the OpenSSL 3.5.6 flags appeared on Docker Hub:
-# no code changed, the world did). A failed run here means a rebuild/release
+# images (this is exactly how the OpenSSL 3.5.6 flags appeared on the published
+# image: no code changed, the world did). A failed run here means a rebuild/release
 # would fix something — the docker-publish workflow's apk upgrade pulls current
 # Alpine patches — so it doubles as the signal to cut a patch release. It also
 # catches the publish workflow's GHA layer cache serving a stale apk upgrade
@@ -13,7 +13,11 @@
 # us the other image's report or gate: each step records its own outcome, and
 # the summary at the end fails the job while naming what actually broke. A red
 # run whose cause you have to go dig for is how this workflow already lost a
-# week of scan coverage to a transient Docker Hub timeout.
+# week of scan coverage to a transient registry timeout.
+#
+# The scan pulls from GHCR: every publish path (release, :dev, and the refresh
+# job below) pushes the same digest to GHCR and Docker Hub, so scanning one
+# registry covers both, and GHCR is the one our own stacks pull from.
 name: Scan Published Image
 
 on:
@@ -26,8 +30,8 @@ permissions:
   security-events: write
 
 env:
-  APP_IMAGE: docker.io/hugalafutro/model-hotel:latest
-  FRONTDESK_IMAGE: docker.io/hugalafutro/model-hotel-frontdesk:latest
+  APP_IMAGE: ghcr.io/${{ github.repository }}:latest
+  FRONTDESK_IMAGE: ghcr.io/${{ github.repository }}-frontdesk:latest
 
 jobs:
   scan:
@@ -40,7 +44,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # We pull rather than letting Trivy fetch from the registry so a single
-      # Docker Hub blip (`dial tcp ...: i/o timeout`) gets retried instead of
+      # registry blip (`dial tcp ...: i/o timeout`) gets retried instead of
       # killing the run. Trivy resolves an image from the local docker daemon
       # before the registry, so each scan reuses the pull above it.
       - name: Pull published image (with retries)
@@ -174,6 +178,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      # packages write: the republish to GHCR uses GITHUB_TOKEN.
+      packages: write
     strategy:
       fail-fast: false
       matrix:
@@ -259,6 +265,9 @@ jobs:
           IMAGE: ${{ matrix.image }}:rebuild-candidate
         run: scripts/ci/smoke-test-image.sh "$IMAGE"
 
+      # :latest must stay one digest across both registries (the scan job only
+      # looks at GHCR, and Docker Hub is what everyone else pulls), so the
+      # rebuilt image goes to both. GHCR first: it is what our own stacks run.
       - name: Publish the rebuilt image as :latest
         id: publish
         if: >-
@@ -266,15 +275,21 @@ jobs:
           && (matrix.smoke != true || steps.smoke.outcome == 'success')
         env:
           IMAGE: ${{ matrix.image }}
-          TARGET: ${{ secrets.DOCKERHUB_USERNAME }}/${{ matrix.image }}:latest
+          GHCR_TARGET: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:latest
+          DOCKERHUB_TARGET: ${{ secrets.DOCKERHUB_USERNAME }}/${{ matrix.image }}:latest
+          GHCR_ACTOR: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
           set -euo pipefail
+          echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_ACTOR" --password-stdin
           echo "$DOCKERHUB_TOKEN" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-          docker tag "$IMAGE:rebuild-candidate" "$TARGET"
-          docker push "$TARGET"
-          echo "Republished $TARGET"
+          for target in "$GHCR_TARGET" "$DOCKERHUB_TARGET"; do
+            docker tag "$IMAGE:rebuild-candidate" "$target"
+            docker push "$target"
+            echo "Republished $target"
+          done
 
       - name: Record what happened
         if: always()

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -28,6 +28,9 @@ on:
 permissions:
   contents: read
   security-events: write
+  # packages read: the scan pulls from GHCR with GITHUB_TOKEN so it keeps
+  # working if a package is ever made private.
+  packages: read
 
 env:
   APP_IMAGE: ghcr.io/${{ github.repository }}:latest
@@ -42,6 +45,13 @@ jobs:
       frontdesk_gate: ${{ steps.gate_frontdesk.outcome }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       # We pull rather than letting Trivy fetch from the registry so a single
       # registry blip (`dial tcp ...: i/o timeout`) gets retried instead of

--- a/scripts/ci/prune-ghcr-versions.sh
+++ b/scripts/ci/prune-ghcr-versions.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+#
+# Prune old versions of a GHCR container package with the same retention as
+# the Docker Hub prune in .github/workflows/dockerhub-prune.yml: keep the
+# newest KEEP release versions (X.Y.Z), every protected moving tag (latest,
+# dev, X.Y), and delete the rest.
+#
+# GHCR has no "delete a tag" call: a package *version* is one manifest digest
+# carrying every tag that points at it, and deleting the version drops all of
+# them. Each release pushes X.Y.Z and sha-<commit> at the same digest, so on
+# GHCR they are one version and are dropped together, which is exactly what
+# the Hub prune achieves by comparing digests. A version is retained when any
+# of its tags is retained; a version whose tags are all release/sha- tags of a
+# dropped release is deleted; a version with an unrecognised tag is left alone.
+#
+# Untagged versions are deleted too, with one exception that matters: older
+# releases were multi-arch (or carried a provenance attestation), so their
+# X.Y.Z tag is an image index whose per-platform manifests show up as
+# *untagged* versions. Deleting those would break the retained index they
+# belong to. Every retained version's manifest is therefore fetched from the
+# registry, and any child digest it references is protected. If a retained
+# manifest cannot be read the run aborts before deleting anything, because
+# "probably fine" is not a retention policy.
+#
+# Usage: prune-ghcr-versions.sh <owner> <package> <keep> <dry_run>
+#   owner    GHCR namespace (the GitHub user that owns the package)
+#   package  container package name (e.g. model-hotel)
+#   keep     number of newest release versions to retain (integer >= 1)
+#   dry_run  "true" lists what would be deleted without deleting
+# Env:
+#   GH_TOKEN  token for the GitHub REST API and the GHCR registry. In Actions,
+#             GITHUB_TOKEN with `packages: write` works for packages this
+#             repository publishes (the publishing repo holds admin on them).
+set -euo pipefail
+
+OWNER="${1:?owner required}"
+PKG="${2:?package required}"
+KEEP="${3:?keep required}"
+DRY_RUN="${4:?dry_run required}"
+: "${GH_TOKEN:?GH_TOKEN required}"
+
+# Guard against keep=0 (or non-numeric), which would leave every release
+# version unprotected and eligible for deletion.
+if ! [ "$KEEP" -ge 1 ] 2>/dev/null; then
+  echo "::error::keep must be an integer >= 1 (got '${KEEP}')"
+  exit 1
+fi
+
+echo "Package: ghcr.io/${OWNER}/${PKG}"
+echo "Keep newest ${KEEP} release versions; dry_run=${DRY_RUN}"
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+# --- collect every version (id, digest, tags, created_at) --------------------
+versions_api="/users/${OWNER}/packages/container/${PKG}/versions"
+gh api --paginate "${versions_api}?per_page=100" \
+  --jq '.[] | {id, digest: .name, tags: (.metadata.container.tags // []), created_at}' \
+  >"$work/versions.jsonl"
+total=$(wc -l <"$work/versions.jsonl")
+echo "Found ${total} versions total."
+if [ "$total" -eq 0 ]; then
+  echo "Nothing to prune in ghcr.io/${OWNER}/${PKG}." | tee -a "${GITHUB_STEP_SUMMARY:-/dev/null}"
+  exit 0
+fi
+
+# --- decide what to retain --------------------------------------------------
+# Retained: versions carrying a protected tag, the newest KEEP versions that
+# carry a release tag, and versions carrying any tag we do not recognise.
+# Everything tagged that is not retained is a dropped release (or its sha-).
+jq -cs --argjson keep "$KEEP" '
+  # Release tags carry no v prefix (docker/metadata-action type=semver strips
+  # it; only the git tag is vX.Y.Z), but the earliest pushes did, so accept both.
+  def isVersion: test("^v?[0-9]+\\.[0-9]+\\.[0-9]+$");
+  def isProtected: (. == "latest") or (. == "dev") or test("^[0-9]+\\.[0-9]+$");
+  def isSha: startswith("sha-");
+  def isKnown: isVersion or isProtected or isSha;
+
+  ( [ .[] | select(any(.tags[]; isVersion)) ]
+    | sort_by(.created_at) | reverse | .[0:$keep] | map(.id) ) as $keepIds
+  | map(
+      . as $v
+      | $v + { retained:
+                 ( any($v.tags[]; isProtected)
+                   or (($keepIds | index($v.id)) != null)
+                   or any($v.tags[]; isKnown | not) ) }
+    )
+' "$work/versions.jsonl" >"$work/classified.json"
+
+# --- protect the children of retained multi-manifest versions ---------------
+# One anonymous-or-authenticated pull token for the registry; the package may
+# be private, and GITHUB_TOKEN is accepted as the password on ghcr.io.
+registry_token=$(curl -fsSL -u "${OWNER}:${GH_TOKEN}" \
+  "https://ghcr.io/token?scope=repository:${OWNER}/${PKG}:pull" | jq -r '.token')
+if [ -z "$registry_token" ] || [ "$registry_token" = "null" ]; then
+  echo "::error::could not obtain a GHCR pull token for ${OWNER}/${PKG}"
+  exit 1
+fi
+
+accept='application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json'
+: >"$work/children.txt"
+while IFS= read -r digest; do
+  [ -n "$digest" ] || continue
+  if ! manifest=$(curl -fsSL -H "Authorization: Bearer ${registry_token}" -H "Accept: ${accept}" \
+      "https://ghcr.io/v2/${OWNER}/${PKG}/manifests/${digest}"); then
+    echo "::error::could not read retained manifest ${digest}; aborting so no child of it gets deleted"
+    exit 1
+  fi
+  jq -r '.manifests[]?.digest // empty' <<<"$manifest" >>"$work/children.txt"
+done < <(jq -r '.[] | select(.retained) | .digest' "$work/classified.json")
+protected_children=$(sort -u "$work/children.txt" | jq -R . | jq -cs .)
+echo "Retained versions reference $(jq length <<<"$protected_children") child manifest(s)."
+
+# --- final delete list ------------------------------------------------------
+# Delete: not retained, and (untagged and not a protected child) or (tagged).
+jq -c --argjson children "$protected_children" '
+  .[]
+  | select(.retained | not)
+  | . as $v
+  | select(($children | index($v.digest)) == null)
+  | {id, digest, tags}
+' "$work/classified.json" >"$work/delete.jsonl"
+
+count=$(wc -l <"$work/delete.jsonl")
+if [ "$count" -eq 0 ]; then
+  echo "Nothing to prune in ghcr.io/${OWNER}/${PKG}." | tee -a "${GITHUB_STEP_SUMMARY:-/dev/null}"
+  exit 0
+fi
+
+{
+  echo "### GHCR prune (ghcr.io/${OWNER}/${PKG})"
+  echo ""
+  echo "dry_run=\`${DRY_RUN}\` — ${count} version(s) targeted:"
+  echo ""
+  jq -r '"- `\(.digest[0:19])` \(if (.tags|length) > 0 then "tags: " + (.tags|join(", ")) else "(untagged)" end)"' \
+    "$work/delete.jsonl"
+} >>"${GITHUB_STEP_SUMMARY:-/dev/null}"
+
+# --- delete -------------------------------------------------------------------
+failed=0
+while IFS= read -r line; do
+  [ -n "$line" ] || continue
+  id=$(jq -r '.id' <<<"$line")
+  label=$(jq -r '"\(.digest[0:19]) [\(.tags|join(","))]"' <<<"$line")
+  if [ "$DRY_RUN" = "true" ]; then
+    echo "[dry-run] would delete: ${label} (id ${id})"
+    continue
+  fi
+  echo "Deleting: ${label} (id ${id})"
+  # 404: already gone (a concurrent run or a manual delete); anything else is
+  # a real failure, reported per version so one refusal does not hide the rest.
+  code=$(curl -sS -o /dev/null -w '%{http_code}' -X DELETE \
+    -H "Authorization: Bearer ${GH_TOKEN}" -H "Accept: application/vnd.github+json" \
+    "https://api.github.com${versions_api}/${id}")
+  if [ "$code" != "204" ] && [ "$code" != "404" ]; then
+    echo "::error::Failed to delete version ${id} (${label}): HTTP ${code}"
+    failed=$((failed + 1))
+  fi
+done <"$work/delete.jsonl"
+
+if [ "$failed" -gt 0 ]; then
+  echo "::error::${failed} version(s) could not be deleted in ghcr.io/${OWNER}/${PKG}"
+  exit 1
+fi
+echo "Prune complete for ghcr.io/${OWNER}/${PKG}."

--- a/scripts/ci/prune-ghcr-versions.sh
+++ b/scripts/ci/prune-ghcr-versions.sh
@@ -30,7 +30,10 @@
 # Env:
 #   GH_TOKEN  token for the GitHub REST API and the GHCR registry. In Actions,
 #             GITHUB_TOKEN with `packages: write` works for packages this
-#             repository publishes (the publishing repo holds admin on them).
+#             repository publishes (the publishing repo holds admin on them);
+#             a PAT with delete:packages works anywhere. A 403 on the first
+#             delete aborts immediately with a message naming the token, so a
+#             permission problem costs one call, not one per version.
 set -euo pipefail
 
 OWNER="${1:?owner required}"
@@ -90,8 +93,8 @@ jq -cs --argjson keep "$KEEP" '
 # --- protect the children of retained multi-manifest versions ---------------
 # One anonymous-or-authenticated pull token for the registry; the package may
 # be private, and GITHUB_TOKEN is accepted as the password on ghcr.io.
-registry_token=$(curl -fsSL -u "${OWNER}:${GH_TOKEN}" \
-  "https://ghcr.io/token?scope=repository:${OWNER}/${PKG}:pull" | jq -r '.token')
+registry_token=$(curl -fsSL --max-time 30 -u "${OWNER}:${GH_TOKEN}" \
+  "https://ghcr.io/token?scope=repository:${OWNER}/${PKG}:pull" | jq -r '.token') || registry_token=""
 if [ -z "$registry_token" ] || [ "$registry_token" = "null" ]; then
   echo "::error::could not obtain a GHCR pull token for ${OWNER}/${PKG}"
   exit 1
@@ -101,12 +104,22 @@ accept='application/vnd.oci.image.index.v1+json, application/vnd.docker.distribu
 : >"$work/children.txt"
 while IFS= read -r digest; do
   [ -n "$digest" ] || continue
-  if ! manifest=$(curl -fsSL -H "Authorization: Bearer ${registry_token}" -H "Accept: ${accept}" \
-      "https://ghcr.io/v2/${OWNER}/${PKG}/manifests/${digest}"); then
-    echo "::error::could not read retained manifest ${digest}; aborting so no child of it gets deleted"
-    exit 1
-  fi
-  jq -r '.manifests[]?.digest // empty' <<<"$manifest" >>"$work/children.txt"
+  # 200: parse it (an index lists children, a plain manifest lists none).
+  # 404: the version exists in the packages API but has no manifest in the
+  #      registry, so it has no children to protect; it is retained anyway, so
+  #      nothing is lost by moving on rather than blocking every future prune.
+  # Anything else (5xx, auth, network) means we do not know: abort.
+  code=$(curl -sS --max-time 30 -o "$work/manifest.json" -w '%{http_code}' \
+    -H "Authorization: Bearer ${registry_token}" -H "Accept: ${accept}" \
+    "https://ghcr.io/v2/${OWNER}/${PKG}/manifests/${digest}") || code=000
+  case "$code" in
+    200) jq -r '.manifests[]?.digest // empty' "$work/manifest.json" >>"$work/children.txt" ;;
+    404) echo "retained ${digest} has no manifest in the registry (HTTP 404); nothing to protect" ;;
+    *)
+      echo "::error::could not read retained manifest ${digest} (HTTP ${code}); aborting so no child of it gets deleted"
+      exit 1
+      ;;
+  esac
 done < <(jq -r '.[] | select(.retained) | .digest' "$work/classified.json")
 protected_children=$(sort -u "$work/children.txt" | jq -R . | jq -cs .)
 echo "Retained versions reference $(jq length <<<"$protected_children") child manifest(s)."
@@ -147,15 +160,29 @@ while IFS= read -r line; do
     continue
   fi
   echo "Deleting: ${label} (id ${id})"
-  # 404: already gone (a concurrent run or a manual delete); anything else is
-  # a real failure, reported per version so one refusal does not hide the rest.
-  code=$(curl -sS -o /dev/null -w '%{http_code}' -X DELETE \
+  # 204: deleted. 404: already gone (a concurrent run or a manual delete).
+  # 403: either the token cannot delete this package or the secondary rate
+  #      limit tripped; both mean every further call fails the same way, so
+  #      stop now instead of burning one request per remaining version.
+  # Anything else (including curl itself failing, reported as 000) is counted
+  # per version so one refusal does not hide the rest.
+  code=$(curl -sS --max-time 30 -o "$work/delete-response.json" -w '%{http_code}' -X DELETE \
     -H "Authorization: Bearer ${GH_TOKEN}" -H "Accept: application/vnd.github+json" \
-    "https://api.github.com${versions_api}/${id}")
-  if [ "$code" != "204" ] && [ "$code" != "404" ]; then
-    echo "::error::Failed to delete version ${id} (${label}): HTTP ${code}"
-    failed=$((failed + 1))
-  fi
+    "https://api.github.com${versions_api}/${id}") || code=000
+  case "$code" in
+    204|404) ;;
+    403)
+      echo "::error::HTTP 403 deleting version ${id} (${label}): $(jq -r '.message // "no message"' "$work/delete-response.json" 2>/dev/null). Either GH_TOKEN cannot delete this package (needs admin on it: GITHUB_TOKEN of the publishing repo, or a PAT with delete:packages) or the API secondary rate limit tripped; aborting."
+      exit 1
+      ;;
+    *)
+      echo "::error::Failed to delete version ${id} (${label}): HTTP ${code}"
+      failed=$((failed + 1))
+      ;;
+  esac
+  # Mutating REST calls are budgeted at roughly 180/minute by GitHub's
+  # secondary rate limit; a first-ever prune can have well over a hundred.
+  sleep 0.5
 done <"$work/delete.jsonl"
 
 if [ "$failed" -gt 0 ]; then

--- a/scripts/ci/pull-image-with-retries.sh
+++ b/scripts/ci/pull-image-with-retries.sh
@@ -4,7 +4,7 @@
 #
 # Used by .github/workflows/image-scan.yml, which scans already-published
 # images. Trivy's own registry fetch has no retry and a 5m default timeout, so
-# one Docker Hub blip (`dial tcp ...: i/o timeout`) fails the whole scheduled
+# one registry blip (`dial tcp ...: i/o timeout`) fails the whole scheduled
 # run: no SARIF is uploaded, and the Security tab shows Trivy red until the
 # next weekly run. Pulling here instead means a blip costs a retry, not a week
 # of scan coverage. Trivy resolves an image from the local docker daemon before


### PR DESCRIPTION
## Why

Own stacks (prod, demo, staging) move to `ghcr.io` so the Docker Hub pull counter stops measuring our own CI and deploys. GHCR is only a drop-in for Hub if every publish path pushes the same digest to both. Release publishes already did; two paths did not.

## What

- **`ci.yml` `publish-dev`**: `:dev` was pushed to Docker Hub only. Now pushed to GHCR and Hub from the same local image (one digest), GHCR first. Adds `packages: write` + GHCR login.
- **`image-scan.yml`**:
  - weekly scan pulls `ghcr.io/hugalafutro/model-hotel(-frontdesk):latest` instead of `docker.io/...` (what our stacks run; digests are identical on Hub so one scan covers both).
  - `refresh` job republished the CVE-rebuilt `:latest` to Docker Hub only, which would have left GHCR `:latest` silently un-patched. Now pushes to both. Adds `packages: write`.
- **`dockerhub-prune.yml`** (renamed "Prune Registry Tags"): new step runs `scripts/ci/prune-ghcr-versions.sh` for both packages before the Hub prune, same `KEEP`/`DRY_RUN` inputs. `dev` added to the protected moving tags on both sides.
- **`scripts/ci/prune-ghcr-versions.sh`** (new): version-level prune (a GHCR version = one digest carrying all its tags). Retains protected tags (`latest`, `dev`, `X.Y`), the newest KEEP release versions, and anything with an unrecognised tag; deletes dropped releases (their `sha-` tag rides along) and untagged versions (superseded `:dev` digests), except children of retained multi-arch indexes: it fetches every retained manifest and protects referenced child digests, aborting before any delete if a retained manifest can't be read.

## Verified

- `actionlint` + `shellcheck` clean.
- Script dry-run against the real packages: MH 194 versions → 160 targeted (130 tagged old releases, 30 untagged), retained set = `latest`/`0.9` + newest 20 `0.9.x` + every `0.N`/`0.N.x` pair, 6 index children protected; FD 20 versions → nothing to prune. Matches the Hub policy exactly.
- Confirmed `latest`/`0.9.98` digests already identical on GHCR and Hub for both images.

## After merge

Owner flips prod/demo/staging `image:` lines to `ghcr.io/...` and rebuilds a fresh `:dev` (first `:dev` on GHCR lands with the next master publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
