### PR TITLE
refactor(web): decompose the request Logs page

### DIFF
--- a/scripts/ci/size-allowlist.txt
+++ b/scripts/ci/size-allowlist.txt
@@ -31,7 +31,6 @@ web/src/components/VirtualModelTable.tsx	858
 web/src/components/__tests__/Layout.navigation.test.tsx	2558
 web/src/pages/Chat/useChat.ts	846
 web/src/pages/FailoverGroups.tsx	1096
-web/src/pages/Logs.tsx	971
 web/src/pages/Models/ModelDetailModal.tsx	823
 web/src/pages/Settings/alerts/AlertsWizard.tsx	801
 web/src/pages/Settings/alerts/steps.tsx	846

--- a/web/src/pages/Logs.tsx
+++ b/web/src/pages/Logs.tsx
@@ -1,36 +1,20 @@
-import {
-	keepPreviousData,
-	useQuery,
-	useQueryClient,
-} from "@tanstack/react-query";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { FileText, ScrollText } from "@/lib/icons";
+import { ScrollText } from "@/lib/icons";
 import { api } from "../api/client";
 import type { LogEntry } from "../api/types";
-import { Badge } from "../components/Badge";
 import type { SortState } from "../components/DataTable";
 import {
 	EmptyRow,
 	PaginationBar,
-	Row,
 	SortableHeader,
 } from "../components/DataTable";
-import { FilterDropdown } from "../components/FilterDropdown";
-import { FilterInput } from "../components/FilterInput";
 import { LoadingSpinner } from "../components/LoadingSpinner";
 import { LogDetailModal } from "../components/LogDetailModal";
-import {
-	DateFilterButton,
-	DateRangePickerPopover,
-	ENDPOINT_FILTER_OPTIONS,
-	EndpointTypeBadge,
-	LiveToggleButton,
-	LogsErrorState,
-} from "../components/logs";
+import { LiveToggleButton, LogsErrorState } from "../components/logs";
 import { LOG_COL_WIDTHS, LOG_TABLE_MIN_W } from "../components/logTableWidths";
 import { PageHeader } from "../components/PageHeader";
-import { ViewModeToggle } from "../components/ViewModeToggle";
 import { VirtualLogTable } from "../components/VirtualLogTable";
 import { useIdentity } from "../context/IdentityContext";
 import { useSidebarMode } from "../context/SidebarModeContext";
@@ -39,40 +23,23 @@ import { useDateRangePicker } from "../hooks/useDateRangePicker";
 import { useDebounce } from "../hooks/useDebounce";
 import { useLocalStorage } from "../hooks/useLocalStorage";
 import { useWheelPaging } from "../hooks/useWheelPaging";
-import { encodeCursor, formatNumber } from "../utils/format";
-import {
-	formatDurationCell,
-	getRowStatusVariant,
-	isCancelled,
-	isInProgress as isInProgressShared,
-	isStale as isStaleShared,
-	liveDurationMs,
-} from "../utils/logHelpers";
+import { encodeCursor } from "../utils/format";
 import { AppLogs } from "./AppLogs";
-import { formatMs, formatTPS } from "./Logs/utils";
+import {
+	RequestLogFilters,
+	type RequestLogFilterValues,
+} from "./Logs/RequestLogFilters";
+import { RequestLogRow } from "./Logs/RequestLogRow";
+import { type LogSortField, requestLogColumns } from "./Logs/requestLogColumns";
+import { useRequestLogLiveUpdates } from "./Logs/useRequestLogLiveUpdates";
+import { useStaleClock } from "./Logs/useStaleClock";
 
