### PR TITLE
refactor(web): dedupe dashboard helpers into shared hooks and utils

### DIFF
--- a/web/src/components/ArenaHistoryModal.tsx
+++ b/web/src/components/ArenaHistoryModal.tsx
@@ -26,6 +26,7 @@ import {
 	type HistoryMode,
 	type HistoryResponse,
 } from "../utils/arenaHistory";
+import { formatDate, formatTime } from "../utils/format";
 
 interface ArenaHistoryModalProps {
 	onClose: () => void;
@@ -52,21 +53,6 @@ function roundLabel(
 
 function shortModelName(modelId: string): string {
 	return modelId.split("/").pop() ?? modelId;
-}
-
-function formatDate(timestamp: number): string {
-	return new Date(timestamp).toLocaleDateString(undefined, {
-		month: "short",
-		day: "numeric",
-		year: "numeric",
-	});
-}
-
-function formatTime(timestamp: number): string {
-	return new Date(timestamp).toLocaleTimeString(undefined, {
-		hour: "2-digit",
-		minute: "2-digit",
-	});
 }
 
 function findPromptPreset(id: string | null) {

--- a/web/src/components/CollapsibleToggle.tsx
+++ b/web/src/components/CollapsibleToggle.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react-refresh/only-export-components */
 
-import { useCallback, useState } from "react";
+import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import {
 	ChevronDown,
@@ -8,6 +8,7 @@ import {
 	ChevronsUpDown,
 	ChevronUp,
 } from "@/lib/icons";
+import { useLocalStorage } from "../hooks/useLocalStorage";
 
 interface CollapsibleToggleProps {
 	collapsed: boolean;
@@ -79,28 +80,16 @@ export function useCollapsible(
 	collapsed: boolean;
 	toggle: () => void;
 } {
-	const [collapsed, setCollapsed] = useState(() => {
-		if (!storageKey) return defaultValue;
-		try {
-			return localStorage.getItem(storageKey) === "true";
-		} catch {
-			return defaultValue;
-		}
-	});
+	// Stored as "true"/"false"; anything else reads as expanded.
+	const [collapsed, setCollapsed] = useLocalStorage<boolean>(
+		storageKey ?? "",
+		defaultValue,
+		{ enabled: !!storageKey, deserialize: (stored) => stored === "true" },
+	);
 
 	const toggle = useCallback(() => {
-		setCollapsed((prev) => {
-			const next = !prev;
-			if (storageKey) {
-				try {
-					localStorage.setItem(storageKey, String(next));
-				} catch {
-					/* ignore */
-				}
-			}
-			return next;
-		});
-	}, [storageKey]);
+		setCollapsed((prev) => !prev);
+	}, [setCollapsed]);
 
 	return { collapsed, toggle };
 }

--- a/web/src/components/CopyButton.tsx
+++ b/web/src/components/CopyButton.tsx
@@ -1,39 +1,73 @@
 import { useTranslation } from "react-i18next";
 import { Copy } from "@/lib/icons";
 import { type ToastType, useToast } from "../context/ToastContext";
+import { useCopyToClipboard } from "../hooks/useCopyToClipboard";
+
+/**
+ * How the button looks and how it reports the result:
+ * - "icon": a copy glyph, result announced as a toast.
+ * - "label": a Copy/Copied text button that says it by swapping its own label.
+ *   A blocked clipboard is silent there; the copied text stays selectable.
+ */
+type CopyButtonVariant = "icon" | "label";
 
 interface CopyButtonProps {
 	text: string;
 	size?: number;
 	className?: string;
 	title?: string;
-	/** Toast severity shown on a successful copy. Defaults to "info". */
+	/** Toast severity shown on a successful copy. Defaults to "info". Icon variant only. */
 	toastType?: ToastType;
+	variant?: CopyButtonVariant;
+	/** Accessible name; falls back to `title`, then the shared "Copy" label. */
+	ariaLabel?: string;
+	testId?: string;
 }
 
 export function CopyButton({
 	text,
 	size = 10,
-	className = "ui-icon-btn inline-flex items-center",
+	className,
 	title,
 	toastType = "info",
+	variant = "icon",
+	ariaLabel,
+	testId,
 }: CopyButtonProps) {
 	const { t } = useTranslation();
 	const { toast } = useToast();
+	const { copy, copied } = useCopyToClipboard();
+	const isIcon = variant === "icon";
+
+	const handleClick = async () => {
+		const ok = await copy(text);
+		// The label variant reports itself; only the icon needs the toast.
+		if (!isIcon) return;
+		if (ok) toast(t("common.copiedToClipboard"), toastType);
+		else toast(t("common.failedToCopy"), "error");
+	};
+
 	return (
 		<button
 			type="button"
-			className={className}
-			onClick={() => {
-				navigator.clipboard
-					.writeText(text)
-					.then(() => toast(t("common.copiedToClipboard"), toastType))
-					.catch(() => toast(t("common.failedToCopy"), "error"));
-			}}
-			title={title ?? t("common.copy")}
-			aria-label={title ?? t("common.copy")}
+			className={
+				className ??
+				(isIcon
+					? "ui-icon-btn inline-flex items-center"
+					: "ui-btn ui-btn-secondary")
+			}
+			data-testid={testId}
+			onClick={handleClick}
+			title={isIcon ? (title ?? t("common.copy")) : title}
+			aria-label={ariaLabel ?? title ?? t("common.copy")}
 		>
-			<Copy size={size} />
+			{isIcon ? (
+				<Copy size={size} />
+			) : copied ? (
+				t("common.copied")
+			) : (
+				t("common.copy")
+			)}
 		</button>
 	);
 }

--- a/web/src/components/CopyButton.tsx
+++ b/web/src/components/CopyButton.tsx
@@ -36,8 +36,10 @@ export function CopyButton({
 }: CopyButtonProps) {
 	const { t } = useTranslation();
 	const { toast } = useToast();
-	const { copy, copied } = useCopyToClipboard();
 	const isIcon = variant === "icon";
+	// The icon variant reports through a toast and never renders the flag, so it
+	// does not pay for the state update and the reset timer behind it.
+	const { copy, copied } = useCopyToClipboard({ trackCopied: !isIcon });
 
 	const handleClick = async () => {
 		const ok = await copy(text);

--- a/web/src/components/ErrorShelf/ErrorShelf.tsx
+++ b/web/src/components/ErrorShelf/ErrorShelf.tsx
@@ -33,7 +33,7 @@ import {
 export function ErrorShelf() {
 	const { t } = useTranslation();
 	const { toast } = useToast();
-	const { copy } = useCopyToClipboard();
+	const { copy } = useCopyToClipboard({ trackCopied: false });
 	const { unacked, ack, ackAll } = useErrorShelf();
 	const [expanded, setExpanded] = useState(false);
 	// Two-step Clear all: first click arms (shows a confirm hint), second

--- a/web/src/components/ErrorShelf/ErrorShelf.tsx
+++ b/web/src/components/ErrorShelf/ErrorShelf.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/lib/icons";
 import type { AppLogEntry, LogEntry } from "../../api/types";
 import { useToast } from "../../context/ToastContext";
+import { useCopyToClipboard } from "../../hooks/useCopyToClipboard";
 import { formatRelativeTime, formatTimestamp } from "../../utils/format";
 import { displayLogMessage } from "../../utils/logText";
 import { truncateWithEllipsis } from "../../utils/truncate";
@@ -32,6 +33,7 @@ import {
 export function ErrorShelf() {
 	const { t } = useTranslation();
 	const { toast } = useToast();
+	const { copy } = useCopyToClipboard();
 	const { unacked, ack, ackAll } = useErrorShelf();
 	const [expanded, setExpanded] = useState(false);
 	// Two-step Clear all: first click arms (shows a confirm hint), second
@@ -68,17 +70,11 @@ export function ErrorShelf() {
 	}, [clearArmed, ackAll, toast, t]);
 
 	const handleCopy = useCallback(
-		(message: string) => {
-			// Run the write inside a promise chain so a missing Clipboard API
-			// (navigator.clipboard is undefined in non-secure/HTTP contexts)
-			// surfaces as a rejection and hits the failure toast, rather than
-			// throwing synchronously and bypassing it.
-			Promise.resolve()
-				.then(() => navigator.clipboard.writeText(message))
-				.then(() => toast(t("common.copiedToClipboard"), "info"))
-				.catch(() => toast(t("common.failedToCopy"), "error"));
+		async (message: string) => {
+			if (await copy(message)) toast(t("common.copiedToClipboard"), "info");
+			else toast(t("common.failedToCopy"), "error");
 		},
-		[toast, t],
+		[copy, toast, t],
 	);
 
 	const handleViewDetails = useCallback((err: ShelfError) => {

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -52,10 +52,10 @@ import { Logo } from "./Logo";
 import { ModelDiscrepancyModal } from "./ModelDiscrepancyModal";
 import { ProviderQuotaPanel } from "./ProviderQuotaPanel";
 import {
-	formatBytesPerSec,
-	formatDuration,
-	formatMB,
-	formatNumber,
+	formatCount,
+	formatMemoryMB,
+	formatThroughput,
+	formatUptime,
 	unitClass,
 } from "./systemStatusFormat";
 
@@ -145,17 +145,17 @@ function SystemStatus() {
 			: undefined;
 	const appMem = dockerMem ? (
 		<>
-			{formatMB(docker.memory_usage_bytes / 1024 / 1024)} /{" "}
-			{formatMB(docker.memory_limit_bytes / 1024 / 1024)}
+			{formatMemoryMB(docker.memory_usage_bytes / 1024 / 1024)} /{" "}
+			{formatMemoryMB(docker.memory_limit_bytes / 1024 / 1024)}
 		</>
 	) : hasLimit ? (
 		<>
-			{formatMB(app.memory_current_bytes / 1024 / 1024)} /{" "}
-			{formatMB(app.memory_limit_bytes / 1024 / 1024)}
+			{formatMemoryMB(app.memory_current_bytes / 1024 / 1024)} /{" "}
+			{formatMemoryMB(app.memory_limit_bytes / 1024 / 1024)}
 		</>
 	) : app ? (
 		<>
-			{formatMB(app.heap_alloc_mb)}
+			{formatMemoryMB(app.heap_alloc_mb)}
 			<span className={unitClass}> {t("layout.stats.heap")}</span>
 		</>
 	) : (
@@ -210,7 +210,7 @@ function SystemStatus() {
 						>
 							<span>{t("layout.stats.uptime")}</span>
 							<span className="text-(--text-secondary)">
-								{app ? formatDuration(app.uptime_seconds) : dash}
+								{app ? formatUptime(app.uptime_seconds) : dash}
 							</span>
 						</div>
 
@@ -267,14 +267,14 @@ function SystemStatus() {
 							<span className="text-(--text-secondary) tabular-nums">
 								<span className="text-sky-400/60 inline-block min-w-22 text-right">
 									{typeof netRx === "number" ? (
-										<>↓{formatBytesPerSec(netRx)}</>
+										<>↓{formatThroughput(netRx)}</>
 									) : (
 										dash
 									)}
 								</span>
 								<span className="text-amber-400/60 inline-block min-w-22 text-right">
 									{typeof netTx === "number" ? (
-										<>↑{formatBytesPerSec(netTx)}</>
+										<>↑{formatThroughput(netTx)}</>
 									) : (
 										dash
 									)}
@@ -297,14 +297,14 @@ function SystemStatus() {
 							<span className="text-(--text-secondary) tabular-nums">
 								<span className="text-sky-400/60 inline-block min-w-22 text-right">
 									{typeof diskRead === "number" ? (
-										<>↓{formatBytesPerSec(diskRead)}</>
+										<>↓{formatThroughput(diskRead)}</>
 									) : (
 										dash
 									)}
 								</span>
 								<span className="text-amber-400/60 inline-block min-w-22 text-right">
 									{typeof diskWrite === "number" ? (
-										<>↑{formatBytesPerSec(diskWrite)}</>
+										<>↑{formatThroughput(diskWrite)}</>
 									) : (
 										dash
 									)}
@@ -352,7 +352,7 @@ function SystemStatus() {
 							<span>{t("layout.stats.requestsToday")}</span>
 							<span className="text-(--text-secondary)">
 								{app && app.requests_today > 0
-									? formatNumber(app.requests_today)
+									? formatCount(app.requests_today)
 									: dash}
 							</span>
 						</div>
@@ -367,7 +367,7 @@ function SystemStatus() {
 											className="text-(--text-secondary)"
 											title={t("layout.tooltips.dbSize")}
 										>
-											{formatMB(stats.db.size_mb)}
+											{formatMemoryMB(stats.db.size_mb)}
 										</span>
 										<span className="text-(--text-secondary)">|</span>
 										<span

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -51,106 +51,13 @@ import { ErrorShelf } from "./ErrorShelf";
 import { Logo } from "./Logo";
 import { ModelDiscrepancyModal } from "./ModelDiscrepancyModal";
 import { ProviderQuotaPanel } from "./ProviderQuotaPanel";
-
-const u = "text-(--text-muted)";
-
-function formatDuration(seconds: number) {
-	const d = Math.floor(seconds / 86400);
-	const h = Math.floor((seconds % 86400) / 3600);
-	const m = Math.floor((seconds % 3600) / 60);
-	if (d > 0)
-		return (
-			<>
-				{d}
-				<span className={u}>d</span> {h}
-				<span className={u}>h</span>
-			</>
-		);
-	if (h > 0)
-		return (
-			<>
-				{h}
-				<span className={u}>h</span> {m}
-				<span className={u}>m</span>
-			</>
-		);
-	return (
-		<>
-			{m}
-			<span className={u}>m</span>
-		</>
-	);
-}
-
-function formatNumber(n: number) {
-	if (n >= 1_000_000)
-		return (
-			<>
-				{(n / 1_000_000).toFixed(1)}
-				<span className={u}>M</span>
-			</>
-		);
-	if (n >= 1_000)
-		return (
-			<>
-				{(n / 1_000).toFixed(1)}
-				<span className={u}>K</span>
-			</>
-		);
-	return n.toLocaleString();
-}
-
-function formatMB(mb: number) {
-	if (mb < 1)
-		return (
-			<>
-				{mb.toFixed(1)}
-				<span className={u}> MB</span>
-			</>
-		);
-	if (mb >= 1024)
-		return (
-			<>
-				{(mb / 1024).toFixed(1)}
-				<span className={u}> GB</span>
-			</>
-		);
-	return (
-		<>
-			{Math.round(mb)}
-			<span className={u}> MB</span>
-		</>
-	);
-}
-
-function formatBytesPerSec(bytesPerSec: number) {
-	if (bytesPerSec <= 0)
-		return (
-			<>
-				0<span className={u}> B/s</span>
-			</>
-		);
-	if (bytesPerSec >= 1024 * 1024)
-		return (
-			<>
-				{(bytesPerSec / 1024 / 1024).toFixed(1)}
-				<span className={u}> MB/s</span>
-			</>
-		);
-	if (bytesPerSec >= 1024)
-		return (
-			<>
-				{(bytesPerSec / 1024).toFixed(1)}
-				<span className={u}> KB/s</span>
-			</>
-		);
-	return (
-		<>
-			{Math.round(bytesPerSec)}
-			<span className={u}> B/s</span>
-		</>
-	);
-}
+import {
+	formatBytesPerSec,
+	formatDuration,
+	formatMB,
+	formatNumber,
+	unitClass,
+} from "./systemStatusFormat";
 
 function SystemStatus() {
 	const { t } = useTranslation();
@@ -249,7 +156,7 @@ function SystemStatus() {
 	) : app ? (
 		<>
 			{formatMB(app.heap_alloc_mb)}
-			<span className={u}> {t("layout.stats.heap")}</span>
+			<span className={unitClass}> {t("layout.stats.heap")}</span>
 		</>
 	) : (
 		"-"
@@ -324,14 +231,14 @@ function SystemStatus() {
 									<>
 										<span>
 											{cpuPct.toFixed(1)}
-											<span className={u}>%</span>
+											<span className={unitClass}>%</span>
 										</span>
 										{procs != null && procs > 0 && (
 											<>
 												<span className="text-(--text-secondary) mx-1">|</span>
 												<span>
 													{procs}
-													<span className={u}>
+													<span className={unitClass}>
 														{" "}
 														{t("layout.stats.procs", { count: procs })}
 													</span>
@@ -471,7 +378,7 @@ function SystemStatus() {
 											{cacheHitLive ? (
 												<>
 													{stats.db.cache_hit_ratio}
-													<span className={u}>%</span>
+													<span className={unitClass}>%</span>
 												</>
 											) : (
 												dash
@@ -482,7 +389,10 @@ function SystemStatus() {
 											title={t("layout.tooltips.dbConnections")}
 										>
 											{stats.db.connections}
-											<span className={u}> {t("layout.stats.conn")}</span>
+											<span className={unitClass}>
+												{" "}
+												{t("layout.stats.conn")}
+											</span>
 										</span>
 										<span className="text-(--text-secondary)">|</span>
 										<span
@@ -490,7 +400,10 @@ function SystemStatus() {
 											title={t("layout.tooltips.dbTxPerSec")}
 										>
 											{stats.db.tx_per_sec.toFixed(1)}
-											<span className={u}> {t("layout.stats.txPerSec")}</span>
+											<span className={unitClass}>
+												{" "}
+												{t("layout.stats.txPerSec")}
+											</span>
 										</span>
 									</>
 								) : (

--- a/web/src/components/ModelReplyCard.tsx
+++ b/web/src/components/ModelReplyCard.tsx
@@ -10,6 +10,7 @@ import {
 	Zap,
 } from "@/lib/icons";
 import type { GenerationParams } from "../api/types";
+import { useCopyToClipboard } from "../hooks/useCopyToClipboard";
 import { formatDuration, formatNumber } from "../utils/format";
 import { is5xxError } from "../utils/model";
 import { InfoHint } from "./InfoHint";
@@ -131,6 +132,7 @@ export const ModelReplyCard = memo(function ModelReplyCard({
 	onDisableModel,
 }: ModelReplyCardProps) {
 	const { t } = useTranslation();
+	const { copy } = useCopyToClipboard();
 	const [elapsed, setElapsed] = useState(0);
 	const [maximized, setMaximized] = useState(false);
 	const bodyRef = useRef<HTMLDivElement>(null);
@@ -449,7 +451,7 @@ export const ModelReplyCard = memo(function ModelReplyCard({
 							<button
 								type="button"
 								onClick={() => {
-									navigator.clipboard.writeText(content);
+									void copy(content);
 								}}
 								className="ui-icon-btn p-1.5 rounded-md"
 								title={t("common.copy")}

--- a/web/src/components/ModelReplyCard.tsx
+++ b/web/src/components/ModelReplyCard.tsx
@@ -132,7 +132,7 @@ export const ModelReplyCard = memo(function ModelReplyCard({
 	onDisableModel,
 }: ModelReplyCardProps) {
 	const { t } = useTranslation();
-	const { copy } = useCopyToClipboard();
+	const { copy } = useCopyToClipboard({ trackCopied: false });
 	const [elapsed, setElapsed] = useState(0);
 	const [maximized, setMaximized] = useState(false);
 	const bodyRef = useRef<HTMLDivElement>(null);

--- a/web/src/components/ProviderQuotaPanel.tsx
+++ b/web/src/components/ProviderQuotaPanel.tsx
@@ -1,11 +1,14 @@
 import { useQuery } from "@tanstack/react-query";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { RefreshCw } from "@/lib/icons";
 import { api } from "../api/client";
 import { useQuotaModal } from "../context/QuotaModalContext";
 import { useToast } from "../context/ToastContext";
-import { useLocalStorage } from "../hooks/useLocalStorage";
+import {
+	useLocalStorage,
+	useLocalStorageValue,
+} from "../hooks/useLocalStorage";
 import { useQuotaData } from "../hooks/useQuotaData";
 import { CollapsibleToggle } from "./CollapsibleToggle";
 import {
@@ -17,17 +20,6 @@ import {
 	ZAICodingQuotaModal,
 } from "./ProviderModals";
 import { QuotaBadges } from "./QuotaBadge";
-
-// Mirrors a flag the Settings page owns and writes. This panel only reads it,
-// so it stays a plain read plus the listeners below rather than useLocalStorage,
-// whose setter would write the value straight back on every event it observes.
-function isQuotaDisabled(): boolean {
-	try {
-		return localStorage.getItem("sidebarQuotaDisabled") === "true";
-	} catch {
-		return false;
-	}
-}
 
 export function ProviderQuotaPanel() {
 	const { t } = useTranslation();
@@ -41,33 +33,27 @@ export function ProviderQuotaPanel() {
 		false,
 		{ deserialize: (stored) => stored === "true" },
 	);
-	const [disabled, setDisabled] = useState(() => isQuotaDisabled());
+	// The show/hide flag belongs to the Settings page, which announces its writes
+	// as "sidebarQuotaToggle"; this panel follows the value and never writes it.
+	// The refresh interval comes from the server setting below, so it needs no
+	// listener of its own.
+	const disabled = useLocalStorageValue("sidebarQuotaDisabled", false, {
+		deserialize: (stored) => stored === "true",
+		events: ["sidebarQuotaToggle"],
+	});
 
-	// Listen for show/hide toggle changes from the Settings page (same tab) and
-	// cross-tab storage events. The refresh interval is now sourced from the
-	// server setting below, so it no longer needs a custom-event listener.
-	useEffect(() => {
-		const toggleHandler = () => setDisabled(isQuotaDisabled());
-		window.addEventListener("sidebarQuotaToggle", toggleHandler);
-		// Also listen for storage events (cross-tab)
-		window.addEventListener("storage", toggleHandler);
-		return () => {
-			window.removeEventListener("sidebarQuotaToggle", toggleHandler);
-			window.removeEventListener("storage", toggleHandler);
-		};
-	}, []);
-
+	// The toast is announced here, outside the state updater, which React may
+	// call more than once for a single toggle.
 	const toggleCollapsed = useCallback(() => {
-		setCollapsed((prev) => {
-			const next = !prev;
-			if (next) {
-				toast(t("components.providerQuotaPanel.quotaPanelCollapsed"), "info");
-			} else {
-				toast(t("components.providerQuotaPanel.quotaPanelExpanded"), "info");
-			}
-			return next;
-		});
-	}, [setCollapsed, toast, t]);
+		const next = !collapsed;
+		setCollapsed(next);
+		toast(
+			next
+				? t("components.providerQuotaPanel.quotaPanelCollapsed")
+				: t("components.providerQuotaPanel.quotaPanelExpanded"),
+			"info",
+		);
+	}, [collapsed, setCollapsed, toast, t]);
 
 	const { data: providers } = useQuery({
 		queryKey: ["providers"],

--- a/web/src/components/ProviderQuotaPanel.tsx
+++ b/web/src/components/ProviderQuotaPanel.tsx
@@ -5,6 +5,7 @@ import { RefreshCw } from "@/lib/icons";
 import { api } from "../api/client";
 import { useQuotaModal } from "../context/QuotaModalContext";
 import { useToast } from "../context/ToastContext";
+import { useLocalStorage } from "../hooks/useLocalStorage";
 import { useQuotaData } from "../hooks/useQuotaData";
 import { CollapsibleToggle } from "./CollapsibleToggle";
 import {
@@ -17,6 +18,9 @@ import {
 } from "./ProviderModals";
 import { QuotaBadges } from "./QuotaBadge";
 
+// Mirrors a flag the Settings page owns and writes. This panel only reads it,
+// so it stays a plain read plus the listeners below rather than useLocalStorage,
+// whose setter would write the value straight back on every event it observes.
 function isQuotaDisabled(): boolean {
 	try {
 		return localStorage.getItem("sidebarQuotaDisabled") === "true";
@@ -31,13 +35,12 @@ export function ProviderQuotaPanel() {
 	const lastManualRefresh = useRef(0);
 	const refreshCooldownMs = 10_000;
 
-	const [collapsed, setCollapsed] = useState(() => {
-		try {
-			return localStorage.getItem("sidebarQuotaCollapsed") === "true";
-		} catch {
-			return false;
-		}
-	});
+	// Stored as "true"/"false"; anything else reads as expanded.
+	const [collapsed, setCollapsed] = useLocalStorage<boolean>(
+		"sidebarQuotaCollapsed",
+		false,
+		{ deserialize: (stored) => stored === "true" },
+	);
 	const [disabled, setDisabled] = useState(() => isQuotaDisabled());
 
 	// Listen for show/hide toggle changes from the Settings page (same tab) and
@@ -57,11 +60,6 @@ export function ProviderQuotaPanel() {
 	const toggleCollapsed = useCallback(() => {
 		setCollapsed((prev) => {
 			const next = !prev;
-			try {
-				localStorage.setItem("sidebarQuotaCollapsed", String(next));
-			} catch {
-				/* ignore */
-			}
 			if (next) {
 				toast(t("components.providerQuotaPanel.quotaPanelCollapsed"), "info");
 			} else {
@@ -69,7 +67,7 @@ export function ProviderQuotaPanel() {
 			}
 			return next;
 		});
-	}, [toast, t]);
+	}, [setCollapsed, toast, t]);
 
 	const { data: providers } = useQuery({
 		queryKey: ["providers"],

--- a/web/src/components/QuotaBadge.tsx
+++ b/web/src/components/QuotaBadge.tsx
@@ -1,5 +1,4 @@
 import i18next from "i18next";
-import { useEffect, useState } from "react";
 import type {
 	DeepSeekBalance,
 	DeepSeekBalanceInfo,
@@ -11,6 +10,7 @@ import type {
 	OpenRouterBalance,
 	ZAICodingQuotaResponse,
 } from "../api/types";
+import { useLocalStorageValue } from "../hooks/useLocalStorage";
 import type { QuotaDataResult, QuotaProviderType } from "../hooks/useQuotaData";
 import {
 	detectQuotaProviderType,
@@ -408,53 +408,14 @@ export function QuotaBadges({
 	onOllamaCloudClick,
 	onNeuralwattClick,
 }: QuotaBadgesProps) {
-	// The quota modals own this key (they write it through useLocalStorage); the
-	// badges only follow it. Reading it raw keeps the listener below free to
-	// adopt an observed value without writing it back and re-announcing it.
-	const [barMode, setBarMode] = useState<QuotaBarMode>(() => {
-		try {
-			return (
-				(localStorage.getItem("quota-bar-mode") as QuotaBarMode) || "remaining"
-			);
-		} catch {
-			return "remaining";
-		}
-	});
+	// The quota modals own this key and write it; the badges only follow it,
+	// re-reading whenever a modal in this tab or another tab changes the mode.
+	const barMode = useLocalStorageValue<QuotaBarMode>(
+		"quota-bar-mode",
+		"remaining",
+		{ deserialize: (stored) => (stored as QuotaBarMode) || "remaining" },
+	);
 
-	// Listen for bar-mode changes from modals (same tab via custom event,
-	// cross-tab via storage event, cross-component via localStorageChange).
-	useEffect(() => {
-		const handleModeChange = (e?: Event) => {
-			// localStorageChange custom events include the key that changed;
-			// ignore unrelated key changes.
-			if (
-				e?.type === "localStorageChange" &&
-				(e as CustomEvent).detail?.key !== "quota-bar-mode"
-			) {
-				return;
-			}
-			// Cross-tab storage events: check StorageEvent.key
-			if (e instanceof StorageEvent) {
-				if (e.key !== null && e.key !== "quota-bar-mode") {
-					return;
-				}
-			}
-			try {
-				setBarMode(
-					(localStorage.getItem("quota-bar-mode") as QuotaBarMode) ||
-						"remaining",
-				);
-			} catch {
-				setBarMode("remaining");
-			}
-		};
-		window.addEventListener("localStorageChange", handleModeChange);
-		window.addEventListener("storage", handleModeChange);
-		return () => {
-			window.removeEventListener("localStorageChange", handleModeChange);
-			window.removeEventListener("storage", handleModeChange);
-		};
-	}, []);
 	const scope = providerBaseUrl
 		? detectQuotaProviderType(providerBaseUrl)
 		: undefined;

--- a/web/src/components/QuotaBadge.tsx
+++ b/web/src/components/QuotaBadge.tsx
@@ -408,6 +408,9 @@ export function QuotaBadges({
 	onOllamaCloudClick,
 	onNeuralwattClick,
 }: QuotaBadgesProps) {
+	// The quota modals own this key (they write it through useLocalStorage); the
+	// badges only follow it. Reading it raw keeps the listener below free to
+	// adopt an observed value without writing it back and re-announcing it.
 	const [barMode, setBarMode] = useState<QuotaBarMode>(() => {
 		try {
 			return (

--- a/web/src/components/VirtualAppLogTable.tsx
+++ b/web/src/components/VirtualAppLogTable.tsx
@@ -3,7 +3,7 @@ import { useCallback, useLayoutEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { AppLogEntry } from "../api/types";
 import {
-	formatTimestamp,
+	formatLogTimestamp,
 	getLevelBadgeVariant,
 	getSourceBadgeClasses,
 } from "../utils/logBadgeUtils";
@@ -244,7 +244,7 @@ export function VirtualAppLogTable(props: VirtualAppLogTableProps) {
 									onClick={() => onRowClick(entry)}
 								>
 									<td className="px-2 py-1 align-middle whitespace-nowrap text-xs text-gray-400">
-										{formatTimestamp(entry.timestamp)}
+										{formatLogTimestamp(entry.timestamp)}
 									</td>
 									<td className="px-2 py-1 align-middle">
 										<Badge variant={getLevelBadgeVariant(entry.level)}>

--- a/web/src/components/__tests__/CopyButton.test.tsx
+++ b/web/src/components/__tests__/CopyButton.test.tsx
@@ -1,6 +1,7 @@
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import i18n from "../../i18n";
 import { renderWithProviders } from "../../test/utils";
 import { CopyButton } from "../CopyButton";
 
@@ -41,5 +42,46 @@ describe("CopyButton", () => {
 		await waitFor(() => {
 			expect(screen.getByText("Copied to clipboard")).toBeInTheDocument();
 		});
+	});
+
+	it("shows failure toast when the clipboard refuses", async () => {
+		const user = userEvent.setup();
+		renderWithProviders(<CopyButton text="test content" />);
+		// Spied after render: userEvent.setup() installs its own clipboard stub,
+		// so the spy has to go on whatever object is in place by then.
+		vi.spyOn(navigator.clipboard, "writeText").mockRejectedValue(
+			new Error("denied"),
+		);
+
+		await user.click(screen.getByRole("button"));
+
+		await waitFor(() => {
+			expect(screen.getByTestId("toast-message")).toHaveTextContent(
+				i18n.t("common.failedToCopy"),
+			);
+		});
+	});
+
+	it("swaps its label instead of toasting in the label variant", async () => {
+		const user = userEvent.setup();
+		renderWithProviders(
+			<CopyButton
+				variant="label"
+				text="test content"
+				testId="label-copy"
+				ariaLabel="Copy: row"
+			/>,
+		);
+		const button = screen.getByTestId("label-copy");
+		expect(button).toHaveClass("ui-btn-secondary");
+		expect(button).toHaveAttribute("aria-label", "Copy: row");
+		expect(button).toHaveTextContent(i18n.t("common.copy"));
+
+		await user.click(button);
+
+		await waitFor(() => {
+			expect(button).toHaveTextContent(i18n.t("common.copied"));
+		});
+		expect(screen.queryByTestId("toast-message")).not.toBeInTheDocument();
 	});
 });

--- a/web/src/components/__tests__/VirtualAppLogTable.test.tsx
+++ b/web/src/components/__tests__/VirtualAppLogTable.test.tsx
@@ -1203,8 +1203,8 @@ describe("VirtualAppLogTable", () => {
 		});
 	});
 
-	// ==================== formatTimestamp Tests ====================
-	describe("formatTimestamp", () => {
+	// ==================== formatLogTimestamp Tests ====================
+	describe("formatLogTimestamp", () => {
 		beforeEach(() => {
 			mockGetVirtualItems.mockReturnValue([
 				{ index: 0, key: "log-1", start: 0, end: 48 },
@@ -1222,7 +1222,7 @@ describe("VirtualAppLogTable", () => {
 			);
 
 			// The timestamp cell should contain formatted date
-			// formatTimestamp returns locale string like "05/23/2026, 10:00:00"
+			// formatLogTimestamp returns locale string like "05/23/2026, 10:00:00"
 			const timestampCell = container.querySelector(
 				'td[class*="whitespace-nowrap"]',
 			);

--- a/web/src/components/__tests__/systemStatusFormat.test.tsx
+++ b/web/src/components/__tests__/systemStatusFormat.test.tsx
@@ -1,0 +1,83 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+	formatBytesPerSec,
+	formatDuration,
+	formatMB,
+	formatNumber,
+	unitClass,
+} from "../systemStatusFormat";
+
+/** Rendered text of a figure, units included, as the sidebar shows it. */
+const text = (node: React.ReactNode) =>
+	render(<>{node}</>).container.textContent;
+
+describe("formatDuration", () => {
+	it("shows days and hours past a day", () => {
+		expect(text(formatDuration(3 * 86400 + 4 * 3600 + 30 * 60))).toBe("3d 4h");
+	});
+
+	it("shows hours and minutes past an hour", () => {
+		expect(text(formatDuration(4 * 3600 + 5 * 60 + 30))).toBe("4h 5m");
+	});
+
+	it("shows minutes alone under an hour", () => {
+		expect(text(formatDuration(5 * 60 + 30))).toBe("5m");
+	});
+});
+
+describe("formatNumber", () => {
+	it("abbreviates millions to one decimal", () => {
+		expect(text(formatNumber(2_500_000))).toBe("2.5M");
+	});
+
+	it("abbreviates thousands to one decimal", () => {
+		expect(text(formatNumber(1_200))).toBe("1.2K");
+	});
+
+	it("leaves smaller counts as a plain number", () => {
+		expect(text(formatNumber(999))).toBe("999");
+	});
+});
+
+describe("formatMB", () => {
+	it("keeps one decimal below a megabyte", () => {
+		expect(text(formatMB(0.5))).toBe("0.5 MB");
+	});
+
+	it("rounds megabytes", () => {
+		expect(text(formatMB(512.4))).toBe("512 MB");
+	});
+
+	it("switches to gigabytes at 1024 MB", () => {
+		expect(text(formatMB(2048))).toBe("2.0 GB");
+	});
+});
+
+describe("formatBytesPerSec", () => {
+	it("shows a flat zero when there is no traffic", () => {
+		expect(text(formatBytesPerSec(0))).toBe("0 B/s");
+		expect(text(formatBytesPerSec(-1))).toBe("0 B/s");
+	});
+
+	it("rounds bytes per second", () => {
+		expect(text(formatBytesPerSec(512.6))).toBe("513 B/s");
+	});
+
+	it("switches to kilobytes at 1024 B/s", () => {
+		expect(text(formatBytesPerSec(2048))).toBe("2.0 KB/s");
+	});
+
+	it("switches to megabytes at 1024 KB/s", () => {
+		expect(text(formatBytesPerSec(3 * 1024 * 1024))).toBe("3.0 MB/s");
+	});
+});
+
+describe("unit styling", () => {
+	it("dims the unit that trails the figure", () => {
+		const { container } = render(<>{formatMB(512)}</>);
+		const unit = container.querySelector("span");
+		expect(unit).toHaveClass(unitClass);
+		expect(unit).toHaveTextContent("MB");
+	});
+});

--- a/web/src/components/__tests__/systemStatusFormat.test.tsx
+++ b/web/src/components/__tests__/systemStatusFormat.test.tsx
@@ -1,10 +1,10 @@
 import { render } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import {
-	formatBytesPerSec,
-	formatDuration,
-	formatMB,
-	formatNumber,
+	formatCount,
+	formatMemoryMB,
+	formatThroughput,
+	formatUptime,
 	unitClass,
 } from "../systemStatusFormat";
 
@@ -12,70 +12,70 @@ import {
 const text = (node: React.ReactNode) =>
 	render(<>{node}</>).container.textContent;
 
-describe("formatDuration", () => {
+describe("formatUptime", () => {
 	it("shows days and hours past a day", () => {
-		expect(text(formatDuration(3 * 86400 + 4 * 3600 + 30 * 60))).toBe("3d 4h");
+		expect(text(formatUptime(3 * 86400 + 4 * 3600 + 30 * 60))).toBe("3d 4h");
 	});
 
 	it("shows hours and minutes past an hour", () => {
-		expect(text(formatDuration(4 * 3600 + 5 * 60 + 30))).toBe("4h 5m");
+		expect(text(formatUptime(4 * 3600 + 5 * 60 + 30))).toBe("4h 5m");
 	});
 
 	it("shows minutes alone under an hour", () => {
-		expect(text(formatDuration(5 * 60 + 30))).toBe("5m");
+		expect(text(formatUptime(5 * 60 + 30))).toBe("5m");
 	});
 });
 
-describe("formatNumber", () => {
+describe("formatCount", () => {
 	it("abbreviates millions to one decimal", () => {
-		expect(text(formatNumber(2_500_000))).toBe("2.5M");
+		expect(text(formatCount(2_500_000))).toBe("2.5M");
 	});
 
 	it("abbreviates thousands to one decimal", () => {
-		expect(text(formatNumber(1_200))).toBe("1.2K");
+		expect(text(formatCount(1_200))).toBe("1.2K");
 	});
 
 	it("leaves smaller counts as a plain number", () => {
-		expect(text(formatNumber(999))).toBe("999");
+		expect(text(formatCount(999))).toBe("999");
 	});
 });
 
-describe("formatMB", () => {
+describe("formatMemoryMB", () => {
 	it("keeps one decimal below a megabyte", () => {
-		expect(text(formatMB(0.5))).toBe("0.5 MB");
+		expect(text(formatMemoryMB(0.5))).toBe("0.5 MB");
 	});
 
 	it("rounds megabytes", () => {
-		expect(text(formatMB(512.4))).toBe("512 MB");
+		expect(text(formatMemoryMB(512.4))).toBe("512 MB");
 	});
 
 	it("switches to gigabytes at 1024 MB", () => {
-		expect(text(formatMB(2048))).toBe("2.0 GB");
+		expect(text(formatMemoryMB(2048))).toBe("2.0 GB");
 	});
 });
 
-describe("formatBytesPerSec", () => {
+describe("formatThroughput", () => {
 	it("shows a flat zero when there is no traffic", () => {
-		expect(text(formatBytesPerSec(0))).toBe("0 B/s");
-		expect(text(formatBytesPerSec(-1))).toBe("0 B/s");
+		expect(text(formatThroughput(0))).toBe("0 B/s");
+		expect(text(formatThroughput(-1))).toBe("0 B/s");
 	});
 
 	it("rounds bytes per second", () => {
-		expect(text(formatBytesPerSec(512.6))).toBe("513 B/s");
+		expect(text(formatThroughput(512.6))).toBe("513 B/s");
 	});
 
 	it("switches to kilobytes at 1024 B/s", () => {
-		expect(text(formatBytesPerSec(2048))).toBe("2.0 KB/s");
+		expect(text(formatThroughput(2048))).toBe("2.0 KB/s");
 	});
 
 	it("switches to megabytes at 1024 KB/s", () => {
-		expect(text(formatBytesPerSec(3 * 1024 * 1024))).toBe("3.0 MB/s");
+		expect(text(formatThroughput(3 * 1024 * 1024))).toBe("3.0 MB/s");
 	});
 });
 
 describe("unit styling", () => {
 	it("dims the unit that trails the figure", () => {
-		const { container } = render(<>{formatMB(512)}</>);
+		const { container } = render(<>{formatMemoryMB(512)}</>);
 		const unit = container.querySelector("span");
 		expect(unit).toHaveClass(unitClass);
 		expect(unit).toHaveTextContent("MB");

--- a/web/src/components/systemStatusFormat.tsx
+++ b/web/src/components/systemStatusFormat.tsx
@@ -15,7 +15,7 @@ function figure(value: ReactNode, unit: string) {
 }
 
 /** Uptime as the two largest units that apply: "3d 4h", "4h 5m", or "5m". */
-export function formatDuration(seconds: number) {
+export function formatUptime(seconds: number) {
 	const d = Math.floor(seconds / 86400);
 	const h = Math.floor((seconds % 86400) / 3600);
 	const m = Math.floor((seconds % 3600) / 60);
@@ -35,21 +35,21 @@ export function formatDuration(seconds: number) {
 }
 
 /** Counts abbreviated to one decimal past a thousand: "1.2K", "3.4M". */
-export function formatNumber(n: number) {
+export function formatCount(n: number) {
 	if (n >= 1_000_000) return figure((n / 1_000_000).toFixed(1), "M");
 	if (n >= 1_000) return figure((n / 1_000).toFixed(1), "K");
 	return n.toLocaleString();
 }
 
 /** Memory in the unit that keeps it readable: "0.5 MB", "512 MB", "1.5 GB". */
-export function formatMB(mb: number) {
+export function formatMemoryMB(mb: number) {
 	if (mb < 1) return figure(mb.toFixed(1), " MB");
 	if (mb >= 1024) return figure((mb / 1024).toFixed(1), " GB");
 	return figure(Math.round(mb), " MB");
 }
 
 /** Throughput in the unit that keeps it readable, down to a flat "0 B/s". */
-export function formatBytesPerSec(bytesPerSec: number) {
+export function formatThroughput(bytesPerSec: number) {
 	if (bytesPerSec <= 0) return figure(0, " B/s");
 	if (bytesPerSec >= 1024 * 1024)
 		return figure((bytesPerSec / 1024 / 1024).toFixed(1), " MB/s");

--- a/web/src/components/systemStatusFormat.tsx
+++ b/web/src/components/systemStatusFormat.tsx
@@ -1,0 +1,59 @@
+import type { ReactNode } from "react";
+
+/** Dims the unit that trails a figure, so the number reads first. */
+export const unitClass = "text-(--text-muted)";
+
+// One figure with its unit dimmed. The unit carries its own leading space when
+// the reading calls for one ("12 MB" against "12d").
+function figure(value: ReactNode, unit: string) {
+	return (
+		<>
+			{value}
+			<span className={unitClass}>{unit}</span>
+		</>
+	);
+}
+
+/** Uptime as the two largest units that apply: "3d 4h", "4h 5m", or "5m". */
+export function formatDuration(seconds: number) {
+	const d = Math.floor(seconds / 86400);
+	const h = Math.floor((seconds % 86400) / 3600);
+	const m = Math.floor((seconds % 3600) / 60);
+	if (d > 0)
+		return (
+			<>
+				{figure(d, "d")} {figure(h, "h")}
+			</>
+		);
+	if (h > 0)
+		return (
+			<>
+				{figure(h, "h")} {figure(m, "m")}
+			</>
+		);
+	return figure(m, "m");
+}
+
+/** Counts abbreviated to one decimal past a thousand: "1.2K", "3.4M". */
+export function formatNumber(n: number) {
+	if (n >= 1_000_000) return figure((n / 1_000_000).toFixed(1), "M");
+	if (n >= 1_000) return figure((n / 1_000).toFixed(1), "K");
+	return n.toLocaleString();
+}
+
+/** Memory in the unit that keeps it readable: "0.5 MB", "512 MB", "1.5 GB". */
+export function formatMB(mb: number) {
+	if (mb < 1) return figure(mb.toFixed(1), " MB");
+	if (mb >= 1024) return figure((mb / 1024).toFixed(1), " GB");
+	return figure(Math.round(mb), " MB");
+}
+
+/** Throughput in the unit that keeps it readable, down to a flat "0 B/s". */
+export function formatBytesPerSec(bytesPerSec: number) {
+	if (bytesPerSec <= 0) return figure(0, " B/s");
+	if (bytesPerSec >= 1024 * 1024)
+		return figure((bytesPerSec / 1024 / 1024).toFixed(1), " MB/s");
+	if (bytesPerSec >= 1024)
+		return figure((bytesPerSec / 1024).toFixed(1), " KB/s");
+	return figure(Math.round(bytesPerSec), " B/s");
+}

--- a/web/src/context/ToastContext.tsx
+++ b/web/src/context/ToastContext.tsx
@@ -204,7 +204,7 @@ function ToastItem({
 	fuse: boolean;
 	onDone: () => void;
 }) {
-	const { copy } = useCopyToClipboard();
+	const { copy } = useCopyToClipboard({ trackCopied: false });
 	const [paused, setPaused] = useState(false);
 	const [fading, setFading] = useState(false);
 	const startTimeRef = useRef(0);

--- a/web/src/context/ToastContext.tsx
+++ b/web/src/context/ToastContext.tsx
@@ -10,6 +10,7 @@ import {
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import { FuseOutline } from "../components/FuseOutline";
+import { useCopyToClipboard } from "../hooks/useCopyToClipboard";
 import { useLocalStorage } from "../hooks/useLocalStorage";
 import { Copy, X } from "../lib/icons";
 
@@ -203,6 +204,7 @@ function ToastItem({
 	fuse: boolean;
 	onDone: () => void;
 }) {
+	const { copy } = useCopyToClipboard();
 	const [paused, setPaused] = useState(false);
 	const [fading, setFading] = useState(false);
 	const startTimeRef = useRef(0);
@@ -306,8 +308,10 @@ function ToastItem({
 		warning: "bg-amber-900/70 text-amber-200",
 	};
 
+	// A blocked clipboard is silent here: a failure toast about a failed copy of
+	// a toast would stack on the very message the user is trying to keep.
 	const handleCopy = () => {
-		navigator.clipboard.writeText(toast.message).catch(() => {});
+		void copy(toast.message);
 	};
 
 	const { t } = useTranslation();

--- a/web/src/hooks/__tests__/useCopyToClipboard.test.ts
+++ b/web/src/hooks/__tests__/useCopyToClipboard.test.ts
@@ -1,0 +1,153 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useCopyToClipboard } from "../useCopyToClipboard";
+
+describe("useCopyToClipboard", () => {
+	const writeText = navigator.clipboard.writeText as ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		writeText.mockResolvedValue(undefined);
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("writes to the clipboard and reports success", async () => {
+		const { result } = renderHook(() => useCopyToClipboard());
+		expect(result.current.copied).toBe(false);
+
+		let ok: boolean | undefined;
+		await act(async () => {
+			ok = await result.current.copy("hello");
+		});
+
+		expect(ok).toBe(true);
+		expect(writeText).toHaveBeenCalledWith("hello");
+		expect(result.current.copied).toBe(true);
+	});
+
+	it("reverts copied after the reset delay", async () => {
+		vi.useFakeTimers();
+		const { result } = renderHook(() =>
+			useCopyToClipboard({ resetAfterMs: 50 }),
+		);
+
+		await act(async () => {
+			await result.current.copy("hello");
+		});
+		expect(result.current.copied).toBe(true);
+
+		act(() => {
+			vi.advanceTimersByTime(50);
+		});
+		expect(result.current.copied).toBe(false);
+	});
+
+	it("restarts the reset timer on a second copy", async () => {
+		vi.useFakeTimers();
+		const { result } = renderHook(() =>
+			useCopyToClipboard({ resetAfterMs: 100 }),
+		);
+
+		await act(async () => {
+			await result.current.copy("first");
+		});
+		act(() => {
+			vi.advanceTimersByTime(80);
+		});
+		await act(async () => {
+			await result.current.copy("second");
+		});
+
+		// The first timer would have fired at 100ms; the second copy replaced it.
+		act(() => {
+			vi.advanceTimersByTime(80);
+		});
+		expect(result.current.copied).toBe(true);
+
+		act(() => {
+			vi.advanceTimersByTime(20);
+		});
+		expect(result.current.copied).toBe(false);
+	});
+
+	it("clears the reset timer on unmount", async () => {
+		vi.useFakeTimers();
+		const clearSpy = vi.spyOn(globalThis, "clearTimeout");
+		const { result, unmount } = renderHook(() => useCopyToClipboard());
+
+		await act(async () => {
+			await result.current.copy("hello");
+		});
+		unmount();
+
+		expect(clearSpy).toHaveBeenCalled();
+		clearSpy.mockRestore();
+	});
+
+	it("reports failure without throwing when the write rejects", async () => {
+		writeText.mockRejectedValueOnce(new Error("denied"));
+		const { result } = renderHook(() => useCopyToClipboard());
+
+		let ok: boolean | undefined;
+		await act(async () => {
+			ok = await result.current.copy("hello");
+		});
+
+		expect(ok).toBe(false);
+		expect(result.current.copied).toBe(false);
+	});
+
+	it("reports failure when the Clipboard API is missing", async () => {
+		const original = navigator.clipboard;
+		Object.defineProperty(navigator, "clipboard", {
+			value: undefined,
+			configurable: true,
+			writable: true,
+		});
+		const { result } = renderHook(() => useCopyToClipboard());
+
+		let ok: boolean | undefined;
+		await act(async () => {
+			ok = await result.current.copy("hello");
+		});
+
+		expect(ok).toBe(false);
+		Object.defineProperty(navigator, "clipboard", {
+			value: original,
+			configurable: true,
+			writable: true,
+		});
+	});
+
+	it("uses a caller-supplied writer instead of the Clipboard API", async () => {
+		const write = vi.fn().mockResolvedValue(undefined);
+		const { result } = renderHook(() => useCopyToClipboard({ write }));
+
+		let ok: boolean | undefined;
+		await act(async () => {
+			ok = await result.current.copy("hello");
+		});
+
+		expect(ok).toBe(true);
+		expect(write).toHaveBeenCalledWith("hello");
+		expect(writeText).not.toHaveBeenCalled();
+	});
+
+	it("reports failure when the caller-supplied writer throws", async () => {
+		const write = vi.fn(() => {
+			throw new Error("no clipboard");
+		});
+		const { result } = renderHook(() => useCopyToClipboard({ write }));
+
+		let ok: boolean | undefined;
+		await act(async () => {
+			ok = await result.current.copy("hello");
+		});
+
+		expect(ok).toBe(false);
+		expect(result.current.copied).toBe(false);
+	});
+});

--- a/web/src/hooks/__tests__/useCopyToClipboard.test.ts
+++ b/web/src/hooks/__tests__/useCopyToClipboard.test.ts
@@ -73,18 +73,70 @@ describe("useCopyToClipboard", () => {
 		expect(result.current.copied).toBe(false);
 	});
 
-	it("clears the reset timer on unmount", async () => {
+	it("clears the reset timer it scheduled on unmount", async () => {
 		vi.useFakeTimers();
+		const setSpy = vi.spyOn(globalThis, "setTimeout");
 		const clearSpy = vi.spyOn(globalThis, "clearTimeout");
 		const { result, unmount } = renderHook(() => useCopyToClipboard());
 
 		await act(async () => {
 			await result.current.copy("hello");
 		});
+		// The id of the reset timer, so the assertion pins this timer and not
+		// whichever clearTimeout React or the fake-timer plumbing happens to call.
+		const timerId = setSpy.mock.results.at(-1)?.value;
+		expect(timerId).toBeDefined();
 		unmount();
 
-		expect(clearSpy).toHaveBeenCalled();
+		expect(clearSpy).toHaveBeenCalledWith(timerId);
+		expect(vi.getTimerCount()).toBe(0);
+		setSpy.mockRestore();
 		clearSpy.mockRestore();
+	});
+
+	it("schedules nothing when the component unmounts mid-write", async () => {
+		vi.useFakeTimers();
+		let settle: (() => void) | undefined;
+		writeText.mockImplementation(
+			() =>
+				new Promise<void>((resolve) => {
+					settle = resolve;
+				}),
+		);
+		const { result, unmount } = renderHook(() => useCopyToClipboard());
+
+		let pending: Promise<boolean> | undefined;
+		act(() => {
+			pending = result.current.copy("hello");
+		});
+		unmount();
+		await act(async () => {
+			settle?.();
+			await pending;
+		});
+
+		// The write landed, so the copy still reports success, but nothing was
+		// flagged and no timer outlived the cleanup that would have cleared it.
+		expect(await pending).toBe(true);
+		expect(result.current.copied).toBe(false);
+		expect(vi.getTimerCount()).toBe(0);
+	});
+
+	it("skips the flag and the timer when trackCopied is false", async () => {
+		vi.useFakeTimers();
+		const { result } = renderHook(() =>
+			useCopyToClipboard({ trackCopied: false }),
+		);
+
+		let ok: boolean | undefined;
+		await act(async () => {
+			ok = await result.current.copy("hello");
+		});
+
+		expect(ok).toBe(true);
+		expect(writeText).toHaveBeenCalledWith("hello");
+		expect(result.current.copied).toBe(false);
+		expect(vi.getTimerCount()).toBe(0);
 	});
 
 	it("reports failure without throwing when the write rejects", async () => {

--- a/web/src/hooks/__tests__/useLocalStorage.test.ts
+++ b/web/src/hooks/__tests__/useLocalStorage.test.ts
@@ -1,6 +1,6 @@
 import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { useLocalStorage } from "../useLocalStorage";
+import { useLocalStorage, useLocalStorageValue } from "../useLocalStorage";
 
 describe("useLocalStorage", () => {
 	const key = "test-key";
@@ -90,5 +90,139 @@ describe("useLocalStorage", () => {
 
 		expect(result.current[0]).toBe("fail"); // state still updated
 		setItemSpy.mockRestore();
+	});
+});
+
+describe("useLocalStorageValue", () => {
+	const key = "mirrored-key";
+
+	beforeEach(() => {
+		localStorage.clear();
+		vi.clearAllMocks();
+	});
+
+	it("reads the stored value on mount", () => {
+		localStorage.setItem(key, "stored");
+		const { result } = renderHook(() => useLocalStorageValue(key, "fallback"));
+		expect(result.current).toBe("stored");
+	});
+
+	it("returns the fallback when the key is absent", () => {
+		const { result } = renderHook(() => useLocalStorageValue(key, "fallback"));
+		expect(result.current).toBe("fallback");
+	});
+
+	it("deserializes the raw string, nulls included", () => {
+		localStorage.setItem(key, "5");
+		const { result } = renderHook(() =>
+			useLocalStorageValue(key, 30_000, {
+				deserialize: (stored, fallback) =>
+					stored === null ? fallback : Number(stored) * 1000,
+			}),
+		);
+		expect(result.current).toBe(5000);
+	});
+
+	it("re-reads on a cross-tab storage event for its key", () => {
+		localStorage.setItem(key, "first");
+		const { result } = renderHook(() => useLocalStorageValue(key, "fallback"));
+
+		localStorage.setItem(key, "second");
+		act(() => {
+			window.dispatchEvent(new StorageEvent("storage", { key }));
+		});
+		expect(result.current).toBe("second");
+	});
+
+	it("re-reads on the localStorageChange event for its key", () => {
+		localStorage.setItem(key, "first");
+		const { result } = renderHook(() => useLocalStorageValue(key, "fallback"));
+
+		localStorage.setItem(key, "second");
+		act(() => {
+			window.dispatchEvent(
+				new CustomEvent("localStorageChange", { detail: { key } }),
+			);
+		});
+		expect(result.current).toBe("second");
+	});
+
+	it("re-reads on an extra event the writer announces", () => {
+		localStorage.setItem(key, "first");
+		const { result } = renderHook(() =>
+			useLocalStorageValue(key, "fallback", { events: ["writerToggle"] }),
+		);
+
+		localStorage.setItem(key, "second");
+		act(() => {
+			window.dispatchEvent(new CustomEvent("writerToggle"));
+		});
+		expect(result.current).toBe("second");
+	});
+
+	it("ignores changes to other keys", () => {
+		localStorage.setItem(key, "first");
+		const { result } = renderHook(() => useLocalStorageValue(key, "fallback"));
+
+		localStorage.setItem(key, "second");
+		act(() => {
+			window.dispatchEvent(new StorageEvent("storage", { key: "other" }));
+			window.dispatchEvent(
+				new CustomEvent("localStorageChange", { detail: { key: "other" } }),
+			);
+		});
+		expect(result.current).toBe("first");
+	});
+
+	it("never writes, not even while following a change", () => {
+		localStorage.setItem(key, "first");
+		const setItemSpy = vi.spyOn(Storage.prototype, "setItem");
+		const dispatchSpy = vi.spyOn(window, "dispatchEvent");
+		const { result, unmount } = renderHook(() =>
+			useLocalStorageValue(key, "fallback"),
+		);
+
+		act(() => {
+			window.dispatchEvent(
+				new CustomEvent("localStorageChange", { detail: { key } }),
+			);
+		});
+		unmount();
+
+		expect(result.current).toBe("first");
+		expect(setItemSpy).not.toHaveBeenCalled();
+		// Only the event the test itself fired; the hook announces nothing.
+		expect(dispatchSpy).toHaveBeenCalledTimes(1);
+		setItemSpy.mockRestore();
+		dispatchSpy.mockRestore();
+	});
+
+	it("falls back when localStorage throws", () => {
+		const getItemSpy = vi
+			.spyOn(Storage.prototype, "getItem")
+			.mockImplementation(() => {
+				throw new Error("SecurityError");
+			});
+
+		const { result } = renderHook(() => useLocalStorageValue(key, "fallback"));
+
+		expect(result.current).toBe("fallback");
+		getItemSpy.mockRestore();
+	});
+
+	it("stops following once unmounted", () => {
+		localStorage.setItem(key, "first");
+		const { result, unmount } = renderHook(() =>
+			useLocalStorageValue(key, "fallback"),
+		);
+		unmount();
+
+		localStorage.setItem(key, "second");
+		act(() => {
+			window.dispatchEvent(
+				new CustomEvent("localStorageChange", { detail: { key } }),
+			);
+		});
+		expect(result.current).toBe("first");
 	});
 });

--- a/web/src/hooks/__tests__/useLocalStorage.test.ts
+++ b/web/src/hooks/__tests__/useLocalStorage.test.ts
@@ -268,6 +268,17 @@ describe("useLocalStorageValue", () => {
 		dispatchSpy.mockRestore();
 	});
 
+	it("falls back when the deserializer throws", () => {
+		localStorage.setItem(key, "not-json");
+		const { result } = renderHook(() =>
+			useLocalStorageValue(key, "fallback", {
+				deserialize: (stored) => JSON.parse(stored ?? "") as string,
+			}),
+		);
+
+		expect(result.current).toBe("fallback");
+	});
+
 	it("falls back when localStorage throws", () => {
 		const getItemSpy = vi
 			.spyOn(Storage.prototype, "getItem")

--- a/web/src/hooks/__tests__/useLocalStorage.test.ts
+++ b/web/src/hooks/__tests__/useLocalStorage.test.ts
@@ -160,6 +160,19 @@ describe("useLocalStorageValue", () => {
 		expect(result.current).toBe("second");
 	});
 
+	it("subscribes to an event name containing a space", () => {
+		localStorage.setItem(key, "first");
+		const { result } = renderHook(() =>
+			useLocalStorageValue(key, "fallback", { events: ["writer toggle"] }),
+		);
+
+		localStorage.setItem(key, "second");
+		act(() => {
+			window.dispatchEvent(new CustomEvent("writer toggle"));
+		});
+		expect(result.current).toBe("second");
+	});
+
 	it("ignores changes to other keys", () => {
 		localStorage.setItem(key, "first");
 		const { result } = renderHook(() => useLocalStorageValue(key, "fallback"));

--- a/web/src/hooks/__tests__/useLocalStorage.test.ts
+++ b/web/src/hooks/__tests__/useLocalStorage.test.ts
@@ -123,6 +123,64 @@ describe("useLocalStorageValue", () => {
 		expect(result.current).toBe(5000);
 	});
 
+	it("reads the new key immediately when the caller rerenders with one", () => {
+		localStorage.setItem(key, "first");
+		localStorage.setItem("other-key", "second");
+		const { result, rerender } = renderHook(
+			({ k }) => useLocalStorageValue(k, "fallback"),
+			{ initialProps: { k: key } },
+		);
+		expect(result.current).toBe("first");
+
+		rerender({ k: "other-key" });
+		expect(result.current).toBe("second");
+	});
+
+	it("falls back immediately when the new key is absent", () => {
+		localStorage.setItem(key, "first");
+		const { result, rerender } = renderHook(
+			({ k }) => useLocalStorageValue(k, "fallback"),
+			{ initialProps: { k: key } },
+		);
+
+		rerender({ k: "absent-key" });
+		expect(result.current).toBe("fallback");
+	});
+
+	it("follows a new fallback while the key is absent", () => {
+		const { result, rerender } = renderHook(
+			({ f }) => useLocalStorageValue(key, f),
+			{ initialProps: { f: "first" } },
+		);
+		expect(result.current).toBe("first");
+
+		rerender({ f: "second" });
+		expect(result.current).toBe("second");
+	});
+
+	it("re-parses when the caller rerenders with a new deserializer", () => {
+		localStorage.setItem(key, "5");
+		const { result, rerender } = renderHook(
+			({ d }) =>
+				useLocalStorageValue(key, 0, {
+					deserialize: d,
+				}),
+			{
+				initialProps: {
+					d: (stored: string | null, fallback: number) =>
+						stored === null ? fallback : Number(stored),
+				},
+			},
+		);
+		expect(result.current).toBe(5);
+
+		rerender({
+			d: (stored: string | null, fallback: number) =>
+				stored === null ? fallback : Number(stored) * 1000,
+		});
+		expect(result.current).toBe(5000);
+	});
+
 	it("re-reads on a cross-tab storage event for its key", () => {
 		localStorage.setItem(key, "first");
 		const { result } = renderHook(() => useLocalStorageValue(key, "fallback"));

--- a/web/src/hooks/useCopyToClipboard.ts
+++ b/web/src/hooks/useCopyToClipboard.ts
@@ -9,6 +9,12 @@ interface UseCopyToClipboardOptions {
 	 * where the Clipboard API does not exist).
 	 */
 	write?: (text: string) => Promise<void> | void;
+	/**
+	 * When false, `copied` stays false and no reset timer is scheduled, for
+	 * callers that report the result some other way (a toast) and never render
+	 * the flag. Defaults to true.
+	 */
+	trackCopied?: boolean;
 }
 
 interface UseCopyToClipboard {
@@ -26,14 +32,15 @@ interface UseCopyToClipboard {
  *   runs inside the async body on purpose: `navigator.clipboard` is undefined in
  *   non-secure (plain HTTP) contexts, and that turns a synchronous throw into a
  *   rejection the catch below sees.
- * - `copied` flips true on success and reverts on a timer that is cleared both
- *   on a re-copy and on unmount, so it never sets state on a component that is
- *   already gone.
+ * - `copied` flips true on success and reverts on a timer cleared on a re-copy
+ *   and on unmount. An unmount while the write is still in flight ends the copy
+ *   there: the text reaches the clipboard, but nothing is flagged and no timer
+ *   is scheduled behind the cleanup that would have cleared it.
  */
 export function useCopyToClipboard(
 	options: UseCopyToClipboardOptions = {},
 ): UseCopyToClipboard {
-	const { resetAfterMs = 2000, write } = options;
+	const { resetAfterMs = 2000, write, trackCopied = true } = options;
 	const [copied, setCopied] = useState(false);
 
 	// Refs so `copy` keeps one identity across renders even when the caller
@@ -44,12 +51,16 @@ export function useCopyToClipboard(
 	}, [write]);
 
 	const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
-	useEffect(
-		() => () => {
+	// False from unmount onwards, so work resumed after an awaited write knows
+	// the component it would touch is gone.
+	const alive = useRef(true);
+	useEffect(() => {
+		alive.current = true;
+		return () => {
+			alive.current = false;
 			if (timer.current !== null) clearTimeout(timer.current);
-		},
-		[],
-	);
+		};
+	}, []);
 
 	const copy = useCallback(
 		async (text: string): Promise<boolean> => {
@@ -59,12 +70,13 @@ export function useCopyToClipboard(
 			} catch {
 				return false;
 			}
+			if (!alive.current || !trackCopied) return true;
 			setCopied(true);
 			if (timer.current !== null) clearTimeout(timer.current);
 			timer.current = setTimeout(() => setCopied(false), resetAfterMs);
 			return true;
 		},
-		[resetAfterMs],
+		[resetAfterMs, trackCopied],
 	);
 
 	return { copy, copied };

--- a/web/src/hooks/useCopyToClipboard.ts
+++ b/web/src/hooks/useCopyToClipboard.ts
@@ -1,0 +1,71 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface UseCopyToClipboardOptions {
+	/** How long `copied` stays true after a successful write. Defaults to 2000ms. */
+	resetAfterMs?: number;
+	/**
+	 * Writer used instead of `navigator.clipboard.writeText`, for the call sites
+	 * that need their own fallback path (e.g. a dashboard served over plain HTTP,
+	 * where the Clipboard API does not exist).
+	 */
+	write?: (text: string) => Promise<void> | void;
+}
+
+interface UseCopyToClipboard {
+	/** Writes `text` to the clipboard. Resolves true on success, false on failure. */
+	copy: (text: string) => Promise<boolean>;
+	/** True from a successful copy until `resetAfterMs` later. */
+	copied: boolean;
+}
+
+/**
+ * A clipboard write plus the "Copied" flag that goes with it.
+ *
+ * - `copy(text)` resolves false instead of throwing when the clipboard is
+ *   missing or refuses, so callers that toast a failure still can. The write
+ *   runs inside the async body on purpose: `navigator.clipboard` is undefined in
+ *   non-secure (plain HTTP) contexts, and that turns a synchronous throw into a
+ *   rejection the catch below sees.
+ * - `copied` flips true on success and reverts on a timer that is cleared both
+ *   on a re-copy and on unmount, so it never sets state on a component that is
+ *   already gone.
+ */
+export function useCopyToClipboard(
+	options: UseCopyToClipboardOptions = {},
+): UseCopyToClipboard {
+	const { resetAfterMs = 2000, write } = options;
+	const [copied, setCopied] = useState(false);
+
+	// Refs so `copy` keeps one identity across renders even when the caller
+	// passes an inline writer.
+	const writeRef = useRef(write);
+	useEffect(() => {
+		writeRef.current = write;
+	}, [write]);
+
+	const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+	useEffect(
+		() => () => {
+			if (timer.current !== null) clearTimeout(timer.current);
+		},
+		[],
+	);
+
+	const copy = useCallback(
+		async (text: string): Promise<boolean> => {
+			try {
+				const writer = writeRef.current;
+				await (writer ? writer(text) : navigator.clipboard.writeText(text));
+			} catch {
+				return false;
+			}
+			setCopied(true);
+			if (timer.current !== null) clearTimeout(timer.current);
+			timer.current = setTimeout(() => setCopied(false), resetAfterMs);
+			return true;
+		},
+		[resetAfterMs],
+	);
+
+	return { copy, copied };
+}

--- a/web/src/hooks/useLocalStorage.ts
+++ b/web/src/hooks/useLocalStorage.ts
@@ -124,8 +124,9 @@ export function useLocalStorageValue<T>(
 		readStored(key, fallback, deserialize),
 	);
 
-	// Joined so an inline array literal does not resubscribe on every render.
-	const extraEvents = events?.join(" ") ?? "";
+	// The names ride as JSON so an inline array literal does not resubscribe on
+	// every render, and so a name is restored exactly as given, spaces included.
+	const extraEvents = JSON.stringify(events ?? []);
 	useEffect(() => {
 		const handler = (e: Event) => {
 			// The custom event names the key that changed; ignore the others.
@@ -144,7 +145,7 @@ export function useLocalStorageValue<T>(
 		const names = [
 			"storage",
 			"localStorageChange",
-			...(extraEvents === "" ? [] : extraEvents.split(" ")),
+			...(JSON.parse(extraEvents) as string[]),
 		];
 		for (const name of names) window.addEventListener(name, handler);
 		return () => {

--- a/web/src/hooks/useLocalStorage.ts
+++ b/web/src/hooks/useLocalStorage.ts
@@ -69,3 +69,88 @@ export function useLocalStorage<T>(
 
 	return [storedValue, setValue];
 }
+
+interface UseLocalStorageValueOptions<T> {
+	/** Turns the raw stored string (null when the key is absent) into the value. */
+	deserialize?: (stored: string | null, fallback: T) => T;
+	/**
+	 * Extra window events that also announce a change to this key, for writers
+	 * that dispatch their own (e.g. "sidebarQuotaToggle").
+	 */
+	events?: string[];
+}
+
+/** Current value of `key`, or `fallback` when it is absent or unreadable. */
+function readStored<T>(
+	key: string,
+	fallback: T,
+	deserialize?: (stored: string | null, fallback: T) => T,
+): T {
+	try {
+		const item = localStorage.getItem(key);
+		if (deserialize) return deserialize(item, fallback);
+		return item === null ? fallback : (item as T);
+	} catch {
+		// localStorage unavailable (private browsing, quota, iframe)
+		return fallback;
+	}
+}
+
+/**
+ * Read-only view of a localStorage key another screen owns and writes.
+ *
+ * Returns the current value and re-reads it whenever the key changes: a
+ * cross-tab `storage` event, the `localStorageChange` this module dispatches on
+ * every write, or any extra event name the writer announces. It never writes,
+ * so it cannot re-enter the listener a write-through setter would trigger.
+ */
+export function useLocalStorageValue<T>(
+	key: string,
+	fallback: T,
+	options: UseLocalStorageValueOptions<T> = {},
+): T {
+	const { deserialize, events } = options;
+
+	// Refs so the listener below re-reads with the current deserializer and
+	// fallback without resubscribing when the caller passes them inline.
+	const deserializeRef = useRef(deserialize);
+	const fallbackRef = useRef(fallback);
+	useEffect(() => {
+		deserializeRef.current = deserialize;
+		fallbackRef.current = fallback;
+	}, [deserialize, fallback]);
+
+	const [value, setValue] = useState<T>(() =>
+		readStored(key, fallback, deserialize),
+	);
+
+	// Joined so an inline array literal does not resubscribe on every render.
+	const extraEvents = events?.join(" ") ?? "";
+	useEffect(() => {
+		const handler = (e: Event) => {
+			// The custom event names the key that changed; ignore the others.
+			if (
+				e.type === "localStorageChange" &&
+				(e as CustomEvent).detail?.key !== key
+			) {
+				return;
+			}
+			// A cross-tab storage event carries its key, or null for a clear().
+			if (e instanceof StorageEvent && e.key !== null && e.key !== key) {
+				return;
+			}
+			setValue(readStored(key, fallbackRef.current, deserializeRef.current));
+		};
+		const names = [
+			"storage",
+			"localStorageChange",
+			...(extraEvents === "" ? [] : extraEvents.split(" ")),
+		];
+		for (const name of names) window.addEventListener(name, handler);
+		return () => {
+			for (const name of names) window.removeEventListener(name, handler);
+		};
+	}, [key, extraEvents]);
+
+	return value;
+}

--- a/web/src/hooks/useLocalStorage.ts
+++ b/web/src/hooks/useLocalStorage.ts
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useReducer, useRef, useState } from "react";
+import {
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+	useSyncExternalStore,
+} from "react";
 
 type SetValue<T> = (value: T | ((prev: T) => T)) => void;
 
@@ -80,32 +87,16 @@ interface UseLocalStorageValueOptions<T> {
 	events?: string[];
 }
 
-/** Current value of `key`, or `fallback` when it is absent or unreadable. */
-function readStored<T>(
-	key: string,
-	fallback: T,
-	deserialize?: (stored: string | null, fallback: T) => T,
-): T {
-	try {
-		const item = localStorage.getItem(key);
-		if (deserialize) return deserialize(item, fallback);
-		return item === null ? fallback : (item as T);
-	} catch {
-		// localStorage unavailable (private browsing, quota, iframe)
-		return fallback;
-	}
-}
-
 /**
  * Read-only view of a localStorage key another screen owns and writes.
  *
- * The value is read at render time, so it follows both sides: a caller that
- * rerenders with a different `key`, `fallback` or deserializer sees the new
- * reading in that same render, and a change announced from elsewhere - a
- * cross-tab `storage` event, the `localStorageChange` this module dispatches on
- * every write, or any extra event name the writer announces - triggers a
- * re-render that reads again. It never writes, so it cannot re-enter the
- * listener a write-through setter would trigger.
+ * The key is treated as the external store React subscribes to: `subscribe`
+ * attaches the listeners that announce a change to it, and the snapshot is the
+ * RAW stored string, so React's Object.is check bails out of a re-render when an
+ * announcement leaves the value alone. The parsed value is derived from that
+ * snapshot, which is what makes a rerender with a different `key`, `fallback` or
+ * deserializer show the new reading in that same render. It never writes, so it
+ * cannot re-enter the listener a write-through setter would trigger.
  */
 export function useLocalStorageValue<T>(
 	key: string,
@@ -114,39 +105,62 @@ export function useLocalStorageValue<T>(
 ): T {
 	const { deserialize, events } = options;
 
-	// The subscription holds no copy of the value: it only says "read again",
-	// which is what keeps the two sources of change - the caller's inputs and
-	// the writer's announcements - from drifting apart.
-	const [, readAgain] = useReducer((reads: number) => reads + 1, 0);
-
 	// The names ride as JSON so an inline array literal does not resubscribe on
 	// every render, and so a name is restored exactly as given, spaces included.
 	const extraEvents = JSON.stringify(events ?? []);
-	useEffect(() => {
-		const handler = (e: Event) => {
-			// The custom event names the key that changed; ignore the others.
-			if (
-				e.type === "localStorageChange" &&
-				(e as CustomEvent).detail?.key !== key
-			) {
-				return;
-			}
-			// A cross-tab storage event carries its key, or null for a clear().
-			if (e instanceof StorageEvent && e.key !== null && e.key !== key) {
-				return;
-			}
-			readAgain();
-		};
-		const names = [
-			"storage",
-			"localStorageChange",
-			...(JSON.parse(extraEvents) as string[]),
-		];
-		for (const name of names) window.addEventListener(name, handler);
-		return () => {
-			for (const name of names) window.removeEventListener(name, handler);
-		};
-	}, [key, extraEvents]);
 
-	return readStored(key, fallback, deserialize);
+	const subscribe = useCallback(
+		(onStoreChange: () => void) => {
+			const handler = (e: Event) => {
+				// The custom event names the key that changed; ignore the others.
+				if (
+					e.type === "localStorageChange" &&
+					(e as CustomEvent).detail?.key !== key
+				) {
+					return;
+				}
+				// A cross-tab storage event carries its key, or null for a clear().
+				if (e instanceof StorageEvent && e.key !== null && e.key !== key) {
+					return;
+				}
+				onStoreChange();
+			};
+			const names = [
+				"storage",
+				"localStorageChange",
+				...(JSON.parse(extraEvents) as string[]),
+			];
+			for (const name of names) window.addEventListener(name, handler);
+			return () => {
+				for (const name of names) window.removeEventListener(name, handler);
+			};
+		},
+		[key, extraEvents],
+	);
+
+	// A string or null, never a fresh object, so React can compare snapshots.
+	const getSnapshot = useCallback((): string | null => {
+		try {
+			return localStorage.getItem(key);
+		} catch {
+			// localStorage unavailable (private browsing, quota, iframe): the key
+			// reads as absent, which lands on the fallback below.
+			return null;
+		}
+	}, [key]);
+
+	// A server render has no localStorage, so the key is absent there too.
+	const getServerSnapshot = useCallback((): string | null => null, []);
+
+	const raw = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+
+	return useMemo(() => {
+		try {
+			if (deserialize) return deserialize(raw, fallback);
+			return raw === null ? fallback : (raw as T);
+		} catch {
+			// A deserializer that chokes on what is stored still owes a value.
+			return fallback;
+		}
+	}, [raw, fallback, deserialize]);
 }

--- a/web/src/hooks/useLocalStorage.ts
+++ b/web/src/hooks/useLocalStorage.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 
 type SetValue<T> = (value: T | ((prev: T) => T)) => void;
 
@@ -99,10 +99,13 @@ function readStored<T>(
 /**
  * Read-only view of a localStorage key another screen owns and writes.
  *
- * Returns the current value and re-reads it whenever the key changes: a
+ * The value is read at render time, so it follows both sides: a caller that
+ * rerenders with a different `key`, `fallback` or deserializer sees the new
+ * reading in that same render, and a change announced from elsewhere - a
  * cross-tab `storage` event, the `localStorageChange` this module dispatches on
- * every write, or any extra event name the writer announces. It never writes,
- * so it cannot re-enter the listener a write-through setter would trigger.
+ * every write, or any extra event name the writer announces - triggers a
+ * re-render that reads again. It never writes, so it cannot re-enter the
+ * listener a write-through setter would trigger.
  */
 export function useLocalStorageValue<T>(
 	key: string,
@@ -111,18 +114,10 @@ export function useLocalStorageValue<T>(
 ): T {
 	const { deserialize, events } = options;
 
-	// Refs so the listener below re-reads with the current deserializer and
-	// fallback without resubscribing when the caller passes them inline.
-	const deserializeRef = useRef(deserialize);
-	const fallbackRef = useRef(fallback);
-	useEffect(() => {
-		deserializeRef.current = deserialize;
-		fallbackRef.current = fallback;
-	}, [deserialize, fallback]);
-
-	const [value, setValue] = useState<T>(() =>
-		readStored(key, fallback, deserialize),
-	);
+	// The subscription holds no copy of the value: it only says "read again",
+	// which is what keeps the two sources of change - the caller's inputs and
+	// the writer's announcements - from drifting apart.
+	const [, readAgain] = useReducer((reads: number) => reads + 1, 0);
 
 	// The names ride as JSON so an inline array literal does not resubscribe on
 	// every render, and so a name is restored exactly as given, spaces included.
@@ -140,7 +135,7 @@ export function useLocalStorageValue<T>(
 			if (e instanceof StorageEvent && e.key !== null && e.key !== key) {
 				return;
 			}
-			setValue(readStored(key, fallbackRef.current, deserializeRef.current));
+			readAgain();
 		};
 		const names = [
 			"storage",
@@ -153,5 +148,5 @@ export function useLocalStorageValue<T>(
 		};
 	}, [key, extraEvents]);
 
-	return value;
+	return readStored(key, fallback, deserialize);
 }

--- a/web/src/lib/__tests__/icons.test.tsx
+++ b/web/src/lib/__tests__/icons.test.tsx
@@ -1,0 +1,20 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { BrainSlashIcon } from "../icons";
+
+describe("BrainSlashIcon", () => {
+	it("renders a Brain glyph in a box the caller's size", () => {
+		const { container } = render(<BrainSlashIcon size={20} />);
+		const box = container.firstElementChild as HTMLElement;
+		expect(box.style.width).toBe("20px");
+		expect(box.style.height).toBe("20px");
+		expect(box.querySelector(".icon-brain")).not.toBeNull();
+	});
+
+	it("keeps the caller's className and defaults the size", () => {
+		const { container } = render(<BrainSlashIcon className="shrink-0" />);
+		const box = container.firstElementChild as HTMLElement;
+		expect(box).toHaveClass("shrink-0");
+		expect(box.style.width).toBe("14px");
+	});
+});

--- a/web/src/lib/icons.tsx
+++ b/web/src/lib/icons.tsx
@@ -1,3 +1,7 @@
+/* eslint-disable react-refresh/only-export-components */
+// Every export here is a component; the withId() wrappers are just opaque to the
+// fast-refresh rule, which only recognises the plainly-declared one below.
+
 // Central icon shim. Maps the app's icon names (formerly lucide-react) to
 // Phosphor icons, so every call site stays unchanged - only the import path
 // moved to "@/lib/icons". Each icon is wrapped to carry a stable, lib-agnostic

--- a/web/src/lib/icons.tsx
+++ b/web/src/lib/icons.tsx
@@ -168,3 +168,26 @@ export const SlidersHorizontal = withId(
 export const ArrowLeftRight = withId(Ph.ArrowsLeftRightIcon, "ArrowLeftRight");
 export const ArrowDownToLine = withId(Ph.ArrowLineDownIcon, "ArrowDownToLine");
 export const ArrowUpFromLine = withId(Ph.ArrowLineUpIcon, "ArrowUpFromLine");
+
+// A Brain struck through, for "reasoning is stripped". Composed here rather
+// than mapped to a Ph.* glyph because Phosphor has no brain-slash: the bar is
+// an overlay sized to the icon box and inherits the surrounding text color.
+export function BrainSlashIcon({
+	size = 14,
+	className = "",
+}: {
+	size?: number;
+	className?: string;
+}) {
+	return (
+		<span
+			className={`relative inline-block ${className}`}
+			style={{ width: size, height: size }}
+		>
+			<Brain size={size} />
+			<span className="absolute inset-0 flex items-center justify-center pointer-events-none">
+				<span className="w-full h-[1.5px] bg-current rotate-45" />
+			</span>
+		</span>
+	);
+}

--- a/web/src/pages/AppLogs.tsx
+++ b/web/src/pages/AppLogs.tsx
@@ -33,7 +33,7 @@ import { useLocalStorage } from "../hooks/useLocalStorage";
 import { useWheelPaging } from "../hooks/useWheelPaging";
 import { encodeCursor } from "../utils/format";
 import {
-	formatTimestamp,
+	formatLogTimestamp,
 	getLevelBadgeVariant,
 	getSourceBadgeClasses,
 } from "../utils/logBadgeUtils";
@@ -442,7 +442,7 @@ export function AppLogs() {
 											onClick={() => setSelectedLog(entry)}
 										>
 											<td className="px-2 py-1 align-middle whitespace-nowrap text-xs text-gray-400">
-												{formatTimestamp(entry.timestamp)}
+												{formatLogTimestamp(entry.timestamp)}
 											</td>
 											<td className="px-2 py-1 align-middle">
 												<Badge variant={getLevelBadgeVariant(entry.level)}>

--- a/web/src/pages/Chat/ChatMessageList.tsx
+++ b/web/src/pages/Chat/ChatMessageList.tsx
@@ -6,8 +6,8 @@ import { MarkdownContent } from "../../components/MarkdownContent";
 import { ModelReplyCard } from "../../components/ModelReplyCard";
 import { CHAT_PERSONAS } from "../../data/presets";
 import { useDisableModel } from "../../hooks/useDisableModel";
+import { formatTime } from "../../utils/format";
 import { parseCapabilities, proxyModelID } from "../../utils/model";
-import { formatTime } from "./chatStreaming";
 
 export interface ChatMessageListProps {
 	messages: ChatMessage[];

--- a/web/src/pages/Chat/__tests__/chatStreaming.test.ts
+++ b/web/src/pages/Chat/__tests__/chatStreaming.test.ts
@@ -4,7 +4,6 @@ import { mockChatStream } from "../../../test/helpers";
 import { server } from "../../../test/mocks/server";
 import {
 	buildMessageContent,
-	formatTime,
 	getApiMessagesForModel,
 	streamModelResponse,
 } from "../chatStreaming";
@@ -21,41 +20,6 @@ const mockT = (key: string) => {
 	};
 	return map[key] ?? key;
 };
-
-describe("formatTime", () => {
-	it("formats timestamp as HH:MM", () => {
-		const ts = new Date("2024-01-15T14:30:00Z").getTime();
-		const result = formatTime(ts);
-
-		expect(result).toMatch(/\d{1,2}:\d{2}/);
-		expect(result).toContain(":");
-	});
-
-	it("formats midnight correctly", () => {
-		const ts = new Date("2024-01-15T00:00:00Z").getTime();
-		const result = formatTime(ts);
-
-		// Matches 00:00 (24h) or 12:00 AM (12h)
-		expect(result).toMatch(/00:00|12:00\s*AM/i);
-	});
-
-	it("formats noon correctly", () => {
-		const ts = new Date("2024-01-15T12:00:00Z").getTime();
-		const result = formatTime(ts);
-
-		// Matches 12:00 (24h) or 12:00 PM (12h)
-		expect(result).toMatch(/12:00/);
-	});
-
-	it("handles different timezones based on locale", () => {
-		const ts = Date.now();
-		const result = formatTime(ts);
-
-		expect(result).toBeDefined();
-		expect(typeof result).toBe("string");
-		expect(result).toContain(":");
-	});
-});
 
 describe("buildMessageContent", () => {
 	it("returns plain string for message without attachments", () => {

--- a/web/src/pages/Chat/chatStreaming.ts
+++ b/web/src/pages/Chat/chatStreaming.ts
@@ -10,14 +10,6 @@ import { readSSEStream, type StreamChunk } from "../../utils/sse";
 import { fetchWithRetry, type RetryOptions } from "../../utils/stagger";
 import { extractThinking, sanitizeDelta } from "../../utils/thinking";
 
-export function formatTime(ts: number): string {
-	const d = new Date(ts);
-	return d.toLocaleTimeString(undefined, {
-		hour: "2-digit",
-		minute: "2-digit",
-	});
-}
-
 export type ConversationState =
 	| "idle"
 	| "running"

--- a/web/src/pages/Dashboard/GaugeModal.tsx
+++ b/web/src/pages/Dashboard/GaugeModal.tsx
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useState } from "react";
 import { api } from "../../api/client";
 import { Modal } from "../../components/Modal";
+import { bucketLabel } from "./bucketLabel";
 import { TimeSeriesChart } from "./TimeSeriesChart";
 import type { GaugeDataKey, Range } from "./types";
 
@@ -45,16 +46,7 @@ export function GaugeModal({
 	const chartData = (() => {
 		if (!tsData?.points) return [];
 		return tsData.points.map((p) => {
-			const d = new Date(p.bucket);
-			const label =
-				range === "1w"
-					? d.toLocaleDateString("en-US", {
-							month: "short",
-							day: "numeric",
-						})
-					: range === "1h"
-						? `${d.getHours().toString().padStart(2, "0")}:${d.getMinutes().toString().padStart(2, "0")}`
-						: `${d.getHours().toString().padStart(2, "0")}:00`;
+			const label = bucketLabel(new Date(p.bucket), range);
 			return {
 				hour: label,
 				rawDate: p.bucket,

--- a/web/src/pages/Dashboard/__tests__/GaugeModal.test.tsx
+++ b/web/src/pages/Dashboard/__tests__/GaugeModal.test.tsx
@@ -372,7 +372,7 @@ describe("GaugeModal", () => {
 		renderWithProviders(<GaugeModal {...defaultProps} />);
 
 		await waitFor(() => {
-			// Day label should be formatted as "Jan 15"
+			// Week buckets carry a day label in the browser's locale
 			expect(screen.getByTestId("area-chart")).toBeInTheDocument();
 		});
 	});

--- a/web/src/pages/Dashboard/__tests__/bucketLabel.test.ts
+++ b/web/src/pages/Dashboard/__tests__/bucketLabel.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { bucketLabel } from "../bucketLabel";
+
+describe("bucketLabel", () => {
+	// Local time on purpose: the labels describe the reader's clock, so the
+	// dates are built the same way the chart's Date(p.bucket) ends up.
+	const at = (h: number, m: number) => new Date(2024, 5, 15, h, m);
+
+	it("labels a week bucket with the day", () => {
+		const label = bucketLabel(at(14, 35), "1w");
+		// Matches both en-GB ("15 Jun") and en-US ("Jun 15")
+		expect(label).toMatch(/15.*Jun|Jun.*15/);
+	});
+
+	it("labels an hour bucket with minutes", () => {
+		expect(bucketLabel(at(14, 35), "1h")).toBe("14:35");
+	});
+
+	it("labels a day bucket with the hour alone", () => {
+		expect(bucketLabel(at(14, 35), "24h")).toBe("14:00");
+	});
+
+	it("zero-pads single-digit hours and minutes", () => {
+		expect(bucketLabel(at(9, 5), "1h")).toBe("09:05");
+		expect(bucketLabel(at(0, 0), "24h")).toBe("00:00");
+	});
+});

--- a/web/src/pages/Dashboard/__tests__/bucketLabel.test.ts
+++ b/web/src/pages/Dashboard/__tests__/bucketLabel.test.ts
@@ -6,10 +6,14 @@ describe("bucketLabel", () => {
 	// dates are built the same way the chart's Date(p.bucket) ends up.
 	const at = (h: number, m: number) => new Date(2024, 5, 15, h, m);
 
-	it("labels a week bucket with the day", () => {
-		const label = bucketLabel(at(14, 35), "1w");
-		// Matches both en-GB ("15 Jun") and en-US ("Jun 15")
-		expect(label).toMatch(/15.*Jun|Jun.*15/);
+	it("labels a week bucket with the day, in the browser's locale", () => {
+		const date = at(14, 35);
+		expect(bucketLabel(date, "1w")).toBe(
+			new Intl.DateTimeFormat(undefined, {
+				month: "short",
+				day: "numeric",
+			}).format(date),
+		);
 	});
 
 	it("labels an hour bucket with minutes", () => {

--- a/web/src/pages/Dashboard/bucketLabel.ts
+++ b/web/src/pages/Dashboard/bucketLabel.ts
@@ -1,0 +1,21 @@
+import type { Range } from "./types";
+
+/**
+ * X-axis label for one timeseries bucket, at the resolution its range implies:
+ * a day ("Jun 15") over a week, minutes ("14:35") over an hour, the hour alone
+ * ("14:00") over a day. The date part follows the browser locale; the clock
+ * parts are zero-padded 24-hour so labels stay the same width on a narrow axis.
+ */
+export function bucketLabel(date: Date, range: Range): string {
+	if (range === "1w") {
+		return date.toLocaleDateString(undefined, {
+			month: "short",
+			day: "numeric",
+		});
+	}
+	const hours = date.getHours().toString().padStart(2, "0");
+	if (range === "1h") {
+		return `${hours}:${date.getMinutes().toString().padStart(2, "0")}`;
+	}
+	return `${hours}:00`;
+}

--- a/web/src/pages/Dashboard/useDashboard.ts
+++ b/web/src/pages/Dashboard/useDashboard.ts
@@ -13,6 +13,7 @@ import type {
 import { useToast } from "../../context/ToastContext";
 import { useLocalStorage } from "../../hooks/useLocalStorage";
 import { proxyModelID } from "../../utils/model";
+import { bucketLabel } from "./bucketLabel";
 import type { Range } from "./types";
 
 /** Synthetic virtual_key_name values the backend meters under its own routes
@@ -603,16 +604,7 @@ export function useDashboard(): UseDashboardReturn {
 	const acData = (() => {
 		if (!tsData?.points) return [];
 		return tsData.points.map((p) => {
-			const d = new Date(p.bucket);
-			const label =
-				requestsChartRange === "1w"
-					? d.toLocaleDateString(undefined, {
-							month: "short",
-							day: "numeric",
-						})
-					: requestsChartRange === "1h"
-						? `${d.getHours().toString().padStart(2, "0")}:${d.getMinutes().toString().padStart(2, "0")}`
-						: `${d.getHours().toString().padStart(2, "0")}:00`;
+			const label = bucketLabel(new Date(p.bucket), requestsChartRange);
 			return {
 				hour: label,
 				rawDate: p.bucket,
@@ -633,16 +625,7 @@ export function useDashboard(): UseDashboardReturn {
 	const tokenAcData = (() => {
 		if (!tokenTsData?.points) return [];
 		return tokenTsData.points.map((p) => {
-			const d = new Date(p.bucket);
-			const label =
-				tokensChartRange === "1w"
-					? d.toLocaleDateString(undefined, {
-							month: "short",
-							day: "numeric",
-						})
-					: tokensChartRange === "1h"
-						? `${d.getHours().toString().padStart(2, "0")}:${d.getMinutes().toString().padStart(2, "0")}`
-						: `${d.getHours().toString().padStart(2, "0")}:00`;
+			const label = bucketLabel(new Date(p.bucket), tokensChartRange);
 			return {
 				hour: label,
 				rawDate: p.bucket,

--- a/web/src/pages/Dashboard/useDashboard.ts
+++ b/web/src/pages/Dashboard/useDashboard.ts
@@ -326,6 +326,9 @@ export function useDashboard(): UseDashboardReturn {
 		};
 	}, []);
 
+	// Milliseconds derived from a seconds value the Settings page owns and
+	// writes. The dashboard only follows it, in a different unit than the key
+	// holds, so it stays a plain read plus the listener below.
 	const [dashboardRefreshMs, setDashboardRefreshMs] = useState(() => {
 		try {
 			const raw = localStorage.getItem("dashboardRefreshSec");

--- a/web/src/pages/Dashboard/useDashboard.ts
+++ b/web/src/pages/Dashboard/useDashboard.ts
@@ -11,7 +11,10 @@ import type {
 	TimeSeriesStats,
 } from "../../api/types";
 import { useToast } from "../../context/ToastContext";
-import { useLocalStorage } from "../../hooks/useLocalStorage";
+import {
+	useLocalStorage,
+	useLocalStorageValue,
+} from "../../hooks/useLocalStorage";
 import { proxyModelID } from "../../utils/model";
 import { bucketLabel } from "./bucketLabel";
 import type { Range } from "./types";
@@ -326,47 +329,24 @@ export function useDashboard(): UseDashboardReturn {
 		};
 	}, []);
 
-	// Milliseconds derived from a seconds value the Settings page owns and
-	// writes. The dashboard only follows it, in a different unit than the key
-	// holds, so it stays a plain read plus the listener below.
-	const [dashboardRefreshMs, setDashboardRefreshMs] = useState(() => {
-		try {
-			const raw = localStorage.getItem("dashboardRefreshSec");
-			if (raw !== null) {
-				const sec = Number(raw);
+	// Milliseconds derived from the seconds value the Settings page owns and
+	// writes, announcing each change as "dashboardRefreshChange". The dashboard
+	// follows it and never writes it; 0 disables auto-refresh and anything
+	// unparsable means the 30s default.
+	const dashboardRefreshMs = useLocalStorageValue(
+		"dashboardRefreshSec",
+		30000,
+		{
+			deserialize: (stored, fallback) => {
+				if (stored === null) return fallback;
+				const sec = Number(stored);
 				if (sec > 0) return sec * 1000;
 				if (sec === 0) return 0;
-			}
-		} catch {
-			// localStorage unavailable (private browsing, quota, iframe)
-		}
-		return 30000;
-	});
-
-	// React to interval changes from Settings page mid-session
-	useEffect(() => {
-		const handler = () => {
-			try {
-				const raw = localStorage.getItem("dashboardRefreshSec");
-				if (raw !== null) {
-					const sec = Number(raw);
-					if (sec > 0) {
-						setDashboardRefreshMs(sec * 1000);
-						return;
-					}
-					if (sec === 0) {
-						setDashboardRefreshMs(0);
-						return;
-					}
-				}
-				setDashboardRefreshMs(30000);
-			} catch {
-				setDashboardRefreshMs(30000);
-			}
-		};
-		window.addEventListener("dashboardRefreshChange", handler);
-		return () => window.removeEventListener("dashboardRefreshChange", handler);
-	}, []);
+				return fallback;
+			},
+			events: ["dashboardRefreshChange"],
+		},
+	);
 
 	const handleRefresh = useCallback(() => {
 		const now = Date.now();

--- a/web/src/pages/FailoverGroups/FailoverGroupCard.tsx
+++ b/web/src/pages/FailoverGroups/FailoverGroupCard.tsx
@@ -68,7 +68,7 @@ export function FailoverGroupCard({
 }) {
 	const { t } = useTranslation();
 	const { toast } = useToast();
-	const { copy } = useCopyToClipboard();
+	const { copy } = useCopyToClipboard({ trackCopied: false });
 
 	// Optimistic local state: reorders immediately on dragEnd so the DOM
 	// order matches the visual drag position. key-based reset ensures

--- a/web/src/pages/FailoverGroups/FailoverGroupCard.tsx
+++ b/web/src/pages/FailoverGroups/FailoverGroupCard.tsx
@@ -20,6 +20,7 @@ import type {
 	FailoverGroup,
 } from "../../api/types";
 import { useToast } from "../../context/ToastContext";
+import { useCopyToClipboard } from "../../hooks/useCopyToClipboard";
 import { formatTokens } from "../../utils/format";
 import { SortableEntry } from "./SortableEntry";
 
@@ -67,6 +68,7 @@ export function FailoverGroupCard({
 }) {
 	const { t } = useTranslation();
 	const { toast } = useToast();
+	const { copy } = useCopyToClipboard();
 
 	// Optimistic local state: reorders immediately on dragEnd so the DOM
 	// order matches the visual drag position. key-based reset ensures
@@ -112,16 +114,11 @@ export function FailoverGroupCard({
 		}
 	};
 
-	const handleCopyModel = () => {
+	const handleCopyModel = async () => {
 		const modelRef = `hotel/${group.display_model}`;
-		// Promise-wrap so a missing Clipboard API (undefined in non-secure/HTTP
-		// contexts) rejects into the failure toast instead of throwing synchronously.
-		Promise.resolve()
-			.then(() => navigator.clipboard.writeText(modelRef))
-			.then(() =>
-				toast(t("failover.copied_model", { model: modelRef }), "success"),
-			)
-			.catch(() => toast(t("common.failedToCopy"), "error"));
+		if (await copy(modelRef))
+			toast(t("failover.copied_model", { model: modelRef }), "success");
+		else toast(t("common.failedToCopy"), "error");
 	};
 
 	return (

--- a/web/src/pages/Security/__tests__/Security.test.tsx
+++ b/web/src/pages/Security/__tests__/Security.test.tsx
@@ -2,6 +2,7 @@ import { screen, waitFor } from "@testing-library/react";
 import { HttpResponse, http } from "msw";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { UserTotpStatus } from "../../../api/types";
+import i18n from "../../../i18n";
 import { server } from "../../../test/mocks/server";
 import { renderWithProviders } from "../../../test/utils";
 import { Security } from "../index";
@@ -248,6 +249,32 @@ describe("Security page edge handlers", () => {
 		expect(
 			screen.queryByTestId("security-verify-code"),
 		).not.toBeInTheDocument();
+	});
+
+	it("toasts when the secret cannot be copied", {
+		timeout: 30000,
+	}, async () => {
+		mockStatus({ enabled: false });
+		server.use(
+			http.post("/api/auth/totp/enroll/start", () =>
+				HttpResponse.json({
+					uri: "otpauth://totp/Model%20Hotel:alice?secret=JBSWY3DP",
+					secret: "JBSWY3DPEHPK3PXP",
+				}),
+			),
+		);
+		const { user } = renderWithProviders(<Security />);
+
+		await user.click(await screen.findByTestId("security-enable-button"));
+		// user-event installs its own clipboard stub; spy on that instance.
+		vi.spyOn(navigator.clipboard, "writeText").mockRejectedValue(
+			new Error("denied"),
+		);
+		await user.click(await screen.findByTestId("security-copy-secret"));
+
+		expect(await screen.findByTestId("toast-message")).toHaveTextContent(
+			i18n.t("common.failedToCopy"),
+		);
 	});
 
 	it("downloads and acknowledges the recovery codes", {

--- a/web/src/pages/Security/index.tsx
+++ b/web/src/pages/Security/index.tsx
@@ -22,7 +22,7 @@ import { isBreachedPasswordError } from "../../utils/passwordPolicy";
 export function Security() {
 	const { t } = useTranslation();
 	const { toast } = useToast();
-	const { copy } = useCopyToClipboard();
+	const { copy } = useCopyToClipboard({ trackCopied: false });
 	const queryClient = useQueryClient();
 
 	const [enrollUri, setEnrollUri] = useState("");

--- a/web/src/pages/Security/index.tsx
+++ b/web/src/pages/Security/index.tsx
@@ -7,6 +7,7 @@ import { ApiError, api, clearAuth } from "../../api/client";
 import { CopyButton } from "../../components/CopyButton";
 import { PageHeader } from "../../components/PageHeader";
 import { useToast } from "../../context/ToastContext";
+import { useCopyToClipboard } from "../../hooks/useCopyToClipboard";
 import { formatDate } from "../../utils/format";
 import { isBreachedPasswordError } from "../../utils/passwordPolicy";
 
@@ -21,6 +22,7 @@ import { isBreachedPasswordError } from "../../utils/passwordPolicy";
 export function Security() {
 	const { t } = useTranslation();
 	const { toast } = useToast();
+	const { copy } = useCopyToClipboard();
 	const queryClient = useQueryClient();
 
 	const [enrollUri, setEnrollUri] = useState("");
@@ -129,12 +131,9 @@ export function Security() {
 	};
 
 	const handleCopySecret = async () => {
-		try {
-			await navigator.clipboard.writeText(enrollSecret);
+		if (await copy(enrollSecret))
 			toast(t("settings.totp.secretCopied"), "success");
-		} catch {
-			toast(t("common.failedToCopy"), "error");
-		}
+		else toast(t("common.failedToCopy"), "error");
 	};
 
 	const handleDownloadCodes = () => {

--- a/web/src/pages/Settings/DatabaseBackupSettings.tsx
+++ b/web/src/pages/Settings/DatabaseBackupSettings.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import {
 	AlertTriangle,
@@ -158,29 +158,38 @@ export function DatabaseBackupSettings({
 	// over plain HTTP on a LAN (a normal self-hosted setup) has none, so fall
 	// back to the legacy selection-based copy rather than fail on the one
 	// button that exists to unblock a verified restore.
-	const writeClipboard = async (text: string) => {
-		if (navigator.clipboard?.writeText) {
-			await navigator.clipboard.writeText(text);
-			return;
-		}
-		const holder = document.createElement("textarea");
-		holder.value = text;
-		holder.setAttribute("readonly", "");
-		holder.style.position = "fixed";
-		holder.style.opacity = "0";
-		document.body.appendChild(holder);
-		holder.select();
-		let copied: boolean;
-		try {
-			copied = document.execCommand("copy");
-		} finally {
-			document.body.removeChild(holder);
-		}
-		if (!copied) {
-			throw new Error(t("common.failedToCopy"));
-		}
-	};
-	const { copy } = useCopyToClipboard({ write: writeClipboard });
+	const writeClipboard = useCallback(
+		async (text: string) => {
+			if (navigator.clipboard?.writeText) {
+				await navigator.clipboard.writeText(text);
+				return;
+			}
+			const holder = document.createElement("textarea");
+			holder.value = text;
+			holder.setAttribute("readonly", "");
+			holder.style.position = "fixed";
+			holder.style.opacity = "0";
+			document.body.appendChild(holder);
+			holder.select();
+			let copied: boolean;
+			try {
+				copied = document.execCommand("copy");
+			} finally {
+				document.body.removeChild(holder);
+			}
+			if (!copied) {
+				throw new Error(t("common.failedToCopy"));
+			}
+		},
+		[t],
+	);
+	// One clipboard path for the whole dashboard, with this page's fallback
+	// writer in front of it. The button reports through a toast, so the "Copied"
+	// flag is not tracked.
+	const { copy } = useCopyToClipboard({
+		write: writeClipboard,
+		trackCopied: false,
+	});
 
 	// Puts the backup's signature sidecar on the clipboard for the restore
 	// form. The download hands over the dump alone, and without shell access to

--- a/web/src/pages/Settings/DatabaseBackupSettings.tsx
+++ b/web/src/pages/Settings/DatabaseBackupSettings.tsx
@@ -21,6 +21,7 @@ import { SettingsSlider } from "../../components/SettingsSlider";
 import { Spinner } from "../../components/Spinner";
 import { Toggle } from "../../components/Toggle";
 import { useToast } from "../../context/ToastContext";
+import { useCopyToClipboard } from "../../hooks/useCopyToClipboard";
 import { formatDateTimeShort } from "../../utils/format";
 
 interface DatabaseBackupSettingsProps {
@@ -179,6 +180,7 @@ export function DatabaseBackupSettings({
 			throw new Error(t("common.failedToCopy"));
 		}
 	};
+	const { copy } = useCopyToClipboard({ write: writeClipboard });
 
 	// Puts the backup's signature sidecar on the clipboard for the restore
 	// form. The download hands over the dump alone, and without shell access to
@@ -187,7 +189,9 @@ export function DatabaseBackupSettings({
 	const copySignature = async (filename: string) => {
 		try {
 			const { signature } = await api.backups.signature(filename);
-			await writeClipboard(signature);
+			if (!(await copy(signature))) {
+				throw new Error(t("common.failedToCopy"));
+			}
 			toast(t("settings.backup.signatureCopied"), "success");
 		} catch (err) {
 			toast(

--- a/web/src/pages/Settings/TotpSettings.tsx
+++ b/web/src/pages/Settings/TotpSettings.tsx
@@ -6,11 +6,13 @@ import { Check, Copy, Download, X } from "@/lib/icons";
 import { api } from "../../api/client";
 import { CopyButton } from "../../components/CopyButton";
 import { useToast } from "../../context/ToastContext";
+import { useCopyToClipboard } from "../../hooks/useCopyToClipboard";
 import { formatDate } from "../../utils/format";
 
 export function TotpPanel() {
 	const { t } = useTranslation();
 	const { toast } = useToast();
+	const { copy } = useCopyToClipboard();
 	const queryClient = useQueryClient();
 
 	const [enrollUri, setEnrollUri] = useState("");
@@ -126,12 +128,9 @@ export function TotpPanel() {
 	};
 
 	const handleCopySecret = async () => {
-		try {
-			await navigator.clipboard.writeText(enrollSecret);
+		if (await copy(enrollSecret))
 			toast(t("settings.totp.secretCopied"), "success");
-		} catch {
-			toast(t("common.failedToCopy"), "error");
-		}
+		else toast(t("common.failedToCopy"), "error");
 	};
 
 	const handleDownloadCodes = () => {

--- a/web/src/pages/Settings/TotpSettings.tsx
+++ b/web/src/pages/Settings/TotpSettings.tsx
@@ -12,7 +12,7 @@ import { formatDate } from "../../utils/format";
 export function TotpPanel() {
 	const { t } = useTranslation();
 	const { toast } = useToast();
-	const { copy } = useCopyToClipboard();
+	const { copy } = useCopyToClipboard({ trackCopied: false });
 	const queryClient = useQueryClient();
 
 	const [enrollUri, setEnrollUri] = useState("");

--- a/web/src/pages/Settings/__tests__/TotpSettings.test.tsx
+++ b/web/src/pages/Settings/__tests__/TotpSettings.test.tsx
@@ -1,6 +1,7 @@
 import { screen, waitFor } from "@testing-library/react";
 import { HttpResponse, http } from "msw";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import i18n from "../../../i18n";
 import { server } from "../../../test/mocks/server";
 import { renderWithProviders } from "../../../test/utils";
 import { TotpPanel } from "../TotpSettings";
@@ -366,6 +367,31 @@ describe("TotpSettings", () => {
 		expect(
 			screen.queryByText(/Save these recovery codes now/i),
 		).not.toBeInTheDocument();
+	});
+
+	it("toasts when the secret cannot be copied", async () => {
+		mockStatus(false);
+		server.use(
+			http.post("/api/totp/enroll/start", () =>
+				HttpResponse.json({ uri: ENROLL_URI, secret: ENROLL_SECRET }),
+			),
+		);
+		const { user } = renderWithProviders(<TotpPanel />);
+
+		await user.click(
+			await screen.findByRole("button", { name: /Enable TOTP/i }),
+		);
+		// user-event installs its own clipboard stub; spy on that instance.
+		vi.spyOn(navigator.clipboard, "writeText").mockRejectedValue(
+			new Error("denied"),
+		);
+		await user.click(
+			await screen.findByRole("button", { name: /Copy TOTP secret/i }),
+		);
+
+		expect(await screen.findByTestId("toast-message")).toHaveTextContent(
+			i18n.t("common.failedToCopy"),
+		);
 	});
 
 	it("copies the secret and recovery codes, and cancels enrollment", async () => {

--- a/web/src/pages/Settings/alerts/DestinationList.tsx
+++ b/web/src/pages/Settings/alerts/DestinationList.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ConfirmDialog } from "../../../components/ConfirmDialog";
+import { CopyButton } from "../../../components/CopyButton";
 import { describeTarget } from "./composers";
 
 // DestinationList renders the saved Apprise targets as one readable row each:
@@ -84,7 +85,14 @@ export function DestinationList({
 							{info.secret || info.url}
 						</code>
 						<span className="flex items-center gap-1.5 ml-auto">
-							<CopyButton url={url} rowName={rowName} />
+							{/* Puts one target URL on the clipboard so it can be pasted
+							    into another Model Hotel or a service's own UI. */}
+							<CopyButton
+								variant="label"
+								text={url}
+								testId="alert-destination-copy"
+								ariaLabel={`${t("common.copy")}: ${rowName}`}
+							/>
 							<button
 								type="button"
 								className="ui-btn ui-btn-secondary"
@@ -127,44 +135,5 @@ export function DestinationList({
 				/>
 			)}
 		</div>
-	);
-}
-
-// CopyButton puts one target URL on the clipboard so it can be pasted into
-// another Model Hotel or a service's own UI. A blocked clipboard is silent; the
-// row text stays selectable.
-function CopyButton({ url, rowName }: { url: string; rowName: string }) {
-	const { t } = useTranslation();
-	const [copied, setCopied] = useState(false);
-	// The "Copied" label reverts on a timer, which has to be dropped if the row
-	// goes first: removing a destination unmounts it, and firing then would set
-	// state on an unmounted button.
-	const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
-	useEffect(
-		() => () => {
-			if (timer.current !== null) clearTimeout(timer.current);
-		},
-		[],
-	);
-	const copy = async () => {
-		try {
-			await navigator.clipboard.writeText(url);
-			setCopied(true);
-			if (timer.current !== null) clearTimeout(timer.current);
-			timer.current = setTimeout(() => setCopied(false), 2000);
-		} catch {
-			/* clipboard blocked: the value stays selectable */
-		}
-	};
-	return (
-		<button
-			type="button"
-			className="ui-btn ui-btn-secondary"
-			data-testid="alert-destination-copy"
-			aria-label={`${t("common.copy")}: ${rowName}`}
-			onClick={copy}
-		>
-			{copied ? t("common.copied") : t("common.copy")}
-		</button>
 	);
 }

--- a/web/src/pages/Settings/alerts/steps.tsx
+++ b/web/src/pages/Settings/alerts/steps.tsx
@@ -1,12 +1,5 @@
 import type { TFunction } from "i18next";
-import {
-	type Dispatch,
-	Fragment,
-	type ReactNode,
-	useEffect,
-	useRef,
-	useState,
-} from "react";
+import { type Dispatch, Fragment, type ReactNode, useState } from "react";
 import {
 	Bell,
 	CheckCircle2,
@@ -24,6 +17,7 @@ import {
 	XCircle,
 } from "@/lib/icons";
 import type { AlertEventDef, AlertStatus } from "../../../api/types";
+import { CopyButton } from "../../../components/CopyButton";
 import { generateTopic } from "../../../utils/ntfy";
 import { AlertEventPicker, eventLabel } from "../AlertEventPicker";
 import {
@@ -835,27 +829,6 @@ function CopyRow({
 	value: string;
 	t: TFunction;
 }) {
-	const [copied, setCopied] = useState(false);
-	// The "Copied" label reverts on a timer, which has to be dropped if the step
-	// is left first: the wizard swaps steps under it, and firing then would set
-	// state on an unmounted row.
-	const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
-	useEffect(
-		() => () => {
-			if (timer.current !== null) clearTimeout(timer.current);
-		},
-		[],
-	);
-	const copy = async () => {
-		try {
-			await navigator.clipboard.writeText(value);
-			setCopied(true);
-			if (timer.current !== null) clearTimeout(timer.current);
-			timer.current = setTimeout(() => setCopied(false), 2000);
-		} catch {
-			/* clipboard blocked: the value stays selectable */
-		}
-	};
 	if (value === "") return null;
 	return (
 		<div className="flex items-center gap-2 flex-wrap">
@@ -866,15 +839,12 @@ function CopyRow({
 			>
 				{value}
 			</code>
-			<button
-				type="button"
-				className="ui-btn ui-btn-secondary"
-				data-testid={testId}
-				aria-label={`${t("common.copy")}: ${label}`}
-				onClick={copy}
-			>
-				{copied ? t("common.copied") : t("common.copy")}
-			</button>
+			<CopyButton
+				variant="label"
+				text={value}
+				testId={testId}
+				ariaLabel={`${t("common.copy")}: ${label}`}
+			/>
 		</div>
 	);
 }

--- a/web/src/pages/VirtualKeys/CreateKeyModal.tsx
+++ b/web/src/pages/VirtualKeys/CreateKeyModal.tsx
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Brain, ChevronRight, RotateCcw } from "@/lib/icons";
+import { BrainSlashIcon, ChevronRight, RotateCcw } from "@/lib/icons";
 import { api } from "../../api/client";
 import type { VirtualKey } from "../../api/types";
 import { CopyablePill } from "../../components/CopyablePill";
@@ -9,26 +9,6 @@ import { Modal } from "../../components/Modal";
 import { Toggle } from "../../components/Toggle";
 import { useIdentity } from "../../context/IdentityContext";
 import { UsageSnippets } from "./UsageSnippets";
-
-function BrainSlashIcon({
-	size = 14,
-	className = "",
-}: {
-	size?: number;
-	className?: string;
-}) {
-	return (
-		<span
-			className={`relative inline-block ${className}`}
-			style={{ width: size, height: size }}
-		>
-			<Brain size={size} />
-			<span className="absolute inset-0 flex items-center justify-center pointer-events-none">
-				<span className="w-full h-[1.5px] bg-current rotate-45" />
-			</span>
-		</span>
-	);
-}
 
 export function CreateKeyModal({
 	onClose,

--- a/web/src/pages/VirtualKeys/KeyDetailModal.tsx
+++ b/web/src/pages/VirtualKeys/KeyDetailModal.tsx
@@ -2,7 +2,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
-	Brain,
+	BrainSlashIcon,
 	CalendarPlus,
 	Clock,
 	Coins,
@@ -44,26 +44,6 @@ function SectionHeader({
 				{label}
 			</span>
 		</div>
-	);
-}
-
-function BrainSlashIcon({
-	size = 14,
-	className = "",
-}: {
-	size?: number;
-	className?: string;
-}) {
-	return (
-		<span
-			className={`relative inline-block ${className}`}
-			style={{ width: size, height: size }}
-		>
-			<Brain size={size} />
-			<span className="absolute inset-0 flex items-center justify-center pointer-events-none">
-				<span className="w-full h-[1.5px] bg-current rotate-45" />
-			</span>
-		</span>
 	);
 }
 

--- a/web/src/utils/__tests__/format.test.ts
+++ b/web/src/utils/__tests__/format.test.ts
@@ -10,6 +10,7 @@ import {
 	formatNumber,
 	formatPercent,
 	formatRelativeTime,
+	formatTime,
 	formatTimestamp,
 	formatTimeUntil,
 	formatTokens,
@@ -217,6 +218,39 @@ describe("formatDate", () => {
 		const now = new Date();
 		const result = formatDate(now.toISOString());
 		expect(result).toContain(now.getFullYear().toString());
+	});
+});
+
+describe("formatTime", () => {
+	it("formats timestamp as HH:MM", () => {
+		const ts = new Date("2024-01-15T14:30:00Z").getTime();
+		const result = formatTime(ts);
+
+		expect(result).toMatch(/\d{1,2}:\d{2}/);
+		expect(result).toContain(":");
+	});
+
+	it("formats midnight correctly", () => {
+		const ts = new Date("2024-01-15T00:00:00Z").getTime();
+		const result = formatTime(ts);
+
+		// Matches 00:00 (24h) or 12:00 AM (12h)
+		expect(result).toMatch(/00:00|12:00\s*AM/i);
+	});
+
+	it("formats noon correctly", () => {
+		const ts = new Date("2024-01-15T12:00:00Z").getTime();
+		const result = formatTime(ts);
+
+		// Matches 12:00 (24h) or 12:00 PM (12h)
+		expect(result).toMatch(/12:00/);
+	});
+
+	it("accepts a date string as well as a numeric timestamp", () => {
+		const result = formatTime("2024-01-15T14:30:00Z");
+
+		expect(typeof result).toBe("string");
+		expect(result).toContain(":");
 	});
 });
 

--- a/web/src/utils/format.ts
+++ b/web/src/utils/format.ts
@@ -78,6 +78,14 @@ export function formatDate(ts: number | string): string {
 	});
 }
 
+/** Clock time alone, in the browser's locale and its 12/24-hour convention. */
+export function formatTime(ts: number | string): string {
+	return new Date(ts).toLocaleTimeString(undefined, {
+		hour: "2-digit",
+		minute: "2-digit",
+	});
+}
+
 export function formatDateTimeShort(ts: number | string): string {
 	return new Date(ts).toLocaleDateString(undefined, {
 		day: "numeric",

--- a/web/src/utils/logBadgeUtils.test.ts
+++ b/web/src/utils/logBadgeUtils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
-	formatTimestamp,
+	formatLogTimestamp,
 	getLevelBadgeVariant,
 	getSourceBadgeClasses,
 } from "./logBadgeUtils";
@@ -203,9 +203,9 @@ describe("getSourceBadgeClasses", () => {
 	});
 });
 
-describe("formatTimestamp", () => {
+describe("formatLogTimestamp", () => {
 	it("formats valid ISO date string", () => {
-		const result = formatTimestamp("2024-01-15T10:30:45Z");
+		const result = formatLogTimestamp("2024-01-15T10:30:45Z");
 		expect(result).toBe(
 			new Date("2024-01-15T10:30:45Z").toLocaleString("en-US", {
 				year: "numeric",
@@ -220,12 +220,12 @@ describe("formatTimestamp", () => {
 	});
 
 	it("returns original string for invalid date", () => {
-		const result = formatTimestamp("not-a-date");
+		const result = formatLogTimestamp("not-a-date");
 		expect(result).toBe("not-a-date");
 	});
 
 	it("returns original string for empty string", () => {
-		const result = formatTimestamp("");
+		const result = formatLogTimestamp("");
 		expect(result).toBe("");
 	});
 });

--- a/web/src/utils/logBadgeUtils.ts
+++ b/web/src/utils/logBadgeUtils.ts
@@ -78,7 +78,11 @@ export const getSourceBadgeClasses = (source: string) => {
 	}
 };
 
-export const formatTimestamp = (ts: string) => {
+// Log-row stamp: fixed-width 24-hour date and time down to the second, so rows
+// line up in the log tables. An unparsable value is passed through as it came.
+// Distinct from utils/format's formatTimestamp, which is the locale-short form
+// used everywhere else.
+export const formatLogTimestamp = (ts: string) => {
 	try {
 		const d = new Date(ts);
 		if (Number.isNaN(d.getTime())) {


### PR DESCRIPTION
## Summary

Second batch of the dedupe sweep: dashboard (`web/`) pages that kept private copies of helpers the shared modules already provide.

- **`hooks/useCopyToClipboard`**: one hook (write, `copied` flag, reset timer cleared on unmount and re-copy, failure swallowed and reported) behind every `navigator.clipboard.writeText` in the dashboard. `CopyButton` gained `variant="label"` (Copy/Copied swap) plus `ariaLabel`/`testId`, so the alerts destination list and wizard rows drop their private buttons with identical test ids and labels.
- **`BrainSlashIcon`** moves from two VirtualKeys modals into `lib/icons.tsx`.
- **`ArenaHistoryModal`** uses `utils/format.ts` `formatDate`/`formatTime` (`formatTime` moved there from `chatStreaming.ts`).
- **Dashboard chart bucket label** extracted from three copies (two in `useDashboard`, one in `GaugeModal`) into one helper.
- **`useLocalStorage`** adoption for the boolean toggles that own their key (`CollapsibleToggle`, `sidebarQuotaCollapsed`), plus a read-only **`useLocalStorageValue`** (built on `useSyncExternalStore`: subscribes to `storage` and the same-tab `localStorageChange` event, never writes, cannot recurse, re-reads when key/fallback/deserializer change) for the three mirrors of keys other screens own (`sidebarQuotaDisabled`, `quota-bar-mode`, `dashboardRefreshSec`), replacing their private listeners.
- **`formatLogTimestamp`** replaces the second `formatTimestamp` (different format, same name) in `logBadgeUtils`.
- **Layout's private JSX formatters** (`formatDuration`/`formatNumber`/`formatMB`/`formatBytesPerSec`) move out of `Layout.tsx` into their own module with the repeated value+unit markup deduplicated; the maths is unchanged.

## User-visible deltas (intentional)

- `GaugeModal` chart labels use the browser locale like the rest of the dashboard (it hardcoded `en-US`).
- `dashboardRefreshSec` now also follows cross-tab changes like the other two mirrors.
- On the backup page a rejected clipboard write toasts the translated "failed to copy" text instead of a raw `DOMException` message.

## Verification

- 5931 vitest tests green (0 skips), `tsc -b` clean, `pnpm lint` and Biome clean, `make i18n-check` OK (no new keys); changed-line coverage 100%.
- Dev stack rebuilt from this branch: container healthy, admin/proxy endpoint smoke green, dashboard bundle serves.
- Independent Opus review of the branch; all findings addressed before opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
