### PR TITLE
fix(proxy): accept a tool call whose arguments are an object

### DIFF
--- a/internal/anthropic/openai_types.go
+++ b/internal/anthropic/openai_types.go
@@ -1,5 +1,7 @@
 package anthropic
 
+import "github.com/hugalafutro/model-hotel/internal/util"
+
 // This file defines the minimal subset of the OpenAI chat-completions wire
 // format the translators consume. We deliberately do not import the proxy
 // package's own chunk types: the dependency runs proxy -> anthropic, never the
@@ -37,8 +39,12 @@ type OAToolCallDelta struct {
 // OAFunctionDelta carries the function name and a fragment of the arguments
 // JSON string.
 type OAFunctionDelta struct {
-	Name      string `json:"name"`
-	Arguments string `json:"arguments"`
+	Name string `json:"name"`
+	// See util.ToolArguments. A plain string here dropped an object-form tool
+	// call from the translated stream, leaving the Anthropic client a
+	// message_delta with stop_reason "tool_use" and no tool_use content block
+	// at all — a shape the Anthropic SDKs reject.
+	Arguments util.ToolArguments `json:"arguments"`
 }
 
 // OAUsage is the OpenAI usage block. Only the token counts matter for the

--- a/internal/anthropic/response.go
+++ b/internal/anthropic/response.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/hugalafutro/model-hotel/internal/jsonfault"
+	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
 // --- Incoming OpenAI non-streaming response shape ---
@@ -64,8 +65,8 @@ type oaiRespToolCall struct {
 	ID       string `json:"id"`
 	Type     string `json:"type"`
 	Function struct {
-		Name      string `json:"name"`
-		Arguments string `json:"arguments"`
+		Name      string             `json:"name"`
+		Arguments util.ToolArguments `json:"arguments"`
 	} `json:"function"`
 }
 

--- a/internal/anthropic/response_test.go
+++ b/internal/anthropic/response_test.go
@@ -218,3 +218,48 @@ func TestBuildMessageResponse_DecodeErrorOmitsPayload(t *testing.T) {
 		})
 	}
 }
+
+// BuildMessageResponse must read a tool call whose arguments the upstream sent
+// as an object. It is defence in depth rather than a live path today — the
+// writer only ever sees bytes the proxy already normalised — but the field was
+// the last one in the repo still typed as a plain string, and an untyped field
+// with no test is how "today" stops being true.
+func TestBuildMessageResponse_ObjectFormToolArguments(t *testing.T) {
+	body := []byte(`{"id":"x","object":"chat.completion","choices":[{"index":0,"finish_reason":"tool_calls","message":{"role":"assistant","tool_calls":[{"id":"c1","type":"function","function":{"name":"get_weather","arguments":{"city":"Prague"}}}]}}]}`)
+
+	out, err := BuildMessageResponse(body, "msg_1", "claude-sonnet-4-6")
+	if err != nil {
+		t.Fatalf("an object-form tool call must decode: %v", err)
+	}
+
+	var msg struct {
+		StopReason string `json:"stop_reason"`
+		Content    []struct {
+			Type  string          `json:"type"`
+			Name  string          `json:"name"`
+			Input json.RawMessage `json:"input"`
+		} `json:"content"`
+	}
+	if err := json.Unmarshal(out, &msg); err != nil {
+		t.Fatalf("decode built message: %v", err)
+	}
+	if msg.StopReason != "tool_use" {
+		t.Errorf("stop_reason = %q, want tool_use", msg.StopReason)
+	}
+	var found bool
+	for _, b := range msg.Content {
+		if b.Type != "tool_use" {
+			continue
+		}
+		found = true
+		if b.Name != "get_weather" {
+			t.Errorf("tool name = %q, want get_weather", b.Name)
+		}
+		if string(b.Input) != `{"city":"Prague"}` {
+			t.Errorf("tool input = %s, want the arguments object", b.Input)
+		}
+	}
+	if !found {
+		t.Error("no tool_use block: stop_reason tool_use without one is a protocol violation")
+	}
+}

