### PR TITLE
fix(frontdesk): keep member URL credentials out of monitor-readable surfaces

### DIFF
--- a/internal/frontdesk/fleetstatus.go
+++ b/internal/frontdesk/fleetstatus.go
@@ -80,7 +80,7 @@ func (s *Server) fleetStatus(w http.ResponseWriter, r *http.Request) {
 		// generic "something went wrong".
 		writeJSON(w, http.StatusOK, fleetStatusResponse{
 			PrimaryID:   primary.ID,
-			PrimaryNote: fmt.Sprintf("could not read this member's admin API: %v. Check its URL and that its stored admin token is current.", err),
+			PrimaryNote: fmt.Sprintf("could not read this member's admin API: %s. Check its URL and that its stored admin token is current.", redactErrURL(err)),
 			Members:     []fleetMemberStatus{},
 			LBPort:      s.lbPort,
 		})

--- a/internal/frontdesk/hardening_test.go
+++ b/internal/frontdesk/hardening_test.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"testing/fstest"
@@ -191,6 +194,133 @@ func TestNormalizeMemberURLHTTPSGate(t *testing.T) {
 	// Opted in (allowHTTP=true): http accepted.
 	if _, err := normalizeMemberURL("http://mh1:8080", true); err != nil {
 		t.Errorf("http with allowHTTP=true: unexpected error %v", err)
+	}
+}
+
+// TestNormalizeMemberURLRejectsUserinfo guards the credential-leak fix: a
+// member base URL carrying userinfo (basic-auth credentials) is rejected at
+// add time, because the stored URL is re-emitted verbatim to wider audiences
+// (the unauthenticated /traefik/config endpoint and the device-readable
+// event log).
+func TestNormalizeMemberURLRejectsUserinfo(t *testing.T) {
+	rejected := []string{
+		"http://admin:S3cretPass@127.0.0.1:8086",
+		"https://user:pass@host.example",
+		"http://user@127.0.0.1:8086", // a bare username is still userinfo
+	}
+	for _, raw := range rejected {
+		if _, err := normalizeMemberURL(raw, true); !errors.Is(err, ErrValidation) {
+			t.Errorf("normalizeMemberURL(%q) = %v, want ErrValidation", raw, err)
+		}
+	}
+	if _, err := normalizeMemberURL("http://127.0.0.1:8086", true); err != nil {
+		t.Errorf("normalizeMemberURL without userinfo: unexpected error %v", err)
+	}
+}
+
+// TestStripUserinfo guards the defensive strip applied where stored member
+// URLs are rendered to unauthenticated or lower-privilege audiences:
+// userinfo is removed, credential-free URLs pass through unchanged, and an
+// unparseable string is returned as-is rather than dropped.
+func TestStripUserinfo(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"http://admin:S3cretPass@10.0.0.5:8080", "http://10.0.0.5:8080"},
+		{"https://user@mh1.internal:8080/base", "https://mh1.internal:8080/base"},
+		{"http://10.0.0.5:8080", "http://10.0.0.5:8080"},
+		{"http://exa mple.com", "http://exa mple.com"}, // unparseable: passthrough
+	}
+	for _, c := range cases {
+		if got := stripUserinfo(c.in); got != c.want {
+			t.Errorf("stripUserinfo(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// TestRedactErrURL guards the error rendering used by monitor-readable status
+// fields: userinfo embedded in a URL inside the error text is removed, whether
+// the *url.Error is the top-level error or wrapped, while the host, path, and
+// cause survive. An error without a URL passes through unchanged.
+func TestRedactErrURL(t *testing.T) {
+	base := &url.Error{Op: "Get", URL: "http://leakuser:leakpass@10.0.0.5:8080/health", Err: errors.New("dial tcp: connection refused")}
+	for _, err := range []error{base, fmt.Errorf("read export: %w", base)} {
+		got := redactErrURL(err)
+		if strings.Contains(got, "leakuser") || strings.Contains(got, "leakpass") {
+			t.Errorf("redactErrURL(%v) = %q, still carries credentials", err, got)
+		}
+		if !strings.Contains(got, "10.0.0.5:8080/health") {
+			t.Errorf("redactErrURL(%v) = %q, lost the host/path", err, got)
+		}
+	}
+	if got := redactErrURL(errors.New("plain failure")); got != "plain failure" {
+		t.Errorf("redactErrURL(plain) = %q, want passthrough", got)
+	}
+	// net/http renders the username percent-decoded, so an email-style
+	// username puts a literal @ inside the userinfo; the whole userinfo up to
+	// the last @ before the host must go.
+	multi := &url.Error{Op: "Get", URL: "http://leakuser@corp:***@10.0.0.5:8080/health", Err: errors.New("dial tcp: connection refused")}
+	got := redactErrURL(multi)
+	if strings.Contains(got, "leakuser") || strings.Contains(got, "corp") {
+		t.Errorf("redactErrURL(multi-@) = %q, still carries part of the username", got)
+	}
+	if !strings.Contains(got, "10.0.0.5:8080/health") {
+		t.Errorf("redactErrURL(multi-@) = %q, lost the host/path", got)
+	}
+}
+
+// TestListEventsStripsStoredURLUserinfo guards the read-side leg of the
+// credential-leak fix: an event row whose stored metadata predates the
+// userinfo rejection (e.g. from a restored backup) is returned with the
+// credentials removed, since /api/events is monitor-readable.
+func TestListEventsStripsStoredURLUserinfo(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	if _, err := s.InsertEvent(ctx, Event{
+		Type: "member.added", Severity: "info", Source: "frontdesk", Message: "legacy added",
+		Metadata: map[string]any{"url": "http://admin:S3cretPass@10.0.0.5:8080", "note": "kept"},
+	}); err != nil {
+		t.Fatalf("InsertEvent: %v", err)
+	}
+	evs, _, err := s.ListEvents(ctx, EventFilter{})
+	if err != nil {
+		t.Fatalf("ListEvents: %v", err)
+	}
+	if len(evs) != 1 {
+		t.Fatalf("events = %d, want 1", len(evs))
+	}
+	if got := evs[0].Metadata["url"]; got != "http://10.0.0.5:8080" {
+		t.Errorf("metadata url = %v, want credentials stripped", got)
+	}
+	if got := evs[0].Metadata["note"]; got != "kept" {
+		t.Errorf("metadata note = %v, want untouched", got)
+	}
+}
+
+// TestListMembersStripsStoredURLUserinfo guards the members-list leg of the
+// credential-leak fix: a member row whose stored URL predates the userinfo
+// rejection is listed without its credentials, since GET /api/members is
+// monitor-readable.
+func TestListMembersStripsStoredURLUserinfo(t *testing.T) {
+	srv, store := newTestServer(t)
+	ctx := context.Background()
+	m, err := store.CreateMember(ctx, "legacy", "http://10.0.0.5:8080", "")
+	if err != nil {
+		t.Fatalf("CreateMember: %v", err)
+	}
+	// Plant a pre-fix row shape directly: CreateMember itself now rejects it.
+	if _, err := store.db.ExecContext(ctx, "UPDATE members SET url = ? WHERE id = ?",
+		"http://admin:S3cretPass@10.0.0.5:8080", m.ID); err != nil {
+		t.Fatalf("plant legacy url: %v", err)
+	}
+	rec := do(t, srv, http.MethodGet, "/api/members", "", true)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /api/members = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	if strings.Contains(body, "S3cretPass") {
+		t.Errorf("members list still carries credentials: %s", body)
+	}
+	if !strings.Contains(body, "http://10.0.0.5:8080") {
+		t.Errorf("members list lost the member URL: %s", body)
 	}
 }
 

--- a/internal/frontdesk/poller.go
+++ b/internal/frontdesk/poller.go
@@ -254,13 +254,17 @@ func (p *Poller) checkHealth(ctx context.Context, baseURL string) HealthStatus {
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+memberHealthPath, http.NoBody)
 	if err != nil {
-		hs.Error = err.Error()
+		// redactErrURL: the status is monitor-readable and the dial error embeds
+		// the member URL, which can carry userinfo on a pre-rejection row.
+		hs.Error = redactErrURL(err)
 		return hs
 	}
 	resp, err := p.client.Do(req)
 	hs.LatencyMs = p.now().Sub(start).Milliseconds()
 	if err != nil {
-		hs.Error = err.Error()
+		// redactErrURL: the status is monitor-readable and the dial error embeds
+		// the member URL, which can carry userinfo on a pre-rejection row.
+		hs.Error = redactErrURL(err)
 		return hs
 	}
 	defer func() { _ = resp.Body.Close() }()

--- a/internal/frontdesk/poller.go
+++ b/internal/frontdesk/poller.go
@@ -563,7 +563,9 @@ func (p *Poller) PollTraefikOnce(ctx context.Context) {
 	var changed []string
 	for _, m := range members {
 		cur := p.statuses[m.ID]
-		next := statusByURL[m.URL] // "" when Traefik does not list it
+		// Key by the same URL BuildTraefikConfig publishes: a legacy row can
+		// still carry userinfo, which the emitted config strips.
+		next := statusByURL[stripUserinfo(m.URL)] // "" when Traefik does not list it
 		if next == "UP" {
 			delete(p.traefikNonUp, m.ID)
 		} else {

--- a/internal/frontdesk/poller_test.go
+++ b/internal/frontdesk/poller_test.go
@@ -529,3 +529,35 @@ func TestCheckHealthRedactsURLError(t *testing.T) {
 		t.Errorf("health error still carries credentials: %q", hs.Error)
 	}
 }
+
+// TestPollTraefikOnceMatchesStrippedLegacyURL guards the correlation key for
+// legacy rows: BuildTraefikConfig publishes a stored URL without its userinfo,
+// so Traefik reports status under the stripped URL, and the lookup must use
+// the same key or the member's Traefik badge stays blank forever.
+func TestPollTraefikOnceMatchesStrippedLegacyURL(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == traefikServicesAPI {
+			_, _ = w.Write([]byte(`[{"name":"hotel@http","serverStatus":{"http://a:8081":"UP"}}]`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	p, store, _ := newTestPoller(t, srv.URL)
+	ctx := context.Background()
+	m, err := store.CreateMember(ctx, "a", "http://a:8081", "")
+	if err != nil {
+		t.Fatalf("CreateMember: %v", err)
+	}
+	// Plant a pre-fix row shape directly: CreateMember itself now rejects it.
+	if _, err := store.db.ExecContext(ctx, "UPDATE members SET url = ? WHERE id = ?",
+		"http://leakuser:leakpass@a:8081", m.ID); err != nil {
+		t.Fatalf("plant legacy url: %v", err)
+	}
+
+	p.PollTraefikOnce(ctx)
+	if got := p.Snapshot()[m.ID].TraefikStatus; got != "UP" {
+		t.Errorf("legacy member traefik status = %q, want UP", got)
+	}
+}

--- a/internal/frontdesk/poller_test.go
+++ b/internal/frontdesk/poller_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -511,5 +512,20 @@ func TestConfigPollStaleAccessor(t *testing.T) {
 	now = base.Add(10 * time.Minute) // default threshold is 30s
 	if !p.ConfigPollStale(context.Background()) {
 		t.Fatal("10-minute-old poll not reported stale")
+	}
+}
+
+// TestCheckHealthRedactsURLError guards the health-status leg of the
+// credential-leak fix: a dial failure against a member URL that still carries
+// userinfo (a row stored before the rejection) is reported without the
+// credentials, since HealthStatus.Error is monitor-readable.
+func TestCheckHealthRedactsURLError(t *testing.T) {
+	p, _, _ := newTestPoller(t, "")
+	hs := p.checkHealth(context.Background(), "http://leakuser:leakpass@127.0.0.1:1")
+	if hs.Healthy || hs.Error == "" {
+		t.Fatalf("unreachable member should report an error: %+v", hs)
+	}
+	if strings.Contains(hs.Error, "leakuser") || strings.Contains(hs.Error, "leakpass") {
+		t.Errorf("health error still carries credentials: %q", hs.Error)
 	}
 }

--- a/internal/frontdesk/server_members.go
+++ b/internal/frontdesk/server_members.go
@@ -44,6 +44,14 @@ func (s *Server) listMembers(w http.ResponseWriter, r *http.Request) {
 	}
 	views := make([]memberView, len(members))
 	for i, m := range members {
+		// This list is monitor-readable: a row stored before normalizeMemberURL
+		// began rejecting userinfo must not surface its credentials. The store
+		// row keeps the URL as written; only the rendered copy is stripped.
+		if stripped := stripUserinfo(m.URL); stripped != m.URL {
+			mc := *m
+			mc.URL = stripped
+			m = &mc
+		}
 		views[i] = memberView{Member: m, Status: snap[m.ID]}
 		if e, ok := newest[m.ID]; ok {
 			ev := e
@@ -177,7 +185,7 @@ func (s *Server) createMember(w http.ResponseWriter, r *http.Request) {
 	s.emit(r.Context(), Event{
 		Type: "member.added", Severity: "info", Source: "frontdesk",
 		Message: m.Name + " added", MemberID: m.ID,
-		Metadata: map[string]any{"url": m.URL},
+		Metadata: map[string]any{"url": stripUserinfo(m.URL)},
 	})
 	writeJSON(w, http.StatusCreated, memberResponse{Member: m})
 }

--- a/internal/frontdesk/store_helpers.go
+++ b/internal/frontdesk/store_helpers.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"regexp"
 	"strings"
 	"time"
 )
@@ -57,6 +58,13 @@ func scanEvent(sc scanner) (Event, error) {
 		if err := json.Unmarshal([]byte(*metaJSON), &e.Metadata); err != nil {
 			return Event{}, fmt.Errorf("frontdesk: unmarshal event metadata: %w", err)
 		}
+		// Strip userinfo from a stored url on the way out: event reads are
+		// monitor-readable, and a row written before normalizeMemberURL began
+		// rejecting userinfo (e.g. from a restored backup) can still carry
+		// credentials. Live emits are already stripped at write time.
+		if raw, ok := e.Metadata["url"].(string); ok {
+			e.Metadata["url"] = stripUserinfo(raw)
+		}
 	}
 	if memberID != nil {
 		e.MemberID = *memberID
@@ -86,6 +94,15 @@ func normalizeMemberURL(raw string, allowHTTP bool) (string, error) {
 	if u.Host == "" {
 		return "", fmt.Errorf("%w: url must include a host", ErrValidation)
 	}
+	// Reject embedded credentials (userinfo): the stored URL is re-emitted
+	// unchanged by consumers with a wider audience than the admin who entered
+	// it (the unauthenticated /traefik/config endpoint and the device-readable
+	// event log), so it must never carry a secret. A member behind a
+	// basic-authenticated proxy needs a dedicated credential field, not
+	// userinfo in the base URL.
+	if u.User != nil {
+		return "", fmt.Errorf("%w: url must not contain credentials (userinfo)", ErrValidation)
+	}
 	// Reject a literal IP that is a known SSRF target (link-local, including the
 	// cloud-metadata endpoint, or the unspecified address) at add time for a
 	// clear error. Hostnames that resolve to such an address are caught later at
@@ -97,6 +114,35 @@ func normalizeMemberURL(raw string, allowHTTP bool) (string, error) {
 	u.RawQuery = ""
 	u.Fragment = ""
 	return u.String(), nil
+}
+
+// stripUserinfo removes embedded credentials (userinfo) from a URL before it
+// is rendered to an unauthenticated or lower-privilege audience. It is a
+// defensive backstop for member rows stored before normalizeMemberURL began
+// rejecting userinfo; an unparseable string is returned unchanged.
+func stripUserinfo(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil || u.User == nil {
+		return raw
+	}
+	u.User = nil
+	return u.String()
+}
+
+// urlUserinfoRE matches the userinfo component of a URL rendered inside free
+// text (everything between "scheme://" and the last @ before the host), so
+// error strings can be redacted without reconstructing the wrapped error
+// chain. The class allows @ and matches greedily: net/http renders the
+// username percent-decoded, so an email-style username carries a literal @
+// inside the userinfo and only the last @ separates it from the host.
+var urlUserinfoRE = regexp.MustCompile(`([a-zA-Z][a-zA-Z0-9+.-]*://)[^/?\s"]*@`)
+
+// redactErrURL renders err for a monitor-readable field, removing any userinfo
+// embedded in a URL inside the message. net/http already masks the password in
+// a *url.Error it returns, but keeps the username, and a member row stored
+// before normalizeMemberURL began rejecting userinfo can still carry both.
+func redactErrURL(err error) string {
+	return urlUserinfoRE.ReplaceAllString(err.Error(), "$1")
 }
 
 func affectedOrNotFound(res sql.Result, err error) error {

--- a/internal/frontdesk/traefik.go
+++ b/internal/frontdesk/traefik.go
@@ -94,7 +94,9 @@ func BuildTraefikConfig(members []*Member, set Settings) TraefikConfig {
 	servers := make([]TraefikServer, 0, len(members))
 	for _, m := range members {
 		if m.State == StateActive {
-			servers = append(servers, TraefikServer{URL: m.URL})
+			// stripUserinfo is a backstop for rows stored before userinfo was
+			// rejected at add time: this payload is served unauthenticated.
+			servers = append(servers, TraefikServer{URL: stripUserinfo(m.URL)})
 		}
 	}
 

--- a/internal/frontdesk/traefik_test.go
+++ b/internal/frontdesk/traefik_test.go
@@ -153,3 +153,21 @@ func TestBuildTraefikConfigJSONShape(t *testing.T) {
 		t.Error("missing services")
 	}
 }
+
+// TestBuildTraefikConfigStripsUserinfo guards the defense-in-depth strip on
+// the unauthenticated /traefik/config payload: a stored member URL that
+// predates the userinfo rejection in normalizeMemberURL is emitted without
+// its credentials.
+func TestBuildTraefikConfigStripsUserinfo(t *testing.T) {
+	cfg := BuildTraefikConfig(
+		[]*Member{{Name: "a", URL: "http://admin:S3cretPass@a:8081", State: StateActive}},
+		defaultSettings(),
+	)
+	servers := cfg.HTTP.Services[traefikServiceName].LoadBalancer.Servers
+	if len(servers) != 1 {
+		t.Fatalf("servers = %d, want 1", len(servers))
+	}
+	if servers[0].URL != "http://a:8081" {
+		t.Errorf("server URL = %q, want credentials stripped", servers[0].URL)
+	}
+}


### PR DESCRIPTION
## Summary

Closes security finding vuln-0001 (LOW, CWE-209): a member base URL with embedded basic-auth userinfo (`http://admin:pass@host`) was stored verbatim and re-emitted to audiences wider than the admin who entered it — the unauthenticated `GET /traefik/config` endpoint and monitor-readable reads.

### Write path (the fix)

`normalizeMemberURL` now rejects a URL carrying userinfo with a 400 (`url must not contain credentials (userinfo)`). A member behind a basic-authenticated proxy needs a dedicated credential field, not userinfo in the base URL.

### Read paths (backstop for pre-fix rows, e.g. restored backups)

An Opus second-opinion review of the initial fix found the validator alone leaves legacy rows leaking, and mapped every monitor-readable emit path. All are now stripped/redacted on the way out (the store row keeps the URL as written, so dialing is unchanged):

- `BuildTraefikConfig` strips userinfo from backend server URLs (unauthenticated consumer).
- `GET /api/members` renders a stripped copy of the member URL.
- `scanEvent` strips a stored `metadata.url`, covering `GET /api/events`, the inline newest-event pills, and `NewestEventOfTypes`.
- The `member.added` emit strips at write time (keeps the process-log/OTLP mirror clean).
- Poller health errors and the fleet-status primary note render through a new `redactErrURL`: `net/http` masks only the password in a `*url.Error` and keeps the username, and since the username is rendered percent-decoded, an email-style username contains a literal `@` — the redaction is regex-based and takes everything from `scheme://` to the last `@` (string-level because `fmt.Errorf`-wrapped chains bake the inner message at construction).

## Testing

- TDD throughout: every test was watched failing before its fix (including the multi-`@` username case, which the first regex got wrong).
- New tests: `TestNormalizeMemberURLRejectsUserinfo`, `TestStripUserinfo`, `TestBuildTraefikConfigStripsUserinfo`, `TestListMembersStripsStoredURLUserinfo`, `TestListEventsStripsStoredURLUserinfo`, `TestRedactErrURL`, `TestCheckHealthRedactsURLError`.
- Full `internal/frontdesk` suite: 559 passed; `golangci-lint` clean.
- Live-verified on the dev HA stack (rebuilt via `make ha-up`): add with creds URL → 400; a legacy row planted via SQL surfaced stripped on `/traefik/config` (unauthenticated), `/api/members`, `/api/events`, and in the poller health error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
