### PR TITLE
fix(proxy): forward SSE frames the gateway has no type for

### DIFF
--- a/internal/proxy/proxy_stream_response.go
+++ b/internal/proxy/proxy_stream_response.go
@@ -419,6 +419,36 @@ func (h *Handler) handleDataChunk(sink *streamSink, st *streamState, ev sseEvent
 		}
 	}
 	if !written && !jsonValid {
+		// Valid JSON this gateway has no Go type for is still the provider's
+		// answer, and must reach the caller.
+		//
+		// streamChunk types delta.content as *string and tool-call arguments as
+		// string. A provider sending either in a wider — but perfectly valid —
+		// shape fails the typed unmarshal above, and used to be discarded here
+		// as though the bytes were corrupt. The caller silently lost real
+		// output; on a tool call it lost the call while finish_reason, which
+		// rides a separate parseable frame, survived to announce it.
+		//
+		// The masking that every other frame gets lives inside the typed branch
+		// above, so it is applied here or not at all: exact-key always, and the
+		// key-shape pass when the frame carries an error member, matching the
+		// policy there. carriesErrorObject rather than a second opinion about
+		// what an error frame is.
+		if json.Valid([]byte(payload)) {
+			masked := st.masker.maskExact([]byte(payload))
+			if carriesErrorObject(masked) {
+				masked = maskKeyShapedTokens(masked)
+			}
+			// Still counted: forwarding the bytes does not tell us whether they
+			// carried output, so the end-of-stream verdict keeps withholding
+			// its judgement rather than charging the provider for an emptiness
+			// it cannot vouch for.
+			st.unparsedChunks++
+			debuglog.Warn("proxy: forwarding an SSE frame the gateway cannot model",
+				"model", logData.modelID, "provider", logData.providerName,
+				"chunk_number", chunkCount, "payload_bytes", len(payload))
+			return !st.emitData(sink, masked, "unmodelled frame", chunkCount, logData)
+		}
 		// Drop invalid/truncated JSON instead of forwarding broken bytes.
 		preview := payload
 		if len(preview) > 80 {

--- a/internal/proxy/proxy_stream_response.go
+++ b/internal/proxy/proxy_stream_response.go
@@ -419,35 +419,8 @@ func (h *Handler) handleDataChunk(sink *streamSink, st *streamState, ev sseEvent
 		}
 	}
 	if !written && !jsonValid {
-		// Valid JSON this gateway has no Go type for is still the provider's
-		// answer, and must reach the caller.
-		//
-		// streamChunk types delta.content as *string and tool-call arguments as
-		// string. A provider sending either in a wider — but perfectly valid —
-		// shape fails the typed unmarshal above, and used to be discarded here
-		// as though the bytes were corrupt. The caller silently lost real
-		// output; on a tool call it lost the call while finish_reason, which
-		// rides a separate parseable frame, survived to announce it.
-		//
-		// The masking that every other frame gets lives inside the typed branch
-		// above, so it is applied here or not at all: exact-key always, and the
-		// key-shape pass when the frame carries an error member, matching the
-		// policy there. carriesErrorObject rather than a second opinion about
-		// what an error frame is.
-		if json.Valid([]byte(payload)) {
-			masked := st.masker.maskExact([]byte(payload))
-			if carriesErrorObject(masked) {
-				masked = maskKeyShapedTokens(masked)
-			}
-			// Still counted: forwarding the bytes does not tell us whether they
-			// carried output, so the end-of-stream verdict keeps withholding
-			// its judgement rather than charging the provider for an emptiness
-			// it cannot vouch for.
-			st.unparsedChunks++
-			debuglog.Warn("proxy: forwarding an SSE frame the gateway cannot model",
-				"model", logData.modelID, "provider", logData.providerName,
-				"chunk_number", chunkCount, "payload_bytes", len(payload))
-			return !st.emitData(sink, masked, "unmodelled frame", chunkCount, logData)
+		if handled, stopStream := st.forwardUnmodelledFrame(sink, payload, stripReasoning, chunkCount, logData); handled {
+			return stopStream
 		}
 		// Drop invalid/truncated JSON instead of forwarding broken bytes.
 		preview := payload
@@ -484,4 +457,76 @@ func (h *Handler) handleDataChunk(sink *streamSink, st *streamState, ev sseEvent
 		sink.swallowBlank = true
 	}
 	return false
+}
+
+// topLevelJSONObject reports whether an SSE payload is a JSON object.
+// Deliberately stricter than json.Valid, which also admits `123`, `"text"`,
+// `true` and arrays: a client decodes every data: event into a chunk struct, so
+// relaying one of those turns a one-frame loss into a decode exception that
+// kills the whole stream. It is also what keeps carriesErrorObject meaningful,
+// since that reports false for anything which is not a top-level object.
+func topLevelJSONObject(payload string) bool {
+	var probe map[string]json.RawMessage
+	return json.Unmarshal([]byte(payload), &probe) == nil
+}
+
+// forwardUnmodelledFrame relays an SSE frame that failed the typed streamChunk
+// unmarshal but is still a JSON object — valid JSON in a shape this gateway has
+// no Go type for. handled is false when the payload is not one, leaving the
+// caller to drop it as malformed; stop reports a client write failure.
+//
+// streamChunk types delta.content as *string and tool-call arguments as string.
+// A provider sending either in a wider but perfectly valid shape failed that
+// unmarshal and had its answer discarded as though the bytes were corrupt. On a
+// tool call the caller lost the call itself while finish_reason, which rides a
+// separate parseable frame, survived to announce it.
+func (st *streamState) forwardUnmodelledFrame(sink *streamSink, payload string, stripReasoning bool, chunkCount int, logData *requestLogData) (handled, stop bool) {
+	if !topLevelJSONObject(payload) {
+		return false, false
+	}
+	// The masking every other frame gets lives inside the typed branch this one
+	// skipped, so it is applied here or not at all: exact-key always, and the
+	// key-shape pass when the frame carries an error member, matching the policy
+	// there. carriesErrorObject rather than a second opinion about what an error
+	// frame is.
+	masked := st.masker.maskExact([]byte(payload))
+	if carriesErrorObject(masked) {
+		masked = maskKeyShapedTokens(masked)
+	}
+	// Counted as unparsed either way: forwarding the bytes does not tell us
+	// whether they carried output, so the end-of-stream breaker verdict keeps
+	// withholding its judgement.
+	st.unparsedChunks++
+	if !st.warnedUnmodelled {
+		// Once per stream. Forwarding makes this shape a normal operating mode
+		// for some providers, and a per-frame Warn would ship thousands of lines
+		// per request to Loki/OTLP.
+		st.warnedUnmodelled = true
+		debuglog.Warn("proxy: forwarding SSE frames the gateway cannot model",
+			"model", logData.modelID, "provider", logData.providerName,
+			"first_chunk_number", chunkCount, "payload_bytes", len(payload))
+	}
+	// strip_reasoning is a per-virtual-key contract, and it also lives inside the
+	// branch this frame skipped. Forwarding without it delivers reasoning to a
+	// caller configured never to receive any — dropping the frame used to satisfy
+	// that guarantee by accident. computeStripReasoning works here because
+	// parseChunkPayload is map-based and does not care about field types.
+	if stripReasoning {
+		switch decision, stripped := computeStripReasoning(string(masked), &st.lastFinishReason, logData); decision {
+		case stripDrop:
+			return true, false
+		case stripKeepalive, stripForward:
+			st.deliveredBytes += len(stripped)
+			return true, !st.emitData(sink, stripped, "unmodelled frame", chunkCount, logData)
+		case stripPassthrough:
+			// No choices/delta to strip, so there is nothing to withhold.
+		}
+	}
+	// The delivery accounting cannot see inside this frame, so the whole payload
+	// stands in for the output it carries. An overestimate is the safe direction:
+	// counting zero left a request that really was served — an agentic tool call
+	// from a provider that omits the usage chunk — metered at nothing against
+	// both quota and TPM while the provider billed for it.
+	st.deliveredBytes += len(masked)
+	return true, !st.emitData(sink, masked, "unmodelled frame", chunkCount, logData)
 }

--- a/internal/proxy/proxy_stream_response.go
+++ b/internal/proxy/proxy_stream_response.go
@@ -459,6 +459,43 @@ func (h *Handler) handleDataChunk(sink *streamSink, st *streamState, ev sseEvent
 	return false
 }
 
+// unmodelledDeliveredBytes sizes the model output carried by a frame the typed
+// path could not read: the raw bytes of the delta members that hold output, and
+// nothing else.
+//
+// It must not be the whole payload. deliveredBytes is documented as "the bytes
+// of content, reasoning and tool-call arguments" and is the sole input to
+// estimateMissingUsage, which charges quota and TPM. Counting the JSON envelope
+// over-charged by orders of magnitude for frames carrying a couple of bytes of
+// text each and — far worse — gave a stream that delivered nothing but an error
+// a non-zero byte count, unlocking a full prompt-size estimate for a request the
+// provider never billed. estimateMissingUsage's own contract is that "an error
+// before the first token costs nothing".
+//
+// Zero means the frame carries no output, and the caller does not forward it at
+// all: there is nothing to rescue, and relaying it would only cost a strict
+// client a decode error.
+func unmodelledDeliveredBytes(payload string) int {
+	p, ok := parseChunkPayload(payload)
+	if !ok {
+		return 0
+	}
+	total := 0
+	for _, key := range []string{"content", "reasoning_content", "reasoning", "reasoning_details", "tool_calls"} {
+		raw, present := p.delta[key]
+		if !present {
+			continue
+		}
+		// An empty container is a member with no output in it.
+		switch strings.TrimSpace(string(raw)) {
+		case "null", `""`, "[]", "{}":
+			continue
+		}
+		total += len(raw)
+	}
+	return total
+}
+
 // topLevelJSONObject reports whether an SSE payload is a JSON object.
 // Deliberately stricter than json.Valid, which also admits `123`, `"text"`,
 // `true` and arrays: a client decodes every data: event into a chunk struct, so
@@ -484,6 +521,16 @@ func (st *streamState) forwardUnmodelledFrame(sink *streamSink, payload string, 
 	if !topLevelJSONObject(payload) {
 		return false, false
 	}
+	// Only a frame that actually carries output is worth rescuing. A frame with
+	// no delta output — an error envelope in a shape the typed path cannot read,
+	// say Ollama's bare {"error":"model not found"} — is left to the drop path
+	// exactly as before. Forwarding it would deliver nothing, bill the caller for
+	// a request the provider never charged for, and tell the circuit breaker the
+	// provider had delivered.
+	delivered := unmodelledDeliveredBytes(payload)
+	if delivered == 0 {
+		return false, false
+	}
 	// The masking every other frame gets lives inside the typed branch this one
 	// skipped, so it is applied here or not at all: exact-key always, and the
 	// key-shape pass when the frame carries an error member, matching the policy
@@ -493,10 +540,14 @@ func (st *streamState) forwardUnmodelledFrame(sink *streamSink, payload string, 
 	if carriesErrorObject(masked) {
 		masked = maskKeyShapedTokens(masked)
 	}
-	// Counted as unparsed either way: forwarding the bytes does not tell us
-	// whether they carried output, so the end-of-stream breaker verdict keeps
-	// withholding its judgement.
-	st.unparsedChunks++
+	// Deliberately NOT counted as unparsed. That counter makes the end-of-stream
+	// breaker verdict withhold judgement because the frame's contents are
+	// unknown — but reaching here means unmodelledDeliveredBytes has measured
+	// output in it, so they are not. Marking these unparsed would leave a
+	// provider whose normal shape lands on this path unable to EVER record a
+	// breaker success, and consecutiveFails only resets on success: five failures
+	// spread over any span, rather than five consecutive, would open its circuit.
+	// The drop path still counts, because there the contents really are unknown.
 	if !st.warnedUnmodelled {
 		// Once per stream. Forwarding makes this shape a normal operating mode
 		// for some providers, and a per-frame Warn would ship thousands of lines
@@ -516,17 +567,25 @@ func (st *streamState) forwardUnmodelledFrame(sink *streamSink, payload string, 
 		case stripDrop:
 			return true, false
 		case stripKeepalive, stripForward:
-			st.deliveredBytes += len(stripped)
+			// Size what SURVIVED the strip. Charging the pre-strip figure bills
+			// the caller for reasoning deliberately withheld from them, and a
+			// keep-alive delivers nothing at all.
+			st.deliveredBytes += unmodelledDeliveredBytes(string(stripped))
 			return true, !st.emitData(sink, stripped, "unmodelled frame", chunkCount, logData)
 		case stripPassthrough:
-			// No choices/delta to strip, so there is nothing to withhold.
+			// parseChunkPayload refused the frame, which does NOT mean it holds
+			// no reasoning: it also refuses a choices/delta that is not the shape
+			// it expects. The gateway cannot prove this frame is reasoning-free,
+			// and strip_reasoning is a promise to a specific caller, so it is
+			// dropped rather than forwarded on a guess.
+			return true, false
 		}
 	}
-	// The delivery accounting cannot see inside this frame, so the whole payload
-	// stands in for the output it carries. An overestimate is the safe direction:
-	// counting zero left a request that really was served — an agentic tool call
-	// from a provider that omits the usage chunk — metered at nothing against
-	// both quota and TPM while the provider billed for it.
-	st.deliveredBytes += len(masked)
+	// Only the output-bearing members, never the envelope. Counting zero left a
+	// request that really was served — an agentic tool call from a provider that
+	// omits the usage chunk — metered at nothing against quota and TPM while the
+	// provider billed for it; counting the envelope over-charged wildly for the
+	// same request.
+	st.deliveredBytes += delivered
 	return true, !st.emitData(sink, masked, "unmodelled frame", chunkCount, logData)
 }

--- a/internal/proxy/proxy_stream_response.go
+++ b/internal/proxy/proxy_stream_response.go
@@ -573,11 +573,16 @@ func (st *streamState) forwardUnmodelledFrame(sink *streamSink, payload string, 
 			st.deliveredBytes += unmodelledDeliveredBytes(string(stripped))
 			return true, !st.emitData(sink, stripped, "unmodelled frame", chunkCount, logData)
 		case stripPassthrough:
-			// parseChunkPayload refused the frame, which does NOT mean it holds
-			// no reasoning: it also refuses a choices/delta that is not the shape
-			// it expects. The gateway cannot prove this frame is reasoning-free,
-			// and strip_reasoning is a promise to a specific caller, so it is
-			// dropped rather than forwarded on a guess.
+			// Unreachable as things stand: stripPassthrough means
+			// parseChunkPayload refused the frame, and the delivered == 0 gate
+			// above — which calls the same parser — already dropped every frame
+			// it refuses. That gate is what actually closes the leak here, since
+			// a refusal does NOT mean the frame is reasoning-free (the parser
+			// also refuses a choices/delta that is not the shape it expects).
+			//
+			// Kept, and kept as a DROP, because strip_reasoning is a promise to
+			// a specific caller: if the two ever stop agreeing, the frame must
+			// not be forwarded on a guess.
 			return true, false
 		}
 	}

--- a/internal/proxy/stream_finalize.go
+++ b/internal/proxy/stream_finalize.go
@@ -40,11 +40,11 @@ type streamState struct {
 	chunkCount            int
 	errorChunkCount       int
 	// unparsedChunks counts data frames the gateway could not unmarshal into a
-	// streamChunk. They are dropped rather than forwarded, so the caller does
-	// lose them — but the provider may have answered perfectly well in a shape
-	// this gateway's types do not cover (tool-call arguments as an object,
-	// content as an array of parts). The delivery accounting cannot see into
-	// such a frame, so it must not conclude the response was empty.
+	// streamChunk. Valid JSON in a shape this gateway's types do not cover
+	// (tool-call arguments as an object, content as an array of parts) is
+	// forwarded to the caller verbatim; only genuinely malformed bytes are
+	// dropped. Either way the delivery accounting cannot see inside such a
+	// frame, so it must not conclude the response was empty.
 	unparsedChunks int
 	lastErrMsg     string
 	sawDone        bool

--- a/internal/proxy/stream_finalize.go
+++ b/internal/proxy/stream_finalize.go
@@ -82,6 +82,11 @@ type streamState struct {
 	errAccum               []byte // P1-B split-error accumulation
 	lastFinishReason       string // P2-2 duplicate-finish suppression + normalization carry
 	lastAnthropicEvent     string // P1-C: last "event:" type, consumed by the next data line
+	// warnedUnmodelled keeps the "cannot model this frame" warning to one line
+	// per stream. Forwarding made the unmodelled shape a normal operating mode
+	// for some providers, so a per-frame Warn would ship thousands of lines per
+	// request to Loki/OTLP.
+	warnedUnmodelled bool
 }
 
 // streamBreakerVerdict is what a finished stream tells the circuit breaker about
@@ -170,10 +175,11 @@ func judgeStreamForBreaker(st *streamState, logData *requestLogData, errMsg stri
 		// sibling, the one that produced frames carrying no output and was
 		// already committed to by the time that became clear.
 		//
-		// unparsedChunks holds the charge back: those frames were dropped by
-		// THIS gateway's parser, not left out by the provider, so their contents
-		// are unknown and emptiness cannot be pinned on the upstream. Recording
-		// nothing is the honest verdict — neither a charge nor a credit.
+		// unparsedChunks holds the charge back: this gateway's parser could not
+		// read those frames, so their contents are unknown and emptiness cannot
+		// be pinned on the upstream — whether they were forwarded verbatim or
+		// dropped. Recording nothing is the honest verdict: neither a charge nor
+		// a credit.
 		if st.unparsedChunks > 0 {
 			return streamBreakerVerdict{}
 		}

--- a/internal/proxy/stream_transforms.go
+++ b/internal/proxy/stream_transforms.go
@@ -1,6 +1,9 @@
 package proxy
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"strings"
+)
 
 // stripReasoningDecision is what computeStripReasoning decided for a chunk.
 type stripReasoningDecision int
@@ -53,8 +56,12 @@ func computeStripReasoning(payload string, lastFinishReason *string, logData *re
 	// Does the delta still carry meaningful data?
 	deltaHasContent := false
 	if cRaw, okC := deltaFields["content"]; okC {
-		var cStr string
-		if json.Unmarshal(cRaw, &cStr) == nil && cStr != "" {
+		// Any non-empty content counts, WHATEVER its shape. Judging only the
+		// plain-string form meant a delta whose content is an array of parts
+		// looked contentless, and was rewritten into a keep-alive with the text
+		// discarded. (The empty-string case was already deleted above; it is
+		// re-checked here so this stays correct if that block moves.)
+		if raw := strings.TrimSpace(string(cRaw)); raw != "null" && raw != `""` {
 			deltaHasContent = true
 		}
 	}

--- a/internal/proxy/unmodelled_frame_test.go
+++ b/internal/proxy/unmodelled_frame_test.go
@@ -198,10 +198,114 @@ func TestHandleStreamingResponse_UnmodelledErrorFrameMasksKeyShapedTokens(t *tes
 	h := newIntegrationHandler()
 	defer stopUnitHandlerIntegration(h)
 
-	// Unmodelled because error is a bare string, not our {message} object.
-	out := streamThrough(t, h, `data: {"error":"upstream rejected key sk-abc123def456ghi789xyz"}`+"\n\ndata: [DONE]\n\n")
+	// The frame must carry BOTH an error member and real delta output: an
+	// error-only frame has nothing to deliver and is dropped, so it would never
+	// reach the mask and the test would pass whatever the code did. Unmodelled
+	// because error is a bare string and content is an array of parts.
+	frame := `{"error":"upstream rejected key sk-abc123def456ghi789xyz",` +
+		`"choices":[{"index":0,"delta":{"content":[{"type":"text","text":"hi"}]}}]}`
+	out := streamThrough(t, h, "data: "+frame+"\n\ndata: [DONE]\n\n")
+	if !strings.Contains(out, "hi") {
+		t.Fatalf("test assumption broken: the frame must be forwarded, got %s", out)
+	}
 	if strings.Contains(out, "sk-abc123def456ghi789xyz") {
 		t.Errorf("a key-shaped token in a forwarded error frame must be redacted, got: %s", out)
+	}
+}
+
+// A frame with no delta output is not worth rescuing, and forwarding it costs
+// real money: deliveredBytes is the sole input to estimateMissingUsage, so a
+// non-zero count for an error-only stream unlocks a full PROMPT-size estimate
+// against quota and TPM for a request the provider never billed.
+// estimateMissingUsage's contract is that an error before the first token costs
+// nothing.
+func TestHandleStreamingResponse_ErrorOnlyFrameIsNeitherForwardedNorBilled(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandlerIntegration(h)
+	logs := captureProxyLogs(t)
+
+	logData := streamingLog()
+	logData.providerName = "shape-provider"
+	logData.promptTextBytes = 100000
+	h.insertRequestLogAsync(logData)
+
+	// Ollama's documented bare-string error shape: valid JSON, an object, and
+	// unreadable by the typed path — but it carries no output.
+	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(
+		`data: {"error":"model not found"}` + "\n\ndata: [DONE]\n\n"))}
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)
+	h.handleStreamingResponse(w, req, logData, resp, time.Now(), streamOptions{
+		responseHeaderMs: 10, providerID: uuid.New(), providerName: "shape-provider",
+		vkHash: "test-hash", attempt: 1,
+	})
+
+	if strings.Contains(w.Body.String(), "model not found") {
+		t.Errorf("a frame carrying no output must not be forwarded, got: %s", w.Body.String())
+	}
+	if est := logs.find("charging estimated tokens"); len(est) > 0 {
+		t.Errorf("a stream that delivered nothing must not be billed, but an estimate ran: %v", est[0].attrs)
+	}
+}
+
+// deliveredBytes is documented as the bytes of content, reasoning and tool-call
+// arguments — not the JSON envelope around them. Counting the envelope charged
+// orders of magnitude more than the output was worth.
+func TestUnmodelledDeliveredBytes_SizesOutputNotEnvelope(t *testing.T) {
+	tests := map[string]struct {
+		frame string
+		want  int
+	}{
+		// The content member is 29 bytes; the frame around it is 75. Counting
+		// the frame is what over-charged.
+		"content as parts": {`{"choices":[{"index":0,"delta":{"content":[{"type":"text","text":"hi"}]}}]}`, 29},
+		"no delta at all":  {`{"error":"model not found"}`, 0},
+		"empty content":    {`{"choices":[{"index":0,"delta":{"content":""}}]}`, 0},
+		"null content":     {`{"choices":[{"index":0,"delta":{"content":null}}]}`, 0},
+		"empty tool calls": {`{"choices":[{"index":0,"delta":{"tool_calls":[]}}]}`, 0},
+		"role only":        {`{"choices":[{"index":0,"delta":{"role":"assistant"}}]}`, 0},
+		"usage only":       {`{"choices":[],"usage":{"completion_tokens":"7"}}`, 0},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := unmodelledDeliveredBytes(tc.frame); got != tc.want {
+				t.Errorf("unmodelledDeliveredBytes = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+// strip_reasoning is a promise to one caller. computeStripReasoning returning
+// stripPassthrough does NOT mean the frame is reasoning-free — parseChunkPayload
+// also refuses a choices/delta that is not the shape it expects — so the frame
+// is dropped rather than forwarded on a guess.
+func TestHandleStreamingResponse_UnstrippableFrameIsDroppedNotLeaked(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandlerIntegration(h)
+
+	const secret = "SECRET-CHAIN-OF-THOUGHT"
+	for name, frame := range map[string]string{
+		// delta is an array, so parseChunkPayload refuses it.
+		"delta as an array": `{"choices":[{"index":0,"delta":["reasoning_content","` + secret + `"]}]}`,
+		// choices is an object, so parseChunkPayload refuses it.
+		"choices as object": `{"choices":{"0":{"delta":{"reasoning_content":"` + secret + `","content":"hi"}}}}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			logData := streamingLog()
+			logData.providerName = "shape-provider"
+			h.insertRequestLogAsync(logData)
+			resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("data: " + frame + "\n\ndata: [DONE]\n\n"))}
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody).
+				WithContext(context.WithValue(context.Background(), ctxkeys.VirtualKeyStripReasoningKey, true))
+			h.handleStreamingResponse(w, req, logData, resp, time.Now(), streamOptions{
+				responseHeaderMs: 10, providerID: uuid.New(), providerName: "shape-provider",
+				vkHash: "test-hash", attempt: 1,
+			})
+			if strings.Contains(w.Body.String(), secret) {
+				t.Errorf("reasoning reached a caller that asked for it to be stripped: %s", w.Body.String())
+			}
+		})
 	}
 }
 

--- a/internal/proxy/unmodelled_frame_test.go
+++ b/internal/proxy/unmodelled_frame_test.go
@@ -1,0 +1,131 @@
+package proxy
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ---------------------------------------------------------------------------
+// A frame this gateway has no Go type for is still the provider's answer.
+//
+// streamChunk types delta.content as *string and tool_calls[].function.arguments
+// as string. A provider sending either in a wider — but perfectly valid — JSON
+// shape fails the typed unmarshal, and the whole frame used to be discarded as
+// though the bytes were corrupt. The client lost real output and was told
+// nothing.
+//
+// The tool-call case is the sharp one: finish_reason rides on a SEPARATE frame
+// that parses fine, so it survives. The caller receives a completion announcing
+// a tool call with no tool call in it.
+// ---------------------------------------------------------------------------
+
+func streamThrough(t *testing.T, h *Handler, body string) string {
+	t.Helper()
+	logData := streamingLog()
+	logData.providerName = "shape-provider"
+	h.insertRequestLogAsync(logData)
+
+	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body))}
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)
+	h.handleStreamingResponse(w, req, logData, resp, time.Now(), streamOptions{
+		responseHeaderMs: 10,
+		providerID:       uuid.New(),
+		providerName:     "shape-provider",
+		vkHash:           "test-hash",
+		attempt:          1,
+	})
+	return w.Body.String()
+}
+
+func TestHandleStreamingResponse_ForwardsFramesItCannotModel(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandlerIntegration(h)
+
+	tests := map[string]struct{ frame, want string }{
+		// The shape that loses a whole tool call.
+		"tool arguments as an object": {
+			`{"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"get_weather","arguments":{"city":"Prague"}}}]}}]}`,
+			"get_weather",
+		},
+		// Content as an array of parts.
+		"content as parts": {
+			`{"choices":[{"index":0,"delta":{"content":[{"type":"text","text":"hello"}]}}]}`,
+			"hello",
+		},
+		// A member whose type we simply do not model.
+		"unmodelled member": {
+			`{"choices":[{"index":0,"delta":{"content":"hi"}}],"usage":{"completion_tokens":"7"}}`,
+			`"hi"`,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			out := streamThrough(t, h, "data: "+tc.frame+"\n\ndata: [DONE]\n\n")
+			if !strings.Contains(out, tc.want) {
+				t.Errorf("the provider's answer must reach the caller.\n got: %s\nwant it to contain: %s", out, tc.want)
+			}
+		})
+	}
+}
+
+// The original protection has to survive: bytes that are not JSON at all are
+// still dropped rather than relayed as broken frames.
+func TestHandleStreamingResponse_StillDropsMalformedBytes(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandlerIntegration(h)
+
+	for name, frame := range map[string]string{
+		"truncated object": `{"choices":[{"delta":{"content":`,
+		"not json at all":  `<html>502 Bad Gateway</html>`,
+		"unclosed string":  `{"choices":[{"delta":{"content":"hel`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			out := streamThrough(t, h, "data: "+frame+"\n\ndata: [DONE]\n\n")
+			if strings.Contains(out, frame) {
+				t.Errorf("malformed bytes must not be relayed, got: %s", out)
+			}
+		})
+	}
+}
+
+// A credential quoted inside a frame we cannot model must still be scrubbed.
+// The masking lives inside the typed-parse branch, so a frame forwarded around
+// it would otherwise reach the caller unmasked.
+func TestHandleStreamingResponse_MasksCredentialInAnUnmodelledFrame(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandlerIntegration(h)
+
+	const apiKey = "hunter2-corp"
+	logData := streamingLog()
+	logData.providerName = "shape-provider"
+	logData.masker = newCredentialMasker(apiKey)
+	h.insertRequestLogAsync(logData)
+
+	// Unmodelled (arguments as an object) AND carrying the key.
+	frame := `{"choices":[{"index":0,"delta":{"tool_calls":[{"function":{"name":"f","arguments":{"key":"` + apiKey + `"}}}]}}]}`
+	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("data: " + frame + "\n\ndata: [DONE]\n\n"))}
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)
+	h.handleStreamingResponse(w, req, logData, resp, time.Now(), streamOptions{
+		responseHeaderMs: 10,
+		providerID:       uuid.New(),
+		providerName:     "shape-provider",
+		vkHash:           "test-hash",
+		attempt:          1,
+		masker:           newCredentialMasker(apiKey),
+	})
+
+	if strings.Contains(w.Body.String(), apiKey) {
+		t.Errorf("the provider credential reached the caller in an unmodelled frame: %s", w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "get_weather") && !strings.Contains(w.Body.String(), `"f"`) {
+		t.Errorf("the frame itself must still be forwarded, got: %s", w.Body.String())
+	}
+}

--- a/internal/proxy/unmodelled_frame_test.go
+++ b/internal/proxy/unmodelled_frame_test.go
@@ -204,3 +204,43 @@ func TestHandleStreamingResponse_UnmodelledErrorFrameMasksKeyShapedTokens(t *tes
 		t.Errorf("a key-shaped token in a forwarded error frame must be redacted, got: %s", out)
 	}
 }