--- a/internal/anthropic/stream.go
+++ b/internal/anthropic/stream.go
@@ -214,7 +214,7 @@ func (t *StreamTranslator) Translate(chunk OAStreamChunk) ([]byte, error) {
 			if err := writeEvent(&buf, "content_block_delta", contentBlockDeltaEvent{
 				Type:  "content_block_delta",
 				Index: blockIdx,
-				Delta: contentDelta{Type: "input_json_delta", PartialJSON: tc.Function.Arguments},
+				Delta: contentDelta{Type: "input_json_delta", PartialJSON: string(tc.Function.Arguments)},
 			}); err != nil {
 				return nil, err
 			}

--- a/internal/anthropic/stream_test.go
+++ b/internal/anthropic/stream_test.go
@@ -2,6 +2,7 @@ package anthropic
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"net/http"
 	"strings"
@@ -186,4 +187,44 @@ func TestStreamTranslator_EmptyCompletion_WellFormed(t *testing.T) {
 	if last != "message_stop" {
 		t.Errorf("last event = %q, want message_stop", last)
 	}
+}
+
+// An object-form tool call must survive the translation to the Anthropic wire
+// format. The OA types are decoded from the upstream JSON, and a plain-string
+// Arguments field failed that decode — so the chunk was skipped and the client
+// received a message_delta with stop_reason "tool_use" and no tool_use content
+// block at all, which the Anthropic SDKs reject.
+//
+// Decoded from JSON rather than built as Go values on purpose: the bug lived in
+// the unmarshal, so constructing OAStreamChunk directly would test nothing.
+func TestStreamTranslator_ObjectFormToolArgumentsSurvive(t *testing.T) {
+	raw := []string{
+		`{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_abc","type":"function","function":{"name":"get_weather","arguments":{"city":"Prague"}}}]}}]}`,
+		`{"choices":[{"delta":{},"finish_reason":"tool_calls"}]}`,
+	}
+	chunks := make([]OAStreamChunk, 0, len(raw))
+	for _, r := range raw {
+		var c OAStreamChunk
+		if err := json.Unmarshal([]byte(r), &c); err != nil {
+			t.Fatalf("an object-form tool call must decode: %v", err)
+		}
+		chunks = append(chunks, c)
+	}
+
+	got := decodeWithSDK(t, runTranslator(t, tr(t), chunks))
+
+	if got.stopReason != "tool_use" {
+		t.Errorf("stop_reason = %q, want tool_use", got.stopReason)
+	}
+	if name := got.toolNameByIx[0]; name != "get_weather" {
+		t.Errorf("tool name = %q, want get_weather: stop_reason tool_use with no tool_use block is a protocol violation", name)
+	}
+	if args := got.toolJSONByIx[0]; args != `{"city":"Prague"}` {
+		t.Errorf("tool input = %q, want the arguments object", args)
+	}
+}
+
+func tr(t *testing.T) *StreamTranslator {
+	t.Helper()
+	return NewStreamTranslator("msg_obj_args", "claude-sonnet-4-6")
 }

--- a/internal/proxy/proxy_stream_response.go
+++ b/internal/proxy/proxy_stream_response.go
@@ -477,10 +477,22 @@ func (h *Handler) handleDataChunk(sink *streamSink, st *streamState, ev sseEvent
 // whether anything changed. The spec form is left untouched, so an ordinary
 // frame is neither reparsed nor re-emitted.
 //
+// A JSON null counts as already-fine and is forwarded as-is: every request
+// decoder reads null into a string without complaint, and rewriting it to ""
+// would invent an empty-arguments call the provider did not send.
+//
 // It works on the raw map rather than the typed chunk because the frame is
 // forwarded as bytes: rebuilding it from streamChunk would drop every field
 // this gateway does not model.
 func normalizeToolArguments(payload string) (string, bool) {
+	// Cheap reject first. Without it every frame of every stream paid for three
+	// json.Unmarshal calls (~5us and ~1.8KB of garbage each) to discover it has
+	// no tool calls — several megabytes of garbage over a long stream, for
+	// nothing. This is also what makes "an ordinary frame is neither reparsed
+	// nor re-emitted" true rather than aspirational.
+	if !strings.Contains(payload, "tool_calls") {
+		return payload, false
+	}
 	var root map[string]json.RawMessage
 	if json.Unmarshal([]byte(payload), &root) != nil {
 		return payload, false

--- a/internal/proxy/proxy_stream_response.go
+++ b/internal/proxy/proxy_stream_response.go
@@ -489,6 +489,10 @@ func normalizeToolArguments(payload string) (string, bool) {
 	if json.Unmarshal(root["choices"], &choices) != nil {
 		return payload, false
 	}
+	// Re-marshalling below cannot fail: every value came out of a successful
+	// Unmarshal, so each RawMessage holds valid JSON. The errors are discarded
+	// rather than handled, because a branch that cannot be taken is a branch
+	// that cannot be tested.
 	changed := false
 	for _, choice := range choices {
 		var delta map[string]json.RawMessage
@@ -516,47 +520,27 @@ func normalizeToolArguments(payload string) (string, bool) {
 			// Compact first, so a pretty-printed object does not carry its
 			// whitespace into the string the caller stores and replays.
 			var buf bytes.Buffer
-			if json.Compact(&buf, args) != nil {
-				continue
-			}
-			quoted, err := json.Marshal(buf.String())
-			if err != nil {
-				continue
-			}
+			_ = json.Compact(&buf, args)
+			quoted, _ := json.Marshal(buf.String())
 			fn["arguments"] = quoted
-			rebuilt, err := json.Marshal(fn)
-			if err != nil {
-				continue
-			}
+			rebuilt, _ := json.Marshal(fn)
 			call["function"] = rebuilt
 			callsChanged = true
 		}
 		if !callsChanged {
 			continue
 		}
-		rebuiltCalls, err := json.Marshal(calls)
-		if err != nil {
-			continue
-		}
+		rebuiltCalls, _ := json.Marshal(calls)
 		delta["tool_calls"] = rebuiltCalls
-		rebuiltDelta, err := json.Marshal(delta)
-		if err != nil {
-			continue
-		}
+		rebuiltDelta, _ := json.Marshal(delta)
 		choice["delta"] = rebuiltDelta
 		changed = true
 	}
 	if !changed {
 		return payload, false
 	}
-	rebuiltChoices, err := json.Marshal(choices)
-	if err != nil {
-		return payload, false
-	}
+	rebuiltChoices, _ := json.Marshal(choices)
 	root["choices"] = rebuiltChoices
-	out, err := json.Marshal(root)
-	if err != nil {
-		return payload, false
-	}
+	out, _ := json.Marshal(root)
 	return string(out), true
 }

--- a/internal/proxy/proxy_stream_response.go
+++ b/internal/proxy/proxy_stream_response.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"bytes"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -370,6 +371,21 @@ func (h *Handler) handleDataChunk(sink *streamSink, st *streamState, ev sseEvent
 			_ = json.Unmarshal(masked, &chunk)
 		}
 
+		// Rewrite an object-form tool call into the spec's JSON string before
+		// it leaves the gateway. Accepting the object on the way IN is what
+		// stops the frame being dropped; forwarding it on the way OUT would
+		// hand the caller a shape this gateway's own request translators
+		// (anthropicegress, gemini, openairesponses) cannot read back — and the
+		// caller echoes the assistant turn into the next request. In a failover
+		// group whose next turn lands on an Anthropic or Gemini member, that
+		// request 400s, and keeps 400ing for the life of the conversation.
+		if normalized, changed := normalizeToolArguments(payload); changed {
+			payload = normalized
+			line = append([]byte("data: "), normalized...)
+			chunk = streamChunk{}
+			_ = json.Unmarshal([]byte(normalized), &chunk)
+		}
+
 		// strip_reasoning: drop reasoning-only deltas (keep-alive) or forward the
 		// stripped chunk. See computeStripReasoning.
 		if stripReasoning && len(chunk.Choices) > 0 && chunk.Choices[0].Delta != nil {
@@ -454,4 +470,93 @@ func (h *Handler) handleDataChunk(sink *streamSink, st *streamState, ev sseEvent
 		sink.swallowBlank = true
 	}
 	return false
+}
+
+// normalizeToolArguments rewrites any tool-call arguments the provider sent as
+// an object (or array, or number) into the spec's JSON string, and reports
+// whether anything changed. The spec form is left untouched, so an ordinary
+// frame is neither reparsed nor re-emitted.
+//
+// It works on the raw map rather than the typed chunk because the frame is
+// forwarded as bytes: rebuilding it from streamChunk would drop every field
+// this gateway does not model.
+func normalizeToolArguments(payload string) (string, bool) {
+	var root map[string]json.RawMessage
+	if json.Unmarshal([]byte(payload), &root) != nil {
+		return payload, false
+	}
+	var choices []map[string]json.RawMessage
+	if json.Unmarshal(root["choices"], &choices) != nil {
+		return payload, false
+	}
+	changed := false
+	for _, choice := range choices {
+		var delta map[string]json.RawMessage
+		if json.Unmarshal(choice["delta"], &delta) != nil {
+			continue
+		}
+		var calls []map[string]json.RawMessage
+		if json.Unmarshal(delta["tool_calls"], &calls) != nil {
+			continue
+		}
+		callsChanged := false
+		for _, call := range calls {
+			var fn map[string]json.RawMessage
+			if json.Unmarshal(call["function"], &fn) != nil {
+				continue
+			}
+			args, ok := fn["arguments"]
+			if !ok {
+				continue
+			}
+			var asString string
+			if json.Unmarshal(args, &asString) == nil {
+				continue // already the spec form
+			}
+			// Compact first, so a pretty-printed object does not carry its
+			// whitespace into the string the caller stores and replays.
+			var buf bytes.Buffer
+			if json.Compact(&buf, args) != nil {
+				continue
+			}
+			quoted, err := json.Marshal(buf.String())
+			if err != nil {
+				continue
+			}
+			fn["arguments"] = quoted
+			rebuilt, err := json.Marshal(fn)
+			if err != nil {
+				continue
+			}
+			call["function"] = rebuilt
+			callsChanged = true
+		}
+		if !callsChanged {
+			continue
+		}
+		rebuiltCalls, err := json.Marshal(calls)
+		if err != nil {
+			continue
+		}
+		delta["tool_calls"] = rebuiltCalls
+		rebuiltDelta, err := json.Marshal(delta)
+		if err != nil {
+			continue
+		}
+		choice["delta"] = rebuiltDelta
+		changed = true
+	}
+	if !changed {
+		return payload, false
+	}
+	rebuiltChoices, err := json.Marshal(choices)
+	if err != nil {
+		return payload, false
+	}
+	root["choices"] = rebuiltChoices
+	out, err := json.Marshal(root)
+	if err != nil {
+		return payload, false
+	}
+	return string(out), true
 }

--- a/internal/proxy/stream_observers.go
+++ b/internal/proxy/stream_observers.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
+	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
 // captureSSEError handles the two error-extraction quirks over a data line:
@@ -87,16 +88,11 @@ type streamChunk struct {
 			ToolCalls        []struct {
 				Function *struct {
 					Name string `json:"name"`
-					// RawMessage, not string. The spec says a JSON string and
-					// several providers send the object itself; typed as string
-					// that mismatch failed the WHOLE chunk unmarshal, and the
-					// frame was dropped as though the bytes were corrupt.
-					//
-					// The loss is not even uniform: finish_reason rides a
-					// separate, parseable frame, so it survives to announce a
-					// tool call the caller never received. Read through
-					// argumentsText.
-					Arguments json.RawMessage `json:"arguments"`
+					// util.ToolArguments, not string: several providers send the
+					// argument OBJECT where the spec says a JSON string, and a
+					// plain string field failed the WHOLE chunk unmarshal, so
+					// the frame was dropped as though the bytes were corrupt.
+					Arguments util.ToolArguments `json:"arguments"`
 				} `json:"function"`
 			} `json:"tool_calls"`
 		} `json:"delta"`
@@ -166,7 +162,7 @@ func (st *streamState) observeDataChunk(chunk streamChunk, anthropicErrorCounted
 		}
 		for _, tc := range choice.Delta.ToolCalls {
 			if tc.Function != nil {
-				st.deliveredBytes += len(tc.Function.Name) + len(argumentsText(tc.Function.Arguments))
+				st.deliveredBytes += len(tc.Function.Name) + len(tc.Function.Arguments)
 			}
 		}
 	}
@@ -211,20 +207,4 @@ func (st *streamState) observeDataChunk(chunk streamChunk, anthropicErrorCounted
 		// so P1-B's next flush must not re-count it.
 		st.errAccum = nil
 	}
-}
-
-// argumentsText sizes a tool call's arguments. The spec says a JSON string, and
-// some providers send the object itself; for the object its own JSON is the
-// honest measure of what the model generated.
-//
-// Sizing only — the frame is forwarded verbatim, never rebuilt from this.
-func argumentsText(raw json.RawMessage) string {
-	if len(raw) == 0 {
-		return ""
-	}
-	var s string
-	if json.Unmarshal(raw, &s) == nil {
-		return s
-	}
-	return string(raw)
 }

--- a/internal/proxy/stream_observers.go
+++ b/internal/proxy/stream_observers.go
@@ -86,8 +86,17 @@ type streamChunk struct {
 			ReasoningDetails json.RawMessage `json:"reasoning_details"`
 			ToolCalls        []struct {
 				Function *struct {
-					Name      string `json:"name"`
-					Arguments string `json:"arguments"`
+					Name string `json:"name"`
+					// RawMessage, not string. The spec says a JSON string and
+					// several providers send the object itself; typed as string
+					// that mismatch failed the WHOLE chunk unmarshal, and the
+					// frame was dropped as though the bytes were corrupt.
+					//
+					// The loss is not even uniform: finish_reason rides a
+					// separate, parseable frame, so it survives to announce a
+					// tool call the caller never received. Read through
+					// argumentsText.
+					Arguments json.RawMessage `json:"arguments"`
 				} `json:"function"`
 			} `json:"tool_calls"`
 		} `json:"delta"`
@@ -157,7 +166,7 @@ func (st *streamState) observeDataChunk(chunk streamChunk, anthropicErrorCounted
 		}
 		for _, tc := range choice.Delta.ToolCalls {
 			if tc.Function != nil {
-				st.deliveredBytes += len(tc.Function.Name) + len(tc.Function.Arguments)
+				st.deliveredBytes += len(tc.Function.Name) + len(argumentsText(tc.Function.Arguments))
 			}
 		}
 	}
@@ -202,4 +211,20 @@ func (st *streamState) observeDataChunk(chunk streamChunk, anthropicErrorCounted
 		// so P1-B's next flush must not re-count it.
 		st.errAccum = nil
 	}
+}
+
+// argumentsText sizes a tool call's arguments. The spec says a JSON string, and
+// some providers send the object itself; for the object its own JSON is the
+// honest measure of what the model generated.
+//
+// Sizing only — the frame is forwarded verbatim, never rebuilt from this.
+func argumentsText(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	if json.Unmarshal(raw, &s) == nil {
+		return s
+	}
+	return string(raw)
 }

