### PR TITLE
refactor(web): decompose the useChat hook

### DIFF
--- a/scripts/ci/size-allowlist.txt
+++ b/scripts/ci/size-allowlist.txt
@@ -29,7 +29,6 @@ web/src/api/types.ts	1058
 web/src/components/Layout.tsx	1065
 web/src/components/VirtualModelTable.tsx	858
 web/src/components/__tests__/Layout.navigation.test.tsx	2558
-web/src/pages/Chat/useChat.ts	846
 web/src/pages/FailoverGroups.tsx	1096
 web/src/pages/Logs.tsx	971
 web/src/pages/Models/ModelDetailModal.tsx	823

--- a/web/src/pages/Chat/chatDerived.ts
+++ b/web/src/pages/Chat/chatDerived.ts
@@ -1,0 +1,58 @@
+import type { ChatMessage } from "../../api/types";
+
+/**
+ * The last failed assistant reply in chat mode, but only if it came from the
+ * currently selected model: after switching models the error is stale and
+ * misleading. Aborted replies are not errors.
+ */
+export function lastChatError(
+	messages: ChatMessage[],
+	chatSubMode: string,
+	selectedModel: string,
+): { error: ChatMessage["error"]; model: string } | null {
+	if (chatSubMode !== "chat") return null;
+	for (let i = messages.length - 1; i >= 0; i--) {
+		if (
+			messages[i].role === "assistant" &&
+			messages[i].error &&
+			!messages[i].aborted
+		) {
+			const errModel = messages[i].model || "";
+			if (errModel !== selectedModel) return null;
+			return { error: messages[i].error, model: errModel };
+		}
+	}
+	return null;
+}
+
+/** The short name of the model whose reply put a conversation into `error`. */
+export function failedConversationModel(
+	messages: ChatMessage[],
+	chatSubMode: string,
+	conversationState: string,
+): string | undefined {
+	if (chatSubMode !== "conversation" || conversationState !== "error")
+		return undefined;
+	const lastErr = [...messages].reverse().find((m) => m.error);
+	return lastErr?.model ? lastErr.model.split("/").pop() : undefined;
+}
+
+/** Token and wall-clock totals across every reply that reported metrics. */
+export function messageTotals(messages: ChatMessage[]): {
+	totalTokens: number;
+	totalDuration: number;
+} {
+	return {
+		totalTokens: messages.reduce(
+			(acc, m) =>
+				acc +
+				(m.metrics?.promptTokens ?? 0) +
+				(m.metrics?.completionTokens ?? 0),
+			0,
+		),
+		totalDuration: messages.reduce(
+			(acc, m) => acc + (m.metrics?.durationMs ?? 0),
+			0,
+		),
+	};
+}

