### PR TITLE
fix(web): stop shipping CSP-blocked data: URIs for the entry preload and fonts

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -5,8 +5,6 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Model Hotel</title>
-    <link rel="modulepreload" href="/src/main.tsx" crossorigin />
-    <link rel="dns-prefetch" href="//api" />
   </head>
   <body>
     <div id="root"></div>

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -39,6 +39,13 @@ export default defineConfig({
 		fs: { allow: [__dirname, path.resolve(__dirname, "../web-shared")] },
 	},
 	build: {
+		// Fonts are never inlined. Vite's default turns any asset under 4 kB into
+		// a base64 data: URI, which put the two smallest woff2 faces straight into
+		// the CSS; the CSP is default-src 'self' with no font-src data:, so the
+		// browser blocked them and fell back to the next face. Emitting them as
+		// files keeps every font behind the same 'self' rule as the rest of the
+		// bundle. Images keep the default: img-src allows data:.
+		assetsInlineLimit: (file) => (file.endsWith(".woff2") ? false : undefined),
 		// The two chunks over Vite's default 500 kB warning line are both benign:
 		// the per-language Shiki grammars (cpp is the largest at ~640 kB raw but
 		// ~50 kB gzip) are lazy-loaded on demand via SHIKI_LAZY below and never


### PR DESCRIPTION
## Summary

Noticed while driving the dashboard on the dev stack for the discrepancy-modal split: every page load logs CSP violations, on prod too.

1. `web/index.html` hand-preloaded `/src/main.tsx`. Vite treats that `<link rel="modulepreload">` as an asset reference and inlines the source as a base64 `data:application/octet-stream` URI in the built `index.html`; the CSP (`script-src 'self'`) blocks it, so it was a dead hint that also shipped the raw entry source. Vite emits its own preload links for the built chunks (7 of them in the output), which are the ones that work. Removed, along with a `dns-prefetch` for a host literally named `api`.
2. The two smallest woff2 faces were under Vite's default 4 kB `assetsInlineLimit`, so they were inlined into the CSS as `data:font/woff2` and blocked by `default-src 'self'` (no `font-src data:`), falling back to the next face. `build.assetsInlineLimit` now returns `false` for `.woff2` so every font is emitted as a file behind the same `'self'` rule as the rest of the bundle; images keep the default since `img-src` allows `data:`.

No runtime or CSP changes: the policy stays as strict as it is; the bundle now complies with it.

## Verification

- `pnpm build`: `dist/index.html` and `dist/assets/*.css` contain no `data:font/*` or `data:application/octet-stream`; 7 Vite-generated `modulepreload` links remain; 32 woff2 files emitted
- **Rebuilt dev stack**: the same Playwright walk that logged 9 CSP errors per load before (3 script, 6 font) now logs none; served `index.html` has no `data:` preload
- `tsc -b`, ESLint, Biome: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
