### PR TITLE
fix(proxy): six gateway defects found by a live all-provider sweep

### DIFF
--- a/internal/paramrewrite/params.go
+++ b/internal/paramrewrite/params.go
@@ -182,6 +182,28 @@ func ParseProviderParamRename(body []byte) map[string]string {
 	return renames
 }
 
+// paramQuoteChars are the quote styles providers wrap a parameter name in when
+// they name it in a 400. Anchoring on a quote is what keeps short names like
+// "n" and "stop" from matching unrelated prose.
+//
+// The single quote was the gap: OpenAI names the offending param that way in
+// its value-validation errors ("Unsupported value: 'temperature' does not
+// support 0 with this model. Only the default (1) value is supported."), so
+// every gpt-5-family request carrying temperature:0 failed with a 400 that
+// model-hotel could have healed by stripping the param and retrying.
+var paramQuoteChars = []byte{'`', '"', '\''}
+
+// paramIsQuoted reports whether the error message names param inside one of the
+// recognised quote styles.
+func paramIsQuoted(msg, param string) bool {
+	for _, q := range paramQuoteChars {
+		if strings.Contains(msg, string(q)+param+string(q)) {
+			return true
+		}
+	}
+	return false
+}
+
 // ParseProviderParamError parses 400 error bodies for rejected sampling/param names.
 // Any LLM API mentioning these param names in a 400 error can only be referring
 // to the request parameter — there is no other meaning in this context.
