### PR TITLE
fix(frontdesk): warn when FRONTDESK_MASTER_KEY is shorter than recommended

### DIFF
--- a/DOCKERHUB-frontdesk.md
+++ b/DOCKERHUB-frontdesk.md
@@ -52,7 +52,7 @@ Set these in `deploy/ha/.env` (the compose file maps them into the container):
 | Variable | Required | Purpose |
 |---|---|---|
 | `FRONTDESK_PUBLIC_ORIGIN` | ✅ | Public `https://` origin the dashboard is reached at (the TLS proxy's hostname). Also the WebAuthn relying-party ID and expected origin. |
-| `FRONTDESK_MASTER_KEY` | ✅ | AES-256-GCM key that encrypts member admin tokens and the TOTP secret at rest. Generate with `openssl rand -base64 32`; Front Desk warns at boot when it is shorter than 32 characters. Independent of any member's `MASTER_KEY`. Rotating it makes stored tokens unrecoverable (re-enter them in the UI). |
+| `FRONTDESK_MASTER_KEY` | ✅ | AES-256-GCM key that encrypts member admin tokens and the TOTP secret at rest. Generate with `openssl rand -base64 32`; Front Desk warns at boot when it is shorter than 32 bytes. Independent of any member's `MASTER_KEY`. Rotating it makes stored tokens unrecoverable (re-enter them in the UI). |
 | `FRONTDESK_TOKEN` | optional | Dashboard login secret. Leave blank to auto-generate one, printed once to the logs on first boot. |
 | `FRONTDESK_TRUSTED_PROXIES` | optional | External reverse-proxy address(es) (CIDR, comma-separated) trusted for `X-Forwarded-*` (real client IP and HTTPS detection). |
 | `LB_PORT` | optional | Host port for client traffic (Traefik). Default `8080`. |

--- a/DOCKERHUB-frontdesk.md
+++ b/DOCKERHUB-frontdesk.md
@@ -52,7 +52,7 @@ Set these in `deploy/ha/.env` (the compose file maps them into the container):
 | Variable | Required | Purpose |
 |---|---|---|
 | `FRONTDESK_PUBLIC_ORIGIN` | ✅ | Public `https://` origin the dashboard is reached at (the TLS proxy's hostname). Also the WebAuthn relying-party ID and expected origin. |
-| `FRONTDESK_MASTER_KEY` | ✅ | AES-256-GCM key that encrypts member admin tokens and the TOTP secret at rest. Independent of any member's `MASTER_KEY`. Rotating it makes stored tokens unrecoverable (re-enter them in the UI). |
+| `FRONTDESK_MASTER_KEY` | ✅ | AES-256-GCM key that encrypts member admin tokens and the TOTP secret at rest. Generate with `openssl rand -base64 32`; Front Desk warns at boot when it is shorter than 32 characters. Independent of any member's `MASTER_KEY`. Rotating it makes stored tokens unrecoverable (re-enter them in the UI). |
 | `FRONTDESK_TOKEN` | optional | Dashboard login secret. Leave blank to auto-generate one, printed once to the logs on first boot. |
 | `FRONTDESK_TRUSTED_PROXIES` | optional | External reverse-proxy address(es) (CIDR, comma-separated) trusted for `X-Forwarded-*` (real client IP and HTTPS detection). |
 | `LB_PORT` | optional | Host port for client traffic (Traefik). Default `8080`. |

--- a/cmd/frontdesk/main.go
+++ b/cmd/frontdesk/main.go
@@ -90,6 +90,7 @@ func main() {
 	if masterKey == "" {
 		debuglog.Fatal("frontdesk: FRONTDESK_MASTER_KEY is required")
 	}
+	warnWeakMasterKey(masterKey)
 
 	rp, err := newRelyingParty(publicOrigin)
 	if err != nil {
@@ -243,4 +244,17 @@ func envOr(key, def string) string {
 		return v
 	}
 	return def
+}
+
+// warnWeakMasterKey mirrors the main server's MASTER_KEY check: the at-rest
+// KDF runs with deliberately low cost on the assumption that the key is
+// high-entropy, so a short one is called out at boot. Warn, never fail:
+// rotating the key would invalidate every stored member token and the TOTP
+// secret, so an existing deployment keeps starting.
+func warnWeakMasterKey(key string) {
+	if !config.WeakMasterKey(key) {
+		return
+	}
+	debuglog.Warn("frontdesk: FRONTDESK_MASTER_KEY is shorter than recommended — a low-entropy key weakens at-rest encryption of member tokens and the TOTP secret; generate a strong one with `openssl rand -base64 32`",
+		"length", len(key), "recommended_min", config.RecommendedMasterKeyLength)
 }

--- a/cmd/frontdesk/main_test.go
+++ b/cmd/frontdesk/main_test.go
@@ -1,6 +1,15 @@
 package main
 
-import "testing"
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/hugalafutro/model-hotel/internal/config"
+	"github.com/hugalafutro/model-hotel/internal/debuglog"
+)
 
 // TestNewRelyingPartyEnforcesHTTPS pins the HTTPS-only ingress guarantee: a
 // plain-http PUBLIC_ORIGIN is refused so a misconfigured deploy fails loudly,
@@ -28,5 +37,50 @@ func TestNewRelyingPartyEnforcesHTTPS(t *testing.T) {
 		if !c.ok && err == nil {
 			t.Errorf("newRelyingParty(%q) = nil, want an error", c.origin)
 		}
+	}
+}
+
+// recordingHandler captures log records so the boot-time warning can be
+// asserted without parsing stdout.
+type recordingHandler struct {
+	mu      sync.Mutex
+	records []slog.Record
+}
+
+func (h *recordingHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h *recordingHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, r)
+	return nil
+}
+func (h *recordingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *recordingHandler) WithGroup(string) slog.Handler      { return h }
+
+// A short FRONTDESK_MASTER_KEY is warned about at boot, like the main server's
+// MASTER_KEY; a generator-length key is silent. Warn only: the process must
+// still start, since rotating the key would orphan everything encrypted.
+func TestWarnWeakMasterKey(t *testing.T) {
+	rec := &recordingHandler{}
+	prev := slog.Default()
+	debuglog.SetHandler(rec)
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	warnWeakMasterKey("hunter2")
+	if n := len(rec.records); n != 1 {
+		t.Fatalf("short key: %d records, want 1 warning", n)
+	}
+	r := rec.records[0]
+	if r.Level != slog.LevelWarn || !strings.Contains(r.Message, "FRONTDESK_MASTER_KEY is shorter than recommended") {
+		t.Errorf("short key: got %v %q", r.Level, r.Message)
+	}
+	if strings.Contains(r.Message, "hunter2") {
+		t.Error("the warning must not echo the key")
+	}
+
+	rec.records = nil
+	warnWeakMasterKey(strings.Repeat("k", config.RecommendedMasterKeyLength))
+	if len(rec.records) != 0 {
+		t.Errorf("strong key: unexpected log %q", rec.records[0].Message)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,10 +15,19 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
-// recommendedMasterKeyLength is the minimum MASTER_KEY length we consider
-// strong enough for the low-cost Argon2id parameters. It matches the output of
-// the documented generator `openssl rand -base64 32` (44 chars), rounded down.
-const recommendedMasterKeyLength = 32
+// RecommendedMasterKeyLength is the minimum at-rest master key length we
+// consider strong enough for the low-cost Argon2id parameters. It matches the
+// output of the documented generator `openssl rand -base64 32` (44 chars),
+// rounded down. Shared with Front Desk, whose FRONTDESK_MASTER_KEY protects
+// member admin tokens and the TOTP secret with the same KDF.
+const RecommendedMasterKeyLength = 32
+
+// WeakMasterKey reports whether key is shorter than RecommendedMasterKeyLength.
+// Callers warn rather than fail: rotating a master key invalidates everything
+// encrypted under it, so an existing deployment must keep booting.
+func WeakMasterKey(key string) bool {
+	return len(key) < RecommendedMasterKeyLength
+}
 
 // Config holds the application configuration.
 type Config struct {
@@ -208,9 +217,9 @@ func Load() (*Config, error) {
 	// generator (`openssl rand -base64 32` → 44 chars) so existing deployments
 	// keep booting (rotating MASTER_KEY would invalidate all encrypted keys),
 	// while operators are nudged toward a stronger value.
-	if len(cfg.MasterKey) < recommendedMasterKeyLength {
+	if WeakMasterKey(cfg.MasterKey) {
 		debuglog.Warn("config: MASTER_KEY is shorter than recommended — a low-entropy key weakens at-rest encryption of provider credentials; generate a strong one with `openssl rand -base64 32`",
-			"length", len(cfg.MasterKey), "recommended_min", recommendedMasterKeyLength)
+			"length", len(cfg.MasterKey), "recommended_min", RecommendedMasterKeyLength)
 	}
 
 	// DEMO_SHOW_TOKEN publishes the admin token on the login screen, which is

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,12 +1,16 @@
 package config
 
 import (
+	"context"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/hugalafutro/model-hotel/internal/debuglog"
 )
 
 // ---------------------------------------------------------------------------
@@ -1676,5 +1680,79 @@ func TestCookieSecure_DefaultsToAlways(t *testing.T) {
 	}
 	if cfg3.CookieSecure != "always" {
 		t.Errorf("CookieSecure = %q, want always for unrecognized value", cfg3.CookieSecure)
+	}
+}
+
+func TestWeakMasterKey(t *testing.T) {
+	cases := []struct {
+		key  string
+		weak bool
+	}{
+		{"", true},
+		{"abc", true},
+		{strings.Repeat("x", RecommendedMasterKeyLength-1), true},
+		{strings.Repeat("x", RecommendedMasterKeyLength), false},
+		{"Q2Fub25pY2FsIG9wZW5zc2wgcmFuZCAtYmFzZTY0IDMyIG91dA==", false}, // 44-char generator output
+	}
+	for _, c := range cases {
+		if got := WeakMasterKey(c.key); got != c.weak {
+			t.Errorf("WeakMasterKey(len %d) = %v, want %v", len(c.key), got, c.weak)
+		}
+	}
+}
+
+// loadRecordingHandler captures log records emitted during Load so the boot
+// warning can be asserted, mirroring the Front Desk test.
+type loadRecordingHandler struct {
+	records []slog.Record
+}
+
+func (h *loadRecordingHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h *loadRecordingHandler) Handle(_ context.Context, r slog.Record) error {
+	h.records = append(h.records, r)
+	return nil
+}
+func (h *loadRecordingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *loadRecordingHandler) WithGroup(string) slog.Handler      { return h }
+
+// Load warns, and still succeeds, on a MASTER_KEY below the recommended length;
+// a generator-length key boots silently.
+func TestLoad_WarnsOnWeakMasterKey(t *testing.T) {
+	os.Setenv("DATABASE_URL", "postgres://user:pass@localhost/test")
+	defer os.Unsetenv("DATABASE_URL")
+	defer os.Unsetenv("MASTER_KEY")
+
+	rec := &loadRecordingHandler{}
+	prev := slog.Default()
+	debuglog.SetHandler(rec)
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	weak := func() []slog.Record {
+		var out []slog.Record
+		for _, r := range rec.records {
+			if r.Level == slog.LevelWarn && strings.Contains(r.Message, "MASTER_KEY is shorter than recommended") {
+				out = append(out, r)
+			}
+		}
+		return out
+	}
+
+	os.Setenv("MASTER_KEY", "hunter2")
+	if _, err := Load(); err != nil {
+		t.Fatalf("a weak key must still load: %v", err)
+	}
+	if got := weak(); len(got) != 1 {
+		t.Fatalf("weak key: %d warnings, want 1", len(got))
+	} else if strings.Contains(got[0].Message, "hunter2") {
+		t.Error("the warning must not echo the key")
+	}
+
+	rec.records = nil
+	os.Setenv("MASTER_KEY", strings.Repeat("k", RecommendedMasterKeyLength))
+	if _, err := Load(); err != nil {
+		t.Fatalf("strong key: %v", err)
+	}
+	if got := weak(); len(got) != 0 {
+		t.Errorf("strong key: unexpected warning %q", got[0].Message)
 	}
 }

--- a/wiki/High-Availability.md
+++ b/wiki/High-Availability.md
@@ -144,7 +144,9 @@ Do not conflate these:
 
 Plus, internal to Front Desk: **`FRONTDESK_MASTER_KEY`** encrypts the member
 admin tokens (and Front Desk's own TOTP secret) that Front Desk stores. It is
-independent of any member's `MASTER_KEY`.
+independent of any member's `MASTER_KEY`. Generate it the same way
+(`openssl rand -base64 32`); Front Desk warns at boot when it is shorter than
+32 characters, like the main server does for `MASTER_KEY`.
 
 ### `MASTER_KEY` must match across members
 

--- a/wiki/High-Availability.md
+++ b/wiki/High-Availability.md
@@ -146,7 +146,7 @@ Plus, internal to Front Desk: **`FRONTDESK_MASTER_KEY`** encrypts the member
 admin tokens (and Front Desk's own TOTP secret) that Front Desk stores. It is
 independent of any member's `MASTER_KEY`. Generate it the same way
 (`openssl rand -base64 32`); Front Desk warns at boot when it is shorter than
-32 characters, like the main server does for `MASTER_KEY`.
+32 bytes, like the main server does for `MASTER_KEY`.
 
 ### `MASTER_KEY` must match across members
 


### PR DESCRIPTION
## Summary

Finding #7 from the security review: the Front Desk binary validated `FRONTDESK_MASTER_KEY` only for non-emptiness, while the main server warns when `MASTER_KEY` is shorter than 32 characters (the at-rest KDF runs with deliberately low Argon2id cost on the assumption the key is high-entropy). Front Desk now has the same check.

## Changes

- `internal/config`: `RecommendedMasterKeyLength` exported and `WeakMasterKey(key) bool` added; `Load` uses it. Warn-not-fail stays: rotating a master key orphans everything encrypted under it, so an existing deployment must keep booting.
- `cmd/frontdesk`: `warnWeakMasterKey` runs after the required-check and the OTLP log fan-out, before `frontdesk.Open`, with the same wording/attrs as the main server (noun swapped: member tokens + TOTP secret). The key itself is never logged.
- Docs: `DOCKERHUB-frontdesk.md` and `wiki/High-Availability.md` now carry the `openssl rand -base64 32` generator hint and the 32-char floor next to `FRONTDESK_MASTER_KEY` (the `.env.example` already did).

## Tests

- `TestWeakMasterKey`: boundary at exactly 32, generator output passes.
- `TestWarnWeakMasterKey` (frontdesk): one Warn record for a short key, none for a strong one, key not echoed.
- `TestLoad_WarnsOnWeakMasterKey` (config): the main server's existing warning is now pinned too, so both surfaces have emission tests.

`go test ./cmd/frontdesk/ ./internal/config/` 184 passed, `golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
