### PR TITLE
fix: keep the FD login token out of the structured log, meter every passthrough path

### DIFF
--- a/cmd/frontdesk/main.go
+++ b/cmd/frontdesk/main.go
@@ -10,6 +10,8 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -110,8 +112,9 @@ func main() {
 		debuglog.Fatal("frontdesk: failed to initialize admin token", "error", err)
 	}
 	if isNew {
-		// Printed once so the operator can capture the generated UI login token.
-		debuglog.Info("frontdesk: generated Front Desk login token", "token", adminMgr.Token())
+		// Straight to stdout, never through the structured logger: see
+		// announceGeneratedToken.
+		announceGeneratedToken(os.Stdout, adminMgr.Token())
 	}
 
 	bus := events.NewBus()
@@ -228,6 +231,28 @@ const (
 	defaultIPRPS   = 5
 	defaultIPBurst = 10
 )
+
+// announceGeneratedToken writes a freshly generated login token to w and logs
+// only the fact that one was generated.
+//
+// The token deliberately never passes through debuglog. Its handler fans out to
+// every configured channel, including the JSON stdout handler (where the value
+// becomes an indexed, queryable field) and the OTLP exporter (which ships it to
+// the operator's log store and retains it there under that store's policy). A
+// one-time admin credential written into log infrastructure is a credential
+// that outlives its one use, in a place chosen for searchability.
+//
+// The gateway has always printed its own token straight to stdout for exactly
+// this reason (printAdminTokenBoxStdout); Front Desk logged it as a structured
+// attribute instead. Same credential, same requirement.
+func announceGeneratedToken(w io.Writer, token string) {
+	// One Fprintf so the block cannot interleave with other Docker log output.
+	// Write failure is not actionable here: the process is booting, this is the
+	// only copy of the token, and there is nowhere safe to report the failure to
+	// (the logger is exactly what must not receive it).
+	_, _ = fmt.Fprintf(w, "\n  Front Desk login token (shown once):\n\n      %s\n\n", token)
+	debuglog.Info("frontdesk: generated a Front Desk login token, printed to stdout once")
+}
 
 // sessionCleanupInterval is how often expired WebAuthn sessions are pruned,
 // matching the gateway's hourly sweep in cmd/server. A var, not a const, so a

--- a/cmd/frontdesk/main.go
+++ b/cmd/frontdesk/main.go
@@ -237,20 +237,30 @@ const (
 //
 // The token deliberately never passes through debuglog. Its handler fans out to
 // every configured channel, including the JSON stdout handler (where the value
-// becomes an indexed, queryable field) and the OTLP exporter (which ships it to
-// the operator's log store and retains it there under that store's policy). A
-// one-time admin credential written into log infrastructure is a credential
-// that outlives its one use, in a place chosen for searchability.
+// becomes an indexed, queryable FIELD) and the OTLP exporter (which ships it off
+// the host to the operator's log store and retains it there under that store's
+// policy).
+//
+// To be precise about what this does and does not achieve: in a container,
+// stdout IS the log stream, so the token still reaches whatever collects
+// container output. What it stops is the token becoming a structured, indexed,
+// queryable attribute, and crossing the OTLP hop into a remote store. That is a
+// real reduction in reach and retention, not a guarantee the value never lands
+// in a log file.
 //
 // The gateway has always printed its own token straight to stdout for exactly
 // this reason (printAdminTokenBoxStdout); Front Desk logged it as a structured
 // attribute instead. Same credential, same requirement.
 func announceGeneratedToken(w io.Writer, token string) {
 	// One Fprintf so the block cannot interleave with other Docker log output.
-	// Write failure is not actionable here: the process is booting, this is the
-	// only copy of the token, and there is nowhere safe to report the failure to
-	// (the logger is exactly what must not receive it).
-	_, _ = fmt.Fprintf(w, "\n  Front Desk login token (shown once):\n\n      %s\n\n", token)
+	// This write is the ONLY copy the operator will ever get: the token is
+	// persisted as a hash, so a lost write means recovering it requires deleting
+	// the token file and restarting. The token itself must not be logged, but
+	// the FAILURE must be, or the loss is silent.
+	if _, err := fmt.Fprintf(w, "\n  Front Desk login token (shown once):\n\n      %s\n\n", token); err != nil {
+		debuglog.Error("frontdesk: failed to print the generated login token; delete the admin token file and restart to generate a new one", "error", err)
+		return
+	}
 	debuglog.Info("frontdesk: generated a Front Desk login token, printed to stdout once")
 }
 

--- a/cmd/frontdesk/main_test.go
+++ b/cmd/frontdesk/main_test.go
@@ -217,3 +217,45 @@ func waitForSweeps(t *testing.T, c *fakeSessionCleaner, want int) {
 	}
 	t.Fatalf("cleanup ran %d times, want at least %d", c.count(), want)
 }
