### PR TITLE
test(api): stop subprocess-style backup tests leaking temp dirs

### DIFF
--- a/internal/api/backup_migrations_test.go
+++ b/internal/api/backup_migrations_test.go
@@ -622,7 +622,7 @@ func TestExtractMigrationNames_FilterFileWriteError(t *testing.T) {
 	}
 
 	cmd := exec.Command(os.Args[0], "-test.run=TestExtractMigrationNames_FilterFileWriteError")
-	cmd.Env = append(os.Environ(), "TEST_FILTER_FILE_WRITE_ERROR=1", "TMPDIR=/nonexistent/path/that/does/not/exist")
+	cmd.Env = append(os.Environ(), "TEST_FILTER_FILE_WRITE_ERROR=1")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("subprocess failed: %v\noutput: %s", err, output)
@@ -739,8 +739,11 @@ func TestParseMigrationNamesFromSQL_ManyMigrations(t *testing.T) {
 func TestExtractMigrationNames_FilterFileWriteError_Direct(t *testing.T) {
 	// This test runs as a subprocess to safely manipulate TMPDIR.
 	if os.Getenv("TEST_FILTER_WRITE_DIRECT") == "1" {
-		// Set TMPDIR to a read-only directory so os.CreateTemp returns an error
-		os.Setenv("TMPDIR", "/proc/1/fd") // not writable on Linux
+		// Set TMPDIR to a read-only directory so os.CreateTemp returns an error.
+		// Scoped via t.Setenv so it is restored before the process exits: the
+		// coverage runtime writes its profile through TMPDIR at exit and a
+		// broken value there fails the child with status 2.
+		t.Setenv("TMPDIR", "/proc/1/fd") // not writable on Linux
 		_, err := extractMigrationNames("/tmp/nonexistent.dump", 100)
 		if err == nil {
 			t.Fatalf("FILTER_WRITE_DIRECT: expected error")

--- a/internal/api/backup_migrations_test.go
+++ b/internal/api/backup_migrations_test.go
@@ -3,7 +3,6 @@ package api
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"net/url"
 	"os"
 	"os/exec"
@@ -609,19 +608,17 @@ func TestExtractMigrationNames_FilterFileWriteError(t *testing.T) {
 	// This test runs itself as a subprocess to safely manipulate TMPDIR
 	// without affecting other tests running in parallel.
 	if os.Getenv("TEST_FILTER_FILE_WRITE_ERROR") == "1" {
-		os.Setenv("TMPDIR", "/nonexistent/path/that/does/not/exist")
+		t.Setenv("TMPDIR", "/nonexistent/path/that/does/not/exist")
 		dumpPath := "/tmp/test.dump"
 
 		_, err := extractMigrationNames(dumpPath, 100)
 		if err == nil {
-			fmt.Printf("FILTER_WRITE: expected error when filter file cannot be created\n")
-			os.Exit(1)
+			t.Fatalf("FILTER_WRITE: expected error when filter file cannot be created")
 		}
 		if !strings.Contains(err.Error(), "failed to create filter file") {
-			fmt.Printf("FILTER_WRITE: expected 'failed to create filter file', got: %v\n", err)
-			os.Exit(1)
+			t.Fatalf("FILTER_WRITE: expected 'failed to create filter file', got: %v", err)
 		}
-		os.Exit(0)
+		return
 	}
 
 	cmd := exec.Command(os.Args[0], "-test.run=TestExtractMigrationNames_FilterFileWriteError")
@@ -640,21 +637,18 @@ func TestExtractMigrationNames_PgRestoreNotFound(t *testing.T) {
 	if os.Getenv("TEST_PG_RESTORE_NOT_FOUND") == "1" {
 		tmpFile, err := os.CreateTemp(t.TempDir(), "test-dump-*.dump")
 		if err != nil {
-			fmt.Printf("PG_RESTORE_NOT_FOUND: failed to create temp file: %v\n", err)
-			os.Exit(1)
+			t.Fatalf("PG_RESTORE_NOT_FOUND: failed to create temp file: %v", err)
 		}
 		tmpFile.Close()
 
 		_, err = extractMigrationNames(tmpFile.Name(), 100)
 		if err == nil {
-			fmt.Printf("PG_RESTORE_NOT_FOUND: expected error when pg_restore not found\n")
-			os.Exit(1)
+			t.Fatalf("PG_RESTORE_NOT_FOUND: expected error when pg_restore not found")
 		}
 		if !strings.Contains(err.Error(), "pg_restore not found") {
-			fmt.Printf("PG_RESTORE_NOT_FOUND: expected 'pg_restore not found', got: %v\n", err)
-			os.Exit(1)
+			t.Fatalf("PG_RESTORE_NOT_FOUND: expected 'pg_restore not found', got: %v", err)
 		}
-		os.Exit(0)
+		return
 	}
 
 	cmd := exec.Command(os.Args[0], "-test.run=TestExtractMigrationNames_PgRestoreNotFound")
@@ -749,15 +743,14 @@ func TestExtractMigrationNames_FilterFileWriteError_Direct(t *testing.T) {
 		os.Setenv("TMPDIR", "/proc/1/fd") // not writable on Linux
 		_, err := extractMigrationNames("/tmp/nonexistent.dump", 100)
 		if err == nil {
-			fmt.Printf("FILTER_WRITE_DIRECT: expected error\n")
-			os.Exit(1)
+			t.Fatalf("FILTER_WRITE_DIRECT: expected error")
 		}
 		// The error should be about creating the filter file
 		if !strings.Contains(err.Error(), "failed to create filter file") {
 			// Could also be about pg_restore not found depending on what fails first
 			t.Logf("got error: %v", err)
 		}
-		os.Exit(0)
+		return
 	}
 
 	cmd := exec.Command(os.Args[0], "-test.run=TestExtractMigrationNames_FilterFileWriteError_Direct")

--- a/internal/api/backup_migrations_test.go
+++ b/internal/api/backup_migrations_test.go
@@ -621,7 +621,7 @@ func TestExtractMigrationNames_FilterFileWriteError(t *testing.T) {
 		return
 	}
 
-	cmd := exec.Command(os.Args[0], "-test.run=TestExtractMigrationNames_FilterFileWriteError")
+	cmd := exec.Command(os.Args[0], "-test.run=^TestExtractMigrationNames_FilterFileWriteError$")
 	cmd.Env = append(os.Environ(), "TEST_FILTER_FILE_WRITE_ERROR=1")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -651,7 +651,7 @@ func TestExtractMigrationNames_PgRestoreNotFound(t *testing.T) {
 		return
 	}
 
-	cmd := exec.Command(os.Args[0], "-test.run=TestExtractMigrationNames_PgRestoreNotFound")
+	cmd := exec.Command(os.Args[0], "-test.run=^TestExtractMigrationNames_PgRestoreNotFound$")
 	cmd.Env = append(os.Environ(), "TEST_PG_RESTORE_NOT_FOUND=1", "PATH=/nonexistent")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -756,7 +756,7 @@ func TestExtractMigrationNames_FilterFileWriteError_Direct(t *testing.T) {
 		return
 	}
 
-	cmd := exec.Command(os.Args[0], "-test.run=TestExtractMigrationNames_FilterFileWriteError_Direct")
+	cmd := exec.Command(os.Args[0], "-test.run=^TestExtractMigrationNames_FilterFileWriteError_Direct$")
 	cmd.Env = append(os.Environ(), "TEST_FILTER_WRITE_DIRECT=1")
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/internal/api/backup_restore_test.go
+++ b/internal/api/backup_restore_test.go
@@ -895,7 +895,7 @@ func TestRestoreBackup_PgRestoreNotFound(t *testing.T) {
 		return
 	}
 
-	cmd := exec.Command(os.Args[0], "-test.run=TestRestoreBackup_PgRestoreNotFound")
+	cmd := exec.Command(os.Args[0], "-test.run=^TestRestoreBackup_PgRestoreNotFound$")
 	cmd.Env = append(os.Environ(), "TEST_NO_PG_RESTORE=1", "PATH=")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -983,7 +983,7 @@ func TestRestoreBackup_ExtractMigrationsError(t *testing.T) {
 		return
 	}
 
-	cmd := exec.Command(os.Args[0], "-test.run=TestRestoreBackup_ExtractMigrationsError")
+	cmd := exec.Command(os.Args[0], "-test.run=^TestRestoreBackup_ExtractMigrationsError$")
 	cmd.Env = append(os.Environ(), "TEST_EXTRACT_MIGRATIONS_ERROR=1")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -1068,7 +1068,7 @@ func TestSaveUploadedDump_CreateTempError(t *testing.T) {
 		return
 	}
 
-	cmd := exec.Command(os.Args[0], "-test.run=TestSaveUploadedDump_CreateTempError")
+	cmd := exec.Command(os.Args[0], "-test.run=^TestSaveUploadedDump_CreateTempError$")
 	cmd.Env = append(os.Environ(), "TEST_SAVE_UPLOAD_CREATE_TEMP=1")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -1099,7 +1099,7 @@ func TestRestoreBackup_SaveUploadedDumpIOCopyError(t *testing.T) {
 		return
 	}
 
-	cmd := exec.Command(os.Args[0], "-test.run=TestRestoreBackup_SaveUploadedDumpIOCopyError")
+	cmd := exec.Command(os.Args[0], "-test.run=^TestRestoreBackup_SaveUploadedDumpIOCopyError$")
 	cmd.Env = append(os.Environ(), "TEST_IO_COPY_ERROR=1")
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/internal/api/backup_restore_test.go
+++ b/internal/api/backup_restore_test.go
@@ -887,14 +887,12 @@ func TestRestoreBackup_PgRestoreNotFound(t *testing.T) {
 		r.ServeHTTP(w, req)
 
 		if w.Code != http.StatusPreconditionFailed {
-			fmt.Printf("NO_PG_RESTORE: expected 412, got %d: %s\n", w.Code, w.Body.String())
-			os.Exit(1)
+			t.Fatalf("NO_PG_RESTORE: expected 412, got %d: %s", w.Code, w.Body.String())
 		}
 		if !strings.Contains(w.Body.String(), "pg_restore not found") {
-			fmt.Printf("NO_PG_RESTORE: expected error to mention pg_restore, got: %s\n", w.Body.String())
-			os.Exit(1)
+			t.Fatalf("NO_PG_RESTORE: expected error to mention pg_restore, got: %s", w.Body.String())
 		}
-		os.Exit(0)
+		return
 	}
 
 	cmd := exec.Command(os.Args[0], "-test.run=TestRestoreBackup_PgRestoreNotFound")
@@ -924,8 +922,7 @@ func TestRestoreBackup_ExtractMigrationsError(t *testing.T) {
 		// Create a valid dump so RestoreBackup passes pg_restore --list validation.
 		u, err := url.Parse(apiTestDBURL)
 		if err != nil {
-			fmt.Printf("EXTRACT_MIG: failed to parse DB URL: %v\n", err)
-			os.Exit(1)
+			t.Fatalf("EXTRACT_MIG: failed to parse DB URL: %v", err)
 		}
 		dumpPath := filepath.Join(dir, "test.dump")
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -943,8 +940,7 @@ func TestRestoreBackup_ExtractMigrationsError(t *testing.T) {
 			}
 		}
 		if err := cmd.Run(); err != nil {
-			fmt.Printf("EXTRACT_MIG: pg_dump failed: %v\n", err)
-			os.Exit(1)
+			t.Fatalf("EXTRACT_MIG: pg_dump failed: %v", err)
 		}
 
 		h := NewBackupHandler(apiTestDBURL, dir, &mockAdminAuth{validateFn: func(string) bool { return true }}, nil)
@@ -959,8 +955,7 @@ func TestRestoreBackup_ExtractMigrationsError(t *testing.T) {
 
 		dumpContent, err := os.ReadFile(dumpPath)
 		if err != nil {
-			fmt.Printf("EXTRACT_MIG: failed to read dump file: %v\n", err)
-			os.Exit(1)
+			t.Fatalf("EXTRACT_MIG: failed to read dump file: %v", err)
 		}
 
 		var buf bytes.Buffer
@@ -972,7 +967,7 @@ func TestRestoreBackup_ExtractMigrationsError(t *testing.T) {
 
 		// Set TMPDIR to non-existent path so extractMigrationNames' filter file
 		// creation fails. Safe to do here since we're in an isolated subprocess.
-		os.Setenv("TMPDIR", "/nonexistent/path/that/does/not/exist")
+		t.Setenv("TMPDIR", "/nonexistent/path/that/does/not/exist")
 
 		req := httptest.NewRequest("POST", "/backups/restore", &buf)
 		req.Header.Set("Content-Type", writer.FormDataContentType())
@@ -980,14 +975,12 @@ func TestRestoreBackup_ExtractMigrationsError(t *testing.T) {
 		r.ServeHTTP(w, req)
 
 		if w.Code != http.StatusInternalServerError {
-			fmt.Printf("EXTRACT_MIG: expected 500, got %d: %s\n", w.Code, w.Body.String())
-			os.Exit(1)
+			t.Fatalf("EXTRACT_MIG: expected 500, got %d: %s", w.Code, w.Body.String())
 		}
 		if !strings.Contains(w.Body.String(), "failed to extract migration info") {
-			fmt.Printf("EXTRACT_MIG: expected error to mention extraction failure, got: %s\n", w.Body.String())
-			os.Exit(1)
+			t.Fatalf("EXTRACT_MIG: expected error to mention extraction failure, got: %s", w.Body.String())
 		}
-		os.Exit(0)
+		return
 	}
 
 	cmd := exec.Command(os.Args[0], "-test.run=TestRestoreBackup_ExtractMigrationsError")
@@ -1064,18 +1057,15 @@ func TestSaveUploadedDump_CreateTempError(t *testing.T) {
 		// Restore permissions for cleanup
 		os.Chmod(dir, 0o755)
 		if ok {
-			fmt.Printf("CREATE_TEMP: expected saveUploadedDump to fail\n")
-			os.Exit(1)
+			t.Fatalf("CREATE_TEMP: expected saveUploadedDump to fail")
 		}
 		if tmpPath != "" {
-			fmt.Printf("CREATE_TEMP: expected empty tmpPath, got %q\n", tmpPath)
-			os.Exit(1)
+			t.Fatalf("CREATE_TEMP: expected empty tmpPath, got %q", tmpPath)
 		}
 		if w.Code != http.StatusInternalServerError {
-			fmt.Printf("CREATE_TEMP: expected 500, got %d: %s\n", w.Code, w.Body.String())
-			os.Exit(1)
+			t.Fatalf("CREATE_TEMP: expected 500, got %d: %s", w.Code, w.Body.String())
 		}
-		os.Exit(0)
+		return
 	}
 
 	cmd := exec.Command(os.Args[0], "-test.run=TestSaveUploadedDump_CreateTempError")
@@ -1106,7 +1096,7 @@ func TestRestoreBackup_SaveUploadedDumpIOCopyError(t *testing.T) {
 		// This is a more direct test: the temp file is created but
 		// io.Copy fails because the file handle was closed.
 		// Since we can't easily trigger this, the test documents the path.
-		os.Exit(0)
+		return
 	}
 
 	cmd := exec.Command(os.Args[0], "-test.run=TestRestoreBackup_SaveUploadedDumpIOCopyError")

--- a/internal/api/backup_test.go
+++ b/internal/api/backup_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -831,14 +830,12 @@ func TestCreateBackup_NoPgDump_ManipulatedPATH(t *testing.T) {
 		r.ServeHTTP(w, req)
 
 		if w.Code != http.StatusPreconditionFailed {
-			fmt.Printf("NO_PG_DUMP: expected 412, got %d: %s\n", w.Code, w.Body.String())
-			os.Exit(1)
+			t.Fatalf("NO_PG_DUMP: expected 412, got %d: %s", w.Code, w.Body.String())
 		}
 		if !strings.Contains(w.Body.String(), "pg_dump not found") {
-			fmt.Printf("NO_PG_DUMP: expected error to mention pg_dump, got: %s\n", w.Body.String())
-			os.Exit(1)
+			t.Fatalf("NO_PG_DUMP: expected error to mention pg_dump, got: %s", w.Body.String())
 		}
-		os.Exit(0)
+		return
 	}
 
 	cmd := exec.Command(os.Args[0], "-test.run=TestCreateBackup_NoPgDump_ManipulatedPATH")
@@ -900,19 +897,17 @@ func TestNewBackupHandler_AbsFallback_Subprocess(t *testing.T) {
 		// Test L39-41: NewBackupHandler falls back to original path
 		h := NewBackupHandler("postgres://test", "my_backup_dir", &mockAdminAuth{}, nil)
 		if h.backupDir != "my_backup_dir" {
-			fmt.Printf("FALLBACK FAILED: expected my_backup_dir, got %q\n", h.backupDir)
-			os.Exit(1)
+			t.Fatalf("FALLBACK FAILED: expected my_backup_dir, got %q", h.backupDir)
 		}
 
 		// Test L192-194: validateBackupFilename returns "" when filepath.Abs fails
 		result := h.validateBackupFilename("test.dump")
 		if result != "" {
-			fmt.Printf("PREFIX CHECK FAILED: expected empty string, got %q\n", result)
-			os.Exit(1)
+			t.Fatalf("PREFIX CHECK FAILED: expected empty string, got %q", result)
 		}
 
 		// Success
-		os.Exit(0)
+		return
 	}
 
 	// Parent: create a temp dir, start subprocess with it as CWD, then delete it

--- a/internal/api/backup_test.go
+++ b/internal/api/backup_test.go
@@ -838,7 +838,7 @@ func TestCreateBackup_NoPgDump_ManipulatedPATH(t *testing.T) {
 		return
 	}
 
-	cmd := exec.Command(os.Args[0], "-test.run=TestCreateBackup_NoPgDump_ManipulatedPATH")
+	cmd := exec.Command(os.Args[0], "-test.run=^TestCreateBackup_NoPgDump_ManipulatedPATH$")
 	cmd.Env = append(os.Environ(), "TEST_NO_PG_DUMP=1", "PATH=")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -913,7 +913,7 @@ func TestNewBackupHandler_AbsFallback_Subprocess(t *testing.T) {
 	// Parent: create a temp dir, start subprocess with it as CWD, then delete it
 	tmpDir := t.TempDir()
 
-	cmd := exec.Command(os.Args[0], "-test.run=TestNewBackupHandler_AbsFallback_Subprocess")
+	cmd := exec.Command(os.Args[0], "-test.run=^TestNewBackupHandler_AbsFallback_Subprocess$")
 	cmd.Env = append(os.Environ(), "TEST_DELETED_CWD=1")
 	cmd.Dir = tmpDir
 


### PR DESCRIPTION
## Summary

Nine backup tests in `internal/api` re-exec the test binary to manipulate `TMPDIR`/`PATH` safely. Their child branch ended with `os.Exit()`, which bypasses `t.Cleanup`, so the `t.TempDir()` each child created was never removed: ~450 `Test*` dirs had piled up in `/tmp` on the dev box.

The child branch now fails through `t.Fatalf` and succeeds by returning. The test binary's exit code carries the same signal to the parent (`cmd.CombinedOutput()` err), and cleanup runs. `os.Setenv("TMPDIR", …)` becomes `t.Setenv`.

Test-only; no production code touched. Verified: the nine tests pass and leave zero `/tmp/Test*` dirs behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