-/* ===== Main Logs page ===== */
-// eslint-disable-next-line max-lines-per-function -- size ratchet: split this page
 function RequestLogs() {
 	const { t } = useTranslation();
-	type LogSortField =
-		| "time"
-		| "model"
-		| "provider"
-		| "status"
-		| "tokens"
-		| "tps"
-		| "response_header_ms"
-		| "ttft"
-		| "duration"
-		| "overhead"
-		| "key"
-		| "ip";
-
 	const { logsSubMode, setLogsSubMode } = useSidebarMode();
 	const [page, setPage] = useState(1);
 	const [pageSize, setPageSize] = useLocalStorage("requestLogsPageSize", 20);
-	const [filters, setFilters] = useState({
+	const [filters, setFilters] = useState<RequestLogFilterValues>({
 		model_id: "",
 		provider_id: "",
 		status_code: "",
@@ -102,22 +69,8 @@ function RequestLogs() {
 	});
 	const debouncedModelId = useDebounce(filters.model_id, 300);
 	const debouncedProviderId = useDebounce(filters.provider_id, 300);
-	const {
-		dateFrom,
-		dateTo,
-		showDatePicker,
-		pendingFrom,
-		pendingTo,
-		datePickerRef,
-		hasDateFilter,
-		pickerYear,
-		pickerMonth,
-		handleCalendarSelect,
-		applyDateFilter,
-		clearDateFilter,
-		toggleDatePicker,
-		closeDatePicker,
-	} = useDateRangePicker(() => setPage(1));
+	const datePicker = useDateRangePicker(() => setPage(1));
+	const { dateFrom, dateTo } = datePicker;
 	const [sort, setSort] = useState<SortState<LogSortField>>({
 		field: "time",
 		dir: "desc",
@@ -129,32 +82,7 @@ function RequestLogs() {
 		"scroll",
 	);
 	const [liveEnabled, setLiveEnabled] = useState(true);
-	const [isVisible, setIsVisible] = useState(!document.hidden);
-	useEffect(() => {
-		const handler = () => setIsVisible(!document.hidden);
-		document.addEventListener("visibilitychange", handler);
-		return () => document.removeEventListener("visibilitychange", handler);
-	}, []);
 
-	const queryClient = useQueryClient();
-
-	useEffect(() => {
-		if (!liveEnabled) return;
-		const handler = (e: Event) => {
-			const event = (e as CustomEvent).detail;
-			if (
-				event.type === "request.started" ||
-				event.type === "request.streaming" ||
-				event.type === "request.completed"
-			) {
-				if (viewMode === "paginate") {
-					queryClient.invalidateQueries({ queryKey: ["logs"] });
-				}
-			}
-		};
-		window.addEventListener("server-event", handler);
-		return () => window.removeEventListener("server-event", handler);
-	}, [liveEnabled, queryClient, viewMode]);
 	const handleSort = useCallback((field: LogSortField) => {
 		setSort((prev) => ({
 			field,
@@ -166,47 +94,6 @@ function RequestLogs() {
 	const { data: settings } = useQuery({
 		queryKey: ["settings"],
 		queryFn: () => api.settings.get(),
-	});
-
-	const {
-		data: logsData,
-		isLoading,
-		error,
-	} = useQuery({
-		queryKey: [
-			"logs",
-			page,
-			pageSize,
-			debouncedModelId,
-			debouncedProviderId,
-			filters.status_code,
-			filters.endpoint_type,
-			filters.virtual_key_id,
-			filters.owner_user_id,
-			dateFrom,
-			dateTo,
-			sort,
-		],
-		queryFn: () =>
-			api.logs.list({
-				page,
-				per_page: pageSize,
-				model_id: debouncedModelId || undefined,
-				provider_id: debouncedProviderId || undefined,
-				status_code: filters.status_code || undefined,
-				endpoint_type: filters.endpoint_type || undefined,
-				virtual_key_id: filters.virtual_key_id || undefined,
-				owner_user_id: filters.owner_user_id || undefined,
-				from: dateFrom || undefined,
-				to: dateTo || undefined,
-				sort_by: sort.field,
-				sort_dir: sort.dir,
-			}),
-		refetchInterval:
-			viewMode === "paginate" && liveEnabled && isVisible ? 30000 : false,
-		refetchIntervalInBackground: false,
-		refetchOnWindowFocus: "always",
-		placeholderData: keepPreviousData,
 	});
 
 	// --- Virtual scroll mode data ---
@@ -270,95 +157,53 @@ function RequestLogs() {
 		getId: (entry) => entry.id,
 	});
 
-	// Slow poll fallback for scroll mode (catches SSE disconnects)
-	useEffect(() => {
-		if (viewMode !== "scroll" || !liveEnabled) return;
-		const interval = setInterval(() => {
-			if (!document.hidden) {
-				scrollFetchNewer();
-			}
-		}, 60000);
-		return () => clearInterval(interval);
-	}, [viewMode, liveEnabled, scrollFetchNewer]);
+	const { isVisible } = useRequestLogLiveUpdates({
+		viewMode,
+		liveEnabled,
+		fetchNewer: scrollFetchNewer,
+		mergeEntries: scrollMergeEntries,
+	});
 
-	// Visibility/focus refresh for scroll mode
-	useEffect(() => {
-		if (viewMode !== "scroll" || !liveEnabled) return;
-		const handler = () => {
-			if (!document.hidden) {
-				scrollFetchNewer();
-			}
-		};
-		document.addEventListener("visibilitychange", handler);
-		return () => document.removeEventListener("visibilitychange", handler);
-	}, [viewMode, liveEnabled, scrollFetchNewer]);
-
-	// SSE-driven live updates for scroll mode
-	useEffect(() => {
-		if (viewMode !== "scroll" || !liveEnabled) return;
-		const handler = async (e: Event) => {
-			const event = (e as CustomEvent).detail;
-			if (event.type === "request.completed") {
-				// Fetch the completed entry by ID and merge it into
-				// the existing entries so the row shows final metrics
-				// (provider, tokens, duration, etc.) instead of the
-				// placeholder values from the initial INSERT.
-				const requestId: string | undefined = event.metadata?.request_id;
-				if (requestId) {
-					try {
-						const entry = await api.logs.get(requestId);
-						scrollMergeEntries([entry]);
-					} catch {
-						// Fall back to fetchNewer on error (e.g. row
-						// was purged between event and fetch)
-						scrollFetchNewer();
-					}
-				} else {
-					// Fallback when request_id is missing from the
-					// event payload (e.g. schema change, old server)
-					scrollFetchNewer();
-				}
-				// Always fetchNewer after request.completed to cover
-				// the race where the pending row hasn't been added to
-				// the list yet (request.started fetch still in-flight).
-				// fetchNewer is guarded against concurrent calls.
-				scrollFetchNewer();
-			} else if (event.type === "request.streaming") {
-				// The provider just committed mid-stream: fetch the row by
-				// ID and merge so it swaps "Resolving" for the real
-				// provider/model (and the "Streaming" state) without waiting
-				// for request.completed. mergeEntries only updates rows that
-				// are already in the list, so the trailing fetchNewer covers
-				// the race where the pending row hasn't landed yet.
-				const requestId: string | undefined = event.metadata?.request_id;
-				if (requestId) {
-					try {
-						const entry = await api.logs.get(requestId);
-						scrollMergeEntries([entry]);
-					} catch {
-						// Fall back to fetchNewer on error (e.g. row
-						// was purged between event and fetch)
-						scrollFetchNewer();
-						return;
-					}
-				} else {
-					// Fallback when request_id is missing from the
-					// event payload (e.g. schema change, old server)
-					scrollFetchNewer();
-					return;
-				}
-				// Always fetchNewer after request.streaming to cover
-				// the race where the pending row hasn't been added to
-				// the list yet (request.started fetch still in-flight).
-				// fetchNewer is guarded against concurrent calls.
-				scrollFetchNewer();
-			} else if (event.type === "request.started") {
-				scrollFetchNewer();
-			}
-		};
-		window.addEventListener("server-event", handler);
-		return () => window.removeEventListener("server-event", handler);
-	}, [viewMode, liveEnabled, scrollFetchNewer, scrollMergeEntries]);
+	const {
+		data: logsData,
+		isLoading,
+		error,
+	} = useQuery({
+		queryKey: [
+			"logs",
+			page,
+			pageSize,
+			debouncedModelId,
+			debouncedProviderId,
+			filters.status_code,
+			filters.endpoint_type,
+			filters.virtual_key_id,
+			filters.owner_user_id,
+			dateFrom,
+			dateTo,
+			sort,
+		],
+		queryFn: () =>
+			api.logs.list({
+				page,
+				per_page: pageSize,
+				model_id: debouncedModelId || undefined,
+				provider_id: debouncedProviderId || undefined,
+				status_code: filters.status_code || undefined,
+				endpoint_type: filters.endpoint_type || undefined,
+				virtual_key_id: filters.virtual_key_id || undefined,
+				owner_user_id: filters.owner_user_id || undefined,
+				from: dateFrom || undefined,
+				to: dateTo || undefined,
+				sort_by: sort.field,
+				sort_dir: sort.dir,
+			}),
+		refetchInterval:
+			viewMode === "paginate" && liveEnabled && isVisible ? 30000 : false,
+		refetchIntervalInBackground: false,
+		refetchOnWindowFocus: "always",
+		placeholderData: keepPreviousData,
+	});
 
 	// Distinguish between "no data has arrived yet" (loading) and
 	// "data arrived but the result set is empty" (0 matching rows).
@@ -378,45 +223,11 @@ function RequestLogs() {
 		onNext: () => setPage(logsSafePage + 1),
 	});
 
-	// A request stuck in pending/streaming longer than the configured timeout
-	// is almost certainly dead (server crash, unhandled error, etc.) - treat it
-	// as stale rather than showing a permanently pulsing "Resolving…" / "Live" row.
-	// Default 30m to accommodate providers with long time-to-first-token.
-	// The setting is stored as a Go duration string (e.g. "30m0s", "1h0m0s").
-	const parseGoDuration = (d: string): number => {
-		let ms = 0;
-		const h = d.match(/(\d+)h/);
-		const m = d.match(/(\d+)m(?!s)/);
-		const s = d.match(/(\d+)s/);
-		if (h) ms += parseInt(h[1], 10) * 3600000;
-		if (m) ms += parseInt(m[1], 10) * 60000;
-		if (s) ms += parseInt(s[1], 10) * 1000;
-		return ms;
-	};
-	const staleMs = parseGoDuration(settings?.stale_request_timeout || "30m0s");
-	const STALE_THRESHOLD_MS = staleMs > 0 ? staleMs : 30 * 60 * 1000;
-	const [nowMs, setNowMs] = useState(() => Date.now());
-	// In-progress rows show a live-ticking duration, so when any are present we
-	// tick every second; otherwise a coarse 60s tick is enough to age rows into
-	// the "stale" state without re-rendering the table needlessly.
-	const hasLiveEntries = displayEntries.some(
-		(log) => log.state === "pending" || log.state === "streaming",
+	const { nowMs, staleThresholdMs } = useStaleClock(
+		settings?.stale_request_timeout,
+		displayEntries,
 	);
-	useEffect(() => {
-		const id = setInterval(
-			() => {
-				setNowMs(Date.now());
-			},
-			hasLiveEntries ? 1_000 : 60_000,
-		);
-		return () => clearInterval(id);
-	}, [hasLiveEntries]);
-
-	const isStale = (log: LogEntry) =>
-		isStaleShared(log, nowMs, STALE_THRESHOLD_MS);
-
-	const isInProgress = (log: LogEntry) =>
-		isInProgressShared(log, nowMs, STALE_THRESHOLD_MS);
+	const columns = requestLogColumns(t);
 
 	return (
 		<>
@@ -456,147 +267,21 @@ function RequestLogs() {
 					}
 				/>
 
-				{/* Controls */}
-				<div className="ui-card has-dropdown p-4 shrink-0">
-					<div className="flex items-center justify-between">
-						<div className="flex items-center gap-1">
-							<button
-								type="button"
-								onClick={() => setLogsSubMode("request")}
-								className={`ui-btn ${
-									logsSubMode === "request"
-										? "ui-btn-primary ui-btn-static"
-										: "ui-btn-secondary"
-								}`}
-							>
-								<ScrollText size={12} className="inline mr-1 -mt-0.5" />
-								{t("logs.tabs.requests")}
-							</button>
-							<button
-								type="button"
-								onClick={() => setLogsSubMode("app")}
-								className={`ui-btn ${
-									logsSubMode === "app"
-										? "ui-btn-primary ui-btn-static"
-										: "ui-btn-secondary"
-								}`}
-							>
-								<FileText size={12} className="inline mr-1 -mt-0.5" />
-								{t("logs.tabs.logs")}
-							</button>
-						</div>
-						<div className="flex items-center gap-2">
-							<ViewModeToggle viewMode={viewMode} onChange={setViewMode} />
-							<FilterInput
-								value={filters.model_id}
-								onChange={(v) => {
-									setFilters({ ...filters, model_id: v });
-									setPage(1);
-								}}
-								placeholder={t("logs.filters.modelPlaceholder")}
-								className="w-43"
-								autoFocus
-							/>
-							<FilterInput
-								value={filters.provider_id}
-								onChange={(v) => {
-									setFilters({ ...filters, provider_id: v });
-									setPage(1);
-								}}
-								placeholder={t("logs.filters.providerPlaceholder")}
-								className="w-43"
-							/>
-							<FilterDropdown
-								value={filters.status_code}
-								onChange={(v) => {
-									setFilters({ ...filters, status_code: v });
-									setPage(1);
-								}}
-								placeholder={t("logs.filters.status")}
-								allLabel={t("logs.filters.allStatus")}
-								options={[
-									{ value: "2xx", label: "2XX" },
-									{ value: "4xx", label: "4XX" },
-									{ value: "5xx", label: "5XX" },
-									{ value: "0", label: "0" },
-								]}
-								className="w-31"
-							/>
-							<FilterDropdown
-								value={filters.endpoint_type}
-								onChange={(v) => {
-									setFilters({ ...filters, endpoint_type: v });
-									setPage(1);
-								}}
-								placeholder={t("logs.filters.endpoint")}
-								allLabel={t("logs.filters.allEndpoints")}
-								options={ENDPOINT_FILTER_OPTIONS.map((o) => ({
-									value: o.value,
-									label: t(o.labelKey),
-								}))}
-								className="w-38"
-							/>
-
-							{(keyOptions?.length ?? 0) > 0 && (
-								<FilterDropdown
-									value={filters.virtual_key_id}
-									onChange={(v) => {
-										setFilters({ ...filters, virtual_key_id: v });
-										setPage(1);
-									}}
-									placeholder={t("logs.filters.key")}
-									allLabel={t("logs.filters.allKeys")}
-									options={(keyOptions ?? []).map((k) => ({
-										value: k.id,
-										label: k.name,
-									}))}
-									className="w-28"
-								/>
-							)}
-
-							{isAdmin && (ownerOptions?.length ?? 0) > 0 && (
-								<FilterDropdown
-									value={filters.owner_user_id}
-									onChange={(v) => {
-										setFilters({ ...filters, owner_user_id: v });
-										setPage(1);
-									}}
-									placeholder={t("logs.filters.owner")}
-									allLabel={t("logs.filters.allOwners")}
-									options={(ownerOptions ?? []).map((u) => ({
-										value: u.id,
-										label: u.username,
-									}))}
-									className="w-30"
-								/>
-							)}
-
-							<div className="relative" ref={datePickerRef}>
-								<DateFilterButton
-									hasDateFilter={hasDateFilter}
-									dateFrom={dateFrom}
-									dateTo={dateTo}
-									onToggleDatePicker={toggleDatePicker}
-									onClearDateFilter={clearDateFilter}
-								/>
-								{showDatePicker && (
-									<DateRangePickerPopover
-										pickerYear={pickerYear}
-										pickerMonth={pickerMonth}
-										pendingFrom={pendingFrom}
-										pendingTo={pendingTo}
-										onCalendarSelect={handleCalendarSelect}
-										onApply={applyDateFilter}
-										onClear={clearDateFilter}
-										onClose={closeDatePicker}
-										anchor="right"
-										triggerRef={datePickerRef}
-									/>
-								)}
-							</div>
-						</div>
-					</div>
-				</div>
+				<RequestLogFilters
+					logsSubMode={logsSubMode}
+					onSubModeChange={setLogsSubMode}
+					viewMode={viewMode}
+					onViewModeChange={setViewMode}
+					filters={filters}
+					onFilterChange={(patch) => {
+						setFilters({ ...filters, ...patch });
+						setPage(1);
+					}}
+					keyOptions={keyOptions}
+					ownerOptions={ownerOptions}
+					isAdmin={isAdmin}
+					datePicker={datePicker}
+				/>
 
 				{/* Initial loading state - show spinner when first fetch hasn't arrived */}
 				{isLoading && !logsData && <LoadingSpinner />}
@@ -620,291 +305,29 @@ function RequestLogs() {
 							</colgroup>
 							<thead>
 								<tr>
-									<SortableHeader
-										label={t("logs.table.timeDate")}
-										field="time"
-										sort={sort}
-										onSort={handleSort}
-										tooltip={t("logs.tooltip.timeDate")}
-									/>
-									<SortableHeader
-										label={t("logs.table.model")}
-										field="model"
-										sort={sort}
-										onSort={handleSort}
-										tooltip={t("logs.tooltip.model")}
-									/>
-									<SortableHeader
-										label={t("logs.table.provider")}
-										field="provider"
-										sort={sort}
-										onSort={handleSort}
-										tooltip={t("logs.tooltip.provider")}
-									/>
-									<SortableHeader
-										label={t("logs.table.status")}
-										field="status"
-										sort={sort}
-										onSort={handleSort}
-										tooltip={t("logs.tooltip.status")}
-									/>
-									<SortableHeader
-										label={t("logs.table.tokens")}
-										field="tokens"
-										sort={sort}
-										onSort={handleSort}
-										tooltip={t("logs.tooltip.tokens")}
-									/>
-									<SortableHeader
-										label={t("logs.table.tps")}
-										field="tps"
-										sort={sort}
-										onSort={handleSort}
-										tooltip={t("logs.tooltip.tps")}
-									/>
-									<SortableHeader
-										label={t("logs.table.headers")}
-										field="response_header_ms"
-										sort={sort}
-										onSort={handleSort}
-										tooltip={t("logs.tooltip.headers")}
-									/>
-									<SortableHeader
-										label={t("logs.table.ttft")}
-										field="ttft"
-										sort={sort}
-										onSort={handleSort}
-										tooltip={t("logs.tooltip.ttft")}
-									/>
-									<SortableHeader
-										label={t("logs.table.duration")}
-										field="duration"
-										sort={sort}
-										onSort={handleSort}
-										tooltip={t("logs.tooltip.duration")}
-									/>
-									<SortableHeader
-										label={t("logs.table.overhead")}
-										field="overhead"
-										sort={sort}
-										onSort={handleSort}
-										tooltip={t("logs.tooltip.overhead")}
-									/>
-									<SortableHeader
-										label={t("logs.table.key")}
-										field="key"
-										sort={sort}
-										onSort={handleSort}
-										tooltip={t("logs.tooltip.key")}
-									/>
-									<SortableHeader
-										label={t("logs.table.ip")}
-										field="ip"
-										sort={sort}
-										onSort={handleSort}
-										tooltip={t("logs.tooltip.ip")}
-									/>
+									{columns.map((col) => (
+										<SortableHeader
+											key={col.field}
+											label={col.label}
+											field={col.field}
+											sort={sort}
+											onSort={handleSort}
+											tooltip={col.tooltip}
+										/>
+									))}
 								</tr>
 							</thead>
 							<tbody>
 								{displayEntries && displayEntries.length > 0 ? (
-									displayEntries.map((log) => {
-										const hasOverhead =
-											log.proxy_overhead_ms != null &&
-											log.proxy_overhead_ms > 0 &&
-											(log.parse_ms > 0 ||
-												log.model_lookup_ms > 0 ||
-												log.provider_lookup_ms > 0 ||
-												log.key_decrypt_ms > 0);
-										return (
-											<Row
-												key={log.id}
-												className={
-													isInProgress(log) ? "animate-pulse-subtle" : ""
-												}
-												onClick={() => setSelectedLog(log)}
-											>
-												<td className="px-2 py-1 whitespace-nowrap text-xs text-gray-400 font-mono">
-													{log.created_at
-														? new Date(log.created_at).toLocaleString()
-														: "-"}
-												</td>
-												<td
-													className="px-2 py-1 whitespace-nowrap text-xs text-gray-200 truncate"
-													title={
-														log.model_id?.startsWith("hotel/") &&
-														log.resolved_model_id
-															? `${log.model_id} (${log.resolved_model_id})`
-															: log.model_id
-													}
-												>
-													<EndpointTypeBadge endpointType={log.endpoint_type} />
-													{log.model_id ? (
-														log.model_id.startsWith("hotel/") ? (
-															<>
-																<span className="text-(--accent)">
-																	{log.model_id}
-																</span>
-																{log.resolved_model_id && (
-																	<span className="text-gray-500">
-																		{" "}
-																		({log.resolved_model_id})
-																	</span>
-																)}
-															</>
-														) : log.model_id.includes("/") ? (
-															log.model_id.slice(log.model_id.indexOf("/") + 1)
-														) : (
-															log.model_id
-														)
-													) : (
-														"-"
-													)}
-												</td>
-												<td
-													className="px-2 py-1 whitespace-nowrap text-xs text-gray-300 truncate"
-													title={log.provider_name || undefined}
-												>
-													{log.provider_name === "Deleted" ? (
-														<span
-															className="text-red-400 italic"
-															title={t("logs.table.providerDeleted")}
-														>
-															{t("logs.table.deletedProvider")}
-														</span>
-													) : isInProgress(log) && !log.provider_name ? (
-														<span className="text-blue-400/60 italic">
-															{t("logs.table.resolving")}
-														</span>
-													) : (
-														log.provider_name || "-"
-													)}
-												</td>
-												<td className="px-2 py-1 whitespace-nowrap">
-													<Badge
-														variant={getRowStatusVariant(
-															log,
-															nowMs,
-															STALE_THRESHOLD_MS,
-														)}
-														className="gap-1 whitespace-nowrap"
-													>
-														{isStale(log) ? (
-															<span className="text-yellow-500/70">⚠</span>
-														) : isInProgress(log) ? (
-															<span className="text-blue-400">
-																{log.state === "streaming"
-																	? t("logs.table.live")
-																	: "…"}
-															</span>
-														) : (
-															log.status_code
-														)}
-													</Badge>
-												</td>
-												<td className="px-2 py-1 whitespace-nowrap text-xs text-gray-400 font-mono">
-													{isCancelled(log) ? (
-														t("logs.table.interrupted")
-													) : log.tokens_prompt + log.tokens_completion > 0 ? (
-														<>
-															{formatNumber(log.tokens_prompt)}
-															<span className="text-gray-600">+</span>
-															{formatNumber(log.tokens_completion)}
-														</>
-													) : (
-														"-"
-													)}
-												</td>
-												<td className="px-2 py-1 whitespace-nowrap text-xs font-mono">
-													{isCancelled(log) ? (
-														"-"
-													) : (
-														<span
-															className={
-																log.tokens_prompt_cache_hit > 0
-																	? "opacity-50"
-																	: undefined
-															}
-															title={
-																log.tokens_prompt_cache_hit > 0
-																	? t("logs.table.cacheInflated")
-																	: undefined
-															}
-														>
-															{formatTPS(log.tokens_per_second)}
-														</span>
-													)}
-												</td>
-												<td className="px-2 py-1 whitespace-nowrap text-xs text-gray-400 font-mono">
-													{log.response_header_ms > 0
-														? formatMs(log.response_header_ms, 1)
-														: "-"}
-												</td>
-												<td className="px-2 py-1 whitespace-nowrap text-xs text-gray-400 font-mono">
-													{log.ttft_ms > 0 ? formatMs(log.ttft_ms, 1) : "-"}
-												</td>
-												<td className="px-2 py-1 whitespace-nowrap text-xs text-gray-400 font-mono">
-													{isInProgress(log) && log.duration_ms === 0 ? (
-														<span className="inline-block text-blue-400">
-															{formatDurationCell(
-																liveDurationMs(log.created_at, nowMs),
-															)}
-														</span>
-													) : log.duration_ms > 0 ? (
-														formatDurationCell(log.duration_ms)
-													) : (
-														"-"
-													)}
-												</td>
-												<td className="px-2 py-1 whitespace-nowrap text-xs font-mono">
-													{log.proxy_overhead_ms != null &&
-													log.proxy_overhead_ms > 0 ? (
-														<span
-															className={
-																hasOverhead
-																	? "text-(--accent)"
-																	: "text-gray-400"
-															}
-														>
-															{formatMs(log.proxy_overhead_ms)}
-														</span>
-													) : (
-														<span className="text-gray-400">-</span>
-													)}
-												</td>
-												<td
-													className="px-2 py-1 text-xs text-gray-400 max-w-[7rem] truncate"
-													title={
-														log.virtual_key_deleted
-															? undefined
-															: log.virtual_key_name ||
-																log.virtual_key_id ||
-																undefined
-													}
-												>
-													{log.virtual_key_deleted ? (
-														<span className="text-red-400 italic">
-															{t("logs.table.keyDeleted")}
-														</span>
-													) : log.virtual_key_name &&
-														log.virtual_key_name.toLowerCase() ===
-															"internal" ? (
-														<span className="text-gray-400 italic">
-															{t("common.internal")}
-														</span>
-													) : (
-														log.virtual_key_name || log.virtual_key_id || "-"
-													)}
-												</td>
-												<td
-													className="px-2 py-1 whitespace-nowrap text-xs text-gray-400 font-mono truncate"
-													title={log.client_ip || undefined}
-												>
-													{log.client_ip || "-"}
-												</td>
-											</Row>
-										);
-									})
+									displayEntries.map((log) => (
+										<RequestLogRow
+											key={log.id}
+											log={log}
+											nowMs={nowMs}
+											staleThresholdMs={staleThresholdMs}
+											onClick={() => setSelectedLog(log)}
+										/>
+									))
 								) : (
 									<EmptyRow
 										colSpan={12}
@@ -940,7 +363,7 @@ function RequestLogs() {
 								onFetchOlder={scrollFetchOlder}
 								onRowClick={(entry) => setSelectedLog(entry)}
 								nowMs={nowMs}
-								staleThresholdMs={STALE_THRESHOLD_MS}
+								staleThresholdMs={staleThresholdMs}
 								sortDir={scrollSortDir}
 								onSortToggle={() =>
 									setSort((prev) => ({

--- a/web/src/pages/Logs/RequestLogFilters.tsx
+++ b/web/src/pages/Logs/RequestLogFilters.tsx
@@ -1,0 +1,193 @@
+import { useTranslation } from "react-i18next";
+import { FileText, ScrollText } from "@/lib/icons";
+import type { DashboardUser, VirtualKey } from "../../api/types";
+import { FilterDropdown } from "../../components/FilterDropdown";
+import { FilterInput } from "../../components/FilterInput";
+import {
+	DateFilterButton,
+	DateRangePickerPopover,
+	ENDPOINT_FILTER_OPTIONS,
+} from "../../components/logs";
+import { ViewModeToggle } from "../../components/ViewModeToggle";
+import type { useDateRangePicker } from "../../hooks/useDateRangePicker";
+
+export interface RequestLogFilterValues {
+	model_id: string;
+	provider_id: string;
+	status_code: string;
+	endpoint_type: string;
+	virtual_key_id: string;
+	owner_user_id: string;
+}
+
+/**
+ * The controls card above the request table: the Requests / Logs sub-mode
+ * switch, the view-mode toggle, the filter inputs and dropdowns, and the date
+ * range picker. Every filter change goes through `onFilterChange`, which the
+ * page pairs with a reset to page 1.
+ */
+export function RequestLogFilters({
+	logsSubMode,
+	onSubModeChange,
+	viewMode,
+	onViewModeChange,
+	filters,
+	onFilterChange,
+	keyOptions,
+	ownerOptions,
+	isAdmin,
+	datePicker,
+}: {
+	logsSubMode: "request" | "app";
+	onSubModeChange: (mode: "request" | "app") => void;
+	viewMode: "paginate" | "scroll";
+	onViewModeChange: (mode: "paginate" | "scroll") => void;
+	filters: RequestLogFilterValues;
+	onFilterChange: (patch: Partial<RequestLogFilterValues>) => void;
+	keyOptions: VirtualKey[] | undefined;
+	ownerOptions: DashboardUser[] | undefined;
+	isAdmin: boolean;
+	datePicker: ReturnType<typeof useDateRangePicker>;
+}) {
+	const { t } = useTranslation();
+	const {
+		dateFrom,
+		dateTo,
+		showDatePicker,
+		pendingFrom,
+		pendingTo,
+		datePickerRef,
+		hasDateFilter,
+		pickerYear,
+		pickerMonth,
+		handleCalendarSelect,
+		applyDateFilter,
+		clearDateFilter,
+		toggleDatePicker,
+		closeDatePicker,
+	} = datePicker;
+	return (
+		<div className="ui-card has-dropdown p-4 shrink-0">
+			<div className="flex items-center justify-between">
+				<div className="flex items-center gap-1">
+					<button
+						type="button"
+						onClick={() => onSubModeChange("request")}
+						className={`ui-btn ${
+							logsSubMode === "request"
+								? "ui-btn-primary ui-btn-static"
+								: "ui-btn-secondary"
+						}`}
+					>
+						<ScrollText size={12} className="inline mr-1 -mt-0.5" />
+						{t("logs.tabs.requests")}
+					</button>
+					<button
+						type="button"
+						onClick={() => onSubModeChange("app")}
+						className={`ui-btn ${
+							logsSubMode === "app"
+								? "ui-btn-primary ui-btn-static"
+								: "ui-btn-secondary"
+						}`}
+					>
+						<FileText size={12} className="inline mr-1 -mt-0.5" />
+						{t("logs.tabs.logs")}
+					</button>
+				</div>
+				<div className="flex items-center gap-2">
+					<ViewModeToggle viewMode={viewMode} onChange={onViewModeChange} />
+					<FilterInput
+						value={filters.model_id}
+						onChange={(model_id) => onFilterChange({ model_id })}
+						placeholder={t("logs.filters.modelPlaceholder")}
+						className="w-43"
+						autoFocus
+					/>
+					<FilterInput
+						value={filters.provider_id}
+						onChange={(provider_id) => onFilterChange({ provider_id })}
+						placeholder={t("logs.filters.providerPlaceholder")}
+						className="w-43"
+					/>
+					<FilterDropdown
+						value={filters.status_code}
+						onChange={(status_code) => onFilterChange({ status_code })}
+						placeholder={t("logs.filters.status")}
+						allLabel={t("logs.filters.allStatus")}
+						options={[
+							{ value: "2xx", label: "2XX" },
+							{ value: "4xx", label: "4XX" },
+							{ value: "5xx", label: "5XX" },
+							{ value: "0", label: "0" },
+						]}
+						className="w-31"
+					/>
+					<FilterDropdown
+						value={filters.endpoint_type}
+						onChange={(endpoint_type) => onFilterChange({ endpoint_type })}
+						placeholder={t("logs.filters.endpoint")}
+						allLabel={t("logs.filters.allEndpoints")}
+						options={ENDPOINT_FILTER_OPTIONS.map((o) => ({
+							value: o.value,
+							label: t(o.labelKey),
+						}))}
+						className="w-38"
+					/>
+
+					{(keyOptions?.length ?? 0) > 0 && (
+						<FilterDropdown
+							value={filters.virtual_key_id}
+							onChange={(virtual_key_id) => onFilterChange({ virtual_key_id })}
+							placeholder={t("logs.filters.key")}
+							allLabel={t("logs.filters.allKeys")}
+							options={(keyOptions ?? []).map((k) => ({
+								value: k.id,
+								label: k.name,
+							}))}
+							className="w-28"
+						/>
+					)}
+
+					{isAdmin && (ownerOptions?.length ?? 0) > 0 && (
+						<FilterDropdown
+							value={filters.owner_user_id}
+							onChange={(owner_user_id) => onFilterChange({ owner_user_id })}
+							placeholder={t("logs.filters.owner")}
+							allLabel={t("logs.filters.allOwners")}
+							options={(ownerOptions ?? []).map((u) => ({
+								value: u.id,
+								label: u.username,
+							}))}
+							className="w-30"
+						/>
+					)}
+
+					<div className="relative" ref={datePickerRef}>
+						<DateFilterButton
+							hasDateFilter={hasDateFilter}
+							dateFrom={dateFrom}
+							dateTo={dateTo}
+							onToggleDatePicker={toggleDatePicker}
+							onClearDateFilter={clearDateFilter}
+						/>
+						{showDatePicker && (
+							<DateRangePickerPopover
+								pickerYear={pickerYear}
+								pickerMonth={pickerMonth}
+								pendingFrom={pendingFrom}
+								pendingTo={pendingTo}
+								onCalendarSelect={handleCalendarSelect}
+								onApply={applyDateFilter}
+								onClear={clearDateFilter}
+								onClose={closeDatePicker}
+								anchor="right"
+								triggerRef={datePickerRef}
+							/>
+						)}
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/web/src/pages/Logs/RequestLogRow.tsx
+++ b/web/src/pages/Logs/RequestLogRow.tsx
@@ -1,0 +1,192 @@
+import { useTranslation } from "react-i18next";
+import type { LogEntry } from "../../api/types";
+import { Badge } from "../../components/Badge";
+import { Row } from "../../components/DataTable";
+import { EndpointTypeBadge } from "../../components/logs";
+import { formatNumber } from "../../utils/format";
+import {
+	formatDurationCell,
+	getRowStatusVariant,
+	isCancelled,
+	isInProgress,
+	isStale,
+	liveDurationMs,
+} from "../../utils/logHelpers";
+import { formatMs, formatTPS } from "./utils";
+
+/** One request in the paginated table. Cells match LOG_COL_WIDTHS in order. */
+export function RequestLogRow({
+	log,
+	nowMs,
+	staleThresholdMs,
+	onClick,
+}: {
+	log: LogEntry;
+	nowMs: number;
+	staleThresholdMs: number;
+	onClick: () => void;
+}) {
+	const { t } = useTranslation();
+	const inProgress = isInProgress(log, nowMs, staleThresholdMs);
+	const stale = isStale(log, nowMs, staleThresholdMs);
+	const hasOverhead =
+		log.proxy_overhead_ms != null &&
+		log.proxy_overhead_ms > 0 &&
+		(log.parse_ms > 0 ||
+			log.model_lookup_ms > 0 ||
+			log.provider_lookup_ms > 0 ||
+			log.key_decrypt_ms > 0);
+	return (
+		<Row className={inProgress ? "animate-pulse-subtle" : ""} onClick={onClick}>
+			<td className="px-2 py-1 whitespace-nowrap text-xs text-gray-400 font-mono">
+				{log.created_at ? new Date(log.created_at).toLocaleString() : "-"}
+			</td>
+			<td
+				className="px-2 py-1 whitespace-nowrap text-xs text-gray-200 truncate"
+				title={
+					log.model_id?.startsWith("hotel/") && log.resolved_model_id
+						? `${log.model_id} (${log.resolved_model_id})`
+						: log.model_id
+				}
+			>
+				<EndpointTypeBadge endpointType={log.endpoint_type} />
+				{log.model_id ? (
+					log.model_id.startsWith("hotel/") ? (
+						<>
+							<span className="text-(--accent)">{log.model_id}</span>
+							{log.resolved_model_id && (
+								<span className="text-gray-500">
+									{" "}
+									({log.resolved_model_id})
+								</span>
+							)}
+						</>
+					) : log.model_id.includes("/") ? (
+						log.model_id.slice(log.model_id.indexOf("/") + 1)
+					) : (
+						log.model_id
+					)
+				) : (
+					"-"
+				)}
+			</td>
+			<td
+				className="px-2 py-1 whitespace-nowrap text-xs text-gray-300 truncate"
+				title={log.provider_name || undefined}
+			>
+				{log.provider_name === "Deleted" ? (
+					<span
+						className="text-red-400 italic"
+						title={t("logs.table.providerDeleted")}
+					>
+						{t("logs.table.deletedProvider")}
+					</span>
+				) : inProgress && !log.provider_name ? (
+					<span className="text-blue-400/60 italic">
+						{t("logs.table.resolving")}
+					</span>
+				) : (
+					log.provider_name || "-"
+				)}
+			</td>
+			<td className="px-2 py-1 whitespace-nowrap">
+				<Badge
+					variant={getRowStatusVariant(log, nowMs, staleThresholdMs)}
+					className="gap-1 whitespace-nowrap"
+				>
+					{stale ? (
+						<span className="text-yellow-500/70">⚠</span>
+					) : inProgress ? (
+						<span className="text-blue-400">
+							{log.state === "streaming" ? t("logs.table.live") : "…"}
+						</span>
+					) : (
+						log.status_code
+					)}
+				</Badge>
+			</td>
+			<td className="px-2 py-1 whitespace-nowrap text-xs text-gray-400 font-mono">
+				{isCancelled(log) ? (
+					t("logs.table.interrupted")
+				) : log.tokens_prompt + log.tokens_completion > 0 ? (
+					<>
+						{formatNumber(log.tokens_prompt)}
+						<span className="text-gray-600">+</span>
+						{formatNumber(log.tokens_completion)}
+					</>
+				) : (
+					"-"
+				)}
+			</td>
+			<td className="px-2 py-1 whitespace-nowrap text-xs font-mono">
+				{isCancelled(log) ? (
+					"-"
+				) : (
+					<span
+						className={
+							log.tokens_prompt_cache_hit > 0 ? "opacity-50" : undefined
+						}
+						title={
+							log.tokens_prompt_cache_hit > 0
+								? t("logs.table.cacheInflated")
+								: undefined
+						}
+					>
+						{formatTPS(log.tokens_per_second)}
+					</span>
+				)}
+			</td>
+			<td className="px-2 py-1 whitespace-nowrap text-xs text-gray-400 font-mono">
+				{log.response_header_ms > 0 ? formatMs(log.response_header_ms, 1) : "-"}
+			</td>
+			<td className="px-2 py-1 whitespace-nowrap text-xs text-gray-400 font-mono">
+				{log.ttft_ms > 0 ? formatMs(log.ttft_ms, 1) : "-"}
+			</td>
+			<td className="px-2 py-1 whitespace-nowrap text-xs text-gray-400 font-mono">
+				{inProgress && log.duration_ms === 0 ? (
+					<span className="inline-block text-blue-400">
+						{formatDurationCell(liveDurationMs(log.created_at, nowMs))}
+					</span>
+				) : log.duration_ms > 0 ? (
+					formatDurationCell(log.duration_ms)
+				) : (
+					"-"
+				)}
+			</td>
+			<td className="px-2 py-1 whitespace-nowrap text-xs font-mono">
+				{log.proxy_overhead_ms != null && log.proxy_overhead_ms > 0 ? (
+					<span className={hasOverhead ? "text-(--accent)" : "text-gray-400"}>
+						{formatMs(log.proxy_overhead_ms)}
+					</span>
+				) : (
+					<span className="text-gray-400">-</span>
+				)}
+			</td>
+			<td
+				className="px-2 py-1 text-xs text-gray-400 max-w-[7rem] truncate"
+				title={
+					log.virtual_key_deleted
+						? undefined
+						: log.virtual_key_name || log.virtual_key_id || undefined
+				}
+			>
+				{log.virtual_key_deleted ? (
+					<span className="text-red-400 italic">
+						{t("logs.table.keyDeleted")}
+					</span>
+				) : log.virtual_key_name &&
+					log.virtual_key_name.toLowerCase() === "internal" ? (
+					<span className="text-gray-400 italic">{t("common.internal")}</span>
+				) : (
+					log.virtual_key_name || log.virtual_key_id || "-"
+				)}
+			</td>
+			<td
+				className="px-2 py-1 whitespace-nowrap text-xs text-gray-400 font-mono truncate"
+				title={log.client_ip || undefined}
+			>
+				{log.client_ip || "-"}
+			</td>
+		</Row>
+	);
+}

--- a/web/src/pages/Logs/requestLogColumns.ts
+++ b/web/src/pages/Logs/requestLogColumns.ts
@@ -1,0 +1,87 @@
+import type { TFunction } from "i18next";
+
+export type LogSortField =
+	| "time"
+	| "model"
+	| "provider"
+	| "status"
+	| "tokens"
+	| "tps"
+	| "response_header_ms"
+	| "ttft"
+	| "duration"
+	| "overhead"
+	| "key"
+	| "ip";
+
+export interface RequestLogColumn {
+	field: LogSortField;
+	label: string;
+	tooltip: string;
+}
+
+/**
+ * The request table's sortable columns, in display order. Built from `t`
+ * rather than declared with key strings so every label stays a literal
+ * t() call the i18n source-key check can follow.
+ */
+export function requestLogColumns(t: TFunction): RequestLogColumn[] {
+	return [
+		{
+			field: "time",
+			label: t("logs.table.timeDate"),
+			tooltip: t("logs.tooltip.timeDate"),
+		},
+		{
+			field: "model",
+			label: t("logs.table.model"),
+			tooltip: t("logs.tooltip.model"),
+		},
+		{
+			field: "provider",
+			label: t("logs.table.provider"),
+			tooltip: t("logs.tooltip.provider"),
+		},
+		{
+			field: "status",
+			label: t("logs.table.status"),
+			tooltip: t("logs.tooltip.status"),
+		},
+		{
+			field: "tokens",
+			label: t("logs.table.tokens"),
+			tooltip: t("logs.tooltip.tokens"),
+		},
+		{
+			field: "tps",
+			label: t("logs.table.tps"),
+			tooltip: t("logs.tooltip.tps"),
+		},
+		{
+			field: "response_header_ms",
+			label: t("logs.table.headers"),
+			tooltip: t("logs.tooltip.headers"),
+		},
+		{
+			field: "ttft",
+			label: t("logs.table.ttft"),
+			tooltip: t("logs.tooltip.ttft"),
+		},
+		{
+			field: "duration",
+			label: t("logs.table.duration"),
+			tooltip: t("logs.tooltip.duration"),
+		},
+		{
+			field: "overhead",
+			label: t("logs.table.overhead"),
+			tooltip: t("logs.tooltip.overhead"),
+		},
+		{
+			field: "key",
+			label: t("logs.table.key"),
+			tooltip: t("logs.tooltip.key"),
+		},
+		{ field: "ip", label: t("logs.table.ip"), tooltip: t("logs.tooltip.ip") },
+	];
+}

--- a/web/src/pages/Logs/useRequestLogLiveUpdates.ts
+++ b/web/src/pages/Logs/useRequestLogLiveUpdates.ts
@@ -1,0 +1,148 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import { api } from "../../api/client";
+import type { LogEntry } from "../../api/types";
+
+/**
+ * Keeps the request list current while the live toggle is on, in whichever
+ * view mode is active.
+ *
+ * Paginate mode simply invalidates the page query on request events. Scroll
+ * mode merges the finished row by id on request.streaming / request.completed
+ * (so it swaps its placeholder values for the real provider, tokens and
+ * duration without waiting for a refetch), and always follows up with
+ * fetchNewer to cover the race where the pending row has not landed in the
+ * list yet. A 60s poll and a visibility/focus refresh cover SSE disconnects.
+ *
+ * Also reports whether the document is visible, which the paginate query uses
+ * to pause its own refetch interval.
+ */
+export function useRequestLogLiveUpdates({
+	viewMode,
+	liveEnabled,
+	fetchNewer,
+	mergeEntries,
+}: {
+	viewMode: "paginate" | "scroll";
+	liveEnabled: boolean;
+	fetchNewer: () => void;
+	mergeEntries: (entries: LogEntry[]) => void;
+}) {
+	const queryClient = useQueryClient();
+	const [isVisible, setIsVisible] = useState(!document.hidden);
+	useEffect(() => {
+		const handler = () => setIsVisible(!document.hidden);
+		document.addEventListener("visibilitychange", handler);
+		return () => document.removeEventListener("visibilitychange", handler);
+	}, []);
+
+	useEffect(() => {
+		if (!liveEnabled) return;
+		const handler = (e: Event) => {
+			const event = (e as CustomEvent).detail;
+			if (
+				event.type === "request.started" ||
+				event.type === "request.streaming" ||
+				event.type === "request.completed"
+			) {
+				if (viewMode === "paginate") {
+					queryClient.invalidateQueries({ queryKey: ["logs"] });
+				}
+			}
+		};
+		window.addEventListener("server-event", handler);
+		return () => window.removeEventListener("server-event", handler);
+	}, [liveEnabled, queryClient, viewMode]);
+
+	// Slow poll fallback for scroll mode (catches SSE disconnects)
+	useEffect(() => {
+		if (viewMode !== "scroll" || !liveEnabled) return;
+		const interval = setInterval(() => {
+			if (!document.hidden) {
+				fetchNewer();
+			}
+		}, 60000);
+		return () => clearInterval(interval);
+	}, [viewMode, liveEnabled, fetchNewer]);
+
+	// Visibility/focus refresh for scroll mode
+	useEffect(() => {
+		if (viewMode !== "scroll" || !liveEnabled) return;
+		const handler = () => {
+			if (!document.hidden) {
+				fetchNewer();
+			}
+		};
+		document.addEventListener("visibilitychange", handler);
+		return () => document.removeEventListener("visibilitychange", handler);
+	}, [viewMode, liveEnabled, fetchNewer]);
+
+	// SSE-driven live updates for scroll mode
+	useEffect(() => {
+		if (viewMode !== "scroll" || !liveEnabled) return;
+		const handler = async (e: Event) => {
+			const event = (e as CustomEvent).detail;
+			if (event.type === "request.completed") {
+				// Fetch the completed entry by ID and merge it into
+				// the existing entries so the row shows final metrics
+				// (provider, tokens, duration, etc.) instead of the
+				// placeholder values from the initial INSERT.
+				const requestId: string | undefined = event.metadata?.request_id;
+				if (requestId) {
+					try {
+						const entry = await api.logs.get(requestId);
+						mergeEntries([entry]);
+					} catch {
+						// Fall back to fetchNewer on error (e.g. row
+						// was purged between event and fetch)
+						fetchNewer();
+					}
+				} else {
+					// Fallback when request_id is missing from the
+					// event payload (e.g. schema change, old server)
+					fetchNewer();
+				}
+				// Always fetchNewer after request.completed to cover
+				// the race where the pending row hasn't been added to
+				// the list yet (request.started fetch still in-flight).
+				// fetchNewer is guarded against concurrent calls.
+				fetchNewer();
+			} else if (event.type === "request.streaming") {
+				// The provider just committed mid-stream: fetch the row by
+				// ID and merge so it swaps "Resolving" for the real
+				// provider/model (and the "Streaming" state) without waiting
+				// for request.completed. mergeEntries only updates rows that
+				// are already in the list, so the trailing fetchNewer covers
+				// the race where the pending row hasn't landed yet.
+				const requestId: string | undefined = event.metadata?.request_id;
+				if (requestId) {
+					try {
+						const entry = await api.logs.get(requestId);
+						mergeEntries([entry]);
+					} catch {
+						// Fall back to fetchNewer on error (e.g. row
+						// was purged between event and fetch)
+						fetchNewer();
+						return;
+					}
+				} else {
+					// Fallback when request_id is missing from the
+					// event payload (e.g. schema change, old server)
+					fetchNewer();
+					return;
+				}
+				// Always fetchNewer after request.streaming to cover
+				// the race where the pending row hasn't been added to
+				// the list yet (request.started fetch still in-flight).
+				// fetchNewer is guarded against concurrent calls.
+				fetchNewer();
+			} else if (event.type === "request.started") {
+				fetchNewer();
+			}
+		};
+		window.addEventListener("server-event", handler);
+		return () => window.removeEventListener("server-event", handler);
+	}, [viewMode, liveEnabled, fetchNewer, mergeEntries]);
+
+	return { isVisible };
+}

--- a/web/src/pages/Logs/useStaleClock.ts
+++ b/web/src/pages/Logs/useStaleClock.ts
@@ -1,0 +1,64 @@
+import { useEffect, useState } from "react";
+import type { LogEntry } from "../../api/types";
+import {
+	isInProgress as isInProgressShared,
+	isStale as isStaleShared,
+} from "../../utils/logHelpers";
+
+/**
+ * Milliseconds in a Go duration string (e.g. "30m0s", "1h0m0s"), which is
+ * how the stale-request timeout setting is stored. Unparseable input yields 0.
+ */
+export function parseGoDuration(d: string): number {
+	let ms = 0;
+	const h = d.match(/(\d+)h/);
+	const m = d.match(/(\d+)m(?!s)/);
+	const s = d.match(/(\d+)s/);
+	if (h) ms += parseInt(h[1], 10) * 3600000;
+	if (m) ms += parseInt(m[1], 10) * 60000;
+	if (s) ms += parseInt(s[1], 10) * 1000;
+	return ms;
+}
+
+const DEFAULT_STALE_MS = 30 * 60 * 1000;
+
+/**
+ * The clock the request rows read their age from, plus the stale threshold.
+ *
+ * A request stuck in pending/streaming longer than the configured timeout is
+ * almost certainly dead (server crash, unhandled error, etc.), so it renders as
+ * stale rather than as a permanently pulsing "Resolving…" / "Live" row. The
+ * default of 30m accommodates providers with long time-to-first-token.
+ *
+ * In-progress rows show a live-ticking duration, so while any are present the
+ * clock ticks every second; otherwise a coarse 60s tick is enough to age rows
+ * into the stale state without re-rendering the table needlessly.
+ */
+export function useStaleClock(
+	staleRequestTimeout: string | undefined,
+	entries: LogEntry[],
+) {
+	const staleMs = parseGoDuration(staleRequestTimeout || "30m0s");
+	const staleThresholdMs = staleMs > 0 ? staleMs : DEFAULT_STALE_MS;
+	const [nowMs, setNowMs] = useState(() => Date.now());
+	const hasLiveEntries = entries.some(
+		(log) => log.state === "pending" || log.state === "streaming",
+	);
+	useEffect(() => {
+		const id = setInterval(
+			() => {
+				setNowMs(Date.now());
+			},
+			hasLiveEntries ? 1_000 : 60_000,
+		);
+		return () => clearInterval(id);
+	}, [hasLiveEntries]);
+
+	return {
+		nowMs,
+		staleThresholdMs,
+		isStale: (log: LogEntry) => isStaleShared(log, nowMs, staleThresholdMs),
+		isInProgress: (log: LogEntry) =>
+			isInProgressShared(log, nowMs, staleThresholdMs),
+	};
+}


### PR DESCRIPTION
## Summary

Size-allowlist burn-down: `pages/Logs.tsx` was one 907-line `RequestLogs` component. It keeps the queries, the state and the page composition; the rest moves under `pages/Logs/` next to the existing `utils.ts`.

| File | Lines | Holds |
|---|---|---|
| `Logs.tsx` | 971 -> 394 | state, the paginate query, the cursor fetch, wheel paging, page composition, both view modes |
| `Logs/useRequestLogLiveUpdates.ts` | 148 (new) | the paginate-mode invalidation, and scroll mode's SSE merge-by-id handler, 60s poll and visibility refresh; also reports document visibility for the paginate refetch interval |
| `Logs/useStaleClock.ts` | 64 (new) | `parseGoDuration`, the stale threshold from the setting, the 1s / 60s ticking `nowMs`, `isStale` / `isInProgress` |
| `Logs/RequestLogRow.tsx` | 192 (new) | one request row of the paginated table |
| `Logs/RequestLogFilters.tsx` | 193 (new) | the controls card: sub-mode switch, view toggle, filters, date picker |
| `Logs/requestLogColumns.ts` | 87 (new) | `LogSortField` and the twelve sortable columns as data; the header row maps over them instead of twelve hand-written `SortableHeader`s. Built from `t` so every label stays a literal `t()` call the i18n key check can follow |

No behaviour change: same markup, query keys, event handling and toasts. The component is under the 500-line `max-lines-per-function` cap, so its `eslint-disable` is removed. The file leaves the size allowlist.

## Verification

- Biome, `tsc -b`, ESLint: clean
- The 11 Logs suites pass unchanged: 141/141
- Coverage of the changed set: 160/174 statements = 92.0%
- **Rebuilt dev stack** (674 requests on dev): scroll mode lists 46 virtual rows; paginate mode renders the 12 headers and 20 rows; a row click opens the detail modal; a no-match filter shows the empty row; the App Logs sub-mode switches; no console errors (the CSP data: ones are fixed in the separate CSP PR)
- `make size-check`: passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
