### PR TITLE
refactor: dedupe Go HTTP/egress/db helpers into shared packages

### DIFF
--- a/internal/adminauth/helpers.go
+++ b/internal/adminauth/helpers.go
@@ -5,20 +5,16 @@
 // The handlers depend only on interfaces (webauthn.Store, AdminAuthenticator,
 // IPLimiterMiddleware) and the webauthn/totp domain packages, never on a
 // database driver, so the same audited code backs Postgres (main server) and
-// SQLite (Front Desk). The small response/guard helpers below are copied from
-// internal/api (their single source before this extraction) to keep this
-// package free of an import dependency on api.
+// SQLite (Front Desk). The small response/guard helpers below are thin wrappers
+// over internal/httpx, the neutral leaf package that holds their single body;
+// they exist only to pin this package's log prefix and keep the call sites
+// short.
 package adminauth
 
 import (
-	"encoding/json"
-	"errors"
-	"net"
 	"net/http"
-	"strings"
-	"syscall"
 
-	"github.com/hugalafutro/model-hotel/internal/debuglog"
+	"github.com/hugalafutro/model-hotel/internal/httpx"
 )
 
 // AdminAuthenticator validates the raw admin token. Implemented by
@@ -35,75 +31,26 @@ type IPLimiterMiddleware interface {
 	ClientIP(r *http.Request) string
 }
 
-// writeJSON encodes v as JSON. Copied from internal/api/helpers.go.
+// logComponent is the log prefix every helper in this package writes.
+const logComponent = "adminauth"
+
+// writeJSON encodes v as JSON.
 func writeJSON(w http.ResponseWriter, v any) {
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(v); err != nil {
-		logEncodeError(err)
-	}
+	httpx.WriteJSON(w, logComponent, v)
 }
 
-// logEncodeError downgrades client-disconnect write errors to debug so a client
-// hanging up before the body is written doesn't spam production error logs;
-// genuine encode bugs stay at error level. Copied from internal/api/helpers.go.
-func logEncodeError(err error) {
-	if isClientDisconnect(err) {
-		debuglog.Debug("adminauth: client disconnected before JSON response completed", "error", err)
-		return
-	}
-	debuglog.Error("adminauth: failed to encode JSON response", "error", err)
-}
-
-// isClientDisconnect reports whether err is an OS-level write error signalling
-// the client closed the connection mid-response. Context cancellation is
-// deliberately excluded. Copied from internal/api/helpers.go.
-func isClientDisconnect(err error) bool {
-	return errors.Is(err, syscall.EPIPE) ||
-		errors.Is(err, syscall.ECONNRESET) ||
-		errors.Is(err, net.ErrClosed)
-}
-
-// respondError writes an error response, logging server faults. Copied from
-// internal/api/helpers.go.
+// respondError writes an error response, logging server faults.
 func respondError(w http.ResponseWriter, message string, err error, code int) {
-	if err != nil {
-		debuglog.Error("adminauth: "+message, "error", err)
-	} else if code >= 500 {
-		debuglog.Error("adminauth: " + message)
-	}
-	http.Error(w, message, code)
+	httpx.RespondError(w, logComponent, message, err, code)
 }
 
-// respondBadRequest writes a 400 response. Copied from internal/api/helpers.go.
+// respondBadRequest writes a 400 response, logging the cause server-side.
 func respondBadRequest(w http.ResponseWriter, message string, err error) {
-	if err != nil {
-		debuglog.Info("adminauth: bad request: "+message, "error", err)
-	}
-	http.Error(w, message, http.StatusBadRequest)
+	httpx.RespondBadRequest(w, logComponent, message, err)
 }
 
-// readOnlyGuard refuses mutating requests in demo read-only mode. Copied from
-// internal/api/readonly.go (the logout exemption mirrors that source).
+// readOnlyGuard refuses mutating requests in demo read-only mode. Only the
+// webauthn/logout exemption is reachable from this package's routes.
 func readOnlyGuard(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.Method {
-		case http.MethodGet, http.MethodHead, http.MethodOptions:
-			next.ServeHTTP(w, r)
-		case http.MethodPost:
-			if isReadOnlyExemptPost(r.URL.Path) {
-				next.ServeHTTP(w, r)
-				return
-			}
-			fallthrough
-		default:
-			respondError(w, "this is a read-only demo: creating, editing, and deleting are disabled", nil, http.StatusForbidden)
-		}
-	})
-}
-
-// isReadOnlyExemptPost lists POST paths allowed in read-only mode. Copied from
-// internal/api/readonly.go (only the webauthn/logout case is reachable here).
-func isReadOnlyExemptPost(path string) bool {
-	return strings.HasSuffix(path, "/discovery/changes/ack") ||
-		strings.HasSuffix(path, "/webauthn/logout")
+	return httpx.ReadOnlyGuard(logComponent, next)
 }

--- a/internal/adminauth/helpers.go
+++ b/internal/adminauth/helpers.go
@@ -39,6 +39,11 @@ func writeJSON(w http.ResponseWriter, v any) {
 	httpx.WriteJSON(w, logComponent, v)
 }
 
