### PR TITLE
fix(proxy): estimate token usage the provider never reported

### DIFF
--- a/internal/anthropic/native.go
+++ b/internal/anthropic/native.go
@@ -119,14 +119,15 @@ func ResponseCarriesContent(body []byte) bool {
 	return len(resp.Content) > 0
 }
 
-// ResponseTextBytes is the byte length of the text, thinking and tool input of
-// a non-streaming Messages response's content blocks, the delivered output a
+// ResponseTextBytes is the byte length of the text, thinking, tool name and
+// tool input of a non-streaming Messages response's content blocks, the delivered output a
 // usage estimate works from when the response carries no usage block.
 func ResponseTextBytes(body []byte) int {
 	var resp struct {
 		Content []struct {
 			Text     string          `json:"text"`
 			Thinking string          `json:"thinking"`
+			Name     string          `json:"name"`
 			Input    json.RawMessage `json:"input"`
 		} `json:"content"`
 	}
@@ -135,7 +136,7 @@ func ResponseTextBytes(body []byte) int {
 	}
 	n := 0
 	for _, block := range resp.Content {
-		n += len(block.Text) + len(block.Thinking) + len(block.Input)
+		n += len(block.Text) + len(block.Thinking) + len(block.Name) + len(block.Input)
 	}
 	return n
 }
@@ -155,9 +156,12 @@ type StreamEvent struct {
 	OutputTokens    int
 	HasOutput       bool
 	ErrorMessage    string // set only when Type == "error"
-	// TextBytes is the byte length of a content_block_delta's text, thinking or
-	// partial JSON, the delivered output the passthrough estimates from when the
-	// stream ends before message_delta reports output_tokens.
+	// TextBytes is the byte length of the output a content block event carries:
+	// a content_block_delta's text, thinking or partial JSON, and a
+	// content_block_start's tool name (its input starts empty and arrives as
+	// deltas, so nothing is counted twice). It is the delivered output the
+	// passthrough estimates from when the stream ends before message_delta
+	// reports output_tokens.
 	TextBytes int
 }
 
@@ -184,6 +188,9 @@ func InspectStreamEvent(payload []byte) StreamEvent {
 			Thinking    string `json:"thinking"`
 			PartialJSON string `json:"partial_json"`
 		} `json:"delta"`