@@ -215,15 +237,14 @@ func ParseProviderParamError(body []byte) map[string]bool {
 		"reasoning",
 	}
 	for _, p := range matchParams {
-		// Match backtick-wrapped: `param` or quote-wrapped: "param"
-		if strings.Contains(msg, "`"+p+"`") || strings.Contains(msg, "\""+p+"\"") {
+		if paramIsQuoted(msg, p) {
 			rejected[p] = true
 		}
 	}
 	// "stop", "n", "seed" are too common as substrings — only match when
 	// explicitly quoted or backticked in the error message.
 	for _, p := range []string{"stop", "n", "seed"} {
-		if strings.Contains(msg, "`"+p+"`") || strings.Contains(msg, "\""+p+"\"") {
+		if paramIsQuoted(msg, p) {
 			rejected[p] = true
 		}
 	}
@@ -238,17 +259,13 @@ func ParseProviderParamError(body []byte) map[string]bool {
 	if strings.Contains(msg, "chat_template_args") {
 		rejected["chat_template_args"] = true
 	}
-	// Also catch any top_{single_letter} variant when backtick/quote-wrapped
-	if idx := strings.Index(msg, "`top_"); idx >= 0 && idx+7 <= len(msg) {
-		c := msg[idx+5]
-		if c >= 'a' && c <= 'z' && msg[idx+6] == '`' {
-			rejected[msg[idx+1:idx+6]] = true
-		}
-	}
-	if idx := strings.Index(msg, "\"top_"); idx >= 0 && idx+7 <= len(msg) {
-		c := msg[idx+5]
-		if c >= 'a' && c <= 'z' && msg[idx+6] == '"' {
-			rejected[msg[idx+1:idx+6]] = true
+	// Also catch any top_{single_letter} variant when quoted in any style.
+	for _, q := range paramQuoteChars {
+		if idx := strings.Index(msg, string(q)+"top_"); idx >= 0 && idx+7 <= len(msg) {
+			c := msg[idx+5]
+			if c >= 'a' && c <= 'z' && msg[idx+6] == q {
+				rejected[msg[idx+1:idx+6]] = true
+			}
 		}
 	}
 	if len(rejected) == 0 {

--- a/internal/paramrewrite/params_test.go
+++ b/internal/paramrewrite/params_test.go
@@ -110,3 +110,45 @@ func TestLearnedCacheKey_ScopedPerProviderNotPerType(t *testing.T) {
 			"must not strip it here")
 	}
 }
+
+// OpenAI names the offending parameter in single quotes in its value-validation
+// errors, which the backtick/double-quote anchors missed. Every gpt-5-family
+// request carrying temperature:0 therefore failed with an unhealed 400.
+func TestParseProviderParamError_SingleQuotedParam(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"error":{"message":"Unsupported value: 'temperature' does not support 0 with this model. Only the default (1) value is supported.","type":"invalid_request_error","param":"temperature","code":"unsupported_value"}}`)
+
+	rejected := ParseProviderParamError(body)
+	if !rejected["temperature"] {
+		t.Fatalf("expected temperature to be rejected, got %v", rejected)
+	}
+}
+
+func TestParseProviderParamError_SingleQuotedShortParams(t *testing.T) {
+	t.Parallel()
+
+	rejected := ParseProviderParamError([]byte(`{"error":{"message":"Unsupported value: 'n' is not supported with this model."}}`))
+	if !rejected["n"] {
+		t.Fatalf("expected n to be rejected, got %v", rejected)
+	}
+}
+
+func TestParseProviderParamError_SingleQuotedTopVariant(t *testing.T) {
+	t.Parallel()
+
+	rejected := ParseProviderParamError([]byte(`{"error":{"message":"Unsupported value: 'top_k' is not supported with this model."}}`))
+	if !rejected["top_k"] {
+		t.Fatalf("expected top_k to be rejected, got %v", rejected)
+	}
+}
+
+// An apostrophe inside ordinary prose must not be read as a quote pair, or a
+// harmless message would start stripping parameters the model accepts.
+func TestParseProviderParamError_ApostropheIsNotAQuotePair(t *testing.T) {
+	t.Parallel()
+
+	if rejected := ParseProviderParamError([]byte(`{"error":{"message":"The model isn't available in this region and can't serve n requests."}}`)); rejected != nil {
+		t.Fatalf("expected no params rejected from prose, got %v", rejected)
+	}
+}

--- a/internal/provider/local_modality_test.go
+++ b/internal/provider/local_modality_test.go
@@ -50,6 +50,21 @@ func TestInferNonChatModality(t *testing.T) {
 		{"gemma3:4b", ""},
 		{"deepseek-r1", ""},
 		{"", ""},
+		// Audio chat models are not named as transcribers, so the modality
+		// arrays alone decide their class.
+		{"gpt-4o-audio-preview", ""},
+		{"gpt-4o-mini-audio-preview", ""},
+		{"gpt-audio", ""},
+		{"qwen2-audio-7b-instruct", ""},
+
+		// Speech endpoints.
+		{"whisper-1", "stt"},
+		{"whisper-large-v3-turbo", "stt"},
+		{"gpt-4o-transcribe", "stt"},
+		{"gpt-4o-mini-transcribe", "stt"},
+		{"gpt-4o-transcribe-diarize", "stt"},
+		{"tts-1", "tts"},
+		{"gpt-4o-mini-tts", "tts"},
 		// "gte"/"e5"/"bge" only match as whole segments, not substrings.
 		{"together-large", ""},
 		{"the5th-model", ""},

--- a/internal/provider/model_class.go
+++ b/internal/provider/model_class.go
@@ -256,7 +256,10 @@ func syncCapsFromInput(raw string, caps map[string]any, input []string) string {
 // array contradicts. Unlike syncCapsFromInput it is not fill-only, so it is
 // used solely where the input array is authoritative rather than accumulated:
 // the stt rewrite, where enrichment has handed a transcription model the
-// vision/pdf flags of the chat model it is named after.
+// vision/pdf flags of the chat model it is named after. Rewriting the input
+// array alone would leave those flags standing, and a stored vision:true on a
+// model whose stored input is ["audio"] is a permanent contradiction that
+// shows the operator a Vision pill on a transcription model.
 func clearCapsNotInInput(raw string, caps map[string]any, input []string) string {
 	changed := false
 	for flag, modality := range capsInputFlags {

--- a/internal/provider/model_class.go
+++ b/internal/provider/model_class.go
@@ -53,11 +53,13 @@ func DeriveModelClass(input, output []string, modelID string) string {
 	// serve chat like any text model (mirrors isOpenRouterChatModel).
 	if containsModality(output, "text") || containsModality(output, "code") {
 		// Audio-in/text-out is structurally identical for Whisper-style
-		// transcription and audio chat models; only the name can tell.
-		if containsModality(input, "audio") && !containsModality(input, "text") {
-			if inferNonChatModality(modelID) == "stt" {
-				return "stt"
-			}
+		// transcription and audio chat models; only the name can tell. The
+		// rest of the input array cannot break the tie either: models.dev
+		// enrichment hands the gpt-4o transcription models the whole modality
+		// set of their chat namesake (text, image and audio in), so audio
+		// input plus a transcriber's name is the whole signal.
+		if containsModality(input, "audio") && inferNonChatModality(modelID) == "stt" {
+			return "stt"
 		}
 		return "chat"
 	}
@@ -140,8 +142,7 @@ func NormalizeModelClassification(m *model.Model) {
 	caps := parseCapabilityFlags(m.Capabilities)
 	input = unionCapsIntoInput(caps, input)
 
-	inputWasEmpty := len(input) == 0
-	if inputWasEmpty {
+	if len(input) == 0 {
 		input = []string{"text"}
 	}
 
@@ -149,8 +150,14 @@ func NormalizeModelClassification(m *model.Model) {
 	if len(output) == 0 {
 		_, output = classDefaultArrays(class)
 	}
-	if class == "stt" && inputWasEmpty {
+	// A transcription endpoint consumes audio and nothing else, so the input
+	// array is rewritten rather than kept: enrichment routinely hands these
+	// models the text/image input of the chat model they are named after, and
+	// leaving that in place would claim image input on an stt model and light
+	// up its Vision pill.
+	if class == "stt" {
 		input = []string{"audio"}
+		m.Capabilities = clearCapsNotInInput(m.Capabilities, caps, input)
 	}
 
 	input = canonicalizeModalityList(input)
@@ -233,6 +240,33 @@ func syncCapsFromInput(raw string, caps map[string]any, input []string) string {
 			caps = map[string]any{}
 		}
 		caps[flag] = true
+		changed = true
+	}
+	if !changed {
+		return raw
+	}
+	out, err := json.Marshal(caps)
+	if err != nil {
+		return raw
+	}
+	return string(out)
+}
+
+// clearCapsNotInInput turns off input-flavored capability flags that the input
+// array contradicts. Unlike syncCapsFromInput it is not fill-only, so it is
+// used solely where the input array is authoritative rather than accumulated:
+// the stt rewrite, where enrichment has handed a transcription model the
+// vision/pdf flags of the chat model it is named after.
+func clearCapsNotInInput(raw string, caps map[string]any, input []string) string {
+	changed := false
+	for flag, modality := range capsInputFlags {
+		if containsModality(input, modality) {
+			continue
+		}
+		if truthy, ok := caps[flag].(bool); !ok || !truthy {
+			continue
+		}
+		caps[flag] = false
 		changed = true
 	}
 	if !changed {

--- a/internal/provider/model_class_test.go
+++ b/internal/provider/model_class_test.go
@@ -74,6 +74,34 @@ func TestDeriveModelClass_TranscriptionModels(t *testing.T) {
 	}
 }
 
+// The name heuristic is authoritative once audio input is present: an
+// audio-input model whose ID carries a whole "whisper" or "transcribe" segment
+// is a transcriber even when it also reports text input, because that is the
+// exact shape models.dev enrichment produces. The heuristic reaches no further
+// than that — it is consulted only for text-or-code output, so an audio-output
+// or rerank-output model with the same name in it is decided by its arrays.
+func TestDeriveModelClass_NameHeuristicBoundary(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   []string
+		output  []string
+		modelID string
+		want    string
+	}{
+		{"text and audio in with transcriber name", []string{"text", "audio"}, []string{"text"}, "some-whisper-chat", "stt"},
+		{"audio output wins over the name", []string{"text"}, []string{"audio"}, "tts-whisper", "tts"},
+		{"rerank output wins over the name", []string{"text"}, []string{"rerank"}, "whisper-reranker-v1", "rerank"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DeriveModelClass(tt.input, tt.output, tt.modelID); got != tt.want {
+				t.Errorf("DeriveModelClass(%v, %v, %q) = %q, want %q",
+					tt.input, tt.output, tt.modelID, got, tt.want)
+			}
+		})
+	}
+}
+
 // A transcription model reclassified out of "chat" must not keep claiming the
 // image input its chat namesake reported.
 func TestNormalizeModelClassification_EnrichedTranscribeInput(t *testing.T) {

--- a/internal/provider/model_class_test.go
+++ b/internal/provider/model_class_test.go
@@ -29,6 +29,7 @@ func TestDeriveModelClass(t *testing.T) {
 		{"whisper stt tiebreak", []string{"audio"}, []string{"text"}, "whisper-large-v3", "stt"},
 		{"transcribe segment stt", []string{"audio"}, []string{"text"}, "gpt-4o-transcribe", "stt"},
 		{"audio-input chat is not stt", []string{"text", "audio"}, []string{"text"}, "gpt-4o-audio-preview", "chat"},
+		{"enriched audio chat is not stt", []string{"text", "image", "audio"}, []string{"text"}, "gpt-4o-audio-preview", "chat"},
 		{"empty arrays embed name", nil, nil, "nomic-embed-text", "embedding"},
 		{"empty arrays rerank name", nil, nil, "bge-reranker-v2-m3", "rerank"},
 		{"empty arrays dall-e name", nil, nil, "dall-e-3", "image"},
@@ -44,6 +45,61 @@ func TestDeriveModelClass(t *testing.T) {
 					tt.input, tt.output, tt.modelID, got, tt.want)
 			}
 		})
+	}
+}
+
+// The gpt-4o transcription models inherit the full modality set of their chat
+// namesakes from models.dev enrichment, so their input arrays are
+// indistinguishable from an audio chat model's. Only the ID names them as
+// transcribers. Rows mirror the live catalogue of one provider.
+func TestDeriveModelClass_TranscriptionModels(t *testing.T) {
+	tests := []struct {
+		modelID string
+		input   []string
+		want    string
+	}{
+		{"gpt-4o-mini-transcribe", []string{"text", "image", "audio"}, "stt"},
+		{"gpt-4o-transcribe", []string{"text", "image", "audio"}, "stt"},
+		{"gpt-4o-transcribe-diarize", []string{"audio"}, "stt"},
+		{"whisper-1", []string{"audio"}, "stt"},
+		{"gpt-4o-audio-preview", []string{"text", "image", "audio"}, "chat"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.modelID, func(t *testing.T) {
+			if got := DeriveModelClass(tt.input, []string{"text"}, tt.modelID); got != tt.want {
+				t.Errorf("DeriveModelClass(%v, [text], %q) = %q, want %q",
+					tt.input, tt.modelID, got, tt.want)
+			}
+		})
+	}
+}
+
+// A transcription model reclassified out of "chat" must not keep claiming the
+// image input its chat namesake reported.
+func TestNormalizeModelClassification_EnrichedTranscribeInput(t *testing.T) {
+	m := model.Model{
+		ModelID:          "gpt-4o-transcribe",
+		InputModalities:  `["text","image","audio"]`,
+		OutputModalities: `["text"]`,
+		Capabilities:     `{"streaming":true,"vision":true}`,
+	}
+	NormalizeModelClassification(&m)
+	if m.Modality != "stt" {
+		t.Errorf("Modality = %q, want stt", m.Modality)
+	}
+	if m.InputModalities != `["audio"]` {
+		t.Errorf("InputModalities = %q, want [\"audio\"]", m.InputModalities)
+	}
+	if m.OutputModalities != `["text"]` {
+		t.Errorf("OutputModalities = %q, want [\"text\"]", m.OutputModalities)
+	}
+	if !containsSubstring(m.Capabilities, `"vision":false`) {
+		t.Errorf("Capabilities = %s, want the inherited vision flag cleared", m.Capabilities)
+	}
+	for _, want := range []string{`"audio_input":true`, `"streaming":true`} {
+		if !containsSubstring(m.Capabilities, want) {
+			t.Errorf("Capabilities = %s, missing %s", m.Capabilities, want)
+		}
 	}
 }
 

--- a/internal/proxy/jsonextras.go
+++ b/internal/proxy/jsonextras.go
@@ -101,6 +101,9 @@ func encodeWithExtras(base any, extras jsonExtras) ([]byte, error) {
 var (
 	messageJSONFields  = jsonFieldNames(Message{})
 	toolCallJSONFields = jsonFieldNames(ToolCall{})
+	choiceJSONFields   = jsonFieldNames(Choice{})
+	responseJSONFields = jsonFieldNames(ChatCompletionResponse{})
+	usageJSONFields    = jsonFieldNames(Usage{})
 )
 
 // UnmarshalJSON decodes a message and retains any provider fields this package
@@ -140,4 +143,63 @@ func (t *ToolCall) UnmarshalJSON(data []byte) error {
 func (t ToolCall) MarshalJSON() ([]byte, error) {
 	type alias ToolCall
 	return encodeWithExtras(alias(t), t.Extra)
+}
+
+// UnmarshalJSON decodes a choice and retains the per-choice fields this package
+// does not model, above all logprobs — a client that asked for them gets
+// nothing back without this — and OpenRouter's native_finish_reason.
+func (c *Choice) UnmarshalJSON(data []byte) error {
+	type alias Choice
+	var a alias
+	if err := json.Unmarshal(data, &a); err != nil {
+		return err
+	}
+	*c = Choice(a)
+	c.Extra = decodeExtras(data, choiceJSONFields)
+	return nil
+}
+
+// MarshalJSON re-emits the choice with its unmodelled fields restored.
+func (c Choice) MarshalJSON() ([]byte, error) {
+	type alias Choice
+	return encodeWithExtras(alias(c), c.Extra)
+}
+
+// UnmarshalJSON decodes a completion and retains the top-level fields this
+// package does not model (system_fingerprint, the routing provider an
+// aggregator reports, service_tier, ...).
+func (c *ChatCompletionResponse) UnmarshalJSON(data []byte) error {
+	type alias ChatCompletionResponse
+	var a alias
+	if err := json.Unmarshal(data, &a); err != nil {
+		return err
+	}
+	*c = ChatCompletionResponse(a)
+	c.Extra = decodeExtras(data, responseJSONFields)
+	return nil
+}
+
+// MarshalJSON re-emits the completion with its unmodelled fields restored.
+func (c ChatCompletionResponse) MarshalJSON() ([]byte, error) {
+	type alias ChatCompletionResponse
+	return encodeWithExtras(alias(c), c.Extra)
+}
+
+// UnmarshalJSON decodes usage and retains the accounting fields this package
+// does not model, above all the per-request cost aggregators report.
+func (u *Usage) UnmarshalJSON(data []byte) error {
+	type alias Usage
+	var a alias
+	if err := json.Unmarshal(data, &a); err != nil {
+		return err
+	}
+	*u = Usage(a)
+	u.Extra = decodeExtras(data, usageJSONFields)
+	return nil
+}
+
+// MarshalJSON re-emits usage with its unmodelled fields restored.
+func (u Usage) MarshalJSON() ([]byte, error) {
+	type alias Usage
+	return encodeWithExtras(alias(u), u.Extra)
 }

--- a/internal/proxy/jsonextras.go
+++ b/internal/proxy/jsonextras.go
@@ -1,0 +1,143 @@
+package proxy
+
+import (
+	"encoding/json"
+	"reflect"
+)
+
+// Provider-specific fields that this package does not model must survive the
+// decode/re-encode in handleNonStreamingResponse, because some of them are
+// required on the NEXT request rather than merely informative.
+//
+// The case that forced this: Gemini 3 returns each tool call with
+// extra_content.google.thought_signature, and rejects the follow-up turn
+// outright ("Function call is missing a thought_signature in functionCall
+// parts") when the client sends the call back without it. The streaming path
+// forwards chunks verbatim and was unaffected; every non-streaming caller lost
+// the signature and could not complete a single tool round trip.
+//
+// Rather than growing a named field per provider extension, the unmodelled keys
+// are kept verbatim and re-emitted. Known keys always win, so a field this
+// package does model can never be shadowed by a stale copy in the overflow.
+type jsonExtras map[string]json.RawMessage
+
+// jsonFieldNames returns the JSON object keys a struct type serialises to.
+// Derived by reflection rather than hand-listed so adding a field to Message or
+// ToolCall cannot silently desynchronise the overflow from the schema and start
+// duplicating that field into the extras map.
+func jsonFieldNames(v any) map[string]struct{} {
+	t := reflect.TypeOf(v)
+	names := make(map[string]struct{}, t.NumField())
+	for i := range t.NumField() {
+		tag := t.Field(i).Tag.Get("json")
+		name := tag
+		if idx := indexByte(tag, ','); idx >= 0 {
+			name = tag[:idx]
+		}
+		if name == "" {
+			name = t.Field(i).Name
+		}
+		if name == "-" {
+			continue
+		}
+		names[name] = struct{}{}
+	}
+	return names
+}
+
+func indexByte(s string, b byte) int {
+	for i := range len(s) {
+		if s[i] == b {
+			return i
+		}
+	}
+	return -1
+}
+
+// decodeExtras collects the keys of a JSON object that the caller's struct does
+// not model. A payload that is not an object (null, or a provider sending a
+// bare string where a message belongs) yields no extras and no error: the
+// typed decode alongside it is what decides whether the payload was valid.
+func decodeExtras(data []byte, known map[string]struct{}) jsonExtras {
+	var all map[string]json.RawMessage
+	if err := json.Unmarshal(data, &all); err != nil {
+		return nil
+	}
+	var extras jsonExtras
+	for k, v := range all {
+		if _, ok := known[k]; ok {
+			continue
+		}
+		if extras == nil {
+			extras = make(jsonExtras, len(all))
+		}
+		extras[k] = v
+	}
+	return extras
+}
+
+// encodeWithExtras marshals base and merges the unmodelled keys back in. Any
+// extras key that collides with a modelled one is dropped: the struct field is
+// the value this package reasoned about, and re-adding the raw original would
+// undo normalisations such as reasoning_content.
+func encodeWithExtras(base any, extras jsonExtras) ([]byte, error) {
+	out, err := json.Marshal(base)
+	if err != nil || len(extras) == 0 {
+		return out, err
+	}
+	var merged map[string]json.RawMessage
+	if err := json.Unmarshal(out, &merged); err != nil {
+		return out, nil //nolint:nilerr // a struct that marshalled but will not re-parse is still valid output
+	}
+	for k, v := range extras {
+		if _, clash := merged[k]; clash {
+			continue
+		}
+		merged[k] = v
+	}
+	return json.Marshal(merged)
+}
+
+var (
+	messageJSONFields  = jsonFieldNames(Message{})
+	toolCallJSONFields = jsonFieldNames(ToolCall{})
+)
+
+// UnmarshalJSON decodes a message and retains any provider fields this package
+// does not model (OpenAI's audio and refusal, provider annotations, ...).
+func (m *Message) UnmarshalJSON(data []byte) error {
+	type alias Message
+	var a alias
+	if err := json.Unmarshal(data, &a); err != nil {
+		return err
+	}
+	*m = Message(a)
+	m.Extra = decodeExtras(data, messageJSONFields)
+	return nil
+}
+
+// MarshalJSON re-emits the message with its unmodelled fields restored.
+func (m Message) MarshalJSON() ([]byte, error) {
+	type alias Message
+	return encodeWithExtras(alias(m), m.Extra)
+}
+
+// UnmarshalJSON decodes a tool call and retains the provider fields this
+// package does not model, above all Gemini's extra_content.
+func (t *ToolCall) UnmarshalJSON(data []byte) error {
+	type alias ToolCall
+	var a alias
+	if err := json.Unmarshal(data, &a); err != nil {
+		return err
+	}
+	*t = ToolCall(a)
+	t.Extra = decodeExtras(data, toolCallJSONFields)
+	return nil
+}
+
+// MarshalJSON re-emits the tool call with its unmodelled fields restored, so a
+// client can send the call back to the provider exactly as it was issued.
+func (t ToolCall) MarshalJSON() ([]byte, error) {
+	type alias ToolCall
+	return encodeWithExtras(alias(t), t.Extra)
+}

--- a/internal/proxy/jsonextras_test.go
+++ b/internal/proxy/jsonextras_test.go
@@ -1,0 +1,187 @@
+package proxy
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// The regression this file exists for: Gemini 3 issues each tool call with an
+// extra_content.google.thought_signature and rejects the follow-up turn when it
+// is missing. The non-streaming path decodes the upstream body into
+// ChatCompletionResponse and re-encodes it, which silently dropped the field
+// and made every non-streaming tool round trip fail with an upstream 400.
+func TestToolCallJSON_PreservesGeminiThoughtSignature(t *testing.T) {
+	t.Parallel()
+
+	const upstream = `{
+		"id": "call_467280",
+		"type": "function",
+		"function": {"name": "get_temperature", "arguments": "{\"city\":\"Prague\"}"},
+		"extra_content": {"google": {"thought_signature": "EnEKbwERTTIPTv3oeLaK"}}
+	}`
+
+	var call ToolCall
+	if err := json.Unmarshal([]byte(upstream), &call); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if call.ID != "call_467280" || call.Function.Name != "get_temperature" {
+		t.Fatalf("modelled fields lost: %+v", call)
+	}
+
+	out, err := json.Marshal(call)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("re-parse: %v", err)
+	}
+	google, ok := got["extra_content"].(map[string]any)["google"].(map[string]any)
+	if !ok {
+		t.Fatalf("extra_content.google missing from re-encoded call: %s", out)
+	}
+	if google["thought_signature"] != "EnEKbwERTTIPTv3oeLaK" {
+		t.Fatalf("thought_signature not round-tripped: %s", out)
+	}
+}
+
+func TestMessageJSON_PreservesUnmodelledFields(t *testing.T) {
+	t.Parallel()
+
+	const upstream = `{
+		"role": "assistant",
+		"content": "hi",
+		"refusal": null,
+		"audio": {"id": "audio_123", "data": "UklGRg=="},
+		"annotations": [{"type": "url_citation"}]
+	}`
+
+	var msg Message
+	if err := json.Unmarshal([]byte(upstream), &msg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if msg.Role != "assistant" || msg.Content != "hi" {
+		t.Fatalf("modelled fields lost: %+v", msg)
+	}
+
+	out, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	for _, want := range []string{`"audio"`, `"audio_123"`, `"annotations"`, `"refusal"`} {
+		if !strings.Contains(string(out), want) {
+			t.Fatalf("re-encoded message dropped %s: %s", want, out)
+		}
+	}
+}
+
+// A field this package models and then normalises must win over the raw copy:
+// re-adding the original would undo the normalisation.
+func TestMessageJSON_ModelledFieldsWinOverExtras(t *testing.T) {
+	t.Parallel()
+
+	var msg Message
+	if err := json.Unmarshal([]byte(`{"role":"assistant","reasoning":"raw thinking"}`), &msg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	// What handleNonStreamingResponse does before re-encoding.
+	msg.ReasoningContent = msg.Reasoning
+
+	out, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got map[string]json.RawMessage
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("re-parse: %v", err)
+	}
+	if _, dup := got["reasoning"]; !dup {
+		t.Fatalf("modelled reasoning field missing: %s", out)
+	}
+	if string(got["reasoning_content"]) != `"raw thinking"` {
+		t.Fatalf("normalisation lost: %s", out)
+	}
+}
+
+// The whole response must survive the decode/re-encode, since that is the path
+// the proxy actually takes.
+func TestChatCompletionResponse_RoundTripKeepsToolCallExtras(t *testing.T) {
+	t.Parallel()
+
+	const upstream = `{
+		"id": "resp_1", "object": "chat.completion", "created": 1, "model": "gemini-3.1-flash-lite",
+		"choices": [{"index": 0, "message": {"role": "assistant", "content": null, "tool_calls": [
+			{"id": "call_1", "type": "function",
+			 "function": {"name": "get_temperature", "arguments": "{}"},
+			 "extra_content": {"google": {"thought_signature": "sig"}}}
+		]}, "finish_reason": "tool_calls"}],
+		"usage": {"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3}
+	}`
+
+	var resp ChatCompletionResponse
+	if err := json.Unmarshal([]byte(upstream), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	out, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(out), "thought_signature") {
+		t.Fatalf("thought_signature lost through the response round trip: %s", out)
+	}
+}
+
+// A message with nothing unmodelled must encode exactly as it did before the
+// overflow existed - no empty extras object, no reordering surprises.
+func TestMessageJSON_NoExtrasIsUnchanged(t *testing.T) {
+	t.Parallel()
+
+	var msg Message
+	if err := json.Unmarshal([]byte(`{"role":"user","content":"hello"}`), &msg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if msg.Extra != nil {
+		t.Fatalf("expected no extras, got %v", msg.Extra)
+	}
+	out, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if string(out) != `{"role":"user","content":"hello"}` {
+		t.Fatalf("plain message re-encoded differently: %s", out)
+	}
+}
+
+// A null delta is normal on the final chunk of a stream; it must not error.
+func TestMessageJSON_NullDecodesClean(t *testing.T) {
+	t.Parallel()
+
+	var msg Message
+	if err := json.Unmarshal([]byte(`null`), &msg); err != nil {
+		t.Fatalf("unmarshal null: %v", err)
+	}
+	if msg.Extra != nil {
+		t.Fatalf("null yielded extras: %v", msg.Extra)
+	}
+}
+
+// jsonFieldNames is reflection-derived so a new field cannot desynchronise the
+// overflow from the schema; pin the two shapes it guards.
+func TestJSONFieldNames_CoversTaggedFieldsAndSkipsIgnored(t *testing.T) {
+	t.Parallel()
+
+	names := jsonFieldNames(Message{})
+	for _, want := range []string{"role", "content", "tool_calls", "reasoning_content"} {
+		if _, ok := names[want]; !ok {
+			t.Fatalf("expected %q among Message JSON fields, got %v", want, names)
+		}
+	}
+	if _, ok := names["Extra"]; ok {
+		t.Fatalf("json:\"-\" field leaked into the known set: %v", names)
+	}
+	if _, ok := jsonFieldNames(ToolCall{})["function"]; !ok {
+		t.Fatal("expected ToolCall to model a function field")
+	}
+}

--- a/internal/proxy/jsonextras_test.go
+++ b/internal/proxy/jsonextras_test.go
@@ -185,3 +185,144 @@ func TestJSONFieldNames_CoversTaggedFieldsAndSkipsIgnored(t *testing.T) {
 		t.Fatal("expected ToolCall to model a function field")
 	}
 }
+
+// The overflow has to cover every level the non-streaming path decodes and
+// re-encodes, not just the message: a client that asked for logprobs was
+// handed a choice without them, and the aggregator fields operators route and
+// bill on (system_fingerprint, provider, usage.cost) were dropped on the floor.
+func TestChatCompletionResponse_PreservesUnmodelledFieldsAtEveryLevel(t *testing.T) {
+	t.Parallel()
+
+	const upstream = `{
+		"id": "chatcmpl-1", "object": "chat.completion", "created": 1, "model": "llama-3.3-70b",
+		"system_fingerprint": "fp_abc123", "provider": "Together", "service_tier": "default",
+		"choices": [{
+			"index": 0,
+			"message": {"role": "assistant", "content": "hi"},
+			"finish_reason": "stop",
+			"native_finish_reason": "STOP",
+			"logprobs": {"content": [{"token": "hi", "logprob": -0.25}]}
+		}],
+		"usage": {"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3, "cost": 0.000123, "is_byok": false}
+	}`
+
+	var resp ChatCompletionResponse
+	if err := json.Unmarshal([]byte(upstream), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.ID != "chatcmpl-1" || resp.Usage.TotalTokens != 3 || len(resp.Choices) != 1 {
+		t.Fatalf("modelled fields lost: %+v", resp)
+	}
+
+	out, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("re-parse: %v", err)
+	}
+	for k, want := range map[string]any{"system_fingerprint": "fp_abc123", "provider": "Together", "service_tier": "default"} {
+		if got[k] != want {
+			t.Errorf("top-level %q = %v, want %v: %s", k, got[k], want, out)
+		}
+	}
+	choice, ok := got["choices"].([]any)[0].(map[string]any)
+	if !ok {
+		t.Fatalf("choice lost: %s", out)
+	}
+	if _, has := choice["logprobs"]; !has {
+		t.Errorf("choice logprobs dropped: %s", out)
+	}
+	if choice["native_finish_reason"] != "STOP" {
+		t.Errorf("choice native_finish_reason dropped: %s", out)
+	}
+	usage, ok := got["usage"].(map[string]any)
+	if !ok {
+		t.Fatalf("usage lost: %s", out)
+	}
+	if usage["cost"] != 0.000123 {
+		t.Errorf("usage cost dropped: %s", out)
+	}
+	if _, has := usage["is_byok"]; !has {
+		t.Errorf("usage is_byok dropped: %s", out)
+	}
+	if usage["total_tokens"] != float64(3) {
+		t.Errorf("modelled usage field lost: %s", out)
+	}
+}
+
+// The invariant the overflow must never break: a field this package models wins
+// over the raw copy at every level, so nothing it rewrote is undone.
+func TestChatCompletionResponse_ModelledFieldsWinOverExtras(t *testing.T) {
+	t.Parallel()
+
+	var resp ChatCompletionResponse
+	if err := json.Unmarshal([]byte(`{"id":"a","model":"m","choices":[{"index":0,"message":{"role":"assistant","content":"x"}}],"usage":{"total_tokens":7}}`), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	// Stand-ins for what handleNonStreamingResponse rewrites before re-encoding.
+	resp.Model = "hotel/rewritten"
+	resp.Usage.TotalTokens = 9
+	resp.Choices[0].Index = 1
+
+	out, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("re-parse: %v", err)
+	}
+	if got["model"] != "hotel/rewritten" {
+		t.Errorf("modelled model overwritten by extras: %s", out)
+	}
+	if got["usage"].(map[string]any)["total_tokens"] != float64(9) {
+		t.Errorf("modelled usage overwritten by extras: %s", out)
+	}
+	if got["choices"].([]any)[0].(map[string]any)["index"] != float64(1) {
+		t.Errorf("modelled choice index overwritten by extras: %s", out)
+	}
+}
+
+// Nothing unmodelled must mean byte-identical output, so an ordinary
+// completion is not reshaped just because the overflow exists.
+func TestChatCompletionResponse_NoExtrasIsUnchanged(t *testing.T) {
+	t.Parallel()
+
+	const plain = `{"id":"a","object":"chat.completion","created":1,"model":"m","choices":[{"index":0,"message":{"role":"assistant","content":"hi"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3}}`
+	var resp ChatCompletionResponse
+	if err := json.Unmarshal([]byte(plain), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Extra != nil || resp.Usage.Extra != nil || resp.Choices[0].Extra != nil {
+		t.Fatalf("plain completion produced extras: %+v", resp)
+	}
+	out, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if string(out) != plain {
+		t.Fatalf("plain completion re-encoded differently:\n got %s\nwant %s", out, plain)
+	}
+}
+
+// The custom marshalers alias their own type; a missed alias would recurse
+// until the stack died rather than fail a comparison, so pin it.
+func TestExtrasMarshalersDoNotRecurse(t *testing.T) {
+	t.Parallel()
+
+	resp := ChatCompletionResponse{
+		Model:   "m",
+		Choices: []Choice{{Message: Message{Role: "assistant", Content: "hi"}, Extra: jsonExtras{"logprobs": json.RawMessage(`null`)}}},
+		Usage:   Usage{TotalTokens: 3, Extra: jsonExtras{"cost": json.RawMessage(`0.5`)}},
+		Extra:   jsonExtras{"provider": json.RawMessage(`"Together"`)},
+	}
+	out, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(out), `"cost":0.5`) || !strings.Contains(string(out), `"provider":"Together"`) {
+		t.Fatalf("extras missing from re-encode: %s", out)
+	}
+}

--- a/internal/proxy/openai_responses.go
+++ b/internal/proxy/openai_responses.go
@@ -99,9 +99,17 @@ func (h *Handler) retryWithResponses(
 		return res, false
 	}
 
-	body, readErr := io.ReadAll(resp.Body)
+	// Same bounded read as the param self-heal: this learner also json.Unmarshals
+	// the whole error document and also has to hand the response on with a
+	// readable body. Reading it unbounded here would defeat readLearnable400's
+	// cap entirely, since every openai-type 400 passes through this function
+	// first.
+	body, readErr := readLearnable400(resp)
+	// The helper closed the upstream body and left a buffered reader in its
+	// place, so this close is a no-op — it is here because bodyclose only
+	// recognises a close applied to the response value in the function that
+	// received it, not the one inside readLearnable400.
 	_ = resp.Body.Close()
-	resp.Body = io.NopCloser(bytes.NewReader(body))
 	if readErr != nil || !h.learnResponsesRequirement(st, candidate, providerType, body) {
 		return res, false
 	}

--- a/internal/proxy/openai_responses_test.go
+++ b/internal/proxy/openai_responses_test.go
@@ -394,3 +394,32 @@ func TestTranslateResponsesResponseBody(t *testing.T) {
 		t.Error("non-Responses 200 body must error (failover)")
 	}
 }
+
+// Every openai-type 400 reaches retryWithResponses before the param self-heal
+// sees it, so an unbounded read here would defeat readLearnable400's cap on the
+// same body. The 400 that is not a Responses rejection is handed straight on,
+// with at most the learner's cap buffered.
+func TestRetryWithResponses_BoundsThe400Read(t *testing.T) {
+	h := &Handler{}
+	st := &requestState{bodyBytes: []byte(toolsReasoningBody), failoverTimeout: time.Second}
+	cand := responsesTestCandidate("https://api.openai.com/v1")
+
+	// Twice the learner's cap of junk: not a Responses rejection, so the call
+	// returns handled=false and the body is restored for the next reader.
+	oversized := `{"error":{"message":"` + strings.Repeat("z", 2*responsesLearnBodyCap) + `"}}`
+	resp := &http.Response{StatusCode: 400, Body: io.NopCloser(strings.NewReader(oversized))}
+	r := httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)
+
+	var dialMs float64
+	res, handled := h.retryWithResponses(r, st, cand, "openai", resp, 0, &dialMs, func() {}, "")
+	if handled {
+		t.Fatal("a junk 400 must not be handled by the responses retry")
+	}
+	restored, err := io.ReadAll(res.resp.Body)
+	if err != nil {
+		t.Fatalf("restored body: %v", err)
+	}
+	if len(restored) > responsesLearnBodyCap {
+		t.Fatalf("buffered %d bytes of a %d-byte 400, cap is %d", len(restored), len(oversized), responsesLearnBodyCap)
+	}
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -451,14 +451,14 @@ func (h *Handler) handleNonStreamingResponse(w http.ResponseWriter, r *http.Requ
 
 	w.Header().Set("Content-Type", "application/json")
 
-	// The body is read once, up front, because both branches below need the same
-	// bytes: the success branch decodes it, the failure branch records it. A
-	// decoder reading straight off resp.Body would leave nothing for the failure
-	// branch to sanitize into the request log.
-	// json.Decoder rather than json.Unmarshal so the accepted set of bodies is
-	// exactly what it was when the decoder read resp.Body directly: a decoder
-	// stops at the end of the first JSON value, an Unmarshal rejects anything
-	// following it.
+	// The body is read into memory once, up front, because both branches below
+	// want the same bytes: the success branch decodes them, the failure branch
+	// sanitizes them into the request log. resp.Body can only be consumed once,
+	// so whichever branch read it directly would starve the other.
+	//
+	// json.Decoder, not json.Unmarshal: a decoder stops at the end of the first
+	// JSON value, so a completion with trailing bytes after it still decodes,
+	// where an Unmarshal rejects the whole body.
 	body, readErr := io.ReadAll(resp.Body)
 	var chatResp ChatCompletionResponse
 	decodeErr := readErr

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -450,8 +450,29 @@ func (h *Handler) handleNonStreamingResponse(w http.ResponseWriter, r *http.Requ
 	debuglog.Debug("proxy: handleNonStreamingResponse entered", "model", logData.modelID, "provider", logData.providerName, "upstream_status", resp.StatusCode, "attempt", attempt, "response_header_ms", responseHeaderMs)
 
 	w.Header().Set("Content-Type", "application/json")
+
+	// The body is read once, up front, because both branches below need the same
+	// bytes: the success branch decodes it, the failure branch records it. A
+	// decoder reading straight off resp.Body would leave nothing for the failure
+	// branch to sanitize into the request log.
+	// json.Decoder rather than json.Unmarshal so the accepted set of bodies is
+	// exactly what it was when the decoder read resp.Body directly: a decoder
+	// stops at the end of the first JSON value, an Unmarshal rejects anything
+	// following it.
+	body, readErr := io.ReadAll(resp.Body)
 	var chatResp ChatCompletionResponse
-	if err := json.NewDecoder(resp.Body).Decode(&chatResp); err == nil {
+	decodeErr := readErr
+	if decodeErr == nil {
+		decodeErr = json.NewDecoder(bytes.NewReader(body)).Decode(&chatResp)
+	}
+
+	// Only a 2xx that decodes is a completion. Some upstreams (OpenCode Zen and
+	// OpenCode Go both do this) answer a failed request with a non-2xx carrying a
+	// complete chat.completion envelope and no error object at all, which decodes
+	// cleanly; forwarding that leaves the caller with a failure status and nothing
+	// to read `.error.message` off. Status decides, the body only says whether the
+	// success shape is even available.
+	if decodeErr == nil && resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		totalDuration := float64(time.Since(startTime).Microseconds()) / 1000.0
 		var tps float64
 		var reasoningTokens int
@@ -540,7 +561,6 @@ func (h *Handler) handleNonStreamingResponse(w http.ResponseWriter, r *http.Requ
 		}
 		debuglog.Info("proxy: non-streaming completed", "model", logData.modelID, "provider", logData.providerName, "attempt", attempt, "status", resp.StatusCode, "duration_ms", totalDuration, "prompt_tokens", chatResp.Usage.PromptTokens, "completion_tokens", chatResp.Usage.CompletionTokens)
 	} else {
-		body, _ := io.ReadAll(resp.Body)
 		errMsg := util.SanitizeLogBody(string(body), 10000)
 		totalDuration := float64(time.Since(startTime).Microseconds()) / 1000.0
 		logData.statusCode = resp.StatusCode
@@ -554,9 +574,15 @@ func (h *Handler) handleNonStreamingResponse(w http.ResponseWriter, r *http.Requ
 		logData.dialMs = dialMs
 		logData.settingsReadMs = settingsReadMs
 		logData.responseHeaderMs = responseHeaderMs
-		logData.errorMessage = fmt.Sprintf("response decode error: %s", errMsg)
-		// This branch is reached when the upstream body would not decode, which
-		// happens both for a non-2xx error body and for a 2xx that is not a chat
+		// The prefix names which of the two ways in led here, so the row does not
+		// report a decode failure for a body that decoded perfectly well.
+		if decodeErr == nil {
+			logData.errorMessage = fmt.Sprintf("upstream HTTP %d: %s", resp.StatusCode, errMsg)
+		} else {
+			logData.errorMessage = fmt.Sprintf("response decode error: %s", errMsg)
+		}
+		// This branch takes every response that is not a 2xx completion: any
+		// non-2xx whatever its body decodes as, plus a 2xx that is not a chat
 		// completion. Classify from the body so the row is not left with an empty
 		// error_kind, and only claim "upstream HTTP n" when n actually was a
 		// failure — reporting "upstream provider returned HTTP 200" for an

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -440,6 +440,57 @@ func (h *Handler) handleDataChunk(sink *streamSink, st *streamState, ev sseEvent
 	return false
 }
 
+// nonStreamingFailureDetail decides what a response that is not a 2xx
+// completion may say about itself: the message stored in the request log
+// (dashboard-visible), the detail handed to the classifier and the debug log,
+// the error kind and the client-facing reason.
+//
+// It takes every response that is not a 2xx completion — any non-2xx whatever
+// its body decodes as, plus a 2xx that is not a chat completion — and the two
+// are NOT treated the same way. Do not merge them back together:
+//
+//   - A 2xx body is a completion. It failed to decode (a relay answering 200
+//     with "created":"1699…" or "total_tokens":"12" as a string is the usual
+//     cause) but it still holds the model's generated text, and this gateway
+//     logs no prompt or response content, ever. Only non-content diagnostics
+//     are reported: the decode error, the body length, the content type. The
+//     body itself goes nowhere near the request log or the debug log.
+//
+//   - A non-2xx carries no completion. Its body is the provider's error
+//     document, and that text is the whole reason such a row is worth reading,
+//     so it is sanitized and kept.
+func nonStreamingFailureDetail(resp *http.Response, body []byte, decodeErr error, modelID string) (logMsg, detail string, kind ErrorKind, reason string) {
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		detail = fmt.Sprintf("response decode error: %s (body_bytes=%d, content_type=%q)",
+			errString(decodeErr), len(body), resp.Header.Get("Content-Type"))
+		// Not "upstream provider returned HTTP 200": reporting the status as the
+		// failure sent operators hunting a provider outage that never happened.
+		return detail, detail, KindProviderBadRequest, "the provider returned a response the gateway could not decode"
+	}
+	detail = util.SanitizeLogBody(string(body), 10000)
+	// The prefix names which of the two ways in led here, so the row does not
+	// report a decode failure for a body that decoded perfectly well.
+	logMsg = fmt.Sprintf("upstream HTTP %d: %s", resp.StatusCode, detail)
+	if decodeErr != nil {
+		logMsg = fmt.Sprintf("response decode error: %s", detail)
+	}
+	// Classify from the body so the row is not left with an empty error_kind.
+	kind, reason = classifyUpstreamError(resp.StatusCode, detail, modelID)
+	return logMsg, detail, kind, reason
+}
+
+// nonStreamingBodyCap bounds the non-streaming completion body held in memory
+// for decoding. Unlike the caps on error bodies (failoverErrorClassifyCap,
+// responsesLearnBodyCap, miniMaxEnvelopeCap) this one guards a legitimate
+// payload, so it is set far above any real answer rather than just above any
+// real error message: 128k output tokens of text is well under 1MB, and the
+// outliers are chat completions carrying base64 image parts, several of which
+// still fit. It is 4x the multimodal pass-through's passthroughJSONBufferCap,
+// which can degrade to an unbuffered stream when a body is too large — this
+// path cannot, since it must decode to meter and normalise, so exceeding the
+// cap fails the request and it is set with that much more headroom.
+const nonStreamingBodyCap = 32 << 20 // 32MB
+
 func (h *Handler) handleNonStreamingResponse(w http.ResponseWriter, r *http.Request, logData *requestLogData, resp *http.Response, startTime time.Time, proxyOverhead, parseMs, failoverLookupMs, modelLookupMs, providerLookupMs, keyDecryptMs, dialMs, settingsReadMs, responseHeaderMs float64, vkHash string, attempt int) {
 	defer func() {
 		if r.Context().Err() == nil {
@@ -459,7 +510,16 @@ func (h *Handler) handleNonStreamingResponse(w http.ResponseWriter, r *http.Requ
 	// json.Decoder, not json.Unmarshal: a decoder stops at the end of the first
 	// JSON value, so a completion with trailing bytes after it still decodes,
 	// where an Unmarshal rejects the whole body.
-	body, readErr := io.ReadAll(resp.Body)
+	//
+	// The read is bounded (nonStreamingBodyCap) so one upstream cannot make the
+	// gateway buffer an arbitrary amount: cap+1 is read, and a body that reaches
+	// cap+1 is refused as oversized rather than decoded, because a truncated
+	// completion re-encoded as a valid one would hand the client silently
+	// mutilated content.
+	body, readErr := io.ReadAll(io.LimitReader(resp.Body, nonStreamingBodyCap+1))
+	if readErr == nil && len(body) > nonStreamingBodyCap {
+		readErr = fmt.Errorf("upstream response exceeds the %d byte non-streaming body cap", nonStreamingBodyCap)
+	}
 	var chatResp ChatCompletionResponse
 	decodeErr := readErr
 	if decodeErr == nil {
@@ -561,7 +621,6 @@ func (h *Handler) handleNonStreamingResponse(w http.ResponseWriter, r *http.Requ
 		}
 		debuglog.Info("proxy: non-streaming completed", "model", logData.modelID, "provider", logData.providerName, "attempt", attempt, "status", resp.StatusCode, "duration_ms", totalDuration, "prompt_tokens", chatResp.Usage.PromptTokens, "completion_tokens", chatResp.Usage.CompletionTokens)
 	} else {
-		errMsg := util.SanitizeLogBody(string(body), 10000)
 		totalDuration := float64(time.Since(startTime).Microseconds()) / 1000.0
 		logData.statusCode = resp.StatusCode
 		logData.durationMs = totalDuration
@@ -574,30 +633,14 @@ func (h *Handler) handleNonStreamingResponse(w http.ResponseWriter, r *http.Requ
 		logData.dialMs = dialMs
 		logData.settingsReadMs = settingsReadMs
 		logData.responseHeaderMs = responseHeaderMs
-		// The prefix names which of the two ways in led here, so the row does not
-		// report a decode failure for a body that decoded perfectly well.
-		if decodeErr == nil {
-			logData.errorMessage = fmt.Sprintf("upstream HTTP %d: %s", resp.StatusCode, errMsg)
-		} else {
-			logData.errorMessage = fmt.Sprintf("response decode error: %s", errMsg)
-		}
-		// This branch takes every response that is not a 2xx completion: any
-		// non-2xx whatever its body decodes as, plus a 2xx that is not a chat
-		// completion. Classify from the body so the row is not left with an empty
-		// error_kind, and only claim "upstream HTTP n" when n actually was a
-		// failure — reporting "upstream provider returned HTTP 200" for an
-		// undecodable success body sent operators hunting the wrong thing.
-		kind, reason := classifyUpstreamError(resp.StatusCode, errMsg, logData.modelID)
-		if resp.StatusCode < 300 {
-			kind = KindProviderBadRequest
-			reason = "the provider returned a response the gateway could not decode"
-		}
+		logMsg, detail, kind, reason := nonStreamingFailureDetail(resp, body, decodeErr, logData.modelID)
+		logData.errorMessage = logMsg
 		logData.errorKind = kind
 		logData.failoverAttempt = attempt
 		logData.state = "failed"
 		// Fire-and-forget: skip WaitForInsert to avoid blocking before error response.
 		h.updateRequestLog(logData, updateLogOption{skipWaitForInsert: true})
-		debuglog.Debug("proxy: non-streaming error details", "status", resp.StatusCode, "error_kind", kind, "model", logData.modelID, "provider", logData.providerName, "error", errMsg, "duration_ms", totalDuration)
+		debuglog.Debug("proxy: non-streaming error details", "status", resp.StatusCode, "error_kind", kind, "model", logData.modelID, "provider", logData.providerName, "error", detail, "duration_ms", totalDuration)
 		writeOpenAIError(w, upstreamClientMessage(logData.providerName, resp.StatusCode, reason), resp.StatusCode)
 	}
 }

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -861,16 +861,6 @@ func (h *Handler) recordBreakerOutcome(st *requestState, candidate modelCandidat
 	}
 }
 
-// retryWithStrippedParams handles a 400 from an upstream: it reads and restores
-// the error body, cancels the original (now-finished) request context, and — if
-// the body is a recognizable param-rejection — learns the rejected params into
-// the deprecation cache, rebuilds the request with them stripped, and re-issues
-// it once. See paramRetryResult for how the loop interprets the return value.
-//
-// failoverCancel is the original request's cancel func; it is invoked here once
-// the 400 body has been consumed (and again, harmlessly, on the successful-retry
-// path). dialMs is the per-request dial-timing pointer threaded into the retry
-// context so SafeDialer records the retry's DNS time.
 // learnedScopeFor scopes the learned reject/rename caches to one provider. The
 // provider id, not its type: many distinct custom endpoints share the "openai"
 // type, and a type-scoped entry would let one of them disable a param for all
@@ -913,6 +903,83 @@ func (h *Handler) learnRejectedParams(candidate modelCandidate, providerType str
 	debuglog.Info("proxy: learned rejected params from upstream 400", "provider", candidate.provider.Name, "model", candidate.model.ModelID, "rejected", fmt.Sprintf("%v", rejected), "renames", fmt.Sprintf("%v", renames))
 }
 
+// paramRetryRounds caps how many times one candidate is re-issued with newly
+// learned params stripped.
+//
+// Upstreams name a single offending param per 400, so a request carrying two of
+// them needs a second round to get through. Past that the provider is objecting
+// to something this self-heal cannot fix, and the 400 belongs to the client.
+const paramRetryRounds = 2
+
+// issueParamRetry rebuilds the upstream body with strip applied on top of the
+// learned caches and re-POSTs it to targetURL.
+//
+// The returned cancel func belongs to the retry's context: non-nil exactly when
+// a response is returned, whose body the caller must consume before calling it.
+// On failure the context is cancelled here (there is no body to read) and the
+// structured cause is returned for the failover loop to record.
+func (h *Handler) issueParamRetry(
+	r *http.Request,
+	st *requestState,
+	candidate modelCandidate,
+	providerType, targetURL string,
+	strip map[string]bool,
+	attempt int,
+	dialMs *float64,
+) (*http.Response, context.CancelFunc, *reqError) {
+	// Rebuild the request body using the shared rewrite path. This ensures
+	// stream_options injection, provider injection, universal/learned param
+	// stripping, and learned renaming are all applied on retry, preventing drift
+	// from the initial attempt path. The renames just cached are picked up from
+	// paramRenameCache; the rejected params learned so far are also passed as
+	// extraStrip so the retry drops them even before the cache writes are observed.
+	rebuilt := paramrewrite.BuildUpstreamBody(st.bodyBytes, providerType, candidate.model.ModelID, st.reqModel, st.isStreaming, &h.deprecationCache, &h.paramRenameCache, strip, learnedScopeFor(candidate))
+	retryCtx, rc := context.WithTimeout(r.Context(), st.failoverTimeout)
+	retryCtx = context.WithValue(retryCtx, ctxkeys.CancelOriginKey, "retry_timeout")
+	retryCtx = context.WithValue(retryCtx, ctxkeys.DialMsKey, dialMs)
+	retryReq, retryErr := newRequestWithContext(retryCtx, "POST", targetURL, bytes.NewReader(rebuilt))
+	if retryErr != nil {
+		rc()
+		return nil, nil, &reqError{Kind: KindInternal, Attempt: attempt, Provider: candidate.provider.Name, Underlying: errString(retryErr)}
+	}
+	util.SetProviderAuthHeaders(retryReq, providerType, candidate.apiKey)
+	retryReq.Header.Set("Content-Type", "application/json")
+	var retryCheckRedirect func(req *http.Request, via []*http.Request) error
+	if h.safeDialer != nil {
+		retryCheckRedirect = h.safeDialer.CheckRedirect
+	}
+	retryClient := &http.Client{Transport: h.upstreamTransport, CheckRedirect: retryCheckRedirect}
+	//nolint:bodyclose // retryResp.Body is returned to the caller, which consumes and closes it
+	retryResp, retryErr := retryClient.Do(retryReq)
+	if retryErr != nil {
+		rc() // no body to consume on retry error
+		debuglog.Warn("proxy: auto-retry request failed", "attempt", attempt+1, "provider", candidate.provider.Name, "provider_id", candidate.provider.ID, "error", retryErr)
+		if errors.Is(retryErr, context.Canceled) || errors.Is(retryErr, context.DeadlineExceeded) {
+			// Branch like the main failover loop: Canceled = client
+			// disconnect, DeadlineExceeded = retry timeout.
+			origin := "retry_timeout"
+			if errors.Is(retryErr, context.Canceled) {
+				origin = "client_disconnect"
+			}
+			return nil, nil, &reqError{Kind: cancelOriginToKind(origin), Attempt: attempt, Provider: candidate.provider.Name}
+		}
+		return nil, nil, &reqError{Kind: KindProviderError, Attempt: attempt, Provider: candidate.provider.Name, Underlying: errString(retryErr)}
+	}
+	return retryResp, rc, nil
+}
+
+// retryWithStrippedParams handles a 400 from an upstream: it reads and restores
+// the error body, cancels the original (now-finished) request context, and — if
+// the body is a recognizable param-rejection — learns the rejected params and
+// renames into the deprecation/rename caches, rebuilds the request with them
+// applied, and re-issues it. A retry that is itself rejected with a 400 is read
+// and learned from in exactly the same way, and re-issued once more when it
+// names a param the retry did not already carry. See paramRetryResult for how
+// the loop interprets the return value.
+//
+// failoverCancel is the original request's cancel func; it is invoked here once
+// the 400 body has been consumed. dialMs is the per-request dial-timing pointer
+// threaded into every retry context so SafeDialer records the retries' DNS time.
 func (h *Handler) retryWithStrippedParams(
 	r *http.Request,
 	st *requestState,
@@ -936,77 +1003,89 @@ func (h *Handler) retryWithStrippedParams(
 	if readErr != nil {
 		return res
 	}
+
+	// Everything applied to the outgoing body so far, accumulated across rounds:
+	// strip holds the rejected params (dropped), renamed the moves (value kept
+	// under the new name). They are also the termination guard — a round is only
+	// worth issuing when a 400 names something outside these sets.
+	strip := map[string]bool{}
+	renamed := map[string]string{}
+
 	// A 400 can ask us to drop a param (rejected → strip) and/or move a param to
 	// a new name (rename → preserve value). Both feed the same self-heal: learn,
-	// cache for future preemptive application, and retry once.
-	rejected := paramrewrite.ParseProviderParamError(body)
-	renames := paramrewrite.ParseProviderParamRename(body)
-	if rejected == nil && renames == nil {
-		return res
-	}
-
-	// Cache the learned rejections and renames for future preemptive application.
-	// Each cache is merged with any existing entries via CompareAndSwap to avoid
-	// data races from concurrent goroutines mutating the same map.
-	cacheKey := paramrewrite.LearnedCacheKey(learnedScopeFor(candidate), candidate.model.ModelID)
-	if rejected != nil {
-		paramrewrite.MergeLearnedParamCache(&h.deprecationCache, cacheKey, rejected)
-	}
-	if renames != nil {
-		paramrewrite.MergeLearnedParamCache(&h.paramRenameCache, cacheKey, renames)
-	}
-
-	// Rebuild the request body using the shared rewrite path. This ensures
-	// stream_options injection, provider injection, universal/learned param
-	// stripping, and learned renaming are all applied on retry, preventing drift
-	// from the initial attempt path. The renames just cached are picked up from
-	// paramRenameCache; the freshly-rejected params are also passed as extraStrip
-	// so the immediate retry strips them even before the cache write is observed.
-	rebuilt := paramrewrite.BuildUpstreamBody(st.bodyBytes, providerType, candidate.model.ModelID, st.reqModel, st.isStreaming, &h.deprecationCache, &h.paramRenameCache, rejected, learnedScopeFor(candidate))
-	retryCtx, rc := context.WithTimeout(r.Context(), st.failoverTimeout)
-	retryCtx = context.WithValue(retryCtx, ctxkeys.CancelOriginKey, "retry_timeout")
-	retryCtx = context.WithValue(retryCtx, ctxkeys.DialMsKey, dialMs)
-	res.streamCancelOrigin = "retry_timeout"
-	retryReq, retryErr := newRequestWithContext(retryCtx, "POST", targetURL, bytes.NewReader(rebuilt))
-	if retryErr != nil {
-		rc()
-		res.lastReqErr = reqError{Kind: KindInternal, Attempt: attempt, Provider: candidate.provider.Name, Underlying: errString(retryErr)}
-		res.cont = true
-		return res
-	}
-	util.SetProviderAuthHeaders(retryReq, providerType, candidate.apiKey)
-	retryReq.Header.Set("Content-Type", "application/json")
-	var retryCheckRedirect func(req *http.Request, via []*http.Request) error
-	if h.safeDialer != nil {
-		retryCheckRedirect = h.safeDialer.CheckRedirect
-	}
-	retryClient := &http.Client{Transport: h.upstreamTransport, CheckRedirect: retryCheckRedirect}
-	//nolint:bodyclose // retryResp.Body is returned to the caller (failover loop), which consumes and closes it after dispatch
-	retryResp, retryErr := retryClient.Do(retryReq)
-	if retryErr != nil {
-		rc() // no body to consume on retry error
-		debuglog.Warn("proxy: auto-retry request failed", "attempt", attempt+1, "provider", candidate.provider.Name, "provider_id", candidate.provider.ID, "error", retryErr)
-		if errors.Is(retryErr, context.Canceled) || errors.Is(retryErr, context.DeadlineExceeded) {
-			// Branch like the main failover loop: Canceled = client
-			// disconnect, DeadlineExceeded = retry timeout.
-			origin := "retry_timeout"
-			if errors.Is(retryErr, context.Canceled) {
-				origin = "client_disconnect"
-			}
-			res.lastReqErr = reqError{Kind: cancelOriginToKind(origin), Attempt: attempt, Provider: candidate.provider.Name}
-		} else {
-			res.lastReqErr = reqError{Kind: KindProviderError, Attempt: attempt, Provider: candidate.provider.Name, Underlying: errString(retryErr)}
+	// cache for future preemptive application, and retry. learnFrom does the
+	// learning half for one 400 body and reports whether that body named anything
+	// the request does not already carry — i.e. whether re-issuing could help.
+	learnFrom := func(errBody []byte) bool {
+		rejected := paramrewrite.ParseProviderParamError(errBody)
+		renames := paramrewrite.ParseProviderParamRename(errBody)
+		if rejected == nil && renames == nil {
+			return false
 		}
-		res.cont = true
-		return res
+		// Cache the learned rejections and renames for future preemptive
+		// application. Each cache is merged with any existing entries via
+		// CompareAndSwap to avoid data races from concurrent goroutines mutating
+		// the same map.
+		h.learnRejectedParams(candidate, providerType, errBody)
+		progressed := false
+		for p := range rejected {
+			if !strip[p] {
+				progressed = true
+			}
+			strip[p] = true
+		}
+		for oldName, newName := range renames {
+			if _, seen := renamed[oldName]; !seen {
+				progressed = true
+			}
+			renamed[oldName] = newName
+		}
+		return progressed
 	}
-	failoverCancel() // original 400 body already consumed, original context no longer needed
-	// retryCancel must NOT be called here — the retry resp.Body is read by the
-	// caller. It is returned for deferred cleanup after body consumption.
-	res.resp = retryResp
-	res.retryCancel = rc
-	res.retried = true
-	debuglog.Info("proxy: auto-retry succeeded", "model", candidate.model.ModelID, "rejected_params", mapKeys(rejected), "renamed_params", renameKeys(renames))
+
+	// Two guards, both required, so the loop always terminates: at most
+	// paramRetryRounds rounds, and a round only when the current 400 names
+	// something the request does not already carry (learnFrom's report), which
+	// makes strip∪renamed grow strictly on every iteration.
+	//
+	// learnFrom runs before the round check on purpose — it is the left operand,
+	// so it is evaluated even on the iteration that ends the loop. That is what
+	// makes the last 400 learned rather than discarded: the round it would have
+	// paid for is refused, but the next request still starts with what it named.
+	//
+	// The first 400 that names nothing recognisable falls straight out here and
+	// is handed back untouched.
+	for round := 0; learnFrom(body) && round < paramRetryRounds; round++ {
+		res.streamCancelOrigin = "retry_timeout"
+		retryResp, rc, retryErr := h.issueParamRetry(r, st, candidate, providerType, targetURL, strip, attempt, dialMs)
+		if retryErr != nil {
+			res.lastReqErr = *retryErr
+			res.cont = true
+			return res
+		}
+		if retryResp.StatusCode != http.StatusBadRequest {
+			// rc must NOT be called here — retryResp.Body is read by the caller.
+			// It is returned for deferred cleanup after body consumption.
+			res.resp = retryResp
+			res.retryCancel = rc
+			res.retried = true
+			debuglog.Info("proxy: auto-retry succeeded", "model", candidate.model.ModelID, "rounds", round+1, "rejected_params", mapKeys(strip), "renamed_params", renameKeys(renamed))
+			return res
+		}
+		// The retry was rejected too. Read its body so the params it names are
+		// learned as well, then hand that response on with the body restored: it
+		// is the client's 400 if no further round is issued.
+		body, readErr = io.ReadAll(retryResp.Body)
+		_ = retryResp.Body.Close()
+		rc() // retry body consumed and buffered, context no longer needed
+		retryResp.Body = io.NopCloser(bytes.NewReader(body))
+		res.resp = retryResp
+		res.retryCancel = nil
+		res.retried = true
+		if readErr != nil {
+			return res
+		}
+	}
 	return res
 }
 

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -744,9 +744,13 @@ func (h *Handler) forwardUpstreamError(w http.ResponseWriter, st *requestState, 
 		// semantic errors (e.g. context_length_exceeded, rate_limit_exceeded).
 		// The upstream's own error object carries detail this gateway cannot
 		// reconstruct — code, type, param, provider-specific fields — so it is
-		// passed through byte for byte. A 2xx that reached this function (any
-		// success status other than a bare 200) is not an error at all and is
-		// likewise left alone.
+		// passed through byte for byte.
+		//
+		// A 2xx that reached this function (any success status other than a bare
+		// 200) is not an error at all and is forwarded whatever its body is,
+		// including a non-JSON or empty one. That is what lets a 204 answer with
+		// no body: an envelope written under a No Content status would be a body
+		// this gateway invented for a request the provider considered successful.
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(resp.StatusCode)
 		_, _ = w.Write(body)
@@ -762,27 +766,56 @@ func (h *Handler) forwardUpstreamError(w http.ResponseWriter, st *requestState, 
 	default:
 		// Body is not JSON (e.g. HTML from a CDN). Wrap in an
 		// OpenAI-compatible envelope so JSON-parsing clients don't crash.
+		//
+		// The sanitized body rides inside the message here, where the case above
+		// hands back only the classified reason. The asymmetry is deliberate: the
+		// full body reaches the request log either way via failRequest, and how
+		// much of a provider's response this gateway echoes to callers is one
+		// decision for all three cases rather than something to widen here.
 		writeOpenAIError(w, errMsg, resp.StatusCode)
 	}
 	return outcomeFatal
 }
 
-// carriesErrorObject reports whether an upstream body is a JSON object with a
-// usable "error" member, which is what decides between forwarding that body
-// verbatim and synthesising an envelope over it.
+// carriesErrorObject reports whether an upstream body is a JSON object with an
+// "error" member that actually carries something, which is what decides between
+// forwarding that body verbatim and synthesising an envelope over it.
 //
-// Presence of the key is the whole test: its contents belong to the provider and
-// are not this gateway's to judge. An explicit null is treated as absent, since
-// `{"error":null}` beside a success-shaped body is the same thing as no error
-// object at all from a client's point of view. A body that is not a JSON object
-// (an array, a bare string, HTML) can carry no member and reports false.
+// The test is emptiness, not shape. What a provider puts inside its error is not
+// this gateway's to judge, so any populated value counts: an object with fields,
+// Ollama's bare string ("model not found"), a list, even a number. What does not
+// count is a member that leaves a client with nothing to read - `null`, `{}`,
+// `""`, `[]` - because a body carrying one of those is, from the caller's side,
+// the same body with no error member at all, which is exactly the case this
+// function exists to catch. A body that is not a JSON object (an array, a bare
+// string, HTML) can carry no member and reports false.
 func carriesErrorObject(body []byte) bool {
 	var envelope map[string]json.RawMessage
 	if err := json.Unmarshal(body, &envelope); err != nil {
 		return false
 	}
 	raw, present := envelope["error"]
-	return present && len(raw) > 0 && string(raw) != "null"
+	if !present {
+		return false
+	}
+	var content any
+	if err := json.Unmarshal(raw, &content); err != nil {
+		return false
+	}
+	switch v := content.(type) {
+	case nil:
+		return false
+	case string:
+		return strings.TrimSpace(v) != ""
+	case map[string]any:
+		return len(v) > 0
+	case []any:
+		return len(v) > 0
+	default:
+		// A number or a bool: peculiar, but the provider put a value there and
+		// a client can render it.
+		return true
+	}
 }
 
 // recordBreakerOutcome records the circuit-breaker result for a completed

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -973,6 +973,25 @@ func (h *Handler) issueParamRetry(
 	return retryResp, rc, nil
 }
 
+// readLearnable400 consumes a 400 body for the param self-heal: it reads what
+// the learner can parse, drains the rest so the connection stays reusable,
+// closes the original body and restores a readable one in its place — the
+// response is handed on to whoever renders the client's error, so it must never
+// leave here empty.
+//
+// The bound is the parse-sized responsesLearnBodyCap rather than the
+// scan-sized failoverErrorClassifyCap: learning json.Unmarshals the whole
+// document, so a body cut mid-JSON parses to nothing and teaches nothing. The
+// cap sits far past any real provider error, and everything above it is
+// discarded rather than held.
+func readLearnable400(resp *http.Response) ([]byte, error) {
+	body, err := io.ReadAll(io.LimitReader(resp.Body, responsesLearnBodyCap))
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+	resp.Body = io.NopCloser(bytes.NewReader(body))
+	return body, err
+}
+
 // retryWithStrippedParams handles a 400 from an upstream: it reads and restores
 // the error body, cancels the original (now-finished) request context, and — if
 // the body is a recognizable param-rejection — learns the rejected params and
@@ -996,13 +1015,11 @@ func (h *Handler) retryWithStrippedParams(
 	failoverCancel context.CancelFunc,
 	streamCancelOrigin string,
 ) paramRetryResult {
-	body, readErr := io.ReadAll(resp.Body)
-	_ = resp.Body.Close()
+	// Restored before anything else, so downstream error handling can read the
+	// body on every path that gives up without retrying.
+	body, readErr := readLearnable400(resp)
 	failoverCancel() // 400 body consumed, context no longer needed
 	debuglog.Debug("proxy: received 400 from upstream, checking for param rejection", "provider", candidate.provider.Name, "provider_id", candidate.provider.ID, "model", candidate.model.ModelID, "body_length", len(body))
-	// Restore the body so downstream error handling can read it if we don't
-	// successfully retry. Must be set before any fallthrough.
-	resp.Body = io.NopCloser(bytes.NewReader(body))
 
 	res := paramRetryResult{resp: resp, streamCancelOrigin: streamCancelOrigin}
 	if readErr != nil {
@@ -1080,18 +1097,8 @@ func (h *Handler) retryWithStrippedParams(
 		// The retry was rejected too. Read its body so the params it names are
 		// learned as well, then hand that response on with the body restored: it
 		// is the client's 400 if no further round is issued.
-		//
-		// Bounded, because this now runs once per round rather than once per
-		// attempt. The cap is the parse-sized one, not failoverErrorClassifyCap:
-		// learnFrom json.Unmarshals the document, so a body cut mid-JSON teaches
-		// nothing at all — responsesLearnBodyCap is sized to sit far past any real
-		// 400 for exactly that reason. Whatever is above it is drained rather than
-		// retained, keeping the connection reusable.
-		body, readErr = io.ReadAll(io.LimitReader(retryResp.Body, responsesLearnBodyCap))
-		_, _ = io.Copy(io.Discard, retryResp.Body)
-		_ = retryResp.Body.Close()
+		body, readErr = readLearnable400(retryResp)
 		rc() // retry body consumed and buffered, context no longer needed
-		retryResp.Body = io.NopCloser(bytes.NewReader(body))
 		res.resp = retryResp
 		res.retryCancel = nil
 		res.retried = true

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -689,11 +689,12 @@ func (h *Handler) doUpstream(ctx context.Context, req *http.Request, st *request
 }
 
 // forwardUpstreamError handles a non-200 upstream response that is NOT being
-// failed over (phase G): log + meter the failure via failRequest, then either
-// return a generic OpenAI error when the candidates are exhausted or forward the
-// upstream body (wrapping non-JSON bodies in an OpenAI envelope) so clients can
-// react to semantic errors. Drains/closes resp.Body exactly once and always
-// returns outcomeFatal.
+// failed over (phase G): log + meter the failure via failRequest, then answer the
+// client. Whatever the route through it, a non-2xx leaves this function as an
+// OpenAI error envelope: the classified reason when the candidates are exhausted,
+// the upstream's own body when that body carries an error object worth
+// forwarding, and a synthesised envelope when it does not. Drains/closes
+// resp.Body exactly once and always returns outcomeFatal.
 func (h *Handler) forwardUpstreamError(w http.ResponseWriter, st *requestState, candidate modelCandidate, resp *http.Response, attempt int, hasMoreCandidates bool, responseHeaderMs float64) candidateOutcome {
 	logData := st.logData
 	// How much of the body is worth holding depends on what happens to it below,
@@ -736,19 +737,52 @@ func (h *Handler) forwardUpstreamError(w http.ResponseWriter, st *requestState, 
 		return outcomeFatal
 	}
 
-	// Non-failover-eligible error with remaining candidates — forward
-	// the upstream response so clients can react to semantic errors
-	// (e.g. context_length_exceeded, rate_limit_exceeded).
-	if json.Valid(body) {
+	// Non-failover-eligible error with remaining candidates.
+	switch {
+	case carriesErrorObject(body) || resp.StatusCode/100 == 2:
+		// Forward the upstream response verbatim so clients can react to
+		// semantic errors (e.g. context_length_exceeded, rate_limit_exceeded).
+		// The upstream's own error object carries detail this gateway cannot
+		// reconstruct — code, type, param, provider-specific fields — so it is
+		// passed through byte for byte. A 2xx that reached this function (any
+		// success status other than a bare 200) is not an error at all and is
+		// likewise left alone.
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(resp.StatusCode)
 		_, _ = w.Write(body)
-	} else {
+	case json.Valid(body):
+		// A non-2xx whose JSON body carries no error object. OpenCode Zen and
+		// OpenCode Go answer some failed requests with a complete
+		// chat.completion envelope under an HTTP 400, which is valid JSON with
+		// nothing for a client to read `.error.message` off. There is no
+		// upstream error detail to preserve here, so the classified reason is
+		// synthesised into an envelope instead; the body itself stays in the
+		// request log via failRequest above.
+		writeOpenAIError(w, upstreamClientMessage(candidate.provider.Name, resp.StatusCode, reason), resp.StatusCode)
+	default:
 		// Body is not JSON (e.g. HTML from a CDN). Wrap in an
 		// OpenAI-compatible envelope so JSON-parsing clients don't crash.
 		writeOpenAIError(w, errMsg, resp.StatusCode)
 	}
 	return outcomeFatal
+}
+
+// carriesErrorObject reports whether an upstream body is a JSON object with a
+// usable "error" member, which is what decides between forwarding that body
+// verbatim and synthesising an envelope over it.
+//
+// Presence of the key is the whole test: its contents belong to the provider and
+// are not this gateway's to judge. An explicit null is treated as absent, since
+// `{"error":null}` beside a success-shaped body is the same thing as no error
+// object at all from a client's point of view. A body that is not a JSON object
+// (an array, a bare string, HTML) can carry no member and reports false.
+func carriesErrorObject(body []byte) bool {
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return false
+	}
+	raw, present := envelope["error"]
+	return present && len(raw) > 0 && string(raw) != "null"
 }
 
 // recordBreakerOutcome records the circuit-breaker result for a completed

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -49,16 +49,18 @@ const responsesLearnBodyCap = 1 << 20
 
 // paramRetryResult is the outcome of the 400 param-stripping auto-retry
 // (retryWithStrippedParams). It tells the failover loop how to proceed:
-//   - resp: the response to continue handling with — the retry's response on a
-//     successful retry, otherwise the original 400 response with its body
-//     restored (so normal non-200 handling can read it).
+//   - resp: the response to continue handling with — the last retry's response
+//     once any retry was issued, otherwise the original 400. Every 400 that
+//     leaves here carries a restored body, so normal non-200 handling can read
+//     it whether it is the original or the one a retry earned.
 //   - retryCancel: the retry context's cancel func, non-nil only when a retry
 //     response is live and its body has NOT yet been consumed. The caller must
 //     call it after consuming the body.
 //   - streamCancelOrigin: "retry_timeout" once a retry was issued, otherwise
 //     the caller's original value, unchanged.
-//   - retried: true when a retry request succeeded — the caller must fold the
-//     retry's dial time into the running totals.
+//   - retried: true once a retry request was issued and answered, whatever it
+//     answered with — the caller must fold the retries' dial time into the
+//     running totals.
 //   - lastReqErr: set only when cont is true; the structured cause the caller
 //     records via st.setReqErr before failing over.
 //   - cont: true => the caller should `continue` to the next candidate (a retry
@@ -158,15 +160,18 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 		resp = res.resp
 		streamCancelOrigin = res.streamCancelOrigin
 		retryCancel = res.retryCancel
-		if res.cont {
-			st.setReqErr(res.lastReqErr)
-			return outcomeFailover
-		}
-		if res.retried {
-			// Accumulate retry's dial time into total.
+		if res.retried || res.cont {
+			// Accumulate the retries' dial time into the total. The cont path is
+			// included because a transport failure on one round must not discard
+			// what the rounds before it already spent dialling; dialMs is zero
+			// when no round got that far, so the fold is a no-op there.
 			st.timings.dialMs += dialMs
 			dialMs = 0
 			st.proxyOverhead = st.timings.proxyOverheadMs(st.parseMs)
+		}
+		if res.cont {
+			st.setReqErr(res.lastReqErr)
+			return outcomeFailover
 		}
 	}
 
@@ -1075,7 +1080,15 @@ func (h *Handler) retryWithStrippedParams(
 		// The retry was rejected too. Read its body so the params it names are
 		// learned as well, then hand that response on with the body restored: it
 		// is the client's 400 if no further round is issued.
-		body, readErr = io.ReadAll(retryResp.Body)
+		//
+		// Bounded, because this now runs once per round rather than once per
+		// attempt. The cap is the parse-sized one, not failoverErrorClassifyCap:
+		// learnFrom json.Unmarshals the document, so a body cut mid-JSON teaches
+		// nothing at all — responsesLearnBodyCap is sized to sit far past any real
+		// 400 for exactly that reason. Whatever is above it is drained rather than
+		// retained, keeping the connection reusable.
+		body, readErr = io.ReadAll(io.LimitReader(retryResp.Body, responsesLearnBodyCap))
+		_, _ = io.Copy(io.Discard, retryResp.Body)
 		_ = retryResp.Body.Close()
 		rc() // retry body consumed and buffered, context no longer needed
 		retryResp.Body = io.NopCloser(bytes.NewReader(body))

--- a/internal/proxy/proxy_failover_test.go
+++ b/internal/proxy/proxy_failover_test.go
@@ -495,6 +495,83 @@ func TestRetryWithStrippedParams_LargeRetry400StaysParseable(t *testing.T) {
 	}
 }
 
+// TestRetryWithStrippedParams_LargeFirst400 pins the same bound on the FIRST
+// 400, which is read through readLearnable400 alongside the retry's. Both
+// halves of that read matter and are asserted separately:
+//
+//   - a body the parser recognises must still be learned from at 32 KiB, i.e.
+//     the cap must not be the 16 KiB classify one;
+//   - a body it does not recognise must still reach the caller byte-identical,
+//     which is the fall-through behaviour the brief pins as unchanged.
+func TestRetryWithStrippedParams_LargeFirst400(t *testing.T) {
+	pad := strings.Repeat("x", 32<<10)
+
+	t.Run("unrecognised body restores intact", func(t *testing.T) {
+		large := `{"error":{"message":"some unrelated validation failure","detail":"` + pad + `"}}`
+		if len(large) <= failoverErrorClassifyCap {
+			t.Fatalf("test body must exceed the classify cap to be meaningful, got %d", len(large))
+		}
+		h := newRetryTestHandler()
+		st := newRetryTestState()
+		cand := newRetryTestCandidate("http://127.0.0.1:0") // never dialled
+		req := httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)
+		var dialMs float64
+
+		res := h.retryWithStrippedParams(req, st, cand, "openai", "http://127.0.0.1:0",
+			resp400(large), 0, &dialMs, func() {}, "failover_timeout")
+
+		if res.retried || res.cont {
+			t.Fatalf("expected no retry for an unrecognised 400, got retried=%v cont=%v", res.retried, res.cont)
+		}
+		body, err := io.ReadAll(res.resp.Body)
+		if err != nil {
+			t.Fatalf("read restored body: %v", err)
+		}
+		if string(body) != large {
+			t.Errorf("expected the oversized body restored whole (%d bytes), got %d", len(large), len(body))
+		}
+	})
+
+	t.Run("named param still learned", func(t *testing.T) {
+		large := `{"error":{"message":"Unsupported parameter: 'top_k' is not supported with this model.","detail":"` + pad + `"}}`
+		var calls atomic.Int32
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			calls.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{"id":"x","object":"chat.completion","choices":[]}`)
+		}))
+		defer upstream.Close()
+
+		h := newRetryTestHandler()
+		st := newRetryTestState()
+		cand := newRetryTestCandidate(upstream.URL)
+		req := httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)
+		var dialMs float64
+
+		res := h.retryWithStrippedParams(req, st, cand, "openai", upstream.URL,
+			resp400(large), 0, &dialMs, func() {}, "failover_timeout")
+
+		if !res.retried {
+			t.Fatalf("a 32 KiB first 400 was not parsed, so no retry was issued (cont=%v)", res.cont)
+		}
+		if res.resp == nil || res.resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected the caller to get the 200, got %+v", res.resp)
+		}
+		if res.retryCancel != nil {
+			res.retryCancel()
+		}
+		_ = res.resp.Body.Close()
+		if got := calls.Load(); got != 1 {
+			t.Errorf("expected one upstream retry, got %d", got)
+		}
+		learnKey := paramrewrite.LearnedCacheKey(cand.provider.ID.String(), cand.model.ModelID)
+		if rejected := learnedRejected(t, h, learnKey); !rejected["top_k"] {
+			t.Errorf("a 32 KiB first 400 was not parsed for learning: %v", rejected)
+		}
+	})
+}
+
 // TestDoUpstream_ProviderErrorCapturesUnderlying verifies that a terminal
 // transport error (here: connection refused, retried then exhausted) is
 // captured into the structured error's Underlying field, classified as a

