### PR TITLE
ci: run the race detector, and pin the markdown sanitization defaults

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,17 +141,15 @@ jobs:
           path: coverage.out
           retention-days: 1
 
-  # The race detector. Everything except the two packages it cannot pay for:
-  # internal/api, whose ~1,450 Postgres-backed tests already sit at a 10m
-  # timeout without instrumentation, and internal/frontdesk, whose autosync
-  # suites are timer-sensitive, so a 2-10x slowdown there yields flakes rather
-  # than findings. Excluding two rather than enumerating the rest keeps a newly
-  # added package covered the day it lands instead of the day someone
-  # remembers this list.
+  # The race detector, over every package. Nothing is excluded for cost: the
+  # slow suites are slow on database round-trips, which instrumentation does not
+  # multiply, so the whole tree races in about the time internal/proxy takes on
+  # its own.
   #
   # Un-raced, the suites written for exactly this (internal/failover/
   # circuitbreaker_race_test.go among them) pass while a data race goes
-  # unreported.
+  # unreported. The first run of this job found one, in the app-log writer's
+  # flush interval.
   go-race:
     name: Go Race
     needs: changes
@@ -181,16 +179,17 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      # No pg_dump/pg_restore install: the tests that shell out to them live in
-      # internal/api, which this job does not run.
+      # internal/api's backup tests exec these; without them ~26 tests skip and
+      # the race job silently stops covering the backup round-trip.
+      - name: Install pg_dump / pg_restore for backup tests
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends postgresql-client
+
+      # A longer clock than go-test's 10m: the detector's slowdown lands on
+      # internal/api, the one package already near that limit.
       - name: go test -race
         env:
           TEST_DATABASE_URL: postgres://modelhotel:${{ env.POSTGRES_PASSWORD }}@localhost:5433/testdb?sslmode=disable
-        run: |
-          set -euo pipefail
-          go list ./... \
-            | grep -vE '/internal/(api|frontdesk)$' \
-            | xargs go test -race -count=1 -timeout 10m
+        run: go test -race -count=1 -timeout 20m ./...
 
   go-lint:
     name: Go Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,57 @@ jobs:
           path: coverage.out
           retention-days: 1
 
+  # The race detector. Everything except the two packages it cannot pay for:
+  # internal/api, whose ~1,450 Postgres-backed tests already sit at a 10m
+  # timeout without instrumentation, and internal/frontdesk, whose autosync
+  # suites are timer-sensitive, so a 2-10x slowdown there yields flakes rather
+  # than findings. Excluding two rather than enumerating the rest keeps a newly
+  # added package covered the day it lands instead of the day someone
+  # remembers this list.
+  #
+  # Un-raced, the suites written for exactly this (internal/failover/
+  # circuitbreaker_race_test.go among them) pass while a data race goes
+  # unreported.
+  go-race:
+    name: Go Race
+    needs: changes
+    if: needs.changes.outputs.go != 'false'
+    runs-on: ubuntu-latest
+    env:
+      POSTGRES_PASSWORD: changeme
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: modelhotel
+          POSTGRES_PASSWORD: changeme
+          POSTGRES_DB: testdb
+        ports:
+          - 5433:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      # No pg_dump/pg_restore install: the tests that shell out to them live in
+      # internal/api, which this job does not run.
+      - name: go test -race
+        env:
+          TEST_DATABASE_URL: postgres://modelhotel:${{ env.POSTGRES_PASSWORD }}@localhost:5433/testdb?sslmode=disable
+        run: |
+          set -euo pipefail
+          go list ./... \
+            | grep -vE '/internal/(api|frontdesk)$' \
+            | xargs go test -race -count=1 -timeout 10m
+
   go-lint:
     name: Go Lint
     needs: changes
@@ -744,9 +795,10 @@ jobs:
   # is a drop-in for the other.
   #
   # This is a dedicated job (not a step in docker-build) so it can `needs:` the
-  # full required gate set: a master commit that fails Go tests, lint, vet,
-  # vulncheck, coverage, i18n, the workflow lint, the frontend gates, or the
-  # Docker build + Trivy scan never becomes a staging image. It runs only on
+  # full required gate set: a master commit that fails Go tests, the race
+  # detector, lint, vet, vulncheck, coverage, i18n, the workflow lint, the
+  # frontend gates, or the Docker build + Trivy scan never becomes a staging
+  # image. It runs only on
   # direct pushes to master (never PRs, which can't see secrets) and skips if
   # master HEAD has already moved past this commit, so a slow older run can't
   # overwrite :dev with a stale image after a newer commit already published it.
