### PR TITLE
fix(api,frontdesk): subscribe to the event bus before announcing the SSE stream

### DIFF
--- a/internal/api/events.go
+++ b/internal/api/events.go
@@ -128,16 +128,22 @@ func (h *Handler) streamEvents(w http.ResponseWriter, r *http.Request, heartbeat
 	w.Header().Set("Connection", "keep-alive")
 	w.Header().Set("X-Accel-Buffering", "no")
 
-	// Write initial comment to establish the stream
-	_, _ = fmt.Fprint(w, ": connected\n\n")
-	flusher.Flush()
-
 	bus := h.eventBus
 	if bus == nil {
 		bus = events.DefaultBus
 	}
+	// Subscribe BEFORE announcing the stream. Announcing first opens a window
+	// where the client believes it is attached and any event published in it is
+	// dropped on the floor — a dashboard that connects during a burst silently
+	// misses the start of it. It also makes the connected frame a sound
+	// handshake: a reader that has seen those bytes knows the subscription
+	// exists, which is what the tests rely on instead of sleeping.
 	ch := bus.Subscribe()
 	defer bus.Unsubscribe(ch)
+
+	// Write initial comment to establish the stream
+	_, _ = fmt.Fprint(w, ": connected\n\n")
+	flusher.Flush()
 
 	// Buffered so a re-auth result never parks its goroutine while this loop is
 	// busy writing an event; the loop drains it on the next pass.

--- a/internal/api/events_filter_test.go
+++ b/internal/api/events_filter_test.go
@@ -137,22 +137,3 @@ func TestStreamEvents_OwnerScoping(t *testing.T) {
 		t.Errorf("discovery progress leaked to logs-granted user: %s", body)
 	}
 }
-
-// awaitStreamOpen blocks until the SSE handler has announced the stream, and
-// fails rather than hanging if it never does.
-//
-// A bare `<-rec.flushed` deadlocks the whole package when the handler returns
-// before its first flush — an auth rejection, a non-Flusher writer, any future
-// early return. syncRecorder's WriteHeader is a no-op, so a 401 leaves no trace
-// either: the symptom is the package timing out ten minutes later with a
-// goroutine dump, where the sleep this replaced would have failed in a line.
-func awaitStreamOpen(t *testing.T, rec *syncRecorder, done <-chan struct{}) {
-	t.Helper()
-	select {
-	case <-rec.flushed:
-	case <-done:
-		t.Fatalf("handler returned before the stream opened: %q", rec.String())
-	case <-time.After(5 * time.Second):
-		t.Fatalf("stream never opened: %q", rec.String())
-	}
-}

