### PR TITLE
refactor(web): decompose VirtualModelTable and fix its prepend scroll correction

### DIFF
--- a/scripts/ci/size-allowlist.txt
+++ b/scripts/ci/size-allowlist.txt
@@ -27,7 +27,6 @@ internal/proxy/proxy.go	976
 internal/proxy/upstream_classify.go	804
 web/src/api/types.ts	1058
 web/src/components/Layout.tsx	1065
-web/src/components/VirtualModelTable.tsx	858
 web/src/components/__tests__/Layout.navigation.test.tsx	2558
 web/src/pages/Models/ModelDetailModal.tsx	823
 web/src/pages/Settings/alerts/AlertsWizard.tsx	801

--- a/web/src/components/VirtualModelTable.tsx
+++ b/web/src/components/VirtualModelTable.tsx
@@ -1,35 +1,28 @@
-import { useVirtualizer } from "@tanstack/react-virtual";
-import {
-	useCallback,
-	useEffect,
-	useLayoutEffect,
-	useMemo,
-	useRef,
-	useState,
-} from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { api } from "../api/client";
 import type { Model, ModelsCursorResponse, Provider } from "../api/types";
-import { useToast } from "../context/ToastContext";
 import { useBidirectionalFetch } from "../hooks/useBidirectionalFetch";
-import {
-	encodeCursor,
-	formatDate,
-	formatNumber,
-	formatRelativeTime,
-} from "../utils/format";
-import { parseCapabilities, proxyModelID } from "../utils/model";
+import { formatNumber } from "../utils/format";
+import { proxyModelID } from "../utils/model";
 import { ConfirmDialog } from "./ConfirmDialog";
-import { CopyablePill } from "./CopyablePill";
-import { CAP_META, type CapKey, hasCap } from "./capMeta";
+import type { CapKey } from "./capMeta";
 import { FilterDropdown } from "./FilterDropdown";
 import { FilterInput } from "./FilterInput";
+import { CapFilterRow } from "./modelTable/CapFilterRow";
+import { ModelRow } from "./modelTable/ModelRow";
+import {
+	fetchModelsPage,
+	type ModelSortField,
+	type ModelSortState,
+	modelCursor,
+} from "./modelTable/modelCursor";
+import { MODEL_HEADER_BASE, SortableTh } from "./modelTable/SortableTh";
+import { useDeleteDisabled } from "./modelTable/useDeleteDisabled";
+import { useVirtualRows } from "./modelTable/useVirtualRows";
 import {
 	MODEL_COL_WIDTHS_NO_PROVIDER,
 	MODEL_COL_WIDTHS_WITH_PROVIDER,
 } from "./modelTableWidths";