+		ContentBlock *struct {
+			Name string `json:"name"`
+		} `json:"content_block"`
 	}
 	if json.Unmarshal(payload, &ev) != nil {
 		return StreamEvent{}
@@ -210,6 +217,10 @@ func InspectStreamEvent(payload []byte) StreamEvent {
 	case "content_block_delta":
 		if ev.Delta != nil {
 			info.TextBytes = len(ev.Delta.Text) + len(ev.Delta.Thinking) + len(ev.Delta.PartialJSON)
+		}
+	case "content_block_start":
+		if ev.ContentBlock != nil {
+			info.TextBytes = len(ev.ContentBlock.Name)
 		}
 	}
 	return info

--- a/internal/anthropic/native.go
+++ b/internal/anthropic/native.go
@@ -119,6 +119,27 @@ func ResponseCarriesContent(body []byte) bool {
 	return len(resp.Content) > 0
 }
 
+// ResponseTextBytes is the byte length of the text, thinking and tool input of
+// a non-streaming Messages response's content blocks, the delivered output a
+// usage estimate works from when the response carries no usage block.
+func ResponseTextBytes(body []byte) int {
+	var resp struct {
+		Content []struct {
+			Text     string          `json:"text"`
+			Thinking string          `json:"thinking"`
+			Input    json.RawMessage `json:"input"`
+		} `json:"content"`
+	}
+	if json.Unmarshal(body, &resp) != nil {
+		return 0
+	}
+	n := 0
+	for _, block := range resp.Content {
+		n += len(block.Text) + len(block.Thinking) + len(block.Input)
+	}
+	return n
+}
+
 // StreamEvent is the decoded summary of a single Anthropic stream event,
 // produced by InspectStreamEvent for the native passthrough path. It carries
 // everything that path needs from one parse: the event Type (so the terminal
@@ -134,6 +155,10 @@ type StreamEvent struct {
 	OutputTokens    int
 	HasOutput       bool
 	ErrorMessage    string // set only when Type == "error"
+	// TextBytes is the byte length of a content_block_delta's text, thinking or
+	// partial JSON, the delivered output the passthrough estimates from when the
+	// stream ends before message_delta reports output_tokens.
+	TextBytes int
 }
 
 // InspectStreamEvent decodes one Anthropic stream event payload (the JSON after
@@ -154,6 +179,11 @@ func InspectStreamEvent(payload []byte) StreamEvent {
 		Error *struct {
 			Message string `json:"message"`
 		} `json:"error"`
+		Delta *struct {
+			Text        string `json:"text"`
+			Thinking    string `json:"thinking"`
+			PartialJSON string `json:"partial_json"`
+		} `json:"delta"`
 	}
 	if json.Unmarshal(payload, &ev) != nil {
 		return StreamEvent{}
@@ -176,6 +206,10 @@ func InspectStreamEvent(payload []byte) StreamEvent {
 	case "error":
 		if ev.Error != nil {
 			info.ErrorMessage = ev.Error.Message
+		}
+	case "content_block_delta":
+		if ev.Delta != nil {
+			info.TextBytes = len(ev.Delta.Text) + len(ev.Delta.Thinking) + len(ev.Delta.PartialJSON)
 		}
 	}
 	return info

--- a/internal/anthropic/native_test.go
+++ b/internal/anthropic/native_test.go
@@ -239,9 +239,9 @@ func TestInspectStreamEvent_TextBytes(t *testing.T) {
 }
 
 func TestResponseTextBytes(t *testing.T) {
-	body := `{"content":[{"type":"thinking","thinking":"hm"},{"type":"text","text":"Hello"},{"type":"tool_use","name":"f","input":{"a":1}}]}`
-	if got := ResponseTextBytes([]byte(body)); got != 14 {
-		t.Errorf("ResponseTextBytes = %d, want 14 (2 thinking + 5 text + 7 input)", got)
+	body := `{"content":[{"type":"thinking","thinking":"hm"},{"type":"text","text":"Hello"},{"type":"tool_use","name":"lookup","input":{"a":1}}]}`
+	if got := ResponseTextBytes([]byte(body)); got != 20 {
+		t.Errorf("ResponseTextBytes = %d, want 20 (2 thinking + 5 text + 6 name + 7 input)", got)
 	}
 	if got := ResponseTextBytes([]byte("nope")); got != 0 {
 		t.Errorf("ResponseTextBytes(invalid) = %d, want 0", got)

--- a/internal/anthropic/native_test.go
+++ b/internal/anthropic/native_test.go
@@ -221,3 +221,29 @@ func TestInspectStreamEvent_SplitsCachedInput(t *testing.T) {
 		t.Errorf("uncached split = (%d,%d), want (0,0)", plain.CacheHitTokens, plain.CacheMissTokens)
 	}
 }
+
+// Text and thinking deltas report their character count so the passthrough can
+// estimate unreported output; other events report none.
+func TestInspectStreamEvent_TextBytes(t *testing.T) {
+	cases := map[string]int{
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}`:                   5,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"hmm"}}`:             3,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"a\":1}"}}`: 7,
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":5}}`:                 0,
+	}
+	for payload, want := range cases {
+		if got := InspectStreamEvent([]byte(payload)).TextBytes; got != want {
+			t.Errorf("TextBytes(%s) = %d, want %d", payload, got, want)
+		}
+	}
+}
+
+func TestResponseTextBytes(t *testing.T) {
+	body := `{"content":[{"type":"thinking","thinking":"hm"},{"type":"text","text":"Hello"},{"type":"tool_use","name":"f","input":{"a":1}}]}`
+	if got := ResponseTextBytes([]byte(body)); got != 14 {
+		t.Errorf("ResponseTextBytes = %d, want 14 (2 thinking + 5 text + 7 input)", got)
+	}
+	if got := ResponseTextBytes([]byte("nope")); got != 0 {
+		t.Errorf("ResponseTextBytes(invalid) = %d, want 0", got)
+	}
+}

--- a/internal/proxy/anthropic_native.go
+++ b/internal/proxy/anthropic_native.go
@@ -94,6 +94,7 @@ func (h *Handler) handleNativeNonStreaming(w http.ResponseWriter, r *http.Reques
 	logData.deliveredContent = outputTokens > 0 || anthropic.ResponseCarriesContent(body)
 	h.updateRequestLog(logData, updateLogOption{skipWaitForInsert: true})
 
+	inputTokens, outputTokens, _ = estimateMissingUsage(inputTokens, outputTokens, 0, logData, anthropic.ResponseTextBytes(body))
 	h.recordTokenUsage(st.vkHash, logData, inputTokens, outputTokens, 0)
 
 	debuglog.Info("proxy: native anthropic non-streaming completed", "model", logData.modelID, "provider", logData.providerName, "attempt", attempt, "duration_ms", totalDuration, "input_tokens", inputTokens, "output_tokens", outputTokens)
@@ -127,6 +128,7 @@ func (h *Handler) emitRawData(sink *streamSink, st *streamState, ev sseEvent, ch
 	if info.HasOutput {
 		st.completionTokens = info.OutputTokens
 	}
+	st.deliveredBytes += info.TextBytes
 	switch info.Type {
 	case "message_stop":
 		st.sawMessageStop = true

--- a/internal/proxy/helpers.go
+++ b/internal/proxy/helpers.go
@@ -329,3 +329,106 @@ func breakerRecordAction(statusCode int) breakerAction {
 		return breakerActionSuccess
 	}
 }
+
+// estimateTokens converts a byte length of text into a token estimate at the
+// conventional 4 bytes per token, rounding up so any delivered text charges at
+// least one token. The ratio is tuned for Latin text; multi-byte scripts run
+// closer to one token per character and estimate low.
+func estimateTokens(textBytes int) int {
+	return (textBytes + 3) / 4
+}
+
+// estimateMissingUsage fills in token counts the provider did not report, so a
+// request that delivered output is always charged against the TPM budget and
+// the key's tokens_used counter. Usage arrives in the LAST chunk of an OpenAI
+// stream, so a client that disconnects after the content but before it (the
+// upstream request is cancelled with the client, the chunk never arrives) or a
+// provider that omits usage altogether would otherwise meter as zero while the
+// provider bills the operator for the real tokens.
+//
+// Each side is estimated independently and only when it is missing: a native
+// Anthropic stream reports input_tokens up front and output_tokens at the end,
+// so a truncated one keeps its reported prompt and estimates only the output.
+// Nothing is estimated when no output was delivered (an error before the first
+// token costs nothing), and the request log keeps the provider's figures:
+// estimates charge the quota, they are not reported as measured usage.
+func estimateMissingUsage(promptTokens, completionTokens, reasoningTokens int, logData *requestLogData, deliveredBytes int) (prompt, completion, reasoning int) {
+	outputTokens := completionTokens + reasoningTokens
+	if deliveredBytes == 0 || (promptTokens > 0 && outputTokens > 0) {
+		return promptTokens, completionTokens, reasoningTokens
+	}
+	promptEstimated, completionEstimated := promptTokens == 0, outputTokens == 0
+	if promptEstimated {
+		promptTokens = estimateTokens(logData.promptTextBytes)
+	}
+	if completionEstimated {
+		completionTokens = estimateTokens(deliveredBytes)
+	}
+	debuglog.Info("proxy: charging estimated tokens for usage the provider did not report", "model", logData.modelID, "provider", logData.providerName, "prompt_estimated", promptEstimated, "completion_estimated", completionEstimated, "prompt_text_bytes", logData.promptTextBytes, "delivered_bytes", deliveredBytes, "prompt_tokens", promptTokens, "completion_tokens", completionTokens, "reasoning_tokens", reasoningTokens)
+	return promptTokens, completionTokens, reasoningTokens
+}
+
+// promptTextBytes sizes the prompt text of an OpenAI-shaped request body: the
+// message text (string content and text parts) plus the tool definitions. It
+// deliberately skips image_url and input_audio parts, which are base64 blobs
+// roughly a thousand times larger than the handful of tokens they cost; sizing
+// those by bytes would turn one vision request into a phantom multi-million
+// token charge. A body that does not parse sizes as zero.
+func promptTextBytes(body []byte) int {
+	var req struct {
+		Messages []struct {
+			Content json.RawMessage `json:"content"`
+		} `json:"messages"`
+		Tools json.RawMessage `json:"tools"`
+	}
+	if json.Unmarshal(body, &req) != nil {
+		return 0
+	}
+	n := len(req.Tools)
+	for _, m := range req.Messages {
+		var text string
+		if json.Unmarshal(m.Content, &text) == nil {
+			n += len(text)
+			continue
+		}
+		var parts []struct {
+			Text string `json:"text"`
+		}
+		if json.Unmarshal(m.Content, &parts) == nil {
+			for _, p := range parts {
+				n += len(p.Text)
+			}
+		}
+	}
+	return n
+}
+
+// chatAnswerBytes sizes the output of a non-streaming answer (content,
+// reasoning in any of the provider spellings, and tool calls), the delivered
+// output estimateMissingUsage works from.
+func chatAnswerBytes(out ChatCompletionResponse) int {
+	n := 0
+	for _, choice := range out.Choices {
+		msg := choice.Message
+		switch c := msg.Content.(type) {
+		case string:
+			n += len(c)
+		case []any:
+			for _, part := range c {
+				if m, ok := part.(map[string]any); ok {
+					if text, ok := m["text"].(string); ok {
+						n += len(text)
+					}
+				}
+			}
+		}
+		n += len(msg.ReasoningContent) + len(msg.Reasoning)
+		for _, rd := range msg.ReasoningDetails {
+			n += len(rd.Text)
+		}
+		for _, tc := range msg.ToolCalls {
+			n += len(tc.Function.Name) + len(tc.Function.Arguments)
+		}
+	}
+	return n
+}

--- a/internal/proxy/multimodal.go
+++ b/internal/proxy/multimodal.go
@@ -674,6 +674,11 @@ func (h *Handler) serveStreamedPassthrough(w http.ResponseWriter, r *http.Reques
 		}
 		debuglog.Warn("proxy: passthrough copy interrupted", "endpoint", logData.endpointType, "model", logData.modelID, "provider", logData.providerName, "bytes", written, "error", copyErr)
 		h.finalizePassthroughLog(st, resp.StatusCode, attempt, responseHeaderMs, promptTokens, completionTokens, "failed", errMsg)
+		// The provider billed whatever usage the SSE tail already reported,
+		// whether or not the client stayed to receive it.
+		if promptTokens > 0 || completionTokens > 0 {
+			h.recordTokenUsage(st.vkHash, logData, promptTokens, completionTokens, 0)
+		}
 		return
 	}
 	h.finalizePassthroughLog(st, resp.StatusCode, attempt, responseHeaderMs, promptTokens, completionTokens, "completed", "")

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -579,7 +579,8 @@ func (h *Handler) handleNonStreamingResponse(w http.ResponseWriter, r *http.Requ
 		// UPDATE simply affects 0 rows (harmless, logged as warning).
 		h.updateRequestLog(logData, updateLogOption{skipWaitForInsert: true})
 
-		h.recordTokenUsage(vkHash, logData, chatResp.Usage.PromptTokens, chatResp.Usage.CompletionTokens, reasoningTokens)
+		promptTokens, completionTokens, reasoningTokens := estimateMissingUsage(chatResp.Usage.PromptTokens, chatResp.Usage.CompletionTokens, reasoningTokens, logData, chatAnswerBytes(chatResp))
+		h.recordTokenUsage(vkHash, logData, promptTokens, completionTokens, reasoningTokens)
 
 		// Normalize reasoning fields in the response message so that
 		// reasoning_content is always populated regardless of upstream

--- a/internal/proxy/proxy_request.go
+++ b/internal/proxy/proxy_request.go
@@ -107,6 +107,8 @@ func (h *Handler) ingestRequest(w http.ResponseWriter, r *http.Request, endpoint
 	debuglog.Info("proxy: request start", "client_ip", clientip.From(r), "model", reqModel, "stream", isStreaming, "key", logData.virtualKeyName)
 	debuglog.Debug("proxy: request details", "model", reqModel, "stream", isStreaming, "key", logData.virtualKeyName, "vk_id", logData.virtualKeyID, "has_hash", vkHash != "", "body_length", len(bodyBytes))
 
+	logData.promptTextBytes = promptTextBytes(bodyBytes)
+
 	return &requestState{
 		startTime:   startTime,
 		reqModel:    reqModel,

--- a/internal/proxy/stream_finalize.go
+++ b/internal/proxy/stream_finalize.go
@@ -46,9 +46,7 @@ type streamState struct {
 	// usage estimate when no usage was reported: the usage chunk is the LAST
 	// chunk of an OpenAI stream, so a client that hangs up after the content
 	// (or a provider that omits the chunk) would otherwise leave the request
-	// unmetered while the provider still bills for it. Only choices[0] is
-	// observed, like the rest of the observers, so an n>1 stream estimates
-	// one choice's worth.
+	// unmetered while the provider still bills for it.
 	deliveredBytes     int
 	clientDisconnected bool
 	stalled            bool

--- a/internal/proxy/stream_finalize.go
+++ b/internal/proxy/stream_finalize.go
@@ -39,7 +39,17 @@ type streamState struct {
 	// reached the client. It is the only signal that a stream actually answered
 	// which does not depend on optional behaviour: usage chunks are omitted by
 	// some providers, and the TTFT probe can be turned off.
-	sawContent         bool
+	sawContent bool
+	// deliveredBytes counts the bytes of content, reasoning and tool-call
+	// arguments the model produced as it streamed (before any strip_reasoning
+	// transform, which drops text the provider still billed). It backs the
+	// usage estimate when no usage was reported: the usage chunk is the LAST
+	// chunk of an OpenAI stream, so a client that hangs up after the content
+	// (or a provider that omits the chunk) would otherwise leave the request
+	// unmetered while the provider still bills for it. Only choices[0] is
+	// observed, like the rest of the observers, so an n>1 stream estimates
+	// one choice's worth.
+	deliveredBytes     int
 	clientDisconnected bool
 	stalled            bool
 
@@ -178,7 +188,12 @@ func (h *Handler) finalizeStream(st *streamState, sink *streamSink, scanErr erro
 	if st.clientDisconnected && (st.promptTokens > 0 || st.completionTokens > 0) {
 		debuglog.Info("proxy: recording token usage despite client disconnect", "model", logData.modelID, "provider", logData.providerName, "prompt_tokens", st.promptTokens, "completion_tokens", st.completionTokens)
 	}
-	h.recordTokenUsage(opts.vkHash, logData, st.promptTokens, st.completionTokens, st.reasoningTokens)
+	// The estimate applies on failed streams too (an SSE error after some
+	// output, a truncation): the provider billed whatever was produced before
+	// the failure. The non-streaming path only meters a decoded 2xx, which is
+	// the same rule, since nothing was produced for the client otherwise.
+	promptTokens, completionTokens, reasoningTokens := estimateMissingUsage(st.promptTokens, st.completionTokens, st.reasoningTokens, logData, st.deliveredBytes)
+	h.recordTokenUsage(opts.vkHash, logData, promptTokens, completionTokens, reasoningTokens)
 }
 
 // deriveStreamError classifies how the stream ended into the error message

--- a/internal/proxy/stream_observers.go
+++ b/internal/proxy/stream_observers.go
@@ -75,6 +75,12 @@ type streamChunk struct {
 		Delta *struct {
 			Content          *string `json:"content"`
 			ReasoningContent *string `json:"reasoning_content"`
+			ToolCalls        []struct {
+				Function *struct {
+					Name      string `json:"name"`
+					Arguments string `json:"arguments"`
+				} `json:"function"`
+			} `json:"tool_calls"`
 		} `json:"delta"`
 		FinishReason       *string `json:"finish_reason"`
 		NativeFinishReason *string `json:"native_finish_reason"` // P2-7: OpenRouter passthrough
@@ -126,6 +132,15 @@ func (st *streamState) observeDataChunk(chunk streamChunk, anthropicErrorCounted
 		currentContent := ""
 		if delta.Content != nil {
 			currentContent = *delta.Content
+			st.deliveredBytes += len(*delta.Content)
+		}
+		if delta.ReasoningContent != nil {
+			st.deliveredBytes += len(*delta.ReasoningContent)
+		}
+		for _, tc := range delta.ToolCalls {
+			if tc.Function != nil {
+				st.deliveredBytes += len(tc.Function.Name) + len(tc.Function.Arguments)
+			}
 		}
 		if delta.ReasoningContent != nil && currentContent == "" {
 			currentContent = *delta.ReasoningContent

--- a/internal/proxy/stream_observers.go
+++ b/internal/proxy/stream_observers.go
@@ -127,20 +127,30 @@ func (st *streamState) observeDataChunk(chunk streamChunk, anthropicErrorCounted
 	// deltas, causing "Thinking... Thinking... Thinking..." loops.
 	// We track consecutive identical content and log a warning when
 	// the threshold is exceeded.
+	// Every choice is delivered output, so the byte count covers all of them
+	// (an n>1 stream is billed for every choice), unlike the observers below,
+	// which only watch choices[0].
+	for _, choice := range chunk.Choices {
+		if choice.Delta == nil {
+			continue
+		}
+		if choice.Delta.Content != nil {
+			st.deliveredBytes += len(*choice.Delta.Content)
+		}
+		if choice.Delta.ReasoningContent != nil {
+			st.deliveredBytes += len(*choice.Delta.ReasoningContent)
+		}
+		for _, tc := range choice.Delta.ToolCalls {
+			if tc.Function != nil {
+				st.deliveredBytes += len(tc.Function.Name) + len(tc.Function.Arguments)
+			}
+		}
+	}
 	if len(chunk.Choices) > 0 && chunk.Choices[0].Delta != nil {
 		delta := chunk.Choices[0].Delta
 		currentContent := ""
 		if delta.Content != nil {
 			currentContent = *delta.Content
-			st.deliveredBytes += len(*delta.Content)
-		}
-		if delta.ReasoningContent != nil {
-			st.deliveredBytes += len(*delta.ReasoningContent)
-		}
-		for _, tc := range delta.ToolCalls {
-			if tc.Function != nil {
-				st.deliveredBytes += len(tc.Function.Name) + len(tc.Function.Arguments)
-			}
 		}
 		if delta.ReasoningContent != nil && currentContent == "" {
 			currentContent = *delta.ReasoningContent

--- a/internal/proxy/types.go
+++ b/internal/proxy/types.go
@@ -149,11 +149,16 @@ type requestLogData struct {
 	// can be switched off — and a real success that reports neither would
 	// otherwise look indistinguishable from a stream that emitted nothing.
 	deliveredContent bool
-	failoverAttempt  int
-	state            string
-	resolvedModelID  string
-	endpointType     string         // endpoint family: chat, embeddings, rerank, image, tts, stt
-	insertWg         sync.WaitGroup // signals when the async INSERT has completed
+	// promptTextBytes is the size of the prompt text in the client's request
+	// (message text and tool definitions, never inline media), recorded at
+	// ingest so every response path can estimate the prompt when the provider
+	// reports no usage (see estimateMissingUsage). Not persisted.
+	promptTextBytes int
+	failoverAttempt int
+	state           string
+	resolvedModelID string
+	endpointType    string         // endpoint family: chat, embeddings, rerank, image, tts, stt
+	insertWg        sync.WaitGroup // signals when the async INSERT has completed
 }
 
 type modelCandidate struct {

--- a/internal/proxy/usage_estimate_test.go
+++ b/internal/proxy/usage_estimate_test.go
@@ -1,0 +1,373 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hugalafutro/model-hotel/internal/virtualkey"
+)
+
+// The metering fallback for streams and responses that end without a usage
+// report. Token counts normally come only from the provider's usage chunk, which
+// is the LAST chunk of an OpenAI stream: a client that hangs up after the
+// content but before it, or a provider that never sends one, used to leave the
+// TPM budget and the key's tokens_used counter uncharged while the provider
+// still billed the operator. The fallback charges an estimate derived from the
+// prompt text size and the delivered output bytes (4 bytes ≈ 1 token).
+
+func TestEstimateTokens(t *testing.T) {
+	cases := map[int]int{0: 0, 1: 1, 3: 1, 4: 1, 5: 2, 40: 10, 41: 11}
+	for textBytes, want := range cases {
+		assert.Equal(t, want, estimateTokens(textBytes), "bytes=%d", textBytes)
+	}
+}
+
+// streamUsageHarness runs one upstream SSE body through handleStreamingResponse
+// with a recording virtual-key repo and a 40-byte prompt on the log row.
+func streamUsageHarness(t *testing.T, upstreamBody string, cancelAfterFirstChunk bool) (*mockVirtualKeyRepo, *requestLogData) {
+	t.Helper()
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+	vkRepo := &mockVirtualKeyRepo{}
+	h.virtualKeyRepo = vkRepo
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	var body io.ReadCloser
+	var served chan struct{}
+	if cancelAfterFirstChunk {
+		// Deliver the first event, then block until the client context is
+		// cancelled so the rest (usage chunk included) never arrives.
+		first, _, _ := strings.Cut(upstreamBody, "\n\n")
+		served = make(chan struct{})
+		body = &blockingReader{first: first + "\n\n", ctx: ctx, served: served}
+	} else {
+		body = io.NopCloser(strings.NewReader(upstreamBody))
+	}
+	resp := &http.Response{StatusCode: http.StatusOK, Body: body}
+	req := withAuthContext(httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody).WithContext(ctx))
+
+	logData := &requestLogData{
+		id:              uuid.New().String(),
+		modelID:         "test-model",
+		streaming:       true,
+		virtualKeyName:  "test-key",
+		virtualKeyID:    "00000000-0000-0000-0000-000000000001",
+		state:           "streaming",
+		promptTextBytes: 40,
+	}
+	h.insertRequestLogAsync(logData)
+	time.Sleep(20 * time.Millisecond)
+
+	done := make(chan struct{})
+	go func() {
+		h.handleStreamingResponse(httptest.NewRecorder(), req, logData, resp, time.Now(), streamOptions{vkHash: "test-hash", attempt: 1, cancelOrigin: "failover_timeout"})
+		close(done)
+	}()
+	if cancelAfterFirstChunk {
+		<-served
+		cancel()
+	}
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handleStreamingResponse did not finish")
+	}
+	return vkRepo, logData
+}
+
+// blockingReader serves `first` (closing `served` once it is fully read), then
+// blocks until ctx is cancelled and returns context.Canceled, the error the
+// transport surfaces when the client goes away.
+type blockingReader struct {
+	first  string
+	ctx    context.Context
+	served chan struct{}
+	off    int
+}
+
+func (r *blockingReader) Read(p []byte) (int, error) {
+	if r.off < len(r.first) {
+		n := copy(p, r.first[r.off:])
+		r.off += n
+		if r.off == len(r.first) {
+			close(r.served)
+		}
+		return n, nil
+	}
+	<-r.ctx.Done()
+	return 0, context.Canceled
+}
+
+func (r *blockingReader) Close() error { return nil }
+
+// singleAddTokens returns the one charge recorded against the key.
+// recordTokenUsage always reaches the repo, with 0 when nothing is owed, so a
+// zero here means "nothing charged", not "nothing recorded".
+func singleAddTokens(t *testing.T, repo *mockVirtualKeyRepo) int {
+	t.Helper()
+	require.Len(t, repo.addTokensCalls, 1, "AddTokens should be called exactly once")
+	assert.Equal(t, "test-hash", repo.addTokensCalls[0].keyHash)
+	return repo.addTokensCalls[0].tokens
+}
+
+const (
+	contentChunk = `data: {"id":"c","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"hello"},"finish_reason":null}]}` + "\n\n"
+	usageChunk   = `data: {"id":"c","object":"chat.completion.chunk","choices":[],"usage":{"prompt_tokens":12,"completion_tokens":220,"total_tokens":232}}` + "\n\n"
+	doneChunk    = "data: [DONE]\n\n"
+)
+
+func TestHandleStreamingResponse_EstimatesUsageWhenClientDisconnectsBeforeUsageChunk(t *testing.T) {
+	repo, logData := streamUsageHarness(t, contentChunk+usageChunk+doneChunk, true)
+
+	require.Contains(t, logData.errorMessage, "client disconnected")
+	// 40 prompt bytes → 10 prompt tokens; "hello" (5 bytes) → 2 completion tokens.
+	assert.Equal(t, 12, singleAddTokens(t, repo))
+}
+
+func TestHandleStreamingResponse_EstimatesUsageWhenProviderOmitsUsageChunk(t *testing.T) {
+	body := contentChunk +
+		`data: {"id":"c","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":" world","reasoning_content":"think"},"finish_reason":"stop"}]}` + "\n\n" +
+		doneChunk
+	repo, logData := streamUsageHarness(t, body, false)
+
+	assert.Equal(t, "completed", logData.state)
+	// 40 prompt bytes → 10; "hello"+" world"+"think" = 16 bytes → 4.
+	assert.Equal(t, 14, singleAddTokens(t, repo))
+	// The request log keeps the provider's (absent) figures: estimates charge
+	// the quota, they are not reported as measured usage.
+	assert.Equal(t, 0, logData.tokensPrompt)
+	assert.Equal(t, 0, logData.tokensCompletion)
+}
+
+// Agent traffic is mostly tool calls, whose output lives in
+// delta.tool_calls[].function.arguments rather than delta.content.
+func TestHandleStreamingResponse_EstimatesUsageFromToolCallArguments(t *testing.T) {
+	body := `data: {"id":"c","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"get_weather","arguments":""}}]},"finish_reason":null}]}` + "\n\n" +
+		`data: {"id":"c","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"city\":\"Paris\"}"}}]},"finish_reason":"tool_calls"}]}` + "\n\n" +
+		doneChunk
+	repo, _ := streamUsageHarness(t, body, false)
+
+	// 40 prompt bytes → 10; "get_weather" (11) + {"city":"Paris"} (16) = 27 bytes → 7.
+	assert.Equal(t, 17, singleAddTokens(t, repo))
+}
+
+// A usage chunk whose counts are all zero is no usage at all.
+func TestHandleStreamingResponse_EstimatesUsageWhenReportedUsageIsZero(t *testing.T) {
+	body := contentChunk +
+		`data: {"id":"c","object":"chat.completion.chunk","choices":[],"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0}}` + "\n\n" +
+		doneChunk
+	repo, _ := streamUsageHarness(t, body, false)
+	assert.Equal(t, 12, singleAddTokens(t, repo))
+}
+
+func TestHandleStreamingResponse_ReportedUsageWinsOverEstimate(t *testing.T) {
+	repo, _ := streamUsageHarness(t, contentChunk+usageChunk+doneChunk, false)
+	assert.Equal(t, 232, singleAddTokens(t, repo))
+}
+
+func TestHandleStreamingResponse_NoEstimateWithoutDeliveredContent(t *testing.T) {
+	body := `data: {"error":{"message":"upstream exploded"}}` + "\n\n" + doneChunk
+	repo, logData := streamUsageHarness(t, body, false)
+
+	assert.Equal(t, "failed", logData.state)
+	assert.Equal(t, 0, singleAddTokens(t, repo))
+}
+
+// The security property itself: the estimate reaches the TPM bucket, so a key
+// that disconnects before the usage chunk still burns its budget and the next
+// request is refused once the budget is spent.
+func TestHandleStreamingResponse_EstimateDebitsTPMBudget(t *testing.T) {
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+	h.virtualKeyRepo = &mockVirtualKeyRepo{}
+
+	const tpm = 10
+	// Admission, as the TPM middleware performs it: creates the bucket and
+	// reserves the 1-token placeholder.
+	require.True(t, h.tpmLimiter.Allow("test-hash", tpm))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	served := make(chan struct{})
+	resp := &http.Response{StatusCode: http.StatusOK, Body: &blockingReader{first: contentChunk, ctx: ctx, served: served}}
+	req := withAuthContext(httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody).WithContext(ctx))
+	logData := &requestLogData{id: uuid.New().String(), modelID: "test-model", streaming: true, virtualKeyName: "test-key", virtualKeyID: "00000000-0000-0000-0000-000000000001", state: "streaming", promptTextBytes: 40}
+	h.insertRequestLogAsync(logData)
+	time.Sleep(20 * time.Millisecond)
+
+	done := make(chan struct{})
+	go func() {
+		h.handleStreamingResponse(httptest.NewRecorder(), req, logData, resp, time.Now(), streamOptions{vkHash: "test-hash", attempt: 1, cancelOrigin: "failover_timeout"})
+		close(done)
+	}()
+	<-served
+	cancel()
+	<-done
+
+	// 12 estimated tokens against a 10-token budget: the bucket is in debt.
+	assert.False(t, h.tpmLimiter.Allow("test-hash", tpm), "next request must be refused after the estimated debit")
+}
+
+// Native Anthropic passthrough: message_start reports input_tokens up front, but
+// output_tokens only arrive on message_delta at the end, so a disconnect after
+// the text deltas leaves output unmetered. The fallback estimates the output
+// from the delivered delta text and keeps the reported input figure.
+func TestNativeStream_EstimatesOutputWhenTruncatedBeforeMessageDelta(t *testing.T) {
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+	vkRepo := &mockVirtualKeyRepo{}
+	h.virtualKeyRepo = vkRepo
+
+	head, _, _ := strings.Cut(nativeStreamHead, "event: message_delta")
+	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(head))}
+	req := httptest.NewRequest("POST", "/v1/messages", http.NoBody)
+	logData := &requestLogData{
+		id:              uuid.New().String(),
+		modelID:         "claude-test",
+		streaming:       true,
+		virtualKeyName:  "test-key",
+		virtualKeyID:    "00000000-0000-0000-0000-000000000001",
+		state:           "streaming",
+		promptTextBytes: 40,
+	}
+	h.insertRequestLogAsync(logData)
+	time.Sleep(20 * time.Millisecond)
+	h.handleStreamingResponse(httptest.NewRecorder(), req, logData, resp, time.Now(), streamOptions{vkHash: "test-hash", attempt: 1, rawPassthrough: true})
+
+	// input_tokens 12 reported by message_start; "Hello" (5 bytes) → 2 estimated.
+	assert.Equal(t, 14, singleAddTokens(t, vkRepo))
+}
+
+func TestHandleNativeNonStreaming_EstimatesUsageWhenOmitted(t *testing.T) {
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+	vkRepo := &mockVirtualKeyRepo{}
+	h.virtualKeyRepo = vkRepo
+
+	anthropicBody := `{"id":"msg_up","type":"message","role":"assistant","content":[{"type":"text","text":"Hello, world!"},{"type":"tool_use","id":"t1","name":"f","input":{"a":1}}],"stop_reason":"end_turn"}`
+	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(anthropicBody)), Header: make(http.Header)}
+	native := true
+	aw := newAnthropicResponseWriter(httptest.NewRecorder(), "msg_ignored", "m")
+	aw.bindNativeFlag(&native)
+	logData := &requestLogData{id: uuid.New().String(), modelID: "claude-x", virtualKeyName: "test-key", virtualKeyID: "00000000-0000-0000-0000-000000000001", state: "streaming", promptTextBytes: 40}
+	st := &requestState{startTime: time.Now(), logData: logData, vkHash: "test-hash"}
+	h.insertRequestLogAsync(logData)
+	time.Sleep(20 * time.Millisecond)
+
+	h.handleNativeNonStreaming(aw, httptest.NewRequest("POST", "/v1/messages", http.NoBody), st, resp, 1, 5)
+
+	// 40 prompt bytes → 10; "Hello, world!" (13) + {"a":1} (7) = 20 bytes → 5.
+	assert.Equal(t, 15, singleAddTokens(t, vkRepo))
+}
+
+func TestHandleNonStreamingResponse_EstimatesUsageWhenProviderOmitsIt(t *testing.T) {
+	vkRepo := &mockVirtualKeyRepo{}
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+	h.virtualKeyRepo = vkRepo
+
+	upstreamBody := `{"id":"x","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"Hello, world!","reasoning_content":"hmm"}}]}`
+	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewBufferString(upstreamBody)), Header: make(http.Header)}
+	w := httptest.NewRecorder()
+	req := withAuthContext(httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody))
+	logData := &requestLogData{
+		modelID:         "gpt-test",
+		providerID:      uuid.New(),
+		virtualKeyName:  "test-key",
+		virtualKeyID:    "00000000-0000-0000-0000-000000000001",
+		state:           "pending",
+		promptTextBytes: 40,
+	}
+	h.handleNonStreamingResponse(w, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	// 40 prompt bytes → 10; "Hello, world!" (13) + "hmm" (3) = 16 bytes → 4.
+	assert.Equal(t, 14, singleAddTokens(t, vkRepo))
+	assert.Equal(t, 0, logData.tokensPrompt, "estimates must not be reported as measured usage")
+}
+
+func TestHandleNonStreamingResponse_NoEstimateForEmptyAnswer(t *testing.T) {
+	vkRepo := &mockVirtualKeyRepo{}
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+	h.virtualKeyRepo = vkRepo
+
+	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewBufferString(`{"id":"x","object":"chat.completion","choices":[]}`)), Header: make(http.Header)}
+	req := withAuthContext(httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody))
+	logData := &requestLogData{modelID: "gpt-test", providerID: uuid.New(), virtualKeyName: "k", virtualKeyID: "00000000-0000-0000-0000-000000000001", state: "pending", promptTextBytes: 40}
+	h.handleNonStreamingResponse(httptest.NewRecorder(), req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
+
+	assert.Equal(t, 0, singleAddTokens(t, vkRepo))
+}
+
+func TestChatAnswerBytes_CountsEveryOutputShape(t *testing.T) {
+	out := ChatCompletionResponse{Choices: []Choice{
+		{Message: Message{Content: "abc", Reasoning: "de"}},
+		{Message: Message{Content: []any{map[string]any{"type": "text", "text": "fghi"}, map[string]any{"type": "image_url"}}, ReasoningContent: "j"}},
+		{Message: Message{ReasoningDetails: []ReasoningDetail{{Type: "reasoning.text", Text: "kl"}}, ToolCalls: []ToolCall{{Function: ToolCallFunc{Name: "m", Arguments: `{}`}}}}},
+	}}
+	assert.Equal(t, 15, chatAnswerBytes(out))
+}
+
+// The prompt is sized from its text, never from the raw body: a vision request
+// carries base64 media that is ~1000x larger in bytes than in tokens, and
+// sizing it by bytes would charge millions of phantom tokens for one request
+// (locking the key out for hours).
+func TestPromptTextBytes_SkipsInlineMedia(t *testing.T) {
+	media := strings.Repeat("A", 1<<20)
+	body := fmt.Sprintf(`{"model":"m","messages":[{"role":"system","content":"be brief"},{"role":"user","content":[{"type":"text","text":"what is this"},{"type":"image_url","image_url":{"url":"data:image/png;base64,%s"}},{"type":"input_audio","input_audio":{"data":"%s","format":"wav"}}]}],"tools":[{"type":"function","function":{"name":"f"}}]}`, media, media)
+
+	// "be brief" (8) + "what is this" (12) + the tools JSON (45).
+	assert.Equal(t, 65, promptTextBytes([]byte(body)))
+	assert.Equal(t, 0, promptTextBytes([]byte("not json")))
+}
+
+// The prompt size reaches the log row at ingest so every response path can
+// estimate from it.
+func TestIngestRequest_RecordsPromptTextBytes(t *testing.T) {
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+	body := `{"model":"m","stream":false,"messages":[{"role":"user","content":"hi there"}]}`
+	req := withAuthContext(httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(body)))
+	st, ok := h.ingestRequest(httptest.NewRecorder(), req, endpointTypeChat)
+	require.True(t, ok)
+	assert.Equal(t, 8, st.logData.promptTextBytes)
+}
+
+// Multimodal SSE passthrough: usage scraped from the SSE tail is charged even
+// when the copy to the client is interrupted, since the provider billed it.
+func TestAudioSpeech_SSEUsageMeteredWhenCopyInterrupted(t *testing.T) {
+	sse := "data: {\"type\":\"speech.audio.delta\",\"audio\":\"cGFydA==\"}\n\ndata: {\"type\":\"speech.audio.done\",\"usage\":{\"input_tokens\":12,\"output_tokens\":34,\"total_tokens\":46}}\n\n"
+	env := newMultimodalEnv(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hj, ok := w.(http.Hijacker)
+		require.True(t, ok, "test server must support hijacking")
+		conn, buf, err := hj.Hijack()
+		require.NoError(t, err)
+		// A Content-Length longer than the bytes sent makes the copy end in
+		// an unexpected EOF after the whole usage tail has been delivered.
+		_, _ = fmt.Fprintf(buf, "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nContent-Length: %d\r\n\r\n%s", len(sse)+100, sse)
+		_ = buf.Flush()
+		_ = conn.Close()
+	}))
+
+	body := fmt.Sprintf(`{"model":"%s/%s","input":"hello","voice":"alloy","stream_format":"sse"}`, env.providerName, env.modelName)
+	req := env.request("/v1/audio/speech", "application/json", strings.NewReader(body))
+	env.handler.AudioSpeech(httptest.NewRecorder(), req)
+
+	vk, err := virtualkey.NewRepository(testDB.Pool()).FindByKeyHash(context.Background(), env.keyHash)
+	require.NoError(t, err)
+	assert.Equal(t, int64(46), vk.TokensUsed, "interrupted copy must still charge the scraped usage")
+}

