### PR TITLE
fix(frontdesk): optional bearer gate for Traefik's /traefik/config polls

### DIFF
--- a/DOCKERHUB-frontdesk.md
+++ b/DOCKERHUB-frontdesk.md
@@ -29,7 +29,7 @@ Front Desk generates Traefik's dynamic config and serves an admin dashboard. It 
 ## Image details
 
 - Self-contained: stores everything in an embedded SQLite database under `DATA_DIR` (no Postgres). Mount a volume at `/data` to persist members, settings, and credentials.
-- Listens on **port 8090** (admin UI plus the internal `/traefik/config` endpoint).
+- Listens on **port 8090** (admin UI plus the internal `/traefik/config` endpoint, lockable to Traefik's own polls via `FRONTDESK_TRAEFIK_TOKEN`).
 - Runs as a non-root user, base packages upgraded for current security patches.
 - `linux/amd64`.
 

--- a/Dockerfile.frontdesk
+++ b/Dockerfile.frontdesk
@@ -82,7 +82,9 @@ ENTRYPOINT ["docker-entrypoint-frontdesk.sh"]
 
 EXPOSE 8090
 
+# /healthz stays open when FRONTDESK_TRAEFIK_TOKEN gates /traefik/config, and
+# still exercises the store like the old config-endpoint spider did.
 HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
-    CMD wget --quiet --tries=1 --spider http://localhost:8090/traefik/config || exit 1
+    CMD wget --quiet --tries=1 --spider http://localhost:8090/healthz || exit 1
 
 CMD ["./frontdesk"]

--- a/cmd/frontdesk/main.go
+++ b/cmd/frontdesk/main.go
@@ -141,6 +141,10 @@ func main() {
 		// Dedicated Prometheus scrape bearer; when unset, /metrics falls back to
 		// the admin-or-session gate (never unauthenticated).
 		MetricsToken: os.Getenv("FRONTDESK_METRICS_TOKEN"),
+		// Dedicated bearer for Traefik's /traefik/config polls; when unset the
+		// endpoint stays open for compose-internal use (Traefik cannot log in,
+		// so there is no admin-auth fallback to give it).
+		TraefikToken: os.Getenv("FRONTDESK_TRAEFIK_TOKEN"),
 		LBPort:       lbPort,
 		Version:      version,
 		// Secure attribute on the fd_session/fd_csrf pair; shares COOKIE_SECURE

--- a/deploy/ha/.env.example
+++ b/deploy/ha/.env.example
@@ -48,6 +48,15 @@ FRONTDESK_DEBUG_LOG=false
 # When unset, /metrics still exists but requires the admin login.
 FRONTDESK_METRICS_TOKEN=
 
+# Optional (recommended): shared secret for Traefik's /traefik/config polls.
+# Set it (e.g. `openssl rand -hex 32`) and the compose feeds the same value to
+# both sides: Front Desk serves the dynamic config only to polls carrying it,
+# so the member-URL list is no longer readable by anything else that can reach
+# port 8090. When unset, the endpoint stays open (compose-internal use), the
+# pre-existing behavior; the reverse-proxy 404 block from the HA wiki then
+# remains the only thing keeping it off the public hostname.
+FRONTDESK_TRAEFIK_TOKEN=
+
 # Optional: Secure attribute on the fd_session/fd_csrf login cookies. Default
 # "always" works out of the box behind this stack's required TLS-terminating
 # proxy and on localhost dev, since both are secure contexts. Set "auto" to

--- a/deploy/ha/docker-compose.yml
+++ b/deploy/ha/docker-compose.yml
@@ -48,6 +48,12 @@ services:
             # HTTP provider: poll Front Desk for the dynamic config every ~5s.
             - "--providers.http.endpoint=http://frontdesk:8090/traefik/config"
             - "--providers.http.pollInterval=5s"
+            # Shared poll secret (optional, recommended): set
+            # FRONTDESK_TRAEFIK_TOKEN in .env and Front Desk serves the config
+            # only to polls carrying this bearer. Left unset, the header is an
+            # empty "Bearer" that Front Desk ignores and the endpoint stays
+            # open as before.
+            - "--providers.http.headers.Authorization=Bearer ${FRONTDESK_TRAEFIK_TOKEN:-}"
             # Access log stays off by default (see the HA wiki, "Observability").
             - "--accesslog=false"
             - "--log.level=INFO"
@@ -100,6 +106,11 @@ services:
             # Dedicated bearer for Prometheus /metrics scrapes; empty keeps the
             # endpoint behind the admin login.
             - FRONTDESK_METRICS_TOKEN=${FRONTDESK_METRICS_TOKEN:-}
+            # Shared poll secret for /traefik/config (optional, recommended).
+            # The same value feeds Traefik's provider headers above, so setting
+            # it once in .env locks the endpoint to Traefik's own polls; empty
+            # keeps it open for compose-internal use as before.
+            - FRONTDESK_TRAEFIK_TOKEN=${FRONTDESK_TRAEFIK_TOKEN:-}
             # Secure attribute on the fd_session/fd_csrf login cookies (shares
             # COOKIE_SECURE with the dashboard). Default "always" works behind
             # this stack's required TLS proxy and on localhost dev; set "never"

--- a/internal/frontdesk/coverage_test.go
+++ b/internal/frontdesk/coverage_test.go
@@ -235,7 +235,8 @@ func TestServerHandlersErrorWhenStoreClosed(t *testing.T) {
 		{http.MethodPut, "/api/settings", `{"health_poll_secs":1,"traefik_poll_secs":1,"traefik_stale_secs":1}`, true},
 		{http.MethodGet, "/api/events", "", true},
 		{http.MethodPost, "/api/config/sync", `{"primary_id":"` + m.ID + `"}`, true},
-		{http.MethodGet, "/traefik/config", "", false}, // unauthenticated, compose-internal
+		{http.MethodGet, "/traefik/config", "", false}, // compose-internal, open without a configured token
+		{http.MethodGet, "/healthz", "", false},        // liveness probe reports the dead store
 	}
 	for _, c := range cases {
 		rec := do(t, srv, c.method, c.path, c.body, c.auth)
@@ -245,8 +246,8 @@ func TestServerHandlersErrorWhenStoreClosed(t *testing.T) {
 	}
 }
 
-// TestHandleTraefikConfig covers the unauthenticated, compose-internal config
-// endpoint that Traefik's HTTP provider polls.
+// TestHandleTraefikConfig covers the compose-internal config endpoint that
+// Traefik's HTTP provider polls (open here: no poll token configured).
 func TestHandleTraefikConfig(t *testing.T) {
 	srv, store := newTestServer(t)
 	if _, err := store.CreateMember(context.Background(), "m1", "http://m1:8081", ""); err != nil {

--- a/internal/frontdesk/hardening_test.go
+++ b/internal/frontdesk/hardening_test.go
@@ -200,7 +200,7 @@ func TestNormalizeMemberURLHTTPSGate(t *testing.T) {
 // TestNormalizeMemberURLRejectsUserinfo guards the credential-leak fix: a
 // member base URL carrying userinfo (basic-auth credentials) is rejected at
 // add time, because the stored URL is re-emitted verbatim to wider audiences
-// (the unauthenticated /traefik/config endpoint and the device-readable
+// (the open-by-default /traefik/config endpoint and the device-readable
 // event log).
 func TestNormalizeMemberURLRejectsUserinfo(t *testing.T) {
 	rejected := []string{

--- a/internal/frontdesk/server.go
+++ b/internal/frontdesk/server.go
@@ -27,9 +27,12 @@ import (
 )
 
 // This file is the Front Desk control-plane HTTP server. It exposes:
-//   - GET /traefik/config: the unauthenticated, compose-internal Traefik dynamic
-//     config (Traefik's HTTP provider polls this; we record each poll for the
-//     staleness watchdog).
+//   - GET /traefik/config: the compose-internal Traefik dynamic config
+//     (Traefik's HTTP provider polls this; we record each poll for the
+//     staleness watchdog). Bearer-gated when FRONTDESK_TRAEFIK_TOKEN is set,
+//     open otherwise.
+//   - GET /healthz: the container liveness probe; unauthenticated, store-backed,
+//     discloses nothing.
 //   - /api/webauthn/* and /api/totp/*: the shared adminauth login/management
 //     ceremonies (Option B parity), backed by the SQLite stores.
 //   - /api/* control-plane REST (members, settings, events, traefik-status) and
@@ -50,6 +53,7 @@ type ServerConfig struct {
 	IPLimiter    adminauth.IPLimiterMiddleware // per-IP limit on login routes
 	UI           fs.FS                         // embedded SPA; nil disables the UI mount
 	MetricsToken string                        // FRONTDESK_METRICS_TOKEN; bearer for /metrics scrapes (falls back to admin auth when empty)
+	TraefikToken string                        // FRONTDESK_TRAEFIK_TOKEN; bearer Traefik's HTTP provider sends when polling /traefik/config (endpoint stays open when empty)
 	LBPort       string                        // host port of the LB (Traefik "web"); shown in the wizard's Done step. Defaults to 8080.
 	Version      string                        // running build, stamped via ldflags; surfaced read-only over GET /api/version. Defaults to "dev".
 	// CookieSecure controls the Secure attribute on Front Desk auth cookies:
@@ -77,6 +81,7 @@ type Server struct {
 	version        string       // running build, surfaced read-only over GET /api/version
 	masterKey      string       // encrypts the Apprise target secret at rest
 	metricsToken   string       // dedicated bearer for Prometheus /metrics scrapes; empty falls back to admin auth
+	traefikToken   string       // dedicated bearer for Traefik's /traefik/config polls; empty keeps the endpoint open (Traefik cannot log in, so admin auth is no fallback here)
 	cookieSecure   string       // Secure-attribute mode for the fd_session/fd_csrf pair: "always", "auto", or "never"
 	alertDisp      *alert.Dispatcher
 	pairing        *pairingCodes                 // one-time Bellhop pairing codes (in-memory)
@@ -204,6 +209,7 @@ func NewServer(cfg ServerConfig) *Server {
 		version:         version,
 		masterKey:       cfg.MasterKey,
 		metricsToken:    strings.TrimSpace(cfg.MetricsToken), // whitespace-only is treated as unset, not a live bearer
+		traefikToken:    strings.TrimSpace(cfg.TraefikToken), // whitespace-only is treated as unset, not a live bearer
 		cookieSecure:    cookieSecure,
 		pairing:         newPairingCodes(),
 		ipLimiter:       cfg.IPLimiter,
@@ -301,8 +307,18 @@ func (s *Server) buildRouter(wa *adminauth.WebAuthnHandler, tp *adminauth.TotpHa
 		})
 	})
 
-	// Unauthenticated, compose-internal: Traefik's HTTP provider polls this.
-	r.Get("/traefik/config", s.handleTraefikConfig)
+	// Traefik's HTTP provider polls this. With FRONTDESK_TRAEFIK_TOKEN set,
+	// only a poll carrying that bearer is served (the compose wires the same
+	// value into Traefik's provider headers); without one the endpoint stays
+	// open for compose-internal use, relying on the deployment boundary and
+	// the reverse-proxy 404 block the HA wiki prescribes.
+	r.Get("/traefik/config", s.traefikAuth(s.handleTraefikConfig))
+
+	// Container liveness probe (the image's HEALTHCHECK). Unauthenticated on
+	// purpose: it must keep answering when FRONTDESK_TRAEFIK_TOKEN gates the
+	// config endpoint, so it discloses nothing and only proves the server and
+	// its store answer.
+	r.Get("/healthz", s.handleHealthz)
 
 	// Prometheus scrape endpoint. Outside /api (matching the main server's
 	// mount) and never rate-limited by IP so scrapers aren't throttled; auth
@@ -486,10 +502,51 @@ func (s *Server) logout(w http.ResponseWriter, r *http.Request) {
 }
 
 // ---------------------------------------------------------------------------
-// Traefik config (unauthenticated, compose-internal)
+// Traefik config (bearer-gated when FRONTDESK_TRAEFIK_TOKEN is set)
 // ---------------------------------------------------------------------------
 
+// traefikAuth gates the Traefik dynamic-config endpoint. With a dedicated
+// FRONTDESK_TRAEFIK_TOKEN configured, only a poll carrying that bearer is
+// served; Traefik's HTTP provider sends it via providers.http.headers, wired
+// to the same value in the HA compose. Without a token the endpoint stays
+// open: Traefik polls credential-less, so unlike /metrics there is no
+// admin-auth fallback — gating an unconfigured fleet would 401 its own data
+// plane and take the front door down on the next Traefik restart.
+func (s *Server) traefikAuth(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if s.traefikToken == "" {
+			next(w, r)
+			return
+		}
+		tok, ok := util.ParseBearerToken(r)
+		if subtle.ConstantTimeCompare([]byte(tok), []byte(s.traefikToken)) == 1 {
+			next(w, r)
+			return
+		}
+		if !ok || tok == "" {
+			debuglog.Warn("frontdesk: traefik config poll missing bearer token", "remote_addr", clientip.From(r))
+		} else {
+			debuglog.Warn("frontdesk: traefik config poll with invalid token", "remote_addr", clientip.From(r))
+		}
+		http.Error(w, "invalid traefik token", http.StatusUnauthorized)
+	}
+}
+
+// handleHealthz answers the container health probe with the cheapest
+// store-backed read, so a wedged database still flips the container unhealthy
+// (the depth the old spider on /traefik/config provided) without exposing any
+// fleet data on an open route.
+func (s *Server) handleHealthz(w http.ResponseWriter, r *http.Request) {
+	if _, err := s.store.GetSettings(r.Context()); err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
 func (s *Server) handleTraefikConfig(w http.ResponseWriter, r *http.Request) {
+	// Recorded after the gate, so a rejected poll cannot keep the staleness
+	// watchdog quiet while a token mismatch is starving the real Traefik.
 	s.poller.RecordConfigPoll()
 
 	members, err := s.store.ListMembers(r.Context())

--- a/internal/frontdesk/server.go
+++ b/internal/frontdesk/server.go
@@ -532,11 +532,15 @@ func (s *Server) traefikAuth(next http.HandlerFunc) http.HandlerFunc {
 	}
 }
 
-// handleHealthz answers the container health probe with the cheapest
-// store-backed read, so a wedged database still flips the container unhealthy
-// (the depth the old spider on /traefik/config provided) without exposing any
-// fleet data on an open route.
+// handleHealthz answers the container health probe with the same store reads
+// a Traefik config refresh performs (members, then settings), so the probe
+// fails exactly when Traefik's own poll would — the depth the old spider on
+// /traefik/config provided — without exposing any fleet data on an open route.
 func (s *Server) handleHealthz(w http.ResponseWriter, r *http.Request) {
+	if _, err := s.store.ListMembers(r.Context()); err != nil {
+		writeError(w, err)
+		return
+	}
 	if _, err := s.store.GetSettings(r.Context()); err != nil {
 		writeError(w, err)
 		return

--- a/internal/frontdesk/store_helpers.go
+++ b/internal/frontdesk/store_helpers.go
@@ -96,7 +96,7 @@ func normalizeMemberURL(raw string, allowHTTP bool) (string, error) {
 	}
 	// Reject embedded credentials (userinfo): the stored URL is re-emitted
 	// unchanged by consumers with a wider audience than the admin who entered
-	// it (the unauthenticated /traefik/config endpoint and the device-readable
+	// it (the open-by-default /traefik/config endpoint and the device-readable
 	// event log), so it must never carry a secret. A member behind a
 	// basic-authenticated proxy needs a dedicated credential field, not
 	// userinfo in the base URL.

--- a/internal/frontdesk/traefik.go
+++ b/internal/frontdesk/traefik.go
@@ -3,8 +3,9 @@ package frontdesk
 import "time"
 
 // This file turns the member list + settings into a Traefik v3 dynamic
-// configuration, served unauthenticated on the compose-internal network at
-// GET /traefik/config and polled by Traefik's HTTP provider. Traefik owns the
+// configuration, served on the compose-internal network at GET /traefik/config
+// (open by default, bearer-gated when FRONTDESK_TRAEFIK_TOKEN is set) and
+// polled by Traefik's HTTP provider. Traefik owns the
 // data path; if Front Desk dies, Traefik keeps the last config it fetched, so
 // the control plane being down never interrupts traffic.
 
@@ -95,7 +96,8 @@ func BuildTraefikConfig(members []*Member, set Settings) TraefikConfig {
 	for _, m := range members {
 		if m.State == StateActive {
 			// stripUserinfo is a backstop for rows stored before userinfo was
-			// rejected at add time: this payload is served unauthenticated.
+			// rejected at add time: this payload is served without admin auth
+			// (open unless FRONTDESK_TRAEFIK_TOKEN gates it).
 			servers = append(servers, TraefikServer{URL: stripUserinfo(m.URL)})
 		}
 	}

--- a/internal/frontdesk/traefik_test.go
+++ b/internal/frontdesk/traefik_test.go
@@ -155,7 +155,7 @@ func TestBuildTraefikConfigJSONShape(t *testing.T) {
 }
 
 // TestBuildTraefikConfigStripsUserinfo guards the defense-in-depth strip on
-// the unauthenticated /traefik/config payload: a stored member URL that
+// the open-by-default /traefik/config payload: a stored member URL that
 // predates the userinfo rejection in normalizeMemberURL is emitted without
 // its credentials.
 func TestBuildTraefikConfigStripsUserinfo(t *testing.T) {

--- a/internal/frontdesk/traefikauth_test.go
+++ b/internal/frontdesk/traefikauth_test.go
@@ -1,0 +1,133 @@
+package frontdesk
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/hugalafutro/model-hotel/internal/admin"
+	"github.com/hugalafutro/model-hotel/internal/events"
+	"github.com/hugalafutro/model-hotel/internal/ratelimit"
+	"github.com/hugalafutro/model-hotel/internal/webauthn"
+)
+
+// newTraefikTestServer builds a test server with a dedicated Traefik poll
+// token so the FRONTDESK_TRAEFIK_TOKEN gate can be exercised (newTestServer
+// leaves it empty, which is the open compose-internal path).
+func newTraefikTestServer(t *testing.T, traefikToken string) *Server {
+	t.Helper()
+	store := newTestStore(t)
+	bus := events.NewBus()
+	poller := NewPoller(store, bus, "")
+
+	adminMgr, _, err := admin.New(t.TempDir(), testFrontdeskToken)
+	if err != nil {
+		t.Fatalf("admin.New: %v", err)
+	}
+	rp, err := webauthn.NewRelyingParty("localhost", "Front Desk", []string{"http://localhost"})
+	if err != nil {
+		t.Fatalf("NewRelyingParty: %v", err)
+	}
+	srv := NewServer(ServerConfig{
+		Store:        store,
+		Poller:       poller,
+		Bus:          bus,
+		AdminMgr:     adminMgr,
+		MasterKey:    testMasterKey,
+		RelyingParty: rp,
+		IPLimiter:    ratelimit.NewIPLimiter(1000, 1000, nil, nil),
+		TraefikToken: traefikToken,
+	})
+	t.Cleanup(srv.Wait)
+	return srv
+}
+
+// pollConfig issues GET /traefik/config with an arbitrary bearer (empty = none).
+func pollConfig(t *testing.T, srv *Server, bearer string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/traefik/config", http.NoBody)
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	return rec
+}
+
+// lastConfigPollAtIsZero reads the staleness watchdog's poll stamp.
+func lastConfigPollAtIsZero(srv *Server) bool {
+	srv.poller.mu.Lock()
+	defer srv.poller.mu.Unlock()
+	return srv.poller.lastConfigPollAt.IsZero()
+}
+
+// TestTraefikConfigTokenAuth covers the dedicated-token configuration: only
+// the shared poll secret is accepted — not the admin token, which never leaves
+// the operator's hands for Traefik's provider config.
+func TestTraefikConfigTokenAuth(t *testing.T) {
+	srv := newTraefikTestServer(t, "poll-secret")
+
+	if rec := pollConfig(t, srv, ""); rec.Code != http.StatusUnauthorized {
+		t.Fatalf("no bearer = %d, want 401", rec.Code)
+	}
+	if rec := pollConfig(t, srv, "wrong"); rec.Code != http.StatusUnauthorized {
+		t.Fatalf("wrong bearer = %d, want 401", rec.Code)
+	}
+	if rec := pollConfig(t, srv, testFrontdeskToken); rec.Code != http.StatusUnauthorized {
+		t.Fatalf("admin bearer with traefik token set = %d, want 401", rec.Code)
+	}
+	// Rejected polls must not feed the staleness watchdog: a scanner hammering
+	// the endpoint with bad tokens would otherwise mask a Traefik whose polls
+	// are failing on a token mismatch.
+	if !lastConfigPollAtIsZero(srv) {
+		t.Fatal("rejected polls recorded a config poll")
+	}
+
+	// The container liveness probe must keep answering with the gate up: the
+	// image's HEALTHCHECK moved off /traefik/config for exactly this reason.
+	hreq := httptest.NewRequest(http.MethodGet, "/healthz", http.NoBody)
+	hrec := httptest.NewRecorder()
+	srv.ServeHTTP(hrec, hreq)
+	if hrec.Code != http.StatusOK {
+		t.Fatalf("GET /healthz with traefik token set = %d, want 200", hrec.Code)
+	}
+
+	rec := pollConfig(t, srv, "poll-secret")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("poll token = %d (%s)", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"routers"`) {
+		t.Errorf("config body missing routers: %s", rec.Body.String())
+	}
+	if lastConfigPollAtIsZero(srv) {
+		t.Error("accepted poll did not record a config poll")
+	}
+}
+
+// TestTraefikConfigOpenWithoutToken pins the back-compat contract: with no
+// token configured the endpoint stays open (Traefik polls credential-less, so
+// unlike /metrics there is no admin-auth fallback to give it), and a stray
+// bearer on an open poll is simply ignored rather than validated.
+func TestTraefikConfigOpenWithoutToken(t *testing.T) {
+	srv, _ := newTestServer(t)
+
+	if rec := pollConfig(t, srv, ""); rec.Code != http.StatusOK {
+		t.Fatalf("unauthenticated poll without token = %d, want 200", rec.Code)
+	}
+	if rec := pollConfig(t, srv, "anything"); rec.Code != http.StatusOK {
+		t.Fatalf("bearer on open endpoint = %d, want 200", rec.Code)
+	}
+}
+
+// TestTraefikConfigWhitespaceTokenIsUnset guards against a blank-looking
+// FRONTDESK_TRAEFIK_TOKEN (only spaces) being stored as a live bearer: the
+// value is normalized to unset, so the endpoint stays open and the whitespace
+// string is not itself a valid credential.
+func TestTraefikConfigWhitespaceTokenIsUnset(t *testing.T) {
+	srv := newTraefikTestServer(t, "   ")
+
+	if rec := pollConfig(t, srv, ""); rec.Code != http.StatusOK {
+		t.Fatalf("unauthenticated poll with whitespace token = %d, want 200", rec.Code)
+	}
+}

--- a/internal/frontdesk/traefikauth_test.go
+++ b/internal/frontdesk/traefikauth_test.go
@@ -120,6 +120,39 @@ func TestTraefikConfigOpenWithoutToken(t *testing.T) {
 	}
 }
 
+// TestHealthzTracksTraefikConfigDependencies pins the probe's contract: it
+// performs the same store reads as a Traefik config refresh, so a members
+// query that would 500 /traefik/config also fails /healthz instead of leaving
+// the container green while Traefik starves (Greptile P1 on PR #747: with only
+// the settings read probed, dropping the members table split the two).
+func TestHealthzTracksTraefikConfigDependencies(t *testing.T) {
+	srv, store := newTestServer(t)
+
+	healthz := func() int {
+		req := httptest.NewRequest(http.MethodGet, "/healthz", http.NoBody)
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, req)
+		return rec.Code
+	}
+
+	if got := healthz(); got != http.StatusOK {
+		t.Fatalf("healthz on intact store = %d, want 200", got)
+	}
+
+	// Break only the members read; settings stays queryable.
+	if _, err := store.db.Exec(`ALTER TABLE members RENAME TO members_gone`); err != nil {
+		t.Fatalf("rename members table: %v", err)
+	}
+	t.Cleanup(func() { _, _ = store.db.Exec(`ALTER TABLE members_gone RENAME TO members`) })
+
+	if got := healthz(); got < 500 {
+		t.Fatalf("healthz with broken members table = %d, want a 5xx", got)
+	}
+	if rec := pollConfig(t, srv, ""); rec.Code < 500 {
+		t.Fatalf("traefik config with broken members table = %d, want a 5xx", rec.Code)
+	}
+}
+
 // TestTraefikConfigWhitespaceTokenIsUnset guards against a blank-looking
 // FRONTDESK_TRAEFIK_TOKEN (only spaces) being stored as a live bearer: the
 // value is normalized to unset, so the endpoint stays open and the whitespace

--- a/internal/frontdesk/traefikauth_test.go
+++ b/internal/frontdesk/traefikauth_test.go
@@ -151,6 +151,19 @@ func TestHealthzTracksTraefikConfigDependencies(t *testing.T) {
 	if rec := pollConfig(t, srv, ""); rec.Code < 500 {
 		t.Fatalf("traefik config with broken members table = %d, want a 5xx", rec.Code)
 	}
+	if _, err := store.db.Exec(`ALTER TABLE members_gone RENAME TO members`); err != nil {
+		t.Fatalf("restore members table: %v", err)
+	}
+
+	// And the mirror image: members reads fine, only the settings read breaks.
+	if _, err := store.db.Exec(`ALTER TABLE settings RENAME TO settings_gone`); err != nil {
+		t.Fatalf("rename settings table: %v", err)
+	}
+	t.Cleanup(func() { _, _ = store.db.Exec(`ALTER TABLE settings_gone RENAME TO settings`) })
+
+	if got := healthz(); got < 500 {
+		t.Fatalf("healthz with broken settings table = %d, want a 5xx", got)
+	}
 }
 
 // TestTraefikConfigWhitespaceTokenIsUnset guards against a blank-looking

--- a/wiki/High-Availability.md
+++ b/wiki/High-Availability.md
@@ -36,7 +36,9 @@ with the last config it fetched; only membership changes pause until it returns.
 
 - **Traefik (data plane)** carries all client traffic and load-balances across
   members. It pulls its routing config from Front Desk over the internal compose
-  network via Traefik's HTTP provider, polling `GET /traefik/config` every ~5s.
+  network via Traefik's HTTP provider, polling `GET /traefik/config` every ~5s
+  (optionally locked to a shared `FRONTDESK_TRAEFIK_TOKEN` bearer; see
+  [TLS Proxy](#tls-proxy)).
 - **Front Desk (control plane)** is a small Go binary with an embedded SQLite
   database and its own web UI. You add, drain, and remove members here, replicate
   config across the fleet, and watch health. It is **never** in the request path.
@@ -431,9 +433,11 @@ server {
     server_name frontdesk.example.com;
     # ssl_certificate / ssl_certificate_key ...
 
-    # Defense in depth: /traefik/config is unauthenticated (Traefik fetches it
-    # over the compose network and it carries no secrets, only member URLs and
-    # settings). Do not expose it through the public proxy.
+    # Defense in depth: keep /traefik/config off the public hostname (Traefik
+    # fetches it over the compose network; it carries no secrets, only member
+    # URLs and settings). Setting FRONTDESK_TRAEFIK_TOKEN in .env additionally
+    # locks the endpoint to Traefik's own polls, so this block stops being the
+    # only line of defense — keep it anyway.
     location = /traefik/config { return 404; }
     location /traefik/ { return 404; }
 


### PR DESCRIPTION
## What

`GET /traefik/config` served the full member-URL list (fleet topology) to anyone who could reach Front Desk's port 8090, relying solely on deployment topology and the wiki's reverse-proxy 404 block. Accepted as by-design in the July Strix triage with the condition "revisit if a future pentest re-surfaces it" — the 2026-08-24 pentest re-surfaced it (vuln-0001, CWE-306, MEDIUM), so this closes it at the application layer.

## How

**Opt-in shared poll secret, mirroring the `FRONTDESK_METRICS_TOKEN` pattern:**

- `FRONTDESK_TRAEFIK_TOKEN` set → `/traefik/config` answers only polls carrying that bearer (constant-time compare); everything else gets 401 plus a debuglog warning with the client IP.
- Unset/whitespace → the endpoint stays **open**, exactly as before. Deliberately *not* the metrics-style admin-auth fallback: Traefik polls credential-less, so a fallback gate would 401 the data plane's own provider and take the front door down on the next Traefik restart of every already-deployed fleet.
- The HA compose feeds the same `.env` value into both sides — Front Desk env + Traefik's `--providers.http.headers.Authorization=Bearer ${FRONTDESK_TRAEFIK_TOKEN:-}` — so setting one variable arms both halves. Verified working on the pinned `traefik:v3` line.
- Rejected polls do **not** feed the config-poll staleness watchdog: bad-token noise from a scanner must not mask a real Traefik starved by a token mismatch.

**Healthcheck fallout (caught during dev verification):** the image's `HEALTHCHECK` spidered `/traefik/config`, so setting the token flipped the container unhealthy. Added a dedicated open `GET /healthz` — store-backed like the old probe (a wedged database still reports unhealthy) but discloses nothing — and pointed the healthcheck at it.

Docs: `.env.example`, HA wiki (architecture note + TLS-proxy defense-in-depth section, which stays recommended), `DOCKERHUB-frontdesk.md`.

## Tests

- `TestTraefikConfigTokenAuth`: 401 for no/wrong/admin bearer, 200 for the shared secret, rejected polls leave the watchdog stamp untouched, `/healthz` stays open with the gate up.
- `TestTraefikConfigOpenWithoutToken` / `TestTraefikConfigWhitespaceTokenIsUnset`: back-compat contract pinned.
- Dead-store coverage table extended with `/healthz`.
- `go test ./internal/frontdesk ./cmd/frontdesk` — 565 passed; lint 0 issues.

**Live verification on the dev HA stack, both modes:** open mode unchanged (200 unauthenticated, Traefik happy); with a token set, outsider polls 401 while Traefik's authorized polls succeed (its API shows the live `hotel@http` service, zero rejects from its container IP) and the FD container reports `healthy` via the new probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
