### PR TITLE
fix(proxy): stop an error frame from winning the hedged race

### DIFF
--- a/internal/proxy/hedge_cancel_origin_test.go
+++ b/internal/proxy/hedge_cancel_origin_test.go
@@ -61,6 +61,16 @@ func (c *attrCapture) find(msg string) []capturedRecord {
 	return out
 }
 
+// all returns a snapshot of every captured record, for assertions that must
+// hold across the whole log rather than one message.
+func (c *attrCapture) all() []capturedRecord {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]capturedRecord, len(c.records))
+	copy(out, c.records)
+	return out
+}
+
 // captureProxyLogs redirects slog for the duration of a test.
 func captureProxyLogs(t *testing.T) *attrCapture {
 	t.Helper()

--- a/internal/proxy/hedging.go
+++ b/internal/proxy/hedging.go
@@ -358,7 +358,7 @@ func (h *Handler) probeStreamingCandidate(ctx context.Context, st *requestState,
 		elapsed := time.Since(st.startTime)
 		re, recordFailure := classifyProbeError(probeErr, candidate.provider.Name, newCredentialMasker(candidate.apiKey), clientGone, elapsed, stallTimeout, ttftTimeout, attempt)
 		if recordFailure && st.circuitBreakerEnabled {
-			debuglog.Warn("proxy: recording circuit breaker failure", "reason", "hedged TTFT probe failed", "provider", candidate.provider.Name, "provider_id", candidate.provider.ID, "model", candidate.model.ModelID, "attempt", attempt, "kind", string(re.Kind), "duration_ms", elapsed.Milliseconds(), "error", errString(probeErr))
+			debuglog.Warn("proxy: recording circuit breaker failure", "reason", "hedged TTFT probe failed", "provider", candidate.provider.Name, "provider_id", candidate.provider.ID, "model", candidate.model.ModelID, "attempt", attempt, "kind", string(re.Kind), "duration_ms", elapsed.Milliseconds(), "error", re.Underlying)
 			h.circuitBreaker.RecordFailure(candidate.provider.ID, candidate.provider.Name)
 		}
 		res.reqErr = re

--- a/internal/proxy/hedging.go
+++ b/internal/proxy/hedging.go
@@ -344,9 +344,6 @@ func (h *Handler) probeStreamingCandidate(ctx context.Context, st *requestState,
 
 	if ttftTimeout <= 0 {
 		// No TTFT probe configured: a 200 is an immediate win (backward compat).
-		if st.circuitBreakerEnabled {
-			h.circuitBreaker.RecordSuccess(candidate.provider.ID, candidate.provider.Name)
-		}
 		return commitHedgeWin(ctx, res, resp, nil, 0, candidate)
 	}
 
@@ -359,7 +356,7 @@ func (h *Handler) probeStreamingCandidate(ctx context.Context, st *requestState,
 		// past the floor is a provider fault. Mirrors dispatchStreaming.
 		clientGone := ctx.Err() != nil
 		elapsed := time.Since(st.startTime)
-		re, recordFailure := classifyProbeError(probeErr, candidate.provider.Name, clientGone, elapsed, stallTimeout, ttftTimeout, attempt)
+		re, recordFailure := classifyProbeError(probeErr, candidate.provider.Name, newCredentialMasker(candidate.apiKey), clientGone, elapsed, stallTimeout, ttftTimeout, attempt)
 		if recordFailure && st.circuitBreakerEnabled {
 			debuglog.Warn("proxy: recording circuit breaker failure", "reason", "hedged TTFT probe failed", "provider", candidate.provider.Name, "provider_id", candidate.provider.ID, "model", candidate.model.ModelID, "attempt", attempt, "kind", string(re.Kind), "duration_ms", elapsed.Milliseconds(), "error", errString(probeErr))
 			h.circuitBreaker.RecordFailure(candidate.provider.ID, candidate.provider.Name)
@@ -368,9 +365,9 @@ func (h *Handler) probeStreamingCandidate(ctx context.Context, st *requestState,
 		return res
 	}
 
-	if st.circuitBreakerEnabled {
-		h.circuitBreaker.RecordSuccess(candidate.provider.ID, candidate.provider.Name)
-	}
+	// No breaker success here either: the winner's stream is judged by
+	// finalizeStream, and a runner-up whose stream is never read is no evidence
+	// of anything. See judgeStreamForBreaker.
 	return commitHedgeWin(ctx, res, resp, probeBuf, trueTtftMs, candidate)
 }
 
@@ -378,8 +375,7 @@ func (h *Handler) probeStreamingCandidate(ctx context.Context, st *requestState,
 // (which already carries the attempt's timing fields). If the attempt's context
 // was cancelled in the meantime (the orchestrator already picked another winner),
 // the open body is closed and the result is downgraded to a client-disconnect drop
-// so no runner-up connection leaks. The breaker success recorded by the caller is
-// left intact: the provider really did produce a first token.
+// so no runner-up connection leaks.
 func commitHedgeWin(ctx context.Context, res hedgeResult, resp *http.Response, preReadBuf *bytes.Buffer, trueTtftMs float64, candidate modelCandidate) hedgeResult {
 	if ctx.Err() != nil {
 		_ = resp.Body.Close()

--- a/internal/proxy/hedging.go
+++ b/internal/proxy/hedging.go
@@ -359,7 +359,7 @@ func (h *Handler) probeStreamingCandidate(ctx context.Context, st *requestState,
 		// past the floor is a provider fault. Mirrors dispatchStreaming.
 		clientGone := ctx.Err() != nil
 		elapsed := time.Since(st.startTime)
-		re, recordFailure := classifyProbeFailure(candidate.provider.Name, errString(probeErr), clientGone, elapsed, stallTimeout, ttftTimeout, attempt)
+		re, recordFailure := classifyProbeError(probeErr, candidate.provider.Name, clientGone, elapsed, stallTimeout, ttftTimeout, attempt)
 		if recordFailure && st.circuitBreakerEnabled {
 			debuglog.Warn("proxy: recording circuit breaker failure", "reason", "hedged TTFT probe failed", "provider", candidate.provider.Name, "provider_id", candidate.provider.ID, "model", candidate.model.ModelID, "attempt", attempt, "kind", string(re.Kind), "duration_ms", elapsed.Milliseconds(), "error", errString(probeErr))
 			h.circuitBreaker.RecordFailure(candidate.provider.ID, candidate.provider.Name)

--- a/internal/proxy/probe_error_frame_test.go
+++ b/internal/proxy/probe_error_frame_test.go
@@ -502,3 +502,69 @@ func TestClassifyProbeError_ChargesEvenWhenTheClientIsGone(t *testing.T) {
 		t.Error("a fast client cancel with zero tokens must still not be charged")
 	}
 }
+
+// A provider is free to quote the api key back inside its own error, and this
+// branch made that text travel further than it used to: into the probe's
+// warning, the sequential dispatcher's "TTFT probe failed" line and the hedged
+// path's breaker warning.
+//
+// Masking reqError.Underlying is not sufficient on its own — the call sites
+// were logging the RAW probeErr beside it — and key-SHAPE masking is not
+// sufficient either, since an operator's credential need not look like a key.
+// Nothing may carry the configured credential verbatim.
+func TestProbeErrorFrame_NeverLogsTheProviderCredential(t *testing.T) {
+	// Deliberately not key-shaped: no sk- prefix, no great length. A shape
+	// heuristic passes this straight through.
+	const apiKey = "hunter2-corp"
+	frame := "data: {\"error\":{\"message\":\"auth failed for " + apiKey + "\"}}\n\n"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, frame)
+	}))
+	defer srv.Close()
+
+	for _, tc := range []struct {
+		name string
+		run  func(t *testing.T, h *Handler, st *requestState, cand modelCandidate)
+	}{
+		{"sequential", func(_ *testing.T, h *Handler, st *requestState, cand modelCandidate) {
+			resp, err := srv.Client().Get(srv.URL) //nolint:noctx // test server, no context needed
+			if err != nil {
+				t.Fatalf("get: %v", err)
+			}
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)
+			h.dispatchStreaming(w, req, st, cand, resp, 0, 10, "failover_timeout")
+		}},
+		{"hedged", func(_ *testing.T, h *Handler, st *requestState, cand modelCandidate) {
+			res := h.probeStreamingCandidate(context.Background(), st, cand, 0, 5*time.Second, 30*time.Second)
+			if res.resp != nil {
+				_ = res.resp.Body.Close()
+			}
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newIntegrationHandler()
+			defer stopUnitHandler(h)
+			logs := captureProxyLogs(t)
+
+			st, cand := probeStateForServer(srv.URL)
+			st.circuitBreakerEnabled = true
+			cand.apiKey = apiKey
+			tc.run(t, h, st, cand)
+
+			for _, r := range logs.all() {
+				for k, v := range r.attrs {
+					if strings.Contains(v, apiKey) {
+						t.Errorf("log %q attr %s = %q leaks the provider credential", r.msg, k, v)
+					}
+				}
+				if strings.Contains(r.msg, apiKey) {
+					t.Errorf("log message %q leaks the provider credential", r.msg)
+				}
+			}
+		})
+	}
+}

--- a/internal/proxy/probe_error_frame_test.go
+++ b/internal/proxy/probe_error_frame_test.go
@@ -187,21 +187,27 @@ func TestRunHedgedStreaming_HealthyCandidateBeatsAFasterErrorFrame(t *testing.T)
 // breaker is the only thing left that can keep the next request away.
 // ---------------------------------------------------------------------------
 
-func TestHandleStreamingResponse_ErrorWithNoContentOpensTheCircuit(t *testing.T) {
+func TestDispatchStreaming_ErrorAfterTheFirstFrameOpensTheCircuit(t *testing.T) {
 	h := newIntegrationHandler()
 	defer stopUnitHandlerIntegration(h)
 
-	// Deliberately at the PRODUCTION default threshold (5), not a threshold of
-	// 1. The first version of this fix passed at 1 and was completely inert at
-	// 5: the TTFT probe recorded a breaker SUCCESS on every request before the
-	// stream ran, which zeroed consecutiveFails, so the failure charged here
-	// could only ever bring the count back to 1. Pinning the threshold to 1 is
-	// the one value at which that bug is invisible.
+	// Two things about this test are load-bearing, and an earlier version of it
+	// had neither.
+	//
+	// It goes through dispatchStreaming, NOT straight to handleStreamingResponse,
+	// so the TTFT probe really runs. The bug being pinned lives in what the probe
+	// tells the breaker, so a test that skips the probe cannot see it — the first
+	// version of this test passed with the bug fully restored.
+	//
+	// And it runs at the PRODUCTION default threshold of 5. The bug is that a
+	// probe success zeroes consecutiveFails on every request, so each failure can
+	// only bring the count back to 1. A threshold of 1 is the single value at
+	// which that is invisible.
 	providerID := uuid.New()
 	const attempts = 5
 	for i := range attempts {
-		// A valid opening frame (so the probe would pass), then the error.
-		// Nothing is ever delivered to the caller.
+		// A valid opening frame, so the probe passes and the provider is
+		// committed to; then the error. Nothing reaches the caller.
 		resp := &http.Response{
 			StatusCode: http.StatusOK,
 			Body: io.NopCloser(strings.NewReader(
@@ -213,23 +219,30 @@ func TestHandleStreamingResponse_ErrorWithNoContentOpensTheCircuit(t *testing.T)
 		logData.providerName = "error-frame-provider"
 		h.insertRequestLogAsync(logData)
 
+		st := &requestState{
+			startTime:             time.Now(),
+			reqModel:              "test-model",
+			isStreaming:           true,
+			circuitBreakerEnabled: true,
+			logData:               logData,
+		}
+		cand := modelCandidate{
+			model:    &model.Model{ModelID: "test-model"},
+			provider: &provider.Provider{ID: providerID, Name: "error-frame-provider"},
+			apiKey:   "sk-test",
+		}
 		w := httptest.NewRecorder()
 		req := httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)
-		h.handleStreamingResponse(w, req, logData, resp, time.Now(), streamOptions{
-			responseHeaderMs: 10,
-			providerID:       providerID,
-			providerName:     "error-frame-provider",
-			circuitBreakerOn: true,
-			vkHash:           "test-hash",
-			attempt:          1,
-		})
+		if got := h.dispatchStreaming(w, req, st, cand, resp, 1, 10, "failover_timeout"); got != outcomeServed {
+			t.Fatalf("attempt %d: outcome = %v, want served (the probe must pass on a healthy first frame)", i, got)
+		}
 		if logData.state != "failed" {
 			t.Fatalf("attempt %d: state = %q, want failed", i, logData.state)
 		}
 	}
 
 	if got := h.circuitBreaker.GetState(providerID); got != failover.StateOpen {
-		t.Errorf("circuit = %s after %d zero-content failures, want open", got, attempts)
+		t.Errorf("circuit = %s after %d committed-then-failed streams, want open", got, attempts)
 	}
 }
 

--- a/internal/proxy/probe_error_frame_test.go
+++ b/internal/proxy/probe_error_frame_test.go
@@ -1,0 +1,349 @@
+package proxy
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/hugalafutro/model-hotel/internal/failover"
+	"github.com/hugalafutro/model-hotel/internal/model"
+	"github.com/hugalafutro/model-hotel/internal/provider"
+)
+
+// ---------------------------------------------------------------------------
+// A provider that answers 200 and then puts an error envelope in its FIRST SSE
+// data frame must not be credited with a first token. The TTFT probe is what
+// picks the winner of a hedged race, so counting an error frame as a token
+// rewards the fastest FAILURE: the broken provider wins, every healthy rival
+// still in flight is cancelled as superseded, and the request dies with no
+// second chance. Observed in production 2026-08-28, 36 consecutive dead
+// requests on hotel/glm52 while a working provider was cancelled each time.
+// ---------------------------------------------------------------------------
+
+const errorFrameSSE = "data: {\"error\":{\"message\":\"Unterminated string starting at: line 1 column 9777 (char 9776)\"}}\n\n"
+
+func TestProbeFirstToken_ErrorEnvelopeIsNotAToken(t *testing.T) {
+	h := &Handler{}
+	body := makeSSEBody(t, errorFrameSSE)
+
+	probeBuf, trueTtftMs, err := h.probeFirstToken(context.Background(), body, 5*time.Second, time.Now())
+
+	if err == nil {
+		t.Fatalf("an error envelope must fail the probe, got a token at ttft=%.1fms buf=%q", trueTtftMs, bufString(probeBuf))
+	}
+	if !strings.Contains(err.Error(), "Unterminated string") {
+		t.Errorf("probe error = %q, want it to carry the provider's own message", err)
+	}
+}
+
+// The error frame is still an error when it arrives behind the keepalives and
+// event: lines the probe skips, which is how a real provider frames it.
+func TestProbeFirstToken_ErrorEnvelopeBehindKeepalive(t *testing.T) {
+	h := &Handler{}
+	body := makeSSEBody(t, ": keepalive\n\nevent: error\n"+errorFrameSSE)
+
+	if _, _, err := h.probeFirstToken(context.Background(), body, 5*time.Second, time.Now()); err == nil {
+		t.Fatal("an error envelope behind a keepalive must fail the probe")
+	}
+}
+
+// The guard must be narrow: an ordinary first token is still a first token.
+// Without this a false positive would fail over every healthy stream.
+func TestProbeFirstToken_ContentFrameStillWins(t *testing.T) {
+	h := &Handler{}
+	for name, frame := range map[string]string{
+		"content delta":     "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"}}]}\n\n",
+		"empty choices":     "data: {\"choices\":[]}\n\n",
+		"role-only delta":   "data: {\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\"}}]}\n\n",
+		"explicit null err": "data: {\"error\":null,\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"}}]}\n\n",
+		"unparseable json":  "data: {not json at all\n\n",
+		"word error inside": "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"the error was mine\"}}]}\n\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			h2 := h
+			if _, ttft, err := h2.probeFirstToken(context.Background(), makeSSEBody(t, frame), 5*time.Second, time.Now()); err != nil {
+				t.Fatalf("a healthy first frame must win the probe, got %v", err)
+			} else if ttft <= 0 {
+				t.Errorf("ttft = %f, want > 0", ttft)
+			}
+		})
+	}
+}
+
+func bufString(b interface{ String() string }) string {
+	if b == nil {
+		return ""
+	}
+	return b.String()
+}
+
+// ---------------------------------------------------------------------------
+// The hedged path: an error frame must lose the race and be charged.
+// ---------------------------------------------------------------------------
+
+func TestProbeStreamingCandidate_ErrorFrameLosesAndIsChargedToTheProvider(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandler(h)
+	withBreakerThresholdOne(t, h)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, errorFrameSSE)
+	}))
+	defer srv.Close()
+
+	st, cand := probeStateForServer(srv.URL)
+	st.circuitBreakerEnabled = true
+
+	res := h.probeStreamingCandidate(context.Background(), st, cand, 0, 5*time.Second, 30*time.Second)
+	if res.resp != nil {
+		_ = res.resp.Body.Close()
+	}
+	if res.won {
+		t.Fatal("a stream whose first frame is an error must not win the race")
+	}
+	if res.reqErr.Kind != KindProviderError {
+		t.Errorf("kind = %s, want %s: the provider answered, it just answered with an error",
+			res.reqErr.Kind, KindProviderError)
+	}
+	// Charged to the breaker, which is the half that stops the next 35
+	// requests walking into the same provider.
+	if got := h.circuitBreaker.GetState(cand.provider.ID); got != failover.StateOpen {
+		t.Errorf("circuit = %s, want open: an error-frame probe is a provider failure", got)
+	}
+}
+
+// The incident, end to end. Two candidates race: the broken one answers with an
+// error frame FIRST, the healthy one answers with a real token later. Before
+// the fix the broken one won at 100ms and the healthy one was cancelled as
+// hedge_superseded, so the caller got nothing.
+func TestRunHedgedStreaming_HealthyCandidateBeatsAFasterErrorFrame(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandler(h)
+
+	broken := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		time.Sleep(100 * time.Millisecond)
+		_, _ = io.WriteString(w, errorFrameSSE)
+	}))
+	defer broken.Close()
+
+	healthy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		time.Sleep(250 * time.Millisecond)
+		_, _ = io.WriteString(w, "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"}}]}\n\ndata: [DONE]\n\n")
+	}))
+	defer healthy.Close()
+
+	st, logData := newHedgeState(10 * time.Millisecond)
+	st.bodyBytes = []byte(`{"model":"test-model","messages":[{"role":"user","content":"hi"}],"stream":true}`)
+	cands := []modelCandidate{
+		liveCandidate("broken", broken.URL),
+		liveCandidate("healthy", healthy.URL),
+	}
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)
+	h.runHedgedStreaming(w, req, st, cands, h.probeStreamingCandidate)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body %s", w.Code, w.Body.String())
+	}
+	if body := w.Body.String(); !strings.Contains(body, `"content":"hi"`) {
+		t.Fatalf("the caller must receive the healthy provider's token, got: %s", body)
+	}
+	if logData.providerName != "healthy" {
+		t.Errorf("winner = %q, want %q: the error frame must not win the race",
+			logData.providerName, "healthy")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// A stream that commits and THEN fails without delivering anything is still a
+// provider failure. The probe guard above only covers the first frame; an error
+// on a later frame arrives after the rivals are already cancelled, so the
+// breaker is the only thing left that can keep the next request away.
+// ---------------------------------------------------------------------------
+
+func TestHandleStreamingResponse_ErrorWithNoContentChargesTheBreaker(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandlerIntegration(h)
+	withBreakerThresholdOne(t, h)
+
+	// A valid opening frame (so the probe would pass), then the error. Nothing
+	// is ever delivered to the caller.
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body: io.NopCloser(strings.NewReader(
+			"data: {\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\"}}]}\n\n" + errorFrameSSE)),
+	}
+
+	providerID := uuid.New()
+	// providerID is deliberately left off logData: the request-log row has a
+	// foreign key to providers and this provider exists only in the breaker.
+	logData := streamingLog()
+	logData.providerName = "error-frame-provider"
+	h.insertRequestLogAsync(logData)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)
+	h.handleStreamingResponse(w, req, logData, resp, time.Now(), streamOptions{
+		responseHeaderMs: 10,
+		providerID:       providerID,
+		providerName:     "error-frame-provider",
+		circuitBreakerOn: true,
+		vkHash:           "test-hash",
+		attempt:          1,
+	})
+
+	if logData.state != "failed" {
+		t.Errorf("state = %q, want failed", logData.state)
+	}
+	if got := h.circuitBreaker.GetState(providerID); got != failover.StateOpen {
+		t.Errorf("circuit = %s, want open: the stream errored having delivered nothing", got)
+	}
+}
+
+// The counterpart guard: a provider that streamed real content before failing
+// did part of its job, and must NOT be broken for it. Without this the fix
+// above would open a circuit on every truncated-but-useful stream.
+func TestHandleStreamingResponse_ErrorAfterContentDoesNotChargeTheBreaker(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandlerIntegration(h)
+	withBreakerThresholdOne(t, h)
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body: io.NopCloser(strings.NewReader(
+			"data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"partial answer\"}}]}\n\n" + errorFrameSSE)),
+	}
+
+	providerID := uuid.New()
+	logData := streamingLog()
+	logData.providerName = "partial-provider"
+	h.insertRequestLogAsync(logData)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)
+	h.handleStreamingResponse(w, req, logData, resp, time.Now(), streamOptions{
+		responseHeaderMs: 10,
+		providerID:       providerID,
+		providerName:     "partial-provider",
+		circuitBreakerOn: true,
+		vkHash:           "test-hash",
+		attempt:          1,
+	})
+
+	if got := h.circuitBreaker.GetState(providerID); got == failover.StateOpen {
+		t.Error("a provider that delivered content before failing must not be broken for it")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+// liveCandidate builds a hedge candidate pointed at a real test server.
+func liveCandidate(name, baseURL string) modelCandidate {
+	return modelCandidate{
+		model:    &model.Model{ModelID: "m-" + name},
+		provider: &provider.Provider{ID: uuid.New(), Name: name, BaseURL: baseURL},
+		apiKey:   "sk-test",
+	}
+}
+
+// withBreakerThresholdOne makes a single RecordFailure open the circuit, so a
+// test can observe "was the breaker charged" through GetState.
+func withBreakerThresholdOne(t *testing.T, h *Handler) {
+	t.Helper()
+	if err := h.settingsRepo.Set(context.Background(), "circuit_breaker_threshold", "1"); err != nil {
+		t.Fatalf("set circuit_breaker_threshold: %v", err)
+	}
+	h.settingsRepo.InvalidateCache("circuit_breaker_threshold")
+	t.Cleanup(func() {
+		_ = h.settingsRepo.Set(context.Background(), "circuit_breaker_threshold", "5")
+		h.settingsRepo.InvalidateCache("circuit_breaker_threshold")
+	})
+}
+
+// errorEnvelopeMessage is unit-tested directly because the probe's scanner-error
+// recovery branch calls it too, and that branch is defence-in-depth for a race
+// the existing tests document as impossible to trigger deterministically
+// (see TestProbeFirstToken_ScannerErrorRecovery_PipeRace). Testing the decision
+// covers both callers of it.
+func TestErrorEnvelopeMessage(t *testing.T) {
+	tests := []struct {
+		name    string
+		frame   string
+		wantMsg string
+		wantOk  bool
+	}{
+		{"provider error", `{"error":{"message":"boom"}}`, "boom", true},
+		{"error with no message", `{"error":{}}`, "provider reported an error with no message", true},
+		{"anthropic error event", `{"type":"error","error":{"type":"overloaded_error","message":"overloaded"}}`, "overloaded", true},
+		{"ordinary token", `{"choices":[{"delta":{"content":"hi"}}]}`, "", false},
+		{"explicit null error", `{"error":null,"choices":[]}`, "", false},
+		{"unparseable frame", `{not json`, "", false},
+		{"error as a string", `{"error":"boom"}`, "", false},
+		{"json array", `[1,2,3]`, "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			msg, ok := errorEnvelopeMessage(tc.frame)
+			if ok != tc.wantOk {
+				t.Fatalf("ok = %v, want %v (msg %q)", ok, tc.wantOk, msg)
+			}
+			if msg != tc.wantMsg {
+				t.Errorf("msg = %q, want %q", msg, tc.wantMsg)
+			}
+		})
+	}
+}
+
+// The provider's own text reaches the request log through reqError.Underlying,
+// so it goes through the same sanitizer every other upstream body does.
+func TestClassifyProbeError_SanitizesTheProvidersMessage(t *testing.T) {
+	msg := "tenant 793ac38b-0211-43e6-baa7-aa7054c39931 exceeded quota"
+	re, charged := classifyProbeError(&upstreamFrameError{msg: msg}, "prov-A", false, time.Second, 30*time.Second, 60*time.Second, 1)
+
+	if !charged {
+		t.Error("an error envelope is always the provider's fault and must be charged")
+	}
+	if re.Kind != KindProviderError {
+		t.Errorf("kind = %s, want %s", re.Kind, KindProviderError)
+	}
+	if strings.Contains(re.Underlying, "793ac38b") {
+		t.Errorf("underlying = %q, want the UUID redacted", re.Underlying)
+	}
+}
+
+// A client that hangs up cannot excuse an error envelope: the provider had
+// already answered with a failure, so the charge does not depend on the
+// downstream connection the way a zero-token stall does.
+func TestClassifyProbeError_ChargesEvenWhenTheClientIsGone(t *testing.T) {
+	_, charged := classifyProbeError(&upstreamFrameError{msg: "boom"}, "prov-A", true, time.Millisecond, 30*time.Second, 60*time.Second, 1)
+	if !charged {
+		t.Error("an error envelope must be charged to the provider even when the client is gone")
+	}
+	// The contrast that makes the case above meaningful: a zero-token stall
+	// with a fast client close is NOT charged.
+	if _, chargedStall := classifyProbeError(errors.New("TTFT timeout"), "prov-A", true, time.Millisecond, 30*time.Second, 60*time.Second, 1); chargedStall {
+		t.Error("a fast client cancel with zero tokens must still not be charged")
+	}
+}