--- a/internal/proxy/usage_estimate_test.go
+++ b/internal/proxy/usage_estimate_test.go
@@ -164,6 +164,17 @@ func TestHandleStreamingResponse_EstimatesUsageFromToolCallArguments(t *testing.
 	assert.Equal(t, 17, singleAddTokens(t, repo))
 }
 
+// Every choice of an n>1 stream is delivered output; the estimate must not
+// stop at choices[0] the way the content observers do.
+func TestHandleStreamingResponse_EstimatesUsageAcrossAllChoices(t *testing.T) {
+	body := `data: {"id":"c","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"hello"},"finish_reason":null},{"index":1,"delta":{"content":"bonjour","tool_calls":[{"index":0,"function":{"name":"f","arguments":"{}"}}]},"finish_reason":null}]}` + "\n\n" +
+		doneChunk
+	repo, _ := streamUsageHarness(t, body, false)
+
+	// 40 prompt bytes → 10; "hello" (5) + "bonjour" (7) + "f" (1) + "{}" (2) = 15 bytes → 4.
+	assert.Equal(t, 14, singleAddTokens(t, repo))
+}
+
 // A usage chunk whose counts are all zero is no usage at all.
 func TestHandleStreamingResponse_EstimatesUsageWhenReportedUsageIsZero(t *testing.T) {
 	body := contentChunk +
@@ -251,6 +262,26 @@ func TestNativeStream_EstimatesOutputWhenTruncatedBeforeMessageDelta(t *testing.
 	assert.Equal(t, 14, singleAddTokens(t, vkRepo))
 }
 
+// A tool call whose input is empty delivers only its name before the stream is
+// cut; the name alone must keep the estimate from reading as "nothing delivered".
+func TestNativeStream_EstimatesOutputFromToolStartName(t *testing.T) {
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+	vkRepo := &mockVirtualKeyRepo{}
+	h.virtualKeyRepo = vkRepo
+
+	head, _, _ := strings.Cut(nativeStreamHead, "event: content_block_start")
+	body := head + "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"t1\",\"name\":\"lookup\",\"input\":{}}}\n\n"
+	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body))}
+	logData := &requestLogData{id: uuid.New().String(), modelID: "claude-test", streaming: true, virtualKeyName: "test-key", virtualKeyID: "00000000-0000-0000-0000-000000000001", state: "streaming", promptTextBytes: 40}
+	h.insertRequestLogAsync(logData)
+	time.Sleep(20 * time.Millisecond)
+	h.handleStreamingResponse(httptest.NewRecorder(), httptest.NewRequest("POST", "/v1/messages", http.NoBody), logData, resp, time.Now(), streamOptions{vkHash: "test-hash", attempt: 1, rawPassthrough: true})
+
+	// input_tokens 12 reported by message_start; "lookup" (6 bytes) → 2 estimated.
+	assert.Equal(t, 14, singleAddTokens(t, vkRepo))
+}
+
 func TestHandleNativeNonStreaming_EstimatesUsageWhenOmitted(t *testing.T) {
 	h := newIntegrationHandler()
 	t.Cleanup(func() { stopUnitHandler(h) })
@@ -269,8 +300,8 @@ func TestHandleNativeNonStreaming_EstimatesUsageWhenOmitted(t *testing.T) {
 
 	h.handleNativeNonStreaming(aw, httptest.NewRequest("POST", "/v1/messages", http.NoBody), st, resp, 1, 5)
 
-	// 40 prompt bytes → 10; "Hello, world!" (13) + {"a":1} (7) = 20 bytes → 5.
-	assert.Equal(t, 15, singleAddTokens(t, vkRepo))
+	// 40 prompt bytes → 10; "Hello, world!" (13) + "f" (1) + {"a":1} (7) = 21 bytes → 6.
+	assert.Equal(t, 16, singleAddTokens(t, vkRepo))
 }
 
 func TestHandleNonStreamingResponse_EstimatesUsageWhenProviderOmitsIt(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes a TPM/billing-integrity bypass on `/v1/chat/completions` (security review finding vuln-0001, MEDIUM).

Streaming metering relied solely on the provider's `usage` SSE chunk, which is the **last** chunk of an OpenAI stream. A virtual-key holder could read the full completion and disconnect before it, or target a provider that omits usage, and the request metered as zero. TPM admission only reserves a 1-token placeholder and `Debit` is a no-op at zero, so the per-key/per-owner TPM budget was bypassed and `tokens_used` never moved while the provider still billed the operator. Keeping the upstream stream open to catch the chunk is not an option: the upstream request shares the client's context, and cancelling it is also what stops the provider billing.

## What changes

- When no usage was reported and output was delivered, an estimate (4 bytes per token, rounded up) is charged against the TPM bucket and `tokens_used`. Reported usage always wins; an error before the first token still costs nothing.
- Each side is estimated independently: a native Anthropic stream that reported `input_tokens` on `message_start` but was cut before `message_delta` keeps its prompt figure and estimates only the output.
- Prompt size comes from the **message text and tool definitions**, never the raw body, so inline base64 media cannot turn one vision request into a phantom multi-million-token charge.
- Output bytes cover content, reasoning in every provider spelling (`reasoning_content`, `reasoning`, `reasoning_details`), and tool-call name + arguments, since agent traffic is mostly tool calls.
- Applied to OpenAI-shaped streaming and non-streaming, and both native Anthropic paths.
- Estimates charge the quota only. The request log keeps the provider's figures (zero when absent); the Info log line reports `prompt_estimated` / `completion_estimated` with the byte inputs.
- Boy-scout: the multimodal SSE passthrough dropped usage it had already scraped from the tail when the client disconnected mid-copy; it now records it.

## Tests

- `internal/proxy/usage_estimate_test.go`: both report variants through the real streaming pipeline, the security property itself (a real `TPMLimiter` with a 10-token cap refuses the next request after an estimated debit), tool-call-only stream, zero-valued usage chunk, reported-usage-wins, no-content-no-charge, native Anthropic truncation and non-streaming omission, non-streaming omission, base64 body sizing, ingest wiring, multimodal interrupted copy.
- `internal/anthropic`: `TextBytes` on stream deltas and `ResponseTextBytes`.
- 1647 tests pass across proxy/anthropic/ratelimit, `-race` clean, golangci-lint 0 issues, 100% line coverage on every new or changed function.

Reviewed by an Opus subagent before opening; its two severe findings (raw-body prompt sizing, tool-call streams) are fixed in this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
