### PR TITLE
fix(ha): forward the TLS proxy's client IP chain through Traefik

### DIFF
--- a/deploy/ha/.env.example
+++ b/deploy/ha/.env.example
@@ -26,6 +26,14 @@ FRONTDESK_TOKEN=
 # real client IPs and HTTPS are read from X-Forwarded-* headers.
 FRONTDESK_TRUSTED_PROXIES=
 
+# Optional: same idea for the Traefik data plane on LB_PORT. CIDRs of the TLS
+# proxy in front of it; when set, Traefik passes that proxy's X-Forwarded-For
+# chain through to members instead of replacing it with the proxy's address.
+# For members to resolve the real client, each member's own TRUSTED_PROXIES
+# must list every hop in front of it: its usual ingress proxy plus the host
+# running this stack.
+LB_TRUSTED_PROXIES=
+
 # Host ports. LB_PORT is the client-facing /v1 + dashboard port; FRONTDESK_PORT
 # is the admin UI. Front both with the external TLS proxy. LB_PORT is also shown
 # in the sync wizard's final step so you know where to point your clients.

--- a/deploy/ha/docker-compose.yml
+++ b/deploy/ha/docker-compose.yml
@@ -31,6 +31,16 @@ services:
             # Data-plane entrypoint. The generated config routes onto "web", so
             # this name must stay in sync with internal/frontdesk/traefik.go.
             - "--entrypoints.web.address=:8080"
+            # CIDRs of the external TLS proxy fronting LB_PORT (comma-
+            # separated). When set, Traefik trusts that proxy's
+            # X-Forwarded-For chain and passes it through to members
+            # instead of replacing it with the proxy's own address, so
+            # members can attribute requests to the real client. Members
+            # must also list this stack's host in their own
+            # TRUSTED_PROXIES to walk the extra hop. Unset, every request
+            # routed through the LB reaches members attributed to a proxy
+            # address.
+            - "--entrypoints.web.forwardedHeaders.trustedIPs=${LB_TRUSTED_PROXIES:-}"
             # API/dashboard on its own entrypoint, NOT published to the host:
             # Front Desk polls it over the compose network for serverStatus.
             - "--entrypoints.traefik.address=:8081"

--- a/wiki/High-Availability.md
+++ b/wiki/High-Availability.md
@@ -460,6 +460,16 @@ stamps the sync), but every long import gets reported as a failed push first.
 Set `FRONTDESK_PUBLIC_ORIGIN=https://frontdesk.example.com` and
 `FRONTDESK_TRUSTED_PROXIES` to the proxy's address in `.env`.
 
+`LB_TRUSTED_PROXIES` is the data-plane counterpart: set it to the same proxy
+CIDRs so Traefik passes the proxy's `X-Forwarded-For` chain through to the
+members instead of replacing it with the proxy's own address. Without it,
+every request routed through the load balancer reaches the members attributed
+to a proxy IP, in their request logs and app logs alike. Two settings must
+line up for members to show the real client: this variable on the HA stack,
+and each member's own `TRUSTED_PROXIES` listing every proxy hop in front of
+it, which behind this stack means its usual ingress proxy plus the host
+running Traefik.
+
 ---
 
 ## Observability


### PR DESCRIPTION
## Problem

The HA stack's Traefik entrypoint has no `forwardedHeaders.trustedIPs`, so it treats the external TLS proxy as an untrusted peer and replaces the `X-Forwarded-For` chain the proxy built with the proxy's own address. Any request routed through the load balancer therefore reaches members attributed to a proxy IP, in both the request log and the app logs, while requests hitting a member's own hostname attribute correctly. `TRUSTED_PROXIES` on the members cannot recover the client because the header no longer contains it by the time they see the request.

Observed live: traffic via the round-robin hostname logged the TLS proxy's address on every member; the same client via a member's direct hostname logged its real IP.

## Fix

New optional `LB_TRUSTED_PROXIES` env (documented in `.env.example`), fed into `--entrypoints.web.forwardedHeaders.trustedIPs` on the `web` entrypoint. When set to the TLS proxy's CIDRs, Traefik passes the proxy's `X-Forwarded-For` chain through to members instead of overwriting it. Empty default keeps current behavior; verified Traefik v3.7 starts cleanly with the empty value and `docker compose config` renders both cases.

Members must additionally list the Traefik host in their own `TRUSTED_PROXIES` to walk the extra hop; the HA wiki's reverse-proxy section now spells out the two settings that must line up.

## Verification

- `docker run traefik:v3` with the flag empty and populated: clean startup both ways.
- Live fleet with the member half applied: a request from the Traefik host with a spoofed `X-Forwarded-For: 9.9.9.9` resolves to `9.9.9.9` (the hop is walked) instead of the Traefik host's own address.
- No Go or frontend code changed; diff is compose, `.env.example`, and wiki only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
