### PR TITLE
fix(proxy): mask the provider's exact credential, not only key shapes

### DIFF
--- a/internal/proxy/anthropic_native.go
+++ b/internal/proxy/anthropic_native.go
@@ -113,7 +113,8 @@ func (h *Handler) handleNativeNonStreaming(w http.ResponseWriter, r *http.Reques
 // (3) captures a provider-sent error event into streamState so the request logs
 // as failed (deriveStreamError surfaces st.lastErrMsg) rather than silently
 // "completed" — the error frame is still forwarded to the client too, with
-// credential-shaped tokens masked (the same scrub handleDataChunk applies).
+// the provider's credential masked (the same credentialMasker scrub
+// handleDataChunk applies).
 // Returns stop=true on a client write failure.
 func (h *Handler) emitRawData(sink *streamSink, st *streamState, ev sseEvent, chunkCount int, logData *requestLogData) (stop bool) {
 	info := anthropic.InspectStreamEvent([]byte(ev.payload))
@@ -142,7 +143,7 @@ func (h *Handler) emitRawData(sink *streamSink, st *streamState, ev sseEvent, ch
 	}
 	line := ev.raw
 	if info.Type == "error" {
-		if masked := maskKeyShapedTokens([]byte(ev.payload)); string(masked) != ev.payload {
+		if masked := st.masker.mask([]byte(ev.payload)); string(masked) != ev.payload {
 			line = append([]byte("data: "), masked...)
 		}
 	}

--- a/internal/proxy/anthropic_native_test.go
+++ b/internal/proxy/anthropic_native_test.go
@@ -204,6 +204,11 @@ func TestHandleNativeNonStreaming_ReadErrorFinalizesLog(t *testing.T) {
 // ttft_stall_test.go.
 func runNativeStream(t *testing.T, sseBody string) (*httptest.ResponseRecorder, *requestLogData) {
 	t.Helper()
+	return runNativeStreamWith(t, sseBody, credentialMasker{})
+}
+
+func runNativeStreamWith(t *testing.T, sseBody string, masker credentialMasker) (*httptest.ResponseRecorder, *requestLogData) {
+	t.Helper()
 	h := newIntegrationHandler()
 	t.Cleanup(func() { stopUnitHandler(h) })
 
@@ -226,6 +231,7 @@ func runNativeStream(t *testing.T, sseBody string) (*httptest.ResponseRecorder, 
 		vkHash:           "test-hash",
 		attempt:          1,
 		rawPassthrough:   true,
+		masker:           masker,
 	}
 	h.handleStreamingResponse(w, req, logData, resp, time.Now(), opts)
 	return w, logData
@@ -328,6 +334,24 @@ func TestNativeStream_ProviderErrorEventMasksKeyShapedTokens(t *testing.T) {
 		t.Errorf("state = %q, want failed", logData.state)
 	}
 	if !strings.Contains(logData.errorMessage, planted) {
+		t.Errorf("request log must keep the unmasked original, got %q", logData.errorMessage)
+	}
+}
+
+// Same contract on the native passthrough: a custom-shaped key is scrubbed by
+// exact value, since no prefix would catch it.
+func TestNativeStream_ProviderErrorEventMasksExactProviderKey(t *testing.T) {
+	const secret = "myCustomGatewayKey2024x9z8"
+	body := nativeStreamHead + "event: error\ndata: {\"type\":\"error\",\"error\":{\"type\":\"authentication_error\",\"message\":\"invalid x-api-key " + secret + "\"}}\n\n"
+	w, logData := runNativeStreamWith(t, body, newCredentialMasker(secret))
+
+	if strings.Contains(w.Body.String(), secret) {
+		t.Fatalf("exact provider key reached the client via the native error frame:\n%s", w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"message":"invalid x-api-key [redacted]"`) {
+		t.Errorf("masked error frame not forwarded to client:\n%s", w.Body.String())
+	}
+	if !strings.Contains(logData.errorMessage, secret) {
 		t.Errorf("request log must keep the unmasked original, got %q", logData.errorMessage)
 	}
 }

--- a/internal/proxy/hedging.go
+++ b/internal/proxy/hedging.go
@@ -440,6 +440,7 @@ func (h *Handler) serveHedgeWinner(w http.ResponseWriter, r *http.Request, st *r
 		vkHash:             st.vkHash,
 		attempt:            res.idx,
 		cancelOrigin:       "failover_timeout",
+		masker:             newCredentialMasker(candidate.apiKey),
 	}
 	// attempt is the 0-based failover_attempt this request is logged and stored
 	// with; it must match the value stream_finalize reports for the same request.

--- a/internal/proxy/hedging_test.go
+++ b/internal/proxy/hedging_test.go
@@ -33,6 +33,7 @@ type fakeProbeSpec struct {
 	won       bool          // true = streamable first token
 	reqErr    reqError      // failover cause when !won
 	ignoreCtx bool          // when true, the probe does not return early on ctx cancel
+	body      string        // SSE body the winner streams; empty = newStreamableResp
 }
 
 // hedgeHarness records how runHedgedStreaming drove the probes and hands back a
@@ -66,10 +67,14 @@ func (hh *hedgeHarness) probe(ctx context.Context, _ *requestState, candidate mo
 		}
 	}
 	if spec.won {
+		resp := newStreamableResp()
+		if spec.body != "" {
+			resp.Body = io.NopCloser(strings.NewReader(spec.body))
+		}
 		return hedgeResult{
 			idx:        attempt,
 			won:        true,
-			resp:       newStreamableResp(),
+			resp:       resp,
 			trueTtftMs: 1,
 		}
 	}
@@ -160,6 +165,34 @@ func TestRunHedgedStreaming_FastWinnerSkipsBackup(t *testing.T) {
 	}
 	if logData.providerName != "prov-A" {
 		t.Errorf("winner identity should be prov-A, got %q", logData.providerName)
+	}
+}
+
+// The winner's streamOptions must carry the winner's own credential masker:
+// an error frame from the hedged winner quoting its key is scrubbed by exact
+// value, which pins serveHedgeWinner as a masker producer.
+func TestRunHedgedStreaming_WinnerErrorFrameMasksExactProviderKey(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandler(h)
+
+	const secret = "myCustomGatewayKey2024x9z8"
+	hh := newHedgeHarness([]fakeProbeSpec{
+		{delay: 5 * time.Millisecond, won: true, body: "data: {\"error\":{\"message\":\"billing key " + secret + " is invalid\"}}\n\ndata: [DONE]\n\n"},
+		{delay: 5 * time.Millisecond, won: true},
+	})
+	st, logData := newHedgeState(500 * time.Millisecond)
+	cands := hedgeCandidates("prov-A", "prov-B")
+	cands[0].apiKey = secret
+	w := runHedge(context.Background(), h, hh, st, cands)
+
+	if strings.Contains(w.Body.String(), secret) {
+		t.Fatalf("winner's provider key reached the client:\n%s", w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"message":"billing key [redacted] is invalid"`) {
+		t.Errorf("expected masked error frame, got:\n%s", w.Body.String())
+	}
+	if !strings.Contains(logData.errorMessage, secret) {
+		t.Errorf("request log must keep the unmasked original, got %q", logData.errorMessage)
 	}
 }
 

--- a/internal/proxy/multimodal.go
+++ b/internal/proxy/multimodal.go
@@ -646,7 +646,7 @@ func (h *Handler) serveStreamedPassthrough(w http.ResponseWriter, r *http.Reques
 	var masker *sseErrorMaskWriter
 	if isSSE {
 		tail = newTailBuffer(passthroughSSETailCap)
-		masker = newSSEErrorMaskWriter(io.MultiWriter(newFlushWriter(w), tail))
+		masker = newSSEErrorMaskWriter(io.MultiWriter(newFlushWriter(w), tail), newCredentialMasker(candidate.apiKey))
 		dst = masker
 	}
 
@@ -822,8 +822,8 @@ const sseErrorMaskEventCap = 4 << 20
 // sseErrorMaskWriter is an io.Writer that forwards a pass-through SSE stream
 // one event at a time, scrubbing credential-shaped tokens from error frames
 // before they reach the client. Pass-through streams are otherwise copied
-// verbatim, so this is the one place the chat paths' maskKeyShapedTokens
-// scrub applies to the image/audio endpoints.
+// verbatim, so this is the one place the chat paths' credentialMasker scrub
+// applies to the image/audio endpoints.
 //
 // It works per event rather than per line because SSE lets one payload span
 // several `data:` lines (joined with "\n"); judging each line alone would let
@@ -841,14 +841,15 @@ const sseErrorMaskEventCap = 4 << 20
 // Flush releases a trailing event that lacked its delimiter.
 type sseErrorMaskWriter struct {
 	w       io.Writer
+	cred    credentialMasker
 	partial []byte   // unterminated line
 	event   [][]byte // complete lines of the event in progress, each with its eol
 	held    int      // input bytes buffered in partial + event
 	raw     bool     // event exceeded the cap: pass through until its delimiter
 }
 
-func newSSEErrorMaskWriter(w io.Writer) *sseErrorMaskWriter {
-	return &sseErrorMaskWriter{w: w}
+func newSSEErrorMaskWriter(w io.Writer, cred credentialMasker) *sseErrorMaskWriter {
+	return &sseErrorMaskWriter{w: w, cred: cred}
 }
 
 func (m *sseErrorMaskWriter) Write(p []byte) (int, error) {
@@ -946,7 +947,7 @@ func (m *sseErrorMaskWriter) emitEvent(delimiter []byte) error {
 	m.event, m.held = nil, 0
 
 	var out []byte
-	if masked, ok := maskSSEErrorEvent(lines); ok {
+	if masked, ok := maskSSEErrorEvent(lines, m.cred); ok {
 		out = masked
 	} else {
 		for _, l := range lines {
@@ -971,11 +972,11 @@ func isSSEBlankLine(line []byte) bool {
 
 // maskSSEErrorEvent joins the event's `data:` payloads per the SSE spec and,
 // when the result is a JSON object with a non-null "error" member that
-// maskKeyShapedTokens changes, returns the event re-serialised: non-data lines
+// cred.mask changes, returns the event re-serialised: non-data lines
 // in their original order and framing, then canonical "data: " lines carrying
 // the masked payload, one per physical line of the original. ok is false when the event is to be forwarded
 // verbatim.
-func maskSSEErrorEvent(lines [][]byte) (out []byte, ok bool) {
+func maskSSEErrorEvent(lines [][]byte, cred credentialMasker) (out []byte, ok bool) {
 	var payload []byte
 	var eol []byte
 	dataLines := 0
@@ -1002,7 +1003,7 @@ func maskSSEErrorEvent(lines [][]byte) (out []byte, ok bool) {
 	if json.Unmarshal(payload, &frame) != nil || len(frame.Error) == 0 || bytes.Equal(frame.Error, []byte("null")) {
 		return nil, false
 	}
-	masked := maskKeyShapedTokens(payload)
+	masked := cred.mask(payload)
 	if bytes.Equal(masked, payload) {
 		return nil, false
 	}

--- a/internal/proxy/multimodal_passthrough_test.go
+++ b/internal/proxy/multimodal_passthrough_test.go
@@ -884,6 +884,30 @@ func TestImageGenerations_SSEPassthroughMasksErrorFrame(t *testing.T) {
 	}
 }
 
+// The test provider's key ("test-api-key") has no prefix the shape regex knows,
+// which is exactly the custom-gateway case: the route must scrub it by value.
+func TestImageGenerations_SSEPassthroughMasksExactProviderKey(t *testing.T) {
+	sse := "event: error\ndata: {\"type\":\"error\",\"error\":{\"message\":\"billing key test-api-key is invalid\"}}\n\n"
+	env := newMultimodalEnv(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, sse)
+	}))
+
+	body := fmt.Sprintf(`{"model":"%s/%s","prompt":"a cat","stream":true,"partial_images":1}`, env.providerName, env.modelName)
+	req := env.request("/v1/images/generations", "application/json", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	env.handler.ImageGenerations(w, req)
+
+	got := w.Body.String()
+	if strings.Contains(got, "test-api-key") {
+		t.Fatalf("exact provider key reached the client through the SSE passthrough:\n%s", got)
+	}
+	want := "event: error\ndata: {\"type\":\"error\",\"error\":{\"message\":\"billing key [redacted] is invalid\"}}\n\n"
+	if got != want {
+		t.Errorf("masked stream mismatch:\ngot  %q\nwant %q", got, want)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Audio transcriptions (multipart)
 // ---------------------------------------------------------------------------
@@ -1466,7 +1490,7 @@ func TestSSEErrorMaskWriter(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			var out bytes.Buffer
-			m := newSSEErrorMaskWriter(&out)
+			m := newSSEErrorMaskWriter(&out, credentialMasker{})
 			for _, w := range tc.writes {
 				n, err := m.Write([]byte(w))
 				if err != nil || n != len(w) {
@@ -1486,7 +1510,7 @@ func TestSSEErrorMaskWriter(t *testing.T) {
 		// The client takes a prefix of the second event and dies. The first
 		// event was delivered in full; the second was not, so the count the
 		// caller logs as bytes delivered must stop at the event boundary.
-		m := newSSEErrorMaskWriter(&prefixFailingWriter{accept: 1})
+		m := newSSEErrorMaskWriter(&prefixFailingWriter{accept: 1}, credentialMasker{})
 		in := "data: x\n\ndata: y\n\n"
 		n, err := m.Write([]byte(in))
 		if err == nil {
@@ -1499,12 +1523,12 @@ func TestSSEErrorMaskWriter(t *testing.T) {
 
 	t.Run("spill and raw-mode write errors surface", func(t *testing.T) {
 		big := []byte("data: " + strings.Repeat("A", sseErrorMaskEventCap) + "\n")
-		m := newSSEErrorMaskWriter(&prefixFailingWriter{})
+		m := newSSEErrorMaskWriter(&prefixFailingWriter{}, credentialMasker{})
 		if n, err := m.Write(big); err == nil || n != 0 {
 			t.Fatalf("spill onto a dead client: got n=%d err=%v, want 0 and an error", n, err)
 		}
 
-		m = newSSEErrorMaskWriter(&prefixFailingWriter{accept: 1})
+		m = newSSEErrorMaskWriter(&prefixFailingWriter{accept: 1}, credentialMasker{})
 		if n, err := m.Write(big); err != nil || n != len(big) {
 			t.Fatalf("spill: got n=%d err=%v, want %d and nil", n, err, len(big))
 		}
@@ -1514,7 +1538,7 @@ func TestSSEErrorMaskWriter(t *testing.T) {
 	})
 
 	t.Run("flush error surfaces", func(t *testing.T) {
-		m := newSSEErrorMaskWriter(&prefixFailingWriter{})
+		m := newSSEErrorMaskWriter(&prefixFailingWriter{}, credentialMasker{})
 		if _, err := m.Write([]byte("data: tail")); err != nil {
 			t.Fatalf("buffering a partial line must not touch the client: %v", err)
 		}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -58,7 +58,7 @@ func (h *Handler) handleStreamingResponse(w http.ResponseWriter, r *http.Request
 	// the transforms/observers and the finalizer share one named contract
 	// instead of a fistful of loop-locals. The stall flag and final chunkCount
 	// are filled from the reader at logUpdate.
-	st := &streamState{}
+	st := &streamState{masker: opts.masker}
 	// Periodic streaming progress logging (every 50 chunks) to give
 	// visibility into stream health without flooding logs.
 	const chunkLogInterval = 50
@@ -368,7 +368,7 @@ func (h *Handler) handleDataChunk(sink *streamSink, st *streamState, ev sseEvent
 		// The observer above already took the unmasked message for the request
 		// log; chunk.Error is parsed, so content chunks pay nothing.
 		if chunk.Error != nil {
-			if masked := maskKeyShapedTokens([]byte(payload)); string(masked) != payload {
+			if masked := st.masker.mask([]byte(payload)); string(masked) != payload {
 				payload = string(masked)
 				line = append([]byte("data: "), masked...)
 			}

--- a/internal/proxy/proxy_chat_completions_test.go
+++ b/internal/proxy/proxy_chat_completions_test.go
@@ -679,6 +679,45 @@ func TestChatCompletions_StreamingSSEFormatError(t *testing.T) {
 	}
 }
 
+// The non-hedged dispatcher must hand the stream the candidate's credential
+// masker: the env provider's key ("test-api-key") has no prefix the shape regex
+// knows, so only the exact-value layer can scrub it. Pins dispatchStreaming as
+// a masker producer.
+func TestChatCompletions_StreamingErrorFrameMasksExactProviderKey(t *testing.T) {
+	env := newTestProxyHandler(t)
+	handler := env.Handler
+	defer handler.Close()
+
+	env.Upstream.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"}}]}\n\n")
+		fmt.Fprint(w, "data: {\"error\":{\"message\":\"billing key test-api-key is invalid\"}}\n\n")
+		fmt.Fprint(w, "data: [DONE]\n\n")
+	})
+
+	body := `{"model": "` + env.ProviderName + `/` + env.ModelName + `", "messages": [{"role": "user", "content": "hello"}], "stream": true}`
+	req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(body))
+	ctx := context.WithValue(req.Context(), virtualKeyNameKey, "test-key")
+	ctx = context.WithValue(ctx, virtualKeyIDKey, uuid.New().String())
+	ctx = context.WithValue(ctx, VirtualKeyHashKey, env.KeyHash)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	handler.ChatCompletions(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	got := w.Body.String()
+	if strings.Contains(got, "test-api-key") {
+		t.Fatalf("provider key reached the client through the dispatched stream:\n%s", got)
+	}
+	if !strings.Contains(got, `"message":"billing key [redacted] is invalid"`) {
+		t.Errorf("expected masked error frame, got:\n%s", got)
+	}
+}
+
 // TestChatCompletions_FailoverOnRateLimit tests failover when rate limit is hit
 
 func TestChatCompletions_FailoverOnRateLimit(t *testing.T) {

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -344,6 +344,7 @@ func (h *Handler) dispatchStreaming(w http.ResponseWriter, r *http.Request, st *
 		attempt:            attempt,
 		cancelOrigin:       streamCancelOrigin,
 		rawPassthrough:     st.anthropicNativeAttempt,
+		masker:             newCredentialMasker(candidate.apiKey),
 	}
 
 	if ttftTimeout > 0 {
@@ -751,13 +752,15 @@ const forwardableErrorBodyCap = 1 << 20
 // the client may see is decided by it together with the static
 // forwardableErrorStatus class. A payload-class refusal (a plain 400 and its
 // kin) judged this caller's own request, so the upstream's error object is
-// forwarded with key-shaped tokens masked. Everything else - auth, billing,
+// forwarded with the provider's credential masked (credentialMasker: exact
+// key, then key-shaped tokens). Everything else - auth, billing,
 // rate limit, not-found, server faults, whether classed by eligibility or by
 // status - gets a synthesised envelope with the classified reason, because
 // those bodies can quote the operator's provider credentials or account
 // details; the body stays in the request log either way. Drains/closes
 // resp.Body exactly once and always returns outcomeFatal.
 func (h *Handler) forwardUpstreamError(w http.ResponseWriter, st *requestState, candidate modelCandidate, resp *http.Response, attempt int, isFailoverEligible bool, responseHeaderMs float64) candidateOutcome {
+	masker := newCredentialMasker(candidate.apiKey)
 	logData := st.logData
 	mayForwardError := !isFailoverEligible && forwardableErrorStatus(resp.StatusCode)
 	// How much of the body is worth holding depends on what happens to it
@@ -839,7 +842,7 @@ func (h *Handler) forwardUpstreamError(w http.ResponseWriter, st *requestState, 
 		// provider-authored free text.
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(resp.StatusCode)
-		_, _ = w.Write(maskKeyShapedTokens(body))
+		_, _ = w.Write(masker.mask(body))
 	case json.Valid(body):
 		// A non-2xx whose JSON body carries no error object. OpenCode Zen and
 		// OpenCode Go answer some failed requests with a complete
@@ -858,7 +861,7 @@ func (h *Handler) forwardUpstreamError(w http.ResponseWriter, st *requestState, 
 		// full body reaches the request log either way via failRequest, and how
 		// much of a provider's response this gateway echoes to callers is one
 		// decision for all three cases rather than something to widen here.
-		writeOpenAIError(w, string(maskKeyShapedTokens([]byte(errMsg))), resp.StatusCode)
+		writeOpenAIError(w, string(masker.mask([]byte(errMsg))), resp.StatusCode)
 	}
 	return outcomeFatal
 }
@@ -870,22 +873,61 @@ func (h *Handler) forwardUpstreamError(w http.ResponseWriter, st *requestState, 
 // (AKIA...), bare JWTs (the MiniMax API key format), and bearer tokens. The
 // minimum tail lengths keep prose like "sk-abc" out of scope; matches without
 // a digit are prose too and are dropped by maskKeyShapedTokens. A prefix list
-// necessarily trails the provider roster - it is the second layer, not the
-// control, which is the status-class gate above.
+// necessarily trails the provider roster - it is the third layer, behind the
+// status-class gate above and credentialMasker's exact match of this
+// gateway's own key.
 var keyShapedToken = regexp.MustCompile(`\b(?:sk|gsk|xai|hf|fw|r8)[-_][A-Za-z0-9_-]{16,}|\bAIza[0-9A-Za-z_-]{30,}|\bAKIA[0-9A-Z]{16}\b|\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{5,}|(?i:\bbearer\s+)[A-Za-z0-9._~+/=-]{16,}`)
+
+// credentialMinLen is the shortest provider key the exact-value mask will
+// redact. Keyless local providers carry an empty key and a handful of test or
+// placeholder setups use tiny ones; rewriting every occurrence of a few
+// characters would shred the body without protecting anything.
+const credentialMinLen = 8
+
+// credentialMasker scrubs a provider's credential out of client-bound text.
+// The exact decrypted key is the primary control: it is an exact byte match,
+// so it covers every key shape, including custom or self-hosted gateways
+// whose format the prefix regex can never anticipate, but not a JSON-escaped
+// rendering of the key (an encoder turning "&" into "\u0026" or "/" into
+// "\/" defeats it; real keys rarely carry such bytes). maskKeyShapedTokens
+// runs after it as the third layer, behind the status-class gate, for
+// credentials a relay quotes that are not ours. Build one per candidate with
+// newCredentialMasker and pass it to every client-facing emit of provider
+// error text: the buffered paths in forwardUpstreamError and the in-stream
+// error frames on the translated (handleDataChunk), native Anthropic
+// (emitRawData) and pass-through (sseErrorMaskWriter) streaming paths. The
+// zero value masks by shape only. Client-side only: the request log keeps the
+// original body.
+type credentialMasker struct {
+	secret []byte
+}
+
+func newCredentialMasker(apiKey string) credentialMasker {
+	if len(apiKey) < credentialMinLen {
+		return credentialMasker{}
+	}
+	return credentialMasker{secret: []byte(apiKey)}
+}
+
+// mask returns body with every occurrence of the exact credential, then any
+// key-shaped token, replaced by "[redacted]". The exact pass runs first so the
+// regex cannot split the key and leave a recognisable remainder.
+func (m credentialMasker) mask(body []byte) []byte {
+	if len(m.secret) > 0 && bytes.Contains(body, m.secret) {
+		body = bytes.ReplaceAll(body, m.secret, []byte("[redacted]"))
+	}
+	return maskKeyShapedTokens(body)
+}
 
 // maskKeyShapedTokens scrubs credential-looking substrings from an upstream
 // body before it is forwarded to a client. Auth-class errors never forward at
-// all; this is the second layer, for a provider quoting a credential inside an
-// otherwise forwardable payload error. A match with no digit in it is an
-// identifier or prose ("sk_business_unit_identifier", "Bearer
-// authentication-required") rather than a credential, and stays - real keys
-// carry digits. The replacement carries no JSON metacharacters, so a valid
-// body stays valid. This covers the buffered error paths and in-stream SSE
-// error frames on the translated (handleDataChunk), native Anthropic
-// (emitRawData) and pass-through (sseErrorMaskWriter) streaming paths.
-// Client-side only: the request
-// log keeps the original body for the operator.
+// all, and credentialMasker has already removed this gateway's own key by
+// exact value; this is the third layer, for a provider quoting some other
+// credential inside an otherwise forwardable payload error. A match with no
+// digit in it is an identifier or prose ("sk_business_unit_identifier",
+// "Bearer authentication-required") rather than a credential, and stays -
+// real keys carry digits. The replacement carries no JSON metacharacters, so
+// a valid body stays valid.
 func maskKeyShapedTokens(body []byte) []byte {
 	return keyShapedToken.ReplaceAllFunc(body, func(m []byte) []byte {
 		if !bytes.ContainsAny(m, "0123456789") {

--- a/internal/proxy/proxy_failover_test.go
+++ b/internal/proxy/proxy_failover_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -653,6 +654,18 @@ func TestDoUpstream_ClientDisconnectPreservesProviderError(t *testing.T) {
 // returns what the client got plus the log row it left behind.
 func runForwardUpstreamError(t *testing.T, h *Handler, status int, body string, isFailoverEligible bool) (*httptest.ResponseRecorder, *requestLogData) {
 	t.Helper()
+	return runForwardUpstreamErrorWith(t, h, status, body, isFailoverEligible, "")
+}
+
+// runForwardUpstreamErrorWithKey is runForwardUpstreamError with the candidate
+// carrying a decrypted provider key, for the exact-value masking tests.
+func runForwardUpstreamErrorWithKey(t *testing.T, h *Handler, status int, body, apiKey string) (*httptest.ResponseRecorder, *requestLogData) {
+	t.Helper()
+	return runForwardUpstreamErrorWith(t, h, status, body, false, apiKey)
+}
+
+func runForwardUpstreamErrorWith(t *testing.T, h *Handler, status int, body string, isFailoverEligible bool, apiKey string) (*httptest.ResponseRecorder, *requestLogData) {
+	t.Helper()
 
 	logData := &requestLogData{
 		modelID:        "gpt-5.1-codex",
@@ -665,6 +678,7 @@ func runForwardUpstreamError(t *testing.T, h *Handler, status int, body string, 
 	candidate := modelCandidate{
 		model:    &model.Model{ModelID: "gpt-5.1-codex"},
 		provider: &provider.Provider{ID: uuid.New(), Name: "opencode-zen"},
+		apiKey:   apiKey,
 	}
 	resp := &http.Response{
 		StatusCode: status,
@@ -1071,4 +1085,51 @@ func TestForwardUpstreamError_2xxBodyUntouched(t *testing.T) {
 			t.Errorf("non-JSON 2xx body rewritten: %s", got)
 		}
 	})
+}
+
+// A custom or self-hosted gateway key has no prefix the shape regex knows, so
+// the exact decrypted credential is the control that covers it. Both forwarded
+// branches must scrub it; the request log keeps the original.
+func TestForwardUpstreamError_MasksExactProviderKey(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandler(h)
+
+	const secret = "myCustomGatewayKey2024x9z8"
+	for name, body := range map[string]string{
+		"json":    `{"error":{"message":"invalid request for account key ` + secret + `: context too long | your key: ` + secret + `","type":"invalid_request_error","code":"context_length_exceeded"}}`,
+		"nonjson": `upstream rejected key ` + secret + ` (not json)`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			w, logData := runForwardUpstreamErrorWithKey(t, h, http.StatusBadRequest, body, secret)
+			got := w.Body.String()
+			if strings.Contains(got, secret) {
+				t.Fatalf("exact provider key reached the client: %s", got)
+			}
+			if strings.Count(got, "[redacted]") != strings.Count(body, secret) {
+				t.Errorf("every occurrence must be masked, got: %s", got)
+			}
+			if !strings.Contains(logData.errorMessage, secret) {
+				t.Errorf("request log lost the original body: %s", logData.errorMessage)
+			}
+		})
+	}
+}
+
+// A keyless or placeholder credential below credentialMinLen must not turn
+// into a body-wide rewrite.
+func TestCredentialMasker(t *testing.T) {
+	body := []byte(`{"error":{"message":"ab: key abcdefgh12 and sk-proj-0123456789abcdef0123456789abcdef"}}`)
+	if got := newCredentialMasker("").mask(body); !bytes.Equal(got, maskKeyShapedTokens(body)) {
+		t.Errorf("empty key must mask by shape only, got %s", got)
+	}
+	if got := newCredentialMasker("ab").mask(body); !bytes.Equal(got, maskKeyShapedTokens(body)) {
+		t.Errorf("short key must mask by shape only, got %s", got)
+	}
+	got := string(newCredentialMasker("abcdefgh12").mask(body))
+	if strings.Contains(got, "abcdefgh12") || strings.Contains(got, "sk-proj-") {
+		t.Errorf("exact and shape layers must both apply, got %s", got)
+	}
+	if !strings.HasPrefix(got, `{"error":{"message":"ab: key [redacted] and [redacted]"}}`) {
+		t.Errorf("unexpected rewrite: %s", got)
+	}
 }

--- a/internal/proxy/proxy_response_test.go
+++ b/internal/proxy/proxy_response_test.go
@@ -798,3 +798,54 @@ func TestHandleStreamingResponse_TransformedErrorChunkMasksKeyShapedTokens(t *te
 		t.Errorf("request log must keep the unmasked original for the operator, got %q", logData.errorMessage)
 	}
 }
+
+// The shape regex cannot know a custom gateway's key format; the stream must
+// scrub the exact credential the dispatcher hands it.
+func TestHandleStreamingResponse_ErrorChunkMasksExactProviderKey(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandler(h)
+
+	const secret = "myCustomGatewayKey2024x9z8"
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `data: {"error":{"message":"billing key `+secret+` is invalid"}}`+"\n\n")
+		fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer upstream.Close()
+
+	req, err := http.NewRequest("POST", upstream.URL+"/v1/chat/completions", strings.NewReader(`{"model":"test","stream":true,"messages":[{"role":"user","content":"hi"}]}`))
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	req = withAuthContext(req)
+	resp, err := upstream.Client().Do(req)
+	if err != nil {
+		t.Fatalf("failed to contact upstream: %v", err)
+	}
+	defer resp.Body.Close()
+
+	inner := httptest.NewRecorder()
+	logData := &requestLogData{
+		modelID:        "test-model",
+		streaming:      true,
+		virtualKeyName: "test-key",
+		virtualKeyID:   "00000000-0000-0000-0000-000000000001",
+		state:          "streaming",
+	}
+	h.insertRequestLogAsync(logData)
+	time.Sleep(100 * time.Millisecond)
+
+	h.handleStreamingResponse(inner, req, logData, resp, time.Now(), streamOptions{vkHash: "test-hash", attempt: 1, masker: newCredentialMasker(secret)})
+
+	body := inner.Body.String()
+	if strings.Contains(body, secret) {
+		t.Fatalf("exact provider key reached the client:\n%s", body)
+	}
+	if !strings.Contains(body, `"message":"billing key [redacted] is invalid"`) {
+		t.Fatalf("expected masked error frame, got:\n%s", body)
+	}
+	if !strings.Contains(logData.errorMessage, secret) {
+		t.Errorf("request log must keep the unmasked original, got %q", logData.errorMessage)
+	}
+}

--- a/internal/proxy/stream_finalize.go
+++ b/internal/proxy/stream_finalize.go
@@ -25,6 +25,9 @@ const (
 // hand-off between the loop and the finalizer; later phases migrate more of the
 // loop-local accumulators here.
 type streamState struct {
+	// masker scrubs the provider's credential from error frames bound for the
+	// client; copied from streamOptions so the chunk handlers can reach it.
+	masker                credentialMasker
 	promptTokens          int
 	completionTokens      int
 	reasoningTokens       int

--- a/internal/proxy/types.go
+++ b/internal/proxy/types.go
@@ -336,6 +336,10 @@ type streamOptions struct {
 	// an OpenAI chunk and applying the transforms. Set for the native Anthropic
 	// /v1/messages passthrough path, whose stream is already Anthropic-shaped.
 	rawPassthrough bool
+	// masker scrubs the candidate's credential from in-stream error frames
+	// before they reach the client. Built from candidate.apiKey by the
+	// dispatcher; the zero value masks by shape only.
+	masker credentialMasker
 }
 
 // ChatCompletionRequest is the request body for /v1/chat/completions.


### PR DESCRIPTION
## Summary

Closes review finding vuln-0003 (CWE-209), the sibling of #734/#735. Those made sure masking runs at every client-facing emit of provider error text; this PR fixes *what* is masked. `maskKeyShapedTokens` matched credentials by known prefix shape only (`sk-`, `gsk_`, `AIza`, `AKIA`, JWT, bearer), so a custom or self-hosted gateway key such as `myCustomGatewayKey2024x9z8` quoted in a forwardable 4xx body or an in-stream error frame reached the virtual-key holder verbatim.

## Changes

- New `credentialMasker` (`proxy_failover.go`): built once per candidate from the decrypted `candidate.apiKey`, it redacts the exact key by byte match first, then runs the prefix regex as the third layer (behind the status-class gate) for credentials a relay quotes that are not ours. Keys shorter than `credentialMinLen` (8) are skipped so keyless and placeholder providers never trigger a body-wide rewrite.
- Threaded to all five emit sites: both branches of `forwardUpstreamError`; `streamOptions.masker` set by `dispatchStreaming` and by the hedging winner path, copied to `streamState` for `handleDataChunk` and `emitRawData`; and `newSSEErrorMaskWriter` in `serveStreamedPassthrough`. No non-test call to `maskKeyShapedTokens` remains outside the masker.
- Doc comments consolidated on a single layer numbering (status gate, exact key, shape regex) and the exact-match limit stated: a JSON-escaped rendering of the key (`&`, `\/`) is not covered.

Client-side only, as before: the request log keeps the original body.

## Tests

Exact-value masking on every surface with a non-prefix key, each failing with its site's wiring reverted:
- `TestForwardUpstreamError_MasksExactProviderKey` (JSON and non-JSON branches)
- `TestHandleStreamingResponse_ErrorChunkMasksExactProviderKey`, `TestNativeStream_ProviderErrorEventMasksExactProviderKey` (consumers)
- `TestChatCompletions_StreamingErrorFrameMasksExactProviderKey`, `TestRunHedgedStreaming_WinnerErrorFrameMasksExactProviderKey` (the two `streamOptions` producers, end-to-end)
- `TestImageGenerations_SSEPassthroughMasksExactProviderKey`
- `TestCredentialMasker`: empty/short key masks by shape only; both layers apply together.

`go test ./internal/proxy/...` 1519 passed, `golangci-lint` clean.

## Known limits (not in scope)

- Masking still fires only on error-shaped frames (`{"error":…}`, Anthropic `type:"error"`); a gateway emitting `{"detail":"…key…"}` under HTTP 200 is forwarded as content. Extending the exact-value layer to every forwarded frame is a possible follow-up.
- Request-log `error_message` is readable by VK-owning dashboard users under multi-user, not only the admin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
