### PR TITLE
fix(proxy): widen streamChunk to the shapes providers actually send

### DIFF
--- a/internal/proxy/helpers.go
+++ b/internal/proxy/helpers.go
@@ -495,19 +495,10 @@ func promptTextBytes(body []byte) int {
 	}
 	n := len(req.Tools)
 	for _, m := range req.Messages {
-		var text string
-		if json.Unmarshal(m.Content, &text) == nil {
-			n += len(text)
-			continue
-		}
-		var parts []struct {
-			Text string `json:"text"`
-		}
-		if json.Unmarshal(m.Content, &parts) == nil {
-			for _, p := range parts {
-				n += len(p.Text)
-			}
-		}
+		// Same string-or-content-parts extraction the stream observers do, and
+		// deliberately the same helper: two copies of this drifted once already.
+		text, _ := deltaText(m.Content)
+		n += len(text)
 	}
 	return n
 }

--- a/internal/proxy/helpers.go
+++ b/internal/proxy/helpers.go
@@ -495,10 +495,25 @@ func promptTextBytes(body []byte) int {
 	}
 	n := len(req.Tools)
 	for _, m := range req.Messages {
-		// Same string-or-content-parts extraction the stream observers do, and
-		// deliberately the same helper: two copies of this drifted once already.
-		text, _ := deltaText(m.Content)
-		n += len(text)
+		// Deliberately NOT deltaText, despite the shapes looking alike. The two
+		// answer different questions and must not be merged: this one SKIPS a
+		// part it does not recognise, because a vision request's base64 media
+		// must not be sized, while deltaText has to report that it failed to
+		// understand a part — the reasoning-strip contract depends on knowing
+		// when the gateway cannot see inside a delta. Sharing them broke this.
+		var text string
+		if json.Unmarshal(m.Content, &text) == nil {
+			n += len(text)
+			continue
+		}
+		var parts []struct {
+			Text string `json:"text"`
+		}
+		if json.Unmarshal(m.Content, &parts) == nil {
+			for _, p := range parts {
+				n += len(p.Text)
+			}
+		}
 	}
 	return n
 }

