### PR TITLE
Request-log client IP, virtual-key filter, 1440p table budget, readable app-log escapes

### DIFF
--- a/internal/api/applogs.go
+++ b/internal/api/applogs.go
@@ -30,9 +30,11 @@ type AppLogEntry struct {
 	// dashboard decodes that escaping only when this is set; legacy rows and
 	// raw io.Writer lines stay false and render verbatim (migration 075).
 	Escaped bool `json:"escaped,omitempty"`
-	// AttrsAt is the byte offset in Message where the encoded attribute
-	// suffix begins (everything before it is raw message text, everything
-	// from it on is quoteLogValue output). The dashboard decodes \x20 only
+	// AttrsAt is the offset in Message where the encoded attribute suffix
+	// begins (everything before it is raw message text, everything from it
+	// on is quoteLogValue output), counted in UTF-16 code units: the unit
+	// JavaScript strings index by, so the dashboard's String.slice lands on
+	// the same boundary for non-ASCII text. The dashboard decodes \x20 only
 	// from this offset. Meaningful only when Escaped is set.
 	AttrsAt int `json:"attrs_at"`
 }

--- a/internal/api/applogs.go
+++ b/internal/api/applogs.go
@@ -29,10 +29,12 @@ type AppLogEntry struct {
 	// values use the flattened quoteLogValue encoding (spaces as \x20). The
 	// dashboard decodes that escaping only when this is set; legacy rows and
 	// raw io.Writer lines stay false and render verbatim (migration 075).
-	// The flag is granted only when the raw message portion holds no quote
-	// and no backslash, so on a flagged row every such character belongs to
-	// encoder output and display-side decoding is exact (see Handle).
 	Escaped bool `json:"escaped,omitempty"`
+	// AttrsAt is the byte offset in Message where the encoded attribute
+	// suffix begins (everything before it is raw message text, everything
+	// from it on is quoteLogValue output). The dashboard decodes \x20 only
+	// from this offset. Meaningful only when Escaped is set.
+	AttrsAt int `json:"attrs_at"`
 }
 
 // parseLogLine extracts the structured fields from a raw log line.
@@ -373,12 +375,12 @@ func appLogWhereClause(conditions []string) string {
 }
 
 // scanAppLogRow scans one row of the cursor projection
-// (id, created_at, timestamp, level, source, message, escaped) into an AppLogEntry.
+// (id, created_at, timestamp, level, source, message, escaped, attrs_at) into an AppLogEntry.
 func scanAppLogRow(rows pgx.Rows) (AppLogEntry, error) {
 	var e AppLogEntry
 	var id string
 	var cat, ts time.Time
-	if err := rows.Scan(&id, &cat, &ts, &e.Level, &e.Source, &e.Message, &e.Escaped); err != nil {
+	if err := rows.Scan(&id, &cat, &ts, &e.Level, &e.Source, &e.Message, &e.Escaped, &e.AttrsAt); err != nil {
 		return e, err
 	}
 	e.ID = id
@@ -482,7 +484,7 @@ func buildAppLogCursorQuery(p appLogCursorParams, q url.Values) (string, []any) 
 		}
 	}
 	query := fmt.Sprintf(
-		"SELECT id, created_at, timestamp, level, source, message, escaped FROM app_logs%s ORDER BY created_at %s, id %s LIMIT $%d",
+		"SELECT id, created_at, timestamp, level, source, message, escaped, attrs_at FROM app_logs%s ORDER BY created_at %s, id %s LIMIT $%d",
 		appLogWhereClause(conditions), fetchSortDir, fetchSortDir, argIdx,
 	)
 	args = append(args, p.limit+1)
