### PR TITLE
fix(proxy): mask credential-shaped tokens in streamed SSE error frames

### DIFF
--- a/internal/proxy/anthropic_native.go
+++ b/internal/proxy/anthropic_native.go
@@ -112,8 +112,9 @@ func (h *Handler) handleNativeNonStreaming(w http.ResponseWriter, r *http.Reques
 // so finalizeStream can tell a real completion from a mid-stream truncation, and
 // (3) captures a provider-sent error event into streamState so the request logs
 // as failed (deriveStreamError surfaces st.lastErrMsg) rather than silently
-// "completed" — the error frame is still forwarded to the client too. Returns
-// stop=true on a client write failure.
+// "completed" — the error frame is still forwarded to the client too, with
+// credential-shaped tokens masked (the same scrub handleDataChunk applies).
+// Returns stop=true on a client write failure.
 func (h *Handler) emitRawData(sink *streamSink, st *streamState, ev sseEvent, chunkCount int, logData *requestLogData) (stop bool) {
 	info := anthropic.InspectStreamEvent([]byte(ev.payload))
 	if info.HasInput {
@@ -139,7 +140,13 @@ func (h *Handler) emitRawData(sink *streamSink, st *streamState, ev sseEvent, ch
 			debuglog.Warn("proxy: native anthropic SSE error event", "error_message", info.ErrorMessage, "model", logData.modelID, "provider", logData.providerName, "chunk_number", chunkCount)
 		}
 	}
-	if err := sink.write(ev.raw); err != nil {
+	line := ev.raw
+	if info.Type == "error" {
+		if masked := maskKeyShapedTokens([]byte(ev.payload)); string(masked) != ev.payload {
+			line = append([]byte("data: "), masked...)
+		}
+	}
+	if err := sink.write(line); err != nil {
 		st.clientDisconnected = true
 		debuglog.Warn("proxy: client write failed during native stream", "error", err, "model", logData.modelID, "provider", logData.providerName, "chunks", chunkCount, "bytes_written", sink.bytesWritten)
 		return true

--- a/internal/proxy/anthropic_native_test.go
+++ b/internal/proxy/anthropic_native_test.go
@@ -311,6 +311,27 @@ func TestNativeStream_ProviderErrorEvent(t *testing.T) {
 	}
 }
 
+// The native passthrough forwards the error frame raw, so it needs the same
+// credential scrub as the translated path; the request log keeps the original.
+func TestNativeStream_ProviderErrorEventMasksKeyShapedTokens(t *testing.T) {
+	const planted = "sk-ant-api03-STANDARDKEY1234567890abcdef1234567890"
+	body := nativeStreamHead + "event: error\ndata: {\"type\":\"error\",\"error\":{\"type\":\"authentication_error\",\"message\":\"invalid x-api-key " + planted + "\"}}\n\n"
+	w, logData := runNativeStream(t, body)
+
+	if strings.Contains(w.Body.String(), planted) {
+		t.Fatalf("operator credential reached the client via the native error frame:\n%s", w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `data: {"type":"error","error":{"type":"authentication_error","message":"invalid x-api-key [redacted]"}}`) {
+		t.Errorf("masked error frame not forwarded to client:\n%s", w.Body.String())
+	}
+	if logData.state != "failed" {
+		t.Errorf("state = %q, want failed", logData.state)
+	}
+	if !strings.Contains(logData.errorMessage, planted) {
+		t.Errorf("request log must keep the unmasked original, got %q", logData.errorMessage)
+	}
+}
+
 // warmCacheStream is a native stream whose message_start reports a warm cache:
 // a tiny uncached remainder beside a large cache read and a cache write.
 const warmCacheStream = `event: message_start

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -358,6 +358,22 @@ func (h *Handler) handleDataChunk(sink *streamSink, st *streamState, ev sseEvent
 		// the immutable typed chunk and never emit, so position doesn't affect output.
 		st.observeDataChunk(chunk, anthropicErrorCounted, chunkCount, logData)
 
+		// Mask credential-shaped tokens in an error frame before any emit. A
+		// provider failing mid-stream (auth, billing, quota) can quote the
+		// operator's provider credential inside the error object, and an HTTP 200
+		// stream never passes through forwardUpstreamError's masking. It sits
+		// here, ahead of the transforms, because every transform re-marshals the
+		// whole top-level object (an error frame that also carries a delta or a
+		// mappable finish_reason is rewritten and emitted with "error" intact).
+		// The observer above already took the unmasked message for the request
+		// log; chunk.Error is parsed, so content chunks pay nothing.
+		if chunk.Error != nil {
+			if masked := maskKeyShapedTokens([]byte(payload)); string(masked) != payload {
+				payload = string(masked)
+				line = append([]byte("data: "), masked...)
+			}
+		}
+
 		// strip_reasoning: drop reasoning-only deltas (keep-alive) or forward the
 		// stripped chunk. See computeStripReasoning.
 		if stripReasoning && len(chunk.Choices) > 0 && chunk.Choices[0].Delta != nil {

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -881,8 +881,9 @@ var keyShapedToken = regexp.MustCompile(`\b(?:sk|gsk|xai|hf|fw|r8)[-_][A-Za-z0-9
 // identifier or prose ("sk_business_unit_identifier", "Bearer
 // authentication-required") rather than a credential, and stays - real keys
 // carry digits. The replacement carries no JSON metacharacters, so a valid
-// body stays valid. This covers the buffered error paths; in-stream SSE error
-// frames ride the streaming pipeline untouched. Client-side only: the request
+// body stays valid. This covers the buffered error paths and in-stream SSE
+// error frames on both the translated (handleDataChunk) and native Anthropic
+// (emitRawData) streaming paths. Client-side only: the request
 // log keeps the original body for the operator.
 func maskKeyShapedTokens(body []byte) []byte {
 	return keyShapedToken.ReplaceAllFunc(body, func(m []byte) []byte {

--- a/internal/proxy/proxy_response_test.go
+++ b/internal/proxy/proxy_response_test.go
@@ -674,3 +674,127 @@ func TestHandleNonStreamingResponse_UpstreamNonJSONResponse(t *testing.T) {
 		t.Errorf("expected 200 (upstream status forwarded), got %d", inner.Code)
 	}
 }
+
+// An in-stream error frame rides the verbatim-forward path, which is the one
+// client-facing emit forwardUpstreamError's masking never sees. A provider that
+// quotes the operator's credential in a mid-stream auth/billing error must not
+// hand it to the virtual-key holder; the request log keeps the original.
+func TestHandleStreamingResponse_ErrorChunkMasksKeyShapedTokens(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandler(h)
+
+	const planted = "sk-proj-STANDARDKEY1234567890abcdef1234567890"
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Fatal("upstream response writer must support flushing")
+		}
+		fmt.Fprint(w, `data: {"id":"c1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","content":"hi"},"finish_reason":null}]}`+"\n\n")
+		fmt.Fprint(w, `data: {"error":{"message":"upstream rejected: billing key `+planted+` is invalid","type":"invalid_request_error","code":"invalid_api_key"}}`+"\n\n")
+		fmt.Fprint(w, "data: [DONE]\n\n")
+		flusher.Flush()
+	}))
+	defer upstream.Close()
+
+	req, err := http.NewRequest("POST", upstream.URL+"/v1/chat/completions", strings.NewReader(`{"model":"test","stream":true,"messages":[{"role":"user","content":"hi"}]}`))
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	req = withAuthContext(req)
+	resp, err := upstream.Client().Do(req)
+	if err != nil {
+		t.Fatalf("failed to contact upstream: %v", err)
+	}
+	defer resp.Body.Close()
+
+	inner := httptest.NewRecorder()
+	logData := &requestLogData{
+		modelID:        "test-model",
+		streaming:      true,
+		virtualKeyName: "test-key",
+		virtualKeyID:   "00000000-0000-0000-0000-000000000001",
+		state:          "streaming",
+	}
+	h.insertRequestLogAsync(logData)
+	time.Sleep(100 * time.Millisecond)
+
+	h.handleStreamingResponse(inner, req, logData, resp, time.Now(), streamOptions{vkHash: "test-hash", attempt: 1})
+
+	body := inner.Body.String()
+	if strings.Contains(body, planted) {
+		t.Fatalf("operator credential reached the client verbatim:\n%s", body)
+	}
+	if !strings.Contains(body, `data: {"error":{"message":"upstream rejected: billing key [redacted] is invalid"`) {
+		t.Fatalf("expected masked error frame in client bytes, got:\n%s", body)
+	}
+	if !strings.Contains(body, `"content":"hi"`) {
+		t.Fatalf("content chunk must still forward untouched, got:\n%s", body)
+	}
+	if !strings.Contains(body, "data: [DONE]") {
+		t.Fatalf("stream must still terminate with [DONE], got:\n%s", body)
+	}
+	if logData.state != "failed" {
+		t.Errorf("expected state=failed, got %q", logData.state)
+	}
+	if !strings.Contains(logData.errorMessage, planted) {
+		t.Errorf("request log must keep the unmasked original for the operator, got %q", logData.errorMessage)
+	}
+}
+
+// An error frame that also carries a mappable finish_reason is rewritten by
+// computeFinishReason, which re-marshals the whole object: the mask must run
+// ahead of the transforms, not only on the verbatim branch. Upstream uses the
+// no-space "data:" framing to pin that the masked frame is re-framed cleanly.
+func TestHandleStreamingResponse_TransformedErrorChunkMasksKeyShapedTokens(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandler(h)
+
+	const planted = "sk-proj-STANDARDKEY1234567890abcdef1234567890"
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `data:{"id":"c1","object":"chat.completion.chunk","error":{"message":"billing key `+planted+` is invalid"},"choices":[{"index":0,"delta":{},"finish_reason":"STOP"}]}`+"\n\n")
+		fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer upstream.Close()
+
+	req, err := http.NewRequest("POST", upstream.URL+"/v1/chat/completions", strings.NewReader(`{"model":"test","stream":true,"messages":[{"role":"user","content":"hi"}]}`))
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	req = withAuthContext(req)
+	resp, err := upstream.Client().Do(req)
+	if err != nil {
+		t.Fatalf("failed to contact upstream: %v", err)
+	}
+	defer resp.Body.Close()
+
+	inner := httptest.NewRecorder()
+	logData := &requestLogData{
+		modelID:        "test-model",
+		streaming:      true,
+		virtualKeyName: "test-key",
+		virtualKeyID:   "00000000-0000-0000-0000-000000000001",
+		state:          "streaming",
+	}
+	h.insertRequestLogAsync(logData)
+	time.Sleep(100 * time.Millisecond)
+
+	h.handleStreamingResponse(inner, req, logData, resp, time.Now(), streamOptions{vkHash: "test-hash", attempt: 1})
+
+	body := inner.Body.String()
+	if strings.Contains(body, planted) {
+		t.Fatalf("operator credential reached the client through a transformed error frame:\n%s", body)
+	}
+	if !strings.Contains(body, `"message":"billing key [redacted] is invalid"`) {
+		t.Fatalf("expected masked error frame in client bytes, got:\n%s", body)
+	}
+	if !strings.Contains(body, `"finish_reason":"stop"`) {
+		t.Fatalf("finish_reason normalization must still apply, got:\n%s", body)
+	}
+	if !strings.Contains(logData.errorMessage, planted) {
+		t.Errorf("request log must keep the unmasked original for the operator, got %q", logData.errorMessage)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a credential-disclosure gap on the streaming proxy path (CWE-209, review finding vuln-0002).

When an upstream provider fails mid-stream under HTTP 200 (auth, billing, quota) and quotes the operator's provider API key inside the SSE error frame, that frame reached the virtual-key holder byte-for-byte. The buffered non-2xx path already scrubs key-shaped tokens via `maskKeyShapedTokens`; in-stream frames never enter `forwardUpstreamError`, and the helper's own comment documented the gap.

## Changes

- `handleDataChunk`: mask the payload when `chunk.Error != nil`, placed directly after `observeDataChunk` (which has already captured the unmasked message for the request log) and **before** any transform. Every transform re-marshals the whole top-level object, so an error frame that also carries a `delta` or a mappable `finish_reason` would otherwise be rewritten and emitted with `"error"` intact. Content chunks pay nothing: `chunk.Error` is already parsed.
- `emitRawData` (native Anthropic passthrough): same scrub keyed on `info.Type == "error"`.
- Comments on `maskKeyShapedTokens` / `emitRawData` updated to describe the new coverage.

Client-side only, as before: the request log keeps the original message for the operator.

## Tests

- `TestHandleStreamingResponse_ErrorChunkMasksKeyShapedTokens`: verbatim-path error frame, content chunk untouched, `[DONE]` still terminates, log keeps the original.
- `TestHandleStreamingResponse_TransformedErrorChunkMasksKeyShapedTokens`: error frame + `finish_reason:"STOP"` with no-space `data:` framing, so it rides the finish_reason rewrite.
- `TestNativeStream_ProviderErrorEventMasksKeyShapedTokens`: Anthropic `event: error` on the native path.

All three fail with the production edits reverted. `go test ./internal/proxy/...` 1493 passed, `golangci-lint` clean.

## Not in scope

`multimodal.go` `serveStreamedPassthrough` (image/audio/embeddings SSE) streams upstream verbatim with the same class of gap; tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
