### PR TITLE
fix: refuse future-dated timestamps in every staleness check

### DIFF
--- a/cmd/server/discovery.go
+++ b/cmd/server/discovery.go
@@ -423,9 +423,44 @@ func syncFailoverAfterDiscovery(ctx context.Context, deps discoveryDeps, source 
 	return changed
 }
 
+// startupDiscoveryWindow is how recently a provider must have been discovered
+// for startup discovery to be skipped. It bounds a restart loop: without it a
+// crash-looping process would rescan every provider on each start.
+const startupDiscoveryWindow = 5 * time.Minute
+
+// anyRecentlyDiscovered reports whether any provider was discovered within
+// window of now.
+//
+// LastDiscoveredAt is read back off the providers row, so it carries no
+// monotonic reading: a backwards step of this host's clock leaves it dated
+// after now, and the raw `now.Sub(t) < window` this preserves is TRUE for the
+// resulting negative duration. That is the negative-duration bug class
+// (util.TrustedAge), and here the resulting answer - "recently discovered, skip
+// the startup run" - is deliberately kept rather than guarded.
+//
+// Skipping costs nothing. discoverySchedulerLoop (background.go) runs discovery
+// on its own timer without consulting this column, the per-provider and manual
+// endpoints write it too, and runDiscovery stamps each provider as it goes, so
+// the value self-corrects the moment any run touches a provider. Refusing the
+// stamp instead would rescan every provider on every restart of a crash-looping
+// process with a stepped clock, which is the exact upstream hammering
+// startupDiscoveryWindow exists to prevent. The safe direction at this site is
+// to under-discover, not to over-discover.
+func anyRecentlyDiscovered(providers []*provider.Provider, now time.Time, window time.Duration) bool {
+	for _, p := range providers {
+		if p.LastDiscoveredAt == nil {
+			continue
+		}
+		if now.Sub(*p.LastDiscoveredAt) < window {
+			return true
+		}
+	}
+	return false
+}
+
 // maybeStartupDiscovery launches the initial discovery run in the background,
 // unless discovery_on_startup is off or any provider was already discovered