--- a/internal/proxy/proxy_failover_test.go
+++ b/internal/proxy/proxy_failover_test.go
@@ -393,6 +393,108 @@ func TestRetryWithStrippedParams_TwoRetryCap(t *testing.T) {
 	}
 }
 
+// TestRetryWithStrippedParams_StopsWhenNoNewParamNamed covers the other half of
+// the termination guard, the one the round cap cannot stand in for: an upstream
+// that keeps naming a param the retry ALREADY applied must not be re-issued at
+// all, because the second request would be byte-identical to the first.
+//
+// Exactly one upstream call is the assertion that carries this. Delete the
+// strict-progress test in retryWithStrippedParams (make it unconditionally true)
+// and the cap alone still permits a second round, so this test — and only this
+// test — turns red.
+func TestRetryWithStrippedParams_StopsWhenNoNewParamNamed(t *testing.T) {
+	var calls atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(w, temperature400)
+	}))
+	defer upstream.Close()
+
+	h := newRetryTestHandler()
+	st := newRetryTestState()
+	cand := newRetryTestCandidate(upstream.URL)
+
+	req := httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)
+	var dialMs float64
+
+	// Seed and retry both name temperature: the retry already stripped it, so a
+	// second round has nothing new to apply.
+	res := h.retryWithStrippedParams(req, st, cand, "openai", upstream.URL,
+		resp400(temperature400), 0, &dialMs, func() {}, "failover_timeout")
+
+	if res.cont {
+		t.Fatalf("expected cont=false, got lastReqErr=%+v", res.lastReqErr)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Errorf("expected the repeated param to stop the loop after one retry, got %d", got)
+	}
+	if res.resp == nil || res.resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected the retry's 400 handed back, got %+v", res.resp)
+	}
+	if res.retryCancel != nil {
+		t.Errorf("expected nil retryCancel: the body was buffered and the context released")
+	}
+	body, err := io.ReadAll(res.resp.Body)
+	if err != nil {
+		t.Fatalf("read restored body: %v", err)
+	}
+	if string(body) != temperature400 {
+		t.Errorf("expected the retry's body restored, got %q", string(body))
+	}
+}
+
+// TestRetryWithStrippedParams_LargeRetry400StaysParseable pins the cap chosen
+// for the retry's own 400 body. It is read through a LimitReader, and the limit
+// has to be the parse-sized one: learning json.Unmarshals the document, so a
+// body clipped at the 16 KiB classify cap would parse to nothing and teach
+// nothing. A 32 KiB error body must still be learned from and still reach the
+// caller whole.
+func TestRetryWithStrippedParams_LargeRetry400StaysParseable(t *testing.T) {
+	large := `{"error":{"message":"Unsupported parameter: 'top_p' is not supported with this model.","detail":"` +
+		strings.Repeat("x", 32<<10) + `"}}`
+	if len(large) <= failoverErrorClassifyCap {
+		t.Fatalf("test body must exceed the classify cap to be meaningful, got %d", len(large))
+	}
+	var calls atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(w, large)
+	}))
+	defer upstream.Close()
+
+	h := newRetryTestHandler()
+	st := newRetryTestState()
+	cand := newRetryTestCandidate(upstream.URL)
+
+	req := httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)
+	var dialMs float64
+
+	res := h.retryWithStrippedParams(req, st, cand, "openai", upstream.URL,
+		resp400(temperature400), 0, &dialMs, func() {}, "failover_timeout")
+
+	if res.cont {
+		t.Fatalf("expected cont=false, got lastReqErr=%+v", res.lastReqErr)
+	}
+	if res.resp == nil || res.resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected a 400 handed back, got %+v", res.resp)
+	}
+	body, err := io.ReadAll(res.resp.Body)
+	if err != nil {
+		t.Fatalf("read restored body: %v", err)
+	}
+	if string(body) != large {
+		t.Errorf("expected the oversized body restored whole (%d bytes), got %d", len(large), len(body))
+	}
+	learnKey := paramrewrite.LearnedCacheKey(cand.provider.ID.String(), cand.model.ModelID)
+	if rejected := learnedRejected(t, h, learnKey); !rejected["top_p"] {
+		t.Errorf("a 32 KiB 400 was not parsed for learning: %v", rejected)
+	}
+}
+
 // TestDoUpstream_ProviderErrorCapturesUnderlying verifies that a terminal
 // transport error (here: connection refused, retried then exhausted) is
 // captured into the structured error's Underlying field, classified as a

