### PR TITLE
fix(proxy): exact-mask the provider key on every client body and in the log

### DIFF
--- a/internal/proxy/anthropic_native.go
+++ b/internal/proxy/anthropic_native.go
@@ -60,6 +60,9 @@ func (h *Handler) handleNativeNonStreaming(w http.ResponseWriter, r *http.Reques
 		writeAnthropicError(w, "failed to read upstream response", http.StatusBadGateway)
 		return outcomeFatal
 	}
+	// Exact-key scrub only: this is a success body, content where the
+	// key-shape regex must not run.
+	body = logData.masker.maskExact(body)
 
 	usage := anthropic.ParseResponseUsage(body)
 	inputTokens, outputTokens := usage.PromptTokens, usage.CompletionTokens
@@ -114,7 +117,7 @@ func (h *Handler) handleNativeNonStreaming(w http.ResponseWriter, r *http.Reques
 // as failed (deriveStreamError surfaces st.lastErrMsg) rather than silently
 // "completed" — the error frame is still forwarded to the client too, with
 // the provider's credential masked (the same credentialMasker scrub
-// handleDataChunk applies).
+// handleDataChunk applies: exact key on every event, key shapes on errors).
 // Returns stop=true on a client write failure.
 func (h *Handler) emitRawData(sink *streamSink, st *streamState, ev sseEvent, chunkCount int, logData *requestLogData) (stop bool) {
 	info := anthropic.InspectStreamEvent([]byte(ev.payload))
@@ -142,10 +145,12 @@ func (h *Handler) emitRawData(sink *streamSink, st *streamState, ev sseEvent, ch
 		}
 	}
 	line := ev.raw
+	masked := st.masker.maskExact([]byte(ev.payload))
 	if info.Type == "error" {
-		if masked := st.masker.mask([]byte(ev.payload)); string(masked) != ev.payload {
-			line = append([]byte("data: "), masked...)
-		}
+		masked = maskKeyShapedTokens(masked)
+	}
+	if string(masked) != ev.payload {
+		line = append([]byte("data: "), masked...)
 	}
 	if err := sink.write(line); err != nil {
 		st.clientDisconnected = true

--- a/internal/proxy/anthropic_native_test.go
+++ b/internal/proxy/anthropic_native_test.go
@@ -333,8 +333,8 @@ func TestNativeStream_ProviderErrorEventMasksKeyShapedTokens(t *testing.T) {
 	if logData.state != "failed" {
 		t.Errorf("state = %q, want failed", logData.state)
 	}
-	if !strings.Contains(logData.errorMessage, planted) {
-		t.Errorf("request log must keep the unmasked original, got %q", logData.errorMessage)
+	if strings.Contains(logData.errorMessage, planted) {
+		t.Errorf("key-shaped token reached the request log, got %q", logData.errorMessage)
 	}
 }
 

--- a/internal/proxy/anthropic_native_test.go
+++ b/internal/proxy/anthropic_native_test.go
@@ -342,17 +342,36 @@ func TestNativeStream_ProviderErrorEventMasksKeyShapedTokens(t *testing.T) {
 // exact value, since no prefix would catch it.
 func TestNativeStream_ProviderErrorEventMasksExactProviderKey(t *testing.T) {
 	const secret = "myCustomGatewayKey2024x9z8"
-	body := nativeStreamHead + "event: error\ndata: {\"type\":\"error\",\"error\":{\"type\":\"authentication_error\",\"message\":\"invalid x-api-key " + secret + "\"}}\n\n"
+	body := nativeStreamHead +
+		"event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"your key is " + secret + "\"}}\n\n" +
+		"event: error\ndata: {\"type\":\"error\",\"error\":{\"type\":\"authentication_error\",\"message\":\"invalid x-api-key " + secret + "\"}}\n\n"
 	w, logData := runNativeStreamWith(t, body, newCredentialMasker(secret))
 
 	if strings.Contains(w.Body.String(), secret) {
-		t.Fatalf("exact provider key reached the client via the native error frame:\n%s", w.Body.String())
+		t.Fatalf("exact provider key reached the client via the native stream:\n%s", w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"text":"your key is [redacted]"`) {
+		t.Errorf("content event not exact-masked:\n%s", w.Body.String())
 	}
 	if !strings.Contains(w.Body.String(), `"message":"invalid x-api-key [redacted]"`) {
 		t.Errorf("masked error frame not forwarded to client:\n%s", w.Body.String())
 	}
-	if !strings.Contains(logData.errorMessage, secret) {
-		t.Errorf("request log must keep the unmasked original, got %q", logData.errorMessage)
+	if strings.Contains(logData.errorMessage, secret) || !strings.Contains(logData.errorMessage, "[redacted]") {
+		t.Errorf("request log must carry the error with the exact key redacted, got %q", logData.errorMessage)
+	}
+}
+
+// The native non-streaming body is content; a gateway quoting its key there is
+// scrubbed by exact value from the per-attempt masker stamped on the log row.
+func TestHandleNativeNonStreaming_MasksExactProviderKey(t *testing.T) {
+	const secret = "myCustomGatewayKey2024x9z8"
+	body := `{"id":"msg_1","type":"message","role":"assistant","model":"claude","content":[{"type":"text","text":"your key is ` + secret + `"}],"stop_reason":"end_turn","usage":{"input_tokens":3,"output_tokens":4}}`
+	rec, _ := runNativeNonStreamingWith(t, body, newCredentialMasker(secret))
+	if strings.Contains(rec.Body.String(), secret) {
+		t.Fatalf("exact provider key reached the client via the native non-streaming body:\n%s", rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"text":"your key is [redacted]"`) {
+		t.Errorf("content not exact-masked:\n%s", rec.Body.String())
 	}
 }
 
@@ -397,6 +416,12 @@ func TestNativeStream_RecordsCacheSplit(t *testing.T) {
 // handleNativeNonStreaming and returns the finalized log row.
 func runNativeNonStreaming(t *testing.T, anthropicBody string) *requestLogData {
 	t.Helper()
+	_, logData := runNativeNonStreamingWith(t, anthropicBody, credentialMasker{})
+	return logData
+}
+
+func runNativeNonStreamingWith(t *testing.T, anthropicBody string, masker credentialMasker) (*httptest.ResponseRecorder, *requestLogData) {
+	t.Helper()
 	h := newIntegrationHandler()
 	t.Cleanup(func() { stopUnitHandler(h) })
 
@@ -413,6 +438,7 @@ func runNativeNonStreaming(t *testing.T, anthropicBody string) *requestLogData {
 		virtualKeyName: "test-key",
 		virtualKeyID:   "00000000-0000-0000-0000-000000000001",
 		state:          "streaming",
+		masker:         masker,
 	}
 	st := &requestState{startTime: time.Now(), logData: logData}
 	h.insertRequestLogAsync(logData)
@@ -422,7 +448,7 @@ func runNativeNonStreaming(t *testing.T, anthropicBody string) *requestLogData {
 		t.Fatalf("outcome = %v, want outcomeServed", outcome)
 	}
 	aw.Finalize()
-	return logData
+	return rec, logData
 }
 
 // Same split on the non-streaming native path, so the two agree.

--- a/internal/proxy/hedging.go
+++ b/internal/proxy/hedging.go
@@ -414,6 +414,7 @@ func (h *Handler) serveHedgeWinner(w http.ResponseWriter, r *http.Request, st *r
 	logData := st.logData
 	logData.providerID = candidate.provider.ID
 	logData.providerName = candidate.provider.Name
+	logData.masker = newCredentialMasker(candidate.apiKey)
 	if st.isFailover {
 		logData.resolvedModelID = candidate.model.ModelID
 	}
@@ -440,7 +441,7 @@ func (h *Handler) serveHedgeWinner(w http.ResponseWriter, r *http.Request, st *r
 		vkHash:             st.vkHash,
 		attempt:            res.idx,
 		cancelOrigin:       "failover_timeout",
-		masker:             newCredentialMasker(candidate.apiKey),
+		masker:             logData.masker,
 	}
 	// attempt is the 0-based failover_attempt this request is logged and stored
 	// with; it must match the value stream_finalize reports for the same request.

--- a/internal/proxy/hedging_test.go
+++ b/internal/proxy/hedging_test.go
@@ -177,7 +177,7 @@ func TestRunHedgedStreaming_WinnerErrorFrameMasksExactProviderKey(t *testing.T) 
 
 	const secret = "myCustomGatewayKey2024x9z8"
 	hh := newHedgeHarness([]fakeProbeSpec{
-		{delay: 5 * time.Millisecond, won: true, body: "data: {\"error\":{\"message\":\"billing key " + secret + " is invalid\"}}\n\ndata: [DONE]\n\n"},
+		{delay: 5 * time.Millisecond, won: true, body: "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"key " + secret + "\"}}]}\n\ndata: {\"error\":{\"message\":\"billing key " + secret + " is invalid\"}}\n\ndata: [DONE]\n\n"},
 		{delay: 5 * time.Millisecond, won: true},
 	})
 	st, logData := newHedgeState(500 * time.Millisecond)
@@ -188,11 +188,14 @@ func TestRunHedgedStreaming_WinnerErrorFrameMasksExactProviderKey(t *testing.T) 
 	if strings.Contains(w.Body.String(), secret) {
 		t.Fatalf("winner's provider key reached the client:\n%s", w.Body.String())
 	}
+	if !strings.Contains(w.Body.String(), `"content":"key [redacted]"`) {
+		t.Errorf("expected masked content chunk, got:\n%s", w.Body.String())
+	}
 	if !strings.Contains(w.Body.String(), `"message":"billing key [redacted] is invalid"`) {
 		t.Errorf("expected masked error frame, got:\n%s", w.Body.String())
 	}
-	if !strings.Contains(logData.errorMessage, secret) {
-		t.Errorf("request log must keep the unmasked original, got %q", logData.errorMessage)
+	if strings.Contains(logData.errorMessage, secret) || !strings.Contains(logData.errorMessage, "[redacted]") {
+		t.Errorf("request log must carry the error with the exact key redacted, got %q", logData.errorMessage)
 	}
 }
 

--- a/internal/proxy/multimodal.go
+++ b/internal/proxy/multimodal.go
@@ -560,8 +560,7 @@ func (h *Handler) serveBufferedJSONPassthrough(w http.ResponseWriter, st *reques
 	// cap+1 read under the cap and drop the streamed remainder.
 	oversized := len(body) > passthroughJSONBufferCap
 	// Exact-key scrub only: a success body is content, where the key-shape
-	// regex could false-positive. The streamed remainder of an oversized body
-	// is not inspected.
+	// regex could false-positive.
 	body = logData.masker.maskExact(body)
 	copyPassthroughHeaders(w, resp, contentType)
 
@@ -569,12 +568,15 @@ func (h *Handler) serveBufferedJSONPassthrough(w http.ResponseWriter, st *reques
 		// Oversized JSON (e.g. several b64 images): forward the buffered
 		// prefix and stream the rest; usage extraction is skipped to keep
 		// memory bounded.
+		// The remainder streams through exactMaskWriter so a key straddling
+		// the buffered-prefix boundary, or any two reads, is still masked.
 		w.WriteHeader(resp.StatusCode)
 		written := int64(len(body))
-		//nolint:gosec // G705 false positive: provider JSON body, not HTML; Content-Type is application/json
-		if _, writeErr := w.Write(body); writeErr == nil {
-			n, _ := io.Copy(w, resp.Body)
+		ew := newExactMaskWriter(w, logData.masker)
+		if _, writeErr := ew.Write(body); writeErr == nil {
+			n, _ := io.Copy(ew, resp.Body)
 			written += n
+			_ = ew.Flush()
 		}
 		h.finalizePassthroughLog(st, resp.StatusCode, attempt, responseHeaderMs, 0, 0, "completed", "")
 		debuglog.Info("proxy: passthrough completed (oversized json)", "endpoint", logData.endpointType, "model", logData.modelID, "provider", logData.providerName, "attempt", attempt, "status", resp.StatusCode, "bytes", written)
@@ -852,14 +854,15 @@ const sseErrorMaskEventCap = 4 << 20
 type sseErrorMaskWriter struct {
 	w       io.Writer
 	cred    credentialMasker
-	partial []byte   // unterminated line
-	event   [][]byte // complete lines of the event in progress, each with its eol
-	held    int      // input bytes buffered in partial + event
-	raw     bool     // event exceeded the cap: pass through until its delimiter
+	rawOut  *exactMaskWriter // raw-mode writes, boundary-safe for the key
+	partial []byte           // unterminated line
+	event   [][]byte         // complete lines of the event in progress, each with its eol
+	held    int              // input bytes buffered in partial + event
+	raw     bool             // event exceeded the cap: pass through until its delimiter
 }
 
 func newSSEErrorMaskWriter(w io.Writer, cred credentialMasker) *sseErrorMaskWriter {
-	return &sseErrorMaskWriter{w: w, cred: cred}
+	return &sseErrorMaskWriter{w: w, cred: cred, rawOut: newExactMaskWriter(w, cred)}
 }
 
 func (m *sseErrorMaskWriter) Write(p []byte) (int, error) {
@@ -873,7 +876,7 @@ func (m *sseErrorMaskWriter) Write(p []byte) (int, error) {
 			chunk := p[consumed:]
 			consumed = len(p)
 			if m.raw {
-				if err := m.emit(chunk); err != nil {
+				if _, err := m.rawOut.Write(chunk); err != nil {
 					return delivered, err
 				}
 				break
@@ -890,13 +893,18 @@ func (m *sseErrorMaskWriter) Write(p []byte) (int, error) {
 		line := p[consumed : consumed+nl+1]
 		consumed += nl + 1
 		if m.raw {
-			if err := m.emit(line); err != nil {
+			if _, err := m.rawOut.Write(line); err != nil {
 				return delivered, err
 			}
-			delivered = consumed
 			if isSSEBlankLine(line) {
+				// The oversized event is over: release the held tail before
+				// normal emits resume so ordering is preserved.
 				m.raw = false
+				if err := m.rawOut.Flush(); err != nil {
+					return delivered, err
+				}
 			}
+			delivered = consumed
 			continue
 		}
 		if len(m.partial) > 0 {
@@ -925,6 +933,10 @@ func (m *sseErrorMaskWriter) Write(p []byte) (int, error) {
 // Flush writes out a trailing event that never received its delimiter (a
 // stream cut mid-event), masked if it turns out to be an error frame.
 func (m *sseErrorMaskWriter) Flush() error {
+	if m.raw {
+		m.raw = false
+		return m.rawOut.Flush()
+	}
 	if len(m.partial) > 0 {
 		m.event = append(m.event, m.partial)
 		m.partial = nil
@@ -946,7 +958,8 @@ func (m *sseErrorMaskWriter) spill() error {
 	}
 	out = append(out, m.partial...)
 	m.event, m.partial, m.held, m.raw = nil, nil, 0, true
-	return m.emit(out)
+	_, err := m.rawOut.Write(out)
+	return err
 }
 
 // emitEvent writes the buffered event plus its delimiter (nil when flushing a
@@ -971,10 +984,10 @@ func (m *sseErrorMaskWriter) emitEvent(delimiter []byte) error {
 	return m.emit(out)
 }
 
-// emit writes one downstream chunk with the exact credential scrubbed. Every
-// byte the client receives passes here, so a gateway quoting its key in a
-// content event is covered too; a key straddling two raw-mode chunks of an
-// oversized event is the one shape this cannot see.
+// emit writes one complete event with the exact credential scrubbed. Every
+// normal-mode byte the client receives passes here, so a gateway quoting its
+// key in a content event is covered too; raw mode goes through rawOut, which
+// is boundary-safe across chunks.
 func (m *sseErrorMaskWriter) emit(b []byte) error {
 	_, err := m.w.Write(m.cred.maskExact(b))
 	return err

--- a/internal/proxy/multimodal.go
+++ b/internal/proxy/multimodal.go
@@ -556,14 +556,22 @@ func (h *Handler) serveBufferedJSONPassthrough(w http.ResponseWriter, st *reques
 	if passthroughAnswered(logData.endpointType, body) {
 		h.noteModelServed(candidate.model, logData.endpointType)
 	}
+	// Oversized is judged on the bytes read, before masking can shrink a
+	// cap+1 read under the cap and drop the streamed remainder.
+	oversized := len(body) > passthroughJSONBufferCap
+	// Exact-key scrub only: a success body is content, where the key-shape
+	// regex could false-positive. The streamed remainder of an oversized body
+	// is not inspected.
+	body = logData.masker.maskExact(body)
 	copyPassthroughHeaders(w, resp, contentType)
 
-	if len(body) > passthroughJSONBufferCap {
+	if oversized {
 		// Oversized JSON (e.g. several b64 images): forward the buffered
 		// prefix and stream the rest; usage extraction is skipped to keep
 		// memory bounded.
 		w.WriteHeader(resp.StatusCode)
 		written := int64(len(body))
+		//nolint:gosec // G705 false positive: provider JSON body, not HTML; Content-Type is application/json
 		if _, writeErr := w.Write(body); writeErr == nil {
 			n, _ := io.Copy(w, resp.Body)
 			written += n
@@ -576,6 +584,7 @@ func (h *Handler) serveBufferedJSONPassthrough(w http.ResponseWriter, st *reques
 	promptTokens, completionTokens := extractPassthroughUsage(body)
 	w.Header().Set("Content-Length", strconv.Itoa(len(body)))
 	w.WriteHeader(resp.StatusCode)
+	//nolint:gosec // G705 false positive: provider JSON body, not HTML; Content-Type is application/json
 	if _, writeErr := w.Write(body); writeErr != nil {
 		debuglog.Warn("proxy: client write failed during passthrough", "endpoint", logData.endpointType, "model", logData.modelID, "provider", logData.providerName, "error", writeErr)
 	}
@@ -646,7 +655,7 @@ func (h *Handler) serveStreamedPassthrough(w http.ResponseWriter, r *http.Reques
 	var masker *sseErrorMaskWriter
 	if isSSE {
 		tail = newTailBuffer(passthroughSSETailCap)
-		masker = newSSEErrorMaskWriter(io.MultiWriter(newFlushWriter(w), tail), newCredentialMasker(candidate.apiKey))
+		masker = newSSEErrorMaskWriter(io.MultiWriter(newFlushWriter(w), tail), logData.masker)
 		dst = masker
 	}
 
@@ -823,7 +832,8 @@ const sseErrorMaskEventCap = 4 << 20
 // one event at a time, scrubbing credential-shaped tokens from error frames
 // before they reach the client. Pass-through streams are otherwise copied
 // verbatim, so this is the one place the chat paths' credentialMasker scrub
-// applies to the image/audio endpoints.
+// applies to the image/audio endpoints: the exact key on every byte, the
+// key-shape regex on error frames.
 //
 // It works per event rather than per line because SSE lets one payload span
 // several `data:` lines (joined with "\n"); judging each line alone would let
@@ -961,8 +971,12 @@ func (m *sseErrorMaskWriter) emitEvent(delimiter []byte) error {
 	return m.emit(out)
 }
 
+// emit writes one downstream chunk with the exact credential scrubbed. Every
+// byte the client receives passes here, so a gateway quoting its key in a
+// content event is covered too; a key straddling two raw-mode chunks of an
+// oversized event is the one shape this cannot see.
 func (m *sseErrorMaskWriter) emit(b []byte) error {
-	_, err := m.w.Write(b)
+	_, err := m.w.Write(m.cred.maskExact(b))
 	return err
 }
 

--- a/internal/proxy/multimodal_passthrough_test.go
+++ b/internal/proxy/multimodal_passthrough_test.go
@@ -828,6 +828,60 @@ func TestImageGenerations_JSONPassthrough(t *testing.T) {
 	}
 }
 
+// Buffered JSON pass-through and SSE content events are content, so only the
+// exact layer runs; the env key ("test-api-key") is scrubbed from both.
+func TestImageGenerations_PassthroughMasksExactProviderKeyInContent(t *testing.T) {
+	t.Run("json", func(t *testing.T) {
+		upstreamBody := `{"created":1,"data":[{"revised_prompt":"key test-api-key","b64_json":"aW1n"}]}`
+		env := newMultimodalEnv(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, upstreamBody)
+		}))
+		body := fmt.Sprintf(`{"model":"%s/%s","prompt":"a cat"}`, env.providerName, env.modelName)
+		req := env.request("/v1/images/generations", "application/json", strings.NewReader(body))
+		w := httptest.NewRecorder()
+		env.handler.ImageGenerations(w, req)
+		if got := strings.TrimSpace(w.Body.String()); got != `{"created":1,"data":[{"revised_prompt":"key [redacted]","b64_json":"aW1n"}]}` {
+			t.Errorf("buffered body not exact-masked: %s", got)
+		}
+	})
+	t.Run("sse", func(t *testing.T) {
+		sse := "event: image_generation.partial_image\ndata: {\"type\":\"image_generation.partial_image\",\"revised_prompt\":\"key test-api-key\"}\n\n"
+		env := newMultimodalEnv(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = io.WriteString(w, sse)
+		}))
+		body := fmt.Sprintf(`{"model":"%s/%s","prompt":"a cat","stream":true,"partial_images":1}`, env.providerName, env.modelName)
+		req := env.request("/v1/images/generations", "application/json", strings.NewReader(body))
+		w := httptest.NewRecorder()
+		env.handler.ImageGenerations(w, req)
+		want := strings.ReplaceAll(sse, "test-api-key", "[redacted]")
+		if w.Body.String() != want {
+			t.Errorf("SSE content not exact-masked:\ngot  %q\nwant %q", w.Body.String(), want)
+		}
+	})
+}
+
+// Oversized is judged before masking: a cap+1 read that shrinks under the cap
+// once the key is redacted must still stream its remainder, byte-complete.
+func TestImageGenerations_OversizedJSONMaskedStillStreamsRemainder(t *testing.T) {
+	huge := strings.Repeat("A", passthroughJSONBufferCap+4096)
+	upstreamBody := `{"created":1,"data":[{"revised_prompt":"key test-api-key","b64_json":"` + huge + `"}]}`
+	env := newMultimodalEnv(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, upstreamBody)
+	}))
+	body := fmt.Sprintf(`{"model":"%s/%s","prompt":"a cat"}`, env.providerName, env.modelName)
+	req := env.request("/v1/images/generations", "application/json", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	env.handler.ImageGenerations(w, req)
+
+	want := strings.ReplaceAll(upstreamBody, "test-api-key", "[redacted]")
+	if got := w.Body.String(); got != want {
+		t.Errorf("oversized body mismatch: got %d bytes, want %d (key masked, remainder intact)", len(got), len(want))
+	}
+}
+
 func TestImageGenerations_SSEPassthrough(t *testing.T) {
 	sse := "event: image_generation.partial_image\ndata: {\"type\":\"image_generation.partial_image\",\"b64_json\":\"cGFydA==\"}\n\nevent: image_generation.completed\ndata: {\"type\":\"image_generation.completed\",\"b64_json\":\"ZnVsbA==\"}\n\n"
 	env := newMultimodalEnv(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/proxy/multimodal_passthrough_test.go
+++ b/internal/proxy/multimodal_passthrough_test.go
@@ -882,6 +882,32 @@ func TestImageGenerations_OversizedJSONMaskedStillStreamsRemainder(t *testing.T)
 	}
 }
 
+// A key that straddles the buffered-prefix boundary of an oversized body (the
+// cap+1 read ends mid-key) must still be masked in what the client receives.
+func TestImageGenerations_OversizedJSONMasksKeyAcrossBufferBoundary(t *testing.T) {
+	head := `{"created":1,"data":[{"b64_json":"`
+	// Pad so the first 6 bytes of "test-api-key" land inside the cap+1 read
+	// and the remaining 6 stream as the remainder.
+	pad := strings.Repeat("A", passthroughJSONBufferCap+1-len(head)-6)
+	upstreamBody := head + pad + "test-api-key" + strings.Repeat("B", 4096) + `"}]}`
+	env := newMultimodalEnv(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, upstreamBody)
+	}))
+	body := fmt.Sprintf(`{"model":"%s/%s","prompt":"a cat"}`, env.providerName, env.modelName)
+	req := env.request("/v1/images/generations", "application/json", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	env.handler.ImageGenerations(w, req)
+
+	got := w.Body.String()
+	if strings.Contains(got, "test-api-key") {
+		t.Fatal("key straddling the buffer boundary reached the client")
+	}
+	if want := strings.ReplaceAll(upstreamBody, "test-api-key", "[redacted]"); got != want {
+		t.Errorf("oversized body mismatch: got %d bytes, want %d", len(got), len(want))
+	}
+}
+
 func TestImageGenerations_SSEPassthrough(t *testing.T) {
 	sse := "event: image_generation.partial_image\ndata: {\"type\":\"image_generation.partial_image\",\"b64_json\":\"cGFydA==\"}\n\nevent: image_generation.completed\ndata: {\"type\":\"image_generation.completed\",\"b64_json\":\"ZnVsbA==\"}\n\n"
 	env := newMultimodalEnv(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -1588,6 +1614,34 @@ func TestSSEErrorMaskWriter(t *testing.T) {
 		}
 		if n, err := m.Write([]byte("data: more\n")); err == nil || n != 0 {
 			t.Fatalf("raw-mode line onto a dead client: got n=%d err=%v, want 0 and an error", n, err)
+		}
+	})
+
+	t.Run("key straddling the spill and raw-mode boundaries is masked", func(t *testing.T) {
+		const secret = "myCustomGatewayKey2024x9z8"
+		var out bytes.Buffer
+		m := newSSEErrorMaskWriter(&out, newCredentialMasker(secret))
+		// First write overflows the event cap mid-key: the buffered bytes
+		// spill with half the key at their end.
+		first := "data: " + strings.Repeat("A", sseErrorMaskEventCap) + secret[:10]
+		// Raw-mode continuation carries the rest, then another split key, then
+		// the delimiter; a normal event follows to prove ordering survives.
+		writes := []string{first, secret[10:] + " " + secret[:5], secret[5:] + "\n", "\n", "data: ok\n\n"}
+		for _, w := range writes {
+			if _, err := m.Write([]byte(w)); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := m.Flush(); err != nil {
+			t.Fatal(err)
+		}
+		got := out.String()
+		if strings.Contains(got, secret) {
+			t.Fatal("key straddling raw-mode writes reached the client")
+		}
+		want := "data: " + strings.Repeat("A", sseErrorMaskEventCap) + "[redacted] [redacted]\n\ndata: ok\n\n"
+		if got != want {
+			t.Errorf("mismatch: got len %d tail %q, want len %d", len(got), got[len(got)-40:], len(want))
 		}
 	})
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -358,20 +358,27 @@ func (h *Handler) handleDataChunk(sink *streamSink, st *streamState, ev sseEvent
 		// the immutable typed chunk and never emit, so position doesn't affect output.
 		st.observeDataChunk(chunk, anthropicErrorCounted, chunkCount, logData)
 
-		// Mask credential-shaped tokens in an error frame before any emit. A
-		// provider failing mid-stream (auth, billing, quota) can quote the
-		// operator's provider credential inside the error object, and an HTTP 200
-		// stream never passes through forwardUpstreamError's masking. It sits
-		// here, ahead of the transforms, because every transform re-marshals the
-		// whole top-level object (an error frame that also carries a delta or a
-		// mappable finish_reason is rewritten and emitted with "error" intact).
-		// The observer above already took the unmasked message for the request
-		// log; chunk.Error is parsed, so content chunks pay nothing.
+		// Mask the provider's credential before any emit. Every chunk gets the
+		// exact-key pass (a gateway may quote the key in a frame of any shape,
+		// and an HTTP 200 stream never passes through forwardUpstreamError's
+		// masking); an error frame additionally gets the key-shape regex. It
+		// sits here, ahead of the transforms, because every transform
+		// re-marshals the whole top-level object (an error frame that also
+		// carries a delta or a mappable finish_reason is rewritten and emitted
+		// with "error" intact). The observer above already took the message
+		// for the request log, which is exact-masked at finalize. The typed
+		// chunk is re-decoded from the masked bytes because reasoning
+		// normalization rebuilds the delta from it, not from payload; a stale
+		// chunk would hand the transform the original text to re-emit.
+		masked := st.masker.maskExact([]byte(payload))
 		if chunk.Error != nil {
-			if masked := st.masker.mask([]byte(payload)); string(masked) != payload {
-				payload = string(masked)
-				line = append([]byte("data: "), masked...)
-			}
+			masked = maskKeyShapedTokens(masked)
+		}
+		if string(masked) != payload {
+			payload = string(masked)
+			line = append([]byte("data: "), masked...)
+			chunk = streamChunk{}
+			_ = json.Unmarshal(masked, &chunk)
 		}
 
 		// strip_reasoning: drop reasoning-only deltas (keep-alive) or forward the
@@ -536,6 +543,10 @@ func (h *Handler) handleNonStreamingResponse(w http.ResponseWriter, r *http.Requ
 	if readErr == nil && len(body) > nonStreamingBodyCap {
 		readErr = fmt.Errorf("upstream response exceeds the %d byte non-streaming body cap", nonStreamingBodyCap)
 	}
+	// Exact-key scrub on the whole body: the client answer and the failure
+	// log message both derive from it, and a success body is content where
+	// the key-shape regex must not run.
+	body = logData.masker.maskExact(body)
 	var chatResp ChatCompletionResponse
 	decodeErr := readErr
 	if decodeErr == nil {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -662,7 +662,9 @@ func (h *Handler) handleNonStreamingResponse(w http.ResponseWriter, r *http.Requ
 		logData.settingsReadMs = settingsReadMs
 		logData.responseHeaderMs = responseHeaderMs
 		logMsg, detail, kind, reason := nonStreamingFailureDetail(resp, body, decodeErr, logData.modelID)
-		logData.errorMessage = logMsg
+		// body is already exact-masked; the log row also gets the key-shape
+		// layer, like every other stored error message.
+		logData.errorMessage = string(maskKeyShapedTokens([]byte(logMsg)))
 		logData.errorKind = kind
 		logData.failoverAttempt = attempt
 		logData.state = "failed"

--- a/internal/proxy/proxy_chat_completions_test.go
+++ b/internal/proxy/proxy_chat_completions_test.go
@@ -691,7 +691,7 @@ func TestChatCompletions_StreamingErrorFrameMasksExactProviderKey(t *testing.T) 
 	env.Upstream.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"}}]}\n\n")
+		fmt.Fprint(w, "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi test-api-key\"}}]}\n\n")
 		fmt.Fprint(w, "data: {\"error\":{\"message\":\"billing key test-api-key is invalid\"}}\n\n")
 		fmt.Fprint(w, "data: [DONE]\n\n")
 	})
@@ -713,8 +713,46 @@ func TestChatCompletions_StreamingErrorFrameMasksExactProviderKey(t *testing.T) 
 	if strings.Contains(got, "test-api-key") {
 		t.Fatalf("provider key reached the client through the dispatched stream:\n%s", got)
 	}
+	if !strings.Contains(got, `"content":"hi [redacted]"`) {
+		t.Errorf("expected masked content chunk, got:\n%s", got)
+	}
 	if !strings.Contains(got, `"message":"billing key [redacted] is invalid"`) {
 		t.Errorf("expected masked error frame, got:\n%s", got)
+	}
+}
+
+// The non-streaming answer is content, so only the exact layer runs on it;
+// the per-attempt masker stamped on the log row is what scrubs it. Pins the
+// non-hedged dispatcher as that masker's producer.
+func TestChatCompletions_NonStreamingMasksExactProviderKey(t *testing.T) {
+	env := newTestProxyHandler(t)
+	handler := env.Handler
+	defer handler.Close()
+
+	env.Upstream.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"id":"c1","object":"chat.completion","model":"m","choices":[{"index":0,"message":{"role":"assistant","content":"your key is test-api-key"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`)
+	})
+
+	body := `{"model": "` + env.ProviderName + `/` + env.ModelName + `", "messages": [{"role": "user", "content": "hello"}], "stream": false}`
+	req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(body))
+	ctx := context.WithValue(req.Context(), virtualKeyNameKey, "test-key")
+	ctx = context.WithValue(ctx, virtualKeyIDKey, uuid.New().String())
+	ctx = context.WithValue(ctx, VirtualKeyHashKey, env.KeyHash)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	handler.ChatCompletions(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (%s)", w.Code, w.Body.String())
+	}
+	got := w.Body.String()
+	if strings.Contains(got, "test-api-key") {
+		t.Fatalf("provider key reached the client in the non-streaming body:\n%s", got)
+	}
+	if !strings.Contains(got, "your key is [redacted]") {
+		t.Errorf("expected masked content, got:\n%s", got)
 	}
 }
 

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptrace"
 	"regexp"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -963,10 +964,7 @@ func (e *exactMaskWriter) Write(p []byte) (int, error) {
 	if len(e.cred.secret) == 0 {
 		return e.w.Write(p)
 	}
-	buf := make([]byte, 0, len(e.tail)+len(p))
-	buf = append(buf, e.tail...)
-	buf = append(buf, p...)
-	buf = e.cred.maskExact(buf)
+	buf := e.cred.maskExact(slices.Concat(e.tail, p))
 	keep := min(len(e.cred.secret)-1, len(buf))
 	out := buf[:len(buf)-keep]
 	e.tail = append([]byte(nil), buf[len(buf)-keep:]...)

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -344,7 +344,7 @@ func (h *Handler) dispatchStreaming(w http.ResponseWriter, r *http.Request, st *
 		attempt:            attempt,
 		cancelOrigin:       streamCancelOrigin,
 		rawPassthrough:     st.anthropicNativeAttempt,
-		masker:             newCredentialMasker(candidate.apiKey),
+		masker:             logData.masker,
 	}
 
 	if ttftTimeout > 0 {
@@ -410,6 +410,7 @@ func (h *Handler) beginAttempt(failoverCtx context.Context, st *requestState, ca
 	logData := st.logData
 	logData.providerID = candidate.provider.ID
 	logData.providerName = candidate.provider.Name
+	logData.masker = newCredentialMasker(candidate.apiKey)
 	if st.isFailover {
 		logData.resolvedModelID = candidate.model.ModelID
 	}
@@ -757,11 +758,12 @@ const forwardableErrorBodyCap = 1 << 20
 // rate limit, not-found, server faults, whether classed by eligibility or by
 // status - gets a synthesised envelope with the classified reason, because
 // those bodies can quote the operator's provider credentials or account
-// details; the body stays in the request log either way. Drains/closes
+// details; the body stays in the request log either way, with only this
+// gateway's own key redacted. Drains/closes
 // resp.Body exactly once and always returns outcomeFatal.
 func (h *Handler) forwardUpstreamError(w http.ResponseWriter, st *requestState, candidate modelCandidate, resp *http.Response, attempt int, isFailoverEligible bool, responseHeaderMs float64) candidateOutcome {
-	masker := newCredentialMasker(candidate.apiKey)
 	logData := st.logData
+	masker := logData.masker
 	mayForwardError := !isFailoverEligible && forwardableErrorStatus(resp.StatusCode)
 	// How much of the body is worth holding depends on what happens to it
 	// below. A 2xx is forwarded whole - truncating a success would corrupt it.
@@ -801,7 +803,7 @@ func (h *Handler) forwardUpstreamError(w http.ResponseWriter, st *requestState, 
 	debuglog.Warn("proxy: upstream non-200", "status", resp.StatusCode, "error_kind", kind, "model", logData.modelID, "provider", logData.providerName, "provider_id", candidate.provider.ID)
 	debuglog.Debug("proxy: upstream error response", "status", resp.StatusCode, "model", logData.modelID, "provider", logData.providerName, "provider_id", candidate.provider.ID, "body_length", len(body), "attempt", attempt+1)
 	logData.responseHeaderMs = responseHeaderMs
-	h.failRequest(logData, resp.StatusCode, kind, errMsg, attempt, st.startTime, st.parseMs, st.timings, st.cacheHits, st.proxyOverhead)
+	h.failRequest(logData, resp.StatusCode, kind, string(masker.maskExact([]byte(errMsg))), attempt, st.startTime, st.parseMs, st.timings, st.cacheHits, st.proxyOverhead)
 
 	// A 2xx that reached this function (any success status other than a bare
 	// 200) is not an error at all and is forwarded whatever its body is,
@@ -812,7 +814,8 @@ func (h *Handler) forwardUpstreamError(w http.ResponseWriter, st *requestState, 
 	if resp.StatusCode/100 == 2 {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(resp.StatusCode)
-		_, _ = w.Write(body)
+		//nolint:gosec // G705 false positive: provider JSON body, not HTML; Content-Type is application/json
+		_, _ = w.Write(masker.maskExact(body))
 		return outcomeFatal
 	}
 
@@ -822,7 +825,7 @@ func (h *Handler) forwardUpstreamError(w http.ResponseWriter, st *requestState, 
 		// static status class. Their bodies are the ones that can quote the
 		// operator's provider credentials ("Incorrect API key provided:
 		// sk-...") or account details a virtual-key holder must not see, so the
-		// body stays in the DB request log via failRequest and the caller gets
+		// body (own key redacted) stays in the DB request log via failRequest and the caller gets
 		// the classified reason: enough to tell "this model is gone" from "top
 		// up your account" from "try again shortly".
 		writeOpenAIError(w, upstreamClientMessage(candidate.provider.Name, resp.StatusCode, reason), resp.StatusCode)
@@ -842,6 +845,7 @@ func (h *Handler) forwardUpstreamError(w http.ResponseWriter, st *requestState, 
 		// provider-authored free text.
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(resp.StatusCode)
+		//nolint:gosec // G705 false positive: provider JSON error body, not HTML; Content-Type is application/json
 		_, _ = w.Write(masker.mask(body))
 	case json.Valid(body):
 		// A non-2xx whose JSON body carries no error object. OpenCode Zen and
@@ -896,8 +900,10 @@ const credentialMinLen = 8
 // error text: the buffered paths in forwardUpstreamError and the in-stream
 // error frames on the translated (handleDataChunk), native Anthropic
 // (emitRawData) and pass-through (sseErrorMaskWriter) streaming paths. The
-// zero value masks by shape only. Client-side only: the request log keeps the
-// original body.
+// zero value masks by shape only. The exact layer alone (maskExact) also runs
+// on every other provider body a client receives and on the request log's
+// error message; the regex layer is client-side error text only, so the log
+// keeps everything but this gateway's own key.
 type credentialMasker struct {
 	secret []byte
 }
@@ -911,12 +917,21 @@ func newCredentialMasker(apiKey string) credentialMasker {
 
 // mask returns body with every occurrence of the exact credential, then any
 // key-shaped token, replaced by "[redacted]". The exact pass runs first so the
-// regex cannot split the key and leave a recognisable remainder.
+// regex cannot split the key and leave a recognisable remainder. For error
+// frames and bodies only: the regex layer can match prose.
 func (m credentialMasker) mask(body []byte) []byte {
+	return maskKeyShapedTokens(m.maskExact(body))
+}
+
+// maskExact replaces only the exact credential. It cannot false-positive, so
+// it is safe on every provider body bound for a client (content chunks,
+// success bodies) and on the request log, where it closes the read a
+// VK-owning dashboard user has on their own failed requests.
+func (m credentialMasker) maskExact(body []byte) []byte {
 	if len(m.secret) > 0 && bytes.Contains(body, m.secret) {
-		body = bytes.ReplaceAll(body, m.secret, []byte("[redacted]"))
+		return bytes.ReplaceAll(body, m.secret, []byte("[redacted]"))
 	}
-	return maskKeyShapedTokens(body)
+	return body
 }
 
 // maskKeyShapedTokens scrubs credential-looking substrings from an upstream

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -803,7 +803,7 @@ func (h *Handler) forwardUpstreamError(w http.ResponseWriter, st *requestState, 
 	debuglog.Warn("proxy: upstream non-200", "status", resp.StatusCode, "error_kind", kind, "model", logData.modelID, "provider", logData.providerName, "provider_id", candidate.provider.ID)
 	debuglog.Debug("proxy: upstream error response", "status", resp.StatusCode, "model", logData.modelID, "provider", logData.providerName, "provider_id", candidate.provider.ID, "body_length", len(body), "attempt", attempt+1)
 	logData.responseHeaderMs = responseHeaderMs
-	h.failRequest(logData, resp.StatusCode, kind, string(masker.maskExact([]byte(errMsg))), attempt, st.startTime, st.parseMs, st.timings, st.cacheHits, st.proxyOverhead)
+	h.failRequest(logData, resp.StatusCode, kind, string(masker.mask([]byte(errMsg))), attempt, st.startTime, st.parseMs, st.timings, st.cacheHits, st.proxyOverhead)
 
 	// A 2xx that reached this function (any success status other than a bare
 	// 200) is not an error at all and is forwarded whatever its body is,
@@ -901,9 +901,9 @@ const credentialMinLen = 8
 // error frames on the translated (handleDataChunk), native Anthropic
 // (emitRawData) and pass-through (sseErrorMaskWriter) streaming paths. The
 // zero value masks by shape only. The exact layer alone (maskExact) also runs
-// on every other provider body a client receives and on the request log's
-// error message; the regex layer is client-side error text only, so the log
-// keeps everything but this gateway's own key.
+// on every other provider body a client receives; the request log's error
+// message gets both layers, since it is error text readable by non-admin
+// users with the logs grant. Content bodies never meet the regex.
 type credentialMasker struct {
 	secret []byte
 }
@@ -934,15 +934,62 @@ func (m credentialMasker) maskExact(body []byte) []byte {
 	return body
 }
 
-// maskKeyShapedTokens scrubs credential-looking substrings from an upstream
-// body before it is forwarded to a client. Auth-class errors never forward at
-// all, and credentialMasker has already removed this gateway's own key by
-// exact value; this is the third layer, for a provider quoting some other
-// credential inside an otherwise forwardable payload error. A match with no
+// maskKeyShapedTokens scrubs credential-looking substrings from upstream error
+// text before it reaches a client or the request log. Auth-class errors never
+// forward at all, and credentialMasker has already removed this gateway's own
+// key by exact value; this is the third layer, for a provider quoting some
+// other credential inside an otherwise forwardable payload error. A match with no
 // digit in it is an identifier or prose ("sk_business_unit_identifier",
 // "Bearer authentication-required") rather than a credential, and stays -
 // real keys carry digits. The replacement carries no JSON metacharacters, so
 // a valid body stays valid.
+// exactMaskWriter applies credentialMasker.maskExact to a byte stream whose
+// writes may split the key: it holds back the last len(key)-1 bytes of each
+// write until the next one arrives, so a key straddling two writes is still
+// seen whole. Flush releases the held tail at end of stream. Used on the two
+// raw forwarding paths (an oversized pass-through JSON remainder and an
+// oversized SSE event) where per-chunk masking has boundaries.
+type exactMaskWriter struct {
+	w    io.Writer
+	cred credentialMasker
+	tail []byte
+}
+
+func newExactMaskWriter(w io.Writer, cred credentialMasker) *exactMaskWriter {
+	return &exactMaskWriter{w: w, cred: cred}
+}
+
+func (e *exactMaskWriter) Write(p []byte) (int, error) {
+	if len(e.cred.secret) == 0 {
+		return e.w.Write(p)
+	}
+	buf := make([]byte, 0, len(e.tail)+len(p))
+	buf = append(buf, e.tail...)
+	buf = append(buf, p...)
+	buf = e.cred.maskExact(buf)
+	keep := min(len(e.cred.secret)-1, len(buf))
+	out := buf[:len(buf)-keep]
+	e.tail = append([]byte(nil), buf[len(buf)-keep:]...)
+	if len(out) > 0 {
+		if _, err := e.w.Write(out); err != nil {
+			return 0, err
+		}
+	}
+	return len(p), nil
+}
+
+// Flush writes the held tail. Call once the stream (or the raw stretch of
+// it) has ended.
+func (e *exactMaskWriter) Flush() error {
+	if len(e.tail) == 0 {
+		return nil
+	}
+	out := e.tail
+	e.tail = nil
+	_, err := e.w.Write(out)
+	return err
+}
+
 func maskKeyShapedTokens(body []byte) []byte {
 	return keyShapedToken.ReplaceAllFunc(body, func(m []byte) []byte {
 		if !bytes.ContainsAny(m, "0123456789") {

--- a/internal/proxy/proxy_failover_test.go
+++ b/internal/proxy/proxy_failover_test.go
@@ -975,10 +975,10 @@ func TestForwardUpstreamError_ForwardedBodyMasksKeyShapedTokens(t *testing.T) {
 	if !json.Valid(w.Body.Bytes()) {
 		t.Errorf("masked body is no longer valid JSON: %s", body)
 	}
-	// The key-shape regex is client-side only: the operator's request log keeps the
-	// original body for diagnostics.
-	if !strings.Contains(logData.errorMessage, secret) {
-		t.Errorf("request log lost the original body: %s", logData.errorMessage)
+	// The request log is readable by non-admin users with the logs grant, so
+	// it gets the same scrub.
+	if strings.Contains(logData.errorMessage, secret) {
+		t.Errorf("key-shaped token reached the request log: %s", logData.errorMessage)
 	}
 }
 
@@ -1117,6 +1117,34 @@ func TestForwardUpstreamError_MasksExactProviderKey(t *testing.T) {
 				t.Errorf("request log should keep the body with the key redacted: %s", logData.errorMessage)
 			}
 		})
+	}
+}
+
+// exactMaskWriter must see a key split across writes, release everything on
+// Flush, and pass bytes straight through when there is no key to hold for.
+func TestExactMaskWriter(t *testing.T) {
+	const secret = "myCustomGatewayKey2024x9z8"
+	var out bytes.Buffer
+	e := newExactMaskWriter(&out, newCredentialMasker(secret))
+	for _, w := range []string{"prefix " + secret[:9], secret[9:20], secret[20:] + " mid " + secret[:3], secret[3:] + " end"} {
+		if n, err := e.Write([]byte(w)); err != nil || n != len(w) {
+			t.Fatalf("Write = %d, %v; want %d, nil", n, err, len(w))
+		}
+	}
+	if err := e.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	if got := out.String(); got != "prefix [redacted] mid [redacted] end" {
+		t.Errorf("got %q", got)
+	}
+
+	out.Reset()
+	e = newExactMaskWriter(&out, credentialMasker{})
+	if _, err := e.Write([]byte("raw " + secret)); err != nil {
+		t.Fatal(err)
+	}
+	if out.String() != "raw "+secret {
+		t.Errorf("no key: bytes must pass through unchanged, got %q", out.String())
 	}
 }
 

--- a/internal/proxy/proxy_failover_test.go
+++ b/internal/proxy/proxy_failover_test.go
@@ -680,6 +680,8 @@ func runForwardUpstreamErrorWith(t *testing.T, h *Handler, status int, body stri
 		provider: &provider.Provider{ID: uuid.New(), Name: "opencode-zen"},
 		apiKey:   apiKey,
 	}
+	// beginAttempt stamps this in production; the helper bypasses it.
+	logData.masker = newCredentialMasker(apiKey)
 	resp := &http.Response{
 		StatusCode: status,
 		Body:       io.NopCloser(strings.NewReader(body)),
@@ -973,7 +975,7 @@ func TestForwardUpstreamError_ForwardedBodyMasksKeyShapedTokens(t *testing.T) {
 	if !json.Valid(w.Body.Bytes()) {
 		t.Errorf("masked body is no longer valid JSON: %s", body)
 	}
-	// Masking is client-side only: the operator's request log keeps the
+	// The key-shape regex is client-side only: the operator's request log keeps the
 	// original body for diagnostics.
 	if !strings.Contains(logData.errorMessage, secret) {
 		t.Errorf("request log lost the original body: %s", logData.errorMessage)
@@ -1108,8 +1110,11 @@ func TestForwardUpstreamError_MasksExactProviderKey(t *testing.T) {
 			if strings.Count(got, "[redacted]") != strings.Count(body, secret) {
 				t.Errorf("every occurrence must be masked, got: %s", got)
 			}
-			if !strings.Contains(logData.errorMessage, secret) {
-				t.Errorf("request log lost the original body: %s", logData.errorMessage)
+			if strings.Contains(logData.errorMessage, secret) {
+				t.Errorf("exact key must not reach the request log either: %s", logData.errorMessage)
+			}
+			if !strings.Contains(logData.errorMessage, "[redacted]") {
+				t.Errorf("request log should keep the body with the key redacted: %s", logData.errorMessage)
 			}
 		})
 	}

--- a/internal/proxy/proxy_response_test.go
+++ b/internal/proxy/proxy_response_test.go
@@ -809,6 +809,13 @@ func TestHandleStreamingResponse_ErrorChunkMasksExactProviderKey(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.WriteHeader(http.StatusOK)
+		// A content chunk quoting the key: no error shape, so only the exact
+		// layer can catch it.
+		fmt.Fprint(w, `data: {"choices":[{"index":0,"delta":{"content":"your key is `+secret+`"}}]}`+"\n\n")
+		// A reasoning chunk quoting the key in both fields: reasoning
+		// normalization rebuilds the delta from the typed chunk, so the mask
+		// must reach that struct and not only the payload string.
+		fmt.Fprint(w, `data: {"choices":[{"index":0,"delta":{"content":"answer `+secret+`","reasoning":"thinking `+secret+`"}}]}`+"\n\n")
 		fmt.Fprint(w, `data: {"error":{"message":"billing key `+secret+` is invalid"}}`+"\n\n")
 		fmt.Fprint(w, "data: [DONE]\n\n")
 	}))
@@ -842,10 +849,16 @@ func TestHandleStreamingResponse_ErrorChunkMasksExactProviderKey(t *testing.T) {
 	if strings.Contains(body, secret) {
 		t.Fatalf("exact provider key reached the client:\n%s", body)
 	}
+	if !strings.Contains(body, `"content":"your key is [redacted]"`) {
+		t.Fatalf("expected masked content chunk, got:\n%s", body)
+	}
+	if !strings.Contains(body, `"content":"answer [redacted]"`) || !strings.Contains(body, `"reasoning_content":"thinking [redacted]"`) {
+		t.Fatalf("expected masked normalized reasoning chunk, got:\n%s", body)
+	}
 	if !strings.Contains(body, `"message":"billing key [redacted] is invalid"`) {
 		t.Fatalf("expected masked error frame, got:\n%s", body)
 	}
-	if !strings.Contains(logData.errorMessage, secret) {
-		t.Errorf("request log must keep the unmasked original, got %q", logData.errorMessage)
+	if strings.Contains(logData.errorMessage, secret) || !strings.Contains(logData.errorMessage, "[redacted]") {
+		t.Errorf("request log must carry the error with the exact key redacted, got %q", logData.errorMessage)
 	}
 }

--- a/internal/proxy/proxy_response_test.go
+++ b/internal/proxy/proxy_response_test.go
@@ -738,8 +738,8 @@ func TestHandleStreamingResponse_ErrorChunkMasksKeyShapedTokens(t *testing.T) {
 	if logData.state != "failed" {
 		t.Errorf("expected state=failed, got %q", logData.state)
 	}
-	if !strings.Contains(logData.errorMessage, planted) {
-		t.Errorf("request log must keep the unmasked original for the operator, got %q", logData.errorMessage)
+	if strings.Contains(logData.errorMessage, planted) {
+		t.Errorf("key-shaped token reached the request log, got %q", logData.errorMessage)
 	}
 }
 
@@ -794,8 +794,8 @@ func TestHandleStreamingResponse_TransformedErrorChunkMasksKeyShapedTokens(t *te
 	if !strings.Contains(body, `"finish_reason":"stop"`) {
 		t.Fatalf("finish_reason normalization must still apply, got:\n%s", body)
 	}
-	if !strings.Contains(logData.errorMessage, planted) {
-		t.Errorf("request log must keep the unmasked original for the operator, got %q", logData.errorMessage)
+	if strings.Contains(logData.errorMessage, planted) {
+		t.Errorf("key-shaped token reached the request log, got %q", logData.errorMessage)
 	}
 }
 

--- a/internal/proxy/stream_finalize.go
+++ b/internal/proxy/stream_finalize.go
@@ -25,8 +25,9 @@ const (
 // hand-off between the loop and the finalizer; later phases migrate more of the
 // loop-local accumulators here.
 type streamState struct {
-	// masker scrubs the provider's credential from error frames bound for the
-	// client; copied from streamOptions so the chunk handlers can reach it.
+	// masker scrubs the provider's credential from every frame bound for the
+	// client and from the log's error message; copied from streamOptions so
+	// the chunk handlers can reach it.
 	masker                credentialMasker
 	promptTokens          int
 	completionTokens      int
@@ -152,7 +153,7 @@ func (h *Handler) finalizeStream(st *streamState, sink *streamSink, scanErr erro
 	// answered. On the native Anthropic passthrough the chunks are never parsed
 	// into deltas, so its terminal message_stop stands in for the same fact.
 	logData.deliveredContent = st.sawContent || st.sawMessageStop
-	logData.errorMessage = errMsg
+	logData.errorMessage = string(opts.masker.maskExact([]byte(errMsg)))
 	logData.failoverAttempt = opts.attempt
 	if errMsg != "" {
 		logData.statusCode = 0

--- a/internal/proxy/stream_finalize.go
+++ b/internal/proxy/stream_finalize.go
@@ -153,7 +153,7 @@ func (h *Handler) finalizeStream(st *streamState, sink *streamSink, scanErr erro
 	// answered. On the native Anthropic passthrough the chunks are never parsed
 	// into deltas, so its terminal message_stop stands in for the same fact.
 	logData.deliveredContent = st.sawContent || st.sawMessageStop
-	logData.errorMessage = string(opts.masker.maskExact([]byte(errMsg)))
+	logData.errorMessage = string(opts.masker.mask([]byte(errMsg)))
 	logData.failoverAttempt = opts.attempt
 	if errMsg != "" {
 		logData.statusCode = 0

--- a/internal/proxy/types.go
+++ b/internal/proxy/types.go
@@ -100,6 +100,10 @@ const (
 )
 
 type requestLogData struct {
+	// masker scrubs the attempt's provider credential from bodies bound for
+	// the client and from the error message stored on this row. Stamped with
+	// the provider identity for each attempt; zero value masks by shape only.
+	masker                    credentialMasker
 	id                        string
 	providerID                uuid.UUID
 	providerName              string
@@ -336,9 +340,9 @@ type streamOptions struct {
 	// an OpenAI chunk and applying the transforms. Set for the native Anthropic
 	// /v1/messages passthrough path, whose stream is already Anthropic-shaped.
 	rawPassthrough bool
-	// masker scrubs the candidate's credential from in-stream error frames
-	// before they reach the client. Built from candidate.apiKey by the
-	// dispatcher; the zero value masks by shape only.
+	// masker scrubs the candidate's credential from the stream and the log's
+	// error message. Copied from requestLogData.masker, the per-attempt stamp;
+	// the zero value masks by shape only.
 	masker credentialMasker
 }
 


### PR DESCRIPTION
## Summary

Closes the two limits stated in #736.

1. **Exact-key masking on every body a client receives, not only error frames.** A self-hosted gateway can quote the operator's key in a frame of any shape (`{"detail":"…"}` under HTTP 200, a content delta, a success body). The exact layer of `credentialMasker` cannot false-positive, so it now runs on every streamed frame (translated `handleDataChunk`, native Anthropic `emitRawData`, multimodal `sseErrorMaskWriter.emit`) and on the buffered success bodies (`handleNonStreamingResponse`, `handleNativeNonStreaming`, `serveBufferedJSONPassthrough`, and the non-200 2xx branch of `forwardUpstreamError`). Error frames still additionally get the key-shape regex; binary audio/image bytes are untouched.
2. **The request log's `error_message` is exact-masked too.** Under multi-user a VK-owning dashboard user can read `error_message` for their own failed requests, which carried the unmasked key. Only the gateway's own key is redacted in the log; the regex layer stays client-only, so the operator keeps the rest of the body verbatim.

## Plumbing

`requestLogData.masker` is stamped in `beginAttempt` alongside the attempt's provider identity (failover and hedging), and is the single source: both dispatchers copy it into `streamOptions`, `forwardUpstreamError` and the multimodal handlers read it, and the non-streaming handlers mask the body right after `ReadAll` so the client answer and the failure log derive from the same bytes.

Two things the Opus review caught before this went up: reasoning normalization rebuilds the delta from the typed chunk, so the chunk is re-decoded from the masked bytes (otherwise a reasoning-model stream re-emitted the key); and the multimodal oversized check now runs before masking, since a shrunk `cap+1` read would otherwise skip the streamed remainder.

## Verification

- `go test ./internal/proxy/...` 1525 passed, `golangci-lint` clean. Every new site mutation-checked against its test.
- **Live on the rebuilt dev stack** with a fake custom HTTP upstream that echoes the presented bearer key: stream content chunk, stream error frame, non-streaming 400 and non-streaming 200 all reach the client as `[redacted]`, and the request-log rows carry `[redacted]`.

## Tests

`TestHandleStreamingResponse_ErrorChunkMasksExactProviderKey` (content + reasoning-normalized chunk + error + log), `TestNativeStream_ProviderErrorEventMasksExactProviderKey` (content event + error + log), `TestHandleNativeNonStreaming_MasksExactProviderKey`, `TestChatCompletions_NonStreamingMasksExactProviderKey` and the streaming sibling (end-to-end through the dispatcher stamp), `TestRunHedgedStreaming_WinnerErrorFrameMasksExactProviderKey` (hedged stamp + log), `TestImageGenerations_PassthroughMasksExactProviderKeyInContent` (json + sse), `TestImageGenerations_OversizedJSONMaskedStillStreamsRemainder`, `TestForwardUpstreamError_MasksExactProviderKey` (log now redacted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Round 2 (Greptile + vuln-0004)

- `exactMaskWriter` (holds back `len(key)-1` bytes between writes) now fronts the two raw forwarding paths Greptile reproduced a straddling leak on: the oversized pass-through JSON remainder and the oversized-SSE spill/raw stretch. `TestExactMaskWriter`, `TestImageGenerations_OversizedJSONMasksKeyAcrossBufferBoundary`, and a spill-boundary case in `TestSSEErrorMaskWriter` pin it.
- The log's `error_message` gets the key-shape regex in addition to the exact key (finding vuln-0004): it is error text readable by non-admin users with the logs grant, and a provider can quote a credential that is not ours. The three regex tests that asserted "log keeps the original" now assert redaction.
