### PR TITLE
feat(deepseek): add the vision model, correct V4 pricing, and stop attachment implying vision

### DIFF
--- a/internal/paramrewrite/inject.go
+++ b/internal/paramrewrite/inject.go
@@ -61,8 +61,17 @@ func InjectProviderParams(raw map[string]any, providerType, modelID string) bool
 		}
 
 	case "deepseek":
-		// DeepSeek V4 and R1 require reasoning_content on every assistant message.
-		// If any assistant message lacks reasoning_content, the API rejects the request.
+		// Backfills reasoning_content onto assistant messages. DeepSeek used to
+		// reject a request when any assistant message lacked the field, which is
+		// why this exists.
+		//
+		// That requirement no longer holds: on 2026-08-21 every current model
+		// (deepseek-v4-flash, -pro, -flash-vision-exp and the aliases) accepted
+		// assistant turns with no reasoning_content, including the shapes most
+		// likely to trip it — a turn carrying tool_calls, and two assistant
+		// turns in a row. The backfill is kept as insurance rather than removed
+		// on the strength of one afternoon's probing, since re-adding it after a
+		// silent upstream change would mean debugging it from a 400 first.
 		//
 		// deepseek-reasoner is matched by name because it names no version: it
 		// is a permanent alias onto deepseek-v4-flash with thinking on, so it
@@ -85,8 +94,8 @@ func InjectProviderParams(raw map[string]any, providerType, modelID string) bool
 }
 
 // backfillDeepSeekReasoning ensures every assistant message in the messages
