### PR TITLE
test(bellhop): move Compose UI tests to the v2 createComposeRule

### DIFF
--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/alerts/AlertsScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/alerts/AlertsScreenTest.kt
@@ -3,7 +3,7 @@ package com.hugalafutro.bellhop.ui.alerts
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.hasTestTag
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/common/BellhopSwitchTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/common/BellhopSwitchTest.kt
@@ -7,7 +7,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertIsOff
 import androidx.compose.ui.test.assertIsOn
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import com.hugalafutro.bellhop.ui.theme.BellhopTheme

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/common/OpenUrlDialogTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/common/OpenUrlDialogTest.kt
@@ -1,7 +1,7 @@
 package com.hugalafutro.bellhop.ui.common
 
 import android.content.Intent
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import com.hugalafutro.bellhop.ui.theme.BellhopTheme

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreenTest.kt
@@ -5,7 +5,7 @@ import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertHasNoClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/QuotaBadgeGeometryTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/QuotaBadgeGeometryTest.kt
@@ -4,7 +4,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.width
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.height

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/QuotaBadgesTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/QuotaBadgesTest.kt
@@ -2,7 +2,7 @@ package com.hugalafutro.bellhop.ui.dashboard
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextContains
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/events/EventsScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/events/EventsScreenTest.kt
@@ -2,7 +2,7 @@ package com.hugalafutro.bellhop.ui.events
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasTestTag
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/lock/LockScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/lock/LockScreenTest.kt
@@ -1,7 +1,7 @@
 package com.hugalafutro.bellhop.ui.lock
 
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import com.hugalafutro.bellhop.ui.theme.BellhopTheme

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreenTest.kt
@@ -2,7 +2,7 @@ package com.hugalafutro.bellhop.ui.member
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasTestTag
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/pairing/PairingScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/pairing/PairingScreenTest.kt
@@ -9,7 +9,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/settings/QuotaBadgesConfigScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/settings/QuotaBadgesConfigScreenTest.kt
@@ -2,7 +2,7 @@ package com.hugalafutro.bellhop.ui.settings
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import com.hugalafutro.bellhop.data.InMemoryPreferencesDataStore

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreenTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreenTest.kt
@@ -4,7 +4,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertIsNotSelected
 import androidx.compose.ui.test.assertIsSelected
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo


### PR DESCRIPTION
Clears the deprecation the AGP 9 / Gradle 9 migration (#706) surfaced, and which that PR explicitly listed as a follow-up.

Compose BOM 2026.08.00 deprecates `androidx.compose.ui.test.junit4.createComposeRule` in favour of the `v2` package. Twelve test files were warning on every compile.

## Why this is a one-line-per-file change

v2's `createComposeRule` returns the same `ComposeContentTestRule`, so every call site, every assertion and every `setContent` block is untouched. The diff is exactly twelve import lines.

## What actually changes

The v2 rule drives composition with `StandardTestDispatcher` instead of `UnconfinedTestDispatcher`. A test that relied on a coroutine running eagerly at launch would now need explicit synchronisation. That is the real risk here, and it is not the kind of thing a single green run proves — a dispatcher swap surfaces as flakiness, not a first-run failure.

So the suite was run five times, four of them with `--rerun-tasks` to force genuine re-execution:

```
run 1: 554 tests, 0 failures
run 2: 554 tests, 0 failures
run 3: 554 tests, 0 failures
run 4: 554 tests, 0 failures
run 5: 554 tests, 0 failures
```

Clean `./gradlew build` is green, and the twelve deprecation warnings are gone.

`BellhopWidgetTest` still mentions `createComposeRule`, deliberately: that is a comment explaining Glance composables cannot be driven by the rule, not a use of it.

## Not in this PR

The same BOM bump also deprecates `LocalClipboardManager` in favour of `LocalClipboard` at four sites in `DashboardScreen`, `EventsScreen`, `MemberDetailScreen` and `SettingsScreen`. That one is not an import swap — `LocalClipboard` is suspend-based, so it needs a coroutine scope at each call site and changes production copy-to-clipboard behaviour. It does not belong in a test-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)