### PR TITLE
chore: build, test and lint with Go 1.27 everywhere

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
         with:
-          version: v2.11
+          version: v2.13
 
   go-vet:
     name: Go Vet

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hugalafutro/model-hotel
 
-go 1.26.6
+go 1.27.0
 
 require (
 	github.com/anthropics/anthropic-sdk-go v1.66.0
@@ -23,6 +23,8 @@ require (
 	go.opentelemetry.io/otel/sdk/log v0.21.0
 	golang.org/x/crypto v0.55.0
 	golang.org/x/oauth2 v0.36.0
+	golang.org/x/sync v0.22.0
+	golang.org/x/time v0.15.0 // direct
 	modernc.org/sqlite v1.57.0
 )
 
@@ -42,6 +44,9 @@ require (
 	github.com/google/go-tpm v0.9.8 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/invopop/jsonschema v0.14.0 // indirect
+	github.com/jackc/pgpassfile v1.0.0 // indirect
+	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
+	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/mattn/go-isatty v0.0.24 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
@@ -66,6 +71,8 @@ require (
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	go.yaml.in/yaml/v4 v4.0.0-rc.2 // indirect
 	golang.org/x/net v0.57.0 // indirect
+	golang.org/x/sys v0.47.0 // indirect
+	golang.org/x/text v0.41.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260803160001-6ac0973c030d // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260803160001-6ac0973c030d // indirect
 	google.golang.org/grpc v1.83.0 // indirect
@@ -73,14 +80,4 @@ require (
 	modernc.org/libc v1.74.4 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect
-)
-
-require (
-	github.com/jackc/pgpassfile v1.0.0 // indirect
-	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
-	github.com/jackc/puddle/v2 v2.2.2 // indirect
-	golang.org/x/sync v0.22.0
-	golang.org/x/sys v0.47.0 // indirect
-	golang.org/x/text v0.41.0 // indirect
-	golang.org/x/time v0.15.0 // direct
 )


### PR DESCRIPTION
## Summary

Align the Go toolchain everywhere. The shipped image is already built with `golang:1.27-alpine` and the dev machines run 1.27, but `go.mod` said `go 1.26.6`, so CI (`go-version-file: go.mod`) tested, linted and measured coverage with a compiler that neither the container nor local development uses. The visible symptom was #774: the Coverage Diff Gate passed locally at 91.4% and failed on CI at 89.8% on the same commit, because 1.26 and 1.27 emit different coverage block boundaries.

- `go.mod`: `go 1.26.6` -> `go 1.27.0` (`go mod tidy` changes nothing else). Anyone still on 1.26 gets the toolchain fetched by `GOTOOLCHAIN=auto`.
- CI golangci-lint: `v2.11` -> `v2.13`, the first line that analyses Go 1.27 code (the local linter is 2.13.1 for the same reason).

No code changes.

## Verification

- `go build ./...`, `go vet ./...`: clean
- `golangci-lint run ./...` (2.13.1 built with go1.27.0): 0 issues
- `go test ./...` (full, against the test Postgres): pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
