### PR TITLE
fix(ci): name the scanned image in the scan report's package table

### DIFF
--- a/scripts/ci/summarise-code-scanning.sh
+++ b/scripts/ci/summarise-code-scanning.sh
@@ -103,6 +103,14 @@ def field($k):
   | ltrimstr($k + ": ")
   | sub("^\\s+|\\s+$"; "");
 
+# The SARIF category is an upload label, not a name anyone would recognise in
+# the report: the table says "scanned image", so the two images this repo
+# builds are shown under the names the rest of the issue already uses.
+def image_name:
+  if . == "published-image" then "model-hotel"
+  elif . == "published-frontdesk-image" then "model-hotel-frontdesk"
+  else . end;
+
 ($self | split(" ") | map(select(length > 0))) as $mine
 | map({
     tool:      (.tool.name // "unknown"),
@@ -128,7 +136,7 @@ def field($k):
           name:      .[0].package,
           installed: .[0].installed,
           fixed:     .[0].fixed,
-          category:  .[0].category,
+          category:  (.[0].category | image_name),
           ours:      .[0].ours,
           n:         length
         })


### PR DESCRIPTION
## Summary

The "Fixable OS packages" table in the published-image tracking issue (see #721) printed the SARIF upload category (`published-image`) under a column headed **scanned image**. `summarise-code-scanning.sh` now maps the two categories this repo uploads to the image names the rest of the report already uses (`model-hotel`, `model-hotel-frontdesk`); unknown categories pass through unchanged, so `(dependency)` rows are unaffected.

## Verification

- `shellcheck` clean.
- Dry-ran the extracted jq program against a synthetic alert list covering both own categories plus a foreign one: own rows render under the image names, the foreign row keeps its category with the `(dependency)` marker. No tests exist for these scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)