--- a/internal/api/events_filter_test.go
+++ b/internal/api/events_filter_test.go
@@ -97,7 +97,7 @@ func TestStreamEvents_OwnerScoping(t *testing.T) {
 	// flushes the connected frame immediately after, so this signal means the
 	// subscription exists and no publish below can be missed. The 50ms sleep
 	// this replaces is what made the test flake under -race on a loaded runner.
-	<-rec.flushed
+	awaitStreamOpen(t, rec, done)
 
 	// Own request (owner_user_id == this user) is visible; another user's request
 	// and operational/discovery events are not.
@@ -105,11 +105,15 @@ func TestStreamEvents_OwnerScoping(t *testing.T) {
 	events.Publish(events.Event{Type: "request.completed", Severity: "info", Message: "theirs done", Metadata: map[string]any{"owner_user_id": uuid.NewString()}})
 	events.Publish(events.Event{Type: "backup.created", Severity: "success", Message: "backup done"})
 	events.Publish(events.Event{Type: "request.discovery.provider_starting", Severity: "info", Message: "discovering"})
-	// Wait for the event that should arrive rather than a guessed interval. The
-	// ones that should NOT arrive are asserted absent after the handler exits,
-	// by which point every publish has been processed or dropped.
-	if !waitFor(t, func() bool { return strings.Contains(rec.String(), "mine done") }) {
-		t.Fatalf("own request.completed never reached the stream: %q", rec.String())
+	// A sentinel AFTER the three that must not appear. The bus feeds one ordered
+	// channel, so seeing this proves the handler read and filtered all three —
+	// waiting on "mine done" instead proves only that the FIRST publish landed,
+	// and leaves the leak assertions below to race a handler that may not have
+	// reached those events yet. Measured against a deliberately leaky filter and
+	// a slowed consumer, that version caught the leak 6 times in 20.
+	events.Publish(events.Event{Type: "request.completed", Severity: "info", Message: "sentinel done", Metadata: map[string]any{"owner_user_id": id}})
+	if !waitFor(t, func() bool { return strings.Contains(rec.String(), "sentinel done") }) {
+		t.Fatalf("sentinel never reached the stream, so the filtering below is unverified: %q", rec.String())
 	}
 
 	cancel()
@@ -131,5 +135,24 @@ func TestStreamEvents_OwnerScoping(t *testing.T) {
 	}
 	if strings.Contains(body, "provider_starting") {
 		t.Errorf("discovery progress leaked to logs-granted user: %s", body)
+	}
+}
+
+// awaitStreamOpen blocks until the SSE handler has announced the stream, and
+// fails rather than hanging if it never does.
+//
+// A bare `<-rec.flushed` deadlocks the whole package when the handler returns
+// before its first flush — an auth rejection, a non-Flusher writer, any future
+// early return. syncRecorder's WriteHeader is a no-op, so a 401 leaves no trace
+// either: the symptom is the package timing out ten minutes later with a
+// goroutine dump, where the sleep this replaced would have failed in a line.
+func awaitStreamOpen(t *testing.T, rec *syncRecorder, done <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-rec.flushed:
+	case <-done:
+		t.Fatalf("handler returned before the stream opened: %q", rec.String())
+	case <-time.After(5 * time.Second):
+		t.Fatalf("stream never opened: %q", rec.String())
 	}
 }

--- a/internal/api/events_filter_test.go
+++ b/internal/api/events_filter_test.go
@@ -85,7 +85,7 @@ func TestStreamEvents_OwnerScoping(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	done := make(chan struct{})
-	rec := httptest.NewRecorder()
+	rec := newSyncRecorder()
 	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/events", http.NoBody)
 	req.Header.Set("Authorization", "Bearer "+token)
 
@@ -93,7 +93,11 @@ func TestStreamEvents_OwnerScoping(t *testing.T) {
 		er.ServeHTTP(rec, req)
 		close(done)
 	}()
-	time.Sleep(50 * time.Millisecond)
+	// A handshake, not a sleep: streamEvents subscribes before it announces, and
+	// flushes the connected frame immediately after, so this signal means the
+	// subscription exists and no publish below can be missed. The 50ms sleep
+	// this replaces is what made the test flake under -race on a loaded runner.
+	<-rec.flushed
 
 	// Own request (owner_user_id == this user) is visible; another user's request
 	// and operational/discovery events are not.
@@ -101,7 +105,12 @@ func TestStreamEvents_OwnerScoping(t *testing.T) {
 	events.Publish(events.Event{Type: "request.completed", Severity: "info", Message: "theirs done", Metadata: map[string]any{"owner_user_id": uuid.NewString()}})
 	events.Publish(events.Event{Type: "backup.created", Severity: "success", Message: "backup done"})
 	events.Publish(events.Event{Type: "request.discovery.provider_starting", Severity: "info", Message: "discovering"})
-	time.Sleep(100 * time.Millisecond)
+	// Wait for the event that should arrive rather than a guessed interval. The
+	// ones that should NOT arrive are asserted absent after the handler exits,
+	// by which point every publish has been processed or dropped.
+	if !waitFor(t, func() bool { return strings.Contains(rec.String(), "mine done") }) {
+		t.Fatalf("own request.completed never reached the stream: %q", rec.String())
+	}
 
 	cancel()
 	select {
@@ -110,7 +119,7 @@ func TestStreamEvents_OwnerScoping(t *testing.T) {
 		t.Fatal("handler goroutine did not exit after context cancellation")
 	}
 
-	body := rec.Body.String()
+	body := rec.String()
 	if !strings.Contains(body, "mine done") {
 		t.Errorf("logs-granted user missing own request.completed, got: %s", body)
 	}

--- a/internal/api/events_integration_test.go
+++ b/internal/api/events_integration_test.go
@@ -65,7 +65,7 @@ func TestStreamEvents_EventDelivery(t *testing.T) {
 
 	// A handshake, not a sleep: streamEvents subscribes before it announces and
 	// flushes immediately after, so this signal means the subscription exists.
-	<-rec.flushed
+	awaitStreamOpen(t, rec, done)
 
 	// Publish an event
 	events.Publish(events.Event{
@@ -184,7 +184,7 @@ func TestStreamEvents_MarshalError(t *testing.T) {
 	}()
 
 	// A handshake, not a sleep.
-	<-rec.flushed
+	awaitStreamOpen(t, rec, done)
 
 	// Publish an event with a value that can't be JSON-marshaled (a channel)
 	events.Publish(events.Event{

--- a/internal/api/events_integration_test.go
+++ b/internal/api/events_integration_test.go
@@ -217,6 +217,13 @@ func TestStreamEvents_MarshalError(t *testing.T) {
 	}
 
 	body := rec.String()
+	// The claim in this test's name: the bad event was read and SKIPPED, not
+	// merely not-yet-arrived. Ordering gives the first half, this gives the
+	// second — without it a handler that wrote the unmarshalable event to the
+	// wire would pass.
+	if strings.Contains(body, "test.bad_event") {
+		t.Errorf("an unmarshalable event reached the wire: %s", body)
+	}
 	if !strings.Contains(body, "test.good_event") {
 		t.Errorf("Expected good event in SSE stream after marshal error, got: %s", body)
 	}

--- a/internal/api/events_integration_test.go
+++ b/internal/api/events_integration_test.go
@@ -52,7 +52,7 @@ func TestStreamEvents_EventDelivery(t *testing.T) {
 	defer cancel()
 
 	done := make(chan struct{})
-	rec := httptest.NewRecorder()
+	rec := newSyncRecorder()
 
 	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/events", http.NoBody)
 	req.Header.Set("Authorization", "Bearer test-admin-token")
@@ -63,8 +63,9 @@ func TestStreamEvents_EventDelivery(t *testing.T) {
 		close(done)
 	}()
 
-	// Give the handler time to subscribe
-	time.Sleep(50 * time.Millisecond)
+	// A handshake, not a sleep: streamEvents subscribes before it announces and
+	// flushes immediately after, so this signal means the subscription exists.
+	<-rec.flushed
 
 	// Publish an event
 	events.Publish(events.Event{
@@ -74,23 +75,23 @@ func TestStreamEvents_EventDelivery(t *testing.T) {
 		Metadata: map[string]any{"test": true},
 	})
 
-	// Give time for event to be delivered
-	time.Sleep(100 * time.Millisecond)
+	// Wait for the event itself rather than a guessed interval.
+	if !waitFor(t, func() bool { return strings.Contains(rec.String(), "test.event") }) {
+		t.Fatalf("event never reached the stream: %q", rec.String())
+	}
 
 	// Cancel the request context to unblock the handler goroutine.
 	cancel()
 
-	// Wait for the handler goroutine to finish BEFORE reading the body
-	// to avoid a race between the goroutine writing to rec.Body and
-	// the test goroutine reading from it.
 	select {
 	case <-done:
 	case <-time.After(2 * time.Second):
 		t.Fatal("handler goroutine did not exit after context cancellation")
 	}
 
-	// Now safe to read the body — the handler goroutine is done writing.
-	body := rec.Body.String()
+	// syncRecorder is safe to read at any point, but reading after the handler
+	// has exited keeps the assertions about a finished stream.
+	body := rec.String()
 	if !strings.Contains(body, "test.event") {
 		t.Errorf("Expected event in SSE stream, got: %s", body)
 	}
@@ -171,7 +172,7 @@ func TestStreamEvents_MarshalError(t *testing.T) {
 	defer cancel()
 
 	done := make(chan struct{})
-	rec := httptest.NewRecorder()
+	rec := newSyncRecorder()
 
 	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/events", http.NoBody)
 	req.Header.Set("Authorization", "Bearer test-admin-token")
@@ -182,8 +183,8 @@ func TestStreamEvents_MarshalError(t *testing.T) {
 		close(done)
 	}()
 
-	// Give the handler time to subscribe
-	time.Sleep(50 * time.Millisecond)
+	// A handshake, not a sleep.
+	<-rec.flushed
 
 	// Publish an event with a value that can't be JSON-marshaled (a channel)
 	events.Publish(events.Event{
@@ -193,34 +194,29 @@ func TestStreamEvents_MarshalError(t *testing.T) {
 		Metadata: map[string]any{"ch": make(chan int)},
 	})
 
-	// Give time for the bad event to be processed
-	time.Sleep(50 * time.Millisecond)
-
-	// Publish a good event that should still be delivered
+	// Publish a good event that should still be delivered. The bus preserves
+	// order, so waiting for this one proves the bad event was processed and
+	// skipped rather than merely not arrived yet — which is the whole claim.
 	events.Publish(events.Event{
 		Type:     "test.good_event",
 		Severity: "info",
 		Message:  "Good event after bad",
 		Metadata: map[string]any{"test": true},
 	})
-
-	// Give time for the good event to be delivered
-	time.Sleep(100 * time.Millisecond)
+	if !waitFor(t, func() bool { return strings.Contains(rec.String(), "test.good_event") }) {
+		t.Fatalf("the good event never reached the stream: %q", rec.String())
+	}
 
 	// Cancel the request context to unblock the handler goroutine.
 	cancel()
 
-	// Wait for the handler goroutine to finish BEFORE reading the body
-	// to avoid a race between the goroutine writing to rec.Body and
-	// the test goroutine reading from it.
 	select {
 	case <-done:
 	case <-time.After(2 * time.Second):
 		t.Fatal("handler goroutine did not exit after context cancellation")
 	}
 
-	// Now safe to read the body — the handler goroutine is done writing.
-	body := rec.Body.String()
+	body := rec.String()
 	if !strings.Contains(body, "test.good_event") {
 		t.Errorf("Expected good event in SSE stream after marshal error, got: %s", body)
 	}

--- a/internal/api/events_reauth_test.go
+++ b/internal/api/events_reauth_test.go
@@ -251,7 +251,7 @@ func TestStreamEvents_RefreshesGrantsMidStream(t *testing.T) {
 		h.streamEvents(rec, req, 20*time.Millisecond)
 		close(done)
 	}()
-	<-rec.flushed
+	awaitStreamOpen(t, rec, done)
 
 	// The event is owned by this user, so the logs grant makes it visible.
 	owned := events.Event{
@@ -303,7 +303,7 @@ func TestStreamEvents_PassingRecheckResetsFailureCount(t *testing.T) {
 		h.streamEvents(rec, streamRequest(ctx), 200*time.Millisecond)
 		close(done)
 	}()
-	<-rec.flushed
+	awaitStreamOpen(t, rec, done)
 
 	// beat waits for the nth heartbeat and asserts the stream is still open.
 	beat := func(n int, why string) {
@@ -459,5 +459,31 @@ func TestStreamEvents_ClosesWhenBusClosed(t *testing.T) {
 	case <-done:
 	case <-ctx.Done():
 		t.Fatal("stream stayed open after the event bus was closed")
+	}
+}
+
+// awaitStreamOpen blocks until the SSE handler has announced the stream, and
+// fails rather than hanging if it never does.
+//
+// A bare `<-rec.flushed` deadlocks the whole package when the handler returns
+// before its first flush — an auth rejection, a non-Flusher writer, any future
+// early return. syncRecorder's WriteHeader is a no-op, so a 401 leaves no trace
+// either: the symptom is the package timing out ten minutes later with a
+// goroutine dump, where the sleep this replaced would have failed in a line.
+func awaitStreamOpen(t *testing.T, rec *syncRecorder, done <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-rec.flushed:
+	case <-done:
+		// Both can be ready at once — a handler that flushes and returns
+		// immediately — and select picks at random, so re-check before
+		// reporting a failure that did not happen.
+		select {
+		case <-rec.flushed:
+		default:
+			t.Fatalf("handler returned before the stream opened: %q", rec.String())
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("stream never opened: %q", rec.String())
 	}
 }

--- a/internal/frontdesk/server_status.go
+++ b/internal/frontdesk/server_status.go
@@ -185,9 +185,12 @@ func (s *Server) streamEvents(w http.ResponseWriter, r *http.Request, heartbeatE
 	w.Header().Set("Connection", "keep-alive")
 	// Subscribe BEFORE announcing, for the same reason the gateway's own SSE
 	// handler does: announcing first opens a window where the client believes it
-	// is attached and any event published in it is dropped. It also makes the
-	// first write a sound handshake for the tests, which otherwise have to treat
-	// the window as a fact of life.
+	// is attached and any event published in it is dropped.
+	//
+	// This is a fix for real clients only. The announce here is a bare 200 with
+	// no body, so it was never observable to the tests, whose first captured
+	// write is the keep-alive — and that already came after the subscribe,
+	// because the ticker producing it starts later.
 	ch := s.bus.Subscribe()
 	defer s.bus.Unsubscribe(ch)
 

--- a/internal/frontdesk/server_status.go
+++ b/internal/frontdesk/server_status.go
@@ -183,11 +183,16 @@ func (s *Server) streamEvents(w http.ResponseWriter, r *http.Request, heartbeatE
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
-	w.WriteHeader(http.StatusOK)
-	flusher.Flush()
-
+	// Subscribe BEFORE announcing, for the same reason the gateway's own SSE
+	// handler does: announcing first opens a window where the client believes it
+	// is attached and any event published in it is dropped. It also makes the
+	// first write a sound handshake for the tests, which otherwise have to treat
+	// the window as a fact of life.
 	ch := s.bus.Subscribe()
 	defer s.bus.Unsubscribe(ch)
+
+	w.WriteHeader(http.StatusOK)
+	flusher.Flush()
 
 	// Buffered so a re-auth verdict never parks its goroutine while this loop is
 	// busy writing an event; the loop drains it on the next pass.

--- a/internal/frontdesk/sse_reauth_test.go
+++ b/internal/frontdesk/sse_reauth_test.go
@@ -355,8 +355,9 @@ func TestSSEDeliversBusEvents(t *testing.T) {
 	req.Header.Set("Authorization", "Bearer "+testFrontdeskToken)
 
 	rec, done := startStream(t, srv, req)
-	// The first keep-alive proves the handler is subscribed — it subscribes
-	// before announcing, so anything written means the subscription exists.
+	// The first keep-alive proves the handler is subscribed: it comes from the
+	// loop that is entered after Subscribe. (The 200 status line is not
+	// observable here — the recorder captures only Write.)
 	awaitWrite(t, rec, "keep-alive")
 	srv.bus.Publish(events.Event{Type: "member.state_changed", Severity: "info", Source: "frontdesk"})
 

--- a/internal/frontdesk/sse_reauth_test.go
+++ b/internal/frontdesk/sse_reauth_test.go
@@ -355,8 +355,8 @@ func TestSSEDeliversBusEvents(t *testing.T) {
 	req.Header.Set("Authorization", "Bearer "+testFrontdeskToken)
 
 	rec, done := startStream(t, srv, req)
-	// The first keep-alive proves the handler is subscribed; the bus drops
-	// events published before that.
+	// The first keep-alive proves the handler is subscribed — it subscribes
+	// before announcing, so anything written means the subscription exists.
 	awaitWrite(t, rec, "keep-alive")
 	srv.bus.Publish(events.Event{Type: "member.state_changed", Severity: "info", Source: "frontdesk"})
 


### PR DESCRIPTION
## The bug behind the flake

`streamEvents` wrote `": connected"` and flushed **before** calling `bus.Subscribe()`. That opens a window where the client believes it is attached and any event published in it is dropped on the floor — a dashboard that connects during a burst silently misses the start of it.

It also made the SSE tests unfixable by design. They slept 50ms hoping the handler goroutine had reached its subscribe:

```go
go func() { er.ServeHTTP(rec, req); close(done) }()
time.Sleep(50 * time.Millisecond)   // hope it has subscribed
events.Publish(...)                  // ← if not, this event is lost
```

Under `-race` on a loaded runner it repeatedly had not. `TestStreamEvents_OwnerScoping` failed that way on two unrelated PRs and `TestStreamEvents_RefreshesGrantsMidStream` on a third — each costing a re-run on work that had nothing to do with it. The failure always looked the same: `got: : connected`, the client having received the connect frame and nothing else.

## The fix

Subscribe first, announce second. That **narrows** the lost-event window — events published between the client's connect/auth and the handler reaching `Subscribe` are still dropped, and there is no `Last-Event-ID` replay — and it makes the connected frame a genuine handshake: a reader that has seen those bytes knows the subscription exists.

Front Desk's `streamEvents` had the identical ordering. Same fix, same reason: sibling surfaces ship together. Note it is a fix for **real clients only** there — FD's announce is a bare 200 with no body, so it was never observable to its tests, whose first captured write is the keep-alive and already came after the subscribe.

The three sleep-based SSE tests now wait on `syncRecorder`'s flush signal, then on the event they expect, instead of guessing intervals. `TestStreamEvents_MarshalError` gains something it didn't have: it publishes the bad event and the good one back to back and waits for the good one, so the bus's ordering proves the bad event was *processed and skipped* rather than merely not arrived yet — which is the claim the test's name makes.

`syncRecorder` and `waitFor` already existed in this package. I had written a second copy of the same helper before finding them, and deleted it.

## Test strength

Review caught the first version of this rewrite **weakening a security assertion**. The filter test waited on the first of four publishes and then cancelled, so the three events that must not reach a logs-granted user could still be unread when the assertions ran. Measured against a deliberately leaky filter with a slowed consumer, the old sleep caught the leak 20 times in 20 and that wait caught it 6. It now publishes an owned sentinel *after* the three negatives and waits for that — the bus feeds one ordered channel, so seeing the sentinel proves all three were read and filtered.

It also caught a way to deadlock the package: a bare `<-rec.flushed` never returns if the handler exits before its first flush (an auth rejection, a non-Flusher writer), and `syncRecorder.WriteHeader` is a no-op so a 401 leaves no trace. The symptom is a ten-minute package timeout with a goroutine dump, where the sleep it replaced failed in one line. `awaitStreamOpen` selects on the handler's done channel and a deadline.

`TestStreamEvents_MarshalError` got stronger, though not for the reason first claimed. Ordering proves the bad event was *reached*; proving it was *skipped* needed an assertion that it never hit the wire, which the test did not have — a handler that wrote the unmarshalable event passed. It has one now, and a mutation doing exactly that fails it.

## What this does and does not establish

The flake does not reproduce locally — verified independently at 60 runs under `-race`, passing both with and without the reordering, because on an idle machine the handler wins the race easily. **The tests therefore do not guard the reorder**; a future revert of those two lines would be silent.

What does confirm the diagnosis: CI run `33188552135` on #808 failed `TestStreamEvents_RefreshesGrantsMidStream` with `": connected"` followed by ~250 heartbeats and no event. That test already used the flush handshake on master, so under the old ordering it lost the race by nanoseconds — this PR is the genuine fix for it.

Verified on a rebuilt dev stack as a regression check: 38 events delivered, correctly typed, filtering intact, clean reconnect, no handler errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
