### PR TITLE
fix(ci): build the runtime stage uncached so published images carry current packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -827,6 +827,20 @@ jobs:
       # that gets scanned is the image that gets pushed (same digest). Scanning
       # docker-build's separate artifact would not cover base-image/Alpine drift
       # between that job and this rebuild.
+      - name: Assert the runtime stage the cache filter targets exists
+        if: steps.changes.outputs.skip == 'false'
+        run: |
+          set -euo pipefail
+          # buildx ignores --no-cache-filter for a stage name it cannot find, so
+          # renaming the runtime stage would silently restore the stale-package
+          # bug the filter below exists to prevent.
+          for f in Dockerfile Dockerfile.frontdesk; do
+            if ! grep -qE '^FROM .+ AS runtime$' "$f"; then
+              echo "::error::$f declares no 'AS runtime' stage; no-cache-filters: runtime would be a no-op"
+              exit 1
+            fi
+          done
+
       - name: Build :dev candidate (load for scan)
         if: steps.changes.outputs.skip == 'false'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
@@ -839,6 +853,13 @@ jobs:
           build-args: COMMIT=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          # The layer cache is for the builder stages only. Serving the
+          # runtime stage from it would reuse the Dockerfile's apk upgrade from
+          # whenever that layer was first built, publishing an image whose OS
+          # packages are frozen in the past — the fixable-HIGH Alpine CVEs the
+          # scan below then fails on, while an uncached build of the same commit
+          # is clean.
+          no-cache-filters: runtime
           platforms: linux/amd64
           provenance: false
 
@@ -869,6 +890,13 @@ jobs:
           build-args: COMMIT=${{ github.sha }}
           cache-from: type=gha,scope=frontdesk
           cache-to: type=gha,mode=max,scope=frontdesk
+          # The layer cache is for the builder stages only. Serving the
+          # runtime stage from it would reuse the Dockerfile's apk upgrade from
+          # whenever that layer was first built, publishing an image whose OS
+          # packages are frozen in the past — the fixable-HIGH Alpine CVEs the
+          # scan below then fails on, while an uncached build of the same commit
+          # is clean.
+          no-cache-filters: runtime
           platforms: linux/amd64
           provenance: false
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -95,6 +95,20 @@ jobs:
         if: steps.version.outputs.skip_existing == 'false'
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
+      - name: Assert the runtime stage the cache filter targets exists
+        if: steps.version.outputs.skip_existing == 'false'
+        run: |
+          set -euo pipefail
+          # buildx ignores --no-cache-filter for a stage name it cannot find, so
+          # renaming the runtime stage would silently restore the stale-package
+          # bug the filter below exists to prevent.
+          for f in Dockerfile Dockerfile.frontdesk; do
+            if ! grep -qE '^FROM .+ AS runtime$' "$f"; then
+              echo "::error::$f declares no 'AS runtime' stage; no-cache-filters: runtime would be a no-op"
+              exit 1
+            fi
+          done
+
       - name: Build and push
         if: steps.version.outputs.skip_existing == 'false'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
@@ -108,6 +122,12 @@ jobs:
             COMMIT=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          # The layer cache is for the builder stages only. Serving the
+          # runtime stage from it would reuse the Dockerfile's apk upgrade from
+          # whenever that layer was first built, so a release would ship OS
+          # packages frozen in the past and image-scan.yml would file the Alpine
+          # CVEs a fresh build of the same commit never has.
+          no-cache-filters: runtime
           platforms: linux/amd64
           provenance: false
 
@@ -144,6 +164,12 @@ jobs:
             COMMIT=${{ github.sha }}
           cache-from: type=gha,scope=frontdesk
           cache-to: type=gha,mode=max,scope=frontdesk