+
+// TestGeneratedTokenNeverReachesTheStructuredLogger is the whole point of
+// printing the token to stdout directly.
+//
+// debuglog's handler fans out to every configured channel: the JSON stdout
+// handler, where the token becomes an indexed queryable field, and the OTLP
+// exporter, which ships it to whatever log store the operator runs and retains
+// it there. A one-time login credential must not be persisted in log
+// infrastructure. The gateway has always printed its own token straight to
+// stdout for this reason; Front Desk logged it as a structured attribute.
+func TestGeneratedTokenNeverReachesTheStructuredLogger(t *testing.T) {
+	const token = "fd-secret-token-do-not-log"
+
+	logs := &recordingHandler{}
+	prev := slog.Default()
+	debuglog.SetHandler(logs)
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	var out strings.Builder
+	announceGeneratedToken(&out, token)
+
+	if !strings.Contains(out.String(), token) {
+		t.Errorf("the token must still reach stdout so the operator can capture it; got %q", out.String())
+	}
+
+	logs.mu.Lock()
+	defer logs.mu.Unlock()
+	for _, r := range logs.records {
+		if strings.Contains(r.Message, token) {
+			t.Errorf("token leaked into a log message: %q", r.Message)
+		}
+		r.Attrs(func(a slog.Attr) bool {
+			if strings.Contains(a.Value.String(), token) {
+				t.Errorf("token leaked into log attribute %q", a.Key)
+			}
+			return true
+		})
+	}
+	if len(logs.records) == 0 {
+		t.Error("expected a (token-free) log line noting that a token was generated")
+	}
+}