--- a/internal/proxy/tool_arguments_shape_test.go
+++ b/internal/proxy/tool_arguments_shape_test.go
@@ -1,0 +1,162 @@
+package proxy
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/hugalafutro/model-hotel/internal/failover"
+)
+
+// ---------------------------------------------------------------------------
+// streamChunk typed tool-call arguments as a string. The spec says a JSON
+// string, but several providers send the object itself — and that mismatch
+// failed the WHOLE chunk unmarshal, so the frame was dropped as though the
+// bytes were corrupt.
+//
+// The loss is not uniform, which is what makes it sharp: finish_reason rides a
+// SEPARATE frame that parses fine, so it survives. The caller receives a
+// completion announcing a tool call with no tool call in it.
+// ---------------------------------------------------------------------------
+
+func streamToolArgs(t *testing.T, h *Handler, body string) (*httptest.ResponseRecorder, *requestLogData) {
+	t.Helper()
+	logData := streamingLog()
+	logData.providerName = "tool-shape-provider"
+	h.insertRequestLogAsync(logData)
+
+	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body))}
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)
+	h.handleStreamingResponse(w, req, logData, resp, time.Now(), streamOptions{
+		responseHeaderMs: 10,
+		providerID:       uuid.New(),
+		providerName:     "tool-shape-provider",
+		vkHash:           "test-hash",
+		attempt:          1,
+	})
+	return w, logData
+}
+
+func TestToolArguments_ObjectFormReachesTheCaller(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandlerIntegration(h)
+
+	body := `data: {"choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"c1","type":"function","function":{"name":"get_weather","arguments":{"city":"Prague"}}}]}}]}` + "\n\n" +
+		`data: {"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}` + "\n\ndata: [DONE]\n\n"
+	w, _ := streamToolArgs(t, h, body)
+
+	out := w.Body.String()
+	if !strings.Contains(out, "get_weather") {
+		t.Errorf("the tool call must reach the caller, got: %s", out)
+	}
+	if strings.Contains(out, "tool_calls\"}") && !strings.Contains(out, "get_weather") {
+		t.Error("the caller was told a tool call happened but never received it")
+	}
+}
+
+// The spec form must be untouched, byte for byte and byte-count for byte-count.
+func TestToolArguments_SpecFormUnchanged(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandlerIntegration(h)
+
+	frame := `{"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"c1","type":"function","function":{"name":"get_weather","arguments":"{\"city\":\"Prague\"}"}}]}}]}`
+	w, _ := streamToolArgs(t, h, "data: "+frame+"\n\ndata: [DONE]\n\n")
+
+	if !strings.Contains(w.Body.String(), frame) {
+		t.Errorf("a spec-form tool call must be forwarded verbatim, got: %s", w.Body.String())
+	}
+}
+
+// Both spellings of the same call must cost the same: deliveredBytes feeds the
+// usage estimate, which charges quota and TPM.
+func TestToolArguments_BothFormsMeterTheSame(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandlerIntegration(h)
+
+	measure := func(frame string) string {
+		logs := captureProxyLogs(t)
+		streamToolArgs(t, h, "data: "+frame+"\n\ndata: [DONE]\n\n")
+		est := logs.find("charging estimated tokens")
+		if len(est) == 0 {
+			t.Fatalf("expected an estimate for a stream with no usage chunk: %s", frame)
+		}
+		return est[0].attrs["delivered_bytes"]
+	}
+	// name "get_weather" (11) + arguments {"city":"Prague"} (17) = 28, both ways.
+	asString := measure(`{"choices":[{"index":0,"delta":{"tool_calls":[{"function":{"name":"get_weather","arguments":"{\"city\":\"Prague\"}"}}]}}]}`)
+	asObject := measure(`{"choices":[{"index":0,"delta":{"tool_calls":[{"function":{"name":"get_weather","arguments":{"city":"Prague"}}}]}}]}`)
+
+	if asString != "28" {
+		t.Errorf("spec form metered %s bytes, want 28", asString)
+	}
+	if asObject != asString {
+		t.Errorf("object form metered %s and the spec form %s: the same call must cost the same", asObject, asString)
+	}
+}
+
+// A tool call is output, so a stream carrying only one must not be charged as
+// an empty response.
+func TestToolArguments_ObjectFormCountsAsDelivery(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandlerIntegration(h)
+	withBreakerThresholdOne(t, h)
+
+	providerID := uuid.New()
+	logData := streamingLog()
+	logData.providerName = "tool-shape-provider"
+	h.insertRequestLogAsync(logData)
+
+	frame := `{"choices":[{"index":0,"delta":{"tool_calls":[{"function":{"name":"get_weather","arguments":{"city":"Prague"}}}]}}]}`
+	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("data: " + frame + "\n\ndata: [DONE]\n\n"))}
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)
+	h.handleStreamingResponse(w, req, logData, resp, time.Now(), streamOptions{
+		responseHeaderMs: 10, providerID: providerID, providerName: "tool-shape-provider",
+		circuitBreakerOn: true, vkHash: "test-hash", attempt: 1,
+	})
+
+	if got := h.circuitBreaker.GetState(providerID); got == failover.StateOpen {
+		t.Error("a stream delivering a tool call must not be charged as empty")
+	}
+	if !strings.Contains(w.Body.String(), "get_weather") {
+		t.Errorf("test assumption broken: the call must be delivered, got %s", w.Body.String())
+	}
+}
+
+// Malformed bytes are still dropped: widening one field must not weaken that.
+func TestToolArguments_MalformedBytesStillDropped(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandlerIntegration(h)
+
+	frame := `{"choices":[{"delta":{"tool_calls":[{"function":{"arguments":`
+	w, _ := streamToolArgs(t, h, "data: "+frame+"\n\ndata: [DONE]\n\n")
+	if strings.Contains(w.Body.String(), frame) {
+		t.Errorf("malformed bytes must not be relayed, got: %s", w.Body.String())
+	}
+}
+
+func TestArgumentsText(t *testing.T) {
+	for name, tc := range map[string]struct{ raw, want string }{
+		"spec form, a JSON string": {`"{\"city\":\"Prague\"}"`, `{"city":"Prague"}`},
+		"object form":              {`{"city":"Prague"}`, `{"city":"Prague"}`},
+		"empty string":             {`""`, ""},
+		"empty object":             {`{}`, "{}"},
+		"absent":                   {``, ""},
+		// json.Unmarshal of "null" into a string SUCCEEDS and leaves it empty,
+		// which is the right size here: a null arguments member carries none.
+		"null": {`null`, ""},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := argumentsText(json.RawMessage(tc.raw)); got != tc.want {
+				t.Errorf("argumentsText(%s) = %q, want %q", tc.raw, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/proxy/tool_arguments_shape_test.go
+++ b/internal/proxy/tool_arguments_shape_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/hugalafutro/model-hotel/internal/failover"
+	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
 // ---------------------------------------------------------------------------
@@ -55,9 +56,6 @@ func TestToolArguments_ObjectFormReachesTheCaller(t *testing.T) {
 	out := w.Body.String()
 	if !strings.Contains(out, "get_weather") {
 		t.Errorf("the tool call must reach the caller, got: %s", out)
-	}
-	if strings.Contains(out, "tool_calls\"}") && !strings.Contains(out, "get_weather") {
-		t.Error("the caller was told a tool call happened but never received it")
 	}
 }
 
@@ -142,21 +140,50 @@ func TestToolArguments_MalformedBytesStillDropped(t *testing.T) {
 	}
 }
 
-func TestArgumentsText(t *testing.T) {
-	for name, tc := range map[string]struct{ raw, want string }{
-		"spec form, a JSON string": {`"{\"city\":\"Prague\"}"`, `{"city":"Prague"}`},
-		"object form":              {`{"city":"Prague"}`, `{"city":"Prague"}`},
-		"empty string":             {`""`, ""},
-		"empty object":             {`{}`, "{}"},
-		"absent":                   {``, ""},
-		// json.Unmarshal of "null" into a string SUCCEEDS and leaves it empty,
-		// which is the right size here: a null arguments member carries none.
-		"null": {`null`, ""},
+// util.ToolArguments is the type the three surfaces share. Encoding always
+// emits the spec form, so a provider's non-standard spelling stops here rather
+// than being passed on to the caller.
+func TestToolArgumentsRoundTrip(t *testing.T) {
+	for name, tc := range map[string]struct{ raw, want, reEncoded string }{
+		"spec form, a JSON string": {`"{\"city\":\"Prague\"}"`, `{"city":"Prague"}`, `"{\"city\":\"Prague\"}"`},
+		"object form":              {`{"city":"Prague"}`, `{"city":"Prague"}`, `"{\"city\":\"Prague\"}"`},
+		"empty string":             {`""`, "", `""`},
+		"empty object":             {`{}`, "{}", `"{}"`},
+		// A null arguments member carries none.
+		"null": {`null`, "", `""`},
 	} {
 		t.Run(name, func(t *testing.T) {
-			if got := argumentsText(json.RawMessage(tc.raw)); got != tc.want {
-				t.Errorf("argumentsText(%s) = %q, want %q", tc.raw, got, tc.want)
+			var got util.ToolArguments
+			if err := json.Unmarshal([]byte(tc.raw), &got); err != nil {
+				t.Fatalf("unmarshal %s: %v", tc.raw, err)
+			}
+			if string(got) != tc.want {
+				t.Errorf("decoded %s = %q, want %q", tc.raw, string(got), tc.want)
+			}
+			out, err := json.Marshal(got)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if string(out) != tc.reEncoded {
+				t.Errorf("re-encoded %s = %s, want %s", tc.raw, out, tc.reEncoded)
 			}
 		})
+	}
+}
+
+// The non-streaming surface: an object-form tool call used to fail the whole
+// ChatCompletionResponse decode, so the caller received an error envelope
+// instead of its tool call.
+func TestToolArguments_NonStreamingDecodesObjectForm(t *testing.T) {
+	body := `{"id":"1","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","tool_calls":[{"id":"c1","type":"function","function":{"name":"get_weather","arguments":{"city":"Prague"}}}]}}]}`
+	var out ChatCompletionResponse
+	if err := json.Unmarshal([]byte(body), &out); err != nil {
+		t.Fatalf("an object-form tool call must decode, got: %v", err)
+	}
+	if len(out.Choices) == 0 || len(out.Choices[0].Message.ToolCalls) == 0 {
+		t.Fatal("the tool call did not survive the decode")
+	}
+	if got := string(out.Choices[0].Message.ToolCalls[0].Function.Arguments); got != `{"city":"Prague"}` {
+		t.Errorf("arguments = %q, want the object's own JSON", got)
 	}
 }

--- a/internal/proxy/tool_arguments_shape_test.go
+++ b/internal/proxy/tool_arguments_shape_test.go
@@ -238,6 +238,10 @@ func TestNormalizeToolArguments(t *testing.T) {
 		"no tool calls": {`{"choices":[{"delta":{"content":"hi"}}]}`, "", false},
 		"not a chunk":   {`{"error":"boom"}`, "", false},
 		"malformed":     {`{"choices":`, "", false},
+		// The three shapes the walk has to step over rather than trip on.
+		"delta is not an object":    {`{"choices":[{"delta":"nope"}]}`, "", false},
+		"function is not an object": {`{"choices":[{"delta":{"tool_calls":[{"function":"nope"}]}}]}`, "", false},
+		"no arguments member":       {`{"choices":[{"delta":{"tool_calls":[{"function":{"name":"f"}}]}}]}`, "", false},
 	} {
 		t.Run(name, func(t *testing.T) {
 			got, changed := normalizeToolArguments(tc.payload)

--- a/internal/proxy/tool_arguments_shape_test.go
+++ b/internal/proxy/tool_arguments_shape_test.go
@@ -149,9 +149,15 @@ func TestToolArguments_ObjectFormIsNormalisedBeforeItLeaves(t *testing.T) {
 }
 
 // What the caller stores has to survive a round trip back through the gateway's
-// own request translators, which is the failure the normalisation prevents: a
+// own request decoders, which is the failure the normalisation prevents: a
 // failover group whose next turn lands on an Anthropic or Gemini member would
 // otherwise 400 for the rest of the conversation.
+//
+// The emitted frame is decoded here with a STRICT `Arguments string`, matching
+// anthropicegress/gemini/openairesponses on the request side. Decoding it with
+// the gateway's own streamChunk would prove nothing: util.ToolArguments absorbs
+// the object form, so that version of this test passed with the normalisation
+// switched off.
 func TestToolArguments_NormalisedOutputIsAcceptedBackAsARequest(t *testing.T) {
 	h := newIntegrationHandler()
 	defer stopUnitHandlerIntegration(h)
@@ -159,60 +165,41 @@ func TestToolArguments_NormalisedOutputIsAcceptedBackAsARequest(t *testing.T) {
 	frame := `{"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"c1","type":"function","function":{"name":"get_weather","arguments":{"city":"Prague"}}}]}}]}`
 	w, _ := streamToolArgs(t, h, "data: "+frame+"\n\ndata: [DONE]\n\n")
 
-	// Lift the assistant turn out of what the caller received, the way a client
-	// building its next request would.
-	var args string
+	// The shape a request-side translator insists on.
+	type strictChunk struct {
+		Choices []struct {
+			Delta struct {
+				ToolCalls []struct {
+					Function struct {
+						Name      string `json:"name"`
+						Arguments string `json:"arguments"`
+					} `json:"function"`
+				} `json:"tool_calls"`
+			} `json:"delta"`
+		} `json:"choices"`
+	}
+
+	var seen string
 	for _, line := range strings.Split(w.Body.String(), "\n") {
 		payload, ok := strings.CutPrefix(strings.TrimSpace(line), "data: ")
 		if !ok || payload == "[DONE]" {
 			continue
 		}
-		var chunk streamChunk
-		if json.Unmarshal([]byte(payload), &chunk) != nil {
-			continue
+		var c strictChunk
+		if err := json.Unmarshal([]byte(payload), &c); err != nil {
+			t.Fatalf("a request decoder could not read back what we emitted: %v\nframe: %s", err, payload)
 		}
-		for _, c := range chunk.Choices {
-			if c.Delta == nil {
-				continue
-			}
-			for _, tc := range c.Delta.ToolCalls {
-				if tc.Function != nil && tc.Function.Arguments != "" {
-					args = string(tc.Function.Arguments)
+		for _, ch := range c.Choices {
+			for _, tc := range ch.Delta.ToolCalls {
+				if tc.Function.Arguments != "" {
+					seen = tc.Function.Arguments
 				}
 			}
 		}
 	}
-	if args != `{"city":"Prague"}` {
-		t.Fatalf("arguments = %q, want the call's own JSON", args)
+	if seen != `{"city":"Prague"}` {
+		t.Errorf("arguments = %q, want the call's own JSON", seen)
 	}
-
-	// The shape the translators need: arguments as a JSON STRING.
-	req := `{"model":"m","messages":[{"role":"assistant","tool_calls":[{"id":"c1","type":"function","function":{"name":"get_weather","arguments":` +
-		mustJSONString(t, args) + `}}]}]}`
-	var probe struct {
-		Messages []struct {
-			ToolCalls []struct {
-				Function struct {
-					Arguments string `json:"arguments"`
-				} `json:"function"`
-			} `json:"tool_calls"`
-		} `json:"messages"`
-	}
-	if err := json.Unmarshal([]byte(req), &probe); err != nil {
-		t.Fatalf("the caller's next request must decode where arguments is typed as a string: %v", err)
-	}
-	if got := probe.Messages[0].ToolCalls[0].Function.Arguments; got != `{"city":"Prague"}` {
-		t.Errorf("round-tripped arguments = %q, want the original", got)
-	}
-}
-
-func mustJSONString(t *testing.T, s string) string {
-	t.Helper()
-	b, err := json.Marshal(s)
-	if err != nil {
-		t.Fatalf("marshal: %v", err)
-	}
-	return string(b)
 }
 
 // A pretty-printed object must not carry its whitespace into the string the

--- a/internal/proxy/tool_arguments_shape_test.go
+++ b/internal/proxy/tool_arguments_shape_test.go
@@ -10,9 +10,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-
-	"github.com/hugalafutro/model-hotel/internal/failover"
-	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
 // ---------------------------------------------------------------------------
@@ -99,35 +96,6 @@ func TestToolArguments_BothFormsMeterTheSame(t *testing.T) {
 	}
 }
 
-// A tool call is output, so a stream carrying only one must not be charged as
-// an empty response.
-func TestToolArguments_ObjectFormCountsAsDelivery(t *testing.T) {
-	h := newIntegrationHandler()
-	defer stopUnitHandlerIntegration(h)
-	withBreakerThresholdOne(t, h)
-
-	providerID := uuid.New()
-	logData := streamingLog()
-	logData.providerName = "tool-shape-provider"
-	h.insertRequestLogAsync(logData)
-
-	frame := `{"choices":[{"index":0,"delta":{"tool_calls":[{"function":{"name":"get_weather","arguments":{"city":"Prague"}}}]}}]}`
-	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("data: " + frame + "\n\ndata: [DONE]\n\n"))}
-	w := httptest.NewRecorder()
-	req := httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)
-	h.handleStreamingResponse(w, req, logData, resp, time.Now(), streamOptions{
-		responseHeaderMs: 10, providerID: providerID, providerName: "tool-shape-provider",
-		circuitBreakerOn: true, vkHash: "test-hash", attempt: 1,
-	})
-
-	if got := h.circuitBreaker.GetState(providerID); got == failover.StateOpen {
-		t.Error("a stream delivering a tool call must not be charged as empty")
-	}
-	if !strings.Contains(w.Body.String(), "get_weather") {
-		t.Errorf("test assumption broken: the call must be delivered, got %s", w.Body.String())
-	}
-}
-
 // Malformed bytes are still dropped: widening one field must not weaken that.
 func TestToolArguments_MalformedBytesStillDropped(t *testing.T) {
 	h := newIntegrationHandler()
@@ -137,37 +105,6 @@ func TestToolArguments_MalformedBytesStillDropped(t *testing.T) {
 	w, _ := streamToolArgs(t, h, "data: "+frame+"\n\ndata: [DONE]\n\n")
 	if strings.Contains(w.Body.String(), frame) {
 		t.Errorf("malformed bytes must not be relayed, got: %s", w.Body.String())
-	}
-}
-
-// util.ToolArguments is the type the three surfaces share. Encoding always
-// emits the spec form, so a provider's non-standard spelling stops here rather
-// than being passed on to the caller.
-func TestToolArgumentsRoundTrip(t *testing.T) {
-	for name, tc := range map[string]struct{ raw, want, reEncoded string }{
-		"spec form, a JSON string": {`"{\"city\":\"Prague\"}"`, `{"city":"Prague"}`, `"{\"city\":\"Prague\"}"`},
-		"object form":              {`{"city":"Prague"}`, `{"city":"Prague"}`, `"{\"city\":\"Prague\"}"`},
-		"empty string":             {`""`, "", `""`},
-		"empty object":             {`{}`, "{}", `"{}"`},
-		// A null arguments member carries none.
-		"null": {`null`, "", `""`},
-	} {
-		t.Run(name, func(t *testing.T) {
-			var got util.ToolArguments
-			if err := json.Unmarshal([]byte(tc.raw), &got); err != nil {
-				t.Fatalf("unmarshal %s: %v", tc.raw, err)
-			}
-			if string(got) != tc.want {
-				t.Errorf("decoded %s = %q, want %q", tc.raw, string(got), tc.want)
-			}
-			out, err := json.Marshal(got)
-			if err != nil {
-				t.Fatalf("marshal: %v", err)
-			}
-			if string(out) != tc.reEncoded {
-				t.Errorf("re-encoded %s = %s, want %s", tc.raw, out, tc.reEncoded)
-			}
-		})
 	}
 }
 
@@ -185,5 +122,137 @@ func TestToolArguments_NonStreamingDecodesObjectForm(t *testing.T) {
 	}
 	if got := string(out.Choices[0].Message.ToolCalls[0].Function.Arguments); got != `{"city":"Prague"}` {
 		t.Errorf("arguments = %q, want the object's own JSON", got)
+	}
+}
+
+// The object form must not leave the gateway. Accepting it on the way IN is
+// what stops the frame being dropped; forwarding it on the way OUT hands the
+// caller a shape this gateway's own request translators cannot read back — and
+// the caller echoes the assistant turn into its next request.
+func TestToolArguments_ObjectFormIsNormalisedBeforeItLeaves(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandlerIntegration(h)
+
+	frame := `{"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"c1","type":"function","function":{"name":"get_weather","arguments":{"city":"Prague"}}}]}}]}`
+	w, _ := streamToolArgs(t, h, "data: "+frame+"\n\ndata: [DONE]\n\n")
+
+	out := w.Body.String()
+	if !strings.Contains(out, "get_weather") {
+		t.Fatalf("test assumption broken: the call must be delivered, got %s", out)
+	}
+	if strings.Contains(out, `"arguments":{`) {
+		t.Errorf("the object form reached the caller: %s", out)
+	}
+	if !strings.Contains(out, `"arguments":"{\"city\":\"Prague\"}"`) {
+		t.Errorf("arguments were not normalised to the spec string: %s", out)
+	}
+}
+
+// What the caller stores has to survive a round trip back through the gateway's
+// own request translators, which is the failure the normalisation prevents: a
+// failover group whose next turn lands on an Anthropic or Gemini member would
+// otherwise 400 for the rest of the conversation.
+func TestToolArguments_NormalisedOutputIsAcceptedBackAsARequest(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandlerIntegration(h)
+
+	frame := `{"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"c1","type":"function","function":{"name":"get_weather","arguments":{"city":"Prague"}}}]}}]}`
+	w, _ := streamToolArgs(t, h, "data: "+frame+"\n\ndata: [DONE]\n\n")
+
+	// Lift the assistant turn out of what the caller received, the way a client
+	// building its next request would.
+	var args string
+	for _, line := range strings.Split(w.Body.String(), "\n") {
+		payload, ok := strings.CutPrefix(strings.TrimSpace(line), "data: ")
+		if !ok || payload == "[DONE]" {
+			continue
+		}
+		var chunk streamChunk
+		if json.Unmarshal([]byte(payload), &chunk) != nil {
+			continue
+		}
+		for _, c := range chunk.Choices {
+			if c.Delta == nil {
+				continue
+			}
+			for _, tc := range c.Delta.ToolCalls {
+				if tc.Function != nil && tc.Function.Arguments != "" {
+					args = string(tc.Function.Arguments)
+				}
+			}
+		}
+	}
+	if args != `{"city":"Prague"}` {
+		t.Fatalf("arguments = %q, want the call's own JSON", args)
+	}
+
+	// The shape the translators need: arguments as a JSON STRING.
+	req := `{"model":"m","messages":[{"role":"assistant","tool_calls":[{"id":"c1","type":"function","function":{"name":"get_weather","arguments":` +
+		mustJSONString(t, args) + `}}]}]}`
+	var probe struct {
+		Messages []struct {
+			ToolCalls []struct {
+				Function struct {
+					Arguments string `json:"arguments"`
+				} `json:"function"`
+			} `json:"tool_calls"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal([]byte(req), &probe); err != nil {
+		t.Fatalf("the caller's next request must decode where arguments is typed as a string: %v", err)
+	}
+	if got := probe.Messages[0].ToolCalls[0].Function.Arguments; got != `{"city":"Prague"}` {
+		t.Errorf("round-tripped arguments = %q, want the original", got)
+	}
+}
+
+func mustJSONString(t *testing.T, s string) string {
+	t.Helper()
+	b, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(b)
+}
+
+// A pretty-printed object must not carry its whitespace into the string the
+// caller stores and replays.
+func TestNormalizeToolArguments(t *testing.T) {
+	for name, tc := range map[string]struct {
+		payload string
+		want    string
+		changed bool
+	}{
+		"object form": {
+			`{"choices":[{"delta":{"tool_calls":[{"function":{"name":"f","arguments":{"a":1}}}]}}]}`,
+			`"{\"a\":1}"`, true,
+		},
+		"pretty printed": {
+			"{\"choices\":[{\"delta\":{\"tool_calls\":[{\"function\":{\"arguments\":{\n  \"a\": 1\n}}}]}}]}",
+			`"{\"a\":1}"`, true,
+		},
+		"already the spec form": {
+			`{"choices":[{"delta":{"tool_calls":[{"function":{"arguments":"{\"a\":1}"}}]}}]}`,
+			`"{\"a\":1}"`, false,
+		},
+		"no tool calls": {`{"choices":[{"delta":{"content":"hi"}}]}`, "", false},
+		"not a chunk":   {`{"error":"boom"}`, "", false},
+		"malformed":     {`{"choices":`, "", false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, changed := normalizeToolArguments(tc.payload)
+			if changed != tc.changed {
+				t.Fatalf("changed = %v, want %v (got %s)", changed, tc.changed, got)
+			}
+			if !tc.changed {
+				if got != tc.payload {
+					t.Errorf("an unchanged payload must be returned untouched, got %s", got)
+				}
+				return
+			}
+			if !strings.Contains(got, tc.want) {
+				t.Errorf("normalised = %s, want it to contain %s", got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/proxy/tool_arguments_shape_test.go
+++ b/internal/proxy/tool_arguments_shape_test.go
@@ -247,3 +247,35 @@ func TestNormalizeToolArguments(t *testing.T) {
 		})
 	}
 }
+
+// The non-streaming surface normalises on its re-encode, and that property
+// comes from util.ToolArguments being a named string type rather than from any
+// method. Nothing else in this package asserted it: re-adding a raw-passthrough
+// MarshalJSON leaked the object form onto the wire with the whole proxy suite
+// still green. This is the wire assertion that catches it.
+func TestToolArguments_NonStreamingEmitsTheSpecForm(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandlerIntegration(h)
+
+	upstream := `{"id":"x","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","tool_calls":[{"id":"c1","type":"function","function":{"name":"get_weather","arguments":{"city":"Prague"}}}]}}]}`
+	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(upstream)), Header: make(http.Header)}
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)
+	logData := streamingLog()
+	logData.streaming = false
+	logData.providerName = "tool-shape-provider"
+	h.insertRequestLogAsync(logData)
+
+	h.handleNonStreamingResponse(w, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
+	}
+	out := w.Body.String()
+	if strings.Contains(out, `"arguments":{`) {
+		t.Errorf("the object form reached the caller: %s", out)
+	}
+	if !strings.Contains(out, `"arguments":"{\"city\":\"Prague\"}"`) {
+		t.Errorf("arguments were not normalised to the spec string: %s", out)
+	}
+}

--- a/internal/proxy/types.go
+++ b/internal/proxy/types.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/ctxkeys"
 	"github.com/hugalafutro/model-hotel/internal/model"
 	"github.com/hugalafutro/model-hotel/internal/provider"
+	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
 // ModelRepository defines the interface for model operations.
@@ -424,8 +425,11 @@ type ToolCall struct {
 
 // ToolCallFunc is the function name + raw JSON arguments of a tool call.
 type ToolCallFunc struct {
-	Name      string `json:"name"`
-	Arguments string `json:"arguments"`
+	Name string `json:"name"`
+	// See util.ToolArguments. A plain string here made the whole
+	// ChatCompletionResponse fail to decode when a provider sent the argument
+	// object, and the caller got an error envelope instead of its tool call.
+	Arguments util.ToolArguments `json:"arguments"`
 }
 
 // PromptTokensDetails breaks down prompt tokens into sub-categories.

--- a/internal/util/toolargs.go
+++ b/internal/util/toolargs.go
@@ -11,9 +11,13 @@ import "encoding/json"
 // frame that decodes fine, so the caller is told a tool call happened and never
 // receives it.
 //
-// Decoding accepts either spelling and keeps the argument text. Encoding always
-// emits the spec string, so a client sees spec-compliant output whatever the
-// provider sent, and a provider's non-standard spelling stops at this gateway.
+// Decoding accepts either spelling and keeps the argument text. Encoding needs
+// no custom method: this is a named string type, so it marshals to the spec's
+// JSON string on its own, and a provider's non-standard spelling is absorbed
+// wherever the value is re-encoded rather than relayed.
+//
+// The streaming surface relays bytes rather than re-encoding, so it normalises
+// explicitly — see normalizeToolArguments.
 type ToolArguments string
 
 // UnmarshalJSON accepts the spec's JSON string or the argument object itself.
@@ -28,11 +32,4 @@ func (a *ToolArguments) UnmarshalJSON(b []byte) error {
 	// The object (or array, or number) form: its own JSON is the argument text.
 	*a = ToolArguments(b)
 	return nil
-}
-
-// MarshalJSON always writes the spec form, normalising a provider that sent the
-// object. Re-encoding it as an object would pass a non-standard shape on to the
-// caller, which is the shape this type exists to absorb.
-func (a ToolArguments) MarshalJSON() ([]byte, error) {
-	return json.Marshal(string(a))
 }

--- a/internal/util/toolargs.go
+++ b/internal/util/toolargs.go
@@ -1,0 +1,38 @@
+package util
+
+import "encoding/json"
+
+// ToolArguments is an OpenAI tool-call arguments value.
+//
+// The spec says a JSON string. Several providers send the object itself, and a
+// field typed as a plain string fails to decode it — which, in a struct decoded
+// as a whole, discards the entire frame or response along with it. On the
+// streaming surface the loss is not even uniform: finish_reason rides a separate
+// frame that decodes fine, so the caller is told a tool call happened and never
+// receives it.
+//
+// Decoding accepts either spelling and keeps the argument text. Encoding always
+// emits the spec string, so a client sees spec-compliant output whatever the
+// provider sent, and a provider's non-standard spelling stops at this gateway.
+type ToolArguments string
+
+// UnmarshalJSON accepts the spec's JSON string or the argument object itself.
+// A JSON null decodes to the empty string, which is the right reading: a null
+// arguments member carries none.
+func (a *ToolArguments) UnmarshalJSON(b []byte) error {
+	var s string
+	if json.Unmarshal(b, &s) == nil {
+		*a = ToolArguments(s)
+		return nil
+	}
+	// The object (or array, or number) form: its own JSON is the argument text.
+	*a = ToolArguments(b)
+	return nil
+}
+
+// MarshalJSON always writes the spec form, normalising a provider that sent the
+// object. Re-encoding it as an object would pass a non-standard shape on to the
+// caller, which is the shape this type exists to absorb.
+func (a ToolArguments) MarshalJSON() ([]byte, error) {
+	return json.Marshal(string(a))
+}

--- a/internal/util/toolargs_test.go
+++ b/internal/util/toolargs_test.go
@@ -1,0 +1,77 @@
+package util_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/hugalafutro/model-hotel/internal/util"
+)
+
+// ToolArguments absorbs a provider's spelling of tool-call arguments and always
+// hands the caller the spec form. A plain string field could not decode the
+// object spelling at all, and because these values sit inside a struct decoded
+// as a whole, that failure discarded the entire frame or response with them.
+func TestToolArguments(t *testing.T) {
+	for name, tc := range map[string]struct {
+		raw       string
+		want      string
+		reEncoded string
+	}{
+		"spec form, a JSON string": {`"{\"city\":\"Prague\"}"`, `{"city":"Prague"}`, `"{\"city\":\"Prague\"}"`},
+		"object form":              {`{"city":"Prague"}`, `{"city":"Prague"}`, `"{\"city\":\"Prague\"}"`},
+		"nested object":            {`{"a":{"b":[1,2]}}`, `{"a":{"b":[1,2]}}`, `"{\"a\":{\"b\":[1,2]}}"`},
+		"array form":               {`[1,2]`, `[1,2]`, `"[1,2]"`},
+		"empty string":             {`""`, "", `""`},
+		"empty object":             {`{}`, "{}", `"{}"`},
+		// A null arguments member carries none. json.Unmarshal of null into a
+		// string succeeds and leaves it empty, which is the reading we want.
+		"null": {`null`, "", `""`},
+		// A string with escapes must survive the round trip unchanged.
+		"escaped quotes": {`"{\"q\":\"a\\\"b\"}"`, `{"q":"a\"b"}`, `"{\"q\":\"a\\\"b\"}"`},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var got util.ToolArguments
+			if err := json.Unmarshal([]byte(tc.raw), &got); err != nil {
+				t.Fatalf("unmarshal %s: %v", tc.raw, err)
+			}
+			if string(got) != tc.want {
+				t.Errorf("decoded %s = %q, want %q", tc.raw, string(got), tc.want)
+			}
+			out, err := json.Marshal(got)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if string(out) != tc.reEncoded {
+				t.Errorf("re-encoded %s = %s, want %s", tc.raw, out, tc.reEncoded)
+			}
+		})
+	}
+}
+
+// Whatever the provider sent, a second decode of what we emit yields the same
+// argument text: the normalisation is stable, not lossy.
+func TestToolArguments_ReEncodeIsStable(t *testing.T) {
+	for _, raw := range []string{
+		`{"city":"Prague"}`,
+		`"{\"city\":\"Prague\"}"`,
+		`{"a":{"b":[1,2]}}`,
+		`""`,
+		`null`,
+	} {
+		var first util.ToolArguments
+		if err := json.Unmarshal([]byte(raw), &first); err != nil {
+			t.Fatalf("unmarshal %s: %v", raw, err)
+		}
+		encoded, err := json.Marshal(first)
+		if err != nil {
+			t.Fatalf("marshal %s: %v", raw, err)
+		}
+		var second util.ToolArguments
+		if err := json.Unmarshal(encoded, &second); err != nil {
+			t.Fatalf("re-unmarshal %s: %v", encoded, err)
+		}
+		if second != first {
+			t.Errorf("%s round-tripped to %q, want %q", raw, string(second), string(first))
+		}
+	}
+}


### PR DESCRIPTION
## The bug

`streamChunk` typed tool-call `arguments` as a `string`. The spec says a JSON string, and several providers send the object itself — a mismatch that failed the **whole chunk** unmarshal, so the frame was dropped as though the bytes were corrupt.

The loss is not uniform, which is what makes it sharp: `finish_reason` rides a **separate** frame that parses fine, so it survives. Reproduced against the dev stack before the fix:

```
UPSTREAM SENDS:
  data: {...function:{"name":"get_weather","arguments":{"city":"Prague"}}}
  data: {...finish_reason:"tool_calls"}

CLIENT RECEIVES:
  data: {...finish_reason:"tool_calls"}
  data: [DONE]
```

A completion announcing a tool call with no tool call in it. Most SDKs then throw, or wait forever for arguments that never arrive.

## The fix

One shared `util.ToolArguments` decodes either spelling on all three ingress surfaces, and the object form is **normalised to the spec string before it leaves**.

| surface | before |
|---|---|
| `/v1/chat/completions` streaming | frame dropped; `finish_reason` survives to announce a call the caller never receives |
| `/v1/messages` | the proxy drops the frame first, so the Anthropic writer never sees it — the client gets `message_delta` with `stop_reason: "tool_use"` and **no `tool_use` content block**, which the Anthropic SDKs reject |
| `/v1/chat/completions` non-streaming | whole body fails to decode; the caller gets an error envelope carrying HTTP 200 |

**Accepting the object form on the way in is only half of it.** Forwarding it on the way *out* would hand the caller a shape this gateway's own request translators cannot read back: `anthropicegress`, `gemini` and `openairesponses` all type tool-call arguments as a string on the request side, and a caller echoes the assistant turn into its next request. In a failover group whose first turn streams from a member sending the object form, the next turn landing on an Anthropic or Gemini member would 400 — and keep 400ing for the life of that conversation. Before this branch the frame was dropped, so no client ever held that shape; this PR would have created the failure it set out to fix. Review caught it.

`normalizeToolArguments` rewrites the emit path, compacting first so a pretty-printed object does not carry its whitespace into the string the caller stores and replays. It works on the raw map rather than the typed chunk, because rebuilding from `streamChunk` would drop every field this gateway does not model.

## Deliberately narrow

An earlier attempt (#807, closed) widened `content` and the `error` member in the same change. Three review rounds established that content-as-parts **cannot** be settled by a shape heuristic: reasoning arrives as `{"type":"thinking",...}` (Anthropic), `{"text":...,"thought":true}` (Gemini — and this repo ships `internal/gemini`), and `{"type":"reasoning.text",...}` (OpenRouter). Every rule for "is this content understood" is an allowlist against an open set, and `strip_reasoning` is a per-key contract where a miss leaks a caller's chain of thought.

Tool arguments carry no such risk and are exactly sizeable, so they ship alone. The error member and content-as-parts follow as their own PRs.

## Verification

Live against a rebuilt dev stack:

| upstream | result |
|---|---|
| `arguments` as an object | tool call **and** its `finish_reason` both delivered |
| `arguments` as the spec string | unchanged, forwarded verbatim |

The Anthropic surface is covered by a test that decodes its chunks **from JSON** rather than building Go values — the bug lived in the unmarshal, so constructing the struct directly would have tested nothing — and asserts through the real Anthropic SDK's stream decoder.

Mutation-tested. Reverting the streaming ingress fails 4 tests; reverting the non-streaming ingress fails its named test on the decode; disabling the emit-path normalisation fails both the wire assertion and the round-trip test; skipping the compaction leaks a pretty-printed object's whitespace; normalising the spec form too fails 4; re-adding a raw-passthrough `MarshalJSON` leaks the object form onto the non-streaming wire; reverting `internal/anthropic/response.go` fails its decode.

The `internal/anthropic` widenings are **defence in depth, not live-path fixes**: that writer sits downstream of the proxy and only ever receives bytes already normalised, so reverting them changes no end-to-end behaviour. They are typed and tested so that stays true if the pipeline changes.

Live on a rebuilt dev stack, both providers now emit byte-identical output — `"arguments":"{\"city\":\"Prague\"}"` — so the object form is absorbed here rather than passed on.

Two things review found and this PR drops rather than keeps: `util.ToolArguments` had a `MarshalJSON` that was redundant (a named string type already marshals to a JSON string, so the non-streaming normalisation came from the type, not the method) and which defeated `SetEscapeHTML(false)`; and `TestToolArguments_ObjectFormCountsAsDelivery` passed with the fix fully reverted, because the pre-existing `unparsedChunks` guard already suppressed the empty-response charge for a dropped frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