+          # The layer cache is for the builder stages only. Serving the
+          # runtime stage from it would reuse the Dockerfile's apk upgrade from
+          # whenever that layer was first built, so a release would ship OS
+          # packages frozen in the past and image-scan.yml would file the Alpine
+          # CVEs a fresh build of the same commit never has.
+          no-cache-filters: runtime
           platforms: linux/amd64
           provenance: false
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,8 +44,12 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     go build -ldflags "-X main.version=$VERSION -X github.com/hugalafutro/model-hotel/internal/api.buildCommit=$COMMIT" -o server ./cmd/server/
 
-# Stage 3: Minimal runtime image
-FROM alpine:3.24
+# Stage 3: Minimal runtime image.
+# Named so cached builds can exclude it with buildx --no-cache-filter=runtime:
+# a reused layer cache would otherwise serve the apk upgrade below from whenever
+# it first ran, freezing the image's package set while the builder stages stay
+# cheaply cached.
+FROM alpine:3.24 AS runtime
 
 # Upgrade base packages so security patches in the 3.24 line (e.g. OpenSSL)
 # land even when the alpine:3.24 tag itself lags behind.

--- a/Dockerfile.frontdesk
+++ b/Dockerfile.frontdesk
@@ -54,8 +54,11 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     CGO_ENABLED=0 go build -ldflags "-X main.version=$VERSION -X github.com/hugalafutro/model-hotel/internal/frontdesk.buildCommit=$COMMIT" -o frontdesk ./cmd/frontdesk/
 
-# Stage 3: Minimal runtime image
-FROM alpine:3.24
+# Stage 3: Minimal runtime image.
+# Named so cached builds can exclude it with buildx --no-cache-filter=runtime,
+# the same as the main image: a reused layer cache would otherwise freeze the
+# package set at whenever the apk upgrade below first ran.
+FROM alpine:3.24 AS runtime
 
 # Upgrade base packages so security patches in the 3.24 line land even when the
 # alpine:3.24 tag itself lags. Same deliberate trade-off as the main image:


### PR DESCRIPTION
## Why

Master went red on `Publish :dev image`: Trivy failed the run with 36 fixable HIGH Alpine CVEs — `libpq` 18.4-r0 (fixed in 18.6-r0) and `postgresql16-client` 16.14-r0 (fixed in 16.15-r0).

The same commit's `Docker Build` job, running the identical scan settings, was clean. The difference is the layer cache. `Docker Build` runs a plain `docker build`; the publish jobs build with `cache-from: type=gha`, which served the runtime stage's `apk upgrade --no-cache` layer from whenever it first ran. Every published image therefore carried OS packages frozen at that date, and the Dockerfile comment promising that each build "picks up the current v3.24 patch level" was only true for uncached builds. `image-scan.yml` already avoided this with `no-cache: true` and a comment naming the hazard.

## What changed

- Both Dockerfiles name their final stage `FROM alpine:3.24 AS runtime`.
- All four cached buildx builds pass `no-cache-filters: runtime` — the `:dev` server and Front Desk candidates, and the release `:latest` server and Front Desk publishes. The release path had the same frozen-package exposure; `image-scan.yml` was catching it a cycle later instead of preventing it.
- Each publish job first asserts both Dockerfiles declare an `AS runtime` stage, because buildx **silently ignores** `--no-cache-filter` for a stage name it cannot find — a rename would otherwise restore the bug with no signal.

Builder stages keep their cache, so the cost is one `apk upgrade` per build.

## Verification

Real Dockerfile, container-driver buildx, local cache:

| pass | build | result |
|---|---|---|
| 1 | fresh | installs `libpq 18.6-r0`, `postgresql16-client 16.15-r0` |
| 2 | `--cache-from`, no filter | runtime stage `CACHED` — reproduces the stale image |
| 3 | `--cache-from --no-cache-filter runtime` | `pnpm run build:docker` and `go build` still `CACHED`; runtime stage re-runs and installs 18.6-r0 / 16.15-r0 |

`actionlint` v1.7.12 (the version CI pins) passes, and the guard script passes against both Dockerfiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)