### PR TITLE
fix(api): give each handler its own discovery factory

### DIFF
--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -159,13 +159,20 @@ type Handler struct {
 	testModelCheckRedirect func(req *http.Request, via []*http.Request) error // SSRF-protected redirect check for TestModel
 	discoveryDialCtx       func(ctx context.Context, network, addr string) (net.Conn, error)
 	discoveryCheckRedirect func(req *http.Request, via []*http.Request) error
-	circuitBreaker         CircuitBreakerControl
-	audit                  *audit.Recorder   // nil until SetAudit (audit trail of admin actions)
-	totpStatus             TotpStatus        // nil when TOTP feature not wired -> TotpEnabled() returns false (today's behavior)
-	totpEnabled            atomic.Bool       // cached IsEnabled result; refreshed by enroll-verify/disable handlers after DB mutations
-	quotaRepo              *quota.Repository // read-through store for polled provider quota snapshots
-	quotaAdvisor           *QuotaAdvisor     // nil until SetQuotaAdvisor; populated by RefreshQuotaAdvice
-	pwnedChecker           PwnedChecker      // nil until SetPwnedChecker (breached-password check on create/reset/change)
+	// newDiscovery builds this handler's DiscoveryService. Per-handler rather
+	// than package-level: NewHandler used to assign a global here, which made
+	// two handlers built concurrently a data race (parallel tests each build
+	// one) and silently coupled every handler in the process to whichever was
+	// constructed last. Nil falls back to the package default, for the handlers
+	// tests build as bare structs.
+	newDiscovery   func() *provider.DiscoveryService
+	circuitBreaker CircuitBreakerControl
+	audit          *audit.Recorder   // nil until SetAudit (audit trail of admin actions)
+	totpStatus     TotpStatus        // nil when TOTP feature not wired -> TotpEnabled() returns false (today's behavior)
+	totpEnabled    atomic.Bool       // cached IsEnabled result; refreshed by enroll-verify/disable handlers after DB mutations
+	quotaRepo      *quota.Repository // read-through store for polled provider quota snapshots
+	quotaAdvisor   *QuotaAdvisor     // nil until SetQuotaAdvisor; populated by RefreshQuotaAdvice
+	pwnedChecker   PwnedChecker      // nil until SetPwnedChecker (breached-password check on create/reset/change)
 
 	// Debounce state for the quota schema-drift watch: a per-provider shape
 	// that has been seen but not yet confirmed by a second consecutive poll.
@@ -209,7 +216,7 @@ func NewHandler(cfg *config.Config, providerRepo ProviderStore, database *db.DB,
 	}
 	// Wire the discovery service factory to use the SSRF-protected dial/redirect
 	// functions so admin-API discovery endpoints are also protected.
-	newDiscoveryService = func() *provider.DiscoveryService {
+	h.newDiscovery = func() *provider.DiscoveryService {
 		return provider.NewDiscoveryService(h.discoveryDialCtx, h.discoveryCheckRedirect)
 	}
 	return h

--- a/internal/api/discovery.go
+++ b/internal/api/discovery.go
@@ -20,11 +20,24 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
-// newDiscoveryService creates a DiscoveryService. NewHandler overwrites this
-// with an SSRF-protected version; the default avoids nil-panics if a discovery
-// call races ahead of initialization.
+// newDiscoveryService is the fallback DiscoveryService factory, used only by a
+// Handler that has no factory of its own (a bare &Handler{} in a test). It is
+// never reassigned: NewHandler sets Handler.newDiscovery instead, because a
+// package-level assignment from a constructor is a data race as soon as two
+// handlers are built concurrently, which parallel tests do.
 var newDiscoveryService = func() *provider.DiscoveryService {
 	return provider.NewDiscoveryService(nil, nil)
+}
+
+// discoveryService returns this handler's DiscoveryService. Every caller inside
+// the package goes through it rather than the package variable, so a handler's
+// SSRF-protected dial and redirect hooks cannot be swapped out from under it by
+// another handler's construction.
+func (h *Handler) discoveryService() *provider.DiscoveryService {
+	if h.newDiscovery != nil {
+		return h.newDiscovery()
+	}
+	return newDiscoveryService()
 }
 
 // Injectable variables for test overrides.
@@ -258,7 +271,7 @@ func (h *Handler) DiscoverProviderModels(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	discovery := newDiscoveryService()
+	discovery := h.discoveryService()
 	// Use a context decoupled from the HTTP request deadline for discovery.
 	// Provider availability tests (especially for slow/unreachable providers)
 	// can exhaust the 60s chi middleware timeout before DB upserts run.
@@ -410,7 +423,7 @@ func (h *Handler) discoverAllProviders(ctx context.Context, recordMisses bool) (
 		return nil, 0, 0, 0, err
 	}
 
-	discovery := newDiscoveryService()
+	discovery := h.discoveryService()
 	modelRepo := newModelRepo(h.dbPool.Pool())
 	failoverRepo := newFailoverRepo(h.dbPool.Pool())
 

--- a/internal/api/discovery_integration_quota_test.go
+++ b/internal/api/discovery_integration_quota_test.go
@@ -268,14 +268,10 @@ func TestGetOllamaCloudAccount_NonOllamaCloud(t *testing.T) {
 // TestGetProviderUsage_ZAICodingError tests that GetProviderUsage handles
 // z.ai API errors (note: z.ai returns 200 with error JSON for invalid keys).
 func TestGetProviderUsage_ZAICodingError(t *testing.T) {
-	// Override newDiscoveryService with mock transport to avoid real API calls
-	// Note: Must override AFTER newTestHandlerWithRouter since NewHandler sets it
-	_, r := newTestHandlerWithRouter(t)
+	// Point this handler's discovery at a mock transport, so no real API is called.
+	h, r := newTestHandlerWithRouter(t)
 
-	orig := newDiscoveryService
-	defer func() { newDiscoveryService = orig }()
-
-	newDiscoveryService = func() *provider.DiscoveryService {
+	h.newDiscovery = func() *provider.DiscoveryService {
 		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{
 				roundTripFunc: func(req *http.Request) (*http.Response, error) {
@@ -337,14 +333,10 @@ func TestGetProviderUsage_ZAICodingError(t *testing.T) {
 // LegacyTypeFromURL still routes purely by hostname, so the provider row's
 // base_url must be an api.kimi.com URL to select the kimi-code arm.
 func TestGetProviderUsage_KimiCodeError(t *testing.T) {
-	// Override newDiscoveryService with mock transport to avoid real API calls
-	// Note: Must override AFTER newTestHandlerWithRouter since NewHandler sets it
-	_, r := newTestHandlerWithRouter(t)
+	// Point this handler's discovery at a mock transport, so no real API is called.
+	h, r := newTestHandlerWithRouter(t)
 
-	orig := newDiscoveryService
-	defer func() { newDiscoveryService = orig }()
-
-	newDiscoveryService = func() *provider.DiscoveryService {
+	h.newDiscovery = func() *provider.DiscoveryService {
 		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{
 				roundTripFunc: func(req *http.Request) (*http.Response, error) {
@@ -401,14 +393,10 @@ func TestGetProviderUsage_KimiCodeError(t *testing.T) {
 // TestGetProviderUsage_NanoGPTError tests that GetProviderUsage returns 500
 // when the NanoGPT API call fails with an invalid key.
 func TestGetProviderUsage_NanoGPTError(t *testing.T) {
-	// Override newDiscoveryService with mock transport to avoid real API calls
-	// Note: Must override AFTER newTestHandlerWithRouter since NewHandler sets it
-	_, r := newTestHandlerWithRouter(t)
+	// Point this handler's discovery at a mock transport, so no real API is called.
+	h, r := newTestHandlerWithRouter(t)
 
-	orig := newDiscoveryService
-	defer func() { newDiscoveryService = orig }()
-
-	newDiscoveryService = func() *provider.DiscoveryService {
+	h.newDiscovery = func() *provider.DiscoveryService {
 		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{
 				roundTripFunc: func(req *http.Request) (*http.Response, error) {
@@ -464,14 +452,10 @@ func TestGetProviderUsage_NanoGPTError(t *testing.T) {
 // TestGetProviderUsage_OpenRouterError tests that GetProviderUsage returns 500
 // when the OpenRouter API call fails with an invalid key.
 func TestGetProviderUsage_OpenRouterError(t *testing.T) {
-	// Override newDiscoveryService with mock transport to avoid real API calls
-	// Note: Must override AFTER newTestHandlerWithRouter since NewHandler sets it
-	_, r := newTestHandlerWithRouter(t)
+	// Point this handler's discovery at a mock transport, so no real API is called.
+	h, r := newTestHandlerWithRouter(t)
 
-	orig := newDiscoveryService
-	defer func() { newDiscoveryService = orig }()
-
-	newDiscoveryService = func() *provider.DiscoveryService {
+	h.newDiscovery = func() *provider.DiscoveryService {
 		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{
 				roundTripFunc: func(req *http.Request) (*http.Response, error) {
@@ -528,14 +512,10 @@ func TestGetProviderUsage_OpenRouterError(t *testing.T) {
 // TestGetProviderBalance_DeepSeekError tests that GetProviderBalance returns 500
 // when the DeepSeek API call fails with an invalid key.
 func TestGetProviderBalance_DeepSeekError(t *testing.T) {
-	// Override newDiscoveryService with mock transport to avoid real API calls
-	// Note: Must override AFTER newTestHandlerWithRouter since NewHandler sets it
-	_, r := newTestHandlerWithRouter(t)
+	// Point this handler's discovery at a mock transport, so no real API is called.
+	h, r := newTestHandlerWithRouter(t)
 
-	orig := newDiscoveryService
-	defer func() { newDiscoveryService = orig }()
-
-	newDiscoveryService = func() *provider.DiscoveryService {
+	h.newDiscovery = func() *provider.DiscoveryService {
 		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{
 				roundTripFunc: func(req *http.Request) (*http.Response, error) {
@@ -591,14 +571,10 @@ func TestGetProviderBalance_DeepSeekError(t *testing.T) {
 // TestGetOllamaCloudAccount_Error tests that GetOllamaCloudAccount returns 500
 // when the Ollama Cloud API call fails with an invalid key.
 func TestGetOllamaCloudAccount_Error(t *testing.T) {
-	// Override newDiscoveryService with mock transport to avoid real API calls
-	// Note: Must override AFTER newTestHandlerWithRouter since NewHandler sets it
-	_, r := newTestHandlerWithRouter(t)
+	// Point this handler's discovery at a mock transport, so no real API is called.
+	h, r := newTestHandlerWithRouter(t)
 
-	orig := newDiscoveryService
-	defer func() { newDiscoveryService = orig }()
-
-	newDiscoveryService = func() *provider.DiscoveryService {
+	h.newDiscovery = func() *provider.DiscoveryService {
 		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{
 				roundTripFunc: func(req *http.Request) (*http.Response, error) {
@@ -657,12 +633,9 @@ func TestGetOllamaCloudAccount_Error(t *testing.T) {
 // written back as JSON. The mock transport intercepts the api.kimi.com request
 // so no real network call is made while LegacyTypeFromURL still routes by host.
 func TestGetProviderUsage_KimiCodeSuccess(t *testing.T) {
-	_, r := newTestHandlerWithRouter(t)
+	h, r := newTestHandlerWithRouter(t)
 
-	orig := newDiscoveryService
-	defer func() { newDiscoveryService = orig }()
-
-	newDiscoveryService = func() *provider.DiscoveryService {
+	h.newDiscovery = func() *provider.DiscoveryService {
 		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{
 				roundTripFunc: func(req *http.Request) (*http.Response, error) {
@@ -726,14 +699,10 @@ func TestGetProviderUsage_KimiCodeSuccess(t *testing.T) {
 // a 401 upstream response is classified by quotaAuthError into the
 // dependency-failure envelope rather than the generic 500 error path.
 func TestGetProviderUsage_MiniMaxError(t *testing.T) {
-	// Override newDiscoveryService with mock transport to avoid real API calls
-	// Note: Must override AFTER newTestHandlerWithRouter since NewHandler sets it
-	_, r := newTestHandlerWithRouter(t)
+	// Point this handler's discovery at a mock transport, so no real API is called.
+	h, r := newTestHandlerWithRouter(t)
 
-	orig := newDiscoveryService
-	defer func() { newDiscoveryService = orig }()
-
-	newDiscoveryService = func() *provider.DiscoveryService {
+	h.newDiscovery = func() *provider.DiscoveryService {
 		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{
 				roundTripFunc: func(req *http.Request) (*http.Response, error) {
@@ -793,12 +762,9 @@ func TestGetProviderUsage_MiniMaxError(t *testing.T) {
 // The mock transport intercepts the api.minimax.io request so no real
 // network call is made while LegacyTypeFromURL still routes by host.
 func TestGetProviderUsage_MiniMaxSuccess(t *testing.T) {
-	_, r := newTestHandlerWithRouter(t)
+	h, r := newTestHandlerWithRouter(t)
 
-	orig := newDiscoveryService
-	defer func() { newDiscoveryService = orig }()
-
-	newDiscoveryService = func() *provider.DiscoveryService {
+	h.newDiscovery = func() *provider.DiscoveryService {
 		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{
 				roundTripFunc: func(req *http.Request) (*http.Response, error) {
@@ -859,11 +825,9 @@ func TestGetProviderUsage_MiniMaxSuccess(t *testing.T) {
 func TestGetProviderUsage_ZAICodingQuotaError(t *testing.T) {
 	// DB-backed handler so the read-through cold-fill has a real quota store and
 	// the provider row satisfies the snapshot FK.
-	_, r := newTestHandlerWithRouter(t)
-	orig := newDiscoveryService
-	defer func() { newDiscoveryService = orig }()
+	h, r := newTestHandlerWithRouter(t)
 
-	newDiscoveryService = func() *provider.DiscoveryService {
+	h.newDiscovery = func() *provider.DiscoveryService {
 		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{
 				roundTripFunc: func(req *http.Request) (*http.Response, error) {
@@ -896,12 +860,10 @@ func TestGetProviderUsage_ZAICodingQuotaError(t *testing.T) {
 
 func TestGetProviderUsage_NanoGPTSuccess(t *testing.T) {
 	// DB-backed handler: read-through cold-fill needs a real quota store + FK row.
-	_, r := newTestHandlerWithRouter(t)
+	h, r := newTestHandlerWithRouter(t)
 	// Override newDiscoveryService with mock transport returning valid NanoGPT JSON
-	orig := newDiscoveryService
-	defer func() { newDiscoveryService = orig }()
 
-	newDiscoveryService = func() *provider.DiscoveryService {
+	h.newDiscovery = func() *provider.DiscoveryService {
 		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{
 				roundTripFunc: func(req *http.Request) (*http.Response, error) {
@@ -939,12 +901,10 @@ func TestGetProviderUsage_NanoGPTSuccess(t *testing.T) {
 
 func TestGetProviderUsage_OpenRouterSuccess(t *testing.T) {
 	// DB-backed handler: read-through cold-fill needs a real quota store + FK row.
-	_, r := newTestHandlerWithRouter(t)
+	h, r := newTestHandlerWithRouter(t)
 	// Override newDiscoveryService with mock transport returning valid OpenRouter JSON
-	orig := newDiscoveryService
-	defer func() { newDiscoveryService = orig }()
 
-	newDiscoveryService = func() *provider.DiscoveryService {
+	h.newDiscovery = func() *provider.DiscoveryService {
 		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{
 				roundTripFunc: func(req *http.Request) (*http.Response, error) {
@@ -995,12 +955,10 @@ func TestGetProviderUsage_OpenRouterSuccess(t *testing.T) {
 
 func TestGetProviderBalance_DeepSeekSuccess(t *testing.T) {
 	// DB-backed handler: read-through cold-fill needs a real quota store + FK row.
-	_, r := newTestHandlerWithRouter(t)
+	h, r := newTestHandlerWithRouter(t)
 	// Override newDiscoveryService with mock transport returning valid DeepSeek JSON
-	orig := newDiscoveryService
-	defer func() { newDiscoveryService = orig }()
 
-	newDiscoveryService = func() *provider.DiscoveryService {
+	h.newDiscovery = func() *provider.DiscoveryService {
 		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{
 				roundTripFunc: func(req *http.Request) (*http.Response, error) {
@@ -1042,12 +1000,10 @@ func TestGetProviderBalance_DeepSeekSuccess(t *testing.T) {
 
 func TestGetOllamaCloudAccount_Success(t *testing.T) {
 	// DB-backed handler: read-through cold-fill needs a real quota store + FK row.
-	_, r := newTestHandlerWithRouter(t)
+	h, r := newTestHandlerWithRouter(t)
 	// Override newDiscoveryService with mock transport returning valid Ollama Cloud JSON
-	orig := newDiscoveryService
-	defer func() { newDiscoveryService = orig }()
 
-	newDiscoveryService = func() *provider.DiscoveryService {
+	h.newDiscovery = func() *provider.DiscoveryService {
 		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{
 				roundTripFunc: func(req *http.Request) (*http.Response, error) {
@@ -1089,11 +1045,9 @@ func TestGetOllamaCloudAccount_Success(t *testing.T) {
 
 func TestGetProviderUsage_NeuralWattSuccess(t *testing.T) {
 	// DB-backed handler: read-through cold-fill needs a real quota store + FK row.
-	_, r := newTestHandlerWithRouter(t)
-	orig := newDiscoveryService
-	defer func() { newDiscoveryService = orig }()
+	h, r := newTestHandlerWithRouter(t)
 
-	newDiscoveryService = func() *provider.DiscoveryService {
+	h.newDiscovery = func() *provider.DiscoveryService {
 		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{
 				roundTripFunc: func(req *http.Request) (*http.Response, error) {
@@ -1131,11 +1085,9 @@ func TestGetProviderUsage_NeuralWattSuccess(t *testing.T) {
 
 func TestGetProviderUsage_NeuralWattFreeTier(t *testing.T) {
 	// DB-backed handler: read-through cold-fill needs a real quota store + FK row.
-	_, r := newTestHandlerWithRouter(t)
-	orig := newDiscoveryService
-	defer func() { newDiscoveryService = orig }()
+	h, r := newTestHandlerWithRouter(t)
 
-	newDiscoveryService = func() *provider.DiscoveryService {
+	h.newDiscovery = func() *provider.DiscoveryService {
 		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{
 				roundTripFunc: func(req *http.Request) (*http.Response, error) {
@@ -1163,11 +1115,9 @@ func TestGetProviderUsage_NeuralWattFreeTier(t *testing.T) {
 
 func TestGetProviderUsage_NeuralWattError(t *testing.T) {
 	// DB-backed handler: read-through cold-fill needs a real quota store + FK row.
-	_, r := newTestHandlerWithRouter(t)
-	orig := newDiscoveryService
-	defer func() { newDiscoveryService = orig }()
+	h, r := newTestHandlerWithRouter(t)
 
-	newDiscoveryService = func() *provider.DiscoveryService {
+	h.newDiscovery = func() *provider.DiscoveryService {
 		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{
 				roundTripFunc: func(req *http.Request) (*http.Response, error) {
@@ -1211,9 +1161,7 @@ func TestGetProviderUsage_ServesStoredSnapshot(t *testing.T) {
 
 	// Any upstream call means the read-through incorrectly fell through to a
 	// live fetch — fail loudly. This replaces the invented panicOnCallDiscovery.
-	orig := newDiscoveryService
-	defer func() { newDiscoveryService = orig }()
-	newDiscoveryService = func() *provider.DiscoveryService {
+	h.newDiscovery = func() *provider.DiscoveryService {
 		return provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{roundTripFunc: func(req *http.Request) (*http.Response, error) {
 				t.Fatalf("unexpected upstream call to %s", req.URL.String())
@@ -1261,9 +1209,7 @@ func TestGetProviderUsage_ColdLazyFill(t *testing.T) {
 	h, r := newTestHandlerWithRouter(t)
 	provID, idStr := createQuotaProvider(t, r, "https://nano-gpt.com")
 
-	orig := newDiscoveryService
-	defer func() { newDiscoveryService = orig }()
-	newDiscoveryService = func() *provider.DiscoveryService {
+	h.newDiscovery = func() *provider.DiscoveryService {
 		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{roundTripFunc: func(req *http.Request) (*http.Response, error) {
 				if strings.Contains(req.URL.Host, "nano-gpt.com") {

--- a/internal/api/discovery_integration_test.go
+++ b/internal/api/discovery_integration_test.go
@@ -200,13 +200,11 @@ func unreachableDiscovery() *provider.DiscoveryService {
 // TestDiscoverAllModels_DiscoveryError tests that DiscoverAllModels handles
 // discovery errors gracefully.
 func TestDiscoverAllModels_DiscoveryError(t *testing.T) {
-	_, r := newTestHandlerWithRouter(t)
+	h, r := newTestHandlerWithRouter(t)
 
 	// Must be overridden after newTestHandlerWithRouter: NewHandler installs its
 	// own SSRF-protected factory.
-	orig := newDiscoveryService
-	defer func() { newDiscoveryService = orig }()
-	newDiscoveryService = unreachableDiscovery
+	h.newDiscovery = unreachableDiscovery
 
 	// Create a provider with an unreachable URL; the stubbed transport above is
 	// what actually makes the discovery call fail.
@@ -400,13 +398,11 @@ func TestDiscoverAllModels_WithEnabledProvider(t *testing.T) {
 // TestDiscoverProviderModels_DiscoveryError tests that DiscoverProviderModels
 // returns 500 when model discovery fails due to unreachable URL.
 func TestDiscoverProviderModels_DiscoveryError(t *testing.T) {
-	_, r := newTestHandlerWithRouter(t)
+	h, r := newTestHandlerWithRouter(t)
 
 	// Must be overridden after newTestHandlerWithRouter: NewHandler installs its
 	// own SSRF-protected factory.
-	orig := newDiscoveryService
-	defer func() { newDiscoveryService = orig }()
-	newDiscoveryService = unreachableDiscovery
+	h.newDiscovery = unreachableDiscovery
 
 	// Create a provider with an unreachable URL; the stubbed transport above is
 	// what actually makes the discovery call fail.

--- a/internal/api/discovery_quota.go
+++ b/internal/api/discovery_quota.go
@@ -56,7 +56,7 @@ func (h *Handler) serveQuota(w http.ResponseWriter, r *http.Request, prov *provi
 		// disconnect does not abort the in-flight upstream call mid-fetch.
 		ctx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), 30*time.Second)
 		defer cancel()
-		disc := newDiscoveryService()
+		disc := h.discoveryService()
 		k, payload, status, ferr := fetchQuotaSnapshot(ctx, disc, prov, h.cfg.MasterKey)
 		if ferr != nil {
 			respondQuotaError(w, prov.Name, kind, ferr)
@@ -153,7 +153,7 @@ func (h *Handler) RefreshAllQuotas(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	discovery := newDiscoveryService()
+	discovery := h.discoveryService()
 
 	var results []QuotaRefreshResult
 	refreshed := 0

--- a/internal/api/discovery_quota_refresh_test.go
+++ b/internal/api/discovery_quota_refresh_test.go
@@ -129,9 +129,7 @@ func TestRefreshAllQuotas_UpsertErrorReportsFailure(t *testing.T) {
 	h, r := newTestHandlerWithRouter(t)
 
 	// Mock a successful DeepSeek balance fetch so the flow reaches the Upsert.
-	orig := newDiscoveryService
-	defer func() { newDiscoveryService = orig }()
-	newDiscoveryService = func() *provider.DiscoveryService {
+	h.newDiscovery = func() *provider.DiscoveryService {
 		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{
 				roundTripFunc: func(req *http.Request) (*http.Response, error) {
@@ -197,14 +195,10 @@ func TestRefreshAllQuotas_UpsertErrorReportsFailure(t *testing.T) {
 // TestRefreshAllQuotas_WithSupportedTypes tests that RefreshAllQuotas handles
 // multiple provider types with errors for unsupported types.
 func TestRefreshAllQuotas_WithSupportedTypes(t *testing.T) {
-	// Override newDiscoveryService with mock transport to avoid real API calls
-	// Note: Must override AFTER newTestHandlerWithRouter since NewHandler sets it
-	_, r := newTestHandlerWithRouter(t)
+	// Point this handler's discovery at a mock transport, so no real API is called.
+	h, r := newTestHandlerWithRouter(t)
 
-	orig := newDiscoveryService
-	defer func() { newDiscoveryService = orig }()
-
-	newDiscoveryService = func() *provider.DiscoveryService {
+	h.newDiscovery = func() *provider.DiscoveryService {
 		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{
 				roundTripFunc: func(req *http.Request) (*http.Response, error) {
@@ -319,14 +313,10 @@ func TestRefreshAllQuotas_WithSupportedTypes(t *testing.T) {
 // TestRefreshAllQuotas_DeepSeekError tests that RefreshAllQuotas handles
 // DeepSeek API errors correctly.
 func TestRefreshAllQuotas_DeepSeekError(t *testing.T) {
-	// Override newDiscoveryService with mock transport to avoid real API calls
-	// Note: Must override AFTER newTestHandlerWithRouter since NewHandler sets it
-	_, r := newTestHandlerWithRouter(t)
+	// Point this handler's discovery at a mock transport, so no real API is called.
+	h, r := newTestHandlerWithRouter(t)
 
-	orig := newDiscoveryService
-	defer func() { newDiscoveryService = orig }()
-
-	newDiscoveryService = func() *provider.DiscoveryService {
+	h.newDiscovery = func() *provider.DiscoveryService {
 		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{
 				roundTripFunc: func(req *http.Request) (*http.Response, error) {
@@ -398,14 +388,10 @@ func TestRefreshAllQuotas_DeepSeekError(t *testing.T) {
 // TestRefreshAllQuotas_OllamaCloudError tests that RefreshAllQuotas handles
 // Ollama Cloud API errors correctly.
 func TestRefreshAllQuotas_OllamaCloudError(t *testing.T) {
-	// Override newDiscoveryService with mock transport to avoid real API calls
-	// Note: Must override AFTER newTestHandlerWithRouter since NewHandler sets it
-	_, r := newTestHandlerWithRouter(t)
+	// Point this handler's discovery at a mock transport, so no real API is called.
+	h, r := newTestHandlerWithRouter(t)
 
-	orig := newDiscoveryService
-	defer func() { newDiscoveryService = orig }()
-
-	newDiscoveryService = func() *provider.DiscoveryService {
+	h.newDiscovery = func() *provider.DiscoveryService {
 		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{
 				roundTripFunc: func(req *http.Request) (*http.Response, error) {
@@ -477,14 +463,10 @@ func TestRefreshAllQuotas_OllamaCloudError(t *testing.T) {
 // TestRefreshAllQuotas_OpenRouterError tests that RefreshAllQuotas handles
 // OpenRouter API errors correctly.
 func TestRefreshAllQuotas_OpenRouterError(t *testing.T) {
-	// Override newDiscoveryService with mock transport to avoid real API calls
-	// Note: Must override AFTER newTestHandlerWithRouter since NewHandler sets it
-	_, r := newTestHandlerWithRouter(t)
+	// Point this handler's discovery at a mock transport, so no real API is called.
+	h, r := newTestHandlerWithRouter(t)
 
-	orig := newDiscoveryService
-	defer func() { newDiscoveryService = orig }()
-
-	newDiscoveryService = func() *provider.DiscoveryService {
+	h.newDiscovery = func() *provider.DiscoveryService {
 		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{
 				roundTripFunc: func(req *http.Request) (*http.Response, error) {
@@ -557,14 +539,10 @@ func TestRefreshAllQuotas_OpenRouterError(t *testing.T) {
 // Kimi Code API errors correctly, exercising the kimi-code arm of the
 // provider-type switch in RefreshAllQuotas.
 func TestRefreshAllQuotas_KimiCodeError(t *testing.T) {
-	// Override newDiscoveryService with mock transport to avoid real API calls
-	// Note: Must override AFTER newTestHandlerWithRouter since NewHandler sets it
-	_, r := newTestHandlerWithRouter(t)
+	// Point this handler's discovery at a mock transport, so no real API is called.
+	h, r := newTestHandlerWithRouter(t)
 
-	orig := newDiscoveryService
-	defer func() { newDiscoveryService = orig }()
-
-	newDiscoveryService = func() *provider.DiscoveryService {
+	h.newDiscovery = func() *provider.DiscoveryService {
 		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{
 				roundTripFunc: func(req *http.Request) (*http.Response, error) {
@@ -637,12 +615,9 @@ func TestRefreshAllQuotas_KimiCodeError(t *testing.T) {
 // kimi-code case in RefreshAllQuotas: a 200 /usages response records the
 // provider as refreshed rather than failed.
 func TestRefreshAllQuotas_KimiCodeSuccess(t *testing.T) {
-	_, r := newTestHandlerWithRouter(t)
+	h, r := newTestHandlerWithRouter(t)
 
-	orig := newDiscoveryService
-	defer func() { newDiscoveryService = orig }()
-
-	newDiscoveryService = func() *provider.DiscoveryService {
+	h.newDiscovery = func() *provider.DiscoveryService {
 		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{
 				roundTripFunc: func(req *http.Request) (*http.Response, error) {
@@ -714,14 +689,10 @@ func TestRefreshAllQuotas_KimiCodeSuccess(t *testing.T) {
 // rather than surfacing a Go error, matching the read-through model where a 424
 // is a valid stored state served back to the dashboard.
 func TestRefreshAllQuotas_MiniMaxError(t *testing.T) {
-	// Override newDiscoveryService with mock transport to avoid real API calls
-	// Note: Must override AFTER newTestHandlerWithRouter since NewHandler sets it
+	// Point this handler's discovery at a mock transport, so no real API is called.
 	h, r := newTestHandlerWithRouter(t)
 
-	orig := newDiscoveryService
-	defer func() { newDiscoveryService = orig }()
-
-	newDiscoveryService = func() *provider.DiscoveryService {
+	h.newDiscovery = func() *provider.DiscoveryService {
 		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{
 				roundTripFunc: func(req *http.Request) (*http.Response, error) {
@@ -792,12 +763,9 @@ func TestRefreshAllQuotas_MiniMaxError(t *testing.T) {
 // minimax case in RefreshAllQuotas: a 200 /token_plan/remains response
 // records the provider as refreshed, not failed.
 func TestRefreshAllQuotas_MiniMaxSuccess(t *testing.T) {
-	_, r := newTestHandlerWithRouter(t)
+	h, r := newTestHandlerWithRouter(t)
 
-	orig := newDiscoveryService
-	defer func() { newDiscoveryService = orig }()
-
-	newDiscoveryService = func() *provider.DiscoveryService {
+	h.newDiscovery = func() *provider.DiscoveryService {
 		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{
 				roundTripFunc: func(req *http.Request) (*http.Response, error) {
@@ -894,13 +862,11 @@ func TestRefreshAllQuotas_ListError(t *testing.T) {
 }
 
 func TestRefreshAllQuotas_NanoGPTSuccess(t *testing.T) {
-	_, r := newTestHandlerWithRouter(t)
+	h, r := newTestHandlerWithRouter(t)
 
 	// Override newDiscoveryService with mock transport returning valid NanoGPT JSON
-	orig := newDiscoveryService
-	defer func() { newDiscoveryService = orig }()
 
-	newDiscoveryService = func() *provider.DiscoveryService {
+	h.newDiscovery = func() *provider.DiscoveryService {
 		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{
 				roundTripFunc: func(req *http.Request) (*http.Response, error) {
@@ -940,13 +906,11 @@ func TestRefreshAllQuotas_NanoGPTSuccess(t *testing.T) {
 }
 
 func TestRefreshAllQuotas_ZAICodingError(t *testing.T) {
-	_, r := newTestHandlerWithRouter(t)
+	h, r := newTestHandlerWithRouter(t)
 
 	// Override newDiscoveryService with mock transport returning error for z.ai
-	orig := newDiscoveryService
-	defer func() { newDiscoveryService = orig }()
 
-	newDiscoveryService = func() *provider.DiscoveryService {
+	h.newDiscovery = func() *provider.DiscoveryService {
 		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{
 				roundTripFunc: func(req *http.Request) (*http.Response, error) {
@@ -987,13 +951,11 @@ func TestRefreshAllQuotas_ZAICodingError(t *testing.T) {
 }
 
 func TestRefreshAllQuotas_ZAICodingSuccess(t *testing.T) {
-	_, r := newTestHandlerWithRouter(t)
+	h, r := newTestHandlerWithRouter(t)
 
 	// Override newDiscoveryService with mock transport returning valid ZAI JSON
-	orig := newDiscoveryService
-	defer func() { newDiscoveryService = orig }()
 
-	newDiscoveryService = func() *provider.DiscoveryService {
+	h.newDiscovery = func() *provider.DiscoveryService {
 		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{
 				roundTripFunc: func(req *http.Request) (*http.Response, error) {
@@ -1035,13 +997,11 @@ func TestRefreshAllQuotas_ZAICodingSuccess(t *testing.T) {
 }
 
 func TestRefreshAllQuotas_OpenRouterSuccess(t *testing.T) {
-	_, r := newTestHandlerWithRouter(t)
+	h, r := newTestHandlerWithRouter(t)
 
 	// Override newDiscoveryService with mock transport returning valid OpenRouter JSON
-	orig := newDiscoveryService
-	defer func() { newDiscoveryService = orig }()
 
-	newDiscoveryService = func() *provider.DiscoveryService {
+	h.newDiscovery = func() *provider.DiscoveryService {
 		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{
 				roundTripFunc: func(req *http.Request) (*http.Response, error) {
@@ -1090,13 +1050,11 @@ func TestRefreshAllQuotas_OpenRouterSuccess(t *testing.T) {
 }
 
 func TestRefreshAllQuotas_DeepSeekSuccess(t *testing.T) {
-	_, r := newTestHandlerWithRouter(t)
+	h, r := newTestHandlerWithRouter(t)
 
 	// Override newDiscoveryService with mock transport returning valid DeepSeek JSON
-	orig := newDiscoveryService
-	defer func() { newDiscoveryService = orig }()
 
-	newDiscoveryService = func() *provider.DiscoveryService {
+	h.newDiscovery = func() *provider.DiscoveryService {
 		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{
 				roundTripFunc: func(req *http.Request) (*http.Response, error) {
@@ -1138,13 +1096,11 @@ func TestRefreshAllQuotas_DeepSeekSuccess(t *testing.T) {
 }
 
 func TestRefreshAllQuotas_OllamaCloudSuccess(t *testing.T) {
-	_, r := newTestHandlerWithRouter(t)
+	h, r := newTestHandlerWithRouter(t)
 
 	// Override newDiscoveryService with mock transport returning valid Ollama Cloud JSON
-	orig := newDiscoveryService
-	defer func() { newDiscoveryService = orig }()
 
-	newDiscoveryService = func() *provider.DiscoveryService {
+	h.newDiscovery = func() *provider.DiscoveryService {
 		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{
 				roundTripFunc: func(req *http.Request) (*http.Response, error) {
@@ -1192,12 +1148,9 @@ func TestRefreshAllQuotas_OllamaCloudSuccess(t *testing.T) {
 // TestRefreshAllQuotas_MixedResults tests that RefreshAllQuotas continues
 // processing all providers even when one fails, returning partial results.
 func TestRefreshAllQuotas_MixedResults(t *testing.T) {
-	_, r := newTestHandlerWithRouter(t)
+	h, r := newTestHandlerWithRouter(t)
 
-	orig := newDiscoveryService
-	defer func() { newDiscoveryService = orig }()
-
-	newDiscoveryService = func() *provider.DiscoveryService {
+	h.newDiscovery = func() *provider.DiscoveryService {
 		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{
 				roundTripFunc: func(req *http.Request) (*http.Response, error) {
@@ -1263,12 +1216,9 @@ func TestRefreshAllQuotas_MixedResults(t *testing.T) {
 }
 
 func TestRefreshAllQuotas_NeuralWattSuccess(t *testing.T) {
-	_, r := newTestHandlerWithRouter(t)
+	h, r := newTestHandlerWithRouter(t)
 
-	orig := newDiscoveryService
-	defer func() { newDiscoveryService = orig }()
-
-	newDiscoveryService = func() *provider.DiscoveryService {
+	h.newDiscovery = func() *provider.DiscoveryService {
 		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{
 				roundTripFunc: func(req *http.Request) (*http.Response, error) {
@@ -1307,12 +1257,9 @@ func TestRefreshAllQuotas_NeuralWattSuccess(t *testing.T) {
 }
 
 func TestRefreshAllQuotas_NeuralWattError(t *testing.T) {
-	_, r := newTestHandlerWithRouter(t)
+	h, r := newTestHandlerWithRouter(t)
 
-	orig := newDiscoveryService
-	defer func() { newDiscoveryService = orig }()
-
-	newDiscoveryService = func() *provider.DiscoveryService {
+	h.newDiscovery = func() *provider.DiscoveryService {
 		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{
 				roundTripFunc: func(req *http.Request) (*http.Response, error) {
@@ -1356,9 +1303,7 @@ func TestRefreshAllQuotas_PersistsSnapshot(t *testing.T) {
 	h, r := newTestHandlerWithRouter(t)
 	provID, _ := createQuotaProvider(t, r, "https://nano-gpt.com")
 
-	orig := newDiscoveryService
-	defer func() { newDiscoveryService = orig }()
-	newDiscoveryService = func() *provider.DiscoveryService {
+	h.newDiscovery = func() *provider.DiscoveryService {
 		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{roundTripFunc: func(req *http.Request) (*http.Response, error) {
 				if strings.Contains(req.URL.Host, "nano-gpt.com") {

--- a/internal/api/handler_discovery_test.go
+++ b/internal/api/handler_discovery_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -250,8 +251,7 @@ func TestRefreshAllQuotasIntegration(t *testing.T) {
 // Events Handler Tests
 
 func TestDiscoverProviderModels_Success(t *testing.T) {
-	h, r := newTestHandlerWithRouter(t)
-	_ = h // Use h to avoid unused variable error
+	_, r := newTestHandlerWithRouter(t)
 
 	// Create a provider with OpenAI URL (will fail with test API key but tests the handler path)
 	providerData := fmt.Sprintf(`{"name": "test-discover-success-%s", "base_url": "https://api.openai.com", "api_key": "test-api-key"}`, uuid.New().String()[:8])
@@ -294,14 +294,9 @@ func TestDiscoverProviderModels_Success(t *testing.T) {
 
 func TestGetProviderUsage_Success(t *testing.T) {
 	h, r := newTestHandlerWithRouter(t)
-	_ = h // Use h to avoid unused variable error
 
-	// Override newDiscoveryService with mock transport to avoid real API calls
-	// Note: Must override AFTER newTestHandlerWithRouter since NewHandler sets it
-	orig := newDiscoveryService
-	defer func() { newDiscoveryService = orig }()
-
-	newDiscoveryService = func() *provider.DiscoveryService {
+	// Point this handler's discovery at a mock transport, so no real API is called.
+	h.newDiscovery = func() *provider.DiscoveryService {
 		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{
 				roundTripFunc: func(req *http.Request) (*http.Response, error) {
@@ -355,14 +350,9 @@ func TestGetProviderUsage_Success(t *testing.T) {
 
 func TestDiscoverAllModels_MultipleProviders(t *testing.T) {
 	h, r := newTestHandlerWithRouter(t)
-	_ = h // Use h to avoid unused variable error
 
-	// Override newDiscoveryService with mock transport to avoid real API calls
-	// Note: Must override AFTER newTestHandlerWithRouter since NewHandler sets it
-	orig := newDiscoveryService
-	defer func() { newDiscoveryService = orig }()
-
-	newDiscoveryService = func() *provider.DiscoveryService {
+	// Point this handler's discovery at a mock transport, so no real API is called.
+	h.newDiscovery = func() *provider.DiscoveryService {
 		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{
 				roundTripFunc: func(req *http.Request) (*http.Response, error) {
@@ -848,14 +838,10 @@ func TestRefreshAllQuotas_DisabledProvider(t *testing.T) {
 // Test for admin.go - CreateProvider_KeylessProvider
 
 func TestDiscoverProviderModels_InvalidProvider(t *testing.T) {
-	// Override newDiscoveryService with mock transport to avoid real API calls
-	// Note: Must override AFTER newTestHandlerWithRouter since NewHandler sets it
-	_, r := newTestHandlerWithRouter(t)
+	// Point this handler's discovery at a mock transport, so no real API is called.
+	h, r := newTestHandlerWithRouter(t)
 
-	orig := newDiscoveryService
-	defer func() { newDiscoveryService = orig }()
-
-	newDiscoveryService = func() *provider.DiscoveryService {
+	h.newDiscovery = func() *provider.DiscoveryService {
 		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{
 				roundTripFunc: func(req *http.Request) (*http.Response, error) {
@@ -1080,14 +1066,10 @@ func TestDiscoverProviderModels_AutodiscoveryDisabled(t *testing.T) {
 // TestListProviders_WithSearchFilter tests the search filter functionality
 
 func TestGetProviderUsage_Error(t *testing.T) {
-	_, r := newTestHandlerWithRouter(t)
+	h, r := newTestHandlerWithRouter(t)
 
-	// Override newDiscoveryService with mock transport to avoid real API calls
-	// Note: Must override AFTER newTestHandlerWithRouter since NewHandler sets it
-	orig := newDiscoveryService
-	defer func() { newDiscoveryService = orig }()
-
-	newDiscoveryService = func() *provider.DiscoveryService {
+	// Point this handler's discovery at a mock transport, so no real API is called.
+	h.newDiscovery = func() *provider.DiscoveryService {
 		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{
 				roundTripFunc: func(req *http.Request) (*http.Response, error) {
@@ -1171,15 +1153,13 @@ func TestGetProviderBalance_Error(t *testing.T) {
 // TestListProviders_WithPaginationAndModelCounts tests pagination query params
 
 func TestDiscoverProviderModels_WithInvalidProviderType(t *testing.T) {
-	_, r := newTestHandlerWithRouter(t)
+	h, r := newTestHandlerWithRouter(t)
 
 	// The point of the test is the unrecognised base URL, not the network: left
 	// to itself this resolved a name that does not exist and then retried,
 	// costing tens of seconds and depending on the runner's DNS. Must be
 	// overridden after newTestHandlerWithRouter, which installs its own factory.
-	orig := newDiscoveryService
-	defer func() { newDiscoveryService = orig }()
-	newDiscoveryService = unreachableDiscovery
+	h.newDiscovery = unreachableDiscovery
 
 	// Create a provider with a custom/self-hosted base URL
 	body := `{"name":"test-custom-provider","base_url":"https://custom.example.com","api_key":"sk-custom"}`
@@ -1352,11 +1332,9 @@ func TestGetProviderBalance_UnsupportedType_Integration(t *testing.T) {
 func TestGetProviderUsage_OpenRouterError_Integration(t *testing.T) {
 	// OpenRouter maps to the "usage" kind and is served from /usage. An upstream
 	// failure surfaces as a 500 from the read-through cold-fill.
-	_, r := newTestHandlerWithRouter(t)
+	h, r := newTestHandlerWithRouter(t)
 
-	orig := newDiscoveryService
-	defer func() { newDiscoveryService = orig }()
-	newDiscoveryService = func() *provider.DiscoveryService {
+	h.newDiscovery = func() *provider.DiscoveryService {
 		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{roundTripFunc: func(req *http.Request) (*http.Response, error) {
 				if strings.Contains(req.URL.Host, "openrouter.ai") {
@@ -1403,3 +1381,59 @@ func TestGetProviderUsage_OpenRouterError_Integration(t *testing.T) {
 }
 
 // TestListModels_WithModels tests listing models with provider_id filter
+
+// TestNewHandler_KeepsItsDiscoveryFactoryToItself pins the fix for a data race
+// that failed CI on master.
+//
+// NewHandler used to assign the PACKAGE-level newDiscoveryService, so building
+// a handler mutated global state. Two handlers built concurrently — which is
+// what parallel tests in this package do, several of them via newTestHandler —
+// raced on that write. Worse than the race: the last handler constructed won,
+// so in a process with more than one handler every discovery call used the last
+// one's SSRF dial and redirect hooks regardless of which handler served the
+// request.
+//
+// The factory now lives on the handler. This test fails on the old code at the
+// first assertion, and the concurrent subtest below trips -race there.
+func TestNewHandler_KeepsItsDiscoveryFactoryToItself(t *testing.T) {
+	before := fmt.Sprintf("%p", newDiscoveryService)
+	h := newTestHandler(t)
+	if got := fmt.Sprintf("%p", newDiscoveryService); got != before {
+		t.Errorf("NewHandler reassigned the package factory (%s -> %s); it must configure its own", before, got)
+	}
+	if h.newDiscovery == nil {
+		t.Fatal("handler has no discovery factory of its own")
+	}
+	if h.discoveryService() == nil {
+		t.Error("discoveryService() returned nil")
+	}
+
+	// A bare handler still resolves, via the package default: plenty of tests
+	// build &Handler{} directly and call discovery paths on it.
+	if (&Handler{}).discoveryService() == nil {
+		t.Error("a handler with no factory must fall back to the package default")
+	}
+}
+
+// TestNewHandler_ConcurrentConstructionIsRaceFree is the -race half. On the old
+// code this is the exact shape that failed: several goroutines in NewHandler,
+// all writing one package variable.
+func TestNewHandler_ConcurrentConstructionIsRaceFree(t *testing.T) {
+	const handlers = 4
+	var wg sync.WaitGroup
+	built := make([]*Handler, handlers)
+	for i := range handlers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			built[i] = newTestHandler(t)
+		}()
+	}
+	wg.Wait()
+
+	for i, h := range built {
+		if h == nil || h.newDiscovery == nil {
+			t.Fatalf("handler %d built without its own discovery factory", i)
+		}
+	}
+}

--- a/internal/api/provider_identity_test.go
+++ b/internal/api/provider_identity_test.go
@@ -54,7 +54,6 @@ func doUpdate(t *testing.T, h *Handler, id uuid.UUID, body string) *httptest.Res
 func TestUpdateProvider_CorrectsABackfilledType(t *testing.T) {
 	srv := koboldcppTestServer(t)
 	defer srv.Close()
-	withDiscoveryAgainst(t, srv.Client())
 
 	stored := &provider.Provider{
 		ID:           uuid.New(),
@@ -64,6 +63,7 @@ func TestUpdateProvider_CorrectsABackfilledType(t *testing.T) {
 	}
 	var captured provider.UpdateProviderRequest
 	h, id := identityHandler(t, stored, &captured)
+	withDiscoveryAgainst(h, srv.Client())
 
 	w := doUpdate(t, h, id, `{"provider_type":"koboldcpp"}`)
 	if w.Code != http.StatusOK {
@@ -79,7 +79,6 @@ func TestUpdateProvider_CorrectsABackfilledType(t *testing.T) {
 func TestUpdateProvider_TypeCorrectionIsProbed(t *testing.T) {
 	srv := koboldcppTestServer(t)
 	defer srv.Close()
-	withDiscoveryAgainst(t, srv.Client())
 
 	stored := &provider.Provider{
 		ID:           uuid.New(),
@@ -89,6 +88,7 @@ func TestUpdateProvider_TypeCorrectionIsProbed(t *testing.T) {
 	}
 	var captured provider.UpdateProviderRequest
 	h, id := identityHandler(t, stored, &captured)
+	withDiscoveryAgainst(h, srv.Client())
 
 	w := doUpdate(t, h, id, `{"provider_type":"lmstudio"}`)
 	if w.Code != http.StatusBadRequest {
@@ -122,7 +122,6 @@ func TestUpdateProvider_RenameDoesNotProbe(t *testing.T) {
 	url := srv.URL
 	client := srv.Client()
 	srv.Close()
-	withDiscoveryAgainst(t, client)
 
 	stored := &provider.Provider{
 		ID:           uuid.New(),
@@ -132,6 +131,7 @@ func TestUpdateProvider_RenameDoesNotProbe(t *testing.T) {
 	}
 	var captured provider.UpdateProviderRequest
 	h, id := identityHandler(t, stored, &captured)
+	withDiscoveryAgainst(h, client)
 
 	for _, body := range []string{
 		`{"name":"KoboldCpp renamed"}`,

--- a/internal/api/provider_typegate.go
+++ b/internal/api/provider_typegate.go
@@ -95,7 +95,7 @@ func (h *Handler) confirmLocalServerType(w http.ResponseWriter, r *http.Request,
 		return true
 	}
 
-	identity, err := newDiscoveryService().IdentifyLocalServer(r.Context(), baseURL, apiKey)
+	identity, err := h.discoveryService().IdentifyLocalServer(r.Context(), baseURL, apiKey)
 	if err != nil {
 		if !errors.Is(err, provider.ErrLocalServerUnreachable) {
 			debuglog.Warn("provider: local server probe failed", "type", providerType, "error", err)

--- a/internal/api/provider_typegate_test.go
+++ b/internal/api/provider_typegate_test.go
@@ -13,15 +13,13 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/provider"
 )
 
-// withDiscoveryAgainst points the package's discovery-service factory at a test
-// server for the duration of a test.
-func withDiscoveryAgainst(t *testing.T, client *http.Client) {
-	t.Helper()
-	orig := newDiscoveryService
-	newDiscoveryService = func() *provider.DiscoveryService {
+// withDiscoveryAgainst points one handler's discovery-service factory at a test
+// server. Scoped to the handler rather than the package, so tests that run in
+// parallel cannot overwrite each other's transport.
+func withDiscoveryAgainst(h *Handler, client *http.Client) {
+	h.newDiscovery = func() *provider.DiscoveryService {
 		return provider.NewDiscoveryServiceWithHTTPClient(client)
 	}
-	t.Cleanup(func() { newDiscoveryService = orig })
 }
 
 func gateBody(t *testing.T, rec *httptest.ResponseRecorder) providerTypeGateResponse {
@@ -42,9 +40,9 @@ func TestConfirmLocalServerType_SkipsNonLocalTypes(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	}))
 	defer srv.Close()
-	withDiscoveryAgainst(t, srv.Client())
 
 	h := &Handler{}
+	withDiscoveryAgainst(h, srv.Client())
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/providers", http.NoBody)
 	if !h.confirmLocalServerType(rec, req, "openai", "https://api.openai.com/v1", "") {
@@ -62,9 +60,9 @@ func TestConfirmLocalServerType_Match(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	}))
 	defer srv.Close()
-	withDiscoveryAgainst(t, srv.Client())
 
 	h := &Handler{}
+	withDiscoveryAgainst(h, srv.Client())
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/providers", http.NoBody)
 	if !h.confirmLocalServerType(rec, req, "koboldcpp", srv.URL+"/v1", "") {
@@ -84,9 +82,9 @@ func TestConfirmLocalServerType_Mismatch(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	}))
 	defer srv.Close()
-	withDiscoveryAgainst(t, srv.Client())
 
 	h := &Handler{}
+	withDiscoveryAgainst(h, srv.Client())
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/providers", http.NoBody)
 	if h.confirmLocalServerType(rec, req, "lmstudio", srv.URL+"/v1", "") {
@@ -114,9 +112,9 @@ func TestConfirmLocalServerType_Unconfirmed(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	}))
 	defer srv.Close()
-	withDiscoveryAgainst(t, srv.Client())
 
 	h := &Handler{}
+	withDiscoveryAgainst(h, srv.Client())
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/providers", http.NoBody)
 	if h.confirmLocalServerType(rec, req, "ollama", srv.URL+"/v1", "") {
@@ -136,9 +134,9 @@ func TestConfirmLocalServerType_Unreachable(t *testing.T) {
 	url := srv.URL
 	client := srv.Client()
 	srv.Close()
-	withDiscoveryAgainst(t, client)
 
 	h := &Handler{}
+	withDiscoveryAgainst(h, client)
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/providers", http.NoBody)
 	if h.confirmLocalServerType(rec, req, "lmstudio", url+"/v1", "") {

--- a/internal/api/quota_snapshot.go
+++ b/internal/api/quota_snapshot.go
@@ -154,7 +154,7 @@ func (h *Handler) PollQuotasOnce(ctx context.Context) {
 		h.ClearQuotaAdvice(ctx)
 		return
 	}
-	disc := newDiscoveryService()
+	disc := h.discoveryService()
 	for _, prov := range providers {
 		if !prov.Enabled {
 			continue
@@ -257,7 +257,7 @@ func (h *Handler) NudgeQuotaPoll(providerID uuid.UUID) {
 		return
 	}
 
-	disc := newDiscoveryService()
+	disc := h.discoveryService()
 	go func() {
 		pollCtx, pollCancel := context.WithTimeout(context.Background(), quotaNudgeTimeout)
 		defer pollCancel()

--- a/internal/api/quota_snapshot_test.go
+++ b/internal/api/quota_snapshot_test.go
@@ -183,9 +183,7 @@ func TestPollQuotasOnce_SuppressesWhenRecentFleetSnapshot(t *testing.T) {
 	}
 
 	called := false
-	orig := newDiscoveryService
-	defer func() { newDiscoveryService = orig }()
-	newDiscoveryService = func() *provider.DiscoveryService {
+	h.newDiscovery = func() *provider.DiscoveryService {
 		return provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{roundTripFunc: func(_ *http.Request) (*http.Response, error) {
 				called = true
@@ -218,9 +216,7 @@ func TestPollQuotasOnce_PollsWhenFleetSnapshotStale(t *testing.T) {
 		t.Fatalf("seed stale fleet snapshot: %v", err)
 	}
 
-	orig := newDiscoveryService
-	defer func() { newDiscoveryService = orig }()
-	newDiscoveryService = func() *provider.DiscoveryService { return nanoGPTPollDiscovery(2) }
+	h.newDiscovery = func() *provider.DiscoveryService { return nanoGPTPollDiscovery(2) }
 
 	h.PollQuotasOnce(context.Background())
 
@@ -234,9 +230,7 @@ func TestPollQuotasOnce_UpsertsEnabledProviders(t *testing.T) {
 	h := newTestHandler(t)
 	id := insertQuotaPollProvider(t, h.dbPool.Pool(), "nanogpt-poll", "https://api.nano-gpt.com/v1", true)
 
-	orig := newDiscoveryService
-	defer func() { newDiscoveryService = orig }()
-	newDiscoveryService = func() *provider.DiscoveryService { return nanoGPTPollDiscovery(9) }
+	h.newDiscovery = func() *provider.DiscoveryService { return nanoGPTPollDiscovery(9) }
 
 	h.PollQuotasOnce(context.Background())
 
@@ -274,9 +268,7 @@ func TestPollQuotasOnce_SkipsDisabled(t *testing.T) {
 	h := newTestHandler(t)
 	id := insertQuotaPollProvider(t, h.dbPool.Pool(), "nanogpt-disabled", "https://api.nano-gpt.com/v1", false)
 
-	orig := newDiscoveryService
-	defer func() { newDiscoveryService = orig }()
-	newDiscoveryService = func() *provider.DiscoveryService {
+	h.newDiscovery = func() *provider.DiscoveryService {
 		return provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 			Transport: &mockTransport{roundTripFunc: func(req *http.Request) (*http.Response, error) {
 				t.Fatalf("disabled provider should not trigger an upstream call to %s", req.URL.String())
@@ -1057,9 +1049,7 @@ func TestNudgeQuotaPoll_DebouncesRepeatOpens(t *testing.T) {
 	id := insertQuotaPollProvider(t, h.dbPool.Pool(), "nanogpt-nudge-debounce", "https://api.nano-gpt.com/v1", true)
 
 	var admitted atomic.Int64
-	orig := newDiscoveryService
-	defer func() { newDiscoveryService = orig }()
-	newDiscoveryService = func() *provider.DiscoveryService {
+	h.newDiscovery = func() *provider.DiscoveryService {
 		admitted.Add(1)
 		return nanoGPTPollDiscovery(7)
 	}
@@ -1095,9 +1085,7 @@ func TestNudgeQuotaPoll_SkipsProvidersWithNothingToPoll(t *testing.T) {
 			id := insertQuotaPollProvider(t, h.dbPool.Pool(), "nudge-"+c.name, c.baseURL, c.enabled)
 
 			var admitted atomic.Int64
-			orig := newDiscoveryService
-			defer func() { newDiscoveryService = orig }()
-			newDiscoveryService = func() *provider.DiscoveryService {
+			h.newDiscovery = func() *provider.DiscoveryService {
 				admitted.Add(1)
 				return nanoGPTPollDiscovery(1)
 			}
@@ -1123,9 +1111,7 @@ func TestNudgeQuotaPoll_RetargetsAdviceFromFreshReading(t *testing.T) {
 	id := insertQuotaPollProvider(t, h.dbPool.Pool(), "zai-nudge", "https://api.z.ai/api/coding/paas/v4", true)
 
 	resetsAt := time.Now().Add(4 * time.Hour)
-	orig := newDiscoveryService
-	defer func() { newDiscoveryService = orig }()
-	newDiscoveryService = func() *provider.DiscoveryService { return exhaustedZaiCodingDiscovery(resetsAt) }
+	h.newDiscovery = func() *provider.DiscoveryService { return exhaustedZaiCodingDiscovery(resetsAt) }
 
 	h.NudgeQuotaPoll(id)
 
@@ -1169,9 +1155,7 @@ func TestNudgeQuotaPoll_RetargetsAnAlreadyOpenCircuit(t *testing.T) {
 	id := insertQuotaPollProvider(t, h.dbPool.Pool(), "zai-repin", "https://api.z.ai/api/coding/paas/v4", true)
 
 	resetsAt := time.Now().Add(4 * time.Hour)
-	orig := newDiscoveryService
-	defer func() { newDiscoveryService = orig }()
-	newDiscoveryService = func() *provider.DiscoveryService { return exhaustedZaiCodingDiscovery(resetsAt) }
+	h.newDiscovery = func() *provider.DiscoveryService { return exhaustedZaiCodingDiscovery(resetsAt) }
 
 	// The advisor is empty until the nudge refreshes it, so this open is
 	// necessarily unpinned and lands on the 60s default cooldown.

--- a/internal/provider/discovery_http_test.go
+++ b/internal/provider/discovery_http_test.go
@@ -33,9 +33,11 @@ func TestDiscoverOllama(t *testing.T) {
 		"model_info": {"llama3.context_length": 8192}
 	}`
 
-	callCount := 0
+	// No request counter here: discoverOllama fetches /api/tags once and then
+	// /api/show per model CONCURRENTLY, so a plain int incremented in this
+	// handler is a data race across those goroutines. The previous one was
+	// written and never read, so it bought nothing and cost a flaky -race run.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		callCount++
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
 		case "/api/tags":


### PR DESCRIPTION
Fixes the two data races that turned Go Race red on master for the #800 merge. Both are real; neither was caused by that PR's content.

## 1. `NewHandler` assigned a package-level variable

```go
newDiscoveryService = func() *provider.DiscoveryService {
    return provider.NewDiscoveryService(h.discoveryDialCtx, h.discoveryCheckRedirect)
}
```

Constructing a handler mutated global state. Several tests in this package run with `t.Parallel()` and build their own handler through `newTestHandler`, so two constructors write that variable at once — `TestGetSystem_Handler` against `TestGetSystem_InvalidSince` in the failing run.

**The race is the symptom.** The defect underneath is that a process with more than one handler had exactly **one** discovery factory, belonging to whichever handler was constructed last. Every discovery call — `DiscoverProviderModels`, `RefreshAllQuotas`, `PollQuotasOnce`, the local-server type gate — then used that handler's SSRF dial and redirect hooks, regardless of which handler was serving the request. In production only one handler is built, so it never bit; it is still the wrong shape, and it is what made the tests fragile enough to notice.

The `Handler` already carried `discoveryDialCtx` and `discoveryCheckRedirect` as fields. The factory built from them now lives beside them, and all seven call sites go through `h.discoveryService()`. The package variable survives **only** as the fallback for the bare `&Handler{}` values tests construct, and is never reassigned.

### The tests got smaller

The 55 overrides were all of this shape:

```go
orig := newDiscoveryService
defer func() { newDiscoveryService = orig }()
newDiscoveryService = func() *provider.DiscoveryService { ... }
```

They become a single assignment to the handler under test. No save, no restore — the handler is per-test, so there is nothing to leak. That is a net **−72 lines**, and it deletes this comment, which had been documenting the bug for some time:

> `// Note: Must override AFTER newTestHandlerWithRouter since NewHandler sets it`

`withDiscoveryAgainst` now takes the handler it configures rather than reaching for the global, so two parallel tests can no longer overwrite each other's mock transport.

## 2. A racing counter in `TestDiscoverOllama`

```go
callCount := 0
server := httptest.NewServer(http.HandlerFunc(func(...) {
    callCount++
```

`discoverOllama` fetches `/api/tags` once and then `/api/show` **per model, concurrently**, so the increments race across those goroutines. The counter was written and never read anywhere, so it asserted nothing and cost a flaky `-race` run. Removed, with a comment recording why a plain `int` cannot go back there.

## Verification

Both regression tests fail on the old code:

- `TestNewHandler_KeepsItsDiscoveryFactoryToItself` reports the reassignment by function pointer (`0x10b6e20 -> 0x10b71a0`).
- `TestNewHandler_ConcurrentConstructionIsRaceFree` trips the detector with **2 data races** when `NewHandler` is reverted to writing the global.

It also pins the fallback: a bare `&Handler{}` still resolves a discovery service through the package default, which is what the directly-constructed handlers in this package's tests rely on.

`go test -race` clean on both packages (`internal/api` 155s, `internal/provider` 16s), full suites green, `golangci-lint` clean, `make size-check` clean.