@@ -772,6 +824,7 @@ jobs:
       # as "nothing went wrong" and publish an entirely untested image.
       - changes
       - go-test
+      - go-race
       - go-lint
       - go-vet
       - govulncheck

--- a/internal/api/applogs_buffer.go
+++ b/internal/api/applogs_buffer.go
@@ -111,28 +111,34 @@ const dbLogChannelSize = 5000
 const dbLogSendTimeout = 5 * time.Second
 
 type dbLogWriter struct {
-	pool *pgxpool.Pool
-	ch   chan AppLogEntry
-	done chan struct{}
+	pool          *pgxpool.Pool
+	ch            chan AppLogEntry
+	done          chan struct{}
+	flushInterval time.Duration
 }
 
-func newDBLogWriter(pool *pgxpool.Pool) *dbLogWriter {
+// newDBLogWriter starts a writer that drains a partial batch every
+// flushInterval. The interval is a parameter rather than a package var a test
+// can shrink: the writer goroutine reads it while another test is assigning to
+// it, which the race detector reports (and which is a real race, not a test
+// artifact, because the goroutine outlives the test that started it).
+func newDBLogWriter(pool *pgxpool.Pool, flushInterval time.Duration) *dbLogWriter {
 	w := &dbLogWriter{
-		pool: pool,
-		ch:   make(chan AppLogEntry, dbLogChannelSize),
-		done: make(chan struct{}),
+		pool:          pool,
+		ch:            make(chan AppLogEntry, dbLogChannelSize),
+		done:          make(chan struct{}),
+		flushInterval: flushInterval,
 	}
 	go w.run()
 	return w
 }
 
-// dbLogFlushInterval controls how often the dbLogWriter flushes entries.
-// Can be reduced in tests for faster execution.
-var dbLogFlushInterval = 500 * time.Millisecond
+// dbLogFlushInterval is how often the writer flushes a partial batch.
+const dbLogFlushInterval = 500 * time.Millisecond
 
 func (w *dbLogWriter) run() {
 	batch := make([]AppLogEntry, 0, 50)
-	ticker := time.NewTicker(dbLogFlushInterval)
+	ticker := time.NewTicker(w.flushInterval)
 	defer ticker.Stop()
 
 	for {
@@ -220,7 +226,7 @@ func InitAppLogBuffer(pool *pgxpool.Pool) {
 		entries: make([]AppLogEntry, appLogBufferSize),
 	}
 	if pool != nil {
-		dbWriter = newDBLogWriter(pool)
+		dbWriter = newDBLogWriter(pool, dbLogFlushInterval)
 	}
 	log.SetOutput(io.MultiWriter(&stderrLogFilter{dst: os.Stderr}, appLogBuffer))
 }

--- a/internal/api/applogs_handler_test.go
+++ b/internal/api/applogs_handler_test.go
@@ -228,7 +228,7 @@ func TestRingBufferClearOlderThan_KeepsUnparseable(t *testing.T) {
 
 func TestNewDBLogWriter(t *testing.T) {
 	// Test constructor - just verify it doesn't panic and returns non-nil
-	writer := newDBLogWriter(nil)
+	writer := newDBLogWriter(nil, dbLogFlushInterval)
 	if writer == nil {
 		t.Error("newDBLogWriter should return non-nil writer")
 	}
@@ -237,7 +237,7 @@ func TestNewDBLogWriter(t *testing.T) {
 
 func TestDBLogWriterWrite_Timeout(t *testing.T) {
 	// Create a writer with a nil pool (no DB)
-	writer := newDBLogWriter(nil)
+	writer := newDBLogWriter(nil, dbLogFlushInterval)
 	defer writer.stop()
 
 	entry := AppLogEntry{
@@ -696,7 +696,7 @@ func TestStopAppLogWriter(t *testing.T) {
 
 	// Create a writer
 	InitAppLogBuffer(nil)
-	writer := newDBLogWriter(nil)
+	writer := newDBLogWriter(nil, dbLogFlushInterval)
 	dbWriter = writer
 
 	// Stop it

--- a/internal/api/applogs_test.go
+++ b/internal/api/applogs_test.go
@@ -239,7 +239,7 @@ func TestDBLogWriter_BatchSizeFlush(t *testing.T) {
 	pool.Exec(context.Background(), "DELETE FROM app_logs WHERE source = 'test'")
 	defer pool.Exec(context.Background(), "DELETE FROM app_logs WHERE source = 'test'")
 
-	w := newDBLogWriter(pool)
+	w := newDBLogWriter(pool, dbLogFlushInterval)
 	defer w.stop()
 
 	// Send 50 entries to trigger the batch-size flush path (lines 127-130)
@@ -287,7 +287,7 @@ func TestDBLogWriter_TickerFlush(t *testing.T) {
 	// Clean up before test
 	pool.Exec(context.Background(), "DELETE FROM app_logs WHERE source = 'ticker-test'")
 
-	w := newDBLogWriter(pool)
+	w := newDBLogWriter(pool, dbLogFlushInterval)
 	defer w.stop()
 
 	// Send a few entries (less than 50) and wait for the ticker to flush
@@ -324,11 +324,6 @@ func TestDBLogWriter_FlushDBError(t *testing.T) {
 	if apiTestDBURL == "" {
 		t.Fatal("apiTestDBURL not set: test database required")
 	}
-	// Reduce flush interval for faster test
-	orig := dbLogFlushInterval
-	dbLogFlushInterval = 10 * time.Millisecond
-	defer func() { dbLogFlushInterval = orig }()
-
 	// Create a writer with a closed pool to trigger the Exec error path (lines 160-164)
 	pool, err := pgxpool.New(context.Background(), apiTestDBURL)
 	if err != nil {
@@ -336,7 +331,7 @@ func TestDBLogWriter_FlushDBError(t *testing.T) {
 	}
 	pool.Close() // Close immediately to cause DB errors
 
-	w := newDBLogWriter(pool)
+	w := newDBLogWriter(pool, 10*time.Millisecond)
 	defer w.stop()
 
 	// Send entries — they'll be flushed but the DB write will fail silently
@@ -360,11 +355,6 @@ func TestRingBuffer_WriteWithDBWriter(t *testing.T) {
 		t.Fatal("apiTestDBURL not set: test database required")
 	}
 
-	// Reduce flush interval for faster test
-	orig := dbLogFlushInterval
-	dbLogFlushInterval = 10 * time.Millisecond
-	defer func() { dbLogFlushInterval = orig }()
-
 	pool, err := pgxpool.New(context.Background(), apiTestDBURL)
 	if err != nil {
 		t.Fatalf("failed to create pool: %v", err)
@@ -373,7 +363,7 @@ func TestRingBuffer_WriteWithDBWriter(t *testing.T) {
 
 	// Save and restore global dbWriter
 	origDBWriter := dbWriter
-	dbWriter = newDBLogWriter(pool)
+	dbWriter = newDBLogWriter(pool, 10*time.Millisecond)
 	defer func() {
 		dbWriter.stop()
 		dbWriter = origDBWriter

--- a/web/src/components/__tests__/MarkdownContent.test.tsx
+++ b/web/src/components/__tests__/MarkdownContent.test.tsx
@@ -113,3 +113,67 @@ describe("MarkdownContent", () => {
 		expect(inline?.querySelector("span")).toBeNull();
 	});
 });
+
+// The markdown here is model output, so it is reachable by prompt injection or
+// by a hostile upstream provider. Three defaults keep that safe and each is one
+// config line from being switched off: react-markdown's urlTransform blanks
+// unsafe hrefs, raw HTML stays unrendered without rehype-raw, and rehype-katex
+// refuses \href while KaTeX's trust option is at its default. These pin the
+// behaviour rather than the config so any of those switches fails a test.
+describe("MarkdownContent sanitization", () => {
+	it("blanks a javascript: link href", () => {
+		const { container } = render(
+			<MarkdownContent>{"[click me](javascript:alert(1))"}</MarkdownContent>,
+		);
+		const link = container.querySelector("a");
+		expect(link).not.toBeNull();
+		expect(link?.getAttribute("href")).toBe("");
+		expect(screen.getByText("click me")).toBeInTheDocument();
+	});
+
+	it("blanks other script-capable link schemes", () => {
+		for (const href of [
+			"data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==",
+			"vbscript:msgbox(1)",
+			"JaVaScRiPt:alert(1)",
+		]) {
+			const { container, unmount } = render(
+				<MarkdownContent>{`[x](${href})`}</MarkdownContent>,
+			);
+			expect(container.querySelector("a")?.getAttribute("href")).toBe("");
+			unmount();
+		}
+	});
+
+	it("keeps ordinary links intact", () => {
+		const { container } = render(
+			<MarkdownContent>{"[ok](https://example.com/a?b=c)"}</MarkdownContent>,
+		);
+		expect(container.querySelector("a")?.getAttribute("href")).toBe(
+			"https://example.com/a?b=c",
+		);
+	});
+
+	it("does not render raw HTML embedded in the markdown", () => {
+		const { container } = render(
+			<MarkdownContent>
+				{'<img src="x" onerror="alert(1)"> and <b>bold</b>'}
+			</MarkdownContent>,
+		);
+		expect(container.querySelector("img")).toBeNull();
+		expect(container.querySelector("b")).toBeNull();
+		// The tags survive as literal text, which is what proves they were
+		// escaped rather than parsed. rehype-raw would turn them into elements
+		// and this text would be gone.
+		expect(container.textContent).toContain(
+			'<img src="x" onerror="alert(1)"> and <b>bold</b>',
+		);
+	});
+
+	it("does not honour \\href inside math", () => {
+		const { container } = render(
+			<MarkdownContent>{"$\\href{javascript:alert(1)}{x}$"}</MarkdownContent>,
+		);
+		expect(container.querySelector('a[href^="javascript:"]')).toBeNull();
+	});
+});


### PR DESCRIPTION
Two independent defense-in-depth items from a security review triage. Neither
closes a live vulnerability: both pin controls that already work today so a
future config change cannot switch them off silently.

## 1. `go-race` CI job

The race detector never ran anywhere. `internal/failover/circuitbreaker_race_test.go`
exists and passes un-raced, which is to say it proves nothing about the thing it
was written for.

The job mirrors `go-test`'s Postgres service and is gated on the same
changed-surface output as the other Go jobs. It races `./...` with nothing
excluded, on a 20m clock rather than go-test's 10m.

The first version of this excluded `internal/api` and `internal/frontdesk` on
an assumption about cost that measurement did not support. The slow suites are
slow on database round-trips, which instrumentation does not multiply, so the
whole tree races in 216s locally, barely more than `internal/proxy` alone.
Greptile was right to call the exclusion a hole rather than a tradeoff: for an
`internal/api` change the job would have gone green while covering nothing that
changed, and `publish-dev` would have read that as a race gate.

**The first full run found a real data race**, in `internal/api/applogs_buffer.go`.
`dbLogFlushInterval` was a package var that two tests reassigned for speed, while
a writer goroutine started by an earlier test read it to build its ticker. The
goroutine outlives the test that started it, so this is a genuine race, and it is
also a test seam in production code. Fixed by making the interval a constructor
parameter and the package-level value a const: production passes the const, the
two tests that wanted 10ms pass 10ms, and nothing mutates shared state.

`publish-dev` now waits on the job, so a race on master cannot become a `:dev`
image. Making `Go Race` a required check for PR merges is a branch-protection
setting and has to be flipped in GitHub Settings; worth doing after master has
passed it once.

One thing to watch: `internal/frontdesk`'s autosync suites are timing-dependent
and take 194s under instrumentation locally. They pass, and the 20m clock has
room, but if that package turns out to flake on a slower runner it is the first
place to look.

Note on this PR's own CI: the Go surface is now touched, so `Go Test` and
`Go Race` both run here.

## 2. Markdown sanitization tests

`MarkdownContent` renders model output, so its input is reachable by prompt injection
or by a hostile upstream provider. Three defaults keep that safe, and each is one line
from being switched off:

- react-markdown's default `urlTransform` blanks `javascript:`, `data:` and friends
- raw HTML stays escaped text while no `rehype-raw` is configured
- `rehype-katex` refuses `\href` while KaTeX's `trust` is at its default

The new tests pin the behaviour rather than the config. Mutation-checked: adding
`urlTransform={(u) => u}` and `trust: true` fails exactly the three config-sensitive
tests, and `trust: true` does produce a real `<a href="javascript:...">`.

`web/` is the only surface with a markdown renderer; Front Desk has none.

## Not done, and why

Three sibling recommendations were triaged out rather than shipped:

- A frontend `href` guard on Front Desk's members table: the only writer is
  `CreateMember` -> `normalizeMemberURL`, member URLs have no update path at all,
  and the route is behind `requireAdmin`, which refuses device tokens outright.
  Poisoning that href needs the top FD credential, so it is self-XSS.
- Filtering `masked_key`/`base_url` out of `GET /api/providers/{id}` for
  usage-grant callers: the list endpoint in the same grant group returns the same
  fields, so filtering only the detail route changes nothing.
- Scoping Android's `usesCleartextTraffic` via `network_security_config.xml`:
  NSC matches hostnames and domain suffixes only, with no CIDR matcher, so
  "cleartext for RFC1918" cannot be expressed and LAN pairing against an arbitrary
  private address would break.