--- a/internal/proxy/multimodal.go
+++ b/internal/proxy/multimodal.go
@@ -435,11 +435,25 @@ func (h *Handler) serveBufferedJSONPassthrough(w http.ResponseWriter, st *reques
 	if _, writeErr := w.Write(body); writeErr != nil {
 		debuglog.Warn("proxy: client write failed during passthrough", "endpoint", logData.endpointType, "model", logData.modelID, "provider", logData.providerName, "error", writeErr)
 	}
+	// The log records what the provider measured, which may be nothing.
 	h.finalizePassthroughLog(st, resp.StatusCode, attempt, responseHeaderMs, promptTokens, completionTokens, "completed", "")
-	if promptTokens > 0 || completionTokens > 0 {
-		h.recordTokenUsage(st.vkHash, logData, promptTokens, completionTokens, 0)
+
+	// Charge the quota even when the provider reported no usage at all. Image
+	// generation and text-to-speech routinely omit the usage block, so guarding
+	// the debit on "did it report something" left those families unmetered on
+	// every ordinary request, not merely on the oversized ones the sibling
+	// branch above handles. Reported figures always win; the estimate only
+	// fills a total absence, and only for the prompt, for the same reason the
+	// oversized branch does not size a response of vectors or base64 as text.
+	chargePrompt, chargeCompletion := promptTokens, completionTokens
+	estimatedPrompt := false
+	if chargePrompt == 0 && chargeCompletion == 0 {
+		chargePrompt, estimatedPrompt = estimateTokens(logData.promptTextBytes), true
 	}
-	debuglog.Info("proxy: passthrough completed", "endpoint", logData.endpointType, "model", logData.modelID, "provider", logData.providerName, "attempt", attempt, "status", resp.StatusCode, "bytes", len(body), "prompt_tokens", promptTokens, "completion_tokens", completionTokens)
+	if chargePrompt > 0 || chargeCompletion > 0 {
+		h.recordTokenUsage(st.vkHash, logData, chargePrompt, chargeCompletion, 0)
+	}
+	debuglog.Info("proxy: passthrough completed", "endpoint", logData.endpointType, "model", logData.modelID, "provider", logData.providerName, "attempt", attempt, "status", resp.StatusCode, "bytes", len(body), "prompt_tokens", promptTokens, "completion_tokens", completionTokens, "charged_prompt_tokens", chargePrompt, "prompt_estimated", estimatedPrompt)
 }
 
 // serveStreamedPassthrough handles SSE and binary shapes: probe the first

--- a/internal/proxy/multimodal.go
+++ b/internal/proxy/multimodal.go
@@ -376,7 +376,8 @@ func (h *Handler) serveBufferedJSONPassthrough(w http.ResponseWriter, st *reques
 	// embeddings 200 says nothing about the chat surface and an image or TTS 200
 	// says nothing about either. And gated on bytes having arrived, judged by the
 	// same rule the probe uses — see passthroughAnswered.
-	if passthroughAnswered(logData.endpointType, body) {
+	answered := passthroughAnswered(logData.endpointType, body)
+	if answered {
 		h.noteModelServed(candidate.model, logData.endpointType)
 	}
 	// Oversized is judged on the bytes read, before masking can shrink a
@@ -445,15 +446,45 @@ func (h *Handler) serveBufferedJSONPassthrough(w http.ResponseWriter, st *reques
 	// branch above handles. Reported figures always win; the estimate only
 	// fills a total absence, and only for the prompt, for the same reason the
 	// oversized branch does not size a response of vectors or base64 as text.
+	charged, estimatedPrompt := h.chargePassthroughUsage(st, promptTokens, completionTokens, answered)
+	debuglog.Info("proxy: passthrough completed", "endpoint", logData.endpointType, "model", logData.modelID, "provider", logData.providerName, "attempt", attempt, "status", resp.StatusCode, "bytes", len(body), "prompt_tokens", promptTokens, "completion_tokens", completionTokens, "charged_tokens", charged, "prompt_estimated", estimatedPrompt)
+}
+
+// chargePassthroughUsage debits a completed pass-through request, estimating
+// the prompt when the provider reported no usage at all.
+//
+// Every pass-through family needs this and they do not share a branch: JSON
+// bodies are metered in serveBufferedJSONPassthrough, while audio/mpeg and
+// other binary shapes go to serveStreamedPassthrough, where the SSE tail that
+// carries usage is not even allocated. Guarding the debit on "did the provider
+// report something" therefore left image generation unmetered on the JSON side
+// and text-to-speech unmetered on the binary side, on every ordinary request.
+//
+// delivered gates the estimate, not the reported figures: a provider that
+// answers 200 with nothing (an aggregator in front of a retired model returning
+// `{"data":[]}`) has cost nothing, and charging a full prompt estimate for it
+// would bill the caller for every empty answer. This is the same rule
+// estimateMissingUsage states for streams: nothing is estimated when no output
+// was delivered.
+//
+// Only the prompt is ever estimated. A pass-through response body is float
+// vectors or base64 or audio, not text, so sizing it the way the streaming path
+// sizes delivered text would invent an enormous completion charge.
+//
+// Returns what was charged and whether the prompt was estimated, for the log.
+func (h *Handler) chargePassthroughUsage(st *requestState, promptTokens, completionTokens int, delivered bool) (charged int, estimated bool) {
+	logData := st.logData
 	chargePrompt, chargeCompletion := promptTokens, completionTokens
-	estimatedPrompt := false
 	if chargePrompt == 0 && chargeCompletion == 0 {
-		chargePrompt, estimatedPrompt = estimateTokens(logData.promptTextBytes), true
+		if !delivered {
+			return 0, false
+		}
+		chargePrompt, estimated = estimateTokens(logData.promptTextBytes), true
 	}
 	if chargePrompt > 0 || chargeCompletion > 0 {
 		h.recordTokenUsage(st.vkHash, logData, chargePrompt, chargeCompletion, 0)
 	}
-	debuglog.Info("proxy: passthrough completed", "endpoint", logData.endpointType, "model", logData.modelID, "provider", logData.providerName, "attempt", attempt, "status", resp.StatusCode, "bytes", len(body), "prompt_tokens", promptTokens, "completion_tokens", completionTokens, "charged_prompt_tokens", chargePrompt, "prompt_estimated", estimatedPrompt)
+	return chargePrompt + chargeCompletion, estimated
 }
 
 // serveStreamedPassthrough handles SSE and binary shapes: probe the first
@@ -553,18 +584,17 @@ func (h *Handler) serveStreamedPassthrough(w http.ResponseWriter, r *http.Reques
 		}
 		debuglog.Warn("proxy: passthrough copy interrupted", "endpoint", logData.endpointType, "model", logData.modelID, "provider", logData.providerName, "bytes", written, "error", copyErr)
 		h.finalizePassthroughLog(st, resp.StatusCode, attempt, responseHeaderMs, promptTokens, completionTokens, "failed", errMsg)
-		// The provider billed whatever usage the SSE tail already reported,
-		// whether or not the client stayed to receive it.
-		if promptTokens > 0 || completionTokens > 0 {
-			h.recordTokenUsage(st.vkHash, logData, promptTokens, completionTokens, 0)
-		}
+		// The provider billed whatever it produced, whether or not the client
+		// stayed to receive it. Bytes reached the client, so an absent usage
+		// report is estimated rather than treated as free: this is the path
+		// audio/mpeg takes, where the SSE tail that would carry usage is never
+		// even allocated, so the report is structurally always absent.
+		h.chargePassthroughUsage(st, promptTokens, completionTokens, written > 0)
 		return
 	}
 	h.finalizePassthroughLog(st, resp.StatusCode, attempt, responseHeaderMs, promptTokens, completionTokens, "completed", "")
-	if promptTokens > 0 || completionTokens > 0 {
-		h.recordTokenUsage(st.vkHash, logData, promptTokens, completionTokens, 0)
-	}
-	debuglog.Info("proxy: passthrough completed", "endpoint", logData.endpointType, "model", logData.modelID, "provider", logData.providerName, "attempt", attempt, "status", resp.StatusCode, "bytes", written, "sse", isSSE, "prompt_tokens", promptTokens, "completion_tokens", completionTokens)
+	charged, estimatedPrompt := h.chargePassthroughUsage(st, promptTokens, completionTokens, written > 0)
+	debuglog.Info("proxy: passthrough completed", "endpoint", logData.endpointType, "model", logData.modelID, "provider", logData.providerName, "attempt", attempt, "status", resp.StatusCode, "bytes", written, "sse", isSSE, "prompt_tokens", promptTokens, "completion_tokens", completionTokens, "charged_tokens", charged, "prompt_estimated", estimatedPrompt)
 }
 
 // copyPassthroughHeaders sets the upstream Content-Type and (when present)

--- a/internal/proxy/multimodal_multipart.go
+++ b/internal/proxy/multimodal_multipart.go
@@ -124,23 +124,29 @@ func newMultipartBodyBuilder(parts []multipartPart) func(string) ([]byte, string
 	}
 }
 
