### PR TITLE
fix(web): pill tooltips carry the routable proxy ID, not the display name

### DIFF
--- a/web/src/components/ModelPicker.tsx
+++ b/web/src/components/ModelPicker.tsx
@@ -11,7 +11,7 @@ import {
 import type { GenerationParams, Model } from "../api/types";
 import { useModels } from "../hooks/useModels";
 import { ModelDetailModal } from "../pages/Models/ModelDetailModal";
-import { parseCapabilities } from "../utils/model";
+import { parseCapabilities, proxyModelID } from "../utils/model";
 import type { CapKey } from "./capMeta";
 import { CAP_META, hasCap, matchesAllCaps } from "./capMeta";
 import { FilterInput } from "./FilterInput";
@@ -80,10 +80,6 @@ interface MultiProps {
 }
 
 type ModelPickerProps = SingleProps | MultiProps;
-
-function proxyModelID(providerName: string, modelId: string): string {
-	return `${providerName.replace(/ /g, "-")}/${modelId}`;
-}
 
 export function ModelPicker({
 	id,
@@ -412,7 +408,10 @@ export function ModelPicker({
 													title={
 														m.unavailable && m.unavailableReason
 															? m.unavailableReason
-															: `${m.provider_name}/${m.display_name || m.model_id}`
+															: // The routable proxy ID, not the display name: two model
+																// paths can share one display name (same model served on
+																// two routes), and the tooltip is what tells them apart.
+																val
 													}
 												>
 													<button

--- a/web/src/components/__tests__/ModelPicker.test.tsx
+++ b/web/src/components/__tests__/ModelPicker.test.tsx
@@ -677,8 +677,71 @@ describe("ModelPicker", () => {
 		it("has proper title on model chips", () => {
 			renderWithProviders(<ModelPicker {...defaultProps} />);
 			const gptChip = screen.getByText("GPT-4").closest("div");
-			// Title format: provider_name/display_name
-			expect(gptChip).toHaveAttribute("title", "OpenAI/GPT-4");
+			// The tooltip carries the routable proxy ID (provider/model_id), the
+			// same string the detail modal's copy icon yields.
+			expect(gptChip).toHaveAttribute("title", "OpenAI/gpt-4");
+		});
+
+		it("gives distinct tooltips to models sharing a display name", () => {
+			// Two provider paths can enrich to the same display name (e.g. both
+			// NeuralWatt DeepSeek variants read "Deepseek V4 Flash"). The pill label
+			// is then identical, so the tooltip must expose the raw model_id or the
+			// pair looks like a duplicate.
+			const twins: Model[] = [
+				{
+					...mockModels[0],
+					model_id: "deepseek-ai/DeepSeek-V4-Flash",
+					display_name: "Deepseek V4 Flash",
+					provider_name: "Neuralwatt",
+				},
+				{
+					...mockModels[1],
+					model_id: "deepseek-v4-flash",
+					display_name: "Deepseek V4 Flash",
+					provider_name: "Neuralwatt",
+				},
+			];
+			renderWithProviders(<ModelPicker {...defaultProps} models={twins} />);
+
+			const titles = screen
+				.getAllByText("Deepseek V4 Flash")
+				.map((el) => el.closest("div")?.getAttribute("title"));
+			expect(titles).toHaveLength(2);
+			expect(new Set(titles)).toEqual(
+				new Set([
+					"Neuralwatt/deepseek-ai/DeepSeek-V4-Flash",
+					"Neuralwatt/deepseek-v4-flash",
+				]),
+			);
+		});
+
+		it("normalizes provider-name spaces in the chip tooltip", () => {
+			// The tooltip is the routable proxy ID, so a spaced provider name shows
+			// its dashed form, exactly as the detail modal's copy icon yields it.
+			const spaced: Model[] = [
+				{
+					...mockModels[0],
+					provider_name: "Model Hotel",
+					model_id: "house-model",
+					display_name: "House Model",
+				},
+			];
+			renderWithProviders(<ModelPicker {...defaultProps} models={spaced} />);
+			const chip = screen.getByText("House Model").closest("div");
+			expect(chip).toHaveAttribute("title", "Model-Hotel/house-model");
+		});
+
+		it("shows the unavailable reason as the chip tooltip for N/A models", () => {
+			const na = [
+				{
+					...mockModels[0],
+					unavailable: true,
+					unavailableReason: "Provider disabled",
+				},
+			];
+			renderWithProviders(<ModelPicker {...defaultProps} models={na} />);
+			const chip = screen.getByText("GPT-4").closest("div");
+			expect(chip).toHaveAttribute("title", "Provider disabled");
 		});
 
 		it("has proper aria-label on collapse buttons", () => {

--- a/web/src/pages/Arena/SwapPicker.tsx
+++ b/web/src/pages/Arena/SwapPicker.tsx
@@ -136,6 +136,9 @@ export function SwapPicker({
 												type="button"
 												key={id}
 												onClick={() => onSelect(id)}
+												// The routable proxy ID: two model paths can share one
+												// display name, and the tooltip is what tells them apart.
+												title={id}
 												className="ui-tab px-2 py-0.5 text-[11px] border bg-(--surface-hover) border-(--border-subtle) text-(--text-secondary) hover:text-(--text-primary) hover:border-(--accent)/40 transition-colors"
 											>
 												{m.display_name || m.model_id}

--- a/web/src/pages/Arena/__tests__/SwapPicker.test.tsx
+++ b/web/src/pages/Arena/__tests__/SwapPicker.test.tsx
@@ -72,6 +72,37 @@ describe("SwapPicker", () => {
 		expect(screen.getByText("Model Two")).toBeInTheDocument();
 	});
 
+	it("gives pills distinct proxy-ID tooltips when display names collide", () => {
+		// Two model paths can share one display name (same model served on two
+		// routes); the label is then identical, so the tooltip must carry the
+		// routable proxy ID or the pair looks like a duplicate.
+		const models = [
+			createModel(
+				"Neuralwatt",
+				"deepseek-ai/DeepSeek-V4-Flash",
+				"Deepseek V4 Flash",
+			),
+			createModel("Neuralwatt", "deepseek-v4-flash", "Deepseek V4 Flash"),
+		];
+		renderWithProviders(
+			<SwapPicker
+				enabledModels={models}
+				disabledModels={new Set()}
+				alreadyUsed={[]}
+				onSelect={mockOnSelect}
+			/>,
+		);
+		const titles = screen
+			.getAllByText("Deepseek V4 Flash")
+			.map((el) => el.getAttribute("title"));
+		expect(new Set(titles)).toEqual(
+			new Set([
+				"Neuralwatt/deepseek-ai/DeepSeek-V4-Flash",
+				"Neuralwatt/deepseek-v4-flash",
+			]),
+		);
+	});
+
 	it("groups models by provider with provider headers", () => {
 		const models = [
 			createModel("OpenAI", "gpt-4", "GPT-4"),


### PR DESCRIPTION
## Problem

NeuralWatt serves the same model on two routes — `deepseek-ai/DeepSeek-V4-Flash` and `deepseek-v4-flash` — and both enrich to the display name **DeepSeek V4 Flash**. In the failover group editor (and every other `ModelPicker` surface) the two pills then look like exact duplicates: the label is the shared display name, and the tooltip was `provider_name/display_name`, so it collapsed to the same string too. Only the detail modal (the `[i]` button) revealed they are different models.

## Fix

- **`ModelPicker`**: the pill tooltip is now the routable proxy ID (`provider/model_id`) — byte-for-byte the string the detail modal's copy icon yields. The N/A-reason tooltip arm is unchanged. The hovering pair now reads `Neuralwatt/deepseek-ai/DeepSeek-V4-Flash` vs `Neuralwatt/deepseek-v4-flash`.
- **Arena `SwapPicker`** (same surface, found in review): its pills had no tooltip at all, so colliding display names were indistinguishable there too; they get the same proxy-ID `title`.
- **Dedup**: `ModelPicker` carried a private copy of `proxyModelID`; it now imports the shared `utils/model` implementation, so "tooltip equals copy-icon string" rests on one implementation.

## Tests

- New: same-display-name twins get distinct tooltips (ModelPicker + SwapPicker), spaced provider names normalize (`Model Hotel` → `Model-Hotel/...`), and the previously uncovered N/A-reason tooltip arm is pinned.
- Updated: the chip-title accessibility test asserts the proxy-ID format.
- Full frontend suite: 5886 passed; `tsc -b`, ESLint, Biome clean.
- Verified live on the rebuilt dev stack: served bundles carry the new tooltip logic and the NeuralWatt twin pair renders distinct titles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
