### PR TITLE
feat(anthropic): control extended thinking from reasoning_effort

### DIFF
--- a/internal/anthropicegress/request.go
+++ b/internal/anthropicegress/request.go
@@ -30,13 +30,63 @@ const DefaultMaxTokens = 4096
 const documentMediaType = "application/pdf"
 
 // thinkingBudgets maps OpenAI reasoning_effort to an Anthropic thinking budget
-// (tokens). An effort outside this map — "none", "minimal", absent — leaves the
-// thinking block off entirely; Anthropic's minimum budget is 1024, so there is
-// no budget that expresses "reason a little".
+// (tokens), for models on the budget dialect. An effort outside this map —
+// "none", absent — leaves the thinking block off entirely; Anthropic's minimum
+// budget is 1024, so there is no budget that expresses "reason a little".
+// "minimal" is OpenAI's floor and maps to Anthropic's.
 var thinkingBudgets = map[string]int{
-	"low":    1024,
-	"medium": 4096,
-	"high":   8192,
+	"minimal": 1024,
+	"low":     1024,
+	"medium":  4096,
+	"high":    8192,
+}
+
+// thinkingEfforts maps OpenAI reasoning_effort to Anthropic's own effort scale,
+// for models on the adaptive dialect. Anthropic accepts low, medium, high,
+// xhigh and max; the three shared words pass through unchanged, OpenAI's
+// "minimal" floors to "low", and Anthropic's two extra levels are honoured for a
+// client that asks for them by name. An effort outside this map leaves thinking
+// off, matching thinkingBudgets.
+var thinkingEfforts = map[string]string{
+	"minimal": "low",
+	"low":     "low",
+	"medium":  "medium",
+	"high":    "high",
+	"xhigh":   "xhigh",
+	"max":     "max",
+}
+
+// ThinkingDialect is how a model wants extended thinking asked for. The two
+// shapes are mutually exclusive and a model accepts one, the other, or both,
+// with no way to tell from the model id — Anthropic moved from one to the other
+// mid-generation, and a Messages endpoint that is not Anthropic's may serve
+// anything. Live behaviour, 2026-08-20:
+//
+//	claude-opus-5, claude-sonnet-5    adaptive only
+//	claude-sonnet-4-6                 both
+//	claude-opus-4-5, claude-haiku-4-5 budget only
+//
+// So the dialect is a per-model fact to be learned from the upstream's own 400,
+// not derived. See DialectFromError.
+type ThinkingDialect int
+
+const (
+	// ThinkingAdaptive asks with `thinking: {type: "adaptive"}` plus
+	// `output_config: {effort}`, letting the model choose how much to think
+	// within the effort ceiling. The default: it is what current models take,
+	// and the only shape the newest ones accept.
+	ThinkingAdaptive ThinkingDialect = iota
+	// ThinkingBudget asks with `thinking: {type: "enabled", budget_tokens}`,
+	// the older shape, which the newest models reject outright.
+	ThinkingBudget
+)
+
+// String names the dialect for logs.
+func (d ThinkingDialect) String() string {
+	if d == ThinkingBudget {
+		return "budget"
+	}
+	return "adaptive"
 }
 
 // --- Incoming OpenAI chat-completions request shape ---
