### PR TITLE
chore(bellhop): move clipboard copies to LocalClipboard, drop OkHttp 4 body guards

### DIFF
--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/FrontDeskClient.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/FrontDeskClient.kt
@@ -157,7 +157,7 @@ open class FrontDeskClient(
                         .post(body)
                         .build()
                 http.newCall(request).execute().use { resp ->
-                    val text = resp.body?.string().orEmpty()
+                    val text = resp.body.string()
                     when {
                         resp.isSuccessful -> PairResult.Success(json.decodeFromString(text))
                         resp.code == 401 -> PairResult.InvalidCode
@@ -459,7 +459,7 @@ open class FrontDeskClient(
                         .header("Authorization", "Bearer $token")
                         .build()
                 http.newCall(request).execute().use { resp ->
-                    val text = resp.body?.string().orEmpty()
+                    val text = resp.body.string()
                     when {
                         resp.isSuccessful -> FetchResult.Success(json.decodeFromString<T>(text))
                         resp.code == 401 -> FetchResult.Unauthorized
@@ -512,7 +512,7 @@ open class FrontDeskClient(
                         .method(method, requestBody)
                         .build()
                 client.newCall(request).execute().use { resp ->
-                    val text = resp.body?.string().orEmpty()
+                    val text = resp.body.string()
                     when {
                         resp.isSuccessful -> ActionResult.Success(json.decodeFromString<T>(text))
                         resp.code == 403 -> ActionResult.Forbidden

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/CopyText.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/common/CopyText.kt
@@ -1,0 +1,34 @@
+package com.hugalafutro.bellhop.ui.common
+
+import android.content.ClipData
+import android.widget.Toast
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.platform.ClipEntry
+import androidx.compose.ui.platform.LocalClipboard
+import androidx.compose.ui.platform.LocalContext
+import kotlinx.coroutines.launch
+
+/**
+ * rememberCopyText returns a `(text, confirmation) -> Unit` that puts [text] on
+ * the system clipboard as plain text and confirms the otherwise-silent act with
+ * a short toast of [confirmation].
+ *
+ * The copy itself is fire-and-forget: [androidx.compose.ui.platform.Clipboard]
+ * exposes a suspend write, so it is launched into the composition's scope
+ * while the toast shows straight away from the caller's event handler. The
+ * toast is what the user sees, and the write lands within the same frame.
+ */
+@Composable
+fun rememberCopyText(): (text: String, confirmation: String) -> Unit {
+    val clipboard = LocalClipboard.current
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    return remember(clipboard, context, scope) {
+        { text, confirmation ->
+            scope.launch { clipboard.setClipEntry(ClipEntry(ClipData.newPlainText(null, text))) }
+            Toast.makeText(context, confirmation, Toast.LENGTH_SHORT).show()
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/DashboardScreen.kt
@@ -1,7 +1,6 @@
 package com.hugalafutro.bellhop.ui.dashboard
 
 import android.content.Context
-import android.widget.Toast
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -53,12 +52,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextOverflow
@@ -85,6 +82,7 @@ import com.hugalafutro.bellhop.ui.common.TrafficChart
 import com.hugalafutro.bellhop.ui.common.healthColor
 import com.hugalafutro.bellhop.ui.common.healthLabel
 import com.hugalafutro.bellhop.ui.common.relativeAgo
+import com.hugalafutro.bellhop.ui.common.rememberCopyText
 import com.hugalafutro.bellhop.ui.common.severityColors
 import com.hugalafutro.bellhop.ui.common.withoutMemberName
 import com.hugalafutro.bellhop.ui.theme.BellhopTheme
@@ -126,7 +124,7 @@ fun DashboardScreen(
 ) {
     // Long-press copies a member row as text, with a toast to confirm the
     // otherwise-silent act. Gated on [holdToCopy] so it never fires by accident.
-    val clipboard = LocalClipboardManager.current
+    val copyText = rememberCopyText()
     val context = LocalContext.current
     val memberCopiedMsg = stringResource(R.string.dashboard_member_copied)
 
@@ -366,8 +364,7 @@ fun DashboardScreen(
                                     onLongClick =
                                         if (holdToCopy) {
                                             {
-                                                clipboard.setText(AnnotatedString(memberClipboardText(member)))
-                                                Toast.makeText(context, memberCopiedMsg, Toast.LENGTH_SHORT).show()
+                                                copyText(memberClipboardText(member), memberCopiedMsg)
                                             }
                                         } else {
                                             null

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/events/EventsScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/events/EventsScreen.kt
@@ -1,6 +1,5 @@
 package com.hugalafutro.bellhop.ui.events
 
-import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -26,12 +25,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalClipboardManager
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -47,6 +43,7 @@ import com.hugalafutro.bellhop.ui.common.SeverityRailRow
 import com.hugalafutro.bellhop.ui.common.StatusBanner
 import com.hugalafutro.bellhop.ui.common.eventTypeLabel
 import com.hugalafutro.bellhop.ui.common.loadMoreSentinel
+import com.hugalafutro.bellhop.ui.common.rememberCopyText
 import com.hugalafutro.bellhop.ui.theme.BellhopTheme
 import com.hugalafutro.bellhop.ui.theme.MonoFamily
 import java.time.Instant
@@ -78,13 +75,11 @@ fun EventsScreen(
     // A row copies the whole event as text (handy for pasting into a bug report),
     // with a toast to confirm the otherwise-silent act. Copy is long-press only
     // and gated on [holdToCopy].
-    val clipboard = LocalClipboardManager.current
-    val context = LocalContext.current
+    val copyText = rememberCopyText()
     val copiedMsg = stringResource(R.string.events_copied)
     val timePattern = LocalTimePattern.current
     val onCopy: (FdEvent) -> Unit = { event ->
-        clipboard.setText(AnnotatedString(eventClipboardText(event, memberNames[event.memberId], timePattern)))
-        Toast.makeText(context, copiedMsg, Toast.LENGTH_SHORT).show()
+        copyText(eventClipboardText(event, memberNames[event.memberId], timePattern), copiedMsg)
     }
     Scaffold(modifier = modifier.fillMaxSize()) { innerPadding ->
         Column(

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/member/MemberDetailScreen.kt
@@ -1,7 +1,6 @@
 package com.hugalafutro.bellhop.ui.member
 
 import android.content.Context
-import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -43,12 +42,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -76,6 +73,7 @@ import com.hugalafutro.bellhop.ui.common.eventTypeLabel
 import com.hugalafutro.bellhop.ui.common.healthColor
 import com.hugalafutro.bellhop.ui.common.loadMoreSentinel
 import com.hugalafutro.bellhop.ui.common.relativeAgo
+import com.hugalafutro.bellhop.ui.common.rememberCopyText
 import com.hugalafutro.bellhop.ui.common.withoutMemberName
 import com.hugalafutro.bellhop.ui.events.eventClipboardText
 import com.hugalafutro.bellhop.ui.events.formatEventTime
@@ -123,14 +121,13 @@ fun MemberDetailScreen(
     val health = member.status.health
     // A row copies the whole event as text, with a toast to confirm the otherwise-
     // silent act — the same affordance as the Events screen's log.
-    val clipboard = LocalClipboardManager.current
+    val copyText = rememberCopyText()
     val context = LocalContext.current
     val copiedMsg = stringResource(R.string.events_copied)
     val timePattern = LocalTimePattern.current
     val onCopyEvent: (FdEvent) -> Unit = { event ->
         val name = member.name.takeIf { event.memberId == member.id }
-        clipboard.setText(AnnotatedString(eventClipboardText(event, name, timePattern)))
-        Toast.makeText(context, copiedMsg, Toast.LENGTH_SHORT).show()
+        copyText(eventClipboardText(event, name, timePattern), copiedMsg)
     }
     // Clear the optimistic pending state once the dashboard's live state (member
     // arrives live from its poll/SSE) has caught up to the accepted target.

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/settings/SettingsScreen.kt
@@ -1,7 +1,6 @@
 package com.hugalafutro.bellhop.ui.settings
 
 import android.app.Activity
-import android.widget.Toast
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -36,14 +35,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -61,6 +58,7 @@ import com.hugalafutro.bellhop.ui.common.BellhopSwitch
 import com.hugalafutro.bellhop.ui.common.FilterPill
 import com.hugalafutro.bellhop.ui.common.NavChevron
 import com.hugalafutro.bellhop.ui.common.Pill
+import com.hugalafutro.bellhop.ui.common.rememberCopyText
 import com.hugalafutro.bellhop.ui.common.severityColors
 import com.hugalafutro.bellhop.ui.theme.BellhopTheme
 import java.time.Instant
@@ -128,7 +126,7 @@ fun SettingsScreen(
     var confirmUnlink by remember { mutableStateOf(false) }
     var confirmCopyAddress by remember { mutableStateOf(false) }
     var showLanguagePicker by remember { mutableStateOf(false) }
-    val clipboard = LocalClipboardManager.current
+    val copyText = rememberCopyText()
     val context = LocalContext.current
     // Read once: choosing a different language recreates the activity, so this
     // never needs to react to a live change.
@@ -210,8 +208,7 @@ fun SettingsScreen(
                 TextButton(
                     onClick = {
                         confirmCopyAddress = false
-                        clipboard.setText(AnnotatedString(address))
-                        Toast.makeText(context, addressCopied, Toast.LENGTH_SHORT).show()
+                        copyText(address, addressCopied)
                     },
                     modifier = Modifier.testTag("settings-fd-copy-confirm"),
                 ) {
@@ -651,8 +648,7 @@ fun SettingsScreen(
                                 )
                                 TextButton(
                                     onClick = {
-                                        clipboard.setText(AnnotatedString(endpoint))
-                                        Toast.makeText(context, pushCopied, Toast.LENGTH_SHORT).show()
+                                        copyText(endpoint, pushCopied)
                                     },
                                     modifier = Modifier.testTag("settings-push-copy"),
                                 ) {


### PR DESCRIPTION
## Summary

- Compose deprecated `LocalClipboardManager`; the four copy-then-toast sites (dashboard member card, events row, member-detail event row, settings FD address + push endpoint) now share one `rememberCopyText()` helper in `ui/common/CopyText.kt` built on `LocalClipboard` (suspend write launched into the composition scope, toast shown immediately). Visible behaviour unchanged, net -15 lines in the screens.
- OkHttp 5 made `ResponseBody` non-null: the three `resp.body?.string().orEmpty()` guards in `FrontDeskClient` were OkHttp 4 leftovers and are now `resp.body.string()`.

Found by running the JetBrains kotlin-lsp diagnostics sweep over every `.kt` file: 200 → 24 warnings, with all 4 `DEPRECATION` and 3 `UNNECESSARY_SAFE_CALL` findings gone. What remains is cosmetic (constant-condition analyzer artifacts on `BuildConfig`, multi-dollar-string nudges in tests).

## Verification

- `compileDebugKotlin` + `compileDebugUnitTestKotlin` clean; `ktlintCheck` clean
- Unit tests for the touched screens and client: 149 ran, 0 failed
- On the emulator, re-paired to the real Front Desk as operator: each of the four copy affordances shows its toast **and** Android's system clipboard preview chip carries the expected text (FD address, member line, event block on both Events and Member detail). No crash-buffer entries across the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