--- a/internal/proxy/proxy_failover_test.go
+++ b/internal/proxy/proxy_failover_test.go
@@ -230,6 +230,169 @@ func TestRetryWithStrippedParams_NonParamErrorFallsThrough(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// Multi-round param self-heal.
+//
+// Upstreams name one offending param per 400, so a request carrying two of them
+// needs the retry's own 400 to be parsed and learned as well.
+// ---------------------------------------------------------------------------
+
+// learnedRejected reads the rejected-param map the deprecation cache holds for
+// one provider+model, or nil when nothing was learned.
+func learnedRejected(t *testing.T, h *Handler, key string) map[string]bool {
+	t.Helper()
+	v, ok := h.deprecationCache.Load(key)
+	if !ok {
+		return nil
+	}
+	m, ok := v.(*map[string]bool)
+	if !ok {
+		t.Fatalf("deprecation cache holds %T under %s, want *map[string]bool", v, key)
+	}
+	return *m
+}
+
+// learnedRenames reads the rename map the rename cache holds for one
+// provider+model, or nil when nothing was learned.
+func learnedRenames(t *testing.T, h *Handler, key string) map[string]string {
+	t.Helper()
+	v, ok := h.paramRenameCache.Load(key)
+	if !ok {
+		return nil
+	}
+	m, ok := v.(*map[string]string)
+	if !ok {
+		t.Fatalf("rename cache holds %T under %s, want *map[string]string", v, key)
+	}
+	return *m
+}
+
+const (
+	// The rename directive OpenAI's gpt-5 family answers max_tokens with.
+	maxTokensRename400 = `{"error":{"message":"Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead."}}`
+	// The value-validation 400 the same models answer temperature:0 with.
+	temperature400 = `{"error":{"message":"Unsupported value: 'temperature' does not support 0 with this model. Only the default (1) value is supported."}}`
+)
+
+// TestRetryWithStrippedParams_LearnsFromRetry400 is the regression test for the
+// two-param request: the first 400 names max_tokens (a rename), the retry's own
+// 400 names temperature. Before the fix that second 400 went straight to the
+// client with nothing learned from it, so the next identical request re-learned
+// from scratch. Both params must now be learned and the caller must get the 200.
+func TestRetryWithStrippedParams_LearnsFromRetry400(t *testing.T) {
+	var calls atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if calls.Add(1) == 1 {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = io.WriteString(w, temperature400)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"id":"x","object":"chat.completion","choices":[]}`)
+	}))
+	defer upstream.Close()
+
+	h := newRetryTestHandler()
+	st := newRetryTestState()
+	st.bodyBytes = []byte(`{"model":"test-model","messages":[{"role":"user","content":"hi"}],"max_tokens":64,"temperature":0}`)
+	cand := newRetryTestCandidate(upstream.URL)
+
+	req := httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)
+	var dialMs float64
+
+	res := h.retryWithStrippedParams(req, st, cand, "openai", upstream.URL,
+		resp400(maxTokensRename400), 0, &dialMs, func() {}, "failover_timeout")
+
+	if res.cont {
+		t.Fatalf("expected cont=false, got lastReqErr=%+v", res.lastReqErr)
+	}
+	if !res.retried {
+		t.Fatalf("expected retried=true")
+	}
+	if res.resp == nil || res.resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected the caller to get the 200, got %+v", res.resp)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Errorf("expected two upstream retries (one per named param), got %d", got)
+	}
+	if res.retryCancel == nil {
+		t.Errorf("expected non-nil retryCancel with a live body")
+	} else {
+		res.retryCancel()
+	}
+	_ = res.resp.Body.Close()
+
+	learnKey := paramrewrite.LearnedCacheKey(cand.provider.ID.String(), cand.model.ModelID)
+	if renames := learnedRenames(t, h, learnKey); renames["max_tokens"] != "max_completion_tokens" {
+		t.Errorf("first 400's rename not learned: %v", renames)
+	}
+	if rejected := learnedRejected(t, h, learnKey); !rejected["temperature"] {
+		t.Errorf("the retry's own 400 was not learned: %v", rejected)
+	}
+}
+
+// TestRetryWithStrippedParams_TwoRetryCap holds the cap: an upstream that 400s
+// forever, naming a fresh param every time, must be re-issued exactly twice.
+// The last 400 is still learned and is handed back with its body restored.
+func TestRetryWithStrippedParams_TwoRetryCap(t *testing.T) {
+	named := []string{"top_p", "top_k", "frequency_penalty"}
+	var calls atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := int(calls.Add(1)) - 1
+		param := "presence_penalty"
+		if n < len(named) {
+			param = named[n]
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = fmt.Fprintf(w, `{"error":{"message":"Unsupported parameter: '%s' is not supported with this model."}}`, param)
+	}))
+	defer upstream.Close()
+
+	h := newRetryTestHandler()
+	st := newRetryTestState()
+	cand := newRetryTestCandidate(upstream.URL)
+
+	req := httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)
+	var dialMs float64
+
+	res := h.retryWithStrippedParams(req, st, cand, "openai", upstream.URL,
+		resp400(temperature400), 0, &dialMs, func() {}, "failover_timeout")
+
+	if res.cont {
+		t.Fatalf("expected cont=false, got lastReqErr=%+v", res.lastReqErr)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Errorf("expected the two-retry cap to hold, got %d upstream retries", got)
+	}
+	if res.resp == nil || res.resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected the last 400 handed back, got %+v", res.resp)
+	}
+	if res.retryCancel != nil {
+		t.Errorf("expected nil retryCancel: the body was buffered and the context released")
+	}
+	// The body must be readable by the caller's normal non-200 handling.
+	body, err := io.ReadAll(res.resp.Body)
+	if err != nil {
+		t.Fatalf("read restored body: %v", err)
+	}
+	if !strings.Contains(string(body), "top_k") {
+		t.Errorf("expected the last 400's body restored, got %q", string(body))
+	}
+
+	learnKey := paramrewrite.LearnedCacheKey(cand.provider.ID.String(), cand.model.ModelID)
+	rejected := learnedRejected(t, h, learnKey)
+	for _, p := range []string{"temperature", "top_p", "top_k"} {
+		if !rejected[p] {
+			t.Errorf("expected %q learned from its 400, got %v", p, rejected)
+		}
+	}
+	if rejected["frequency_penalty"] {
+		t.Errorf("frequency_penalty was learned, so a third retry was issued: %v", rejected)
+	}
+}
+
 // TestDoUpstream_ProviderErrorCapturesUnderlying verifies that a terminal
 // transport error (here: connection refused, retried then exhausted) is
 // captured into the structured error's Underlying field, classified as a

--- a/internal/proxy/proxy_failover_test.go
+++ b/internal/proxy/proxy_failover_test.go
@@ -302,7 +302,7 @@ func TestDoUpstream_ClientDisconnectPreservesProviderError(t *testing.T) {
 // This is the reachable half of "a non-2xx must never reach the client as a
 // success-shaped body": the chat path sends every non-200 here before
 // handleNonStreamingResponse can see it, and with a candidate still in the group
-// a non-failover-eligible status forwards the provider's body as-is.
+// a non-failover-eligible status answers straight from the provider's body.
 // ---------------------------------------------------------------------------
 
 // runForwardUpstreamError drives one upstream answer through the function and
@@ -344,9 +344,15 @@ func TestForwardUpstreamError_Non2xxWithoutErrorObjectGetsEnvelope(t *testing.T)
 	h := newIntegrationHandler()
 	defer stopUnitHandler(h)
 
+	// Every shape whose "error" member leaves a client with nothing to read is
+	// the same case as no error member at all.
 	bodies := map[string]string{
 		"chat completion shape": zenChatShapedBody,
 		"explicit null error":   `{"id":"chatcmpl_u5tt67g6rmf","error":null}`,
+		"empty error object":    `{"id":"chatcmpl_u5tt67g6rmf","error":{}}`,
+		"empty error string":    `{"id":"chatcmpl_u5tt67g6rmf","error":""}`,
+		"blank error string":    `{"id":"chatcmpl_u5tt67g6rmf","error":"   "}`,
+		"empty error list":      `{"id":"chatcmpl_u5tt67g6rmf","error":[]}`,
 		"not an object":         `["upstream said no"]`,
 		"not json at all":       `<html><body>400 Bad Request</body></html>`,
 	}
@@ -415,18 +421,76 @@ func TestForwardUpstreamError_ErrorObjectForwardedVerbatim(t *testing.T) {
 	}
 }
 
+// An error member that carries something is the provider's to describe, whatever
+// shape it chose. Ollama answers with a bare string rather than an object, which
+// is real detail and must survive.
+func TestForwardUpstreamError_NonObjectErrorForwardedVerbatim(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandler(h)
+
+	bodies := map[string]string{
+		"ollama string error": `{"error":"model not found, try pulling it first"}`,
+		"list of errors":      `{"error":[{"message":"first"},{"message":"second"}]}`,
+	}
+
+	for name, upstreamBody := range bodies {
+		t.Run(name, func(t *testing.T) {
+			w, _ := runForwardUpstreamError(t, h, http.StatusNotFound, upstreamBody, true)
+
+			if w.Code != http.StatusNotFound {
+				t.Errorf("expected status 404, got %d", w.Code)
+			}
+			if got := w.Body.String(); got != upstreamBody {
+				t.Errorf("upstream error detail not forwarded byte for byte:\n got: %s\nwant: %s", got, upstreamBody)
+			}
+		})
+	}
+}
+
 // A success status other than a bare 200 reaches this function too (the caller
-// only special-cases 200). It is not an error and must not be rewritten.
+// only special-cases 200). It is not an error and must not be rewritten,
+// whatever its body looks like.
 func TestForwardUpstreamError_2xxBodyUntouched(t *testing.T) {
 	h := newIntegrationHandler()
 	defer stopUnitHandler(h)
 
-	w, _ := runForwardUpstreamError(t, h, http.StatusCreated, zenChatShapedBody, true)
+	t.Run("json body", func(t *testing.T) {
+		w, _ := runForwardUpstreamError(t, h, http.StatusCreated, zenChatShapedBody, true)
 
-	if w.Code != http.StatusCreated {
-		t.Errorf("expected status 201, got %d", w.Code)
-	}
-	if got := w.Body.String(); got != zenChatShapedBody {
-		t.Errorf("2xx body not forwarded byte for byte:\n got: %s\nwant: %s", got, zenChatShapedBody)
-	}
+		if w.Code != http.StatusCreated {
+			t.Errorf("expected status 201, got %d", w.Code)
+		}
+		if got := w.Body.String(); got != zenChatShapedBody {
+			t.Errorf("2xx body not forwarded byte for byte:\n got: %s\nwant: %s", got, zenChatShapedBody)
+		}
+	})
+
+	// A 204 is the case that makes forwarding rather than wrapping the right
+	// rule for every 2xx: writing an error envelope under a No Content status
+	// would be a body invented by this gateway for a request the provider
+	// considered successful.
+	t.Run("empty 204 body stays empty", func(t *testing.T) {
+		w, _ := runForwardUpstreamError(t, h, http.StatusNoContent, "", true)
+
+		if w.Code != http.StatusNoContent {
+			t.Errorf("expected status 204, got %d", w.Code)
+		}
+		if got := w.Body.String(); got != "" {
+			t.Errorf("204 answered with a body: %s", got)
+		}
+	})
+
+	// The same rule with a body that is not JSON at all: still a success status,
+	// still the provider's answer, still forwarded untouched.
+	t.Run("non-json body", func(t *testing.T) {
+		const plain = `accepted`
+		w, _ := runForwardUpstreamError(t, h, http.StatusAccepted, plain, true)
+
+		if w.Code != http.StatusAccepted {
+			t.Errorf("expected status 202, got %d", w.Code)
+		}
+		if got := w.Body.String(); got != plain {
+			t.Errorf("non-JSON 2xx body rewritten: %s", got)
+		}
+	})
 }

--- a/internal/proxy/proxy_failover_test.go
+++ b/internal/proxy/proxy_failover_test.go
@@ -2,6 +2,8 @@ package proxy
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -291,5 +293,140 @@ func TestDoUpstream_ClientDisconnectPreservesProviderError(t *testing.T) {
 	}
 	if !strings.Contains(st.lastReqErr.Underlying, "connection refused") {
 		t.Errorf("client disconnect DROPPED the real provider error (the bug this fixes): Underlying=%q", st.lastReqErr.Underlying)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// forwardUpstreamError response shape.
+//
+// This is the reachable half of "a non-2xx must never reach the client as a
+// success-shaped body": the chat path sends every non-200 here before
+// handleNonStreamingResponse can see it, and with a candidate still in the group
+// a non-failover-eligible status forwards the provider's body as-is.
+// ---------------------------------------------------------------------------
+
+// runForwardUpstreamError drives one upstream answer through the function and
+// returns what the client got plus the log row it left behind.
+func runForwardUpstreamError(t *testing.T, h *Handler, status int, body string, hasMoreCandidates bool) (*httptest.ResponseRecorder, *requestLogData) {
+	t.Helper()
+
+	logData := &requestLogData{
+		modelID:        "gpt-5.1-codex",
+		providerName:   "opencode-zen",
+		virtualKeyName: "test-key",
+		virtualKeyID:   "00000000-0000-0000-0000-000000000001",
+		state:          "pending",
+	}
+	st := &requestState{startTime: time.Now(), logData: logData}
+	candidate := modelCandidate{
+		model:    &model.Model{ModelID: "gpt-5.1-codex"},
+		provider: &provider.Provider{ID: uuid.New(), Name: "opencode-zen"},
+	}
+	resp := &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}
+
+	w := httptest.NewRecorder()
+	if outcome := h.forwardUpstreamError(w, st, candidate, resp, 0, hasMoreCandidates, 1.5); outcome != outcomeFatal {
+		t.Fatalf("expected outcomeFatal, got %v", outcome)
+	}
+	return w, logData
+}
+
+// A non-2xx whose body carries no error object leaves as a synthesised envelope,
+// whether or not candidates remain. zenChatShapedBody is the production shape:
+// OpenCode Zen and OpenCode Go answer some failed requests with a complete
+// chat.completion under an HTTP 400, which is valid JSON with nothing for a
+// client to read `.error.message` off.
+func TestForwardUpstreamError_Non2xxWithoutErrorObjectGetsEnvelope(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandler(h)
+
+	bodies := map[string]string{
+		"chat completion shape": zenChatShapedBody,
+		"explicit null error":   `{"id":"chatcmpl_u5tt67g6rmf","error":null}`,
+		"not an object":         `["upstream said no"]`,
+		"not json at all":       `<html><body>400 Bad Request</body></html>`,
+	}
+
+	for name, upstreamBody := range bodies {
+		for _, hasMore := range []bool{true, false} {
+			t.Run(fmt.Sprintf("%s/hasMoreCandidates=%v", name, hasMore), func(t *testing.T) {
+				w, logData := runForwardUpstreamError(t, h, http.StatusBadRequest, upstreamBody, hasMore)
+
+				if w.Code != http.StatusBadRequest {
+					t.Errorf("expected upstream status 400 to reach the client, got %d", w.Code)
+				}
+				var got map[string]json.RawMessage
+				if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+					t.Fatalf("client body is not JSON: %v (%s)", err, w.Body.String())
+				}
+				rawErr, present := got["error"]
+				if !present {
+					t.Fatalf("client body has no error object: %s", w.Body.String())
+				}
+				var errObj struct {
+					Message string `json:"message"`
+				}
+				if err := json.Unmarshal(rawErr, &errObj); err != nil {
+					t.Fatalf("re-parse error object: %v", err)
+				}
+				if errObj.Message == "" {
+					t.Errorf("error envelope carries no message: %s", w.Body.String())
+				}
+				if _, present := got["choices"]; present {
+					t.Errorf("success-shaped choices reached the client on a 400: %s", w.Body.String())
+				}
+				if logData.state != "failed" {
+					t.Errorf("expected state=%q, got %q", "failed", logData.state)
+				}
+				if logData.errorMessage == "" {
+					t.Error("upstream body not recoverable from error_message")
+				}
+			})
+		}
+	}
+}
+
+// The upstream's own error object is detail this gateway cannot reconstruct
+// (code, type, param, provider-specific fields), so with a candidate still in
+// the group the body is forwarded byte for byte.
+func TestForwardUpstreamError_ErrorObjectForwardedVerbatim(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandler(h)
+
+	const upstreamBody = `{"error":{"message":"custom_validation_error","type":"invalid_request_error","param":"messages[0].content","code":"context_length_exceeded"},"request_id":"req_abc123"}`
+
+	w, logData := runForwardUpstreamError(t, h, http.StatusBadRequest, upstreamBody, true)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected status 400, got %d", w.Code)
+	}
+	if got := w.Body.String(); got != upstreamBody {
+		t.Errorf("upstream error body not forwarded byte for byte:\n got: %s\nwant: %s", got, upstreamBody)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("expected application/json, got %q", ct)
+	}
+	if logData.state != "failed" {
+		t.Errorf("expected state=%q, got %q", "failed", logData.state)
+	}
+}
+
+// A success status other than a bare 200 reaches this function too (the caller
+// only special-cases 200). It is not an error and must not be rewritten.
+func TestForwardUpstreamError_2xxBodyUntouched(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandler(h)
+
+	w, _ := runForwardUpstreamError(t, h, http.StatusCreated, zenChatShapedBody, true)
+
+	if w.Code != http.StatusCreated {
+		t.Errorf("expected status 201, got %d", w.Code)
+	}
+	if got := w.Body.String(); got != zenChatShapedBody {
+		t.Errorf("2xx body not forwarded byte for byte:\n got: %s\nwant: %s", got, zenChatShapedBody)
 	}
 }

--- a/internal/proxy/proxy_nonstreaming_test.go
+++ b/internal/proxy/proxy_nonstreaming_test.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -418,4 +419,319 @@ func TestHandleNonStreamingResponse_ChatShapedNon2xxDoesNotMeter(t *testing.T) {
 	if logData.deliveredContent {
 		t.Error("a non-2xx must not count as the model having served content")
 	}
+}
+
+// ---------------------------------------------------------------------------
+// What a failed decode may put in the logs
+// ---------------------------------------------------------------------------
+
+// paddingReader is an endless source of one filler byte, so an oversized
+// upstream body can be produced without allocating it test-side.
+type paddingReader struct{}
+
+func (paddingReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 'a'
+	}
+	return len(p), nil
+}
+
+func nonStreamingLogData() *requestLogData {
+	return &requestLogData{
+		modelID:         "test-model",
+		streaming:       false,
+		virtualKeyName:  "test-key",
+		virtualKeyID:    "00000000-0000-0000-0000-000000000001",
+		failoverAttempt: 0,
+		state:           "pending",
+	}
+}
+
+// A 2xx whose body fails to decode is still a completion: it holds the model's
+// generated text. No prompt or response content is ever logged, so the row may
+// carry only the decode diagnostics. errorMessage is dashboard-visible and
+// stored, and it is the same string handed to the debug log, so asserting on it
+// covers both sinks.
+func TestHandleNonStreamingResponse_Undecodable2xxDoesNotLogContent(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandlerIntegration(h)
+
+	// A real shape from a relay: valid completion, "created" sent as a string.
+	// The decode fails on the type; the assistant's answer is right beside it.
+	const secret = "the-user-private-answer-text"
+	body := `{"id":"chatcmpl-1","object":"chat.completion","created":"1699999999","model":"m",` +
+		`"choices":[{"index":0,"message":{"role":"assistant","content":"` + secret + `"},"finish_reason":"stop"}],` +
+		`"usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3}}`
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+	}
+	req := withAuthContext(httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody))
+	logData := nonStreamingLogData()
+
+	h.handleNonStreamingResponse(httptest.NewRecorder(), req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 1)
+
+	if logData.state != "failed" {
+		t.Fatalf("state = %q, want failed", logData.state)
+	}
+	if strings.Contains(logData.errorMessage, secret) {
+		t.Fatalf("response content leaked into the request log: %q", logData.errorMessage)
+	}
+	if strings.Contains(logData.errorMessage, "chatcmpl-1") {
+		t.Fatalf("response body leaked into the request log: %q", logData.errorMessage)
+	}
+	for _, want := range []string{"response decode error", fmt.Sprintf("body_bytes=%d", len(body)), "application/json"} {
+		if !strings.Contains(logData.errorMessage, want) {
+			t.Errorf("errorMessage missing diagnostic %q: %q", want, logData.errorMessage)
+		}
+	}
+	if logData.errorKind != KindProviderBadRequest {
+		t.Errorf("error kind = %v, want %v", logData.errorKind, KindProviderBadRequest)
+	}
+}
+
+// The other half of the same rule: a non-2xx carries no completion, so its
+// body is the provider's error text and that text is what makes the row worth
+// reading. It must keep landing in the log.
+func TestHandleNonStreamingResponse_Non2xxKeepsUpstreamErrorText(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandlerIntegration(h)
+
+	const upstreamText = "model overloaded, try again shortly"
+	resp := &http.Response{
+		StatusCode: http.StatusBadGateway,
+		Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"` + upstreamText + `"}}`)),
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+	}
+	req := withAuthContext(httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody))
+	logData := nonStreamingLogData()
+
+	h.handleNonStreamingResponse(httptest.NewRecorder(), req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 1)
+
+	if logData.state != "failed" {
+		t.Fatalf("state = %q, want failed", logData.state)
+	}
+	if !strings.Contains(logData.errorMessage, upstreamText) {
+		t.Fatalf("upstream error text lost from the request log: %q", logData.errorMessage)
+	}
+}
+
+// A non-2xx that fails to decode as well (an HTML error page from a proxy in
+// front of the provider) keeps its text too — it is still an error document.
+func TestHandleNonStreamingResponse_UndecodableNon2xxKeepsBody(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandlerIntegration(h)
+
+	const page = "<html><body>504 Gateway Time-out (nginx)</body></html>"
+	resp := &http.Response{
+		StatusCode: http.StatusGatewayTimeout,
+		Body:       io.NopCloser(strings.NewReader(page)),
+		Header:     http.Header{"Content-Type": []string{"text/html"}},
+	}
+	req := withAuthContext(httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody))
+	logData := nonStreamingLogData()
+
+	h.handleNonStreamingResponse(httptest.NewRecorder(), req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 1)
+
+	if !strings.Contains(logData.errorMessage, "504 Gateway Time-out") {
+		t.Fatalf("upstream error page lost from the request log: %q", logData.errorMessage)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The non-streaming body read is bounded
+// ---------------------------------------------------------------------------
+
+// Past the cap the request fails instead of buffering the whole body — and it
+// fails rather than silently forwarding a truncated completion.
+func TestHandleNonStreamingResponse_OversizedBodyRefused(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandlerIntegration(h)
+
+	const head = `{"id":"chatcmpl-1","object":"chat.completion","created":1,"model":"m","choices":[{"index":0,"message":{"role":"assistant","content":"`
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body: io.NopCloser(io.MultiReader(
+			strings.NewReader(head),
+			io.LimitReader(paddingReader{}, nonStreamingBodyCap),
+		)),
+		Header: http.Header{"Content-Type": []string{"application/json"}},
+	}
+	req := withAuthContext(httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody))
+	logData := nonStreamingLogData()
+	rec := httptest.NewRecorder()
+
+	h.handleNonStreamingResponse(rec, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 1)
+
+	if logData.state != "failed" {
+		t.Fatalf("state = %q, want failed for an oversized body", logData.state)
+	}
+	if !strings.Contains(logData.errorMessage, "non-streaming body cap") {
+		t.Fatalf("errorMessage does not name the cap: %q", logData.errorMessage)
+	}
+	if strings.Contains(rec.Body.String(), "aaaa") {
+		t.Fatalf("truncated body forwarded to the client: %.200q", rec.Body.String())
+	}
+	if rec.Body.Len() > 4096 {
+		t.Fatalf("oversized body echoed to the client (%d bytes)", rec.Body.Len())
+	}
+}
+
+// A body of exactly the cap is legitimate and must still decode and reach the
+// client whole: the read takes cap+1 bytes precisely so the boundary case is
+// not mistaken for an overflow.
+func TestHandleNonStreamingResponse_BodyAtCapDecodesIntact(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandlerIntegration(h)
+
+	const head = `{"id":"chatcmpl-1","object":"chat.completion","created":1,"model":"m","choices":[{"index":0,"message":{"role":"assistant","content":"`
+	const tail = `"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3}}`
+	pad := nonStreamingBodyCap - len(head) - len(tail)
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body: io.NopCloser(io.MultiReader(
+			strings.NewReader(head),
+			io.LimitReader(paddingReader{}, int64(pad)),
+			strings.NewReader(tail),
+		)),
+		Header: http.Header{"Content-Type": []string{"application/json"}},
+	}
+	req := withAuthContext(httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody))
+	logData := nonStreamingLogData()
+	rec := httptest.NewRecorder()
+
+	h.handleNonStreamingResponse(rec, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 1)
+
+	if logData.state != "completed" {
+		t.Fatalf("state = %q (%s), want completed for a body exactly at the cap", logData.state, logData.errorMessage)
+	}
+	var got ChatCompletionResponse
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("client response did not decode: %v", err)
+	}
+	content, _ := got.Choices[0].Message.Content.(string)
+	if len(content) != pad {
+		t.Fatalf("content forwarded truncated: %d bytes, want %d", len(content), pad)
+	}
+}
+
+// Everything unmodelled in a completion has to reach the client: a client that
+// asked for logprobs gets them, aggregator routing/cost fields survive, and the
+// normalisation this package does still wins over the raw copy.
+func TestHandleNonStreamingResponse_PreservesUnmodelledFields(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandlerIntegration(h)
+
+	const body = `{"id":"chatcmpl-1","object":"chat.completion","created":1,"model":"m",
+		"system_fingerprint":"fp_abc","provider":"Together",
+		"choices":[{"index":0,"logprobs":{"content":[{"token":"hi","logprob":-0.25}]},
+		  "native_finish_reason":"STOP",
+		  "message":{"role":"assistant","content":"hi","reasoning":"pondered"},"finish_reason":"stop"}],
+		"usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3,"cost":0.000123}}`
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+	}
+	req := withAuthContext(httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody))
+	rec := httptest.NewRecorder()
+
+	h.handleNonStreamingResponse(rec, req, nonStreamingLogData(), resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "", 1)
+
+	var got map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("client response did not decode: %v (%s)", err, rec.Body.String())
+	}
+	if got["system_fingerprint"] != "fp_abc" || got["provider"] != "Together" {
+		t.Errorf("top-level provider fields dropped: %s", rec.Body.String())
+	}
+	choice, ok := got["choices"].([]any)[0].(map[string]any)
+	if !ok {
+		t.Fatalf("no choice in response: %s", rec.Body.String())
+	}
+	if _, has := choice["logprobs"]; !has {
+		t.Errorf("logprobs dropped: %s", rec.Body.String())
+	}
+	if choice["native_finish_reason"] != "STOP" {
+		t.Errorf("native_finish_reason dropped: %s", rec.Body.String())
+	}
+	usage, ok := got["usage"].(map[string]any)
+	if !ok {
+		t.Fatalf("no usage in response: %s", rec.Body.String())
+	}
+	if usage["cost"] != 0.000123 {
+		t.Errorf("usage.cost dropped: %s", rec.Body.String())
+	}
+	if usage["total_tokens"] != float64(3) {
+		t.Errorf("modelled usage field lost: %s", rec.Body.String())
+	}
+	msg := choice["message"].(map[string]any)
+	if msg["reasoning_content"] != "pondered" {
+		t.Errorf("reasoning normalisation lost: %s", rec.Body.String())
+	}
+}
+
+// The content rule at the unit level, both directions at once.
+func TestNonStreamingFailureDetail(t *testing.T) {
+	t.Parallel()
+
+	jsonHeader := http.Header{"Content-Type": []string{"application/json"}}
+	decodeErr := errors.New("json: cannot unmarshal string into Go struct field ChatCompletionResponse.created of type int64")
+
+	t.Run("2xx keeps the completion out of the logs", func(t *testing.T) {
+		t.Parallel()
+		body := []byte(`{"choices":[{"message":{"role":"assistant","content":"private answer"}}],"created":"1"}`)
+		resp := &http.Response{StatusCode: http.StatusOK, Header: jsonHeader}
+
+		logMsg, detail, kind, reason := nonStreamingFailureDetail(resp, body, decodeErr, "m")
+
+		for _, s := range []string{logMsg, detail} {
+			if strings.Contains(s, "private answer") || strings.Contains(s, "choices") {
+				t.Fatalf("body content leaked: %q", s)
+			}
+			if !strings.Contains(s, fmt.Sprintf("body_bytes=%d", len(body))) || !strings.Contains(s, "application/json") {
+				t.Errorf("diagnostics missing: %q", s)
+			}
+		}
+		if kind != KindProviderBadRequest {
+			t.Errorf("kind = %v, want %v", kind, KindProviderBadRequest)
+		}
+		if !strings.Contains(reason, "could not decode") || strings.Contains(reason, "200") {
+			t.Errorf("reason = %q", reason)
+		}
+	})
+
+	t.Run("non-2xx keeps the upstream error text", func(t *testing.T) {
+		t.Parallel()
+		body := []byte(`{"error":{"message":"rate limit reached for gpt-4o"}}`)
+		resp := &http.Response{StatusCode: http.StatusTooManyRequests, Header: jsonHeader}
+
+		logMsg, detail, kind, _ := nonStreamingFailureDetail(resp, body, nil, "gpt-4o")
+
+		if !strings.Contains(logMsg, "upstream HTTP 429") || !strings.Contains(logMsg, "rate limit reached") {
+			t.Errorf("logMsg = %q", logMsg)
+		}
+		if !strings.Contains(detail, "rate limit reached") {
+			t.Errorf("detail = %q", detail)
+		}
+		if kind == "" {
+			t.Error("non-2xx must be classified")
+		}
+	})
+
+	t.Run("non-2xx that also fails to decode is named as such", func(t *testing.T) {
+		t.Parallel()
+		body := []byte(`<html>502 Bad Gateway</html>`)
+		resp := &http.Response{StatusCode: http.StatusBadGateway, Header: http.Header{"Content-Type": []string{"text/html"}}}
+
+		logMsg, _, _, _ := nonStreamingFailureDetail(resp, body, decodeErr, "m")
+
+		if !strings.Contains(logMsg, "response decode error") || !strings.Contains(logMsg, "502 Bad Gateway") {
+			t.Errorf("logMsg = %q", logMsg)
+		}
+	})
 }

