### PR TITLE
refactor(web): decompose ModelDetailModal

### DIFF
--- a/scripts/ci/size-allowlist.txt
+++ b/scripts/ci/size-allowlist.txt
@@ -29,6 +29,5 @@ web/src/api/types.ts	1058
 web/src/components/Layout.tsx	1065
 web/src/components/VirtualModelTable.tsx	858
 web/src/components/__tests__/Layout.navigation.test.tsx	2558
-web/src/pages/Models/ModelDetailModal.tsx	823
 web/src/pages/Settings/alerts/AlertsWizard.tsx	801
 web/src/pages/Settings/alerts/steps.tsx	846

--- a/web/src/pages/Models/ModelActionsFooter.tsx
+++ b/web/src/pages/Models/ModelActionsFooter.tsx
@@ -1,0 +1,128 @@
+import { useTranslation } from "react-i18next";
+import type { Model } from "../../api/types";
+import { Spinner } from "../../components/Spinner";
+
+/**
+ * The management footer: enable/disable, test, delete (two-step) on the left;
+ * edit / save-cancel and re-discover with its cooldown on the right.
+ */
+export function ModelActionsFooter({
+	model,
+	editing,
+	testing,
+	testError,
+	cooldown,
+	discovering,
+	confirmDelete,
+	onToggle,
+	onTest,
+	onArmDelete,
+	onDelete,
+	onEdit,
+	onCancelEdit,
+	onSave,
+	onDiscover,
+}: {
+	model: Model;
+	editing: boolean;
+	testing: boolean;
+	testError: boolean;
+	cooldown: number;
+	discovering: boolean;
+	confirmDelete: boolean;
+	onToggle: () => void;
+	onTest: () => void;
+	onArmDelete: () => void;
+	onDelete: () => void;
+	onEdit: () => void;
+	onCancelEdit: () => void;
+	onSave: () => void;
+	onDiscover: () => void;
+}) {
+	const { t } = useTranslation();
+	return (
+		<div className="flex items-center justify-between mt-4 pt-4">
+			<div className="flex items-center gap-2">
+				<button
+					type="button"
+					onClick={onToggle}
+					className={`ui-btn ${model.enabled ? "ui-btn-primary" : "ui-btn-danger"}`}
+				>
+					{model.enabled ? t("common.enabled") : t("common.disabled")}
+				</button>
+				<button
+					type="button"
+					disabled={testing}
+					onClick={onTest}
+					className={`ui-btn ${testError ? "ui-btn-danger" : "ui-btn-secondary"}`}
+				>
+					{testing && <Spinner />}
+					{testing ? t("models.detail.testing") : t("models.detail.test")}
+				</button>
+				{!confirmDelete ? (
+					<button
+						type="button"
+						onClick={onArmDelete}
+						className="ui-btn ui-btn-danger-muted"
+					>
+						{t("common.delete")}
+					</button>
+				) : (
+					<button
+						type="button"
+						onClick={onDelete}
+						className="ui-btn ui-btn-danger"
+					>
+						{t("models.detail.confirmDelete")}
+					</button>
+				)}
+			</div>
+			<div className="flex items-center gap-2">
+				{editing ? (
+					<>
+						<button
+							type="button"
+							onClick={onCancelEdit}
+							className="ui-btn ui-btn-secondary"
+						>
+							{t("common.cancel")}
+						</button>
+						<button
+							type="button"
+							onClick={onSave}
+							className="ui-btn ui-btn-primary"
+						>
+							{t("common.saveChanges")}
+						</button>
+					</>
+				) : (
+					<>
+						<button
+							type="button"
+							onClick={onEdit}
+							className="ui-btn ui-btn-secondary"
+						>
+							{t("common.edit")}
+						</button>
+						<button
+							type="button"
+							disabled={cooldown > 0 || discovering}
+							onClick={onDiscover}
+							className="ui-btn bg-(--accent-light) text-(--accent) hover:brightness-125"
+						>
+							{discovering ? (
+								<>
+									<Spinner /> {t("models.detail.updating")}
+								</>
+							) : cooldown > 0 ? (
+								t("models.detail.updateCooldown", { cooldown })
+							) : (
+								t("models.detail.updateInfo")
+							)}
+						</button>
+					</>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/web/src/pages/Models/ModelDetailModal.tsx
+++ b/web/src/pages/Models/ModelDetailModal.tsx
@@ -1,86 +1,29 @@
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import {
-	ArrowDownToLine,
-	ArrowUpFromLine,
-	Clock,
-	Coins,
-	DollarSign,
-	Hash,
-	Layers,
-	Pin,
-	RefreshCw,
-	Server,
-	Sparkles,
-	Tag,
-} from "@/lib/icons";
+import { Pin, RefreshCw, Sparkles } from "@/lib/icons";
 import type { Model } from "../../api/types";
 import { CapBadge } from "../../components/CapBadge";
 import { ConfirmDialog } from "../../components/ConfirmDialog";
 import { CopyablePill } from "../../components/CopyablePill";
-import { CopyButton } from "../../components/CopyButton";
 import { CAP_META, hasCap } from "../../components/capMeta";
 import { DetailSectionHeader } from "../../components/DetailSectionHeader";
-import { DetailItem } from "../../components/LogDetailItem";
-import { LangIcon, type LangIconKey } from "../../components/langIcons";
+import type { LangIconKey } from "../../components/langIcons";
 import { Modal } from "../../components/Modal";
 import { OutputBadges } from "../../components/OutputBadges";
-import { ShikiCode } from "../../components/ShikiCode";
-import { Spinner } from "../../components/Spinner";
-import { TerminalPreview } from "../../components/TerminalPreview";
-import { formatNumber, formatRelativeTime } from "../../utils/format";
 import {
-	formatPrice,
 	formatPriceInput,
 	nonTextOutputs,
 	parseCapabilities,
 	proxyModelID,
 } from "../../utils/model";
-import type { SnippetLang } from "../../utils/shikiHighlighter";
-import {
-	snippetClaudeCodeModelText,
-	snippetCurlModelText,
-	snippetHermesModelText,
-	snippetJSModelText,
-	snippetLibreChatModelText,
-	snippetOpenClawModelText,
-	snippetOpencodeModelText,
-	snippetPowershellModelText,
-	snippetPythonModelText,
-	snippetZedModelText,
-} from "../../utils/snippets";
+import { ModelActionsFooter } from "./ModelActionsFooter";
+import { ModelSnippetPanel } from "./ModelSnippetPanel";
+import { ModelStatsGrid } from "./ModelStatsGrid";
+import { modelModalities, parseParams } from "./modelDetailParse";
+import { modelSnippetEntries } from "./modelSnippets";
+import { type ModelTestResult, useModelActions } from "./useModelActions";
 import { useModelEditor } from "./useModelEditor";
 
-/** Small revert button that restores a field to its discovered default value. */
-function RevertButton({
-	onClick,
-	className,
-}: {
-	onClick: () => void;
-	className?: string;
-}) {
-	const { t } = useTranslation();
-	return (
-		<button
-			type="button"
-			onClick={onClick}
-			className={`text-[10px] px-1.5 py-0.5 rounded-(--radius-button) bg-gray-700 text-gray-400 hover:text-white border border-gray-600 ${className ?? ""}`}
-			title={t("model.revertToDiscoveredValue")}
-			aria-label={t("model.revertToDiscoveredValue")}
-		>
-			↩
-		</button>
-	);
-}
-
-function parseParams(raw: string): Record<string, unknown> | null {
-	try {
-		return JSON.parse(raw);
-	} catch {
-		return null;
-	}
-}
-// eslint-disable-next-line max-lines-per-function -- size ratchet: split this component
 export function ModelDetailModal({
 	model,
 	onClose,
@@ -98,14 +41,7 @@ export function ModelDetailModal({
 	 * Dashboard and Arena), the action footer and editing are hidden. */
 	onToggle?: (id: string, enabled: boolean) => void;
 	onDiscover?: (providerId: string) => Promise<unknown>;
-	onTest?: (id: string) => Promise<{
-		success: boolean;
-		streaming: boolean;
-		ttft_ms: number;
-		duration_ms: number;
-		response: string;
-		error?: string;
-	}>;
+	onTest?: (id: string) => Promise<ModelTestResult>;
 	onToast?: (msg: string, type?: "success" | "error" | "info") => void;
 	onUpdate?: (id: string, updates: Partial<Model>) => void;
 	onDelete?: (id: string) => void;
@@ -118,26 +54,7 @@ export function ModelDetailModal({
 	);
 	const caps = parseCapabilities(model.capabilities);
 	const params = parseParams(model.params);
-	const inputMods = (() => {
-		try {
-			const v = JSON.parse(model.input_modalities);
-			return Array.isArray(v) ? v : [v];
-		} catch {
-			return [];
-		}
-	})();
-	const outputMods = (() => {
-		try {
-			const v = JSON.parse(model.output_modalities);
-			return Array.isArray(v) ? v : [v];
-		} catch {
-			return [];
-		}
-	})();
-	const [cooldown, setCooldown] = useState(0);
-	const [discovering, setDiscovering] = useState(false);
-	const [testing, setTesting] = useState(false);
-	const [testError, setTestError] = useState(false);
+	const { inputMods, outputMods } = modelModalities(model);
 	const [snippetTab, setSnippetTab] = useState<LangIconKey>("curl");
 	const {
 		editing,
@@ -152,89 +69,14 @@ export function ModelDetailModal({
 		revertField,
 	} = useModelEditor({ model, onUpdate: onUpdate ?? (() => {}) });
 	const [confirmDelete, setConfirmDelete] = useState(false);
-	const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
-	const testErrorTimers = useRef<ReturnType<typeof setTimeout>[]>([]);
-
-	useEffect(() => {
-		return () => {
-			if (timerRef.current) clearInterval(timerRef.current);
-			// eslint-disable-next-line react-hooks/exhaustive-deps -- cleanup reads ref at unmount time
-			for (const timer of testErrorTimers.current) clearTimeout(timer);
-		};
-	}, []);
-
-	const handleDiscover = async () => {
-		if (!onDiscover || cooldown > 0 || discovering) return;
-		setDiscovering(true);
-		try {
-			await onDiscover(model.provider_id);
-			setCooldown(30);
-			timerRef.current = setInterval(() => {
-				setCooldown((prev) => {
-					if (prev <= 1) {
-						if (timerRef.current) clearInterval(timerRef.current);
-						return 0;
-					}
-					return prev - 1;
-				});
-			}, 1000);
-		} finally {
-			setDiscovering(false);
-		}
-	};
-
-	const handleTest = async () => {
-		if (!onTest || !onToast || testing) return;
-		setTesting(true);
-		setTestError(false);
-		try {
-			const result = await onTest(model.id);
-			if (result.success) {
-				const content = result.response.replace(/\n/g, " ").slice(0, 80);
-				const isStreaming = result.streaming;
-				const ttftPart = isStreaming
-					? ` | TTFT: ${(result.ttft_ms / 1000).toFixed(1)}s`
-					: "";
-				onToast(
-					t(
-						// Reasoning models can succeed with empty content (the budget
-						// went to reasoning); omit the "Response:" part in that case.
-						content
-							? "models.detail.testSuccess"
-							: "models.detail.testSuccessNoResponse",
-						{
-							content,
-							ttftPart,
-							duration: (result.duration_ms / 1000).toFixed(1),
-						},
-					),
-					"success",
-				);
-			} else {
-				setTestError(true);
-				onToast(
-					t("models.detail.testFailed", {
-						error: result.error || t("common.unknownError"),
-					}),
-					"error",
-				);
-				const timer = setTimeout(() => setTestError(false), 3000);
-				testErrorTimers.current.push(timer);
-			}
-		} catch (err) {
-			setTestError(true);
-			onToast(
-				t("models.detail.testFailed", {
-					error: err instanceof Error ? err.message : t("common.unknownError"),
-				}),
-				"error",
-			);
-			const timer = setTimeout(() => setTestError(false), 3000);
-			testErrorTimers.current.push(timer);
-		} finally {
-			setTesting(false);
-		}
-	};
+	const {
+		cooldown,
+		discovering,
+		testing,
+		testError,
+		handleDiscover,
+		handleTest,
+	} = useModelActions({ model, onDiscover, onTest, onToast });
 
 	const handleClose = () => {
 		if (editing) {
@@ -246,100 +88,15 @@ export function ModelDetailModal({
 
 	const pMid = proxyModelID(model.provider_name, model.model_id);
 	const origin = window.location.origin;
-	const modelSnippetOpts = { proxyModelId: pMid, origin };
-	const zedOpts = {
+	const snippets = modelSnippetEntries({
+		t,
+		model,
 		proxyModelId: pMid,
-		displayName: model.display_name || model.name,
-		contextLength: model.context_length,
-		maxOutputTokens: model.max_output_tokens,
-		capabilities: caps,
+		caps,
+		inputMods,
+		outputMods,
 		origin,
-	};
-	const opencodeOpts = {
-		proxyModelId: pMid,
-		displayName: model.display_name || model.name || pMid,
-		contextLength: model.context_length,
-		maxOutputTokens: model.max_output_tokens,
-		capabilities: caps,
-		inputModalities: inputMods,
-		outputModalities: outputMods,
-		inputPricePerMillion: model.input_price_per_million,
-		outputPricePerMillion: model.output_price_per_million,
-		origin,
-	};
-
-	type SnippetEntry = {
-		key: LangIconKey;
-		title: string;
-		lang: SnippetLang;
-		copyText: string;
-	};
-
-	const SNIPPET_ENTRIES: SnippetEntry[] = [
-		{
-			key: "curl",
-			title: t("models.detail.snippet.curl"),
-			lang: "bash",
-			copyText: snippetCurlModelText(modelSnippetOpts),
-		},
-		{
-			key: "powershell",
-			title: t("models.detail.snippet.powershell"),
-			lang: "powershell",
-			copyText: snippetPowershellModelText(modelSnippetOpts),
-		},
-		{
-			key: "javascript",
-			title: t("models.detail.snippet.javascript"),
-			lang: "javascript",
-			copyText: snippetJSModelText(modelSnippetOpts),
-		},
-		{
-			key: "python",
-			title: t("models.detail.snippet.python"),
-			lang: "python",
-			copyText: snippetPythonModelText(modelSnippetOpts),
-		},
-		{
-			key: "claude",
-			title: t("models.detail.snippet.claudeCode"),
-			lang: "bash",
-			copyText: snippetClaudeCodeModelText(modelSnippetOpts),
-		},
-		{
-			key: "openclaw",
-			title: t("models.detail.snippet.openClaw"),
-			lang: "bash",
-			copyText: snippetOpenClawModelText(modelSnippetOpts),
-		},
-		{
-			key: "hermes",
-			title: t("models.detail.snippet.hermes"),
-			lang: "bash",
-			copyText: snippetHermesModelText(modelSnippetOpts),
-		},
-		{
-			key: "librechat",
-			title: t("models.detail.snippet.librechat"),
-			lang: "yaml",
-			copyText: snippetLibreChatModelText(modelSnippetOpts),
-		},
-		{
-			key: "zed",
-			title: t("models.detail.snippet.zed"),
-			lang: "json",
-			copyText: snippetZedModelText(zedOpts),
-		},
-		{
-			key: "opencode",
-			title: t("models.detail.snippet.opencode"),
-			lang: "json",
-			copyText: snippetOpencodeModelText(opencodeOpts),
-		},
-	];
-
-	const activeSnippet =
-		SNIPPET_ENTRIES.find((e) => e.key === snippetTab) ?? SNIPPET_ENTRIES[0];
+	});
 
 	return (
 		<Modal
@@ -372,224 +129,16 @@ export function ModelDetailModal({
 				</div>
 			)}
 
-			<div className="grid grid-cols-2 gap-2 mb-4">
-				<DetailItem
-					icon={Server}
-					label={t("models.detail.provider")}
-					value={model.provider_name}
-				/>
-				<DetailItem
-					icon={Clock}
-					label={t("models.detail.lastDiscovered")}
-					value={formatRelativeTime(model.last_seen_at)}
-				/>
-				{/* Display name is shown in big letters in the modal header, so the
-				    view-mode pill would be redundant; only surface it as an editable
-				    field when editing. */}
-				{editing && (
-					<DetailItem
-						icon={Tag}
-						label={t("models.detail.displayName")}
-						className="col-span-2"
-					>
-						<div className="flex items-center gap-1">
-							<input
-								type="text"
-								maxLength={128}
-								value={editData.display_name}
-								onChange={(e) =>
-									setEditData((prev) => ({
-										...prev,
-										display_name: e.target.value,
-									}))
-								}
-								className="ui-input text-sm"
-							/>
-							{editData.display_name !== discoveredDefaults.display_name && (
-								<RevertButton onClick={() => revertField("display_name")} />
-							)}
-						</div>
-					</DetailItem>
-				)}
-				<DetailItem
-					emphasis="stat"
-					icon={Layers}
-					label={t("models.detail.contextLength")}
-					value={`${formatNumber(model.context_length)} ${t("models.detail.tokens")}`}
-					mono
-					labelExtra={
-						model.context_length != null ? (
-							<CopyButton
-								text={String(model.context_length)}
-								title={t("models.detail.copyRawValue")}
-							/>
-						) : undefined
-					}
-				>
-					{editing ? (
-						<div className="flex items-center gap-1">
-							<input
-								type="number"
-								min={256}
-								max={2000000}
-								value={editData.context_length}
-								onChange={(e) =>
-									setEditData((prev) => ({
-										...prev,
-										context_length: e.target.value,
-									}))
-								}
-								className="ui-input text-sm"
-								placeholder={t("models.detail.tokens")}
-							/>
-							{editData.context_length !==
-								(discoveredDefaults.context_length?.toString() ?? "") && (
-								<RevertButton onClick={() => revertField("context_length")} />
-							)}
-						</div>
-					) : undefined}
-				</DetailItem>
-				<DetailItem
-					emphasis="stat"
-					icon={Hash}
-					label={t("models.detail.maxOutput")}
-					value={`${formatNumber(model.max_output_tokens)} ${t("models.detail.tokens")}`}
-					mono
-					labelExtra={
-						model.max_output_tokens != null ? (
-							<CopyButton
-								text={String(model.max_output_tokens)}
-								title={t("models.detail.copyRawValue")}
-							/>
-						) : undefined
-					}
-				>
-					{editing ? (
-						<div className="flex items-center gap-1">
-							<input
-								type="number"
-								min={1}
-								max={128000}
-								value={editData.max_output_tokens}
-								onChange={(e) =>
-									setEditData((prev) => ({
-										...prev,
-										max_output_tokens: e.target.value,
-									}))
-								}
-								className="ui-input text-sm"
-								placeholder={t("models.detail.tokens")}
-							/>
-							{editData.max_output_tokens !==
-								(discoveredDefaults.max_output_tokens?.toString() ?? "") && (
-								<RevertButton
-									onClick={() => revertField("max_output_tokens")}
-								/>
-							)}
-						</div>
-					) : undefined}
-				</DetailItem>
-				<DetailItem
-					emphasis="stat"
-					icon={DollarSign}
-					label={t("models.detail.inputPrice")}
-					value={
-						model.input_price_per_million != null
-							? `$${formatPrice(model.input_price_per_million)}/1M`
-							: "-"
-					}
-					mono
-				>
-					{editing ? (
-						<div className="flex items-center gap-1">
-							<div className="relative w-full">
-								<input
-									type="number"
-									step="0.01"
-									min={0}
-									max={1000}
-									value={editData.input_price_per_million}
-									onChange={(e) =>
-										setEditData((prev) => ({
-											...prev,
-											input_price_per_million: e.target.value,
-										}))
-									}
-									className="ui-input text-sm pr-16!"
-									placeholder={t("models.detail.placeholder.price")}
-								/>
-								<span className="absolute right-2 top-1/2 -translate-y-1/2 text-[10px] text-gray-400">
-									{t("models.detail.perMillionTokens")}
-								</span>
-							</div>
-							{editData.input_price_per_million !==
-								formatPriceInput(
-									discoveredDefaults.input_price_per_million,
-								) && (
-								<RevertButton
-									onClick={() => revertField("input_price_per_million")}
-									className="shrink-0"
-								/>
-							)}
-						</div>
-					) : undefined}
-				</DetailItem>
-				<DetailItem
-					emphasis="stat"
-					icon={Coins}
-					label={t("models.detail.outputPrice")}
-					value={
-						model.output_price_per_million != null
-							? `$${formatPrice(model.output_price_per_million)}/1M`
-							: "-"
-					}
-					mono
-				>
-					{editing ? (
-						<div className="flex items-center gap-1">
-							<div className="relative w-full">
-								<input
-									type="number"
-									step="0.01"
-									min={0}
-									max={1000}
-									value={editData.output_price_per_million}
-									onChange={(e) =>
-										setEditData((prev) => ({
-											...prev,
-											output_price_per_million: e.target.value,
-										}))
-									}
-									className="ui-input text-sm pr-16!"
-									placeholder={t("models.detail.placeholder.price")}
-								/>
-								<span className="absolute right-2 top-1/2 -translate-y-1/2 text-[10px] text-gray-400">
-									{t("models.detail.perMillionTokens")}
-								</span>
-							</div>
-							{editData.output_price_per_million !==
-								formatPriceInput(
-									discoveredDefaults.output_price_per_million,
-								) && (
-								<RevertButton
-									onClick={() => revertField("output_price_per_million")}
-									className="shrink-0"
-								/>
-							)}
-						</div>
-					) : undefined}
-				</DetailItem>
-				<DetailItem
-					icon={ArrowDownToLine}
-					label={t("models.detail.input")}
-					value={inputMods.join(", ") || t("models.detail.modality.text")}
-				/>
-				<DetailItem
-					icon={ArrowUpFromLine}
-					label={t("models.detail.output")}
-					value={outputMods.join(", ") || t("models.detail.modality.text")}
-				/>
-			</div>
+			<ModelStatsGrid
+				model={model}
+				inputMods={inputMods}
+				outputMods={outputMods}
+				editing={editing}
+				editData={editData}
+				setEditData={setEditData}
+				discoveredDefaults={discoveredDefaults}
+				revertField={revertField}
+			/>
 
 			{/* Editing a price pins it server-side; while pinned, discovery stops
 			    refreshing this model's prices from live/catalog/models.dev.
@@ -667,133 +216,34 @@ export function ModelDetailModal({
 				</div>
 			)}
 
-			<div className="mt-4 pt-4">
-				<div
-					role="tablist"
-					aria-label={t("models.detail.snippetFormatPicker")}
-					className="flex items-center gap-1 mb-3"
-				>
-					{SNIPPET_ENTRIES.map((entry) => (
-						<button
-							key={entry.key}
-							type="button"
-							role="tab"
-							aria-selected={snippetTab === entry.key}
-							onClick={() => setSnippetTab(entry.key)}
-							className={`ui-tab p-1.5 transition-all ${
-								snippetTab === entry.key
-									? "bg-slate-700/30 border border-slate-600/30"
-									: "text-slate-500 hover:text-slate-400 border border-transparent"
-							}`}
-							title={entry.title}
-							aria-label={entry.title}
-						>
-							<LangIcon name={entry.key} size={16} />
-						</button>
-					))}
-				</div>
-				<TerminalPreview
-					variant="code"
-					title={activeSnippet.title}
-					icon={activeSnippet.key}
-					copyText={activeSnippet.copyText}
-					height={200}
-				>
-					<ShikiCode
-						code={activeSnippet.copyText}
-						lang={activeSnippet.lang}
-						highlights={[origin, "YOUR_API_KEY", pMid]}
-					/>
-				</TerminalPreview>
-			</div>
+			<ModelSnippetPanel
+				entries={snippets}
+				activeKey={snippetTab}
+				onSelect={setSnippetTab}
+				highlights={[origin, "YOUR_API_KEY", pMid]}
+			/>
 
 			{manageable && (
-				<div className="flex items-center justify-between mt-4 pt-4">
-					<div className="flex items-center gap-2">
-						<button
-							type="button"
-							onClick={() => onToggle?.(model.id, !model.enabled)}
-							className={`ui-btn ${model.enabled ? "ui-btn-primary" : "ui-btn-danger"}`}
-						>
-							{model.enabled ? t("common.enabled") : t("common.disabled")}
-						</button>
-						<button
-							type="button"
-							disabled={testing}
-							onClick={handleTest}
-							className={`ui-btn ${testError ? "ui-btn-danger" : "ui-btn-secondary"}`}
-						>
-							{testing && <Spinner />}
-							{testing ? t("models.detail.testing") : t("models.detail.test")}
-						</button>
-						{!confirmDelete ? (
-							<button
-								type="button"
-								onClick={() => setConfirmDelete(true)}
-								className="ui-btn ui-btn-danger-muted"
-							>
-								{t("common.delete")}
-							</button>
-						) : (
-							<button
-								type="button"
-								onClick={() => {
-									onDelete?.(model.id);
-									onClose();
-								}}
-								className="ui-btn ui-btn-danger"
-							>
-								{t("models.detail.confirmDelete")}
-							</button>
-						)}
-					</div>
-					<div className="flex items-center gap-2">
-						{editing ? (
-							<>
-								<button
-									type="button"
-									onClick={handleCancelEdit}
-									className="ui-btn ui-btn-secondary"
-								>
-									{t("common.cancel")}
-								</button>
-								<button
-									type="button"
-									onClick={handleSave}
-									className="ui-btn ui-btn-primary"
-								>
-									{t("common.saveChanges")}
-								</button>
-							</>
-						) : (
-							<>
-								<button
-									type="button"
-									onClick={() => setEditing(true)}
-									className="ui-btn ui-btn-secondary"
-								>
-									{t("common.edit")}
-								</button>
-								<button
-									type="button"
-									disabled={cooldown > 0 || discovering}
-									onClick={handleDiscover}
-									className="ui-btn bg-(--accent-light) text-(--accent) hover:brightness-125"
-								>
-									{discovering ? (
-										<>
-											<Spinner /> {t("models.detail.updating")}
-										</>
-									) : cooldown > 0 ? (
-										t("models.detail.updateCooldown", { cooldown })
-									) : (
-										t("models.detail.updateInfo")
-									)}
-								</button>
-							</>
-						)}
-					</div>
-				</div>
+				<ModelActionsFooter
+					model={model}
+					editing={editing}
+					testing={testing}
+					testError={testError}
+					cooldown={cooldown}
+					discovering={discovering}
+					confirmDelete={confirmDelete}
+					onToggle={() => onToggle?.(model.id, !model.enabled)}
+					onTest={handleTest}
+					onArmDelete={() => setConfirmDelete(true)}
+					onDelete={() => {
+						onDelete?.(model.id);
+						onClose();
+					}}
+					onEdit={() => setEditing(true)}
+					onCancelEdit={handleCancelEdit}
+					onSave={handleSave}
+					onDiscover={handleDiscover}
+				/>
 			)}
 
 			{confirmFields && (

--- a/web/src/pages/Models/ModelSnippetPanel.tsx
+++ b/web/src/pages/Models/ModelSnippetPanel.tsx
@@ -1,0 +1,62 @@
+import { useTranslation } from "react-i18next";
+import { LangIcon, type LangIconKey } from "../../components/langIcons";
+import { ShikiCode } from "../../components/ShikiCode";
+import { TerminalPreview } from "../../components/TerminalPreview";
+import type { SnippetEntry } from "./modelSnippets";
+
+/** The snippet tabs and the highlighted, copyable snippet for the active one. */
+export function ModelSnippetPanel({
+	entries,
+	activeKey,
+	onSelect,
+	highlights,
+}: {
+	entries: SnippetEntry[];
+	activeKey: LangIconKey;
+	onSelect: (key: LangIconKey) => void;
+	highlights: string[];
+}) {
+	const { t } = useTranslation();
+	const active = entries.find((e) => e.key === activeKey) ?? entries[0];
+	return (
+		<div className="mt-4 pt-4">
+			<div
+				role="tablist"
+				aria-label={t("models.detail.snippetFormatPicker")}
+				className="flex items-center gap-1 mb-3"
+			>
+				{entries.map((entry) => (
+					<button
+						key={entry.key}
+						type="button"
+						role="tab"
+						aria-selected={activeKey === entry.key}
+						onClick={() => onSelect(entry.key)}
+						className={`ui-tab p-1.5 transition-all ${
+							activeKey === entry.key
+								? "bg-slate-700/30 border border-slate-600/30"
+								: "text-slate-500 hover:text-slate-400 border border-transparent"
+						}`}
+						title={entry.title}
+						aria-label={entry.title}
+					>
+						<LangIcon name={entry.key} size={16} />
+					</button>
+				))}
+			</div>
+			<TerminalPreview
+				variant="code"
+				title={active.title}
+				icon={active.key}
+				copyText={active.copyText}
+				height={200}
+			>
+				<ShikiCode
+					code={active.copyText}
+					lang={active.lang}
+					highlights={highlights}
+				/>
+			</TerminalPreview>
+		</div>
+	);
+}

--- a/web/src/pages/Models/ModelStatsGrid.tsx
+++ b/web/src/pages/Models/ModelStatsGrid.tsx
@@ -1,0 +1,249 @@
+import { useTranslation } from "react-i18next";
+import {
+	ArrowDownToLine,
+	ArrowUpFromLine,
+	Clock,
+	Coins,
+	DollarSign,
+	Hash,
+	Layers,
+	Server,
+	Tag,
+} from "@/lib/icons";
+import type { Model } from "../../api/types";
+import { CopyButton } from "../../components/CopyButton";
+import { DetailItem } from "../../components/LogDetailItem";
+import { formatNumber, formatRelativeTime } from "../../utils/format";
+import { formatPrice, formatPriceInput } from "../../utils/model";
+import type { useModelEditor } from "./useModelEditor";
+
+type Editor = ReturnType<typeof useModelEditor>;
+
+/** Small revert button that restores a field to its discovered default value. */
+function RevertButton({
+	onClick,
+	className,
+}: {
+	onClick: () => void;
+	className?: string;
+}) {
+	const { t } = useTranslation();
+	return (
+		<button
+			type="button"
+			onClick={onClick}
+			className={`text-[10px] px-1.5 py-0.5 rounded-(--radius-button) bg-gray-700 text-gray-400 hover:text-white border border-gray-600 ${className ?? ""}`}
+			title={t("model.revertToDiscoveredValue")}
+			aria-label={t("model.revertToDiscoveredValue")}
+		>
+			↩
+		</button>
+	);
+}
+
+/**
+ * The two-column facts grid: provider, discovery time, context and output
+ * limits, prices and modalities. In edit mode the editable cells show their
+ * inputs, each with a revert button once it differs from the discovered value.
+ */
+export function ModelStatsGrid({
+	model,
+	inputMods,
+	outputMods,
+	editing,
+	editData,
+	setEditData,
+	discoveredDefaults,
+	revertField,
+}: {
+	model: Model;
+	inputMods: string[];
+	outputMods: string[];
+	editing: boolean;
+	editData: Editor["editData"];
+	setEditData: Editor["setEditData"];
+	discoveredDefaults: Editor["discoveredDefaults"];
+	revertField: Editor["revertField"];
+}) {
+	const { t } = useTranslation();
+	const priceEditor = (
+		field: "input_price_per_million" | "output_price_per_million",
+	) => (
+		<div className="flex items-center gap-1">
+			<div className="relative w-full">
+				<input
+					type="number"
+					step="0.01"
+					min={0}
+					max={1000}
+					value={editData[field]}
+					onChange={(e) =>
+						setEditData((prev) => ({ ...prev, [field]: e.target.value }))
+					}
+					className="ui-input text-sm pr-16!"
+					placeholder={t("models.detail.placeholder.price")}
+				/>
+				<span className="absolute right-2 top-1/2 -translate-y-1/2 text-[10px] text-gray-400">
+					{t("models.detail.perMillionTokens")}
+				</span>
+			</div>
+			{editData[field] !== formatPriceInput(discoveredDefaults[field]) && (
+				<RevertButton onClick={() => revertField(field)} className="shrink-0" />
+			)}
+		</div>
+	);
+	return (
+		<div className="grid grid-cols-2 gap-2 mb-4">
+			<DetailItem
+				icon={Server}
+				label={t("models.detail.provider")}
+				value={model.provider_name}
+			/>
+			<DetailItem
+				icon={Clock}
+				label={t("models.detail.lastDiscovered")}
+				value={formatRelativeTime(model.last_seen_at)}
+			/>
+			{/* Display name is shown in big letters in the modal header, so the
+			    view-mode pill would be redundant; only surface it as an editable
+			    field when editing. */}
+			{editing && (
+				<DetailItem
+					icon={Tag}
+					label={t("models.detail.displayName")}
+					className="col-span-2"
+				>
+					<div className="flex items-center gap-1">
+						<input
+							type="text"
+							maxLength={128}
+							value={editData.display_name}
+							onChange={(e) =>
+								setEditData((prev) => ({
+									...prev,
+									display_name: e.target.value,
+								}))
+							}
+							className="ui-input text-sm"
+						/>
+						{editData.display_name !== discoveredDefaults.display_name && (
+							<RevertButton onClick={() => revertField("display_name")} />
+						)}
+					</div>
+				</DetailItem>
+			)}
+			<DetailItem
+				emphasis="stat"
+				icon={Layers}
+				label={t("models.detail.contextLength")}
+				value={`${formatNumber(model.context_length)} ${t("models.detail.tokens")}`}
+				mono
+				labelExtra={
+					model.context_length != null ? (
+						<CopyButton
+							text={String(model.context_length)}
+							title={t("models.detail.copyRawValue")}
+						/>
+					) : undefined
+				}
+			>
+				{editing ? (
+					<div className="flex items-center gap-1">
+						<input
+							type="number"
+							min={256}
+							max={2000000}
+							value={editData.context_length}
+							onChange={(e) =>
+								setEditData((prev) => ({
+									...prev,
+									context_length: e.target.value,
+								}))
+							}
+							className="ui-input text-sm"
+							placeholder={t("models.detail.tokens")}
+						/>
+						{editData.context_length !==
+							(discoveredDefaults.context_length?.toString() ?? "") && (
+							<RevertButton onClick={() => revertField("context_length")} />
+						)}
+					</div>
+				) : undefined}
+			</DetailItem>
+			<DetailItem
+				emphasis="stat"
+				icon={Hash}
+				label={t("models.detail.maxOutput")}
+				value={`${formatNumber(model.max_output_tokens)} ${t("models.detail.tokens")}`}
+				mono
+				labelExtra={
+					model.max_output_tokens != null ? (
+						<CopyButton
+							text={String(model.max_output_tokens)}
+							title={t("models.detail.copyRawValue")}
+						/>
+					) : undefined
+				}
+			>
+				{editing ? (
+					<div className="flex items-center gap-1">
+						<input
+							type="number"
+							min={1}
+							max={128000}
+							value={editData.max_output_tokens}
+							onChange={(e) =>
+								setEditData((prev) => ({
+									...prev,
+									max_output_tokens: e.target.value,
+								}))
+							}
+							className="ui-input text-sm"
+							placeholder={t("models.detail.tokens")}
+						/>
+						{editData.max_output_tokens !==
+							(discoveredDefaults.max_output_tokens?.toString() ?? "") && (
+							<RevertButton onClick={() => revertField("max_output_tokens")} />
+						)}
+					</div>
+				) : undefined}
+			</DetailItem>
+			<DetailItem
+				emphasis="stat"
+				icon={DollarSign}
+				label={t("models.detail.inputPrice")}
+				value={
+					model.input_price_per_million != null
+						? `$${formatPrice(model.input_price_per_million)}/1M`
+						: "-"
+				}
+				mono
+			>
+				{editing ? priceEditor("input_price_per_million") : undefined}
+			</DetailItem>
+			<DetailItem
+				emphasis="stat"
+				icon={Coins}
+				label={t("models.detail.outputPrice")}
+				value={
+					model.output_price_per_million != null
+						? `$${formatPrice(model.output_price_per_million)}/1M`
+						: "-"
+				}
+				mono
+			>
+				{editing ? priceEditor("output_price_per_million") : undefined}
+			</DetailItem>
+			<DetailItem
+				icon={ArrowDownToLine}
+				label={t("models.detail.input")}
+				value={inputMods.join(", ") || t("models.detail.modality.text")}
+			/>
+			<DetailItem
+				icon={ArrowUpFromLine}
+				label={t("models.detail.output")}
+				value={outputMods.join(", ") || t("models.detail.modality.text")}
+			/>
+		</div>
+	);
+}

--- a/web/src/pages/Models/__tests__/useModelActions.test.tsx
+++ b/web/src/pages/Models/__tests__/useModelActions.test.tsx
@@ -1,0 +1,135 @@
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Model } from "../../../api/types";
+import { useModelActions } from "../useModelActions";
+
+const model = { id: "m1", provider_id: "p1" } as Model;
+
+function Harness(props: Parameters<typeof useModelActions>[0]) {
+	const a = useModelActions(props);
+	return (
+		<div>
+			<span data-testid="state">
+				{a.cooldown}|{a.discovering ? "d" : "-"}|{a.testing ? "t" : "-"}|
+				{a.testError ? "e" : "-"}
+			</span>
+			<button type="button" onClick={a.handleDiscover}>
+				discover
+			</button>
+			<button type="button" onClick={a.handleTest}>
+				test
+			</button>
+		</div>
+	);
+}
+
+const state = () => screen.getByTestId("state").textContent;
+
+describe("useModelActions", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("arms a 30 s cooldown after a re-discovery and counts it down to zero", async () => {
+		const onDiscover = vi.fn().mockResolvedValue(undefined);
+		render(<Harness model={model} onDiscover={onDiscover} />);
+		await act(async () => {
+			screen.getByText("discover").click();
+		});
+		expect(onDiscover).toHaveBeenCalledWith("p1");
+		expect(state()).toBe("30|-|-|-");
+		// A second press inside the cooldown is ignored.
+		await act(async () => {
+			screen.getByText("discover").click();
+		});
+		expect(onDiscover).toHaveBeenCalledTimes(1);
+		act(() => {
+			vi.advanceTimersByTime(29_000);
+		});
+		expect(state()).toBe("1|-|-|-");
+		act(() => {
+			vi.advanceTimersByTime(1_000);
+		});
+		expect(state()).toBe("0|-|-|-");
+		await act(async () => {
+			screen.getByText("discover").click();
+		});
+		expect(onDiscover).toHaveBeenCalledTimes(2);
+	});
+
+	it("flashes the test button red for three seconds on a failed test and toasts the error", async () => {
+		const onToast = vi.fn();
+		const onTest = vi.fn().mockResolvedValue({
+			success: false,
+			streaming: false,
+			ttft_ms: 0,
+			duration_ms: 10,
+			response: "",
+			error: "boom",
+		});
+		render(<Harness model={model} onTest={onTest} onToast={onToast} />);
+		await act(async () => {
+			screen.getByText("test").click();
+		});
+		expect(state()).toBe("0|-|-|e");
+		expect(onToast).toHaveBeenCalledWith(
+			expect.stringContaining("boom"),
+			"error",
+		);
+		act(() => {
+			vi.advanceTimersByTime(3_000);
+		});
+		expect(state()).toBe("0|-|-|-");
+	});
+
+	it("treats a thrown test as a failure with the error's message", async () => {
+		const onToast = vi.fn();
+		const onTest = vi.fn().mockRejectedValue(new Error("network down"));
+		render(<Harness model={model} onTest={onTest} onToast={onToast} />);
+		await act(async () => {
+			screen.getByText("test").click();
+		});
+		expect(state()).toBe("0|-|-|e");
+		expect(onToast).toHaveBeenCalledWith(
+			expect.stringContaining("network down"),
+			"error",
+		);
+	});
+
+	it("reports a successful test with its duration, and the TTFT only when it streamed", async () => {
+		const onToast = vi.fn();
+		const onTest = vi
+			.fn()
+			.mockResolvedValueOnce({
+				success: true,
+				streaming: true,
+				ttft_ms: 1500,
+				duration_ms: 4000,
+				response: "hi\nthere",
+			})
+			.mockResolvedValueOnce({
+				success: true,
+				streaming: false,
+				ttft_ms: 0,
+				duration_ms: 2000,
+				response: "",
+			});
+		render(<Harness model={model} onTest={onTest} onToast={onToast} />);
+		await act(async () => {
+			screen.getByText("test").click();
+		});
+		expect(onToast).toHaveBeenLastCalledWith(
+			expect.stringContaining("1.5"),
+			"success",
+		);
+		await act(async () => {
+			screen.getByText("test").click();
+		});
+		expect(onToast).toHaveBeenCalledTimes(2);
+		expect(onToast).toHaveBeenLastCalledWith(expect.any(String), "success");
+		expect(state()).toBe("0|-|-|-");
+	});
+});

--- a/web/src/pages/Models/modelDetailParse.ts
+++ b/web/src/pages/Models/modelDetailParse.ts
@@ -1,0 +1,30 @@
+import type { Model } from "../../api/types";
+
+/** The model's stored params JSON, or null when it is missing or malformed. */
+export function parseParams(raw: string): Record<string, unknown> | null {
+	try {
+		return JSON.parse(raw);
+	} catch {
+		return null;
+	}
+}
+
+/** A modalities column (JSON array or bare value) as a list; malformed = none. */
+export function parseModalities(raw: string): string[] {
+	try {
+		const v = JSON.parse(raw);
+		return Array.isArray(v) ? v : [v];
+	} catch {
+		return [];
+	}
+}
+
+export function modelModalities(model: Model): {
+	inputMods: string[];
+	outputMods: string[];
+} {
+	return {
+		inputMods: parseModalities(model.input_modalities),
+		outputMods: parseModalities(model.output_modalities),
+	};
+}

--- a/web/src/pages/Models/modelSnippets.ts
+++ b/web/src/pages/Models/modelSnippets.ts
@@ -1,0 +1,127 @@
+import type { TFunction } from "i18next";
+import type { Model } from "../../api/types";
+import type { LangIconKey } from "../../components/langIcons";
+import type { parseCapabilities } from "../../utils/model";
+import type { SnippetLang } from "../../utils/shikiHighlighter";
+import {
+	snippetClaudeCodeModelText,
+	snippetCurlModelText,
+	snippetHermesModelText,
+	snippetJSModelText,
+	snippetLibreChatModelText,
+	snippetOpenClawModelText,
+	snippetOpencodeModelText,
+	snippetPowershellModelText,
+	snippetPythonModelText,
+	snippetZedModelText,
+} from "../../utils/snippets";
+
+export interface SnippetEntry {
+	key: LangIconKey;
+	title: string;
+	lang: SnippetLang;
+	copyText: string;
+}
+
+/** The per-client usage snippets for one model, in tab order. */
+export function modelSnippetEntries({
+	t,
+	model,
+	proxyModelId,
+	caps,
+	inputMods,
+	outputMods,
+	origin,
+}: {
+	t: TFunction;
+	model: Model;
+	proxyModelId: string;
+	caps: ReturnType<typeof parseCapabilities>;
+	inputMods: string[];
+	outputMods: string[];
+	origin: string;
+}): SnippetEntry[] {
+	const modelSnippetOpts = { proxyModelId, origin };
+	const zedOpts = {
+		proxyModelId,
+		displayName: model.display_name || model.name,
+		contextLength: model.context_length,
+		maxOutputTokens: model.max_output_tokens,
+		capabilities: caps,
+		origin,
+	};
+	const opencodeOpts = {
+		proxyModelId,
+		displayName: model.display_name || model.name || proxyModelId,
+		contextLength: model.context_length,
+		maxOutputTokens: model.max_output_tokens,
+		capabilities: caps,
+		inputModalities: inputMods,
+		outputModalities: outputMods,
+		inputPricePerMillion: model.input_price_per_million,
+		outputPricePerMillion: model.output_price_per_million,
+		origin,
+	};
+	return [
+		{
+			key: "curl",
+			title: t("models.detail.snippet.curl"),
+			lang: "bash",
+			copyText: snippetCurlModelText(modelSnippetOpts),
+		},
+		{
+			key: "powershell",
+			title: t("models.detail.snippet.powershell"),
+			lang: "powershell",
+			copyText: snippetPowershellModelText(modelSnippetOpts),
+		},
+		{
+			key: "javascript",
+			title: t("models.detail.snippet.javascript"),
+			lang: "javascript",
+			copyText: snippetJSModelText(modelSnippetOpts),
+		},
+		{
+			key: "python",
+			title: t("models.detail.snippet.python"),
+			lang: "python",
+			copyText: snippetPythonModelText(modelSnippetOpts),
+		},
+		{
+			key: "claude",
+			title: t("models.detail.snippet.claudeCode"),
+			lang: "bash",
+			copyText: snippetClaudeCodeModelText(modelSnippetOpts),
+		},
+		{
+			key: "openclaw",
+			title: t("models.detail.snippet.openClaw"),
+			lang: "bash",
+			copyText: snippetOpenClawModelText(modelSnippetOpts),
+		},
+		{
+			key: "hermes",
+			title: t("models.detail.snippet.hermes"),
+			lang: "bash",
+			copyText: snippetHermesModelText(modelSnippetOpts),
+		},
+		{
+			key: "librechat",
+			title: t("models.detail.snippet.librechat"),
+			lang: "yaml",
+			copyText: snippetLibreChatModelText(modelSnippetOpts),
+		},
+		{
+			key: "zed",
+			title: t("models.detail.snippet.zed"),
+			lang: "json",
+			copyText: snippetZedModelText(zedOpts),
+		},
+		{
+			key: "opencode",
+			title: t("models.detail.snippet.opencode"),
+			lang: "json",
+			copyText: snippetOpencodeModelText(opencodeOpts),
+		},
+	];
+}

--- a/web/src/pages/Models/useModelActions.ts
+++ b/web/src/pages/Models/useModelActions.ts
@@ -1,0 +1,130 @@
+import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import type { Model } from "../../api/types";
+
+export interface ModelTestResult {
+	success: boolean;
+	streaming: boolean;
+	ttft_ms: number;
+	duration_ms: number;
+	response: string;
+	error?: string;
+}
+
+/**
+ * The modal's two provider-facing actions and their transient state: a
+ * re-discovery with a 30s cooldown, and a test request whose outcome toasts
+ * and flashes the button red for three seconds on failure. Every timer is
+ * cleared on unmount.
+ */
+export function useModelActions({
+	model,
+	onDiscover,
+	onTest,
+	onToast,
+}: {
+	model: Model;
+	onDiscover?: (providerId: string) => Promise<unknown>;
+	onTest?: (id: string) => Promise<ModelTestResult>;
+	onToast?: (msg: string, type?: "success" | "error" | "info") => void;
+}) {
+	const { t } = useTranslation();
+	const [cooldown, setCooldown] = useState(0);
+	const [discovering, setDiscovering] = useState(false);
+	const [testing, setTesting] = useState(false);
+	const [testError, setTestError] = useState(false);
+	const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+	const testErrorTimers = useRef<ReturnType<typeof setTimeout>[]>([]);
+
+	useEffect(() => {
+		return () => {
+			if (timerRef.current) clearInterval(timerRef.current);
+			// eslint-disable-next-line react-hooks/exhaustive-deps -- cleanup reads ref at unmount time
+			for (const timer of testErrorTimers.current) clearTimeout(timer);
+		};
+	}, []);
+
+	const handleDiscover = async () => {
+		if (!onDiscover || cooldown > 0 || discovering) return;
+		setDiscovering(true);
+		try {
+			await onDiscover(model.provider_id);
+			setCooldown(30);
+			timerRef.current = setInterval(() => {
+				setCooldown((prev) => {
+					if (prev <= 1) {
+						if (timerRef.current) clearInterval(timerRef.current);
+						return 0;
+					}
+					return prev - 1;
+				});
+			}, 1000);
+		} finally {
+			setDiscovering(false);
+		}
+	};
+
+	const flashTestError = () => {
+		setTestError(true);
+		const timer = setTimeout(() => setTestError(false), 3000);
+		testErrorTimers.current.push(timer);
+	};
+
+	const handleTest = async () => {
+		if (!onTest || !onToast || testing) return;
+		setTesting(true);
+		setTestError(false);
+		try {
+			const result = await onTest(model.id);
+			if (result.success) {
+				const content = result.response.replace(/\n/g, " ").slice(0, 80);
+				const isStreaming = result.streaming;
+				const ttftPart = isStreaming
+					? ` | TTFT: ${(result.ttft_ms / 1000).toFixed(1)}s`
+					: "";
+				onToast(
+					t(
+						// Reasoning models can succeed with empty content (the budget
+						// went to reasoning); omit the "Response:" part in that case.
+						content
+							? "models.detail.testSuccess"
+							: "models.detail.testSuccessNoResponse",
+						{
+							content,
+							ttftPart,
+							duration: (result.duration_ms / 1000).toFixed(1),
+						},
+					),
+					"success",
+				);
+			} else {
+				flashTestError();
+				onToast(
+					t("models.detail.testFailed", {
+						error: result.error || t("common.unknownError"),
+					}),
+					"error",
+				);
+			}
+		} catch (err) {
+			flashTestError();
+			onToast(
+				t("models.detail.testFailed", {
+					error: err instanceof Error ? err.message : t("common.unknownError"),
+				}),
+				"error",
+			);
+		} finally {
+			setTesting(false);
+		}
+	};
+
+	return {
+		cooldown,
+		discovering,
+		testing,
+		testError,
+		handleDiscover,
+		handleTest,
+	};
+}


### PR DESCRIPTION
## Summary

Size-allowlist burn-down, the last monolith component: `pages/Models/ModelDetailModal.tsx` was one 740-line component. It keeps the editor hook, the header, the price-pin banner, the capabilities and subscription sections, the unsaved-changes dialog and the composition; the rest moves next to it:

| File | Lines | Holds |
|---|---|---|
| `ModelDetailModal.tsx` | 823 -> 273 | composition, header, price-pin banner, capabilities, subscription, unsaved-changes dialog |
| `ModelStatsGrid.tsx` | 249 (new) | the two-column facts grid with its edit inputs and revert buttons |
| `ModelActionsFooter.tsx` | 128 (new) | toggle, test, two-step delete, edit/save/cancel, re-discover with cooldown |
| `ModelSnippetPanel.tsx` | 62 (new) | the snippet tabs and the highlighted, copyable snippet |
| `modelSnippets.ts` | 127 (new) | the per-client snippet table as a pure builder |
| `modelDetailParse.ts` | 30 (new) | `parseParams`, modalities parsing |
| `useModelActions.ts` | 130 (new) | the re-discovery cooldown and the test flow with their timers |

No behaviour change. The component is under the 500-line `max-lines-per-function` cap, so its `eslint-disable` is removed. The file leaves the size allowlist.

New test: `useModelActions` with fake timers (the 30 s cooldown counts down and re-enables, a second press inside it is ignored, a failed test flashes the button for 3 s and toasts, a thrown test is a failure with its message, a streamed success reports its TTFT).

## Verification

- Biome, `tsc -b`, ESLint: clean
- The modal's suite and the Models suites pass unchanged; with the new test: 179/179
- Coverage of the changed set: 115/117 statements = 98.3%
- **Rebuilt dev stack**: a row opens the modal with its 8 facts and 10 snippet tabs (switching changes the code); edit mode shows its 5 inputs with Save; changing a value reveals the revert buttons; cancelling with unsaved changes opens the confirm dialog; no console errors
- `make size-check`: passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
