### PR TITLE
fix(ci): make the rebuild matrix guard compare like with like

### DIFF
--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -329,6 +329,13 @@ jobs:
     # if either image needs a rebuild, and without this the other image would be
     # rebuilt and republished alongside it for no reason, handing everyone who
     # pulls it a new digest that fixes nothing.
+    #
+    # format() is not decoration. A bare comparison here yields a BOOLEAN, and
+    # `matrix.triggered == 'true'` then compares a boolean to a string, which
+    # GitHub resolves by casting both to numbers: true becomes 1, 'true' becomes
+    # NaN, and the guard is false forever. That silently skipped every rebuild
+    # step on the first real run. format() makes the value a string, so the
+    # comparison below is string to string.
     strategy:
       fail-fast: false
       matrix:
@@ -336,11 +343,11 @@ jobs:
           - image: model-hotel
             dockerfile: Dockerfile
             smoke: true
-            triggered: ${{ needs.scan.outputs.app_gate == 'failure' || needs.scan.outputs.app_advisory == 'failure' }}
+            triggered: ${{ format('{0}', needs.scan.outputs.app_gate == 'failure' || needs.scan.outputs.app_advisory == 'failure') }}
           - image: model-hotel-frontdesk
             dockerfile: Dockerfile.frontdesk
             smoke: false
-            triggered: ${{ needs.scan.outputs.frontdesk_gate == 'failure' || needs.scan.outputs.frontdesk_advisory == 'failure' }}
+            triggered: ${{ format('{0}', needs.scan.outputs.frontdesk_gate == 'failure' || needs.scan.outputs.frontdesk_advisory == 'failure') }}
     services:
       postgres:
         image: postgres:16-alpine


### PR DESCRIPTION
The per-image rebuild guard added in #691 never fired.

`triggered` was a bare comparison, which yields a **boolean**, while the step guard was `matrix.triggered == 'true'` — a boolean compared to a string. GitHub resolves a mismatched comparison by casting both sides to numbers: `true` becomes 1, `'true'` becomes `NaN`, and `NaN` equals nothing, so the guard was false forever.

Run 32039579398 showed it precisely. The scan tier worked:

```
gate_app             success
advisory_app         failure (advisory)
advisory_frontdesk   success (advisory)
```

So the app image should have been rebuilt and Front Desk left alone. Instead every step in **both** matrix legs skipped, and `:latest` was never republished.

Wrapping the condition in `format()` makes the matrix value a string, so the guard is a string-to-string comparison.

The rest of #691 behaved correctly on that run: the advisory tier found the backlog without turning the run red, the non-fatal outcome tier reported it as advisory, and the digest rendered the 54 alerts as the two packages causing them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)