-// array has a reasoning_content field. DeepSeek V4/R1 reject requests where
-// any assistant message is missing this field.
+// array has a reasoning_content field. See the "deepseek" case above for why
+// this is kept now that the API accepts messages without it.
 func backfillDeepSeekReasoning(raw map[string]any) bool {
 	messages, ok := raw["messages"].([]any)
 	if !ok {

--- a/internal/paramrewrite/inject.go
+++ b/internal/paramrewrite/inject.go
@@ -63,8 +63,16 @@ func InjectProviderParams(raw map[string]any, providerType, modelID string) bool
 	case "deepseek":
 		// DeepSeek V4 and R1 require reasoning_content on every assistant message.
 		// If any assistant message lacks reasoning_content, the API rejects the request.
+		//
+		// deepseek-reasoner is matched by name because it names no version: it
+		// is a permanent alias onto deepseek-v4-flash with thinking on, so it
+		// reaches the same backend as an id the substring test already covers.
+		// deepseek-chat stays out on purpose — it is the same model with
+		// thinking off, and returns no reasoning_content to echo back.
 		modelLower := strings.ToLower(modelID)
-		isReasoningModel := strings.Contains(modelLower, "v4") || strings.Contains(modelLower, "r1")
+		isReasoningModel := strings.Contains(modelLower, "v4") ||
+			strings.Contains(modelLower, "r1") ||
+			modelLower == "deepseek-reasoner"
 		if isReasoningModel {
 			if backfillDeepSeekReasoning(raw) {
 				modified = true

--- a/internal/paramrewrite/inject_test.go
+++ b/internal/paramrewrite/inject_test.go
@@ -178,6 +178,49 @@ func TestInjectProviderParams_DeepSeekNonReasoning(t *testing.T) {
 	}
 }
 
+// TestInjectProviderParams_DeepSeekReasonerAlias covers the alias whose name
+// carries no version. deepseek-reasoner is absent from DeepSeek's /models
+// listing and resolves to deepseek-v4-flash with thinking on, so it needs the
+// same backfill as the versioned id, which the v4/r1 substring test misses.
+func TestInjectProviderParams_DeepSeekReasonerAlias(t *testing.T) {
+	raw := map[string]any{
+		"model": "deepseek-reasoner",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "Q1"},
+			map[string]any{"role": "assistant", "content": "A1"},
+			map[string]any{"role": "user", "content": "Q2"},
+		},
+	}
+	if !InjectProviderParams(raw, "deepseek", "deepseek-reasoner") {
+		t.Fatal("expected reasoning_content backfill for deepseek-reasoner")
+	}
+	assistant := raw["messages"].([]any)[1].(map[string]any)
+	if _, exists := assistant["reasoning_content"]; !exists {
+		t.Error("assistant message missing reasoning_content")
+	}
+}
+
+// TestInjectProviderParams_DeepSeekChatAliasSkipped is the other half: chat is
+// the non-thinking preset on the same model and returns no reasoning_content,
+// so it must stay out of the backfill.
+func TestInjectProviderParams_DeepSeekChatAliasSkipped(t *testing.T) {
+	raw := map[string]any{
+		"model": "deepseek-chat",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "Q1"},
+			map[string]any{"role": "assistant", "content": "A1"},
+			map[string]any{"role": "user", "content": "Q2"},
+		},
+	}
+	if InjectProviderParams(raw, "deepseek", "deepseek-chat") {
+		t.Error("deepseek-chat is non-thinking and must not be backfilled")
+	}
+	assistant := raw["messages"].([]any)[1].(map[string]any)
+	if _, exists := assistant["reasoning_content"]; exists {
+		t.Error("deepseek-chat assistant message should not gain reasoning_content")
+	}
+}
+
 func TestInjectProviderParams_DeepSeekV4_AllAssistantBackfilled(t *testing.T) {
 	raw := map[string]any{
 		"model": "deepseek-v4-pro",

--- a/internal/provider/catalogs/deepseek.json
+++ b/internal/provider/catalogs/deepseek.json
@@ -1,6 +1,7 @@
 [
   {
     "model_id": "deepseek-chat",
+    "description": "Alias for deepseek-v4-flash with thinking off. Listed price is DeepSeek's off-peak rate; billing doubles during peak hours (01:00-04:00 and 06:00-10:00 UTC).",
     "context_length": 1000000,
     "max_output_tokens": 384000,
     "reasoning": false,
@@ -10,6 +11,7 @@
   },
   {
     "model_id": "deepseek-reasoner",
+    "description": "Alias for deepseek-v4-flash with thinking on. Listed price is DeepSeek's off-peak rate; billing doubles during peak hours (01:00-04:00 and 06:00-10:00 UTC).",
     "context_length": 1000000,
     "max_output_tokens": 384000,
     "reasoning": true,
@@ -19,6 +21,7 @@
   },
   {
     "model_id": "deepseek-v4-flash",
+    "description": "DeepSeek V4 Flash. Listed price is DeepSeek's off-peak rate; billing doubles during peak hours (01:00-04:00 and 06:00-10:00 UTC).",
     "context_length": 1000000,
     "max_output_tokens": 384000,
     "reasoning": true,
@@ -28,6 +31,7 @@
   },
   {
     "model_id": "deepseek-v4-pro",
+    "description": "DeepSeek V4 Pro. Listed price is DeepSeek's off-peak rate; billing doubles during peak hours (01:00-04:00 and 06:00-10:00 UTC).",
     "context_length": 1000000,
     "max_output_tokens": 384000,
     "reasoning": true,
@@ -37,6 +41,7 @@
   },
   {
     "model_id": "deepseek-v4-flash-vision-exp",
+    "description": "DeepSeek V4 Flash Vision (experimental); accepts image input. Listed price is DeepSeek's off-peak rate; billing doubles during peak hours (01:00-04:00 and 06:00-10:00 UTC).",
     "context_length": 1000000,
     "max_output_tokens": 384000,
     "reasoning": true,

--- a/internal/provider/catalogs/deepseek.json
+++ b/internal/provider/catalogs/deepseek.json
@@ -4,35 +4,46 @@
     "context_length": 1000000,
     "max_output_tokens": 384000,
     "reasoning": false,
-    "input_price_per_million_cache_hit": 0.0028,
-    "input_price_per_million_cache_miss": 0.14,
-    "output_price_per_million": 0.28
+    "input_price_per_million_cache_hit": 0.007,
+    "input_price_per_million_cache_miss": 0.22,
+    "output_price_per_million": 0.66
   },
   {
     "model_id": "deepseek-reasoner",
     "context_length": 1000000,
     "max_output_tokens": 384000,
     "reasoning": true,
-    "input_price_per_million_cache_hit": 0.0028,
-    "input_price_per_million_cache_miss": 0.14,
-    "output_price_per_million": 0.28
+    "input_price_per_million_cache_hit": 0.007,
+    "input_price_per_million_cache_miss": 0.22,
+    "output_price_per_million": 0.66
   },
   {
     "model_id": "deepseek-v4-flash",
     "context_length": 1000000,
     "max_output_tokens": 384000,
-    "reasoning": false,
-    "input_price_per_million_cache_hit": 0.0028,
-    "input_price_per_million_cache_miss": 0.14,
-    "output_price_per_million": 0.28
+    "reasoning": true,
+    "input_price_per_million_cache_hit": 0.007,
+    "input_price_per_million_cache_miss": 0.22,
+    "output_price_per_million": 0.66
   },
   {
     "model_id": "deepseek-v4-pro",
     "context_length": 1000000,
     "max_output_tokens": 384000,
     "reasoning": true,
-    "input_price_per_million_cache_hit": 0.003625,
-    "input_price_per_million_cache_miss": 0.435,
-    "output_price_per_million": 0.87
+    "input_price_per_million_cache_hit": 0.022,
+    "input_price_per_million_cache_miss": 0.66,
+    "output_price_per_million": 1.98
+  },
+  {
+    "model_id": "deepseek-v4-flash-vision-exp",
+    "context_length": 1000000,
+    "max_output_tokens": 384000,
+    "reasoning": true,
+    "vision": true,
+    "input_modalities": "[\"text\",\"image\"]",
+    "input_price_per_million_cache_hit": 0.007,
+    "input_price_per_million_cache_miss": 0.22,
+    "output_price_per_million": 0.66
   }
 ]

--- a/internal/provider/catalogs_embed_test.go
+++ b/internal/provider/catalogs_embed_test.go
@@ -1,7 +1,12 @@
 package provider
 
 import (
+	"encoding/json"
 	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/hugalafutro/model-hotel/internal/model"
 )
 
 // TestLoadCatalog_ValidJSON verifies that loadCatalog successfully parses
@@ -90,6 +95,48 @@ func TestLoadCatalog_DeepSeekCatalog(t *testing.T) {
 	}
 	if first.ContextLength <= 0 {
 		t.Errorf("first entry (%s): ContextLength = %d, want > 0", first.ModelID, first.ContextLength)
+	}
+}
+
+// TestDeepSeekCatalog_VisionModel covers the one DeepSeek model models.dev has
+// never heard of. Without a row here it discovers as a bare stub: no price (so
+// it meters at zero), no context window, and no vision flag despite being the
+// only DeepSeek model that accepts an image.
+func TestDeepSeekCatalog_VisionModel(t *testing.T) {
+	spec := GetDeepSeekModelSpec("deepseek-v4-flash-vision-exp")
+	if spec == nil {
+		t.Fatal("deepseek.json must carry deepseek-v4-flash-vision-exp: models.dev has no entry for it")
+	}
+	if !spec.Vision {
+		t.Error("the vision model must declare Vision")
+	}
+	if spec.InputPricePerMillionCacheMiss <= 0 || spec.OutputPricePerMillion <= 0 {
+		t.Error("the vision model must carry prices, or it meters at zero")
+	}
+
+	m := deepseekSpecToModel(spec, uuid.New())
+	if m.InputModalities != `["text","image"]` {
+		t.Errorf("InputModalities = %s, want [\"text\",\"image\"]", m.InputModalities)
+	}
+	var caps model.Capability
+	if err := json.Unmarshal([]byte(m.Capabilities), &caps); err != nil {
+		t.Fatalf("unmarshal capabilities: %v", err)
+	}
+	if !caps.Vision {
+		t.Error("Vision capability should reach the model")
+	}
+}
+
+// TestDeepSeekCatalog_DefaultsToTextOnly guards the other side of that field:
+// every other DeepSeek model omits input_modalities and must stay text-only.
+func TestDeepSeekCatalog_DefaultsToTextOnly(t *testing.T) {
+	spec := GetDeepSeekModelSpec("deepseek-chat")
+	if spec == nil {
+		t.Fatal("deepseek.json must keep deepseek-chat: the live listing does not return it")
+	}
+	m := deepseekSpecToModel(spec, uuid.New())
+	if m.InputModalities != `["text"]` {
+		t.Errorf("InputModalities = %s, want [\"text\"]", m.InputModalities)
 	}
 }
 

--- a/internal/provider/catalogs_embed_test.go
+++ b/internal/provider/catalogs_embed_test.go
@@ -68,6 +68,39 @@ func TestLoadCatalog_AllCatalogsParse(t *testing.T) {
 	}
 }
 
