### PR TITLE
fix(proxy): a completely empty response counts against the provider

### DIFF
--- a/internal/proxy/probe_error_frame_test.go
+++ b/internal/proxy/probe_error_frame_test.go
@@ -916,10 +916,13 @@ func TestJudgeStreamForBreaker_DeliveredStreamsStillSucceed(t *testing.T) {
 		st      *streamState
 		logData *requestLogData
 	}{
-		"content seen":       {&streamState{sawDone: true, sawContent: true}, &requestLogData{}},
-		"bytes delivered":    {&streamState{sawDone: true, deliveredBytes: 42}, &requestLogData{}},
-		"usage reported":     {&streamState{sawDone: true, completionTokens: 7}, &requestLogData{}},
-		"anthropic finished": {&streamState{sawMessageStop: true}, &requestLogData{deliveredContent: true}},
+		"content seen":    {&streamState{sawDone: true, sawContent: true}, &requestLogData{}},
+		"bytes delivered": {&streamState{sawDone: true, deliveredBytes: 42}, &requestLogData{}},
+		"usage reported":  {&streamState{sawDone: true, completionTokens: 7}, &requestLogData{}},
+		// The native Anthropic path never runs observeDataChunk, so sawContent
+		// is unreachable there; deliveredBytes (from the event's TextBytes) is
+		// what proves it answered.
+		"anthropic delivered": {&streamState{sawMessageStop: true, deliveredBytes: 120}, &requestLogData{deliveredContent: true}},
 	} {
 		t.Run(name, func(t *testing.T) {
 			v := judgeStreamForBreaker(tc.st, tc.logData, "", true)
@@ -1073,5 +1076,115 @@ func TestHandleStreamingResponse_FramesWithNoOutputAreCharged(t *testing.T) {
 
 	if got := h.circuitBreaker.GetState(providerID); got != failover.StateOpen {
 		t.Errorf("circuit = %s, want open: the caller received nothing", got)
+	}
+}
+
+// message_stop is a TERMINATION signal, not a delivery one: it is present on
+// every native stream that ends cleanly, including one that ended having
+// produced nothing. Treating it as delivery let a completely empty
+// /v1/messages response escape the charge entirely.
+func TestJudgeStreamForBreaker_EmptyNativeStreamIsCharged(t *testing.T) {
+	st := &streamState{sawMessageStop: true}
+	// What finalizeStream derives for the retirement verdict, where
+	// message_stop IS allowed to stand in for "the model answered". The breaker
+	// verdict must not inherit that.
+	logData := &requestLogData{deliveredContent: true}
+
+	v := judgeStreamForBreaker(st, logData, "", true)
+	if v.failureReason == "" {
+		t.Error("a native stream that terminated having delivered nothing must be charged")
+	}
+	if v.success {
+		t.Error("message_stop alone must not be recorded as a success")
+	}
+}
+
+// A frame this gateway could not parse is not evidence the provider sent
+// nothing — it may have answered in a shape our types do not cover (tool-call
+// arguments as an object, content as an array of parts). The contents are
+// unknown, so the verdict is neither a charge nor a credit.
+func TestJudgeStreamForBreaker_UnparseableFramesWithholdTheVerdict(t *testing.T) {
+	st := &streamState{sawDone: true, unparsedChunks: 1}
+	v := judgeStreamForBreaker(st, &requestLogData{}, "", true)
+	if v.failureReason != "" {
+		t.Errorf("charged %q: emptiness cannot be pinned on the provider when our own parser dropped a frame", v.failureReason)
+	}
+	if v.success {
+		t.Error("an unreadable stream is not evidence of health either")
+	}
+}
+
+// The reasoning spellings the observers never saw. normalizeReasoningChunk
+// rewrites "reasoning" and "reasoning_details" into reasoning_content for the
+// client, but it runs AFTER the observers — so the caller received a real
+// answer while the accounting saw nothing, and the provider was charged for it.
+func TestHandleStreamingResponse_ReasoningSpellingsAreDelivery(t *testing.T) {
+	for name, body := range map[string]string{
+		"reasoning_content": "data: {\"choices\":[{\"index\":0,\"delta\":{\"reasoning_content\":\"thinking\"}}]}\n\ndata: [DONE]\n\n",
+		"reasoning":         "data: {\"choices\":[{\"index\":0,\"delta\":{\"reasoning\":\"thinking hard\"}}]}\n\ndata: [DONE]\n\n",
+		"reasoning_details": "data: {\"choices\":[{\"index\":0,\"delta\":{\"reasoning_details\":[{\"type\":\"reasoning.text\",\"text\":\"thinking\"}]}}]}\n\ndata: [DONE]\n\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			h := newIntegrationHandler()
+			defer stopUnitHandlerIntegration(h)
+			withBreakerThresholdOne(t, h)
+
+			providerID := uuid.New()
+			logData := streamingLog()
+			logData.providerName = "reasoning-provider"
+			h.insertRequestLogAsync(logData)
+
+			resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body))}
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)
+			h.handleStreamingResponse(w, req, logData, resp, time.Now(), streamOptions{
+				responseHeaderMs: 10,
+				providerID:       providerID,
+				providerName:     "reasoning-provider",
+				circuitBreakerOn: true,
+				vkHash:           "test-hash",
+				attempt:          1,
+			})
+
+			if got := h.circuitBreaker.GetState(providerID); got == failover.StateOpen {
+				t.Errorf("a reasoning answer spelled %q is output and must not break the circuit", name)
+			}
+		})
+	}
+}
+
+// A chunk this gateway's types cannot represent: the provider answered, we
+// dropped the frame, and the provider must not be charged for our parser.
+func TestHandleStreamingResponse_UnparseableChunkDoesNotCharge(t *testing.T) {
+	for name, body := range map[string]string{
+		"tool arguments as an object": "data: {\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"function\":{\"name\":\"f\",\"arguments\":{\"city\":\"Prague\"}}}]}}]}\n\ndata: [DONE]\n\n",
+		"content as parts":            "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":[{\"type\":\"text\",\"text\":\"hello\"}]}}]}\n\ndata: [DONE]\n\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			h := newIntegrationHandler()
+			defer stopUnitHandlerIntegration(h)
+			withBreakerThresholdOne(t, h)
+
+			providerID := uuid.New()
+			logData := streamingLog()
+			logData.providerName = "wide-shape-provider"
+			h.insertRequestLogAsync(logData)
+
+			resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body))}
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)
+			h.handleStreamingResponse(w, req, logData, resp, time.Now(), streamOptions{
+				responseHeaderMs: 10,
+				providerID:       providerID,
+				providerName:     "wide-shape-provider",
+				circuitBreakerOn: true,
+				vkHash:           "test-hash",
+				attempt:          1,
+			})
+
+			if got := h.circuitBreaker.GetState(providerID); got == failover.StateOpen {
+				t.Error("a frame our own parser dropped must not be charged to the provider")
+			}
+		})
 	}
 }