+
+// A stream delivered entirely in unmodelled frames must still be metered.
+// observeDataChunk never sees them, so without the payload standing in for the
+// output it carries, estimateMissingUsage bails on its first line and the
+// request is charged nothing against quota or TPM while the provider bills for
+// it. That is the motivating case for this whole change: an agentic tool call
+// from a provider that both sends arguments as an object and omits usage.
+func TestHandleStreamingResponse_UnmodelledFramesAreStillMetered(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandlerIntegration(h)
+	logs := captureProxyLogs(t)
+
+	logData := streamingLog()
+	logData.providerName = "shape-provider"
+	h.insertRequestLogAsync(logData)
+
+	// Unmodelled (arguments as an object), no usage chunk anywhere.
+	frame := `{"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"c1","type":"function","function":{"name":"get_weather","arguments":{"city":"Prague"}}}]}}]}`
+	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("data: " + frame + "\n\ndata: [DONE]\n\n"))}
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)
+	h.handleStreamingResponse(w, req, logData, resp, time.Now(), streamOptions{
+		responseHeaderMs: 10, providerID: uuid.New(), providerName: "shape-provider",
+		vkHash: "test-hash", attempt: 1,
+	})
+
+	if !strings.Contains(w.Body.String(), "get_weather") {
+		t.Fatalf("test assumption broken: the frame must be delivered, got %s", w.Body.String())
+	}
+	// The estimate is asserted through its log line, not logData: it runs after
+	// logData.tokensCompletion is assigned and its result goes to the meter and
+	// quota, never back onto the request-log row.
+	est := logs.find("charging estimated tokens")
+	if len(est) == 0 {
+		t.Fatal("a delivered answer with no usage chunk must be estimated, not metered at zero")
+	}
+	if got := est[0].attrs["delivered_bytes"]; got == "0" || got == "" {
+		t.Errorf("delivered_bytes = %q, want > 0: the frame's output was invisible to the meter", got)
+	}
+}

