### PR TITLE
feat(proxy): route document-bearing Anthropic requests via native /v1/messages

### DIFF
--- a/internal/anthropic/native.go
+++ b/internal/anthropic/native.go
@@ -29,8 +29,10 @@ func RewriteModel(body []byte, model string) []byte {
 }
 
 // ResponseUsage is the metering summary of one Anthropic Messages response,
-// produced from a single parse. PromptTokens is the whole prompt; CacheHit and
-// CacheMiss split it by how the tokens were billed, and always sum back to it.
+// produced from a single parse. PromptTokens is the whole prompt. CacheHit and
+// CacheMiss split it by how the tokens were billed and sum back to it, but only
+// when the response reports cache activity at all; an uncached response leaves
+// both zero rather than calling the whole prompt a miss (see summary).
 type ResponseUsage struct {
 	PromptTokens     int
 	CompletionTokens int
@@ -60,8 +62,7 @@ func ParseResponseUsage(body []byte) ResponseUsage {
 }
 
 // antUsage is an Anthropic usage block. The cache fields are absent from
-// responses that use no cache, which decodes to zero and leaves the whole
-// prompt counted as a miss.
+// responses that use no cache, which decodes to zero.
 type antUsage struct {
 	InputTokens              int `json:"input_tokens"`
 	OutputTokens             int `json:"output_tokens"`
@@ -76,13 +77,24 @@ type antUsage struct {
 // on this request and only pay off on the next one. Reporting the sum without
 // this split prices every cached token at full input rate, which is a different
 // skew from under-counting, not an absence of one.
+//
+// A response with no cache activity at all reports NO cache counts rather than
+// "miss = the whole prompt". The translated egress path cannot express that
+// reading — its usage carries the cache fields only when nonzero, so
+// extractCacheTokens yields (0, 0) — and one Anthropic path claiming cache data
+// the other cannot is exactly the inconsistency this split exists to remove. It
+// is also what every other provider reports for an uncached request, which is
+// what the dashboard's cache panel and the cache-miss stats series assume.
 func (u antUsage) summary() ResponseUsage {
-	return ResponseUsage{
+	out := ResponseUsage{
 		PromptTokens:     u.InputTokens + u.CacheReadInputTokens + u.CacheCreationInputTokens,
 		CompletionTokens: u.OutputTokens,
-		CacheHitTokens:   u.CacheReadInputTokens,
-		CacheMissTokens:  u.InputTokens + u.CacheCreationInputTokens,
 	}
+	if u.CacheReadInputTokens > 0 || u.CacheCreationInputTokens > 0 {
+		out.CacheHitTokens = u.CacheReadInputTokens
+		out.CacheMissTokens = u.InputTokens + u.CacheCreationInputTokens
+	}
+	return out
 }
 
 // ResponseCarriesContent reports whether a non-streaming Messages response holds
@@ -111,8 +123,8 @@ func ResponseCarriesContent(body []byte) bool {
 type StreamEvent struct {
 	Type            string
 	InputTokens     int
-	CacheHitTokens  int // the cache-served share of InputTokens
-	CacheMissTokens int // the rest of InputTokens, billed at full input rate
+	CacheHitTokens  int // the cache-served share of InputTokens; 0 when uncached
+	CacheMissTokens int // the rest of InputTokens; 0 when uncached, not the whole prompt
 	HasInput        bool
 	OutputTokens    int
 	HasOutput       bool

--- a/internal/anthropic/native.go
+++ b/internal/anthropic/native.go
@@ -29,19 +29,39 @@ func RewriteModel(body []byte, model string) []byte {
 }
 
 // ParseResponseUsage extracts input/output token counts from a non-streaming
-// Anthropic Messages response (top-level usage{input_tokens, output_tokens}) for
-// metering. Missing/unparseable usage yields zeros.
+// Anthropic Messages response (top-level usage{...}) for metering.
+// Missing/unparseable usage yields zeros.
+//
+// inputTokens is the SUM of input_tokens, cache_read_input_tokens and
+// cache_creation_input_tokens: Anthropic's three counts are disjoint additions,
+// not a breakdown, so a cache hit reports input_tokens: 4 alongside
+// cache_read_input_tokens: 20000 for a ~20004-token prompt. Metering the bare
+// input_tokens under-reports a warm-cache request by the whole cached figure.
+// The egress adapter does the same arithmetic (see
+// internal/anthropicegress.translateUsage), so both Anthropic paths agree.
 func ParseResponseUsage(body []byte) (inputTokens, outputTokens int) {
 	var resp struct {
-		Usage struct {
-			InputTokens  int `json:"input_tokens"`
-			OutputTokens int `json:"output_tokens"`
-		} `json:"usage"`
+		Usage antUsage `json:"usage"`
 	}
 	if json.Unmarshal(body, &resp) != nil {
 		return 0, 0
 	}
-	return resp.Usage.InputTokens, resp.Usage.OutputTokens
+	return resp.Usage.promptTokens(), resp.Usage.OutputTokens
+}
+
+// antUsage is an Anthropic usage block. The cache fields are absent from
+// responses that use no cache, which decodes to zero and leaves the sum equal
+// to input_tokens.
+type antUsage struct {
+	InputTokens              int `json:"input_tokens"`
+	OutputTokens             int `json:"output_tokens"`
+	CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+	CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+}
+
+// promptTokens is the full prompt size: the three disjoint input counts summed.
+func (u antUsage) promptTokens() int {
+	return u.InputTokens + u.CacheReadInputTokens + u.CacheCreationInputTokens
 }
 
 // ResponseCarriesContent reports whether a non-streaming Messages response holds
@@ -77,22 +97,20 @@ type StreamEvent struct {
 }
 
 // InspectStreamEvent decodes one Anthropic stream event payload (the JSON after
-// "data: "). message_start carries usage.input_tokens; message_delta carries the
+// "data: "). message_start carries the input usage; message_delta carries the
 // cumulative usage.output_tokens; an "error" event carries error.message. A
 // payload that does not parse yields a zero StreamEvent (Type == "").
+//
+// InputTokens is the sum of the three disjoint Anthropic input counts, the same
+// arithmetic ParseResponseUsage does, so a streamed warm-cache request meters
+// its full prompt rather than the uncached remainder.
 func InspectStreamEvent(payload []byte) StreamEvent {
 	var ev struct {
 		Type    string `json:"type"`
 		Message *struct {
-			Usage *struct {
-				InputTokens  int `json:"input_tokens"`
-				OutputTokens int `json:"output_tokens"`
-			} `json:"usage"`
+			Usage *antUsage `json:"usage"`
 		} `json:"message"`
-		Usage *struct {
-			InputTokens  int `json:"input_tokens"`
-			OutputTokens int `json:"output_tokens"`
-		} `json:"usage"`
+		Usage *antUsage `json:"usage"`
 		Error *struct {
 			Message string `json:"message"`
 		} `json:"error"`
@@ -104,7 +122,7 @@ func InspectStreamEvent(payload []byte) StreamEvent {
 	switch ev.Type {
 	case "message_start":
 		if ev.Message != nil && ev.Message.Usage != nil {
-			info.InputTokens, info.HasInput = ev.Message.Usage.InputTokens, true
+			info.InputTokens, info.HasInput = ev.Message.Usage.promptTokens(), true
 			if ev.Message.Usage.OutputTokens > 0 {
 				info.OutputTokens, info.HasOutput = ev.Message.Usage.OutputTokens, true
 			}

--- a/internal/anthropic/native.go
+++ b/internal/anthropic/native.go
@@ -28,30 +28,40 @@ func RewriteModel(body []byte, model string) []byte {
 	return out
 }
 
-// ParseResponseUsage extracts input/output token counts from a non-streaming
-// Anthropic Messages response (top-level usage{...}) for metering.
-// Missing/unparseable usage yields zeros.
+// ResponseUsage is the metering summary of one Anthropic Messages response,
+// produced from a single parse. PromptTokens is the whole prompt; CacheHit and
+// CacheMiss split it by how the tokens were billed, and always sum back to it.
+type ResponseUsage struct {
+	PromptTokens     int
+	CompletionTokens int
+	CacheHitTokens   int
+	CacheMissTokens  int
+}
+
+// ParseResponseUsage extracts the token counts from a non-streaming Anthropic
+// Messages response (top-level usage{...}) for metering. A missing or
+// unparseable usage block yields a zero ResponseUsage.
 //
-// inputTokens is the SUM of input_tokens, cache_read_input_tokens and
+// PromptTokens is the SUM of input_tokens, cache_read_input_tokens and
 // cache_creation_input_tokens: Anthropic's three counts are disjoint additions,
 // not a breakdown, so a cache hit reports input_tokens: 4 alongside
 // cache_read_input_tokens: 20000 for a ~20004-token prompt. Metering the bare
 // input_tokens under-reports a warm-cache request by the whole cached figure.
 // The egress adapter does the same arithmetic (see
 // internal/anthropicegress.translateUsage), so both Anthropic paths agree.
-func ParseResponseUsage(body []byte) (inputTokens, outputTokens int) {
+func ParseResponseUsage(body []byte) ResponseUsage {
 	var resp struct {
 		Usage antUsage `json:"usage"`
 	}
 	if json.Unmarshal(body, &resp) != nil {
-		return 0, 0
+		return ResponseUsage{}
 	}
-	return resp.Usage.promptTokens(), resp.Usage.OutputTokens
+	return resp.Usage.summary()
 }
 
 // antUsage is an Anthropic usage block. The cache fields are absent from
-// responses that use no cache, which decodes to zero and leaves the sum equal
-// to input_tokens.
+// responses that use no cache, which decodes to zero and leaves the whole
+// prompt counted as a miss.
 type antUsage struct {
 	InputTokens              int `json:"input_tokens"`
 	OutputTokens             int `json:"output_tokens"`
@@ -59,9 +69,20 @@ type antUsage struct {
 	CacheReadInputTokens     int `json:"cache_read_input_tokens"`
 }
 
-// promptTokens is the full prompt size: the three disjoint input counts summed.
-func (u antUsage) promptTokens() int {
-	return u.InputTokens + u.CacheReadInputTokens + u.CacheCreationInputTokens
+// summary splits the block into the counts the proxy meters. The whole prompt
+// is the three disjoint input counts summed; of those, only
+// cache_read_input_tokens was served from cache and billed at the cache-hit
+// rate. Cache CREATION is a miss: those tokens are processed (and surcharged)
+// on this request and only pay off on the next one. Reporting the sum without
+// this split prices every cached token at full input rate, which is a different
+// skew from under-counting, not an absence of one.
+func (u antUsage) summary() ResponseUsage {
+	return ResponseUsage{
+		PromptTokens:     u.InputTokens + u.CacheReadInputTokens + u.CacheCreationInputTokens,
+		CompletionTokens: u.OutputTokens,
+		CacheHitTokens:   u.CacheReadInputTokens,
+		CacheMissTokens:  u.InputTokens + u.CacheCreationInputTokens,
+	}
 }
 
 // ResponseCarriesContent reports whether a non-streaming Messages response holds
@@ -88,12 +109,14 @@ func ResponseCarriesContent(body []byte) bool {
 // the error message on an "error" event (so a provider-sent error is recorded,
 // not just forwarded blind).
 type StreamEvent struct {
-	Type         string
-	InputTokens  int
-	HasInput     bool
-	OutputTokens int
-	HasOutput    bool
-	ErrorMessage string // set only when Type == "error"
+	Type            string
+	InputTokens     int
+	CacheHitTokens  int // the cache-served share of InputTokens
+	CacheMissTokens int // the rest of InputTokens, billed at full input rate
+	HasInput        bool
+	OutputTokens    int
+	HasOutput       bool
+	ErrorMessage    string // set only when Type == "error"
 }
 
 // InspectStreamEvent decodes one Anthropic stream event payload (the JSON after
@@ -101,9 +124,9 @@ type StreamEvent struct {
 // cumulative usage.output_tokens; an "error" event carries error.message. A
 // payload that does not parse yields a zero StreamEvent (Type == "").
 //
-// InputTokens is the sum of the three disjoint Anthropic input counts, the same
-// arithmetic ParseResponseUsage does, so a streamed warm-cache request meters
-// its full prompt rather than the uncached remainder.
+// InputTokens and its cache split come from the same arithmetic
+// ParseResponseUsage does, so a streamed warm-cache request meters its full
+// prompt — and prices it — exactly as the non-streaming path would.
 func InspectStreamEvent(payload []byte) StreamEvent {
 	var ev struct {
 		Type    string `json:"type"`
@@ -122,7 +145,9 @@ func InspectStreamEvent(payload []byte) StreamEvent {
 	switch ev.Type {
 	case "message_start":
 		if ev.Message != nil && ev.Message.Usage != nil {
-			info.InputTokens, info.HasInput = ev.Message.Usage.promptTokens(), true
+			u := ev.Message.Usage.summary()
+			info.InputTokens, info.HasInput = u.PromptTokens, true
+			info.CacheHitTokens, info.CacheMissTokens = u.CacheHitTokens, u.CacheMissTokens
 			if ev.Message.Usage.OutputTokens > 0 {
 				info.OutputTokens, info.HasOutput = ev.Message.Usage.OutputTokens, true
 			}

--- a/internal/anthropic/native.go
+++ b/internal/anthropic/native.go
@@ -78,19 +78,24 @@ type antUsage struct {
 // this split prices every cached token at full input rate, which is a different
 // skew from under-counting, not an absence of one.
 //
-// A response with no cache activity at all reports NO cache counts rather than
-// "miss = the whole prompt". The translated egress path cannot express that
-// reading — its usage carries the cache fields only when nonzero, so
-// extractCacheTokens yields (0, 0) — and one Anthropic path claiming cache data
-// the other cannot is exactly the inconsistency this split exists to remove. It
-// is also what every other provider reports for an uncached request, which is
-// what the dashboard's cache panel and the cache-miss stats series assume.
+// The split is reported only when a cache READ occurred. A response that
+// created a cache entry without reading one — and one with no cache activity at
+// all — reports NO cache counts rather than "miss = the whole prompt". The
+// translated egress path cannot express either reading: extractCacheTokens
+// keys off the cache-READ fields alone, so it yields (0, 0) for both, and one
+// Anthropic path claiming cache data the other cannot is exactly the
+// inconsistency this split exists to remove. It is also what every other
+// provider reports for a request that read nothing from cache, which is what
+// the dashboard's cache panel and the cache-miss stats series assume.
+//
+// Creation tokens are never lost either way: they count inside PromptTokens,
+// which is what the request is metered and priced on.
 func (u antUsage) summary() ResponseUsage {
 	out := ResponseUsage{
 		PromptTokens:     u.InputTokens + u.CacheReadInputTokens + u.CacheCreationInputTokens,
 		CompletionTokens: u.OutputTokens,
 	}
-	if u.CacheReadInputTokens > 0 || u.CacheCreationInputTokens > 0 {
+	if u.CacheReadInputTokens > 0 {
 		out.CacheHitTokens = u.CacheReadInputTokens
 		out.CacheMissTokens = u.InputTokens + u.CacheCreationInputTokens
 	}

--- a/internal/anthropic/native_test.go
+++ b/internal/anthropic/native_test.go
@@ -77,17 +77,31 @@ func TestParseResponseUsage_SplitsCachedInput(t *testing.T) {
 	}
 }
 
-// Writing a cache entry is cache activity even though nothing was read back, so
-// the split is reported — with the creation tokens on the miss side, where they
-// are billed.
+// Writing a cache entry without reading one reports no cache counts: the
+// translated egress path meters this same response off the cache-READ fields
+// alone and can only ever record (0,0), and one Anthropic path claiming cache
+// data the other cannot is the inconsistency this split exists to remove. The
+// creation tokens still count inside the prompt, which is what is billed.
 func TestParseResponseUsage_CacheCreationOnly(t *testing.T) {
 	body := []byte(`{"id":"msg_1","type":"message","usage":{"input_tokens":4,"output_tokens":7,"cache_creation_input_tokens":30}}`)
 	u := ParseResponseUsage(body)
 	if u.PromptTokens != 34 {
 		t.Errorf("prompt tokens = %d, want 34 (4 + 30)", u.PromptTokens)
 	}
-	if u.CacheHitTokens != 0 || u.CacheMissTokens != 34 {
-		t.Errorf("cache split = (%d,%d), want (0,34)", u.CacheHitTokens, u.CacheMissTokens)
+	if u.CacheHitTokens != 0 || u.CacheMissTokens != 0 {
+		t.Errorf("cache split = (%d,%d), want (0,0)", u.CacheHitTokens, u.CacheMissTokens)
+	}
+}
+
+// The streaming path reads its usage through the same summary(), so
+// message_start reports the creation-only response the same way.
+func TestInspectStreamEvent_CacheCreationOnly(t *testing.T) {
+	ev := InspectStreamEvent([]byte(`{"type":"message_start","message":{"usage":{"input_tokens":4,"output_tokens":1,"cache_creation_input_tokens":30}}}`))
+	if !ev.HasInput || ev.InputTokens != 34 {
+		t.Errorf("input tokens = %d (has=%v), want 34 (4 + 30)", ev.InputTokens, ev.HasInput)
+	}
+	if ev.CacheHitTokens != 0 || ev.CacheMissTokens != 0 {
+		t.Errorf("cache split = (%d,%d), want (0,0)", ev.CacheHitTokens, ev.CacheMissTokens)
 	}
 }
 

--- a/internal/anthropic/native_test.go
+++ b/internal/anthropic/native_test.go
@@ -38,9 +38,11 @@ func TestParseResponseUsage(t *testing.T) {
 	if u.PromptTokens != 42 || u.CompletionTokens != 7 {
 		t.Errorf("usage = %+v, want prompt=42 completion=7", u)
 	}
-	// No cache fields: the whole prompt is a miss, and nothing is a hit.
-	if u.CacheHitTokens != 0 || u.CacheMissTokens != 42 {
-		t.Errorf("cache split = (%d,%d), want (0,42)", u.CacheHitTokens, u.CacheMissTokens)
+	// No cache fields: no cache information at all. Calling the whole prompt a
+	// miss is a claim the translated egress path cannot make, and would light up
+	// the dashboard's cache panel for every uncached Anthropic request.
+	if u.CacheHitTokens != 0 || u.CacheMissTokens != 0 {
+		t.Errorf("uncached split = (%d,%d), want (0,0)", u.CacheHitTokens, u.CacheMissTokens)
 	}
 	// Invalid body yields zeros.
 	if u := ParseResponseUsage([]byte(`not json`)); u != (ResponseUsage{}) {
@@ -72,6 +74,20 @@ func TestParseResponseUsage_SplitsCachedInput(t *testing.T) {
 	}
 	if u.CacheHitTokens+u.CacheMissTokens != u.PromptTokens {
 		t.Errorf("split %d+%d does not sum back to the prompt %d", u.CacheHitTokens, u.CacheMissTokens, u.PromptTokens)
+	}
+}
+
+// Writing a cache entry is cache activity even though nothing was read back, so
+// the split is reported — with the creation tokens on the miss side, where they
+// are billed.
+func TestParseResponseUsage_CacheCreationOnly(t *testing.T) {
+	body := []byte(`{"id":"msg_1","type":"message","usage":{"input_tokens":4,"output_tokens":7,"cache_creation_input_tokens":30}}`)
+	u := ParseResponseUsage(body)
+	if u.PromptTokens != 34 {
+		t.Errorf("prompt tokens = %d, want 34 (4 + 30)", u.PromptTokens)
+	}
+	if u.CacheHitTokens != 0 || u.CacheMissTokens != 34 {
+		t.Errorf("cache split = (%d,%d), want (0,34)", u.CacheHitTokens, u.CacheMissTokens)
 	}
 }
 
@@ -180,10 +196,14 @@ func TestInspectStreamEvent_SplitsCachedInput(t *testing.T) {
 		t.Errorf("output tokens = %d (has=%v), want 1", ev.OutputTokens, ev.HasOutput)
 	}
 
-	// An uncached stream reports no hit, so the proxy's (hit>0||miss>0) guard
-	// still records the miss rather than leaving the split empty.
+	// An uncached stream reports no cache counts, so the proxy's
+	// (hit>0||miss>0) guard leaves the log row's cache fields untouched — the
+	// same thing every other provider's uncached request produces.
 	plain := InspectStreamEvent([]byte(`{"type":"message_start","message":{"usage":{"input_tokens":15,"output_tokens":0}}}`))
-	if plain.CacheHitTokens != 0 || plain.CacheMissTokens != 15 {
-		t.Errorf("uncached split = (%d,%d), want (0,15)", plain.CacheHitTokens, plain.CacheMissTokens)
+	if plain.InputTokens != 15 {
+		t.Errorf("uncached input tokens = %d, want 15", plain.InputTokens)
+	}
+	if plain.CacheHitTokens != 0 || plain.CacheMissTokens != 0 {
+		t.Errorf("uncached split = (%d,%d), want (0,0)", plain.CacheHitTokens, plain.CacheMissTokens)
 	}
 }

--- a/internal/anthropic/native_test.go
+++ b/internal/anthropic/native_test.go
@@ -44,6 +44,21 @@ func TestParseResponseUsage(t *testing.T) {
 	}
 }
 
+// Anthropic's cache counts are disjoint additions to input_tokens, not a
+// breakdown of it, so a warm-cache request reports a tiny input_tokens beside a
+// huge cache_read_input_tokens. Metering the bare field would under-report the
+// prompt by the whole cached figure.
+func TestParseResponseUsage_SumsCachedInput(t *testing.T) {
+	body := []byte(`{"id":"msg_1","type":"message","usage":{"input_tokens":4,"output_tokens":50,"cache_creation_input_tokens":30,"cache_read_input_tokens":20000}}`)
+	in, out := ParseResponseUsage(body)
+	if in != 20034 {
+		t.Errorf("prompt tokens = %d, want 20034 (4 + 20000 + 30)", in)
+	}
+	if out != 50 {
+		t.Errorf("completion tokens = %d, want 50", out)
+	}
+}
+
 // ResponseCarriesContent decides whether a native 200 counts as the model
 // answering, which is what clears its gone-strike streak in the proxy. The
 // distinction that matters is a nonempty body carrying an empty content array:
@@ -131,5 +146,17 @@ func TestInspectStreamEvent(t *testing.T) {
 	// garbage parses to a zero value.
 	if ev := InspectStreamEvent([]byte(`not json`)); ev.Type != "" {
 		t.Errorf("garbage = %+v, want zero StreamEvent", ev)
+	}
+}
+
+// The streamed message_start reports the same summed prompt size the
+// non-streaming path does, so the two native paths meter a cached prompt alike.
+func TestInspectStreamEvent_SumsCachedInput(t *testing.T) {
+	ev := InspectStreamEvent([]byte(`{"type":"message_start","message":{"usage":{"input_tokens":4,"output_tokens":1,"cache_creation_input_tokens":30,"cache_read_input_tokens":20000}}}`))
+	if !ev.HasInput || ev.InputTokens != 20034 {
+		t.Errorf("input tokens = %d (has=%v), want 20034 (4 + 20000 + 30)", ev.InputTokens, ev.HasInput)
+	}
+	if !ev.HasOutput || ev.OutputTokens != 1 {
+		t.Errorf("output tokens = %d (has=%v), want 1", ev.OutputTokens, ev.HasOutput)
 	}
 }

--- a/internal/anthropic/native_test.go
+++ b/internal/anthropic/native_test.go
@@ -34,28 +34,44 @@ func TestRewriteModel_InvalidBodyUnchanged(t *testing.T) {
 
 func TestParseResponseUsage(t *testing.T) {
 	body := []byte(`{"id":"msg_1","type":"message","usage":{"input_tokens":42,"output_tokens":7}}`)
-	in, out := ParseResponseUsage(body)
-	if in != 42 || out != 7 {
-		t.Errorf("usage = (%d,%d), want (42,7)", in, out)
+	u := ParseResponseUsage(body)
+	if u.PromptTokens != 42 || u.CompletionTokens != 7 {
+		t.Errorf("usage = %+v, want prompt=42 completion=7", u)
+	}
+	// No cache fields: the whole prompt is a miss, and nothing is a hit.
+	if u.CacheHitTokens != 0 || u.CacheMissTokens != 42 {
+		t.Errorf("cache split = (%d,%d), want (0,42)", u.CacheHitTokens, u.CacheMissTokens)
 	}
 	// Invalid body yields zeros.
-	if in, out := ParseResponseUsage([]byte(`not json`)); in != 0 || out != 0 {
-		t.Errorf("invalid usage = (%d,%d), want (0,0)", in, out)
+	if u := ParseResponseUsage([]byte(`not json`)); u != (ResponseUsage{}) {
+		t.Errorf("invalid usage = %+v, want a zero ResponseUsage", u)
 	}
 }
 
 // Anthropic's cache counts are disjoint additions to input_tokens, not a
 // breakdown of it, so a warm-cache request reports a tiny input_tokens beside a
-// huge cache_read_input_tokens. Metering the bare field would under-report the
-// prompt by the whole cached figure.
-func TestParseResponseUsage_SumsCachedInput(t *testing.T) {
+// huge cache_read_input_tokens. Metering the bare field under-reports the
+// prompt by the whole cached figure; metering the sum alone then prices every
+// cached token at the full input rate. Both halves have to be right.
+func TestParseResponseUsage_SplitsCachedInput(t *testing.T) {
 	body := []byte(`{"id":"msg_1","type":"message","usage":{"input_tokens":4,"output_tokens":50,"cache_creation_input_tokens":30,"cache_read_input_tokens":20000}}`)
-	in, out := ParseResponseUsage(body)
-	if in != 20034 {
-		t.Errorf("prompt tokens = %d, want 20034 (4 + 20000 + 30)", in)
+	u := ParseResponseUsage(body)
+	if u.PromptTokens != 20034 {
+		t.Errorf("prompt tokens = %d, want 20034 (4 + 20000 + 30)", u.PromptTokens)
 	}
-	if out != 50 {
-		t.Errorf("completion tokens = %d, want 50", out)
+	if u.CompletionTokens != 50 {
+		t.Errorf("completion tokens = %d, want 50", u.CompletionTokens)
+	}
+	// Only the cache READ is a hit. Cache creation is processed on this
+	// request and surcharged, so it belongs on the miss side.
+	if u.CacheHitTokens != 20000 {
+		t.Errorf("cache hit tokens = %d, want 20000", u.CacheHitTokens)
+	}
+	if u.CacheMissTokens != 34 {
+		t.Errorf("cache miss tokens = %d, want 34 (4 + 30)", u.CacheMissTokens)
+	}
+	if u.CacheHitTokens+u.CacheMissTokens != u.PromptTokens {
+		t.Errorf("split %d+%d does not sum back to the prompt %d", u.CacheHitTokens, u.CacheMissTokens, u.PromptTokens)
 	}
 }
 
@@ -149,14 +165,25 @@ func TestInspectStreamEvent(t *testing.T) {
 	}
 }
 
-// The streamed message_start reports the same summed prompt size the
-// non-streaming path does, so the two native paths meter a cached prompt alike.
-func TestInspectStreamEvent_SumsCachedInput(t *testing.T) {
+// The streamed message_start reports the same prompt size AND the same cache
+// split the non-streaming path does, so the two native paths meter and price a
+// cached prompt alike.
+func TestInspectStreamEvent_SplitsCachedInput(t *testing.T) {
 	ev := InspectStreamEvent([]byte(`{"type":"message_start","message":{"usage":{"input_tokens":4,"output_tokens":1,"cache_creation_input_tokens":30,"cache_read_input_tokens":20000}}}`))
 	if !ev.HasInput || ev.InputTokens != 20034 {
 		t.Errorf("input tokens = %d (has=%v), want 20034 (4 + 20000 + 30)", ev.InputTokens, ev.HasInput)
 	}
+	if ev.CacheHitTokens != 20000 || ev.CacheMissTokens != 34 {
+		t.Errorf("cache split = (%d,%d), want (20000,34)", ev.CacheHitTokens, ev.CacheMissTokens)
+	}
 	if !ev.HasOutput || ev.OutputTokens != 1 {
 		t.Errorf("output tokens = %d (has=%v), want 1", ev.OutputTokens, ev.HasOutput)
+	}
+
+	// An uncached stream reports no hit, so the proxy's (hit>0||miss>0) guard
+	// still records the miss rather than leaving the split empty.
+	plain := InspectStreamEvent([]byte(`{"type":"message_start","message":{"usage":{"input_tokens":15,"output_tokens":0}}}`))
+	if plain.CacheHitTokens != 0 || plain.CacheMissTokens != 15 {
+		t.Errorf("uncached split = (%d,%d), want (0,15)", plain.CacheHitTokens, plain.CacheMissTokens)
 	}
 }

--- a/internal/anthropic/request.go
+++ b/internal/anthropic/request.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+
+	"github.com/hugalafutro/model-hotel/internal/jsonfault"
 )
 
 // --- Incoming Anthropic Messages request shape ---
@@ -131,7 +133,7 @@ type oaiToolFunc struct {
 func TranslateRequest(body []byte) (openaiBody []byte, model string, stream bool, err error) {
 	var req Request
 	if err := json.Unmarshal(body, &req); err != nil {
-		return nil, "", false, fmt.Errorf("anthropic: invalid request body: %w", err)
+		return nil, "", false, fmt.Errorf("anthropic: invalid request body: %s", jsonfault.Describe(err, len(body)))
 	}
 	if req.Model == "" {
 		return nil, "", false, fmt.Errorf("anthropic: model is required")
@@ -201,7 +203,7 @@ func translateMessage(m ReqMessage) ([]oaiMessage, error) {
 
 	var blocks []reqBlock
 	if err := json.Unmarshal(m.Content, &blocks); err != nil {
-		return nil, fmt.Errorf("anthropic: invalid message content: %w", err)
+		return nil, fmt.Errorf("anthropic: invalid message content: %s", jsonfault.Describe(err, len(m.Content)))
 	}
 
 	var out []oaiMessage

--- a/internal/anthropic/request_test.go
+++ b/internal/anthropic/request_test.go
@@ -2,6 +2,7 @@ package anthropic
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -289,5 +290,59 @@ func TestBuildErrorResponseFromMessage_EmptyDefaults(t *testing.T) {
 	}
 	if e["message"] != "Service Unavailable" {
 		t.Errorf("message = %v, want status text default", e["message"])
+	}
+}
+
+func TestTranslateRequest_MessageContentErrorOmitsPayload(t *testing.T) {
+	// The per-message content decoder sees the user's own prompt. A syntax
+	// error cannot reach it (the outer body parse fails first), but a type
+	// error can, and *json.UnmarshalTypeError prints the offending literal
+	// verbatim — so that is what must not survive into the error.
+	_, _, _, err := TranslateRequest([]byte(`{"model":"m","max_tokens":10,"messages":[{"role":"user","content":[8675309.42]}]}`))
+	if err == nil {
+		t.Fatal("expected an error for undecodable message content")
+	}
+	if !strings.HasPrefix(err.Error(), "anthropic: invalid message content: unexpected JSON value at byte ") {
+		t.Errorf("error = %q, want the sanitized unexpected-value form", err)
+	}
+	if strings.Contains(err.Error(), "8675309.42") {
+		t.Errorf("error leaked the message content: %q", err)
+	}
+}
+
+func TestTranslateRequest_DecodeErrorOmitsPayload(t *testing.T) {
+	// A malformed request body is the user's own prompt: encoding/json quotes the\n\t// offending byte and prints an offending literal verbatim, so the error must\n\t// say WHERE the body broke and nothing about what it said.
+	cases := []struct {
+		name    string
+		payload string
+		want    string
+		secret  string
+	}{
+		{
+			name:    "syntax error",
+			payload: `{"model":"claude-x","messages":[{"role":"user","content":"Kohlrabi"`,
+			want:    "malformed JSON at byte ",
+			secret:  "Kohlrabi",
+		},
+		{
+			name:    "type error",
+			payload: `{"model":8675309.42}`,
+			want:    "unexpected JSON value at byte ",
+			secret:  "8675309.42",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, _, err := TranslateRequest([]byte(tc.payload))
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if !strings.HasPrefix(err.Error(), "anthropic: invalid request body: "+tc.want) {
+				t.Errorf("error = %q, want the sanitized %q form", err, tc.want)
+			}
+			if strings.Contains(err.Error(), tc.secret) {
+				t.Errorf("error leaked the payload: %q", err)
+			}
+		})
 	}
 }

--- a/internal/anthropic/request_test.go
+++ b/internal/anthropic/request_test.go
@@ -311,7 +311,9 @@ func TestTranslateRequest_MessageContentErrorOmitsPayload(t *testing.T) {
 }
 
 func TestTranslateRequest_DecodeErrorOmitsPayload(t *testing.T) {
-	// A malformed request body is the user's own prompt: encoding/json quotes the\n\t// offending byte and prints an offending literal verbatim, so the error must\n\t// say WHERE the body broke and nothing about what it said.
+	// A malformed request body is the user's own prompt: encoding/json quotes the
+	// offending byte and prints an offending literal verbatim, so the error must
+	// say WHERE the body broke and nothing about what it said.
 	cases := []struct {
 		name    string
 		payload string

--- a/internal/anthropic/response.go
+++ b/internal/anthropic/response.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+
+	"github.com/hugalafutro/model-hotel/internal/jsonfault"
 )
 
 // --- Incoming OpenAI non-streaming response shape ---
@@ -75,7 +77,7 @@ type oaiRespToolCall struct {
 func BuildMessageResponse(body []byte, messageID, model string) ([]byte, error) {
 	var resp oaiResponse
 	if err := json.Unmarshal(body, &resp); err != nil {
-		return nil, fmt.Errorf("anthropic: invalid upstream response: %w", err)
+		return nil, fmt.Errorf("anthropic: invalid upstream response: %s", jsonfault.Describe(err, len(body)))
 	}
 
 	msg := message{

--- a/internal/anthropic/response_test.go
+++ b/internal/anthropic/response_test.go
@@ -182,7 +182,8 @@ func TestBuildErrorResponse_RawBodyFallback(t *testing.T) {
 }
 
 func TestBuildMessageResponse_DecodeErrorOmitsPayload(t *testing.T) {
-	// A malformed response body is model output; the decode error reports the\n\t// offset, never the content.
+	// A malformed response body is model output; the decode error reports the
+	// offset, never the content.
 	cases := []struct {
 		name    string
 		payload string

--- a/internal/anthropic/response_test.go
+++ b/internal/anthropic/response_test.go
@@ -2,6 +2,7 @@ package anthropic
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -177,5 +178,42 @@ func TestBuildErrorResponse_RawBodyFallback(t *testing.T) {
 	e := m["error"].(map[string]any)
 	if e["message"] != "not json" {
 		t.Errorf("message = %v, want raw body fallback", e["message"])
+	}
+}
+
+func TestBuildMessageResponse_DecodeErrorOmitsPayload(t *testing.T) {
+	// A malformed response body is model output; the decode error reports the\n\t// offset, never the content.
+	cases := []struct {
+		name    string
+		payload string
+		want    string
+		secret  string
+	}{
+		{
+			name:    "syntax error",
+			payload: `{"choices":[{"message":{"role":"assistant","content":"Kohlrabi"`,
+			want:    "malformed JSON at byte ",
+			secret:  "Kohlrabi",
+		},
+		{
+			name:    "type error",
+			payload: `{"id":8675309.42}`,
+			want:    "unexpected JSON value at byte ",
+			secret:  "8675309.42",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := BuildMessageResponse([]byte(tc.payload), "msg_1", "m")
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if !strings.HasPrefix(err.Error(), "anthropic: invalid upstream response: "+tc.want) {
+				t.Errorf("error = %q, want the sanitized %q form", err, tc.want)
+			}
+			if strings.Contains(err.Error(), tc.secret) {
+				t.Errorf("error leaked the payload: %q", err)
+			}
+		})
 	}
 }

--- a/internal/anthropicegress/adapter.go
+++ b/internal/anthropicegress/adapter.go
@@ -1,0 +1,118 @@
+package anthropicegress
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/hugalafutro/model-hotel/internal/debuglog"
+)
+
+// StreamAdapter wraps an upstream Anthropic /v1/messages SSE body as an
+// io.ReadCloser that yields chat.completion.chunk SSE bytes. Wrapping the
+// UPSTREAM body (not the client writer) lets the whole existing streaming
+// pipeline — TTFT probe, stall watchdog, transforms, metering — run unchanged
+// on what it already understands (same trick as gemini.StreamAdapter).
+//
+// Anthropic ends its stream with message_stop and carries no [DONE] sentinel,
+// so the translator emits the terminal chunk + [DONE] on message_stop. An
+// upstream that reaches EOF without message_stop gets that terminal pair from
+// Finish() instead; any other upstream error surfaces as a stream without
+// [DONE], which the pipeline already classifies as a truncation.
+type StreamAdapter struct {
+	upstream io.ReadCloser
+	tr       *StreamTranslator
+
+	lineBuf  []byte // partial SSE line carried across reads
+	pending  []byte // translated bytes not yet handed to the caller
+	readBuf  []byte
+	srcErr   error
+	transErr error // first translation failure; poisons the stream
+}
+
+// NewStreamAdapter builds an adapter for one streaming response. model is
+// echoed in every emitted chunk (the model string the client requested).
+func NewStreamAdapter(upstream io.ReadCloser, model string) *StreamAdapter {
+	id := "chatcmpl-" + strings.ReplaceAll(uuid.NewString(), "-", "")
+	return &StreamAdapter{
+		upstream: upstream,
+		tr:       NewStreamTranslator(id, model, time.Now().Unix()),
+		readBuf:  make([]byte, 32*1024),
+	}
+}
+
+// Read refills the pending buffer from upstream (translating as it goes) and
+// copies out. On EOF the terminal Finish() bytes are appended before the EOF is
+// surfaced; other upstream errors surface only after all translated bytes have
+// been drained. A translation failure poisons the stream: already translated
+// bytes drain, then the error surfaces — Finish() is never fabricated over a
+// corrupt upstream, so the proxy sees a failed stream instead of a clean
+// empty/partial success.
+func (a *StreamAdapter) Read(p []byte) (int, error) {
+	for len(a.pending) == 0 {
+		if a.transErr != nil {
+			return 0, a.transErr
+		}
+		if a.srcErr != nil {
+			return 0, a.srcErr
+		}
+		n, err := a.upstream.Read(a.readBuf)
+		if n > 0 {
+			a.consume(a.readBuf[:n])
+		}
+		if err != nil {
+			a.srcErr = err
+			if err == io.EOF && a.transErr == nil {
+				fin, finErr := a.tr.Finish()
+				if finErr != nil {
+					debuglog.Warn("anthropicegress: stream finish failed", "error", finErr)
+				}
+				a.pending = append(a.pending, fin...)
+			}
+		}
+	}
+	n := copy(p, a.pending)
+	a.pending = a.pending[n:]
+	return n, nil
+}
+
+// consume splits incoming bytes into SSE lines and feeds each data payload to
+// the translator. "event:"/comment/blank lines are dropped; the adapter
+// generates its own framing.
+func (a *StreamAdapter) consume(p []byte) {
+	a.lineBuf = append(a.lineBuf, p...)
+	for {
+		idx := bytes.IndexByte(a.lineBuf, '\n')
+		if idx < 0 {
+			return
+		}
+		line := bytes.TrimRight(a.lineBuf[:idx], "\r")
+		a.lineBuf = a.lineBuf[idx+1:]
+		if !bytes.HasPrefix(line, []byte("data:")) {
+			continue
+		}
+		payload := bytes.TrimSpace(line[len("data:"):])
+		if len(payload) == 0 {
+			continue
+		}
+		out, err := a.tr.Translate(payload)
+		if err != nil {
+			// A malformed data line or an upstream error event means the
+			// stream is dead; record it and stop translating so Read surfaces
+			// the failure.
+			debuglog.Warn("anthropicegress: stream event translate failed", "error", err)
+			a.transErr = err
+			return
+		}
+		a.pending = append(a.pending, out...)
+	}
+}
+
+// Close closes the upstream body. The stall watchdog calls this to unblock a
+// hung read, so it must propagate to the wrapped connection.
+func (a *StreamAdapter) Close() error {
+	return a.upstream.Close()
+}

--- a/internal/anthropicegress/adapter.go
+++ b/internal/anthropicegress/adapter.go
@@ -2,6 +2,8 @@ package anthropicegress
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"time"
@@ -10,6 +12,12 @@ import (
 
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 )
+
+// maxSSELineBytes caps the unterminated SSE line the adapter will buffer.
+// Anthropic's deltas are orders of magnitude smaller than this, so an upstream
+// that never emits a newline is a broken peer, not a large response — the
+// stream fails instead of growing the buffer until the process suffers.
+const maxSSELineBytes = 1 << 20
 
 // StreamAdapter wraps an upstream Anthropic /v1/messages SSE body as an
 // io.ReadCloser that yields chat.completion.chunk SSE bytes. Wrapping the
@@ -45,7 +53,8 @@ func NewStreamAdapter(upstream io.ReadCloser, model string) *StreamAdapter {
 }
 
 // Read refills the pending buffer from upstream (translating as it goes) and
-// copies out. On EOF the terminal Finish() bytes are appended before the EOF is
+// copies out. On EOF any residual partial line is flushed through the
+// translator and the terminal Finish() bytes are appended before the EOF is
 // surfaced; other upstream errors surface only after all translated bytes have
 // been drained. A translation failure poisons the stream: already translated
 // bytes drain, then the error surfaces — Finish() is never fabricated over a
@@ -65,12 +74,20 @@ func (a *StreamAdapter) Read(p []byte) (int, error) {
 		}
 		if err != nil {
 			a.srcErr = err
-			if err == io.EOF && a.transErr == nil {
-				fin, finErr := a.tr.Finish()
-				if finErr != nil {
-					debuglog.Warn("anthropicegress: stream finish failed", "error", finErr)
+			if errors.Is(err, io.EOF) {
+				// io.Copy and io.ReadAll compare the terminating error against
+				// io.EOF with ==, so a wrapped EOF from a reader between the
+				// transport and here would be reported as a broken stream even
+				// though it ended normally. This adapter ends on io.EOF itself.
+				a.srcErr = io.EOF
+				a.flushPartialLine()
+				if a.transErr == nil {
+					fin, finErr := a.tr.Finish()
+					if finErr != nil {
+						debuglog.Warn("anthropicegress: stream finish failed", "error", finErr)
+					}
+					a.pending = append(a.pending, fin...)
 				}
-				a.pending = append(a.pending, fin...)
 			}
 		}
 	}
@@ -87,6 +104,11 @@ func (a *StreamAdapter) consume(p []byte) {
 	for {
 		idx := bytes.IndexByte(a.lineBuf, '\n')
 		if idx < 0 {
+			if len(a.lineBuf) > maxSSELineBytes {
+				a.lineBuf = nil
+				a.transErr = fmt.Errorf("anthropicegress: upstream SSE line exceeds %d bytes", maxSSELineBytes)
+				debuglog.Warn("anthropicegress: stream line exceeds buffer cap", "limit", maxSSELineBytes)
+			}
 			return
 		}
 		line := bytes.TrimRight(a.lineBuf[:idx], "\r")
@@ -109,6 +131,19 @@ func (a *StreamAdapter) consume(p []byte) {
 		}
 		a.pending = append(a.pending, out...)
 	}
+}
+
+// flushPartialLine feeds a residual line to the translator at EOF. An upstream
+// that closes without a trailing newline would otherwise lose its last event
+// entirely — including a final message_delta's stop_reason — while Finish()
+// still emitted a clean terminal chunk, which is exactly the quiet truncation
+// this adapter exists to prevent.
+func (a *StreamAdapter) flushPartialLine() {
+	if len(a.lineBuf) == 0 || a.transErr != nil {
+		return
+	}
+	a.lineBuf = append(a.lineBuf, '\n')
+	a.consume(nil)
 }
 
 // Close closes the upstream body. The stall watchdog calls this to unblock a

--- a/internal/anthropicegress/adapter_test.go
+++ b/internal/anthropicegress/adapter_test.go
@@ -248,6 +248,32 @@ func TestStreamAdapter_FlushesPartialLineAtEOF(t *testing.T) {
 	}
 }
 
+func TestStreamAdapter_TruncatedResidualAfterMessageStopIgnored(t *testing.T) {
+	// The stream already completed on message_stop; the connection then drops
+	// mid-line. Flushing that residual must not poison a finished stream or
+	// append anything behind the sentinel.
+	upstream := &scriptedBody{script: []string{
+		"data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":2}}}\n\n",
+		"data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":1}}\n\n",
+		"data: {\"type\":\"message_stop\"}\n\n",
+		"data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_del",
+	}}
+	out, err := io.ReadAll(NewStreamAdapter(upstream, "m"))
+	if err != nil {
+		t.Fatalf("a truncated line after message_stop poisoned a finished stream: %v", err)
+	}
+	s := string(out)
+	if n := strings.Count(s, "data: [DONE]"); n != 1 {
+		t.Errorf("[DONE] count = %d, want 1:\n%s", n, s)
+	}
+	if n := strings.Count(s, `"finish_reason":"stop"`); n != 1 {
+		t.Errorf("terminal chunks = %d, want 1:\n%s", n, s)
+	}
+	if !strings.HasSuffix(s, "data: [DONE]\n\n") {
+		t.Errorf("bytes emitted after the sentinel:\n%s", s)
+	}
+}
+
 func TestStreamAdapter_OverlongLineFailsStream(t *testing.T) {
 	// An upstream that never emits a newline must fail the stream rather than
 	// grow the line buffer without bound.

--- a/internal/anthropicegress/adapter_test.go
+++ b/internal/anthropicegress/adapter_test.go
@@ -2,6 +2,7 @@ package anthropicegress
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"testing"
@@ -198,6 +199,74 @@ func TestStreamAdapter_UpstreamDiesMidStream(t *testing.T) {
 	}
 	if strings.Contains(string(out), "[DONE]") {
 		t.Errorf("[DONE] fabricated on a dropped connection:\n%s", out)
+	}
+}
+
+func TestStreamAdapter_WrappedEOFStillFinishes(t *testing.T) {
+	// EOF can arrive wrapped by any reader sitting between the transport and
+	// this adapter; a wrapped EOF must still produce the terminal chunk rather
+	// than leaving the client with no [DONE].
+	body := &dyingBody{
+		data: "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"x\"}}\n\n",
+		err:  fmt.Errorf("transport read: %w", io.EOF),
+	}
+	out, err := io.ReadAll(NewStreamAdapter(body, "m"))
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if _, done := parseChunks(t, string(out)); !done {
+		t.Errorf("wrapped EOF skipped the terminal chunk:\n%s", out)
+	}
+}
+
+func TestStreamAdapter_FlushesPartialLineAtEOF(t *testing.T) {
+	// An upstream that closes without a trailing newline must not lose its last
+	// event: dropping a final message_delta would silently downgrade a
+	// max_tokens truncation to a clean "stop" alongside a clean [DONE].
+	upstream := &scriptedBody{script: []string{
+		"data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":2}}}\n\n",
+		"data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"tail\"}}\n\n",
+		"data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"max_tokens\"},\"usage\":{\"output_tokens\":6}}",
+	}}
+	out, err := io.ReadAll(NewStreamAdapter(upstream, "m"))
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	chunks, done := parseChunks(t, string(out))
+	if !done {
+		t.Fatalf("stream did not end with [DONE]:\n%s", out)
+	}
+	if got := joinContent(chunks); got != "tail" {
+		t.Errorf("content = %q, want tail", got)
+	}
+	last := chunks[len(chunks)-1]
+	if r := last.Choices[0].FinishReason; r == nil || *r != "length" {
+		t.Errorf("finish_reason = %v, want length from the unterminated message_delta", r)
+	}
+	if last.Usage == nil || last.Usage.CompletionTokens != 6 {
+		t.Errorf("usage = %+v, want completion_tokens 6 from the unterminated message_delta", last.Usage)
+	}
+}
+
+func TestStreamAdapter_OverlongLineFailsStream(t *testing.T) {
+	// An upstream that never emits a newline must fail the stream rather than
+	// grow the line buffer without bound.
+	upstream := &scriptedBody{script: []string{
+		"data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"" +
+			strings.Repeat("a", maxSSELineBytes+1),
+	}}
+	out, err := io.ReadAll(NewStreamAdapter(upstream, "m"))
+	if err == nil {
+		t.Fatal("expected an error once the line exceeded the cap")
+	}
+	if !strings.Contains(err.Error(), "exceeds") {
+		t.Errorf("error = %q, want it to name the exceeded cap", err)
+	}
+	if strings.Contains(string(out), "[DONE]") {
+		t.Errorf("[DONE] fabricated over an unterminated line:\n%s", out)
+	}
+	if strings.Contains(err.Error(), "aaaa") {
+		t.Errorf("error leaked the buffered line: %q", err)
 	}
 }
 

--- a/internal/anthropicegress/adapter_test.go
+++ b/internal/anthropicegress/adapter_test.go
@@ -1,0 +1,213 @@
+package anthropicegress
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+// scriptedBody yields its script one entry per Read call, simulating SSE
+// arriving in arbitrary splits (including mid-line).
+type scriptedBody struct {
+	script []string
+	closed bool
+}
+
+func (r *scriptedBody) Read(p []byte) (int, error) {
+	if len(r.script) == 0 {
+		return 0, io.EOF
+	}
+	n := copy(p, r.script[0])
+	rest := r.script[0][n:]
+	if rest == "" {
+		r.script = r.script[1:]
+	} else {
+		r.script[0] = rest
+	}
+	return n, nil
+}
+
+func (r *scriptedBody) Close() error {
+	r.closed = true
+	return nil
+}
+
+// dyingBody serves its data and then fails, standing in for an upstream
+// connection that drops mid-stream.
+type dyingBody struct {
+	data string
+	err  error
+}
+
+func (r *dyingBody) Read(p []byte) (int, error) {
+	if r.data == "" {
+		return 0, r.err
+	}
+	n := copy(p, r.data)
+	r.data = r.data[n:]
+	return n, nil
+}
+
+func (r *dyingBody) Close() error { return nil }
+
+func TestStreamAdapter_TranslatesFullStream(t *testing.T) {
+	// Real Anthropic framing: "event:" lines, blank lines and payloads split
+	// awkwardly across reads.
+	upstream := &scriptedBody{script: []string{
+		"event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":11,\"output_tokens\":1}}}\n\n",
+		"event: content_block_start\r\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\r\n\r\n",
+		": keepalive\nevent: ping\ndata: {\"type\":\"ping\"}\n\n",
+		"event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_de",
+		"lta\",\"text\":\"Hello\"}}\n\nevent: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}\n\n",
+		"event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":4}}\n\n",
+		"event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n",
+	}}
+
+	out, err := io.ReadAll(NewStreamAdapter(upstream, "claude-sonnet-4-5"))
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	chunks, done := parseChunks(t, string(out))
+	if !done {
+		t.Fatalf("stream did not end with [DONE]:\n%s", out)
+	}
+	if len(chunks) != 3 { // role, "Hello", terminal
+		t.Fatalf("chunks = %d, want 3:\n%s", len(chunks), out)
+	}
+	if got := joinContent(chunks); got != "Hello" {
+		t.Errorf("content = %q, want Hello (payload split across reads)", got)
+	}
+	for _, c := range chunks {
+		if c.Model != "claude-sonnet-4-5" {
+			t.Errorf("model = %q, want the model the client requested", c.Model)
+		}
+		if !strings.HasPrefix(c.ID, "chatcmpl-") {
+			t.Errorf("id = %q, want a chatcmpl- id", c.ID)
+		}
+	}
+	last := chunks[len(chunks)-1]
+	if r := last.Choices[0].FinishReason; r == nil || *r != "stop" {
+		t.Errorf("finish_reason = %v, want stop", r)
+	}
+	if last.Usage == nil || last.Usage.PromptTokens != 11 || last.Usage.CompletionTokens != 4 {
+		t.Errorf("usage = %+v, want prompt 11 / completion 4", last.Usage)
+	}
+}
+
+func TestStreamAdapter_MessageStopFinishesOnce(t *testing.T) {
+	// message_stop already emitted the terminal chunk + [DONE]; the EOF that
+	// follows must not append a second one.
+	upstream := &scriptedBody{script: []string{
+		"data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":2}}}\n\n",
+		"data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":1}}\n\n",
+		"data: {\"type\":\"message_stop\"}\n\n",
+	}}
+	out, err := io.ReadAll(NewStreamAdapter(upstream, "m"))
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	s := string(out)
+	if n := strings.Count(s, "data: [DONE]"); n != 1 {
+		t.Errorf("[DONE] count = %d, want 1:\n%s", n, s)
+	}
+	if n := strings.Count(s, `"finish_reason":"stop"`); n != 1 {
+		t.Errorf("terminal chunks = %d, want 1:\n%s", n, s)
+	}
+}
+
+func TestStreamAdapter_EOFWithoutMessageStopStillFinishes(t *testing.T) {
+	// Anthropic carries no [DONE] sentinel, so an upstream that ends at EOF
+	// without message_stop still owes the client a terminal chunk.
+	upstream := &scriptedBody{script: []string{
+		"data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":2}}}\n\n",
+		"data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"hi\"}}\n\n",
+		"data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\"},\"usage\":{\"output_tokens\":5}}\n\n",
+	}}
+	out, err := io.ReadAll(NewStreamAdapter(upstream, "m"))
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	chunks, done := parseChunks(t, string(out))
+	if !done {
+		t.Fatalf("EOF did not produce [DONE]:\n%s", out)
+	}
+	if r := chunks[len(chunks)-1].Choices[0].FinishReason; r == nil || *r != "tool_calls" {
+		t.Errorf("finish_reason = %v, want tool_calls", r)
+	}
+}
+
+func TestStreamAdapter_ErrorEventPoisonsStream(t *testing.T) {
+	// An error event mid-stream is a failed generation: translated bytes drain,
+	// then the error surfaces, and no terminal chunk is fabricated over it.
+	upstream := &scriptedBody{script: []string{
+		"data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":2}}}\n\n",
+		"data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"pre\"}}\n\n",
+		"event: error\ndata: {\"type\":\"error\",\"error\":{\"type\":\"overloaded_error\",\"message\":\"boom\"}}\n\n",
+		"data: {\"type\":\"message_stop\"}\n\n",
+	}}
+	out, err := io.ReadAll(NewStreamAdapter(upstream, "m"))
+	if err == nil {
+		t.Fatal("expected an error for an upstream error event")
+	}
+	if !strings.Contains(err.Error(), "overloaded_error") {
+		t.Errorf("error = %q, want the upstream error type named", err)
+	}
+	s := string(out)
+	if !strings.Contains(s, `"content":"pre"`) {
+		t.Errorf("pre-error content lost:\n%s", s)
+	}
+	if strings.Contains(s, "[DONE]") || strings.Contains(s, `"finish_reason":"`) {
+		t.Errorf("terminal chunks fabricated after an error event:\n%s", s)
+	}
+}
+
+func TestStreamAdapter_MalformedEventPoisonsStream(t *testing.T) {
+	upstream := &scriptedBody{script: []string{
+		"data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"pre\"}}\n\n",
+		"data: {not json}\n\n",
+		"data: {\"type\":\"message_stop\"}\n\n",
+	}}
+	out, err := io.ReadAll(NewStreamAdapter(upstream, "m"))
+	if err == nil {
+		t.Fatal("expected an error for a malformed event")
+	}
+	s := string(out)
+	if !strings.Contains(s, `"content":"pre"`) {
+		t.Errorf("pre-error content lost:\n%s", s)
+	}
+	if strings.Contains(s, "[DONE]") {
+		t.Errorf("[DONE] fabricated after a malformed event:\n%s", s)
+	}
+}
+
+func TestStreamAdapter_UpstreamDiesMidStream(t *testing.T) {
+	boom := errors.New("connection reset")
+	body := &dyingBody{
+		data: "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"x\"}}\n\n",
+		err:  boom,
+	}
+	out, err := io.ReadAll(NewStreamAdapter(body, "m"))
+	if !errors.Is(err, boom) {
+		t.Fatalf("err = %v, want the upstream error", err)
+	}
+	// Bytes translated before the failure are still delivered, but a broken
+	// stream never gets a [DONE] the pipeline would read as a clean end.
+	if !strings.Contains(string(out), `"content":"x"`) {
+		t.Errorf("pre-failure content lost:\n%s", out)
+	}
+	if strings.Contains(string(out), "[DONE]") {
+		t.Errorf("[DONE] fabricated on a dropped connection:\n%s", out)
+	}
+}
+
+func TestStreamAdapter_ClosePropagates(t *testing.T) {
+	upstream := &scriptedBody{}
+	a := NewStreamAdapter(upstream, "m")
+	if err := a.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if !upstream.closed {
+		t.Error("Close did not propagate to the upstream body")
+	}
+}

--- a/internal/anthropicegress/adapter_test.go
+++ b/internal/anthropicegress/adapter_test.go
@@ -79,6 +79,11 @@ func TestStreamAdapter_TranslatesFullStream(t *testing.T) {
 	if got := joinContent(chunks); got != "Hello" {
 		t.Errorf("content = %q, want Hello (payload split across reads)", got)
 	}
+	// The upstream ping reaches the proxy as a keepalive comment, which is what
+	// resets the stall watchdog across a long generation gap.
+	if !strings.Contains(string(out), ": ping\n\n") {
+		t.Errorf("adapter dropped the upstream ping keepalive:\n%s", out)
+	}
 	for _, c := range chunks {
 		if c.Model != "claude-sonnet-4-5" {
 			t.Errorf("model = %q, want the model the client requested", c.Model)

--- a/internal/anthropicegress/detect.go
+++ b/internal/anthropicegress/detect.go
@@ -16,10 +16,28 @@ var imageMediaTypes = map[string]bool{
 	"image/webp": true,
 }
 
+// carriesDocuments reports whether a message role's non-text content survives
+// translation to Anthropic's Messages shape. Only conversation turns do:
+// system and developer content is lifted into the top-level system prompt and
+// a tool message becomes a tool_result, and Anthropic types both as text, so
+// translateMessages flattens them and any document there is dropped. Routing a
+// request native for a document that cannot be carried would ask the model
+// about a file it never received, where the compat endpoint returns a clean
+// 400 instead.
+func carriesDocuments(role string) bool {
+	switch role {
+	case "system", "developer", "tool":
+		return false
+	default: // "user", "assistant", and anything unrecognised (a user turn)
+		return true
+	}
+}
+
 // NeedsNativeRouting reports whether a chat-completions request body carries a
 // content part Anthropic's OpenAI-compat endpoint cannot express and that
 // therefore has to go to the native /v1/messages route: an OpenAI file part, or
-// an image part whose data: URI holds a non-image media type.
+// an image part whose data: URI holds a non-image media type, on a message role
+// whose documents survive translation.
 //
 // Detection is conservative by construction: an unparseable body, string
 // message content, or a request holding only text and real images returns false
@@ -27,6 +45,7 @@ var imageMediaTypes = map[string]bool{
 func NeedsNativeRouting(chatBody []byte) bool {
 	var probe struct {
 		Messages []struct {
+			Role    string          `json:"role"`
 			Content json.RawMessage `json:"content"`
 		} `json:"messages"`
 	}
@@ -35,6 +54,9 @@ func NeedsNativeRouting(chatBody []byte) bool {
 	}
 
 	for _, m := range probe.Messages {
+		if !carriesDocuments(m.Role) {
+			continue
+		}
 		var parts []oaiContentPart
 		// String content (and null content) fails this decode; only part arrays
 		// can carry a file or an image source.

--- a/internal/anthropicegress/detect.go
+++ b/internal/anthropicegress/detect.go
@@ -1,0 +1,86 @@
+package anthropicegress
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// imageMediaTypes are the media types Anthropic accepts in an image source.
+// A data: URI carrying anything else is a document wearing an image costume —
+// clients smuggle PDFs through image_url precisely because the OpenAI file
+// part 400s on the compat endpoint.
+var imageMediaTypes = map[string]bool{
+	"image/jpeg": true,
+	"image/png":  true,
+	"image/gif":  true,
+	"image/webp": true,
+}
+
+// NeedsNativeRouting reports whether a chat-completions request body carries a
+// content part Anthropic's OpenAI-compat endpoint cannot express and that
+// therefore has to go to the native /v1/messages route: an OpenAI file part, or
+// an image part whose data: URI holds a non-image media type.
+//
+// Detection is conservative by construction: an unparseable body, string
+// message content, or a request holding only text and real images returns false
+// and keeps the cheaper chat-completions path.
+func NeedsNativeRouting(chatBody []byte) bool {
+	var probe struct {
+		Messages []struct {
+			Content json.RawMessage `json:"content"`
+		} `json:"messages"`
+	}
+	if json.Unmarshal(chatBody, &probe) != nil {
+		return false
+	}
+
+	for _, m := range probe.Messages {
+		var parts []oaiContentPart
+		// String content (and null content) fails this decode; only part arrays
+		// can carry a file or an image source.
+		if json.Unmarshal(m.Content, &parts) != nil {
+			continue
+		}
+		for _, p := range parts {
+			switch p.Type {
+			case "file":
+				return true
+			case "image_url":
+				if p.ImageURL == nil {
+					continue
+				}
+				if du, ok := parseDataURI(p.ImageURL.URL); ok && !imageMediaTypes[du.mediaType] {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// dataURI is a parsed data: URI.
+type dataURI struct {
+	mediaType string // lower-cased, parameters stripped ("application/pdf")
+	base64    bool   // the payload carries the ";base64" marker
+	payload   string // everything after the comma, undecoded
+}
+
+// parseDataURI splits a data: URI into its media type and payload. ok is false
+// for anything that is not a parseable data: URI — an http(s) URL, or a
+// truncated data: value with no comma or no payload.
+func parseDataURI(u string) (dataURI, bool) {
+	rest, isData := strings.CutPrefix(u, "data:")
+	if !isData {
+		return dataURI{}, false
+	}
+	meta, payload, found := strings.Cut(rest, ",")
+	if !found || payload == "" {
+		return dataURI{}, false
+	}
+	mediaType, params, _ := strings.Cut(meta, ";")
+	return dataURI{
+		mediaType: strings.ToLower(strings.TrimSpace(mediaType)),
+		base64:    strings.Contains(strings.ToLower(params), "base64"),
+		payload:   payload,
+	}, true
+}

--- a/internal/anthropicegress/detect.go
+++ b/internal/anthropicegress/detect.go
@@ -123,27 +123,31 @@ func startsWithImageMediaType(b []byte) bool {
 // saw. Nothing in the logs would show it: the request completes, delivers
 // content, and meters normally. The compat endpoint answers the same request
 // with a clean 400, which is the better outcome, so the untranslatable part
-// keeps the compat path. Every check below therefore runs the same helper
-// translateBlocks runs, not a copy of its conditions.
+// keeps the compat path.
+//
+// Every branch below therefore calls the same helper translateBlocks calls and
+// judges the block it produced, never a copy of that helper's conditions. A
+// copied condition is the same drift in miniature: the next change to
+// imageBlock or fileBlock would leave the gate behind while this comment still
+// claimed otherwise.
 func routesNative(p oaiContentPart) bool {
 	switch p.Type {
 	case "file":
 		if p.File == nil {
 			return false
 		}
+		// Every block fileBlock produces is a document.
 		_, ok := fileBlock(p.File)
 		return ok
 	case "image_url":
 		if p.ImageURL == nil || p.ImageURL.URL == "" {
 			return false
 		}
-		du, ok := parseDataURI(p.ImageURL.URL)
-		if !ok || imageMediaTypes[du.mediaType] {
-			// A real image, or a URL the compat endpoint carries itself.
-			return false
-		}
-		_, ok = documentBlock(du)
-		return ok
+		// imageBlock resolves the image slot three ways: a base64 image, a url
+		// image, or the document a client smuggled through it. Only the
+		// document needs the native route.
+		b, ok := imageBlock(p.ImageURL.URL)
+		return ok && b.Type == "document"
 	}
 	return false
 }

--- a/internal/anthropicegress/detect.go
+++ b/internal/anthropicegress/detect.go
@@ -1,6 +1,7 @@
 package anthropicegress
 
 import (
+	"bytes"
 	"encoding/json"
 	"strings"
 )
@@ -16,33 +17,153 @@ var imageMediaTypes = map[string]bool{
 	"image/webp": true,
 }
 
-// carriesDocuments reports whether a message role's non-text content survives
-// translation to Anthropic's Messages shape. Only conversation turns do:
-// system and developer content is lifted into the top-level system prompt and
-// a tool message becomes a tool_result, and Anthropic types both as text, so
-// translateMessages flattens them and any document there is dropped. Routing a
-// request native for a document that cannot be carried would ask the model
-// about a file it never received, where the compat endpoint returns a clean
-// 400 instead.
+// carriesDocuments reports whether a document on a message role reaches
+// Anthropic intact. Only a user turn does. System and developer content is
+// lifted into the top-level system prompt and a tool message becomes a
+// tool_result, and Anthropic types both as text, so translateMessages flattens
+// them and any document there is dropped. An assistant turn holds blocks, but
+// document is not in Anthropic's assistant content-block schema, so a document
+// there is a guaranteed 400.
+//
+// A document on a non-carrying role is dropped in translation, and a request
+// routes native on the strength of its carrying-role documents alone: a request
+// pairing a user document with a system one goes native and loses the system
+// one, where the compat endpoint would have 400'd on both. That is the accepted
+// cost of serving the document the request is actually about.
 func carriesDocuments(role string) bool {
 	switch role {
-	case "system", "developer", "tool":
+	case "system", "developer", "tool", "assistant":
 		return false
-	default: // "user", "assistant", and anything unrecognised (a user turn)
+	default: // "user", and anything unrecognised (translated as a user turn)
 		return true
 	}
+}
+
+// filePartHint is the literal an OpenAI file part cannot avoid: "file" is both
+// its type and its content object's key.
+var filePartHint = []byte(`"file"`)
+
+// jsonEscapeHint is the pre-filter's escape hatch. JSON may spell any of the
+// literals scanned for here with \uXXXX escapes that only the full decode
+// resolves, so a body carrying any escape at all falls through to that decode
+// rather than being ruled out on a byte scan that cannot see through it.
+var jsonEscapeHint = []byte(`\u`)
+
+// dataURIHint opens every inline payload, image or document alike.
+var dataURIHint = []byte("data:")
+
+// mayNeedNativeRouting is a pre-filter over the raw request body. The full
+// decode below materialises every image and file payload as a Go string, on
+// every chat request to an Anthropic provider and once per candidate attempt,
+// so a multi-megabyte base64 image is copied and thrown away on requests that
+// were never going native. This byte scan rules out the traffic that makes up
+// almost all of it — plain text, and the vision requests this detector exists
+// to reject — without allocating.
+//
+// It is one-sided by construction: false means no part can possibly route
+// native, true only means the decode has to run.
+func mayNeedNativeRouting(chatBody []byte) bool {
+	return bytes.Contains(chatBody, filePartHint) ||
+		bytes.Contains(chatBody, jsonEscapeHint) ||
+		hasNonImageDataURI(chatBody)
+}
+
+// hasNonImageDataURI reports whether the body holds a data: URI that is not
+// plainly one of Anthropic's four image media types. A base64 image is the one
+// bulky payload that never routes native, so ruling it out here is the whole
+// point of the pre-filter.
+//
+// Every way of being unsure resolves to true: an escaped or padded media type,
+// an image/* type outside imageMediaTypes (image/svg+xml), a truncated URI. The
+// scan returns false for an occurrence only when the bytes after "data:" are
+// exactly an accepted image media type followed by the ";" or "," that ends it
+// — precisely the shape parseDataURI and imageMediaTypes accept together.
+func hasNonImageDataURI(body []byte) bool {
+	for rest := body; ; {
+		i := bytes.Index(rest, dataURIHint)
+		if i < 0 {
+			return false
+		}
+		rest = rest[i+len(dataURIHint):]
+		if !startsWithImageMediaType(rest) {
+			return true
+		}
+	}
+}
+
+// maxMediaTypeBytes bounds how far the pre-filter looks for the end of a media
+// type. Every accepted one is under a dozen bytes; the cap keeps a body that
+// opens a data: URI and never closes its media type from being copied out.
+const maxMediaTypeBytes = 64
+
+// startsWithImageMediaType reports whether b opens with an accepted image media
+// type terminated by ";" or ",". The comparison is case-insensitive to match
+// parseDataURI, which lower-cases before the imageMediaTypes lookup.
+func startsWithImageMediaType(b []byte) bool {
+	if len(b) > maxMediaTypeBytes {
+		b = b[:maxMediaTypeBytes]
+	}
+	end := bytes.IndexAny(b, ";,")
+	if end < 0 {
+		return false
+	}
+	return imageMediaTypes[strings.ToLower(string(b[:end]))]
+}
+
+// routesNative reports whether one content part both needs the native route
+// and survives translation to an Anthropic block.
+//
+// The two halves are inseparable, and this is the invariant any change here
+// has to keep: A REQUEST ROUTES NATIVE ONLY IF EVERY PART THAT MADE IT ROUTE
+// NATIVE SURVIVES TRANSLATION. translateBlocks drops a part it cannot express,
+// so a gate that matched on the part TYPE alone would send a file part with
+// nothing usable in it — {"file":{"file_id":"file-abc"}}, an unparseable
+// file_data, an undecodable payload — to /v1/messages carrying only the
+// surrounding text, and return a confident 200 about a document the model never
+// saw. Nothing in the logs would show it: the request completes, delivers
+// content, and meters normally. The compat endpoint answers the same request
+// with a clean 400, which is the better outcome, so the untranslatable part
+// keeps the compat path. Every check below therefore runs the same helper
+// translateBlocks runs, not a copy of its conditions.
+func routesNative(p oaiContentPart) bool {
+	switch p.Type {
+	case "file":
+		if p.File == nil {
+			return false
+		}
+		_, ok := fileBlock(p.File)
+		return ok
+	case "image_url":
+		if p.ImageURL == nil || p.ImageURL.URL == "" {
+			return false
+		}
+		du, ok := parseDataURI(p.ImageURL.URL)
+		if !ok || imageMediaTypes[du.mediaType] {
+			// A real image, or a URL the compat endpoint carries itself.
+			return false
+		}
+		_, ok = documentBlock(du)
+		return ok
+	}
+	return false
 }
 
 // NeedsNativeRouting reports whether a chat-completions request body carries a
 // content part Anthropic's OpenAI-compat endpoint cannot express and that
 // therefore has to go to the native /v1/messages route: an OpenAI file part, or
 // an image part whose data: URI holds a non-image media type, on a message role
-// whose documents survive translation.
+// whose documents survive translation — and that TranslateRequest can actually
+// turn into an Anthropic block (see routesNative for why the second half is not
+// optional).
 //
 // Detection is conservative by construction: an unparseable body, string
 // message content, or a request holding only text and real images returns false
 // and keeps the cheaper chat-completions path.
 func NeedsNativeRouting(chatBody []byte) bool {
+	if !mayNeedNativeRouting(chatBody) {
+		return false
+	}
+
 	var probe struct {
 		Messages []struct {
 			Role    string          `json:"role"`
@@ -64,16 +185,8 @@ func NeedsNativeRouting(chatBody []byte) bool {
 			continue
 		}
 		for _, p := range parts {
-			switch p.Type {
-			case "file":
+			if routesNative(p) {
 				return true
-			case "image_url":
-				if p.ImageURL == nil {
-					continue
-				}
-				if du, ok := parseDataURI(p.ImageURL.URL); ok && !imageMediaTypes[du.mediaType] {
-					return true
-				}
 			}
 		}
 	}

--- a/internal/anthropicegress/detect_test.go
+++ b/internal/anthropicegress/detect_test.go
@@ -42,6 +42,49 @@ func TestNeedsNativeRouting(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "file part on an assistant turn",
+			body: `{"messages":[{"role":"assistant","content":[
+				{"type":"file","file":{"file_url":"https://example.com/a.pdf"}}]}]}`,
+			want: true,
+		},
+		// The roles below drop their documents in translation (system and
+		// developer content is flattened into the system prompt, a tool message
+		// into a text tool_result). Routing native for one would ask the model
+		// about a file that never arrived; the compat endpoint 400s instead.
+		{
+			name: "file part on a system turn",
+			body: `{"messages":[
+				{"role":"system","content":[{"type":"file","file":{"file_url":"https://example.com/a.pdf"}}]},
+				{"role":"user","content":"summarise it"}]}`,
+			want: false,
+		},
+		{
+			name: "file part on a developer turn",
+			body: `{"messages":[
+				{"role":"developer","content":[{"type":"file","file":{"file_data":"data:application/pdf;base64,JVBERi0="}}]},
+				{"role":"user","content":"summarise it"}]}`,
+			want: false,
+		},
+		{
+			name: "file part on a tool turn",
+			body: `{"messages":[
+				{"role":"tool","tool_call_id":"call_1","content":[{"type":"file","file":{"file_url":"https://example.com/a.pdf"}}]}]}`,
+			want: false,
+		},
+		{
+			name: "smuggled pdf on a system turn",
+			body: `{"messages":[
+				{"role":"system","content":[{"type":"image_url","image_url":{"url":"data:application/pdf;base64,JVBERi0="}}]}]}`,
+			want: false,
+		},
+		{
+			name: "system document beside a user document still routes native",
+			body: `{"messages":[
+				{"role":"system","content":[{"type":"file","file":{"file_url":"https://example.com/ignored.pdf"}}]},
+				{"role":"user","content":[{"type":"file","file":{"file_url":"https://example.com/a.pdf"}}]}]}`,
+			want: true,
+		},
+		{
 			name: "base64 image data uri",
 			body: `{"messages":[{"role":"user","content":[
 				{"type":"image_url","image_url":{"url":"data:image/png;base64,iVBORw0="}}]}]}`,

--- a/internal/anthropicegress/detect_test.go
+++ b/internal/anthropicegress/detect_test.go
@@ -2,12 +2,17 @@ package anthropicegress
 
 import "testing"
 
-func TestNeedsNativeRouting(t *testing.T) {
-	tests := []struct {
-		name string
-		body string
-		want bool
-	}{
+type routingCase struct {
+	name string
+	body string
+	want bool
+}
+
+// routingCases is shared by TestNeedsNativeRouting and the pre-filter test, so
+// the cheap byte scan is exercised against every routing decision the detector
+// makes rather than a separate list that can drift from it.
+func routingCases() []routingCase {
+	return []routingCase{
 		{
 			name: "file part",
 			body: `{"messages":[{"role":"user","content":[
@@ -41,11 +46,30 @@ func TestNeedsNativeRouting(t *testing.T) {
 				{"role":"user","content":[{"type":"file","file":{"file_url":"https://example.com/a.pdf"}}]}]}`,
 			want: true,
 		},
+		// An unrecognised role is translated as a user turn, so its document
+		// arrives intact.
+		{
+			name: "file part on an unrecognised role",
+			body: `{"messages":[{"role":"human","content":[
+				{"type":"file","file":{"file_url":"https://example.com/a.pdf"}}]}]}`,
+			want: true,
+		},
+		// A part type spelled with \uXXXX escapes carries none of the literal
+		// hint bytes, so the pre-filter has to fall through to the full decode
+		// on the escape alone.
+		{
+			name: "file part spelled with unicode escapes",
+			body: `{"messages":[{"role":"user","content":[
+				{"type":"\u0066ile","\u0066ile":{"\u0066ile_url":"https://example.com/a.pdf"}}]}]}`,
+			want: true,
+		},
+		// document is not in Anthropic's assistant content-block schema, so an
+		// assistant document is a guaranteed 400 on the native route.
 		{
 			name: "file part on an assistant turn",
 			body: `{"messages":[{"role":"assistant","content":[
 				{"type":"file","file":{"file_url":"https://example.com/a.pdf"}}]}]}`,
-			want: true,
+			want: false,
 		},
 		// The roles below drop their documents in translation (system and
 		// developer content is flattened into the system prompt, a tool message
@@ -119,6 +143,73 @@ func TestNeedsNativeRouting(t *testing.T) {
 			body: `{"messages":[{"role":"user","content":[{"type":"image_url"}]}]}`,
 			want: false,
 		},
+		// Every shape below is one TestTranslateRequest_UnusableFileAndImagePartsAreDropped
+		// pins as DROPPED by translateBlocks. Routing native on one would send a
+		// request whose document never arrives and answer it with a confident
+		// 200; the compat endpoint 400s instead, so they stay on it. These cases
+		// exist to keep the gate and the translation from drifting apart.
+		{
+			name: "file part carrying only a file_id",
+			body: `{"messages":[{"role":"user","content":[
+				{"type":"text","text":"summarise"},
+				{"type":"file","file":{"file_id":"file-abc"}}]}]}`,
+			want: false,
+		},
+		{
+			name: "file part with no file object",
+			body: `{"messages":[{"role":"user","content":[{"type":"file"}]}]}`,
+			want: false,
+		},
+		{
+			name: "file part with an empty file object",
+			body: `{"messages":[{"role":"user","content":[{"type":"file","file":{}}]}]}`,
+			want: false,
+		},
+		{
+			name: "file_data that is not a data uri",
+			body: `{"messages":[{"role":"user","content":[
+				{"type":"file","file":{"file_data":"JVBERi0="}}]}]}`,
+			want: false,
+		},
+		{
+			name: "file_data data uri with no payload",
+			body: `{"messages":[{"role":"user","content":[
+				{"type":"file","file":{"file_data":"data:application/pdf;base64,"}}]}]}`,
+			want: false,
+		},
+		{
+			name: "undecodable base64 text payload",
+			body: `{"messages":[{"role":"user","content":[
+				{"type":"file","file":{"file_data":"data:text/plain;base64,!!not-base64!!"}}]}]}`,
+			want: false,
+		},
+		{
+			name: "malformed percent-encoded pdf file part",
+			body: `{"messages":[{"role":"user","content":[
+				{"type":"file","file":{"file_data":"data:application/pdf,%PDF-1.4"}}]}]}`,
+			want: false,
+		},
+		{
+			name: "malformed percent-encoded pdf in the image slot",
+			body: `{"messages":[{"role":"user","content":[
+				{"type":"image_url","image_url":{"url":"data:application/pdf,%PDF-1.4"}}]}]}`,
+			want: false,
+		},
+		{
+			name: "empty image url",
+			body: `{"messages":[{"role":"user","content":[
+				{"type":"image_url","image_url":{"url":""}}]}]}`,
+			want: false,
+		},
+		// A dropped file part beside a translatable one still routes native:
+		// the surviving document is what the request is about.
+		{
+			name: "dropped file part beside a usable one",
+			body: `{"messages":[{"role":"user","content":[
+				{"type":"file","file":{"file_id":"file-abc"}},
+				{"type":"file","file":{"file_url":"https://example.com/a.pdf"}}]}]}`,
+			want: true,
+		},
 		{
 			name: "text parts only",
 			body: `{"messages":[{"role":"user","content":[{"type":"text","text":"hello"}]}]}`,
@@ -150,11 +241,73 @@ func TestNeedsNativeRouting(t *testing.T) {
 			want: false,
 		},
 	}
+}
 
-	for _, tt := range tests {
+func TestNeedsNativeRouting(t *testing.T) {
+	for _, tt := range routingCases() {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := NeedsNativeRouting([]byte(tt.body)); got != tt.want {
 				t.Errorf("NeedsNativeRouting() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// The pre-filter is one-sided: it may let a body through that does not route
+// native, but it must never rule out one that does, or the adapter silently
+// stops working for the requests it exists to serve.
+func TestMayNeedNativeRouting_NeverRulesOutANativeRequest(t *testing.T) {
+	for _, tt := range routingCases() {
+		if !tt.want {
+			continue
+		}
+		t.Run(tt.name, func(t *testing.T) {
+			if !mayNeedNativeRouting([]byte(tt.body)) {
+				t.Errorf("mayNeedNativeRouting() = false for a body that routes native")
+			}
+		})
+	}
+}
+
+// An image/* media type outside the four Anthropic accepts is a document as far
+// as the translation is concerned, so the pre-filter must not mistake the
+// "image/" prefix for proof that a payload is an image.
+func TestMayNeedNativeRouting_UnacceptedImageTypeFallsThrough(t *testing.T) {
+	body := []byte(`{"messages":[{"role":"user","content":[
+		{"type":"image_url","image_url":{"url":"data:image/svg+xml;base64,PHN2Zz4="}}]}]}`)
+	if !mayNeedNativeRouting(body) {
+		t.Fatal("mayNeedNativeRouting() = false for an image/svg+xml data uri")
+	}
+	if !NeedsNativeRouting(body) {
+		t.Error("NeedsNativeRouting() = false, want true (svg is not an Anthropic image type)")
+	}
+}
+
+// The bodies the pre-filter is for: the text and vision traffic that makes up
+// almost every request to an Anthropic provider, ruled out on a byte scan
+// without materialising a single base64 payload.
+func TestMayNeedNativeRouting_SkipsTheCommonPath(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{"plain text", `{"model":"claude-sonnet-4-5","messages":[{"role":"user","content":"hello"}]}`},
+		{"text parts", `{"messages":[{"role":"user","content":[{"type":"text","text":"hello"}]}]}`},
+		{"http image url", `{"messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":"https://example.com/cat.png"}}]}]}`},
+		// The payload the pre-filter is worth having for: a base64 image never
+		// routes native, and the full decode would copy the whole thing.
+		{"base64 png", `{"messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":"data:image/png;base64,iVBORw0="}}]}]}`},
+		{"base64 jpeg, upper case media type", `{"messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":"data:IMAGE/JPEG;base64,/9j/4AAQ"}}]}]}`},
+		{"base64 webp with extra parameters", `{"messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":"data:image/webp;charset=binary;base64,UklGRg=="}}]}]}`},
+		{"percent-encoded gif", `{"messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":"data:image/gif,GIF89a"}}]}]}`},
+		{"two base64 images", `{"messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":"data:image/png;base64,iVBORw0="}},{"type":"image_url","image_url":{"url":"data:image/jpeg;base64,/9j/4AAQ"}}]}]}`},
+		{"tool result", `{"messages":[{"role":"tool","tool_call_id":"call_1","content":"42"}]}`},
+		{"empty body", ``},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if mayNeedNativeRouting([]byte(tt.body)) {
+				t.Errorf("mayNeedNativeRouting() = true, want false (no full decode needed)")
 			}
 		})
 	}

--- a/internal/anthropicegress/detect_test.go
+++ b/internal/anthropicegress/detect_test.go
@@ -1,0 +1,118 @@
+package anthropicegress
+
+import "testing"
+
+func TestNeedsNativeRouting(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{
+			name: "file part",
+			body: `{"messages":[{"role":"user","content":[
+				{"type":"text","text":"summarise"},
+				{"type":"file","file":{"file_data":"data:application/pdf;base64,JVBERi0="}}]}]}`,
+			want: true,
+		},
+		{
+			name: "file part by url",
+			body: `{"messages":[{"role":"user","content":[
+				{"type":"file","file":{"file_url":"https://example.com/a.pdf"}}]}]}`,
+			want: true,
+		},
+		{
+			name: "pdf smuggled through the image slot",
+			body: `{"messages":[{"role":"user","content":[
+				{"type":"image_url","image_url":{"url":"data:application/pdf;base64,JVBERi0="}}]}]}`,
+			want: true,
+		},
+		{
+			name: "data uri with no media type",
+			body: `{"messages":[{"role":"user","content":[
+				{"type":"image_url","image_url":{"url":"data:;base64,JVBERi0="}}]}]}`,
+			want: true,
+		},
+		{
+			name: "file part in a later message",
+			body: `{"messages":[
+				{"role":"user","content":"hello"},
+				{"role":"assistant","content":"hi"},
+				{"role":"user","content":[{"type":"file","file":{"file_url":"https://example.com/a.pdf"}}]}]}`,
+			want: true,
+		},
+		{
+			name: "base64 image data uri",
+			body: `{"messages":[{"role":"user","content":[
+				{"type":"image_url","image_url":{"url":"data:image/png;base64,iVBORw0="}}]}]}`,
+			want: false,
+		},
+		{
+			name: "image media type is matched case-insensitively",
+			body: `{"messages":[{"role":"user","content":[
+				{"type":"image_url","image_url":{"url":"data:IMAGE/JPEG;base64,/9j/4AAQ"}}]}]}`,
+			want: false,
+		},
+		{
+			name: "image data uri with extra parameters",
+			body: `{"messages":[{"role":"user","content":[
+				{"type":"image_url","image_url":{"url":"data:image/webp;charset=binary;base64,UklGRg=="}}]}]}`,
+			want: false,
+		},
+		{
+			name: "http image url",
+			body: `{"messages":[{"role":"user","content":[
+				{"type":"image_url","image_url":{"url":"https://example.com/cat.png"}}]}]}`,
+			want: false,
+		},
+		{
+			name: "truncated data uri stays on the compat path",
+			body: `{"messages":[{"role":"user","content":[
+				{"type":"image_url","image_url":{"url":"data:application/pdf;base64"}}]}]}`,
+			want: false,
+		},
+		{
+			name: "image_url part with no image_url object",
+			body: `{"messages":[{"role":"user","content":[{"type":"image_url"}]}]}`,
+			want: false,
+		},
+		{
+			name: "text parts only",
+			body: `{"messages":[{"role":"user","content":[{"type":"text","text":"hello"}]}]}`,
+			want: false,
+		},
+		{
+			name: "string content",
+			body: `{"messages":[{"role":"user","content":"hello"}]}`,
+			want: false,
+		},
+		{
+			name: "null content",
+			body: `{"messages":[{"role":"assistant","content":null}]}`,
+			want: false,
+		},
+		{
+			name: "no messages",
+			body: `{"model":"claude-sonnet-4-5"}`,
+			want: false,
+		},
+		{
+			name: "unparseable body",
+			body: `{"messages":[`,
+			want: false,
+		},
+		{
+			name: "empty body",
+			body: ``,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NeedsNativeRouting([]byte(tt.body)); got != tt.want {
+				t.Errorf("NeedsNativeRouting() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/anthropicegress/detect_test.go
+++ b/internal/anthropicegress/detect_test.go
@@ -190,6 +190,12 @@ func routingCases() []routingCase {
 			want: false,
 		},
 		{
+			name: "malformed percent-encoded image payload",
+			body: `{"messages":[{"role":"user","content":[
+				{"type":"image_url","image_url":{"url":"data:image/png,%ZZ"}}]}]}`,
+			want: false,
+		},
+		{
 			name: "malformed percent-encoded pdf in the image slot",
 			body: `{"messages":[{"role":"user","content":[
 				{"type":"image_url","image_url":{"url":"data:application/pdf,%PDF-1.4"}}]}]}`,
@@ -199,6 +205,24 @@ func routingCases() []routingCase {
 			name: "empty image url",
 			body: `{"messages":[{"role":"user","content":[
 				{"type":"image_url","image_url":{"url":""}}]}]}`,
+			want: false,
+		},
+		// The pre-filter rules out a body whose only payload is an accepted
+		// image, so these pair one with a part that trips the filter. That is
+		// what puts a real image in front of routesNative, where imageBlock has
+		// to resolve it to an image rather than a document.
+		{
+			name: "base64 image beside a dropped file part",
+			body: `{"messages":[{"role":"user","content":[
+				{"type":"image_url","image_url":{"url":"data:image/png;base64,iVBORw0="}},
+				{"type":"file","file":{"file_id":"file-abc"}}]}]}`,
+			want: false,
+		},
+		{
+			name: "http image url beside a dropped file part",
+			body: `{"messages":[{"role":"user","content":[
+				{"type":"image_url","image_url":{"url":"https://example.com/cat.png"}},
+				{"type":"file","file":{"file_id":"file-abc"}}]}]}`,
 			want: false,
 		},
 		// A dropped file part beside a translatable one still routes native:

--- a/internal/anthropicegress/request.go
+++ b/internal/anthropicegress/request.go
@@ -165,7 +165,7 @@ type antThinking struct {
 func TranslateRequest(chatBody []byte) (body []byte, model string, stream bool, err error) {
 	var req oaiRequest
 	if err := json.Unmarshal(chatBody, &req); err != nil {
-		return nil, "", false, fmt.Errorf("anthropicegress: invalid request body: %w", err)
+		return nil, "", false, fmt.Errorf("anthropicegress: invalid request body: %s", jsonFault(err, len(chatBody)))
 	}
 	if req.Model == "" {
 		return nil, "", false, errors.New("anthropicegress: model is required")

--- a/internal/anthropicegress/request.go
+++ b/internal/anthropicegress/request.go
@@ -395,15 +395,14 @@ func imageBlock(u string) (antBlock, bool) {
 		return antBlock{Type: "image", Source: &antSource{Type: "url", URL: u}}, true
 	}
 	if imageMediaTypes[du.mediaType] {
-		// A payload without the ";base64" marker is percent-encoded bytes, not
-		// base64; forwarding it under a base64 source would ship garbage.
-		if !du.base64 {
+		data, ok := base64Payload(du)
+		if !ok {
 			return antBlock{}, false
 		}
 		return antBlock{Type: "image", Source: &antSource{
 			Type:      "base64",
 			MediaType: du.mediaType,
-			Data:      du.payload,
+			Data:      data,
 		}}, true
 	}
 	return documentBlock(du)
@@ -439,16 +438,31 @@ func documentBlock(du dataURI) (antBlock, bool) {
 			Data:      text,
 		}}, true
 	}
-	// Same rule as an image source: without the ";base64" marker the payload is
-	// percent-encoded bytes and cannot be passed off as base64.
-	if !du.base64 {
+	data, ok := base64Payload(du)
+	if !ok {
 		return antBlock{}, false
 	}
 	return antBlock{Type: "document", Source: &antSource{
 		Type:      "base64",
 		MediaType: documentMediaType,
-		Data:      du.payload,
+		Data:      data,
 	}}, true
+}
+
+// base64Payload returns a data: URI payload in the base64 an Anthropic base64
+// source expects. A ";base64" payload is already there; anything else is
+// percent-encoded bytes, which re-encode losslessly. ok is false when the
+// percent-decode fails — malformed input is unrecoverable, and forwarding it
+// under a base64 label would ship garbage.
+func base64Payload(du dataURI) (string, bool) {
+	if du.base64 {
+		return du.payload, true
+	}
+	raw, err := url.PathUnescape(du.payload)
+	if err != nil {
+		return "", false
+	}
+	return base64.StdEncoding.EncodeToString([]byte(raw)), true
 }
 
 // decodePayload returns the plain-text bytes of a data: URI payload: base64 for

--- a/internal/anthropicegress/request.go
+++ b/internal/anthropicegress/request.go
@@ -10,6 +10,7 @@ package anthropicegress
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -167,7 +168,7 @@ func TranslateRequest(chatBody []byte) (body []byte, model string, stream bool, 
 		return nil, "", false, fmt.Errorf("anthropicegress: invalid request body: %w", err)
 	}
 	if req.Model == "" {
-		return nil, "", false, fmt.Errorf("anthropicegress: model is required")
+		return nil, "", false, errors.New("anthropicegress: model is required")
 	}
 
 	out := antRequest{
@@ -184,7 +185,7 @@ func TranslateRequest(chatBody []byte) (body []byte, model string, stream bool, 
 		return nil, "", false, err
 	}
 	if len(messages) == 0 {
-		return nil, "", false, fmt.Errorf("anthropicegress: at least one user or assistant message with content is required")
+		return nil, "", false, errors.New("anthropicegress: at least one user or assistant message with content is required")
 	}
 	out.System = system
 	out.Messages = messages
@@ -199,12 +200,13 @@ func TranslateRequest(chatBody []byte) (body []byte, model string, stream bool, 
 	}
 
 	// max_completion_tokens is the modern OpenAI field and wins over the
-	// deprecated max_tokens when both are present.
+	// deprecated max_tokens when both are present. A non-positive value is no
+	// budget at all — Anthropic 400s on it — so it falls through to the default.
 	out.MaxTokens = req.MaxCompletionTokens
-	if out.MaxTokens == 0 {
+	if out.MaxTokens <= 0 {
 		out.MaxTokens = req.MaxTokens
 	}
-	if out.MaxTokens == 0 {
+	if out.MaxTokens <= 0 {
 		out.MaxTokens = DefaultMaxTokens
 	}
 
@@ -228,18 +230,19 @@ func TranslateRequest(chatBody []byte) (body []byte, model string, stream bool, 
 
 // translateMessages converts the OpenAI message list into the Anthropic system
 // prompt plus the conversation turns. system/developer messages lift out of the
-// turn list (Anthropic has no such role), and a run of role:"tool" messages
-// coalesces into one user turn.
+// turn list (Anthropic has no such role), a run of role:"tool" messages
+// coalesces into one user turn, and adjacent same-role turns merge.
 func translateMessages(in []oaiMessage) (string, []antMessage, error) {
 	var systemParts []string
 	var out []antMessage
-	// Open run of tool_result blocks: Anthropic rejects a sequence of user
-	// turns each holding a single result, so consecutive tool messages
-	// accumulate here and flush as one turn when the run ends.
+	// Open run of tool_result blocks: Anthropic's turns must alternate and it
+	// rejects a sequence of user turns each holding a single result, so
+	// consecutive tool messages accumulate here and flush as one turn when the
+	// run ends.
 	var toolRun []antBlock
 	flushToolRun := func() {
 		if len(toolRun) > 0 {
-			out = append(out, antMessage{Role: "user", Content: toolRun})
+			out = appendTurn(out, antMessage{Role: "user", Content: toolRun})
 			toolRun = nil
 		}
 	}
@@ -255,32 +258,52 @@ func translateMessages(in []oaiMessage) (string, []antMessage, error) {
 		}
 		flushToolRun()
 
-		switch m.Role {
-		case "system", "developer":
+		if m.Role == "system" || m.Role == "developer" {
 			if text := flattenText(m.Content); text != "" {
 				systemParts = append(systemParts, text)
 			}
-		case "assistant":
-			msg, err := translateTurn("assistant", m)
-			if err != nil {
-				return "", nil, err
-			}
-			if msg != nil {
-				out = append(out, *msg)
-			}
-		default: // "user" and anything unrecognised
-			msg, err := translateTurn("user", m)
-			if err != nil {
-				return "", nil, err
-			}
-			if msg != nil {
-				out = append(out, *msg)
-			}
+			continue
+		}
+
+		role := "user" // anything unrecognised is a user turn
+		if m.Role == "assistant" {
+			role = "assistant"
+		}
+		msg, err := translateTurn(role, m)
+		if err != nil {
+			return "", nil, err
+		}
+		if msg != nil {
+			out = appendTurn(out, *msg)
 		}
 	}
 	flushToolRun()
 
 	return strings.Join(systemParts, "\n\n"), out, nil
+}
+
+// appendTurn adds a turn to the conversation, merging its content into the
+// previous turn when the roles match. Anthropic's turns must alternate, and
+// OpenAI accepts (and clients send) adjacent same-role messages.
+func appendTurn(out []antMessage, m antMessage) []antMessage {
+	if len(out) == 0 || out[len(out)-1].Role != m.Role {
+		return append(out, m)
+	}
+	prev := &out[len(out)-1]
+	prev.Content = append(contentBlocks(prev.Content), contentBlocks(m.Content)...)
+	return out
+}
+
+// contentBlocks normalises a turn's content to blocks so two turns can merge:
+// a plain string is promoted to a single text block.
+func contentBlocks(content any) []antBlock {
+	switch c := content.(type) {
+	case []antBlock:
+		return c
+	case string:
+		return []antBlock{{Type: "text", Text: c}}
+	}
+	return nil
 }
 
 // translateTurn builds one Anthropic turn from an OpenAI message. It returns
@@ -372,6 +395,11 @@ func imageBlock(u string) (antBlock, bool) {
 		return antBlock{Type: "image", Source: &antSource{Type: "url", URL: u}}, true
 	}
 	if imageMediaTypes[du.mediaType] {
+		// A payload without the ";base64" marker is percent-encoded bytes, not
+		// base64; forwarding it under a base64 source would ship garbage.
+		if !du.base64 {
+			return antBlock{}, false
+		}
 		return antBlock{Type: "image", Source: &antSource{
 			Type:      "base64",
 			MediaType: du.mediaType,
@@ -411,6 +439,11 @@ func documentBlock(du dataURI) (antBlock, bool) {
 			Data:      text,
 		}}, true
 	}
+	// Same rule as an image source: without the ";base64" marker the payload is
+	// percent-encoded bytes and cannot be passed off as base64.
+	if !du.base64 {
+		return antBlock{}, false
+	}
 	return antBlock{Type: "document", Source: &antSource{
 		Type:      "base64",
 		MediaType: documentMediaType,
@@ -436,8 +469,9 @@ func decodePayload(du dataURI) (string, bool) {
 }
 
 // translateTools maps OpenAI function tools onto Anthropic tools. Anthropic
-// requires an input_schema, so a tool that declares no parameters gets an empty
-// object schema instead of a missing field.
+// requires an input_schema and reads it as a JSON object, so a tool whose
+// parameters are absent, null or any other non-object gets an empty object
+// schema instead of a field the upstream rejects.
 func translateTools(in []oaiTool) []antTool {
 	if len(in) == 0 {
 		return nil
@@ -445,7 +479,7 @@ func translateTools(in []oaiTool) []antTool {
 	out := make([]antTool, 0, len(in))
 	for _, t := range in {
 		schema := t.Function.Parameters
-		if len(schema) == 0 || string(schema) == "null" {
+		if len(schema) == 0 || schema[0] != '{' {
 			schema = json.RawMessage(`{"type":"object","properties":{}}`)
 		}
 		out = append(out, antTool{
@@ -500,9 +534,11 @@ func toolInput(arguments string) json.RawMessage {
 	return raw
 }
 
-// asJSONString returns the value when raw is a JSON string literal, ok=false
-// otherwise (including arrays and objects). Used to tell plain-string message
-// content from a content-part array.
+// asJSONString returns the value when raw is a JSON string literal, and
+// ok=false for arrays, objects and an absent field. JSON null decodes into a
+// string without error, so it yields ("", true) — which every caller wants,
+// since a null content field carries nothing either way. Used to tell
+// plain-string message content from a content-part array.
 func asJSONString(raw json.RawMessage) (string, bool) {
 	if len(raw) == 0 {
 		return "", false

--- a/internal/anthropicegress/request.go
+++ b/internal/anthropicegress/request.go
@@ -14,6 +14,8 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+
+	"github.com/hugalafutro/model-hotel/internal/jsonfault"
 )
 
 // DefaultMaxTokens is the max_tokens supplied when the caller sends none.
@@ -165,7 +167,7 @@ type antThinking struct {
 func TranslateRequest(chatBody []byte) (body []byte, model string, stream bool, err error) {
 	var req oaiRequest
 	if err := json.Unmarshal(chatBody, &req); err != nil {
-		return nil, "", false, fmt.Errorf("anthropicegress: invalid request body: %s", jsonFault(err, len(chatBody)))
+		return nil, "", false, fmt.Errorf("anthropicegress: invalid request body: %s", jsonfault.Describe(err, len(chatBody)))
 	}
 	if req.Model == "" {
 		return nil, "", false, errors.New("anthropicegress: model is required")
@@ -353,7 +355,7 @@ func translateBlocks(raw json.RawMessage) ([]antBlock, error) {
 
 	var parts []oaiContentPart
 	if err := json.Unmarshal(raw, &parts); err != nil {
-		return nil, fmt.Errorf("anthropicegress: invalid message content: %w", err)
+		return nil, fmt.Errorf("anthropicegress: invalid message content: %s", jsonfault.Describe(err, len(raw)))
 	}
 
 	var blocks []antBlock

--- a/internal/anthropicegress/request.go
+++ b/internal/anthropicegress/request.go
@@ -1,0 +1,552 @@
+// Package anthropicegress translates between the OpenAI chat-completions wire
+// shape and Anthropic's native Messages shape. It is an *egress* dialect
+// adapter (the mirror image of internal/anthropic, which translates on
+// ingress): Anthropic's OpenAI-compat /v1/chat/completions endpoint cannot
+// carry a document — a request holding an OpenAI file content part comes back
+// as "messages.0.user.content.str: Input should be a valid string" — so a
+// request carrying one is rewritten here and sent to /v1/messages instead.
+package anthropicegress
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// DefaultMaxTokens is the max_tokens supplied when the caller sends none.
+// Anthropic requires the field, and a request that omits it 400s rather than
+// falling back to a model default.
+const DefaultMaxTokens = 4096
+
+// documentMediaType is the media type stamped on a base64 document source.
+// Anthropic's base64 document source accepts application/pdf only, and the
+// media type on the way in is unreliable — clients hand us PDFs labelled
+// application/octet-stream, or unlabelled inside an image part.
+const documentMediaType = "application/pdf"
+
+// thinkingBudgets maps OpenAI reasoning_effort to an Anthropic thinking budget
+// (tokens). An effort outside this map — "none", "minimal", absent — leaves the
+// thinking block off entirely; Anthropic's minimum budget is 1024, so there is
+// no budget that expresses "reason a little".
+var thinkingBudgets = map[string]int{
+	"low":    1024,
+	"medium": 4096,
+	"high":   8192,
+}
+
+// --- Incoming OpenAI chat-completions request shape ---
+//
+// Only the fields the translation needs are decoded. Params with no Anthropic
+// equivalent (frequency_penalty, presence_penalty, n, seed, response_format,
+// logprobs, stream_options, ...) are dropped by omission.
+
+type oaiRequest struct {
+	Model               string          `json:"model"`
+	Messages            []oaiMessage    `json:"messages"`
+	MaxTokens           int             `json:"max_tokens"`
+	MaxCompletionTokens int             `json:"max_completion_tokens"`
+	Stream              bool            `json:"stream"`
+	Temperature         *float64        `json:"temperature"`
+	TopP                *float64        `json:"top_p"`
+	TopK                *int            `json:"top_k"`
+	Stop                json.RawMessage `json:"stop"` // string OR []string
+	Tools               []oaiTool       `json:"tools"`
+	ToolChoice          json.RawMessage `json:"tool_choice"`
+	ReasoningEffort     string          `json:"reasoning_effort"`
+}
+
+type oaiMessage struct {
+	Role       string          `json:"role"`
+	Content    json.RawMessage `json:"content"` // string OR []oaiContentPart OR null
+	ToolCalls  []oaiToolCall   `json:"tool_calls"`
+	ToolCallID string          `json:"tool_call_id"`
+}
+
+type oaiContentPart struct {
+	Type     string `json:"type"` // "text" | "image_url" | "file"
+	Text     string `json:"text"`
+	ImageURL *struct {
+		URL string `json:"url"`
+	} `json:"image_url"`
+	File *oaiFile `json:"file"`
+}
+
+type oaiFile struct {
+	FileData string `json:"file_data"` // data: URI
+	FileURL  string `json:"file_url"`
+}
+
+type oaiToolCall struct {
+	ID       string `json:"id"`
+	Function struct {
+		Name      string `json:"name"`
+		Arguments string `json:"arguments"` // a JSON *string*
+	} `json:"function"`
+}
+
+type oaiTool struct {
+	Function struct {
+		Name        string          `json:"name"`
+		Description string          `json:"description"`
+		Parameters  json.RawMessage `json:"parameters"`
+	} `json:"function"`
+}
+
+// --- Outgoing Anthropic Messages request shape ---
+
+type antRequest struct {
+	Model         string         `json:"model"`
+	MaxTokens     int            `json:"max_tokens"`
+	Messages      []antMessage   `json:"messages"`
+	System        string         `json:"system,omitempty"`
+	Stream        bool           `json:"stream,omitempty"`
+	Temperature   *float64       `json:"temperature,omitempty"`
+	TopP          *float64       `json:"top_p,omitempty"`
+	TopK          *int           `json:"top_k,omitempty"`
+	StopSequences []string       `json:"stop_sequences,omitempty"`
+	Tools         []antTool      `json:"tools,omitempty"`
+	ToolChoice    *antToolChoice `json:"tool_choice,omitempty"`
+	Thinking      *antThinking   `json:"thinking,omitempty"`
+}
+
+// antMessage carries Content as any because Anthropic accepts either a plain
+// string or an array of blocks, and a string round-trips a string-content
+// message unchanged.
+type antMessage struct {
+	Role    string `json:"role"`
+	Content any    `json:"content"`
+}
+
+type antBlock struct {
+	Type string `json:"type"` // "text" | "image" | "document" | "tool_use" | "tool_result"
+	// text
+	Text string `json:"text,omitempty"`
+	// image / document
+	Source *antSource `json:"source,omitempty"`
+	// tool_use
+	ID    string          `json:"id,omitempty"`
+	Name  string          `json:"name,omitempty"`
+	Input json.RawMessage `json:"input,omitempty"`
+	// tool_result
+	ToolUseID string `json:"tool_use_id,omitempty"`
+	Content   string `json:"content,omitempty"`
+}
+
+type antSource struct {
+	Type      string `json:"type"` // "base64" | "url" | "text"
+	MediaType string `json:"media_type,omitempty"`
+	Data      string `json:"data,omitempty"`
+	URL       string `json:"url,omitempty"`
+}
+
+type antTool struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	InputSchema json.RawMessage `json:"input_schema"`
+}
+
+type antToolChoice struct {
+	Type string `json:"type"` // "auto" | "any" | "tool"
+	Name string `json:"name,omitempty"`
+}
+
+type antThinking struct {
+	Type         string `json:"type"` // "enabled"
+	BudgetTokens int    `json:"budget_tokens"`
+}
+
+// TranslateRequest converts an OpenAI chat-completions request body into an
+// Anthropic Messages request body. It returns the Anthropic JSON, the model
+// string (verbatim — the body carries it, and the caller keeps it for routing
+// and metering) and the stream flag.
+func TranslateRequest(chatBody []byte) (body []byte, model string, stream bool, err error) {
+	var req oaiRequest
+	if err := json.Unmarshal(chatBody, &req); err != nil {
+		return nil, "", false, fmt.Errorf("anthropicegress: invalid request body: %w", err)
+	}
+	if req.Model == "" {
+		return nil, "", false, fmt.Errorf("anthropicegress: model is required")
+	}
+
+	out := antRequest{
+		Model:         req.Model,
+		Stream:        req.Stream,
+		Temperature:   req.Temperature,
+		TopP:          req.TopP,
+		TopK:          req.TopK,
+		StopSequences: decodeStop(req.Stop),
+	}
+
+	system, messages, err := translateMessages(req.Messages)
+	if err != nil {
+		return nil, "", false, err
+	}
+	if len(messages) == 0 {
+		return nil, "", false, fmt.Errorf("anthropicegress: at least one user or assistant message with content is required")
+	}
+	out.System = system
+	out.Messages = messages
+
+	// tool_choice "none" has no Anthropic equivalent; the tools array goes with
+	// it, or the model would treat the request as tools-with-auto and call one
+	// against the caller's intent.
+	choice, keepTools := translateToolChoice(req.ToolChoice)
+	out.ToolChoice = choice
+	if keepTools {
+		out.Tools = translateTools(req.Tools)
+	}
+
+	// max_completion_tokens is the modern OpenAI field and wins over the
+	// deprecated max_tokens when both are present.
+	out.MaxTokens = req.MaxCompletionTokens
+	if out.MaxTokens == 0 {
+		out.MaxTokens = req.MaxTokens
+	}
+	if out.MaxTokens == 0 {
+		out.MaxTokens = DefaultMaxTokens
+	}
+
+	if budget, ok := thinkingBudgets[strings.ToLower(req.ReasoningEffort)]; ok {
+		out.Thinking = &antThinking{Type: "enabled", BudgetTokens: budget}
+		// Anthropic rejects sampling knobs alongside thinking, and requires
+		// max_tokens strictly greater than the budget — the remainder is the
+		// visible answer's allowance, so it gets a full default budget.
+		out.Temperature, out.TopP, out.TopK = nil, nil, nil
+		if out.MaxTokens <= budget {
+			out.MaxTokens = budget + DefaultMaxTokens
+		}
+	}
+
+	body, err = json.Marshal(out)
+	if err != nil {
+		return nil, "", false, fmt.Errorf("anthropicegress: marshal messages request: %w", err)
+	}
+	return body, req.Model, req.Stream, nil
+}
+
+// translateMessages converts the OpenAI message list into the Anthropic system
+// prompt plus the conversation turns. system/developer messages lift out of the
+// turn list (Anthropic has no such role), and a run of role:"tool" messages
+// coalesces into one user turn.
+func translateMessages(in []oaiMessage) (string, []antMessage, error) {
+	var systemParts []string
+	var out []antMessage
+	// Open run of tool_result blocks: Anthropic rejects a sequence of user
+	// turns each holding a single result, so consecutive tool messages
+	// accumulate here and flush as one turn when the run ends.
+	var toolRun []antBlock
+	flushToolRun := func() {
+		if len(toolRun) > 0 {
+			out = append(out, antMessage{Role: "user", Content: toolRun})
+			toolRun = nil
+		}
+	}
+
+	for _, m := range in {
+		if m.Role == "tool" {
+			toolRun = append(toolRun, antBlock{
+				Type:      "tool_result",
+				ToolUseID: m.ToolCallID,
+				Content:   flattenText(m.Content),
+			})
+			continue
+		}
+		flushToolRun()
+
+		switch m.Role {
+		case "system", "developer":
+			if text := flattenText(m.Content); text != "" {
+				systemParts = append(systemParts, text)
+			}
+		case "assistant":
+			msg, err := translateTurn("assistant", m)
+			if err != nil {
+				return "", nil, err
+			}
+			if msg != nil {
+				out = append(out, *msg)
+			}
+		default: // "user" and anything unrecognised
+			msg, err := translateTurn("user", m)
+			if err != nil {
+				return "", nil, err
+			}
+			if msg != nil {
+				out = append(out, *msg)
+			}
+		}
+	}
+	flushToolRun()
+
+	return strings.Join(systemParts, "\n\n"), out, nil
+}
+
+// translateTurn builds one Anthropic turn from an OpenAI message. It returns
+// nil when the message carries nothing Anthropic can hold (empty or null
+// content and no tool calls).
+func translateTurn(role string, m oaiMessage) (*antMessage, error) {
+	// Plain string content stays a plain string — but only when nothing else
+	// has to ride along in the same turn.
+	if s, ok := asJSONString(m.Content); ok && len(m.ToolCalls) == 0 {
+		if s == "" {
+			return nil, nil
+		}
+		return &antMessage{Role: role, Content: s}, nil
+	}
+
+	blocks, err := translateBlocks(m.Content)
+	if err != nil {
+		return nil, err
+	}
+	for _, tc := range m.ToolCalls {
+		blocks = append(blocks, antBlock{
+			Type:  "tool_use",
+			ID:    tc.ID,
+			Name:  tc.Function.Name,
+			Input: toolInput(tc.Function.Arguments),
+		})
+	}
+	if len(blocks) == 0 {
+		return nil, nil
+	}
+	return &antMessage{Role: role, Content: blocks}, nil
+}
+
+// translateBlocks converts an OpenAI message content field (string, part array
+// or null) into Anthropic content blocks. Part types with no Anthropic
+// equivalent are dropped rather than forwarded raw.
+func translateBlocks(raw json.RawMessage) ([]antBlock, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil, nil
+	}
+	if s, ok := asJSONString(raw); ok {
+		if s == "" {
+			return nil, nil
+		}
+		return []antBlock{{Type: "text", Text: s}}, nil
+	}
+
+	var parts []oaiContentPart
+	if err := json.Unmarshal(raw, &parts); err != nil {
+		return nil, fmt.Errorf("anthropicegress: invalid message content: %w", err)
+	}
+
+	var blocks []antBlock
+	for _, p := range parts {
+		switch p.Type {
+		case "text":
+			// An empty text block marshals as {"type":"text"}, which Anthropic
+			// rejects — drop it.
+			if p.Text == "" {
+				continue
+			}
+			blocks = append(blocks, antBlock{Type: "text", Text: p.Text})
+		case "image_url":
+			if p.ImageURL == nil || p.ImageURL.URL == "" {
+				continue
+			}
+			if b, ok := imageBlock(p.ImageURL.URL); ok {
+				blocks = append(blocks, b)
+			}
+		case "file":
+			if p.File == nil {
+				continue
+			}
+			if b, ok := fileBlock(p.File); ok {
+				blocks = append(blocks, b)
+			}
+		}
+	}
+	return blocks, nil
+}
+
+// imageBlock maps an OpenAI image_url value onto an Anthropic block: a base64
+// image source for a data: URI with an image media type, a url image source for
+// an ordinary URL, and a document for a data: URI carrying anything else (which
+// is how clients smuggle PDFs past the compat endpoint's file-part rejection).
+func imageBlock(u string) (antBlock, bool) {
+	du, ok := parseDataURI(u)
+	if !ok {
+		return antBlock{Type: "image", Source: &antSource{Type: "url", URL: u}}, true
+	}
+	if imageMediaTypes[du.mediaType] {
+		return antBlock{Type: "image", Source: &antSource{
+			Type:      "base64",
+			MediaType: du.mediaType,
+			Data:      du.payload,
+		}}, true
+	}
+	return documentBlock(du)
+}
+
+// fileBlock maps an OpenAI file part onto an Anthropic document block.
+func fileBlock(f *oaiFile) (antBlock, bool) {
+	if f.FileData != "" {
+		du, ok := parseDataURI(f.FileData)
+		if !ok {
+			return antBlock{}, false
+		}
+		return documentBlock(du)
+	}
+	if f.FileURL != "" {
+		return antBlock{Type: "document", Source: &antSource{Type: "url", URL: f.FileURL}}, true
+	}
+	return antBlock{}, false
+}
+
+// documentBlock builds a document block from a parsed data: URI. A text/plain
+// payload becomes a text source carrying the decoded text; everything else
+// becomes a base64 PDF source, the only binary document Anthropic accepts.
+func documentBlock(du dataURI) (antBlock, bool) {
+	if du.mediaType == "text/plain" {
+		text, ok := decodePayload(du)
+		if !ok || text == "" {
+			return antBlock{}, false
+		}
+		return antBlock{Type: "document", Source: &antSource{
+			Type:      "text",
+			MediaType: "text/plain",
+			Data:      text,
+		}}, true
+	}
+	return antBlock{Type: "document", Source: &antSource{
+		Type:      "base64",
+		MediaType: documentMediaType,
+		Data:      du.payload,
+	}}, true
+}
+
+// decodePayload returns the plain-text bytes of a data: URI payload: base64 for
+// a ";base64" URI, percent-decoding otherwise.
+func decodePayload(du dataURI) (string, bool) {
+	if du.base64 {
+		decoded, err := base64.StdEncoding.DecodeString(du.payload)
+		if err != nil {
+			return "", false
+		}
+		return string(decoded), true
+	}
+	unescaped, err := url.PathUnescape(du.payload)
+	if err != nil {
+		return "", false
+	}
+	return unescaped, true
+}
+
+// translateTools maps OpenAI function tools onto Anthropic tools. Anthropic
+// requires an input_schema, so a tool that declares no parameters gets an empty
+// object schema instead of a missing field.
+func translateTools(in []oaiTool) []antTool {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]antTool, 0, len(in))
+	for _, t := range in {
+		schema := t.Function.Parameters
+		if len(schema) == 0 || string(schema) == "null" {
+			schema = json.RawMessage(`{"type":"object","properties":{}}`)
+		}
+		out = append(out, antTool{
+			Name:        t.Function.Name,
+			Description: t.Function.Description,
+			InputSchema: schema,
+		})
+	}
+	return out
+}
+
+// translateToolChoice maps the OpenAI tool_choice union onto Anthropic's. The
+// second return reports whether tools may be sent at all: it is false only for
+// "none", which Anthropic cannot express and which therefore drops the tools
+// array along with the choice.
+func translateToolChoice(raw json.RawMessage) (*antToolChoice, bool) {
+	if len(raw) == 0 {
+		return nil, true
+	}
+	if s, ok := asJSONString(raw); ok {
+		switch s {
+		case "auto":
+			return &antToolChoice{Type: "auto"}, true
+		case "required":
+			return &antToolChoice{Type: "any"}, true
+		case "none":
+			return nil, false
+		}
+		return nil, true
+	}
+
+	var tc struct {
+		Function struct {
+			Name string `json:"name"`
+		} `json:"function"`
+	}
+	if json.Unmarshal(raw, &tc) == nil && tc.Function.Name != "" {
+		return &antToolChoice{Type: "tool", Name: tc.Function.Name}, true
+	}
+	return nil, true
+}
+
+// toolInput converts OpenAI's tool-call arguments — a JSON string — into the
+// JSON object Anthropic's tool_use input expects. Empty, unparseable and
+// non-object arguments all become an empty object; anything else would be a
+// malformed tool_use block the model cannot read.
+func toolInput(arguments string) json.RawMessage {
+	raw := json.RawMessage(strings.TrimSpace(arguments))
+	if len(raw) == 0 || raw[0] != '{' || !json.Valid(raw) {
+		return json.RawMessage(`{}`)
+	}
+	return raw
+}
+
+// asJSONString returns the value when raw is a JSON string literal, ok=false
+// otherwise (including arrays and objects). Used to tell plain-string message
+// content from a content-part array.
+func asJSONString(raw json.RawMessage) (string, bool) {
+	if len(raw) == 0 {
+		return "", false
+	}
+	var s string
+	if json.Unmarshal(raw, &s) == nil {
+		return s, true
+	}
+	return "", false
+}
+
+// flattenText reduces a content field (string or part array) to plain text, for
+// the fields Anthropic types as text: the system prompt and tool_result content.
+func flattenText(raw json.RawMessage) string {
+	if s, ok := asJSONString(raw); ok {
+		return s
+	}
+	var parts []oaiContentPart
+	if json.Unmarshal(raw, &parts) == nil {
+		var sb strings.Builder
+		for _, p := range parts {
+			if p.Type == "" || p.Type == "text" {
+				sb.WriteString(p.Text)
+			}
+		}
+		return sb.String()
+	}
+	return ""
+}
+
+// decodeStop accepts OpenAI's string-or-array stop field.
+func decodeStop(raw json.RawMessage) []string {
+	if len(raw) == 0 {
+		return nil
+	}
+	if s, ok := asJSONString(raw); ok {
+		if s == "" {
+			return nil
+		}
+		return []string{s}
+	}
+	var list []string
+	if json.Unmarshal(raw, &list) == nil {
+		return list
+	}
+	return nil
+}

--- a/internal/anthropicegress/request_test.go
+++ b/internal/anthropicegress/request_test.go
@@ -1,6 +1,7 @@
 package anthropicegress
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -217,11 +218,11 @@ func TestTranslateRequest_UnusableFileAndImagePartsAreDropped(t *testing.T) {
 		{name: "file part with an empty file object", part: `{"type":"file","file":{}}`},
 		{name: "file_data that is not a data uri", part: `{"type":"file","file":{"file_data":"JVBERi0="}}`},
 		{name: "undecodable base64 text payload", part: `{"type":"file","file":{"file_data":"data:text/plain;base64,!!not-base64!!"}}`},
-		// A payload with no ";base64" marker is percent-encoded bytes: passing
-		// it off as a base64 source would ship garbage Anthropic rejects.
-		{name: "percent-encoded image payload", part: `{"type":"image_url","image_url":{"url":"data:image/png,%89PNG%0D%0A"}}`},
-		{name: "percent-encoded pdf in the image slot", part: `{"type":"image_url","image_url":{"url":"data:application/pdf,%PDF-1.4"}}`},
-		{name: "percent-encoded pdf file part", part: `{"type":"file","file":{"file_data":"data:application/pdf,%PDF-1.4"}}`},
+		// Malformed percent-encoding is unrecoverable: "%PD" and "%ZZ" are not
+		// escapes, so there are no bytes to re-encode as base64.
+		{name: "malformed percent-encoded image payload", part: `{"type":"image_url","image_url":{"url":"data:image/png,%ZZ"}}`},
+		{name: "malformed percent-encoded pdf in the image slot", part: `{"type":"image_url","image_url":{"url":"data:application/pdf,%PDF-1.4"}}`},
+		{name: "malformed percent-encoded pdf file part", part: `{"type":"file","file":{"file_data":"data:application/pdf,%PDF-1.4"}}`},
 	}
 
 	for _, tt := range tests {
@@ -247,6 +248,67 @@ func TestTranslateRequest_PlainTextDataURIIsPercentDecoded(t *testing.T) {
 	}
 	if src := sourceOf(t, blocks[0]); src.Type != "text" || src.Data != "hello world" {
 		t.Errorf("source = %+v, want a text source carrying the decoded text", src)
+	}
+}
+
+func TestTranslateRequest_PercentEncodedPayloadIsReEncodedAsBase64(t *testing.T) {
+	// A data: URI with no ";base64" marker carries percent-encoded bytes. The
+	// conversion is lossless, so the bytes are re-encoded rather than dropped:
+	// dropping would leave the request asking about a document that is not
+	// attached, and the model would answer confidently about nothing.
+	tests := []struct {
+		name          string
+		part          string
+		wantType      string
+		wantMediaType string
+		wantBytes     string
+	}{
+		{
+			name:          "image slot",
+			part:          `{"type":"image_url","image_url":{"url":"data:image/png,%89PNG%0D%0A"}}`,
+			wantType:      "image",
+			wantMediaType: "image/png",
+			wantBytes:     "\x89PNG\r\n",
+		},
+		{
+			name:          "pdf in the image slot",
+			part:          `{"type":"image_url","image_url":{"url":"data:application/pdf,%25PDF-1.4"}}`,
+			wantType:      "document",
+			wantMediaType: "application/pdf",
+			wantBytes:     "%PDF-1.4",
+		},
+		{
+			name:          "pdf file part",
+			part:          `{"type":"file","file":{"file_data":"data:application/pdf,%25PDF-1.4%0A%25%E2%E3%CF%D3"}}`,
+			wantType:      "document",
+			wantMediaType: "application/pdf",
+			wantBytes:     "%PDF-1.4\n%\xe2\xe3\xcf\xd3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := translate(t, `{"model":"m","messages":[{"role":"user","content":[`+tt.part+`]}]}`)
+
+			blocks := blocksOf(t, req.Messages[0])
+			if len(blocks) != 1 {
+				t.Fatalf("got %d blocks, want 1: %+v", len(blocks), blocks)
+			}
+			if blocks[0].Type != tt.wantType {
+				t.Errorf("block type = %q, want %q", blocks[0].Type, tt.wantType)
+			}
+			src := sourceOf(t, blocks[0])
+			if src.Type != "base64" || src.MediaType != tt.wantMediaType {
+				t.Errorf("source = %+v, want a base64 %s source", src, tt.wantMediaType)
+			}
+			decoded, err := base64.StdEncoding.DecodeString(src.Data)
+			if err != nil {
+				t.Fatalf("source data is not valid base64: %v", err)
+			}
+			if string(decoded) != tt.wantBytes {
+				t.Errorf("decoded data = %q, want the original bytes %q", decoded, tt.wantBytes)
+			}
+		})
 	}
 }
 

--- a/internal/anthropicegress/request_test.go
+++ b/internal/anthropicegress/request_test.go
@@ -40,19 +40,21 @@ type translatedTool struct {
 }
 
 type translatedBlock struct {
-	Type   string `json:"type"`
-	Text   string `json:"text"`
-	Source *struct {
-		Type      string `json:"type"`
-		MediaType string `json:"media_type"`
-		Data      string `json:"data"`
-		URL       string `json:"url"`
-	} `json:"source"`
-	ID        string          `json:"id"`
-	Name      string          `json:"name"`
-	Input     json.RawMessage `json:"input"`
-	ToolUseID string          `json:"tool_use_id"`
-	Content   string          `json:"content"`
+	Type      string            `json:"type"`
+	Text      string            `json:"text"`
+	Source    *translatedSource `json:"source"`
+	ID        string            `json:"id"`
+	Name      string            `json:"name"`
+	Input     json.RawMessage   `json:"input"`
+	ToolUseID string            `json:"tool_use_id"`
+	Content   string            `json:"content"`
+}
+
+type translatedSource struct {
+	Type      string `json:"type"`
+	MediaType string `json:"media_type"`
+	Data      string `json:"data"`
+	URL       string `json:"url"`
 }
 
 // translate runs TranslateRequest and decodes the result for assertions.
@@ -77,6 +79,16 @@ func blocksOf(t *testing.T, m translatedMessage) []translatedBlock {
 		t.Fatalf("message content is not a block array: %v", err)
 	}
 	return blocks
+}
+
+// sourceOf returns a block's image/document source, failing rather than
+// panicking when the block carries none.
+func sourceOf(t *testing.T, b translatedBlock) translatedSource {
+	t.Helper()
+	if b.Source == nil {
+		t.Fatalf("block %+v carries no source", b)
+	}
+	return *b.Source
 }
 
 func TestTranslateRequest_PassesThroughModelAndStream(t *testing.T) {
@@ -170,44 +182,58 @@ func TestTranslateRequest_ContentParts(t *testing.T) {
 	if blocks[0].Type != "text" || blocks[0].Text != "look" {
 		t.Errorf("block 0 = %+v, want a text block", blocks[0])
 	}
-	if blocks[1].Type != "image" || blocks[1].Source.Type != "base64" ||
-		blocks[1].Source.MediaType != "image/png" || blocks[1].Source.Data != "iVBORw0=" {
-		t.Errorf("block 1 = %+v, want a base64 image source", blocks[1])
+
+	want := []struct {
+		blockType string
+		source    translatedSource
+		desc      string
+	}{
+		{"image", translatedSource{Type: "base64", MediaType: "image/png", Data: "iVBORw0="}, "a base64 image source"},
+		{"image", translatedSource{Type: "url", URL: "https://example.com/cat.png"}, "a url image source"},
+		{"document", translatedSource{Type: "base64", MediaType: "application/pdf", Data: "JVBERi0="}, "the image-slot PDF as a base64 document"},
+		{"document", translatedSource{Type: "base64", MediaType: "application/pdf", Data: "SGVsbG8="}, "a base64 document source"},
+		{"document", translatedSource{Type: "text", MediaType: "text/plain", Data: "hello world"}, "a text document source carrying the decoded text"},
+		{"document", translatedSource{Type: "url", URL: "https://example.com/report.pdf"}, "a url document source"},
 	}
-	if blocks[2].Type != "image" || blocks[2].Source.Type != "url" ||
-		blocks[2].Source.URL != "https://example.com/cat.png" {
-		t.Errorf("block 2 = %+v, want a url image source", blocks[2])
-	}
-	if blocks[3].Type != "document" || blocks[3].Source.Type != "base64" ||
-		blocks[3].Source.MediaType != "application/pdf" || blocks[3].Source.Data != "JVBERi0=" {
-		t.Errorf("block 3 = %+v, want the image-slot PDF as a base64 document", blocks[3])
-	}
-	if blocks[4].Type != "document" || blocks[4].Source.Type != "base64" ||
-		blocks[4].Source.MediaType != "application/pdf" || blocks[4].Source.Data != "SGVsbG8=" {
-		t.Errorf("block 4 = %+v, want a base64 document source", blocks[4])
-	}
-	if blocks[5].Type != "document" || blocks[5].Source.Type != "text" ||
-		blocks[5].Source.MediaType != "text/plain" || blocks[5].Source.Data != "hello world" {
-		t.Errorf("block 5 = %+v, want a text document source carrying the decoded text", blocks[5])
-	}
-	if blocks[6].Type != "document" || blocks[6].Source.Type != "url" ||
-		blocks[6].Source.URL != "https://example.com/report.pdf" {
-		t.Errorf("block 6 = %+v, want a url document source", blocks[6])
+	for i, w := range want {
+		b := blocks[i+1]
+		if b.Type != w.blockType {
+			t.Errorf("block %d type = %q, want %q", i+1, b.Type, w.blockType)
+			continue
+		}
+		if got := sourceOf(t, b); got != w.source {
+			t.Errorf("block %d source = %+v, want %s: %+v", i+1, got, w.desc, w.source)
+		}
 	}
 }
 
 func TestTranslateRequest_UnusableFileAndImagePartsAreDropped(t *testing.T) {
-	req := translate(t, `{"model":"m","messages":[{"role":"user","content":[
-		{"type":"text","text":"look"},
-		{"type":"image_url","image_url":{"url":""}},
-		{"type":"file"},
-		{"type":"file","file":{}},
-		{"type":"file","file":{"file_data":"JVBERi0="}},
-		{"type":"file","file":{"file_data":"data:text/plain;base64,!!not-base64!!"}}]}]}`)
+	tests := []struct {
+		name string
+		part string
+	}{
+		{name: "empty image url", part: `{"type":"image_url","image_url":{"url":""}}`},
+		{name: "file part with no file object", part: `{"type":"file"}`},
+		{name: "file part with an empty file object", part: `{"type":"file","file":{}}`},
+		{name: "file_data that is not a data uri", part: `{"type":"file","file":{"file_data":"JVBERi0="}}`},
+		{name: "undecodable base64 text payload", part: `{"type":"file","file":{"file_data":"data:text/plain;base64,!!not-base64!!"}}`},
+		// A payload with no ";base64" marker is percent-encoded bytes: passing
+		// it off as a base64 source would ship garbage Anthropic rejects.
+		{name: "percent-encoded image payload", part: `{"type":"image_url","image_url":{"url":"data:image/png,%89PNG%0D%0A"}}`},
+		{name: "percent-encoded pdf in the image slot", part: `{"type":"image_url","image_url":{"url":"data:application/pdf,%PDF-1.4"}}`},
+		{name: "percent-encoded pdf file part", part: `{"type":"file","file":{"file_data":"data:application/pdf,%PDF-1.4"}}`},
+	}
 
-	blocks := blocksOf(t, req.Messages[0])
-	if len(blocks) != 1 || blocks[0].Type != "text" {
-		t.Errorf("blocks = %+v, want only the text block", blocks)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := translate(t, `{"model":"m","messages":[{"role":"user","content":[
+				{"type":"text","text":"look"},`+tt.part+`]}]}`)
+
+			blocks := blocksOf(t, req.Messages[0])
+			if len(blocks) != 1 || blocks[0].Type != "text" {
+				t.Errorf("blocks = %+v, want only the text block", blocks)
+			}
+		})
 	}
 }
 
@@ -216,8 +242,78 @@ func TestTranslateRequest_PlainTextDataURIIsPercentDecoded(t *testing.T) {
 		{"type":"file","file":{"file_data":"data:text/plain,hello%20world"}}]}]}`)
 
 	blocks := blocksOf(t, req.Messages[0])
-	if len(blocks) != 1 || blocks[0].Source.Type != "text" || blocks[0].Source.Data != "hello world" {
-		t.Errorf("blocks = %+v, want one text document source carrying the decoded text", blocks)
+	if len(blocks) != 1 {
+		t.Fatalf("got %d blocks, want one text document: %+v", len(blocks), blocks)
+	}
+	if src := sourceOf(t, blocks[0]); src.Type != "text" || src.Data != "hello world" {
+		t.Errorf("source = %+v, want a text source carrying the decoded text", src)
+	}
+}
+
+func TestTranslateRequest_AdjacentSameRoleTurnsMerge(t *testing.T) {
+	// Anthropic's turns must alternate; OpenAI accepts adjacent same-role
+	// messages, so they have to be folded into one turn.
+	req := translate(t, `{"model":"m","messages":[
+		{"role":"user","content":"hello"},
+		{"role":"user","content":[{"type":"text","text":"and again"}]},
+		{"role":"assistant","content":"hi"},
+		{"role":"user","content":"third"},
+		{"role":"user","content":"fourth"}]}`)
+
+	if len(req.Messages) != 3 {
+		t.Fatalf("got %d messages, want 3: %+v", len(req.Messages), req.Messages)
+	}
+	roles := []string{"user", "assistant", "user"}
+	for i, want := range roles {
+		if req.Messages[i].Role != want {
+			t.Errorf("message %d role = %q, want %q", i, req.Messages[i].Role, want)
+		}
+	}
+
+	merged := blocksOf(t, req.Messages[0])
+	if len(merged) != 2 || merged[0].Text != "hello" || merged[1].Text != "and again" {
+		t.Errorf("first turn = %+v, want the string promoted to a text block and both parts merged", merged)
+	}
+	// The assistant turn breaks the run: the later pair merges on its own.
+	if string(req.Messages[1].Content) != `"hi"` {
+		t.Errorf("assistant content = %s, want the plain string kept", req.Messages[1].Content)
+	}
+	tail := blocksOf(t, req.Messages[2])
+	if len(tail) != 2 || tail[0].Text != "third" || tail[1].Text != "fourth" {
+		t.Errorf("last turn = %+v, want the trailing pair merged", tail)
+	}
+}
+
+func TestTranslateRequest_AdjacentAssistantTurnsMerge(t *testing.T) {
+	req := translate(t, `{"model":"m","messages":[
+		{"role":"user","content":"weather?"},
+		{"role":"assistant","content":"checking"},
+		{"role":"assistant","content":null,"tool_calls":[
+			{"id":"call_1","function":{"name":"get_weather","arguments":"{}"}}]},
+		{"role":"tool","tool_call_id":"call_1","content":"sunny"}]}`)
+
+	if len(req.Messages) != 3 {
+		t.Fatalf("got %d messages, want 3: %+v", len(req.Messages), req.Messages)
+	}
+	blocks := blocksOf(t, req.Messages[1])
+	if len(blocks) != 2 || blocks[0].Type != "text" || blocks[1].Type != "tool_use" {
+		t.Errorf("assistant turn = %+v, want the text and the tool_use merged into one turn", blocks)
+	}
+}
+
+func TestTranslateRequest_ToolResultsMergeIntoAPrecedingUserTurn(t *testing.T) {
+	req := translate(t, `{"model":"m","messages":[
+		{"role":"assistant","content":null,"tool_calls":[
+			{"id":"call_1","function":{"name":"get_weather","arguments":"{}"}}]},
+		{"role":"user","content":"and be brief"},
+		{"role":"tool","tool_call_id":"call_1","content":"sunny"}]}`)
+
+	if len(req.Messages) != 2 {
+		t.Fatalf("got %d messages, want 2: %+v", len(req.Messages), req.Messages)
+	}
+	blocks := blocksOf(t, req.Messages[1])
+	if len(blocks) != 2 || blocks[0].Type != "text" || blocks[1].Type != "tool_result" {
+		t.Errorf("user turn = %+v, want the text and the tool_result in one turn", blocks)
 	}
 }
 
@@ -312,11 +408,13 @@ func TestTranslateRequest_ConsecutiveToolResultsCoalesce(t *testing.T) {
 func TestTranslateRequest_ToolResultContentPartsFlatten(t *testing.T) {
 	req := translate(t, `{"model":"m","messages":[
 		{"role":"user","content":"weather?"},
+		{"role":"assistant","content":null,"tool_calls":[
+			{"id":"call_1","function":{"name":"get_weather","arguments":"{}"}}]},
 		{"role":"tool","tool_call_id":"call_1","content":[
 			{"type":"text","text":"sun"},
 			{"type":"text","text":"ny"}]}]}`)
 
-	results := blocksOf(t, req.Messages[1])
+	results := blocksOf(t, req.Messages[2])
 	if len(results) != 1 || results[0].Content != "sunny" {
 		t.Errorf("tool_result = %+v, want the parts flattened to text", results)
 	}
@@ -327,10 +425,13 @@ func TestTranslateRequest_ToolsGetAnInputSchema(t *testing.T) {
 		"tools":[
 			{"type":"function","function":{"name":"get_weather","description":"Weather.",
 				"parameters":{"type":"object","properties":{"city":{"type":"string"}}}}},
-			{"type":"function","function":{"name":"ping"}}]}`)
+			{"type":"function","function":{"name":"ping"}},
+			{"type":"function","function":{"name":"nullish","parameters":null}},
+			{"type":"function","function":{"name":"stringy","parameters":"notanobject"}},
+			{"type":"function","function":{"name":"listy","parameters":[]}}]}`)
 
-	if len(req.Tools) != 2 {
-		t.Fatalf("got %d tools, want 2", len(req.Tools))
+	if len(req.Tools) != 5 {
+		t.Fatalf("got %d tools, want 5", len(req.Tools))
 	}
 	if req.Tools[0].Name != "get_weather" || req.Tools[0].Description != "Weather." {
 		t.Errorf("tool 0 = %+v, want name and description carried over", req.Tools[0])
@@ -338,8 +439,13 @@ func TestTranslateRequest_ToolsGetAnInputSchema(t *testing.T) {
 	if !strings.Contains(string(req.Tools[0].InputSchema), `"city"`) {
 		t.Errorf("tool 0 input_schema = %s, want the parameters verbatim", req.Tools[0].InputSchema)
 	}
-	if string(req.Tools[1].InputSchema) != `{"type":"object","properties":{}}` {
-		t.Errorf("tool 1 input_schema = %s, want an empty object schema", req.Tools[1].InputSchema)
+	// Absent, null and non-object parameters all fall back to a schema
+	// Anthropic accepts, rather than a field it rejects.
+	for _, i := range []int{1, 2, 3, 4} {
+		if string(req.Tools[i].InputSchema) != `{"type":"object","properties":{}}` {
+			t.Errorf("tool %d (%s) input_schema = %s, want an empty object schema",
+				i, req.Tools[i].Name, req.Tools[i].InputSchema)
+		}
 	}
 }
 
@@ -414,6 +520,16 @@ func TestTranslateRequest_MaxTokens(t *testing.T) {
 			body: `{"model":"m","messages":[{"role":"user","content":"hi"}],"max_tokens":100,"max_completion_tokens":200}`,
 			want: 200,
 		},
+		{
+			name: "negative max_tokens falls through to the default",
+			body: `{"model":"m","messages":[{"role":"user","content":"hi"}],"max_tokens":-1}`,
+			want: DefaultMaxTokens,
+		},
+		{
+			name: "negative max_completion_tokens falls back to max_tokens",
+			body: `{"model":"m","messages":[{"role":"user","content":"hi"}],"max_tokens":100,"max_completion_tokens":-1}`,
+			want: 100,
+		},
 	}
 
 	for _, tt := range tests {
@@ -450,9 +566,13 @@ func TestTranslateRequest_SamplingAndStop(t *testing.T) {
 	if err != nil {
 		t.Fatalf("TranslateRequest failed: %v", err)
 	}
-	for _, dropped := range []string{"frequency_penalty", "presence_penalty", `"n"`, "seed", "logprobs", "response_format", "stream_options"} {
-		if strings.Contains(string(out), dropped) {
-			t.Errorf("translated body still carries %s: %s", dropped, out)
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(out, &fields); err != nil {
+		t.Fatalf("translated body is not a JSON object: %v", err)
+	}
+	for _, dropped := range []string{"frequency_penalty", "presence_penalty", "n", "seed", "logprobs", "response_format", "stream_options"} {
+		if _, ok := fields[dropped]; ok {
+			t.Errorf("translated body still carries the %q field", dropped)
 		}
 	}
 }
@@ -491,14 +611,17 @@ func TestTranslateRequest_EmptyTurnsAreDropped(t *testing.T) {
 		{"role":"user","content":"hi"},
 		{"role":"assistant","content":""},
 		{"role":"assistant","content":[{"type":"text","text":""}]},
+		{"role":"assistant","content":"answer"},
 		{"role":"user","content":null},
 		{"role":"user","content":"still here"}]}`)
 
-	if len(req.Messages) != 2 {
-		t.Fatalf("got %d messages, want the two non-empty turns: %+v", len(req.Messages), req.Messages)
+	if len(req.Messages) != 3 {
+		t.Fatalf("got %d messages, want the three non-empty turns: %+v", len(req.Messages), req.Messages)
 	}
-	if string(req.Messages[1].Content) != `"still here"` {
-		t.Errorf("second message content = %s, want the trailing user turn", req.Messages[1].Content)
+	for i, want := range []string{`"hi"`, `"answer"`, `"still here"`} {
+		if got := string(req.Messages[i].Content); got != want {
+			t.Errorf("message %d content = %s, want %s", i, got, want)
+		}
 	}
 }
 
@@ -567,6 +690,9 @@ func TestTranslateRequest_ThinkingRaisesMaxTokensAboveTheBudget(t *testing.T) {
 
 			if req.MaxTokens != tt.want {
 				t.Errorf("max_tokens = %d, want %d", req.MaxTokens, tt.want)
+			}
+			if req.Thinking == nil {
+				t.Fatal("thinking omitted, want it enabled for reasoning_effort high")
 			}
 			if req.MaxTokens <= req.Thinking.BudgetTokens {
 				t.Errorf("max_tokens %d is not above the thinking budget %d", req.MaxTokens, req.Thinking.BudgetTokens)

--- a/internal/anthropicegress/request_test.go
+++ b/internal/anthropicegress/request_test.go
@@ -817,7 +817,7 @@ func TestTranslateRequest_DecodeErrorOmitsPayload(t *testing.T) {
 		{
 			name:    "type error",
 			payload: `{"model":8675309.42}`,
-			want:    "undecodable JSON (",
+			want:    "unexpected JSON value at byte ",
 			secret:  "8675309.42",
 		},
 	}
@@ -834,5 +834,22 @@ func TestTranslateRequest_DecodeErrorOmitsPayload(t *testing.T) {
 				t.Errorf("error leaked the payload: %q", err)
 			}
 		})
+	}
+}
+
+func TestTranslateRequest_MessageContentErrorOmitsPayload(t *testing.T) {
+	// The per-message content decoder sees the user's own prompt. A syntax
+	// error cannot reach it (the outer body parse fails first), but a type
+	// error can, and *json.UnmarshalTypeError prints the offending literal
+	// verbatim — so that is what must not survive into the error.
+	_, _, _, err := TranslateRequest([]byte(`{"model":"m","messages":[{"role":"user","content":[8675309.42]}]}`))
+	if err == nil {
+		t.Fatal("expected an error for undecodable message content")
+	}
+	if !strings.HasPrefix(err.Error(), "anthropicegress: invalid message content: unexpected JSON value at byte ") {
+		t.Errorf("error = %q, want the sanitized unexpected-value form", err)
+	}
+	if strings.Contains(err.Error(), "8675309.42") {
+		t.Errorf("error leaked the message content: %q", err)
 	}
 }

--- a/internal/anthropicegress/request_test.go
+++ b/internal/anthropicegress/request_test.go
@@ -1,0 +1,611 @@
+package anthropicegress
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// translatedRequest is the Anthropic Messages body as the assertions read it.
+type translatedRequest struct {
+	Model         string              `json:"model"`
+	MaxTokens     int                 `json:"max_tokens"`
+	Messages      []translatedMessage `json:"messages"`
+	System        string              `json:"system"`
+	Stream        bool                `json:"stream"`
+	Temperature   *float64            `json:"temperature"`
+	TopP          *float64            `json:"top_p"`
+	TopK          *int                `json:"top_k"`
+	StopSequences []string            `json:"stop_sequences"`
+	Tools         []translatedTool    `json:"tools"`
+	ToolChoice    *struct {
+		Type string `json:"type"`
+		Name string `json:"name"`
+	} `json:"tool_choice"`
+	Thinking *struct {
+		Type         string `json:"type"`
+		BudgetTokens int    `json:"budget_tokens"`
+	} `json:"thinking"`
+}
+
+type translatedMessage struct {
+	Role    string          `json:"role"`
+	Content json.RawMessage `json:"content"`
+}
+
+type translatedTool struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	InputSchema json.RawMessage `json:"input_schema"`
+}
+
+type translatedBlock struct {
+	Type   string `json:"type"`
+	Text   string `json:"text"`
+	Source *struct {
+		Type      string `json:"type"`
+		MediaType string `json:"media_type"`
+		Data      string `json:"data"`
+		URL       string `json:"url"`
+	} `json:"source"`
+	ID        string          `json:"id"`
+	Name      string          `json:"name"`
+	Input     json.RawMessage `json:"input"`
+	ToolUseID string          `json:"tool_use_id"`
+	Content   string          `json:"content"`
+}
+
+// translate runs TranslateRequest and decodes the result for assertions.
+func translate(t *testing.T, body string) translatedRequest {
+	t.Helper()
+	out, _, _, err := TranslateRequest([]byte(body))
+	if err != nil {
+		t.Fatalf("TranslateRequest failed: %v", err)
+	}
+	var req translatedRequest
+	if err := json.Unmarshal(out, &req); err != nil {
+		t.Fatalf("translated body is not valid JSON: %v", err)
+	}
+	return req
+}
+
+// blocksOf decodes one message's content as a block array.
+func blocksOf(t *testing.T, m translatedMessage) []translatedBlock {
+	t.Helper()
+	var blocks []translatedBlock
+	if err := json.Unmarshal(m.Content, &blocks); err != nil {
+		t.Fatalf("message content is not a block array: %v", err)
+	}
+	return blocks
+}
+
+func TestTranslateRequest_PassesThroughModelAndStream(t *testing.T) {
+	body := []byte(`{"model":"claude-sonnet-4-5","stream":true,"messages":[{"role":"user","content":"hi"}]}`)
+
+	out, model, stream, err := TranslateRequest(body)
+	if err != nil {
+		t.Fatalf("TranslateRequest failed: %v", err)
+	}
+	if model != "claude-sonnet-4-5" {
+		t.Errorf("model = %q, want claude-sonnet-4-5", model)
+	}
+	if !stream {
+		t.Error("stream = false, want true")
+	}
+
+	var req translatedRequest
+	if err := json.Unmarshal(out, &req); err != nil {
+		t.Fatalf("translated body is not valid JSON: %v", err)
+	}
+	if req.Model != "claude-sonnet-4-5" {
+		t.Errorf("body model = %q, want claude-sonnet-4-5", req.Model)
+	}
+	if !req.Stream {
+		t.Error("body stream = false, want true")
+	}
+}
+
+func TestTranslateRequest_StringContentStaysAString(t *testing.T) {
+	req := translate(t, `{"model":"m","messages":[
+		{"role":"user","content":"hello"},
+		{"role":"assistant","content":"hi"}]}`)
+
+	if len(req.Messages) != 2 {
+		t.Fatalf("got %d messages, want 2", len(req.Messages))
+	}
+	if got := string(req.Messages[0].Content); got != `"hello"` {
+		t.Errorf("user content = %s, want a plain JSON string", got)
+	}
+	if req.Messages[1].Role != "assistant" || string(req.Messages[1].Content) != `"hi"` {
+		t.Errorf("assistant message = %+v, want a plain-string assistant turn", req.Messages[1])
+	}
+}
+
+func TestTranslateRequest_SystemAndDeveloperLiftToSystem(t *testing.T) {
+	req := translate(t, `{"model":"m","messages":[
+		{"role":"system","content":"Be terse."},
+		{"role":"developer","content":[{"type":"text","text":"Cite sources."}]},
+		{"role":"user","content":"hello"}]}`)
+
+	if req.System != "Be terse.\n\nCite sources." {
+		t.Errorf("system = %q, want the two prompts joined by a blank line", req.System)
+	}
+	if len(req.Messages) != 1 || req.Messages[0].Role != "user" {
+		t.Fatalf("messages = %+v, want only the user turn", req.Messages)
+	}
+}
+
+func TestTranslateRequest_EmptySystemMessageIsDropped(t *testing.T) {
+	req := translate(t, `{"model":"m","messages":[
+		{"role":"system","content":""},
+		{"role":"system","content":"Be terse."},
+		{"role":"user","content":"hello"}]}`)
+
+	if req.System != "Be terse." {
+		t.Errorf("system = %q, want only the non-empty prompt", req.System)
+	}
+}
+
+func TestTranslateRequest_ContentParts(t *testing.T) {
+	// "hello world" base64-encoded, as a text/plain file payload arrives.
+	req := translate(t, `{"model":"m","messages":[{"role":"user","content":[
+		{"type":"text","text":"look"},
+		{"type":"text","text":""},
+		{"type":"image_url","image_url":{"url":"data:image/png;base64,iVBORw0="}},
+		{"type":"image_url","image_url":{"url":"https://example.com/cat.png"}},
+		{"type":"image_url","image_url":{"url":"data:application/pdf;base64,JVBERi0="}},
+		{"type":"file","file":{"file_data":"data:application/pdf;base64,SGVsbG8="}},
+		{"type":"file","file":{"file_data":"data:text/plain;base64,aGVsbG8gd29ybGQ="}},
+		{"type":"file","file":{"file_url":"https://example.com/report.pdf"}},
+		{"type":"input_audio","input_audio":{"data":"AAAA","format":"wav"}}]}]}`)
+
+	if len(req.Messages) != 1 {
+		t.Fatalf("got %d messages, want 1", len(req.Messages))
+	}
+	blocks := blocksOf(t, req.Messages[0])
+	if len(blocks) != 7 {
+		t.Fatalf("got %d blocks, want 7 (empty text and the unknown part are dropped): %+v", len(blocks), blocks)
+	}
+
+	if blocks[0].Type != "text" || blocks[0].Text != "look" {
+		t.Errorf("block 0 = %+v, want a text block", blocks[0])
+	}
+	if blocks[1].Type != "image" || blocks[1].Source.Type != "base64" ||
+		blocks[1].Source.MediaType != "image/png" || blocks[1].Source.Data != "iVBORw0=" {
+		t.Errorf("block 1 = %+v, want a base64 image source", blocks[1])
+	}
+	if blocks[2].Type != "image" || blocks[2].Source.Type != "url" ||
+		blocks[2].Source.URL != "https://example.com/cat.png" {
+		t.Errorf("block 2 = %+v, want a url image source", blocks[2])
+	}
+	if blocks[3].Type != "document" || blocks[3].Source.Type != "base64" ||
+		blocks[3].Source.MediaType != "application/pdf" || blocks[3].Source.Data != "JVBERi0=" {
+		t.Errorf("block 3 = %+v, want the image-slot PDF as a base64 document", blocks[3])
+	}
+	if blocks[4].Type != "document" || blocks[4].Source.Type != "base64" ||
+		blocks[4].Source.MediaType != "application/pdf" || blocks[4].Source.Data != "SGVsbG8=" {
+		t.Errorf("block 4 = %+v, want a base64 document source", blocks[4])
+	}
+	if blocks[5].Type != "document" || blocks[5].Source.Type != "text" ||
+		blocks[5].Source.MediaType != "text/plain" || blocks[5].Source.Data != "hello world" {
+		t.Errorf("block 5 = %+v, want a text document source carrying the decoded text", blocks[5])
+	}
+	if blocks[6].Type != "document" || blocks[6].Source.Type != "url" ||
+		blocks[6].Source.URL != "https://example.com/report.pdf" {
+		t.Errorf("block 6 = %+v, want a url document source", blocks[6])
+	}
+}
+
+func TestTranslateRequest_UnusableFileAndImagePartsAreDropped(t *testing.T) {
+	req := translate(t, `{"model":"m","messages":[{"role":"user","content":[
+		{"type":"text","text":"look"},
+		{"type":"image_url","image_url":{"url":""}},
+		{"type":"file"},
+		{"type":"file","file":{}},
+		{"type":"file","file":{"file_data":"JVBERi0="}},
+		{"type":"file","file":{"file_data":"data:text/plain;base64,!!not-base64!!"}}]}]}`)
+
+	blocks := blocksOf(t, req.Messages[0])
+	if len(blocks) != 1 || blocks[0].Type != "text" {
+		t.Errorf("blocks = %+v, want only the text block", blocks)
+	}
+}
+
+func TestTranslateRequest_PlainTextDataURIIsPercentDecoded(t *testing.T) {
+	req := translate(t, `{"model":"m","messages":[{"role":"user","content":[
+		{"type":"file","file":{"file_data":"data:text/plain,hello%20world"}}]}]}`)
+
+	blocks := blocksOf(t, req.Messages[0])
+	if len(blocks) != 1 || blocks[0].Source.Type != "text" || blocks[0].Source.Data != "hello world" {
+		t.Errorf("blocks = %+v, want one text document source carrying the decoded text", blocks)
+	}
+}
+
+func TestTranslateRequest_ToolCallArgumentsBecomeAnObject(t *testing.T) {
+	req := translate(t, `{"model":"m","messages":[
+		{"role":"user","content":"weather?"},
+		{"role":"assistant","content":"checking","tool_calls":[
+			{"id":"call_1","function":{"name":"get_weather","arguments":"{\"city\":\"Oslo\"}"}},
+			{"id":"call_2","function":{"name":"get_time","arguments":""}},
+			{"id":"call_3","function":{"name":"get_news","arguments":"{not json"}},
+			{"id":"call_4","function":{"name":"get_stocks","arguments":"[1,2]"}}]}]}`)
+
+	if len(req.Messages) != 2 {
+		t.Fatalf("got %d messages, want 2", len(req.Messages))
+	}
+	blocks := blocksOf(t, req.Messages[1])
+	if len(blocks) != 5 {
+		t.Fatalf("got %d blocks, want a text block plus four tool_use blocks: %+v", len(blocks), blocks)
+	}
+	if blocks[0].Type != "text" || blocks[0].Text != "checking" {
+		t.Errorf("block 0 = %+v, want the assistant text alongside the calls", blocks[0])
+	}
+
+	wantInputs := []string{`{"city":"Oslo"}`, `{}`, `{}`, `{}`}
+	wantNames := []string{"get_weather", "get_time", "get_news", "get_stocks"}
+	for i, b := range blocks[1:] {
+		if b.Type != "tool_use" {
+			t.Errorf("block %d type = %q, want tool_use", i+1, b.Type)
+		}
+		if b.Name != wantNames[i] {
+			t.Errorf("block %d name = %q, want %q", i+1, b.Name, wantNames[i])
+		}
+		if string(b.Input) != wantInputs[i] {
+			t.Errorf("block %d input = %s, want %s", i+1, b.Input, wantInputs[i])
+		}
+	}
+	if blocks[1].ID != "call_1" {
+		t.Errorf("tool_use id = %q, want call_1", blocks[1].ID)
+	}
+}
+
+func TestTranslateRequest_ToolCallOnlyAssistantTurn(t *testing.T) {
+	req := translate(t, `{"model":"m","messages":[
+		{"role":"user","content":"weather?"},
+		{"role":"assistant","content":null,"tool_calls":[
+			{"id":"call_1","function":{"name":"get_weather","arguments":"{}"}}]}]}`)
+
+	blocks := blocksOf(t, req.Messages[1])
+	if len(blocks) != 1 || blocks[0].Type != "tool_use" {
+		t.Errorf("blocks = %+v, want a single tool_use block", blocks)
+	}
+}
+
+func TestTranslateRequest_ConsecutiveToolResultsCoalesce(t *testing.T) {
+	req := translate(t, `{"model":"m","messages":[
+		{"role":"user","content":"weather?"},
+		{"role":"assistant","content":null,"tool_calls":[
+			{"id":"call_1","function":{"name":"get_weather","arguments":"{}"}},
+			{"id":"call_2","function":{"name":"get_time","arguments":"{}"}}]},
+		{"role":"tool","tool_call_id":"call_1","content":"sunny"},
+		{"role":"tool","tool_call_id":"call_2","content":"12:00"},
+		{"role":"assistant","content":"Sunny at noon."},
+		{"role":"tool","tool_call_id":"call_3","content":"late"}]}`)
+
+	if len(req.Messages) != 5 {
+		t.Fatalf("got %d messages, want 5: %+v", len(req.Messages), req.Messages)
+	}
+	roles := []string{"user", "assistant", "user", "assistant", "user"}
+	for i, want := range roles {
+		if req.Messages[i].Role != want {
+			t.Errorf("message %d role = %q, want %q", i, req.Messages[i].Role, want)
+		}
+	}
+
+	results := blocksOf(t, req.Messages[2])
+	if len(results) != 2 {
+		t.Fatalf("got %d tool_result blocks in the coalesced turn, want 2: %+v", len(results), results)
+	}
+	for i, want := range []struct{ id, content string }{{"call_1", "sunny"}, {"call_2", "12:00"}} {
+		if results[i].Type != "tool_result" || results[i].ToolUseID != want.id || results[i].Content != want.content {
+			t.Errorf("tool_result %d = %+v, want %+v", i, results[i], want)
+		}
+	}
+
+	// The run breaks on the assistant turn: the later tool message opens a new one.
+	tail := blocksOf(t, req.Messages[4])
+	if len(tail) != 1 || tail[0].ToolUseID != "call_3" {
+		t.Errorf("trailing tool turn = %+v, want a single call_3 result", tail)
+	}
+}
+
+func TestTranslateRequest_ToolResultContentPartsFlatten(t *testing.T) {
+	req := translate(t, `{"model":"m","messages":[
+		{"role":"user","content":"weather?"},
+		{"role":"tool","tool_call_id":"call_1","content":[
+			{"type":"text","text":"sun"},
+			{"type":"text","text":"ny"}]}]}`)
+
+	results := blocksOf(t, req.Messages[1])
+	if len(results) != 1 || results[0].Content != "sunny" {
+		t.Errorf("tool_result = %+v, want the parts flattened to text", results)
+	}
+}
+
+func TestTranslateRequest_ToolsGetAnInputSchema(t *testing.T) {
+	req := translate(t, `{"model":"m","messages":[{"role":"user","content":"hi"}],
+		"tools":[
+			{"type":"function","function":{"name":"get_weather","description":"Weather.",
+				"parameters":{"type":"object","properties":{"city":{"type":"string"}}}}},
+			{"type":"function","function":{"name":"ping"}}]}`)
+
+	if len(req.Tools) != 2 {
+		t.Fatalf("got %d tools, want 2", len(req.Tools))
+	}
+	if req.Tools[0].Name != "get_weather" || req.Tools[0].Description != "Weather." {
+		t.Errorf("tool 0 = %+v, want name and description carried over", req.Tools[0])
+	}
+	if !strings.Contains(string(req.Tools[0].InputSchema), `"city"`) {
+		t.Errorf("tool 0 input_schema = %s, want the parameters verbatim", req.Tools[0].InputSchema)
+	}
+	if string(req.Tools[1].InputSchema) != `{"type":"object","properties":{}}` {
+		t.Errorf("tool 1 input_schema = %s, want an empty object schema", req.Tools[1].InputSchema)
+	}
+}
+
+func TestTranslateRequest_ToolChoice(t *testing.T) {
+	tests := []struct {
+		name       string
+		toolChoice string
+		wantType   string
+		wantName   string
+		wantTools  bool
+	}{
+		{name: "absent", toolChoice: "", wantType: "", wantTools: true},
+		{name: "auto", toolChoice: `"auto"`, wantType: "auto", wantTools: true},
+		{name: "required", toolChoice: `"required"`, wantType: "any", wantTools: true},
+		{name: "none drops the tools too", toolChoice: `"none"`, wantType: "", wantTools: false},
+		{
+			name:       "named function",
+			toolChoice: `{"type":"function","function":{"name":"get_weather"}}`,
+			wantType:   "tool",
+			wantName:   "get_weather",
+			wantTools:  true,
+		},
+		{name: "unrecognised string", toolChoice: `"banana"`, wantType: "", wantTools: true},
+		{name: "object with no function name", toolChoice: `{"type":"function"}`, wantType: "", wantTools: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := `{"model":"m","messages":[{"role":"user","content":"hi"}],
+				"tools":[{"type":"function","function":{"name":"get_weather"}}]`
+			if tt.toolChoice != "" {
+				body += `,"tool_choice":` + tt.toolChoice
+			}
+			req := translate(t, body+"}")
+
+			switch {
+			case tt.wantType == "":
+				if req.ToolChoice != nil {
+					t.Errorf("tool_choice = %+v, want it omitted", req.ToolChoice)
+				}
+			case req.ToolChoice == nil:
+				t.Fatalf("tool_choice omitted, want type %q", tt.wantType)
+			case req.ToolChoice.Type != tt.wantType || req.ToolChoice.Name != tt.wantName:
+				t.Errorf("tool_choice = %+v, want type %q name %q", req.ToolChoice, tt.wantType, tt.wantName)
+			}
+
+			if gotTools := len(req.Tools) > 0; gotTools != tt.wantTools {
+				t.Errorf("tools present = %v, want %v", gotTools, tt.wantTools)
+			}
+		})
+	}
+}
+
+func TestTranslateRequest_MaxTokens(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want int
+	}{
+		{
+			name: "default when neither field is set",
+			body: `{"model":"m","messages":[{"role":"user","content":"hi"}]}`,
+			want: DefaultMaxTokens,
+		},
+		{
+			name: "max_tokens",
+			body: `{"model":"m","messages":[{"role":"user","content":"hi"}],"max_tokens":100}`,
+			want: 100,
+		},
+		{
+			name: "max_completion_tokens wins",
+			body: `{"model":"m","messages":[{"role":"user","content":"hi"}],"max_tokens":100,"max_completion_tokens":200}`,
+			want: 200,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := translate(t, tt.body).MaxTokens; got != tt.want {
+				t.Errorf("max_tokens = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTranslateRequest_SamplingAndStop(t *testing.T) {
+	body := `{"model":"m","messages":[{"role":"user","content":"hi"}],
+		"temperature":0.5,"top_p":0.9,"top_k":40,"stop":"END",
+		"frequency_penalty":1,"presence_penalty":1,"n":2,"seed":7,
+		"response_format":{"type":"json_object"},"logprobs":true,"stream_options":{"include_usage":true}}`
+	req := translate(t, body)
+
+	if req.Temperature == nil || *req.Temperature != 0.5 {
+		t.Errorf("temperature = %v, want 0.5", req.Temperature)
+	}
+	if req.TopP == nil || *req.TopP != 0.9 {
+		t.Errorf("top_p = %v, want 0.9", req.TopP)
+	}
+	if req.TopK == nil || *req.TopK != 40 {
+		t.Errorf("top_k = %v, want 40", req.TopK)
+	}
+	if len(req.StopSequences) != 1 || req.StopSequences[0] != "END" {
+		t.Errorf("stop_sequences = %v, want [END]", req.StopSequences)
+	}
+
+	// Params with no Anthropic equivalent must not survive the translation.
+	out, _, _, err := TranslateRequest([]byte(body))
+	if err != nil {
+		t.Fatalf("TranslateRequest failed: %v", err)
+	}
+	for _, dropped := range []string{"frequency_penalty", "presence_penalty", `"n"`, "seed", "logprobs", "response_format", "stream_options"} {
+		if strings.Contains(string(out), dropped) {
+			t.Errorf("translated body still carries %s: %s", dropped, out)
+		}
+	}
+}
+
+func TestTranslateRequest_Stop(t *testing.T) {
+	tests := []struct {
+		name string
+		stop string
+		want []string
+	}{
+		{name: "array", stop: `["A","B"]`, want: []string{"A", "B"}},
+		{name: "string", stop: `"END"`, want: []string{"END"}},
+		{name: "empty string", stop: `""`, want: nil},
+		{name: "null", stop: `null`, want: nil},
+		{name: "unusable shape", stop: `{"a":1}`, want: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := translate(t, `{"model":"m","messages":[{"role":"user","content":"hi"}],"stop":`+tt.stop+`}`)
+
+			if len(req.StopSequences) != len(tt.want) {
+				t.Fatalf("stop_sequences = %v, want %v", req.StopSequences, tt.want)
+			}
+			for i, want := range tt.want {
+				if req.StopSequences[i] != want {
+					t.Errorf("stop_sequences[%d] = %q, want %q", i, req.StopSequences[i], want)
+				}
+			}
+		})
+	}
+}
+
+func TestTranslateRequest_EmptyTurnsAreDropped(t *testing.T) {
+	req := translate(t, `{"model":"m","messages":[
+		{"role":"user","content":"hi"},
+		{"role":"assistant","content":""},
+		{"role":"assistant","content":[{"type":"text","text":""}]},
+		{"role":"user","content":null},
+		{"role":"user","content":"still here"}]}`)
+
+	if len(req.Messages) != 2 {
+		t.Fatalf("got %d messages, want the two non-empty turns: %+v", len(req.Messages), req.Messages)
+	}
+	if string(req.Messages[1].Content) != `"still here"` {
+		t.Errorf("second message content = %s, want the trailing user turn", req.Messages[1].Content)
+	}
+}
+
+func TestTranslateRequest_Thinking(t *testing.T) {
+	tests := []struct {
+		name       string
+		effort     string
+		wantBudget int // 0 means no thinking block
+	}{
+		{name: "low", effort: "low", wantBudget: 1024},
+		{name: "medium", effort: "medium", wantBudget: 4096},
+		{name: "high", effort: "high", wantBudget: 8192},
+		{name: "none", effort: "none", wantBudget: 0},
+		{name: "absent", effort: "", wantBudget: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := `{"model":"m","messages":[{"role":"user","content":"hi"}],
+				"max_tokens":16000,"temperature":0.5,"top_p":0.9,"top_k":40`
+			if tt.effort != "" {
+				body += `,"reasoning_effort":"` + tt.effort + `"`
+			}
+			req := translate(t, body+"}")
+
+			if tt.wantBudget == 0 {
+				if req.Thinking != nil {
+					t.Errorf("thinking = %+v, want it omitted", req.Thinking)
+				}
+				if req.Temperature == nil || req.TopP == nil || req.TopK == nil {
+					t.Error("sampling params dropped without a thinking block")
+				}
+				return
+			}
+
+			if req.Thinking == nil {
+				t.Fatalf("thinking omitted, want budget %d", tt.wantBudget)
+			}
+			if req.Thinking.Type != "enabled" || req.Thinking.BudgetTokens != tt.wantBudget {
+				t.Errorf("thinking = %+v, want enabled with budget %d", req.Thinking, tt.wantBudget)
+			}
+			// Anthropic rejects sampling params alongside thinking.
+			if req.Temperature != nil || req.TopP != nil || req.TopK != nil {
+				t.Errorf("sampling params survived thinking: temperature=%v top_p=%v top_k=%v",
+					req.Temperature, req.TopP, req.TopK)
+			}
+		})
+	}
+}
+
+func TestTranslateRequest_ThinkingRaisesMaxTokensAboveTheBudget(t *testing.T) {
+	tests := []struct {
+		name      string
+		maxTokens string
+		want      int
+	}{
+		{name: "default is below the budget", maxTokens: "", want: 8192 + DefaultMaxTokens},
+		{name: "equal to the budget", maxTokens: `,"max_tokens":8192`, want: 8192 + DefaultMaxTokens},
+		{name: "already above the budget", maxTokens: `,"max_tokens":9000`, want: 9000},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := translate(t, `{"model":"m","messages":[{"role":"user","content":"hi"}],
+				"reasoning_effort":"high"`+tt.maxTokens+`}`)
+
+			if req.MaxTokens != tt.want {
+				t.Errorf("max_tokens = %d, want %d", req.MaxTokens, tt.want)
+			}
+			if req.MaxTokens <= req.Thinking.BudgetTokens {
+				t.Errorf("max_tokens %d is not above the thinking budget %d", req.MaxTokens, req.Thinking.BudgetTokens)
+			}
+		})
+	}
+}
+
+func TestTranslateRequest_Errors(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "invalid json", body: `{"model":`},
+		{name: "no model", body: `{"messages":[{"role":"user","content":"hi"}]}`},
+		{name: "no usable messages", body: `{"model":"m","messages":[{"role":"system","content":"Be terse."}]}`},
+		{name: "invalid message content", body: `{"model":"m","messages":[{"role":"user","content":[1,2,3]}]}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, _, err := TranslateRequest([]byte(tt.body))
+			if err == nil {
+				t.Fatal("TranslateRequest succeeded, want an error")
+			}
+			if !strings.HasPrefix(err.Error(), "anthropicegress: ") {
+				t.Errorf("error = %q, want an anthropicegress: prefix", err)
+			}
+		})
+	}
+}
+
+func TestTranslateRequest_ErrorsCarryNoRequestContent(t *testing.T) {
+	_, _, _, err := TranslateRequest([]byte(`{"model":"m","messages":[
+		{"role":"user","content":["sensitive prompt text"]}]}`))
+	if err == nil {
+		t.Fatal("TranslateRequest succeeded, want an error")
+	}
+	if strings.Contains(err.Error(), "sensitive prompt text") {
+		t.Errorf("error leaks request content: %q", err)
+	}
+}

--- a/internal/anthropicegress/request_test.go
+++ b/internal/anthropicegress/request_test.go
@@ -797,3 +797,42 @@ func TestTranslateRequest_ErrorsCarryNoRequestContent(t *testing.T) {
 		t.Errorf("error leaks request content: %q", err)
 	}
 }
+
+func TestTranslateRequest_DecodeErrorOmitsPayload(t *testing.T) {
+	// A malformed request body is the user's own prompt: encoding/json quotes the
+	// offending byte and prints an offending literal verbatim, so the error must
+	// say WHERE the body broke and nothing about what it said.
+	cases := []struct {
+		name    string
+		payload string
+		want    string
+		secret  string
+	}{
+		{
+			name:    "syntax error",
+			payload: `{"model":"claude-x","messages":[{"role":"user","content":"Kohlrabi"`,
+			want:    "malformed JSON at byte ",
+			secret:  "Kohlrabi",
+		},
+		{
+			name:    "type error",
+			payload: `{"model":8675309.42}`,
+			want:    "undecodable JSON (",
+			secret:  "8675309.42",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, _, err := TranslateRequest([]byte(tc.payload))
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if !strings.HasPrefix(err.Error(), "anthropicegress: invalid request body: "+tc.want) {
+				t.Errorf("error = %q, want the sanitized %q form", err, tc.want)
+			}
+			if strings.Contains(err.Error(), tc.secret) {
+				t.Errorf("error leaked the payload: %q", err)
+			}
+		})
+	}
+}

--- a/internal/anthropicegress/response.go
+++ b/internal/anthropicegress/response.go
@@ -110,7 +110,7 @@ type completionCacheDetails struct {
 func BuildChatCompletion(anthropicBody []byte, id, model string, created int64) ([]byte, error) {
 	var resp antResponse
 	if err := json.Unmarshal(anthropicBody, &resp); err != nil {
-		return nil, fmt.Errorf("anthropicegress: invalid upstream response: %w", err)
+		return nil, fmt.Errorf("anthropicegress: invalid upstream response: %s", jsonFault(err, len(anthropicBody)))
 	}
 	if resp.Type == "error" {
 		kind := "unknown"

--- a/internal/anthropicegress/response.go
+++ b/internal/anthropicegress/response.go
@@ -3,6 +3,7 @@ package anthropicegress
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 )
@@ -118,6 +119,13 @@ func BuildChatCompletion(anthropicBody []byte, id, model string, created int64) 
 		}
 		return nil, fmt.Errorf("anthropicegress: upstream error: %s", kind)
 	}
+	if resp.Type != "message" {
+		// Anything that is not a Messages response or a recognised error
+		// envelope — null, {}, a truncated body that still parses — must not
+		// become a synthetic empty success. The received type is upstream-
+		// controlled data and is not named here.
+		return nil, errors.New("anthropicegress: unexpected upstream response shape")
+	}
 
 	text, reasoning, toolCalls := translateContent(resp.Content)
 
@@ -172,16 +180,19 @@ func translateContent(blocks []antRespBlock) (text, reasoning string, toolCalls 
 }
 
 // toolArguments re-encodes a tool_use block's input object as the compact
-// JSON string OpenAI's tool_calls[].function.arguments field expects. Empty
-// or malformed input becomes "{}" rather than shipping a broken string.
+// JSON string OpenAI's tool_calls[].function.arguments field expects. Absent
+// input (the key omitted entirely) and an explicit JSON null both become "{}"
+// — a bare "null" is valid JSON but is not the object shape a client's
+// argument parser expects from a zero-argument tool call. Input is decoded
+// from the already-validated response document, so it is always
+// syntactically valid JSON here; Compact cannot fail on it.
 func toolArguments(input json.RawMessage) string {
-	if len(input) == 0 || !json.Valid(input) {
+	trimmed := bytes.TrimSpace(input)
+	if len(trimmed) == 0 || string(trimmed) == "null" {
 		return "{}"
 	}
 	var buf bytes.Buffer
-	if err := json.Compact(&buf, input); err != nil {
-		return "{}"
-	}
+	_ = json.Compact(&buf, trimmed)
 	return buf.String()
 }
 
@@ -200,19 +211,27 @@ func mapFinishReason(stopReason string) string {
 	}
 }
 
-// translateUsage maps Anthropic usage onto OpenAI usage. The cache-creation
-// and cache-read counts, when present, ride through under their Anthropic
-// field names (which proxy.Usage decodes directly) and the read count is
-// additionally restated under prompt_tokens_details.cached_tokens for the
-// OpenAI-shaped nested field.
+// translateUsage maps Anthropic usage onto OpenAI usage. Anthropic's
+// input_tokens, cache_creation_input_tokens and cache_read_input_tokens are
+// disjoint additions, not a breakdown — a cache hit can carry input_tokens: 4
+// alongside cache_read_input_tokens: 20000 for a ~20004-token prompt. OpenAI's
+// convention is the opposite: prompt_tokens_details.cached_tokens is a SUBSET
+// of prompt_tokens. So prompt_tokens here is the sum of all three Anthropic
+// counts (making cached_tokens a genuine subset of it), and the cache pair
+// additionally rides through under their own Anthropic field names, since
+// proxy.Usage decodes those directly too. Getting this wrong undercounts
+// billed prompt tokens and fabricates cache-miss counts downstream (see
+// internal/proxy/helpers.go's extractCacheTokens, which computes
+// missTokens = promptTokens - cacheReadTokens).
 func translateUsage(u *antRespUsage) *completionUsage {
 	if u == nil {
 		return nil
 	}
+	prompt := u.InputTokens + u.CacheReadInputTokens + u.CacheCreationInputTokens
 	out := &completionUsage{
-		PromptTokens:     u.InputTokens,
+		PromptTokens:     prompt,
 		CompletionTokens: u.OutputTokens,
-		TotalTokens:      u.InputTokens + u.OutputTokens,
+		TotalTokens:      prompt + u.OutputTokens,
 	}
 	if u.CacheCreationInputTokens > 0 {
 		out.CacheCreationInputTokens = u.CacheCreationInputTokens

--- a/internal/anthropicegress/response.go
+++ b/internal/anthropicegress/response.go
@@ -1,0 +1,225 @@
+package anthropicegress
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// --- Incoming Anthropic Messages response shape ---
+//
+// antBlock (request.go) has no thinking/signature fields and cannot decode a
+// response content block, so this package declares its own response-side
+// block type.
+
+type antResponse struct {
+	Type       string         `json:"type"` // "message" (or "error")
+	Content    []antRespBlock `json:"content"`
+	StopReason string         `json:"stop_reason"`
+	Usage      *antRespUsage  `json:"usage"`
+	Error      *antRespError  `json:"error"`
+}
+
+type antRespBlock struct {
+	Type string `json:"type"` // "text" | "thinking" | "tool_use" | other (ignored)
+	// text
+	Text string `json:"text,omitempty"`
+	// thinking
+	Thinking string `json:"thinking,omitempty"`
+	// tool_use
+	ID    string          `json:"id,omitempty"`
+	Name  string          `json:"name,omitempty"`
+	Input json.RawMessage `json:"input,omitempty"`
+}
+
+// antRespUsage carries Anthropic token accounting, including the two cache
+// fields Anthropic reports at the top level of usage (unlike OpenAI, which
+// nests its cached-read count under prompt_tokens_details).
+type antRespUsage struct {
+	InputTokens              int `json:"input_tokens"`
+	OutputTokens             int `json:"output_tokens"`
+	CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+	CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+}
+
+// antRespError is the body of an Anthropic {"type":"error"} envelope. Only
+// Type is surfaced in error messages — Message can echo fragments of the
+// request that produced it, and response content must never reach an error
+// string.
+type antRespError struct {
+	Type string `json:"type"`
+}
+
+// --- Outgoing OpenAI chat-completion response shape ---
+
+type completionResponse struct {
+	ID      string             `json:"id"`
+	Object  string             `json:"object"`
+	Created int64              `json:"created"`
+	Model   string             `json:"model"`
+	Choices []completionChoice `json:"choices"`
+	Usage   *completionUsage   `json:"usage,omitempty"`
+}
+
+type completionChoice struct {
+	Index        int               `json:"index"`
+	Message      completionMessage `json:"message"`
+	FinishReason string            `json:"finish_reason"`
+}
+
+type completionMessage struct {
+	Role             string               `json:"role"`
+	Content          *string              `json:"content"`
+	ReasoningContent string               `json:"reasoning_content,omitempty"`
+	ToolCalls        []completionToolCall `json:"tool_calls,omitempty"`
+}
+
+type completionToolCall struct {
+	ID       string `json:"id"`
+	Type     string `json:"type"`
+	Function struct {
+		Name      string `json:"name"`
+		Arguments string `json:"arguments"`
+	} `json:"function"`
+}
+
+// completionUsage mirrors the fields internal/proxy.Usage reads off a
+// chat-completion response: the standard three, plus the cache pair at the
+// top level (Anthropic's own field names, which proxy.Usage decodes
+// directly) and the read count restated under prompt_tokens_details for
+// providers that only look there.
+type completionUsage struct {
+	PromptTokens             int                     `json:"prompt_tokens"`
+	CompletionTokens         int                     `json:"completion_tokens"`
+	TotalTokens              int                     `json:"total_tokens"`
+	CacheCreationInputTokens int                     `json:"cache_creation_input_tokens,omitempty"`
+	CacheReadInputTokens     int                     `json:"cache_read_input_tokens,omitempty"`
+	PromptTokensDetails      *completionCacheDetails `json:"prompt_tokens_details,omitempty"`
+}
+
+type completionCacheDetails struct {
+	CachedTokens int `json:"cached_tokens"`
+}
+
+// BuildChatCompletion converts a non-streaming Anthropic Messages response
+// body into an OpenAI chat-completion body. id, model and created are
+// supplied by the caller (the model string the client requested is echoed
+// back, matching the proxy's existing dialect adapters).
+func BuildChatCompletion(anthropicBody []byte, id, model string, created int64) ([]byte, error) {
+	var resp antResponse
+	if err := json.Unmarshal(anthropicBody, &resp); err != nil {
+		return nil, fmt.Errorf("anthropicegress: invalid upstream response: %w", err)
+	}
+	if resp.Type == "error" {
+		kind := "unknown"
+		if resp.Error != nil && resp.Error.Type != "" {
+			kind = resp.Error.Type
+		}
+		return nil, fmt.Errorf("anthropicegress: upstream error: %s", kind)
+	}
+
+	text, reasoning, toolCalls := translateContent(resp.Content)
+
+	msg := completionMessage{
+		Role:             "assistant",
+		Content:          &text,
+		ReasoningContent: reasoning,
+		ToolCalls:        toolCalls,
+	}
+
+	out := completionResponse{
+		ID:      id,
+		Object:  "chat.completion",
+		Created: created,
+		Model:   model,
+		Choices: []completionChoice{{
+			Index:        0,
+			Message:      msg,
+			FinishReason: mapFinishReason(resp.StopReason),
+		}},
+		Usage: translateUsage(resp.Usage),
+	}
+
+	encoded, err := json.Marshal(out)
+	if err != nil {
+		return nil, fmt.Errorf("anthropicegress: marshal chat completion: %w", err)
+	}
+	return encoded, nil
+}
+
+// translateContent splits an Anthropic content block list into the three
+// pieces a chat-completion message carries separately: visible text, thinking
+// text (which OpenAI has no content block for) and tool calls. Block types
+// with no chat-completion equivalent (redacted_thinking, server-side tool
+// blocks, ...) are dropped rather than forwarded.
+func translateContent(blocks []antRespBlock) (text, reasoning string, toolCalls []completionToolCall) {
+	var textParts, reasoningParts []string
+	for _, b := range blocks {
+		switch b.Type {
+		case "text":
+			textParts = append(textParts, b.Text)
+		case "thinking":
+			reasoningParts = append(reasoningParts, b.Thinking)
+		case "tool_use":
+			tc := completionToolCall{ID: b.ID, Type: "function"}
+			tc.Function.Name = b.Name
+			tc.Function.Arguments = toolArguments(b.Input)
+			toolCalls = append(toolCalls, tc)
+		}
+	}
+	return strings.Join(textParts, ""), strings.Join(reasoningParts, ""), toolCalls
+}
+
+// toolArguments re-encodes a tool_use block's input object as the compact
+// JSON string OpenAI's tool_calls[].function.arguments field expects. Empty
+// or malformed input becomes "{}" rather than shipping a broken string.
+func toolArguments(input json.RawMessage) string {
+	if len(input) == 0 || !json.Valid(input) {
+		return "{}"
+	}
+	var buf bytes.Buffer
+	if err := json.Compact(&buf, input); err != nil {
+		return "{}"
+	}
+	return buf.String()
+}
+
+// mapFinishReason maps an Anthropic stop_reason to an OpenAI finish_reason.
+// An absent or unrecognised reason (including the pause/refusal reasons newer
+// Anthropic models can emit) maps to "stop" rather than failing the
+// translation over a field that only ever changes client-side behaviour.
+func mapFinishReason(stopReason string) string {
+	switch stopReason {
+	case "max_tokens":
+		return "length"
+	case "tool_use":
+		return "tool_calls"
+	default: // "end_turn", "stop_sequence", "", and anything unrecognised
+		return "stop"
+	}
+}
+
+// translateUsage maps Anthropic usage onto OpenAI usage. The cache-creation
+// and cache-read counts, when present, ride through under their Anthropic
+// field names (which proxy.Usage decodes directly) and the read count is
+// additionally restated under prompt_tokens_details.cached_tokens for the
+// OpenAI-shaped nested field.
+func translateUsage(u *antRespUsage) *completionUsage {
+	if u == nil {
+		return nil
+	}
+	out := &completionUsage{
+		PromptTokens:     u.InputTokens,
+		CompletionTokens: u.OutputTokens,
+		TotalTokens:      u.InputTokens + u.OutputTokens,
+	}
+	if u.CacheCreationInputTokens > 0 {
+		out.CacheCreationInputTokens = u.CacheCreationInputTokens
+	}
+	if u.CacheReadInputTokens > 0 {
+		out.CacheReadInputTokens = u.CacheReadInputTokens
+		out.PromptTokensDetails = &completionCacheDetails{CachedTokens: u.CacheReadInputTokens}
+	}
+	return out
+}

--- a/internal/anthropicegress/response.go
+++ b/internal/anthropicegress/response.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+
+	"github.com/hugalafutro/model-hotel/internal/jsonfault"
 )
 
 // --- Incoming Anthropic Messages response shape ---
@@ -110,7 +112,7 @@ type completionCacheDetails struct {
 func BuildChatCompletion(anthropicBody []byte, id, model string, created int64) ([]byte, error) {
 	var resp antResponse
 	if err := json.Unmarshal(anthropicBody, &resp); err != nil {
-		return nil, fmt.Errorf("anthropicegress: invalid upstream response: %s", jsonFault(err, len(anthropicBody)))
+		return nil, fmt.Errorf("anthropicegress: invalid upstream response: %s", jsonfault.Describe(err, len(anthropicBody)))
 	}
 	if resp.Type == "error" {
 		kind := "unknown"

--- a/internal/anthropicegress/response_test.go
+++ b/internal/anthropicegress/response_test.go
@@ -353,6 +353,22 @@ func TestBuildChatCompletion_InvalidBody(t *testing.T) {
 	}
 }
 
+func TestBuildChatCompletion_InvalidBodyErrorOmitsContent(t *testing.T) {
+	// The decode error describes WHERE the body broke, never what it said:
+	// encoding/json quotes the offending byte and prints an offending literal
+	// verbatim, and a response body is model output.
+	_, err := BuildChatCompletion([]byte(`{"type":"message","content":[{"type":"text","text":"Kohlrabi"`), "resp_1", "claude-x", 1234)
+	if err == nil {
+		t.Fatal("expected an error for a truncated body")
+	}
+	if !strings.HasPrefix(err.Error(), "anthropicegress: invalid upstream response: malformed JSON at byte ") {
+		t.Errorf("error = %q, want the sanitized malformed-JSON form", err)
+	}
+	if strings.Contains(err.Error(), "Kohlrabi") {
+		t.Errorf("error leaked response content: %q", err)
+	}
+}
+
 func TestBuildChatCompletion_ErrorEnvelope(t *testing.T) {
 	_, err := BuildChatCompletion(
 		[]byte(`{"type":"error","error":{"type":"overloaded_error","message":"secret upstream detail"}}`),

--- a/internal/anthropicegress/response_test.go
+++ b/internal/anthropicegress/response_test.go
@@ -1,0 +1,267 @@
+package anthropicegress
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// build runs BuildChatCompletion and decodes the result for assertions.
+func build(t *testing.T, body string) completionResponse {
+	t.Helper()
+	out, err := BuildChatCompletion([]byte(body), "resp_1", "claude-x", 1234)
+	if err != nil {
+		t.Fatalf("BuildChatCompletion failed: %v", err)
+	}
+	var resp completionResponse
+	if err := json.Unmarshal(out, &resp); err != nil {
+		t.Fatalf("translated body is not valid JSON: %v", err)
+	}
+	return resp
+}
+
+func TestBuildChatCompletion_Envelope(t *testing.T) {
+	resp := build(t, `{"type":"message","content":[{"type":"text","text":"hi"}],"stop_reason":"end_turn"}`)
+	if resp.ID != "resp_1" {
+		t.Errorf("ID = %q, want resp_1", resp.ID)
+	}
+	if resp.Object != "chat.completion" {
+		t.Errorf("Object = %q, want chat.completion", resp.Object)
+	}
+	if resp.Created != 1234 {
+		t.Errorf("Created = %d, want 1234", resp.Created)
+	}
+	if resp.Model != "claude-x" {
+		t.Errorf("Model = %q, want claude-x", resp.Model)
+	}
+	if len(resp.Choices) != 1 || resp.Choices[0].Index != 0 {
+		t.Fatalf("Choices = %+v, want exactly one choice at index 0", resp.Choices)
+	}
+}
+
+func TestBuildChatCompletion_TextBlocksConcatenate(t *testing.T) {
+	resp := build(t, `{"type":"message","content":[
+		{"type":"text","text":"Hello, "},
+		{"type":"text","text":"world."}
+	],"stop_reason":"end_turn"}`)
+	msg := resp.Choices[0].Message
+	if msg.Content == nil || *msg.Content != "Hello, world." {
+		t.Errorf("Content = %v, want %q", msg.Content, "Hello, world.")
+	}
+	if msg.Role != "assistant" {
+		t.Errorf("Role = %q, want assistant", msg.Role)
+	}
+}
+
+func TestBuildChatCompletion_NoTextBlocksIsEmptyString(t *testing.T) {
+	resp := build(t, `{"type":"message","content":[],"stop_reason":"end_turn"}`)
+	msg := resp.Choices[0].Message
+	if msg.Content == nil || *msg.Content != "" {
+		t.Errorf("Content = %v, want empty string (not omitted)", msg.Content)
+	}
+}
+
+func TestBuildChatCompletion_ThinkingBlocksConcatenate(t *testing.T) {
+	resp := build(t, `{"type":"message","content":[
+		{"type":"thinking","thinking":"step one. "},
+		{"type":"text","text":"answer"},
+		{"type":"thinking","thinking":"step two."}
+	],"stop_reason":"end_turn"}`)
+	msg := resp.Choices[0].Message
+	if msg.ReasoningContent != "step one. step two." {
+		t.Errorf("ReasoningContent = %q, want %q", msg.ReasoningContent, "step one. step two.")
+	}
+	if msg.Content == nil || *msg.Content != "answer" {
+		t.Errorf("Content = %v, want %q", msg.Content, "answer")
+	}
+}
+
+func TestBuildChatCompletion_ReasoningContentOmittedWhenEmpty(t *testing.T) {
+	out, err := BuildChatCompletion(
+		[]byte(`{"type":"message","content":[{"type":"text","text":"hi"}],"stop_reason":"end_turn"}`),
+		"resp_1", "claude-x", 1234)
+	if err != nil {
+		t.Fatalf("BuildChatCompletion failed: %v", err)
+	}
+	if strings.Contains(string(out), "reasoning_content") {
+		t.Errorf("output carries reasoning_content when no thinking block was present: %s", out)
+	}
+}
+
+func TestBuildChatCompletion_ToolUseBlocksBecomeToolCalls(t *testing.T) {
+	resp := build(t, `{"type":"message","content":[
+		{"type":"tool_use","id":"toolu_1","name":"get_weather","input":{"city":"Lyon"}},
+		{"type":"tool_use","id":"toolu_2","name":"get_time","input":{}}
+	],"stop_reason":"tool_use"}`)
+	msg := resp.Choices[0].Message
+	if len(msg.ToolCalls) != 2 {
+		t.Fatalf("ToolCalls = %+v, want 2 entries", msg.ToolCalls)
+	}
+	first := msg.ToolCalls[0]
+	if first.ID != "toolu_1" || first.Type != "function" || first.Function.Name != "get_weather" {
+		t.Errorf("first tool call = %+v", first)
+	}
+	if first.Function.Arguments != `{"city":"Lyon"}` {
+		t.Errorf("Arguments = %q, want a compact JSON string of the input object", first.Function.Arguments)
+	}
+	var decoded map[string]string
+	if err := json.Unmarshal([]byte(first.Function.Arguments), &decoded); err != nil {
+		t.Fatalf("Arguments is not valid JSON: %v", err)
+	}
+	second := msg.ToolCalls[1]
+	if second.ID != "toolu_2" || second.Function.Arguments != "{}" {
+		t.Errorf("second tool call = %+v, want empty-object arguments", second)
+	}
+	if resp.Choices[0].FinishReason != "tool_calls" {
+		t.Errorf("FinishReason = %q, want tool_calls", resp.Choices[0].FinishReason)
+	}
+}
+
+func TestBuildChatCompletion_ToolCallsOmittedWhenAbsent(t *testing.T) {
+	out, err := BuildChatCompletion(
+		[]byte(`{"type":"message","content":[{"type":"text","text":"hi"}],"stop_reason":"end_turn"}`),
+		"resp_1", "claude-x", 1234)
+	if err != nil {
+		t.Fatalf("BuildChatCompletion failed: %v", err)
+	}
+	if strings.Contains(string(out), "tool_calls") {
+		t.Errorf("output carries tool_calls when no tool_use block was present: %s", out)
+	}
+}
+
+func TestBuildChatCompletion_UnknownBlockTypeIgnored(t *testing.T) {
+	resp := build(t, `{"type":"message","content":[
+		{"type":"redacted_thinking","data":"opaque"},
+		{"type":"text","text":"visible"}
+	],"stop_reason":"end_turn"}`)
+	msg := resp.Choices[0].Message
+	if msg.Content == nil || *msg.Content != "visible" {
+		t.Errorf("Content = %v, want %q", msg.Content, "visible")
+	}
+	if msg.ReasoningContent != "" {
+		t.Errorf("ReasoningContent = %q, want empty", msg.ReasoningContent)
+	}
+}
+
+func TestBuildChatCompletion_FinishReasonMapping(t *testing.T) {
+	cases := []struct {
+		stopReason string
+		want       string
+	}{
+		{"end_turn", "stop"},
+		{"stop_sequence", "stop"},
+		{"max_tokens", "length"},
+		{"tool_use", "tool_calls"},
+		{"", "stop"},
+		{"pause_turn", "stop"},
+		{"refusal", "stop"},
+	}
+	for _, c := range cases {
+		body := `{"type":"message","content":[],"stop_reason":"` + c.stopReason + `"}`
+		if c.stopReason == "" {
+			body = `{"type":"message","content":[]}`
+		}
+		resp := build(t, body)
+		if got := resp.Choices[0].FinishReason; got != c.want {
+			t.Errorf("stop_reason=%q: FinishReason = %q, want %q", c.stopReason, got, c.want)
+		}
+	}
+}
+
+func TestMapFinishReason(t *testing.T) {
+	cases := map[string]string{
+		"end_turn":      "stop",
+		"stop_sequence": "stop",
+		"max_tokens":    "length",
+		"tool_use":      "tool_calls",
+		"":              "stop",
+		"pause_turn":    "stop",
+	}
+	for in, want := range cases {
+		if got := mapFinishReason(in); got != want {
+			t.Errorf("mapFinishReason(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestBuildChatCompletion_UsageBasic(t *testing.T) {
+	resp := build(t, `{"type":"message","content":[{"type":"text","text":"hi"}],"stop_reason":"end_turn",
+		"usage":{"input_tokens":10,"output_tokens":5}}`)
+	if resp.Usage == nil {
+		t.Fatal("Usage is nil, want populated")
+	}
+	if resp.Usage.PromptTokens != 10 || resp.Usage.CompletionTokens != 5 || resp.Usage.TotalTokens != 15 {
+		t.Errorf("Usage = %+v, want prompt=10 completion=5 total=15", resp.Usage)
+	}
+	if resp.Usage.CacheCreationInputTokens != 0 || resp.Usage.CacheReadInputTokens != 0 {
+		t.Errorf("Usage cache fields = %+v, want zero", resp.Usage)
+	}
+	if resp.Usage.PromptTokensDetails != nil {
+		t.Errorf("PromptTokensDetails = %+v, want nil when no cache read", resp.Usage.PromptTokensDetails)
+	}
+}
+
+func TestBuildChatCompletion_UsageAbsent(t *testing.T) {
+	resp := build(t, `{"type":"message","content":[{"type":"text","text":"hi"}],"stop_reason":"end_turn"}`)
+	if resp.Usage != nil {
+		t.Errorf("Usage = %+v, want nil when upstream sent none", resp.Usage)
+	}
+}
+
+func TestBuildChatCompletion_UsageCacheFields(t *testing.T) {
+	resp := build(t, `{"type":"message","content":[{"type":"text","text":"hi"}],"stop_reason":"end_turn",
+		"usage":{"input_tokens":100,"output_tokens":20,"cache_creation_input_tokens":30,"cache_read_input_tokens":70}}`)
+	if resp.Usage == nil {
+		t.Fatal("Usage is nil, want populated")
+	}
+	if resp.Usage.CacheCreationInputTokens != 30 {
+		t.Errorf("CacheCreationInputTokens = %d, want 30", resp.Usage.CacheCreationInputTokens)
+	}
+	if resp.Usage.CacheReadInputTokens != 70 {
+		t.Errorf("CacheReadInputTokens = %d, want 70", resp.Usage.CacheReadInputTokens)
+	}
+	if resp.Usage.PromptTokensDetails == nil || resp.Usage.PromptTokensDetails.CachedTokens != 70 {
+		t.Errorf("PromptTokensDetails = %+v, want CachedTokens=70", resp.Usage.PromptTokensDetails)
+	}
+	if resp.Usage.TotalTokens != 120 {
+		t.Errorf("TotalTokens = %d, want 120", resp.Usage.TotalTokens)
+	}
+}
+
+func TestBuildChatCompletion_InvalidBody(t *testing.T) {
+	_, err := BuildChatCompletion([]byte(`{not json`), "resp_1", "claude-x", 1234)
+	if err == nil {
+		t.Fatal("expected an error for an invalid body")
+	}
+	if !strings.HasPrefix(err.Error(), "anthropicegress:") {
+		t.Errorf("error %q not prefixed anthropicegress:", err.Error())
+	}
+}
+
+func TestBuildChatCompletion_ErrorEnvelope(t *testing.T) {
+	_, err := BuildChatCompletion(
+		[]byte(`{"type":"error","error":{"type":"overloaded_error","message":"secret upstream detail"}}`),
+		"resp_1", "claude-x", 1234)
+	if err == nil {
+		t.Fatal("expected an error for an error envelope")
+	}
+	if !strings.HasPrefix(err.Error(), "anthropicegress:") {
+		t.Errorf("error %q not prefixed anthropicegress:", err.Error())
+	}
+	if strings.Contains(err.Error(), "secret upstream detail") {
+		t.Errorf("error %q leaks the upstream error message (response content)", err.Error())
+	}
+	if !strings.Contains(err.Error(), "overloaded_error") {
+		t.Errorf("error %q does not name the error type", err.Error())
+	}
+}
+
+func TestBuildChatCompletion_ErrorEnvelopeWithoutErrorField(t *testing.T) {
+	_, err := BuildChatCompletion([]byte(`{"type":"error"}`), "resp_1", "claude-x", 1234)
+	if err == nil {
+		t.Fatal("expected an error for an error envelope with no error field")
+	}
+	if !strings.HasPrefix(err.Error(), "anthropicegress:") {
+		t.Errorf("error %q not prefixed anthropicegress:", err.Error())
+	}
+}

--- a/internal/anthropicegress/response_test.go
+++ b/internal/anthropicegress/response_test.go
@@ -6,14 +6,64 @@ import (
 	"testing"
 )
 
+// The types below mirror the wire shape BuildChatCompletion produces, but are
+// declared independently of completionResponse and friends (the production
+// types) — same pattern as translatedRequest in request_test.go. Decoding the
+// output with the very struct that produced it would make a JSON-tag
+// regression on the production side invisible to these tests.
+
+type translatedCompletion struct {
+	ID      string             `json:"id"`
+	Object  string             `json:"object"`
+	Created int64              `json:"created"`
+	Model   string             `json:"model"`
+	Choices []translatedChoice `json:"choices"`
+	Usage   *translatedUsage   `json:"usage"`
+}
+
+type translatedChoice struct {
+	Index        int                  `json:"index"`
+	FinishReason string               `json:"finish_reason"`
+	Message      translatedMessageOut `json:"message"`
+}
+
+type translatedMessageOut struct {
+	Role             string               `json:"role"`
+	Content          *string              `json:"content"`
+	ReasoningContent string               `json:"reasoning_content"`
+	ToolCalls        []translatedToolCall `json:"tool_calls"`
+}
+
+type translatedToolCall struct {
+	ID       string `json:"id"`
+	Type     string `json:"type"`
+	Function struct {
+		Name      string `json:"name"`
+		Arguments string `json:"arguments"`
+	} `json:"function"`
+}
+
+type translatedUsage struct {
+	PromptTokens             int                      `json:"prompt_tokens"`
+	CompletionTokens         int                      `json:"completion_tokens"`
+	TotalTokens              int                      `json:"total_tokens"`
+	CacheCreationInputTokens int                      `json:"cache_creation_input_tokens"`
+	CacheReadInputTokens     int                      `json:"cache_read_input_tokens"`
+	PromptTokensDetails      *translatedPromptDetails `json:"prompt_tokens_details"`
+}
+
+type translatedPromptDetails struct {
+	CachedTokens int `json:"cached_tokens"`
+}
+
 // build runs BuildChatCompletion and decodes the result for assertions.
-func build(t *testing.T, body string) completionResponse {
+func build(t *testing.T, body string) translatedCompletion {
 	t.Helper()
 	out, err := BuildChatCompletion([]byte(body), "resp_1", "claude-x", 1234)
 	if err != nil {
 		t.Fatalf("BuildChatCompletion failed: %v", err)
 	}
-	var resp completionResponse
+	var resp translatedCompletion
 	if err := json.Unmarshal(out, &resp); err != nil {
 		t.Fatalf("translated body is not valid JSON: %v", err)
 	}
@@ -117,6 +167,36 @@ func TestBuildChatCompletion_ToolUseBlocksBecomeToolCalls(t *testing.T) {
 	}
 }
 
+// TestBuildChatCompletion_ToolUseInputAbsent covers a realistic zero-argument
+// tool call: Anthropic omits the "input" key entirely rather than sending
+// "input":{}. This is the only live branch of toolArguments' len(trimmed)==0
+// guard (an "input":{} block never reaches it).
+func TestBuildChatCompletion_ToolUseInputAbsent(t *testing.T) {
+	resp := build(t, `{"type":"message","content":[
+		{"type":"tool_use","id":"toolu_3","name":"noop"}
+	],"stop_reason":"tool_use"}`)
+	msg := resp.Choices[0].Message
+	if len(msg.ToolCalls) != 1 {
+		t.Fatalf("ToolCalls = %+v, want 1 entry", msg.ToolCalls)
+	}
+	if got := msg.ToolCalls[0].Function.Arguments; got != "{}" {
+		t.Errorf("Arguments = %q, want {} for an absent input key", got)
+	}
+}
+
+// TestBuildChatCompletion_ToolUseInputNull covers an explicit JSON null
+// input, which is valid JSON but not the object shape a tool-call arguments
+// string is supposed to carry.
+func TestBuildChatCompletion_ToolUseInputNull(t *testing.T) {
+	resp := build(t, `{"type":"message","content":[
+		{"type":"tool_use","id":"toolu_4","name":"noop","input":null}
+	],"stop_reason":"tool_use"}`)
+	msg := resp.Choices[0].Message
+	if got := msg.ToolCalls[0].Function.Arguments; got != "{}" {
+		t.Errorf("Arguments = %q, want {} for an explicit null input", got)
+	}
+}
+
 func TestBuildChatCompletion_ToolCallsOmittedWhenAbsent(t *testing.T) {
 	out, err := BuildChatCompletion(
 		[]byte(`{"type":"message","content":[{"type":"text","text":"hi"}],"stop_reason":"end_turn"}`),
@@ -208,6 +288,10 @@ func TestBuildChatCompletion_UsageAbsent(t *testing.T) {
 	}
 }
 
+// TestBuildChatCompletion_UsageCacheFields checks that prompt_tokens is the
+// SUM of input_tokens, cache_creation_input_tokens and cache_read_input_tokens
+// (Anthropic's three counts are disjoint additions), not just input_tokens —
+// and that the cache pair also rides through under their own field names.
 func TestBuildChatCompletion_UsageCacheFields(t *testing.T) {
 	resp := build(t, `{"type":"message","content":[{"type":"text","text":"hi"}],"stop_reason":"end_turn",
 		"usage":{"input_tokens":100,"output_tokens":20,"cache_creation_input_tokens":30,"cache_read_input_tokens":70}}`)
@@ -223,8 +307,39 @@ func TestBuildChatCompletion_UsageCacheFields(t *testing.T) {
 	if resp.Usage.PromptTokensDetails == nil || resp.Usage.PromptTokensDetails.CachedTokens != 70 {
 		t.Errorf("PromptTokensDetails = %+v, want CachedTokens=70", resp.Usage.PromptTokensDetails)
 	}
-	if resp.Usage.TotalTokens != 120 {
-		t.Errorf("TotalTokens = %d, want 120", resp.Usage.TotalTokens)
+	if resp.Usage.PromptTokens != 200 {
+		t.Errorf("PromptTokens = %d, want 100+30+70=200 (Anthropic's three counts are disjoint additions)", resp.Usage.PromptTokens)
+	}
+	if resp.Usage.TotalTokens != 220 {
+		t.Errorf("TotalTokens = %d, want 220", resp.Usage.TotalTokens)
+	}
+}
+
+// TestBuildChatCompletion_UsageCacheHitInvariant reproduces the case the
+// undercounting bug broke: a heavily cached prompt where input_tokens is tiny
+// relative to cache_read_input_tokens. prompt_tokens must be at least the
+// cached_tokens count, or internal/proxy/helpers.go's extractCacheTokens
+// computes a negative-clamped miss count and hides the vast majority of the
+// prompt from billing.
+func TestBuildChatCompletion_UsageCacheHitInvariant(t *testing.T) {
+	resp := build(t, `{"type":"message","content":[{"type":"text","text":"hi"}],"stop_reason":"end_turn",
+		"usage":{"input_tokens":4,"output_tokens":50,"cache_read_input_tokens":20000}}`)
+	if resp.Usage == nil {
+		t.Fatal("Usage is nil, want populated")
+	}
+	cached := resp.Usage.PromptTokensDetails
+	if cached == nil {
+		t.Fatal("PromptTokensDetails is nil, want CachedTokens=20000")
+	}
+	if resp.Usage.PromptTokens < cached.CachedTokens {
+		t.Errorf("PromptTokens = %d is less than cached_tokens = %d: cached_tokens must be a subset of prompt_tokens",
+			resp.Usage.PromptTokens, cached.CachedTokens)
+	}
+	if resp.Usage.PromptTokens != 20004 {
+		t.Errorf("PromptTokens = %d, want 4+20000=20004", resp.Usage.PromptTokens)
+	}
+	if resp.Usage.TotalTokens != 20054 {
+		t.Errorf("TotalTokens = %d, want 20004+50=20054", resp.Usage.TotalTokens)
 	}
 }
 
@@ -263,5 +378,27 @@ func TestBuildChatCompletion_ErrorEnvelopeWithoutErrorField(t *testing.T) {
 	}
 	if !strings.HasPrefix(err.Error(), "anthropicegress:") {
 		t.Errorf("error %q not prefixed anthropicegress:", err.Error())
+	}
+}
+
+// TestBuildChatCompletion_NotAMessage covers bodies that parse as valid JSON
+// but are neither a Messages response nor a recognised error envelope: they
+// must not become a synthetic empty success.
+func TestBuildChatCompletion_NotAMessage(t *testing.T) {
+	cases := map[string]string{
+		"empty object":            `{}`,
+		"null":                    `null`,
+		"message-shaped, no type": `{"id":"msg_1","content":[]}`,
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := BuildChatCompletion([]byte(body), "resp_1", "claude-x", 1234)
+			if err == nil {
+				t.Fatalf("expected an error for body %s", body)
+			}
+			if !strings.HasPrefix(err.Error(), "anthropicegress:") {
+				t.Errorf("error %q not prefixed anthropicegress:", err.Error())
+			}
+		})
 	}
 }

--- a/internal/anthropicegress/stream.go
+++ b/internal/anthropicegress/stream.go
@@ -159,8 +159,14 @@ func (t *StreamTranslator) writeChunk(buf *bytes.Buffer, delta chunkDelta, finis
 // Translate processes one Anthropic SSE data payload and returns the chunk
 // bytes to forward to the client (often empty: ping, content_block_stop and
 // message_delta update state silently). message_stop produces the terminal
-// chunk plus "data: [DONE]", after which Finish is a no-op.
+// chunk plus "data: [DONE]", after which Finish is a no-op and further payloads
+// are ignored: nothing may be emitted after the sentinel, and a truncated line
+// trailing a completed stream must not poison it.
 func (t *StreamTranslator) Translate(payload []byte) ([]byte, error) {
+	if t.finished {
+		return nil, nil
+	}
+
 	var ev antEvent
 	if err := json.Unmarshal(payload, &ev); err != nil {
 		return nil, fmt.Errorf("anthropicegress: invalid stream event: %s", jsonfault.Describe(err, len(payload)))

--- a/internal/anthropicegress/stream.go
+++ b/internal/anthropicegress/stream.go
@@ -48,6 +48,21 @@ type antEventDelta struct {
 	StopReason  string `json:"stop_reason"`
 }
 
+// jsonFault describes a JSON decode failure without echoing the document that
+// caused it. encoding/json's own messages embed a fragment of the input — a
+// *json.SyntaxError quotes the offending byte, a *json.UnmarshalTypeError the
+// offending literal — and every document this package decodes carries prompt
+// or response content, which must never reach an error string or a log line.
+// The byte offset and the document length are structure, not content, so they
+// stay: they are what makes a malformed stream diagnosable.
+func jsonFault(err error, size int) string {
+	var syntaxErr *json.SyntaxError
+	if errors.As(err, &syntaxErr) {
+		return fmt.Sprintf("malformed JSON at byte %d of %d", syntaxErr.Offset, size)
+	}
+	return fmt.Sprintf("undecodable JSON (%d bytes)", size)
+}
+
 // --- Outgoing OpenAI chat.completion.chunk shape ---
 
 type chunk struct {
@@ -106,9 +121,10 @@ type StreamTranslator struct {
 
 	// Anthropic reports input counts on message_start and output tokens on
 	// message_delta, so both halves accumulate here and the terminal chunk
-	// runs them through translateUsage's arithmetic.
-	usage    antRespUsage
-	sawUsage bool
+	// runs them through translateUsage's arithmetic. A usage object carrying
+	// nothing but zeros leaves this zero-valued, and the terminal chunk then
+	// omits usage rather than reporting a fabricated 0/0/0.
+	usage antRespUsage
 
 	// Anthropic's content-block indices count every block; OpenAI's
 	// tool_calls[].index counts only tool calls. This maps one to the other so
@@ -160,7 +176,7 @@ func (t *StreamTranslator) writeChunk(buf *bytes.Buffer, delta chunkDelta, finis
 func (t *StreamTranslator) Translate(payload []byte) ([]byte, error) {
 	var ev antEvent
 	if err := json.Unmarshal(payload, &ev); err != nil {
-		return nil, fmt.Errorf("anthropicegress: invalid stream event: %w", err)
+		return nil, fmt.Errorf("anthropicegress: invalid stream event: %s", jsonFault(err, len(payload)))
 	}
 
 	var buf bytes.Buffer
@@ -170,7 +186,6 @@ func (t *StreamTranslator) Translate(payload []byte) ([]byte, error) {
 			t.usage.InputTokens = ev.Message.Usage.InputTokens
 			t.usage.CacheCreationInputTokens = ev.Message.Usage.CacheCreationInputTokens
 			t.usage.CacheReadInputTokens = ev.Message.Usage.CacheReadInputTokens
-			t.sawUsage = true
 		}
 		if err := t.writeChunk(&buf, chunkDelta{}, nil, nil); err != nil {
 			return nil, err
@@ -189,7 +204,6 @@ func (t *StreamTranslator) Translate(payload []byte) ([]byte, error) {
 		}
 		if ev.Usage != nil {
 			t.usage.OutputTokens = ev.Usage.OutputTokens
-			t.sawUsage = true
 		}
 	case "message_stop":
 		return t.Finish()
@@ -284,7 +298,7 @@ func (t *StreamTranslator) Finish() ([]byte, error) {
 	var buf bytes.Buffer
 	reason := mapFinishReason(t.stopReason)
 	var usage *antRespUsage
-	if t.sawUsage {
+	if t.usage != (antRespUsage{}) {
 		usage = &t.usage
 	}
 	if err := t.writeChunk(&buf, chunkDelta{}, &reason, translateUsage(usage)); err != nil {

--- a/internal/anthropicegress/stream.go
+++ b/internal/anthropicegress/stream.go
@@ -1,0 +1,295 @@
+package anthropicegress
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// --- Incoming Anthropic SSE event shapes ---
+
+// antEvent is the union of every Anthropic streaming event this package
+// consumes. Each event populates only the members its own type carries, so one
+// decode covers the whole sequence:
+//
+//	message_start        -> Message.Usage (input-side token counts)
+//	content_block_start  -> Index + ContentBlock
+//	content_block_delta  -> Index + Delta (text/thinking/partial_json)
+//	content_block_stop   -> Index
+//	message_delta        -> Delta.StopReason + Usage.OutputTokens
+//	message_stop, ping   -> nothing beyond Type
+//	error                -> Error
+type antEvent struct {
+	Type         string           `json:"type"`
+	Index        int              `json:"index"`
+	Message      *antEventMessage `json:"message"`
+	ContentBlock *antRespBlock    `json:"content_block"`
+	Delta        *antEventDelta   `json:"delta"`
+	Usage        *antRespUsage    `json:"usage"`
+	Error        *antRespError    `json:"error"`
+}
+
+// antEventMessage is the partial Message object message_start carries. Only
+// usage is read: id and model are the caller's to choose, and the content array
+// is always empty at that point.
+type antEventMessage struct {
+	Usage *antRespUsage `json:"usage"`
+}
+
+// antEventDelta is the delta union shared by content_block_delta (text_delta,
+// thinking_delta, input_json_delta, and the signature/citation deltas this
+// package ignores) and message_delta (stop_reason).
+type antEventDelta struct {
+	Type        string `json:"type"`
+	Text        string `json:"text"`
+	Thinking    string `json:"thinking"`
+	PartialJSON string `json:"partial_json"`
+	StopReason  string `json:"stop_reason"`
+}
+
+// --- Outgoing OpenAI chat.completion.chunk shape ---
+
+type chunk struct {
+	ID      string           `json:"id"`
+	Object  string           `json:"object"`
+	Created int64            `json:"created"`
+	Model   string           `json:"model"`
+	Choices []chunkChoice    `json:"choices"`
+	Usage   *completionUsage `json:"usage,omitempty"`
+}
+
+type chunkChoice struct {
+	Index        int        `json:"index"`
+	Delta        chunkDelta `json:"delta"`
+	FinishReason *string    `json:"finish_reason"`
+}
+
+type chunkDelta struct {
+	Role             string          `json:"role,omitempty"`
+	Content          string          `json:"content,omitempty"`
+	ReasoningContent string          `json:"reasoning_content,omitempty"`
+	ToolCalls        []chunkToolCall `json:"tool_calls,omitempty"`
+}
+
+// chunkToolCall is one streamed tool-call fragment. Index is the OpenAI
+// tool-call ordinal (not Anthropic's content-block index); id and type ride on
+// the header fragment only, matching how OpenAI streams tool calls.
+type chunkToolCall struct {
+	Index    int               `json:"index"`
+	ID       string            `json:"id,omitempty"`
+	Type     string            `json:"type,omitempty"`
+	Function chunkToolFunction `json:"function"`
+}
+
+type chunkToolFunction struct {
+	Name      string `json:"name,omitempty"`
+	Arguments string `json:"arguments"`
+}
+
+// StreamTranslator converts an Anthropic Messages SSE stream into an OpenAI
+// chat.completion.chunk SSE stream ending in "data: [DONE]".
+//
+// It is the streaming counterpart of BuildChatCompletion and single-goroutine
+// by design: the adapter feeds it one upstream data payload at a time and
+// forwards whatever bytes come back.
+type StreamTranslator struct {
+	id      string
+	model   string
+	created int64
+
+	started  bool // role delta emitted
+	finished bool // terminal chunk + [DONE] already emitted
+	failed   bool // an error event arrived; no clean finish may follow
+
+	stopReason string // stop_reason from message_delta
+
+	// Anthropic reports input counts on message_start and output tokens on
+	// message_delta, so both halves accumulate here and the terminal chunk
+	// runs them through translateUsage's arithmetic.
+	usage    antRespUsage
+	sawUsage bool
+
+	// Anthropic's content-block indices count every block; OpenAI's
+	// tool_calls[].index counts only tool calls. This maps one to the other so
+	// a response interleaving text and two tool calls emits tool-call indices
+	// 0 and 1.
+	toolIndexByBlock map[int]int
+	toolCalls        int
+}
+
+// NewStreamTranslator builds a translator for one response. id, model and
+// created are echoed in every chunk envelope (the model string the client
+// requested, not the id or model Anthropic reports on message_start).
+func NewStreamTranslator(id, model string, created int64) *StreamTranslator {
+	return &StreamTranslator{
+		id:               id,
+		model:            model,
+		created:          created,
+		toolIndexByBlock: map[int]int{},
+	}
+}
+
+// writeChunk appends one framed SSE chunk ("data: <json>\n\n").
+func (t *StreamTranslator) writeChunk(buf *bytes.Buffer, delta chunkDelta, finishReason *string, usage *completionUsage) error {
+	if !t.started {
+		delta.Role = "assistant"
+		t.started = true
+	}
+	payload, err := json.Marshal(chunk{
+		ID:      t.id,
+		Object:  "chat.completion.chunk",
+		Created: t.created,
+		Model:   t.model,
+		Choices: []chunkChoice{{Index: 0, Delta: delta, FinishReason: finishReason}},
+		Usage:   usage,
+	})
+	if err != nil {
+		return fmt.Errorf("anthropicegress: marshal stream chunk: %w", err)
+	}
+	buf.WriteString("data: ")
+	buf.Write(payload)
+	buf.WriteString("\n\n")
+	return nil
+}
+
+// Translate processes one Anthropic SSE data payload and returns the chunk
+// bytes to forward to the client (often empty: ping, content_block_stop and
+// message_delta update state silently). message_stop produces the terminal
+// chunk plus "data: [DONE]", after which Finish is a no-op.
+func (t *StreamTranslator) Translate(payload []byte) ([]byte, error) {
+	var ev antEvent
+	if err := json.Unmarshal(payload, &ev); err != nil {
+		return nil, fmt.Errorf("anthropicegress: invalid stream event: %w", err)
+	}
+
+	var buf bytes.Buffer
+	switch ev.Type {
+	case "message_start":
+		if ev.Message != nil && ev.Message.Usage != nil {
+			t.usage.InputTokens = ev.Message.Usage.InputTokens
+			t.usage.CacheCreationInputTokens = ev.Message.Usage.CacheCreationInputTokens
+			t.usage.CacheReadInputTokens = ev.Message.Usage.CacheReadInputTokens
+			t.sawUsage = true
+		}
+		if err := t.writeChunk(&buf, chunkDelta{}, nil, nil); err != nil {
+			return nil, err
+		}
+	case "content_block_start":
+		if err := t.startBlock(&buf, ev); err != nil {
+			return nil, err
+		}
+	case "content_block_delta":
+		if err := t.blockDelta(&buf, ev); err != nil {
+			return nil, err
+		}
+	case "message_delta":
+		if ev.Delta != nil && ev.Delta.StopReason != "" {
+			t.stopReason = ev.Delta.StopReason
+		}
+		if ev.Usage != nil {
+			t.usage.OutputTokens = ev.Usage.OutputTokens
+			t.sawUsage = true
+		}
+	case "message_stop":
+		return t.Finish()
+	case "error":
+		// The stream is dead: the caller must surface a failure, never a
+		// terminal chunk that reads as a clean completion. Only the error type
+		// is named — error.message can echo request content.
+		t.failed = true
+		kind := "unknown"
+		if ev.Error != nil && ev.Error.Type != "" {
+			kind = ev.Error.Type
+		}
+		return nil, fmt.Errorf("anthropicegress: upstream error: %s", kind)
+	}
+	// content_block_stop, ping and any unrecognised event type carry nothing a
+	// chat.completion.chunk stream represents.
+	return buf.Bytes(), nil
+}
+
+// startBlock handles content_block_start. Only tool_use blocks open anything on
+// the OpenAI side (the header fragment carrying the tool-call index, id, type
+// and name); text and thinking blocks emit content in their deltas alone.
+func (t *StreamTranslator) startBlock(buf *bytes.Buffer, ev antEvent) error {
+	if ev.ContentBlock == nil || ev.ContentBlock.Type != "tool_use" {
+		return nil
+	}
+	oaIndex := t.toolCalls
+	t.toolCalls++
+	t.toolIndexByBlock[ev.Index] = oaIndex
+
+	return t.writeChunk(buf, chunkDelta{ToolCalls: []chunkToolCall{{
+		Index:    oaIndex,
+		ID:       ev.ContentBlock.ID,
+		Type:     "function",
+		Function: chunkToolFunction{Name: ev.ContentBlock.Name},
+	}}}, nil, nil)
+}
+
+// blockDelta handles content_block_delta: text and thinking become content and
+// reasoning_content deltas, partial JSON becomes a tool-call arguments fragment
+// under the tool-call index its content_block_start claimed.
+func (t *StreamTranslator) blockDelta(buf *bytes.Buffer, ev antEvent) error {
+	if ev.Delta == nil {
+		return nil
+	}
+	var delta chunkDelta
+	switch ev.Delta.Type {
+	case "text_delta":
+		if ev.Delta.Text == "" {
+			return nil
+		}
+		delta.Content = ev.Delta.Text
+	case "thinking_delta":
+		if ev.Delta.Thinking == "" {
+			return nil
+		}
+		delta.ReasoningContent = ev.Delta.Thinking
+	case "input_json_delta":
+		if ev.Delta.PartialJSON == "" {
+			return nil
+		}
+		oaIndex, ok := t.toolIndexByBlock[ev.Index]
+		if !ok {
+			// Arguments for a block no content_block_start opened. Dropping
+			// them would hand the client a tool call with silently truncated
+			// arguments, so the stream fails instead.
+			return errors.New("anthropicegress: tool arguments for an unopened content block")
+		}
+		delta.ToolCalls = []chunkToolCall{{
+			Index:    oaIndex,
+			Function: chunkToolFunction{Arguments: ev.Delta.PartialJSON},
+		}}
+	default:
+		// signature_delta, citations_delta and anything newer have no
+		// chat-completion equivalent.
+		return nil
+	}
+	return t.writeChunk(buf, delta, nil, nil)
+}
+
+// Finish emits the terminal chunk (empty delta, mapped finish_reason, usage
+// when the upstream reported any) followed by "data: [DONE]". It is idempotent,
+// so a stream that ended on message_stop receives nothing further on EOF, and
+// it stays silent after an error event so a failed stream is never closed off
+// as a clean one.
+func (t *StreamTranslator) Finish() ([]byte, error) {
+	if t.finished || t.failed {
+		return nil, nil
+	}
+	t.finished = true
+
+	var buf bytes.Buffer
+	reason := mapFinishReason(t.stopReason)
+	var usage *antRespUsage
+	if t.sawUsage {
+		usage = &t.usage
+	}
+	if err := t.writeChunk(&buf, chunkDelta{}, &reason, translateUsage(usage)); err != nil {
+		return nil, err
+	}
+	buf.WriteString("data: [DONE]\n\n")
+	return buf.Bytes(), nil
+}

--- a/internal/anthropicegress/stream.go
+++ b/internal/anthropicegress/stream.go
@@ -210,8 +210,17 @@ func (t *StreamTranslator) Translate(payload []byte) ([]byte, error) {
 			kind = ev.Error.Type
 		}
 		return nil, fmt.Errorf("anthropicegress: upstream error: %s", kind)
+	case "ping":
+		// Anthropic's keepalive across a generation gap, and the gap is longest
+		// exactly where this adapter earns its keep: prompt processing after
+		// message_start on a large document, and server-side tool pauses. The
+		// proxy's stall watchdog is pinged per line of THIS stream, so
+		// swallowing the keepalive would let a healthy stream be closed and
+		// logged as a provider stall. An SSE comment frame pings it and is
+		// ignored by every SSE client, so nothing reaches the caller as a chunk.
+		buf.WriteString(": ping\n\n")
 	}
-	// content_block_stop, ping and any unrecognised event type carry nothing a
+	// content_block_stop and any unrecognised event type carry nothing a
 	// chat.completion.chunk stream represents.
 	return buf.Bytes(), nil
 }

--- a/internal/anthropicegress/stream.go
+++ b/internal/anthropicegress/stream.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+
+	"github.com/hugalafutro/model-hotel/internal/jsonfault"
 )
 
 // --- Incoming Anthropic SSE event shapes ---
@@ -46,21 +48,6 @@ type antEventDelta struct {
 	Thinking    string `json:"thinking"`
 	PartialJSON string `json:"partial_json"`
 	StopReason  string `json:"stop_reason"`
-}
-
-// jsonFault describes a JSON decode failure without echoing the document that
-// caused it. encoding/json's own messages embed a fragment of the input — a
-// *json.SyntaxError quotes the offending byte, a *json.UnmarshalTypeError the
-// offending literal — and every document this package decodes carries prompt
-// or response content, which must never reach an error string or a log line.
-// The byte offset and the document length are structure, not content, so they
-// stay: they are what makes a malformed stream diagnosable.
-func jsonFault(err error, size int) string {
-	var syntaxErr *json.SyntaxError
-	if errors.As(err, &syntaxErr) {
-		return fmt.Sprintf("malformed JSON at byte %d of %d", syntaxErr.Offset, size)
-	}
-	return fmt.Sprintf("undecodable JSON (%d bytes)", size)
 }
 
 // --- Outgoing OpenAI chat.completion.chunk shape ---
@@ -176,7 +163,7 @@ func (t *StreamTranslator) writeChunk(buf *bytes.Buffer, delta chunkDelta, finis
 func (t *StreamTranslator) Translate(payload []byte) ([]byte, error) {
 	var ev antEvent
 	if err := json.Unmarshal(payload, &ev); err != nil {
-		return nil, fmt.Errorf("anthropicegress: invalid stream event: %s", jsonFault(err, len(payload)))
+		return nil, fmt.Errorf("anthropicegress: invalid stream event: %s", jsonfault.Describe(err, len(payload)))
 	}
 
 	var buf bytes.Buffer

--- a/internal/anthropicegress/stream_test.go
+++ b/internal/anthropicegress/stream_test.go
@@ -467,7 +467,7 @@ func TestStreamTranslator_DecodeErrorOmitsPayload(t *testing.T) {
 		{
 			name:    "type error",
 			payload: `{"type":"content_block_delta","index":8675309.42}`,
-			want:    "undecodable JSON (",
+			want:    "unexpected JSON value at byte ",
 			secret:  "8675309.42",
 		},
 	}

--- a/internal/anthropicegress/stream_test.go
+++ b/internal/anthropicegress/stream_test.go
@@ -381,6 +381,33 @@ func TestStreamTranslator_FinishIdempotentAfterMessageStop(t *testing.T) {
 	}
 }
 
+func TestStreamTranslator_EventsAfterMessageStopIgnored(t *testing.T) {
+	// [DONE] has already gone out. A late event must not append content behind
+	// the sentinel, and a truncated one must not fail a stream that completed.
+	tr := NewStreamTranslator("chatcmpl-14", "m", 1)
+	feed(t, tr,
+		`{"type":"message_start","message":{"usage":{"input_tokens":2}}}`,
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}`,
+		`{"type":"message_stop"}`,
+	)
+
+	late := []string{
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"late"}}`,
+		`{"type":"message_stop"}`,
+		`{"type":"error","error":{"type":"overloaded_error"}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_del`,
+	}
+	for _, ev := range late {
+		out, err := tr.Translate([]byte(ev))
+		if err != nil {
+			t.Errorf("Translate(%s) after message_stop: %v", ev, err)
+		}
+		if len(out) != 0 {
+			t.Errorf("Translate(%s) emitted %q after [DONE]", ev, out)
+		}
+	}
+}
+
 func TestStreamTranslator_FinishWithoutMessageStop(t *testing.T) {
 	// An upstream that dies after message_delta still owes the client a
 	// terminal chunk; Finish supplies it, carrying the role when no chunk did.

--- a/internal/anthropicegress/stream_test.go
+++ b/internal/anthropicegress/stream_test.go
@@ -1,0 +1,462 @@
+package anthropicegress
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// The types below mirror the wire shape the translator emits but are declared
+// independently of chunk and friends (the production types) — same pattern as
+// translatedCompletion in response_test.go. Decoding the output with the very
+// struct that produced it would make a JSON-tag regression on the production
+// side invisible to these tests. translatedUsage is shared with response_test.go
+// because a chunk's usage block is the same shape a completion's is.
+
+type streamedChunk struct {
+	ID      string           `json:"id"`
+	Object  string           `json:"object"`
+	Created int64            `json:"created"`
+	Model   string           `json:"model"`
+	Choices []streamedChoice `json:"choices"`
+	Usage   *translatedUsage `json:"usage"`
+}
+
+type streamedChoice struct {
+	Index        int           `json:"index"`
+	Delta        streamedDelta `json:"delta"`
+	FinishReason *string       `json:"finish_reason"`
+}
+
+type streamedDelta struct {
+	Role             string             `json:"role"`
+	Content          string             `json:"content"`
+	ReasoningContent string             `json:"reasoning_content"`
+	ToolCalls        []streamedToolCall `json:"tool_calls"`
+}
+
+type streamedToolCall struct {
+	Index    int    `json:"index"`
+	ID       string `json:"id"`
+	Type     string `json:"type"`
+	Function struct {
+		Name      string `json:"name"`
+		Arguments string `json:"arguments"`
+	} `json:"function"`
+}
+
+// parseChunks decodes an emitted SSE stream into its chunks and reports whether
+// it ended with the [DONE] sentinel. Every frame must be a "data: " frame: the
+// adapter generates its own framing, so anything else is a defect.
+func parseChunks(t *testing.T, sse string) (chunks []streamedChunk, done bool) {
+	t.Helper()
+	for _, frame := range strings.Split(sse, "\n\n") {
+		frame = strings.TrimSpace(frame)
+		if frame == "" {
+			continue
+		}
+		payload, ok := strings.CutPrefix(frame, "data: ")
+		if !ok {
+			t.Fatalf("frame is not a data frame: %q", frame)
+		}
+		if payload == "[DONE]" {
+			done = true
+			continue
+		}
+		if done {
+			t.Fatalf("frame after [DONE]: %q", frame)
+		}
+		var c streamedChunk
+		if err := json.Unmarshal([]byte(payload), &c); err != nil {
+			t.Fatalf("decode chunk %q: %v", payload, err)
+		}
+		if c.Object != "chat.completion.chunk" {
+			t.Errorf("object = %q, want chat.completion.chunk", c.Object)
+		}
+		if len(c.Choices) != 1 {
+			t.Fatalf("choices = %d, want 1 in %q", len(c.Choices), payload)
+		}
+		chunks = append(chunks, c)
+	}
+	return chunks, done
+}
+
+// feed runs each event through the translator and returns the concatenated SSE
+// output.
+func feed(t *testing.T, tr *StreamTranslator, events ...string) string {
+	t.Helper()
+	var sb strings.Builder
+	for _, ev := range events {
+		out, err := tr.Translate([]byte(ev))
+		if err != nil {
+			t.Fatalf("Translate(%s): %v", ev, err)
+		}
+		sb.Write(out)
+	}
+	return sb.String()
+}
+
+// joinContent concatenates the content deltas of a chunk list.
+func joinContent(chunks []streamedChunk) string {
+	var sb strings.Builder
+	for _, c := range chunks {
+		sb.WriteString(c.Choices[0].Delta.Content)
+	}
+	return sb.String()
+}
+
+// toolArgsByIndex reassembles the streamed arguments per OpenAI tool-call index.
+func toolArgsByIndex(chunks []streamedChunk) map[int]string {
+	args := map[int]string{}
+	for _, c := range chunks {
+		for _, tc := range c.Choices[0].Delta.ToolCalls {
+			args[tc.Index] += tc.Function.Arguments
+		}
+	}
+	return args
+}
+
+func TestStreamTranslator_TextStream(t *testing.T) {
+	tr := NewStreamTranslator("chatcmpl-1", "claude-sonnet-4-5", 1700)
+	out := feed(t, tr,
+		`{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-sonnet-4-5-20250929","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"cache_creation_input_tokens":5,"cache_read_input_tokens":20,"output_tokens":1}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`{"type":"ping"}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hel"}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"lo"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":7}}`,
+		`{"type":"message_stop"}`,
+	)
+
+	chunks, done := parseChunks(t, out)
+	if !done {
+		t.Fatalf("stream did not end with [DONE]:\n%s", out)
+	}
+	// message_start (role), two text deltas, terminal. ping,
+	// content_block_start(text), content_block_stop and message_delta emit
+	// nothing.
+	if len(chunks) != 4 {
+		t.Fatalf("chunks = %d, want 4:\n%s", len(chunks), out)
+	}
+	if got := chunks[0].Choices[0].Delta.Role; got != "assistant" {
+		t.Errorf("first chunk role = %q, want assistant", got)
+	}
+	roles := 0
+	for _, c := range chunks {
+		if c.Choices[0].Delta.Role != "" {
+			roles++
+		}
+		if c.ID != "chatcmpl-1" || c.Model != "claude-sonnet-4-5" || c.Created != 1700 {
+			t.Errorf("envelope = %q/%q/%d, want the caller's id/model/created", c.ID, c.Model, c.Created)
+		}
+	}
+	if roles != 1 {
+		t.Errorf("role deltas = %d, want 1", roles)
+	}
+	if got := joinContent(chunks); got != "Hello" {
+		t.Errorf("content = %q, want Hello", got)
+	}
+
+	last := chunks[len(chunks)-1]
+	if last.Choices[0].FinishReason == nil || *last.Choices[0].FinishReason != "stop" {
+		t.Errorf("terminal finish_reason = %v, want stop", last.Choices[0].FinishReason)
+	}
+	// Only the terminal chunk carries finish_reason and usage.
+	for _, c := range chunks[:len(chunks)-1] {
+		if c.Choices[0].FinishReason != nil {
+			t.Errorf("non-terminal chunk carries finish_reason %q", *c.Choices[0].FinishReason)
+		}
+		if c.Usage != nil {
+			t.Errorf("non-terminal chunk carries usage %+v", c.Usage)
+		}
+	}
+	// Anthropic's three input counts are disjoint, so prompt_tokens is their
+	// sum; output_tokens comes from message_delta, not message_start's 1.
+	u := last.Usage
+	if u == nil {
+		t.Fatal("terminal chunk has no usage")
+	}
+	if u.PromptTokens != 35 || u.CompletionTokens != 7 || u.TotalTokens != 42 {
+		t.Errorf("usage = %d/%d/%d, want 35/7/42", u.PromptTokens, u.CompletionTokens, u.TotalTokens)
+	}
+	if u.CacheReadInputTokens != 20 || u.CacheCreationInputTokens != 5 {
+		t.Errorf("cache counts = %d/%d, want 20/5", u.CacheReadInputTokens, u.CacheCreationInputTokens)
+	}
+	if u.PromptTokensDetails == nil || u.PromptTokensDetails.CachedTokens != 20 {
+		t.Errorf("prompt_tokens_details = %+v, want cached_tokens 20", u.PromptTokensDetails)
+	}
+}
+
+func TestStreamTranslator_ToolCallFragmentedArguments(t *testing.T) {
+	tr := NewStreamTranslator("chatcmpl-2", "m", 1)
+	out := feed(t, tr,
+		`{"type":"message_start","message":{"usage":{"input_tokens":4}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_a","name":"get_weather","input":{}}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"city\""}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":":\"Oslo\""}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"}"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":9}}`,
+		`{"type":"message_stop"}`,
+	)
+
+	chunks, done := parseChunks(t, out)
+	if !done {
+		t.Fatalf("stream did not end with [DONE]:\n%s", out)
+	}
+
+	// The header fragment carries id/type/name and empty arguments; the
+	// fragments that follow carry arguments only.
+	header := chunks[1].Choices[0].Delta.ToolCalls
+	if len(header) != 1 {
+		t.Fatalf("header tool_calls = %d, want 1:\n%s", len(header), out)
+	}
+	if header[0].ID != "toolu_a" || header[0].Type != "function" || header[0].Function.Name != "get_weather" {
+		t.Errorf("header = %+v, want id toolu_a, type function, name get_weather", header[0])
+	}
+	if header[0].Function.Arguments != "" {
+		t.Errorf("header arguments = %q, want empty", header[0].Function.Arguments)
+	}
+	for _, c := range chunks[2:] {
+		for _, tc := range c.Choices[0].Delta.ToolCalls {
+			if tc.ID != "" || tc.Type != "" || tc.Function.Name != "" {
+				t.Errorf("argument fragment repeats header fields: %+v", tc)
+			}
+		}
+	}
+
+	if got := toolArgsByIndex(chunks)[0]; got != `{"city":"Oslo"}` {
+		t.Errorf("reassembled arguments = %q, want {\"city\":\"Oslo\"}", got)
+	}
+	last := chunks[len(chunks)-1]
+	if last.Choices[0].FinishReason == nil || *last.Choices[0].FinishReason != "tool_calls" {
+		t.Errorf("finish_reason = %v, want tool_calls", last.Choices[0].FinishReason)
+	}
+}
+
+func TestStreamTranslator_ToolCallIndicesSkipTextBlocks(t *testing.T) {
+	// Anthropic block indices count every block (text at 0, tools at 1 and 2);
+	// OpenAI tool-call indices count only tool calls, so they must be 0 and 1.
+	tr := NewStreamTranslator("chatcmpl-3", "m", 1)
+	out := feed(t, tr,
+		`{"type":"message_start","message":{"usage":{"input_tokens":4}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"checking"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_a","name":"first","input":{}}}`,
+		`{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"a\":1}"}}`,
+		`{"type":"content_block_stop","index":1}`,
+		`{"type":"content_block_start","index":2,"content_block":{"type":"tool_use","id":"toolu_b","name":"second","input":{}}}`,
+		`{"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"{\"b\":2}"}}`,
+		`{"type":"content_block_stop","index":2}`,
+		`{"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":9}}`,
+		`{"type":"message_stop"}`,
+	)
+
+	chunks, _ := parseChunks(t, out)
+	if got := joinContent(chunks); got != "checking" {
+		t.Errorf("content = %q, want checking", got)
+	}
+
+	var headers []streamedToolCall
+	for _, c := range chunks {
+		for _, tc := range c.Choices[0].Delta.ToolCalls {
+			if tc.ID != "" {
+				headers = append(headers, tc)
+			}
+		}
+	}
+	if len(headers) != 2 {
+		t.Fatalf("tool-call headers = %d, want 2:\n%s", len(headers), out)
+	}
+	if headers[0].Index != 0 || headers[0].Function.Name != "first" {
+		t.Errorf("first header = index %d name %q, want 0/first", headers[0].Index, headers[0].Function.Name)
+	}
+	if headers[1].Index != 1 || headers[1].Function.Name != "second" {
+		t.Errorf("second header = index %d name %q, want 1/second", headers[1].Index, headers[1].Function.Name)
+	}
+
+	// Each block's arguments land under its own tool-call index, not its
+	// Anthropic block index.
+	args := toolArgsByIndex(chunks)
+	if args[0] != `{"a":1}` || args[1] != `{"b":2}` {
+		t.Errorf("arguments by index = %v, want 0:{\"a\":1} 1:{\"b\":2}", args)
+	}
+	if _, ok := args[2]; ok {
+		t.Errorf("arguments emitted under Anthropic block index 2: %v", args)
+	}
+}
+
+func TestStreamTranslator_ThinkingStream(t *testing.T) {
+	tr := NewStreamTranslator("chatcmpl-4", "m", 1)
+	out := feed(t, tr,
+		`{"type":"message_start","message":{"usage":{"input_tokens":4}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"weigh"}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"ing"}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"abc123"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}`,
+		`{"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"answer"}}`,
+		`{"type":"content_block_stop","index":1}`,
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":12}}`,
+		`{"type":"message_stop"}`,
+	)
+
+	chunks, done := parseChunks(t, out)
+	if !done {
+		t.Fatalf("stream did not end with [DONE]:\n%s", out)
+	}
+	var reasoning strings.Builder
+	for _, c := range chunks {
+		reasoning.WriteString(c.Choices[0].Delta.ReasoningContent)
+	}
+	if reasoning.String() != "weighing" {
+		t.Errorf("reasoning_content = %q, want weighing", reasoning.String())
+	}
+	if got := joinContent(chunks); got != "answer" {
+		t.Errorf("content = %q, want answer", got)
+	}
+	// signature_delta has no chat-completion equivalent and must not leak into
+	// either stream.
+	if strings.Contains(out, "abc123") {
+		t.Errorf("signature_delta leaked into the chunk stream:\n%s", out)
+	}
+}
+
+func TestStreamTranslator_ErrorEventFailsWithoutFinish(t *testing.T) {
+	tr := NewStreamTranslator("chatcmpl-5", "m", 1)
+	feed(t, tr, `{"type":"message_start","message":{"usage":{"input_tokens":4}}}`)
+
+	_, err := tr.Translate([]byte(`{"type":"error","error":{"type":"overloaded_error","message":"the prompt about kittens is too long"}}`))
+	if err == nil {
+		t.Fatal("expected an error for an error event")
+	}
+	if !strings.HasPrefix(err.Error(), "anthropicegress:") {
+		t.Errorf("error = %q, want an anthropicegress: prefix", err)
+	}
+	if !strings.Contains(err.Error(), "overloaded_error") {
+		t.Errorf("error = %q, want the error type named", err)
+	}
+	// The upstream error message can echo request content and must not appear.
+	if strings.Contains(err.Error(), "kittens") {
+		t.Errorf("error message leaked upstream content: %q", err)
+	}
+
+	// A failed stream is never closed off as a clean one.
+	fin, finErr := tr.Finish()
+	if finErr != nil {
+		t.Fatalf("Finish after error: %v", finErr)
+	}
+	if len(fin) != 0 {
+		t.Errorf("Finish emitted a terminal chunk after an error event:\n%s", fin)
+	}
+}
+
+func TestStreamTranslator_FinishIdempotentAfterMessageStop(t *testing.T) {
+	tr := NewStreamTranslator("chatcmpl-6", "m", 1)
+	out := feed(t, tr,
+		`{"type":"message_start","message":{"usage":{"input_tokens":4}}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hi"}}`,
+		`{"type":"message_delta","delta":{"stop_reason":"max_tokens"},"usage":{"output_tokens":2}}`,
+		`{"type":"message_stop"}`,
+	)
+	chunks, done := parseChunks(t, out)
+	if !done {
+		t.Fatalf("message_stop did not emit [DONE]:\n%s", out)
+	}
+	if r := chunks[len(chunks)-1].Choices[0].FinishReason; r == nil || *r != "length" {
+		t.Errorf("finish_reason = %v, want length", r)
+	}
+
+	for i := range 2 {
+		fin, err := tr.Finish()
+		if err != nil {
+			t.Fatalf("Finish %d: %v", i, err)
+		}
+		if len(fin) != 0 {
+			t.Errorf("Finish %d emitted a second terminal chunk:\n%s", i, fin)
+		}
+	}
+}
+
+func TestStreamTranslator_FinishWithoutMessageStop(t *testing.T) {
+	// An upstream that dies after message_delta still owes the client a
+	// terminal chunk; Finish supplies it, carrying the role when no chunk did.
+	tr := NewStreamTranslator("chatcmpl-7", "m", 1)
+	feed(t, tr, `{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":3}}`)
+
+	fin, err := tr.Finish()
+	if err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+	chunks, done := parseChunks(t, string(fin))
+	if !done || len(chunks) != 1 {
+		t.Fatalf("Finish = %d chunks, done=%v:\n%s", len(chunks), done, fin)
+	}
+	if chunks[0].Choices[0].Delta.Role != "assistant" {
+		t.Errorf("terminal chunk carries no role: %+v", chunks[0].Choices[0].Delta)
+	}
+	if r := chunks[0].Choices[0].FinishReason; r == nil || *r != "stop" {
+		t.Errorf("finish_reason = %v, want stop", r)
+	}
+	// output_tokens alone still counts as usage; prompt_tokens is simply 0.
+	if chunks[0].Usage == nil || chunks[0].Usage.CompletionTokens != 3 {
+		t.Errorf("usage = %+v, want completion_tokens 3", chunks[0].Usage)
+	}
+}
+
+func TestStreamTranslator_NoUsageReportedOmitsUsage(t *testing.T) {
+	tr := NewStreamTranslator("chatcmpl-8", "m", 1)
+	fin, err := tr.Finish()
+	if err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+	chunks, _ := parseChunks(t, string(fin))
+	if len(chunks) != 1 {
+		t.Fatalf("chunks = %d, want 1", len(chunks))
+	}
+	if chunks[0].Usage != nil {
+		t.Errorf("usage = %+v, want none when the upstream reported none", chunks[0].Usage)
+	}
+}
+
+func TestStreamTranslator_EmptyDeltasEmitNothing(t *testing.T) {
+	// A delta with nothing in it must not become a chunk carrying an empty
+	// delta object, which clients read as a content-free assistant message.
+	tr := NewStreamTranslator("chatcmpl-11", "m", 1)
+	out := feed(t, tr,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_a","name":"f","input":{}}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":""}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":""}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}}`,
+		`{"type":"content_block_delta","index":0}`,
+	)
+	chunks, _ := parseChunks(t, out)
+	if len(chunks) != 1 { // the tool-call header alone
+		t.Errorf("chunks = %d, want 1:\n%s", len(chunks), out)
+	}
+}
+
+func TestStreamTranslator_InvalidEventFails(t *testing.T) {
+	tr := NewStreamTranslator("chatcmpl-9", "m", 1)
+	if _, err := tr.Translate([]byte(`{not json`)); err == nil {
+		t.Fatal("expected an error for a malformed event")
+	} else if !strings.HasPrefix(err.Error(), "anthropicegress:") {
+		t.Errorf("error = %q, want an anthropicegress: prefix", err)
+	}
+}
+
+func TestStreamTranslator_OrphanToolArgumentsFail(t *testing.T) {
+	// Arguments for a block no content_block_start opened cannot be indexed;
+	// dropping them would hand the client silently truncated arguments.
+	tr := NewStreamTranslator("chatcmpl-10", "m", 1)
+	_, err := tr.Translate([]byte(`{"type":"content_block_delta","index":3,"delta":{"type":"input_json_delta","partial_json":"{\"a\":1}"}}`))
+	if err == nil {
+		t.Fatal("expected an error for arguments on an unopened block")
+	}
+	if !strings.HasPrefix(err.Error(), "anthropicegress:") {
+		t.Errorf("error = %q, want an anthropicegress: prefix", err)
+	}
+}

--- a/internal/anthropicegress/stream_test.go
+++ b/internal/anthropicegress/stream_test.go
@@ -448,6 +448,60 @@ func TestStreamTranslator_InvalidEventFails(t *testing.T) {
 	}
 }
 
+func TestStreamTranslator_DecodeErrorOmitsPayload(t *testing.T) {
+	// encoding/json's own messages quote the offending byte and print the
+	// offending literal verbatim, and a stream event's fields are model output.
+	// The error must describe WHERE the document broke, never what it said.
+	cases := []struct {
+		name    string
+		payload string
+		want    string // the sanitized shape the error must take
+		secret  string // a fragment of the payload that must not survive
+	}{
+		{
+			name:    "syntax error",
+			payload: `{"type":"content_block_delta","delta":{"type":"text_delta","text":"Kohlrabi"`,
+			want:    "malformed JSON at byte ",
+			secret:  "Kohlrabi",
+		},
+		{
+			name:    "type error",
+			payload: `{"type":"content_block_delta","index":8675309.42}`,
+			want:    "undecodable JSON (",
+			secret:  "8675309.42",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewStreamTranslator("chatcmpl-12", "m", 1).Translate([]byte(tc.payload))
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if !strings.HasPrefix(err.Error(), "anthropicegress: invalid stream event: "+tc.want) {
+				t.Errorf("error = %q, want the sanitized %q form", err, tc.want)
+			}
+			if strings.Contains(err.Error(), tc.secret) {
+				t.Errorf("error leaked the payload: %q", err)
+			}
+		})
+	}
+}
+
+func TestStreamTranslator_AllZeroUsageOmitsUsage(t *testing.T) {
+	// A usage object reporting nothing is not usage: emitting 0/0/0 would have
+	// the meter record a real completion as free.
+	tr := NewStreamTranslator("chatcmpl-13", "m", 1)
+	out := feed(t, tr,
+		`{"type":"message_start","message":{"usage":{"input_tokens":0,"output_tokens":0}}}`,
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":0}}`,
+		`{"type":"message_stop"}`,
+	)
+	chunks, _ := parseChunks(t, out)
+	if u := chunks[len(chunks)-1].Usage; u != nil {
+		t.Errorf("usage = %+v, want none when every count is zero", u)
+	}
+}
+
 func TestStreamTranslator_OrphanToolArgumentsFail(t *testing.T) {
 	// Arguments for a block no content_block_start opened cannot be indexed;
 	// dropping them would hand the client silently truncated arguments.

--- a/internal/anthropicegress/stream_test.go
+++ b/internal/anthropicegress/stream_test.go
@@ -46,13 +46,19 @@ type streamedToolCall struct {
 }
 
 // parseChunks decodes an emitted SSE stream into its chunks and reports whether
-// it ended with the [DONE] sentinel. Every frame must be a "data: " frame: the
-// adapter generates its own framing, so anything else is a defect.
+// it ended with the [DONE] sentinel. Every frame is either a "data: " frame or
+// a comment: the adapter generates its own framing, so anything else is a
+// defect.
 func parseChunks(t *testing.T, sse string) (chunks []streamedChunk, done bool) {
 	t.Helper()
 	for _, frame := range strings.Split(sse, "\n\n") {
 		frame = strings.TrimSpace(frame)
 		if frame == "" {
+			continue
+		}
+		// A comment frame is a keepalive: it pings the proxy's stall watchdog
+		// and no SSE client sees it as an event.
+		if strings.HasPrefix(frame, ":") {
 			continue
 		}
 		payload, ok := strings.CutPrefix(frame, "data: ")
@@ -539,5 +545,84 @@ func TestStreamTranslator_OrphanToolArgumentsFail(t *testing.T) {
 	}
 	if !strings.HasPrefix(err.Error(), "anthropicegress:") {
 		t.Errorf("error = %q, want an anthropicegress: prefix", err)
+	}
+}
+
+// The proxy's stall watchdog is pinged per scanned line of the ADAPTER's
+// output, so an event that emits nothing does not reset it. Anthropic's ping is
+// the keepalive across a generation gap — prompt processing on a large
+// document, a server-side tool pause — and swallowing it would let a healthy
+// stream be closed and logged as a provider stall. It becomes an SSE comment:
+// output bytes for the watchdog, and nothing an SSE client reads as an event.
+func TestStreamTranslator_PingEmitsAKeepaliveFrame(t *testing.T) {
+	tr := NewStreamTranslator("chatcmpl-ping", "m", 1)
+	out, err := tr.Translate([]byte(`{"type":"ping"}`))
+	if err != nil {
+		t.Fatalf("Translate(ping): %v", err)
+	}
+	if len(out) == 0 {
+		t.Fatal("ping emitted no bytes: the stall watchdog is only pinged per output line")
+	}
+	if strings.Contains(string(out), "data:") {
+		t.Errorf("ping emitted a data frame %q, want an SSE comment", out)
+	}
+	if !strings.HasPrefix(string(out), ":") {
+		t.Errorf("ping frame = %q, want an SSE comment starting with ':'", out)
+	}
+	if !strings.HasSuffix(string(out), "\n\n") {
+		t.Errorf("ping frame = %q, want a frame terminated by a blank line", out)
+	}
+}
+
+// Pings interleaved through a stream must not disturb its shape: still exactly
+// one terminal chunk and one [DONE].
+func TestStreamTranslator_PingsDoNotDisturbTheStream(t *testing.T) {
+	tr := NewStreamTranslator("chatcmpl-ping2", "m", 1)
+	out := feed(t, tr,
+		`{"type":"message_start","message":{"usage":{"input_tokens":11,"output_tokens":1}}}`,
+		`{"type":"ping"}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`{"type":"ping"}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}`,
+		`{"type":"ping"}`,
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":4}}`,
+		`{"type":"message_stop"}`,
+	)
+
+	if got := strings.Count(out, ": ping\n\n"); got != 3 {
+		t.Errorf("keepalive frames = %d, want 3:\n%s", got, out)
+	}
+	if got := strings.Count(out, "data: [DONE]"); got != 1 {
+		t.Errorf("[DONE] sentinels = %d, want exactly 1:\n%s", got, out)
+	}
+
+	chunks, done := parseChunks(t, out)
+	if !done {
+		t.Fatalf("stream did not end with [DONE]:\n%s", out)
+	}
+	if got := joinContent(chunks); got != "Hi" {
+		t.Errorf("content = %q, want Hi", got)
+	}
+	terminal := 0
+	for _, c := range chunks {
+		if c.Choices[0].FinishReason != nil {
+			terminal++
+		}
+	}
+	if terminal != 1 {
+		t.Errorf("chunks carrying a finish_reason = %d, want exactly 1:\n%s", terminal, out)
+	}
+}
+
+// A ping arriving after the sentinel stays silent: nothing may follow [DONE].
+func TestStreamTranslator_PingAfterDoneEmitsNothing(t *testing.T) {
+	tr := NewStreamTranslator("chatcmpl-ping3", "m", 1)
+	feed(t, tr, `{"type":"message_stop"}`)
+	out, err := tr.Translate([]byte(`{"type":"ping"}`))
+	if err != nil {
+		t.Fatalf("Translate(ping): %v", err)
+	}
+	if len(out) != 0 {
+		t.Errorf("ping after [DONE] emitted %q, want nothing", out)
 	}
 }

--- a/internal/gemini/request.go
+++ b/internal/gemini/request.go
@@ -10,6 +10,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+
+	"github.com/hugalafutro/model-hotel/internal/jsonfault"
 )
 
 // --- Incoming OpenAI chat-completions request shape ---
@@ -175,7 +177,7 @@ var reasoningBudgets = map[string]int{
 func TranslateRequest(body []byte) (geminiBody []byte, model string, stream bool, err error) {
 	var req oaiRequest
 	if err := json.Unmarshal(body, &req); err != nil {
-		return nil, "", false, fmt.Errorf("gemini: invalid request body: %s", jsonFault(err, len(body)))
+		return nil, "", false, fmt.Errorf("gemini: invalid request body: %s", jsonfault.Describe(err, len(body)))
 	}
 	if req.Model == "" {
 		return nil, "", false, fmt.Errorf("gemini: model is required")
@@ -333,7 +335,7 @@ func translateParts(raw json.RawMessage) ([]genPart, error) {
 
 	var oaiParts []oaiContentPart
 	if err := json.Unmarshal(raw, &oaiParts); err != nil {
-		return nil, fmt.Errorf("gemini: invalid message content: %w", err)
+		return nil, fmt.Errorf("gemini: invalid message content: %s", jsonfault.Describe(err, len(raw)))
 	}
 	var parts []genPart
 	for _, p := range oaiParts {

--- a/internal/gemini/request.go
+++ b/internal/gemini/request.go
@@ -175,7 +175,7 @@ var reasoningBudgets = map[string]int{
 func TranslateRequest(body []byte) (geminiBody []byte, model string, stream bool, err error) {
 	var req oaiRequest
 	if err := json.Unmarshal(body, &req); err != nil {
-		return nil, "", false, fmt.Errorf("gemini: invalid request body: %w", err)
+		return nil, "", false, fmt.Errorf("gemini: invalid request body: %s", jsonFault(err, len(body)))
 	}
 	if req.Model == "" {
 		return nil, "", false, fmt.Errorf("gemini: model is required")

--- a/internal/gemini/request_test.go
+++ b/internal/gemini/request_test.go
@@ -584,7 +584,7 @@ func TestTranslateRequest_DecodeErrorOmitsPayload(t *testing.T) {
 		{
 			name:    "type error",
 			payload: `{"model":8675309.42}`,
-			want:    "undecodable JSON (",
+			want:    "unexpected JSON value at byte ",
 			secret:  "8675309.42",
 		},
 	}
@@ -601,5 +601,22 @@ func TestTranslateRequest_DecodeErrorOmitsPayload(t *testing.T) {
 				t.Errorf("error leaked the payload: %q", err)
 			}
 		})
+	}
+}
+
+func TestTranslateRequest_MessageContentErrorOmitsPayload(t *testing.T) {
+	// The per-message content decoder sees the user's own prompt. A syntax
+	// error cannot reach it (the outer body parse fails first), but a type
+	// error can, and *json.UnmarshalTypeError prints the offending literal
+	// verbatim — so that is what must not survive into the error.
+	_, _, _, err := TranslateRequest([]byte(`{"model":"m","messages":[{"role":"user","content":[8675309.42]}]}`))
+	if err == nil {
+		t.Fatal("expected an error for undecodable message content")
+	}
+	if !strings.HasPrefix(err.Error(), "gemini: invalid message content: unexpected JSON value at byte ") {
+		t.Errorf("error = %q, want the sanitized unexpected-value form", err)
+	}
+	if strings.Contains(err.Error(), "8675309.42") {
+		t.Errorf("error leaked the message content: %q", err)
 	}
 }

--- a/internal/gemini/request_test.go
+++ b/internal/gemini/request_test.go
@@ -564,3 +564,42 @@ func TestTranslateRequest_NoTranslatableMessages(t *testing.T) {
 		}
 	}
 }
+
+func TestTranslateRequest_DecodeErrorOmitsPayload(t *testing.T) {
+	// A malformed request body is the user's own prompt: encoding/json quotes the
+	// offending byte and prints an offending literal verbatim, so the error must
+	// say WHERE the body broke and nothing about what it said.
+	cases := []struct {
+		name    string
+		payload string
+		want    string
+		secret  string
+	}{
+		{
+			name:    "syntax error",
+			payload: `{"model":"gemini-x","messages":[{"role":"user","content":"Kohlrabi"`,
+			want:    "malformed JSON at byte ",
+			secret:  "Kohlrabi",
+		},
+		{
+			name:    "type error",
+			payload: `{"model":8675309.42}`,
+			want:    "undecodable JSON (",
+			secret:  "8675309.42",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, _, err := TranslateRequest([]byte(tc.payload))
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if !strings.HasPrefix(err.Error(), "gemini: invalid request body: "+tc.want) {
+				t.Errorf("error = %q, want the sanitized %q form", err, tc.want)
+			}
+			if strings.Contains(err.Error(), tc.secret) {
+				t.Errorf("error leaked the payload: %q", err)
+			}
+		})
+	}
+}

--- a/internal/gemini/response.go
+++ b/internal/gemini/response.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+
+	"github.com/hugalafutro/model-hotel/internal/jsonfault"
 )
 
 // --- Incoming Gemini generateContent response shape ---
@@ -91,7 +93,7 @@ type oaiUsage struct {
 func BuildChatCompletion(body []byte, id, model string, created int64) ([]byte, error) {
 	var resp genResponse
 	if err := json.Unmarshal(body, &resp); err != nil {
-		return nil, fmt.Errorf("gemini: invalid upstream response: %s", jsonFault(err, len(body)))
+		return nil, fmt.Errorf("gemini: invalid upstream response: %s", jsonfault.Describe(err, len(body)))
 	}
 	if len(resp.Candidates) == 0 {
 		reason := "no candidates in response"

--- a/internal/gemini/response.go
+++ b/internal/gemini/response.go
@@ -91,7 +91,7 @@ type oaiUsage struct {
 func BuildChatCompletion(body []byte, id, model string, created int64) ([]byte, error) {
 	var resp genResponse
 	if err := json.Unmarshal(body, &resp); err != nil {
-		return nil, fmt.Errorf("gemini: invalid upstream response: %w", err)
+		return nil, fmt.Errorf("gemini: invalid upstream response: %s", jsonFault(err, len(body)))
 	}
 	if len(resp.Candidates) == 0 {
 		reason := "no candidates in response"

--- a/internal/gemini/response_test.go
+++ b/internal/gemini/response_test.go
@@ -2,6 +2,7 @@ package gemini
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -150,5 +151,43 @@ func TestBuildChatCompletion_SafetyAndErrors(t *testing.T) {
 	// Prompt blocked: no candidates at all.
 	if _, err := BuildChatCompletion([]byte(`{"promptFeedback": {"blockReason": "SAFETY"}}`), "id", "m", 0); err == nil {
 		t.Error("expected error for zero candidates")
+	}
+}
+
+func TestBuildChatCompletion_DecodeErrorOmitsPayload(t *testing.T) {
+	// A malformed response body is model output; the decode error reports the
+	// offset, never the content.
+	cases := []struct {
+		name    string
+		payload string
+		want    string
+		secret  string
+	}{
+		{
+			name:    "syntax error",
+			payload: `{"candidates":[{"content":{"parts":[{"text":"Kohlrabi"`,
+			want:    "malformed JSON at byte ",
+			secret:  "Kohlrabi",
+		},
+		{
+			name:    "type error",
+			payload: `{"usageMetadata":{"promptTokenCount":8675309.42}}`,
+			want:    "undecodable JSON (",
+			secret:  "8675309.42",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := BuildChatCompletion([]byte(tc.payload), "id", "m", 0)
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if !strings.HasPrefix(err.Error(), "gemini: invalid upstream response: "+tc.want) {
+				t.Errorf("error = %q, want the sanitized %q form", err, tc.want)
+			}
+			if strings.Contains(err.Error(), tc.secret) {
+				t.Errorf("error leaked the payload: %q", err)
+			}
+		})
 	}
 }

--- a/internal/gemini/response_test.go
+++ b/internal/gemini/response_test.go
@@ -172,7 +172,7 @@ func TestBuildChatCompletion_DecodeErrorOmitsPayload(t *testing.T) {
 		{
 			name:    "type error",
 			payload: `{"usageMetadata":{"promptTokenCount":8675309.42}}`,
-			want:    "undecodable JSON (",
+			want:    "unexpected JSON value at byte ",
 			secret:  "8675309.42",
 		},
 	}

--- a/internal/gemini/stream.go
+++ b/internal/gemini/stream.go
@@ -3,24 +3,10 @@ package gemini
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
-)
 
-// jsonFault describes a JSON decode failure without echoing the document that
-// caused it. encoding/json's own messages embed a fragment of the input — a
-// *json.SyntaxError quotes the offending byte, a *json.UnmarshalTypeError the
-// offending literal — and every document this package decodes carries prompt or
-// response content, which must never reach an error string or a log line. The
-// byte offset and the document length are structure, not content, so they stay:
-// they are what makes a malformed stream diagnosable.
-func jsonFault(err error, size int) string {
-	var syntaxErr *json.SyntaxError
-	if errors.As(err, &syntaxErr) {
-		return fmt.Sprintf("malformed JSON at byte %d of %d", syntaxErr.Offset, size)
-	}
-	return fmt.Sprintf("undecodable JSON (%d bytes)", size)
-}
+	"github.com/hugalafutro/model-hotel/internal/jsonfault"
+)
 
 // StreamTranslator converts a Gemini streamGenerateContent SSE stream
 // (alt=sse: each data line is a full generateContent-shaped JSON chunk) into
@@ -114,7 +100,7 @@ func (t *StreamTranslator) writeChunk(buf *bytes.Buffer, delta oaiChunkDelta, fi
 func (t *StreamTranslator) Translate(chunkJSON []byte) ([]byte, error) {
 	var chunk genResponse
 	if err := json.Unmarshal(chunkJSON, &chunk); err != nil {
-		return nil, fmt.Errorf("gemini: invalid stream chunk: %s", jsonFault(err, len(chunkJSON)))
+		return nil, fmt.Errorf("gemini: invalid stream chunk: %s", jsonfault.Describe(err, len(chunkJSON)))
 	}
 
 	if chunk.UsageMetadata != nil {

--- a/internal/gemini/stream.go
+++ b/internal/gemini/stream.go
@@ -3,8 +3,24 @@ package gemini
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 )
+
+// jsonFault describes a JSON decode failure without echoing the document that
+// caused it. encoding/json's own messages embed a fragment of the input — a
+// *json.SyntaxError quotes the offending byte, a *json.UnmarshalTypeError the
+// offending literal — and every document this package decodes carries prompt or
+// response content, which must never reach an error string or a log line. The
+// byte offset and the document length are structure, not content, so they stay:
+// they are what makes a malformed stream diagnosable.
+func jsonFault(err error, size int) string {
+	var syntaxErr *json.SyntaxError
+	if errors.As(err, &syntaxErr) {
+		return fmt.Sprintf("malformed JSON at byte %d of %d", syntaxErr.Offset, size)
+	}
+	return fmt.Sprintf("undecodable JSON (%d bytes)", size)
+}
 
 // StreamTranslator converts a Gemini streamGenerateContent SSE stream
 // (alt=sse: each data line is a full generateContent-shaped JSON chunk) into
@@ -98,7 +114,7 @@ func (t *StreamTranslator) writeChunk(buf *bytes.Buffer, delta oaiChunkDelta, fi
 func (t *StreamTranslator) Translate(chunkJSON []byte) ([]byte, error) {
 	var chunk genResponse
 	if err := json.Unmarshal(chunkJSON, &chunk); err != nil {
-		return nil, fmt.Errorf("gemini: invalid stream chunk: %w", err)
+		return nil, fmt.Errorf("gemini: invalid stream chunk: %s", jsonFault(err, len(chunkJSON)))
 	}
 
 	if chunk.UsageMetadata != nil {

--- a/internal/gemini/stream_test.go
+++ b/internal/gemini/stream_test.go
@@ -258,7 +258,7 @@ func TestStreamTranslator_DecodeErrorOmitsPayload(t *testing.T) {
 		{
 			name:   "type error",
 			chunk:  `{"usageMetadata":{"promptTokenCount":8675309.42}}`,
-			want:   "undecodable JSON (",
+			want:   "unexpected JSON value at byte ",
 			secret: "8675309.42",
 		},
 	}

--- a/internal/gemini/stream_test.go
+++ b/internal/gemini/stream_test.go
@@ -237,3 +237,43 @@ func TestStreamTranslator_InvalidChunk(t *testing.T) {
 		t.Error("expected error for invalid chunk JSON")
 	}
 }
+
+func TestStreamTranslator_DecodeErrorOmitsPayload(t *testing.T) {
+	// encoding/json quotes the offending byte and prints an offending literal
+	// verbatim; a stream chunk is model output, which must never reach an error
+	// string or a log line. The error says WHERE the chunk broke, not what it
+	// said.
+	cases := []struct {
+		name   string
+		chunk  string
+		want   string
+		secret string
+	}{
+		{
+			name:   "syntax error",
+			chunk:  `{"candidates":[{"content":{"parts":[{"text":"Kohlrabi"`,
+			want:   "malformed JSON at byte ",
+			secret: "Kohlrabi",
+		},
+		{
+			name:   "type error",
+			chunk:  `{"usageMetadata":{"promptTokenCount":8675309.42}}`,
+			want:   "undecodable JSON (",
+			secret: "8675309.42",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewStreamTranslator("id", "m", 0).Translate([]byte(tc.chunk))
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if !strings.HasPrefix(err.Error(), "gemini: invalid stream chunk: "+tc.want) {
+				t.Errorf("error = %q, want the sanitized %q form", err, tc.want)
+			}
+			if strings.Contains(err.Error(), tc.secret) {
+				t.Errorf("error leaked the chunk: %q", err)
+			}
+		})
+	}
+}

--- a/internal/jsonfault/jsonfault.go
+++ b/internal/jsonfault/jsonfault.go
@@ -1,0 +1,42 @@
+// Package jsonfault renders a JSON decode failure as a diagnostic that cannot
+// echo the document it failed on.
+//
+// encoding/json's own error strings quote a fragment of their input: a
+// *json.SyntaxError names the offending byte ("invalid character 'K' looking
+// for beginning of value") and a *json.UnmarshalTypeError prints the offending
+// literal verbatim ("cannot unmarshal number 8675309.42 into ..."). Wrapping
+// such an error with %w therefore carries that fragment into every error string
+// and log line built from it.
+//
+// The dialect translators decode documents that are prompt or completion
+// content: client request bodies, upstream responses, streaming events. None of
+// that content may ever reach a log or an error message, so those decode
+// failures are described through this package instead of wrapped. The byte
+// offset and the document length are structure rather than content, and they
+// are what makes a broken document diagnosable, so they stay.
+package jsonfault
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// Describe returns a content-free description of a JSON decode failure. size is
+// the length of the document that failed to decode. The result is a phrase, not
+// a sentence: callers prefix it with their own context, e.g.
+//
+//	fmt.Errorf("gemini: invalid stream chunk: %s", jsonfault.Describe(err, len(chunk)))
+func Describe(err error, size int) string {
+	var syntaxErr *json.SyntaxError
+	if errors.As(err, &syntaxErr) {
+		return fmt.Sprintf("malformed JSON at byte %d of %d", syntaxErr.Offset, size)
+	}
+	var typeErr *json.UnmarshalTypeError
+	if errors.As(err, &typeErr) {
+		// Neither Value nor Field is reported: Value is the offending literal
+		// itself, and Field is built from the document's own keys.
+		return fmt.Sprintf("unexpected JSON value at byte %d of %d", typeErr.Offset, size)
+	}
+	return fmt.Sprintf("undecodable JSON (%d bytes)", size)
+}

--- a/internal/jsonfault/jsonfault_test.go
+++ b/internal/jsonfault/jsonfault_test.go
@@ -1,0 +1,112 @@
+package jsonfault
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// decodeErr returns the error encoding/json produces for the given document,
+// decoded into the given target.
+func decodeErr(t *testing.T, doc string, target any) error {
+	t.Helper()
+	err := json.Unmarshal([]byte(doc), target)
+	if err == nil {
+		t.Fatalf("document %q decoded without error", doc)
+	}
+	return err
+}
+
+func TestDescribe_SyntaxError(t *testing.T) {
+	// A *json.SyntaxError quotes the offending byte, so the raw message would
+	// carry a character of the document. The description reports position only.
+	var v struct {
+		Text string `json:"text"`
+	}
+	doc := `{"text":"Kohlrabi"` // truncated
+	err := decodeErr(t, doc, &v)
+
+	var syntaxErr *json.SyntaxError
+	if !errors.As(err, &syntaxErr) {
+		t.Fatalf("err = %T, want *json.SyntaxError", err)
+	}
+	got := Describe(err, len(doc))
+	want := "malformed JSON at byte 18 of 18"
+	if got != want {
+		t.Errorf("Describe = %q, want %q", got, want)
+	}
+}
+
+func TestDescribe_UnmarshalTypeError(t *testing.T) {
+	// A *json.UnmarshalTypeError prints the offending literal verbatim
+	// ("number 8675309.42") and names the field it landed in; neither may
+	// survive into the description.
+	var v struct {
+		Count int `json:"Kohlrabi"`
+	}
+	doc := `{"Kohlrabi":8675309.42}`
+	err := decodeErr(t, doc, &v)
+
+	var typeErr *json.UnmarshalTypeError
+	if !errors.As(err, &typeErr) {
+		t.Fatalf("err = %T, want *json.UnmarshalTypeError", err)
+	}
+	if !strings.Contains(err.Error(), "8675309.42") {
+		t.Fatalf("precondition failed: %q no longer carries the literal", err)
+	}
+
+	got := Describe(err, len(doc))
+	if !strings.HasPrefix(got, "unexpected JSON value at byte ") {
+		t.Errorf("Describe = %q, want an unexpected-value description", got)
+	}
+	if !strings.HasSuffix(got, " of 23") {
+		t.Errorf("Describe = %q, want the document length reported", got)
+	}
+	if strings.Contains(got, "8675309.42") || strings.Contains(got, "Kohlrabi") {
+		t.Errorf("Describe leaked the document: %q", got)
+	}
+}
+
+func TestDescribe_OtherErrorKinds(t *testing.T) {
+	// Anything else — a custom UnmarshalJSON's own error, an opaque sentinel —
+	// falls back to the size alone, since only the caller knows whether such an
+	// error is safe to print.
+	cases := map[string]error{
+		"custom unmarshaler error": json.Unmarshal([]byte(`{}`), &pickyTarget{}),
+		"opaque error":             errors.New("Kohlrabi is not a fruit"),
+	}
+	for name, err := range cases {
+		t.Run(name, func(t *testing.T) {
+			if err == nil {
+				t.Fatal("precondition failed: no error to describe")
+			}
+			got := Describe(err, 42)
+			if got != "undecodable JSON (42 bytes)" {
+				t.Errorf("Describe = %q, want the generic form", got)
+			}
+		})
+	}
+}
+
+func TestDescribe_WrappedErrorsAreMatched(t *testing.T) {
+	// Callers may hand over an error some intermediate layer already wrapped;
+	// errors.As must still find the concrete kind underneath.
+	var v struct {
+		Text string `json:"text"`
+	}
+	doc := `{"text":"Kohlrabi"`
+	wrapped := errFmt(decodeErr(t, doc, &v))
+	if got := Describe(wrapped, len(doc)); !strings.HasPrefix(got, "malformed JSON at byte ") {
+		t.Errorf("Describe = %q, want the wrapped syntax error to be recognised", got)
+	}
+}
+
+// errFmt wraps err the way an intermediate layer would.
+func errFmt(err error) error { return errors.Join(errors.New("upstream read"), err) }
+
+// pickyTarget rejects every document with an error of its own making, standing
+// in for a type whose UnmarshalJSON fails for reasons encoding/json never sees.
+type pickyTarget struct{}
+
+func (*pickyTarget) UnmarshalJSON([]byte) error { return errors.New("Kohlrabi is not a fruit") }

--- a/internal/openairesponses/request.go
+++ b/internal/openairesponses/request.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+
+	"github.com/hugalafutro/model-hotel/internal/jsonfault"
 )
 
 // --- Incoming OpenAI chat-completions request shape ---
@@ -68,7 +70,7 @@ type chatContentPart struct {
 func TranslateChatToResponses(chatBody []byte, resolvedModel string) ([]byte, error) {
 	var req chatRequest
 	if err := json.Unmarshal(chatBody, &req); err != nil {
-		return nil, fmt.Errorf("openairesponses: invalid chat request body: %s", jsonFault(err, len(chatBody)))
+		return nil, fmt.Errorf("openairesponses: invalid chat request body: %s", jsonfault.Describe(err, len(chatBody)))
 	}
 
 	out := Request{
@@ -199,7 +201,7 @@ func translateUserContent(raw json.RawMessage) ([]contentPart, error) {
 	}
 	var parts []chatContentPart
 	if err := json.Unmarshal(raw, &parts); err != nil {
-		return nil, fmt.Errorf("openairesponses: invalid message content: %w", err)
+		return nil, fmt.Errorf("openairesponses: invalid message content: %s", jsonfault.Describe(err, len(raw)))
 	}
 	var out []contentPart
 	for _, p := range parts {

--- a/internal/openairesponses/request.go
+++ b/internal/openairesponses/request.go
@@ -68,7 +68,7 @@ type chatContentPart struct {
 func TranslateChatToResponses(chatBody []byte, resolvedModel string) ([]byte, error) {
 	var req chatRequest
 	if err := json.Unmarshal(chatBody, &req); err != nil {
-		return nil, fmt.Errorf("openairesponses: invalid chat request body: %w", err)
+		return nil, fmt.Errorf("openairesponses: invalid chat request body: %s", jsonFault(err, len(chatBody)))
 	}
 
 	out := Request{

--- a/internal/openairesponses/request_test.go
+++ b/internal/openairesponses/request_test.go
@@ -265,7 +265,7 @@ func TestTranslateChatToResponses_DecodeErrorOmitsPayload(t *testing.T) {
 		{
 			name:    "type error",
 			payload: `{"model":8675309.42}`,
-			want:    "undecodable JSON (",
+			want:    "unexpected JSON value at byte ",
 			secret:  "8675309.42",
 		},
 	}
@@ -282,5 +282,22 @@ func TestTranslateChatToResponses_DecodeErrorOmitsPayload(t *testing.T) {
 				t.Errorf("error leaked the payload: %q", err)
 			}
 		})
+	}
+}
+
+func TestTranslateChatToResponses_MessageContentErrorOmitsPayload(t *testing.T) {
+	// The per-message content decoder sees the user's own prompt. A syntax
+	// error cannot reach it (the outer body parse fails first), but a type
+	// error can, and *json.UnmarshalTypeError prints the offending literal
+	// verbatim — so that is what must not survive into the error.
+	_, err := TranslateChatToResponses([]byte(`{"model":"m","messages":[{"role":"user","content":[8675309.42]}]}`), "m")
+	if err == nil {
+		t.Fatal("expected an error for undecodable message content")
+	}
+	if !strings.HasPrefix(err.Error(), "openairesponses: invalid message content: unexpected JSON value at byte ") {
+		t.Errorf("error = %q, want the sanitized unexpected-value form", err)
+	}
+	if strings.Contains(err.Error(), "8675309.42") {
+		t.Errorf("error leaked the message content: %q", err)
 	}
 }

--- a/internal/openairesponses/request_test.go
+++ b/internal/openairesponses/request_test.go
@@ -2,6 +2,7 @@ package openairesponses
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -242,5 +243,44 @@ func TestTranslateChat_EdgeCases(t *testing.T) {
 func TestTranslateChat_InvalidBody(t *testing.T) {
 	if _, err := TranslateChatToResponses([]byte("not json"), "m"); err == nil {
 		t.Error("want error for invalid body")
+	}
+}
+
+func TestTranslateChatToResponses_DecodeErrorOmitsPayload(t *testing.T) {
+	// A malformed request body is the user's own prompt: encoding/json quotes the
+	// offending byte and prints an offending literal verbatim, so the error must
+	// say WHERE the body broke and nothing about what it said.
+	cases := []struct {
+		name    string
+		payload string
+		want    string
+		secret  string
+	}{
+		{
+			name:    "syntax error",
+			payload: `{"model":"gpt-x","messages":[{"role":"user","content":"Kohlrabi"`,
+			want:    "malformed JSON at byte ",
+			secret:  "Kohlrabi",
+		},
+		{
+			name:    "type error",
+			payload: `{"model":8675309.42}`,
+			want:    "undecodable JSON (",
+			secret:  "8675309.42",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := TranslateChatToResponses([]byte(tc.payload), "m")
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if !strings.HasPrefix(err.Error(), "openairesponses: invalid chat request body: "+tc.want) {
+				t.Errorf("error = %q, want the sanitized %q form", err, tc.want)
+			}
+			if strings.Contains(err.Error(), tc.secret) {
+				t.Errorf("error leaked the payload: %q", err)
+			}
+		})
 	}
 }

--- a/internal/openairesponses/response.go
+++ b/internal/openairesponses/response.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/hugalafutro/model-hotel/internal/jsonfault"
 )
 
 // TranslateResponsesToChat converts a non-streaming Responses API response
@@ -18,7 +20,7 @@ import (
 func TranslateResponsesToChat(respBody []byte, model string) ([]byte, error) {
 	var resp Response
 	if err := json.Unmarshal(respBody, &resp); err != nil {
-		return nil, fmt.Errorf("openairesponses: invalid upstream response: %s", jsonFault(err, len(respBody)))
+		return nil, fmt.Errorf("openairesponses: invalid upstream response: %s", jsonfault.Describe(err, len(respBody)))
 	}
 	// A Responses body always carries an object id and a status; a 200 body
 	// without either is not a Responses payload and must not be silently

--- a/internal/openairesponses/response.go
+++ b/internal/openairesponses/response.go
@@ -18,7 +18,7 @@ import (
 func TranslateResponsesToChat(respBody []byte, model string) ([]byte, error) {
 	var resp Response
 	if err := json.Unmarshal(respBody, &resp); err != nil {
-		return nil, fmt.Errorf("openairesponses: invalid upstream response: %w", err)
+		return nil, fmt.Errorf("openairesponses: invalid upstream response: %s", jsonFault(err, len(respBody)))
 	}
 	// A Responses body always carries an object id and a status; a 200 body
 	// without either is not a Responses payload and must not be silently

--- a/internal/openairesponses/response_test.go
+++ b/internal/openairesponses/response_test.go
@@ -177,7 +177,7 @@ func TestTranslateResponsesToChat_DecodeErrorOmitsPayload(t *testing.T) {
 		{
 			name:    "type error",
 			payload: `{"id":8675309.42}`,
-			want:    "undecodable JSON (",
+			want:    "unexpected JSON value at byte ",
 			secret:  "8675309.42",
 		},
 	}

--- a/internal/openairesponses/response_test.go
+++ b/internal/openairesponses/response_test.go
@@ -158,3 +158,41 @@ func TestTranslateResponses_NotAResponsesBody(t *testing.T) {
 		t.Error("want error for invalid JSON")
 	}
 }
+
+func TestTranslateResponsesToChat_DecodeErrorOmitsPayload(t *testing.T) {
+	// A malformed response body is model output; the decode error reports the
+	// offset, never the content.
+	cases := []struct {
+		name    string
+		payload string
+		want    string
+		secret  string
+	}{
+		{
+			name:    "syntax error",
+			payload: `{"id":"resp_1","status":"completed","output":[{"type":"message","content":[{"type":"output_text","text":"Kohlrabi"`,
+			want:    "malformed JSON at byte ",
+			secret:  "Kohlrabi",
+		},
+		{
+			name:    "type error",
+			payload: `{"id":8675309.42}`,
+			want:    "undecodable JSON (",
+			secret:  "8675309.42",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := TranslateResponsesToChat([]byte(tc.payload), "m")
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if !strings.HasPrefix(err.Error(), "openairesponses: invalid upstream response: "+tc.want) {
+				t.Errorf("error = %q, want the sanitized %q form", err, tc.want)
+			}
+			if strings.Contains(err.Error(), tc.secret) {
+				t.Errorf("error leaked the payload: %q", err)
+			}
+		})
+	}
+}

--- a/internal/openairesponses/stream.go
+++ b/internal/openairesponses/stream.go
@@ -3,6 +3,7 @@ package openairesponses
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -63,6 +64,21 @@ type streamEvent struct {
 	Message string `json:"message"`
 }
 
+// jsonFault describes a JSON decode failure without echoing the document that
+// caused it. encoding/json's own messages embed a fragment of the input — a
+// *json.SyntaxError quotes the offending byte, a *json.UnmarshalTypeError the
+// offending literal — and every document this package decodes carries prompt or
+// response content, which must never reach an error string or a log line. The
+// byte offset and the document length are structure, not content, so they stay:
+// they are what makes a malformed stream diagnosable.
+func jsonFault(err error, size int) string {
+	var syntaxErr *json.SyntaxError
+	if errors.As(err, &syntaxErr) {
+		return fmt.Sprintf("malformed JSON at byte %d of %d", syntaxErr.Offset, size)
+	}
+	return fmt.Sprintf("undecodable JSON (%d bytes)", size)
+}
+
 // TranslateEvent processes one Responses SSE data payload and returns the
 // chat-completions SSE bytes to forward (possibly empty). After the terminal
 // response.* event it emits the finish chunk, a usage chunk and [DONE]; any
@@ -73,7 +89,7 @@ func (t *StreamTranslator) TranslateEvent(data []byte) ([]byte, error) {
 	}
 	var ev streamEvent
 	if err := json.Unmarshal(data, &ev); err != nil {
-		return nil, fmt.Errorf("openairesponses: invalid stream event: %w", err)
+		return nil, fmt.Errorf("openairesponses: invalid stream event: %s", jsonFault(err, len(data)))
 	}
 
 	switch ev.Type {

--- a/internal/openairesponses/stream.go
+++ b/internal/openairesponses/stream.go
@@ -3,7 +3,6 @@ package openairesponses
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -12,6 +11,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
+	"github.com/hugalafutro/model-hotel/internal/jsonfault"
 )
 
 // StreamTranslator converts the Responses API typed SSE event stream into the
@@ -64,21 +64,6 @@ type streamEvent struct {
 	Message string `json:"message"`
 }
 
-// jsonFault describes a JSON decode failure without echoing the document that
-// caused it. encoding/json's own messages embed a fragment of the input — a
-// *json.SyntaxError quotes the offending byte, a *json.UnmarshalTypeError the
-// offending literal — and every document this package decodes carries prompt or
-// response content, which must never reach an error string or a log line. The
-// byte offset and the document length are structure, not content, so they stay:
-// they are what makes a malformed stream diagnosable.
-func jsonFault(err error, size int) string {
-	var syntaxErr *json.SyntaxError
-	if errors.As(err, &syntaxErr) {
-		return fmt.Sprintf("malformed JSON at byte %d of %d", syntaxErr.Offset, size)
-	}
-	return fmt.Sprintf("undecodable JSON (%d bytes)", size)
-}
-
 // TranslateEvent processes one Responses SSE data payload and returns the
 // chat-completions SSE bytes to forward (possibly empty). After the terminal
 // response.* event it emits the finish chunk, a usage chunk and [DONE]; any
@@ -89,7 +74,7 @@ func (t *StreamTranslator) TranslateEvent(data []byte) ([]byte, error) {
 	}
 	var ev streamEvent
 	if err := json.Unmarshal(data, &ev); err != nil {
-		return nil, fmt.Errorf("openairesponses: invalid stream event: %s", jsonFault(err, len(data)))
+		return nil, fmt.Errorf("openairesponses: invalid stream event: %s", jsonfault.Describe(err, len(data)))
 	}
 
 	switch ev.Type {

--- a/internal/openairesponses/stream_test.go
+++ b/internal/openairesponses/stream_test.go
@@ -184,6 +184,46 @@ func TestStream_UnknownEventsAndTruncation(t *testing.T) {
 	}
 }
 
+func TestStream_DecodeErrorOmitsPayload(t *testing.T) {
+	// encoding/json quotes the offending byte and prints an offending literal
+	// verbatim; a stream event carries model output, which must never reach an
+	// error string or a log line. The error says WHERE the event broke, not
+	// what it said.
+	cases := []struct {
+		name   string
+		event  string
+		want   string
+		secret string
+	}{
+		{
+			name:   "syntax error",
+			event:  `{"type":"response.output_text.delta","delta":"Kohlrabi"`,
+			want:   "malformed JSON at byte ",
+			secret: "Kohlrabi",
+		},
+		{
+			name:   "type error",
+			event:  `{"type":"response.output_text.delta","delta":8675309.42}`,
+			want:   "undecodable JSON (",
+			secret: "8675309.42",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewStreamTranslator("m").TranslateEvent([]byte(tc.event))
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if !strings.HasPrefix(err.Error(), "openairesponses: invalid stream event: "+tc.want) {
+				t.Errorf("error = %q, want the sanitized %q form", err, tc.want)
+			}
+			if strings.Contains(err.Error(), tc.secret) {
+				t.Errorf("error leaked the event: %q", err)
+			}
+		})
+	}
+}
+
 // A failed response surfaces as an OpenAI-style error frame so the streaming
 // pipeline records the provider's message, then the stream ends.
 func TestStream_FailedResponse(t *testing.T) {

--- a/internal/openairesponses/stream_test.go
+++ b/internal/openairesponses/stream_test.go
@@ -204,7 +204,7 @@ func TestStream_DecodeErrorOmitsPayload(t *testing.T) {
 		{
 			name:   "type error",
 			event:  `{"type":"response.output_text.delta","delta":8675309.42}`,
-			want:   "undecodable JSON (",
+			want:   "unexpected JSON value at byte ",
 			secret: "8675309.42",
 		},
 	}

--- a/internal/proxy/anthropic_egress.go
+++ b/internal/proxy/anthropic_egress.go
@@ -3,12 +3,7 @@ package proxy
 import (
 	"bytes"
 	"context"
-	"io"
 	"net/http"
-	"strings"
-	"time"
-
-	"github.com/google/uuid"
 
 	"github.com/hugalafutro/model-hotel/internal/anthropicegress"
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
@@ -68,24 +63,4 @@ func (h *Handler) buildAnthropicEgressRequest(ctx context.Context, st *requestSt
 	util.SetProviderAuthHeaders(proxyReq, providerType, candidate.apiKey)
 	proxyReq.Header.Set("Content-Type", "application/json")
 	return proxyReq, providerType, targetURL, nil
-}
-
-// translateAnthropicEgressResponseBody swaps a non-streaming Messages 200 body
-// for its chat.completion translation so handleNonStreamingResponse can meter
-// and forward it unchanged.
-func translateAnthropicEgressResponseBody(resp *http.Response, model string) error {
-	body, err := io.ReadAll(resp.Body)
-	_ = resp.Body.Close()
-	if err != nil {
-		resp.Body = io.NopCloser(bytes.NewReader(nil))
-		return err
-	}
-	id := "chatcmpl-" + strings.ReplaceAll(uuid.NewString(), "-", "")
-	translated, err := anthropicegress.BuildChatCompletion(body, id, model, time.Now().Unix())
-	if err != nil {
-		resp.Body = io.NopCloser(bytes.NewReader(nil))
-		return err
-	}
-	resp.Body = io.NopCloser(bytes.NewReader(translated))
-	return nil
 }

--- a/internal/proxy/anthropic_egress.go
+++ b/internal/proxy/anthropic_egress.go
@@ -1,0 +1,91 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/hugalafutro/model-hotel/internal/anthropicegress"
+	"github.com/hugalafutro/model-hotel/internal/debuglog"
+	"github.com/hugalafutro/model-hotel/internal/paramrewrite"
+	"github.com/hugalafutro/model-hotel/internal/util"
+)
+
+// The Anthropic egress adapter. Anthropic's OpenAI-compat
+// /v1/chat/completions cannot express a document: an OpenAI {"type":"file"}
+// content part is rejected with `messages.0.user.content.str: Input should be
+// a valid string`. Such a request is translated to Anthropic's native
+// /v1/messages shape on the way out (internal/anthropicegress) and the answer
+// translated back on the upstream side of the pipeline — the same trick as the
+// gemini egress adapter and the /v1/responses re-route, so the TTFT probe,
+// stall watchdog, transforms and metering all run unchanged.
+
+// isAnthropicEgressAttempt reports whether this candidate is served through the
+// Anthropic egress adapter: a plain chat-completions request (no explicit
+// endpoint override, no multipart body) bound for an Anthropic provider and
+// carrying a content part the compat endpoint cannot express.
+//
+// An Anthropic-in request is excluded: it already has a better path
+// (buildNativeAnthropicRequest forwards its original Messages body verbatim),
+// and translating a body that is already Anthropic-shaped would corrupt it.
+func isAnthropicEgressAttempt(st *requestState, providerType string) bool {
+	if providerType != "anthropic" || st.anthropicIn {
+		return false
+	}
+	if st.endpointPath != "" || st.makeUpstreamBody != nil {
+		return false
+	}
+	return anthropicegress.NeedsNativeRouting(st.bodyBytes)
+}
+
+// buildAnthropicEgressRequest builds the upstream request for an Anthropic
+// egress attempt. The chat body goes through the shared rewrite path first
+// (model rename, learned strips; isStreaming=false so no stream_options is
+// injected — Anthropic has no such knob), then chat -> Messages translation.
+// One route serves both modes: Anthropic streams from /v1/messages too, with
+// the body's "stream" field making the difference.
+func (h *Handler) buildAnthropicEgressRequest(ctx context.Context, st *requestState, candidate modelCandidate, providerType string) (*http.Request, string, string, error) {
+	cleaned := paramrewrite.BuildUpstreamBody(st.bodyBytes, providerType, candidate.model.ModelID, st.reqModel, false, &h.deprecationCache, &h.paramRenameCache, nil, learnedScopeFor(candidate))
+	body, model, stream, err := anthropicegress.TranslateRequest(cleaned)
+	if err != nil {
+		return nil, providerType, "", err
+	}
+
+	targetURL := util.BuildProviderTargetURL(candidate.provider.BaseURL, providerType, "/messages")
+	debuglog.Info("proxy: routing via anthropic egress adapter", "target_url", targetURL, "model", model, "provider", candidate.provider.Name, "stream", stream)
+
+	proxyReq, err := newRequestWithContext(ctx, "POST", targetURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, providerType, targetURL, err
+	}
+	// SetProviderAuthHeaders already sends x-api-key + anthropic-version for
+	// this provider type, which is exactly what the native route requires.
+	util.SetProviderAuthHeaders(proxyReq, providerType, candidate.apiKey)
+	proxyReq.Header.Set("Content-Type", "application/json")
+	return proxyReq, providerType, targetURL, nil
+}
+
+// translateAnthropicEgressResponseBody swaps a non-streaming Messages 200 body
+// for its chat.completion translation so handleNonStreamingResponse can meter
+// and forward it unchanged.
+func translateAnthropicEgressResponseBody(resp *http.Response, model string) error {
+	body, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		resp.Body = io.NopCloser(bytes.NewReader(nil))
+		return err
+	}
+	id := "chatcmpl-" + strings.ReplaceAll(uuid.NewString(), "-", "")
+	translated, err := anthropicegress.BuildChatCompletion(body, id, model, time.Now().Unix())
+	if err != nil {
+		resp.Body = io.NopCloser(bytes.NewReader(nil))
+		return err
+	}
+	resp.Body = io.NopCloser(bytes.NewReader(translated))
+	return nil
+}

--- a/internal/proxy/anthropic_egress_test.go
+++ b/internal/proxy/anthropic_egress_test.go
@@ -9,7 +9,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -130,6 +132,34 @@ type anthropicUpstreamCall struct {
 	body map[string]any
 }
 
+// upstreamCallLog collects those records across goroutines: the httptest
+// handler appends from the server goroutine while the test goroutine reads and
+// resets between phases.
+type upstreamCallLog struct {
+	mu    sync.Mutex
+	calls []anthropicUpstreamCall
+}
+
+func (l *upstreamCallLog) record(c anthropicUpstreamCall) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.calls = append(l.calls, c)
+}
+
+// takeOne returns the single call of the phase just run and clears the log for
+// the next one, failing when the count is anything but one.
+func (l *upstreamCallLog) takeOne(t *testing.T, phase string) anthropicUpstreamCall {
+	t.Helper()
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	got := l.calls
+	l.calls = nil
+	if len(got) != 1 {
+		t.Fatalf("%s: upstream calls = %d, want 1", phase, len(got))
+	}
+	return got[0]
+}
+
 // TestChatCompletions_AnthropicEgress drives chat requests through the real
 // ChatCompletions pipeline against a fake Anthropic upstream. It proves the
 // whole adapter chain: a document-bearing request is translated to a Messages
@@ -137,7 +167,7 @@ type anthropicUpstreamCall struct {
 // chunks ending in [DONE]), while a text-only request to the same provider
 // stays on the untouched compat route.
 func TestChatCompletions_AnthropicEgress(t *testing.T) {
-	var calls []anthropicUpstreamCall
+	var log upstreamCallLog
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("x-api-key") != "test-api-key" {
 			t.Errorf("x-api-key = %q", r.Header.Get("x-api-key"))
@@ -149,7 +179,7 @@ func TestChatCompletions_AnthropicEgress(t *testing.T) {
 		}
 		var body map[string]any
 		_ = json.NewDecoder(r.Body).Decode(&body)
-		calls = append(calls, anthropicUpstreamCall{path: r.URL.Path, body: body})
+		log.record(anthropicUpstreamCall{path: r.URL.Path, body: body})
 
 		if r.URL.Path != "/v1/messages" {
 			// The compat route: answer in OpenAI shape, as Anthropic does.
@@ -199,22 +229,20 @@ func TestChatCompletions_AnthropicEgress(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("non-streaming: %d\n%s", w.Code, w.Body.String())
 	}
-	if len(calls) != 1 {
-		t.Fatalf("upstream calls = %d, want 1", len(calls))
+	call := log.takeOne(t, "non-streaming document")
+	if call.path != "/v1/messages" {
+		t.Fatalf("document request went to %s, want /v1/messages", call.path)
 	}
-	if calls[0].path != "/v1/messages" {
-		t.Fatalf("document request went to %s, want /v1/messages", calls[0].path)
+	if _, hasMessages := call.body["messages"]; !hasMessages {
+		t.Errorf("translated body has no messages: %v", call.body)
 	}
-	if _, hasMessages := calls[0].body["messages"]; !hasMessages {
-		t.Errorf("translated body has no messages: %v", calls[0].body)
+	if call.body["model"] != env.ModelName {
+		t.Errorf("upstream model = %v, want the resolved id %q", call.body["model"], env.ModelName)
 	}
-	if calls[0].body["model"] != env.ModelName {
-		t.Errorf("upstream model = %v, want the resolved id %q", calls[0].body["model"], env.ModelName)
+	if _, hasMaxTokens := call.body["max_tokens"]; !hasMaxTokens {
+		t.Errorf("Messages body missing the required max_tokens: %v", call.body)
 	}
-	if _, hasMaxTokens := calls[0].body["max_tokens"]; !hasMaxTokens {
-		t.Errorf("Messages body missing the required max_tokens: %v", calls[0].body)
-	}
-	assertDocumentBlockPresent(t, calls[0].body)
+	assertDocumentBlockPresent(t, call.body)
 
 	var resp map[string]any
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
@@ -235,19 +263,16 @@ func TestChatCompletions_AnthropicEgress(t *testing.T) {
 	}
 
 	// Text-only: the gate keeps it on the untouched compat route.
-	calls = nil
 	w = send(false, `"just text"`)
 	if w.Code != http.StatusOK {
 		t.Fatalf("text-only: %d\n%s", w.Code, w.Body.String())
 	}
-	if len(calls) != 1 {
-		t.Fatalf("upstream calls = %d, want 1", len(calls))
+	call = log.takeOne(t, "text-only")
+	if call.path != "/v1/chat/completions" {
+		t.Errorf("text-only request went to %s, want /v1/chat/completions", call.path)
 	}
-	if calls[0].path != "/v1/chat/completions" {
-		t.Errorf("text-only request went to %s, want /v1/chat/completions", calls[0].path)
-	}
-	if _, translated := calls[0].body["max_tokens"]; translated {
-		t.Errorf("text-only body was translated: %v", calls[0].body)
+	if _, translated := call.body["max_tokens"]; translated {
+		t.Errorf("text-only body was translated: %v", call.body)
 	}
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("text-only response not JSON: %v\n%s", err, w.Body.String())
@@ -258,16 +283,16 @@ func TestChatCompletions_AnthropicEgress(t *testing.T) {
 	}
 
 	// Streaming document: translated chunk stream ending in [DONE].
-	calls = nil
 	w = send(true, documentContent)
 	if w.Code != http.StatusOK {
 		t.Fatalf("streaming: %d\n%s", w.Code, w.Body.String())
 	}
-	if len(calls) != 1 || calls[0].path != "/v1/messages" {
-		t.Fatalf("streaming document calls = %+v, want one /v1/messages", calls)
+	call = log.takeOne(t, "streaming document")
+	if call.path != "/v1/messages" {
+		t.Fatalf("streaming document request went to %s, want /v1/messages", call.path)
 	}
-	if stream, _ := calls[0].body["stream"].(bool); !stream {
-		t.Errorf("streaming request lost its stream flag: %v", calls[0].body)
+	if stream, _ := call.body["stream"].(bool); !stream {
+		t.Errorf("streaming request lost its stream flag: %v", call.body)
 	}
 	sse := w.Body.String()
 	if !strings.Contains(sse, `"object":"chat.completion.chunk"`) {
@@ -345,5 +370,101 @@ func TestMessages_AnthropicProviderStaysNative(t *testing.T) {
 	}
 	if resp["type"] != "message" {
 		t.Errorf("response envelope = %v, want a verbatim Anthropic message", resp)
+	}
+}
+
+// A hedged streaming race builds its own request through buildCandidateRequest,
+// so a document-bearing candidate takes the egress route inside the race too —
+// and the hedged pipeline must see chat-completions SSE, not Anthropic events,
+// because the TTFT probe and everything after it only understand the former.
+func TestProbeStreamingCandidate_AnthropicEgress(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandler(h)
+
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		for _, ev := range []string{
+			`{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude","content":[],"usage":{"input_tokens":9,"output_tokens":1}}}`,
+			`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+			`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hedged"}}`,
+			`{"type":"content_block_stop","index":0}`,
+			`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":3}}`,
+			`{"type":"message_stop"}`,
+		} {
+			_, _ = io.WriteString(w, "data: "+ev+"\n\n")
+		}
+	}))
+	defer srv.Close()
+
+	st, cand := probeStateForServer(srv.URL)
+	st.bodyBytes = []byte(`{"model":"orig-model","stream":true,"messages":[{"role":"user","content":[{"type":"file","file":{"file_data":"` + pdfDataURI + `"}}]}]}`)
+	// An Anthropic base URL with the dialer pinned to the test server, so the
+	// candidate detects as anthropic while the bytes still land here.
+	cand.provider.BaseURL = "http://api.anthropic.com"
+	target := srv.Listener.Addr().String()
+	h.upstreamTransport = &http.Transport{
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, network, target)
+		},
+	}
+
+	res := h.probeStreamingCandidate(context.Background(), st, cand, 0, 5*time.Second, 30*time.Second)
+	if !res.won {
+		t.Fatalf("expected a win, got reqErr=%+v", res.reqErr)
+	}
+	defer func() { _ = res.resp.Body.Close() }()
+
+	if gotPath != "/v1/messages" {
+		t.Errorf("hedged document probe went to %s, want /v1/messages", gotPath)
+	}
+	if !st.anthropicEgressAttempt {
+		t.Error("buildCandidateRequest did not mark the hedged attempt as egress")
+	}
+
+	// The probe holds back the bytes it already read; the stream is both halves.
+	var sse strings.Builder
+	if res.preReadBuf != nil {
+		sse.Write(res.preReadBuf.Bytes())
+	}
+	rest, err := io.ReadAll(res.resp.Body)
+	if err != nil {
+		t.Fatalf("reading hedged stream: %v", err)
+	}
+	sse.Write(rest)
+	out := sse.String()
+
+	if !strings.Contains(out, `"object":"chat.completion.chunk"`) {
+		t.Errorf("hedged stream not translated to chat chunks:\n%s", out)
+	}
+	if !strings.Contains(out, `"content":"hedged"`) {
+		t.Errorf("content delta missing:\n%s", out)
+	}
+	if !strings.Contains(out, `"finish_reason":"stop"`) || !strings.Contains(out, "data: [DONE]") {
+		t.Errorf("terminal chunks missing:\n%s", out)
+	}
+}
+
+// A 400 is only readable as OpenAI when the attempt actually sent an OpenAI
+// body. Both 400 paths — sequential and hedged — gate on this one predicate, so
+// a dialect added later is covered at both sites by extending it.
+func TestSentChatCompletionsBody(t *testing.T) {
+	if !(&requestState{}).sentChatCompletionsBody() {
+		t.Error("a plain chat attempt must read as a chat-completions body")
+	}
+	tests := map[string]*requestState{
+		"native anthropic": {anthropicNativeAttempt: true},
+		"responses":        {responsesAttempt: true},
+		"gemini egress":    {geminiAttempt: true},
+		"anthropic egress": {anthropicEgressAttempt: true},
+	}
+	for name, st := range tests {
+		t.Run(name, func(t *testing.T) {
+			if st.sentChatCompletionsBody() {
+				t.Error("a dialect attempt must not read as a chat-completions body")
+			}
+		})
 	}
 }

--- a/internal/proxy/anthropic_egress_test.go
+++ b/internal/proxy/anthropic_egress_test.go
@@ -1,0 +1,349 @@
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/hugalafutro/model-hotel/internal/provider"
+)
+
+// pdfDataURI is a minimal base64 data: URI standing in for an uploaded PDF.
+// Only its media type matters to the adapter; the payload rides through as
+// opaque base64.
+const pdfDataURI = "data:application/pdf;base64,JVBERi0xLjQK"
+
+// isAnthropicEgressAttempt gates the whole adapter, so each disqualifier is
+// worth pinning: the compat endpoint stays in charge of everything it can
+// actually express, and an Anthropic-in request must reach the verbatim
+// passthrough rather than being translated a second time.
+func TestIsAnthropicEgressAttempt(t *testing.T) {
+	docBody := []byte(`{"model":"m","messages":[{"role":"user","content":[{"type":"file","file":{"file_data":"` + pdfDataURI + `"}}]}]}`)
+	textBody := []byte(`{"model":"m","messages":[{"role":"user","content":"hi"}]}`)
+
+	tests := []struct {
+		name         string
+		st           *requestState
+		providerType string
+		want         bool
+	}{
+		{"document to anthropic", &requestState{bodyBytes: docBody}, "anthropic", true},
+		{"text to anthropic", &requestState{bodyBytes: textBody}, "anthropic", false},
+		{"document to another provider", &requestState{bodyBytes: docBody}, "openai", false},
+		{"anthropic-in document", &requestState{bodyBytes: docBody, anthropicIn: true}, "anthropic", false},
+		{"endpoint override", &requestState{bodyBytes: docBody, endpointPath: "/audio/speech"}, "anthropic", false},
+		{"multimodal body builder", &requestState{
+			bodyBytes:        docBody,
+			makeUpstreamBody: func(string) ([]byte, string, error) { return nil, "", nil },
+		}, "anthropic", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isAnthropicEgressAttempt(tt.st, tt.providerType); got != tt.want {
+				t.Errorf("isAnthropicEgressAttempt = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// translateAnthropicEgressResponseBody swaps a Messages 200 body for its chat
+// translation in place, and errors on anything that is not a Messages response
+// so the caller fails over instead of forwarding garbage.
+func TestTranslateAnthropicEgressResponseBody(t *testing.T) {
+	resp := &http.Response{Body: newBodyReader(`{"id":"msg_1","type":"message","role":"assistant","model":"claude","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn","usage":{"input_tokens":3,"output_tokens":2}}`)}
+	if err := translateAnthropicEgressResponseBody(resp, "claude-sonnet-4-5"); err != nil {
+		t.Fatalf("translateAnthropicEgressResponseBody: %v", err)
+	}
+	var out map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("translated body not JSON: %v", err)
+	}
+	if out["object"] != "chat.completion" || out["model"] != "claude-sonnet-4-5" {
+		t.Errorf("translated = %v", out)
+	}
+	if id, _ := out["id"].(string); !strings.HasPrefix(id, "chatcmpl-") {
+		t.Errorf("id = %q, want a chatcmpl- id", id)
+	}
+
+	// An Anthropic error envelope must not become a synthetic empty success.
+	resp = &http.Response{Body: newBodyReader(`{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`)}
+	if err := translateAnthropicEgressResponseBody(resp, "m"); err == nil {
+		t.Error("expected error for an error envelope")
+	}
+	resp = &http.Response{Body: newBodyReader(`not json`)}
+	if err := translateAnthropicEgressResponseBody(resp, "m"); err == nil {
+		t.Error("expected error for invalid JSON body")
+	}
+}
+
+// The retirement probe reads the flag buildCandidateRequest set, so a probe
+// that ever routes through the adapter translates its answer before judging it.
+func TestTranslateProbeDialect_AnthropicEgress(t *testing.T) {
+	resp := &http.Response{Body: newBodyReader(`{"id":"msg_1","type":"message","role":"assistant","model":"claude","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn"}`)}
+	st := &requestState{anthropicEgressAttempt: true}
+	if err := translateProbeDialect(resp, st, "claude-sonnet-4-5"); err != nil {
+		t.Fatalf("translateProbeDialect: %v", err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("reading translated probe body: %v", err)
+	}
+	if !probeDeliveredContent(endpointTypeChat, body) {
+		t.Errorf("translated probe answer read as empty: %s", body)
+	}
+}
+
+// newAnthropicEgressEnv builds a test env whose provider detects as Anthropic
+// (api.anthropic.com base URL) while a pinned dialer routes the TCP connection
+// to the supplied test server.
+func newAnthropicEgressEnv(t *testing.T, upstream *httptest.Server) *testProxyEnv {
+	t.Helper()
+	env := newTestProxyEnvWithUpstream(t, upstream)
+	pool := testDB.Pool()
+	if _, err := pool.Exec(context.Background(),
+		`UPDATE providers SET base_url = 'http://api.anthropic.com' WHERE id = $1`, env.ProviderID); err != nil {
+		t.Fatalf("failed to update provider base URL: %v", err)
+	}
+	provider.InvalidateProviderCache()
+	target := upstream.Listener.Addr().String()
+	env.Handler.upstreamTransport = &http.Transport{
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, network, target)
+		},
+	}
+	return env
+}
+
+// anthropicUpstreamCall records which route one upstream call reached and the
+// body it carried, so the tests can assert the routing decision as well as the
+// wire shape.
+type anthropicUpstreamCall struct {
+	path string
+	body map[string]any
+}
+
+// TestChatCompletions_AnthropicEgress drives chat requests through the real
+// ChatCompletions pipeline against a fake Anthropic upstream. It proves the
+// whole adapter chain: a document-bearing request is translated to a Messages
+// body on /v1/messages and translated back to a chat.completion (streaming: to
+// chunks ending in [DONE]), while a text-only request to the same provider
+// stays on the untouched compat route.
+func TestChatCompletions_AnthropicEgress(t *testing.T) {
+	var calls []anthropicUpstreamCall
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("x-api-key") != "test-api-key" {
+			t.Errorf("x-api-key = %q", r.Header.Get("x-api-key"))
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		if r.Header.Get("anthropic-version") == "" {
+			t.Error("anthropic-version header missing")
+		}
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		calls = append(calls, anthropicUpstreamCall{path: r.URL.Path, body: body})
+
+		if r.URL.Path != "/v1/messages" {
+			// The compat route: answer in OpenAI shape, as Anthropic does.
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"chatcmpl-compat","object":"chat.completion","created":1,"model":"claude","choices":[{"index":0,"message":{"role":"assistant","content":"plain text answer"},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":3,"total_tokens":8}}`))
+			return
+		}
+		if stream, _ := body["stream"].(bool); stream {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			for _, ev := range []string{
+				`{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude","content":[],"usage":{"input_tokens":9,"output_tokens":1}}}`,
+				`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+				`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"PLUM"}}`,
+				`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"-7431"}}`,
+				`{"type":"content_block_stop","index":0}`,
+				`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":4}}`,
+				`{"type":"message_stop"}`,
+			} {
+				fmt.Fprint(w, "data: "+ev+"\n\n")
+			}
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","role":"assistant","model":"claude","content":[{"type":"text","text":"PLUM-7431"}],"stop_reason":"end_turn","usage":{"input_tokens":9,"output_tokens":4}}`))
+	}))
+	defer upstream.Close()
+
+	env := newAnthropicEgressEnv(t, upstream)
+
+	send := func(stream bool, content string) *httptest.ResponseRecorder {
+		body := fmt.Sprintf(`{"model":"%s/%s","stream":%v,"messages":[{"role":"user","content":%s}]}`,
+			env.ProviderName, env.ModelName, stream, content)
+		req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(body))
+		ctx := context.WithValue(req.Context(), virtualKeyNameKey, "test-key")
+		ctx = context.WithValue(ctx, virtualKeyIDKey, uuid.New().String())
+		ctx = context.WithValue(ctx, VirtualKeyHashKey, env.KeyHash)
+		req = req.WithContext(ctx)
+		w := httptest.NewRecorder()
+		env.Handler.ChatCompletions(w, req)
+		return w
+	}
+	documentContent := `[{"type":"text","text":"what is the code?"},{"type":"file","file":{"file_data":"` + pdfDataURI + `"}}]`
+
+	// Non-streaming document: native route, Anthropic body, chat.completion back.
+	w := send(false, documentContent)
+	if w.Code != http.StatusOK {
+		t.Fatalf("non-streaming: %d\n%s", w.Code, w.Body.String())
+	}
+	if len(calls) != 1 {
+		t.Fatalf("upstream calls = %d, want 1", len(calls))
+	}
+	if calls[0].path != "/v1/messages" {
+		t.Fatalf("document request went to %s, want /v1/messages", calls[0].path)
+	}
+	if _, hasMessages := calls[0].body["messages"]; !hasMessages {
+		t.Errorf("translated body has no messages: %v", calls[0].body)
+	}
+	if calls[0].body["model"] != env.ModelName {
+		t.Errorf("upstream model = %v, want the resolved id %q", calls[0].body["model"], env.ModelName)
+	}
+	if _, hasMaxTokens := calls[0].body["max_tokens"]; !hasMaxTokens {
+		t.Errorf("Messages body missing the required max_tokens: %v", calls[0].body)
+	}
+	assertDocumentBlockPresent(t, calls[0].body)
+
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("response not JSON: %v\n%s", err, w.Body.String())
+	}
+	if resp["object"] != "chat.completion" {
+		t.Errorf("object = %v", resp["object"])
+	}
+	choice := resp["choices"].([]any)[0].(map[string]any)
+	if choice["message"].(map[string]any)["content"] != "PLUM-7431" {
+		t.Errorf("content = %v", choice["message"])
+	}
+	if choice["finish_reason"] != "stop" {
+		t.Errorf("finish_reason = %v", choice["finish_reason"])
+	}
+	if resp["usage"].(map[string]any)["prompt_tokens"] != float64(9) {
+		t.Errorf("usage = %v", resp["usage"])
+	}
+
+	// Text-only: the gate keeps it on the untouched compat route.
+	calls = nil
+	w = send(false, `"just text"`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("text-only: %d\n%s", w.Code, w.Body.String())
+	}
+	if len(calls) != 1 {
+		t.Fatalf("upstream calls = %d, want 1", len(calls))
+	}
+	if calls[0].path != "/v1/chat/completions" {
+		t.Errorf("text-only request went to %s, want /v1/chat/completions", calls[0].path)
+	}
+	if _, translated := calls[0].body["max_tokens"]; translated {
+		t.Errorf("text-only body was translated: %v", calls[0].body)
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("text-only response not JSON: %v\n%s", err, w.Body.String())
+	}
+	choice = resp["choices"].([]any)[0].(map[string]any)
+	if choice["message"].(map[string]any)["content"] != "plain text answer" {
+		t.Errorf("text-only content = %v", choice["message"])
+	}
+
+	// Streaming document: translated chunk stream ending in [DONE].
+	calls = nil
+	w = send(true, documentContent)
+	if w.Code != http.StatusOK {
+		t.Fatalf("streaming: %d\n%s", w.Code, w.Body.String())
+	}
+	if len(calls) != 1 || calls[0].path != "/v1/messages" {
+		t.Fatalf("streaming document calls = %+v, want one /v1/messages", calls)
+	}
+	if stream, _ := calls[0].body["stream"].(bool); !stream {
+		t.Errorf("streaming request lost its stream flag: %v", calls[0].body)
+	}
+	sse := w.Body.String()
+	if !strings.Contains(sse, `"object":"chat.completion.chunk"`) {
+		t.Errorf("chunks not in chat shape:\n%s", sse)
+	}
+	if !strings.Contains(sse, `"content":"PLUM"`) || !strings.Contains(sse, `"content":"-7431"`) {
+		t.Errorf("content deltas missing:\n%s", sse)
+	}
+	if !strings.Contains(sse, `"finish_reason":"stop"`) || !strings.Contains(sse, "data: [DONE]") {
+		t.Errorf("terminal chunks missing:\n%s", sse)
+	}
+	if !strings.Contains(sse, `"prompt_tokens":9`) {
+		t.Errorf("usage missing:\n%s", sse)
+	}
+}
+
+// assertDocumentBlockPresent checks that the translated Messages body carries
+// the PDF as an Anthropic document block — the whole reason this route exists.
+func assertDocumentBlockPresent(t *testing.T, body map[string]any) {
+	t.Helper()
+	messages, _ := body["messages"].([]any)
+	if len(messages) == 0 {
+		t.Fatalf("translated body carries no messages: %v", body)
+	}
+	parts, _ := messages[0].(map[string]any)["content"].([]any)
+	for _, p := range parts {
+		block, _ := p.(map[string]any)
+		if block["type"] != "document" {
+			continue
+		}
+		source, _ := block["source"].(map[string]any)
+		if source["media_type"] != "application/pdf" {
+			t.Errorf("document source = %v, want an application/pdf source", source)
+		}
+		return
+	}
+	t.Errorf("no document block in translated content: %v", parts)
+}
+
+// An Anthropic-in request to an Anthropic provider keeps the verbatim native
+// passthrough: the egress adapter must not translate a body that already speaks
+// Messages, even when it carries a document.
+func TestMessages_AnthropicProviderStaysNative(t *testing.T) {
+	var gotPath string
+	var gotBody map[string]any
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","role":"assistant","model":"claude","content":[{"type":"text","text":"native answer"}],"stop_reason":"end_turn","usage":{"input_tokens":3,"output_tokens":2}}`))
+	}))
+	defer upstream.Close()
+
+	env := newAnthropicEgressEnv(t, upstream)
+	body := fmt.Sprintf(`{"model":"%s/%s","max_tokens":64,"messages":[{"role":"user","content":[{"type":"document","source":{"type":"base64","media_type":"application/pdf","data":"JVBERi0xLjQK"}}]}]}`,
+		env.ProviderName, env.ModelName)
+	w := doMessagesRequest(env, body)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("code = %d, body = %s", w.Code, w.Body.String())
+	}
+	if gotPath != "/v1/messages" {
+		t.Fatalf("anthropic-in request went to %s, want /v1/messages", gotPath)
+	}
+	if gotBody["max_tokens"] != float64(64) {
+		t.Errorf("max_tokens = %v, want the caller's 64 (verbatim passthrough)", gotBody["max_tokens"])
+	}
+	parts, _ := gotBody["messages"].([]any)[0].(map[string]any)["content"].([]any)
+	if len(parts) != 1 || parts[0].(map[string]any)["type"] != "document" {
+		t.Errorf("content = %v, want the caller's document block untouched", parts)
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("response not JSON: %v\n%s", err, w.Body.String())
+	}
+	if resp["type"] != "message" {
+		t.Errorf("response envelope = %v, want a verbatim Anthropic message", resp)
+	}
+}

--- a/internal/proxy/anthropic_egress_test.go
+++ b/internal/proxy/anthropic_egress_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/hugalafutro/model-hotel/internal/anthropicegress"
 	"github.com/hugalafutro/model-hotel/internal/provider"
 )
 
@@ -56,13 +57,13 @@ func TestIsAnthropicEgressAttempt(t *testing.T) {
 	}
 }
 
-// translateAnthropicEgressResponseBody swaps a Messages 200 body for its chat
+// translateEgressResponseBody swaps a Messages 200 body for its chat
 // translation in place, and errors on anything that is not a Messages response
 // so the caller fails over instead of forwarding garbage.
 func TestTranslateAnthropicEgressResponseBody(t *testing.T) {
 	resp := &http.Response{Body: newBodyReader(`{"id":"msg_1","type":"message","role":"assistant","model":"claude","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn","usage":{"input_tokens":3,"output_tokens":2}}`)}
-	if err := translateAnthropicEgressResponseBody(resp, "claude-sonnet-4-5"); err != nil {
-		t.Fatalf("translateAnthropicEgressResponseBody: %v", err)
+	if err := translateEgressResponseBody(resp, "claude-sonnet-4-5", anthropicegress.BuildChatCompletion); err != nil {
+		t.Fatalf("translateEgressResponseBody: %v", err)
 	}
 	var out map[string]any
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
@@ -77,11 +78,11 @@ func TestTranslateAnthropicEgressResponseBody(t *testing.T) {
 
 	// An Anthropic error envelope must not become a synthetic empty success.
 	resp = &http.Response{Body: newBodyReader(`{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`)}
-	if err := translateAnthropicEgressResponseBody(resp, "m"); err == nil {
+	if err := translateEgressResponseBody(resp, "m", anthropicegress.BuildChatCompletion); err == nil {
 		t.Error("expected error for an error envelope")
 	}
 	resp = &http.Response{Body: newBodyReader(`not json`)}
-	if err := translateAnthropicEgressResponseBody(resp, "m"); err == nil {
+	if err := translateEgressResponseBody(resp, "m", anthropicegress.BuildChatCompletion); err == nil {
 		t.Error("expected error for invalid JSON body")
 	}
 }

--- a/internal/proxy/anthropic_egress_test.go
+++ b/internal/proxy/anthropic_egress_test.go
@@ -381,9 +381,9 @@ func TestProbeStreamingCandidate_AnthropicEgress(t *testing.T) {
 	h := newIntegrationHandler()
 	defer stopUnitHandler(h)
 
-	var gotPath string
+	var log upstreamCallLog
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotPath = r.URL.Path
+		log.record(anthropicUpstreamCall{path: r.URL.Path})
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.WriteHeader(http.StatusOK)
 		for _, ev := range []string{
@@ -417,8 +417,8 @@ func TestProbeStreamingCandidate_AnthropicEgress(t *testing.T) {
 	}
 	defer func() { _ = res.resp.Body.Close() }()
 
-	if gotPath != "/v1/messages" {
-		t.Errorf("hedged document probe went to %s, want /v1/messages", gotPath)
+	if call := log.takeOne(t, "hedged document probe"); call.path != "/v1/messages" {
+		t.Errorf("hedged document probe went to %s, want /v1/messages", call.path)
 	}
 	if !st.anthropicEgressAttempt {
 		t.Error("buildCandidateRequest did not mark the hedged attempt as egress")

--- a/internal/proxy/anthropic_native.go
+++ b/internal/proxy/anthropic_native.go
@@ -61,7 +61,8 @@ func (h *Handler) handleNativeNonStreaming(w http.ResponseWriter, r *http.Reques
 		return outcomeFatal
 	}
 
-	inputTokens, outputTokens := anthropic.ParseResponseUsage(body)
+	usage := anthropic.ParseResponseUsage(body)
+	inputTokens, outputTokens := usage.PromptTokens, usage.CompletionTokens
 	totalDuration := float64(time.Since(st.startTime).Microseconds()) / 1000.0
 
 	logData.statusCode = http.StatusOK
@@ -77,6 +78,11 @@ func (h *Handler) handleNativeNonStreaming(w http.ResponseWriter, r *http.Reques
 	logData.responseHeaderMs = responseHeaderMs
 	logData.tokensPrompt = inputTokens
 	logData.tokensCompletion = outputTokens
+	// The cache split, not just the total: metering the cache-inclusive prompt
+	// without it prices every cached token at full input rate. The translated
+	// path reaches the same two fields through extractCacheTokens.
+	logData.tokensPromptCacheHit = usage.CacheHitTokens
+	logData.tokensPromptCacheMiss = usage.CacheMissTokens
 	logData.failoverAttempt = attempt
 	logData.state = "completed"
 	// What clears the model's gone-strike streak (see attemptCandidate), so the
@@ -111,6 +117,12 @@ func (h *Handler) emitRawData(sink *streamSink, st *streamState, ev sseEvent, ch
 	info := anthropic.InspectStreamEvent([]byte(ev.payload))
 	if info.HasInput {
 		st.promptTokens = info.InputTokens
+		// Guarded like the translated path's observer: a later usage event
+		// without cache fields must not zero a split an earlier one reported.
+		if info.CacheHitTokens > 0 || info.CacheMissTokens > 0 {
+			st.promptCacheHitTokens = info.CacheHitTokens
+			st.promptCacheMissTokens = info.CacheMissTokens
+		}
 	}
 	if info.HasOutput {
 		st.completionTokens = info.OutputTokens

--- a/internal/proxy/anthropic_native_test.go
+++ b/internal/proxy/anthropic_native_test.go
@@ -348,14 +348,14 @@ func TestNativeStream_RecordsCacheSplit(t *testing.T) {
 	}
 }
 
-// Same split on the non-streaming native path, so the two agree.
-func TestHandleNativeNonStreaming_RecordsCacheSplit(t *testing.T) {
+// runNativeNonStreaming serves one native Anthropic 200 body through
+// handleNativeNonStreaming and returns the finalized log row.
+func runNativeNonStreaming(t *testing.T, anthropicBody string) *requestLogData {
+	t.Helper()
 	h := newIntegrationHandler()
 	t.Cleanup(func() { stopUnitHandler(h) })
 
-	anthropicBody := `{"id":"msg_up","type":"message","role":"assistant","content":[{"type":"text","text":"hi"}],"stop_reason":"end_turn","usage":{"input_tokens":4,"output_tokens":50,"cache_creation_input_tokens":30,"cache_read_input_tokens":20000}}`
 	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(anthropicBody)), Header: make(http.Header)}
-
 	rec := httptest.NewRecorder()
 	native := true
 	aw := newAnthropicResponseWriter(rec, "msg_ignored", "m")
@@ -377,6 +377,12 @@ func TestHandleNativeNonStreaming_RecordsCacheSplit(t *testing.T) {
 		t.Fatalf("outcome = %v, want outcomeServed", outcome)
 	}
 	aw.Finalize()
+	return logData
+}
+
+// Same split on the non-streaming native path, so the two agree.
+func TestHandleNativeNonStreaming_RecordsCacheSplit(t *testing.T) {
+	logData := runNativeNonStreaming(t, `{"id":"msg_up","type":"message","role":"assistant","content":[{"type":"text","text":"hi"}],"stop_reason":"end_turn","usage":{"input_tokens":4,"output_tokens":50,"cache_creation_input_tokens":30,"cache_read_input_tokens":20000}}`)
 
 	if logData.tokensPrompt != 20034 || logData.tokensCompletion != 50 {
 		t.Errorf("usage = (%d,%d), want (20034,50)", logData.tokensPrompt, logData.tokensCompletion)
@@ -384,4 +390,45 @@ func TestHandleNativeNonStreaming_RecordsCacheSplit(t *testing.T) {
 	if logData.tokensPromptCacheHit != 20000 || logData.tokensPromptCacheMiss != 34 {
 		t.Errorf("cache split = (%d,%d), want (20000,34)", logData.tokensPromptCacheHit, logData.tokensPromptCacheMiss)
 	}
+}
+
+// Writing a cache entry counts as cache activity, so the split is recorded —
+// with the creation tokens on the miss side, which is where they are billed.
+func TestHandleNativeNonStreaming_CacheCreationOnly(t *testing.T) {
+	logData := runNativeNonStreaming(t, `{"id":"msg_up","type":"message","role":"assistant","content":[{"type":"text","text":"hi"}],"stop_reason":"end_turn","usage":{"input_tokens":4,"output_tokens":7,"cache_creation_input_tokens":30}}`)
+
+	if logData.tokensPrompt != 34 {
+		t.Errorf("tokensPrompt = %d, want 34 (4 + 30)", logData.tokensPrompt)
+	}
+	if logData.tokensPromptCacheHit != 0 || logData.tokensPromptCacheMiss != 34 {
+		t.Errorf("cache split = (%d,%d), want (0,34)", logData.tokensPromptCacheHit, logData.tokensPromptCacheMiss)
+	}
+}
+
+// An uncached response records NO cache counts on either native path. The
+// translated egress path cannot express "miss = the whole prompt" — its usage
+// omits the cache fields when they are zero — so recording it here would make
+// every uncached Anthropic-in request show a cache panel the identical request
+// through any other path does not, and feed a cache-miss stats series only
+// native Anthropic traffic contributes to.
+func TestNative_UncachedRecordsNoCacheSplit(t *testing.T) {
+	t.Run("non-streaming", func(t *testing.T) {
+		logData := runNativeNonStreaming(t, `{"id":"msg_up","type":"message","role":"assistant","content":[{"type":"text","text":"hi"}],"stop_reason":"end_turn","usage":{"input_tokens":9,"output_tokens":3}}`)
+		if logData.tokensPrompt != 9 {
+			t.Errorf("tokensPrompt = %d, want 9", logData.tokensPrompt)
+		}
+		if logData.tokensPromptCacheHit != 0 || logData.tokensPromptCacheMiss != 0 {
+			t.Errorf("cache split = (%d,%d), want (0,0)", logData.tokensPromptCacheHit, logData.tokensPromptCacheMiss)
+		}
+	})
+
+	t.Run("streaming", func(t *testing.T) {
+		_, logData := runNativeStream(t, nativeStreamHead+"event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n")
+		if logData.tokensPrompt != 12 {
+			t.Errorf("tokensPrompt = %d, want 12", logData.tokensPrompt)
+		}
+		if logData.tokensPromptCacheHit != 0 || logData.tokensPromptCacheMiss != 0 {
+			t.Errorf("cache split = (%d,%d), want (0,0)", logData.tokensPromptCacheHit, logData.tokensPromptCacheMiss)
+		}
+	})
 }

--- a/internal/proxy/anthropic_native_test.go
+++ b/internal/proxy/anthropic_native_test.go
@@ -392,17 +392,50 @@ func TestHandleNativeNonStreaming_RecordsCacheSplit(t *testing.T) {
 	}
 }
 
-// Writing a cache entry counts as cache activity, so the split is recorded —
-// with the creation tokens on the miss side, which is where they are billed.
-func TestHandleNativeNonStreaming_CacheCreationOnly(t *testing.T) {
-	logData := runNativeNonStreaming(t, `{"id":"msg_up","type":"message","role":"assistant","content":[{"type":"text","text":"hi"}],"stop_reason":"end_turn","usage":{"input_tokens":4,"output_tokens":7,"cache_creation_input_tokens":30}}`)
+// creationOnlyStream is a native stream whose message_start reports a cache
+// WRITE and no read.
+const creationOnlyStream = `event: message_start
+data: {"type":"message_start","message":{"id":"msg_up","type":"message","role":"assistant","model":"claude","content":[],"usage":{"input_tokens":4,"output_tokens":0,"cache_creation_input_tokens":30}}}
 
-	if logData.tokensPrompt != 34 {
-		t.Errorf("tokensPrompt = %d, want 34 (4 + 30)", logData.tokensPrompt)
-	}
-	if logData.tokensPromptCacheHit != 0 || logData.tokensPromptCacheMiss != 34 {
-		t.Errorf("cache split = (%d,%d), want (0,34)", logData.tokensPromptCacheHit, logData.tokensPromptCacheMiss)
-	}
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":5}}
+
+event: message_stop
+data: {"type":"message_stop"}
+
+`
+
+// Writing a cache entry without reading one records NO cache split, on both
+// native paths. The translated egress path meters the identical response
+// through extractCacheTokens, which keys off the cache-READ fields alone and
+// can only ever record (0,0) here — so recording a split would put the two
+// Anthropic paths back into disagreement. The creation tokens are not lost:
+// they count inside tokensPrompt, which is what the request is priced on.
+func TestNative_CacheCreationOnlyRecordsNoCacheSplit(t *testing.T) {
+	t.Run("non-streaming", func(t *testing.T) {
+		logData := runNativeNonStreaming(t, `{"id":"msg_up","type":"message","role":"assistant","content":[{"type":"text","text":"hi"}],"stop_reason":"end_turn","usage":{"input_tokens":4,"output_tokens":7,"cache_creation_input_tokens":30}}`)
+
+		if logData.tokensPrompt != 34 {
+			t.Errorf("tokensPrompt = %d, want 34 (4 + 30)", logData.tokensPrompt)
+		}
+		if logData.tokensPromptCacheHit != 0 || logData.tokensPromptCacheMiss != 0 {
+			t.Errorf("cache split = (%d,%d), want (0,0)", logData.tokensPromptCacheHit, logData.tokensPromptCacheMiss)
+		}
+	})
+
+	t.Run("streaming", func(t *testing.T) {
+		_, logData := runNativeStream(t, creationOnlyStream)
+
+		if logData.tokensPrompt != 34 {
+			t.Errorf("tokensPrompt = %d, want 34 (4 + 30)", logData.tokensPrompt)
+		}
+		if logData.tokensPromptCacheHit != 0 || logData.tokensPromptCacheMiss != 0 {
+			t.Errorf("cache split = (%d,%d), want (0,0)", logData.tokensPromptCacheHit, logData.tokensPromptCacheMiss)
+		}
+	})
 }
 
 // An uncached response records NO cache counts on either native path. The

--- a/internal/proxy/anthropic_native_test.go
+++ b/internal/proxy/anthropic_native_test.go
@@ -310,3 +310,78 @@ func TestNativeStream_ProviderErrorEvent(t *testing.T) {
 		t.Errorf("error frame not forwarded to client:\n%s", w.Body.String())
 	}
 }
+
+// warmCacheStream is a native stream whose message_start reports a warm cache:
+// a tiny uncached remainder beside a large cache read and a cache write.
+const warmCacheStream = `event: message_start
+data: {"type":"message_start","message":{"id":"msg_up","type":"message","role":"assistant","model":"claude","content":[],"usage":{"input_tokens":4,"output_tokens":0,"cache_creation_input_tokens":30,"cache_read_input_tokens":20000}}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":5}}
+
+event: message_stop
+data: {"type":"message_stop"}
+
+`
+
+// The native passthrough meters the cache-inclusive prompt, so it must record
+// the hit/miss split too — without it every cached token is priced at the full
+// input rate, which is a different skew from under-counting, not a fixed one.
+// The translated path reaches these same fields via extractCacheTokens.
+func TestNativeStream_RecordsCacheSplit(t *testing.T) {
+	_, logData := runNativeStream(t, warmCacheStream)
+
+	if logData.state != "completed" {
+		t.Fatalf("state = %q, want completed (err: %s)", logData.state, logData.errorMessage)
+	}
+	if logData.tokensPrompt != 20034 {
+		t.Errorf("tokensPrompt = %d, want 20034 (4 + 20000 + 30)", logData.tokensPrompt)
+	}
+	if logData.tokensPromptCacheHit != 20000 {
+		t.Errorf("tokensPromptCacheHit = %d, want 20000", logData.tokensPromptCacheHit)
+	}
+	if logData.tokensPromptCacheMiss != 34 {
+		t.Errorf("tokensPromptCacheMiss = %d, want 34 (4 + 30)", logData.tokensPromptCacheMiss)
+	}
+}
+
+// Same split on the non-streaming native path, so the two agree.
+func TestHandleNativeNonStreaming_RecordsCacheSplit(t *testing.T) {
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+
+	anthropicBody := `{"id":"msg_up","type":"message","role":"assistant","content":[{"type":"text","text":"hi"}],"stop_reason":"end_turn","usage":{"input_tokens":4,"output_tokens":50,"cache_creation_input_tokens":30,"cache_read_input_tokens":20000}}`
+	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(anthropicBody)), Header: make(http.Header)}
+
+	rec := httptest.NewRecorder()
+	native := true
+	aw := newAnthropicResponseWriter(rec, "msg_ignored", "m")
+	aw.bindNativeFlag(&native)
+
+	req := httptest.NewRequest("POST", "/v1/messages", http.NoBody)
+	logData := &requestLogData{
+		id:             uuid.New().String(),
+		modelID:        "claude-x",
+		virtualKeyName: "test-key",
+		virtualKeyID:   "00000000-0000-0000-0000-000000000001",
+		state:          "streaming",
+	}
+	st := &requestState{startTime: time.Now(), logData: logData}
+	h.insertRequestLogAsync(logData)
+	time.Sleep(100 * time.Millisecond)
+
+	if outcome := h.handleNativeNonStreaming(aw, req, st, resp, 1, 10.0); outcome != outcomeServed {
+		t.Fatalf("outcome = %v, want outcomeServed", outcome)
+	}
+	aw.Finalize()
+
+	if logData.tokensPrompt != 20034 || logData.tokensCompletion != 50 {
+		t.Errorf("usage = (%d,%d), want (20034,50)", logData.tokensPrompt, logData.tokensCompletion)
+	}
+	if logData.tokensPromptCacheHit != 20000 || logData.tokensPromptCacheMiss != 34 {
+		t.Errorf("cache split = (%d,%d), want (20000,34)", logData.tokensPromptCacheHit, logData.tokensPromptCacheMiss)
+	}
+}

--- a/internal/proxy/egress.go
+++ b/internal/proxy/egress.go
@@ -1,0 +1,41 @@
+package proxy
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// chatCompletionBuilder turns one egress dialect's non-streaming success body
+// into a chat.completion body. gemini.BuildChatCompletion and
+// anthropicegress.BuildChatCompletion both have this shape.
+type chatCompletionBuilder func(body []byte, id, model string, created int64) ([]byte, error)
+
+// translateEgressResponseBody swaps a non-streaming native 200 body for its
+// chat.completion translation so handleNonStreamingResponse can meter and
+// forward it unchanged. The dialect differs only in the builder, so every
+// egress adapter shares this body: read, translate, re-seat.
+//
+// resp.Body is always left readable — an empty reader on failure — so a caller
+// that surfaces the error still hands the pipeline a closed-once, drainable
+// response.
+func translateEgressResponseBody(resp *http.Response, model string, build chatCompletionBuilder) error {
+	body, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		resp.Body = io.NopCloser(bytes.NewReader(nil))
+		return err
+	}
+	id := "chatcmpl-" + strings.ReplaceAll(uuid.NewString(), "-", "")
+	translated, err := build(body, id, model, time.Now().Unix())
+	if err != nil {
+		resp.Body = io.NopCloser(bytes.NewReader(nil))
+		return err
+	}
+	resp.Body = io.NopCloser(bytes.NewReader(translated))
+	return nil
+}

--- a/internal/proxy/gemini_egress.go
+++ b/internal/proxy/gemini_egress.go
@@ -3,13 +3,9 @@ package proxy
 import (
 	"bytes"
 	"context"
-	"io"
 	"net/http"
 	"net/url"
 	"strings"
-	"time"
-
-	"github.com/google/uuid"
 
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 	"github.com/hugalafutro/model-hotel/internal/gemini"
@@ -104,24 +100,4 @@ func (h *Handler) buildGeminiRequest(ctx context.Context, st *requestState, cand
 	setGeminiEgressAuth(proxyReq, providerType, candidate.apiKey)
 	proxyReq.Header.Set("Content-Type", "application/json")
 	return proxyReq, providerType, targetURL, nil
-}
-
-// translateGeminiResponseBody swaps a non-streaming generateContent 200 body
-// for its chat.completion translation so handleNonStreamingResponse can meter
-// and forward it unchanged.
-func translateGeminiResponseBody(resp *http.Response, model string) error {
-	body, err := io.ReadAll(resp.Body)
-	_ = resp.Body.Close()
-	if err != nil {
-		resp.Body = io.NopCloser(bytes.NewReader(nil))
-		return err
-	}
-	id := "chatcmpl-" + strings.ReplaceAll(uuid.NewString(), "-", "")
-	translated, err := gemini.BuildChatCompletion(body, id, model, time.Now().Unix())
-	if err != nil {
-		resp.Body = io.NopCloser(bytes.NewReader(nil))
-		return err
-	}
-	resp.Body = io.NopCloser(bytes.NewReader(translated))
-	return nil
 }

--- a/internal/proxy/gemini_egress_test.go
+++ b/internal/proxy/gemini_egress_test.go
@@ -13,16 +13,17 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/hugalafutro/model-hotel/internal/gemini"
 	"github.com/hugalafutro/model-hotel/internal/provider"
 )
 
-// translateGeminiResponseBody swaps a generateContent 200 body for its chat
+// translateEgressResponseBody swaps a generateContent 200 body for its chat
 // translation in place, and errors on a non-Gemini body so the caller can
 // fail over instead of forwarding garbage.
 func TestTranslateGeminiResponseBody(t *testing.T) {
 	resp := &http.Response{Body: newBodyReader(`{"candidates":[{"content":{"role":"model","parts":[{"text":"ok"}]},"finishReason":"STOP"}]}`)}
-	if err := translateGeminiResponseBody(resp, "gemini-2.5-flash"); err != nil {
-		t.Fatalf("translateGeminiResponseBody: %v", err)
+	if err := translateEgressResponseBody(resp, "gemini-2.5-flash", gemini.BuildChatCompletion); err != nil {
+		t.Fatalf("translateEgressResponseBody: %v", err)
 	}
 	var out map[string]any
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
@@ -34,11 +35,11 @@ func TestTranslateGeminiResponseBody(t *testing.T) {
 
 	// Zero-candidate body (e.g. blocked prompt) must error, not forward.
 	resp = &http.Response{Body: newBodyReader(`{"promptFeedback":{"blockReason":"SAFETY"}}`)}
-	if err := translateGeminiResponseBody(resp, "m"); err == nil {
+	if err := translateEgressResponseBody(resp, "m", gemini.BuildChatCompletion); err == nil {
 		t.Error("expected error for candidate-less body")
 	}
 	resp = &http.Response{Body: newBodyReader(`not json`)}
-	if err := translateGeminiResponseBody(resp, "m"); err == nil {
+	if err := translateEgressResponseBody(resp, "m", gemini.BuildChatCompletion); err == nil {
 		t.Error("expected error for invalid JSON body")
 	}
 }

--- a/internal/proxy/hedging.go
+++ b/internal/proxy/hedging.go
@@ -285,7 +285,7 @@ func (h *Handler) probeStreamingCandidate(ctx context.Context, st *requestState,
 		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, readCap))
 		_, _ = io.Copy(io.Discard, resp.Body)
 		_ = resp.Body.Close()
-		if resp.StatusCode == http.StatusBadRequest {
+		if resp.StatusCode == http.StatusBadRequest && st.sentChatCompletionsBody() {
 			// A hedged probe cannot retry in-race (a second upstream round-trip
 			// inside one race slot would skew the TTFT contest), but it can
 			// still LEARN the /v1/responses requirement from the 400 so every
@@ -295,6 +295,11 @@ func (h *Handler) probeStreamingCandidate(ctx context.Context, st *requestState,
 			// in-race, but learning here means the next request — hedged or
 			// sequential — is built without the params this model refuses.
 			h.learnRejectedParams(candidate, providerType, errBody)
+			// Both readings are only valid on a chat-completions attempt: a
+			// dialect 400 names that dialect's fields, and a strip mislearned
+			// from one poisons the compat path for this model on every later
+			// request. The sequential path gates its own 400 handling the same
+			// way.
 		}
 		// A hedged race drops every candidate but the winner here, so without
 		// this a dead model in a hedged group accrued strikes only on the runs it

--- a/internal/proxy/hedging.go
+++ b/internal/proxy/hedging.go
@@ -9,6 +9,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/hugalafutro/model-hotel/internal/anthropicegress"
 	"github.com/hugalafutro/model-hotel/internal/ctxkeys"
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 	"github.com/hugalafutro/model-hotel/internal/gemini"
@@ -319,6 +320,11 @@ func (h *Handler) probeStreamingCandidate(ctx context.Context, st *requestState,
 		// Vertex-express candidate in a hedged race: same upstream-side
 		// translation so the hedged pipeline sees chat-completions SSE.
 		resp.Body = gemini.NewStreamAdapter(resp.Body, st.reqModel)
+	}
+	if st.anthropicEgressAttempt {
+		// Anthropic egress candidate in a hedged race: same upstream-side
+		// translation so the hedged pipeline sees chat-completions SSE.
+		resp.Body = anthropicegress.NewStreamAdapter(resp.Body, st.reqModel)
 	}
 
 	if ttftTimeout <= 0 {

--- a/internal/proxy/model_gone_test.go
+++ b/internal/proxy/model_gone_test.go
@@ -1466,7 +1466,7 @@ func TestAttemptCandidate_ATranslationFailureKeepsTheStreak(t *testing.T) {
 	h := newIntegrationHandler()
 	defer stopUnitHandler(h)
 
-	// A 200 that is not a Gemini answer, so translateGeminiResponseBody fails.
+	// A 200 that is not a Gemini answer, so translateEgressResponseBody fails.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = io.WriteString(w, `<html>502 Bad Gateway</html>`)

--- a/internal/proxy/model_probe.go
+++ b/internal/proxy/model_probe.go
@@ -9,8 +9,10 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/hugalafutro/model-hotel/internal/anthropicegress"
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 	"github.com/hugalafutro/model-hotel/internal/failover"
+	"github.com/hugalafutro/model-hotel/internal/gemini"
 	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
@@ -462,9 +464,9 @@ func translateProbeDialect(resp *http.Response, st *requestState, modelID string
 	case st.responsesAttempt:
 		return translateResponsesResponseBody(resp, modelID)
 	case st.geminiAttempt:
-		return translateGeminiResponseBody(resp, modelID)
+		return translateEgressResponseBody(resp, modelID, gemini.BuildChatCompletion)
 	case st.anthropicEgressAttempt:
-		return translateAnthropicEgressResponseBody(resp, modelID)
+		return translateEgressResponseBody(resp, modelID, anthropicegress.BuildChatCompletion)
 	default:
 		return nil
 	}

--- a/internal/proxy/model_probe.go
+++ b/internal/proxy/model_probe.go
@@ -448,10 +448,12 @@ func judgeProbeSuccess(resp *http.Response, st *requestState, candidate modelCan
 //
 // Only the non-streaming translators are reachable: the probe never asks for a
 // stream. The Responses case cannot fire as the probe body stands — that
-// re-route also requires tools in the request — but it is kept because the flag
-// is set by buildCandidateRequest and not by anything here. If the re-route rules
-// widen, a probe that skipped the translation would read a Responses object as
-// an empty chat completion and postpone those retirements forever, silently.
+// re-route also requires tools in the request — and neither can the Anthropic
+// egress case, whose re-route requires a document part the probe body has no
+// reason to carry. Both are kept because the flag is set by
+// buildCandidateRequest and not by anything here. If the re-route rules widen, a
+// probe that skipped the translation would read a dialect object as an empty
+// chat completion and postpone those retirements forever, silently.
 func translateProbeDialect(resp *http.Response, st *requestState, modelID string) error {
 	// The upstream model id, NOT st.reqModel: the served path passes the name the
 	// client asked for, and a probe has no client (st.reqModel is empty by design,
@@ -461,6 +463,8 @@ func translateProbeDialect(resp *http.Response, st *requestState, modelID string
 		return translateResponsesResponseBody(resp, modelID)
 	case st.geminiAttempt:
 		return translateGeminiResponseBody(resp, modelID)
+	case st.anthropicEgressAttempt:
+		return translateAnthropicEgressResponseBody(resp, modelID)
 	default:
 		return nil
 	}

--- a/internal/proxy/model_probe_test.go
+++ b/internal/proxy/model_probe_test.go
@@ -809,7 +809,7 @@ func TestProbeModel_DialectAnswerIsBounded(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	// A vertex-express candidate, so the answer goes through
-	// translateGeminiResponseBody rather than through this file's own reads.
+	// translateEgressResponseBody rather than through this file's own reads.
 	h := &Handler{upstreamTransport: dialToTestServer(t, srv)}
 	candidate := probeCandidateFor("http://us-central1-aiplatform.googleapis.com/v1", "gemini-2.0-flash")
 

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/hugalafutro/model-hotel/internal/anthropicegress"
 	"github.com/hugalafutro/model-hotel/internal/ctxkeys"
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 	"github.com/hugalafutro/model-hotel/internal/gemini"
@@ -152,7 +153,10 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 	// generateContent-shaped, so re-POSTing a rebuilt chat body (or learning
 	// OpenAI param names from Gemini's error text) would be wrong; a Gemini
 	// 400 fails over or is forwarded as-is.
-	if resp.StatusCode == 400 && !st.anthropicNativeAttempt && !st.responsesAttempt && !st.geminiAttempt {
+	// Skipped for the same reason on anthropic egress attempts: that upstream
+	// body is Messages-shaped, so a rebuilt chat body re-POSTed to /v1/messages
+	// would be malformed and Anthropic's param names are not OpenAI's.
+	if resp.StatusCode == 400 && !st.anthropicNativeAttempt && !st.responsesAttempt && !st.geminiAttempt && !st.anthropicEgressAttempt {
 		res, handled := h.retryWithResponses(r, st, candidate, providerType, resp, attempt, &dialMs, failoverCancel, streamCancelOrigin)
 		if !handled {
 			res = h.retryWithStrippedParams(r, st, candidate, providerType, targetURL, resp, attempt, &dialMs, failoverCancel, streamCancelOrigin)
@@ -246,6 +250,17 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 			resp.Body = gemini.NewStreamAdapter(resp.Body, st.reqModel)
 		} else if err := translateGeminiResponseBody(resp, st.reqModel); err != nil {
 			debuglog.Warn("proxy: gemini translation failed", "error", err, "model", logData.modelID, "provider", logData.providerName)
+			st.setReqErr(reqError{Kind: KindProviderError, Attempt: attempt, Provider: candidate.provider.Name, Underlying: errString(err)})
+			logData.failoverAttempt = attempt
+			return outcomeFailover
+		}
+	}
+	if st.anthropicEgressAttempt {
+		// Same upstream-side trick for the anthropic egress adapter.
+		if st.isStreaming {
+			resp.Body = anthropicegress.NewStreamAdapter(resp.Body, st.reqModel)
+		} else if err := translateAnthropicEgressResponseBody(resp, st.reqModel); err != nil {
+			debuglog.Warn("proxy: anthropic egress translation failed", "error", err, "model", logData.modelID, "provider", logData.providerName)
 			st.setReqErr(reqError{Kind: KindProviderError, Attempt: attempt, Provider: candidate.provider.Name, Underlying: errString(err)})
 			logData.failoverAttempt = attempt
 			return outcomeFailover
@@ -478,6 +493,7 @@ func (h *Handler) buildCandidateRequest(ctx context.Context, st *requestState, c
 	// don't, so all dialect flags reset on every candidate.
 	st.responsesAttempt = false
 	st.geminiAttempt = false
+	st.anthropicEgressAttempt = false
 	if st.anthropicNativeAttempt {
 		return h.buildNativeAnthropicRequest(ctx, st, candidate, providerType)
 	}
@@ -497,6 +513,15 @@ func (h *Handler) buildCandidateRequest(ctx context.Context, st *requestState, c
 	if isGeminiEgressAttempt(st, providerType, candidate.model.ModelID) {
 		st.geminiAttempt = true
 		return h.buildGeminiRequest(ctx, st, candidate, providerType)
+	}
+
+	// Anthropic egress adapter: a chat request carrying a document is
+	// translated to Anthropic's native Messages shape on the way out and back
+	// on the response side (see anthropic_egress.go). Text and image requests
+	// stay on the cheaper compat endpoint below.
+	if isAnthropicEgressAttempt(st, providerType) {
+		st.anthropicEgressAttempt = true
+		return h.buildAnthropicEgressRequest(ctx, st, candidate, providerType)
 	}
 
 	endpoint := st.endpointPath

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -242,7 +242,7 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 		// Same upstream-side trick for the gemini egress adapter.
 		if st.isStreaming {
 			resp.Body = gemini.NewStreamAdapter(resp.Body, st.reqModel)
-		} else if err := translateGeminiResponseBody(resp, st.reqModel); err != nil {
+		} else if err := translateEgressResponseBody(resp, st.reqModel, gemini.BuildChatCompletion); err != nil {
 			debuglog.Warn("proxy: gemini translation failed", "error", err, "model", logData.modelID, "provider", logData.providerName)
 			st.setReqErr(reqError{Kind: KindProviderError, Attempt: attempt, Provider: candidate.provider.Name, Underlying: errString(err)})
 			logData.failoverAttempt = attempt
@@ -253,7 +253,7 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 		// Same upstream-side trick for the anthropic egress adapter.
 		if st.isStreaming {
 			resp.Body = anthropicegress.NewStreamAdapter(resp.Body, st.reqModel)
-		} else if err := translateAnthropicEgressResponseBody(resp, st.reqModel); err != nil {
+		} else if err := translateEgressResponseBody(resp, st.reqModel, anthropicegress.BuildChatCompletion); err != nil {
 			debuglog.Warn("proxy: anthropic egress translation failed", "error", err, "model", logData.modelID, "provider", logData.providerName)
 			st.setReqErr(reqError{Kind: KindProviderError, Attempt: attempt, Provider: candidate.provider.Name, Underlying: errString(err)})
 			logData.failoverAttempt = attempt

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -139,24 +139,18 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 	// Works universally — any LLM API mentioning "temperature" or "top_p"
 	// in a 400 error can only mean the sampling parameter.
 	//
-	// Skipped for native Anthropic passthrough: this self-heal rebuilds the
-	// OpenAI-shaped st.bodyBytes via paramrewrite.BuildUpstreamBody and re-POSTs it, but a
-	// native attempt's targetURL is the provider's /v1/messages (Anthropic wire
-	// format). Stripping OpenAI params off the wrong body and sending it to the
-	// native endpoint would be malformed; a native 400 is forwarded as-is.
-	// Also skipped when the attempt already went to /v1/responses: rebuilding
-	// a chat-completions body and re-POSTing it there would be malformed, and
-	// a Responses-required 400 must run BEFORE the param retry — its error
-	// message names reasoning_effort, which the param parser would otherwise
-	// learn as a strip (useless on reason-by-default models).
-	// Also skipped for gemini egress attempts: the upstream body is
-	// generateContent-shaped, so re-POSTing a rebuilt chat body (or learning
-	// OpenAI param names from Gemini's error text) would be wrong; a Gemini
-	// 400 fails over or is forwarded as-is.
-	// Skipped for the same reason on anthropic egress attempts: that upstream
-	// body is Messages-shaped, so a rebuilt chat body re-POSTed to /v1/messages
-	// would be malformed and Anthropic's param names are not OpenAI's.
-	if resp.StatusCode == 400 && !st.anthropicNativeAttempt && !st.responsesAttempt && !st.geminiAttempt && !st.anthropicEgressAttempt {
+	// Skipped on every dialect attempt (see sentChatCompletionsBody): this
+	// self-heal rebuilds the OpenAI-shaped st.bodyBytes via
+	// paramrewrite.BuildUpstreamBody and re-POSTs it to the same targetURL, which
+	// for a native /v1/messages, /v1/responses or generateContent route is a
+	// malformed request — and those endpoints' 400s name their own fields, not
+	// OpenAI's. A dialect 400 fails over or is forwarded as-is.
+	//
+	// Ordering, for the chat-completions case: retryWithResponses runs BEFORE the
+	// param retry because a Responses-required 400 names reasoning_effort, which
+	// the param parser would otherwise learn as a strip (useless on
+	// reason-by-default models).
+	if resp.StatusCode == 400 && st.sentChatCompletionsBody() {
 		res, handled := h.retryWithResponses(r, st, candidate, providerType, resp, attempt, &dialMs, failoverCancel, streamCancelOrigin)
 		if !handled {
 			res = h.retryWithStrippedParams(r, st, candidate, providerType, targetURL, resp, attempt, &dialMs, failoverCancel, streamCancelOrigin)

--- a/internal/proxy/types.go
+++ b/internal/proxy/types.go
@@ -217,6 +217,15 @@ type requestState struct {
 	// shape the pipeline and client expect.
 	geminiAttempt bool
 
+	// Anthropic egress adapter (zero value = plain chat-completions).
+	// anthropicEgressAttempt is set per failover attempt by
+	// buildCandidateRequest: true when the current candidate is an Anthropic
+	// provider served through the internal/anthropicegress translation (the
+	// request carries a document its OpenAI-compat endpoint cannot express),
+	// read by the response dispatch so it translates the Messages body/stream
+	// back to the chat-completions shape the pipeline and client expect.
+	anthropicEgressAttempt bool
+
 	// Populated by resolveCandidates (phase B).
 	timings    resolveTimings
 	cacheHits  resolveCacheHits

--- a/internal/proxy/types.go
+++ b/internal/proxy/types.go
@@ -260,6 +260,26 @@ func (st *requestState) setReqErr(e reqError) {
 	st.lastErr = e.render()
 }
 
+// sentChatCompletionsBody reports whether the current attempt POSTed an OpenAI
+// chat-completions body to a chat-completions route — that is, no dialect flag
+// is set for it.
+//
+// Everything that interprets a 400 as OpenAI gates on this: the param
+// self-heal's rebuild-and-re-POST, and learning a rejected param or a
+// /v1/responses requirement from the error text. On a dialect attempt both are
+// wrong — another dialect's error names another dialect's fields, so a strip
+// learned there poisons the compat path for that model, and a rebuilt chat body
+// re-POSTed to a native endpoint would be malformed. The sequential and hedged
+// 400 paths share this predicate, so a dialect added later is covered at both
+// sites by extending it here.
+//
+// It reads the attempt's own state: the hedged path holds a private snapshot
+// whose flags its own buildCandidateRequest set, so there is no shared-state
+// race.
+func (st *requestState) sentChatCompletionsBody() bool {
+	return !st.anthropicNativeAttempt && !st.responsesAttempt && !st.geminiAttempt && !st.anthropicEgressAttempt
+}
+
 // candidateOutcome is the result of a single failover attempt
 // (attemptCandidate): whether the caller should try the next candidate, has
 // already served the client, or has written a terminal error.


### PR DESCRIPTION
## The defect

Anthropic's OpenAI-compatible `/v1/chat/completions` endpoint cannot carry a document. An
OpenAI `{"type":"file"}` content part is rejected outright:

```
messages.0.user.content.str: Input should be a valid string
```

and a PDF smuggled through an `image_url` data URI dies one layer deeper, in Anthropic's
block mapper:

```
messages.0.content.1.image.source.base64.media_type:
  Input should be 'image/jpeg', 'image/png', 'image/gif' or 'image/webp'
```

The same model and the same PDF answer correctly on Anthropic's **native** `/v1/messages`.
So the defect is the wire shape Model Hotel speaks, not the model, the fixture or the
failover group.

Model Hotel already translated the other direction (Anthropic-in `/v1/messages` → OpenAI
chat-completions for non-Anthropic providers, verbatim passthrough for Anthropic ones).
This adds the missing direction.

## What this does

A chat-completions request that carries a document is translated to Anthropic Messages
shape and sent to `/v1/messages`; the response is translated back on the **upstream** side
of the pipeline, so the TTFT probe, stall watchdog, stream transforms and metering keep
running on the shape they already understand. That is the same trick
`internal/proxy/gemini_egress.go` uses for vertex-express, and this mirrors it.

New leaf package `internal/anthropicegress`:

| file | role |
|---|---|
| `detect.go` | the routing gate |
| `request.go` | chat-completions → Anthropic Messages |
| `response.go` | Anthropic message → `chat.completion` |
| `stream.go` | Anthropic SSE → `chat.completion.chunk` |
| `adapter.go` | wraps the upstream body |

Wired in through `internal/proxy/anthropic_egress.go` plus the per-attempt dialect flag,
mirroring every existing `st.geminiAttempt` site.

**The gate is deliberately narrow.** Only a request carrying a document routes natively.
Text-only and vision-only requests to the same Anthropic provider keep the existing compat
path untouched. Widening it to every Anthropic request would also recover extended
thinking and `cache_control`, which the compat layer silently drops — that is the right end
state, but it changes the path of every Anthropic request at once and is left as a separate
decision.

## Verified live

Against a rebuilt dev container and the real Anthropic API, 11/11 — up from 5/10 at
baseline, where exactly the document cases failed:

```
pdf / file part / non-stream                PLUM-7431
pdf / file part / stream                    PLUM-7431   finish_reason=stop, [DONE]
pdf + tools / tool_call arguments           {"code": "PLUM-7431"}
pdf + image / both blocks survive           PLUM-7431 7431
pdf / image_url data-uri / non-stream       PLUM-7431
untranslatable file part / no silent 200    HTTP 400
text only / compat path unchanged           Paris
vision only / compat path unchanged         7431
anthropic-in / native passthrough / pdf     PLUM-7431
anthropic-in / translated to non-anthropic  Paris
anthropic-in / native stream                Paris
```

The container log shows **exactly 5** `routing via anthropic egress adapter` lines across
the 11 cases — the five document cases and nothing else — so the gate holds in practice,
not only in tests.

## Two fixes beyond the core, both found while reviewing this

**A content-leak class.** `%w`-wrapping an `encoding/json` error puts a quoted byte of the
input into the error string, and those errors reach `debuglog`. On these paths the input is
prompt or completion content, which this project never logs. New leaf package
`internal/jsonfault` is now the single home for content-free decode diagnostics (offsets
and lengths only); 15 call sites across `anthropic`, `anthropicegress`, `gemini` and
`openairesponses` were converted, three per-package copies deleted. Three of those sites
decode request bodies, where the quoted byte would have been the user's own prompt. The
~22 remaining wrapped decodes carry provider catalogs, quota payloads and version
manifests, and are deliberately left alone.

**Anthropic prompt-token accounting.** Anthropic's `usage.input_tokens` *excludes* cached
input — `cache_read_input_tokens` and `cache_creation_input_tokens` are disjoint additions,
not a breakdown. The pre-existing native passthrough path reported the bare `input_tokens`,
under-counting a warm-cache request by orders of magnitude. Both Anthropic paths now sum
the three counts and record the same hit/miss split, and both report no cache information
when there was no cache activity.

## Testing

- `go test ./...` green; `golangci-lint run ./...` 0 issues; `-race` clean on every touched
  httptest suite.
- ~5.6k lines added, the bulk of it tests. Wire-shape tests decode into structs declared
  independently of the production types, so a JSON-tag regression cannot hide behind a
  tautology.
- Every fix in the review rounds was mutation-checked: reverted, a named test confirmed
  failing, restored.

## Reviewer notes

Known and deliberate, so they are not re-filed:

- `translateBlocks` can still build a `document` block inside an assistant turn, which
  Anthropic rejects. An assistant document can no longer *cause* the native route; a loud
  400 beats silently dropping the document.
- `DefaultMaxTokens = 4096` when a client omits `max_tokens` (Anthropic requires the
  field). Truncation surfaces as `finish_reason=length`; substituting the model's full
  ceiling would hand a large bill to a client that omitted the field precisely because it
  was not thinking about size.
- `internal/gemini/adapter.go` and `internal/openairesponses/stream.go` do **not** have this
  adapter's 1 MiB SSE line cap or its EOF partial-line flush. Extracting a shared reader was
  left out because it would refactor two shipping streaming paths this branch cannot verify
  live — but the follow-up is "backport the cap and the flush while extracting", not
  cosmetic de-duplication.
