### PR TITLE
fix(api): owner-scope the provider list's total_tokens for non-admins

### DIFF
--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -756,7 +756,11 @@ func (h *Handler) ListProviders(w http.ResponseWriter, r *http.Request) {
 		modelCounts[providerID] = count
 	}
 
-	tokenRows, err := h.dbPool.Pool().Query(r.Context(), "SELECT provider_id, SUM(COALESCE(tokens_prompt, 0) + COALESCE(tokens_completion, 0)) FROM request_logs WHERE provider_id IS NOT NULL GROUP BY provider_id")
+	// Non-admins only ever see their own traffic in these totals: the same
+	// owner predicate the logs/stats surfaces apply, so a usage-granted user
+	// cannot read other tenants' aggregate volume off the provider list.
+	ownerFrag, ownerArgs := ownerFilterFragment(ownerScopeFromIdentity(r), 1)
+	tokenRows, err := h.dbPool.Pool().Query(r.Context(), "SELECT rl.provider_id, SUM(COALESCE(rl.tokens_prompt, 0) + COALESCE(rl.tokens_completion, 0)) FROM request_logs rl WHERE rl.provider_id IS NOT NULL"+ownerFrag+" GROUP BY rl.provider_id", ownerArgs...)
 	if err != nil {
 		respondError(w, "failed to query token counts", err, http.StatusInternalServerError)
 		return

--- a/internal/api/providers_ownerscope_test.go
+++ b/internal/api/providers_ownerscope_test.go
@@ -1,0 +1,109 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/hugalafutro/model-hotel/internal/user"
+)
+
+// The provider list's total_tokens is owner-scoped for non-admins: it applies
+// the same two-shape owner predicate as the logs/stats surfaces (keyed rows
+// through the key's current owner, keyless chat rows through the request-time
+// owner_user_id), so a usage-granted user reads only their own aggregate
+// volume while an admin still sees the fleet-wide total.
+func TestListProviders_TotalTokensOwnerScoped(t *testing.T) {
+	router, loginAs, mkUser := setupOwnershipTest(t)
+	pool := apiTestDB.Pool()
+	if _, err := pool.Exec(context.Background(), `TRUNCATE request_logs`); err != nil {
+		t.Fatalf("truncate request_logs: %v", err)
+	}
+
+	w := doJSON(t, router, http.MethodPost, "/providers", envAdminToken,
+		`{"name":"scope-provider","base_url":"https://api.example.com","api_key":"sk-scope"}`)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create provider: %d %s", w.Code, w.Body.String())
+	}
+	var created struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode provider: %v", err)
+	}
+
+	aliceID := mkUser("prov-alice", []string{string(user.GrantUsage)})
+	bobID := mkUser("prov-bob", []string{string(user.GrantUsage)})
+	aliceToken := loginAs(aliceID)
+	bobToken := loginAs(bobID)
+
+	mkKey := func(name, owner string) string {
+		w := doJSON(t, router, http.MethodPost, "/virtual-keys", envAdminToken,
+			fmt.Sprintf(`{"name":%q,"owner_user_id":%q}`, name, owner))
+		if w.Code != http.StatusCreated {
+			t.Fatalf("create key %s: %d %s", name, w.Code, w.Body.String())
+		}
+		return decodeVK(t, w.Body.Bytes()).ID
+	}
+	aliceKey := mkKey("prov-alice-key", aliceID)
+	bobKey := mkKey("prov-bob-key", bobID)
+
+	insert := func(vkID any, vkName string, ownerID any, prompt, completion int) {
+		_, err := pool.Exec(context.Background(),
+			`INSERT INTO request_logs (model_id, status_code, virtual_key_id, virtual_key_name, owner_user_id, provider_id, tokens_prompt, tokens_completion, created_at)
+			 VALUES ($1, 200, $2, $3, $4, $5, $6, $7, NOW())`,
+			"scope-model", vkID, vkName, ownerID, created.ID, prompt, completion)
+		if err != nil {
+			t.Fatalf("insert log: %v", err)
+		}
+	}
+	// Keyed rows resolve their owner through the key.
+	insert(aliceKey, "prov-alice-key", nil, 100, 200)
+	insert(bobKey, "prov-bob-key", nil, 300, 400)
+	// Keyless dashboard-chat row: owner stamped on the row itself.
+	insert(nil, "", aliceID, 7, 13)
+	// Pre-067 keyless row with no owner: counted for admins only.
+	insert(nil, "", nil, 1000, 1000)
+	// A row behind a key that is then deleted: the dangling virtual_key_id no
+	// longer resolves an owner, so its tokens leave bob's total and stay
+	// visible to admins only (same semantics as the logs/stats surfaces).
+	doomedKey := mkKey("prov-doomed-key", bobID)
+	insert(doomedKey, "prov-doomed-key", nil, 50, 50)
+	if w := doJSON(t, router, http.MethodDelete, "/virtual-keys/"+doomedKey, envAdminToken, ""); w.Code != http.StatusNoContent && w.Code != http.StatusOK {
+		t.Fatalf("delete doomed key: %d %s", w.Code, w.Body.String())
+	}
+
+	totalFor := func(token string) int {
+		t.Helper()
+		w := doJSON(t, router, http.MethodGet, "/providers", token, "")
+		if w.Code != http.StatusOK {
+			t.Fatalf("GET /providers: %d %s", w.Code, w.Body.String())
+		}
+		var resp []struct {
+			ID          string `json:"id"`
+			TotalTokens int    `json:"total_tokens"`
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode providers: %v", err)
+		}
+		for _, p := range resp {
+			if p.ID == created.ID {
+				return p.TotalTokens
+			}
+		}
+		t.Fatalf("provider %s missing from list", created.ID)
+		return 0
+	}
+
+	if got := totalFor(aliceToken); got != 320 {
+		t.Errorf("alice total_tokens = %d, want 320 (own keyed 300 + own chat 20)", got)
+	}
+	if got := totalFor(bobToken); got != 700 {
+		t.Errorf("bob total_tokens = %d, want 700 (own keyed traffic only, deleted-key row excluded)", got)
+	}
+	if got := totalFor(envAdminToken); got != 3120 {
+		t.Errorf("admin total_tokens = %d, want 3120 (all owners, unattributed, and deleted-key rows)", got)
+	}
+}