--- a/internal/proxy/proxy_nonstreaming_test.go
+++ b/internal/proxy/proxy_nonstreaming_test.go
@@ -319,9 +319,6 @@ func TestHandleNonStreamingResponse_ChatShapedNon2xxGetsErrorEnvelope(t *testing
 	if !strings.Contains(logData.errorMessage, "chatcmpl_u5tt67g6rmf") {
 		t.Errorf("upstream body not recoverable from error_message: %q", logData.errorMessage)
 	}
-	if logData.deliveredContent {
-		t.Error("a non-2xx must not count as the model having served content")
-	}
 }
 
 // The same body under a 200 is an ordinary completion and must pass through
@@ -412,5 +409,13 @@ func TestHandleNonStreamingResponse_ChatShapedNon2xxDoesNotMeter(t *testing.T) {
 	}
 	if logData.tokensPerSecond != 0 {
 		t.Errorf("recorded a throughput figure for a failed request: %v", logData.tokensPerSecond)
+	}
+	// The usage block is what makes this assertion bite: chatAnswerCarriesContent
+	// falls back to Usage.CompletionTokens > 0 when no choice carries content, so
+	// a body with completion_tokens 22 is the one shape that would mark a failed
+	// request as having delivered content. deliveredContent feeds producedOutput
+	// at the call site, where it clears a model's gone-strike streak.
+	if logData.deliveredContent {
+		t.Error("a non-2xx must not count as the model having served content")
 	}
 }