--- a/internal/proxy/probe_error_frame_test.go
+++ b/internal/proxy/probe_error_frame_test.go
@@ -63,8 +63,14 @@ func TestProbeFirstToken_ContentFrameStillWins(t *testing.T) {
 		"empty choices":     "data: {\"choices\":[]}\n\n",
 		"role-only delta":   "data: {\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\"}}]}\n\n",
 		"explicit null err": "data: {\"error\":null,\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"}}]}\n\n",
-		"unparseable json":  "data: {not json at all\n\n",
-		"word error inside": "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"the error was mine\"}}]}\n\n",
+		// An empty boilerplate error member alongside a real token: the frame
+		// delivered content, so failing it over would throw away an answer.
+		"empty err + content": "data: {\"error\":{},\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"}}]}\n\n",
+		// The native Anthropic passthrough is probed like any other stream, and
+		// its first frame must keep winning.
+		"anthropic message_start": "data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"usage\":{\"input_tokens\":10}}}\n\n",
+		"unparseable json":        "data: {not json at all\n\n",
+		"word error inside":       "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"the error was mine\"}}]}\n\n",
 	} {
 		t.Run(name, func(t *testing.T) {
 			h2 := h
@@ -181,42 +187,160 @@ func TestRunHedgedStreaming_HealthyCandidateBeatsAFasterErrorFrame(t *testing.T)
 // breaker is the only thing left that can keep the next request away.
 // ---------------------------------------------------------------------------
 
-func TestHandleStreamingResponse_ErrorWithNoContentChargesTheBreaker(t *testing.T) {
+func TestHandleStreamingResponse_ErrorWithNoContentOpensTheCircuit(t *testing.T) {
 	h := newIntegrationHandler()
 	defer stopUnitHandlerIntegration(h)
-	withBreakerThresholdOne(t, h)
 
-	// A valid opening frame (so the probe would pass), then the error. Nothing
-	// is ever delivered to the caller.
-	resp := &http.Response{
-		StatusCode: http.StatusOK,
-		Body: io.NopCloser(strings.NewReader(
-			"data: {\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\"}}]}\n\n" + errorFrameSSE)),
+	// Deliberately at the PRODUCTION default threshold (5), not a threshold of
+	// 1. The first version of this fix passed at 1 and was completely inert at
+	// 5: the TTFT probe recorded a breaker SUCCESS on every request before the
+	// stream ran, which zeroed consecutiveFails, so the failure charged here
+	// could only ever bring the count back to 1. Pinning the threshold to 1 is
+	// the one value at which that bug is invisible.
+	providerID := uuid.New()
+	const attempts = 5
+	for i := range attempts {
+		// A valid opening frame (so the probe would pass), then the error.
+		// Nothing is ever delivered to the caller.
+		resp := &http.Response{
+			StatusCode: http.StatusOK,
+			Body: io.NopCloser(strings.NewReader(
+				"data: {\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\"}}]}\n\n" + errorFrameSSE)),
+		}
+		// providerID is deliberately left off logData: the request-log row has a
+		// foreign key to providers and this provider exists only in the breaker.
+		logData := streamingLog()
+		logData.providerName = "error-frame-provider"
+		h.insertRequestLogAsync(logData)
+
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)
+		h.handleStreamingResponse(w, req, logData, resp, time.Now(), streamOptions{
+			responseHeaderMs: 10,
+			providerID:       providerID,
+			providerName:     "error-frame-provider",
+			circuitBreakerOn: true,
+			vkHash:           "test-hash",
+			attempt:          1,
+		})
+		if logData.state != "failed" {
+			t.Fatalf("attempt %d: state = %q, want failed", i, logData.state)
+		}
 	}
+
+	if got := h.circuitBreaker.GetState(providerID); got != failover.StateOpen {
+		t.Errorf("circuit = %s after %d zero-content failures, want open", got, attempts)
+	}
+}
+
+// A stream that completes is what lets a provider recover, and it is now
+// recorded by the finalizer rather than the probe. Without it a provider would
+// accumulate failures forever with nothing able to clear them.
+func TestHandleStreamingResponse_CompletedStreamClearsTheFailureCount(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandlerIntegration(h)
 
 	providerID := uuid.New()
-	// providerID is deliberately left off logData: the request-log row has a
-	// foreign key to providers and this provider exists only in the breaker.
-	logData := streamingLog()
-	logData.providerName = "error-frame-provider"
-	h.insertRequestLogAsync(logData)
-
-	w := httptest.NewRecorder()
-	req := httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)
-	h.handleStreamingResponse(w, req, logData, resp, time.Now(), streamOptions{
-		responseHeaderMs: 10,
-		providerID:       providerID,
-		providerName:     "error-frame-provider",
-		circuitBreakerOn: true,
-		vkHash:           "test-hash",
-		attempt:          1,
-	})
-
-	if logData.state != "failed" {
-		t.Errorf("state = %q, want failed", logData.state)
+	opts := func() streamOptions {
+		return streamOptions{
+			responseHeaderMs: 10,
+			providerID:       providerID,
+			providerName:     "recovering-provider",
+			circuitBreakerOn: true,
+			vkHash:           "test-hash",
+			attempt:          1,
+		}
 	}
-	if got := h.circuitBreaker.GetState(providerID); got != failover.StateOpen {
-		t.Errorf("circuit = %s, want open: the stream errored having delivered nothing", got)
+	fail := func() {
+		logData := streamingLog()
+		logData.providerName = "recovering-provider"
+		h.insertRequestLogAsync(logData)
+		resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(errorFrameSSE))}
+		h.handleStreamingResponse(httptest.NewRecorder(), httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody), logData, resp, time.Now(), opts())
+	}
+	succeed := func() {
+		logData := streamingLog()
+		logData.providerName = "recovering-provider"
+		h.insertRequestLogAsync(logData)
+		resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(
+			"data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"}}]}\n\ndata: [DONE]\n\n"))}
+		h.handleStreamingResponse(httptest.NewRecorder(), httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody), logData, resp, time.Now(), opts())
+	}
+
+	// Four failures is one short of the default threshold; a completed stream
+	// must reset the count so the fifth failure does not open the circuit.
+	for range 4 {
+		fail()
+	}
+	succeed()
+	fail()
+	if got := h.circuitBreaker.GetState(providerID); got == failover.StateOpen {
+		t.Errorf("circuit = %s, want closed: a completed stream must clear the failure count", got)
+	}
+}
+
+// A gateway-authored failure is not the provider's fault and must not darken it.
+// deriveStreamError produces these for the param-strip retry budget, the
+// per-attempt failover timeout, and internal cancels.
+func TestJudgeStreamForBreaker_DoesNotChargeGatewayAuthoredFailures(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		kind ErrorKind
+		want bool // charged
+	}{
+		{"provider error", KindProviderError, true},
+		{"provider timeout", KindProviderTimeout, true},
+		{"model gone", KindProviderModelGone, true},
+		{"gateway internal", KindInternal, false},
+		{"param-strip retry budget", KindRetryTimeout, false},
+		{"failover deadline", KindFailoverTimeout, false},
+		{"validation", KindValidation, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			st := &streamState{}
+			logData := &requestLogData{errorKind: tc.kind}
+			got := judgeStreamForBreaker(st, logData, "something went wrong", true).failureReason != ""
+			if got != tc.want {
+				t.Errorf("charged = %v, want %v for kind %s", got, tc.want, tc.kind)
+			}
+		})
+	}
+}
+
+// Neither a shutdown nor a client hangup is the provider's fault, and neither is
+// evidence that it is healthy: both record nothing at all.
+func TestJudgeStreamForBreaker_ShutdownAndClientHangupRecordNothing(t *testing.T) {
+	for name, st := range map[string]*streamState{
+		"gateway restarting": {interrupted: true},
+		"client hung up":     {clientDisconnected: true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			logData := &requestLogData{errorKind: KindProviderError}
+			v := judgeStreamForBreaker(st, logData, "stream interrupted", true)
+			if v.failureReason != "" {
+				t.Errorf("charged %q, want no charge", v.failureReason)
+			}
+			if v.success {
+				t.Error("recorded a success, want nothing at all")
+			}
+		})
+	}
+}
+
+// The native Anthropic passthrough never runs observeDataChunk, so sawContent is
+// structurally unreachable there. A truncated native stream that delivered
+// thousands of tokens must not be charged as though it delivered nothing.
+func TestJudgeStreamForBreaker_NativePassthroughCountsDeliveredBytes(t *testing.T) {
+	logData := &requestLogData{errorKind: KindProviderError}
+	truncated := "stream truncated: upstream closed before message_stop"
+
+	delivered := &streamState{deliveredBytes: 3900}
+	if v := judgeStreamForBreaker(delivered, logData, truncated, true); v.failureReason != "" {
+		t.Errorf("charged %q, want no charge: the caller received 3900 bytes", v.failureReason)
+	}
+	empty := &streamState{}
+	if v := judgeStreamForBreaker(empty, logData, truncated, true); v.failureReason == "" {
+		t.Error("a native stream that delivered nothing must be charged")
 	}
 }
 