--- a/web/src/pages/Chat/useAssistantStream.ts
+++ b/web/src/pages/Chat/useAssistantStream.ts
@@ -1,0 +1,318 @@
+import type { TFunction } from "i18next";
+import {
+	type Dispatch,
+	type SetStateAction,
+	useCallback,
+	useEffect,
+	useRef,
+} from "react";
+import type {
+	ChatMessage,
+	GenerationParams,
+	MessageContent,
+} from "../../api/types";
+import type { useToast } from "../../context/ToastContext";
+import { hasAnyParam } from "../../utils/params";
+import { getApiMessagesForModel, streamModelResponse } from "./chatStreaming";
+import type { useMultimodalAttachments } from "./useMultimodalAttachments";
+
+type Attachments = ReturnType<typeof useMultimodalAttachments>;
+
+/**
+ * Chat mode's single-model streaming: the shared assistant-reply streamer and
+ * the send / stop / regenerate handlers built on it. Owns the abort controller
+ * for the in-flight request and aborts it on unmount.
+ */
+export function useAssistantStream({
+	messages,
+	setMessages,
+	input,
+	setInput,
+	selectedModel,
+	systemPrompt,
+	messageParams,
+	modelsReady,
+	isStreaming,
+	setIsStreaming,
+	pendingImage,
+	setPendingImage,
+	pendingAudio,
+	setPendingAudio,
+	toast,
+	t,
+}: {
+	messages: ChatMessage[];
+	setMessages: Dispatch<SetStateAction<ChatMessage[]>>;
+	input: string;
+	setInput: (v: string) => void;
+	selectedModel: string;
+	systemPrompt: string;
+	messageParams: GenerationParams;
+	/** False while the chat model list is doing its first load. */
+	modelsReady: boolean;
+	isStreaming: boolean;
+	setIsStreaming: (v: boolean) => void;
+	pendingImage: Attachments["pendingImage"];
+	setPendingImage: Attachments["setPendingImage"];
+	pendingAudio: Attachments["pendingAudio"];
+	setPendingAudio: Attachments["setPendingAudio"];
+	toast: ReturnType<typeof useToast>["toast"];
+	t: TFunction;
+}) {
+	const abortRef = useRef<AbortController | null>(null);
+	const sendingRef = useRef(false);
+	// A separate cleanup ref so the React Compiler doesn't mark abortRef as
+	// "effect-only" and forbid mutation in event handlers - which is perfectly
+	// valid React.
+	const cleanupAbortRef = useRef<AbortController | null>(null);
+
+	// Cleanup on unmount only: abort the in-flight request.
+	useEffect(() => {
+		const abortCtrl = cleanupAbortRef;
+		return () => {
+			abortCtrl.current?.abort();
+		};
+	}, []);
+
+	// Shared streaming helper: creates abort controller, assistant placeholder,
+	// streams the response, applies progressive + final updates.
+	const streamAssistantReply = useCallback(
+		async (
+			model: string,
+			chatMessages: Array<{ role: string; content: MessageContent }>,
+		) => {
+			const abortCtrl = new AbortController();
+			abortRef.current = abortCtrl;
+			cleanupAbortRef.current = abortCtrl;
+
+			const createdAt = Date.now();
+			const assistantMessage: ChatMessage = {
+				role: "assistant",
+				content: "",
+				rawContent: "",
+				thinkingContent: "",
+				model,
+				timestamp: createdAt,
+				params: hasAnyParam(messageParams) ? messageParams : undefined,
+			};
+			setMessages((prev) => [...prev, assistantMessage]);
+
+			const result = await streamModelResponse(
+				model,
+				chatMessages,
+				messageParams,
+				abortCtrl,
+				(raw, content, thinking) => {
+					setMessages((prev) => {
+						const idx = prev.findIndex(
+							(m) => m.timestamp === createdAt && m.role === "assistant",
+						);
+						if (idx === -1) return prev;
+						const next = [...prev];
+						next[idx] = {
+							...next[idx],
+							rawContent: raw,
+							content,
+							thinkingContent: thinking,
+						};
+						return next;
+					});
+				},
+				undefined,
+				t,
+			);
+
+			setMessages((prev) => {
+				const idx = prev.findIndex(
+					(m) => m.timestamp === createdAt && m.role === "assistant",
+				);
+				if (idx === -1) return prev;
+				const next = [...prev];
+				next[idx] = {
+					...next[idx],
+					rawContent: result.rawContent,
+					content: result.content,
+					thinkingContent: result.thinkingContent,
+					error: result.error,
+					aborted: result.aborted || undefined,
+					metrics: {
+						tokensPerSecond: result.tokensPerSecond,
+						durationMs: result.durationMs,
+						promptTokens: result.promptTokens,
+						completionTokens: result.completionTokens,
+					},
+				};
+				return next;
+			});
+
+			return result;
+		},
+		[messageParams, setMessages, t],
+	);
+
+	const handleSend = useCallback(async () => {
+		const hasAttachment = pendingImage || pendingAudio;
+		// Wait for the model list to settle so a persisted stale selection is
+		// reconciled away before it could be sent to a non-chat endpoint.
+		if (
+			!modelsReady ||
+			(!input.trim() && !hasAttachment) ||
+			!selectedModel ||
+			isStreaming
+		)
+			return;
+		if (sendingRef.current) return;
+
+		const userMessage: ChatMessage = {
+			role: "user",
+			content: input.trim(),
+			timestamp: Date.now(),
+			...(pendingImage ? { imageUrl: pendingImage.dataUrl } : {}),
+			...(pendingAudio
+				? {
+						audioAttachment: {
+							data: pendingAudio.dataUrl.split(",")[1] || pendingAudio.dataUrl,
+							format: pendingAudio.format,
+						},
+					}
+				: {}),
+		};
+		// Clear attachments
+		setPendingImage(null);
+		setPendingAudio(null);
+
+		const updatedMessages = [...messages, userMessage];
+		setMessages(updatedMessages);
+		setInput("");
+		setIsStreaming(true);
+		sendingRef.current = true;
+
+		const chatMessages = getApiMessagesForModel(
+			updatedMessages,
+			selectedModel,
+			systemPrompt,
+		);
+
+		try {
+			const result = await streamAssistantReply(selectedModel, chatMessages);
+
+			if (result.error && !result.aborted) toast(result.error, "error");
+		} catch (err) {
+			if (err instanceof Error && err.name === "AbortError") {
+				// User-initiated abort, no toast needed
+			} else {
+				const msg = err instanceof Error ? err.message : "Unknown error";
+				toast(msg, "error");
+			}
+		} finally {
+			setIsStreaming(false);
+			abortRef.current = null;
+			cleanupAbortRef.current = null;
+			sendingRef.current = false;
+		}
+	}, [
+		input,
+		modelsReady,
+		selectedModel,
+		isStreaming,
+		messages,
+		systemPrompt,
+		toast,
+		streamAssistantReply,
+		pendingImage,
+		pendingAudio,
+		setPendingImage,
+		setPendingAudio,
+		setMessages,
+		setInput,
+		setIsStreaming,
+	]);
+
+	const handleStop = useCallback(() => {
+		abortRef.current?.abort();
+		abortRef.current = null;
+		cleanupAbortRef.current = null;
+		setIsStreaming(false);
+	}, [setIsStreaming]);
+
+	const handleRegenerate = useCallback(async () => {
+		if (isStreaming) return;
+		// Wait for the model list to settle so a persisted stale selection is
+		// reconciled away first; same guard as handleSend: without a selected model
+		// regenerate would stream with an empty model id.
+		if (!modelsReady || !selectedModel) return;
+		let lastUserIdx = -1;
+		for (let i = messages.length - 1; i >= 0; i--) {
+			if (messages[i].role === "user") {
+				lastUserIdx = i;
+				break;
+			}
+		}
+		if (lastUserIdx === -1) return;
+		const userContent = messages[lastUserIdx].content;
+		const baseMessages = messages.slice(0, lastUserIdx);
+		setMessages(baseMessages);
+		setInput(userContent);
+
+		const chatMessages: Array<{ role: string; content: string }> = [];
+		if (systemPrompt.trim()) {
+			chatMessages.push({
+				role: "system",
+				content: systemPrompt.trim(),
+			});
+		}
+		for (const m of baseMessages) {
+			chatMessages.push({ role: m.role, content: m.content });
+		}
+		chatMessages.push({ role: "user", content: userContent });
+
+		const userMessage: ChatMessage = {
+			role: "user",
+			content: userContent,
+			timestamp: Date.now(),
+		};
+		const updatedMessages = [...baseMessages, userMessage];
+		setMessages(updatedMessages);
+		setInput("");
+		setIsStreaming(true);
+
+		try {
+			const result = await streamAssistantReply(
+				selectedModel || "",
+				chatMessages,
+			);
+
+			if (result.error && !result.aborted) toast(result.error, "error");
+		} catch (err) {
+			if (err instanceof Error && err.name === "AbortError") {
+				// User-initiated abort, no toast needed
+			} else {
+				const msg = err instanceof Error ? err.message : "Unknown error";
+				toast(msg, "error");
+			}
+		} finally {
+			setIsStreaming(false);
+			abortRef.current = null;
+			cleanupAbortRef.current = null;
+		}
+	}, [
+		isStreaming,
+		modelsReady,
+		messages,
+		selectedModel,
+		systemPrompt,
+		toast,
+		streamAssistantReply,
+		setMessages,
+		setInput,
+		setIsStreaming,
+	]);
+
+	return {
+		sendingRef,
+		streamAssistantReply,
+		handleSend,
+		handleStop,
+		handleRegenerate,
+	};
+}