-// multipartPromptTextBytes sizes the text a multipart request carries: the form
-// fields, never the uploaded file.
+// multipartPromptFields are the form fields that carry prompt TEXT on the
+// multipart endpoints. "prompt" is the only one: an image edit's prompt is the
+// same string /v1/images/generations sends as JSON, and a transcription's
+// prompt is the context hint the model conditions on.
 //
-// A part with a filename is the payload (audio to transcribe, an image to edit)
-// and is orders of magnitude larger than the tokens it costs, so measuring it
-// would invent a colossal charge -- the same reason promptTextBytes skips
-// image_url parts and passthroughPromptTextBytes refuses to size an upload. The
-// text fields are the prompt: an image edit's "prompt" is the same string the
-// JSON image endpoint sends, and it was being counted as zero purely because it
-// arrived as form data.
+// An allowlist rather than a denylist, because everything else on these forms is
+// configuration -- language, temperature, response_format, size, n, voice,
+// timestamp_granularities -- and charging for it would bill the caller for their
+// own options. A denylist gets that wrong by default every time a provider adds
+// a parameter, which is the wrong direction for a billing decision to fail in.
+var multipartPromptFields = map[string]bool{"prompt": true}
+
+// multipartPromptTextBytes sizes the prompt text a multipart request carries.
 //
