### PR TITLE
ci(image-scan): scan daily and on release, not weekly

### DIFF
--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -43,13 +43,24 @@ concurrency:
   cancel-in-progress: false
 
 on:
+  # Detection runs daily, the below-gate auto-fix stays weekly, and the two crons
+  # exist so a run can tell which it is (github.event.schedule).
+  #
+  # Detection wants to be daily: a fixable finding lands when the distro ships the
+  # patch, which has no relationship to when we build. The 28 fixable PostgreSQL
+  # client CVEs that reached :latest on 2026-08-18 were unfixed at build time and
+  # became fixable days later, so nothing but this workflow could notice, and the
+  # cron interval IS the detection latency. A clean day costs one pull, one scan.
+  #
+  # The rebuild does NOT want to be daily. It republishes :latest on the
+  # CRITICAL/HIGH rescan alone, deliberately (see the publish step), so a fixable
+  # below-gate finding that a rebuild cannot shift — a go.mod CVE, say — makes
+  # every run rebuild, change nothing, and push a fresh :latest digest anyway.
+  # Weekly that is one wasted digest; daily it is one every day until a human
+  # lands a code fix. The below-gate tier keeps the cadence it already had.
   schedule:
-    # Daily, not weekly. A fixable finding lands when the distro ships the patch,
-    # which has no relationship to when we build: the 28 fixable PostgreSQL client
-    # CVEs that reached :latest on 2026-08-18 were unfixed at build time and became
-    # fixable days later. Nothing but this workflow notices that, so the cron
-    # interval IS the detection latency. A clean day costs one pull and one scan.
-    - cron: '17 6 * * *' # daily 06:17 UTC
+    - cron: '17 6 * * 1' # Mondays 06:17 UTC: detect, and auto-fix below-gate findings
+    - cron: '17 6 * * 0,2-6' # other days 06:17 UTC: detect and report only
   # A release moves :latest, so scan the thing that was just published instead of
   # waiting up to a day for the cron. This covers the other half of the same gap:
   # the cron catches the world changing under a static image, this catches the
@@ -90,6 +101,12 @@ jobs:
       app_sarif: ${{ steps.upload_app.outputs.sarif-id }}
       frontdesk_sarif: ${{ steps.upload_frontdesk.outputs.sarif-id }}
       postgres_line: ${{ steps.postgres_summary.outputs.line }}
