### PR TITLE
ci(frontdesk): gate the Front Desk web tree on biome

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -426,6 +426,11 @@ jobs:
       - name: Lint
         run: pnpm run lint
 
+      - name: Format check (biome)
+        # `biome check` (no --write) fails on any formatter/linter/assist drift,
+        # so formatting + import-order + lint regressions are caught at PR time.
+        run: pnpm run format
+
       - name: Build
         run: pnpm run build
 

--- a/frontdesk/web/package.json
+++ b/frontdesk/web/package.json
@@ -10,7 +10,8 @@
 		"build:docker": "vite build",
 		"typecheck:tests": "tsc --noEmit -p tsconfig.test.json",
 		"lint": "eslint --no-warn-ignored ${@:-.}",
-		"format": "biome check --write src",
+		"format": "biome check .",
+		"format:fix": "biome check --write",
 		"test": "vitest run"
 	},
 	"dependencies": {


### PR DESCRIPTION
Follow-up to #704, which found a `noSvgWithoutTitle` violation sitting unnoticed in `frontdesk/web/public/favicon.svg`. This closes the hole that let it sit there.

## The gap

The **Front Desk Web Test** job ran eslint and the build but never biome, and the package script it would have used was:

```json
"format": "biome check --write src"
```

Two problems compounding: `--write` fixes drift rather than failing on it, so it could never gate anything, and `src` means `public/` was never scanned at all. Between them the Front Desk tree had no formatter, import-order or lint-rule gate at PR time. `web/` has had one all along (`biome check . ../web-shared`, run as a `Format check (biome)` CI step).

## The fix

- `frontdesk/web/package.json`: `format` becomes `biome check .` (whole tree, no `--write`), and gains the `format:fix` counterpart `web/` already has, so the documented `pnpm format:fix <file>` workflow now works in Front Desk too.
- `.github/workflows/ci.yml`: run `pnpm run format` as a `Format check (biome)` step in the Front Desk Web Test job, in the same position and with the same comment as `web/`'s.

This adds a step to an existing required job rather than a new check context, so branch protection needs no change.

## Verification

- `pnpm run format` on the current tree: exits 0, 131 files clean.
- Same command with deliberate formatting drift injected into `src/main.tsx`: exits 1. The gate fails when it should.
- It is the same invocation that surfaced the favicon violation in #704, so `public/` is genuinely in scope now.
- `pnpm run lint` still exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)