+// writeJSONStatus encodes v as JSON under an explicit status code.
+func writeJSONStatus(w http.ResponseWriter, status int, v any) {
+	httpx.WriteJSONStatus(w, logComponent, status, v)
+}
+
 // respondError writes an error response, logging server faults.
 func respondError(w http.ResponseWriter, message string, err error, code int) {
 	httpx.RespondError(w, logComponent, message, err, code)

--- a/internal/adminauth/userlogin.go
+++ b/internal/adminauth/userlogin.go
@@ -216,9 +216,7 @@ func (h *UserLoginHandler) checkSecondFactor(w http.ResponseWriter, r *http.Requ
 		return true
 	}
 	if code == "" {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusUnauthorized)
-		_ = json.NewEncoder(w).Encode(map[string]bool{"totp_required": true})
+		writeJSONStatus(w, http.StatusUnauthorized, map[string]bool{"totp_required": true})
 		return false
 	}
 	if ok, verr := repo.Verify(r.Context(), code); verr == nil && ok {

--- a/internal/adminauth/webauthn.go
+++ b/internal/adminauth/webauthn.go
@@ -108,7 +108,7 @@ func (h *WebAuthnHandler) Register(r chi.Router) {
 			// and must be refused like the rest of the admin CRUD surface —
 			// otherwise a visitor holding the (published) admin token could
 			// register, rename, or delete passkeys. Logout is exempt (see
-			// isReadOnlyExemptPost) and the unauthenticated login flow lives in
+			// httpx.IsReadOnlyExemptPost) and the unauthenticated login flow lives in
 			// the separate group below, so neither is blocked.
 			if h.demoReadOnly {
 				r.Use(readOnlyGuard)

--- a/internal/anthropic/request.go
+++ b/internal/anthropic/request.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hugalafutro/model-hotel/internal/egress"
 	"github.com/hugalafutro/model-hotel/internal/jsonfault"
 )
 
@@ -197,7 +198,7 @@ func translateMessage(m ReqMessage) ([]oaiMessage, error) {
 	// Plain string content: straight passthrough. Only a genuine JSON string
 	// short-circuits here — an array of blocks must fall through to block
 	// handling, or non-text blocks (images, tool_use, tool_result) are dropped.
-	if s, ok := asJSONString(m.Content); ok {
+	if s, ok := egress.AsJSONString(m.Content); ok {
 		return []oaiMessage{{Role: m.Role, Content: s}}, nil
 	}
 
@@ -268,26 +269,12 @@ func translateMessage(m ReqMessage) ([]oaiMessage, error) {
 	return out, nil
 }
 
-// asJSONString returns the value when raw is a JSON string literal, ok=false
-// otherwise (including arrays/objects). Used to distinguish plain-string message
-// content from a content-block array.
-func asJSONString(raw json.RawMessage) (string, bool) {
-	if len(raw) == 0 {
-		return "", false
-	}
-	var s string
-	if json.Unmarshal(raw, &s) == nil {
-		return s, true
-	}
-	return "", false
-}
-
 // decodeText returns the string when raw is a JSON string, or the concatenation
 // of the text blocks when raw is a content-block array. ok is false when raw is
 // neither (e.g. an empty/absent field). Used for fields where flattening to text
 // is correct (system prompt, tool_result content).
 func decodeText(raw json.RawMessage) (string, bool) {
-	if s, ok := asJSONString(raw); ok {
+	if s, ok := egress.AsJSONString(raw); ok {
 		return s, true
 	}
 	var blocks []reqBlock

--- a/internal/anthropicegress/adapter.go
+++ b/internal/anthropicegress/adapter.go
@@ -11,17 +11,19 @@ import (
 )
 
 // StreamAdapter re-frames an upstream Anthropic /v1/messages SSE body as
-// chat.completion.chunk SSE bytes. The mechanics (line splitting, EOF finish
-// including the residual partial line, poisoning on a bad event) are shared
-// with the other dialects; see egress.StreamAdapter.
+// chat.completion.chunk SSE bytes. The mechanics (event assembly, EOF finish
+// including the unterminated tail, poisoning on a bad event) are shared with
+// the other dialects; see egress.StreamAdapter.
 //
 // Anthropic ends its stream with message_stop and carries no [DONE] sentinel,
 // so the translator emits the terminal chunk + [DONE] on message_stop. An
 // upstream that reaches EOF without message_stop gets that terminal pair from
 // Finish() instead.
-// This is an alias, not a defined type: anthropicegress.StreamAdapter and
-// gemini.StreamAdapter are the same type, so a type switch cannot tell them
-// apart.
+//
+// StreamAdapter is the shared egress adapter driving this dialect's
+// StreamTranslator. It is an alias, not a defined type: gemini,
+// anthropicegress and openairesponses all alias it, so a type switch cannot
+// tell them apart.
 type StreamAdapter = egress.StreamAdapter
 
 // NewStreamAdapter builds an adapter for one streaming response. model is

--- a/internal/anthropicegress/adapter.go
+++ b/internal/anthropicegress/adapter.go
@@ -1,153 +1,29 @@
 package anthropicegress
 
 import (
-	"bytes"
-	"errors"
-	"fmt"
 	"io"
 	"strings"
 	"time"
 
 	"github.com/google/uuid"
 
-	"github.com/hugalafutro/model-hotel/internal/debuglog"
+	"github.com/hugalafutro/model-hotel/internal/egress"
 )
 
-// maxSSELineBytes caps the unterminated SSE line the adapter will buffer.
-// Anthropic's deltas are orders of magnitude smaller than this, so an upstream
-// that never emits a newline is a broken peer, not a large response — the
-// stream fails instead of growing the buffer until the process suffers.
-const maxSSELineBytes = 1 << 20
-
-// StreamAdapter wraps an upstream Anthropic /v1/messages SSE body as an
-// io.ReadCloser that yields chat.completion.chunk SSE bytes. Wrapping the
-// UPSTREAM body (not the client writer) lets the whole existing streaming
-// pipeline — TTFT probe, stall watchdog, transforms, metering — run unchanged
-// on what it already understands (same trick as gemini.StreamAdapter).
+// StreamAdapter re-frames an upstream Anthropic /v1/messages SSE body as
+// chat.completion.chunk SSE bytes. The mechanics (line splitting, EOF finish
+// including the residual partial line, poisoning on a bad event) are shared
+// with the other dialects; see egress.StreamAdapter.
 //
 // Anthropic ends its stream with message_stop and carries no [DONE] sentinel,
 // so the translator emits the terminal chunk + [DONE] on message_stop. An
 // upstream that reaches EOF without message_stop gets that terminal pair from
-// Finish() instead; any other upstream error surfaces as a stream without
-// [DONE], which the pipeline already classifies as a truncation.
-type StreamAdapter struct {
-	upstream io.ReadCloser
-	tr       *StreamTranslator
-
-	lineBuf  []byte // partial SSE line carried across reads
-	pending  []byte // translated bytes not yet handed to the caller
-	readBuf  []byte
-	srcErr   error
-	transErr error // first translation failure; poisons the stream
-}
+// Finish() instead.
+type StreamAdapter = egress.StreamAdapter
 
 // NewStreamAdapter builds an adapter for one streaming response. model is
 // echoed in every emitted chunk (the model string the client requested).
 func NewStreamAdapter(upstream io.ReadCloser, model string) *StreamAdapter {
 	id := "chatcmpl-" + strings.ReplaceAll(uuid.NewString(), "-", "")
-	return &StreamAdapter{
-		upstream: upstream,
-		tr:       NewStreamTranslator(id, model, time.Now().Unix()),
-		readBuf:  make([]byte, 32*1024),
-	}
-}
-
-// Read refills the pending buffer from upstream (translating as it goes) and
-// copies out. On EOF any residual partial line is flushed through the
-// translator and the terminal Finish() bytes are appended before the EOF is
-// surfaced; other upstream errors surface only after all translated bytes have
-// been drained. A translation failure poisons the stream: already translated
-// bytes drain, then the error surfaces — Finish() is never fabricated over a
-// corrupt upstream, so the proxy sees a failed stream instead of a clean
-// empty/partial success.
-func (a *StreamAdapter) Read(p []byte) (int, error) {
-	for len(a.pending) == 0 {
-		if a.transErr != nil {
-			return 0, a.transErr
-		}
-		if a.srcErr != nil {
-			return 0, a.srcErr
-		}
-		n, err := a.upstream.Read(a.readBuf)
-		if n > 0 {
-			a.consume(a.readBuf[:n])
-		}
-		if err != nil {
-			a.srcErr = err
-			if errors.Is(err, io.EOF) {
-				// io.Copy and io.ReadAll compare the terminating error against
-				// io.EOF with ==, so a wrapped EOF from a reader between the
-				// transport and here would be reported as a broken stream even
-				// though it ended normally. This adapter ends on io.EOF itself.
-				a.srcErr = io.EOF
-				a.flushPartialLine()
-				if a.transErr == nil {
-					fin, finErr := a.tr.Finish()
-					if finErr != nil {
-						debuglog.Warn("anthropicegress: stream finish failed", "error", finErr)
-					}
-					a.pending = append(a.pending, fin...)
-				}
-			}
-		}
-	}
-	n := copy(p, a.pending)
-	a.pending = a.pending[n:]
-	return n, nil
-}
-
-// consume splits incoming bytes into SSE lines and feeds each data payload to
-// the translator. "event:"/comment/blank lines are dropped; the adapter
-// generates its own framing.
-func (a *StreamAdapter) consume(p []byte) {
-	a.lineBuf = append(a.lineBuf, p...)
-	for {
-		idx := bytes.IndexByte(a.lineBuf, '\n')
-		if idx < 0 {
-			if len(a.lineBuf) > maxSSELineBytes {
-				a.lineBuf = nil
-				a.transErr = fmt.Errorf("anthropicegress: upstream SSE line exceeds %d bytes", maxSSELineBytes)
-				debuglog.Warn("anthropicegress: stream line exceeds buffer cap", "limit", maxSSELineBytes)
-			}
-			return
-		}
-		line := bytes.TrimRight(a.lineBuf[:idx], "\r")
-		a.lineBuf = a.lineBuf[idx+1:]
-		if !bytes.HasPrefix(line, []byte("data:")) {
-			continue
-		}
-		payload := bytes.TrimSpace(line[len("data:"):])
-		if len(payload) == 0 {
-			continue
-		}
-		out, err := a.tr.Translate(payload)
-		if err != nil {
-			// A malformed data line or an upstream error event means the
-			// stream is dead; record it and stop translating so Read surfaces
-			// the failure.
-			debuglog.Warn("anthropicegress: stream event translate failed", "error", err)
-			a.transErr = err
-			return
-		}
-		a.pending = append(a.pending, out...)
-	}
-}
-
-// flushPartialLine feeds a residual line to the translator at EOF. An upstream
-// that closes without a trailing newline would otherwise lose its last event
-// entirely — including a final message_delta's stop_reason — while Finish()
-// still emitted a clean terminal chunk, which is exactly the quiet truncation
-// this adapter exists to prevent.
-func (a *StreamAdapter) flushPartialLine() {
-	if len(a.lineBuf) == 0 || a.transErr != nil {
-		return
-	}
-	a.lineBuf = append(a.lineBuf, '\n')
-	a.consume(nil)
-}
-
-// Close closes the upstream body. The stall watchdog calls this to unblock a
-// hung read, so it must propagate to the wrapped connection.
-func (a *StreamAdapter) Close() error {
-	return a.upstream.Close()
+	return egress.NewStreamAdapter("anthropicegress", upstream, NewStreamTranslator(id, model, time.Now().Unix()))
 }

--- a/internal/anthropicegress/adapter.go
+++ b/internal/anthropicegress/adapter.go
@@ -19,6 +19,9 @@ import (
 // so the translator emits the terminal chunk + [DONE] on message_stop. An
 // upstream that reaches EOF without message_stop gets that terminal pair from
 // Finish() instead.
+// This is an alias, not a defined type: anthropicegress.StreamAdapter and
+// gemini.StreamAdapter are the same type, so a type switch cannot tell them
+// apart.
 type StreamAdapter = egress.StreamAdapter
 
 // NewStreamAdapter builds an adapter for one streaming response. model is

--- a/internal/anthropicegress/adapter_test.go
+++ b/internal/anthropicegress/adapter_test.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"strings"
 	"testing"
+
+	"github.com/hugalafutro/model-hotel/internal/egress"
 )
 
 // scriptedBody yields its script one entry per Read call, simulating SSE
@@ -284,7 +286,7 @@ func TestStreamAdapter_OverlongLineFailsStream(t *testing.T) {
 	// grow the line buffer without bound.
 	upstream := &scriptedBody{script: []string{
 		"data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"" +
-			strings.Repeat("a", maxSSELineBytes+1),
+			strings.Repeat("a", egress.MaxSSELineBytes+1),
 	}}
 	out, err := io.ReadAll(NewStreamAdapter(upstream, "m"))
 	if err == nil {

--- a/internal/anthropicegress/adapter_test.go
+++ b/internal/anthropicegress/adapter_test.go
@@ -103,6 +103,31 @@ func TestStreamAdapter_TranslatesFullStream(t *testing.T) {
 	}
 }
 
+// TestStreamAdapter_FoldedEventTranslatesCleanly folds one content_block_delta
+// across two "data:" fields, which SSE allows. The payload is their
+// newline-join, so the event must translate once rather than as two JSON
+// fragments that would poison the stream.
+func TestStreamAdapter_FoldedEventTranslatesCleanly(t *testing.T) {
+	upstream := &scriptedBody{script: []string{
+		"event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":2}}}\n\n",
+		"event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\n" +
+			"data: \"delta\":{\"type\":\"text_delta\",\"text\":\"hi\"}}\n\n",
+		"event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n",
+	}}
+
+	out, err := io.ReadAll(NewStreamAdapter(upstream, "m"))
+	if err != nil {
+		t.Fatalf("a folded event failed the stream: %v", err)
+	}
+	s := string(out)
+	if !strings.Contains(s, `"content":"hi"`) {
+		t.Errorf("folded event lost its text:\n%s", s)
+	}
+	if n := strings.Count(s, "data: [DONE]"); n != 1 {
+		t.Errorf("[DONE] count = %d, want 1:\n%s", n, s)
+	}
+}
+
 func TestStreamAdapter_MessageStopFinishesOnce(t *testing.T) {
 	// message_stop already emitted the terminal chunk + [DONE]; the EOF that
 	// follows must not append a second one.
@@ -281,12 +306,12 @@ func TestStreamAdapter_TruncatedResidualAfterMessageStopIgnored(t *testing.T) {
 	}
 }
 
-func TestStreamAdapter_OverlongLineFailsStream(t *testing.T) {
+func TestStreamAdapter_OverlongEventFailsStream(t *testing.T) {
 	// An upstream that never emits a newline must fail the stream rather than
 	// grow the line buffer without bound.
 	upstream := &scriptedBody{script: []string{
 		"data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"" +
-			strings.Repeat("a", egress.MaxSSELineBytes+1),
+			strings.Repeat("a", egress.MaxSSEEventBytes+1),
 	}}
 	out, err := io.ReadAll(NewStreamAdapter(upstream, "m"))
 	if err == nil {

--- a/internal/anthropicegress/request.go
+++ b/internal/anthropicegress/request.go
@@ -15,6 +15,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/hugalafutro/model-hotel/internal/egress"
 	"github.com/hugalafutro/model-hotel/internal/jsonfault"
 )
 
@@ -247,7 +248,7 @@ func TranslateRequestWithDialect(chatBody []byte, dialect ThinkingDialect) (body
 		Temperature:   req.Temperature,
 		TopP:          req.TopP,
 		TopK:          req.TopK,
-		StopSequences: decodeStop(req.Stop),
+		StopSequences: egress.DecodeStop(req.Stop),
 	}
 
 	system, messages, err := translateMessages(req.Messages)
@@ -426,7 +427,7 @@ func contentBlocks(content any) []antBlock {
 func translateTurn(role string, m oaiMessage) (*antMessage, error) {
 	// Plain string content stays a plain string — but only when nothing else
 	// has to ride along in the same turn.
-	if s, ok := asJSONString(m.Content); ok && len(m.ToolCalls) == 0 {
+	if s, ok := egress.AsJSONString(m.Content); ok && len(m.ToolCalls) == 0 {
 		if s == "" {
 			return nil, nil
 		}
@@ -458,7 +459,7 @@ func translateBlocks(raw json.RawMessage) ([]antBlock, error) {
 	if len(raw) == 0 || string(raw) == "null" {
 		return nil, nil
 	}
-	if s, ok := asJSONString(raw); ok {
+	if s, ok := egress.AsJSONString(raw); ok {
 		if s == "" {
 			return nil, nil
 		}
@@ -627,7 +628,7 @@ func translateToolChoice(raw json.RawMessage) (*antToolChoice, bool) {
 	if len(raw) == 0 {
 		return nil, true
 	}
-	if s, ok := asJSONString(raw); ok {
+	if s, ok := egress.AsJSONString(raw); ok {
 		switch s {
 		case "auto":
 			return &antToolChoice{Type: "auto"}, true
@@ -662,26 +663,10 @@ func toolInput(arguments string) json.RawMessage {
 	return raw
 }
 
-// asJSONString returns the value when raw is a JSON string literal, and
-// ok=false for arrays, objects and an absent field. JSON null decodes into a
-// string without error, so it yields ("", true) — which every caller wants,
-// since a null content field carries nothing either way. Used to tell
-// plain-string message content from a content-part array.
-func asJSONString(raw json.RawMessage) (string, bool) {
-	if len(raw) == 0 {
-		return "", false
-	}
-	var s string
-	if json.Unmarshal(raw, &s) == nil {
-		return s, true
-	}
-	return "", false
-}
-
 // flattenText reduces a content field (string or part array) to plain text, for
 // the fields Anthropic types as text: the system prompt and tool_result content.
 func flattenText(raw json.RawMessage) string {
-	if s, ok := asJSONString(raw); ok {
+	if s, ok := egress.AsJSONString(raw); ok {
 		return s
 	}
 	var parts []oaiContentPart
@@ -695,22 +680,4 @@ func flattenText(raw json.RawMessage) string {
 		return sb.String()
 	}
 	return ""
-}
-
-// decodeStop accepts OpenAI's string-or-array stop field.
-func decodeStop(raw json.RawMessage) []string {
-	if len(raw) == 0 {
-		return nil
-	}
-	if s, ok := asJSONString(raw); ok {
-		if s == "" {
-			return nil
-		}
-		return []string{s}
-	}
-	var list []string
-	if json.Unmarshal(raw, &list) == nil {
-		return list
-	}
-	return nil
 }

--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -713,7 +713,7 @@ func (h *Handler) CreateProvider(w http.ResponseWriter, r *http.Request) {
 
 	p, err := h.providerRepo.Create(r.Context(), req, encCiphertext, encNonce, encSalt)
 	if err != nil {
-		if isUniqueViolation(err) {
+		if db.IsUniqueViolation(err) {
 			http.Error(w, "a provider with this name already exists", http.StatusConflict)
 			return
 		}
@@ -1011,7 +1011,7 @@ func (h *Handler) UpdateProvider(w http.ResponseWriter, r *http.Request) {
 
 	p, err := h.providerRepo.Update(r.Context(), id, req, encryptedKey, keyNonce, keySalt)
 	if err != nil {
-		if isUniqueViolation(err) {
+		if db.IsUniqueViolation(err) {
 			http.Error(w, "a provider with this name already exists", http.StatusConflict)
 			return
 		}
@@ -1085,14 +1085,6 @@ func providerTypeAllowsEmptyKey(providerType string) bool {
 	default:
 		return false
 	}
-}
-
-// isUniqueViolation checks if the error is a PostgreSQL unique constraint violation (error code 23505).
-func isUniqueViolation(err error) bool {
-	if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok {
-		return pgErr.Code == "23505"
-	}
-	return false
 }
 
 // isForeignKeyViolation checks if the error is a PostgreSQL foreign key violation (error code 23503).

--- a/internal/api/admin_test.go
+++ b/internal/api/admin_test.go
@@ -1219,56 +1219,6 @@ func TestAuthMiddleware_DisableRevertsToRawToken(t *testing.T) {
 	}
 }
 
-func TestIsUniqueViolation(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name string
-		err  error
-		want bool
-	}{
-		{
-			name: "nil_error",
-			err:  nil,
-			want: false,
-		},
-		{
-			name: "pg_error_23505_unique_violation",
-			err:  &pgconn.PgError{Code: "23505"},
-			want: true,
-		},
-		{
-			name: "pg_error_23503_fk_violation",
-			err:  &pgconn.PgError{Code: "23503"},
-			want: false,
-		},
-		{
-			name: "pg_error_42P01_undefined_table",
-			err:  &pgconn.PgError{Code: "42P01"},
-			want: false,
-		},
-		{
-			name: "wrapped_pg_error_23505",
-			err:  fmt.Errorf("wrap: %w", &pgconn.PgError{Code: "23505"}),
-			want: true,
-		},
-		{
-			name: "non_pg_error",
-			err:  errors.New("some other error"),
-			want: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := isUniqueViolation(tt.err)
-			if got != tt.want {
-				t.Errorf("isUniqueViolation(%v) = %v, want %v", tt.err, got, tt.want)
-			}
-		})
-	}
-}
-
 func TestProviderTypeAllowsEmptyKey(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/alerts.go
+++ b/internal/api/alerts.go
@@ -97,10 +97,7 @@ func (h *Handler) ProbeAlert(w http.ResponseWriter, r *http.Request) {
 // The dashboard renders its event picker from this, so a new Go-side event
 // surfaces in the UI without any frontend change.
 func (h *Handler) GetAlertEvents(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(alert.Catalog()); err != nil {
-		respondError(w, "failed to encode alert events", err, http.StatusInternalServerError)
-	}
+	writeJSON(w, alert.Catalog())
 }
 
 // SendAlertTest (POST /alert/test) fires a test notification. With no body it

--- a/internal/api/applogs.go
+++ b/internal/api/applogs.go
@@ -213,10 +213,7 @@ func (h *Handler) GetAppLogs(w http.ResponseWriter, r *http.Request) {
 
 	// Ring buffer mode (default, backward compatible)
 	if appLogBuffer == nil {
-		w.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode([]AppLogEntry{}); err != nil {
-			debuglog.Error("applogs: failed to encode empty response", "error", err)
-		}
+		writeJSON(w, []AppLogEntry{})
 		return
 	}
 
@@ -237,10 +234,7 @@ func (h *Handler) GetAppLogs(w http.ResponseWriter, r *http.Request) {
 		entries = entries[len(entries)-limit:]
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(entries); err != nil {
-		debuglog.Error("applogs: failed to encode entries", "error", err)
-	}
+	writeJSON(w, entries)
 }
 
 // getAppLogCounts returns cached unfiltered level and source counts.
@@ -549,9 +543,7 @@ func buildAppLogHistoryQuery(p appLogHistoryParams, q url.Values) (string, []any
 // getAppLogsHistory queries app_logs from the database with filtering and pagination.
 func (h *Handler) getAppLogsHistory(w http.ResponseWriter, r *http.Request) {
 	if h.dbPool == nil {
-		if err := json.NewEncoder(w).Encode(appLogsHistoryResponse{}); err != nil {
-			debuglog.Error("applogs: failed to encode response", "error", err)
-		}
+		writeJSON(w, appLogsHistoryResponse{})
 		return
 	}
 
@@ -566,18 +558,14 @@ func (h *Handler) getAppLogsHistory(w http.ResponseWriter, r *http.Request) {
 
 	total, err := h.appLogTotal(ctx, q, levelCounts)
 	if err != nil {
-		if encErr := json.NewEncoder(w).Encode(map[string]string{"error": "failed to count logs"}); encErr != nil {
-			debuglog.Error("applogs: failed to encode error response", "error", encErr)
-		}
+		writeJSON(w, map[string]string{"error": "failed to count logs"})
 		return
 	}
 
 	query, args := buildAppLogHistoryQuery(p, q)
 	rows, err := h.dbPool.Pool().Query(ctx, query, args...)
 	if err != nil {
-		if err := json.NewEncoder(w).Encode(map[string]string{"error": "failed to query logs"}); err != nil {
-			debuglog.Error("applogs: failed to encode error response", "error", err)
-		}
+		writeJSON(w, map[string]string{"error": "failed to query logs"})
 		return
 	}
 	defer rows.Close()
@@ -594,17 +582,14 @@ func (h *Handler) getAppLogsHistory(w http.ResponseWriter, r *http.Request) {
 		entries = append(entries, e)
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(appLogsHistoryResponse{
+	writeJSON(w, appLogsHistoryResponse{
 		Entries:      entries,
 		Total:        total,
 		Page:         p.page,
 		PerPage:      p.perPage,
 		LevelCounts:  levelCounts,
 		SourceCounts: sourceCounts,
-	}); err != nil {
-		debuglog.Error("applogs: failed to encode history response", "error", err)
-	}
+	})
 }
 
 // appLogCursor is the keyset cursor for cursor-based app log pagination.
@@ -646,8 +631,7 @@ type AppLogsCursorResponse struct {
 //   - sort_dir: "desc" (default) or "asc"
 func (h *Handler) GetAppLogsCursor(w http.ResponseWriter, r *http.Request) {
 	if h.dbPool == nil {
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(AppLogsCursorResponse{})
+		writeJSON(w, AppLogsCursorResponse{})
 		return
 	}
 
@@ -684,17 +668,14 @@ func (h *Handler) GetAppLogsCursor(w http.ResponseWriter, r *http.Request) {
 	levelCounts, sourceCounts := h.getAppLogCounts(ctx)
 	total, _ := h.appLogTotal(ctx, q, levelCounts) // best-effort
 
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(AppLogsCursorResponse{
+	writeJSON(w, AppLogsCursorResponse{
 		Entries:      entries,
 		Total:        total,
 		HasBefore:    hasBefore,
 		HasAfter:     hasAfter,
 		LevelCounts:  levelCounts,
 		SourceCounts: sourceCounts,
-	}); err != nil {
-		debuglog.Error("applogs-cursor: failed to encode response", "error", err)
-	}
+	})
 }
 
 // ClearAppLogs clears application logs from the ring buffer and DB, returning
@@ -738,8 +719,5 @@ func (h *Handler) ClearAppLogs(w http.ResponseWriter, r *http.Request) {
 			invalidateAppLogCountCache()
 		}
 	}
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(map[string]int{"deleted": deleted}); err != nil {
-		debuglog.Error("applogs: failed to encode delete response", "error", err)
-	}
+	writeJSON(w, map[string]int{"deleted": deleted})
 }

--- a/internal/api/applogs_handler_test.go
+++ b/internal/api/applogs_handler_test.go
@@ -1004,6 +1004,33 @@ func TestGetAppLogs_HistoryWithDB(t *testing.T) {
 	}
 }
 
+// TestGetAppLogs_HistoryCountFailure covers the filtered-count error branch:
+// a filter forces a real COUNT query, and a cancelled request context makes it
+// fail. The handler answers 200 with an {"error": ...} body rather than an
+// empty page, so the dashboard can tell the two apart.
+func TestGetAppLogs_HistoryCountFailure(t *testing.T) {
+	_, r := newTestHandlerWithRouter(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // the COUNT query cannot run on a dead context
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/logs/app?history=true&level=error", http.NoBody).WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer test-admin-token")
+	r.ServeHTTP(rec, req)
+
+	if rec.Header().Get("Content-Type") != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", rec.Header().Get("Content-Type"))
+	}
+	var body map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if body["error"] != "failed to count logs" {
+		t.Errorf("body = %v, want the count-failure error", body)
+	}
+}
+
 // TestGetAppLogs_HistorySuccessWithDB tests the full success path of
 // getAppLogsHistory: entries are read from the DB, scanned, and returned
 // with proper pagination metadata including level/source counts.

--- a/internal/api/applogs_handler_test.go
+++ b/internal/api/applogs_handler_test.go
@@ -1011,6 +1011,11 @@ func TestGetAppLogs_HistoryWithDB(t *testing.T) {
 func TestGetAppLogs_HistoryCountFailure(t *testing.T) {
 	_, r := newTestHandlerWithRouter(t)
 
+	// getAppLogCounts caches whatever the counts query returned, failure
+	// included, so a run on a dead context would leave every level at zero for
+	// the rest of the TTL and skew any later test reading the unfiltered total.
+	t.Cleanup(invalidateAppLogCountCache)
+
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // the COUNT query cannot run on a dead context
 

--- a/internal/api/configsync.go
+++ b/internal/api/configsync.go
@@ -2,16 +2,13 @@ package api
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
-	"net/http"
 	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5"
 
 	"github.com/hugalafutro/model-hotel/internal/db"
-	"github.com/hugalafutro/model-hotel/internal/debuglog"
 	"github.com/hugalafutro/model-hotel/internal/settings"
 )
 
@@ -549,13 +546,4 @@ func syncableSettingKeys() []string {
 		}
 	}
 	return out
-}
-
-// writeJSONStatus writes v as JSON with an explicit status code.
-func writeJSONStatus(w http.ResponseWriter, status int, v any) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	if err := json.NewEncoder(w).Encode(v); err != nil && !errors.Is(err, http.ErrHandlerTimeout) {
-		debuglog.Error("configsync: encode response", "error", err)
-	}
 }

--- a/internal/api/discovery.go
+++ b/internal/api/discovery.go
@@ -788,7 +788,7 @@ type DismissDiscoveryClaimsRequest struct {
 // healthy model cannot be pre-dismissed; those affect zero rows and fall
 // through the 404 path below like any other unmatched model ID.
 //
-// Deliberately NOT added to isReadOnlyExemptPost: unlike the discovery-change
+// Deliberately NOT added to httpx.IsReadOnlyExemptPost: unlike the discovery-change
 // ack it sits beside, this suppresses a real discrepancy from every operator's
 // view, which is a genuine state change.
 func (h *Handler) DismissDiscoveryClaims(w http.ResponseWriter, r *http.Request) {
@@ -851,7 +851,7 @@ type UnpinDiscoveryClaimsRequest struct {
 // reason. What does change on the next scan — the model being disabled — flows
 // through the same path any auto-disable does.
 //
-// Deliberately NOT added to isReadOnlyExemptPost: it hands a model back to
+// Deliberately NOT added to httpx.IsReadOnlyExemptPost: it hands a model back to
 // automatic management, which is a genuine state change.
 func (h *Handler) UnpinDiscoveryClaims(w http.ResponseWriter, r *http.Request) {
 	var req UnpinDiscoveryClaimsRequest

--- a/internal/api/handler_settings_test.go
+++ b/internal/api/handler_settings_test.go
@@ -718,9 +718,12 @@ func TestResetSettings_CommitError(t *testing.T) {
 	fw := &trackingFailingWriter{}
 	h.ResetSettings(fw, req)
 
-	// After encode fails, respondError is called with 500.
-	if fw.statusCode != http.StatusInternalServerError {
-		t.Errorf("Expected 500 for encode error, got %d", fw.statusCode)
+	// The response body has already started when the encode fails, so the
+	// handler must not fabricate a second status: it logs the failure and
+	// leaves the truncated stream for the client to detect. Writing a 500 here
+	// would be a superfluous WriteHeader on a committed response.
+	if fw.statusCode != 0 {
+		t.Errorf("encode failure wrote status %d after the body started; want none", fw.statusCode)
 	}
 }
 
@@ -884,8 +887,12 @@ func TestUpdateSettings_ResponseEncodeError(t *testing.T) {
 	fw := &statusTrackingFailWriter{}
 	h.UpdateSettings(fw, req)
 
-	if fw.statusCode != http.StatusInternalServerError {
-		t.Errorf("expected status %d, got %d", http.StatusInternalServerError, fw.statusCode)
+	// The response body has already started when the encode fails, so the
+	// handler must not fabricate a second status: it logs the failure and
+	// leaves the truncated stream for the client to detect. Writing a 500 here
+	// would be a superfluous WriteHeader on a committed response.
+	if fw.statusCode != 0 {
+		t.Errorf("encode failure wrote status %d after the body started; want none", fw.statusCode)
 	}
 }
 

--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -1,113 +1,56 @@
 package api
 
 import (
-	"encoding/json"
-	"errors"
-	"net"
 	"net/http"
-	"syscall"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 
-	"github.com/hugalafutro/model-hotel/internal/debuglog"
+	"github.com/hugalafutro/model-hotel/internal/httpx"
 )
+
+// logComponent is the log prefix every helper in this package writes.
+const logComponent = "api"
 
 // respondError logs the error details server-side and sends an HTTP error response.
 // Internal error details are logged but never sent to the client.
-// For 5xx errors without an error value, the message is still logged for debugging.
 func respondError(w http.ResponseWriter, message string, err error, code int) {
-	if err != nil {
-		debuglog.Error("api: "+message, "error", err)
-	} else if code >= 500 {
-		debuglog.Error("api: " + message)
-	}
-	http.Error(w, message, code)
+	httpx.RespondError(w, logComponent, message, err, code)
 }
 
 // respondLookupError maps a repository lookup error to an HTTP response: a
-// genuine miss (err matching the notFound sentinel) becomes a 404 with
-// notFoundMsg; any other error becomes a logged 500 with loadMsg. This keeps a
-// database outage from being silently reported to the client as "not found".
+// genuine miss becomes a 404, any other error a logged 500.
 func respondLookupError(w http.ResponseWriter, err, notFound error, notFoundMsg, loadMsg string) {
-	if errors.Is(err, notFound) {
-		http.Error(w, notFoundMsg, http.StatusNotFound)
-		return
-	}
-	respondError(w, loadMsg, err, http.StatusInternalServerError)
+	httpx.RespondLookupError(w, logComponent, err, notFound, notFoundMsg, loadMsg)
 }
 
 // respondBadRequest sends a 400 response with a sanitized message.
-// If err is non-nil, the error details are logged server-side only.
 func respondBadRequest(w http.ResponseWriter, message string, err error) {
-	if err != nil {
-		debuglog.Info("api: bad request: "+message, "error", err)
-	}
-	http.Error(w, message, http.StatusBadRequest)
+	httpx.RespondBadRequest(w, logComponent, message, err)
 }
 
 // parseUUIDParam extracts and validates a UUID from the chi URL params.
 // The optional label parameter customizes the error message (defaults to key).
 func parseUUIDParam(w http.ResponseWriter, r *http.Request, key string, label ...string) (uuid.UUID, bool) {
-	idStr := chi.URLParam(r, key)
-	id, err := uuid.Parse(idStr)
-	if err != nil {
-		name := key
-		if len(label) > 0 {
-			name = label[0]
-		}
-		http.Error(w, "invalid "+name, http.StatusBadRequest)
-		return uuid.Nil, false
-	}
-	return id, true
+	return httpx.ParseUUIDParam(w, r, key, label...)
 }
 
 // writeJSON sets the Content-Type header and encodes the response as JSON.
 func writeJSON(w http.ResponseWriter, v any) {
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(v); err != nil {
-		logEncodeError(err)
-	}
+	httpx.WriteJSON(w, logComponent, v)
+}
+
+// writeJSONStatus writes v as JSON with an explicit status code.
+func writeJSONStatus(w http.ResponseWriter, status int, v any) {
+	httpx.WriteJSONStatus(w, logComponent, status, v)
 }
 
 // writeJSONCreated sets the Content-Type header, writes 201 status, and encodes the response.
 func writeJSONCreated(w http.ResponseWriter, v any) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusCreated)
-	if err := json.NewEncoder(w).Encode(v); err != nil {
-		logEncodeError(err)
-	}
+	httpx.WriteJSONStatus(w, logComponent, http.StatusCreated, v)
 }
 
 // writeCodedError writes a JSON {code, error} body so the dashboard can route
 // on a stable code instead of matching English text.
 func writeCodedError(w http.ResponseWriter, status int, code, msg string) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	_ = json.NewEncoder(w).Encode(map[string]string{"code": code, "error": msg})
-}
-
-// logEncodeError logs a failure to encode a JSON response. A client that hangs
-// up before the body is written (broken pipe, connection reset, closed conn) is
-// not a server fault, so it is logged at debug level to keep production logs
-// clean; any other failure (e.g. an unmarshalable value) stays at error level
-// so genuine bugs remain visible even with debug disabled.
-func logEncodeError(err error) {
-	if isClientDisconnect(err) {
-		debuglog.Debug("api: client disconnected before JSON response completed", "error", err)
-		return
-	}
-	debuglog.Error("api: failed to encode JSON response", "error", err)
-}
-
-// isClientDisconnect reports whether err indicates the client closed the
-// connection before the response could be fully written. These are the
-// OS-level write errors that unambiguously signal a dead client TCP connection;
-// context cancellation is deliberately excluded because it crosses a different
-// boundary (a server-side cancel must not be silently downgraded), and the
-// response-encode path produces these write errors, not context.Canceled.
-func isClientDisconnect(err error) bool {
-	return errors.Is(err, syscall.EPIPE) ||
-		errors.Is(err, syscall.ECONNRESET) ||
-		errors.Is(err, net.ErrClosed)
+	httpx.WriteCodedError(w, logComponent, status, code, msg)
 }

--- a/internal/api/helpers_test.go
+++ b/internal/api/helpers_test.go
@@ -3,18 +3,65 @@ package api
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log/slog"
-	"net"
 	"net/http"
 	"net/http/httptest"
-	"syscall"
 	"testing"
 
 	"github.com/jackc/pgx/v5"
 
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 )
+
+// The helper bodies live in internal/httpx and are tested there. What this
+// package owns is the wrapper layer: it must keep the "api" log prefix and the
+// argument order the ~250 call sites rely on.
+
+// msgCaptureHandler records the message of the last record it handled.
+type msgCaptureHandler struct{ msg string }
+
+func (h *msgCaptureHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h *msgCaptureHandler) Handle(_ context.Context, r slog.Record) error {
+	h.msg = r.Message
+	return nil
+}
+func (h *msgCaptureHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *msgCaptureHandler) WithGroup(string) slog.Handler      { return h }
+
+func captureAPILogs(t *testing.T) *msgCaptureHandler {
+	t.Helper()
+	// SetHandler swaps the process-wide slog default; restore it afterwards so
+	// later tests in this package aren't silently swallowed by the capture handler.
+	prev := slog.Default().Handler()
+	t.Cleanup(func() { debuglog.SetHandler(prev) })
+	capt := &msgCaptureHandler{}
+	debuglog.SetHandler(capt)
+	return capt
+}
+
+func TestRespondError_UsesAPIPrefix(t *testing.T) {
+	capt := captureAPILogs(t)
+	w := httptest.NewRecorder()
+	respondError(w, "failed to load thing", errors.New("db down"), http.StatusInternalServerError)
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", w.Code)
+	}
+	if capt.msg != "api: failed to load thing" {
+		t.Errorf("log message = %q, want the api prefix", capt.msg)
+	}
+}
+
+func TestRespondBadRequest_UsesAPIPrefix(t *testing.T) {
+	capt := captureAPILogs(t)
+	w := httptest.NewRecorder()
+	respondBadRequest(w, "invalid JSON body", errors.New("unexpected EOF"))
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+	if capt.msg != "api: bad request: invalid JSON body" {
+		t.Errorf("log message = %q, want the api prefix", capt.msg)
+	}
+}
 
 func TestRespondLookupError(t *testing.T) {
 	t.Run("not-found sentinel returns 404", func(t *testing.T) {
@@ -25,80 +72,52 @@ func TestRespondLookupError(t *testing.T) {
 		}
 	})
 
-	t.Run("wrapped not-found sentinel returns 404", func(t *testing.T) {
-		w := httptest.NewRecorder()
-		wrapped := fmt.Errorf("query failed: %w", pgx.ErrNoRows)
-		respondLookupError(w, wrapped, pgx.ErrNoRows, "thing not found", "failed to load thing")
-		if w.Code != http.StatusNotFound {
-			t.Errorf("expected 404 for wrapped sentinel, got %d", w.Code)
-		}
-	})
-
-	t.Run("any other error returns a logged 500", func(t *testing.T) {
+	t.Run("any other error returns a logged 500 under the api prefix", func(t *testing.T) {
+		capt := captureAPILogs(t)
 		w := httptest.NewRecorder()
 		respondLookupError(w, errors.New("db connection lost"), pgx.ErrNoRows, "thing not found", "failed to load thing")
 		if w.Code != http.StatusInternalServerError {
 			t.Errorf("expected 500, got %d", w.Code)
 		}
+		if capt.msg != "api: failed to load thing" {
+			t.Errorf("log message = %q, want the api prefix", capt.msg)
+		}
 	})
 }
 
-func TestIsClientDisconnect(t *testing.T) {
-	cases := []struct {
-		name string
-		err  error
-		want bool
-	}{
-		{"broken pipe", syscall.EPIPE, true},
-		{"connection reset", syscall.ECONNRESET, true},
-		{"closed conn", net.ErrClosed, true},
-		{"context canceled is not a disconnect", context.Canceled, false},
-		{"wrapped broken pipe", fmt.Errorf("write tcp: %w", syscall.EPIPE), true},
-		{"unmarshalable value", errors.New("json: unsupported type: chan int"), false},
-		{"nil", nil, false},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := isClientDisconnect(tc.err); got != tc.want {
-				t.Errorf("isClientDisconnect(%v) = %v, want %v", tc.err, got, tc.want)
-			}
-		})
-	}
-}
-
-// levelCaptureHandler records the level of the last record it handled.
-type levelCaptureHandler struct{ last slog.Level }
-
-func (h *levelCaptureHandler) Enabled(context.Context, slog.Level) bool { return true }
-func (h *levelCaptureHandler) Handle(_ context.Context, r slog.Record) error {
-	h.last = r.Level
-	return nil
-}
-func (h *levelCaptureHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
-func (h *levelCaptureHandler) WithGroup(string) slog.Handler      { return h }
-
-func TestLogEncodeError_Level(t *testing.T) {
-	// SetHandler swaps the process-wide slog default; restore it afterwards so
-	// later tests in this package aren't silently swallowed by the capture handler.
-	prev := slog.Default().Handler()
-	t.Cleanup(func() { debuglog.SetHandler(prev) })
-
-	capt := &levelCaptureHandler{}
-	debuglog.SetHandler(capt)
-
-	t.Run("client disconnect logs at debug", func(t *testing.T) {
-		capt.last = slog.LevelError + 1 // sentinel
-		logEncodeError(fmt.Errorf("write tcp 1.2.3.4:8080->5.6.7.8:9: write: %w", syscall.EPIPE))
-		if capt.last != slog.LevelDebug {
-			t.Errorf("expected debug level, got %v", capt.last)
+func TestWriteJSONHelpers(t *testing.T) {
+	t.Run("writeJSON", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		writeJSON(w, map[string]string{"a": "b"})
+		if w.Code != http.StatusOK || w.Header().Get("Content-Type") != "application/json" {
+			t.Errorf("got %d %q", w.Code, w.Header().Get("Content-Type"))
 		}
 	})
 
-	t.Run("genuine encode error logs at error", func(t *testing.T) {
-		capt.last = slog.LevelDebug - 1 // sentinel
-		logEncodeError(errors.New("json: unsupported type: chan int"))
-		if capt.last != slog.LevelError {
-			t.Errorf("expected error level, got %v", capt.last)
+	t.Run("writeJSONCreated writes 201", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		writeJSONCreated(w, map[string]string{"a": "b"})
+		if w.Code != http.StatusCreated {
+			t.Errorf("status = %d, want 201", w.Code)
+		}
+	})
+
+	t.Run("writeJSONStatus writes the given status", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		writeJSONStatus(w, http.StatusAccepted, map[string]string{"a": "b"})
+		if w.Code != http.StatusAccepted {
+			t.Errorf("status = %d, want 202", w.Code)
+		}
+	})
+
+	t.Run("writeCodedError writes {code,error}", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		writeCodedError(w, http.StatusConflict, "duplicate", "already exists")
+		if w.Code != http.StatusConflict {
+			t.Errorf("status = %d, want 409", w.Code)
+		}
+		if got := w.Body.String(); got != "{\"code\":\"duplicate\",\"error\":\"already exists\"}\n" {
+			t.Errorf("body = %q", got)
 		}
 	})
 }

--- a/internal/api/logs.go
+++ b/internal/api/logs.go
@@ -271,10 +271,7 @@ func (h *Handler) ListLogsCursor(w http.ResponseWriter, r *http.Request) {
 		HasAfter:  hasAfter,
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(response); err != nil {
-		respondError(w, "failed to encode response", err, http.StatusInternalServerError)
-	}
+	writeJSON(w, response)
 }
 
 // logEntrySelectColumns is the shared 37-column request_logs projection plus the
@@ -749,9 +746,8 @@ func (h *Handler) ListLogs(w http.ResponseWriter, r *http.Request) {
 	offset := (page - 1) * perPage
 
 	if cached, ok := globalLogsCache.get(cacheKey); ok {
-		w.Header().Set("Content-Type", "application/json")
 		w.Header().Set("X-Cache", "HIT")
-		_ = json.NewEncoder(w).Encode(cached)
+		writeJSON(w, cached)
 		return
 	}
 
@@ -809,8 +805,5 @@ func (h *Handler) ListLogs(w http.ResponseWriter, r *http.Request) {
 
 	globalLogsCache.set(cacheKey, &response)
 	w.Header().Set("X-Cache", "MISS")
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(response); err != nil {
-		respondError(w, "failed to encode response", err, http.StatusInternalServerError)
-	}
+	writeJSON(w, response)
 }

--- a/internal/api/models_cursor.go
+++ b/internal/api/models_cursor.go
@@ -32,8 +32,7 @@ import (
 //   - enabled: "true" or "false" to filter on the model's own enabled flag
 func (h *Handler) ListModelsCursor(w http.ResponseWriter, r *http.Request) {
 	if h.dbPool == nil {
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(ModelsCursorResponse{})
+		writeJSON(w, ModelsCursorResponse{})
 		return
 	}
 

--- a/internal/api/provider_typegate.go
+++ b/internal/api/provider_typegate.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"errors"
 	"net/http"
 
@@ -59,15 +58,11 @@ func (h *Handler) rejectDuplicateLocalServer(w http.ResponseWriter, r *http.Requ
 			continue
 		}
 		if provider.SameLocalAddress(p.BaseURL, baseURL) {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusConflict)
-			if err := json.NewEncoder(w).Encode(map[string]string{
+			writeJSONStatus(w, http.StatusConflict, map[string]string{
 				"code":     codeProviderDuplicateAddress,
 				"error":    "a provider for this address already exists: " + p.Name,
 				"existing": p.Name,
-			}); err != nil {
-				logEncodeError(err)
-			}
+			})
 			return false
 		}
 	}
@@ -75,11 +70,7 @@ func (h *Handler) rejectDuplicateLocalServer(w http.ResponseWriter, r *http.Requ
 }
 
 func writeProviderTypeGateError(w http.ResponseWriter, body providerTypeGateResponse) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusBadRequest)
-	if err := json.NewEncoder(w).Encode(body); err != nil {
-		logEncodeError(err)
-	}
+	writeJSONStatus(w, http.StatusBadRequest, body)
 }
 
 // confirmLocalServerType blocks a create or a URL change whose address does not

--- a/internal/api/readonly.go
+++ b/internal/api/readonly.go
@@ -2,50 +2,15 @@ package api
 
 import (
 	"net/http"
-	"strings"
+
+	"github.com/hugalafutro/model-hotel/internal/httpx"
 )
 
 // readOnlyGuard rejects state-changing requests when the instance runs in
-// read-only mode (DEMO_READONLY=true). Safe methods (GET/HEAD/OPTIONS) pass
-// through so the dashboard stays fully browsable; every mutating method —
-// create, update, delete — gets a 403.
-//
-// It is mounted only on the admin CRUD router (Handler.Register), so the admin
-// chat (/api/chat) and the public proxy (/v1) are deliberately unaffected: a
-// demo visitor can still chat against the seeded providers and use a seeded
-// virtual key, they just cannot add, edit, or delete anything.
-//
-// One exception: acknowledging background-discovery notifications. That POST
-// only flips a per-row "seen" flag on the discovery_changes table — it does not
-// touch the model catalog — so it is allowed even in read-only mode. Without
-// this, a demo instance can show the Models nav badge but never clear it, and it
-// reappears on every poll/reload.
+// read-only mode (DEMO_READONLY=true). It is mounted only on the admin CRUD
+// router (Handler.Register), so the admin chat (/api/chat) and the public
+// proxy (/v1) are deliberately unaffected. See httpx.ReadOnlyGuard for the
+// method matrix and the discovery-ack exemption.
 func readOnlyGuard(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.Method {
-		case http.MethodGet, http.MethodHead, http.MethodOptions:
-			next.ServeHTTP(w, r)
-		case http.MethodPost:
-			if isReadOnlyExemptPost(r.URL.Path) {
-				next.ServeHTTP(w, r)
-				return
-			}
-			fallthrough
-		default:
-			// nil err + a 4xx code: respondError does not log this (it is a
-			// client-facing policy rejection, not a server fault).
-			respondError(w, "this is a read-only demo: creating, editing, and deleting are disabled", nil, http.StatusForbidden)
-		}
-	})
-}
-
-// isReadOnlyExemptPost reports whether a POST path stays allowed in read-only
-// mode. These mutate no catalog or credential data. Matched by suffix so they
-// are independent of the router's mount prefix:
-//   - discovery-change acknowledgement (flips a per-row "seen" flag), and
-//   - WebAuthn logout (revokes the current session only; it is not admin
-//     credential management like registering or deleting a passkey).
-func isReadOnlyExemptPost(path string) bool {
-	return strings.HasSuffix(path, "/discovery/changes/ack") ||
-		strings.HasSuffix(path, "/webauthn/logout")
+	return httpx.ReadOnlyGuard(logComponent, next)
 }

--- a/internal/api/readonly_test.go
+++ b/internal/api/readonly_test.go
@@ -29,6 +29,8 @@ func TestReadOnlyGuard(t *testing.T) {
 	}{
 		{http.MethodGet, "/providers", true, http.StatusOK},
 		{http.MethodPost, "/providers", false, http.StatusForbidden},
+		// The ack only flips a per-row "seen" flag, so it stays allowed in
+		// read-only mode and a demo instance can clear the Models nav badge.
 		{http.MethodPost, "/api/discovery/changes/ack", true, http.StatusOK},
 	}
 	for _, tc := range cases {

--- a/internal/api/readonly_test.go
+++ b/internal/api/readonly_test.go
@@ -9,8 +9,10 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
-// TestReadOnlyGuard verifies the middleware in isolation: safe methods reach the
-// next handler, mutating methods are refused with 403 and never reach it.
+// TestReadOnlyGuard verifies the api wrapper delegates to httpx.ReadOnlyGuard:
+// safe methods reach the next handler, mutating methods are refused with 403,
+// and the discovery-ack exemption still passes through. The full method matrix
+// and the exempt-path list are tested in internal/httpx.
 func TestReadOnlyGuard(t *testing.T) {
 	var called bool
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -19,54 +21,26 @@ func TestReadOnlyGuard(t *testing.T) {
 	})
 	guard := readOnlyGuard(next)
 
-	for _, m := range []string{http.MethodGet, http.MethodHead, http.MethodOptions} {
+	cases := []struct {
+		method     string
+		path       string
+		wantCalled bool
+		wantCode   int
+	}{
+		{http.MethodGet, "/providers", true, http.StatusOK},
+		{http.MethodPost, "/providers", false, http.StatusForbidden},
+		{http.MethodPost, "/api/discovery/changes/ack", true, http.StatusOK},
+	}
+	for _, tc := range cases {
 		called = false
 		rec := httptest.NewRecorder()
-		guard.ServeHTTP(rec, httptest.NewRequest(m, "/providers", http.NoBody))
-		if !called {
-			t.Errorf("%s: expected next handler to be called", m)
+		guard.ServeHTTP(rec, httptest.NewRequest(tc.method, tc.path, http.NoBody))
+		if called != tc.wantCalled {
+			t.Errorf("%s %s: next handler called = %v, want %v", tc.method, tc.path, called, tc.wantCalled)
 		}
-		if rec.Code != http.StatusOK {
-			t.Errorf("%s: expected 200, got %d", m, rec.Code)
+		if rec.Code != tc.wantCode {
+			t.Errorf("%s %s: status = %d, want %d", tc.method, tc.path, rec.Code, tc.wantCode)
 		}
-	}
-
-	for _, m := range []string{http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete} {
-		called = false
-		rec := httptest.NewRecorder()
-		guard.ServeHTTP(rec, httptest.NewRequest(m, "/providers", http.NoBody))
-		if called {
-			t.Errorf("%s: next handler must not be called in read-only mode", m)
-		}
-		if rec.Code != http.StatusForbidden {
-			t.Errorf("%s: expected 403, got %d", m, rec.Code)
-		}
-	}
-
-	// Acknowledging background-discovery notifications is exempt: it only flips a
-	// per-row "seen" flag, so it must pass through even in read-only mode.
-	called = false
-	rec := httptest.NewRecorder()
-	guard.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/api/discovery/changes/ack", http.NoBody))
-	if !called {
-		t.Error("POST /discovery/changes/ack: expected exemption to reach next handler")
-	}
-	if rec.Code != http.StatusOK {
-		t.Errorf("POST /discovery/changes/ack: expected 200, got %d", rec.Code)
-	}
-
-	// Dismiss is NOT exempt. It suppresses a real discrepancy from everyone's
-	// view, unlike the ack it sits next to, which only flips a per-row seen
-	// flag. Pattern-matching the neighbouring exemption is the easy way to get
-	// this wrong, so it is asserted explicitly.
-	called = false
-	rec = httptest.NewRecorder()
-	guard.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/api/discovery/dismiss", http.NoBody))
-	if called {
-		t.Error("POST /api/discovery/dismiss: next handler must not be called in read-only mode")
-	}
-	if rec.Code != http.StatusForbidden {
-		t.Errorf("read-only POST /api/discovery/dismiss = %d, want 403", rec.Code)
 	}
 }
 

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -133,10 +133,7 @@ func (h *Handler) GetSettings(w http.ResponseWriter, r *http.Request) {
 
 	all = h.injectReadOnlyStatus(all)
 
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(all); err != nil {
-		respondError(w, "failed to encode response", err, http.StatusInternalServerError)
-	}
+	writeJSON(w, all)
 }
 
 // allowedSettings defines which keys can be set and their validation rules.
@@ -346,10 +343,7 @@ func (h *Handler) UpdateSettings(w http.ResponseWriter, r *http.Request) {
 	all, _ := h.settingsRepo.GetAll(r.Context())
 	all = h.injectReadOnlyStatus(all)
 
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(all); err != nil {
-		respondError(w, "failed to encode response", err, http.StatusInternalServerError)
-	}
+	writeJSON(w, all)
 }
 
 // ResetSettings deletes specified settings keys from the database so they
@@ -427,8 +421,5 @@ func (h *Handler) ResetSettings(w http.ResponseWriter, r *http.Request) {
 	all, _ := h.settingsRepo.GetAll(r.Context())
 	all = h.injectReadOnlyStatus(all)
 
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(all); err != nil {
-		respondError(w, "failed to encode response", err, http.StatusInternalServerError)
-	}
+	writeJSON(w, all)
 }

--- a/internal/api/settings_test.go
+++ b/internal/api/settings_test.go
@@ -48,9 +48,12 @@ func TestGetSettings_EncodeError(t *testing.T) {
 	fw := &trackingFailingWriter{}
 	h.GetSettings(fw, req)
 
-	// After encode fails, respondError is called with 500
-	if fw.statusCode != http.StatusInternalServerError {
-		t.Errorf("expected status %d, got %d", http.StatusInternalServerError, fw.statusCode)
+	// The response body has already started when the encode fails, so the
+	// handler must not fabricate a second status: it logs the failure and
+	// leaves the truncated stream for the client to detect. Writing a 500 here
+	// would be a superfluous WriteHeader on a committed response.
+	if fw.statusCode != 0 {
+		t.Errorf("encode failure wrote status %d after the body started; want none", fw.statusCode)
 	}
 }
 

--- a/internal/api/stats.go
+++ b/internal/api/stats.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"encoding/json"
 	"math"
 	"net/http"
 	"time"
@@ -193,10 +192,7 @@ func (h *StatsHandler) GetStats(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(stats); err != nil {
-		respondError(w, "failed to encode response", err, http.StatusInternalServerError)
-	}
+	writeJSON(w, stats)
 }
 
 // modelKeySQL is the aggregation key for per-model stats: the "Provider/model"
@@ -720,10 +716,7 @@ func (h *StatsHandler) GetTimeSeries(w http.ResponseWriter, r *http.Request) {
 		result.Points = fillEmptyBuckets(result.Points, since, endTrunc, bucketSize)
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(result); err != nil {
-		respondError(w, "failed to encode response", err, http.StatusInternalServerError)
-	}
+	writeJSON(w, result)
 }
 
 func fillEmptyBuckets(points []TimeSeriesPoint, start, end time.Time, bucketSize string) []TimeSeriesPoint {
@@ -846,8 +839,5 @@ func (h *StatsHandler) GetProviderDistribution(w http.ResponseWriter, r *http.Re
 		result.Items[0].Share = math.Round((100-roundedSum+result.Items[0].Share)*10) / 10
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(result); err != nil {
-		respondError(w, "failed to encode response", err, http.StatusInternalServerError)
-	}
+	writeJSON(w, result)
 }

--- a/internal/api/stats_handlers_test.go
+++ b/internal/api/stats_handlers_test.go
@@ -787,8 +787,12 @@ func TestGetStats_JSONEncodeError(t *testing.T) {
 
 	handler.GetStats(w, r)
 
-	if w.code != http.StatusInternalServerError {
-		t.Errorf("Expected 500, got %d", w.code)
+	// The response body has already started when the encode fails, so the
+	// handler must not fabricate a second status: it logs the failure and
+	// leaves the truncated stream for the client to detect. Writing a 500 here
+	// would be a superfluous WriteHeader on a committed response.
+	if w.code != 0 {
+		t.Errorf("encode failure wrote status %d after the body started; want none", w.code)
 	}
 }
 
@@ -807,8 +811,12 @@ func TestGetTimeSeries_JSONEncodeError(t *testing.T) {
 
 	handler.GetTimeSeries(w, r)
 
-	if w.code != http.StatusInternalServerError {
-		t.Errorf("Expected 500, got %d", w.code)
+	// The response body has already started when the encode fails, so the
+	// handler must not fabricate a second status: it logs the failure and
+	// leaves the truncated stream for the client to detect. Writing a 500 here
+	// would be a superfluous WriteHeader on a committed response.
+	if w.code != 0 {
+		t.Errorf("encode failure wrote status %d after the body started; want none", w.code)
 	}
 }
 
@@ -827,8 +835,12 @@ func TestGetProviderDistribution_JSONEncodeError(t *testing.T) {
 
 	handler.GetProviderDistribution(w, r)
 
-	if w.code != http.StatusInternalServerError {
-		t.Errorf("Expected 500, got %d", w.code)
+	// The response body has already started when the encode fails, so the
+	// handler must not fabricate a second status: it logs the failure and
+	// leaves the truncated stream for the client to detect. Writing a 500 here
+	// would be a superfluous WriteHeader on a committed response.
+	if w.code != 0 {
+		t.Errorf("encode failure wrote status %d after the body started; want none", w.code)
 	}
 }
 

--- a/internal/api/system.go
+++ b/internal/api/system.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"math"
 	"net/http"
@@ -228,10 +227,7 @@ func cachedSystemFor(since string) (*SystemStats, bool) {
 }
 
 func writeSystemJSON(w http.ResponseWriter, stats *SystemStats) {
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(stats); err != nil {
-		respondError(w, "failed to encode response", err, http.StatusInternalServerError)
-	}
+	writeJSON(w, stats)
 }
 
 // requestsSince returns the number of request_logs rows at or after `since`,

--- a/internal/api/system_test.go
+++ b/internal/api/system_test.go
@@ -371,8 +371,8 @@ func TestGetSystem_CachedJSONEncodeError(t *testing.T) {
 	// handler must not fabricate a second status: it logs the failure and
 	// leaves the truncated stream for the client to detect. Writing a 500 here
 	// would be a superfluous WriteHeader on a committed response.
-	if w.code == http.StatusInternalServerError {
-		t.Error("encode failure wrote a superfluous 500 after the body started")
+	if w.code != 0 {
+		t.Errorf("encode failure wrote status %d after the body started; want none", w.code)
 	}
 }
 
@@ -391,8 +391,8 @@ func TestGetSystem_FreshJSONEncodeError(t *testing.T) {
 	// handler must not fabricate a second status: it logs the failure and
 	// leaves the truncated stream for the client to detect. Writing a 500 here
 	// would be a superfluous WriteHeader on a committed response.
-	if w.code == http.StatusInternalServerError {
-		t.Error("encode failure wrote a superfluous 500 after the body started")
+	if w.code != 0 {
+		t.Errorf("encode failure wrote status %d after the body started; want none", w.code)
 	}
 }
 

--- a/internal/api/system_test.go
+++ b/internal/api/system_test.go
@@ -367,8 +367,12 @@ func TestGetSystem_CachedJSONEncodeError(t *testing.T) {
 	req2.Header.Set("Authorization", "Bearer test-admin-token")
 	r.ServeHTTP(w, req2)
 
-	if w.code != http.StatusInternalServerError {
-		t.Errorf("expected 500, got %d", w.code)
+	// The response body has already started when the encode fails, so the
+	// handler must not fabricate a second status: it logs the failure and
+	// leaves the truncated stream for the client to detect. Writing a 500 here
+	// would be a superfluous WriteHeader on a committed response.
+	if w.code == http.StatusInternalServerError {
+		t.Error("encode failure wrote a superfluous 500 after the body started")
 	}
 }
 
@@ -383,8 +387,12 @@ func TestGetSystem_FreshJSONEncodeError(t *testing.T) {
 	req.Header.Set("Authorization", "Bearer test-admin-token")
 	r.ServeHTTP(w, req)
 
-	if w.code != http.StatusInternalServerError {
-		t.Errorf("expected 500, got %d", w.code)
+	// The response body has already started when the encode fails, so the
+	// handler must not fabricate a second status: it logs the failure and
+	// leaves the truncated stream for the client to detect. Writing a 500 here
+	// would be a superfluous WriteHeader on a committed response.
+	if w.code == http.StatusInternalServerError {
+		t.Error("encode failure wrote a superfluous 500 after the body started")
 	}
 }
 

--- a/internal/api/users.go
+++ b/internal/api/users.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 
+	"github.com/hugalafutro/model-hotel/internal/db"
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 	"github.com/hugalafutro/model-hotel/internal/user"
 )
@@ -203,7 +204,7 @@ func (h *Handler) CreateUser(w http.ResponseWriter, r *http.Request) {
 	}
 	u, err := h.userRepo.Create(r.Context(), req.Username, req.DisplayName, req.Email, hash, role, req.Grants, req.limits(), req.AllowedProviders)
 	if err != nil {
-		if isUniqueViolation(err) {
+		if db.IsUniqueViolation(err) {
 			http.Error(w, "a user with this username or email already exists", http.StatusConflict)
 			return
 		}
@@ -268,7 +269,7 @@ func (h *Handler) UpdateUser(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "user not found", http.StatusNotFound)
 			return
 		}
-		if isUniqueViolation(err) {
+		if db.IsUniqueViolation(err) {
 			http.Error(w, "a user with this username or email already exists", http.StatusConflict)
 			return
 		}

--- a/internal/db/pgerr.go
+++ b/internal/db/pgerr.go
@@ -1,0 +1,18 @@
+package db
+
+import (
+	"errors"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// IsUniqueViolation reports whether err is a PostgreSQL unique-constraint
+// violation (SQLSTATE 23505). Callers use it to turn a racing insert into a
+// 409/duplicate response instead of a 500. The SQLite Front Desk store has its
+// own variant: the driver reports a different error shape entirely.
+func IsUniqueViolation(err error) bool {
+	if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok {
+		return pgErr.Code == "23505"
+	}
+	return false
+}

--- a/internal/db/pgerr_test.go
+++ b/internal/db/pgerr_test.go
@@ -1,0 +1,59 @@
+package db
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+func TestIsUniqueViolation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil_error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "pg_error_23505_unique_violation",
+			err:  &pgconn.PgError{Code: "23505"},
+			want: true,
+		},
+		{
+			name: "pg_error_23503_fk_violation",
+			err:  &pgconn.PgError{Code: "23503"},
+			want: false,
+		},
+		{
+			name: "pg_error_42P01_undefined_table",
+			err:  &pgconn.PgError{Code: "42P01"},
+			want: false,
+		},
+		{
+			name: "wrapped_pg_error_23505",
+			err:  fmt.Errorf("wrap: %w", &pgconn.PgError{Code: "23505"}),
+			want: true,
+		},
+		{
+			name: "non_pg_error",
+			err:  errors.New("some other error"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := IsUniqueViolation(tt.err); got != tt.want {
+				t.Errorf("IsUniqueViolation(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/egress/adapter.go
+++ b/internal/egress/adapter.go
@@ -32,7 +32,8 @@ type Translator interface {
 // yields chat.completion.chunk SSE bytes. Wrapping the UPSTREAM body (not the
 // client writer) lets the whole existing streaming pipeline — TTFT probe, stall
 // watchdog, transforms, metering — run unchanged on what it already
-// understands.
+// understands. openairesponses.StreamAdapter plays the same trick with a
+// simpler shape: its translator has no Finish(), so it stays outside this type.
 //
 // Vendor streams carry no [DONE] sentinel of their own, so the translator's
 // Finish() supplies the terminal chunk + [DONE] when upstream EOF arrives. Any

--- a/internal/egress/adapter.go
+++ b/internal/egress/adapter.go
@@ -9,19 +9,21 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 )
 
-// MaxSSELineBytes caps the unterminated SSE line an adapter will buffer. Vendor
-// deltas are orders of magnitude smaller than this, so an upstream that never
-// emits a newline is a broken peer, not a large response — the stream fails
-// instead of growing the buffer until the process suffers.
-const MaxSSELineBytes = 1 << 20
+// MaxSSEEventBytes caps the SSE event an adapter will buffer: the data fields
+// joined so far plus the line still being read. Vendor deltas are orders of
+// magnitude smaller than this, so an upstream that never closes an event is a
+// broken peer, not a large response — the stream fails instead of growing the
+// buffer until the process suffers.
+const MaxSSEEventBytes = 1 << 20
 
 // Translator converts one upstream SSE data payload into the client-facing
 // bytes for that event, and produces the stream's terminal bytes on Finish.
 // Implemented by each dialect's StreamTranslator.
 type Translator interface {
-	// Translate maps one "data:" payload to zero or more output bytes. A
-	// non-nil error means the upstream stream is corrupt or carried an error
-	// event, and poisons the adapter.
+	// Translate maps one event's payload — every "data:" field of that event,
+	// joined with newlines — to zero or more output bytes. A non-nil error
+	// means the upstream stream is corrupt or carried an error event, and
+	// poisons the adapter.
 	Translate(payload []byte) ([]byte, error)
 	// Finish returns the terminal chunk plus the [DONE] sentinel, or nothing
 	// when the translator already emitted them.
@@ -45,6 +47,7 @@ type StreamAdapter struct {
 	tr        Translator
 
 	lineBuf  []byte // partial SSE line carried across reads
+	eventBuf []byte // data fields of the event under construction, newline-joined
 	pending  []byte // translated bytes not yet handed to the caller
 	readBuf  []byte
 	srcErr   error
@@ -64,8 +67,8 @@ func NewStreamAdapter(component string, upstream io.ReadCloser, tr Translator) *
 }
 
 // Read refills the pending buffer from upstream (translating as it goes) and
-// copies out. On EOF any residual partial line is flushed through the
-// translator and the terminal Finish() bytes are appended before the EOF is
+// copies out. On EOF any unterminated tail is flushed through the translator
+// and the terminal Finish() bytes are appended before the EOF is
 // surfaced; other upstream errors surface only after all translated bytes have
 // been drained. A translation failure poisons the stream: already translated
 // bytes drain, then the error surfaces — Finish() is never fabricated over a
@@ -91,7 +94,7 @@ func (a *StreamAdapter) Read(p []byte) (int, error) {
 				// transport and here would be reported as a broken stream even
 				// though it ended normally. This adapter ends on io.EOF itself.
 				a.srcErr = io.EOF
-				a.flushPartialLine()
+				a.flushAtEOF()
 				if a.transErr == nil {
 					fin, finErr := a.tr.Finish()
 					if finErr != nil {
@@ -107,54 +110,107 @@ func (a *StreamAdapter) Read(p []byte) (int, error) {
 	return n, nil
 }
 
-// consume splits incoming bytes into SSE lines and feeds each data payload to
-// the translator. "event:"/comment/blank lines are dropped; the adapter
-// generates its own framing.
+// consume splits incoming bytes into SSE lines and assembles those lines into
+// events. SSE lets one event fold its payload across several "data:" fields,
+// so a field is appended to the event under construction rather than
+// translated on its own, and the blank line that terminates the event hands
+// the joined payload to the translator exactly once. Comment lines (":") and
+// every other field — "event:", "id:", "retry:" — are ignored, because the
+// dialect translators key off the payload's own JSON type rather than the SSE
+// event name. The adapter generates its own framing on the way out.
 func (a *StreamAdapter) consume(p []byte) {
 	a.lineBuf = append(a.lineBuf, p...)
 	for {
 		idx := bytes.IndexByte(a.lineBuf, '\n')
 		if idx < 0 {
-			if len(a.lineBuf) > MaxSSELineBytes {
-				a.lineBuf = nil
-				a.transErr = fmt.Errorf("%s: upstream SSE line exceeds %d bytes", a.component, MaxSSELineBytes)
-				debuglog.Warn(a.component+": stream line exceeds buffer cap", "limit", MaxSSELineBytes)
-			}
+			a.withinEventCap(len(a.lineBuf))
 			return
 		}
 		line := bytes.TrimRight(a.lineBuf[:idx], "\r")
 		a.lineBuf = a.lineBuf[idx+1:]
+		if len(line) == 0 {
+			if !a.dispatchEvent() {
+				return
+			}
+			continue
+		}
 		if !bytes.HasPrefix(line, []byte("data:")) {
 			continue
 		}
-		payload := bytes.TrimSpace(line[len("data:"):])
-		if len(payload) == 0 {
+		// The spec strips one optional leading space; trimming both ends is
+		// safe on top of that because JSON ignores whitespace around a value,
+		// and a folded payload cannot split inside a string literal — the
+		// newline the join inserts would be illegal there — so no byte a
+		// translator reads can be trimmed away. A field with no value adds
+		// nothing to the event.
+		value := bytes.TrimSpace(line[len("data:"):])
+		if len(value) == 0 {
 			continue
 		}
-		out, err := a.tr.Translate(payload)
-		if err != nil {
-			// A malformed data line or an upstream error event means the
-			// stream is dead; record it and stop translating so Read surfaces
-			// the failure.
-			debuglog.Warn(a.component+": stream chunk translate failed", "error", err)
-			a.transErr = err
+		if len(a.eventBuf) > 0 {
+			a.eventBuf = append(a.eventBuf, '\n')
+		}
+		a.eventBuf = append(a.eventBuf, value...)
+		if !a.withinEventCap(0) {
 			return
 		}
-		a.pending = append(a.pending, out...)
 	}
 }
 
-// flushPartialLine feeds a residual line to the translator at EOF. An upstream
-// that closes without a trailing newline would otherwise lose its last event
+// withinEventCap poisons the stream when the event under construction outgrows
+// the cap, and reports whether parsing may continue. partialLine is the length
+// of the line still being read, counted with the fields already joined so that
+// a folded event cannot carry more than a single line could.
+func (a *StreamAdapter) withinEventCap(partialLine int) bool {
+	if len(a.eventBuf)+partialLine <= MaxSSEEventBytes {
+		return true
+	}
+	a.lineBuf, a.eventBuf = nil, nil
+	a.transErr = fmt.Errorf("%s: upstream SSE event exceeds %d bytes", a.component, MaxSSEEventBytes)
+	debuglog.Warn(a.component+": stream event exceeds buffer cap", "limit", MaxSSEEventBytes)
+	return false
+}
+
+// dispatchEvent hands the assembled payload to the translator once and clears
+// the buffer for the next event. An event that carried no data fields
+// dispatches nothing. It reports whether parsing may continue.
+func (a *StreamAdapter) dispatchEvent() bool {
+	if len(a.eventBuf) == 0 {
+		return true
+	}
+	payload := a.eventBuf
+	a.eventBuf = nil
+	out, err := a.tr.Translate(payload)
+	if err != nil {
+		// A malformed event or an upstream error event means the stream is
+		// dead; record it and stop translating so Read surfaces the failure.
+		debuglog.Warn(a.component+": stream event translate failed", "error", err)
+		a.transErr = err
+		return false
+	}
+	a.pending = append(a.pending, out...)
+	return true
+}
+
+// flushAtEOF dispatches the stream's unterminated tail: the residual line the
+// upstream never terminated, and then the event no blank line ever closed. An
+// upstream that closes without that framing would otherwise lose its last event
 // entirely — including a final message_delta's stop_reason — while Finish()
 // still emitted a clean terminal chunk, which is exactly the quiet truncation
-// this adapter exists to prevent.
-func (a *StreamAdapter) flushPartialLine() {
-	if len(a.lineBuf) == 0 || a.transErr != nil {
+// this adapter exists to prevent. A tail that does not translate poisons the
+// stream, so a connection cut mid-event surfaces as the failure it is.
+func (a *StreamAdapter) flushAtEOF() {
+	if a.transErr != nil {
 		return
 	}
-	a.lineBuf = append(a.lineBuf, '\n')
-	a.consume(nil)
+	if len(a.lineBuf) > 0 {
+		a.lineBuf = append(a.lineBuf, '\n')
+		a.consume(nil)
+		if a.transErr != nil {
+			return
+		}
+	}
+	a.dispatchEvent()
 }
 
 // Close closes the upstream body. The stall watchdog calls this to unblock a

--- a/internal/egress/adapter.go
+++ b/internal/egress/adapter.go
@@ -1,0 +1,163 @@
+package egress
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/hugalafutro/model-hotel/internal/debuglog"
+)
+
+// MaxSSELineBytes caps the unterminated SSE line an adapter will buffer. Vendor
+// deltas are orders of magnitude smaller than this, so an upstream that never
+// emits a newline is a broken peer, not a large response — the stream fails
+// instead of growing the buffer until the process suffers.
+const MaxSSELineBytes = 1 << 20
+
+// Translator converts one upstream SSE data payload into the client-facing
+// bytes for that event, and produces the stream's terminal bytes on Finish.
+// Implemented by each dialect's StreamTranslator.
+type Translator interface {
+	// Translate maps one "data:" payload to zero or more output bytes. A
+	// non-nil error means the upstream stream is corrupt or carried an error
+	// event, and poisons the adapter.
+	Translate(payload []byte) ([]byte, error)
+	// Finish returns the terminal chunk plus the [DONE] sentinel, or nothing
+	// when the translator already emitted them.
+	Finish() ([]byte, error)
+}
+
+// StreamAdapter wraps an upstream vendor SSE body as an io.ReadCloser that
+// yields chat.completion.chunk SSE bytes. Wrapping the UPSTREAM body (not the
+// client writer) lets the whole existing streaming pipeline — TTFT probe, stall
+// watchdog, transforms, metering — run unchanged on what it already
+// understands.
+//
+// Vendor streams carry no [DONE] sentinel of their own, so the translator's
+// Finish() supplies the terminal chunk + [DONE] when upstream EOF arrives. Any
+// other upstream error surfaces as a stream without [DONE], which the pipeline
+// already classifies as a truncation.
+type StreamAdapter struct {
+	component string // log prefix: the dialect that built this adapter
+	upstream  io.ReadCloser
+	tr        Translator
+
+	lineBuf  []byte // partial SSE line carried across reads
+	pending  []byte // translated bytes not yet handed to the caller
+	readBuf  []byte
+	srcErr   error
+	transErr error // first translation failure; poisons the stream
+}
+
+// NewStreamAdapter builds an adapter for one streaming response. component is
+// the log prefix ("gemini", "anthropicegress"); tr is that dialect's stream
+// translator, already primed with the chunk id and model to echo.
+func NewStreamAdapter(component string, upstream io.ReadCloser, tr Translator) *StreamAdapter {
+	return &StreamAdapter{
+		component: component,
+		upstream:  upstream,
+		tr:        tr,
+		readBuf:   make([]byte, 32*1024),
+	}
+}
+
+// Read refills the pending buffer from upstream (translating as it goes) and
+// copies out. On EOF any residual partial line is flushed through the
+// translator and the terminal Finish() bytes are appended before the EOF is
+// surfaced; other upstream errors surface only after all translated bytes have
+// been drained. A translation failure poisons the stream: already translated
+// bytes drain, then the error surfaces — Finish() is never fabricated over a
+// corrupt upstream, so the proxy sees a failed stream instead of a clean
+// empty/partial success.
+func (a *StreamAdapter) Read(p []byte) (int, error) {
+	for len(a.pending) == 0 {
+		if a.transErr != nil {
+			return 0, a.transErr
+		}
+		if a.srcErr != nil {
+			return 0, a.srcErr
+		}
+		n, err := a.upstream.Read(a.readBuf)
+		if n > 0 {
+			a.consume(a.readBuf[:n])
+		}
+		if err != nil {
+			a.srcErr = err
+			if errors.Is(err, io.EOF) {
+				// io.Copy and io.ReadAll compare the terminating error against
+				// io.EOF with ==, so a wrapped EOF from a reader between the
+				// transport and here would be reported as a broken stream even
+				// though it ended normally. This adapter ends on io.EOF itself.
+				a.srcErr = io.EOF
+				a.flushPartialLine()
+				if a.transErr == nil {
+					fin, finErr := a.tr.Finish()
+					if finErr != nil {
+						debuglog.Warn(a.component+": stream finish failed", "error", finErr)
+					}
+					a.pending = append(a.pending, fin...)
+				}
+			}
+		}
+	}
+	n := copy(p, a.pending)
+	a.pending = a.pending[n:]
+	return n, nil
+}
+
+// consume splits incoming bytes into SSE lines and feeds each data payload to
+// the translator. "event:"/comment/blank lines are dropped; the adapter
+// generates its own framing.
+func (a *StreamAdapter) consume(p []byte) {
+	a.lineBuf = append(a.lineBuf, p...)
+	for {
+		idx := bytes.IndexByte(a.lineBuf, '\n')
+		if idx < 0 {
+			if len(a.lineBuf) > MaxSSELineBytes {
+				a.lineBuf = nil
+				a.transErr = fmt.Errorf("%s: upstream SSE line exceeds %d bytes", a.component, MaxSSELineBytes)
+				debuglog.Warn(a.component+": stream line exceeds buffer cap", "limit", MaxSSELineBytes)
+			}
+			return
+		}
+		line := bytes.TrimRight(a.lineBuf[:idx], "\r")
+		a.lineBuf = a.lineBuf[idx+1:]
+		if !bytes.HasPrefix(line, []byte("data:")) {
+			continue
+		}
+		payload := bytes.TrimSpace(line[len("data:"):])
+		if len(payload) == 0 {
+			continue
+		}
+		out, err := a.tr.Translate(payload)
+		if err != nil {
+			// A malformed data line or an upstream error event means the
+			// stream is dead; record it and stop translating so Read surfaces
+			// the failure.
+			debuglog.Warn(a.component+": stream chunk translate failed", "error", err)
+			a.transErr = err
+			return
+		}
+		a.pending = append(a.pending, out...)
+	}
+}
+
+// flushPartialLine feeds a residual line to the translator at EOF. An upstream
+// that closes without a trailing newline would otherwise lose its last event
+// entirely — including a final message_delta's stop_reason — while Finish()
+// still emitted a clean terminal chunk, which is exactly the quiet truncation
+// this adapter exists to prevent.
+func (a *StreamAdapter) flushPartialLine() {
+	if len(a.lineBuf) == 0 || a.transErr != nil {
+		return
+	}
+	a.lineBuf = append(a.lineBuf, '\n')
+	a.consume(nil)
+}
+
+// Close closes the upstream body. The stall watchdog calls this to unblock a
+// hung read, so it must propagate to the wrapped connection.
+func (a *StreamAdapter) Close() error {
+	return a.upstream.Close()
+}

--- a/internal/egress/adapter.go
+++ b/internal/egress/adapter.go
@@ -206,10 +206,9 @@ func (a *StreamAdapter) flushAtEOF() {
 	if len(a.lineBuf) > 0 {
 		a.lineBuf = append(a.lineBuf, '\n')
 		a.consume(nil)
-		if a.transErr != nil {
-			return
-		}
 	}
+	// consume can only have poisoned the stream here by tripping the event cap,
+	// which clears the buffer, so dispatchEvent then has nothing to hand on.
 	a.dispatchEvent()
 }
 

--- a/internal/egress/adapter.go
+++ b/internal/egress/adapter.go
@@ -10,11 +10,13 @@ import (
 )
 
 // MaxSSEEventBytes caps the SSE event an adapter will buffer: the data fields
-// joined so far plus the line still being read. Vendor deltas are orders of
-// magnitude smaller than this, so an upstream that never closes an event is a
-// broken peer, not a large response — the stream fails instead of growing the
-// buffer until the process suffers.
-const MaxSSEEventBytes = 1 << 20
+// joined so far plus the line still being read. The Responses dialect sets the
+// floor — its response.completed event embeds the whole generated output, so a
+// 128k-token generation with JSON escaping approaches 1 MiB — and 4 MiB clears
+// that with headroom while still bounding a runaway upstream: one that never
+// closes an event fails the stream instead of growing the buffer until the
+// process suffers.
+const MaxSSEEventBytes = 4 << 20
 
 // Translator converts one upstream SSE data payload into the client-facing
 // bytes for that event, and produces the stream's terminal bytes on Finish.

--- a/internal/egress/adapter.go
+++ b/internal/egress/adapter.go
@@ -34,8 +34,9 @@ type Translator interface {
 // yields chat.completion.chunk SSE bytes. Wrapping the UPSTREAM body (not the
 // client writer) lets the whole existing streaming pipeline — TTFT probe, stall
 // watchdog, transforms, metering — run unchanged on what it already
-// understands. openairesponses.StreamAdapter plays the same trick with a
-// simpler shape: its translator has no Finish(), so it stays outside this type.
+// understands. All three dialect adapters — gemini, anthropicegress and
+// openairesponses — are this type; each supplies only its translator and its
+// log prefix.
 //
 // Vendor streams carry no [DONE] sentinel of their own, so the translator's
 // Finish() supplies the terminal chunk + [DONE] when upstream EOF arrives. Any

--- a/internal/egress/adapter_test.go
+++ b/internal/egress/adapter_test.go
@@ -1,76 +1,25 @@
 package egress
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
-	"reflect"
 	"strings"
 	"testing"
 )
-
-func TestAsJSONString(t *testing.T) {
-	cases := []struct {
-		name    string
-		raw     string
-		want    string
-		wantOK  bool
-		comment string
-	}{
-		{name: "absent field", raw: "", want: "", wantOK: false},
-		{name: "string literal", raw: `"hello"`, want: "hello", wantOK: true},
-		{name: "empty string literal", raw: `""`, want: "", wantOK: true},
-		{name: "escapes are decoded", raw: `"a\nb"`, want: "a\nb", wantOK: true},
-		{name: "null decodes to the empty string", raw: `null`, want: "", wantOK: true},
-		{name: "array is not a string", raw: `[{"type":"text"}]`, want: "", wantOK: false},
-		{name: "object is not a string", raw: `{"type":"text"}`, want: "", wantOK: false},
-		{name: "number is not a string", raw: `42`, want: "", wantOK: false},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			got, ok := AsJSONString(json.RawMessage(tc.raw))
-			if got != tc.want || ok != tc.wantOK {
-				t.Errorf("AsJSONString(%q) = (%q, %v), want (%q, %v)", tc.raw, got, ok, tc.want, tc.wantOK)
-			}
-		})
-	}
-}
-
-func TestDecodeStop(t *testing.T) {
-	cases := []struct {
-		name string
-		raw  string
-		want []string
-	}{
-		{name: "absent field", raw: "", want: nil},
-		{name: "single string", raw: `"STOP"`, want: []string{"STOP"}},
-		{name: "empty string is not a stop sequence", raw: `""`, want: nil},
-		{name: "array", raw: `["a","b"]`, want: []string{"a", "b"}},
-		{name: "empty array", raw: `[]`, want: []string{}},
-		{name: "wrong type", raw: `{"a":1}`, want: nil},
-		{name: "malformed", raw: `[not json`, want: nil},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			got := DecodeStop(json.RawMessage(tc.raw))
-			if !reflect.DeepEqual(got, tc.want) {
-				t.Errorf("DecodeStop(%q) = %#v, want %#v", tc.raw, got, tc.want)
-			}
-		})
-	}
-}
 
 // fakeTranslator echoes each payload back in a recognisable frame, so the
 // adapter's own mechanics (line splitting, EOF finish, poisoning) are what the
 // assertions below measure rather than any real dialect's translation.
 type fakeTranslator struct {
-	failOn    string // payload that makes Translate fail
+	failOn    string   // payload that makes Translate fail
+	seen      []string // one entry per Translate call, so folding is measurable
 	finishErr error
 	finished  int
 }
 
 func (f *fakeTranslator) Translate(payload []byte) ([]byte, error) {
+	f.seen = append(f.seen, string(payload))
 	if f.failOn != "" && string(payload) == f.failOn {
 		return nil, errors.New("bad payload")
 	}
@@ -141,6 +90,118 @@ func TestStreamAdapter_NonDataLinesIgnored(t *testing.T) {
 	}
 	if got := string(out); got != "<real>[DONE]" {
 		t.Errorf("output = %q, want only the data payload translated", got)
+	}
+}
+
+// TestStreamAdapter_FoldedEventTranslatedOnce pins the SSE folding rule: one
+// event may spread its payload over several "data:" fields, and the payload is
+// their newline-join. Translating each field on its own would hand the
+// translator JSON fragments and poison the stream.
+func TestStreamAdapter_FoldedEventTranslatedOnce(t *testing.T) {
+	tr := &fakeTranslator{}
+	body := &scriptedBody{script: []string{"data: {\"text\":\ndata: \"hello\"}\n\n"}}
+
+	out, err := io.ReadAll(NewStreamAdapter("test", body, tr))
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if len(tr.seen) != 1 {
+		t.Fatalf("Translate called %d times, want 1: %q", len(tr.seen), tr.seen)
+	}
+	if tr.seen[0] != "{\"text\":\n\"hello\"}" {
+		t.Errorf("payload = %q, want the two fields joined with a newline", tr.seen[0])
+	}
+	if got := string(out); got != "<{\"text\":\n\"hello\"}>[DONE]" {
+		t.Errorf("output = %q", got)
+	}
+}
+
+// TestStreamAdapter_NonDataFieldsInsideEventIgnored keeps comment lines and the
+// other SSE fields out of the payload even when they sit between the data
+// fields of one folded event: the dialect translators key off the payload's own
+// JSON type, never the SSE event name.
+func TestStreamAdapter_NonDataFieldsInsideEventIgnored(t *testing.T) {
+	tr := &fakeTranslator{}
+	body := &scriptedBody{script: []string{
+		"event: content_block_delta\n: keepalive\ndata: {\"a\":1,\nid: 7\ndata: \"b\":2}\nretry: 100\n\n",
+	}}
+
+	out, err := io.ReadAll(NewStreamAdapter("test", body, tr))
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if len(tr.seen) != 1 {
+		t.Fatalf("Translate called %d times, want 1: %q", len(tr.seen), tr.seen)
+	}
+	if tr.seen[0] != "{\"a\":1,\n\"b\":2}" {
+		t.Errorf("payload = %q, want only the data fields joined", tr.seen[0])
+	}
+	if got := string(out); got != "<{\"a\":1,\n\"b\":2}>[DONE]" {
+		t.Errorf("output = %q", got)
+	}
+}
+
+// TestStreamAdapter_BlankLineSeparatesEvents pins the other half of the rule:
+// the blank line ends an event, so two of them stay two Translate calls rather
+// than merging into one payload.
+func TestStreamAdapter_BlankLineSeparatesEvents(t *testing.T) {
+	tr := &fakeTranslator{}
+	body := &scriptedBody{script: []string{"data: one\n\ndata: two\n\n"}}
+
+	out, err := io.ReadAll(NewStreamAdapter("test", body, tr))
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if len(tr.seen) != 2 || tr.seen[0] != "one" || tr.seen[1] != "two" {
+		t.Errorf("Translate calls = %q, want [one two]", tr.seen)
+	}
+	if got := string(out); got != "<one><two>[DONE]" {
+		t.Errorf("output = %q", got)
+	}
+}
+
+// TestStreamAdapter_UnterminatedFoldedEventFlushedAtEOF covers the tail an
+// upstream leaves when it closes without the blank line: the folded event is
+// still dispatched once, before Finish().
+func TestStreamAdapter_UnterminatedFoldedEventFlushedAtEOF(t *testing.T) {
+	tr := &fakeTranslator{}
+	body := &scriptedBody{script: []string{"data: {\"text\":\ndata: \"tail\"}"}}
+
+	out, err := io.ReadAll(NewStreamAdapter("test", body, tr))
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if len(tr.seen) != 1 {
+		t.Fatalf("Translate called %d times, want 1: %q", len(tr.seen), tr.seen)
+	}
+	if tr.seen[0] != "{\"text\":\n\"tail\"}" {
+		t.Errorf("payload = %q, want the whole folded tail", tr.seen[0])
+	}
+	if got := string(out); got != "<{\"text\":\n\"tail\"}>[DONE]" {
+		t.Errorf("output = %q, want the tail translated before the terminal bytes", got)
+	}
+}
+
+// TestStreamAdapter_FoldedEventOverCapFailsStream pins the cap as an event-size
+// cap: neither field is close to the limit on its own, but the event they build
+// is over it, so it must fail rather than grow the buffer.
+func TestStreamAdapter_FoldedEventOverCapFailsStream(t *testing.T) {
+	tr := &fakeTranslator{}
+	half := strings.Repeat("a", MaxSSEEventBytes/2+1)
+	body := &scriptedBody{script: []string{"data: " + half + "\ndata: " + half + "\n\n"}}
+
+	_, err := io.ReadAll(NewStreamAdapter("test", body, tr))
+	if err == nil {
+		t.Fatal("expected the joined event to exceed the cap")
+	}
+	if !strings.Contains(err.Error(), "exceeds") || !strings.HasPrefix(err.Error(), "test: ") {
+		t.Errorf("error = %q, want the component prefix and the exceeded cap", err)
+	}
+	if strings.Contains(err.Error(), "aaaa") {
+		t.Errorf("error leaked the buffered event: %q", err)
+	}
+	if len(tr.seen) != 0 {
+		t.Errorf("Translate called on an over-cap event: %q", tr.seen)
 	}
 }
 
@@ -220,11 +281,11 @@ func TestStreamAdapter_FinishErrorIsLoggedNotFatal(t *testing.T) {
 	}
 }
 
-func TestStreamAdapter_OverlongLineFailsStream(t *testing.T) {
+func TestStreamAdapter_OverlongEventFailsStream(t *testing.T) {
 	tr := &fakeTranslator{}
 	// An upstream that never emits a newline must fail the stream rather than
 	// grow the line buffer without bound.
-	body := &scriptedBody{script: []string{"data: " + strings.Repeat("a", MaxSSELineBytes+1)}}
+	body := &scriptedBody{script: []string{"data: " + strings.Repeat("a", MaxSSEEventBytes+1)}}
 
 	out, err := io.ReadAll(NewStreamAdapter("test", body, tr))
 	if err == nil {

--- a/internal/egress/adapter_test.go
+++ b/internal/egress/adapter_test.go
@@ -268,6 +268,41 @@ func TestStreamAdapter_UpstreamErrorAfterDrain(t *testing.T) {
 	}
 }
 
+// lastReadEOFBody hands back its whole payload and io.EOF from a single Read,
+// the shape io.Reader permits and a transport produces when the final packet
+// closes the connection.
+type lastReadEOFBody struct{ data string }
+
+func (r *lastReadEOFBody) Read(p []byte) (int, error) {
+	n := copy(p, r.data)
+	r.data = r.data[n:]
+	if r.data == "" {
+		return n, io.EOF
+	}
+	return n, nil
+}
+
+func (r *lastReadEOFBody) Close() error { return nil }
+
+// TestStreamAdapter_PoisonedByLastReadSkipsFinish covers the stream that dies in
+// the very read that reports EOF: the EOF flush must not hand a finished-looking
+// terminal to a corrupt stream.
+func TestStreamAdapter_PoisonedByLastReadSkipsFinish(t *testing.T) {
+	tr := &fakeTranslator{failOn: "bad"}
+	body := &lastReadEOFBody{data: "data: pre\n\ndata: bad\n\n"}
+
+	out, err := io.ReadAll(NewStreamAdapter("test", body, tr))
+	if err == nil {
+		t.Fatal("expected the translation failure to surface")
+	}
+	if got := string(out); got != "<pre>" {
+		t.Errorf("output = %q, want only the bytes translated before the failure", got)
+	}
+	if tr.finished != 0 {
+		t.Error("Finish must not be called over a stream poisoned in its last read")
+	}
+}
+
 func TestStreamAdapter_FinishErrorIsLoggedNotFatal(t *testing.T) {
 	tr := &fakeTranslator{finishErr: errors.New("finish blew up")}
 	body := &scriptedBody{script: []string{"data: x\n\n"}}

--- a/internal/egress/egress_test.go
+++ b/internal/egress/egress_test.go
@@ -1,0 +1,256 @@
+package egress
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestAsJSONString(t *testing.T) {
+	cases := []struct {
+		name    string
+		raw     string
+		want    string
+		wantOK  bool
+		comment string
+	}{
+		{name: "absent field", raw: "", want: "", wantOK: false},
+		{name: "string literal", raw: `"hello"`, want: "hello", wantOK: true},
+		{name: "empty string literal", raw: `""`, want: "", wantOK: true},
+		{name: "escapes are decoded", raw: `"a\nb"`, want: "a\nb", wantOK: true},
+		{name: "null decodes to the empty string", raw: `null`, want: "", wantOK: true},
+		{name: "array is not a string", raw: `[{"type":"text"}]`, want: "", wantOK: false},
+		{name: "object is not a string", raw: `{"type":"text"}`, want: "", wantOK: false},
+		{name: "number is not a string", raw: `42`, want: "", wantOK: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := AsJSONString(json.RawMessage(tc.raw))
+			if got != tc.want || ok != tc.wantOK {
+				t.Errorf("AsJSONString(%q) = (%q, %v), want (%q, %v)", tc.raw, got, ok, tc.want, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestDecodeStop(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want []string
+	}{
+		{name: "absent field", raw: "", want: nil},
+		{name: "single string", raw: `"STOP"`, want: []string{"STOP"}},
+		{name: "empty string is not a stop sequence", raw: `""`, want: nil},
+		{name: "array", raw: `["a","b"]`, want: []string{"a", "b"}},
+		{name: "empty array", raw: `[]`, want: []string{}},
+		{name: "wrong type", raw: `{"a":1}`, want: nil},
+		{name: "malformed", raw: `[not json`, want: nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := DecodeStop(json.RawMessage(tc.raw))
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("DecodeStop(%q) = %#v, want %#v", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+// fakeTranslator echoes each payload back in a recognisable frame, so the
+// adapter's own mechanics (line splitting, EOF finish, poisoning) are what the
+// assertions below measure rather than any real dialect's translation.
+type fakeTranslator struct {
+	failOn    string // payload that makes Translate fail
+	finishErr error
+	finished  int
+}
+
+func (f *fakeTranslator) Translate(payload []byte) ([]byte, error) {
+	if f.failOn != "" && string(payload) == f.failOn {
+		return nil, errors.New("bad payload")
+	}
+	return []byte("<" + string(payload) + ">"), nil
+}
+
+func (f *fakeTranslator) Finish() ([]byte, error) {
+	f.finished++
+	if f.finishErr != nil {
+		return nil, f.finishErr
+	}
+	return []byte("[DONE]"), nil
+}
+
+// scriptedBody yields its script one entry per Read call, simulating SSE data
+// arriving in arbitrary splits (including mid-line), then err (default io.EOF).
+type scriptedBody struct {
+	script []string
+	err    error
+	closed bool
+}
+
+func (r *scriptedBody) Read(p []byte) (int, error) {
+	if len(r.script) == 0 {
+		if r.err != nil {
+			return 0, r.err
+		}
+		return 0, io.EOF
+	}
+	n := copy(p, r.script[0])
+	if rest := r.script[0][n:]; rest == "" {
+		r.script = r.script[1:]
+	} else {
+		r.script[0] = rest
+	}
+	return n, nil
+}
+
+func (r *scriptedBody) Close() error {
+	r.closed = true
+	return nil
+}
+
+func TestStreamAdapter_TranslatesLinesAndFinishesOnEOF(t *testing.T) {
+	tr := &fakeTranslator{}
+	// The first event is split mid-line across two reads.
+	body := &scriptedBody{script: []string{"data: on", "e\r\n\ndata: two\n\n"}}
+
+	out, err := io.ReadAll(NewStreamAdapter("test", body, tr))
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if got := string(out); got != "<one><two>[DONE]" {
+		t.Errorf("output = %q, want the two events plus the terminal bytes", got)
+	}
+	if tr.finished != 1 {
+		t.Errorf("Finish called %d times, want 1", tr.finished)
+	}
+}
+
+func TestStreamAdapter_NonDataLinesIgnored(t *testing.T) {
+	tr := &fakeTranslator{}
+	body := &scriptedBody{script: []string{": keepalive\nevent: message_start\ndata:\ndata: real\n\n"}}
+
+	out, err := io.ReadAll(NewStreamAdapter("test", body, tr))
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if got := string(out); got != "<real>[DONE]" {
+		t.Errorf("output = %q, want only the data payload translated", got)
+	}
+}
+
+func TestStreamAdapter_FlushesPartialLineAtEOF(t *testing.T) {
+	tr := &fakeTranslator{}
+	// No trailing newline: without the EOF flush the last event is lost while
+	// Finish() still emits a clean terminal — a silent truncation.
+	body := &scriptedBody{script: []string{"data: first\n\ndata: last"}}
+
+	out, err := io.ReadAll(NewStreamAdapter("test", body, tr))
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if got := string(out); got != "<first><last>[DONE]" {
+		t.Errorf("output = %q, want the residual line flushed before Finish", got)
+	}
+}
+
+func TestStreamAdapter_WrappedEOFStillFinishes(t *testing.T) {
+	tr := &fakeTranslator{}
+	// io.ReadAll compares the terminating error against io.EOF with ==, so a
+	// wrapped EOF must be normalised or the stream reads as broken.
+	body := &scriptedBody{script: []string{"data: x\n\n"}, err: fmt.Errorf("transport: %w", io.EOF)}
+
+	out, err := io.ReadAll(NewStreamAdapter("test", body, tr))
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if got := string(out); got != "<x>[DONE]" {
+		t.Errorf("output = %q, want a wrapped EOF to end the stream cleanly", got)
+	}
+}
+
+func TestStreamAdapter_TranslateFailurePoisonsStream(t *testing.T) {
+	tr := &fakeTranslator{failOn: "bad"}
+	body := &scriptedBody{script: []string{"data: pre\n\ndata: bad\n\ndata: post\n\n"}}
+
+	out, err := io.ReadAll(NewStreamAdapter("test", body, tr))
+	if err == nil {
+		t.Fatal("expected the translation failure to surface")
+	}
+	if got := string(out); got != "<pre>" {
+		t.Errorf("output = %q, want only the bytes translated before the failure", got)
+	}
+	if tr.finished != 0 {
+		t.Error("Finish must not be called over a corrupt upstream")
+	}
+}
+
+func TestStreamAdapter_UpstreamErrorAfterDrain(t *testing.T) {
+	boom := errors.New("boom")
+	tr := &fakeTranslator{}
+	body := &scriptedBody{script: []string{"data: x\n\n"}, err: boom}
+
+	out, err := io.ReadAll(NewStreamAdapter("test", body, tr))
+	if !errors.Is(err, boom) {
+		t.Fatalf("err = %v, want boom", err)
+	}
+	if got := string(out); got != "<x>" {
+		t.Errorf("output = %q, want the drained bytes without a fabricated terminal", got)
+	}
+	if tr.finished != 0 {
+		t.Error("Finish must not be called on a non-EOF upstream error")
+	}
+}
+
+func TestStreamAdapter_FinishErrorIsLoggedNotFatal(t *testing.T) {
+	tr := &fakeTranslator{finishErr: errors.New("finish blew up")}
+	body := &scriptedBody{script: []string{"data: x\n\n"}}
+
+	out, err := io.ReadAll(NewStreamAdapter("test", body, tr))
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if got := string(out); got != "<x>" {
+		t.Errorf("output = %q, want the translated bytes with no terminal appended", got)
+	}
+}
+
+func TestStreamAdapter_OverlongLineFailsStream(t *testing.T) {
+	tr := &fakeTranslator{}
+	// An upstream that never emits a newline must fail the stream rather than
+	// grow the line buffer without bound.
+	body := &scriptedBody{script: []string{"data: " + strings.Repeat("a", MaxSSELineBytes+1)}}
+
+	out, err := io.ReadAll(NewStreamAdapter("test", body, tr))
+	if err == nil {
+		t.Fatal("expected an error once the line exceeded the cap")
+	}
+	if !strings.Contains(err.Error(), "exceeds") {
+		t.Errorf("error = %q, want it to name the exceeded cap", err)
+	}
+	if !strings.HasPrefix(err.Error(), "test: ") {
+		t.Errorf("error = %q, want the component prefix", err)
+	}
+	if strings.Contains(err.Error(), "aaaa") {
+		t.Errorf("error leaked the buffered line: %q", err)
+	}
+	if strings.Contains(string(out), "[DONE]") {
+		t.Errorf("terminal bytes fabricated over an unterminated line: %q", out)
+	}
+}
+
+func TestStreamAdapter_ClosePropagates(t *testing.T) {
+	body := &scriptedBody{}
+	a := NewStreamAdapter("test", body, &fakeTranslator{})
+	if err := a.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if !body.closed {
+		t.Error("Close must reach the wrapped upstream body")
+	}
+}

--- a/internal/egress/json.go
+++ b/internal/egress/json.go
@@ -1,0 +1,47 @@
+// Package egress holds the pieces the vendor dialect translators share.
+//
+// Each translator (anthropic, anthropicegress, gemini, openairesponses) maps an
+// OpenAI-shaped request onto one vendor's wire format and the reply back again.
+// They are deliberately independent of each other, but the mechanical parts —
+// reading OpenAI's string-or-array union fields, and re-framing an upstream SSE
+// body as chat.completion.chunk bytes — are the same work in every one of them,
+// so they live here once.
+package egress
+
+import "encoding/json"
+
+// AsJSONString returns the value when raw is a JSON string literal, and
+// ok=false for arrays, objects and an absent field. JSON null decodes into a
+// string without error, so it yields ("", true) — which every caller wants,
+// since a null content field carries nothing either way. Used to tell
+// plain-string message content from a content-part array.
+func AsJSONString(raw json.RawMessage) (string, bool) {
+	if len(raw) == 0 {
+		return "", false
+	}
+	var s string
+	if json.Unmarshal(raw, &s) == nil {
+		return s, true
+	}
+	return "", false
+}
+
+// DecodeStop accepts OpenAI's string-or-array stop field. An empty string is
+// not a stop sequence, so it decodes to nil rather than to a one-element list
+// that would truncate the completion immediately.
+func DecodeStop(raw json.RawMessage) []string {
+	if len(raw) == 0 {
+		return nil
+	}
+	if s, ok := AsJSONString(raw); ok {
+		if s == "" {
+			return nil
+		}
+		return []string{s}
+	}
+	var list []string
+	if json.Unmarshal(raw, &list) == nil {
+		return list
+	}
+	return nil
+}

--- a/internal/egress/json_test.go
+++ b/internal/egress/json_test.go
@@ -1,0 +1,58 @@
+package egress
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestAsJSONString(t *testing.T) {
+	cases := []struct {
+		name    string
+		raw     string
+		want    string
+		wantOK  bool
+		comment string
+	}{
+		{name: "absent field", raw: "", want: "", wantOK: false},
+		{name: "string literal", raw: `"hello"`, want: "hello", wantOK: true},
+		{name: "empty string literal", raw: `""`, want: "", wantOK: true},
+		{name: "escapes are decoded", raw: `"a\nb"`, want: "a\nb", wantOK: true},
+		{name: "null decodes to the empty string", raw: `null`, want: "", wantOK: true},
+		{name: "array is not a string", raw: `[{"type":"text"}]`, want: "", wantOK: false},
+		{name: "object is not a string", raw: `{"type":"text"}`, want: "", wantOK: false},
+		{name: "number is not a string", raw: `42`, want: "", wantOK: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := AsJSONString(json.RawMessage(tc.raw))
+			if got != tc.want || ok != tc.wantOK {
+				t.Errorf("AsJSONString(%q) = (%q, %v), want (%q, %v)", tc.raw, got, ok, tc.want, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestDecodeStop(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want []string
+	}{
+		{name: "absent field", raw: "", want: nil},
+		{name: "single string", raw: `"STOP"`, want: []string{"STOP"}},
+		{name: "empty string is not a stop sequence", raw: `""`, want: nil},
+		{name: "array", raw: `["a","b"]`, want: []string{"a", "b"}},
+		{name: "empty array", raw: `[]`, want: []string{}},
+		{name: "wrong type", raw: `{"a":1}`, want: nil},
+		{name: "malformed", raw: `[not json`, want: nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := DecodeStop(json.RawMessage(tc.raw))
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("DecodeStop(%q) = %#v, want %#v", tc.raw, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/frontdesk/httputil.go
+++ b/internal/frontdesk/httputil.go
@@ -10,25 +10,26 @@ import (
 	"time"
 
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
+	"github.com/hugalafutro/model-hotel/internal/httpx"
 )
 
+// logComponent is the log prefix the shared response helpers write under.
+const logComponent = "frontdesk"
+
+// writeJSON encodes v as JSON with an explicit status code.
 func writeJSON(w http.ResponseWriter, status int, v any) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	if err := json.NewEncoder(w).Encode(v); err != nil {
-		debuglog.Error("frontdesk: encode response", "error", err)
-	}
+	httpx.WriteJSONStatus(w, logComponent, status, v)
 }
 
-// writeError maps store errors to HTTP status codes.
 // writeCodedError writes a JSON error body carrying a stable machine-readable
 // code alongside the human message, so the frontend can route on the code rather
 // than matching translatable English text. Plain-text writeError is kept for the
 // many endpoints that need no client-side discrimination.
 func writeCodedError(w http.ResponseWriter, status int, code, msg string) {
-	writeJSON(w, status, map[string]string{"code": code, "error": msg})
+	httpx.WriteCodedError(w, logComponent, status, code, msg)
 }
 
+// writeError maps store errors to HTTP status codes.
 func writeError(w http.ResponseWriter, err error) {
 	switch {
 	case errors.Is(err, ErrNotFound):

--- a/internal/gemini/adapter.go
+++ b/internal/gemini/adapter.go
@@ -1,116 +1,28 @@
 package gemini
 
 import (
-	"bytes"
 	"io"
 	"strings"
 	"time"
 
 	"github.com/google/uuid"
 
-	"github.com/hugalafutro/model-hotel/internal/debuglog"
+	"github.com/hugalafutro/model-hotel/internal/egress"
 )
 
-// StreamAdapter wraps an upstream Gemini streamGenerateContent alt=sse body as
-// an io.ReadCloser that yields chat.completion.chunk SSE bytes. Wrapping the
-// UPSTREAM body (not the client writer) lets the whole existing streaming
-// pipeline — TTFT probe, stall watchdog, transforms, metering — run unchanged
-// on what it already understands (same trick as openairesponses.StreamAdapter).
+// StreamAdapter re-frames an upstream Gemini streamGenerateContent alt=sse body
+// as chat.completion.chunk SSE bytes. The mechanics (line splitting, EOF
+// finish, poisoning on a bad chunk) are shared with the other dialects; see
+// egress.StreamAdapter.
 //
 // Vertex streams carry no [DONE] sentinel: EOF is the natural end, so the
-// adapter emits the translator's terminal chunk + [DONE] when upstream EOF
-// arrives. Any other upstream error surfaces as a stream without [DONE], which
-// the pipeline already classifies as a truncation.
-type StreamAdapter struct {
-	upstream io.ReadCloser
-	tr       *StreamTranslator
-
-	lineBuf  []byte // partial SSE line carried across reads
-	pending  []byte // translated bytes not yet handed to the caller
-	readBuf  []byte
-	srcErr   error
-	transErr error // first translation failure; poisons the stream
-}
+// terminal chunk + [DONE] come from the translator's Finish() when upstream EOF
+// arrives.
+type StreamAdapter = egress.StreamAdapter
 
 // NewStreamAdapter builds an adapter for one streaming response. model is
 // echoed in every emitted chunk (the model string the client requested).
 func NewStreamAdapter(upstream io.ReadCloser, model string) *StreamAdapter {
 	id := "chatcmpl-" + strings.ReplaceAll(uuid.NewString(), "-", "")
-	return &StreamAdapter{
-		upstream: upstream,
-		tr:       NewStreamTranslator(id, model, time.Now().Unix()),
-		readBuf:  make([]byte, 32*1024),
-	}
-}
-
-// Read refills the pending buffer from upstream (translating as it goes) and
-// copies out. On EOF the terminal Finish() bytes are appended before the EOF
-// is surfaced; other upstream errors surface only after all translated bytes
-// have been drained. A translation failure poisons the stream: already
-// translated bytes drain, then the error surfaces — Finish() is never
-// fabricated over a corrupt upstream, so the proxy sees a failed stream
-// instead of a clean empty/partial success.
-func (a *StreamAdapter) Read(p []byte) (int, error) {
-	for len(a.pending) == 0 {
-		if a.transErr != nil {
-			return 0, a.transErr
-		}
-		if a.srcErr != nil {
-			return 0, a.srcErr
-		}
-		n, err := a.upstream.Read(a.readBuf)
-		if n > 0 {
-			a.consume(a.readBuf[:n])
-		}
-		if err != nil {
-			a.srcErr = err
-			if err == io.EOF && a.transErr == nil {
-				fin, finErr := a.tr.Finish()
-				if finErr != nil {
-					debuglog.Warn("gemini: stream finish failed", "error", finErr)
-				}
-				a.pending = append(a.pending, fin...)
-			}
-		}
-	}
-	n := copy(p, a.pending)
-	a.pending = a.pending[n:]
-	return n, nil
-}
-
-// consume splits incoming bytes into SSE lines and feeds each data payload to
-// the translator. "event:"/comment/blank lines are dropped; the adapter
-// generates its own framing.
-func (a *StreamAdapter) consume(p []byte) {
-	a.lineBuf = append(a.lineBuf, p...)
-	for {
-		idx := bytes.IndexByte(a.lineBuf, '\n')
-		if idx < 0 {
-			return
-		}
-		line := bytes.TrimRight(a.lineBuf[:idx], "\r")
-		a.lineBuf = a.lineBuf[idx+1:]
-		if !bytes.HasPrefix(line, []byte("data:")) {
-			continue
-		}
-		payload := bytes.TrimSpace(line[len("data:"):])
-		if len(payload) == 0 {
-			continue
-		}
-		out, err := a.tr.Translate(payload)
-		if err != nil {
-			// A malformed data line means a corrupt upstream; record it and
-			// stop translating so Read surfaces the failure.
-			debuglog.Warn("gemini: stream chunk translate failed", "error", err)
-			a.transErr = err
-			return
-		}
-		a.pending = append(a.pending, out...)
-	}
-}
-
-// Close closes the upstream body. The stall watchdog calls this to unblock a
-// hung read, so it must propagate to the wrapped connection.
-func (a *StreamAdapter) Close() error {
-	return a.upstream.Close()
+	return egress.NewStreamAdapter("gemini", upstream, NewStreamTranslator(id, model, time.Now().Unix()))
 }

--- a/internal/gemini/adapter.go
+++ b/internal/gemini/adapter.go
@@ -18,6 +18,9 @@ import (
 // Vertex streams carry no [DONE] sentinel: EOF is the natural end, so the
 // terminal chunk + [DONE] come from the translator's Finish() when upstream EOF
 // arrives.
+// This is an alias, not a defined type: gemini.StreamAdapter and
+// anthropicegress.StreamAdapter are the same type, so a type switch cannot tell
+// them apart.
 type StreamAdapter = egress.StreamAdapter
 
 // NewStreamAdapter builds an adapter for one streaming response. model is

--- a/internal/gemini/adapter.go
+++ b/internal/gemini/adapter.go
@@ -11,16 +11,18 @@ import (
 )
 
 // StreamAdapter re-frames an upstream Gemini streamGenerateContent alt=sse body
-// as chat.completion.chunk SSE bytes. The mechanics (line splitting, EOF
+// as chat.completion.chunk SSE bytes. The mechanics (event assembly, EOF
 // finish, poisoning on a bad chunk) are shared with the other dialects; see
 // egress.StreamAdapter.
 //
 // Vertex streams carry no [DONE] sentinel: EOF is the natural end, so the
 // terminal chunk + [DONE] come from the translator's Finish() when upstream EOF
 // arrives.
-// This is an alias, not a defined type: gemini.StreamAdapter and
-// anthropicegress.StreamAdapter are the same type, so a type switch cannot tell
-// them apart.
+//
+// StreamAdapter is the shared egress adapter driving this dialect's
+// StreamTranslator. It is an alias, not a defined type: gemini,
+// anthropicegress and openairesponses all alias it, so a type switch cannot
+// tell them apart.
 type StreamAdapter = egress.StreamAdapter
 
 // NewStreamAdapter builds an adapter for one streaming response. model is

--- a/internal/gemini/adapter_test.go
+++ b/internal/gemini/adapter_test.go
@@ -86,6 +86,37 @@ func TestStreamAdapter_NonDataLinesIgnored(t *testing.T) {
 	}
 }
 
+// TestStreamAdapter_FoldedChunkTranslatesCleanly builds a Vertex body whose
+// first chunk folds its JSON across two "data:" fields, which SSE allows. The
+// payload is their newline-join, so the chunk must translate as one event
+// rather than as two fragments that would poison the stream.
+func TestStreamAdapter_FoldedChunkTranslatesCleanly(t *testing.T) {
+	upstream := &slowReader{script: []string{
+		"data: {\"candidates\":[{\"content\":{\"role\":\"model\",\r\n" +
+			"data: \"parts\":[{\"text\":\"Hello\"}]}}]}\r\n\n",
+		"data: {\"candidates\":[{\"content\":{\"role\":\"model\",\"parts\":[{\"text\":\"!\"}]},\"finishReason\":\"STOP\"}]," +
+			"\"usageMetadata\":{\"promptTokenCount\":1,\"candidatesTokenCount\":2,\"totalTokenCount\":3}}\n\n",
+	}}
+
+	out, err := io.ReadAll(NewStreamAdapter(upstream, "gemini-2.5-flash"))
+	if err != nil {
+		t.Fatalf("a folded chunk failed the stream: %v", err)
+	}
+	s := string(out)
+	if !strings.Contains(s, `"content":"Hello"`) {
+		t.Errorf("folded chunk lost its text:\n%s", s)
+	}
+	if !strings.Contains(s, `"content":"!"`) {
+		t.Errorf("following chunk lost:\n%s", s)
+	}
+	if !strings.Contains(s, `"finish_reason":"stop"`) || !strings.Contains(s, `"total_tokens":3`) {
+		t.Errorf("terminal chunk or usage missing:\n%s", s)
+	}
+	if !strings.HasSuffix(s, "data: [DONE]\n\n") {
+		t.Errorf("stream must end with [DONE], got tail %q", s[max(0, len(s)-40):])
+	}
+}
+
 func TestStreamAdapter_MalformedChunkPoisonsStream(t *testing.T) {
 	// A malformed data line means a corrupt upstream. Already-translated bytes
 	// drain, then the stream errors — and EOF must NOT fabricate a clean

--- a/internal/gemini/adapter_test.go
+++ b/internal/gemini/adapter_test.go
@@ -108,6 +108,30 @@ func TestStreamAdapter_MalformedChunkPoisonsStream(t *testing.T) {
 	}
 }
 
+// TestStreamAdapter_TruncatedFinalLineFailsStream pins the direction of the
+// EOF partial-line flush that matters most: a connection cut mid-chunk leaves a
+// truncated JSON fragment with no newline. It is flushed through the translator
+// at EOF, which rejects it, so the stream ends as an error with no [DONE] and
+// the proxy classifies it as the truncation it is instead of recording a short
+// but clean success.
+func TestStreamAdapter_TruncatedFinalLineFailsStream(t *testing.T) {
+	upstream := &slowReader{script: []string{
+		"data: {\"candidates\":[{\"content\":{\"role\":\"model\",\"parts\":[{\"text\":\"ok\"}]}}]}\n\n",
+		"data: {\"candidates\":[{\"content\":{\"role\":\"mo",
+	}}
+	out, err := io.ReadAll(NewStreamAdapter(upstream, "m"))
+	if err == nil {
+		t.Fatal("expected a truncated final chunk to fail the stream")
+	}
+	s := string(out)
+	if !strings.Contains(s, `"content":"ok"`) {
+		t.Errorf("content translated before the cut was lost:\n%s", s)
+	}
+	if strings.Contains(s, "[DONE]") || strings.Contains(s, `"finish_reason":"`) {
+		t.Errorf("terminal chunks fabricated over a truncated tail:\n%s", s)
+	}
+}
+
 func TestStreamAdapter_UpstreamErrorAfterDrain(t *testing.T) {
 	boom := errors.New("boom")
 	a := NewStreamAdapter(&errReader{data: "data: {\"candidates\":[{\"content\":{\"role\":\"model\",\"parts\":[{\"text\":\"x\"}]}}]}\n\n", err: boom}, "m")

--- a/internal/gemini/request.go
+++ b/internal/gemini/request.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hugalafutro/model-hotel/internal/egress"
 	"github.com/hugalafutro/model-hotel/internal/jsonfault"
 )
 
@@ -290,7 +291,7 @@ func buildGenerationConfig(req *oaiRequest) *genConfig {
 		FrequencyPenalty: req.FrequencyPenalty,
 		PresencePenalty:  req.PresencePenalty,
 		Seed:             req.Seed,
-		StopSequences:    decodeStop(req.Stop),
+		StopSequences:    egress.DecodeStop(req.Stop),
 	}
 	// max_completion_tokens is the modern OpenAI field and wins over the
 	// deprecated max_tokens when both are present.
@@ -401,25 +402,6 @@ func toolResponseValue(raw json.RawMessage) any {
 		return obj
 	}
 	return map[string]any{"result": text}
-}
-
-// decodeStop accepts OpenAI's string-or-array stop field.
-func decodeStop(raw json.RawMessage) []string {
-	if len(raw) == 0 {
-		return nil
-	}
-	var s string
-	if json.Unmarshal(raw, &s) == nil {
-		if s == "" {
-			return nil
-		}
-		return []string{s}
-	}
-	var list []string
-	if json.Unmarshal(raw, &list) == nil {
-		return list
-	}
-	return nil
 }
 
 // translateToolChoice maps the OpenAI tool_choice union onto Gemini's

--- a/internal/httpx/httpx.go
+++ b/internal/httpx/httpx.go
@@ -1,0 +1,171 @@
+// Package httpx holds the HTTP response helpers shared by the admin surfaces
+// (internal/api, internal/adminauth, internal/frontdesk). Each of those
+// packages previously carried its own copy of these bodies; the copies existed
+// only to avoid an import dependency between the packages, so a neutral
+// leaf package removes the reason for them.
+//
+// Every helper that logs takes a component prefix ("api", "adminauth",
+// "frontdesk") so the log lines keep naming the surface that produced them.
+package httpx
+
+import (
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http"
+	"strings"
+	"syscall"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+
+	"github.com/hugalafutro/model-hotel/internal/debuglog"
+)
+
+// RespondError logs the error details server-side and sends an HTTP error
+// response. Internal error details are logged but never sent to the client.
+// For 5xx errors without an error value, the message is still logged for
+// debugging.
+func RespondError(w http.ResponseWriter, component, message string, err error, code int) {
+	if err != nil {
+		debuglog.Error(component+": "+message, "error", err)
+	} else if code >= 500 {
+		debuglog.Error(component + ": " + message)
+	}
+	http.Error(w, message, code)
+}
+
+// RespondLookupError maps a repository lookup error to an HTTP response: a
+// genuine miss (err matching the notFound sentinel) becomes a 404 with
+// notFoundMsg; any other error becomes a logged 500 with loadMsg. This keeps a
+// database outage from being silently reported to the client as "not found".
+func RespondLookupError(w http.ResponseWriter, component string, err, notFound error, notFoundMsg, loadMsg string) {
+	if errors.Is(err, notFound) {
+		http.Error(w, notFoundMsg, http.StatusNotFound)
+		return
+	}
+	RespondError(w, component, loadMsg, err, http.StatusInternalServerError)
+}
+
+// RespondBadRequest sends a 400 response with a sanitized message.
+// If err is non-nil, the error details are logged server-side only.
+func RespondBadRequest(w http.ResponseWriter, component, message string, err error) {
+	if err != nil {
+		debuglog.Info(component+": bad request: "+message, "error", err)
+	}
+	http.Error(w, message, http.StatusBadRequest)
+}
+
+// ParseUUIDParam extracts and validates a UUID from the chi URL params.
+// The optional label parameter customizes the error message (defaults to key).
+func ParseUUIDParam(w http.ResponseWriter, r *http.Request, key string, label ...string) (uuid.UUID, bool) {
+	idStr := chi.URLParam(r, key)
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		name := key
+		if len(label) > 0 {
+			name = label[0]
+		}
+		http.Error(w, "invalid "+name, http.StatusBadRequest)
+		return uuid.Nil, false
+	}
+	return id, true
+}
+
+// WriteJSON sets the Content-Type header and encodes the response as JSON.
+func WriteJSON(w http.ResponseWriter, component string, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		LogEncodeError(component, err)
+	}
+}
+
+// WriteJSONStatus sets the Content-Type header, writes an explicit status code,
+// and encodes the response as JSON.
+func WriteJSONStatus(w http.ResponseWriter, component string, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		LogEncodeError(component, err)
+	}
+}
+
+// WriteCodedError writes a JSON {code, error} body so the dashboard can route
+// on a stable code instead of matching English text.
+func WriteCodedError(w http.ResponseWriter, component string, status int, code, msg string) {
+	WriteJSONStatus(w, component, status, map[string]string{"code": code, "error": msg})
+}
+
+// LogEncodeError logs a failure to encode a JSON response. A client that hangs
+// up before the body is written (broken pipe, connection reset, closed conn)
+// and a handler whose deadline fired mid-response (http.ErrHandlerTimeout) are
+// not server faults, so they are logged at debug level to keep production logs
+// clean; any other failure (e.g. an unmarshalable value) stays at error level
+// so genuine bugs remain visible even with debug disabled.
+func LogEncodeError(component string, err error) {
+	switch {
+	case IsClientDisconnect(err):
+		debuglog.Debug(component+": client disconnected before JSON response completed", "error", err)
+	case errors.Is(err, http.ErrHandlerTimeout):
+		debuglog.Debug(component+": handler timed out before JSON response completed", "error", err)
+	default:
+		debuglog.Error(component+": failed to encode JSON response", "error", err)
+	}
+}
+
+// IsClientDisconnect reports whether err indicates the client closed the
+// connection before the response could be fully written. These are the
+// OS-level write errors that unambiguously signal a dead client TCP connection;
+// context cancellation is deliberately excluded because it crosses a different
+// boundary (a server-side cancel must not be silently downgraded), and the
+// response-encode path produces these write errors, not context.Canceled.
+func IsClientDisconnect(err error) bool {
+	return errors.Is(err, syscall.EPIPE) ||
+		errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, net.ErrClosed)
+}
+
+// ReadOnlyGuard rejects state-changing requests when the instance runs in
+// read-only mode (DEMO_READONLY=true). Safe methods (GET/HEAD/OPTIONS) pass
+// through so the dashboard stays fully browsable; every mutating method —
+// create, update, delete — gets a 403.
+//
+// It is mounted only on the admin CRUD routers, so the admin chat (/api/chat)
+// and the public proxy (/v1) are deliberately unaffected: a demo visitor can
+// still chat against the seeded providers and use a seeded virtual key, they
+// just cannot add, edit, or delete anything.
+//
+// One exception: acknowledging background-discovery notifications. That POST
+// only flips a per-row "seen" flag on the discovery_changes table — it does not
+// touch the model catalog — so it is allowed even in read-only mode. Without
+// this, a demo instance can show the Models nav badge but never clear it, and it
+// reappears on every poll/reload.
+func ReadOnlyGuard(component string, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet, http.MethodHead, http.MethodOptions:
+			next.ServeHTTP(w, r)
+		case http.MethodPost:
+			if IsReadOnlyExemptPost(r.URL.Path) {
+				next.ServeHTTP(w, r)
+				return
+			}
+			fallthrough
+		default:
+			// nil err + a 4xx code: RespondError does not log this (it is a
+			// client-facing policy rejection, not a server fault).
+			RespondError(w, component, "this is a read-only demo: creating, editing, and deleting are disabled", nil, http.StatusForbidden)
+		}
+	})
+}
+
+// IsReadOnlyExemptPost reports whether a POST path stays allowed in read-only
+// mode. These mutate no catalog or credential data. Matched by suffix so they
+// are independent of the router's mount prefix:
+//   - discovery-change acknowledgement (flips a per-row "seen" flag), and
+//   - WebAuthn logout (revokes the current session only; it is not admin
+//     credential management like registering or deleting a passkey).
+func IsReadOnlyExemptPost(path string) bool {
+	return strings.HasSuffix(path, "/discovery/changes/ack") ||
+		strings.HasSuffix(path, "/webauthn/logout")
+}

--- a/internal/httpx/httpx.go
+++ b/internal/httpx/httpx.go
@@ -72,20 +72,54 @@ func ParseUUIDParam(w http.ResponseWriter, r *http.Request, key string, label ..
 	return id, true
 }
 
-// WriteJSON sets the Content-Type header and encodes the response as JSON.
+// marshalBody renders v as a response body. Marshalling separately from writing
+// is what lets the writers below tell the two failure modes apart: a marshal
+// failure (an unmarshalable value — NaN/Inf, a chan or func field, a cycle) has
+// put nothing on the wire, so a real status is still deliverable, whereas a
+// write failure has already committed the response. The trailing newline
+// matches what json.Encoder.Encode emits, which callers and tests rely on.
+func marshalBody(v any) ([]byte, error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return append(b, '\n'), nil
+}
+
+// WriteJSON sets the Content-Type header and writes v as a JSON body with an
+// implicit 200. A value that cannot be marshalled is a server fault caught
+// before any byte is written, so it becomes a logged 500; a write that fails
+// mid-body is only logged, since the response is already committed and a second
+// WriteHeader could never reach the client.
 func WriteJSON(w http.ResponseWriter, component string, v any) {
+	b, err := marshalBody(v)
+	if err != nil {
+		RespondError(w, component, "failed to encode response", err, http.StatusInternalServerError)
+		return
+	}
 	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(v); err != nil {
+	if _, err := w.Write(b); err != nil {
 		LogEncodeError(component, err)
 	}
 }
 
 // WriteJSONStatus sets the Content-Type header, writes an explicit status code,
-// and encodes the response as JSON.
+// and writes v as the JSON body. Unlike WriteJSON it keeps the caller's status
+// when the value cannot be marshalled: that status is usually the whole message
+// (a 409 the dashboard routes on, a 422 the config-sync import checks), so
+// replacing it with a 500 would lose more than the body already lost. Either
+// failure is logged.
 func WriteJSONStatus(w http.ResponseWriter, component string, status int, v any) {
+	b, err := marshalBody(v)
+	if err != nil {
+		LogEncodeError(component, err)
+	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	if err := json.NewEncoder(w).Encode(v); err != nil {
+	if b == nil {
+		return
+	}
+	if _, err := w.Write(b); err != nil {
 		LogEncodeError(component, err)
 	}
 }

--- a/internal/httpx/httpx_test.go
+++ b/internal/httpx/httpx_test.go
@@ -243,10 +243,60 @@ func TestWriteJSON(t *testing.T) {
 	}
 }
 
-func TestWriteJSON_EncodeFailureIsLogged(t *testing.T) {
+// TestWriteJSON_WriteFailureIsLogOnly pins the post-commit half of the split:
+// the value marshalled, so bytes were on their way out and the status line is
+// already gone. A second WriteHeader could never reach the client, so the
+// failure is logged and nothing else.
+func TestWriteJSON_WriteFailureIsLogOnly(t *testing.T) {
 	capt := captureLogs(t)
 	w := newErrWriter(errors.New("boom"))
 	WriteJSON(w, "api", map[string]string{"a": "b"})
+	if capt.msg != "api: failed to encode JSON response" {
+		t.Errorf("log message = %q", capt.msg)
+	}
+	if capt.last != slog.LevelError {
+		t.Errorf("log level = %v, want error", capt.last)
+	}
+	if w.code != 0 {
+		t.Errorf("wrote status %d after the body started; want none", w.code)
+	}
+}
+
+// TestWriteJSON_MarshalFailureIs500 pins the pre-commit half: json.Marshal
+// fails having written nothing, so a real 500 is still deliverable and must be
+// sent rather than letting net/http emit a 200 with an empty body.
+func TestWriteJSON_MarshalFailureIs500(t *testing.T) {
+	capt := captureLogs(t)
+	w := httptest.NewRecorder()
+	WriteJSON(w, "api", map[string]any{"ch": make(chan int)})
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", w.Code)
+	}
+	if got := strings.TrimSpace(w.Body.String()); got != "failed to encode response" {
+		t.Errorf("body = %q, want the sanitized encode-failure message", got)
+	}
+	if capt.msg != "api: failed to encode response" {
+		t.Errorf("log message = %q", capt.msg)
+	}
+	if capt.last != slog.LevelError {
+		t.Errorf("log level = %v, want error", capt.last)
+	}
+}
+
+// TestWriteJSONStatus_MarshalFailureKeepsStatus pins the deliberate difference
+// from WriteJSON: the caller already chose a status that carries the meaning
+// (409 duplicate, 422 schema mismatch), so an unmarshalable body loses the body
+// and nothing more.
+func TestWriteJSONStatus_MarshalFailureKeepsStatus(t *testing.T) {
+	capt := captureLogs(t)
+	w := httptest.NewRecorder()
+	WriteJSONStatus(w, "api", http.StatusConflict, map[string]any{"ch": make(chan int)})
+	if w.Code != http.StatusConflict {
+		t.Errorf("status = %d, want the caller's 409", w.Code)
+	}
+	if w.Body.Len() != 0 {
+		t.Errorf("body = %q, want empty", w.Body.String())
+	}
 	if capt.msg != "api: failed to encode JSON response" {
 		t.Errorf("log message = %q", capt.msg)
 	}

--- a/internal/httpx/httpx_test.go
+++ b/internal/httpx/httpx_test.go
@@ -1,0 +1,436 @@
+package httpx
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+
+	"github.com/hugalafutro/model-hotel/internal/debuglog"
+)
+
+// levelCaptureHandler records the level and message of the last record it handled.
+type levelCaptureHandler struct {
+	last slog.Level
+	msg  string
+}
+
+func (h *levelCaptureHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h *levelCaptureHandler) Handle(_ context.Context, r slog.Record) error {
+	h.last = r.Level
+	h.msg = r.Message
+	return nil
+}
+func (h *levelCaptureHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *levelCaptureHandler) WithGroup(string) slog.Handler      { return h }
+
+// captureLogs swaps the process-wide slog default for a recorder and restores
+// it afterwards so later tests are not swallowed by the capture handler.
+func captureLogs(t *testing.T) *levelCaptureHandler {
+	t.Helper()
+	prev := slog.Default().Handler()
+	t.Cleanup(func() { debuglog.SetHandler(prev) })
+	capt := &levelCaptureHandler{}
+	debuglog.SetHandler(capt)
+	return capt
+}
+
+// errWriter fails every write, so the JSON encoder inside the write helpers
+// reports the failure the logging branches exist for.
+type errWriter struct {
+	hdr http.Header
+	err error
+	// code records the status the helper wrote before the body failed.
+	code int
+}
+
+func newErrWriter(err error) *errWriter {
+	return &errWriter{hdr: http.Header{}, err: err}
+}
+
+func (w *errWriter) Header() http.Header       { return w.hdr }
+func (w *errWriter) Write([]byte) (int, error) { return 0, w.err }
+func (w *errWriter) WriteHeader(code int)      { w.code = code }
+
+func TestRespondError(t *testing.T) {
+	t.Run("logs the error and writes the message", func(t *testing.T) {
+		capt := captureLogs(t)
+		w := httptest.NewRecorder()
+		RespondError(w, "api", "failed to load thing", errors.New("db down"), http.StatusInternalServerError)
+		if w.Code != http.StatusInternalServerError {
+			t.Errorf("status = %d, want 500", w.Code)
+		}
+		if got := strings.TrimSpace(w.Body.String()); got != "failed to load thing" {
+			t.Errorf("body = %q, want the sanitized message", got)
+		}
+		if capt.msg != "api: failed to load thing" {
+			t.Errorf("log message = %q, want the component prefix", capt.msg)
+		}
+		if capt.last != slog.LevelError {
+			t.Errorf("log level = %v, want error", capt.last)
+		}
+	})
+
+	t.Run("5xx without an error value is still logged", func(t *testing.T) {
+		capt := captureLogs(t)
+		w := httptest.NewRecorder()
+		RespondError(w, "adminauth", "upstream unavailable", nil, http.StatusBadGateway)
+		if capt.msg != "adminauth: upstream unavailable" {
+			t.Errorf("log message = %q, want the message logged for a 5xx", capt.msg)
+		}
+		if capt.last != slog.LevelError {
+			t.Errorf("log level = %v, want error", capt.last)
+		}
+	})
+
+	t.Run("4xx without an error value is not logged", func(t *testing.T) {
+		capt := captureLogs(t)
+		capt.msg = "sentinel"
+		w := httptest.NewRecorder()
+		RespondError(w, "api", "nope", nil, http.StatusForbidden)
+		if capt.msg != "sentinel" {
+			t.Errorf("log message = %q, want no log for a client-facing 4xx", capt.msg)
+		}
+		if w.Code != http.StatusForbidden {
+			t.Errorf("status = %d, want 403", w.Code)
+		}
+	})
+}
+
+func TestRespondLookupError(t *testing.T) {
+	notFound := errors.New("no rows")
+
+	t.Run("not-found sentinel returns 404", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		RespondLookupError(w, "api", notFound, notFound, "thing not found", "failed to load thing")
+		if w.Code != http.StatusNotFound {
+			t.Errorf("expected 404, got %d", w.Code)
+		}
+		if got := strings.TrimSpace(w.Body.String()); got != "thing not found" {
+			t.Errorf("body = %q, want the not-found message", got)
+		}
+	})
+
+	t.Run("wrapped not-found sentinel returns 404", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		wrapped := fmt.Errorf("query failed: %w", notFound)
+		RespondLookupError(w, "api", wrapped, notFound, "thing not found", "failed to load thing")
+		if w.Code != http.StatusNotFound {
+			t.Errorf("expected 404 for wrapped sentinel, got %d", w.Code)
+		}
+	})
+
+	t.Run("any other error returns a logged 500", func(t *testing.T) {
+		capt := captureLogs(t)
+		w := httptest.NewRecorder()
+		RespondLookupError(w, "api", errors.New("db connection lost"), notFound, "thing not found", "failed to load thing")
+		if w.Code != http.StatusInternalServerError {
+			t.Errorf("expected 500, got %d", w.Code)
+		}
+		if capt.msg != "api: failed to load thing" {
+			t.Errorf("log message = %q, want the load message", capt.msg)
+		}
+	})
+}
+
+func TestRespondBadRequest(t *testing.T) {
+	t.Run("logs the cause at info", func(t *testing.T) {
+		capt := captureLogs(t)
+		w := httptest.NewRecorder()
+		RespondBadRequest(w, "api", "invalid JSON body", errors.New("unexpected EOF"))
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("status = %d, want 400", w.Code)
+		}
+		if capt.msg != "api: bad request: invalid JSON body" {
+			t.Errorf("log message = %q", capt.msg)
+		}
+		if capt.last != slog.LevelInfo {
+			t.Errorf("log level = %v, want info", capt.last)
+		}
+	})
+
+	t.Run("nil error logs nothing", func(t *testing.T) {
+		capt := captureLogs(t)
+		capt.msg = "sentinel"
+		w := httptest.NewRecorder()
+		RespondBadRequest(w, "api", "missing field", nil)
+		if capt.msg != "sentinel" {
+			t.Errorf("log message = %q, want no log without a cause", capt.msg)
+		}
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("status = %d, want 400", w.Code)
+		}
+	})
+}
+
+func TestParseUUIDParam(t *testing.T) {
+	// serve routes a request through chi so URLParam resolves, returning what
+	// ParseUUIDParam produced plus the recorder.
+	serve := func(pattern, path string, label ...string) (uuid.UUID, bool, *httptest.ResponseRecorder) {
+		var (
+			gotID uuid.UUID
+			gotOK bool
+		)
+		r := chi.NewRouter()
+		r.Get(pattern, func(w http.ResponseWriter, req *http.Request) {
+			gotID, gotOK = ParseUUIDParam(w, req, "id", label...)
+		})
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, http.NoBody))
+		return gotID, gotOK, rec
+	}
+
+	t.Run("valid UUID", func(t *testing.T) {
+		want := uuid.New()
+		id, ok, rec := serve("/things/{id}", "/things/"+want.String())
+		if !ok || id != want {
+			t.Errorf("got (%v, %v), want (%v, true)", id, ok, want)
+		}
+		if rec.Code != http.StatusOK {
+			t.Errorf("status = %d, want 200", rec.Code)
+		}
+	})
+
+	t.Run("invalid UUID uses the key in the message", func(t *testing.T) {
+		id, ok, rec := serve("/things/{id}", "/things/not-a-uuid")
+		if ok || id != uuid.Nil {
+			t.Errorf("got (%v, %v), want (nil, false)", id, ok)
+		}
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("status = %d, want 400", rec.Code)
+		}
+		if got := strings.TrimSpace(rec.Body.String()); got != "invalid id" {
+			t.Errorf("body = %q, want %q", got, "invalid id")
+		}
+	})
+
+	t.Run("invalid UUID uses the label when given", func(t *testing.T) {
+		_, ok, rec := serve("/things/{id}", "/things/nope", "provider id")
+		if ok {
+			t.Error("expected ok=false")
+		}
+		if got := strings.TrimSpace(rec.Body.String()); got != "invalid provider id" {
+			t.Errorf("body = %q, want %q", got, "invalid provider id")
+		}
+	})
+}
+
+func TestWriteJSON(t *testing.T) {
+	w := httptest.NewRecorder()
+	WriteJSON(w, "api", map[string]string{"hello": "world"})
+	if got := w.Header().Get("Content-Type"); got != "application/json" {
+		t.Errorf("Content-Type = %q", got)
+	}
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", w.Code)
+	}
+	var body map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("body is not JSON: %v", err)
+	}
+	if body["hello"] != "world" {
+		t.Errorf("body = %v", body)
+	}
+}
+
+func TestWriteJSON_EncodeFailureIsLogged(t *testing.T) {
+	capt := captureLogs(t)
+	w := newErrWriter(errors.New("boom"))
+	WriteJSON(w, "api", map[string]string{"a": "b"})
+	if capt.msg != "api: failed to encode JSON response" {
+		t.Errorf("log message = %q", capt.msg)
+	}
+	if capt.last != slog.LevelError {
+		t.Errorf("log level = %v, want error", capt.last)
+	}
+}
+
+func TestWriteJSONStatus(t *testing.T) {
+	w := httptest.NewRecorder()
+	WriteJSONStatus(w, "api", http.StatusCreated, map[string]int{"n": 1})
+	if w.Code != http.StatusCreated {
+		t.Errorf("status = %d, want 201", w.Code)
+	}
+	if got := w.Header().Get("Content-Type"); got != "application/json" {
+		t.Errorf("Content-Type = %q", got)
+	}
+	if strings.TrimSpace(w.Body.String()) != `{"n":1}` {
+		t.Errorf("body = %q", w.Body.String())
+	}
+}
+
+func TestWriteJSONStatus_EncodeFailureIsLogged(t *testing.T) {
+	capt := captureLogs(t)
+	w := newErrWriter(syscall.EPIPE)
+	WriteJSONStatus(w, "frontdesk", http.StatusOK, map[string]int{"n": 1})
+	if w.code != http.StatusOK {
+		t.Errorf("WriteHeader got %d, want 200", w.code)
+	}
+	if capt.last != slog.LevelDebug {
+		t.Errorf("log level = %v, want debug for a client disconnect", capt.last)
+	}
+	if capt.msg != "frontdesk: client disconnected before JSON response completed" {
+		t.Errorf("log message = %q", capt.msg)
+	}
+}
+
+func TestWriteCodedError(t *testing.T) {
+	w := httptest.NewRecorder()
+	WriteCodedError(w, "api", http.StatusConflict, "duplicate", "already exists")
+	if w.Code != http.StatusConflict {
+		t.Errorf("status = %d, want 409", w.Code)
+	}
+	if got := w.Header().Get("Content-Type"); got != "application/json" {
+		t.Errorf("Content-Type = %q", got)
+	}
+	var body map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("body is not JSON: %v", err)
+	}
+	if body["code"] != "duplicate" || body["error"] != "already exists" {
+		t.Errorf("body = %v, want {code, error}", body)
+	}
+}
+
+func TestIsClientDisconnect(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"broken pipe", syscall.EPIPE, true},
+		{"connection reset", syscall.ECONNRESET, true},
+		{"closed conn", net.ErrClosed, true},
+		{"context canceled is not a disconnect", context.Canceled, false},
+		{"wrapped broken pipe", fmt.Errorf("write tcp: %w", syscall.EPIPE), true},
+		{"unmarshalable value", errors.New("json: unsupported type: chan int"), false},
+		{"nil", nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsClientDisconnect(tc.err); got != tc.want {
+				t.Errorf("IsClientDisconnect(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLogEncodeError_Level(t *testing.T) {
+	capt := captureLogs(t)
+
+	t.Run("client disconnect logs at debug", func(t *testing.T) {
+		capt.last = slog.LevelError + 1 // sentinel
+		LogEncodeError("api", fmt.Errorf("write tcp 1.2.3.4:8080->5.6.7.8:9: write: %w", syscall.EPIPE))
+		if capt.last != slog.LevelDebug {
+			t.Errorf("expected debug level, got %v", capt.last)
+		}
+	})
+
+	t.Run("handler timeout logs at debug", func(t *testing.T) {
+		capt.last = slog.LevelError + 1 // sentinel
+		LogEncodeError("api", fmt.Errorf("encode: %w", http.ErrHandlerTimeout))
+		if capt.last != slog.LevelDebug {
+			t.Errorf("expected debug level, got %v", capt.last)
+		}
+		if capt.msg != "api: handler timed out before JSON response completed" {
+			t.Errorf("log message = %q", capt.msg)
+		}
+	})
+
+	t.Run("genuine encode error logs at error", func(t *testing.T) {
+		capt.last = slog.LevelDebug - 1 // sentinel
+		LogEncodeError("api", errors.New("json: unsupported type: chan int"))
+		if capt.last != slog.LevelError {
+			t.Errorf("expected error level, got %v", capt.last)
+		}
+	})
+}
+
+// TestReadOnlyGuard verifies the middleware in isolation: safe methods reach the
+// next handler, mutating methods are refused with 403 and never reach it.
+func TestReadOnlyGuard(t *testing.T) {
+	var called bool
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+	guard := ReadOnlyGuard("api", next)
+
+	for _, m := range []string{http.MethodGet, http.MethodHead, http.MethodOptions} {
+		called = false
+		rec := httptest.NewRecorder()
+		guard.ServeHTTP(rec, httptest.NewRequest(m, "/providers", http.NoBody))
+		if !called {
+			t.Errorf("%s: expected next handler to be called", m)
+		}
+		if rec.Code != http.StatusOK {
+			t.Errorf("%s: expected 200, got %d", m, rec.Code)
+		}
+	}
+
+	for _, m := range []string{http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete} {
+		called = false
+		rec := httptest.NewRecorder()
+		guard.ServeHTTP(rec, httptest.NewRequest(m, "/providers", http.NoBody))
+		if called {
+			t.Errorf("%s: next handler must not be called in read-only mode", m)
+		}
+		if rec.Code != http.StatusForbidden {
+			t.Errorf("%s: expected 403, got %d", m, rec.Code)
+		}
+	}
+
+	// The exempt POSTs mutate no catalog or credential data, so they pass
+	// through even in read-only mode.
+	for _, path := range []string{"/api/discovery/changes/ack", "/api/auth/webauthn/logout"} {
+		called = false
+		rec := httptest.NewRecorder()
+		guard.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, path, http.NoBody))
+		if !called {
+			t.Errorf("POST %s: expected exemption to reach next handler", path)
+		}
+		if rec.Code != http.StatusOK {
+			t.Errorf("POST %s: expected 200, got %d", path, rec.Code)
+		}
+	}
+
+	// Dismiss is NOT exempt. It suppresses a real discrepancy from everyone's
+	// view, unlike the ack it sits next to, which only flips a per-row seen
+	// flag. Pattern-matching the neighbouring exemption is the easy way to get
+	// this wrong, so it is asserted explicitly.
+	called = false
+	rec := httptest.NewRecorder()
+	guard.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/api/discovery/dismiss", http.NoBody))
+	if called {
+		t.Error("POST /api/discovery/dismiss: next handler must not be called in read-only mode")
+	}
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("read-only POST /api/discovery/dismiss = %d, want 403", rec.Code)
+	}
+}
+
+func TestIsReadOnlyExemptPost(t *testing.T) {
+	cases := map[string]bool{
+		"/api/discovery/changes/ack":  true,
+		"/discovery/changes/ack":      true,
+		"/api/auth/webauthn/logout":   true,
+		"/api/discovery/dismiss":      false,
+		"/api/providers":              false,
+		"/api/discovery/changes/acks": false,
+	}
+	for path, want := range cases {
+		if got := IsReadOnlyExemptPost(path); got != want {
+			t.Errorf("IsReadOnlyExemptPost(%q) = %v, want %v", path, got, want)
+		}
+	}
+}

--- a/internal/openairesponses/request.go
+++ b/internal/openairesponses/request.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hugalafutro/model-hotel/internal/egress"
 	"github.com/hugalafutro/model-hotel/internal/jsonfault"
 )
 
@@ -193,7 +194,7 @@ func translateChatMessages(msgs []chatReqMessage) (string, []any, error) {
 // Responses re-route only triggers for tools+reasoning requests, which are
 // text/vision workloads.
 func translateUserContent(raw json.RawMessage) ([]contentPart, error) {
-	if s, ok := asJSONString(raw); ok {
+	if s, ok := egress.AsJSONString(raw); ok {
 		return []contentPart{{Type: "input_text", Text: s}}, nil
 	}
 	if len(raw) == 0 || string(raw) == "null" {
@@ -221,7 +222,7 @@ func translateUserContent(raw json.RawMessage) ([]contentPart, error) {
 // string verbatim, or the concatenated text parts of an array. ok is false
 // when the field is absent/null.
 func flattenContent(raw json.RawMessage) (string, bool) {
-	if s, ok := asJSONString(raw); ok {
+	if s, ok := egress.AsJSONString(raw); ok {
 		return s, true
 	}
 	if len(raw) == 0 || string(raw) == "null" {
@@ -240,18 +241,6 @@ func flattenContent(raw json.RawMessage) (string, bool) {
 	return sb.String(), true
 }
 
-// asJSONString returns the value when raw is a JSON string literal.
-func asJSONString(raw json.RawMessage) (string, bool) {
-	if len(raw) == 0 {
-		return "", false
-	}
-	var s string
-	if json.Unmarshal(raw, &s) == nil {
-		return s, true
-	}
-	return "", false
-}
-
 // translateToolChoice maps the chat tool_choice union onto the Responses one:
 // the string modes are shared verbatim; the named-function object flattens
 // from {type:"function",function:{name}} to {type:"function",name}.
@@ -259,7 +248,7 @@ func translateToolChoice(raw json.RawMessage) (any, bool) {
 	if len(raw) == 0 {
 		return nil, false
 	}
-	if s, ok := asJSONString(raw); ok {
+	if s, ok := egress.AsJSONString(raw); ok {
 		switch s {
 		case "auto", "none", "required":
 			return s, true

--- a/internal/openairesponses/stream.go
+++ b/internal/openairesponses/stream.go
@@ -288,9 +288,10 @@ func (t *StreamTranslator) Finish() ([]byte, error) { return nil, nil }
 // (event assembly, EOF flush, framing) are shared with the other dialects; see
 // egress.StreamAdapter.
 //
-// This is an alias, not a defined type: openairesponses.StreamAdapter,
-// gemini.StreamAdapter and anthropicegress.StreamAdapter are the same type, so
-// a type switch cannot tell them apart.
+// StreamAdapter is the shared egress adapter driving this dialect's
+// StreamTranslator. It is an alias, not a defined type: gemini,
+// anthropicegress and openairesponses all alias it, so a type switch cannot
+// tell them apart.
 type StreamAdapter = egress.StreamAdapter
 
 // NewStreamAdapter builds an adapter for one streaming response. model is

--- a/internal/openairesponses/stream.go
+++ b/internal/openairesponses/stream.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
+	"github.com/hugalafutro/model-hotel/internal/egress"
 	"github.com/hugalafutro/model-hotel/internal/jsonfault"
 )
 
@@ -254,85 +255,46 @@ func (t *StreamTranslator) frame(chunk chatChunk) []byte {
 // Finished reports whether the terminal sequence has been emitted.
 func (t *StreamTranslator) Finished() bool { return t.finished }
 
-// StreamAdapter wraps the upstream /v1/responses SSE body as an io.ReadCloser
-// that yields chat.completion.chunk SSE bytes. Wrapping the UPSTREAM body (not
-// the client writer) lets the whole existing streaming pipeline — TTFT probe,
-// stall watchdog, transforms, metering, and any client-side writer such as the
-// Anthropic one — run unchanged on what it already understands.
-//
-// A truncated upstream (EOF before response.completed) surfaces as a stream
-// without [DONE], which the pipeline already classifies as a truncation.
-type StreamAdapter struct {
-	upstream io.ReadCloser
-	tr       *StreamTranslator
-
-	lineBuf []byte // partial SSE line carried across reads
-	pending []byte // translated bytes not yet handed to the caller
-	readBuf []byte
-	srcErr  error
+// Translate satisfies egress.Translator, and carries the two dispatch rules
+// that belong to this dialect rather than to the shared adapter. A "[DONE]"
+// payload is ignored: Responses streams do not use that sentinel, so one
+// arriving is an upstream quirk rather than data. A malformed event is logged
+// and skipped rather than failing the stream, because a Responses stream stays
+// readable across a single bad event.
+func (t *StreamTranslator) Translate(payload []byte) ([]byte, error) {
+	if bytes.Equal(payload, []byte("[DONE]")) {
+		return nil, nil
+	}
+	out, err := t.TranslateEvent(payload)
+	if err != nil {
+		debuglog.Warn("openairesponses: stream event translate failed", "error", err)
+		return nil, nil
+	}
+	return out, nil
 }
+
+// Finish satisfies egress.Translator. It adds nothing: the Responses stream
+// carries its own terminal chunk and [DONE], both emitted by TranslateEvent on
+// response.completed. A truncated upstream (EOF before response.completed)
+// therefore surfaces as a stream without [DONE], which the pipeline already
+// classifies as a truncation.
+func (t *StreamTranslator) Finish() ([]byte, error) { return nil, nil }
+
+// StreamAdapter re-frames the upstream /v1/responses SSE body as
+// chat.completion.chunk SSE bytes. Wrapping the UPSTREAM body (not the client
+// writer) lets the whole existing streaming pipeline — TTFT probe, stall
+// watchdog, transforms, metering, and any client-side writer such as the
+// Anthropic one — run unchanged on what it already understands. The mechanics
+// (event assembly, EOF flush, framing) are shared with the other dialects; see
+// egress.StreamAdapter.
+//
+// This is an alias, not a defined type: openairesponses.StreamAdapter,
+// gemini.StreamAdapter and anthropicegress.StreamAdapter are the same type, so
+// a type switch cannot tell them apart.
+type StreamAdapter = egress.StreamAdapter
 
 // NewStreamAdapter builds an adapter for one streaming response. model is
 // echoed in every emitted chunk.
 func NewStreamAdapter(upstream io.ReadCloser, model string) *StreamAdapter {
-	return &StreamAdapter{
-		upstream: upstream,
-		tr:       NewStreamTranslator(model),
-		readBuf:  make([]byte, 32*1024),
-	}
-}
-
-// Read refills the pending buffer from upstream (translating as it goes) and
-// copies out. Upstream errors are surfaced only after all translated bytes
-// have been drained.
-func (a *StreamAdapter) Read(p []byte) (int, error) {
-	for len(a.pending) == 0 {
-		if a.srcErr != nil {
-			return 0, a.srcErr
-		}
-		n, err := a.upstream.Read(a.readBuf)
-		if n > 0 {
-			a.consume(a.readBuf[:n])
-		}
-		if err != nil {
-			a.srcErr = err
-		}
-	}
-	n := copy(p, a.pending)
-	a.pending = a.pending[n:]
-	return n, nil
-}
-
-// consume splits incoming bytes into SSE lines and feeds each data payload to
-// the translator. "event:"/comment/blank lines are dropped: the payload's own
-// "type" field drives dispatch, and the adapter generates its own framing.
-func (a *StreamAdapter) consume(p []byte) {
-	a.lineBuf = append(a.lineBuf, p...)
-	for {
-		idx := bytes.IndexByte(a.lineBuf, '\n')
-		if idx < 0 {
-			return
-		}
-		line := bytes.TrimRight(a.lineBuf[:idx], "\r")
-		a.lineBuf = a.lineBuf[idx+1:]
-		if !bytes.HasPrefix(line, []byte("data:")) {
-			continue
-		}
-		payload := bytes.TrimSpace(line[len("data:"):])
-		if len(payload) == 0 || bytes.Equal(payload, []byte("[DONE]")) {
-			continue // Responses streams do not use the [DONE] sentinel; ignore defensively
-		}
-		out, err := a.tr.TranslateEvent(payload)
-		if err != nil {
-			debuglog.Warn("openairesponses: stream event translate failed", "error", err)
-			continue
-		}
-		a.pending = append(a.pending, out...)
-	}
-}
-
-// Close closes the upstream body. The stall watchdog calls this to unblock a
-// hung read, so it must propagate to the wrapped connection.
-func (a *StreamAdapter) Close() error {
-	return a.upstream.Close()
+	return egress.NewStreamAdapter("openairesponses", upstream, NewStreamTranslator(model))
 }

--- a/internal/openairesponses/stream_test.go
+++ b/internal/openairesponses/stream_test.go
@@ -272,6 +272,68 @@ func TestStreamAdapter_EndToEnd(t *testing.T) {
 	}
 }
 
+// TestStreamAdapter_FoldedEventTranslatesCleanly folds one output_text.delta
+// across two "data:" fields, which SSE allows: the payload is their
+// newline-join and the blank line ends the event. Dispatching each field on its
+// own hands the translator JSON fragments, and because this dialect logs and
+// skips a malformed event the delta is dropped silently — the stream still ends
+// with [DONE], just short of its content.
+func TestStreamAdapter_FoldedEventTranslatesCleanly(t *testing.T) {
+	sse := "event: response.created\r\n" +
+		"data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\"}}\r\n" +
+		"\r\n" +
+		"event: response.output_text.delta\r\n" +
+		"data: {\"type\":\"response.output_text.delta\",\r\n" +
+		"data: \"delta\":\"Hello\"}\r\n" +
+		"\r\n" +
+		"event: response.completed\r\n" +
+		"data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\",\"usage\":{\"input_tokens\":1,\"output_tokens\":2}}}\r\n" +
+		"\r\n"
+	out, err := io.ReadAll(NewStreamAdapter(io.NopCloser(iotest{r: strings.NewReader(sse)}), "m"))
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	chunks, sawDone := collectChunks(t, out)
+	if !sawDone {
+		t.Fatalf("no [DONE]:\n%s", out)
+	}
+	if len(chunks) != 3 { // content + finish + usage
+		t.Fatalf("got %d chunks, want 3 (the folded delta was dropped):\n%s", len(chunks), out)
+	}
+	if d := delta(t, chunks[0]); d["content"] != "Hello" {
+		t.Errorf("folded delta lost its content: chunk[0] = %v", d)
+	}
+}
+
+// TestStreamAdapter_SkipsDoneAndMalformedEvents pins the two dispatch rules
+// this dialect owns: a "[DONE]" payload is ignored (Responses streams do not
+// use that sentinel), and a malformed event is skipped rather than failing the
+// stream, so the events around it still translate.
+func TestStreamAdapter_SkipsDoneAndMalformedEvents(t *testing.T) {
+	sse := "data: [DONE]\n\n" +
+		"data: {\"type\":\"response.output_text.delta\",\"delta\":\"Hel\"}\n\n" +
+		"data: {not json}\n\n" +
+		"data: {\"type\":\"response.output_text.delta\",\"delta\":\"lo\"}\n\n" +
+		"data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\"}}\n\n"
+	out, err := io.ReadAll(NewStreamAdapter(io.NopCloser(strings.NewReader(sse)), "m"))
+	if err != nil {
+		t.Fatalf("a malformed event failed the stream: %v", err)
+	}
+	chunks, sawDone := collectChunks(t, out)
+	if !sawDone {
+		t.Fatalf("no [DONE]:\n%s", out)
+	}
+	if len(chunks) != 3 { // two content deltas + finish
+		t.Fatalf("got %d chunks, want 3:\n%s", len(chunks), out)
+	}
+	if d := delta(t, chunks[0]); d["content"] != "Hel" {
+		t.Errorf("chunk[0] = %v, want the delta before the malformed event", d)
+	}
+	if d := delta(t, chunks[1]); d["content"] != "lo" {
+		t.Errorf("chunk[1] = %v, want the delta after the malformed event", d)
+	}
+}
+
 // iotest yields one byte per Read to exercise line reassembly.
 type iotest struct{ r io.Reader }
 

--- a/internal/user/user.go
+++ b/internal/user/user.go
@@ -11,8 +11,9 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/hugalafutro/model-hotel/internal/db"
 )
 
 // Role separates full operators from grant-limited users.
@@ -204,7 +205,7 @@ func (r *Repository) ResolveSSOIdentity(ctx context.Context, provider, subject, 
 		if _, err := tx.Exec(ctx,
 			`UPDATE users SET sso_provider = $2, sso_subject = $3 WHERE id = $1`,
 			u.ID, provider, subject); err != nil {
-			if isUniqueViolation(err) {
+			if db.IsUniqueViolation(err) {
 				return nil, false, ErrSSOMismatch
 			}
 			return nil, false, err
@@ -220,15 +221,6 @@ func (r *Repository) ResolveSSOIdentity(ctx context.Context, provider, subject, 
 		return nil, false, err
 	}
 	return u, bound, nil
-}
-
-// isUniqueViolation reports whether err is a PostgreSQL unique-constraint
-// violation (SQLSTATE 23505).
-func isUniqueViolation(err error) bool {
-	if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok {
-		return pgErr.Code == "23505"
-	}
-	return false
 }
 
 // HasEnabled reports whether at least one enabled user exists, so the login


### PR DESCRIPTION
## Summary

First batch of a dedupe sweep: every duplicated Go helper body now exists exactly once.

- **`internal/httpx`** (new): `RespondError`, `RespondBadRequest`, `WriteJSON`, `WriteJSONStatus`, `WriteCodedError`, `LogEncodeError`, `IsClientDisconnect`, `ReadOnlyGuard`, `IsReadOnlyExemptPost`. `internal/api`, `internal/adminauth` (which carried a full copy of api's helpers to avoid an import cycle) and `internal/frontdesk` keep thin wrappers over it.
- **`writeJSON` adopted** at the 23 `internal/api` sites that hand-rolled `Content-Type` + `json.NewEncoder(w).Encode` + error handling (applogs, stats, settings, logs, system, alerts, provider_typegate, configsync, models_cursor).
- **`internal/egress`** (new): `AsJSONString`, `DecodeStop`, and one generic `StreamAdapter` behind a `Translator` interface; the gemini, anthropicegress and openairesponses adapters reduce to constructors. Three identical `asJSONString` and two `decodeStop` copies are gone.
- **SSE events are parsed per event, not per line**: `data:` fields are joined with `\n` and translated once on the blank-line delimiter (or at EOF), so a spec-valid folded event reaches the translator whole. The old per-dialect adapters split such events into JSON fragments (gemini/anthropic failed the stream, openairesponses dropped the event silently); the per-line cap became a 4 MiB event cap (`MaxSSEEventBytes`; the Responses `response.completed` event embeds the whole output, so 1 MiB was too tight for long generations).
- **`db.IsUniqueViolation`** replaces the identical pgconn 23505 check in `api` and `user` (Front Desk's SQLite variant stays).

## Behaviour deltas (intentional)

- `WriteJSON` distinguishes "encode failed before any byte was written" (responds 500, as before) from "encode failed after the body started" (logs; the old code issued a superfluous `WriteHeader(500)` that never reached the client). Tests pin both.
- Three `applogs` JSON error bodies now carry `Content-Type: application/json` (they were sniffed as `text/plain`).
- `http.ErrHandlerTimeout` during encode logs at debug everywhere (configsync used to swallow it, api logged at error).
- The gemini stream adapter takes the newer adapter semantics: a residual partial line at EOF is flushed through the translator (a truncated final line now errors the stream instead of being dropped with a clean `[DONE]`), the unterminated-event cap applies, and EOF is matched with `errors.Is`.
- Log-plane only: per-site encode-failure messages collapse to one per component; frontdesk gains the client-disconnect debug downgrade.

## Verification

- `make test` green (0 skips), `golangci-lint run ./...` clean, changed-line coverage 100%.
- Dev stack rebuilt from this branch: 20/20 admin/proxy endpoint smoke, live streaming completions through Google AI Studio (gemini) and Anthropic return `pong` / `finish_reason: stop` / `[DONE]`.
- Independent Opus review of the branch; all findings addressed before opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