@@ -233,6 +357,8 @@ func TestHandleStreamingResponse_ErrorAfterContentDoesNotChargeTheBreaker(t *tes
 		Body: io.NopCloser(strings.NewReader(
 			"data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"partial answer\"}}]}\n\n" + errorFrameSSE)),
 	}
+	// Threshold 1 here is deliberate and safe: it makes a single stray charge
+	// visible, which is exactly what this negative test is looking for.
 
 	providerID := uuid.New()
 	logData := streamingLog()
@@ -295,12 +421,21 @@ func TestErrorEnvelopeMessage(t *testing.T) {
 		wantOk  bool
 	}{
 		{"provider error", `{"error":{"message":"boom"}}`, "boom", true},
-		{"error with no message", `{"error":{}}`, "provider reported an error with no message", true},
 		{"anthropic error event", `{"type":"error","error":{"type":"overloaded_error","message":"overloaded"}}`, "overloaded", true},
+		// Ollama answers with a bare string. carriesErrorObject has always
+		// counted that as an error; the first version of this check unmarshalled
+		// the frame into a streamChunk, which fails outright on this shape, so a
+		// local Ollama box in a hedged group reproduced the whole incident.
+		{"ollama bare string", `{"error":"model not found"}`, "model not found", true},
+		{"object without a message", `{"error":{"code":500}}`, `{"code":500}`, true},
 		{"ordinary token", `{"choices":[{"delta":{"content":"hi"}}]}`, "", false},
 		{"explicit null error", `{"error":null,"choices":[]}`, "", false},
 		{"unparseable frame", `{not json`, "", false},
-		{"error as a string", `{"error":"boom"}`, "", false},
+		// Empty of every shape leaves a caller nothing to read, so it is not an
+		// error frame — the same judgement carriesErrorObject makes.
+		{"empty error object", `{"error":{}}`, "", false},
+		{"empty error string", `{"error":""}`, "", false},
+		{"empty error list", `{"error":[]}`, "", false},
 		{"json array", `[1,2,3]`, "", false},
 	}
 	for _, tc := range tests {
@@ -316,17 +451,24 @@ func TestErrorEnvelopeMessage(t *testing.T) {
 	}
 }
 
