### PR TITLE
fix(proxy): forward payload-class upstream errors on the last candidate

### DIFF
--- a/internal/proxy/hedge_cancel_origin_test.go
+++ b/internal/proxy/hedge_cancel_origin_test.go
@@ -353,7 +353,7 @@ func TestLearnRejectedParams(t *testing.T) {
 	t.Run("learns a rejected param under the provider's own scope", func(t *testing.T) {
 		h := &Handler{}
 		cand := newCandidate()
-		h.learnRejectedParams(cand, "openai", []byte(`{"error":{"message":"`+"`top_p`"+` is not supported"}}`))
+		h.learnRejectedParams(cand, []byte(`{"error":{"message":"`+"`top_p`"+` is not supported"}}`))
 
 		key := paramrewrite.LearnedCacheKey(cand.provider.ID.String(), "gpt-4o")
 		cached, ok := h.deprecationCache.Load(key)
@@ -372,7 +372,7 @@ func TestLearnRejectedParams(t *testing.T) {
 	t.Run("learns a rename", func(t *testing.T) {
 		h := &Handler{}
 		cand := newCandidate()
-		h.learnRejectedParams(cand, "openai", []byte(`{"error":{"message":"Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead."}}`))
+		h.learnRejectedParams(cand, []byte(`{"error":{"message":"Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead."}}`))
 
 		key := paramrewrite.LearnedCacheKey(cand.provider.ID.String(), "gpt-4o")
 		if _, ok := h.paramRenameCache.Load(key); !ok {
@@ -383,7 +383,7 @@ func TestLearnRejectedParams(t *testing.T) {
 	t.Run("a 400 that names no param teaches nothing", func(t *testing.T) {
 		h := &Handler{}
 		cand := newCandidate()
-		h.learnRejectedParams(cand, "openai", []byte(`{"error":{"message":"context length exceeded"}}`))
+		h.learnRejectedParams(cand, []byte(`{"error":{"message":"context length exceeded"}}`))
 
 		key := paramrewrite.LearnedCacheKey(cand.provider.ID.String(), "gpt-4o")
 		if _, ok := h.deprecationCache.Load(key); ok {

--- a/internal/proxy/hedging.go
+++ b/internal/proxy/hedging.go
@@ -294,7 +294,7 @@ func (h *Handler) probeStreamingCandidate(ctx context.Context, st *requestState,
 			// Same reasoning for rejected/renamed params: the retry is refused
 			// in-race, but learning here means the next request — hedged or
 			// sequential — is built without the params this model refuses.
-			h.learnRejectedParams(candidate, providerType, errBody)
+			h.learnRejectedParams(candidate, errBody)
 			// Both readings are only valid on a chat-completions attempt: a
 			// dialect 400 names that dialect's fields, and a strip mislearned
 			// from one poisons the compat path for this model on every later

--- a/internal/proxy/multimodal.go
+++ b/internal/proxy/multimodal.go
@@ -409,7 +409,7 @@ func (h *Handler) attemptPassthroughCandidate(w http.ResponseWriter, r *http.Req
 		if !isFailoverEligible && st.circuitBreakerEnabled {
 			h.circuitBreaker.RecordSuccess(candidate.provider.ID, candidate.provider.Name)
 		}
-		return h.forwardUpstreamError(w, st, candidate, resp, attempt, hasMoreCandidates, responseHeaderMs)
+		return h.forwardUpstreamError(w, st, candidate, resp, attempt, isFailoverEligible, responseHeaderMs)
 	}
 
 	// Breaker success for 2xx is recorded inside servePassthroughResponse at

--- a/internal/proxy/proxy_chat_test.go
+++ b/internal/proxy/proxy_chat_test.go
@@ -1332,7 +1332,7 @@ func TestChatCompletions_AllowedProviders_EmptySliceDeniesAll(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestChatCompletions_UpstreamErrorForwarding(t *testing.T) {
-	t.Run("failover exhausted returns generic error", func(t *testing.T) {
+	t.Run("payload error on the last candidate forwards upstream body", func(t *testing.T) {
 		pool := testDB.Pool()
 		ctx := context.Background()
 
@@ -1397,18 +1397,17 @@ func TestChatCompletions_UpstreamErrorForwarding(t *testing.T) {
 		w := httptest.NewRecorder()
 		handler.ChatCompletions(w, req)
 
-		// Single provider (no failover candidates) with 400 → generic error
+		// Single provider (no failover candidates) with 400: a payload-class
+		// refusal is about this caller's own request, so the provider's error
+		// object is forwarded even on the last candidate — the same body the
+		// same error gets when it arrives through a hotel/ group.
 		if w.Code != http.StatusBadRequest {
 			t.Errorf("expected status 400, got %d", w.Code)
 		}
 
 		bodyStr := w.Body.String()
-		// Classified reason plus the upstream status, never the provider's body.
-		if !strings.Contains(bodyStr, "upstream HTTP 400") {
-			t.Errorf("expected classified error naming the upstream status, got: %s", bodyStr)
-		}
-		if strings.Contains(bodyStr, "context_length_exceeded") {
-			t.Errorf("should NOT forward upstream JSON details, got: %s", bodyStr)
+		if !strings.Contains(bodyStr, "context_length_exceeded") {
+			t.Errorf("expected the upstream error object to be forwarded, got: %s", bodyStr)
 		}
 	})
 

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptrace"
+	"regexp"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -218,7 +219,7 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return h.forwardUpstreamError(w, st, candidate, resp, attempt, hasMoreCandidates, responseHeaderMs)
+		return h.forwardUpstreamError(w, st, candidate, resp, attempt, isFailoverEligible, responseHeaderMs)
 	}
 
 	debuglog.Debug("proxy: upstream responded OK, dispatching to handler", "stream", st.isStreaming, "native_anthropic", st.anthropicNativeAttempt, "responses_api", st.responsesAttempt, "model", logData.modelID, "provider", logData.providerName, "provider_id", candidate.provider.ID, "status", resp.StatusCode)
@@ -714,21 +715,25 @@ func (h *Handler) doUpstream(ctx context.Context, req *http.Request, st *request
 
 // forwardUpstreamError handles a non-200 upstream response that is NOT being
 // failed over (phase G): log + meter the failure via failRequest, then answer the
-// client. Whatever the route through it, a non-2xx leaves this function as an
-// OpenAI error envelope: the classified reason when the candidates are exhausted,
-// the upstream's own body when that body carries an error object worth
-// forwarding, and a synthesised envelope when it does not. Drains/closes
+// client. isFailoverEligible carries the caller's shouldFailover verdict and
+// decides what the client may see. A payload-class refusal (a plain 400 and its
+// kin) judged this caller's own request, so the upstream's error object is
+// forwarded with key-shaped tokens masked. An eligible class (auth, billing,
+// rate limit, server fault) only reaches here with the candidates exhausted,
+// and those are the bodies that can quote the operator's provider credentials
+// or account details, so the client gets a synthesised envelope with the
+// classified reason and the body stays in the request log. Drains/closes
 // resp.Body exactly once and always returns outcomeFatal.
-func (h *Handler) forwardUpstreamError(w http.ResponseWriter, st *requestState, candidate modelCandidate, resp *http.Response, attempt int, hasMoreCandidates bool, responseHeaderMs float64) candidateOutcome {
+func (h *Handler) forwardUpstreamError(w http.ResponseWriter, st *requestState, candidate modelCandidate, resp *http.Response, attempt int, isFailoverEligible bool, responseHeaderMs float64) candidateOutcome {
 	logData := st.logData
 	// How much of the body is worth holding depends on what happens to it below,
-	// which hasMoreCandidates already decides. Forwarded, it is read whole:
+	// which isFailoverEligible already decides. Forwarded, it is read whole:
 	// truncating on the way to the client would hand them invalid JSON where the
 	// provider sent something complete. Discarded, it is read under the same cap
 	// as the two drain sites, since all that is left to take from it is a
 	// classification and the first 10 000 bytes of request log.
 	var body []byte
-	if hasMoreCandidates {
+	if !isFailoverEligible {
 		body, _ = io.ReadAll(resp.Body)
 	} else {
 		body, _ = io.ReadAll(io.LimitReader(resp.Body, failoverErrorClassifyCap))
@@ -737,7 +742,7 @@ func (h *Handler) forwardUpstreamError(w http.ResponseWriter, st *requestState, 
 	_ = resp.Body.Close()
 	errMsg := util.SanitizeLogBody(string(body), 10000)
 	// Classify for the request log and metrics only — routing is unaffected,
-	// hasMoreCandidates was already decided from the status code.
+	// the caller already decided it from the status code.
 	kind, reason := classifyUpstreamError(resp.StatusCode, errMsg, candidate.model.ModelID)
 	if kind == KindProviderModelGone {
 		// Same as the drain path above: the candidate carries what the
@@ -750,34 +755,46 @@ func (h *Handler) forwardUpstreamError(w http.ResponseWriter, st *requestState, 
 	logData.responseHeaderMs = responseHeaderMs
 	h.failRequest(logData, resp.StatusCode, kind, errMsg, attempt, st.startTime, st.parseMs, st.timings, st.cacheHits, st.proxyOverhead)
 
-	if !hasMoreCandidates {
-		// All failover candidates exhausted. The upstream body is recorded to the
-		// DB request log via failRequest (not the structured server log) and is
-		// never forwarded to the client, as it may echo the request back. The
-		// caller gets the classified reason instead of a bare status, which is
-		// enough to tell "this model is gone" from "top up your account" from
-		// "try again shortly".
+	// A 2xx that reached this function (any success status other than a bare
+	// 200) is not an error at all and is forwarded whatever its body is,
+	// including a non-JSON or empty one. That is what lets a 204 answer with
+	// no body: an envelope written under a No Content status would be a body
+	// this gateway invented for a request the provider considered successful.
+	// Checked before eligibility so a success can never be rewritten.
+	if resp.StatusCode/100 == 2 {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(resp.StatusCode)
+		_, _ = w.Write(body)
+		return outcomeFatal
+	}
+
+	if isFailoverEligible {
+		// Auth, billing, rate-limit, not-found and server-fault classes reach
+		// here only with the candidates exhausted (with one still in hand the
+		// caller fails over instead). Their bodies are the ones that can quote
+		// the operator's provider credentials ("Incorrect API key provided:
+		// sk-...") or account details a virtual-key holder must not see, so the
+		// body stays in the DB request log via failRequest and the caller gets
+		// the classified reason: enough to tell "this model is gone" from "top
+		// up your account" from "try again shortly".
 		writeOpenAIError(w, upstreamClientMessage(candidate.provider.Name, resp.StatusCode, reason), resp.StatusCode)
 		return outcomeFatal
 	}
 
-	// Non-failover-eligible error with remaining candidates.
+	// Payload-class refusal: the provider judged this caller's own request, so
+	// the caller is entitled to the detail, whether or not this was the last
+	// candidate.
 	switch {
-	case carriesErrorObject(body) || resp.StatusCode/100 == 2:
-		// Forward the upstream response verbatim so clients can react to
-		// semantic errors (e.g. context_length_exceeded, rate_limit_exceeded).
-		// The upstream's own error object carries detail this gateway cannot
-		// reconstruct — code, type, param, provider-specific fields — so it is
-		// passed through byte for byte.
-		//
-		// A 2xx that reached this function (any success status other than a bare
-		// 200) is not an error at all and is forwarded whatever its body is,
-		// including a non-JSON or empty one. That is what lets a 204 answer with
-		// no body: an envelope written under a No Content status would be a body
-		// this gateway invented for a request the provider considered successful.
+	case carriesErrorObject(body):
+		// Forward the upstream response so clients can react to semantic errors
+		// (e.g. context_length_exceeded). The upstream's own error object
+		// carries detail this gateway cannot reconstruct — code, type, param,
+		// provider-specific fields — so it is passed through byte for byte
+		// apart from masking key-shaped tokens, since even a payload error is
+		// provider-authored free text.
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(resp.StatusCode)
-		_, _ = w.Write(body)
+		_, _ = w.Write(maskKeyShapedTokens(body))
 	case json.Valid(body):
 		// A non-2xx whose JSON body carries no error object. OpenCode Zen and
 		// OpenCode Go answer some failed requests with a complete
@@ -796,9 +813,26 @@ func (h *Handler) forwardUpstreamError(w http.ResponseWriter, st *requestState, 
 		// full body reaches the request log either way via failRequest, and how
 		// much of a provider's response this gateway echoes to callers is one
 		// decision for all three cases rather than something to widen here.
-		writeOpenAIError(w, errMsg, resp.StatusCode)
+		writeOpenAIError(w, string(maskKeyShapedTokens([]byte(errMsg))), resp.StatusCode)
 	}
 	return outcomeFatal
+}
+
+// keyShapedToken matches credential-looking substrings a provider may quote
+// inside an error body: prefixed secret keys (sk-..., which also covers
+// sk-ant-, sk-or- and sk-proj-, plus gsk_ and xai-), Google API keys (AIza...)
+// and bare bearer tokens. The minimum tail lengths keep prose like "sk-abc" or
+// "risk-based" out of scope.
+var keyShapedToken = regexp.MustCompile(`\b(?:sk|gsk|xai)[-_][A-Za-z0-9_-]{16,}|\bAIza[0-9A-Za-z_-]{30,}|(?i:\bbearer\s+)[A-Za-z0-9._~+/=-]{16,}`)
+
+// maskKeyShapedTokens scrubs credential-looking substrings from an upstream
+// body before it is forwarded to a client. Auth-class errors never forward at
+// all; this is the second layer, for a provider quoting a credential inside an
+// otherwise forwardable payload error. The replacement carries no JSON
+// metacharacters, so a valid body stays valid. Client-side only: the request
+// log keeps the original body for the operator.
+func maskKeyShapedTokens(body []byte) []byte {
+	return keyShapedToken.ReplaceAll(body, []byte("[redacted]"))
 }
 
 // carriesErrorObject reports whether an upstream body is a JSON object with an
@@ -911,7 +945,7 @@ func candidateModelID(candidate modelCandidate) string {
 // learning half of retryWithStrippedParams, split out for callers that cannot
 // retry in place (a hedged probe, which must not spend a second round-trip
 // inside one race slot).
-func (h *Handler) learnRejectedParams(candidate modelCandidate, providerType string, body []byte) {
+func (h *Handler) learnRejectedParams(candidate modelCandidate, body []byte) {
 	rejected := paramrewrite.ParseProviderParamError(body)
 	renames := paramrewrite.ParseProviderParamRename(body)
 	if rejected == nil && renames == nil {
@@ -1067,7 +1101,7 @@ func (h *Handler) retryWithStrippedParams(
 		// application. Each cache is merged with any existing entries via
 		// CompareAndSwap to avoid data races from concurrent goroutines mutating
 		// the same map.
-		h.learnRejectedParams(candidate, providerType, errBody)
+		h.learnRejectedParams(candidate, errBody)
 		progressed := false
 		for p := range rejected {
 			if !strip[p] {

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -713,29 +713,71 @@ func (h *Handler) doUpstream(ctx context.Context, req *http.Request, st *request
 	return resp, true
 }
 
+// forwardableErrorStatus reports whether a status is in the payload class a
+// client may see the provider's body for: a 4xx that judged the caller's own
+// request. Deliberately static where shouldFailover is dynamic: its 429
+// verdict follows the failover_on_rate_limit setting, but a quota body is the
+// operator's account state whichever way that toggle points, and what can
+// reach a client must not be a side effect of a routing knob. The denied 4xx
+// are the auth, billing, quota and routing classes whose bodies can carry
+// operator account detail; 1xx/3xx are not payload errors and 5xx bodies are
+// the provider talking about itself, so none of those forward either.
+func forwardableErrorStatus(status int) bool {
+	if status < 400 || status >= 500 {
+		return false
+	}
+	switch status {
+	case http.StatusUnauthorized, http.StatusPaymentRequired, http.StatusForbidden,
+		http.StatusNotFound, http.StatusProxyAuthRequired, http.StatusTooManyRequests, 499:
+		return false
+	}
+	return true
+}
+
+// forwardableErrorBodyCap bounds a payload-class error body that may be
+// forwarded to the client. Reading it whole keeps forwarded JSON intact, but
+// "whole" needs a ceiling: the multimodal endpoints have no upstream pre-cap,
+// so a broken or hostile custom endpoint could answer an error status with
+// anything. A megabyte is far past any real error document; a body over it is
+// answered with the synthesised envelope instead.
+const forwardableErrorBodyCap = 1 << 20
+
 // forwardUpstreamError handles a non-200 upstream response that is NOT being
 // failed over (phase G): log + meter the failure via failRequest, then answer the
-// client. isFailoverEligible carries the caller's shouldFailover verdict and
-// decides what the client may see. A payload-class refusal (a plain 400 and its
+// client. isFailoverEligible carries the caller's shouldFailover verdict; what
+// the client may see is decided by it together with the static
+// forwardableErrorStatus class. A payload-class refusal (a plain 400 and its
 // kin) judged this caller's own request, so the upstream's error object is
-// forwarded with key-shaped tokens masked. An eligible class (auth, billing,
-// rate limit, server fault) only reaches here with the candidates exhausted,
-// and those are the bodies that can quote the operator's provider credentials
-// or account details, so the client gets a synthesised envelope with the
-// classified reason and the body stays in the request log. Drains/closes
+// forwarded with key-shaped tokens masked. Everything else - auth, billing,
+// rate limit, not-found, server faults, whether classed by eligibility or by
+// status - gets a synthesised envelope with the classified reason, because
+// those bodies can quote the operator's provider credentials or account
+// details; the body stays in the request log either way. Drains/closes
 // resp.Body exactly once and always returns outcomeFatal.
 func (h *Handler) forwardUpstreamError(w http.ResponseWriter, st *requestState, candidate modelCandidate, resp *http.Response, attempt int, isFailoverEligible bool, responseHeaderMs float64) candidateOutcome {
 	logData := st.logData
-	// How much of the body is worth holding depends on what happens to it below,
-	// which isFailoverEligible already decides. Forwarded, it is read whole:
-	// truncating on the way to the client would hand them invalid JSON where the
-	// provider sent something complete. Discarded, it is read under the same cap
-	// as the two drain sites, since all that is left to take from it is a
-	// classification and the first 10 000 bytes of request log.
+	mayForwardError := !isFailoverEligible && forwardableErrorStatus(resp.StatusCode)
+	// How much of the body is worth holding depends on what happens to it
+	// below. A 2xx is forwarded whole - truncating a success would corrupt it.
+	// A forwardable error is read under its own cap, and one that overflows it
+	// is demoted to the envelope rather than forwarded truncated, so a client
+	// never receives invalid JSON where the provider sent something complete.
+	// A discarded body is read under the same cap as the two drain sites,
+	// since all that is left to take from it is a classification and the first
+	// 10 000 bytes of request log.
 	var body []byte
-	if !isFailoverEligible {
+	oversized := false
+	switch {
+	case resp.StatusCode/100 == 2:
 		body, _ = io.ReadAll(resp.Body)
-	} else {
+	case mayForwardError:
+		body, _ = io.ReadAll(io.LimitReader(resp.Body, forwardableErrorBodyCap+1))
+		if len(body) > forwardableErrorBodyCap {
+			oversized = true
+			body = body[:forwardableErrorBodyCap]
+		}
+		_, _ = io.Copy(io.Discard, resp.Body)
+	default:
 		body, _ = io.ReadAll(io.LimitReader(resp.Body, failoverErrorClassifyCap))
 		_, _ = io.Copy(io.Discard, resp.Body)
 	}
@@ -768,11 +810,11 @@ func (h *Handler) forwardUpstreamError(w http.ResponseWriter, st *requestState, 
 		return outcomeFatal
 	}
 
-	if isFailoverEligible {
-		// Auth, billing, rate-limit, not-found and server-fault classes reach
-		// here only with the candidates exhausted (with one still in hand the
-		// caller fails over instead). Their bodies are the ones that can quote
-		// the operator's provider credentials ("Incorrect API key provided:
+	if !mayForwardError {
+		// Auth, billing, rate-limit, not-found and server-fault classes -
+		// whether ruled out by the caller's eligibility verdict or by the
+		// static status class. Their bodies are the ones that can quote the
+		// operator's provider credentials ("Incorrect API key provided:
 		// sk-...") or account details a virtual-key holder must not see, so the
 		// body stays in the DB request log via failRequest and the caller gets
 		// the classified reason: enough to tell "this model is gone" from "top
@@ -785,7 +827,7 @@ func (h *Handler) forwardUpstreamError(w http.ResponseWriter, st *requestState, 
 	// the caller is entitled to the detail, whether or not this was the last
 	// candidate.
 	switch {
-	case carriesErrorObject(body):
+	case carriesErrorObject(body) && !oversized:
 		// Forward the upstream response so clients can react to semantic errors
 		// (e.g. context_length_exceeded). The upstream's own error object
 		// carries detail this gateway cannot reconstruct — code, type, param,
@@ -819,20 +861,33 @@ func (h *Handler) forwardUpstreamError(w http.ResponseWriter, st *requestState, 
 }
 
 // keyShapedToken matches credential-looking substrings a provider may quote
-// inside an error body: prefixed secret keys (sk-..., which also covers
-// sk-ant-, sk-or- and sk-proj-, plus gsk_ and xai-), Google API keys (AIza...)
-// and bare bearer tokens. The minimum tail lengths keep prose like "sk-abc" or
-// "risk-based" out of scope.
-var keyShapedToken = regexp.MustCompile(`\b(?:sk|gsk|xai)[-_][A-Za-z0-9_-]{16,}|\bAIza[0-9A-Za-z_-]{30,}|(?i:\bbearer\s+)[A-Za-z0-9._~+/=-]{16,}`)
+// inside an error body: prefixed secret keys (sk- also covers sk-ant-, sk-or-
+// and sk-proj-; hf_, fw_, r8_, gsk_, xai- cover HuggingFace, Fireworks,
+// Replicate, Groq and xAI), Google API keys (AIza...), AWS access key ids
+// (AKIA...), bare JWTs (the MiniMax API key format), and bearer tokens. The
+// minimum tail lengths keep prose like "sk-abc" out of scope; matches without
+// a digit are prose too and are dropped by maskKeyShapedTokens. A prefix list
+// necessarily trails the provider roster - it is the second layer, not the
+// control, which is the status-class gate above.
+var keyShapedToken = regexp.MustCompile(`\b(?:sk|gsk|xai|hf|fw|r8)[-_][A-Za-z0-9_-]{16,}|\bAIza[0-9A-Za-z_-]{30,}|\bAKIA[0-9A-Z]{16}\b|\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{5,}|(?i:\bbearer\s+)[A-Za-z0-9._~+/=-]{16,}`)
 
 // maskKeyShapedTokens scrubs credential-looking substrings from an upstream
 // body before it is forwarded to a client. Auth-class errors never forward at
 // all; this is the second layer, for a provider quoting a credential inside an
-// otherwise forwardable payload error. The replacement carries no JSON
-// metacharacters, so a valid body stays valid. Client-side only: the request
+// otherwise forwardable payload error. A match with no digit in it is an
+// identifier or prose ("sk_business_unit_identifier", "Bearer
+// authentication-required") rather than a credential, and stays - real keys
+// carry digits. The replacement carries no JSON metacharacters, so a valid
+// body stays valid. This covers the buffered error paths; in-stream SSE error
+// frames ride the streaming pipeline untouched. Client-side only: the request
 // log keeps the original body for the operator.
 func maskKeyShapedTokens(body []byte) []byte {
-	return keyShapedToken.ReplaceAll(body, []byte("[redacted]"))
+	return keyShapedToken.ReplaceAllFunc(body, func(m []byte) []byte {
+		if !bytes.ContainsAny(m, "0123456789") {
+			return m
+		}
+		return []byte("[redacted]")
+	})
 }
 
 // carriesErrorObject reports whether an upstream body is a JSON object with an

--- a/internal/proxy/proxy_failover_test.go
+++ b/internal/proxy/proxy_failover_test.go
@@ -744,7 +744,9 @@ func TestForwardUpstreamError_Non2xxWithoutErrorObjectGetsEnvelope(t *testing.T)
 // (code, type, param, provider-specific fields), so a payload-class error
 // forwards it byte for byte. The eligibility verdict is what decides, not how
 // many candidates remain: a direct single-provider request gets the same body
-// a hotel/ group request does.
+// a sequentially failing-over hotel/ group request does. (A hedged race is the
+// exception - its orchestrator writes the terminal error without this
+// function.)
 func TestForwardUpstreamError_ErrorObjectForwardedVerbatim(t *testing.T) {
 	h := newIntegrationHandler()
 	defer stopUnitHandler(h)
@@ -845,6 +847,90 @@ func TestForwardUpstreamError_EligibleClassGetsEnvelopeNotBody(t *testing.T) {
 	}
 }
 
+// The forward-deny status class is static. shouldFailover's 429 verdict
+// follows the failover_on_rate_limit setting, so with that toggle off a 429
+// arrives here as NOT failover-eligible - and its body is still the operator's
+// account state (OpenAI's insufficient_quota text, MiniMax's "insufficient
+// balance" remapped onto 429 by remapMiniMaxBusinessError). What a client may
+// see must not move with a routing knob, so these stay enveloped even when
+// ineligible.
+func TestForwardUpstreamError_StaticDenyClassIgnoresEligibility(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandler(h)
+
+	upstreamBody := `{"error":{"message":"You exceeded your current quota, please check your plan and billing details.","type":"insufficient_quota"}}`
+
+	for _, status := range []int{
+		http.StatusTooManyRequests,
+		http.StatusUnauthorized,
+		http.StatusPaymentRequired,
+		http.StatusNotFound,
+		http.StatusBadGateway,
+	} {
+		t.Run(fmt.Sprintf("status=%d", status), func(t *testing.T) {
+			w, _ := runForwardUpstreamError(t, h, status, upstreamBody, false)
+
+			if w.Code != status {
+				t.Errorf("expected status %d to reach the client, got %d", status, w.Code)
+			}
+			body := w.Body.String()
+			if strings.Contains(body, "insufficient_quota") || strings.Contains(body, "billing details") {
+				t.Errorf("operator account detail reached the client on a denied status: %s", body)
+			}
+			var got struct {
+				Error struct {
+					Message string `json:"message"`
+				} `json:"error"`
+			}
+			if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil || got.Error.Message == "" {
+				t.Errorf("expected a classified envelope, got: %s", body)
+			}
+		})
+	}
+}
+
+// A forwardable body that overflows its cap is demoted to the envelope rather
+// than forwarded truncated: a client must never receive invalid JSON where the
+// provider sent something complete.
+func TestForwardUpstreamError_OversizedPayloadBodyGetsEnvelope(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandler(h)
+
+	upstreamBody := `{"error":{"message":"` + strings.Repeat("a", forwardableErrorBodyCap) + `"}}`
+
+	w, _ := runForwardUpstreamError(t, h, http.StatusBadRequest, upstreamBody, false)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected status 400, got %d", w.Code)
+	}
+	if !json.Valid(w.Body.Bytes()) {
+		t.Fatalf("client received invalid JSON (%d bytes)", w.Body.Len())
+	}
+	if w.Body.Len() > 32<<10 {
+		t.Errorf("oversized upstream body reached the client: %d bytes", w.Body.Len())
+	}
+}
+
+// The non-JSON default branch echoes the sanitized body inside an envelope, so
+// it needs the same credential scrub as the verbatim branch.
+func TestForwardUpstreamError_NonJSONBodyMasksKeyShapedTokens(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandler(h)
+
+	const secret = "sk-live-0123456789abcdef0123456789abcdef"
+	upstreamBody := `upstream proxy rejected key ` + secret + ` (not json)`
+
+	w, _ := runForwardUpstreamError(t, h, http.StatusBadRequest, upstreamBody, false)
+
+	body := w.Body.String()
+	if strings.Contains(body, secret) {
+		t.Errorf("key-shaped token reached the client via the non-JSON branch: %s", body)
+	}
+	if !strings.Contains(body, "[redacted]") {
+		t.Errorf("non-JSON branch did not mask: %s", body)
+	}
+}
+
 // A forwarded payload-class body is the provider's text, and providers have
 // been known to quote credentials in it. Key-shaped tokens are masked on the
 // way to the client; everything else is untouched.
@@ -884,13 +970,16 @@ func TestForwardUpstreamError_ForwardedBodyMasksKeyShapedTokens(t *testing.T) {
 // shapes it eats and, just as much, which prose it leaves alone.
 func TestMaskKeyShapedTokens(t *testing.T) {
 	masked := map[string]string{
-		"openai key":     `key sk-0123456789abcdef0123 rejected`,
-		"openai project": `key sk-proj-0123456789abcdef0123 rejected`,
-		"anthropic key":  `key sk-ant-api03-0123456789abcdef rejected`,
-		"groq key":       `key gsk_0123456789abcdef0123 rejected`,
-		"xai key":        `key xai-0123456789abcdef0123 rejected`,
-		"google key":     `key AIzaSyA0123456789abcdef0123456789abcde rejected`,
-		"bearer token":   `header "Bearer eyJhbGciOiJIUzI1NiJ9.payload.sig" invalid`,
+		"openai key":      `key sk-0123456789abcdef0123 rejected`,
+		"openai project":  `key sk-proj-0123456789abcdef0123 rejected`,
+		"anthropic key":   `key sk-ant-api03-0123456789abcdef rejected`,
+		"groq key":        `key gsk_0123456789abcdef0123 rejected`,
+		"xai key":         `key xai-0123456789abcdef0123 rejected`,
+		"google key":      `key AIzaSyA0123456789abcdef0123456789abcde rejected`,
+		"huggingface key": `key hf_0123456789abcdefABCDEF rejected`,
+		"aws access key":  `credential AKIAIOSFODNN7EXAMPLE not authorized`,
+		"bare jwt":        `key eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N in body`,
+		"bearer token":    `header "Bearer eyJhbGciOiJIUzI1NiJ9.payload.sig" invalid`,
 	}
 	for name, in := range masked {
 		t.Run("masks/"+name, func(t *testing.T) {
@@ -905,12 +994,14 @@ func TestMaskKeyShapedTokens(t *testing.T) {
 	}
 
 	untouched := map[string]string{
-		"short sk prefix":  `the sk-abc field is required`,
-		"prose with sk":    `risk-based checks and task-level errors`,
-		"request id":       `request req_abc123 failed`,
-		"embedded in word": `whisk-0123456789abcdef0123`,
-		"plain json error": `{"error":{"message":"custom_validation_error","param":"messages[0].content"}}`,
-		"bare word bearer": `the bearer of this token`,
+		"short sk prefix":       `the sk-abc field is required`,
+		"prose with sk":         `risk-based checks and task-level errors`,
+		"request id":            `request req_abc123 failed`,
+		"embedded in word":      `whisk-0123456789abcdef0123`,
+		"plain json error":      `{"error":{"message":"custom_validation_error","param":"messages[0].content"}}`,
+		"bare word bearer":      `the bearer of this token`,
+		"snake_case identifier": `param 'sk_business_unit_identifier' unknown`,
+		"digitless bearer tail": `Bearer authentication-required for this endpoint`,
 	}
 	for name, in := range untouched {
 		t.Run("leaves/"+name, func(t *testing.T) {
@@ -951,6 +1042,19 @@ func TestForwardUpstreamError_2xxBodyUntouched(t *testing.T) {
 		}
 		if got := w.Body.String(); got != "" {
 			t.Errorf("204 answered with a body: %s", got)
+		}
+	})
+
+	// The 2xx check sits before the eligibility gate on purpose: whatever the
+	// caller's verdict claims, a success is never rewritten into an envelope.
+	t.Run("forwarded even when marked eligible", func(t *testing.T) {
+		w, _ := runForwardUpstreamError(t, h, http.StatusCreated, zenChatShapedBody, true)
+
+		if w.Code != http.StatusCreated {
+			t.Errorf("expected status 201, got %d", w.Code)
+		}
+		if got := w.Body.String(); got != zenChatShapedBody {
+			t.Errorf("2xx body rewritten under an eligible verdict:\n got: %s\nwant: %s", got, zenChatShapedBody)
 		}
 	})
 

--- a/internal/proxy/proxy_failover_test.go
+++ b/internal/proxy/proxy_failover_test.go
@@ -643,13 +643,15 @@ func TestDoUpstream_ClientDisconnectPreservesProviderError(t *testing.T) {
 //
 // This is the reachable half of "a non-2xx must never reach the client as a
 // success-shaped body": the chat path sends every non-200 here before
-// handleNonStreamingResponse can see it, and with a candidate still in the group
-// a non-failover-eligible status answers straight from the provider's body.
+// handleNonStreamingResponse can see it. A non-failover-eligible status (a
+// payload-class refusal) answers straight from the provider's body whether or
+// not candidates remain; a failover-eligible one only arrives here exhausted
+// and answers with the classified envelope, never the body.
 // ---------------------------------------------------------------------------
 
 // runForwardUpstreamError drives one upstream answer through the function and
 // returns what the client got plus the log row it left behind.
-func runForwardUpstreamError(t *testing.T, h *Handler, status int, body string, hasMoreCandidates bool) (*httptest.ResponseRecorder, *requestLogData) {
+func runForwardUpstreamError(t *testing.T, h *Handler, status int, body string, isFailoverEligible bool) (*httptest.ResponseRecorder, *requestLogData) {
 	t.Helper()
 
 	logData := &requestLogData{
@@ -671,14 +673,14 @@ func runForwardUpstreamError(t *testing.T, h *Handler, status int, body string, 
 	}
 
 	w := httptest.NewRecorder()
-	if outcome := h.forwardUpstreamError(w, st, candidate, resp, 0, hasMoreCandidates, 1.5); outcome != outcomeFatal {
+	if outcome := h.forwardUpstreamError(w, st, candidate, resp, 0, isFailoverEligible, 1.5); outcome != outcomeFatal {
 		t.Fatalf("expected outcomeFatal, got %v", outcome)
 	}
 	return w, logData
 }
 
 // A non-2xx whose body carries no error object leaves as a synthesised envelope,
-// whether or not candidates remain. zenChatShapedBody is the production shape:
+// whatever the eligibility verdict. zenChatShapedBody is the production shape:
 // OpenCode Zen and OpenCode Go answer some failed requests with a complete
 // chat.completion under an HTTP 400, which is valid JSON with nothing for a
 // client to read `.error.message` off.
@@ -700,9 +702,9 @@ func TestForwardUpstreamError_Non2xxWithoutErrorObjectGetsEnvelope(t *testing.T)
 	}
 
 	for name, upstreamBody := range bodies {
-		for _, hasMore := range []bool{true, false} {
-			t.Run(fmt.Sprintf("%s/hasMoreCandidates=%v", name, hasMore), func(t *testing.T) {
-				w, logData := runForwardUpstreamError(t, h, http.StatusBadRequest, upstreamBody, hasMore)
+		for _, eligible := range []bool{true, false} {
+			t.Run(fmt.Sprintf("%s/isFailoverEligible=%v", name, eligible), func(t *testing.T) {
+				w, logData := runForwardUpstreamError(t, h, http.StatusBadRequest, upstreamBody, eligible)
 
 				if w.Code != http.StatusBadRequest {
 					t.Errorf("expected upstream status 400 to reach the client, got %d", w.Code)
@@ -739,15 +741,17 @@ func TestForwardUpstreamError_Non2xxWithoutErrorObjectGetsEnvelope(t *testing.T)
 }
 
 // The upstream's own error object is detail this gateway cannot reconstruct
-// (code, type, param, provider-specific fields), so with a candidate still in
-// the group the body is forwarded byte for byte.
+// (code, type, param, provider-specific fields), so a payload-class error
+// forwards it byte for byte. The eligibility verdict is what decides, not how
+// many candidates remain: a direct single-provider request gets the same body
+// a hotel/ group request does.
 func TestForwardUpstreamError_ErrorObjectForwardedVerbatim(t *testing.T) {
 	h := newIntegrationHandler()
 	defer stopUnitHandler(h)
 
 	const upstreamBody = `{"error":{"message":"custom_validation_error","type":"invalid_request_error","param":"messages[0].content","code":"context_length_exceeded"},"request_id":"req_abc123"}`
 
-	w, logData := runForwardUpstreamError(t, h, http.StatusBadRequest, upstreamBody, true)
+	w, logData := runForwardUpstreamError(t, h, http.StatusBadRequest, upstreamBody, false)
 
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("expected status 400, got %d", w.Code)
@@ -771,19 +775,147 @@ func TestForwardUpstreamError_NonObjectErrorForwardedVerbatim(t *testing.T) {
 	defer stopUnitHandler(h)
 
 	bodies := map[string]string{
-		"ollama string error": `{"error":"model not found, try pulling it first"}`,
+		"ollama string error": `{"error":"unknown parameter, check the request body"}`,
 		"list of errors":      `{"error":[{"message":"first"},{"message":"second"}]}`,
 	}
 
 	for name, upstreamBody := range bodies {
 		t.Run(name, func(t *testing.T) {
-			w, _ := runForwardUpstreamError(t, h, http.StatusNotFound, upstreamBody, true)
+			w, _ := runForwardUpstreamError(t, h, http.StatusBadRequest, upstreamBody, false)
 
-			if w.Code != http.StatusNotFound {
-				t.Errorf("expected status 404, got %d", w.Code)
+			if w.Code != http.StatusBadRequest {
+				t.Errorf("expected status 400, got %d", w.Code)
 			}
 			if got := w.Body.String(); got != upstreamBody {
 				t.Errorf("upstream error detail not forwarded byte for byte:\n got: %s\nwant: %s", got, upstreamBody)
+			}
+		})
+	}
+}
+
+// A failover-eligible status only reaches forwardUpstreamError with no
+// candidates left, and its body is the kind that can quote the operator's
+// provider credentials or account details (auth failures, billing, quota,
+// server faults). The client gets the classified envelope, never the body, no
+// matter how juicy the error object inside it is.
+func TestForwardUpstreamError_EligibleClassGetsEnvelopeNotBody(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandler(h)
+
+	const secret = "sk-live-0123456789abcdef0123456789abcdef"
+	upstreamBody := `{"error":{"message":"Incorrect API key provided: ` + secret + `. You can find your API key at https://platform.example.com.","type":"invalid_request_error","code":"invalid_api_key"}}`
+
+	for _, status := range []int{
+		http.StatusUnauthorized,
+		http.StatusPaymentRequired,
+		http.StatusForbidden,
+		http.StatusNotFound,
+		http.StatusTooManyRequests,
+		http.StatusInternalServerError,
+	} {
+		t.Run(fmt.Sprintf("status=%d", status), func(t *testing.T) {
+			w, logData := runForwardUpstreamError(t, h, status, upstreamBody, true)
+
+			if w.Code != status {
+				t.Errorf("expected status %d to reach the client, got %d", status, w.Code)
+			}
+			body := w.Body.String()
+			if strings.Contains(body, secret) {
+				t.Errorf("provider credential reached the client: %s", body)
+			}
+			if strings.Contains(body, "Incorrect API key") {
+				t.Errorf("upstream error body reached the client on an eligible status: %s", body)
+			}
+			var got struct {
+				Error struct {
+					Message string `json:"message"`
+				} `json:"error"`
+			}
+			if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+				t.Fatalf("client body is not an error envelope: %v (%s)", err, body)
+			}
+			if got.Error.Message == "" {
+				t.Errorf("envelope carries no classified reason: %s", body)
+			}
+			// The operator still gets the full detail in the request log.
+			if !strings.Contains(logData.errorMessage, "Incorrect API key") {
+				t.Errorf("upstream body missing from the request log: %s", logData.errorMessage)
+			}
+		})
+	}
+}
+
+// A forwarded payload-class body is the provider's text, and providers have
+// been known to quote credentials in it. Key-shaped tokens are masked on the
+// way to the client; everything else is untouched.
+func TestForwardUpstreamError_ForwardedBodyMasksKeyShapedTokens(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandler(h)
+
+	const secret = "sk-proj-0123456789abcdef0123456789abcdef"
+	upstreamBody := `{"error":{"message":"invalid key ` + secret + ` for this endpoint","type":"invalid_request_error","param":"api_key"}}`
+
+	w, logData := runForwardUpstreamError(t, h, http.StatusBadRequest, upstreamBody, false)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected status 400, got %d", w.Code)
+	}
+	body := w.Body.String()
+	if strings.Contains(body, secret) {
+		t.Errorf("key-shaped token reached the client: %s", body)
+	}
+	if !strings.Contains(body, "[redacted]") {
+		t.Errorf("masked token not marked as redacted: %s", body)
+	}
+	if !strings.Contains(body, "invalid_request_error") || !strings.Contains(body, `"param":"api_key"`) {
+		t.Errorf("masking damaged the rest of the body: %s", body)
+	}
+	if !json.Valid(w.Body.Bytes()) {
+		t.Errorf("masked body is no longer valid JSON: %s", body)
+	}
+	// Masking is client-side only: the operator's request log keeps the
+	// original body for diagnostics.
+	if !strings.Contains(logData.errorMessage, secret) {
+		t.Errorf("request log lost the original body: %s", logData.errorMessage)
+	}
+}
+
+// maskKeyShapedTokens is a text scrub, so the contract worth pinning is which
+// shapes it eats and, just as much, which prose it leaves alone.
+func TestMaskKeyShapedTokens(t *testing.T) {
+	masked := map[string]string{
+		"openai key":     `key sk-0123456789abcdef0123 rejected`,
+		"openai project": `key sk-proj-0123456789abcdef0123 rejected`,
+		"anthropic key":  `key sk-ant-api03-0123456789abcdef rejected`,
+		"groq key":       `key gsk_0123456789abcdef0123 rejected`,
+		"xai key":        `key xai-0123456789abcdef0123 rejected`,
+		"google key":     `key AIzaSyA0123456789abcdef0123456789abcde rejected`,
+		"bearer token":   `header "Bearer eyJhbGciOiJIUzI1NiJ9.payload.sig" invalid`,
+	}
+	for name, in := range masked {
+		t.Run("masks/"+name, func(t *testing.T) {
+			got := string(maskKeyShapedTokens([]byte(in)))
+			if !strings.Contains(got, "[redacted]") {
+				t.Errorf("nothing masked in %q -> %q", in, got)
+			}
+			if got == in {
+				t.Errorf("input unchanged: %q", in)
+			}
+		})
+	}
+
+	untouched := map[string]string{
+		"short sk prefix":  `the sk-abc field is required`,
+		"prose with sk":    `risk-based checks and task-level errors`,
+		"request id":       `request req_abc123 failed`,
+		"embedded in word": `whisk-0123456789abcdef0123`,
+		"plain json error": `{"error":{"message":"custom_validation_error","param":"messages[0].content"}}`,
+		"bare word bearer": `the bearer of this token`,
+	}
+	for name, in := range untouched {
+		t.Run("leaves/"+name, func(t *testing.T) {
+			if got := string(maskKeyShapedTokens([]byte(in))); got != in {
+				t.Errorf("false positive:\n in:  %s\n got: %s", in, got)
 			}
 		})
 	}
@@ -797,7 +929,7 @@ func TestForwardUpstreamError_2xxBodyUntouched(t *testing.T) {
 	defer stopUnitHandler(h)
 
 	t.Run("json body", func(t *testing.T) {
-		w, _ := runForwardUpstreamError(t, h, http.StatusCreated, zenChatShapedBody, true)
+		w, _ := runForwardUpstreamError(t, h, http.StatusCreated, zenChatShapedBody, false)
 
 		if w.Code != http.StatusCreated {
 			t.Errorf("expected status 201, got %d", w.Code)
@@ -812,7 +944,7 @@ func TestForwardUpstreamError_2xxBodyUntouched(t *testing.T) {
 	// would be a body invented by this gateway for a request the provider
 	// considered successful.
 	t.Run("empty 204 body stays empty", func(t *testing.T) {
-		w, _ := runForwardUpstreamError(t, h, http.StatusNoContent, "", true)
+		w, _ := runForwardUpstreamError(t, h, http.StatusNoContent, "", false)
 
 		if w.Code != http.StatusNoContent {
 			t.Errorf("expected status 204, got %d", w.Code)
@@ -826,7 +958,7 @@ func TestForwardUpstreamError_2xxBodyUntouched(t *testing.T) {
 	// still the provider's answer, still forwarded untouched.
 	t.Run("non-json body", func(t *testing.T) {
 		const plain = `accepted`
-		w, _ := runForwardUpstreamError(t, h, http.StatusAccepted, plain, true)
+		w, _ := runForwardUpstreamError(t, h, http.StatusAccepted, plain, false)
 
 		if w.Code != http.StatusAccepted {
 			t.Errorf("expected status 202, got %d", w.Code)

--- a/wiki/Request-Logging.md
+++ b/wiki/Request-Logging.md
@@ -475,7 +475,7 @@ Two background states are written by the stale-log sweep in `cmd/server/main.go`
 
 For SSE events, error messages are truncated to 200 characters with a `…` suffix:
 
-For **failover non-200 responses**, the upstream error body is truncated to **2000 characters** (with `…` suffix) before logging and forwarding to the client. This prevents excessively large error responses from consuming memory or log space.
+For **failover non-200 responses**, the upstream error body is sanitized and truncated to **10,000 characters** before it is written to the request log. What the *client* receives depends on the error class: a payload-class 4xx (a plain `400` and its kin — not `401`/`402`/`403`/`404`/`407`/`429`) forwards the provider's own error body with credential-looking tokens masked, read under a 1 MiB cap; anything else — auth, billing, rate-limit, not-found and server-fault classes, or a body over the cap — gets a synthesized OpenAI-style envelope carrying the classified reason, because those upstream bodies can quote the operator's provider credentials or account details.
 
 ```go
 msg = fmt.Sprintf("Request failed: %s - %s", logEntry.modelID, logEntry.errorMessage)
@@ -483,8 +483,6 @@ if len(msg) > 200 {
     msg = msg[:200] + "…"
 }
 ```
-
-The full error message is stored in the database without truncation.
 
 ### Client Disconnect Handling
 


### PR DESCRIPTION
## The asymmetry

`forwardUpstreamError` branched on `hasMoreCandidates`. Failover-eligible statuses (401/402/403/404/429/499/5xx) can only reach it exhausted, so in practice: a payload-class 400 through a `hotel/` group forwarded the provider's error object byte for byte, while the same error on a direct single-provider request got a synthesised envelope — the actionable detail (DeepSeek's "This response_format type is unavailable now", found during a live fleet sweep) existed only in the request log.

## The fix

The client-facing decision is now the caller's `shouldFailover` verdict **plus a static status class**:

- **Payload-class 4xx** (a plain 400 and its kin — not 401/402/403/404/407/429) judged the caller's own request, so the upstream error object forwards on any route, direct or group.
- **Everything else** — auth, billing, rate-limit, not-found, server-fault — keeps the synthesised envelope, because those bodies are the ones that quote the operator's provider credentials ("Incorrect API key provided: sk-…") or account state (OpenRouter's "Insufficient credits", MiniMax's insufficient-balance remapped onto 429). The full body stays in the request log for the operator.
- The deny class is deliberately **static** where `shouldFailover` is dynamic: its 429 verdict follows the `failover_on_rate_limit` setting, and what a client may see must not move with a routing knob.
- Forwarded bodies pass `maskKeyShapedTokens` (sk-/gsk_/xai-/hf_/fw_/r8_ keys, AIza, AKIA, bare JWTs — the MiniMax key format — and bearer tokens; matches without digits are prose and survive) as a second layer.
- The forward-path read is capped at 1 MiB; an overflowing body is demoted to the envelope rather than forwarded truncated. This also closes an unbounded error-body read on the multimodal endpoints.
- A 2xx (204 included) is checked first and forwarded untouched — the old exhausted branch wrote an invented envelope body under a No Content status.

Also: drops the unused `providerType` param from `learnRejectedParams`, and corrects the stale error-truncation paragraph in `wiki/Request-Logging.md`.

## Review

Second-opinion review by a different-model agent; every finding addressed in the second commit: the `failover_on_rate_limit`/429 exposure, the unbounded forward read, an untested masking branch, regex false negatives (AWS/HF/JWT shapes) and false positives (`sk_business_unit_identifier`, `Bearer authentication-required` now survive). Known accepted gaps, deliberately not in scope: in-stream SSE error frames are a pre-existing unmasked path, and hedged races write their terminal error without this function.

## Verification

- `go test ./...` green (6491), `golangci-lint run ./...` 0 issues.
- Eight behaviours mutation-checked: each mutation (drop the eligibility gate, drop 429 from the static class, uncap the read, remove either masking site, disable forwarding, reorder the 2xx check, remove the digit filter) fails exactly its pinned test.
- Live on a dev-stack rebuild: DeepSeek `json_schema` 400 now returns the verbatim upstream body on the direct route and the group route identically; a real OpenRouter 402 returns only the classified envelope while the request log keeps the full "Insufficient credits" body; non-streaming and streaming completions unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)