--- a/internal/proxy/probe_error_frame_test.go
+++ b/internal/proxy/probe_error_frame_test.go
@@ -441,7 +441,12 @@ func TestErrorEnvelopeMessage(t *testing.T) {
 		// the frame into a streamChunk, which fails outright on this shape, so a
 		// local Ollama box in a hedged group reproduced the whole incident.
 		{"ollama bare string", `{"error":"model not found"}`, "model not found", true},
-		{"object without a message", `{"error":{"code":500}}`, `{"code":500}`, true},
+		// Named, not rendered raw. This message is persisted to
+		// request_logs.error_message, and providers echo the offending input
+		// inside content-filter and moderation errors — rendering the member
+		// verbatim would put the caller's prompt in the log, against the rule
+		// that no prompt or response content is ever logged.
+		{"object without a message", `{"error":{"code":500}}`, "provider reported an error with no message", true},
 		{"ordinary token", `{"choices":[{"delta":{"content":"hi"}}]}`, "", false},
 		{"explicit null error", `{"error":null,"choices":[]}`, "", false},
 		{"unparseable frame", `{not json`, "", false},

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -397,8 +397,10 @@ func errorEnvelopeMessage(content string) (msg string, ok bool) {
 		return "", false
 	}
 	var chunk streamChunk
-	if err := json.Unmarshal(raw, &chunk); err == nil && chunk.Error != nil && chunk.Error.Message != "" {
-		return chunk.Error.Message, true
+	if err := json.Unmarshal(raw, &chunk); err == nil {
+		if msg, ok := chunkErrorMessage(chunk.Error); ok {
+			return msg, true
+		}
 	}
 	// A bare string, a list, a number, or an object without a "message": render
 	// what the provider put there rather than dropping a frame already judged to

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -409,12 +409,15 @@ func errorEnvelopeMessage(content string) (msg string, ok bool) {
 		Error json.RawMessage `json:"error"`
 	}
 	if err := json.Unmarshal(raw, &envelope); err == nil && len(envelope.Error) > 0 {
-		var bare string
-		if json.Unmarshal(envelope.Error, &bare) == nil {
-			return bare, true
+		if msg, ok := chunkErrorMessage(envelope.Error); ok {
+			return msg, true
 		}
-		return string(envelope.Error), true
 	}
+	// Never the raw member. This text is persisted to
+	// request_logs.error_message, and providers echo the offending input inside
+	// content-filter and moderation errors, which would put the caller's prompt
+	// in the log. Reached when the frame does not decode as a streamChunk at
+	// all — a numeric finish_reason, a string-valued usage count.
 	return "provider reported an error with no message", true
 }
 

--- a/internal/proxy/proxy_stream_response.go
+++ b/internal/proxy/proxy_stream_response.go
@@ -304,7 +304,8 @@ func (st *streamState) applyEmptyContentStrip(sink *streamSink, chunk streamChun
 		return false, false
 	}
 	delta := chunk.Choices[0].Delta
-	hasReasoning := deltaText(delta.ReasoningContent) != ""
+	reasoningText, _ := deltaText(delta.ReasoningContent)
+	hasReasoning := reasoningText != ""
 	// Present AND literally the empty string. A null content is absent, not
 	// empty, which is what the *string form of this field used to express.
 	hasEmptyContent := string(delta.Content) == `""`
@@ -362,7 +363,13 @@ func (h *Handler) handleDataChunk(sink *streamSink, st *streamState, ev sseEvent
 		// normalization rebuilds the delta from it, not from payload; a stale
 		// chunk would hand the transform the original text to re-emit.
 		masked := st.masker.maskExact([]byte(payload))
-		if chunk.Error != nil {
+		// carriesErrorMember, not a nil check: Error is json.RawMessage now, so
+		// a present-but-null member is non-nil, and a gateway that stamps
+		// "error": null on every chunk would have the key-shape regex run over
+		// the model's answer — silently mangling text that merely looks like a
+		// key. One definition of what counts as an error, shared with the
+		// observers.
+		if carriesErrorMember(chunk.Error) {
 			masked = maskKeyShapedTokens(masked)
 		}
 		if string(masked) != payload {

--- a/internal/proxy/proxy_stream_response.go
+++ b/internal/proxy/proxy_stream_response.go
@@ -285,7 +285,7 @@ func (st *streamState) applyReasoningNormalize(sink *streamSink, chunk streamChu
 		return false, false
 	}
 	delta := chunk.Choices[0].Delta
-	newPayload, ok := normalizeReasoningChunk(delta.Content, delta.ReasoningContent, payload, &st.lastFinishReason, logData)
+	newPayload, ok := normalizeReasoningChunk(deltaTextPtr(delta.Content), deltaTextPtr(delta.ReasoningContent), payload, &st.lastFinishReason, logData)
 	if !ok {
 		return false, false
 	}
@@ -304,8 +304,10 @@ func (st *streamState) applyEmptyContentStrip(sink *streamSink, chunk streamChun
 		return false, false
 	}
 	delta := chunk.Choices[0].Delta
-	hasReasoning := delta.ReasoningContent != nil && *delta.ReasoningContent != ""
-	hasEmptyContent := delta.Content != nil && *delta.Content == ""
+	hasReasoning := deltaText(delta.ReasoningContent) != ""
+	// Present AND literally the empty string. A null content is absent, not
+	// empty, which is what the *string form of this field used to express.
+	hasEmptyContent := string(delta.Content) == `""`
 	if !hasReasoning || !hasEmptyContent {
 		return false, false
 	}

--- a/internal/proxy/stream_observers.go
+++ b/internal/proxy/stream_observers.go
@@ -73,8 +73,17 @@ const repeatedContentLimit = 10
 type streamChunk struct {
 	Choices []struct {
 		Delta *struct {
-			Content          *string `json:"content"`
-			ReasoningContent *string `json:"reasoning_content"`
+			// The output-bearing fields are RawMessage, not string, because a
+			// type mismatch in ANY of them fails the whole-chunk unmarshal and
+			// the frame is dropped — the provider's answer discarded as though
+			// the bytes were corrupt. Real providers send content as an array of
+			// parts and tool-call arguments as an object; on a tool call the
+			// caller lost the call while finish_reason, which rides a separate
+			// parseable frame, survived to announce it.
+			//
+			// Read them through deltaText/argumentsText, never directly.
+			Content          json.RawMessage `json:"content"`
+			ReasoningContent json.RawMessage `json:"reasoning_content"`
 			// The two other spellings of the same thing. Ollama and OpenRouter
 			// send "reasoning"; OpenRouter and MiniMax send "reasoning_details".
 			// normalizeReasoningChunk rewrites both into reasoning_content for
@@ -82,20 +91,24 @@ type streamChunk struct {
 			// caller receives a full answer while the delivery accounting sees
 			// nothing, and the provider is charged for an empty response it did
 			// not give.
-			Reasoning        *string         `json:"reasoning"`
+			Reasoning        json.RawMessage `json:"reasoning"`
 			ReasoningDetails json.RawMessage `json:"reasoning_details"`
 			ToolCalls        []struct {
 				Function *struct {
-					Name      string `json:"name"`
-					Arguments string `json:"arguments"`
+					Name      string          `json:"name"`
+					Arguments json.RawMessage `json:"arguments"`
 				} `json:"function"`
 			} `json:"tool_calls"`
 		} `json:"delta"`
 		FinishReason       *string `json:"finish_reason"`
 		NativeFinishReason *string `json:"native_finish_reason"` // P2-7: OpenRouter passthrough
 	} `json:"choices"`
-	Usage *Usage                    `json:"usage"`
-	Error *struct{ Message string } `json:"error"`
+	Usage *Usage `json:"usage"`
+	// RawMessage for the same reason: Ollama answers with a bare
+	// {"error":"model not found"}, which fails an unmarshal into an object and
+	// took the whole frame — content included — down with it. Read through
+	// chunkErrorMessage.
+	Error json.RawMessage `json:"error"`
 }
 
 // observeDataChunk applies the four non-emitting, side-channel observers over a
@@ -143,32 +156,23 @@ func (st *streamState) observeDataChunk(chunk streamChunk, anthropicErrorCounted
 		if choice.Delta == nil {
 			continue
 		}
-		if choice.Delta.Content != nil {
-			st.deliveredBytes += len(*choice.Delta.Content)
-		}
-		if choice.Delta.ReasoningContent != nil {
-			st.deliveredBytes += len(*choice.Delta.ReasoningContent)
-		}
-		if choice.Delta.Reasoning != nil {
-			st.deliveredBytes += len(*choice.Delta.Reasoning)
-		}
+		st.deliveredBytes += len(deltaText(choice.Delta.Content))
+		st.deliveredBytes += len(deltaText(choice.Delta.ReasoningContent))
+		st.deliveredBytes += len(deltaText(choice.Delta.Reasoning))
 		if rd := choice.Delta.ReasoningDetails; len(rd) > 0 && string(rd) != "null" {
 			st.deliveredBytes += len(rd)
 		}
 		for _, tc := range choice.Delta.ToolCalls {
 			if tc.Function != nil {
-				st.deliveredBytes += len(tc.Function.Name) + len(tc.Function.Arguments)
+				st.deliveredBytes += len(tc.Function.Name) + len(argumentsText(tc.Function.Arguments))
 			}
 		}
 	}
 	if len(chunk.Choices) > 0 && chunk.Choices[0].Delta != nil {
 		delta := chunk.Choices[0].Delta
-		currentContent := ""
-		if delta.Content != nil {
-			currentContent = *delta.Content
-		}
-		if delta.ReasoningContent != nil && currentContent == "" {
-			currentContent = *delta.ReasoningContent
+		currentContent := deltaText(delta.Content)
+		if rc := deltaText(delta.ReasoningContent); rc != "" && currentContent == "" {
+			currentContent = rc
 			if !st.sawThinking {
 				st.sawThinking = true
 				debuglog.Debug("proxy: thinking/reasoning block started", "model", logData.modelID, "provider", logData.providerName, "chunk_number", chunkCount)
@@ -192,14 +196,95 @@ func (st *streamState) observeDataChunk(chunk streamChunk, anthropicErrorCounted
 		}
 		st.lastContent = currentContent
 	}
-	if chunk.Error != nil && !anthropicErrorCounted {
+	if errMsg, isErr := chunkErrorMessage(chunk.Error); isErr && !anthropicErrorCounted {
 		// Only count if P1-C didn't already handle this as an
 		// Anthropic error event (which shares the same data line).
-		st.lastErrMsg = chunk.Error.Message
+		st.lastErrMsg = errMsg
 		st.errorChunkCount++
-		debuglog.Warn("proxy: SSE error chunk", "model", logData.modelID, "provider", logData.providerName, "error_message", chunk.Error.Message, "chunk_number", chunkCount)
+		debuglog.Warn("proxy: SSE error chunk", "model", logData.modelID, "provider", logData.providerName, "error_message", errMsg, "chunk_number", chunkCount)
 		// Clear st.errAccum: chunk.Error already captured this error,
 		// so P1-B's next flush must not re-count it.
 		st.errAccum = nil
 	}
+}
+
+// deltaText extracts the model's text from a delta field that carries output.
+//
+// Providers spell the same thing several ways. The plain string is the OpenAI
+// spec; an array of content parts is what several send, and a part carries its
+// text under "text". Anything else yields "", because the caller is sizing what
+// the model produced and cannot guess at a shape it does not recognise.
+//
+// This exists so the fields can be json.RawMessage. Typed as *string they made a
+// wider-but-valid shape fail the whole-chunk unmarshal, which dropped the frame
+// and lost the answer.
+func deltaText(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	if json.Unmarshal(raw, &s) == nil {
+		return s
+	}
+	var parts []struct {
+		Text string `json:"text"`
+	}
+	if json.Unmarshal(raw, &parts) != nil {
+		return ""
+	}
+	var b strings.Builder
+	for _, p := range parts {
+		b.WriteString(p.Text)
+	}
+	return b.String()
+}
+
+// deltaTextPtr adapts an output field for the transforms, which still take
+// *string. nil means the member is absent or null — the distinction the old
+// *string fields carried — and a present member yields its extracted text, which
+// may legitimately be "".
+func deltaTextPtr(raw json.RawMessage) *string {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil
+	}
+	s := deltaText(raw)
+	return &s
+}
+
+// argumentsText sizes a tool call's arguments. The spec says a JSON string, and
+// some providers send the object itself; for the object its own JSON is the
+// honest measure of what the model generated.
+func argumentsText(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	if json.Unmarshal(raw, &s) == nil {
+		return s
+	}
+	return string(raw)
+}
+
+// chunkErrorMessage reports the provider's message when a chunk's error member
+// holds one, and ok == false when the member is absent or empty.
+//
+// Shapes accepted deliberately mirror carriesErrorObject, which this package
+// already uses to decide what counts as an error: an object with a message,
+// Ollama's bare string, or any other populated value. null/{}/""/[] leave the
+// caller nothing to read and are not errors.
+func chunkErrorMessage(raw json.RawMessage) (string, bool) {
+	if !carriesErrorMember(raw) {
+		return "", false
+	}
+	var obj struct {
+		Message string `json:"message"`
+	}
+	if json.Unmarshal(raw, &obj) == nil && obj.Message != "" {
+		return obj.Message, true
+	}
+	var bare string
+	if json.Unmarshal(raw, &bare) == nil {
+		return bare, true
+	}
+	return string(raw), true
 }

--- a/internal/proxy/stream_observers.go
+++ b/internal/proxy/stream_observers.go
@@ -158,16 +158,18 @@ func (st *streamState) observeDataChunk(chunk streamChunk, anthropicErrorCounted
 		}
 		for _, raw := range []json.RawMessage{choice.Delta.Content, choice.Delta.ReasoningContent, choice.Delta.Reasoning} {
 			text, readable := deltaText(raw)
-			if !readable {
-				// The frame parsed, but this member is in a shape we cannot
-				// size. Counted as unparsed so the end-of-stream breaker
-				// verdict withholds judgement rather than charging the provider
-				// for an emptiness that is our blind spot, not its silence —
-				// the caller did receive this text.
-				st.unparsedChunks++
+			if readable {
+				st.deliveredBytes += len(text)
 				continue
 			}
-			st.deliveredBytes += len(text)
+			// The frame parsed but this member is in a shape we cannot read.
+			// The caller still RECEIVED it, so the provider delivered: say so,
+			// and size it approximately. Treating this as "delivered nothing"
+			// charged the circuit breaker for a provider answering correctly,
+			// left the retirement verdict reading the model as mute, and
+			// metered a served request at zero.
+			st.sawContent = true
+			st.deliveredBytes += approxOutputBytes(raw)
 		}
 		if rd := choice.Delta.ReasoningDetails; len(rd) > 0 && string(rd) != "null" {
 			st.deliveredBytes += len(rd)
@@ -237,34 +239,79 @@ func deltaText(raw json.RawMessage) (text string, readable bool) {
 	if json.Unmarshal(raw, &s) == nil {
 		return s, true
 	}
-	var parts []struct {
-		Text string `json:"text"`
-	}
+	var parts []map[string]json.RawMessage
 	if json.Unmarshal(raw, &parts) != nil {
 		return "", false
 	}
 	var b strings.Builder
-	for _, p := range parts {
-		b.WriteString(p.Text)
-	}
-	if b.Len() == 0 && len(parts) > 0 {
-		// An array of parts none of which carried a "text" — a provider
-		// spelling this gateway does not know (say {"type":"thinking",
-		// "thinking":"..."}). The caller receives it; we cannot size it.
-		return "", false
+	for _, part := range parts {
+		// EVERY element must be understood, not merely one of them. Accepting
+		// an array because a single member carried "text" let a mixed array —
+		// {"type":"thinking",...} beside {"type":"text",...}, which is exactly
+		// how Anthropic-style content blocks arrive — count as read, and the
+		// reasoning-strip transform then forwarded the whole delta verbatim to
+		// a caller whose key forbids reasoning.
+		textRaw, ok := part["text"]
+		if !ok {
+			return "", false
+		}
+		var text string
+		if json.Unmarshal(textRaw, &text) != nil {
+			return "", false
+		}
+		b.WriteString(text)
 	}
 	return b.String(), true
 }
 
-// deltaTextPtr adapts an output field for the transforms, which still take
-// *string. nil means the member is absent, null, or in a shape this gateway
-// cannot read — in every one of those cases there is no text to hand over.
-func deltaTextPtr(raw json.RawMessage) *string {
-	if len(raw) == 0 || string(raw) == "null" {
-		return nil
+// approxOutputBytes is a bounded stand-in for the size of an output member
+// deltaText could not read: the total length of the strings inside it.
+//
+// The caller received those bytes, so metering the request at zero would let
+// the provider's bill exceed the meter — the drift deliveredBytes exists to
+// prevent. Summing the string leaves overshoots slightly (it counts the
+// provider's own key vocabulary) and that is the safe direction here, where the
+// alternative is charging nothing at all for a served request.
+func approxOutputBytes(raw json.RawMessage) int {
+	var v any
+	if json.Unmarshal(raw, &v) != nil {
+		return 0
 	}
-	s, readable := deltaText(raw)
-	if !readable {
+	var walk func(any) int
+	walk = func(n any) int {
+		switch t := n.(type) {
+		case string:
+			return len(t)
+		case []any:
+			sum := 0
+			for _, e := range t {
+				sum += walk(e)
+			}
+			return sum
+		case map[string]any:
+			sum := 0
+			for _, e := range t {
+				sum += walk(e)
+			}
+			return sum
+		default:
+			return 0
+		}
+	}
+	return walk(v)
+}
+
+// deltaTextPtr adapts an output field for the transforms, which still take
+// *string, and is deliberately EXACTLY what the old *string field was: a plain
+// JSON string, or nil.
+//
+// It must not hand over extracted text. normalizeReasoningChunk patches what it
+// is given back into the delta as a plain string, so feeding it the joined text
+// of a parts array rewrote the array into that string and destroyed every
+// non-text part — an image part vanishing from the caller's answer.
+func deltaTextPtr(raw json.RawMessage) *string {
+	var s string
+	if json.Unmarshal(raw, &s) != nil {
 		return nil
 	}
 	return &s

--- a/internal/proxy/stream_observers.go
+++ b/internal/proxy/stream_observers.go
@@ -156,9 +156,19 @@ func (st *streamState) observeDataChunk(chunk streamChunk, anthropicErrorCounted
 		if choice.Delta == nil {
 			continue
 		}
-		st.deliveredBytes += len(deltaText(choice.Delta.Content))
-		st.deliveredBytes += len(deltaText(choice.Delta.ReasoningContent))
-		st.deliveredBytes += len(deltaText(choice.Delta.Reasoning))
+		for _, raw := range []json.RawMessage{choice.Delta.Content, choice.Delta.ReasoningContent, choice.Delta.Reasoning} {
+			text, readable := deltaText(raw)
+			if !readable {
+				// The frame parsed, but this member is in a shape we cannot
+				// size. Counted as unparsed so the end-of-stream breaker
+				// verdict withholds judgement rather than charging the provider
+				// for an emptiness that is our blind spot, not its silence —
+				// the caller did receive this text.
+				st.unparsedChunks++
+				continue
+			}
+			st.deliveredBytes += len(text)
+		}
 		if rd := choice.Delta.ReasoningDetails; len(rd) > 0 && string(rd) != "null" {
 			st.deliveredBytes += len(rd)
 		}
@@ -170,8 +180,8 @@ func (st *streamState) observeDataChunk(chunk streamChunk, anthropicErrorCounted
 	}
 	if len(chunk.Choices) > 0 && chunk.Choices[0].Delta != nil {
 		delta := chunk.Choices[0].Delta
-		currentContent := deltaText(delta.Content)
-		if rc := deltaText(delta.ReasoningContent); rc != "" && currentContent == "" {
+		currentContent, _ := deltaText(delta.Content)
+		if rc, _ := deltaText(delta.ReasoningContent); rc != "" && currentContent == "" {
 			currentContent = rc
 			if !st.sawThinking {
 				st.sawThinking = true
@@ -218,36 +228,45 @@ func (st *streamState) observeDataChunk(chunk streamChunk, anthropicErrorCounted
 // This exists so the fields can be json.RawMessage. Typed as *string they made a
 // wider-but-valid shape fail the whole-chunk unmarshal, which dropped the frame
 // and lost the answer.
-func deltaText(raw json.RawMessage) string {
-	if len(raw) == 0 {
-		return ""
+func deltaText(raw json.RawMessage) (text string, readable bool) {
+	if len(raw) == 0 || string(raw) == "null" {
+		// Absent. Nothing to read, and nothing unreadable about that.
+		return "", true
 	}
 	var s string
 	if json.Unmarshal(raw, &s) == nil {
-		return s
+		return s, true
 	}
 	var parts []struct {
 		Text string `json:"text"`
 	}
 	if json.Unmarshal(raw, &parts) != nil {
-		return ""
+		return "", false
 	}
 	var b strings.Builder
 	for _, p := range parts {
 		b.WriteString(p.Text)
 	}
-	return b.String()
+	if b.Len() == 0 && len(parts) > 0 {
+		// An array of parts none of which carried a "text" — a provider
+		// spelling this gateway does not know (say {"type":"thinking",
+		// "thinking":"..."}). The caller receives it; we cannot size it.
+		return "", false
+	}
+	return b.String(), true
 }
 
 // deltaTextPtr adapts an output field for the transforms, which still take
-// *string. nil means the member is absent or null — the distinction the old
-// *string fields carried — and a present member yields its extracted text, which
-// may legitimately be "".
+// *string. nil means the member is absent, null, or in a shape this gateway
+// cannot read — in every one of those cases there is no text to hand over.
 func deltaTextPtr(raw json.RawMessage) *string {
 	if len(raw) == 0 || string(raw) == "null" {
 		return nil
 	}
-	s := deltaText(raw)
+	s, readable := deltaText(raw)
+	if !readable {
+		return nil
+	}
 	return &s
 }
 
@@ -286,5 +305,10 @@ func chunkErrorMessage(raw json.RawMessage) (string, bool) {
 	if json.Unmarshal(raw, &bare) == nil {
 		return bare, true
 	}
-	return string(raw), true
+	// Deliberately NOT the raw member. This message is persisted to
+	// request_logs.error_message, and providers routinely echo the offending
+	// input inside content-filter and moderation errors — which would put the
+	// caller's prompt in the log, against the rule that no prompt or response
+	// content is ever logged. Naming the failure is enough.
+	return "provider reported an error with no message", true
 }

--- a/internal/proxy/stream_transforms.go
+++ b/internal/proxy/stream_transforms.go
@@ -1,6 +1,9 @@
 package proxy
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"strings"
+)
 
 // stripReasoningDecision is what computeStripReasoning decided for a chunk.
 type stripReasoningDecision int
@@ -53,8 +56,14 @@ func computeStripReasoning(payload string, lastFinishReason *string, logData *re
 	// Does the delta still carry meaningful data?
 	deltaHasContent := false
 	if cRaw, okC := deltaFields["content"]; okC {
-		var cStr string
-		if json.Unmarshal(cRaw, &cStr) == nil && cStr != "" {
+		// Any non-empty content counts, WHATEVER its shape. Judging only the
+		// plain-string form meant a delta whose content is an array of parts
+		// looked contentless and was rewritten into a keep-alive, taking the
+		// text with it. (The empty-string case was already deleted above; it is
+		// re-checked here so this stays correct if that block moves.)
+		switch strings.TrimSpace(string(cRaw)) {
+		case "null", `""`:
+		default:
 			deltaHasContent = true
 		}
 	}
@@ -138,10 +147,10 @@ func computeFinishReason(chunk streamChunk, payload string, lastFinishReason *st
 		hasContent := false
 		if chunk.Choices[0].Delta != nil {
 			delta := chunk.Choices[0].Delta
-			if delta.Content != nil && *delta.Content != "" {
+			if deltaText(delta.Content) != "" {
 				hasContent = true
 			}
-			if delta.ReasoningContent != nil && *delta.ReasoningContent != "" {
+			if deltaText(delta.ReasoningContent) != "" {
 				hasContent = true
 			}
 		}

--- a/internal/proxy/stream_transforms.go
+++ b/internal/proxy/stream_transforms.go
@@ -1,9 +1,6 @@
 package proxy
 
-import (
-	"encoding/json"
-	"strings"
-)
+import "encoding/json"
 
 // stripReasoningDecision is what computeStripReasoning decided for a chunk.
 type stripReasoningDecision int
@@ -56,14 +53,18 @@ func computeStripReasoning(payload string, lastFinishReason *string, logData *re
 	// Does the delta still carry meaningful data?
 	deltaHasContent := false
 	if cRaw, okC := deltaFields["content"]; okC {
-		// Any non-empty content counts, WHATEVER its shape. Judging only the
+		// Content in ANY shape this gateway can read counts. Judging only the
 		// plain-string form meant a delta whose content is an array of parts
 		// looked contentless and was rewritten into a keep-alive, taking the
-		// text with it. (The empty-string case was already deleted above; it is
-		// re-checked here so this stays correct if that block moves.)
-		switch strings.TrimSpace(string(cRaw)) {
-		case "null", `""`:
-		default:
+		// text with it.
+		//
+		// Content it CANNOT read deliberately does not count, and the frame
+		// becomes a keep-alive. This transform strips the reasoning* keys; it
+		// never looks inside content. A parts array carrying the chain of
+		// thought under a spelling we do not know would otherwise be forwarded
+		// whole to a caller whose key says it must never receive reasoning.
+		// Withholding an unreadable frame is the only safe answer.
+		if text, readable := deltaText(cRaw); readable && text != "" {
 			deltaHasContent = true
 		}
 	}
@@ -147,10 +148,10 @@ func computeFinishReason(chunk streamChunk, payload string, lastFinishReason *st
 		hasContent := false
 		if chunk.Choices[0].Delta != nil {
 			delta := chunk.Choices[0].Delta
-			if deltaText(delta.Content) != "" {
+			if text, _ := deltaText(delta.Content); text != "" {
 				hasContent = true
 			}
-			if deltaText(delta.ReasoningContent) != "" {
+			if text, _ := deltaText(delta.ReasoningContent); text != "" {
 				hasContent = true
 			}
 		}

--- a/internal/proxy/tolerant_chunk_test.go
+++ b/internal/proxy/tolerant_chunk_test.go
@@ -239,11 +239,16 @@ func TestDeltaText(t *testing.T) {
 		// Present, but in a spelling this gateway does not know. Reporting
 		// these as readable-and-empty is what let a stream the caller received
 		// in full be charged to the provider as having delivered nothing.
-		"part without text":   {`[{"type":"image_url"}]`, "", false},
-		"thinking parts":      {`[{"type":"thinking","thinking":"deep"}]`, "", false},
-		"bare string parts":   {`["hello"]`, "", false},
-		"unrecognised object": {`{"weird":"object"}`, "", false},
-		"number":              {`12345`, "", false},
+		"part without text": {`[{"type":"image_url"}]`, "", false},
+		"thinking parts":    {`[{"type":"thinking","thinking":"deep"}]`, "", false},
+		// One understood part does not make the array understood. This is how
+		// Anthropic-style content blocks arrive, and accepting it let the
+		// reasoning-strip transform forward the whole delta verbatim.
+		"mixed known and unknown":   {`[{"type":"thinking","thinking":"secret"},{"type":"text","text":"hi"}]`, "", false},
+		"part with non-string text": {`[{"type":"text","text":{"nested":"x"}}]`, "", false},
+		"bare string parts":         {`["hello"]`, "", false},
+		"unrecognised object":       {`{"weird":"object"}`, "", false},
+		"number":                    {`12345`, "", false},
 	} {
 		t.Run(name, func(t *testing.T) {
 			got, readable := deltaText(json.RawMessage(tc.raw))
@@ -382,6 +387,79 @@ func TestTolerantChunk_FalseErrorMemberIsNotAnError(t *testing.T) {
 
 	_, logData := streamTolerant(t, h,
 		`data: {"choices":[{"index":0,"delta":{"content":"hi"}}],"error":false}`+"\n\ndata: [DONE]\n\n")
+	if logData.state != "completed" {
+		t.Errorf("state = %q, want completed", logData.state)
+	}
+}
+
+// The leak the strict readability rule exists to close: a parts array where one
+// element is understood and another carries the chain of thought under a
+// spelling we do not know. Judging the array readable let the strip transform
+// forward the whole delta verbatim, reasoning and all.
+func TestTolerantChunk_MixedPartsArrayDoesNotLeakReasoning(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandlerIntegration(h)
+
+	const secret = "SECRET-CHAIN-OF-THOUGHT"
+	frame := `{"choices":[{"index":0,"delta":{"content":[{"type":"thinking","thinking":"` + secret + `"},{"type":"text","text":"hi"}]}}]}`
+	w, _ := streamTolerant(t, h, "data: "+frame+"\n\ndata: [DONE]\n\n", func(r *http.Request) *http.Request {
+		return r.WithContext(context.WithValue(r.Context(), ctxkeys.VirtualKeyStripReasoningKey, true))
+	})
+
+	if strings.Contains(w.Body.String(), secret) {
+		t.Errorf("a mixed parts array leaked reasoning to a strip_reasoning caller: %s", w.Body.String())
+	}
+}
+
+// An unreadable member still means the provider DELIVERED: the caller received
+// those bytes. Metering the request at zero would let the provider's bill exceed
+// the meter, and reading it as "produced nothing" would tell the retirement
+// verdict the model never answers.
+func TestTolerantChunk_UnreadableOutputIsStillDelivery(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandlerIntegration(h)
+	logs := captureProxyLogs(t)
+
+	frame := `{"choices":[{"index":0,"delta":{"content":[{"type":"thinking","thinking":"deep thought"}]}}]}`
+	w, logData := streamTolerant(t, h, "data: "+frame+"\n\ndata: [DONE]\n\n")
+
+	if !strings.Contains(w.Body.String(), "deep thought") {
+		t.Fatalf("test assumption broken: the frame must be delivered, got %s", w.Body.String())
+	}
+	if !logData.deliveredContent {
+		t.Error("deliveredContent = false: the retirement verdict would read a served stream as mute")
+	}
+	est := logs.find("charging estimated tokens")
+	if len(est) == 0 {
+		t.Fatal("a delivered stream with no usage chunk must be estimated, not metered at zero")
+	}
+	if got := est[0].attrs["delivered_bytes"]; got == "0" || got == "" {
+		t.Errorf("delivered_bytes = %q, want > 0", got)
+	}
+}
+
+// normalizeReasoningChunk patches what it is handed back into the delta as a
+// plain string. Handing it the joined text of a parts array rewrote the array
+// into that string and destroyed every non-text part.
+func TestTolerantChunk_ReasoningNormalizeKeepsNonTextParts(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandlerIntegration(h)
+
+	frame := `{"choices":[{"index":0,"delta":{"content":[{"type":"text","text":"hi"},{"type":"image_url","image_url":{"url":"data:image/png;base64,AAA"}}],"reasoning":"think"}}]}`
+	w, _ := streamTolerant(t, h, "data: "+frame+"\n\ndata: [DONE]\n\n")
+
+	if !strings.Contains(w.Body.String(), "image_url") {
+		t.Errorf("a non-text content part was destroyed by reasoning normalization: %s", w.Body.String())
+	}
+}
+
+// "error": 0 is the numeric form of the no-error idiom.
+func TestTolerantChunk_ZeroErrorMemberIsNotAnError(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandlerIntegration(h)
+
+	_, logData := streamTolerant(t, h,
+		`data: {"choices":[{"index":0,"delta":{"content":"hi"}}],"error":0}`+"\n\ndata: [DONE]\n\n")
 	if logData.state != "completed" {
 		t.Errorf("state = %q, want completed", logData.state)
 	}

--- a/internal/proxy/tolerant_chunk_test.go
+++ b/internal/proxy/tolerant_chunk_test.go
@@ -1,0 +1,284 @@
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/hugalafutro/model-hotel/internal/ctxkeys"
+	"github.com/hugalafutro/model-hotel/internal/failover"
+)
+
+// ---------------------------------------------------------------------------
+// streamChunk used to type delta.content as *string and tool-call arguments as
+// string. A provider sending either in a wider — but perfectly valid — shape
+// failed the whole-chunk unmarshal, and the frame was discarded as though the
+// bytes were corrupt.
+//
+// The tool-call case was the sharp one: finish_reason rides a SEPARATE frame
+// that parses fine, so it survived. The caller received a completion announcing
+// a tool call with no tool call in it.
+//
+// Widening the fields, rather than routing around the parser, is what makes the
+// rest of this correct for free: the frame now takes the ordinary path, so
+// masking, strip_reasoning, delivery accounting, the circuit-breaker verdict and
+// the retirement verdict all apply to it exactly as they do to any other frame.
+// ---------------------------------------------------------------------------
+
+func streamTolerant(t *testing.T, h *Handler, body string, opts ...func(*http.Request) *http.Request) (*httptest.ResponseRecorder, *requestLogData) {
+	t.Helper()
+	logData := streamingLog()
+	logData.providerName = "wide-shape-provider"
+	h.insertRequestLogAsync(logData)
+
+	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body))}
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)
+	for _, o := range opts {
+		req = o(req)
+	}
+	h.handleStreamingResponse(w, req, logData, resp, time.Now(), streamOptions{
+		responseHeaderMs: 10,
+		providerID:       uuid.New(),
+		providerName:     "wide-shape-provider",
+		vkHash:           "test-hash",
+		attempt:          1,
+	})
+	return w, logData
+}
+
+func TestTolerantChunk_WiderShapesReachTheCaller(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandlerIntegration(h)
+
+	tests := map[string]struct{ frame, want string }{
+		"tool arguments as an object": {
+			`{"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"c1","type":"function","function":{"name":"get_weather","arguments":{"city":"Prague"}}}]}}]}`,
+			"get_weather",
+		},
+		"content as parts": {
+			`{"choices":[{"index":0,"delta":{"content":[{"type":"text","text":"hello"}]}}]}`,
+			"hello",
+		},
+		"reasoning content as parts": {
+			`{"choices":[{"index":0,"delta":{"reasoning_content":[{"type":"text","text":"thinking"}]}}]}`,
+			"thinking",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			w, _ := streamTolerant(t, h, "data: "+tc.frame+"\n\ndata: [DONE]\n\n")
+			if !strings.Contains(w.Body.String(), tc.want) {
+				t.Errorf("the provider's answer must reach the caller.\n got: %s\nwant it to contain: %s", w.Body.String(), tc.want)
+			}
+		})
+	}
+}
+
+// The whole reason this shape mattered: the tool call vanished while the
+// finish_reason announcing it survived, because they ride different frames.
+func TestTolerantChunk_ToolCallAndItsFinishReasonArriveTogether(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandlerIntegration(h)
+
+	body := `data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"c1","type":"function","function":{"name":"get_weather","arguments":{"city":"Prague"}}}]}}]}` + "\n\n" +
+		`data: {"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}` + "\n\ndata: [DONE]\n\n"
+	w, _ := streamTolerant(t, h, body)
+
+	out := w.Body.String()
+	if strings.Contains(out, "tool_calls") && !strings.Contains(out, "get_weather") {
+		t.Errorf("the caller was told a tool call happened but never received it: %s", out)
+	}
+}
+
+// Delivery accounting must size the model's OUTPUT, not the JSON around it.
+// deliveredBytes feeds estimateMissingUsage, which charges quota and TPM, so an
+// envelope-sized count silently over-bills the caller.
+func TestTolerantChunk_MetersTheTextNotTheEnvelope(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandlerIntegration(h)
+
+	// Same five characters of output, spelled two ways. The parts form is a
+	// far bigger frame; the metered figure must not notice.
+	asString := `{"choices":[{"index":0,"delta":{"content":"hello"}}]}`
+	asParts := `{"choices":[{"index":0,"delta":{"content":[{"type":"text","text":"hello"}]}}]}`
+
+	measure := func(frame string) string {
+		logs := captureProxyLogs(t)
+		streamTolerant(t, h, "data: "+frame+"\n\ndata: [DONE]\n\n")
+		est := logs.find("charging estimated tokens")
+		if len(est) == 0 {
+			t.Fatalf("expected an estimate for a stream with no usage chunk, frame %s", frame)
+		}
+		return est[0].attrs["delivered_bytes"]
+	}
+	gotString, gotParts := measure(asString), measure(asParts)
+	if gotString != "5" {
+		t.Errorf("string form metered %s bytes, want 5", gotString)
+	}
+	if gotParts != gotString {
+		t.Errorf("parts form metered %s bytes and the string form %s: the same output must cost the same",
+			gotParts, gotString)
+	}
+}
+
+// strip_reasoning is a per-virtual-key contract. Because the frame now takes the
+// ordinary path, the transform applies to it with no special handling at all.
+func TestTolerantChunk_StripReasoningAppliesToWiderShapes(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandlerIntegration(h)
+
+	const secret = "SECRET-CHAIN-OF-THOUGHT"
+	frame := `{"choices":[{"index":0,"delta":{"reasoning_content":"` + secret + `","content":[{"type":"text","text":"hi"}]}}]}`
+	w, _ := streamTolerant(t, h, "data: "+frame+"\n\ndata: [DONE]\n\n", func(r *http.Request) *http.Request {
+		return r.WithContext(context.WithValue(r.Context(), ctxkeys.VirtualKeyStripReasoningKey, true))
+	})
+
+	out := w.Body.String()
+	if strings.Contains(out, secret) {
+		t.Errorf("reasoning reached a caller that asked for it to be stripped: %s", out)
+	}
+	if !strings.Contains(out, "hi") {
+		t.Errorf("stripping reasoning must not take the content with it: %s", out)
+	}
+}
+
+// Ollama answers with a bare {"error":"model not found"}. That failed the
+// unmarshal into an object and took the whole frame down with it, so the client
+// saw nothing and the request log recorded a clean completion. Now the error is
+// recognised and the two agree.
+func TestTolerantChunk_BareStringErrorIsRecognised(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandlerIntegration(h)
+
+	_, logData := streamTolerant(t, h, `data: {"error":"model not found"}`+"\n\ndata: [DONE]\n\n")
+
+	if logData.state != "failed" {
+		t.Errorf("state = %q, want failed: the provider reported an error", logData.state)
+	}
+	if !strings.Contains(logData.errorMessage, "model not found") {
+		t.Errorf("error_message = %q, want the provider's message", logData.errorMessage)
+	}
+}
+
+// A stream that really delivers must still record a breaker success and read as
+// served, whatever shape it used. Both verdicts read signals the observers set,
+// which is precisely what the old narrow struct denied them.
+func TestTolerantChunk_WiderShapesCountAsDelivery(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandlerIntegration(h)
+	withBreakerThresholdOne(t, h)
+
+	providerID := uuid.New()
+	logData := streamingLog()
+	logData.providerName = "wide-shape-provider"
+	h.insertRequestLogAsync(logData)
+
+	frame := `{"choices":[{"index":0,"delta":{"content":[{"type":"text","text":"hello"}]}}]}`
+	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("data: " + frame + "\n\ndata: [DONE]\n\n"))}
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)
+	h.handleStreamingResponse(w, req, logData, resp, time.Now(), streamOptions{
+		responseHeaderMs: 10, providerID: providerID, providerName: "wide-shape-provider",
+		circuitBreakerOn: true, vkHash: "test-hash", attempt: 1,
+	})
+
+	if got := h.circuitBreaker.GetState(providerID); got == failover.StateOpen {
+		t.Errorf("circuit = %s: a stream that delivered must not be charged", got)
+	}
+	if !logData.deliveredContent {
+		t.Error("deliveredContent = false: the retirement verdict would read a served stream as inconclusive")
+	}
+}
+
+// The original protection survives: bytes that are not JSON are still dropped
+// rather than relayed as broken frames.
+func TestTolerantChunk_MalformedBytesStillDropped(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandlerIntegration(h)
+
+	for name, frame := range map[string]string{
+		"truncated object": `{"choices":[{"delta":{"content":`,
+		"not json at all":  `<html>502 Bad Gateway</html>`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			w, _ := streamTolerant(t, h, "data: "+frame+"\n\ndata: [DONE]\n\n")
+			if strings.Contains(w.Body.String(), frame) {
+				t.Errorf("malformed bytes must not be relayed, got: %s", w.Body.String())
+			}
+		})
+	}
+}
+
+func TestDeltaText(t *testing.T) {
+	for name, tc := range map[string]struct {
+		raw  string
+		want string
+	}{
+		"plain string":      {`"hello"`, "hello"},
+		"empty string":      {`""`, ""},
+		"single part":       {`[{"type":"text","text":"hello"}]`, "hello"},
+		"several parts":     {`[{"type":"text","text":"a"},{"type":"text","text":"b"}]`, "ab"},
+		"part without text": {`[{"type":"image_url"}]`, ""},
+		"absent":            {``, ""},
+		"null":              {`null`, ""},
+		"unrecognised":      {`{"weird":"object"}`, ""},
+		"number":            {`12345`, ""},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := deltaText(json.RawMessage(tc.raw)); got != tc.want {
+				t.Errorf("deltaText(%s) = %q, want %q", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestArgumentsText(t *testing.T) {
+	for name, tc := range map[string]struct {
+		raw  string
+		want string
+	}{
+		"spec form, a JSON string": {`"{\"city\":\"Prague\"}"`, `{"city":"Prague"}`},
+		"object form":              {`{"city":"Prague"}`, `{"city":"Prague"}`},
+		"absent":                   {``, ""},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := argumentsText(json.RawMessage(tc.raw)); got != tc.want {
+				t.Errorf("argumentsText(%s) = %q, want %q", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestChunkErrorMessage(t *testing.T) {
+	for name, tc := range map[string]struct {
+		raw   string
+		msg   string
+		isErr bool
+	}{
+		"object with a message": {`{"message":"boom"}`, "boom", true},
+		"ollama bare string":    {`"model not found"`, "model not found", true},
+		"object without one":    {`{"code":500}`, `{"code":500}`, true},
+		"absent":                {``, "", false},
+		"null":                  {`null`, "", false},
+		"empty object":          {`{}`, "", false},
+		"empty string":          {`""`, "", false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			msg, isErr := chunkErrorMessage(json.RawMessage(tc.raw))
+			if isErr != tc.isErr {
+				t.Fatalf("isErr = %v, want %v", isErr, tc.isErr)
+			}
+			if msg != tc.msg {
+				t.Errorf("msg = %q, want %q", msg, tc.msg)
+			}
+		})
+	}
+}

--- a/internal/proxy/tolerant_chunk_test.go
+++ b/internal/proxy/tolerant_chunk_test.go
@@ -158,8 +158,14 @@ func TestTolerantChunk_BareStringErrorIsRecognised(t *testing.T) {
 	h := newIntegrationHandler()
 	defer stopUnitHandlerIntegration(h)
 
-	_, logData := streamTolerant(t, h, `data: {"error":"model not found"}`+"\n\ndata: [DONE]\n\n")
+	w, logData := streamTolerant(t, h, `data: {"error":"model not found"}`+"\n\ndata: [DONE]\n\n")
 
+	// The client half is the actual change. Master already recorded this as a
+	// failure via captureSSEError's accumulator, but forwarded only [DONE], so
+	// the caller was left with an empty success while the log said otherwise.
+	if !strings.Contains(w.Body.String(), "model not found") {
+		t.Errorf("the caller must be told what the provider said, got: %s", w.Body.String())
+	}
 	if logData.state != "failed" {
 		t.Errorf("state = %q, want failed: the provider reported an error", logData.state)
 	}
@@ -219,22 +225,33 @@ func TestTolerantChunk_MalformedBytesStillDropped(t *testing.T) {
 
 func TestDeltaText(t *testing.T) {
 	for name, tc := range map[string]struct {
-		raw  string
-		want string
+		raw      string
+		want     string
+		readable bool
 	}{
-		"plain string":      {`"hello"`, "hello"},
-		"empty string":      {`""`, ""},
-		"single part":       {`[{"type":"text","text":"hello"}]`, "hello"},
-		"several parts":     {`[{"type":"text","text":"a"},{"type":"text","text":"b"}]`, "ab"},
-		"part without text": {`[{"type":"image_url"}]`, ""},
-		"absent":            {``, ""},
-		"null":              {`null`, ""},
-		"unrecognised":      {`{"weird":"object"}`, ""},
-		"number":            {`12345`, ""},
+		"plain string":  {`"hello"`, "hello", true},
+		"empty string":  {`""`, "", true},
+		"single part":   {`[{"type":"text","text":"hello"}]`, "hello", true},
+		"several parts": {`[{"type":"text","text":"a"},{"type":"text","text":"b"}]`, "ab", true},
+		"empty array":   {`[]`, "", true},
+		"absent":        {``, "", true},
+		"null":          {`null`, "", true},
+		// Present, but in a spelling this gateway does not know. Reporting
+		// these as readable-and-empty is what let a stream the caller received
+		// in full be charged to the provider as having delivered nothing.
+		"part without text":   {`[{"type":"image_url"}]`, "", false},
+		"thinking parts":      {`[{"type":"thinking","thinking":"deep"}]`, "", false},
+		"bare string parts":   {`["hello"]`, "", false},
+		"unrecognised object": {`{"weird":"object"}`, "", false},
+		"number":              {`12345`, "", false},
 	} {
 		t.Run(name, func(t *testing.T) {
-			if got := deltaText(json.RawMessage(tc.raw)); got != tc.want {
+			got, readable := deltaText(json.RawMessage(tc.raw))
+			if got != tc.want {
 				t.Errorf("deltaText(%s) = %q, want %q", tc.raw, got, tc.want)
+			}
+			if readable != tc.readable {
+				t.Errorf("deltaText(%s) readable = %v, want %v", tc.raw, readable, tc.readable)
 			}
 		})
 	}
@@ -265,11 +282,14 @@ func TestChunkErrorMessage(t *testing.T) {
 	}{
 		"object with a message": {`{"message":"boom"}`, "boom", true},
 		"ollama bare string":    {`"model not found"`, "model not found", true},
-		"object without one":    {`{"code":500}`, `{"code":500}`, true},
-		"absent":                {``, "", false},
-		"null":                  {`null`, "", false},
-		"empty object":          {`{}`, "", false},
-		"empty string":          {`""`, "", false},
+		// NOT the raw member: this text is persisted to the request log, and
+		// providers echo the offending input inside content-filter errors.
+		"object without one": {`{"code":500}`, "provider reported an error with no message", true},
+		"boolean false":      {`false`, "", false},
+		"absent":             {``, "", false},
+		"null":               {`null`, "", false},
+		"empty object":       {`{}`, "", false},
+		"empty string":       {`""`, "", false},
 	} {
 		t.Run(name, func(t *testing.T) {
 			msg, isErr := chunkErrorMessage(json.RawMessage(tc.raw))
@@ -280,5 +300,89 @@ func TestChunkErrorMessage(t *testing.T) {
 				t.Errorf("msg = %q, want %q", msg, tc.msg)
 			}
 		})
+	}
+}
+
+// A content shape this gateway cannot read is still delivered to the caller —
+// but it must not be counted as the provider delivering NOTHING. The frame now
+// parses, so the "our parser could not read it" escape hatch has to be raised
+// deliberately, or a provider answering every request correctly accrues a
+// breaker failure every time and leaves rotation for all tenants after five.
+func TestTolerantChunk_UnreadableContentWithholdsTheBreakerVerdict(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandlerIntegration(h)
+	withBreakerThresholdOne(t, h)
+
+	providerID := uuid.New()
+	logData := streamingLog()
+	logData.providerName = "unknown-shape-provider"
+	h.insertRequestLogAsync(logData)
+
+	// Parts carrying their text under a spelling we do not know.
+	frame := `{"choices":[{"index":0,"delta":{"content":[{"type":"thinking","thinking":"deep"}]}}]}`
+	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("data: " + frame + "\n\ndata: [DONE]\n\n"))}
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)
+	h.handleStreamingResponse(w, req, logData, resp, time.Now(), streamOptions{
+		responseHeaderMs: 10, providerID: providerID, providerName: "unknown-shape-provider",
+		circuitBreakerOn: true, vkHash: "test-hash", attempt: 1,
+	})
+
+	if !strings.Contains(w.Body.String(), "deep") {
+		t.Fatalf("test assumption broken: the frame must be delivered, got %s", w.Body.String())
+	}
+	if got := h.circuitBreaker.GetState(providerID); got == failover.StateOpen {
+		t.Error("a provider whose answer we could not size must not be charged for delivering nothing")
+	}
+}
+
+// strip_reasoning is a per-key contract, and the strip transform deletes the
+// reasoning* KEYS — it never looks inside content. A parts array carrying the
+// chain of thought under an unknown spelling must therefore be withheld, not
+// forwarded on the assumption that content is safe.
+func TestTolerantChunk_StripWithholdsContentItCannotInspect(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandlerIntegration(h)
+
+	const secret = "SECRET-CHAIN-OF-THOUGHT"
+	frame := `{"choices":[{"index":0,"delta":{"content":[{"type":"thinking","thinking":"` + secret + `"}]}}]}`
+	w, _ := streamTolerant(t, h, "data: "+frame+"\n\ndata: [DONE]\n\n", func(r *http.Request) *http.Request {
+		return r.WithContext(context.WithValue(r.Context(), ctxkeys.VirtualKeyStripReasoningKey, true))
+	})
+
+	if strings.Contains(w.Body.String(), secret) {
+		t.Errorf("content the gateway cannot inspect was forwarded to a strip_reasoning caller: %s", w.Body.String())
+	}
+}
+
+// Error is json.RawMessage now, so a present-but-null member is non-nil. A
+// gateway that stamps "error": null on every chunk would otherwise have the
+// key-shape regex run over the model's answer, silently mangling text that
+// merely looks like a key.
+func TestTolerantChunk_NullErrorMemberDoesNotMangleContent(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandlerIntegration(h)
+
+	const looksLikeAKey = "try sk-abcdef1234567890abcdef"
+	frame := `{"choices":[{"index":0,"delta":{"content":"` + looksLikeAKey + `"}}],"error":null}`
+	w, logData := streamTolerant(t, h, "data: "+frame+"\n\ndata: [DONE]\n\n")
+
+	if !strings.Contains(w.Body.String(), looksLikeAKey) {
+		t.Errorf("the model's answer was mangled by the key-shape mask: %s", w.Body.String())
+	}
+	if logData.state != "completed" {
+		t.Errorf("state = %q, want completed: \"error\": null is not an error", logData.state)
+	}
+}
+
+// "error": false is how several OpenAI-compatible gateways spell "no error".
+func TestTolerantChunk_FalseErrorMemberIsNotAnError(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandlerIntegration(h)
+
+	_, logData := streamTolerant(t, h,
+		`data: {"choices":[{"index":0,"delta":{"content":"hi"}}],"error":false}`+"\n\ndata: [DONE]\n\n")
+	if logData.state != "completed" {
+		t.Errorf("state = %q, want completed", logData.state)
 	}
 }

--- a/internal/proxy/upstream_error_forward.go
+++ b/internal/proxy/upstream_error_forward.go
@@ -337,9 +337,11 @@ func carriesErrorMember(raw json.RawMessage) bool {
 		// "error": false is how several OpenAI-compatible gateways spell "no
 		// error". Reading it as one marks a perfectly good stream failed.
 		return v
+	case float64:
+		// Same idiom in numeric form: 0 means no error, anything else is a code.
+		return v != 0
 	default:
-		// A number: peculiar, but the provider put a value there and a client
-		// can render it.
+		// Peculiar, but the provider put a value there and a client can render it.
 		return true
 	}
 }

--- a/internal/proxy/upstream_error_forward.go
+++ b/internal/proxy/upstream_error_forward.go
@@ -333,9 +333,13 @@ func carriesErrorMember(raw json.RawMessage) bool {
 		return len(v) > 0
 	case []any:
 		return len(v) > 0
+	case bool:
+		// "error": false is how several OpenAI-compatible gateways spell "no
+		// error". Reading it as one marks a perfectly good stream failed.
+		return v
 	default:
-		// A number or a bool: peculiar, but the provider put a value there and
-		// a client can render it.
+		// A number: peculiar, but the provider put a value there and a client
+		// can render it.
 		return true
 	}
 }

--- a/internal/proxy/upstream_error_forward.go
+++ b/internal/proxy/upstream_error_forward.go
@@ -312,6 +312,14 @@ func carriesErrorObject(body []byte) bool {
 	if !present {
 		return false
 	}
+	return carriesErrorMember(raw)
+}
+
+// carriesErrorMember is the same judgement applied to an already-extracted
+// "error" value, for callers that hold the member rather than the whole body
+// (the SSE observers, which have it off a parsed chunk). One definition of what
+// counts as an error, so the two cannot drift.
+func carriesErrorMember(raw json.RawMessage) bool {
 	var content any
 	if err := json.Unmarshal(raw, &content); err != nil {
 		return false


### PR DESCRIPTION
Replaces #806, which took the wrong approach. Same bug, much smaller change.

## The bug

Every SSE `data:` payload is unmarshalled into `streamChunk`, and a frame that failed was dropped. But the struct typed `delta.content` as `*string`, tool-call `arguments` as `string`, and the error member as an object — so a provider sending any of them in a **wider but perfectly valid** shape had its answer discarded as though the bytes were corrupt.

The tool-call case is the sharp one, because the loss isn't uniform: `finish_reason` rides a *separate* frame that parses fine, so it survives. Reproduced against the dev stack before the fix:

```
UPSTREAM SENDS:
  data: {...function:{"name":"get_weather","arguments":{"city":"Prague"}}}
  data: {...finish_reason:"tool_calls"}

CLIENT RECEIVES:
  data: {...finish_reason:"tool_calls"}
  data: [DONE]
```

A completion announcing a tool call with no tool call in it. Ollama's bare `{"error":"model not found"}` failed the same way, so the client saw nothing while the request log recorded a clean completion.

## The fix

The output- and error-bearing fields become `json.RawMessage`, read through `deltaText` / `argumentsText` / `chunkErrorMessage`.

That is the whole change. These frames now take the **ordinary path**, so masking, `strip_reasoning`, delivery accounting, the circuit-breaker verdict and the retirement verdict apply to them with no special handling — correct by construction rather than re-derived.

`deltaHasContent` no longer judges only the plain-string form of `content`, which otherwise rewrote a content-as-parts delta into a keep-alive and lost the text on the strip path. `carriesErrorObject`'s judgement is factored into `carriesErrorMember` so the observers, which hold the extracted member rather than the whole body, share one definition of what counts as an error.

**The existing suite passes unchanged**, which is the point: for shapes that already parsed, nothing is different.

## Why not #806's approach

#806 forwarded these frames *around* the typed parser. That meant hand-deriving everything the typed path feeds, and two review rounds found a different one of those broken each time — metering over-charged 8×, a failing provider escaped its circuit-breaker charge, reasoning leaked past a per-key strip contract, and a served stream still read as inconclusive to retirement. Each fix was another hand-derivation of work the typed path already does exactly. Widening the struct removes the second path instead of trying to keep it in step.

It also reaches cases the bypass could not: output living in `choices[1..n]`, which `observeDataChunk` already loops over.

## Telling readable output from output we cannot size

Widening the fields is not enough on its own, and two review rounds found why.

**Every part must be understood, not merely one of them.** `deltaText` called a parts array readable as soon as one element carried `"text"`, so a mixed array — `{"type":"thinking"}` beside `{"type":"text"}`, which is how Anthropic-style content blocks arrive — counted as read, and the reasoning-strip transform forwarded the whole delta verbatim to a caller whose key forbids reasoning.

**Unreadable output is still output.** An unreadable member was treated as "the provider may have delivered nothing". The caller *received* those bytes, so the provider delivered — saying otherwise metered a served request at zero while the provider billed for it, and told the retirement verdict the model never answers. `approxOutputBytes` sizes it by the strings inside; over-counting slightly is the safe direction when the alternative is charging nothing for a served request.

**`deltaTextPtr` is exactly what the `*string` field was** — a plain JSON string or nil. It had been handing `normalizeReasoningChunk` the *joined text* of a parts array, which the transform patched back as a plain string, destroying every non-text part: an image part vanishing from the caller's answer.

**`promptTextBytes` keeps its own extraction.** Sharing `deltaText` was wrong: it deliberately *skips* parts it does not recognise, because a vision request's base64 media must not be sized, while `deltaText` has to report failure to understand. They look alike and answer different questions.

`"error": null` was triggering the key-shape mask — `Error` is `RawMessage` now, so a present-but-null member is non-nil, and a gateway that stamps it on every chunk had the redaction regex run over the model's answer. `"error": false` and `"error": 0`, which several gateways use to mean *no* error, no longer mark a delivering stream failed. And an error member with no `message` is **named** rather than rendered raw, on both the observer and the probe path, because that string is persisted to `request_logs.error_message` and providers echo the offending input inside content-filter errors.

## Verification

Live against a rebuilt dev stack, one fake upstream per shape:

| upstream shape | result |
|---|---|
| tool `arguments` as an object | tool call **and** its `finish_reason` both delivered |
| `content` as an array of parts | delivered |
| `reasoning_content` as parts | delivered |
| Ollama bare-string error | 502, `error_kind=provider_error` — recognised instead of silently swallowed |
| spec-correct string content | unchanged |
| malformed bytes, then a good frame | garbage dropped, the good frame delivered |

No circuit-breaker transitions for any of the delivering providers.

Metering exactness is covered by unit test rather than live: the estimate charges quota and TPM but is deliberately never written to the request-log row, and the dev stack's stdout logging was dropping the INFO line that carries it. `TestTolerantChunk_MetersTheTextNotTheEnvelope` pins that the same five characters of output cost the same whether sent as a string or as parts, and fails if the extraction is removed.

Mutation-tested throughout: narrowing `deltaText` back to strings fails 5 tests and making it report everything readable fails 7; `argumentsText` rejecting the object form fails its table; `chunkErrorMessage` rejecting bare strings fails 2 and rendering the raw member fails 4; the mask on a raw nil check leaks a mangled answer; `deltaHasContent` trusting unreadable content leaks the chain of thought.

A differential harness over 48 SSE bodies confirmed that every shape which already parsed — plain string, empty, null, reasoning-only, spec-form tool calls, usage chunks, finish-reason normalisation and suppression, the empty-content strip, multi-choice, and all five `strip_reasoning` variants — is byte-identical to master, metering included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
