### PR TITLE
feat(frontdesk,bellhop): show the build commit where every member reads "dev"

### DIFF
--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/BuildLabel.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/BuildLabel.kt
@@ -1,0 +1,50 @@
+package com.hugalafutro.bellhop.data
+
+// A member's build identity: the app version it reports plus the commit that
+// version was built from. Both are stamped into the binary at image build time,
+// so neither can drift from the running code.
+//
+// Mirrors buildLabel/buildTitle in frontdesk/web/src/utils/build.ts and the
+// verdict half of buildSkew in internal/frontdesk/versionskew.go. The three
+// surfaces must agree: a member Front Desk shows as one build and Bellhop shows
+// as another is worse than either showing nothing.
+
+/** The sentinel a binary built without the commit ldflag reports. */
+private const val UNSTAMPED_COMMIT = "unknown"
+
+private val RELEASE_TAG = Regex("""^v?\d+\.\d+\.\d+$""")
+
+/**
+ * isDevVersion treats a build as a "dev" build unless its version is exactly a
+ * semver release tag. Anchored, so a `git describe` fallback like
+ * "v1.2.3-15-gabc123" is a dev build rather than the tag it derives from.
+ */
+fun isDevVersion(version: String): Boolean = !RELEASE_TAG.matches(version)
+
+/** stampedCommit reports whether a commit string names an actual build. */
+fun stampedCommit(commit: String): Boolean = commit.isNotBlank() && commit != UNSTAMPED_COMMIT
+
+/**
+ * buildLabel is the short identity for a tight space (the dashboard card). A
+ * release tag identifies itself, so it wins; a dev version does not, because
+ * every untagged image reports the same "dev" placeholder and a fleet of them
+ * reads identical, so the commit is the only part that says which build this is.
+ */
+fun buildLabel(
+    version: String,
+    commit: String,
+): String = if (isDevVersion(version) && stampedCommit(commit)) commit else version
+
+/**
+ * buildDetail is the long form for the detail screen, where there is room for
+ * both halves: "dev · b80c04d4494f". Falls back to whichever half exists.
+ */
+fun buildDetail(
+    version: String,
+    commit: String,
+): String =
+    when {
+        version.isBlank() -> ""
+        stampedCommit(commit) -> "$version · $commit"
+        else -> version
+    }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/FleetModels.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/FleetModels.kt
@@ -40,6 +40,10 @@ data class MemberStatus(
     val health: HealthStatus = HealthStatus(),
     @SerialName("traefik_status") val traefikStatus: String = "",
     val version: String = "",
+    // The commit this member's binary was built from. On a fleet of self-built
+    // images every version reads "dev", so this is the half that says which
+    // build a member runs; empty on a member too old to report app_commit.
+    val commit: String = "",
     // The auto-syncer's "still in sync with the primary" heartbeat: advances
     // ~every tick while the member is reachable, distinct from lastConfigSyncAt
     // (which only moves on a real config write). Empty until first verified.

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
@@ -73,6 +73,7 @@ import com.hugalafutro.bellhop.data.LinkState
 import com.hugalafutro.bellhop.data.MemberStatus
 import com.hugalafutro.bellhop.data.MemberTraffic
 import com.hugalafutro.bellhop.data.QuotaBarMode
+import com.hugalafutro.bellhop.data.buildLabel
 import com.hugalafutro.bellhop.ui.common.BellhopSwitch
 import com.hugalafutro.bellhop.ui.common.ConfirmOpenUrlDialog
 import com.hugalafutro.bellhop.ui.common.LockFab
@@ -745,8 +746,12 @@ private fun MemberCard(
                     )
                 }
                 if (member.status.version.isNotBlank()) {
+                    // The commit, not the version, on a "dev" fleet: every card
+                    // would otherwise read the same placeholder. The card has room
+                    // for one line, so it carries the identifying half only; the
+                    // detail screen shows both.
                     Text(
-                        text = member.status.version,
+                        text = buildLabel(member.status.version, member.status.commit),
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreen.kt
@@ -60,6 +60,7 @@ import com.hugalafutro.bellhop.data.MemberState
 import com.hugalafutro.bellhop.data.MemberStatus
 import com.hugalafutro.bellhop.data.MemberTraffic
 import com.hugalafutro.bellhop.data.TrafficPoint
+import com.hugalafutro.bellhop.data.buildDetail
 import com.hugalafutro.bellhop.ui.common.ConfirmOpenUrlDialog
 import com.hugalafutro.bellhop.ui.common.CustomDateRange
 import com.hugalafutro.bellhop.ui.common.EventRange
@@ -354,10 +355,12 @@ private fun MetaLedger(
         }
         if (member.status.version.isNotBlank()) {
             // Build the member reports running — the dashboard card shows it, so the
-            // detail screen carries it too. Static identity, no age suffix.
+            // detail screen carries it too. Static identity, no age suffix. Both
+            // halves here, unlike the card: "dev" alone identifies no build, and
+            // the commit alone does not say which release line it came from.
             LedgerRow(
                 label = stringResource(R.string.member_detail_label_version),
-                value = member.status.version,
+                value = buildDetail(member.status.version, member.status.commit),
                 tag = "member-detail-version",
             )
         }

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/BuildLabelTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/BuildLabelTest.kt
@@ -1,0 +1,57 @@
+package com.hugalafutro.bellhop.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The rule here has to match frontdesk/web/src/utils/build.ts and the verdict
+ * half of internal/frontdesk/versionskew.go: a member Front Desk shows as one
+ * build and Bellhop shows as another is worse than either showing nothing.
+ */
+class BuildLabelTest {
+    @Test
+    fun `only an exact semver tag is a release`() {
+        assertFalse(isDevVersion("v1.2.3"))
+        assertFalse(isDevVersion("1.2.3"))
+        assertTrue(isDevVersion("dev"))
+        assertTrue(isDevVersion("v1.2.3-15-gabc123"))
+        assertTrue(isDevVersion("v1.2.3-dirty"))
+    }
+
+    @Test
+    fun `sentinels name no build`() {
+        assertTrue(stampedCommit("b80c04d4494f"))
+        assertFalse(stampedCommit(""))
+        assertFalse(stampedCommit("unknown"))
+    }
+
+    @Test
+    fun `card shows the commit for a dev build`() {
+        assertEquals("b80c04d4494f", buildLabel("dev", "b80c04d4494f"))
+    }
+
+    @Test
+    fun `card keeps a release tag, which identifies itself`() {
+        assertEquals("v1.2.3", buildLabel("v1.2.3", "b80c04d4494f"))
+    }
+
+    @Test
+    fun `card falls back to the version when no commit names the build`() {
+        assertEquals("dev", buildLabel("dev", ""))
+        assertEquals("dev", buildLabel("dev", "unknown"))
+    }
+
+    @Test
+    fun `detail screen carries both halves`() {
+        assertEquals("dev · b80c04d4494f", buildDetail("dev", "b80c04d4494f"))
+        assertEquals("v1.2.3 · b80c04d4494f", buildDetail("v1.2.3", "b80c04d4494f"))
+    }
+
+    @Test
+    fun `detail screen shows what it has`() {
+        assertEquals("dev", buildDetail("dev", "unknown"))
+        assertEquals("", buildDetail("", "b80c04d4494f"))
+    }
+}

--- a/frontdesk/web/src/api/types.ts
+++ b/frontdesk/web/src/api/types.ts
@@ -57,6 +57,11 @@ export interface MemberStatus {
 	health: HealthStatus;
 	traefik_status?: string; // "UP" | "DOWN" | ""
 	version?: string;
+	// The commit this member's binary was built from. It is what distinguishes
+	// two builds on a fleet whose images all report the "dev" placeholder
+	// version, so it is what the Members table shows and what the skew badges
+	// compare. Absent on a member too old to report app_commit.
+	commit?: string;
 	// Live "auto-sync is running" heartbeat: the last time the auto-syncer
 	// confirmed this member matches the primary (a real write, a self-converged
 	// empty diff, or a quiet verify tick). RFC3339; absent until first verified,

--- a/frontdesk/web/src/components/VersionFooter.tsx
+++ b/frontdesk/web/src/components/VersionFooter.tsx
@@ -2,20 +2,11 @@ import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { api } from "../api/client";
 import type { VersionInfo } from "../api/types";
+import { isDevVersion } from "../utils/build";
 
 const REPO_URL = "https://github.com/hugalafutro/model-hotel";
 const WIKI_URL =
 	"https://github.com/hugalafutro/model-hotel/wiki/High-Availability";
-
-// isDevVersion treats a build as a "dev" build unless its version is exactly a
-// semver release tag (optionally v-prefixed: "v1.2.3" / "1.2.3"). The match is
-// anchored so a `git describe` fallback like "v1.2.3-15-gabc123" or
-// "v1.2.3-dirty" is correctly classed as dev and shows its commit, rather than
-// masquerading as the v1.2.3 release. A `dev` image is rebuilt on every master
-// commit, so it shows its source commit SHA instead of a tag.
-function isDevVersion(v: string): boolean {
-	return !/^v?\d+\.\d+\.\d+$/.test(v);
-}
 
 // VersionFooter shows which Front Desk build is running, centered at the bottom
 // of the shell, plus a link to the HA wiki. The version (e.g. "dev") links to

--- a/frontdesk/web/src/pages/MembersPage.tsx
+++ b/frontdesk/web/src/pages/MembersPage.tsx
@@ -338,9 +338,10 @@ function MemberRow({
 }: {
 	member: MemberView;
 	groupBuild: Build | null;
-	// The designated primary's build, or null when no primary is set. A build
-	// with an empty version means the primary's is unknown, which anchors
-	// nothing: the badge needs something confirmed to compare against.
+	// The designated primary's build, or null when no primary is set. A build with
+	// an empty version means the primary's own build is unconfirmed, which the
+	// gate treats as skew against every member rather than as "nothing to
+	// compare" - so it anchors the badge too.
 	primaryBuild: Build | null;
 	isPrimary: boolean;
 	// True when the fleet has at most one active member. The drain control is
@@ -364,14 +365,15 @@ function MemberRow({
 		!!build.version && !!groupBuild && buildsDiffer(build, groupBuild);
 	// Mirrors the backend gate: config sync (autosync and the wizard) holds a
 	// tokened member while its BUILD differs from the primary's, including an
-	// unknown version (the gate fails closed). Comparing versions alone would
+	// unknown version on EITHER side (the gate fails closed, so a primary whose
+	// own version is unread holds the whole fleet). Comparing versions alone would
 	// leave this badge silent on a "dev" fleet held for a commit difference,
 	// telling the operator a member is in sync while sync is refusing it.
 	// Tokenless members are skipped by sync entirely, never held.
 	const heldForSkew =
 		!isPrimary &&
 		m.has_token &&
-		!!primaryBuild?.version &&
+		!!primaryBuild &&
 		buildsDiffer(build, primaryBuild);
 
 	return (

--- a/frontdesk/web/src/pages/MembersPage.tsx
+++ b/frontdesk/web/src/pages/MembersPage.tsx
@@ -13,22 +13,49 @@ import { ConfirmModal } from "../components/ConfirmModal";
 import { Notice } from "../components/Notice";
 import { useToast } from "../context/ToastContext";
 import { useMembers } from "../hooks/useMembers";
+import type { Build } from "../utils/build";
+import {
+	buildLabel,
+	buildsDiffer,
+	buildTitle,
+	stampedCommit,
+} from "../utils/build";
 import { formatRelative, formatTimeOfDay } from "../utils/time";
 
-// majorityVersion returns the most common non-empty version across members, used
-// to flag the odd one(s) out only when the group actually disagrees.
-function majorityVersion(members: MemberView[]): string | null {
-	const counts = new Map<string, number>();
+// memberBuild reads a member's build identity off its polled status. Front Desk
+// clears both halves together when a read fails, so an empty version means "not
+// confirmed" rather than "no version".
+function memberBuild(m: MemberView): Build {
+	return { version: m.status.version ?? "", commit: m.status.commit ?? "" };
+}
+
+// buildKey identifies a build for counting. The commit joins the key only when
+// it names a real build, so members that cannot report one still group by their
+// version instead of each landing in a bucket of its own.
+function buildKey(b: Build): string {
+	return stampedCommit(b.commit) ? `${b.version}@${b.commit}` : b.version;
+}
+
+// majorityBuild returns the most common known build across members, used to flag
+// the odd one(s) out only when the group actually disagrees. Keyed on the build
+// rather than the version: on a fleet of "dev" images every version matches, so
+// a version-keyed count can never see a disagreement.
+function majorityBuild(members: MemberView[]): Build | null {
+	const counts = new Map<string, { build: Build; n: number }>();
 	for (const m of members) {
-		const v = m.status.version;
-		if (v) counts.set(v, (counts.get(v) ?? 0) + 1);
+		const b = memberBuild(m);
+		if (!b.version) continue;
+		const k = buildKey(b);
+		const cur = counts.get(k);
+		if (cur) cur.n += 1;
+		else counts.set(k, { build: b, n: 1 });
 	}
 	if (counts.size <= 1) return null;
-	let best: string | null = null;
+	let best: Build | null = null;
 	let bestN = 0;
-	for (const [v, n] of counts) {
+	for (const { build, n } of counts.values()) {
 		if (n > bestN) {
-			best = v;
+			best = build;
 			bestN = n;
 		}
 	}
@@ -108,13 +135,14 @@ export function MembersPage() {
 	const [removing, setRemoving] = useState<MemberView | null>(null);
 	useEffect(refreshPrimary, [refreshPrimary]);
 
-	const groupVersion = majorityVersion(members);
+	const groupBuild = majorityBuild(members);
 	// With a designated primary, version divergence is anchored to it (that is
 	// what holds config sync); the majority "odd one out" flag only fills in
 	// when no primary is set and there is nothing else to anchor to.
-	const primaryVersion = primaryId
-		? (members.find((m) => m.id === primaryId)?.status.version ?? null)
-		: null;
+	const primaryMember = primaryId
+		? members.find((m) => m.id === primaryId)
+		: undefined;
+	const primaryBuild = primaryMember ? memberBuild(primaryMember) : null;
 	// Pin the fleet primary to the top; every other member keeps its order.
 	const orderedMembers = primaryId
 		? [
@@ -239,8 +267,8 @@ export function MembersPage() {
 								<MemberRow
 									key={m.id}
 									member={m}
-									groupVersion={primaryId ? null : groupVersion}
-									primaryVersion={primaryVersion}
+									groupBuild={primaryId ? null : groupBuild}
+									primaryBuild={primaryBuild}
 									isPrimary={m.id === primaryId}
 									soleActive={soleActive}
 									disbandOnRemove={disbandOnRemove}
@@ -299,8 +327,8 @@ export function MembersPage() {
 
 function MemberRow({
 	member: m,
-	groupVersion,
-	primaryVersion,
+	groupBuild,
+	primaryBuild,
 	isPrimary,
 	soleActive,
 	disbandOnRemove,
@@ -309,10 +337,11 @@ function MemberRow({
 	onRemove,
 }: {
 	member: MemberView;
-	groupVersion: string | null;
-	// The designated primary's version, or null when no primary is set (or its
-	// version is unknown). Non-null anchors the "sync held" badge.
-	primaryVersion: string | null;
+	groupBuild: Build | null;
+	// The designated primary's build, or null when no primary is set. A build
+	// with an empty version means the primary's is unknown, which anchors
+	// nothing: the badge needs something confirmed to compare against.
+	primaryBuild: Build | null;
 	isPrimary: boolean;
 	// True when the fleet has at most one active member. The drain control is
 	// disabled for the active member in that case: draining the last active member
@@ -330,17 +359,20 @@ function MemberRow({
 }) {
 	const { t } = useTranslation();
 	const health = m.status.health;
+	const build = memberBuild(m);
 	const mismatch =
-		!!m.status.version && !!groupVersion && m.status.version !== groupVersion;
+		!!build.version && !!groupBuild && buildsDiffer(build, groupBuild);
 	// Mirrors the backend gate: config sync (autosync and the wizard) holds a
-	// tokened member while its version differs from the primary's, including an
-	// unknown version (the gate fails closed). Tokenless members are skipped by
-	// sync entirely, never held.
+	// tokened member while its BUILD differs from the primary's, including an
+	// unknown version (the gate fails closed). Comparing versions alone would
+	// leave this badge silent on a "dev" fleet held for a commit difference,
+	// telling the operator a member is in sync while sync is refusing it.
+	// Tokenless members are skipped by sync entirely, never held.
 	const heldForSkew =
 		!isPrimary &&
 		m.has_token &&
-		!!primaryVersion &&
-		m.status.version !== primaryVersion;
+		!!primaryBuild?.version &&
+		buildsDiffer(build, primaryBuild);
 
 	return (
 		<tr className={isPrimary ? "fd-row-primary" : undefined}>
@@ -400,8 +432,10 @@ function MemberRow({
 			</td>
 			<td>
 				<span className="fd-row">
-					{m.status.version ? (
-						<span className="fd-mono">{m.status.version}</span>
+					{build.version ? (
+						<span className="fd-mono" title={buildTitle(build)}>
+							{buildLabel(build)}
+						</span>
 					) : (
 						<span className="fd-faint">
 							{m.has_token ? t("members.versionUnknown") : t("members.noToken")}

--- a/frontdesk/web/src/pages/__tests__/MembersPage.test.tsx
+++ b/frontdesk/web/src/pages/__tests__/MembersPage.test.tsx
@@ -605,6 +605,122 @@ describe("MembersPage", () => {
 		expect(within(bodyRows[1]).getByText("hotel-2")).toBeInTheDocument();
 	});
 
+	it("shows the commit instead of the shared 'dev' placeholder", async () => {
+		const health = {
+			known: true,
+			healthy: true,
+			latency_ms: 9,
+			checked_at: "",
+		};
+		server.use(
+			http.get("/api/members", () =>
+				HttpResponse.json([
+					member({
+						id: "1",
+						name: "hotel-1",
+						status: { health, version: "dev", commit: "b80c04d4494f" },
+					}),
+					// A release tag identifies itself, so it stays the label.
+					member({
+						id: "2",
+						name: "hotel-2",
+						status: { health, version: "v1.2.3", commit: "aaaaaaaaaaaa" },
+					}),
+					// Nothing to show but the version: a member that reports no commit.
+					member({
+						id: "3",
+						name: "hotel-3",
+						status: { health, version: "dev", commit: "unknown" },
+					}),
+				]),
+			),
+		);
+		renderPage();
+
+		const row1 = (await screen.findByText("hotel-1")).closest(
+			"tr",
+		) as HTMLElement;
+		expect(within(row1).getByText("b80c04d4494f")).toBeInTheDocument();
+		expect(within(row1).queryByText("dev")).toBeNull();
+		// The version is not lost, it moves to the hover detail.
+		expect(within(row1).getByTitle("dev · b80c04d4494f")).toBeInTheDocument();
+
+		const row2 = (await screen.findByText("hotel-2")).closest(
+			"tr",
+		) as HTMLElement;
+		expect(within(row2).getByText("v1.2.3")).toBeInTheDocument();
+
+		const row3 = (await screen.findByText("hotel-3")).closest(
+			"tr",
+		) as HTMLElement;
+		expect(within(row3).getByText("dev")).toBeInTheDocument();
+		expect(within(row3).queryByText("unknown")).toBeNull();
+	});
+
+	it("badges a commit-only skew as sync held, where the versions match", async () => {
+		// The case the version cannot see, and the one the backend gate now holds
+		// on: both members report "dev", and only the commit separates them. A
+		// badge that compared versions would call this member in sync while sync
+		// is refusing it.
+		const health = {
+			known: true,
+			healthy: true,
+			latency_ms: 9,
+			checked_at: "",
+		};
+		server.use(
+			http.get("/api/members", () =>
+				HttpResponse.json([
+					member({
+						id: "1",
+						name: "hotel-1",
+						has_token: true,
+						status: { health, version: "dev", commit: "aaaaaaaaaaaa" },
+					}),
+					member({
+						id: "2",
+						name: "hotel-2",
+						has_token: true,
+						status: { health, version: "dev", commit: "bbbbbbbbbbbb" },
+					}),
+					member({
+						id: "3",
+						name: "hotel-3",
+						has_token: true,
+						status: { health, version: "dev", commit: "aaaaaaaaaaaa" },
+					}),
+					// Reports no commit: the gate falls back to the version and syncs
+					// it, so the badge must stay off rather than invent a difference.
+					member({
+						id: "4",
+						name: "hotel-4",
+						has_token: true,
+						status: { health, version: "dev", commit: "unknown" },
+					}),
+				]),
+			),
+			http.get("/api/fleet/autosync", () =>
+				HttpResponse.json({ enabled: true, primary_id: "1" }),
+			),
+		);
+		renderPage();
+
+		const row2 = (await screen.findByText("hotel-2")).closest(
+			"tr",
+		) as HTMLElement;
+		expect(within(row2).getByTestId("member-sync-held")).toBeInTheDocument();
+
+		const row3 = (await screen.findByText("hotel-3")).closest(
+			"tr",
+		) as HTMLElement;
+		expect(within(row3).queryByTestId("member-sync-held")).toBeNull();
+
+		const row4 = (await screen.findByText("hotel-4")).closest(
+			"tr",
+		) as HTMLElement;
+		expect(within(row4).queryByTestId("member-sync-held")).toBeNull();
+	});
+
 	it("badges a member whose version differs from the primary's as sync held", async () => {
 		const health = {
 			known: true,

--- a/frontdesk/web/src/pages/__tests__/MembersPage.test.tsx
+++ b/frontdesk/web/src/pages/__tests__/MembersPage.test.tsx
@@ -657,6 +657,95 @@ describe("MembersPage", () => {
 		expect(within(row3).queryByText("unknown")).toBeNull();
 	});
 
+	it("flags the odd build out when no primary is set", async () => {
+		// No primary designated, so the majority tally is what flags divergence.
+		// Every member reports "dev": a version-keyed tally sees one bucket and
+		// flags nothing, which is the whole reason it counts builds.
+		const health = {
+			known: true,
+			healthy: true,
+			latency_ms: 9,
+			checked_at: "",
+		};
+		server.use(
+			http.get("/api/members", () =>
+				HttpResponse.json([
+					member({
+						id: "1",
+						name: "hotel-1",
+						status: { health, version: "dev", commit: "aaaaaaaaaaaa" },
+					}),
+					member({
+						id: "2",
+						name: "hotel-2",
+						status: { health, version: "dev", commit: "aaaaaaaaaaaa" },
+					}),
+					member({
+						id: "3",
+						name: "hotel-3",
+						status: { health, version: "dev", commit: "bbbbbbbbbbbb" },
+					}),
+				]),
+			),
+			http.get("/api/fleet/autosync", () =>
+				HttpResponse.json({ enabled: false, primary_id: "" }),
+			),
+		);
+		renderPage();
+
+		const row3 = (await screen.findByText("hotel-3")).closest(
+			"tr",
+		) as HTMLElement;
+		expect(
+			within(row3).getByTitle(/differs from the group/i),
+		).toBeInTheDocument();
+
+		const row1 = (await screen.findByText("hotel-1")).closest(
+			"tr",
+		) as HTMLElement;
+		expect(within(row1).queryByTitle(/differs from the group/i)).toBeNull();
+	});
+
+	it("badges every member as held when the primary's own build is unread", async () => {
+		// The gate fails closed on an unreadable version, and the primary's counts:
+		// with nothing confirmed to push from, sync is refused fleet-wide. A badge
+		// that stayed silent here would report the fleet in sync at the one moment
+		// none of it is.
+		const health = {
+			known: true,
+			healthy: true,
+			latency_ms: 9,
+			checked_at: "",
+		};
+		server.use(
+			http.get("/api/members", () =>
+				HttpResponse.json([
+					member({
+						id: "1",
+						name: "hotel-1",
+						has_token: true,
+						status: { health },
+					}),
+					member({
+						id: "2",
+						name: "hotel-2",
+						has_token: true,
+						status: { health, version: "dev", commit: "aaaaaaaaaaaa" },
+					}),
+				]),
+			),
+			http.get("/api/fleet/autosync", () =>
+				HttpResponse.json({ enabled: true, primary_id: "1" }),
+			),
+		);
+		renderPage();
+
+		const row2 = (await screen.findByText("hotel-2")).closest(
+			"tr",
+		) as HTMLElement;
+		expect(within(row2).getByTestId("member-sync-held")).toBeInTheDocument();
+	});
+
 	it("badges a commit-only skew as sync held, where the versions match", async () => {
 		// The case the version cannot see, and the one the backend gate now holds
 		// on: both members report "dev", and only the commit separates them. A

--- a/frontdesk/web/src/utils/__tests__/build.test.ts
+++ b/frontdesk/web/src/utils/__tests__/build.test.ts
@@ -88,6 +88,21 @@ describe("buildsDiffer", () => {
 		).toBe(false);
 	});
 
+	it("fails closed when either version is unreadable", () => {
+		// Mirrors the gate: an unread version on EITHER side is skew, so a primary
+		// whose own build is unconfirmed holds the whole fleet rather than
+		// silently passing it.
+		expect(
+			buildsDiffer({ version: "", commit: "" }, { version: "dev", commit: "" }),
+		).toBe(true);
+		expect(
+			buildsDiffer({ version: "dev", commit: "" }, { version: "", commit: "" }),
+		).toBe(true);
+		expect(
+			buildsDiffer({ version: "", commit: "" }, { version: "", commit: "" }),
+		).toBe(true);
+	});
+
 	it("falls back to the version when either commit names no build", () => {
 		expect(
 			buildsDiffer(

--- a/frontdesk/web/src/utils/__tests__/build.test.ts
+++ b/frontdesk/web/src/utils/__tests__/build.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildLabel,
+	buildsDiffer,
+	buildTitle,
+	isDevVersion,
+	stampedCommit,
+} from "../build";
+
+describe("isDevVersion", () => {
+	it("treats only an exact semver tag as a release", () => {
+		expect(isDevVersion("v1.2.3")).toBe(false);
+		expect(isDevVersion("1.2.3")).toBe(false);
+		expect(isDevVersion("dev")).toBe(true);
+		// A `git describe` fallback is a dev build, not the tag it derives from.
+		expect(isDevVersion("v1.2.3-15-gabc123")).toBe(true);
+		expect(isDevVersion("v1.2.3-dirty")).toBe(true);
+	});
+});
+
+describe("stampedCommit", () => {
+	it("rejects the sentinels that name no build", () => {
+		expect(stampedCommit("b80c04d4494f")).toBe(true);
+		expect(stampedCommit("")).toBe(false);
+		expect(stampedCommit("unknown")).toBe(false);
+	});
+});
+
+describe("buildLabel", () => {
+	it("shows the commit for a dev build, since every dev image reports 'dev'", () => {
+		expect(buildLabel({ version: "dev", commit: "b80c04d4494f" })).toBe(
+			"b80c04d4494f",
+		);
+	});
+
+	it("keeps a release tag, which identifies itself", () => {
+		expect(buildLabel({ version: "v1.2.3", commit: "b80c04d4494f" })).toBe(
+			"v1.2.3",
+		);
+	});
+
+	it("falls back to the version when no commit names the build", () => {
+		expect(buildLabel({ version: "dev", commit: "" })).toBe("dev");
+		expect(buildLabel({ version: "dev", commit: "unknown" })).toBe("dev");
+	});
+});
+
+describe("buildTitle", () => {
+	it("carries the half the label does not show", () => {
+		expect(buildTitle({ version: "dev", commit: "b80c04d4494f" })).toBe(
+			"dev · b80c04d4494f",
+		);
+	});
+
+	it("is absent when there is no second half", () => {
+		expect(buildTitle({ version: "dev", commit: "unknown" })).toBeUndefined();
+		expect(buildTitle({ version: "", commit: "b80c04d4494f" })).toBeUndefined();
+	});
+});
+
+describe("buildsDiffer", () => {
+	// Mirrors internal/frontdesk/versionskew.go's buildSkew, which is what
+	// actually holds config sync.
+	it("differs on the version", () => {
+		expect(
+			buildsDiffer(
+				{ version: "v1.0.0", commit: "" },
+				{ version: "v0.9.0", commit: "" },
+			),
+		).toBe(true);
+	});
+
+	it("differs on the commit when the versions match", () => {
+		expect(
+			buildsDiffer(
+				{ version: "dev", commit: "aaaaaaaaaaaa" },
+				{ version: "dev", commit: "bbbbbbbbbbbb" },
+			),
+		).toBe(true);
+	});
+
+	it("agrees when both halves match", () => {
+		expect(
+			buildsDiffer(
+				{ version: "dev", commit: "aaaaaaaaaaaa" },
+				{ version: "dev", commit: "aaaaaaaaaaaa" },
+			),
+		).toBe(false);
+	});
+
+	it("falls back to the version when either commit names no build", () => {
+		expect(
+			buildsDiffer(
+				{ version: "dev", commit: "aaaaaaaaaaaa" },
+				{ version: "dev", commit: "" },
+			),
+		).toBe(false);
+		expect(
+			buildsDiffer(
+				{ version: "dev", commit: "aaaaaaaaaaaa" },
+				{ version: "dev", commit: "unknown" },
+			),
+		).toBe(false);
+	});
+});

--- a/frontdesk/web/src/utils/build.ts
+++ b/frontdesk/web/src/utils/build.ts
@@ -1,0 +1,57 @@
+// A member's build identity: the app version it reports plus the commit that
+// version was built from. Both are stamped into the binary at image build time
+// (the Dockerfile's -ldflags), so neither can drift from the running code.
+export interface Build {
+	version: string;
+	commit: string;
+}
+
+// isDevVersion treats a build as a "dev" build unless its version is exactly a
+// semver release tag (optionally v-prefixed: "v1.2.3" / "1.2.3"). The match is
+// anchored so a `git describe` fallback like "v1.2.3-15-gabc123" or
+// "v1.2.3-dirty" is correctly classed as dev and shows its commit, rather than
+// masquerading as the v1.2.3 release.
+export function isDevVersion(version: string): boolean {
+	return !/^v?\d+\.\d+\.\d+$/.test(version);
+}
+
+// stampedCommit reports whether a commit string names an actual build. Mirrors
+// the backend's sentinel: a binary built without the commit ldflag reports
+// "unknown", and a member too old to carry app_commit reports nothing.
+export function stampedCommit(commit: string): boolean {
+	return commit !== "" && commit !== "unknown";
+}
+
+// buildLabel is what to show for a build. A release tag identifies itself, so it
+// wins. A dev version does not: every untagged image reports the same "dev"
+// placeholder, so a column of them says nothing about whether the fleet agrees,
+// and the commit is the only part that does.
+export function buildLabel(build: Build): string {
+	if (isDevVersion(build.version) && stampedCommit(build.commit)) {
+		return build.commit;
+	}
+	return build.version;
+}
+
+// buildTitle is the hover detail behind the label: both halves, so a column
+// showing commits still says which version they are, and vice versa. Undefined
+// when there is no second half to add.
+export function buildTitle(build: Build): string | undefined {
+	if (build.version === "" || !stampedCommit(build.commit)) return undefined;
+	return `${build.version} · ${build.commit}`;
+}
+
+// buildsDiffer mirrors buildSkew in internal/frontdesk/versionskew.go, which is
+// what actually holds config sync. Keeping the badge's verdict and the gate's
+// verdict derived from the same rule is the point: a member held by the backend
+// while the UI shows it aligned is worse than no badge at all.
+//
+// The version decides it where the versions differ. Where they match - as they
+// always do on a fleet of "dev" images - the commit does, and only when both
+// sides report a real one: an unanswerable commit falls back to the version
+// verdict rather than manufacturing a difference.
+export function buildsDiffer(a: Build, b: Build): boolean {
+	if (a.version !== b.version) return true;
+	if (!stampedCommit(a.commit) || !stampedCommit(b.commit)) return false;
+	return a.commit !== b.commit;
+}

--- a/frontdesk/web/src/utils/build.ts
+++ b/frontdesk/web/src/utils/build.ts
@@ -51,6 +51,11 @@ export function buildTitle(build: Build): string | undefined {
 // sides report a real one: an unanswerable commit falls back to the version
 // verdict rather than manufacturing a difference.
 export function buildsDiffer(a: Build, b: Build): boolean {
+	// Fail closed on a version we could not read, exactly as the gate does. This
+	// covers the primary's own version being unread: the backend then holds every
+	// member in the fleet, and a badge that stayed silent would report the whole
+	// fleet in sync at the moment sync is refusing all of it.
+	if (a.version === "" || b.version === "") return true;
 	if (a.version !== b.version) return true;
 	if (!stampedCommit(a.commit) || !stampedCommit(b.commit)) return false;
 	return a.commit !== b.commit;


### PR DESCRIPTION
Follow-on to #711, which made config sync compare builds. This makes the surfaces that display a member show the same thing the gate decides on.

## The column said nothing

Front Desk's Members table rendered `app_version`. On a self-built fleet that is the `dev` placeholder on every row — four identical cells that cannot tell an aligned fleet from a mid-rebuild one. Right now, prod:

```
MH docker-vm      version='dev' commit='b80c04d4494f'
MH docker-pc      version='dev' commit='b80c04d4494f'
MH truenas        version='dev' commit='b80c04d4494f'
MH turbofreenas   version='dev' commit='b80c04d4494f'
```

The column showed the left-hand half. It now shows the commit for a dev build and keeps the tag for a release (a tag identifies itself; `dev` does not), with the other half in the hover detail — `dev · b80c04d4494f`. A member reporting no commit still shows its version rather than the word `unknown`, which would dress an unplaceable build as a placed one.

`app_commit` was already in the members payload as of #711, so this renders data the deployed API already serves.

## Bellhop had the same four "dev"s

`member.status.version` is rendered in two places in the Android app, so the phone showed exactly what the Members table did. It now shows the commit on the dashboard card, where there is room for one line, and both halves on the detail screen. `BuildLabel.kt` mirrors the TS and Go copies of the rule: a member Front Desk calls one build and Bellhop calls another is worse than either showing nothing.

## Badges that had gone stale

The column carries two badges, and one says in its own comment that it mirrors the backend gate. Since #711 that gate compares commits, and these still compared version strings — so a fleet held for a commit-only difference rendered as **aligned**, telling the operator a member was in sync while sync was refusing it.

Both now compare through `buildsDiffer`, a mirror of `buildSkew` in `internal/frontdesk/versionskew.go`, fallback included: when either side reports no usable commit the verdict falls back to the version rather than manufacturing a difference. The majority "odd one out" flag had the same blind spot (a version-keyed tally cannot see disagreement on a fleet of `dev` images) and is now keyed on the build.

## From review

Two findings, both fixed here:

- **The badge did not fail closed on an unread *primary*.** `buildSkew` fails closed when *either* version is empty, so an unpolled primary holds the whole fleet; the guard only checked the member's side, so the badge went silent exactly when nothing was syncing. `buildsDiffer` now fails closed itself rather than leaving each caller to remember, and the comment that claimed to mirror the gate no longer overstates what it handled.
- **The majority tally had no coverage.** Reverting `buildKey` to ignore the commit left all 33 tests passing, because the one commit-skew test designates a primary and never reaches that path. Now covered by a no-primary fleet whose members differ only by commit.

## Verified

Front Desk web: 562 passed / 49 files, lint and `tsc -b` clean. Bellhop: `make android-test` green, ktlint clean.

Every behaviour here was mutation-checked rather than trusted:

- forcing the label back to the version fails the two label tests
- reverting `buildsDiffer` to version-only fails the commit-skew tests
- removing the fail-closed guard fails `fails closed when either version is unreadable`
- restoring the old `!!primaryBuild?.version` guard fails `badges every member as held when the primary's own build is unread`
- the reviewer's own mutation (`buildKey` ignoring the commit) now fails `flags the odd build out when no primary is set`

🤖 Generated with [Claude Code](https://claude.com/claude-code)