### PR TITLE
fix(frontdesk): join the auto-sync rearm watcher and drain the server on shutdown

### DIFF
--- a/cmd/frontdesk/main.go
+++ b/cmd/frontdesk/main.go
@@ -153,12 +153,15 @@ func main() {
 		CookieSecure: config.NormalizeCookieSecure(os.Getenv("COOKIE_SECURE")),
 	})
 
-	go poller.Run(ctx)
-	go srv.RunAutoSync(ctx)
-	go srv.RunQuotaDistribute(ctx)
-	go srv.RunFleetState(ctx)
-	go srv.RunBackupWatch(ctx)
-	go srv.RunAlerts(ctx)
+	// Every process-lifetime loop runs on the server's background group, so the
+	// drain below joins them before the store closes. Each returns when ctx is
+	// done, which the signal handler above does on SIGINT/SIGTERM.
+	srv.StartBackground(ctx, poller.Run)
+	srv.StartBackground(ctx, srv.RunAutoSync)
+	srv.StartBackground(ctx, srv.RunQuotaDistribute)
+	srv.StartBackground(ctx, srv.RunFleetState)
+	srv.StartBackground(ctx, srv.RunBackupWatch)
+	srv.StartBackground(ctx, srv.RunAlerts)
 
 	httpServer := &http.Server{
 		Addr:              port,
@@ -184,6 +187,16 @@ func main() {
 	if err := httpServer.Shutdown(shutdownCtx); err != nil {
 		debuglog.Error("frontdesk: graceful shutdown failed", "error", err)
 	}
+	// Nothing accepts requests any more, so no new background work can start:
+	// drain what is in flight and close the store. Its own budget, not
+	// shutdownCtx, which the HTTP drain may already have spent. Bounded, so a
+	// loop that ignores its cancellation delays exit rather than hanging it.
+	drainCtx, drainCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer drainCancel()
+	if err := srv.Shutdown(drainCtx); err != nil {
+		debuglog.Error("frontdesk: store shutdown failed", "error", err)
+	}
+	debuglog.Info("frontdesk: stopped")
 	// Flush and close the OTLP log exporter so batched records aren't lost. Use a
 	// fresh context, not shutdownCtx: a slow HTTP drain can consume most or all of
 	// that budget, leaving the exporter no time to flush (or an already-expired

--- a/cmd/frontdesk/main.go
+++ b/cmd/frontdesk/main.go
@@ -101,7 +101,9 @@ func main() {
 	if err != nil {
 		debuglog.Fatal("frontdesk: failed to open store", "error", err)
 	}
-	defer func() { _ = store.Close() }()
+	// No deferred close: srv.Shutdown owns the store from here (it closes it after
+	// draining), and every bail-out below is debuglog.Fatal, which is os.Exit and
+	// runs no defers. A deferred close would only ever be a second, redundant one.
 
 	adminMgr, isNew, err := admin.New(dataDir, os.Getenv("FRONTDESK_TOKEN"))
 	if err != nil {
@@ -191,7 +193,11 @@ func main() {
 	// drain what is in flight and close the store. Its own budget, not
 	// shutdownCtx, which the HTTP drain may already have spent. Bounded, so a
 	// loop that ignores its cancellation delays exit rather than hanging it.
-	drainCtx, drainCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	// 5s, not the HTTP drain's 10s: every loop returns on ctx within a tick, so the
+	// budget only has to absorb a straggler. It keeps the worst case (10s HTTP + 5s
+	// drain + 5s OTLP flush) at cmd/server's shape plus the drain, which the
+	// stop_grace_period on the front-desk service in deploy/ha covers.
+	drainCtx, drainCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer drainCancel()
 	if err := srv.Shutdown(drainCtx); err != nil {
 		debuglog.Error("frontdesk: store shutdown failed", "error", err)

--- a/deploy/ha/docker-compose.yml
+++ b/deploy/ha/docker-compose.yml
@@ -79,6 +79,13 @@ services:
                 COMMIT: ${COMMIT:-unknown}
         # Prebuilt image (uncomment to pin a published tag instead of building):
         # image: ghcr.io/hugalafutro/model-hotel-frontdesk:latest
+        # Front Desk winds down in stages on SIGTERM: up to 10s draining HTTP
+        # (an open SSE tab ends at once, so this is usually instant), up to 5s
+        # joining the background poll loops before the SQLite store closes, and
+        # up to 5s flushing the OTLP log exporter. Docker's default grace is 10s,
+        # which would SIGKILL partway through and cut off both the store close and
+        # the final log lines.
+        stop_grace_period: 30s
         labels:
             app.group: model-hotel-ha
         environment:

--- a/internal/frontdesk/autosync.go
+++ b/internal/frontdesk/autosync.go
@@ -371,15 +371,15 @@ func (s *Server) applyAutoSync(ctx context.Context, primary *Member, primaryToke
 	// passCtx is the cancellation point the pre-import gates cannot provide: a
 	// watcher cancels it the instant a rearm moves the generation, aborting an
 	// import already in flight. Every member HTTP call below runs under it, and the
-	// deferred cancel stops the watcher when the pass returns.
+	// deferred stop cancels the watcher and waits for it when the pass returns.
 	//
 	// rearmCh is captured before watchRearm re-reads the generation, so a rearm
 	// landing in that gap still wakes the watcher: the channel is closed, not
 	// missed.
 	rearmCh := s.rearmChan()
 	passCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	go s.watchRearm(passCtx, rearmCh, gen, cancel)
+	stopWatch := s.startRearmWatch(passCtx, rearmCh, gen, cancel)
+	defer stopWatch()
 
 	// The primary's export is fetched on demand: a settled fleet never needs it, and
 	// building and shipping the whole envelope every tick is the bulk of what an idle
@@ -1133,6 +1133,33 @@ func (s *Server) resetIncompleteRetries() {
 	}
 }
 
+// startRearmWatch spawns a pass's rearm watcher and returns the stop func that
+// cancels it and blocks until it has returned.
+//
+// The pass joins the watcher rather than merely cancelling it because the watcher
+// reads the store: a pass that returned while its watcher was still in flight
+// would leave that read owned by nobody. Cancelling is not enough on its own,
+// since a goroutine that has already entered a query does not observe the cancel
+// until it comes back out. Everything that waits for a pass therefore waits for
+// the watcher too: the tick loop in RunAutoSync, the enable-time kick's drain via
+// Server.Wait, and a test tearing down the store its temp dir holds. Without the
+// join, that store read outlives the store and races its Close and the removal of
+// its directory.
+//
+// cancel is the pass's own context cancel and is idempotent, so the ordinary case
+// where the watcher cancels on a rearm and stop then cancels again is harmless.
+func (s *Server) startRearmWatch(ctx context.Context, rearmCh <-chan struct{}, gen int64, cancel context.CancelFunc) (stop func()) {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		s.watchRearm(ctx, rearmCh, gen, cancel)
+	}()
+	return func() {
+		cancel()
+		<-done
+	}
+}
+
 // watchRearm cancels a convergence pass the moment its rearm generation goes
 // stale, so a rearm landing while applyMemberConfig is mid-flight aborts the HTTP
 // request instead of finishing a now-stale write.
@@ -1141,8 +1168,9 @@ func (s *Server) resetIncompleteRetries() {
 // synchronous with the generation bump rather than gated on a poll. The generation
 // is re-read first to close the gap between the caller capturing gen and this
 // watcher starting, where the channel close may predate the capture. The watcher
-// exits as soon as ctx is done, so it never outlives the pass. A transient read
-// error is ignored; the pass's own stale() gates remain.
+// exits as soon as ctx is done, and startRearmWatch's stop waits for that exit, so
+// it never outlives the pass. A transient read error is ignored; the pass's own
+// stale() gates remain.
 func (s *Server) watchRearm(ctx context.Context, rearmCh <-chan struct{}, gen int64, cancel context.CancelFunc) {
 	if cur, err := s.store.AutoSyncGen(ctx); err == nil && cur != gen {
 		cancel()

--- a/internal/frontdesk/autosync.go
+++ b/internal/frontdesk/autosync.go
@@ -1133,59 +1133,6 @@ func (s *Server) resetIncompleteRetries() {
 	}
 }
 
-// startRearmWatch spawns a pass's rearm watcher and returns the stop func that
-// cancels it and blocks until it has returned.
-//
-// The pass joins the watcher rather than merely cancelling it because the watcher
-// reads the store: a pass that returned while its watcher was still in flight
-// would leave that read owned by nobody. Cancelling is not enough on its own,
-// since a goroutine that has already entered a query does not observe the cancel
-// until it comes back out. Everything that waits for a pass therefore waits for
-// the watcher too: the tick loop in RunAutoSync, the enable-time kick's drain via
-// Server.Wait, and a test tearing down the store its temp dir holds. Without the
-// join, that store read outlives the store and races its Close and the removal of
-// its directory.
-//
-// cancel is the pass's own context cancel and is idempotent, so the ordinary case
-// where the watcher cancels on a rearm and stop then cancels again is harmless.
-func (s *Server) startRearmWatch(ctx context.Context, rearmCh <-chan struct{}, gen int64, cancel context.CancelFunc) (stop func()) {
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		s.watchRearm(ctx, rearmCh, gen, cancel)
-	}()
-	return func() {
-		cancel()
-		<-done
-	}
-}
-
-// watchRearm cancels a convergence pass the moment its rearm generation goes
-// stale, so a rearm landing while applyMemberConfig is mid-flight aborts the HTTP
-// request instead of finishing a now-stale write.
-//
-// rearmCh is the in-process broadcast closed by signalRearm, so the wake is
-// synchronous with the generation bump rather than gated on a poll. The generation
-// is re-read first to close the gap between the caller capturing gen and this
-// watcher starting, where the channel close may predate the capture. The watcher
-// exits as soon as ctx is done, and startRearmWatch's stop waits for that exit, so
-// it never outlives the pass. A transient read error is ignored; the pass's own
-// stale() gates remain.
-func (s *Server) watchRearm(ctx context.Context, rearmCh <-chan struct{}, gen int64, cancel context.CancelFunc) {
-	if cur, err := s.store.AutoSyncGen(ctx); err == nil && cur != gen {
-		cancel()
-		return
-	}
-	select {
-	case <-ctx.Done():
-	case <-rearmCh:
-		// A rearm broadcast woke us: the fleet's sync inputs changed (a gen-bumping
-		// rearm/repoint, or a disband that cleared the designation without touching
-		// the gen), so this pass is stale either way: cancel it.
-		cancel()
-	}
-}
-
 // fetchMemberConfigVersion reads a member's syncable-config hash from
 // GET /api/config/version. The hash changes if and only if a synced entity changed,
 // and every member computes it over the same deterministically ordered payload, so

--- a/internal/frontdesk/autosync_rearm.go
+++ b/internal/frontdesk/autosync_rearm.go
@@ -1,0 +1,56 @@
+package frontdesk
+
+import "context"
+
+// startRearmWatch spawns a pass's rearm watcher and returns the stop func that
+// cancels it and blocks until it has returned.
+//
+// The pass joins the watcher rather than merely cancelling it because the watcher
+// reads the store: a pass that returned while its watcher was still in flight
+// would leave that read owned by nobody. Cancelling is not enough on its own,
+// since a goroutine that has already entered a query does not observe the cancel
+// until it comes back out. Everything that waits for a pass therefore waits for
+// the watcher too: the tick loop in RunAutoSync, the enable-time kick's drain via
+// Server.Wait, and a test tearing down the store its temp dir holds. Without the
+// join, that store read outlives the store and races its Close and the removal of
+// its directory.
+//
+// cancel is the pass's own context cancel and is idempotent, so the ordinary case
+// where the watcher cancels on a rearm and stop then cancels again is harmless.
+func (s *Server) startRearmWatch(ctx context.Context, rearmCh <-chan struct{}, gen int64, cancel context.CancelFunc) (stop func()) {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		s.watchRearm(ctx, rearmCh, gen, cancel)
+	}()
+	return func() {
+		cancel()
+		<-done
+	}
+}
+
+// watchRearm cancels a convergence pass the moment its rearm generation goes
+// stale, so a rearm landing while applyMemberConfig is mid-flight aborts the HTTP
+// request instead of finishing a now-stale write.
+//
+// rearmCh is the in-process broadcast closed by signalRearm, so the wake is
+// synchronous with the generation bump rather than gated on a poll. The generation
+// is re-read first to close the gap between the caller capturing gen and this
+// watcher starting, where the channel close may predate the capture. The watcher
+// exits as soon as ctx is done, and startRearmWatch's stop waits for that exit, so
+// it never outlives the pass. A transient read error is ignored; the pass's own
+// stale() gates remain.
+func (s *Server) watchRearm(ctx context.Context, rearmCh <-chan struct{}, gen int64, cancel context.CancelFunc) {
+	if cur, err := s.store.AutoSyncGen(ctx); err == nil && cur != gen {
+		cancel()
+		return
+	}
+	select {
+	case <-ctx.Done():
+	case <-rearmCh:
+		// A rearm broadcast woke us: the fleet's sync inputs changed (a gen-bumping
+		// rearm/repoint, or a disband that cleared the designation without touching
+		// the gen), so this pass is stale either way: cancel it.
+		cancel()
+	}
+}

--- a/internal/frontdesk/autosync_rearm_test.go
+++ b/internal/frontdesk/autosync_rearm_test.go
@@ -1,0 +1,66 @@
+package frontdesk
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestRearmWatchStopJoinsTheWatcher: the watcher reads the store, so a pass must
+// join it, not merely cancel it. Cancelling alone lets a watcher that is already
+// inside a query keep reading after the pass returned, past everything that waits
+// on the pass, and that read then races the store's Close and the removal of the
+// directory holding its database.
+//
+// The watcher is parked inside the cancel it calls on the rearm broadcast, which
+// stands in for it being mid-query. stop must not return while it sits there.
+func TestRearmWatchStopJoinsTheWatcher(t *testing.T) {
+	srv, store := newTestServer(t)
+	gen, err := store.AutoSyncGen(t.Context())
+	if err != nil {
+		t.Fatalf("AutoSyncGen: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	rearmCh := make(chan struct{})
+	inCancel := make(chan struct{})
+	release := make(chan struct{})
+	// Releasing on the way out as well as on the happy path keeps a failing run from
+	// leaving the watcher parked forever.
+	releaseWatcher := sync.OnceFunc(func() { close(release) })
+	defer releaseWatcher()
+	// cancel is called twice in the ordinary flow (the watcher on the rearm, then
+	// stop), so only the first call parks: the second must return so stop can get
+	// as far as waiting on the watcher.
+	var parked atomic.Bool
+	stop := srv.startRearmWatch(ctx, rearmCh, gen, func() {
+		if parked.CompareAndSwap(false, true) {
+			close(inCancel)
+			<-release
+		}
+		cancel()
+	})
+
+	close(rearmCh) // the rearm broadcast: wakes the watcher into cancel
+	<-inCancel     // the watcher is running and has not returned
+
+	stopped := make(chan struct{})
+	go func() {
+		stop()
+		close(stopped)
+	}()
+	// An unjoined watcher makes stop return immediately; a joined one cannot
+	// return until the watcher is released below. The window only has to outlast
+	// a goroutine handoff.
+	select {
+	case <-stopped:
+		t.Fatal("stop returned while the rearm watcher was still running")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	releaseWatcher()
+	<-stopped
+}

--- a/internal/frontdesk/autosync_test.go
+++ b/internal/frontdesk/autosync_test.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -533,6 +534,63 @@ func TestConvergeFleetCancelsImportInFlightOnRearm(t *testing.T) {
 	if replica.didRealSync() {
 		t.Error("in-flight import committed after a rearm; want the request cancelled before commit")
 	}
+}
+
+// TestRearmWatchStopJoinsTheWatcher: the watcher reads the store, so a pass must
+// join it, not merely cancel it. Cancelling alone lets a watcher that is already
+// inside a query keep reading after the pass returned, past everything that waits
+// on the pass, and that read then races the store's Close and the removal of the
+// directory holding its database.
+//
+// The watcher is parked inside the cancel it calls on the rearm broadcast, which
+// stands in for it being mid-query. stop must not return while it sits there.
+func TestRearmWatchStopJoinsTheWatcher(t *testing.T) {
+	srv, store := newTestServer(t)
+	gen, err := store.AutoSyncGen(t.Context())
+	if err != nil {
+		t.Fatalf("AutoSyncGen: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	rearmCh := make(chan struct{})
+	inCancel := make(chan struct{})
+	release := make(chan struct{})
+	// Releasing on the way out as well as on the happy path keeps a failing run from
+	// leaving the watcher parked forever.
+	releaseWatcher := sync.OnceFunc(func() { close(release) })
+	defer releaseWatcher()
+	// cancel is called twice in the ordinary flow (the watcher on the rearm, then
+	// stop), so only the first call parks: the second must return so stop can get
+	// as far as waiting on the watcher.
+	var parked atomic.Bool
+	stop := srv.startRearmWatch(ctx, rearmCh, gen, func() {
+		if parked.CompareAndSwap(false, true) {
+			close(inCancel)
+			<-release
+		}
+		cancel()
+	})
+
+	close(rearmCh) // the rearm broadcast: wakes the watcher into cancel
+	<-inCancel     // the watcher is running and has not returned
+
+	stopped := make(chan struct{})
+	go func() {
+		stop()
+		close(stopped)
+	}()
+	// An unjoined watcher makes stop return immediately; a joined one cannot
+	// return until the watcher is released below. The window only has to outlast
+	// a goroutine handoff.
+	select {
+	case <-stopped:
+		t.Fatal("stop returned while the rearm watcher was still running")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	releaseWatcher()
+	<-stopped
 }
 
 // TestAutoSyncSkipsConvergedMember: a member already serving the primary's hash

--- a/internal/frontdesk/autosync_test.go
+++ b/internal/frontdesk/autosync_test.go
@@ -12,7 +12,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -534,63 +533,6 @@ func TestConvergeFleetCancelsImportInFlightOnRearm(t *testing.T) {
 	if replica.didRealSync() {
 		t.Error("in-flight import committed after a rearm; want the request cancelled before commit")
 	}
-}
-
-// TestRearmWatchStopJoinsTheWatcher: the watcher reads the store, so a pass must
-// join it, not merely cancel it. Cancelling alone lets a watcher that is already
-// inside a query keep reading after the pass returned, past everything that waits
-// on the pass, and that read then races the store's Close and the removal of the
-// directory holding its database.
-//
-// The watcher is parked inside the cancel it calls on the rearm broadcast, which
-// stands in for it being mid-query. stop must not return while it sits there.
-func TestRearmWatchStopJoinsTheWatcher(t *testing.T) {
-	srv, store := newTestServer(t)
-	gen, err := store.AutoSyncGen(t.Context())
-	if err != nil {
-		t.Fatalf("AutoSyncGen: %v", err)
-	}
-
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-	rearmCh := make(chan struct{})
-	inCancel := make(chan struct{})
-	release := make(chan struct{})
-	// Releasing on the way out as well as on the happy path keeps a failing run from
-	// leaving the watcher parked forever.
-	releaseWatcher := sync.OnceFunc(func() { close(release) })
-	defer releaseWatcher()
-	// cancel is called twice in the ordinary flow (the watcher on the rearm, then
-	// stop), so only the first call parks: the second must return so stop can get
-	// as far as waiting on the watcher.
-	var parked atomic.Bool
-	stop := srv.startRearmWatch(ctx, rearmCh, gen, func() {
-		if parked.CompareAndSwap(false, true) {
-			close(inCancel)
-			<-release
-		}
-		cancel()
-	})
-
-	close(rearmCh) // the rearm broadcast: wakes the watcher into cancel
-	<-inCancel     // the watcher is running and has not returned
-
-	stopped := make(chan struct{})
-	go func() {
-		stop()
-		close(stopped)
-	}()
-	// An unjoined watcher makes stop return immediately; a joined one cannot
-	// return until the watcher is released below. The window only has to outlast
-	// a goroutine handoff.
-	select {
-	case <-stopped:
-		t.Fatal("stop returned while the rearm watcher was still running")
-	case <-time.After(50 * time.Millisecond):
-	}
-
-	releaseWatcher()
-	<-stopped
 }
 
 // TestAutoSyncSkipsConvergedMember: a member already serving the primary's hash

--- a/internal/frontdesk/configsync.go
+++ b/internal/frontdesk/configsync.go
@@ -142,6 +142,10 @@ func (d memberConfigDiff) counts() (added, updated, removed int) {
 // answered badly) rather than a store error.
 var errPrimaryExportUnreadable = errors.New("could not read the primary's config")
 
+// syncInterruptedCode is the stable code on the answer to a run shutdown cut
+// short, so a client can route on it instead of matching the English message.
+const syncInterruptedCode = "sync_interrupted"
+
 // configSyncRun is one manual sync run's outcome, handed back to the handler
 // parked on it: the per-member results, or the error that ended the run before
 // any member was touched.
@@ -149,6 +153,38 @@ type configSyncRun struct {
 	primaryID string
 	results   []syncResultItem
 	err       error
+	// interrupted marks a run the server's shutdown ended before it finished, so
+	// results covers only part of the fleet. It is answered as a 503 rather than a
+	// 200: the wizard reads a 200 as the whole run and would report "N of N synced"
+	// for a fleet whose remaining members were never touched.
+	interrupted bool
+	// notAttempted counts the syncable members the run never reached. Zero on an
+	// interrupted run whose last member was the one cut off mid-push.
+	notAttempted int
+}
+
+// interruptedMessage names what the operator is looking at: a partial run, how
+// much of the fleet it never reached, and what to do about it. It reaches the UI
+// as the error text of the 503, so it is written for a person.
+func (run configSyncRun) interruptedMessage() string {
+	msg := "front desk began shutting down during the sync, so it did not finish"
+	if run.notAttempted > 0 {
+		msg += fmt.Sprintf("; %d member(s) were not attempted", run.notAttempted)
+	}
+	return msg + ". Run the sync again once front desk is back."
+}
+
+// syncableCount counts the members a run still owes a push: the primary is the
+// source and a token-less member is skipped without a result, so neither is
+// something the operator is waiting on.
+func syncableCount(members []*Member, primaryID string) int {
+	n := 0
+	for _, m := range members {
+		if m.ID != primaryID && m.HasToken {
+			n++
+		}
+	}
+	return n
 }
 
 // configSync pulls the primary's config and applies it to every other member
@@ -192,6 +228,16 @@ func (s *Server) configSync(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, run.err.Error(), http.StatusBadGateway)
 	case run.err != nil:
 		writeError(w, run.err)
+	case run.interrupted:
+		// The coded-error shape (code + error), with the partial results alongside
+		// it: a caller that only reads the message still learns the run was cut
+		// short and how much of the fleet it never reached, and one that reads the
+		// body still sees what did happen. Not a 200, which would be read as a
+		// complete run of a fleet this size.
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{
+			"code": syncInterruptedCode, "error": run.interruptedMessage(),
+			"primary_id": run.primaryID, "results": run.results,
+		})
 	default:
 		writeJSON(w, http.StatusOK, map[string]any{"primary_id": run.primaryID, "results": run.results})
 	}
@@ -245,13 +291,17 @@ func (s *Server) runConfigSync(ctx context.Context, primaryID string) configSync
 
 	primaryBuild := s.poller.memberBuildOf(primary.ID)
 	results := make([]syncResultItem, 0)
-	for _, m := range members {
+	notAttempted := 0
+	for i, m := range members {
 		if ctx.Err() != nil {
 			// The server is shutting down. Stop between members rather than push a
 			// config whose outcome nothing can record: the store is waiting on this
-			// goroutine to close, and the members left over are reported unsynced,
-			// which is what they are. The operator re-runs the sync after the restart.
-			debuglog.Info("frontdesk: manual config sync stopped by shutdown", "primary", primary.Name)
+			// goroutine to close. The members left here go unattempted and are
+			// counted, not silently dropped, so the answer can say how much of the
+			// fleet this run never reached.
+			notAttempted = syncableCount(members[i:], primary.ID)
+			debuglog.Info("frontdesk: manual config sync stopped by shutdown",
+				"primary", primary.Name, "not_attempted", notAttempted)
 			break
 		}
 		if m.ID == primary.ID || !m.HasToken {
@@ -279,12 +329,21 @@ func (s *Server) runConfigSync(ctx context.Context, primaryID string) configSync
 		}
 		results = append(results, s.applyMemberConfig(ctx, m, token, export, reason, true, gen, pushedHash))
 	}
-	// The run marker is a write like any other, so it is skipped once the server is
-	// going: a cancelled run is not a run the fleet's staleness watchdog should
-	// count, and the store it would be written to is about to close.
-	if ctx.Err() == nil {
-		s.recordFleetSyncRun(ctx, primary, results)
+	// Checked again after the loop, because a run can be cut short without ever
+	// reaching the guard above: the member being pushed when shutdown lands takes
+	// the cancellation on its own HTTP call, and the loop then ends of its own
+	// accord with nothing left to skip. Either way the run did not finish, so it
+	// reports itself interrupted rather than as a clean sweep of the fleet.
+	//
+	// The run marker is skipped with it. It is a write like any other, and a
+	// cancelled run is not a run the fleet's staleness watchdog should count.
+	if ctx.Err() != nil {
+		return configSyncRun{
+			primaryID: primary.ID, results: results,
+			interrupted: true, notAttempted: notAttempted,
+		}
 	}
+	s.recordFleetSyncRun(ctx, primary, results)
 	return configSyncRun{primaryID: primary.ID, results: results}
 }
 

--- a/internal/frontdesk/configsync.go
+++ b/internal/frontdesk/configsync.go
@@ -135,9 +135,33 @@ func (d memberConfigDiff) counts() (added, updated, removed int) {
 	return added, updated, removed
 }
 
+// errPrimaryExportUnreadable stops a run before any member is touched: the
+// primary's config could not be read, so there is nothing to push. It is a
+// sentinel rather than a message because the run happens away from the handler
+// that renders it, and this is the one failure that is a 502 (the primary
+// answered badly) rather than a store error.
+var errPrimaryExportUnreadable = errors.New("could not read the primary's config")
+
+// configSyncRun is one manual sync run's outcome, handed back to the handler
+// parked on it: the per-member results, or the error that ended the run before
+// any member was touched.
+type configSyncRun struct {
+	primaryID string
+	results   []syncResultItem
+	err       error
+}
+
 // configSync pulls the primary's config and applies it to every other member
 // Front Desk can authenticate to. Each member is independent: a failure leaves
 // that member untouched and is reported.
+//
+// The run itself happens on a goroutine registered with the server's background
+// group, and the handler parks on it so the operator still gets the per-member
+// results on this request. Detaching the run from the request context is what
+// keeps a client with a short HTTP timeout (Bellhop, a proxy) from cancelling
+// member imports, event emits and sync stamps half-way; registering it is what
+// keeps that same detached run from outliving Shutdown's drain and recording
+// itself against a closed store.
 func (s *Server) configSync(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		PrimaryID string `json:"primary_id"`
@@ -145,31 +169,58 @@ func (s *Server) configSync(w http.ResponseWriter, r *http.Request) {
 	if !decodeJSON(w, r, &req) {
 		return
 	}
-	// Once the sync is requested it runs to completion detached from the
-	// client's connection: a caller with a short HTTP timeout (Bellhop, a
-	// proxy) hanging up would otherwise cancel r.Context() mid-run and abort
-	// member imports, event emits and sync stamps half-way, leaving no trace
-	// of the run at all.
-	ctx := context.WithoutCancel(r.Context())
-	// Attribute the run to whoever authenticated it (a paired device or the
-	// dashboard). WithoutCancel keeps the context values, so the device is still
-	// resolvable off ctx. Stamped on each member and carried in the audit event.
-	reason := manualSyncReason(actorFromContext(ctx))
-	primary, primaryToken, err := s.memberTokenOrErr(ctx, req.PrimaryID)
-	if err != nil {
-		writeError(w, err)
+
+	var run configSyncRun
+	done := make(chan struct{})
+	if !s.StartBackground(s.detachedContext(r), func(ctx context.Context) {
+		defer close(done)
+		run = s.runConfigSync(ctx, req.PrimaryID)
+	}) {
+		// Shutdown has begun. The auto-sync kick simply goes unfired at this point;
+		// here the run is the response, so say so instead: a fleet-wide write started
+		// now would be cancelled a moment later with nowhere to record what it did.
+		http.Error(w, "front desk is shutting down; run the sync again once it is back", http.StatusServiceUnavailable)
 		return
+	}
+	// Bounded by the run itself: every member call carries the sync client's
+	// deadline, and the server's lifetime ends the whole run at shutdown, which is
+	// the same goroutine the drain is waiting on.
+	<-done
+
+	switch {
+	case errors.Is(run.err, errPrimaryExportUnreadable):
+		http.Error(w, run.err.Error(), http.StatusBadGateway)
+	case run.err != nil:
+		writeError(w, run.err)
+	default:
+		writeJSON(w, http.StatusOK, map[string]any{"primary_id": run.primaryID, "results": run.results})
+	}
+}
+
+// runConfigSync is the manual sync run: pull the primary's config, push it to
+// every other member, record the run. It carries no ResponseWriter because it
+// executes on the server's background group rather than on the handler's
+// goroutine; the handler renders what it returns.
+//
+// ctx ends when the server shuts down, so a fleet-wide push stops between
+// members rather than continuing into a store that is about to close.
+func (s *Server) runConfigSync(ctx context.Context, primaryID string) configSyncRun {
+	// Attribute the run to whoever authenticated it (a paired device or the
+	// dashboard). The detached context keeps the request's values, so the device is
+	// still resolvable off ctx. Stamped on each member and carried in the audit event.
+	reason := manualSyncReason(actorFromContext(ctx))
+	primary, primaryToken, err := s.memberTokenOrErr(ctx, primaryID)
+	if err != nil {
+		return configSyncRun{err: err}
 	}
 	export, err := s.fetchMemberExport(ctx, primary, primaryToken)
 	if err != nil {
-		http.Error(w, "could not read the primary's config", http.StatusBadGateway)
-		return
+		return configSyncRun{err: errPrimaryExportUnreadable}
 	}
 
 	members, err := s.store.ListMembers(ctx)
 	if err != nil {
-		writeError(w, err)
-		return
+		return configSyncRun{err: err}
 	}
 
 	// Stamp this manual sync with the current source generation so it advances the
@@ -179,8 +230,7 @@ func (s *Server) configSync(w http.ResponseWriter, r *http.Request) {
 	// auto-sync applied, and an equal generation still applies (not refused).
 	gen, err := s.store.AutoSyncGen(ctx)
 	if err != nil {
-		writeError(w, err)
-		return
+		return configSyncRun{err: err}
 	}
 
 	// The primary's config hash keys any lost-answer push so a later verification
@@ -196,6 +246,14 @@ func (s *Server) configSync(w http.ResponseWriter, r *http.Request) {
 	primaryBuild := s.poller.memberBuildOf(primary.ID)
 	results := make([]syncResultItem, 0)
 	for _, m := range members {
+		if ctx.Err() != nil {
+			// The server is shutting down. Stop between members rather than push a
+			// config whose outcome nothing can record: the store is waiting on this
+			// goroutine to close, and the members left over are reported unsynced,
+			// which is what they are. The operator re-runs the sync after the restart.
+			debuglog.Info("frontdesk: manual config sync stopped by shutdown", "primary", primary.Name)
+			break
+		}
 		if m.ID == primary.ID || !m.HasToken {
 			continue // the source, and token-less members (flagged in preview), are skipped
 		}
@@ -221,8 +279,13 @@ func (s *Server) configSync(w http.ResponseWriter, r *http.Request) {
 		}
 		results = append(results, s.applyMemberConfig(ctx, m, token, export, reason, true, gen, pushedHash))
 	}
-	s.recordFleetSyncRun(ctx, primary, results)
-	writeJSON(w, http.StatusOK, map[string]any{"primary_id": primary.ID, "results": results})
+	// The run marker is a write like any other, so it is skipped once the server is
+	// going: a cancelled run is not a run the fleet's staleness watchdog should
+	// count, and the store it would be written to is about to close.
+	if ctx.Err() == nil {
+		s.recordFleetSyncRun(ctx, primary, results)
+	}
+	return configSyncRun{primaryID: primary.ID, results: results}
 }
 
 // prepareMemberSync runs the dry-run that gates the wizard's destructive replace

--- a/internal/frontdesk/configsync_shutdown_test.go
+++ b/internal/frontdesk/configsync_shutdown_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -64,20 +65,92 @@ func TestConfigSyncInFlightAtShutdownNeverStampsAClosedStore(t *testing.T) {
 		t.Error("store still usable after Shutdown; want it closed")
 	}
 
-	if rec.Code != http.StatusOK {
-		t.Fatalf("sync = %d (%s)", rec.Code, rec.Body.String())
-	}
-	var resp struct {
-		Results []syncResultItem `json:"results"`
-	}
-	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode results: %v", err)
-	}
+	resp := decodeSyncResponse(t, rec)
 	for _, item := range resp.Results {
 		if strings.Contains(item.Error, "could not record the sync stamp") {
 			t.Errorf("the run wrote a member's config and then failed to stamp it: %+v; it persisted against a store Shutdown had closed", item)
 		}
 	}
+}
+
+// TestConfigSyncCutShortReportsThePartialRun: a run shutdown ended is not a run
+// that succeeded. It answers 503 carrying the members it did reach plus a
+// message naming how many it never attempted, because the wizard reads a 200 as
+// the whole fleet and would toast "1 of 1 synced" over a member Front Desk never
+// touched.
+func TestConfigSyncCutShortReportsThePartialRun(t *testing.T) {
+	srv, store := newTestServer(t)
+	primary := newStubConfigMember(t, "ptoken")
+	// Both replicas hold their real import, so whichever the run reaches first is
+	// the one it is parked on when shutdown lands: the assertion does not depend on
+	// the order the store lists them in.
+	first := newStubConfigMember(t, "rtoken1")
+	second := newStubConfigMember(t, "rtoken2")
+	enteredFirst, releaseFirst := first.holdRealImport()
+	enteredSecond, releaseSecond := second.holdRealImport()
+	defer releaseFirst()
+	defer releaseSecond()
+
+	pm, err := store.CreateMember(t.Context(), "primary", primary.srv.URL, "ptoken")
+	if err != nil {
+		t.Fatalf("create primary: %v", err)
+	}
+	for i, m := range []*stubConfigMember{first, second} {
+		if _, err := store.CreateMember(t.Context(), "replica"+strconv.Itoa(i), m.srv.URL, m.token); err != nil {
+			t.Fatalf("create replica: %v", err)
+		}
+	}
+	alignFleetVersions(t, srv, store, "dev")
+
+	syncDone := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		syncDone <- do(t, srv, http.MethodPost, "/api/config/sync", `{"primary_id":"`+pm.ID+`"}`, true)
+	}()
+	select { // one replica is mid-import; the other has not been reached
+	case <-enteredFirst:
+	case <-enteredSecond:
+	}
+
+	if err := srv.Shutdown(t.Context()); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+	var rec *httptest.ResponseRecorder
+	select {
+	case rec = <-syncDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the manual sync was still running after Shutdown closed the store")
+	}
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("interrupted sync = %d, want 503; body=%s", rec.Code, rec.Body.String())
+	}
+	resp := decodeSyncResponse(t, rec)
+	if len(resp.Results) != 1 {
+		t.Errorf("results = %d (%+v), want the one member the run reached", len(resp.Results), resp.Results)
+	}
+	if resp.Code != "sync_interrupted" {
+		t.Errorf("code = %q, want sync_interrupted", resp.Code)
+	}
+	if !strings.Contains(resp.Error, "1 member(s) were not attempted") {
+		t.Errorf("error = %q, want it to name the one member the run never reached", resp.Error)
+	}
+}
+
+// syncResponse is the manual sync answer in both its shapes: the results, plus
+// the code/error an interrupted run carries alongside them.
+type syncResponse struct {
+	Results []syncResultItem `json:"results"`
+	Code    string           `json:"code"`
+	Error   string           `json:"error"`
+}
+
+func decodeSyncResponse(t *testing.T, rec *httptest.ResponseRecorder) syncResponse {
+	t.Helper()
+	var resp syncResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode sync response (%d %s): %v", rec.Code, rec.Body.String(), err)
+	}
+	return resp
 }
 
 // TestConfigSyncRefusedOnceShutdownBegins: an http.Server drain returns on its

--- a/internal/frontdesk/configsync_shutdown_test.go
+++ b/internal/frontdesk/configsync_shutdown_test.go
@@ -1,0 +1,115 @@
+package frontdesk
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// A manual config sync detaches from the request context on purpose: a client
+// with a short HTTP timeout must not be able to abort a fleet-wide run half-way.
+// Detached is not the same as unowned, and these tests hold the difference. The
+// run reads and writes the store all the way to its last sync stamp, so
+// Shutdown, which closes that store, has to know about it.
+
+// TestConfigSyncInFlightAtShutdownNeverStampsAClosedStore is the ordering
+// Shutdown owes a manual sync. With the run registered on the server's
+// background group, Shutdown ends its lifetime and the drain waits for it, so by
+// the time the store closes the run has stopped and recorded nothing. Left
+// unregistered, the drain has nothing to wait for: the store closes under a run
+// that is still pushing, and the member that answers next is reported as
+// "applied but could not record the sync stamp" — a fleet Front Desk changed and
+// then forgot.
+func TestConfigSyncInFlightAtShutdownNeverStampsAClosedStore(t *testing.T) {
+	srv, store := newTestServer(t)
+	primary := newStubConfigMember(t, "ptoken")
+	replica := newStubConfigMember(t, "rtoken")
+	importing, releaseImport := replica.holdRealImport()
+	// Released on every exit, failing ones included, so the stub's handler and the
+	// sync goroutine are never left parked on a test that has gone.
+	defer releaseImport()
+
+	pm, err := store.CreateMember(t.Context(), "primary", primary.srv.URL, "ptoken")
+	if err != nil {
+		t.Fatalf("create primary: %v", err)
+	}
+	if _, err := store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken"); err != nil {
+		t.Fatalf("create replica: %v", err)
+	}
+	alignFleetVersions(t, srv, store, "dev")
+
+	syncDone := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		syncDone <- do(t, srv, http.MethodPost, "/api/config/sync", `{"primary_id":"`+pm.ID+`"}`, true)
+	}()
+	<-importing // the run is detached from the request and mid-import
+
+	// t.Context() outlives the test body, so this drain has no deadline to escape
+	// through: only the run ending can release it.
+	if err := srv.Shutdown(t.Context()); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+
+	var rec *httptest.ResponseRecorder
+	select {
+	case rec = <-syncDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the manual sync was still running after Shutdown closed the store; the drain did not cover it")
+	}
+	if _, err := store.AutoSyncGen(context.Background()); err == nil {
+		t.Error("store still usable after Shutdown; want it closed")
+	}
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("sync = %d (%s)", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Results []syncResultItem `json:"results"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode results: %v", err)
+	}
+	for _, item := range resp.Results {
+		if strings.Contains(item.Error, "could not record the sync stamp") {
+			t.Errorf("the run wrote a member's config and then failed to stamp it: %+v; it persisted against a store Shutdown had closed", item)
+		}
+	}
+}
+
+// TestConfigSyncRefusedOnceShutdownBegins: an http.Server drain returns on its
+// own deadline without stopping the handlers still in flight, so this handler
+// can be reached after Shutdown has parked its waiter. Starting a fleet-wide
+// write then is refused rather than run unowned: nothing would record what it
+// did, and it would be cancelled a moment later anyway. The operator is told, so
+// they can run the sync again after the restart instead of reading a 200 for a
+// run that never happened.
+func TestConfigSyncRefusedOnceShutdownBegins(t *testing.T) {
+	srv, store := newTestServer(t)
+	primary := newStubConfigMember(t, "ptoken")
+	replica := newStubConfigMember(t, "rtoken")
+
+	pm, err := store.CreateMember(t.Context(), "primary", primary.srv.URL, "ptoken")
+	if err != nil {
+		t.Fatalf("create primary: %v", err)
+	}
+	if _, err := store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken"); err != nil {
+		t.Fatalf("create replica: %v", err)
+	}
+	alignFleetVersions(t, srv, store, "dev")
+
+	if err := srv.Shutdown(t.Context()); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+
+	rec := do(t, srv, http.MethodPost, "/api/config/sync", `{"primary_id":"`+pm.ID+`"}`, true)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("sync during shutdown = %d (%s), want 503", rec.Code, strings.TrimSpace(rec.Body.String()))
+	}
+	if primary.gotImport || replica.gotImport {
+		t.Error("a refused sync still pushed to a member")
+	}
+}

--- a/internal/frontdesk/configsync_test.go
+++ b/internal/frontdesk/configsync_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -28,7 +29,24 @@ type stubConfigMember struct {
 	gotImport   bool
 	gotDryRun   bool
 	gotBackup   bool
-	srv         *httptest.Server
+	// importHeld, when set, holds a real (non dry-run) import open: entry is
+	// announced on importEntered and the answer waits for importGate, so a test can
+	// park a sync mid-import and act while it is in flight. A caller that hangs up
+	// (a cancelled context) releases the handler too, which is how a real member
+	// behaves when Front Desk abandons the push.
+	importHeld    bool
+	importEntered chan struct{}
+	importGate    chan struct{}
+	srv           *httptest.Server
+}
+
+// holdRealImport parks the stub's real import until the returned release func is
+// called, and returns the channel closed when the import is entered.
+func (sm *stubConfigMember) holdRealImport() (entered <-chan struct{}, release func()) {
+	sm.importHeld = true
+	sm.importEntered = make(chan struct{})
+	sm.importGate = make(chan struct{})
+	return sm.importEntered, sync.OnceFunc(func() { close(sm.importGate) })
 }
 
 func newStubConfigMember(t *testing.T, token string) *stubConfigMember {
@@ -50,6 +68,14 @@ func newStubConfigMember(t *testing.T, token string) *stubConfigMember {
 		case r.Method == http.MethodPost && r.URL.Path == "/api/config/import":
 			sm.gotImport = true
 			sm.gotDryRun = r.URL.Query().Get("dryRun") != ""
+			if sm.importHeld && !sm.gotDryRun {
+				close(sm.importEntered)
+				select {
+				case <-sm.importGate:
+				case <-r.Context().Done():
+					return
+				}
+			}
 			if sm.importDelay > 0 {
 				time.Sleep(sm.importDelay)
 			}

--- a/internal/frontdesk/server.go
+++ b/internal/frontdesk/server.go
@@ -269,6 +269,7 @@ func NewServer(cfg ServerConfig) *Server {
 	// The server's own lifetime, handed to detached request work. Cancelled by
 	// Shutdown and by nothing else, so a server that is never shut down simply
 	// never ends it.
+	//nolint:gosec // G118: the cancel func is stored on the server and called by Shutdown
 	s.shutdownCtx, s.shutdownCancel = context.WithCancel(context.Background())
 
 	// Bind the scrape-time member-fleet collector to this server's store and

--- a/internal/frontdesk/server.go
+++ b/internal/frontdesk/server.go
@@ -168,6 +168,41 @@ type Server struct {
 	bgMu      sync.Mutex
 	bgClosing bool
 	bgWG      sync.WaitGroup
+	// shutdownCtx is cancelled at the top of Shutdown, before the drain parks.
+	// Work a request starts but the server owns (the manual config sync, the
+	// auto-sync kick) takes its lifetime from here, so a fleet-wide run that is
+	// still going when shutdown begins stops at its next cancellation point
+	// instead of outliving the drain budget and recording itself against a store
+	// Shutdown has already closed. It is never cancelled anywhere else: the server
+	// is not restartable, so this is a one-way end-of-life signal.
+	shutdownCtx    context.Context
+	shutdownCancel context.CancelFunc
+}
+
+// detachedCtx pairs one context's lifetime with another's values: Deadline, Done
+// and Err come from the embedded context, Value from values. Neither standard
+// combinator does both, which is why this type exists — context.WithoutCancel
+// keeps a request's values but yields a context nothing can ever cancel, and a
+// plain child of the server's shutdown context can be cancelled but has lost the
+// request's values (the actor a manual sync is attributed to).
+type detachedCtx struct {
+	context.Context                 // lifetime only
+	values          context.Context // values only
+}
+
+// Value answers from the request. The lifetime context carries no values, so
+// there is nothing to fall through to.
+func (d detachedCtx) Value(key any) any { return d.values.Value(key) }
+
+// detachedContext returns the context for work a request starts and the server
+// owns: the request's values with the server's lifetime. Dropping the request's
+// cancellation is what stops a client hanging up from aborting a run half-way;
+// keeping the server's is what stops that same run from writing into a store
+// Shutdown has closed. Hand it to StartBackground (or StartBackgroundTimeout, to
+// bound the run as well), never to a bare goroutine: the lifetime only helps if
+// the drain waits for the work it ends.
+func (s *Server) detachedContext(r *http.Request) context.Context {
+	return detachedCtx{Context: s.shutdownCtx, values: r.Context()}
 }
 
 // defaultLBPort is the load-balancer host port assumed when FLEET_LB_PORT is
@@ -231,6 +266,10 @@ func NewServer(cfg ServerConfig) *Server {
 		backupStale:     make(map[string]bool),
 		startedAt:       time.Now(),
 	}
+	// The server's own lifetime, handed to detached request work. Cancelled by
+	// Shutdown and by nothing else, so a server that is never shut down simply
+	// never ends it.
+	s.shutdownCtx, s.shutdownCancel = context.WithCancel(context.Background())
 
 	// Bind the scrape-time member-fleet collector to this server's store and
 	// poller so /metrics always reflects current state (one server per process
@@ -333,6 +372,10 @@ func (s *Server) StartBackgroundTimeout(parent context.Context, d time.Duration,
 // forever; the store is closed either way and the timed-out drain is logged, so
 // the operator sees which shutdown was untidy.
 //
+// Work that took the server's lifetime rather than a caller's (see
+// detachedContext) is cancelled here as well, before the waiter parks, so it
+// stops on its own instead of racing that budget.
+//
 // It takes ownership of the store it was configured with and closes it, so a
 // caller holding the same *Store must not keep using it afterwards.
 //
@@ -344,6 +387,11 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	s.bgMu.Lock()
 	s.bgClosing = true
 	s.bgMu.Unlock()
+	// Ending the server's lifetime before the waiter parks is what keeps the drain
+	// short for work that carries no deadline of its own: a manual config sync
+	// pushing the fleet on a detached context stops at its next cancellation point
+	// rather than spending the whole budget while the store waits to close.
+	s.shutdownCancel()
 
 	drained := make(chan struct{})
 	go func() {

--- a/internal/frontdesk/server.go
+++ b/internal/frontdesk/server.go
@@ -155,11 +155,19 @@ type Server struct {
 	// staleness window has passed since this process started.
 	startedAt time.Time
 	router    http.Handler
-	// bgWG tracks detached background goroutines (e.g. the auto-sync kick) so
-	// callers can drain them on shutdown. Without it, a kick fired by an enable
-	// keeps writing to the store after a caller (or a test) has moved on, which
-	// races store teardown.
-	bgWG sync.WaitGroup
+	// bgWG tracks every background goroutine the server owns: the detached
+	// auto-sync kick, the process-lifetime poll loops, and an SSE stream's re-auth
+	// ticker. Without it, work fired by a request keeps reading the store after a
+	// caller (or a test) has moved on, which races store teardown.
+	//
+	// bgMu guards bgClosing and pairs registration with it. A sync.WaitGroup panics
+	// on an Add that lifts the counter off zero while a Wait is parked, so
+	// registration and the "are we draining yet" decision have to be one atomic
+	// step: StartBackground holds bgMu across both, and Shutdown takes it to set
+	// bgClosing before it parks. bgClosing stays set; the server is not restartable.
+	bgMu      sync.Mutex
+	bgClosing bool
+	bgWG      sync.WaitGroup
 }
 
 // defaultLBPort is the load-balancer host port assumed when FLEET_LB_PORT is
@@ -272,15 +280,30 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) { s.router.Se
 // prefer at process exit.
 func (s *Server) Wait() { s.bgWG.Wait() }
 
-// StartBackground runs fn as a tracked background goroutine, so Wait and Shutdown
-// cover it. The registration happens on the caller's goroutine, before fn is
-// spawned, so a shutdown racing startup still waits for fn rather than missing a
-// counter that had not been incremented yet.
+// StartBackground runs fn as a tracked background goroutine and reports whether it
+// started, so Wait and Shutdown cover it. The registration happens on the caller's
+// goroutine, before fn is spawned, so a shutdown racing startup still waits for fn
+// rather than missing a counter that had not been incremented yet.
+//
+// It refuses once Shutdown has begun, and that refusal is the whole point of the
+// lock: an http.Server drain returns on its own deadline without stopping the
+// handlers still in flight, so a handler outliving it and registering here would
+// otherwise trip the WaitGroup's "Add called concurrently with Wait" panic.
+// Refusing is also the right answer on its own terms, since anything started at
+// that moment is cancelled milliseconds later. The caller decides what to do
+// without the goroutine; false is a normal shutdown-time answer, not an error.
 //
 // fn owns its exit: it is expected to return when ctx is done, which is how
 // Shutdown's drain ever completes.
-func (s *Server) StartBackground(ctx context.Context, fn func(context.Context)) {
+func (s *Server) StartBackground(ctx context.Context, fn func(context.Context)) (started bool) {
+	s.bgMu.Lock()
+	defer s.bgMu.Unlock()
+	if s.bgClosing {
+		debuglog.Debug("frontdesk: background work refused, server is shutting down")
+		return false
+	}
 	s.bgWG.Go(func() { fn(ctx) })
+	return true
 }
 
 // Shutdown drains the server's background goroutines and then closes the store,
@@ -293,9 +316,18 @@ func (s *Server) StartBackground(ctx context.Context, fn func(context.Context)) 
 // forever; the store is closed either way and the timed-out drain is logged, so
 // the operator sees which shutdown was untidy.
 //
-// Callers stop accepting new work first (the HTTP server's own Shutdown), so
-// nothing can register another goroutine while this drains.
+// It takes ownership of the store it was configured with and closes it, so a
+// caller holding the same *Store must not keep using it afterwards.
+//
+// Nothing can register another goroutine while this drains: the closing flag is
+// set before the waiter parks, and StartBackground refuses from that point on.
+// Callers should still stop accepting requests first (the HTTP server's own
+// Shutdown), so in-flight work has its chance to finish rather than being refused.
 func (s *Server) Shutdown(ctx context.Context) error {
+	s.bgMu.Lock()
+	s.bgClosing = true
+	s.bgMu.Unlock()
+
 	drained := make(chan struct{})
 	go func() {
 		defer close(drained)

--- a/internal/frontdesk/server.go
+++ b/internal/frontdesk/server.go
@@ -306,6 +306,23 @@ func (s *Server) StartBackground(ctx context.Context, fn func(context.Context)) 
 	return true
 }
 
+// StartBackgroundTimeout is StartBackground for detached work that needs its own
+// deadline: it derives a time-bounded context from parent, hands it to fn, and
+// releases it exactly once whichever way the registration goes. fn's own run
+// releases it on the way out; a refusal releases it here, so a caller that is too
+// late to start work never leaks the context it prepared.
+func (s *Server) StartBackgroundTimeout(parent context.Context, d time.Duration, fn func(context.Context)) (started bool) {
+	ctx, cancel := context.WithTimeout(parent, d)
+	if !s.StartBackground(ctx, func(c context.Context) {
+		defer cancel()
+		fn(c)
+	}) {
+		cancel()
+		return false
+	}
+	return true
+}
+
 // Shutdown drains the server's background goroutines and then closes the store,
 // in that order: a goroutine still mid-query would otherwise be reading a store
 // that is already closed, which is the same unowned-read race a convergence pass

--- a/internal/frontdesk/server.go
+++ b/internal/frontdesk/server.go
@@ -1,6 +1,7 @@
 package frontdesk
 
 import (
+	"context"
 	"crypto/subtle"
 	"io/fs"
 	"net"
@@ -263,11 +264,56 @@ func NewServer(cfg ServerConfig) *Server {
 // ServeHTTP implements http.Handler.
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) { s.router.ServeHTTP(w, r) }
 
-// Wait blocks until every detached background goroutine the server has spawned
-// (currently the auto-sync kick) has returned. Use it on graceful shutdown, or
-// in tests before tearing down the backing store, so a still-running kick can't
-// write into a store or temp dir that is being removed.
+// Wait blocks until every background goroutine the server tracks has returned:
+// the detached auto-sync kick, and every process-lifetime loop started through
+// StartBackground. Use it on graceful shutdown, or in tests before tearing down
+// the backing store, so a still-running goroutine can't write into a store or
+// temp dir that is being removed. Shutdown is the bounded version callers should
+// prefer at process exit.
 func (s *Server) Wait() { s.bgWG.Wait() }
+
+// StartBackground runs fn as a tracked background goroutine, so Wait and Shutdown
+// cover it. The registration happens on the caller's goroutine, before fn is
+// spawned, so a shutdown racing startup still waits for fn rather than missing a
+// counter that had not been incremented yet.
+//
+// fn owns its exit: it is expected to return when ctx is done, which is how
+// Shutdown's drain ever completes.
+func (s *Server) StartBackground(ctx context.Context, fn func(context.Context)) {
+	s.bgWG.Go(func() { fn(ctx) })
+}
+
+// Shutdown drains the server's background goroutines and then closes the store,
+// in that order: a goroutine still mid-query would otherwise be reading a store
+// that is already closed, which is the same unowned-read race a convergence pass
+// avoids by joining its rearm watcher.
+//
+// The drain is bounded by ctx. A goroutine that ignores its own cancellation
+// therefore delays exit by the caller's budget rather than hanging the process
+// forever; the store is closed either way and the timed-out drain is logged, so
+// the operator sees which shutdown was untidy.
+//
+// Callers stop accepting new work first (the HTTP server's own Shutdown), so
+// nothing can register another goroutine while this drains.
+func (s *Server) Shutdown(ctx context.Context) error {
+	drained := make(chan struct{})
+	go func() {
+		defer close(drained)
+		s.Wait()
+	}()
+	select {
+	case <-drained:
+		debuglog.Info("frontdesk: background goroutines drained")
+	case <-ctx.Done():
+		debuglog.Warn("frontdesk: background goroutines still running at shutdown; closing the store anyway",
+			"error", ctx.Err())
+	}
+	// Closing is last and unconditional: the drain above only decides whether it
+	// happens with goroutines still live. The caller logs a failure, which is all
+	// that is left to do at this point in the process's life.
+	debuglog.Info("frontdesk: closing store")
+	return s.store.Close()
+}
 
 // SessionManager exposes the session manager (used by callers wiring background
 // cleanup of expired sessions).

--- a/internal/frontdesk/server_settings.go
+++ b/internal/frontdesk/server_settings.go
@@ -391,9 +391,11 @@ func (s *Server) putAutoSync(w http.ResponseWriter, r *http.Request) {
 	// Registering through the server's background group rather than a bare
 	// goroutine is what keeps this safe during shutdown: a handler can still be
 	// running after the HTTP drain gave up, and the kick is refused from that point
-	// on, its context released for it.
+	// on, its context released for it. A kick that is already running takes the
+	// server's lifetime from detachedContext, so shutdown ends it instead of
+	// leaving the drain to wait out a fifteen-minute pass.
 	if status.Enabled && status.PrimaryID != "" {
-		s.StartBackgroundTimeout(context.WithoutCancel(r.Context()), autoSyncKickTimeout, s.forceAutoSyncNow)
+		s.StartBackgroundTimeout(s.detachedContext(r), autoSyncKickTimeout, s.forceAutoSyncNow)
 	}
 	writeJSON(w, http.StatusOK, status)
 }

--- a/internal/frontdesk/server_settings.go
+++ b/internal/frontdesk/server_settings.go
@@ -388,12 +388,18 @@ func (s *Server) putAutoSync(w http.ResponseWriter, r *http.Request) {
 	// context (which ends when we respond) but time-bounded so a stuck pass cannot
 	// leak the goroutine. A no-op when nothing has drifted; the loop still owns the
 	// steady-state watch. Disabling (or no primary) never kicks.
+	// Registering through StartBackground rather than the WaitGroup directly is
+	// what keeps this safe during shutdown: a handler can still be running after
+	// the HTTP drain gave up, and the kick is refused from that point on.
 	if status.Enabled && status.PrimaryID != "" {
 		kickCtx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), autoSyncKickTimeout)
-		s.bgWG.Go(func() {
+		if !s.StartBackground(kickCtx, func(ctx context.Context) {
 			defer cancel()
-			s.forceAutoSyncNow(kickCtx)
-		})
+			s.forceAutoSyncNow(ctx)
+		}) {
+			// Nothing will run it, so release the context here instead.
+			cancel()
+		}
 	}
 	writeJSON(w, http.StatusOK, status)
 }

--- a/internal/frontdesk/server_settings.go
+++ b/internal/frontdesk/server_settings.go
@@ -388,18 +388,12 @@ func (s *Server) putAutoSync(w http.ResponseWriter, r *http.Request) {
 	// context (which ends when we respond) but time-bounded so a stuck pass cannot
 	// leak the goroutine. A no-op when nothing has drifted; the loop still owns the
 	// steady-state watch. Disabling (or no primary) never kicks.
-	// Registering through StartBackground rather than the WaitGroup directly is
-	// what keeps this safe during shutdown: a handler can still be running after
-	// the HTTP drain gave up, and the kick is refused from that point on.
+	// Registering through the server's background group rather than a bare
+	// goroutine is what keeps this safe during shutdown: a handler can still be
+	// running after the HTTP drain gave up, and the kick is refused from that point
+	// on, its context released for it.
 	if status.Enabled && status.PrimaryID != "" {
-		kickCtx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), autoSyncKickTimeout)
-		if !s.StartBackground(kickCtx, func(ctx context.Context) {
-			defer cancel()
-			s.forceAutoSyncNow(ctx)
-		}) {
-			// Nothing will run it, so release the context here instead.
-			cancel()
-		}
+		s.StartBackgroundTimeout(context.WithoutCancel(r.Context()), autoSyncKickTimeout, s.forceAutoSyncNow)
 	}
 	writeJSON(w, http.StatusOK, status)
 }

--- a/internal/frontdesk/server_status.go
+++ b/internal/frontdesk/server_status.go
@@ -140,25 +140,31 @@ func (s *Server) revalidate(r *http.Request) bool {
 }
 
 // reauthLoop re-checks the caller's credentials on every tick and reports the
-// verdict on out. Exits when the request context is cancelled.
+// verdict on out. Exits when ctx is cancelled.
+//
+// ctx is the stream's own child of the request context, not r.Context() itself:
+// the parked send below escapes only on a cancel, and the request context does not
+// fire until after the handler has returned, which is too late for the handler to
+// wait on this goroutine. Cancelling the child first is what lets streamEvents
+// join it.
 //
 // Runs off the read loop deliberately. revalidate makes a store round-trip, and
 // the event bus drops events for any subscriber that is not draining its channel
 // (internal/events/bus.go), so doing this inline would trade a slow credential
 // lookup for lost live events on a busy control plane.
-func (s *Server) reauthLoop(r *http.Request, every time.Duration, out chan<- bool) {
+func (s *Server) reauthLoop(ctx context.Context, r *http.Request, every time.Duration, out chan<- bool) {
 	ticker := time.NewTicker(every)
 	defer ticker.Stop()
 
 	for {
 		select {
-		case <-r.Context().Done():
+		case <-ctx.Done():
 			return
 		case <-ticker.C:
 			valid := s.revalidate(r)
 			select {
 			case out <- valid:
-			case <-r.Context().Done():
+			case <-ctx.Done():
 				return
 			}
 		}
@@ -186,7 +192,26 @@ func (s *Server) streamEvents(w http.ResponseWriter, r *http.Request, heartbeatE
 	// Buffered so a re-auth verdict never parks its goroutine while this loop is
 	// busy writing an event; the loop drains it on the next pass.
 	reauth := make(chan bool, 1)
-	go s.reauthLoop(r, heartbeatEvery, reauth)
+	// The ticker reads the session and device tables, so it is tracked (Shutdown's
+	// drain covers it, even when the HTTP drain gave up on this stream) and joined
+	// (the handler does not return while a store read of its own is still in
+	// flight). Cancelling loopCtx before the join is what unparks a ticker sitting
+	// on the send above.
+	loopCtx, cancelLoop := context.WithCancel(r.Context())
+	loopDone := make(chan struct{})
+	if !s.StartBackground(loopCtx, func(ctx context.Context) {
+		defer close(loopDone)
+		s.reauthLoop(ctx, r, heartbeatEvery, reauth)
+	}) {
+		// Shutting down: nothing will re-check this caller or drive the keep-alive,
+		// so end the stream now rather than serve one that cannot expire.
+		cancelLoop()
+		return
+	}
+	defer func() {
+		cancelLoop()
+		<-loopDone
+	}()
 
 	failures := 0
 	for {

--- a/internal/frontdesk/server_test.go
+++ b/internal/frontdesk/server_test.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -109,6 +110,66 @@ func do(t *testing.T, srv *Server, method, path, body string, auth bool) *httpte
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
 	return rec
+}
+
+// TestShutdownDrainsBackgroundBeforeClosingTheStore: the ordering Shutdown
+// exists for. A tracked background goroutine finishing its last store read must
+// find the store still open; closing first would leave that read querying a
+// closed handle, which is the unowned-read race the rearm watcher's join avoids
+// inside a pass.
+func TestShutdownDrainsBackgroundBeforeClosingTheStore(t *testing.T) {
+	srv, store := newTestServer(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	started := make(chan struct{})
+	var readErr error
+	srv.StartBackground(ctx, func(c context.Context) {
+		close(started)
+		<-c.Done()
+		// The last read on the way out, as every poll loop does.
+		_, readErr = store.AutoSyncGen(context.Background())
+	})
+	<-started
+	cancel() // what the signal handler does before the process winds down
+
+	if err := srv.Shutdown(t.Context()); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+	if readErr != nil {
+		t.Errorf("background read on the way out failed: %v; the store closed before the drain finished", readErr)
+	}
+	if _, err := store.AutoSyncGen(context.Background()); err == nil {
+		t.Error("store still usable after Shutdown; want it closed")
+	}
+}
+
+// TestShutdownBoundsTheDrain: a background goroutine that ignores its
+// cancellation delays exit by the caller's budget, not forever. Shutdown returns
+// when the context does and closes the store regardless, so a stuck loop cannot
+// hang the process.
+func TestShutdownBoundsTheDrain(t *testing.T) {
+	srv, store := newTestServer(t)
+
+	release := make(chan struct{})
+	releaseStuck := sync.OnceFunc(func() { close(release) })
+	// The server's own Wait cleanup joins this goroutine, so it is released on
+	// every exit from the test, failing ones included.
+	defer releaseStuck()
+	started := make(chan struct{})
+	srv.StartBackground(context.Background(), func(context.Context) {
+		close(started)
+		<-release
+	})
+	<-started
+
+	drainCtx, drainCancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+	defer drainCancel()
+	if err := srv.Shutdown(drainCtx); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+	if _, err := store.AutoSyncGen(context.Background()); err == nil {
+		t.Error("store still usable after a timed-out drain; want it closed anyway")
+	}
 }
 
 func TestServerAuthGate(t *testing.T) {

--- a/internal/frontdesk/server_test.go
+++ b/internal/frontdesk/server_test.go
@@ -172,6 +172,59 @@ func TestShutdownBoundsTheDrain(t *testing.T) {
 	}
 }
 
+// TestStartBackgroundRefusedOnceShutdownBegins: an http.Server drain returns on
+// its own deadline without stopping the handlers still in flight, so a handler
+// can reach a registration after Shutdown has parked its waiter. Registering then
+// would trip sync.WaitGroup's "Add called concurrently with Wait" panic, so the
+// answer is a refusal: the work is not started and the caller is told.
+func TestStartBackgroundRefusedOnceShutdownBegins(t *testing.T) {
+	srv, _ := newTestServer(t)
+
+	if err := srv.Shutdown(t.Context()); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+
+	ran := make(chan struct{})
+	if srv.StartBackground(t.Context(), func(context.Context) { close(ran) }) {
+		t.Error("StartBackground reported the work started after Shutdown; want a refusal")
+	}
+	select {
+	case <-ran:
+		t.Error("refused background work ran anyway")
+	default:
+	}
+}
+
+// TestShutdownWaitsForTheSSEReauthTicker: a stream's re-auth ticker reads the
+// session and device tables, so the drain has to cover it. Shutdown must not
+// return, and so must not close the store, while one is still ticking; the
+// request context is what ends it, exactly as a disconnecting client would.
+func TestShutdownWaitsForTheSSEReauthTicker(t *testing.T) {
+	srv, _ := newTestServer(t)
+
+	req, cancelReq := sseRequest(t)
+	req.Header.Set("Authorization", "Bearer "+testFrontdeskToken)
+	rec := newSSERecorder()
+	streamDone := startStreamWith(t, srv, req, rec, sseTick)
+	awaitWrite(t, rec, "keep-alive") // the ticker is running and re-checking
+
+	shutdownDone := make(chan error, 1)
+	go func() { shutdownDone <- srv.Shutdown(t.Context()) }()
+	// t.Context() outlives the test body, so this drain has no deadline of its own
+	// to escape through: only the ticker returning can release it.
+	select {
+	case <-shutdownDone:
+		t.Fatal("Shutdown returned while an SSE re-auth ticker was still running")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	cancelReq()
+	awaitClosed(t, streamDone, "after its request context was cancelled")
+	if err := <-shutdownDone; err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+}
+
 func TestServerAuthGate(t *testing.T) {
 	srv, _ := newTestServer(t)
 

--- a/internal/frontdesk/server_test.go
+++ b/internal/frontdesk/server_test.go
@@ -193,6 +193,18 @@ func TestStartBackgroundRefusedOnceShutdownBegins(t *testing.T) {
 		t.Error("refused background work ran anyway")
 	default:
 	}
+
+	// The timeout variant prepares a context before it registers, so a refusal has
+	// to release it rather than leave it to the deadline. govet's lostcancel and
+	// the race detector both watch this path; the assertion here is that the
+	// refusal is reported, and that the context comes back already cancelled.
+	var kickCtx context.Context
+	if srv.StartBackgroundTimeout(t.Context(), time.Minute, func(c context.Context) { kickCtx = c }) {
+		t.Error("StartBackgroundTimeout reported the work started after Shutdown; want a refusal")
+	}
+	if kickCtx != nil {
+		t.Error("refused timed background work ran anyway")
+	}
 }
 
 // TestShutdownWaitsForTheSSEReauthTicker: a stream's re-auth ticker reads the

--- a/internal/frontdesk/sse_reauth_test.go
+++ b/internal/frontdesk/sse_reauth_test.go
@@ -126,6 +126,22 @@ func sseRequest(t *testing.T) (*http.Request, context.CancelFunc) {
 	return httptest.NewRequestWithContext(ctx, http.MethodGet, "/api/sse", http.NoBody), cancel
 }
 
+// A stream opened while the server is shutting down ends at once: its re-auth
+// ticker is refused, and a stream whose credentials are never re-checked would
+// outlive the revocation it is there to notice.
+func TestSSEStreamEndsWhileShuttingDown(t *testing.T) {
+	srv, _ := newTestServer(t)
+	if err := srv.Shutdown(t.Context()); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+
+	req, _ := sseRequest(t)
+	req.Header.Set("Authorization", "Bearer "+testFrontdeskToken)
+	rec := newSSERecorder()
+	done := startStreamWith(t, srv, req, rec, sseTick)
+	awaitClosed(t, done, "while the server was shutting down")
+}
+
 // A device unpaired while its stream is open must lose the stream: the next
 // re-checks fail and the handler returns.
 func TestSSEClosesAfterDeviceRevoked(t *testing.T) {

--- a/scripts/ci/size-allowlist.txt
+++ b/scripts/ci/size-allowlist.txt
@@ -20,7 +20,7 @@ internal/api/logs.go	809
 internal/api/stats.go	843
 internal/failover/circuitbreaker_test.go	2056
 internal/failover/failover.go	1091
-internal/frontdesk/autosync.go	1196
+internal/frontdesk/autosync.go	1171
 internal/frontdesk/autosync_test.go	4254
 internal/frontdesk/poller.go	930
 internal/model/model.go	983


### PR DESCRIPTION
## Summary

CI on #764 hit `TestForceAutoSyncNowConvergesImmediately` failing with `TempDir RemoveAll cleanup: directory not empty` on a diff that touched no Go: a writer was still alive in the Front Desk test's SQLite temp dir when the test ended, past the `srv.Wait` drain the helper registers.

Root cause: `applyAutoSync` started its rearm watcher with a bare `go` and only cancelled it on the way out, never joined it, so a watcher already inside `store.AutoSyncGen` kept reading the store (leaving the SQLite `-wal`/`-shm` sidecars) after the pass and `Server.Wait` had returned. The same leak existed in the binary, where nothing drained the server at all.

- `startRearmWatch` now returns a stop function that cancels and joins; the pass waits for its watcher before returning. `TestRearmWatchStopJoinsTheWatcher` fails if the join is removed.
- Front Desk shutdown now stops the HTTP server, waits (bounded) for background goroutines, and closes the store, in that order; the ordering lives in `Server.Shutdown` (tested) and `main` keeps only the signal plumbing. Every lifetime loop and the settings-toggle kick register through `StartBackground`, which refuses once shutdown has begun (so nothing can race the drain), the SSE reauth loop is tracked and cancelled before it is joined, and the manual config sync runs as owned work too (503 once shutdown has begun; an in-flight sync observes the shutdown context and stops before persisting). Budgets total 20 s; the compose service gets `stop_grace_period: 30s`.

## Verification

- Instrumented reproduction showed the escaped watcher and the `-wal`/`-shm` files before the fix; none after. Repeated `-race` runs green after.
- `make test` green (0 skips), `golangci-lint run ./...` clean; 100% of changed lines covered; three new tests each fail against the pre-fix shape.
- Dev Front Desk rebuilt from this branch: healthy; `docker stop` logs `shutting down → background goroutines drained → closing store → stopped`, exits 0 in 0.4 s, and comes back healthy.
- Independent Opus review of the branch; all findings addressed before opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