-// The provider's own text reaches the request log through reqError.Underlying,
-// so it goes through the same sanitizer every other upstream body does.
-func TestClassifyProbeError_SanitizesTheProvidersMessage(t *testing.T) {
-	msg := "tenant 793ac38b-0211-43e6-baa7-aa7054c39931 exceeded quota"
-	re, charged := classifyProbeError(&upstreamFrameError{msg: msg}, "prov-A", false, time.Second, 30*time.Second, 60*time.Second, 1)
+// The provider's own text reaches request_logs.error_message through
+// reqError.Underlying, where the virtual key's owner can read it. A provider is
+// free to quote the api key back inside its error, so this goes through the same
+// credential masking every other upstream error body does — not just the UUID
+// redaction and the length cap.
+func TestClassifyProbeError_MasksTheProvidersMessage(t *testing.T) {
+	const apiKey = "sk-live-abc123def456ghi789"
+	msg := "invalid api key " + apiKey + " for tenant 793ac38b-0211-43e6-baa7-aa7054c39931"
+	re, charged := classifyProbeError(&upstreamFrameError{msg: msg}, "prov-A", newCredentialMasker(apiKey), false, time.Second, 30*time.Second, 60*time.Second, 1)
 
 	if !charged {
 		t.Error("an error envelope is always the provider's fault and must be charged")
 	}
 	if re.Kind != KindProviderError {
 		t.Errorf("kind = %s, want %s", re.Kind, KindProviderError)
+	}
+	if strings.Contains(re.Underlying, apiKey) {
+		t.Errorf("underlying = %q, still carries the provider credential", re.Underlying)
 	}
 	if strings.Contains(re.Underlying, "793ac38b") {
 		t.Errorf("underlying = %q, want the UUID redacted", re.Underlying)
@@ -337,13 +479,13 @@ func TestClassifyProbeError_SanitizesTheProvidersMessage(t *testing.T) {
 // already answered with a failure, so the charge does not depend on the
 // downstream connection the way a zero-token stall does.
 func TestClassifyProbeError_ChargesEvenWhenTheClientIsGone(t *testing.T) {
-	_, charged := classifyProbeError(&upstreamFrameError{msg: "boom"}, "prov-A", true, time.Millisecond, 30*time.Second, 60*time.Second, 1)
+	_, charged := classifyProbeError(&upstreamFrameError{msg: "boom"}, "prov-A", newCredentialMasker("sk-x"), true, time.Millisecond, 30*time.Second, 60*time.Second, 1)
 	if !charged {
 		t.Error("an error envelope must be charged to the provider even when the client is gone")
 	}
 	// The contrast that makes the case above meaningful: a zero-token stall
 	// with a fast client close is NOT charged.
-	if _, chargedStall := classifyProbeError(errors.New("TTFT timeout"), "prov-A", true, time.Millisecond, 30*time.Second, 60*time.Second, 1); chargedStall {
+	if _, chargedStall := classifyProbeError(errors.New("TTFT timeout"), "prov-A", newCredentialMasker("sk-x"), true, time.Millisecond, 30*time.Second, 60*time.Second, 1); chargedStall {
 		t.Error("a fast client cancel with zero tokens must still not be charged")
 	}
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -368,24 +368,46 @@ func (e *upstreamFrameError) Error() string { return e.msg }
 // is an error envelope instead of a token, and ok == false for every ordinary
 // frame.
 //
-// A frame that does not parse is deliberately NOT an error envelope: the job
-// here is to spot a provider REPORTING a failure, not to validate its JSON, and
-// the streaming path downstream already handles malformed frames. Narrowness
-// matters in this direction — a false positive fails over a healthy stream.
+// Whether the frame IS an error is carriesErrorObject's question, not a second
+// opinion: this package already decided what counts (a populated error member of
+// any shape, including Ollama's bare string; not null/{}/""/[], which leave a
+// caller nothing to read). Answering it twice is how the two drift, and either
+// direction is a bug — a miss lets a broken provider win a hedged race, a false
+// positive fails over a healthy stream.
+//
+// Only the message is extracted here, and the shapes carriesErrorObject accepts
+// are wider than {"error":{"message":...}}, so the fallbacks are not decoration.
 func errorEnvelopeMessage(content string) (msg string, ok bool) {
+	raw := []byte(content)
+	if !carriesErrorObject(raw) {
+		return "", false
+	}
 	var chunk streamChunk
-	if err := json.Unmarshal([]byte(content), &chunk); err != nil {
-		return "", false
+	if err := json.Unmarshal(raw, &chunk); err == nil && chunk.Error != nil && chunk.Error.Message != "" {
+		return chunk.Error.Message, true
 	}
-	if chunk.Error == nil {
-		return "", false
+	// A bare string, a list, a number, or an object without a "message": render
+	// what the provider put there rather than dropping a frame already judged to
+	// be an error. Bounded by the caller's sanitizer.
+	var envelope struct {
+		Error json.RawMessage `json:"error"`
 	}
-	if chunk.Error.Message == "" {
-		// Still an error, just a mute one. Naming it beats handing the caller
-		// and the request log an empty string to explain the failure.
-		return "provider reported an error with no message", true
+	if err := json.Unmarshal(raw, &envelope); err == nil && len(envelope.Error) > 0 {
+		var bare string
+		if json.Unmarshal(envelope.Error, &bare) == nil {
+			return bare, true
+		}
+		return string(envelope.Error), true
 	}
-	return chunk.Error.Message, true
+	return "provider reported an error with no message", true
+}
+
+// safeProviderText prepares provider-authored error text for a log line: the
+// credential shapes masked, UUIDs redacted, length capped. The probe has no
+// credentialMasker of its own (it never saw the api key), so the key-shape pass
+// stands in for the exact-value one the request log gets downstream.
+func safeProviderText(msg string) string {
+	return util.SanitizeLogBody(string(maskKeyShapedTokens([]byte(msg))), 500)
 }
 
 // probeFirstToken reads from body until it finds the first real SSE data chunk
@@ -477,7 +499,7 @@ func (h *Handler) probeFirstToken(
 				// The provider answered, but with its own failure. Counting
 				// this as a first token is what lets a broken provider win a
 				// hedged race against a working one.
-				debuglog.Warn("proxy: TTFT probe saw an error envelope instead of a first token", "error_message", msg)
+				debuglog.Warn("proxy: TTFT probe saw an error envelope instead of a first token", "error_message", safeProviderText(msg))
 				closeProbe()
 				return nil, 0, &upstreamFrameError{msg: msg}
 			}
@@ -520,7 +542,7 @@ func (h *Handler) probeFirstToken(
 						// recovered from the buffer is no more a token than
 						// one read straight off the scanner.
 						if msg, isErr := errorEnvelopeMessage(content); isErr {
-							debuglog.Warn("proxy: TTFT probe recovered an error envelope after scanner error", "error_message", msg, "scan_error", scanErr)
+							debuglog.Warn("proxy: TTFT probe recovered an error envelope after scanner error", "error_message", safeProviderText(msg), "scan_error", scanErr)
 							return nil, 0, &upstreamFrameError{msg: msg}
 						}
 						ttft := float64(time.Since(startTime).Microseconds()) / 1000.0

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -355,14 +355,53 @@ func (h *Handler) runFailoverLoop(w http.ResponseWriter, r *http.Request, st *re
 	h.failAllExhausted(w, st, len(candidates))
 }
 
+// upstreamFrameError reports that the provider's first SSE data frame carried an
+// error envelope rather than a token. It is distinct from every other probe
+// failure because the provider answered: the fault is never the client's, so it
+// is charged to the provider whatever the downstream connection was doing. See
+// classifyProbeError.
+type upstreamFrameError struct{ msg string }
+
+func (e *upstreamFrameError) Error() string { return e.msg }
+
+// errorEnvelopeMessage reports the provider's own message when an SSE data frame
+// is an error envelope instead of a token, and ok == false for every ordinary
+// frame.
+//
+// A frame that does not parse is deliberately NOT an error envelope: the job
+// here is to spot a provider REPORTING a failure, not to validate its JSON, and
+// the streaming path downstream already handles malformed frames. Narrowness
+// matters in this direction — a false positive fails over a healthy stream.
+func errorEnvelopeMessage(content string) (msg string, ok bool) {
+	var chunk streamChunk
+	if err := json.Unmarshal([]byte(content), &chunk); err != nil {
+		return "", false
+	}
+	if chunk.Error == nil {
+		return "", false
+	}
+	if chunk.Error.Message == "" {
+		// Still an error, just a mute one. Naming it beats handing the caller
+		// and the request log an empty string to explain the failure.
+		return "provider reported an error with no message", true
+	}
+	return chunk.Error.Message, true
+}
+
 // probeFirstToken reads from body until it finds the first real SSE data chunk
 // or the timeout fires. It returns a buffer containing all bytes read (for
 // replay via io.MultiReader), the true time-to-first-token in milliseconds,
 // and any error.
 //
 // A "real data chunk" is any "data:" line where the content after "data:" is
-// not "[DONE]". Keepalive comments (":"), empty lines, "event:", "id:", and
-// "retry:" directives are skipped but still captured in probeBuf for replay.
+// neither "[DONE]" nor an error envelope. Keepalive comments (":"), empty lines,
+// "event:", "id:", and "retry:" directives are skipped but still captured in
+// probeBuf for replay.
+//
+// The error-envelope case exists because this probe picks the winner of a hedged
+// race. Treating a provider's error frame as a first token means the fastest
+// FAILURE wins: the broken candidate is committed to, every healthy rival still
+// in flight is cancelled as superseded, and the request has no second chance.
 func (h *Handler) probeFirstToken(
 	ctx context.Context,
 	body io.ReadCloser,
@@ -434,6 +473,14 @@ func (h *Handler) probeFirstToken(
 				closeProbe()
 				return &buf, 0, nil
 			}
+			if msg, isErr := errorEnvelopeMessage(content); isErr {
+				// The provider answered, but with its own failure. Counting
+				// this as a first token is what lets a broken provider win a
+				// hedged race against a working one.
+				debuglog.Warn("proxy: TTFT probe saw an error envelope instead of a first token", "error_message", msg)
+				closeProbe()
+				return nil, 0, &upstreamFrameError{msg: msg}
+			}
 			// First real data chunk found.
 			ttft := float64(time.Since(startTime).Microseconds()) / 1000.0
 			debuglog.Info("proxy: TTFT probe found first token", "ttft_ms", ttft)
@@ -469,6 +516,13 @@ func (h *Handler) probeFirstToken(
 					}
 					content := strings.TrimSpace(strings.TrimPrefix(l, "data:"))
 					if content != "[DONE]" {
+						// Same envelope check as the main loop: a frame
+						// recovered from the buffer is no more a token than
+						// one read straight off the scanner.
+						if msg, isErr := errorEnvelopeMessage(content); isErr {
+							debuglog.Warn("proxy: TTFT probe recovered an error envelope after scanner error", "error_message", msg, "scan_error", scanErr)
+							return nil, 0, &upstreamFrameError{msg: msg}
+						}
 						ttft := float64(time.Since(startTime).Microseconds()) / 1000.0
 						debuglog.Info("proxy: TTFT probe recovered data after scanner error", "ttft_ms", ttft, "scan_error", scanErr)
 						return &buf, ttft, nil

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -402,14 +402,6 @@ func errorEnvelopeMessage(content string) (msg string, ok bool) {
 	return "provider reported an error with no message", true
 }
 
-// safeProviderText prepares provider-authored error text for a log line: the
-// credential shapes masked, UUIDs redacted, length capped. The probe has no
-// credentialMasker of its own (it never saw the api key), so the key-shape pass
-// stands in for the exact-value one the request log gets downstream.
-func safeProviderText(msg string) string {
-	return util.SanitizeLogBody(string(maskKeyShapedTokens([]byte(msg))), 500)
-}
-
 // probeFirstToken reads from body until it finds the first real SSE data chunk
 // or the timeout fires. It returns a buffer containing all bytes read (for
 // replay via io.MultiReader), the true time-to-first-token in milliseconds,
@@ -499,7 +491,13 @@ func (h *Handler) probeFirstToken(
 				// The provider answered, but with its own failure. Counting
 				// this as a first token is what lets a broken provider win a
 				// hedged race against a working one.
-				debuglog.Warn("proxy: TTFT probe saw an error envelope instead of a first token", "error_message", safeProviderText(msg))
+				// The provider's own text is NOT logged here. This function never
+				// saw the api key, so it cannot mask it, and a provider is free
+				// to quote the credential back inside its error. Key-SHAPE
+				// masking is not enough — it only catches tokens that look like
+				// keys, and an operator's key need not. Both callers log the
+				// message one line later, exact-masked by classifyProbeError.
+				debuglog.Warn("proxy: TTFT probe saw an error envelope instead of a first token", "message_bytes", len(msg))
 				closeProbe()
 				return nil, 0, &upstreamFrameError{msg: msg}
 			}
@@ -542,7 +540,8 @@ func (h *Handler) probeFirstToken(
 						// recovered from the buffer is no more a token than
 						// one read straight off the scanner.
 						if msg, isErr := errorEnvelopeMessage(content); isErr {
-							debuglog.Warn("proxy: TTFT probe recovered an error envelope after scanner error", "error_message", safeProviderText(msg), "scan_error", scanErr)
+							// Text withheld for the same reason as above.
+							debuglog.Warn("proxy: TTFT probe recovered an error envelope after scanner error", "message_bytes", len(msg), "scan_error", scanErr)
 							return nil, 0, &upstreamFrameError{msg: msg}
 						}
 						ttft := float64(time.Since(startTime).Microseconds()) / 1000.0

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -356,7 +356,11 @@ func (h *Handler) dispatchStreaming(w http.ResponseWriter, r *http.Request, st *
 			st.setReqErr(re)
 			logData.failoverAttempt = attempt
 			logData.responseHeaderMs = responseHeaderMs
-			debuglog.Warn("proxy: TTFT probe failed", "attempt", attempt+1, "provider", candidate.provider.Name, "client_gone", clientGone, "elapsed", elapsed, "provider_stalled", recordFailure, "error", probeErr)
+			// "kind", not "provider_stalled": a probe can now fail because the
+			// provider reported its own error rather than because it went
+			// silent, and calling that a stall sends the operator hunting the
+			// wrong thing. charged says what the breaker was told either way.
+			debuglog.Warn("proxy: TTFT probe failed", "attempt", attempt+1, "provider", candidate.provider.Name, "client_gone", clientGone, "elapsed", elapsed, "kind", string(re.Kind), "charged", recordFailure, "error", probeErr)
 			return outcomeFailover
 		}
 		// First token confirmed (or [DONE] received). No breaker success is

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -265,6 +265,27 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 // provider was stalling, the error carries a hint that an upstream reverse proxy,
 // load balancer, or CDN idle-read timeout is the likely cause (Model Hotel sends
 // nothing downstream during the probe, so a silent connection looks idle).
+// classifyProbeError maps any TTFT probe failure to the error recorded for the
+// attempt and whether the provider is charged for it. It is the single entry
+// point both the sequential and the hedged path use, so the two cannot drift.
+//
+// An error envelope in the first frame is split out from the zero-token cases
+// below: the provider did answer, so this is its failure and never the client's,
+// and it is charged whatever the downstream connection was doing. The message is
+// sanitized because it is the provider's text, not ours.
+func classifyProbeError(probeErr error, providerName string, clientGone bool, elapsed, stallTimeout, ttftTimeout time.Duration, attempt int) (re reqError, recordFailure bool) {
+	var frameErr *upstreamFrameError
+	if errors.As(probeErr, &frameErr) {
+		return reqError{
+			Kind:       KindProviderError,
+			Attempt:    attempt,
+			Provider:   providerName,
+			Underlying: util.SanitizeLogBody(frameErr.msg, 500),
+		}, true
+	}
+	return classifyProbeFailure(providerName, errString(probeErr), clientGone, elapsed, stallTimeout, ttftTimeout, attempt)
+}
+
 func classifyProbeFailure(providerName, underlying string, clientGone bool, elapsed, stallTimeout, ttftTimeout time.Duration, attempt int) (re reqError, recordFailure bool) {
 	if clientGone && elapsed < stallTimeout {
 		// Fast downstream close with zero tokens: a genuine client cancel.
@@ -324,7 +345,7 @@ func (h *Handler) dispatchStreaming(w http.ResponseWriter, r *http.Request, st *
 			// fast client cancel that must not penalize the provider.
 			clientGone := r.Context().Err() != nil
 			elapsed := time.Since(st.startTime)
-			re, recordFailure := classifyProbeFailure(candidate.provider.Name, errString(probeErr), clientGone, elapsed, stallTimeout, ttftTimeout, attempt)
+			re, recordFailure := classifyProbeError(probeErr, candidate.provider.Name, clientGone, elapsed, stallTimeout, ttftTimeout, attempt)
 			if recordFailure && st.circuitBreakerEnabled {
 				h.circuitBreaker.RecordFailure(candidate.provider.ID, candidate.provider.Name)
 			}

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -271,16 +271,20 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 //
 // An error envelope in the first frame is split out from the zero-token cases
 // below: the provider did answer, so this is its failure and never the client's,
-// and it is charged whatever the downstream connection was doing. The message is
-// sanitized because it is the provider's text, not ours.
-func classifyProbeError(probeErr error, providerName string, clientGone bool, elapsed, stallTimeout, ttftTimeout time.Duration, attempt int) (re reqError, recordFailure bool) {
+// and it is charged whatever the downstream connection was doing.
+func classifyProbeError(probeErr error, providerName string, masker credentialMasker, clientGone bool, elapsed, stallTimeout, ttftTimeout time.Duration, attempt int) (re reqError, recordFailure bool) {
 	var frameErr *upstreamFrameError
 	if errors.As(probeErr, &frameErr) {
+		// This text is durable: on the last candidate it becomes the request
+		// log's error_message, which the virtual key's owner can read. Every
+		// other path that moves provider error text into that row masks the
+		// credential first, and a provider is free to quote the key back inside
+		// its error. Same treatment here.
 		return reqError{
 			Kind:       KindProviderError,
 			Attempt:    attempt,
 			Provider:   providerName,
-			Underlying: util.SanitizeLogBody(frameErr.msg, 500),
+			Underlying: util.SanitizeLogBody(string(masker.mask([]byte(frameErr.msg))), 500),
 		}, true
 	}
 	return classifyProbeFailure(providerName, errString(probeErr), clientGone, elapsed, stallTimeout, ttftTimeout, attempt)
@@ -345,7 +349,7 @@ func (h *Handler) dispatchStreaming(w http.ResponseWriter, r *http.Request, st *
 			// fast client cancel that must not penalize the provider.
 			clientGone := r.Context().Err() != nil
 			elapsed := time.Since(st.startTime)
-			re, recordFailure := classifyProbeError(probeErr, candidate.provider.Name, clientGone, elapsed, stallTimeout, ttftTimeout, attempt)
+			re, recordFailure := classifyProbeError(probeErr, candidate.provider.Name, newCredentialMasker(candidate.apiKey), clientGone, elapsed, stallTimeout, ttftTimeout, attempt)
 			if recordFailure && st.circuitBreakerEnabled {
 				h.circuitBreaker.RecordFailure(candidate.provider.ID, candidate.provider.Name)
 			}
@@ -355,15 +359,13 @@ func (h *Handler) dispatchStreaming(w http.ResponseWriter, r *http.Request, st *
 			debuglog.Warn("proxy: TTFT probe failed", "attempt", attempt+1, "provider", candidate.provider.Name, "client_gone", clientGone, "elapsed", elapsed, "provider_stalled", recordFailure, "error", probeErr)
 			return outcomeFailover
 		}
-		// First token confirmed (or [DONE] received).
-		if st.circuitBreakerEnabled {
-			h.circuitBreaker.RecordSuccess(candidate.provider.ID, candidate.provider.Name)
-		}
+		// First token confirmed (or [DONE] received). No breaker success is
+		// recorded here: a first token is not a served stream, and recording one
+		// zeroes consecutiveFails on every request, which left the finalizer's
+		// own failure charges unable to ever reach the threshold. finalizeStream
+		// owns the verdict for a streaming 200 — see judgeStreamForBreaker.
 		opts.preReadBuf = probeBuf
 		opts.trueTtftMs = trueTtftMs
-	} else if st.circuitBreakerEnabled {
-		// Disabled — immediate commit (backward compat).
-		h.circuitBreaker.RecordSuccess(candidate.provider.ID, candidate.provider.Name)
 	}
 
 	h.handleStreamingResponse(w, r, logData, resp, st.startTime, opts)

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -360,7 +360,7 @@ func (h *Handler) dispatchStreaming(w http.ResponseWriter, r *http.Request, st *
 			// provider reported its own error rather than because it went
 			// silent, and calling that a stall sends the operator hunting the
 			// wrong thing. charged says what the breaker was told either way.
-			debuglog.Warn("proxy: TTFT probe failed", "attempt", attempt+1, "provider", candidate.provider.Name, "client_gone", clientGone, "elapsed", elapsed, "kind", string(re.Kind), "charged", recordFailure, "error", probeErr)
+			debuglog.Warn("proxy: TTFT probe failed", "attempt", attempt+1, "provider", candidate.provider.Name, "client_gone", clientGone, "elapsed", elapsed, "kind", string(re.Kind), "charged", recordFailure, "error", re.Underlying)
 			return outcomeFailover
 		}
 		// First token confirmed (or [DONE] received). No breaker success is

--- a/internal/proxy/stream_finalize.go
+++ b/internal/proxy/stream_finalize.go
@@ -77,38 +77,80 @@ type streamState struct {
 	lastAnthropicEvent     string // P1-C: last "event:" type, consumed by the next data line
 }
 
-// breakerFailureReason reports why a finished stream is charged to the circuit
-// breaker, or "" when it is not. It is the whole charging policy for a stream
-// that reached the response body, in one place.
+// streamBreakerVerdict is what a finished stream tells the circuit breaker about
+// its provider: charge a failure (naming why, for the operator log), credit a
+// success, or say nothing at all.
+type streamBreakerVerdict struct {
+	failureReason string
+	success       bool
+}
+
+// providerAtFault reports whether an error kind is the provider's to answer for.
+// The gateway's own timeouts, its internal cancels and a client hangup are not,
+// and must never darken a provider that was doing nothing wrong.
+func providerAtFault(kind ErrorKind) bool {
+	switch kind {
+	case KindProviderError, KindProviderTimeout, KindProviderModelGone:
+		return true
+	default:
+		return false
+	}
+}
+
+// streamDeliveredOutput reports whether the caller actually received model
+// output. deliveredContent alone is not enough: st.sawContent is set by
+// observeDataChunk, which never runs on the native Anthropic passthrough, so on
+// that path a truncated stream that delivered thousands of tokens would look
+// empty. deliveredBytes is counted on both paths and is the honest signal.
+func streamDeliveredOutput(st *streamState, logData *requestLogData) bool {
+	return logData.deliveredContent || st.deliveredBytes > 0 || st.completionTokens > 0
+}
+
+// judgeStreamForBreaker decides what a finished stream tells the circuit
+// breaker. It is the whole policy for a streaming 200, in one place.
 //
-// Two shapes qualify. A stall is the provider going silent; an error is the
-// provider saying it failed. Neither is charged once the caller actually
-// received content: a stream that delivered real output before dying did part
-// of its job, and charging it would break the circuit on every
-// truncated-but-useful response.
+// Why the verdict lives HERE rather than at the TTFT probe: recordBreakerOutcome
+// deliberately says nothing for a streaming 200, so the probe was the only voice
+// these requests had — and it spoke too early. A first token is not a served
+// stream. Recording success there zeroed consecutiveFails on every single
+// request, so a provider that failed AFTER the first token oscillated 0→1 against
+// a threshold of 5 and could never open its circuit. Both charges below were
+// therefore inert in production. Move a success back to the probe and they go
+// inert again.
 //
-// The error case matters because the TTFT probe has already committed to this
+// Failure has two shapes. A stall is the provider going silent; an error is the
+// provider saying it failed. The stall charge is unconditional (as it has always
+// been), but an error is only charged when the caller received nothing: a stream
+// that delivered real output before dying did part of its job, and charging it
+// would break the circuit on every truncated-but-useful response.
+//
+// The error charge matters because the probe has already committed to this
 // provider by the time a later frame turns out to be an error, and the hedged
-// rivals were cancelled when it did (see probeFirstToken, which keeps an error
-// in the FIRST frame from ever winning that race). The breaker is then the only
-// thing left that can keep the next request away.
-//
-// A shutdown or a client hang-up is never the provider's fault, so both drop out
-// before either shape is considered.
-func breakerFailureReason(st *streamState, logData *requestLogData, errMsg string, circuitBreakerOn bool) string {
+// rivals were cancelled when it did (probeFirstToken keeps an error in the FIRST
+// frame from ever winning that race). The breaker is then the only thing left
+// that can keep the next request away.
+func judgeStreamForBreaker(st *streamState, logData *requestLogData, errMsg string, circuitBreakerOn bool) streamBreakerVerdict {
 	if !circuitBreakerOn || st.interrupted || st.clientDisconnected {
-		return ""
+		return streamBreakerVerdict{}
+	}
+	if errMsg == "" {
+		// Includes the stream whose absent [DONE] was injected above: the
+		// sentinel was missing, the answer was not.
+		return streamBreakerVerdict{success: true}
+	}
+	if !providerAtFault(logData.errorKind) {
+		return streamBreakerVerdict{}
 	}
 	// !sawDone/!sawMessageStop avoids penalising a provider whose stream
 	// completed normally but whose stall timer fired concurrently with the
 	// terminal frame.
 	if st.stalled && !st.sawDone && !st.sawMessageStop {
-		return "stream stalled"
+		return streamBreakerVerdict{failureReason: "stream stalled"}
 	}
-	if errMsg != "" && !logData.deliveredContent && st.completionTokens == 0 {
-		return "stream failed without delivering content"
+	if !streamDeliveredOutput(st, logData) {
+		return streamBreakerVerdict{failureReason: "stream failed without delivering content"}
 	}
-	return ""
+	return streamBreakerVerdict{}
 }
 
 // finalizeStream performs the end-of-stream bookkeeping that used to live under
@@ -211,12 +253,14 @@ func (h *Handler) finalizeStream(st *streamState, sink *streamSink, scanErr erro
 	}
 	h.updateRequestLog(logData)
 
-	// deriveStreamError already warns about the stall or the error itself; this
-	// line records that the breaker was CHARGED for it, which those do not say
-	// and which is otherwise invisible above Debug.
-	if reason := breakerFailureReason(st, logData, errMsg, opts.circuitBreakerOn); reason != "" {
-		debuglog.Warn("proxy: recording circuit breaker failure", "reason", reason, "provider", opts.providerName, "provider_id", opts.providerID, "model", logData.modelID, "attempt", opts.attempt, "chunks", st.chunkCount, "error_chunks", st.errorChunkCount, "duration_ms", totalDuration)
+	// deriveStreamError already warns about the stall or the error itself; the
+	// line below records that the breaker was CHARGED for it, which those do not
+	// say and which is otherwise invisible above Debug.
+	if verdict := judgeStreamForBreaker(st, logData, errMsg, opts.circuitBreakerOn); verdict.failureReason != "" {
+		debuglog.Warn("proxy: recording circuit breaker failure", "reason", verdict.failureReason, "provider", opts.providerName, "provider_id", opts.providerID, "model", logData.modelID, "attempt", opts.attempt, "chunks", st.chunkCount, "error_chunks", st.errorChunkCount, "duration_ms", totalDuration)
 		h.circuitBreaker.RecordFailure(opts.providerID, opts.providerName)
+	} else if verdict.success {
+		h.circuitBreaker.RecordSuccess(opts.providerID, opts.providerName)
 	}
 
 	debuglog.Info("proxy: streaming finished", "model", logData.modelID, "provider", logData.providerName, "attempt", opts.attempt, "response_header_ms", opts.responseHeaderMs, "true_ttft_ms", opts.trueTtftMs, "duration_ms", totalDuration, "chunks", st.chunkCount, "bytes_written", sink.bytesWritten, "prompt_tokens", st.promptTokens, "completion_tokens", st.completionTokens, "error_chunks", st.errorChunkCount, "has_error", errMsg != "")

--- a/internal/proxy/stream_finalize.go
+++ b/internal/proxy/stream_finalize.go
@@ -77,6 +77,40 @@ type streamState struct {
 	lastAnthropicEvent     string // P1-C: last "event:" type, consumed by the next data line
 }
 
+// breakerFailureReason reports why a finished stream is charged to the circuit
+// breaker, or "" when it is not. It is the whole charging policy for a stream
+// that reached the response body, in one place.
+//
+// Two shapes qualify. A stall is the provider going silent; an error is the
+// provider saying it failed. Neither is charged once the caller actually
+// received content: a stream that delivered real output before dying did part
+// of its job, and charging it would break the circuit on every
+// truncated-but-useful response.
+//
+// The error case matters because the TTFT probe has already committed to this
+// provider by the time a later frame turns out to be an error, and the hedged
+// rivals were cancelled when it did (see probeFirstToken, which keeps an error
+// in the FIRST frame from ever winning that race). The breaker is then the only
+// thing left that can keep the next request away.
+//
+// A shutdown or a client hang-up is never the provider's fault, so both drop out
+// before either shape is considered.
+func breakerFailureReason(st *streamState, logData *requestLogData, errMsg string, circuitBreakerOn bool) string {
+	if !circuitBreakerOn || st.interrupted || st.clientDisconnected {
+		return ""
+	}
+	// !sawDone/!sawMessageStop avoids penalising a provider whose stream
+	// completed normally but whose stall timer fired concurrently with the
+	// terminal frame.
+	if st.stalled && !st.sawDone && !st.sawMessageStop {
+		return "stream stalled"
+	}
+	if errMsg != "" && !logData.deliveredContent && st.completionTokens == 0 {
+		return "stream failed without delivering content"
+	}
+	return ""
+}
+
 // finalizeStream performs the end-of-stream bookkeeping that used to live under
 // the handleStreamingResponse `logUpdate:` label: TPS computation, scanner-error
 // and stall classification, missing-[DONE] injection vs "truncated", the final
@@ -177,14 +211,11 @@ func (h *Handler) finalizeStream(st *streamState, sink *streamSink, scanErr erro
 	}
 	h.updateRequestLog(logData)
 
-	// Record circuit breaker failure for stream stalls.
-	// Guard with !sawDone to avoid penalising a provider whose stream completed
-	// normally but whose stall timer fired concurrently with [DONE].
-	if st.stalled && !st.interrupted && !st.sawDone && !st.sawMessageStop && !st.clientDisconnected && opts.circuitBreakerOn {
-		// deriveStreamError already warns that the stream stalled; this records
-		// that the breaker was charged for it, which the stall line does not say
-		// and which is otherwise invisible above Debug.
-		debuglog.Warn("proxy: recording circuit breaker failure", "reason", "stream stalled", "provider", opts.providerName, "provider_id", opts.providerID, "model", logData.modelID, "attempt", opts.attempt, "chunks", st.chunkCount, "duration_ms", totalDuration)
+	// deriveStreamError already warns about the stall or the error itself; this
+	// line records that the breaker was CHARGED for it, which those do not say
+	// and which is otherwise invisible above Debug.
+	if reason := breakerFailureReason(st, logData, errMsg, opts.circuitBreakerOn); reason != "" {
+		debuglog.Warn("proxy: recording circuit breaker failure", "reason", reason, "provider", opts.providerName, "provider_id", opts.providerID, "model", logData.modelID, "attempt", opts.attempt, "chunks", st.chunkCount, "error_chunks", st.errorChunkCount, "duration_ms", totalDuration)
 		h.circuitBreaker.RecordFailure(opts.providerID, opts.providerName)
 	}
 


### PR DESCRIPTION
## The incident

On 2026-08-28, Neuralwatt started answering `hotel/glm52` with HTTP 200 followed by a single SSE frame:

```
data: {"error":{"message":"Unterminated string starting at: line 1 column 9777 (char 9776)"}}
```

**36 consecutive requests died over 13 minutes.** Each one looked like this:

```
TTFT probe found first token            ttft_ms=9364
hedge winner provider=Neuralwatt        attempt=1
context cancelled ... Z.ai Coding Plan  origin=hedge_superseded
SSE error chunk ...                     chunk_number=1
streaming finished  chunks=3  bytes_written=171  completion_tokens=0
```

The probe counted the error frame as a first token, so the hedge crowned the broken provider and **cancelled the healthy Z.ai attempt that was still in flight**. The race rewarded the fastest *failure*: an instant error beat a real answer one second slower.

## What changes

**`probeFirstToken` no longer counts an error envelope as a token.** The candidate loses the race and a healthy rival wins. Both probe call sites — sequential and hedged — go through a new `classifyProbeError`, which records `provider_error` and always charges the breaker: the provider answered, so the fault is never the client's, unlike the zero-token stall it sits beside.

**The streaming breaker verdict moves from the probe to the finalizer.** Review of the first commit found the breaker half inert in production, and the pre-existing stall charge inert for the same reason. `recordBreakerOutcome` deliberately says nothing for a streaming 200, so the probe was the only voice these requests had with the breaker — and it spoke too early. A first token is not a served stream. `RecordSuccess` there zeroed `consecutiveFails` on every request, so a provider failing *after* the first token oscillated 0→1 against a threshold of 5 and could never open its circuit. `judgeStreamForBreaker` now records a failure, a success, or nothing, from how the stream actually ended.

Also from that review:

- Only a provider-attributable error kind is charged. The gateway's own param-strip retry budget, its failover deadline and its internal cancels all reach the finalizer as a non-empty `errMsg`, and none is the provider's fault.
- Delivered output is measured with `deliveredBytes` as well as `deliveredContent`. `st.sawContent` is set by `observeDataChunk`, which never runs on the native Anthropic passthrough, so a truncated native stream that delivered thousands of tokens looked empty and was charged.
- `errorEnvelopeMessage` asks the existing `carriesErrorObject` whether a frame is an error rather than answering it a second way and disagreeing in both directions. It had missed Ollama's bare `{"error":"model not found"}` entirely — a local Ollama box in a hedged group reproduced the whole incident unfixed — and flagged an empty `{"error":{}}` boilerplate member sitting alongside a real token.
- The provider's message is credential-masked, not just UUID-redacted and capped, before it reaches `reqError.Underlying` and the request log the virtual key's owner can read. A provider is free to quote the key back inside its own error.

## Verification

Live against the dev stack, with a fake upstream reproducing the incident frame byte for byte:

```
req1=502 req2=502 req3=502 req4=502 req5=502 req6=502
circuit-breaker: provider state=closed→open provider=incident-repro
                 consecutive_failures=5 cooldown_ms=60000
```

502 instead of streaming an error frame back as a 200, `error_kind=provider_error` in the request log, and the circuit opening after exactly five failures at the production default threshold.

Every fix is mutation-tested. The one that matters most: putting `RecordSuccess` back on the probe fails `TestDispatchStreaming_ErrorAfterTheFirstFrameOpensTheCircuit` with `circuit = closed after 5 committed-then-failed streams`. That test is deliberately driven through `dispatchStreaming` rather than `handleStreamingResponse`, and at the default threshold of 5 rather than 1 — an earlier version did neither and passed with the bug fully restored.

Diff coverage 92.8%.

## Two related things deliberately left alone

**A `[DONE]`-first frame still wins the race.** A provider answering 200 + an immediate `data: [DONE]` wins by the same mechanism and hands the caller an empty completion. Failing the probe there would turn a legitimate empty completion into an exhausted-providers error for a single-provider group, so it wants a decision rather than a reflex.

**`ttft_timeout: 0` turns the guard off.** With the probe disabled a 200 is an immediate win on headers alone, and the incident reproduces. The default is 60s, so it is latent, but the setting silently disables this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