--- a/internal/proxy/unmodelled_frame_test.go
+++ b/internal/proxy/unmodelled_frame_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -9,6 +10,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/hugalafutro/model-hotel/internal/ctxkeys"
 )
 
 // ---------------------------------------------------------------------------
@@ -127,5 +130,77 @@ func TestHandleStreamingResponse_MasksCredentialInAnUnmodelledFrame(t *testing.T
 	}
 	if !strings.Contains(w.Body.String(), "get_weather") && !strings.Contains(w.Body.String(), `"f"`) {
 		t.Errorf("the frame itself must still be forwarded, got: %s", w.Body.String())
+	}
+}
+
+// strip_reasoning is a per-virtual-key contract: that caller must never receive
+// reasoning. The transform lives inside the typed-parse branch, so a frame
+// forwarded around it delivers reasoning anyway. Dropping the frame used to
+// satisfy the guarantee by accident; forwarding it must satisfy the guarantee on
+// purpose.
+func TestHandleStreamingResponse_UnmodelledFrameStillStripsReasoning(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandlerIntegration(h)
+
+	const secret = "SECRET-CHAIN-OF-THOUGHT"
+	// Unmodelled (content as parts) AND carrying reasoning.
+	frame := `{"choices":[{"index":0,"delta":{"reasoning_content":"` + secret + `","content":[{"type":"text","text":"hi"}]}}]}`
+
+	logData := streamingLog()
+	logData.providerName = "shape-provider"
+	h.insertRequestLogAsync(logData)
+	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("data: " + frame + "\n\ndata: [DONE]\n\n"))}
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody).
+		WithContext(context.WithValue(context.Background(), ctxkeys.VirtualKeyStripReasoningKey, true))
+	h.handleStreamingResponse(w, req, logData, resp, time.Now(), streamOptions{
+		responseHeaderMs: 10, providerID: uuid.New(), providerName: "shape-provider",
+		vkHash: "test-hash", attempt: 1,
+	})
+
+	out := w.Body.String()
+	if strings.Contains(out, secret) {
+		t.Errorf("reasoning reached a caller that asked for it to be stripped: %s", out)
+	}
+	// And the content it rode with must survive the strip.
+	if !strings.Contains(out, "hi") {
+		t.Errorf("stripping reasoning must not take the content with it, got: %s", out)
+	}
+}
+
+// json.Valid admits any JSON value, but a client decodes every data: event into
+// a chunk struct. Relaying a bare number or an array turns a one-frame loss into
+// a decode exception that kills the whole stream, so only objects are forwarded.
+func TestHandleStreamingResponse_NonObjectPayloadsAreStillDropped(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandlerIntegration(h)
+
+	for name, frame := range map[string]string{
+		"bare number": `123`,
+		"bare string": `"just a string"`,
+		"bare bool":   `true`,
+		"array":       `[{"choices":[]}]`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			out := streamThrough(t, h, "data: "+frame+"\n\ndata: [DONE]\n\n")
+			if strings.Contains(out, "data: "+frame) {
+				t.Errorf("a non-object payload must not be relayed, got: %s", out)
+			}
+		})
+	}
+}
+
+// The key-shape pass is what catches a THIRD-PARTY key the provider quoted in
+// its error — the gateway's own credential is handled by the exact mask. It runs
+// only when the frame carries an error member, matching the typed branch's
+// policy.
+func TestHandleStreamingResponse_UnmodelledErrorFrameMasksKeyShapedTokens(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandlerIntegration(h)
+
+	// Unmodelled because error is a bare string, not our {message} object.
+	out := streamThrough(t, h, `data: {"error":"upstream rejected key sk-abc123def456ghi789xyz"}`+"\n\ndata: [DONE]\n\n")
+	if strings.Contains(out, "sk-abc123def456ghi789xyz") {
+		t.Errorf("a key-shaped token in a forwarded error frame must be redacted, got: %s", out)
 	}
 }