--- a/web/src/pages/Chat/useChat.ts
+++ b/web/src/pages/Chat/useChat.ts
@@ -1,25 +1,26 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { MessageSquare, MessagesSquare } from "@/lib/icons";
-import type {
-	ChatMessage,
-	GenerationParams,
-	MessageContent,
-} from "../../api/types";
+import type { ChatMessage, GenerationParams } from "../../api/types";
 import { useSidebarMode } from "../../context/SidebarModeContext";
 import { useStorage } from "../../context/StorageContext";
 import { useToast } from "../../context/ToastContext";
 import { useLocalStorage } from "../../hooks/useLocalStorage";
 import { useChatModels } from "../../hooks/useModels";
 import { parseCapabilities, proxyModelID } from "../../utils/model";
-import { hasAnyParam } from "../../utils/params";
-import { getApiMessagesForModel, streamModelResponse } from "./chatStreaming";
+import {
+	failedConversationModel,
+	lastChatError,
+	messageTotals,
+} from "./chatDerived";
+import { useAssistantStream } from "./useAssistantStream";
 import { useChatConversationState } from "./useChatConversationState";
 import { useChatPersistence } from "./useChatPersistence";
 import { useChatRandomActions } from "./useChatRandom";
+import { useChatScroll } from "./useChatScroll";
 import { useConversationRunner } from "./useConversationRunner";
+import { useDeleteMessage } from "./useDeleteMessage";
 import { useMultimodalAttachments } from "./useMultimodalAttachments";
-// eslint-disable-next-line max-lines-per-function -- size ratchet: split this hook
 export function useChat() {
 	const { data: enabledModels, isLoading: modelsLoading } = useChatModels();
 	// False while the chat model list is doing its first load. Actions that would
@@ -114,11 +115,8 @@ export function useChat() {
 	const [input, setInput] = useState("");
 	const [isStreaming, setIsStreaming] = useState(false);
 	const [controlsCollapsed, setControlsCollapsed] = useState(false);
-	const abortRef = useRef<AbortController | null>(null);
-	const sendingRef = useRef(false);
 	/** Saves the conversation prompt before it's cleared, so it can be restored on error */
 	const lastPromptRef = useRef<string>("");
-	const messagesContainerRef = useRef<HTMLDivElement>(null);
 	const { toast } = useToast();
 	const { t } = useTranslation();
 
@@ -155,19 +153,14 @@ export function useChat() {
 		}
 	}, [chatSubMode, setCurrentTurn, setConversationState]);
 
-	// Cleanup: abort streams on unmount
-	// We store the abort controllers in separate cleanup refs so the React
-	// Compiler doesn't mark conversationAbortRef as "effect-only" and forbid
-	// mutation in event handlers - which is perfectly valid React.
-	const cleanupAbortRef = useRef<AbortController | null>(null);
+	// Cleanup: abort the conversation stream on unmount. Stored in a separate
+	// cleanup ref so the React Compiler doesn't mark conversationAbortRef as
+	// "effect-only" and forbid mutation in event handlers - which is perfectly
+	// valid React. Chat mode's own abort lives in useAssistantStream.
 	const cleanupConvAbortRef = useRef<AbortController | null>(null);