--- a/internal/proxy/proxy_nonstreaming_test.go
+++ b/internal/proxy/proxy_nonstreaming_test.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -247,5 +248,169 @@ func TestHandleNonStreamingResponse_AddTokensError(t *testing.T) {
 	}
 	if logData.tokensPrompt != 5 || logData.tokensCompletion != 7 {
 		t.Errorf("expected tokens 5/7, got %d/%d", logData.tokensPrompt, logData.tokensCompletion)
+	}
+}
+
+// zenChatShapedBody is what OpenCode Zen and OpenCode Go answer some failed
+// requests with: a complete chat.completion envelope, no error object, no
+// content, delivered under a non-2xx status.
+const zenChatShapedBody = `{"id":"chatcmpl_u5tt67g6rmf","object":"chat.completion","created":1787135446,"model":"gpt-5.1-codex","choices":[{"index":0,"message":{"role":"assistant"},"finish_reason":null}]}`
+
+// A non-2xx upstream is a failure whatever its body decodes as. The client must
+// get an OpenAI error envelope it can read `.error.message` off, not the
+// success-shaped body the provider sent.
+func TestHandleNonStreamingResponse_ChatShapedNon2xxGetsErrorEnvelope(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandlerIntegration(h)
+
+	resp := &http.Response{
+		StatusCode: http.StatusBadRequest,
+		Body:       io.NopCloser(strings.NewReader(zenChatShapedBody)),
+		Header:     make(http.Header),
+	}
+
+	req := withAuthContext(httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody))
+	inner := httptest.NewRecorder()
+	logData := &requestLogData{
+		modelID:         "gpt-5.1-codex",
+		providerName:    "opencode-zen",
+		streaming:       false,
+		virtualKeyName:  "test-key",
+		virtualKeyID:    "00000000-0000-0000-0000-000000000001",
+		failoverAttempt: 0,
+		state:           "pending",
+	}
+	h.insertRequestLogAsync(logData)
+	time.Sleep(100 * time.Millisecond)
+
+	h.handleNonStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
+
+	if inner.Code != http.StatusBadRequest {
+		t.Errorf("expected upstream status %d to be forwarded, got %d", http.StatusBadRequest, inner.Code)
+	}
+
+	var body map[string]json.RawMessage
+	if err := json.Unmarshal(inner.Body.Bytes(), &body); err != nil {
+		t.Fatalf("client body is not JSON: %v (%s)", err, inner.Body.String())
+	}
+	rawErr, present := body["error"]
+	if !present {
+		t.Fatalf("client body has no error object: %s", inner.Body.String())
+	}
+	var errObj struct {
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(rawErr, &errObj); err != nil {
+		t.Fatalf("re-parse error object: %v", err)
+	}
+	if errObj.Message == "" {
+		t.Errorf("error envelope carries no message: %s", inner.Body.String())
+	}
+	if _, present := body["choices"]; present {
+		t.Errorf("success-shaped choices forwarded on a non-2xx: %s", inner.Body.String())
+	}
+
+	if logData.state != "failed" {
+		t.Errorf("expected state=%q, got %q", "failed", logData.state)
+	}
+	if logData.errorKind == "" {
+		t.Error("expected a classified error_kind, got empty")
+	}
+	if !strings.Contains(logData.errorMessage, "chatcmpl_u5tt67g6rmf") {
+		t.Errorf("upstream body not recoverable from error_message: %q", logData.errorMessage)
+	}
+	if logData.deliveredContent {
+		t.Error("a non-2xx must not count as the model having served content")
+	}
+}
+
+// The same body under a 200 is an ordinary completion and must pass through
+// untouched: same choices, same metering, same log state.
+func TestHandleNonStreamingResponse_ChatShaped2xxPassesThrough(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandlerIntegration(h)
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(zenChatShapedBody)),
+		Header:     make(http.Header),
+	}
+
+	req := withAuthContext(httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody))
+	inner := httptest.NewRecorder()
+	logData := &requestLogData{
+		modelID:         "gpt-5.1-codex",
+		providerName:    "opencode-zen",
+		streaming:       false,
+		virtualKeyName:  "test-key",
+		virtualKeyID:    "00000000-0000-0000-0000-000000000001",
+		failoverAttempt: 0,
+		state:           "pending",
+	}
+	h.insertRequestLogAsync(logData)
+	time.Sleep(100 * time.Millisecond)
+
+	h.handleNonStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
+
+	if inner.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, inner.Code)
+	}
+	var body map[string]json.RawMessage
+	if err := json.Unmarshal(inner.Body.Bytes(), &body); err != nil {
+		t.Fatalf("client body is not JSON: %v (%s)", err, inner.Body.String())
+	}
+	if _, present := body["error"]; present {
+		t.Errorf("2xx completion wrapped in an error envelope: %s", inner.Body.String())
+	}
+	if _, present := body["choices"]; !present {
+		t.Errorf("2xx completion lost its choices: %s", inner.Body.String())
+	}
+	if logData.state != "completed" {
+		t.Errorf("expected state=%q, got %q", "completed", logData.state)
+	}
+}
+
+// Metering is the other half of the contract: a failed request has no
+// completion to charge for, so neither the log counters nor the virtual key's
+// token balance may move even when the upstream attaches a usage block.
+func TestHandleNonStreamingResponse_ChatShapedNon2xxDoesNotMeter(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandlerIntegration(h)
+
+	vkRepo := &mockVirtualKeyRepo{}
+	h.virtualKeyRepo = vkRepo
+
+	const withUsage = `{"id":"chatcmpl_u5tt67g6rmf","object":"chat.completion","created":1787135446,"model":"gpt-5.1-codex","choices":[{"index":0,"message":{"role":"assistant"},"finish_reason":null}],"usage":{"prompt_tokens":11,"completion_tokens":22,"total_tokens":33}}`
+
+	resp := &http.Response{
+		StatusCode: http.StatusBadRequest,
+		Body:       io.NopCloser(strings.NewReader(withUsage)),
+		Header:     make(http.Header),
+	}
+
+	req := withAuthContext(httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody))
+	inner := httptest.NewRecorder()
+	logData := &requestLogData{
+		modelID:         "gpt-5.1-codex",
+		providerName:    "opencode-zen",
+		streaming:       false,
+		virtualKeyName:  "test-key",
+		virtualKeyID:    "00000000-0000-0000-0000-000000000001",
+		failoverAttempt: 0,
+		state:           "pending",
+	}
+	h.insertRequestLogAsync(logData)
+	time.Sleep(100 * time.Millisecond)
+
+	h.handleNonStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
+
+	if logData.tokensPrompt != 0 || logData.tokensCompletion != 0 {
+		t.Errorf("metered a failed request: prompt=%d completion=%d", logData.tokensPrompt, logData.tokensCompletion)
+	}
+	if len(vkRepo.addTokensCalls) != 0 {
+		t.Errorf("charged the virtual key for a failed request: %+v", vkRepo.addTokensCalls)
+	}
+	if logData.tokensPerSecond != 0 {
+		t.Errorf("recorded a throughput figure for a failed request: %v", logData.tokensPerSecond)
 	}
 }