@@ -100,18 +150,26 @@ type oaiTool struct {
 // --- Outgoing Anthropic Messages request shape ---
 
 type antRequest struct {
-	Model         string         `json:"model"`
-	MaxTokens     int            `json:"max_tokens"`
-	Messages      []antMessage   `json:"messages"`
-	System        string         `json:"system,omitempty"`
-	Stream        bool           `json:"stream,omitempty"`
-	Temperature   *float64       `json:"temperature,omitempty"`
-	TopP          *float64       `json:"top_p,omitempty"`
-	TopK          *int           `json:"top_k,omitempty"`
-	StopSequences []string       `json:"stop_sequences,omitempty"`
-	Tools         []antTool      `json:"tools,omitempty"`
-	ToolChoice    *antToolChoice `json:"tool_choice,omitempty"`
-	Thinking      *antThinking   `json:"thinking,omitempty"`
+	Model         string           `json:"model"`
+	MaxTokens     int              `json:"max_tokens"`
+	Messages      []antMessage     `json:"messages"`
+	System        string           `json:"system,omitempty"`
+	Stream        bool             `json:"stream,omitempty"`
+	Temperature   *float64         `json:"temperature,omitempty"`
+	TopP          *float64         `json:"top_p,omitempty"`
+	TopK          *int             `json:"top_k,omitempty"`
+	StopSequences []string         `json:"stop_sequences,omitempty"`
+	Tools         []antTool        `json:"tools,omitempty"`
+	ToolChoice    *antToolChoice   `json:"tool_choice,omitempty"`
+	Thinking      *antThinking     `json:"thinking,omitempty"`
+	OutputConfig  *antOutputConfig `json:"output_config,omitempty"`
+}
+
+// antOutputConfig carries the effort ceiling that accompanies adaptive
+// thinking. A model on the budget dialect ignores it rather than rejecting it,
+// so it rides along harmlessly if the dialects are ever confused.
+type antOutputConfig struct {
+	Effort string `json:"effort,omitempty"`
 }
 
 // antMessage carries Content as any because Anthropic accepts either a plain
@@ -156,15 +214,25 @@ type antToolChoice struct {
 }
 
 type antThinking struct {
-	Type         string `json:"type"` // "enabled"
-	BudgetTokens int    `json:"budget_tokens"`
+	Type         string `json:"type"`                    // "enabled" | "adaptive"
+	BudgetTokens int    `json:"budget_tokens,omitempty"` // budget dialect only
 }
 
 // TranslateRequest converts an OpenAI chat-completions request body into an
-// Anthropic Messages request body. It returns the Anthropic JSON, the model
-// string (verbatim — the body carries it, and the caller keeps it for routing
-// and metering) and the stream flag.
+// Anthropic Messages request body, asking for extended thinking in the default
+// adaptive dialect. It returns the Anthropic JSON, the model string (verbatim —
+// the body carries it, and the caller keeps it for routing and metering) and the
+// stream flag.
+//
+// Callers that know a model wants the older budget dialect (the proxy learns
+// this from a 400, see DialectFromError) use TranslateRequestWithDialect.
 func TranslateRequest(chatBody []byte) (body []byte, model string, stream bool, err error) {
+	return TranslateRequestWithDialect(chatBody, ThinkingAdaptive)
+}
+
+// TranslateRequestWithDialect is TranslateRequest with the thinking dialect
+// chosen by the caller.
+func TranslateRequestWithDialect(chatBody []byte, dialect ThinkingDialect) (body []byte, model string, stream bool, err error) {
 	var req oaiRequest
 	if err := json.Unmarshal(chatBody, &req); err != nil {
 		return nil, "", false, fmt.Errorf("anthropicegress: invalid request body: %s", jsonfault.Describe(err, len(chatBody)))
@@ -212,16 +280,7 @@ func TranslateRequest(chatBody []byte) (body []byte, model string, stream bool, 
 		out.MaxTokens = DefaultMaxTokens
 	}
 
-	if budget, ok := thinkingBudgets[strings.ToLower(req.ReasoningEffort)]; ok {
-		out.Thinking = &antThinking{Type: "enabled", BudgetTokens: budget}
-		// Anthropic rejects sampling knobs alongside thinking, and requires
-		// max_tokens strictly greater than the budget — the remainder is the
-		// visible answer's allowance, so it gets a full default budget.
-		out.Temperature, out.TopP, out.TopK = nil, nil, nil
-		if out.MaxTokens <= budget {
-			out.MaxTokens = budget + DefaultMaxTokens
-		}
-	}
+	applyThinking(&out, req.ReasoningEffort, dialect)
 
 	body, err = json.Marshal(out)
 	if err != nil {
@@ -229,6 +288,59 @@ func TranslateRequest(chatBody []byte) (body []byte, model string, stream bool, 
 	}
 	return body, req.Model, req.Stream, nil
 }
+
+// applyThinking turns an OpenAI reasoning_effort into the Anthropic thinking
+// request the given dialect expects, and makes the rest of the body consistent
+// with it. An effort the dialect has no mapping for leaves the request
+// untouched, thinking off — the same outcome as sending no effort at all.
+//
+// Both dialects share one hard constraint, which is why this is not two
+// unrelated branches: Anthropic rejects a temperature other than 1 whenever
+// thinking is on, in either shape (`temperature may only be set to 1 when
+// thinking is enabled or in adaptive mode`), and treats top_p/top_k the same
+// way. Dropping the sampling knobs is the only way to honour the caller's
+// reasoning request at all, and it is the lesser loss: a caller who asks to
+// think is asking about reasoning depth, not sampling.
+func applyThinking(out *antRequest, reasoningEffort string, dialect ThinkingDialect) {
+	effort := strings.ToLower(strings.TrimSpace(reasoningEffort))
+
+	switch dialect {
+	case ThinkingBudget:
+		budget, ok := thinkingBudgets[effort]
+		if !ok {
+			return
+		}
+		out.Thinking = &antThinking{Type: "enabled", BudgetTokens: budget}
+		// Anthropic requires max_tokens strictly greater than the budget: the
+		// remainder is the visible answer's allowance, so it gets a full default.
+		if out.MaxTokens <= budget {
+			out.MaxTokens = budget + DefaultMaxTokens
+		}
+	default: // ThinkingAdaptive
+		level, ok := thinkingEfforts[effort]
+		if !ok {
+			return
+		}
+		// The model decides how much to think, up to this ceiling, so there is no
+		// budget to keep max_tokens clear of. It still needs room for thinking AND
+		// an answer, and a caller who sent a small max_tokens with a big effort
+		// gets a stream of pure thinking cut off before any text (observed live:
+		// max_tokens 30 spent 29 thinking tokens and returned no content). Raising
+		// a too-small allowance is the difference between an answer and nothing.
+		out.Thinking = &antThinking{Type: "adaptive"}
+		out.OutputConfig = &antOutputConfig{Effort: level}
+		if out.MaxTokens < minAdaptiveMaxTokens {
+			out.MaxTokens = minAdaptiveMaxTokens
+		}
+	}
+	out.Temperature, out.TopP, out.TopK = nil, nil, nil
+}
+
+// minAdaptiveMaxTokens is the allowance an adaptive-thinking request is raised
+// to when the caller asked for less. It is DefaultMaxTokens, the same figure a
+// caller who named no budget gets: enough that thinking cannot consume the whole
+// allowance before the answer starts.
+const minAdaptiveMaxTokens = DefaultMaxTokens
 
 // translateMessages converts the OpenAI message list into the Anthropic system
 // prompt plus the conversation turns. system/developer messages lift out of the

--- a/internal/anthropicegress/request_test.go
+++ b/internal/anthropicegress/request_test.go
@@ -27,6 +27,9 @@ type translatedRequest struct {
 		Type         string `json:"type"`
 		BudgetTokens int    `json:"budget_tokens"`
 	} `json:"thinking"`
+	OutputConfig *struct {
+		Effort string `json:"effort"`
+	} `json:"output_config"`
 }
 
 type translatedMessage struct {
@@ -61,9 +64,16 @@ type translatedSource struct {
 // translate runs TranslateRequest and decodes the result for assertions.
 func translate(t *testing.T, body string) translatedRequest {
 	t.Helper()
-	out, _, _, err := TranslateRequest([]byte(body))
+	return translateWith(t, body, ThinkingAdaptive)
+}
+
+// translateWith is translate with the thinking dialect named, for the tests that
+// are about the dialects themselves.
+func translateWith(t *testing.T, body string, dialect ThinkingDialect) translatedRequest {
+	t.Helper()
+	out, _, _, err := TranslateRequestWithDialect([]byte(body), dialect)
 	if err != nil {
-		t.Fatalf("TranslateRequest failed: %v", err)
+		t.Fatalf("TranslateRequestWithDialect failed: %v", err)
 	}
 	var req translatedRequest
 	if err := json.Unmarshal(out, &req); err != nil {
@@ -687,12 +697,13 @@ func TestTranslateRequest_EmptyTurnsAreDropped(t *testing.T) {
 	}
 }
 
-func TestTranslateRequest_Thinking(t *testing.T) {
+func TestTranslateRequest_ThinkingBudgetDialect(t *testing.T) {
 	tests := []struct {
 		name       string
 		effort     string
 		wantBudget int // 0 means no thinking block
 	}{
+		{name: "minimal floors to the smallest budget", effort: "minimal", wantBudget: 1024},
 		{name: "low", effort: "low", wantBudget: 1024},
 		{name: "medium", effort: "medium", wantBudget: 4096},
 		{name: "high", effort: "high", wantBudget: 8192},
@@ -707,7 +718,7 @@ func TestTranslateRequest_Thinking(t *testing.T) {
 			if tt.effort != "" {
 				body += `,"reasoning_effort":"` + tt.effort + `"`
 			}
-			req := translate(t, body+"}")
+			req := translateWith(t, body+"}", ThinkingBudget)
 
 			if tt.wantBudget == 0 {
 				if req.Thinking != nil {
@@ -725,12 +736,93 @@ func TestTranslateRequest_Thinking(t *testing.T) {
 			if req.Thinking.Type != "enabled" || req.Thinking.BudgetTokens != tt.wantBudget {
 				t.Errorf("thinking = %+v, want enabled with budget %d", req.Thinking, tt.wantBudget)
 			}
+			// The budget dialect carries no effort field; sending one would be
+			// harmless but meaningless.
+			if req.OutputConfig != nil {
+				t.Errorf("output_config = %+v, want it omitted on the budget dialect", req.OutputConfig)
+			}
 			// Anthropic rejects sampling params alongside thinking.
 			if req.Temperature != nil || req.TopP != nil || req.TopK != nil {
 				t.Errorf("sampling params survived thinking: temperature=%v top_p=%v top_k=%v",
 					req.Temperature, req.TopP, req.TopK)
 			}
 		})
+	}
+}
+
+// The adaptive dialect is the default and what current models require: a
+// type:"adaptive" thinking block plus an effort ceiling, and no budget at all
+// (the model decides how much to spend beneath the ceiling).
+func TestTranslateRequest_ThinkingAdaptiveDialect(t *testing.T) {
+	tests := []struct {
+		name       string
+		effort     string
+		wantEffort string // "" means no thinking block
+	}{
+		{name: "minimal floors to low", effort: "minimal", wantEffort: "low"},
+		{name: "low", effort: "low", wantEffort: "low"},
+		{name: "medium", effort: "medium", wantEffort: "medium"},
+		{name: "high", effort: "high", wantEffort: "high"},
+		// Anthropic has two levels above high; a client that names one gets it.
+		{name: "xhigh", effort: "xhigh", wantEffort: "xhigh"},
+		{name: "max", effort: "max", wantEffort: "max"},
+		{name: "uppercase is normalised", effort: "HIGH", wantEffort: "high"},
+		{name: "none", effort: "none", wantEffort: ""},
+		{name: "absent", effort: "", wantEffort: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := `{"model":"m","messages":[{"role":"user","content":"hi"}],
+				"max_tokens":16000,"temperature":0.5,"top_p":0.9,"top_k":40`
+			if tt.effort != "" {
+				body += `,"reasoning_effort":"` + tt.effort + `"`
+			}
+			req := translateWith(t, body+"}", ThinkingAdaptive)
+
+			if tt.wantEffort == "" {
+				if req.Thinking != nil || req.OutputConfig != nil {
+					t.Errorf("thinking = %+v, output_config = %+v, want both omitted", req.Thinking, req.OutputConfig)
+				}
+				if req.Temperature == nil || req.TopP == nil || req.TopK == nil {
+					t.Error("sampling params dropped without a thinking block")
+				}
+				return
+			}
+
+			if req.Thinking == nil || req.Thinking.Type != "adaptive" {
+				t.Fatalf("thinking = %+v, want type adaptive", req.Thinking)
+			}
+			// A budget on an adaptive request is what the newest models reject.
+			if req.Thinking.BudgetTokens != 0 {
+				t.Errorf("budget_tokens = %d, want it absent on the adaptive dialect", req.Thinking.BudgetTokens)
+			}
+			if req.OutputConfig == nil || req.OutputConfig.Effort != tt.wantEffort {
+				t.Errorf("output_config = %+v, want effort %q", req.OutputConfig, tt.wantEffort)
+			}
+			// The same constraint as the budget dialect: `temperature may only be
+			// set to 1 when thinking is enabled or in adaptive mode`.
+			if req.Temperature != nil || req.TopP != nil || req.TopK != nil {
+				t.Errorf("sampling params survived thinking: temperature=%v top_p=%v top_k=%v",
+					req.Temperature, req.TopP, req.TopK)
+			}
+		})
+	}
+}
+
+// TranslateRequest is the adaptive dialect, so a caller that names no dialect
+// gets the shape current models accept.
+func TestTranslateRequest_DefaultsToAdaptive(t *testing.T) {
+	out, _, _, err := TranslateRequest([]byte(`{"model":"m","messages":[{"role":"user","content":"hi"}],"reasoning_effort":"low"}`))
+	if err != nil {
+		t.Fatalf("TranslateRequest: %v", err)
+	}
+	var req translatedRequest
+	if err := json.Unmarshal(out, &req); err != nil {
+		t.Fatalf("not JSON: %v", err)
+	}
+	if req.Thinking == nil || req.Thinking.Type != "adaptive" {
+		t.Errorf("thinking = %+v, want the adaptive default", req.Thinking)
 	}
 }
 
@@ -747,8 +839,8 @@ func TestTranslateRequest_ThinkingRaisesMaxTokensAboveTheBudget(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := translate(t, `{"model":"m","messages":[{"role":"user","content":"hi"}],
-				"reasoning_effort":"high"`+tt.maxTokens+`}`)
+			req := translateWith(t, `{"model":"m","messages":[{"role":"user","content":"hi"}],
+				"reasoning_effort":"high"`+tt.maxTokens+`}`, ThinkingBudget)
 
 			if req.MaxTokens != tt.want {
 				t.Errorf("max_tokens = %d, want %d", req.MaxTokens, tt.want)
@@ -760,6 +852,41 @@ func TestTranslateRequest_ThinkingRaisesMaxTokensAboveTheBudget(t *testing.T) {
 				t.Errorf("max_tokens %d is not above the thinking budget %d", req.MaxTokens, req.Thinking.BudgetTokens)
 			}
 		})
+	}
+}
+
+// An adaptive request has no budget to clear, but it still needs room for
+// thinking AND an answer. A small max_tokens is raised, because the alternative
+// is what a live claude-sonnet-5 did with max_tokens 30: spend 29 tokens
+// thinking, hit the cap, and return no text at all.
+func TestTranslateRequest_AdaptiveThinkingRaisesASmallMaxTokens(t *testing.T) {
+	tests := []struct {
+		name      string
+		maxTokens string
+		want      int
+	}{
+		{name: "tiny allowance is raised", maxTokens: `,"max_tokens":30`, want: minAdaptiveMaxTokens},
+		{name: "absent allowance gets the default", maxTokens: "", want: minAdaptiveMaxTokens},
+		{name: "generous allowance is left alone", maxTokens: `,"max_tokens":50000`, want: 50000},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := translateWith(t, `{"model":"m","messages":[{"role":"user","content":"hi"}],
+				"reasoning_effort":"high"`+tt.maxTokens+`}`, ThinkingAdaptive)
+			if req.MaxTokens != tt.want {
+				t.Errorf("max_tokens = %d, want %d", req.MaxTokens, tt.want)
+			}
+		})
+	}
+}
+
+// Without a thinking request, a small max_tokens is the caller's business and
+// stays exactly as sent.
+func TestTranslateRequest_MaxTokensUntouchedWithoutThinking(t *testing.T) {
+	req := translateWith(t, `{"model":"m","messages":[{"role":"user","content":"hi"}],"max_tokens":30}`, ThinkingAdaptive)
+	if req.MaxTokens != 30 {
+		t.Errorf("max_tokens = %d, want the caller's 30", req.MaxTokens)
 	}
 }
 

--- a/internal/anthropicegress/thinking.go
+++ b/internal/anthropicegress/thinking.go
@@ -1,0 +1,79 @@
+package anthropicegress
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// The thinking-dialect self-heal. A model accepts the adaptive thinking shape,
+// the older budget shape, or both, and nothing in the model id says which (see
+// ThinkingDialect). Rather than guess from a name that a third-party Messages
+// endpoint need not follow at all, the proxy sends its current best guess and
+// reads the answer: Anthropic names the shape it wanted in the 400 body, in
+// terms specific enough to act on.
+//
+// The two messages, live 2026-08-20:
+//
+//	"thinking.type.enabled" is not supported for this model. Use
+//	"thinking.type.adaptive" and "output_config.effort" to control thinking behavior.
+//
+//	adaptive thinking is not supported on this model
+//
+// Each names the dialect it rejected AND, in the first case, the one to use
+// instead. Matching is on the distinguishing phrases rather than the whole
+// string, so a reworded message keeps working as long as it still says which
+// shape is unsupported.
+
+// anthropicErrorEnvelope is the error body shape both messages arrive in.
+type anthropicErrorEnvelope struct {
+	Type  string `json:"type"`
+	Error struct {
+		Type    string `json:"type"`
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+// DialectFromError reports the thinking dialect an upstream 400 is asking for.
+// ok is false for any body that is not one of these two complaints, which is
+// almost all of them: a 400 about a document, a bad model id or a malformed
+// message must not be mistaken for a dialect switch and retried unchanged.
+//
+// The check is deliberately narrow in one more way. A body has to mention
+// thinking at all before either phrase is consulted, so an unrelated error that
+// happens to contain the word "adaptive" cannot flip a model onto a shape it
+// does not support and cost every later request a wasted round-trip.
+func DialectFromError(body []byte) (dialect ThinkingDialect, ok bool) {
+	var env anthropicErrorEnvelope
+	if json.Unmarshal(body, &env) != nil {
+		return 0, false
+	}
+	msg := strings.ToLower(env.Error.Message)
+	if !strings.Contains(msg, "thinking") {
+		return 0, false
+	}
+	switch {
+	// "thinking.type.enabled is not supported for this model" — the budget shape
+	// was refused, so this model is adaptive-only.
+	case strings.Contains(msg, "thinking.type.enabled") && strings.Contains(msg, "not supported"):
+		return ThinkingAdaptive, true
+	// "adaptive thinking is not supported on this model" — the reverse.
+	case strings.Contains(msg, "adaptive") && strings.Contains(msg, "not supported"):
+		return ThinkingBudget, true
+	}
+	return 0, false
+}
+
+// RequestAsksForThinking reports whether a translated Messages body carries a
+// thinking request. It is what makes the retry conditional: a 400 naming a
+// dialect is only worth re-issuing if the request that earned it actually asked
+// for thinking, and re-issuing one that did not would repeat the same body and
+// the same 400.
+func RequestAsksForThinking(messagesBody []byte) bool {
+	var probe struct {
+		Thinking json.RawMessage `json:"thinking"`
+	}
+	if json.Unmarshal(messagesBody, &probe) != nil {
+		return false
+	}
+	return len(probe.Thinking) > 0 && string(probe.Thinking) != "null"
+}

--- a/internal/anthropicegress/thinking_test.go
+++ b/internal/anthropicegress/thinking_test.go
@@ -1,0 +1,116 @@
+package anthropicegress
+
+import "testing"
+
+// The two error bodies are copied from live Anthropic responses (2026-08-20):
+// claude-sonnet-5 refusing the budget shape, and claude-haiku-4-5 refusing the
+// adaptive one. If Anthropic rewords them, this test is where it shows up.
+const (
+	budgetRefusedBody   = `{"type":"error","error":{"type":"invalid_request_error","message":"\"thinking.type.enabled\" is not supported for this model. Use \"thinking.type.adaptive\" and \"output_config.effort\" to control thinking behavior."}}`
+	adaptiveRefusedBody = `{"type":"error","error":{"type":"invalid_request_error","message":"adaptive thinking is not supported on this model"}}`
+)
+
+func TestDialectFromError(t *testing.T) {
+	tests := []struct {
+		name        string
+		body        string
+		wantDialect ThinkingDialect
+		wantOK      bool
+	}{
+		{
+			name:        "budget refused means the model is adaptive-only",
+			body:        budgetRefusedBody,
+			wantDialect: ThinkingAdaptive,
+			wantOK:      true,
+		},
+		{
+			name:        "adaptive refused means the model wants a budget",
+			body:        adaptiveRefusedBody,
+			wantDialect: ThinkingBudget,
+			wantOK:      true,
+		},
+		// Everything below must NOT be read as a dialect complaint: acting on one
+		// would re-issue a request whose 400 has nothing to do with thinking, and
+		// would poison the learned cache for every later request to that model.
+		{
+			name:   "an unrelated 400 is not a dialect complaint",
+			body:   `{"type":"error","error":{"type":"invalid_request_error","message":"messages.0.user.content.str: Input should be a valid string"}}`,
+			wantOK: false,
+		},
+		{
+			name:   "a missing max_tokens is not a dialect complaint",
+			body:   `{"type":"error","error":{"type":"invalid_request_error","message":"max_tokens: Field required"}}`,
+			wantOK: false,
+		},
+		{
+			name:   "an unknown model is not a dialect complaint",
+			body:   `{"type":"error","error":{"type":"not_found_error","message":"model: claude-nope"}}`,
+			wantOK: false,
+		},
+		{
+			// The word alone is not enough: a message about adaptive anything else
+			// must not flip a model onto a shape it cannot serve.
+			name:   "adaptive mentioned without thinking is not a dialect complaint",
+			body:   `{"type":"error","error":{"type":"invalid_request_error","message":"adaptive streaming is not supported on this endpoint"}}`,
+			wantOK: false,
+		},
+		{
+			name:   "the temperature complaint mentions thinking but names no dialect",
+			body:   `{"type":"error","error":{"type":"invalid_request_error","message":"` + "`temperature`" + ` may only be set to 1 when thinking is enabled or in adaptive mode."}}`,
+			wantOK: false,
+		},
+		{name: "not JSON", body: `<html>502 Bad Gateway</html>`, wantOK: false},
+		{name: "empty", body: ``, wantOK: false},
+		{name: "empty JSON object", body: `{}`, wantOK: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dialect, ok := DialectFromError([]byte(tt.body))
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if ok && dialect != tt.wantDialect {
+				t.Errorf("dialect = %s, want %s", dialect, tt.wantDialect)
+			}
+		})
+	}
+}
+
+// The temperature complaint deserves its own note: it is the one non-dialect
+// error that mentions BOTH "thinking" and "adaptive", so it is the case a
+// looser matcher would get wrong. Retrying it in the other dialect would fail
+// identically, since the sampling params, not the shape, are the problem.
+func TestDialectFromError_TemperatureComplaintIsNotADialectSwitch(t *testing.T) {
+	body := []byte(`{"type":"error","error":{"type":"invalid_request_error","message":"temperature may only be set to 1 when thinking is enabled or in adaptive mode. Please consult our documentation."}}`)
+	if _, ok := DialectFromError(body); ok {
+		t.Error("the temperature complaint was read as a dialect switch")
+	}
+}
+
+func TestRequestAsksForThinking(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{name: "adaptive", body: `{"model":"m","thinking":{"type":"adaptive"}}`, want: true},
+		{name: "budget", body: `{"model":"m","thinking":{"type":"enabled","budget_tokens":1024}}`, want: true},
+		{name: "no thinking key", body: `{"model":"m","max_tokens":10}`, want: false},
+		{name: "explicit null", body: `{"model":"m","thinking":null}`, want: false},
+		{name: "not JSON", body: `nope`, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := RequestAsksForThinking([]byte(tt.body)); got != tt.want {
+				t.Errorf("RequestAsksForThinking = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestThinkingDialectString(t *testing.T) {
+	if ThinkingAdaptive.String() != "adaptive" || ThinkingBudget.String() != "budget" {
+		t.Errorf("dialect names = %q / %q", ThinkingAdaptive.String(), ThinkingBudget.String())
+	}
+}

--- a/internal/paramrewrite/build_upstream_body_test.go
+++ b/internal/paramrewrite/build_upstream_body_test.go
@@ -6,35 +6,73 @@ import (
 	"testing"
 )
 
-// Both Anthropic types strip the same params. The Messages type is the one that
-// invites an exception, since its requests are always translated and the
-// translator can turn reasoning_effort into a thinking budget: that was tried
-// and reverted, because current models reject the budget shape the translator
-// emits (`"thinking.type.enabled" is not supported for this model`) and an
-// egress attempt never parses that 400 as an OpenAI error to learn from. The
-// params must be gone before the body is translated, not after.
-func TestBuildUpstreamBody_BothAnthropicTypesStripTheSameParams(t *testing.T) {
+// The two Anthropic types differ by exactly one param, and the difference is
+// load-bearing. Every chat request to anthropic-messages is translated by
+// internal/anthropicegress, which turns reasoning_effort into an Anthropic
+// thinking request in whichever shape the model accepts, so stripping it here
+// would discard the caller's reasoning request before the translator saw it.
+// The "anthropic" type keeps stripping it: its default route is the
+// OpenAI-compat endpoint, which has no thinking control at all.
+func TestBuildUpstreamBody_AnthropicTypesDifferOnReasoningEffort(t *testing.T) {
 	t.Parallel()
 
 	body := `{"model":"m","messages":[{"role":"user","content":"hi"}],"reasoning_effort":"low","top_p":0.9,"min_p":0.1,"frequency_penalty":0.2,"temperature":0.5}`
 
-	for _, providerType := range []string{"anthropic", "anthropic-messages"} {
-		t.Run(providerType, func(t *testing.T) {
-			out := BuildUpstreamBody([]byte(body), providerType, "m", "m", false, &sync.Map{}, &sync.Map{}, nil, providerType)
+	for _, tc := range []struct {
+		providerType      string
+		wantReasoningKept bool
+	}{
+		{"anthropic", false},
+		{"anthropic-messages", true},
+	} {
+		t.Run(tc.providerType, func(t *testing.T) {
+			out := BuildUpstreamBody([]byte(body), tc.providerType, "m", "m", false, &sync.Map{}, &sync.Map{}, nil, tc.providerType)
 			var raw map[string]any
 			if err := json.Unmarshal(out, &raw); err != nil {
 				t.Fatalf("result is not valid JSON: %v", err)
 			}
-			for _, gone := range []string{"reasoning_effort", "top_p", "min_p", "frequency_penalty"} {
+			if _, kept := raw["reasoning_effort"]; kept != tc.wantReasoningKept {
+				t.Errorf("reasoning_effort kept = %v, want %v: %s", kept, tc.wantReasoningKept, out)
+			}
+			// Everything else is stripped for both: the translator would drop them
+			// anyway, and on the compat route they 400.
+			for _, gone := range []string{"top_p", "min_p", "frequency_penalty"} {
 				if _, kept := raw[gone]; kept {
-					t.Errorf("%s survived for %s: %s", gone, providerType, out)
+					t.Errorf("%s survived for %s: %s", gone, tc.providerType, out)
 				}
 			}
-			// Everything Anthropic does accept still rides through.
 			if _, kept := raw["temperature"]; !kept {
-				t.Errorf("temperature was stripped for %s: %s", providerType, out)
+				t.Errorf("temperature was stripped for %s: %s", tc.providerType, out)
 			}
 		})
+	}
+}
+
+// The Messages list is derived from the compat one, so a param added to the
+// shared list is stripped from both rather than only the type it was added to.
+func TestAnthropicStripListsShareEverythingButReasoningEffort(t *testing.T) {
+	t.Parallel()
+
+	compat := map[string]bool{}
+	for _, p := range ProviderUnsupportedParams["anthropic"] {
+		compat[p] = true
+	}
+	messages := map[string]bool{}
+	for _, p := range ProviderUnsupportedParams["anthropic-messages"] {
+		messages[p] = true
+	}
+	if !compat["reasoning_effort"] || messages["reasoning_effort"] {
+		t.Errorf("reasoning_effort: compat=%v messages=%v, want stripped only on compat", compat["reasoning_effort"], messages["reasoning_effort"])
+	}
+	for p := range compat {
+		if p != "reasoning_effort" && !messages[p] {
+			t.Errorf("%q is stripped for anthropic but not anthropic-messages", p)
+		}
+	}
+	for p := range messages {
+		if !compat[p] {
+			t.Errorf("%q is stripped for anthropic-messages but not anthropic", p)
+		}
 	}
 }
 

--- a/internal/paramrewrite/params.go
+++ b/internal/paramrewrite/params.go
@@ -14,9 +14,8 @@ import (
 	"sync"
 )
 
-// anthropicUnsupportedParams is shared by both Anthropic provider types, which
-// reject the same params whether the request reaches them over the
-// OpenAI-compat endpoint or as a translated Messages body.
+// anthropicUnsupportedParams are the params no Anthropic endpoint accepts as
+// itself, over the OpenAI-compat route or as a translated Messages body.
 var anthropicUnsupportedParams = []string{
 	"top_p",             // deprecated on all current Anthropic models
 	"frequency_penalty", // Anthropic uses a single penalties param, not separate freq/presence
@@ -25,22 +24,40 @@ var anthropicUnsupportedParams = []string{
 	"reasoning_effort",  // not supported by Anthropic API
 }
 
+// anthropicMessagesUnsupportedParams is the same list without reasoning_effort,
+// which the Messages type translates rather than forwards. Derived from the list
+// above rather than restated, so a param added there is stripped from both.
+var anthropicMessagesUnsupportedParams = withoutParam(anthropicUnsupportedParams, "reasoning_effort")
+
+// withoutParam copies a strip list minus one entry.
+func withoutParam(params []string, drop string) []string {
+	out := make([]string, 0, len(params))
+	for _, p := range params {
+		if p != drop {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
 // ProviderUnsupportedParams lists OpenAI Chat Completions parameters that are
 // universally unsupported (cause 400 errors) per provider type. These are
 // preemptively stripped from requests to avoid a wasted round-trip.
 // Sources: official provider docs + empirical testing.
 var ProviderUnsupportedParams = map[string][]string{
 	"anthropic": anthropicUnsupportedParams,
-	// Identical to "anthropic", deliberately. Keeping reasoning_effort here was
-	// tried, so the egress translator could turn it into Anthropic's thinking
-	// budget, and it fails against current models: claude-sonnet-5 answers
-	// `"thinking.type.enabled" is not supported for this model. Use
-	// "thinking.type.adaptive" and "output_config.effort"`. Nothing recovers from
-	// that 400 either, because an egress attempt never parses one as an OpenAI
-	// error (sentChatCompletionsBody), so the param has to go before it is sent.
-	// Plumbing thinking control through the adapter needs the newer request
-	// shape, and is a feature in its own right.
-	"anthropic-messages": anthropicUnsupportedParams,
+	// The Messages type strips one param fewer: reasoning_effort survives, for
+	// internal/anthropicegress to turn into an Anthropic thinking request. Every
+	// chat request to this type is translated, so the param never reaches an
+	// upstream as itself, and the translator asks in the shape the model wants
+	// (learned from a 400 the first time; see proxy/anthropic_thinking_retry.go).
+	//
+	// "anthropic" keeps stripping it, deliberately. Its default route is
+	// Anthropic's OpenAI-compat endpoint, which has no thinking control at all,
+	// and honouring the param only on the rarer document-egress requests would
+	// make one provider reason and the next not, for a difference the caller
+	// cannot see. That type reasons by model default, uniformly.
+	"anthropic-messages": anthropicMessagesUnsupportedParams,
 	"google": {
 		"frequency_penalty", // not supported on Gemini OpenAI-compat endpoint
 		"presence_penalty",  // not supported on Gemini OpenAI-compat endpoint

--- a/internal/proxy/anthropic_egress.go
+++ b/internal/proxy/anthropic_egress.go
@@ -73,11 +73,13 @@ func isAnthropicEgressAttempt(st *requestState, providerType string) bool {
 // One route serves both modes: Anthropic streams from /v1/messages too, with
 // the body's "stream" field making the difference.
 func (h *Handler) buildAnthropicEgressRequest(ctx context.Context, st *requestState, candidate modelCandidate, providerType string) (*http.Request, string, string, error) {
-	cleaned := paramrewrite.BuildUpstreamBody(st.bodyBytes, providerType, candidate.model.ModelID, st.reqModel, false, &h.deprecationCache, &h.paramRenameCache, nil, learnedScopeFor(candidate))
-	body, model, stream, err := anthropicegress.TranslateRequest(cleaned)
+	body, model, stream, err := h.anthropicEgressBody(st, candidate, providerType, h.thinkingDialectFor(candidate))
 	if err != nil {
 		return nil, providerType, "", err
 	}
+	// Kept for the self-heal to compare a rebuild against (see
+	// learnAndRebuildMessages400); overwritten per attempt, like the dialect flags.
+	st.lastMessagesBody = body
 
 	targetURL := util.BuildProviderTargetURL(candidate.provider.BaseURL, providerType, "/messages")
 	debuglog.Info("proxy: routing via anthropic egress adapter", "target_url", targetURL, "model", model, "provider", candidate.provider.Name, "stream", stream)
@@ -91,4 +93,36 @@ func (h *Handler) buildAnthropicEgressRequest(ctx context.Context, st *requestSt
 	util.SetProviderAuthHeaders(proxyReq, providerType, candidate.apiKey)
 	proxyReq.Header.Set("Content-Type", "application/json")
 	return proxyReq, providerType, targetURL, nil
+}
+
+// anthropicEgressBody builds the Messages body for one egress attempt: the
+// shared chat rewrite (model rename, learned strips) followed by translation in
+// the given thinking dialect. The initial attempt and the dialect retry both go
+// through here so a change to either half cannot apply to only one of them.
+func (h *Handler) anthropicEgressBody(st *requestState, candidate modelCandidate, providerType string, dialect anthropicegress.ThinkingDialect) (body []byte, model string, stream bool, err error) {
+	cleaned := paramrewrite.BuildUpstreamBody(st.bodyBytes, providerType, candidate.model.ModelID, st.reqModel, false, &h.deprecationCache, &h.paramRenameCache, nil, learnedScopeFor(candidate))
+	return anthropicegress.TranslateRequestWithDialect(cleaned, dialect)
+}
+
+// thinkingDialectFor returns the extended-thinking shape to ask this candidate's
+// model for: whatever a previous 400 taught, else the adaptive default. The key
+// is the provider scope plus the upstream model id, the same one the learned
+// param caches use, because the fact is per model AND per provider — the same
+// model id behind two Messages endpoints need not be the same build.
+func (h *Handler) thinkingDialectFor(candidate modelCandidate) anthropicegress.ThinkingDialect {
+	key := paramrewrite.LearnedCacheKey(learnedScopeFor(candidate), candidate.model.ModelID)
+	if v, ok := h.thinkingDialectCache.Load(key); ok {
+		if dialect, isDialect := v.(anthropicegress.ThinkingDialect); isDialect {
+			return dialect
+		}
+	}
+	return anthropicegress.ThinkingAdaptive
+}
+
+// learnThinkingDialect records the shape an upstream 400 asked for, so later
+// requests to the same provider+model are built with it from the start.
+func (h *Handler) learnThinkingDialect(candidate modelCandidate, dialect anthropicegress.ThinkingDialect) {
+	key := paramrewrite.LearnedCacheKey(learnedScopeFor(candidate), candidate.model.ModelID)
+	h.thinkingDialectCache.Store(key, dialect)
+	debuglog.Info("proxy: learned anthropic thinking dialect from upstream 400", "provider", candidate.provider.Name, "model", candidate.model.ModelID, "dialect", dialect.String())
 }

--- a/internal/proxy/anthropic_egress_test.go
+++ b/internal/proxy/anthropic_egress_test.go
@@ -160,6 +160,16 @@ func (l *upstreamCallLog) record(c anthropicUpstreamCall) {
 	l.calls = append(l.calls, c)
 }
 
+// takeAll returns the calls recorded since the last take and clears the log, for
+// phases whose expected count is the thing under test.
+func (l *upstreamCallLog) takeAll() []anthropicUpstreamCall {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	got := l.calls
+	l.calls = nil
+	return got
+}
+
 // takeOne returns the single call of the phase just run and clears the log for
 // the next one, failing when the count is anything but one.
 func (l *upstreamCallLog) takeOne(t *testing.T, phase string) anthropicUpstreamCall {
@@ -426,17 +436,22 @@ func TestChatCompletions_AnthropicMessagesProvider(t *testing.T) {
 		t.Errorf("usage = %v, want the Messages usage block metered", resp["usage"])
 	}
 
-	// reasoning_effort is stripped before translation, so no thinking budget is
-	// requested: the shape the translator emits for one is rejected by current
-	// models, and an egress attempt cannot learn from that 400. It must not
-	// reach the Messages body in either form.
+	// reasoning_effort becomes an Anthropic thinking request rather than being
+	// stripped or forwarded as itself: the adaptive shape by default, with the
+	// effort carried on output_config. (The dialect self-heal that recovers when
+	// a model wants the older shape lives in anthropic_thinking_retry_test.go.)
 	w = send(false, `,"reasoning_effort":"low"`)
 	if w.Code != http.StatusOK {
 		t.Fatalf("reasoning_effort request: %d\n%s", w.Code, w.Body.String())
 	}
 	call = log.takeOne(t, "reasoning_effort")
-	if _, thinking := call.body["thinking"]; thinking {
-		t.Errorf("thinking budget requested from reasoning_effort: %v", call.body["thinking"])
+	thinking, ok := call.body["thinking"].(map[string]any)
+	if !ok || thinking["type"] != "adaptive" {
+		t.Errorf("thinking = %v, want the adaptive shape translated from reasoning_effort", call.body["thinking"])
+	}
+	outputConfig, ok := call.body["output_config"].(map[string]any)
+	if !ok || outputConfig["effort"] != "low" {
+		t.Errorf("output_config = %v, want effort low", call.body["output_config"])
 	}
 	if _, leaked := call.body["reasoning_effort"]; leaked {
 		t.Errorf("reasoning_effort reached the Messages body verbatim: %v", call.body)

--- a/internal/proxy/anthropic_thinking_retry.go
+++ b/internal/proxy/anthropic_thinking_retry.go
@@ -1,0 +1,183 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/hugalafutro/model-hotel/internal/anthropicegress"
+	"github.com/hugalafutro/model-hotel/internal/ctxkeys"
+	"github.com/hugalafutro/model-hotel/internal/debuglog"
+	"github.com/hugalafutro/model-hotel/internal/paramrewrite"
+	"github.com/hugalafutro/model-hotel/internal/util"
+)
+
+// The Messages-route self-heal, sibling of the chat-completions param retry. It
+// covers the two 400s that route can fix by asking differently, both of which
+// are per-model facts that no model id reveals:
+//
+//   - The extended-thinking shape. A model takes adaptive, budget, or both
+//     (anthropicegress.ThinkingDialect); the proxy asks in its best-known shape
+//     and switches on the 400 that names the other.
+//   - A param the model has retired. Anthropic deprecates sampling params per
+//     model generation — claude-sonnet-5 and claude-opus-5 answer
+//     "`temperature` is deprecated for this model" while every 4.x model accepts
+//     it — and OpenAI clients send temperature as a matter of course.
+//
+// Either way the fact is learned for this provider+model and the request
+// re-issued once, so the caller sees an answer rather than a 400 and no later
+// request to that model pays the round trip again.
+//
+// One retry is enough for both, because they cannot co-occur: a request that
+// asks for thinking has its sampling params dropped in translation (Anthropic
+// rejects them alongside thinking), and a request that does not ask for thinking
+// cannot earn a dialect complaint.
+//
+// This cannot ride on retryWithStrippedParams. That path is skipped for every
+// dialect attempt (sentChatCompletionsBody) because it rebuilds an OpenAI body
+// and re-POSTs it, which /v1/messages would reject.
+
+// retryLearnableMessages400 handles a 400 from an Anthropic egress attempt. It
+// returns handled=false for any 400 it cannot learn from, leaving the response
+// untouched for the caller to fail over or forward as it would have.
+//
+// The contract matches retryWithResponses: on handled=true the caller adopts
+// res.resp (and res.retryCancel, whose body it must consume), or res.cont with
+// res.lastReqErr when the retry could not be issued.
+func (h *Handler) retryLearnableMessages400(
+	r *http.Request,
+	st *requestState,
+	candidate modelCandidate,
+	providerType string,
+	resp *http.Response,
+	attempt int,
+	dialMs *float64,
+	failoverCancel context.CancelFunc,
+	streamCancelOrigin string,
+) (paramRetryResult, bool) {
+	res := paramRetryResult{resp: resp, streamCancelOrigin: streamCancelOrigin}
+	if !st.anthropicEgressAttempt || st.messagesRetried {
+		return res, false
+	}
+
+	// The same bounded read the other learners use: the body is decoded here and
+	// still has to be handed on readable when nothing can be learned from it.
+	body, readErr := readLearnable400(resp)
+	// No-op close on the buffered replacement, for bodyclose's benefit — see the
+	// identical note in retryWithResponses.
+	_ = resp.Body.Close()
+	if readErr != nil {
+		return res, false
+	}
+
+	rebuilt, model, stream, ok := h.learnAndRebuildMessages400(st, candidate, providerType, body)
+	if !ok {
+		return res, false
+	}
+
+	failoverCancel() // 400 body fully consumed, original context no longer needed
+
+	targetURL := util.BuildProviderTargetURL(candidate.provider.BaseURL, providerType, "/messages")
+	retryCtx, rc := context.WithTimeout(r.Context(), st.failoverTimeout)
+	retryCtx = context.WithValue(retryCtx, ctxkeys.CancelOriginKey, "retry_timeout")
+	retryCtx = context.WithValue(retryCtx, ctxkeys.DialMsKey, dialMs)
+	res.streamCancelOrigin = "retry_timeout"
+
+	retryReq, retryErr := newRequestWithContext(retryCtx, "POST", targetURL, bytes.NewReader(rebuilt))
+	if retryErr != nil {
+		rc()
+		res.lastReqErr = reqError{Kind: KindInternal, Attempt: attempt, Provider: candidate.provider.Name, Underlying: errString(retryErr)}
+		res.cont = true
+		return res, true
+	}
+	util.SetProviderAuthHeaders(retryReq, providerType, candidate.apiKey)
+	retryReq.Header.Set("Content-Type", "application/json")
+
+	var checkRedirect func(req *http.Request, via []*http.Request) error
+	if h.safeDialer != nil {
+		checkRedirect = h.safeDialer.CheckRedirect
+	}
+	//nolint:bodyclose // retry resp.Body is consumed by the caller's dispatch
+	retryResp, doErr := (&http.Client{Transport: h.upstreamTransport, CheckRedirect: checkRedirect}).Do(retryReq)
+	if doErr != nil {
+		rc()
+		debuglog.Warn("proxy: anthropic thinking dialect retry failed", "attempt", attempt+1, "provider", candidate.provider.Name, "provider_id", candidate.provider.ID, "error", doErr)
+		if errors.Is(doErr, context.Canceled) || errors.Is(doErr, context.DeadlineExceeded) {
+			origin := "retry_timeout"
+			if errors.Is(doErr, context.Canceled) {
+				origin = "client_disconnect"
+			}
+			res.lastReqErr = reqError{Kind: cancelOriginToKind(origin), Attempt: attempt, Provider: candidate.provider.Name}
+		} else {
+			res.lastReqErr = reqError{Kind: KindProviderError, Attempt: attempt, Provider: candidate.provider.Name, Underlying: errString(doErr)}
+		}
+		res.cont = true
+		return res, true
+	}
+
+	// The retry is still an egress attempt, so the response side keeps
+	// translating it. The guard flag stops a second round: what this self-heal
+	// can learn, it has learned, and a 400 after the re-issue is about something
+	// else.
+	st.messagesRetried = true
+	st.lastMessagesBody = rebuilt
+	res.resp = retryResp
+	res.retryCancel = rc
+	res.retried = true
+	debuglog.Info("proxy: anthropic messages self-heal retry issued", "model", model, "stream", stream, "status", retryResp.StatusCode)
+	return res, true
+}
+
+// learnAndRebuildMessages400 reads what a Messages 400 has to teach, records it,
+// and rebuilds the request accordingly. ok is false when the body teaches
+// nothing, or when what it teaches cannot change this particular request — in
+// which case re-issuing would send identical bytes and earn the identical 400.
+func (h *Handler) learnAndRebuildMessages400(st *requestState, candidate modelCandidate, providerType string, body []byte) (rebuilt []byte, model string, stream, ok bool) {
+	if dialect, isDialectError := anthropicegress.DialectFromError(body); isDialectError {
+		// Learn before deciding whether this request can be retried: a hedged
+		// attempt reaches the same learner, and the cached fact is what stops the
+		// next request repeating the mistake even when this one cannot be
+		// re-issued.
+		h.learnThinkingDialect(candidate, dialect)
+		rebuilt, model, stream, err := h.anthropicEgressBody(st, candidate, providerType, dialect)
+		if err != nil {
+			debuglog.Warn("proxy: anthropic messages retry could not rebuild for dialect", "provider", candidate.provider.Name, "model", candidate.model.ModelID, "error", err)
+			return nil, "", false, false
+		}
+		// Only a request that actually asked for thinking is changed by asking in
+		// the other dialect.
+		if !anthropicegress.RequestAsksForThinking(rebuilt) {
+			return nil, "", false, false
+		}
+		return rebuilt, model, stream, true
+	}
+
+	// Param learning is scoped to anthropic-messages, whose ONLY route is
+	// Messages. The learned strip is keyed by provider+model and consulted by
+	// every build for that key, so learning one on an `anthropic` provider —
+	// whose default route is the OpenAI-compat endpoint — would let a name read
+	// out of a Messages 400 strip a param from compat traffic that accepts it.
+	if providerType != "anthropic-messages" {
+		return nil, "", false, false
+	}
+	rejected := paramrewrite.ParseProviderParamError(body)
+	if len(rejected) == 0 {
+		return nil, "", false, false
+	}
+	// The names shared by the two dialects are exactly the ones the translator
+	// forwards unchanged (temperature, top_p, top_k), so a name learned here
+	// means the same thing it would on the compat path.
+	h.learnRejectedParams(candidate, body)
+	rebuilt, model, stream, err := h.anthropicEgressBody(st, candidate, providerType, h.thinkingDialectFor(candidate))
+	if err != nil {
+		debuglog.Warn("proxy: anthropic messages retry could not rebuild without rejected params", "provider", candidate.provider.Name, "model", candidate.model.ModelID, "error", err)
+		return nil, "", false, false
+	}
+	// The rebuild reads the cache just written, so a param that survived it was
+	// not actually removed and the retry would be pointless.
+	if bytes.Equal(rebuilt, st.lastMessagesBody) {
+		return nil, "", false, false
+	}
+	return rebuilt, model, stream, true
+}

--- a/internal/proxy/anthropic_thinking_retry_test.go
+++ b/internal/proxy/anthropic_thinking_retry_test.go
@@ -1,0 +1,539 @@
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/hugalafutro/model-hotel/internal/anthropicegress"
+	"github.com/hugalafutro/model-hotel/internal/model"
+	"github.com/hugalafutro/model-hotel/internal/provider"
+)
+
+// testModelNamed is a bare model carrying only the upstream id, which is all the
+// dialect cache keys on.
+func testModelNamed(id string) *model.Model {
+	return &model.Model{ID: uuid.New(), ModelID: id}
+}
+
+// budgetOnlyUpstream is a model on the older thinking dialect: it refuses an
+// adaptive request exactly as claude-haiku-4-5 does, and answers a budget one.
+// Every call is recorded so a test can assert both the refusal and the retry.
+func budgetOnlyUpstream(t *testing.T, log *upstreamCallLog) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		log.record(anthropicUpstreamCall{path: r.URL.Path, body: body})
+
+		thinking, _ := body["thinking"].(map[string]any)
+		if thinking != nil && thinking["type"] == "adaptive" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"type":"error","error":{"type":"invalid_request_error","message":"adaptive thinking is not supported on this model"}}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","role":"assistant","model":"claude","content":[{"type":"text","text":"THOUGHT-9021"}],"stop_reason":"end_turn","usage":{"input_tokens":11,"output_tokens":6}}`))
+	}))
+}
+
+// sendThinkingChat drives one chat request carrying reasoning_effort through the
+// full ChatCompletions pipeline.
+func sendThinkingChat(env *testProxyEnv, extra string) *httptest.ResponseRecorder {
+	body := fmt.Sprintf(`{"model":"%s/%s","max_tokens":20000,"reasoning_effort":"high"%s,"messages":[{"role":"user","content":"think about it"}]}`,
+		env.ProviderName, env.ModelName, extra)
+	req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(body))
+	ctx := context.WithValue(req.Context(), virtualKeyNameKey, "test-key")
+	ctx = context.WithValue(ctx, virtualKeyIDKey, uuid.New().String())
+	ctx = context.WithValue(ctx, VirtualKeyHashKey, env.KeyHash)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	env.Handler.ChatCompletions(w, req)
+	return w
+}
+
+// The whole point of the self-heal: a model that refuses the adaptive shape gets
+// asked again in the budget shape, the caller sees an answer rather than the
+// 400, and the second request to that model skips the refusal entirely because
+// the dialect was learned.
+func TestChatCompletions_ThinkingDialectRetryAndLearn(t *testing.T) {
+	var log upstreamCallLog
+	upstream := budgetOnlyUpstream(t, &log)
+	defer upstream.Close()
+
+	env := newAnthropicMessagesEnv(t, upstream)
+
+	w := sendThinkingChat(env, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("first request: %d\n%s", w.Code, w.Body.String())
+	}
+
+	calls := log.takeAll()
+	if len(calls) != 2 {
+		t.Fatalf("upstream calls = %d, want 2 (the refusal and the retry)", len(calls))
+	}
+	firstThinking, _ := calls[0].body["thinking"].(map[string]any)
+	if firstThinking == nil || firstThinking["type"] != "adaptive" {
+		t.Errorf("first attempt thinking = %v, want the adaptive default", calls[0].body["thinking"])
+	}
+	retryThinking, _ := calls[1].body["thinking"].(map[string]any)
+	if retryThinking == nil || retryThinking["type"] != "enabled" {
+		t.Fatalf("retry thinking = %v, want the budget shape", calls[1].body["thinking"])
+	}
+	if retryThinking["budget_tokens"] == nil {
+		t.Errorf("retry carries no budget_tokens: %v", retryThinking)
+	}
+	if calls[1].path != "/v1/messages" {
+		t.Errorf("retry went to %s, want /v1/messages", calls[1].path)
+	}
+
+	// The client sees the answer, translated back to chat shape: the 400 never
+	// reaches it.
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("response not JSON: %v\n%s", err, w.Body.String())
+	}
+	if resp["object"] != "chat.completion" {
+		t.Fatalf("object = %v, want chat.completion", resp["object"])
+	}
+	choice := resp["choices"].([]any)[0].(map[string]any)
+	if choice["message"].(map[string]any)["content"] != "THOUGHT-9021" {
+		t.Errorf("content = %v", choice["message"])
+	}
+
+	// Second request: the dialect is known, so there is no refusal to recover
+	// from and only one upstream call.
+	w = sendThinkingChat(env, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("second request: %d\n%s", w.Code, w.Body.String())
+	}
+	calls = log.takeAll()
+	if len(calls) != 1 {
+		t.Fatalf("second request made %d upstream calls, want 1: the dialect was already learned", len(calls))
+	}
+	learned, _ := calls[0].body["thinking"].(map[string]any)
+	if learned == nil || learned["type"] != "enabled" {
+		t.Errorf("second request thinking = %v, want the learned budget shape", calls[0].body["thinking"])
+	}
+}
+
+// The other half of the Messages self-heal: a model that has retired a param
+// says so in a 400, and the request is re-issued without it. This is the common
+// case, not an exotic one — claude-sonnet-5 and claude-opus-5 answer
+// "`temperature` is deprecated for this model", and OpenAI clients send
+// temperature by default.
+func TestChatCompletions_MessagesRetryLearnsRejectedParam(t *testing.T) {
+	var log upstreamCallLog
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		log.record(anthropicUpstreamCall{path: r.URL.Path, body: body})
+
+		if _, sent := body["temperature"]; sent {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte("{\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"`temperature` is deprecated for this model.\"}}"))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","role":"assistant","model":"claude","content":[{"type":"text","text":"TEMP-4417"}],"stop_reason":"end_turn","usage":{"input_tokens":5,"output_tokens":4}}`))
+	}))
+	defer upstream.Close()
+
+	env := newAnthropicMessagesEnv(t, upstream)
+
+	send := func() *httptest.ResponseRecorder {
+		body := fmt.Sprintf(`{"model":"%s/%s","temperature":0.7,"max_tokens":100,"messages":[{"role":"user","content":"hi"}]}`,
+			env.ProviderName, env.ModelName)
+		req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(body))
+		ctx := context.WithValue(req.Context(), virtualKeyNameKey, "test-key")
+		ctx = context.WithValue(ctx, virtualKeyIDKey, uuid.New().String())
+		ctx = context.WithValue(ctx, VirtualKeyHashKey, env.KeyHash)
+		w := httptest.NewRecorder()
+		env.Handler.ChatCompletions(w, req.WithContext(ctx))
+		return w
+	}
+
+	w := send()
+	if w.Code != http.StatusOK {
+		t.Fatalf("first request: %d\n%s", w.Code, w.Body.String())
+	}
+	calls := log.takeAll()
+	if len(calls) != 2 {
+		t.Fatalf("upstream calls = %d, want 2 (the refusal and the retry)", len(calls))
+	}
+	if _, sent := calls[0].body["temperature"]; !sent {
+		t.Error("first attempt did not carry the caller's temperature")
+	}
+	if _, sent := calls[1].body["temperature"]; sent {
+		t.Errorf("retry still carries temperature: %v", calls[1].body)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("response not JSON: %v", err)
+	}
+	choice := resp["choices"].([]any)[0].(map[string]any)
+	if choice["message"].(map[string]any)["content"] != "TEMP-4417" {
+		t.Errorf("content = %v", choice["message"])
+	}
+
+	// Learned: the next request omits the param without needing the refusal.
+	if w = send(); w.Code != http.StatusOK {
+		t.Fatalf("second request: %d\n%s", w.Code, w.Body.String())
+	}
+	calls = log.takeAll()
+	if len(calls) != 1 {
+		t.Fatalf("second request made %d upstream calls, want 1: the strip was already learned", len(calls))
+	}
+	if _, sent := calls[0].body["temperature"]; sent {
+		t.Errorf("second request still carries temperature: %v", calls[0].body)
+	}
+}
+
+// A request that never asked for thinking cannot be fixed by asking in another
+// dialect, so a dialect 400 on one must not be retried: the re-issued body would
+// be byte-identical and earn the same 400.
+func TestChatCompletions_NoThinkingRequestIsNotRetried(t *testing.T) {
+	var log upstreamCallLog
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		log.record(anthropicUpstreamCall{path: r.URL.Path, body: body})
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"type":"error","error":{"type":"invalid_request_error","message":"adaptive thinking is not supported on this model"}}`))
+	}))
+	defer upstream.Close()
+
+	env := newAnthropicMessagesEnv(t, upstream)
+
+	body := fmt.Sprintf(`{"model":"%s/%s","max_tokens":100,"messages":[{"role":"user","content":"no thinking here"}]}`,
+		env.ProviderName, env.ModelName)
+	req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(body))
+	ctx := context.WithValue(req.Context(), virtualKeyNameKey, "test-key")
+	ctx = context.WithValue(ctx, virtualKeyIDKey, uuid.New().String())
+	ctx = context.WithValue(ctx, VirtualKeyHashKey, env.KeyHash)
+	w := httptest.NewRecorder()
+	env.Handler.ChatCompletions(w, req.WithContext(ctx))
+
+	if calls := log.takeAll(); len(calls) != 1 {
+		t.Errorf("upstream calls = %d, want 1: a request with no thinking has nothing to retry", len(calls))
+	}
+}
+
+// A 400 that is not about thinking must reach the client as the failure it is,
+// with no second round-trip spent on it.
+func TestChatCompletions_UnrelatedBadRequestIsNotRetried(t *testing.T) {
+	var log upstreamCallLog
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		log.record(anthropicUpstreamCall{path: r.URL.Path, body: body})
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"type":"error","error":{"type":"invalid_request_error","message":"messages.0.user.content.str: Input should be a valid string"}}`))
+	}))
+	defer upstream.Close()
+
+	env := newAnthropicMessagesEnv(t, upstream)
+	w := sendThinkingChat(env, "")
+
+	if w.Code == http.StatusOK {
+		t.Errorf("code = 200, want the upstream failure surfaced")
+	}
+	if calls := log.takeAll(); len(calls) != 1 {
+		t.Errorf("upstream calls = %d, want 1: a non-dialect 400 is not a retry", len(calls))
+	}
+}
+
+// A hedged race cannot spend a second round-trip inside one slot, so a dialect
+// 400 there is learned rather than retried: this race is lost, and the next
+// request to that model asks in the right shape from the start.
+func TestProbeStreamingCandidate_LearnsThinkingDialectWithoutRetrying(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandler(h)
+
+	var log upstreamCallLog
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		log.record(anthropicUpstreamCall{path: r.URL.Path, body: body})
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"type":"error","error":{"type":"invalid_request_error","message":"adaptive thinking is not supported on this model"}}`))
+	}))
+	defer srv.Close()
+
+	st, cand := probeStateForServer(srv.URL)
+	st.bodyBytes = []byte(`{"model":"orig-model","stream":true,"reasoning_effort":"high","max_tokens":20000,"messages":[{"role":"user","content":"think"}]}`)
+	cand.provider.ProviderType = "anthropic-messages"
+
+	res := h.probeStreamingCandidate(context.Background(), st, cand, 0, 5*time.Second, 30*time.Second)
+	if res.won {
+		t.Fatal("a 400 must not win the race")
+	}
+	if calls := log.takeAll(); len(calls) != 1 {
+		t.Errorf("upstream calls = %d, want 1: a hedged slot learns but does not retry", len(calls))
+	}
+	if got := h.thinkingDialectFor(cand); got != anthropicegress.ThinkingBudget {
+		t.Errorf("dialect after the hedged 400 = %s, want budget learned", got)
+	}
+}
+
+// The self-heal is per candidate, not per request. A failover group mixes
+// providers, so the second anthropic-messages candidate must get its own
+// self-heal even when the first already spent one: each is a different model
+// behind a different endpoint, with its own facts to learn. Within a single
+// attempt the flag cannot fire twice anyway — attemptCandidate consults it from
+// one branch, not a loop — so carrying it forward would deny the next candidate
+// a retry it never used.
+func TestBuildCandidateRequest_ResetsTheMessagesSelfHealPerCandidate(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandler(h)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","role":"assistant","content":[],"stop_reason":"end_turn"}`))
+	}))
+	defer srv.Close()
+
+	st, cand := probeStateForServer(srv.URL)
+	st.bodyBytes = []byte(`{"model":"orig-model","messages":[{"role":"user","content":"hi"}]}`)
+	cand.provider.ProviderType = "anthropic-messages"
+
+	// Stand in for a previous candidate that already used its one retry.
+	st.messagesRetried = true
+	st.lastMessagesBody = []byte(`{"stale":true}`)
+
+	if _, _, _, err := h.buildCandidateRequest(context.Background(), st, cand); err != nil {
+		t.Fatalf("buildCandidateRequest: %v", err)
+	}
+	if st.messagesRetried {
+		t.Error("messagesRetried survived into the next candidate, which would deny it a self-heal it never used")
+	}
+	if string(st.lastMessagesBody) == `{"stale":true}` {
+		t.Error("lastMessagesBody still holds the previous candidate's body")
+	}
+	if !st.anthropicEgressAttempt {
+		t.Error("the candidate was not marked as an egress attempt")
+	}
+}
+
+// learnAndRebuildMessages400 decides whether a 400 is worth acting on at all.
+// Every "no" here is a 400 that must reach the client (or the next candidate)
+// untouched, so each one is worth pinning: a false yes spends a round-trip
+// re-sending bytes that will fail identically, and can poison a learned cache.
+func TestLearnAndRebuildMessages400_DecidesWhatIsWorthRetrying(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandler(h)
+
+	const thinkingBody = `{"model":"m","reasoning_effort":"high","messages":[{"role":"user","content":"hi"}]}`
+	const plainBody = `{"model":"m","temperature":0.7,"messages":[{"role":"user","content":"hi"}]}`
+
+	tests := []struct {
+		name         string
+		providerType string
+		chatBody     string
+		errBody      string
+		wantOK       bool
+	}{
+		{
+			name:         "dialect complaint on a thinking request is retried",
+			providerType: "anthropic-messages",
+			chatBody:     thinkingBody,
+			errBody:      `{"type":"error","error":{"type":"invalid_request_error","message":"adaptive thinking is not supported on this model"}}`,
+			wantOK:       true,
+		},
+		{
+			name:         "rejected param is retried",
+			providerType: "anthropic-messages",
+			chatBody:     plainBody,
+			errBody:      "{\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"`temperature` is deprecated for this model.\"}}",
+			wantOK:       true,
+		},
+		{
+			// The whole scoping rule: an `anthropic` provider's default route is
+			// the compat endpoint, and the learned strip is keyed by
+			// provider+model, so a name read out of a Messages 400 here would
+			// remove a param from compat traffic that accepts it.
+			name:         "a rejected param on an anthropic provider is NOT learned",
+			providerType: "anthropic",
+			chatBody:     plainBody,
+			errBody:      "{\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"`temperature` is deprecated for this model.\"}}",
+			wantOK:       false,
+		},
+		{
+			name:         "a 400 naming nothing learnable is left alone",
+			providerType: "anthropic-messages",
+			chatBody:     plainBody,
+			errBody:      `{"type":"error","error":{"type":"invalid_request_error","message":"messages.0.user.content.str: Input should be a valid string"}}`,
+			wantOK:       false,
+		},
+		{
+			name:         "an unreadable error body teaches nothing",
+			providerType: "anthropic-messages",
+			chatBody:     plainBody,
+			errBody:      `<html>502</html>`,
+			wantOK:       false,
+		},
+		{
+			// A dialect complaint is only actionable on a request that asked for
+			// thinking; anything else re-sends identical bytes.
+			name:         "dialect complaint on a request without thinking is not retried",
+			providerType: "anthropic-messages",
+			chatBody:     plainBody,
+			errBody:      `{"type":"error","error":{"type":"invalid_request_error","message":"adaptive thinking is not supported on this model"}}`,
+			wantOK:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			st, cand := probeStateForServer("http://unused.example")
+			st.bodyBytes = []byte(tt.chatBody)
+			st.lastMessagesBody = []byte(`{"previous":true}`)
+			// A fresh provider per case, so one case's learned facts cannot leak
+			// into the next through the shared handler caches.
+			cand.provider.ID = uuid.New()
+
+			rebuilt, _, _, ok := h.learnAndRebuildMessages400(st, cand, tt.providerType, []byte(tt.errBody))
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if ok && len(rebuilt) == 0 {
+				t.Error("retry accepted but produced an empty body")
+			}
+			if !ok && rebuilt != nil {
+				t.Errorf("no retry, but a body was returned: %s", rebuilt)
+			}
+		})
+	}
+}
+
+// The guard is what stops a second round on the same candidate. Nothing inside
+// one attempt loops, so this is belt and braces — but the flag is also what the
+// per-candidate reset clears, so its effect is worth pinning.
+func TestRetryLearnableMessages400_GuardsAndPreconditions(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandler(h)
+
+	dialect400 := func() *http.Response {
+		return &http.Response{
+			StatusCode: http.StatusBadRequest,
+			Body:       newBodyReader(`{"type":"error","error":{"type":"invalid_request_error","message":"adaptive thinking is not supported on this model"}}`),
+		}
+	}
+
+	t.Run("an attempt that already retried is not retried again", func(t *testing.T) {
+		st, cand := probeStateForServer("http://unused.example")
+		st.bodyBytes = []byte(`{"model":"m","reasoning_effort":"high","messages":[{"role":"user","content":"hi"}]}`)
+		st.messagesRetried = true
+		resp := dialect400()
+		defer func() { _ = resp.Body.Close() }()
+
+		if _, handled := h.retryLearnableMessages400(httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody),
+			st, cand, "anthropic-messages", resp, 0, new(float64), func() {}, ""); handled {
+			t.Error("a second retry was issued on the same attempt")
+		}
+	})
+
+	t.Run("a non-egress attempt is not this learner's business", func(t *testing.T) {
+		st, cand := probeStateForServer("http://unused.example")
+		st.anthropicEgressAttempt = false
+		resp := dialect400()
+		defer func() { _ = resp.Body.Close() }()
+
+		if _, handled := h.retryLearnableMessages400(httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody),
+			st, cand, "anthropic-messages", resp, 0, new(float64), func() {}, ""); handled {
+			t.Error("a chat-completions attempt was handled by the Messages learner")
+		}
+	})
+}
+
+// A transport failure on the retry must surface as a failover-worthy error
+// rather than a silent success or a leaked context.
+func TestRetryLearnableMessages400_TransportFailureFailsOver(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandler(h)
+
+	// A listener that accepts and immediately hangs up, so the retry's own
+	// round-trip fails at the transport.
+	dead := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			return
+		}
+		conn, _, err := hj.Hijack()
+		if err == nil {
+			_ = conn.Close()
+		}
+	}))
+	defer dead.Close()
+
+	st, cand := probeStateForServer(dead.URL)
+	st.anthropicEgressAttempt = true
+	st.bodyBytes = []byte(`{"model":"m","reasoning_effort":"high","messages":[{"role":"user","content":"hi"}]}`)
+	resp := &http.Response{
+		StatusCode: http.StatusBadRequest,
+		Body:       newBodyReader(`{"type":"error","error":{"type":"invalid_request_error","message":"adaptive thinking is not supported on this model"}}`),
+	}
+
+	res, handled := h.retryLearnableMessages400(httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody),
+		st, cand, "anthropic-messages", resp, 0, new(float64), func() {}, "")
+	if !handled {
+		t.Fatal("a dialect 400 was not handled")
+	}
+	if !res.cont {
+		t.Error("a failed retry must ask the caller to fail over")
+	}
+	if res.lastReqErr.Kind == "" {
+		t.Error("a failed retry must carry an error kind for the log row")
+	}
+	if res.retried {
+		t.Error("a retry that never got a response must not be marked as retried")
+	}
+	// The dialect is still learned: this race was lost, but the next request to
+	// this model should not repeat the refusal.
+	if got := h.thinkingDialectFor(cand); got != anthropicegress.ThinkingBudget {
+		t.Errorf("dialect = %s, want budget learned even though the retry failed", got)
+	}
+}
+
+// thinkingDialectFor is what every attempt consults, so its default and its
+// scoping are worth pinning directly.
+func TestThinkingDialectFor(t *testing.T) {
+	h := &Handler{}
+	prov := &provider.Provider{ID: uuid.New(), Name: "p"}
+	candidate := modelCandidate{provider: prov, model: testModelNamed("claude-x")}
+
+	if got := h.thinkingDialectFor(candidate); got != anthropicegress.ThinkingAdaptive {
+		t.Errorf("unlearned dialect = %s, want the adaptive default", got)
+	}
+
+	h.learnThinkingDialect(candidate, anthropicegress.ThinkingBudget)
+	if got := h.thinkingDialectFor(candidate); got != anthropicegress.ThinkingBudget {
+		t.Errorf("learned dialect = %s, want budget", got)
+	}
+
+	// A different model on the same provider is a separate fact.
+	other := modelCandidate{provider: prov, model: testModelNamed("claude-y")}
+	if got := h.thinkingDialectFor(other); got != anthropicegress.ThinkingAdaptive {
+		t.Errorf("sibling model dialect = %s, want the default: the fact is per model", got)
+	}
+
+	// So is the same model id behind a different provider, which need not be the
+	// same build at all.
+	elsewhere := modelCandidate{provider: &provider.Provider{ID: uuid.New(), Name: "q"}, model: testModelNamed("claude-x")}
+	if got := h.thinkingDialectFor(elsewhere); got != anthropicegress.ThinkingAdaptive {
+		t.Errorf("same model at another provider = %s, want the default", got)
+	}
+}

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -53,6 +53,17 @@ type Handler struct {
 	// max_completion_tokens for OpenAI gpt-5/o-series), keyed by
 	// "providerType:modelID". Value: map[string]string of old->new param names.
 	paramRenameCache sync.Map
+	// thinkingDialectCache caches which extended-thinking shape a model wants,
+	// learned from an upstream 400, keyed by the same "providerScope:modelID" the
+	// param caches use. Value: anthropicegress.ThinkingDialect.
+	//
+	// Only models that answered a 400 appear here; everything else takes the
+	// adaptive default. In-memory and per-instance on purpose, like the param
+	// caches: the cost of relearning after a restart is one 400 on the first
+	// thinking request to a budget-dialect model, and the alternative is a
+	// persisted fact that goes stale the next time Anthropic moves a model
+	// between dialects.
+	thinkingDialectCache sync.Map
 	// goneStrikes counts consecutive KindProviderModelGone responses per model
 	// UUID, so a model the provider has retired is probed and then disabled
 	// after goneStrikeThreshold refusals. Deliberately in-memory and

--- a/internal/proxy/hedging.go
+++ b/internal/proxy/hedging.go
@@ -301,6 +301,16 @@ func (h *Handler) probeStreamingCandidate(ctx context.Context, st *requestState,
 			// request. The sequential path gates its own 400 handling the same
 			// way.
 		}
+		if resp.StatusCode == http.StatusBadRequest && st.anthropicEgressAttempt {
+			// The Messages route's own learnable 400, gated the opposite way: a
+			// thinking-dialect complaint only arrives on an egress attempt, and
+			// naming a dialect is the whole content of it. Learning here spares
+			// every later request to this model the refusal, even though this
+			// race slot cannot re-issue to recover the current one.
+			if dialect, ok := anthropicegress.DialectFromError(errBody); ok {
+				h.learnThinkingDialect(candidate, dialect)
+			}
+		}
 		// A hedged race drops every candidate but the winner here, so without
 		// this a dead model in a hedged group accrued strikes only on the runs it
 		// happened to win — almost never, since a model answering 404 loses the

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -130,47 +130,40 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 	}()
 	failoverCtx = context.WithValue(failoverCtx, ctxkeys.CancelOriginKey, "failover_timeout")
 