-// The "model" field is excluded: it is routing metadata, not prompt text, and
-// it is already recorded separately on the log row.
+// The uploaded file is never measured: it is the payload (audio to transcribe,
+// an image to edit) and is orders of magnitude larger than the tokens it costs,
+// so sizing it would invent a colossal charge. That is the same rule
+// promptTextBytes applies to image_url parts and passthroughPromptTextBytes
+// applies to an upload.
 func multipartPromptTextBytes(parts []multipartPart) int {
 	n := 0
 	for _, p := range parts {
-		if p.fileName != "" || p.fieldName == "model" {
+		if p.fileName != "" || !multipartPromptFields[p.fieldName] {
 			continue
 		}
 		n += len(p.data)

--- a/internal/proxy/multimodal_multipart.go
+++ b/internal/proxy/multimodal_multipart.go
@@ -124,6 +124,30 @@ func newMultipartBodyBuilder(parts []multipartPart) func(string) ([]byte, string
 	}
 }
 
+// multipartPromptTextBytes sizes the text a multipart request carries: the form
+// fields, never the uploaded file.
+//
+// A part with a filename is the payload (audio to transcribe, an image to edit)
+// and is orders of magnitude larger than the tokens it costs, so measuring it
+// would invent a colossal charge -- the same reason promptTextBytes skips
+// image_url parts and passthroughPromptTextBytes refuses to size an upload. The
+// text fields are the prompt: an image edit's "prompt" is the same string the
+// JSON image endpoint sends, and it was being counted as zero purely because it
+// arrived as form data.
+//
+// The "model" field is excluded: it is routing metadata, not prompt text, and
+// it is already recorded separately on the log row.
+func multipartPromptTextBytes(parts []multipartPart) int {
+	n := 0
+	for _, p := range parts {
+		if p.fileName != "" || p.fieldName == "model" {
+			continue
+		}
+		n += len(p.data)
+	}
+	return n
+}
+
 // ingestMultipartRequest performs phase A for multipart endpoints: read the
 // (middleware-cached) body, parse the multipart form, extract the `model`
 // field, create the early "pending" request-log entry, publish the
@@ -185,6 +209,12 @@ func (h *Handler) ingestMultipartRequest(w http.ResponseWriter, r *http.Request,
 	// bodyBytes stays nil: the parsed parts are the upstream-body source for
 	// multipart requests (via makeUpstreamBody), so retaining the raw body
 	// would pin a redundant full copy of the upload for the request lifetime.
+	// Size the text form fields, skipping the upload itself. Without this
+	// logData.promptTextBytes stays at its zero value for every multipart
+	// request, so the metering estimate downstream silently charges nothing --
+	// the same no-op that the chat-only sizer produced for the JSON families.
+	logData.promptTextBytes = multipartPromptTextBytes(parts)
+
 	return &requestState{
 		startTime: startTime,
 		reqModel:  reqModel,

--- a/internal/proxy/passthrough_metering_test.go
+++ b/internal/proxy/passthrough_metering_test.go
@@ -368,11 +368,35 @@ func TestPassthrough_EmptyAnswerIsNotCharged(t *testing.T) {
 // nothing, exactly as the chat-only sizer did for the JSON families.
 func TestMultipartPromptTextBytes_SizesFormFieldsNotTheUpload(t *testing.T) {
 	parts := []multipartPart{
-		{fieldName: "model", data: []byte("whisper-1")},                       // routing, not prompt
-		{fieldName: "prompt", data: []byte("transcribe carefully")},           // 20 bytes
+		{fieldName: "model", data: []byte("whisper-1")},                       // routing
+		{fieldName: "language", data: []byte("en")},                           // config
+		{fieldName: "response_format", data: []byte("verbose_json")},          // config
+		{fieldName: "temperature", data: []byte("0")},                         // config
+		{fieldName: "prompt", data: []byte("transcribe carefully")},           // 20 bytes, the only prompt
 		{fieldName: "file", fileName: "audio.mp3", data: make([]byte, 5<<20)}, // the upload
 	}
 	if got, want := multipartPromptTextBytes(parts), 20; got != want {
-		t.Errorf("sized %d, want %d: only non-file, non-model fields count", got, want)
+		t.Errorf("sized %d, want %d: only the prompt field counts", got, want)
+	}
+}
+
+// TestMultipartPromptTextBytes_MetadataOnlyFormChargesNothing is the overcharge
+// guard. Every field on these forms except "prompt" is configuration, so a
+// request that sends only options and a file must cost the caller nothing: an
+// allowlist keeps a newly added provider parameter from silently becoming
+// billable text.
+func TestMultipartPromptTextBytes_MetadataOnlyFormChargesNothing(t *testing.T) {
+	parts := []multipartPart{
+		{fieldName: "model", data: []byte("whisper-1")},
+		{fieldName: "language", data: []byte("en")},
+		{fieldName: "response_format", data: []byte("verbose_json")},
+		{fieldName: "temperature", data: []byte("0")},
+		{fieldName: "timestamp_granularities[]", data: []byte("word")},
+		{fieldName: "size", data: []byte("1024x1024")},
+		{fieldName: "n", data: []byte("1")},
+		{fieldName: "file", fileName: "audio.mp3", data: make([]byte, 1<<20)},
+	}
+	if got := multipartPromptTextBytes(parts); got != 0 {
+		t.Errorf("sized %d, want 0: configuration fields are not prompt text and must not be charged", got)
 	}
 }

--- a/internal/proxy/passthrough_metering_test.go
+++ b/internal/proxy/passthrough_metering_test.go
@@ -178,3 +178,94 @@ func TestPassthrough_OversizedJSONChargesTheEstimate(t *testing.T) {
 		t.Errorf("status = %d, want 200", rec.Code)
 	}
 }
+
+// TestPassthrough_NoUsageBlockStillMeters is the sibling of the oversized case,
+// and the half the first fix left behind. A normal-sized pass-through response
+// that carries no "usage" block extracts (0,0), and the guard below it only
+// charged when one of them was non-zero, so nothing was metered at all.
+//
+// Image generation and text-to-speech routinely report no usage, so this is not
+// a corner: those two families were unmetered on every ordinary request, not
+// merely on the oversized ones.
+func TestPassthrough_NoUsageBlockStillMeters(t *testing.T) {
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+	vkRepo := &mockVirtualKeyRepo{}
+	h.virtualKeyRepo = vkRepo
+
+	reqBody := `{"model":"tts-1","input":"` + strings.Repeat("s", 400) + `","voice":"alloy"}`
+	logData := &requestLogData{
+		id:              uuid.New().String(),
+		modelID:         "tts-1",
+		endpointType:    endpointTypeTTS,
+		virtualKeyName:  "test-key",
+		virtualKeyID:    "00000000-0000-0000-0000-000000000001",
+		state:           "streaming",
+		promptTextBytes: passthroughPromptTextBytes([]byte(reqBody), endpointTypeTTS),
+	}
+	if logData.promptTextBytes != 400 {
+		t.Fatalf("probe body sized %d, want 400", logData.promptTextBytes)
+	}
+	st := &requestState{startTime: time.Now(), logData: logData, vkHash: "test-hash"}
+	h.insertRequestLogAsync(logData)
+	time.Sleep(20 * time.Millisecond)
+
+	// A perfectly ordinary provider response with no usage block.
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"created":1,"data":[{"b64":"AAAA"}]}`)),
+	}
+	h.serveBufferedJSONPassthrough(httptest.NewRecorder(), st, modelCandidate{
+		model:    &model.Model{ID: uuid.New(), ModelID: "tts-1"},
+		provider: &provider.Provider{ID: uuid.New(), Name: "test-provider"},
+	}, resp, "application/json", 1, 10.0)
+
+	const wantCharge = 100 // 400 prompt bytes at 4 bytes per token
+	if got := singleAddTokens(t, vkRepo); got != wantCharge {
+		t.Errorf("charged %d tokens, want %d: a response without usage must still meter", got, wantCharge)
+	}
+	if logData.tokensPrompt != 0 {
+		t.Errorf("request log prompt = %d, want 0: an estimate is not measured usage", logData.tokensPrompt)
+	}
+}
+
+// TestPassthrough_ReportedUsageWinsOverEstimate keeps the estimate from
+// displacing a real figure: when the provider does report usage, that is what
+// gets charged and what the request log records.
+func TestPassthrough_ReportedUsageWinsOverEstimate(t *testing.T) {
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+	vkRepo := &mockVirtualKeyRepo{}
+	h.virtualKeyRepo = vkRepo
+
+	logData := &requestLogData{
+		id:              uuid.New().String(),
+		modelID:         "text-embedding-x",
+		endpointType:    endpointTypeEmbeddings,
+		virtualKeyName:  "test-key",
+		virtualKeyID:    "00000000-0000-0000-0000-000000000001",
+		state:           "streaming",
+		promptTextBytes: 4000, // an estimate here would be 1000 tokens
+	}
+	st := &requestState{startTime: time.Now(), logData: logData, vkHash: "test-hash"}
+	h.insertRequestLogAsync(logData)
+	time.Sleep(20 * time.Millisecond)
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"usage":{"prompt_tokens":7,"total_tokens":7}}`)),
+	}
+	h.serveBufferedJSONPassthrough(httptest.NewRecorder(), st, modelCandidate{
+		model:    &model.Model{ID: uuid.New(), ModelID: "text-embedding-x"},
+		provider: &provider.Provider{ID: uuid.New(), Name: "test-provider"},
+	}, resp, "application/json", 1, 10.0)
+
+	if got := singleAddTokens(t, vkRepo); got != 7 {
+		t.Errorf("charged %d, want the provider's reported 7", got)
+	}
+	if logData.tokensPrompt != 7 {
+		t.Errorf("request log prompt = %d, want the measured 7", logData.tokensPrompt)
+	}
+}