--- a/internal/proxy/probe_error_frame_test.go
+++ b/internal/proxy/probe_error_frame_test.go
@@ -989,3 +989,89 @@ func TestDispatchStreaming_EmptyStreamsOpenTheCircuit(t *testing.T) {
 		t.Errorf("circuit = %s after %d empty streams, want open", got, attempts)
 	}
 }
+
+// A tool call IS output. A completion whose only product is a function call has
+// answered — that is the whole point of tool use — and must never be charged as
+// an empty response, or a provider answering correctly would be taken out of
+// rotation for every tenant after five such requests.
+//
+// Driven through the real streaming pipeline rather than a hand-built
+// streamState, because the thing under test is whether the pipeline's own
+// accounting (observeDataChunk -> deliveredBytes) registers tool calls at all.
+func TestHandleStreamingResponse_ToolCallOnlyIsNotAnEmptyResponse(t *testing.T) {
+	streams := map[string]string{
+		// Tool calls arrive incrementally: the name in one chunk, argument
+		// fragments after it. No content delta appears anywhere.
+		"tool call in fragments": "data: {\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"tool_calls\":[{\"function\":{\"name\":\"get_weather\",\"arguments\":\"\"}}]}}]}\n\n" +
+			"data: {\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"function\":{\"arguments\":\"{\\\"city\\\":\"}}]}}]}\n\n" +
+			"data: {\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"function\":{\"arguments\":\"\\\"Prague\\\"}\"}}]}}]}\n\n" +
+			"data: {\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"tool_calls\"}]}\n\ndata: [DONE]\n\n",
+		// Reasoning with no visible content is output too.
+		"reasoning only": "data: {\"choices\":[{\"index\":0,\"delta\":{\"reasoning_content\":\"thinking about it\"}}]}\n\ndata: [DONE]\n\n",
+	}
+	for name, body := range streams {
+		t.Run(name, func(t *testing.T) {
+			h := newIntegrationHandler()
+			defer stopUnitHandlerIntegration(h)
+			withBreakerThresholdOne(t, h)
+
+			providerID := uuid.New()
+			logData := streamingLog()
+			logData.providerName = "tool-provider"
+			h.insertRequestLogAsync(logData)
+
+			resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body))}
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)
+			h.handleStreamingResponse(w, req, logData, resp, time.Now(), streamOptions{
+				responseHeaderMs: 10,
+				providerID:       providerID,
+				providerName:     "tool-provider",
+				circuitBreakerOn: true,
+				vkHash:           "test-hash",
+				attempt:          1,
+			})
+
+			if logData.state != "completed" {
+				t.Errorf("state = %q, want completed", logData.state)
+			}
+			// Threshold is 1, so a single stray charge shows immediately.
+			if got := h.circuitBreaker.GetState(providerID); got == failover.StateOpen {
+				t.Error("a completion whose only output is a tool call or reasoning is not empty and must not break the circuit")
+			}
+		})
+	}
+}
+
+// The counterpart: a stream carrying frames that deliver nothing at all really
+// is empty, and is charged. Without this the guard above could be satisfied by
+// simply never charging.
+func TestHandleStreamingResponse_FramesWithNoOutputAreCharged(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandlerIntegration(h)
+	withBreakerThresholdOne(t, h)
+
+	providerID := uuid.New()
+	logData := streamingLog()
+	logData.providerName = "silent-provider"
+	h.insertRequestLogAsync(logData)
+
+	// A role delta and a finish reason: well-formed frames, zero output.
+	body := "data: {\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\"}}]}\n\n" +
+		"data: {\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n"
+	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body))}
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)
+	h.handleStreamingResponse(w, req, logData, resp, time.Now(), streamOptions{
+		responseHeaderMs: 10,
+		providerID:       providerID,
+		providerName:     "silent-provider",
+		circuitBreakerOn: true,
+		vkHash:           "test-hash",
+		attempt:          1,
+	})
+
+	if got := h.circuitBreaker.GetState(providerID); got != failover.StateOpen {
+		t.Errorf("circuit = %s, want open: the caller received nothing", got)
+	}
+}