+	// The response is owned by the dispatch at the end of this function, which
+	// closes it on every outcome. On a learnable 400 that ownership passes
+	// through retryLearnable400: the learner consumes and closes the body it
+	// reads, and either hands back a retry response to be closed in its place or
+	// returns this one untouched. bodyclose cannot follow a handover through a
+	// function boundary, so without this it reads the original as leaked.
+	//nolint:bodyclose // closed by the dispatch below, or by retryLearnable400's handover
 	resp, providerType, targetURL, ok := h.beginAttempt(failoverCtx, st, candidate, attempt, totalCandidates, &dialMs)
 	if !ok {
 		return outcomeFailover
 	}
 
-	// Auto-retry param-rejection 400s: parse the error, learn which params
-	// are rejected for this model, strip them, and retry once.
-	// Works universally — any LLM API mentioning "temperature" or "top_p"
-	// in a 400 error can only mean the sampling parameter.
-	//
-	// Skipped on every dialect attempt (see sentChatCompletionsBody): this
-	// self-heal rebuilds the OpenAI-shaped st.bodyBytes via
-	// paramrewrite.BuildUpstreamBody and re-POSTs it to the same targetURL, which
-	// for a native /v1/messages, /v1/responses or generateContent route is a
-	// malformed request — and those endpoints' 400s name their own fields, not
-	// OpenAI's. A dialect 400 fails over or is forwarded as-is.
-	//
-	// Ordering, for the chat-completions case: retryWithResponses runs BEFORE the
-	// param retry because a Responses-required 400 names reasoning_effort, which
-	// the param parser would otherwise learn as a strip (useless on
-	// reason-by-default models).
-	if resp.StatusCode == 400 && st.sentChatCompletionsBody() {
-		res, handled := h.retryWithResponses(r, st, candidate, providerType, resp, attempt, &dialMs, failoverCancel, streamCancelOrigin)
-		if !handled {
-			res = h.retryWithStrippedParams(r, st, candidate, providerType, targetURL, resp, attempt, &dialMs, failoverCancel, streamCancelOrigin)
-		}
-		resp = res.resp
-		streamCancelOrigin = res.streamCancelOrigin
-		retryCancel = res.retryCancel
-		if res.retried || res.cont {
-			// Accumulate the retries' dial time into the total. The cont path is
-			// included because a transport failure on one round must not discard
-			// what the rounds before it already spent dialling; dialMs is zero
-			// when no round got that far, so the fold is a no-op there.
-			st.timings.dialMs += dialMs
-			dialMs = 0
-			st.proxyOverhead = st.timings.proxyOverheadMs(st.parseMs)
-		}
-		if res.cont {
-			st.setReqErr(res.lastReqErr)
-			return outcomeFailover
+	// Auto-retry learnable 400s (see retryLearnable400 for which are learnable in
+	// which dialect). A 400 nothing can learn from is left exactly as it arrived,
+	// to fail over or be forwarded to the client.
+	if resp.StatusCode == 400 {
+		res, handled := h.retryLearnable400(r, st, candidate, providerType, targetURL, resp, attempt, &dialMs, failoverCancel, streamCancelOrigin)
+		if handled {
+			resp = res.resp
+			streamCancelOrigin = res.streamCancelOrigin
+			retryCancel = res.retryCancel
+			if res.retried || res.cont {
+				// Accumulate the retries' dial time into the total. The cont path is
+				// included because a transport failure on one round must not discard
+				// what the rounds before it already spent dialling; dialMs is zero
+				// when no round got that far, so the fold is a no-op there.
+				st.timings.dialMs += dialMs
+				dialMs = 0
+				st.proxyOverhead = st.timings.proxyOverheadMs(st.parseMs)
+			}
+			if res.cont {
+				st.setReqErr(res.lastReqErr)
+				return outcomeFailover
+			}
 		}
 	}
 
@@ -489,6 +482,14 @@ func (h *Handler) buildCandidateRequest(ctx context.Context, st *requestState, c
 	st.responsesAttempt = false
 	st.geminiAttempt = false
 	st.anthropicEgressAttempt = false
+	// The Messages self-heal is per candidate too. Within one attempt it cannot
+	// fire twice — attemptCandidate consults it from a single branch, not a loop
+	// — so carrying the flag forward would only deny the NEXT candidate a
+	// self-heal it has not used yet, which is precisely the multi-provider case
+	// a failover group exists for. Each candidate is a different model behind a
+	// different endpoint, with its own facts to learn.
+	st.messagesRetried = false
+	st.lastMessagesBody = nil
 	if st.anthropicNativeAttempt {
 		return h.buildNativeAnthropicRequest(ctx, st, candidate, providerType)
 	}
@@ -995,6 +996,49 @@ func candidateModelID(candidate modelCandidate) string {
 		return ""
 	}
 	return candidate.model.ModelID
+}
+
+// retryLearnable400 picks the self-heal that fits what this attempt actually
+// sent, and reports handled=false when none does. Each family can only read the
+// dialect it speaks: a 400 names the fields of the request that earned it, so a
+// reading taken from the wrong dialect is not merely useless but harmful — a
+// param mislearned from a Messages 400 would poison the compat path for that
+// model on every later request.
+//
+// Chat-completions attempts get two, in this order: retryWithResponses runs
+// BEFORE the param retry because a Responses-required 400 names
+// reasoning_effort, which the param parser would otherwise learn as a strip
+// (useless on reason-by-default models). The param retry itself works
+// universally — any LLM API naming "temperature" or "top_p" in a 400 can only
+// mean the sampling parameter — but it rebuilds the OpenAI-shaped st.bodyBytes
+// and re-POSTs it to the same targetURL, which for a native /v1/messages,
+// /v1/responses or generateContent route would be a malformed request.
+//
+// Anthropic egress attempts get the one 400 that route can fix by asking
+// differently: a model refusing the extended-thinking shape it was asked in
+// (anthropic_thinking_retry.go). Every other Messages 400 is left alone.
+func (h *Handler) retryLearnable400(
+	r *http.Request,
+	st *requestState,
+	candidate modelCandidate,
+	providerType, targetURL string,
+	resp *http.Response,
+	attempt int,
+	dialMs *float64,
+	failoverCancel context.CancelFunc,
+	streamCancelOrigin string,
+) (paramRetryResult, bool) {
+	switch {
+	case st.anthropicEgressAttempt:
+		return h.retryLearnableMessages400(r, st, candidate, providerType, resp, attempt, dialMs, failoverCancel, streamCancelOrigin)
+	case st.sentChatCompletionsBody():
+		res, handled := h.retryWithResponses(r, st, candidate, providerType, resp, attempt, dialMs, failoverCancel, streamCancelOrigin)
+		if !handled {
+			res = h.retryWithStrippedParams(r, st, candidate, providerType, targetURL, resp, attempt, dialMs, failoverCancel, streamCancelOrigin)
+		}
+		return res, true
+	}
+	return paramRetryResult{resp: resp, streamCancelOrigin: streamCancelOrigin}, false
 }
 
 // learnRejectedParams caches the params and renames a 400 body names, so later

--- a/internal/proxy/types.go
+++ b/internal/proxy/types.go
@@ -219,12 +219,23 @@ type requestState struct {
 
 	// Anthropic egress adapter (zero value = plain chat-completions).
 	// anthropicEgressAttempt is set per failover attempt by
-	// buildCandidateRequest: true when the current candidate is an Anthropic
-	// provider served through the internal/anthropicegress translation (the
-	// request carries a document its OpenAI-compat endpoint cannot express),
-	// read by the response dispatch so it translates the Messages body/stream
-	// back to the chat-completions shape the pipeline and client expect.
+	// buildCandidateRequest: true when the current candidate is served through
+	// the internal/anthropicegress translation (every chat request to an
+	// anthropic-messages provider, and an anthropic one carrying a document its
+	// OpenAI-compat endpoint cannot express), read by the response dispatch so
+	// it translates the Messages body/stream back to the chat-completions shape
+	// the pipeline and client expect.
 	anthropicEgressAttempt bool
+	// messagesRetried marks that this candidate's request has already been
+	// re-issued once by the Messages-route self-heal (see
+	// anthropic_thinking_retry.go). A 400 after that is about something the
+	// self-heal cannot fix, so the attempt ends rather than asking a third time.
+	// Reset per candidate with the dialect flags above.
+	messagesRetried bool
+	// lastMessagesBody is the Messages body of the current egress attempt, kept
+	// so the self-heal can tell whether a rebuild actually changed anything.
+	// Re-issuing an identical body would earn an identical 400.
+	lastMessagesBody []byte
 
 	// Populated by resolveCandidates (phase B).
 	timings    resolveTimings

--- a/wiki/Model-Discovery.md
+++ b/wiki/Model-Discovery.md
@@ -321,7 +321,33 @@ Model metadata, `owned_by` included, is produced exactly as for `anthropic`: the
 
 The one real difference from `anthropic`: **every chat request is translated**, not just the ones carrying a document. An `anthropic` provider defaults to Anthropic's OpenAI-compat `/v1/chat/completions` and only re-routes through `internal/anthropicegress` for content that endpoint cannot express; an `anthropic-messages` provider has no compat endpoint at all, so all of its chat traffic goes to `/v1/messages` through the same adapter. A client that speaks Anthropic natively (`/v1/messages` in, see `anthropic_native.go`) is forwarded verbatim in both directions, so `cache_control` and thinking blocks survive.
 
+Because everything is translated, `reasoning_effort` is honoured on this type (and only this type: `anthropic` strips it, since its default route has no thinking control and honouring it on document requests alone would make one request reason and the next not). See **Extended thinking** below.
+
 Discovery fails loudly if the endpoint does not serve the listing, rather than adding a provider whose models were never confirmed to exist.
+
+#### Extended thinking
+
+An OpenAI client asks for reasoning with `reasoning_effort`, and Anthropic takes that request in one of two mutually exclusive shapes:
+
+| Shape | Request | Models |
+|-------|---------|--------|
+| adaptive | `thinking: {type: "adaptive"}` + `output_config: {effort}` | the newer ones; the model chooses how much to think under the ceiling |
+| budget | `thinking: {type: "enabled", budget_tokens}` | the older ones; a fixed token allowance |
+
+Nothing in a model id says which it takes, and the split is not generational. Measured live on 2026-08-20: `claude-opus-5` and `claude-sonnet-5` accept adaptive **only**, `claude-opus-4-5` and `claude-haiku-4-5` accept budget **only**, and `claude-sonnet-4-6` accepts **both**. A third-party Messages endpoint may serve model ids that follow no Anthropic naming convention at all.
+
+So the dialect is learned rather than guessed. MH asks in the adaptive shape (what current models want), and if the upstream refuses with the 400 that names the other shape, it records the dialect for that provider+model and re-issues the request once. The caller sees the answer, not the 400, and no later request to that model pays the extra round-trip. The cache is in memory and per instance, like the learned param caches: relearning after a restart costs one 400, and the alternative is a stored fact that goes stale when Anthropic moves a model between dialects. See `internal/proxy/anthropic_thinking_retry.go`.
+
+The same self-heal covers the other per-model fact no id reveals: **a param the model has retired.** `claude-sonnet-5` and `claude-opus-5` answer `` `temperature` is deprecated for this model `` while every 4.x model accepts it, and OpenAI clients send `temperature` as a matter of course, so this is the more common of the two. A Messages 400 naming a rejected param is learned into the same `deprecationCache` the compat path uses and the request re-issued without it. Learning is deliberately restricted to `anthropic-messages` providers, whose only route is Messages: the cache is keyed by provider+model, so learning a strip from a Messages 400 on an `anthropic` provider could remove a param from that model's compat traffic, which accepts it.
+
+One retry covers both, because they cannot co-occur: a thinking request has already had its sampling params dropped, and a request without thinking cannot earn a dialect complaint.
+
+Two consequences worth knowing:
+
+- **Sampling params are dropped from a thinking request.** Anthropic rejects any `temperature` but 1 when thinking is on, in either shape, and treats `top_p`/`top_k` the same way. A caller who asks to think is asking about reasoning depth, so the reasoning request wins and the sampling knobs go.
+- **A small `max_tokens` is raised.** Thinking tokens come out of the same allowance as the answer, so a tight budget can be spent entirely on thinking: a live `claude-sonnet-5` given `max_tokens: 30` returned 29 thinking tokens, no text, and `finish_reason: "length"`. An adaptive request with a smaller allowance is raised to the default, and a budget request is raised above its budget.
+
+Effort maps across directly: `low`/`medium`/`high` are common to both scales, OpenAI's `minimal` floors to Anthropic's `low`, and Anthropic's two extra levels (`xhigh`, `max`) are honoured if a client names them. Anything else (`none`, absent) leaves thinking off and the sampling params intact.
 
 ### AWS Bedrock
 


### PR DESCRIPTION
An OpenAI client asks for reasoning with `reasoning_effort`. On an `anthropic-messages` provider every chat request is already translated, so that param can become a real Anthropic thinking request instead of being stripped.

## Why it needs a self-heal

Anthropic takes thinking in two mutually exclusive shapes, and nothing in a model id says which one a model accepts. Measured live, 2026-08-20:

| model | `thinking:{type:"adaptive"}` + `output_config.effort` | `thinking:{type:"enabled",budget_tokens}` |
|-------|:---:|:---:|
| claude-opus-5, claude-sonnet-5 | yes | **400** |
| claude-sonnet-4-6 | yes | yes |
| claude-opus-4-5, claude-haiku-4-5 | **400** | yes |

Not a generational split, and a third-party Messages endpoint may serve ids following no Anthropic convention at all. So the dialect is learned rather than derived: ask in the adaptive shape, and on the 400 that names the other one, record it for this provider+model and re-issue once. The caller sees the answer, not the 400, and no later request to that model pays the round trip. Same in-memory, per-instance treatment as the learned param caches, for the same reason: a stored fact would go stale the next time Anthropic moves a model between dialects.

## A bug this found

While testing the above: `claude-sonnet-5` and `claude-opus-5` answer `` `temperature` is deprecated for this model ``, while every 4.x model accepts it. OpenAI clients send `temperature` as a matter of course, so **a plain request to a Claude 5 model through an `anthropic-messages` provider was 400ing** before this — a far more common shape than `reasoning_effort`.

Same per-model, unguessable pattern, so the same self-heal covers it: a Messages 400 naming a rejected param is learned into the same `deprecationCache` the compat path uses and the request re-issued without it. Learning is scoped to `anthropic-messages` providers only — the cache is keyed by provider+model, so learning a strip from a Messages 400 on an `anthropic` provider could remove a param from that model's compat traffic, which accepts it.

One retry serves both, because they cannot co-occur: a thinking request has already had its sampling params dropped (Anthropic rejects them alongside thinking, in either shape), and a request without thinking cannot earn a dialect complaint.

## Notes

- The two 400 self-heals now dispatch through one `retryLearnable400`, which picks the learner that fits the dialect actually sent. Each can only read the dialect it speaks: a param mislearned from a Messages 400 would poison the compat path for that model on every later request. The pre-existing chat-completions chain is unchanged in behaviour.
- A too-small `max_tokens` is raised on an adaptive request. Thinking comes out of the same allowance as the answer, so a tight budget is spent entirely on thinking: live, `claude-sonnet-5` given `max_tokens: 30` returned 29 thinking tokens, no text, and `finish_reason: "length"`.
- Effort maps directly: `low`/`medium`/`high` are common to both scales, OpenAI's `minimal` floors to `low`, and Anthropic's `xhigh`/`max` are honoured if named.
- Review flagged that the retry guard did not reset per candidate, which would have denied the second Anthropic candidate in a failover group a self-heal it never used. Fixed and mutation-tested.

## Verification

Live against `api.anthropic.com`: effort reaches the model (the same puzzle cost 50 completion tokens at `low` and 223 at `max`), a budget-only model self-heals (`learned anthropic thinking dialect ... dialect=budget` then `retry issued ... status=200`) and the next request skips the refusal, the `temperature` 400 is gone, and tools, streaming, native `/v1/messages` passthrough and the Test button all still work.

6287 backend tests, golangci-lint and gofmt clean, 90.9% diff coverage on changed lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)