+      # Defined once here and read by both the refresh job's `if` and its matrix,
+      # which have to agree: the job gate can let the job start for one image
+      # while a matrix leg still decides to rebuild the other. Every trigger that
+      # is not the detect-only cron may auto-fix, so a manual dispatch still
+      # rebuilds on demand.
+      autofix: ${{ github.event.schedule != '17 6 * * 0,2-6' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -340,9 +357,17 @@ jobs:
   # The trigger is fixable-at-any-severity, not the CRITICAL/HIGH gate. Keying it
   # to the gate left findings that this job could have fixed in one step sitting
   # on the published image indefinitely: nothing else rebuilds :latest, so a
-  # below-gate finding had no path to ever being fixed or noticed. Widening the
-  # trigger costs a rebuild on the days something fixable exists and nothing on
-  # the days it does not.
+  # below-gate finding had no path to ever being fixed or noticed.
+  #
+  # The two tiers run on different cadences, which is what `autofix` decides. A
+  # CRITICAL/HIGH gate failure rebuilds on any run, because waiting a week to ship
+  # a fix we already have is the thing this job exists to prevent. A below-gate
+  # finding rebuilds only on the weekly slot or a manual dispatch. That asymmetry
+  # is not tidiness: the publish step below ships on the CRITICAL/HIGH rescan
+  # alone, so a below-gate finding a rebuild cannot shift makes every triggered
+  # run push a fresh :latest digest that fixes nothing, and daily detection would
+  # otherwise turn one wasted digest a week into one a day for as long as the
+  # finding stands.
   #
   # Skipped on the release trigger. The rebuild's whole value is picking up
   # Alpine patches published since the image was built, and on that trigger the
@@ -358,8 +383,9 @@ jobs:
       always() && github.event_name != 'workflow_run'
       && (needs.scan.outputs.app_gate == 'failure'
       || needs.scan.outputs.frontdesk_gate == 'failure'
-      || needs.scan.outputs.app_advisory == 'failure'
-      || needs.scan.outputs.frontdesk_advisory == 'failure')
+      || (needs.scan.outputs.autofix == 'true'
+      && (needs.scan.outputs.app_advisory == 'failure'
+      || needs.scan.outputs.frontdesk_advisory == 'failure')))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -383,11 +409,11 @@ jobs:
           - image: model-hotel
             dockerfile: Dockerfile
             smoke: true
-            triggered: ${{ format('{0}', needs.scan.outputs.app_gate == 'failure' || needs.scan.outputs.app_advisory == 'failure') }}
+            triggered: ${{ format('{0}', needs.scan.outputs.app_gate == 'failure' || (needs.scan.outputs.autofix == 'true' && needs.scan.outputs.app_advisory == 'failure')) }}
           - image: model-hotel-frontdesk
             dockerfile: Dockerfile.frontdesk
             smoke: false
-            triggered: ${{ format('{0}', needs.scan.outputs.frontdesk_gate == 'failure' || needs.scan.outputs.frontdesk_advisory == 'failure') }}
+            triggered: ${{ format('{0}', needs.scan.outputs.frontdesk_gate == 'failure' || (needs.scan.outputs.autofix == 'true' && needs.scan.outputs.frontdesk_advisory == 'failure')) }}
     services:
       postgres:
         image: postgres:16-alpine
@@ -604,5 +630,9 @@ jobs:
           BACKLOG: ${{ steps.digest.outputs.fixable_backlog }}
           DIGEST_FILE: code-scanning.md
           POSTGRES_LINE: ${{ needs.scan.outputs.postgres_line }}
+          # Lets the report tell "the rebuild is not due yet" apart from "the
+          # rebuild tried and did not get there", which read identically before
+          # the below-gate tier had a cadence of its own.
+          AUTOFIX: ${{ needs.scan.outputs.autofix }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: scripts/ci/compose-scan-report.sh

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -1,4 +1,4 @@
-# Weekly vulnerability scan of the published images (app + Front Desk).
+# Daily vulnerability scan of the published images (app + Front Desk).
 #
 # The CI gate only runs when a PR is open, but CVEs land in already-published
 # images (this is exactly how the OpenSSL 3.5.6 flags appeared on the published
@@ -17,9 +17,10 @@
 #
 # The scan pulls from GHCR: every publish path (release, :dev, and the refresh
 # job below) pushes the same digest to GHCR and Docker Hub, so scanning one
-# registry covers both, and GHCR is the one our own stacks pull from. Note it
-# scans :latest specifically — a :dev publish does not move :latest, and no
-# publish of any kind re-runs this workflow, so nothing here reacts to a merge.
+# registry covers both, and GHCR is the one our own stacks pull from. It scans
+# :latest specifically, which is why a release is the only publish wired to the
+# workflow_run trigger: ci.yml publishes :dev, and :dev does not move :latest,
+# so a plain merge still has nothing here to react to.
 #
 # Findings come in two tiers. Fixable CRITICAL/HIGH decides red or green, as it
 # always has. Below that sits everything else fixable, which for a long time was
@@ -31,9 +32,34 @@
 # turns anything red.
 name: Scan Published Image
 
+# Serialise runs. With a weekly cron and manual dispatch, overlap was hard to
+# arrange; a daily cron plus a per-release trigger makes it routine, and two
+# refresh jobs rebuilding and pushing :latest at once would race to decide which
+# digest wins. Queue rather than cancel: a cancelled run can drop a SARIF upload
+# or interrupt a push, and the two-dispatch trick for closing alerts in one
+# sitting still works, just one after the other.
+concurrency:
+  group: image-scan
+  cancel-in-progress: false
+
 on:
   schedule:
-    - cron: '17 6 * * 1' # Mondays 06:17 UTC
+    # Daily, not weekly. A fixable finding lands when the distro ships the patch,
+    # which has no relationship to when we build: the 28 fixable PostgreSQL client
+    # CVEs that reached :latest on 2026-08-18 were unfixed at build time and became
+    # fixable days later. Nothing but this workflow notices that, so the cron
+    # interval IS the detection latency. A clean day costs one pull and one scan.
+    - cron: '17 6 * * *' # daily 06:17 UTC
+  # A release moves :latest, so scan the thing that was just published instead of
+  # waiting up to a day for the cron. This covers the other half of the same gap:
+  # the cron catches the world changing under a static image, this catches the
+  # image changing. Only "Publish Docker Image" is listed because it is the only
+  # workflow that moves :latest — ci.yml publishes :dev, which this never scans,
+  # and the refresh job below republishes :latest directly rather than through the
+  # publish workflow, so neither can loop back into here.
+  workflow_run:
+    workflows: ['Publish Docker Image']
+    types: [completed]
   workflow_dispatch:
 
 permissions:
@@ -50,6 +76,11 @@ env:
 jobs:
   scan:
     name: Trivy Scan (latest)
+    # A failed publish leaves :latest where it was, so scanning on that event
+    # reports the picture the previous run already reported. The first clause
+    # carries the cron and dispatch runs, where there is no workflow_run context
+    # and the conclusion would be empty.
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     outputs:
       app_gate: ${{ steps.gate_app.outcome }}
@@ -308,15 +339,24 @@ jobs:
   #
   # The trigger is fixable-at-any-severity, not the CRITICAL/HIGH gate. Keying it
   # to the gate left findings that this job could have fixed in one step sitting
-  # on the published image indefinitely: nothing else rebuilds :latest, and no
-  # image publish re-runs this scan, so a below-gate finding had no path to ever
-  # being fixed or noticed. Widening the trigger costs a rebuild in the weeks
-  # something fixable exists and nothing in the weeks it does not.
+  # on the published image indefinitely: nothing else rebuilds :latest, so a
+  # below-gate finding had no path to ever being fixed or noticed. Widening the
+  # trigger costs a rebuild on the days something fixable exists and nothing on
+  # the days it does not.
+  #
+  # Skipped on the release trigger. The rebuild's whole value is picking up
+  # Alpine patches published since the image was built, and on that trigger the
+  # image was built minutes ago by a runtime stage that buildx is forbidden to
+  # cache (no-cache-filters: runtime), so its apk upgrade already pulled the
+  # current patch level. Rebuilding would produce the same packages and republish
+  # :latest at a new digest, splitting it from the release tag it was cut from,
+  # in exchange for nothing. On that trigger this workflow only reports.
   refresh:
     name: Rebuild ${{ matrix.image }} from the current release
     needs: scan
     if: >-
-      always() && (needs.scan.outputs.app_gate == 'failure'
+      always() && github.event_name != 'workflow_run'
+      && (needs.scan.outputs.app_gate == 'failure'
       || needs.scan.outputs.frontdesk_gate == 'failure'
       || needs.scan.outputs.app_advisory == 'failure'
       || needs.scan.outputs.frontdesk_advisory == 'failure')
@@ -500,13 +540,19 @@ jobs:
           name: refresh-status-${{ matrix.image }}
           path: refresh-status/
 
-  # One issue, reused, that says what it wants from you. The weekly scan's only
-  # previous output was a failure email, and an email that says "network error"
-  # on the one week that mattered is how a real finding went unnoticed.
+  # One issue, reused, that says what it wants from you. This scan's only output
+  # used to be a failure email, and an email that says "network error" on the one
+  # run that mattered is how a real finding went unnoticed.
+  #
+  # A skipped scan is not a clean scan. The scan job skips when a failed release
+  # triggers this workflow, and reporting on its empty outputs would read as
+  # nothing-found and close a tracking issue that is still legitimately open.
   report:
     name: Report scan result
     needs: [scan, refresh]
-    if: always() && needs.scan.result != 'cancelled'
+    if: >-
+      always() && needs.scan.result != 'cancelled'
+      && needs.scan.result != 'skipped'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/scripts/ci/compose-scan-report.sh
+++ b/scripts/ci/compose-scan-report.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 #
-# Turn the weekly scan + rebuild results into the tracking issue's body, then
-# file it via report-image-scan-issue.sh.
+# Turn the scan + rebuild results into the tracking issue's body, then file it
+# via report-image-scan-issue.sh.
+#
+# Detection runs daily; the rebuild that clears below-gate findings runs weekly.
+# AUTOFIX says which kind of run this is, so a report from a detect-only day can
+# say the rebuild is waiting rather than implying one failed.
 #
 # The point of the wording here is to answer "what do you want from me" without
 # a log dig. A rebuild can only clear OS-level CVEs, because it rebuilds the
@@ -26,6 +30,9 @@ DIGEST_FILE=${DIGEST_FILE:-}
 POSTGRES_LINE=${POSTGRES_LINE:-}
 RUN_URL=${RUN_URL:-}
 STATUS_DIR=${STATUS_DIR:-refresh-status}
+# Defaults true so a caller that does not set it keeps the old wording: every
+# other entry point to this script rebuilds when it finds something fixable.
+AUTOFIX=${AUTOFIX:-true}
 
 body=$(mktemp)
 trap 'rm -f "$body"' EXIT
@@ -157,6 +164,13 @@ done
     echo "The scan found fixable vulnerabilities, but the rebuild did not get as far as"
     echo "republishing \`:latest\`, so nothing has been fixed automatically. Check the run below"
     echo "to see whether the rebuild failed or never started."
+  elif [ "$AUTOFIX" != true ]; then
+    echo "### Below the gate, queued for the weekly rebuild"
+    echo
+    echo "Nothing here is HIGH or CRITICAL, so the run is green and no release is needed. These are"
+    echo "fixable though, meaning the fix already exists upstream and a rebuild would apply it."
+    echo "This run only looks; the rebuild that applies below-gate fixes runs on Mondays, so there"
+    echo "is nothing to chase here. Dispatch this workflow to bring it forward."
   else
     echo "### Below the gate, and still unfixed"
     echo
@@ -208,13 +222,13 @@ if [ "$vulnerable" != true ] && [ "$backlog" != true ]; then
 fi
 
 if [ "$vulnerable" = true ]; then
-  header="The weekly scan of the published images found fixable HIGH/CRITICAL vulnerabilities."
+  header="The scan of the published images found fixable HIGH/CRITICAL vulnerabilities."
   title="Published images: fixable vulnerabilities found"
   if [ "$needs_release" = true ]; then
     title="Published images need a patch release"
   fi
 else
-  header="The weekly scan found fixable vulnerabilities on the published images, all below the CRITICAL/HIGH gate."
+  header="The scan found fixable vulnerabilities on the published images, all below the CRITICAL/HIGH gate."
   title="Published images: fixable vulnerabilities below the gate"
 fi
 


### PR DESCRIPTION
## What

`image-scan.yml` is the only thing in this repo that looks at a published image, so its cron interval **is** its detection latency. That interval was a week.

- **Detection is now daily**, via two crons: `'17 6 * * 1'` (Monday) and `'17 6 * * 0,2-6'` (other days).
- **The below-gate auto-rebuild stays weekly.** A CRITICAL/HIGH gate failure still rebuilds on any run, as does a manual dispatch.
- New `workflow_run` trigger on **Publish Docker Image**, the only workflow that moves `:latest`.
- New `concurrency` group, `cancel-in-progress: false`.
- Four guards (below), and a matching report state.

No change to what is scanned, to either severity tier's thresholds, or to the rebuild/publish logic itself.

## Why

`:latest` (0.9.99, published 2026-08-18) is currently shipping **28 fixable PostgreSQL client CVEs** on `libpq 18.4-r0` + `postgresql16-client`, which Docker Hub grades 18 HIGH / 7 MEDIUM / 3 LOW. Nothing told us.

Neither existing gate could have:

- The **build-time** gates (`ci.yml:662`, `:872`) run `severity: CRITICAL,HIGH` with `ignore-unfixed: true`. The CVEs were published 08-13, but Alpine had not shipped the fix (`18.5-r0`) when the image was built on 08-18 — the build ran `apk upgrade --no-cache` through an uncacheable runtime stage and still produced `18.4-r0`. An unfixed CVE is invisible at **any** severity threshold, so lowering that gate to MEDIUM would have changed nothing.
- The **published-image** scan already catches exactly this (`severity: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL`, `ignore-unfixed: true`) and already auto-rebuilds, rescans, smoke-tests and republishes. It just last ran 08-17 15:02, and `:latest` published 08-18 10:08. **Nothing has scanned the current `:latest` since it was built.**

Daily cron closes the "world changed under a static image" half. The release trigger closes the "image changed" half.

## Why the rebuild did not come along for the ride

Review caught this and it is the reason for the two-cron split.

The publish step ships on the CRITICAL/HIGH rescan alone, deliberately, so that a rebuild carrying real OS fixes is not withheld over a go.mod finding it could never clear. The cost is that a below-gate finding a rebuild *cannot* shift makes every triggered run rebuild, change nothing, and push a fresh `:latest` digest anyway. Weekly that is one wasted digest; daily it would be one every day, indefinitely, until a human lands a code fix on master.

So the tiers get separate cadences. `scan` exports `autofix` once, and both the `refresh` job's `if` and its matrix read it — those two have to agree, or a matrix leg rebuilds an image the job gate never opened for.

## Guards

| Job | Guard | Reason |
|---|---|---|
| `scan` | skip if `workflow_run.conclusion != 'success'` | a failed publish leaves `:latest` where it was |
| `refresh` | skip on `workflow_run` entirely | the image was built minutes ago through a stage buildx may not cache (`no-cache-filters: runtime`), so a rebuild yields an identical package set and would republish `:latest` at a new digest, splitting it from the release tag |
| `refresh` | below-gate tier requires `autofix == 'true'` | keeps the rebuild cadence weekly, as above |
| `report` | skip if `needs.scan.result == 'skipped'` | empty scan outputs would read as nothing-found and close a still-open tracking issue |

No loop risk: `ci.yml` publishes `:dev` (never scanned here, and `:dev` does not move `:latest`), and `refresh` pushes `:latest` directly rather than through the publish workflow.

## Report

A below-gate finding on a detect-only day used to render as *"the rebuild did not get as far as republishing, check the run below for why"*, which would send someone hunting for a failure that never happened. `compose-scan-report.sh` takes an `AUTOFIX` env and splits that into *"queued for Monday, dispatch to bring it forward"*. It defaults to `true`, so any caller that does not set it keeps the existing wording. Two stale "the weekly scan..." issue headers fixed while there.

## Verification

- `actionlint` clean; `shellcheck` and `bash -n` clean.
- YAML parsed; all job conditions and both matrix `triggered` expressions confirmed after folding.
- `compose-scan-report.sh` run over all four states — detect-only with below-gate findings, the same on a rebuild day, all clean (still closes the issue), and gate red — each rendering the intended section.

## Not in scope

- The `1 unspecified` finding on every image is `GO-2026-5932` (`x/crypto/openpgp` unmaintained). It has no fix version and cannot be engineered away: `go list -deps ./cmd/server` links `x/crypto/{argon2,blake2b,ocsp}`, and `go mod why` puts `ocsp` behind `go-webauthn/webauthn`, so `x/crypto` stays in the binary regardless of what we use for password hashing. Trivy's gobinary scanner is module-granular and cannot see we never import `openpgp`. Left alone deliberately.
- `docker-publish.yml` reports `success` even when its `skip_existing` path publishes nothing (a re-run of an already-published version), so the release trigger can fire one redundant scan. Accepted: the result is a correct scan run slightly early, and distinguishing it would mean an extra API call into the triggering run's job outputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)