--- a/internal/proxy/probe_error_frame_test.go
+++ b/internal/proxy/probe_error_frame_test.go
@@ -653,11 +653,9 @@ func TestRunHedgedStreaming_HealthyCandidateBeatsAFasterEmptyStream(t *testing.T
 	}
 }
 
-// An empty stream loses the race exactly as an error frame does, but is NOT
-// charged to the breaker. Whether a model emits anything depends on the prompt,
-// which the caller controls, so charging it would let one virtual key blackhole
-// a healthy provider for every tenant.
-func TestProbeStreamingCandidate_EmptyStreamLosesButIsNotCharged(t *testing.T) {
+// An empty stream loses the race exactly as an error frame does, and is charged
+// exactly as one too: a zero-token answer is not a valid answer.
+func TestProbeStreamingCandidate_EmptyStreamLosesAndIsCharged(t *testing.T) {
 	h := newIntegrationHandler()
 	defer stopUnitHandler(h)
 	withBreakerThresholdOne(t, h)
@@ -682,9 +680,9 @@ func TestProbeStreamingCandidate_EmptyStreamLosesButIsNotCharged(t *testing.T) {
 	if res.reqErr.Kind != KindProviderError {
 		t.Errorf("kind = %s, want %s", res.reqErr.Kind, KindProviderError)
 	}
-	// Threshold is 1 here, so a single charge would show immediately.
-	if got := h.circuitBreaker.GetState(cand.provider.ID); got == failover.StateOpen {
-		t.Error("an empty stream must not break the circuit: the prompt, not the provider, decides whether a model emits anything")
+	// Threshold is 1 here, so a single charge shows immediately.
+	if got := h.circuitBreaker.GetState(cand.provider.ID); got != failover.StateOpen {
+		t.Errorf("circuit = %s, want open: a provider that produced nothing is charged", got)
 	}
 }
 
@@ -865,4 +863,129 @@ func TestRecoverFirstToken(t *testing.T) {
 			})
 		}
 	})
