### PR TITLE
fix(proxy): never meter a delivered pass-through request as zero

### DIFF
--- a/internal/proxy/helpers.go
+++ b/internal/proxy/helpers.go
@@ -341,6 +341,24 @@ func estimateTokens(textBytes int) int {
 // bytesPerToken is the conventional text-to-token ratio the estimates above use.
 const bytesPerToken = 4
 
+// minPassthroughTokens is the floor chargePassthroughUsage applies to a
+// pass-through request that was delivered but whose prompt sizes to nothing. It exists because the multipart
+// families (speech-to-text, image edits and variations) carry their payload as
+// an uploaded file, which is deliberately not measured, and their only promptable
+// field is optional or absent — so the honest estimate is zero and the request
+// would otherwise be free.
+//
+// One token, not a guess at the upload's real cost. Anything proportional to
+// file bytes would invent a charge: audio is billed by duration and images by
+// dimension, neither of which a byte count approximates. The floor's job is to
+// stop a served request metering as nothing, so it reaches tokens_used and the
+// TPM bucket at all; a provider that reports real usage always displaces it.
+//
+// It does NOT reach the request log, which continues to report only what the
+// provider measured, so a metered-by-floor request still shows 0 tokens there.
+// That is the same split the chat and streaming estimates keep.
+const minPassthroughTokens = 1
+
 // estimateMissingUsage fills in token counts the provider did not report, so a
 // request that delivered output is always charged against the TPM budget and
 // the key's tokens_used counter. Usage arrives in the LAST chunk of an OpenAI

--- a/internal/proxy/multimodal.go
+++ b/internal/proxy/multimodal.go
@@ -420,11 +420,16 @@ func (h *Handler) serveBufferedJSONPassthrough(w http.ResponseWriter, st *reques
 		// quota WITHOUT being reported as measured usage, matching what the
 		// chat and streaming paths do (they update the log before calling
 		// estimateMissingUsage) and keeping the stats pages honest.
-		estimated := estimateTokens(logData.promptTextBytes)
+		//
+		// Charged through the same helper as every other pass-through branch,
+		// rather than hand-rolled here. Hand-rolling it is what left this branch
+		// free: it carried its own `if estimated > 0` guard, so the zero-prompt
+		// families skipped the debit exactly as they did below. /images/variations
+		// has no prompt field at all, and four b64_json images clear the 8 MiB cap
+		// routinely, so the endpoint that motivated the floor was still free on
+		// precisely the requests the provider bills most for.
 		h.finalizePassthroughLog(st, resp.StatusCode, attempt, responseHeaderMs, 0, 0, "completed", "")
-		if estimated > 0 {
-			h.recordTokenUsage(st.vkHash, logData, estimated, 0, 0)
-		}
+		estimated, _ := h.chargePassthroughUsage(st, 0, 0, answered)
 		debuglog.Info("proxy: passthrough completed (oversized json)", "endpoint", logData.endpointType, "model", logData.modelID, "provider", logData.providerName, "attempt", attempt, "status", resp.StatusCode, "bytes", written, "estimated_prompt_tokens", estimated)
 		return
 	}
@@ -471,6 +476,21 @@ func (h *Handler) serveBufferedJSONPassthrough(w http.ResponseWriter, st *reques
 // vectors or base64 or audio, not text, so sizing it the way the streaming path
 // sizes delivered text would invent an enormous completion charge.
 //
+// A delivered request that reaches this helper is never charged zero. (Every
+// pass-through branch does reach it -- the oversized-JSON one was hand-rolling
+// its own debit and was the last exception.) The estimate legitimately sizes to
+// nothing on the multipart families: multipartPromptTextBytes counts only the
+// "prompt" form field, which is optional on transcriptions and translations and
+// absent entirely from /images/variations, so the ordinary shape of those
+// requests carries no promptable text at all. Without the floor a served
+// transcription cost the key nothing — no tokens_used, no TPM draw — on every
+// request. The upload is still not measured, for the reason given on
+// multipartPromptTextBytes, so this is deliberately a floor and not a
+// proportional estimate: it makes the request countable, not priced. A provider
+// that reports real usage always displaces it, and per-key RPS limiting -- on by
+// default over the whole /v1 group, though an operator can set rps <= 0 for
+// unlimited -- bounds request volume independently.
+//
 // Returns what was charged and whether the prompt was estimated, for the log.
 func (h *Handler) chargePassthroughUsage(st *requestState, promptTokens, completionTokens int, delivered bool) (charged int, estimated bool) {
 	logData := st.logData
@@ -480,6 +500,9 @@ func (h *Handler) chargePassthroughUsage(st *requestState, promptTokens, complet
 			return 0, false
 		}
 		chargePrompt, estimated = estimateTokens(logData.promptTextBytes), true
+		if chargePrompt < minPassthroughTokens {
+			chargePrompt = minPassthroughTokens
+		}
 	}
 	if chargePrompt > 0 || chargeCompletion > 0 {
 		h.recordTokenUsage(st.vkHash, logData, chargePrompt, chargeCompletion, 0)

--- a/internal/proxy/passthrough_metering_test.go
+++ b/internal/proxy/passthrough_metering_test.go
@@ -380,12 +380,18 @@ func TestMultipartPromptTextBytes_SizesFormFieldsNotTheUpload(t *testing.T) {
 	}
 }
 
-// TestMultipartPromptTextBytes_MetadataOnlyFormChargesNothing is the overcharge
+// TestMultipartPromptTextBytes_MetadataOnlyFormSizesNothing is the overcharge
 // guard. Every field on these forms except "prompt" is configuration, so a
-// request that sends only options and a file must cost the caller nothing: an
+// request that sends only options and a file must size to zero PROMPT BYTES: an
 // allowlist keeps a newly added provider parameter from silently becoming
 // billable text.
-func TestMultipartPromptTextBytes_MetadataOnlyFormChargesNothing(t *testing.T) {
+//
+// Zero bytes is not zero charge. This is the exact shape that made a served
+// transcription free, so the charge path applies minPassthroughTokens on top —
+// see TestMultipartPassthrough_NoPromptFieldStillMeters. The two are separate
+// on purpose: the sizer says what text the caller sent, the charge decides what
+// a delivered request costs.
+func TestMultipartPromptTextBytes_MetadataOnlyFormSizesNothing(t *testing.T) {
 	parts := []multipartPart{
 		{fieldName: "model", data: []byte("whisper-1")},
 		{fieldName: "language", data: []byte("en")},
@@ -398,5 +404,287 @@ func TestMultipartPromptTextBytes_MetadataOnlyFormChargesNothing(t *testing.T) {
 	}
 	if got := multipartPromptTextBytes(parts); got != 0 {
 		t.Errorf("sized %d, want 0: configuration fields are not prompt text and must not be charged", got)
+	}
+}
+
+// TestMultipartPassthrough_NoPromptFieldStillMeters closes the free-request
+// hole the allowlist above left behind.
+//
+// multipartPromptTextBytes counts only the "prompt" form field, correctly: every
+// other field is configuration and charging for it bills the caller for their
+// own options. But "prompt" is OPTIONAL on transcriptions and translations, and
+// /images/variations has no such field at all, so the ordinary shape of these
+// requests sizes as zero. The estimate then came out zero, nothing was debited,
+// and a served transcription cost the key nothing at all — no tokens_used, no
+// TPM draw — on every request.
+//
+// A served pass-through request is never free. The upload still is not measured
+// (see multipartPromptTextBytes: it is the payload, not the prompt, and sizing
+// it would invent an enormous charge), so what is charged is a floor, not a
+// proportional estimate.
+func TestMultipartPassthrough_NoPromptFieldStillMeters(t *testing.T) {
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+	vkRepo := &mockVirtualKeyRepo{}
+	h.virtualKeyRepo = vkRepo
+
+	// Exactly what ingestMultipartRequest produces for a transcription that
+	// sends only a file and its options: no prompt field, so zero prompt bytes.
+	parts := []multipartPart{
+		{fieldName: "model", data: []byte("whisper-1")},
+		{fieldName: "response_format", data: []byte("json")},
+		{fieldName: "file", fileName: "audio.mp3", data: make([]byte, 3<<20)},
+	}
+	logData := &requestLogData{
+		id:              uuid.New().String(),
+		modelID:         "whisper-1",
+		endpointType:    endpointTypeSTT,
+		virtualKeyName:  "test-key",
+		virtualKeyID:    "00000000-0000-0000-0000-000000000001",
+		state:           "streaming",
+		promptTextBytes: multipartPromptTextBytes(parts),
+	}
+	if logData.promptTextBytes != 0 {
+		t.Fatalf("probe sized %d prompt bytes, want 0 (the case under test)", logData.promptTextBytes)
+	}
+	st := &requestState{startTime: time.Now(), logData: logData, vkHash: "test-hash"}
+	h.insertRequestLogAsync(logData)
+	time.Sleep(20 * time.Millisecond)
+
+	// A real transcription answer, with no usage block (the common case).
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"text":"hello there"}`)),
+	}
+	h.serveBufferedJSONPassthrough(httptest.NewRecorder(), st, modelCandidate{
+		model:    &model.Model{ID: uuid.New(), ModelID: "whisper-1"},
+		provider: &provider.Provider{ID: uuid.New(), Name: "test-provider"},
+	}, resp, "application/json", 1, 10.0)
+
+	got := singleAddTokens(t, vkRepo)
+	if got == 0 {
+		t.Fatal("charged 0 tokens: a served transcription with no prompt field is free, evading tokens_used and the TPM budget")
+	}
+	// Literal, not minPassthroughTokens: comparing the charge against the same
+	// constant the code uses would pass for any value of it, including one large
+	// enough to overcharge every zero-prompt request. The floor is a
+	// billing-visible number, so changing it should break a test.
+	if got != 1 {
+		t.Errorf("charged %d tokens, want 1 (minPassthroughTokens)", got)
+	}
+	if logData.tokensPrompt != 0 {
+		t.Errorf("request log prompt = %d, want 0: a floor is not measured usage", logData.tokensPrompt)
+	}
+}
+
+// TestMultipartPassthrough_FloorDoesNotDisplaceRealFigures keeps the floor from
+// becoming a ceiling or a substitute: a request that does carry prompt text is
+// charged its estimate, and a provider that reports usage is charged that.
+func TestMultipartPassthrough_FloorDoesNotDisplaceRealFigures(t *testing.T) {
+	newLog := func(promptBytes int) *requestLogData {
+		return &requestLogData{
+			id:              uuid.New().String(),
+			modelID:         "whisper-1",
+			endpointType:    endpointTypeSTT,
+			virtualKeyName:  "test-key",
+			virtualKeyID:    "00000000-0000-0000-0000-000000000001",
+			state:           "streaming",
+			promptTextBytes: promptBytes,
+		}
+	}
+
+	t.Run("a sized prompt is charged its estimate, not the floor", func(t *testing.T) {
+		h := newIntegrationHandler()
+		t.Cleanup(func() { stopUnitHandler(h) })
+		vkRepo := &mockVirtualKeyRepo{}
+		h.virtualKeyRepo = vkRepo
+
+		logData := newLog(400) // 100 tokens, far above the floor
+		st := &requestState{startTime: time.Now(), logData: logData, vkHash: "test-hash"}
+		h.insertRequestLogAsync(logData)
+		time.Sleep(20 * time.Millisecond)
+
+		resp := &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"text":"ok"}`)),
+		}
+		h.serveBufferedJSONPassthrough(httptest.NewRecorder(), st, modelCandidate{
+			model:    &model.Model{ID: uuid.New(), ModelID: "whisper-1"},
+			provider: &provider.Provider{ID: uuid.New(), Name: "test-provider"},
+		}, resp, "application/json", 1, 10.0)
+
+		if got := singleAddTokens(t, vkRepo); got != 100 {
+			t.Errorf("charged %d, want 100: the floor must not replace a real estimate", got)
+		}
+	})
+
+	t.Run("reported usage wins over the floor", func(t *testing.T) {
+		h := newIntegrationHandler()
+		t.Cleanup(func() { stopUnitHandler(h) })
+		vkRepo := &mockVirtualKeyRepo{}
+		h.virtualKeyRepo = vkRepo
+
+		logData := newLog(0)
+		st := &requestState{startTime: time.Now(), logData: logData, vkHash: "test-hash"}
+		h.insertRequestLogAsync(logData)
+		time.Sleep(20 * time.Millisecond)
+
+		resp := &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body: io.NopCloser(strings.NewReader(
+				`{"text":"ok","usage":{"prompt_tokens":7,"completion_tokens":3,"total_tokens":10}}`)),
+		}
+		h.serveBufferedJSONPassthrough(httptest.NewRecorder(), st, modelCandidate{
+			model:    &model.Model{ID: uuid.New(), ModelID: "whisper-1"},
+			provider: &provider.Provider{ID: uuid.New(), Name: "test-provider"},
+		}, resp, "application/json", 1, 10.0)
+
+		if got := singleAddTokens(t, vkRepo); got != 10 {
+			t.Errorf("charged %d, want 10: a reported figure always wins", got)
+		}
+	})
+}
+
+// TestPassthroughFloor_StaysBehindTheDeliveryGate keeps the floor from undoing
+// the gate it sits behind. An aggregator in front of a retired model answering
+// 200 with `{"data":[]}` served nothing, and charging even one token there would
+// bill the caller on every empty answer — the regression the gate was added to
+// prevent.
+//
+// Embeddings is the endpoint this can be shown on: passthroughAnswered only
+// inspects the body for that type. For the multipart and binary families any
+// non-empty 200 body counts as delivered, so a junk answer there does draw the
+// floor. That is the intended trade — one token is the price of not being able
+// to tell a bad transcription from a good one, and per-key RPS limiting bounds
+// how often it can be paid.
+func TestPassthroughFloor_StaysBehindTheDeliveryGate(t *testing.T) {
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+	vkRepo := &mockVirtualKeyRepo{}
+	h.virtualKeyRepo = vkRepo
+
+	logData := &requestLogData{
+		id:              uuid.New().String(),
+		modelID:         "text-embedding-3-small",
+		endpointType:    endpointTypeEmbeddings,
+		virtualKeyName:  "test-key",
+		virtualKeyID:    "00000000-0000-0000-0000-000000000001",
+		state:           "streaming",
+		promptTextBytes: 0,
+	}
+	st := &requestState{startTime: time.Now(), logData: logData, vkHash: "test-hash"}
+	h.insertRequestLogAsync(logData)
+	time.Sleep(20 * time.Millisecond)
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"data":[]}`)),
+	}
+	h.serveBufferedJSONPassthrough(httptest.NewRecorder(), st, modelCandidate{
+		model:    &model.Model{ID: uuid.New(), ModelID: "text-embedding-3-small"},
+		provider: &provider.Provider{ID: uuid.New(), Name: "test-provider"},
+	}, resp, "application/json", 1, 10.0)
+
+	if n := len(vkRepo.addTokensCalls); n != 0 {
+		t.Errorf("charged %d times for an empty answer, want 0: the floor must not defeat the delivery gate", n)
+	}
+}
+
+// TestOversizedPassthrough_ZeroPromptStillMeters covers the sibling branch the
+// first attempt at the floor missed.
+//
+// serveBufferedJSONPassthrough charges in two places: the ordinary path, and an
+// oversized path that streams past the 8 MiB cap with usage extraction skipped.
+// The oversized one hand-rolled its own estimate behind the identical
+// `if estimated > 0` guard, so the zero-prompt families were still free there
+// after the floor was added below it. /images/variations has no prompt field at
+// all and four b64_json images clear the cap routinely, so the endpoint that
+// motivated the fix stayed free on exactly the requests that cost the most.
+func TestOversizedPassthrough_ZeroPromptStillMeters(t *testing.T) {
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+	vkRepo := &mockVirtualKeyRepo{}
+	h.virtualKeyRepo = vkRepo
+
+	logData := &requestLogData{
+		id:              uuid.New().String(),
+		modelID:         "dall-e-2",
+		endpointType:    endpointTypeImage,
+		virtualKeyName:  "test-key",
+		virtualKeyID:    "00000000-0000-0000-0000-000000000001",
+		state:           "streaming",
+		promptTextBytes: 0, // /images/variations carries no prompt field
+	}
+	st := &requestState{startTime: time.Now(), logData: logData, vkHash: "test-hash"}
+	h.insertRequestLogAsync(logData)
+	time.Sleep(20 * time.Millisecond)
+
+	// A body past passthroughJSONBufferCap, as four b64_json images produce.
+	huge := `{"created":1,"data":[{"b64_json":"` + strings.Repeat("A", passthroughJSONBufferCap+16) + `"}]}`
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(huge)),
+	}
+	h.serveBufferedJSONPassthrough(httptest.NewRecorder(), st, modelCandidate{
+		model:    &model.Model{ID: uuid.New(), ModelID: "dall-e-2"},
+		provider: &provider.Provider{ID: uuid.New(), Name: "test-provider"},
+	}, resp, "application/json", 1, 10.0)
+
+	got := singleAddTokens(t, vkRepo)
+	if got == 0 {
+		t.Fatal("charged 0 tokens: an oversized answer with no prompt text is free, on the costliest requests")
+	}
+	if got != 1 {
+		t.Errorf("charged %d tokens, want 1 (minPassthroughTokens)", got)
+	}
+}
+
+// TestStreamedPassthrough_ZeroPromptStillMeters pins the floor on the OTHER
+// serve path. A transcription with response_format=text|srt|vtt answers
+// text/plain, which is neither JSON nor SSE, so it routes to
+// serveStreamedPassthrough — a branch none of the other floor tests touch.
+// Without this, a refactor that inlined the floor into the buffered branch
+// would keep the suite green while re-freeing every non-JSON transcription.
+func TestStreamedPassthrough_ZeroPromptStillMeters(t *testing.T) {
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+	vkRepo := &mockVirtualKeyRepo{}
+	h.virtualKeyRepo = vkRepo
+
+	logData := &requestLogData{
+		id:              uuid.New().String(),
+		modelID:         "whisper-1",
+		endpointType:    endpointTypeSTT,
+		virtualKeyName:  "test-key",
+		virtualKeyID:    "00000000-0000-0000-0000-000000000001",
+		state:           "streaming",
+		promptTextBytes: 0,
+	}
+	st := &requestState{startTime: time.Now(), logData: logData, vkHash: "test-hash"}
+	h.insertRequestLogAsync(logData)
+	time.Sleep(20 * time.Millisecond)
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/plain"}},
+		Body:       io.NopCloser(strings.NewReader("hello there, this is the transcript")),
+	}
+	h.serveStreamedPassthrough(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/v1/audio/transcriptions", http.NoBody),
+		st, modelCandidate{
+			model:    &model.Model{ID: uuid.New(), ModelID: "whisper-1"},
+			provider: &provider.Provider{ID: uuid.New(), Name: "test-provider"},
+		}, resp, "text/plain", false, 1, 10.0)
+
+	got := singleAddTokens(t, vkRepo)
+	if got == 0 {
+		t.Fatal("charged 0 tokens: a response_format=text transcription answers text/plain and is free on the streamed path")
+	}
+	if got != 1 {
+		t.Errorf("charged %d tokens, want 1 (minPassthroughTokens)", got)
 	}
 }

--- a/internal/proxy/usage_estimate_test.go
+++ b/internal/proxy/usage_estimate_test.go
@@ -136,8 +136,13 @@ func (d *deliveredRecorder) Write(b []byte) (int, error) {
 }
 
 // singleAddTokens returns the one charge recorded against the key.
-// recordTokenUsage always reaches the repo, with 0 when nothing is owed, so a
-// zero here means "nothing charged", not "nothing recorded".
+//
+// On the chat and streaming paths recordTokenUsage always reaches the repo,
+// with 0 when nothing is owed, so a zero here means "nothing charged", not
+// "nothing recorded". The pass-through path differs: chargePassthroughUsage
+// skips the call entirely when nothing is owed, so a caller asserting "not
+// charged" there must check the call count rather than expect a zero from this
+// helper (see TestPassthroughFloor_StaysBehindTheDeliveryGate).
 func singleAddTokens(t *testing.T, repo *mockVirtualKeyRepo) int {
 	t.Helper()
 	require.Len(t, repo.addTokensCalls, 1, "AddTokens should be called exactly once")


### PR DESCRIPTION
Closes the one finding from the third Strix run (DeepSeek 4 Pro, diff scope over #797–#799): the multipart pass-through endpoints meter **zero tokens**.

## The hole

`multipartPromptTextBytes` counts only the `prompt` form field. That allowlist is right and stays — a prior review found the denylist version charging callers for `language`, `temperature`, `response_format`, `size`, `n`, i.e. their own configuration, and a denylist fails billable-by-default every time a provider adds a parameter.

But `prompt` is **optional** on `/v1/audio/transcriptions` and `/v1/audio/translations`, and **absent entirely** from `/v1/images/variations`. So the ordinary shape of those requests sizes to zero prompt bytes, the estimate came out zero, and the debit was skipped: the request was served, the provider billed, and neither `tokens_used` nor the TPM bucket moved. Any virtual-key holder could do it, on every request.

The scan framed this as unlimited compute. It is narrower than that — per-key RPS limiting is mounted over the whole `/v1` group and on by default, so request volume is bounded independently. What was genuinely broken is the accounting.

## The fix

`minPassthroughTokens = 1`, applied by `chargePassthroughUsage` when the provider reported no usage and the estimate sizes to nothing.

A **floor, not a price**. Sizing the upload would invent a charge: audio is billed by duration and images by dimension, and a byte count approximates neither — the same reason this file already refuses to size `image_url` parts, and the reason the streaming path's delivered-bytes arithmetic is kept away from vectors and base64. The floor's job is to make a served request countable, not to guess what it cost.

Two properties it must not break, both pinned:

- **Reported usage always wins.** The floor only fills a total absence.
- **It stays behind the delivery gate.** A 200 carrying `{"data":[]}` — an aggregator in front of a retired model — served nothing, and charging even one token there would bill the caller on every empty answer, which is the regression the gate exists to prevent.

## One branch was not enough, again

`serveBufferedJSONPassthrough` charges in **two** places. The first attempt converted the ordinary path and left the oversized one — responses past the 8 MiB cap, where usage extraction is skipped to bound memory — still hand-rolling its own estimate behind the identical `if estimated > 0` guard.

That is not a corner. `/images/variations` has no prompt field at all, and four `b64_json` images clear the cap routinely, so the endpoint that motivated this fix stayed free on precisely the requests the provider charges most for. Small response: 1 token. Large response: nothing.

The oversized branch now charges through the same helper as every other path. That is the actual repair — one debit site rather than three that have to be remembered separately — and it is the third time in this package that fixing one branch and leaving its sibling has had to be corrected in review.

## Coverage of the serve paths

The floor had to be shown on all three, because they are reached by different request shapes and nothing else forces them to agree:

| Path | Reached by |
|---|---|
| `serveBufferedJSONPassthrough`, normal | transcription with `response_format=json`, image edits |
| `serveBufferedJSONPassthrough`, oversized | `/images/variations` with several `b64_json` images |
| `serveStreamedPassthrough` | `response_format=text\|srt\|vtt` (answers `text/plain`), and STT `stream=true` |

The last one is the trap that caught the previous PR in this area: text-format transcriptions are neither JSON nor SSE, so they never enter the branch that looks like the obvious place to fix.

## Known limit, stated rather than glossed

The floor reaches `recordTokenUsage` only. `finalizePassthroughLog` still records the provider's figures, which here are none, so **these requests continue to show 0 tokens in the request log**. That is deliberate and matches the invariant the chat and streaming paths hold — the log reports measured usage, estimates charge the quota — but it means per-key totals derived from request logs now differ from `virtual_keys.tokens_used` by the floor. Worth knowing before reading either number as the other.

## Verification

- Mutation-verified: removing the floor, hoisting it above the delivery gate, restoring the hand-rolled oversized charge, and applying the floor to only one serve path each fail a test.
- The charge is asserted against a literal `1`, not against `minPassthroughTokens` — comparing the code's constant to itself passes for any value, including one large enough to overcharge every zero-prompt request. Changing a billing-visible number should break a test.
- A stale comment on `singleAddTokens` is corrected: it claimed `recordTokenUsage` always reaches the repo, which is not true on the pass-through path, where absence is the "nothing charged" signal.
- `go test ./internal/proxy/` green, `golangci-lint` clean, `make size-check` clean, `-race` clean.
