### PR TITLE
fix(http): bound every JSON request body

### DIFF
--- a/internal/adminauth/bodylimit_test.go
+++ b/internal/adminauth/bodylimit_test.go
@@ -1,0 +1,52 @@
+package adminauth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/hugalafutro/model-hotel/internal/authcookie"
+	"github.com/hugalafutro/model-hotel/internal/httpx"
+)
+
+// TestTokenExchange_OversizedBody_413 covers this package's defining property:
+// every ceremony here (token exchange, password login, TOTP, WebAuthn) is
+// reachable before authentication, so their request bodies are the ones an
+// anonymous caller fully controls. The body is valid JSON with a valid token,
+// so only the size limit can reject it.
+func TestTokenExchange_OversizedBody_413(t *testing.T) {
+	sessionMgr := newTestSessionManager(t)
+	adminMgr := &mockAdminAuth{validateFn: func(token string) bool { return token == "sekrit" }}
+	h := TokenExchange(adminMgr, sessionMgr, nil, authcookie.FrontDesk, "never", nil)
+
+	body := `{"admin_token":"sekrit","padding":"` + strings.Repeat("a", httpx.MaxJSONBody+1) + `"}`
+	rec := httptest.NewRecorder()
+	h(rec, httptest.NewRequest(http.MethodPost, "/api/auth/admin-exchange", strings.NewReader(body)))
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want 413; body=%q", rec.Code, rec.Body.String())
+	}
+	if len(rec.Result().Cookies()) != 0 {
+		t.Errorf("a rejected exchange must mint no cookie, got %+v", rec.Result().Cookies())
+	}
+}
+
+// TestTokenExchange_MissingToken_400 pins the split of the old combined
+// decode-or-empty-token condition: an empty token is still a 400, not a 413 and
+// not a session.
+func TestTokenExchange_MissingToken_400(t *testing.T) {
+	sessionMgr := newTestSessionManager(t)
+	adminMgr := &mockAdminAuth{validateFn: func(string) bool { return true }}
+	h := TokenExchange(adminMgr, sessionMgr, nil, authcookie.FrontDesk, "never", nil)
+
+	rec := httptest.NewRecorder()
+	h(rec, httptest.NewRequest(http.MethodPost, "/api/auth/admin-exchange", strings.NewReader(`{}`)))
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%q", rec.Code, rec.Body.String())
+	}
+	if len(rec.Result().Cookies()) != 0 {
+		t.Errorf("an empty admin_token must mint no cookie, got %+v", rec.Result().Cookies())
+	}
+}