+}
+
+// ---------------------------------------------------------------------------
+// A completely empty response counts against the provider. A zero-token answer
+// is not a valid one in almost any real use, and a caller deliberately coercing
+// a model into silence is not a case worth protecting a provider from. Decided
+// 2026-08-28, reversing the narrower call made when the empty-stream guard
+// first shipped.
+//
+// Two paths produce a completely empty response and both charge:
+//   - the stream never produced a chunk at all (caught by the probe)
+//   - the stream produced frames but delivered no output (caught by the
+//     finalizer, after the provider was already committed to)
+// ---------------------------------------------------------------------------
+
+func TestClassifyProbeError_ChargesAnEmptyStream(t *testing.T) {
+	re, charged := classifyProbeError(&emptyStreamError{}, "prov-A", newCredentialMasker("sk-x"), false, time.Second, 30*time.Second, 60*time.Second, 1)
+	if !charged {
+		t.Error("a stream that produced nothing must be charged to the provider")
+	}
+	if re.Kind != KindProviderError {
+		t.Errorf("kind = %s, want %s", re.Kind, KindProviderError)
+	}
+	// A client hanging up cannot excuse it either: the provider had already
+	// finished saying nothing.
+	if _, chargedGone := classifyProbeError(&emptyStreamError{}, "prov-A", newCredentialMasker("sk-x"), true, time.Millisecond, 30*time.Second, 60*time.Second, 1); !chargedGone {
+		t.Error("an empty stream must be charged even when the client is gone")
+	}
+}
+
+// The finalizer half: a stream that got past the probe, completed cleanly, and
+// still handed the caller nothing. Previously recorded as a SUCCESS, which
+// actively cleared any accumulated failures for that provider.
+func TestJudgeStreamForBreaker_CompletedButEmptyIsCharged(t *testing.T) {
+	st := &streamState{sawDone: true}
+	logData := &requestLogData{}
+	v := judgeStreamForBreaker(st, logData, "", true)
+	if v.failureReason == "" {
+		t.Error("a stream that completed having delivered nothing must be charged")
+	}
+	if v.success {
+		t.Error("an empty stream must not be recorded as a success")
+	}
+}
+
+// The guard that keeps the above from swallowing every ordinary stream: any
+// evidence the caller actually received output means success, and the three
+// signals are checked because no single one is available on every path.
+func TestJudgeStreamForBreaker_DeliveredStreamsStillSucceed(t *testing.T) {
+	for name, tc := range map[string]struct {
+		st      *streamState
+		logData *requestLogData
+	}{
+		"content seen":       {&streamState{sawDone: true, sawContent: true}, &requestLogData{}},
+		"bytes delivered":    {&streamState{sawDone: true, deliveredBytes: 42}, &requestLogData{}},
+		"usage reported":     {&streamState{sawDone: true, completionTokens: 7}, &requestLogData{}},
+		"anthropic finished": {&streamState{sawMessageStop: true}, &requestLogData{deliveredContent: true}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			v := judgeStreamForBreaker(tc.st, tc.logData, "", true)
+			if v.failureReason != "" {
+				t.Errorf("charged %q, want a success", v.failureReason)
+			}
+			if !v.success {
+				t.Error("a stream that delivered output must be recorded as a success")
+			}
+		})
+	}
+}
+
+// A client that hangs up before anything arrives is not the provider's doing,
+// and must not charge it under the new rule either.
+func TestJudgeStreamForBreaker_EmptyOnClientHangupIsNotCharged(t *testing.T) {
+	for name, st := range map[string]*streamState{
+		"client hung up":     {clientDisconnected: true},
+		"gateway restarting": {interrupted: true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			v := judgeStreamForBreaker(st, &requestLogData{}, "", true)
+			if v.failureReason != "" {
+				t.Errorf("charged %q, want no charge", v.failureReason)
+			}
+		})
+	}
+}
+
+// End to end at the production default threshold, through the real probe: five
+// providers-that-say-nothing take the provider out of rotation.
+func TestDispatchStreaming_EmptyStreamsOpenTheCircuit(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandlerIntegration(h)
+
+	providerID := uuid.New()
+	const attempts = 5
+	for i := range attempts {
+		resp := &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(emptyStreamSSE)),
+		}
+		logData := streamingLog()
+		logData.providerName = "empty-provider"
+		h.insertRequestLogAsync(logData)
+
+		st := &requestState{
+			startTime:             time.Now(),
+			reqModel:              "test-model",
+			isStreaming:           true,
+			circuitBreakerEnabled: true,
+			logData:               logData,
+		}
+		cand := modelCandidate{
+			model:    &model.Model{ModelID: "test-model"},
+			provider: &provider.Provider{ID: providerID, Name: "empty-provider"},
+			apiKey:   "sk-test",
+		}
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)
+		if got := h.dispatchStreaming(w, req, st, cand, resp, 1, 10, "failover_timeout"); got != outcomeFailover {
+			t.Fatalf("attempt %d: outcome = %v, want failover", i, got)
+		}
+	}
+
+	if got := h.circuitBreaker.GetState(providerID); got != failover.StateOpen {
+		t.Errorf("circuit = %s after %d empty streams, want open", got, attempts)
+	}
 }

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -275,9 +275,8 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 func classifyProbeError(probeErr error, providerName string, masker credentialMasker, clientGone bool, elapsed, stallTimeout, ttftTimeout time.Duration, attempt int) (re reqError, recordFailure bool) {
 	// The provider answered, but with nothing the caller can use: either it
 	// reported an error, or it ended the stream without a single chunk. Neither
-	// is ever the client's doing, so neither depends on what the downstream
-	// connection was up to — but only the first is CHARGED to the breaker. See
-	// the empty-stream branch for why.
+	// is ever the client's doing, so both are charged whatever the downstream
+	// connection was up to.
 	answered := func(underlying string) (reqError, bool) {
 		return reqError{
 			Kind:       KindProviderError,
@@ -297,23 +296,18 @@ func classifyProbeError(probeErr error, providerName string, masker credentialMa
 	}
 	var emptyErr *emptyStreamError
 	if errors.As(probeErr, &emptyErr) {
-		// Fails over like an error frame, but is NOT charged to the breaker.
+		// Charged, exactly like an error frame. A zero-token answer is not a
+		// valid one in almost any real use, so a provider that keeps producing
+		// them belongs out of rotation.
 		//
-		// The two are not equally the provider's fault. "The provider said
-		// error" is unambiguous. "The provider said nothing" is a function of
-		// the PROMPT, which the caller controls: one virtual key repeatedly
-		// sending something a provider answers with an instant terminator would
-		// otherwise drive its consecutive-fail count to the threshold and take
-		// that provider out of rotation for every tenant. Losing the race costs
-		// the caller one slow request; a charge costs everyone the cooldown.
+		// This was once left uncharged on the reasoning that silence is a
+		// function of the PROMPT, which the caller controls, so one virtual key
+		// could darken a provider for every tenant. That risk is real and
+		// accepted: a caller deliberately coercing a model into saying nothing
+		// is not a case worth keeping a provider in rotation for.
 		//
 		// Gateway-authored text, so nothing to mask.
-		return reqError{
-			Kind:       KindProviderError,
-			Attempt:    attempt,
-			Provider:   providerName,
-			Underlying: emptyErr.Error(),
-		}, false
+		return answered(emptyErr.Error())
 	}
 	return classifyProbeFailure(providerName, errString(probeErr), clientGone, elapsed, stallTimeout, ttftTimeout, attempt)
 }

--- a/internal/proxy/proxy_stream_response.go
+++ b/internal/proxy/proxy_stream_response.go
@@ -427,6 +427,10 @@ func (h *Handler) handleDataChunk(sink *streamSink, st *streamState, ev sseEvent
 				preview = string(runes[:80]) + "..."
 			}
 		}
+		// Counted so the end-of-stream verdict knows its view of what was
+		// delivered is incomplete, and does not charge the provider for an
+		// emptiness it cannot actually vouch for.
+		st.unparsedChunks++
 		debuglog.Warn("proxy: skipping invalid JSON chunk from upstream",
 			"model", logData.modelID, "provider", logData.providerName,
 			"chunk_number", chunkCount, "payload_preview", preview)

--- a/internal/proxy/stream_finalize.go
+++ b/internal/proxy/stream_finalize.go
@@ -98,12 +98,27 @@ func providerAtFault(kind ErrorKind) bool {
 }
 
 // streamDeliveredOutput reports whether the caller actually received model
-// output. deliveredContent alone is not enough: st.sawContent is set by
-// observeDataChunk, which never runs on the native Anthropic passthrough, so on
-// that path a truncated stream that delivered thousands of tokens would look
-// empty. deliveredBytes is counted on both paths and is the honest signal.
+// output. Every available signal is checked, because no single one is present
+// on every path and the cost of missing one is now a charge against a healthy
+// provider rather than merely a charge withheld:
+//
+//   - logData.deliveredContent is the value finalizeStream derives just above,
+//     and is what the retirement verdict reads.
+//   - st.sawContent / st.sawMessageStop are read directly too, so this does not
+//     depend on that assignment having happened first. sawContent is set by
+//     observeDataChunk, which never runs on the native Anthropic passthrough;
+//     sawMessageStop is that path's equivalent.
+//   - st.deliveredBytes is counted on BOTH paths, so it is the one signal that
+//     catches a native stream which delivered thousands of tokens and would
+//     otherwise look empty.
+//   - st.completionTokens covers a provider that reported usage without this
+//     gateway parsing content out of the deltas.
 func streamDeliveredOutput(st *streamState, logData *requestLogData) bool {
-	return logData.deliveredContent || st.deliveredBytes > 0 || st.completionTokens > 0
+	return logData.deliveredContent ||
+		st.sawContent ||
+		st.sawMessageStop ||
+		st.deliveredBytes > 0 ||
+		st.completionTokens > 0
 }
 
 // judgeStreamForBreaker decides what a finished stream tells the circuit
@@ -118,11 +133,13 @@ func streamDeliveredOutput(st *streamState, logData *requestLogData) bool {
 // therefore inert in production. Move a success back to the probe and they go
 // inert again.
 //
-// Failure has two shapes. A stall is the provider going silent; an error is the
-// provider saying it failed. The stall charge is unconditional (as it has always
-// been), but an error is only charged when the caller received nothing: a stream
-// that delivered real output before dying did part of its job, and charging it
-// would break the circuit on every truncated-but-useful response.
+// Failure has three shapes. A stall is the provider going silent; an error is
+// the provider saying it failed; an empty finish is the provider completing
+// having said nothing at all. The stall charge is unconditional (as it has
+// always been); the other two are charged only when the caller received
+// nothing, because a stream that delivered real output before dying did part of
+// its job and charging it would break the circuit on every
+// truncated-but-useful response.
 //
 // The error charge matters because the probe has already committed to this
 // provider by the time a later frame turns out to be an error, and the hedged
@@ -134,6 +151,18 @@ func judgeStreamForBreaker(st *streamState, logData *requestLogData, errMsg stri
 		return streamBreakerVerdict{}
 	}
 	if errMsg == "" {
+		// A clean finish still has to have finished something. A stream that
+		// got past the probe, completed without error and handed the caller
+		// nothing is a completely empty response, and counts against the
+		// provider rather than clearing its failures — which is what recording
+		// a success here used to do.
+		//
+		// The probe catches the stream that never produced a chunk; this is its
+		// sibling, the one that produced frames carrying no output and was
+		// already committed to by the time that became clear.
+		if !streamDeliveredOutput(st, logData) {
+			return streamBreakerVerdict{failureReason: "stream completed without delivering content"}
+		}
 		// Includes the stream whose absent [DONE] was injected above: the
 		// sentinel was missing, the answer was not.
 		return streamBreakerVerdict{success: true}

--- a/internal/proxy/stream_finalize.go
+++ b/internal/proxy/stream_finalize.go
@@ -39,9 +39,16 @@ type streamState struct {
 	promptCacheMissTokens int
 	chunkCount            int
 	errorChunkCount       int
-	lastErrMsg            string
-	sawDone               bool
-	sawMessageStop        bool // native Anthropic passthrough: terminal message_stop event seen
+	// unparsedChunks counts data frames the gateway could not unmarshal into a
+	// streamChunk. They are dropped rather than forwarded, so the caller does
+	// lose them — but the provider may have answered perfectly well in a shape
+	// this gateway's types do not cover (tool-call arguments as an object,
+	// content as an array of parts). The delivery accounting cannot see into
+	// such a frame, so it must not conclude the response was empty.
+	unparsedChunks int
+	lastErrMsg     string
+	sawDone        bool
+	sawMessageStop bool // native Anthropic passthrough: terminal message_stop event seen
 	// sawContent records that at least one non-empty content or reasoning delta
 	// reached the client. It is the only signal that a stream actually answered
 	// which does not depend on optional behaviour: usage chunks are omitted by
@@ -98,27 +105,29 @@ func providerAtFault(kind ErrorKind) bool {
 }
 
 // streamDeliveredOutput reports whether the caller actually received model
-// output. Every available signal is checked, because no single one is present
-// on every path and the cost of missing one is now a charge against a healthy
-// provider rather than merely a charge withheld:
+// output, from the signals that answer that question and only those:
 //
-//   - logData.deliveredContent is the value finalizeStream derives just above,
-//     and is what the retirement verdict reads.
-//   - st.sawContent / st.sawMessageStop are read directly too, so this does not
-//     depend on that assignment having happened first. sawContent is set by
-//     observeDataChunk, which never runs on the native Anthropic passthrough;
-//     sawMessageStop is that path's equivalent.
-//   - st.deliveredBytes is counted on BOTH paths, so it is the one signal that
-//     catches a native stream which delivered thousands of tokens and would
-//     otherwise look empty.
-//   - st.completionTokens covers a provider that reported usage without this
-//     gateway parsing content out of the deltas.
-func streamDeliveredOutput(st *streamState, logData *requestLogData) bool {
-	return logData.deliveredContent ||
-		st.sawContent ||
-		st.sawMessageStop ||
-		st.deliveredBytes > 0 ||
-		st.completionTokens > 0
+//   - st.sawContent — a non-empty content or reasoning delta reached the client.
+//   - st.deliveredBytes — the bytes of content, reasoning, reasoning_details and
+//     tool-call arguments the model produced. Counted on BOTH the translated and
+//     the native Anthropic path, so it is the one signal that catches a native
+//     stream which really did deliver.
+//   - st.completionTokens — the provider reported usage even if this gateway
+//     never parsed content out of the deltas.
+//
+// Deliberately NOT logData.deliveredContent, and deliberately NOT
+// st.sawMessageStop. deliveredContent is derived as sawContent||sawMessageStop
+// for the RETIREMENT verdict, where a terminal message_stop is allowed to stand
+// in for "the model answered". Here it cannot: message_stop is a TERMINATION
+// signal, present on every native stream that ends cleanly, including one that
+// ended having produced nothing. Reading it as delivery is what let a completely
+// empty /v1/messages response escape the charge entirely.
+//
+// A tool call is output. So is reasoning. The cost of missing one of these is a
+// charge against a provider that answered correctly, which after five requests
+// takes it out of rotation for every tenant — so this errs toward "delivered".
+func streamDeliveredOutput(st *streamState) bool {
+	return st.sawContent || st.deliveredBytes > 0 || st.completionTokens > 0
 }
 
 // judgeStreamForBreaker decides what a finished stream tells the circuit
@@ -160,13 +169,26 @@ func judgeStreamForBreaker(st *streamState, logData *requestLogData, errMsg stri
 		// The probe catches the stream that never produced a chunk; this is its
 		// sibling, the one that produced frames carrying no output and was
 		// already committed to by the time that became clear.
-		if !streamDeliveredOutput(st, logData) {
+		//
+		// unparsedChunks holds the charge back: those frames were dropped by
+		// THIS gateway's parser, not left out by the provider, so their contents
+		// are unknown and emptiness cannot be pinned on the upstream. Recording
+		// nothing is the honest verdict — neither a charge nor a credit.
+		if st.unparsedChunks > 0 {
+			return streamBreakerVerdict{}
+		}
+		if !streamDeliveredOutput(st) {
 			return streamBreakerVerdict{failureReason: "stream completed without delivering content"}
 		}
 		// Includes the stream whose absent [DONE] was injected above: the
 		// sentinel was missing, the answer was not.
 		return streamBreakerVerdict{success: true}
 	}
+	// Reached only with a non-empty errMsg, so errorKind is always set:
+	// deriveStreamError writes the two together. The clean-finish charge above
+	// sits ABOVE this gate deliberately — it has no errMsg and therefore no
+	// kind, and the two non-provider causes that could reach it (interrupted,
+	// clientDisconnected) are already short-circuited at the top.
 	if !providerAtFault(logData.errorKind) {
 		return streamBreakerVerdict{}
 	}
@@ -176,7 +198,7 @@ func judgeStreamForBreaker(st *streamState, logData *requestLogData, errMsg stri
 	if st.stalled && !st.sawDone && !st.sawMessageStop {
 		return streamBreakerVerdict{failureReason: "stream stalled"}
 	}
-	if !streamDeliveredOutput(st, logData) {
+	if !streamDeliveredOutput(st) {
 		return streamBreakerVerdict{failureReason: "stream failed without delivering content"}
 	}
 	return streamBreakerVerdict{}

--- a/internal/proxy/stream_observers.go
+++ b/internal/proxy/stream_observers.go
@@ -75,6 +75,15 @@ type streamChunk struct {
 		Delta *struct {
 			Content          *string `json:"content"`
 			ReasoningContent *string `json:"reasoning_content"`
+			// The two other spellings of the same thing. Ollama and OpenRouter
+			// send "reasoning"; OpenRouter and MiniMax send "reasoning_details".
+			// normalizeReasoningChunk rewrites both into reasoning_content for
+			// the client, but it runs AFTER the observers — so without these the
+			// caller receives a full answer while the delivery accounting sees
+			// nothing, and the provider is charged for an empty response it did
+			// not give.
+			Reasoning        *string         `json:"reasoning"`
+			ReasoningDetails json.RawMessage `json:"reasoning_details"`
 			ToolCalls        []struct {
 				Function *struct {
 					Name      string `json:"name"`
@@ -139,6 +148,12 @@ func (st *streamState) observeDataChunk(chunk streamChunk, anthropicErrorCounted
 		}
 		if choice.Delta.ReasoningContent != nil {
 			st.deliveredBytes += len(*choice.Delta.ReasoningContent)
+		}
+		if choice.Delta.Reasoning != nil {
+			st.deliveredBytes += len(*choice.Delta.Reasoning)
+		}
+		if rd := choice.Delta.ReasoningDetails; len(rd) > 0 && string(rd) != "null" {
+			st.deliveredBytes += len(rd)
 		}
 		for _, tc := range choice.Delta.ToolCalls {
 			if tc.Function != nil {


### PR DESCRIPTION
A zero-token answer is not a valid one, so a provider that keeps producing them belongs out of rotation. #804 deliberately withheld that charge, reasoning that silence depends on the prompt and one virtual key could therefore darken a provider for every tenant. That call is reversed: a caller coercing a model into saying nothing is not a case worth keeping a provider in rotation for.

**A tool call is output. So is reasoning.** Only a genuinely empty response counts.

## What charges

Both paths that produce a completely empty response:

- **The stream never produced a chunk** — a bare `[DONE]`, or nothing but empty `data:` fields. The probe already refused these; that refusal is now recorded.
- **The stream got past the probe and completed having delivered nothing** — well-formed frames carrying no output. `finalizeStream` recorded this as a **success**, which did not merely fail to charge it: it actively cleared whatever failures the provider had already accumulated.

## What does not charge

Review found two **confirmed** false charges in the first version, both reproduced against the real pipeline. A false charge is the entire risk here — five of them take a provider that answered correctly out of rotation for every tenant.

**Reasoning under its other two spellings was invisible.** Ollama and OpenRouter send `reasoning`; OpenRouter and MiniMax send `reasoning_details`. `normalizeReasoningChunk` rewrites both into `reasoning_content` for the client, but it runs *after* the observers — so the caller received a complete answer while `deliveredBytes` stayed at zero. The only backstop was a usage chunk, and `paramrewrite` does not request one for `opencode-go` or `opencode-zen`. Both spellings are now counted.

**A frame this gateway could not parse now withholds the verdict entirely.** `streamChunk` types `content` as `*string` and tool-call `arguments` as `string`; a provider sending either in a wider shape fails the unmarshal, so the frame is dropped *and* nothing is counted. The dropping is pre-existing — but charging a provider for *our* parser's strictness is not. Those frames' contents are unknown, so the honest verdict is neither a charge nor a credit.

**`sawMessageStop` is no longer read as delivery.** It is a *termination* signal, present on every native Anthropic stream that ends cleanly — including one that ended having produced nothing, which was escaping the charge entirely. `streamDeliveredOutput` now reads only the signals that answer the question: `sawContent`, `deliveredBytes`, `completionTokens`. That also retires the previous commit's claim that checking the derived `logData.deliveredContent` guarded an ordering hazard; the derived value was identical to its own inputs, so that widening was inert.

## Verification

Live against the dev stack, six requests each at the production default threshold of 5:

| provider | circuit |
|---|---|
| genuinely empty (role delta + finish reason) | **opened** at 5 consecutive failures |
| tool call only, no content delta | closed |
| reasoning, Ollama spelling | closed |
| content as an array of parts (parser drops the frame) | closed |

```
circuit-breaker: provider state=closed→open provider=cb-genuinely-empty
                 consecutive_failures=5 cooldown_ms=60000
```

Every fix is mutation-tested. Stripping tool-call byte counting fails the tool-call guard; dropping either reasoning spelling fails that guard; ignoring `unparsedChunks` fails the wide-shape guard; restoring `sawMessageStop` fails the empty-native guard.

The tool-call and reasoning guards drive the **real streaming pipeline** rather than a hand-built `streamState`, because what is under test is whether the pipeline's own accounting registers them at all.

## Known gap, not addressed here

The non-streaming path is now inconsistent with this. `recordBreakerOutcome` records an unconditional success for any non-streaming 200, so `{"choices":[{"message":{"content":""}}]}` — the exact twin of what streaming now charges — is still credited. Fixing it means moving the breaker verdict to after the body is decoded, which is the same premature-commit shape as the probe bug fixed in #803 and deserves its own change. `chatAnswerCarriesContent` already exists and is the right predicate for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