--- a/internal/api/stats.go
+++ b/internal/api/stats.go
@@ -151,8 +151,9 @@ func vkScope(excludeDeleted bool) (join, filter string) {
 // reassigning a key moves its history), keyless rows (dashboard chat/arena)
 // through the request-time owner_user_id stamped on the row itself; see
 // migration 067. The id binds through the $argIdx placeholder, so the caller
-// must state how many args the consuming query already carries; every stats
-// query takes a single timestamp, hence argIdx 2 everywhere today. The parse
+// must state how many args the consuming query already carries; the stats
+// queries take a leading timestamp and pass 2, the provider-list token totals
+// carry no other args and pass 1. The parse
 // stays as defense in depth: a non-empty id that is not a valid UUID fails
 // CLOSED to a no-match fragment (" AND 1=0"), never to "" — dropping the
 // filter there would silently widen a scoped query to every owner's rows, an


### PR DESCRIPTION
## What

`GET /api/providers` is mounted behind `requireGrant(GrantVirtualKeys, GrantUsage)`, so non-admin users reach it — but its per-provider `total_tokens` summed `request_logs` across **every** owner. A `usage`-grant user could read other tenants' aggregate token volume off the provider list, while the owner-scoped `/api/stats` deliberately hides it (pentest finding vuln-0002, IDOR/BOLA, CWE-639, MEDIUM).

## Fix

Apply the same two-shape owner predicate every logs/stats surface already uses, by reusing `ownerFilterFragment` with `ownerScopeFromIdentity`:

- keyed rows resolve through the virtual key's **current** owner (reassigning a key moves its history),
- keyless dashboard-chat rows resolve through the request-time `owner_user_id` stamped on the row (migration 067),
- admins stay unscoped; a non-admin identity without a users row fails closed to zero.

`ownerScopeFromIdentity` (not `logOwnerScope`) keeps admin semantics bit-for-bit identical — no accidental `?owner_user_id=` filter on this endpoint. Also amends the `ownerFilterFragment` docstring, which claimed `argIdx 2 everywhere today` — this is the first `argIdx 1` caller.

## Tests

New `TestListProviders_TotalTokensOwnerScoped` seeds one provider with rows for two owners across all attribution shapes (keyed, keyless-owned, pre-067 unattributed, and a row behind a since-deleted key) and asserts each non-admin sees only their own total while the admin sees everything. Mutation-verified: with the scope removed, both non-admin assertions fail on exactly the reported leak.

- `go test ./internal/api/` — 2242 passed
- `golangci-lint` — 0 issues; diff coverage 2/2 = 100%

## Notes

Second-opinion review (Opus) swept the other `total_tokens` producers: `GetProvider` never populates it, the failover-group aggregate is admin-only, stats are already scoped, models expose no usage numbers, and VK `tokens_used` already scopes through `ListByOwner`. The UI is unaffected: the Providers page is admin-only and the non-admin consumers of this endpoint never read `total_tokens`. The ungated system-health request count and provider `last_used_at` remain deliberately readable coarse signals — this finding's closure should claim "per-provider token totals are owner-scoped", not "no cross-tenant volume readable".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