--- a/internal/adminauth/exchange.go
+++ b/internal/adminauth/exchange.go
@@ -1,7 +1,6 @@
 package adminauth
 
 import (
-	"encoding/json"
 	"net/http"
 
 	"github.com/hugalafutro/model-hotel/internal/authcookie"
@@ -28,7 +27,10 @@ func TokenExchange(
 		var req struct {
 			AdminToken string `json:"admin_token"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.AdminToken == "" {
+		if !decodeJSON(w, r, &req) {
+			return
+		}
+		if req.AdminToken == "" {
 			http.Error(w, "invalid request body", http.StatusBadRequest)
 			return
 		}

--- a/internal/adminauth/helpers.go
+++ b/internal/adminauth/helpers.go
@@ -59,3 +59,13 @@ func respondBadRequest(w http.ResponseWriter, message string, err error) {
 func readOnlyGuard(next http.Handler) http.Handler {
 	return httpx.ReadOnlyGuard(logComponent, next)
 }
+
+// decodeJSON bounds the request body to httpx.MaxJSONBody and decodes it,
+// writing the 400/413 response itself and reporting whether the handler may
+// continue. It matters most here: every login, TOTP and WebAuthn ceremony in
+// this package is reachable before authentication, so their bodies are the ones
+// an anonymous caller controls. internal/httpx's TestNoUnboundedJSONDecode
+// guard keeps new ceremonies on this path.
+func decodeJSON(w http.ResponseWriter, r *http.Request, v any) bool {
+	return httpx.DecodeJSON(w, r, logComponent, httpx.MaxJSONBody, v)
+}

--- a/internal/adminauth/totp.go
+++ b/internal/adminauth/totp.go
@@ -2,7 +2,6 @@ package adminauth
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 	"strconv"
 	"sync"
@@ -233,8 +232,7 @@ func (h *TotpHandler) EnrollVerify(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Code string `json:"code"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		respondBadRequest(w, "invalid request body", err)
+	if !decodeJSON(w, r, &req) {
 		return
 	}
 	ok, err := h.totpRepo.Verify(r.Context(), req.Code)
@@ -305,8 +303,7 @@ func (h *TotpHandler) Disable(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Code string `json:"code"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		respondBadRequest(w, "invalid request body", err)
+	if !decodeJSON(w, r, &req) {
 		return
 	}
 	// Authorize and disable atomically: the code is only spent if the whole
@@ -347,8 +344,7 @@ func (h *TotpHandler) Login(w http.ResponseWriter, r *http.Request) {
 		Token string `json:"token"`
 		Code  string `json:"code"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		respondBadRequest(w, "invalid request body", err)
+	if !decodeJSON(w, r, &req) {
 		return
 	}
 	// Check the admin-token first factor, then the second factor ONLY when the

--- a/internal/adminauth/userlogin.go
+++ b/internal/adminauth/userlogin.go
@@ -2,7 +2,6 @@ package adminauth
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"net/http"
 	"strconv"
@@ -123,8 +122,7 @@ func (h *UserLoginHandler) Login(w http.ResponseWriter, r *http.Request) {
 		// enabled (the missing-code response tells the login UI to ask).
 		Code string `json:"code"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		respondBadRequest(w, "invalid request body", err)
+	if !decodeJSON(w, r, &req) {
 		return
 	}
 	if req.Username == "" || req.Password == "" {

--- a/internal/adminauth/webauthn.go
+++ b/internal/adminauth/webauthn.go
@@ -208,8 +208,7 @@ type registerFinishRequest struct {
 // POST /webauthn/register/finish (admin auth required)
 func (h *WebAuthnHandler) RegisterFinish(w http.ResponseWriter, r *http.Request) {
 	var req registerFinishRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		respondBadRequest(w, "invalid request body", err)
+	if !decodeJSON(w, r, &req) {
 		return
 	}
 
@@ -357,8 +356,7 @@ type loginFinishRequest struct {
 // POST /webauthn/login/finish (no auth required)
 func (h *WebAuthnHandler) LoginFinish(w http.ResponseWriter, r *http.Request) {
 	var req loginFinishRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		respondBadRequest(w, "invalid request body", err)
+	if !decodeJSON(w, r, &req) {
 		return
 	}
 
@@ -584,8 +582,7 @@ func (h *WebAuthnHandler) RenameCredential(w http.ResponseWriter, r *http.Reques
 	}
 
 	var req renameCredentialRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		respondBadRequest(w, "invalid request body", err)
+	if !decodeJSON(w, r, &req) {
 		return
 	}
 

--- a/internal/api/admin_token_exchange.go
+++ b/internal/api/admin_token_exchange.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
@@ -23,8 +22,11 @@ type adminTokenExchangeRequest struct {
 // callers to the /api/totp/login flow instead.
 func (h *Handler) AdminTokenExchange(w http.ResponseWriter, r *http.Request) {
 	var req adminTokenExchangeRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.AdminToken == "" {
-		respondBadRequest(w, "invalid request body", err)
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	if req.AdminToken == "" {
+		respondBadRequest(w, "invalid request body", nil)
 		return
 	}
 

--- a/internal/api/applogs.go
+++ b/internal/api/applogs.go
@@ -684,8 +684,12 @@ func (h *Handler) GetAppLogsCursor(w http.ResponseWriter, r *http.Request) {
 // "all", preserving the original clear-everything behaviour.
 func (h *Handler) ClearAppLogs(w http.ResponseWriter, r *http.Request) {
 	var req PurgeLogsRequest
-	// Body is optional: a clear-all request may send nothing.
-	_ = json.NewDecoder(r.Body).Decode(&req)
+	// Body is optional: a clear-all request may send nothing, and a malformed
+	// one keeps the older_than default rather than failing the clear. Oversized
+	// is still refused, so the tolerance is not an unbounded read.
+	if !decodeJSONOptional(w, r, &req) {
+		return
+	}
 	if req.OlderThan == "" {
 		req.OlderThan = "all"
 	}

--- a/internal/api/applogs.go
+++ b/internal/api/applogs.go
@@ -684,9 +684,10 @@ func (h *Handler) GetAppLogsCursor(w http.ResponseWriter, r *http.Request) {
 // "all", preserving the original clear-everything behaviour.
 func (h *Handler) ClearAppLogs(w http.ResponseWriter, r *http.Request) {
 	var req PurgeLogsRequest
-	// Body is optional: a clear-all request may send nothing, and a malformed
-	// one keeps the older_than default rather than failing the clear. Oversized
-	// is still refused, so the tolerance is not an unbounded read.
+	// Body is optional: a clear-all request may send nothing, and older_than
+	// then defaults to "all". A body that was sent but cannot be read is a 400,
+	// not a silent fall back to that default, which would turn a request to
+	// clear one hour into clearing everything.
 	if !decodeJSONOptional(w, r, &req) {
 		return
 	}

--- a/internal/api/audit.go
+++ b/internal/api/audit.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"net/http"
 	"time"
 
@@ -114,8 +113,7 @@ func (h *Handler) PurgeAudit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var req PurgeLogsRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		respondBadRequest(w, "invalid request body", err)
+	if !decodeJSON(w, r, &req) {
 		return
 	}
 	cutoff, all, ok := olderThanCutoff(req.OlderThan)

--- a/internal/api/bodylimit_test.go
+++ b/internal/api/bodylimit_test.go
@@ -1,10 +1,13 @@
 package api
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/google/uuid"
 
 	"github.com/hugalafutro/model-hotel/internal/httpx"
 )
@@ -71,9 +74,12 @@ func TestConfigSyncImport_AcceptsBodyAboveDefaultLimit(t *testing.T) {
 	}
 }
 
-// TestClearAppLogs_OptionalBodyStaysOptionalButBounded pins both halves of the
-// tolerant decode: no body still means "clear everything", and an oversized one
-// is still refused.
+// TestClearAppLogs_OptionalBodyStaysOptionalButBounded pins all three halves of
+// the optional decode on the one endpoint that uses it. No body still means
+// "clear everything"; an oversized body is refused; and a body that was sent but
+// cannot be read is refused rather than falling back to the clear-everything
+// default, which is the difference between clearing an hour of logs and
+// clearing all of them.
 func TestClearAppLogs_OptionalBodyStaysOptionalButBounded(t *testing.T) {
 	h := testHandler(nil, nil, nil, &mockAdminAuth{}, nil)
 
@@ -88,5 +94,42 @@ func TestClearAppLogs_OptionalBodyStaysOptionalButBounded(t *testing.T) {
 	h.ClearAppLogs(rec, httptest.NewRequest(http.MethodPost, "/api/logs/app/clear", strings.NewReader(body)))
 	if rec.Code != http.StatusRequestEntityTooLarge {
 		t.Fatalf("oversized body status = %d, want 413; body=%q", rec.Code, rec.Body.String())
+	}
+
+	// A truncated "clear the last hour" must not become "clear everything".
+	rec = httptest.NewRecorder()
+	h.ClearAppLogs(rec, httptest.NewRequest(http.MethodPost, "/api/logs/app/clear", strings.NewReader(`{"older_than":"1h"`)))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("truncated body status = %d, want 400; body=%q", rec.Code, rec.Body.String())
+	}
+}
+
+// TestBulkDeleteWorstCaseFitsDefaultLimit ties together the two numbers that
+// have to stay in step. A full bulk model delete is the largest body any route
+// bounded by the package default can legitimately carry, so raising
+// maxBulkDeleteIDs without revisiting httpx.MaxJSONBody would start answering
+// 413 to a request the Models page can really send: the user selects everything
+// and the clear silently fails. Sized with the real encoder rather than an
+// estimate of how long a UUID is.
+func TestBulkDeleteWorstCaseFitsDefaultLimit(t *testing.T) {
+	ids := make([]string, maxBulkDeleteIDs)
+	for i := range ids {
+		ids[i] = uuid.New().String()
+	}
+	body, err := json.Marshal(BulkDeleteRequest{IDs: ids})
+	if err != nil {
+		t.Fatalf("marshal worst-case bulk delete: %v", err)
+	}
+
+	// Decoded through the real helper at the real limit, so this fails the same
+	// way the endpoint would.
+	rec := httptest.NewRecorder()
+	var got BulkDeleteRequest
+	if !decodeJSON(rec, httptest.NewRequest(http.MethodPost, "/api/models/bulk-delete", strings.NewReader(string(body))), &got) {
+		t.Fatalf("a full %d-ID bulk delete (%d bytes) does not fit the %d-byte default limit; status %d",
+			maxBulkDeleteIDs, len(body), httpx.MaxJSONBody, rec.Code)
+	}
+	if len(got.IDs) != maxBulkDeleteIDs {
+		t.Errorf("decoded %d ids, want %d", len(got.IDs), maxBulkDeleteIDs)
 	}
 }

--- a/internal/api/bodylimit_test.go
+++ b/internal/api/bodylimit_test.go
@@ -1,0 +1,92 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/hugalafutro/model-hotel/internal/httpx"
+)
+
+// oversizedJSON returns a syntactically valid JSON object of at least n bytes.
+// Valid on purpose: a malformed body would earn a 400 on its own, which would
+// let a size test pass without the size limit doing anything.
+func oversizedJSON(n int) string {
+	return `{"admin_token":"x","padding":"` + strings.Repeat("a", n) + `"}`
+}
+
+// TestAdminTokenExchange_OversizedBody_413 covers the pre-auth surface: the
+// exchange is the login front-end and sits in the auth-exempt route group, so
+// its body is one an anonymous caller controls end to end.
+func TestAdminTokenExchange_OversizedBody_413(t *testing.T) {
+	h := exchangeHandler(t)
+	rec := httptest.NewRecorder()
+	body := oversizedJSON(httpx.MaxJSONBody + 1)
+	h.AdminTokenExchange(rec, httptest.NewRequest(http.MethodPost, "/api/auth/admin-exchange", strings.NewReader(body)))
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want 413; body=%q", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "padding") {
+		t.Errorf("the rejection must not echo the body: %q", rec.Body.String())
+	}
+}
+
+// TestFleetAnnounce_KeepsItsOwnTighterLimit pins that decodeJSONLimit really
+// threads the endpoint's ceiling rather than quietly falling back to the
+// package default: this body is far under httpx.MaxJSONBody, so it would be
+// accepted if announce had been folded onto the default limit, and it is well
+// over the 1 KiB an announce needs.
+func TestFleetAnnounce_KeepsItsOwnTighterLimit(t *testing.T) {
+	h := NewFleetHandler(newFakeFleetSettings())
+	rec := httptest.NewRecorder()
+	body := `{"frontdesk_id":"fd-1","primary_name":"` + strings.Repeat("a", maxAnnounceBody) + `"}`
+	if len(body) >= httpx.MaxJSONBody {
+		t.Fatalf("test body (%d) must stay under the package default (%d)", len(body), httpx.MaxJSONBody)
+	}
+	h.Announce(rec, httptest.NewRequest(http.MethodPost, "/fleet/announce", strings.NewReader(body)))
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want 413; body=%q", rec.Code, rec.Body.String())
+	}
+}
+
+// TestConfigSyncImport_AcceptsBodyAboveDefaultLimit is the other direction: the
+// import's ceiling is deliberately larger than the default, so an envelope that
+// a control plane could really send must not be cut off at 1 MiB. The schema
+// version is wrong on purpose, so the 422 proves the body was decoded rather
+// than refused for its size.
+func TestConfigSyncImport_AcceptsBodyAboveDefaultLimit(t *testing.T) {
+	h := &ConfigSyncHandler{}
+	rec := httptest.NewRecorder()
+	body := `{"schema_version":0,"padding":"` + strings.Repeat("a", httpx.MaxJSONBody+1) + `"}`
+	if len(body) >= maxConfigImportBody {
+		t.Fatalf("test body (%d) must stay under the import ceiling (%d)", len(body), maxConfigImportBody)
+	}
+	h.Import(rec, httptest.NewRequest(http.MethodPost, "/api/config/import", strings.NewReader(body)))
+
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422 (decoded, wrong schema version); body=%q", rec.Code, rec.Body.String())
+	}
+}
+
+// TestClearAppLogs_OptionalBodyStaysOptionalButBounded pins both halves of the
+// tolerant decode: no body still means "clear everything", and an oversized one
+// is still refused.
+func TestClearAppLogs_OptionalBodyStaysOptionalButBounded(t *testing.T) {
+	h := testHandler(nil, nil, nil, &mockAdminAuth{}, nil)
+
+	rec := httptest.NewRecorder()
+	h.ClearAppLogs(rec, httptest.NewRequest(http.MethodPost, "/api/logs/app/clear", http.NoBody))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("empty body status = %d, want 200; body=%q", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	body := `{"older_than":"all","padding":"` + strings.Repeat("a", httpx.MaxJSONBody+1) + `"}`
+	h.ClearAppLogs(rec, httptest.NewRequest(http.MethodPost, "/api/logs/app/clear", strings.NewReader(body)))
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("oversized body status = %d, want 413; body=%q", rec.Code, rec.Body.String())
+	}
+}

--- a/internal/api/configsync_import.go
+++ b/internal/api/configsync_import.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"net/http"
 	"strconv"
@@ -20,11 +19,8 @@ import (
 // single transaction: all-or-nothing.
 func (h *ConfigSyncHandler) Import(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	r.Body = http.MaxBytesReader(w, r.Body, maxConfigImportBody)
-
 	var env ConfigEnvelope
-	if err := json.NewDecoder(r.Body).Decode(&env); err != nil {
-		http.Error(w, "invalid JSON body", http.StatusBadRequest)
+	if !decodeJSONLimit(w, r, maxConfigImportBody, &env) {
 		return
 	}
 	if env.SchemaVersion != configSchemaVersion {

--- a/internal/api/discovery_dismiss.go
+++ b/internal/api/discovery_dismiss.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"net/http"
 
 	"github.com/google/uuid"
@@ -40,8 +39,7 @@ type DismissDiscoveryClaimsRequest struct {
 // view, which is a genuine state change.
 func (h *Handler) DismissDiscoveryClaims(w http.ResponseWriter, r *http.Request) {
 	var req DismissDiscoveryClaimsRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, "invalid request body", http.StatusBadRequest)
+	if !decodeJSON(w, r, &req) {
 		return
 	}
 	providerID, err := uuid.Parse(req.ProviderID)
@@ -102,8 +100,7 @@ type UnpinDiscoveryClaimsRequest struct {
 // automatic management, which is a genuine state change.
 func (h *Handler) UnpinDiscoveryClaims(w http.ResponseWriter, r *http.Request) {
 	var req UnpinDiscoveryClaimsRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, "invalid request body", http.StatusBadRequest)
+	if !decodeJSON(w, r, &req) {
 		return
 	}
 	providerID, err := uuid.Parse(req.ProviderID)

--- a/internal/api/failover.go
+++ b/internal/api/failover.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -234,8 +233,7 @@ type CreateFailoverGroupRequest struct {
 // Create creates a new failover group.
 func (h *FailoverHandler) Create(w http.ResponseWriter, r *http.Request) {
 	var req CreateFailoverGroupRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		respondBadRequest(w, "invalid request body", err)
+	if !decodeJSON(w, r, &req) {
 		return
 	}
 
@@ -423,8 +421,7 @@ func (h *FailoverHandler) Update(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req UpdateFailoverGroupRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		respondBadRequest(w, "invalid request body", err)
+	if !decodeJSON(w, r, &req) {
 		return
 	}
 

--- a/internal/api/fleet.go
+++ b/internal/api/fleet.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 	"strconv"
 	"strings"
@@ -255,10 +254,8 @@ type announceRequest struct {
 // the (non-allowlisted) keys are accepted; the same property keeps them out of
 // config-sync's declarative replace.
 func (h *FleetHandler) Announce(w http.ResponseWriter, r *http.Request) {
-	r.Body = http.MaxBytesReader(w, r.Body, maxAnnounceBody)
 	var req announceRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, "invalid JSON body", http.StatusBadRequest)
+	if !decodeJSONLimit(w, r, maxAnnounceBody, &req) {
 		return
 	}
 

--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -54,3 +54,26 @@ func writeJSONCreated(w http.ResponseWriter, v any) {
 func writeCodedError(w http.ResponseWriter, status int, code, msg string) {
 	httpx.WriteCodedError(w, logComponent, status, code, msg)
 }
+
+// decodeJSON bounds the request body to httpx.MaxJSONBody and decodes it,
+// writing the 400/413 response itself and reporting whether the handler may
+// continue. Every handler in this package decodes through here (or through
+// decodeJSONLimit) so no route can be added with an unbounded body, which
+// internal/httpx's TestNoUnboundedJSONDecode guard enforces.
+func decodeJSON(w http.ResponseWriter, r *http.Request, v any) bool {
+	return httpx.DecodeJSON(w, r, logComponent, httpx.MaxJSONBody, v)
+}
+
+// decodeJSONLimit is decodeJSON with an endpoint-specific ceiling, for the two
+// routes whose payload is legitimately larger or smaller than the default: a
+// config-sync import and the fleet announce heartbeat.
+func decodeJSONLimit(w http.ResponseWriter, r *http.Request, limit int64, v any) bool {
+	return httpx.DecodeJSON(w, r, logComponent, limit, v)
+}
+
+// decodeJSONOptional is decodeJSON for a body the endpoint treats as optional:
+// a missing or malformed body leaves the request struct at its defaults, but an
+// oversized one is still refused.
+func decodeJSONOptional(w http.ResponseWriter, r *http.Request, v any) bool {
+	return httpx.DecodeJSONOptional(w, r, logComponent, httpx.MaxJSONBody, v)
+}

--- a/internal/api/logs.go
+++ b/internal/api/logs.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"net/http"
 	"time"
@@ -303,8 +302,7 @@ func olderThanCutoff(olderThan string) (cutoff time.Time, all, ok bool) {
 // PurgeLogs deletes old request logs based on the specified time range.
 func (h *Handler) PurgeLogs(w http.ResponseWriter, r *http.Request) {
 	var req PurgeLogsRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		respondBadRequest(w, "invalid request body", err)
+	if !decodeJSON(w, r, &req) {
 		return
 	}
 

--- a/internal/api/models.go
+++ b/internal/api/models.go
@@ -231,8 +231,7 @@ func (h *Handler) UpdateModel(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req model.UpdateModelRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		respondBadRequest(w, "invalid request body", err)
+	if !decodeJSON(w, r, &req) {
 		return
 	}
 
@@ -356,8 +355,7 @@ type BulkDeleteResponse struct {
 // that trips the admin IP rate limiter and surfaces spurious "N failed" toasts.
 func (h *Handler) BulkDeleteModels(w http.ResponseWriter, r *http.Request) {
 	var req BulkDeleteRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		respondBadRequest(w, "invalid request body", err)
+	if !decodeJSON(w, r, &req) {
 		return
 	}
 	if len(req.IDs) == 0 {

--- a/internal/api/providers.go
+++ b/internal/api/providers.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -24,8 +23,7 @@ import (
 // CreateProvider creates a new provider.
 func (h *Handler) CreateProvider(w http.ResponseWriter, r *http.Request) {
 	var req provider.CreateProviderRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		respondBadRequest(w, "invalid request body", err)
+	if !decodeJSON(w, r, &req) {
 		return
 	}
 
@@ -350,8 +348,7 @@ func (h *Handler) UpdateProvider(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req provider.UpdateProviderRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		respondBadRequest(w, "invalid request body", err)
+	if !decodeJSON(w, r, &req) {
 		return
 	}
 

--- a/internal/api/quota_fleet.go
+++ b/internal/api/quota_fleet.go
@@ -120,8 +120,7 @@ func (h *QuotaFleetHandler) ReceiveSnapshots(w http.ResponseWriter, r *http.Requ
 	var in struct {
 		Snapshots []QuotaSnapshotWire `json:"snapshots"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
-		http.Error(w, "invalid body", http.StatusBadRequest)
+	if !decodeJSON(w, r, &in) {
 		return
 	}
 

--- a/internal/api/quota_fleet.go
+++ b/internal/api/quota_fleet.go
@@ -112,6 +112,17 @@ func (h *QuotaFleetHandler) ExportSnapshots(w http.ResponseWriter, r *http.Reque
 	writeJSON(w, map[string]any{"snapshots": wire})
 }
 
+// maxQuotaSnapshotsBody bounds a fleet quota distribution. This body is not
+// client-written: Front Desk reads the primary's snapshot export and relays it
+// verbatim, so the producer's own read ceiling (internal/frontdesk's
+// maxMemberRespBody, 1 MiB) is what actually caps what can arrive here. Keeping
+// this strictly above it means that if Front Desk ever needs a bigger ceiling
+// for quota, as it already did for one config-sync endpoint, members do not
+// start answering 413 to a payload Front Desk considers legal. The failure
+// would be near-silent: the distributor logs a non-200 at debug level and each
+// member quietly falls back to polling upstream itself.
+const maxQuotaSnapshotsBody = 4 << 20
+
 // ReceiveSnapshots stores fleet-distributed snapshots, mapping each by provider
 // name onto this member's own provider IDs and writing with UpsertIfNewer so an
 // older fleet write never clobbers a fresher local (e.g. manual) snapshot. A
@@ -120,7 +131,7 @@ func (h *QuotaFleetHandler) ReceiveSnapshots(w http.ResponseWriter, r *http.Requ
 	var in struct {
 		Snapshots []QuotaSnapshotWire `json:"snapshots"`
 	}
-	if !decodeJSON(w, r, &in) {
+	if !decodeJSONLimit(w, r, maxQuotaSnapshotsBody, &in) {
 		return
 	}
 

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"sort"
@@ -219,8 +218,7 @@ func validateSettingIntRange(key string, v int, lo, hi float64) string {
 // UpdateSettings updates user settings in the database.
 func (h *Handler) UpdateSettings(w http.ResponseWriter, r *http.Request) {
 	var req map[string]string
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		respondBadRequest(w, "invalid request body", err)
+	if !decodeJSON(w, r, &req) {
 		return
 	}
 
@@ -353,8 +351,7 @@ func (h *Handler) ResetSettings(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Keys []string `json:"keys"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		respondBadRequest(w, "invalid request body", err)
+	if !decodeJSON(w, r, &req) {
 		return
 	}
 

--- a/internal/api/userpassword.go
+++ b/internal/api/userpassword.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"errors"
 	"net/http"
 	"strconv"
@@ -31,8 +30,7 @@ func (h *Handler) ChangeOwnPassword(w http.ResponseWriter, r *http.Request) {
 		CurrentPassword string `json:"current_password"`
 		NewPassword     string `json:"new_password"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		respondBadRequest(w, "invalid request body", err)
+	if !decodeJSON(w, r, &req) {
 		return
 	}
 	if len(req.NewPassword) < minPasswordLen {

--- a/internal/api/users.go
+++ b/internal/api/users.go
@@ -181,8 +181,7 @@ func (req *userRequest) validate() (user.Role, error) {
 // CreateUser adds a user account.
 func (h *Handler) CreateUser(w http.ResponseWriter, r *http.Request) {
 	var req userRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		respondBadRequest(w, "invalid request body", err)
+	if !decodeJSON(w, r, &req) {
 		return
 	}
 	role, err := req.validate()
@@ -224,8 +223,7 @@ func (h *Handler) UpdateUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var req userRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		respondBadRequest(w, "invalid request body", err)
+	if !decodeJSON(w, r, &req) {
 		return
 	}
 	role, err := req.validate()
@@ -292,8 +290,7 @@ func (h *Handler) SetUserPassword(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Password string `json:"password"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		respondBadRequest(w, "invalid request body", err)
+	if !decodeJSON(w, r, &req) {
 		return
 	}
 	if err := h.validateNewPassword(r.Context(), req.Password); err != nil {

--- a/internal/api/usertotp.go
+++ b/internal/api/usertotp.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"net/http"
 	"strconv"
 	"time"
@@ -121,8 +120,7 @@ func (h *Handler) UserTotpEnrollVerify(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Code string `json:"code"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		respondBadRequest(w, "invalid request body", err)
+	if !decodeJSON(w, r, &req) {
 		return
 	}
 	verified, err := repo.Verify(r.Context(), req.Code)
@@ -161,8 +159,7 @@ func (h *Handler) UserTotpDisable(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Code string `json:"code"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		respondBadRequest(w, "invalid request body", err)
+	if !decodeJSON(w, r, &req) {
 		return
 	}
 	key := id.UserID.String()

--- a/internal/api/virtualkeys.go
+++ b/internal/api/virtualkeys.go
@@ -326,8 +326,7 @@ func cond(val string, condition bool) string {
 // CreateVirtualKey creates a new virtual API key.
 func (h *Handler) CreateVirtualKey(w http.ResponseWriter, r *http.Request) {
 	var req CreateVirtualKeyRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		respondBadRequest(w, "invalid request body", err)
+	if !decodeJSON(w, r, &req) {
 		return
 	}
 
@@ -477,8 +476,7 @@ func (h *Handler) UpdateVirtualKey(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req UpdateVirtualKeyRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		respondBadRequest(w, "invalid request body", err)
+	if !decodeJSON(w, r, &req) {
 		return
 	}
 

--- a/internal/frontdesk/bodylimit_test.go
+++ b/internal/frontdesk/bodylimit_test.go
@@ -1,0 +1,54 @@
+package frontdesk
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/hugalafutro/model-hotel/internal/httpx"
+)
+
+// TestPair_OversizedBody_413 covers the reason Front Desk's decodeJSON is
+// bounded at all: the pairing exchange is unauthenticated by design (only the
+// per-IP limiter stands in front of it), so without a ceiling anyone who can
+// reach Front Desk could make it read a body of any size. The code is valid
+// JSON and simply wrong, so a 400 here would mean the size limit did nothing.
+func TestPair_OversizedBody_413(t *testing.T) {
+	srv, _ := newTestServer(t)
+
+	body := `{"code":"nope","label":"` + strings.Repeat("a", httpx.MaxJSONBody+1) + `"}`
+	rec := do(t, srv, http.MethodPost, "/api/pair", body, false)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want 413; body=%q", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "aaaa") {
+		t.Errorf("the rejection must not echo the body: %q", rec.Body.String())
+	}
+}
+
+// TestPair_MalformedBody_400 keeps the two failure modes distinct: malformed
+// still answers 400, so the new 413 means "too much", not "unparseable".
+func TestPair_MalformedBody_400(t *testing.T) {
+	srv, _ := newTestServer(t)
+
+	rec := do(t, srv, http.MethodPost, "/api/pair", `{"code":`, false)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%q", rec.Code, rec.Body.String())
+	}
+}
+
+// TestAuthenticatedEndpoint_OversizedBody_413 pins that the bound is not
+// pairing-only: every handler in the package decodes through the same helper,
+// so an admin-authenticated route is bounded too.
+func TestAuthenticatedEndpoint_OversizedBody_413(t *testing.T) {
+	srv, _ := newTestServer(t)
+
+	body := `{"name":"` + strings.Repeat("a", httpx.MaxJSONBody+1) + `","url":"http://example.com"}`
+	rec := do(t, srv, http.MethodPost, "/api/members", body, true)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want 413; body=%q", rec.Code, rec.Body.String())
+	}
+}

--- a/internal/frontdesk/devices_test.go
+++ b/internal/frontdesk/devices_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 )
 
 // ---------------------------------------------------------------------------
@@ -41,6 +42,22 @@ func TestCreatePairedDeviceValidation(t *testing.T) {
 	}
 	if len(d2.Label) != maxDeviceLabelLen {
 		t.Errorf("label len = %d, want %d", len(d2.Label), maxDeviceLabelLen)
+	}
+
+	// Truncation cuts characters, not bytes. Slicing bytes would split the last
+	// character in half and store the broken half, which renders as a
+	// replacement glyph everywhere the label is shown. The label comes from the
+	// unauthenticated pairing request, so its content is the caller's entirely.
+	wide := strings.Repeat("\u754c", maxDeviceLabelLen+50)
+	d3, err := store.CreatePairedDevice(ctx, wide, "hash-3", RoleMonitor)
+	if err != nil {
+		t.Fatalf("CreatePairedDevice wide label: %v", err)
+	}
+	if !utf8.ValidString(d3.Label) {
+		t.Errorf("truncated label is not valid UTF-8: %q", d3.Label)
+	}
+	if got := utf8.RuneCountInString(d3.Label); got != maxDeviceLabelLen {
+		t.Errorf("label = %d characters, want %d", got, maxDeviceLabelLen)
 	}
 	if d2.Role != RoleOperator {
 		t.Errorf("role = %q", d2.Role)

--- a/internal/frontdesk/httputil.go
+++ b/internal/frontdesk/httputil.go
@@ -1,7 +1,6 @@
 package frontdesk
 
 import (
-	"encoding/json"
 	"errors"
 	"io/fs"
 	"net/http"
@@ -42,14 +41,15 @@ func writeError(w http.ResponseWriter, err error) {
 	}
 }
 
-// decodeJSON decodes the request body, writing a 400 and returning false on
-// failure.
+// decodeJSON bounds the request body to httpx.MaxJSONBody and decodes it,
+// writing the 400/413 response itself and reporting whether the handler may
+// continue. The bound matters most for the pairing exchange, which is
+// unauthenticated by design (only the per-IP limiter stands in front of it), so
+// without a ceiling any caller that can reach Front Desk could make it read an
+// arbitrarily large body. Every handler in this package decodes through here;
+// internal/httpx's TestNoUnboundedJSONDecode guard keeps it that way.
 func decodeJSON(w http.ResponseWriter, r *http.Request, v any) bool {
-	if err := json.NewDecoder(r.Body).Decode(v); err != nil {
-		http.Error(w, "invalid JSON body", http.StatusBadRequest)
-		return false
-	}
-	return true
+	return httpx.DecodeJSON(w, r, logComponent, httpx.MaxJSONBody, v)
 }
 
 func atoiDefault(s string, def int) int {

--- a/internal/frontdesk/memberapi.go
+++ b/internal/frontdesk/memberapi.go
@@ -22,6 +22,12 @@ import (
 // the small JSON documents routine calls return (a config hash, a settings object,
 // a stats series); a response that grows with the member's own history passes its
 // own limit to callMemberLimited.
+//
+// Quota distribution relays a response read under this ceiling straight back to
+// the other members, whose receiving handler bounds its own request body at
+// internal/api's maxQuotaSnapshotsBody. That constant is deliberately larger
+// than this one; raising this one past it would make members answer 413 to a
+// payload Front Desk considers legal.
 const maxMemberRespBody = 1 << 20
 
 // errMemberRespTooLarge reports a member response that did not fit its read limit.

--- a/internal/frontdesk/store_devices.go
+++ b/internal/frontdesk/store_devices.go
@@ -42,8 +42,8 @@ type PairedDevice struct {
 	LastSeenAt *time.Time `json:"last_seen_at,omitempty"`
 }
 
-// maxDeviceLabelLen bounds the device label so a hostile pairing request can't
-// store unbounded text.
+// maxDeviceLabelLen bounds the device label, in characters, so a hostile pairing
+// request can't store unbounded text.
 const maxDeviceLabelLen = 100
 
 // CreatePairedDevice inserts a new paired device holding tokenHash. The label
@@ -56,8 +56,12 @@ func (s *Store) CreatePairedDevice(ctx context.Context, label, tokenHash string,
 	if label == "" {
 		label = "Paired device"
 	}
-	if len(label) > maxDeviceLabelLen {
-		label = label[:maxDeviceLabelLen]
+	// Cut on a character boundary, not a byte one. Slicing bytes splits a
+	// multibyte character in half and stores the broken half, which every
+	// consumer then renders as a replacement glyph. The label arrives from the
+	// unauthenticated pairing request, so its content is entirely the caller's.
+	if runes := []rune(label); len(runes) > maxDeviceLabelLen {
+		label = string(runes[:maxDeviceLabelLen])
 	}
 	if tokenHash == "" {
 		return nil, fmt.Errorf("%w: token hash is required", ErrValidation)

--- a/internal/frontdesk/store_members.go
+++ b/internal/frontdesk/store_members.go
@@ -17,14 +17,37 @@ import (
 // Members
 // ---------------------------------------------------------------------------
 
+// maxMemberNameLen caps a member's display name. The name is not decoration:
+// the primary's copy rides in every fleet announce, whose receiving handler
+// bounds that body at 1 KiB. An unbounded name therefore breaks announces
+// fleet-wide, and near-silently, since the poller logs a failed announce at
+// debug level only. 200 characters is far beyond any real hostname-shaped label
+// and leaves the announce most of its budget.
+const maxMemberNameLen = 200
+
+// validMemberName trims a display name and rejects one that is empty or past
+// maxMemberNameLen. Rejected rather than truncated, unlike a paired device's
+// label: a member's name identifies it across the fleet, so silently storing a
+// different name than the operator typed would be worse than refusing.
+func validMemberName(name string) (string, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", fmt.Errorf("%w: name is required", ErrValidation)
+	}
+	if len(name) > maxMemberNameLen {
+		return "", fmt.Errorf("%w: name must be at most %d characters", ErrValidation, maxMemberNameLen)
+	}
+	return name, nil
+}
+
 // CreateMember validates and inserts a new member. name must be non-empty and
 // rawURL must be a valid http(s) URL with a host; the URL is normalized (scheme
 // lowercased, trailing slash trimmed) and deduped. token is optional; when set
 // it is encrypted at rest with the store master key.
 func (s *Store) CreateMember(ctx context.Context, name, rawURL, token string) (*Member, error) {
-	name = strings.TrimSpace(name)
-	if name == "" {
-		return nil, fmt.Errorf("%w: name is required", ErrValidation)
+	name, err := validMemberName(name)
+	if err != nil {
+		return nil, err
 	}
 	normURL, err := normalizeMemberURL(rawURL, s.allowHTTPMembers)
 	if err != nil {
@@ -90,9 +113,9 @@ func (s *Store) GetMember(ctx context.Context, id string) (*Member, error) {
 
 // RenameMember updates a member's display name.
 func (s *Store) RenameMember(ctx context.Context, id, name string) error {
-	name = strings.TrimSpace(name)
-	if name == "" {
-		return fmt.Errorf("%w: name is required", ErrValidation)
+	name, err := validMemberName(name)
+	if err != nil {
+		return err
 	}
 	return s.touchMember(ctx, `UPDATE members SET name = ?, updated_at = ? WHERE id = ?`, id, name)
 }

--- a/internal/frontdesk/store_members.go
+++ b/internal/frontdesk/store_members.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/google/uuid"
 
@@ -17,13 +18,26 @@ import (
 // Members
 // ---------------------------------------------------------------------------
 
-// maxMemberNameLen caps a member's display name. The name is not decoration:
-// the primary's copy rides in every fleet announce, whose receiving handler
-// bounds that body at 1 KiB. An unbounded name therefore breaks announces
-// fleet-wide, and near-silently, since the poller logs a failed announce at
-// debug level only. 200 characters is far beyond any real hostname-shaped label
-// and leaves the announce most of its budget.
-const maxMemberNameLen = 200
+// maxMemberNameLen caps a member's display name, in characters.
+//
+// The name is not decoration: the primary's copy rides in every fleet announce,
+// whose receiving handler bounds that body at 1 KiB. An unbounded name
+// therefore breaks announces fleet-wide, and near-silently, since the poller
+// logs a failed announce at debug level only.
+//
+// The budget is in bytes and the cap is in characters, so the number has to
+// survive the worst ratio between them: an astral-plane character is 4 bytes of
+// UTF-8, and a character JSON has to escape is 6. 128 characters is therefore
+// at most 768 bytes on the wire, which still leaves the announce's other fields
+// room inside the kilobyte, while staying far beyond any real hostname-shaped
+// label. TestMemberNameFitsAnnounceBudget marshals the actual worst case rather
+// than trusting this arithmetic.
+//
+// Counted in characters and not bytes because that is what the operator is told
+// and what they can see. Measuring bytes would silently give a shorter name to
+// anyone not writing in ASCII, which this codebase deliberately does not do to
+// identifiers elsewhere either.
+const maxMemberNameLen = 128
 
 // validMemberName trims a display name and rejects one that is empty or past
 // maxMemberNameLen. Rejected rather than truncated, unlike a paired device's
@@ -34,7 +48,7 @@ func validMemberName(name string) (string, error) {
 	if name == "" {
 		return "", fmt.Errorf("%w: name is required", ErrValidation)
 	}
-	if len(name) > maxMemberNameLen {
+	if utf8.RuneCountInString(name) > maxMemberNameLen {
 		return "", fmt.Errorf("%w: name must be at most %d characters", ErrValidation, maxMemberNameLen)
 	}
 	return name, nil

--- a/internal/frontdesk/store_test.go
+++ b/internal/frontdesk/store_test.go
@@ -919,3 +919,49 @@ func TestDeleteMemberClearsGhostFleetState(t *testing.T) {
 		t.Errorf("fleet_sync_state still names deleted member %q", gm.ID)
 	}
 }
+
+// TestMemberNameLengthCapped covers the coupling that makes an unbounded name
+// dangerous rather than merely untidy: the primary's name rides in every fleet
+// announce, and the receiving handler bounds that body at 1 KiB, so a long
+// enough name breaks announces for the whole fleet and does it at debug-log
+// volume. Both write paths are capped, and the cap rejects rather than
+// truncates, since a member's name identifies it across the fleet.
+func TestMemberNameLengthCapped(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	long := strings.Repeat("n", maxMemberNameLen+1)
+	if _, err := s.CreateMember(ctx, long, "http://member.example.com", "tok"); !errors.Is(err, ErrValidation) {
+		t.Errorf("CreateMember with an over-long name err = %v, want ErrValidation", err)
+	}
+
+	m, err := s.CreateMember(ctx, strings.Repeat("n", maxMemberNameLen), "http://member.example.com", "tok")
+	if err != nil {
+		t.Fatalf("CreateMember at exactly the cap: %v", err)
+	}
+
+	if err := s.RenameMember(ctx, m.ID, long); !errors.Is(err, ErrValidation) {
+		t.Errorf("RenameMember to an over-long name err = %v, want ErrValidation", err)
+	}
+	stored, err := s.GetMember(ctx, m.ID)
+	if err != nil {
+		t.Fatalf("GetMember: %v", err)
+	}
+	if len(stored.Name) != maxMemberNameLen {
+		t.Errorf("stored name len = %d, want the rejected rename to have changed nothing", len(stored.Name))
+	}
+}
+
+// TestMemberNameFitsAnnounceBudget ties the cap to the constraint it exists for,
+// so raising it without revisiting the announce body fails here rather than in
+// the field. maxAnnounceBody lives in internal/api and cannot be imported, so
+// its value is restated: 1 KiB.
+func TestMemberNameFitsAnnounceBudget(t *testing.T) {
+	const announceBodyLimit = 1 << 10
+	// The announce carries the name plus is_primary, frontdesk_id and the JSON
+	// scaffolding; leave that comfortably more room than it needs.
+	if maxMemberNameLen > announceBodyLimit/2 {
+		t.Errorf("maxMemberNameLen = %d leaves too little of the %d-byte announce budget for the rest of the payload",
+			maxMemberNameLen, announceBodyLimit)
+	}
+}

--- a/internal/frontdesk/store_test.go
+++ b/internal/frontdesk/store_test.go
@@ -2,6 +2,7 @@ package frontdesk
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"path/filepath"
@@ -954,14 +955,57 @@ func TestMemberNameLengthCapped(t *testing.T) {
 
 // TestMemberNameFitsAnnounceBudget ties the cap to the constraint it exists for,
 // so raising it without revisiting the announce body fails here rather than in
-// the field. maxAnnounceBody lives in internal/api and cannot be imported, so
-// its value is restated: 1 KiB.
+// the field. The cap counts characters and the budget counts bytes, so this
+// marshals the real worst case instead of doing the arithmetic: a name of
+// nothing but 4-byte characters, beside a full-length Front Desk id. Anything
+// that widens the gap between the two units shows up here.
+//
+// maxAnnounceBody lives in internal/api and cannot be imported from here, so its
+// value is restated.
 func TestMemberNameFitsAnnounceBudget(t *testing.T) {
 	const announceBodyLimit = 1 << 10
-	// The announce carries the name plus is_primary, frontdesk_id and the JSON
-	// scaffolding; leave that comfortably more room than it needs.
-	if maxMemberNameLen > announceBodyLimit/2 {
-		t.Errorf("maxMemberNameLen = %d leaves too little of the %d-byte announce budget for the rest of the payload",
-			maxMemberNameLen, announceBodyLimit)
+
+	worstName := strings.Repeat("\U0001F600", maxMemberNameLen)
+	if len(worstName) != 4*maxMemberNameLen {
+		t.Fatalf("probe is stale: expected 4 bytes per character, got %d for %d characters", len(worstName), maxMemberNameLen)
+	}
+	body, err := json.Marshal(memberAnnounce{
+		IsPrimary:     true,
+		PrimaryName:   worstName,
+		FrontdeskID:   strings.Repeat("f", 36), // a UUID
+		ActiveMembers: 9999,
+	})
+	if err != nil {
+		t.Fatalf("marshal worst-case announce: %v", err)
+	}
+	if len(body) > announceBodyLimit {
+		t.Errorf("a worst-case announce is %d bytes, over the %d-byte limit the member enforces; maxMemberNameLen (%d) is too high",
+			len(body), announceBodyLimit, maxMemberNameLen)
+	}
+}
+
+// TestMemberNameCapCountsCharactersNotBytes is the operator-facing half of the
+// cap. The error says "characters", so a name of 128 Chinese characters has to
+// be as acceptable as 128 Latin ones; measuring bytes would quietly hand a
+// shorter name to anyone not writing in ASCII.
+func TestMemberNameCapCountsCharactersNotBytes(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	atCap := strings.Repeat("\u754c", maxMemberNameLen) // 3 bytes each, well over the cap in bytes
+	m, err := s.CreateMember(ctx, atCap, "http://wide.example.com", "tok")
+	if err != nil {
+		t.Fatalf("CreateMember with %d multibyte characters: %v", maxMemberNameLen, err)
+	}
+	if m.Name != atCap {
+		t.Errorf("stored name was altered; want the name as typed")
+	}
+
+	overCap := strings.Repeat("\u754c", maxMemberNameLen+1)
+	if _, err := s.CreateMember(ctx, overCap, "http://wider.example.com", "tok"); !errors.Is(err, ErrValidation) {
+		t.Errorf("CreateMember one character over the cap err = %v, want ErrValidation", err)
+	}
+	if err := s.RenameMember(ctx, m.ID, overCap); !errors.Is(err, ErrValidation) {
+		t.Errorf("RenameMember one character over the cap err = %v, want ErrValidation", err)
 	}
 }

--- a/internal/httpx/decodeguard_test.go
+++ b/internal/httpx/decodeguard_test.go
@@ -13,28 +13,53 @@ import (
 // server buffer as much as the client is willing to send.
 const unboundedDecode = "json.NewDecoder(r.Body)"
 
+// skipDir is the directory names the guard does not descend into: source
+// control and the frontends' dependency trees hold no Go of ours and would
+// dominate the walk.
+var skipDir = map[string]bool{".git": true, "node_modules": true}
+
 // TestNoUnboundedJSONDecode keeps the bounded-decode contract from decaying.
 // DecodeJSON exists so no HTTP surface reads an unbounded request body, but a
 // helper only holds while handlers actually use it, and the tempting one-liner
 // is exactly what a new handler copies from its neighbours. The guard lives
 // beside the contract rather than in each consumer package so there is one copy
-// of it, and it walks all of internal/ rather than a list of packages so a new
-// surface is covered the day it is added instead of the day someone remembers
-// to register it.
+// of it, and it walks the whole repository rather than a list of packages so a
+// new surface is covered the day it is added instead of the day someone
+// remembers to register it. The repository and not just internal/, because a
+// handler defined in cmd/ or a tool would be exactly as unbounded.
 //
 // Only this package is exempt, because DecodeJSON is where the bounded read is
 // implemented.
+//
+// What it does not catch, stated so nobody mistakes it for more than it is: it
+// matches one call shape, so io.ReadAll(r.Body) followed by json.Unmarshal (the
+// idiom internal/proxy uses for the deliberately larger /v1 data plane) passes,
+// and it says nothing about whether a limit is a sensible size. It is a
+// backstop against the one-line copy, not a proof of boundedness.
 func TestNoUnboundedJSONDecode(t *testing.T) {
 	selfDir, err := filepath.Abs(".")
 	if err != nil {
 		t.Fatalf("resolve package dir: %v", err)
 	}
 
-	walkErr := filepath.WalkDir("..", func(path string, d fs.DirEntry, err error) error {
+	// The package sits at internal/httpx, so the repository root is two up.
+	walkErr := filepath.WalkDir("../..", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
+			// A directory the test process cannot read (the dev stack's
+			// bind-mounted pgdata is root-owned) holds none of our source, so
+			// skipping it keeps the guard usable on a working checkout.
+			if d != nil && d.IsDir() {
+				return fs.SkipDir
+			}
 			return err
 		}
-		if d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+		if d.IsDir() {
+			if skipDir[d.Name()] {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
 			return nil
 		}
 		abs, err := filepath.Abs(path)
@@ -49,13 +74,21 @@ func TestNoUnboundedJSONDecode(t *testing.T) {
 			return err
 		}
 		for i, line := range strings.Split(string(src), "\n") {
-			if strings.Contains(line, unboundedDecode) {
-				t.Errorf("%s:%d reads the request body without a size limit; decode through the package's decodeJSON helper (httpx.DecodeJSON) instead", path, i+1)
+			if !strings.Contains(line, unboundedDecode) {
+				continue
 			}
+			// A comment may legitimately name the call (this file's own const
+			// does), and a line that binds the reader in place is bounded even
+			// though it matches.
+			if strings.HasPrefix(strings.TrimSpace(line), "//") ||
+				strings.Contains(line, "MaxBytesReader") || strings.Contains(line, "LimitReader") {
+				continue
+			}
+			t.Errorf("%s:%d reads the request body without a size limit; decode through the package's decodeJSON helper (httpx.DecodeJSON) instead", path, i+1)
 		}
 		return nil
 	})
 	if walkErr != nil {
-		t.Fatalf("walk internal/: %v", walkErr)
+		t.Fatalf("walk the repository: %v", walkErr)
 	}
 }

--- a/internal/httpx/decodeguard_test.go
+++ b/internal/httpx/decodeguard_test.go
@@ -1,0 +1,61 @@
+package httpx
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// unboundedDecode is the call that must not appear outside this package: it
+// reads the request body with no ceiling, so a single request can make the
+// server buffer as much as the client is willing to send.
+const unboundedDecode = "json.NewDecoder(r.Body)"
+
+// TestNoUnboundedJSONDecode keeps the bounded-decode contract from decaying.
+// DecodeJSON exists so no HTTP surface reads an unbounded request body, but a
+// helper only holds while handlers actually use it, and the tempting one-liner
+// is exactly what a new handler copies from its neighbours. The guard lives
+// beside the contract rather than in each consumer package so there is one copy
+// of it, and it walks all of internal/ rather than a list of packages so a new
+// surface is covered the day it is added instead of the day someone remembers
+// to register it.
+//
+// Only this package is exempt, because DecodeJSON is where the bounded read is
+// implemented.
+func TestNoUnboundedJSONDecode(t *testing.T) {
+	selfDir, err := filepath.Abs(".")
+	if err != nil {
+		t.Fatalf("resolve package dir: %v", err)
+	}
+
+	walkErr := filepath.WalkDir("..", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		abs, err := filepath.Abs(path)
+		if err != nil {
+			return err
+		}
+		if filepath.Dir(abs) == selfDir {
+			return nil
+		}
+		src, err := os.ReadFile(path) //nolint:gosec // walking this repo's own source tree
+		if err != nil {
+			return err
+		}
+		for i, line := range strings.Split(string(src), "\n") {
+			if strings.Contains(line, unboundedDecode) {
+				t.Errorf("%s:%d reads the request body without a size limit; decode through the package's decodeJSON helper (httpx.DecodeJSON) instead", path, i+1)
+			}
+		}
+		return nil
+	})
+	if walkErr != nil {
+		t.Fatalf("walk internal/: %v", walkErr)
+	}
+}

--- a/internal/httpx/decodejson_test.go
+++ b/internal/httpx/decodejson_test.go
@@ -1,6 +1,9 @@
 package httpx
 
 import (
+	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -77,22 +80,40 @@ func TestDecodeJSON_ExactlyAtLimit_Accepted(t *testing.T) {
 	}
 }
 
-func TestDecodeJSONOptional_EmptyAndMalformedBodiesContinue(t *testing.T) {
+func TestDecodeJSONOptional_EmptyBodyContinues(t *testing.T) {
+	rec := httptest.NewRecorder()
+	var got decodeTarget
+	if !DecodeJSONOptional(rec, decodeRequest(""), "test", MaxJSONBody, &got) {
+		t.Fatalf("DecodeJSONOptional = false, body %q", rec.Body.String())
+	}
+	if got.Name != "" {
+		t.Errorf("name = %q, want zero value", got.Name)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want untouched 200", rec.Code)
+	}
+}
+
+// TestDecodeJSONOptional_PresentButBrokenBody_400 is the line between the two
+// situations the tolerance must not blur. A body that never arrived means "use
+// the default"; a body that arrived and could not be read means the caller
+// asked for something specific, and answering it with the default silently does
+// something other than what was asked. On the purge endpoint that is the
+// difference between clearing an hour of logs and clearing all of them.
+func TestDecodeJSONOptional_PresentButBrokenBody_400(t *testing.T) {
 	for _, tc := range []struct{ name, body string }{
-		{"empty", ""},
-		{"malformed", `{"name":`},
+		{"truncated", `{"name":"a"`},
+		{"wrong type", `{"name":5}`},
+		{"not json", `nonsense`},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			rec := httptest.NewRecorder()
 			var got decodeTarget
-			if !DecodeJSONOptional(rec, decodeRequest(tc.body), "test", MaxJSONBody, &got) {
-				t.Fatalf("DecodeJSONOptional = false, body %q", rec.Body.String())
+			if DecodeJSONOptional(rec, decodeRequest(tc.body), "test", MaxJSONBody, &got) {
+				t.Fatal("DecodeJSONOptional = true for a body that was sent and could not be read")
 			}
-			if got.Name != "" {
-				t.Errorf("name = %q, want zero value", got.Name)
-			}
-			if rec.Code != http.StatusOK {
-				t.Errorf("status = %d, want untouched 200", rec.Code)
+			if rec.Code != http.StatusBadRequest {
+				t.Errorf("status = %d, want 400", rec.Code)
 			}
 		})
 	}
@@ -128,5 +149,110 @@ func TestDecodeJSON_LimitAppliesToStreamNotContentLength(t *testing.T) {
 	}
 	if rec.Code != http.StatusRequestEntityTooLarge {
 		t.Errorf("status = %d, want 413", rec.Code)
+	}
+}
+
+// TestDecodeJSON_TrailingDataAfterValue_Rejected covers what makes the ceiling
+// real rather than nominal. json.Decoder stops the moment it has one complete
+// value, so without draining what follows, a tiny object with a huge tail would
+// decode fine and never trip the limit: the endpoint would answer 200 to a body
+// of any size, and 413 would stop meaning "oversized". A tail under the limit is
+// a smuggled second payload and earns a 400; a tail that runs past the limit is
+// the 413 the naive version never produced.
+func TestDecodeJSON_TrailingDataAfterValue_Rejected(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+		want int
+	}{
+		{"second value", `{"name":"a"}{"name":"b"}`, http.StatusBadRequest},
+		{"junk", `{"name":"a"}garbage`, http.StatusBadRequest},
+		{"tail past the limit", `{"name":"a"}` + strings.Repeat(" ", 4096), http.StatusRequestEntityTooLarge},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			var got decodeTarget
+			if DecodeJSON(rec, decodeRequest(tc.body), "test", 64, &got) {
+				t.Fatal("DecodeJSON = true for a body with trailing data")
+			}
+			if rec.Code != tc.want {
+				t.Errorf("status = %d, want %d; body=%q", rec.Code, tc.want, rec.Body.String())
+			}
+		})
+	}
+}
+
+// TestDecodeJSON_TrailingNewlineAccepted keeps the drain from breaking clients
+// that end a request body with a newline, which is ordinary and not a tail.
+func TestDecodeJSON_TrailingNewlineAccepted(t *testing.T) {
+	rec := httptest.NewRecorder()
+	var got decodeTarget
+	if !DecodeJSON(rec, decodeRequest("{\"name\":\"ok\"}\n"), "test", MaxJSONBody, &got) {
+		t.Fatalf("DecodeJSON = false for a trailing newline, body %q", rec.Body.String())
+	}
+	if got.Name != "ok" {
+		t.Errorf("name = %q, want ok", got.Name)
+	}
+}
+
+// TestDecodeFailure_NamesTheFailureWithoutQuotingTheBody pins the logging
+// invariant: this gateway never logs request content, and the
+// pre-authentication routes decode through here, so the byte a json.SyntaxError
+// quotes must not reach the log. Every other failure is normalised to the same
+// fixed vocabulary so no decoder message reaches a log line by accident. The
+// errors here are the real ones the decoder produces, not hand-built ones, so
+// the test fails if a future Go release changes what they carry.
+func TestDecodeFailure_NamesTheFailureWithoutQuotingTheBody(t *testing.T) {
+	var target decodeTarget
+	syntaxErr := json.Unmarshal([]byte(`{qqqq}`), &target)
+	typeErr := json.Unmarshal([]byte(`{"name":31337}`), &target)
+	if syntaxErr == nil || typeErr == nil {
+		t.Fatal("expected the decoder to reject both probe bodies")
+	}
+
+	for _, tc := range []struct {
+		name   string
+		err    error
+		want   string
+		secret string // the caller-controlled fragment the raw error carries
+	}{
+		{"syntax", syntaxErr, "malformed JSON", "q"},
+		{"wrong type", typeErr, "wrong JSON type for field", ""},
+		{"truncated", io.ErrUnexpectedEOF, "truncated JSON value", ""},
+		{"empty", io.EOF, "empty body", ""},
+		{"trailing", nil, "trailing data after JSON value", ""},
+		{"other", errors.New("boom"), "unreadable body", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			kind, _ := decodeFailure(tc.err)
+			if kind != tc.want {
+				t.Errorf("kind = %q, want %q", kind, tc.want)
+			}
+			if tc.secret != "" {
+				if !strings.Contains(tc.err.Error(), tc.secret) {
+					t.Fatalf("probe is stale: %q no longer carries %q", tc.err, tc.secret)
+				}
+				if strings.Contains(kind, tc.secret) {
+					t.Errorf("kind %q leaks the body fragment %q", kind, tc.secret)
+				}
+			}
+		})
+	}
+}
+
+// TestDecodeFailure_OffsetIsAPositionNotAValue keeps the one number the log does
+// carry honest: it locates the failure, it is not read out of the body.
+func TestDecodeFailure_OffsetIsAPositionNotAValue(t *testing.T) {
+	var target decodeTarget
+	err := json.Unmarshal([]byte(`{"name":"ok","x":}`), &target)
+	if err == nil {
+		t.Fatal("expected a syntax error")
+	}
+	kind, offset := decodeFailure(err)
+	if kind != "malformed JSON" {
+		t.Fatalf("kind = %q", kind)
+	}
+	if offset <= 0 {
+		t.Errorf("offset = %d, want the position of the bad byte", offset)
 	}
 }

--- a/internal/httpx/decodejson_test.go
+++ b/internal/httpx/decodejson_test.go
@@ -1,0 +1,132 @@
+package httpx
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type decodeTarget struct {
+	Name string `json:"name"`
+}
+
+func decodeRequest(body string) *http.Request {
+	return httptest.NewRequest(http.MethodPost, "/api/thing", strings.NewReader(body))
+}
+
+func TestDecodeJSON_ValidBody(t *testing.T) {
+	rec := httptest.NewRecorder()
+	var got decodeTarget
+	if !DecodeJSON(rec, decodeRequest(`{"name":"ok"}`), "test", MaxJSONBody, &got) {
+		t.Fatalf("DecodeJSON = false, body %q", rec.Body.String())
+	}
+	if got.Name != "ok" {
+		t.Errorf("name = %q, want ok", got.Name)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want untouched 200", rec.Code)
+	}
+}
+
+func TestDecodeJSON_MalformedBody_400(t *testing.T) {
+	rec := httptest.NewRecorder()
+	var got decodeTarget
+	if DecodeJSON(rec, decodeRequest(`{"name":`), "test", MaxJSONBody, &got) {
+		t.Fatal("DecodeJSON = true for malformed body")
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "invalid request body") {
+		t.Errorf("body = %q", rec.Body.String())
+	}
+}
+
+// TestDecodeJSON_OversizedBody_413 pins the whole point of the helper: a body
+// past the limit is refused with 413 rather than read, and the distinct status
+// is what lets an operator tell "the client sent junk" from "the client sent
+// too much".
+func TestDecodeJSON_OversizedBody_413(t *testing.T) {
+	rec := httptest.NewRecorder()
+	var got decodeTarget
+	huge := `{"name":"` + strings.Repeat("a", 4096) + `"}`
+	if DecodeJSON(rec, decodeRequest(huge), "test", 64, &got) {
+		t.Fatal("DecodeJSON = true for oversized body")
+	}
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("status = %d, want 413", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "request body too large") {
+		t.Errorf("body = %q", rec.Body.String())
+	}
+}
+
+// TestDecodeJSON_ExactlyAtLimit_Accepted pins the boundary as inclusive: a body
+// of exactly the limit is legal, so a limit chosen to fit a known payload does
+// not reject that payload by one byte.
+func TestDecodeJSON_ExactlyAtLimit_Accepted(t *testing.T) {
+	body := `{"name":"abc"}`
+	rec := httptest.NewRecorder()
+	var got decodeTarget
+	if !DecodeJSON(rec, decodeRequest(body), "test", int64(len(body)), &got) {
+		t.Fatalf("DecodeJSON = false at exactly the limit, body %q", rec.Body.String())
+	}
+	if got.Name != "abc" {
+		t.Errorf("name = %q, want abc", got.Name)
+	}
+}
+
+func TestDecodeJSONOptional_EmptyAndMalformedBodiesContinue(t *testing.T) {
+	for _, tc := range []struct{ name, body string }{
+		{"empty", ""},
+		{"malformed", `{"name":`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			var got decodeTarget
+			if !DecodeJSONOptional(rec, decodeRequest(tc.body), "test", MaxJSONBody, &got) {
+				t.Fatalf("DecodeJSONOptional = false, body %q", rec.Body.String())
+			}
+			if got.Name != "" {
+				t.Errorf("name = %q, want zero value", got.Name)
+			}
+			if rec.Code != http.StatusOK {
+				t.Errorf("status = %d, want untouched 200", rec.Code)
+			}
+		})
+	}
+}
+
+// TestDecodeJSONOptional_OversizedBody_413 is the half of the tolerance that is
+// not tolerant: ignoring a malformed body must not turn into ignoring an
+// unbounded read.
+func TestDecodeJSONOptional_OversizedBody_413(t *testing.T) {
+	rec := httptest.NewRecorder()
+	var got decodeTarget
+	huge := `{"name":"` + strings.Repeat("a", 4096) + `"}`
+	if DecodeJSONOptional(rec, decodeRequest(huge), "test", 64, &got) {
+		t.Fatal("DecodeJSONOptional = true for oversized body")
+	}
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("status = %d, want 413", rec.Code)
+	}
+}
+
+// TestDecodeJSON_ValidBodyUnderLimitAfterHugeField guards the read itself, not
+// just the outcome: MaxBytesReader must cut the stream off, so a body whose
+// declared JSON is fine but whose length is not never reaches the decoder.
+func TestDecodeJSON_LimitAppliesToStreamNotContentLength(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := decodeRequest(`{"name":"` + strings.Repeat("a", 4096) + `"}`)
+	// A client that under-declares its length gets no extra budget: the reader
+	// counts bytes, it does not trust the header.
+	req.ContentLength = 8
+	var got decodeTarget
+	if DecodeJSON(rec, req, "test", 64, &got) {
+		t.Fatal("DecodeJSON = true for oversized body with an understated Content-Length")
+	}
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("status = %d, want 413", rec.Code)
+	}
+}

--- a/internal/httpx/httpx.go
+++ b/internal/httpx/httpx.go
@@ -11,6 +11,7 @@ package httpx
 import (
 	"encoding/json"
 	"errors"
+	"io"
 	"net"
 	"net/http"
 	"strings"
@@ -208,46 +209,95 @@ func IsReadOnlyExemptPost(path string) bool {
 // Every admin, auth and Front Desk payload is a small settings/credential/ID
 // document, so a megabyte is orders of magnitude more than any of them needs
 // while still bounding what an unauthenticated caller (a login attempt, a
-// device pairing exchange) can make the server read and buffer. Endpoints that
+// device pairing exchange) can make the server read and buffer. The largest
+// legitimate payload on any route that uses it is a full bulk model delete, at
+// roughly 400 KiB; TestBulkDeleteWorstCaseFitsDefaultLimit pins that headroom
+// so raising the ID cap cannot silently outgrow this one. Endpoints that
 // legitimately carry more (a config-sync import, a backup upload) pass their
 // own limit instead of using this one.
+//
+// This is a second, much tighter ceiling on the main server, whose router
+// already caps every request at MAX_REQUEST_SIZE (50 MB by default) for the
+// sake of the proxy's multimodal uploads: 50 MB is the right bound for a
+// base64 image and a badly wrong one for a login body. The Front Desk binary
+// mounts no such global cap at all, so for its handlers this is the only
+// ceiling there is.
 const MaxJSONBody = 1 << 20 // 1 MiB
 
-// DecodeJSON bounds r.Body to limit bytes and decodes it into v, reporting
-// whether the caller may continue. On failure it has already written the
-// response: 413 when the body ran past the limit, 400 when it is malformed.
+// DecodeJSON bounds r.Body to limit bytes and decodes exactly one JSON value
+// into v, reporting whether the caller may continue. On failure it has already
+// written the response: 413 when the body ran past the limit, 400 when it is
+// malformed or carries anything after that value.
 //
 // The bound is applied with http.MaxBytesReader rather than by checking
 // Content-Length, so a chunked or lying request is cut off mid-read instead of
-// being trusted, and the ResponseWriter is told the request was oversized so
-// the connection is closed rather than left waiting for the rest of a body
-// nobody will read.
+// being trusted. MaxBytesReader also tries to tell the ResponseWriter the
+// request was oversized, but it does that through an unexported interface that
+// no wrapped writer in either binary implements (chi's logger and compressor
+// both wrap it), so in practice the connection is closed by net/http's own
+// post-handler drain instead. Either way the handler never reads past the
+// limit, which is the property that matters.
 func DecodeJSON(w http.ResponseWriter, r *http.Request, component string, limit int64, v any) bool {
 	r.Body = http.MaxBytesReader(w, r.Body, limit)
-	if err := json.NewDecoder(r.Body).Decode(v); err != nil {
+	dec := json.NewDecoder(r.Body)
+	if err := dec.Decode(v); err != nil {
+		return rejectDecode(w, r, component, limit, err)
+	}
+	return checkNothingFollows(w, r, component, limit, dec)
+}
+
+// DecodeJSONOptional is DecodeJSON for an endpoint whose body is optional: no
+// body at all leaves v at its zero value and the request continues, so the
+// caller keeps its documented default.
+//
+// Only an entirely absent body is tolerated. A body that is present but
+// malformed is rejected exactly as DecodeJSON rejects it, because "the client
+// sent nothing, so use the default" and "the client asked for something and we
+// could not read it, so use the default" are different situations, and
+// treating the second as the first silently substitutes the default for what
+// was actually asked. On a purge endpoint that is the difference between
+// deleting an hour of logs and deleting all of them.
+func DecodeJSONOptional(w http.ResponseWriter, r *http.Request, component string, limit int64, v any) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, limit)
+	dec := json.NewDecoder(r.Body)
+	err := dec.Decode(v)
+	if errors.Is(err, io.EOF) {
+		return true
+	}
+	if err != nil {
+		return rejectDecode(w, r, component, limit, err)
+	}
+	return checkNothingFollows(w, r, component, limit, dec)
+}
+
+// checkNothingFollows rejects a request that carries anything after its one
+// JSON value. It is what makes the ceiling real rather than nominal:
+// json.Decoder stops reading the moment it has a complete value, so a small
+// object followed by a huge tail would decode happily and never trip
+// MaxBytesReader. Draining to the end forces the tail through the limit, and a
+// tail that is under the limit but non-empty is a smuggled second payload, so
+// it earns the same 400 a malformed body does.
+//
+// Trailing whitespace is not a tail: Token skips it, and a client that ends its
+// body with a newline is well behaved.
+func checkNothingFollows(w http.ResponseWriter, r *http.Request, component string, limit int64, dec *json.Decoder) bool {
+	if _, err := dec.Token(); !errors.Is(err, io.EOF) {
 		return rejectDecode(w, r, component, limit, err)
 	}
 	return true
 }
 
-// DecodeJSONOptional is DecodeJSON for an endpoint whose body is optional: a
-// missing or malformed body leaves v at its zero value and the request
-// continues, so the caller keeps its documented default. An oversized body is
-// still refused, because tolerating a malformed body must not become a way to
-// make the server read an unbounded stream.
-func DecodeJSONOptional(w http.ResponseWriter, r *http.Request, component string, limit int64, v any) bool {
-	r.Body = http.MaxBytesReader(w, r.Body, limit)
-	err := json.NewDecoder(r.Body).Decode(v)
-	if err == nil || !isBodyTooLarge(err) {
-		return true
-	}
-	return rejectDecode(w, r, component, limit, err)
-}
-
 // rejectDecode writes the response for a failed decode and always reports
-// false, so a caller can return it directly. An oversized body is a 413 logged
-// with the limit it broke (never the body itself); anything else is the
-// existing 400.
+// false, so a caller can return it directly. An oversized body is a 413;
+// anything else is a 400.
+//
+// Neither log line carries any of the body. The obvious thing to log is the
+// decoder error, but json.SyntaxError's message embeds the offending byte, and
+// these routes include the pre-authentication ones, so that would put
+// caller-controlled content into the log of a gateway whose whole premise is
+// that request content is never logged. Normalising every failure to a fixed
+// phrase means no decoder message can reach a log line by accident either. The
+// phrase and the byte offset say everything an operator needs.
 func rejectDecode(w http.ResponseWriter, r *http.Request, component string, limit int64, err error) bool {
 	if isBodyTooLarge(err) {
 		debuglog.Info(component+": rejected oversized request body",
@@ -255,8 +305,35 @@ func rejectDecode(w http.ResponseWriter, r *http.Request, component string, limi
 		http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
 		return false
 	}
-	RespondBadRequest(w, component, "invalid request body", err)
+	kind, offset := decodeFailure(err)
+	debuglog.Info(component+": rejected malformed request body",
+		"path", r.URL.Path, "method", r.Method, "reason", kind, "offset", offset)
+	http.Error(w, "invalid request body", http.StatusBadRequest)
 	return false
+}
+
+// decodeFailure classifies a decode failure into a fixed phrase and a byte
+// offset, both safe to log: the phrase is one of these constants and the offset
+// is a position, never a value from the body. A nil error is the
+// something-follows case, where the decoder read a valid token that should not
+// have been there.
+func decodeFailure(err error) (kind string, offset int64) {
+	var syntax *json.SyntaxError
+	var wrongType *json.UnmarshalTypeError
+	switch {
+	case err == nil:
+		return "trailing data after JSON value", 0
+	case errors.Is(err, io.ErrUnexpectedEOF):
+		return "truncated JSON value", 0
+	case errors.Is(err, io.EOF):
+		return "empty body", 0
+	case errors.As(err, &syntax):
+		return "malformed JSON", syntax.Offset
+	case errors.As(err, &wrongType):
+		return "wrong JSON type for field", wrongType.Offset
+	default:
+		return "unreadable body", 0
+	}
 }
 
 // isBodyTooLarge reports whether err is MaxBytesReader's over-the-limit error.

--- a/internal/httpx/httpx.go
+++ b/internal/httpx/httpx.go
@@ -203,3 +203,66 @@ func IsReadOnlyExemptPost(path string) bool {
 	return strings.HasSuffix(path, "/discovery/changes/ack") ||
 		strings.HasSuffix(path, "/webauthn/logout")
 }
+
+// MaxJSONBody is the default ceiling on a control-plane JSON request body.
+// Every admin, auth and Front Desk payload is a small settings/credential/ID
+// document, so a megabyte is orders of magnitude more than any of them needs
+// while still bounding what an unauthenticated caller (a login attempt, a
+// device pairing exchange) can make the server read and buffer. Endpoints that
+// legitimately carry more (a config-sync import, a backup upload) pass their
+// own limit instead of using this one.
+const MaxJSONBody = 1 << 20 // 1 MiB
+
+// DecodeJSON bounds r.Body to limit bytes and decodes it into v, reporting
+// whether the caller may continue. On failure it has already written the
+// response: 413 when the body ran past the limit, 400 when it is malformed.
+//
+// The bound is applied with http.MaxBytesReader rather than by checking
+// Content-Length, so a chunked or lying request is cut off mid-read instead of
+// being trusted, and the ResponseWriter is told the request was oversized so
+// the connection is closed rather than left waiting for the rest of a body
+// nobody will read.
+func DecodeJSON(w http.ResponseWriter, r *http.Request, component string, limit int64, v any) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, limit)
+	if err := json.NewDecoder(r.Body).Decode(v); err != nil {
+		return rejectDecode(w, r, component, limit, err)
+	}
+	return true
+}
+
+// DecodeJSONOptional is DecodeJSON for an endpoint whose body is optional: a
+// missing or malformed body leaves v at its zero value and the request
+// continues, so the caller keeps its documented default. An oversized body is
+// still refused, because tolerating a malformed body must not become a way to
+// make the server read an unbounded stream.
+func DecodeJSONOptional(w http.ResponseWriter, r *http.Request, component string, limit int64, v any) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, limit)
+	err := json.NewDecoder(r.Body).Decode(v)
+	if err == nil || !isBodyTooLarge(err) {
+		return true
+	}
+	return rejectDecode(w, r, component, limit, err)
+}
+
+// rejectDecode writes the response for a failed decode and always reports
+// false, so a caller can return it directly. An oversized body is a 413 logged
+// with the limit it broke (never the body itself); anything else is the
+// existing 400.
+func rejectDecode(w http.ResponseWriter, r *http.Request, component string, limit int64, err error) bool {
+	if isBodyTooLarge(err) {
+		debuglog.Info(component+": rejected oversized request body",
+			"path", r.URL.Path, "method", r.Method, "limit_bytes", limit)
+		http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+		return false
+	}
+	RespondBadRequest(w, component, "invalid request body", err)
+	return false
+}
+
+// isBodyTooLarge reports whether err is MaxBytesReader's over-the-limit error.
+// json.Decoder surfaces a read error unwrapped, but errors.As keeps this
+// correct if a future decode path wraps it.
+func isBodyTooLarge(err error) bool {
+	var tooLarge *http.MaxBytesError
+	return errors.As(err, &tooLarge)
+}

--- a/internal/proxy/usage_estimate_test.go
+++ b/internal/proxy/usage_estimate_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -46,16 +47,15 @@ func streamUsageHarness(t *testing.T, upstreamBody string, cancelAfterFirstChunk
 	t.Cleanup(cancel)
 
 	var body io.ReadCloser
-	var served chan struct{}
 	if cancelAfterFirstChunk {
 		// Deliver the first event, then block until the client context is
 		// cancelled so the rest (usage chunk included) never arrives.
 		first, _, _ := strings.Cut(upstreamBody, "\n\n")
-		served = make(chan struct{})
-		body = &blockingReader{first: first + "\n\n", ctx: ctx, served: served}
+		body = &blockingReader{first: first + "\n\n", ctx: ctx}
 	} else {
 		body = io.NopCloser(strings.NewReader(upstreamBody))
 	}
+	rec := newDeliveredRecorder()
 	resp := &http.Response{StatusCode: http.StatusOK, Body: body}
 	req := withAuthContext(httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody).WithContext(ctx))
 
@@ -73,11 +73,11 @@ func streamUsageHarness(t *testing.T, upstreamBody string, cancelAfterFirstChunk
 
 	done := make(chan struct{})
 	go func() {
-		h.handleStreamingResponse(httptest.NewRecorder(), req, logData, resp, time.Now(), streamOptions{vkHash: "test-hash", attempt: 1, cancelOrigin: "failover_timeout"})
+		h.handleStreamingResponse(rec, req, logData, resp, time.Now(), streamOptions{vkHash: "test-hash", attempt: 1, cancelOrigin: "failover_timeout"})
 		close(done)
 	}()
 	if cancelAfterFirstChunk {
-		<-served
+		<-rec.served
 		cancel()
 	}
 	select {
@@ -88,23 +88,19 @@ func streamUsageHarness(t *testing.T, upstreamBody string, cancelAfterFirstChunk
 	return vkRepo, logData
 }
 
-// blockingReader serves `first` (closing `served` once it is fully read), then
-// blocks until ctx is cancelled and returns context.Canceled, the error the
+// blockingReader serves `first`, then blocks until ctx is cancelled and returns
+// context.Canceled, the error the
 // transport surfaces when the client goes away.
 type blockingReader struct {
-	first  string
-	ctx    context.Context
-	served chan struct{}
-	off    int
+	first string
+	ctx   context.Context
+	off   int
 }
 
 func (r *blockingReader) Read(p []byte) (int, error) {
 	if r.off < len(r.first) {
 		n := copy(p, r.first[r.off:])
 		r.off += n
-		if r.off == len(r.first) {
-			close(r.served)
-		}
 		return n, nil
 	}
 	<-r.ctx.Done()
@@ -112,6 +108,32 @@ func (r *blockingReader) Read(p []byte) (int, error) {
 }
 
 func (r *blockingReader) Close() error { return nil }
+
+// deliveredRecorder signals the first byte written to the client.
+//
+// A disconnect test has to cancel after the chunk has been DELIVERED, not after
+// its bytes reached the scanner. Those are two different moments: the stream
+// loop reads, parses, and only then writes to the client, so cancelling on the
+// earlier signal races the write and the stream ends with deliveredBytes == 0.
+// The estimate is computed from delivered bytes, so it comes out as zero, no
+// debit lands, and the assertion fails intermittently for a reason that has
+// nothing to do with the property under test. Signalling on the write removes
+// the window: by then the byte count these tests measure exists.
+type deliveredRecorder struct {
+	*httptest.ResponseRecorder
+	once   sync.Once
+	served chan struct{}
+}
+
+func newDeliveredRecorder() *deliveredRecorder {
+	return &deliveredRecorder{ResponseRecorder: httptest.NewRecorder(), served: make(chan struct{})}
+}
+
+func (d *deliveredRecorder) Write(b []byte) (int, error) {
+	n, err := d.ResponseRecorder.Write(b)
+	d.once.Do(func() { close(d.served) })
+	return n, err
+}
 
 // singleAddTokens returns the one charge recorded against the key.
 // recordTokenUsage always reaches the repo, with 0 when nothing is owed, so a
@@ -212,8 +234,8 @@ func TestHandleStreamingResponse_EstimateDebitsTPMBudget(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
-	served := make(chan struct{})
-	resp := &http.Response{StatusCode: http.StatusOK, Body: &blockingReader{first: contentChunk, ctx: ctx, served: served}}
+	rec := newDeliveredRecorder()
+	resp := &http.Response{StatusCode: http.StatusOK, Body: &blockingReader{first: contentChunk, ctx: ctx}}
 	req := withAuthContext(httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody).WithContext(ctx))
 	logData := &requestLogData{id: uuid.New().String(), modelID: "test-model", streaming: true, virtualKeyName: "test-key", virtualKeyID: "00000000-0000-0000-0000-000000000001", state: "streaming", promptTextBytes: 40}
 	h.insertRequestLogAsync(logData)
@@ -221,10 +243,10 @@ func TestHandleStreamingResponse_EstimateDebitsTPMBudget(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		h.handleStreamingResponse(httptest.NewRecorder(), req, logData, resp, time.Now(), streamOptions{vkHash: "test-hash", attempt: 1, cancelOrigin: "failover_timeout"})
+		h.handleStreamingResponse(rec, req, logData, resp, time.Now(), streamOptions{vkHash: "test-hash", attempt: 1, cancelOrigin: "failover_timeout"})
 		close(done)
 	}()
-	<-served
+	<-rec.served
 	cancel()
 	<-done
 

--- a/wiki/Security.md
+++ b/wiki/Security.md
@@ -316,9 +316,13 @@ This provides smoother handling of bursty traffic while still enforcing limits.
 
 ## Request Size Limiting
 
-All requests are subject to `MAX_REQUEST_SIZE` (default: 50 MB, sized for multipart audio uploads to the `/v1/audio/*` endpoints). The middleware uses `http.MaxBytesReader` which enforces the limit at the stream level - the entire request body is never buffered beyond this limit.
+Two ceilings apply, and the tighter one wins.
 
-Exceeded limits return HTTP 413 (Payload Too Large).
+The gateway's router caps every request at `MAX_REQUEST_SIZE` (default: 50 MB, sized for multipart audio uploads to the `/v1/audio/*` endpoints). The middleware uses `http.MaxBytesReader` which enforces the limit at the stream level - the entire request body is never buffered beyond this limit.
+
+Control-plane JSON routes (the dashboard API, the auth ceremonies, and every Front Desk endpoint) are bounded again at 1 MB, because 50 MB is sized for an audio upload and is the wrong bound for a login body. Two routes carry their own ceiling instead: a config-sync import (8 MB) and the fleet announce heartbeat (1 KB). Front Desk runs as its own binary and mounts no global size middleware, so for its handlers the per-route ceiling is the only one.
+
+Exceeded limits return HTTP 413 (Payload Too Large). A body that is malformed, truncated, or carries anything after its one JSON value returns HTTP 400.
 
 ---
 


### PR DESCRIPTION
## What

Every HTTP handler on the three admin surfaces (`internal/api`, `internal/adminauth`,
`internal/frontdesk`) decoded its request body with a bare
`json.NewDecoder(r.Body).Decode(&x)` and no ceiling of its own.

On the main server that was not unbounded: the router already caps every request at
`MAX_REQUEST_SIZE` (50 MB by default). But 50 MB is sized for the proxy's multimodal uploads, and
it is the wrong bound for a login body. **The Front Desk binary mounts no global cap at all**, so
its handlers really did read as much as a client was willing to send, including on
`POST /api/pair`, the Bellhop pairing exchange, which is unauthenticated by design with only the
per-IP limiter in front of it.

The other routes that answer before authentication: `POST /api/auth/admin-exchange` on both
binaries, and the password, TOTP and WebAuthn ceremonies in `internal/adminauth`.

## How

`httpx.DecodeJSON` binds the body with `http.MaxBytesReader` before decoding, answers **413** past
the limit and **400** for a body that is malformed or carries anything after its one JSON value.
The bound counts bytes rather than trusting `Content-Length`.

Draining what follows the value is what makes the ceiling real rather than nominal: `json.Decoder`
stops the moment it has a complete value, so without the drain a tiny object with a huge tail
decodes fine and never trips the limit. A trailing newline is not a tail.

- Default `httpx.MaxJSONBody` = 1 MiB. The largest legitimate payload on any route using it is a
  full 10 000-ID bulk model delete at roughly 400 KiB, pinned by a test that decodes the real
  worst case through the real helper.
- `decodeJSONLimit` carries the per-endpoint ceilings: config-sync import (8 MiB) and fleet
  announce (1 KiB), both unchanged, plus a new named ceiling for the fleet quota receiver, which
  previously sat at exactly the Front Desk read ceiling that feeds it.
- `DecodeJSONOptional` tolerates an absent body only. A body that arrived and could not be read is
  a 400, not a silent fall back to the default: on `DELETE /api/logs/app` that was the difference
  between clearing an hour of logs and clearing all of them.
- Decode failures are logged as a fixed phrase plus a byte offset, never the decoder error, whose
  message quotes the offending byte. These routes answer before authentication and this gateway
  does not log request content.

## Guard

`internal/httpx/decodeguard_test.go` walks the repository and fails on any
`json.NewDecoder(r.Body)` outside the package that implements the bounded read, skipping comments
and lines that bind the reader in place. Verified to fire on a probe handler planted in `cmd/`.
Its doc states what it does not catch: it matches one call shape, and it says nothing about
whether a given limit is a sensible size.

## Also fixed, found in review

A member's display name had no length cap, and the primary's name rides in every fleet announce
against a 1 KiB ceiling, so a long enough name broke announces fleet-wide and near-silently (the
poller logs a failed announce at debug level only). Capped at 200 characters on both write paths,
rejected rather than truncated, with a test tying the cap to the announce budget.

## Verified

- `go test` on the four touched packages, `golangci-lint run`, `make size-check`, `go build ./...`
- Live on the rebuilt dev stack (app :8081, Front Desk :8090):

  | surface | case | result |
  |---|---|---|
  | MH `/api/auth/admin-exchange` | oversized / malformed / valid | 413 / 400 / 200 |
  | MH `/api/auth/admin-exchange` | valid value + trailing second value | 400 |
  | MH `/api/auth/admin-exchange` | valid value + trailing newline | 200 |
  | MH `/api/providers` (authed) | oversized | 413 |
  | MH `/api/fleet/announce` | 2 KiB body | 413 (1 KiB ceiling intact) |
  | MH `/api/fleet/announce` | tiny value + tail past the ceiling | 413 |
  | MH `DELETE /api/logs/app` | truncated `older_than` | 400, nothing cleared |
  | FD `/api/pair` (unauth) | oversized / malformed / wrong code | 413 / 400 / 401 |
  | FD `POST /api/members` | 250-character name | 400 |

- No client keys off the old error text: nothing in `web/src`, `frontdesk/web/src`, `web-shared`
  or `android/` matches it, and both machine-to-machine consumers (the announce poller, config
  sync, quota distribution) funnel 400 and 413 into the same arm.

## Context

Raised by a Strix AI pentest run. Four other recommendations from the same batch were checked and
rejected: `COOKIE_SECURE` is already `always` by default, blocking `fc00::/7` in `netguard` would
break the internal IPv6 destinations that package exists to reach, the fair-share limiter's 24 h
divisor TTL is a deliberate tradeoff rather than a fail-open, and routing the version check
through `SafeDialer` guards a compile-time constant URL. The Traefik config endpoint was already
gated in #747.