@@ -535,7 +537,7 @@ func buildAppLogHistoryQuery(p appLogHistoryParams, q url.Values) (string, []any
 	conditions, args, argIdx := appendAppLogFilters(nil, nil, 1,
 		q.Get("level"), q.Get("source"), q.Get("search"), q.Get("from"), q.Get("to"))
 	query := fmt.Sprintf(
-		"SELECT timestamp, level, source, message, escaped FROM app_logs%s ORDER BY %s %s LIMIT $%d OFFSET $%d",
+		"SELECT timestamp, level, source, message, escaped, attrs_at FROM app_logs%s ORDER BY %s %s LIMIT $%d OFFSET $%d",
 		appLogWhereClause(conditions), p.sortCol, p.sortDir, argIdx, argIdx+1,
 	)
 	args = append(args, p.perPage, (p.page-1)*p.perPage)
@@ -583,7 +585,7 @@ func (h *Handler) getAppLogsHistory(w http.ResponseWriter, r *http.Request) {
 	for rows.Next() {
 		var e AppLogEntry
 		var ts time.Time
-		if err := rows.Scan(&ts, &e.Level, &e.Source, &e.Message, &e.Escaped); err != nil {
+		if err := rows.Scan(&ts, &e.Level, &e.Source, &e.Message, &e.Escaped, &e.AttrsAt); err != nil {
 			continue
 		}
 		e.Timestamp = ts.UTC().Format(time.RFC3339Nano)

--- a/internal/api/applogs.go
+++ b/internal/api/applogs.go
@@ -25,6 +25,11 @@ type AppLogEntry struct {
 	Level     string `json:"level"`                // "info", "warning", "error"
 	Source    string `json:"source"`               // "proxy", "auth", "discovery", etc. (without brackets)
 	Message   string `json:"message"`
+	// Escaped marks messages produced by the slog handler, whose attribute
+	// values use the flattened quoteLogValue encoding (spaces as \x20). The
+	// dashboard decodes that escaping only when this is set; legacy rows and
+	// raw io.Writer lines stay false and render verbatim (migration 075).
+	Escaped bool `json:"escaped,omitempty"`
 }
 
 // parseLogLine extracts the structured fields from a raw log line.
@@ -365,12 +370,12 @@ func appLogWhereClause(conditions []string) string {
 }
 
 // scanAppLogRow scans one row of the cursor projection
-// (id, created_at, timestamp, level, source, message) into an AppLogEntry.
+// (id, created_at, timestamp, level, source, message, escaped) into an AppLogEntry.
 func scanAppLogRow(rows pgx.Rows) (AppLogEntry, error) {
 	var e AppLogEntry
 	var id string
 	var cat, ts time.Time
-	if err := rows.Scan(&id, &cat, &ts, &e.Level, &e.Source, &e.Message); err != nil {
+	if err := rows.Scan(&id, &cat, &ts, &e.Level, &e.Source, &e.Message, &e.Escaped); err != nil {
 		return e, err
 	}
 	e.ID = id
@@ -474,7 +479,7 @@ func buildAppLogCursorQuery(p appLogCursorParams, q url.Values) (string, []any) 
 		}
 	}
 	query := fmt.Sprintf(
-		"SELECT id, created_at, timestamp, level, source, message FROM app_logs%s ORDER BY created_at %s, id %s LIMIT $%d",
+		"SELECT id, created_at, timestamp, level, source, message, escaped FROM app_logs%s ORDER BY created_at %s, id %s LIMIT $%d",
 		appLogWhereClause(conditions), fetchSortDir, fetchSortDir, argIdx,
 	)
 	args = append(args, p.limit+1)
@@ -527,7 +532,7 @@ func buildAppLogHistoryQuery(p appLogHistoryParams, q url.Values) (string, []any
 	conditions, args, argIdx := appendAppLogFilters(nil, nil, 1,
 		q.Get("level"), q.Get("source"), q.Get("search"), q.Get("from"), q.Get("to"))
 	query := fmt.Sprintf(
-		"SELECT timestamp, level, source, message FROM app_logs%s ORDER BY %s %s LIMIT $%d OFFSET $%d",
+		"SELECT timestamp, level, source, message, escaped FROM app_logs%s ORDER BY %s %s LIMIT $%d OFFSET $%d",
 		appLogWhereClause(conditions), p.sortCol, p.sortDir, argIdx, argIdx+1,
 	)
 	args = append(args, p.perPage, (p.page-1)*p.perPage)
@@ -575,7 +580,7 @@ func (h *Handler) getAppLogsHistory(w http.ResponseWriter, r *http.Request) {
 	for rows.Next() {
 		var e AppLogEntry
 		var ts time.Time
-		if err := rows.Scan(&ts, &e.Level, &e.Source, &e.Message); err != nil {
+		if err := rows.Scan(&ts, &e.Level, &e.Source, &e.Message, &e.Escaped); err != nil {
 			continue
 		}
 		e.Timestamp = ts.UTC().Format(time.RFC3339Nano)

--- a/internal/api/applogs.go
+++ b/internal/api/applogs.go
@@ -304,9 +304,21 @@ func appendAppLogFilters(conditions []string, args []any, argIdx int, level, sou
 		argIdx++
 	}
 	if search != "" {
-		conditions = append(conditions, fmt.Sprintf("message ILIKE $%d", argIdx))
-		args = append(args, "%"+search+"%")
-		argIdx++
+		// Attribute values escape their spaces as \x20 (quoteLogValue), so a
+		// term with a space also has to match the escaped form or a search for
+		// a provider name like "Ollama Cloud" misses every line that carries
+		// it as an attribute. The pattern doubles the backslash because \ is
+		// the LIKE escape character.
+		escaped := strings.ReplaceAll(search, " ", `\\x20`)
+		if escaped != search {
+			conditions = append(conditions, fmt.Sprintf("(message ILIKE $%d OR message ILIKE $%d)", argIdx, argIdx+1))
+			args = append(args, "%"+search+"%", "%"+escaped+"%")
+			argIdx += 2
+		} else {
+			conditions = append(conditions, fmt.Sprintf("message ILIKE $%d", argIdx))
+			args = append(args, "%"+search+"%")
+			argIdx++
+		}
 	}
 	if from != "" {
 		if t, err := time.Parse(time.RFC3339, from); err == nil {

--- a/internal/api/applogs.go
+++ b/internal/api/applogs.go
@@ -29,6 +29,9 @@ type AppLogEntry struct {
 	// values use the flattened quoteLogValue encoding (spaces as \x20). The
 	// dashboard decodes that escaping only when this is set; legacy rows and
 	// raw io.Writer lines stay false and render verbatim (migration 075).
+	// The flag is granted only when the raw message portion holds no quote
+	// and no backslash, so on a flagged row every such character belongs to
+	// encoder output and display-side decoding is exact (see Handle).
 	Escaped bool `json:"escaped,omitempty"`
 }
 

--- a/internal/api/applogs_buffer.go
+++ b/internal/api/applogs_buffer.go
@@ -169,15 +169,15 @@ func (w *dbLogWriter) flush(entries []AppLogEntry) {
 
 	// Build batch INSERT
 	builder := strings.Builder{}
-	builder.WriteString("INSERT INTO app_logs (timestamp, level, source, message, escaped) VALUES ")
-	args := make([]any, 0, len(entries)*5)
+	builder.WriteString("INSERT INTO app_logs (timestamp, level, source, message, escaped, attrs_at) VALUES ")
+	args := make([]any, 0, len(entries)*6)
 	for i, e := range entries {
 		if i > 0 {
 			builder.WriteString(", ")
 		}
-		offset := i * 5
-		fmt.Fprintf(&builder, "($%d, $%d, $%d, $%d, $%d)", offset+1, offset+2, offset+3, offset+4, offset+5)
-		args = append(args, e.Timestamp, e.Level, e.Source, e.Message, e.Escaped)
+		offset := i * 6
+		fmt.Fprintf(&builder, "($%d, $%d, $%d, $%d, $%d, $%d)", offset+1, offset+2, offset+3, offset+4, offset+5, offset+6)
+		args = append(args, e.Timestamp, e.Level, e.Source, e.Message, e.Escaped, e.AttrsAt)
 	}
 	_, err := w.pool.Exec(ctx, builder.String(), args...)
 	if err != nil {

--- a/internal/api/applogs_buffer.go
+++ b/internal/api/applogs_buffer.go
@@ -169,15 +169,15 @@ func (w *dbLogWriter) flush(entries []AppLogEntry) {
 
 	// Build batch INSERT
 	builder := strings.Builder{}
-	builder.WriteString("INSERT INTO app_logs (timestamp, level, source, message) VALUES ")
-	args := make([]any, 0, len(entries)*4)
+	builder.WriteString("INSERT INTO app_logs (timestamp, level, source, message, escaped) VALUES ")
+	args := make([]any, 0, len(entries)*5)
 	for i, e := range entries {
 		if i > 0 {
 			builder.WriteString(", ")
 		}
-		offset := i * 4
-		fmt.Fprintf(&builder, "($%d, $%d, $%d, $%d)", offset+1, offset+2, offset+3, offset+4)
-		args = append(args, e.Timestamp, e.Level, e.Source, e.Message)
+		offset := i * 5
+		fmt.Fprintf(&builder, "($%d, $%d, $%d, $%d, $%d)", offset+1, offset+2, offset+3, offset+4, offset+5)
+		args = append(args, e.Timestamp, e.Level, e.Source, e.Message, e.Escaped)
 	}
 	_, err := w.pool.Exec(ctx, builder.String(), args...)
 	if err != nil {

--- a/internal/api/applogs_slog.go
+++ b/internal/api/applogs_slog.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 	"unicode"
+	"unicode/utf16"
 
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 )
@@ -118,9 +119,12 @@ func (h *appSlogHandler) Handle(_ context.Context, r slog.Record) error {
 		// in the stored message, so the dashboard decodes \x20 only there
 		// and raw message text is never altered, whatever it contains.
 		// SplitSource/stripLevelPrefix above trimmed a PREFIX of msgStr, so
-		// the attrs suffix length is unchanged by them.
+		// the attrs suffix length is unchanged by them. The offset is
+		// counted in UTF-16 code units, the unit JavaScript strings index
+		// by, so the browser's String.slice lands on the same boundary for
+		// non-ASCII message text (a Go byte offset would not).
 		Escaped: true,
-		AttrsAt: max(0, len(msgStr)-(msg.Len()-preAttrLen)),
+		AttrsAt: len(utf16.Encode([]rune(msgStr[:max(0, len(msgStr)-(msg.Len()-preAttrLen))]))),
 	}
 
 	// Write to ring buffer and DB.

--- a/internal/api/applogs_slog.go
+++ b/internal/api/applogs_slog.go
@@ -112,9 +112,16 @@ func (h *appSlogHandler) Handle(_ context.Context, r slog.Record) error {
 		Level:     appLevel,
 		Source:    source,
 		Message:   msgStr,
-		// Attribute values above went through quoteLogValue's flattened
-		// encoding, so the dashboard may decode \x20 in this message.
-		Escaped: true,
+		// The attribute values above went through quoteLogValue's flattened
+		// encoding, so the dashboard may decode \x20 in this message. The
+		// flag vouches for the WHOLE flattened row, so it is granted only
+		// when the raw message portion contains neither a quote nor a
+		// backslash: then every quote and backslash in the row provably
+		// belongs to encoder output and the display-side decode cannot touch
+		// raw text or desync on it. A message that does carry those
+		// characters (they are developer-written constants, so this is rare)
+		// simply renders verbatim, escapes and all.
+		Escaped: !strings.ContainsAny(baseMsg, "\"\\"),
 	}
 
 	// Write to ring buffer and DB.

--- a/internal/api/applogs_slog.go
+++ b/internal/api/applogs_slog.go
@@ -112,6 +112,9 @@ func (h *appSlogHandler) Handle(_ context.Context, r slog.Record) error {
 		Level:     appLevel,
 		Source:    source,
 		Message:   msgStr,
+		// Attribute values above went through quoteLogValue's flattened
+		// encoding, so the dashboard may decode \x20 in this message.
+		Escaped: true,
 	}
 
 	// Write to ring buffer and DB.

--- a/internal/api/applogs_slog.go
+++ b/internal/api/applogs_slog.go
@@ -80,6 +80,7 @@ func (h *appSlogHandler) Handle(_ context.Context, r slog.Record) error {
 	}
 	msg.WriteString(r.Message)
 	baseMsg := msg.String() // message before attrs are appended (for the JSON field)
+	preAttrLen := msg.Len() // everything appended after this is encoder output
 
 	fields := make(map[string]any)
 	appendAttr := func(a slog.Attr) {
@@ -113,15 +114,13 @@ func (h *appSlogHandler) Handle(_ context.Context, r slog.Record) error {
 		Source:    source,
 		Message:   msgStr,
 		// The attribute values above went through quoteLogValue's flattened
-		// encoding, so the dashboard may decode \x20 in this message. The
-		// flag vouches for the WHOLE flattened row, so it is granted only
-		// when the raw message portion contains neither a quote nor a
-		// backslash: then every quote and backslash in the row provably
-		// belongs to encoder output and the display-side decode cannot touch
-		// raw text or desync on it. A message that does carry those
-		// characters (they are developer-written constants, so this is rare)
-		// simply renders verbatim, escapes and all.
-		Escaped: !strings.ContainsAny(baseMsg, "\"\\"),
+		// encoding; AttrsAt records exactly where that encoder output begins
+		// in the stored message, so the dashboard decodes \x20 only there
+		// and raw message text is never altered, whatever it contains.
+		// SplitSource/stripLevelPrefix above trimmed a PREFIX of msgStr, so
+		// the attrs suffix length is unchanged by them.
+		Escaped: true,
+		AttrsAt: max(0, len(msgStr)-(msg.Len()-preAttrLen)),
 	}
 
 	// Write to ring buffer and DB.

--- a/internal/api/applogs_test.go
+++ b/internal/api/applogs_test.go
@@ -1405,7 +1405,7 @@ func TestBuildAppLogCursorQuery_NoCursorNoFilters(t *testing.T) {
 	q := url.Values{}
 	query, args := buildAppLogCursorQuery(p, q)
 
-	if !strings.Contains(query, "SELECT id, created_at, timestamp, level, source, message, escaped FROM app_logs") {
+	if !strings.Contains(query, "SELECT id, created_at, timestamp, level, source, message, escaped, attrs_at FROM app_logs") {
 		t.Errorf("expected SELECT from app_logs, got %q", query)
 	}
 	if !strings.Contains(query, "ORDER BY created_at DESC, id DESC") {

--- a/internal/api/applogs_test.go
+++ b/internal/api/applogs_test.go
@@ -1405,7 +1405,7 @@ func TestBuildAppLogCursorQuery_NoCursorNoFilters(t *testing.T) {
 	q := url.Values{}
 	query, args := buildAppLogCursorQuery(p, q)
 
-	if !strings.Contains(query, "SELECT id, created_at, timestamp, level, source, message FROM app_logs") {
+	if !strings.Contains(query, "SELECT id, created_at, timestamp, level, source, message, escaped FROM app_logs") {
 		t.Errorf("expected SELECT from app_logs, got %q", query)
 	}
 	if !strings.Contains(query, "ORDER BY created_at DESC, id DESC") {

--- a/internal/api/handler_applogs_test.go
+++ b/internal/api/handler_applogs_test.go
@@ -1115,6 +1115,26 @@ func TestAppSlogHandler_MarksEntriesEscaped(t *testing.T) {
 	if last := entries[len(entries)-1]; last.Escaped {
 		t.Error("legacy io.Writer entry must not claim the flattened-encoding flag")
 	}
+
+	// The flag vouches for the WHOLE flattened row, message text included. A
+	// raw message containing a quote or a backslash could interact with the
+	// display-side decode (desynced quote state, or a literal \x20), so such
+	// a record must not claim the flag and renders verbatim instead.
+	for _, msg := range []string{
+		`discovery: could not parse "x`,
+		`discovery: literal path="\x20evidence" in message`,
+		`discovery: windows path C:\temp`,
+	} {
+		rec := slog.NewRecord(time.Now(), slog.LevelInfo, msg, 0)
+		rec.AddAttrs(slog.String("provider", "Ollama Cloud"))
+		if err := h.Handle(context.Background(), rec); err != nil {
+			t.Fatalf("Handle returned %v", err)
+		}
+		entries = rb.GetEntries()
+		if last := entries[len(entries)-1]; last.Escaped {
+			t.Errorf("message %q contains decode-relevant characters; entry must not claim the flag", msg)
+		}
+	}
 }
 
 // TestGetAppLogs_EscapedFlagProvenance verifies the escaped flag round-trips

--- a/internal/api/handler_applogs_test.go
+++ b/internal/api/handler_applogs_test.go
@@ -1082,10 +1082,12 @@ func TestGetAppLogs_SearchMatchesEscapedSpaces(t *testing.T) {
 	}
 }
 
-// TestAppSlogHandler_MarksEntriesEscaped pins the provenance flag: only the
+// TestAppSlogHandler_MarksEntriesEscaped pins the provenance contract: the
 // slog path (whose attribute values go through quoteLogValue's flattened
-// encoding) marks entries escaped; a raw line through the legacy io.Writer
-// path never went through the encoder and must not claim the flag.
+// encoding) marks entries escaped and records where the encoded attribute
+// suffix begins, so the dashboard decodes exactly the encoder's output and
+// never the raw message text. A raw line through the legacy io.Writer path
+// never went through the encoder and must not claim the flag.
 func TestAppSlogHandler_MarksEntriesEscaped(t *testing.T) {
 	savedBuf, savedWriter := appLogBuffer, dbWriter
 	rb := &ringBuffer{entries: make([]AppLogEntry, appLogBufferSize)}
@@ -1094,33 +1096,13 @@ func TestAppSlogHandler_MarksEntriesEscaped(t *testing.T) {
 
 	var buf bytes.Buffer
 	h := &appSlogHandler{level: slog.LevelInfo, stderr: &stderrLogFilter{dst: &buf}}
-	rec := slog.NewRecord(time.Now(), slog.LevelInfo, "discovery: account fetched", 0)
-	rec.AddAttrs(slog.String("provider", "Ollama Cloud"))
-	if err := h.Handle(context.Background(), rec); err != nil {
-		t.Fatalf("Handle returned %v", err)
-	}
 
-	entries := rb.GetEntries()
-	if len(entries) != 1 {
-		t.Fatalf("expected 1 ring entry, got %d", len(entries))
-	}
-	if !entries[0].Escaped {
-		t.Error("slog-produced entry should carry the flattened-encoding provenance flag")
-	}
-
-	if _, err := rb.Write([]byte(`2026/08/24 01:00:00 [legacy] raw line path="\x20evidence"`)); err != nil {
-		t.Fatalf("ring Write: %v", err)
-	}
-	entries = rb.GetEntries()
-	if last := entries[len(entries)-1]; last.Escaped {
-		t.Error("legacy io.Writer entry must not claim the flattened-encoding flag")
-	}
-
-	// The flag vouches for the WHOLE flattened row, message text included. A
-	// raw message containing a quote or a backslash could interact with the
-	// display-side decode (desynced quote state, or a literal \x20), so such
-	// a record must not claim the flag and renders verbatim instead.
+	// Messages that could confuse a whole-string decode: a lone quote, an
+	// attribute-shaped literal with \x20, a backslashed path. The boundary
+	// makes them irrelevant: everything before AttrsAt is raw text, everything
+	// from AttrsAt on is encoder output.
 	for _, msg := range []string{
+		"discovery: account fetched",
 		`discovery: could not parse "x`,
 		`discovery: literal path="\x20evidence" in message`,
 		`discovery: windows path C:\temp`,
@@ -1130,10 +1112,26 @@ func TestAppSlogHandler_MarksEntriesEscaped(t *testing.T) {
 		if err := h.Handle(context.Background(), rec); err != nil {
 			t.Fatalf("Handle returned %v", err)
 		}
-		entries = rb.GetEntries()
-		if last := entries[len(entries)-1]; last.Escaped {
-			t.Errorf("message %q contains decode-relevant characters; entry must not claim the flag", msg)
+		entries := rb.GetEntries()
+		e := entries[len(entries)-1]
+		if !e.Escaped {
+			t.Errorf("slog entry for %q should carry the provenance flag", msg)
 		}
+		if e.AttrsAt < 0 || e.AttrsAt > len(e.Message) {
+			t.Fatalf("AttrsAt %d out of range for %q", e.AttrsAt, e.Message)
+		}
+		wantSuffix := " provider=\"Ollama\\x20Cloud\""
+		if got := e.Message[e.AttrsAt:]; got != wantSuffix {
+			t.Errorf("message %q: attrs suffix = %q, want %q", msg, got, wantSuffix)
+		}
+	}
+
+	if _, err := rb.Write([]byte(`2026/08/24 01:00:00 [legacy] raw line path="\x20evidence"`)); err != nil {
+		t.Fatalf("ring Write: %v", err)
+	}
+	entries := rb.GetEntries()
+	if last := entries[len(entries)-1]; last.Escaped {
+		t.Error("legacy io.Writer entry must not claim the flattened-encoding flag")
 	}
 }
 
@@ -1146,9 +1144,9 @@ func TestGetAppLogs_EscapedFlagProvenance(t *testing.T) {
 	h.Register(r)
 
 	_, err := h.Pool().Pool().Exec(context.Background(),
-		`INSERT INTO app_logs (timestamp, level, source, message, escaped) VALUES
-		 (now(), 'info', 'provtest', 'legacy path="\x20evidence"', false),
-		 (now(), 'info', 'provtest', 'fetched provider="Ollama\x20Cloud"', true)`)
+		`INSERT INTO app_logs (timestamp, level, source, message, escaped, attrs_at) VALUES
+		 (now(), 'info', 'provtest', 'legacy path="\x20evidence"', false, 0),
+		 (now(), 'info', 'provtest', 'fetched provider="Ollama\x20Cloud"', true, 8)`)
 	if err != nil {
 		t.Fatalf("insert app logs: %v", err)
 	}
@@ -1166,6 +1164,7 @@ func TestGetAppLogs_EscapedFlagProvenance(t *testing.T) {
 			Entries []struct {
 				Message string `json:"message"`
 				Escaped bool   `json:"escaped"`
+				AttrsAt *int   `json:"attrs_at"`
 			} `json:"entries"`
 		}
 		if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
@@ -1177,6 +1176,9 @@ func TestGetAppLogs_EscapedFlagProvenance(t *testing.T) {
 				seen++
 				if !e.Escaped {
 					t.Errorf("%s: encoder row should be escaped=true", path)
+				}
+				if e.AttrsAt == nil || *e.AttrsAt != 8 {
+					t.Errorf("%s: encoder row attrs_at = %v, want 8", path, e.AttrsAt)
 				}
 			}
 			if strings.Contains(e.Message, "legacy") {

--- a/internal/api/handler_applogs_test.go
+++ b/internal/api/handler_applogs_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf16"
 
 	"github.com/go-chi/chi/v5"
 
@@ -1123,6 +1124,30 @@ func TestAppSlogHandler_MarksEntriesEscaped(t *testing.T) {
 		wantSuffix := " provider=\"Ollama\\x20Cloud\""
 		if got := e.Message[e.AttrsAt:]; got != wantSuffix {
 			t.Errorf("message %q: attrs suffix = %q, want %q", msg, got, wantSuffix)
+		}
+	}
+
+	// AttrsAt crosses the stack into JavaScript's String.slice, which indexes
+	// UTF-16 code units, not UTF-8 bytes. A non-ASCII message prefix must
+	// therefore yield a boundary in UTF-16 units: for this message the byte
+	// length of the prefix differs from its UTF-16 length, so a byte-based
+	// offset would land inside the attribute suffix.
+	{
+		rec := slog.NewRecord(time.Now(), slog.LevelInfo, "discovery: \U0001F680\u6a21\u578b ready", 0)
+		rec.AddAttrs(slog.String("provider", "Ollama Cloud"))
+		if err := h.Handle(context.Background(), rec); err != nil {
+			t.Fatalf("Handle returned %v", err)
+		}
+		entries := rb.GetEntries()
+		e := entries[len(entries)-1]
+		wantSuffix := " provider=\"Ollama\\x20Cloud\""
+		prefix := strings.TrimSuffix(e.Message, wantSuffix)
+		if prefix == e.Message {
+			t.Fatalf("message %q does not end with the attrs suffix", e.Message)
+		}
+		wantAt := len(utf16.Encode([]rune(prefix)))
+		if e.AttrsAt != wantAt {
+			t.Errorf("AttrsAt = %d, want %d UTF-16 code units for prefix %q", e.AttrsAt, wantAt, prefix)
 		}
 	}
 

--- a/internal/api/handler_applogs_test.go
+++ b/internal/api/handler_applogs_test.go
@@ -1037,3 +1037,46 @@ func TestGetAppLogsCursor_SortDirAsc(t *testing.T) {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
 }
+
+// TestGetAppLogs_SearchMatchesEscapedSpaces verifies a search term with a
+// space also matches messages whose attribute values carry the \x20 space
+// escaping from quoteLogValue (a search for a provider name like
+// "Ollama Cloud" must find `provider="Ollama\x20Cloud"` lines).
+func TestGetAppLogs_SearchMatchesEscapedSpaces(t *testing.T) {
+	h := newTestHandler(t)
+	r := chi.NewRouter()
+	h.Register(r)
+
+	_, err := h.Pool().Pool().Exec(context.Background(),
+		`INSERT INTO app_logs (timestamp, level, source, message) VALUES (now(), 'info', 'discovery', $1)`,
+		`account fetched provider="Ollama\x20Cloud" plan=pro`)
+	if err != nil {
+		t.Fatalf("insert app log: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/logs/app?history=true&search=Ollama+Cloud", http.NoBody)
+	req.Header.Set("Authorization", "Bearer test-admin-token")
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var response struct {
+		Entries []struct {
+			Message string `json:"message"`
+		} `json:"entries"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("parse response: %v", err)
+	}
+	found := false
+	for _, e := range response.Entries {
+		if strings.Contains(e.Message, `Ollama\x20Cloud`) {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("search=Ollama Cloud did not match the \\x20-escaped message; got %d entries", len(response.Entries))
+	}
+}

--- a/internal/api/handler_applogs_test.go
+++ b/internal/api/handler_applogs_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -1079,4 +1080,96 @@ func TestGetAppLogs_SearchMatchesEscapedSpaces(t *testing.T) {
 	if !found {
 		t.Errorf("search=Ollama Cloud did not match the \\x20-escaped message; got %d entries", len(response.Entries))
 	}
+}
+
+// TestAppSlogHandler_MarksEntriesEscaped pins the provenance flag: only the
+// slog path (whose attribute values go through quoteLogValue's flattened
+// encoding) marks entries escaped; a raw line through the legacy io.Writer
+// path never went through the encoder and must not claim the flag.
+func TestAppSlogHandler_MarksEntriesEscaped(t *testing.T) {
+	savedBuf, savedWriter := appLogBuffer, dbWriter
+	rb := &ringBuffer{entries: make([]AppLogEntry, appLogBufferSize)}
+	appLogBuffer, dbWriter = rb, nil
+	defer func() { appLogBuffer, dbWriter = savedBuf, savedWriter }()
+
+	var buf bytes.Buffer
+	h := &appSlogHandler{level: slog.LevelInfo, stderr: &stderrLogFilter{dst: &buf}}
+	rec := slog.NewRecord(time.Now(), slog.LevelInfo, "discovery: account fetched", 0)
+	rec.AddAttrs(slog.String("provider", "Ollama Cloud"))
+	if err := h.Handle(context.Background(), rec); err != nil {
+		t.Fatalf("Handle returned %v", err)
+	}
+
+	entries := rb.GetEntries()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 ring entry, got %d", len(entries))
+	}
+	if !entries[0].Escaped {
+		t.Error("slog-produced entry should carry the flattened-encoding provenance flag")
+	}
+
+	if _, err := rb.Write([]byte(`2026/08/24 01:00:00 [legacy] raw line path="\x20evidence"`)); err != nil {
+		t.Fatalf("ring Write: %v", err)
+	}
+	entries = rb.GetEntries()
+	if last := entries[len(entries)-1]; last.Escaped {
+		t.Error("legacy io.Writer entry must not claim the flattened-encoding flag")
+	}
+}
+
+// TestGetAppLogs_EscapedFlagProvenance verifies the escaped flag round-trips
+// through the DB on both the history and cursor endpoints, so the dashboard
+// can decode \x20 only on rows known to use the flattened encoder.
+func TestGetAppLogs_EscapedFlagProvenance(t *testing.T) {
+	h := newTestHandler(t)
+	r := chi.NewRouter()
+	h.Register(r)
+
+	_, err := h.Pool().Pool().Exec(context.Background(),
+		`INSERT INTO app_logs (timestamp, level, source, message, escaped) VALUES
+		 (now(), 'info', 'provtest', 'legacy path="\x20evidence"', false),
+		 (now(), 'info', 'provtest', 'fetched provider="Ollama\x20Cloud"', true)`)
+	if err != nil {
+		t.Fatalf("insert app logs: %v", err)
+	}
+
+	assertFlags := func(path string) {
+		t.Helper()
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", path, http.NoBody)
+		req.Header.Set("Authorization", "Bearer test-admin-token")
+		r.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("%s: expected 200, got %d: %s", path, rec.Code, rec.Body.String())
+		}
+		var response struct {
+			Entries []struct {
+				Message string `json:"message"`
+				Escaped bool   `json:"escaped"`
+			} `json:"entries"`
+		}
+		if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+			t.Fatalf("%s: parse response: %v", path, err)
+		}
+		seen := 0
+		for _, e := range response.Entries {
+			if strings.Contains(e.Message, "Ollama") {
+				seen++
+				if !e.Escaped {
+					t.Errorf("%s: encoder row should be escaped=true", path)
+				}
+			}
+			if strings.Contains(e.Message, "legacy") {
+				seen++
+				if e.Escaped {
+					t.Errorf("%s: legacy row must stay escaped=false", path)
+				}
+			}
+		}
+		if seen != 2 {
+			t.Errorf("%s: expected both rows, matched %d", path, seen)
+		}
+	}
+	assertFlags("/logs/app?history=true&source=provtest")
+	assertFlags("/logs/app/cursor?source=provtest")
 }

--- a/internal/api/handler_logs_test.go
+++ b/internal/api/handler_logs_test.go
@@ -738,3 +738,169 @@ func TestListLogs_SortByStatus(t *testing.T) {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
 }
+
+// createLogTestKey creates a virtual key via the API and returns its id.
+func createLogTestKey(t *testing.T, r chi.Router, name string) string {
+	t.Helper()
+	req := httptest.NewRequest("POST", "/virtual-keys", strings.NewReader(fmt.Sprintf(`{"name":%q}`, name)))
+	req.Header.Set("Authorization", "Bearer test-admin-token")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated && w.Code != http.StatusOK {
+		t.Fatalf("create virtual key: %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode virtual key: %v", err)
+	}
+	return resp["id"].(string)
+}
+
+// insertLogRowForKey inserts a minimal request_logs row bound to a virtual key,
+// optionally carrying a client IP.
+func insertLogRowForKey(t *testing.T, h *Handler, vkID, vkName, clientIP string) string {
+	t.Helper()
+	id := uuid.NewString()
+	var ip any
+	if clientIP != "" {
+		ip = clientIP
+	}
+	_, err := h.Pool().Pool().Exec(context.Background(), `
+		INSERT INTO request_logs (id, model_id, virtual_key_id, virtual_key_name, client_ip, status_code, state, created_at)
+		VALUES ($1, 'gpt-4', $2, $3, $4, 200, 'completed', $5)`,
+		id, uuid.MustParse(vkID), vkName, ip, time.Now())
+	if err != nil {
+		t.Fatalf("insert request log: %v", err)
+	}
+	return id
+}
+
+// TestListLogs_FilterByVirtualKeyID verifies ?virtual_key_id= narrows the offset
+// list to that key's rows only.
+func TestListLogs_FilterByVirtualKeyID(t *testing.T) {
+	h, r := newTestHandlerWithRouter(t)
+	vk1 := createLogTestKey(t, r, "vk-logs-filter-a")
+	vk2 := createLogTestKey(t, r, "vk-logs-filter-b")
+	insertLogRowForKey(t, h, vk1, "vk-logs-filter-a", "")
+	insertLogRowForKey(t, h, vk2, "vk-logs-filter-b", "")
+
+	req := httptest.NewRequest(http.MethodGet, "/logs?virtual_key_id="+vk1, http.NoBody)
+	req.Header.Set("Authorization", "Bearer test-admin-token")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	json.NewDecoder(w.Body).Decode(&resp)
+	entries := resp["entries"].([]any)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry for virtual_key_id filter, got %d", len(entries))
+	}
+	if got := entries[0].(map[string]any)["virtual_key_id"]; got != vk1 {
+		t.Errorf("entry virtual_key_id = %v, want %s", got, vk1)
+	}
+}
+
+// TestListLogsCursor_FilterByVirtualKeyID verifies the same filter on the
+// cursor (scroll-mode) endpoint.
+func TestListLogsCursor_FilterByVirtualKeyID(t *testing.T) {
+	h, r := newTestHandlerWithRouter(t)
+	vk1 := createLogTestKey(t, r, "vk-cursor-filter-a")
+	vk2 := createLogTestKey(t, r, "vk-cursor-filter-b")
+	insertLogRowForKey(t, h, vk1, "vk-cursor-filter-a", "")
+	insertLogRowForKey(t, h, vk2, "vk-cursor-filter-b", "")
+
+	req := httptest.NewRequest(http.MethodGet, "/logs/cursor?virtual_key_id="+vk2, http.NoBody)
+	req.Header.Set("Authorization", "Bearer test-admin-token")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	json.NewDecoder(w.Body).Decode(&resp)
+	entries := resp["entries"].([]any)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry for virtual_key_id filter, got %d", len(entries))
+	}
+	if got := entries[0].(map[string]any)["virtual_key_id"]; got != vk2 {
+		t.Errorf("entry virtual_key_id = %v, want %s", got, vk2)
+	}
+	if total := resp["total"].(float64); total != 1 {
+		t.Errorf("total = %v, want 1", total)
+	}
+}
+
+// TestListLogs_IncludesClientIP verifies the stored client IP is projected into
+// list responses (empty string for rows predating the column).
+func TestListLogs_IncludesClientIP(t *testing.T) {
+	h, r := newTestHandlerWithRouter(t)
+	vk := createLogTestKey(t, r, "vk-client-ip")
+	insertLogRowForKey(t, h, vk, "vk-client-ip", "203.0.113.7")
+
+	req := httptest.NewRequest(http.MethodGet, "/logs?virtual_key_id="+vk, http.NoBody)
+	req.Header.Set("Authorization", "Bearer test-admin-token")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	json.NewDecoder(w.Body).Decode(&resp)
+	entries := resp["entries"].([]any)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if got := entries[0].(map[string]any)["client_ip"]; got != "203.0.113.7" {
+		t.Errorf("client_ip = %v, want 203.0.113.7", got)
+	}
+}
+
+// TestGetLog_IncludesClientIP verifies the single-row endpoint carries the
+// client IP for the detail modal.
+func TestGetLog_IncludesClientIP(t *testing.T) {
+	h, r := newTestHandlerWithRouter(t)
+	vk := createLogTestKey(t, r, "vk-client-ip-get")
+	id := insertLogRowForKey(t, h, vk, "vk-client-ip-get", "198.51.100.42")
+
+	req := httptest.NewRequest(http.MethodGet, "/logs/"+id, http.NoBody)
+	req.Header.Set("Authorization", "Bearer test-admin-token")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var entry map[string]any
+	json.NewDecoder(w.Body).Decode(&entry)
+	if got := entry["client_ip"]; got != "198.51.100.42" {
+		t.Errorf("client_ip = %v, want 198.51.100.42", got)
+	}
+}
+
+// TestListLogs_SortByIP covers the ip sort key (tier expression puts rows
+// without an IP last).
+func TestListLogs_SortByIP(t *testing.T) {
+	h, r := newTestHandlerWithRouter(t)
+	vk := createLogTestKey(t, r, "vk-sort-ip")
+	insertLogRowForKey(t, h, vk, "vk-sort-ip", "")
+	insertLogRowForKey(t, h, vk, "vk-sort-ip", "192.0.2.1")
+
+	req := httptest.NewRequest(http.MethodGet, "/logs?sort_by=ip&sort_dir=asc&virtual_key_id="+vk, http.NoBody)
+	req.Header.Set("Authorization", "Bearer test-admin-token")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	json.NewDecoder(w.Body).Decode(&resp)
+	entries := resp["entries"].([]any)
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(entries))
+	}
+	if got := entries[0].(map[string]any)["client_ip"]; got != "192.0.2.1" {
+		t.Errorf("first entry client_ip = %v, want 192.0.2.1 (empty IPs sort last)", got)
+	}
+}

--- a/internal/api/handler_logs_test.go
+++ b/internal/api/handler_logs_test.go
@@ -879,6 +879,37 @@ func TestGetLog_IncludesClientIP(t *testing.T) {
 	}
 }
 
+// TestListLogs_FilterByClientIP verifies ?client_ip= narrows both listing
+// endpoints to rows from that exact address.
+func TestListLogs_FilterByClientIP(t *testing.T) {
+	h, r := newTestHandlerWithRouter(t)
+	vk := createLogTestKey(t, r, "vk-ip-filter")
+	insertLogRowForKey(t, h, vk, "vk-ip-filter", "198.51.100.9")
+	insertLogRowForKey(t, h, vk, "vk-ip-filter", "203.0.113.7")
+
+	for _, path := range []string{
+		"/logs?client_ip=198.51.100.9",
+		"/logs/cursor?client_ip=198.51.100.9",
+	} {
+		req := httptest.NewRequest(http.MethodGet, path, http.NoBody)
+		req.Header.Set("Authorization", "Bearer test-admin-token")
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("%s: expected 200, got %d: %s", path, w.Code, w.Body.String())
+		}
+		var resp map[string]any
+		json.NewDecoder(w.Body).Decode(&resp)
+		entries := resp["entries"].([]any)
+		if len(entries) != 1 {
+			t.Fatalf("%s: expected 1 entry for client_ip filter, got %d", path, len(entries))
+		}
+		if got := entries[0].(map[string]any)["client_ip"]; got != "198.51.100.9" {
+			t.Errorf("%s: entry client_ip = %v, want 198.51.100.9", path, got)
+		}
+	}
+}
+
 // TestListLogs_SortByIP covers the ip sort key (tier expression puts rows
 // without an IP last).
 func TestListLogs_SortByIP(t *testing.T) {

--- a/internal/api/handler_models_test.go
+++ b/internal/api/handler_models_test.go
@@ -1611,3 +1611,65 @@ func TestListModels_ProviderEnabledFilter(t *testing.T) {
 		}
 	})
 }
+
+// TestTestModel_LogsClientIP verifies the Test button's request_logs row
+// carries the admin's resolved client IP, matching the proxy ingest paths.
+func TestTestModel_LogsClientIP(t *testing.T) {
+	h, r := newTestHandlerWithRouter(t)
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]any{"error": map[string]any{"message": "invalid api key"}})
+	}))
+	defer mockServer.Close()
+
+	origTransport := h.testModelTransport
+	h.testModelTransport = &http.Transport{}
+	defer func() { h.testModelTransport = origTransport }()
+
+	providerData := fmt.Sprintf(`{"name": "test-ip-provider-%s", "base_url": "%s", "api_key": "sk-test-key"}`, uuid.New().String()[:8], mockServer.URL)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/providers", strings.NewReader(providerData))
+	req.Header.Set("Authorization", "Bearer test-admin-token")
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("Failed to create provider: %d", rec.Code)
+	}
+	var providerResp struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &providerResp); err != nil {
+		t.Fatalf("Failed to parse provider response: %v", err)
+	}
+
+	modelID := uuid.New().String()
+	testModelName := "ip-test-" + uuid.New().String()[:8]
+	pool := h.Pool().Pool()
+	_, err := pool.Exec(context.Background(),
+		`INSERT INTO models (id, provider_id, model_id, name, enabled) VALUES ($1, $2, $3, $4, $5)`,
+		modelID, providerResp.ID, testModelName, "IP Test Model", true)
+	if err != nil {
+		t.Fatalf("Failed to insert model: %v", err)
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest("POST", "/models/"+modelID+"/test", http.NoBody)
+	req.RemoteAddr = "198.51.100.77:4242"
+	req.Header.Set("Authorization", "Bearer test-admin-token")
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var ip *string
+	if err := pool.QueryRow(context.Background(),
+		`SELECT client_ip FROM request_logs WHERE model_id = $1 ORDER BY created_at DESC LIMIT 1`, testModelName,
+	).Scan(&ip); err != nil {
+		t.Fatalf("read test request log: %v", err)
+	}
+	if ip == nil || *ip != "198.51.100.77" {
+		t.Errorf("client_ip = %v, want 198.51.100.77", ip)
+	}
+}

--- a/internal/api/logs.go
+++ b/internal/api/logs.go
@@ -56,6 +56,7 @@ type LogEntry struct {
 	VirtualKeyName            string     `json:"virtual_key_name"`
 	VirtualKeyDeleted         bool       `json:"virtual_key_deleted"`
 	VirtualKeyID              string     `json:"virtual_key_id"`
+	ClientIP                  string     `json:"client_ip"` // "" for rows predating migration 073 or address-less ingest paths
 	ErrorMessage              string     `json:"error_message"`
 	ErrorKind                 string     `json:"error_kind"` // "" when unclassified (legacy rows); frontend falls back to substring matching
 	FailoverAttempt           int        `json:"failover_attempt"`
@@ -137,7 +138,8 @@ func (h *Handler) GetLog(w http.ResponseWriter, r *http.Request) {
 			COALESCE(rl.response_header_ms, 0),
 			COALESCE(rl.resolved_model_id, ''),
 			COALESCE(rl.endpoint_type, 'chat'),
-			COALESCE(rl.error_kind, '')
+			COALESCE(rl.error_kind, ''),
+			COALESCE(rl.client_ip, '')
 		FROM request_logs rl LEFT JOIN providers p ON rl.provider_id = p.id
 		LEFT JOIN virtual_keys vk ON rl.virtual_key_id = vk.id
 		WHERE rl.id = $1`+ownerPredicate,
@@ -160,6 +162,7 @@ func (h *Handler) GetLog(w http.ResponseWriter, r *http.Request) {
 		&entry.ResolvedModelID,
 		&entry.EndpointType,
 		&entry.ErrorKind,
+		&entry.ClientIP,
 	)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -219,7 +222,8 @@ type LogsCursorResponse struct {
 //   - cursor: encoded cursor from a previous response (base64 JSON of {created_at, id})
 //   - direction: "after" (default) or "before" — which way to scroll from cursor
 //   - limit: page size (default 20, max 200)
-//   - model_id, provider_id, status_code, from, to: same filters as ListLogs
+//   - model_id, provider_id, virtual_key_id, status_code, from, to: same
+//     filters as ListLogs
 //   - sort_by: only "time" is supported for cursor pagination (default "time")
 //   - sort_dir: "desc" (default, newest first) or "asc"
 //
@@ -273,7 +277,7 @@ func (h *Handler) ListLogsCursor(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// logEntrySelectColumns is the shared 36-column request_logs projection plus the
+// logEntrySelectColumns is the shared 37-column request_logs projection plus the
 // FROM/JOIN/WHERE 1=1 tail. The cursor list prefixes it with "SELECT "; the
 // offset list (ListLogs) prefixes it with the windowed total count. Its column
 // order matches logEntryScanDests exactly.
@@ -304,7 +308,8 @@ const logEntrySelectColumns = `rl.id, COALESCE(rl.provider_id::text, ''),
             COALESCE(rl.response_header_ms, 0),
             COALESCE(rl.resolved_model_id, ''),
             COALESCE(rl.endpoint_type, 'chat'),
-            COALESCE(rl.error_kind, '')
+            COALESCE(rl.error_kind, ''),
+            COALESCE(rl.client_ip, '')
         FROM request_logs rl LEFT JOIN providers p ON rl.provider_id = p.id
         LEFT JOIN virtual_keys vk ON rl.virtual_key_id = vk.id
         WHERE 1=1
@@ -319,7 +324,7 @@ func buildLogListQuery(p logListParams) (string, []any) {
 
 	args := []any{}
 	argIndex := 1
-	query, args, argIndex = appendLogFilters(query, args, argIndex, p.modelID, p.providerID, p.statusCode, p.fromDate, p.toDate, p.endpointType, p.ownerUserID)
+	query, args, argIndex = appendLogFilters(query, args, argIndex, p.modelID, p.providerID, p.virtualKeyID, p.statusCode, p.fromDate, p.toDate, p.endpointType, p.ownerUserID)
 	if p.cursorStr != "" {
 		query, args, argIndex = appendKeysetPredicate(query, args, argIndex, p.cursor, p.direction, p.sortDir)
 	}
@@ -344,7 +349,7 @@ func buildLogListQuery(p logListParams) (string, []any) {
 func (h *Handler) countLogs(ctx context.Context, p logListParams) int {
 	query := "SELECT COUNT(*) FROM request_logs rl WHERE 1=1"
 	args := []any{}
-	query, args, _ = appendLogFilters(query, args, 1, p.modelID, p.providerID, p.statusCode, p.fromDate, p.toDate, p.endpointType, p.ownerUserID)
+	query, args, _ = appendLogFilters(query, args, 1, p.modelID, p.providerID, p.virtualKeyID, p.statusCode, p.fromDate, p.toDate, p.endpointType, p.ownerUserID)
 	var total int
 	_ = h.dbPool.Pool().QueryRow(ctx, query, args...).Scan(&total)
 	return total
@@ -388,7 +393,7 @@ func paginateCursor[T any](entries []T, direction string, limit int, hasCursor b
 	return entries, hasAfter, hasBefore
 }
 
-// logEntryScanDests returns the ordered Scan() targets for the shared 35-column
+// logEntryScanDests returns the ordered Scan() targets for the shared 37-column
 // request_logs projection (logEntrySelectColumns). The cursor list scans these
 // directly; the offset list (ListLogs) prepends its windowed total count.
 func logEntryScanDests(entry *LogEntry) []any {
@@ -410,10 +415,11 @@ func logEntryScanDests(entry *LogEntry) []any {
 		&entry.ResolvedModelID,
 		&entry.EndpointType,
 		&entry.ErrorKind,
+		&entry.ClientIP,
 	}
 }
 
-// scanLogEntry scans one request_logs row (the 35-column projection shared by
+// scanLogEntry scans one request_logs row (the 37-column projection shared by
 // ListLogsCursor and ListLogs) into a LogEntry.
 func scanLogEntry(rows pgx.Rows) (LogEntry, error) {
 	var entry LogEntry
@@ -428,7 +434,7 @@ func scanLogEntry(rows pgx.Rows) (LogEntry, error) {
 // count copy lacked the `statusCode >= 0` guard the data copy has; both now use
 // the guard, so an invalid negative status_code is uniformly ignored — a
 // behaviour-neutral fix since status codes are always >= 0).
-func appendLogFilters(query string, args []any, argIndex int, modelID, providerID, statusCodeStr, fromDate, toDate, endpointType, ownerUserID string) (string, []any, int) {
+func appendLogFilters(query string, args []any, argIndex int, modelID, providerID, virtualKeyID, statusCodeStr, fromDate, toDate, endpointType, ownerUserID string) (string, []any, int) {
 	// Owner scope first: for non-admins this is mandatory row-level security,
 	// for admins an optional dashboard filter. The two branches cover the two
 	// disjoint row shapes. A KEYED row resolves through the key's CURRENT owner,
@@ -459,6 +465,14 @@ func appendLogFilters(query string, args []any, argIndex int, modelID, providerI
 		if err == nil {
 			query += " AND rl.provider_id = $" + util.IntToStr(argIndex)
 			args = append(args, providerUUID)
+			argIndex++
+		}
+	}
+	if virtualKeyID != "" {
+		vkUUID, err := uuid.Parse(virtualKeyID)
+		if err == nil {
+			query += " AND rl.virtual_key_id = $" + util.IntToStr(argIndex)
+			args = append(args, vkUUID)
 			argIndex++
 		}
 	}
@@ -536,6 +550,7 @@ type logListParams struct {
 	ownerUserID  string
 	modelID      string
 	providerID   string
+	virtualKeyID string
 	statusCode   string
 	fromDate     string
 	toDate       string
@@ -553,6 +568,7 @@ func parseLogListParams(w http.ResponseWriter, r *http.Request) (logListParams, 
 		ownerUserID:  logOwnerScope(r),
 		modelID:      r.URL.Query().Get("model_id"),
 		providerID:   r.URL.Query().Get("provider_id"),
+		virtualKeyID: r.URL.Query().Get("virtual_key_id"),
 		statusCode:   r.URL.Query().Get("status_code"),
 		fromDate:     r.URL.Query().Get("from"),
 		toDate:       r.URL.Query().Get("to"),
@@ -683,6 +699,10 @@ func logsSortDef(sortBy string) (string, logSortDef) {
 		"duration":           {"CASE WHEN rl.duration_ms = 0 THEN 1 ELSE 0 END", "rl.duration_ms"},
 		"overhead":           {"CASE WHEN rl.proxy_overhead_ms = 0 THEN 1 ELSE 0 END", "rl.proxy_overhead_ms"},
 		"key":                {"", "CASE WHEN rl.virtual_key_id IS NOT NULL AND rl.virtual_key_id::text != '' AND vk.id IS NULL THEN 'zzzzzzzz' ELSE COALESCE(rl.virtual_key_name, '') END"},
+		// client_ip is TEXT, so this orders lexicographically (10.* before 9.*);
+		// good enough for grouping same-address rows, which is what the column
+		// sort is for. Rows without an address always sort last.
+		"ip": {"CASE WHEN COALESCE(rl.client_ip, '') = '' THEN 1 ELSE 0 END", "COALESCE(rl.client_ip, '')"},
 	}
 	if _, ok := sortColumns[sortBy]; !ok {
 		sortBy = "time"
@@ -707,6 +727,7 @@ func (h *Handler) ListLogs(w http.ResponseWriter, r *http.Request) {
 	cacheKey := ownerUserID + "|" + r.URL.RawQuery
 	modelID := r.URL.Query().Get("model_id")
 	providerID := r.URL.Query().Get("provider_id")
+	virtualKeyID := r.URL.Query().Get("virtual_key_id")
 	statusCodeStr := r.URL.Query().Get("status_code")
 	fromDate := r.URL.Query().Get("from")
 	toDate := r.URL.Query().Get("to")
@@ -730,7 +751,7 @@ func (h *Handler) ListLogs(w http.ResponseWriter, r *http.Request) {
 
 	args := []any{}
 	argIndex := 1
-	query, args, argIndex = appendLogFilters(query, args, argIndex, modelID, providerID, statusCodeStr, fromDate, toDate, endpointType, ownerUserID)
+	query, args, argIndex = appendLogFilters(query, args, argIndex, modelID, providerID, virtualKeyID, statusCodeStr, fromDate, toDate, endpointType, ownerUserID)
 
 	orderClause := " ORDER BY "
 	if sd.tierExpr != "" {

--- a/internal/api/logs.go
+++ b/internal/api/logs.go
@@ -222,7 +222,7 @@ type LogsCursorResponse struct {
 //   - cursor: encoded cursor from a previous response (base64 JSON of {created_at, id})
 //   - direction: "after" (default) or "before" — which way to scroll from cursor
 //   - limit: page size (default 20, max 200)
-//   - model_id, provider_id, virtual_key_id, status_code, from, to: same
+//   - model_id, provider_id, virtual_key_id, client_ip, status_code, from, to: same
 //     filters as ListLogs
 //   - sort_by: only "time" is supported for cursor pagination (default "time")
 //   - sort_dir: "desc" (default, newest first) or "asc"
@@ -324,7 +324,7 @@ func buildLogListQuery(p logListParams) (string, []any) {
 
 	args := []any{}
 	argIndex := 1
-	query, args, argIndex = appendLogFilters(query, args, argIndex, p.modelID, p.providerID, p.virtualKeyID, p.statusCode, p.fromDate, p.toDate, p.endpointType, p.ownerUserID)
+	query, args, argIndex = appendLogFilters(query, args, argIndex, p.modelID, p.providerID, p.virtualKeyID, p.clientIP, p.statusCode, p.fromDate, p.toDate, p.endpointType, p.ownerUserID)
 	if p.cursorStr != "" {
 		query, args, argIndex = appendKeysetPredicate(query, args, argIndex, p.cursor, p.direction, p.sortDir)
 	}
@@ -349,7 +349,7 @@ func buildLogListQuery(p logListParams) (string, []any) {
 func (h *Handler) countLogs(ctx context.Context, p logListParams) int {
 	query := "SELECT COUNT(*) FROM request_logs rl WHERE 1=1"
 	args := []any{}
-	query, args, _ = appendLogFilters(query, args, 1, p.modelID, p.providerID, p.virtualKeyID, p.statusCode, p.fromDate, p.toDate, p.endpointType, p.ownerUserID)
+	query, args, _ = appendLogFilters(query, args, 1, p.modelID, p.providerID, p.virtualKeyID, p.clientIP, p.statusCode, p.fromDate, p.toDate, p.endpointType, p.ownerUserID)
 	var total int
 	_ = h.dbPool.Pool().QueryRow(ctx, query, args...).Scan(&total)
 	return total
@@ -434,7 +434,7 @@ func scanLogEntry(rows pgx.Rows) (LogEntry, error) {
 // count copy lacked the `statusCode >= 0` guard the data copy has; both now use
 // the guard, so an invalid negative status_code is uniformly ignored — a
 // behaviour-neutral fix since status codes are always >= 0).
-func appendLogFilters(query string, args []any, argIndex int, modelID, providerID, virtualKeyID, statusCodeStr, fromDate, toDate, endpointType, ownerUserID string) (string, []any, int) {
+func appendLogFilters(query string, args []any, argIndex int, modelID, providerID, virtualKeyID, clientIP, statusCodeStr, fromDate, toDate, endpointType, ownerUserID string) (string, []any, int) {
 	// Owner scope first: for non-admins this is mandatory row-level security,
 	// for admins an optional dashboard filter. The two branches cover the two
 	// disjoint row shapes. A KEYED row resolves through the key's CURRENT owner,
@@ -475,6 +475,11 @@ func appendLogFilters(query string, args []any, argIndex int, modelID, providerI
 			args = append(args, vkUUID)
 			argIndex++
 		}
+	}
+	if clientIP != "" {
+		query += " AND rl.client_ip = $" + util.IntToStr(argIndex)
+		args = append(args, clientIP)
+		argIndex++
 	}
 	if statusCodeStr != "" {
 		if statusCodeStr == "4xx" {
@@ -551,6 +556,7 @@ type logListParams struct {
 	modelID      string
 	providerID   string
 	virtualKeyID string
+	clientIP     string
 	statusCode   string
 	fromDate     string
 	toDate       string
@@ -569,6 +575,7 @@ func parseLogListParams(w http.ResponseWriter, r *http.Request) (logListParams, 
 		modelID:      r.URL.Query().Get("model_id"),
 		providerID:   r.URL.Query().Get("provider_id"),
 		virtualKeyID: r.URL.Query().Get("virtual_key_id"),
+		clientIP:     r.URL.Query().Get("client_ip"),
 		statusCode:   r.URL.Query().Get("status_code"),
 		fromDate:     r.URL.Query().Get("from"),
 		toDate:       r.URL.Query().Get("to"),
@@ -728,6 +735,7 @@ func (h *Handler) ListLogs(w http.ResponseWriter, r *http.Request) {
 	modelID := r.URL.Query().Get("model_id")
 	providerID := r.URL.Query().Get("provider_id")
 	virtualKeyID := r.URL.Query().Get("virtual_key_id")
+	clientIP := r.URL.Query().Get("client_ip")
 	statusCodeStr := r.URL.Query().Get("status_code")
 	fromDate := r.URL.Query().Get("from")
 	toDate := r.URL.Query().Get("to")
@@ -751,7 +759,7 @@ func (h *Handler) ListLogs(w http.ResponseWriter, r *http.Request) {
 
 	args := []any{}
 	argIndex := 1
-	query, args, argIndex = appendLogFilters(query, args, argIndex, modelID, providerID, virtualKeyID, statusCodeStr, fromDate, toDate, endpointType, ownerUserID)
+	query, args, argIndex = appendLogFilters(query, args, argIndex, modelID, providerID, virtualKeyID, clientIP, statusCodeStr, fromDate, toDate, endpointType, ownerUserID)
 
 	orderClause := " ORDER BY "
 	if sd.tierExpr != "" {

--- a/internal/api/logs_test.go
+++ b/internal/api/logs_test.go
@@ -1276,7 +1276,7 @@ func TestListLogsCursor_CancelledContext(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestAppendLogFilters_NoFilters(t *testing.T) {
-	query, args, idx := appendLogFilters("SELECT * FROM t WHERE 1=1", nil, 1, "", "", "", "", "", "", "", "")
+	query, args, idx := appendLogFilters("SELECT * FROM t WHERE 1=1", nil, 1, "", "", "", "", "", "", "", "", "")
 	if !strings.Contains(query, "WHERE 1=1") {
 		t.Errorf("base query should be preserved, got %q", query)
 	}
@@ -1289,7 +1289,7 @@ func TestAppendLogFilters_NoFilters(t *testing.T) {
 }
 
 func TestAppendLogFilters_ModelID(t *testing.T) {
-	query, args, idx := appendLogFilters("WHERE 1=1", nil, 1, "gpt-4", "", "", "", "", "", "", "")
+	query, args, idx := appendLogFilters("WHERE 1=1", nil, 1, "gpt-4", "", "", "", "", "", "", "", "")
 	if !strings.Contains(query, `AND rl.model_id ILIKE $1`) {
 		t.Errorf("expected model_id ILIKE filter, got %q", query)
 	}
@@ -1303,7 +1303,7 @@ func TestAppendLogFilters_ModelID(t *testing.T) {
 
 func TestAppendLogFilters_ProviderID_ValidUUID(t *testing.T) {
 	validUUID := uuid.New().String()
-	query, args, idx := appendLogFilters("WHERE 1=1", nil, 1, "", validUUID, "", "", "", "", "", "")
+	query, args, idx := appendLogFilters("WHERE 1=1", nil, 1, "", validUUID, "", "", "", "", "", "", "")
 	if !strings.Contains(query, "AND rl.provider_id = $1") {
 		t.Errorf("expected provider_id filter for valid UUID, got %q", query)
 	}
@@ -1316,7 +1316,7 @@ func TestAppendLogFilters_ProviderID_ValidUUID(t *testing.T) {
 }
 
 func TestAppendLogFilters_ProviderID_InvalidUUID(t *testing.T) {
-	query, args, idx := appendLogFilters("WHERE 1=1", nil, 1, "", "not-a-uuid", "", "", "", "", "", "")
+	query, args, idx := appendLogFilters("WHERE 1=1", nil, 1, "", "not-a-uuid", "", "", "", "", "", "", "")
 	if strings.Contains(query, "provider_id") {
 		t.Errorf("invalid UUID should not add provider_id filter, got %q", query)
 	}
@@ -1329,7 +1329,7 @@ func TestAppendLogFilters_ProviderID_InvalidUUID(t *testing.T) {
 }
 
 func TestAppendLogFilters_StatusCode4xx(t *testing.T) {
-	query, args, idx := appendLogFilters("WHERE 1=1", nil, 1, "", "", "", "4xx", "", "", "", "")
+	query, args, idx := appendLogFilters("WHERE 1=1", nil, 1, "", "", "", "", "4xx", "", "", "", "")
 	if !strings.Contains(query, "AND rl.status_code >= 400 AND rl.status_code < 500") {
 		t.Errorf("expected 4xx range filter, got %q", query)
 	}
@@ -1342,7 +1342,7 @@ func TestAppendLogFilters_StatusCode4xx(t *testing.T) {
 }
 
 func TestAppendLogFilters_StatusCode5xx(t *testing.T) {
-	query, args, idx := appendLogFilters("WHERE 1=1", nil, 1, "", "", "", "5xx", "", "", "", "")
+	query, args, idx := appendLogFilters("WHERE 1=1", nil, 1, "", "", "", "", "5xx", "", "", "", "")
 	if !strings.Contains(query, "AND rl.status_code >= 500") {
 		t.Errorf("expected 5xx range filter, got %q", query)
 	}
@@ -1355,7 +1355,7 @@ func TestAppendLogFilters_StatusCode5xx(t *testing.T) {
 }
 
 func TestAppendLogFilters_StatusCodeSpecific(t *testing.T) {
-	query, args, idx := appendLogFilters("WHERE 1=1", nil, 1, "", "", "", "404", "", "", "", "")
+	query, args, idx := appendLogFilters("WHERE 1=1", nil, 1, "", "", "", "", "404", "", "", "", "")
 	if !strings.Contains(query, "AND rl.status_code = $1") {
 		t.Errorf("expected specific status code filter, got %q", query)
 	}
@@ -1368,7 +1368,7 @@ func TestAppendLogFilters_StatusCodeSpecific(t *testing.T) {
 }
 
 func TestAppendLogFilters_StatusCodeZero(t *testing.T) {
-	query, args, idx := appendLogFilters("WHERE 1=1", nil, 1, "", "", "", "0", "", "", "", "")
+	query, args, idx := appendLogFilters("WHERE 1=1", nil, 1, "", "", "", "", "0", "", "", "", "")
 	if !strings.Contains(query, "AND (rl.status_code = 0 OR rl.status_code IS NULL)") {
 		t.Errorf("expected status_code=0 or NULL filter, got %q", query)
 	}
@@ -1381,7 +1381,7 @@ func TestAppendLogFilters_StatusCodeZero(t *testing.T) {
 }
 
 func TestAppendLogFilters_StatusCodeNegative(t *testing.T) {
-	query, args, _ := appendLogFilters("WHERE 1=1", nil, 1, "", "", "", "-1", "", "", "", "")
+	query, args, _ := appendLogFilters("WHERE 1=1", nil, 1, "", "", "", "", "-1", "", "", "", "")
 	if strings.Contains(query, "status_code") {
 		t.Errorf("negative status code should be ignored, got %q", query)
 	}
@@ -1391,7 +1391,7 @@ func TestAppendLogFilters_StatusCodeNegative(t *testing.T) {
 }
 
 func TestAppendLogFilters_StatusCodeNonNumeric(t *testing.T) {
-	query, args, _ := appendLogFilters("WHERE 1=1", nil, 1, "", "", "", "abc", "", "", "", "")
+	query, args, _ := appendLogFilters("WHERE 1=1", nil, 1, "", "", "", "", "abc", "", "", "", "")
 	if strings.Contains(query, "status_code") {
 		t.Errorf("non-numeric status code should be ignored, got %q", query)
 	}
@@ -1402,7 +1402,7 @@ func TestAppendLogFilters_StatusCodeNonNumeric(t *testing.T) {
 
 func TestAppendLogFilters_FromDate(t *testing.T) {
 	from := "2024-01-01T00:00:00Z"
-	query, args, idx := appendLogFilters("WHERE 1=1", nil, 1, "", "", "", "", from, "", "", "")
+	query, args, idx := appendLogFilters("WHERE 1=1", nil, 1, "", "", "", "", "", from, "", "", "")
 	if !strings.Contains(query, "AND rl.created_at >= $1") {
 		t.Errorf("expected from date filter, got %q", query)
 	}
@@ -1416,7 +1416,7 @@ func TestAppendLogFilters_FromDate(t *testing.T) {
 
 func TestAppendLogFilters_ToDate(t *testing.T) {
 	to := "2024-12-31T23:59:59Z"
-	query, args, idx := appendLogFilters("WHERE 1=1", nil, 1, "", "", "", "", "", to, "", "")
+	query, args, idx := appendLogFilters("WHERE 1=1", nil, 1, "", "", "", "", "", "", to, "", "")
 	if !strings.Contains(query, "AND rl.created_at <= $1") {
 		t.Errorf("expected to date filter, got %q", query)
 	}
@@ -1429,7 +1429,7 @@ func TestAppendLogFilters_ToDate(t *testing.T) {
 }
 
 func TestAppendLogFilters_InvalidFromDate(t *testing.T) {
-	query, args, idx := appendLogFilters("WHERE 1=1", nil, 1, "", "", "", "", "not-a-date", "", "", "")
+	query, args, idx := appendLogFilters("WHERE 1=1", nil, 1, "", "", "", "", "", "not-a-date", "", "", "")
 	if strings.Contains(query, "rl.created_at >=") {
 		t.Errorf("invalid from date should be ignored, got %q", query)
 	}
@@ -1442,7 +1442,7 @@ func TestAppendLogFilters_InvalidFromDate(t *testing.T) {
 }
 
 func TestAppendLogFilters_InvalidToDate(t *testing.T) {
-	query, args, idx := appendLogFilters("WHERE 1=1", nil, 1, "", "", "", "", "", "garbage", "", "")
+	query, args, idx := appendLogFilters("WHERE 1=1", nil, 1, "", "", "", "", "", "", "garbage", "", "")
 	if strings.Contains(query, "rl.created_at <=") {
 		t.Errorf("invalid to date should be ignored, got %q", query)
 	}
@@ -1456,7 +1456,7 @@ func TestAppendLogFilters_InvalidToDate(t *testing.T) {
 
 func TestAppendLogFilters_AllFilters(t *testing.T) {
 	validUUID := uuid.New().String()
-	query, args, idx := appendLogFilters("WHERE 1=1", nil, 3, "gpt-4", validUUID, "", "404", "2024-01-01T00:00:00Z", "2024-12-31T23:59:59Z", "", "")
+	query, args, idx := appendLogFilters("WHERE 1=1", nil, 3, "gpt-4", validUUID, "", "", "404", "2024-01-01T00:00:00Z", "2024-12-31T23:59:59Z", "", "")
 	if !strings.Contains(query, `AND rl.model_id ILIKE $3`) {
 		t.Errorf("expected model_id filter at $3, got %q", query)
 	}
@@ -1481,7 +1481,7 @@ func TestAppendLogFilters_AllFilters(t *testing.T) {
 }
 
 func TestAppendLogFilters_EndpointType(t *testing.T) {
-	query, args, idx := appendLogFilters("WHERE 1=1", nil, 1, "", "", "", "", "", "", "embeddings", "")
+	query, args, idx := appendLogFilters("WHERE 1=1", nil, 1, "", "", "", "", "", "", "", "embeddings", "")
 	if !strings.Contains(query, "AND COALESCE(rl.endpoint_type, 'chat') = $1") {
 		t.Errorf("expected endpoint_type filter at $1, got %q", query)
 	}
@@ -1494,7 +1494,7 @@ func TestAppendLogFilters_EndpointType(t *testing.T) {
 }
 
 func TestAppendLogFilters_EndpointTypeInvalidIgnored(t *testing.T) {
-	query, args, idx := appendLogFilters("WHERE 1=1", nil, 1, "", "", "", "", "", "", "bogus", "")
+	query, args, idx := appendLogFilters("WHERE 1=1", nil, 1, "", "", "", "", "", "", "", "bogus", "")
 	if strings.Contains(query, "endpoint_type") {
 		t.Errorf("unknown endpoint_type must be ignored, got %q", query)
 	}

--- a/internal/api/logs_test.go
+++ b/internal/api/logs_test.go
@@ -1276,7 +1276,7 @@ func TestListLogsCursor_CancelledContext(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestAppendLogFilters_NoFilters(t *testing.T) {
-	query, args, idx := appendLogFilters("SELECT * FROM t WHERE 1=1", nil, 1, "", "", "", "", "", "", "")
+	query, args, idx := appendLogFilters("SELECT * FROM t WHERE 1=1", nil, 1, "", "", "", "", "", "", "", "")
 	if !strings.Contains(query, "WHERE 1=1") {
 		t.Errorf("base query should be preserved, got %q", query)
 	}
@@ -1289,7 +1289,7 @@ func TestAppendLogFilters_NoFilters(t *testing.T) {
 }
 
 func TestAppendLogFilters_ModelID(t *testing.T) {
-	query, args, idx := appendLogFilters("WHERE 1=1", nil, 1, "gpt-4", "", "", "", "", "", "")
+	query, args, idx := appendLogFilters("WHERE 1=1", nil, 1, "gpt-4", "", "", "", "", "", "", "")
 	if !strings.Contains(query, `AND rl.model_id ILIKE $1`) {
 		t.Errorf("expected model_id ILIKE filter, got %q", query)
 	}
@@ -1303,7 +1303,7 @@ func TestAppendLogFilters_ModelID(t *testing.T) {
 
 func TestAppendLogFilters_ProviderID_ValidUUID(t *testing.T) {
 	validUUID := uuid.New().String()
-	query, args, idx := appendLogFilters("WHERE 1=1", nil, 1, "", validUUID, "", "", "", "", "")
+	query, args, idx := appendLogFilters("WHERE 1=1", nil, 1, "", validUUID, "", "", "", "", "", "")
 	if !strings.Contains(query, "AND rl.provider_id = $1") {
 		t.Errorf("expected provider_id filter for valid UUID, got %q", query)
 	}
@@ -1316,7 +1316,7 @@ func TestAppendLogFilters_ProviderID_ValidUUID(t *testing.T) {
 }
 
 func TestAppendLogFilters_ProviderID_InvalidUUID(t *testing.T) {
-	query, args, idx := appendLogFilters("WHERE 1=1", nil, 1, "", "not-a-uuid", "", "", "", "", "")
+	query, args, idx := appendLogFilters("WHERE 1=1", nil, 1, "", "not-a-uuid", "", "", "", "", "", "")
 	if strings.Contains(query, "provider_id") {
 		t.Errorf("invalid UUID should not add provider_id filter, got %q", query)
 	}
@@ -1329,7 +1329,7 @@ func TestAppendLogFilters_ProviderID_InvalidUUID(t *testing.T) {
 }
 
 func TestAppendLogFilters_StatusCode4xx(t *testing.T) {
-	query, args, idx := appendLogFilters("WHERE 1=1", nil, 1, "", "", "4xx", "", "", "", "")
+	query, args, idx := appendLogFilters("WHERE 1=1", nil, 1, "", "", "", "4xx", "", "", "", "")
 	if !strings.Contains(query, "AND rl.status_code >= 400 AND rl.status_code < 500") {
 		t.Errorf("expected 4xx range filter, got %q", query)
 	}
@@ -1342,7 +1342,7 @@ func TestAppendLogFilters_StatusCode4xx(t *testing.T) {
 }
 
 func TestAppendLogFilters_StatusCode5xx(t *testing.T) {
-	query, args, idx := appendLogFilters("WHERE 1=1", nil, 1, "", "", "5xx", "", "", "", "")
+	query, args, idx := appendLogFilters("WHERE 1=1", nil, 1, "", "", "", "5xx", "", "", "", "")
 	if !strings.Contains(query, "AND rl.status_code >= 500") {
 		t.Errorf("expected 5xx range filter, got %q", query)
 	}
@@ -1355,7 +1355,7 @@ func TestAppendLogFilters_StatusCode5xx(t *testing.T) {
 }
 
 func TestAppendLogFilters_StatusCodeSpecific(t *testing.T) {
-	query, args, idx := appendLogFilters("WHERE 1=1", nil, 1, "", "", "404", "", "", "", "")
+	query, args, idx := appendLogFilters("WHERE 1=1", nil, 1, "", "", "", "404", "", "", "", "")
 	if !strings.Contains(query, "AND rl.status_code = $1") {
 		t.Errorf("expected specific status code filter, got %q", query)
 	}
@@ -1368,7 +1368,7 @@ func TestAppendLogFilters_StatusCodeSpecific(t *testing.T) {
 }
 
 func TestAppendLogFilters_StatusCodeZero(t *testing.T) {
-	query, args, idx := appendLogFilters("WHERE 1=1", nil, 1, "", "", "0", "", "", "", "")
+	query, args, idx := appendLogFilters("WHERE 1=1", nil, 1, "", "", "", "0", "", "", "", "")
 	if !strings.Contains(query, "AND (rl.status_code = 0 OR rl.status_code IS NULL)") {
 		t.Errorf("expected status_code=0 or NULL filter, got %q", query)
 	}
@@ -1381,7 +1381,7 @@ func TestAppendLogFilters_StatusCodeZero(t *testing.T) {
 }
 
 func TestAppendLogFilters_StatusCodeNegative(t *testing.T) {
-	query, args, _ := appendLogFilters("WHERE 1=1", nil, 1, "", "", "-1", "", "", "", "")
+	query, args, _ := appendLogFilters("WHERE 1=1", nil, 1, "", "", "", "-1", "", "", "", "")
 	if strings.Contains(query, "status_code") {
 		t.Errorf("negative status code should be ignored, got %q", query)
 	}
@@ -1391,7 +1391,7 @@ func TestAppendLogFilters_StatusCodeNegative(t *testing.T) {
 }
 
 func TestAppendLogFilters_StatusCodeNonNumeric(t *testing.T) {
-	query, args, _ := appendLogFilters("WHERE 1=1", nil, 1, "", "", "abc", "", "", "", "")
+	query, args, _ := appendLogFilters("WHERE 1=1", nil, 1, "", "", "", "abc", "", "", "", "")
 	if strings.Contains(query, "status_code") {
 		t.Errorf("non-numeric status code should be ignored, got %q", query)
 	}
@@ -1402,7 +1402,7 @@ func TestAppendLogFilters_StatusCodeNonNumeric(t *testing.T) {
 
 func TestAppendLogFilters_FromDate(t *testing.T) {
 	from := "2024-01-01T00:00:00Z"
-	query, args, idx := appendLogFilters("WHERE 1=1", nil, 1, "", "", "", from, "", "", "")
+	query, args, idx := appendLogFilters("WHERE 1=1", nil, 1, "", "", "", "", from, "", "", "")
 	if !strings.Contains(query, "AND rl.created_at >= $1") {
 		t.Errorf("expected from date filter, got %q", query)
 	}
@@ -1416,7 +1416,7 @@ func TestAppendLogFilters_FromDate(t *testing.T) {
 
 func TestAppendLogFilters_ToDate(t *testing.T) {
 	to := "2024-12-31T23:59:59Z"
-	query, args, idx := appendLogFilters("WHERE 1=1", nil, 1, "", "", "", "", to, "", "")
+	query, args, idx := appendLogFilters("WHERE 1=1", nil, 1, "", "", "", "", "", to, "", "")
 	if !strings.Contains(query, "AND rl.created_at <= $1") {
 		t.Errorf("expected to date filter, got %q", query)
 	}
@@ -1429,7 +1429,7 @@ func TestAppendLogFilters_ToDate(t *testing.T) {
 }
 
 func TestAppendLogFilters_InvalidFromDate(t *testing.T) {
-	query, args, idx := appendLogFilters("WHERE 1=1", nil, 1, "", "", "", "not-a-date", "", "", "")
+	query, args, idx := appendLogFilters("WHERE 1=1", nil, 1, "", "", "", "", "not-a-date", "", "", "")
 	if strings.Contains(query, "rl.created_at >=") {
 		t.Errorf("invalid from date should be ignored, got %q", query)
 	}
@@ -1442,7 +1442,7 @@ func TestAppendLogFilters_InvalidFromDate(t *testing.T) {
 }
 
 func TestAppendLogFilters_InvalidToDate(t *testing.T) {
-	query, args, idx := appendLogFilters("WHERE 1=1", nil, 1, "", "", "", "", "garbage", "", "")
+	query, args, idx := appendLogFilters("WHERE 1=1", nil, 1, "", "", "", "", "", "garbage", "", "")
 	if strings.Contains(query, "rl.created_at <=") {
 		t.Errorf("invalid to date should be ignored, got %q", query)
 	}
@@ -1456,7 +1456,7 @@ func TestAppendLogFilters_InvalidToDate(t *testing.T) {
 
 func TestAppendLogFilters_AllFilters(t *testing.T) {
 	validUUID := uuid.New().String()
-	query, args, idx := appendLogFilters("WHERE 1=1", nil, 3, "gpt-4", validUUID, "404", "2024-01-01T00:00:00Z", "2024-12-31T23:59:59Z", "", "")
+	query, args, idx := appendLogFilters("WHERE 1=1", nil, 3, "gpt-4", validUUID, "", "404", "2024-01-01T00:00:00Z", "2024-12-31T23:59:59Z", "", "")
 	if !strings.Contains(query, `AND rl.model_id ILIKE $3`) {
 		t.Errorf("expected model_id filter at $3, got %q", query)
 	}
@@ -1481,7 +1481,7 @@ func TestAppendLogFilters_AllFilters(t *testing.T) {
 }
 
 func TestAppendLogFilters_EndpointType(t *testing.T) {
-	query, args, idx := appendLogFilters("WHERE 1=1", nil, 1, "", "", "", "", "", "embeddings", "")
+	query, args, idx := appendLogFilters("WHERE 1=1", nil, 1, "", "", "", "", "", "", "embeddings", "")
 	if !strings.Contains(query, "AND COALESCE(rl.endpoint_type, 'chat') = $1") {
 		t.Errorf("expected endpoint_type filter at $1, got %q", query)
 	}
@@ -1494,7 +1494,7 @@ func TestAppendLogFilters_EndpointType(t *testing.T) {
 }
 
 func TestAppendLogFilters_EndpointTypeInvalidIgnored(t *testing.T) {
-	query, args, idx := appendLogFilters("WHERE 1=1", nil, 1, "", "", "", "", "", "bogus", "")
+	query, args, idx := appendLogFilters("WHERE 1=1", nil, 1, "", "", "", "", "", "", "bogus", "")
 	if strings.Contains(query, "endpoint_type") {
 		t.Errorf("unknown endpoint_type must be ignored, got %q", query)
 	}

--- a/internal/api/models.go
+++ b/internal/api/models.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/hugalafutro/model-hotel/internal/anthropicegress"
 	"github.com/hugalafutro/model-hotel/internal/auth"
+	"github.com/hugalafutro/model-hotel/internal/clientip"
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 	"github.com/hugalafutro/model-hotel/internal/failover"
 	"github.com/hugalafutro/model-hotel/internal/gemini"
@@ -482,7 +483,7 @@ func (h *Handler) TestModel(w http.ResponseWriter, r *http.Request) {
 	resp, err := h.doTestModelRequest(r.Context(), providerType, targetURL, m.ModelID, apiKey, baseBody)
 	if err != nil {
 		durationMs := float64(time.Since(start).Milliseconds())
-		h.logTestModelRequestError(r.Context(), m, reqHash, durationMs, proxyOverheadMs, keyDecryptMs, err.Error())
+		h.logTestModelRequestError(r.Context(), m, reqHash, durationMs, proxyOverheadMs, keyDecryptMs, err.Error(), clientip.From(r))
 		writeJSON(w, TestModelResponse{Error: err.Error()})
 		return
 	}
@@ -493,13 +494,13 @@ func (h *Handler) TestModel(w http.ResponseWriter, r *http.Request) {
 
 	if resp.StatusCode != http.StatusOK {
 		errMsg := util.SanitizeLogBody(fmt.Sprintf("HTTP %d: %s", resp.StatusCode, string(respBody)), 10000)
-		h.logTestModelHTTPError(r.Context(), m, reqHash, resp.StatusCode, float64(duration), proxyOverheadMs, keyDecryptMs, errMsg)
+		h.logTestModelHTTPError(r.Context(), m, reqHash, resp.StatusCode, float64(duration), proxyOverheadMs, keyDecryptMs, errMsg, clientip.From(r))
 		writeJSON(w, TestModelResponse{DurationMs: duration, Error: errMsg})
 		return
 	}
 
 	content, tps, promptTokens, completionTokens := parseTestModelResponse(respBody, duration)
-	h.logTestModelCompleted(r.Context(), m, reqHash, resp.StatusCode, float64(duration), proxyOverheadMs, keyDecryptMs, tps, promptTokens, completionTokens)
+	h.logTestModelCompleted(r.Context(), m, reqHash, resp.StatusCode, float64(duration), proxyOverheadMs, keyDecryptMs, tps, promptTokens, completionTokens, clientip.From(r))
 	writeJSON(w, TestModelResponse{
 		Success:          true,
 		Streaming:        false,
@@ -707,21 +708,21 @@ func parseTestModelResponse(respBody []byte, duration int64) (content string, tp
 
 // logTestModelRequestError records a failed test request (the upstream call
 // never completed) as a 502 "failed" request_logs row.
-func (h *Handler) logTestModelRequestError(ctx context.Context, m *model.Model, reqHash string, durationMs, proxyOverheadMs, keyDecryptMs float64, errMsg string) {
+func (h *Handler) logTestModelRequestError(ctx context.Context, m *model.Model, reqHash string, durationMs, proxyOverheadMs, keyDecryptMs float64, errMsg, clientIP string) {
 	logQuery := `
 		INSERT INTO request_logs (
 			provider_id, model_id, request_hash, status_code,
 			latency_ms, duration_ms, response_header_ms, ttft_ms,
 			proxy_overhead_ms, parse_ms, failover_lookup_ms, model_lookup_ms, provider_lookup_ms, key_decrypt_ms, dial_ms, settings_read_ms,
-			error_message, streaming, virtual_key_name, virtual_key_id, failover_attempt, state
+			error_message, streaming, virtual_key_name, virtual_key_id, failover_attempt, state, client_ip
 		)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, 0, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, 0, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22)
 	`
 	_, logErr := h.dbPool.Pool().Exec(ctx, logQuery,
 		m.ProviderID, m.ModelID, reqHash, 502,
 		durationMs, durationMs, 0,
 		proxyOverheadMs, 0, 0, 0, 0, keyDecryptMs, 0, 0,
-		errMsg, false, "internal", nil, 0, "failed",
+		errMsg, false, "internal", nil, 0, "failed", textOrNull(clientIP),
 	)
 	if logErr != nil {
 		debuglog.Error("admin: TestModel log insert failed", "error", logErr)
@@ -730,21 +731,21 @@ func (h *Handler) logTestModelRequestError(ctx context.Context, m *model.Model, 
 
 // logTestModelHTTPError records a test request that reached the upstream but
 // returned a non-200 status as a "failed" request_logs row.
-func (h *Handler) logTestModelHTTPError(ctx context.Context, m *model.Model, reqHash string, statusCode int, durationMs, proxyOverheadMs, keyDecryptMs float64, errMsg string) {
+func (h *Handler) logTestModelHTTPError(ctx context.Context, m *model.Model, reqHash string, statusCode int, durationMs, proxyOverheadMs, keyDecryptMs float64, errMsg, clientIP string) {
 	logQuery := `
 		INSERT INTO request_logs (
 			provider_id, model_id, request_hash, status_code,
 			latency_ms, duration_ms, response_header_ms, ttft_ms,
 			proxy_overhead_ms, parse_ms, failover_lookup_ms, model_lookup_ms, provider_lookup_ms, key_decrypt_ms, dial_ms, settings_read_ms,
-			error_message, tokens_per_second, tokens_prompt, tokens_completion, streaming, virtual_key_name, virtual_key_id, failover_attempt, state
+			error_message, tokens_per_second, tokens_prompt, tokens_completion, streaming, virtual_key_name, virtual_key_id, failover_attempt, state, client_ip
 		)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, 0, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, 0, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25)
 	`
 	_, logErr := h.dbPool.Pool().Exec(ctx, logQuery,
 		m.ProviderID, m.ModelID, reqHash, statusCode,
 		durationMs, durationMs, 0,
 		proxyOverheadMs, 0, 0, 0, 0, keyDecryptMs, 0, 0,
-		errMsg, 0, 0, 0, false, "internal", nil, 0, "failed",
+		errMsg, 0, 0, 0, false, "internal", nil, 0, "failed", textOrNull(clientIP),
 	)
 	if logErr != nil {
 		debuglog.Error("admin: TestModel log insert failed", "error", logErr)
@@ -755,25 +756,34 @@ func (h *Handler) logTestModelHTTPError(ctx context.Context, m *model.Model, req
 // "completed" request_logs row. For a non-streaming test, response_header_ms
 // equals total duration (no separate streaming phase) and ttft_ms is stored as
 // 0 to indicate non-streaming.
-func (h *Handler) logTestModelCompleted(ctx context.Context, m *model.Model, reqHash string, statusCode int, durationMs, proxyOverheadMs, keyDecryptMs, tps float64, promptTokens, completionTokens int) {
+func (h *Handler) logTestModelCompleted(ctx context.Context, m *model.Model, reqHash string, statusCode int, durationMs, proxyOverheadMs, keyDecryptMs, tps float64, promptTokens, completionTokens int, clientIP string) {
 	logQuery := `
 		INSERT INTO request_logs (
 			provider_id, model_id, request_hash, status_code,
 			latency_ms, duration_ms, response_header_ms, ttft_ms,
 			proxy_overhead_ms, parse_ms, failover_lookup_ms, model_lookup_ms, provider_lookup_ms, key_decrypt_ms, dial_ms, settings_read_ms,
-			tokens_per_second, tokens_prompt, tokens_completion, streaming, virtual_key_name, virtual_key_id, failover_attempt, state
+			tokens_per_second, tokens_prompt, tokens_completion, streaming, virtual_key_name, virtual_key_id, failover_attempt, state, client_ip
 		)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, 0, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, 0, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24)
 	`
 	_, logErr := h.dbPool.Pool().Exec(ctx, logQuery,
 		m.ProviderID, m.ModelID, reqHash, statusCode,
 		durationMs, durationMs, durationMs,
 		proxyOverheadMs, 0, 0, 0, 0, keyDecryptMs, 0, 0,
-		tps, promptTokens, completionTokens, false, "internal", nil, 0, "completed",
+		tps, promptTokens, completionTokens, false, "internal", nil, 0, "completed", textOrNull(clientIP),
 	)
 	if logErr != nil {
 		debuglog.Error("admin: TestModel log insert failed", "error", logErr)
 	}
+}
+
+// textOrNull maps "" to NULL so address-less rows look the same as rows
+// predating the client_ip column.
+func textOrNull(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
 }
 
 // See util.BuildProviderTargetURL for URL construction and util.SetProviderAuthHeaders for auth.

--- a/internal/api/models_helpers_test.go
+++ b/internal/api/models_helpers_test.go
@@ -590,7 +590,7 @@ func TestLogTestModelRequestError(t *testing.T) {
 
 	m := insertTestModelForLog(t, h, "test-log-req-err")
 
-	h.logTestModelRequestError(ctx, m, "reqhash001", 1500, 200, 50, "connection refused")
+	h.logTestModelRequestError(ctx, m, "reqhash001", 1500, 200, 50, "connection refused", "192.0.2.10")
 
 	// Verify the row was inserted
 	var count int
@@ -633,7 +633,7 @@ func TestLogTestModelHTTPError(t *testing.T) {
 
 	m := insertTestModelForLog(t, h, "test-log-http-err")
 
-	h.logTestModelHTTPError(ctx, m, "reqhash002", 429, 3000, 250, 30, "rate limited")
+	h.logTestModelHTTPError(ctx, m, "reqhash002", 429, 3000, 250, 30, "rate limited", "192.0.2.10")
 
 	var count int
 	err := h.dbPool.Pool().QueryRow(ctx,
@@ -674,7 +674,7 @@ func TestLogTestModelCompleted(t *testing.T) {
 
 	m := insertTestModelForLog(t, h, "test-log-completed")
 
-	h.logTestModelCompleted(ctx, m, "reqhash003", 200, 2500, 100, 40, 8.5, 10, 3)
+	h.logTestModelCompleted(ctx, m, "reqhash003", 200, 2500, 100, 40, 8.5, 10, 3, "192.0.2.10")
 
 	var count int
 	err := h.dbPool.Pool().QueryRow(ctx,
@@ -727,7 +727,7 @@ func TestLogTestModelRequestError_InsertError(t *testing.T) {
 	m := insertTestModelForLog(t, h, "test-log-req-err-fail")
 
 	// This should not panic; the log insert failure is silently logged.
-	h.logTestModelRequestError(ctx, m, "reqhash-err-001", 1500, 200, 50, "connection refused")
+	h.logTestModelRequestError(ctx, m, "reqhash-err-001", 1500, 200, 50, "connection refused", "")
 
 	// Verify no row was inserted (since the context was cancelled).
 	var count int
@@ -752,7 +752,7 @@ func TestLogTestModelHTTPError_InsertError(t *testing.T) {
 
 	m := insertTestModelForLog(t, h, "test-log-http-err-fail")
 
-	h.logTestModelHTTPError(ctx, m, "reqhash-err-002", 429, 3000, 250, 30, "rate limited")
+	h.logTestModelHTTPError(ctx, m, "reqhash-err-002", 429, 3000, 250, 30, "rate limited", "")
 
 	// Verify no row was inserted.
 	var count int
@@ -777,7 +777,7 @@ func TestLogTestModelCompleted_InsertError(t *testing.T) {
 
 	m := insertTestModelForLog(t, h, "test-log-completed-fail")
 
-	h.logTestModelCompleted(ctx, m, "reqhash-err-003", 200, 2500, 100, 40, 8.5, 10, 3)
+	h.logTestModelCompleted(ctx, m, "reqhash-err-003", 200, 2500, 100, 40, 8.5, 10, 3, "")
 
 	// Verify no row was inserted.
 	var count int

--- a/internal/api/sort_whitelist_test.go
+++ b/internal/api/sort_whitelist_test.go
@@ -53,7 +53,7 @@ func TestModelSortColumn_Whitelist(t *testing.T) {
 func TestLogsSortDef_Whitelist(t *testing.T) {
 	valid := []string{
 		"time", "model", "provider", "status", "tokens", "tps", "ttft",
-		"response_header_ms", "duration", "overhead", "key",
+		"response_header_ms", "duration", "overhead", "key", "ip",
 	}
 	validSet := map[string]bool{}
 	for _, k := range valid {
@@ -79,6 +79,8 @@ func TestLogsSortDef_Whitelist(t *testing.T) {
 		"CASE WHEN rl.proxy_overhead_ms = 0 THEN 1 ELSE 0 END":  true,
 		"rl.proxy_overhead_ms":                                  true,
 		"CASE WHEN rl.virtual_key_id IS NOT NULL AND rl.virtual_key_id::text != '' AND vk.id IS NULL THEN 'zzzzzzzz' ELSE COALESCE(rl.virtual_key_name, '') END": true,
+		"CASE WHEN COALESCE(rl.client_ip, '') = '' THEN 1 ELSE 0 END":                                                                                            true,
+		"COALESCE(rl.client_ip, '')": true,
 	}
 	for _, in := range append(append([]string{}, valid...), hostileSortInputs...) {
 		_, def := logsSortDef(in)

--- a/internal/db/migrations/073_request_log_client_ip.sql
+++ b/internal/db/migrations/073_request_log_client_ip.sql
@@ -1,0 +1,7 @@
+-- client_ip is the proxied request's client address, resolved trusted-proxy
+-- aware at ingest (internal/clientip: forwarded headers are honored only when
+-- the TCP peer is a configured trusted proxy). Stored so key usage stays
+-- attributable for as long as the request-log retention window, instead of
+-- only in the fast-rotating app logs. NULL on rows predating this column and
+-- on rows whose ingest path had no client address.
+ALTER TABLE request_logs ADD COLUMN IF NOT EXISTS client_ip TEXT;

--- a/internal/db/migrations/074_request_log_vk_index.sql
+++ b/internal/db/migrations/074_request_log_vk_index.sql
@@ -1,0 +1,10 @@
+-- request_logs.virtual_key_id was deliberately unindexed while it only served
+-- the owner-scope disjunction (see migration 067's note). The Logs page now
+-- offers a first-class virtual-key filter dropdown, so every filtered page
+-- costs a predicate scan over the busiest table in the schema (data query
+-- plus its count twin); index the column the same way 067 indexed the filter
+-- it shipped. Partial for the same reason as idx_request_logs_owner: the
+-- filter is an equality match, which a NULL row can never satisfy, so
+-- indexing keyless rows would be pure overhead.
+CREATE INDEX IF NOT EXISTS idx_request_logs_virtual_key_id
+    ON request_logs (virtual_key_id) WHERE virtual_key_id IS NOT NULL;

--- a/internal/db/migrations/075_app_log_escaped.sql
+++ b/internal/db/migrations/075_app_log_escaped.sql
@@ -1,0 +1,8 @@
+-- escaped marks app_logs rows whose message was produced by the slog handler,
+-- i.e. whose attribute values use the flattened quoteLogValue encoding
+-- (spaces inside quoted values stored as \x20). The dashboard decodes that
+-- escaping for display ONLY on rows carrying this flag, so a legacy or raw
+-- line containing a literal \x20 is never altered: rows predating the column
+-- (and lines ingested through the legacy io.Writer path) stay FALSE and
+-- render verbatim.
+ALTER TABLE app_logs ADD COLUMN IF NOT EXISTS escaped BOOLEAN NOT NULL DEFAULT FALSE;

--- a/internal/db/migrations/076_app_log_attrs_at.sql
+++ b/internal/db/migrations/076_app_log_attrs_at.sql
@@ -1,5 +1,7 @@
--- attrs_at is the byte offset in app_logs.message where the encoded attribute
--- suffix begins, recorded by the slog handler that built the row. Everything
+-- attrs_at is the offset in app_logs.message where the encoded attribute
+-- suffix begins, recorded by the slog handler that built the row, counted in
+-- UTF-16 code units (the unit JavaScript strings index by, so the dashboard
+-- slices on the same boundary for non-ASCII text). Everything
 -- before it is raw developer-written message text; everything from it on is
 -- quoteLogValue output. The dashboard decodes the \x20 space escaping ONLY
 -- from this offset, so raw message text is never altered no matter what

--- a/internal/db/migrations/076_app_log_attrs_at.sql
+++ b/internal/db/migrations/076_app_log_attrs_at.sql
@@ -1,0 +1,8 @@
+-- attrs_at is the byte offset in app_logs.message where the encoded attribute
+-- suffix begins, recorded by the slog handler that built the row. Everything
+-- before it is raw developer-written message text; everything from it on is
+-- quoteLogValue output. The dashboard decodes the \x20 space escaping ONLY
+-- from this offset, so raw message text is never altered no matter what
+-- characters it contains, and attributes always decode. Meaningful only on
+-- rows with escaped = TRUE; legacy rows keep the default.
+ALTER TABLE app_logs ADD COLUMN IF NOT EXISTS attrs_at INTEGER NOT NULL DEFAULT 0;

--- a/internal/proxy/logging.go
+++ b/internal/proxy/logging.go
@@ -56,6 +56,7 @@ func (h *Handler) insertRequestLogAsync(logEntry *requestLogData) {
 	streaming := logEntry.streaming
 	virtualKeyName := logEntry.virtualKeyName
 	virtualKeyID := logEntry.virtualKeyID
+	clientIP := logEntry.clientIP
 	ownerUserID := logEntry.ownerUserID
 	failoverAttempt := logEntry.failoverAttempt
 	state := logEntry.state
@@ -88,10 +89,16 @@ func (h *Handler) insertRequestLogAsync(logEntry *requestLogData) {
 		if vkID == nil && ownerUserID != "" {
 			ownerID = ownerUserID
 		}
+		// NULL (not "") when the ingest path had no client address, so old and
+		// address-less rows look the same to the dashboard.
+		var ip any
+		if clientIP != "" {
+			ip = clientIP
+		}
 		_, err := h.dbPool.Exec(ctx, `
-			INSERT INTO request_logs (id, model_id, request_hash, streaming, virtual_key_name, virtual_key_id, failover_attempt, state, endpoint_type, owner_user_id)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
-			id, modelID, requestHash, streaming, virtualKeyName, vkID, failoverAttempt, state, endpointType, ownerID,
+			INSERT INTO request_logs (id, model_id, request_hash, streaming, virtual_key_name, virtual_key_id, failover_attempt, state, endpoint_type, owner_user_id, client_ip)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
+			id, modelID, requestHash, streaming, virtualKeyName, vkID, failoverAttempt, state, endpointType, ownerID, ip,
 		)
 		if err != nil {
 			debuglog.Error("proxy: failed to insert initial request log", "request_id", id, "error", err)

--- a/internal/proxy/logging_test.go
+++ b/internal/proxy/logging_test.go
@@ -2,6 +2,8 @@ package proxy
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -503,4 +505,48 @@ func TestUpdateRequestLog_SkipWaitForInsert(t *testing.T) {
 	// the async insert (which would hang since insertWg is never Done).
 	// The nil dbPool also prevents any DB operations.
 	h.updateRequestLog(logEntry, updateLogOption{skipWaitForInsert: true})
+}
+
+// TestInsertRequestLogAsync_PersistsClientIP verifies the resolved client IP
+// stamped on the log entry lands in request_logs.client_ip (NULL when empty).
+func TestInsertRequestLogAsync_PersistsClientIP(t *testing.T) {
+	h := newIntegrationHandler()
+	pool := testDB.Pool()
+	ctx := context.Background()
+
+	storedIP := func(logEntry *requestLogData) *string {
+		h.insertRequestLogAsync(logEntry)
+		h.WaitForInsert(logEntry)
+		var ip *string
+		if err := pool.QueryRow(ctx,
+			`SELECT client_ip FROM request_logs WHERE id = $1`, logEntry.id,
+		).Scan(&ip); err != nil {
+			t.Fatalf("read inserted row: %v", err)
+		}
+		return ip
+	}
+
+	withIP := storedIP(&requestLogData{modelID: uuid.NewString(), state: "pending", clientIP: "198.51.100.9"})
+	if withIP == nil || *withIP != "198.51.100.9" {
+		t.Errorf("client_ip = %v, want 198.51.100.9", withIP)
+	}
+
+	withoutIP := storedIP(&requestLogData{modelID: uuid.NewString(), state: "pending"})
+	if withoutIP != nil {
+		t.Errorf("client_ip = %q, want NULL for an empty client IP", *withoutIP)
+	}
+}
+
+// TestNewPendingRequestLog_StampsClientIP verifies the pending log entry is
+// created with the request's resolved client address.
+func TestNewPendingRequestLog_StampsClientIP(t *testing.T) {
+	h := &Handler{}
+
+	req := httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)
+	req.RemoteAddr = "198.51.100.7:51234"
+
+	logData, _ := h.newPendingRequestLog(req, endpointTypeChat, "gpt-4", false)
+	if logData.clientIP != "198.51.100.7" {
+		t.Errorf("clientIP = %q, want 198.51.100.7", logData.clientIP)
+	}
 }

--- a/internal/proxy/proxy_request.go
+++ b/internal/proxy/proxy_request.go
@@ -152,6 +152,7 @@ func (h *Handler) newPendingRequestLog(r *http.Request, endpointType, modelID st
 		streaming:       isStreaming,
 		virtualKeyName:  vkName,
 		virtualKeyID:    vkID,
+		clientIP:        clientip.From(r),
 		ownerUserID:     ownerUserID,
 		failoverAttempt: 0,
 		state:           "pending",

--- a/internal/proxy/types.go
+++ b/internal/proxy/types.go
@@ -132,6 +132,11 @@ type requestLogData struct {
 	streaming                 bool
 	virtualKeyName            string
 	virtualKeyID              string
+	// clientIP is the trusted-proxy-aware client address (internal/clientip),
+	// stamped when the pending row is created and persisted to
+	// request_logs.client_ip so key usage stays attributable for the whole
+	// log-retention window.
+	clientIP string
 	// ownerUserID is the owning dashboard user's UUID; "" for unowned keys
 	// (admin-only visibility). Persisted to request_logs.owner_user_id only when
 	// there is no virtual key (migration 067); keyed rows resolve their owner

--- a/tools/i18n-translate/allow-english.json
+++ b/tools/i18n-translate/allow-english.json
@@ -1850,6 +1850,9 @@
 		"tr",
 		"vi"
 	],
+	"components.virtualLogTable.ip": [
+		"*"
+	],
 	"components.virtualLogTable.model": [
 		"af",
 		"ca",
@@ -2923,6 +2926,9 @@
 		"sv",
 		"tr",
 		"vi"
+	],
+	"logs.table.ip": [
+		"*"
 	],
 	"logs.table.live": [
 		"da",

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -670,6 +670,8 @@ export const api = {
 				to?: string;
 				sort_by?: string;
 				sort_dir?: string;
+				/** Filter to a single virtual key's traffic. */
+				virtual_key_id?: string;
 				/** Admin-only filter: scope to keys owned by this user. */
 				owner_user_id?: string;
 			} = {},
@@ -686,6 +688,7 @@ export const api = {
 					to: params.to,
 					sort_by: params.sort_by,
 					sort_dir: params.sort_dir,
+					virtual_key_id: params.virtual_key_id,
 					owner_user_id: params.owner_user_id,
 				}),
 				{ headers: getAuthHeaders() },
@@ -724,6 +727,8 @@ export const api = {
 			from?: string;
 			to?: string;
 			sort_dir?: string;
+			/** Filter to a single virtual key's traffic. */
+			virtual_key_id?: string;
 			/** Admin-only filter: scope to keys owned by this user. */
 			owner_user_id?: string;
 		}): Promise<LogsCursorResponse> => {
@@ -739,6 +744,7 @@ export const api = {
 					from: params.from,
 					to: params.to,
 					sort_dir: params.sort_dir,
+					virtual_key_id: params.virtual_key_id,
 					owner_user_id: params.owner_user_id,
 				}),
 				{ headers: getAuthHeaders() },

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -666,6 +666,8 @@ export const api = {
 				sort_dir?: string;
 				/** Filter to a single virtual key's traffic. */
 				virtual_key_id?: string;
+				/** Filter to requests from one exact client address. */
+				client_ip?: string;
 				/** Admin-only filter: scope to keys owned by this user. */
 				owner_user_id?: string;
 			} = {},
@@ -683,6 +685,7 @@ export const api = {
 					sort_by: params.sort_by,
 					sort_dir: params.sort_dir,
 					virtual_key_id: params.virtual_key_id,
+					client_ip: params.client_ip,
 					owner_user_id: params.owner_user_id,
 				}),
 				{ headers: getAuthHeaders() },
@@ -723,6 +726,8 @@ export const api = {
 			sort_dir?: string;
 			/** Filter to a single virtual key's traffic. */
 			virtual_key_id?: string;
+			/** Filter to requests from one exact client address. */
+			client_ip?: string;
 			/** Admin-only filter: scope to keys owned by this user. */
 			owner_user_id?: string;
 		}): Promise<LogsCursorResponse> => {
@@ -739,6 +744,7 @@ export const api = {
 					to: params.to,
 					sort_dir: params.sort_dir,
 					virtual_key_id: params.virtual_key_id,
+					client_ip: params.client_ip,
 					owner_user_id: params.owner_user_id,
 				}),
 				{ headers: getAuthHeaders() },

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2,6 +2,7 @@ import type {
 	AlertEventDef,
 	AlertStatus,
 	AlertTargets,
+	AppLogEntry,
 	AppLogsCursorResponse,
 	AuditListResponse,
 	AuthSession,
@@ -55,13 +56,6 @@ import type {
 	VirtualKey,
 	ZAICodingQuotaResponse,
 } from "./types";
-
-export interface AppLogEntry {
-	timestamp: string;
-	level: "info" | "warning" | "error";
-	source: string;
-	message: string;
-}
 
 export const API_BASE = "";
 

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -113,6 +113,8 @@ export interface LogEntry {
 	virtual_key_name: string;
 	virtual_key_deleted?: boolean;
 	virtual_key_id?: string;
+	/** Trusted-proxy-aware client address; "" or absent for rows predating it. */
+	client_ip?: string;
 	error_message: string;
 	/** Machine-readable failure classification; "" or absent for legacy rows. */
 	error_kind?: string;

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -135,6 +135,9 @@ export interface AppLogEntry {
 	 * encoding (spaces as \x20); gates display-side decoding. Absent/false on
 	 * legacy rows and raw io.Writer lines, which render verbatim. */
 	escaped?: boolean;
+	/** Byte offset where the encoded attribute suffix begins; decoding applies
+	 * only from here, so raw message text is never altered. */
+	attrs_at?: number;
 }
 
 export interface LogsResponse {

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -131,6 +131,10 @@ export interface AppLogEntry {
 	level: "info" | "warning" | "error";
 	source: string;
 	message: string;
+	/** True when the message's attribute values use the backend's flattened
+	 * encoding (spaces as \x20); gates display-side decoding. Absent/false on
+	 * legacy rows and raw io.Writer lines, which render verbatim. */
+	escaped?: boolean;
 }
 
 export interface LogsResponse {

--- a/web/src/components/ErrorShelf/ErrorShelf.tsx
+++ b/web/src/components/ErrorShelf/ErrorShelf.tsx
@@ -11,6 +11,7 @@ import {
 import type { AppLogEntry, LogEntry } from "../../api/types";
 import { useToast } from "../../context/ToastContext";
 import { formatRelativeTime, formatTimestamp } from "../../utils/format";
+import { decodeLogEscapes } from "../../utils/logText";
 import { truncateWithEllipsis } from "../../utils/truncate";
 import { LogDetailModal } from "../LogDetailModal";
 import {
@@ -194,6 +195,7 @@ export function ErrorShelf() {
 										: isSsoSource(err.source)
 											? "sso"
 											: err.kind;
+								const displayMessage = decodeLogEscapes(err.message);
 								const chipLabel =
 									category === "ha"
 										? t("layout.errorShelf.haKind")
@@ -253,11 +255,11 @@ export function ErrorShelf() {
 										</div>
 										<p
 											className="ui-error-shelf-msg mt-0.5 break-words font-mono text-[9.5px] leading-relaxed text-[var(--error-text-muted)]"
-											title={err.message}
+											title={displayMessage}
 										>
-											{err.message.length > 200
-												? truncateWithEllipsis(err.message, 200)
-												: err.message}
+											{displayMessage.length > 200
+												? truncateWithEllipsis(displayMessage, 200)
+												: displayMessage}
 										</p>
 									</li>
 								);

--- a/web/src/components/ErrorShelf/ErrorShelf.tsx
+++ b/web/src/components/ErrorShelf/ErrorShelf.tsx
@@ -11,7 +11,7 @@ import {
 import type { AppLogEntry, LogEntry } from "../../api/types";
 import { useToast } from "../../context/ToastContext";
 import { formatRelativeTime, formatTimestamp } from "../../utils/format";
-import { decodeLogEscapes } from "../../utils/logText";
+import { displayLogMessage } from "../../utils/logText";
 import { truncateWithEllipsis } from "../../utils/truncate";
 import { LogDetailModal } from "../LogDetailModal";
 import {
@@ -195,7 +195,10 @@ export function ErrorShelf() {
 										: isSsoSource(err.source)
 											? "sso"
 											: err.kind;
-								const displayMessage = decodeLogEscapes(err.message);
+								const displayMessage = displayLogMessage(
+									err.message,
+									err.escaped,
+								);
 								const chipLabel =
 									category === "ha"
 										? t("layout.errorShelf.haKind")

--- a/web/src/components/ErrorShelf/ErrorShelf.tsx
+++ b/web/src/components/ErrorShelf/ErrorShelf.tsx
@@ -198,6 +198,7 @@ export function ErrorShelf() {
 								const displayMessage = displayLogMessage(
 									err.message,
 									err.escaped,
+									err.attrsAt,
 								);
 								const chipLabel =
 									category === "ha"

--- a/web/src/components/ErrorShelf/useErrorShelf.ts
+++ b/web/src/components/ErrorShelf/useErrorShelf.ts
@@ -78,6 +78,8 @@ export interface ShelfError {
 	/** True when the message uses the backend's flattened \x20 encoding
 	 * (app errors only); gates display-side decoding. */
 	escaped?: boolean;
+	/** Attribute-suffix offset for the decode (app errors only). */
+	attrsAt?: number;
 }
 
 function makeKey(kind: ShelfErrorKind, timestamp: string, message: string) {
@@ -260,6 +262,7 @@ export function useErrorShelf(): UseErrorShelf {
 				entry,
 				source: entry.source || undefined,
 				escaped: entry.escaped,
+				attrsAt: entry.attrs_at,
 			});
 		}
 

--- a/web/src/components/ErrorShelf/useErrorShelf.ts
+++ b/web/src/components/ErrorShelf/useErrorShelf.ts
@@ -75,6 +75,9 @@ export interface ShelfError {
 	errorKind?: string;
 	/** App-log emitter source (app errors only); drives the HA sub-category. */
 	source?: string;
+	/** True when the message uses the backend's flattened \x20 encoding
+	 * (app errors only); gates display-side decoding. */
+	escaped?: boolean;
 }
 
 function makeKey(kind: ShelfErrorKind, timestamp: string, message: string) {
@@ -256,6 +259,7 @@ export function useErrorShelf(): UseErrorShelf {
 				timestamp: entry.timestamp,
 				entry,
 				source: entry.source || undefined,
+				escaped: entry.escaped,
 			});
 		}
 

--- a/web/src/components/LogDetailModal.tsx
+++ b/web/src/components/LogDetailModal.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from "react-i18next";
 import { Activity, Calendar, FileText, Tag } from "@/lib/icons";
 import type { AppLogEntry, LogEntry } from "../api/types";
+import { decodeLogEscapes } from "../utils/logText";
 import { CopyablePill } from "./CopyablePill";
 import { DetailItem } from "./LogDetailItem";
 import { formatDateTime } from "./logDetailUtils";
@@ -67,7 +68,7 @@ function AppLogDetail({
 					label={t("components.appLogDetail.message")}
 					labelExtra={
 						<CopyablePill
-							text={log.message}
+							text={decodeLogEscapes(log.message)}
 							displayText={t("common.copy")}
 							tooltip={t("components.appLogDetail.copyMessage")}
 							textClassName="text-[11px] uppercase tracking-wider"
@@ -77,7 +78,7 @@ function AppLogDetail({
 				>
 					<MaybeJsonBlock
 						className="text-sm text-(--text-primary) font-mono whitespace-pre-wrap break-words bg-(--surface-elevated) p-3 rounded-(--radius-box) border border-(--border-subtle) max-h-60 overflow-y-auto"
-						text={log.message}
+						text={decodeLogEscapes(log.message)}
 					/>
 				</DetailItem>
 			</div>

--- a/web/src/components/LogDetailModal.tsx
+++ b/web/src/components/LogDetailModal.tsx
@@ -68,7 +68,7 @@ function AppLogDetail({
 					label={t("components.appLogDetail.message")}
 					labelExtra={
 						<CopyablePill
-							text={displayLogMessage(log.message, log.escaped)}
+							text={displayLogMessage(log.message, log.escaped, log.attrs_at)}
 							displayText={t("common.copy")}
 							tooltip={t("components.appLogDetail.copyMessage")}
 							textClassName="text-[11px] uppercase tracking-wider"
@@ -78,7 +78,7 @@ function AppLogDetail({
 				>
 					<MaybeJsonBlock
 						className="text-sm text-(--text-primary) font-mono whitespace-pre-wrap break-words bg-(--surface-elevated) p-3 rounded-(--radius-box) border border-(--border-subtle) max-h-60 overflow-y-auto"
-						text={displayLogMessage(log.message, log.escaped)}
+						text={displayLogMessage(log.message, log.escaped, log.attrs_at)}
 					/>
 				</DetailItem>
 			</div>

--- a/web/src/components/LogDetailModal.tsx
+++ b/web/src/components/LogDetailModal.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from "react-i18next";
 import { Activity, Calendar, FileText, Tag } from "@/lib/icons";
 import type { AppLogEntry, LogEntry } from "../api/types";
-import { decodeLogEscapes } from "../utils/logText";
+import { displayLogMessage } from "../utils/logText";
 import { CopyablePill } from "./CopyablePill";
 import { DetailItem } from "./LogDetailItem";
 import { formatDateTime } from "./logDetailUtils";
@@ -68,7 +68,7 @@ function AppLogDetail({
 					label={t("components.appLogDetail.message")}
 					labelExtra={
 						<CopyablePill
-							text={decodeLogEscapes(log.message)}
+							text={displayLogMessage(log.message, log.escaped)}
 							displayText={t("common.copy")}
 							tooltip={t("components.appLogDetail.copyMessage")}
 							textClassName="text-[11px] uppercase tracking-wider"
@@ -78,7 +78,7 @@ function AppLogDetail({
 				>
 					<MaybeJsonBlock
 						className="text-sm text-(--text-primary) font-mono whitespace-pre-wrap break-words bg-(--surface-elevated) p-3 rounded-(--radius-box) border border-(--border-subtle) max-h-60 overflow-y-auto"
-						text={decodeLogEscapes(log.message)}
+						text={displayLogMessage(log.message, log.escaped)}
 					/>
 				</DetailItem>
 			</div>

--- a/web/src/components/RequestLogDetail.tsx
+++ b/web/src/components/RequestLogDetail.tsx
@@ -8,6 +8,7 @@ import {
 	ChevronRight,
 	Clock,
 	Gauge,
+	Globe,
 	Hash,
 	Key,
 	Layers,
@@ -229,14 +230,18 @@ export function RequestLogDetail({
 					value={requestLog.provider_name}
 				/>
 				<DetailItem
-					icon={Hash}
-					label={t("components.requestLogDetail.dbRowId")}
+					icon={Globe}
+					label={t("components.requestLogDetail.clientIp")}
 				>
-					<CopyablePill
-						text={requestLog.id}
-						tooltip={t("components.requestLogDetail.copyDbRowId")}
-						textClassName="font-mono text-sm"
-					/>
+					{requestLog.client_ip ? (
+						<CopyablePill
+							text={requestLog.client_ip}
+							tooltip={t("components.requestLogDetail.copyClientIp")}
+							textClassName="font-mono text-sm"
+						/>
+					) : (
+						"-"
+					)}
 				</DetailItem>
 				<DetailItem
 					icon={Key}

--- a/web/src/components/VirtualAppLogTable.tsx
+++ b/web/src/components/VirtualAppLogTable.tsx
@@ -7,7 +7,7 @@ import {
 	getLevelBadgeVariant,
 	getSourceBadgeClasses,
 } from "../utils/logBadgeUtils";
-import { decodeLogEscapes } from "../utils/logText";
+import { displayLogMessage } from "../utils/logText";
 import { Badge } from "./Badge";
 
 interface VirtualAppLogTableProps {
@@ -266,7 +266,7 @@ export function VirtualAppLogTable(props: VirtualAppLogTableProps) {
 									<td className="px-2 py-1 align-middle">
 										<div className="min-h-[2lh] flex items-center">
 											<div className="text-xs font-mono line-clamp-2 text-gray-400">
-												{decodeLogEscapes(entry.message)}
+												{displayLogMessage(entry.message, entry.escaped)}
 											</div>
 										</div>
 									</td>

--- a/web/src/components/VirtualAppLogTable.tsx
+++ b/web/src/components/VirtualAppLogTable.tsx
@@ -7,6 +7,7 @@ import {
 	getLevelBadgeVariant,
 	getSourceBadgeClasses,
 } from "../utils/logBadgeUtils";
+import { decodeLogEscapes } from "../utils/logText";
 import { Badge } from "./Badge";
 
 interface VirtualAppLogTableProps {
@@ -265,7 +266,7 @@ export function VirtualAppLogTable(props: VirtualAppLogTableProps) {
 									<td className="px-2 py-1 align-middle">
 										<div className="min-h-[2lh] flex items-center">
 											<div className="text-xs font-mono line-clamp-2 text-gray-400">
-												{entry.message}
+												{decodeLogEscapes(entry.message)}
 											</div>
 										</div>
 									</td>

--- a/web/src/components/VirtualAppLogTable.tsx
+++ b/web/src/components/VirtualAppLogTable.tsx
@@ -266,7 +266,11 @@ export function VirtualAppLogTable(props: VirtualAppLogTableProps) {
 									<td className="px-2 py-1 align-middle">
 										<div className="min-h-[2lh] flex items-center">
 											<div className="text-xs font-mono line-clamp-2 text-gray-400">
-												{displayLogMessage(entry.message, entry.escaped)}
+												{displayLogMessage(
+													entry.message,
+													entry.escaped,
+													entry.attrs_at,
+												)}
 											</div>
 										</div>
 									</td>

--- a/web/src/components/VirtualLogTable.tsx
+++ b/web/src/components/VirtualLogTable.tsx
@@ -158,7 +158,7 @@ export function VirtualLogTable(props: VirtualLogTableProps) {
 						<tbody>
 							<tr>
 								<td
-									colSpan={11}
+									colSpan={12}
 									className="px-4 py-8 text-center text-gray-500 text-sm"
 								>
 									{t("components.virtualLogTable.noLogsFound")}
@@ -279,6 +279,12 @@ export function VirtualLogTable(props: VirtualLogTableProps) {
 								title={t("components.virtualLogTable.key")}
 							>
 								{t("components.virtualLogTable.key")}
+							</th>
+							<th
+								className={HEADER_BASE}
+								title={t("components.virtualLogTable.ip")}
+							>
+								{t("components.virtualLogTable.ip")}
 							</th>
 						</tr>
 					</thead>
@@ -465,6 +471,12 @@ export function VirtualLogTable(props: VirtualLogTableProps) {
 										) : (
 											log.virtual_key_name || log.virtual_key_id || "-"
 										)}
+									</td>
+									<td
+										className="px-2 py-1 whitespace-nowrap text-xs text-gray-400 font-mono truncate"
+										title={log.client_ip || undefined}
+									>
+										{log.client_ip || "-"}
 									</td>
 								</tr>
 							);

--- a/web/src/components/__tests__/LogDetailModal.decodeEscapes.test.tsx
+++ b/web/src/components/__tests__/LogDetailModal.decodeEscapes.test.tsx
@@ -13,6 +13,7 @@ const baseLog: AppLogEntry = {
 	level: "info",
 	source: "discovery",
 	message: 'account fetched provider="Ollama\\x20Cloud" plan=pro',
+	attrs_at: 15,
 };
 
 describe("LogDetailModal app-log escape decoding", () => {
@@ -28,6 +29,30 @@ describe("LogDetailModal app-log escape decoding", () => {
 			screen.getByText('account fetched provider="Ollama Cloud" plan=pro'),
 		).toBeInTheDocument();
 		expect(screen.queryByText(/Ollama\\x20Cloud/)).not.toBeInTheDocument();
+	});
+
+	it("decodes only the attribute suffix, never the raw message text", () => {
+		// The message portion itself carries an attribute-shaped literal; the
+		// attrs_at boundary keeps it verbatim while the real attributes after
+		// it still decode.
+		renderWithProviders(
+			<LogDetailModal
+				log={{
+					...baseLog,
+					message:
+						'literal path="\\x20evidence" in text provider="Ollama\\x20Cloud"',
+					attrs_at: 35,
+					escaped: true,
+				}}
+				type="app"
+				onClose={() => {}}
+			/>,
+		);
+		expect(
+			screen.getByText(
+				'literal path="\\x20evidence" in text provider="Ollama Cloud"',
+			),
+		).toBeInTheDocument();
 	});
 
 	it("renders unflagged (legacy/raw) rows verbatim", () => {

--- a/web/src/components/__tests__/LogDetailModal.decodeEscapes.test.tsx
+++ b/web/src/components/__tests__/LogDetailModal.decodeEscapes.test.tsx
@@ -1,0 +1,27 @@
+import { screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { AppLogEntry } from "../../api/types";
+import { renderWithProviders } from "../../test/utils";
+import { LogDetailModal } from "../LogDetailModal";
+
+// App-log attribute values escape their spaces as \x20 in the stored line
+// (log-injection defense); the dashboard shows the human form.
+
+const escapedLog: AppLogEntry = {
+	timestamp: "2026-08-23T10:00:00Z",
+	level: "info",
+	source: "discovery",
+	message: 'account fetched provider="Ollama\\x20Cloud" plan=pro',
+};
+
+describe("LogDetailModal app-log escape decoding", () => {
+	it("renders \\x20-escaped attribute values with real spaces", () => {
+		renderWithProviders(
+			<LogDetailModal log={escapedLog} type="app" onClose={() => {}} />,
+		);
+		expect(
+			screen.getByText('account fetched provider="Ollama Cloud" plan=pro'),
+		).toBeInTheDocument();
+		expect(screen.queryByText(/Ollama\\x20Cloud/)).not.toBeInTheDocument();
+	});
+});

--- a/web/src/components/__tests__/LogDetailModal.decodeEscapes.test.tsx
+++ b/web/src/components/__tests__/LogDetailModal.decodeEscapes.test.tsx
@@ -5,9 +5,10 @@ import { renderWithProviders } from "../../test/utils";
 import { LogDetailModal } from "../LogDetailModal";
 
 // App-log attribute values escape their spaces as \x20 in the stored line
-// (log-injection defense); the dashboard shows the human form.
+// (log-injection defense); the dashboard shows the human form, but only for
+// rows the backend marked as using the flattened encoding (escaped=true).
 
-const escapedLog: AppLogEntry = {
+const baseLog: AppLogEntry = {
 	timestamp: "2026-08-23T10:00:00Z",
 	level: "info",
 	source: "discovery",
@@ -15,13 +16,30 @@ const escapedLog: AppLogEntry = {
 };
 
 describe("LogDetailModal app-log escape decoding", () => {
-	it("renders \\x20-escaped attribute values with real spaces", () => {
+	it("renders \\x20-escaped attribute values with real spaces on flagged rows", () => {
 		renderWithProviders(
-			<LogDetailModal log={escapedLog} type="app" onClose={() => {}} />,
+			<LogDetailModal
+				log={{ ...baseLog, escaped: true }}
+				type="app"
+				onClose={() => {}}
+			/>,
 		);
 		expect(
 			screen.getByText('account fetched provider="Ollama Cloud" plan=pro'),
 		).toBeInTheDocument();
 		expect(screen.queryByText(/Ollama\\x20Cloud/)).not.toBeInTheDocument();
+	});
+
+	it("renders unflagged (legacy/raw) rows verbatim", () => {
+		// A row without the provenance flag never went through the flattened
+		// encoder, so its \x20 is raw evidence and must not be altered.
+		renderWithProviders(
+			<LogDetailModal
+				log={{ ...baseLog, message: 'legacy path="\\x20evidence"' }}
+				type="app"
+				onClose={() => {}}
+			/>,
+		);
+		expect(screen.getByText('legacy path="\\x20evidence"')).toBeInTheDocument();
 	});
 });

--- a/web/src/components/__tests__/LogDetailModal.test.tsx
+++ b/web/src/components/__tests__/LogDetailModal.test.tsx
@@ -312,17 +312,17 @@ describe("LogDetailModal", () => {
 			expect(screen.getByText("Ollama Cloud")).toBeInTheDocument();
 		});
 
-		it("displays DB row ID with copy button", () => {
+		it("displays the client IP with copy button", () => {
 			renderWithProviders(
 				<LogDetailModal
-					log={mockRequestLog}
+					log={{ ...mockRequestLog, client_ip: "203.0.113.7" }}
 					type="request"
 					onClose={onClose}
 				/>,
 			);
 
-			expect(screen.getByText("DB Row ID")).toBeInTheDocument();
-			expect(screen.getByText("req-123")).toBeInTheDocument();
+			expect(screen.getByText("Client IP")).toBeInTheDocument();
+			expect(screen.getByText("203.0.113.7")).toBeInTheDocument();
 		});
 
 		it("displays virtual key name", () => {
@@ -643,21 +643,21 @@ describe("LogDetailModal", () => {
 			expect(clipboardText).toBe("gemma3:4b");
 		});
 
-		it("copies DB row ID to clipboard", async () => {
+		it("copies the client IP to clipboard", async () => {
 			const user = userEvent.setup();
 			renderWithProviders(
 				<LogDetailModal
-					log={mockRequestLog}
+					log={{ ...mockRequestLog, client_ip: "203.0.113.7" }}
 					type="request"
 					onClose={onClose}
 				/>,
 			);
 
-			const copyButton = screen.getByLabelText("Copy DB row ID");
+			const copyButton = screen.getByLabelText("Copy client IP");
 			await user.click(copyButton);
 
 			const clipboardText = await navigator.clipboard.readText();
-			expect(clipboardText).toBe("req-123");
+			expect(clipboardText).toBe("203.0.113.7");
 		});
 
 		it("copies error message to clipboard", async () => {

--- a/web/src/components/__tests__/RequestLogDetail.clientIp.test.tsx
+++ b/web/src/components/__tests__/RequestLogDetail.clientIp.test.tsx
@@ -1,0 +1,76 @@
+import { screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { LogEntry } from "../../api/types";
+import { renderWithProviders } from "../../test/utils";
+import { RequestLogDetail } from "../RequestLogDetail";
+
+const baseLog: LogEntry = {
+	id: "test-id",
+	provider_id: "prov-1",
+	provider_name: "test-provider",
+	model_id: "model-1",
+	request_hash: "hash123",
+	status_code: 200,
+	latency_ms: 500,
+	duration_ms: 500,
+	ttft_ms: 100,
+	response_header_ms: 50,
+	proxy_overhead_ms: 0,
+	parse_ms: 1.0,
+	failover_lookup_ms: 0.5,
+	model_lookup_ms: 0.5,
+	provider_lookup_ms: 0.5,
+	key_decrypt_ms: 0.5,
+	dial_ms: 10.0,
+	settings_read_ms: 0.5,
+	cache_hits: null,
+	tokens_per_second: null,
+	tokens_prompt: 0,
+	tokens_completion: 0,
+	tokens_prompt_cache_hit: 0,
+	tokens_prompt_cache_miss: 0,
+	tokens_completion_reasoning: 0,
+	streaming: false,
+	state: "completed",
+	virtual_key_name: "test-key",
+	error_message: "",
+	failover_attempt: 0,
+	created_at: "2024-01-01T00:00:00Z",
+	resolved_model_id: "",
+	endpoint_type: "chat",
+};
+
+const onClose = () => {};
+
+describe("RequestLogDetail client IP", () => {
+	it("shows the client IP where the DB row id used to be", () => {
+		renderWithProviders(
+			<RequestLogDetail
+				requestLog={{ ...baseLog, client_ip: "203.0.113.7" }}
+				onClose={onClose}
+			/>,
+		);
+		expect(screen.getByText("Client IP")).toBeInTheDocument();
+		expect(screen.getByText("203.0.113.7")).toBeInTheDocument();
+		// The DB row id cell is gone entirely.
+		expect(screen.queryByText("DB Row ID")).not.toBeInTheDocument();
+		expect(screen.queryByText("test-id")).not.toBeInTheDocument();
+	});
+
+	it("falls back to a dash for rows without a stored IP", () => {
+		// Fill every other tile so the IP cell renders the only dash.
+		renderWithProviders(
+			<RequestLogDetail
+				requestLog={{
+					...baseLog,
+					tokens_prompt: 100,
+					tokens_completion: 50,
+					tokens_per_second: 12,
+				}}
+				onClose={onClose}
+			/>,
+		);
+		expect(screen.getByText("Client IP")).toBeInTheDocument();
+		expect(screen.getByText("-")).toBeInTheDocument();
+	});
+});

--- a/web/src/components/__tests__/VirtualLogTable.ipcolumn.test.tsx
+++ b/web/src/components/__tests__/VirtualLogTable.ipcolumn.test.tsx
@@ -1,0 +1,112 @@
+import { screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { LogEntry } from "../../api/types";
+import { renderWithProviders } from "../../test/utils";
+import { VirtualLogTable } from "../VirtualLogTable";
+
+const mockGetVirtualItems = vi.fn();
+const mockGetTotalSize = vi.fn();
+const mockMeasureElement = vi.fn();
+
+vi.mock("@tanstack/react-virtual", () => ({
+	useVirtualizer: vi.fn(() => ({
+		getVirtualItems: mockGetVirtualItems,
+		getTotalSize: mockGetTotalSize,
+		measureElement: mockMeasureElement,
+	})),
+}));
+
+function createLogEntry(overrides: Partial<LogEntry> = {}): LogEntry {
+	return {
+		id: "log-1",
+		provider_id: "prov-1",
+		provider_name: "Test Provider",
+		model_id: "test-provider/model-v1",
+		request_hash: "abc123def456",
+		status_code: 200,
+		latency_ms: 150,
+		duration_ms: 200,
+		ttft_ms: 50,
+		response_header_ms: 50,
+		proxy_overhead_ms: 5,
+		parse_ms: 1,
+		failover_lookup_ms: 0,
+		model_lookup_ms: 1,
+		provider_lookup_ms: 1,
+		key_decrypt_ms: 2,
+		dial_ms: 10,
+		settings_read_ms: 1,
+		tokens_per_second: 25.5,
+		tokens_prompt: 100,
+		tokens_completion: 50,
+		tokens_prompt_cache_hit: 0,
+		tokens_prompt_cache_miss: 100,
+		tokens_completion_reasoning: 0,
+		streaming: true,
+		state: "completed",
+		virtual_key_name: "test-key",
+		virtual_key_id: "vk-1",
+		error_message: "",
+		failover_attempt: 0,
+		created_at: "2026-05-23T10:00:00Z",
+		resolved_model_id: "",
+		endpoint_type: "chat",
+		...overrides,
+	};
+}
+
+const defaultProps = {
+	entries: [] as LogEntry[],
+	total: 0,
+	hasBefore: false,
+	hasAfter: false,
+	isLoadingBefore: false,
+	isLoadingAfter: false,
+	onFetchNewer: vi.fn(),
+	onFetchOlder: vi.fn(),
+	onRowClick: vi.fn(),
+	nowMs: Date.now(),
+	staleThresholdMs: 30 * 60 * 1000,
+	sortDir: "desc" as const,
+	onSortToggle: vi.fn(),
+};
+
+describe("VirtualLogTable IP column", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockGetVirtualItems.mockReturnValue([]);
+		mockGetTotalSize.mockReturnValue(0);
+		mockMeasureElement.mockImplementation(() => {});
+	});
+
+	it("renders the IP header and the entry's client IP", () => {
+		const entries = [createLogEntry({ client_ip: "203.0.113.7" })];
+		mockGetVirtualItems.mockReturnValue([
+			{ index: 0, key: entries[0].id, start: 0, end: 29 },
+		]);
+		mockGetTotalSize.mockReturnValue(29);
+
+		renderWithProviders(
+			<VirtualLogTable {...defaultProps} entries={entries} total={1} />,
+		);
+
+		expect(screen.getByText("IP")).toBeInTheDocument();
+		expect(screen.getByText("203.0.113.7")).toBeInTheDocument();
+	});
+
+	it("renders a dash for entries without a stored IP", () => {
+		// Every other cell of this entry has a non-dash value, so the only "-"
+		// in the row is the IP cell's fallback.
+		const entries = [createLogEntry()];
+		mockGetVirtualItems.mockReturnValue([
+			{ index: 0, key: entries[0].id, start: 0, end: 29 },
+		]);
+		mockGetTotalSize.mockReturnValue(29);
+
+		renderWithProviders(
+			<VirtualLogTable {...defaultProps} entries={entries} total={1} />,
+		);
+
+		expect(screen.getByText("-")).toBeInTheDocument();
+	});
+});

--- a/web/src/components/__tests__/VirtualLogTable.test.tsx
+++ b/web/src/components/__tests__/VirtualLogTable.test.tsx
@@ -280,7 +280,10 @@ describe("VirtualLogTable", () => {
 		});
 
 		it('renders "-" when provider_name is empty', () => {
-			const entries = [createLogEntry({ provider_name: "" })];
+			// client_ip is set so the provider cell renders the row's only "-".
+			const entries = [
+				createLogEntry({ provider_name: "", client_ip: "198.51.100.1" }),
+			];
 			mockGetVirtualItems.mockReturnValue([
 				{ index: 0, key: entries[0].id, start: 0, end: 29 },
 			]);
@@ -1437,23 +1440,24 @@ describe("VirtualLogTable", () => {
 
 			expect(screen.getByText("vk-abc123")).toBeInTheDocument();
 
-			// Find the key column cell (last column in the row)
+			// Find the key column cell (second-to-last column, before IP)
 			const row = screen.getByText("vk-abc123").closest("tr");
 			expect(row).not.toBeNull();
 			if (row) {
 				const cells = row.querySelectorAll("td");
-				// Key column is the last column
-				const keyCell = cells[cells.length - 1];
+				const keyCell = cells[cells.length - 2];
 				expect(keyCell).toHaveAttribute("title", "vk-abc123");
 			}
 		});
 
 		it("does NOT set title attribute when virtual_key_name and virtual_key_id are both empty", () => {
+			// client_ip is set so the key cell renders the row's only "-".
 			const entries = [
 				createLogEntry({
 					virtual_key_deleted: false,
 					virtual_key_name: "",
 					virtual_key_id: "",
+					client_ip: "198.51.100.1",
 				}),
 			];
 			mockGetVirtualItems.mockReturnValue([
@@ -1468,13 +1472,12 @@ describe("VirtualLogTable", () => {
 			// The cell should show "-" as fallback
 			expect(screen.getByText("-")).toBeInTheDocument();
 
-			// Find the key column cell (last column in the row)
+			// Find the key column cell (second-to-last column, before IP)
 			const row = screen.getByText("-").closest("tr");
 			expect(row).not.toBeNull();
 			if (row) {
 				const cells = row.querySelectorAll("td");
-				// Key column is the last column
-				const keyCell = cells[cells.length - 1];
+				const keyCell = cells[cells.length - 2];
 				expect(keyCell).not.toHaveAttribute("title");
 			}
 		});

--- a/web/src/components/logTableWidths.ts
+++ b/web/src/components/logTableWidths.ts
@@ -3,12 +3,14 @@
  *  Edit here once — both modes stay in sync.
  *
  *  Budgeted for the 1440p layout the dashboard targets, where the centered
- *  content column gives the table ~1340px: the widths below sum to just under
- *  that (one Tailwind unit renders at 4.25px under the app's 17px root font
- *  size), so at that size every column renders at its declared width with no
- *  horizontal scroll. In fixed table layout the column sum acts as a MINIMUM
- *  table width, so a sum past the card budget makes the card scroll sideways.
- *  Two costs drive the numbers:
+ *  content column gives the table ~1340px. Each column is a PERCENTAGE of the
+ *  table and the twelve sum to exactly 100%, so the table is always precisely
+ *  the card's width: in fixed table layout an absolute column sum acts as a
+ *  MINIMUM table width, and an absolute budget solved at one root font size
+ *  overshot the card by a pixel at another (the 1080p root font is 16px, the
+ *  1440p one 17px), leaving a horizontal scrollbar that scrolled nowhere.
+ *  The percentages are the 1440p pixel budget below, normalised. Two costs
+ *  drive that budget:
  *  - paginated headers (SortableHeader) spend px-4 padding plus a reserved
  *    sort-arrow slot: label text + ~48px;
  *  - mono cells at the 12px table size run ~7.2px per character plus the
@@ -19,16 +21,16 @@
  *  with its tooltip. Below the 1440p budget the table scales down evenly and
  *  headers ellipsize (+ title tooltip) as the safety net, min-w-250 last. */
 export const LOG_COL_WIDTHS = [
-	{ key: "date", width: "w-38" }, // Time/Date - "23/08/2026, 22:59:28" (20ch mono)
-	{ key: "model", width: "w-35.5" }, // Model (truncates long names; takes the leftover)
-	{ key: "provider", width: "w-26.5" }, // Provider - "PROVIDER" header
-	{ key: "status", width: "w-22.5" }, // Status - "STATUS" header
-	{ key: "tokens", width: "w-24.25" }, // Tokens - "99,999+9,999" (12ch)
-	{ key: "tps", width: "w-16" }, // T/s
-	{ key: "headers", width: "w-25" }, // Headers - "HEADERS" header
-	{ key: "ttft", width: "w-18.75" }, // TTFT
-	{ key: "duration", width: "w-26.75" }, // Duration - "DURATION" header
-	{ key: "overhead", width: "w-27.75" }, // Overhead - "OVERHEAD" header
-	{ key: "key", width: "w-23.75" }, // Key (truncates; cell is max-w-[7rem])
-	{ key: "ip", width: "w-31" }, // IP - full IPv4 (15ch); IPv6 truncates
+	{ key: "date", width: "w-[12.03%]" }, // Time/Date - "23/08/2026, 22:59:28" (20ch mono, ~162px)
+	{ key: "model", width: "w-[11.24%]" }, // Model (truncates long names; takes the leftover, ~151px)
+	{ key: "provider", width: "w-[8.39%]" }, // Provider - "PROVIDER" header (~113px)
+	{ key: "status", width: "w-[7.13%]" }, // Status - "STATUS" header (~96px)
+	{ key: "tokens", width: "w-[7.68%]" }, // Tokens - "99,999+9,999" (12ch, ~103px)
+	{ key: "tps", width: "w-[5.07%]" }, // T/s (~68px)
+	{ key: "headers", width: "w-[7.92%]" }, // Headers - "HEADERS" header (~106px)
+	{ key: "ttft", width: "w-[5.94%]" }, // TTFT (~80px)
+	{ key: "duration", width: "w-[8.47%]" }, // Duration - "DURATION" header (~114px)
+	{ key: "overhead", width: "w-[8.79%]" }, // Overhead - "OVERHEAD" header (~118px)
+	{ key: "key", width: "w-[7.52%]" }, // Key (truncates; cell is max-w-[7rem], ~101px)
+	{ key: "ip", width: "w-[9.82%]" }, // IP - full IPv4 (15ch, ~132px); IPv6 truncates
 ] as const;

--- a/web/src/components/logTableWidths.ts
+++ b/web/src/components/logTableWidths.ts
@@ -1,25 +1,34 @@
 /** Shared column definitions for the requests/logs table.
  *  Used by both Logs.tsx (paginated) and VirtualLogTable.tsx (scroll).
  *  Edit here once — both modes stay in sync.
- *  Sized against mono digits at the 12px table size (numeric cells are
- *  font-mono in every theme, so the budget is theme-independent):
- *  ~7.2px per character plus the 16px px-2 cell padding.
  *
- *  A couple of columns (status, duration) are budgeted for their HEADER word
- *  rather than their short data so the English labels don't truncate; the
- *  borrowed width comes from model/key, which already truncate their long
- *  values anyway. Total stays ~constant so the table width is unchanged.
- *  Headers ellipsize (+ title tooltip) as the safety net for longer locales. */
+ *  Budgeted for the 1440p layout the dashboard targets, where the centered
+ *  content column gives the table ~1340px: the widths below sum to just under
+ *  that (one Tailwind unit renders at 4.25px under the app's 17px root font
+ *  size), so at that size every column renders at its declared width with no
+ *  horizontal scroll. In fixed table layout the column sum acts as a MINIMUM
+ *  table width, so a sum past the card budget makes the card scroll sideways.
+ *  Two costs drive the numbers:
+ *  - paginated headers (SortableHeader) spend px-4 padding plus a reserved
+ *    sort-arrow slot: label text + ~48px;
+ *  - mono cells at the 12px table size run ~7.2px per character plus the
+ *    16px px-2 cell padding.
+ *  Each column takes max(header, widest expected cell). Model and key
+ *  truncate long values by design (title tooltip carries the rest), and the
+ *  IP column fits a full IPv4 ("255.255.255.255", 15ch) while IPv6 truncates
+ *  with its tooltip. Below the 1440p budget the table scales down evenly and
+ *  headers ellipsize (+ title tooltip) as the safety net, min-w-250 last. */
 export const LOG_COL_WIDTHS = [
-	{ key: "date", width: "w-38" }, // Time/Date - "12/06/2026, 10:45:12" (20ch)
-	{ key: "model", width: "w-48" }, // Model (truncates long names)
-	{ key: "provider", width: "w-25" }, // Provider
-	{ key: "status", width: "w-17" }, // Status - fits the "STATUS" header
-	{ key: "tokens", width: "w-27" }, // Tokens - "99,999+9,999" (12ch)
-	{ key: "tps", width: "w-18.25" }, // T/s
-	{ key: "headers", width: "w-20.75" }, // Headers (response_header_ms)
-	{ key: "ttft", width: "w-20.75" }, // TTFT
-	{ key: "duration", width: "w-20" }, // Duration - fits the "DURATION" header
-	{ key: "overhead", width: "w-19.5" }, // Overhead
-	{ key: "key", width: "w-24" }, // Key (truncates; cell is max-w-[7rem])
+	{ key: "date", width: "w-38" }, // Time/Date - "23/08/2026, 22:59:28" (20ch mono)
+	{ key: "model", width: "w-35.5" }, // Model (truncates long names; takes the leftover)
+	{ key: "provider", width: "w-26.5" }, // Provider - "PROVIDER" header
+	{ key: "status", width: "w-22.5" }, // Status - "STATUS" header
+	{ key: "tokens", width: "w-24.25" }, // Tokens - "99,999+9,999" (12ch)
+	{ key: "tps", width: "w-16" }, // T/s
+	{ key: "headers", width: "w-25" }, // Headers - "HEADERS" header
+	{ key: "ttft", width: "w-18.75" }, // TTFT
+	{ key: "duration", width: "w-26.75" }, // Duration - "DURATION" header
+	{ key: "overhead", width: "w-27.75" }, // Overhead - "OVERHEAD" header
+	{ key: "key", width: "w-23.75" }, // Key (truncates; cell is max-w-[7rem])
+	{ key: "ip", width: "w-31" }, // IP - full IPv4 (15ch); IPv6 truncates
 ] as const;

--- a/web/src/i18n/locales/af.json
+++ b/web/src/i18n/locales/af.json
@@ -1304,7 +1304,9 @@
 			"allStatus": "Alle statusse",
 			"allEndpoints": "Alle modaliteite",
 			"owner": "Eienaar",
-			"allOwners": "Alle gebruikers"
+			"allOwners": "Alle gebruikers",
+			"key": "Virtuele sleutel",
+			"allKeys": "Alle sleutels"
 		},
 		"endpoint": {
 			"chat": "Klets",
@@ -1333,7 +1335,8 @@
 			"live": "Regstreeks",
 			"interrupted": "onderbroke",
 			"cacheInflated": "Opgeblaas deur opdrag-kastreffers",
-			"keyDeleted": "Verwyder"
+			"keyDeleted": "Verwyder",
+			"ip": "IP"
 		},
 		"tooltip": {
 			"timeDate": "Tydstempel van die versoek",
@@ -1357,7 +1360,8 @@
 			"keyDecryption": "Sleutelontsleuteling",
 			"dial": "Dial (DNS+TCP)",
 			"settingsReads": "Instellings lees",
-			"reused": "hergebruik"
+			"reused": "hergebruik",
+			"ip": "Kliënt-IP-adres waarvandaan die versoek gekom het"
 		},
 		"status": {
 			"interrupted": "onderbroke"
@@ -2721,9 +2725,7 @@
 			"copyModelId": "Kopieer model-ID",
 			"resolved": "opgelos",
 			"provider": "Verskaffer",
-			"dbRowId": "DB-ry-ID",
 			"timestamp": "Tydstempel",
-			"copyDbRowId": "Kopieer DB-ry-ID",
 			"virtualKey": "Virtuele Sleutel",
 			"tokenUsage": "Tokengebruik",
 			"prompt": "Opdrag",
@@ -2753,7 +2755,9 @@
 			"error": "Fout",
 			"copyErrorMessage": "Kopieer foutboodskap",
 			"expandForBreakdown": "Brei uit vir die stap-vir-stap-uiteensetting",
-			"performance": "Prestasie"
+			"performance": "Prestasie",
+			"clientIp": "Kliënt-IP",
+			"copyClientIp": "Kopieer kliënt-IP"
 		},
 		"statusBadge": {
 			"streaming": "Stroom",
@@ -2794,7 +2798,8 @@
 			"internal": "intern",
 			"cacheInflated": "Opgeblaas deur opdrag-kastreffers",
 			"deleted": "Verwyder",
-			"zeroEntries": "0 inskrywings"
+			"zeroEntries": "0 inskrywings",
+			"ip": "IP"
 		},
 		"virtualAppLogTable": {
 			"noEntriesFound": "Geen loginskrywings gevind nie",

--- a/web/src/i18n/locales/ar.json
+++ b/web/src/i18n/locales/ar.json
@@ -1472,7 +1472,9 @@
 			"allStatus": "جميع الحالات",
 			"allEndpoints": "جميع الأنماط",
 			"owner": "المالك",
-			"allOwners": "كل المستخدمين"
+			"allOwners": "كل المستخدمين",
+			"key": "المفتاح الافتراضي",
+			"allKeys": "كل المفاتيح"
 		},
 		"endpoint": {
 			"chat": "الدردشة",
@@ -1501,7 +1503,8 @@
 			"live": "مباشر",
 			"interrupted": "مقطوع",
 			"cacheInflated": "متضخم بسبب إصابات ذاكرة الموجّهات المؤقتة",
-			"keyDeleted": "محذوف"
+			"keyDeleted": "محذوف",
+			"ip": "IP"
 		},
 		"tooltip": {
 			"timeDate": "الطابع الزمني للطلب",
@@ -1525,7 +1528,8 @@
 			"keyDecryption": "فك تشفير المفتاح",
 			"dial": "الاتصال (DNS+TCP)",
 			"settingsReads": "قراءة الإعدادات",
-			"reused": "إعادة الاستخدام"
+			"reused": "إعادة الاستخدام",
+			"ip": "عنوان IP للعميل الذي جاء منه الطلب"
 		},
 		"status": {
 			"interrupted": "مقطوع"
@@ -2961,9 +2965,7 @@
 			"copyModelId": "نسخ معرف النموذج",
 			"resolved": "تم الحل",
 			"provider": "موفر",
-			"dbRowId": "معرف صف DB",
 			"timestamp": "الطابع الزمني",
-			"copyDbRowId": "نسخ معرف صف DB",
 			"virtualKey": "المفتاح الافتراضي",
 			"tokenUsage": "استخدام الرمز",
 			"prompt": "Prompt",
@@ -2993,7 +2995,9 @@
 			"error": "خطأ",
 			"copyErrorMessage": "نسخ رسالة الخطأ",
 			"expandForBreakdown": "وسّع لعرض التفصيل لكل خطوة",
-			"performance": "الأداء"
+			"performance": "الأداء",
+			"clientIp": "IP العميل",
+			"copyClientIp": "نسخ IP العميل"
 		},
 		"statusBadge": {
 			"streaming": "البث",
@@ -3034,7 +3038,8 @@
 			"internal": "داخلي",
 			"cacheInflated": "متضخم بسبب إصابات ذاكرة الموجّهات المؤقتة",
 			"deleted": "محذوف",
-			"zeroEntries": "0 إدخالات"
+			"zeroEntries": "0 إدخالات",
+			"ip": "IP"
 		},
 		"virtualAppLogTable": {
 			"noEntriesFound": "لم يتم العثور على إدخالات السجل",

--- a/web/src/i18n/locales/ca.json
+++ b/web/src/i18n/locales/ca.json
@@ -1346,7 +1346,9 @@
 			"allStatus": "Tots els estats",
 			"allEndpoints": "Totes les modalitats",
 			"owner": "Propietari",
-			"allOwners": "Tots els usuaris"
+			"allOwners": "Tots els usuaris",
+			"key": "Clau virtual",
+			"allKeys": "Totes les claus"
 		},
 		"endpoint": {
 			"chat": "Xat",
@@ -1375,7 +1377,8 @@
 			"live": "En directe",
 			"interrupted": "Interromput",
 			"cacheInflated": "Inflat pels encerts de memòria cau del prompt",
-			"keyDeleted": "Eliminat"
+			"keyDeleted": "Eliminat",
+			"ip": "IP"
 		},
 		"tooltip": {
 			"timeDate": "Segell de temps de la sol·licitud",
@@ -1399,7 +1402,8 @@
 			"keyDecryption": "Desxifratge de la clau",
 			"dial": "Connexió (DNS+TCP)",
 			"settingsReads": "Lectures de configuració",
-			"reused": "reutilitzat"
+			"reused": "reutilitzat",
+			"ip": "Adreça IP del client des d'on va arribar la sol·licitud"
 		},
 		"status": {
 			"interrupted": "Interromput"
@@ -2781,9 +2785,7 @@
 			"copyModelId": "Copia l'ID del model",
 			"resolved": "resolt",
 			"provider": "Proveïdor",
-			"dbRowId": "ID de fila de DB",
 			"timestamp": "Segell de temps",
-			"copyDbRowId": "Copia l'ID de fila de la base de dades",
 			"virtualKey": "Clau virtual",
 			"tokenUsage": "Ús de tokens",
 			"prompt": "Instrucció",
@@ -2813,7 +2815,9 @@
 			"error": "Error",
 			"copyErrorMessage": "Copiar missatge d'error",
 			"expandForBreakdown": "Desplega per veure el desglossament per passos",
-			"performance": "Rendiment"
+			"performance": "Rendiment",
+			"clientIp": "IP del client",
+			"copyClientIp": "Copia la IP del client"
 		},
 		"statusBadge": {
 			"streaming": "Streaming",
@@ -2854,7 +2858,8 @@
 			"internal": "intern",
 			"cacheInflated": "Inflat pels encerts de memòria cau del prompt",
 			"deleted": "Eliminat",
-			"zeroEntries": "0 entrades"
+			"zeroEntries": "0 entrades",
+			"ip": "IP"
 		},
 		"virtualAppLogTable": {
 			"noEntriesFound": "No s'han trobat entrades de registre",

--- a/web/src/i18n/locales/cs.json
+++ b/web/src/i18n/locales/cs.json
@@ -1388,7 +1388,9 @@
 			"allStatus": "Všechny stavy",
 			"allEndpoints": "Všechny modality",
 			"owner": "Vlastník",
-			"allOwners": "Všichni uživatelé"
+			"allOwners": "Všichni uživatelé",
+			"key": "Virtuální klíč",
+			"allKeys": "Všechny klíče"
 		},
 		"endpoint": {
 			"chat": "Chat",
@@ -1417,7 +1419,8 @@
 			"live": "Živě",
 			"interrupted": "Přerušeno",
 			"cacheInflated": "Nadhodnoceno zásahy do promptové mezipaměti",
-			"keyDeleted": "Smazáno"
+			"keyDeleted": "Smazáno",
+			"ip": "IP"
 		},
 		"tooltip": {
 			"timeDate": "Časové razítko požadavku",
@@ -1441,7 +1444,8 @@
 			"keyDecryption": "Dešifrování klíče",
 			"dial": "Navázání spojení (DNS+TCP)",
 			"settingsReads": "Nastavení – Čtení",
-			"reused": "znovu použité"
+			"reused": "znovu použité",
+			"ip": "IP adresa klienta, ze které požadavek přišel"
 		},
 		"status": {
 			"interrupted": "Přerušeno"
@@ -2841,9 +2845,7 @@
 			"copyModelId": "Zkopírovat ID modelu",
 			"resolved": "vyřešeno",
 			"provider": "Poskytovatel",
-			"dbRowId": "ID řádku v databázi",
 			"timestamp": "Časové razítko",
-			"copyDbRowId": "Zkopírovat ID řádku databáze",
 			"virtualKey": "Virtuální klíč",
 			"tokenUsage": "Použití tokenů",
 			"prompt": "Výzva",
@@ -2873,7 +2875,9 @@
 			"error": "Chyba",
 			"copyErrorMessage": "Zkopírujte chybovou zprávu",
 			"expandForBreakdown": "Rozbalte pro podrobné rozdělení podle kroků",
-			"performance": "Výkon"
+			"performance": "Výkon",
+			"clientIp": "IP klienta",
+			"copyClientIp": "Kopírovat IP klienta"
 		},
 		"statusBadge": {
 			"streaming": "Streamování",
@@ -2914,7 +2918,8 @@
 			"internal": "interní",
 			"cacheInflated": "Nadhodnoceno zásahy do promptové mezipaměti",
 			"deleted": "Smazáno",
-			"zeroEntries": "0 záznamů"
+			"zeroEntries": "0 záznamů",
+			"ip": "IP"
 		},
 		"virtualAppLogTable": {
 			"noEntriesFound": "Žádné log záznamy nenalezeny",

--- a/web/src/i18n/locales/da.json
+++ b/web/src/i18n/locales/da.json
@@ -1304,7 +1304,9 @@
 			"allStatus": "Alle statusser",
 			"allEndpoints": "Alle modaliteter",
 			"owner": "Ejer",
-			"allOwners": "Alle brugere"
+			"allOwners": "Alle brugere",
+			"key": "Virtuel nøgle",
+			"allKeys": "Alle nøgler"
 		},
 		"endpoint": {
 			"chat": "Chat",
@@ -1333,7 +1335,8 @@
 			"live": "Live",
 			"interrupted": "Afbrudt",
 			"cacheInflated": "Oppustet af prompt-cache-hits",
-			"keyDeleted": "Slettet"
+			"keyDeleted": "Slettet",
+			"ip": "IP"
 		},
 		"tooltip": {
 			"timeDate": "Tidsstempel for anmodningen",
@@ -1357,7 +1360,8 @@
 			"keyDecryption": "Dekryptering Af Nøgle",
 			"dial": "Ring Til (DNS+TCP)",
 			"settingsReads": "Læsning af indstillinger",
-			"reused": "genbrugt"
+			"reused": "genbrugt",
+			"ip": "Klientens IP-adresse, som anmodningen kom fra"
 		},
 		"status": {
 			"interrupted": "Afbrudt"
@@ -2721,9 +2725,7 @@
 			"copyModelId": "Kopier model ID",
 			"resolved": "løst",
 			"provider": "Udbyder",
-			"dbRowId": "Db Række ID",
 			"timestamp": "Tidsstempel",
-			"copyDbRowId": "Kopier DB række-ID",
 			"virtualKey": "Virtuel Nøgle",
 			"tokenUsage": "Token Anvendelse",
 			"prompt": "Prompt",
@@ -2753,7 +2755,9 @@
 			"error": "Fejl",
 			"copyErrorMessage": "Kopiér fejlmeddelelse",
 			"expandForBreakdown": "Udvid for at se opdelingen pr. trin",
-			"performance": "Ydeevne"
+			"performance": "Ydeevne",
+			"clientIp": "Klient-IP",
+			"copyClientIp": "Kopiér klient-IP"
 		},
 		"statusBadge": {
 			"streaming": "Streaming",
@@ -2794,7 +2798,8 @@
 			"internal": "intern",
 			"cacheInflated": "Oppustet af prompt-cache-hits",
 			"deleted": "Slettet",
-			"zeroEntries": "0 poster"
+			"zeroEntries": "0 poster",
+			"ip": "IP"
 		},
 		"virtualAppLogTable": {
 			"noEntriesFound": "Ingen logposter fundet",

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -1304,7 +1304,9 @@
 			"allStatus": "Alle Status",
 			"allEndpoints": "Alle Modalitäten",
 			"owner": "Besitzer",
-			"allOwners": "Alle Benutzer"
+			"allOwners": "Alle Benutzer",
+			"key": "Virtueller Schlüssel",
+			"allKeys": "Alle Schlüssel"
 		},
 		"endpoint": {
 			"chat": "Chat",
@@ -1333,7 +1335,8 @@
 			"live": "Live",
 			"interrupted": "Unterbrochen",
 			"cacheInflated": "Erhöht durch Prompt-Cache-Treffer",
-			"keyDeleted": "Gelöscht"
+			"keyDeleted": "Gelöscht",
+			"ip": "IP"
 		},
 		"tooltip": {
 			"timeDate": "Zeitstempel der Anfrage",
@@ -1357,7 +1360,8 @@
 			"keyDecryption": "Schlüssel Entschlüsselung",
 			"dial": "Wählen (DNS+TCP)",
 			"settingsReads": "Einstellungs-Lesezugriffe",
-			"reused": "wiederverwendet"
+			"reused": "wiederverwendet",
+			"ip": "Client-IP-Adresse, von der die Anfrage kam"
 		},
 		"status": {
 			"interrupted": "Unterbrochen"
@@ -2721,9 +2725,7 @@
 			"copyModelId": "Model-ID kopieren",
 			"resolved": "aufgelöst",
 			"provider": "Anbieter",
-			"dbRowId": "DB-Zeilen-ID",
 			"timestamp": "Zeitstempel",
-			"copyDbRowId": "DB-Zeilennummer kopieren",
 			"virtualKey": "Virtueller Schlüssel",
 			"tokenUsage": "Token-Nutzung",
 			"prompt": "Prompt",
@@ -2753,7 +2755,9 @@
 			"error": "Fehler",
 			"copyErrorMessage": "Fehlermeldung kopieren",
 			"expandForBreakdown": "Für die Aufschlüsselung pro Schritt ausklappen",
-			"performance": "Leistung"
+			"performance": "Leistung",
+			"clientIp": "Client-IP",
+			"copyClientIp": "Client-IP kopieren"
 		},
 		"statusBadge": {
 			"streaming": "Streaming",
@@ -2794,7 +2798,8 @@
 			"internal": "intern",
 			"cacheInflated": "Erhöht durch Prompt-Cache-Treffer",
 			"deleted": "Gelöscht",
-			"zeroEntries": "0 Einträge"
+			"zeroEntries": "0 Einträge",
+			"ip": "IP"
 		},
 		"virtualAppLogTable": {
 			"noEntriesFound": "Keine Logeinträge gefunden",

--- a/web/src/i18n/locales/el.json
+++ b/web/src/i18n/locales/el.json
@@ -1304,7 +1304,9 @@
 			"allStatus": "Όλες οι καταστάσεις",
 			"allEndpoints": "Όλες οι λειτουργίες",
 			"owner": "Κάτοχος",
-			"allOwners": "Όλοι οι χρήστες"
+			"allOwners": "Όλοι οι χρήστες",
+			"key": "Εικονικό κλειδί",
+			"allKeys": "Όλα τα κλειδιά"
 		},
 		"endpoint": {
 			"chat": "Συνομιλία",
@@ -1333,7 +1335,8 @@
 			"live": "Ζωντανά",
 			"interrupted": "Διακόπηκε",
 			"cacheInflated": "Διογκωμένο από επιτυχίες προσωρινής μνήμης προτροπής",
-			"keyDeleted": "Διαγράφηκε"
+			"keyDeleted": "Διαγράφηκε",
+			"ip": "IP"
 		},
 		"tooltip": {
 			"timeDate": "Χρονοσήμανση της αίτησης",
@@ -1357,7 +1360,8 @@
 			"keyDecryption": "Αποκρυπτογράφηση Κλειδιού",
 			"dial": "Κλήση (DNS+TCP)",
 			"settingsReads": "Ανάγνωση Ρυθμίσεων",
-			"reused": "επαναχρησιμοποίηση"
+			"reused": "επαναχρησιμοποίηση",
+			"ip": "Διεύθυνση IP του πελάτη από την οποία ήρθε το αίτημα"
 		},
 		"status": {
 			"interrupted": "Διακόπηκε"
@@ -2721,9 +2725,7 @@
 			"copyModelId": "Αντιγραφή ID μοντέλου",
 			"resolved": "επιλύθηκε",
 			"provider": "Πάροχος",
-			"dbRowId": "Αναγνωριστικό Γραμμής Βάσης Δεδομένων",
 			"timestamp": "Χρονοσήμανση",
-			"copyDbRowId": "Αντιγραφή ID γραμμής DB",
 			"virtualKey": "Εικονικό Κλειδί",
 			"tokenUsage": "Χρήση Token",
 			"prompt": "Prompt",
@@ -2753,7 +2755,9 @@
 			"error": "Σφάλμα",
 			"copyErrorMessage": "Αντιγραφή μηνύματος σφάλματος",
 			"expandForBreakdown": "Αναπτύξτε για την ανάλυση ανά βήμα",
-			"performance": "Επιδόσεις"
+			"performance": "Επιδόσεις",
+			"clientIp": "IP πελάτη",
+			"copyClientIp": "Αντιγραφή IP πελάτη"
 		},
 		"statusBadge": {
 			"streaming": "Ροή",
@@ -2794,7 +2798,8 @@
 			"internal": "εσωτερικός",
 			"cacheInflated": "Διογκωμένο από επιτυχίες προσωρινής μνήμης προτροπής",
 			"deleted": "Διαγράφηκε",
-			"zeroEntries": "0 καταχωρήσεις"
+			"zeroEntries": "0 καταχωρήσεις",
+			"ip": "IP"
 		},
 		"virtualAppLogTable": {
 			"noEntriesFound": "Δεν βρέθηκαν καταχωρήσεις καταγραφής",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1304,7 +1304,9 @@
 			"source": "Source",
 			"logsPlaceholder": "Filter logs…",
 			"owner": "Owner",
-			"allOwners": "All users"
+			"allOwners": "All users",
+			"key": "Virtual key",
+			"allKeys": "All keys"
 		},
 		"endpoint": {
 			"chat": "Chat",
@@ -1333,7 +1335,8 @@
 			"live": "Live",
 			"interrupted": "Interrupted",
 			"cacheInflated": "Inflated by prompt cache hits",
-			"keyDeleted": "Deleted"
+			"keyDeleted": "Deleted",
+			"ip": "IP"
 		},
 		"tooltip": {
 			"timeDate": "Timestamp of the request",
@@ -1357,7 +1360,8 @@
 			"keyDecryption": "Key Decryption",
 			"dial": "Dial (DNS+TCP)",
 			"settingsReads": "Settings Reads",
-			"reused": "reused"
+			"reused": "reused",
+			"ip": "Client IP address the request came from"
 		},
 		"status": {
 			"interrupted": "Interrupted"
@@ -2722,9 +2726,7 @@
 			"copyModelId": "Copy model ID",
 			"resolved": "resolved",
 			"provider": "Provider",
-			"dbRowId": "DB Row ID",
 			"timestamp": "Timestamp",
-			"copyDbRowId": "Copy DB row ID",
 			"virtualKey": "Virtual Key",
 			"tokenUsage": "Token Usage",
 			"prompt": "Prompt",
@@ -2753,7 +2755,9 @@
 			"totalOverhead": "Total Overhead",
 			"error": "Error",
 			"copyErrorMessage": "Copy error message",
-			"expandForBreakdown": "Expand for the per-step breakdown"
+			"expandForBreakdown": "Expand for the per-step breakdown",
+			"clientIp": "Client IP",
+			"copyClientIp": "Copy client IP"
 		},
 		"statusBadge": {
 			"streaming": "Streaming",
@@ -2794,7 +2798,8 @@
 			"internal": "internal",
 			"cacheInflated": "Inflated by prompt cache hits",
 			"deleted": "Deleted",
-			"zeroEntries": "0 entries"
+			"zeroEntries": "0 entries",
+			"ip": "IP"
 		},
 		"virtualAppLogTable": {
 			"noEntriesFound": "No log entries found",

--- a/web/src/i18n/locales/es.json
+++ b/web/src/i18n/locales/es.json
@@ -1346,7 +1346,9 @@
 			"allStatus": "Todos los estados",
 			"allEndpoints": "Todas las modalidades",
 			"owner": "Propietario",
-			"allOwners": "Todos los usuarios"
+			"allOwners": "Todos los usuarios",
+			"key": "Clave virtual",
+			"allKeys": "Todas las claves"
 		},
 		"endpoint": {
 			"chat": "Chat",
@@ -1375,7 +1377,8 @@
 			"live": "En directo",
 			"interrupted": "Interrumpido",
 			"cacheInflated": "Inflado por aciertos de la caché de prompt",
-			"keyDeleted": "Eliminado"
+			"keyDeleted": "Eliminado",
+			"ip": "IP"
 		},
 		"tooltip": {
 			"timeDate": "Marca de tiempo de la solicitud",
@@ -1399,7 +1402,8 @@
 			"keyDecryption": "Descifrado de clave",
 			"dial": "Marcar (DNS+TCP)",
 			"settingsReads": "Lecturas de ajustes",
-			"reused": "reutilizado"
+			"reused": "reutilizado",
+			"ip": "Dirección IP del cliente desde la que llegó la solicitud"
 		},
 		"status": {
 			"interrupted": "Interrumpido"
@@ -2781,9 +2785,7 @@
 			"copyModelId": "Copiar ID del modelo",
 			"resolved": "resuelto",
 			"provider": "Proveedor",
-			"dbRowId": "ID fila DB",
 			"timestamp": "Timestamp",
-			"copyDbRowId": "Copiar ID de fila DB",
 			"virtualKey": "Clave virtual",
 			"tokenUsage": "Uso de Token",
 			"prompt": "Prompt",
@@ -2813,7 +2815,9 @@
 			"error": "Error",
 			"copyErrorMessage": "Copiar mensaje de error",
 			"expandForBreakdown": "Expande para ver el desglose por pasos",
-			"performance": "Rendimiento"
+			"performance": "Rendimiento",
+			"clientIp": "IP del cliente",
+			"copyClientIp": "Copiar IP del cliente"
 		},
 		"statusBadge": {
 			"streaming": "Transmisión",
@@ -2854,7 +2858,8 @@
 			"internal": "interno",
 			"cacheInflated": "Inflado por aciertos de la caché de prompt",
 			"deleted": "Eliminado",
-			"zeroEntries": "0 entradas"
+			"zeroEntries": "0 entradas",
+			"ip": "IP"
 		},
 		"virtualAppLogTable": {
 			"noEntriesFound": "No se encontraron registros",

--- a/web/src/i18n/locales/fi.json
+++ b/web/src/i18n/locales/fi.json
@@ -1304,7 +1304,9 @@
 			"allStatus": "Kaikki tilat",
 			"allEndpoints": "Kaikki modaliteetit",
 			"owner": "Omistaja",
-			"allOwners": "Kaikki käyttäjät"
+			"allOwners": "Kaikki käyttäjät",
+			"key": "Virtuaalinen avain",
+			"allKeys": "Kaikki avaimet"
 		},
 		"endpoint": {
 			"chat": "Keskustelu",
@@ -1333,7 +1335,8 @@
 			"live": "Suora",
 			"interrupted": "Keskeytetty",
 			"cacheInflated": "Kasvatettu kehotevälimuistin osumilla",
-			"keyDeleted": "Poistettu"
+			"keyDeleted": "Poistettu",
+			"ip": "IP"
 		},
 		"tooltip": {
 			"timeDate": "Pyyntöön liittyvä aikaleima",
@@ -1357,7 +1360,8 @@
 			"keyDecryption": "Avaimen Salauksen Purku",
 			"dial": "Yhteydenotto (DNS+TCP)",
 			"settingsReads": "Asetukset Lukemat",
-			"reused": "uudelleenkäytetty"
+			"reused": "uudelleenkäytetty",
+			"ip": "Asiakkaan IP-osoite, josta pyyntö tuli"
 		},
 		"status": {
 			"interrupted": "Keskeytetty"
@@ -2721,9 +2725,7 @@
 			"copyModelId": "Kopioi mallin ID",
 			"resolved": "ratkaistu",
 			"provider": "Tarjoaja",
-			"dbRowId": "Tietokannan Rivin Tunnus",
 			"timestamp": "Aikaleima",
-			"copyDbRowId": "Kopioi DB rivin ID",
 			"virtualKey": "Virtuaalinen Avain",
 			"tokenUsage": "Tokenien käyttö",
 			"prompt": "Prompt",
@@ -2753,7 +2755,9 @@
 			"error": "Virhe",
 			"copyErrorMessage": "Kopioi virheviesti",
 			"expandForBreakdown": "Laajenna nähdäksesi vaihekohtaisen erittelyn",
-			"performance": "Suorituskyky"
+			"performance": "Suorituskyky",
+			"clientIp": "Asiakkaan IP",
+			"copyClientIp": "Kopioi asiakkaan IP"
 		},
 		"statusBadge": {
 			"streaming": "Suoratoistaminen",
@@ -2794,7 +2798,8 @@
 			"internal": "sisäinen",
 			"cacheInflated": "Kasvatettu kehotevälimuistin osumilla",
 			"deleted": "Poistettu",
-			"zeroEntries": "0 merkintää"
+			"zeroEntries": "0 merkintää",
+			"ip": "IP"
 		},
 		"virtualAppLogTable": {
 			"noEntriesFound": "Lokitietoja ei löytynyt",

--- a/web/src/i18n/locales/fr.json
+++ b/web/src/i18n/locales/fr.json
@@ -1346,7 +1346,9 @@
 			"allStatus": "Tous les statuts",
 			"allEndpoints": "Toutes les modalités",
 			"owner": "Propriétaire",
-			"allOwners": "Tous les utilisateurs"
+			"allOwners": "Tous les utilisateurs",
+			"key": "Clé virtuelle",
+			"allKeys": "Toutes les clés"
 		},
 		"endpoint": {
 			"chat": "Chat",
@@ -1375,7 +1377,8 @@
 			"live": "En direct",
 			"interrupted": "Interrompu",
 			"cacheInflated": "Gonflé par les hits du cache d'invite",
-			"keyDeleted": "Supprimé"
+			"keyDeleted": "Supprimé",
+			"ip": "IP"
 		},
 		"tooltip": {
 			"timeDate": "Horodatage de la demande",
@@ -1399,7 +1402,8 @@
 			"keyDecryption": "Déchiffrement de clé",
 			"dial": "Connexion (DNS+TCP)",
 			"settingsReads": "Lectures des paramètres",
-			"reused": "réutilisé"
+			"reused": "réutilisé",
+			"ip": "Adresse IP du client d'où provient la requête"
 		},
 		"status": {
 			"interrupted": "Interrompu"
@@ -2781,9 +2785,7 @@
 			"copyModelId": "Copier l'ID du modèle",
 			"resolved": "résolu",
 			"provider": "Fournisseur",
-			"dbRowId": "ID de la ligne de la base de données",
 			"timestamp": "Horodatage",
-			"copyDbRowId": "Copier l'ID de la ligne de la BD",
 			"virtualKey": "Clé virtuelle",
 			"tokenUsage": "Utilisation du jeton",
 			"prompt": "Prompt",
@@ -2813,7 +2815,9 @@
 			"error": "Erreur",
 			"copyErrorMessage": "Copier le message d'erreur",
 			"expandForBreakdown": "Développez pour voir le détail par étape",
-			"performance": "Performances"
+			"performance": "Performances",
+			"clientIp": "IP du client",
+			"copyClientIp": "Copier l'IP du client"
 		},
 		"statusBadge": {
 			"streaming": "Streaming en cours",
@@ -2854,7 +2858,8 @@
 			"internal": "interne",
 			"cacheInflated": "Gonflé par les hits du cache d'invite",
 			"deleted": "Supprimé",
-			"zeroEntries": "0 entrées"
+			"zeroEntries": "0 entrées",
+			"ip": "IP"
 		},
 		"virtualAppLogTable": {
 			"noEntriesFound": "Aucune entrée de journal trouvée",

--- a/web/src/i18n/locales/he.json
+++ b/web/src/i18n/locales/he.json
@@ -1346,7 +1346,9 @@
 			"allStatus": "כל הסטטוסים",
 			"allEndpoints": "כל המודאליות",
 			"owner": "בעלים",
-			"allOwners": "כל המשתמשים"
+			"allOwners": "כל המשתמשים",
+			"key": "מפתח וירטואלי",
+			"allKeys": "כל המפתחות"
 		},
 		"endpoint": {
 			"chat": "צ'אט",
@@ -1375,7 +1377,8 @@
 			"live": "בשידור חי",
 			"interrupted": "נקטע",
 			"cacheInflated": "מוגדל עקב פגיעות במטמון ההנחיות",
-			"keyDeleted": "נמחק"
+			"keyDeleted": "נמחק",
+			"ip": "IP"
 		},
 		"tooltip": {
 			"timeDate": "תאריך ושעה של הבקשה",
@@ -1399,7 +1402,8 @@
 			"keyDecryption": "פענוח מפתח",
 			"dial": "חיוג (DNS+TCP)",
 			"settingsReads": "הגדרות קריאה",
-			"reused": "בשימוש חוזר"
+			"reused": "בשימוש חוזר",
+			"ip": "כתובת ה-IP של הלקוח שממנה הגיעה הבקשה"
 		},
 		"status": {
 			"interrupted": "נקטע"
@@ -2781,9 +2785,7 @@
 			"copyModelId": "העתק מזהה הדגם",
 			"resolved": "נפתר",
 			"provider": "ספק",
-			"dbRowId": "מזהה שורה בבסיס הנתונים",
 			"timestamp": "תאריך ושעה",
-			"copyDbRowId": "העתקת מזהה שורה בבסיס הנתונים",
 			"virtualKey": "מפתח וירטואלי",
 			"tokenUsage": "שימוש באסימונים",
 			"prompt": "הנחיה",
@@ -2813,7 +2815,9 @@
 			"error": "שגיאה",
 			"copyErrorMessage": "העתק את הודעת השגיאה",
 			"expandForBreakdown": "הרחב לפירוט לפי שלבים",
-			"performance": "ביצועים"
+			"performance": "ביצועים",
+			"clientIp": "IP של הלקוח",
+			"copyClientIp": "העתק את ה-IP של הלקוח"
 		},
 		"statusBadge": {
 			"streaming": "סטרימינג",
@@ -2854,7 +2858,8 @@
 			"internal": "פנימי",
 			"cacheInflated": "מוגדל עקב פגיעות במטמון ההנחיות",
 			"deleted": "נמחק",
-			"zeroEntries": "0 רשומות"
+			"zeroEntries": "0 רשומות",
+			"ip": "IP"
 		},
 		"virtualAppLogTable": {
 			"noEntriesFound": "לא נמצאו רשומות ביומן",

--- a/web/src/i18n/locales/hu.json
+++ b/web/src/i18n/locales/hu.json
@@ -1304,7 +1304,9 @@
 			"allStatus": "Minden állapot",
 			"allEndpoints": "Minden modalitás",
 			"owner": "Tulajdonos",
-			"allOwners": "Minden felhasználó"
+			"allOwners": "Minden felhasználó",
+			"key": "Virtuális kulcs",
+			"allKeys": "Minden kulcs"
 		},
 		"endpoint": {
 			"chat": "Csevegés",
@@ -1333,7 +1335,8 @@
 			"live": "Élőben",
 			"interrupted": "Megszakítva",
 			"cacheInflated": "A prompt-cache találatai miatt megnövelt",
-			"keyDeleted": "Törölve"
+			"keyDeleted": "Törölve",
+			"ip": "IP"
 		},
 		"tooltip": {
 			"timeDate": "A kérés időbélyege",
@@ -1357,7 +1360,8 @@
 			"keyDecryption": "Kulcs visszafejtése",
 			"dial": "Kapcsolódás (DNS+TCP)",
 			"settingsReads": "Beállítások megtekintése",
-			"reused": "újrahasznosított"
+			"reused": "újrahasznosított",
+			"ip": "A kliens IP-címe, ahonnan a kérés érkezett"
 		},
 		"status": {
 			"interrupted": "Megszakítva"
@@ -2721,9 +2725,7 @@
 			"copyModelId": "Modellazonosító másolása",
 			"resolved": "feloldva",
 			"provider": "Szolgáltató",
-			"dbRowId": "Adatbázis-sor azonosító",
 			"timestamp": "Időbélyeg",
-			"copyDbRowId": "Adatbázis-sor azonosítójának másolása",
 			"virtualKey": "Virtuális kulcs",
 			"tokenUsage": "A token használata",
 			"prompt": "Prompt tokenek",
@@ -2753,7 +2755,9 @@
 			"error": "Hiba",
 			"copyErrorMessage": "Hibaüzenet másolása",
 			"expandForBreakdown": "Bontsa ki a lépésenkénti bontáshoz",
-			"performance": "Teljesítmény"
+			"performance": "Teljesítmény",
+			"clientIp": "Kliens IP",
+			"copyClientIp": "Kliens IP másolása"
 		},
 		"statusBadge": {
 			"streaming": "Streaming",
@@ -2794,7 +2798,8 @@
 			"internal": "belső",
 			"cacheInflated": "A prompt-cache találatai miatt megnövelt",
 			"deleted": "Törölve",
-			"zeroEntries": "0 találat"
+			"zeroEntries": "0 találat",
+			"ip": "IP"
 		},
 		"virtualAppLogTable": {
 			"noEntriesFound": "Nem találtam naplóbejegyzéseket",

--- a/web/src/i18n/locales/it.json
+++ b/web/src/i18n/locales/it.json
@@ -1346,7 +1346,9 @@
 			"allStatus": "Tutti gli stati",
 			"allEndpoints": "Tutte le modalità",
 			"owner": "Proprietario",
-			"allOwners": "Tutti gli utenti"
+			"allOwners": "Tutti gli utenti",
+			"key": "Chiave virtuale",
+			"allKeys": "Tutte le chiavi"
 		},
 		"endpoint": {
 			"chat": "Chat",
@@ -1375,7 +1377,8 @@
 			"live": "Live",
 			"interrupted": "Interrotto",
 			"cacheInflated": "Gonfiato dagli hit della cache dei prompt",
-			"keyDeleted": "Eliminato"
+			"keyDeleted": "Eliminato",
+			"ip": "IP"
 		},
 		"tooltip": {
 			"timeDate": "Timestamp della richiesta",
@@ -1399,7 +1402,8 @@
 			"keyDecryption": "Decifratura Chiave",
 			"dial": "Connessione (DNS+TCP)",
 			"settingsReads": "Letture Delle Impostazioni",
-			"reused": "riutilizzato"
+			"reused": "riutilizzato",
+			"ip": "Indirizzo IP del client da cui è arrivata la richiesta"
 		},
 		"status": {
 			"interrupted": "Interrotto"
@@ -2781,9 +2785,7 @@
 			"copyModelId": "Copia ID modello",
 			"resolved": "risolto",
 			"provider": "Provider",
-			"dbRowId": "ID Riga DB",
 			"timestamp": "Timestamp",
-			"copyDbRowId": "Copia ID riga DB",
 			"virtualKey": "Chiave Virtuale",
 			"tokenUsage": "Utilizzo Token",
 			"prompt": "Prompt",
@@ -2813,7 +2815,9 @@
 			"error": "Errore",
 			"copyErrorMessage": "Copia messaggio di errore",
 			"expandForBreakdown": "Espandi per il dettaglio per passaggio",
-			"performance": "Prestazioni"
+			"performance": "Prestazioni",
+			"clientIp": "IP del client",
+			"copyClientIp": "Copia IP del client"
 		},
 		"statusBadge": {
 			"streaming": "Streaming",
@@ -2854,7 +2858,8 @@
 			"internal": "interno",
 			"cacheInflated": "Gonfiato dagli hit della cache dei prompt",
 			"deleted": "Eliminato",
-			"zeroEntries": "0 voci"
+			"zeroEntries": "0 voci",
+			"ip": "IP"
 		},
 		"virtualAppLogTable": {
 			"noEntriesFound": "Nessun log trovato",

--- a/web/src/i18n/locales/ja.json
+++ b/web/src/i18n/locales/ja.json
@@ -1304,7 +1304,9 @@
 			"allStatus": "すべてのステータス",
 			"allEndpoints": "すべてのモダリティ",
 			"owner": "所有者",
-			"allOwners": "すべてのユーザー"
+			"allOwners": "すべてのユーザー",
+			"key": "仮想キー",
+			"allKeys": "すべてのキー"
 		},
 		"endpoint": {
 			"chat": "チャット",
@@ -1333,7 +1335,8 @@
 			"live": "ライブ",
 			"interrupted": "中断されました",
 			"cacheInflated": "プロンプトキャッシュのヒットにより水増しされています",
-			"keyDeleted": "削除しました"
+			"keyDeleted": "削除しました",
+			"ip": "IP"
 		},
 		"tooltip": {
 			"timeDate": "リクエストのタイムスタンプ",
@@ -1357,7 +1360,8 @@
 			"keyDecryption": "鍵の復号化",
 			"dial": "ダイヤル (DNS+TCP)",
 			"settingsReads": "設定を読み込みます",
-			"reused": "再利用しました"
+			"reused": "再利用しました",
+			"ip": "リクエスト元のクライアントIPアドレス"
 		},
 		"status": {
 			"interrupted": "中断されました"
@@ -2721,9 +2725,7 @@
 			"copyModelId": "モデル ID をコピー",
 			"resolved": "解決済み",
 			"provider": "プロバイダー",
-			"dbRowId": "DB 行 ID",
 			"timestamp": "タイムスタンプ",
-			"copyDbRowId": "DB 行 ID をコピー",
 			"virtualKey": "仮想キー",
 			"tokenUsage": "トークンの使用状況",
 			"prompt": "Prompt",
@@ -2753,7 +2755,9 @@
 			"error": "エラー",
 			"copyErrorMessage": "エラーメッセージをコピー",
 			"expandForBreakdown": "ステップごとの内訳を表示するには展開してください",
-			"performance": "パフォーマンス"
+			"performance": "パフォーマンス",
+			"clientIp": "クライアントIP",
+			"copyClientIp": "クライアントIPをコピー"
 		},
 		"statusBadge": {
 			"streaming": "ストリーミング",
@@ -2794,7 +2798,8 @@
 			"internal": "内部",
 			"cacheInflated": "プロンプトキャッシュのヒットにより水増しされています",
 			"deleted": "削除しました",
-			"zeroEntries": "0 項目"
+			"zeroEntries": "0 項目",
+			"ip": "IP"
 		},
 		"virtualAppLogTable": {
 			"noEntriesFound": "ログエントリが見つかりません",

--- a/web/src/i18n/locales/ko.json
+++ b/web/src/i18n/locales/ko.json
@@ -1304,7 +1304,9 @@
 			"allStatus": "모든 상태",
 			"allEndpoints": "모든 모달리티",
 			"owner": "소유자",
-			"allOwners": "모든 사용자"
+			"allOwners": "모든 사용자",
+			"key": "가상 키",
+			"allKeys": "모든 키"
 		},
 		"endpoint": {
 			"chat": "채팅",
@@ -1333,7 +1335,8 @@
 			"live": "실시간",
 			"interrupted": "중단됨",
 			"cacheInflated": "프롬프트 캐시 적중으로 인해 부풀려짐",
-			"keyDeleted": "삭제됨"
+			"keyDeleted": "삭제됨",
+			"ip": "IP"
 		},
 		"tooltip": {
 			"timeDate": "요청의 타임스탬프",
@@ -1357,7 +1360,8 @@
 			"keyDecryption": "키 복호화",
 			"dial": "다이얼 (DNS+TCP)",
 			"settingsReads": "설정 읽기",
-			"reused": "재사용된"
+			"reused": "재사용된",
+			"ip": "요청이 들어온 클라이언트 IP 주소"
 		},
 		"status": {
 			"interrupted": "중단됨"
@@ -2721,9 +2725,7 @@
 			"copyModelId": "모델 ID 복사",
 			"resolved": "확인됨",
 			"provider": "제공업체",
-			"dbRowId": "DB 행 ID",
 			"timestamp": "시간 표시",
-			"copyDbRowId": "DB 행 ID 복사",
 			"virtualKey": "가상 키",
 			"tokenUsage": "토큰 사용",
 			"prompt": "프롬프트",
@@ -2753,7 +2755,9 @@
 			"error": "오류",
 			"copyErrorMessage": "오류 메시지 복사",
 			"expandForBreakdown": "단계별 분석을 보려면 펼치세요",
-			"performance": "성능"
+			"performance": "성능",
+			"clientIp": "클라이언트 IP",
+			"copyClientIp": "클라이언트 IP 복사"
 		},
 		"statusBadge": {
 			"streaming": "스트리밍",
@@ -2794,7 +2798,8 @@
 			"internal": "내부",
 			"cacheInflated": "프롬프트 캐시 적중으로 인해 부풀려짐",
 			"deleted": "삭제됨",
-			"zeroEntries": "0건"
+			"zeroEntries": "0건",
+			"ip": "IP"
 		},
 		"virtualAppLogTable": {
 			"noEntriesFound": "로그 항목이 없습니다",

--- a/web/src/i18n/locales/nl.json
+++ b/web/src/i18n/locales/nl.json
@@ -1304,7 +1304,9 @@
 			"allStatus": "Alle statussen",
 			"allEndpoints": "Alle modaliteiten",
 			"owner": "Eigenaar",
-			"allOwners": "Alle gebruikers"
+			"allOwners": "Alle gebruikers",
+			"key": "Virtuele sleutel",
+			"allKeys": "Alle sleutels"
 		},
 		"endpoint": {
 			"chat": "Chatten",
@@ -1333,7 +1335,8 @@
 			"live": "Live",
 			"interrupted": "Onderbroken",
 			"cacheInflated": "Inflated by prompt cache hits",
-			"keyDeleted": "Verwijderd"
+			"keyDeleted": "Verwijderd",
+			"ip": "IP"
 		},
 		"tooltip": {
 			"timeDate": "Tijdstempel van de aanvraag",
@@ -1357,7 +1360,8 @@
 			"keyDecryption": "Sleutel decoderen",
 			"dial": "Verbinden (DNS+TCP)",
 			"settingsReads": "Instellingen Lezen",
-			"reused": "hergebruikt"
+			"reused": "hergebruikt",
+			"ip": "IP-adres van de client waarvan het verzoek kwam"
 		},
 		"status": {
 			"interrupted": "Onderbroken"
@@ -2721,9 +2725,7 @@
 			"copyModelId": "model-ID kopiëren",
 			"resolved": "opgelost",
 			"provider": "Leverancier",
-			"dbRowId": "DB rij ID",
 			"timestamp": "Tijdstempel",
-			"copyDbRowId": "Kopieer DB rij ID",
 			"virtualKey": "Virtuele sleutel",
 			"tokenUsage": "Token gebruik",
 			"prompt": "Prompt",
@@ -2753,7 +2755,9 @@
 			"error": "Foutmelding",
 			"copyErrorMessage": "Foutmelding kopiëren",
 			"expandForBreakdown": "Vouw uit voor de uitsplitsing per stap",
-			"performance": "Prestaties"
+			"performance": "Prestaties",
+			"clientIp": "Client-IP",
+			"copyClientIp": "Client-IP kopiëren"
 		},
 		"statusBadge": {
 			"streaming": "Streamen",
@@ -2794,7 +2798,8 @@
 			"internal": "Intern",
 			"cacheInflated": "Inflated by prompt cache hits",
 			"deleted": "Verwijderd",
-			"zeroEntries": "0 vermeldingen"
+			"zeroEntries": "0 vermeldingen",
+			"ip": "IP"
 		},
 		"virtualAppLogTable": {
 			"noEntriesFound": "Geen logs gevonden",

--- a/web/src/i18n/locales/no.json
+++ b/web/src/i18n/locales/no.json
@@ -1304,7 +1304,9 @@
 			"allStatus": "Alle statuser",
 			"allEndpoints": "Alle modaliteter",
 			"owner": "Eier",
-			"allOwners": "Alle brukere"
+			"allOwners": "Alle brukere",
+			"key": "Virtuell nøkkel",
+			"allKeys": "Alle nøkler"
 		},
 		"endpoint": {
 			"chat": "Samtale",
@@ -1333,7 +1335,8 @@
 			"live": "Direkte",
 			"interrupted": "Avbrutt",
 			"cacheInflated": "Blåst opp av treff i prompt-bufferen",
-			"keyDeleted": "Slettet"
+			"keyDeleted": "Slettet",
+			"ip": "IP"
 		},
 		"tooltip": {
 			"timeDate": "Tidsstempel for anmodningen",
@@ -1357,7 +1360,8 @@
 			"keyDecryption": "Nøkkel dekryptering",
 			"dial": "Dial (DNS+TCP)",
 			"settingsReads": "Innstillinger Leser",
-			"reused": "gjenbrukt"
+			"reused": "gjenbrukt",
+			"ip": "Klientens IP-adresse som forespørselen kom fra"
 		},
 		"status": {
 			"interrupted": "Avbrutt"
@@ -2721,9 +2725,7 @@
 			"copyModelId": "Kopier modell-ID",
 			"resolved": "løst",
 			"provider": "Leverandør",
-			"dbRowId": "DB rad ID",
 			"timestamp": "Tidsstempel",
-			"copyDbRowId": "Kopier rad-ID for DB",
 			"virtualKey": "Virtuell nøkkel",
 			"tokenUsage": "Token bruk",
 			"prompt": "Prompt",
@@ -2753,7 +2755,9 @@
 			"error": "Feil",
 			"copyErrorMessage": "Kopier feilmelding",
 			"expandForBreakdown": "Utvid for fordelingen per trinn",
-			"performance": "Ytelse"
+			"performance": "Ytelse",
+			"clientIp": "Klient-IP",
+			"copyClientIp": "Kopier klient-IP"
 		},
 		"statusBadge": {
 			"streaming": "Strømming",
@@ -2794,7 +2798,8 @@
 			"internal": "intern",
 			"cacheInflated": "Blåst opp av treff i prompt-bufferen",
 			"deleted": "Slettet",
-			"zeroEntries": "0 oppføringer"
+			"zeroEntries": "0 oppføringer",
+			"ip": "IP"
 		},
 		"virtualAppLogTable": {
 			"noEntriesFound": "Ingen loggoppføringer funnet",

--- a/web/src/i18n/locales/pl.json
+++ b/web/src/i18n/locales/pl.json
@@ -1388,7 +1388,9 @@
 			"allStatus": "Wszystkie statusy",
 			"allEndpoints": "Wszystkie modalności",
 			"owner": "Właściciel",
-			"allOwners": "Wszyscy użytkownicy"
+			"allOwners": "Wszyscy użytkownicy",
+			"key": "Klucz wirtualny",
+			"allKeys": "Wszystkie klucze"
 		},
 		"endpoint": {
 			"chat": "Czat",
@@ -1417,7 +1419,8 @@
 			"live": "Na żywo",
 			"interrupted": "Przerwane",
 			"cacheInflated": "Zawyżone przez trafienia w pamięci podręcznej promptu",
-			"keyDeleted": "Usunięto"
+			"keyDeleted": "Usunięto",
+			"ip": "IP"
 		},
 		"tooltip": {
 			"timeDate": "Znacznik czasu wniosku",
@@ -1441,7 +1444,8 @@
 			"keyDecryption": "Odszyfrowanie klucza",
 			"dial": "Wybieranie (DNS+TCP)",
 			"settingsReads": "Odczyty ustawień",
-			"reused": "ponownie wykorzystane"
+			"reused": "ponownie wykorzystane",
+			"ip": "Adres IP klienta, z którego przyszło żądanie"
 		},
 		"status": {
 			"interrupted": "Przerwane"
@@ -2841,9 +2845,7 @@
 			"copyModelId": "Kopiuj ID modelu",
 			"resolved": "rozwiązane",
 			"provider": "Dostawca",
-			"dbRowId": "ID wiersza bazy danych",
 			"timestamp": "Znacznik czasu",
-			"copyDbRowId": "Kopiuj ID wiersza DB",
 			"virtualKey": "Klucz wirtualny",
 			"tokenUsage": "Użycie tokenu",
 			"prompt": "Prompt",
@@ -2873,7 +2875,9 @@
 			"error": "Błąd",
 			"copyErrorMessage": "Kopiuj komunikat o błędzie",
 			"expandForBreakdown": "Rozwiń, aby zobaczyć podział na kroki",
-			"performance": "Wydajność"
+			"performance": "Wydajność",
+			"clientIp": "IP klienta",
+			"copyClientIp": "Kopiuj IP klienta"
 		},
 		"statusBadge": {
 			"streaming": "Strumieniowanie",
@@ -2914,7 +2918,8 @@
 			"internal": "wewnętrzna",
 			"cacheInflated": "Zawyżone przez trafienia w pamięci podręcznej promptu",
 			"deleted": "Usunięto",
-			"zeroEntries": "0 wpisów"
+			"zeroEntries": "0 wpisów",
+			"ip": "IP"
 		},
 		"virtualAppLogTable": {
 			"noEntriesFound": "Nie znaleziono wpisów dziennika",

--- a/web/src/i18n/locales/pt.json
+++ b/web/src/i18n/locales/pt.json
@@ -1346,7 +1346,9 @@
 			"allStatus": "Todos os status",
 			"allEndpoints": "Todas as modalidades",
 			"owner": "Proprietário",
-			"allOwners": "Todos os usuários"
+			"allOwners": "Todos os usuários",
+			"key": "Chave virtual",
+			"allKeys": "Todas as chaves"
 		},
 		"endpoint": {
 			"chat": "Bate-papo",
@@ -1375,7 +1377,8 @@
 			"live": "Ao vivo",
 			"interrupted": "Interrompido",
 			"cacheInflated": "Inflado por acertos do cache de prompt",
-			"keyDeleted": "Excluído"
+			"keyDeleted": "Excluído",
+			"ip": "IP"
 		},
 		"tooltip": {
 			"timeDate": "Carimbo de tempo do pedido",
@@ -1399,7 +1402,8 @@
 			"keyDecryption": "Descriptografia de Chave",
 			"dial": "Discar (DNS+TCP)",
 			"settingsReads": "Leituras de configurações",
-			"reused": "reutilizado"
+			"reused": "reutilizado",
+			"ip": "Endereço IP do cliente de onde veio a solicitação"
 		},
 		"status": {
 			"interrupted": "Interrompido"
@@ -2781,9 +2785,7 @@
 			"copyModelId": "Copiar modelo ID",
 			"resolved": "resolvido",
 			"provider": "Fornecedor",
-			"dbRowId": "ID da linha do BD",
 			"timestamp": "Timestamp",
-			"copyDbRowId": "Copiar ID da linha do BD",
 			"virtualKey": "Chave Virtual",
 			"tokenUsage": "Uso do token",
 			"prompt": "Prompt",
@@ -2813,7 +2815,9 @@
 			"error": "ERRO",
 			"copyErrorMessage": "Copiar mensagem de erro",
 			"expandForBreakdown": "Expanda para ver o detalhamento por etapa",
-			"performance": "Desempenho"
+			"performance": "Desempenho",
+			"clientIp": "IP do cliente",
+			"copyClientIp": "Copiar IP do cliente"
 		},
 		"statusBadge": {
 			"streaming": "Transmitindo",
@@ -2854,7 +2858,8 @@
 			"internal": "Interno",
 			"cacheInflated": "Inflado por acertos do cache de prompt",
 			"deleted": "Excluído",
-			"zeroEntries": "0 entradas"
+			"zeroEntries": "0 entradas",
+			"ip": "IP"
 		},
 		"virtualAppLogTable": {
 			"noEntriesFound": "Nenhuma entrada de log encontrada",

--- a/web/src/i18n/locales/ro.json
+++ b/web/src/i18n/locales/ro.json
@@ -1346,7 +1346,9 @@
 			"allStatus": "Toate stările",
 			"allEndpoints": "Toate modalitățile",
 			"owner": "Proprietar",
-			"allOwners": "Toți utilizatorii"
+			"allOwners": "Toți utilizatorii",
+			"key": "Cheie virtuală",
+			"allKeys": "Toate cheile"
 		},
 		"endpoint": {
 			"chat": "Chat",
@@ -1375,7 +1377,8 @@
 			"live": "Live",
 			"interrupted": "Întrerupere",
 			"cacheInflated": "Umflat de accesările în cache ale promptului",
-			"keyDeleted": "Șters"
+			"keyDeleted": "Șters",
+			"ip": "IP"
 		},
 		"tooltip": {
 			"timeDate": "Momentul cererii",
@@ -1399,7 +1402,8 @@
 			"keyDecryption": "Decriptarea cheii",
 			"dial": "Apelare (DNS+TCP)",
 			"settingsReads": "Setări Lecturi",
-			"reused": "reutilizat"
+			"reused": "reutilizat",
+			"ip": "Adresa IP a clientului de la care a venit cererea"
 		},
 		"status": {
 			"interrupted": "Întrerupere"
@@ -2781,9 +2785,7 @@
 			"copyModelId": "Copiază ID-ul modelului",
 			"resolved": "rezolvat",
 			"provider": "Furnizor",
-			"dbRowId": "ID Rând DB",
 			"timestamp": "Ora",
-			"copyDbRowId": "Copiază ID rând DB",
 			"virtualKey": "Cheie virtuală",
 			"tokenUsage": "Utilizare token",
 			"prompt": "Prompt",
@@ -2813,7 +2815,9 @@
 			"error": "Eroare",
 			"copyErrorMessage": "Copiază mesajul de eroare",
 			"expandForBreakdown": "Extinde pentru defalcarea pe pași",
-			"performance": "Performanță"
+			"performance": "Performanță",
+			"clientIp": "IP-ul clientului",
+			"copyClientIp": "Copiază IP-ul clientului"
 		},
 		"statusBadge": {
 			"streaming": "Streaming",
@@ -2854,7 +2858,8 @@
 			"internal": "intern",
 			"cacheInflated": "Umflat de accesările în cache ale promptului",
 			"deleted": "Șters",
-			"zeroEntries": "0 intrări"
+			"zeroEntries": "0 intrări",
+			"ip": "IP"
 		},
 		"virtualAppLogTable": {
 			"noEntriesFound": "Nu s-au găsit intrări în jurnal",

--- a/web/src/i18n/locales/ru.json
+++ b/web/src/i18n/locales/ru.json
@@ -1388,7 +1388,9 @@
 			"allStatus": "Все статусы",
 			"allEndpoints": "Все модальности",
 			"owner": "Владелец",
-			"allOwners": "Все пользователи"
+			"allOwners": "Все пользователи",
+			"key": "Виртуальный ключ",
+			"allKeys": "Все ключи"
 		},
 		"endpoint": {
 			"chat": "Чат",
@@ -1417,7 +1419,8 @@
 			"live": "Онлайн",
 			"interrupted": "Прервано",
 			"cacheInflated": "Завышено попаданиями в кэш промптов",
-			"keyDeleted": "Удалено"
+			"keyDeleted": "Удалено",
+			"ip": "IP"
 		},
 		"tooltip": {
 			"timeDate": "Отметка времени для запроса",
@@ -1441,7 +1444,8 @@
 			"keyDecryption": "Расшифровка ключа",
 			"dial": "Набор (DNS+TCP)",
 			"settingsReads": "Чтения настроек",
-			"reused": "повторно использовано"
+			"reused": "повторно использовано",
+			"ip": "IP-адрес клиента, с которого пришёл запрос"
 		},
 		"status": {
 			"interrupted": "Прервано"
@@ -2841,9 +2845,7 @@
 			"copyModelId": "Копировать ID модели",
 			"resolved": "разрешено",
 			"provider": "Поставщик",
-			"dbRowId": "ID строки БД",
 			"timestamp": "Отметка времени",
-			"copyDbRowId": "Копировать ID строки базы данных",
 			"virtualKey": "Виртуальный ключ",
 			"tokenUsage": "Использование токена",
 			"prompt": "Prompt",
@@ -2873,7 +2875,9 @@
 			"error": "Ошибка",
 			"copyErrorMessage": "Копировать сообщение об ошибке",
 			"expandForBreakdown": "Разверните для пошаговой разбивки",
-			"performance": "Производительность"
+			"performance": "Производительность",
+			"clientIp": "IP клиента",
+			"copyClientIp": "Копировать IP клиента"
 		},
 		"statusBadge": {
 			"streaming": "Стриминг",
@@ -2914,7 +2918,8 @@
 			"internal": "внутренняя",
 			"cacheInflated": "Завышено попаданиями в кэш промптов",
 			"deleted": "Удалено",
-			"zeroEntries": "0 записей"
+			"zeroEntries": "0 записей",
+			"ip": "IP"
 		},
 		"virtualAppLogTable": {
 			"noEntriesFound": "Записи журнала не найдены",

--- a/web/src/i18n/locales/sk.json
+++ b/web/src/i18n/locales/sk.json
@@ -1388,7 +1388,9 @@
 			"allStatus": "Všetky stavy",
 			"allEndpoints": "Všetky modality",
 			"owner": "Vlastník",
-			"allOwners": "Všetci používatelia"
+			"allOwners": "Všetci používatelia",
+			"key": "Virtuálny kľúč",
+			"allKeys": "Všetky kľúče"
 		},
 		"endpoint": {
 			"chat": "Chat",
@@ -1417,7 +1419,8 @@
 			"live": "Naživo",
 			"interrupted": "Prerušené",
 			"cacheInflated": "Navýšené zásahmi do cache výziev",
-			"keyDeleted": "Odstránené"
+			"keyDeleted": "Odstránené",
+			"ip": "IP"
 		},
 		"tooltip": {
 			"timeDate": "Časová pečiatka požiadavky",
@@ -1441,7 +1444,8 @@
 			"keyDecryption": "Dešifrovanie kľúča",
 			"dial": "Vytočenie (DNS+TCP)",
 			"settingsReads": "Čítania nastavení",
-			"reused": "opätovne použitý"
+			"reused": "opätovne použitý",
+			"ip": "IP adresa klienta, z ktorej požiadavka prišla"
 		},
 		"status": {
 			"interrupted": "Prerušené"
@@ -2841,9 +2845,7 @@
 			"copyModelId": "Skopírovať ID modelu",
 			"resolved": "vyriešené",
 			"provider": "Poskytovateľ",
-			"dbRowId": "ID riadku v databáze",
 			"timestamp": "Časová pečiatka",
-			"copyDbRowId": "Kopírovať ID riadku databázy",
 			"virtualKey": "Virtuálny kľúč",
 			"tokenUsage": "Použitie tokenov",
 			"prompt": "Výzva",
@@ -2873,7 +2875,9 @@
 			"error": "Chyba",
 			"copyErrorMessage": "Skopírujte chybovú správu",
 			"expandForBreakdown": "Rozbaľte pre podrobné rozdelenie podľa krokov",
-			"performance": "Výkon"
+			"performance": "Výkon",
+			"clientIp": "IP klienta",
+			"copyClientIp": "Kopírovať IP klienta"
 		},
 		"statusBadge": {
 			"streaming": "Streamovanie",
@@ -2914,7 +2918,8 @@
 			"internal": "interný",
 			"cacheInflated": "Navýšené zásahmi do cache výziev",
 			"deleted": "Odstránené",
-			"zeroEntries": "0 záznamov"
+			"zeroEntries": "0 záznamov",
+			"ip": "IP"
 		},
 		"virtualAppLogTable": {
 			"noEntriesFound": "Nenašli sa žiadne záznamy v protokole",

--- a/web/src/i18n/locales/sr.json
+++ b/web/src/i18n/locales/sr.json
@@ -1346,7 +1346,9 @@
 			"allStatus": "Сви статуси",
 			"allEndpoints": "Сви модалитети",
 			"owner": "Власник",
-			"allOwners": "Сви корисници"
+			"allOwners": "Сви корисници",
+			"key": "Виртуелни кључ",
+			"allKeys": "Сви кључеви"
 		},
 		"endpoint": {
 			"chat": "Чет",
@@ -1375,7 +1377,8 @@
 			"live": "Уживо",
 			"interrupted": "Прекинуто",
 			"cacheInflated": "Увећано погоцима кеша упита",
-			"keyDeleted": "Избрисано"
+			"keyDeleted": "Избрисано",
+			"ip": "IP"
 		},
 		"tooltip": {
 			"timeDate": "Временски печат захтева",
@@ -1399,7 +1402,8 @@
 			"keyDecryption": "Дешифровање кључа",
 			"dial": "Дијал (DNS+TCP)",
 			"settingsReads": "Читања подешавања",
-			"reused": "поново искоришћено"
+			"reused": "поново искоришћено",
+			"ip": "IP адреса клијента са које је захтев стигао"
 		},
 		"status": {
 			"interrupted": "Прекинуто"
@@ -2781,9 +2785,7 @@
 			"copyModelId": "Копирајте ИД модела",
 			"resolved": "решено",
 			"provider": "Пружалац",
-			"dbRowId": "ИД реда у бази података",
 			"timestamp": "Временски жиг",
-			"copyDbRowId": "Копирајте ИД реда у бази података",
 			"virtualKey": "Виртуелни кључ",
 			"tokenUsage": "Употреба токена",
 			"prompt": "Упит",
@@ -2813,7 +2815,9 @@
 			"error": "Грешка",
 			"copyErrorMessage": "Копирајте поруку о грешци",
 			"expandForBreakdown": "Прошири за рашчлањавање по корацима",
-			"performance": "Перформансе"
+			"performance": "Перформансе",
+			"clientIp": "IP клијента",
+			"copyClientIp": "Копирај IP клијента"
 		},
 		"statusBadge": {
 			"streaming": "Стриминг",
@@ -2854,7 +2858,8 @@
 			"internal": "унутрашњи",
 			"cacheInflated": "Увећано погоцима кеша упита",
 			"deleted": "Избрисано",
-			"zeroEntries": "0 уноса"
+			"zeroEntries": "0 уноса",
+			"ip": "IP"
 		},
 		"virtualAppLogTable": {
 			"noEntriesFound": "Није пронађен ниједан запис у дневнику",

--- a/web/src/i18n/locales/sv.json
+++ b/web/src/i18n/locales/sv.json
@@ -1304,7 +1304,9 @@
 			"allStatus": "Alla statusar",
 			"allEndpoints": "Alla modaliteter",
 			"owner": "Ägare",
-			"allOwners": "Alla användare"
+			"allOwners": "Alla användare",
+			"key": "Virtuell nyckel",
+			"allKeys": "Alla nycklar"
 		},
 		"endpoint": {
 			"chat": "Chatt",
@@ -1333,7 +1335,8 @@
 			"live": "Live",
 			"interrupted": "Avbruten",
 			"cacheInflated": "Inflated by prompt cache hits",
-			"keyDeleted": "Borttagen"
+			"keyDeleted": "Borttagen",
+			"ip": "IP"
 		},
 		"tooltip": {
 			"timeDate": "Tidsstämpel för begäran",
@@ -1357,7 +1360,8 @@
 			"keyDecryption": "Nyckel dekryptering",
 			"dial": "Uppkoppling (DNS+TCP)",
 			"settingsReads": "Läser inställningar",
-			"reused": "återanvänd"
+			"reused": "återanvänd",
+			"ip": "Klientens IP-adress som begäran kom från"
 		},
 		"status": {
 			"interrupted": "Avbruten"
@@ -2721,9 +2725,7 @@
 			"copyModelId": "Kopiera modell-ID",
 			"resolved": "löst",
 			"provider": "Leverantör",
-			"dbRowId": "DB Rad ID",
 			"timestamp": "Tidsstämpel",
-			"copyDbRowId": "Kopiera DB rad-ID",
 			"virtualKey": "Virtuell nyckel",
 			"tokenUsage": "Token användning",
 			"prompt": "Prompt",
@@ -2753,7 +2755,9 @@
 			"error": "Fel",
 			"copyErrorMessage": "Kopiera felmeddelande",
 			"expandForBreakdown": "Expandera för uppdelningen per steg",
-			"performance": "Prestanda"
+			"performance": "Prestanda",
+			"clientIp": "Klient-IP",
+			"copyClientIp": "Kopiera klient-IP"
 		},
 		"statusBadge": {
 			"streaming": "Strömning",
@@ -2794,7 +2798,8 @@
 			"internal": "intern",
 			"cacheInflated": "Inflated by prompt cache hits",
 			"deleted": "Borttagen",
-			"zeroEntries": "0 poster"
+			"zeroEntries": "0 poster",
+			"ip": "IP"
 		},
 		"virtualAppLogTable": {
 			"noEntriesFound": "Inga loggposter hittades",

--- a/web/src/i18n/locales/tr.json
+++ b/web/src/i18n/locales/tr.json
@@ -1304,7 +1304,9 @@
 			"allStatus": "Tüm Durumlar",
 			"allEndpoints": "Tüm Modaliteler",
 			"owner": "Sahip",
-			"allOwners": "Tüm kullanıcılar"
+			"allOwners": "Tüm kullanıcılar",
+			"key": "Sanal anahtar",
+			"allKeys": "Tüm anahtarlar"
 		},
 		"endpoint": {
 			"chat": "Sohbet",
@@ -1333,7 +1335,8 @@
 			"live": "Canlı",
 			"interrupted": "Kesintiye uğramış",
 			"cacheInflated": "Komut istemi önbellek isabetleriyle şişmiş",
-			"keyDeleted": "Silindi"
+			"keyDeleted": "Silindi",
+			"ip": "IP"
 		},
 		"tooltip": {
 			"timeDate": "İsteğin zaman damgası",
@@ -1357,7 +1360,8 @@
 			"keyDecryption": "Anahtar Şifre Çözme",
 			"dial": "Arama (DNS+TCP)",
 			"settingsReads": "Ayar Okumaları",
-			"reused": "yeniden kullanılmış"
+			"reused": "yeniden kullanılmış",
+			"ip": "İsteğin geldiği istemci IP adresi"
 		},
 		"status": {
 			"interrupted": "Kesintiye uğramış"
@@ -2721,9 +2725,7 @@
 			"copyModelId": "Model kimliğini kopyala",
 			"resolved": "çözümlendi",
 			"provider": "Sağlayıcı",
-			"dbRowId": "Veritabanı Satır Kimliği",
 			"timestamp": "Zaman damgası",
-			"copyDbRowId": "Veritabanı satır kimliğini kopyala",
 			"virtualKey": "Sanal Anahtar",
 			"tokenUsage": "Jeton Kullanımı",
 			"prompt": "Komut",
@@ -2753,7 +2755,9 @@
 			"error": "Hata",
 			"copyErrorMessage": "Hata mesajını kopyala",
 			"expandForBreakdown": "Adım adım dökümü görmek için genişletin",
-			"performance": "Performans"
+			"performance": "Performans",
+			"clientIp": "İstemci IP'si",
+			"copyClientIp": "İstemci IP'sini kopyala"
 		},
 		"statusBadge": {
 			"streaming": "Akış",
@@ -2794,7 +2798,8 @@
 			"internal": "iç",
 			"cacheInflated": "Komut istemi önbellek isabetleriyle şişmiş",
 			"deleted": "Silindi",
-			"zeroEntries": "0 kayıt"
+			"zeroEntries": "0 kayıt",
+			"ip": "IP"
 		},
 		"virtualAppLogTable": {
 			"noEntriesFound": "Günlük girdisi bulunamadı",

--- a/web/src/i18n/locales/uk.json
+++ b/web/src/i18n/locales/uk.json
@@ -1388,7 +1388,9 @@
 			"allStatus": "Усі статуси",
 			"allEndpoints": "Усі модальності",
 			"owner": "Власник",
-			"allOwners": "Усі користувачі"
+			"allOwners": "Усі користувачі",
+			"key": "Віртуальний ключ",
+			"allKeys": "Усі ключі"
 		},
 		"endpoint": {
 			"chat": "Чат",
@@ -1417,7 +1419,8 @@
 			"live": "Наживо",
 			"interrupted": "Перервано",
 			"cacheInflated": "Завищено через влучання в кеш промптів",
-			"keyDeleted": "Видалено"
+			"keyDeleted": "Видалено",
+			"ip": "IP"
 		},
 		"tooltip": {
 			"timeDate": "Часова відмітка запиту",
@@ -1441,7 +1444,8 @@
 			"keyDecryption": "Розшифрування ключа",
 			"dial": "Набрати (DNS+TCP)",
 			"settingsReads": "Налаштування прочитань",
-			"reused": "повторно використовується"
+			"reused": "повторно використовується",
+			"ip": "IP-адреса клієнта, з якої надійшов запит"
 		},
 		"status": {
 			"interrupted": "Перервано"
@@ -2841,9 +2845,7 @@
 			"copyModelId": "Скопіювати ID моделі",
 			"resolved": "вирішено",
 			"provider": "Постачальник",
-			"dbRowId": "Id рядка БД",
 			"timestamp": "Часові відмітки",
-			"copyDbRowId": "Копіювати рядок бази даних ID",
 			"virtualKey": "Віртуальний ключ",
 			"tokenUsage": "Використання токенів",
 			"prompt": "Prompt",
@@ -2873,7 +2875,9 @@
 			"error": "Помилка",
 			"copyErrorMessage": "Скопіювати повідомлення про помилку",
 			"expandForBreakdown": "Розгорніть для покрокового розподілу",
-			"performance": "Продуктивність"
+			"performance": "Продуктивність",
+			"clientIp": "IP клієнта",
+			"copyClientIp": "Копіювати IP клієнта"
 		},
 		"statusBadge": {
 			"streaming": "Трансляція",
@@ -2914,7 +2918,8 @@
 			"internal": "внутрішній",
 			"cacheInflated": "Завищено через влучання в кеш промптів",
 			"deleted": "Видалено",
-			"zeroEntries": "0 записів"
+			"zeroEntries": "0 записів",
+			"ip": "IP"
 		},
 		"virtualAppLogTable": {
 			"noEntriesFound": "Не знайдено записів у журналі",

--- a/web/src/i18n/locales/vi.json
+++ b/web/src/i18n/locales/vi.json
@@ -1304,7 +1304,9 @@
 			"allStatus": "Tất cả trạng thái",
 			"allEndpoints": "Tất cả các phương thức",
 			"owner": "Chủ sở hữu",
-			"allOwners": "Tất cả người dùng"
+			"allOwners": "Tất cả người dùng",
+			"key": "Khóa ảo",
+			"allKeys": "Tất cả các khóa"
 		},
 		"endpoint": {
 			"chat": "Trò chuyện",
@@ -1333,7 +1335,8 @@
 			"live": "Trực tiếp",
 			"interrupted": "Bị gián đoạn",
 			"cacheInflated": "Tăng do các lần trúng bộ nhớ đệm lời nhắc",
-			"keyDeleted": "Đã xóa"
+			"keyDeleted": "Đã xóa",
+			"ip": "IP"
 		},
 		"tooltip": {
 			"timeDate": "Dấu thời gian của yêu cầu",
@@ -1357,7 +1360,8 @@
 			"keyDecryption": "Giải mã khóa",
 			"dial": "Quay số (DNS+TCP)",
 			"settingsReads": "Lượt đọc cài đặt",
-			"reused": "đã được tái sử dụng"
+			"reused": "đã được tái sử dụng",
+			"ip": "Địa chỉ IP của máy khách gửi yêu cầu"
 		},
 		"status": {
 			"interrupted": "Bị gián đoạn"
@@ -2721,9 +2725,7 @@
 			"copyModelId": "Sao chép ID mô hình",
 			"resolved": "đã được giải quyết",
 			"provider": "Nhà cung cấp",
-			"dbRowId": "ID hàng trong cơ sở dữ liệu",
 			"timestamp": "Dấu thời gian",
-			"copyDbRowId": "Sao chép ID hàng trong cơ sở dữ liệu",
 			"virtualKey": "Khóa ảo",
 			"tokenUsage": "Mức sử dụng token",
 			"prompt": "Lời nhắc",
@@ -2753,7 +2755,9 @@
 			"error": "Lỗi",
 			"copyErrorMessage": "Sao chép thông báo lỗi",
 			"expandForBreakdown": "Mở rộng để xem chi tiết theo từng bước",
-			"performance": "Hiệu suất"
+			"performance": "Hiệu suất",
+			"clientIp": "IP máy khách",
+			"copyClientIp": "Sao chép IP máy khách"
 		},
 		"statusBadge": {
 			"streaming": "Phát trực tuyến",
@@ -2794,7 +2798,8 @@
 			"internal": "nội bộ",
 			"cacheInflated": "Tăng do các lần trúng bộ nhớ đệm lời nhắc",
 			"deleted": "Đã xóa",
-			"zeroEntries": "0 kết quả"
+			"zeroEntries": "0 kết quả",
+			"ip": "IP"
 		},
 		"virtualAppLogTable": {
 			"noEntriesFound": "Không tìm thấy mục nhật ký nào",

--- a/web/src/i18n/locales/zh.json
+++ b/web/src/i18n/locales/zh.json
@@ -1304,7 +1304,9 @@
 			"allStatus": "所有状态",
 			"allEndpoints": "所有模态",
 			"owner": "所有者",
-			"allOwners": "所有用户"
+			"allOwners": "所有用户",
+			"key": "虚拟密钥",
+			"allKeys": "所有密钥"
 		},
 		"endpoint": {
 			"chat": "聊天",
@@ -1333,7 +1335,8 @@
 			"live": "实时模式",
 			"interrupted": "已中断",
 			"cacheInflated": "因提示缓存命中而偏高",
-			"keyDeleted": "已删除"
+			"keyDeleted": "已删除",
+			"ip": "IP"
 		},
 		"tooltip": {
 			"timeDate": "请求的时间戳",
@@ -1357,7 +1360,8 @@
 			"keyDecryption": "密钥解码",
 			"dial": "拨号 (DNS+TCP)",
 			"settingsReads": "设置读取",
-			"reused": "已重新使用"
+			"reused": "已重新使用",
+			"ip": "请求来源的客户端 IP 地址"
 		},
 		"status": {
 			"interrupted": "已中断"
@@ -2721,9 +2725,7 @@
 			"copyModelId": "复制模型ID",
 			"resolved": "已解决",
 			"provider": "提供商",
-			"dbRowId": "数据库行 ID",
 			"timestamp": "时间戳",
-			"copyDbRowId": "复制 DB 行 ID",
 			"virtualKey": "虚拟密钥",
 			"tokenUsage": "令牌使用情况",
 			"prompt": "Prompt",
@@ -2753,7 +2755,9 @@
 			"error": "错误",
 			"copyErrorMessage": "复制错误消息",
 			"expandForBreakdown": "展开以查看分步明细",
-			"performance": "性能"
+			"performance": "性能",
+			"clientIp": "客户端 IP",
+			"copyClientIp": "复制客户端 IP"
 		},
 		"statusBadge": {
 			"streaming": "流式传输",
@@ -2794,7 +2798,8 @@
 			"internal": "内部设置",
 			"cacheInflated": "因提示缓存命中而偏高",
 			"deleted": "已删除",
-			"zeroEntries": "0 个条目"
+			"zeroEntries": "0 个条目",
+			"ip": "IP"
 		},
 		"virtualAppLogTable": {
 			"noEntriesFound": "未找到日志条目",

--- a/web/src/lib/icons.tsx
+++ b/web/src/lib/icons.tsx
@@ -86,6 +86,7 @@ export const GitBranch = withId(Ph.GitBranchIcon, "GitBranch");
 export const GitCompare = withId(Ph.GitDiffIcon, "GitCompare");
 export const HardDrive = withId(Ph.HardDriveIcon, "HardDrive");
 export const Server = withId(Ph.HardDrivesIcon, "Server");
+export const Globe = withId(Ph.GlobeIcon, "Globe");
 export const Hash = withId(Ph.HashIcon, "Hash");
 export const Image = withId(Ph.ImageIcon, "Image");
 export const Info = withId(Ph.InfoIcon, "Info");

--- a/web/src/pages/AppLogs.tsx
+++ b/web/src/pages/AppLogs.tsx
@@ -37,7 +37,7 @@ import {
 	getLevelBadgeVariant,
 	getSourceBadgeClasses,
 } from "../utils/logBadgeUtils";
-import { decodeLogEscapes } from "../utils/logText";
+import { displayLogMessage } from "../utils/logText";
 
 type AppLogSortField = "time" | "level" | "source" | "message";
 
@@ -464,7 +464,7 @@ export function AppLogs() {
 											<td className="px-2 py-1 align-middle">
 												<div className="min-h-[2lh] flex items-center">
 													<div className="text-xs font-mono line-clamp-2 text-gray-400">
-														{decodeLogEscapes(entry.message)}
+														{displayLogMessage(entry.message, entry.escaped)}
 													</div>
 												</div>
 											</td>

--- a/web/src/pages/AppLogs.tsx
+++ b/web/src/pages/AppLogs.tsx
@@ -37,6 +37,7 @@ import {
 	getLevelBadgeVariant,
 	getSourceBadgeClasses,
 } from "../utils/logBadgeUtils";
+import { decodeLogEscapes } from "../utils/logText";
 
 type AppLogSortField = "time" | "level" | "source" | "message";
 
@@ -463,7 +464,7 @@ export function AppLogs() {
 											<td className="px-2 py-1 align-middle">
 												<div className="min-h-[2lh] flex items-center">
 													<div className="text-xs font-mono line-clamp-2 text-gray-400">
-														{entry.message}
+														{decodeLogEscapes(entry.message)}
 													</div>
 												</div>
 											</td>

--- a/web/src/pages/AppLogs.tsx
+++ b/web/src/pages/AppLogs.tsx
@@ -464,7 +464,11 @@ export function AppLogs() {
 											<td className="px-2 py-1 align-middle">
 												<div className="min-h-[2lh] flex items-center">
 													<div className="text-xs font-mono line-clamp-2 text-gray-400">
-														{displayLogMessage(entry.message, entry.escaped)}
+														{displayLogMessage(
+															entry.message,
+															entry.escaped,
+															entry.attrs_at,
+														)}
 													</div>
 												</div>
 											</td>

--- a/web/src/pages/Logs.tsx
+++ b/web/src/pages/Logs.tsx
@@ -67,7 +67,8 @@ function RequestLogs() {
 		| "ttft"
 		| "duration"
 		| "overhead"
-		| "key";
+		| "key"
+		| "ip";
 
 	const { logsSubMode, setLogsSubMode } = useSidebarMode();
 	const [page, setPage] = useState(1);
@@ -77,16 +78,27 @@ function RequestLogs() {
 		provider_id: "",
 		status_code: "",
 		endpoint_type: "",
+		virtual_key_id: "",
 		owner_user_id: "",
 	});
 
 	// Owner filter is admin-only: non-admins are already server-scoped to
 	// their own keys, so the dropdown would be dead weight for them.
-	const { isAdmin } = useIdentity();
+	const { isAdmin, can } = useIdentity();
 	const { data: ownerOptions } = useQuery({
 		queryKey: ["users"],
 		queryFn: () => api.users.list(),
 		enabled: isAdmin,
+		staleTime: 60_000,
+	});
+	// Key filter rides the same card: the roster endpoint needs the
+	// virtual-keys grant, and the server scopes non-admins to their own keys.
+	const { data: keyOptions } = useQuery({
+		// Same key as the Virtual Keys page, so VK create/rename/delete
+		// invalidations refresh this dropdown too.
+		queryKey: ["virtualKeys"],
+		queryFn: () => api.virtualKeys.list(),
+		enabled: can("virtual_keys"),
 		staleTime: 60_000,
 	});
 	const debouncedModelId = useDebounce(filters.model_id, 300);
@@ -170,6 +182,7 @@ function RequestLogs() {
 			debouncedProviderId,
 			filters.status_code,
 			filters.endpoint_type,
+			filters.virtual_key_id,
 			filters.owner_user_id,
 			dateFrom,
 			dateTo,
@@ -183,6 +196,7 @@ function RequestLogs() {
 				provider_id: debouncedProviderId || undefined,
 				status_code: filters.status_code || undefined,
 				endpoint_type: filters.endpoint_type || undefined,
+				virtual_key_id: filters.virtual_key_id || undefined,
 				owner_user_id: filters.owner_user_id || undefined,
 				from: dateFrom || undefined,
 				to: dateTo || undefined,
@@ -205,6 +219,7 @@ function RequestLogs() {
 			provider_id: debouncedProviderId || undefined,
 			status_code: filters.status_code || undefined,
 			endpoint_type: filters.endpoint_type || undefined,
+			virtual_key_id: filters.virtual_key_id || undefined,
 			owner_user_id: filters.owner_user_id || undefined,
 			from: dateFrom || undefined,
 			to: dateTo || undefined,
@@ -214,6 +229,7 @@ function RequestLogs() {
 			debouncedProviderId,
 			filters.status_code,
 			filters.endpoint_type,
+			filters.virtual_key_id,
 			filters.owner_user_id,
 			dateFrom,
 			dateTo,
@@ -243,6 +259,7 @@ function RequestLogs() {
 				provider_id: params.provider_id as string | undefined,
 				status_code: params.status_code as string | undefined,
 				endpoint_type: params.endpoint_type as string | undefined,
+				virtual_key_id: params.virtual_key_id as string | undefined,
 				owner_user_id: params.owner_user_id as string | undefined,
 				from: params.from as string | undefined,
 				to: params.to as string | undefined,
@@ -478,7 +495,7 @@ function RequestLogs() {
 									setPage(1);
 								}}
 								placeholder={t("logs.filters.modelPlaceholder")}
-								className="w-50"
+								className="w-43"
 								autoFocus
 							/>
 							<FilterInput
@@ -488,7 +505,7 @@ function RequestLogs() {
 									setPage(1);
 								}}
 								placeholder={t("logs.filters.providerPlaceholder")}
-								className="w-50"
+								className="w-43"
 							/>
 							<FilterDropdown
 								value={filters.status_code}
@@ -504,7 +521,7 @@ function RequestLogs() {
 									{ value: "5xx", label: "5XX" },
 									{ value: "0", label: "0" },
 								]}
-								className="w-36"
+								className="w-31"
 							/>
 							<FilterDropdown
 								value={filters.endpoint_type}
@@ -518,8 +535,25 @@ function RequestLogs() {
 									value: o.value,
 									label: t(o.labelKey),
 								}))}
-								className="w-36"
+								className="w-38"
 							/>
+
+							{(keyOptions?.length ?? 0) > 0 && (
+								<FilterDropdown
+									value={filters.virtual_key_id}
+									onChange={(v) => {
+										setFilters({ ...filters, virtual_key_id: v });
+										setPage(1);
+									}}
+									placeholder={t("logs.filters.key")}
+									allLabel={t("logs.filters.allKeys")}
+									options={(keyOptions ?? []).map((k) => ({
+										value: k.id,
+										label: k.name,
+									}))}
+									className="w-28"
+								/>
+							)}
 
 							{isAdmin && (ownerOptions?.length ?? 0) > 0 && (
 								<FilterDropdown
@@ -534,7 +568,7 @@ function RequestLogs() {
 										value: u.id,
 										label: u.username,
 									}))}
-									className="w-36"
+									className="w-30"
 								/>
 							)}
 
@@ -663,6 +697,13 @@ function RequestLogs() {
 										sort={sort}
 										onSort={handleSort}
 										tooltip={t("logs.tooltip.key")}
+									/>
+									<SortableHeader
+										label={t("logs.table.ip")}
+										field="ip"
+										sort={sort}
+										onSort={handleSort}
+										tooltip={t("logs.tooltip.ip")}
 									/>
 								</tr>
 							</thead>
@@ -856,12 +897,18 @@ function RequestLogs() {
 														log.virtual_key_name || log.virtual_key_id || "-"
 													)}
 												</td>
+												<td
+													className="px-2 py-1 whitespace-nowrap text-xs text-gray-400 font-mono truncate"
+													title={log.client_ip || undefined}
+												>
+													{log.client_ip || "-"}
+												</td>
 											</Row>
 										);
 									})
 								) : (
 									<EmptyRow
-										colSpan={11}
+										colSpan={12}
 										message={t("logs.emptyState.requests")}
 									/>
 								)}

--- a/web/src/pages/__tests__/Logs.ipcolumn.test.tsx
+++ b/web/src/pages/__tests__/Logs.ipcolumn.test.tsx
@@ -1,0 +1,42 @@
+import { screen, waitFor } from "@testing-library/react";
+import { HttpResponse, http } from "msw";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createMockLogEntry, createMockLogs } from "../../test/logFixtures";
+import { server } from "../../test/mocks/server";
+import { renderWithProviders } from "../../test/utils";
+import { Logs } from "../Logs";
+
+// The paginated request-logs table carries an IP column fed by
+// request_logs.client_ip; rows predating the column fall back to a dash.
+
+describe("Logs IP column", () => {
+	beforeEach(() => {
+		server.resetHandlers();
+		vi.clearAllMocks();
+		localStorage.clear();
+		localStorage.setItem("requestLogsViewMode", "paginate");
+	});
+
+	it("renders the IP header and the row's client IP in paginate mode", async () => {
+		server.use(
+			http.get("/api/logs", () =>
+				HttpResponse.json(
+					createMockLogs([
+						createMockLogEntry({
+							model_id: "ip-model",
+							client_ip: "203.0.113.7",
+						}),
+					]),
+				),
+			),
+		);
+
+		renderWithProviders(<Logs />);
+
+		await waitFor(() => {
+			expect(screen.getByText("ip-model")).toBeInTheDocument();
+		});
+		expect(screen.getByText("IP")).toBeInTheDocument();
+		expect(screen.getByText("203.0.113.7")).toBeInTheDocument();
+	});
+});

--- a/web/src/pages/__tests__/Logs.keyfilter.test.tsx
+++ b/web/src/pages/__tests__/Logs.keyfilter.test.tsx
@@ -1,0 +1,130 @@
+import { screen, waitFor } from "@testing-library/react";
+import { HttpResponse, http } from "msw";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createMockLogEntry, createMockLogs } from "../../test/logFixtures";
+import { server } from "../../test/mocks/server";
+import { renderWithProviders } from "../../test/utils";
+import { Logs } from "../Logs";
+
+// Virtual-key filter on the request-logs page: the dropdown renders from
+// GET /api/virtual-keys and its selection rides the list query as
+// virtual_key_id.
+
+const keysFixture = [
+	{
+		id: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+		name: "jcode",
+		key_preview: "sk-...aa",
+		tokens_used: 0,
+		last_used_at: null,
+		created_at: "2026-07-01T10:00:00Z",
+	},
+	{
+		id: "11111111-2222-4333-8444-555555555555",
+		name: "other-key",
+		key_preview: "sk-...bb",
+		tokens_used: 0,
+		last_used_at: null,
+		created_at: "2026-07-01T10:00:00Z",
+	},
+];
+
+describe("Logs virtual-key filter", () => {
+	beforeEach(() => {
+		server.resetHandlers();
+		vi.clearAllMocks();
+		localStorage.clear();
+		localStorage.setItem("requestLogsViewMode", "paginate");
+	});
+
+	it("filters the list by the selected virtual key", async () => {
+		const keyedLogs = createMockLogs([
+			createMockLogEntry({ model_id: "jcode-model" }),
+		]);
+		const allLogs = createMockLogs([
+			createMockLogEntry({ model_id: "everyone-model" }),
+		]);
+		server.use(
+			http.get("/api/virtual-keys", () => HttpResponse.json(keysFixture)),
+			http.get("/api/logs", ({ request }) => {
+				const vk = new URL(request.url).searchParams.get("virtual_key_id");
+				return HttpResponse.json(
+					vk === keysFixture[0].id ? keyedLogs : allLogs,
+				);
+			}),
+		);
+
+		const { user } = renderWithProviders(<Logs />);
+
+		await waitFor(() => {
+			expect(screen.getByText("everyone-model")).toBeInTheDocument();
+		});
+
+		const keyButton = await screen.findByRole("button", {
+			name: /Virtual key/,
+		});
+		await user.click(keyButton);
+		await user.click(await screen.findByText("jcode"));
+
+		await waitFor(() => {
+			expect(screen.getByText("jcode-model")).toBeInTheDocument();
+		});
+		expect(screen.queryByText("everyone-model")).not.toBeInTheDocument();
+	});
+
+	it("forwards the selected key to the cursor fetch in scroll mode", async () => {
+		localStorage.setItem("requestLogsViewMode", "scroll");
+		const cursorKeys: (string | null)[] = [];
+		server.use(
+			http.get("/api/virtual-keys", () => HttpResponse.json(keysFixture)),
+			http.get("/api/logs/cursor", ({ request }) => {
+				const vk = new URL(request.url).searchParams.get("virtual_key_id");
+				cursorKeys.push(vk);
+				return HttpResponse.json({
+					entries: [
+						createMockLogEntry({
+							model_id:
+								vk === keysFixture[0].id ? "jcode-model" : "everyone-model",
+						}),
+					],
+					total: 1,
+					has_before: false,
+					has_after: false,
+				});
+			}),
+		);
+
+		const { user } = renderWithProviders(<Logs />);
+
+		await waitFor(() => {
+			expect(cursorKeys.length).toBeGreaterThan(0);
+		});
+
+		const keyButton = await screen.findByRole("button", {
+			name: /Virtual key/,
+		});
+		await user.click(keyButton);
+		await user.click(await screen.findByText("jcode"));
+
+		await waitFor(() => {
+			expect(cursorKeys).toContain(keysFixture[0].id);
+		});
+	});
+
+	it("hides the key dropdown when the key list is empty", async () => {
+		const seen = createMockLogs([
+			createMockLogEntry({ model_id: "solo-model" }),
+		]);
+		server.use(
+			http.get("/api/virtual-keys", () => HttpResponse.json([])),
+			http.get("/api/logs", () => HttpResponse.json(seen)),
+		);
+		renderWithProviders(<Logs />);
+		await waitFor(() => {
+			expect(screen.getByText("solo-model")).toBeInTheDocument();
+		});
+		expect(
+			screen.queryByRole("button", { name: /Virtual key/ }),
+		).not.toBeInTheDocument();
+	});
+});

--- a/web/src/test/logFixtures.ts
+++ b/web/src/test/logFixtures.ts
@@ -30,6 +30,7 @@ export interface MockLogEntry {
 	virtual_key_id: string;
 	virtual_key_name?: string;
 	endpoint_type?: string;
+	client_ip?: string;
 }
 
 export function createMockLogEntry(

--- a/web/src/utils/__tests__/logText.test.ts
+++ b/web/src/utils/__tests__/logText.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { decodeLogEscapes } from "../logText";
+
+describe("decodeLogEscapes", () => {
+	it("turns the \\x20 space escaping back into spaces for display", () => {
+		expect(
+			decodeLogEscapes('account fetched provider="Ollama\\x20Cloud" plan=pro'),
+		).toBe('account fetched provider="Ollama Cloud" plan=pro');
+	});
+
+	it("decodes multiple escaped spaces in one value", () => {
+		expect(decodeLogEscapes('model="My\\x20Great\\x20Model"')).toBe(
+			'model="My Great Model"',
+		);
+	});
+
+	it("preserves a literal \\x20 whose backslash is itself escaped", () => {
+		// The original value contained a literal `\x20`; quoteLogValue escaped
+		// its backslash to `\\`, so the line shows `\\x20` and must stay put.
+		expect(decodeLogEscapes('path="C:\\\\x20dir"')).toBe('path="C:\\\\x20dir"');
+	});
+
+	it("decodes an escaped space after a literal backslash", () => {
+		// `\\` (a literal backslash) followed by our `\x20` space escape.
+		expect(decodeLogEscapes('v="a\\\\\\x20b"')).toBe('v="a\\\\ b"');
+	});
+
+	it("leaves messages without escapes untouched", () => {
+		expect(decodeLogEscapes("request start client_ip=10.0.0.1")).toBe(
+			"request start client_ip=10.0.0.1",
+		);
+	});
+});

--- a/web/src/utils/__tests__/logText.test.ts
+++ b/web/src/utils/__tests__/logText.test.ts
@@ -50,10 +50,27 @@ describe("displayLogMessage", () => {
 	it("decodes only rows the backend marked as flattened-encoded", async () => {
 		const { displayLogMessage } = await import("../logText");
 		const msg = 'fetched provider="Ollama\\x20Cloud"';
-		expect(displayLogMessage(msg, true)).toBe(
+		expect(displayLogMessage(msg, true, 7)).toBe(
 			'fetched provider="Ollama Cloud"',
 		);
-		expect(displayLogMessage(msg, false)).toBe(msg);
-		expect(displayLogMessage(msg, undefined)).toBe(msg);
+		expect(displayLogMessage(msg, false, 7)).toBe(msg);
+		expect(displayLogMessage(msg, undefined, 7)).toBe(msg);
+	});
+
+	it("never decodes before the attribute boundary", async () => {
+		const { displayLogMessage } = await import("../logText");
+		// The message portion is an attribute-shaped literal; only the real
+		// attribute suffix decodes.
+		const msg = 'literal path="\\x20raw" provider="Ollama\\x20Cloud"';
+		expect(displayLogMessage(msg, true, 22)).toBe(
+			'literal path="\\x20raw" provider="Ollama Cloud"',
+		);
+	});
+
+	it("clamps an out-of-range boundary", async () => {
+		const { displayLogMessage } = await import("../logText");
+		const msg = 'a="b\\x20c"';
+		expect(displayLogMessage(msg, true, 9999)).toBe(msg);
+		expect(displayLogMessage(msg, true, -5)).toBe('a="b c"');
 	});
 });

--- a/web/src/utils/__tests__/logText.test.ts
+++ b/web/src/utils/__tests__/logText.test.ts
@@ -45,3 +45,15 @@ describe("decodeLogEscapes", () => {
 		);
 	});
 });
+
+describe("displayLogMessage", () => {
+	it("decodes only rows the backend marked as flattened-encoded", async () => {
+		const { displayLogMessage } = await import("../logText");
+		const msg = 'fetched provider="Ollama\\x20Cloud"';
+		expect(displayLogMessage(msg, true)).toBe(
+			'fetched provider="Ollama Cloud"',
+		);
+		expect(displayLogMessage(msg, false)).toBe(msg);
+		expect(displayLogMessage(msg, undefined)).toBe(msg);
+	});
+});

--- a/web/src/utils/__tests__/logText.test.ts
+++ b/web/src/utils/__tests__/logText.test.ts
@@ -67,6 +67,17 @@ describe("displayLogMessage", () => {
 		);
 	});
 
+	it("slices the boundary in UTF-16 code units, matching the backend", async () => {
+		const { displayLogMessage } = await import("../logText");
+		// "\u{1F680}\u6A21\u578B ready" is 10 UTF-16 code units (the emoji is a
+		// surrogate pair); the backend counts attrs_at in the same units, so
+		// slice(10) lands exactly on the attribute suffix.
+		const msg = '\u{1F680}\u6A21\u578B ready v="\\x20a"';
+		expect(displayLogMessage(msg, true, 10)).toBe(
+			'\u{1F680}\u6A21\u578B ready v=" a"',
+		);
+	});
+
 	it("clamps an out-of-range boundary", async () => {
 		const { displayLogMessage } = await import("../logText");
 		const msg = 'a="b\\x20c"';

--- a/web/src/utils/__tests__/logText.test.ts
+++ b/web/src/utils/__tests__/logText.test.ts
@@ -14,8 +14,16 @@ describe("decodeLogEscapes", () => {
 		);
 	});
 
+	it("leaves a raw \\x20 outside quotes alone", () => {
+		// The encoder only ever writes the space escape inside a quoted value;
+		// a bare one is raw text from a legacy line and must survive verbatim.
+		expect(decodeLogEscapes("legacy path=\\x20evidence")).toBe(
+			"legacy path=\\x20evidence",
+		);
+	});
+
 	it("preserves a literal \\x20 whose backslash is itself escaped", () => {
-		// The original value contained a literal `\x20`; quoteLogValue escaped
+		// The original value contained a literal `\x20`; the encoder escaped
 		// its backslash to `\\`, so the line shows `\\x20` and must stay put.
 		expect(decodeLogEscapes('path="C:\\\\x20dir"')).toBe('path="C:\\\\x20dir"');
 	});
@@ -23,6 +31,12 @@ describe("decodeLogEscapes", () => {
 	it("decodes an escaped space after a literal backslash", () => {
 		// `\\` (a literal backslash) followed by our `\x20` space escape.
 		expect(decodeLogEscapes('v="a\\\\\\x20b"')).toBe('v="a\\\\ b"');
+	});
+
+	it("does not treat an escaped quote as the end of the quoted value", () => {
+		expect(decodeLogEscapes('v="say\\x20\\"hi\\"\\x20now" next=\\x20raw')).toBe(
+			'v="say \\"hi\\" now" next=\\x20raw',
+		);
 	});
 
 	it("leaves messages without escapes untouched", () => {

--- a/web/src/utils/logText.ts
+++ b/web/src/utils/logText.ts
@@ -18,16 +18,19 @@
  * a quoted value does not end the token.
  */
 /** The display form of an app-log message: decoded only when the backend
- * marked the row as using the flattened encoding (AppLogEntry.escaped), so a
- * legacy or raw message containing a literal `\x20` is never altered. The
- * backend grants the flag only when the raw message portion contains neither
- * a quote nor a backslash, so on a flagged row every quote and backslash
- * belongs to encoder output and this scan cannot touch raw text or desync. */
+ * marked the row as using the flattened encoding (AppLogEntry.escaped), and
+ * only from the recorded attribute boundary (AppLogEntry.attrs_at) onward.
+ * Everything before the boundary is raw developer-written message text and
+ * is never altered, whatever it contains; everything after it is pure
+ * quoteLogValue output, on which the scan is exact. */
 export function displayLogMessage(
 	message: string,
 	escaped: boolean | undefined,
+	attrsAt?: number,
 ): string {
-	return escaped ? decodeLogEscapes(message) : message;
+	if (!escaped) return message;
+	const at = Math.min(Math.max(attrsAt ?? 0, 0), message.length);
+	return message.slice(0, at) + decodeLogEscapes(message.slice(at));
 }
 
 export function decodeLogEscapes(message: string): string {

--- a/web/src/utils/logText.ts
+++ b/web/src/utils/logText.ts
@@ -19,7 +19,10 @@
  */
 /** The display form of an app-log message: decoded only when the backend
  * marked the row as using the flattened encoding (AppLogEntry.escaped), so a
- * legacy or raw message containing a literal `\x20` is never altered. */
+ * legacy or raw message containing a literal `\x20` is never altered. The
+ * backend grants the flag only when the raw message portion contains neither
+ * a quote nor a backslash, so on a flagged row every quote and backslash
+ * belongs to encoder output and this scan cannot touch raw text or desync. */
 export function displayLogMessage(
 	message: string,
 	escaped: boolean | undefined,

--- a/web/src/utils/logText.ts
+++ b/web/src/utils/logText.ts
@@ -1,0 +1,19 @@
+/** Display-layer decoding for app-log lines.
+ *
+ * The backend's flattened k=v log form escapes spaces inside quoted attribute
+ * values as `\x20` (see internal/api/applogs_slog.go quoteLogValue) so that
+ * whitespace-splitting readers (CrowdSec grok, fail2ban, awk) can never be
+ * fed a forged key=value token by caller-controlled input. That protection is
+ * about the STORED text and line parsers; the dashboard renders text nodes,
+ * so it can safely show the human form.
+ *
+ * Only the space escaping is reversed. A `\x20` whose backslash is itself
+ * escaped (`\\x20`) was a literal `\x20` in the original value and stays put:
+ * an even run of preceding backslashes means the escape is ours, an odd run
+ * means the backslash belongs to the value.
+ */
+export function decodeLogEscapes(message: string): string {
+	return message.replace(/(\\*)\\x20/g, (match, slashes: string) =>
+		slashes.length % 2 === 0 ? `${slashes} ` : match,
+	);
+}

--- a/web/src/utils/logText.ts
+++ b/web/src/utils/logText.ts
@@ -1,19 +1,51 @@
 /** Display-layer decoding for app-log lines.
  *
- * The backend's flattened k=v log form escapes spaces inside quoted attribute
- * values as `\x20` (see internal/api/applogs_slog.go quoteLogValue) so that
- * whitespace-splitting readers (CrowdSec grok, fail2ban, awk) can never be
- * fed a forged key=value token by caller-controlled input. That protection is
- * about the STORED text and line parsers; the dashboard renders text nodes,
- * so it can safely show the human form.
+ * The backend's flattened k=v log form quotes any attribute value that holds
+ * a space, quote, backslash or control character (strconv.Quote) and then
+ * escapes the spaces inside that quoted value as `\x20` (see
+ * internal/api/applogs_slog.go quoteLogValue), so whitespace-splitting readers
+ * (CrowdSec grok, fail2ban, awk) can never be fed a forged key=value token by
+ * caller-controlled input. That protection is about the STORED text and line
+ * parsers; the dashboard renders text nodes, so it can safely show the human
+ * form.
  *
- * Only the space escaping is reversed. A `\x20` whose backslash is itself
- * escaped (`\\x20`) was a literal `\x20` in the original value and stays put:
- * an even run of preceding backslashes means the escape is ours, an odd run
- * means the backslash belongs to the value.
+ * Only the space escaping is reversed, and only where the encoder can have
+ * produced it: inside a double-quoted token. A `\x20` outside quotes is raw
+ * text (the pre-quoting encoder wrote bare values) and stays put, and so does
+ * a `\x20` whose backslash is itself escaped (`\\x20`): the encoder doubles a
+ * literal backslash, so an odd run of backslashes before `x20` is our space
+ * escape and an even run belongs to the value. An escaped quote (`\"`) inside
+ * a quoted value does not end the token.
  */
 export function decodeLogEscapes(message: string): string {
-	return message.replace(/(\\*)\\x20/g, (match, slashes: string) =>
-		slashes.length % 2 === 0 ? `${slashes} ` : match,
-	);
+	let out = "";
+	let inQuotes = false;
+	let i = 0;
+	while (i < message.length) {
+		const ch = message[i];
+		if (ch === "\\") {
+			let j = i;
+			while (j < message.length && message[j] === "\\") j++;
+			const run = j - i;
+			const escapesNext = run % 2 === 1;
+			if (inQuotes && escapesNext && message.startsWith("x20", j)) {
+				out += `${"\\".repeat(run - 1)} `;
+				i = j + 3;
+				continue;
+			}
+			if (escapesNext && message[j] === '"') {
+				// \" inside a quoted value: copy it through without toggling.
+				out += message.slice(i, j + 1);
+				i = j + 1;
+				continue;
+			}
+			out += message.slice(i, j);
+			i = j;
+			continue;
+		}
+		if (ch === '"') inQuotes = !inQuotes;
+		out += ch;
+		i++;
+	}
+	return out;
 }

--- a/web/src/utils/logText.ts
+++ b/web/src/utils/logText.ts
@@ -17,6 +17,16 @@
  * escape and an even run belongs to the value. An escaped quote (`\"`) inside
  * a quoted value does not end the token.
  */
+/** The display form of an app-log message: decoded only when the backend
+ * marked the row as using the flattened encoding (AppLogEntry.escaped), so a
+ * legacy or raw message containing a literal `\x20` is never altered. */
+export function displayLogMessage(
+	message: string,
+	escaped: boolean | undefined,
+): string {
+	return escaped ? decodeLogEscapes(message) : message;
+}
+
 export function decodeLogEscapes(message: string): string {
 	let out = "";
 	let inQuotes = false;

--- a/wiki/Privacy.md
+++ b/wiki/Privacy.md
@@ -48,6 +48,7 @@ The only information recorded is strictly necessary for routing, metering, and d
 | Request state | `state` | Lifecycle status: `pending` → `streaming` → `completed` / `failed` |
 | Endpoint family | `endpoint_type` | Which endpoint the request came through: `chat`, `embeddings`, `image`, `tts`, `stt` |
 | Request hash | `request_hash` | Random 16-character hex request identifier (see below) |
+| Client IP | `client_ip` | Source-address attribution of key usage (trusted-proxy resolved, see [IP Address Handling](#ip-address-handling); `NULL` on rows predating migration 073) |
 
 ### About `error_message`
 
@@ -113,7 +114,7 @@ To be explicit about the boundaries:
 | Audio input | ❌ Never | Passed through to provider unchanged |
 | API keys (provider or virtual) | ❌ Never | Decrypted in memory only, never written to logs or DB |
 | Request body content | ❌ Never | JSON bodies are parsed only for `model` and `stream`; multipart forms only for `model` |
-| IP addresses | ⚠️ Metadata | Recorded in app-log lines (access/auth), the audit trail, and the active-sessions list, each retention-bound; never in `request_logs` |
+| IP addresses | ⚠️ Metadata | Recorded in app-log lines (access/auth), the audit trail, the active-sessions list, and per-request in `request_logs.client_ip`; each follows its surface's retention (request logs: the `log_retention` setting, which defaults to keep-forever) |
 | User-agent strings | ⚠️ Sessions only | Up to 256 bytes stored per dashboard login for the active-sessions list; deleted with the session |
 | X-Forwarded-For headers | ⚠️ Resolved | Honored only from `TRUSTED_PROXIES`; the resolved client IP is what gets recorded, never the raw header |
 
@@ -182,8 +183,9 @@ The client address is resolved once per request with trusted-proxy awareness: `X
 - **Application logs**: access lines and auth warnings (failed logins, invalid keys) record the client IP alongside routing metadata, subject to the same retention as other app logs. Never request or prompt content.
 - **Audit trail**: each recorded admin action stores the caller address, pruned per the `audit_retention_days` setting.
 - **Active sessions**: each dashboard login stores the IP it was minted from, shown in Settings so the operator can spot a session that isn't theirs; it is deleted with the session.
+- **Request logs**: each proxied call's `request_logs` row stores the resolved client address (`client_ip`, since migration 073), so virtual-key usage stays attributable to a source address for as long as request logs are kept. Rows are purged together with the rest of the request log per the `log_retention` setting.
 
-`request_logs` (the per-proxied-call metering table) does **not** store client IPs.
+Note that `log_retention` defaults to keep-forever: if storing client addresses indefinitely is a concern for your deployment, set a bounded `log_retention` (see [Data Retention](#data-retention)) so request-log rows, `client_ip` included, are purged on schedule.
 
 ## Data Retention
 
@@ -277,7 +279,7 @@ See [Configuration](Configuration) for details.
 | Virtual key storage | SHA-256 hash (one-way) |
 | Provider key storage | AES-256-GCM + Argon2id (per-provider random salt, 8MB) |
 | Request content | Never logged, never stored |
-| IP addresses | Rate-limit buckets in-memory (10-minute cleanup); logged addresses follow app-log and audit retention |
+| IP addresses | Rate-limit buckets in-memory (10-minute cleanup); logged addresses follow app-log, audit, and request-log retention |
 | Error messages | Provider diagnostics only (200-char SSE, 2000-char failover, full in DB) |
 | Request identifiers | Random 8-byte hex (not content-based) |
 | Data retention | Configurable (1h to 30d, or forever) |
@@ -287,7 +289,7 @@ See [Configuration](Configuration) for details.
 
 Model Hotel's architecture supports compliance with data protection regulations:
 
-- **GDPR**: Prompts and responses are never stored. Operational metadata does include client IP addresses (personal data under the GDPR) in app logs, the audit trail, and the active-sessions list, all with bounded retention.
+- **GDPR**: Prompts and responses are never stored. Operational metadata does include client IP addresses (personal data under the GDPR) in app logs, the audit trail, the active-sessions list, and request logs (`client_ip`). App logs, the audit trail, and sessions are retention-bound by default; request logs default to keep-forever, so set `log_retention` to bound them when IP addresses must not be kept indefinitely.
 - **Data minimization**: Only essential operational data is collected.
 - **Purpose limitation**: Logged data is used only for routing, metering, and diagnostics.
 - **Storage limitation**: Automatic retention policies ensure logs are purged after configurable periods.

--- a/wiki/Request-Logging.md
+++ b/wiki/Request-Logging.md
@@ -46,6 +46,8 @@ All fields are written to the `request_logs` PostgreSQL table.
 | `tokens_completion_reasoning` | INT | Reasoning tokens (DeepSeek-R1, etc.). Written to DB and exposed in Logs API. |
 | `tokens_prompt_cache_hit` | INT | Prompt cache hit tokens (DeepSeek). Written to DB and exposed in the Logs API response. |
 | `tokens_prompt_cache_miss` | INT | Prompt cache miss tokens (DeepSeek). Written to DB and exposed in the Logs API response. |
+| `owner_user_id` | UUID | Owning dashboard user, stored **only** for keyless rows (dashboard chat/arena); keyed rows resolve their owner through the key's current owner instead (migration 067) |
+| `client_ip` | TEXT | Trusted-proxy-resolved client address, written at INSERT time (migration 073). NULL on rows predating the column. Shown in the dashboard Logs IP column and detail modal; see [Privacy](Privacy#ip-address-handling). |
 | `created_at` | TIMESTAMPTZ | When the request was inserted (defaults to `now()`) |
 
 ### Privacy Note
@@ -104,8 +106,8 @@ func (h *Handler) insertRequestLogAsync(logEntry *requestLogData) {
     logEntry.requestHash = generateRequestHash()
     
     // Async INSERT with minimal fields
-    INSERT INTO request_logs (id, model_id, request_hash, streaming, virtual_key_name, virtual_key_id, failover_attempt, state)
-    VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+    INSERT INTO request_logs (id, model_id, request_hash, streaming, virtual_key_name, virtual_key_id, failover_attempt, state, endpoint_type, owner_user_id, client_ip)
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
 }
 ```
 
@@ -118,6 +120,9 @@ Fields written at this stage:
 - `virtual_key_id` - From context (if authenticated)
 - `failover_attempt` - `0` initially
 - `state` - `"pending"`
+- `endpoint_type` - Endpoint family (`chat` when unset)
+- `owner_user_id` - Only for keyless dashboard rows (see the schema table)
+- `client_ip` - Trusted-proxy-resolved client address (NULL when the ingest path had none)
 
 All other fields are NULL at this point. The INSERT runs in a goroutine with a 5-second timeout.
 
@@ -523,6 +528,9 @@ The `request_logs` table has evolved through these migrations:
 | `042_cache_hits.sql` | Added: `cache_hits` JSONB (per-component cache hit/miss flags) |
 | `043_endpoint_type.sql` | Added: `endpoint_type` with default `'chat'` (multimodal proxy endpoints: embeddings, image, tts, stt) |
 | `045_error_kind.sql` | Added: `error_kind` (nullable machine-readable failure classification; no backfill) |
+| `067_request_log_owner.sql` | Added: `owner_user_id` (keyless-row attribution) + a partial index on it |
+| `073_request_log_client_ip.sql` | Added: `client_ip` (trusted-proxy-resolved client address; no backfill) |
+| `074_request_log_vk_index.sql` | Added a partial index on `virtual_key_id` for the Logs page's virtual-key filter |
 
 ## Implementation Details
 

--- a/wiki/Security.md
+++ b/wiki/Security.md
@@ -274,7 +274,7 @@ Applied **before authentication**, before the per-key limiter:
 - Always active when `RATE_LIMIT_ENABLED=true` (cannot be bypassed by users)
 - Mounted before auth middleware to catch unauthenticated floods (brute-force key guessing, etc.)
 - Respects `X-Forwarded-For` and `X-Real-IP` headers only when request originates from trusted proxy (configured via `TRUSTED_PROXIES` CIDR list)
-- The same resolved client IP is what access log lines, auth warnings, the audit trail, and the active-sessions list record, so every surface reports one consistent address per request
+- The same resolved client IP is what access log lines, auth warnings, the audit trail, the active-sessions list, and each request-log row (`request_logs.client_ip`) record, so every surface reports one consistent address per request
 - List only CIDRs of proxies you control in `TRUSTED_PROXIES`: an entry there lets that peer's forwarded header dictate the address recorded in logs and the audit trail, so an over-broad list (never use `0.0.0.0/0`) turns the audit trail forgeable
 
 ### Layer 2: Per-Virtual-Key Rate Limiting (Usage Control)


### PR DESCRIPTION
## What

Request-log attribution and Logs-page usability, in one batch:

- **Client IP on request logs**: migration 073 adds `request_logs.client_ip`, stamped from the trusted-proxy-aware resolver (`internal/clientip`, the same one the app-log access lines use) on every ingest path: chat, `/v1/messages`, multipart endpoints, admin chat, and the admin Test button. "Who used this key" is now answerable from the durable, retention-controlled table instead of the fast-rotating app logs.
- **Virtual-key filter**: `/api/logs` and `/api/logs/cursor` accept `virtual_key_id` (partial index in migration 074), surfaced as a grant-gated "Virtual key" dropdown on the Logs page. New `ip` sort key, whitelist-pinned like the others.
- **Dashboard**: new IP column in both pagination and scroll modes; the request detail modal shows a copyable Client IP where the DB row id cell used to be (nobody needed a DB row id in normal operation). i18n filled across all 29 locales.
- **1440p width pass**: the requests table and its filter row are re-budgeted to the content column's measured width, so every header renders unclipped at 1440p in both modes (Status/Headers/Duration/Overhead used to ellipsize, as did the "All Modalities" dropdown). Only IPv6 and long model/key values truncate, behind tooltips.
- **Readable app-log escapes**: the stored `\x20` space-escaping in attribute values stays (log-injection defense for whitespace-splitting parsers), but the dashboard now decodes it for display and copy, and the server-side app-log search also matches the escaped form, so searching "Ollama Cloud" finds `provider="Ollama\x20Cloud"` lines.

## Privacy note

`request_logs` now carries an IP, which the wiki previously said it never would. Privacy.md, Security.md, and Request-Logging.md are updated accordingly, including the GDPR paragraph: request-log retention defaults to keep-forever, so deployments that must bound IP storage should set `log_retention` (the docs now say so explicitly).

## Verification

- TDD throughout; 3846+ backend tests, full frontend suite with coverage, golangci-lint, Biome/ESLint/tsc, and `make i18n-check` all green.
- Column budget verified by measurement at 2560x1440 (headless Chromium, per-cell overflow audit), not by eye.
- Second-opinion review by an opus agent; all 8 findings fixed (the three majors were the stale wiki privacy claims, which auto-publish on merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
