### PR TITLE
fix(security): enforce webauthn ceremony TTL, bind stats owner id, pin sort whitelists

### DIFF
--- a/internal/adminauth/webauthn.go
+++ b/internal/adminauth/webauthn.go
@@ -240,6 +240,16 @@ func (h *WebAuthnHandler) RegisterFinish(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	// Enforce the ceremony TTL at consume time: the hourly cleanup sweep is the
+	// only other thing that removes stale rows, and the go-webauthn library only
+	// checks SessionData.Expires when Timeouts.*.Enforce is configured — mirrors
+	// webauthn.SessionManager.ConsumeLoginState.
+	if sessionRec.ExpiresAt.Before(time.Now()) {
+		debuglog.Info("webauthn: registration session expired", "session_id", sessionID)
+		http.Error(w, "session expired", http.StatusBadRequest)
+		return
+	}
+
 	var session webauthnx.SessionData
 	if err := json.Unmarshal(sessionRec.SessionData, &session); err != nil {
 		debuglog.Error("webauthn: failed to unmarshal session data", "session_id", sessionID, "error", err)
@@ -373,6 +383,16 @@ func (h *WebAuthnHandler) LoginFinish(w http.ResponseWriter, r *http.Request) {
 	if err := h.webauthnRepo.DeleteSession(r.Context(), sessionID); err != nil {
 		debuglog.Info("webauthn: login session already consumed", "session_id", sessionID, "error", err)
 		respondError(w, "session not found", err, http.StatusBadRequest)
+		return
+	}
+
+	// Enforce the ceremony TTL at consume time: the hourly cleanup sweep is the
+	// only other thing that removes stale rows, and the go-webauthn library only
+	// checks SessionData.Expires when Timeouts.*.Enforce is configured — mirrors
+	// webauthn.SessionManager.ConsumeLoginState.
+	if sessionRec.ExpiresAt.Before(time.Now()) {
+		debuglog.Info("webauthn: login session expired", "session_id", sessionID)
+		http.Error(w, "session expired", http.StatusBadRequest)
 		return
 	}
 

--- a/internal/adminauth/webauthn.go
+++ b/internal/adminauth/webauthn.go
@@ -240,13 +240,16 @@ func (h *WebAuthnHandler) RegisterFinish(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// Enforce the ceremony TTL at consume time: the hourly cleanup sweep is the
-	// only other thing that removes stale rows, and the go-webauthn library only
-	// checks SessionData.Expires when Timeouts.*.Enforce is configured — mirrors
-	// webauthn.SessionManager.ConsumeLoginState.
+	// Enforce the ceremony TTL at consume time, as
+	// webauthn.SessionManager.ConsumeLoginState does: the hourly cleanup sweep is
+	// the only other thing that removes stale rows, and the go-webauthn library
+	// only checks SessionData.Expires when Timeouts.*.Enforce is configured.
+	// The response stays the generic "session not found" so a probing caller
+	// cannot tell an expired ceremony from an unknown one; the reason is kept in
+	// the log line.
 	if sessionRec.ExpiresAt.Before(time.Now()) {
 		debuglog.Info("webauthn: registration session expired", "session_id", sessionID)
-		http.Error(w, "session expired", http.StatusBadRequest)
+		http.Error(w, "session not found", http.StatusBadRequest)
 		return
 	}
 
@@ -386,13 +389,16 @@ func (h *WebAuthnHandler) LoginFinish(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Enforce the ceremony TTL at consume time: the hourly cleanup sweep is the
-	// only other thing that removes stale rows, and the go-webauthn library only
-	// checks SessionData.Expires when Timeouts.*.Enforce is configured — mirrors
-	// webauthn.SessionManager.ConsumeLoginState.
+	// Enforce the ceremony TTL at consume time, as
+	// webauthn.SessionManager.ConsumeLoginState does: the hourly cleanup sweep is
+	// the only other thing that removes stale rows, and the go-webauthn library
+	// only checks SessionData.Expires when Timeouts.*.Enforce is configured.
+	// The response stays the generic "session not found" so a probing caller
+	// cannot tell an expired ceremony from an unknown one; the reason is kept in
+	// the log line.
 	if sessionRec.ExpiresAt.Before(time.Now()) {
 		debuglog.Info("webauthn: login session expired", "session_id", sessionID)
-		http.Error(w, "session expired", http.StatusBadRequest)
+		http.Error(w, "session not found", http.StatusBadRequest)
 		return
 	}
 

--- a/internal/adminauth/webauthn_expiry_test.go
+++ b/internal/adminauth/webauthn_expiry_test.go
@@ -70,8 +70,13 @@ func TestWebAuthnHandler_RegisterFinish_ExpiredSession(t *testing.T) {
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("expected status %d, got %d; body: %s", http.StatusBadRequest, w.Code, w.Body.String())
 	}
-	if !strings.Contains(w.Body.String(), "session expired") {
-		t.Errorf("expected 'session expired' error, got: %s", w.Body.String())
+	// The body is deliberately the generic "session not found" (no expired-vs-
+	// unknown oracle). Without the guard the handler would fall through to
+	// credential parsing and answer "invalid credential response" instead, so
+	// this assertion still pins the guard: the session exists and its delete
+	// succeeds, leaving the expiry check as the only path to this response.
+	if !strings.Contains(w.Body.String(), "session not found") {
+		t.Errorf("expected 'session not found' error, got: %s", w.Body.String())
 	}
 	// The expired session must be consumed, not left claimable.
 	if _, err := repo.GetSession(context.Background(), sessionID); !errors.Is(err, webauthn.ErrNotFound) {
@@ -98,8 +103,13 @@ func TestWebAuthnHandler_LoginFinish_ExpiredSession(t *testing.T) {
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("expected status %d, got %d; body: %s", http.StatusBadRequest, w.Code, w.Body.String())
 	}
-	if !strings.Contains(w.Body.String(), "session expired") {
-		t.Errorf("expected 'session expired' error, got: %s", w.Body.String())
+	// The body is deliberately the generic "session not found" (no expired-vs-
+	// unknown oracle). Without the guard the handler would fall through to
+	// credential parsing and answer "invalid credential response" instead, so
+	// this assertion still pins the guard: the session exists and its delete
+	// succeeds, leaving the expiry check as the only path to this response.
+	if !strings.Contains(w.Body.String(), "session not found") {
+		t.Errorf("expected 'session not found' error, got: %s", w.Body.String())
 	}
 	// The expired session must be consumed, not left claimable.
 	if _, err := repo.GetSession(context.Background(), sessionID); !errors.Is(err, webauthn.ErrNotFound) {

--- a/internal/adminauth/webauthn_expiry_test.go
+++ b/internal/adminauth/webauthn_expiry_test.go
@@ -1,0 +1,108 @@
+package adminauth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/hugalafutro/model-hotel/internal/webauthn"
+)
+
+// expiredCeremonySession stores a ceremony session whose expires_at is already
+// in the past, simulating a challenge issued longer ago than the ceremony TTL.
+func expiredCeremonySession(t *testing.T, repo *webauthn.Repository, sessionType string) uuid.UUID {
+	t.Helper()
+	sessionID := uuid.New()
+	session := &webauthn.SessionRecord{
+		ID:          sessionID,
+		Challenge:   "test-challenge",
+		SessionData: []byte(`{"challenge":"test-challenge"}`),
+		Type:        sessionType,
+		UserID:      []byte("admin"),
+		ExpiresAt:   time.Now().Add(-1 * time.Minute),
+	}
+	if err := repo.CreateSession(context.Background(), session); err != nil {
+		t.Fatalf("failed to create session: %v", err)
+	}
+	t.Cleanup(func() {
+		repo.DeleteSession(context.Background(), sessionID)
+	})
+	return sessionID
+}
+
+func expiryTestRepo(t *testing.T) *webauthn.Repository {
+	t.Helper()
+	if apiTestDBURL == "" {
+		t.Fatal("test database not available")
+	}
+	pool, err := pgxpool.New(context.Background(), apiTestDBURL)
+	if err != nil {
+		t.Fatal("test database not available")
+	}
+	t.Cleanup(pool.Close)
+	return webauthn.NewRepository(pool)
+}
+
+// TestWebAuthnHandler_RegisterFinish_ExpiredSession tests that a registration
+// ceremony session past its expires_at is rejected instead of waiting for the
+// hourly cleanup sweep to remove it.
+func TestWebAuthnHandler_RegisterFinish_ExpiredSession(t *testing.T) {
+	repo := expiryTestRepo(t)
+	adminMgr := &mockAdminAuth{validateFn: func(token string) bool { return true }}
+	h := newTestWebAuthnHandler(repo, nil, nil, adminMgr)
+
+	sessionID := expiredCeremonySession(t, repo, "registration")
+
+	body := `{"session_id": "` + sessionID.String() + `", "credential": {}}`
+	req := httptest.NewRequest(http.MethodPost, "/webauthn/register/finish", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	h.RegisterFinish(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected status %d, got %d; body: %s", http.StatusBadRequest, w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "session expired") {
+		t.Errorf("expected 'session expired' error, got: %s", w.Body.String())
+	}
+	// The expired session must be consumed, not left claimable.
+	if _, err := repo.GetSession(context.Background(), sessionID); !errors.Is(err, webauthn.ErrNotFound) {
+		t.Errorf("expected expired session to be deleted, GetSession err = %v", err)
+	}
+}
+
+// TestWebAuthnHandler_LoginFinish_ExpiredSession tests that a login ceremony
+// session past its expires_at is rejected instead of waiting for the hourly
+// cleanup sweep to remove it.
+func TestWebAuthnHandler_LoginFinish_ExpiredSession(t *testing.T) {
+	repo := expiryTestRepo(t)
+	h := newTestWebAuthnHandler(repo, nil, nil, nil)
+
+	sessionID := expiredCeremonySession(t, repo, "login")
+
+	body := `{"session_id": "` + sessionID.String() + `", "credential": {}}`
+	req := httptest.NewRequest(http.MethodPost, "/webauthn/login/finish", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	h.LoginFinish(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected status %d, got %d; body: %s", http.StatusBadRequest, w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "session expired") {
+		t.Errorf("expected 'session expired' error, got: %s", w.Body.String())
+	}
+	// The expired session must be consumed, not left claimable.
+	if _, err := repo.GetSession(context.Background(), sessionID); !errors.Is(err, webauthn.ErrNotFound) {
+		t.Errorf("expected expired session to be deleted, GetSession err = %v", err)
+	}
+}

--- a/internal/api/handler_stats_test.go
+++ b/internal/api/handler_stats_test.go
@@ -1086,7 +1086,7 @@ func TestStats_StatTotalsWithExcludeDeleted(t *testing.T) {
 	err := handler.statTotals(context.Background(), stats,
 		" LEFT JOIN virtual_keys vk ON rl.virtual_key_id = vk.id",
 		" AND (rl.virtual_key_id IS NULL OR vk.id IS NOT NULL)",
-		24*time.Hour, since, now)
+		nil, 24*time.Hour, since, now)
 	if err != nil {
 		t.Fatalf("statTotals with excludeDeleted: %v", err)
 	}
@@ -1138,7 +1138,7 @@ func TestStats_StatTotalsWith7dPeriod(t *testing.T) {
 	since := now.Add(-7 * 24 * time.Hour)
 
 	err := handler.statTotals(context.Background(), stats, "", "",
-		7*24*time.Hour, since, now)
+		nil, 7*24*time.Hour, since, now)
 	if err != nil {
 		t.Fatalf("statTotals with 7d period: %v", err)
 	}

--- a/internal/api/logs.go
+++ b/internal/api/logs.go
@@ -666,6 +666,36 @@ func (h *Handler) PurgeLogs(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// logsSortDef resolves a user-supplied sort_by value to its ORDER BY
+// expressions, normalizing anything outside the whitelist to "time". Every
+// expression is a fixed compile-time constant; user input only ever selects a
+// map key, never reaches the SQL.
+func logsSortDef(sortBy string) (string, logSortDef) {
+	sortColumns := map[string]logSortDef{
+		"time":               {"", "rl.created_at"},
+		"model":              {"", "rl.model_id"},
+		"provider":           {"CASE WHEN rl.provider_id IS NULL THEN 2 WHEN p.name IS NULL THEN 1 ELSE 0 END", "CASE WHEN rl.provider_id IS NULL THEN '' WHEN p.name IS NOT NULL THEN p.name ELSE 'Deleted' END"},
+		"status":             {"", "rl.status_code"},
+		"tokens":             {"CASE WHEN rl.tokens_prompt + rl.tokens_completion + COALESCE(rl.tokens_completion_reasoning, 0) = 0 THEN CASE WHEN COALESCE(rl.error_message, '') ILIKE '%cancel%' OR COALESCE(rl.error_message, '') ILIKE '%disconnect%' OR COALESCE(rl.error_message, '') ILIKE '%context canceled%' THEN 1 ELSE 2 END ELSE 0 END", "rl.tokens_prompt + rl.tokens_completion + COALESCE(rl.tokens_completion_reasoning, 0)"},
+		"tps":                {"CASE WHEN rl.tokens_per_second = 0 THEN 1 ELSE 0 END", "rl.tokens_per_second"},
+		"ttft":               {"CASE WHEN rl.ttft_ms = 0 THEN 1 ELSE 0 END", "rl.ttft_ms"},
+		"response_header_ms": {"CASE WHEN rl.response_header_ms = 0 THEN 1 ELSE 0 END", "rl.response_header_ms"},
+		"duration":           {"CASE WHEN rl.duration_ms = 0 THEN 1 ELSE 0 END", "rl.duration_ms"},
+		"overhead":           {"CASE WHEN rl.proxy_overhead_ms = 0 THEN 1 ELSE 0 END", "rl.proxy_overhead_ms"},
+		"key":                {"", "CASE WHEN rl.virtual_key_id IS NOT NULL AND rl.virtual_key_id::text != '' AND vk.id IS NULL THEN 'zzzzzzzz' ELSE COALESCE(rl.virtual_key_name, '') END"},
+	}
+	if _, ok := sortColumns[sortBy]; !ok {
+		sortBy = "time"
+	}
+	return sortBy, sortColumns[sortBy]
+}
+
+// logSortDef holds the tier and value ORDER BY expressions for one sort key.
+type logSortDef struct {
+	tierExpr  string
+	valueExpr string
+}
+
 // ListLogs returns paginated request logs with filtering and sorting.
 func (h *Handler) ListLogs(w http.ResponseWriter, r *http.Request) {
 	page := max(util.GetIntQueryParam(r, "page", 1), 1)
@@ -681,31 +711,8 @@ func (h *Handler) ListLogs(w http.ResponseWriter, r *http.Request) {
 	fromDate := r.URL.Query().Get("from")
 	toDate := r.URL.Query().Get("to")
 	endpointType := r.URL.Query().Get("endpoint_type")
-	sortBy := r.URL.Query().Get("sort_by")
+	sortBy, sd := logsSortDef(r.URL.Query().Get("sort_by"))
 	sortDir := r.URL.Query().Get("sort_dir")
-
-	type sortDef struct {
-		tierExpr  string
-		valueExpr string
-	}
-
-	sortColumns := map[string]sortDef{
-		"time":               {"", "rl.created_at"},
-		"model":              {"", "rl.model_id"},
-		"provider":           {"CASE WHEN rl.provider_id IS NULL THEN 2 WHEN p.name IS NULL THEN 1 ELSE 0 END", "CASE WHEN rl.provider_id IS NULL THEN '' WHEN p.name IS NOT NULL THEN p.name ELSE 'Deleted' END"},
-		"status":             {"", "rl.status_code"},
-		"tokens":             {"CASE WHEN rl.tokens_prompt + rl.tokens_completion + COALESCE(rl.tokens_completion_reasoning, 0) = 0 THEN CASE WHEN COALESCE(rl.error_message, '') ILIKE '%cancel%' OR COALESCE(rl.error_message, '') ILIKE '%disconnect%' OR COALESCE(rl.error_message, '') ILIKE '%context canceled%' THEN 1 ELSE 2 END ELSE 0 END", "rl.tokens_prompt + rl.tokens_completion + COALESCE(rl.tokens_completion_reasoning, 0)"},
-		"tps":                {"CASE WHEN rl.tokens_per_second = 0 THEN 1 ELSE 0 END", "rl.tokens_per_second"},
-		"ttft":               {"CASE WHEN rl.ttft_ms = 0 THEN 1 ELSE 0 END", "rl.ttft_ms"},
-		"response_header_ms": {"CASE WHEN rl.response_header_ms = 0 THEN 1 ELSE 0 END", "rl.response_header_ms"},
-		"duration":           {"CASE WHEN rl.duration_ms = 0 THEN 1 ELSE 0 END", "rl.duration_ms"},
-		"overhead":           {"CASE WHEN rl.proxy_overhead_ms = 0 THEN 1 ELSE 0 END", "rl.proxy_overhead_ms"},
-		"key":                {"", "CASE WHEN rl.virtual_key_id IS NOT NULL AND rl.virtual_key_id::text != '' AND vk.id IS NULL THEN 'zzzzzzzz' ELSE COALESCE(rl.virtual_key_name, '') END"},
-	}
-
-	if _, ok := sortColumns[sortBy]; !ok {
-		sortBy = "time"
-	}
 	if sortDir != "asc" && sortDir != "desc" {
 		sortDir = "desc"
 	}
@@ -725,7 +732,6 @@ func (h *Handler) ListLogs(w http.ResponseWriter, r *http.Request) {
 	argIndex := 1
 	query, args, argIndex = appendLogFilters(query, args, argIndex, modelID, providerID, statusCodeStr, fromDate, toDate, endpointType, ownerUserID)
 
-	sd := sortColumns[sortBy]
 	orderClause := " ORDER BY "
 	if sd.tierExpr != "" {
 		orderClause += sd.tierExpr + " ASC, "

--- a/internal/api/logs_ownerscope_test.go
+++ b/internal/api/logs_ownerscope_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
 
 	"github.com/hugalafutro/model-hotel/internal/user"
 )
@@ -288,6 +289,88 @@ func TestStats_OwnerScope(t *testing.T) {
 	}
 	if s := getStats("/stats?period=7d&owner_user_id="+fx.bobID, envAdminToken); s.TotalRequestsLast7d != 2 {
 		t.Errorf("admin owner-filtered total7d = %d, want 2", s.TotalRequestsLast7d)
+	}
+}
+
+// TestStats_OwnerScope_ScalarsAndLatency covers the two owner-scoped stats
+// helpers whose failures are silent: statScalars and statLatencyBreakdown both
+// log and zero their fields rather than returning an error, so a wrong bind
+// index in either would hand scoped users an empty latency chart and zeroed
+// scalars while every other assertion stayed green.
+func TestStats_OwnerScope_ScalarsAndLatency(t *testing.T) {
+	router, loginAs, mkUser := setupOwnershipTest(t)
+	pool := apiTestDB.Pool()
+	if _, err := pool.Exec(context.Background(), `TRUNCATE request_logs`); err != nil {
+		t.Fatalf("truncate request_logs: %v", err)
+	}
+	globalLogsCache.clear()
+
+	aliceID := mkUser("latency-alice", []string{string(user.GrantLogs), string(user.GrantUsage)})
+	aliceToken := loginAs(aliceID)
+
+	providerID := uuid.New()
+	insertTestProvider(t, pool, providerID, "latency-provider", "https://api.example.com/v1")
+
+	// The per-provider breakdown needs at least 3 rows per provider (HAVING
+	// COUNT(*) >= 3), so give alice exactly 3 and leave 3 unowned: scoped to
+	// alice the provider still clears the bar, so an empty result means the
+	// scoped query broke rather than the threshold filtering it out.
+	insertOwned := func(model string, owner any) {
+		_, err := pool.Exec(context.Background(),
+			`INSERT INTO request_logs (provider_id, model_id, status_code, duration_ms, proxy_overhead_ms, tokens_prompt, tokens_completion, owner_user_id, created_at)
+			 VALUES ($1, $2, 200, 500, 20, 100, 50, $3, NOW())`, providerID, model, owner)
+		if err != nil {
+			t.Fatalf("insert log: %v", err)
+		}
+	}
+	for i := range 3 {
+		insertOwned(fmt.Sprintf("alice-model-%d", i), aliceID)
+		insertOwned(fmt.Sprintf("unowned-model-%d", i), nil)
+	}
+
+	getStats := func(token string) StatsResponse {
+		w := doJSON(t, router, http.MethodGet, "/stats?period=7d&include_latency=true", token, "")
+		if w.Code != http.StatusOK {
+			t.Fatalf("GET stats: %d %s", w.Code, w.Body.String())
+		}
+		var s StatsResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &s); err != nil {
+			t.Fatalf("decode stats: %v", err)
+		}
+		return s
+	}
+
+	alice := getStats(aliceToken)
+	// statScalars, scoped: the 1h count builds its own arg list, separate from
+	// the other scalar queries, so it is asserted explicitly.
+	if alice.RequestsLast1h != 3 {
+		t.Errorf("alice requests_last_1h = %d, want 3", alice.RequestsLast1h)
+	}
+	if alice.TotalTokensPrompt != 300 || alice.TotalTokensCompletion != 150 {
+		t.Errorf("alice tokens = %d/%d, want 300/150",
+			alice.TotalTokensPrompt, alice.TotalTokensCompletion)
+	}
+	if alice.AvgLatencyMs != 500 {
+		t.Errorf("alice avg_latency_ms = %v, want 500", alice.AvgLatencyMs)
+	}
+	if alice.AvgOverheadMs != 20 {
+		t.Errorf("alice avg_overhead_ms = %v, want 20", alice.AvgOverheadMs)
+	}
+	// statLatencyBreakdown, scoped.
+	if len(alice.ByProviderLatency) != 1 {
+		t.Fatalf("alice by_provider_latency = %d entries, want 1", len(alice.ByProviderLatency))
+	}
+	if got := alice.ByProviderLatency[0]; got.ProviderName != "latency-provider" || got.RequestCount != 3 {
+		t.Errorf("alice latency entry = %s/%d, want latency-provider/3", got.ProviderName, got.RequestCount)
+	}
+
+	// Admin is unscoped and sees all six rows through the same helpers.
+	admin := getStats(envAdminToken)
+	if admin.RequestsLast1h != 6 {
+		t.Errorf("admin requests_last_1h = %d, want 6", admin.RequestsLast1h)
+	}
+	if len(admin.ByProviderLatency) != 1 || admin.ByProviderLatency[0].RequestCount != 6 {
+		t.Errorf("admin latency entry = %+v, want one entry counting 6", admin.ByProviderLatency)
 	}
 }
 

--- a/internal/api/sort_whitelist_test.go
+++ b/internal/api/sort_whitelist_test.go
@@ -60,6 +60,36 @@ func TestLogsSortDef_Whitelist(t *testing.T) {
 		validSet[k] = true
 	}
 
+	// Pin the expressions too, not just the key set: a future sort key wired to
+	// a dynamically built expression would otherwise slip through.
+	allowedExprs := map[string]bool{
+		"": true, "rl.created_at": true, "rl.model_id": true, "rl.status_code": true,
+		"CASE WHEN rl.provider_id IS NULL THEN 2 WHEN p.name IS NULL THEN 1 ELSE 0 END":                   true,
+		"CASE WHEN rl.provider_id IS NULL THEN '' WHEN p.name IS NOT NULL THEN p.name ELSE 'Deleted' END": true,
+		"CASE WHEN rl.tokens_prompt + rl.tokens_completion + COALESCE(rl.tokens_completion_reasoning, 0) = 0 THEN CASE WHEN COALESCE(rl.error_message, '') ILIKE '%cancel%' OR COALESCE(rl.error_message, '') ILIKE '%disconnect%' OR COALESCE(rl.error_message, '') ILIKE '%context canceled%' THEN 1 ELSE 2 END ELSE 0 END": true,
+		"rl.tokens_prompt + rl.tokens_completion + COALESCE(rl.tokens_completion_reasoning, 0)": true,
+		"CASE WHEN rl.tokens_per_second = 0 THEN 1 ELSE 0 END":                                  true,
+		"rl.tokens_per_second":                       true,
+		"CASE WHEN rl.ttft_ms = 0 THEN 1 ELSE 0 END": true,
+		"rl.ttft_ms": true,
+		"CASE WHEN rl.response_header_ms = 0 THEN 1 ELSE 0 END": true,
+		"rl.response_header_ms":                                 true,
+		"CASE WHEN rl.duration_ms = 0 THEN 1 ELSE 0 END":        true,
+		"rl.duration_ms":                                        true,
+		"CASE WHEN rl.proxy_overhead_ms = 0 THEN 1 ELSE 0 END":  true,
+		"rl.proxy_overhead_ms":                                  true,
+		"CASE WHEN rl.virtual_key_id IS NOT NULL AND rl.virtual_key_id::text != '' AND vk.id IS NULL THEN 'zzzzzzzz' ELSE COALESCE(rl.virtual_key_name, '') END": true,
+	}
+	for _, in := range append(append([]string{}, valid...), hostileSortInputs...) {
+		_, def := logsSortDef(in)
+		if !allowedExprs[def.tierExpr] {
+			t.Errorf("logsSortDef(%q) tier expression %q not in the whitelist", in, def.tierExpr)
+		}
+		if !allowedExprs[def.valueExpr] {
+			t.Errorf("logsSortDef(%q) value expression %q not in the whitelist", in, def.valueExpr)
+		}
+	}
+
 	for _, in := range valid {
 		if key, _ := logsSortDef(in); key != in {
 			t.Errorf("logsSortDef(%q) normalized to %q, want identity", in, key)

--- a/internal/api/sort_whitelist_test.go
+++ b/internal/api/sort_whitelist_test.go
@@ -1,0 +1,99 @@
+package api
+
+import (
+	"net/url"
+	"testing"
+)
+
+// hostileSortInputs are values an attacker could send as sort_by; every sort
+// surface must map them to a fixed whitelisted column, never into the SQL.
+var hostileSortInputs = []string{
+	"",
+	"name; DROP TABLE models;--",
+	"1); DELETE FROM request_logs;--",
+	"created_at, (SELECT pg_sleep(10))",
+	"time'--",
+	"rl.created_at DESC; --",
+	"unknown_key",
+	"NAME",
+	"time ",
+}
+
+// TestModelSortColumn_Whitelist pins modelSortColumn to a closed set of
+// expressions: any input outside the whitelist must resolve to the default
+// name expression. Adding a new sort key requires extending this set, which
+// forces a review of the new column expression.
+func TestModelSortColumn_Whitelist(t *testing.T) {
+	allowed := map[string]bool{
+		"COALESCE(m.last_seen_at, m.created_at)": true,
+		"COALESCE(m.context_length, 0)":          true,
+		"COALESCE(m.max_output_tokens, 0)":       true,
+		"COALESCE(p.name, '')":                   true,
+		"CASE WHEN m.enabled AND NOT m.disabled_manually THEN 0 WHEN m.enabled AND m.disabled_manually THEN 1 ELSE 2 END": true,
+		"COALESCE(m.name, m.model_id, '')": true,
+	}
+	valid := []string{"name", "discovered", "context", "output", "provider", "status"}
+	defaultExpr := modelSortColumn("name")
+
+	for _, in := range append(append([]string{}, valid...), hostileSortInputs...) {
+		if got := modelSortColumn(in); !allowed[got] {
+			t.Errorf("modelSortColumn(%q) = %q, not in the whitelist", in, got)
+		}
+	}
+	for _, in := range hostileSortInputs {
+		if got := modelSortColumn(in); got != defaultExpr {
+			t.Errorf("modelSortColumn(%q) = %q, want default %q", in, got, defaultExpr)
+		}
+	}
+}
+
+// TestLogsSortDef_Whitelist pins the request-log sort resolver to its closed
+// key set: arbitrary input must normalize to one of the known keys, and
+// anything unknown must fall back to "time".
+func TestLogsSortDef_Whitelist(t *testing.T) {
+	valid := []string{
+		"time", "model", "provider", "status", "tokens", "tps", "ttft",
+		"response_header_ms", "duration", "overhead", "key",
+	}
+	validSet := map[string]bool{}
+	for _, k := range valid {
+		validSet[k] = true
+	}
+
+	for _, in := range valid {
+		if key, _ := logsSortDef(in); key != in {
+			t.Errorf("logsSortDef(%q) normalized to %q, want identity", in, key)
+		}
+	}
+	timeKey, timeDef := logsSortDef("time")
+	if timeKey != "time" {
+		t.Fatalf("logsSortDef(\"time\") normalized to %q", timeKey)
+	}
+	for _, in := range hostileSortInputs {
+		key, def := logsSortDef(in)
+		if !validSet[key] {
+			t.Errorf("logsSortDef(%q) normalized to %q, not in the whitelist", in, key)
+		}
+		if key != "time" || def != timeDef {
+			t.Errorf("logsSortDef(%q) = (%q, %+v), want the time fallback", in, key, def)
+		}
+	}
+}
+
+// TestParseAppLogHistoryParams_SortWhitelist pins the app-log history sort to
+// its closed column set and the direction to ASC/DESC only.
+func TestParseAppLogHistoryParams_SortWhitelist(t *testing.T) {
+	allowedCols := map[string]bool{"created_at": true, "level": true, "source": true, "message": true}
+
+	for _, in := range append([]string{"time", "level", "source", "message"}, hostileSortInputs...) {
+		for _, dir := range []string{"asc", "desc", "asc; DROP TABLE app_logs;--", ""} {
+			p := parseAppLogHistoryParams(url.Values{"sort_by": {in}, "sort_dir": {dir}})
+			if !allowedCols[p.sortCol] {
+				t.Errorf("sort_by=%q resolved to column %q, not in the whitelist", in, p.sortCol)
+			}
+			if p.sortDir != "ASC" && p.sortDir != "DESC" {
+				t.Errorf("sort_dir=%q resolved to %q, want ASC or DESC", dir, p.sortDir)
+			}
+		}
+	}
+}

--- a/internal/api/stats.go
+++ b/internal/api/stats.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
+	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
 // StatsHandler provides statistics and analytics API endpoints.
@@ -144,30 +145,29 @@ func vkScope(excludeDeleted bool) (join, filter string) {
 }
 
 // ownerFilterFragment returns a WHERE fragment restricting rows to traffic
-// belonging to ownerID, or "" when unscoped (empty ownerID). It matches the two
-// disjoint row shapes the same way appendLogFilters does: keyed rows through the
-// key's CURRENT owner (so reassigning a key moves its history), keyless rows
-// (dashboard chat/arena) through the request-time owner_user_id stamped on the
-// row itself; see migration 067. The id is inlined
-// as a literal because threading an extra bind arg through every stats query
-// would touch a dozen call sites, so this is the one place that must guarantee
-// the value can never carry SQL. Today the only caller feeds logOwnerScope,
-// which is already uuid.Parse-validated, but this function re-parses defensively
-// so a future caller cannot reintroduce an injection: a non-empty id that is not
-// a valid UUID fails CLOSED to a no-match fragment (" AND 1=0"), never to "" —
-// dropping the filter there would silently widen a scoped query to every owner's
-// rows, an authorization leak. The canonical uuid.String() form is inlined, so
-// only the 36-char hex/hyphen shape ever reaches the query.
-func ownerFilterFragment(ownerID string) string {
+// belonging to ownerID, plus the bind args it needs, or ("", nil) when unscoped
+// (empty ownerID). It matches the two disjoint row shapes the same way
+// appendLogFilters does: keyed rows through the key's CURRENT owner (so
+// reassigning a key moves its history), keyless rows (dashboard chat/arena)
+// through the request-time owner_user_id stamped on the row itself; see
+// migration 067. The id binds through the $argIdx placeholder, so the caller
+// must state how many args the consuming query already carries; every stats
+// query takes a single timestamp, hence argIdx 2 everywhere today. The parse
+// stays as defense in depth: a non-empty id that is not a valid UUID fails
+// CLOSED to a no-match fragment (" AND 1=0"), never to "" — dropping the
+// filter there would silently widen a scoped query to every owner's rows, an
+// authorization leak.
+func ownerFilterFragment(ownerID string, argIdx int) (string, []any) {
 	if ownerID == "" {
-		return ""
+		return "", nil
 	}
 	u, err := uuid.Parse(ownerID)
 	if err != nil {
-		return " AND 1=0"
+		return " AND 1=0", nil
 	}
-	return " AND (rl.virtual_key_id IN (SELECT vko.id FROM virtual_keys vko WHERE vko.owner_user_id = '" + u.String() + "')" +
-		" OR (rl.virtual_key_id IS NULL AND rl.owner_user_id = '" + u.String() + "'))"
+	ph := "$" + util.IntToStr(argIdx)
+	return " AND (rl.virtual_key_id IN (SELECT vko.id FROM virtual_keys vko WHERE vko.owner_user_id = " + ph + ")" +
+		" OR (rl.virtual_key_id IS NULL AND rl.owner_user_id = " + ph + "))", []any{u}
 }
 
 // metricValueSelect returns the aggregate column expression (aliased "val") for
@@ -215,7 +215,7 @@ const modelKeySQL = `
 // statByModel fills stats.ByModel with the top-10 models by the requested
 // metric (Q2). A query failure is fatal (returned); a per-row scan error skips
 // the row, matching the original loop.
-func (h *StatsHandler) statByModel(ctx context.Context, stats *StatsResponse, vkJoin, vkFilter, metric string, since time.Time) error {
+func (h *StatsHandler) statByModel(ctx context.Context, stats *StatsResponse, vkJoin, vkFilter string, filterArgs []any, metric string, since time.Time) error {
 	query := `
 		SELECT
 			` + modelKeySQL + ` as model_id,
@@ -227,7 +227,7 @@ func (h *StatsHandler) statByModel(ctx context.Context, stats *StatsResponse, vk
 		ORDER BY val DESC
 		LIMIT 10`
 
-	rows, err := h.dbPool.Query(ctx, query, since)
+	rows, err := h.dbPool.Query(ctx, query, append([]any{since}, filterArgs...)...)
 	if err != nil {
 		debuglog.Error("stats: query failed", "query", "by_model", "error", err)
 		return err
@@ -247,7 +247,7 @@ func (h *StatsHandler) statByModel(ctx context.Context, stats *StatsResponse, vk
 
 // statByProvider fills stats.ByProvider with the top-10 providers by the
 // requested metric (Q3). Query failure fatal; per-row scan error skips the row.
-func (h *StatsHandler) statByProvider(ctx context.Context, stats *StatsResponse, vkJoin, vkFilter, metric string, since time.Time) error {
+func (h *StatsHandler) statByProvider(ctx context.Context, stats *StatsResponse, vkJoin, vkFilter string, filterArgs []any, metric string, since time.Time) error {
 	query := `
 		SELECT p.name, ` + metricValueSelect(metric) + `
 		FROM request_logs rl
@@ -257,7 +257,7 @@ func (h *StatsHandler) statByProvider(ctx context.Context, stats *StatsResponse,
 		ORDER BY val DESC
 		LIMIT 10`
 
-	rows, err := h.dbPool.Query(ctx, query, since)
+	rows, err := h.dbPool.Query(ctx, query, append([]any{since}, filterArgs...)...)
 	if err != nil {
 		debuglog.Error("stats: query failed", "query", "by_provider", "error", err)
 		return err
@@ -281,16 +281,17 @@ func (h *StatsHandler) statByProvider(ctx context.Context, stats *StatsResponse,
 // virtual_key_name (Q4c). The main query failure is fatal; the two aggregates
 // are best-effort (logged via their nil-error guards, never abort).
 func (h *StatsHandler) statByVirtualKey(ctx context.Context, stats *StatsResponse, metric string, since time.Time, excludeDeleted bool, ownerID string) error {
+	ownerFrag, ownerArgs := ownerFilterFragment(ownerID, 2)
 	virtualKeyQuery := `
 		SELECT vk.name, ` + metricValueSelect(metric) + `
 		FROM request_logs rl
 		JOIN virtual_keys vk ON rl.virtual_key_id = vk.id
-		WHERE rl.created_at >= $1` + ownerFilterFragment(ownerID) + `
+		WHERE rl.created_at >= $1` + ownerFrag + `
 		GROUP BY vk.name
 		ORDER BY val DESC
 		LIMIT 10`
 
-	rows, err := h.dbPool.Query(ctx, virtualKeyQuery, since)
+	rows, err := h.dbPool.Query(ctx, virtualKeyQuery, append([]any{since}, ownerArgs...)...)
 	if err != nil {
 		debuglog.Error("stats: query failed", "query", "by_virtual_key", "error", err)
 		return err
@@ -356,14 +357,16 @@ func (h *StatsHandler) statByVirtualKey(ctx context.Context, stats *StatsRespons
 // hits (Q10), avg TTFT (Q11), and the always-fresh requests-in-last-1h count.
 // Every query is best-effort: on error it logs and leaves the field(s) zeroed,
 // never aborting — matching the original inline behavior.
-func (h *StatsHandler) statScalars(ctx context.Context, stats *StatsResponse, vkJoin, vkFilter string, since, now time.Time) {
+func (h *StatsHandler) statScalars(ctx context.Context, stats *StatsResponse, vkJoin, vkFilter string, filterArgs []any, since, now time.Time) {
+	sinceArgs := append([]any{since}, filterArgs...)
+
 	// Query 5: Avg latency
 	query := `
 		SELECT COALESCE(AVG(rl.duration_ms), 0) as avg_duration
 		FROM request_logs rl` + vkJoin + `
 		WHERE rl.created_at >= $1 AND rl.status_code > 0 AND rl.status_code < 400` + vkFilter
 
-	err := h.dbPool.QueryRow(ctx, query, since).Scan(&stats.AvgLatencyMs)
+	err := h.dbPool.QueryRow(ctx, query, sinceArgs...).Scan(&stats.AvgLatencyMs)
 	if err != nil {
 		debuglog.Error("stats: query failed", "query", "avg_latency", "error", err)
 		stats.AvgLatencyMs = 0
@@ -379,7 +382,7 @@ func (h *StatsHandler) statScalars(ctx context.Context, stats *StatsResponse, vk
 		FROM request_logs rl` + vkJoin + `
 		WHERE rl.created_at >= $1` + vkFilter
 
-	err = h.dbPool.QueryRow(ctx, query, since).Scan(&stats.ErrorRate)
+	err = h.dbPool.QueryRow(ctx, query, sinceArgs...).Scan(&stats.ErrorRate)
 	if err != nil {
 		debuglog.Error("stats: query failed", "query", "error_rate", "error", err)
 		stats.ErrorRate = 0
@@ -391,7 +394,7 @@ func (h *StatsHandler) statScalars(ctx context.Context, stats *StatsResponse, vk
 		FROM request_logs rl` + vkJoin + `
 		WHERE rl.created_at >= $1 AND rl.proxy_overhead_ms > 0` + vkFilter
 
-	err = h.dbPool.QueryRow(ctx, query, since).Scan(&stats.AvgOverheadMs)
+	err = h.dbPool.QueryRow(ctx, query, sinceArgs...).Scan(&stats.AvgOverheadMs)
 	if err != nil {
 		debuglog.Error("stats: query failed", "query", "avg_overhead", "error", err)
 		stats.AvgOverheadMs = 0
@@ -403,7 +406,7 @@ func (h *StatsHandler) statScalars(ctx context.Context, stats *StatsResponse, vk
 		FROM request_logs rl` + vkJoin + `
 		WHERE rl.created_at >= $1` + vkFilter
 
-	err = h.dbPool.QueryRow(ctx, query, since).Scan(&stats.TotalTokensPrompt, &stats.TotalTokensCompletion, &stats.TotalTokensCacheHit)
+	err = h.dbPool.QueryRow(ctx, query, sinceArgs...).Scan(&stats.TotalTokensPrompt, &stats.TotalTokensCompletion, &stats.TotalTokensCacheHit)
 	if err != nil {
 		debuglog.Error("stats: query failed", "query", "total_tokens", "error", err)
 		stats.TotalTokensPrompt = 0
@@ -420,7 +423,7 @@ func (h *StatsHandler) statScalars(ctx context.Context, stats *StatsResponse, vk
 		FROM request_logs rl` + vkJoin + `
 		WHERE rl.created_at >= $1 AND rl.status_code > 0 AND rl.status_code < 400` + vkFilter
 
-	err = h.dbPool.QueryRow(ctx, query, since).Scan(&stats.AvgTokensPerRequest)
+	err = h.dbPool.QueryRow(ctx, query, sinceArgs...).Scan(&stats.AvgTokensPerRequest)
 	if err != nil {
 		debuglog.Error("stats: query failed", "query", "avg_tokens_per_request", "error", err)
 		stats.AvgTokensPerRequest = 0
@@ -432,7 +435,7 @@ func (h *StatsHandler) statScalars(ctx context.Context, stats *StatsResponse, vk
 		FROM request_logs rl` + vkJoin + `
 		WHERE rl.created_at >= $1` + vkFilter
 
-	err = h.dbPool.QueryRow(ctx, query, since).Scan(&stats.RateLimitHits)
+	err = h.dbPool.QueryRow(ctx, query, sinceArgs...).Scan(&stats.RateLimitHits)
 	if err != nil {
 		debuglog.Error("stats: query failed", "query", "rate_limit_hits", "error", err)
 		stats.RateLimitHits = 0
@@ -444,7 +447,7 @@ func (h *StatsHandler) statScalars(ctx context.Context, stats *StatsResponse, vk
 		FROM request_logs rl` + vkJoin + `
 		WHERE rl.created_at >= $1 AND rl.status_code > 0 AND rl.status_code < 400` + vkFilter
 
-	err = h.dbPool.QueryRow(ctx, query, since).Scan(&stats.AvgTTFTMs)
+	err = h.dbPool.QueryRow(ctx, query, sinceArgs...).Scan(&stats.AvgTTFTMs)
 	if err != nil {
 		debuglog.Error("stats: query failed", "query", "avg_ttft", "error", err)
 		stats.AvgTTFTMs = 0
@@ -457,7 +460,7 @@ func (h *StatsHandler) statScalars(ctx context.Context, stats *StatsResponse, vk
 	err = h.dbPool.QueryRow(ctx, `
 		SELECT COUNT(*) as count
 		FROM request_logs rl`+vkJoin+`
-		WHERE rl.created_at >= $1`+vkFilter, _1hAgo).Scan(&requests1h)
+		WHERE rl.created_at >= $1`+vkFilter, append([]any{_1hAgo}, filterArgs...)...).Scan(&requests1h)
 	if err != nil {
 		debuglog.Error("stats: query failed", "query", "requests_last_1h", "error", err)
 		requests1h = 0
@@ -469,7 +472,7 @@ func (h *StatsHandler) statScalars(ctx context.Context, stats *StatsResponse, vk
 // requested period plus the cross-fill of the other window (a 24h request also
 // fills the 7d total and vice-versa). A query failure here is fatal — returned
 // so calculateStats aborts.
-func (h *StatsHandler) statTotals(ctx context.Context, stats *StatsResponse, vkJoin, vkFilter string, period time.Duration, since, now time.Time) error {
+func (h *StatsHandler) statTotals(ctx context.Context, stats *StatsResponse, vkJoin, vkFilter string, filterArgs []any, period time.Duration, since, now time.Time) error {
 	switch period {
 	case 7 * 24 * time.Hour:
 		stats.TotalRequestsLast7d = 0
@@ -484,7 +487,7 @@ func (h *StatsHandler) statTotals(ctx context.Context, stats *StatsResponse, vkJ
 		WHERE rl.created_at >= $1` + vkFilter
 
 	var count int
-	err := h.dbPool.QueryRow(ctx, query, since).Scan(&count)
+	err := h.dbPool.QueryRow(ctx, query, append([]any{since}, filterArgs...)...).Scan(&count)
 	if err != nil {
 		debuglog.Error("stats: query failed", "query", "total_requests", "error", err)
 		return err
@@ -499,7 +502,7 @@ func (h *StatsHandler) statTotals(ctx context.Context, stats *StatsResponse, vkJ
 
 	if period == 24*time.Hour {
 		_7dAgo := now.Add(-7 * 24 * time.Hour)
-		err = h.dbPool.QueryRow(ctx, query, _7dAgo).Scan(&count)
+		err = h.dbPool.QueryRow(ctx, query, append([]any{_7dAgo}, filterArgs...)...).Scan(&count)
 		if err != nil {
 			debuglog.Error("stats: query failed", "query", "total_requests_7d", "error", err)
 			return err
@@ -507,7 +510,7 @@ func (h *StatsHandler) statTotals(ctx context.Context, stats *StatsResponse, vkJ
 		stats.TotalRequestsLast7d = count
 	} else {
 		_24hAgo := now.Add(-24 * time.Hour)
-		err = h.dbPool.QueryRow(ctx, query, _24hAgo).Scan(&count)
+		err = h.dbPool.QueryRow(ctx, query, append([]any{_24hAgo}, filterArgs...)...).Scan(&count)
 		if err != nil {
 			debuglog.Error("stats: query failed", "query", "total_requests_24h", "error", err)
 			return err
@@ -521,7 +524,7 @@ func (h *StatsHandler) statTotals(ctx context.Context, stats *StatsResponse, vkJ
 // latency breakdown. Best-effort: a query failure logs and leaves the slice
 // empty; a per-row scan error skips the row. Only invoked when the caller
 // requested latency data.
-func (h *StatsHandler) statLatencyBreakdown(ctx context.Context, stats *StatsResponse, vkJoin, vkFilter string, since time.Time) {
+func (h *StatsHandler) statLatencyBreakdown(ctx context.Context, stats *StatsResponse, vkJoin, vkFilter string, filterArgs []any, since time.Time) {
 	// Query 13: Per-provider latency breakdown (top 6 by avg total latency).
 	query := `
 			WITH provider_latency AS (
@@ -542,7 +545,7 @@ func (h *StatsHandler) statLatencyBreakdown(ctx context.Context, stats *StatsRes
 				GREATEST(0, avg_total - avg_overhead) as avg_provider
 			FROM provider_latency`
 
-	rows, err := h.dbPool.Query(ctx, query, since)
+	rows, err := h.dbPool.Query(ctx, query, append([]any{since}, filterArgs...)...)
 	if err != nil {
 		debuglog.Error("stats: query failed", "query", "by_provider_latency", "error", err)
 	} else {
@@ -567,22 +570,24 @@ func (h *StatsHandler) calculateStats(ctx context.Context, period time.Duration,
 	vkJoin, vkFilter := vkScope(excludeDeleted)
 	// Owner scope rides the same filter seam as the deleted-key toggle: for
 	// non-admins it is mandatory row-level security, for admins an optional
-	// dashboard filter.
-	vkFilter += ownerFilterFragment(ownerID)
+	// dashboard filter. Every consuming query binds $1 = timestamp, so the
+	// owner id rides $2.
+	ownerFrag, filterArgs := ownerFilterFragment(ownerID, 2)
+	vkFilter += ownerFrag
 
 	now := time.Now().UTC()
 	since := now.Add(-period)
 
 	// Query 1 + cross-fill: total request counts (fatal on error).
-	if err := h.statTotals(ctx, stats, vkJoin, vkFilter, period, since, now); err != nil {
+	if err := h.statTotals(ctx, stats, vkJoin, vkFilter, filterArgs, period, since, now); err != nil {
 		return nil, err
 	}
 
 	// Queries 2–4c: dimension breakdowns (top-10 by model / provider / virtual key).
-	if err := h.statByModel(ctx, stats, vkJoin, vkFilter, metric, since); err != nil {
+	if err := h.statByModel(ctx, stats, vkJoin, vkFilter, filterArgs, metric, since); err != nil {
 		return nil, err
 	}
-	if err := h.statByProvider(ctx, stats, vkJoin, vkFilter, metric, since); err != nil {
+	if err := h.statByProvider(ctx, stats, vkJoin, vkFilter, filterArgs, metric, since); err != nil {
 		return nil, err
 	}
 	if err := h.statByVirtualKey(ctx, stats, metric, since, excludeDeleted, ownerID); err != nil {
@@ -590,12 +595,12 @@ func (h *StatsHandler) calculateStats(ctx context.Context, period time.Duration,
 	}
 
 	// Queries 5–11 + requests-in-last-1h: scalar aggregates (best-effort).
-	h.statScalars(ctx, stats, vkJoin, vkFilter, since, now)
+	h.statScalars(ctx, stats, vkJoin, vkFilter, filterArgs, since, now)
 
 	// Queries 12–13: per-model / per-provider latency breakdown (best-effort,
 	// only when the caller requested latency data).
 	if includeLatency {
-		h.statLatencyBreakdown(ctx, stats, vkJoin, vkFilter, since)
+		h.statLatencyBreakdown(ctx, stats, vkJoin, vkFilter, filterArgs, since)
 	}
 
 	return stats, nil
@@ -613,7 +618,8 @@ func (h *StatsHandler) GetTimeSeries(w http.ResponseWriter, r *http.Request) {
 		vkJoin = " LEFT JOIN virtual_keys vk ON rl.virtual_key_id = vk.id"
 		vkFilter = " AND (rl.virtual_key_id IS NULL OR vk.id IS NOT NULL)"
 	}
-	vkFilter += ownerFilterFragment(logOwnerScope(r))
+	ownerFrag, ownerArgs := ownerFilterFragment(logOwnerScope(r), 2)
+	vkFilter += ownerFrag
 
 	bucketSize := "5min"
 	expectedBuckets := 288
@@ -671,7 +677,7 @@ func (h *StatsHandler) GetTimeSeries(w http.ResponseWriter, r *http.Request) {
 		ORDER BY 1`
 	}
 
-	rows, err := h.dbPool.Query(ctx, query, since)
+	rows, err := h.dbPool.Query(ctx, query, append([]any{since}, ownerArgs...)...)
 	if err != nil {
 		respondError(w, "failed to query time series", err, http.StatusInternalServerError)
 		return
@@ -762,7 +768,8 @@ func (h *StatsHandler) GetProviderDistribution(w http.ResponseWriter, r *http.Re
 		vkJoin = " LEFT JOIN virtual_keys vk ON rl.virtual_key_id = vk.id"
 		vkFilter = " AND (rl.virtual_key_id IS NULL OR vk.id IS NOT NULL)"
 	}
-	vkFilter += ownerFilterFragment(logOwnerScope(r))
+	ownerFrag, ownerArgs := ownerFilterFragment(logOwnerScope(r), 2)
+	vkFilter += ownerFrag
 
 	var selectCol string
 	var havingClause string
@@ -782,7 +789,7 @@ func (h *StatsHandler) GetProviderDistribution(w http.ResponseWriter, r *http.Re
 		ORDER BY val DESC
 		LIMIT 5`
 
-	rows, err := h.dbPool.Query(ctx, query, since)
+	rows, err := h.dbPool.Query(ctx, query, append([]any{since}, ownerArgs...)...)
 	if err != nil {
 		respondError(w, "failed to query provider distribution", err, http.StatusInternalServerError)
 		return

--- a/internal/api/stats.go
+++ b/internal/api/stats.go
@@ -309,6 +309,9 @@ func (h *StatsHandler) statByVirtualKey(ctx context.Context, stats *StatsRespons
 
 	// Queries 4b/4c only make sense unscoped: deleted-key rows cannot be
 	// attributed to an owner anymore, and chat/arena rows are admin traffic.
+	// This early return is also what keeps Q4c's own $2 (keyName) from
+	// colliding with the owner fragment's $2 — anything that lets a scoped
+	// caller reach Q4c must renumber it first.
 	if ownerID != "" {
 		return nil
 	}

--- a/internal/api/stats_errorpaths_test.go
+++ b/internal/api/stats_errorpaths_test.go
@@ -30,13 +30,13 @@ func TestStats_QueryErrorPaths(t *testing.T) {
 	since := now.Add(-24 * time.Hour)
 
 	// Fatal helpers must surface the error.
-	if err := handler.statTotals(ctx, newStats(), "", "", 24*time.Hour, since, now); err == nil {
+	if err := handler.statTotals(ctx, newStats(), "", "", nil, 24*time.Hour, since, now); err == nil {
 		t.Error("statTotals: expected error on cancelled context")
 	}
-	if err := handler.statByModel(ctx, newStats(), "", "", "requests", since); err == nil {
+	if err := handler.statByModel(ctx, newStats(), "", "", nil, "requests", since); err == nil {
 		t.Error("statByModel: expected error on cancelled context")
 	}
-	if err := handler.statByProvider(ctx, newStats(), "", "", "requests", since); err == nil {
+	if err := handler.statByProvider(ctx, newStats(), "", "", nil, "requests", since); err == nil {
 		t.Error("statByProvider: expected error on cancelled context")
 	}
 	if err := handler.statByVirtualKey(ctx, newStats(), "requests", since, false, ""); err == nil {
@@ -45,7 +45,7 @@ func TestStats_QueryErrorPaths(t *testing.T) {
 
 	// Best-effort helpers must not panic and must leave their fields zeroed.
 	s := newStats()
-	handler.statScalars(ctx, s, "", "", since, now)
+	handler.statScalars(ctx, s, "", "", nil, since, now)
 	if s.AvgLatencyMs != 0 || s.ErrorRate != 0 || s.AvgOverheadMs != 0 ||
 		s.TotalTokensPrompt != 0 || s.TotalTokensCompletion != 0 || s.TotalTokensCacheHit != 0 ||
 		s.AvgTokensPerRequest != 0 || s.RateLimitHits != 0 || s.AvgTTFTMs != 0 || s.RequestsLast1h != 0 {
@@ -53,7 +53,7 @@ func TestStats_QueryErrorPaths(t *testing.T) {
 	}
 
 	s2 := newStats()
-	handler.statLatencyBreakdown(ctx, s2, "", "", since)
+	handler.statLatencyBreakdown(ctx, s2, "", "", nil, since)
 	if len(s2.ByProviderLatency) != 0 {
 		t.Errorf("statLatencyBreakdown on error: expected empty slice, got %d",
 			len(s2.ByProviderLatency))
@@ -82,7 +82,7 @@ func TestStats_StatTotals7DayPeriod(t *testing.T) {
 		ByVirtualKey: make(map[string]int64),
 	}
 
-	err := handler.statTotals(ctx, stats, "", "", 7*24*time.Hour, since, now)
+	err := handler.statTotals(ctx, stats, "", "", nil, 7*24*time.Hour, since, now)
 	if err != nil {
 		t.Fatalf("statTotals with 7-day period: %v", err)
 	}
@@ -114,7 +114,7 @@ func TestStats_StatTotals7DayErrorPath(t *testing.T) {
 	now := time.Now().UTC()
 	since := now.Add(-7 * 24 * time.Hour)
 
-	if err := handler.statTotals(ctx, stats, "", "", 7*24*time.Hour, since, now); err == nil {
+	if err := handler.statTotals(ctx, stats, "", "", nil, 7*24*time.Hour, since, now); err == nil {
 		t.Error("statTotals with 7-day period: expected error on cancelled context")
 	}
 }

--- a/internal/api/stats_test.go
+++ b/internal/api/stats_test.go
@@ -676,27 +676,34 @@ func TestNewStatsHandler_Constructor(t *testing.T) {
 }
 
 // TestOwnerFilterFragment covers the SQL-injection-defense hardening of the
-// owner scope fragment: empty scope stays unscoped, a valid UUID is inlined in
-// canonical form, and a non-empty-but-invalid id fails CLOSED to a no-match
-// fragment (never to unscoped, which would leak every owner's rows).
+// owner scope fragment: empty scope stays unscoped, a valid UUID rides a bound
+// placeholder (never string-interpolated SQL), and a non-empty-but-invalid id
+// fails CLOSED to a no-match fragment (never to unscoped, which would leak
+// every owner's rows).
 func TestOwnerFilterFragment(t *testing.T) {
-	if got := ownerFilterFragment(""); got != "" {
-		t.Errorf("empty owner should be unscoped, got %q", got)
+	if frag, args := ownerFilterFragment("", 2); frag != "" || len(args) != 0 {
+		t.Errorf("empty owner should be unscoped, got %q with args %v", frag, args)
 	}
 
-	id := uuid.New().String()
-	got := ownerFilterFragment(id)
-	if !strings.Contains(got, "'"+id+"'") {
-		t.Errorf("valid owner id not inlined: %q", got)
+	id := uuid.New()
+	frag, args := ownerFilterFragment(id.String(), 2)
+	if !strings.Contains(frag, "$2") {
+		t.Errorf("valid owner id must bind through the given placeholder, got %q", frag)
 	}
-	if strings.Contains(got, " AND 1=0") {
-		t.Errorf("valid owner id must not fail closed: %q", got)
+	if strings.Contains(frag, id.String()) {
+		t.Errorf("owner id must not be inlined into the SQL: %q", frag)
+	}
+	if strings.Contains(frag, " AND 1=0") {
+		t.Errorf("valid owner id must not fail closed: %q", frag)
+	}
+	if len(args) != 1 || args[0] != id {
+		t.Errorf("expected the parsed UUID as the single bind arg, got %v", args)
 	}
 
 	for _, bad := range []string{"' OR '1'='1", "not-a-uuid", "123"} {
-		got := ownerFilterFragment(bad)
-		if got != " AND 1=0" {
-			t.Errorf("invalid owner id %q must fail closed to no-match, got %q", bad, got)
+		frag, args := ownerFilterFragment(bad, 2)
+		if frag != " AND 1=0" || len(args) != 0 {
+			t.Errorf("invalid owner id %q must fail closed to no-match, got %q with args %v", bad, frag, args)
 		}
 	}
 }


### PR DESCRIPTION
Three follow-ups from the security assessment, plus the fixes from a second-opinion review of the first commit.

## 1. WebAuthn ceremony TTL is now enforced

`RegisterStart`/`LoginStart` stamp a 5-minute `ExpiresAt`, but neither finish handler ever looked at it, and `Repository.GetSession` has no `expires_at` filter. The go-webauthn library only checks `SessionData.Expires` when `Timeouts.*.Enforce` is set — it defaults to `false` and the handler never configures it, so `session.Expires` was never populated and the library check was a no-op.

Net effect: the TTL was enforced by nothing except the hourly cleanup sweep, leaving a ceremony challenge consumable for up to ~an hour. Single-use claiming already prevented replay, so exploitability was low. Both finish handlers now reject an expired session at consume time. Front Desk mounts the same shared `adminauth` handler, so it gets the guard too.

The response is the generic `session not found`, so a probing caller cannot distinguish an expired ceremony from an unknown one (matching `ConsumeLoginState`'s documented opacity); the reason stays in the log line.

## 2. Stats owner id binds instead of interpolating

`ownerFilterFragment` inlined the owner UUID as a SQL literal. Not exploitable — `uuid.Parse` guarantees canonical form and invalid input fails closed to `AND 1=0` — but it was the one deviation from the all-bound query pattern. It now returns `(fragment, []any)` binding through `$N`, with args threaded through every stats helper and the two direct handlers. Invalid ids still fail closed.

Side benefit: each distinct owner previously produced a distinct SQL string, churning pgx's prepared-statement cache. There is now one statement shape.

## 3. Sort whitelists pinned by property tests

New tests feed every API-accepted `sort_by` value **plus hostile input** (`name; DROP TABLE models;--`, `1); DELETE FROM request_logs;--`, …) through all three sort surfaces — models cursor, request logs, app-log history — and assert the output is always a member of a fixed set of column expressions. The request-log sort map moved out of the handler to a package-level `logsSortDef` to make it testable; behavior is identical (same fallback key, same `status` tiebreaker, same cache keys).

## Review follow-ups

A second-opinion review found no bugs but one real test gap: `statScalars` and `statLatencyBreakdown` are best-effort — they log and zero their fields rather than returning an error — and no test ran them with a non-nil owner arg. A wrong bind index there would have handed scoped users an empty latency chart and zeroed scalars with a green suite. `TestStats_OwnerScope_ScalarsAndLatency` now covers both.

## Verification

- 3130 tests pass across `internal/api`, `internal/adminauth`, `internal/webauthn`, `internal/frontdesk`; `golangci-lint` clean; diff coverage 100% (65/65 changed lines).
- **Mutation-tested**, since a passing test proves nothing on already-correct code: starving either silent helper of its bind args fails the new test with exactly the silent-empty symptom; removing either expiry guard fails both expiry tests.
- Exercised against the dev stack with 648 real request-log rows: all 12 sort keys produce distinct orderings, both injection attempts fall back to `time` ordering with `request_logs` intact, and the owner-scoped stats path (including the latency breakdown) returns valid JSON rather than a bind error.
- A full `tools/live-model-test` sweep against dev showed no gateway-side failures — every failure is upstream (401/402/403/404/429 on test-provider credentials, plus local model servers not running).

🤖 Generated with [Claude Code](https://claude.com/claude-code)