--- a/internal/proxy/passthrough_metering_test.go
+++ b/internal/proxy/passthrough_metering_test.go
@@ -184,24 +184,26 @@ func TestPassthrough_OversizedJSONChargesTheEstimate(t *testing.T) {
 // that carries no "usage" block extracts (0,0), and the guard below it only
 // charged when one of them was non-zero, so nothing was metered at all.
 //
-// Image generation and text-to-speech routinely report no usage, so this is not
-// a corner: those two families were unmetered on every ordinary request, not
-// merely on the oversized ones.
+// Image generation returns JSON and routinely reports no usage, so it is the
+// family this branch actually rescues. Text-to-speech does NOT reach here: it
+// answers audio/mpeg and routes to serveStreamedPassthrough, which is covered
+// by TestStreamedPassthrough_BinaryResponseIsMetered. Labelling this case as
+// TTS, as an earlier version did, described a JSON response TTS never returns.
 func TestPassthrough_NoUsageBlockStillMeters(t *testing.T) {
 	h := newIntegrationHandler()
 	t.Cleanup(func() { stopUnitHandler(h) })
 	vkRepo := &mockVirtualKeyRepo{}
 	h.virtualKeyRepo = vkRepo
 
-	reqBody := `{"model":"tts-1","input":"` + strings.Repeat("s", 400) + `","voice":"alloy"}`
+	reqBody := `{"model":"dall-e-3","prompt":"` + strings.Repeat("s", 400) + `"}`
 	logData := &requestLogData{
 		id:              uuid.New().String(),
-		modelID:         "tts-1",
-		endpointType:    endpointTypeTTS,
+		modelID:         "dall-e-3",
+		endpointType:    endpointTypeImage,
 		virtualKeyName:  "test-key",
 		virtualKeyID:    "00000000-0000-0000-0000-000000000001",
 		state:           "streaming",
-		promptTextBytes: passthroughPromptTextBytes([]byte(reqBody), endpointTypeTTS),
+		promptTextBytes: passthroughPromptTextBytes([]byte(reqBody), endpointTypeImage),
 	}
 	if logData.promptTextBytes != 400 {
 		t.Fatalf("probe body sized %d, want 400", logData.promptTextBytes)
@@ -217,7 +219,7 @@ func TestPassthrough_NoUsageBlockStillMeters(t *testing.T) {
 		Body:       io.NopCloser(strings.NewReader(`{"created":1,"data":[{"b64":"AAAA"}]}`)),
 	}
 	h.serveBufferedJSONPassthrough(httptest.NewRecorder(), st, modelCandidate{
-		model:    &model.Model{ID: uuid.New(), ModelID: "tts-1"},
+		model:    &model.Model{ID: uuid.New(), ModelID: "dall-e-3"},
 		provider: &provider.Provider{ID: uuid.New(), Name: "test-provider"},
 	}, resp, "application/json", 1, 10.0)
 
@@ -267,5 +269,110 @@ func TestPassthrough_ReportedUsageWinsOverEstimate(t *testing.T) {
 	}
 	if logData.tokensPrompt != 7 {
 		t.Errorf("request log prompt = %d, want the measured 7", logData.tokensPrompt)
+	}
+}
+
+// TestStreamedPassthrough_BinaryResponseIsMetered covers where text-to-speech
+// actually lands. /v1/audio/speech answers audio/mpeg, which is neither JSON nor
+// SSE, so it routes to serveStreamedPassthrough — and there the SSE tail that
+// carries usage is only allocated for SSE, so the usage report is structurally
+// always absent for audio. Guarding the debit on a report that can never arrive
+// left TTS unmetered on every single request.
+//
+// A previous version of this fix claimed to have rescued TTS while only touching
+// the JSON branch, and its test constructed a JSON response TTS never returns.
+func TestStreamedPassthrough_BinaryResponseIsMetered(t *testing.T) {
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+	vkRepo := &mockVirtualKeyRepo{}
+	h.virtualKeyRepo = vkRepo
+
+	reqBody := `{"model":"tts-1","input":"` + strings.Repeat("s", 400) + `","voice":"alloy"}`
+	logData := &requestLogData{
+		id:              uuid.New().String(),
+		modelID:         "tts-1",
+		endpointType:    endpointTypeTTS,
+		virtualKeyName:  "test-key",
+		virtualKeyID:    "00000000-0000-0000-0000-000000000001",
+		state:           "streaming",
+		promptTextBytes: passthroughPromptTextBytes([]byte(reqBody), endpointTypeTTS),
+	}
+	if logData.promptTextBytes != 400 {
+		t.Fatalf("probe body sized %d, want 400", logData.promptTextBytes)
+	}
+	st := &requestState{startTime: time.Now(), logData: logData, vkHash: "test-hash"}
+	h.insertRequestLogAsync(logData)
+	time.Sleep(20 * time.Millisecond)
+
+	// Real shape: binary audio, no usage anywhere.
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"audio/mpeg"}},
+		Body:       io.NopCloser(strings.NewReader("ID3\x04\x00\x00\x00fake mp3 payload")),
+	}
+	req := httptest.NewRequest("POST", "/v1/audio/speech", http.NoBody)
+	h.serveStreamedPassthrough(httptest.NewRecorder(), req, st, modelCandidate{
+		model:    &model.Model{ID: uuid.New(), ModelID: "tts-1"},
+		provider: &provider.Provider{ID: uuid.New(), Name: "test-provider"},
+	}, resp, "audio/mpeg", false, 1, 10.0)
+
+	const wantCharge = 100 // 400 prompt bytes at 4 bytes per token
+	if got := singleAddTokens(t, vkRepo); got != wantCharge {
+		t.Errorf("charged %d tokens for a TTS request, want %d: binary passthrough must meter too", got, wantCharge)
+	}
+}
+
+// TestPassthrough_EmptyAnswerIsNotCharged is the gate on the estimate. An
+// aggregator in front of a retired model answers 200 with `{"data":[]}` — the
+// case passthroughAnswered exists to detect — and that costs the operator
+// nothing, so charging a full prompt estimate for it would bill the caller for
+// every empty reply. estimateMissingUsage states the same rule for streams:
+// nothing is estimated when nothing was delivered.
+func TestPassthrough_EmptyAnswerIsNotCharged(t *testing.T) {
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+	vkRepo := &mockVirtualKeyRepo{}
+	h.virtualKeyRepo = vkRepo
+
+	logData := &requestLogData{
+		id:              uuid.New().String(),
+		modelID:         "text-embedding-x",
+		endpointType:    endpointTypeEmbeddings,
+		virtualKeyName:  "test-key",
+		virtualKeyID:    "00000000-0000-0000-0000-000000000001",
+		state:           "streaming",
+		promptTextBytes: 4000,
+	}
+	st := &requestState{startTime: time.Now(), logData: logData, vkHash: "test-hash"}
+	h.insertRequestLogAsync(logData)
+	time.Sleep(20 * time.Millisecond)
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"data":[]}`)),
+	}
+	h.serveBufferedJSONPassthrough(httptest.NewRecorder(), st, modelCandidate{
+		model:    &model.Model{ID: uuid.New(), ModelID: "text-embedding-x"},
+		provider: &provider.Provider{ID: uuid.New(), Name: "test-provider"},
+	}, resp, "application/json", 1, 10.0)
+
+	if len(vkRepo.addTokensCalls) != 0 {
+		t.Errorf("charged %d times for an empty answer, want 0", len(vkRepo.addTokensCalls))
+	}
+}
+
+// TestMultipartPromptTextBytes_SizesFormFieldsNotTheUpload keeps the multipart
+// families from being the next silent no-op: their prompt is a form field, and
+// leaving promptTextBytes at zero would make every estimate downstream charge
+// nothing, exactly as the chat-only sizer did for the JSON families.
+func TestMultipartPromptTextBytes_SizesFormFieldsNotTheUpload(t *testing.T) {
+	parts := []multipartPart{
+		{fieldName: "model", data: []byte("whisper-1")},                       // routing, not prompt
+		{fieldName: "prompt", data: []byte("transcribe carefully")},           // 20 bytes
+		{fieldName: "file", fileName: "audio.mp3", data: make([]byte, 5<<20)}, // the upload
+	}
+	if got, want := multipartPromptTextBytes(parts), 20; got != want {
+		t.Errorf("sized %d, want %d: only non-file, non-model fields count", got, want)
 	}
 }


### PR DESCRIPTION
Two findings from the GLM 5.2 Strix run, plus the paths review found still uncovered after the first attempt.

## 1. Front Desk logged its generated admin token as a structured attribute

```go
debuglog.Info("frontdesk: generated Front Desk login token", "token", adminMgr.Token())
```

`debuglog`'s handler fans out to every configured channel, so on first boot the plaintext login credential reached the JSON stdout handler — where it becomes an **indexed, queryable field** — and the **OTLP exporter**, which ships it off the host into the operator's log store and retains it under that store's policy. The gateway has always printed its own token straight to stdout for exactly this reason (`printAdminTokenBoxStdout`); Front Desk was the asymmetry.

Front Desk now uses `announceGeneratedToken`, writing to stdout and logging only the token-free fact that one was generated.

**Stated precisely**, because review rightly pushed back on the first wording: in a container, stdout *is* the log stream, so the token still reaches whatever collects container output. What this removes is the structured indexed attribute and the OTLP hop into a remote store. That is a real reduction in reach and retention, not a guarantee the value never lands in a log file.

The write error is also no longer discarded. That `Fprintf` is the **only** copy the operator gets — the token is persisted as a hash — so a silently lost write means deleting the token file and restarting to recover. The token must not be logged; the failure must be.

## 2. Pass-through responses without a usage block were never metered

`extractPassthroughUsage` returns `(0,0)` when a provider reports no usage, and the debit was guarded on one of them being non-zero. So the request was charged against neither the TPM budget nor `tokens_used`.

**The first attempt fixed one branch and left the class** — the same criticism its own message quoted, earned again. Review caught two families still unmetered:

**Text-to-speech never reached the fixed branch.** `/v1/audio/speech` answers `audio/mpeg`, which is neither JSON nor SSE, so it routes to `serveStreamedPassthrough`. There the tail buffer carrying usage is only allocated `if isSSE`, so for binary audio the report is *structurally always absent* and the old guard could never be true. TTS was unmetered before and after that commit. Its test asserted otherwise by constructing an `application/json` response TTS does not return.

**Speech-to-text and image edits were a no-op for a different reason.** `ingestMultipartRequest` never assigned `promptTextBytes`, so the estimate computed from zero — the same silent-zero failure as the chat-only sizer, one family over. The asymmetry was visible in the result: `/v1/images/generations` charged an estimate while `/v1/images/edits`, same model and same `prompt` field, charged nothing purely because the prompt arrived as form data.

Both paths now charge through one `chargePassthroughUsage` helper, and `multipartPromptTextBytes` sizes the text form fields while skipping the upload — the same rule every other sizer here applies to blobs.

## 3. The estimate is gated on delivery

Charging whenever the provider reported nothing meant a 200 carrying `{"data":[]}` — an aggregator in front of a retired model, precisely what `passthroughAnswered` exists to detect — billed the caller a full prompt estimate for an empty answer, on every request. `estimateMissingUsage` already states the rule this restores: nothing is estimated when nothing was delivered.

Reported figures always win; the estimate fills only a total absence, covers the prompt alone (a response of vectors, base64 or audio is not text), and reaches `recordTokenUsage` without entering the request log, which continues to report only what the provider measured.

## Verification

- Both new guards mutation-verified: reverting the streamed-path charge fails the TTS test, and removing the delivery gate fails with `charged 1 times for an empty answer, want 0`.
- The mislabelled TTS test is now an honest image-generation test, beside a real binary-response one that exercises the route TTS actually takes.
- `go test` on both touched packages (1,561 pass), `golangci-lint` clean, `make size-check` clean, `-race` clean.

**Known limit, stated rather than glossed:** `TestGeneratedTokenNeverReachesTheStructuredLogger` covers the helper, not `main()`. Re-adding the original `debuglog.Info(..., "token", ...)` call to `main()` would leave it green. `cmd/` is coverage-excluded and a `main()`-level test is awkward, so the guard is narrower than ideal.