+// TestLoadCatalog_ModalityStringsParse checks every embedded catalog row whose
+// modalities are carried as an embedded JSON-array string.
+//
+// Nothing validates those at load time: loadCatalog only unmarshals the outer
+// struct, so `[text,image]` survives all the way to NormalizeModels, where
+// parseModalityList fails silently and the row degrades to text-only. No crash,
+// no log, no failing test — which is why this asserts the shape directly.
+func TestLoadCatalog_ModalityStringsParse(t *testing.T) {
+	check := func(t *testing.T, id, field, raw string) {
+		t.Helper()
+		if raw == "" {
+			return
+		}
+		var mods []string
+		if err := json.Unmarshal([]byte(raw), &mods); err != nil {
+			t.Errorf("%s %s = %q, which is not a JSON string array: %v", id, field, raw, err)
+		}
+	}
+	for _, file := range []string{"opencode_zen.json", "opencode_go.json", "xai.json"} {
+		for _, e := range loadCatalog[[]OpenCodeModelSpec](file) {
+			check(t, file+"/"+e.ModelID, "input_modalities", e.InputModalities)
+			check(t, file+"/"+e.ModelID, "output_modalities", e.OutputModalities)
+		}
+	}
+	for _, e := range loadCatalog[[]OpenAIModelSpec]("openai.json") {
+		check(t, "openai.json/"+e.ModelID, "input_modalities", e.InputModalities)
+		check(t, "openai.json/"+e.ModelID, "output_modalities", e.OutputModalities)
+	}
+	for _, e := range loadCatalog[[]DeepSeekModelSpec]("deepseek.json") {
+		check(t, "deepseek.json/"+e.ModelID, "input_modalities", e.InputModalities)
+	}
+}
+
 // TestLoadCatalog_InvalidPath panics on missing file.
 func TestLoadCatalog_InvalidPath(t *testing.T) {
 	defer func() {

--- a/internal/provider/catalogs_embed_test.go
+++ b/internal/provider/catalogs_embed_test.go
@@ -127,6 +127,73 @@ func TestDeepSeekCatalog_VisionModel(t *testing.T) {
 	}
 }
 
+// TestDeepSeekCatalog_Prices pins DeepSeek's published off-peak rates. Nothing
+// else can catch a typo here: models.dev still carries the pre-V4 figures, so a
+// diff against it reports every one of these rows as diverging by design.
+func TestDeepSeekCatalog_Prices(t *testing.T) {
+	// cache-hit / cache-miss / output, dollars per million tokens.
+	want := map[string][3]float64{
+		"deepseek-chat":                {0.007, 0.22, 0.66},
+		"deepseek-reasoner":            {0.007, 0.22, 0.66},
+		"deepseek-v4-flash":            {0.007, 0.22, 0.66},
+		"deepseek-v4-flash-vision-exp": {0.007, 0.22, 0.66},
+		"deepseek-v4-pro":              {0.022, 0.66, 1.98},
+	}
+	catalog := GetDeepSeekModels()
+	if len(catalog) != len(want) {
+		t.Errorf("catalog has %d rows, want %d", len(catalog), len(want))
+	}
+	for id, w := range want {
+		spec := GetDeepSeekModelSpec(id)
+		if spec == nil {
+			t.Errorf("deepseek.json is missing %q", id)
+			continue
+		}
+		got := [3]float64{
+			spec.InputPricePerMillionCacheHit,
+			spec.InputPricePerMillionCacheMiss,
+			spec.OutputPricePerMillion,
+		}
+		if got != w {
+			t.Errorf("%s prices = %v, want %v (cache-hit/cache-miss/output)", id, got, w)
+		}
+	}
+}
+
+// TestDeepSeekCatalog_ThinkingModes pins which rows report reasoning. DeepSeek
+// V4 models default to thinking mode, and deepseek-chat is the one alias that
+// selects the non-thinking preset on the same underlying deepseek-v4-flash.
+// Verified against the live API: a bare "say hi" to deepseek-v4-flash returns
+// reasoning_content with 16 reasoning tokens, the same call to deepseek-chat
+// returns none.
+func TestDeepSeekCatalog_ThinkingModes(t *testing.T) {
+	want := map[string]bool{
+		"deepseek-chat":                false,
+		"deepseek-reasoner":            true,
+		"deepseek-v4-flash":            true,
+		"deepseek-v4-pro":              true,
+		"deepseek-v4-flash-vision-exp": true,
+	}
+	for id, reasoning := range want {
+		spec := GetDeepSeekModelSpec(id)
+		if spec == nil {
+			t.Errorf("deepseek.json is missing %q", id)
+			continue
+		}
+		if spec.Reasoning != reasoning {
+			t.Errorf("%s: Reasoning = %v, want %v", id, spec.Reasoning, reasoning)
+		}
+		m := deepseekSpecToModel(spec, uuid.New())
+		var caps model.Capability
+		if err := json.Unmarshal([]byte(m.Capabilities), &caps); err != nil {
+			t.Fatalf("%s: unmarshal capabilities: %v", id, err)
+		}
+		if caps.Reasoning != reasoning {
+			t.Errorf("%s: capability Reasoning = %v, want %v", id, caps.Reasoning, reasoning)
+		}
+	}
+}
+
 // TestDeepSeekCatalog_DefaultsToTextOnly guards the other side of that field:
 // every other DeepSeek model omits input_modalities and must stay text-only.
 func TestDeepSeekCatalog_DefaultsToTextOnly(t *testing.T) {

--- a/internal/provider/deepseek_catalog.go
+++ b/internal/provider/deepseek_catalog.go
@@ -17,7 +17,10 @@ import (
 // conditional surcharge (openai.json carries gpt-5.x-pro at its standard rate,
 // not the >200K-context tier).
 type DeepSeekModelSpec struct {
-	ModelID         string `json:"model_id"`
+	ModelID string `json:"model_id"`
+	// Description reaches the dashboard, and is the only place an operator can
+	// find out that the listed price is the off-peak one.
+	Description     string `json:"description,omitempty"`
 	ContextLength   int    `json:"context_length"`
 	MaxOutputTokens int    `json:"max_output_tokens"`
 	Reasoning       bool   `json:"reasoning"`
@@ -83,6 +86,7 @@ func deepseekSpecToModel(spec *DeepSeekModelSpec, providerID uuid.UUID) *model.M
 		ModelID:                      spec.ModelID,
 		Name:                         spec.ModelID,
 		DisplayName:                  spec.ModelID,
+		Description:                  spec.Description,
 		Capabilities:                 string(capJSON),
 		Params:                       "{}",
 		InputModalities:              inputModalities,

--- a/internal/provider/deepseek_catalog.go
+++ b/internal/provider/deepseek_catalog.go
@@ -9,16 +9,34 @@ import (
 )
 
 // DeepSeekModelSpec contains specification and pricing for a DeepSeek model.
+//
+// Prices are DeepSeek's OFF-PEAK rates, which apply for 17 of every 24 hours.
+// Peak hours (01:00-04:00 and 06:00-10:00 UTC) bill at exactly double, and a
+// model row holds one figure, so metering under-reports during that window.
+// This matches how the other catalogs store a base rate rather than a
+// conditional surcharge (openai.json carries gpt-5.x-pro at its standard rate,
+// not the >200K-context tier).
 type DeepSeekModelSpec struct {
-	ModelID                       string  `json:"model_id"`
-	ContextLength                 int     `json:"context_length"`
-	MaxOutputTokens               int     `json:"max_output_tokens"`
-	Reasoning                     bool    `json:"reasoning"`
+	ModelID         string `json:"model_id"`
+	ContextLength   int    `json:"context_length"`
+	MaxOutputTokens int    `json:"max_output_tokens"`
+	Reasoning       bool   `json:"reasoning"`
+	Vision          bool   `json:"vision,omitempty"`
+	// InputModalities is a JSON array literal, e.g. `["text","image"]`. Empty
+	// defaults to text-only, which is every DeepSeek model but the vision one.
+	InputModalities               string  `json:"input_modalities,omitempty"`
 	InputPricePerMillionCacheHit  float64 `json:"input_price_per_million_cache_hit,omitempty"`
 	InputPricePerMillionCacheMiss float64 `json:"input_price_per_million_cache_miss"`
 	OutputPricePerMillion         float64 `json:"output_price_per_million"`
 }
 
+// deepseekCatalog is not an ordinary price-override channel. models.dev still
+// carries DeepSeek's pre-V4 rates (0.14/0.28) under the V4 model IDs, and knows
+// nothing at all about deepseek-v4-flash-vision-exp, so these rows are the only
+// correct pricing MH has. deepseek-chat and deepseek-reasoner are absent from
+// the live /models listing entirely — they are permanent aliases onto
+// deepseek-v4-flash, non-thinking and thinking respectively — so the catalog is
+// also the only thing surfacing them.
 var deepseekCatalog = loadCatalog[[]DeepSeekModelSpec]("deepseek.json")
 
 // GetDeepSeekModels returns the full DeepSeek model catalog.
@@ -44,8 +62,14 @@ func deepseekSpecToModel(spec *DeepSeekModelSpec, providerID uuid.UUID) *model.M
 		Streaming:   true,
 		Reasoning:   spec.Reasoning,
 		ToolCalling: true,
+		Vision:      spec.Vision,
 	}
 	capJSON, _ := json.Marshal(caps)
+
+	inputModalities := spec.InputModalities
+	if inputModalities == "" {
+		inputModalities = `["text"]`
+	}
 
 	contextLen := spec.ContextLength
 	maxOutput := spec.MaxOutputTokens
@@ -61,7 +85,7 @@ func deepseekSpecToModel(spec *DeepSeekModelSpec, providerID uuid.UUID) *model.M
 		DisplayName:                  spec.ModelID,
 		Capabilities:                 string(capJSON),
 		Params:                       "{}",
-		InputModalities:              `["text"]`,
+		InputModalities:              inputModalities,
 		OutputModalities:             `["text"]`,
 		ContextLength:                &contextLen,
 		MaxOutputTokens:              &maxOutput,

--- a/internal/provider/deepseek_catalog.go
+++ b/internal/provider/deepseek_catalog.go
@@ -27,6 +27,11 @@ type DeepSeekModelSpec struct {
 	Vision          bool   `json:"vision,omitempty"`
 	// InputModalities is a JSON array literal, e.g. `["text","image"]`. Empty
 	// defaults to text-only, which is every DeepSeek model but the vision one.
+	//
+	// It overlaps with Vision rather than complementing it: NormalizeModels
+	// derives "image" from the flag and the flag back from the array, so
+	// setting either alone reaches the same end state. Set both, so a reader of
+	// the row does not have to know that.
 	InputModalities               string  `json:"input_modalities,omitempty"`
 	InputPricePerMillionCacheHit  float64 `json:"input_price_per_million_cache_hit,omitempty"`
 	InputPricePerMillionCacheMiss float64 `json:"input_price_per_million_cache_miss"`

--- a/internal/provider/modelsdev.go
+++ b/internal/provider/modelsdev.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -464,26 +465,34 @@ func mergeSpecCapabilities(spec *ModelsDevModelSpec, caps *model.Capability) boo
 		merged = true
 	}
 	// Attachment → Vision mapping, corroborated by the declared input
-	// modalities. models.dev sets attachment on 109 models whose only input
-	// modality is text, including deepseek-chat and deepseek-reasoner, which
-	// answer an image with HTTP 400 "This model does not support image".
+	// modalities. models.dev sets attachment on a number of models whose only
+	// input modality is text, among them deepseek-chat and deepseek-reasoner,
+	// which answer an image with HTTP 400 "This model does not support image".
 	// Attachment alone therefore advertises vision the provider will refuse.
-	if spec.Attachment && hasMediaInput(spec.Modalities.Input) && !caps.Vision {
+	if spec.Attachment && attachmentImpliesVision(spec.Modalities.Input) && !caps.Vision {
 		caps.Vision = true
 		merged = true
 	}
 	return merged
 }
 
-// hasMediaInput reports whether any declared input modality is something other
-// than text, which is what makes an attachment claim believable.
-func hasMediaInput(input []string) bool {
-	for _, mod := range input {
-		if mod != "" && mod != "text" {
-			return true
-		}
+// attachmentImpliesVision reports whether an attachment claim is corroborated
+// by the declared input modalities.
+//
+// Vision means image specifically (capsInputFlags maps it that way), so audio,
+// video and pdf inputs are not evidence for it. Accepting them would grant
+// vision to models that take a document but refuse a picture, and because
+// unionCapsIntoInput derives modalities back out of the flags, it would also
+// append "image" to their stored input array.
+//
+// An absent input list is no evidence either way, so the attachment flag stands
+// alone there rather than silently losing vision on a models.dev entry that
+// simply carries no modality data.
+func attachmentImpliesVision(input []string) bool {
+	if len(input) == 0 {
+		return true
 	}
-	return false
+	return slices.Contains(input, "image")
 }
 
 // fillModalities marshals mods into *dst when *dst is currently empty,

--- a/internal/provider/modelsdev.go
+++ b/internal/provider/modelsdev.go
@@ -463,12 +463,27 @@ func mergeSpecCapabilities(spec *ModelsDevModelSpec, caps *model.Capability) boo
 		caps.StructuredOutput = true
 		merged = true
 	}
-	// Attachment → Vision mapping.
-	if spec.Attachment && !caps.Vision {
+	// Attachment → Vision mapping, corroborated by the declared input
+	// modalities. models.dev sets attachment on 109 models whose only input
+	// modality is text, including deepseek-chat and deepseek-reasoner, which
+	// answer an image with HTTP 400 "This model does not support image".
+	// Attachment alone therefore advertises vision the provider will refuse.
+	if spec.Attachment && hasMediaInput(spec.Modalities.Input) && !caps.Vision {
 		caps.Vision = true
 		merged = true
 	}
 	return merged
+}
+
+// hasMediaInput reports whether any declared input modality is something other
+// than text, which is what makes an attachment claim believable.
+func hasMediaInput(input []string) bool {
+	for _, mod := range input {
+		if mod != "" && mod != "text" {
+			return true
+		}
+	}
+	return false
 }
 
 // fillModalities marshals mods into *dst when *dst is currently empty,

--- a/internal/provider/modelsdev_cache_test.go
+++ b/internal/provider/modelsdev_cache_test.go
@@ -925,44 +925,61 @@ func TestModelsDevCacheEnrichModel_Capabilities(t *testing.T) {
 		t.Error("expected structured output capability to be set")
 	}
 	if !caps.Vision {
-		t.Error("expected vision capability to be set (from attachment)")
+		t.Error("expected vision capability to be set (from attachment plus an image input modality)")
 	}
 }
 
-// TestModelsDevCacheEnrichModel_AttachmentWithoutMediaModality pins the rule
-// that an attachment flag alone does not make a model multimodal. models.dev
-// sets attachment on deepseek-chat and deepseek-reasoner while declaring their
-// only input modality as text, and DeepSeek answers an image on either with
-// HTTP 400 "This model does not support image" — so trusting attachment on its
-// own advertises a capability the provider refuses.
-func TestModelsDevCacheEnrichModel_AttachmentWithoutMediaModality(t *testing.T) {
-	spec := &ModelsDevModelSpec{
-		ID:         "text-only-model",
-		Name:       "Text Only Model",
-		Attachment: true,
-		Modalities: ModelsDevModalities{
-			Input:  []string{"text"},
-			Output: []string{"text"},
-		},
-		Cost:  ModelsDevCost{Input: 1, Output: 2},
-		Limit: ModelsDevLimit{Context: 100, Output: 50},
+// TestModelsDevCacheEnrichModel_AttachmentNeedsImageInput pins the rule that an
+// attachment flag only implies vision when the input modalities name an image.
+//
+// models.dev sets attachment on deepseek-chat and deepseek-reasoner while
+// declaring their only input as text, and DeepSeek answers an image on either
+// with HTTP 400 "This model does not support image". A further 71 entries pair
+// attachment with audio, video or pdf but no image; granting those vision would
+// be the same error, and unionCapsIntoInput would then append "image" to their
+// stored input array. An entry with no modality data at all is no evidence
+// either way, so the attachment flag still stands there.
+func TestModelsDevCacheEnrichModel_AttachmentNeedsImageInput(t *testing.T) {
+	cases := []struct {
+		name       string
+		input      []string
+		wantVision bool
+	}{
+		{"text only", []string{"text"}, false},
+		{"pdf but no image", []string{"text", "pdf"}, false},
+		{"audio but no image", []string{"text", "audio"}, false},
+		{"video but no image", []string{"video"}, false},
+		{"image present", []string{"text", "image"}, true},
+		{"no modality data", nil, true},
 	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := &ModelsDevModelSpec{
+				ID:         "probe-model",
+				Name:       "Probe Model",
+				Attachment: true,
+				Modalities: ModelsDevModalities{Input: tc.input, Output: []string{"text"}},
+				Cost:       ModelsDevCost{Input: 1, Output: 2},
+				Limit:      ModelsDevLimit{Context: 100, Output: 50},
+			}
 
-	cache := &ModelsDevCache{}
-	cache.mu.Lock()
-	cache.byID = map[string]*ModelsDevModelSpec{"text-only-model": spec}
-	cache.loaded = true
-	cache.mu.Unlock()
+			cache := &ModelsDevCache{}
+			cache.mu.Lock()
+			cache.byID = map[string]*ModelsDevModelSpec{"probe-model": spec}
+			cache.loaded = true
+			cache.mu.Unlock()
 
-	m := &model.Model{ModelID: "text-only-model", Capabilities: "{}", Modality: "text"}
-	cache.EnrichModel(m, "")
+			m := &model.Model{ModelID: "probe-model", Capabilities: "{}", Modality: "text"}
+			cache.EnrichModel(m, "")
 
-	var caps model.Capability
-	if err := json.Unmarshal([]byte(m.Capabilities), &caps); err != nil {
-		t.Fatalf("unmarshal capabilities: %v", err)
-	}
-	if caps.Vision {
-		t.Error("attachment on a text-only model must not set vision")
+			var caps model.Capability
+			if err := json.Unmarshal([]byte(m.Capabilities), &caps); err != nil {
+				t.Fatalf("unmarshal capabilities: %v", err)
+			}
+			if caps.Vision != tc.wantVision {
+				t.Errorf("input %v: Vision = %v, want %v", tc.input, caps.Vision, tc.wantVision)
+			}
+		})
 	}
 }
 

--- a/internal/provider/modelsdev_cache_test.go
+++ b/internal/provider/modelsdev_cache_test.go
@@ -886,7 +886,9 @@ func TestModelsDevCacheEnrichModel_Capabilities(t *testing.T) {
 		StructuredOutput: &structuredOutput,
 		Attachment:       true,
 		Modalities: ModelsDevModalities{
-			Input:  []string{"text"},
+			// An attachment claim only yields vision when the input modalities
+			// corroborate it; see TestModelsDevCacheEnrichModel_AttachmentWithoutMediaModality.
+			Input:  []string{"text", "image"},
 			Output: []string{"text"},
 		},
 		Cost:  ModelsDevCost{Input: 1, Output: 2},
@@ -924,6 +926,43 @@ func TestModelsDevCacheEnrichModel_Capabilities(t *testing.T) {
 	}
 	if !caps.Vision {
 		t.Error("expected vision capability to be set (from attachment)")
+	}
+}
+
+// TestModelsDevCacheEnrichModel_AttachmentWithoutMediaModality pins the rule
+// that an attachment flag alone does not make a model multimodal. models.dev
+// sets attachment on deepseek-chat and deepseek-reasoner while declaring their
+// only input modality as text, and DeepSeek answers an image on either with
+// HTTP 400 "This model does not support image" — so trusting attachment on its
+// own advertises a capability the provider refuses.
+func TestModelsDevCacheEnrichModel_AttachmentWithoutMediaModality(t *testing.T) {
+	spec := &ModelsDevModelSpec{
+		ID:         "text-only-model",
+		Name:       "Text Only Model",
+		Attachment: true,
+		Modalities: ModelsDevModalities{
+			Input:  []string{"text"},
+			Output: []string{"text"},
+		},
+		Cost:  ModelsDevCost{Input: 1, Output: 2},
+		Limit: ModelsDevLimit{Context: 100, Output: 50},
+	}
+
+	cache := &ModelsDevCache{}
+	cache.mu.Lock()
+	cache.byID = map[string]*ModelsDevModelSpec{"text-only-model": spec}
+	cache.loaded = true
+	cache.mu.Unlock()
+
+	m := &model.Model{ModelID: "text-only-model", Capabilities: "{}", Modality: "text"}
+	cache.EnrichModel(m, "")
+
+	var caps model.Capability
+	if err := json.Unmarshal([]byte(m.Capabilities), &caps); err != nil {
+		t.Fatalf("unmarshal capabilities: %v", err)
+	}
+	if caps.Vision {
+		t.Error("attachment on a text-only model must not set vision")
 	}
 }
 


### PR DESCRIPTION
## What

Adds `deepseek-v4-flash-vision-exp`, corrects every DeepSeek price, and stops models.dev's
`attachment` flag inventing vision support on text-only models.

All of it was verified against the live DeepSeek API with a throwaway key, not inferred.

## The vision model

Discovery already *found* `deepseek-v4-flash-vision-exp` (it flags it `new_model`), but it landed as
a bare stub: models.dev has no entry for it, so no price (metering at zero), no context window, and
no vision flag despite being the only DeepSeek model that accepts an image. `DeepSeekModelSpec` had
nowhere to say otherwise — it hardcoded `["text"]` modalities and never set `Vision` — so this adds
`vision` and `input_modalities` fields plus the catalog row that uses them.

Probed directly: images work, thinking works (`reasoning_content` returned), tool calls work.

## The prices were wrong in both sources

models.dev still carries DeepSeek's pre-V4 rates under the V4 model IDs, and the catalog had copied
them. Published rates vs what we shipped:

| model | was (catalog + models.dev) | actual (off-peak) |
|---|---|---|
| deepseek-v4-flash | 0.14 / 0.28, cache 0.0028 | 0.22 / 0.66, cache 0.007 |
| deepseek-v4-pro | 0.435 / 0.87, cache 0.003625 | 0.66 / 1.98, cache 0.022 |

v4-pro was metering at roughly a third of its real cost. Because both sources were stale in the same
direction, a catalog-vs-models.dev diff reported "in sync" — the one thing that comparison cannot catch.

These are the **off-peak** figures, which apply 17 hours a day. Peak (01:00-04:00 and 06:00-10:00 UTC)
is exactly double, and a row holds one number, so metering under-reports in that window. This matches
how the other catalogs store a base rate rather than a conditional surcharge (`openai.json` carries
gpt-5.x-pro at its standard rate, not the >200K-context tier).

## The aliases

`/models` returns only the v4 pair plus the vision model. `deepseek-chat` and `deepseek-reasoner` are
absent from the listing but still answer, and both resolve to `deepseek-v4-flash` — non-thinking and
thinking respectively. So they keep their catalog rows (the catalog is the only thing surfacing them)
and are priced as v4-flash.

## Bug: two models advertised vision they refuse

models.dev sets `attachment: true` on `deepseek-chat` and `deepseek-reasoner` while declaring their
only input modality as text. `EnrichModel` mapped attachment straight to vision, so all four prod
members advertised both as vision-capable. Sending either an image returns:

```
HTTP 400 {"error":{"message":"This model does not support image",...}}
```

Capabilities only ever merge upward, so no catalog row could correct it. Vision means image
specifically (`capsInputFlags` maps it that way), so the flag now only implies vision when the
declared input modalities name an image. An entry with no modality data at all keeps the old
behaviour, since that is no evidence either way.

**The trade, measured.** It fixes 109 attachment-true entries whose input is text-only, plus 71 more
that pair attachment with audio/video/pdf but no image — the latter would otherwise get vision *and*
have a fabricated `"image"` appended to their stored input array by `unionCapsIntoInput`.

Against that, an entry that genuinely takes images but declares text-only input would lose vision.
I checked how many of those Model Hotel can actually reach, since being present in models.dev is not
the same as being resolvable: the only candidate on a provider type MH supports is `azure/codex-mini`.
The Llama 4 entries that look alarming (`cerebras-llama-4-scout-17b-16e-instruct` and friends) sit
under models.dev's `llama` provider, which is Meta's own Llama API (`api.llama.com`) — MH has no
`llama` provider type and `modelsDevProviderForType` never maps to it, so those rows are only
reachable if some provider serves a model under that exact id, and none does. The Llama 4 models
actually discovered here arrive as `meta-llama/llama-4-scout` / `-maverick` via NanoGPT and
OpenRouter, and both declare `["text","image"]`, so they keep vision. No model currently on the fleet
changes its vision flag except the two DeepSeek aliases this PR is about.

Worth knowing either way: `capabilities = EXCLUDED.capabilities` on upsert has no
`capabilities_customized` guard, so if a model ever does lose vision wrongly, an operator cannot pin
it back — every discovery scan rewrites it.

## Verification

Rebuilt the dev stack and re-ran discovery. All five rows correct, including the vision flag clearing
itself off the two aliases:

```
deepseek-chat                  0.22/0.66 cache=0.007  inmod=["text"]          vision=False reason=False
deepseek-reasoner              0.22/0.66 cache=0.007  inmod=["text"]          vision=False reason=True
deepseek-v4-flash              0.22/0.66 cache=0.007  inmod=["text"]          vision=False reason=True
deepseek-v4-flash-vision-exp   0.22/0.66 cache=0.007  inmod=["text","image"]  vision=True  reason=True
deepseek-v4-pro                0.66/1.98 cache=0.022  inmod=["text"]          vision=False reason=True
```

993 provider tests and 3,812 across api/proxy/model pass; `golangci-lint` clean. Three new tests
cover the vision row, the text-only default, and the attachment-without-media rule.

## Note

Prod keeps serving the old prices and the false vision flags until this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
