### PR TITLE
ui(models): scope picker sits beside the badge in the title row

### DIFF
--- a/web/src/components/FilterDropdown.tsx
+++ b/web/src/components/FilterDropdown.tsx
@@ -19,9 +19,11 @@ interface FilterDropdownProps {
 	 * Trigger sizing. "input" (default) matches a form field (ui-input, h-9).
 	 * "compact" drops ui-input for a 10px, minimally-padded trigger that sits
 	 * flush with the dashboard's segmented toggles (ui-tab) rather than towering
-	 * over them. Only the trigger changes; the popup menu is shared.
+	 * over them. "badge" takes the ui-badge box (same padding, line-height and
+	 * font size) so the trigger lines up with a badge beside a page title.
+	 * Only the trigger changes; the popup menu is shared.
 	 */
-	variant?: "input" | "compact";
+	variant?: "input" | "compact" | "badge";
 }
 
 export function FilterDropdown({
@@ -60,15 +62,18 @@ export function FilterDropdown({
 		? (selectedOption?.label ?? value)
 		: effectiveAllLabel;
 
-	const compact = variant === "compact";
+	const compact = variant === "compact" || variant === "badge";
 	// Compact avoids ui-input (whose themed base font/padding beat Tailwind
 	// utilities) so it can shrink to the 10px, py-px scale of the ui-tab toggles
 	// it sits beside; the default keeps the form-field look. w-full lets the
 	// button fill (and so truncate within) a width-capped wrapper such as the
 	// dashboard's max-w-32 rather than growing to a long owner label.
-	const triggerClass = compact
-		? "text-[10px] leading-[1.6] font-semibold py-px px-1.5 rounded-(--radius-button) border border-(--border-input) bg-(--surface-input) hover:border-(--accent) transition-colors flex items-center justify-between gap-1 w-full"
-		: "ui-input text-xs py-1.5 px-2.5 h-9 w-full flex items-center justify-between gap-2";
+	const triggerClass =
+		variant === "badge"
+			? "ui-badge ui-badge-neutral text-xs leading-[1.6] font-medium py-1 px-2.5 hover:border-(--accent) transition-colors flex items-center justify-between gap-2 w-full"
+			: compact
+				? "text-[10px] leading-[1.6] font-semibold py-px px-1.5 rounded-(--radius-button) border border-(--border-input) bg-(--surface-input) hover:border-(--accent) transition-colors flex items-center justify-between gap-1 w-full"
+				: "ui-input text-xs py-1.5 px-2.5 h-9 w-full flex items-center justify-between gap-2";
 	const iconSize = compact ? 12 : 14;
 
 	return (

--- a/web/src/pages/Models.tsx
+++ b/web/src/pages/Models.tsx
@@ -259,31 +259,52 @@ export function Models() {
 	);
 	const parkedCount = counts.parked;
 
-	const modelBadge =
-		disabledCount > 0 || parkedCount > 0 ? (
-			<span className="inline-flex items-center gap-2 px-2.5 py-1 leading-[1.6] text-xs font-medium ui-badge ui-badge-neutral">
-				{disabledCount > 0 && (
-					<span className="text-red-400">
-						<span className="badge-text">
-							{t("models.badge_disabled", { count: disabledCount })}
+	// The title row reads "N Models [remainder] [scope]": the scope picker sits
+	// beside the badge, in the badge's box, so what the count covers and what
+	// is being counted are read in one glance.
+	const scopePicker = (
+		<FilterDropdown
+			value={providerScope}
+			onChange={handleScopeChange}
+			allowClear={false}
+			variant="badge"
+			options={PROVIDER_SCOPES.map((scope) => ({
+				value: scope,
+				label: t(`models.scope_${scope}`),
+			}))}
+			className="shrink-0"
+		/>
+	);
+
+	const modelBadge = (
+		<>
+			{(disabledCount > 0 || parkedCount > 0) && (
+				<span className="inline-flex items-center gap-2 px-2.5 py-1 leading-[1.6] text-xs font-medium ui-badge ui-badge-neutral">
+					{disabledCount > 0 && (
+						<span className="text-red-400">
+							<span className="badge-text">
+								{t("models.badge_disabled", { count: disabledCount })}
+							</span>
 						</span>
-					</span>
-				)}
-				{disabledCount > 0 && parkedCount > 0 && (
-					<span className="text-gray-600">/</span>
-				)}
-				{parkedCount > 0 && (
-					<span
-						className="text-gray-400"
-						title={t("models.status_parked_hint")}
-					>
-						<span className="badge-text">
-							{t("models.badge_parked", { count: parkedCount })}
+					)}
+					{disabledCount > 0 && parkedCount > 0 && (
+						<span className="text-gray-600">/</span>
+					)}
+					{parkedCount > 0 && (
+						<span
+							className="text-gray-400"
+							title={t("models.status_parked_hint")}
+						>
+							<span className="badge-text">
+								{t("models.badge_parked", { count: parkedCount })}
+							</span>
 						</span>
-					</span>
-				)}
-			</span>
-		) : undefined;
+					)}
+				</span>
+			)}
+			{scopePicker}
+		</>
+	);
 
 	return (
 		<div className="space-y-4">
@@ -294,17 +315,6 @@ export function Models() {
 				badge={modelBadge}
 				actions={
 					<div className="flex items-center gap-2">
-						<FilterDropdown
-							value={providerScope}
-							onChange={handleScopeChange}
-							allowClear={false}
-							variant="compact"
-							options={PROVIDER_SCOPES.map((scope) => ({
-								value: scope,
-								label: t(`models.scope_${scope}`),
-							}))}
-							className="w-[190px] shrink-0"
-						/>
 						<button
 							type="button"
 							onClick={() =>

--- a/web/src/pages/Models.tsx
+++ b/web/src/pages/Models.tsx
@@ -272,7 +272,9 @@ export function Models() {
 				value: scope,
 				label: t(`models.scope_${scope}`),
 			}))}
-			className="shrink-0"
+			// Bounded so a long localized label truncates inside the picker
+			// instead of pushing the non-wrapping title row sideways.
+			className="max-w-[220px] min-w-0"
 		/>
 	);
 

--- a/web/src/pages/__tests__/Models.test.tsx
+++ b/web/src/pages/__tests__/Models.test.tsx
@@ -206,6 +206,24 @@ describe("Models", () => {
 			expect(screen.getByText("All (1) Providers")).toBeInTheDocument();
 		});
 
+		it("places the scope picker in the title row beside the badge", async () => {
+			const requested: string[] = [];
+			serveScoped(requested);
+
+			const { container } = renderWithProviders(<Models />);
+			await waitFor(() => {
+				expect(screen.getByText("1 Model")).toBeInTheDocument();
+			});
+
+			const titleRow = container.querySelector(".page-header-title-row");
+			expect(titleRow).not.toBeNull();
+			expect(
+				within(titleRow as HTMLElement).getByRole("button", {
+					name: "Filter: Active providers",
+				}),
+			).toBeInTheDocument();
+		});
+
 		it("switches scope and requests the parked rows", async () => {
 			const user = userEvent.setup();
 			const requested: string[] = [];


### PR DESCRIPTION
## Change

The provider-scope picker on the Models page moves from the header's action slot into the title row, beside the count badge, rendered in the badge's box (new `FilterDropdown` variant `"badge"`: same padding, line-height and font size as `ui-badge`). The title now reads as one line: `(icon) 315 Models [8 disabled] [Active providers]`.

No behaviour change; the picker still drives the same scope filter. One test added asserting the picker sits inside `.page-header-title-row`.

## Verification

vitest (Models page suites + FilterDropdown) 89 passed; tsc, ESLint, Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