--- a/internal/proxy/unmodelled_frame_test.go
+++ b/internal/proxy/unmodelled_frame_test.go
@@ -275,10 +275,15 @@ func TestUnmodelledDeliveredBytes_SizesOutputNotEnvelope(t *testing.T) {
 	}
 }
 
-// strip_reasoning is a promise to one caller. computeStripReasoning returning
-// stripPassthrough does NOT mean the frame is reasoning-free — parseChunkPayload
-// also refuses a choices/delta that is not the shape it expects — so the frame
-// is dropped rather than forwarded on a guess.
+// strip_reasoning is a promise to one caller, and the gateway must not forward a
+// frame it cannot prove is reasoning-free. Both shapes below defeat
+// parseChunkPayload — a delta that is not an object, and a choices that is not
+// an array — so the strip transform could not clean them even if it ran.
+//
+// What stops them is the delivered == 0 gate: the same parser sizes the output,
+// refuses these, and the frame is dropped before it can be forwarded. (The
+// stripPassthrough arm is therefore unreachable; it stays as a drop in case the
+// two ever stop agreeing.) Both of these leaked verbatim before the gate existed.
 func TestHandleStreamingResponse_UnstrippableFrameIsDroppedNotLeaked(t *testing.T) {
 	h := newIntegrationHandler()
 	defer stopUnitHandlerIntegration(h)


### PR DESCRIPTION
## The bug

Every SSE `data:` payload is unmarshalled into a `streamChunk` struct, and a frame that failed was dropped — *"Drop invalid/truncated JSON instead of forwarding broken bytes"*. Sound intent, too narrow a struct: `delta.content` is typed `*string` and tool-call `arguments` is typed `string`, so a provider sending either in a wider but perfectly valid shape failed the unmarshal and had its answer discarded as though the bytes were corrupt.

The tool-call case is the sharp one, because the loss isn't uniform. `finish_reason` rides a *separate* frame that parses fine, so it survives. Reproduced against the dev stack with `arguments` as an object:

```
UPSTREAM SENDS:
  data: {...tool_calls:[{...function:{"name":"get_weather","arguments":{"city":"Prague"}}}]}
  data: {...finish_reason:"tool_calls"}

CLIENT RECEIVES:
  data: {...finish_reason:"tool_calls"}
  data: [DONE]
```

A completion announcing a tool call with no tool call in it. Most SDKs will throw or wait forever for arguments that never arrive.

Syntactically valid JSON objects are now forwarded; only genuinely malformed bytes are still dropped, which is what that guard was for.

## What the forwarded frame still has to obey

The frame skips the typed-parse branch, so everything living inside that branch had to be re-established. Review found three that weren't, one of them a regression this PR introduced:

**`strip_reasoning` is a per-virtual-key contract** and its transform is inside that branch, so a forwarded frame delivered reasoning to a caller configured never to receive any. Dropping the frame had been satisfying that guarantee by accident. Confirmed byte-for-byte before the fix. `computeStripReasoning` now runs on this path too — it works because `parseChunkPayload` is map-based and doesn't care about field types — and `deltaHasContent` no longer judges only the plain-string form of `content`, which would have turned a content-as-parts delta into an empty keep-alive and lost the text a second way.

**Only top-level JSON objects are forwarded.** `json.Valid` also admits `123`, `"text"`, `true` and arrays; a client decodes every `data:` event into a chunk struct, so relaying one of those converts a one-frame loss into a decode exception that kills the whole stream. That gate is also what keeps `carriesErrorObject` meaningful, since it reports false for anything that isn't an object — so a key-shaped token quoted inside an array-shaped error frame no longer escapes the key-shape mask.

**Only frames that carry output are forwarded, and only their output is metered.** `deliveredBytes` is the sole input to `estimateMissingUsage`, which charges quota and TPM. An earlier revision counted the whole JSON envelope, which over-charged wildly and — worse — gave a stream that delivered nothing but an error a non-zero count, unlocking a full *prompt*-size estimate for a request the provider never billed. `unmodelledDeliveredBytes` now sizes only the delta members that hold output, and a frame measuring zero is not forwarded at all: an error envelope the typed path cannot read (Ollama's bare `{"error":"model not found"}`) behaves exactly as it did before this PR. That also keeps a failing provider receiving the circuit-breaker charge it should — a zero-output frame counted as delivery was letting it escape one.

**The strip path sizes what survived the strip**, so a caller is never billed for reasoning deliberately withheld from them, and a keep-alive costs nothing.

**Forwarded frames are not counted as unparsed.** That counter makes the breaker verdict withhold judgement because a frame's contents are unknown — but reaching the forward path means output was measured in them. Left in, a provider whose normal shape lands here could never record a breaker success, and `consecutiveFails` only resets on success, so five failures spread over any span would open its circuit.

**Masking is repeated here**, since it also lives in the skipped branch: exact-key always, key-shape when the frame carries an error member, matching the typed branch's policy. Without it a forwarded frame reaches the caller carrying the provider credential — a test pins this with a deliberately non-key-shaped credential.

**The warning is once per stream.** Forwarding makes the unmodelled shape a normal operating mode for some providers, so a per-frame Warn would ship thousands of lines per request to Loki/OTLP.

## Verification

Every fix is mutation-tested, and two of those mutations initially produced *no* signal — one broke compilation, one had no test behind it. Both were chased down rather than counted as passes:

| mutation | result |
|---|---|
| drop unmodelled frames again | 3 tests fail |
| forward malformed bytes | original guard fails |
| skip masking | credential reaches the caller |
| bypass `strip_reasoning` | reasoning reaches the caller |
| allow non-object payloads | 5 subtests fail |
| forward frames carrying no output | error-only frame is forwarded and billed |
| count the envelope instead of the output | 9 subtests fail |
| remove the key-shape mask | key-shaped token reaches the caller |
| narrow `deltaHasContent` back to strings | content-as-parts becomes an empty keep-alive |

Two mutations initially produced *no* signal and were chased rather than counted as passes: one broke compilation, one had no test behind it. A third revealed a test passing vacuously — the key-shape test used an error-only frame, which this revision drops, so the mask was never reached; it now uses a frame carrying both an error member and real output.

The metering test asserts through the estimate's log line, not `logData` — the estimate runs after `logData.tokensCompletion` is assigned and its result goes to the meter and quota, never back onto the request-log row. The first version asserted `logData` and failed against a correct implementation.

Prod app logs show zero occurrences of the drop across all four fleet members, so this was latent rather than active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
