### PR TITLE
fix: meter oversized passthrough, prune FD sessions, reject future quota stamps

### DIFF
--- a/cmd/frontdesk/main.go
+++ b/cmd/frontdesk/main.go
@@ -130,6 +130,10 @@ func main() {
 	trustedProxies := config.LoadTrustedProxies()
 	ipLimiter := ratelimit.NewIPLimiter(defaultIPRPS, defaultIPBurst, trustedProxies, nil)
 
+	// Prune expired WebAuthn sessions for as long as the process runs. Tied to
+	// ctx so it stops with the rest of the process rather than outliving it.
+	go webauthnSessionCleanupLoop(ctx, frontdesk.NewWebAuthnStore(store))
+
 	srv := frontdesk.NewServer(frontdesk.ServerConfig{
 		Store:          store,
 		Poller:         poller,
@@ -220,6 +224,52 @@ const (
 	defaultIPRPS   = 5
 	defaultIPBurst = 10
 )
+
+// sessionCleanupInterval is how often expired WebAuthn sessions are pruned,
+// matching the gateway's hourly sweep in cmd/server.
+const sessionCleanupInterval = time.Hour
+
+// sessionCleaner is the slice of the WebAuthn store the cleanup loop needs.
+// An interface rather than the concrete store so the loop is testable without
+// a database.
+type sessionCleaner interface {
+	CleanupExpiredSessions(ctx context.Context) (int64, error)
+}
+
+// webauthnSessionCleanupLoop prunes expired WebAuthn sessions until ctx is done.
+//
+// Front Desk had the store method and a SessionManager accessor documented as
+// existing for exactly this wiring, but nothing ever ran it, so the table only
+// grew. That matters here more than on the gateway: the OIDC login start is
+// unauthenticated and writes a session row per request, so anyone able to reach
+// Front Desk could grow its embedded SQLite database without limit.
+//
+// The first sweep runs immediately rather than after a full interval: any
+// deployment upgrading into this fix already carries a backlog, and waiting an
+// hour to touch it serves nobody. A failed sweep is logged and the loop
+// continues, because a transient SQLite error must not disable cleanup for the
+// remaining life of the process.
+func webauthnSessionCleanupLoop(ctx context.Context, store sessionCleaner) {
+	sweep := func() {
+		if n, err := store.CleanupExpiredSessions(ctx); err != nil {
+			debuglog.Error("frontdesk: webauthn session cleanup failed", "error", err)
+		} else if n > 0 {
+			debuglog.Info("frontdesk: cleaned up expired webauthn sessions", "count", n)
+		}
+	}
+
+	sweep()
+	ticker := time.NewTicker(sessionCleanupInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			sweep()
+		}
+	}
+}
 
 // newRelyingParty builds the WebAuthn relying party from PUBLIC_ORIGIN: the RP
 // ID is the hostname and the expected origin is scheme://host.

--- a/cmd/frontdesk/main.go
+++ b/cmd/frontdesk/main.go
@@ -130,10 +130,6 @@ func main() {
 	trustedProxies := config.LoadTrustedProxies()
 	ipLimiter := ratelimit.NewIPLimiter(defaultIPRPS, defaultIPBurst, trustedProxies, nil)
 
-	// Prune expired WebAuthn sessions for as long as the process runs. Tied to
-	// ctx so it stops with the rest of the process rather than outliving it.
-	go webauthnSessionCleanupLoop(ctx, frontdesk.NewWebAuthnStore(store))
-
 	srv := frontdesk.NewServer(frontdesk.ServerConfig{
 		Store:          store,
 		Poller:         poller,
@@ -157,6 +153,14 @@ func main() {
 		// and its normalization with the dashboard so one fleet-wide knob covers
 		// both surfaces.
 		CookieSecure: config.NormalizeCookieSecure(os.Getenv("COOKIE_SECURE")),
+	})
+
+	// Prune expired WebAuthn sessions for as long as the process runs. On the
+	// background group, not a bare goroutine: the drain below has to join it
+	// before Shutdown closes the store, or a sweep mid-DELETE would be reading a
+	// handle that is already closed.
+	srv.StartBackground(ctx, func(c context.Context) {
+		webauthnSessionCleanupLoop(c, frontdesk.NewWebAuthnStore(store))
 	})
 
 	// Every process-lifetime loop runs on the server's background group, so the
@@ -226,8 +230,10 @@ const (
 )
 
 // sessionCleanupInterval is how often expired WebAuthn sessions are pruned,
-// matching the gateway's hourly sweep in cmd/server.
-const sessionCleanupInterval = time.Hour
+// matching the gateway's hourly sweep in cmd/server. A var, not a const, so a
+// test can prove the loop KEEPS sweeping after a failure rather than only that
+// it swept once and exited.
+var sessionCleanupInterval = time.Hour
 
 // sessionCleaner is the slice of the WebAuthn store the cleanup loop needs.
 // An interface rather than the concrete store so the loop is testable without
@@ -252,6 +258,9 @@ type sessionCleaner interface {
 func webauthnSessionCleanupLoop(ctx context.Context, store sessionCleaner) {
 	sweep := func() {
 		if n, err := store.CleanupExpiredSessions(ctx); err != nil {
+			if errors.Is(err, context.Canceled) {
+				return // shutting down, not a fault
+			}
 			debuglog.Error("frontdesk: webauthn session cleanup failed", "error", err)
 		} else if n > 0 {
 			debuglog.Info("frontdesk: cleaned up expired webauthn sessions", "count", n)

--- a/cmd/frontdesk/main_test.go
+++ b/cmd/frontdesk/main_test.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/hugalafutro/model-hotel/internal/config"
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
@@ -83,4 +85,93 @@ func TestWarnWeakMasterKey(t *testing.T) {
 	if len(rec.records) != 0 {
 		t.Errorf("strong key: unexpected log %q", rec.records[0].Message)
 	}
+}
+
+// fakeSessionCleaner records sweeps and can fail on demand.
+type fakeSessionCleaner struct {
+	mu      sync.Mutex
+	calls   int
+	removed int64
+	err     error
+}
+
+func (f *fakeSessionCleaner) CleanupExpiredSessions(context.Context) (int64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	return f.removed, f.err
+}
+
+func (f *fakeSessionCleaner) count() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+// TestWebauthnSessionCleanupLoop_SweepsImmediately covers the gap this exists to
+// close. The gateway prunes expired WebAuthn sessions hourly; Front Desk had the
+// store method and an accessor documented as being "used by callers wiring
+// background cleanup of expired sessions", and nothing ever called it. Front
+// Desk's OIDC login start is unauthenticated and writes a session row per
+// request, so the table only ever grew.
+//
+// The sweep runs once at startup rather than waiting a full interval, because
+// any Front Desk upgrading into this fix already carries a backlog that a
+// tick-first loop would leave in place until the next hour.
+func TestWebauthnSessionCleanupLoop_SweepsImmediately(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	c := &fakeSessionCleaner{removed: 3}
+
+	done := make(chan struct{})
+	go func() {
+		webauthnSessionCleanupLoop(ctx, c)
+		close(done)
+	}()
+
+	waitForSweeps(t, c, 1)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("cleanup loop did not return after context cancel")
+	}
+}
+
+// TestWebauthnSessionCleanupLoop_SurvivesStoreError keeps one failed sweep from
+// ending the loop: a transient SQLite error must not silently disable cleanup
+// for the rest of the process's life, which is the failure mode that would
+// recreate the unbounded growth this fixes.
+func TestWebauthnSessionCleanupLoop_SurvivesStoreError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	c := &fakeSessionCleaner{err: errors.New("database is locked")}
+
+	done := make(chan struct{})
+	go func() {
+		webauthnSessionCleanupLoop(ctx, c)
+		close(done)
+	}()
+
+	waitForSweeps(t, c, 1)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("cleanup loop did not return after a failing sweep")
+	}
+}
+
+func waitForSweeps(t *testing.T, c *fakeSessionCleaner, want int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if c.count() >= want {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("cleanup ran %d times, want at least %d", c.count(), want)
 }

--- a/cmd/frontdesk/main_test.go
+++ b/cmd/frontdesk/main_test.go
@@ -143,7 +143,15 @@ func TestWebauthnSessionCleanupLoop_SweepsImmediately(t *testing.T) {
 // ending the loop: a transient SQLite error must not silently disable cleanup
 // for the rest of the process's life, which is the failure mode that would
 // recreate the unbounded growth this fixes.
+//
+// It waits for SEVERAL sweeps on a shortened interval. Waiting for one would
+// pass against a loop that bailed out on its first error, which is exactly the
+// implementation the test is supposed to reject.
 func TestWebauthnSessionCleanupLoop_SurvivesStoreError(t *testing.T) {
+	restore := sessionCleanupInterval
+	sessionCleanupInterval = 5 * time.Millisecond
+	t.Cleanup(func() { sessionCleanupInterval = restore })
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	c := &fakeSessionCleaner{err: errors.New("database is locked")}
@@ -154,13 +162,47 @@ func TestWebauthnSessionCleanupLoop_SurvivesStoreError(t *testing.T) {
 		close(done)
 	}()
 
-	waitForSweeps(t, c, 1)
+	waitForSweeps(t, c, 3)
 	cancel()
 
 	select {
 	case <-done:
 	case <-time.After(2 * time.Second):
 		t.Fatal("cleanup loop did not return after a failing sweep")
+	}
+}
+
+// TestWebauthnSessionCleanupLoop_ShutdownIsNotAFault pins the quiet half.
+// Shutdown cancels the context while the loop is registered on the server's
+// background group, so a sweep racing the drain gets its query cancelled. That
+// is the ordinary way this loop ends and it must not be reported as a failure,
+// or every clean shutdown would log an error.
+func TestWebauthnSessionCleanupLoop_ShutdownIsNotAFault(t *testing.T) {
+	logs := &recordingHandler{}
+	prev := slog.Default()
+	debuglog.SetHandler(logs)
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // shutdown has already begun when the sweep runs
+
+	done := make(chan struct{})
+	go func() {
+		webauthnSessionCleanupLoop(ctx, &fakeSessionCleaner{err: context.Canceled})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("loop did not return once the context was cancelled")
+	}
+	logs.mu.Lock()
+	defer logs.mu.Unlock()
+	for _, r := range logs.records {
+		if r.Level >= slog.LevelError {
+			t.Errorf("clean shutdown logged an error: %q", r.Message)
+		}
 	}
 }
 

--- a/internal/api/quota_drift.go
+++ b/internal/api/quota_drift.go
@@ -93,7 +93,10 @@ func driftEligible(s quota.Snapshot, maxAge time.Duration, now time.Time) bool {
 	if maxAge <= 0 || s.HTTPStatus != http.StatusOK || len(s.Payload) == 0 {
 		return false
 	}
-	return now.Sub(s.FetchedAt) <= maxAge
+	// Negative age (a future stamp) is untrustworthy, not eligible: see
+	// snapshotWithinAge. This is the same field and the same repository feed as
+	// the two staleness checks in quota_snapshot.go.
+	return snapshotWithinAge(now, s.FetchedAt, maxAge)
 }
 
 // driftDecision is the whole per-provider decision, kept pure so the debounce

--- a/internal/api/quota_snapshot.go
+++ b/internal/api/quota_snapshot.go
@@ -14,6 +14,32 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/quota"
 )
 
+// snapshotFresherThan and snapshotWithinAge exist so a future-dated snapshot can
+// never read as fresh.
+//
+// Both questions used to be asked with a bare time.Since/Sub comparison, which
+// returns a NEGATIVE duration when the stamp is in the future. Negative
+// satisfies every "< interval" and fails every "> maxAge", so a single
+// future-dated row silently made a provider permanently fresh: its upstream poll
+// was skipped forever, and its stale quota kept counting as evidence. The
+// repository now clamps on write, so these guards are defence in depth for rows
+// that predate the clamp or arrive by another path (a direct database write, a
+// restored backup).
+//
+// Same class of bug, and the same repair, as the fleet rate-limit divisor's
+// staleness check: treat a negative age as untrustworthy rather than as fresh.
+func snapshotFresherThan(now, fetchedAt time.Time, within time.Duration) bool {
+	age := now.Sub(fetchedAt)
+	return age >= 0 && age < within
+}
+
+// snapshotWithinAge reports whether a snapshot is recent enough to be trusted as
+// evidence. A future stamp is not.
+func snapshotWithinAge(now, fetchedAt time.Time, maxAge time.Duration) bool {
+	age := now.Sub(fetchedAt)
+	return age >= 0 && age <= maxAge
+}
+
 // quotaKindFor maps a provider type to the snapshot kind it produces, or
 // ok=false when the type exposes no quota/usage/balance/account endpoint.
 func quotaKindFor(providerType string) (string, bool) {
@@ -144,7 +170,7 @@ func (h *Handler) PollQuotasOnce(ctx context.Context) {
 		// never worse than standalone.
 		interval := time.Duration(h.settingsRepo.GetInt(ctx, "quota_refresh_interval_min", 5)) * time.Minute
 		if interval > 0 {
-			if snap, _ := h.quotaRepo.Get(ctx, prov.ID, kind); snap != nil && snap.Source == "fleet" && time.Since(snap.FetchedAt) < interval {
+			if snap, _ := h.quotaRepo.Get(ctx, prov.ID, kind); snap != nil && snap.Source == "fleet" && snapshotFresherThan(time.Now(), snap.FetchedAt, interval) {
 				continue
 			}
 		}
@@ -441,7 +467,7 @@ func buildQuotaAdvice(
 		return advice, recovered
 	}
 	for _, s := range snaps {
-		if now.Sub(s.FetchedAt) > maxAge {
+		if !snapshotWithinAge(now, s.FetchedAt, maxAge) {
 			continue
 		}
 		a := quota.Assess(typeByID[s.ProviderID], s)

--- a/internal/api/quota_staleness_test.go
+++ b/internal/api/quota_staleness_test.go
@@ -1,0 +1,56 @@
+package api
+
+import (
+	"testing"
+	"time"
+)
+
+// TestSnapshotFreshness_FutureStampIsNeverFresh is the bug these guards exist
+// for. time.Since and Sub return a NEGATIVE duration for a future timestamp,
+// which satisfies every "< interval" test and fails every "> maxAge" test, so a
+// single future-dated snapshot made a provider permanently fresh: its upstream
+// poll was skipped forever and its stale quota kept counting as evidence.
+//
+// The same mistake was found and fixed once already in the fleet rate-limit
+// divisor. These cases pin the repair at the two remaining sites.
+func TestSnapshotFreshness_FutureStampIsNeverFresh(t *testing.T) {
+	now := time.Now()
+
+	for _, tc := range []struct {
+		name       string
+		fetchedAt  time.Time
+		wantFresh  bool
+		wantWithin bool
+	}{
+		{"just fetched", now, true, true},
+		{"comfortably recent", now.Add(-1 * time.Minute), true, true},
+		{"older than the window", now.Add(-30 * time.Minute), false, false},
+		{"one second in the future", now.Add(1 * time.Second), false, false},
+		{"far in the future", now.Add(48 * time.Hour), false, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := snapshotFresherThan(now, tc.fetchedAt, 5*time.Minute); got != tc.wantFresh {
+				t.Errorf("snapshotFresherThan = %v, want %v", got, tc.wantFresh)
+			}
+			if got := snapshotWithinAge(now, tc.fetchedAt, 5*time.Minute); got != tc.wantWithin {
+				t.Errorf("snapshotWithinAge = %v, want %v", got, tc.wantWithin)
+			}
+		})
+	}
+}
+
+// TestSnapshotFreshness_BoundariesUnchanged keeps the guards from quietly
+// shifting the windows they replaced: the dedup check was strictly-less-than and
+// the evidence check kept a snapshot at exactly maxAge.
+func TestSnapshotFreshness_BoundariesUnchanged(t *testing.T) {
+	now := time.Now()
+	const window = 5 * time.Minute
+	atWindow := now.Add(-window)
+
+	if snapshotFresherThan(now, atWindow, window) {
+		t.Error("snapshotFresherThan at exactly the window = true, want false (was <, not <=)")
+	}
+	if !snapshotWithinAge(now, atWindow, window) {
+		t.Error("snapshotWithinAge at exactly maxAge = false, want true (was >, so equal was kept)")
+	}
+}

--- a/internal/api/quota_staleness_test.go
+++ b/internal/api/quota_staleness_test.go
@@ -1,8 +1,11 @@
 package api
 
 import (
+	"net/http"
 	"testing"
 	"time"
+
+	"github.com/hugalafutro/model-hotel/internal/quota"
 )
 
 // TestSnapshotFreshness_FutureStampIsNeverFresh is the bug these guards exist
@@ -52,5 +55,33 @@ func TestSnapshotFreshness_BoundariesUnchanged(t *testing.T) {
 	}
 	if !snapshotWithinAge(now, atWindow, window) {
 		t.Error("snapshotWithinAge at exactly maxAge = false, want true (was >, so equal was kept)")
+	}
+}
+
+// TestDriftEligible_FutureStampIsNotEligible pins the guard at its call site
+// rather than only on the helper. driftEligible was the third site with this
+// bug and was missed by the first pass at the fix, so a helper-only test would
+// have gone on passing while the site itself stayed broken.
+func TestDriftEligible_FutureStampIsNotEligible(t *testing.T) {
+	now := time.Now()
+	const maxAge = 15 * time.Minute
+	ok := quota.Snapshot{HTTPStatus: http.StatusOK, Payload: []byte(`{"a":1}`)}
+
+	fresh := ok
+	fresh.FetchedAt = now.Add(-1 * time.Minute)
+	if !driftEligible(fresh, maxAge, now) {
+		t.Error("a recent snapshot should be drift-eligible")
+	}
+
+	stale := ok
+	stale.FetchedAt = now.Add(-1 * time.Hour)
+	if driftEligible(stale, maxAge, now) {
+		t.Error("an old snapshot should not be drift-eligible")
+	}
+
+	future := ok
+	future.FetchedAt = now.Add(48 * time.Hour)
+	if driftEligible(future, maxAge, now) {
+		t.Error("a future-dated snapshot is drift-eligible forever; the negative-age guard is missing at this site")
 	}
 }

--- a/internal/frontdesk/backups.go
+++ b/internal/frontdesk/backups.go
@@ -128,7 +128,14 @@ func (s *Server) checkMemberBackups(ctx context.Context) {
 			continue
 		}
 		newest, found := newestScheduledBackup(entries)
-		if !found || time.Since(newest) > memberBackupStaleAfter {
+		// The timestamp is parsed straight out of the member's own listing, so a
+		// member with a fast clock (or a bad created_at) can report a backup
+		// dated in the future. time.Since then returns a NEGATIVE duration,
+		// which never exceeds the threshold, so the staleness alert would be
+		// permanently silenced for exactly the member most likely to be
+		// misconfigured. An impossible age is treated as stale, not as fresh.
+		age := time.Since(newest)
+		if !found || age < 0 || age > memberBackupStaleAfter {
 			s.markBackupStale(ctx, m, newest, found)
 			continue
 		}

--- a/internal/frontdesk/server.go
+++ b/internal/frontdesk/server.go
@@ -413,8 +413,14 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	return s.store.Close()
 }
 
-// SessionManager exposes the session manager (used by callers wiring background
-// cleanup of expired sessions).
+// SessionManager exposes the session manager for tests that need to mint or
+// inspect sessions directly.
+//
+// It used to claim it existed for "callers wiring background cleanup of expired
+// sessions". No such caller was ever written, and the cleanup that eventually
+// arrived (cmd/frontdesk) builds its own WebAuthnStore over the same database
+// instead, since it needs the store's cleanup method rather than the manager.
+// The comment is corrected rather than the accessor deleted: the tests use it.
 func (s *Server) SessionManager() *webauthn.SessionManager { return s.sessionMgr }
 
 func (s *Server) buildRouter(wa *adminauth.WebAuthnHandler, tp *adminauth.TotpHandler, oidc *adminauth.OIDCHandler, ui fs.FS) http.Handler {

--- a/internal/proxy/helpers.go
+++ b/internal/proxy/helpers.go
@@ -335,8 +335,11 @@ func breakerRecordAction(statusCode int) breakerAction {
 // least one token. The ratio is tuned for Latin text; multi-byte scripts run
 // closer to one token per character and estimate low.
 func estimateTokens(textBytes int) int {
-	return (textBytes + 3) / 4
+	return (textBytes + bytesPerToken - 1) / bytesPerToken
 }
+
+// bytesPerToken is the conventional text-to-token ratio the estimates above use.
+const bytesPerToken = 4
 
 // estimateMissingUsage fills in token counts the provider did not report, so a
 // request that delivered output is always charged against the TPM budget and
@@ -366,6 +369,94 @@ func estimateMissingUsage(promptTokens, completionTokens, reasoningTokens int, l
 	}
 	debuglog.Info("proxy: charging estimated tokens for usage the provider did not report", "model", logData.modelID, "provider", logData.providerName, "prompt_estimated", promptEstimated, "completion_estimated", completionEstimated, "prompt_text_bytes", logData.promptTextBytes, "delivered_bytes", deliveredBytes, "prompt_tokens", promptTokens, "completion_tokens", completionTokens, "reasoning_tokens", reasoningTokens)
 	return promptTokens, completionTokens, reasoningTokens
+}
+
+// passthroughPromptTextBytes sizes the prompt text of a multimodal pass-through
+// request body, the way promptTextBytes does for a chat body. Those endpoints
+// carry no "messages", so promptTextBytes sizes every one of them as zero and
+// any estimate derived from it is silently no charge at all.
+//
+// Only text is counted, never a file or a blob: an audio upload or a base64
+// image is orders of magnitude larger than the tokens it costs, and sizing it
+// by bytes would invent a colossal charge. That is the same rule promptTextBytes
+// applies when it skips image_url and input_audio parts.
+//
+// Embeddings input may also arrive pre-tokenised as arrays of token ids. Those
+// are a token count already, so they are converted back to the byte scale the
+// caller divides by (bytesPerToken) rather than measured as JSON text, which
+// would charge for the digits.
+func passthroughPromptTextBytes(body []byte, endpointType string) int {
+	switch endpointType {
+	case endpointTypeEmbeddings:
+		return embeddingsInputBytes(body)
+	case endpointTypeRerank:
+		var req struct {
+			Query     string   `json:"query"`
+			Documents []string `json:"documents"`
+		}
+		if json.Unmarshal(body, &req) != nil {
+			return 0
+		}
+		n := len(req.Query)
+		for _, d := range req.Documents {
+			n += len(d)
+		}
+		return n
+	case endpointTypeImage, endpointTypeTTS:
+		// Image generation prompts and text-to-speech input are both a single
+		// text field; TTS uses "input", images use "prompt".
+		var req struct {
+			Prompt string `json:"prompt"`
+			Input  string `json:"input"`
+		}
+		if json.Unmarshal(body, &req) != nil {
+			return 0
+		}
+		return len(req.Prompt) + len(req.Input)
+	default:
+		// Multipart families (speech-to-text, image edits) carry their payload
+		// as an uploaded file, which has no honest text size, so they are left
+		// unsized rather than guessed at.
+		return 0
+	}
+}
+
+// embeddingsInputBytes sizes an embeddings "input", which the OpenAI schema
+// allows as a string, an array of strings, an array of token ids, or an array of
+// token-id arrays.
+func embeddingsInputBytes(body []byte) int {
+	var req struct {
+		Input json.RawMessage `json:"input"`
+	}
+	if json.Unmarshal(body, &req) != nil || len(req.Input) == 0 {
+		return 0
+	}
+	var text string
+	if json.Unmarshal(req.Input, &text) == nil {
+		return len(text)
+	}
+	var texts []string
+	if json.Unmarshal(req.Input, &texts) == nil {
+		n := 0
+		for _, t := range texts {
+			n += len(t)
+		}
+		return n
+	}
+	// Pre-tokenised: a flat token array, or one array per input.
+	var tokens []int
+	if json.Unmarshal(req.Input, &tokens) == nil {
+		return len(tokens) * bytesPerToken
+	}
+	var batches [][]int
+	if json.Unmarshal(req.Input, &batches) == nil {
+		n := 0
+		for _, b := range batches {
+			n += len(b)
+		}
+		return n * bytesPerToken
+	}
+	return 0
 }
 
 // promptTextBytes sizes the prompt text of an OpenAI-shaped request body: the

--- a/internal/proxy/multimodal.go
+++ b/internal/proxy/multimodal.go
@@ -88,6 +88,11 @@ func (h *Handler) serveJSONPassthrough(w http.ResponseWriter, r *http.Request, e
 	}
 	st.endpointPath = endpointPath
 	st.longRunning = isLongRunningEndpoint(endpointType)
+	// ingestRequest sizes the prompt with the chat rule, which finds no
+	// "messages" in these bodies and so returns zero for every one of them.
+	// Size them by their own shape instead, or the metering estimate below is
+	// silently no charge at all.
+	st.logData.promptTextBytes = passthroughPromptTextBytes(st.bodyBytes, endpointType)
 	st.makeUpstreamBody = makeJSONModelRewriter(st.bodyBytes, st.reqModel)
 	h.servePassthroughPipeline(w, r, st)
 }
@@ -409,12 +414,17 @@ func (h *Handler) serveBufferedJSONPassthrough(w http.ResponseWriter, st *reques
 		// roughly two million completion tokens for one 8 MiB embeddings
 		// response. Undercharging the output is the deliberate choice, and it
 		// is still strictly better than charging nothing.
-		promptTokens := estimateTokens(logData.promptTextBytes)
-		h.finalizePassthroughLog(st, resp.StatusCode, attempt, responseHeaderMs, promptTokens, 0, "completed", "")
-		if promptTokens > 0 {
-			h.recordTokenUsage(st.vkHash, logData, promptTokens, 0, 0)
+		// The log keeps the provider's figures, which here are none: usage was
+		// never extracted, so nothing was measured. The estimate charges the
+		// quota WITHOUT being reported as measured usage, matching what the
+		// chat and streaming paths do (they update the log before calling
+		// estimateMissingUsage) and keeping the stats pages honest.
+		estimated := estimateTokens(logData.promptTextBytes)
+		h.finalizePassthroughLog(st, resp.StatusCode, attempt, responseHeaderMs, 0, 0, "completed", "")
+		if estimated > 0 {
+			h.recordTokenUsage(st.vkHash, logData, estimated, 0, 0)
 		}
-		debuglog.Info("proxy: passthrough completed (oversized json)", "endpoint", logData.endpointType, "model", logData.modelID, "provider", logData.providerName, "attempt", attempt, "status", resp.StatusCode, "bytes", written, "prompt_tokens", promptTokens, "prompt_estimated", true)
+		debuglog.Info("proxy: passthrough completed (oversized json)", "endpoint", logData.endpointType, "model", logData.modelID, "provider", logData.providerName, "attempt", attempt, "status", resp.StatusCode, "bytes", written, "estimated_prompt_tokens", estimated)
 		return
 	}
 

--- a/internal/proxy/multimodal.go
+++ b/internal/proxy/multimodal.go
@@ -396,8 +396,25 @@ func (h *Handler) serveBufferedJSONPassthrough(w http.ResponseWriter, st *reques
 			written += n
 			_ = ew.Flush()
 		}
-		h.finalizePassthroughLog(st, resp.StatusCode, attempt, responseHeaderMs, 0, 0, "completed", "")
-		debuglog.Info("proxy: passthrough completed (oversized json)", "endpoint", logData.endpointType, "model", logData.modelID, "provider", logData.providerName, "attempt", attempt, "status", resp.StatusCode, "bytes", written)
+		// Skipping usage EXTRACTION must not mean skipping metering: the
+		// provider billed for this request and the client got the whole
+		// response, so recording (0,0) here charged it against nothing — not
+		// the key's tokens_used counter, not its TPM budget. The cap is 8 MiB
+		// and a batch embeddings call clears it at around 140 inputs, so the
+		// free requests were the routine ones, not the exotic ones.
+		//
+		// Only the prompt is estimated. The streaming path derives output from
+		// delivered bytes because those bytes are text; here they are float
+		// vectors or base64 image data, so the same arithmetic would invent
+		// roughly two million completion tokens for one 8 MiB embeddings
+		// response. Undercharging the output is the deliberate choice, and it
+		// is still strictly better than charging nothing.
+		promptTokens := estimateTokens(logData.promptTextBytes)
+		h.finalizePassthroughLog(st, resp.StatusCode, attempt, responseHeaderMs, promptTokens, 0, "completed", "")
+		if promptTokens > 0 {
+			h.recordTokenUsage(st.vkHash, logData, promptTokens, 0, 0)
+		}
+		debuglog.Info("proxy: passthrough completed (oversized json)", "endpoint", logData.endpointType, "model", logData.modelID, "provider", logData.providerName, "attempt", attempt, "status", resp.StatusCode, "bytes", written, "prompt_tokens", promptTokens, "prompt_estimated", true)
 		return
 	}
 

--- a/internal/proxy/passthrough_metering_test.go
+++ b/internal/proxy/passthrough_metering_test.go
@@ -1,0 +1,154 @@
+package proxy
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/hugalafutro/model-hotel/internal/model"
+	"github.com/hugalafutro/model-hotel/internal/provider"
+)
+
+// oversizedPassthroughBody returns a JSON body one byte past the buffer cap, the
+// shape that sends serveBufferedJSONPassthrough down its streaming branch.
+// Deliberately built at the real cap rather than against a lowered test
+// constant: the branch is chosen by comparing against passthroughJSONBufferCap
+// itself, so a test that shrinks the cap would not exercise the same decision.
+func oversizedPassthroughBody() string {
+	return `{"data":"` + strings.Repeat("a", passthroughJSONBufferCap) + `"}`
+}
+
+func passthroughCandidate() modelCandidate {
+	return modelCandidate{
+		model:    &model.Model{ID: uuid.New(), ModelID: "text-embedding-x"},
+		provider: &provider.Provider{ID: uuid.New(), Name: "test-provider"},
+	}
+}
+
+// TestPassthrough_OversizedJSONIsStillMetered is the metering hole itself. The
+// oversized branch forwards a complete provider response to the client and then
+// finalized the log with (0,0) tokens and never called recordTokenUsage, so the
+// request was charged against nothing: not the key's tokens_used counter, not
+// its TPM budget.
+//
+// This is not an exotic path. The buffer cap is 8 MiB and a batch embeddings
+// call clears it at roughly 140 inputs of 3072 dimensions, which is ordinary
+// document-indexing traffic, so the free requests are the routine ones.
+func TestPassthrough_OversizedJSONIsStillMetered(t *testing.T) {
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+	vkRepo := &mockVirtualKeyRepo{}
+	h.virtualKeyRepo = vkRepo
+
+	logData := &requestLogData{
+		id:              uuid.New().String(),
+		modelID:         "text-embedding-x",
+		endpointType:    endpointTypeEmbeddings,
+		virtualKeyName:  "test-key",
+		virtualKeyID:    "00000000-0000-0000-0000-000000000001",
+		state:           "streaming",
+		promptTextBytes: 400,
+	}
+	st := &requestState{startTime: time.Now(), logData: logData, vkHash: "test-hash"}
+	h.insertRequestLogAsync(logData)
+	time.Sleep(20 * time.Millisecond)
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(oversizedPassthroughBody())),
+	}
+	rec := httptest.NewRecorder()
+	h.serveBufferedJSONPassthrough(rec, st, passthroughCandidate(), resp, "application/json", 1, 10.0)
+
+	// 400 prompt bytes at the conventional 4 bytes per token.
+	const wantPrompt = 100
+	if logData.tokensPrompt != wantPrompt {
+		t.Errorf("logged prompt tokens = %d, want %d (estimated from promptTextBytes)", logData.tokensPrompt, wantPrompt)
+	}
+	if got := singleAddTokens(t, vkRepo); got != wantPrompt {
+		t.Errorf("charged %d tokens against the key, want %d", got, wantPrompt)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+}
+
+// TestPassthrough_OversizedJSONDoesNotEstimateFromResponseBytes pins the half of
+// the estimate that must NOT happen here. The streaming path estimates output
+// from delivered bytes because those bytes are text, but a pass-through response
+// is float vectors or base64 image data: charging 8 MiB of embedding floats at
+// four bytes per token would invent roughly two million completion tokens.
+// Undercharging the output is the deliberate choice; inventing it is not.
+func TestPassthrough_OversizedJSONDoesNotEstimateFromResponseBytes(t *testing.T) {
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+	h.virtualKeyRepo = &mockVirtualKeyRepo{}
+
+	logData := &requestLogData{
+		id:              uuid.New().String(),
+		modelID:         "text-embedding-x",
+		endpointType:    endpointTypeEmbeddings,
+		virtualKeyName:  "test-key",
+		virtualKeyID:    "00000000-0000-0000-0000-000000000001",
+		state:           "streaming",
+		promptTextBytes: 400,
+	}
+	st := &requestState{startTime: time.Now(), logData: logData, vkHash: "test-hash"}
+	h.insertRequestLogAsync(logData)
+	time.Sleep(20 * time.Millisecond)
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(oversizedPassthroughBody())),
+	}
+	h.serveBufferedJSONPassthrough(httptest.NewRecorder(), st, passthroughCandidate(), resp, "application/json", 1, 10.0)
+
+	if logData.tokensCompletion != 0 {
+		t.Errorf("completion tokens = %d, want 0; response bytes are not text and must not be estimated as tokens", logData.tokensCompletion)
+	}
+}
+
+// TestPassthrough_OversizedJSONWithNoPromptChargesNothing keeps the estimate
+// honest in the other direction: with no prompt text recorded there is nothing
+// to derive a charge from, and inventing one would bill a key for a request
+// whose size the gateway never measured.
+func TestPassthrough_OversizedJSONWithNoPromptChargesNothing(t *testing.T) {
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+	vkRepo := &mockVirtualKeyRepo{}
+	h.virtualKeyRepo = vkRepo
+
+	logData := &requestLogData{
+		id:              uuid.New().String(),
+		modelID:         "text-embedding-x",
+		endpointType:    endpointTypeEmbeddings,
+		virtualKeyName:  "test-key",
+		virtualKeyID:    "00000000-0000-0000-0000-000000000001",
+		state:           "streaming",
+		promptTextBytes: 0,
+	}
+	st := &requestState{startTime: time.Now(), logData: logData, vkHash: "test-hash"}
+	h.insertRequestLogAsync(logData)
+	time.Sleep(20 * time.Millisecond)
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(oversizedPassthroughBody())),
+	}
+	h.serveBufferedJSONPassthrough(httptest.NewRecorder(), st, passthroughCandidate(), resp, "application/json", 1, 10.0)
+
+	if logData.tokensPrompt != 0 || logData.tokensCompletion != 0 {
+		t.Errorf("usage = (%d,%d), want (0,0) when no prompt bytes were measured", logData.tokensPrompt, logData.tokensCompletion)
+	}
+	if len(vkRepo.addTokensCalls) != 0 {
+		t.Errorf("charged the key %d times, want 0", len(vkRepo.addTokensCalls))
+	}
+}

--- a/internal/proxy/passthrough_metering_test.go
+++ b/internal/proxy/passthrough_metering_test.go
@@ -14,37 +14,131 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/provider"
 )
 
-// oversizedPassthroughBody returns a JSON body one byte past the buffer cap, the
-// shape that sends serveBufferedJSONPassthrough down its streaming branch.
-// Deliberately built at the real cap rather than against a lowered test
-// constant: the branch is chosen by comparing against passthroughJSONBufferCap
-// itself, so a test that shrinks the cap would not exercise the same decision.
-func oversizedPassthroughBody() string {
-	return `{"data":"` + strings.Repeat("a", passthroughJSONBufferCap) + `"}`
-}
-
-func passthroughCandidate() modelCandidate {
-	return modelCandidate{
-		model:    &model.Model{ID: uuid.New(), ModelID: "text-embedding-x"},
-		provider: &provider.Provider{ID: uuid.New(), Name: "test-provider"},
+// TestPassthroughPromptTextBytes_SizesRealBodies is the test the first attempt
+// at this fix should have had. That attempt estimated the prompt from
+// logData.promptTextBytes, which ingestRequest fills using the CHAT rule: it
+// looks for "messages" and "tools", finds neither in any pass-through body, and
+// returns zero. The estimate was therefore always zero and the fix charged
+// nothing, while a unit test that hand-set promptTextBytes on a fabricated
+// logData reported success.
+//
+// These are the real request shapes, so a regression back to the chat-only
+// sizer fails here instead of passing.
+func TestPassthroughPromptTextBytes_SizesRealBodies(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		endpointType string
+		body         string
+		want         int
+	}{
+		{
+			name:         "embeddings single string",
+			endpointType: endpointTypeEmbeddings,
+			body:         `{"model":"text-embedding-3","input":"hello world"}`,
+			want:         11,
+		},
+		{
+			name:         "embeddings batch",
+			endpointType: endpointTypeEmbeddings,
+			body:         `{"model":"text-embedding-3","input":["abcd","efghij"]}`,
+			want:         10,
+		},
+		{
+			name:         "embeddings pre-tokenised",
+			endpointType: endpointTypeEmbeddings,
+			body:         `{"model":"text-embedding-3","input":[1,2,3]}`,
+			want:         3 * bytesPerToken,
+		},
+		{
+			name:         "embeddings pre-tokenised batches",
+			endpointType: endpointTypeEmbeddings,
+			body:         `{"model":"text-embedding-3","input":[[1,2],[3,4,5]]}`,
+			want:         5 * bytesPerToken,
+		},
+		{
+			name:         "rerank query and documents",
+			endpointType: endpointTypeRerank,
+			body:         `{"model":"rerank-1","query":"abc","documents":["de","fgh"]}`,
+			want:         8,
+		},
+		{
+			name:         "image prompt",
+			endpointType: endpointTypeImage,
+			body:         `{"model":"dall-e-3","prompt":"a red cube"}`,
+			want:         10,
+		},
+		{
+			name:         "tts input",
+			endpointType: endpointTypeTTS,
+			body:         `{"model":"tts-1","input":"say this","voice":"alloy"}`,
+			want:         8,
+		},
+		{
+			name:         "multipart family is not guessed at",
+			endpointType: endpointTypeSTT,
+			body:         `{"model":"whisper-1"}`,
+			want:         0,
+		},
+		{
+			name:         "unparseable body sizes as zero",
+			endpointType: endpointTypeEmbeddings,
+			body:         `not json`,
+			want:         0,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := passthroughPromptTextBytes([]byte(tc.body), tc.endpointType); got != tc.want {
+				t.Errorf("passthroughPromptTextBytes = %d, want %d", got, tc.want)
+			}
+		})
 	}
 }
 
-// TestPassthrough_OversizedJSONIsStillMetered is the metering hole itself. The
-// oversized branch forwards a complete provider response to the client and then
-// finalized the log with (0,0) tokens and never called recordTokenUsage, so the
-// request was charged against nothing: not the key's tokens_used counter, not
-// its TPM budget.
+// TestPassthroughPromptTextBytes_IgnoresBlobs keeps the sizer from doing the one
+// thing that would be worse than undercharging. A base64 image or an audio blob
+// is orders of magnitude larger than the tokens it costs, so sizing it by bytes
+// would invent an enormous charge. promptTextBytes already refuses to measure
+// image_url and input_audio parts for the same reason.
+func TestPassthroughPromptTextBytes_IgnoresBlobs(t *testing.T) {
+	blob := strings.Repeat("A", 4096) // stands in for a base64 image payload
+	body := `{"model":"dall-e-3","prompt":"tiny","image":"` + blob + `"}`
+	got := passthroughPromptTextBytes([]byte(body), endpointTypeImage)
+	if got != len("tiny") {
+		t.Errorf("sized = %d, want %d: only the prompt text may be measured", got, len("tiny"))
+	}
+}
+
+// TestEstimateTokens_UsesTheDocumentedRatio pins the conversion the sizer feeds,
+// so the pre-tokenised branch above stays in the same unit as the text branches.
+func TestEstimateTokens_UsesTheDocumentedRatio(t *testing.T) {
+	if got := estimateTokens(bytesPerToken * 3); got != 3 {
+		t.Errorf("estimateTokens(%d) = %d, want 3", bytesPerToken*3, got)
+	}
+	if got := estimateTokens(1); got != 1 {
+		t.Errorf("estimateTokens(1) = %d, want 1 (any delivered text costs at least one token)", got)
+	}
+	if got := estimateTokens(0); got != 0 {
+		t.Errorf("estimateTokens(0) = %d, want 0", got)
+	}
+}
+
+// TestPassthrough_OversizedJSONChargesTheEstimate is the end-to-end half: the
+// oversized branch forwards a complete provider response, and must charge the
+// caller's quota for it rather than nothing. The prompt size is derived from a
+// real embeddings body through the same sizer serveJSONPassthrough uses, so the
+// test cannot pass on a value production would never produce.
 //
-// This is not an exotic path. The buffer cap is 8 MiB and a batch embeddings
-// call clears it at roughly 140 inputs of 3072 dimensions, which is ordinary
-// document-indexing traffic, so the free requests are the routine ones.
-func TestPassthrough_OversizedJSONIsStillMetered(t *testing.T) {
+// The request LOG stays at zero on purpose. Usage was never extracted here, so
+// nothing was measured, and the log reports measured usage only — the estimate
+// charges the quota without being reported as a provider figure, exactly as the
+// chat and streaming paths do it.
+func TestPassthrough_OversizedJSONChargesTheEstimate(t *testing.T) {
 	h := newIntegrationHandler()
 	t.Cleanup(func() { stopUnitHandler(h) })
 	vkRepo := &mockVirtualKeyRepo{}
 	h.virtualKeyRepo = vkRepo
 
+	reqBody := `{"model":"text-embedding-3","input":"` + strings.Repeat("d", 400) + `"}`
 	logData := &requestLogData{
 		id:              uuid.New().String(),
 		modelID:         "text-embedding-x",
@@ -52,7 +146,10 @@ func TestPassthrough_OversizedJSONIsStillMetered(t *testing.T) {
 		virtualKeyName:  "test-key",
 		virtualKeyID:    "00000000-0000-0000-0000-000000000001",
 		state:           "streaming",
-		promptTextBytes: 400,
+		promptTextBytes: passthroughPromptTextBytes([]byte(reqBody), endpointTypeEmbeddings),
+	}
+	if logData.promptTextBytes != 400 {
+		t.Fatalf("sizer produced %d bytes for the probe body, want 400", logData.promptTextBytes)
 	}
 	st := &requestState{startTime: time.Now(), logData: logData, vkHash: "test-hash"}
 	h.insertRequestLogAsync(logData)
@@ -61,94 +158,23 @@ func TestPassthrough_OversizedJSONIsStillMetered(t *testing.T) {
 	resp := &http.Response{
 		StatusCode: http.StatusOK,
 		Header:     http.Header{"Content-Type": []string{"application/json"}},
-		Body:       io.NopCloser(strings.NewReader(oversizedPassthroughBody())),
+		Body:       io.NopCloser(strings.NewReader(`{"data":"` + strings.Repeat("a", passthroughJSONBufferCap) + `"}`)),
 	}
 	rec := httptest.NewRecorder()
-	h.serveBufferedJSONPassthrough(rec, st, passthroughCandidate(), resp, "application/json", 1, 10.0)
+	h.serveBufferedJSONPassthrough(rec, st, modelCandidate{
+		model:    &model.Model{ID: uuid.New(), ModelID: "text-embedding-x"},
+		provider: &provider.Provider{ID: uuid.New(), Name: "test-provider"},
+	}, resp, "application/json", 1, 10.0)
 
-	// 400 prompt bytes at the conventional 4 bytes per token.
-	const wantPrompt = 100
-	if logData.tokensPrompt != wantPrompt {
-		t.Errorf("logged prompt tokens = %d, want %d (estimated from promptTextBytes)", logData.tokensPrompt, wantPrompt)
+	const wantCharge = 100 // 400 prompt bytes at the conventional 4 bytes per token
+	if got := singleAddTokens(t, vkRepo); got != wantCharge {
+		t.Errorf("charged %d tokens against the key, want %d", got, wantCharge)
 	}
-	if got := singleAddTokens(t, vkRepo); got != wantPrompt {
-		t.Errorf("charged %d tokens against the key, want %d", got, wantPrompt)
+	if logData.tokensPrompt != 0 || logData.tokensCompletion != 0 {
+		t.Errorf("request log usage = (%d,%d), want (0,0): an estimate is not measured usage",
+			logData.tokensPrompt, logData.tokensCompletion)
 	}
 	if rec.Code != http.StatusOK {
 		t.Errorf("status = %d, want 200", rec.Code)
-	}
-}
-
-// TestPassthrough_OversizedJSONDoesNotEstimateFromResponseBytes pins the half of
-// the estimate that must NOT happen here. The streaming path estimates output
-// from delivered bytes because those bytes are text, but a pass-through response
-// is float vectors or base64 image data: charging 8 MiB of embedding floats at
-// four bytes per token would invent roughly two million completion tokens.
-// Undercharging the output is the deliberate choice; inventing it is not.
-func TestPassthrough_OversizedJSONDoesNotEstimateFromResponseBytes(t *testing.T) {
-	h := newIntegrationHandler()
-	t.Cleanup(func() { stopUnitHandler(h) })
-	h.virtualKeyRepo = &mockVirtualKeyRepo{}
-
-	logData := &requestLogData{
-		id:              uuid.New().String(),
-		modelID:         "text-embedding-x",
-		endpointType:    endpointTypeEmbeddings,
-		virtualKeyName:  "test-key",
-		virtualKeyID:    "00000000-0000-0000-0000-000000000001",
-		state:           "streaming",
-		promptTextBytes: 400,
-	}
-	st := &requestState{startTime: time.Now(), logData: logData, vkHash: "test-hash"}
-	h.insertRequestLogAsync(logData)
-	time.Sleep(20 * time.Millisecond)
-
-	resp := &http.Response{
-		StatusCode: http.StatusOK,
-		Header:     http.Header{"Content-Type": []string{"application/json"}},
-		Body:       io.NopCloser(strings.NewReader(oversizedPassthroughBody())),
-	}
-	h.serveBufferedJSONPassthrough(httptest.NewRecorder(), st, passthroughCandidate(), resp, "application/json", 1, 10.0)
-
-	if logData.tokensCompletion != 0 {
-		t.Errorf("completion tokens = %d, want 0; response bytes are not text and must not be estimated as tokens", logData.tokensCompletion)
-	}
-}
-
-// TestPassthrough_OversizedJSONWithNoPromptChargesNothing keeps the estimate
-// honest in the other direction: with no prompt text recorded there is nothing
-// to derive a charge from, and inventing one would bill a key for a request
-// whose size the gateway never measured.
-func TestPassthrough_OversizedJSONWithNoPromptChargesNothing(t *testing.T) {
-	h := newIntegrationHandler()
-	t.Cleanup(func() { stopUnitHandler(h) })
-	vkRepo := &mockVirtualKeyRepo{}
-	h.virtualKeyRepo = vkRepo
-
-	logData := &requestLogData{
-		id:              uuid.New().String(),
-		modelID:         "text-embedding-x",
-		endpointType:    endpointTypeEmbeddings,
-		virtualKeyName:  "test-key",
-		virtualKeyID:    "00000000-0000-0000-0000-000000000001",
-		state:           "streaming",
-		promptTextBytes: 0,
-	}
-	st := &requestState{startTime: time.Now(), logData: logData, vkHash: "test-hash"}
-	h.insertRequestLogAsync(logData)
-	time.Sleep(20 * time.Millisecond)
-
-	resp := &http.Response{
-		StatusCode: http.StatusOK,
-		Header:     http.Header{"Content-Type": []string{"application/json"}},
-		Body:       io.NopCloser(strings.NewReader(oversizedPassthroughBody())),
-	}
-	h.serveBufferedJSONPassthrough(httptest.NewRecorder(), st, passthroughCandidate(), resp, "application/json", 1, 10.0)
-
-	if logData.tokensPrompt != 0 || logData.tokensCompletion != 0 {
-		t.Errorf("usage = (%d,%d), want (0,0) when no prompt bytes were measured", logData.tokensPrompt, logData.tokensCompletion)
-	}
-	if len(vkRepo.addTokensCalls) != 0 {
-		t.Errorf("charged the key %d times, want 0", len(vkRepo.addTokensCalls))
 	}
 }

--- a/internal/quota/repository.go
+++ b/internal/quota/repository.go
@@ -37,9 +37,7 @@ func NewRepository(pool *pgxpool.Pool) *Repository { return &Repository{pool: po
 // Upsert writes a fresh snapshot (used by poll and manual refresh), replacing
 // any prior row for the provider+kind and clearing any recorded failure.
 func (r *Repository) Upsert(ctx context.Context, s Snapshot) error {
-	if s.FetchedAt.IsZero() {
-		s.FetchedAt = time.Now()
-	}
+	s.FetchedAt = sanitizeFetchedAt(s.FetchedAt)
 	_, err := r.pool.Exec(ctx, `
 		INSERT INTO provider_quota_snapshots
 			(provider_id, kind, payload, http_status, fetched_at, source, last_error, last_attempt_at)
@@ -116,6 +114,29 @@ func (r *Repository) List(ctx context.Context) ([]Snapshot, error) {
 	return out, rows.Err()
 }
 
+// sanitizeFetchedAt normalises a snapshot's fetch time. Unset means "now"; a
+// time in the future is clamped to now.
+//
+// The clamp is load-bearing, not tidiness. FetchedAt crosses the wire on the
+// fleet distribution path, and a future value broke two mechanisms at once:
+// every staleness check measures with time.Since, which returns a NEGATIVE
+// duration for a future stamp and so satisfies any "still fresh" comparison
+// forever; and the upsert below keeps whichever row is newer, so the poisoned
+// row outranked every genuine poll that followed. One bad timestamp froze a
+// provider's quota data permanently, and near-silently.
+//
+// Clamped rather than rejected because the snapshot itself is still worth
+// recording: only its claim about when it was fetched is impossible, and a
+// fetch cannot have happened in the future. Same shape as the fix applied to
+// the fleet rate-limit divisor, which had this bug in its own staleness check.
+func sanitizeFetchedAt(t time.Time) time.Time {
+	now := time.Now()
+	if t.IsZero() || t.After(now) {
+		return now
+	}
+	return t
+}
+
 // UpsertIfNewer writes only when there is no existing row or the incoming
 // fetched_at is strictly newer, so an older fleet write never clobbers a
 // member's fresher manual refresh. Returns whether the write applied.
@@ -136,9 +157,7 @@ func (r *Repository) List(ctx context.Context) ([]Snapshot, error) {
 // never release one, and it is idempotent once applied. Clearing a marker still
 // requires a strictly newer row, i.e. an actual successful refresh.
 func (r *Repository) UpsertIfNewer(ctx context.Context, s Snapshot) (bool, error) {
-	if s.FetchedAt.IsZero() {
-		s.FetchedAt = time.Now()
-	}
+	s.FetchedAt = sanitizeFetchedAt(s.FetchedAt)
 	tag, err := r.pool.Exec(ctx, `
 		INSERT INTO provider_quota_snapshots
 			(provider_id, kind, payload, http_status, fetched_at, source, last_error, last_attempt_at)

--- a/internal/quota/repository.go
+++ b/internal/quota/repository.go
@@ -129,9 +129,24 @@ func (r *Repository) List(ctx context.Context) ([]Snapshot, error) {
 // recording: only its claim about when it was fetched is impossible, and a
 // fetch cannot have happened in the future. Same shape as the fix applied to
 // the fleet rate-limit divisor, which had this bug in its own staleness check.
+//
+// The skew tolerance is what keeps the cure from causing the disease. Fleet
+// members do not share a clock, and Front Desk redistributes the SAME snapshot
+// every 60s against a ~5 minute poll cycle, relying on "skip if not newer" to
+// make the repeats free. Clamping any future stamp to now would rewrite each
+// repeat to the receiving member's own clock, so every redistribution would
+// look newer, apply instead of skip, and re-stamp the row as freshly fetched.
+// A provider whose primary had stopped polling would then look permanently
+// fresh on every member, suppressing their own polls: precisely the wedge this
+// function exists to prevent, reached through a second of NTP drift instead of
+// a hostile timestamp. Ordinary skew therefore passes through untouched (the
+// read-side age >= 0 guards cover the residue), and only stamps too far ahead
+// to be a clock difference are corrected.
+const fetchedAtSkewTolerance = 2 * time.Minute
+
 func sanitizeFetchedAt(t time.Time) time.Time {
 	now := time.Now()
-	if t.IsZero() || t.After(now) {
+	if t.IsZero() || t.After(now.Add(fetchedAtSkewTolerance)) {
 		return now
 	}
 	return t

--- a/internal/quota/repository_test.go
+++ b/internal/quota/repository_test.go
@@ -499,3 +499,38 @@ func TestUpsertIfNewer_ClampsFutureFetchedAt(t *testing.T) {
 		t.Errorf("payload = %v, want the later real poll to have replaced the poisoned row", after)
 	}
 }
+
+// TestUpsertIfNewer_SmallSkewStillDedupes is the other half of the clamp, and
+// the reason it has a tolerance. Front Desk redistributes the same snapshot
+// every 60s while the primary polls every ~5 minutes, and relies on "skip if not
+// newer" to make the repeats free. If the clamp rewrote every future-looking
+// stamp to now, a member whose clock trails the primary by a second would apply
+// each repeat instead of skipping it, re-stamping the row as freshly fetched and
+// suppressing its own polling of a provider nobody is refreshing any more.
+func TestUpsertIfNewer_SmallSkewStillDedupes(t *testing.T) {
+	ctx := context.Background()
+	repo := quota.NewRepository(testPool)
+
+	provID := insertTestProvider(ctx, t, "test-quota-small-skew")
+	t.Cleanup(func() { cleanupProvider(ctx, t, provID) })
+
+	// A primary one second ahead of this member: ordinary NTP drift.
+	skewed := time.Now().Add(1 * time.Second)
+	snap := quota.Snapshot{
+		ProviderID: provID, Kind: "usage", Payload: json.RawMessage(`{"v":1}`),
+		HTTPStatus: 200, Source: "fleet", FetchedAt: skewed,
+	}
+
+	applied, err := repo.UpsertIfNewer(ctx, snap)
+	if err != nil || !applied {
+		t.Fatalf("first distribution should apply: applied=%v err=%v", applied, err)
+	}
+	// The same snapshot redistributed a minute later must be a no-op write.
+	applied, err = repo.UpsertIfNewer(ctx, snap)
+	if err != nil {
+		t.Fatalf("second distribution: %v", err)
+	}
+	if applied {
+		t.Error("an identical redistributed snapshot applied again; the clamp rewrote its timestamp and broke skip-if-newer")
+	}
+}

--- a/internal/quota/repository_test.go
+++ b/internal/quota/repository_test.go
@@ -448,3 +448,54 @@ func TestList(t *testing.T) {
 		t.Fatalf("list did not contain the inserted snapshot (got %d rows)", len(all))
 	}
 }
+
+// TestUpsertIfNewer_ClampsFutureFetchedAt covers a wedge, not a cosmetic oddity.
+// FetchedAt arrives from the wire on the fleet distribution path (internal/api
+// ReceiveSnapshots) and was stored unvalidated, which broke two things at once:
+// every "is this still fresh" check uses time.Since, which goes negative for a
+// future stamp and so reads as permanently fresh; and the upsert keeps the newer
+// row, so a future-dated snapshot outranks every real poll that follows it. One
+// poisoned row therefore froze a provider's quota data indefinitely.
+//
+// A fetch cannot have happened in the future, so the honest repair is to clamp
+// rather than reject: the row is still recorded, just not with a timestamp that
+// wins forever.
+func TestUpsertIfNewer_ClampsFutureFetchedAt(t *testing.T) {
+	ctx := context.Background()
+	repo := quota.NewRepository(testPool)
+
+	provID := insertTestProvider(ctx, t, "test-quota-future-fetched-at")
+	t.Cleanup(func() { cleanupProvider(ctx, t, provID) })
+
+	future := time.Now().Add(48 * time.Hour)
+	if _, err := repo.UpsertIfNewer(ctx, quota.Snapshot{
+		ProviderID: provID, Kind: "usage", Payload: json.RawMessage(`{"poisoned":true}`),
+		HTTPStatus: 200, Source: "fleet", FetchedAt: future,
+	}); err != nil {
+		t.Fatalf("UpsertIfNewer(future): %v", err)
+	}
+
+	stored, err := repo.Get(ctx, provID, "usage")
+	if err != nil || stored == nil {
+		t.Fatalf("Get after future upsert: %v", err)
+	}
+	if stored.FetchedAt.After(time.Now().Add(time.Minute)) {
+		t.Errorf("stored fetched_at = %v, want clamped to about now, not %v", stored.FetchedAt, future)
+	}
+
+	// The point of the clamp: an ordinary poll landing afterwards must still win.
+	applied, err := repo.UpsertIfNewer(ctx, quota.Snapshot{
+		ProviderID: provID, Kind: "usage", Payload: json.RawMessage(`{"real":true}`),
+		HTTPStatus: 200, Source: "poll", FetchedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("UpsertIfNewer(real): %v", err)
+	}
+	if !applied {
+		t.Fatal("a real poll after a future-dated row was rejected; the poisoned row still outranks it")
+	}
+	after, _ := repo.Get(ctx, provID, "usage")
+	if after == nil || !jsonEqual(t, after.Payload, json.RawMessage(`{"real":true}`)) {
+		t.Errorf("payload = %v, want the later real poll to have replaced the poisoned row", after)
+	}
+}


### PR DESCRIPTION
Three findings from the 2026-08-27 Strix run, each verified against the code before fixing. Two more of the same bug class were found during review.

## 1. Oversized pass-through was metered as zero

`serveBufferedJSONPassthrough` streams responses past the 8 MiB buffer cap and finalized them with `(0,0)` tokens, never calling `recordTokenUsage`. The provider billed for the request, the client received the whole response, and it was charged against neither the key's `tokens_used` counter nor its TPM budget.

Skipping usage **extraction** to bound memory is correct; skipping **metering** was not meant to follow from it. Not an exotic path either: the code's own comment notes a batch embeddings call clears the cap at around 140 inputs, "ordinary document-indexing traffic".

**The first attempt at this fix did nothing**, and review caught it. It estimated from `logData.promptTextBytes`, which `ingestRequest` fills using the *chat* rule: it reads `messages` and `tools`, and no pass-through body has either. All four real body shapes size as zero, so the guard never fired. The unit test passed only because it hand-set `promptTextBytes` on a fabricated `logData` — a state no request can produce.

`passthroughPromptTextBytes` now sizes each family by its own shape: embeddings `input` (including both pre-tokenised forms), rerank `query` + `documents`, image `prompt`, TTS `input`. Multipart families stay unsized rather than guessed at, since their payload is an uploaded file with no honest text size.

Output is deliberately **not** estimated. The streaming path derives it from delivered bytes because those bytes are text; here they are float vectors or base64 images, so the same arithmetic would invent roughly two million completion tokens for one 8 MiB embeddings response. A guard test pins completion at zero so this cannot later be "fixed" into an overcharge.

The estimate also does not land in the request log. `finalizePassthroughLog` keeps `(0,0)`; only `recordTokenUsage` receives the estimate. That matches the invariant the chat and streaming paths already hold: estimates charge the quota, they are not reported as measured usage that the stats pages sum.

## 2. Front Desk never pruned expired WebAuthn sessions

The gateway sweeps hourly. Front Desk had the store method **and** an accessor whose doc comment said it existed for "callers wiring background cleanup of expired sessions" — and nothing ever called it. Its login ceremonies write a session row per request, so the embedded SQLite table only grew.

The loop sweeps once at startup rather than after a full interval, because any deployment upgrading into this fix already carries a backlog.

Review caught that the first version used a bare `go`, 27 lines above a comment stating that *every* process-lifetime loop runs on the server's background group so the drain joins it before the store closes. It now goes through `StartBackground`, so a sweep mid-`DELETE` cannot outlive the store, and a sweep cancelled during shutdown is no longer logged as a fault.

## 3. A future-dated quota snapshot wedged a provider permanently

`FetchedAt` crosses the wire on the fleet distribution path and was stored unvalidated, which broke two mechanisms at once:

- staleness is measured with `time.Since`, which returns a **negative** duration for a future stamp and so satisfies every "still fresh" test forever
- `UpsertIfNewer` keeps the newer row, so the poisoned row **outranked every genuine poll after it**

The regression test proves both halves — a real poll landing afterwards was rejected outright. The repository now clamps on write (the snapshot is still worth recording; only its claim about *when* it was fetched is impossible), and the staleness checks treat a negative age as untrustworthy.

Review caught that clamping every future stamp would recreate the wedge through ordinary clock drift: Front Desk redistributes the same snapshot every 60s against a ~5 minute poll cycle and relies on skip-if-newer to make repeats free. Clamping rewrote each repeat to the receiving member's clock, so every redistribution applied instead of skipping and re-stamped the row as freshly fetched — one second of NTP drift would suppress a member's own polling of a provider nobody was refreshing. Ordinary skew now passes through untouched, with the read-side negative-age guards covering the residue.

## Two more sites of the same bug, found in review

The first commit claimed to have fixed "both" staleness checks. There were more:

- **`internal/api/quota_drift.go`** `driftEligible` — same field, same repository feed, left unconverted, so a future-dated snapshot was drift-eligible forever.
- **`internal/frontdesk/backups.go`** — measured a timestamp parsed straight out of a *member's own HTTP listing*, entirely peer-supplied and unbounded. A member with a fast clock could silence its own `backup.stale` alert permanently, disabling backup monitoring for the member most likely to be misconfigured.

## Verification

- Every guard is mutation-verified: each regression test fails under the exact change it guards, including the "real poll was rejected" and "clamp broke skip-if-newer" cases.
- `go test` on the five touched packages (4,477 pass), `golangci-lint` clean, `make size-check` clean, `-race` clean on the two packages with new concurrency.
- Two test-quality defects from review are also fixed: the survives-an-error test waited for a single sweep (which a loop bailing on first error would also pass), so the interval is now injectable and it waits for several; the staleness tests exercised only the helpers, so `driftEligible` is now pinned at its call site.