-
-	// Cleanup on unmount only: abort in-flight requests.
 	useEffect(() => {
-		const abortCtrl = cleanupAbortRef;
 		const convAbortCtrl = cleanupConvAbortRef;
 		return () => {
-			abortCtrl.current?.abort();
 			convAbortCtrl.current?.abort();
 		};
 	}, []);
@@ -230,130 +223,9 @@ export function useChat() {
 		handleAudioSelect,
 	} = useMultimodalAttachments(hasVision, toast);
 
-	const scrollToBottom = useCallback((smooth = false) => {
-		requestAnimationFrame(() => {
-			const el = messagesContainerRef.current;
-			if (!el) return;
-			if (smooth) {
-				el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
-			} else {
-				el.scrollTop = el.scrollHeight;
-			}
-		});
-	}, []);
-
-	// Track whether the user deliberately scrolled up to read earlier messages.
-	// Reset on new user messages and when scrolling back to bottom.
-	const userScrolledUpRef = useRef(false);
-
-	// Attach scroll listener to detect user scrolling up vs programmatic scroll.
-	useEffect(() => {
-		const el = messagesContainerRef.current;
-		if (!el) return;
-		const onScroll = () => {
-			const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 40;
-			userScrolledUpRef.current = !atBottom;
-		};
-		el.addEventListener("scroll", onScroll, { passive: true });
-		return () => el.removeEventListener("scroll", onScroll);
-	}, []);
-
-	// Scroll on new messages. Reset userScrolledUp since the user initiated this.
-	const messagesLen = messages.length;
-	// biome-ignore lint/correctness/useExhaustiveDependencies: scroll on new messages
-	useEffect(() => {
-		userScrolledUpRef.current = false;
-		scrollToBottom(true);
-		const timer = setTimeout(() => scrollToBottom(false), 300);
-		return () => clearTimeout(timer);
-	}, [messagesLen, scrollToBottom]);
-
-	// Smooth auto-scroll during streaming — follows tokens as they arrive.
-	const streamingContentLen = messages.reduce(
-		(sum, m) => sum + m.content.length,
-		0,
-	);
-	// biome-ignore lint/correctness/useExhaustiveDependencies: streamingContentLen triggers re-scroll on streaming updates
-	useEffect(() => {
-		if (!isStreaming) return;
-		if (userScrolledUpRef.current) return;
-		scrollToBottom(true);
-	}, [streamingContentLen, isStreaming, scrollToBottom]);
-
-	// Shared streaming helper: creates abort controller, assistant placeholder,
-	// streams the response, applies progressive + final updates.
-	const streamAssistantReply = useCallback(
-		async (
-			model: string,
-			chatMessages: Array<{ role: string; content: MessageContent }>,
-		) => {
-			const abortCtrl = new AbortController();
-			abortRef.current = abortCtrl;
-			cleanupAbortRef.current = abortCtrl;
-
-			const createdAt = Date.now();
-			const assistantMessage: ChatMessage = {
-				role: "assistant",
-				content: "",
-				rawContent: "",
-				thinkingContent: "",
-				model,
-				timestamp: createdAt,
-				params: hasAnyParam(messageParams) ? messageParams : undefined,
-			};
-			setMessages((prev) => [...prev, assistantMessage]);
-
-			const result = await streamModelResponse(
-				model,
-				chatMessages,
-				messageParams,
-				abortCtrl,
-				(raw, content, thinking) => {
-					setMessages((prev) => {
-						const idx = prev.findIndex(
-							(m) => m.timestamp === createdAt && m.role === "assistant",
-						);
-						if (idx === -1) return prev;
-						const next = [...prev];
-						next[idx] = {
-							...next[idx],
-							rawContent: raw,
-							content,
-							thinkingContent: thinking,
-						};
-						return next;
-					});
-				},
-				undefined,
-				t,
-			);
-
-			setMessages((prev) => {
-				const idx = prev.findIndex(
-					(m) => m.timestamp === createdAt && m.role === "assistant",
-				);
-				if (idx === -1) return prev;
-				const next = [...prev];
-				next[idx] = {
-					...next[idx],
-					rawContent: result.rawContent,
-					content: result.content,
-					thinkingContent: result.thinkingContent,
-					error: result.error,
-					aborted: result.aborted || undefined,
-					metrics: {
-						tokensPerSecond: result.tokensPerSecond,
-						durationMs: result.durationMs,
-						promptTokens: result.promptTokens,
-						completionTokens: result.completionTokens,
-					},
-				};
-				return next;
-			});
-
-			return result;
-		},
-		[messageParams, t],
+	const { messagesContainerRef, scrollToBottom } = useChatScroll(
+		messages,
+		isStreaming,
 	);
 
 	const {
@@ -377,157 +249,30 @@ export function useChat() {
 		setSelectedModelB,
 	});
 
-	const handleSend = useCallback(async () => {
-		const hasAttachment = pendingImage || pendingAudio;
-		// Wait for the model list to settle so a persisted stale selection is
-		// reconciled away before it could be sent to a non-chat endpoint.
-		if (
-			!modelsReady ||
-			(!input.trim() && !hasAttachment) ||
-			!selectedModel ||
-			isStreaming
-		)
-			return;
-		if (sendingRef.current) return;
-
-		const userMessage: ChatMessage = {
-			role: "user",
-			content: input.trim(),
-			timestamp: Date.now(),
-			...(pendingImage ? { imageUrl: pendingImage.dataUrl } : {}),
-			...(pendingAudio
-				? {
-						audioAttachment: {
-							data: pendingAudio.dataUrl.split(",")[1] || pendingAudio.dataUrl,
-							format: pendingAudio.format,
-						},
-					}
-				: {}),
-		};
-		// Clear attachments
-		setPendingImage(null);
-		setPendingAudio(null);
-
-		const updatedMessages = [...messages, userMessage];
-		setMessages(updatedMessages);
-		setInput("");
-		setIsStreaming(true);
-		sendingRef.current = true;
-
-		const chatMessages = getApiMessagesForModel(
-			updatedMessages,
-			selectedModel,
-			systemPrompt,
-		);
-
-		try {
-			const result = await streamAssistantReply(selectedModel, chatMessages);
-
-			if (result.error && !result.aborted) toast(result.error, "error");
-		} catch (err) {
-			if (err instanceof Error && err.name === "AbortError") {
-				// User-initiated abort, no toast needed
-			} else {
-				const msg = err instanceof Error ? err.message : "Unknown error";
-				toast(msg, "error");
-			}
-		} finally {
-			setIsStreaming(false);
-			abortRef.current = null;
-			cleanupAbortRef.current = null;
-			sendingRef.current = false;
-		}
-	}, [
+	const {
+		sendingRef,
+		streamAssistantReply,
+		handleSend,
+		handleStop,
+		handleRegenerate,
+	} = useAssistantStream({
+		messages,
+		setMessages,
 		input,
-		modelsReady,
+		setInput,
 		selectedModel,
-		isStreaming,
-		messages,
 		systemPrompt,
-		toast,
-		streamAssistantReply,
+		messageParams,
+		modelsReady,
+		isStreaming,
+		setIsStreaming,
 		pendingImage,
-		pendingAudio,
 		setPendingImage,
+		pendingAudio,
 		setPendingAudio,
-	]);
-
-	const handleStop = useCallback(() => {
-		abortRef.current?.abort();
-		abortRef.current = null;
-		cleanupAbortRef.current = null;
-		setIsStreaming(false);
-	}, []);
-
-	const handleRegenerate = useCallback(async () => {
-		if (isStreaming) return;
-		// Wait for the model list to settle so a persisted stale selection is
-		// reconciled away first; same guard as handleSend: without a selected model
-		// regenerate would stream with an empty model id.
-		if (!modelsReady || !selectedModel) return;
-		let lastUserIdx = -1;
-		for (let i = messages.length - 1; i >= 0; i--) {
-			if (messages[i].role === "user") {
-				lastUserIdx = i;
-				break;
-			}
-		}
-		if (lastUserIdx === -1) return;
-		const userContent = messages[lastUserIdx].content;
-		const baseMessages = messages.slice(0, lastUserIdx);
-		setMessages(baseMessages);
-		setInput(userContent);
-
-		const chatMessages: Array<{ role: string; content: string }> = [];
-		if (systemPrompt.trim()) {
-			chatMessages.push({
-				role: "system",
-				content: systemPrompt.trim(),
-			});
-		}
-		for (const m of baseMessages) {
-			chatMessages.push({ role: m.role, content: m.content });
-		}
-		chatMessages.push({ role: "user", content: userContent });
-
-		const userMessage: ChatMessage = {
-			role: "user",
-			content: userContent,
-			timestamp: Date.now(),
-		};
-		const updatedMessages = [...baseMessages, userMessage];
-		setMessages(updatedMessages);
-		setInput("");
-		setIsStreaming(true);
-
-		try {
-			const result = await streamAssistantReply(
-				selectedModel || "",
-				chatMessages,
-			);
-
-			if (result.error && !result.aborted) toast(result.error, "error");
-		} catch (err) {
-			if (err instanceof Error && err.name === "AbortError") {
-				// User-initiated abort, no toast needed
-			} else {
-				const msg = err instanceof Error ? err.message : "Unknown error";
-				toast(msg, "error");
-			}
-		} finally {
-			setIsStreaming(false);
-			abortRef.current = null;
-			cleanupAbortRef.current = null;
-		}
-	}, [
-		isStreaming,
-		modelsReady,
-		messages,
-		selectedModel,
-		systemPrompt,
 		toast,
-		streamAssistantReply,
-	]);
+		t,
+	});
 
 	// ── Extracted conversation runner hook ──
 	const {
@@ -564,96 +309,19 @@ export function useChat() {
 		setTurnCountdown,
 	});
 
-	// Helper to delete a message
-	const handleDeleteMessage = useCallback(
-		(msgIndex: number) => {
-			const msg = messages[msgIndex];
-			if (!msg) return;
-
-			const toRemove = new Set<number>();
-
-			if (chatSubMode === "chat") {
-				// In chat mode, delete the assistant and preceding user message
-				toRemove.add(msgIndex);
-				if (msgIndex > 0 && messages[msgIndex - 1].role === "user") {
-					toRemove.add(msgIndex - 1);
-				}
-				setMessages(messages.filter((_, i) => !toRemove.has(i)));
-				toast(t("hooks.useChat.messageDeleted"), "info");
-				return;
-			}
-
-			// In conversation mode:
-			// - If streaming, can only delete the last (currently generating) message
-			// - If not streaming, can only delete the last pair
-			const lastAssistantIdx = messages.findLastIndex(
-				(m) => m.role === "assistant",
-			);
-			const isLastAssistant = msgIndex === lastAssistantIdx;
-			const isStreamingLast = isStreaming && msgIndex === messages.length - 1;
-
-			if (!isLastAssistant && !isStreamingLast) {
-				// Can't delete - not the last message
-				toast(t("hooks.useChat.canOnlyDeleteRecent"), "error");
-				return;
-			}
-
-			// Delete this assistant message and the preceding message (either user or other assistant)
-			toRemove.add(msgIndex);
-			if (msgIndex > 0) {
-				toRemove.add(msgIndex - 1);
-			}
-
-			// After deletion, determine the correct conversation state
-			const remaining = messages.filter((_, i) => !toRemove.has(i));
-
-			if (remaining.length === 0) {
-				// Deleted everything - back to idle, restore the prompt
-				setConversationState("idle");
-				setCurrentTurn(0);
-				if (lastPromptRef.current) {
-					setInput(lastPromptRef.current);
-				}
-				setMessages([]);
-				toast(t("hooks.useChat.messageDeleted"), "info");
-				return;
-			}
-
-			if (remaining.length === 1 && remaining[0]?.role === "user") {
-				// Only the initial user prompt remains - back to idle
-				setConversationState("idle");
-				setCurrentTurn(0);
-				setInput(remaining[0].content);
-				setMessages([]);
-				toast(t("hooks.useChat.messageDeleted"), "info");
-				return;
-			}
-
-			// There are earlier successful turns remaining
-			if (conversationState === "error" || conversationState === "completed") {
-				// Transition to "paused" so the user can continue
-				setConversationState("paused");
-				// Adjust turn counter: count remaining assistant messages
-				const remainingAssistantCount = remaining.filter(
-					(m) => m.role === "assistant",
-				).length;
-				setCurrentTurn(remainingAssistantCount);
-			}
-
-			setMessages(remaining);
-			toast(t("hooks.useChat.messageDeleted"), "info");
-		},
-		[
-			chatSubMode,
-			t,
-			toast,
-			isStreaming,
-			conversationState,
-			messages,
-			setCurrentTurn,
-			setConversationState,
-		],
-	);
+	const handleDeleteMessage = useDeleteMessage({
+		messages,
+		setMessages,
+		chatSubMode,
+		isStreaming,
+		conversationState,
+		setConversationState,
+		setCurrentTurn,
+		setInput,
+		lastPromptRef,
+		toast,
+		t,
+	});
 
 	const handleKeyDown = (e: React.KeyboardEvent) => {
 		if (e.key === "Enter" && !e.shiftKey) {
@@ -671,15 +339,7 @@ export function useChat() {
 		}
 	};
 
-	const totalTokens = messages.reduce(
-		(acc, m) =>
-			acc + (m.metrics?.promptTokens ?? 0) + (m.metrics?.completionTokens ?? 0),
-		0,
-	);
-	const totalDuration = messages.reduce(
-		(acc, m) => acc + (m.metrics?.durationMs ?? 0),
-		0,
-	);
+	const { totalTokens, totalDuration } = messageTotals(messages);
 
 	// Can start if: both models selected, has input, and not currently running
 	const canStartConversation =
@@ -690,30 +350,12 @@ export function useChat() {
 		!!input.trim() &&
 		conversationState !== "running";
 
-	const lastChatError = (() => {
-		if (chatSubMode !== "chat") return null;
-		for (let i = messages.length - 1; i >= 0; i--) {
-			if (
-				messages[i].role === "assistant" &&
-				messages[i].error &&
-				!messages[i].aborted
-			) {
-				const errModel = messages[i].model || "";
-				// Only show the error if it's from the currently selected model.
-				// After switching models the error is stale and misleading.
-				if (errModel !== selectedModel) return null;
-				return { error: messages[i].error, model: errModel };
-			}
-		}
-		return null;
-	})();
-
-	const failedConversationModel = (() => {
-		if (chatSubMode !== "conversation" || conversationState !== "error")
-			return undefined;
-		const lastErr = [...messages].reverse().find((m) => m.error);
-		return lastErr?.model ? lastErr.model.split("/").pop() : undefined;
-	})();
+	const chatError = lastChatError(messages, chatSubMode, selectedModel);
+	const failedModel = failedConversationModel(
+		messages,
+		chatSubMode,
+		conversationState,
+	);
 
 	const conversationDisabledReason = useMemo(() => {
 		if (chatSubMode !== "conversation") return "";
@@ -808,8 +450,8 @@ export function useChat() {
 		totalTokens,
 		totalDuration,
 		canStartConversation,
-		lastChatError,
-		failedConversationModel,
+		lastChatError: chatError,
+		failedConversationModel: failedModel,
 		conversationDisabledReason,
 		chatIcon,
 		// Refs are grouped in a sub-object so consumers can destructure them away

--- a/web/src/pages/Chat/useChatScroll.ts
+++ b/web/src/pages/Chat/useChatScroll.ts
@@ -1,0 +1,63 @@
+import { useCallback, useEffect, useRef } from "react";
+import type { ChatMessage } from "../../api/types";
+
+/**
+ * Keeps the message list pinned to the bottom as messages and tokens arrive,
+ * unless the user deliberately scrolled up to read earlier messages. A new
+ * message resets that intent (the user caused it); streaming respects it.
+ */
+export function useChatScroll(messages: ChatMessage[], isStreaming: boolean) {
+	const messagesContainerRef = useRef<HTMLDivElement>(null);
+
+	const scrollToBottom = useCallback((smooth = false) => {
+		requestAnimationFrame(() => {
+			const el = messagesContainerRef.current;
+			if (!el) return;
+			if (smooth) {
+				el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
+			} else {
+				el.scrollTop = el.scrollHeight;
+			}
+		});
+	}, []);
+
+	// Track whether the user deliberately scrolled up to read earlier messages.
+	// Reset on new user messages and when scrolling back to bottom.
+	const userScrolledUpRef = useRef(false);
+
+	// Attach scroll listener to detect user scrolling up vs programmatic scroll.
+	useEffect(() => {
+		const el = messagesContainerRef.current;
+		if (!el) return;
+		const onScroll = () => {
+			const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 40;
+			userScrolledUpRef.current = !atBottom;
+		};
+		el.addEventListener("scroll", onScroll, { passive: true });
+		return () => el.removeEventListener("scroll", onScroll);
+	}, []);
+
+	// Scroll on new messages. Reset userScrolledUp since the user initiated this.
+	const messagesLen = messages.length;
+	// biome-ignore lint/correctness/useExhaustiveDependencies: scroll on new messages
+	useEffect(() => {
+		userScrolledUpRef.current = false;
+		scrollToBottom(true);
+		const timer = setTimeout(() => scrollToBottom(false), 300);
+		return () => clearTimeout(timer);
+	}, [messagesLen, scrollToBottom]);
+
+	// Smooth auto-scroll during streaming — follows tokens as they arrive.
+	const streamingContentLen = messages.reduce(
+		(sum, m) => sum + m.content.length,
+		0,
+	);
+	// biome-ignore lint/correctness/useExhaustiveDependencies: streamingContentLen triggers re-scroll on streaming updates
+	useEffect(() => {
+		if (!isStreaming) return;
+		if (userScrolledUpRef.current) return;
+		scrollToBottom(true);
+	}, [streamingContentLen, isStreaming, scrollToBottom]);
+
+	return { messagesContainerRef, scrollToBottom };
+}

--- a/web/src/pages/Chat/useDeleteMessage.ts
+++ b/web/src/pages/Chat/useDeleteMessage.ts
@@ -1,0 +1,138 @@
+import type { TFunction } from "i18next";
+import {
+	type Dispatch,
+	type RefObject,
+	type SetStateAction,
+	useCallback,
+} from "react";
+import type { ChatMessage } from "../../api/types";
+import type { useSidebarMode } from "../../context/SidebarModeContext";
+import type { useToast } from "../../context/ToastContext";
+import type { useChatConversationState } from "./useChatConversationState";
+
+type ConversationState = ReturnType<typeof useChatConversationState>;
+
+/**
+ * Deleting a message. Chat mode drops the assistant reply and the user
+ * message before it. Conversation mode only ever lets the most recent pair
+ * go (or the message still being generated), and re-derives the
+ * conversation state from what remains so the run can be continued.
+ */
+export function useDeleteMessage({
+	messages,
+	setMessages,
+	chatSubMode,
+	isStreaming,
+	conversationState,
+	setConversationState,
+	setCurrentTurn,
+	setInput,
+	lastPromptRef,
+	toast,
+	t,
+}: {
+	messages: ChatMessage[];
+	setMessages: Dispatch<SetStateAction<ChatMessage[]>>;
+	chatSubMode: ReturnType<typeof useSidebarMode>["chatSubMode"];
+	isStreaming: boolean;
+	conversationState: ConversationState["conversationState"];
+	setConversationState: ConversationState["setConversationState"];
+	setCurrentTurn: ConversationState["setCurrentTurn"];
+	setInput: (v: string) => void;
+	lastPromptRef: RefObject<string>;
+	toast: ReturnType<typeof useToast>["toast"];
+	t: TFunction;
+}) {
+	return useCallback(
+		(msgIndex: number) => {
+			const msg = messages[msgIndex];
+			if (!msg) return;
+
+			const toRemove = new Set<number>();
+
+			if (chatSubMode === "chat") {
+				// In chat mode, delete the assistant and preceding user message
+				toRemove.add(msgIndex);
+				if (msgIndex > 0 && messages[msgIndex - 1].role === "user") {
+					toRemove.add(msgIndex - 1);
+				}
+				setMessages(messages.filter((_, i) => !toRemove.has(i)));
+				toast(t("hooks.useChat.messageDeleted"), "info");
+				return;
+			}
+
+			// In conversation mode:
+			// - If streaming, can only delete the last (currently generating) message
+			// - If not streaming, can only delete the last pair
+			const lastAssistantIdx = messages.findLastIndex(
+				(m) => m.role === "assistant",
+			);
+			const isLastAssistant = msgIndex === lastAssistantIdx;
+			const isStreamingLast = isStreaming && msgIndex === messages.length - 1;
+
+			if (!isLastAssistant && !isStreamingLast) {
+				// Can't delete - not the last message
+				toast(t("hooks.useChat.canOnlyDeleteRecent"), "error");
+				return;
+			}
+
+			// Delete this assistant message and the preceding message (either user or other assistant)
+			toRemove.add(msgIndex);
+			if (msgIndex > 0) {
+				toRemove.add(msgIndex - 1);
+			}
+
+			// After deletion, determine the correct conversation state
+			const remaining = messages.filter((_, i) => !toRemove.has(i));
+
+			if (remaining.length === 0) {
+				// Deleted everything - back to idle, restore the prompt
+				setConversationState("idle");
+				setCurrentTurn(0);
+				if (lastPromptRef.current) {
+					setInput(lastPromptRef.current);
+				}
+				setMessages([]);
+				toast(t("hooks.useChat.messageDeleted"), "info");
+				return;
+			}
+
+			if (remaining.length === 1 && remaining[0]?.role === "user") {
+				// Only the initial user prompt remains - back to idle
+				setConversationState("idle");
+				setCurrentTurn(0);
+				setInput(remaining[0].content);
+				setMessages([]);
+				toast(t("hooks.useChat.messageDeleted"), "info");
+				return;
+			}
+
+			// There are earlier successful turns remaining
+			if (conversationState === "error" || conversationState === "completed") {
+				// Transition to "paused" so the user can continue
+				setConversationState("paused");
+				// Adjust turn counter: count remaining assistant messages
+				const remainingAssistantCount = remaining.filter(
+					(m) => m.role === "assistant",
+				).length;
+				setCurrentTurn(remainingAssistantCount);
+			}
+
+			setMessages(remaining);
+			toast(t("hooks.useChat.messageDeleted"), "info");
+		},
+		[
+			chatSubMode,
+			t,
+			toast,
+			isStreaming,
+			conversationState,
+			messages,
+			setCurrentTurn,
+			setConversationState,
+			setMessages,
+			setInput,
+			lastPromptRef,
+		],
+	);
+}


### PR DESCRIPTION
## Summary

Size-allowlist burn-down: `pages/Chat/useChat.ts` was one 824-line hook. It keeps the mode state, the chat/conversation selectors, the model-list reconciliation and the returned surface; four self-contained pieces move out next to the hooks already split from it:

| File | Lines | Holds |
|---|---|---|
| `useChat.ts` | 846 -> 488 | mode and message state, chat/conversation selectors, selection reconciliation, the conversation-abort cleanup, composition and the return object |
| `useAssistantStream.ts` | 318 (new) | chat mode's single-model streaming: `streamAssistantReply`, `handleSend`, `handleStop`, `handleRegenerate`; owns the request abort controller and aborts it on unmount |
| `useDeleteMessage.ts` | 138 (new) | `handleDeleteMessage` with its chat-mode pair rule and conversation-mode last-pair rule and state re-derivation |
| `useChatScroll.ts` | 63 (new) | the messages container ref, `scrollToBottom`, the scrolled-up intent tracking and the two auto-scroll effects |
| `chatDerived.ts` | 58 (new) | `lastChatError`, `failedConversationModel`, `messageTotals` as pure functions |

No behaviour change: `useChat()` returns the same surface with the same semantics (the two unmount cleanups are now one per owner instead of one effect for both). The hook is under the 500-line `max-lines-per-function` cap, so its `eslint-disable` is removed. The file leaves the size allowlist.

## Verification

- Biome, `tsc -b`, ESLint: clean
- The 27 Chat suites pass unchanged: 318/318
- Coverage of the changed set: 299/309 statements = 96.8% (`chatDerived` 100%, `useChat` 98%, `useAssistantStream` 97%, `useDeleteMessage` 96%, `useChatScroll` 92%)
- **Rebuilt dev stack**: the chat page renders; Shift+Enter inserts a newline without sending; Send stays disabled without a model; conversation mode renders its Start disabled until both models and a prompt exist; navigating back restores the chat view; no console errors. (No prompt was sent: that would spend provider credit; send/regenerate/stop are covered by the suites.)
- `make size-check`: passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