-// within the last 5 minutes (a restart loop must not hammer providers).
+// within startupDiscoveryWindow (a restart loop must not hammer providers).
 func maybeStartupDiscovery(deps discoveryDeps, settingsRepo *settings.Repository) {
 	if !settingsRepo.GetBool(context.Background(), "discovery_on_startup", true) {
 		return
@@ -433,12 +468,7 @@ func maybeStartupDiscovery(deps discoveryDeps, settingsRepo *settings.Repository
 	recentlyDiscovered := false
 	providers, err := deps.providerRepo.List(context.Background())
 	if err == nil {
-		for _, p := range providers {
-			if p.LastDiscoveredAt != nil && time.Since(*p.LastDiscoveredAt) < 5*time.Minute {
-				recentlyDiscovered = true
-				break
-			}
-		}
+		recentlyDiscovered = anyRecentlyDiscovered(providers, time.Now(), startupDiscoveryWindow)
 	}
 	if recentlyDiscovered {
 		debuglog.Info("discovery: skipping startup — last discovery within 5 minutes")

--- a/cmd/server/discovery_test.go
+++ b/cmd/server/discovery_test.go
@@ -857,3 +857,53 @@ func TestRecordMissingModelsUntrustedWhenSuspect(t *testing.T) {
 		t.Error("a suspect scan must not record a miss")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Startup-discovery recency guard
+// ---------------------------------------------------------------------------
+
+// TestAnyRecentlyDiscovered covers the predicate maybeStartupDiscovery uses to
+// decide whether a restart loop is hammering providers.
+//
+// It is also where the negative-duration bug class is deliberately NOT guarded:
+// a future LastDiscoveredAt counts as "recently discovered" and suppresses the
+// startup run. See the function's comment for why under-discovering is the safe
+// direction here - the scheduler loop runs regardless, and refusing the stamp
+// would rescan every provider on every restart of a crash-looping process.
+func TestAnyRecentlyDiscovered(t *testing.T) {
+	now := time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
+	const window = 5 * time.Minute
+	at := func(d time.Duration) *time.Time { u := now.Add(d); return &u }
+
+	cases := []struct {
+		name      string
+		providers []*provider.Provider
+		want      bool
+	}{
+		{"no providers", nil, false},
+		{"never discovered", []*provider.Provider{{}}, false},
+		{"discovered just now", []*provider.Provider{{LastDiscoveredAt: at(-time.Second)}}, true},
+		{"discovered outside the window", []*provider.Provider{{LastDiscoveredAt: at(-window - time.Second)}}, false},
+		{"exactly at the window is outside it", []*provider.Provider{{LastDiscoveredAt: at(-window)}}, false},
+		{
+			name: "any one recent provider is enough",
+			providers: []*provider.Provider{
+				{LastDiscoveredAt: at(-time.Hour)},
+				{LastDiscoveredAt: at(-time.Second)},
+			},
+			want: true,
+		},
+		// A future stamp suppresses the run, on purpose. Pinned so the choice is
+		// visible: converting this to util.TrustedAge would flip both of these
+		// to false and rescan on every restart under a stepped clock.
+		{"a few seconds ahead counts as recent", []*provider.Provider{{LastDiscoveredAt: at(3 * time.Second)}}, true},
+		{"years ahead still counts as recent", []*provider.Provider{{LastDiscoveredAt: at(9 * 365 * 24 * time.Hour)}}, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := anyRecentlyDiscovered(c.providers, now, window); got != c.want {
+				t.Errorf("anyRecentlyDiscovered = %v, want %v", got, c.want)
+			}
+		})
+	}
+}

--- a/internal/api/fleet.go
+++ b/internal/api/fleet.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 	"github.com/hugalafutro/model-hotel/internal/events"
+	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
 // maxAnnounceBody bounds the announce request body. The payload is a handful of
@@ -156,7 +157,32 @@ func computeFleetStatus(ctx context.Context, s fleetSettings, now time.Time) (*F
 		debuglog.Warn("fleet: unparseable managed-seen-at; treating as standalone", "value", seen)
 		return nil, nil //nolint:nilerr // corrupt value means standalone, not error
 	}
-	age := now.Sub(seenAt)
+	// The stamp is written by this member and read back out of settings, so it
+	// carries no monotonic reading: a backwards step of the member's own clock
+	// leaves it dated ahead of now, and a raw subtraction then reports a
+	// negative age that is below every threshold below. util.TrustedAge absorbs
+	// ordinary skew and refuses to measure an impossible stamp.
+	age, aged := util.TrustedAge(now, seenAt)
+	if !aged {
+		// Same answer as the unparseable case above: a stamp describing a moment
+		// that has not happened says nothing about being managed, and treating it
+		// as fresh would pin the badge on forever for a member pulled out of the
+		// fleet.
+		//
+		// Deliberately not logged. Unlike a corrupt value, this condition
+		// persists until Front Desk announces again, and this function runs on
+		// /api/system (polled every 10s per open dashboard tab) and on
+		// isManagedMember for every synced-entity write, so a warning here would
+		// repeat several times a minute for as long as it lasted.
+		//
+		// The second caller is worth stating: isManagedMember reads this, so a
+		// member whose stamp is unusable also stops being treated as managed by
+		// managedWriteGuard and accepts local writes again. That is the same
+		// fail-open direction the guard already takes when Front Desk is away,
+		// and it is strictly better than the alternative this replaces, where a
+		// future stamp left those writes refused with 403 indefinitely.
+		return nil, nil
+	}
 	if age >= fleetForgetTTL {
 		return nil, nil // long gone: forget the fleet, behave as standalone again
 	}
@@ -331,8 +357,16 @@ func (h *FleetHandler) Announce(w http.ResponseWriter, r *http.Request) {
 }
 
 // ownerStale reports whether the current owner's last-heartbeat timestamp is
-// older than fleetManagedTTL (or absent/unparseable), meaning the owning Front
-// Desk is gone and its member may be adopted by a new one.
+// older than fleetManagedTTL (or absent, unparseable, or dated in the future),
+// meaning the owning Front Desk is gone and its member may be adopted by a new
+// one.
+//
+// The future case matters most here. A negative age is below fleetManagedTTL,
+// so a departed Front Desk would read as still live and every announce from its
+// replacement would be refused with 409. Nothing recovers from that on its own:
+// the only writer of a fresher stamp is the Front Desk that is gone. An
+// unusable stamp therefore gets the same answer as an absent one, which is
+// already the function's policy for anything it cannot trust.
 func ownerStale(seen string, now time.Time) bool {
 	if seen == "" {
 		return true
@@ -341,7 +375,11 @@ func ownerStale(seen string, now time.Time) bool {
 	if err != nil {
 		return true
 	}
-	return now.Sub(seenAt) >= fleetManagedTTL
+	age, aged := util.TrustedAge(now, seenAt)
+	if !aged {
+		return true
+	}
+	return age >= fleetManagedTTL
 }
 
 // rejectConflict surfaces a rejected ownership claim: a debounced Warn plus a

--- a/internal/api/fleet_test.go
+++ b/internal/api/fleet_test.go
@@ -573,3 +573,102 @@ func TestFleetStatusJSONOmitsWhenStandalone(t *testing.T) {
 		t.Errorf("standalone payload contains fleet key: %s", b)
 	}
 }
+
+// --------------------------------------------------------------------------
+// Future-dated heartbeats. _fleet_managed_seen_at is written by the member
+// itself (time.Now().UTC() in the announce handler) and read back out of the
+// settings table, so it carries no monotonic reading. A backwards step of the
+// member's own clock - an NTP correction, a VM restore, an RTC fixed up at boot
+// - leaves a stamp dated after "now", and every duration measured from it comes
+// out negative. See internal/util.TrustedAge.
+// --------------------------------------------------------------------------
+
+// TestOwnerStale_ImpossibleStampIsAdoptable covers the worst consequence: a
+// negative age is below fleetManagedTTL, so the departed Front Desk reads as
+// still live and its replacement is refused with 409 on every announce. Nothing
+// clears it, because the only writer of a fresher stamp is the Front Desk that
+// is gone. The wedge lasts as long as the clock step, which for a dead RTC
+// jumping years ahead is indistinguishable from forever.
+func TestOwnerStale_ImpossibleStampIsAdoptable(t *testing.T) {
+	now := time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
+	rfc := func(d time.Duration) string { return now.Add(d).Format(time.RFC3339) }
+
+	cases := []struct {
+		name string
+		seen string
+		want bool
+	}{
+		{"fresh heartbeat holds ownership", rfc(-10 * time.Second), false},
+		{"aged past the TTL is adoptable", rfc(-(fleetManagedTTL + time.Second)), true},
+		{"absent is adoptable", "", true},
+		{"unparseable is adoptable", "not-a-timestamp", true},
+		// Any future stamp is evidence of nothing and must be treated like an
+		// absent one rather than as a live owner. There is no tolerance band:
+		// this member writes the stamp itself with a whole-second RFC3339
+		// truncation, so it cannot legitimately land ahead of its own later now.
+		{"a second ahead is adoptable", rfc(time.Second), true},
+		{"years ahead is adoptable", rfc(9 * 365 * 24 * time.Hour), true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := ownerStale(c.seen, now); got != c.want {
+				t.Errorf("ownerStale(%q) = %v, want %v", c.seen, got, c.want)
+			}
+		})
+	}
+}
+
+// TestComputeFleetStatus_ImpossibleStampIsStandalone pins the read side. A
+// future stamp never reaches fleetForgetTTL, so a member pulled out of the
+// fleet would sit on a "member"/"primary" badge forever instead of self-
+// clearing to standalone. An unusable stamp is treated exactly like the
+// unparseable one the function already handles.
+func TestComputeFleetStatus_ImpossibleStampIsStandalone(t *testing.T) {
+	now := time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
+	f := newFakeFleetSettings()
+	f.values[keyFleetManagedSeenAt] = now.Add(time.Hour).Format(time.RFC3339)
+	f.values[keyFleetIsPrimary] = "true"
+
+	got, err := computeFleetStatus(context.Background(), f, now)
+	if err != nil {
+		t.Fatalf("computeFleetStatus: %v", err)
+	}
+	if got != nil {
+		t.Errorf("an impossible heartbeat must read as standalone, got %+v", got)
+	}
+}
+
+// TestComputeFleetStatus_ManagedWindowIsNotWidened pins the fleet badge's own
+// version of the rule in util.TrustedAge's tests: a member reads as actively
+// managed for exactly fleetManagedTTL after the recorded announce, and never
+// before it. A tolerance band on the age would light the badge up for stamps
+// dated ahead of now, widening the window past the TTL the constant promises -
+// which mattered here in particular, since the tolerance first written was 2
+// minutes against a 90-second TTL.
+func TestComputeFleetStatus_ManagedWindowIsNotWidened(t *testing.T) {
+	stamp := time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
+
+	managed := func(now time.Time) bool {
+		f := newFakeFleetSettings()
+		f.values[keyFleetManagedSeenAt] = stamp.Format(time.RFC3339)
+		f.values[keyFleetIsPrimary] = "false"
+		got, err := computeFleetStatus(context.Background(), f, now)
+		if err != nil {
+			t.Fatalf("computeFleetStatus: %v", err)
+		}
+		return got != nil && got.State == "member"
+	}
+
+	if managed(stamp.Add(-time.Second)) {
+		t.Error("a stamp one second ahead of now read as actively managed; the announce has not happened yet")
+	}
+	if !managed(stamp) {
+		t.Error("the announce instant itself must read as managed")
+	}
+	if !managed(stamp.Add(fleetManagedTTL - time.Second)) {
+		t.Error("still inside fleetManagedTTL must read as managed")
+	}
+	if managed(stamp.Add(fleetManagedTTL)) {
+		t.Error("at fleetManagedTTL the member must drop to warning, not stay managed")
+	}
+}

--- a/internal/frontdesk/autosync.go
+++ b/internal/frontdesk/autosync.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
+	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
 // HA auto config sync: the "set and forget" half of fleet config replication.
@@ -106,7 +107,21 @@ func autoSyncStaleTier(cfg AutoSyncConfig, lastSync time.Time, haveSync bool, no
 	if !haveSync {
 		return 1
 	}
-	switch age := now.Sub(lastSync); {
+	// lastSync comes back from SQLite as time.Unix(0, at).UTC() (store_fleet.go),
+	// so it has no monotonic reading and a backwards step of this host's clock
+	// leaves it dated after now. A raw subtraction would then be negative, which
+	// is under both thresholds, and a fleet that stopped syncing entirely would
+	// report tier 0 for as long as the step lasted - silencing the
+	// config.autosync_stale watchdog and the degraded/faulty fleet state
+	// together. util.TrustedAge absorbs ordinary skew and refuses the rest.
+	age, aged := util.TrustedAge(now, lastSync)
+	if !aged {
+		// Same answer as a fleet with no recorded sync at all: the timestamp
+		// cannot vouch for freshness, but neither can it honestly age far enough
+		// to claim tier 2.
+		return 1
+	}
+	switch {
 	case age > autoSyncFaultyThreshold:
 		return 2
 	case age > autoSyncStaleThreshold:

--- a/internal/frontdesk/autosync_divergence_test.go
+++ b/internal/frontdesk/autosync_divergence_test.go
@@ -839,6 +839,15 @@ func TestAutoSyncStaleTier(t *testing.T) {
 		{"just over a day", off, now.Add(-25 * time.Hour), true, 1},
 		{"just under three days", off, now.Add(-71 * time.Hour), true, 1},
 		{"over three days", off, now.Add(-73 * time.Hour), true, 2},
+		// LastRunAt comes back from SQLite as time.Unix(0, at).UTC() (store_fleet.go),
+		// so it carries no monotonic reading and a backwards step of Front Desk's own
+		// clock leaves it dated ahead of now. A raw subtraction then goes negative,
+		// which is under both thresholds, so a fleet that stopped syncing would report
+		// tier 0 - perfectly fresh - for as long as the step lasts. That silences the
+		// config.autosync_stale watchdog and the degraded/faulty fleet state at once,
+		// which is the whole point of the tier.
+		{"a second ahead cannot vouch for freshness", off, now.Add(time.Second), true, 1},
+		{"years ahead cannot vouch for freshness", off, now.Add(9 * 365 * 24 * time.Hour), true, 1},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/frontdesk/backups.go
+++ b/internal/frontdesk/backups.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
+	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
 // This file holds the watchdog for a member with no recent scheduled backup. It
@@ -130,12 +131,12 @@ func (s *Server) checkMemberBackups(ctx context.Context) {
 		newest, found := newestScheduledBackup(entries)
 		// The timestamp is parsed straight out of the member's own listing, so a
 		// member with a fast clock (or a bad created_at) can report a backup
-		// dated in the future. time.Since then returns a NEGATIVE duration,
-		// which never exceeds the threshold, so the staleness alert would be
-		// permanently silenced for exactly the member most likely to be
-		// misconfigured. An impossible age is treated as stale, not as fresh.
-		age := time.Since(newest)
-		if !found || age < 0 || age > memberBackupStaleAfter {
+		// dated in the future. A raw subtraction then returns a NEGATIVE
+		// duration, which never exceeds the threshold, so the staleness alert
+		// would be permanently silenced for exactly the member most likely to be
+		// misconfigured. util.TrustedAge treats an impossible age as stale.
+		age, aged := util.TrustedAge(time.Now(), newest)
+		if !found || !aged || age > memberBackupStaleAfter {
 			s.markBackupStale(ctx, m, newest, found)
 			continue
 		}

--- a/internal/frontdesk/poller_test.go
+++ b/internal/frontdesk/poller_test.go
@@ -561,3 +561,45 @@ func TestPollTraefikOnceMatchesStrippedLegacyURL(t *testing.T) {
 		t.Errorf("legacy member traefik status = %q, want UP", got)
 	}
 }
+
+// TestTraefikStalenessInputsKeepMonotonicReadings guards the exemption stated
+// above checkConfigStaleness in poller_versions.go.
+//
+// The three Traefik staleness checks subtract raw, without the util.TrustedAge
+// guard every settings- and database-backed staleness check in this codebase
+// uses. That is only safe while both operands carry Go monotonic readings, so
+// that Sub uses the monotonic clock and cannot go negative under a wall-clock
+// step. The whole risk of the exemption is a later refactor writing
+// `startedAt: time.Now().UTC()`, or wrapping p.now, or routing the stamp
+// through a store - each of which silently strips the reading and reinstates
+// the bug with no test failing. This is that test.
+//
+// Round(0) drops the monotonic reading, so a Time that differs from its own
+// Round(0) as a STRUCT still has one. (Equal would compare wall clocks, which
+// agree either way.)
+func TestTraefikStalenessInputsKeepMonotonicReadings(t *testing.T) {
+	p, _, _ := newTestPoller(t, "")
+
+	p.RecordConfigPoll()
+	p.mu.RLock()
+	last := p.lastConfigPollAt
+	p.mu.RUnlock()
+	if last.IsZero() {
+		t.Fatal("RecordConfigPoll left lastConfigPollAt zero")
+	}
+	if last == last.Round(0) { //nolint:staticcheck // QF1009: identity, not temporal equality
+		t.Error("lastConfigPollAt lost its monotonic reading: ConfigPollStale and " +
+			"checkConfigStaleness now compare wall clocks and need util.TrustedAge")
+	}
+
+	// p.now is the other operand of all three comparisons.
+	if n := p.now(); n == n.Round(0) { //nolint:staticcheck // QF1009: identity, not temporal equality
+		t.Error("p.now() lost its monotonic reading; the raw subtractions are no longer safe")
+	}
+
+	// Server.startedAt is ConfigPollWarm's second operand (fleetstate.go).
+	srv, _ := newTestServer(t)
+	if srv.startedAt == srv.startedAt.Round(0) { //nolint:staticcheck // QF1009: identity, not temporal equality
+		t.Error("Server.startedAt lost its monotonic reading; ConfigPollWarm now compares wall clocks")
+	}
+}

--- a/internal/frontdesk/poller_versions.go
+++ b/internal/frontdesk/poller_versions.go
@@ -144,6 +144,17 @@ func (p *Poller) fetchMemberBuild(ctx context.Context, baseURL, token string) (m
 	return out, nil
 }
 
+// The three Traefik staleness checks below subtract raw, without the
+// util.TrustedAge guard the settings- and database-backed staleness checks use,
+// and that is deliberate. Both operands are time.Time values taken by
+// time.Now() in THIS process (p.now is time.Now; lastConfigPollAt is assigned in
+// RecordConfigPoll; Server.startedAt in NewServer), so each carries a monotonic
+// reading and Sub uses the monotonic clock. No wall-clock step can make those
+// differences negative, which is the failure the guard exists for. Anything
+// that crosses a boundary - parsed from RFC3339, read back from a row, or
+// passed through .UTC()/.Round()/.Truncate() - loses the reading and does need
+// the guard. util.TrustedAge's doc comment carries the full rule.
+
 // checkConfigStaleness emits a single warning when Traefik has not polled the
 // dynamic config within the configured threshold. It resets on the next poll
 // (RecordConfigPoll), so a recovered provider re-arms the warning.

--- a/internal/ratelimit/fleet_share.go
+++ b/internal/ratelimit/fleet_share.go
@@ -3,6 +3,8 @@ package ratelimit
 import (
 	"context"
 	"time"
+
+	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
 // settingsKeyFleetActiveMembers is the instance-local count of StateActive fleet
@@ -60,8 +62,10 @@ func fleetDivisor(ctx context.Context, s SettingsReader) int {
 	if at == 0 {
 		return 1
 	}
-	// Negative age == future stamp; both ends of the range are untrustworthy.
-	if age := time.Since(time.Unix(int64(at), 0)); age < 0 || age > fleetDivisorTTL {
+	// Both ends of the range are untrustworthy: util.TrustedAge refuses a future
+	// stamp, and anything past the TTL has aged out.
+	age, aged := util.TrustedAge(time.Now(), time.Unix(int64(at), 0))
+	if !aged || age > fleetDivisorTTL {
 		return 1
 	}
 	return n

--- a/internal/util/staleness.go
+++ b/internal/util/staleness.go
@@ -1,0 +1,50 @@
+package util
+
+import "time"
+
+// TrustedAge measures how long ago t happened and reports whether that
+// measurement can be trusted.
+//
+// It exists because `now.Sub(t) < window` is wrong for any timestamp the
+// current process did not just take. A future t yields a NEGATIVE duration,
+// which is below every positive threshold, so the thing being aged reads as
+// "still fresh" forever and "too old" never. Nothing errors; the check simply
+// stops working. That bug has been found repeatedly in this codebase, always on
+// a timestamp that crossed a boundary: parsed from RFC3339, read back from a
+// database row, or received from a peer.
+//
+// Timestamps that stay inside one process do NOT need this. A time.Time from
+// time.Now() carries a monotonic reading, and Sub uses it whenever both
+// operands have one, so an in-process duration is immune to wall-clock steps.
+// Note that .UTC(), .Round() and .Truncate() strip that reading.
+//
+// A future stamp is refused outright rather than tolerated up to some skew
+// window, matching the two checks that already implement this rule by hand
+// (internal/ratelimit.fleetDivisor and the Front Desk backup listing). Every
+// caller here reads a stamp its own host wrote, and every writer rounds
+// downward - RFC3339 truncates to whole seconds, UnixNano and timestamptz are
+// exact - so no amount of ordinary clock jitter can legitimately place one in
+// the future. Only a backwards step of the clock can, and a tolerance would do
+// nothing but extend each caller's freshness window by its own width during
+// exactly that fault.
+//
+// (The quota repository clamps on WRITE with a two-minute tolerance instead.
+// That is a genuinely different problem - the same snapshot is redistributed
+// across hosts every 60s and relies on skip-if-newer to make repeats free, so
+// rewriting near-now stamps there breaks deduplication. Do not copy its
+// tolerance to a read-side check.)
+//
+// The zero Time is likewise untrusted; callers that need to tell "never
+// happened" from "happened long ago" must test IsZero themselves. In practice
+// each one already has a separate signal for it (a found flag, a haveSync
+// flag, or a nil pointer).
+func TrustedAge(now, t time.Time) (time.Duration, bool) {
+	if t.IsZero() {
+		return 0, false
+	}
+	age := now.Sub(t)
+	if age < 0 {
+		return 0, false
+	}
+	return age, true
+}

--- a/internal/util/staleness_test.go
+++ b/internal/util/staleness_test.go
@@ -1,0 +1,167 @@
+package util
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTrustedAge(t *testing.T) {
+	now := time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name    string
+		at      time.Time
+		wantAge time.Duration
+		wantOK  bool
+	}{
+		{"past is measured as-is", now.Add(-90 * time.Second), 90 * time.Second, true},
+		{"the present is zero", now, 0, true},
+		{"a long-past stamp keeps its full age", now.Add(-72 * time.Hour), 72 * time.Hour, true},
+		// Any future stamp is refused. There is no tolerance band: every caller
+		// reads a stamp its own host wrote, with a writer that rounds downward, so
+		// a future value can only mean the clock stepped back.
+		{"a nanosecond ahead is untrusted", now.Add(time.Nanosecond), 0, false},
+		{"a few seconds ahead is untrusted", now.Add(3 * time.Second), 0, false},
+		{"far future is untrusted", now.Add(9 * 365 * 24 * time.Hour), 0, false},
+		// The zero Time is not a measurement. Callers that distinguish "never
+		// happened" from "happened long ago" must check IsZero themselves; this
+		// only refuses to invent an age of ~2026 years for it.
+		{"the zero time is untrusted", time.Time{}, 0, false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			age, ok := TrustedAge(now, c.at)
+			if ok != c.wantOK {
+				t.Fatalf("TrustedAge ok = %v, want %v", ok, c.wantOK)
+			}
+			if age != c.wantAge {
+				t.Errorf("TrustedAge age = %v, want %v", age, c.wantAge)
+			}
+		})
+	}
+}
+
+// TestTrustedAgeNeverReturnsNegative is the whole point of the helper: every
+// caller compares the age against a threshold, and a negative duration is below
+// every positive one, so an unguarded future stamp reads as permanently fresh.
+func TestTrustedAgeNeverReturnsNegative(t *testing.T) {
+	now := time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
+	for _, ahead := range []time.Duration{
+		time.Nanosecond, time.Second, time.Minute, time.Hour,
+		24 * time.Hour, 365 * 24 * time.Hour,
+	} {
+		age, ok := TrustedAge(now, now.Add(ahead))
+		if age < 0 {
+			t.Errorf("stamp %v ahead produced a negative age %v", ahead, age)
+		}
+		if ok {
+			t.Errorf("stamp %v ahead reported as trusted", ahead)
+		}
+	}
+}
+
+// TestTrustedAgeFreshWindowIsExactlyTheCallersWindow pins what refusing every
+// future stamp actually buys, stated precisely.
+//
+// Hold a stamp fixed and sweep now across it. A caller's "trusted and inside my
+// window" verdict is false, then true, then false again: before the stamp's own
+// instant it is untrusted, and after the window it has aged out. That shape is
+// inherent - once the clock catches up, a stamp written before a backwards step
+// is indistinguishable from one genuinely written just now - so the guard does
+// NOT eliminate the interval during which a stepped clock reads as fresh.
+//
+// What it does is stop that interval being WIDER than the caller asked for. A
+// tolerance band of T reports age zero for a stamp up to T ahead, so the true
+// interval becomes [stamp-T, stamp+window): every caller's freshness window
+// silently grows by T. That mattered concretely - the tolerance first written
+// here was 2 minutes while the window it guarded (fleetManagedTTL) is 90
+// seconds, so the widening was larger than the window itself.
+//
+// This test fails if any tolerance is reintroduced.
+func TestTrustedAgeFreshWindowIsExactlyTheCallersWindow(t *testing.T) {
+	stamp := time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
+
+	for _, window := range []time.Duration{90 * time.Second, 5 * time.Minute, 24 * time.Hour} {
+		fresh := func(now time.Time) bool {
+			age, ok := TrustedAge(now, stamp)
+			return ok && age < window
+		}
+
+		// Sweep from well before the stamp to well past the window, at a
+		// resolution fine enough to place both edges exactly.
+		step := time.Second
+		var first, last time.Time
+		var seen bool
+		for offset := -10 * time.Minute; offset <= window+10*time.Minute; offset += step {
+			at := stamp.Add(offset)
+			if !fresh(at) {
+				continue
+			}
+			if !seen {
+				first, seen = at, true
+			}
+			last = at
+		}
+		if !seen {
+			t.Fatalf("window %v: never fresh", window)
+		}
+		// The first fresh instant must be the stamp itself, not earlier: an
+		// earlier one is a tolerance band admitting future stamps.
+		if !first.Equal(stamp) {
+			t.Errorf("window %v: first fresh at %v, want the stamp itself %v (a future stamp was accepted)",
+				window, first, stamp)
+		}
+		if got := last.Sub(first) + step; got != window {
+			t.Errorf("window %v: fresh interval spans %v, want exactly the window", window, got)
+		}
+	}
+}
+
+// TestMonotonicReadingIsWhatExemptsInProcessChecks documents why the Traefik
+// staleness checks in internal/frontdesk/poller_versions.go are deliberately
+// NOT converted to TrustedAge, and pins the stdlib property they rest on. The
+// companion test that the poller's own fields really do keep that reading lives
+// in internal/frontdesk (TestTraefikStalenessInputsKeepMonotonicReadings) -
+// this one only establishes the rule.
+func TestMonotonicReadingIsWhatExemptsInProcessChecks(t *testing.T) {
+	captured := time.Now()
+
+	// Round(0) strips the monotonic reading and is the documented way to ask
+	// whether one is present. The comparison is struct identity on purpose:
+	// Equal compares wall clocks, which agree by construction here, so it would
+	// be true whether or not a monotonic reading exists - the very distinction
+	// under test.
+	if captured == captured.Round(0) { //nolint:staticcheck // QF1009: identity, not temporal equality
+		t.Fatal("time.Now() carried no monotonic reading; the exemption does not hold")
+	}
+	if !captured.Equal(captured.Round(0)) {
+		t.Error("Round(0) must preserve the wall clock, only drop the monotonic reading")
+	}
+
+	// The trap: the conversions that look purely cosmetic drop it. A site that
+	// stores time.Now().UTC() has already lost the protection, which is why the
+	// exemption is stated per-site rather than "anything from time.Now()".
+	for name, stripped := range map[string]time.Time{
+		"UTC":      captured.UTC(),
+		"Round":    captured.Round(time.Second),
+		"Truncate": captured.Truncate(time.Second),
+	} {
+		if stripped != stripped.Round(0) {
+			t.Errorf("%s() unexpectedly kept the monotonic reading", name)
+		}
+	}
+
+	// In-process durations stay ordered: the poller's situation, where both
+	// operands come from time.Now() in the same process.
+	if got := time.Since(captured); got < 0 {
+		t.Errorf("in-process Sub went negative (%v)", got)
+	}
+
+	// Once the reading is gone, ordering is whatever the wall clock says, and a
+	// stamp that ended up ahead of "now" is exactly the swept bug.
+	wallNow := captured.Round(0)
+	if age, ok := TrustedAge(wallNow, wallNow.Add(time.Second)); ok || age != 0 {
+		t.Errorf("TrustedAge = (%v, %v), want (0, false)", age, ok)
+	}
+}

--- a/internal/webauthn/session.go
+++ b/internal/webauthn/session.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
+	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
 // AuthTokenTTL is the idle lifetime of an auth-token session: how long it
@@ -188,7 +189,18 @@ func (m *SessionManager) authenticate(ctx context.Context, token string, slide b
 	// still in use, and slide the expiry on the same beat, both throttled so
 	// the hot path does not gain a write per request. Best-effort: a failed
 	// stamp or extension must not fail an otherwise valid authentication.
-	if session.LastSeenAt == nil || now.Sub(*session.LastSeenAt) >= lastSeenThrottle {
+	// A future last_seen_at (this host's clock stepped back after the row was
+	// written; the column carries no monotonic reading) would make the raw
+	// subtraction negative, hold the throttle closed forever, and stop the
+	// session sliding while it is in active use - an unexplained logout. The
+	// touch below is the only writer of the column, so nothing else corrects it.
+	// util.TrustedAge keeps ordinary skew throttled and treats an impossible
+	// stamp as no stamp at all.
+	lastSeenAge, aged := time.Duration(0), false
+	if session.LastSeenAt != nil {
+		lastSeenAge, aged = util.TrustedAge(now, *session.LastSeenAt)
+	}
+	if !aged || lastSeenAge >= lastSeenThrottle {
 		if err := m.store.TouchSessionLastSeen(ctx, session.ID, now); err != nil {
 			debuglog.Error("webauthn: failed to stamp session last-seen", "error", err)
 		}

--- a/internal/webauthn/session_sliding_test.go
+++ b/internal/webauthn/session_sliding_test.go
@@ -333,3 +333,62 @@ func TestListAuthSessions_IncludesSlidSession(t *testing.T) {
 		t.Errorf("listed expiry %v, want the slid %v", rows[0].ExpiresAt, res.ExpiresAt)
 	}
 }
+
+// TestAuthenticate_FutureLastSeenStillSlides covers the negative-duration hole
+// in the throttle. last_seen_at is a timestamptz read back off the row, so a
+// backwards step of the server's clock can leave it dated ahead of now.
+// `now.Sub(*LastSeenAt) >= lastSeenThrottle` is then FALSE for the resulting
+// negative duration, so the touch never fires - and because that touch is the
+// only writer of last_seen_at, nothing corrects the stamp either. The session
+// stops sliding entirely and expires at its original deadline while in active
+// use, which for a user is an unexplained logout.
+func TestAuthenticate_FutureLastSeenStillSlides(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+	mgr := NewSessionManager(repo)
+
+	token := mintSession(t, repo, mgr, "admin-future-lastseen")
+	// A negative "ago" puts last_seen_at in the future.
+	ageSession(t, repo, token, 48*time.Hour, AuthTokenTTL-time.Hour, -2*time.Hour)
+	before := sessionByToken(t, repo, token).ExpiresAt
+
+	res, ok := mgr.Authenticate(ctx, token)
+	if !ok {
+		t.Fatal("token should validate")
+	}
+	if !res.Extended {
+		t.Fatal("Extended = false: a future last_seen_at froze the slide, so the session expires while in use")
+	}
+	if after := sessionByToken(t, repo, token).ExpiresAt; !after.After(before) {
+		t.Errorf("expires_at %v did not move past %v", after, before)
+	}
+}
+
+// TestAuthenticate_FutureLastSeenSelfCorrects pins why refusing a future stamp
+// costs at most one extra write per session rather than a write per request:
+// the touch it releases rewrites last_seen_at with the current clock, so the
+// throttle closes again immediately. Without this the guard would look like a
+// write-amplification risk under a fleet-wide clock step.
+func TestAuthenticate_FutureLastSeenSelfCorrects(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+	mgr := NewSessionManager(repo)
+
+	token := mintSession(t, repo, mgr, "admin-selfcorrect-lastseen")
+	ageSession(t, repo, token, 48*time.Hour, AuthTokenTTL-time.Hour, -2*time.Hour)
+
+	if res, ok := mgr.Authenticate(ctx, token); !ok || !res.Extended {
+		t.Fatalf("first call: ok=%v extended=%v, want both true", ok, res.Extended)
+	}
+	if seen := sessionByToken(t, repo, token).LastSeenAt; seen == nil || seen.After(time.Now().Add(time.Minute)) {
+		t.Fatalf("the touch must rewrite last_seen_at to the current clock, got %v", seen)
+	}
+	// Second call: the stamp is sane again, so the throttle holds.
+	res, ok := mgr.Authenticate(ctx, token)
+	if !ok {
+		t.Fatal("second call should validate")
+	}
+	if res.Extended {
+		t.Error("Extended = true on the second call: the corrected stamp must re-close the throttle")
+	}
+}


### PR DESCRIPTION
Sweeps the outstanding sites of a bug class this repo has now hit six times, and gives it one shared, documented guard instead of a sixth hand-rolled comparison.

## The class

`time.Since(t) < window` and `now.Sub(t) > maxAge` are wrong for any timestamp the current process did not just take. A **future** `t` yields a **negative** duration, which is below every positive threshold, so the thing being aged reads as "still fresh" forever and "too old" never. Nothing errors and nothing logs; the check simply stops working.

## The guard

`internal/util.TrustedAge(now, t) (time.Duration, bool)` — a past stamp is measured as-is, and **any** future stamp is refused.

There is deliberately **no skew-tolerance band**. Every caller here reads a stamp its own host wrote, and every writer rounds downward (`Format(time.RFC3339)` truncates to whole seconds; `UnixNano` and `timestamptz` are exact), so ordinary jitter cannot legitimately place one in the future — only a backwards clock step can. A tolerance would do nothing during normal operation and, during exactly the fault it claims to absorb, would **widen every caller's freshness window by its own width**. The first draft of this change made that mistake concretely: a 2-minute tolerance guarding a 90-second `fleetManagedTTL`, so the widening exceeded the window itself.

This also makes the codebase hold **one** policy. `internal/ratelimit.fleetDivisor` and the Front Desk backup watchdog already implemented this rule by hand, strictly; both now call the helper. Their existing tests pass unchanged, which is the proof it is a pure unification.

The quota repository keeps its own 2-minute clamp on the **write** side, for a genuinely different problem — the same snapshot is redistributed across hosts every 60s and relies on skip-if-newer to make repeats free, so rewriting near-now stamps there breaks deduplication. The doc comment says so, to stop it being copied to a read-side check.

## Sites converted

**1. `internal/api/fleet.go` — the one that wedges permanently.** `_fleet_managed_seen_at` is written by the member (`time.Now().UTC()`) and read back as RFC3339. A backwards step of the member's own clock leaves it dated ahead of now, and `ownerStale` then reports the *departed* Front Desk as still live. Its replacement is refused with **409 on every announce**, and nothing recovers: the write that would fix the stamp sits behind the very ownership check that is failing, so the only writer of a fresher value is the Front Desk that is gone. A `pg_dump` restored onto a host whose clock trails the backup source produces the same state with no clock step at all.

`computeFleetStatus` had the same read on the forget window, where a future stamp pins the dashboard's fleet badge on forever for a member pulled out of the fleet. Note the second consumer: `isManagedMember` reads it, so an unusable stamp also stops `managedWriteGuard` treating the member as managed and lets local writes through again — the same fail-open direction the guard already takes when Front Desk is away, and strictly better than leaving those writes 403'd indefinitely.

**2. `internal/frontdesk/autosync.go`.** `LastRunAt` comes back from SQLite as `time.Unix(0, at).UTC()`. A future value made `autoSyncStaleTier` report tier 0 — perfectly fresh — for a fleet that had stopped syncing entirely, silencing the `config.autosync_stale` watchdog and the degraded/faulty fleet state together. An untrusted stamp is now tier 1: the same answer as a fleet with no recorded sync, since it cannot vouch for freshness but cannot honestly age far enough to claim tier 2 either.

**3. `internal/webauthn/session.go`.** A future `last_seen_at` held the `lastSeenThrottle` closed permanently, so the sliding-expiry touch never fired and a session in active use stopped sliding and expired at its original deadline — for the operator, an unexplained logout. Cost of the guard is bounded: the touch it releases rewrites the column with the current clock, so a fleet-wide clock step costs exactly one extra write per session, not one per request. There is a test for that.

## Sites deliberately left alone, with the reason in place

**The three Traefik staleness checks** (`internal/frontdesk/poller_versions.go`) subtract raw, and should. Both operands are `time.Time` values taken by `time.Now()` in the same process, so each carries a Go monotonic reading and `Sub` uses the monotonic clock — no wall-clock step can make those differences negative. The risk is a later refactor writing `startedAt: time.Now().UTC()` or wrapping `p.now`, which strips the reading silently. `TestTraefikStalenessInputsKeepMonotonicReadings` now guards precisely that, and is mutation-verified against that exact edit.

**Startup discovery** (`cmd/server/discovery.go`) keeps treating a future `LastDiscoveredAt` as "recently discovered". Skipping costs nothing — `discoverySchedulerLoop` runs on its own timer without consulting the column, the manual endpoints write it, and `runDiscovery` stamps each provider as it goes, so the value self-corrects the moment any run touches a provider. Refusing the stamp would instead rescan every provider on every restart of a crash-looping process with a stepped clock, which is the exact upstream hammering `startupDiscoveryWindow` exists to prevent. The predicate is still extracted as `anyRecentlyDiscovered` so the behaviour is testable and the choice is pinned; the previous test could only assert the call did not panic.

**Two further candidates are not bugs.** `discovery_claim_alert.go` computes `oldestAt` as the *minimum* stamp across claims, and a future value is never the minimum — it only bites when every claim is future-dated, where suppressing the alert is the answer the guard would give anyway. `discovery_claims.go` lets a future `LastSeenAt` fall through to `Gone`, which is the counted, operator-visible state; the guard would reclassify it to `Stale`, which is uncounted, making alerting *quieter*. (That one is genuinely cross-host — `models.last_seen_at` is written by the Postgres clock and compared against the Go app clock — so future-dating is more likely there than at any converted site. It still fails loud.)

## Verification

- Every guard is mutation-verified: reverting each to a raw subtraction fails the test covering it.
- The window-width tests fail if a tolerance band is reintroduced, reporting the widened span (`fresh interval spans 3m30s, want exactly the window`). An earlier pair of tests here asserted a monotonicity property that does not actually hold — the false→true→false shape is inherent, since a stamp becomes indistinguishable from a genuine one once the clock catches up — and passed vacuously. They were replaced rather than kept.
- `go test` on six packages, `golangci-lint` clean, `make size-check` clean, `-race` clean.