-import { OutputBadges } from "./OutputBadges";
-import { OUTPUT_META } from "./outputMeta";
 
 interface VirtualModelTableProps {
 	providers?: Provider[];
@@ -60,16 +53,6 @@ export interface ModelCounts {
 	parked: number;
 }
 
-interface SortState {
-	field: "name" | "discovered" | "context" | "output" | "provider" | "status";
-	dir: "asc" | "desc";
-}
-
-const HEADER_BASE =
-	"px-4 py-2 text-left text-xs font-medium uppercase tracking-wider whitespace-nowrap ui-table-header-text";
-
-const EDGE_THRESHOLD_PX = 500;
-// eslint-disable-next-line max-lines-per-function -- size ratchet: split this component
 export function VirtualModelTable({
 	providers,
 	providerFilter = "",
@@ -83,20 +66,12 @@ export function VirtualModelTable({
 	"use no memo";
 	const [searchQuery, setSearchQuery] = useState("");
 	const [capFilter, setCapFilter] = useState<Set<CapKey>>(new Set());
-	const [sort, setSort] = useState<SortState>({
+	const [outputFilter, setOutputFilter] = useState<Set<string>>(new Set());
+	const [sort, setSort] = useState<ModelSortState>({
 		field: "name",
 		dir: "asc",
 	});
 	const { t } = useTranslation();
-	const { toast } = useToast();
-	// The rows the confirm dialog lists and the delete removes: every disabled
-	// row of the current filters, fetched when the button is pressed. null
-	// while nothing is pending; the dialog opens once the fetch lands.
-	const [pendingDisabled, setPendingDisabled] = useState<Model[] | null>(null);
-	const [loadingDisabled, setLoadingDisabled] = useState(false);
-
-	const scrollRef = useRef<HTMLDivElement>(null);
-
 	const showProviderCol = providers !== undefined;
 
 	const toggleCapFilter = useCallback((key: CapKey) => {
@@ -107,8 +82,6 @@ export function VirtualModelTable({
 			return next;
 		});
 	}, []);
-
-	const [outputFilter, setOutputFilter] = useState<Set<string>>(new Set());
 	const toggleOutputFilter = useCallback((key: string) => {
 		setOutputFilter((prev) => {
 			const next = new Set(prev);
@@ -117,40 +90,12 @@ export function VirtualModelTable({
 			return next;
 		});
 	}, []);
-
-	const handleSort = useCallback((field: SortState["field"]) => {
+	const handleSort = useCallback((field: ModelSortField) => {
 		setSort((prev) => ({
 			field,
 			dir: prev.field === field && prev.dir === "asc" ? "desc" : "asc",
 		}));
 	}, []);
-
-	const fetchFn = useCallback(
-		async (params: {
-			cursor?: string;
-			direction: "after" | "before";
-			limit: number;
-			sort_dir: string;
-			[key: string]: string | number | undefined;
-		}): Promise<ModelsCursorResponse> => {
-			return api.models.cursor({
-				cursor: params.cursor,
-				direction: params.direction as "after" | "before",
-				limit: params.limit,
-				sort_by: params.sort_by as string | undefined,
-				sort_dir: params.sort_dir,
-				provider_id: params.provider_id as string | undefined,
-				search: params.search as string | undefined,
-				capabilities: params.capabilities as string | undefined,
-				outputs: params.outputs as string | undefined,
-				provider_enabled:
-					params.provider_enabled === undefined
-						? undefined
-						: params.provider_enabled === "true",
-			});
-		},
-		[],
-	);
 
 	const filters = useMemo(() => {
 		const result: Record<string, string | undefined> = {
@@ -181,57 +126,7 @@ export function VirtualModelTable({
 	]);
 
 	const getCursor = useCallback(
-		(entry: Model): string => {
-			let cursorObj: Record<string, unknown>;
-			switch (sort.field) {
-				case "name":
-					cursorObj = {
-						sort_by: "name",
-						name: entry.name || entry.model_id,
-						model_id: entry.model_id,
-						id: entry.id,
-					};
-					break;
-				case "discovered":
-					cursorObj = {
-						sort_by: "discovered",
-						last_seen_at: entry.last_seen_at,
-						id: entry.id,
-					};
-					break;
-				case "context":
-					cursorObj = {
-						sort_by: "context",
-						context_length: entry.context_length ?? 0,
-						id: entry.id,
-					};
-					break;
-				case "output":
-					cursorObj = {
-						sort_by: "output",
-						max_output_tokens: entry.max_output_tokens ?? 0,
-						id: entry.id,
-					};
-					break;
-				case "provider":
-					cursorObj = {
-						sort_by: "provider",
-						provider_name: entry.provider_name,
-						id: entry.id,
-					};
-					break;
-				case "status":
-					cursorObj = {
-						sort_by: "status",
-						status_sort: entry.enabled ? (entry.disabled_manually ? 1 : 0) : 2,
-						id: entry.id,
-					};
-					break;
-				default:
-					cursorObj = { sort_by: "name", name: entry.name, id: entry.id };
-			}
-			return encodeCursor(cursorObj);
-		},
+		(entry: Model): string => modelCursor(sort.field, entry),
 		[sort.field],
 	);
 
@@ -249,7 +144,7 @@ export function VirtualModelTable({
 		fetchInitial,
 		lastResponse,
 	} = useBidirectionalFetch<Model, ModelsCursorResponse>({
-		fetchFn,
+		fetchFn: fetchModelsPage,
 		filters,
 		sortDir: sort.dir,
 		getCursor,
@@ -270,60 +165,12 @@ export function VirtualModelTable({
 	// rows, so counting the loaded ones would hide the button (and cap the
 	// delete) at whatever happened to be scrolled in.
 	const disabledCount = lastResponse?.disabled_total ?? 0;
-
-	// Walk every disabled row of the current filters, page by page, so the
-	// delete covers exactly what disabledCount promised. Sorted by name with
-	// its own cursor chain: the table's sort and cursor are irrelevant here.
-	const loadDisabledModels = useCallback(async () => {
-		const { provider_id, search, capabilities, outputs, provider_enabled } =
-			filters;
-		const all: Model[] = [];
-		let cursor: string | undefined;
-		for (;;) {
-			const page = await api.models.cursor({
-				cursor,
-				direction: "after",
-				limit: 200,
-				sort_by: "name",
-				sort_dir: "asc",
-				provider_id,
-				search,
-				capabilities,
-				outputs,
-				provider_enabled:
-					provider_enabled === undefined
-						? undefined
-						: provider_enabled === "true",
-				enabled: false,
-			});
-			all.push(...page.entries);
-			const last = page.entries.at(-1);
-			if (!page.has_after || !last) break;
-			cursor = encodeCursor({
-				sort_by: "name",
-				name: last.name || last.model_id,
-				model_id: last.model_id,
-				id: last.id,
-			});
-		}
-		return all;
-	}, [filters]);
-
-	const openDeleteDisabled = useCallback(async () => {
-		setLoadingDisabled(true);
-		try {
-			setPendingDisabled(await loadDisabledModels());
-		} catch (err) {
-			toast(
-				t("components.virtualModelTable.deleteDisabledLoadFailed", {
-					message: err instanceof Error ? err.message : String(err),
-				}),
-				"error",
-			);
-		} finally {
-			setLoadingDisabled(false);
-		}
-	}, [loadDisabledModels, toast, t]);
+	const {
+		pendingDisabled,
+		clearPendingDisabled,
+		loadingDisabled,
+		openDeleteDisabled,
+	} = useDeleteDisabled(filters);
 
 	// Re-fetch when parent signals data changed (e.g. after model update)
 	const prevRefreshRef = useRef(refreshTrigger);
@@ -338,91 +185,38 @@ export function VirtualModelTable({
 		}
 	}, [refreshTrigger, reset, fetchInitial]);
 
-	// eslint-disable-next-line react-hooks/incompatible-library -- TanStack Virtual returns mutable functions; compiler skips memoization
-	const virtualizer = useVirtualizer({
-		count: entries.length,
-		getScrollElement: () => scrollRef.current,
-		estimateSize: () => 45,
-		overscan: 20,
-	});
-
-	const virtualItems = virtualizer.getVirtualItems();
-
-	const prevEntriesRef = useRef(entries);
-	// State counter to force synchronous re-render after scrollTop adjustment.
-	// React guarantees setState inside useLayoutEffect is flushed before paint.
-	const [, forceRerender] = useState(0);
-
-	// When items are prepended (fetchNewer), all item indices shift but
-	// scrollTop stays the same, so the virtualizer maps the old scroll
-	// position to different items. Adjust scrollTop by the average of
-	// the virtualizer's measured row sizes (from measureElement /
-	// ResizeObserver), falling back to estimateSize when no measurements
-	// exist yet. Then force a synchronous re-render so the virtualizer
-	// recomputes before the browser paints.
-	useLayoutEffect(() => {
-		const prev = prevEntriesRef.current;
-		if (entries.length > prev.length && prev.length > 0) {
-			const newItemCount = entries.length - prev.length;
-			if (entries[newItemCount]?.id === prev[0]?.id && scrollRef.current) {
-				const cache = virtualizer.measurementsCache;
-				const avgSize =
-					cache.length > 0
-						? cache.reduce((sum, m) => sum + m.size, 0) / cache.length
-						: 45;
-				scrollRef.current.scrollTop += newItemCount * avgSize;
-				prevEntriesRef.current = entries;
-				forceRerender((c) => c + 1);
-				return;
-			}
-		}
-		prevEntriesRef.current = entries;
-	}, [entries, virtualizer.measurementsCache]);
-
-	const [paddingTop, paddingBottom] =
-		virtualItems.length > 0
-			? [
-					Math.max(0, virtualItems[0].start),
-					Math.max(
-						0,
-						virtualizer.getTotalSize() -
-							virtualItems[virtualItems.length - 1].end,
-					),
-				]
-			: [0, 0];
-
-	const handleScroll = useCallback(() => {
-		const el = scrollRef.current;
-		if (!el) return;
-
-		const nearTop = el.scrollTop < EDGE_THRESHOLD_PX;
-		const nearBottom =
-			el.scrollHeight - el.scrollTop - el.clientHeight < EDGE_THRESHOLD_PX;
-
-		if (nearTop && hasBefore && !isLoadingBefore) {
-			fetchNewer();
-		}
-		if (nearBottom && hasAfter && !isLoadingAfter) {
-			fetchOlder();
-		}
-	}, [
+	const {
+		scrollRef,
+		virtualizer,
+		virtualItems,
+		paddingTop,
+		paddingBottom,
+		handleScroll,
+		startIndex,
+		endIndex,
+	} = useVirtualRows({
+		entries,
 		hasBefore,
 		hasAfter,
 		isLoadingBefore,
 		isLoadingAfter,
 		fetchNewer,
 		fetchOlder,
-	]);
-
-	const startIndex = virtualItems.length > 0 ? virtualItems[0].index + 1 : 0;
-	const endIndex =
-		virtualItems.length > 0
-			? virtualItems[virtualItems.length - 1].index + 1
-			: 0;
+	});
 
 	// Render the full table (including filter controls) even when empty,
 	// so users can clear/change filters when they get zero results.
 	const isEmpty = entries.length === 0 && !isLoadingInitial;
+
+	const th = (field: ModelSortField, label: string, ariaLabel: string) => (
+		<SortableTh
+			field={field}
+			label={label}
+			ariaLabel={ariaLabel}
+			sort={sort}
+			onSort={handleSort}
+		/>
+	);
 
 	return (
 		<div className="flex flex-col min-h-0">
@@ -496,201 +290,58 @@ export function VirtualModelTable({
 					</colgroup>
 					<thead className="sticky top-0 z-10">
 						<tr>
+							{th(
+								"name",
+								t("models.table.model"),
+								t("models.table.sortByModelName"),
+							)}
 							<th
-								className={`${HEADER_BASE} cursor-pointer select-none hover:text-gray-200`}
-								onClick={() => handleSort("name")}
-								title={t("models.table.model")}
-							>
-								<button
-									type="button"
-									className=""
-									aria-label={t("models.table.sortByModelName")}
-								>
-									{t("models.table.model")}{" "}
-									<span className="inline-block w-3 text-center">
-										{sort.field === "name"
-											? sort.dir === "asc"
-												? "↑"
-												: "↓"
-											: " "}
-									</span>
-								</button>
-							</th>
-							<th
-								className={HEADER_BASE}
+								className={MODEL_HEADER_BASE}
 								title={t("models.table.capabilities")}
 							>
 								{t("models.table.capabilities")}
 							</th>
-							{showProviderCol && (
-								<th
-									className={`${HEADER_BASE} cursor-pointer select-none hover:text-gray-200`}
-									onClick={() => handleSort("provider")}
-									title={t("models.table.provider")}
-								>
-									<button
-										type="button"
-										className=""
-										aria-label={t("models.table.sortByProviderName")}
-									>
-										{t("models.table.provider")}{" "}
-										<span className="inline-block w-3 text-center">
-											{sort.field === "provider"
-												? sort.dir === "asc"
-													? "↑"
-													: "↓"
-												: " "}
-										</span>
-									</button>
-								</th>
+							{showProviderCol &&
+								th(
+									"provider",
+									t("models.table.provider"),
+									t("models.table.sortByProviderName"),
+								)}
+							{th(
+								"discovered",
+								t("models.table.discovered"),
+								t("models.table.sortByDiscoveredDate"),
 							)}
-							<th
-								className={`${HEADER_BASE} cursor-pointer select-none hover:text-gray-200`}
-								onClick={() => handleSort("discovered")}
-								title={t("models.table.discovered")}
-							>
-								<button
-									type="button"
-									className=""
-									aria-label={t("models.table.sortByDiscoveredDate")}
-								>
-									{t("models.table.discovered")}{" "}
-									<span className="inline-block w-3 text-center">
-										{sort.field === "discovered"
-											? sort.dir === "asc"
-												? "↑"
-												: "↓"
-											: " "}
-									</span>
-								</button>
-							</th>
 							<th aria-hidden />
-							<th
-								className={`${HEADER_BASE} cursor-pointer select-none hover:text-gray-200`}
-								onClick={() => handleSort("context")}
-								title={t("models.table.ctx")}
-							>
-								<button
-									type="button"
-									className=""
-									aria-label={t("models.table.sortByContextLength")}
-								>
-									{t("models.table.ctx")}{" "}
-									<span className="inline-block w-3 text-center">
-										{sort.field === "context"
-											? sort.dir === "asc"
-												? "↑"
-												: "↓"
-											: " "}
-									</span>
-								</button>
-							</th>
+							{th(
+								"context",
+								t("models.table.ctx"),
+								t("models.table.sortByContextLength"),
+							)}
 							<th aria-hidden />
-							<th
-								className={`${HEADER_BASE} cursor-pointer select-none hover:text-gray-200`}
-								onClick={() => handleSort("output")}
-								title={t("models.table.maxOut")}
-							>
-								<button
-									type="button"
-									className=""
-									aria-label={t("models.table.sortByMaxOutput")}
-								>
-									{t("models.table.maxOut")}{" "}
-									<span className="inline-block w-3 text-center">
-										{sort.field === "output"
-											? sort.dir === "asc"
-												? "↑"
-												: "↓"
-											: " "}
-									</span>
-								</button>
-							</th>
+							{th(
+								"output",
+								t("models.table.maxOut"),
+								t("models.table.sortByMaxOutput"),
+							)}
 							<th aria-hidden />
-							<th
-								className={`${HEADER_BASE} cursor-pointer select-none hover:text-gray-200`}
-								onClick={() => handleSort("status")}
-								title={t("models.table.status")}
-							>
-								<button
-									type="button"
-									className=""
-									aria-label={t("models.table.sortByStatus")}
-								>
-									{t("models.table.status")}{" "}
-									<span className="inline-block w-3 text-center">
-										{sort.field === "status"
-											? sort.dir === "asc"
-												? "↑"
-												: "↓"
-											: " "}
-									</span>
-								</button>
-							</th>
+							{th(
+								"status",
+								t("models.table.status"),
+								t("models.table.sortByStatus"),
+							)}
 						</tr>
-						<tr className="ui-table-row-filter">
-							<th className="px-4 py-2" />
-							<th className="px-4 py-2">
-								<span className="flex flex-wrap gap-1">
-									{/* All pills render unconditionally: filtering is
-									    server-side, so a matching model may exist outside
-									    the loaded window and every pill must stay
-									    reachable. */}
-									{CAP_META.map((m) => {
-										const isActive = capFilter.has(m.key);
-										return (
-											<button
-												key={m.key}
-												type="button"
-												aria-pressed={isActive}
-												onClick={() => toggleCapFilter(m.key)}
-												className={`ui-badge inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium border transition-colors ${
-													isActive ? m.style : m.muted
-												}`}
-											>
-												{m.label}
-											</button>
-										);
-									})}
-									{OUTPUT_META.map((m) => {
-										const isActive = outputFilter.has(m.key);
-										return (
-											<button
-												key={m.key}
-												type="button"
-												aria-pressed={isActive}
-												onClick={() => toggleOutputFilter(m.key)}
-												className={`ui-badge inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium border transition-colors ${
-													isActive ? m.style : m.muted
-												}`}
-											>
-												{t(m.labelKey)}
-											</button>
-										);
-									})}
-									{(capFilter.size > 0 || outputFilter.size > 0) && (
-										<button
-											type="button"
-											onClick={() => {
-												setCapFilter(new Set());
-												setOutputFilter(new Set());
-											}}
-											className="ui-badge inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium text-gray-400 hover:text-gray-200"
-										>
-											✕
-										</button>
-									)}
-								</span>
-							</th>
-							{showProviderCol && <th className="px-4 py-2" />}
-							<th className="px-4 py-2" />
-							<th aria-hidden />
-							<th className="px-4 py-2" />
-							<th aria-hidden />
-							<th className="px-4 py-2" />
-							<th aria-hidden />
-							<th className="px-4 py-2" />
-						</tr>
+						<CapFilterRow
+							capFilter={capFilter}
+							outputFilter={outputFilter}
+							onToggleCap={toggleCapFilter}
+							onToggleOutput={toggleOutputFilter}
+							onClear={() => {
+								setCapFilter(new Set());
+								setOutputFilter(new Set());
+							}}
+							showProviderCol={showProviderCol}
+						/>
 					</thead>
 					<tbody>
 						{isEmpty ? (
@@ -703,117 +354,16 @@ export function VirtualModelTable({
 								</td>
 							</tr>
 						) : (
-							virtualItems.map((vItem) => {
-								const model = entries[vItem.index];
-								const caps = parseCapabilities(model.capabilities);
-								const isParked = !model.provider_enabled;
-								const isActive = model.enabled && !model.disabled_manually;
-								const isManuallyDisabled =
-									model.enabled && model.disabled_manually;
-								return (
-									<tr
-										key={model.id}
-										data-index={vItem.index}
-										ref={virtualizer.measureElement}
-										className={`hover:bg-(--surface-hover) ${vItem.index % 2 === 1 ? "ui-row-even" : ""} ${onModelClick ? "cursor-pointer" : ""}`}
-										onClick={() => onModelClick?.(model)}
-									>
-										<td className="px-4 py-1.5">
-											<div className="flex flex-col">
-												<span
-													className={`text-left text-sm ${isActive ? "font-medium text-white" : "text-gray-500"}`}
-												>
-													{model.name ||
-														proxyModelID(model.provider_name, model.model_id)}
-												</span>
-												<CopyablePill
-													text={proxyModelID(
-														model.provider_name,
-														model.model_id,
-													)}
-													textClassName="text-[11px] model-id-text font-mono leading-tight"
-													tooltip={t("components.modelTable.clickToCopyId")}
-												/>
-											</div>
-										</td>
-										<td className="px-4 py-1.5">
-											<div className="flex flex-wrap gap-1">
-												{CAP_META.filter((m) => hasCap(caps, m.key)).map(
-													(m) => (
-														<span
-															key={m.key}
-															className={`ui-badge inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium border ${m.style}`}
-														>
-															{m.label}
-														</span>
-													),
-												)}
-												<OutputBadges
-													outputModalities={model.output_modalities}
-												/>
-											</div>
-										</td>
-										{showProviderCol && (
-											<td
-												className="px-4 py-1.5 whitespace-nowrap text-sm text-gray-300 truncate"
-												title={model.provider_name}
-											>
-												{model.provider_name}
-											</td>
-										)}
-										<td className="px-4 py-1.5 whitespace-nowrap text-sm text-gray-400">
-											{formatRelativeTime(model.last_seen_at)}
-										</td>
-										<td aria-hidden />
-										<td className="px-4 py-1.5 whitespace-nowrap text-sm text-gray-300">
-											{formatNumber(model.context_length)}
-										</td>
-										<td aria-hidden />
-										<td className="px-4 py-1.5 whitespace-nowrap text-sm text-gray-300">
-											{formatNumber(model.max_output_tokens)}
-										</td>
-										<td aria-hidden />
-										<td className="px-4 py-1.5 whitespace-nowrap">
-											{isParked ? (
-												<span
-													className="ui-badge ui-badge-neutral px-2 py-px leading-[1.6] text-xs"
-													title={t("models.status_parked_hint")}
-												>
-													<span className="badge-text">
-														{t("models.status_parked")}
-													</span>
-												</span>
-											) : (
-												<span
-													className={`ui-badge px-2 py-px leading-[1.6] text-xs ${
-														isActive
-															? "ui-badge-success"
-															: isManuallyDisabled
-																? "ui-badge-warning"
-																: "ui-badge-error"
-													}`}
-													{...(!model.enabled && !model.disabled_manually
-														? {
-																title: t("models.disabledByDiscovery", {
-																	date: formatDate(model.last_seen_at),
-																}),
-																"data-testid": "disabled-by-discovery",
-															}
-														: {})}
-												>
-													<span className="badge-text">
-														{isActive
-															? t("common.enabled")
-															: isManuallyDisabled
-																? t("common.manuallyDisabled")
-																: t("common.disabled")}
-													</span>
-												</span>
-											)}
-										</td>
-									</tr>
-								);
-							})
+							virtualItems.map((vItem) => (
+								<ModelRow
+									key={entries[vItem.index].id}
+									model={entries[vItem.index]}
+									index={vItem.index}
+									measureRef={virtualizer.measureElement}
+									showProviderCol={showProviderCol}
+									onClick={onModelClick}
+								/>
+							))
 						)}
 					</tbody>
 				</table>
@@ -848,9 +398,9 @@ export function VirtualModelTable({
 					confirmLabel={t("common.delete")}
 					onConfirm={() => {
 						onDeleteDisabled?.(pendingDisabled.map((m) => m.id));
-						setPendingDisabled(null);
+						clearPendingDisabled();
 					}}
-					onCancel={() => setPendingDisabled(null)}
+					onCancel={clearPendingDisabled}
 				/>
 			)}
 		</div>

--- a/web/src/components/modelTable/CapFilterRow.tsx
+++ b/web/src/components/modelTable/CapFilterRow.tsx
@@ -1,0 +1,86 @@
+import { useTranslation } from "react-i18next";
+import { CAP_META, type CapKey } from "../capMeta";
+import { OUTPUT_META } from "../outputMeta";
+
+/**
+ * The second header row: one pill per capability and per output modality,
+ * each toggling a server-side filter, plus a clear button once any is set.
+ * All pills render unconditionally: filtering is server-side, so a matching
+ * model may exist outside the loaded window and every pill must stay
+ * reachable.
+ */
+export function CapFilterRow({
+	capFilter,
+	outputFilter,
+	onToggleCap,
+	onToggleOutput,
+	onClear,
+	showProviderCol,
+}: {
+	capFilter: Set<CapKey>;
+	outputFilter: Set<string>;
+	onToggleCap: (key: CapKey) => void;
+	onToggleOutput: (key: string) => void;
+	onClear: () => void;
+	showProviderCol: boolean;
+}) {
+	const { t } = useTranslation();
+	return (
+		<tr className="ui-table-row-filter">
+			<th className="px-4 py-2" />
+			<th className="px-4 py-2">
+				<span className="flex flex-wrap gap-1">
+					{CAP_META.map((m) => {
+						const isActive = capFilter.has(m.key);
+						return (
+							<button
+								key={m.key}
+								type="button"
+								aria-pressed={isActive}
+								onClick={() => onToggleCap(m.key)}
+								className={`ui-badge inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium border transition-colors ${
+									isActive ? m.style : m.muted
+								}`}
+							>
+								{m.label}
+							</button>
+						);
+					})}
+					{OUTPUT_META.map((m) => {
+						const isActive = outputFilter.has(m.key);
+						return (
+							<button
+								key={m.key}
+								type="button"
+								aria-pressed={isActive}
+								onClick={() => onToggleOutput(m.key)}
+								className={`ui-badge inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium border transition-colors ${
+									isActive ? m.style : m.muted
+								}`}
+							>
+								{t(m.labelKey)}
+							</button>
+						);
+					})}
+					{(capFilter.size > 0 || outputFilter.size > 0) && (
+						<button
+							type="button"
+							onClick={onClear}
+							className="ui-badge inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium text-gray-400 hover:text-gray-200"
+						>
+							✕
+						</button>
+					)}
+				</span>
+			</th>
+			{showProviderCol && <th className="px-4 py-2" />}
+			<th className="px-4 py-2" />
+			<th aria-hidden />
+			<th className="px-4 py-2" />
+			<th aria-hidden />
+			<th className="px-4 py-2" />
+			<th aria-hidden />
+			<th className="px-4 py-2" />
+		</tr>
+	);
+}

--- a/web/src/components/modelTable/ModelRow.tsx
+++ b/web/src/components/modelTable/ModelRow.tsx
@@ -1,0 +1,126 @@
+import type { Ref } from "react";
+import { useTranslation } from "react-i18next";
+import type { Model } from "../../api/types";
+import {
+	formatDate,
+	formatNumber,
+	formatRelativeTime,
+} from "../../utils/format";
+import { parseCapabilities, proxyModelID } from "../../utils/model";
+import { CopyablePill } from "../CopyablePill";
+import { CAP_META, hasCap } from "../capMeta";
+import { OutputBadges } from "../OutputBadges";
+
+/** One model in the virtual table. Cells match the width tables in order. */
+export function ModelRow({
+	model,
+	index,
+	measureRef,
+	showProviderCol,
+	onClick,
+}: {
+	model: Model;
+	index: number;
+	/** The virtualizer's measureElement, so the row reports its real height. */
+	measureRef: Ref<HTMLTableRowElement>;
+	showProviderCol: boolean;
+	onClick?: (model: Model) => void;
+}) {
+	const { t } = useTranslation();
+	const caps = parseCapabilities(model.capabilities);
+	const isParked = !model.provider_enabled;
+	const isActive = model.enabled && !model.disabled_manually;
+	const isManuallyDisabled = model.enabled && model.disabled_manually;
+	return (
+		<tr
+			data-index={index}
+			ref={measureRef}
+			className={`hover:bg-(--surface-hover) ${index % 2 === 1 ? "ui-row-even" : ""} ${onClick ? "cursor-pointer" : ""}`}
+			onClick={() => onClick?.(model)}
+		>
+			<td className="px-4 py-1.5">
+				<div className="flex flex-col">
+					<span
+						className={`text-left text-sm ${isActive ? "font-medium text-white" : "text-gray-500"}`}
+					>
+						{model.name || proxyModelID(model.provider_name, model.model_id)}
+					</span>
+					<CopyablePill
+						text={proxyModelID(model.provider_name, model.model_id)}
+						textClassName="text-[11px] model-id-text font-mono leading-tight"
+						tooltip={t("components.modelTable.clickToCopyId")}
+					/>
+				</div>
+			</td>
+			<td className="px-4 py-1.5">
+				<div className="flex flex-wrap gap-1">
+					{CAP_META.filter((m) => hasCap(caps, m.key)).map((m) => (
+						<span
+							key={m.key}
+							className={`ui-badge inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium border ${m.style}`}
+						>
+							{m.label}
+						</span>
+					))}
+					<OutputBadges outputModalities={model.output_modalities} />
+				</div>
+			</td>
+			{showProviderCol && (
+				<td
+					className="px-4 py-1.5 whitespace-nowrap text-sm text-gray-300 truncate"
+					title={model.provider_name}
+				>
+					{model.provider_name}
+				</td>
+			)}
+			<td className="px-4 py-1.5 whitespace-nowrap text-sm text-gray-400">
+				{formatRelativeTime(model.last_seen_at)}
+			</td>
+			<td aria-hidden />
+			<td className="px-4 py-1.5 whitespace-nowrap text-sm text-gray-300">
+				{formatNumber(model.context_length)}
+			</td>
+			<td aria-hidden />
+			<td className="px-4 py-1.5 whitespace-nowrap text-sm text-gray-300">
+				{formatNumber(model.max_output_tokens)}
+			</td>
+			<td aria-hidden />
+			<td className="px-4 py-1.5 whitespace-nowrap">
+				{isParked ? (
+					<span
+						className="ui-badge ui-badge-neutral px-2 py-px leading-[1.6] text-xs"
+						title={t("models.status_parked_hint")}
+					>
+						<span className="badge-text">{t("models.status_parked")}</span>
+					</span>
+				) : (
+					<span
+						className={`ui-badge px-2 py-px leading-[1.6] text-xs ${
+							isActive
+								? "ui-badge-success"
+								: isManuallyDisabled
+									? "ui-badge-warning"
+									: "ui-badge-error"
+						}`}
+						{...(!model.enabled && !model.disabled_manually
+							? {
+									title: t("models.disabledByDiscovery", {
+										date: formatDate(model.last_seen_at),
+									}),
+									"data-testid": "disabled-by-discovery",
+								}
+							: {})}
+					>
+						<span className="badge-text">
+							{isActive
+								? t("common.enabled")
+								: isManuallyDisabled
+									? t("common.manuallyDisabled")
+									: t("common.disabled")}
+						</span>
+					</span>
+				)}
+			</td>
+		</tr>
+	);
+}

--- a/web/src/components/modelTable/SortableTh.tsx
+++ b/web/src/components/modelTable/SortableTh.tsx
@@ -1,0 +1,34 @@
+import type { ModelSortField, ModelSortState } from "./modelCursor";
+
+export const MODEL_HEADER_BASE =
+	"px-4 py-2 text-left text-xs font-medium uppercase tracking-wider whitespace-nowrap ui-table-header-text";
+
+/** A sortable header cell: the label, the sort arrow for the active field, one click to toggle. */
+export function SortableTh({
+	field,
+	label,
+	ariaLabel,
+	sort,
+	onSort,
+}: {
+	field: ModelSortField;
+	label: string;
+	ariaLabel: string;
+	sort: ModelSortState;
+	onSort: (field: ModelSortField) => void;
+}) {
+	return (
+		<th
+			className={`${MODEL_HEADER_BASE} cursor-pointer select-none hover:text-gray-200`}
+			onClick={() => onSort(field)}
+			title={label}
+		>
+			<button type="button" className="" aria-label={ariaLabel}>
+				{label}{" "}
+				<span className="inline-block w-3 text-center">
+					{sort.field === field ? (sort.dir === "asc" ? "↑" : "↓") : " "}
+				</span>
+			</button>
+		</th>
+	);
+}

--- a/web/src/components/modelTable/__tests__/useVirtualRows.test.tsx
+++ b/web/src/components/modelTable/__tests__/useVirtualRows.test.tsx
@@ -1,0 +1,176 @@
+import { act, render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useVirtualRows } from "../useVirtualRows";
+
+type Row = { id: string };
+
+function rows(from: number, to: number): Row[] {
+	return Array.from({ length: to - from }, (_, i) => ({ id: `r${from + i}` }));
+}
+
+/** Renders the hook against a real scroll element whose geometry the test controls. */
+function Harness({
+	entries,
+	hasBefore,
+	hasAfter,
+	fetchNewer,
+	fetchOlder,
+	expose,
+}: {
+	entries: Row[];
+	hasBefore: boolean;
+	hasAfter: boolean;
+	fetchNewer: () => void;
+	fetchOlder: () => void;
+	expose: (api: { handleScroll: () => void }) => void;
+}) {
+	const { scrollRef, handleScroll, startIndex, endIndex } = useVirtualRows({
+		entries,
+		hasBefore,
+		hasAfter,
+		isLoadingBefore: false,
+		isLoadingAfter: false,
+		fetchNewer,
+		fetchOlder,
+	});
+	expose({ handleScroll });
+	return (
+		<div ref={scrollRef} data-testid="scroller">
+			<span data-testid="range">
+				{startIndex}-{endIndex}
+			</span>
+		</div>
+	);
+}
+
+function geometry(
+	el: HTMLElement,
+	{
+		scrollTop,
+		scrollHeight,
+		clientHeight,
+	}: { scrollTop: number; scrollHeight: number; clientHeight: number },
+) {
+	Object.defineProperty(el, "scrollHeight", {
+		configurable: true,
+		value: scrollHeight,
+	});
+	Object.defineProperty(el, "clientHeight", {
+		configurable: true,
+		value: clientHeight,
+	});
+	el.scrollTop = scrollTop;
+}
+
+describe("useVirtualRows", () => {
+	it("keeps the viewport on the same rows when rows are prepended", () => {
+		const fetchNewer = vi.fn();
+		const fetchOlder = vi.fn();
+		const { rerender, getByTestId } = render(
+			<Harness
+				entries={rows(10, 50)}
+				hasBefore
+				hasAfter
+				fetchNewer={fetchNewer}
+				fetchOlder={fetchOlder}
+				expose={() => {}}
+			/>,
+		);
+		const el = getByTestId("scroller") as HTMLDivElement;
+		geometry(el, { scrollTop: 900, scrollHeight: 4000, clientHeight: 600 });
+
+		// Ten rows land in front of the first one: the old first row keeps its
+		// place on screen, so scrollTop grows by ten row heights (45px estimate
+		// while nothing has been measured).
+		act(() => {
+			rerender(
+				<Harness
+					entries={[...rows(0, 10), ...rows(10, 50)]}
+					hasBefore
+					hasAfter
+					fetchNewer={fetchNewer}
+					fetchOlder={fetchOlder}
+					expose={() => {}}
+				/>,
+			);
+		});
+		expect(el.scrollTop).toBe(900 + 10 * 45);
+	});
+
+	it("leaves scrollTop alone when rows are appended", () => {
+		const { rerender, getByTestId } = render(
+			<Harness
+				entries={rows(0, 40)}
+				hasBefore={false}
+				hasAfter
+				fetchNewer={vi.fn()}
+				fetchOlder={vi.fn()}
+				expose={() => {}}
+			/>,
+		);
+		const el = getByTestId("scroller") as HTMLDivElement;
+		geometry(el, { scrollTop: 300, scrollHeight: 4000, clientHeight: 600 });
+		act(() => {
+			rerender(
+				<Harness
+					entries={rows(0, 60)}
+					hasBefore={false}
+					hasAfter
+					fetchNewer={vi.fn()}
+					fetchOlder={vi.fn()}
+					expose={() => {}}
+				/>,
+			);
+		});
+		expect(el.scrollTop).toBe(300);
+	});
+
+	it("fetches newer near the top and older near the bottom, only when there is more", () => {
+		const fetchNewer = vi.fn();
+		const fetchOlder = vi.fn();
+		let api: { handleScroll: () => void } = { handleScroll: () => {} };
+		const { getByTestId, rerender } = render(
+			<Harness
+				entries={rows(0, 40)}
+				hasBefore
+				hasAfter
+				fetchNewer={fetchNewer}
+				fetchOlder={fetchOlder}
+				expose={(a) => {
+					api = a;
+				}}
+			/>,
+		);
+		const el = getByTestId("scroller") as HTMLDivElement;
+
+		geometry(el, { scrollTop: 100, scrollHeight: 4000, clientHeight: 600 });
+		api.handleScroll();
+		expect(fetchNewer).toHaveBeenCalledTimes(1);
+		expect(fetchOlder).not.toHaveBeenCalled();
+
+		geometry(el, { scrollTop: 3300, scrollHeight: 4000, clientHeight: 600 });
+		api.handleScroll();
+		expect(fetchOlder).toHaveBeenCalledTimes(1);
+		expect(fetchNewer).toHaveBeenCalledTimes(1);
+
+		// With nothing beyond either edge the same positions fetch nothing.
+		rerender(
+			<Harness
+				entries={rows(0, 40)}
+				hasBefore={false}
+				hasAfter={false}
+				fetchNewer={fetchNewer}
+				fetchOlder={fetchOlder}
+				expose={(a) => {
+					api = a;
+				}}
+			/>,
+		);
+		geometry(el, { scrollTop: 100, scrollHeight: 4000, clientHeight: 600 });
+		api.handleScroll();
+		geometry(el, { scrollTop: 3300, scrollHeight: 4000, clientHeight: 600 });
+		api.handleScroll();
+		expect(fetchNewer).toHaveBeenCalledTimes(1);
+		expect(fetchOlder).toHaveBeenCalledTimes(1);
+	});
+});

--- a/web/src/components/modelTable/__tests__/useVirtualRows.test.tsx
+++ b/web/src/components/modelTable/__tests__/useVirtualRows.test.tsx
@@ -8,9 +8,15 @@ function rows(from: number, to: number): Row[] {
 	return Array.from({ length: to - from }, (_, i) => ({ id: `r${from + i}` }));
 }
 
-/** Renders the hook against a real scroll element whose geometry the test controls. */
+/**
+ * Real hook, real virtualizer, mocked geometry: the scroller reports a
+ * 600px viewport and every mounted row reports the height `heights` assigns
+ * to its id (45px when unlisted), so the virtualizer measures rows the way a
+ * browser would.
+ */
 function Harness({
 	entries,
+	heights,
 	hasBefore,
 	hasAfter,
 	fetchNewer,
@@ -18,13 +24,21 @@ function Harness({
 	expose,
 }: {
 	entries: Row[];
+	heights: Record<string, number>;
 	hasBefore: boolean;
 	hasAfter: boolean;
 	fetchNewer: () => void;
 	fetchOlder: () => void;
 	expose: (api: { handleScroll: () => void }) => void;
 }) {
-	const { scrollRef, handleScroll, startIndex, endIndex } = useVirtualRows({
+	const {
+		scrollRef,
+		virtualizer,
+		virtualItems,
+		handleScroll,
+		startIndex,
+		endIndex,
+	} = useVirtualRows({
 		entries,
 		hasBefore,
 		hasAfter,
@@ -35,61 +49,88 @@ function Harness({
 	});
 	expose({ handleScroll });
 	return (
-		<div ref={scrollRef} data-testid="scroller">
+		<div ref={scrollRef} data-testid="scroller" style={{ height: 600 }}>
 			<span data-testid="range">
 				{startIndex}-{endIndex}
 			</span>
+			{virtualItems.map((item) => (
+				<div
+					key={entries[item.index].id}
+					data-index={item.index}
+					data-height={heights[entries[item.index].id] ?? 45}
+					ref={virtualizer.measureElement}
+				>
+					{entries[item.index].id}
+				</div>
+			))}
 		</div>
 	);
 }
 
-function geometry(
+/**
+ * TanStack Virtual sizes the scroller and each row from offsetHeight, which
+ * jsdom leaves at 0; the getter below answers with the height `data-height`
+ * declares (600 for the scroller), so the real measurement path runs.
+ */
+function mockOffsetHeights() {
+	const original = Object.getOwnPropertyDescriptor(
+		HTMLElement.prototype,
+		"offsetHeight",
+	);
+	Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+		configurable: true,
+		get(this: HTMLElement) {
+			if (this.hasAttribute("data-height"))
+				return Number(this.getAttribute("data-height"));
+			if (this.getAttribute("data-testid") === "scroller") return 600;
+			return 0;
+		},
+	});
+	return () => {
+		if (original)
+			Object.defineProperty(HTMLElement.prototype, "offsetHeight", original);
+	};
+}
+
+function scrollGeometry(
 	el: HTMLElement,
-	{
-		scrollTop,
-		scrollHeight,
-		clientHeight,
-	}: { scrollTop: number; scrollHeight: number; clientHeight: number },
+	scrollTop: number,
+	scrollHeight: number,
 ) {
 	Object.defineProperty(el, "scrollHeight", {
 		configurable: true,
 		value: scrollHeight,
 	});
-	Object.defineProperty(el, "clientHeight", {
-		configurable: true,
-		value: clientHeight,
-	});
+	Object.defineProperty(el, "clientHeight", { configurable: true, value: 600 });
 	el.scrollTop = scrollTop;
 }
 
 describe("useVirtualRows", () => {
-	it("keeps the viewport on the same rows when rows are prepended", () => {
-		const fetchNewer = vi.fn();
-		const fetchOlder = vi.fn();
+	it("keeps the viewport on the same rows when unmeasured rows are prepended", () => {
 		const { rerender, getByTestId } = render(
 			<Harness
 				entries={rows(10, 50)}
+				heights={{}}
 				hasBefore
 				hasAfter
-				fetchNewer={fetchNewer}
-				fetchOlder={fetchOlder}
+				fetchNewer={vi.fn()}
+				fetchOlder={vi.fn()}
 				expose={() => {}}
 			/>,
 		);
 		const el = getByTestId("scroller") as HTMLDivElement;
-		geometry(el, { scrollTop: 900, scrollHeight: 4000, clientHeight: 600 });
-
-		// Ten rows land in front of the first one: the old first row keeps its
-		// place on screen, so scrollTop grows by ten row heights (45px estimate
-		// while nothing has been measured).
+		scrollGeometry(el, 900, 4000);
+		// Ten rows land in front: the old first row keeps its place, so scrollTop
+		// grows by ten row heights (the 45px estimate while nothing is measured).
 		act(() => {
 			rerender(
 				<Harness
 					entries={[...rows(0, 10), ...rows(10, 50)]}
+					heights={{}}
 					hasBefore
 					hasAfter
-					fetchNewer={fetchNewer}
-					fetchOlder={fetchOlder}
+					fetchNewer={vi.fn()}
+					fetchOlder={vi.fn()}
 					expose={() => {}}
 				/>,
 			);
@@ -97,10 +138,47 @@ describe("useVirtualRows", () => {
 		expect(el.scrollTop).toBe(900 + 10 * 45);
 	});
 
+	it("uses the prepended rows' own measured heights, not the old rows' measurements", () => {
+		const restore = mockOffsetHeights();
+		// The two rows at the top are short and measured; the two that will be
+		// prepended are tall. An index-keyed correction would shift by the short
+		// rows' 20 + 30; the right answer is the tall rows' 100 + 200.
+		const heights = { r10: 20, r11: 30, r8: 100, r9: 200 };
+		const { rerender, getByTestId } = render(
+			<Harness
+				entries={rows(10, 50)}
+				heights={heights}
+				hasBefore
+				hasAfter
+				fetchNewer={vi.fn()}
+				fetchOlder={vi.fn()}
+				expose={() => {}}
+			/>,
+		);
+		const el = getByTestId("scroller") as HTMLDivElement;
+		scrollGeometry(el, 500, 4000);
+		act(() => {
+			rerender(
+				<Harness
+					entries={[...rows(8, 10), ...rows(10, 50)]}
+					heights={heights}
+					hasBefore
+					hasAfter
+					fetchNewer={vi.fn()}
+					fetchOlder={vi.fn()}
+					expose={() => {}}
+				/>,
+			);
+		});
+		expect(el.scrollTop).toBe(500 + 100 + 200);
+		restore();
+	});
+
 	it("leaves scrollTop alone when rows are appended", () => {
 		const { rerender, getByTestId } = render(
 			<Harness
 				entries={rows(0, 40)}
+				heights={{}}
 				hasBefore={false}
 				hasAfter
 				fetchNewer={vi.fn()}
@@ -109,11 +187,12 @@ describe("useVirtualRows", () => {
 			/>,
 		);
 		const el = getByTestId("scroller") as HTMLDivElement;
-		geometry(el, { scrollTop: 300, scrollHeight: 4000, clientHeight: 600 });
+		scrollGeometry(el, 300, 4000);
 		act(() => {
 			rerender(
 				<Harness
 					entries={rows(0, 60)}
+					heights={{}}
 					hasBefore={false}
 					hasAfter
 					fetchNewer={vi.fn()}
@@ -132,6 +211,7 @@ describe("useVirtualRows", () => {
 		const { getByTestId, rerender } = render(
 			<Harness
 				entries={rows(0, 40)}
+				heights={{}}
 				hasBefore
 				hasAfter
 				fetchNewer={fetchNewer}
@@ -143,12 +223,12 @@ describe("useVirtualRows", () => {
 		);
 		const el = getByTestId("scroller") as HTMLDivElement;
 
-		geometry(el, { scrollTop: 100, scrollHeight: 4000, clientHeight: 600 });
+		scrollGeometry(el, 100, 4000);
 		api.handleScroll();
 		expect(fetchNewer).toHaveBeenCalledTimes(1);
 		expect(fetchOlder).not.toHaveBeenCalled();
 
-		geometry(el, { scrollTop: 3300, scrollHeight: 4000, clientHeight: 600 });
+		scrollGeometry(el, 3300, 4000);
 		api.handleScroll();
 		expect(fetchOlder).toHaveBeenCalledTimes(1);
 		expect(fetchNewer).toHaveBeenCalledTimes(1);
@@ -157,6 +237,7 @@ describe("useVirtualRows", () => {
 		rerender(
 			<Harness
 				entries={rows(0, 40)}
+				heights={{}}
 				hasBefore={false}
 				hasAfter={false}
 				fetchNewer={fetchNewer}
@@ -166,9 +247,9 @@ describe("useVirtualRows", () => {
 				}}
 			/>,
 		);
-		geometry(el, { scrollTop: 100, scrollHeight: 4000, clientHeight: 600 });
+		scrollGeometry(el, 100, 4000);
 		api.handleScroll();
-		geometry(el, { scrollTop: 3300, scrollHeight: 4000, clientHeight: 600 });
+		scrollGeometry(el, 3300, 4000);
 		api.handleScroll();
 		expect(fetchNewer).toHaveBeenCalledTimes(1);
 		expect(fetchOlder).toHaveBeenCalledTimes(1);

--- a/web/src/components/modelTable/modelCursor.ts
+++ b/web/src/components/modelTable/modelCursor.ts
@@ -1,0 +1,131 @@
+import { api } from "../../api/client";
+import type { Model, ModelsCursorResponse } from "../../api/types";
+import { encodeCursor } from "../../utils/format";
+
+export type ModelSortField =
+	| "name"
+	| "discovered"
+	| "context"
+	| "output"
+	| "provider"
+	| "status";
+
+export interface ModelSortState {
+	field: ModelSortField;
+	dir: "asc" | "desc";
+}
+
+/** The keyset cursor for `entry` under `field`, matching the server's ORDER BY. */
+export function modelCursor(field: ModelSortField, entry: Model): string {
+	let cursorObj: Record<string, unknown>;
+	switch (field) {
+		case "name":
+			cursorObj = {
+				sort_by: "name",
+				name: entry.name || entry.model_id,
+				model_id: entry.model_id,
+				id: entry.id,
+			};
+			break;
+		case "discovered":
+			cursorObj = {
+				sort_by: "discovered",
+				last_seen_at: entry.last_seen_at,
+				id: entry.id,
+			};
+			break;
+		case "context":
+			cursorObj = {
+				sort_by: "context",
+				context_length: entry.context_length ?? 0,
+				id: entry.id,
+			};
+			break;
+		case "output":
+			cursorObj = {
+				sort_by: "output",
+				max_output_tokens: entry.max_output_tokens ?? 0,
+				id: entry.id,
+			};
+			break;
+		case "provider":
+			cursorObj = {
+				sort_by: "provider",
+				provider_name: entry.provider_name,
+				id: entry.id,
+			};
+			break;
+		case "status":
+			cursorObj = {
+				sort_by: "status",
+				status_sort: entry.enabled ? (entry.disabled_manually ? 1 : 0) : 2,
+				id: entry.id,
+			};
+			break;
+		default:
+			cursorObj = { sort_by: "name", name: entry.name, id: entry.id };
+	}
+	return encodeCursor(cursorObj);
+}
+
+/** The string-keyed filter bag the cursor hook carries, mapped back to the client's typed call. */
+export function fetchModelsPage(params: {
+	cursor?: string;
+	direction: "after" | "before";
+	limit: number;
+	sort_dir: string;
+	[key: string]: string | number | undefined;
+}): Promise<ModelsCursorResponse> {
+	return api.models.cursor({
+		cursor: params.cursor,
+		direction: params.direction as "after" | "before",
+		limit: params.limit,
+		sort_by: params.sort_by as string | undefined,
+		sort_dir: params.sort_dir,
+		provider_id: params.provider_id as string | undefined,
+		search: params.search as string | undefined,
+		capabilities: params.capabilities as string | undefined,
+		outputs: params.outputs as string | undefined,
+		provider_enabled:
+			params.provider_enabled === undefined
+				? undefined
+				: params.provider_enabled === "true",
+	});
+}
+
+/**
+ * Walk every disabled row of the current filters, page by page, so a delete
+ * covers exactly what the server's disabled count promised. Sorted by name
+ * with its own cursor chain: the table's sort and cursor are irrelevant here.
+ */
+export async function loadAllDisabledModels(
+	filters: Record<string, string | undefined>,
+): Promise<Model[]> {
+	const { provider_id, search, capabilities, outputs, provider_enabled } =
+		filters;
+	const all: Model[] = [];
+	let cursor: string | undefined;
+	for (;;) {
+		const page = await api.models.cursor({
+			cursor,
+			direction: "after",
+			limit: 200,
+			sort_by: "name",
+			sort_dir: "asc",
+			provider_id,
+			search,
+			capabilities,
+			outputs,
+			provider_enabled:
+				provider_enabled === undefined
+					? undefined
+					: provider_enabled === "true",
+			enabled: false,
+		});
+		all.push(...page.entries);
+		const last = page.entries.at(-1);
+		if (!page.has_after || !last) break;
+		cursor = modelCursor("name", last);
+	}
+	return all;
+}

--- a/web/src/components/modelTable/useDeleteDisabled.ts
+++ b/web/src/components/modelTable/useDeleteDisabled.ts
@@ -1,0 +1,40 @@
+import { useCallback, useState } from "react";
+import { useTranslation } from "react-i18next";
+import type { Model } from "../../api/types";
+import { useToast } from "../../context/ToastContext";
+import { loadAllDisabledModels } from "./modelCursor";
+
+/**
+ * The "Delete disabled" flow: pressing the button fetches every disabled row
+ * of the current filters; the confirm dialog opens once that lands and lists
+ * exactly those rows. `pendingDisabled` is null while nothing is pending.
+ */
+export function useDeleteDisabled(filters: Record<string, string | undefined>) {
+	const { t } = useTranslation();
+	const { toast } = useToast();
+	const [pendingDisabled, setPendingDisabled] = useState<Model[] | null>(null);
+	const [loadingDisabled, setLoadingDisabled] = useState(false);
+
+	const openDeleteDisabled = useCallback(async () => {
+		setLoadingDisabled(true);
+		try {
+			setPendingDisabled(await loadAllDisabledModels(filters));
+		} catch (err) {
+			toast(
+				t("components.virtualModelTable.deleteDisabledLoadFailed", {
+					message: err instanceof Error ? err.message : String(err),
+				}),
+				"error",
+			);
+		} finally {
+			setLoadingDisabled(false);
+		}
+	}, [filters, toast, t]);
+
+	return {
+		pendingDisabled,
+		clearPendingDisabled: () => setPendingDisabled(null),
+		loadingDisabled,
+		openDeleteDisabled,
+	};
+}

--- a/web/src/components/modelTable/useVirtualRows.ts
+++ b/web/src/components/modelTable/useVirtualRows.ts
@@ -38,6 +38,11 @@ export function useVirtualRows<T extends { id: string }>({
 	// eslint-disable-next-line react-hooks/incompatible-library -- TanStack Virtual returns mutable functions; compiler skips memoization
 	const virtualizer = useVirtualizer({
 		count: entries.length,
+		// Measurements follow the ROW, not its index: after a prepend every row
+		// shifts to a new index, and index-keyed measurements would describe the
+		// old rows' heights under the new rows' slots, which is exactly the data
+		// the prepend correction below reads.
+		getItemKey: (index) => entries[index]?.id ?? index,
 		getScrollElement: () => scrollEl,
 		estimateSize: () => 45,
 		overscan: 20,
@@ -54,8 +59,9 @@ export function useVirtualRows<T extends { id: string }>({
 	// scrollTop stays the same, so the virtualizer maps the old scroll
 	// position to different items. Push scrollTop down by the height the new
 	// rows occupy: the start offset of the row that used to be first, which
-	// the virtualizer computes from measured sizes where it has them and
-	// estimateSize where it does not. Read measurementsCache BY INDEX: it is
+	// the virtualizer computes from measured sizes where it has them (rows are
+	// keyed by id, so a measurement survives the shift) and estimateSize where
+	// it does not. Read measurementsCache BY INDEX: it is
 	// a lazy view, not an array, so Array.prototype iteration (reduce, slice)
 	// over it sees nothing and an averaged size came out as 0. Then force a
 	// synchronous re-render so the virtualizer recomputes before the browser
@@ -65,6 +71,10 @@ export function useVirtualRows<T extends { id: string }>({
 		if (entries.length > prev.length && prev.length > 0) {
 			const newItemCount = entries.length - prev.length;
 			if (entries[newItemCount]?.id === prev[0]?.id && scrollEl) {
+				// The rows committed in this same pass were measured by their ref
+				// callbacks a moment ago; getVirtualItems() folds those sizes into
+				// the measurements before they are read.
+				virtualizer.getVirtualItems();
 				const cache = virtualizer.measurementsCache;
 				const first = cache[0];
 				const oldFirst = cache[newItemCount];
@@ -77,7 +87,7 @@ export function useVirtualRows<T extends { id: string }>({
 			}
 		}
 		prevEntriesRef.current = entries;
-	}, [entries, virtualizer.measurementsCache, scrollEl]);
+	}, [entries, virtualizer, scrollEl]);
 
 	const [paddingTop, paddingBottom] =
 		virtualItems.length > 0

--- a/web/src/components/modelTable/useVirtualRows.ts
+++ b/web/src/components/modelTable/useVirtualRows.ts
@@ -1,0 +1,135 @@
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { useCallback, useLayoutEffect, useRef, useState } from "react";
+
+const EDGE_THRESHOLD_PX = 500;
+
+/**
+ * The virtual window over a bidirectionally-fetched list: the virtualizer,
+ * the scroll-position correction when rows are prepended, the table padding
+ * that stands in for the unmounted rows, the edge-triggered fetches, and the
+ * visible index range for the footer.
+ */
+export function useVirtualRows<T extends { id: string }>({
+	entries,
+	hasBefore,
+	hasAfter,
+	isLoadingBefore,
+	isLoadingAfter,
+	fetchNewer,
+	fetchOlder,
+}: {
+	entries: T[];
+	hasBefore: boolean;
+	hasAfter: boolean;
+	isLoadingBefore: boolean;
+	isLoadingAfter: boolean;
+	fetchNewer: () => void;
+	fetchOlder: () => void;
+}) {
+	"use no memo";
+	// TanStack Virtual hands back mutable functions and a measurements cache
+	// that changes identity under the compiler's feet; memoizing around them
+	// silently disables the prepend correction below.
+	//
+	// The scroll element lives in state behind a callback ref rather than in a
+	// ref: the virtualizer and the handlers below read it during render and in
+	// callbacks, and a ref read there is exactly what react-hooks/refs forbids.
+	const [scrollEl, setScrollEl] = useState<HTMLDivElement | null>(null);
+	// eslint-disable-next-line react-hooks/incompatible-library -- TanStack Virtual returns mutable functions; compiler skips memoization
+	const virtualizer = useVirtualizer({
+		count: entries.length,
+		getScrollElement: () => scrollEl,
+		estimateSize: () => 45,
+		overscan: 20,
+	});
+
+	const virtualItems = virtualizer.getVirtualItems();
+
+	const prevEntriesRef = useRef(entries);
+	// State counter to force synchronous re-render after scrollTop adjustment.
+	// React guarantees setState inside useLayoutEffect is flushed before paint.
+	const [, forceRerender] = useState(0);
+
+	// When items are prepended (fetchNewer), all item indices shift but
+	// scrollTop stays the same, so the virtualizer maps the old scroll
+	// position to different items. Push scrollTop down by the height the new
+	// rows occupy: the start offset of the row that used to be first, which
+	// the virtualizer computes from measured sizes where it has them and
+	// estimateSize where it does not. Read measurementsCache BY INDEX: it is
+	// a lazy view, not an array, so Array.prototype iteration (reduce, slice)
+	// over it sees nothing and an averaged size came out as 0. Then force a
+	// synchronous re-render so the virtualizer recomputes before the browser
+	// paints.
+	useLayoutEffect(() => {
+		const prev = prevEntriesRef.current;
+		if (entries.length > prev.length && prev.length > 0) {
+			const newItemCount = entries.length - prev.length;
+			if (entries[newItemCount]?.id === prev[0]?.id && scrollEl) {
+				const cache = virtualizer.measurementsCache;
+				const first = cache[0];
+				const oldFirst = cache[newItemCount];
+				const added =
+					first && oldFirst ? oldFirst.start - first.start : newItemCount * 45;
+				scrollEl.scrollTop += added;
+				prevEntriesRef.current = entries;
+				forceRerender((c) => c + 1);
+				return;
+			}
+		}
+		prevEntriesRef.current = entries;
+	}, [entries, virtualizer.measurementsCache, scrollEl]);
+
+	const [paddingTop, paddingBottom] =
+		virtualItems.length > 0
+			? [
+					Math.max(0, virtualItems[0].start),
+					Math.max(
+						0,
+						virtualizer.getTotalSize() -
+							virtualItems[virtualItems.length - 1].end,
+					),
+				]
+			: [0, 0];
+
+	const handleScroll = useCallback(() => {
+		const el = scrollEl;
+		if (!el) return;
+
+		const nearTop = el.scrollTop < EDGE_THRESHOLD_PX;
+		const nearBottom =
+			el.scrollHeight - el.scrollTop - el.clientHeight < EDGE_THRESHOLD_PX;
+
+		if (nearTop && hasBefore && !isLoadingBefore) {
+			fetchNewer();
+		}
+		if (nearBottom && hasAfter && !isLoadingAfter) {
+			fetchOlder();
+		}
+	}, [
+		scrollEl,
+		hasBefore,
+		hasAfter,
+		isLoadingBefore,
+		isLoadingAfter,
+		fetchNewer,
+		fetchOlder,
+	]);
+
+	const startIndex = virtualItems.length > 0 ? virtualItems[0].index + 1 : 0;
+	const endIndex =
+		virtualItems.length > 0
+			? virtualItems[virtualItems.length - 1].index + 1
+			: 0;
+
+	return {
+		/** Attach to the scroller: `ref={scrollRef}`. */
+		scrollRef: setScrollEl,
+		virtualizer,
+		virtualItems,
+		paddingTop,
+		paddingBottom,
+		handleScroll,
+		startIndex,
+		endIndex,
+	};
+}


### PR DESCRIPTION
## Summary

Size-allowlist burn-down: `components/VirtualModelTable.tsx` was one 786-line component. It keeps the filter/sort state, the cursor filters, the bidirectional fetch and the composition; the rest moves under `components/modelTable/`:

| File | Lines | Holds |
|---|---|---|
| `VirtualModelTable.tsx` | 858 -> ~410 | state, filters, `useBidirectionalFetch`, total/refresh effects, toolbar, table composition, the confirm dialog |
| `modelTable/useVirtualRows.ts` | ~130 (new) | the virtualizer, the prepend scroll correction, the padding for unmounted rows, the edge-triggered fetches, the footer index range |
| `modelTable/ModelRow.tsx` | ~125 (new) | one model row |
| `modelTable/CapFilterRow.tsx` | ~85 (new) | the capability / output pill filter row |
| `modelTable/SortableTh.tsx` | ~35 (new) | the sortable header cell the header wrote out six times by hand |
| `modelTable/modelCursor.ts` | ~130 (new) | `modelCursor` (the keyset cursor per sort field), `fetchModelsPage`, `loadAllDisabledModels` |
| `modelTable/useDeleteDisabled.ts` | ~40 (new) | the "Delete disabled" fetch-then-confirm flow |

The component is under the 500-line `max-lines-per-function` cap, so its `eslint-disable` is removed. The file leaves the size allowlist.

## A behaviour fix the split surfaced

The new hook test for the prepend correction (scrolling up loads newer rows in front; the viewport must stay on the same rows) failed against the moved code: the correction averaged `virtualizer.measurementsCache` with `Array.prototype.reduce`, but since TanStack Virtual 3.17 that cache is a lazy view, not an array, so iteration sees nothing and the average was 0. In a browser that meant the correction moved by 0 and the list jumped on every upward load. It now reads the cache by index (which the view supports) and shifts by the start offset of the row that used to be first: measured sizes where the virtualizer has them, its estimate where it does not.

Review round: Greptile reproduced a second, related defect in the same correction. The virtualizer keyed measurements by index (the default), so after a prepend the slots 0..k still described the OLD rows' measured heights and the delta read those (20 + 30 instead of the new rows' 100 + 200). Measurements are now keyed by row id (`getItemKey: (index) => entries[index].id`), so they follow rows across the shift and the delta is the prepended rows' real extent (measured, or the estimate for a row not yet measured). The hook test gained a variable-height case that drives the real virtualizer measurement path (`offsetHeight` mocked per row) and asserts the 300px shift.

The hook also holds the scroll element in state behind a callback ref instead of reading a ref during render, which `react-hooks/refs` rejects for a hook (the component had opted the whole function out of the compiler).

## Verification

- Biome, `tsc -b`, ESLint: clean
- The table's suite and the Models page suites pass unchanged; with the new `useVirtualRows` test: 237/237
- Coverage of the changed set: 157/162 statements = 96.9% (was 88.4% for the old single file)
- **Rebuilt dev stack** (925 models): the list renders 38 rows in view; sort by context flips the arrow and the order; the Vision pill filters to 530 with the clear button; a no-match search shows the empty row; scrolling to the bottom loads older rows (footer moves to `367–423 / 925`); a row opens the detail modal; the delete-disabled button shows; no console errors. The prepend path itself cannot be provoked on dev (the cursor window kept all 925 rows, so there is never a newer page), so the hook test is its coverage
- `make size-check`: passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