--- a/internal/proxy/response_shape_test.go
+++ b/internal/proxy/response_shape_test.go
@@ -1,0 +1,90 @@
+package proxy
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// choiceKeys re-parses one encoded choice so a test can ask which JSON keys the
+// client actually receives, rather than substring-matching the whole body.
+func choiceKeys(t *testing.T, encoded []byte) map[string]json.RawMessage {
+	t.Helper()
+
+	var envelope struct {
+		Choices []map[string]json.RawMessage `json:"choices"`
+	}
+	if err := json.Unmarshal(encoded, &envelope); err != nil {
+		t.Fatalf("re-parse: %v", err)
+	}
+	if len(envelope.Choices) != 1 {
+		t.Fatalf("expected exactly one choice, got %d: %s", len(envelope.Choices), encoded)
+	}
+	return envelope.Choices[0]
+}
+
+// A non-streaming completion has no delta in the OpenAI schema. The proxy
+// decodes the upstream body into ChatCompletionResponse and re-encodes it, so a
+// Choice that always serialises a delta invents a key on every response the
+// gateway serves.
+func TestChatCompletionResponse_NonStreamingHasNoDelta(t *testing.T) {
+	t.Parallel()
+
+	const upstream = `{
+		"id": "chatcmpl-1", "object": "chat.completion", "created": 1, "model": "gpt-4o-mini",
+		"choices": [{"index": 0, "message": {"role": "assistant", "content": "hi"}, "finish_reason": "stop"}],
+		"usage": {"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3}
+	}`
+
+	var resp ChatCompletionResponse
+	if err := json.Unmarshal([]byte(upstream), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	out, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	keys := choiceKeys(t, out)
+	if raw, present := keys["delta"]; present {
+		t.Fatalf("non-streaming choice carries a delta key (%s): %s", raw, out)
+	}
+	if _, present := keys["message"]; !present {
+		t.Fatalf("non-streaming choice lost its message: %s", out)
+	}
+}
+
+// The streaming shape is the mirror image: a chunk's delta must survive the
+// round trip even when it carries nothing but the role, which is exactly what
+// the first chunk of every stream looks like.
+func TestChatCompletionResponse_StreamingChunkKeepsDelta(t *testing.T) {
+	t.Parallel()
+
+	const chunk = `{
+		"id": "chatcmpl-1", "object": "chat.completion.chunk", "created": 1, "model": "gpt-4o-mini",
+		"choices": [{"index": 0, "delta": {"role": "assistant"}}]
+	}`
+
+	var resp ChatCompletionResponse
+	if err := json.Unmarshal([]byte(chunk), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	out, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	keys := choiceKeys(t, out)
+	raw, present := keys["delta"]
+	if !present {
+		t.Fatalf("streaming chunk lost its delta: %s", out)
+	}
+	var delta struct {
+		Role string `json:"role"`
+	}
+	if err := json.Unmarshal(raw, &delta); err != nil {
+		t.Fatalf("re-parse delta: %v", err)
+	}
+	if delta.Role != "assistant" {
+		t.Fatalf("delta role not round-tripped: %s", raw)
+	}
+}

--- a/internal/proxy/response_test.go
+++ b/internal/proxy/response_test.go
@@ -185,8 +185,9 @@ func TestHandleNonStreamingResponse_Success(t *testing.T) {
 }
 
 // TestHandleNonStreamingResponse_Non200Status tests handling of upstream
-// responses with non-200 status codes. The JSON parses successfully but
-// represents an error response from the upstream.
+// responses with non-200 status codes whose body is valid JSON. A non-2xx is a
+// failed request whatever its body parses as, so the caller gets an error
+// envelope and the row is logged as failed.
 func TestHandleNonStreamingResponse_Non200Status(t *testing.T) {
 	h := newIntegrationHandler()
 	defer stopUnitHandler(h)
@@ -224,21 +225,28 @@ func TestHandleNonStreamingResponse_Non200Status(t *testing.T) {
 	result := w.Result()
 	defer result.Body.Close()
 
-	// The function writes the response as-is when JSON parses successfully
-	assert.Equal(t, http.StatusOK, result.StatusCode)
+	// The upstream status reaches the caller, together with an error envelope.
+	assert.Equal(t, http.StatusBadRequest, result.StatusCode)
 	assert.Equal(t, "application/json", result.Header.Get("Content-Type"))
 
-	var decodedResp ChatCompletionResponse
-	err := json.NewDecoder(result.Body).Decode(&decodedResp)
+	var responseBody map[string]any
+	err := json.NewDecoder(result.Body).Decode(&responseBody)
 	require.NoError(t, err)
 
-	// The response will have empty fields since upstream returned error format
-	assert.Equal(t, "", decodedResp.ID)
-	assert.Equal(t, "", decodedResp.Model)
+	errorObj, ok := responseBody["error"].(map[string]any)
+	require.True(t, ok, "Should have error object in response")
+	assert.NotEmpty(t, errorObj["message"])
+	// The message is gateway-authored: the upstream body can quote the request
+	// back at us, so it is recorded in the request log and never forwarded.
+	assert.NotContains(t, errorObj["message"], "Invalid request")
 
-	// Log should show completed state (JSON parsed successfully)
-	assert.Equal(t, "completed", logData.state)
+	assert.Equal(t, "failed", logData.state)
 	assert.Equal(t, http.StatusBadRequest, logData.statusCode)
+	assert.Equal(t, KindProviderBadRequest, logData.errorKind)
+	// The body stays recoverable for diagnostics, labelled by what actually
+	// happened rather than as a decode failure it was not.
+	assert.Contains(t, logData.errorMessage, "upstream HTTP 400")
+	assert.Contains(t, logData.errorMessage, "invalid_request_error")
 }
 
 // TestHandleNonStreamingResponse_InvalidJSON tests handling of 200 status

--- a/internal/proxy/types.go
+++ b/internal/proxy/types.go
@@ -330,6 +330,9 @@ type Message struct {
 	ReasoningContent string            `json:"reasoning_content,omitempty"`
 	Reasoning        string            `json:"reasoning,omitempty"`         // Ollama, OpenRouter
 	ReasoningDetails []ReasoningDetail `json:"reasoning_details,omitempty"` // OpenRouter, MiniMax
+	// Extra carries the response fields this struct does not model, so they
+	// survive the non-streaming decode + re-encode. See jsonextras.go.
+	Extra jsonExtras `json:"-"`
 }
 
 // ToolCall is an OpenAI function tool call on an assistant message. Preserved
@@ -339,6 +342,11 @@ type ToolCall struct {
 	Type     string       `json:"type"`
 	Index    *int         `json:"index,omitempty"`
 	Function ToolCallFunc `json:"function"`
+	// Extra carries provider fields this struct does not model. Gemini 3 puts
+	// extra_content.google.thought_signature here and rejects the follow-up
+	// turn without it, so dropping it breaks tool use outright. See
+	// jsonextras.go.
+	Extra jsonExtras `json:"-"`
 }
 
 // ToolCallFunc is the function name + raw JSON arguments of a tool call.

--- a/internal/proxy/types.go
+++ b/internal/proxy/types.go
@@ -307,6 +307,10 @@ type ChatCompletionResponse struct {
 	Model   string   `json:"model"`
 	Choices []Choice `json:"choices"`
 	Usage   Usage    `json:"usage"`
+	// Extra carries the top-level fields this struct does not model
+	// (system_fingerprint, OpenRouter's provider, service_tier, ...) so they
+	// survive the non-streaming decode + re-encode. See jsonextras.go.
+	Extra jsonExtras `json:"-"`
 }
 
 // Choice represents a single completion choice in the response.
@@ -322,6 +326,10 @@ type Choice struct {
 	Message      Message  `json:"message"`
 	Delta        *Message `json:"delta,omitempty"`
 	FinishReason *string  `json:"finish_reason,omitempty"`
+	// Extra carries the per-choice fields this struct does not model (logprobs,
+	// OpenRouter's native_finish_reason, ...) so they survive the non-streaming
+	// decode + re-encode. See jsonextras.go.
+	Extra jsonExtras `json:"-"`
 }
 
 // Message represents a chat message with role and content.
@@ -388,4 +396,8 @@ type Usage struct {
 	CacheCreationInputTokens int                      `json:"cache_creation_input_tokens,omitempty"`
 	PromptTokensDetails      *PromptTokensDetails     `json:"prompt_tokens_details,omitempty"`
 	CompletionTokensDetails  *CompletionTokensDetails `json:"completion_tokens_details,omitempty"`
+	// Extra carries the usage fields this struct does not model (OpenRouter's
+	// cost and is_byok, provider-specific token breakdowns, ...) so they survive
+	// the non-streaming decode + re-encode. See jsonextras.go.
+	Extra jsonExtras `json:"-"`
 }

--- a/internal/proxy/types.go
+++ b/internal/proxy/types.go
@@ -310,11 +310,18 @@ type ChatCompletionResponse struct {
 }
 
 // Choice represents a single completion choice in the response.
+//
+// Delta is a pointer so the two response shapes stay distinct. A struct is
+// never empty to encoding/json, so a value field emitted "delta":{"role":"",
+// "content":null} on every non-streaming completion, a key the OpenAI
+// non-streaming schema does not have. Nil omits it; a streaming chunk that
+// carries a delta still round-trips one, even a delta holding nothing but the
+// role.
 type Choice struct {
-	Index        int     `json:"index"`
-	Message      Message `json:"message"`
-	Delta        Message `json:"delta"`
-	FinishReason *string `json:"finish_reason,omitempty"`
+	Index        int      `json:"index"`
+	Message      Message  `json:"message"`
+	Delta        *Message `json:"delta,omitempty"`
+	FinishReason *string  `json:"finish_reason,omitempty"`
 }
 
 // Message represents a chat message with role and content.


### PR DESCRIPTION
A live capability sweep across all 12 providers on the prod fleet turned up six gateway
defects. Each was measured against a real upstream before it was fixed, and re-measured
against the same call afterwards.

## Gemini 3 tool calling was impossible for non-streaming callers

The non-streaming path decodes the upstream body into `ChatCompletionResponse` and
re-encodes it. Gemini 3 issues every tool call with
`extra_content.google.thought_signature`, which the struct does not model, so it was
dropped — and Gemini rejects the follow-up turn without it (*"Function call is missing a
thought_signature in functionCall parts"*). Streaming forwards chunks verbatim and was
unaffected, which is why this read as a model quirk rather than a gateway bug.

Proven before the fix: the identical round-two request returns 200 with the signature and
400 without it.

`Message`, `ToolCall`, `Choice`, `ChatCompletionResponse` and `Usage` now carry a
reflection-derived overflow of the fields this package does not model and re-emit them.
Modelled fields always win, so normalisations such as `reasoning_content` survive. This
also stops dropping `message.audio`, `refusal`, `annotations`, `system_fingerprint`,
`provider`, `logprobs`, `native_finish_reason` and `usage.cost`.

## gpt-5-family requests carrying `temperature:0` always failed

OpenAI answers them with `Unsupported value: 'temperature' does not support 0 with this
model.` The param self-heal anchors a parameter name on backticks or double quotes only,
so the single-quoted name never matched and the retry never fired. Quote matching now
covers single quotes; an apostrophe inside prose is still not a quote pair.

## The self-heal could only learn one parameter per request

`retryWithStrippedParams` read the first 400, learned from it, and retried once. If that
retry returned another 400 naming a different parameter, the second body was never parsed,
so a request with two offending parameters cost two client-visible failures. It is now a
bounded loop: the retry's own 400 is learned too, and re-issued once more when it names
something not already applied. Two retries maximum, and a round only happens on genuine
progress, so it always terminates.

Together with the fix above, `OpenAI/gpt-5.6-luna` with `temperature:0` now succeeds on the
first request instead of failing six different ways.

## A non-2xx could reach the client shaped like a success

OpenCode Zen and OpenCode Go answer some failed requests with HTTP 400 and a body that is
still a chat completion. That decodes cleanly, so the proxy took the success branch and
handed the caller a non-2xx with no `error` object at all. `forwardUpstreamError` now
judges an upstream error member by content rather than shape: bodies that carry real error
detail are still forwarded byte for byte, and only those without one get a synthesised
envelope. `handleNonStreamingResponse` gained the same invariant.

## Non-streaming responses carried a bogus `delta`

`Choice.Delta` had no `omitempty`, so every non-streaming completion shipped
`"delta":{"role":"","content":null}`, which is not part of the OpenAI non-streaming schema.

## Transcription models were classified as chat

models.dev enrichment gives the gpt-4o transcription models the full modality set of their
chat namesakes, so they arrived as `in=text,image,audio`, failed the audio-only guard, and
were classified `chat` — taking chat traffic they cannot serve and feeding the retirement
strike machinery for the wrong reason. `gpt-4o-transcribe` and `gpt-4o-mini-transcribe`
were `chat` while `whisper-1` and `gpt-4o-transcribe-diarize` were `stt`, same provider,
same family. The model id is now authoritative once audio input is present. Replaying all
1403 rows of a live catalogue through the classifier moves exactly the four intended rows
and nothing else.

## Not in scope

- OpenRouter answering 402 on every model is an account credit condition, not a defect.
  `shouldFailover` already treats 402 as failover-eligible and `breakerRecordAction`
  already records it as a breaker failure.
- Routing OpenAI-in requests carrying PDF parts to Anthropic's native `/v1/messages`.
  Anthropic's OpenAI-compatible endpoint cannot carry a PDF in any wire format, so every
  Anthropic model advertising `pdf_upload` currently 400s on one. Scoped separately.

## Verification

Every fix has a regression test that was watched failing first; several were additionally
mutation-checked. `go test ./...` green and `golangci-lint run ./...` at 0 issues, verified
independently of the implementing agents. Each defect was then re-confirmed against the
real upstream through a rebuilt gateway.

The reviews also caught a regression this branch introduced and fixed before merge: reading
the response body once up front meant an undecodable 2xx wrote the full body — including
generated assistant text — into the request log, against the project's rule that no
prompt or response content is ever logged. Diagnostics on a 2xx are now limited to the
decode error, body length and content type; non-2xx rows keep the upstream error text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
